### PR TITLE
Add instance-owned deferred NBA with compile-time transport elimination

### DIFF
--- a/include/lyra/llvm_backend/codegen_session.hpp
+++ b/include/lyra/llvm_backend/codegen_session.hpp
@@ -79,6 +79,9 @@ struct SpecSlotInfo {
   // For kInlineValue: offset of the slot's value bytes from body base.
   // For kOwnedContainer: offset of the OwnedStorageHandle from body base.
   std::vector<BodyByteOffset> inline_offsets;
+  // Per-slot appendix byte offset (for kOwnedContainer backing data).
+  // nullopt for non-container slots.
+  std::vector<std::optional<BodyByteOffset>> appendix_offsets;
   // Per-slot storage shape.
   std::vector<mir::StorageShape> shapes;
   // Per-slot access classification.

--- a/include/lyra/llvm_backend/connection_analysis.hpp
+++ b/include/lyra/llvm_backend/connection_analysis.hpp
@@ -49,6 +49,7 @@ struct SlotUsageSummary {
   bool has_non_downstream_trigger_role = false;
   bool is_non_connection_trigger = false;
   bool is_process_body_read = false;
+  bool is_container = false;
 };
 
 // Build per-slot usage summaries from connection kernels and trigger summary.
@@ -66,6 +67,18 @@ auto BuildSlotUsageSummaries(
 // true means "this slot may be bypassable in realized routing/fanout".
 auto IsTrivialRelayCandidate(const SlotUsageSummary& summary) -> bool;
 
+// Identity-copy comb: a module body process that just copies one slot
+// to another (e.g., `assign data_out = data_reg`). When the output slot
+// is a relay candidate, downstream connections are rewritten to read
+// from the source slot directly. The comb itself continues to execute
+// inline (cheaper than full process activation) but its output becomes
+// dead storage -- no downstream connections or subscriptions observe it.
+struct IdentityCopyComb {
+  common::SlotId src_slot;
+  common::SlotId dst_slot;
+  common::SlotId trigger_slot;
+};
+
 // Connection analysis result for a design.
 // Carries the original connection edges (using original slot IDs, no
 // canonical-owner rewriting), per-slot usage summaries, and per-slot
@@ -74,6 +87,10 @@ struct ConnectionAnalysisResult {
   std::vector<ConnectionKernelEntry> connection_edges;
   std::vector<SlotUsageSummary> slot_usage;
   std::vector<bool> is_relay_candidate;
+  // Identity-copy combs detected during analysis. Consumed by
+  // EliminateRelayConnections to extend relay elimination to
+  // comb-backed pass-throughs.
+  std::vector<IdentityCopyComb> identity_copy_combs;
 };
 
 // Analyze connections for a design. Produces connection edges using original

--- a/include/lyra/llvm_backend/connection_analysis.hpp
+++ b/include/lyra/llvm_backend/connection_analysis.hpp
@@ -21,6 +21,11 @@ namespace lyra::lowering::mir_to_llvm {
 // init processes and module body processes only.
 struct TriggerSlotSummary {
   std::unordered_set<uint32_t> non_connection_trigger_slots;
+  // Slots whose values are read by non-connection process bodies
+  // (e.g., $display reading a relay wire). A relay candidate with
+  // process-body readers cannot be eliminated because the relay slot's
+  // storage must remain updated for those reads to see correct values.
+  std::unordered_set<uint32_t> process_body_read_slots;
 };
 
 // Collect non-connection trigger slot sets from MIR processes before layout.
@@ -43,6 +48,7 @@ struct SlotUsageSummary {
   std::vector<uint32_t> trigger_conn_indices;
   bool has_non_downstream_trigger_role = false;
   bool is_non_connection_trigger = false;
+  bool is_process_body_read = false;
 };
 
 // Build per-slot usage summaries from connection kernels and trigger summary.
@@ -82,5 +88,18 @@ auto AnalyzeConnections(
     std::span<const LayoutModulePlan> module_plans, const mir::Design& design,
     const mir::Arena& design_arena, uint32_t expanded_num_slots = 0)
     -> ConnectionAnalysisResult;
+
+// Compile-time connection elimination for transform-safe relay candidates.
+// For each relay slot R with upstream edge U->R and downstream edges R->D...,
+// rewrites downstream edges to read directly from U (U->D...) and deletes the
+// upstream edge. Does not change storage layout or slot ownership.
+//
+// Safety boundary (first cut):
+//   - exactly 1 upstream edge (port-binding origin, full-slot copy)
+//   - all downstream edges are port-binding, self-triggered, full-slot
+//   - no process/comb triggers on the relay slot
+//
+// Returns the number of relay slots eliminated.
+auto EliminateRelayConnections(ConnectionAnalysisResult& analysis) -> uint32_t;
 
 }  // namespace lyra::lowering::mir_to_llvm

--- a/include/lyra/llvm_backend/context.hpp
+++ b/include/lyra/llvm_backend/context.hpp
@@ -319,6 +319,9 @@ class Context {
   [[nodiscard]] auto GetLyraStoreStringLocal() -> llvm::Function*;
   [[nodiscard]] auto GetLyraStoreStringGlobal() -> llvm::Function*;
   [[nodiscard]] auto GetLyraDeferredWriteLocal() -> llvm::Function*;
+  [[nodiscard]] auto GetLyraDeferredMaskedWriteLocal() -> llvm::Function*;
+  [[nodiscard]] auto GetLyraDeferredCanonicalPackedWriteLocal()
+      -> llvm::Function*;
   [[nodiscard]] auto GetLyraScheduleNbaLocal() -> llvm::Function*;
   [[nodiscard]] auto GetLyraScheduleNbaGlobal() -> llvm::Function*;
   [[nodiscard]] auto GetLyraScheduleNbaCanonicalPackedLocal()
@@ -857,6 +860,13 @@ class Context {
   [[nodiscard]] auto IsOwnedInlineSlot(mir::PlaceId place_id) const -> bool;
   [[nodiscard]] auto GetSlotBodyByteOffset(mir::PlaceId place_id) const
       -> uint32_t;
+  // Compute byte offset within a slot for static FieldProjection /
+  // UnionMemberProjection chains. Returns (sub_offset, sub_size) if all
+  // projections are statically resolvable, nullopt otherwise (IndexProjection
+  // or BitRangeProjection present). UnionMemberProjection contributes
+  // zero offset; FieldProjection contributes struct field byte offset.
+  [[nodiscard]] auto ComputeStaticProjectionOffset(mir::PlaceId place_id)
+      -> std::optional<std::pair<uint32_t, uint32_t>>;
   [[nodiscard]] auto GetBitRangeProjection(mir::PlaceId place_id) const
       -> const mir::BitRangeProjection&;
   // LLVM type of the base value that GetPlacePointer() points to.
@@ -1101,6 +1111,8 @@ class Context {
   llvm::Function* lyra_store_string_local_ = nullptr;
   llvm::Function* lyra_store_string_global_ = nullptr;
   llvm::Function* lyra_deferred_write_local_ = nullptr;
+  llvm::Function* lyra_deferred_masked_write_local_ = nullptr;
+  llvm::Function* lyra_deferred_canonical_packed_write_local_ = nullptr;
   llvm::Function* lyra_schedule_nba_local_ = nullptr;
   llvm::Function* lyra_schedule_nba_global_ = nullptr;
   llvm::Function* lyra_schedule_nba_canonical_packed_local_ = nullptr;

--- a/include/lyra/llvm_backend/context.hpp
+++ b/include/lyra/llvm_backend/context.hpp
@@ -858,7 +858,10 @@ class Context {
   // BitRangeProjection helpers
   [[nodiscard]] auto HasBitRangeProjection(mir::PlaceId place_id) const -> bool;
   [[nodiscard]] auto IsOwnedInlineSlot(mir::PlaceId place_id) const -> bool;
+  [[nodiscard]] auto IsOwnedContainerSlot(mir::PlaceId place_id) const -> bool;
   [[nodiscard]] auto GetSlotBodyByteOffset(mir::PlaceId place_id) const
+      -> uint32_t;
+  [[nodiscard]] auto GetContainerBodyByteOffset(mir::PlaceId place_id) const
       -> uint32_t;
   // Compute byte offset within a slot for static FieldProjection /
   // UnionMemberProjection chains. Returns (sub_offset, sub_size) if all

--- a/include/lyra/llvm_backend/context.hpp
+++ b/include/lyra/llvm_backend/context.hpp
@@ -318,6 +318,7 @@ class Context {
   [[nodiscard]] auto GetLyraStorePackedGlobal() -> llvm::Function*;
   [[nodiscard]] auto GetLyraStoreStringLocal() -> llvm::Function*;
   [[nodiscard]] auto GetLyraStoreStringGlobal() -> llvm::Function*;
+  [[nodiscard]] auto GetLyraDeferredWriteLocal() -> llvm::Function*;
   [[nodiscard]] auto GetLyraScheduleNbaLocal() -> llvm::Function*;
   [[nodiscard]] auto GetLyraScheduleNbaGlobal() -> llvm::Function*;
   [[nodiscard]] auto GetLyraScheduleNbaCanonicalPackedLocal()
@@ -853,6 +854,9 @@ class Context {
 
   // BitRangeProjection helpers
   [[nodiscard]] auto HasBitRangeProjection(mir::PlaceId place_id) const -> bool;
+  [[nodiscard]] auto IsOwnedInlineSlot(mir::PlaceId place_id) const -> bool;
+  [[nodiscard]] auto GetSlotBodyByteOffset(mir::PlaceId place_id) const
+      -> uint32_t;
   [[nodiscard]] auto GetBitRangeProjection(mir::PlaceId place_id) const
       -> const mir::BitRangeProjection&;
   // LLVM type of the base value that GetPlacePointer() points to.
@@ -1096,6 +1100,7 @@ class Context {
   llvm::Function* lyra_store_packed_global_ = nullptr;
   llvm::Function* lyra_store_string_local_ = nullptr;
   llvm::Function* lyra_store_string_global_ = nullptr;
+  llvm::Function* lyra_deferred_write_local_ = nullptr;
   llvm::Function* lyra_schedule_nba_local_ = nullptr;
   llvm::Function* lyra_schedule_nba_global_ = nullptr;
   llvm::Function* lyra_schedule_nba_canonical_packed_local_ = nullptr;

--- a/include/lyra/llvm_backend/context.hpp
+++ b/include/lyra/llvm_backend/context.hpp
@@ -587,8 +587,9 @@ class Context {
       -> Result<llvm::Value*>;
 
   // Compute the typed signal coordinate for an external ref's storage.
-  // Returns a runtime-loaded GlobalRuntime signal coord from the per-instance
-  // ext_ref_bindings table.
+  // Returns a runtime-loaded signal coord from the per-instance
+  // ext_ref_bindings table. External refs are never instance-owned,
+  // so they always route through the generic NBA queue.
   [[nodiscard]] auto EmitExternalRefSignalCoord(mir::ExternalRefId ref_id)
       -> SignalCoordExpr;
 

--- a/include/lyra/llvm_backend/layout/layout.hpp
+++ b/include/lyra/llvm_backend/layout/layout.hpp
@@ -413,6 +413,8 @@ struct Layout {
   size_t num_module_process_base = 0;
   // Connection processes evaluated as batch memcpy
   std::vector<ConnectionKernelEntry> connection_kernel_entries;
+  // Number of relay slots eliminated by compile-time connection elimination.
+  uint32_t relay_slots_eliminated = 0;
   // ProcessStateHeader type: {SuspendRecord, DesignState*}
   llvm::StructType* header_type = nullptr;
   // SuspendRecord type (opaque blob matching C++ struct size)

--- a/include/lyra/llvm_backend/lowering_reports.hpp
+++ b/include/lyra/llvm_backend/lowering_reports.hpp
@@ -89,6 +89,7 @@ class ForwardingAnalysisReport {
 
 struct LoweringReport {
   ForwardingAnalysisReport forwarding_analysis;
+  uint32_t relay_slots_eliminated = 0;
 };
 
 }  // namespace lyra::lowering::mir_to_llvm

--- a/include/lyra/llvm_backend/packed_storage_view.hpp
+++ b/include/lyra/llvm_backend/packed_storage_view.hpp
@@ -35,30 +35,30 @@ class Context;
 // - non-canonical (process locals): LLVM-managed alloca storage where plane
 //   layout follows LLVM struct alignment rules. Byte-addressable localized
 //   access is not valid for non-canonical storage.
+// Backing-domain classification for packed storage.
+// Enforces the invariant: canonical backing has no local type; local backing
+// requires a non-null LLVM type.
+class PackedStorageBacking {
+ public:
+  [[nodiscard]] auto IsCanonical() const -> bool {
+    return is_canonical_;
+  }
+  [[nodiscard]] auto RequireLocalType() const -> llvm::Type*;
+  void SetCanonical();
+  void SetLocal(llvm::Type* local_llvm_type);
+
+ private:
+  bool is_canonical_ = false;
+  llvm::Type* local_llvm_type_ = nullptr;
+};
+
 struct PackedStorageView {
   llvm::Value* base_ptr = nullptr;
   uint32_t total_semantic_bits = 0;
   uint32_t storage_plane_byte_size = 0;
   uint32_t unk_plane_offset_bytes = 0;
   bool is_four_state = false;
-
-  // Backing-domain accessors. Only used by load/store boundary functions
-  // (LoadLanePlanes, StoreLanePlanes) and classification helpers.
-  // Lane-domain algebra should not call these.
-  [[nodiscard]] auto IsCanonicalBacking() const -> bool {
-    return backing_.is_canonical;
-  }
-
-  [[nodiscard]] auto RequireLocalBackingType() const -> llvm::Type*;
-
-  void SetCanonicalBacking();
-  void SetLocalBacking(llvm::Type* local_llvm_type);
-
- private:
-  struct BackingInfo {
-    bool is_canonical = false;
-    llvm::Type* local_llvm_type = nullptr;
-  } backing_;
+  PackedStorageBacking backing;
 };
 
 // A single step in a packed projection path.
@@ -319,6 +319,11 @@ struct PackedNbaPolicy {
   llvm::Value* engine_ptr = nullptr;
   llvm::Value* notify_base_ptr = nullptr;
   SignalCoordExpr signal_id;
+  // Instance-owned deferred storage routing. When true, local packed NBA
+  // writes go to deferred storage instead of generic nba_queue_.
+  // slot_body_offset is the byte offset of the root slot from inline_base.
+  bool is_local_owned_inline = false;
+  uint32_t slot_body_offset = 0;
 };
 
 // Localized subview deferred/NBA write.

--- a/include/lyra/llvm_backend/packed_storage_view.hpp
+++ b/include/lyra/llvm_backend/packed_storage_view.hpp
@@ -321,8 +321,10 @@ struct PackedNbaPolicy {
   SignalCoordExpr signal_id;
   // Instance-owned deferred storage routing. When true, local packed NBA
   // writes go to deferred storage instead of generic nba_queue_.
-  // slot_body_offset is the byte offset of the root slot from inline_base.
-  bool is_local_owned_inline = false;
+  // slot_body_offset is the byte offset of the root slot's data:
+  //   inline slots: offset from inline_base (< inline_size)
+  //   container slots: offset from body base (>= inline_size, in appendix)
+  bool is_local_owned = false;
   uint32_t slot_body_offset = 0;
 };
 

--- a/include/lyra/runtime/body_realization_desc.hpp
+++ b/include/lyra/runtime/body_realization_desc.hpp
@@ -286,9 +286,13 @@ struct ObservableDescriptorEntry {
   // Defines the canonical LocalSignalId for this signal within the body.
   // Set at descriptor emission time. UINT32_MAX for design-global entries.
   uint32_t local_signal_id = UINT32_MAX;
+  // Body-relative byte offset of the container backing data (appendix region).
+  // Non-zero only for owned-container slots (kOwnedContainer storage shape).
+  // For non-container slots, this is 0.
+  uint32_t backing_rel_off = 0;
 };
 
-static_assert(sizeof(ObservableDescriptorEntry) == 56);
+static_assert(sizeof(ObservableDescriptorEntry) == 60);
 static_assert(offsetof(ObservableDescriptorEntry, storage_byte_offset) == 0);
 static_assert(offsetof(ObservableDescriptorEntry, total_bytes) == 4);
 static_assert(offsetof(ObservableDescriptorEntry, storage_kind) == 8);
@@ -303,6 +307,7 @@ static_assert(offsetof(ObservableDescriptorEntry, storage_owner_ref) == 40);
 static_assert(offsetof(ObservableDescriptorEntry, flags) == 44);
 static_assert(offsetof(ObservableDescriptorEntry, storage_domain) == 48);
 static_assert(offsetof(ObservableDescriptorEntry, local_signal_id) == 52);
+static_assert(offsetof(ObservableDescriptorEntry, backing_rel_off) == 56);
 static_assert(std::is_trivially_copyable_v<ObservableDescriptorEntry>);
 static_assert(std::is_standard_layout_v<ObservableDescriptorEntry>);
 

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -1386,9 +1386,10 @@ class Engine {
   // Instead of scheduling connection processes through the full engine,
   // connections are evaluated inline during signal propagation.
   struct BatchedConnection {
-    uint32_t src_slot_id;  // flat, for ResolveSlotBytes (read-only)
+    const uint8_t* src_ptr;  // precomputed source storage pointer
+    uint8_t* dst_ptr;        // precomputed destination storage pointer
     uint32_t byte_size;
-    ConnectionTarget dst;
+    ConnectionTarget dst;  // typed target for dirty-mark dispatch
   };
   // All batched connections (for initial evaluation).
   std::vector<BatchedConnection> all_connections_;

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -78,6 +78,12 @@ struct CoreRuntimeStats {
   uint64_t nba_entries = 0;
   uint64_t nba_elided = 0;
   uint64_t nba_changed = 0;
+  // Split NBA routing counters for architectural boundary enforcement.
+  // nba_generic_queue: entries enqueued onto nba_queue_ (global, package,
+  //   cross-instance). nba_deferred_local: signals committed through
+  //   per-instance deferred storage (CommitDeferredLocalNbas).
+  uint64_t nba_generic_queue = 0;
+  uint64_t nba_deferred_local = 0;
 };
 
 // Opt-in per-element counters: collected only when kDetailedStats is enabled.
@@ -285,16 +291,12 @@ class Engine {
   // Used for kRepeat terminator.
   void ScheduleNextDelta(ProcessHandle handle, ResumePoint resume);
 
-  // Enqueue a non-blocking assignment for later commit in the NBA region.
-  // mask_ptr == nullptr: full overwrite (direct compare/copy).
-  // mask_ptr != nullptr: masked merge (per-byte mask).
+  // Enqueue onto generic nba_queue_ for later commit in the NBA region.
+  // Only for non-instance-owned targets (global, package, cross-instance).
+  // Instance-owned local targets use MarkInstanceNbaPending + deferred storage.
   void ScheduleNba(
       void* write_ptr, const void* notify_base_ptr, const void* value_ptr,
       const void* mask_ptr, uint32_t byte_size, NbaNotifySignal notify_signal);
-
-  // Schedule a canonical two-plane packed narrow NBA write as one semantic
-  // record. Writes region_byte_size bytes to write_ptr (value plane) and to
-  // write_ptr + second_region_offset (unknown plane).
   void ScheduleNbaCanonicalPacked(
       void* write_ptr, const void* notify_base_ptr, const void* value_ptr,
       const void* unk_ptr, uint32_t region_byte_size,
@@ -583,19 +585,22 @@ class Engine {
   void MarkDirty(GlobalSignalId signal);
   void MarkDirtyRange(
       GlobalSignalId signal, uint32_t byte_off, uint32_t byte_size);
-  void ScheduleNba(
+  // Generic NBA queue: cross-instance local and global/package targets only.
+  // Instance-owned local targets must use deferred storage
+  // (LyraDeferredWriteLocal and friends), never the generic queue.
+  void ScheduleNbaCrossInstanceLocal(
       ObjectSignalRef notify_signal, void* write_ptr,
       const void* notify_base_ptr, const void* value_ptr, const void* mask_ptr,
       uint32_t byte_size);
-  void ScheduleNba(
+  void ScheduleNbaGlobal(
       GlobalSignalId notify_signal, void* write_ptr,
       const void* notify_base_ptr, const void* value_ptr, const void* mask_ptr,
       uint32_t byte_size);
-  void ScheduleNbaCanonicalPacked(
+  void ScheduleNbaCanonicalPackedCrossInstanceLocal(
       ObjectSignalRef notify_signal, void* write_ptr,
       const void* notify_base_ptr, const void* value_ptr, const void* unk_ptr,
       uint32_t region_byte_size, uint32_t second_region_offset);
-  void ScheduleNbaCanonicalPacked(
+  void ScheduleNbaCanonicalPackedGlobal(
       GlobalSignalId notify_signal, void* write_ptr,
       const void* notify_base_ptr, const void* value_ptr, const void* unk_ptr,
       uint32_t region_byte_size, uint32_t second_region_offset);

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -1379,6 +1379,11 @@ class Engine {
   void MarkLocalSignalDirtyRange(
       RuntimeInstance& inst, LocalSignalId lid, uint32_t byte_off,
       uint32_t byte_size, uint32_t instance_idx);
+  // Fast path for full-extent local dirty marking. Skips range
+  // validation and size comparison. Used by CommitDeferredLocalNbas
+  // where all writes are whole-slot.
+  void MarkLocalSignalDirtyFull(
+      RuntimeInstance& inst, LocalSignalId lid, uint32_t instance_idx);
 
   UpdateSet update_set_;
 

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -300,6 +300,15 @@ class Engine {
       const void* unk_ptr, uint32_t region_byte_size,
       uint32_t second_region_offset, NbaNotifySignal notify_signal);
 
+  // Mark an instance as having pending deferred local NBA writes.
+  // Called by LyraDeferredWriteLocal after writing to deferred storage.
+  void MarkInstanceNbaPending(uint32_t instance_idx) {
+    if (in_nba_pending_[instance_idx] == 0) {
+      in_nba_pending_[instance_idx] = 1;
+      nba_pending_instances_.push_back(instance_idx);
+    }
+  }
+
   // Register a strobe observer for the Postponed region.
   // Executes at end of time slot with final signal values.
   void RegisterStrobe(
@@ -940,6 +949,9 @@ class Engine {
   void ExecuteActiveRegion();
   void ExecuteInactiveRegion();
   void ExecuteNbaRegion();
+  void CommitDeferredLocalNbas();
+  void EvictDeferredNba(RuntimeInstance& inst, LocalSignalId lid);
+  void MarkLocalNbaGeneric(RuntimeInstance& inst, LocalSignalId lid);
   void ExecutePostponedRegion();
   void FlushDirtySlots();
 
@@ -1212,8 +1224,15 @@ class Engine {
   // once per delta (dedup guard prevents overwrite).
   std::vector<WakeTraceInfo> wake_trace_;
 
-  // NBA queue: deferred writes committed in ExecuteRegion(kNBA)
+  // NBA queue: deferred writes committed in ExecuteRegion(kNBA).
+  // Generic fallback for global, masked, canonical-packed, container,
+  // cross-instance, and dynamic-index NBA writes.
   std::vector<NbaEntry> nba_queue_;
+
+  // Instance-owned deferred NBA: sparse index of instances with pending
+  // deferred local writes. Same pattern as delta_dirty_instances_.
+  std::vector<uint8_t> in_nba_pending_;
+  std::vector<uint32_t> nba_pending_instances_;
 
   // Dense per-slot subscription storage (indexed by slot_id, sized in
   // InitSlotMeta). Four typed vectors per slot for branch-free flush scans.

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -950,8 +950,6 @@ class Engine {
   void ExecuteInactiveRegion();
   void ExecuteNbaRegion();
   void CommitDeferredLocalNbas();
-  void EvictDeferredNba(RuntimeInstance& inst, LocalSignalId lid);
-  void MarkLocalNbaGeneric(RuntimeInstance& inst, LocalSignalId lid);
   void ExecutePostponedRegion();
   void FlushDirtySlots();
 

--- a/include/lyra/runtime/engine_scheduler.hpp
+++ b/include/lyra/runtime/engine_scheduler.hpp
@@ -82,8 +82,17 @@ struct NbaNotifyLocal {
 };
 using NbaNotifySignal = std::variant<NbaNotifyGlobal, NbaNotifyLocal>;
 
-// NBA queue entry: deferred write committed in the NBA region.
+// Generic NBA queue entry: deferred write committed in the NBA region.
 // Common header (write target + notification) plus typed payload.
+//
+// ARCHITECTURAL INVARIANT:
+// The generic nba_queue_ serves only non-instance-owned targets:
+//   - Global/package signals (NbaNotifyGlobal)
+//   - Cross-instance local signals (NbaNotifyLocal where the writing
+//     process belongs to a different instance than the target)
+// Instance-owned local signals use per-instance deferred storage
+// (RuntimeInstanceStorage::deferred_inline_base / deferred_appendix_base)
+// committed by CommitDeferredLocalNbas, not this queue.
 struct NbaEntry {
   void* write_ptr;
   const void* notify_base_ptr;

--- a/include/lyra/runtime/instance_observability.hpp
+++ b/include/lyra/runtime/instance_observability.hpp
@@ -26,6 +26,17 @@ struct InstanceSlotMeta {
   uint32_t total_bytes = 0;
   SlotStorageKind kind = SlotStorageKind::kPacked2;
   PackedPlanes planes;
+  // True if this slot is an owned container (backing data in appendix).
+  // When true, backing_rel_off/backing_bytes locate the actual data in the
+  // appendix region (body-relative offset >= inline_size).
+  // instance_rel_off still points to the OwnedStorageHandle in inline region.
+  bool is_container = false;
+  // Body-relative byte offset of the backing data (appendix region).
+  // Valid only when is_container is true.
+  uint32_t backing_rel_off = 0;
+  // Byte size of the backing data.
+  // Valid only when is_container is true.
+  uint32_t backing_bytes = 0;
 };
 
 // Instance-owned trace metadata for one body -- shared across all instances

--- a/include/lyra/runtime/local_update_set.hpp
+++ b/include/lyra/runtime/local_update_set.hpp
@@ -32,6 +32,15 @@ class LocalUpdateSet {
       common::MutationKind kind = common::MutationKind::kValueWrite,
       common::EpochEffect epoch = common::EpochEffect::kNone) -> bool;
 
+  // Fast path for full-extent dirty marking with default kind/epoch.
+  // Skips bounds validation and range-size comparison. Caller must
+  // guarantee signal is within range (i.e., Contains(signal) is true).
+  void MarkSlotDirtyFull(LocalSignalId signal) {
+    TouchSignal(
+        signal, common::MutationKind::kValueWrite, common::EpochEffect::kNone);
+    delta_ranges_[signal.value].MarkFullExtent();
+  }
+
   // Mark a byte range within a local signal as dirty.
   void MarkDirtyRange(
       LocalSignalId signal, uint32_t byte_off, uint32_t byte_size,

--- a/include/lyra/runtime/nba_stats_hook.hpp
+++ b/include/lyra/runtime/nba_stats_hook.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+namespace lyra::runtime {
+
+// NBA routing stats captured after simulation for test assertions.
+struct NbaRoutingStats {
+  uint64_t generic_queue = 0;
+  uint64_t deferred_local = 0;
+};
+
+// Callback for capturing NBA routing stats after simulation.
+// Called by LyraRunSimulation before engine destruction.
+using NbaStatsCallback = std::function<void(NbaRoutingStats)>;
+
+void SetNbaStatsCallback(NbaStatsCallback callback);
+auto GetNbaStatsCallback() -> NbaStatsCallback;
+
+// RAII guard for the NBA stats callback.
+class NbaStatsCallbackScope {
+ public:
+  explicit NbaStatsCallbackScope(NbaStatsCallback callback)
+      : prev_(GetNbaStatsCallback()) {
+    SetNbaStatsCallback(std::move(callback));
+  }
+  ~NbaStatsCallbackScope() {
+    SetNbaStatsCallback(std::move(prev_));
+  }
+
+  NbaStatsCallbackScope(const NbaStatsCallbackScope&) = delete;
+  NbaStatsCallbackScope(NbaStatsCallbackScope&&) = delete;
+  auto operator=(const NbaStatsCallbackScope&)
+      -> NbaStatsCallbackScope& = delete;
+  auto operator=(NbaStatsCallbackScope&&) -> NbaStatsCallbackScope& = delete;
+
+ private:
+  NbaStatsCallback prev_;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_instance.hpp
+++ b/include/lyra/runtime/runtime_instance.hpp
@@ -2,6 +2,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <span>
+#include <vector>
 
 #include "lyra/common/ext_ref_binding.hpp"
 #include "lyra/runtime/instance_event_state.hpp"
@@ -13,20 +15,105 @@ namespace lyra::runtime {
 
 // Per-instance owned storage.
 // Each RuntimeInstance owns its module-local state. Storage is always
-// heap-allocated via AllocateOwnedInlineStorage / AllocateOwnedAppendixStorage
-// and freed by FreeRuntimeInstanceStorage.
+// heap-allocated via AllocateOwnedStorage and freed by
+// FreeRuntimeInstanceStorage.
 // The inline region holds fixed-offset slot data; the appendix region holds
 // backing data for owned containers.
+//
+// Binary contract: field order and types must match the LLVM struct type
+// emitted by BuildRuntimeInstanceStorageType. Codegen accesses these fields
+// via GEP, so the layout is a hard ABI. Raw pointers are intentional --
+// unique_ptr would change the struct layout.
 struct RuntimeInstanceStorage {
   std::byte* inline_base = nullptr;
   uint64_t inline_size = 0;
 
   std::byte* appendix_base = nullptr;
   uint64_t appendix_size = 0;
+
+  // Deferred inline region: mirrors inline_base layout for NBA writes.
+  // Simple local <= writes go here; committed in the NBA phase.
+  std::byte* deferred_inline_base = nullptr;
+
+  // Span accessors for owned storage regions. Non-const overloads return
+  // mutable spans for write access; const overloads return read-only spans.
+  // The non-const versions do not modify the struct itself (shallow const),
+  // but provide mutable access to the pointed-to storage -- same pattern as
+  // std::vector::data().
+  // NOLINTBEGIN(readability-make-member-function-const)
+  [[nodiscard]] auto InlineRegion() -> std::span<std::byte> {
+    return {inline_base, inline_size};
+  }
+  [[nodiscard]] auto AppendixRegion() -> std::span<std::byte> {
+    return {appendix_base, appendix_size};
+  }
+  [[nodiscard]] auto DeferredInlineRegion() -> std::span<std::byte> {
+    return {deferred_inline_base, inline_size};
+  }
+  // NOLINTEND(readability-make-member-function-const)
+  [[nodiscard]] auto InlineRegion() const -> std::span<const std::byte> {
+    return {inline_base, inline_size};
+  }
+  [[nodiscard]] auto DeferredInlineRegion() const
+      -> std::span<const std::byte> {
+    return {deferred_inline_base, inline_size};
+  }
 };
 
 // Free any owned storage in an instance's storage record.
 void FreeRuntimeInstanceStorage(RuntimeInstanceStorage& storage);
+
+// Per-instance set of local signals with pending deferred (NBA) writes.
+// Lightweight sparse-set: O(1) mark, O(pending_count) iterate and clear.
+struct NbaPendingSet {
+  std::vector<uint8_t> seen;
+  std::vector<LocalSignalId> list;
+  // Cross-lane ordering: tracks signals that have generic-queue NBA writes
+  // this delta. When set, subsequent simple-lane writes to the same signal
+  // must fall back to the generic queue to preserve write ordering.
+  std::vector<uint8_t> in_generic;
+  std::vector<LocalSignalId> generic_list;
+  // Cached engine-level instance index. Set once during init,
+  // avoids per-write GetInstanceIndex lookup.
+  uint32_t instance_idx = UINT32_MAX;
+
+  void Init(uint32_t local_signal_count, uint32_t idx) {
+    seen.assign(local_signal_count, 0);
+    in_generic.assign(local_signal_count, 0);
+    list.reserve(local_signal_count);
+    generic_list.reserve(local_signal_count);
+    instance_idx = idx;
+  }
+
+  void MarkPending(LocalSignalId lid) {
+    if (seen[lid.value] == 0) {
+      seen[lid.value] = 1;
+      list.push_back(lid);
+    }
+  }
+
+  void MarkGeneric(LocalSignalId lid) {
+    if (in_generic[lid.value] == 0) {
+      in_generic[lid.value] = 1;
+      generic_list.push_back(lid);
+    }
+  }
+
+  void Clear() {
+    for (auto lid : list) {
+      seen[lid.value] = 0;
+    }
+    list.clear();
+    for (auto lid : generic_list) {
+      in_generic[lid.value] = 0;
+    }
+    generic_list.clear();
+  }
+
+  [[nodiscard]] auto IsInitialized() const -> bool {
+    return instance_idx != UINT32_MAX;
+  }
+};
 
 // Runtime-owned representation of one module instance.
 //
@@ -81,6 +168,11 @@ struct RuntimeInstance {
   // Populated by Engine::InitModuleInstancesFromBundles from body-local
   // event count. Not part of the binary contract with codegen.
   RuntimeInstanceEventState event_state;
+
+  // Per-instance pending NBA set for instance-owned deferred writes.
+  // Tracks which local signals have pending deferred values in
+  // storage.deferred_inline_base. Not part of the binary contract.
+  NbaPendingSet nba_pending;
 };
 
 // Strongly typed field indices for RuntimeInstanceStorage.
@@ -90,7 +182,8 @@ enum class RuntimeInstanceStorageField : unsigned {
   kInlineSize = 1,
   kAppendixBase = 2,
   kAppendixSize = 3,
-  kFieldCount = 4,
+  kDeferredInlineBase = 4,
+  kFieldCount = 5,
 };
 
 // Strongly typed field indices for RuntimeInstance.
@@ -120,6 +213,9 @@ static_assert(
 static_assert(
     offsetof(RuntimeInstanceStorage, appendix_size) ==
     offsetof(RuntimeInstanceStorage, appendix_base) + sizeof(std::byte*));
+static_assert(
+    offsetof(RuntimeInstanceStorage, deferred_inline_base) ==
+    offsetof(RuntimeInstanceStorage, appendix_size) + sizeof(uint64_t));
 
 // Hard binary contract assertions for RuntimeInstance.
 // Field order must match RuntimeInstanceField enum and LLVM struct type.

--- a/include/lyra/runtime/runtime_instance.hpp
+++ b/include/lyra/runtime/runtime_instance.hpp
@@ -32,8 +32,12 @@ struct RuntimeInstanceStorage {
   uint64_t appendix_size = 0;
 
   // Deferred inline region: mirrors inline_base layout for NBA writes.
-  // Simple local <= writes go here; committed in the NBA phase.
+  // Local owned-inline <= writes go here; committed in the NBA phase.
   std::byte* deferred_inline_base = nullptr;
+
+  // Deferred appendix region: mirrors appendix_base layout for NBA writes.
+  // Local owned-container <= writes go here; committed in the NBA phase.
+  std::byte* deferred_appendix_base = nullptr;
 
   // Span accessors for owned storage regions. Non-const overloads return
   // mutable spans for write access; const overloads return read-only spans.
@@ -49,6 +53,9 @@ struct RuntimeInstanceStorage {
   }
   [[nodiscard]] auto DeferredInlineRegion() -> std::span<std::byte> {
     return {deferred_inline_base, inline_size};
+  }
+  [[nodiscard]] auto DeferredAppendixRegion() -> std::span<std::byte> {
+    return {deferred_appendix_base, appendix_size};
   }
   // NOLINTEND(readability-make-member-function-const)
   [[nodiscard]] auto InlineRegion() const -> std::span<const std::byte> {
@@ -66,10 +73,10 @@ void FreeRuntimeInstanceStorage(RuntimeInstanceStorage& storage);
 // Per-instance set of local signals with pending deferred (NBA) writes.
 // Lightweight sparse-set: O(1) mark, O(pending_count) iterate and clear.
 //
-// All local owned-inline NBA writes go through instance-owned deferred
-// storage. The pending set tracks which signals have uncommitted writes
-// and whether the deferred slot has been initialized this delta (for
-// copy-on-first-touch of partial writes).
+// All local owned NBA writes (inline and container-backed) go through
+// instance-owned deferred storage. The pending set tracks which signals
+// have uncommitted writes and whether the deferred slot has been
+// initialized this delta (for copy-on-first-touch of partial writes).
 struct NbaPendingSet {
   std::vector<uint8_t> seen;
   std::vector<LocalSignalId> list;
@@ -177,7 +184,8 @@ enum class RuntimeInstanceStorageField : unsigned {
   kAppendixBase = 2,
   kAppendixSize = 3,
   kDeferredInlineBase = 4,
-  kFieldCount = 5,
+  kDeferredAppendixBase = 5,
+  kFieldCount = 6,
 };
 
 // Strongly typed field indices for RuntimeInstance.
@@ -210,6 +218,10 @@ static_assert(
 static_assert(
     offsetof(RuntimeInstanceStorage, deferred_inline_base) ==
     offsetof(RuntimeInstanceStorage, appendix_size) + sizeof(uint64_t));
+static_assert(
+    offsetof(RuntimeInstanceStorage, deferred_appendix_base) ==
+    offsetof(RuntimeInstanceStorage, deferred_inline_base) +
+        sizeof(std::byte*));
 
 // Hard binary contract assertions for RuntimeInstance.
 // Field order must match RuntimeInstanceField enum and LLVM struct type.

--- a/include/lyra/runtime/runtime_instance.hpp
+++ b/include/lyra/runtime/runtime_instance.hpp
@@ -65,23 +65,27 @@ void FreeRuntimeInstanceStorage(RuntimeInstanceStorage& storage);
 
 // Per-instance set of local signals with pending deferred (NBA) writes.
 // Lightweight sparse-set: O(1) mark, O(pending_count) iterate and clear.
+//
+// All local owned-inline NBA writes go through instance-owned deferred
+// storage. The pending set tracks which signals have uncommitted writes
+// and whether the deferred slot has been initialized this delta (for
+// copy-on-first-touch of partial writes).
 struct NbaPendingSet {
   std::vector<uint8_t> seen;
   std::vector<LocalSignalId> list;
-  // Cross-lane ordering: tracks signals that have generic-queue NBA writes
-  // this delta. When set, subsequent simple-lane writes to the same signal
-  // must fall back to the generic queue to preserve write ordering.
-  std::vector<uint8_t> in_generic;
-  std::vector<LocalSignalId> generic_list;
+  // Per-signal: whether deferred storage contains a valid full-slot
+  // snapshot for this signal in the current delta. Set on first write
+  // (whole-slot sets implicitly; partial triggers copy-on-first-touch).
+  // Reset in Clear().
+  std::vector<uint8_t> slot_initialized;
   // Cached engine-level instance index. Set once during init,
   // avoids per-write GetInstanceIndex lookup.
   uint32_t instance_idx = UINT32_MAX;
 
   void Init(uint32_t local_signal_count, uint32_t idx) {
     seen.assign(local_signal_count, 0);
-    in_generic.assign(local_signal_count, 0);
+    slot_initialized.assign(local_signal_count, 0);
     list.reserve(local_signal_count);
-    generic_list.reserve(local_signal_count);
     instance_idx = idx;
   }
 
@@ -92,22 +96,12 @@ struct NbaPendingSet {
     }
   }
 
-  void MarkGeneric(LocalSignalId lid) {
-    if (in_generic[lid.value] == 0) {
-      in_generic[lid.value] = 1;
-      generic_list.push_back(lid);
-    }
-  }
-
   void Clear() {
     for (auto lid : list) {
       seen[lid.value] = 0;
+      slot_initialized[lid.value] = 0;
     }
     list.clear();
-    for (auto lid : generic_list) {
-      in_generic[lid.value] = 0;
-    }
-    generic_list.clear();
   }
 
   [[nodiscard]] auto IsInitialized() const -> bool {

--- a/src/lyra/llvm_backend/connection_analysis.cpp
+++ b/src/lyra/llvm_backend/connection_analysis.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <unordered_map>
 
 #include "lyra/common/overloaded.hpp"
 #include "lyra/mir/effect.hpp"
@@ -192,9 +193,81 @@ auto IsTrivialRelayCandidate(const SlotUsageSummary& summary) -> bool {
   if (summary.has_non_downstream_trigger_role) return false;
   if (summary.is_non_connection_trigger) return false;
   if (summary.is_process_body_read) return false;
+  if (summary.is_container) return false;
 
   return true;
 }
+
+namespace {
+
+// Detect identity-copy comb processes: single-block looping processes
+// with exactly one Assign statement that copies one module slot to
+// another, triggered by the source slot via anychange Wait.
+auto CollectIdentityCopyCombs(std::span<const LayoutModulePlan> module_plans)
+    -> std::vector<IdentityCopyComb> {
+  std::vector<IdentityCopyComb> results;
+
+  for (uint32_t mi = 0; mi < module_plans.size(); ++mi) {
+    const auto& plan = module_plans[mi];
+    const auto& body = *plan.body;
+    uint32_t slot_base = plan.design_state_base_slot;
+
+    for (uint32_t pi = 0; pi < plan.body_processes.size(); ++pi) {
+      const auto& process = body.arena[plan.body_processes[pi]];
+      if (process.kind != mir::ProcessKind::kLooping) continue;
+      if (process.blocks.size() != 1) continue;
+
+      const auto& block = process.blocks[0];
+      if (block.statements.size() != 1) continue;
+
+      const auto* assign = std::get_if<mir::Assign>(&block.statements[0].data);
+      if (assign == nullptr) continue;
+
+      // Destination must be a module slot.
+      const auto* dst_place_id = std::get_if<mir::PlaceId>(&assign->dest);
+      if (dst_place_id == nullptr) continue;
+      const auto& dst_place = body.arena[*dst_place_id];
+      if (dst_place.root.kind != mir::PlaceRoot::Kind::kModuleSlot) continue;
+      if (!dst_place.projections.empty()) continue;
+
+      // RHS must be a simple use of another module slot (no projections).
+      const auto* rhs_op = std::get_if<mir::Operand>(&assign->rhs);
+      if (rhs_op == nullptr) continue;
+      if (rhs_op->kind != mir::Operand::Kind::kUse) continue;
+      auto src_place_id = std::get<mir::PlaceId>(rhs_op->payload);
+      const auto& src_place = body.arena[src_place_id];
+      if (src_place.root.kind != mir::PlaceRoot::Kind::kModuleSlot) continue;
+      if (!src_place.projections.empty()) continue;
+
+      // Terminator must be a Wait on the source slot with kAnyChange.
+      const auto* wait = std::get_if<mir::Wait>(&block.terminator.data);
+      if (wait == nullptr) continue;
+      if (wait->triggers.size() != 1) continue;
+      const auto& trigger = wait->triggers[0];
+      if (trigger.edge != common::EdgeKind::kAnyChange) continue;
+      if (trigger.signal.scope != mir::SignalRef::Scope::kModuleLocal) continue;
+      if (trigger.signal.id != static_cast<uint32_t>(src_place.root.id)) {
+        continue;
+      }
+
+      uint32_t src_global =
+          slot_base + static_cast<uint32_t>(src_place.root.id);
+      uint32_t dst_global =
+          slot_base + static_cast<uint32_t>(dst_place.root.id);
+
+      results.push_back(
+          IdentityCopyComb{
+              .src_slot = common::SlotId{src_global},
+              .dst_slot = common::SlotId{dst_global},
+              .trigger_slot = common::SlotId{src_global},
+          });
+    }
+  }
+
+  return results;
+}
+
+}  // namespace
 
 auto AnalyzeConnections(
     std::vector<ConnectionKernelEntry> kernel_entries,
@@ -208,8 +281,52 @@ auto AnalyzeConnections(
   auto trigger_summary =
       CollectTriggerSlotSummary(module_plans, design, design_arena);
 
+  auto identity_combs = CollectIdentityCopyCombs(module_plans);
+
   auto usage_summaries =
       BuildSlotUsageSummaries(kernel_entries, trigger_summary, num_slots);
+
+  // Mark container slots as non-eliminable. Package-level slots come from
+  // design.slots; instance-local slots come from module body slots.
+  auto num_package_slots = static_cast<uint32_t>(design.slots.size());
+  for (uint32_t s = 0; s < num_package_slots && s < num_slots; ++s) {
+    if (design.slots[s].IsOwnedContainer()) {
+      usage_summaries[s].is_container = true;
+    }
+  }
+  for (const auto& plan : module_plans) {
+    const auto& body_slots = plan.body->slots;
+    for (uint32_t ls = 0; ls < body_slots.size(); ++ls) {
+      uint32_t global = plan.design_state_base_slot + ls;
+      if (global < num_slots && body_slots[ls].IsOwnedContainer()) {
+        usage_summaries[global].is_container = true;
+      }
+    }
+  }
+
+  // For identity-copy combs, mark the output slot as having an upstream
+  // writer and the input slot as having a downstream consumer. This lets
+  // IsTrivialRelayCandidate classify comb-backed pass-throughs alongside
+  // connection-backed relays, without injecting synthetic connections.
+  for (const auto& ic : identity_combs) {
+    auto dst = ic.dst_slot.value;
+    auto src = ic.src_slot.value;
+    if (dst < num_slots) {
+      // The comb writes to dst -- count as an upstream writer.
+      // Use a sentinel index (UINT32_MAX) to distinguish from real
+      // connection indices.
+      usage_summaries[dst].upstream_conn_indices.push_back(UINT32_MAX);
+    }
+    if (src < num_slots) {
+      // The comb reads from src -- this is a downstream use of src,
+      // self-triggered (src == trigger) and full-slot.
+      usage_summaries[src].downstream_src_uses.push_back({
+          .conn_index = UINT32_MAX,
+          .self_triggered = true,
+          .full_slot_trigger = true,
+      });
+    }
+  }
 
   std::vector<bool> relay_candidates(num_slots, false);
   for (uint32_t i = 0; i < num_slots; ++i) {
@@ -220,6 +337,7 @@ auto AnalyzeConnections(
       .connection_edges = std::move(kernel_entries),
       .slot_usage = std::move(usage_summaries),
       .is_relay_candidate = std::move(relay_candidates),
+      .identity_copy_combs = std::move(identity_combs),
   };
 }
 
@@ -227,6 +345,12 @@ auto EliminateRelayConnections(ConnectionAnalysisResult& analysis) -> uint32_t {
   auto& edges = analysis.connection_edges;
   const auto& slot_usage = analysis.slot_usage;
   const auto& is_relay = analysis.is_relay_candidate;
+
+  // Build dst_slot -> identity-copy-comb lookup for comb-backed relays.
+  std::unordered_map<uint32_t, const IdentityCopyComb*> comb_by_dst;
+  for (const auto& ic : analysis.identity_copy_combs) {
+    comb_by_dst[ic.dst_slot.value] = &ic;
+  }
 
   std::vector<bool> edge_deleted(edges.size(), false);
   uint32_t eliminated = 0;
@@ -239,36 +363,52 @@ auto EliminateRelayConnections(ConnectionAnalysisResult& analysis) -> uint32_t {
     // Safety: exactly 1 upstream writer.
     if (summary.upstream_conn_indices.size() != 1) continue;
     uint32_t up_idx = summary.upstream_conn_indices[0];
-    if (edge_deleted[up_idx]) continue;
-    const auto& up_edge = edges[up_idx];
 
-    // Safety: upstream must be port-binding origin.
-    if (up_edge.origin != metadata::ConnectionKernelOrigin::kPortBinding) {
-      continue;
+    // Determine upstream source: either a real connection edge or an
+    // identity-copy comb (sentinel UINT32_MAX).
+    bool upstream_is_comb = (up_idx == UINT32_MAX);
+    common::SlotId upstream_src{};
+    common::SlotId upstream_trigger{};
+    common::EdgeKind upstream_edge = common::EdgeKind::kAnyChange;
+
+    if (upstream_is_comb) {
+      auto it = comb_by_dst.find(slot);
+      if (it == comb_by_dst.end()) continue;
+      upstream_src = it->second->src_slot;
+      upstream_trigger = it->second->trigger_slot;
+    } else {
+      if (edge_deleted[up_idx]) continue;
+      const auto& up_edge = edges[up_idx];
+      if (up_edge.origin != metadata::ConnectionKernelOrigin::kPortBinding) {
+        continue;
+      }
+      if (up_edge.trigger_observation.has_value() &&
+          up_edge.trigger_observation->byte_size > 0) {
+        continue;
+      }
+      upstream_src = up_edge.src_slot;
+      upstream_trigger = up_edge.trigger_slot;
+      upstream_edge = up_edge.trigger_edge;
     }
 
-    // Safety: upstream must be full-slot copy (no sub-slot observation).
-    if (up_edge.trigger_observation.has_value() &&
-        up_edge.trigger_observation->byte_size > 0) {
-      continue;
-    }
-
-    // Check all downstream edges.
+    // Check all downstream edges (must be real connections, not combs).
     bool all_safe = true;
     for (const auto& down_use : summary.downstream_src_uses) {
+      if (down_use.conn_index == UINT32_MAX) {
+        // Downstream is another comb -- skip this relay (chained combs
+        // not handled in this first cut).
+        all_safe = false;
+        break;
+      }
       if (edge_deleted[down_use.conn_index]) {
         all_safe = false;
         break;
       }
       const auto& down_edge = edges[down_use.conn_index];
-
-      // Safety: port-binding origin.
       if (down_edge.origin != metadata::ConnectionKernelOrigin::kPortBinding) {
         all_safe = false;
         break;
       }
-
-      // Safety: self-triggered, full-slot.
       if (!down_use.self_triggered || !down_use.full_slot_trigger) {
         all_safe = false;
         break;
@@ -276,17 +416,22 @@ auto EliminateRelayConnections(ConnectionAnalysisResult& analysis) -> uint32_t {
     }
     if (!all_safe) continue;
 
-    // Rewrite downstream edges to read from the upstream source.
+    // Rewrite downstream connection edges to read from upstream source.
     for (const auto& down_use : summary.downstream_src_uses) {
+      if (down_use.conn_index == UINT32_MAX) continue;
       auto& down_edge = edges[down_use.conn_index];
-      down_edge.src_slot = up_edge.src_slot;
-      down_edge.trigger_slot = up_edge.trigger_slot;
-      down_edge.trigger_edge = up_edge.trigger_edge;
-      down_edge.trigger_observation = up_edge.trigger_observation;
+      down_edge.src_slot = upstream_src;
+      down_edge.trigger_slot = upstream_trigger;
+      down_edge.trigger_edge = upstream_edge;
+      down_edge.trigger_observation = std::nullopt;
     }
 
-    // Delete the upstream edge (U -> R).
-    edge_deleted[up_idx] = true;
+    // Delete the upstream edge if it is a real connection.
+    // Comb-backed upstreams continue to execute inline (cheaper than
+    // full process activation) -- only the downstream routing is removed.
+    if (!upstream_is_comb) {
+      edge_deleted[up_idx] = true;
+    }
     ++eliminated;
   }
 

--- a/src/lyra/llvm_backend/connection_analysis.cpp
+++ b/src/lyra/llvm_backend/connection_analysis.cpp
@@ -3,7 +3,12 @@
 #include <algorithm>
 #include <cstdint>
 
+#include "lyra/common/overloaded.hpp"
+#include "lyra/mir/effect.hpp"
+#include "lyra/mir/operand.hpp"
+#include "lyra/mir/place.hpp"
 #include "lyra/mir/routine.hpp"
+#include "lyra/mir/statement.hpp"
 #include "lyra/mir/terminator.hpp"
 
 namespace lyra::lowering::mir_to_llvm {
@@ -50,8 +55,7 @@ auto CollectTriggerSlotSummary(
     const mir::Arena& design_arena) -> TriggerSlotSummary {
   TriggerSlotSummary summary;
 
-  auto collect_from_process = [&](const mir::Process& process,
-                                  uint32_t slot_base) {
+  auto collect_triggers = [&](const mir::Process& process, uint32_t slot_base) {
     for (const auto& block : process.blocks) {
       const auto* wait = std::get_if<mir::Wait>(&block.terminator.data);
       if (wait == nullptr) continue;
@@ -63,9 +67,77 @@ auto CollectTriggerSlotSummary(
     }
   };
 
+  auto collect_reads = [&](const mir::Process& process, uint32_t slot_base,
+                           const mir::Arena& arena) {
+    auto record_operand = [&](const mir::Operand& op) {
+      if (op.kind != mir::Operand::Kind::kUse) return;
+      auto place_id = std::get<mir::PlaceId>(op.payload);
+      const auto& place = arena[place_id];
+      if (place.root.kind == mir::PlaceRoot::Kind::kModuleSlot) {
+        summary.process_body_read_slots.insert(
+            slot_base + static_cast<uint32_t>(place.root.id));
+      } else if (place.root.kind == mir::PlaceRoot::Kind::kDesignGlobal) {
+        summary.process_body_read_slots.insert(
+            static_cast<uint32_t>(place.root.id));
+      }
+    };
+
+    auto record_format_ops = [&](const std::vector<mir::FormatOp>& ops) {
+      for (const auto& fop : ops) {
+        if (fop.value) record_operand(*fop.value);
+      }
+    };
+
+    auto record_effect = [&](const mir::EffectOp& op) {
+      std::visit(
+          common::Overloaded{
+              [&](const mir::DisplayEffect& d) {
+                record_format_ops(d.ops);
+                if (d.descriptor) record_operand(*d.descriptor);
+              },
+              [&](const mir::ReportEffect& r) { record_format_ops(r.ops); },
+              [&](const mir::MonitorEffect& m) {
+                record_format_ops(m.format_ops);
+              },
+              [&](const mir::SystemTfEffect& s) {
+                for (const auto& a : s.args) record_operand(a);
+              },
+              [&](const mir::FillPackedEffect& f) {
+                record_operand(f.fill_value);
+              },
+              [&](const mir::EnqueueDeferredAssertionEffect& e) {
+                for (const auto& v : e.snapshot_values) record_operand(v);
+              },
+              [&](const mir::RecordDecisionObservationDynamic& r) {
+                record_operand(r.match_class);
+                record_operand(r.selected_kind);
+                record_operand(r.selected_arm);
+              },
+              [&](const mir::MemIOEffect& m) {
+                record_operand(m.filename.operand);
+                if (m.start_addr) record_operand(*m.start_addr);
+                if (m.end_addr) record_operand(*m.end_addr);
+              },
+              [](const auto&) {},
+          },
+          op);
+    };
+
+    for (const auto& block : process.blocks) {
+      for (const auto& stmt : block.statements) {
+        mir::ForEachOperand(stmt.data, record_operand);
+        if (const auto* eff = std::get_if<mir::Effect>(&stmt.data)) {
+          record_effect(eff->op);
+        }
+      }
+      mir::ForEachLocalOperand(block.terminator, record_operand);
+    }
+  };
+
   for (const auto& proc_id : design.init_processes) {
     const auto& process = design_arena[proc_id];
-    collect_from_process(process, 0);
+    collect_triggers(process, 0);
+    collect_reads(process, 0, design_arena);
   }
 
   for (const auto& plan : module_plans) {
@@ -73,7 +145,8 @@ auto CollectTriggerSlotSummary(
     for (const auto& proc_id : plan.body_processes) {
       const auto& process = body.arena[proc_id];
       if (process.kind == mir::ProcessKind::kFinal) continue;
-      collect_from_process(process, plan.design_state_base_slot);
+      collect_triggers(process, plan.design_state_base_slot);
+      collect_reads(process, plan.design_state_base_slot, body.arena);
     }
   }
 
@@ -96,6 +169,12 @@ auto BuildSlotUsageSummaries(
     }
   }
 
+  for (uint32_t slot_id : trigger_summary.process_body_read_slots) {
+    if (slot_id < num_slots) {
+      summaries[slot_id].is_process_body_read = true;
+    }
+  }
+
   return summaries;
 }
 
@@ -112,6 +191,7 @@ auto IsTrivialRelayCandidate(const SlotUsageSummary& summary) -> bool {
 
   if (summary.has_non_downstream_trigger_role) return false;
   if (summary.is_non_connection_trigger) return false;
+  if (summary.is_process_body_read) return false;
 
   return true;
 }
@@ -141,6 +221,88 @@ auto AnalyzeConnections(
       .slot_usage = std::move(usage_summaries),
       .is_relay_candidate = std::move(relay_candidates),
   };
+}
+
+auto EliminateRelayConnections(ConnectionAnalysisResult& analysis) -> uint32_t {
+  auto& edges = analysis.connection_edges;
+  const auto& slot_usage = analysis.slot_usage;
+  const auto& is_relay = analysis.is_relay_candidate;
+
+  std::vector<bool> edge_deleted(edges.size(), false);
+  uint32_t eliminated = 0;
+
+  for (uint32_t slot = 0; slot < is_relay.size(); ++slot) {
+    if (!is_relay[slot]) continue;
+
+    const auto& summary = slot_usage[slot];
+
+    // Safety: exactly 1 upstream writer.
+    if (summary.upstream_conn_indices.size() != 1) continue;
+    uint32_t up_idx = summary.upstream_conn_indices[0];
+    if (edge_deleted[up_idx]) continue;
+    const auto& up_edge = edges[up_idx];
+
+    // Safety: upstream must be port-binding origin.
+    if (up_edge.origin != metadata::ConnectionKernelOrigin::kPortBinding) {
+      continue;
+    }
+
+    // Safety: upstream must be full-slot copy (no sub-slot observation).
+    if (up_edge.trigger_observation.has_value() &&
+        up_edge.trigger_observation->byte_size > 0) {
+      continue;
+    }
+
+    // Check all downstream edges.
+    bool all_safe = true;
+    for (const auto& down_use : summary.downstream_src_uses) {
+      if (edge_deleted[down_use.conn_index]) {
+        all_safe = false;
+        break;
+      }
+      const auto& down_edge = edges[down_use.conn_index];
+
+      // Safety: port-binding origin.
+      if (down_edge.origin != metadata::ConnectionKernelOrigin::kPortBinding) {
+        all_safe = false;
+        break;
+      }
+
+      // Safety: self-triggered, full-slot.
+      if (!down_use.self_triggered || !down_use.full_slot_trigger) {
+        all_safe = false;
+        break;
+      }
+    }
+    if (!all_safe) continue;
+
+    // Rewrite downstream edges to read from the upstream source.
+    for (const auto& down_use : summary.downstream_src_uses) {
+      auto& down_edge = edges[down_use.conn_index];
+      down_edge.src_slot = up_edge.src_slot;
+      down_edge.trigger_slot = up_edge.trigger_slot;
+      down_edge.trigger_edge = up_edge.trigger_edge;
+      down_edge.trigger_observation = up_edge.trigger_observation;
+    }
+
+    // Delete the upstream edge (U -> R).
+    edge_deleted[up_idx] = true;
+    ++eliminated;
+  }
+
+  // Compact: remove deleted edges.
+  if (eliminated > 0) {
+    std::vector<ConnectionKernelEntry> surviving;
+    surviving.reserve(edges.size());
+    for (uint32_t i = 0; i < edges.size(); ++i) {
+      if (!edge_deleted[i]) {
+        surviving.push_back(std::move(edges[i]));
+      }
+    }
+    edges = std::move(surviving);
+  }
+
+  return eliminated;
 }
 
 }  // namespace lyra::lowering::mir_to_llvm

--- a/src/lyra/llvm_backend/context.cpp
+++ b/src/lyra/llvm_backend/context.cpp
@@ -528,6 +528,8 @@ auto Context::LoadExternalRef(mir::ExternalRefId ref_id)
   return builder_.CreateLoad(llvm_type, ptr, "ext_ref_load");
 }
 
+// External refs are never instance-owned, so they always route through
+// the generic NBA queue (never deferred storage).
 auto Context::EmitExternalRefSignalCoord(mir::ExternalRefId ref_id)
     -> SignalCoordExpr {
   return SignalCoordExpr::ExtRef(ref_id.value);

--- a/src/lyra/llvm_backend/context_place.cpp
+++ b/src/lyra/llvm_backend/context_place.cpp
@@ -580,6 +580,44 @@ auto Context::GetSlotBodyByteOffset(mir::PlaceId place_id) const -> uint32_t {
       spec_slot_info_->inline_offsets[local_slot_id].value);
 }
 
+auto Context::ComputeStaticProjectionOffset(mir::PlaceId place_id)
+    -> std::optional<std::pair<uint32_t, uint32_t>> {
+  const auto& place = LookupPlace(place_id);
+  if (place.projections.empty()) return std::nullopt;
+
+  const auto& dl = llvm_module_->getDataLayout();
+  TypeId current_type = place.root.type;
+  uint32_t byte_offset = 0;
+
+  for (const auto& proj : place.projections) {
+    if (const auto* field = std::get_if<mir::FieldProjection>(&proj.info)) {
+      auto struct_type_result = BuildLlvmTypeForTypeId(*this, current_type);
+      if (!struct_type_result) return std::nullopt;
+      auto* struct_ty = llvm::dyn_cast<llvm::StructType>(*struct_type_result);
+      if (struct_ty == nullptr) return std::nullopt;
+      const auto* layout = dl.getStructLayout(struct_ty);
+      byte_offset +=
+          static_cast<uint32_t>(layout->getElementOffset(field->field_index));
+      const auto& struct_info = types_[current_type].AsUnpackedStruct();
+      current_type =
+          struct_info.fields[static_cast<size_t>(field->field_index)].type;
+      continue;
+    }
+    if (const auto* umem =
+            std::get_if<mir::UnionMemberProjection>(&proj.info)) {
+      const auto& union_info = types_[current_type].AsUnpackedUnion();
+      current_type = union_info.members[umem->member_index].type;
+      continue;
+    }
+    return std::nullopt;
+  }
+
+  auto final_ty_result = BuildLlvmTypeForTypeId(*this, current_type);
+  if (!final_ty_result) return std::nullopt;
+  auto sub_size = static_cast<uint32_t>(dl.getTypeStoreSize(*final_ty_result));
+  return std::pair{byte_offset, sub_size};
+}
+
 auto Context::GetPlaceLlvmType(mir::PlaceId place_id) -> Result<llvm::Type*> {
   const auto& place = LookupPlace(place_id);
 

--- a/src/lyra/llvm_backend/context_place.cpp
+++ b/src/lyra/llvm_backend/context_place.cpp
@@ -573,11 +573,34 @@ auto Context::IsOwnedInlineSlot(mir::PlaceId place_id) const -> bool {
          SpecSlotAccessKind::kOwnedInline;
 }
 
+auto Context::IsOwnedContainerSlot(mir::PlaceId place_id) const -> bool {
+  const auto& place = LookupPlace(place_id);
+  if (place.root.kind != mir::PlaceRoot::Kind::kModuleSlot) return false;
+  if (spec_slot_info_ == nullptr) return false;
+  auto local_slot_id = static_cast<uint32_t>(place.root.id);
+  if (local_slot_id >= spec_slot_info_->access_kinds.size()) return false;
+  return spec_slot_info_->access_kinds[local_slot_id] ==
+         SpecSlotAccessKind::kOwnedContainer;
+}
+
 auto Context::GetSlotBodyByteOffset(mir::PlaceId place_id) const -> uint32_t {
   const auto& place = LookupPlace(place_id);
   auto local_slot_id = static_cast<uint32_t>(place.root.id);
   return static_cast<uint32_t>(
       spec_slot_info_->inline_offsets[local_slot_id].value);
+}
+
+auto Context::GetContainerBodyByteOffset(mir::PlaceId place_id) const
+    -> uint32_t {
+  const auto& place = LookupPlace(place_id);
+  auto local_slot_id = static_cast<uint32_t>(place.root.id);
+  const auto& appendix_off = spec_slot_info_->appendix_offsets[local_slot_id];
+  if (!appendix_off.has_value()) {
+    throw common::InternalError(
+        "Context::GetContainerBodyByteOffset",
+        std::format("slot {} is not an owned container", local_slot_id));
+  }
+  return static_cast<uint32_t>(appendix_off->value);
 }
 
 auto Context::ComputeStaticProjectionOffset(mir::PlaceId place_id)

--- a/src/lyra/llvm_backend/context_place.cpp
+++ b/src/lyra/llvm_backend/context_place.cpp
@@ -563,6 +563,23 @@ auto Context::GetStorageRootPointer(mir::PlaceId place_id) -> llvm::Value* {
   return GetSlotRootPointer(LookupPlace(place_id).root);
 }
 
+auto Context::IsOwnedInlineSlot(mir::PlaceId place_id) const -> bool {
+  const auto& place = LookupPlace(place_id);
+  if (place.root.kind != mir::PlaceRoot::Kind::kModuleSlot) return false;
+  if (spec_slot_info_ == nullptr) return false;
+  auto local_slot_id = static_cast<uint32_t>(place.root.id);
+  if (local_slot_id >= spec_slot_info_->access_kinds.size()) return false;
+  return spec_slot_info_->access_kinds[local_slot_id] ==
+         SpecSlotAccessKind::kOwnedInline;
+}
+
+auto Context::GetSlotBodyByteOffset(mir::PlaceId place_id) const -> uint32_t {
+  const auto& place = LookupPlace(place_id);
+  auto local_slot_id = static_cast<uint32_t>(place.root.id);
+  return static_cast<uint32_t>(
+      spec_slot_info_->inline_offsets[local_slot_id].value);
+}
+
 auto Context::GetPlaceLlvmType(mir::PlaceId place_id) -> Result<llvm::Type*> {
   const auto& place = LookupPlace(place_id);
 

--- a/src/lyra/llvm_backend/context_runtime.cpp
+++ b/src/lyra/llvm_backend/context_runtime.cpp
@@ -707,15 +707,46 @@ auto Context::GetLyraDeferredWriteLocal() -> llvm::Function* {
   if (lyra_deferred_write_local_ == nullptr) {
     auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
     auto* i32_ty = llvm::Type::getInt32Ty(*llvm_context_);
-    // (eng, inst, vp, bsz, id, body_offset)
+    // (eng, inst, vp, bsz, id, body_offset, is_partial)
     auto* fn_type = llvm::FunctionType::get(
         llvm::Type::getVoidTy(*llvm_context_),
-        {ptr_ty, ptr_ty, ptr_ty, i32_ty, i32_ty, i32_ty}, false);
+        {ptr_ty, ptr_ty, ptr_ty, i32_ty, i32_ty, i32_ty, i32_ty}, false);
     lyra_deferred_write_local_ = llvm::Function::Create(
         fn_type, llvm::Function::ExternalLinkage, "LyraDeferredWriteLocal",
         llvm_module_.get());
   }
   return lyra_deferred_write_local_;
+}
+
+auto Context::GetLyraDeferredMaskedWriteLocal() -> llvm::Function* {
+  if (lyra_deferred_masked_write_local_ == nullptr) {
+    auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
+    auto* i32_ty = llvm::Type::getInt32Ty(*llvm_context_);
+    // (eng, inst, vp, mp, bsz, id, body_offset)
+    auto* fn_type = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*llvm_context_),
+        {ptr_ty, ptr_ty, ptr_ty, ptr_ty, i32_ty, i32_ty, i32_ty}, false);
+    lyra_deferred_masked_write_local_ = llvm::Function::Create(
+        fn_type, llvm::Function::ExternalLinkage,
+        "LyraDeferredMaskedWriteLocal", llvm_module_.get());
+  }
+  return lyra_deferred_masked_write_local_;
+}
+
+auto Context::GetLyraDeferredCanonicalPackedWriteLocal() -> llvm::Function* {
+  if (lyra_deferred_canonical_packed_write_local_ == nullptr) {
+    auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
+    auto* i32_ty = llvm::Type::getInt32Ty(*llvm_context_);
+    // (eng, inst, val, unk, region_bsz, id, body_offset, second_region_offset)
+    auto* fn_type = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*llvm_context_),
+        {ptr_ty, ptr_ty, ptr_ty, ptr_ty, i32_ty, i32_ty, i32_ty, i32_ty},
+        false);
+    lyra_deferred_canonical_packed_write_local_ = llvm::Function::Create(
+        fn_type, llvm::Function::ExternalLinkage,
+        "LyraDeferredCanonicalPackedWriteLocal", llvm_module_.get());
+  }
+  return lyra_deferred_canonical_packed_write_local_;
 }
 
 auto Context::GetLyraScheduleNbaLocal() -> llvm::Function* {

--- a/src/lyra/llvm_backend/context_runtime.cpp
+++ b/src/lyra/llvm_backend/context_runtime.cpp
@@ -703,6 +703,21 @@ auto Context::GetLyraStoreStringGlobal() -> llvm::Function* {
   return lyra_store_string_global_;
 }
 
+auto Context::GetLyraDeferredWriteLocal() -> llvm::Function* {
+  if (lyra_deferred_write_local_ == nullptr) {
+    auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
+    auto* i32_ty = llvm::Type::getInt32Ty(*llvm_context_);
+    // (eng, inst, vp, bsz, id, body_offset)
+    auto* fn_type = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*llvm_context_),
+        {ptr_ty, ptr_ty, ptr_ty, i32_ty, i32_ty, i32_ty}, false);
+    lyra_deferred_write_local_ = llvm::Function::Create(
+        fn_type, llvm::Function::ExternalLinkage, "LyraDeferredWriteLocal",
+        llvm_module_.get());
+  }
+  return lyra_deferred_write_local_;
+}
+
 auto Context::GetLyraScheduleNbaLocal() -> llvm::Function* {
   if (lyra_schedule_nba_local_ == nullptr) {
     auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);

--- a/src/lyra/llvm_backend/emit_design_main.cpp
+++ b/src/lyra/llvm_backend/emit_design_main.cpp
@@ -640,11 +640,11 @@ auto EmitObservableDescriptorTemplate(
 
   auto num_entries = static_cast<uint32_t>(tmpl.entries.size());
   if (num_entries > 0) {
-    auto* entry_type = llvm::ArrayType::get(i32_ty, 14);
+    auto* entry_type = llvm::ArrayType::get(i32_ty, 15);
     std::vector<llvm::Constant*> entry_constants;
     entry_constants.reserve(num_entries);
     for (const auto& e : tmpl.entries) {
-      std::array<llvm::Constant*, 14> fields = {
+      std::array<llvm::Constant*, 15> fields = {
           llvm::ConstantInt::get(i32_ty, e.storage_byte_offset),
           llvm::ConstantInt::get(i32_ty, e.total_bytes),
           llvm::ConstantInt::get(i32_ty, e.storage_kind),
@@ -659,6 +659,7 @@ auto EmitObservableDescriptorTemplate(
           llvm::ConstantInt::get(i32_ty, e.flags),
           llvm::ConstantInt::get(i32_ty, e.storage_domain),
           llvm::ConstantInt::get(i32_ty, e.local_signal_id),
+          llvm::ConstantInt::get(i32_ty, e.backing_rel_off),
       };
       entry_constants.push_back(llvm::ConstantArray::get(entry_type, fields));
     }

--- a/src/lyra/llvm_backend/emit_design_main.cpp
+++ b/src/lyra/llvm_backend/emit_design_main.cpp
@@ -2774,6 +2774,7 @@ auto EmitDesignMain(
 
   return LoweringReport{
       .forwarding_analysis = std::move(forwarding_report),
+      .relay_slots_eliminated = layout.relay_slots_eliminated,
   };
 }
 

--- a/src/lyra/llvm_backend/instruction/deferred_assign.cpp
+++ b/src/lyra/llvm_backend/instruction/deferred_assign.cpp
@@ -212,6 +212,42 @@ auto EmitDeferredStoreCore(
   return {};
 }
 
+// Instance-owned deferred write for simple local full-overwrite NBA.
+// Writes new value directly to per-instance deferred storage and marks
+// the local signal pending. No NbaEntry, no SmallByteBuffer, no variant.
+// Identity-based: passes (local_signal_id, body_byte_offset) instead of
+// current-storage pointer, so the runtime fast path has no pointer arithmetic.
+auto EmitDeferredWriteLocal(
+    Context& context, const mir::DeferredAssign& deferred,
+    const StoreShape& shape, uint32_t body_byte_offset,
+    const SignalCoordExpr& signal_id, TypeId target_type) -> Result<void> {
+  auto& builder = context.GetBuilder();
+  auto& llvm_ctx = context.GetLlvmContext();
+
+  auto raw_or_err = LowerRhsRaw(context, deferred.rhs, target_type);
+  if (!raw_or_err) return std::unexpected(raw_or_err.error());
+
+  llvm::Value* source_value = CoerceValueToShape(context, *raw_or_err, shape);
+  auto* val_alloca = builder.CreateAlloca(shape.storage_ty, nullptr, "nba.val");
+  builder.CreateStore(source_value, val_alloca);
+
+  uint32_t byte_size =
+      (shape.kind == StoreKind::kAggregateBytes)
+          ? shape.byte_size
+          : static_cast<uint32_t>(
+                context.GetModule().getDataLayout().getTypeStoreSize(
+                    shape.storage_ty));
+
+  auto* i32_ty = llvm::Type::getInt32Ty(llvm_ctx);
+  builder.CreateCall(
+      context.GetLyraDeferredWriteLocal(),
+      {context.GetEnginePointer(),
+       signal_id.GetInstancePointer(context.GetInstancePointer()), val_alloca,
+       llvm::ConstantInt::get(i32_ty, byte_size), signal_id.Emit(builder),
+       llvm::ConstantInt::get(i32_ty, body_byte_offset)});
+  return {};
+}
+
 // BitRangeProjection NBA: route through packed storage view module.
 // The storage layer owns subview classification and emission shape;
 // this function is a thin routing wrapper.
@@ -364,6 +400,18 @@ auto LowerDeferredAssign(Context& context, const mir::DeferredAssign& deferred)
     write_ptr = context.EmitExternalRefAddress(ref_id);
     notify_base_ptr = write_ptr;
   }
+
+  // Instance-owned deferred write fast path: local target, no projections
+  // (full slot write), owned-inline storage. Writes directly to per-instance
+  // deferred storage instead of building NbaEntry into nba_queue_.
+  if (dest_place != nullptr && signal_id.IsLocal() &&
+      context.LookupPlace(*dest_place).projections.empty() &&
+      context.IsOwnedInlineSlot(*dest_place)) {
+    auto body_offset = context.GetSlotBodyByteOffset(*dest_place);
+    return EmitDeferredWriteLocal(
+        context, deferred, shape, body_offset, signal_id, dest_type);
+  }
+
   return EmitDeferredStoreCore(
       context, deferred, shape, write_ptr, notify_base_ptr, signal_id,
       dest_type);

--- a/src/lyra/llvm_backend/instruction/deferred_assign.cpp
+++ b/src/lyra/llvm_backend/instruction/deferred_assign.cpp
@@ -162,8 +162,17 @@ auto CoerceValueToShape(
   return nullptr;
 }
 
-// Canonical deferred store core parameterized by TypeId.
-// Handles value/mask construction uniformly via StoreShape classification.
+// Generic NBA queue path for non-instance-owned targets.
+//
+// ARCHITECTURAL INVARIANT:
+// This function emits calls to LyraScheduleNba{Local,Global}, which enqueue
+// onto the generic nba_queue_. Only the following targets are permitted:
+//   - Global/package signals (SignalCoordExpr::kGlobal)
+//   - Cross-instance local signals (SignalCoordExpr::kLocalCrossInstance)
+//   - ExternalRefId targets (always global)
+// Instance-owned local signals (same-instance, owned inline or container)
+// MUST use EmitDeferredWriteLocal instead. The ownership gate in
+// LowerDeferredAssign enforces this at codegen time.
 auto EmitDeferredStoreCore(
     Context& context, const mir::DeferredAssign& deferred,
     const StoreShape& shape, llvm::Value* write_ptr,
@@ -385,6 +394,14 @@ auto LowerDeferredAssignWithOobGuard(
         context, deferred, shape, body_offset, signal_id, dest_type, true);
     if (!result) return result;
   } else {
+    if (signal_id.GetKind() == SignalCoordExpr::Kind::kLocal) {
+      if (context.IsOwnedInlineSlot(dest) ||
+          context.IsOwnedContainerSlot(dest)) {
+        throw common::InternalError(
+            "LowerDeferredAssignWithOobGuard",
+            "same-instance owned signal reached generic NBA queue fallback");
+      }
+    }
     auto write_ptr_or_err = context.GetPlacePointer(dest);
     if (!write_ptr_or_err) return std::unexpected(write_ptr_or_err.error());
     llvm::Value* write_ptr = *write_ptr_or_err;
@@ -418,10 +435,18 @@ auto LowerDeferredAssign(Context& context, const mir::DeferredAssign& deferred)
                                   : context.EmitExternalRefSignalCoord(
                                         std::get<mir::ExternalRefId>(dest));
 
-  // Ownership gate: local module slot with owned storage (inline or container).
-  // All NBA writes to such targets go through instance-owned deferred
-  // storage. Generic nba_queue_ is only for non-instance-owned targets
-  // (global, package, cross-instance).
+  // ROUTING INVARIANT: local owned state <= must use deferred storage.
+  //
+  // Same-instance owned signals (inline or container) go through
+  // EmitDeferredWriteLocal -> LyraDeferredWriteLocal, writing to
+  // per-instance deferred storage committed in CommitDeferredLocalNbas.
+  //
+  // Everything else (global, package, cross-instance, ExternalRefId)
+  // goes through EmitDeferredStoreCore -> LyraScheduleNba{Local,Global},
+  // enqueuing onto the generic nba_queue_.
+  //
+  // ExternalRefId always produces SignalCoordExpr::Global -- it never
+  // reaches the ownership gate (dest_place is nullptr for external refs).
   bool is_local_owned_inline = dest_place != nullptr && signal_id.IsLocal() &&
                                context.IsOwnedInlineSlot(*dest_place);
   bool is_local_owned_container = dest_place != nullptr &&
@@ -479,6 +504,19 @@ auto LowerDeferredAssign(Context& context, const mir::DeferredAssign& deferred)
   }
 
   // Non-local fallback: global, external ref, or cross-instance targets.
+  // Invariant: if we reach here with a same-instance local signal, the
+  // ownership gate above must have determined it is NOT instance-owned.
+  // A same-instance owned signal reaching the generic queue is a bug.
+  if (dest_place != nullptr &&
+      signal_id.GetKind() == SignalCoordExpr::Kind::kLocal) {
+    if (context.IsOwnedInlineSlot(*dest_place) ||
+        context.IsOwnedContainerSlot(*dest_place)) {
+      throw common::InternalError(
+          "LowerDeferredAssign",
+          "same-instance owned signal reached generic NBA queue fallback");
+    }
+  }
+
   llvm::Value* write_ptr = nullptr;
   llvm::Value* notify_base_ptr = nullptr;
   if (dest_place != nullptr) {

--- a/src/lyra/llvm_backend/instruction/deferred_assign.cpp
+++ b/src/lyra/llvm_backend/instruction/deferred_assign.cpp
@@ -212,15 +212,16 @@ auto EmitDeferredStoreCore(
   return {};
 }
 
-// Instance-owned deferred write for simple local full-overwrite NBA.
-// Writes new value directly to per-instance deferred storage and marks
-// the local signal pending. No NbaEntry, no SmallByteBuffer, no variant.
-// Identity-based: passes (local_signal_id, body_byte_offset) instead of
-// current-storage pointer, so the runtime fast path has no pointer arithmetic.
+// Instance-owned deferred byte-range write for local NBA.
+// Handles whole-slot and sub-slot writes. Identity-based: passes
+// (local_signal_id, body_byte_offset, is_partial) instead of
+// current-storage pointers. body_byte_offset is an LLVM Value to
+// support both static (field/union) and dynamic (index) offsets.
 auto EmitDeferredWriteLocal(
     Context& context, const mir::DeferredAssign& deferred,
-    const StoreShape& shape, uint32_t body_byte_offset,
-    const SignalCoordExpr& signal_id, TypeId target_type) -> Result<void> {
+    const StoreShape& shape, llvm::Value* body_byte_offset,
+    const SignalCoordExpr& signal_id, TypeId target_type, bool is_partial)
+    -> Result<void> {
   auto& builder = context.GetBuilder();
   auto& llvm_ctx = context.GetLlvmContext();
 
@@ -244,16 +245,19 @@ auto EmitDeferredWriteLocal(
       {context.GetEnginePointer(),
        signal_id.GetInstancePointer(context.GetInstancePointer()), val_alloca,
        llvm::ConstantInt::get(i32_ty, byte_size), signal_id.Emit(builder),
-       llvm::ConstantInt::get(i32_ty, body_byte_offset)});
+       body_byte_offset, llvm::ConstantInt::get(i32_ty, is_partial ? 1 : 0)});
   return {};
 }
 
 // BitRangeProjection NBA: route through packed storage view module.
 // The storage layer owns subview classification and emission shape;
-// this function is a thin routing wrapper.
+// this function is a thin routing wrapper. The ownership flag is forwarded
+// to PackedNbaPolicy so the packed dispatch can route local owned-inline
+// targets to deferred storage.
 auto LowerDeferredAssignBitRange(
     Context& context, const mir::DeferredAssign& deferred,
-    const SignalCoordExpr& signal_id, mir::PlaceId dest) -> Result<void> {
+    const SignalCoordExpr& signal_id, mir::PlaceId dest,
+    bool is_local_owned_inline) -> Result<void> {
   auto path = ExtractPackedAccessPath(context, dest);
   if (!path) return std::unexpected(path.error());
 
@@ -264,38 +268,42 @@ auto LowerDeferredAssignBitRange(
       context, deferred.rhs, subview->semantic_bit_width, subview->result_type);
   if (!rvalue) return std::unexpected(rvalue.error());
 
+  uint32_t slot_body_offset = 0;
+  if (is_local_owned_inline) {
+    slot_body_offset = context.GetSlotBodyByteOffset(dest);
+  }
+
   PackedNbaPolicy nba_policy{
       .engine_ptr = context.GetEnginePointer(),
       .notify_base_ptr = context.GetStorageRootPointer(dest),
       .signal_id = signal_id,
+      .is_local_owned_inline = is_local_owned_inline,
+      .slot_body_offset = slot_body_offset,
   };
 
   return EmitDeferredStoreToPackedSubview(
       context, *subview, *rvalue, nba_policy);
 }
 
-// IndexProjection NBA: array element write with OOB guard.
-// Uses StoreShape classification and EmitDeferredStoreCore.
-auto LowerDeferredAssignWithOobGuard(
-    Context& context, const mir::DeferredAssign& deferred,
-    const StoreShape& shape, const SignalCoordExpr& signal_id,
-    mir::PlaceId dest) -> Result<void> {
-  auto& builder = context.GetBuilder();
-  auto& llvm_ctx = context.GetLlvmContext();
+// Extract array bounds info from a place with IndexProjection.
+// Returns (IndexProjection*, array_size) for the first IndexProjection found.
+struct IndexProjectionInfo {
+  const mir::IndexProjection* proj = nullptr;
+  uint64_t array_size = 0;
+};
+
+auto ExtractIndexProjectionInfo(Context& context, mir::PlaceId dest)
+    -> IndexProjectionInfo {
   const auto& types = context.GetTypeArena();
   const auto& place = context.LookupPlace(dest);
 
-  // Walk projections to find the first IndexProjection and compute the array
-  // type AT that projection site. This handles cases like s.field[i] where the
-  // root type is a struct but the indexed type is an array field.
   const mir::IndexProjection* idx_proj = nullptr;
   TypeId array_type_id = place.root.type;
   for (const auto& proj : place.projections) {
     if (const auto* idx = std::get_if<mir::IndexProjection>(&proj.info)) {
       idx_proj = idx;
-      break;  // array_type_id is now the array being indexed
+      break;
     }
-    // Advance type through non-index projections
     const Type& cur_type = types[array_type_id];
     if (const auto* fp = std::get_if<mir::FieldProjection>(&proj.info)) {
       array_type_id = cur_type.AsUnpackedStruct()
@@ -308,44 +316,79 @@ auto LowerDeferredAssignWithOobGuard(
         const auto* bp = std::get_if<mir::BitRangeProjection>(&proj.info)) {
       array_type_id = bp->element_type;
     }
-    // SliceProjection and DerefProjection not yet supported
   }
 
   const Type& arr_type = types[array_type_id];
   if (arr_type.Kind() != TypeKind::kUnpackedArray) {
     throw common::InternalError(
-        "LowerDeferredAssignWithOobGuard",
+        "ExtractIndexProjectionInfo",
         std::format(
             "expected UnpackedArray at IndexProjection, got {}",
             ToString(arr_type.Kind())));
   }
-  auto arr_size = arr_type.AsUnpackedArray().range.Size();
+  return {
+      .proj = idx_proj, .array_size = arr_type.AsUnpackedArray().range.Size()};
+}
 
-  // Compute bounds check
+// IndexProjection NBA: array element write with OOB guard.
+// For local owned-inline targets, uses deferred byte-range write with
+// dynamic body_offset. For non-local, uses generic EmitDeferredStoreCore.
+auto LowerDeferredAssignWithOobGuard(
+    Context& context, const mir::DeferredAssign& deferred,
+    const StoreShape& shape, const SignalCoordExpr& signal_id,
+    mir::PlaceId dest, bool is_local_owned_inline) -> Result<void> {
+  auto& builder = context.GetBuilder();
+  auto& llvm_ctx = context.GetLlvmContext();
+  const auto& types = context.GetTypeArena();
+
+  auto [idx_proj, arr_size] = ExtractIndexProjectionInfo(context, dest);
+
   auto index_or_err = LowerOperand(context, idx_proj->index);
   if (!index_or_err) return std::unexpected(index_or_err.error());
   llvm::Value* index = *index_or_err;
   auto* arr_size_val = llvm::ConstantInt::get(index->getType(), arr_size);
   auto* in_bounds = builder.CreateICmpULT(index, arr_size_val, "nba.inbounds");
 
-  // Create conditional branch
   auto* func = builder.GetInsertBlock()->getParent();
   auto* schedule_bb = llvm::BasicBlock::Create(llvm_ctx, "nba.schedule", func);
   auto* skip_bb = llvm::BasicBlock::Create(llvm_ctx, "nba.skip", func);
   builder.CreateCondBr(in_bounds, schedule_bb, skip_bb);
 
-  // Schedule block: compute pointers and emit via shared core
   builder.SetInsertPoint(schedule_bb);
-  auto write_ptr_or_err = context.GetPlacePointer(dest);
-  if (!write_ptr_or_err) return std::unexpected(write_ptr_or_err.error());
-  llvm::Value* write_ptr = *write_ptr_or_err;
-  llvm::Value* notify_base_ptr = context.GetStorageRootPointer(dest);
 
-  TypeId dest_type = mir::TypeOfPlace(types, context.LookupPlace(dest));
-  auto result = EmitDeferredStoreCore(
-      context, deferred, shape, write_ptr, notify_base_ptr, signal_id,
-      dest_type);
-  if (!result) return result;
+  if (is_local_owned_inline) {
+    // Compute dynamic body_offset: write_ptr - inline_base, expressed as
+    // slot_body_offset + (write_ptr - slot_root). GetPlacePointer applies
+    // all projections (field + index), so ptr - root = sub-slot offset.
+    auto write_ptr_or_err = context.GetPlacePointer(dest);
+    if (!write_ptr_or_err) return std::unexpected(write_ptr_or_err.error());
+    llvm::Value* write_ptr = *write_ptr_or_err;
+    llvm::Value* slot_root = context.GetStorageRootPointer(dest);
+
+    auto* i32_ty = llvm::Type::getInt32Ty(llvm_ctx);
+    auto* sub_offset = builder.CreatePtrDiff(
+        llvm::Type::getInt8Ty(llvm_ctx), write_ptr, slot_root, "nba.suboff");
+    auto* sub_offset_i32 = builder.CreateTrunc(sub_offset, i32_ty);
+    uint32_t slot_body_off = context.GetSlotBodyByteOffset(dest);
+    auto* body_offset = builder.CreateAdd(
+        llvm::ConstantInt::get(i32_ty, slot_body_off), sub_offset_i32,
+        "nba.bodyoff");
+
+    TypeId dest_type = mir::TypeOfPlace(types, context.LookupPlace(dest));
+    auto result = EmitDeferredWriteLocal(
+        context, deferred, shape, body_offset, signal_id, dest_type, true);
+    if (!result) return result;
+  } else {
+    auto write_ptr_or_err = context.GetPlacePointer(dest);
+    if (!write_ptr_or_err) return std::unexpected(write_ptr_or_err.error());
+    llvm::Value* write_ptr = *write_ptr_or_err;
+    llvm::Value* notify_base_ptr = context.GetStorageRootPointer(dest);
+    TypeId dest_type = mir::TypeOfPlace(types, context.LookupPlace(dest));
+    auto result = EmitDeferredStoreCore(
+        context, deferred, shape, write_ptr, notify_base_ptr, signal_id,
+        dest_type);
+    if (!result) return result;
+  }
   builder.CreateBr(skip_bb);
 
   builder.SetInsertPoint(skip_bb);
@@ -369,25 +412,59 @@ auto LowerDeferredAssign(Context& context, const mir::DeferredAssign& deferred)
                                   : context.EmitExternalRefSignalCoord(
                                         std::get<mir::ExternalRefId>(dest));
 
+  // Ownership gate: local module slot with owned-inline storage.
+  // All NBA writes to such targets go through instance-owned deferred
+  // storage. Generic nba_queue_ is only for non-instance-owned targets.
+  bool is_local_owned_inline = dest_place != nullptr && signal_id.IsLocal() &&
+                               context.IsOwnedInlineSlot(*dest_place);
+
   // Case 1: BitRangeProjection (PlaceId-only, external refs have no
-  // projections).
+  // projections). PackedNbaPolicy carries the ownership flag so the packed
+  // subview dispatch can route to deferred storage for local targets.
   if (dest_place != nullptr && context.HasBitRangeProjection(*dest_place)) {
     return LowerDeferredAssignBitRange(
-        context, deferred, signal_id, *dest_place);
+        context, deferred, signal_id, *dest_place, is_local_owned_inline);
   }
 
   // Classify destination once via MIR type.
   StoreShape shape = ClassifyDeferredStoreByType(context, dest_type);
 
-  // Case 2: IndexProjection (PlaceId-only).
+  // Case 2: IndexProjection (PlaceId-only). Dynamic offset, always partial.
   if (dest_place != nullptr &&
       HasIndexProjection(context.LookupPlace(*dest_place))) {
     return LowerDeferredAssignWithOobGuard(
-        context, deferred, shape, signal_id, *dest_place);
+        context, deferred, shape, signal_id, *dest_place,
+        is_local_owned_inline);
   }
 
-  // Case 3: Simple full-width write. Works for both PlaceId and ExternalRefId.
-  // Resolve write pointer and notify base from WriteTarget.
+  // Case 3: Full-width write or static field/union projection chain.
+  auto* i32_ty = llvm::Type::getInt32Ty(context.GetLlvmContext());
+
+  if (is_local_owned_inline) {
+    uint32_t slot_body_off = context.GetSlotBodyByteOffset(*dest_place);
+    const auto& projs = context.LookupPlace(*dest_place).projections;
+
+    if (!projs.empty()) {
+      auto static_proj = context.ComputeStaticProjectionOffset(*dest_place);
+      if (!static_proj.has_value()) {
+        throw common::InternalError(
+            "LowerDeferredAssign",
+            "local owned-inline target has unsupported projection chain "
+            "that reached Case 3 (not BitRange, not Index)");
+      }
+      auto [sub_offset, sub_size] = *static_proj;
+      auto* body_offset =
+          llvm::ConstantInt::get(i32_ty, slot_body_off + sub_offset);
+      return EmitDeferredWriteLocal(
+          context, deferred, shape, body_offset, signal_id, dest_type, true);
+    }
+    // Whole-slot write: no projections.
+    auto* body_offset = llvm::ConstantInt::get(i32_ty, slot_body_off);
+    return EmitDeferredWriteLocal(
+        context, deferred, shape, body_offset, signal_id, dest_type, false);
+  }
+
+  // Non-local fallback: global, external ref, or container-backed targets.
   llvm::Value* write_ptr = nullptr;
   llvm::Value* notify_base_ptr = nullptr;
   if (dest_place != nullptr) {
@@ -399,17 +476,6 @@ auto LowerDeferredAssign(Context& context, const mir::DeferredAssign& deferred)
     auto ref_id = std::get<mir::ExternalRefId>(dest);
     write_ptr = context.EmitExternalRefAddress(ref_id);
     notify_base_ptr = write_ptr;
-  }
-
-  // Instance-owned deferred write fast path: local target, no projections
-  // (full slot write), owned-inline storage. Writes directly to per-instance
-  // deferred storage instead of building NbaEntry into nba_queue_.
-  if (dest_place != nullptr && signal_id.IsLocal() &&
-      context.LookupPlace(*dest_place).projections.empty() &&
-      context.IsOwnedInlineSlot(*dest_place)) {
-    auto body_offset = context.GetSlotBodyByteOffset(*dest_place);
-    return EmitDeferredWriteLocal(
-        context, deferred, shape, body_offset, signal_id, dest_type);
   }
 
   return EmitDeferredStoreCore(

--- a/src/lyra/llvm_backend/instruction/deferred_assign.cpp
+++ b/src/lyra/llvm_backend/instruction/deferred_assign.cpp
@@ -256,8 +256,8 @@ auto EmitDeferredWriteLocal(
 // targets to deferred storage.
 auto LowerDeferredAssignBitRange(
     Context& context, const mir::DeferredAssign& deferred,
-    const SignalCoordExpr& signal_id, mir::PlaceId dest,
-    bool is_local_owned_inline) -> Result<void> {
+    const SignalCoordExpr& signal_id, mir::PlaceId dest, bool is_local_owned)
+    -> Result<void> {
   auto path = ExtractPackedAccessPath(context, dest);
   if (!path) return std::unexpected(path.error());
 
@@ -269,15 +269,17 @@ auto LowerDeferredAssignBitRange(
   if (!rvalue) return std::unexpected(rvalue.error());
 
   uint32_t slot_body_offset = 0;
-  if (is_local_owned_inline) {
-    slot_body_offset = context.GetSlotBodyByteOffset(dest);
+  if (is_local_owned) {
+    slot_body_offset = context.IsOwnedContainerSlot(dest)
+                           ? context.GetContainerBodyByteOffset(dest)
+                           : context.GetSlotBodyByteOffset(dest);
   }
 
   PackedNbaPolicy nba_policy{
       .engine_ptr = context.GetEnginePointer(),
       .notify_base_ptr = context.GetStorageRootPointer(dest),
       .signal_id = signal_id,
-      .is_local_owned_inline = is_local_owned_inline,
+      .is_local_owned = is_local_owned,
       .slot_body_offset = slot_body_offset,
   };
 
@@ -331,12 +333,12 @@ auto ExtractIndexProjectionInfo(Context& context, mir::PlaceId dest)
 }
 
 // IndexProjection NBA: array element write with OOB guard.
-// For local owned-inline targets, uses deferred byte-range write with
+// For local owned targets, uses deferred byte-range write with
 // dynamic body_offset. For non-local, uses generic EmitDeferredStoreCore.
 auto LowerDeferredAssignWithOobGuard(
     Context& context, const mir::DeferredAssign& deferred,
     const StoreShape& shape, const SignalCoordExpr& signal_id,
-    mir::PlaceId dest, bool is_local_owned_inline) -> Result<void> {
+    mir::PlaceId dest, bool is_local_owned) -> Result<void> {
   auto& builder = context.GetBuilder();
   auto& llvm_ctx = context.GetLlvmContext();
   const auto& types = context.GetTypeArena();
@@ -356,10 +358,12 @@ auto LowerDeferredAssignWithOobGuard(
 
   builder.SetInsertPoint(schedule_bb);
 
-  if (is_local_owned_inline) {
-    // Compute dynamic body_offset: write_ptr - inline_base, expressed as
-    // slot_body_offset + (write_ptr - slot_root). GetPlacePointer applies
-    // all projections (field + index), so ptr - root = sub-slot offset.
+  if (is_local_owned) {
+    // Compute dynamic body_offset: base_offset + (write_ptr - slot_root).
+    // GetPlacePointer applies all projections (field + index), so
+    // ptr - root = sub-slot offset.
+    // For inline slots: base is the inline slot offset.
+    // For container slots: base is the appendix backing data offset.
     auto write_ptr_or_err = context.GetPlacePointer(dest);
     if (!write_ptr_or_err) return std::unexpected(write_ptr_or_err.error());
     llvm::Value* write_ptr = *write_ptr_or_err;
@@ -369,7 +373,9 @@ auto LowerDeferredAssignWithOobGuard(
     auto* sub_offset = builder.CreatePtrDiff(
         llvm::Type::getInt8Ty(llvm_ctx), write_ptr, slot_root, "nba.suboff");
     auto* sub_offset_i32 = builder.CreateTrunc(sub_offset, i32_ty);
-    uint32_t slot_body_off = context.GetSlotBodyByteOffset(dest);
+    uint32_t slot_body_off = context.IsOwnedContainerSlot(dest)
+                                 ? context.GetContainerBodyByteOffset(dest)
+                                 : context.GetSlotBodyByteOffset(dest);
     auto* body_offset = builder.CreateAdd(
         llvm::ConstantInt::get(i32_ty, slot_body_off), sub_offset_i32,
         "nba.bodyoff");
@@ -412,18 +418,23 @@ auto LowerDeferredAssign(Context& context, const mir::DeferredAssign& deferred)
                                   : context.EmitExternalRefSignalCoord(
                                         std::get<mir::ExternalRefId>(dest));
 
-  // Ownership gate: local module slot with owned-inline storage.
+  // Ownership gate: local module slot with owned storage (inline or container).
   // All NBA writes to such targets go through instance-owned deferred
-  // storage. Generic nba_queue_ is only for non-instance-owned targets.
+  // storage. Generic nba_queue_ is only for non-instance-owned targets
+  // (global, package, cross-instance).
   bool is_local_owned_inline = dest_place != nullptr && signal_id.IsLocal() &&
                                context.IsOwnedInlineSlot(*dest_place);
+  bool is_local_owned_container = dest_place != nullptr &&
+                                  signal_id.IsLocal() &&
+                                  context.IsOwnedContainerSlot(*dest_place);
+  bool is_local_owned = is_local_owned_inline || is_local_owned_container;
 
   // Case 1: BitRangeProjection (PlaceId-only, external refs have no
   // projections). PackedNbaPolicy carries the ownership flag so the packed
   // subview dispatch can route to deferred storage for local targets.
   if (dest_place != nullptr && context.HasBitRangeProjection(*dest_place)) {
     return LowerDeferredAssignBitRange(
-        context, deferred, signal_id, *dest_place, is_local_owned_inline);
+        context, deferred, signal_id, *dest_place, is_local_owned);
   }
 
   // Classify destination once via MIR type.
@@ -433,15 +444,18 @@ auto LowerDeferredAssign(Context& context, const mir::DeferredAssign& deferred)
   if (dest_place != nullptr &&
       HasIndexProjection(context.LookupPlace(*dest_place))) {
     return LowerDeferredAssignWithOobGuard(
-        context, deferred, shape, signal_id, *dest_place,
-        is_local_owned_inline);
+        context, deferred, shape, signal_id, *dest_place, is_local_owned);
   }
 
   // Case 3: Full-width write or static field/union projection chain.
   auto* i32_ty = llvm::Type::getInt32Ty(context.GetLlvmContext());
 
-  if (is_local_owned_inline) {
-    uint32_t slot_body_off = context.GetSlotBodyByteOffset(*dest_place);
+  if (is_local_owned) {
+    // For inline slots: body_offset is the inline slot offset.
+    // For container slots: body_offset is the appendix backing data offset.
+    uint32_t slot_body_off =
+        is_local_owned_inline ? context.GetSlotBodyByteOffset(*dest_place)
+                              : context.GetContainerBodyByteOffset(*dest_place);
     const auto& projs = context.LookupPlace(*dest_place).projections;
 
     if (!projs.empty()) {
@@ -449,7 +463,7 @@ auto LowerDeferredAssign(Context& context, const mir::DeferredAssign& deferred)
       if (!static_proj.has_value()) {
         throw common::InternalError(
             "LowerDeferredAssign",
-            "local owned-inline target has unsupported projection chain "
+            "local owned target has unsupported projection chain "
             "that reached Case 3 (not BitRange, not Index)");
       }
       auto [sub_offset, sub_size] = *static_proj;
@@ -464,7 +478,7 @@ auto LowerDeferredAssign(Context& context, const mir::DeferredAssign& deferred)
         context, deferred, shape, body_offset, signal_id, dest_type, false);
   }
 
-  // Non-local fallback: global, external ref, or container-backed targets.
+  // Non-local fallback: global, external ref, or cross-instance targets.
   llvm::Value* write_ptr = nullptr;
   llvm::Value* notify_base_ptr = nullptr;
   if (dest_place != nullptr) {

--- a/src/lyra/llvm_backend/layout/layout.cpp
+++ b/src/lyra/llvm_backend/layout/layout.cpp
@@ -951,11 +951,11 @@ auto BuildRuntimeInstanceStorageType(llvm::LLVMContext& ctx)
   auto* ptr_ty = llvm::PointerType::getUnqual(ctx);
   auto* i64_ty = llvm::Type::getInt64Ty(ctx);
   // { inline_base, inline_size, appendix_base, appendix_size,
-  //   deferred_inline_base }
+  //   deferred_inline_base, deferred_appendix_base }
   using F = lyra::runtime::RuntimeInstanceStorageField;
   constexpr auto kFieldCount = static_cast<size_t>(F::kFieldCount);
-  std::array<llvm::Type*, kFieldCount> fields = {
-      ptr_ty, i64_ty, ptr_ty, i64_ty, ptr_ty};
+  std::array<llvm::Type*, kFieldCount> fields = {ptr_ty, i64_ty, ptr_ty,
+                                                 i64_ty, ptr_ty, ptr_ty};
   return llvm::StructType::create(ctx, fields, "RuntimeInstanceStorage");
 }
 

--- a/src/lyra/llvm_backend/layout/layout.cpp
+++ b/src/lyra/llvm_backend/layout/layout.cpp
@@ -950,11 +950,12 @@ auto BuildRuntimeInstanceStorageType(llvm::LLVMContext& ctx)
     -> llvm::StructType* {
   auto* ptr_ty = llvm::PointerType::getUnqual(ctx);
   auto* i64_ty = llvm::Type::getInt64Ty(ctx);
-  // { inline_base, inline_size, appendix_base, appendix_size }
+  // { inline_base, inline_size, appendix_base, appendix_size,
+  //   deferred_inline_base }
   using F = lyra::runtime::RuntimeInstanceStorageField;
   constexpr auto kFieldCount = static_cast<size_t>(F::kFieldCount);
   std::array<llvm::Type*, kFieldCount> fields = {
-      ptr_ty, i64_ty, ptr_ty, i64_ty};
+      ptr_ty, i64_ty, ptr_ty, i64_ty, ptr_ty};
   return llvm::StructType::create(ctx, fields, "RuntimeInstanceStorage");
 }
 

--- a/src/lyra/llvm_backend/layout_pipeline.cpp
+++ b/src/lyra/llvm_backend/layout_pipeline.cpp
@@ -80,17 +80,22 @@ auto BuildBackendLayout(
       std::move(connections.kernel_entries), topology.module_plans,
       *input.design, *input.mir_arena, topology.total_design_slot_count);
 
+  uint32_t relays_eliminated = EliminateRelayConnections(connection_analysis);
+
   auto design_layout = BuildDesignLayout(
       input.design->slots, *input.type_arena, data_layout,
       input.force_two_state, instance_ranges);
 
-  return std::make_unique<Layout>(BuildLayout(
+  auto layout = std::make_unique<Layout>(BuildLayout(
       input.design->init_processes,
       std::move(connection_analysis.connection_edges),
       std::move(connections.non_kernelized_processes), topology.module_plans,
       *input.design, *input.mir_arena, *input.type_arena,
       std::move(design_layout), body_storage_layouts, input.body_timescales,
       llvm_ctx, data_layout, input.force_two_state));
+
+  layout->relay_slots_eliminated = relays_eliminated;
+  return layout;
 }
 
 }  // namespace lyra::lowering::mir_to_llvm

--- a/src/lyra/llvm_backend/packed_storage_view.cpp
+++ b/src/lyra/llvm_backend/packed_storage_view.cpp
@@ -24,27 +24,28 @@
 
 namespace lyra::lowering::mir_to_llvm {
 
-auto PackedStorageView::RequireLocalBackingType() const -> llvm::Type* {
-  if (backing_.is_canonical || backing_.local_llvm_type == nullptr) {
+auto PackedStorageBacking::RequireLocalType() const -> llvm::Type* {
+  if (is_canonical_ || local_llvm_type_ == nullptr) {
     throw common::InternalError(
-        "PackedStorageView::RequireLocalBackingType",
+        "PackedStorageBacking::RequireLocalType",
         "local backing type requested for canonical or unset backing");
   }
-  return backing_.local_llvm_type;
+  return local_llvm_type_;
 }
 
-void PackedStorageView::SetCanonicalBacking() {
-  backing_ = BackingInfo{.is_canonical = true, .local_llvm_type = nullptr};
+void PackedStorageBacking::SetCanonical() {
+  is_canonical_ = true;
+  local_llvm_type_ = nullptr;
 }
 
-void PackedStorageView::SetLocalBacking(llvm::Type* local_llvm_type) {
+void PackedStorageBacking::SetLocal(llvm::Type* local_llvm_type) {
   if (local_llvm_type == nullptr) {
     throw common::InternalError(
-        "PackedStorageView::SetLocalBacking",
+        "PackedStorageBacking::SetLocal",
         "non-canonical backing requires local backing type");
   }
-  backing_ =
-      BackingInfo{.is_canonical = false, .local_llvm_type = local_llvm_type};
+  is_canonical_ = false;
+  local_llvm_type_ = local_llvm_type;
 }
 
 // BitRangeProjection byte-alignment proof.
@@ -108,9 +109,9 @@ auto ResolvePackedStorageRoot(Context& ctx, mir::PlaceId place_id)
   if (!is_canonical) {
     auto llvm_type_result = BuildLlvmTypeForTypeId(ctx, base_type_id);
     if (!llvm_type_result) return std::unexpected(llvm_type_result.error());
-    view.SetLocalBacking(*llvm_type_result);
+    view.backing.SetLocal(*llvm_type_result);
   } else {
-    view.SetCanonicalBacking();
+    view.backing.SetCanonical();
   }
 
   return view;
@@ -219,7 +220,7 @@ auto ResolvePackedSubview(Context& ctx, const PackedAccessPath& path)
   //    values. Currently proven only by BitRangeProjection-specific
   //    analysis (IsBitRangeStepProvablyByteAligned). Future packed struct
   //    field and part-select steps will need their own proofs.
-  if (path.storage.IsCanonicalBacking() && final_width % 8 == 0 &&
+  if (path.storage.backing.IsCanonical() && final_width % 8 == 0 &&
       all_steps_byte_aligned) {
     access.kind = PackedSubviewKind::kByteAddressable;
     access.byte_offset =
@@ -281,7 +282,7 @@ auto LoadLanePlanes(Context& ctx, const PackedStorageView& storage)
   auto lane_bits =
       GetCanonicalLaneBits(SemanticBits::FromRaw(storage.total_semantic_bits));
 
-  if (storage.IsCanonicalBacking()) {
+  if (storage.backing.IsCanonical()) {
     auto val = LaneValue::FromNormalized(
         EmitTypedPlaneLoad(
             builder, ctx.GetLlvmContext(), storage.base_ptr, 0, lane_bits.Raw(),
@@ -300,10 +301,10 @@ auto LoadLanePlanes(Context& ctx, const PackedStorageView& storage)
 
   // Non-canonical: LLVM typed load, then normalize to lane width.
   auto* loaded = builder.CreateLoad(
-      storage.RequireLocalBackingType(), storage.base_ptr, "fp.local");
+      storage.backing.RequireLocalType(), storage.base_ptr, "fp.local");
   if (storage.is_four_state) {
     auto* st =
-        llvm::dyn_cast<llvm::StructType>(storage.RequireLocalBackingType());
+        llvm::dyn_cast<llvm::StructType>(storage.backing.RequireLocalType());
     if (st == nullptr || st->getNumElements() != 2 ||
         st->getElementType(0) != st->getElementType(1) ||
         !st->getElementType(0)->isIntegerTy()) {
@@ -357,7 +358,7 @@ void StoreLanePlanes(
             planes.Unk()->Bits().Raw(), expected_lane_bits.Raw()));
   }
 
-  if (storage.IsCanonicalBacking()) {
+  if (storage.backing.IsCanonical()) {
     EmitRuntimePlaneWriteback(
         builder, storage.base_ptr, 0, planes.Val().Raw(), "fp.val.store");
     if (storage.is_four_state) {
@@ -371,7 +372,7 @@ void StoreLanePlanes(
   // Non-canonical: convert lane-width values back to backing element width.
   if (storage.is_four_state) {
     auto* st =
-        llvm::dyn_cast<llvm::StructType>(storage.RequireLocalBackingType());
+        llvm::dyn_cast<llvm::StructType>(storage.backing.RequireLocalType());
     if (st == nullptr || st->getNumElements() != 2 ||
         st->getElementType(0) != st->getElementType(1) ||
         !st->getElementType(0)->isIntegerTy()) {
@@ -385,7 +386,7 @@ void StoreLanePlanes(
     auto* store_unk =
         ConvertLaneToBackingWidth(builder, *planes.Unk(), elem_ty);
     llvm::Value* packed =
-        llvm::UndefValue::get(storage.RequireLocalBackingType());
+        llvm::UndefValue::get(storage.backing.RequireLocalType());
     packed = builder.CreateInsertValue(packed, store_val, 0);
     packed = builder.CreateInsertValue(packed, store_unk, 1);
     builder.CreateStore(packed, storage.base_ptr);
@@ -394,7 +395,7 @@ void StoreLanePlanes(
 
   // Non-canonical 2-state: scalar store.
   auto* store_val = ConvertLaneToBackingWidth(
-      builder, planes.Val(), storage.RequireLocalBackingType());
+      builder, planes.Val(), storage.backing.RequireLocalType());
   builder.CreateStore(store_val, storage.base_ptr);
 }
 
@@ -512,7 +513,7 @@ auto EmitBitAddressableLoad(Context& ctx, const PackedSubviewAccess& access)
 auto EmitByteAddressableStore(
     Context& ctx, const PackedSubviewAccess& access, const PackedRValue& value,
     const PackedStorePlan& plan) -> llvm::Value* {
-  if (!access.storage.IsCanonicalBacking()) {
+  if (!access.storage.backing.IsCanonical()) {
     throw common::InternalError(
         "EmitByteAddressableStore",
         "byte-addressable store requires canonical storage");
@@ -929,14 +930,31 @@ void EmitNarrow2StateNbaCall(
       builder, llvm_ctx, plane_value, access.subview_byte_span,
       access.semantic_bit_width);
 
-  auto* write_ptr = builder.CreateGEP(
-      i8_ty, access.storage.base_ptr, access.byte_offset, "nba.write.ptr");
-
   uint32_t narrow_bytes = access.subview_byte_span;
   auto* buf_ty = llvm::ArrayType::get(i8_ty, narrow_bytes);
   auto* val_alloca = builder.CreateAlloca(buf_ty, nullptr, "nba.val.a");
   EncodePlaneValueToByteBuffer(builder, llvm_ctx, val_alloca, 0, store_val);
 
+  if (policy.is_local_owned_inline) {
+    // Deferred byte-range write: body_offset = slot_body_offset + byte_offset
+    auto* byte_off_i32 = builder.CreateTrunc(
+        builder.CreateZExtOrTrunc(access.byte_offset, builder.getInt64Ty()),
+        i32_ty, "nba.byteoff");
+    auto* body_offset = builder.CreateAdd(
+        llvm::ConstantInt::get(i32_ty, policy.slot_body_offset), byte_off_i32,
+        "nba.bodyoff");
+    builder.CreateCall(
+        ctx.GetLyraDeferredWriteLocal(),
+        {policy.engine_ptr,
+         policy.signal_id.GetInstancePointer(ctx.GetInstancePointer()),
+         val_alloca, llvm::ConstantInt::get(i32_ty, narrow_bytes),
+         policy.signal_id.Emit(builder), body_offset,
+         llvm::ConstantInt::get(i32_ty, 1)});
+    return;
+  }
+
+  auto* write_ptr = builder.CreateGEP(
+      i8_ty, access.storage.base_ptr, access.byte_offset, "nba.write.ptr");
   auto* null_ptr =
       llvm::ConstantPointerNull::get(llvm::PointerType::get(llvm_ctx, 0));
   if (policy.signal_id.IsLocal()) {
@@ -978,15 +996,35 @@ void EmitNarrow4StateNbaCall(
   auto* unk_store = PrepareNarrowPlaneValue(
       builder, llvm_ctx, unk_payload, narrow_bytes, access.semantic_bit_width);
 
-  auto* write_ptr = builder.CreateGEP(
-      i8_ty, access.storage.base_ptr, access.byte_offset, "nba.write.ptr");
-
   auto* buf_ty = llvm::ArrayType::get(i8_ty, narrow_bytes);
   auto* val_alloca = builder.CreateAlloca(buf_ty, nullptr, "nba.val.a");
   EncodePlaneValueToByteBuffer(builder, llvm_ctx, val_alloca, 0, val_store);
 
   auto* unk_alloca = builder.CreateAlloca(buf_ty, nullptr, "nba.unk.a");
   EncodePlaneValueToByteBuffer(builder, llvm_ctx, unk_alloca, 0, unk_store);
+
+  if (policy.is_local_owned_inline) {
+    // Deferred canonical packed write: two planes in deferred storage.
+    // body_offset = slot_body_offset + byte_offset (val plane position)
+    auto* byte_off_i32 = builder.CreateTrunc(
+        builder.CreateZExtOrTrunc(access.byte_offset, builder.getInt64Ty()),
+        i32_ty, "nba.byteoff");
+    auto* body_offset = builder.CreateAdd(
+        llvm::ConstantInt::get(i32_ty, policy.slot_body_offset), byte_off_i32,
+        "nba.bodyoff");
+    builder.CreateCall(
+        ctx.GetLyraDeferredCanonicalPackedWriteLocal(),
+        {policy.engine_ptr,
+         policy.signal_id.GetInstancePointer(ctx.GetInstancePointer()),
+         val_alloca, unk_alloca, llvm::ConstantInt::get(i32_ty, narrow_bytes),
+         policy.signal_id.Emit(builder), body_offset,
+         llvm::ConstantInt::get(
+             i32_ty, access.storage.unk_plane_offset_bytes)});
+    return;
+  }
+
+  auto* write_ptr = builder.CreateGEP(
+      i8_ty, access.storage.base_ptr, access.byte_offset, "nba.write.ptr");
 
   if (policy.signal_id.IsExtRef()) {
     builder.CreateCall(
@@ -1063,7 +1101,16 @@ void EmitFullWidthMaskedNbaCall(
     EncodePlaneValueToByteBuffer(
         builder, llvm_ctx, mask_alloca, plane_bytes, mask_shifted);
 
-    if (policy.signal_id.IsLocal()) {
+    if (policy.is_local_owned_inline) {
+      auto* body_offset =
+          llvm::ConstantInt::get(i32_ty, policy.slot_body_offset);
+      builder.CreateCall(
+          ctx.GetLyraDeferredMaskedWriteLocal(),
+          {policy.engine_ptr,
+           policy.signal_id.GetInstancePointer(ctx.GetInstancePointer()),
+           val_alloca, mask_alloca, llvm::ConstantInt::get(i32_ty, total_bytes),
+           policy.signal_id.Emit(builder), body_offset});
+    } else if (policy.signal_id.IsLocal()) {
       builder.CreateCall(
           ctx.GetLyraScheduleNbaLocal(),
           {policy.engine_ptr,
@@ -1087,7 +1134,16 @@ void EmitFullWidthMaskedNbaCall(
     EncodePlaneValueToByteBuffer(
         builder, llvm_ctx, mask_alloca, 0, mask_shifted);
 
-    if (policy.signal_id.IsLocal()) {
+    if (policy.is_local_owned_inline) {
+      auto* body_offset =
+          llvm::ConstantInt::get(i32_ty, policy.slot_body_offset);
+      builder.CreateCall(
+          ctx.GetLyraDeferredMaskedWriteLocal(),
+          {policy.engine_ptr,
+           policy.signal_id.GetInstancePointer(ctx.GetInstancePointer()),
+           val_alloca, mask_alloca, llvm::ConstantInt::get(i32_ty, plane_bytes),
+           policy.signal_id.Emit(builder), body_offset});
+    } else if (policy.signal_id.IsLocal()) {
       builder.CreateCall(
           ctx.GetLyraScheduleNbaLocal(),
           {policy.engine_ptr,
@@ -1231,9 +1287,9 @@ auto BuildWholeValueStorageView(
           "BuildWholeValueStorageView",
           "failed to resolve LLVM type for non-canonical storage");
     }
-    view.SetLocalBacking(*llvm_type_result);
+    view.backing.SetLocal(*llvm_type_result);
   } else {
-    view.SetCanonicalBacking();
+    view.backing.SetCanonical();
   }
 
   return view;
@@ -1247,7 +1303,7 @@ auto BuildRawBytesStorageView(llvm::Value* base_ptr, uint32_t byte_size)
   view.storage_plane_byte_size = byte_size;
   view.unk_plane_offset_bytes = 0;
   view.is_four_state = false;
-  view.SetCanonicalBacking();
+  view.backing.SetCanonical();
   return view;
 }
 
@@ -1581,7 +1637,7 @@ void EmitWholeValueStoreCore(
             val.Bits().Raw(), expected_lane_bits.Raw()));
   }
 
-  if (!storage.IsCanonicalBacking()) {
+  if (!storage.backing.IsCanonical()) {
     // Non-canonical (local allocas): typed store, no compare/notify.
     StoreLanePlanes(ctx, storage, LanePlaneValues::Make(val, unk));
     return;
@@ -1809,7 +1865,7 @@ auto StorePackedValueFromCanonicalBytes(
     return {};
   }
 
-  if (!storage.IsCanonicalBacking()) {
+  if (!storage.backing.IsCanonical()) {
     builder.CreateMemCpy(
         storage.base_ptr, llvm::MaybeAlign(), src_bytes_ptr, llvm::MaybeAlign(),
         total_bytes);
@@ -1859,7 +1915,7 @@ auto NotifyPackedStorageWritten(
     return {};
   }
 
-  if (!storage.IsCanonicalBacking() || !policy.signal_id.has_value()) {
+  if (!storage.backing.IsCanonical() || !policy.signal_id.has_value()) {
     return {};
   }
 

--- a/src/lyra/llvm_backend/packed_storage_view.cpp
+++ b/src/lyra/llvm_backend/packed_storage_view.cpp
@@ -935,7 +935,7 @@ void EmitNarrow2StateNbaCall(
   auto* val_alloca = builder.CreateAlloca(buf_ty, nullptr, "nba.val.a");
   EncodePlaneValueToByteBuffer(builder, llvm_ctx, val_alloca, 0, store_val);
 
-  if (policy.is_local_owned_inline) {
+  if (policy.is_local_owned) {
     // Deferred byte-range write: body_offset = slot_body_offset + byte_offset
     auto* byte_off_i32 = builder.CreateTrunc(
         builder.CreateZExtOrTrunc(access.byte_offset, builder.getInt64Ty()),
@@ -1003,7 +1003,7 @@ void EmitNarrow4StateNbaCall(
   auto* unk_alloca = builder.CreateAlloca(buf_ty, nullptr, "nba.unk.a");
   EncodePlaneValueToByteBuffer(builder, llvm_ctx, unk_alloca, 0, unk_store);
 
-  if (policy.is_local_owned_inline) {
+  if (policy.is_local_owned) {
     // Deferred canonical packed write: two planes in deferred storage.
     // body_offset = slot_body_offset + byte_offset (val plane position)
     auto* byte_off_i32 = builder.CreateTrunc(
@@ -1101,7 +1101,7 @@ void EmitFullWidthMaskedNbaCall(
     EncodePlaneValueToByteBuffer(
         builder, llvm_ctx, mask_alloca, plane_bytes, mask_shifted);
 
-    if (policy.is_local_owned_inline) {
+    if (policy.is_local_owned) {
       auto* body_offset =
           llvm::ConstantInt::get(i32_ty, policy.slot_body_offset);
       builder.CreateCall(
@@ -1134,7 +1134,7 @@ void EmitFullWidthMaskedNbaCall(
     EncodePlaneValueToByteBuffer(
         builder, llvm_ctx, mask_alloca, 0, mask_shifted);
 
-    if (policy.is_local_owned_inline) {
+    if (policy.is_local_owned) {
       auto* body_offset =
           llvm::ConstantInt::get(i32_ty, policy.slot_body_offset);
       builder.CreateCall(

--- a/src/lyra/llvm_backend/runtime_data_extraction.cpp
+++ b/src/lyra/llvm_backend/runtime_data_extraction.cpp
@@ -89,7 +89,7 @@ auto MakeObservableDescriptorEntry(
     uint32_t storage_byte_offset, uint32_t local_name_pool_off,
     const ObservableDescriptorOwnerRefFields& refs,
     const ObservableDescriptorShapeFields& sf, uint32_t storage_domain,
-    uint32_t local_signal_id = UINT32_MAX)
+    uint32_t local_signal_id = UINT32_MAX, uint32_t backing_rel_off = 0)
     -> runtime::ObservableDescriptorEntry {
   return runtime::ObservableDescriptorEntry{
       .storage_byte_offset = storage_byte_offset,
@@ -106,6 +106,7 @@ auto MakeObservableDescriptorEntry(
       .flags = refs.flags,
       .storage_domain = storage_domain,
       .local_signal_id = local_signal_id,
+      .backing_rel_off = backing_rel_off,
   };
 }
 
@@ -929,8 +930,16 @@ void ExtractBodyObservableDescriptors(
           narrow_u64_to_u32(body_offset.value, "body-local byte offset");
 
       uint32_t body_local_signal_id = gsi - base_slot;
+      uint32_t backing_off = 0;
+      if (layout.design.owned_data_offsets[gsi].has_value()) {
+        auto backing_body_off =
+            *layout.design.owned_data_offsets[gsi] - owned_base->value;
+        backing_off = narrow_u64_to_u32(
+            backing_body_off, "container backing body offset");
+      }
       tmpl.entries.push_back(MakeObservableDescriptorEntry(
-          storage_offset, name_off, refs, sf, domain, body_local_signal_id));
+          storage_offset, name_off, refs, sf, domain, body_local_signal_id,
+          backing_off));
     }
 
     // Validate dense population.

--- a/src/lyra/llvm_backend/spec_planning.cpp
+++ b/src/lyra/llvm_backend/spec_planning.cpp
@@ -220,10 +220,12 @@ auto BuildSpecSlotInfos(
     auto slot_count = body_info.slot_count;
 
     info.inline_offsets.reserve(slot_count);
+    info.appendix_offsets.reserve(slot_count);
     info.shapes.reserve(slot_count);
     info.access_kinds.reserve(slot_count);
     for (uint32_t s = 0; s < slot_count; ++s) {
       info.inline_offsets.push_back(body_layout.inline_offsets[s]);
+      info.appendix_offsets.push_back(body_layout.appendix_offsets[s]);
       auto shape = body.slots[s].storage_shape;
       info.shapes.push_back(shape);
       bool is_container = shape == mir::StorageShape::kOwnedContainer;

--- a/src/lyra/runtime/constructor_.cpp
+++ b/src/lyra/runtime/constructor_.cpp
@@ -643,6 +643,8 @@ void Constructor::AddInstance(
   instance->storage.appendix_size = realized_appendix_size;
   instance->storage.deferred_inline_base =
       AllocateOwnedInlineStorage(realized_inline_size);
+  instance->storage.deferred_appendix_base =
+      AllocateOwnedAppendixStorage(realized_appendix_size);
 
   // Invariant: zero-slot bodies must not carry instance-state init.
   if (body_.slot_count == 0) {

--- a/src/lyra/runtime/constructor_.cpp
+++ b/src/lyra/runtime/constructor_.cpp
@@ -641,6 +641,8 @@ void Constructor::AddInstance(
   instance->storage.appendix_base =
       AllocateOwnedAppendixStorage(realized_appendix_size);
   instance->storage.appendix_size = realized_appendix_size;
+  instance->storage.deferred_inline_base =
+      AllocateOwnedInlineStorage(realized_inline_size);
 
   // Invariant: zero-slot bodies must not carry instance-state init.
   if (body_.slot_count == 0) {

--- a/src/lyra/runtime/engine_bundle_init.cpp
+++ b/src/lyra/runtime/engine_bundle_init.cpp
@@ -447,6 +447,10 @@ void Engine::InitModuleInstancesFromBundles(
       bundle.instance->observability.Init();
     }
 
+    // Initialize deferred-NBA pending set sized to local signal count.
+    bundle.instance->nba_pending.Init(
+        local_count, GetInstanceIndex(bundle.instance_id));
+
     // R5: populate process-to-instance mapping for subscription routing.
     for (uint32_t p = 0; p < bundle.num_module_processes; ++p) {
       uint32_t proc_idx = bundle.module_proc_base + p;

--- a/src/lyra/runtime/engine_bundle_init.cpp
+++ b/src/lyra/runtime/engine_bundle_init.cpp
@@ -385,6 +385,7 @@ void Engine::InitModuleInstancesFromBundles(
       populated[entry.local_signal_id] = 1;
 
       auto lid = entry.local_signal_id;
+      bool is_container = entry.backing_rel_off != 0;
       layout.slot_meta[lid] = InstanceSlotMeta{
           .instance_rel_off = entry.storage_byte_offset,
           .total_bytes = entry.total_bytes,
@@ -396,6 +397,9 @@ void Engine::InitModuleInstancesFromBundles(
                   .unk_off = entry.unk_lane_offset,
                   .unk_bytes = entry.unk_lane_bytes,
               },
+          .is_container = is_container,
+          .backing_rel_off = entry.backing_rel_off,
+          .backing_bytes = is_container ? entry.total_bytes : 0U,
       };
 
       auto local_name =

--- a/src/lyra/runtime/engine_scheduler_fixpoint.cpp
+++ b/src/lyra/runtime/engine_scheduler_fixpoint.cpp
@@ -92,6 +92,9 @@ void Engine::InitConnectionBatch(std::span<const ConnectionDescriptor> descs) {
       }
     }
 
+    const auto* src_ptr = ResolveSlotBytes(d.src_slot_id);
+    auto* dst_ptr = ResolveConnectionDstMut(dst);
+
     sorted.push_back(
         IndexedConn{
             .trigger_is_local = trigger_is_local,
@@ -100,7 +103,8 @@ void Engine::InitConnectionBatch(std::span<const ConnectionDescriptor> descs) {
             .trigger_global_id = trigger_global_id,
             .conn =
                 BatchedConnection{
-                    .src_slot_id = d.src_slot_id,
+                    .src_ptr = src_ptr,
+                    .dst_ptr = dst_ptr,
                     .byte_size = d.byte_size,
                     .dst = dst,
                 },
@@ -200,8 +204,8 @@ void Engine::InitConnectionBatch(std::span<const ConnectionDescriptor> descs) {
 void Engine::EvaluateAllConnections() {
   if (all_connections_.empty()) return;
   for (const auto& conn : all_connections_) {
-    const auto* src = ResolveSlotBytes(conn.src_slot_id);
-    auto* dst = ResolveConnectionDstMut(conn.dst);
+    const auto* src = conn.src_ptr;
+    auto* dst = conn.dst_ptr;
     if (std::memcmp(dst, src, conn.byte_size) != 0) {
       std::memcpy(dst, src, conn.byte_size);
       std::visit(
@@ -696,8 +700,8 @@ void Engine::FlushAndPropagateConnections() {
         for (uint32_t ci = start; ci < start + count; ++ci) {
           if (detailed) ++stats_.detailed.conn_considered;
           const auto& conn = all_connections_[ci];
-          const auto* src = ResolveSlotBytes(conn.src_slot_id);
-          auto* dst = ResolveConnectionDstMut(conn.dst);
+          const auto* src = conn.src_ptr;
+          auto* dst = conn.dst_ptr;
           if (detailed) ++stats_.detailed.conn_memcmp_executed;
           if (std::memcmp(dst, src, conn.byte_size) != 0) {
             if (detailed) ++stats_.detailed.conn_memcpy_executed;
@@ -720,8 +724,8 @@ void Engine::FlushAndPropagateConnections() {
           for (uint32_t ci = start; ci < start + count; ++ci) {
             if (detailed) ++stats_.detailed.conn_considered;
             const auto& conn = all_connections_[ci];
-            const auto* src = ResolveSlotBytes(conn.src_slot_id);
-            auto* dst = ResolveConnectionDstMut(conn.dst);
+            const auto* src = conn.src_ptr;
+            auto* dst = conn.dst_ptr;
             if (detailed) ++stats_.detailed.conn_memcmp_executed;
             if (std::memcmp(dst, src, conn.byte_size) != 0) {
               if (detailed) ++stats_.detailed.conn_memcpy_executed;

--- a/src/lyra/runtime/engine_scheduler_fixpoint.cpp
+++ b/src/lyra/runtime/engine_scheduler_fixpoint.cpp
@@ -512,15 +512,10 @@ void Engine::PromoteGlobalFrontier() {
 
 void Engine::FlushAndPropagateConnections() {
   // Check whether there is any work to do across both domains.
+  // Use the sparse delta_dirty_instances_ index for local dirty check
+  // instead of scanning all instances -- O(1) vs O(N).
   bool has_global_dirty = !update_set_.DeltaDirtySlots().empty();
-  bool has_local_dirty = false;
-  for (auto* inst : instances_) {
-    if (inst->observability.local_signal_count > 0 &&
-        !inst->observability.local_updates.DeltaDirtySignals().empty()) {
-      has_local_dirty = true;
-      break;
-    }
-  }
+  bool has_local_dirty = !delta_dirty_instances_.empty();
 
   if (detailed_stats_enabled_) {
     auto pending = update_set_.DeltaDirtySlots().size();

--- a/src/lyra/runtime/engine_scheduler_nba.cpp
+++ b/src/lyra/runtime/engine_scheduler_nba.cpp
@@ -185,44 +185,6 @@ auto ApplyNba(const NbaCanonicalPackedTwoPlane& p, void* write_ptr)
       .second_region_offset = p.second_region_offset};
 }
 
-void Engine::EvictDeferredNba(RuntimeInstance& inst, LocalSignalId lid) {
-  auto& pending = inst.nba_pending;
-  if (pending.seen[lid.value] == 0) return;
-
-  const auto& meta = inst.observability.layout->slot_meta[lid.value];
-  auto deferred_slot = inst.storage.DeferredInlineRegion().subspan(
-      meta.instance_rel_off, meta.total_bytes);
-
-  // For the simple lane (no projections), write_ptr == notify_base_ptr.
-  // Compute current-storage pointer for the NbaEntry target.
-  auto* current_ptr =
-      inst.storage.InlineRegion().subspan(meta.instance_rel_off).data();
-
-  NbaNotifySignal notify{
-      NbaNotifyLocal{.instance_id = inst.instance_id, .signal = lid}};
-  NbaEntry entry;
-  entry.write_ptr = current_ptr;
-  entry.notify_base_ptr = current_ptr;
-  entry.notify_signal = notify;
-  NbaFullOverwrite p;
-  p.byte_size = meta.total_bytes;
-  p.value.AssignCopy(deferred_slot.data(), meta.total_bytes);
-  entry.payload = std::move(p);
-  nba_queue_.push_back(std::move(entry));
-
-  pending.seen[lid.value] = 0;
-}
-
-void Engine::MarkLocalNbaGeneric(RuntimeInstance& inst, LocalSignalId lid) {
-  auto& pending = inst.nba_pending;
-  if (!pending.IsInitialized()) return;
-  if (lid.value >= pending.in_generic.size()) return;
-
-  EvictDeferredNba(inst, lid);
-  pending.MarkGeneric(lid);
-  MarkInstanceNbaPending(pending.instance_idx);
-}
-
 void Engine::CommitDeferredLocalNbas() {
   for (uint32_t instance_idx : nba_pending_instances_) {
     auto* inst = instances_[instance_idx];

--- a/src/lyra/runtime/engine_scheduler_nba.cpp
+++ b/src/lyra/runtime/engine_scheduler_nba.cpp
@@ -6,6 +6,7 @@
 #include "lyra/common/internal_error.hpp"
 #include "lyra/runtime/engine.hpp"
 #include "lyra/runtime/engine_scheduler.hpp"
+#include "lyra/runtime/instance_observability.hpp"
 #include "lyra/runtime/runtime_instance.hpp"
 #include "lyra/runtime/slot_meta.hpp"
 
@@ -184,7 +185,86 @@ auto ApplyNba(const NbaCanonicalPackedTwoPlane& p, void* write_ptr)
       .second_region_offset = p.second_region_offset};
 }
 
+void Engine::EvictDeferredNba(RuntimeInstance& inst, LocalSignalId lid) {
+  auto& pending = inst.nba_pending;
+  if (pending.seen[lid.value] == 0) return;
+
+  const auto& meta = inst.observability.layout->slot_meta[lid.value];
+  auto deferred_slot = inst.storage.DeferredInlineRegion().subspan(
+      meta.instance_rel_off, meta.total_bytes);
+
+  // For the simple lane (no projections), write_ptr == notify_base_ptr.
+  // Compute current-storage pointer for the NbaEntry target.
+  auto* current_ptr =
+      inst.storage.InlineRegion().subspan(meta.instance_rel_off).data();
+
+  NbaNotifySignal notify{
+      NbaNotifyLocal{.instance_id = inst.instance_id, .signal = lid}};
+  NbaEntry entry;
+  entry.write_ptr = current_ptr;
+  entry.notify_base_ptr = current_ptr;
+  entry.notify_signal = notify;
+  NbaFullOverwrite p;
+  p.byte_size = meta.total_bytes;
+  p.value.AssignCopy(deferred_slot.data(), meta.total_bytes);
+  entry.payload = std::move(p);
+  nba_queue_.push_back(std::move(entry));
+
+  pending.seen[lid.value] = 0;
+}
+
+void Engine::MarkLocalNbaGeneric(RuntimeInstance& inst, LocalSignalId lid) {
+  auto& pending = inst.nba_pending;
+  if (!pending.IsInitialized()) return;
+  if (lid.value >= pending.in_generic.size()) return;
+
+  EvictDeferredNba(inst, lid);
+  pending.MarkGeneric(lid);
+  MarkInstanceNbaPending(pending.instance_idx);
+}
+
+void Engine::CommitDeferredLocalNbas() {
+  for (uint32_t instance_idx : nba_pending_instances_) {
+    auto* inst = instances_[instance_idx];
+    auto& pending = inst->nba_pending;
+    if (inst->observability.layout == nullptr) {
+      pending.Clear();
+      in_nba_pending_[instance_idx] = 0;
+      continue;
+    }
+    const auto& layout = *inst->observability.layout;
+    auto current_region = inst->storage.InlineRegion();
+    auto deferred_region = inst->storage.DeferredInlineRegion();
+
+    for (LocalSignalId lid : pending.list) {
+      if (pending.seen[lid.value] == 0) continue;
+      const auto& meta = layout.slot_meta[lid.value];
+      auto current_slot =
+          current_region.subspan(meta.instance_rel_off, meta.total_bytes);
+      auto deferred_slot =
+          deferred_region.subspan(meta.instance_rel_off, meta.total_bytes);
+
+      ++stats_.core.nba_entries;
+      if (std::memcmp(
+              current_slot.data(), deferred_slot.data(), meta.total_bytes) !=
+          0) {
+        std::memcpy(
+            current_slot.data(), deferred_slot.data(), meta.total_bytes);
+        ++stats_.core.nba_changed;
+        MarkLocalSignalDirtyRange(
+            *inst, lid, 0, meta.total_bytes, instance_idx);
+      }
+    }
+
+    pending.Clear();
+    in_nba_pending_[instance_idx] = 0;
+  }
+  nba_pending_instances_.clear();
+}
+
 void Engine::ExecuteNbaRegion() {
+  CommitDeferredLocalNbas();
+
   if (nba_queue_.empty()) {
     return;
   }

--- a/src/lyra/runtime/engine_scheduler_nba.cpp
+++ b/src/lyra/runtime/engine_scheduler_nba.cpp
@@ -195,26 +195,37 @@ void Engine::CommitDeferredLocalNbas() {
       continue;
     }
     const auto& layout = *inst->observability.layout;
-    auto current_region = inst->storage.InlineRegion();
-    auto deferred_region = inst->storage.DeferredInlineRegion();
 
     for (LocalSignalId lid : pending.list) {
       if (pending.seen[lid.value] == 0) continue;
       const auto& meta = layout.slot_meta[lid.value];
-      auto current_slot =
-          current_region.subspan(meta.instance_rel_off, meta.total_bytes);
-      auto deferred_slot =
-          deferred_region.subspan(meta.instance_rel_off, meta.total_bytes);
+
+      std::span<std::byte> current_slot;
+      std::span<std::byte> deferred_slot;
+      uint32_t compare_bytes = 0;
+      if (meta.is_container) {
+        uint32_t appendix_off =
+            meta.backing_rel_off -
+            static_cast<uint32_t>(inst->storage.inline_size);
+        current_slot = inst->storage.AppendixRegion().subspan(
+            appendix_off, meta.backing_bytes);
+        deferred_slot = inst->storage.DeferredAppendixRegion().subspan(
+            appendix_off, meta.backing_bytes);
+        compare_bytes = meta.backing_bytes;
+      } else {
+        current_slot = inst->storage.InlineRegion().subspan(
+            meta.instance_rel_off, meta.total_bytes);
+        deferred_slot = inst->storage.DeferredInlineRegion().subspan(
+            meta.instance_rel_off, meta.total_bytes);
+        compare_bytes = meta.total_bytes;
+      }
 
       ++stats_.core.nba_entries;
       if (std::memcmp(
-              current_slot.data(), deferred_slot.data(), meta.total_bytes) !=
-          0) {
-        std::memcpy(
-            current_slot.data(), deferred_slot.data(), meta.total_bytes);
+              current_slot.data(), deferred_slot.data(), compare_bytes) != 0) {
+        std::memcpy(current_slot.data(), deferred_slot.data(), compare_bytes);
         ++stats_.core.nba_changed;
-        MarkLocalSignalDirtyRange(
-            *inst, lid, 0, meta.total_bytes, instance_idx);
+        MarkLocalSignalDirtyRange(*inst, lid, 0, compare_bytes, instance_idx);
       }
     }
 

--- a/src/lyra/runtime/engine_scheduler_nba.cpp
+++ b/src/lyra/runtime/engine_scheduler_nba.cpp
@@ -40,10 +40,17 @@ void ValidateSlotRootPointer(
 
 }  // namespace
 
+// ARCHITECTURAL INVARIANT:
+// Generic nba_queue_ is only for global/package and cross-instance targets.
+// Instance-owned local signals use per-instance deferred storage
+// (deferred_inline_base / deferred_appendix_base) committed by
+// CommitDeferredLocalNbas. If a same-instance owned signal reaches here,
+// it is a codegen bug in the ownership gate of LowerDeferredAssign.
 void Engine::ScheduleNba(
     void* write_ptr, const void* notify_base_ptr, const void* value_ptr,
     const void* mask_ptr, uint32_t byte_size, NbaNotifySignal notify_signal) {
   ++stats_.core.nba_entries;
+  ++stats_.core.nba_generic_queue;
 
   if (write_ptr == nullptr || notify_base_ptr == nullptr ||
       value_ptr == nullptr || byte_size == 0) {
@@ -91,6 +98,7 @@ void Engine::ScheduleNbaCanonicalPacked(
     const void* unk_ptr, uint32_t region_byte_size,
     uint32_t second_region_offset, NbaNotifySignal notify_signal) {
   ++stats_.core.nba_entries;
+  ++stats_.core.nba_generic_queue;
 
   if (write_ptr == nullptr || notify_base_ptr == nullptr ||
       value_ptr == nullptr || unk_ptr == nullptr || region_byte_size == 0) {
@@ -221,6 +229,7 @@ void Engine::CommitDeferredLocalNbas() {
       }
 
       ++stats_.core.nba_entries;
+      ++stats_.core.nba_deferred_local;
       if (std::memcmp(
               current_slot.data(), deferred_slot.data(), compare_bytes) != 0) {
         std::memcpy(current_slot.data(), deferred_slot.data(), compare_bytes);

--- a/src/lyra/runtime/engine_scheduler_nba.cpp
+++ b/src/lyra/runtime/engine_scheduler_nba.cpp
@@ -234,7 +234,7 @@ void Engine::CommitDeferredLocalNbas() {
               current_slot.data(), deferred_slot.data(), compare_bytes) != 0) {
         std::memcpy(current_slot.data(), deferred_slot.data(), compare_bytes);
         ++stats_.core.nba_changed;
-        MarkLocalSignalDirtyRange(*inst, lid, 0, compare_bytes, instance_idx);
+        MarkLocalSignalDirtyFull(*inst, lid, instance_idx);
       }
     }
 

--- a/src/lyra/runtime/engine_scheduler_observability.cpp
+++ b/src/lyra/runtime/engine_scheduler_observability.cpp
@@ -52,12 +52,14 @@ void Engine::DumpRuntimeStats(FILE* sink) const {
       " propagation_calls={} propagation_iterations={}"
       " propagation_max_iterations={}"
       " nba_entries={} nba_elided={} nba_changed={}"
+      " nba_generic_queue={} nba_deferred_local={}"
       " conn_full_slot={} conn_narrow={}"
       " comb_full_slot={} comb_narrow={}\n",
       c.total_activations, c.activations_nba_only, c.propagation_calls,
       c.propagation_iterations, c.propagation_max_iterations, c.nba_entries,
-      c.nba_elided, c.nba_changed, conn_full_slot_count_, conn_narrow_count_,
-      comb_full_slot_count_, comb_narrow_count_);
+      c.nba_elided, c.nba_changed, c.nba_generic_queue, c.nba_deferred_local,
+      conn_full_slot_count_, conn_narrow_count_, comb_full_slot_count_,
+      comb_narrow_count_);
 
   // Trigger group stats (G13 metadata).
   const auto& reg = process_trigger_registry_;

--- a/src/lyra/runtime/engine_signal_coord.cpp
+++ b/src/lyra/runtime/engine_signal_coord.cpp
@@ -70,6 +70,7 @@ void Engine::MarkDirtyRange(
 void Engine::ScheduleNba(
     ObjectSignalRef notify_signal, void* write_ptr, const void* notify_base_ptr,
     const void* value_ptr, const void* mask_ptr, uint32_t byte_size) {
+  MarkLocalNbaGeneric(*notify_signal.instance, notify_signal.local);
   NbaNotifySignal notify{NbaNotifyLocal{
       .instance_id = notify_signal.instance->instance_id,
       .signal = notify_signal.local}};
@@ -81,6 +82,7 @@ void Engine::ScheduleNbaCanonicalPacked(
     ObjectSignalRef notify_signal, void* write_ptr, const void* notify_base_ptr,
     const void* value_ptr, const void* unk_ptr, uint32_t region_byte_size,
     uint32_t second_region_offset) {
+  MarkLocalNbaGeneric(*notify_signal.instance, notify_signal.local);
   NbaNotifySignal notify{NbaNotifyLocal{
       .instance_id = notify_signal.instance->instance_id,
       .signal = notify_signal.local}};
@@ -189,6 +191,11 @@ void Engine::SetInstances(std::span<const RuntimeInstance* const> instances) {
   delta_dirty_instances_.reserve(n);
   timeslot_dirty_instances_.clear();
   timeslot_dirty_instances_.reserve(n);
+
+  // Initialize deferred-NBA pending sparse index.
+  in_nba_pending_.assign(n, 0);
+  nba_pending_instances_.clear();
+  nba_pending_instances_.reserve(n);
 }
 
 void InstanceIdTraceResolver::Build(

--- a/src/lyra/runtime/engine_signal_coord.cpp
+++ b/src/lyra/runtime/engine_signal_coord.cpp
@@ -67,7 +67,7 @@ void Engine::MarkDirtyRange(
       *signal.instance, signal.local, byte_off, byte_size);
 }
 
-void Engine::ScheduleNba(
+void Engine::ScheduleNbaCrossInstanceLocal(
     ObjectSignalRef notify_signal, void* write_ptr, const void* notify_base_ptr,
     const void* value_ptr, const void* mask_ptr, uint32_t byte_size) {
   NbaNotifySignal notify{NbaNotifyLocal{
@@ -77,7 +77,7 @@ void Engine::ScheduleNba(
       write_ptr, notify_base_ptr, value_ptr, mask_ptr, byte_size, notify);
 }
 
-void Engine::ScheduleNbaCanonicalPacked(
+void Engine::ScheduleNbaCanonicalPackedCrossInstanceLocal(
     ObjectSignalRef notify_signal, void* write_ptr, const void* notify_base_ptr,
     const void* value_ptr, const void* unk_ptr, uint32_t region_byte_size,
     uint32_t second_region_offset) {
@@ -107,7 +107,7 @@ void Engine::MarkDirtyRange(
   MarkDirtyRange(signal.value, byte_off, byte_size);
 }
 
-void Engine::ScheduleNba(
+void Engine::ScheduleNbaGlobal(
     GlobalSignalId notify_signal, void* write_ptr, const void* notify_base_ptr,
     const void* value_ptr, const void* mask_ptr, uint32_t byte_size) {
   NbaNotifySignal notify{NbaNotifyGlobal{notify_signal}};
@@ -115,7 +115,7 @@ void Engine::ScheduleNba(
       write_ptr, notify_base_ptr, value_ptr, mask_ptr, byte_size, notify);
 }
 
-void Engine::ScheduleNbaCanonicalPacked(
+void Engine::ScheduleNbaCanonicalPackedGlobal(
     GlobalSignalId notify_signal, void* write_ptr, const void* notify_base_ptr,
     const void* value_ptr, const void* unk_ptr, uint32_t region_byte_size,
     uint32_t second_region_offset) {

--- a/src/lyra/runtime/engine_signal_coord.cpp
+++ b/src/lyra/runtime/engine_signal_coord.cpp
@@ -53,6 +53,16 @@ void Engine::MarkLocalSignalDirtyRange(
   MarkInstanceDeltaDirty(instance_idx);
 }
 
+void Engine::MarkLocalSignalDirtyFull(
+    RuntimeInstance& inst, LocalSignalId lid, uint32_t instance_idx) {
+  auto& obs = inst.observability;
+  if (obs.local_has_observers[lid.value] == 0 && !trace_manager_.IsEnabled()) {
+    return;
+  }
+  obs.local_updates.MarkSlotDirtyFull(lid);
+  MarkInstanceDeltaDirty(instance_idx);
+}
+
 // --- Instance-owned local paths (source of truth: per-instance containers) ---
 
 void Engine::MarkDirty(ObjectSignalRef signal) {

--- a/src/lyra/runtime/engine_signal_coord.cpp
+++ b/src/lyra/runtime/engine_signal_coord.cpp
@@ -70,7 +70,6 @@ void Engine::MarkDirtyRange(
 void Engine::ScheduleNba(
     ObjectSignalRef notify_signal, void* write_ptr, const void* notify_base_ptr,
     const void* value_ptr, const void* mask_ptr, uint32_t byte_size) {
-  MarkLocalNbaGeneric(*notify_signal.instance, notify_signal.local);
   NbaNotifySignal notify{NbaNotifyLocal{
       .instance_id = notify_signal.instance->instance_id,
       .signal = notify_signal.local}};
@@ -82,7 +81,6 @@ void Engine::ScheduleNbaCanonicalPacked(
     ObjectSignalRef notify_signal, void* write_ptr, const void* notify_base_ptr,
     const void* value_ptr, const void* unk_ptr, uint32_t region_byte_size,
     uint32_t second_region_offset) {
-  MarkLocalNbaGeneric(*notify_signal.instance, notify_signal.local);
   NbaNotifySignal notify{NbaNotifyLocal{
       .instance_id = notify_signal.instance->instance_id,
       .signal = notify_signal.local}};

--- a/src/lyra/runtime/nba_stats_hook.cpp
+++ b/src/lyra/runtime/nba_stats_hook.cpp
@@ -1,0 +1,22 @@
+#include "lyra/runtime/nba_stats_hook.hpp"
+
+namespace lyra::runtime {
+
+namespace {
+
+auto CallbackStorage() -> NbaStatsCallback& {
+  thread_local NbaStatsCallback instance;
+  return instance;
+}
+
+}  // namespace
+
+void SetNbaStatsCallback(NbaStatsCallback callback) {
+  CallbackStorage() = std::move(callback);
+}
+
+auto GetNbaStatsCallback() -> NbaStatsCallback {
+  return CallbackStorage();
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/runtime/runtime_instance.cpp
+++ b/src/lyra/runtime/runtime_instance.cpp
@@ -8,28 +8,28 @@
 
 namespace lyra::runtime {
 
-auto AllocateOwnedInlineStorage(uint64_t size) -> std::byte* {
+// RuntimeInstanceStorage owns raw heap byte regions whose layout is a binary
+// contract with codegen (accessed via GEP). Raw new[]/delete[] is intentional;
+// unique_ptr would change the struct layout.
+// NOLINTBEGIN(cppcoreguidelines-owning-memory)
+
+auto AllocateOwnedStorage(uint64_t size, const char* caller) -> std::byte* {
   if (size == 0) return nullptr;
   auto* mem = new (std::nothrow) std::byte[size];
   if (mem == nullptr) {
     throw common::InternalError(
-        "AllocateOwnedInlineStorage",
-        std::format("allocation of {} bytes failed", size));
+        caller, std::format("allocation of {} bytes failed", size));
   }
   std::memset(mem, 0, size);
   return mem;
 }
 
+auto AllocateOwnedInlineStorage(uint64_t size) -> std::byte* {
+  return AllocateOwnedStorage(size, "AllocateOwnedInlineStorage");
+}
+
 auto AllocateOwnedAppendixStorage(uint64_t size) -> std::byte* {
-  if (size == 0) return nullptr;
-  auto* mem = new (std::nothrow) std::byte[size];
-  if (mem == nullptr) {
-    throw common::InternalError(
-        "AllocateOwnedAppendixStorage",
-        std::format("allocation of {} bytes failed", size));
-  }
-  std::memset(mem, 0, size);
-  return mem;
+  return AllocateOwnedStorage(size, "AllocateOwnedAppendixStorage");
 }
 
 void FreeRuntimeInstanceStorage(RuntimeInstanceStorage& storage) {
@@ -37,6 +37,10 @@ void FreeRuntimeInstanceStorage(RuntimeInstanceStorage& storage) {
   storage.inline_base = nullptr;
   delete[] storage.appendix_base;
   storage.appendix_base = nullptr;
+  delete[] storage.deferred_inline_base;
+  storage.deferred_inline_base = nullptr;
 }
+
+// NOLINTEND(cppcoreguidelines-owning-memory)
 
 }  // namespace lyra::runtime

--- a/src/lyra/runtime/runtime_instance.cpp
+++ b/src/lyra/runtime/runtime_instance.cpp
@@ -39,6 +39,8 @@ void FreeRuntimeInstanceStorage(RuntimeInstanceStorage& storage) {
   storage.appendix_base = nullptr;
   delete[] storage.deferred_inline_base;
   storage.deferred_inline_base = nullptr;
+  delete[] storage.deferred_appendix_base;
+  storage.deferred_appendix_base = nullptr;
 }
 
 // NOLINTEND(cppcoreguidelines-owning-memory)

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -1145,21 +1145,48 @@ extern "C" void LyraStoreStringGlobal(
   StoreStringTyped(eng, GlobalSignalId{id}, slot, str);
 }
 
+// Resolve a body-relative byte offset to a subspan in the deferred region.
+// Offsets < inline_size resolve to deferred_inline_base.
+// Offsets >= inline_size resolve to deferred_appendix_base.
+inline auto ResolveDeferredSubspan(
+    lyra::runtime::RuntimeInstanceStorage& storage, uint32_t body_offset,
+    uint32_t size) -> std::span<std::byte> {
+  auto inline_size = static_cast<uint32_t>(storage.inline_size);
+  if (body_offset < inline_size) {
+    return storage.DeferredInlineRegion().subspan(body_offset, size);
+  }
+  return storage.DeferredAppendixRegion().subspan(
+      body_offset - inline_size, size);
+}
+
+// Resolve a body-relative byte offset to a subspan in the current region.
+inline auto ResolveCurrentSubspan(
+    lyra::runtime::RuntimeInstanceStorage& storage, uint32_t body_offset,
+    uint32_t size) -> std::span<std::byte> {
+  auto inline_size = static_cast<uint32_t>(storage.inline_size);
+  if (body_offset < inline_size) {
+    return storage.InlineRegion().subspan(body_offset, size);
+  }
+  return storage.AppendixRegion().subspan(body_offset - inline_size, size);
+}
+
 // Copy-on-first-touch: ensure deferred storage for signal `id` contains a
 // valid full-slot snapshot. Called before any partial write to a signal that
 // hasn't been touched yet this delta. After this, all bytes in the deferred
 // slot match the current slot, so subsequent partial writes accumulate
 // correctly and the commit can compare the full slot.
+// Works for both inline and container-backed slots.
 inline void EnsureDeferredSlotInitialized(
     RuntimeInstance* instance, lyra::runtime::NbaPendingSet& pending,
     uint32_t id) {
   if (pending.slot_initialized[id] != 0) return;
   const auto& meta = instance->observability.layout->slot_meta[id];
-  auto current = instance->storage.InlineRegion().subspan(
-      meta.instance_rel_off, meta.total_bytes);
-  auto deferred = instance->storage.DeferredInlineRegion().subspan(
-      meta.instance_rel_off, meta.total_bytes);
-  std::memcpy(deferred.data(), current.data(), meta.total_bytes);
+  uint32_t off =
+      meta.is_container ? meta.backing_rel_off : meta.instance_rel_off;
+  uint32_t bytes = meta.is_container ? meta.backing_bytes : meta.total_bytes;
+  auto current = ResolveCurrentSubspan(instance->storage, off, bytes);
+  auto deferred = ResolveDeferredSubspan(instance->storage, off, bytes);
+  std::memcpy(deferred.data(), current.data(), bytes);
   pending.slot_initialized[id] = 1;
 }
 
@@ -1179,7 +1206,7 @@ extern "C" void LyraDeferredWriteLocal(
   }
 
   auto deferred_slot =
-      instance->storage.DeferredInlineRegion().subspan(body_offset, bsz);
+      ResolveDeferredSubspan(instance->storage, body_offset, bsz);
   std::memcpy(deferred_slot.data(), vp, bsz);
   pending.MarkPending(LocalSignalId{id});
   AsEngine(eng)->MarkInstanceNbaPending(pending.instance_idx);
@@ -1198,7 +1225,7 @@ extern "C" void LyraDeferredMaskedWriteLocal(
   EnsureDeferredSlotInitialized(instance, pending, id);
 
   auto deferred_slot =
-      instance->storage.DeferredInlineRegion().subspan(body_offset, bsz);
+      ResolveDeferredSubspan(instance->storage, body_offset, bsz);
   auto val_span = std::span(static_cast<const std::byte*>(vp), bsz);
   auto mask_span = std::span(static_cast<const std::byte*>(mp), bsz);
   for (uint32_t i = 0; i < bsz; ++i) {
@@ -1222,12 +1249,12 @@ extern "C" void LyraDeferredCanonicalPackedWriteLocal(
 
   EnsureDeferredSlotInitialized(instance, pending, id);
 
-  auto deferred = instance->storage.DeferredInlineRegion();
-  std::memcpy(
-      deferred.subspan(body_offset, region_bsz).data(), val, region_bsz);
-  std::memcpy(
-      deferred.subspan(body_offset + second_region_offset, region_bsz).data(),
-      unk, region_bsz);
+  auto deferred_val =
+      ResolveDeferredSubspan(instance->storage, body_offset, region_bsz);
+  std::memcpy(deferred_val.data(), val, region_bsz);
+  auto deferred_unk = ResolveDeferredSubspan(
+      instance->storage, body_offset + second_region_offset, region_bsz);
+  std::memcpy(deferred_unk.data(), unk, region_bsz);
   pending.MarkPending(LocalSignalId{id});
   AsEngine(eng)->MarkInstanceNbaPending(pending.instance_idx);
 }

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -1145,25 +1145,89 @@ extern "C" void LyraStoreStringGlobal(
   StoreStringTyped(eng, GlobalSignalId{id}, slot, str);
 }
 
+// Copy-on-first-touch: ensure deferred storage for signal `id` contains a
+// valid full-slot snapshot. Called before any partial write to a signal that
+// hasn't been touched yet this delta. After this, all bytes in the deferred
+// slot match the current slot, so subsequent partial writes accumulate
+// correctly and the commit can compare the full slot.
+inline void EnsureDeferredSlotInitialized(
+    RuntimeInstance* instance, lyra::runtime::NbaPendingSet& pending,
+    uint32_t id) {
+  if (pending.slot_initialized[id] != 0) return;
+  const auto& meta = instance->observability.layout->slot_meta[id];
+  auto current = instance->storage.InlineRegion().subspan(
+      meta.instance_rel_off, meta.total_bytes);
+  auto deferred = instance->storage.DeferredInlineRegion().subspan(
+      meta.instance_rel_off, meta.total_bytes);
+  std::memcpy(deferred.data(), current.data(), meta.total_bytes);
+  pending.slot_initialized[id] = 1;
+}
+
+// Instance-owned deferred byte-range write for local NBA.
+// Handles both whole-slot and sub-slot (field, array element, byte-addressable
+// packed subview) writes. Identity-based: no current-storage pointers.
 extern "C" void LyraDeferredWriteLocal(
     void* eng, void* inst, const void* vp, uint32_t bsz, uint32_t id,
-    uint32_t body_offset) {
+    uint32_t body_offset, uint32_t is_partial) {
   auto* instance = static_cast<RuntimeInstance*>(inst);
   auto& pending = instance->nba_pending;
 
-  // Cross-lane conflict: if this signal already has generic-queue writes
-  // this delta, fall back to the generic queue to preserve write ordering.
-  if (pending.in_generic[id] != 0) {
-    auto* wp = instance->storage.InlineRegion().subspan(body_offset).data();
-    AsEngine(eng)->ScheduleNba(
-        ObjectSignalRef{.instance = instance, .local = LocalSignalId{id}}, wp,
-        wp, vp, nullptr, bsz);
-    return;
+  if (is_partial != 0) {
+    EnsureDeferredSlotInitialized(instance, pending, id);
+  } else {
+    pending.slot_initialized[id] = 1;
   }
 
   auto deferred_slot =
       instance->storage.DeferredInlineRegion().subspan(body_offset, bsz);
   std::memcpy(deferred_slot.data(), vp, bsz);
+  pending.MarkPending(LocalSignalId{id});
+  AsEngine(eng)->MarkInstanceNbaPending(pending.instance_idx);
+}
+
+// Instance-owned deferred masked-merge write for local NBA.
+// For bit-addressable packed subview writes where the store uses a mask.
+// Always partial: copy-on-first-touch, then apply mask merge in deferred
+// storage.
+extern "C" void LyraDeferredMaskedWriteLocal(
+    void* eng, void* inst, const void* vp, const void* mp, uint32_t bsz,
+    uint32_t id, uint32_t body_offset) {
+  auto* instance = static_cast<RuntimeInstance*>(inst);
+  auto& pending = instance->nba_pending;
+
+  EnsureDeferredSlotInitialized(instance, pending, id);
+
+  auto deferred_slot =
+      instance->storage.DeferredInlineRegion().subspan(body_offset, bsz);
+  auto val_span = std::span(static_cast<const std::byte*>(vp), bsz);
+  auto mask_span = std::span(static_cast<const std::byte*>(mp), bsz);
+  for (uint32_t i = 0; i < bsz; ++i) {
+    deferred_slot[i] =
+        (deferred_slot[i] & ~mask_span[i]) | (val_span[i] & mask_span[i]);
+  }
+  pending.MarkPending(LocalSignalId{id});
+  AsEngine(eng)->MarkInstanceNbaPending(pending.instance_idx);
+}
+
+// Instance-owned deferred canonical packed two-plane write for local NBA.
+// For byte-addressable 4-state packed subview writes with val+unk planes.
+// Always partial: copy-on-first-touch, then write both planes in deferred
+// storage.
+extern "C" void LyraDeferredCanonicalPackedWriteLocal(
+    void* eng, void* inst, const void* val, const void* unk,
+    uint32_t region_bsz, uint32_t id, uint32_t body_offset,
+    uint32_t second_region_offset) {
+  auto* instance = static_cast<RuntimeInstance*>(inst);
+  auto& pending = instance->nba_pending;
+
+  EnsureDeferredSlotInitialized(instance, pending, id);
+
+  auto deferred = instance->storage.DeferredInlineRegion();
+  std::memcpy(
+      deferred.subspan(body_offset, region_bsz).data(), val, region_bsz);
+  std::memcpy(
+      deferred.subspan(body_offset + second_region_offset, region_bsz).data(),
+      unk, region_bsz);
   pending.MarkPending(LocalSignalId{id});
   AsEngine(eng)->MarkInstanceNbaPending(pending.instance_idx);
 }

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -1145,6 +1145,29 @@ extern "C" void LyraStoreStringGlobal(
   StoreStringTyped(eng, GlobalSignalId{id}, slot, str);
 }
 
+extern "C" void LyraDeferredWriteLocal(
+    void* eng, void* inst, const void* vp, uint32_t bsz, uint32_t id,
+    uint32_t body_offset) {
+  auto* instance = static_cast<RuntimeInstance*>(inst);
+  auto& pending = instance->nba_pending;
+
+  // Cross-lane conflict: if this signal already has generic-queue writes
+  // this delta, fall back to the generic queue to preserve write ordering.
+  if (pending.in_generic[id] != 0) {
+    auto* wp = instance->storage.InlineRegion().subspan(body_offset).data();
+    AsEngine(eng)->ScheduleNba(
+        ObjectSignalRef{.instance = instance, .local = LocalSignalId{id}}, wp,
+        wp, vp, nullptr, bsz);
+    return;
+  }
+
+  auto deferred_slot =
+      instance->storage.DeferredInlineRegion().subspan(body_offset, bsz);
+  std::memcpy(deferred_slot.data(), vp, bsz);
+  pending.MarkPending(LocalSignalId{id});
+  AsEngine(eng)->MarkInstanceNbaPending(pending.instance_idx);
+}
+
 extern "C" void LyraScheduleNbaLocal(
     void* eng, void* inst, void* wp, const void* nb, const void* vp,
     const void* mp, uint32_t bsz, uint32_t id) {

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -26,6 +26,7 @@
 #include "lyra/runtime/engine_types.hpp"
 #include "lyra/runtime/feature_flags.hpp"
 #include "lyra/runtime/iteration_limit.hpp"
+#include "lyra/runtime/nba_stats_hook.hpp"
 #include "lyra/runtime/output_sink.hpp"
 #include "lyra/runtime/process_frame.hpp"
 #include "lyra/runtime/process_meta.hpp"
@@ -780,6 +781,19 @@ extern "C" void LyraRunSimulation(
     }
   }
 
+  // Invoke NBA stats callback if registered (test framework hook).
+  {
+    auto callback = lyra::runtime::GetNbaStatsCallback();
+    if (callback) {
+      const auto& stats = engine.GetStats().core;
+      callback(
+          lyra::runtime::NbaRoutingStats{
+              .generic_queue = stats.nba_generic_queue,
+              .deferred_local = stats.nba_deferred_local,
+          });
+    }
+  }
+
   // Release string-typed slot handles before engine destruction.
   // The engine owns the slot meta registry needed for address resolution.
   engine.ReleaseStringSlots();
@@ -1259,27 +1273,30 @@ extern "C" void LyraDeferredCanonicalPackedWriteLocal(
   AsEngine(eng)->MarkInstanceNbaPending(pending.instance_idx);
 }
 
+// Generic NBA queue entry points for cross-instance local and global targets.
+// Instance-owned local targets use LyraDeferredWriteLocal and friends above.
 extern "C" void LyraScheduleNbaLocal(
     void* eng, void* inst, void* wp, const void* nb, const void* vp,
     const void* mp, uint32_t bsz, uint32_t id) {
-  AsEngine(eng)->ScheduleNba(MakeLocalRef(inst, id), wp, nb, vp, mp, bsz);
+  AsEngine(eng)->ScheduleNbaCrossInstanceLocal(
+      MakeLocalRef(inst, id), wp, nb, vp, mp, bsz);
 }
 extern "C" void LyraScheduleNbaGlobal(
     void* eng, void* wp, const void* nb, const void* vp, const void* mp,
     uint32_t bsz, uint32_t id) {
-  AsEngine(eng)->ScheduleNba(GlobalSignalId{id}, wp, nb, vp, mp, bsz);
+  AsEngine(eng)->ScheduleNbaGlobal(GlobalSignalId{id}, wp, nb, vp, mp, bsz);
 }
 
 extern "C" void LyraScheduleNbaCanonicalPackedLocal(
     void* eng, void* inst, void* wp, const void* nb, const void* vp,
     const void* up, uint32_t rsz, uint32_t sro, uint32_t id) {
-  AsEngine(eng)->ScheduleNbaCanonicalPacked(
+  AsEngine(eng)->ScheduleNbaCanonicalPackedCrossInstanceLocal(
       MakeLocalRef(inst, id), wp, nb, vp, up, rsz, sro);
 }
 extern "C" void LyraScheduleNbaCanonicalPackedGlobal(
     void* eng, void* wp, const void* nb, const void* vp, const void* up,
     uint32_t rsz, uint32_t sro, uint32_t id) {
-  AsEngine(eng)->ScheduleNbaCanonicalPacked(
+  AsEngine(eng)->ScheduleNbaCanonicalPackedGlobal(
       GlobalSignalId{id}, wp, nb, vp, up, rsz, sro);
 }
 

--- a/tests/framework/case_runner.cpp
+++ b/tests/framework/case_runner.cpp
@@ -71,6 +71,15 @@ void WriteCaseResult(int fd, const CaseExecutionResult& result) {
   for (auto hit : result.artifacts.cover_hits) out << hit;
   out << YAML::EndSeq;
 
+  out << YAML::Key << "nba_stats" << YAML::Value << YAML::BeginMap;
+  out << YAML::Key << "captured" << YAML::Value
+      << result.artifacts.nba_stats.captured;
+  out << YAML::Key << "generic_queue" << YAML::Value
+      << result.artifacts.nba_stats.generic_queue;
+  out << YAML::Key << "deferred_local" << YAML::Value
+      << result.artifacts.nba_stats.deferred_local;
+  out << YAML::EndMap;
+
   out << YAML::Key << "produced_files" << YAML::Value << YAML::BeginMap;
   for (const auto& [name, content] : result.artifacts.produced_files) {
     out << YAML::Key << name << YAML::Value << content;
@@ -138,6 +147,15 @@ auto ParseCaseResult(std::string_view yaml) -> CaseExecutionResult {
   if (node["cover_hits"]) {
     for (const auto& hit : node["cover_hits"])
       result.artifacts.cover_hits.push_back(hit.as<uint64_t>());
+  }
+
+  if (node["nba_stats"]) {
+    const auto& ns = node["nba_stats"];
+    result.artifacts.nba_stats.captured = ns["captured"].as<bool>(false);
+    result.artifacts.nba_stats.generic_queue =
+        ns["generic_queue"].as<uint64_t>(0);
+    result.artifacts.nba_stats.deferred_local =
+        ns["deferred_local"].as<uint64_t>(0);
   }
 
   if (node["produced_files"]) {

--- a/tests/framework/expectation_eval.cpp
+++ b/tests/framework/expectation_eval.cpp
@@ -236,6 +236,35 @@ auto EvaluateExpectations(
     }
   }
 
+  if (test_case.expected_nba_stats.has_value()) {
+    const auto& expected = *test_case.expected_nba_stats;
+    const auto& actual = result.artifacts.nba_stats;
+    if (!actual.captured) {
+      return {
+          .passed = false,
+          .failure_message = "nba_stats expected but not captured from engine",
+      };
+    }
+    if (expected.generic_queue.has_value() &&
+        actual.generic_queue != *expected.generic_queue) {
+      return {
+          .passed = false,
+          .failure_message = std::format(
+              "nba_stats.generic_queue mismatch: expected {}, got {}",
+              *expected.generic_queue, actual.generic_queue),
+      };
+    }
+    if (expected.deferred_local.has_value() &&
+        actual.deferred_local != *expected.deferred_local) {
+      return {
+          .passed = false,
+          .failure_message = std::format(
+              "nba_stats.deferred_local mismatch: expected {}, got {}",
+              *expected.deferred_local, actual.deferred_local),
+      };
+    }
+  }
+
   if (!test_case.expected_files.empty()) {
     for (const auto& [filename, expected] : test_case.expected_files) {
       auto it = result.artifacts.produced_files.find(filename);

--- a/tests/framework/jit_backend.cpp
+++ b/tests/framework/jit_backend.cpp
@@ -12,6 +12,7 @@
 #include "lyra/common/opt_level.hpp"
 #include "lyra/llvm_backend/execution.hpp"
 #include "lyra/runtime/cover_hook.hpp"
+#include "lyra/runtime/nba_stats_hook.hpp"
 #include "lyra/runtime/output_sink.hpp"
 #include "tests/framework/dpi_test_support.hpp"
 #include "tests/framework/llvm_common.hpp"
@@ -61,6 +62,7 @@ auto RunJitBackend(
   // Compile using in-process ORC JIT with host process symbols.
   // DPI object files are added directly to the JIT symbol space.
   std::string captured_output;
+  NbaRoutingStatsResult nba_stats;
   auto t_backend = Clock::now();
   lowering::mir_to_llvm::JitCompileOptions jit_opts{
       .opt_level = OptLevel::kO0,
@@ -96,6 +98,12 @@ auto RunJitBackend(
         [&cover_hits](std::vector<uint64_t> hits) {
           cover_hits = std::move(hits);
         });
+    runtime::NbaStatsCallbackScope nba_scope(
+        [&nba_stats](runtime::NbaRoutingStats stats) {
+          nba_stats.generic_queue = stats.generic_queue;
+          nba_stats.deferred_local = stats.deferred_local;
+          nba_stats.captured = true;
+        });
     exit_code = session->Run();
   }
   result.artifacts.timings.execute =
@@ -117,6 +125,7 @@ auto RunJitBackend(
   result.artifacts.variables = std::move(parsed.variables);
   result.artifacts.final_time = parsed.final_time;
   result.artifacts.cover_hits = std::move(cover_hits);
+  result.artifacts.nba_stats = nba_stats;
   result.artifacts.timings.total =
       std::chrono::duration<double>(Clock::now() - t_total).count();
 

--- a/tests/framework/test_case.hpp
+++ b/tests/framework/test_case.hpp
@@ -62,6 +62,12 @@ struct TestCase {
   bool dump_dpi_header = false;          // Dump generated DPI-C header
   bool dump_llvm_ir = false;             // Dump LLVM IR module
   std::optional<std::vector<uint64_t>> expected_cover_hits;
+  // NBA routing boundary assertions: {generic_queue: N, deferred_local: N}
+  struct NbaStatsExpectation {
+    std::optional<uint64_t> generic_queue;
+    std::optional<uint64_t> deferred_local;
+  };
+  std::optional<NbaStatsExpectation> expected_nba_stats;
   bool disable_assertions = false;
   bool single_unit = false;
   std::vector<std::string> defines;

--- a/tests/framework/test_case_loader.cpp
+++ b/tests/framework/test_case_loader.cpp
@@ -450,7 +450,7 @@ auto LoadTestCasesFromYaml(const std::string& path) -> std::vector<TestCase> {
       ValidateKeys(
           expect,
           {"variables", "time", "stdout", "compiler_output", "files", "error",
-           "mutations", "runtime_fatal", "cover_hits"},
+           "mutations", "runtime_fatal", "cover_hits", "nba_stats"},
           expect_context, path);
 
       // expect.variables: {var: value, ...}
@@ -547,6 +547,21 @@ auto LoadTestCasesFromYaml(const std::string& path) -> std::vector<TestCase> {
           hits.push_back(item.as<uint64_t>());
         }
         test_case.expected_cover_hits = std::move(hits);
+      }
+
+      if (expect["nba_stats"]) {
+        const auto& ns = expect["nba_stats"];
+        ValidateKeys(
+            ns, {"generic_queue", "deferred_local"},
+            std::format("expect.nba_stats in {}", case_context), path);
+        TestCase::NbaStatsExpectation nse;
+        if (ns["generic_queue"]) {
+          nse.generic_queue = ns["generic_queue"].as<uint64_t>();
+        }
+        if (ns["deferred_local"]) {
+          nse.deferred_local = ns["deferred_local"].as<uint64_t>();
+        }
+        test_case.expected_nba_stats = nse;
       }
     }
 

--- a/tests/framework/test_result.hpp
+++ b/tests/framework/test_result.hpp
@@ -43,6 +43,13 @@ struct ExecutionResult {
 };
 
 // Simulation payload (only meaningful when outcome == kSuccess).
+// NBA routing stats captured from engine after simulation.
+struct NbaRoutingStatsResult {
+  uint64_t generic_queue = 0;
+  uint64_t deferred_local = 0;
+  bool captured = false;
+};
+
 struct SimulationArtifacts {
   std::string captured_output;
   std::string compiler_output;
@@ -50,6 +57,7 @@ struct SimulationArtifacts {
   uint64_t final_time = 0;
   std::vector<common::MutationEvent> mutation_events;
   std::vector<uint64_t> cover_hits;
+  NbaRoutingStatsResult nba_stats;
   // File contents produced by the simulation (e.g., $fwrite output).
   // Captured before child exit so they survive the fork boundary.
   std::map<std::string, std::string> produced_files;

--- a/tests/sv_features/scheduling/nba_routing/default.yaml
+++ b/tests/sv_features/scheduling/nba_routing/default.yaml
@@ -1,0 +1,213 @@
+feature: nba_routing
+description: >
+  NBA routing boundary regression tests. Verifies that instance-owned
+  local signals use deferred storage (nba_stats.deferred_local) and
+  global/package/ExternalRefId signals use the generic queue
+  (nba_stats.generic_queue). These tests lock in the architectural
+  invariant: local owned state never touches the generic queue.
+
+cases:
+  - name: owned_inline_whole_slot
+    description: >
+      Module-level scalar with whole-slot NBA routes through
+      deferred local storage, not the generic queue.
+    sv: |
+      module Test;
+        logic [31:0] x;
+        int result;
+        initial begin
+          x = 32'hAAAA_BBBB;
+          x <= 32'h1234_5678;
+          #0;
+          result = x;
+        end
+      endmodule
+    expect:
+      variables:
+        result: "0x12345678"
+      nba_stats:
+        deferred_local: 1
+        generic_queue: 0
+
+  - name: owned_inline_field_projection
+    description: >
+      NBA to a struct field (static field projection) routes through
+      deferred local storage.
+    sv: |
+      module Test;
+        typedef struct packed {
+          logic [15:0] hi;
+          logic [15:0] lo;
+        } pair_t;
+        pair_t p;
+        int result;
+        initial begin
+          p = '0;
+          p.lo <= 16'hBEEF;
+          #0;
+          result = p;
+        end
+      endmodule
+    expect:
+      variables:
+        result: "0x0000BEEF"
+      nba_stats:
+        deferred_local: 1
+        generic_queue: 0
+
+  - name: owned_inline_union_member
+    description: >
+      NBA to a packed union member routes through deferred local storage.
+    sv: |
+      module Test;
+        typedef union packed {
+          logic [31:0] bits;
+          logic [31:0] word;
+        } overlay_t;
+        overlay_t u;
+        int result;
+        initial begin
+          u.bits = 32'hFFFF_FFFF;
+          u.word <= 32'hDEAD_BEEF;
+          #0;
+          result = u.bits;
+        end
+      endmodule
+    expect:
+      variables:
+        result: "0xDEADBEEF"
+      nba_stats:
+        deferred_local: 1
+        generic_queue: 0
+
+  - name: owned_inline_index_projection
+    description: >
+      NBA to an array element (dynamic index projection with OOB guard)
+      routes through deferred local storage.
+    sv: |
+      module Test;
+        int arr [4];
+        int result;
+        initial begin
+          arr[0] = 0;
+          arr[1] = 0;
+          arr[2] = 0;
+          arr[3] = 0;
+          arr[2] <= 999;
+          #0;
+          result = arr[2];
+        end
+      endmodule
+    expect:
+      variables:
+        result: 999
+      nba_stats:
+        deferred_local: 1
+        generic_queue: 0
+
+  - name: owned_inline_packed_bit_range
+    description: >
+      NBA to a packed bit-range (masked merge path) routes through
+      deferred local storage, not the generic queue.
+    sv: |
+      module Test;
+        logic [31:0] x;
+        int result;
+        initial begin
+          x = 32'hFF00_FF00;
+          x[15:8] <= 8'hAB;
+          #0;
+          result = x;
+        end
+      endmodule
+    expect:
+      variables:
+        result: "0xFF00AB00"
+      nba_stats:
+        deferred_local: 1
+        generic_queue: 0
+
+  - name: owned_container_local
+    description: >
+      NBA to a module-level array in a parameterized module uses
+      owned-container storage shape. The deferred write routes through
+      deferred appendix storage, not the generic queue.
+    sv: |
+      module inner #(parameter int N = 4);
+        int arr [N];
+        int result;
+        initial begin
+          for (int i = 0; i < N; i++) arr[i] = 0;
+          arr[1] <= 42;
+          #0;
+          result = arr[1];
+        end
+      endmodule
+
+      module Test;
+        int result;
+        inner #(.N(4)) u();
+        assign result = u.result;
+      endmodule
+    expect:
+      variables:
+        result: 42
+      nba_stats:
+        deferred_local: 1
+        generic_queue: 0
+
+  - name: package_global_nba
+    description: >
+      NBA to a package-scoped variable routes through the generic
+      queue (global signal), not deferred local storage.
+    sv: |
+      package pkg;
+        int g;
+      endpackage
+
+      module Test;
+        int result;
+        initial begin
+          pkg::g = 0;
+          pkg::g <= 77;
+          #0;
+          result = pkg::g;
+        end
+      endmodule
+    expect:
+      variables:
+        result: 77
+      nba_stats:
+        deferred_local: 0
+        generic_queue: 1
+
+  - name: mixed_local_and_global
+    description: >
+      Mixed NBA writes: one to a local owned signal (deferred storage)
+      and one to a package global (generic queue). Both counters should
+      increment, confirming the routing boundary splits correctly.
+    sv: |
+      package pkg;
+        int g;
+      endpackage
+
+      module Test;
+        logic [31:0] x;
+        int r_local, r_global;
+        initial begin
+          x = '0;
+          pkg::g = 0;
+          x <= 32'hAAAA;
+          pkg::g <= 55;
+          #0;
+          r_local = x;
+          r_global = pkg::g;
+        end
+      endmodule
+    expect:
+      variables:
+        r_local: "0x0000AAAA"
+        r_global: 55
+      nba_stats:
+        deferred_local: 1
+        generic_queue: 1


### PR DESCRIPTION
## Summary

Migrates local module-owned NBA (non-blocking assignment) writes from the generic runtime queue to per-instance deferred storage, then adds compile-time transport-node elimination to reduce runtime propagation graph volume. Together these changes reduce clock-pipeline benchmark Ir by ~18% while establishing a clean architectural boundary between instance-owned and non-local NBA paths.

The deferred storage model writes NBA values into a shadow copy of the instance's inline storage region during process execution, then commits changed values in bulk during the NBA region. This eliminates generic queue allocation, variant dispatch, and slot-meta lookup for the dominant write path (local owned-inline signals).

The transport elimination identifies relay slots and identity-copy combs at compile time, rewrites downstream connections to bypass them, and precomputes storage pointers so connection propagation uses direct memcmp/memcpy without per-access address resolution.

## Design

**Deferred NBA storage**: Each RuntimeInstance allocates a deferred inline region (and appendix region for containers) sized to match its owned storage. Generated code writes NBA values directly into the deferred region via `LyraDeferredWriteLocal`. At NBA commit time, `CommitDeferredLocalNbas` compares deferred vs current storage and copies changed values. Split counters (`nba_generic_queue` / `nba_deferred_local`) enforce the routing boundary.

**Transport elimination**: `EliminateRelayConnections` in connection analysis rewrites the connection kernel graph before layout. For connection-backed relays, the upstream edge is deleted and downstream edges read from the true source. For identity-copy combs (`assign data_out = data_reg`), downstream connections are rewritten to the comb's input slot; the comb continues to execute inline (cheaper than full process activation) but its output triggers no downstream work. Container slots are excluded from elimination. Process-body reads ($display, $monitor, etc.) are detected by scanning MIR Effect operands.

**Precomputed pointers**: `BatchedConnection` stores resolved `src_ptr`/`dst_ptr` at init time, eliminating `ResolveSlotBytes`/`ResolveConnectionDstMut` from the propagation hot path.

## Testing

- 8 NBA routing boundary regression tests (`nba_routing/default.yaml`) verify split counter invariants via `NbaStatsCallback`
- All existing jit_dev_tests pass
- clock-pipeline benchmark: 24.3B -> 19.9B Ir (-18%)