### PR TITLE
Move activation-local shadows to persistent process frame

### DIFF
--- a/include/lyra/llvm_backend/layout/layout.hpp
+++ b/include/lyra/llvm_backend/layout/layout.hpp
@@ -17,6 +17,7 @@
 #include "lyra/common/slot_id.hpp"
 #include "lyra/common/type.hpp"
 #include "lyra/common/type_arena.hpp"
+#include "lyra/llvm_backend/activation_local.hpp"
 #include "lyra/llvm_backend/kernel_types.hpp"
 #include "lyra/llvm_backend/layout/body_layout.hpp"
 #include "lyra/llvm_backend/layout/storage_contract.hpp"
@@ -161,19 +162,44 @@ struct DesignLayout {
       -> std::optional<ArenaByteOffset>;
 };
 
-// Process frame layout - one per process
+// Activation-local shadow field in the persistent process frame.
+// Maps a managed signal slot to its frame field index so codegen
+// can emit GEPs instead of stack allocas.
+struct ShadowFieldEntry {
+  uint32_t slot_id;
+  uint32_t field_index;
+  TypeId root_type;
+};
+
+// Process frame layout - one per process.
 // Maps place root identity to field index in ProcessFrameN struct.
 // Multiple PlaceIds sharing a root (with different projections) map to
 // the same frame slot.
+//
+// The LLVM struct contains two regions, contiguous in field order:
+//   [0, num_semantic_roots): semantic roots collected from MIR places
+//   [num_semantic_roots, N): activation-local shadow fields
+// Both regions participate in 4-state patch collection.
 struct FrameLayout {
-  // Root types in field order (for 4-state initialization)
-  std::vector<TypeId> root_types;
-  // Map from root identity to field index
+  // Number of semantic root fields (MIR-derived process locals/temps).
+  // Fields [0, num_semantic_roots) are semantic roots.
+  uint32_t num_semantic_roots = 0;
+  // Type of each field in struct order (semantic roots + shadow fields).
+  // Used for 4-state patch collection. Size = total field count.
+  std::vector<TypeId> field_types;
+  // Map from root identity to field index (semantic roots only).
   std::unordered_map<PlaceRootKey, uint32_t, PlaceRootKeyHash> root_to_field;
-  // LLVM struct type for ProcessFrameN (built by BuildLayout)
+  // LLVM struct type for ProcessFrameN (built by BuildLayout).
   llvm::StructType* llvm_type = nullptr;
-  // Patches for 4-state X-encoding (byte offsets to unknown planes)
+  // Patches for 4-state X-encoding (byte offsets to unknown planes).
   FourStatePatchTable four_state_patches;
+  // Activation-local shadow fields (sorted by slot_id).
+  std::vector<ShadowFieldEntry> shadow_fields;
+
+  // Canonical lookup for a shadow field by managed slot id.
+  // Throws InternalError if the slot has no shadow field.
+  [[nodiscard]] auto GetShadowField(uint32_t slot_id) const
+      -> const ShadowFieldEntry&;
 };
 
 // Root identity + type pair for alloca allocation in suspension-free processes.
@@ -195,6 +221,10 @@ struct ProcessLayout {
   // Root identity + type for each local/temp that needs an alloca.
   // Populated only when has_suspension is false (suspension-free processes).
   std::vector<AllocaRootInfo> alloca_roots;
+  // Activation-local plan, present only for processes with suspension.
+  // Computed at layout time so shadow fields can be added to the
+  // persistent frame. Codegen must assert presence before use.
+  std::optional<ProcessActivationPlan> activation_plan;
 };
 
 // Index into module-instance parallel arrays (instance_storage_bases,

--- a/include/lyra/llvm_backend/slot_access.hpp
+++ b/include/lyra/llvm_backend/slot_access.hpp
@@ -78,10 +78,16 @@ class CanonicalSlotAccess final : public SlotAccessResolver,
   Context& ctx_;
 };
 
