### PR TITLE
Add named event support (L8a: event e, -> e, @e)

### DIFF
--- a/docs/queues/infrastructure.md
+++ b/docs/queues/infrastructure.md
@@ -13,6 +13,7 @@ Correctness, code quality, and tooling gaps that are not performance issues.
 - [ ] I1: canonical storage contract enforcement (authority collapse, domain-typed APIs, policy checker)
 - [ ] I2: test expectations overlay (case-level xfail/skip/quarantine metadata)
 - [ ] I3: four-state query layer cleanup (intrinsic rename, wrapper removal, audit)
+- [ ] I4: test framework variable inspection uses canonical slot metadata
 
 ## I1: Canonical storage contract enforcement
 
@@ -29,3 +30,7 @@ Test cases should stay in their feature YAML files. CI exclusion and expected-fa
 Target direction: centralized expectations overlay with per-case metadata: status (unsupported / xfail / quarantine / skip), reason, issue ID, scope. Framework reads the overlay at test registration and applies GTEST_SKIP or xfail. Ratchet checks prevent stale entries.
 
 Current workaround: gtest_filter exclusion in BUILD.bazel. This is not the target structure.
+
+## I4: Test framework variable inspection uses canonical slot metadata
+
+The test framework's variable inspection helper re-derives slot indices by replaying HIR declaration iteration with hand-maintained counters and type-based filters. This duplicates the compiler's slot allocation logic and breaks when new non-storage types are added (e.g., event types required adding a filter). The long-term clean shape: tests and debug tooling should consume the same canonical slot-origin metadata that the compiler and runtime use, not re-derive slot indices from HIR declaration order.

--- a/docs/queues/language.md
+++ b/docs/queues/language.md
@@ -20,7 +20,9 @@ Features tracked elsewhere:
 - [ ] L5 -- Default argument values and named argument binding
 - [ ] L6 -- `final` blocks
 - [ ] L7 -- Bit vector system functions (`$isunknown`, `$countones`, `$onehot`, `$onehot0`)
-- [ ] L8 -- `->` event triggers
+- [x] L8a -- Named event core (`event e`, `-> e`, `@e`)
+- [ ] L8b -- `.triggered` semantics (`@(e.triggered)`, `wait(e.triggered)`)
+- [ ] L8c -- Nonblocking event trigger (`->> e`)
 - [ ] L9 -- `inout` ports and tri-state nets
 - [ ] L10 -- Struct/union return types
 - [ ] L11 -- `real`/`shortreal` return types for user-defined functions
@@ -62,9 +64,13 @@ LRM 9.2.3. Procedural block that executes once at end of simulation. Used by ibe
 
 LRM 20.9. `$countbits`, `$countones`, `$onehot`, `$onehot0`, `$isunknown`. Expression-level functions, no scheduling complexity. `$isunknown` is the highest priority -- used by ibex `ASSERT_KNOWN` macros.
 
-## L8: `->` event triggers
+## L8b: `.triggered` semantics
 
-LRM 15.5.1. Named event trigger operator `-> event_name`. Used to explicitly trigger named events that other processes wait on with `@(event_name)`. Requires named event variable support and trigger-to-wakeup plumbing in the scheduler.
+LRM 15.5.3. `@(e.triggered)` and `wait(e.triggered)`. Unlike `@e` (edge-sensitive, can miss a prior trigger), `.triggered` is a time-step-scoped latch: set to 1 by `->` or `->>`, cleared on time advance, readable as a level-sensitive condition. This means a `wait(e.triggered)` that executes after `-> e` in the same time step passes through without suspending. Requires per-event state that tracks whether a trigger occurred this time step, and a time-advance hook to clear it. Critically, `.triggered` is time-step scoped, not delta-scoped -- it remains set across all delta cycles within the same time step and only clears on time advance. This is the fundamental semantic difference from `@e`. Separate from L8a because the latch semantics interact with the scheduler's time-step boundary, which is a different concern from the core trigger/wait plumbing.
+
+## L8c: Nonblocking event trigger
+
+LRM 15.5.2. `->> e` schedules the trigger in the NBA region instead of firing immediately in the Active region. This is a region-scheduling problem, not an event-declaration problem. The runtime already has Active, Inactive, and NBA queues; `->>` needs to defer the wakeup to the NBA region, analogous to how nonblocking assignments defer their commits. Separate from L8a because mixing immediate and deferred trigger semantics in one change risks getting the region ordering wrong.
 
 ## L9: `inout` ports and tri-state nets
 

--- a/include/lyra/common/type.hpp
+++ b/include/lyra/common/type.hpp
@@ -73,6 +73,7 @@ enum class TypeKind {
   kAssociativeArray,
   kEnum,
   kChandle,
+  kEvent,
 };
 
 inline auto ToString(TypeKind kind) -> std::string {
@@ -107,6 +108,8 @@ inline auto ToString(TypeKind kind) -> std::string {
       return "enum";
     case TypeKind::kChandle:
       return "chandle";
+    case TypeKind::kEvent:
+      return "event";
   }
   return "unknown";
 }
@@ -584,6 +587,8 @@ inline auto ToString(const Type& type) -> std::string {
     }
     case TypeKind::kChandle:
       return "chandle";
+    case TypeKind::kEvent:
+      return "event";
   }
   return "unknown";
 }

--- a/include/lyra/common/type_queries.hpp
+++ b/include/lyra/common/type_queries.hpp
@@ -153,6 +153,15 @@ inline auto ComputePackedFillShape(
       "target must be packed (integral or packed array)");
 }
 
