### PR TITLE
Move ext-ref runtime identity to per-instance object-local bindings

### DIFF
--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -129,6 +129,7 @@ For any design change, ask in order:
 6. **Is it specialization-local?** -- Does it require cross-module or design-global knowledge?
 
 7. **Does it avoid materializing final object identity at compile time?** -- Does it require knowing final instance count, object ordering, or target object identity during specialization compilation?
+8. **Does the backend reach per-instance data only through instance_ptr?** -- Backend codegen must not receive design-wide query APIs (ConstructionInput, body-group-to-objects maps) or scan construction-level tables to derive compile-time facts from one representative instance. Per-instance data is loaded at runtime from instance_ptr-reachable state, never baked as a compile-time constant derived from a design-topology scan.
 
 If a proposed change fails any of these questions, reconsider the design before proceeding.
 

--- a/docs/queues/specialization.md
+++ b/docs/queues/specialization.md
@@ -35,6 +35,7 @@ For the stable architecture: see [compilation-model.md](../compilation-model.md)
   - [ ] F1-impl -- Per-group isolated compilation with deterministic merge
 - [ ] F2 -- Specialization caching
 - [x] I1 -- Constructor-time container construction recipes
+- [ ] Compilation unit isolation enforcement (I-1 through I-5)
 - [ ] Documentation: natural model, ownership boundaries, and runtime model docs need alignment
 - [ ] CI policy gates: specialization invariants and natural model regression checks
 
@@ -167,6 +168,45 @@ Several docs need alignment with the natural model and R-series runtime model mi
 - runtime.md, change-propagation.md, and module-hierarchy.md describe mechanisms without referencing the natural model or noting current-state mismatches
 
 The code already implements the correct projection for types. The docs need to catch up with both the type ownership model and the broader natural model / runtime model direction.
+
+## Compilation unit isolation enforcement
+
+The specialization-scoped IR principle is documented in architecture-principles.md, but enforcement today relies on convention and code review. Violations recur because the wrong thing is merely discouraged, not structurally impossible. The goal is to make boundary violations unrepresentable or prohibitively expensive.
+
+### I-1: Backend must not link frontend/slang
+
+The LLVM backend library currently transitively includes slang headers. This allows backend code to reach frontend AST objects, instance symbols, and scope trees. The backend build target should not depend on the slang library. Frontend types must not appear in any backend header or source file.
+
+Target: remove slang from the backend's dependency closure. Any data the backend needs from the frontend must cross the HIR/MIR serialization boundary as owned, frontend-free types.
+
+### I-2: HIR as owned quarantine boundary
+
+HIR currently carries slang pointers (SymbolId referencing slang symbols, source locations pointing into slang source buffers). After AST-to-HIR lowering, subsequent phases should not require the slang compilation to remain alive. HIR should be fully owned and reconstructable without frontend memory.
+
+Target: HIR types carry no pointers into the slang AST. After HIR is built, the frontend world can be dropped. This makes "sneak a frontend pointer into MIR/backend" structurally impossible.
+
+### I-3: No design-wide query API in backend codegen
+
+Backend codegen (Context, SpecLocalScope, spec_session) currently receives ConstructionInput, which provides a design-wide object table queryable by body_group. This enables body-group-indexed scanning for "first instance" or "representative" lookups that violate compilation unit isolation.
+
+Target: codegen receives only specialization-scoped data (recipes, layout, slot info) and runtime-instance-reachable handles. No ConstructionInput, no Design, no body-group-to-objects query. Per-instance data is loaded at runtime via instance_ptr, not looked up at codegen time via design-wide tables.
+
+### I-4: Opaque typed IDs across layers
+
+A single body_group uint32_t can be used to re-open the whole design-level world from any layer. Different layers should use opaque typed IDs that cannot be directly cross-referenced without explicit conversion at an owning boundary.
+
+Target: separate opaque ID types per layer (HIR, MIR, codegen, runtime). No raw uint32_t body/instance indices cross layer boundaries without typed wrappers that restrict what queries are available.
+
+### I-5: CI forbidden-dependency checks
+
+Static enforcement of include/dependency rules:
+
+- `llvm_backend/` must not include `slang/` headers
+- `llvm_backend/context*.cpp` must not include `construction_input.hpp`
+- Codegen-facing structs (CompiledModuleSpecInput, SpecLocalScope, ExternalRefResolutionEnv) must not carry body_group, object_index, or construction-level grouping keys
+- New fields on codegen-facing structs that carry design-topology identity must fail CI
+
+Target: policy check script (like check_exceptions.py) that enforces these rules on every PR.
 
 ## CI policy gates
 

--- a/include/lyra/common/ext_ref_binding.hpp
+++ b/include/lyra/common/ext_ref_binding.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdint>
+
+#include "lyra/common/local_slot_id.hpp"
+#include "lyra/common/slot_id.hpp"
+
+namespace lyra::common {
+
+// Resolved external-ref runtime binding record.
+// One per external-ref recipe per owning instance.
+// Single source of truth for both storage access and behavioral identity.
+//
+// storage_slot: design-global slot for address resolution (storage only).
+// target_instance_id + target_local_signal: object-local behavioral identity
+// for dirty notification, trigger subscription, and NBA scheduling.
+//
+// This struct is the canonical runtime carrier for resolved ext-ref
+// identity. It must not contain raw uint32_t for semantic fields,
+// except target_instance_id which matches runtime::InstanceId layout
+// but is declared as uint32_t to avoid a cross-layer dependency on
+// runtime types from the common layer.
+struct ResolvedExtRefBinding {
+  SlotId storage_slot;
+  // InstanceId.value of the target instance. Matches runtime::InstanceId
+  // by layout (uint32_t). Stored here as uint32_t because common cannot
+  // depend on runtime. Callers in the runtime layer cast via InstanceId{}.
+  uint32_t target_instance_id = 0;
+  LocalSlotId target_local_signal;
+};
+
+static_assert(sizeof(ResolvedExtRefBinding) == 12);
+static_assert(offsetof(ResolvedExtRefBinding, storage_slot) == 0);
+static_assert(offsetof(ResolvedExtRefBinding, target_instance_id) == 4);
+static_assert(offsetof(ResolvedExtRefBinding, target_local_signal) == 8);
+
+}  // namespace lyra::common

--- a/include/lyra/llvm_backend/behavioral_trigger_contracts.hpp
+++ b/include/lyra/llvm_backend/behavioral_trigger_contracts.hpp
@@ -6,6 +6,7 @@
 
 namespace lyra::mir {
 class Arena;
+struct ConstructionInput;
 struct Design;
 }  // namespace lyra::mir
 
@@ -17,9 +18,13 @@ namespace lyra::lowering::mir_to_llvm {
 //   2. Design-global behavioral trigger bitmap
 //   (slot_has_design_behavioral_trigger)
 //
+// construction: used to resolve ext-ref trigger targets to body-local
+// slots on the target body for cross-body behavioral dirty marking.
+//
 // Must complete before codegen reads RequiresDirtyPropagation.
 void PopulateBehavioralTriggerContracts(
     std::span<const LayoutModulePlan> module_plans, const mir::Design& design,
-    const mir::Arena& design_arena, Layout& layout);
+    const mir::Arena& design_arena, const mir::ConstructionInput& construction,
+    Layout& layout);
 
 }  // namespace lyra::lowering::mir_to_llvm

--- a/include/lyra/llvm_backend/behavioral_trigger_contracts.hpp
+++ b/include/lyra/llvm_backend/behavioral_trigger_contracts.hpp
@@ -6,7 +6,6 @@
 
 namespace lyra::mir {
 class Arena;
-struct ConstructionInput;
 struct Design;
 }  // namespace lyra::mir
 
@@ -21,7 +20,6 @@ namespace lyra::lowering::mir_to_llvm {
 // Must complete before codegen reads RequiresDirtyPropagation.
 void PopulateBehavioralTriggerContracts(
     std::span<const LayoutModulePlan> module_plans, const mir::Design& design,
-    const mir::Arena& design_arena, const mir::ConstructionInput* construction,
-    Layout& layout);
+    const mir::Arena& design_arena, Layout& layout);
 
 }  // namespace lyra::lowering::mir_to_llvm

--- a/include/lyra/llvm_backend/codegen_session.hpp
+++ b/include/lyra/llvm_backend/codegen_session.hpp
@@ -181,6 +181,11 @@ struct ConstructionProgramData {
   std::vector<uint8_t> path_pool;
   std::vector<uint8_t> param_pool;
   std::vector<runtime::ConstructionProgramEntry> entries;
+  // Per-instance external-ref resolved global slot tables, packed flat.
+  // ext_ref_offsets[i] is the offset into ext_ref_pool for instance i
+  // (UINT32_MAX if that instance has no external refs).
+  std::vector<uint32_t> ext_ref_pool;
+  std::vector<uint32_t> ext_ref_offsets;
 };
 
 // Design-derived inputs for the realization/assembly phase, extracted during
@@ -235,10 +240,11 @@ auto CompileDesignProcesses(const LoweringInput& input)
 // generates shared/template process functions, and returns an explicit product.
 // Does not inspect design-global state, package functions, or wrapper logic.
 // All body-specific data is carried on the input -- no design or provenance
-// parameter needed.
+// parameter needed. Per-instance data (external ref slots) is loaded at
+// runtime from instance_ptr, not passed through the compilation session.
 auto CompileModuleSpecSession(
-    Context& context, const CompiledModuleSpecInput& input,
-    const mir::ConstructionInput* construction) -> Result<CompiledModuleSpec>;
+    Context& context, const CompiledModuleSpecInput& input)
+    -> Result<CompiledModuleSpec>;
 
 // Backend phase: extract LLVM ownership from a completed session.
 auto FinalizeModule(CodegenSession session, LoweringReport report)

--- a/include/lyra/llvm_backend/codegen_session.hpp
+++ b/include/lyra/llvm_backend/codegen_session.hpp
@@ -11,6 +11,7 @@
 #include <llvm/IR/Function.h>
 
 #include "lyra/common/diagnostic/diagnostic.hpp"
+#include "lyra/common/ext_ref_binding.hpp"
 #include "lyra/llvm_backend/deferred_thunk_abi.hpp"
 #include "lyra/llvm_backend/layout/layout.hpp"
 #include "lyra/llvm_backend/lowering_reports.hpp"
@@ -181,11 +182,13 @@ struct ConstructionProgramData {
   std::vector<uint8_t> path_pool;
   std::vector<uint8_t> param_pool;
   std::vector<runtime::ConstructionProgramEntry> entries;
-  // Per-instance external-ref resolved global slot tables, packed flat.
-  // ext_ref_offsets[i] is the offset into ext_ref_pool for instance i
+  // Per-instance ext-ref binding records, packed flat.
+  // ext_ref_binding_offsets[i] is the index into binding_pool for instance i
   // (UINT32_MAX if that instance has no external refs).
-  std::vector<uint32_t> ext_ref_pool;
-  std::vector<uint32_t> ext_ref_offsets;
+  // ext_ref_binding_counts[i] is the number of bindings for instance i.
+  std::vector<common::ResolvedExtRefBinding> ext_ref_binding_pool;
+  std::vector<uint32_t> ext_ref_binding_offsets;
+  std::vector<uint32_t> ext_ref_binding_counts;
 };
 
 // Design-derived inputs for the realization/assembly phase, extracted during

--- a/include/lyra/llvm_backend/commit/signal_id_expr.hpp
+++ b/include/lyra/llvm_backend/commit/signal_id_expr.hpp
@@ -60,17 +60,7 @@ class SignalCoordExpr {
     return e;
   }
 
-  // Runtime-loaded global signal. The slot ID is an LLVM Value loaded
-  // at runtime (e.g., from per-instance ext_ref_slots). Used by external-ref
-  // read address resolution.
-  static auto GlobalRuntime(llvm::Value* slot_value) -> SignalCoordExpr {
-    SignalCoordExpr e;
-    e.kind_ = Kind::kGlobal;
-    e.runtime_value_ = slot_value;
-    return e;
-  }
-
-  // External-ref write notification. Dirty mark resolves through
+  // External-ref write/NBA notification. Dirty mark resolves through
   // per-instance ext-ref target tables to the target instance's local signal.
   // value_ is the ext-ref recipe index.
   static auto ExtRef(uint32_t ref_index) -> SignalCoordExpr {

--- a/include/lyra/llvm_backend/commit/signal_id_expr.hpp
+++ b/include/lyra/llvm_backend/commit/signal_id_expr.hpp
@@ -57,6 +57,16 @@ class SignalCoordExpr {
     return e;
   }
 
+  // Runtime-loaded global signal. The slot ID is an LLVM Value loaded
+  // at runtime (e.g., from per-instance ext_ref_slots). Used by external-ref
+  // write paths where the target slot varies per instance.
+  static auto GlobalRuntime(llvm::Value* slot_value) -> SignalCoordExpr {
+    SignalCoordExpr e;
+    e.kind_ = Kind::kGlobal;
+    e.runtime_value_ = slot_value;
+    return e;
+  }
+
   [[nodiscard]] auto GetKind() const -> Kind {
     return kind_;
   }
@@ -96,9 +106,11 @@ class SignalCoordExpr {
     return std::nullopt;
   }
 
-  // Emit the semantic id value as an LLVM i32 constant.
-  // This is the raw local or global id, NOT a dense coordination coordinate.
+  // Emit the semantic id value as an LLVM i32 value.
+  // For compile-time-constant signals, returns ConstantInt.
+  // For runtime-loaded signals (GlobalRuntime), returns the pre-loaded value.
   [[nodiscard]] auto Emit(llvm::IRBuilder<>& builder) const -> llvm::Value* {
+    if (runtime_value_ != nullptr) return runtime_value_;
     auto& ctx = builder.getContext();
     return llvm::ConstantInt::get(llvm::Type::getInt32Ty(ctx), value_);
   }
@@ -110,6 +122,9 @@ class SignalCoordExpr {
   uint32_t value_ = 0;
   llvm::Value* instance_override_ = nullptr;
   runtime::InstanceId instance_id_override_ = runtime::InstanceId{0};
+  // Non-null for GlobalRuntime: the signal ID is a runtime-loaded LLVM
+  // value, not a compile-time constant. Emit() returns this directly.
+  llvm::Value* runtime_value_ = nullptr;
 };
 
 }  // namespace lyra::lowering::mir_to_llvm