+// Shadow storage for an activation-local managed signal slot.
+// Always backed by a persistent process frame field (GEP into ProcessFrameN).
+// Suspension-free processes do not use activation-local storage.
 struct ManagedSlotStorage {
   mir::SignalRef slot;
   TypeId root_type;
-  llvm::AllocaInst* alloca_inst = nullptr;
+  // GEP into the persistent process frame for this shadow cell.
+  llvm::Value* shadow_ptr = nullptr;
+  // LLVM type of the shadow cell (matches the frame field type).
+  llvm::Type* shadow_type = nullptr;
 };
 
 class ActivationLocalSlotAccess final : public SlotAccessResolver,
@@ -111,7 +117,15 @@ class ActivationLocalSlotAccess final : public SlotAccessResolver,
   std::unordered_map<uint32_t, ManagedSlotStorage> managed_;
 };
 
+// Create managed slot storage backed by persistent frame fields.
+// For processes with suspension only (frame fields survive suspend/resume).
 auto CreateManagedSlotStorage(const ProcessActivationPlan& plan, Context& ctx)
+    -> std::vector<ManagedSlotStorage>;
+
+// Create managed slot storage backed by stack allocas.
+// For suspension-free processes only (single function call, no resume).
+auto CreateManagedSlotStorageAsAllocas(
+    const ProcessActivationPlan& plan, Context& ctx)
     -> std::vector<ManagedSlotStorage>;
 
 }  // namespace lyra::lowering::mir_to_llvm