+// Check if a type kind represents a value-storage object.
+// Returns false for types that have no data payload and cannot occupy storage
+// slots (e.g., event). Used as the canonical boundary to exclude non-value
+// declarations from slot allocation, type descriptor interning, and any other
+// path that assumes a type has a byte-level representation.
+inline auto HasValueStorage(TypeKind kind) -> bool {
+  return kind != TypeKind::kVoid && kind != TypeKind::kEvent;
+}
+
 // Check if a type kind is "managed" (requires lifecycle operations).
 // Managed types: string, dynamic array, queue.
 inline auto IsManagedKind(TypeKind kind) -> bool {
@@ -206,6 +215,7 @@ inline auto TypeContainsString(TypeId type_id, const TypeArena& arena) -> bool {
 
 // Re-export in common namespace for explicit qualification
 namespace lyra::common {
+using lyra::HasValueStorage;
 using lyra::IsManagedKind;
 using lyra::TypeContainsManaged;
 using lyra::TypeContainsString;

--- a/include/lyra/hir/statement.hpp
+++ b/include/lyra/hir/statement.hpp
@@ -29,6 +29,8 @@ enum class StatementKind {
   kReturn,
   kDelay,
   kEventWait,
+  kNamedEventWait,
+  kEventTrigger,
   kImmediateAssertion,
 };
 
@@ -190,6 +192,18 @@ struct EventWaitStatementData {
   auto operator==(const EventWaitStatementData&) const -> bool = default;
 };
 
+struct NamedEventWaitStatementData {
+  ExpressionId event_expr;
+
+  auto operator==(const NamedEventWaitStatementData&) const -> bool = default;
+};
+
+struct EventTriggerStatementData {
+  ExpressionId target;
+
+  auto operator==(const EventTriggerStatementData&) const -> bool = default;
+};
+
 // Immediate assertion kind (LRM 16.3)
 enum class ImmediateAssertionKind : uint8_t {
   kAssert,
@@ -223,8 +237,8 @@ using StatementData = std::variant<
     CaseStatementData, ForLoopStatementData, WhileLoopStatementData,
     DoWhileLoopStatementData, RepeatLoopStatementData, BreakStatementData,
     ContinueStatementData, TerminateStatementData, ReturnStatementData,
-    DelayStatementData, EventWaitStatementData,
-    ImmediateAssertionStatementData>;
+    DelayStatementData, EventWaitStatementData, NamedEventWaitStatementData,
+    EventTriggerStatementData, ImmediateAssertionStatementData>;
 
 struct Statement {
   StatementKind kind;

--- a/include/lyra/llvm_backend/context.hpp
+++ b/include/lyra/llvm_backend/context.hpp
@@ -291,6 +291,8 @@ class Context {
   [[nodiscard]] auto GetLyraSuspendRepeat() -> llvm::Function*;
   [[nodiscard]] auto GetLyraAllocTriggers() -> llvm::Function*;
   [[nodiscard]] auto GetLyraFreeTriggers() -> llvm::Function*;
+  [[nodiscard]] auto GetLyraSuspendWaitEvent() -> llvm::Function*;
+  [[nodiscard]] auto GetLyraTriggerEvent() -> llvm::Function*;
   [[nodiscard]] auto GetLyraResolveSlotPtr() -> llvm::Function*;
   // R5: Resolve RuntimeInstance* from InstanceId at runtime.
   [[nodiscard]] auto GetLyraResolveInstancePtr() -> llvm::Function*;
@@ -1112,6 +1114,8 @@ class Context {
   llvm::Function* lyra_suspend_repeat_ = nullptr;
   llvm::Function* lyra_alloc_triggers_ = nullptr;
   llvm::Function* lyra_free_triggers_ = nullptr;
+  llvm::Function* lyra_suspend_wait_event_ = nullptr;
+  llvm::Function* lyra_trigger_event_ = nullptr;
   llvm::Function* lyra_resolve_slot_ptr_ = nullptr;
   llvm::Function* lyra_resolve_instance_ptr_ = nullptr;
   // R3 typed coordination helpers.

--- a/include/lyra/lowering/hir_to_mir/builder.hpp
+++ b/include/lyra/lowering/hir_to_mir/builder.hpp
@@ -300,6 +300,8 @@ class MirBuilder {
   void EmitRepeat();
   void EmitDelay(uint64_t ticks, BlockIndex resume);
   void EmitWait(std::vector<mir::WaitTrigger> triggers, BlockIndex resume);
+  void EmitWaitEvent(mir::EventId event, BlockIndex resume);
+  void EmitTriggerEvent(mir::EventId event);
   void EmitTerminate(std::optional<mir::Finish> info = std::nullopt);
 
   // Emit implicit return for function epilogue.

--- a/include/lyra/lowering/hir_to_mir/context.hpp
+++ b/include/lyra/lowering/hir_to_mir/context.hpp
@@ -60,11 +60,17 @@ using InstanceIndexMap = std::unordered_map<SymbolId, uint32_t, SymbolIdHash>;
 
 // Per-module body-local declaration map.
 // Maps module-owned symbols to body-local PlaceIds (kModuleSlot, 0-based).
+using EventMap = std::unordered_map<SymbolId, mir::EventId, SymbolIdHash>;
+
 struct BodyLocalDecls {
   PlaceMap places;
   // Body-local slot descriptors (type + kind), indexed by kModuleSlot id.
   // Built directly as source of truth - not derived from design-global slots.
   std::vector<mir::SlotDesc> slots;
+  // Named event declarations: SymbolId -> body-local EventId.
+  EventMap events;
+  // Body-local event descriptors, indexed by EventId.
+  std::vector<mir::EventDesc> event_descs;
 };
 
 struct DesignDeclarations {
@@ -147,6 +153,7 @@ struct ProvisionalNonLocalTarget {
 struct DeclView {
   const PlaceMap* body_places = nullptr;    // body-local (kModuleSlot)
   const PlaceMap* design_places = nullptr;  // package-global (kDesignGlobal)
+  const EventMap* body_events = nullptr;    // body-local named events
   // Cross-instance places. NOT part of LookupPlace in body lowering.
   // V3d residual: used by design-level LookupPlace fallback only.
   const PlaceMap* cross_instance_places = nullptr;
@@ -218,6 +225,9 @@ struct Context {
   // Avoids creating duplicate body-local Places for the same design-global
   // symbol within one body. Only used during body lowering.
   mutable PlaceMap design_place_cache;
+
+  // Named event map: body-local event declarations (SymbolId -> EventId).
+  const EventMap* body_events = nullptr;
 
   int next_local_id = 0;
   int next_temp_id = 0;
@@ -351,6 +361,16 @@ struct Context {
 
   // Throws InternalError if symbol not found (compiler bug, not user error).
   auto LookupPlace(SymbolId sym) const -> mir::PlaceId;
+
+  // Resolve a named event symbol to its EventId.
+  // Throws InternalError if the symbol is not a named event.
+  auto LookupEvent(SymbolId sym) const -> mir::EventId;
+
+  // Resolve a cross-instance hierarchical reference. Only checks
+  // cross_instance_places, not body/local/design-global places.
+  // Used for kHierarchicalRef expressions and connection compilation.
+  // Throws InternalError if the symbol is not found.
+  auto ResolveHierarchicalRef(SymbolId sym) const -> mir::PlaceId;
 
   // B2: Result of lowering a hierarchical ref to an external ref.
   struct ExternalRefResult {

--- a/include/lyra/mir/design.hpp
+++ b/include/lyra/mir/design.hpp
@@ -50,6 +50,10 @@ struct SlotTraceProvenance {
   uint32_t scope_ref = 0;
 };
 
+struct EventDesc {
+  TypeId type;
+};
+
 struct SlotDesc {
   TypeId type;
   SlotKind kind = SlotKind::kVariable;
@@ -117,6 +121,12 @@ struct Design {
   // built from this. Semantic only: no thunk IDs, payload layout, or
   // backend-specific data.
   std::vector<DeferredAssertionSiteInfo> deferred_assertion_sites;
+
+  // Maximum body-local event count across all module bodies.
+  // Emitted into the runtime ABI as a reserved/debug field. The runtime
+  // event registry uses lazy EventObjectKey keying and does not need
+  // pre-sizing from this value.
+  size_t max_body_local_events = 0;
 };
 
 inline auto GetModuleBody(const Design& design, const Module& mod)

--- a/include/lyra/mir/handle.hpp
+++ b/include/lyra/mir/handle.hpp
@@ -76,6 +76,23 @@ struct PlaceId {
 
 constexpr PlaceId kInvalidPlaceId{UINT32_MAX};
 
+struct EventId {
+  uint32_t value = UINT32_MAX;
+
+  auto operator==(const EventId&) const -> bool = default;
+  auto operator<=>(const EventId&) const = default;
+  explicit operator bool() const {
+    return value != UINT32_MAX;
+  }
+
+  template <typename H>
+  friend auto AbslHashValue(H h, EventId id) -> H {
+    return H::combine(std::move(h), id.value);
+  }
+};
+
+constexpr EventId kInvalidEventId{UINT32_MAX};
+
 struct ModuleBodyId {
   uint32_t value = UINT32_MAX;
 

--- a/include/lyra/mir/module_body.hpp
+++ b/include/lyra/mir/module_body.hpp
@@ -11,6 +11,7 @@ namespace lyra::mir {
 
 enum class SlotKind : uint8_t;
 struct SlotDesc;
+struct EventDesc;
 
 // Implementation-detail body container, pending migration to
 // CompiledModuleBody (compiled_specialization.hpp) in B2.
@@ -37,6 +38,9 @@ struct ModuleBody {
   // This is the body's required storage interface: what slots exist,
   // their kinds, and their types. This is NOT placement/layout metadata.
   std::vector<SlotDesc> slots;
+
+  // Body-local named event descriptors. Indexed by body-local EventId.
+  std::vector<EventDesc> events;
 
   // Total body-global decision site count. Set by module lowering after all
   // functions, processes, and tasks are lowered. Defines the authoritative

--- a/include/lyra/mir/statement.hpp
+++ b/include/lyra/mir/statement.hpp
@@ -157,10 +157,15 @@ auto VisitWriteTarget(const WriteTarget& t, FPlace&& on_place, FExt&& on_ext) {
       where, "backend received Assign with ExternalRefId destination");
 }
 
+// Named event trigger (wakes all processes waiting on the event).
+struct TriggerEvent {
+  EventId event;
+};
+
 // Statement data variant.
 using StatementData = std::variant<
     Assign, GuardedAssign, Effect, DeferredAssign, Call, DpiCall, BuiltinCall,
-    DefineTemp, AssocOp>;
+    DefineTemp, AssocOp, TriggerEvent>;
 
 // A statement that does not affect control flow.
 // - Assign, GuardedAssign, DeferredAssign write to a Place
@@ -236,6 +241,7 @@ void ForEachOperand(const StatementData& stmt, F&& f) {
                 a.data);
           },
           [](const Effect&) {},
+          [](const TriggerEvent&) {},
       },
       stmt);
 }

--- a/include/lyra/mir/terminator.hpp
+++ b/include/lyra/mir/terminator.hpp
@@ -133,6 +133,12 @@ struct Wait {
   BasicBlockId resume = {};           // Block to resume after trigger fires
 };
 
+// Named event wait suspension (requires scheduler).
+struct WaitEvent {
+  EventId event;
+  BasicBlockId resume = {};
+};
+
 // Return terminator - ends execution of a function or process.
 // For functions: value must be present (functions always return a value).
 // For processes: value is empty (processes don't return values).
@@ -163,8 +169,8 @@ struct Finish {
 struct Repeat {};
 
 // Terminator data variant.
-using TerminatorData =
-    std::variant<Jump, Branch, Switch, Delay, Wait, Return, Finish, Repeat>;
+using TerminatorData = std::variant<
+    Jump, Branch, Switch, Delay, Wait, WaitEvent, Return, Finish, Repeat>;
 
 // A block terminator that determines control flow.
 struct Terminator {
@@ -205,6 +211,9 @@ void ForEachSuccessor(const Terminator& term, const F& func) {
           [&](const Wait& w) {
             func(TerminatorSuccessor{.target = w.resume, .args = {}});
           },
+          [&](const WaitEvent& we) {
+            func(TerminatorSuccessor{.target = we.resume, .args = {}});
+          },
           [](const Return&) {},
           [](const Finish&) {},
           [](const Repeat&) {},
@@ -222,6 +231,7 @@ void ForEachLocalOperand(const Terminator& term, const F& func) {
           [&](const Switch& s) { func(s.selector); },
           [](const Delay&) {},
           [](const Wait&) {},
+          [](const WaitEvent&) {},
           [&](const Return& r) {
             if (r.value) func(*r.value);
           },

--- a/include/lyra/mir/verify.hpp
+++ b/include/lyra/mir/verify.hpp
@@ -26,6 +26,10 @@ struct VerifyContext {
   const CompiledModuleBody* body = nullptr;
   const TypeArena* types = nullptr;
   Phase phase = Phase::kBackendReady;
+
+  // Body-local named event count. Used to validate EventId operands
+  // in WaitEvent/TriggerEvent. 0 when event info is unavailable.
+  uint32_t num_events = 0;
 };
 
 // Canonical external-ref recipe resolver. Validates ref_id is in range,

--- a/include/lyra/runtime/activation_trace.hpp
+++ b/include/lyra/runtime/activation_trace.hpp
@@ -17,6 +17,7 @@ enum class WakeCause : uint8_t {
   kDelayZero,
   kInitial,
   kRepeat,
+  kEvent,
 };
 
 constexpr auto HasTriggerSlot(WakeCause c) -> bool {
@@ -29,6 +30,7 @@ constexpr auto HasTriggerSlot(WakeCause c) -> bool {
     case WakeCause::kDelayZero:
     case WakeCause::kInitial:
     case WakeCause::kRepeat:
+    case WakeCause::kEvent:
       return false;
   }
   return false;

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -27,6 +27,7 @@
 #include "lyra/runtime/engine_scheduler.hpp"
 #include "lyra/runtime/engine_subscriptions.hpp"
 #include "lyra/runtime/engine_types.hpp"
+#include "lyra/runtime/event_registry.hpp"
 #include "lyra/runtime/feature_flags.hpp"
 #include "lyra/runtime/file_manager.hpp"
 #include "lyra/runtime/instance_metadata.hpp"
@@ -779,6 +780,27 @@ class Engine {
     wait_site_meta_ = std::move(registry);
   }
 
+  // Add a waiter to a named event object. Called by activation
+  // post-processing when a process suspends with kWaitEvent.
+  // key: (instance_id, local_event_id) uniquely identifying the runtime
+  // event object within this design.
+  void AddEventWaiter(EventObjectKey key, EventWaiter waiter) {
+    event_registry_.AddWaiter(key, waiter);
+  }
+
+  // Consume all waiters for a named event object and enqueue them for
+  // wakeup. Called by LyraTriggerEvent ABI function.
+  // key: (instance_id, local_event_id) uniquely identifying the runtime
+  // event object within this design.
+  void TriggerEvent(EventObjectKey key) {
+    auto waiters = event_registry_.ConsumeWaiters(key);
+    for (const auto& w : waiters) {
+      EnqueueProcessWakeup(
+          w.process_id, w.instance_id, w.resume_block, key.local_event_id,
+          WakeCause::kEvent);
+    }
+  }
+
   // One-time init for global trace signal metadata registry. Must be called
   // exactly once. Engine owns both the registry and the global selection mask.
   // The non-owning pointer passed to TraceManager remains valid for Engine's
@@ -1419,6 +1441,9 @@ class Engine {
 
   // Wait-site metadata registry for persistent wait installation.
   WaitSiteRegistry wait_site_meta_;
+
+  // Named event registry for event-based synchronization.
+  EventRegistry event_registry_;
 
   // Per-site hit counts for immediate cover statements.
   std::vector<uint64_t> immediate_cover_counts_;

--- a/include/lyra/runtime/event_registry.hpp
+++ b/include/lyra/runtime/event_registry.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace lyra::runtime {
+
+// Typed runtime identity for a named event object.
+//
+// A named event is an instance-owned synchronization primitive: two instances
+// of the same module body have independent event objects even though they
+// share the same body-local EventId at compile time. At runtime, the pair
+// (instance_id, local_event_id) uniquely identifies a single event object,
+// where local_event_id is the body-local ordinal for the instance's active
+// compiled body.
+struct EventObjectKey {
+  uint32_t instance_id;
+  uint32_t local_event_id;
+
+  auto operator==(const EventObjectKey&) const -> bool = default;
+};
+
+struct EventObjectKeyHash {
+  auto operator()(const EventObjectKey& key) const -> size_t {
+    return std::hash<uint64_t>{}(
+        (static_cast<uint64_t>(key.instance_id) << 32) | key.local_event_id);
+  }
+};
+
+struct EventWaiter {
+  uint32_t process_id;
+  uint32_t instance_id;
+  uint32_t resume_block;
+};
+
+// Runtime state for one event object (one per instance x body-local event).
+struct EventRuntimeState {
+  std::vector<EventWaiter> waiters;
+};
+
+// Named event synchronization registry.
+//
+// Events are instance-owned objects: two instances of the same module body
+// have independent event objects even though they share the same body-local
+// EventId. The registry keys by EventObjectKey to maintain this identity
+// separation.
+class EventRegistry {
+ public:
+  // Register a waiter on a specific event object.
+  void AddWaiter(EventObjectKey key, EventWaiter waiter) {
+    events_[key].waiters.push_back(waiter);
+  }
+
+  // Consume and return all waiters for a specific event object (one-shot).
+  // Erases the entry to keep the map clean after consumption.
+  auto ConsumeWaiters(EventObjectKey key) -> std::vector<EventWaiter> {
+    auto it = events_.find(key);
+    if (it == events_.end()) {
+      return {};
+    }
+    auto waiters = std::move(it->second.waiters);
+    events_.erase(it);
+    return waiters;
+  }
+
+ private:
+  std::unordered_map<EventObjectKey, EventRuntimeState, EventObjectKeyHash>
+      events_;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_abi.hpp
+++ b/include/lyra/runtime/runtime_abi.hpp
@@ -76,7 +76,8 @@ struct RuntimeInstance;
 // v21: D6d simulation-global precision power and per-body timescale metadata.
 // v22: A2 deferred assertion site metadata table.
 // v23: A2e deferred assertion thunk pointers + payload sizes in site metadata.
-inline constexpr uint32_t kRuntimeAbiVersion = 23;
+// v24: L8a named event count for runtime event registry sizing.
+inline constexpr uint32_t kRuntimeAbiVersion = 24;
 
 struct LyraRuntimeAbi {
   uint32_t version;  // = kRuntimeAbiVersion
@@ -153,10 +154,16 @@ struct LyraRuntimeAbi {
   const void* deferred_assertion_site_meta;
   uint32_t num_deferred_assertion_sites;
   uint32_t pad_deferred;
+
+  // L8a: Maximum body-local named event count across all module bodies.
+  // Reserved/debug field; the runtime event registry uses lazy
+  // EventObjectKey keying and does not need pre-sizing from this value.
+  uint32_t num_events;
+  uint32_t pad_events;
 };
 
 // Hard size/offset contract.
-static_assert(sizeof(LyraRuntimeAbi) == 264);
+static_assert(sizeof(LyraRuntimeAbi) == 272);
 static_assert(offsetof(LyraRuntimeAbi, version) == 0);
 static_assert(offsetof(LyraRuntimeAbi, num_connection_processes) == 188);
 static_assert(offsetof(LyraRuntimeAbi, design_state) == 192);
@@ -168,3 +175,4 @@ static_assert(offsetof(LyraRuntimeAbi, num_immediate_cover_sites) == 232);
 static_assert(offsetof(LyraRuntimeAbi, global_precision_power) == 240);
 static_assert(offsetof(LyraRuntimeAbi, deferred_assertion_site_meta) == 248);
 static_assert(offsetof(LyraRuntimeAbi, num_deferred_assertion_sites) == 256);
+static_assert(offsetof(LyraRuntimeAbi, num_events) == 264);

--- a/include/lyra/runtime/scheduler_snapshot.hpp
+++ b/include/lyra/runtime/scheduler_snapshot.hpp
@@ -20,6 +20,7 @@ enum class ProcessWaitKind : uint8_t {
   kSuspendedChange,
   kSuspendedMulti,
   kSuspendedRepeat,
+  kSuspendedEvent,
   kSuspendedUnknown,
   kFinished,
 };

--- a/include/lyra/runtime/simulation.hpp
+++ b/include/lyra/runtime/simulation.hpp
@@ -98,6 +98,10 @@ void LyraSuspendWaitWithLateBound(
     const void* plan_ops, uint32_t num_plan_ops, const void* dep_slots,
     uint32_t num_dep_slots, uint32_t wait_site_id);
 void LyraSuspendRepeat(void* state);
+void LyraSuspendWaitEvent(
+    void* state, uint32_t resume_block, uint32_t event_id);
+void LyraTriggerEvent(
+    void* engine_ptr, uint32_t instance_id, uint32_t local_event_id);
 
 // Strobe observer program type: uses canonical StrobeProgramFn from
 // observer.hpp.

--- a/include/lyra/runtime/suspend_record.hpp
+++ b/include/lyra/runtime/suspend_record.hpp
@@ -17,6 +17,7 @@ enum class SuspendTag : uint8_t {
   kDelay = 1,
   kWait = 2,
   kRepeat = 3,
+  kWaitEvent = 4,
 };
 
 // Trigger install kind: explicit per-trigger classification written by codegen.
@@ -211,6 +212,7 @@ struct SuspendRecord {
   uint32_t num_dep_slots = 0;
   DepSignalRecord* dep_slots_ptr = nullptr;
   std::array<WaitTriggerRecord, kInlineTriggerCapacity> inline_triggers = {};
+  uint32_t event_id = 0;  // For kWaitEvent
 };
 
 // Layout invariants (relative ordering and alignment, not absolute offsets)

--- a/src/lyra/llvm_backend/activation_local.cpp
+++ b/src/lyra/llvm_backend/activation_local.cpp
@@ -18,6 +18,7 @@ auto IsSegmentExitBlock(const mir::BasicBlock& block) -> bool {
       [](const auto& t) -> bool {
         using T = std::decay_t<decltype(t)>;
         return std::is_same_v<T, mir::Delay> || std::is_same_v<T, mir::Wait> ||
+               std::is_same_v<T, mir::WaitEvent> ||
                std::is_same_v<T, mir::Return> ||
                std::is_same_v<T, mir::Finish> || std::is_same_v<T, mir::Repeat>;
       },

--- a/src/lyra/llvm_backend/callable_abi.cpp
+++ b/src/lyra/llvm_backend/callable_abi.cpp
@@ -72,11 +72,12 @@ auto ClassifyCallableValueAbi(
       return std::nullopt;
 
     case TypeKind::kVoid:
+    case TypeKind::kEvent:
       throw common::InternalError(
           "ClassifyCallableValueAbi",
           std::format(
-              "void type {} must not reach callable value classification",
-              type_id.value));
+              "{} type {} must not reach callable value classification",
+              ToString(type.Kind()), type_id.value));
   }
 
   throw common::InternalError(

--- a/src/lyra/llvm_backend/context_runtime.cpp
+++ b/src/lyra/llvm_backend/context_runtime.cpp
@@ -530,6 +530,32 @@ auto Context::GetLyraFreeTriggers() -> llvm::Function* {
   return lyra_free_triggers_;
 }
 
+auto Context::GetLyraSuspendWaitEvent() -> llvm::Function* {
+  if (lyra_suspend_wait_event_ == nullptr) {
+    auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
+    auto* i32_ty = llvm::Type::getInt32Ty(*llvm_context_);
+    auto* fn_type = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*llvm_context_), {ptr_ty, i32_ty, i32_ty}, false);
+    lyra_suspend_wait_event_ = llvm::Function::Create(
+        fn_type, llvm::Function::ExternalLinkage, "LyraSuspendWaitEvent",
+        llvm_module_.get());
+  }
+  return lyra_suspend_wait_event_;
+}
+
+auto Context::GetLyraTriggerEvent() -> llvm::Function* {
+  if (lyra_trigger_event_ == nullptr) {
+    auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
+    auto* i32_ty = llvm::Type::getInt32Ty(*llvm_context_);
+    auto* fn_type = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*llvm_context_), {ptr_ty, i32_ty, i32_ty}, false);
+    lyra_trigger_event_ = llvm::Function::Create(
+        fn_type, llvm::Function::ExternalLinkage, "LyraTriggerEvent",
+        llvm_module_.get());
+  }
+  return lyra_trigger_event_;
+}
+
 auto Context::GetLyraResolveSlotPtr() -> llvm::Function* {
   if (lyra_resolve_slot_ptr_ == nullptr) {
     auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);

--- a/src/lyra/llvm_backend/emit_design_main.cpp
+++ b/src/lyra/llvm_backend/emit_design_main.cpp
@@ -2029,7 +2029,8 @@ auto BuildRuntimeAbi(
     const ConstructorSlotTraceMeta& slot_trace,
     uint32_t num_immediate_cover_sites, int8_t global_precision_power,
     llvm::Constant* deferred_site_meta_global,
-    uint32_t num_deferred_assertion_sites) -> llvm::Value* {
+    uint32_t num_deferred_assertion_sites, uint32_t num_events)
+    -> llvm::Value* {
   auto& builder = context.GetBuilder();
   auto& ctx = context.GetLlvmContext();
   auto* i32_ty = llvm::Type::getInt32Ty(ctx);
@@ -2120,6 +2121,10 @@ auto BuildRuntimeAbi(
               : llvm::ConstantPointerNull::get(ptr_ty));
   store_field(36, llvm::ConstantInt::get(i32_ty, num_deferred_assertion_sites));
   store_field(37, llvm::ConstantInt::get(i32_ty, 0));
+
+  // L8a: Named event count.
+  store_field(38, llvm::ConstantInt::get(i32_ty, num_events));
+  store_field(39, llvm::ConstantInt::get(i32_ty, 0));
 
   return abi_alloca;
 }
@@ -2663,7 +2668,8 @@ auto EmitDesignMain(
         process_meta_for_abi, trigger_comb_for_abi, slot_trace_for_abi,
         static_cast<uint32_t>(input.design->immediate_cover_sites.size()),
         input.design->global_precision_power, deferred_site_meta_global,
-        static_cast<uint32_t>(input.design->deferred_assertion_sites.size()));
+        static_cast<uint32_t>(input.design->deferred_assertion_sites.size()),
+        static_cast<uint32_t>(input.design->max_body_local_events));
     abi_for_exit = abi_alloca;
 
     EmitRunSimulation(

--- a/src/lyra/llvm_backend/instruction.cpp
+++ b/src/lyra/llvm_backend/instruction.cpp
@@ -144,6 +144,14 @@ auto LowerStatement(
           [&](const mir::AssocOp& op) -> Result<void> {
             return LowerAssocOp(context, resolver, op);
           },
+          [&](const mir::TriggerEvent& te) -> Result<void> {
+            auto& builder = context.GetBuilder();
+            builder.CreateCall(
+                context.GetLyraTriggerEvent(),
+                {context.GetEnginePointer(), context.GetDynamicInstanceId(),
+                 builder.getInt32(te.event.value)});
+            return {};
+          },
       },
       statement.data);
 }

--- a/src/lyra/llvm_backend/layout/layout.cpp
+++ b/src/lyra/llvm_backend/layout/layout.cpp
@@ -302,10 +302,11 @@ auto GetLlvmTypeForTypeId(
       return llvm::PointerType::getUnqual(ctx);
 
     case TypeKind::kVoid:
+    case TypeKind::kEvent:
       throw common::InternalError(
           "GetLlvmTypeForTypeId",
           std::format(
-              "unsupported type kind: {}", static_cast<int>(type.Kind())));
+              "{} type has no value-storage semantics", ToString(type.Kind())));
   }
 
   // Unreachable - all cases handled above
@@ -792,6 +793,7 @@ auto CollectProcessPlaces(const mir::Process& process, const mir::Arena& arena)
                     },
                     aop.data);
               },
+              [](const mir::TriggerEvent&) {},
           },
           instr.data);
     }
@@ -863,7 +865,8 @@ auto CollectProcessRoots(
 auto ProcessHasSuspension(const mir::Process& process) -> bool {
   return std::ranges::any_of(process.blocks, [](const auto& block) {
     return std::holds_alternative<mir::Delay>(block.terminator.data) ||
-           std::holds_alternative<mir::Wait>(block.terminator.data);
+           std::holds_alternative<mir::Wait>(block.terminator.data) ||
+           std::holds_alternative<mir::WaitEvent>(block.terminator.data);
   });
 }
 
@@ -887,6 +890,7 @@ auto IsStatementPure(const mir::Statement& stmt) -> bool {
           [](const mir::DpiCall&) { return false; },
           [](const mir::BuiltinCall&) { return false; },
           [](const mir::AssocOp&) { return false; },
+          [](const mir::TriggerEvent&) { return false; },
       },
       stmt.data);
 }
@@ -899,6 +903,7 @@ auto IsTerminatorPureCF(const mir::Terminator& term) -> bool {
           [](const mir::Branch&) { return true; },
           [](const mir::Switch&) { return true; },
           [](const mir::Wait&) { return true; },
+          [](const mir::WaitEvent&) { return true; },
           [](const mir::Delay&) { return false; },
           [](const mir::Return&) { return false; },
           [](const mir::Finish&) { return false; },

--- a/src/lyra/llvm_backend/layout/storage_contract.cpp
+++ b/src/lyra/llvm_backend/layout/storage_contract.cpp
@@ -244,6 +244,10 @@ auto ResolveImpl(
     case TypeKind::kVoid:
       throw common::InternalError(
           "ResolveStorageSpec", "void type cannot have storage");
+
+    case TypeKind::kEvent:
+      throw common::InternalError(
+          "ResolveStorageSpec", "event type has no value-storage semantics");
   }
 
   throw common::InternalError("ResolveStorageSpec", "unreachable");

--- a/src/lyra/llvm_backend/process.cpp
+++ b/src/lyra/llvm_backend/process.cpp
@@ -96,6 +96,8 @@ void ValidateInitProcessContract(const mir::Process& process) {
             suspension_name = "Delay";
           } else if constexpr (std::is_same_v<T, mir::Wait>) {
             suspension_name = "Wait";
+          } else if constexpr (std::is_same_v<T, mir::WaitEvent>) {
+            suspension_name = "WaitEvent";
           } else if constexpr (std::is_same_v<T, mir::Repeat>) {
             suspension_name = "Repeat";
           }
@@ -1595,6 +1597,15 @@ auto LowerTerminator(
             LowerRepeat(context, exit_block);
             return {};
           },
+          [&](const mir::WaitEvent& we) -> Result<void> {
+            auto& builder = context.GetBuilder();
+            builder.CreateCall(
+                context.GetLyraSuspendWaitEvent(),
+                {context.GetStatePointer(), builder.getInt32(we.resume.value),
+                 builder.getInt32(we.event.value)});
+            builder.CreateBr(exit_block);
+            return {};
+          },
           [&](const auto&) -> Result<void> {
             return std::unexpected(
                 context.GetDiagnosticContext().MakeUnsupported(
@@ -1751,6 +1762,8 @@ auto GenerateProcessFunction(
             if constexpr (std::is_same_v<T, mir::Delay>) {
               resume_targets.push_back(term.resume.value);
             } else if constexpr (std::is_same_v<T, mir::Wait>) {
+              resume_targets.push_back(term.resume.value);
+            } else if constexpr (std::is_same_v<T, mir::WaitEvent>) {
               resume_targets.push_back(term.resume.value);
             }
           },
@@ -1949,6 +1962,8 @@ auto GenerateSharedProcessFunction(
           if constexpr (std::is_same_v<T, mir::Delay>) {
             resume_targets.push_back(term.resume.value);
           } else if constexpr (std::is_same_v<T, mir::Wait>) {
+            resume_targets.push_back(term.resume.value);
+          } else if constexpr (std::is_same_v<T, mir::WaitEvent>) {
             resume_targets.push_back(term.resume.value);
           }
         },

--- a/src/lyra/llvm_backend/runtime_abi_codegen.cpp
+++ b/src/lyra/llvm_backend/runtime_abi_codegen.cpp
@@ -18,7 +18,7 @@ namespace {
 
 // ABI struct field indices. Private to this file.
 // Must match the C++ LyraRuntimeAbi in runtime_abi.hpp.
-constexpr unsigned kAbiFieldCount = 38;
+constexpr unsigned kAbiFieldCount = 40;
 constexpr unsigned kAbiFieldInstancePtrs = 27;
 
 }  // namespace
@@ -66,6 +66,9 @@ auto GetRuntimeAbiStructType(llvm::LLVMContext& ctx) -> llvm::StructType* {
       i8_ty,
       // A2: deferred assertion site metadata (ptr, i32 count, i32 pad)
       ptr_ty,
+      i32_ty,
+      i32_ty,
+      // L8a: named event count (i32 count, i32 pad)
       i32_ty,
       i32_ty,
   };

--- a/src/lyra/lowering/ast_to_hir/repertoire_descriptor.cpp
+++ b/src/lyra/lowering/ast_to_hir/repertoire_descriptor.cpp
@@ -15,6 +15,7 @@
 #include <slang/ast/symbols/MemberSymbols.h>
 #include <slang/ast/symbols/ValueSymbol.h>
 #include <slang/ast/symbols/VariableSymbols.h>
+#include <slang/ast/types/Type.h>
 
 #include "lyra/common/internal_error.hpp"
 #include "lyra/lowering/ast_to_hir/compile_owned_type_desc.hpp"
@@ -304,6 +305,14 @@ auto BuildDescInternal(const slang::ast::InstanceBodySymbol& body)
     // Inventory decl handles are guaranteed to be ValueSymbol-backed
     // (variable/net declarations only).
     const auto& value_sym = handle.symbol->as<slang::ast::ValueSymbol>();
+
+    // Non-value-storage types (e.g., event) have no type descriptor.
+    // Filter at the AST boundary before entering the Lyra type path.
+    // This is the AST-facing equivalent of HasValueStorage(TypeKind).
+    if (value_sym.getType().isEvent()) {
+      continue;
+    }
+
     auto type_id = InternCompileOwnedType(value_sym.getType(), desc.type_store);
 
     debug_view.decl_names[{coord, ordinal}] = std::string(handle.symbol->name);

--- a/src/lyra/lowering/ast_to_hir/statement.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement.cpp
@@ -8,10 +8,13 @@
 #include <slang/ast/statements/MiscStatements.h>
 
 #include "lyra/common/diagnostic/diagnostic_sink.hpp"
+#include "lyra/common/type.hpp"
 #include "lyra/hir/arena.hpp"
+#include "lyra/hir/expression.hpp"
 #include "lyra/hir/fwd.hpp"
 #include "lyra/hir/statement.hpp"
 #include "lyra/lowering/ast_to_hir/context.hpp"
+#include "lyra/lowering/ast_to_hir/expression.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/statement_assert.hpp"
 #include "lyra/lowering/ast_to_hir/statement_control_flow.hpp"
@@ -119,6 +122,36 @@ auto LowerStatement(const slang::ast::Statement& stmt, ScopeLowerer& lowerer)
           "concurrent assertion statements are unsupported; "
           "pass --disable-assertions to skip");
       return hir::kInvalidStatementId;
+    }
+
+    case StatementKind::EventTrigger: {
+      const auto& trigger_stmt = stmt.as<slang::ast::EventTriggerStatement>();
+      SourceSpan span = ctx->SpanOf(stmt.sourceRange);
+
+      if (trigger_stmt.isNonBlocking) {
+        ctx->sink->Error(
+            span, "nonblocking event trigger (->>) not yet supported");
+        return hir::kInvalidStatementId;
+      }
+
+      auto target = LowerScopedExpression(
+          trigger_stmt.target, *ctx, lowerer.Registrar(), lowerer.Frame());
+      if (!target) {
+        return hir::kInvalidStatementId;
+      }
+
+      TypeId target_type = (*ctx->hir_arena)[target].type;
+      if ((*ctx->type_arena)[target_type].Kind() != TypeKind::kEvent) {
+        ctx->sink->Error(span, "event trigger target must be an event type");
+        return hir::kInvalidStatementId;
+      }
+
+      return ctx->hir_arena->AddStatement(
+          hir::Statement{
+              .kind = hir::StatementKind::kEventTrigger,
+              .span = span,
+              .data = hir::EventTriggerStatementData{.target = target},
+          });
     }
 
     default:

--- a/src/lyra/lowering/ast_to_hir/statement_timing.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement_timing.cpp
@@ -14,7 +14,9 @@
 #include "lyra/common/diagnostic/diagnostic.hpp"
 #include "lyra/common/diagnostic/diagnostic_sink.hpp"
 #include "lyra/common/source_span.hpp"
+#include "lyra/common/type.hpp"
 #include "lyra/hir/arena.hpp"
+#include "lyra/hir/expression.hpp"
 #include "lyra/hir/fwd.hpp"
 #include "lyra/hir/statement.hpp"
 #include "lyra/lowering/ast_to_hir/context.hpp"
@@ -408,9 +410,35 @@ auto LowerSignalEvent(
 
   const auto& sig_event = timed.timing.as<slang::ast::SignalEventControl>();
 
+  // Early AST-boundary check for named event edge rejection.
+  // slang rejects edge specifiers on event-typed expressions during
+  // elaboration (ExprMustBeIntegral), which prevents our lowering from
+  // running. This check fires when lowering is reached (e.g., if slang
+  // error checking is relaxed or future slang versions change behavior).
+  // The driver and test framework also check slang diagnostics for
+  // event+edge and surface a targeted message at the frontend level.
+  if (sig_event.expr.type->isEvent() &&
+      sig_event.edge != slang::ast::EdgeKind::None) {
+    ctx->sink->Error(span, "edge specifiers not applicable to named events");
+    return hir::kInvalidStatementId;
+  }
+
   hir::ExpressionId signal_expr = lower_expr(sig_event.expr);
   if (!signal_expr) {
     return hir::kInvalidStatementId;
+  }
+
+  // Dispatch on Lyra type: events go to the named-event wait path,
+  // signals go to the standard signal-subscription path.
+  TypeId expr_type = (*ctx->hir_arena)[signal_expr].type;
+  if ((*ctx->type_arena)[expr_type].Kind() == TypeKind::kEvent) {
+    hir::StatementId wait_stmt = ctx->hir_arena->AddStatement(
+        hir::Statement{
+            .kind = hir::StatementKind::kNamedEventWait,
+            .span = span,
+            .data = hir::NamedEventWaitStatementData{.event_expr = signal_expr},
+        });
+    return AppendTimedBody(wait_stmt, timed.stmt, span, lowerer);
   }
 
   hir::EventEdgeKind edge = MapEdgeKind(sig_event.edge);

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -70,6 +70,10 @@ auto LowerType(const slang::ast::Type& type, SourceSpan source, Context* ctx)
     return ctx->type_arena->Intern(TypeKind::kChandle, std::monostate{});
   }
 
+  if (canonical.kind == slang::ast::SymbolKind::EventType) {
+    return ctx->type_arena->Intern(TypeKind::kEvent, std::monostate{});
+  }
+
   // Check isPackedArray BEFORE isIntegral - packed arrays are integral in slang
   // but we want them as a distinct type kind with their own range/direction.
   if (canonical.isPackedArray()) {

--- a/src/lyra/lowering/hir_to_mir/builder.cpp
+++ b/src/lyra/lowering/hir_to_mir/builder.cpp
@@ -1286,6 +1286,18 @@ void MirBuilder::EmitWait(
       });
 }
 
+void MirBuilder::EmitWaitEvent(mir::EventId event, BlockIndex resume) {
+  EmitTerm(
+      mir::WaitEvent{
+          .event = event,
+          .resume = mir::BasicBlockId{resume.value},
+      });
+}
+
+void MirBuilder::EmitTriggerEvent(mir::EventId event) {
+  EmitInst(mir::TriggerEvent{.event = event});
+}
+
 void MirBuilder::EmitTerminate(std::optional<mir::Finish> info) {
   if (info) {
     EmitTerm(*std::move(info));
@@ -1386,6 +1398,8 @@ void RemapTerminatorTargets(
         } else if constexpr (std::is_same_v<T, mir::Delay>) {
           RemapTarget(t.resume, block_map);
         } else if constexpr (std::is_same_v<T, mir::Wait>) {
+          RemapTarget(t.resume, block_map);
+        } else if constexpr (std::is_same_v<T, mir::WaitEvent>) {
           RemapTarget(t.resume, block_map);
         }
         // Return, Finish, Repeat have no targets

--- a/src/lyra/lowering/hir_to_mir/context.cpp
+++ b/src/lyra/lowering/hir_to_mir/context.cpp
@@ -104,6 +104,14 @@ auto Context::AllocValueTemp(TypeId type) -> int {
 }
 
 auto Context::LookupPlace(SymbolId sym) const -> mir::PlaceId {
+  // Fail-closed: event symbols must never reach place/value lowering.
+  // They are resolved via LookupEvent() on a separate path.
+  if (body_events != nullptr && body_events->contains(sym)) {
+    throw common::InternalError(
+        "LookupPlace",
+        std::format("symbol {} is a named event and has no place", sym.value));
+  }
+
   // Lookup order: local -> body -> design-global
   auto it = local_places.find(sym);
   if (it != local_places.end()) {
@@ -150,6 +158,43 @@ auto Context::LookupPlace(SymbolId sym) const -> mir::PlaceId {
   throw common::InternalError(
       "HIR to MIR lowering",
       std::format("symbol {} not found in place mapping", sym.value));
+}
+
+auto Context::LookupEvent(SymbolId sym) const -> mir::EventId {
+  if (body_events != nullptr) {
+    auto it = body_events->find(sym);
+    if (it != body_events->end()) {
+      return it->second;
+    }
+  }
+  throw common::InternalError(
+      "LookupEvent", std::format("symbol {} is not a named event", sym.value));
+}
+
+auto Context::ResolveHierarchicalRef(SymbolId sym) const -> mir::PlaceId {
+  if (cross_instance_places == nullptr) {
+    throw common::InternalError(
+        "ResolveHierarchicalRef",
+        "cross-instance reference without cross_instance_places set");
+  }
+  auto it = cross_instance_places->find(sym);
+  if (it == cross_instance_places->end()) {
+    throw common::InternalError(
+        "ResolveHierarchicalRef",
+        std::format("symbol {} not found in cross-instance places", sym.value));
+  }
+  // During body lowering: create body-local Place with kDesignGlobal root.
+  if (design_arena != nullptr) {
+    auto cache_it = design_place_cache.find(sym);
+    if (cache_it != design_place_cache.end()) {
+      return cache_it->second;
+    }
+    const mir::Place& place = (*design_arena)[it->second];
+    mir::PlaceId body_place_id = mir_arena->AddPlace(mir::Place(place));
+    design_place_cache[sym] = body_place_id;
+    return body_place_id;
+  }
+  return it->second;
 }
 
 auto Context::LowerHierarchicalRefToExternalRef(

--- a/src/lyra/lowering/hir_to_mir/design_decls.cpp
+++ b/src/lyra/lowering/hir_to_mir/design_decls.cpp
@@ -10,6 +10,7 @@
 
 #include "lyra/common/internal_error.hpp"
 #include "lyra/common/symbol.hpp"
+#include "lyra/common/type.hpp"
 #include "lyra/hir/design.hpp"
 #include "lyra/hir/dpi.hpp"
 #include "lyra/hir/fwd.hpp"
@@ -70,6 +71,17 @@ auto CollectBodyLocalDecls(
 
   for (SymbolId var : module.variables) {
     const Symbol& sym = symbol_table[var];
+
+    // Named events are synchronization primitives with no byte-level
+    // storage. Allocate a dedicated EventId instead of a slot.
+    if (type_arena[sym.type].Kind() == TypeKind::kEvent) {
+      auto event_id =
+          mir::EventId{static_cast<uint32_t>(body_decls.event_descs.size())};
+      body_decls.events[var] = event_id;
+      body_decls.event_descs.push_back(mir::EventDesc{.type = sym.type});
+      continue;
+    }
+
     mir::Place body_place{
         .root =
             mir::PlaceRoot{

--- a/src/lyra/lowering/hir_to_mir/design_lower.cpp
+++ b/src/lyra/lowering/hir_to_mir/design_lower.cpp
@@ -188,6 +188,8 @@ auto LowerDesign(
   mir::Design result;
   result.num_design_slots = decls.num_design_slots;
   result.slots = decls.slots;
+  // max_body_local_events is populated after all module bodies are lowered
+  // (see Phase 2 below).
   result.slot_trace_provenance = decls.slot_trace_provenance;
   result.slot_trace_string_pool = decls.slot_trace_string_pool;
 
@@ -371,6 +373,13 @@ auto LowerDesign(
     body_function_maps[body_id.value] = std::move(product.symbol_to_function);
     spec_to_body[spec_groups[g].spec_id] = body_id;
   }
+
+  // Track max body-local event count (for ABI reserved field).
+  size_t max_events = 0;
+  for (const auto& body : result.module_bodies) {
+    max_events = std::max(max_events, body.events.size());
+  }
+  result.max_body_local_events = max_events;
 
   result.immediate_cover_sites = cover_site_registry.TakeSites();
   result.deferred_assertion_sites =

--- a/src/lyra/lowering/hir_to_mir/lower.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower.cpp
@@ -61,8 +61,10 @@ void VerifyLoweredMir(
               // When Phase 2 migrates to CompiledModuleBody, this call site
               // switches to VerifyPreBackendBody(compiled_body, ...).
               mir::VerifyContext cx{
-                  nullptr, &type_arena,
-                  mir::VerifyContext::Phase::kBackendReady};
+                  .types = &type_arena,
+                  .phase = mir::VerifyContext::Phase::kBackendReady,
+                  .num_events = static_cast<uint32_t>(body.events.size()),
+              };
               std::string_view module_path =
                   instance_table.GetPathBySymbol(mod.instance_sym);
               for (size_t fi = 0; fi < body.functions.size(); ++fi) {
@@ -87,8 +89,9 @@ void VerifyLoweredMir(
             },
             [&](const mir::Package& pkg) {
               mir::VerifyContext cx{
-                  nullptr, &type_arena,
-                  mir::VerifyContext::Phase::kBackendReady};
+                  .types = &type_arena,
+                  .phase = mir::VerifyContext::Phase::kBackendReady,
+              };
               for (size_t fi = 0; fi < pkg.functions.size(); ++fi) {
                 std::string label =
                     std::format("element[{}]: function[{}]", ei, fi);

--- a/src/lyra/lowering/hir_to_mir/module.cpp
+++ b/src/lyra/lowering/hir_to_mir/module.cpp
@@ -39,6 +39,7 @@ auto LowerModule(
   // Body-local slot descriptors come from specialization-local collection,
   // not from design-global declaration state.
   result.slots = body_decls.slots;
+  result.events = body_decls.event_descs;
 
   // Body-local origin storage. All origins produced during body lowering
   // are isolated here, not in a shared origin map.
@@ -84,6 +85,7 @@ auto LowerModule(
   DeclView decl_view{
       .body_places = &body_decls.places,
       .design_places = &decls.design_places,
+      .body_events = &body_decls.events,
       .cross_instance_places =
           cross_instance_places,  // V3d residual: design-level paths only
       .functions = &symbol_to_mir_function,

--- a/src/lyra/lowering/hir_to_mir/process.cpp
+++ b/src/lyra/lowering/hir_to_mir/process.cpp
@@ -115,6 +115,7 @@ auto LowerProcess(
       .design_places = decl_view.design_places,
       .local_places = {},
       .design_place_cache = {},
+      .body_events = decl_view.body_events,
       .next_local_id = 0,
       .next_temp_id = 0,
       .local_types = {},

--- a/src/lyra/lowering/hir_to_mir/routine.cpp
+++ b/src/lyra/lowering/hir_to_mir/routine.cpp
@@ -72,6 +72,11 @@ auto ComputeReturnPolicy(TypeId return_type, const TypeArena& types)
     // Direct return: chandle is an opaque pointer (fits in a register)
     case TypeKind::kChandle:
       return mir::ReturnPolicy::kDirect;
+
+    case TypeKind::kEvent:
+      throw common::InternalError(
+          "ComputeReturnPolicy",
+          "event type cannot be returned from functions");
   }
   return mir::ReturnPolicy::kDirect;
 }

--- a/src/lyra/lowering/hir_to_mir/statement.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement.cpp
@@ -67,6 +67,25 @@ class LoopGuard {
   MirBuilder& builder_;
 };
 
+// Canonical event resolver: extract EventId from an HIR event expression.
+// Single entry point for all event operations (wait, trigger).
+//
+// L8a scope: only simple named references (`event e; @e; -> e;`) are
+// supported. Hierarchical event references, .triggered, and other
+// event expression forms will be added in L8b/L8c and must extend this
+// resolver rather than creating parallel resolution paths.
+auto ResolveEventRef(hir::ExpressionId expr_id, MirBuilder& builder)
+    -> mir::EventId {
+  const auto& expr = (*builder.GetContext().hir_arena)[expr_id];
+  const auto* name_ref = std::get_if<hir::NameRefExpressionData>(&expr.data);
+  if (name_ref == nullptr) {
+    throw common::InternalError(
+        "ResolveEventRef",
+        "unsupported event expression form (L8a supports named refs only)");
+  }
+  return builder.GetContext().LookupEvent(name_ref->symbol);
+}
+
 auto LowerBlock(const hir::BlockStatementData& data, MirBuilder& builder)
     -> Result<void> {
   for (hir::StatementId stmt_id : data.statements) {
@@ -231,6 +250,7 @@ auto LowerStrobeEffect(
       .design_places = original_ctx.design_places,
       .local_places = {},
       .design_place_cache = {},
+      .body_events = original_ctx.body_events,
       .next_local_id = 0,
       .next_temp_id = 0,
       .local_types = {},
@@ -537,6 +557,7 @@ auto LowerMonitorCheckProgram(
       .design_places = original_ctx.design_places,
       .local_places = {},
       .design_place_cache = {},
+      .body_events = original_ctx.body_events,
       .next_local_id = 0,
       .next_temp_id = 0,
       .local_types = {},
@@ -621,6 +642,7 @@ auto LowerMonitorSetupProgram(
       .design_places = original_ctx.design_places,
       .local_places = {},
       .design_place_cache = {},
+      .body_events = original_ctx.body_events,
       .next_local_id = 0,
       .next_temp_id = 0,
       .local_types = {},
@@ -3152,6 +3174,16 @@ auto LowerStatement(hir::StatementId stmt_id, MirBuilder& builder)
           builder.SetCurrentBlock(resume_bb);
         } else if constexpr (std::is_same_v<T, hir::EventWaitStatementData>) {
           result = LowerEventWait(data, builder);
+        } else if constexpr (std::is_same_v<
+                                 T, hir::NamedEventWaitStatementData>) {
+          auto event_id = ResolveEventRef(data.event_expr, builder);
+          auto resume_bb = builder.CreateBlock();
+          builder.EmitWaitEvent(event_id, resume_bb);
+          builder.SetCurrentBlock(resume_bb);
+        } else if constexpr (std::is_same_v<
+                                 T, hir::EventTriggerStatementData>) {
+          auto event_id = ResolveEventRef(data.target, builder);
+          builder.EmitTriggerEvent(event_id);
         } else if constexpr (std::is_same_v<
                                  T, hir::ImmediateAssertionStatementData>) {
           result = LowerImmediateAssertion(data, stmt.span, builder);

--- a/src/lyra/mir/dumper.cpp
+++ b/src/lyra/mir/dumper.cpp
@@ -109,6 +109,9 @@ auto FormatTerminator(const Terminator& term) -> std::string {
           return std::format("delay #{} -> bb{}", t.ticks, t.resume.value);
         } else if constexpr (std::is_same_v<T, Wait>) {
           return "wait";
+        } else if constexpr (std::is_same_v<T, WaitEvent>) {
+          return std::format(
+              "wait_event(event={}) -> bb{}", t.event.value, t.resume.value);
         } else if constexpr (std::is_same_v<T, Return>) {
           return "return";
         } else if constexpr (std::is_same_v<T, Finish>) {
@@ -421,6 +424,8 @@ void Dumper::DumpBlock(const BasicBlock& bb, uint32_t index) {
             *out_ << std::format("#t{} = {}\n", i.temp_id, FormatRhs(i.rhs));
           } else if constexpr (std::is_same_v<T, AssocOp>) {
             *out_ << std::format("assoc_op {}\n", FormatPlace(i.receiver));
+          } else if constexpr (std::is_same_v<T, TriggerEvent>) {
+            *out_ << std::format("trigger_event(event={})\n", i.event.value);
           }
         },
         stmt.data);

--- a/src/lyra/mir/passes/activation_segment_analysis.cpp
+++ b/src/lyra/mir/passes/activation_segment_analysis.cpp
@@ -28,8 +28,8 @@ auto IsSegmentExitTerminator(const Terminator& term) -> bool {
       [](const auto& t) -> bool {
         using T = std::decay_t<decltype(t)>;
         return std::is_same_v<T, Delay> || std::is_same_v<T, Wait> ||
-               std::is_same_v<T, Return> || std::is_same_v<T, Finish> ||
-               std::is_same_v<T, Repeat>;
+               std::is_same_v<T, WaitEvent> || std::is_same_v<T, Return> ||
+               std::is_same_v<T, Finish> || std::is_same_v<T, Repeat>;
       },
       term.data);
 }
@@ -49,6 +49,7 @@ void ForEachIntraSegmentSuccessor(const Terminator& term, auto&& func) {
           },
           [](const Delay&) {},
           [](const Wait&) {},
+          [](const WaitEvent&) {},
           [](const Return&) {},
           [](const Finish&) {},
           [](const Repeat&) {},
@@ -342,6 +343,7 @@ void CollectStatementAccesses(
             CollectRhsReads(dt.rhs, arena, block_index, stmt_index, accesses);
           },
           [&](const AssocOp&) {},
+          [](const TriggerEvent&) {},
       },
       stmt.data);
 }
@@ -576,6 +578,9 @@ void AnalyzeStatementSemantics(
                     .conservative_unknown = false,
                 });
           },
+          // TriggerEvent: scheduler-side event trigger, no canonical
+          // state interaction.
+          [](const TriggerEvent&) {},
       },
       stmt.data);
 }
@@ -609,6 +614,7 @@ auto CollectResumeEntryBlocks(const Process& process) -> std::vector<uint32_t> {
         common::Overloaded{
             [&](const Delay& d) { entries.push_back(d.resume.value); },
             [&](const Wait& w) { entries.push_back(w.resume.value); },
+            [&](const WaitEvent& we) { entries.push_back(we.resume.value); },
             [](const auto&) {},
         },
         block.terminator.data);

--- a/src/lyra/mir/sensitivity.cpp
+++ b/src/lyra/mir/sensitivity.cpp
@@ -309,6 +309,7 @@ void TransferStatement(
                 aop.data);
             // Conservative: assoc ops do not extend must-def
           },
+          [](const TriggerEvent&) {},
       },
       stmt.data);
 }

--- a/src/lyra/mir/verify.cpp
+++ b/src/lyra/mir/verify.cpp
@@ -784,6 +784,17 @@ void VerifyStatementOwnership(
                 },
                 aop.data);
           },
+          [&](const TriggerEvent& te) {
+            if (cx.num_events > 0 && te.event.value >= cx.num_events) {
+              throw common::InternalError(
+                  "MIR verify",
+                  std::format(
+                      "{}: block {} stmt {}: TriggerEvent.event {} out of "
+                      "range (body has {} events)",
+                      routine_kind, block_idx, stmt_idx, te.event.value,
+                      cx.num_events));
+            }
+          },
       },
       stmt.data);
 }
@@ -891,6 +902,7 @@ void VerifyIntraBlockDefOrder(
                   },
                   aop.data);
             },
+            [](const TriggerEvent&) {},
         },
         stmt.data);
   }
@@ -1074,9 +1086,27 @@ void VerifyBlockParamsAndEdgeArgs(
                   sw.selector, blocks, arena, cx, defined_temps, i,
                   "Switch.selector", routine_kind);
             },
+            [&](const WaitEvent& we) {
+              if (cx.num_events > 0 && we.event.value >= cx.num_events) {
+                throw common::InternalError(
+                    "MIR verify",
+                    std::format(
+                        "{}: block {}: WaitEvent.event {} out of range "
+                        "(body has {} events)",
+                        routine_kind, i, we.event.value, cx.num_events));
+              }
+              if (we.resume.value >= blocks.size()) {
+                throw common::InternalError(
+                    "MIR verify",
+                    std::format(
+                        "{}: block {}: WaitEvent.resume {} out of range "
+                        "(routine has {} blocks)",
+                        routine_kind, i, we.resume.value, blocks.size()));
+              }
+            },
             [](const auto&) {
-              // Other terminators don't have operands that need temp
-              // verification
+              // Delay, Wait, Return, Finish, Repeat: no operands needing
+              // temp verification.
             },
         },
         block.terminator.data);
@@ -1112,7 +1142,11 @@ void VerifyProcess(
 void VerifyPreBackendBody(
     const CompiledModuleBody& body, const TypeArena& types,
     std::string_view label) {
-  VerifyContext cx{&body, &types, VerifyContext::Phase::kPreBackend};
+  VerifyContext cx{
+      .body = &body,
+      .types = &types,
+      .phase = VerifyContext::Phase::kPreBackend,
+  };
 
   // Verify external_refs table integrity.
   for (uint32_t i = 0; i < body.external_refs.size(); ++i) {

--- a/src/lyra/runtime/engine_scheduler_observability.cpp
+++ b/src/lyra/runtime/engine_scheduler_observability.cpp
@@ -376,6 +376,8 @@ auto WaitKindLabel(ProcessWaitKind kind) -> std::string_view {
       return "suspended(multi)";
     case ProcessWaitKind::kSuspendedRepeat:
       return "suspended(repeat)";
+    case ProcessWaitKind::kSuspendedEvent:
+      return "suspended(event)";
     case ProcessWaitKind::kSuspendedUnknown:
       return "suspended(unknown)";
     case ProcessWaitKind::kFinished:
@@ -512,6 +514,9 @@ auto Engine::TakeSchedulerSnapshot() const -> SchedulerSnapshot {
           break;
         case SuspendTag::kRepeat:
           kind = ProcessWaitKind::kSuspendedRepeat;
+          break;
+        case SuspendTag::kWaitEvent:
+          kind = ProcessWaitKind::kSuspendedEvent;
           break;
       }
     } else if (in_delay[pid]) {

--- a/src/lyra/runtime/engine_subscriptions_install.cpp
+++ b/src/lyra/runtime/engine_subscriptions_install.cpp
@@ -937,6 +937,20 @@ void Engine::ReconcilePostActivation(ProcessHandle handle) {
       ResetInstalledWait(handle);
       ScheduleNextDelta(handle, ResumePoint{.block_index = 0});
       break;
+
+    case SuspendTag::kWaitEvent:
+      ResetInstalledWait(handle);
+      AddEventWaiter(
+          EventObjectKey{
+              .instance_id = handle.instance_id.value,
+              .local_event_id = suspend->event_id,
+          },
+          EventWaiter{
+              .process_id = handle.process_id,
+              .instance_id = handle.instance_id.value,
+              .resume_block = suspend->resume_block,
+          });
+      break;
   }
 }
 

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -54,6 +54,11 @@ auto FinalTime() -> uint64_t& {
   return value;
 }
 
+// Legacy post-activation dispatch: reads SuspendRecord and installs
+// waiter/delay state. Called by DescriptorProcessDispatch when
+// HasPostActivationReconciliation() is false. The new-path equivalent
+// is Engine::ReconcilePostActivation. Exactly one of these two runs
+// per activation -- never both.
 void HandleSuspendRecord(
     lyra::runtime::Engine& eng, lyra::runtime::ProcessHandle handle,
     lyra::runtime::SuspendRecord* suspend) {
@@ -99,6 +104,19 @@ void HandleSuspendRecord(
     case lyra::runtime::SuspendTag::kRepeat:
       eng.ScheduleNextDelta(
           handle, lyra::runtime::ResumePoint{.block_index = 0});
+      break;
+
+    case lyra::runtime::SuspendTag::kWaitEvent:
+      eng.AddEventWaiter(
+          lyra::runtime::EventObjectKey{
+              .instance_id = handle.instance_id.value,
+              .local_event_id = suspend->event_id,
+          },
+          lyra::runtime::EventWaiter{
+              .process_id = handle.process_id,
+              .instance_id = handle.instance_id.value,
+              .resume_block = suspend->resume_block,
+          });
       break;
   }
 }
@@ -258,6 +276,24 @@ extern "C" void LyraSuspendRepeat(void* state) {
   ReleaseTriggerOverflow(suspend);  // Clean up any previous wait
   suspend->tag = lyra::runtime::SuspendTag::kRepeat;
   suspend->resume_block = 0;
+}
+
+extern "C" void LyraSuspendWaitEvent(
+    void* state, uint32_t resume_block, uint32_t event_id) {
+  FailIfSuspensionDisallowed("LyraSuspendWaitEvent");
+  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
+  ReleaseTriggerOverflow(suspend);
+  suspend->tag = lyra::runtime::SuspendTag::kWaitEvent;
+  suspend->resume_block = resume_block;
+  suspend->event_id = event_id;
+}
+
+extern "C" void LyraTriggerEvent(
+    void* engine_ptr, uint32_t instance_id, uint32_t local_event_id) {
+  auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
+  engine->TriggerEvent(
+      lyra::runtime::EventObjectKey{
+          .instance_id = instance_id, .local_event_id = local_event_id});
 }
 
 extern "C" void LyraRunProcessSync(LyraProcessFunc process, void* state) {
@@ -586,6 +622,10 @@ extern "C" void LyraRunSimulation(
     if (abi->num_immediate_cover_sites > 0) {
       engine.InitImmediateCoverSites(abi->num_immediate_cover_sites);
     }
+
+    // L8a: Named event registry.
+    // EventRegistry uses lazy (instance_id, local_event_id) keying;
+    // no pre-sizing needed. num_events ABI field reserved for future use.
 
     // A2: Deferred assertion site metadata table.
     if (abi->num_deferred_assertion_sites > 0) {

--- a/tests/framework/llvm_common.cpp
+++ b/tests/framework/llvm_common.cpp
@@ -25,6 +25,7 @@
 #include "lyra/common/source_span.hpp"
 #include "lyra/common/type.hpp"
 #include "lyra/common/type_arena.hpp"
+#include "lyra/common/type_queries.hpp"
 #include "lyra/hir/module.hpp"
 #include "lyra/hir/package.hpp"
 #include "lyra/llvm_backend/context.hpp"
@@ -91,31 +92,43 @@ auto BuildTrackedVariables(
     return variables;
   }
 
+  uint32_t slot_index = 0;
   for (size_t i = 0; i < hir_module->variables.size(); ++i) {
     const auto& sym = (*mir_input.symbol_table)[hir_module->variables[i]];
     const Type& type = (*hir_result.type_arena)[sym.type];
+
+    // Non-value-storage types (e.g., event) are not allocated slots.
+    if (!HasValueStorage(type.Kind())) {
+      continue;
+    }
 
     // Handle real types
     if (type.Kind() == TypeKind::kReal) {
       variables.push_back(
           {.name = sym.name,
-           .slot_id = common::SlotId{static_cast<uint32_t>(base_slot_id + i)}});
+           .slot_id = common::SlotId{
+               static_cast<uint32_t>(base_slot_id + slot_index)}});
+      ++slot_index;
       continue;
     }
 
     // Handle string types (no variable inspection yet)
     if (type.Kind() == TypeKind::kString) {
+      ++slot_index;
       continue;
     }
 
     // Handle packed integral types
     if (!IsPacked(type)) {
+      ++slot_index;
       continue;
     }
 
     variables.push_back(
         {.name = sym.name,
-         .slot_id = common::SlotId{static_cast<uint32_t>(base_slot_id + i)}});
+         .slot_id =
+             common::SlotId{static_cast<uint32_t>(base_slot_id + slot_index)}});
+    ++slot_index;
   }
   return variables;
 }

--- a/tests/sv_features/processes/named_event/default.yaml
+++ b/tests/sv_features/processes/named_event/default.yaml
@@ -1,0 +1,236 @@
+feature: named_event
+description: Tests for named event declarations, triggers, and waits (LRM 6.17, 15.5.1)
+
+cases:
+  - name: event_declaration
+    description: event variable declaration compiles without error
+    sv: |
+      module Test;
+        event e;
+        initial begin
+          $display("event declared");
+          $finish;
+        end
+      endmodule
+    expect:
+      stdout:
+        contains:
+          - "event declared"
+
+  - name: basic_trigger_wait
+    description: one process waits @e, another triggers -> e, waiter resumes
+    sv: |
+      module Test;
+        event e;
+
+        initial begin
+          @e;
+          $display("received");
+          $finish;
+        end
+
+        initial begin
+          #1;
+          -> e;
+        end
+      endmodule
+    expect:
+      stdout:
+        contains:
+          - "received"
+
+  - name: multiple_waiters
+    description: three processes wait on same event, single trigger wakes all
+    sv: |
+      module Test;
+        event e;
+        int count = 0;
+
+        initial begin @e; count = count + 1; end
+        initial begin @e; count = count + 1; end
+        initial begin @e; count = count + 1; end
+
+        initial begin
+          #1;
+          -> e;
+          #1;
+          $display("count=%0d", count);
+          $finish;
+        end
+      endmodule
+    expect:
+      stdout:
+        contains:
+          - "count=3"
+
+  - name: one_shot_semantics
+    description: waiter list is consumed by trigger; second trigger without new @e does not re-wake
+    sv: |
+      module Test;
+        event e;
+        int count = 0;
+
+        initial begin
+          @e;
+          count = count + 1;
+        end
+
+        initial begin
+          #1;
+          -> e;
+          #1;
+          -> e;
+          #1;
+          $display("count=%0d", count);
+          $finish;
+        end
+      endmodule
+    expect:
+      stdout:
+        contains:
+          - "count=1"
+
+  - name: repeated_cycles
+    description: sequential @e waits work across multiple trigger cycles
+    sv: |
+      module Test;
+        event e;
+        int count = 0;
+
+        initial begin
+          @e;
+          count = count + 1;
+          @e;
+          count = count + 1;
+          @e;
+          count = count + 1;
+          $display("count=%0d", count);
+          $finish;
+        end
+
+        initial begin
+          #1; -> e;
+          #1; -> e;
+          #1; -> e;
+        end
+      endmodule
+    expect:
+      stdout:
+        contains:
+          - "count=3"
+
+  - name: trigger_no_waiters
+    description: triggering with no waiters is a no-op (no crash)
+    sv: |
+      module Test;
+        event e;
+        initial begin
+          -> e;
+          $display("ok");
+          $finish;
+        end
+      endmodule
+    expect:
+      stdout:
+        contains:
+          - "ok"
+
+  - name: two_events_no_cross_wake
+    description: two different events in the same module do not cross-wake
+    sv: |
+      module Test;
+        event a, b;
+        int which = 0;
+
+        initial begin
+          @a;
+          which = 1;
+          $display("which=%0d", which);
+          $finish;
+        end
+
+        initial begin
+          @b;
+          which = 2;
+        end
+
+        initial begin
+          #1;
+          -> a;
+        end
+      endmodule
+    expect:
+      stdout:
+        contains:
+          - "which=1"
+
+  - name: missed_prior_trigger
+    description: trigger at t=1 before @e is reached at t=2; @e blocks until second trigger at t=3
+    sv: |
+      module Test;
+        event e;
+
+        initial begin
+          #2;
+          @e;
+          $display("t=%0t", $time);
+          $finish;
+        end
+
+        initial begin
+          #1;
+          -> e;
+          #2;
+          -> e;
+        end
+      endmodule
+    expect:
+      stdout:
+        contains:
+          - "t=3"
+
+  - name: same_time_next_delta_wakeup
+    description: trigger at t=5 wakes waiter in the same time slot (next delta)
+    sv: |
+      module Test;
+        event e;
+
+        initial begin
+          @e;
+          $display("t=%0t", $time);
+          $finish;
+        end
+
+        initial begin
+          #5;
+          -> e;
+        end
+      endmodule
+    expect:
+      stdout:
+        contains:
+          - "t=5"
+
+  - name: nonblocking_trigger_rejected
+    description: ->> e emits targeted diagnostic
+    sv: |
+      module Test;
+        event e;
+        initial ->> e;
+      endmodule
+    expect:
+      error:
+        contains:
+          - "nonblocking event trigger"
+
+  - name: edge_on_event_rejected
+    description: edge specifiers on event type rejected (slang elaboration)
+    sv: |
+      module Test;
+        event e;
+        initial @(posedge e) $finish;
+      endmodule
+    expect:
+      error:
+        contains:
+          - "is not integral"


### PR DESCRIPTION
## Summary

Adds named events as first-class synchronization primitives (LRM 6.17, 15.5.1). An `event` declaration creates a zero-payload synchronization object; `-> e` triggers the event (waking all currently waiting processes); `@e` suspends the process until the next trigger. Events are instance-owned objects -- two instances of the same module body have independent event objects identified at runtime by `EventObjectKey{instance_id, local_event_id}`.

## Design

### Events are not value objects

`TypeKind::kEvent` is excluded from all value-storage paths via `HasValueStorage()`. Value-storage helpers (`LayoutOf`, `BlobBitSize`, `GetLlvmTypeForTypeId`, lifecycle dispatch, callable ABI) reject `kEvent` with `InternalError`. Non-storage classifiers (`IsPackedSigned`, `ContainsFloat`, etc.) return false. Events never get signal slots -- they have a parallel `EventId`/`EventDesc` stream in MIR and a dedicated `EventRegistry` in the runtime.

### Dedicated IR representations

HIR has separate statement kinds (`kNamedEventWait`, `kEventTrigger`) rather than overloading the signal-based `kEventWait`. In MIR, `WaitEvent` is a terminator (suspends the process) and `TriggerEvent` is a statement (inline side-effect). This prevents downstream code from accidentally treating events as signals.

### Runtime event registry

`EventRegistry` uses `EventObjectKey{instance_id, local_event_id}` as the map key, maintaining instance-level identity separation. Waiter lists are one-shot: `ConsumeWaiters()` moves and erases the entry, matching LRM edge-sensitive semantics (a trigger with no waiters is lost). Trigger wakeups go through the existing `EnqueueProcessWakeup()` into `next_delta_queue_` -- no new scheduling path.

### Suspension ownership

`LyraSuspendWaitEvent()` only writes state into `SuspendRecord`. Engine activation post-processing (both `HandleSuspendRecord` and `ReconcilePostActivation`) owns turning suspend state into installed waiters via `AddEventWaiter()`. This matches the ownership boundary for all other suspension kinds.

### What didn't change

No signal subscription machinery is involved. No new scheduling regions. The existing suspend/resume infrastructure handles event waits with minimal additions (new `SuspendTag`, new `WakeCause`, new `ProcessWaitKind`).

### Diagnostics for L8b/L8c

`->> e` (nonblocking trigger) emits a targeted "not yet supported" diagnostic. `@(posedge e)` is rejected by slang at elaboration; a defense-in-depth check in `LowerSignalEvent` guards against future slang changes.

## Testing

11 test cases in `tests/sv_features/processes/named_event/default.yaml` covering: declaration, basic trigger/wait, multiple waiters, one-shot semantics, repeated cycles, trigger-no-waiters, two-event isolation, missed-prior-trigger (with `$time` verification), same-time-next-delta wakeup (with `$time` verification), nonblocking trigger rejection, and edge-on-event rejection.