--- a/include/lyra/llvm_backend/commit/signal_id_expr.hpp
+++ b/include/lyra/llvm_backend/commit/signal_id_expr.hpp
@@ -27,6 +27,9 @@ class SignalCoordExpr {
     kLocal,
     kLocalCrossInstance,
     kGlobal,
+    // External-ref write: dirty notification resolves through per-instance
+    // ext-ref target tables at runtime. value_ carries the ext-ref index.
+    kExtRef,
   };
 
   static auto Local(uint32_t id) -> SignalCoordExpr {
@@ -59,11 +62,21 @@ class SignalCoordExpr {
 
   // Runtime-loaded global signal. The slot ID is an LLVM Value loaded
   // at runtime (e.g., from per-instance ext_ref_slots). Used by external-ref
-  // write paths where the target slot varies per instance.
+  // read address resolution.
   static auto GlobalRuntime(llvm::Value* slot_value) -> SignalCoordExpr {
     SignalCoordExpr e;
     e.kind_ = Kind::kGlobal;
     e.runtime_value_ = slot_value;
+    return e;
+  }
+
+  // External-ref write notification. Dirty mark resolves through
+  // per-instance ext-ref target tables to the target instance's local signal.
+  // value_ is the ext-ref recipe index.
+  static auto ExtRef(uint32_t ref_index) -> SignalCoordExpr {
+    SignalCoordExpr e;
+    e.kind_ = Kind::kExtRef;
+    e.value_ = ref_index;
     return e;
   }
 
@@ -75,6 +88,9 @@ class SignalCoordExpr {
   }
   [[nodiscard]] auto IsGlobal() const -> bool {
     return kind_ == Kind::kGlobal;
+  }
+  [[nodiscard]] auto IsExtRef() const -> bool {
+    return kind_ == Kind::kExtRef;
   }
 
   [[nodiscard]] auto Value() const -> uint32_t {

--- a/include/lyra/llvm_backend/context.hpp
+++ b/include/lyra/llvm_backend/context.hpp
@@ -516,7 +516,7 @@ class Context {
   // External ref resolution environment. Installed as a unit by
   // SpecLocalScope; cleared on scope exit.
   // Contains only specialization-scoped data (recipes for type/access info).
-  // Per-instance data is loaded at runtime from instance_ptr->ext_ref_slots.
+  // Per-instance data is loaded at runtime from instance_ptr->ext_ref_bindings.
   struct ExternalRefResolutionEnv {
     const std::vector<mir::ExternalAccessRecipe>* recipes = nullptr;
   };
@@ -564,25 +564,9 @@ class Context {
 
   // Resolve external ref to runtime global_slot + type.
   // Emits LLVM IR that loads the design-global slot from the current
-  // instance's ext_ref_slots table.
+  // instance's ext_ref_bindings table.
   [[nodiscard]] auto ResolveExternalRefRoot(mir::ExternalRefId ref_id)
       -> ResolvedExternalRefRoot;
-
-  // Normalize an ExternalRefId to topology-resolved signal identity.
-  // Returns a compile-time constant SignalRef for trigger/sensitivity
-  // metadata. Per-instance external refs require per-instance trigger
-  // resolution (not yet implemented); this function uses the global_slot
-  // loaded from the current instance's ext_ref_slots table at construction
-  // time, which is correct for single-instance bodies and representative-
-  // correct for multi-instance bodies in the trigger/sensitivity path.
-  //
-  // TODO(hankhsu): Per-instance trigger/sensitivity resolution. The signal
-  // identity returned here is a compile-time constant derived from the
-  // per-instance table built at construction time. For multi-instance
-  // bodies, each instance would need its own trigger entries. This is a
-  // separate architectural change.
-  [[nodiscard]] auto NormalizeExternalRefSignalIdentity(
-      mir::ExternalRefId ref_id) const -> mir::SignalRef;
 
   // Get the type of an external ref from its recipe.
   [[nodiscard]] auto GetExternalRefType(mir::ExternalRefId ref_id) const
@@ -600,14 +584,9 @@ class Context {
 
   // Compute the typed signal coordinate for an external ref's storage.
   // Returns a runtime-loaded GlobalRuntime signal coord from the per-instance
-  // ext_ref_slots table.
+  // ext_ref_bindings table.
   [[nodiscard]] auto EmitExternalRefSignalCoord(mir::ExternalRefId ref_id)
       -> SignalCoordExpr;
-
-  // Get the target local slot for an external ref from the recipe.
-  // Compile-time constant, used for cross-instance local trigger identity.
-  [[nodiscard]] auto GetExternalRefTargetLocalSlot(
-      mir::ExternalRefId ref_id) const -> uint32_t;
 
   // Load ext_ref_bindings pointer from RuntimeInstance via instance_ptr_.
   [[nodiscard]] auto EmitLoadExtRefBindingsPtr() -> llvm::Value*;
@@ -726,7 +705,7 @@ class Context {
   // Legacy runtime-interop: resolve a signal reference to a design-global
   // slot index for runtime APIs that still use flat slot identity (trace
   // observation, packed store notifications). For module-local signals,
-  // maps through ResolveLegacyRepresentativeDesignSlot. For design-global
+  // maps through ResolveRepresentativeDesignSlot. For design-global
   // signals, returns the id directly.
   // Must NOT be used for spec compilation decisions -- only for runtime
   // signal identity at the codegen->runtime boundary.

--- a/include/lyra/llvm_backend/context.hpp
+++ b/include/lyra/llvm_backend/context.hpp
@@ -324,12 +324,16 @@ class Context {
       -> llvm::Function*;
   [[nodiscard]] auto GetLyraScheduleNbaCanonicalPackedGlobal()
       -> llvm::Function*;
+  [[nodiscard]] auto GetLyraScheduleNbaExtRef() -> llvm::Function*;
+  [[nodiscard]] auto GetLyraScheduleNbaCanonicalPackedExtRef()
+      -> llvm::Function*;
   [[nodiscard]] auto GetLyraIsTraceObservedLocal() -> llvm::Function*;
   [[nodiscard]] auto GetLyraIsTraceObservedGlobal() -> llvm::Function*;
   [[nodiscard]] auto GetLyraNotifyContainerMutationLocal() -> llvm::Function*;
   [[nodiscard]] auto GetLyraNotifyContainerMutationGlobal() -> llvm::Function*;
   [[nodiscard]] auto GetLyraNotifySignalLocal() -> llvm::Function*;
   [[nodiscard]] auto GetLyraNotifySignalGlobal() -> llvm::Function*;
+  [[nodiscard]] auto GetLyraMarkDirtyExtRef() -> llvm::Function*;
   [[nodiscard]] auto GetLyraTerminate() -> llvm::Function*;
   [[nodiscard]] auto GetLyraGetTime() -> llvm::Function*;
   [[nodiscard]] auto GetLyraInitRuntime() -> llvm::Function*;
@@ -600,8 +604,16 @@ class Context {
   [[nodiscard]] auto EmitExternalRefSignalCoord(mir::ExternalRefId ref_id)
       -> SignalCoordExpr;
 
-  // Load ext_ref_slots pointer from RuntimeInstance via instance_ptr_.
-  [[nodiscard]] auto EmitLoadExtRefSlotsPtr() -> llvm::Value*;
+  // Get the target local slot for an external ref from the recipe.
+  // Compile-time constant, used for cross-instance local trigger identity.
+  [[nodiscard]] auto GetExternalRefTargetLocalSlot(
+      mir::ExternalRefId ref_id) const -> uint32_t;
+
+  // Load ext_ref_bindings pointer from RuntimeInstance via instance_ptr_.
+  [[nodiscard]] auto EmitLoadExtRefBindingsPtr() -> llvm::Value*;
+
+  // Get the LLVM struct type for ResolvedExtRefBinding: {i32, i32, i32}.
+  [[nodiscard]] auto GetExtRefBindingType() -> llvm::StructType*;
 
   // Resolve a WriteTarget to a storage pointer.
   // PlaceId: delegates to GetPlacePointer.
@@ -1097,8 +1109,10 @@ class Context {
   llvm::Function* lyra_resolve_slot_ptr_ = nullptr;
   llvm::Function* lyra_resolve_instance_ptr_ = nullptr;
   // R3 typed coordination helpers.
+  llvm::StructType* ext_ref_binding_type_ = nullptr;
   llvm::Function* lyra_mark_dirty_local_ = nullptr;
   llvm::Function* lyra_mark_dirty_global_ = nullptr;
+  llvm::Function* lyra_mark_dirty_ext_ref_ = nullptr;
   llvm::Function* lyra_store_packed_local_ = nullptr;
   llvm::Function* lyra_store_packed_global_ = nullptr;
   llvm::Function* lyra_store_string_local_ = nullptr;
@@ -1107,6 +1121,8 @@ class Context {
   llvm::Function* lyra_schedule_nba_global_ = nullptr;
   llvm::Function* lyra_schedule_nba_canonical_packed_local_ = nullptr;
   llvm::Function* lyra_schedule_nba_canonical_packed_global_ = nullptr;
+  llvm::Function* lyra_schedule_nba_ext_ref_ = nullptr;
+  llvm::Function* lyra_schedule_nba_canonical_packed_ext_ref_ = nullptr;
   llvm::Function* lyra_is_trace_observed_local_ = nullptr;
   llvm::Function* lyra_is_trace_observed_global_ = nullptr;
   llvm::Function* lyra_notify_container_mutation_local_ = nullptr;

--- a/include/lyra/llvm_backend/context.hpp
+++ b/include/lyra/llvm_backend/context.hpp
@@ -23,7 +23,6 @@
 #include "lyra/llvm_backend/layout/layout.hpp"
 #include "lyra/lowering/diagnostic_context.hpp"
 #include "lyra/mir/arena.hpp"
-#include "lyra/mir/construction_input.hpp"
 #include "lyra/mir/external_ref.hpp"
 #include "lyra/mir/handle.hpp"
 #include "lyra/mir/routine.hpp"
@@ -510,11 +509,12 @@ class Context {
   void SetConnectionNotificationMask(const ConnectionNotificationMask* mask) {
     connection_notification_mask_ = mask;
   }
-  // B2: External ref resolution environment. Installed as a unit by
-  // SpecLocalScope; cleared on scope exit. All fields must be consistent.
+  // External ref resolution environment. Installed as a unit by
+  // SpecLocalScope; cleared on scope exit.
+  // Contains only specialization-scoped data (recipes for type/access info).
+  // Per-instance data is loaded at runtime from instance_ptr->ext_ref_slots.
   struct ExternalRefResolutionEnv {
-    const std::vector<mir::ResolvedExternalRefBinding>* bindings = nullptr;
-    const mir::ConstructionInput* construction = nullptr;
+    const std::vector<mir::ExternalAccessRecipe>* recipes = nullptr;
   };
   void SetExternalRefResolutionEnv(std::optional<ExternalRefResolutionEnv> env);
 
@@ -548,49 +548,44 @@ class Context {
     Context& ctx_;
   };
 
-  // V3: Direct external-ref helpers. Consume ResolvedExternalRefBinding
-  // directly for reads (operand loads, type queries) and writes
-  // (immediate/deferred assign). No synthetic PlaceId, no scratch arena.
+  // External-ref helpers. Recipes are specialization-scoped; actual slot
+  // resolution uses per-instance data loaded from RuntimeInstance at runtime.
 
-  // Resolved external-ref root: carries the design-global slot ID and type
-  // as a single result. All external-ref address/type/signal-coord helpers
-  // derive from this.
+  // Resolved external-ref root: carries the design-global slot as a
+  // runtime-loaded LLVM Value and the type as compile-time data.
   struct ResolvedExternalRefRoot {
-    uint32_t global_slot = 0;
+    llvm::Value* global_slot_value = nullptr;
     TypeId type = {};
   };
 
-  // Canonical external-ref resolution: binding -> design-global slot + type.
-  // Used by all external-ref helpers (read and write paths).
-  // All invariant checks (env installed, bindings present, target_object in
-  // range, local_slot within target object's domain, no overflow) are
-  // enforced here.
-  [[nodiscard]] auto ResolveExternalRefRoot(mir::ExternalRefId ref_id) const
+  // Resolve external ref to runtime global_slot + type.
+  // Emits LLVM IR that loads the design-global slot from the current
+  // instance's ext_ref_slots table.
+  [[nodiscard]] auto ResolveExternalRefRoot(mir::ExternalRefId ref_id)
       -> ResolvedExternalRefRoot;
 
-  // Access the resolved binding for an external ref.
-  [[nodiscard]] auto GetExternalRefBinding(mir::ExternalRefId ref_id) const
-      -> const mir::ResolvedExternalRefBinding&;
-
-  // Access the construction input (objects, instance table).
-  [[nodiscard]] auto GetConstruction() const -> const mir::ConstructionInput&;
-
   // Normalize an ExternalRefId to topology-resolved signal identity.
-  // Uses ResolvedExternalRefBinding (target_object + target_local_slot)
-  // to compute the design-global slot via topology facts. EmitSignalCoord
-  // then reclassifies instance-owned signals to local runtime identity.
-  // This is the canonical normalization for sensitivity, trigger,
-  // index-plan, and write-path signal identity.
+  // Returns a compile-time constant SignalRef for trigger/sensitivity
+  // metadata. Per-instance external refs require per-instance trigger
+  // resolution (not yet implemented); this function uses the global_slot
+  // loaded from the current instance's ext_ref_slots table at construction
+  // time, which is correct for single-instance bodies and representative-
+  // correct for multi-instance bodies in the trigger/sensitivity path.
+  //
+  // TODO(hankhsu): Per-instance trigger/sensitivity resolution. The signal
+  // identity returned here is a compile-time constant derived from the
+  // per-instance table built at construction time. For multi-instance
+  // bodies, each instance would need its own trigger entries. This is a
+  // separate architectural change.
   [[nodiscard]] auto NormalizeExternalRefSignalIdentity(
       mir::ExternalRefId ref_id) const -> mir::SignalRef;
 
-  // Get the type of an external ref from its resolved root.
+  // Get the type of an external ref from its recipe.
   [[nodiscard]] auto GetExternalRefType(mir::ExternalRefId ref_id) const
       -> TypeId;
 
   // Emit LLVM IR computing a pointer to the external ref's storage.
-  // Backend-internal address arithmetic via ResolveExternalRefRoot ->
-  // GetDesignGlobalSlotPointer. Not a rebuilt Place.
+  // Loads the global slot from per-instance data, then resolves to pointer.
   [[nodiscard]] auto EmitExternalRefAddress(mir::ExternalRefId ref_id)
       -> llvm::Value*;
 
@@ -600,9 +595,13 @@ class Context {
       -> Result<llvm::Value*>;
 
   // Compute the typed signal coordinate for an external ref's storage.
-  // Always returns SignalCoordExpr::Global(global_slot).
-  [[nodiscard]] auto EmitExternalRefSignalCoord(mir::ExternalRefId ref_id) const
+  // Returns a runtime-loaded GlobalRuntime signal coord from the per-instance
+  // ext_ref_slots table.
+  [[nodiscard]] auto EmitExternalRefSignalCoord(mir::ExternalRefId ref_id)
       -> SignalCoordExpr;
+
+  // Load ext_ref_slots pointer from RuntimeInstance via instance_ptr_.
+  [[nodiscard]] auto EmitLoadExtRefSlotsPtr() -> llvm::Value*;
 
   // Resolve a WriteTarget to a storage pointer.
   // PlaceId: delegates to GetPlacePointer.
@@ -649,6 +648,11 @@ class Context {
 
   // Design-global storage: design_ptr + struct GEP via field index.
   [[nodiscard]] auto GetDesignGlobalSlotPointer(uint32_t global_slot_id)
+      -> llvm::Value*;
+
+  // Design-global storage with runtime-loaded slot ID.
+  // Used by external-ref resolution where the slot varies per instance.
+  [[nodiscard]] auto GetDesignGlobalSlotPointer(llvm::Value* global_slot_id)
       -> llvm::Value*;
 
   // Central dispatch: resolve a design-storage root (kModuleSlot or

--- a/include/lyra/llvm_backend/layout/layout.hpp
+++ b/include/lyra/llvm_backend/layout/layout.hpp
@@ -571,18 +571,18 @@ struct Layout {
   // notifications). Must NOT be used for spec compilation decisions.
   // Will be deleted when runtime signal identity moves fully to
   // object-local coordinates.
-  [[nodiscard]] auto ResolveLegacyRepresentativeDesignSlot(
+  [[nodiscard]] auto ResolveRepresentativeDesignSlot(
       uint32_t body_info_index, uint32_t local_slot) const -> uint32_t {
     if (body_info_index >= body_representative_base_slots.size()) {
       throw common::InternalError(
-          "ResolveLegacyRepresentativeDesignSlot",
+          "ResolveRepresentativeDesignSlot",
           std::format(
               "body_info_index {} out of range (size={})", body_info_index,
               body_representative_base_slots.size()));
     }
     if (local_slot >= body_realization_infos.at(body_info_index).slot_count) {
       throw common::InternalError(
-          "ResolveLegacyRepresentativeDesignSlot",
+          "ResolveRepresentativeDesignSlot",
           std::format(
               "local_slot {} out of range for body {} (slot_count={})",
               local_slot, body_realization_infos[body_info_index].body_id.value,

--- a/include/lyra/llvm_backend/process.hpp
+++ b/include/lyra/llvm_backend/process.hpp
@@ -52,10 +52,16 @@ struct WaitSiteEntry {
 // Canonical compile-time process trigger fact.
 // Captures the signal identity and edge kind from a MIR WaitTrigger.
 // G13 metadata, separate from runtime wait-site plumbing.
+// For external-ref triggers, signal is unused and external_ref_index
+// carries the body-local external-ref recipe index. Resolution to a
+// concrete design-global slot happens at construction time.
 struct ProcessTriggerFact {
-  mir::SignalRef signal;
-  common::EdgeKind edge;
-  bool has_observed_place;
+  mir::SignalRef signal = {};
+  common::EdgeKind edge = common::EdgeKind::kAnyChange;
+  bool has_observed_place = false;
+  // External-ref recipe index (body-local). When set, signal is unused
+  // and the template entry carries kTriggerTemplateFlagExternalRef.
+  std::optional<uint32_t> external_ref_index;
 };
 
 // Canonical compile-time process trigger entry.

--- a/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
@@ -15,6 +15,10 @@ namespace lyra::lowering::ast_to_hir {
 struct LoweringFrame {
   int unit_power;  // Scope's timeunit as power of 10 (e.g., -9 for 1ns)
   int global_precision_power;  // Compilation-wide finest precision
+  // The slang instance being lowered. Used by hierarchical reference path
+  // extraction to determine whether a path element is an ancestor
+  // self-reference or a real child traversal step. Null for package lowering.
+  const slang::ast::InstanceSymbol* instance = nullptr;
 };
 
 /// Drives AST->HIR lowering for a single module or package.

--- a/include/lyra/lowering/hir_to_mir/bound_hierarchy.hpp
+++ b/include/lyra/lowering/hir_to_mir/bound_hierarchy.hpp
@@ -112,11 +112,12 @@ void FinalizeExternalRefTargetSlots(
     const BoundHierarchyIndex& topo, const mir::ConstructionInput& construction,
     std::span<const hir::Module* const> hir_modules);
 
-// Build per-instance external-ref resolved global slot tables.
+// Build per-instance resolved ext-ref runtime bindings.
 // For each realized object, walks each external ref recipe from that
-// object's actual position in the hierarchy and computes the final
-// design-global slot. Results stored in construction.instance_ext_ref_slots.
-void BuildPerInstanceExternalRefSlotTables(
+// object's actual position and produces a ResolvedExtRefBinding with
+// storage slot, target instance, and target local signal.
+// Results stored in construction.instance_ext_ref_bindings.
+void BuildPerInstanceExtRefBindings(
     const mir::Design& design, mir::ConstructionInput& construction,
     const BoundHierarchyIndex& topo);
 

--- a/include/lyra/lowering/hir_to_mir/bound_hierarchy.hpp
+++ b/include/lyra/lowering/hir_to_mir/bound_hierarchy.hpp
@@ -8,6 +8,7 @@
 
 #include "lyra/common/local_slot_id.hpp"
 #include "lyra/common/module_identity.hpp"
+#include "lyra/common/object_index.hpp"
 #include "lyra/common/symbol_types.hpp"
 #include "lyra/mir/external_ref.hpp"
 
@@ -111,11 +112,13 @@ void FinalizeExternalRefTargetSlots(
     const BoundHierarchyIndex& topo, const mir::ConstructionInput& construction,
     std::span<const hir::Module* const> hir_modules);
 
-// Validate that no body with active external refs has multiple instances.
-// Must be called before any pass that relies on representative-derived
-// durable-child mappings. Throws InternalError on violation.
-void EnforceExternalRefSingleInstanceGuard(
-    const mir::Design& design, const mir::ConstructionInput& construction);
+// Build per-instance external-ref resolved global slot tables.
+// For each realized object, walks each external ref recipe from that
+// object's actual position in the hierarchy and computes the final
+// design-global slot. Results stored in construction.instance_ext_ref_slots.
+void BuildPerInstanceExternalRefSlotTables(
+    const mir::Design& design, mir::ConstructionInput& construction,
+    const BoundHierarchyIndex& topo);
 
 // Populate external_refs[i].target.path with final DescendantPathStep entries
 // by resolving topology-walked child object indices to DurableChildIds.
@@ -139,15 +142,6 @@ auto WalkCanonicalPath(
     const mir::NonLocalTargetRecipe& recipe, uint32_t current_oi,
     const BoundHierarchyIndex& topo, const mir::ConstructionInput& construction)
     -> uint32_t;
-
-// Build per-body resolved external ref bindings and store on each body.
-// Consumes the finalized canonical recipe (target.path + target.target_slot),
-// NOT provisionals. Requires CanonicalizeExternalRefPaths to have run.
-// Single-instance specs only: throws if a body with external refs has
-// multiple objects (multi-instance resolution requires per-instance binding).
-void BuildResolvedExternalRefBindings(
-    mir::Design& design, const BoundHierarchyIndex& topo,
-    const mir::ConstructionInput& construction);
 
 // Check whether a ConnectionRecipe is in the fully-bindable subset:
 // source is kLocalSlot and trigger is slot-based (kLocalSlot or kChildSlot).

--- a/include/lyra/mir/construction_input.hpp
+++ b/include/lyra/mir/construction_input.hpp
@@ -48,6 +48,13 @@ struct ConstructionInput {
   InstanceTable instance_table;
   std::vector<InstanceConstBlock> const_blocks;
   std::vector<ObjectRecord> objects;
+
+  // Per-instance resolved external-ref global slot tables.
+  // Parallel to objects: instance_ext_ref_slots[oi] contains the resolved
+  // design-global slot for each external ref in the body's recipe list.
+  // Empty vector for instances whose body has no external refs.
+  // Computed by BuildPerInstanceExternalRefSlotTables during design lowering.
+  std::vector<std::vector<uint32_t>> instance_ext_ref_slots;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/construction_input.hpp
+++ b/include/lyra/mir/construction_input.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "lyra/common/ext_ref_binding.hpp"
 #include "lyra/common/integral_constant.hpp"
 #include "lyra/common/module_identity.hpp"
 #include "lyra/common/symbol_types.hpp"
@@ -49,12 +50,12 @@ struct ConstructionInput {
   std::vector<InstanceConstBlock> const_blocks;
   std::vector<ObjectRecord> objects;
 
-  // Per-instance resolved external-ref global slot tables.
-  // Parallel to objects: instance_ext_ref_slots[oi] contains the resolved
-  // design-global slot for each external ref in the body's recipe list.
-  // Empty vector for instances whose body has no external refs.
-  // Computed by BuildPerInstanceExternalRefSlotTables during design lowering.
-  std::vector<std::vector<uint32_t>> instance_ext_ref_slots;
+  // Per-instance resolved external-ref runtime bindings.
+  // Parallel to objects. Each inner vector has one binding per ext-ref recipe
+  // in the owning body. Empty for instances whose body has no external refs.
+  // Computed by BuildPerInstanceExtRefRuntimeBindings during design lowering.
+  std::vector<std::vector<common::ResolvedExtRefBinding>>
+      instance_ext_ref_bindings;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/external_ref.hpp
+++ b/include/lyra/mir/external_ref.hpp
@@ -2,11 +2,9 @@
 
 #include <cstdint>
 #include <functional>
-#include <optional>
 #include <vector>
 
 #include "lyra/common/local_slot_id.hpp"
-#include "lyra/common/object_index.hpp"
 #include "lyra/common/origin_id.hpp"
 #include "lyra/common/selection_step.hpp"
 #include "lyra/common/type.hpp"
@@ -106,35 +104,6 @@ struct ExternalAccessRecipe {
   ExternalAccessKind access_kind = ExternalAccessKind::kRead;
   common::OriginId origin = common::OriginId::Invalid();
   NonLocalTargetRecipe target;
-};
-
-// Durable binding fact for a resolved external reference.
-// Produced by HIR-to-MIR topology resolution, consumed by LLVM backend.
-// Contains only semantic identity (object + slot + type), not layout data.
-// Backend computes design-global address from ConstructionInput at codegen
-// time.
-//
-// Two kinds of bindings:
-//   Instance-owned: target_object + target_local_slot identify the storage.
-//     Backend resolves via obj.design_state_base_slot + local_slot.
-//   Package/global: global_slot directly identifies a design-global slot.
-//     Currently unused (package globals use design_places, not ExternalRefId).
-//     Reserved for future NonLocalAnchor::kPackage support.
-struct ResolvedExternalRefBinding {
-  common::ObjectIndex target_object;
-  common::LocalSlotId target_local_slot;
-  TypeId type;
-  // Set for package/global targets (no target_object traversal needed).
-  // nullopt for instance-owned targets.
-  std::optional<uint32_t> global_slot;
-
-  [[nodiscard]] auto IsPackageOrGlobal() const -> bool {
-    return global_slot.has_value();
-  }
-
-  [[nodiscard]] auto GlobalSlotId() const -> uint32_t {
-    return *global_slot;
-  }
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/module_body.hpp
+++ b/include/lyra/mir/module_body.hpp
@@ -55,12 +55,11 @@ struct ModuleBody {
   Arena arena;
 
   // B2: External access recipes for this body.
+  // Specialization-scoped: contains only instance-invariant data (upward_count,
+  // canonical durable child path, target_local_slot, type, access_kind).
+  // No concrete target_object. Per-instance resolution happens at construction
+  // time via ConstructionInput::instance_ext_ref_slots.
   std::vector<ExternalAccessRecipe> external_refs;
-
-  // B2: Resolved external ref bindings (parallel to external_refs).
-  // Durable identity facts: {target_object_index, target_local_slot, type}.
-  // Backend computes addresses from ConstructionInput at codegen time.
-  std::vector<ResolvedExternalRefBinding> resolved_external_ref_bindings;
 
   // B2: Child instantiation sites for this body.
   std::vector<ChildInstantiationSite> child_sites;

--- a/include/lyra/mir/module_body.hpp
+++ b/include/lyra/mir/module_body.hpp
@@ -58,7 +58,7 @@ struct ModuleBody {
   // Specialization-scoped: contains only instance-invariant data (upward_count,
   // canonical durable child path, target_local_slot, type, access_kind).
   // No concrete target_object. Per-instance resolution happens at construction
-  // time via ConstructionInput::instance_ext_ref_slots.
+  // time via ConstructionInput::instance_ext_ref_bindings.
   std::vector<ExternalAccessRecipe> external_refs;
 
   // B2: Child instantiation sites for this body.

--- a/include/lyra/runtime/body_realization_desc.hpp
+++ b/include/lyra/runtime/body_realization_desc.hpp
@@ -134,6 +134,10 @@ inline constexpr uint32_t kTriggerTemplateFlagHasObservedPlace = 1U << 0;
 // slot_id is body-relative and constructor adds the per-instance
 // slot-base offset (legacy flat relocation, still globally indexed).
 inline constexpr uint32_t kTriggerTemplateFlagDesignGlobal = 1U << 1;
+// Slot ID is an external-ref recipe index (body-local). Constructor
+// resolves via the per-instance ext_ref_bindings to a design-global
+// slot at realization time. Mutually exclusive with kDesignGlobal.
+inline constexpr uint32_t kTriggerTemplateFlagExternalRef = 1U << 2;
 
 // Named values for OwnedTriggerTemplate::proc_groupable entries.
 // Restricts the uint8_t transport type to a binary contract.

--- a/include/lyra/runtime/constructor_.hpp
+++ b/include/lyra/runtime/constructor_.hpp
@@ -522,4 +522,12 @@ auto LyraConstructionResultGetInstanceBundleCount(void* result) -> uint32_t;
 
 void LyraConstructionResultDestroy(void* result);
 
+// Set per-instance external-ref resolved global slot table pointers.
+// pool/pool_size: flat array of uint32_t global_slot values for all instances.
+// offsets/num_instances: per-instance offset into pool (UINT32_MAX = no ext
+// refs). Called after LyraConstructorFinalize, before simulation.
+void LyraConstructionResultSetExtRefSlots(
+    void* result, const uint32_t* pool, uint32_t pool_size,
+    const uint32_t* offsets, uint32_t num_instances);
+
 }  // extern "C"

--- a/include/lyra/runtime/constructor_.hpp
+++ b/include/lyra/runtime/constructor_.hpp
@@ -522,12 +522,13 @@ auto LyraConstructionResultGetInstanceBundleCount(void* result) -> uint32_t;
 
 void LyraConstructionResultDestroy(void* result);
 
-// Set per-instance external-ref resolved global slot table pointers.
-// pool/pool_size: flat array of uint32_t global_slot values for all instances.
-// offsets/num_instances: per-instance offset into pool (UINT32_MAX = no ext
-// refs). Called after LyraConstructorFinalize, before simulation.
-void LyraConstructionResultSetExtRefSlots(
-    void* result, const uint32_t* pool, uint32_t pool_size,
-    const uint32_t* offsets, uint32_t num_instances);
+// Set per-instance ext-ref binding records.
+// pool: flat array of ResolvedExtRefBinding records for all instances.
+// offsets[i]: index into pool for instance i (UINT32_MAX = no ext refs).
+// counts[i]: number of bindings for instance i.
+// Called after LyraConstructorFinalize, before simulation.
+void LyraConstructionResultSetExtRefBindings(
+    void* result, const void* pool, uint32_t pool_count,
+    const uint32_t* offsets, const uint32_t* counts, uint32_t num_instances);
 
 }  // extern "C"

--- a/include/lyra/runtime/runtime_instance.hpp
+++ b/include/lyra/runtime/runtime_instance.hpp
@@ -63,6 +63,13 @@ struct RuntimeInstance {
   uint32_t module_proc_base = 0;
   uint32_t num_module_processes = 0;
 
+  // Per-instance external-ref resolved global slot table.
+  // Points to a flat array of design-global slot IDs, one per external ref
+  // in the body's recipe list. Null if the body has no external refs.
+  // Populated at construction time; codegen loads from this via GEP.
+  // Part of the binary contract with codegen.
+  const uint32_t* ext_ref_slots = nullptr;
+
   // R5: Per-instance observability state.
   // Populated by Engine::InitModuleInstancesFromBundles. Not part of the
   // binary contract with codegen (not accessed via GEP, no LLVM struct type).
@@ -94,7 +101,8 @@ enum class RuntimeInstanceField : unsigned {
   kOwnerOrdinal = 4,
   kModuleProcBase = 5,
   kNumModuleProcesses = 6,
-  kFieldCount = 7,
+  kExtRefSlots = 7,
+  kFieldCount = 8,
 };
 
 // Hard binary contract assertions for RuntimeInstanceStorage.
@@ -130,6 +138,9 @@ static_assert(
 static_assert(
     offsetof(RuntimeInstance, num_module_processes) ==
     offsetof(RuntimeInstance, module_proc_base) + sizeof(uint32_t));
+static_assert(
+    offsetof(RuntimeInstance, ext_ref_slots) >
+    offsetof(RuntimeInstance, num_module_processes));
 
 // Allocate zero-initialized owned storage for an instance's inline region.
 auto AllocateOwnedInlineStorage(uint64_t size) -> std::byte*;

--- a/include/lyra/runtime/runtime_instance.hpp
+++ b/include/lyra/runtime/runtime_instance.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "lyra/common/ext_ref_binding.hpp"
 #include "lyra/runtime/instance_event_state.hpp"
 #include "lyra/runtime/instance_observability.hpp"
 #include "lyra/runtime/process_frame.hpp"
@@ -63,12 +64,13 @@ struct RuntimeInstance {
   uint32_t module_proc_base = 0;
   uint32_t num_module_processes = 0;
 
-  // Per-instance external-ref resolved global slot table.
-  // Points to a flat array of design-global slot IDs, one per external ref
-  // in the body's recipe list. Null if the body has no external refs.
-  // Populated at construction time; codegen loads from this via GEP.
-  // Part of the binary contract with codegen.
-  const uint32_t* ext_ref_slots = nullptr;
+  // Per-instance resolved ext-ref binding records.
+  // One entry per external-ref recipe in the body. Each record carries
+  // storage slot (address), target instance, and target local signal
+  // (behavioral identity). Null if the body has no external refs.
+  // Part of the binary contract with codegen (accessed via GEP).
+  const common::ResolvedExtRefBinding* ext_ref_bindings = nullptr;
+  uint32_t ext_ref_binding_count = 0;
 
   // R5: Per-instance observability state.
   // Populated by Engine::InitModuleInstancesFromBundles. Not part of the
@@ -101,8 +103,9 @@ enum class RuntimeInstanceField : unsigned {
   kOwnerOrdinal = 4,
   kModuleProcBase = 5,
   kNumModuleProcesses = 6,
-  kExtRefSlots = 7,
-  kFieldCount = 8,
+  kExtRefBindings = 7,
+  kExtRefBindingCount = 8,
+  kFieldCount = 9,
 };
 
 // Hard binary contract assertions for RuntimeInstanceStorage.
@@ -139,7 +142,7 @@ static_assert(
     offsetof(RuntimeInstance, num_module_processes) ==
     offsetof(RuntimeInstance, module_proc_base) + sizeof(uint32_t));
 static_assert(
-    offsetof(RuntimeInstance, ext_ref_slots) >
+    offsetof(RuntimeInstance, ext_ref_bindings) >
     offsetof(RuntimeInstance, num_module_processes));
 
 // Allocate zero-initialized owned storage for an instance's inline region.

--- a/src/lyra/llvm_backend/behavioral_trigger_contracts.cpp
+++ b/src/lyra/llvm_backend/behavioral_trigger_contracts.cpp
@@ -11,6 +11,7 @@
 #include "lyra/common/internal_error.hpp"
 #include "lyra/mir/arena.hpp"
 #include "lyra/mir/basic_block.hpp"
+#include "lyra/mir/construction_input.hpp"
 #include "lyra/mir/module.hpp"
 #include "lyra/mir/terminator.hpp"
 
@@ -55,6 +56,7 @@ auto BuildBodyBehavioralDirtyTriggerBitmaps(
         const auto* wait = std::get_if<mir::Wait>(&block.terminator.data);
         if (wait == nullptr) continue;
         for (const auto& trigger : wait->triggers) {
+          if (trigger.unresolved_external_ref.has_value()) continue;
           if (trigger.signal.scope == mir::SignalRef::Scope::kModuleLocal) {
             mark_local(
                 static_cast<uint32_t>(trigger.signal.id),
@@ -77,6 +79,70 @@ auto BuildBodyBehavioralDirtyTriggerBitmaps(
   return result;
 }
 
+// Mark body-local slots that are targets of cross-body ext-ref behavioral
+// triggers. For each body with ext-ref wait triggers, resolve each triggered
+// ext-ref binding to the target body and mark the target local slot in
+// that body's bitmap. This is body-local identity, not design-global.
+void MarkExtRefTriggerTargetsInBodyBitmaps(
+    std::span<const LayoutModulePlan> module_plans, const mir::Design& design,
+    const mir::ConstructionInput& construction,
+    BodyBehavioralTriggerBitmaps& bitmaps) {
+  // Step 1: per body, collect which ext-ref indices appear in triggers.
+  std::unordered_map<uint32_t, std::vector<uint32_t>> trigger_refs_by_body;
+  for (const auto& plan : module_plans) {
+    auto body_id =
+        static_cast<uint32_t>(plan.body - design.module_bodies.data());
+    if (trigger_refs_by_body.contains(body_id)) continue;
+    const auto& body = *plan.body;
+    std::vector<uint32_t> refs;
+    for (const auto& proc_id : plan.body_processes) {
+      const auto& process = body.arena[proc_id];
+      if (process.kind == mir::ProcessKind::kFinal) continue;
+      for (const auto& block : process.blocks) {
+        const auto* wait = std::get_if<mir::Wait>(&block.terminator.data);
+        if (wait == nullptr) continue;
+        for (const auto& trigger : wait->triggers) {
+          if (trigger.unresolved_external_ref.has_value()) {
+            refs.push_back(trigger.unresolved_external_ref->value);
+          }
+        }
+      }
+    }
+    if (!refs.empty()) {
+      trigger_refs_by_body[body_id] = std::move(refs);
+    }
+  }
+  if (trigger_refs_by_body.empty()) return;
+
+  // Step 2: for each instance with ext-ref triggers, resolve to target
+  // body and mark the target local slot in that body's bitmap.
+  const auto& bindings = construction.instance_ext_ref_bindings;
+  for (uint32_t oi = 0; oi < construction.objects.size(); ++oi) {
+    uint32_t body_group = construction.objects[oi].body_group;
+    auto it = trigger_refs_by_body.find(body_group);
+    if (it == trigger_refs_by_body.end()) continue;
+    if (oi >= bindings.size() || bindings[oi].empty()) continue;
+
+    for (uint32_t ref_idx : it->second) {
+      if (ref_idx >= bindings[oi].size()) continue;
+      const auto& binding = bindings[oi][ref_idx];
+      // Find the target body from the target instance's object record.
+      uint32_t target_oi = binding.target_instance_id;
+      if (target_oi >= construction.objects.size()) continue;
+      uint32_t target_body = construction.objects[target_oi].body_group;
+      uint32_t target_local = binding.target_local_signal.value;
+
+      auto& bitmap = bitmaps.by_body_id_value[target_body];
+      if (bitmap.empty()) {
+        bitmap.assign(construction.objects[target_oi].slot_count, false);
+      }
+      if (target_local < bitmap.size()) {
+        bitmap[target_local] = true;
+      }
+    }
+  }
+}
+
 auto BuildDesignGlobalBehavioralTriggerBitmap(
     std::span<const LayoutModulePlan> module_plans, const mir::Design& design,
     const mir::Arena& design_arena, const DesignLayout& design_layout,
@@ -84,16 +150,16 @@ auto BuildDesignGlobalBehavioralTriggerBitmap(
   auto num_slots = design_layout.slots.size();
   std::vector<bool> bitmap(num_slots, false);
 
-  auto mark_global_slot = [&](common::SlotId trigger_slot) {
-    if (trigger_slot.value >= num_slots) {
+  auto mark_global_slot = [&](uint32_t slot) {
+    if (slot >= num_slots) {
       throw common::InternalError(
           "BuildDesignGlobalBehavioralTriggerBitmap",
           std::format(
               "design-global trigger slot {} out of "
               "range ({} slots)",
-              trigger_slot.value, num_slots));
+              slot, num_slots));
     }
-    bitmap[trigger_slot.value] = true;
+    bitmap[slot] = true;
   };
 
   // Init processes: design-level, data lives in design_arena.
@@ -111,13 +177,12 @@ auto BuildDesignGlobalBehavioralTriggerBitmap(
                   "non-design-global scope (id={})",
                   proc_id.value, trigger.signal.id));
         }
-        mark_global_slot(
-            common::SlotId{static_cast<uint32_t>(trigger.signal.id)});
+        mark_global_slot(static_cast<uint32_t>(trigger.signal.id));
       }
     }
   }
 
-  // Body processes with kDesignGlobal or unresolved external ref triggers.
+  // Body processes with kDesignGlobal triggers.
   for (const auto& plan : module_plans) {
     const auto& body = *plan.body;
     for (const auto& proc_id : plan.body_processes) {
@@ -127,17 +192,11 @@ auto BuildDesignGlobalBehavioralTriggerBitmap(
         const auto* wait = std::get_if<mir::Wait>(&block.terminator.data);
         if (wait == nullptr) continue;
         for (const auto& trigger : wait->triggers) {
-          if (trigger.unresolved_external_ref.has_value()) {
-            // External-ref signal identity is per-instance. Skip in the
-            // compile-time behavioral dirty bitmap. Per-instance trigger
-            // resolution is a separate architectural change.
-            continue;
-          }
+          if (trigger.unresolved_external_ref.has_value()) continue;
           if (trigger.signal.scope != mir::SignalRef::Scope::kDesignGlobal) {
             continue;
           }
-          mark_global_slot(
-              common::SlotId{static_cast<uint32_t>(trigger.signal.id)});
+          mark_global_slot(static_cast<uint32_t>(trigger.signal.id));
         }
       }
     }
@@ -172,7 +231,7 @@ auto BuildDesignGlobalBehavioralTriggerBitmap(
                 "design_layout.slots[{}].value={}, expected identity",
                 design_slot_row, canonical_slot.value));
       }
-      mark_global_slot(canonical_slot);
+      mark_global_slot(canonical_slot.value);
     }
   }
 
@@ -203,9 +262,13 @@ void PopulateBodyBitmaps(
 
 void PopulateBehavioralTriggerContracts(
     std::span<const LayoutModulePlan> module_plans, const mir::Design& design,
-    const mir::Arena& design_arena, Layout& layout) {
+    const mir::Arena& design_arena, const mir::ConstructionInput& construction,
+    Layout& layout) {
   auto body_bitmaps =
       BuildBodyBehavioralDirtyTriggerBitmaps(module_plans, design);
+  // Mark target body-local slots that have cross-body ext-ref subscribers.
+  MarkExtRefTriggerTargetsInBodyBitmaps(
+      module_plans, design, construction, body_bitmaps);
   PopulateBodyBitmaps(body_bitmaps, layout);
   layout.slot_has_design_behavioral_trigger =
       BuildDesignGlobalBehavioralTriggerBitmap(

--- a/src/lyra/llvm_backend/behavioral_trigger_contracts.cpp
+++ b/src/lyra/llvm_backend/behavioral_trigger_contracts.cpp
@@ -11,8 +11,6 @@
 #include "lyra/common/internal_error.hpp"
 #include "lyra/mir/arena.hpp"
 #include "lyra/mir/basic_block.hpp"
-#include "lyra/mir/construction_input.hpp"
-#include "lyra/mir/external_ref.hpp"
 #include "lyra/mir/module.hpp"
 #include "lyra/mir/terminator.hpp"
 
@@ -79,27 +77,10 @@ auto BuildBodyBehavioralDirtyTriggerBitmaps(
   return result;
 }
 
-auto ResolveExternalRefToDesignGlobalSlot(
-    mir::ExternalRefId ref_id,
-    const std::vector<mir::ResolvedExternalRefBinding>& bindings,
-    const mir::ConstructionInput& construction) -> std::optional<uint32_t> {
-  if (ref_id.value >= bindings.size()) return std::nullopt;
-  const auto& binding = bindings[ref_id.value];
-  if (binding.IsPackageOrGlobal()) {
-    return binding.GlobalSlotId();
-  }
-  if (binding.target_object.value >= construction.objects.size()) {
-    return std::nullopt;
-  }
-  const auto& obj = construction.objects[binding.target_object.value];
-  return obj.design_state_base_slot + binding.target_local_slot.value;
-}
-
 auto BuildDesignGlobalBehavioralTriggerBitmap(
     std::span<const LayoutModulePlan> module_plans, const mir::Design& design,
     const mir::Arena& design_arena, const DesignLayout& design_layout,
-    const BodyBehavioralTriggerBitmaps& body_bitmaps,
-    const mir::ConstructionInput* construction) -> std::vector<bool> {
+    const BodyBehavioralTriggerBitmaps& body_bitmaps) -> std::vector<bool> {
   auto num_slots = design_layout.slots.size();
   std::vector<bool> bitmap(num_slots, false);
 
@@ -146,14 +127,10 @@ auto BuildDesignGlobalBehavioralTriggerBitmap(
         const auto* wait = std::get_if<mir::Wait>(&block.terminator.data);
         if (wait == nullptr) continue;
         for (const auto& trigger : wait->triggers) {
-          if (trigger.unresolved_external_ref.has_value() &&
-              construction != nullptr) {
-            auto slot = ResolveExternalRefToDesignGlobalSlot(
-                *trigger.unresolved_external_ref,
-                body.resolved_external_ref_bindings, *construction);
-            if (slot.has_value()) {
-              mark_global_slot(common::SlotId{*slot});
-            }
+          if (trigger.unresolved_external_ref.has_value()) {
+            // External-ref signal identity is per-instance. Skip in the
+            // compile-time behavioral dirty bitmap. Per-instance trigger
+            // resolution is a separate architectural change.
             continue;
           }
           if (trigger.signal.scope != mir::SignalRef::Scope::kDesignGlobal) {
@@ -226,15 +203,13 @@ void PopulateBodyBitmaps(
 
 void PopulateBehavioralTriggerContracts(
     std::span<const LayoutModulePlan> module_plans, const mir::Design& design,
-    const mir::Arena& design_arena, const mir::ConstructionInput* construction,
-    Layout& layout) {
+    const mir::Arena& design_arena, Layout& layout) {
   auto body_bitmaps =
       BuildBodyBehavioralDirtyTriggerBitmaps(module_plans, design);
   PopulateBodyBitmaps(body_bitmaps, layout);
   layout.slot_has_design_behavioral_trigger =
       BuildDesignGlobalBehavioralTriggerBitmap(
-          module_plans, design, design_arena, layout.design, body_bitmaps,
-          construction);
+          module_plans, design, design_arena, layout.design, body_bitmaps);
 }
 
 }  // namespace lyra::lowering::mir_to_llvm

--- a/src/lyra/llvm_backend/commit/commit_container.cpp
+++ b/src/lyra/llvm_backend/commit/commit_container.cpp
@@ -31,7 +31,17 @@ void StoreContainerToWriteTarget(
 
   auto emit_notifying_store = [&]() {
     auto* old_handle = builder.CreateLoad(ptr_ty, wt.ptr, "ctr.old");
-    if (wt.canonical_signal_id->IsLocal()) {
+    if (wt.canonical_signal_id->IsExtRef()) {
+      builder.CreateCall(
+          ctx.GetLyraStoreDynArrayGlobal(),
+          {ctx.GetEnginePointer(), wt.ptr, new_handle,
+           builder.getInt32(UINT32_MAX)});
+      builder.CreateCall(
+          ctx.GetLyraMarkDirtyExtRef(),
+          {ctx.GetEnginePointer(), ctx.GetInstancePointer(),
+           wt.canonical_signal_id->Emit(builder), builder.getInt32(0),
+           builder.getInt32(0)});
+    } else if (wt.canonical_signal_id->IsLocal()) {
       auto* inst_ptr =
           wt.canonical_signal_id->GetInstancePointer(ctx.GetInstancePointer());
       builder.CreateCall(

--- a/src/lyra/llvm_backend/commit/commit_notify.cpp
+++ b/src/lyra/llvm_backend/commit/commit_notify.cpp
@@ -133,7 +133,13 @@ void CommitNotifyAggregateIfDesignSlot(
   auto& builder = ctx.GetBuilder();
 
   auto emit_notify = [&]() {
-    if (wt.canonical_signal_id->IsLocal()) {
+    if (wt.canonical_signal_id->IsExtRef()) {
+      builder.CreateCall(
+          ctx.GetLyraMarkDirtyExtRef(),
+          {ctx.GetEnginePointer(), ctx.GetInstancePointer(),
+           wt.canonical_signal_id->Emit(builder), builder.getInt32(0),
+           builder.getInt32(0)});
+    } else if (wt.canonical_signal_id->IsLocal()) {
       builder.CreateCall(
           ctx.GetLyraNotifySignalLocal(),
           {ctx.GetEnginePointer(),

--- a/src/lyra/llvm_backend/commit/commit_string.cpp
+++ b/src/lyra/llvm_backend/commit/commit_string.cpp
@@ -71,7 +71,14 @@ void StoreStringToWriteTarget(
           "StoreStringToWriteTarget",
           "deferred notification not supported for string store path");
     }
-    if (wt.canonical_signal_id->IsLocal()) {
+    if (wt.canonical_signal_id->IsExtRef()) {
+      builder.CreateStore(new_val, wt.ptr);
+      builder.CreateCall(
+          ctx.GetLyraMarkDirtyExtRef(),
+          {ctx.GetEnginePointer(), ctx.GetInstancePointer(),
+           wt.canonical_signal_id->Emit(builder), builder.getInt32(0),
+           builder.getInt32(0)});
+    } else if (wt.canonical_signal_id->IsLocal()) {
       builder.CreateCall(
           ctx.GetLyraStoreStringLocal(),
           {ctx.GetEnginePointer(),

--- a/src/lyra/llvm_backend/context.cpp
+++ b/src/lyra/llvm_backend/context.cpp
@@ -490,23 +490,6 @@ auto Context::ResolveExternalRefRoot(mir::ExternalRefId ref_id)
   };
 }
 
-auto Context::NormalizeExternalRefSignalIdentity(
-    mir::ExternalRefId ref_id) const -> mir::SignalRef {
-  // Signal identity for external refs is per-instance (the design-global
-  // slot varies by instance position). The trigger/sensitivity system
-  // requires compile-time constant signal IDs, which cannot represent
-  // per-instance variation. This function is only reachable for processes
-  // with wait/sensitivity on external refs. Per-instance trigger descriptor
-  // resolution is a separate architectural cut.
-  (void)this;
-  throw common::InternalError(
-      "NormalizeExternalRefSignalIdentity",
-      std::format(
-          "external ref {} signal identity requires per-instance trigger "
-          "resolution (not yet implemented)",
-          ref_id.value));
-}
-
 auto Context::GetExternalRefType(mir::ExternalRefId ref_id) const -> TypeId {
   if (!ext_ref_env_.has_value() || ext_ref_env_->recipes == nullptr) {
     throw common::InternalError("GetExternalRefType", "env not installed");
@@ -548,22 +531,6 @@ auto Context::LoadExternalRef(mir::ExternalRefId ref_id)
 auto Context::EmitExternalRefSignalCoord(mir::ExternalRefId ref_id)
     -> SignalCoordExpr {
   return SignalCoordExpr::ExtRef(ref_id.value);
-}
-
-auto Context::GetExternalRefTargetLocalSlot(mir::ExternalRefId ref_id) const
-    -> uint32_t {
-  if (!ext_ref_env_.has_value() || ext_ref_env_->recipes == nullptr) {
-    throw common::InternalError(
-        "GetExternalRefTargetLocalSlot", "no external ref env");
-  }
-  const auto& recipes = *ext_ref_env_->recipes;
-  if (ref_id.value >= recipes.size()) {
-    throw common::InternalError(
-        "GetExternalRefTargetLocalSlot",
-        std::format(
-            "ref_id {} out of range ({})", ref_id.value, recipes.size()));
-  }
-  return recipes[ref_id.value].target.target_slot.value;
 }
 
 auto Context::EmitLoadExtRefBindingsPtr() -> llvm::Value* {

--- a/src/lyra/llvm_backend/context.cpp
+++ b/src/lyra/llvm_backend/context.cpp
@@ -472,13 +472,17 @@ auto Context::ResolveExternalRefRoot(mir::ExternalRefId ref_id)
   }
   TypeId type = recipes[ref_id.value].type;
 
-  // Load global_slot from per-instance ext_ref_slots table via instance_ptr.
-  auto* slots_ptr = EmitLoadExtRefSlotsPtr();
-  auto* slot_ptr = builder_.CreateGEP(
-      llvm::Type::getInt32Ty(*llvm_context_), slots_ptr,
-      builder_.getInt32(ref_id.value), "ext_ref_slot_ptr");
+  // Load storage_slot from per-instance ext_ref_bindings[ref_id].storage_slot.
+  auto* bindings_ptr = EmitLoadExtRefBindingsPtr();
+  auto* binding_ty = GetExtRefBindingType();
+  auto* binding_ptr = builder_.CreateGEP(
+      binding_ty, bindings_ptr, builder_.getInt32(ref_id.value),
+      "ext_ref_binding_ptr");
+  auto* storage_slot_ptr = builder_.CreateStructGEP(
+      binding_ty, binding_ptr, 0, "ext_ref_storage_slot_ptr");
   auto* global_slot = builder_.CreateLoad(
-      llvm::Type::getInt32Ty(*llvm_context_), slot_ptr, "ext_ref_global_slot");
+      llvm::Type::getInt32Ty(*llvm_context_), storage_slot_ptr,
+      "ext_ref_storage_slot");
 
   return ResolvedExternalRefRoot{
       .global_slot_value = global_slot,
@@ -543,21 +547,45 @@ auto Context::LoadExternalRef(mir::ExternalRefId ref_id)
 
 auto Context::EmitExternalRefSignalCoord(mir::ExternalRefId ref_id)
     -> SignalCoordExpr {
-  auto root = ResolveExternalRefRoot(ref_id);
-  return SignalCoordExpr::GlobalRuntime(root.global_slot_value);
+  return SignalCoordExpr::ExtRef(ref_id.value);
 }
 
-auto Context::EmitLoadExtRefSlotsPtr() -> llvm::Value* {
+auto Context::GetExternalRefTargetLocalSlot(mir::ExternalRefId ref_id) const
+    -> uint32_t {
+  if (!ext_ref_env_.has_value() || ext_ref_env_->recipes == nullptr) {
+    throw common::InternalError(
+        "GetExternalRefTargetLocalSlot", "no external ref env");
+  }
+  const auto& recipes = *ext_ref_env_->recipes;
+  if (ref_id.value >= recipes.size()) {
+    throw common::InternalError(
+        "GetExternalRefTargetLocalSlot",
+        std::format(
+            "ref_id {} out of range ({})", ref_id.value, recipes.size()));
+  }
+  return recipes[ref_id.value].target.target_slot.value;
+}
+
+auto Context::EmitLoadExtRefBindingsPtr() -> llvm::Value* {
   if (instance_ptr_ == nullptr) {
     throw common::InternalError(
-        "EmitLoadExtRefSlotsPtr", "instance_ptr not set");
+        "EmitLoadExtRefBindingsPtr", "instance_ptr not set");
   }
   using IF = lyra::runtime::RuntimeInstanceField;
   auto* ptr = builder_.CreateStructGEP(
       GetRuntimeInstanceType(), instance_ptr_,
-      static_cast<unsigned>(IF::kExtRefSlots), "ext_ref_slots_ptr");
+      static_cast<unsigned>(IF::kExtRefBindings), "ext_ref_bindings_field");
   return builder_.CreateLoad(
-      llvm::PointerType::getUnqual(*llvm_context_), ptr, "ext_ref_slots");
+      llvm::PointerType::getUnqual(*llvm_context_), ptr, "ext_ref_bindings");
+}
+
+auto Context::GetExtRefBindingType() -> llvm::StructType* {
+  if (ext_ref_binding_type_ == nullptr) {
+    auto* i32_ty = llvm::Type::getInt32Ty(*llvm_context_);
+    ext_ref_binding_type_ = llvm::StructType::get(
+        *llvm_context_, {i32_ty, i32_ty, i32_ty}, "ExtRefBinding");
+  }
+  return ext_ref_binding_type_;
 }
 
 auto Context::GetWriteDestPointer(const mir::WriteTarget& dest)

--- a/src/lyra/llvm_backend/context.cpp
+++ b/src/lyra/llvm_backend/context.cpp
@@ -452,129 +452,82 @@ auto Context::LookupPlace(mir::PlaceId place_id) const -> const mir::Place& {
   return (*arena_)[place_id];
 }
 
-// V3: Direct external-ref helpers -- consume resolved binding directly
-// for operand loads, type queries, signal coordinates, and write-path
-// root resolution. All external-ref resolution flows through
-// ResolveExternalRefRoot.
+// External-ref helpers. Recipes provide compile-time type info; actual
+// slot resolution uses per-instance data loaded from RuntimeInstance.
 
-auto Context::ResolveExternalRefRoot(mir::ExternalRefId ref_id) const
+auto Context::ResolveExternalRefRoot(mir::ExternalRefId ref_id)
     -> ResolvedExternalRefRoot {
-  if (!ext_ref_env_.has_value() || ext_ref_env_->bindings == nullptr) {
+  if (!ext_ref_env_.has_value() || ext_ref_env_->recipes == nullptr) {
     throw common::InternalError(
         "ResolveExternalRefRoot",
-        "env not installed -- kSpecializationLocal scope missing "
-        "SetExternalRefResolutionEnv");
-  }
-  const auto& bindings = *ext_ref_env_->bindings;
-  if (ref_id.value >= bindings.size()) {
-    throw common::InternalError(
-        "ResolveExternalRefRoot",
-        std::format(
-            "external ref {} out of range (bindings size {})", ref_id.value,
-            bindings.size()));
-  }
-  const auto& binding = bindings[ref_id.value];
-  if (ext_ref_env_->construction == nullptr) {
-    throw common::InternalError(
-        "ResolveExternalRefRoot", "construction not set in env");
-  }
-  const auto& objects = ext_ref_env_->construction->objects;
-  if (binding.target_object.value >= objects.size()) {
-    throw common::InternalError(
-        "ResolveExternalRefRoot",
-        std::format(
-            "target_object {} out of range (objects size {})",
-            binding.target_object.value, objects.size()));
-  }
-  const auto& obj = objects[binding.target_object.value];
-  if (binding.target_local_slot.value >= obj.slot_count) {
-    throw common::InternalError(
-        "ResolveExternalRefRoot",
-        std::format(
-            "target_local_slot {} out of range for object {} "
-            "(slot_count {})",
-            binding.target_local_slot.value, binding.target_object.value,
-            obj.slot_count));
-  }
-  uint32_t base = obj.design_state_base_slot;
-  uint32_t local = binding.target_local_slot.value;
-  if (local > UINT32_MAX - base) {
-    throw common::InternalError(
-        "ResolveExternalRefRoot",
-        std::format(
-            "design_state_base_slot {} + target_local_slot {} overflows "
-            "uint32_t",
-            base, local));
-  }
-  auto global_slot = base + local;
-  return ResolvedExternalRefRoot{
-      .global_slot = global_slot,
-      .type = binding.type,
-  };
-}
-
-auto Context::GetExternalRefBinding(mir::ExternalRefId ref_id) const
-    -> const mir::ResolvedExternalRefBinding& {
-  if (!ext_ref_env_.has_value() || ext_ref_env_->bindings == nullptr) {
-    throw common::InternalError(
-        "GetExternalRefBinding",
         "env not installed -- missing SetExternalRefResolutionEnv");
   }
-  const auto& bindings = *ext_ref_env_->bindings;
-  if (ref_id.value >= bindings.size()) {
+  const auto& recipes = *ext_ref_env_->recipes;
+  if (ref_id.value >= recipes.size()) {
     throw common::InternalError(
-        "GetExternalRefBinding",
+        "ResolveExternalRefRoot",
         std::format(
-            "external ref {} out of range (bindings size {})", ref_id.value,
-            bindings.size()));
+            "external ref {} out of range (recipes size {})", ref_id.value,
+            recipes.size()));
   }
-  return bindings[ref_id.value];
-}
+  TypeId type = recipes[ref_id.value].type;
 
-auto Context::GetConstruction() const -> const mir::ConstructionInput& {
-  if (!ext_ref_env_.has_value() || ext_ref_env_->construction == nullptr) {
-    throw common::InternalError(
-        "GetConstruction", "construction not set in env");
-  }
-  return *ext_ref_env_->construction;
+  // Load global_slot from per-instance ext_ref_slots table via instance_ptr.
+  auto* slots_ptr = EmitLoadExtRefSlotsPtr();
+  auto* slot_ptr = builder_.CreateGEP(
+      llvm::Type::getInt32Ty(*llvm_context_), slots_ptr,
+      builder_.getInt32(ref_id.value), "ext_ref_slot_ptr");
+  auto* global_slot = builder_.CreateLoad(
+      llvm::Type::getInt32Ty(*llvm_context_), slot_ptr, "ext_ref_global_slot");
+
+  return ResolvedExternalRefRoot{
+      .global_slot_value = global_slot,
+      .type = type,
+  };
 }
 
 auto Context::NormalizeExternalRefSignalIdentity(
     mir::ExternalRefId ref_id) const -> mir::SignalRef {
-  const auto& binding = GetExternalRefBinding(ref_id);
-  if (binding.IsPackageOrGlobal()) {
-    return mir::SignalRef{
-        .scope = mir::SignalRef::Scope::kDesignGlobal,
-        .id = binding.GlobalSlotId()};
-  }
-  const auto& objects = GetConstruction().objects;
-  if (binding.target_object.value >= objects.size()) {
-    throw common::InternalError(
-        "NormalizeExternalRefSignalIdentity",
-        std::format(
-            "target_object {} out of range (objects size {})",
-            binding.target_object.value, objects.size()));
-  }
-  const auto& obj = objects[binding.target_object.value];
-  return mir::SignalRef{
-      .scope = mir::SignalRef::Scope::kDesignGlobal,
-      .id = obj.design_state_base_slot + binding.target_local_slot.value};
+  // Signal identity for external refs is per-instance (the design-global
+  // slot varies by instance position). The trigger/sensitivity system
+  // requires compile-time constant signal IDs, which cannot represent
+  // per-instance variation. This function is only reachable for processes
+  // with wait/sensitivity on external refs. Per-instance trigger descriptor
+  // resolution is a separate architectural cut.
+  (void)this;
+  throw common::InternalError(
+      "NormalizeExternalRefSignalIdentity",
+      std::format(
+          "external ref {} signal identity requires per-instance trigger "
+          "resolution (not yet implemented)",
+          ref_id.value));
 }
 
 auto Context::GetExternalRefType(mir::ExternalRefId ref_id) const -> TypeId {
-  return ResolveExternalRefRoot(ref_id).type;
+  if (!ext_ref_env_.has_value() || ext_ref_env_->recipes == nullptr) {
+    throw common::InternalError("GetExternalRefType", "env not installed");
+  }
+  const auto& recipes = *ext_ref_env_->recipes;
+  if (ref_id.value >= recipes.size()) {
+    throw common::InternalError(
+        "GetExternalRefType",
+        std::format(
+            "external ref {} out of range (recipes size {})", ref_id.value,
+            recipes.size()));
+  }
+  return recipes[ref_id.value].type;
 }
 
 auto Context::EmitExternalRefAddress(mir::ExternalRefId ref_id)
     -> llvm::Value* {
   auto root = ResolveExternalRefRoot(ref_id);
-  return GetDesignGlobalSlotPointer(root.global_slot);
+  return GetDesignGlobalSlotPointer(root.global_slot_value);
 }
 
 auto Context::LoadExternalRef(mir::ExternalRefId ref_id)
     -> Result<llvm::Value*> {
   auto root = ResolveExternalRefRoot(ref_id);
-  auto* ptr = GetDesignGlobalSlotPointer(root.global_slot);
+  auto* ptr = GetDesignGlobalSlotPointer(root.global_slot_value);
   const Type& type = types_[root.type];
 
   // Canonical 4-state load for design-global slots (same logic as
@@ -588,10 +541,23 @@ auto Context::LoadExternalRef(mir::ExternalRefId ref_id)
   return builder_.CreateLoad(llvm_type, ptr, "ext_ref_load");
 }
 
-auto Context::EmitExternalRefSignalCoord(mir::ExternalRefId ref_id) const
+auto Context::EmitExternalRefSignalCoord(mir::ExternalRefId ref_id)
     -> SignalCoordExpr {
   auto root = ResolveExternalRefRoot(ref_id);
-  return SignalCoordExpr::Global(root.global_slot);
+  return SignalCoordExpr::GlobalRuntime(root.global_slot_value);
+}
+
+auto Context::EmitLoadExtRefSlotsPtr() -> llvm::Value* {
+  if (instance_ptr_ == nullptr) {
+    throw common::InternalError(
+        "EmitLoadExtRefSlotsPtr", "instance_ptr not set");
+  }
+  using IF = lyra::runtime::RuntimeInstanceField;
+  auto* ptr = builder_.CreateStructGEP(
+      GetRuntimeInstanceType(), instance_ptr_,
+      static_cast<unsigned>(IF::kExtRefSlots), "ext_ref_slots_ptr");
+  return builder_.CreateLoad(
+      llvm::PointerType::getUnqual(*llvm_context_), ptr, "ext_ref_slots");
 }
 
 auto Context::GetWriteDestPointer(const mir::WriteTarget& dest)

--- a/src/lyra/llvm_backend/context_place.cpp
+++ b/src/lyra/llvm_backend/context_place.cpp
@@ -817,11 +817,11 @@ auto Context::RequiresBehavioralDirtyPropagation(
     bool behavioral = body_info.slot_has_behavioral_trigger[local_slot];
     if (behavioral) return true;
 
-    // Check design-global behavioral triggers projected from other bodies.
-    // Covers cross-body dependents like hierarchical sensitivity
-    // (e.g., always_ff @(posedge child.clk) in a parent module).
+    // Check design-global behavioral triggers for package/init signals.
+    // Body-local slots are projected to their representative design-global
+    // equivalent for this check.
     const auto& spec = *GetSpecSlotInfo();
-    auto global_slot = layout_.ResolveLegacyRepresentativeDesignSlot(
+    auto global_slot = layout_.ResolveRepresentativeDesignSlot(
         spec.body_realization_info_index, local_slot);
     if (global_slot < layout_.slot_has_design_behavioral_trigger.size()) {
       if (layout_.slot_has_design_behavioral_trigger[global_slot]) return true;
@@ -895,7 +895,7 @@ auto Context::GetLegacyRuntimeSignalSlot(const mir::SignalRef& sig) const
     }
     const auto& spec = *GetSpecSlotInfo();
     auto local_slot = static_cast<uint32_t>(sig.id);
-    owner_slot = layout_.ResolveLegacyRepresentativeDesignSlot(
+    owner_slot = layout_.ResolveRepresentativeDesignSlot(
         spec.body_realization_info_index, local_slot);
   } else if (sig.scope == mir::SignalRef::Scope::kDesignGlobal) {
     owner_slot = static_cast<uint32_t>(sig.id);

--- a/src/lyra/llvm_backend/context_place.cpp
+++ b/src/lyra/llvm_backend/context_place.cpp
@@ -257,15 +257,10 @@ auto Context::GetWriteTarget(mir::PlaceId place_id) -> Result<WriteTarget> {
 auto Context::GetWriteTarget(mir::ExternalRefId ref_id) -> Result<WriteTarget> {
   auto root = ResolveExternalRefRoot(ref_id);
   auto* ptr = GetDesignGlobalSlotPointer(root.global_slot_value);
-  // External-ref signal identity is per-instance. The global_slot is
-  // already runtime-loaded from instance_ptr->ext_ref_slots[ref_id].
-  // Use GlobalRuntime to carry the runtime value through the commit layer.
-  auto signal_coord = SignalCoordExpr::GlobalRuntime(root.global_slot_value);
-  // External ref targets always require static dirty propagation.
-  // They are cross-instance writes that must always notify; the
-  // design-level contract bitmaps may not cover instance-owned slots.
-  // Since static propagation is unconditional, mutation_signal is not
-  // consulted (no trace-observation gating needed).
+  // External-ref dirty notification resolves through per-instance
+  // target tables to the target instance's local signal. Storage
+  // addressing still uses the design-global slot pointer.
+  auto signal_coord = SignalCoordExpr::ExtRef(ref_id.value);
   return WriteTarget{
       .ptr = ptr,
       .canonical_signal_id = signal_coord,

--- a/src/lyra/llvm_backend/context_place.cpp
+++ b/src/lyra/llvm_backend/context_place.cpp
@@ -256,21 +256,22 @@ auto Context::GetWriteTarget(mir::PlaceId place_id) -> Result<WriteTarget> {
 
 auto Context::GetWriteTarget(mir::ExternalRefId ref_id) -> Result<WriteTarget> {
   auto root = ResolveExternalRefRoot(ref_id);
-  auto* ptr = GetDesignGlobalSlotPointer(root.global_slot);
-  // Derive mutation identity from the same binding-based normalization
-  // used by sensitivity/trigger transport. EmitSignalCoord reclassifies
-  // instance-owned signals to local runtime identity.
-  auto mutation_sig = NormalizeExternalRefSignalIdentity(ref_id);
-  auto signal_coord = EmitSignalCoord(mutation_sig);
+  auto* ptr = GetDesignGlobalSlotPointer(root.global_slot_value);
+  // External-ref signal identity is per-instance. The global_slot is
+  // already runtime-loaded from instance_ptr->ext_ref_slots[ref_id].
+  // Use GlobalRuntime to carry the runtime value through the commit layer.
+  auto signal_coord = SignalCoordExpr::GlobalRuntime(root.global_slot_value);
   // External ref targets always require static dirty propagation.
   // They are cross-instance writes that must always notify; the
   // design-level contract bitmaps may not cover instance-owned slots.
+  // Since static propagation is unconditional, mutation_signal is not
+  // consulted (no trace-observation gating needed).
   return WriteTarget{
       .ptr = ptr,
       .canonical_signal_id = signal_coord,
       .dirty_off = 0,
       .dirty_size = 0,
-      .mutation_signal = mutation_sig,
+      .mutation_signal = std::nullopt,
       .requires_static_dirty_propagation = true,
   };
 }
@@ -514,6 +515,19 @@ auto Context::GetDesignGlobalSlotPointer(uint32_t global_slot_id)
   return builder_.CreateGEP(
       llvm::Type::getInt8Ty(*llvm_context_), design_ptr_,
       builder_.getInt64(offset), "design_global_slot_ptr");
+}
+
+auto Context::GetDesignGlobalSlotPointer(llvm::Value* global_slot_id)
+    -> llvm::Value* {
+  // Runtime-loaded slot ID: must use engine resolver (simulation context).
+  if (engine_ptr_ != nullptr) {
+    return builder_.CreateCall(
+        GetLyraResolveSlotPtr(), {engine_ptr_, global_slot_id},
+        "resolved_slot_ptr");
+  }
+  throw common::InternalError(
+      "GetDesignGlobalSlotPointer(Value*)",
+      "runtime-loaded slot ID requires engine context");
 }
 
 auto Context::GetSlotRootPointer(const mir::PlaceRoot& root) -> llvm::Value* {

--- a/src/lyra/llvm_backend/context_runtime.cpp
+++ b/src/lyra/llvm_backend/context_runtime.cpp
@@ -615,6 +615,21 @@ auto Context::GetLyraMarkDirtyLocal() -> llvm::Function* {
   return lyra_mark_dirty_local_;
 }
 
+auto Context::GetLyraMarkDirtyExtRef() -> llvm::Function* {
+  if (lyra_mark_dirty_ext_ref_ == nullptr) {
+    auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
+    auto* i32_ty = llvm::Type::getInt32Ty(*llvm_context_);
+    // (eng, inst, ref_id, off, size)
+    auto* fn_type = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*llvm_context_),
+        {ptr_ty, ptr_ty, i32_ty, i32_ty, i32_ty}, false);
+    lyra_mark_dirty_ext_ref_ = llvm::Function::Create(
+        fn_type, llvm::Function::ExternalLinkage, "LyraMarkDirtyExtRef",
+        llvm_module_.get());
+  }
+  return lyra_mark_dirty_ext_ref_;
+}
+
 auto Context::GetLyraMarkDirtyGlobal() -> llvm::Function* {
   if (lyra_mark_dirty_global_ == nullptr) {
     auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
@@ -748,6 +763,39 @@ auto Context::GetLyraScheduleNbaCanonicalPackedGlobal() -> llvm::Function* {
         "LyraScheduleNbaCanonicalPackedGlobal", llvm_module_.get());
   }
   return lyra_schedule_nba_canonical_packed_global_;
+}
+
+auto Context::GetLyraScheduleNbaExtRef() -> llvm::Function* {
+  if (lyra_schedule_nba_ext_ref_ == nullptr) {
+    auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
+    auto* i32_ty = llvm::Type::getInt32Ty(*llvm_context_);
+    // (eng, inst, ref_id, wp, nb, vp, mp, bsz)
+    auto* fn_type = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*llvm_context_),
+        {ptr_ty, ptr_ty, i32_ty, ptr_ty, ptr_ty, ptr_ty, ptr_ty, i32_ty},
+        false);
+    lyra_schedule_nba_ext_ref_ = llvm::Function::Create(
+        fn_type, llvm::Function::ExternalLinkage, "LyraScheduleNbaExtRef",
+        llvm_module_.get());
+  }
+  return lyra_schedule_nba_ext_ref_;
+}
+
+auto Context::GetLyraScheduleNbaCanonicalPackedExtRef() -> llvm::Function* {
+  if (lyra_schedule_nba_canonical_packed_ext_ref_ == nullptr) {
+    auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
+    auto* i32_ty = llvm::Type::getInt32Ty(*llvm_context_);
+    // (eng, inst, ref_id, wp, nb, vp, up, rsz, sro)
+    auto* fn_type = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*llvm_context_),
+        {ptr_ty, ptr_ty, i32_ty, ptr_ty, ptr_ty, ptr_ty, ptr_ty, i32_ty,
+         i32_ty},
+        false);
+    lyra_schedule_nba_canonical_packed_ext_ref_ = llvm::Function::Create(
+        fn_type, llvm::Function::ExternalLinkage,
+        "LyraScheduleNbaCanonicalPackedExtRef", llvm_module_.get());
+  }
+  return lyra_schedule_nba_canonical_packed_ext_ref_;
 }
 
 auto Context::GetLyraIsTraceObservedLocal() -> llvm::Function* {

--- a/src/lyra/llvm_backend/emit_design_main.cpp
+++ b/src/lyra/llvm_backend/emit_design_main.cpp
@@ -2221,6 +2221,7 @@ struct ConstructorRuntimeFuncs {
   llvm::Function* result_get_instance_bundles;
   llvm::Function* result_get_instance_bundle_count;
   llvm::Function* result_destroy;
+  llvm::Function* result_set_ext_ref_slots;
 };
 
 auto DeclareConstructorRuntimeFuncs(Context& context)
@@ -2301,6 +2302,9 @@ auto DeclareConstructorRuntimeFuncs(Context& context)
           "LyraConstructionResultGetInstanceBundleCount", i32_ty, {ptr_ty}),
       .result_destroy =
           declare("LyraConstructionResultDestroy", void_ty, {ptr_ty}),
+      .result_set_ext_ref_slots = declare(
+          "LyraConstructionResultSetExtRefSlots", void_ty,
+          {ptr_ty, ptr_ty, i32_ty, ptr_ty, i32_ty}),
   };
 }
 
@@ -2423,6 +2427,27 @@ auto EmitConstructorFunction(
 
   // Finalize: returns a single constructor-owned result handle.
   auto* result = builder.CreateCall(rt.finalize, {ctor}, "ctor_result");
+
+  // Set per-instance external-ref resolved global slot table pointers.
+  if (!prog.ext_ref_pool.empty()) {
+    auto* ext_ref_pool_ptr = new llvm::GlobalVariable(
+        context.GetModule(),
+        llvm::ArrayType::get(i32_ty, prog.ext_ref_pool.size()), true,
+        llvm::GlobalValue::PrivateLinkage,
+        llvm::ConstantDataArray::get(ctx, prog.ext_ref_pool),
+        "__lyra_ext_ref_pool");
+    auto* ext_ref_offsets_ptr = new llvm::GlobalVariable(
+        context.GetModule(),
+        llvm::ArrayType::get(i32_ty, prog.ext_ref_offsets.size()), true,
+        llvm::GlobalValue::PrivateLinkage,
+        llvm::ConstantDataArray::get(ctx, prog.ext_ref_offsets),
+        "__lyra_ext_ref_offsets");
+    auto pool_size = static_cast<uint32_t>(prog.ext_ref_pool.size());
+    builder.CreateCall(
+        rt.result_set_ext_ref_slots,
+        {result, ext_ref_pool_ptr, llvm::ConstantInt::get(i32_ty, pool_size),
+         ext_ref_offsets_ptr, llvm::ConstantInt::get(i32_ty, entry_count)});
+  }
 
   // Extract states, counts, and process metadata from the result.
   auto* states_array =

--- a/src/lyra/llvm_backend/emit_design_main.cpp
+++ b/src/lyra/llvm_backend/emit_design_main.cpp
@@ -2221,7 +2221,7 @@ struct ConstructorRuntimeFuncs {
   llvm::Function* result_get_instance_bundles;
   llvm::Function* result_get_instance_bundle_count;
   llvm::Function* result_destroy;
-  llvm::Function* result_set_ext_ref_slots;
+  llvm::Function* result_set_ext_ref_bindings;
 };
 
 auto DeclareConstructorRuntimeFuncs(Context& context)
@@ -2302,9 +2302,9 @@ auto DeclareConstructorRuntimeFuncs(Context& context)
           "LyraConstructionResultGetInstanceBundleCount", i32_ty, {ptr_ty}),
       .result_destroy =
           declare("LyraConstructionResultDestroy", void_ty, {ptr_ty}),
-      .result_set_ext_ref_slots = declare(
-          "LyraConstructionResultSetExtRefSlots", void_ty,
-          {ptr_ty, ptr_ty, i32_ty, ptr_ty, i32_ty}),
+      .result_set_ext_ref_bindings = declare(
+          "LyraConstructionResultSetExtRefBindings", void_ty,
+          {ptr_ty, ptr_ty, i32_ty, ptr_ty, ptr_ty, i32_ty}),
   };
 }
 
@@ -2428,25 +2428,47 @@ auto EmitConstructorFunction(
   // Finalize: returns a single constructor-owned result handle.
   auto* result = builder.CreateCall(rt.finalize, {ctor}, "ctor_result");
 
-  // Set per-instance external-ref resolved global slot table pointers.
-  if (!prog.ext_ref_pool.empty()) {
-    auto* ext_ref_pool_ptr = new llvm::GlobalVariable(
-        context.GetModule(),
-        llvm::ArrayType::get(i32_ty, prog.ext_ref_pool.size()), true,
-        llvm::GlobalValue::PrivateLinkage,
-        llvm::ConstantDataArray::get(ctx, prog.ext_ref_pool),
-        "__lyra_ext_ref_pool");
-    auto* ext_ref_offsets_ptr = new llvm::GlobalVariable(
-        context.GetModule(),
-        llvm::ArrayType::get(i32_ty, prog.ext_ref_offsets.size()), true,
-        llvm::GlobalValue::PrivateLinkage,
-        llvm::ConstantDataArray::get(ctx, prog.ext_ref_offsets),
-        "__lyra_ext_ref_offsets");
-    auto pool_size = static_cast<uint32_t>(prog.ext_ref_pool.size());
+  // Set per-instance ext-ref binding records.
+  if (!prog.ext_ref_binding_pool.empty()) {
+    auto& mod = context.GetModule();
+    // Binding struct type: {i32 storage_slot, i32 target_instance_id,
+    //                       i32 target_local_signal}
+    auto* binding_ty = llvm::StructType::get(ctx, {i32_ty, i32_ty, i32_ty});
+
+    // Encode each binding record as a constant struct.
+    std::vector<llvm::Constant*> binding_constants;
+    binding_constants.reserve(prog.ext_ref_binding_pool.size());
+    for (const auto& b : prog.ext_ref_binding_pool) {
+      binding_constants.push_back(
+          llvm::ConstantStruct::get(
+              binding_ty,
+              {llvm::ConstantInt::get(i32_ty, b.storage_slot.value),
+               llvm::ConstantInt::get(i32_ty, b.target_instance_id),
+               llvm::ConstantInt::get(i32_ty, b.target_local_signal.value)}));
+    }
+    auto pool_count = static_cast<uint32_t>(prog.ext_ref_binding_pool.size());
+    auto* pool_array_ty = llvm::ArrayType::get(binding_ty, pool_count);
+    auto* pool_global = new llvm::GlobalVariable(
+        mod, pool_array_ty, true, llvm::GlobalValue::PrivateLinkage,
+        llvm::ConstantArray::get(pool_array_ty, binding_constants),
+        "__lyra_ext_ref_bindings");
+
+    auto* offsets_global = new llvm::GlobalVariable(
+        mod, llvm::ArrayType::get(i32_ty, prog.ext_ref_binding_offsets.size()),
+        true, llvm::GlobalValue::PrivateLinkage,
+        llvm::ConstantDataArray::get(ctx, prog.ext_ref_binding_offsets),
+        "__lyra_ext_ref_binding_offsets");
+    auto* counts_global = new llvm::GlobalVariable(
+        mod, llvm::ArrayType::get(i32_ty, prog.ext_ref_binding_counts.size()),
+        true, llvm::GlobalValue::PrivateLinkage,
+        llvm::ConstantDataArray::get(ctx, prog.ext_ref_binding_counts),
+        "__lyra_ext_ref_binding_counts");
+
     builder.CreateCall(
-        rt.result_set_ext_ref_slots,
-        {result, ext_ref_pool_ptr, llvm::ConstantInt::get(i32_ty, pool_size),
-         ext_ref_offsets_ptr, llvm::ConstantInt::get(i32_ty, entry_count)});
+        rt.result_set_ext_ref_bindings,
+        {result, pool_global, llvm::ConstantInt::get(i32_ty, pool_count),
+         offsets_global, counts_global,
+         llvm::ConstantInt::get(i32_ty, entry_count)});
   }
 
   // Extract states, counts, and process metadata from the result.

--- a/src/lyra/llvm_backend/instruction/deferred_assign.cpp
+++ b/src/lyra/llvm_backend/instruction/deferred_assign.cpp
@@ -189,7 +189,13 @@ auto EmitDeferredStoreCore(
                     shape.storage_ty));
 
   auto* i32_ty = llvm::Type::getInt32Ty(llvm_ctx);
-  if (signal_id.IsLocal()) {
+  if (signal_id.IsExtRef()) {
+    builder.CreateCall(
+        context.GetLyraScheduleNbaExtRef(),
+        {context.GetEnginePointer(), context.GetInstancePointer(),
+         signal_id.Emit(builder), write_ptr, notify_base_ptr, val_alloca,
+         null_ptr, llvm::ConstantInt::get(i32_ty, byte_size)});
+  } else if (signal_id.IsLocal()) {
     builder.CreateCall(
         context.GetLyraScheduleNbaLocal(),
         {context.GetEnginePointer(),

--- a/src/lyra/llvm_backend/layout/layout.cpp
+++ b/src/lyra/llvm_backend/layout/layout.cpp
@@ -967,11 +967,11 @@ auto BuildRuntimeInstanceType(
   auto* ptr_ty = llvm::PointerType::getUnqual(ctx);
   auto* i32_ty = llvm::Type::getInt32Ty(ctx);
   // { instance_id, body, storage, path_c_str, owner_ordinal,
-  //   module_proc_base, num_module_processes }
+  //   module_proc_base, num_module_processes, ext_ref_slots }
   using F = lyra::runtime::RuntimeInstanceField;
   constexpr auto kFieldCount = static_cast<size_t>(F::kFieldCount);
   std::array<llvm::Type*, kFieldCount> fields = {
-      i32_ty, ptr_ty, storage_type, ptr_ty, i32_ty, i32_ty, i32_ty};
+      i32_ty, ptr_ty, storage_type, ptr_ty, i32_ty, i32_ty, i32_ty, ptr_ty};
   return llvm::StructType::create(ctx, fields, "RuntimeInstance");
 }
 

--- a/src/lyra/llvm_backend/layout/layout.cpp
+++ b/src/lyra/llvm_backend/layout/layout.cpp
@@ -967,11 +967,13 @@ auto BuildRuntimeInstanceType(
   auto* ptr_ty = llvm::PointerType::getUnqual(ctx);
   auto* i32_ty = llvm::Type::getInt32Ty(ctx);
   // { instance_id, body, storage, path_c_str, owner_ordinal,
-  //   module_proc_base, num_module_processes, ext_ref_slots }
+  //   module_proc_base, num_module_processes, ext_ref_bindings,
+  //   ext_ref_binding_count }
   using F = lyra::runtime::RuntimeInstanceField;
   constexpr auto kFieldCount = static_cast<size_t>(F::kFieldCount);
-  std::array<llvm::Type*, kFieldCount> fields = {
-      i32_ty, ptr_ty, storage_type, ptr_ty, i32_ty, i32_ty, i32_ty, ptr_ty};
+  std::array<llvm::Type*, kFieldCount> fields = {i32_ty, ptr_ty, storage_type,
+                                                 ptr_ty, i32_ty, i32_ty,
+                                                 i32_ty, ptr_ty, i32_ty};
   return llvm::StructType::create(ctx, fields, "RuntimeInstance");
 }
 

--- a/src/lyra/llvm_backend/lower.cpp
+++ b/src/lyra/llvm_backend/lower.cpp
@@ -256,8 +256,7 @@ auto CompileDesignProcesses(const LoweringInput& input)
       input, topology, connections, *llvm_ctx, module->getDataLayout());
 
   PopulateBehavioralTriggerContracts(
-      topology.module_plans, *input.design, *input.mir_arena,
-      input.construction, *layout);
+      topology.module_plans, *input.design, *input.mir_arena, *layout);
 
   auto context = std::make_unique<Context>(
       *input.mir_arena, *input.type_arena, *layout, std::move(llvm_ctx),

--- a/src/lyra/llvm_backend/lower.cpp
+++ b/src/lyra/llvm_backend/lower.cpp
@@ -256,7 +256,8 @@ auto CompileDesignProcesses(const LoweringInput& input)
       input, topology, connections, *llvm_ctx, module->getDataLayout());
 
   PopulateBehavioralTriggerContracts(
-      topology.module_plans, *input.design, *input.mir_arena, *layout);
+      topology.module_plans, *input.design, *input.mir_arena,
+      *input.construction, *layout);
 
   auto context = std::make_unique<Context>(
       *input.mir_arena, *input.type_arena, *layout, std::move(llvm_ctx),

--- a/src/lyra/llvm_backend/packed_storage_view.cpp
+++ b/src/lyra/llvm_backend/packed_storage_view.cpp
@@ -803,7 +803,13 @@ void EmitPackedStoreNotification(
     builder.CreateCondBr(should_mark, dirty_bb, done_bb);
 
     builder.SetInsertPoint(dirty_bb);
-    if (policy.signal_id->IsLocal()) {
+    if (policy.signal_id->IsExtRef()) {
+      builder.CreateCall(
+          ctx.GetLyraMarkDirtyExtRef(),
+          {policy.engine_ptr, ctx.GetInstancePointer(),
+           policy.signal_id->Emit(builder), dirty_range.byte_offset,
+           dirty_range.byte_size});
+    } else if (policy.signal_id->IsLocal()) {
       builder.CreateCall(
           ctx.GetLyraMarkDirtyLocal(),
           {policy.engine_ptr,
@@ -982,7 +988,15 @@ void EmitNarrow4StateNbaCall(
   auto* unk_alloca = builder.CreateAlloca(buf_ty, nullptr, "nba.unk.a");
   EncodePlaneValueToByteBuffer(builder, llvm_ctx, unk_alloca, 0, unk_store);
 
-  if (policy.signal_id.IsLocal()) {
+  if (policy.signal_id.IsExtRef()) {
+    builder.CreateCall(
+        ctx.GetLyraScheduleNbaCanonicalPackedExtRef(),
+        {policy.engine_ptr, ctx.GetInstancePointer(),
+         policy.signal_id.Emit(builder), write_ptr, policy.notify_base_ptr,
+         val_alloca, unk_alloca, llvm::ConstantInt::get(i32_ty, narrow_bytes),
+         llvm::ConstantInt::get(
+             i32_ty, access.storage.unk_plane_offset_bytes)});
+  } else if (policy.signal_id.IsLocal()) {
     builder.CreateCall(
         ctx.GetLyraScheduleNbaCanonicalPackedLocal(),
         {policy.engine_ptr,
@@ -1420,7 +1434,24 @@ void EmitGuardedLyraStorePacked(
   auto* i32_ty = llvm::Type::getInt32Ty(llvm_ctx);
 
   auto emit_call = [&]() {
-    if (policy.signal_id->IsLocal()) {
+    if (policy.signal_id->IsExtRef()) {
+      // External-ref: store directly, then notify via ext-ref resolution.
+      builder.CreateCall(
+          ctx.GetLyraStorePackedGlobal(),
+          {policy.engine_ptr, dst_ptr, src_ptr,
+           llvm::ConstantInt::get(i32_ty, byte_size),
+           // Use a sentinel global_slot=UINT32_MAX to suppress global dirty
+           // mark. The actual dirty notification comes from MarkDirtyExtRef
+           // below.
+           llvm::ConstantInt::get(i32_ty, UINT32_MAX),
+           llvm::ConstantInt::get(i32_ty, 0),
+           llvm::ConstantInt::get(i32_ty, 0)});
+      builder.CreateCall(
+          ctx.GetLyraMarkDirtyExtRef(),
+          {policy.engine_ptr, ctx.GetInstancePointer(),
+           policy.signal_id->Emit(builder), llvm::ConstantInt::get(i32_ty, 0),
+           llvm::ConstantInt::get(i32_ty, 0)});
+    } else if (policy.signal_id->IsLocal()) {
       builder.CreateCall(
           ctx.GetLyraStorePackedLocal(),
           {policy.engine_ptr,

--- a/src/lyra/llvm_backend/process.cpp
+++ b/src/lyra/llvm_backend/process.cpp
@@ -1348,15 +1348,16 @@ auto EmitLateBoundData(
     builder.CreateStore(
         llvm::ConstantInt::get(i32_ty, container_elem_stride), f8);
 
-    // Normalize pending external refs for this late-bound entry.
-    // Build a lookup from op_index -> resolved SignalRef.
+    // Late-bound external-ref index plan resolution is not yet implemented.
+    // External refs in late-bound triggers require per-instance resolution
+    // through the binding record, which is a separate feature.
+    if (!lb.pending_external_refs.empty()) {
+      throw common::InternalError(
+          "EmitLateBoundData",
+          "late-bound triggers with external refs not yet supported");
+    }
     std::unordered_map<uint32_t, mir::SignalRef> resolved_ext_ops;
     std::unordered_map<uint32_t, mir::SignalRef> resolved_ext_deps;
-    for (const auto& pending : lb.pending_external_refs) {
-      auto sig = context.NormalizeExternalRefSignalIdentity(pending.ref_id);
-      resolved_ext_ops[pending.op_index] = sig;
-      resolved_ext_deps[pending.dep_index] = sig;
-    }
 
     // Fill plan ops. Module-local reads emit body-local signal_id with
     // kIndexPlanLocalSignal flag; runtime resolves via the instance.

--- a/src/lyra/llvm_backend/process.cpp
+++ b/src/lyra/llvm_backend/process.cpp
@@ -77,10 +77,6 @@
 
 namespace lyra::lowering::mir_to_llvm {
 
-// Forward declaration for ExtractProcessTriggerEntry.
-auto ExtractProcessTriggerEntry(Context& context, const mir::Process& process)
-    -> std::optional<ProcessTriggerEntry>;
-
 namespace {
 
 // Validate that a process meets the init execution contract:
@@ -1056,46 +1052,54 @@ auto TriggerKindFromEdge(common::EdgeKind edge) -> runtime::TriggerInstallKind {
 void FillTriggerArray(
     Context& context, llvm::Value* base_ptr, llvm::Type* trigger_type,
     llvm::Type* array_type, const std::vector<mir::WaitTrigger>& triggers) {
-  // Normalize unresolved external ref triggers to topology-resolved identity.
-  auto resolved_triggers = triggers;
-  for (auto& trigger : resolved_triggers) {
-    if (trigger.unresolved_external_ref.has_value()) {
-      trigger.signal = context.NormalizeExternalRefSignalIdentity(
-          *trigger.unresolved_external_ref);
-      trigger.unresolved_external_ref = std::nullopt;
-    }
-  }
-
   auto& builder = context.GetBuilder();
   auto& llvm_ctx = context.GetLlvmContext();
   auto* i8_ty = llvm::Type::getInt8Ty(llvm_ctx);
   auto* i32_ty = llvm::Type::getInt32Ty(llvm_ctx);
 
-  for (uint32_t i = 0; i < resolved_triggers.size(); ++i) {
+  for (uint32_t i = 0; i < triggers.size(); ++i) {
     auto* elem_ptr = builder.CreateConstGEP2_32(array_type, base_ptr, 0, i);
 
     // Write signal_id (field 0).
     // R5: local signals emit body-local LocalSignalId directly (no flat
     // base addition). Global signals emit GlobalSignalId. The domain
     // is recorded in the flags field (kTriggerLocalSignal).
+    // External-ref triggers emit cross-instance local identity: the
+    // target's local signal id (compile-time constant from recipe).
     auto* signal_ptr = builder.CreateStructGEP(trigger_type, elem_ptr, 0);
-    auto signal_expr = context.EmitSignalCoord(resolved_triggers[i].signal);
-    bool is_local_signal = signal_expr.IsLocal();
-    builder.CreateStore(signal_expr.Emit(builder), signal_ptr);
+    bool is_ext_ref = triggers[i].unresolved_external_ref.has_value();
+    SignalCoordExpr signal_expr =
+        is_ext_ref
+            ? SignalCoordExpr::Local(0)  // placeholder, overwritten below
+            : context.EmitSignalCoord(triggers[i].signal);
+    bool is_local_signal = is_ext_ref || signal_expr.IsLocal();
+    if (is_ext_ref) {
+      // External-ref trigger: load target local signal from binding record.
+      auto ref_id = *triggers[i].unresolved_external_ref;
+      auto* binding_ty = context.GetExtRefBindingType();
+      auto* bindings_ptr = context.EmitLoadExtRefBindingsPtr();
+      auto* binding_ptr = builder.CreateGEP(
+          binding_ty, bindings_ptr, builder.getInt32(ref_id.value),
+          "ext_ref_binding_sig");
+      auto* local_ptr = builder.CreateStructGEP(
+          binding_ty, binding_ptr, 2, "binding_local_sig");
+      auto* local_val = builder.CreateLoad(i32_ty, local_ptr, "ext_ref_local");
+      builder.CreateStore(local_val, signal_ptr);
+    } else {
+      builder.CreateStore(signal_expr.Emit(builder), signal_ptr);
+    }
 
     // Write edge (field 1)
     auto* edge_ptr = builder.CreateStructGEP(trigger_type, elem_ptr, 1);
     builder.CreateStore(
-        llvm::ConstantInt::get(
-            i8_ty, static_cast<uint8_t>(resolved_triggers[i].edge)),
+        llvm::ConstantInt::get(i8_ty, static_cast<uint8_t>(triggers[i].edge)),
         edge_ptr);
 
     // Write kind (field 3) -- determined by trigger classification.
-    bool is_container = resolved_triggers[i].late_bound &&
-                        resolved_triggers[i].late_bound->is_container;
-    auto install_kind = is_container
-                            ? runtime::TriggerInstallKind::kContainer
-                            : TriggerKindFromEdge(resolved_triggers[i].edge);
+    bool is_container =
+        triggers[i].late_bound && triggers[i].late_bound->is_container;
+    auto install_kind = is_container ? runtime::TriggerInstallKind::kContainer
+                                     : TriggerKindFromEdge(triggers[i].edge);
     auto* kind_ptr = builder.CreateStructGEP(trigger_type, elem_ptr, 3);
     builder.CreateStore(
         llvm::ConstantInt::get(i8_ty, static_cast<uint8_t>(install_kind)),
@@ -1104,28 +1108,24 @@ void FillTriggerArray(
     if (is_container) {
       // Container element: emit dynamic container target.
       // container_elem_stride and flags are set by EmitDynamicContainerTarget.
-      EmitDynamicContainerTarget(
-          context, elem_ptr, trigger_type, resolved_triggers[i]);
-    } else if (
-        resolved_triggers[i].late_bound &&
-        resolved_triggers[i].late_bound->element_type) {
+      EmitDynamicContainerTarget(context, elem_ptr, trigger_type, triggers[i]);
+    } else if (triggers[i].late_bound && triggers[i].late_bound->element_type) {
       // Dynamic unpacked array element.
       // container_elem_stride = 0 (non-container), flags set by Emit*.
       auto* stride_ptr = builder.CreateStructGEP(trigger_type, elem_ptr, 7);
       builder.CreateStore(llvm::ConstantInt::get(i32_ty, 0), stride_ptr);
       EmitDynamicUnpackedBitTarget(
-          context, elem_ptr, trigger_type, resolved_triggers[i]);
-    } else if (resolved_triggers[i].late_bound) {
+          context, elem_ptr, trigger_type, triggers[i]);
+    } else if (triggers[i].late_bound) {
       // Dynamic bit-select.
       // container_elem_stride = 0 (non-container), flags set by Emit*.
       auto* stride_ptr = builder.CreateStructGEP(trigger_type, elem_ptr, 7);
       builder.CreateStore(llvm::ConstantInt::get(i32_ty, 0), stride_ptr);
-      EmitDynamicBitTarget(
-          context, elem_ptr, trigger_type, resolved_triggers[i]);
+      EmitDynamicBitTarget(context, elem_ptr, trigger_type, triggers[i]);
     } else {
       // Static path: resolve observation range at compile time.
       // Always active, container_elem_stride = 0.
-      auto range = ResolveObservationRange(context, resolved_triggers[i]);
+      auto range = ResolveObservationRange(context, triggers[i]);
       auto* bit_idx_ptr = builder.CreateStructGEP(trigger_type, elem_ptr, 2);
       builder.CreateStore(
           llvm::ConstantInt::get(i8_ty, range.bit_index), bit_idx_ptr);
@@ -1148,7 +1148,43 @@ void FillTriggerArray(
 
     // R5: set domain flags and cross-instance identity. Done after the
     // per-kind path because each path writes its own flags value.
-    if (is_local_signal) {
+    if (is_ext_ref) {
+      // External-ref trigger: cross-instance local identity.
+      // Load target identity from per-instance binding record.
+      auto ref_id = *triggers[i].unresolved_external_ref;
+      auto* binding_ty = context.GetExtRefBindingType();
+      auto* bindings_ptr = context.EmitLoadExtRefBindingsPtr();
+      auto* binding_ptr = builder.CreateGEP(
+          binding_ty, bindings_ptr, builder.getInt32(ref_id.value),
+          "ext_ref_binding_ptr");
+
+      uint8_t local_flags =
+          runtime::kTriggerLocalSignal | runtime::kTriggerCrossInstanceLocal;
+      auto* flags_ptr = builder.CreateStructGEP(trigger_type, elem_ptr, 4);
+      auto* current = builder.CreateLoad(i8_ty, flags_ptr, "trigger.flags");
+      auto* with_local = builder.CreateOr(
+          current, llvm::ConstantInt::get(i8_ty, local_flags),
+          "trigger.flags.local");
+      builder.CreateStore(with_local, flags_ptr);
+
+      // target_instance_id (field 8): from binding.target_instance_id (field
+      // 1).
+      auto* target_inst_id_ptr = builder.CreateStructGEP(
+          binding_ty, binding_ptr, 1, "binding_target_inst_id_ptr");
+      auto* target_inst_id = builder.CreateLoad(
+          i32_ty, target_inst_id_ptr, "ext_ref_target_inst_id");
+      auto* inst_id_ptr = builder.CreateStructGEP(trigger_type, elem_ptr, 8);
+      builder.CreateStore(target_inst_id, inst_id_ptr);
+
+      // target_local_signal_id (field 9): from binding.target_local_signal
+      // (field 2).
+      auto* target_local_ptr = builder.CreateStructGEP(
+          binding_ty, binding_ptr, 2, "binding_target_local_ptr");
+      auto* target_local =
+          builder.CreateLoad(i32_ty, target_local_ptr, "ext_ref_target_local");
+      auto* local_id_ptr = builder.CreateStructGEP(trigger_type, elem_ptr, 9);
+      builder.CreateStore(target_local, local_id_ptr);
+    } else if (is_local_signal) {
       uint8_t local_flags = runtime::kTriggerLocalSignal;
       auto cross_id = signal_expr.GetInstanceIdOverride();
       if (cross_id.has_value()) {
@@ -1927,7 +1963,7 @@ auto GenerateProcessFunction(
   return ProcessCodegenResult{
       .function = func,
       .wait_sites = std::move(wait_sites),
-      .process_trigger = ExtractProcessTriggerEntry(context, process)};
+      .process_trigger = ExtractProcessTriggerEntry(process)};
 }
 
 auto GenerateSharedProcessFunction(
@@ -2129,7 +2165,7 @@ auto GenerateSharedProcessFunction(
   return ProcessCodegenResult{
       .function = func,
       .wait_sites = std::move(wait_sites),
-      .process_trigger = ExtractProcessTriggerEntry(context, process)};
+      .process_trigger = ExtractProcessTriggerEntry(process)};
 }
 
 auto DeclareMirFunction(
@@ -3549,7 +3585,7 @@ auto DefineMirFunction(
   return {};
 }
 
-auto ExtractProcessTriggerEntry(Context& context, const mir::Process& process)
+auto ExtractProcessTriggerEntry(const mir::Process& process)
     -> std::optional<ProcessTriggerEntry> {
   ProcessTriggerEntry entry;
   bool found_wait = false;
@@ -3569,16 +3605,21 @@ auto ExtractProcessTriggerEntry(Context& context, const mir::Process& process)
           has_rebindable = true;
         }
       }
-      mir::SignalRef signal = t.signal;
       if (t.unresolved_external_ref.has_value()) {
-        signal = context.NormalizeExternalRefSignalIdentity(
-            *t.unresolved_external_ref);
+        entry.triggers.push_back({
+            .signal = {},
+            .edge = t.edge,
+            .has_observed_place = t.observed_place.has_value(),
+            .external_ref_index = t.unresolved_external_ref->value,
+        });
+      } else {
+        entry.triggers.push_back({
+            .signal = t.signal,
+            .edge = t.edge,
+            .has_observed_place = t.observed_place.has_value(),
+            .external_ref_index = std::nullopt,
+        });
       }
-      entry.triggers.push_back({
-          .signal = signal,
-          .edge = t.edge,
-          .has_observed_place = t.observed_place.has_value(),
-      });
     }
   }
 

--- a/src/lyra/llvm_backend/runtime_data_extraction.cpp
+++ b/src/lyra/llvm_backend/runtime_data_extraction.cpp
@@ -250,11 +250,13 @@ auto BuildParamPayloads(
 auto BuildConstructionProgram(
     std::span<const uint32_t> instance_body_group, const Layout& layout,
     const mir::InstanceTable& instance_table,
-    std::span<const std::vector<uint8_t>> param_payloads)
+    std::span<const std::vector<uint8_t>> param_payloads,
+    const std::vector<std::vector<uint32_t>>& instance_ext_ref_slots)
     -> ConstructionProgramData {
   auto instance_count = static_cast<uint32_t>(instance_body_group.size());
   ConstructionProgramData prog;
   prog.entries.reserve(instance_count);
+  prog.ext_ref_offsets.reserve(instance_count);
 
   for (uint32_t mi = 0; mi < instance_count; ++mi) {
     runtime::ConstructionProgramEntry entry{};
@@ -277,6 +279,18 @@ auto BuildConstructionProgram(
     const auto& sizes = layout.instance_storage_sizes[mi];
     entry.realized_inline_size = sizes.inline_bytes;
     entry.realized_appendix_size = sizes.appendix_bytes;
+
+    // Pack per-instance ext_ref slots into flat pool.
+    if (mi < instance_ext_ref_slots.size() &&
+        !instance_ext_ref_slots[mi].empty()) {
+      prog.ext_ref_offsets.push_back(
+          static_cast<uint32_t>(prog.ext_ref_pool.size()));
+      const auto& slots = instance_ext_ref_slots[mi];
+      prog.ext_ref_pool.insert(
+          prog.ext_ref_pool.end(), slots.begin(), slots.end());
+    } else {
+      prog.ext_ref_offsets.push_back(UINT32_MAX);
+    }
 
     prog.entries.push_back(entry);
   }
@@ -1063,7 +1077,7 @@ void ExtractBodyInitDescriptors(
 
   construction_program = BuildConstructionProgram(
       instance_body_group, layout, input.construction->instance_table,
-      param_payloads);
+      param_payloads, input.construction->instance_ext_ref_slots);
 
   // Validate construction program.
   for (size_t i = 0; i < construction_program.entries.size(); ++i) {

--- a/src/lyra/llvm_backend/runtime_data_extraction.cpp
+++ b/src/lyra/llvm_backend/runtime_data_extraction.cpp
@@ -251,12 +251,13 @@ auto BuildConstructionProgram(
     std::span<const uint32_t> instance_body_group, const Layout& layout,
     const mir::InstanceTable& instance_table,
     std::span<const std::vector<uint8_t>> param_payloads,
-    const std::vector<std::vector<uint32_t>>& instance_ext_ref_slots)
-    -> ConstructionProgramData {
+    const std::vector<std::vector<common::ResolvedExtRefBinding>>&
+        instance_ext_ref_bindings) -> ConstructionProgramData {
   auto instance_count = static_cast<uint32_t>(instance_body_group.size());
   ConstructionProgramData prog;
   prog.entries.reserve(instance_count);
-  prog.ext_ref_offsets.reserve(instance_count);
+  prog.ext_ref_binding_offsets.reserve(instance_count);
+  prog.ext_ref_binding_counts.reserve(instance_count);
 
   for (uint32_t mi = 0; mi < instance_count; ++mi) {
     runtime::ConstructionProgramEntry entry{};
@@ -280,16 +281,19 @@ auto BuildConstructionProgram(
     entry.realized_inline_size = sizes.inline_bytes;
     entry.realized_appendix_size = sizes.appendix_bytes;
 
-    // Pack per-instance ext_ref slots into flat pool.
-    if (mi < instance_ext_ref_slots.size() &&
-        !instance_ext_ref_slots[mi].empty()) {
-      prog.ext_ref_offsets.push_back(
-          static_cast<uint32_t>(prog.ext_ref_pool.size()));
-      const auto& slots = instance_ext_ref_slots[mi];
-      prog.ext_ref_pool.insert(
-          prog.ext_ref_pool.end(), slots.begin(), slots.end());
+    // Pack per-instance ext-ref binding records into flat pool.
+    if (mi < instance_ext_ref_bindings.size() &&
+        !instance_ext_ref_bindings[mi].empty()) {
+      auto offset = static_cast<uint32_t>(prog.ext_ref_binding_pool.size());
+      prog.ext_ref_binding_offsets.push_back(offset);
+      prog.ext_ref_binding_counts.push_back(
+          static_cast<uint32_t>(instance_ext_ref_bindings[mi].size()));
+      const auto& bindings = instance_ext_ref_bindings[mi];
+      prog.ext_ref_binding_pool.insert(
+          prog.ext_ref_binding_pool.end(), bindings.begin(), bindings.end());
     } else {
-      prog.ext_ref_offsets.push_back(UINT32_MAX);
+      prog.ext_ref_binding_offsets.push_back(UINT32_MAX);
+      prog.ext_ref_binding_counts.push_back(0);
     }
 
     prog.entries.push_back(entry);
@@ -586,22 +590,38 @@ void ExtractBodyTriggerTemplates(
         if (fact.has_observed_place) {
           flags |= runtime::kTriggerTemplateFlagHasObservedPlace;
         }
-        if (fact.signal.scope == mir::SignalRef::Scope::kDesignGlobal) {
+        if (fact.external_ref_index.has_value()) {
+          flags |= runtime::kTriggerTemplateFlagExternalRef;
+          bp.triggers.entries.push_back(
+              runtime::TriggerTemplateEntry{
+                  .slot_id = *fact.external_ref_index,
+                  .edge = static_cast<uint32_t>(fact.edge),
+                  .flags = flags,
+              });
+        } else if (fact.signal.scope == mir::SignalRef::Scope::kDesignGlobal) {
           flags |= runtime::kTriggerTemplateFlagDesignGlobal;
-        } else if (fact.signal.id >= info.slot_count) {
-          throw common::InternalError(
-              "ExtractBodyTriggerTemplates",
-              std::format(
-                  "body {} proc {} trigger slot_id {} >= slot_count {}",
-                  info.body_id.value, nonfinal_proc_ordinal, fact.signal.id,
-                  info.slot_count));
+          bp.triggers.entries.push_back(
+              runtime::TriggerTemplateEntry{
+                  .slot_id = fact.signal.id,
+                  .edge = static_cast<uint32_t>(fact.edge),
+                  .flags = flags,
+              });
+        } else {
+          if (fact.signal.id >= info.slot_count) {
+            throw common::InternalError(
+                "ExtractBodyTriggerTemplates",
+                std::format(
+                    "body {} proc {} trigger slot_id {} >= slot_count {}",
+                    info.body_id.value, nonfinal_proc_ordinal, fact.signal.id,
+                    info.slot_count));
+          }
+          bp.triggers.entries.push_back(
+              runtime::TriggerTemplateEntry{
+                  .slot_id = fact.signal.id,
+                  .edge = static_cast<uint32_t>(fact.edge),
+                  .flags = flags,
+              });
         }
-        bp.triggers.entries.push_back(
-            runtime::TriggerTemplateEntry{
-                .slot_id = fact.signal.id,
-                .edge = static_cast<uint32_t>(fact.edge),
-                .flags = flags,
-            });
       }
       auto range_count =
           static_cast<uint32_t>(bp.triggers.entries.size() - range_start);
@@ -1077,7 +1097,7 @@ void ExtractBodyInitDescriptors(
 
   construction_program = BuildConstructionProgram(
       instance_body_group, layout, input.construction->instance_table,
-      param_payloads, input.construction->instance_ext_ref_slots);
+      param_payloads, input.construction->instance_ext_ref_bindings);
 
   // Validate construction program.
   for (size_t i = 0; i < construction_program.entries.size(); ++i) {

--- a/src/lyra/llvm_backend/spec_session.cpp
+++ b/src/lyra/llvm_backend/spec_session.cpp
@@ -19,7 +19,6 @@
 #include "lyra/llvm_backend/process.hpp"
 #include "lyra/lowering/origin_map_lookup.hpp"
 #include "lyra/mir/arena.hpp"
-#include "lyra/mir/construction_input.hpp"
 #include "lyra/mir/deferred_assertion_site.hpp"
 #include "lyra/mir/routine.hpp"
 
@@ -57,8 +56,8 @@ auto CaptureDeferredCalleeInfoForBody(
 }  // namespace
 
 auto CompileModuleSpecSession(
-    Context& context, const CompiledModuleSpecInput& input,
-    const mir::ConstructionInput* construction) -> Result<CompiledModuleSpec> {
+    Context& context, const CompiledModuleSpecInput& input)
+    -> Result<CompiledModuleSpec> {
   const auto& body = *input.body;
   Context::ArenaScope arena_scope(context, &body.arena);
 
@@ -73,10 +72,9 @@ auto CompileModuleSpecSession(
   }
 
   std::optional<Context::ExternalRefResolutionEnv> ext_ref_env;
-  if (!body.resolved_external_ref_bindings.empty()) {
-    ext_ref_env = Context::ExternalRefResolutionEnv{
-        .bindings = &body.resolved_external_ref_bindings,
-        .construction = construction};
+  if (!body.external_refs.empty()) {
+    ext_ref_env =
+        Context::ExternalRefResolutionEnv{.recipes = &body.external_refs};
   }
   Context::SpecLocalScope spec_scope(
       context, input.spec_slot_info, input.connection_notification_mask,
@@ -206,8 +204,7 @@ auto CompileSpecializations(
       input.design->deferred_assertion_sites.size());
 
   for (const auto& spec_input : spec_plan.inputs) {
-    auto product =
-        CompileModuleSpecSession(context, spec_input, input.construction);
+    auto product = CompileModuleSpecSession(context, spec_input);
     if (!product) return std::unexpected(product.error());
 
     // Merge DPI export callees.

--- a/src/lyra/llvm_backend/write_dispatch.cpp
+++ b/src/lyra/llvm_backend/write_dispatch.cpp
@@ -115,7 +115,13 @@ auto EmitPlainAggregateStore(
       ctx.GetDesignStoreMode() != DesignStoreMode::kDirectInit) {
     auto& builder = ctx.GetBuilder();
     auto emit_notify = [&]() {
-      if (wt->canonical_signal_id->IsLocal()) {
+      if (wt->canonical_signal_id->IsExtRef()) {
+        builder.CreateCall(
+            ctx.GetLyraMarkDirtyExtRef(),
+            {ctx.GetEnginePointer(), ctx.GetInstancePointer(),
+             wt->canonical_signal_id->Emit(builder), builder.getInt32(0),
+             builder.getInt32(0)});
+      } else if (wt->canonical_signal_id->IsLocal()) {
         builder.CreateCall(
             ctx.GetLyraNotifySignalLocal(),
             {ctx.GetEnginePointer(),

--- a/src/lyra/lowering/ast_to_hir/expression.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression.cpp
@@ -992,46 +992,82 @@ auto LowerExpression(
         return steps;
       };
 
+      // Walk up exactly N instance boundaries from the current instance
+      // and return the InstanceSymbol at that level. Returns nullptr if
+      // the walk runs out of parents (e.g., frame is null or N too large).
+      auto walk_up_instances =
+          [&](uint32_t count) -> const slang::ast::InstanceSymbol* {
+        if (frame == nullptr || frame->instance == nullptr) return nullptr;
+        const auto* inst = frame->instance;
+        for (uint32_t i = 0; i < count; ++i) {
+          const auto* parent_scope = inst->getParentScope();
+          if (parent_scope == nullptr) return nullptr;
+          const auto& parent_sym = parent_scope->asSymbol();
+          if (parent_sym.kind != slang::ast::SymbolKind::InstanceBody) {
+            return nullptr;
+          }
+          inst = parent_sym.as<slang::ast::InstanceBodySymbol>().parentInstance;
+          if (inst == nullptr) return nullptr;
+        }
+        return inst;
+      };
+
       // Extract descendant path elements from slang's hierarchical
       // reference path. Each element is an instance traversal step with
       // its generate-scope selection extracted from the symbol's parent
       // scope chain.
+      //
+      // slang's upward lookup can find names in two ways:
+      //   1. scope->find(): name found as a child of an ancestor scope.
+      //      path[0] is a real downward child step -- must be kept.
+      //   2. Definition-name match: module definition name matches.
+      //      path[0] IS the ancestor instance itself -- must be skipped.
+      //
+      // We distinguish by checking whether path[0]'s InstanceBody is an
+      // ancestor of the current instance being lowered.
       auto extract_path_elements =
           [&](const slang::ast::HierarchicalReference& ref)
           -> std::vector<hir::HierPathElement> {
         std::vector<hir::HierPathElement> elements;
-        // The slang path includes all symbols from reference scope to
-        // target. Exclude:
-        //   - The last element: target variable/net (carried by target_sym)
-        //   - The first element when upwardCount > 0: scope name at the
-        //     resolution root (e.g., "Top" in "Top.var"), not a child
-        //     instance traversal
-        // Skip the first element when it is the resolution root scope:
-        //   - upwardCount > 0: first element is the named scope reached
-        //     by upward navigation (e.g., "Test" in "Test.var" from child)
-        //   - upwardCount == 0 with explicit scope name: first element is
-        //     the enclosing scope itself (e.g., "Test" in "Test.a.value"
-        //     from Test's own initial block)
-        // Detect the second case: if first element is an Instance whose
-        // parent is the root compilation unit, it's the enclosing module.
+        // The last path element is always the target variable/net,
+        // carried separately by target_sym. Skip it.
+        // The first element may need to be skipped if it is an ancestor
+        // self-reference (definition-name match or enclosing scope name).
         size_t start = 0;
-        if (!ref.path.empty()) {
+        if (!ref.path.empty() &&
+            ref.path[0].symbol->kind == slang::ast::SymbolKind::Instance) {
+          const auto& first_inst =
+              ref.path[0].symbol->as<slang::ast::InstanceSymbol>();
           if (ref.upwardCount > 0) {
-            start = 1;
-          } else if (
-              ref.path[0].symbol->kind == slang::ast::SymbolKind::Instance &&
-              ref.path[0].symbol->getParentScope() != nullptr &&
-              ref.path[0].symbol->getParentScope()->asSymbol().kind ==
-                  slang::ast::SymbolKind::Root) {
-            start = 1;
+            // Upward lookup: skip only if path[0] is the exact instance
+            // reached by walking up (definition-name self-reference).
+            // Keep if it's a child found in the ancestor scope.
+            //
+            // Exact instance identity is required -- body/definition
+            // equality is not sufficient because two different instances
+            // can share the same module definition. A child instance of
+            // the same module type as the ancestor must still be kept as
+            // a real traversal step.
+            const auto* ancestor =
+                walk_up_instances(static_cast<uint32_t>(ref.upwardCount));
+            if (ancestor != nullptr && ancestor == &first_inst) {
+              start = 1;
+            }
+          } else {
+            // No upward walk: skip if the first element is the enclosing
+            // scope itself (e.g., "Test" in "Test.a.value" from Test's
+            // own initial block).
+            if (ref.path[0].symbol->getParentScope() != nullptr &&
+                ref.path[0].symbol->getParentScope()->asSymbol().kind ==
+                    slang::ast::SymbolKind::Root) {
+              start = 1;
+            }
           }
         }
         if (ref.path.size() <= start + 1) return elements;
         for (size_t i = start; i + 1 < ref.path.size(); ++i) {
           const auto& sym = *ref.path[i].symbol;
           SymbolId step_sym = registrar.Lookup(sym);
-          // Classify: InstanceSymbol -> kChildInstance, everything else
-          // (GenerateBlock, GenerateBlockArray) -> kGenerateScope.
           auto kind = sym.kind == slang::ast::SymbolKind::Instance
                           ? hir::HierPathStepKind::kChildInstance
                           : hir::HierPathStepKind::kGenerateScope;

--- a/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
@@ -41,6 +41,7 @@ ScopeLowerer::ScopeLowerer(
     Context& ctx, SymbolRegistrar& registrar,
     const slang::ast::InstanceSymbol& instance)
     : ScopeLowerer(ctx, registrar, ComputeFrame(ctx, instance.body)) {
+  frame_.instance = &instance;
 }
 
 ScopeLowerer::ScopeLowerer(

--- a/src/lyra/lowering/hir_to_mir/bound_hierarchy.cpp
+++ b/src/lyra/lowering/hir_to_mir/bound_hierarchy.cpp
@@ -237,22 +237,27 @@ void FinalizeExternalRefTargetSlots(
   }
 }
 
-void EnforceExternalRefSingleInstanceGuard(
-    const mir::Design& design, const mir::ConstructionInput& construction) {
-  std::unordered_map<uint32_t, uint32_t> objects_per_body;
-  for (const auto& obj : construction.objects) {
-    ++objects_per_body[obj.body_group];
-  }
-  for (uint32_t body_idx = 0; body_idx < design.module_bodies.size();
-       ++body_idx) {
-    if (design.module_bodies[body_idx].external_refs.empty()) continue;
-    if (objects_per_body[body_idx] > 1) {
-      throw common::InternalError(
-          "EnforceExternalRefSingleInstanceGuard",
-          std::format(
-              "body group {} has {} instances but active external refs -- "
-              "multi-instance spec with external refs not yet supported",
-              body_idx, objects_per_body[body_idx]));
+void BuildPerInstanceExternalRefSlotTables(
+    const mir::Design& design, mir::ConstructionInput& construction,
+    const BoundHierarchyIndex& topo) {
+  auto num_objects = static_cast<uint32_t>(construction.objects.size());
+  construction.instance_ext_ref_slots.resize(num_objects);
+
+  for (uint32_t oi = 0; oi < num_objects; ++oi) {
+    uint32_t body_idx = construction.objects[oi].body_group;
+    const auto& body = design.module_bodies[body_idx];
+    if (body.external_refs.empty()) continue;
+
+    auto& table = construction.instance_ext_ref_slots[oi];
+    table.reserve(body.external_refs.size());
+
+    for (size_t i = 0; i < body.external_refs.size(); ++i) {
+      const auto& recipe = body.external_refs[i].target;
+      uint32_t target_oi = WalkCanonicalPath(recipe, oi, topo, construction);
+      const auto& target_obj = construction.objects[target_oi];
+      uint32_t global_slot =
+          target_obj.design_state_base_slot + recipe.target_slot.value;
+      table.push_back(global_slot);
     }
   }
 }
@@ -335,34 +340,6 @@ auto WalkCanonicalPath(
     oi = topo.ResolveChildByDurableId(parent_bg, step.child);
   }
   return oi;
-}
-
-void BuildResolvedExternalRefBindings(
-    mir::Design& design, const BoundHierarchyIndex& topo,
-    const mir::ConstructionInput& construction) {
-  // Guard already enforced by EnforceExternalRefSingleInstanceGuard
-  // before this pass runs.
-  for (uint32_t body_idx = 0; body_idx < design.module_bodies.size();
-       ++body_idx) {
-    auto& body = design.module_bodies[body_idx];
-    if (body.external_refs.empty()) continue;
-
-    uint32_t rep_oi = topo.rep_object_for_body.at(body_idx);
-    auto& bindings = body.resolved_external_ref_bindings;
-    bindings.reserve(body.external_refs.size());
-
-    for (size_t i = 0; i < body.external_refs.size(); ++i) {
-      const auto& recipe = body.external_refs[i].target;
-      uint32_t target_oi =
-          WalkCanonicalPath(recipe, rep_oi, topo, construction);
-      bindings.push_back(
-          mir::ResolvedExternalRefBinding{
-              .target_object = common::ObjectIndex{target_oi},
-              .target_local_slot = recipe.target_slot,
-              .type = body.external_refs[i].type,
-              .global_slot = std::nullopt});
-    }
-  }
 }
 
 auto IsFullyBindableRecipe(const mir::ConnectionRecipe& recipe) -> bool {

--- a/src/lyra/lowering/hir_to_mir/bound_hierarchy.cpp
+++ b/src/lyra/lowering/hir_to_mir/bound_hierarchy.cpp
@@ -237,27 +237,34 @@ void FinalizeExternalRefTargetSlots(
   }
 }
 
-void BuildPerInstanceExternalRefSlotTables(
+void BuildPerInstanceExtRefBindings(
     const mir::Design& design, mir::ConstructionInput& construction,
     const BoundHierarchyIndex& topo) {
   auto num_objects = static_cast<uint32_t>(construction.objects.size());
-  construction.instance_ext_ref_slots.resize(num_objects);
+  construction.instance_ext_ref_bindings.resize(num_objects);
 
   for (uint32_t oi = 0; oi < num_objects; ++oi) {
     uint32_t body_idx = construction.objects[oi].body_group;
     const auto& body = design.module_bodies[body_idx];
     if (body.external_refs.empty()) continue;
 
-    auto& table = construction.instance_ext_ref_slots[oi];
-    table.reserve(body.external_refs.size());
+    auto& out = construction.instance_ext_ref_bindings[oi];
+    out.reserve(body.external_refs.size());
 
-    for (size_t i = 0; i < body.external_refs.size(); ++i) {
-      const auto& recipe = body.external_refs[i].target;
+    for (const auto& ext_ref : body.external_refs) {
+      const auto& recipe = ext_ref.target;
       uint32_t target_oi = WalkCanonicalPath(recipe, oi, topo, construction);
       const auto& target_obj = construction.objects[target_oi];
-      uint32_t global_slot =
-          target_obj.design_state_base_slot + recipe.target_slot.value;
-      table.push_back(global_slot);
+      // target_oi == InstanceId.value by construction program order.
+      out.push_back(
+          common::ResolvedExtRefBinding{
+              .storage_slot =
+                  common::SlotId{
+                      target_obj.design_state_base_slot +
+                      recipe.target_slot.value},
+              .target_instance_id = target_oi,
+              .target_local_signal = recipe.target_slot,
+          });
     }
   }
 }

--- a/src/lyra/lowering/hir_to_mir/design_lower.cpp
+++ b/src/lyra/lowering/hir_to_mir/design_lower.cpp
@@ -1073,9 +1073,9 @@ auto LowerDesign(
   // provisionals for target_sym). CanonicalizeExternalRefPaths fills
   // target.path with DurableChildId entries (needs provisionals for
   // topology walk, but resolves through oi_to_durable_child, not
-  // debug_instance_sym). BuildPerInstanceExternalRefSlotTables walks
+  // debug_instance_sym). BuildPerInstanceExtRefBindings walks
   // each recipe from each instance's actual position to compute
-  // per-instance resolved global slot tables.
+  // per-instance resolved ext-ref runtime bindings.
   auto topo = BuildBoundHierarchyIndex(
       construction, parent_to_children, body_to_representative,
       oi_to_durable_child);
@@ -1090,8 +1090,9 @@ auto LowerDesign(
       result, provisionals_by_body, topo, oi_to_durable_child);
 
   // After canonicalization, provisionals_by_body is scratch-only.
-  // Build per-instance resolved global slot tables from canonical recipes.
-  BuildPerInstanceExternalRefSlotTables(result, construction, topo);
+  // Build per-instance resolved ext-ref runtime bindings from canonical
+  // recipes.
+  BuildPerInstanceExtRefBindings(result, construction, topo);
 
   // Propagate decision owner acceptance through design-global call graph.
   mir_arena.PropagateDeferredOwnerAbi();

--- a/src/lyra/lowering/hir_to_mir/design_lower.cpp
+++ b/src/lyra/lowering/hir_to_mir/design_lower.cpp
@@ -1068,17 +1068,14 @@ auto LowerDesign(
     result.module_bodies[body_id_val].connection_recipes = std::move(recipes);
   }
 
-  // B2: Build topology index and resolve external refs.
-  // Enforce single-instance guard before any pass that relies on
-  // representative-derived durable-child mappings.
-  EnforceExternalRefSingleInstanceGuard(result, construction);
-
+  // B2: Build topology index and resolve external ref recipes.
   // Ordering: FinalizeExternalRefTargetSlots fills target_slot (needs
   // provisionals for target_sym). CanonicalizeExternalRefPaths fills
   // target.path with DurableChildId entries (needs provisionals for
   // topology walk, but resolves through oi_to_durable_child, not
-  // debug_instance_sym). BuildResolvedExternalRefBindings creates
-  // durable binding facts from the canonical recipe (no provisionals).
+  // debug_instance_sym). BuildPerInstanceExternalRefSlotTables walks
+  // each recipe from each instance's actual position to compute
+  // per-instance resolved global slot tables.
   auto topo = BuildBoundHierarchyIndex(
       construction, parent_to_children, body_to_representative,
       oi_to_durable_child);
@@ -1093,8 +1090,8 @@ auto LowerDesign(
       result, provisionals_by_body, topo, oi_to_durable_child);
 
   // After canonicalization, provisionals_by_body is scratch-only.
-  // BuildResolvedExternalRefBindings consumes the canonical recipe.
-  BuildResolvedExternalRefBindings(result, topo, construction);
+  // Build per-instance resolved global slot tables from canonical recipes.
+  BuildPerInstanceExternalRefSlotTables(result, construction, topo);
 
   // Propagate decision owner acceptance through design-global call graph.
   mir_arena.PropagateDeferredOwnerAbi();

--- a/src/lyra/runtime/constructor_.cpp
+++ b/src/lyra/runtime/constructor_.cpp
@@ -1643,3 +1643,20 @@ void LyraConstructionResultDestroy(void* result_raw) {
   std::unique_ptr<lyra::runtime::ConstructionResult> result(
       static_cast<lyra::runtime::ConstructionResult*>(result_raw));
 }
+
+void LyraConstructionResultSetExtRefSlots(
+    void* result_raw, const uint32_t* pool, uint32_t pool_size,
+    const uint32_t* offsets, uint32_t num_instances) {
+  if (result_raw == nullptr) return;
+  auto& result = *static_cast<lyra::runtime::ConstructionResult*>(result_raw);
+  auto pool_span = std::span(pool, pool_size);
+  auto offset_span = std::span(offsets, num_instances);
+  auto count =
+      std::min(static_cast<size_t>(num_instances), result.instances.size());
+  for (size_t i = 0; i < count; ++i) {
+    if (offset_span[i] != UINT32_MAX && !pool_span.empty()) {
+      result.instances[i]->ext_ref_slots =
+          pool_span.subspan(offset_span[i]).data();
+    }
+  }
+}

--- a/src/lyra/runtime/constructor_.cpp
+++ b/src/lyra/runtime/constructor_.cpp
@@ -1644,19 +1644,26 @@ void LyraConstructionResultDestroy(void* result_raw) {
       static_cast<lyra::runtime::ConstructionResult*>(result_raw));
 }
 
-void LyraConstructionResultSetExtRefSlots(
-    void* result_raw, const uint32_t* pool, uint32_t pool_size,
-    const uint32_t* offsets, uint32_t num_instances) {
+void LyraConstructionResultSetExtRefBindings(
+    void* result_raw, const void* pool_raw, uint32_t pool_count,
+    const uint32_t* offsets, const uint32_t* counts, uint32_t num_instances) {
   if (result_raw == nullptr) return;
   auto& result = *static_cast<lyra::runtime::ConstructionResult*>(result_raw);
-  auto pool_span = std::span(pool, pool_size);
+  auto pool = std::span(
+      static_cast<const lyra::common::ResolvedExtRefBinding*>(pool_raw),
+      pool_count);
   auto offset_span = std::span(offsets, num_instances);
-  auto count =
+  auto count_span = std::span(counts, num_instances);
+  auto n =
       std::min(static_cast<size_t>(num_instances), result.instances.size());
-  for (size_t i = 0; i < count; ++i) {
-    if (offset_span[i] != UINT32_MAX && !pool_span.empty()) {
-      result.instances[i]->ext_ref_slots =
-          pool_span.subspan(offset_span[i]).data();
+  for (size_t i = 0; i < n; ++i) {
+    if (offset_span[i] == UINT32_MAX) {
+      result.instances[i]->ext_ref_bindings = nullptr;
+      result.instances[i]->ext_ref_binding_count = 0;
+    } else {
+      result.instances[i]->ext_ref_bindings =
+          pool.subspan(offset_span[i]).data();
+      result.instances[i]->ext_ref_binding_count = count_span[i];
     }
   }
 }

--- a/src/lyra/runtime/engine_bundle_init.cpp
+++ b/src/lyra/runtime/engine_bundle_init.cpp
@@ -152,9 +152,34 @@ auto BuildModuleTriggerDescriptors(
 
       for (uint32_t t = 0; t < range.count; ++t) {
         const auto& te = triggers.entries[range.start + t];
+        bool is_ext_ref = (te.flags & kTriggerTemplateFlagExternalRef) != 0;
         bool is_global = (te.flags & kTriggerTemplateFlagDesignGlobal) != 0;
 
-        if (is_global) {
+        if (is_ext_ref) {
+          // External-ref trigger: resolve to object-local identity on
+          // the target instance via the binding record.
+          auto bindings = std::span(
+              bundle.instance->ext_ref_bindings,
+              bundle.instance->ext_ref_binding_count);
+          if (te.slot_id >= bindings.size()) {
+            throw common::InternalError(
+                "BuildModuleTriggerDescriptors",
+                std::format(
+                    "instance {} ext-ref trigger index {} >= binding "
+                    "count {}",
+                    bundle.instance_id, te.slot_id, bindings.size()));
+          }
+          const auto& binding = bindings[te.slot_id];
+          descriptors.push_back(
+              ProcessTriggerDescriptor{
+                  .scheduled_process_index = proc_idx,
+                  .slot_id = binding.target_local_signal.value,
+                  .edge = static_cast<common::EdgeKind>(te.edge),
+                  .is_groupable = groupable,
+                  .is_local = true,
+                  .instance_id = InstanceId{binding.target_instance_id},
+              });
+        } else if (is_global) {
           if (te.slot_id >= total_slot_count) {
             throw common::InternalError(
                 "BuildModuleTriggerDescriptors",

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -1110,6 +1110,21 @@ extern "C" void LyraMarkDirtyGlobal(
   MarkDirtyTyped(AsEngine(eng), GlobalSignalId{id}, off, size);
 }
 
+extern "C" void LyraMarkDirtyExtRef(
+    void* eng, void* inst, uint32_t ref_id, uint32_t off, uint32_t size) {
+  auto* instance = static_cast<lyra::runtime::RuntimeInstance*>(inst);
+  auto bindings =
+      std::span(instance->ext_ref_bindings, instance->ext_ref_binding_count);
+  const auto& binding = bindings[ref_id];
+  auto target_instance_id =
+      lyra::runtime::InstanceId{binding.target_instance_id};
+  auto* engine = AsEngine(eng);
+  auto& target = engine->GetInstanceMut(target_instance_id);
+  MarkDirtyTyped(
+      engine, MakeLocalRef(&target, binding.target_local_signal.value), off,
+      size);
+}
+
 extern "C" void LyraStorePackedLocal(
     void* eng, void* inst, void* slot, const void* val, uint32_t bsz,
     uint32_t id, uint32_t off, uint32_t dsz) {
@@ -1152,6 +1167,34 @@ extern "C" void LyraScheduleNbaCanonicalPackedGlobal(
     uint32_t rsz, uint32_t sro, uint32_t id) {
   AsEngine(eng)->ScheduleNbaCanonicalPacked(
       GlobalSignalId{id}, wp, nb, vp, up, rsz, sro);
+}
+
+extern "C" void LyraScheduleNbaExtRef(
+    void* eng, void* inst, uint32_t ref_id, void* wp, const void* nb,
+    const void* vp, const void* mp, uint32_t bsz) {
+  auto* owner = static_cast<lyra::runtime::RuntimeInstance*>(inst);
+  auto bindings =
+      std::span(owner->ext_ref_bindings, owner->ext_ref_binding_count);
+  const auto& binding = bindings[ref_id];
+  lyra::runtime::NbaNotifySignal notify{lyra::runtime::NbaNotifyLocal{
+      .instance_id = lyra::runtime::InstanceId{binding.target_instance_id},
+      .signal = lyra::runtime::LocalSignalId{binding.target_local_signal.value},
+  }};
+  AsEngine(eng)->ScheduleNba(wp, nb, vp, mp, bsz, notify);
+}
+
+extern "C" void LyraScheduleNbaCanonicalPackedExtRef(
+    void* eng, void* inst, uint32_t ref_id, void* wp, const void* nb,
+    const void* vp, const void* up, uint32_t rsz, uint32_t sro) {
+  auto* owner = static_cast<lyra::runtime::RuntimeInstance*>(inst);
+  auto bindings =
+      std::span(owner->ext_ref_bindings, owner->ext_ref_binding_count);
+  const auto& binding = bindings[ref_id];
+  lyra::runtime::NbaNotifySignal notify{lyra::runtime::NbaNotifyLocal{
+      .instance_id = lyra::runtime::InstanceId{binding.target_instance_id},
+      .signal = lyra::runtime::LocalSignalId{binding.target_local_signal.value},
+  }};
+  AsEngine(eng)->ScheduleNbaCanonicalPacked(wp, nb, vp, up, rsz, sro, notify);
 }
 
 // R5: Resolve RuntimeInstance* from InstanceId at runtime.

--- a/tests/sv_features/hierarchy/refs/upward_refs/child_lookup.yaml
+++ b/tests/sv_features/hierarchy/refs/upward_refs/child_lookup.yaml
@@ -1,0 +1,69 @@
+feature: upward_hierarchical_refs_child_lookup
+description: >
+  Tests for hierarchical references where the upward lookup finds a child
+  instance in an ancestor scope (scope->find() case), as opposed to the
+  definition-name match case. The first path element is a real downward
+  child traversal step that must be preserved.
+
+cases:
+  - name: upward_then_child_read
+    description: >
+      Deep module reads a variable in a sibling child of an ancestor.
+      Hierarchy: Test > u_core(Core) > u_stage(Stage) > u_ctrl(Controller).
+      Controller references u_core.value -- walks up 3 to Test, then finds
+      u_core as a child of Test, then accesses value in Core. The first path
+      element (u_core) is a real child traversal step, not a self-reference.
+    sv: |
+      module Controller;
+        int result;
+        initial begin
+          result = u_core.value;
+          $display("result=%0d", result);
+        end
+      endmodule
+
+      module Stage;
+        Controller u_ctrl();
+      endmodule
+
+      module Core;
+        int value = 66;
+        Stage u_stage();
+      endmodule
+
+      module Test;
+        Core u_core();
+        initial #1;
+      endmodule
+    expect:
+      stdout: "result=66\n"
+
+  - name: upward_then_child_two_levels
+    description: >
+      Same pattern but with two child traversal steps after the upward walk.
+      Controller references u_core.u_stage.some_var -- walks up to Test,
+      then descends through u_core and u_stage.
+    sv: |
+      module Controller;
+        int result;
+        initial begin
+          result = u_core.u_stage.stage_val;
+          $display("result=%0d", result);
+        end
+      endmodule
+
+      module Stage;
+        int stage_val = 77;
+        Controller u_ctrl();
+      endmodule
+
+      module Core;
+        Stage u_stage();
+      endmodule
+
+      module Test;
+        Core u_core();
+        initial #1;
+      endmodule
+    expect:
+      stdout: "result=77\n"


### PR DESCRIPTION
## Summary

Replaces the design-global behavioral identity model for external refs (hierarchical references) with per-instance object-local bindings. Each ext-ref now resolves to a typed `ResolvedExtRefBinding{storage_slot, target_instance_id, target_local_signal}` record, stored per-instance at construction time. All behavioral paths -- triggers, dirty marks, NBA, immediate writes -- resolve through this single binding record instead of design-global slot projections.

This eliminates the Phase 3 local-to-global forwarding bridge in `FlushLocalSignalUpdates`, the `design_state_base_slot` field, the design-global ext-ref bitmap compensation, and three parallel raw-integer transport pools. The runtime now thinks in objects and fields: behavioral identity is `(instance, local_signal)`, storage identity is `SlotId`.

## Design

The key architectural change is that ext-ref behavioral identity is no longer projected through a design-global bitmap or forwarding bridge. Instead:

- **Construction time**: `BuildPerInstanceExtRefBindings` resolves each ext-ref recipe to a `ResolvedExtRefBinding` with the target instance's `InstanceId` and `LocalSlotId`
- **Trigger path**: `kTriggerTemplateFlagExternalRef` triggers resolve through the binding record at bundle-init time, installing as local-domain subscriptions on the target instance
- **Write/NBA path**: `LyraMarkDirtyExtRef` and `LyraScheduleNbaExtRef` resolve through `owner.ext_ref_bindings[ref_id]` at runtime
- **Body-local bitmaps**: `MarkExtRefTriggerTargetsInBodyBitmaps` marks target body slots directly, no design-global projection

Also includes a fix for hierarchical ref paths that dropped child traversal steps when the path contained upward references followed by downward lookups.

## Testing

All 544 JIT dev tests pass including new `child_lookup.yaml` test for the hier-ref path fix. Zero IDE diagnostics, zero policy violations.