--- a/src/lyra/llvm_backend/emit_design_main.cpp
+++ b/src/lyra/llvm_backend/emit_design_main.cpp
@@ -125,8 +125,8 @@ void InitializeProcessState(
   EmitApply4StatePatches(context, frame_ptr, frame_layout.four_state_patches);
 
   const auto& types = context.GetTypeArena();
-  for (uint32_t i = 0; i < frame_layout.root_types.size(); ++i) {
-    TypeId type_id = frame_layout.root_types[i];
+  for (uint32_t i = 0; i < frame_layout.field_types.size(); ++i) {
+    TypeId type_id = frame_layout.field_types[i];
     if (!context.IsFourState(type_id)) {
       continue;
     }
@@ -315,8 +315,8 @@ auto EmitPerSchemaFrameInitFunctions(Context& context, const Layout& layout)
     // Apply composite 4-state initialization.
     auto* frame_type = proc_layout.frame.llvm_type;
     const auto& types = context.GetTypeArena();
-    for (uint32_t fi = 0; fi < proc_layout.frame.root_types.size(); ++fi) {
-      TypeId type_id = proc_layout.frame.root_types[fi];
+    for (uint32_t fi = 0; fi < proc_layout.frame.field_types.size(); ++fi) {
+      TypeId type_id = proc_layout.frame.field_types[fi];
       if (!context.IsFourState(type_id)) continue;
       if (IsScalarPatchable(type_id, types, force_two_state)) continue;
       auto* field_ptr =

--- a/src/lyra/llvm_backend/layout/layout.cpp
+++ b/src/lyra/llvm_backend/layout/layout.cpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <format>
+#include <span>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
@@ -1443,36 +1444,62 @@ auto DesignLayout::GetStorageBaseForRange(
 
 namespace {
 
-// Build FrameLayout from de-duplicated roots.
+// Descriptor for an activation-local shadow field to append to the frame.
+struct ShadowFieldDesc {
+  uint32_t slot_id;
+  TypeId root_type;
+};
+
+// Build FrameLayout from de-duplicated roots and optional shadow fields.
+// Shadow fields are appended after regular roots in the LLVM struct.
 // frame_name is the semantic type name (e.g., "Body0Frame0", "Conn3Frame").
 auto BuildFrameLayout(
-    const std::vector<RootInfo>& roots, const TypeArena& types,
+    const std::vector<RootInfo>& roots,
+    std::span<const ShadowFieldDesc> shadows, const TypeArena& types,
     llvm::LLVMContext& ctx, std::string_view frame_name,
     const llvm::DataLayout& dl, bool force_two_state) -> FrameLayout {
   FrameLayout layout;
-  std::vector<llvm::Type*> field_types;
+  layout.num_semantic_roots = static_cast<uint32_t>(roots.size());
+  std::vector<llvm::Type*> llvm_field_types;
 
+  // Region 1: semantic roots from MIR places.
   for (size_t i = 0; i < roots.size(); ++i) {
     const auto& root = roots[i];
-    layout.root_types.push_back(root.type);
+    layout.field_types.push_back(root.type);
     layout.root_to_field[root.key] = static_cast<uint32_t>(i);
-    field_types.push_back(
+    llvm_field_types.push_back(
         GetLlvmTypeForTypeId(ctx, root.type, types, force_two_state));
   }
 
-  if (field_types.empty()) {
+  // Region 2: activation-local shadow fields.
+  for (const auto& shadow : shadows) {
+    auto field_index = static_cast<uint32_t>(llvm_field_types.size());
+    layout.shadow_fields.push_back(
+        ShadowFieldEntry{
+            .slot_id = shadow.slot_id,
+            .field_index = field_index,
+            .root_type = shadow.root_type,
+        });
+    layout.field_types.push_back(shadow.root_type);
+    llvm_field_types.push_back(
+        GetLlvmTypeForTypeId(ctx, shadow.root_type, types, force_two_state));
+  }
+
+  if (llvm_field_types.empty()) {
     layout.llvm_type = llvm::StructType::create(
         ctx, {llvm::Type::getInt8Ty(ctx)}, std::string(frame_name));
   } else {
-    layout.llvm_type =
-        llvm::StructType::create(ctx, field_types, std::string(frame_name));
+    layout.llvm_type = llvm::StructType::create(
+        ctx, llvm_field_types, std::string(frame_name));
   }
 
-  // Collect 4-state patches for scalar patchable fields
-  if (!roots.empty()) {
+  // Collect 4-state patches over both regions.
+  size_t total_fields = layout.field_types.size();
+  if (total_fields > 0) {
     CollectPatches(
         layout.four_state_patches, layout.llvm_type, dl, types,
-        [&](size_t i) { return roots[i].type; }, roots.size(), force_two_state);
+        [&](size_t i) { return layout.field_types[i]; }, total_fields,
+        force_two_state);
   }
 
   return layout;
@@ -1489,6 +1516,16 @@ auto BuildProcessStateType(
 }
 
 }  // namespace
+
+auto FrameLayout::GetShadowField(uint32_t slot_id) const
+    -> const ShadowFieldEntry& {
+  for (const auto& entry : shadow_fields) {
+    if (entry.slot_id == slot_id) return entry;
+  }
+  throw common::InternalError(
+      "FrameLayout::GetShadowField",
+      std::format("no shadow field for managed slot {}", slot_id));
+}
 
 auto IsScalarPatchable(
     TypeId type_id, const TypeArena& types, bool force_two_state) -> bool {
@@ -1762,12 +1799,43 @@ auto BuildLayout(
     auto roots = CollectProcessRoots(process, sched_arena, types);
 
     if (proc_layout.has_suspension) {
-      proc_layout.frame =
-          BuildFrameLayout(roots, types, ctx, frame_name, dl, force_two_state);
+      // Compute activation plan at layout time so shadow fields can be
+      // added to the persistent process frame (not stack allocas).
+      proc_layout.activation_plan.emplace(
+          BuildProcessActivationPlan(process, sched_arena, types));
+
+      // Collect deduplicated shadow field descriptors from the plan.
+      std::vector<ShadowFieldDesc> shadows;
+      if (proc_layout.activation_plan->HasActivationLocalSlots()) {
+        std::unordered_set<uint32_t> seen;
+        for (const auto& seg : proc_layout.activation_plan->segments) {
+          for (const auto& ms : seg.managed_slots.slots) {
+            if (seen.insert(ms.slot.id).second) {
+              shadows.push_back(
+                  ShadowFieldDesc{
+                      .slot_id = ms.slot.id, .root_type = ms.root_type});
+            }
+          }
+        }
+        std::ranges::sort(shadows, {}, &ShadowFieldDesc::slot_id);
+      }
+
+      proc_layout.frame = BuildFrameLayout(
+          roots, shadows, types, ctx, frame_name, dl, force_two_state);
+
+      // Structural invariant: every managed slot in the activation plan
+      // must resolve to a frame shadow field. This guards against drift
+      // between plan semantics and frame population, making the
+      // stale-stack-alloca bug class structurally impossible.
+      for (const auto& seg : proc_layout.activation_plan->segments) {
+        for (const auto& ms : seg.managed_slots.slots) {
+          proc_layout.frame.GetShadowField(ms.slot.id);
+        }
+      }
     } else {
       // Suspension-free: empty frame, roots become allocas at codegen time.
       proc_layout.frame =
-          BuildFrameLayout({}, types, ctx, frame_name, dl, force_two_state);
+          BuildFrameLayout({}, {}, types, ctx, frame_name, dl, force_two_state);
       proc_layout.alloca_roots.reserve(roots.size());
       for (const auto& root : roots) {
         proc_layout.alloca_roots.push_back(
@@ -1802,7 +1870,7 @@ auto BuildLayout(
       bool needs =
           !force_two_state && !proc_layout.frame.four_state_patches.IsEmpty();
       if (!force_two_state && !needs) {
-        for (TypeId type_id : proc_layout.frame.root_types) {
+        for (TypeId type_id : proc_layout.frame.field_types) {
           if (IsLayoutFourState(type_id, types, force_two_state) &&
               !IsScalarPatchable(type_id, types, force_two_state)) {
             needs = true;

--- a/src/lyra/llvm_backend/process.cpp
+++ b/src/lyra/llvm_backend/process.cpp
@@ -1898,8 +1898,12 @@ auto GenerateSharedProcessFunction(
       process.blocks, context.GetMirArena(), context.GetTypeArena());
   auto deferred_blocks = BuildDeferredPolicyBlocks(deferred_loops);
 
-  auto activation_plan = BuildProcessActivationPlan(
-      process, context.GetMirArena(), context.GetTypeArena());
+  // Activation plan is computed at layout time so shadow fields live in the
+  // persistent process frame (not stack allocas that die on suspend).
+  // Present only for processes with suspension; suspension-free processes
+  // skip activation-local lowering entirely.
+  const auto& shared_proc_layout_for_plan =
+      context.GetLayout().processes[context.GetCurrentProcessIndex()];
 
   auto& llvm_ctx = context.GetLlvmContext();
   auto& module = context.GetModule();
@@ -1949,9 +1953,20 @@ auto GenerateSharedProcessFunction(
   context.SetSlotAddressingMode(SlotAddressingMode::kSpecializationLocal);
   context.EmitSharedBodyBindingSetup(func->getArg(0));
 
-  // Create activation-local managed slot storage (shadow allocas).
+  // Create activation-local managed slot storage.
   // Must be after slot addressing setup (this_ptr, instance binding).
-  auto managed_storage = CreateManagedSlotStorage(activation_plan, context);
+  // Processes with suspension use persistent frame fields (survive
+  // suspend/resume). Suspension-free processes use stack allocas
+  // (safe because the function runs to completion without suspending).
+  std::vector<ManagedSlotStorage> managed_storage;
+  if (shared_proc_layout_for_plan.activation_plan.has_value()) {
+    managed_storage = CreateManagedSlotStorage(
+        *shared_proc_layout_for_plan.activation_plan, context);
+  } else {
+    auto local_plan = BuildProcessActivationPlan(
+        process, context.GetMirArena(), context.GetTypeArena());
+    managed_storage = CreateManagedSlotStorageAsAllocas(local_plan, context);
+  }
 
   // Resume dispatch (same logic as GenerateProcessFunction)
   std::vector<size_t> resume_targets;
@@ -1993,6 +2008,11 @@ auto GenerateSharedProcessFunction(
   if (!phi_state_or_err) return std::unexpected(phi_state_or_err.error());
   auto& phi_state = *phi_state_or_err;
 
+  static const ProcessActivationPlan kEmptyPlan;
+  const auto& activation_plan =
+      shared_proc_layout_for_plan.activation_plan.has_value()
+          ? *shared_proc_layout_for_plan.activation_plan
+          : kEmptyPlan;
   ContractExecutor executor(
       context, activation_plan, std::move(managed_storage));
 

--- a/src/lyra/llvm_backend/slot_access.cpp
+++ b/src/lyra/llvm_backend/slot_access.cpp
@@ -78,8 +78,7 @@ auto ActivationLocalSlotAccess::LoadSlotValue(mir::PlaceId place_id)
   }
   auto& builder = ctx_.GetBuilder();
   return builder.CreateLoad(
-      storage->alloca_inst->getAllocatedType(), storage->alloca_inst,
-      "actlocal.load");
+      storage->shadow_type, storage->shadow_ptr, "actlocal.load");
 }
 
 auto ActivationLocalSlotAccess::CommitSlotValue(
@@ -89,7 +88,7 @@ auto ActivationLocalSlotAccess::CommitSlotValue(
   if (storage == nullptr) {
     return CommitValue(ctx_, target, value, type_id, policy);
   }
-  ctx_.GetBuilder().CreateStore(value, storage->alloca_inst);
+  ctx_.GetBuilder().CreateStore(value, storage->shadow_ptr);
   return {};
 }
 
@@ -107,9 +106,9 @@ void ActivationLocalSlotAccess::SeedSlot(const ManagedSlotStorage& storage) {
   }
   auto& builder = ctx_.GetBuilder();
   auto* canonical_ptr = ctx_.GetSignalSlotPointer(storage.slot);
-  auto* llvm_type = storage.alloca_inst->getAllocatedType();
-  auto* val = builder.CreateLoad(llvm_type, canonical_ptr, "actlocal.seed");
-  builder.CreateStore(val, storage.alloca_inst);
+  auto* val =
+      builder.CreateLoad(storage.shadow_type, canonical_ptr, "actlocal.seed");
+  builder.CreateStore(val, storage.shadow_ptr);
 }
 
 void ActivationLocalSlotAccess::SyncSlot(const ManagedSlotStorage& storage) {
@@ -118,10 +117,9 @@ void ActivationLocalSlotAccess::SyncSlot(const ManagedSlotStorage& storage) {
         "SyncSlot", "managed slot must be module-local");
   }
   auto& builder = ctx_.GetBuilder();
-  auto* llvm_type = storage.alloca_inst->getAllocatedType();
 
-  auto* val =
-      builder.CreateLoad(llvm_type, storage.alloca_inst, "actlocal.sync");
+  auto* val = builder.CreateLoad(
+      storage.shadow_type, storage.shadow_ptr, "actlocal.sync");
   auto* canonical_ptr = ctx_.GetSignalSlotPointer(storage.slot);
   // Mutation-target: resolve to storage owner for dirty-mark identity.
   auto signal_id = ctx_.EmitMutationTargetSignalCoord(storage.slot);
@@ -198,37 +196,42 @@ void ActivationLocalSlotAccess::SyncAndReloadSpecific(
   }
 }
 
-namespace {
+auto CreateManagedSlotStorage(const ProcessActivationPlan& plan, Context& ctx)
+    -> std::vector<ManagedSlotStorage> {
+  const auto& proc_layout =
+      ctx.GetLayout().processes[ctx.GetCurrentProcessIndex()];
+  const auto& frame = proc_layout.frame;
+  auto& builder = ctx.GetBuilder();
+  auto* frame_type = frame.llvm_type;
+  auto* frame_ptr = ctx.GetFramePointer();
 
-// Get the LLVM storage type for an activation-local managed slot.
-// Asserts v1 invariants: only plain scalar types are eligible for
-// activation-local treatment. For these types, the canonical slot
-// storage representation is identical to GetLlvmTypeForTypeId:
-//   kIntegral -> iN (2-state) or {iN, iN} (4-state)
-//   kReal -> double
-//   kShortReal -> float
-//   kEnum with integral base -> same as kIntegral
-auto GetActivationLocalStorageType(
-    llvm::LLVMContext& llvm_ctx, TypeId root_type, const TypeArena& types,
-    bool force_two_state) -> llvm::Type* {
-  const auto& type = types[root_type];
-  auto kind = type.Kind();
-  if (kind == TypeKind::kEnum) {
-    kind = types[type.AsEnum().base_type].Kind();
+  std::unordered_set<uint32_t> seen_slot_ids;
+  std::vector<ManagedSlotStorage> result;
+
+  for (const auto& segment : plan.segments) {
+    for (const auto& managed : segment.managed_slots.slots) {
+      if (!seen_slot_ids.insert(managed.slot.id).second) continue;
+
+      const auto& shadow = frame.GetShadowField(managed.slot.id);
+      auto* gep = builder.CreateStructGEP(
+          frame_type, frame_ptr, shadow.field_index, "actlocal.shadow");
+      auto* field_type = frame_type->getElementType(shadow.field_index);
+
+      result.push_back(
+          ManagedSlotStorage{
+              .slot = managed.slot,
+              .root_type = managed.root_type,
+              .shadow_ptr = gep,
+              .shadow_type = field_type,
+          });
+    }
   }
-  if (kind != TypeKind::kIntegral && kind != TypeKind::kReal &&
-      kind != TypeKind::kShortReal) {
-    throw common::InternalError(
-        "GetActivationLocalStorageType",
-        "managed slot type must be a v1-eligible scalar (integral, real, "
-        "shortreal, or enum with integral base)");
-  }
-  return GetLlvmTypeForTypeId(llvm_ctx, root_type, types, force_two_state);
+
+  return result;
 }
 
-}  // namespace
-
-auto CreateManagedSlotStorage(const ProcessActivationPlan& plan, Context& ctx)
+auto CreateManagedSlotStorageAsAllocas(
+    const ProcessActivationPlan& plan, Context& ctx)
     -> std::vector<ManagedSlotStorage> {
   auto& llvm_ctx = ctx.GetLlvmContext();
   const auto& types = ctx.GetTypeArena();
@@ -245,9 +248,8 @@ auto CreateManagedSlotStorage(const ProcessActivationPlan& plan, Context& ctx)
     for (const auto& managed : segment.managed_slots.slots) {
       if (!seen_slot_ids.insert(managed.slot.id).second) continue;
 
-      auto* alloca_type = GetActivationLocalStorageType(
+      auto* alloca_type = GetLlvmTypeForTypeId(
           llvm_ctx, managed.root_type, types, force_two_state);
-
       auto* alloca_inst =
           alloca_builder.CreateAlloca(alloca_type, nullptr, "actlocal.shadow");
 
@@ -255,7 +257,8 @@ auto CreateManagedSlotStorage(const ProcessActivationPlan& plan, Context& ctx)
           ManagedSlotStorage{
               .slot = managed.slot,
               .root_type = managed.root_type,
-              .alloca_inst = alloca_inst,
+              .shadow_ptr = alloca_inst,
+              .shadow_type = alloca_type,
           });
     }
   }


### PR DESCRIPTION
## Summary

Activation-local shadow storage (`actlocal.shadow`) was implemented as stack allocas in the process function. When a process suspended and resumed, the stack frame was destroyed and recreated with garbage in the alloca. Resume paths that entered a managed segment's blocks without going through the segment's entry block never re-seeded the shadow, causing the garbage to be synced back to canonical storage and corrupting signals.

This manifested as a flaky `mixed_assertions_skipped` test (~50% fail rate in JIT): `rst_n` was corrupted by stale stack data, causing `always_ff` to never take the reset branch. The simulation produced `count = 6` instead of the expected `3`.

The fix moves shadow storage from stack allocas into the persistent process frame struct (`ProcessFrameN`). The activation plan is now computed at layout time so shadow fields can be added to the frame before codegen. Shadow values are seeded from canonical storage on first entry and persist across suspend/resume. A structural invariant at layout-build time ensures every managed slot in the activation plan resolves to a frame shadow field, making the stale-stack-alloca bug class structurally impossible to reintroduce.

## Design

- `FrameLayout` now has two field regions: semantic roots (MIR-derived locals/temps) and shadow fields (activation-local managed slots), tracked by `num_semantic_roots` and `shadow_fields` respectively
- `FrameLayout::GetShadowField()` is the canonical lookup; codegen does not inspect the storage table directly
- `ManagedSlotStorage` is explicitly frame-backed only (GEP into `ProcessFrameN`, not `AllocaInst*`)
- `ProcessLayout::activation_plan` is `std::optional`, present only for processes with suspension
- Suspension-free processes skip activation-local setup entirely

## Testing

- JIT dev tests: 20/20 consecutive passes (was ~50% fail rate)
- AOT dev tests: pass
- Zero build warnings