### PR TITLE
Introduce process envelope boundary for suspend protocol isolation

### DIFF
--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -35,6 +35,7 @@
 #include "lyra/runtime/observer.hpp"
 #include "lyra/runtime/process_frame.hpp"
 #include "lyra/runtime/process_meta.hpp"
+#include "lyra/runtime/process_requests.hpp"
 #include "lyra/runtime/process_trigger_registry.hpp"
 #include "lyra/runtime/reporting.hpp"
 #include "lyra/runtime/runtime_instance.hpp"
@@ -290,6 +291,11 @@ class Engine {
   // Schedule process to resume in the next delta cycle (same time).
   // Used for kRepeat terminator.
   void ScheduleNextDelta(ProcessHandle handle, ResumePoint resume);
+
+  // Reset the installed wait state for a process (subscription lifecycle).
+  // Called by the envelope when a process finishes, changes wait site,
+  // or re-suspends at a non-wait terminator.
+  void ResetInstalledWait(ProcessHandle handle);
 
   // Enqueue onto generic nba_queue_ for later commit in the NBA region.
   // Only for non-instance-owned targets (global, package, cross-instance).
@@ -883,18 +889,22 @@ class Engine {
     return trace_selection_;
   }
 
-  // Register suspend record pointers for post-activation reconciliation.
+  // Register suspend record pointers for observability (scheduler snapshot
+  // wait-kind classification). Not used by activation or reconciliation flow.
   void RegisterSuspendRecords(std::span<SuspendRecord*> records);
 
-  // Single source of truth for whether the engine uses post-activation
-  // reconciliation (new path) vs legacy HandleSuspendRecord (old path).
-  // True when both wait-site metadata and suspend-record access are present.
+  // Whether the engine uses wait-site-aware subscription management.
+  // When true, the envelope's HandleWaitRequest uses refresh-in-place
+  // and compiled wait-site descriptors. When false, triggers are installed
+  // directly without subscription lifecycle tracking.
   [[nodiscard]] auto HasPostActivationReconciliation() const -> bool {
-    return wait_site_meta_.IsPopulated() && !suspend_records_.empty();
+    return wait_site_meta_.IsPopulated();
   }
 
-  // Post-activation reconciliation: engine-owned dispatch after process runs.
-  void ReconcilePostActivation(ProcessHandle handle);
+  // Handle a wait request from process activation. Manages subscription
+  // lifecycle: direct install when no reconciliation, or refresh-in-place /
+  // reinstall when reconciliation is enabled. Called by the process envelope.
+  void HandleWaitRequest(ProcessHandle handle, const WaitRequest& request);
 
   [[nodiscard]] auto GetProcessMetaRegistry() const
       -> const ProcessMetaRegistry& {
@@ -984,7 +994,6 @@ class Engine {
   // Subscription lifecycle
   void ClearInstalledSubscriptions(ProcessHandle handle);
   void InvalidateInstalledWait(ProcessHandle handle);
-  void ResetInstalledWait(ProcessHandle handle);
   void ClearProcessSubscriptions(ProcessHandle handle);
 
   // Typed cold pool management.
@@ -1067,9 +1076,10 @@ class Engine {
       std::span<const IndexPlanOp> plan, BitTargetMapping mapping,
       std::span<const SignalRef> dep_signals);
 
-  // Persistent wait-site installation
+  // Persistent wait-site installation. Validates compiled descriptor
+  // against the request, then installs triggers.
   void InstallWaitSite(
-      ProcessHandle handle, SuspendRecord* suspend,
+      ProcessHandle handle, const WaitRequest& request,
       const CompiledWaitSite& descriptor);
   auto RefreshInstalledSnapshots(ProcessHandle handle) -> bool;
 
@@ -1499,7 +1509,8 @@ class Engine {
   // The deque provides pointer stability across inserts.
   std::deque<BodyObservableLayout> body_observable_layouts_;
 
-  // Suspend record access for post-activation reconciliation.
+  // Suspend record pointers for observability only (scheduler snapshot
+  // wait-kind classification). Not used by activation or reconciliation flow.
   std::vector<SuspendRecord*> suspend_records_;
 
   // Scheduler observability atomics (signal-safe reads from SIGUSR1).

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -43,7 +43,6 @@
 #include "lyra/runtime/signal_coord.hpp"
 #include "lyra/runtime/slot_meta.hpp"
 #include "lyra/runtime/small_byte_buffer.hpp"
-#include "lyra/runtime/suspend_record.hpp"
 #include "lyra/runtime/trace_selection.hpp"
 #include "lyra/runtime/trace_signal_meta.hpp"
 #include "lyra/runtime/trap.hpp"
@@ -191,6 +190,8 @@ class InstanceIdTraceResolver final : public trace::InstanceTraceResolver {
 // 2. Schedule initial processes with ScheduleInitial()
 // 3. Call Run() to execute until completion or time limit
 class Engine {
+  friend class ProcessEnvelopeAccess;
+
  public:
   explicit Engine(
       ProcessDispatch process_dispatch, uint32_t num_processes = 0,
@@ -262,17 +263,6 @@ class Engine {
       common::EdgeKind edge, int64_t sv_index, uint32_t elem_stride,
       bool initially_active = true) -> uint32_t;
 
-  // Canonical trigger installation from typed descriptors.
-  // Installs subscriptions directly from per-trigger metadata (kind, flags,
-  // container_elem_stride), then hooks up rebind watchers from late-bound
-  // headers. Both InstallWaitSite and HandleSuspendRecord delegate here.
-  void InstallTriggers(
-      ProcessHandle handle, ResumePoint resume,
-      std::span<const WaitTriggerRecord> triggers,
-      std::span<const LateBoundHeader> late_bound,
-      std::span<const IndexPlanOp> plan_ops,
-      std::span<const DepSignalRecord> dep_records);
-
   // Create rebind subscriptions for a late-bound edge trigger. For each dep
   // slot, an AnyChange rebind node is created. When any dep changes, the plan
   // is re-evaluated and the edge target's observation position is updated.
@@ -291,11 +281,6 @@ class Engine {
   // Schedule process to resume in the next delta cycle (same time).
   // Used for kRepeat terminator.
   void ScheduleNextDelta(ProcessHandle handle, ResumePoint resume);
-
-  // Reset the installed wait state for a process (subscription lifecycle).
-  // Called by the envelope when a process finishes, changes wait site,
-  // or re-suspends at a non-wait terminator.
-  void ResetInstalledWait(ProcessHandle handle);
 
   // Enqueue onto generic nba_queue_ for later commit in the NBA region.
   // Only for non-instance-owned targets (global, package, cross-instance).
@@ -804,8 +789,8 @@ class Engine {
 
   // Register a waiter on a named event owned by the given instance.
   // Called by activation post-processing when a process suspends with
-  // kWaitEvent. Shared by both HandleSuspendRecord and
-  // ReconcilePostActivation to keep event-wait installation in one place.
+  // kWaitEvent. Called by the process envelope when a process suspends
+  // on a named event.
   static void AddInstanceEventWaiter(
       RuntimeInstance& inst, uint32_t local_event_id, EventWaiter waiter) {
     inst.event_state.AddWaiter(local_event_id, std::move(waiter));
@@ -888,23 +873,6 @@ class Engine {
   auto GetTraceSelection() -> TraceSelectionRegistry& {
     return trace_selection_;
   }
-
-  // Register suspend record pointers for observability (scheduler snapshot
-  // wait-kind classification). Not used by activation or reconciliation flow.
-  void RegisterSuspendRecords(std::span<SuspendRecord*> records);
-
-  // Whether the engine uses wait-site-aware subscription management.
-  // When true, the envelope's HandleWaitRequest uses refresh-in-place
-  // and compiled wait-site descriptors. When false, triggers are installed
-  // directly without subscription lifecycle tracking.
-  [[nodiscard]] auto HasPostActivationReconciliation() const -> bool {
-    return wait_site_meta_.IsPopulated();
-  }
-
-  // Handle a wait request from process activation. Manages subscription
-  // lifecycle: direct install when no reconciliation, or refresh-in-place /
-  // reinstall when reconciliation is enabled. Called by the process envelope.
-  void HandleWaitRequest(ProcessHandle handle, const WaitRequest& request);
 
   [[nodiscard]] auto GetProcessMetaRegistry() const
       -> const ProcessMetaRegistry& {
@@ -991,7 +959,22 @@ class Engine {
       DecisionOwnerId owner_id, const DecisionMetaEntry& meta,
       DecisionViolation violation) const -> ReportRequest;
 
-  // Subscription lifecycle
+  // Subscription lifecycle (used by ProcessEnvelopeAccess and internally).
+  void SetProcessWaitKind(uint32_t process_id, ProcessWaitKind kind) {
+    if (process_id < process_states_.size()) {
+      process_states_[process_id].wait_kind = kind;
+    }
+  }
+  [[nodiscard]] auto UsesWaitSiteLifecycle() const -> bool {
+    return wait_site_meta_.IsPopulated();
+  }
+  [[nodiscard]] auto CanRefreshInstalledWait(
+      ProcessHandle handle, WaitSiteId wait_site_id) const -> bool;
+  [[nodiscard]] auto HasPendingDirtyState() const -> bool;
+  void ResetInstalledWait(ProcessHandle handle);
+  void InstallTriggers(ProcessHandle handle, const WaitRequest& req);
+  void InstallWaitSite(ProcessHandle handle, const WaitRequest& req);
+  auto RefreshInstalledSnapshots(ProcessHandle handle) -> bool;
   void ClearInstalledSubscriptions(ProcessHandle handle);
   void InvalidateInstalledWait(ProcessHandle handle);
   void ClearProcessSubscriptions(ProcessHandle handle);
@@ -1075,13 +1058,6 @@ class Engine {
       uint8_t target_edge_group, EdgeBucket target_edge_bucket,
       std::span<const IndexPlanOp> plan, BitTargetMapping mapping,
       std::span<const SignalRef> dep_signals);
-
-  // Persistent wait-site installation. Validates compiled descriptor
-  // against the request, then installs triggers.
-  void InstallWaitSite(
-      ProcessHandle handle, const WaitRequest& request,
-      const CompiledWaitSite& descriptor);
-  auto RefreshInstalledSnapshots(ProcessHandle handle) -> bool;
 
   // Late-bound rebinding: re-read index value, recompute edge target.
   void RebindSubscription(uint32_t edge_target_id);
@@ -1508,10 +1484,6 @@ class Engine {
   // Each RuntimeInstance's observability.layout points into this storage.
   // The deque provides pointer stability across inserts.
   std::deque<BodyObservableLayout> body_observable_layouts_;
-
-  // Suspend record pointers for observability only (scheduler snapshot
-  // wait-kind classification). Not used by activation or reconciliation flow.
-  std::vector<SuspendRecord*> suspend_records_;
 
   // Scheduler observability atomics (signal-safe reads from SIGUSR1).
   // Written by scheduler, read by signal handler via relaxed loads.

--- a/include/lyra/runtime/engine_process_envelope_access.hpp
+++ b/include/lyra/runtime/engine_process_envelope_access.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "lyra/runtime/engine.hpp"
+
+namespace lyra::runtime {
+
+// Internal bridge for process envelope <-> engine collaboration.
+// These operations are not part of the public engine API; they exist
+// solely to support the envelope's wait lifecycle orchestration.
+// Engine declares this class as a friend.
+class ProcessEnvelopeAccess {
+ public:
+  static auto UsesWaitSiteLifecycle(const Engine& engine) -> bool {
+    return engine.wait_site_meta_.IsPopulated();
+  }
+
+  static auto CanRefreshInstalledWait(
+      const Engine& engine, ProcessHandle handle, WaitSiteId wait_site_id)
+      -> bool {
+    return engine.CanRefreshInstalledWait(handle, wait_site_id);
+  }
+
+  static auto HasPendingDirtyState(const Engine& engine) -> bool {
+    return engine.HasPendingDirtyState();
+  }
+
+  static void SetProcessWaitKind(
+      Engine& engine, uint32_t process_id, ProcessWaitKind kind) {
+    engine.SetProcessWaitKind(process_id, kind);
+  }
+
+  static void ResetInstalledWait(Engine& engine, ProcessHandle handle) {
+    engine.ResetInstalledWait(handle);
+  }
+
+  static void InstallTriggers(
+      Engine& engine, ProcessHandle handle, const WaitRequest& req) {
+    engine.InstallTriggers(handle, req);
+  }
+
+  static void InstallWaitSite(
+      Engine& engine, ProcessHandle handle, const WaitRequest& req) {
+    engine.InstallWaitSite(handle, req);
+  }
+
+  static auto RefreshInstalledSnapshots(Engine& engine, ProcessHandle handle)
+      -> bool {
+    return engine.RefreshInstalledSnapshots(handle);
+  }
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/engine_subscriptions.hpp
+++ b/include/lyra/runtime/engine_subscriptions.hpp
@@ -8,6 +8,7 @@
 #include "lyra/common/bit_target_mapping.hpp"
 #include "lyra/common/edge_kind.hpp"
 #include "lyra/common/index_plan.hpp"
+#include "lyra/runtime/engine_types.hpp"
 #include "lyra/runtime/signal_coord.hpp"
 #include "lyra/runtime/wait_site.hpp"
 
@@ -279,7 +280,8 @@ struct InstalledWaitState {
 
 // Per-process state (keyed by ProcessHandle).
 struct ProcessState {
-  bool is_enqueued = false;  // De-dup flag for next-delta queue
+  bool is_enqueued = false;
+  ProcessWaitKind wait_kind = ProcessWaitKind::kFinished;
   size_t subscription_count = 0;
   std::vector<SubRef> sub_refs;
   IndexPlanPool plan_pool;

--- a/include/lyra/runtime/engine_types.hpp
+++ b/include/lyra/runtime/engine_types.hpp
@@ -71,4 +71,21 @@ struct LocalConnectionTarget {
 using ConnectionTarget =
     std::variant<GlobalConnectionTarget, LocalConnectionTarget>;
 
+// Coarse per-process wait-state classification.
+// Set by the process envelope after each activation. Observability may
+// refine kSuspendedWait into edge/change/multi via subscription analysis.
+enum class ProcessWaitKind : uint8_t {
+  kRunning,
+  kReady,
+  kSuspendedDelay,
+  kSuspendedWait,
+  kSuspendedEdge,
+  kSuspendedChange,
+  kSuspendedMulti,
+  kSuspendedRepeat,
+  kSuspendedEvent,
+  kSuspendedUnknown,
+  kFinished,
+};
+
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/process_envelope.hpp
+++ b/include/lyra/runtime/process_envelope.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+
+#include "lyra/runtime/engine_types.hpp"
+#include "lyra/runtime/simulation.hpp"
+
+namespace lyra::runtime {
+
+class Engine;
+
+// Dispatch a process activation and handle the result.
+// Envelope-owned orchestration: resets SuspendRecord, invokes the process
+// body, decodes the raw suspend protocol into semantic requests, then calls
+// narrow engine scheduling primitives (Delay, InstallTriggers, HandleTrap,
+// etc.) to act on the result. All protocol details and borrowed spans are
+// confined to this function's scope.
+void DispatchAndHandleActivation(
+    std::span<LyraProcessFunc> connection_procs, std::span<void*> states,
+    uint32_t num_connection, Engine& engine, ProcessHandle handle,
+    ResumePoint resume);
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/process_requests.hpp
+++ b/include/lyra/runtime/process_requests.hpp
@@ -3,13 +3,12 @@
 #include <cstdint>
 #include <span>
 
+#include "lyra/common/index_plan.hpp"
 #include "lyra/runtime/engine_types.hpp"
 #include "lyra/runtime/trigger_record.hpp"
 #include "lyra/runtime/wait_site.hpp"
 
 namespace lyra::runtime {
-
-struct IndexPlanOp;
 
 // Semantic process scheduling requests. Produced by the process envelope
 // after decoding the raw suspend protocol. Consumed by engine scheduling
@@ -20,13 +19,21 @@ struct DelayRequest {
   uint64_t ticks = 0;
 };
 
+// Late-bound rebind payload: headers index into plan_ops and dep_slots
+// via start/count pairs. These three arrays are always consumed together
+// and only by the subscription install path's rebind loop.
+// Empty headers means no late-bound data.
+struct LateBoundData {
+  std::span<const LateBoundHeader> headers = {};
+  std::span<const IndexPlanOp> plan_ops = {};
+  std::span<const DepSignalRecord> dep_slots = {};
+};
+
 struct WaitRequest {
   ResumePoint resume = {};
   WaitSiteId wait_site_id = kInvalidWaitSiteId;
   std::span<const WaitTriggerRecord> triggers = {};
-  std::span<const LateBoundHeader> late_bound = {};
-  std::span<const IndexPlanOp> plan_ops = {};
-  std::span<const DepSignalRecord> dep_slots = {};
+  LateBoundData late_bound = {};
 };
 
 struct RepeatRequest {

--- a/include/lyra/runtime/process_requests.hpp
+++ b/include/lyra/runtime/process_requests.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+
+#include "lyra/runtime/engine_types.hpp"
+#include "lyra/runtime/trigger_record.hpp"
+#include "lyra/runtime/wait_site.hpp"
+
+namespace lyra::runtime {
+
+struct IndexPlanOp;
+
+// Semantic process scheduling requests. Produced by the process envelope
+// after decoding the raw suspend protocol. Consumed by engine scheduling
+// primitives. These are runtime-semantic types, not transport artifacts.
+
+struct DelayRequest {
+  ResumePoint resume = {};
+  uint64_t ticks = 0;
+};
+
+struct WaitRequest {
+  ResumePoint resume = {};
+  WaitSiteId wait_site_id = kInvalidWaitSiteId;
+  std::span<const WaitTriggerRecord> triggers = {};
+  std::span<const LateBoundHeader> late_bound = {};
+  std::span<const IndexPlanOp> plan_ops = {};
+  std::span<const DepSignalRecord> dep_slots = {};
+};
+
+struct RepeatRequest {
+  ResumePoint resume = {};
+};
+
+struct EventWaitRequest {
+  ResumePoint resume = {};
+  uint32_t event_id = 0;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/scheduler_snapshot.hpp
+++ b/include/lyra/runtime/scheduler_snapshot.hpp
@@ -9,22 +9,6 @@
 
 namespace lyra::runtime {
 
-// Canonical per-process wait-state classification.
-// Derived from SuspendTag in the process's SuspendRecord (the runtime's
-// canonical suspend state), enriched by subscription and queue membership.
-enum class ProcessWaitKind : uint8_t {
-  kRunning,
-  kReady,
-  kSuspendedDelay,
-  kSuspendedEdge,
-  kSuspendedChange,
-  kSuspendedMulti,
-  kSuspendedRepeat,
-  kSuspendedEvent,
-  kSuspendedUnknown,
-  kFinished,
-};
-
 // Why the simulation stopped. Stored as canonical state in Engine, set
 // exactly once at the point where termination reason becomes known.
 enum class SimulationEndReason : uint8_t {

--- a/include/lyra/runtime/signal_coord.hpp
+++ b/include/lyra/runtime/signal_coord.hpp
@@ -5,7 +5,7 @@
 #include <variant>
 
 #include "lyra/common/edge_kind.hpp"
-#include "lyra/runtime/suspend_record.hpp"
+#include "lyra/runtime/trigger_record.hpp"
 
 namespace lyra::runtime {
 

--- a/include/lyra/runtime/suspend_record.hpp
+++ b/include/lyra/runtime/suspend_record.hpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "lyra/runtime/trigger_record.hpp"
 #include "lyra/runtime/wait_site.hpp"
 
 namespace lyra::runtime {
@@ -19,134 +20,6 @@ enum class SuspendTag : uint8_t {
   kRepeat = 3,
   kWaitEvent = 4,
 };
-
-// Trigger install kind: explicit per-trigger classification written by codegen.
-// Runtime installs subscriptions directly from this kind without inferring it
-// from EdgeKind or late-bound header presence.
-enum class TriggerInstallKind : uint8_t {
-  kEdge = 0,
-  kChange = 1,
-  kContainer = 2,
-};
-
-// Trigger flags: explicit per-trigger metadata written by codegen.
-inline constexpr uint8_t kTriggerInitiallyActive = 0x01;
-// R5: signal_id is a body-local LocalSignalId. Runtime resolves the
-// owning instance from the process owner (same-instance).
-inline constexpr uint8_t kTriggerLocalSignal = 0x02;
-// R5: cross-instance local trigger. target_instance_id and
-// target_local_signal_id carry the typed identity. Always combined
-// with kTriggerLocalSignal.
-inline constexpr uint8_t kTriggerCrossInstanceLocal = 0x04;
-
-// R5: Per-dependency signal record for typed rebind dependencies.
-// Each dependency carries its own domain identity (local or global),
-// independent of the target trigger's domain.
-struct DepSignalRecord {
-  uint32_t signal_id = 0;
-  uint8_t flags = 0;
-  std::array<uint8_t, 3> padding = {};
-  // R5: valid when kDepCrossInstanceLocal is set.
-  uint32_t target_instance_id = 0;
-  uint32_t target_local_signal_id = 0;
-};
-inline constexpr uint8_t kDepLocalSignal = 0x01;
-inline constexpr uint8_t kDepCrossInstanceLocal = 0x02;
-static_assert(sizeof(DepSignalRecord) == 16);
-static_assert(alignof(DepSignalRecord) == 4);
-
-struct WaitTriggerRecord {
-  uint32_t signal_id = 0;
-  uint8_t edge = 0;  // common::EdgeKind
-  // kEdge/kChange: bit position within observed byte.
-  // kContainer: must be 0 (unused).
-  uint8_t bit_index = 0;
-  uint8_t kind = 0;   // TriggerInstallKind
-  uint8_t flags = 0;  // kTriggerInitiallyActive
-
-  // Per-kind semantics:
-  //   kEdge/kChange: byte offset within slot (observation start).
-  //   kContainer: element index (sv_index). Runtime uses this directly
-  //     as the logical container element index, not as a byte offset.
-  uint32_t byte_offset = 0;
-
-  // Per-kind semantics:
-  //   kEdge/kChange: observation size in bytes; 0 = full slot.
-  //   kContainer: unused (set to 0).
-  uint32_t byte_size = 0;
-
-  // For kContainer only. Element stride in bytes. 0 for non-container triggers.
-  uint32_t container_elem_stride = 0;
-
-  // R5: valid when kTriggerCrossInstanceLocal is set.
-  uint32_t target_instance_id = 0;
-  uint32_t target_local_signal_id = 0;
-};
-
-static_assert(
-    sizeof(WaitTriggerRecord) == 28, "WaitTriggerRecord size mismatch");
-static_assert(
-    alignof(WaitTriggerRecord) == 4, "WaitTriggerRecord alignment mismatch");
-static_assert(
-    offsetof(WaitTriggerRecord, bit_index) == 5,
-    "WaitTriggerRecord bit_index offset mismatch");
-static_assert(
-    offsetof(WaitTriggerRecord, kind) == 6,
-    "WaitTriggerRecord kind offset mismatch");
-static_assert(
-    offsetof(WaitTriggerRecord, flags) == 7,
-    "WaitTriggerRecord flags offset mismatch");
-static_assert(
-    offsetof(WaitTriggerRecord, byte_offset) == 8,
-    "WaitTriggerRecord byte_offset offset mismatch");
-static_assert(
-    offsetof(WaitTriggerRecord, byte_size) == 12,
-    "WaitTriggerRecord byte_size offset mismatch");
-static_assert(
-    offsetof(WaitTriggerRecord, container_elem_stride) == 16,
-    "WaitTriggerRecord container_elem_stride offset mismatch");
-static_assert(
-    offsetof(WaitTriggerRecord, target_instance_id) == 20,
-    "WaitTriggerRecord target_instance_id offset mismatch");
-static_assert(
-    offsetof(WaitTriggerRecord, target_local_signal_id) == 24,
-    "WaitTriggerRecord target_local_signal_id offset mismatch");
-
-// Late-bound header for dynamic-index edge triggers.
-// References into plan_ops and dep_slots pools via start/count spans.
-struct LateBoundHeader {
-  uint32_t trigger_index = 0;
-  uint16_t plan_ops_start = 0;
-  uint16_t plan_ops_count = 0;
-  uint16_t dep_slots_start = 0;
-  uint16_t dep_slots_count = 0;
-  int32_t index_base = 0;
-  int32_t index_step = 1;
-  uint32_t total_bits = 0;
-  uint32_t container_elem_stride = 0;  // 0 = not container, >0 = container mode
-};
-
-static_assert(sizeof(LateBoundHeader) == 28, "LateBoundHeader size mismatch");
-static_assert(
-    alignof(LateBoundHeader) == 4, "LateBoundHeader alignment mismatch");
-static_assert(
-    offsetof(LateBoundHeader, plan_ops_start) == 4,
-    "LateBoundHeader plan_ops_start offset mismatch");
-static_assert(
-    offsetof(LateBoundHeader, dep_slots_start) == 8,
-    "LateBoundHeader dep_slots_start offset mismatch");
-static_assert(
-    offsetof(LateBoundHeader, index_base) == 12,
-    "LateBoundHeader index_base offset mismatch");
-static_assert(
-    offsetof(LateBoundHeader, index_step) == 16,
-    "LateBoundHeader index_step offset mismatch");
-static_assert(
-    offsetof(LateBoundHeader, total_bits) == 20,
-    "LateBoundHeader total_bits offset mismatch");
-static_assert(
-    offsetof(LateBoundHeader, container_elem_stride) == 24,
-    "LateBoundHeader container_elem_stride offset mismatch");
 
 // Descriptor for kernelized connection processes.
 // Stored in the process frame; the single runtime kernel reads these fields

--- a/include/lyra/runtime/trigger_record.hpp
+++ b/include/lyra/runtime/trigger_record.hpp
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace lyra::runtime {
+
+// Trigger install kind: explicit per-trigger classification written by codegen.
+// Runtime installs subscriptions directly from this kind without inferring it
+// from EdgeKind or late-bound header presence.
+enum class TriggerInstallKind : uint8_t {
+  kEdge = 0,
+  kChange = 1,
+  kContainer = 2,
+};
+
+// Trigger flags: explicit per-trigger metadata written by codegen.
+inline constexpr uint8_t kTriggerInitiallyActive = 0x01;
+// R5: signal_id is a body-local LocalSignalId. Runtime resolves the
+// owning instance from the process owner (same-instance).
+inline constexpr uint8_t kTriggerLocalSignal = 0x02;
+// R5: cross-instance local trigger. target_instance_id and
+// target_local_signal_id carry the typed identity. Always combined
+// with kTriggerLocalSignal.
+inline constexpr uint8_t kTriggerCrossInstanceLocal = 0x04;
+
+// R5: Per-dependency signal record for typed rebind dependencies.
+// Each dependency carries its own domain identity (local or global),
+// independent of the target trigger's domain.
+struct DepSignalRecord {
+  uint32_t signal_id = 0;
+  uint8_t flags = 0;
+  std::array<uint8_t, 3> padding = {};
+  // R5: valid when kDepCrossInstanceLocal is set.
+  uint32_t target_instance_id = 0;
+  uint32_t target_local_signal_id = 0;
+};
+inline constexpr uint8_t kDepLocalSignal = 0x01;
+inline constexpr uint8_t kDepCrossInstanceLocal = 0x02;
+static_assert(sizeof(DepSignalRecord) == 16);
+static_assert(alignof(DepSignalRecord) == 4);
+
+struct WaitTriggerRecord {
+  uint32_t signal_id = 0;
+  uint8_t edge = 0;  // common::EdgeKind
+  // kEdge/kChange: bit position within observed byte.
+  // kContainer: must be 0 (unused).
+  uint8_t bit_index = 0;
+  uint8_t kind = 0;   // TriggerInstallKind
+  uint8_t flags = 0;  // kTriggerInitiallyActive
+
+  // Per-kind semantics:
+  //   kEdge/kChange: byte offset within slot (observation start).
+  //   kContainer: element index (sv_index). Runtime uses this directly
+  //     as the logical container element index, not as a byte offset.
+  uint32_t byte_offset = 0;
+
+  // Per-kind semantics:
+  //   kEdge/kChange: observation size in bytes; 0 = full slot.
+  //   kContainer: unused (set to 0).
+  uint32_t byte_size = 0;
+
+  // For kContainer only. Element stride in bytes. 0 for non-container triggers.
+  uint32_t container_elem_stride = 0;
+
+  // R5: valid when kTriggerCrossInstanceLocal is set.
+  uint32_t target_instance_id = 0;
+  uint32_t target_local_signal_id = 0;
+};
+
+static_assert(
+    sizeof(WaitTriggerRecord) == 28, "WaitTriggerRecord size mismatch");
+static_assert(
+    alignof(WaitTriggerRecord) == 4, "WaitTriggerRecord alignment mismatch");
+static_assert(
+    offsetof(WaitTriggerRecord, bit_index) == 5,
+    "WaitTriggerRecord bit_index offset mismatch");
+static_assert(
+    offsetof(WaitTriggerRecord, kind) == 6,
+    "WaitTriggerRecord kind offset mismatch");
+static_assert(
+    offsetof(WaitTriggerRecord, flags) == 7,
+    "WaitTriggerRecord flags offset mismatch");
+static_assert(
+    offsetof(WaitTriggerRecord, byte_offset) == 8,
+    "WaitTriggerRecord byte_offset offset mismatch");
+static_assert(
+    offsetof(WaitTriggerRecord, byte_size) == 12,
+    "WaitTriggerRecord byte_size offset mismatch");
+static_assert(
+    offsetof(WaitTriggerRecord, container_elem_stride) == 16,
+    "WaitTriggerRecord container_elem_stride offset mismatch");
+static_assert(
+    offsetof(WaitTriggerRecord, target_instance_id) == 20,
+    "WaitTriggerRecord target_instance_id offset mismatch");
+static_assert(
+    offsetof(WaitTriggerRecord, target_local_signal_id) == 24,
+    "WaitTriggerRecord target_local_signal_id offset mismatch");
+
+// Late-bound header for dynamic-index edge triggers.
+// References into plan_ops and dep_slots pools via start/count spans.
+struct LateBoundHeader {
+  uint32_t trigger_index = 0;
+  uint16_t plan_ops_start = 0;
+  uint16_t plan_ops_count = 0;
+  uint16_t dep_slots_start = 0;
+  uint16_t dep_slots_count = 0;
+  int32_t index_base = 0;
+  int32_t index_step = 1;
+  uint32_t total_bits = 0;
+  uint32_t container_elem_stride = 0;  // 0 = not container, >0 = container mode
+};
+
+static_assert(sizeof(LateBoundHeader) == 28, "LateBoundHeader size mismatch");
+static_assert(
+    alignof(LateBoundHeader) == 4, "LateBoundHeader alignment mismatch");
+static_assert(
+    offsetof(LateBoundHeader, plan_ops_start) == 4,
+    "LateBoundHeader plan_ops_start offset mismatch");
+static_assert(
+    offsetof(LateBoundHeader, dep_slots_start) == 8,
+    "LateBoundHeader dep_slots_start offset mismatch");
+static_assert(
+    offsetof(LateBoundHeader, index_base) == 12,
+    "LateBoundHeader index_base offset mismatch");
+static_assert(
+    offsetof(LateBoundHeader, index_step) == 16,
+    "LateBoundHeader index_step offset mismatch");
+static_assert(
+    offsetof(LateBoundHeader, total_bits) == 20,
+    "LateBoundHeader total_bits offset mismatch");
+static_assert(
+    offsetof(LateBoundHeader, container_elem_stride) == 24,
+    "LateBoundHeader container_elem_stride offset mismatch");
+
+}  // namespace lyra::runtime

--- a/src/lyra/runtime/engine_scheduler_activation.cpp
+++ b/src/lyra/runtime/engine_scheduler_activation.cpp
@@ -203,10 +203,11 @@ void Engine::ExecuteActiveRegion() {
       if (!HasPostActivationReconciliation()) {
         ClearProcessSubscriptions(handle);
       }
+      // Activation handling (scheduling, subscription install/refresh)
+      // is performed by the process envelope inside the dispatch callback.
+      // DispatchAndHandleActivation decodes the raw suspend protocol into
+      // semantic requests and calls engine primitives directly.
       RunOneActivation(entry);
-      if (!finished_ && HasPostActivationReconciliation()) {
-        ReconcilePostActivation(handle);
-      }
     }
     ++active_iterations;
     if (active_iterations % 2 == 0) {

--- a/src/lyra/runtime/engine_scheduler_activation.cpp
+++ b/src/lyra/runtime/engine_scheduler_activation.cpp
@@ -200,7 +200,7 @@ void Engine::ExecuteActiveRegion() {
       }
 
       ProcessHandle handle{entry.process_id, entry.instance_id};
-      if (!HasPostActivationReconciliation()) {
+      if (!UsesWaitSiteLifecycle()) {
         ClearProcessSubscriptions(handle);
       }
       // Activation handling (scheduling, subscription install/refresh)

--- a/src/lyra/runtime/engine_scheduler_observability.cpp
+++ b/src/lyra/runtime/engine_scheduler_observability.cpp
@@ -380,6 +380,7 @@ auto WaitKindLabel(ProcessWaitKind kind) -> std::string_view {
       return "suspended(repeat)";
     case ProcessWaitKind::kSuspendedEvent:
       return "suspended(event)";
+    case ProcessWaitKind::kSuspendedWait:
     case ProcessWaitKind::kSuspendedUnknown:
       return "suspended(unknown)";
     case ProcessWaitKind::kFinished:
@@ -500,31 +501,16 @@ auto Engine::TakeSchedulerSnapshot() const -> SchedulerSnapshot {
       kind = ProcessWaitKind::kRunning;
     } else if (is_ready[pid] || proc.is_enqueued) {
       kind = ProcessWaitKind::kReady;
-    } else if (
-        pid < suspend_records_.size() && suspend_records_[pid] != nullptr) {
-      // Use SuspendRecord::tag as the canonical authority.
-      switch (suspend_records_[pid]->tag) {
-        case SuspendTag::kFinished:
-          kind = ProcessWaitKind::kFinished;
-          break;
-        case SuspendTag::kDelay:
-          kind = ProcessWaitKind::kSuspendedDelay;
-          if (in_delay[pid]) target_time = delay_target[pid];
-          break;
-        case SuspendTag::kWait:
-          kind = RefineWaitKind(proc.sub_refs);
-          break;
-        case SuspendTag::kRepeat:
-          kind = ProcessWaitKind::kSuspendedRepeat;
-          break;
-        case SuspendTag::kWaitEvent:
-          kind = ProcessWaitKind::kSuspendedEvent;
-          break;
+    } else {
+      kind = proc.wait_kind;
+      // Refine coarse kSuspendedWait into edge/change/multi from
+      // subscription state.
+      if (kind == ProcessWaitKind::kSuspendedWait) {
+        kind = RefineWaitKind(proc.sub_refs);
       }
-    } else if (in_delay[pid]) {
-      // Fallback for processes without suspend records.
-      kind = ProcessWaitKind::kSuspendedDelay;
-      target_time = delay_target[pid];
+      if (kind == ProcessWaitKind::kSuspendedDelay && in_delay[pid]) {
+        target_time = delay_target[pid];
+      }
     }
 
     // Only include suspended processes.

--- a/src/lyra/runtime/engine_subscriptions_install.cpp
+++ b/src/lyra/runtime/engine_subscriptions_install.cpp
@@ -17,7 +17,6 @@
 #include "lyra/runtime/engine_types.hpp"
 #include "lyra/runtime/index_plan.hpp"
 #include "lyra/runtime/slot_meta.hpp"
-#include "lyra/runtime/suspend_record.hpp"
 #include "lyra/runtime/update_set.hpp"
 #include "lyra/runtime/wait_site.hpp"
 
@@ -30,9 +29,8 @@
 //      SubscribeRebind
 //   2. Subscription removal: Remove{Edge,Change,RebindWatcher,Container}Sub,
 //      ClearInstalledSubscriptions (swap-and-pop with SubRef backpatch)
-//   3. Post-activation reconciliation: ReconcilePostActivation,
-//      RefreshInstalledSnapshots (routes by SuspendTag, refreshes cold
-//      snapshots for persistent waits)
+//   3. Wait-site lifecycle: InstallWaitSite, RefreshInstalledSnapshots,
+//      CanRefreshInstalledWait, HasPendingDirtyState (called by envelope)
 //
 // Cross-file dependency: RemoveEdgeSubFromBucket is also called from
 // engine_subscriptions_flush.cpp (RebindSubscription group migration).
@@ -525,12 +523,10 @@ auto Engine::RefreshInstalledSnapshots(ProcessHandle handle) -> bool {
   return needs_reinstall;
 }
 
-void Engine::InstallTriggers(
-    ProcessHandle handle, ResumePoint resume,
-    std::span<const WaitTriggerRecord> triggers,
-    std::span<const LateBoundHeader> late_bound,
-    std::span<const IndexPlanOp> plan_ops,
-    std::span<const DepSignalRecord> dep_records) {
+void Engine::InstallTriggers(ProcessHandle handle, const WaitRequest& req) {
+  auto resume = req.resume;
+  auto triggers = req.triggers;
+  const auto& late_bound = req.late_bound;
   // Track created subscription info for late-bound rebinding.
   // Invariant: created_subs[i] records the dense vector index assigned
   // to trigger i at creation time. These indices remain stable within
@@ -544,7 +540,7 @@ void Engine::InstallTriggers(
     EdgeBucket edge_bucket = EdgeBucket::kPosedge;
     bool is_local = false;
   };
-  bool has_late_bound = !late_bound.empty();
+  bool has_late_bound = !late_bound.headers.empty();
   std::vector<CreatedSub> created_subs;
   if (has_late_bound) {
     created_subs.resize(
@@ -691,8 +687,8 @@ void Engine::InstallTriggers(
   }
 
   // Install rebind watchers from late-bound headers.
-  for (uint32_t h = 0; h < late_bound.size(); ++h) {
-    const auto& hdr = late_bound[h];
+  for (uint32_t h = 0; h < late_bound.headers.size(); ++h) {
+    const auto& hdr = late_bound.headers[h];
 
     if (hdr.trigger_index >= triggers.size()) {
       throw common::InternalError(
@@ -702,20 +698,22 @@ void Engine::InstallTriggers(
               hdr.trigger_index, triggers.size()));
     }
     if (static_cast<uint64_t>(hdr.plan_ops_start) + hdr.plan_ops_count >
-        plan_ops.size()) {
+        late_bound.plan_ops.size()) {
       throw common::InternalError(
           "Engine::InstallTriggers",
           std::format(
               "late_bound[{}]: plan_ops span [{}, +{}) exceeds pool size {}", h,
-              hdr.plan_ops_start, hdr.plan_ops_count, plan_ops.size()));
+              hdr.plan_ops_start, hdr.plan_ops_count,
+              late_bound.plan_ops.size()));
     }
     if (static_cast<uint64_t>(hdr.dep_slots_start) + hdr.dep_slots_count >
-        dep_records.size()) {
+        late_bound.dep_slots.size()) {
       throw common::InternalError(
           "Engine::InstallTriggers",
           std::format(
               "late_bound[{}]: dep_slots span [{}, +{}) exceeds pool size {}",
-              h, hdr.dep_slots_start, hdr.dep_slots_count, dep_records.size()));
+              h, hdr.dep_slots_start, hdr.dep_slots_count,
+              late_bound.dep_slots.size()));
     }
 
     const auto& target = created_subs[hdr.trigger_index];
@@ -726,7 +724,8 @@ void Engine::InstallTriggers(
         .index_base = hdr.index_base,
         .index_step = hdr.index_step,
         .total_bits = hdr.total_bits};
-    auto hdr_plan = plan_ops.subspan(hdr.plan_ops_start, hdr.plan_ops_count);
+    auto hdr_plan =
+        late_bound.plan_ops.subspan(hdr.plan_ops_start, hdr.plan_ops_count);
 
     // Resolve instance_id for the process (used for local deps).
     InstanceId rebind_inst_id =
@@ -736,7 +735,7 @@ void Engine::InstallTriggers(
 
     // Decode each dep record into a typed SignalRef.
     auto hdr_dep_records =
-        dep_records.subspan(hdr.dep_slots_start, hdr.dep_slots_count);
+        late_bound.dep_slots.subspan(hdr.dep_slots_start, hdr.dep_slots_count);
     std::vector<SignalRef> dep_signals;
     dep_signals.reserve(hdr_dep_records.size());
     for (const auto& rec : hdr_dep_records) {
@@ -772,9 +771,8 @@ void Engine::InstallTriggers(
   }
 }
 
-void Engine::InstallWaitSite(
-    ProcessHandle handle, const WaitRequest& req,
-    const CompiledWaitSite& descriptor) {
+void Engine::InstallWaitSite(ProcessHandle handle, const WaitRequest& req) {
+  const auto& descriptor = wait_site_meta_.Get(req.wait_site_id);
   // Validate compiled-vs-runtime agreement before any installation work.
   if (descriptor.resume_block != req.resume.block_index) {
     throw common::InternalError(
@@ -795,7 +793,7 @@ void Engine::InstallWaitSite(
             req.triggers.size()));
   }
 
-  bool has_late_bound = !req.late_bound.empty();
+  bool has_late_bound = !req.late_bound.headers.empty();
 
   // Validate late-bound presence matches compiled descriptor.
   if (has_late_bound != descriptor.has_late_bound) {
@@ -808,9 +806,7 @@ void Engine::InstallWaitSite(
             has_late_bound));
   }
 
-  InstallTriggers(
-      handle, req.resume, req.triggers, req.late_bound, req.plan_ops,
-      req.dep_slots);
+  InstallTriggers(handle, req);
 
   // Install-time realized-state invariant: when the compiled shape is
   // kStatic, the installed subscription set must contain only
@@ -872,58 +868,17 @@ void Engine::InstallWaitSite(
   }
 }
 
-void Engine::RegisterSuspendRecords(std::span<SuspendRecord*> records) {
-  suspend_records_.assign(records.begin(), records.end());
-}
-
-// True when the process re-entered the same wait site whose installed
-// subscriptions support snapshot-only refresh.
-static auto CanRefreshInPlace(
-    const InstalledWaitState& installed, WaitSiteId suspend_wait_site_id)
-    -> bool {
-  return installed.valid && installed.wait_site_id == suspend_wait_site_id &&
+auto Engine::CanRefreshInstalledWait(
+    ProcessHandle handle, WaitSiteId wait_site_id) const -> bool {
+  if (handle.process_id >= process_states_.size()) return false;
+  const auto& installed = process_states_[handle.process_id].installed_wait;
+  return installed.valid && installed.wait_site_id == wait_site_id &&
          installed.can_refresh_snapshot;
 }
 
-void Engine::HandleWaitRequest(ProcessHandle handle, const WaitRequest& req) {
-  if (!HasPostActivationReconciliation()) {
-    InstallTriggers(
-        handle, req.resume, req.triggers, req.late_bound, req.plan_ops,
-        req.dep_slots);
-    return;
-  }
-
-  if (req.wait_site_id == kInvalidWaitSiteId) {
-    throw common::InternalError(
-        "Engine::HandleWaitRequest",
-        std::format(
-            "process {} suspended with kWait but wait_site_id is invalid",
-            handle.process_id));
-  }
-
-  auto& proc_state = process_states_[handle.process_id];
-
-  if (!CanRefreshInPlace(proc_state.installed_wait, req.wait_site_id)) {
-    const auto& descriptor = wait_site_meta_.Get(req.wait_site_id);
-    ResetInstalledWait(handle);
-    InstallWaitSite(handle, req, descriptor);
-    return;
-  }
-
-  // Flush owns baseline advancement for installed edge/change waits.
-  // Post-activation refresh is only needed when post-flush slot
-  // dirties are recorded in delta_dirty_.
-  bool has_any_dirty =
-      !update_set_.DeltaDirtySlots().empty() || !delta_dirty_instances_.empty();
-  if (!has_any_dirty) {
-    return;
-  }
-
-  if (RefreshInstalledSnapshots(handle)) {
-    const auto& descriptor = wait_site_meta_.Get(req.wait_site_id);
-    ResetInstalledWait(handle);
-    InstallWaitSite(handle, req, descriptor);
-  }
+auto Engine::HasPendingDirtyState() const -> bool {
+  return !update_set_.DeltaDirtySlots().empty() ||
+         !delta_dirty_instances_.empty();
 }
 
 // R5: Domain-split edge/change subscribe helpers.

--- a/src/lyra/runtime/engine_subscriptions_install.cpp
+++ b/src/lyra/runtime/engine_subscriptions_install.cpp
@@ -3,6 +3,8 @@
 #include <cstring>
 #include <format>
 #include <span>
+#include <type_traits>
+#include <variant>
 #include <vector>
 
 #include "lyra/common/bit_target_mapping.hpp"
@@ -771,34 +773,29 @@ void Engine::InstallTriggers(
 }
 
 void Engine::InstallWaitSite(
-    ProcessHandle handle, SuspendRecord* suspend,
+    ProcessHandle handle, const WaitRequest& req,
     const CompiledWaitSite& descriptor) {
   // Validate compiled-vs-runtime agreement before any installation work.
-  if (descriptor.resume_block != suspend->resume_block) {
+  if (descriptor.resume_block != req.resume.block_index) {
     throw common::InternalError(
         "Engine::InstallWaitSite",
         std::format(
             "process {} wait_site {} resume_block mismatch: "
-            "descriptor={} vs suspend={}",
+            "descriptor={} vs request={}",
             handle.process_id, descriptor.id, descriptor.resume_block,
-            suspend->resume_block));
+            req.resume.block_index));
   }
-  if (descriptor.num_triggers != suspend->num_triggers) {
+  if (descriptor.num_triggers != static_cast<uint32_t>(req.triggers.size())) {
     throw common::InternalError(
         "Engine::InstallWaitSite",
         std::format(
             "process {} wait_site {} num_triggers mismatch: "
-            "descriptor={} vs suspend={}",
+            "descriptor={} vs request={}",
             handle.process_id, descriptor.id, descriptor.num_triggers,
-            suspend->num_triggers));
+            req.triggers.size()));
   }
 
-  auto resume =
-      ResumePoint{.block_index = suspend->resume_block, .instruction_index = 0};
-  auto triggers = std::span(suspend->triggers_ptr, suspend->num_triggers);
-
-  bool has_late_bound =
-      suspend->num_late_bound > 0 && suspend->late_bound_ptr != nullptr;
+  bool has_late_bound = !req.late_bound.empty();
 
   // Validate late-bound presence matches compiled descriptor.
   if (has_late_bound != descriptor.has_late_bound) {
@@ -806,24 +803,14 @@ void Engine::InstallWaitSite(
         "Engine::InstallWaitSite",
         std::format(
             "process {} wait_site {}: has_late_bound mismatch: "
-            "descriptor={} vs suspend={}",
+            "descriptor={} vs request={}",
             handle.process_id, descriptor.id, descriptor.has_late_bound,
             has_late_bound));
   }
 
-  auto late_bound =
-      has_late_bound
-          ? std::span(suspend->late_bound_ptr, suspend->num_late_bound)
-          : std::span<const LateBoundHeader>{};
-  auto plan_ops = (suspend->plan_ops_ptr != nullptr)
-                      ? std::span(suspend->plan_ops_ptr, suspend->num_plan_ops)
-                      : std::span<const IndexPlanOp>{};
-  auto dep_records =
-      (suspend->dep_slots_ptr != nullptr)
-          ? std::span(suspend->dep_slots_ptr, suspend->num_dep_slots)
-          : std::span<const DepSignalRecord>{};
-
-  InstallTriggers(handle, resume, triggers, late_bound, plan_ops, dep_records);
+  InstallTriggers(
+      handle, req.resume, req.triggers, req.late_bound, req.plan_ops,
+      req.dep_slots);
 
   // Install-time realized-state invariant: when the compiled shape is
   // kStatic, the installed subscription set must contain only
@@ -898,103 +885,44 @@ static auto CanRefreshInPlace(
          installed.can_refresh_snapshot;
 }
 
-void Engine::ReconcilePostActivation(ProcessHandle handle) {
+void Engine::HandleWaitRequest(ProcessHandle handle, const WaitRequest& req) {
   if (!HasPostActivationReconciliation()) {
-    throw common::InternalError(
-        "Engine::ReconcilePostActivation",
-        "called without post-activation reconciliation capability");
+    InstallTriggers(
+        handle, req.resume, req.triggers, req.late_bound, req.plan_ops,
+        req.dep_slots);
+    return;
   }
-  if (handle.process_id >= suspend_records_.size()) {
+
+  if (req.wait_site_id == kInvalidWaitSiteId) {
     throw common::InternalError(
-        "Engine::ReconcilePostActivation",
+        "Engine::HandleWaitRequest",
         std::format(
-            "process_id {} >= suspend_records size {}", handle.process_id,
-            suspend_records_.size()));
+            "process {} suspended with kWait but wait_site_id is invalid",
+            handle.process_id));
   }
-  auto* suspend = suspend_records_[handle.process_id];
 
-  auto resume =
-      ResumePoint{.block_index = suspend->resume_block, .instruction_index = 0};
+  auto& proc_state = process_states_[handle.process_id];
 
-  switch (suspend->tag) {
-    case SuspendTag::kFinished:
-      ResetInstalledWait(handle);
-      break;
+  if (!CanRefreshInPlace(proc_state.installed_wait, req.wait_site_id)) {
+    const auto& descriptor = wait_site_meta_.Get(req.wait_site_id);
+    ResetInstalledWait(handle);
+    InstallWaitSite(handle, req, descriptor);
+    return;
+  }
 
-    case SuspendTag::kDelay:
-      ResetInstalledWait(handle);
-      Delay(handle, resume, suspend->delay_ticks);
-      break;
+  // Flush owns baseline advancement for installed edge/change waits.
+  // Post-activation refresh is only needed when post-flush slot
+  // dirties are recorded in delta_dirty_.
+  bool has_any_dirty =
+      !update_set_.DeltaDirtySlots().empty() || !delta_dirty_instances_.empty();
+  if (!has_any_dirty) {
+    return;
+  }
 
-    case SuspendTag::kWait: {
-      if (suspend->wait_site_id == kInvalidWaitSiteId) {
-        throw common::InternalError(
-            "Engine::ReconcilePostActivation",
-            std::format(
-                "process {} suspended with kWait but wait_site_id is invalid",
-                handle.process_id));
-      }
-
-      auto& proc_state = process_states_[handle.process_id];
-
-      if (!CanRefreshInPlace(
-              proc_state.installed_wait, suspend->wait_site_id)) {
-        // Reinstall required: different wait site or non-static shape.
-        const auto& descriptor = wait_site_meta_.Get(suspend->wait_site_id);
-        ResetInstalledWait(handle);
-        InstallWaitSite(handle, suspend, descriptor);
-        break;
-      }
-
-      // Flush owns baseline advancement for installed edge/change waits.
-      // FlushSlotEdgeGroups sets group.last_bit; FlushSlotChangeSubs
-      // memcpy's snapshots. ClearDelta() resets post-flush dirtiness
-      // tracking but does NOT invalidate those installed baselines.
-      // Post-activation refresh is only needed when post-flush slot
-      // dirties are recorded in delta_dirty_ (any active-region mutation
-      // path that calls MarkSlotDirty or MarkDirtyRange).
-      //
-      // Note: MarkExternalDirtyRange (container heap mutations) also
-      // pushes to delta_dirty_ via TouchSlot, which is intentional
-      // over-invalidation. Edge/change baselines observe design-state
-      // bytes, not heap data, so the per-sub IsDeltaDirty checks inside
-      // RefreshInstalledSnapshots filter these out harmlessly.
-      // R5: check both global and local dirty state. Instance-owned
-      // signals go to local_updates, not update_set_.
-      bool has_any_dirty = !update_set_.DeltaDirtySlots().empty() ||
-                           !delta_dirty_instances_.empty();
-      if (!has_any_dirty) {
-        break;
-      }
-
-      if (RefreshInstalledSnapshots(handle)) {
-        // A same-delta blocking write changed an observed edge bit.
-        // group.last_bit is shared state and cannot be updated here.
-        // Fall back to full reinstall to get a fresh group baseline.
-        const auto& descriptor = wait_site_meta_.Get(suspend->wait_site_id);
-        ResetInstalledWait(handle);
-        InstallWaitSite(handle, suspend, descriptor);
-      }
-      break;
-    }
-
-    case SuspendTag::kRepeat:
-      ResetInstalledWait(handle);
-      ScheduleNextDelta(handle, ResumePoint{.block_index = 0});
-      break;
-
-    case SuspendTag::kWaitEvent: {
-      ResetInstalledWait(handle);
-      auto& inst = GetInstanceMut(handle.instance_id);
-      AddInstanceEventWaiter(
-          inst, suspend->event_id,
-          EventWaiter{
-              .process_id = handle.process_id,
-              .instance_id = handle.instance_id.value,
-              .resume_block = suspend->resume_block,
-          });
-      break;
-    }
+  if (RefreshInstalledSnapshots(handle)) {
+    const auto& descriptor = wait_site_meta_.Get(req.wait_site_id);
+    ResetInstalledWait(handle);
+    InstallWaitSite(handle, req, descriptor);
   }
 }
 

--- a/src/lyra/runtime/process_envelope.cpp
+++ b/src/lyra/runtime/process_envelope.cpp
@@ -10,8 +10,7 @@
 #include "lyra/common/diagnostic/print.hpp"
 #include "lyra/common/internal_error.hpp"
 #include "lyra/runtime/dpi_export_context.hpp"
-#include "lyra/runtime/engine.hpp"
-#include "lyra/runtime/index_plan.hpp"
+#include "lyra/runtime/engine_process_envelope_access.hpp"
 #include "lyra/runtime/instance_event_state.hpp"
 #include "lyra/runtime/iteration_limit.hpp"
 #include "lyra/runtime/process_frame.hpp"
@@ -20,6 +19,7 @@
 
 namespace {
 
+using Access = lyra::runtime::ProcessEnvelopeAccess;
 using StateHeader = lyra::runtime::ProcessFrameHeader;
 
 void ReleaseTriggerOverflow(lyra::runtime::SuspendRecord* suspend) {
@@ -62,6 +62,39 @@ using ProcessRequest = std::variant<
     lyra::runtime::WaitRequest, lyra::runtime::RepeatRequest,
     lyra::runtime::EventWaitRequest>;
 
+// Translate the decoded process request into the engine-owned wait-kind
+// for observability. Called once per activation before engine dispatch.
+auto ClassifyWaitKind(const ProcessRequest& request)
+    -> lyra::runtime::ProcessWaitKind {
+  using lyra::runtime::ProcessWaitKind;
+  return std::visit(
+      [](const auto& v) -> ProcessWaitKind {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, CompletedRequest>) {
+          return ProcessWaitKind::kFinished;
+        } else if constexpr (std::is_same_v<T, TrapRequest>) {
+          return ProcessWaitKind::kFinished;
+        } else if constexpr (std::is_same_v<T, lyra::runtime::DelayRequest>) {
+          return ProcessWaitKind::kSuspendedDelay;
+        } else if constexpr (std::is_same_v<T, lyra::runtime::WaitRequest>) {
+          return ProcessWaitKind::kSuspendedWait;
+        } else if constexpr (std::is_same_v<T, lyra::runtime::RepeatRequest>) {
+          return ProcessWaitKind::kSuspendedRepeat;
+        } else if constexpr (std::is_same_v<
+                                 T, lyra::runtime::EventWaitRequest>) {
+          return ProcessWaitKind::kSuspendedEvent;
+        }
+      },
+      request);
+}
+
+// Whether the request requires resetting the installed wait state.
+// All non-wait requests must tear down prior subscriptions.
+auto NeedsWaitReset(const ProcessRequest& request) -> bool {
+  return !std::holds_alternative<lyra::runtime::WaitRequest>(request) &&
+         !std::holds_alternative<TrapRequest>(request);
+}
+
 // Decode a SuspendRecord into a semantic ProcessRequest.
 // Spans in WaitRequest point into still-alive SuspendRecord storage.
 auto DecodeSuspendRecord(lyra::runtime::SuspendRecord* suspend)
@@ -95,7 +128,7 @@ auto DecodeSuspendRecord(lyra::runtime::SuspendRecord* suspend)
       auto triggers = std::span(suspend->triggers_ptr, suspend->num_triggers);
       bool has_late_bound =
           suspend->num_late_bound > 0 && suspend->late_bound_ptr != nullptr;
-      auto late_bound =
+      auto headers =
           has_late_bound
               ? std::span(suspend->late_bound_ptr, suspend->num_late_bound)
               : std::span<const LateBoundHeader>{};
@@ -111,9 +144,10 @@ auto DecodeSuspendRecord(lyra::runtime::SuspendRecord* suspend)
           .resume = resume,
           .wait_site_id = suspend->wait_site_id,
           .triggers = triggers,
-          .late_bound = late_bound,
-          .plan_ops = plan_ops,
-          .dep_slots = dep_records};
+          .late_bound = {
+              .headers = headers,
+              .plan_ops = plan_ops,
+              .dep_slots = dep_records}};
     }
 
     case SuspendTag::kRepeat:
@@ -184,6 +218,40 @@ auto DispatchProcess(
   }
 }
 
+// Envelope-owned wait lifecycle orchestration. Decides whether to do a
+// direct trigger install, a full wait-site install, or an in-place refresh.
+void HandleWaitRequest(
+    lyra::runtime::Engine& engine, lyra::runtime::ProcessHandle handle,
+    const lyra::runtime::WaitRequest& req) {
+  if (!Access::UsesWaitSiteLifecycle(engine)) {
+    Access::InstallTriggers(engine, handle, req);
+    return;
+  }
+
+  if (req.wait_site_id == lyra::runtime::kInvalidWaitSiteId) {
+    throw lyra::common::InternalError(
+        "HandleWaitRequest",
+        std::format(
+            "process {} suspended with kWait but wait_site_id is invalid",
+            handle.process_id));
+  }
+
+  if (!Access::CanRefreshInstalledWait(engine, handle, req.wait_site_id)) {
+    Access::ResetInstalledWait(engine, handle);
+    Access::InstallWaitSite(engine, handle, req);
+    return;
+  }
+
+  if (!Access::HasPendingDirtyState(engine)) {
+    return;
+  }
+
+  if (Access::RefreshInstalledSnapshots(engine, handle)) {
+    Access::ResetInstalledWait(engine, handle);
+    Access::InstallWaitSite(engine, handle, req);
+  }
+}
+
 // Handle the decoded process request by calling narrow engine primitives.
 void HandleProcessRequest(
     lyra::runtime::Engine& engine, lyra::runtime::ProcessHandle handle,
@@ -194,31 +262,33 @@ void HandleProcessRequest(
   using lyra::runtime::EventWaitRequest;
   using lyra::runtime::RepeatRequest;
   using lyra::runtime::WaitRequest;
-  bool reconcile = engine.HasPostActivationReconciliation();
+
+  // Single structural reset point: all non-wait, non-trap requests must
+  // tear down prior subscriptions when wait-site lifecycle is active.
+  if (Access::UsesWaitSiteLifecycle(engine) && NeedsWaitReset(request)) {
+    Access::ResetInstalledWait(engine, handle);
+  }
 
   std::visit(
       [&](const auto& v) {
         using T = std::decay_t<decltype(v)>;
 
         if constexpr (std::is_same_v<T, CompletedRequest>) {
-          if (reconcile) engine.ResetInstalledWait(handle);
+          // No scheduling action needed.
 
         } else if constexpr (std::is_same_v<T, TrapRequest>) {
           engine.HandleTrap(handle.process_id, v.payload);
 
         } else if constexpr (std::is_same_v<T, DelayRequest>) {
-          if (reconcile) engine.ResetInstalledWait(handle);
           engine.Delay(handle, v.resume, v.ticks);
 
         } else if constexpr (std::is_same_v<T, WaitRequest>) {
-          engine.HandleWaitRequest(handle, v);
+          HandleWaitRequest(engine, handle, v);
 
         } else if constexpr (std::is_same_v<T, RepeatRequest>) {
-          if (reconcile) engine.ResetInstalledWait(handle);
           engine.ScheduleNextDelta(handle, v.resume);
 
         } else if constexpr (std::is_same_v<T, EventWaitRequest>) {
-          if (reconcile) engine.ResetInstalledWait(handle);
           auto& inst = engine.GetInstanceMut(handle.instance_id);
           Engine::AddInstanceEventWaiter(
               inst, v.event_id,
@@ -242,6 +312,8 @@ void DispatchAndHandleActivation(
     ResumePoint resume) {
   auto request =
       DispatchProcess(connection_procs, states, num_connection, handle, resume);
+  Access::SetProcessWaitKind(
+      engine, handle.process_id, ClassifyWaitKind(request));
   HandleProcessRequest(engine, handle, request);
 }
 

--- a/src/lyra/runtime/process_envelope.cpp
+++ b/src/lyra/runtime/process_envelope.cpp
@@ -1,0 +1,417 @@
+#include "lyra/runtime/process_envelope.hpp"
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <format>
+#include <span>
+#include <variant>
+
+#include "lyra/common/diagnostic/print.hpp"
+#include "lyra/common/internal_error.hpp"
+#include "lyra/runtime/dpi_export_context.hpp"
+#include "lyra/runtime/engine.hpp"
+#include "lyra/runtime/index_plan.hpp"
+#include "lyra/runtime/instance_event_state.hpp"
+#include "lyra/runtime/iteration_limit.hpp"
+#include "lyra/runtime/process_frame.hpp"
+#include "lyra/runtime/process_requests.hpp"
+#include "lyra/runtime/suspend_record.hpp"
+
+namespace {
+
+using StateHeader = lyra::runtime::ProcessFrameHeader;
+
+void ReleaseTriggerOverflow(lyra::runtime::SuspendRecord* suspend) {
+  if (suspend->triggers_ptr != nullptr &&
+      suspend->triggers_ptr != suspend->inline_triggers.data()) {
+    delete[] suspend->triggers_ptr;
+  }
+  suspend->num_triggers = 0;
+  suspend->triggers_ptr = nullptr;
+  delete[] suspend->late_bound_ptr;
+  suspend->num_late_bound = 0;
+  suspend->late_bound_ptr = nullptr;
+  delete[] suspend->plan_ops_ptr;
+  suspend->num_plan_ops = 0;
+  suspend->plan_ops_ptr = nullptr;
+  delete[] suspend->dep_slots_ptr;
+  suspend->num_dep_slots = 0;
+  suspend->dep_slots_ptr = nullptr;
+}
+
+void SuspendReset(lyra::runtime::SuspendRecord* suspend) {
+  ReleaseTriggerOverflow(suspend);
+  *suspend = lyra::runtime::SuspendRecord{};
+}
+
+void FailIfSuspensionDisallowed(const char* api) {
+  if (LyraIsDpiExportSuspensionDisallowed()) {
+    throw lyra::common::InternalError(
+        api, "non-suspending DPI export task attempted to suspend");
+  }
+}
+
+// Envelope-internal process request variant. Never exposed publicly.
+struct CompletedRequest {};
+struct TrapRequest {
+  lyra::runtime::TrapPayload payload = {};
+};
+using ProcessRequest = std::variant<
+    CompletedRequest, TrapRequest, lyra::runtime::DelayRequest,
+    lyra::runtime::WaitRequest, lyra::runtime::RepeatRequest,
+    lyra::runtime::EventWaitRequest>;
+
+// Decode a SuspendRecord into a semantic ProcessRequest.
+// Spans in WaitRequest point into still-alive SuspendRecord storage.
+auto DecodeSuspendRecord(lyra::runtime::SuspendRecord* suspend)
+    -> ProcessRequest {
+  using lyra::runtime::DelayRequest;
+  using lyra::runtime::DepSignalRecord;
+  using lyra::runtime::EventWaitRequest;
+  using lyra::runtime::IndexPlanOp;
+  using lyra::runtime::LateBoundHeader;
+  using lyra::runtime::RepeatRequest;
+  using lyra::runtime::ResumePoint;
+  using lyra::runtime::SuspendTag;
+  using lyra::runtime::WaitRequest;
+
+  auto resume =
+      ResumePoint{.block_index = suspend->resume_block, .instruction_index = 0};
+
+  switch (suspend->tag) {
+    case SuspendTag::kFinished:
+      return CompletedRequest{};
+
+    case SuspendTag::kDelay:
+      return DelayRequest{.resume = resume, .ticks = suspend->delay_ticks};
+
+    case SuspendTag::kWait: {
+      if (suspend->num_triggers > 0 && suspend->triggers_ptr == nullptr) {
+        throw lyra::common::InternalError(
+            "DecodeSuspendRecord",
+            "triggers_ptr null with non-zero num_triggers");
+      }
+      auto triggers = std::span(suspend->triggers_ptr, suspend->num_triggers);
+      bool has_late_bound =
+          suspend->num_late_bound > 0 && suspend->late_bound_ptr != nullptr;
+      auto late_bound =
+          has_late_bound
+              ? std::span(suspend->late_bound_ptr, suspend->num_late_bound)
+              : std::span<const LateBoundHeader>{};
+      auto plan_ops =
+          (suspend->plan_ops_ptr != nullptr)
+              ? std::span(suspend->plan_ops_ptr, suspend->num_plan_ops)
+              : std::span<const IndexPlanOp>{};
+      auto dep_records =
+          (suspend->dep_slots_ptr != nullptr)
+              ? std::span(suspend->dep_slots_ptr, suspend->num_dep_slots)
+              : std::span<const DepSignalRecord>{};
+      return WaitRequest{
+          .resume = resume,
+          .wait_site_id = suspend->wait_site_id,
+          .triggers = triggers,
+          .late_bound = late_bound,
+          .plan_ops = plan_ops,
+          .dep_slots = dep_records};
+    }
+
+    case SuspendTag::kRepeat:
+      return RepeatRequest{
+          .resume = ResumePoint{.block_index = 0, .instruction_index = 0}};
+
+    case SuspendTag::kWaitEvent:
+      return EventWaitRequest{.resume = resume, .event_id = suspend->event_id};
+  }
+
+  throw lyra::common::InternalError(
+      "DecodeSuspendRecord",
+      std::format("unknown SuspendTag {}", static_cast<int>(suspend->tag)));
+}
+
+// Dispatch a process body and decode the raw protocol into a ProcessRequest.
+auto DispatchProcess(
+    std::span<LyraProcessFunc> connection_procs, std::span<void*> states,
+    uint32_t num_connection, lyra::runtime::ProcessHandle handle,
+    lyra::runtime::ResumePoint resume) -> ProcessRequest {
+  using lyra::runtime::ProcessExitCode;
+  using lyra::runtime::ProcessOutcome;
+  using lyra::runtime::SuspendRecord;
+  using lyra::runtime::SuspendTag;
+  using lyra::runtime::TrapReason;
+
+  uint32_t proc_idx = handle.process_id;
+  void* state = states[proc_idx];
+  auto* suspend = static_cast<SuspendRecord*>(state);
+
+  if (resume.block_index != 0 && suspend->tag == SuspendTag::kWait &&
+      suspend->triggers_ptr == suspend->inline_triggers.data()) {
+    suspend->tag = SuspendTag::kFinished;
+  } else {
+    SuspendReset(suspend);
+  }
+
+  ProcessOutcome outcome{};
+  outcome.tag = UINT32_MAX;
+
+  if (proc_idx < num_connection) {
+    connection_procs[proc_idx](state, resume.block_index, &outcome);
+  } else {
+    auto* header = static_cast<StateHeader*>(state);
+    header->outcome.tag = UINT32_MAX;
+    header->body(state, resume.block_index);
+    outcome = header->outcome;
+  }
+
+  switch (static_cast<ProcessExitCode>(outcome.tag)) {
+    case ProcessExitCode::kOk:
+      return DecodeSuspendRecord(suspend);
+
+    case ProcessExitCode::kTrap:
+      return TrapRequest{
+          .payload = {
+              .reason = static_cast<TrapReason>(outcome.reason),
+              .a = outcome.a,
+              .b = outcome.b}};
+
+    default:
+      throw lyra::common::InternalError(
+          "DispatchProcess",
+          std::format(
+              "process returned invalid exit tag {} (sentinel=codegen bug, "
+              "other=unknown tag)",
+              outcome.tag));
+  }
+}
+
+// Handle the decoded process request by calling narrow engine primitives.
+void HandleProcessRequest(
+    lyra::runtime::Engine& engine, lyra::runtime::ProcessHandle handle,
+    const ProcessRequest& request) {
+  using lyra::runtime::DelayRequest;
+  using lyra::runtime::Engine;
+  using lyra::runtime::EventWaiter;
+  using lyra::runtime::EventWaitRequest;
+  using lyra::runtime::RepeatRequest;
+  using lyra::runtime::WaitRequest;
+  bool reconcile = engine.HasPostActivationReconciliation();
+
+  std::visit(
+      [&](const auto& v) {
+        using T = std::decay_t<decltype(v)>;
+
+        if constexpr (std::is_same_v<T, CompletedRequest>) {
+          if (reconcile) engine.ResetInstalledWait(handle);
+
+        } else if constexpr (std::is_same_v<T, TrapRequest>) {
+          engine.HandleTrap(handle.process_id, v.payload);
+
+        } else if constexpr (std::is_same_v<T, DelayRequest>) {
+          if (reconcile) engine.ResetInstalledWait(handle);
+          engine.Delay(handle, v.resume, v.ticks);
+
+        } else if constexpr (std::is_same_v<T, WaitRequest>) {
+          engine.HandleWaitRequest(handle, v);
+
+        } else if constexpr (std::is_same_v<T, RepeatRequest>) {
+          if (reconcile) engine.ResetInstalledWait(handle);
+          engine.ScheduleNextDelta(handle, v.resume);
+
+        } else if constexpr (std::is_same_v<T, EventWaitRequest>) {
+          if (reconcile) engine.ResetInstalledWait(handle);
+          auto& inst = engine.GetInstanceMut(handle.instance_id);
+          Engine::AddInstanceEventWaiter(
+              inst, v.event_id,
+              EventWaiter{
+                  .process_id = handle.process_id,
+                  .instance_id = handle.instance_id.value,
+                  .resume_block = v.resume.block_index,
+              });
+        }
+      },
+      request);
+}
+
+}  // namespace
+
+namespace lyra::runtime {
+
+void DispatchAndHandleActivation(
+    std::span<LyraProcessFunc> connection_procs, std::span<void*> states,
+    uint32_t num_connection, Engine& engine, ProcessHandle handle,
+    ResumePoint resume) {
+  auto request =
+      DispatchProcess(connection_procs, states, num_connection, handle, resume);
+  HandleProcessRequest(engine, handle, request);
+}
+
+}  // namespace lyra::runtime
+
+// All suspend protocol C ABI functions. These are the only code outside
+// the envelope header that touches SuspendRecord fields directly.
+
+extern "C" auto LyraAllocTriggers(uint32_t count)
+    -> lyra::runtime::WaitTriggerRecord* {
+  return new lyra::runtime::WaitTriggerRecord[count];
+}
+
+extern "C" void LyraFreeTriggers(lyra::runtime::WaitTriggerRecord* ptr) {
+  delete[] ptr;
+}
+
+extern "C" void LyraSuspendDelay(
+    void* state, uint64_t ticks, uint32_t resume_block) {
+  FailIfSuspensionDisallowed("LyraSuspendDelay");
+  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
+  ReleaseTriggerOverflow(suspend);
+  suspend->tag = lyra::runtime::SuspendTag::kDelay;
+  suspend->delay_ticks = ticks;
+  suspend->resume_block = resume_block;
+}
+
+extern "C" void LyraSuspendWait(
+    void* state, uint32_t resume_block, const void* triggers,
+    uint32_t num_triggers, uint32_t wait_site_id) {
+  FailIfSuspensionDisallowed("LyraSuspendWait");
+  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
+  ReleaseTriggerOverflow(suspend);
+
+  suspend->tag = lyra::runtime::SuspendTag::kWait;
+  suspend->resume_block = resume_block;
+  suspend->wait_site_id = wait_site_id;
+  suspend->num_triggers = num_triggers;
+
+  if (num_triggers <= lyra::runtime::kInlineTriggerCapacity) {
+    suspend->triggers_ptr = suspend->inline_triggers.data();
+  } else {
+    suspend->triggers_ptr = new lyra::runtime::WaitTriggerRecord[num_triggers];
+  }
+
+  if (num_triggers > 0) {
+    std::memcpy(
+        suspend->triggers_ptr, triggers,
+        num_triggers * sizeof(lyra::runtime::WaitTriggerRecord));
+  }
+}
+
+extern "C" void LyraSuspendWaitStatic(
+    void* state, uint32_t resume_block, uint32_t wait_site_id) {
+  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
+  suspend->tag = lyra::runtime::SuspendTag::kWait;
+  suspend->resume_block = resume_block;
+  suspend->wait_site_id = wait_site_id;
+}
+
+extern "C" void LyraSuspendWaitWithLateBound(
+    void* state, uint32_t resume_block, const void* triggers,
+    uint32_t num_triggers, const void* headers, uint32_t num_headers,
+    const void* plan_ops, uint32_t num_plan_ops, const void* dep_slots,
+    uint32_t num_dep_slots, uint32_t wait_site_id) {
+  FailIfSuspensionDisallowed("LyraSuspendWaitWithLateBound");
+  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
+  ReleaseTriggerOverflow(suspend);
+
+  suspend->tag = lyra::runtime::SuspendTag::kWait;
+  suspend->resume_block = resume_block;
+  suspend->wait_site_id = wait_site_id;
+  suspend->num_triggers = num_triggers;
+
+  if (num_triggers <= lyra::runtime::kInlineTriggerCapacity) {
+    suspend->triggers_ptr = suspend->inline_triggers.data();
+  } else {
+    suspend->triggers_ptr = new lyra::runtime::WaitTriggerRecord[num_triggers];
+  }
+
+  if (num_triggers > 0) {
+    std::memcpy(
+        suspend->triggers_ptr, triggers,
+        num_triggers * sizeof(lyra::runtime::WaitTriggerRecord));
+  }
+
+  suspend->num_late_bound = num_headers;
+  if (num_headers > 0 && headers != nullptr) {
+    suspend->late_bound_ptr = new lyra::runtime::LateBoundHeader[num_headers];
+    std::memcpy(
+        suspend->late_bound_ptr, headers,
+        num_headers * sizeof(lyra::runtime::LateBoundHeader));
+  } else {
+    suspend->late_bound_ptr = nullptr;
+  }
+
+  suspend->num_plan_ops = num_plan_ops;
+  if (num_plan_ops > 0 && plan_ops != nullptr) {
+    suspend->plan_ops_ptr = new lyra::runtime::IndexPlanOp[num_plan_ops];
+    std::memcpy(
+        suspend->plan_ops_ptr, plan_ops,
+        num_plan_ops * sizeof(lyra::runtime::IndexPlanOp));
+  } else {
+    suspend->plan_ops_ptr = nullptr;
+  }
+
+  suspend->num_dep_slots = num_dep_slots;
+  if (num_dep_slots > 0 && dep_slots != nullptr) {
+    suspend->dep_slots_ptr = new lyra::runtime::DepSignalRecord[num_dep_slots];
+    std::memcpy(
+        suspend->dep_slots_ptr, dep_slots,
+        num_dep_slots * sizeof(lyra::runtime::DepSignalRecord));
+  } else {
+    suspend->dep_slots_ptr = nullptr;
+  }
+}
+
+extern "C" void LyraSuspendRepeat(void* state) {
+  FailIfSuspensionDisallowed("LyraSuspendRepeat");
+  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
+  ReleaseTriggerOverflow(suspend);
+  suspend->tag = lyra::runtime::SuspendTag::kRepeat;
+  suspend->resume_block = 0;
+}
+
+extern "C" void LyraSuspendWaitEvent(
+    void* state, uint32_t resume_block, uint32_t event_id) {
+  FailIfSuspensionDisallowed("LyraSuspendWaitEvent");
+  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
+  ReleaseTriggerOverflow(suspend);
+  suspend->tag = lyra::runtime::SuspendTag::kWaitEvent;
+  suspend->resume_block = resume_block;
+  suspend->event_id = event_id;
+}
+
+extern "C" void LyraRunProcessSync(LyraProcessFunc process, void* state) {
+  constexpr uint32_t kEntryBlock = 0;
+
+  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
+  suspend->tag = lyra::runtime::SuspendTag::kFinished;
+  uint32_t limit = LyraGetIterationLimit();
+  LyraResetIterationLimit(limit > 0 ? limit : UINT32_MAX);
+
+  lyra::runtime::ProcessOutcome outcome{};
+  outcome.tag = UINT32_MAX;
+  process(state, kEntryBlock, &outcome);
+
+  switch (static_cast<lyra::runtime::ProcessExitCode>(outcome.tag)) {
+    case lyra::runtime::ProcessExitCode::kOk:
+      break;
+    case lyra::runtime::ProcessExitCode::kTrap:
+      lyra::PrintError(
+          std::format(
+              "init process trapped (reason={}, a={}, b={}), aborting",
+              outcome.reason, outcome.a, outcome.b));
+      std::abort();
+    default:
+      throw lyra::common::InternalError(
+          "LyraRunProcessSync",
+          std::format(
+              "process returned invalid exit tag {} (sentinel=codegen bug, "
+              "other=unknown tag)",
+              outcome.tag));
+  }
+
+  if (suspend->tag != lyra::runtime::SuspendTag::kFinished) {
+    lyra::PrintError(
+        std::format(
+            "init process suspended (tag={}), aborting",
+            static_cast<int>(suspend->tag)));
+    std::abort();
+  }
+}

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -35,7 +35,6 @@
 #include "lyra/runtime/signal_dump.hpp"
 #include "lyra/runtime/slot_meta.hpp"
 #include "lyra/runtime/string.hpp"
-#include "lyra/runtime/suspend_record.hpp"
 #include "lyra/runtime/trace_signal_meta.hpp"
 #include "lyra/trace/text_trace_sink.hpp"
 
@@ -338,18 +337,6 @@ extern "C" void LyraRunSimulation(
     // R5: Trace selection must cover all flat slot_ids (global +
     // instance-owned). Called unconditionally after all init paths.
     engine.InitTraceSelection();
-  }
-
-  // Register suspend record pointers for observability (scheduler snapshot
-  // wait-kind classification). Not used by activation or reconciliation flow.
-  if (abi != nullptr && abi->wait_site_words != nullptr &&
-      abi->wait_site_word_count > 0) {
-    std::vector<lyra::runtime::SuspendRecord*> suspend_ptrs;
-    suspend_ptrs.reserve(states.size());
-    for (auto* state : states) {
-      suspend_ptrs.push_back(static_cast<lyra::runtime::SuspendRecord*>(state));
-    }
-    engine.RegisterSuspendRecords(suspend_ptrs);
   }
 
   if (HasFlag(flags, FeatureFlag::kDumpSlotMeta)) {

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -16,7 +16,6 @@
 
 #include <fmt/core.h>
 
-#include "lyra/common/diagnostic/print.hpp"
 #include "lyra/common/internal_error.hpp"
 #include "lyra/runtime/assertions.hpp"
 #include "lyra/runtime/back_edge_site_meta.hpp"
@@ -28,6 +27,7 @@
 #include "lyra/runtime/iteration_limit.hpp"
 #include "lyra/runtime/nba_stats_hook.hpp"
 #include "lyra/runtime/output_sink.hpp"
+#include "lyra/runtime/process_envelope.hpp"
 #include "lyra/runtime/process_frame.hpp"
 #include "lyra/runtime/process_meta.hpp"
 #include "lyra/runtime/reporting.hpp"
@@ -55,251 +55,7 @@ auto FinalTime() -> uint64_t& {
   return value;
 }
 
-// Legacy post-activation dispatch: reads SuspendRecord and installs
-// waiter/delay state. Called by DescriptorProcessDispatch when
-// HasPostActivationReconciliation() is false. The new-path equivalent
-// is Engine::ReconcilePostActivation. Exactly one of these two runs
-// per activation -- never both.
-void HandleSuspendRecord(
-    lyra::runtime::Engine& eng, lyra::runtime::ProcessHandle handle,
-    lyra::runtime::SuspendRecord* suspend) {
-  auto resume = lyra::runtime::ResumePoint{
-      .block_index = suspend->resume_block, .instruction_index = 0};
-
-  switch (suspend->tag) {
-    case lyra::runtime::SuspendTag::kFinished:
-      break;
-
-    case lyra::runtime::SuspendTag::kDelay:
-      eng.Delay(handle, resume, suspend->delay_ticks);
-      break;
-
-    case lyra::runtime::SuspendTag::kWait: {
-      if (suspend->num_triggers > 0 && suspend->triggers_ptr == nullptr) {
-        throw lyra::common::InternalError(
-            "HandleSuspendRecord",
-            "triggers_ptr null with non-zero num_triggers");
-      }
-      auto triggers = std::span(suspend->triggers_ptr, suspend->num_triggers);
-
-      bool has_late_bound =
-          suspend->num_late_bound > 0 && suspend->late_bound_ptr != nullptr;
-      auto late_bound =
-          has_late_bound
-              ? std::span(suspend->late_bound_ptr, suspend->num_late_bound)
-              : std::span<const lyra::runtime::LateBoundHeader>{};
-      auto plan_ops =
-          (suspend->plan_ops_ptr != nullptr)
-              ? std::span(suspend->plan_ops_ptr, suspend->num_plan_ops)
-              : std::span<const lyra::runtime::IndexPlanOp>{};
-      auto dep_records =
-          (suspend->dep_slots_ptr != nullptr)
-              ? std::span(suspend->dep_slots_ptr, suspend->num_dep_slots)
-              : std::span<const lyra::runtime::DepSignalRecord>{};
-
-      eng.InstallTriggers(
-          handle, resume, triggers, late_bound, plan_ops, dep_records);
-      break;
-    }
-
-    case lyra::runtime::SuspendTag::kRepeat:
-      eng.ScheduleNextDelta(
-          handle, lyra::runtime::ResumePoint{.block_index = 0});
-      break;
-
-    case lyra::runtime::SuspendTag::kWaitEvent: {
-      auto& inst = eng.GetInstanceMut(handle.instance_id);
-      lyra::runtime::Engine::AddInstanceEventWaiter(
-          inst, suspend->event_id,
-          lyra::runtime::EventWaiter{
-              .process_id = handle.process_id,
-              .instance_id = handle.instance_id.value,
-              .resume_block = suspend->resume_block,
-          });
-      break;
-    }
-  }
-}
-
-// Release heap-allocated triggers if any (call before overwriting
-// SuspendRecord) Resets num_triggers and triggers_ptr to make non-wait states
-// trivially safe.
-void ReleaseTriggerOverflow(lyra::runtime::SuspendRecord* suspend) {
-  if (suspend->triggers_ptr != nullptr &&
-      suspend->triggers_ptr != suspend->inline_triggers.data()) {
-    delete[] suspend->triggers_ptr;  // NOLINT(cppcoreguidelines-owning-memory)
-  }
-  suspend->num_triggers = 0;
-  suspend->triggers_ptr = nullptr;
-  // NOLINTBEGIN(cppcoreguidelines-owning-memory)
-  delete[] suspend->late_bound_ptr;
-  suspend->num_late_bound = 0;
-  suspend->late_bound_ptr = nullptr;
-  delete[] suspend->plan_ops_ptr;
-  suspend->num_plan_ops = 0;
-  suspend->plan_ops_ptr = nullptr;
-  delete[] suspend->dep_slots_ptr;
-  // NOLINTEND(cppcoreguidelines-owning-memory)
-  suspend->num_dep_slots = 0;
-  suspend->dep_slots_ptr = nullptr;
-}
-
-void SuspendReset(lyra::runtime::SuspendRecord* suspend) {
-  ReleaseTriggerOverflow(suspend);
-  *suspend = lyra::runtime::SuspendRecord{};
-}
-
-// Defense-in-depth guard: abort if a non-suspending DPI export task
-// attempts to suspend. The static gate in design.cpp prevents direct timing
-// controls; this catches unforeseen indirect paths.
-void FailIfSuspensionDisallowed(const char* api) {
-  if (LyraIsDpiExportSuspensionDisallowed()) {
-    throw lyra::common::InternalError(
-        api, "non-suspending DPI export task attempted to suspend");
-  }
-}
-
 }  // namespace
-
-// Runtime allocation for large trigger lists (called from LLVM-generated code)
-extern "C" auto LyraAllocTriggers(uint32_t count)
-    -> lyra::runtime::WaitTriggerRecord* {
-  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-  return new lyra::runtime::WaitTriggerRecord[count];
-}
-
-extern "C" void LyraFreeTriggers(lyra::runtime::WaitTriggerRecord* ptr) {
-  delete[] ptr;  // NOLINT(cppcoreguidelines-owning-memory)
-}
-
-extern "C" void LyraSuspendDelay(
-    void* state, uint64_t ticks, uint32_t resume_block) {
-  FailIfSuspensionDisallowed("LyraSuspendDelay");
-  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
-  ReleaseTriggerOverflow(suspend);  // Clean up any previous wait
-  suspend->tag = lyra::runtime::SuspendTag::kDelay;
-  suspend->delay_ticks = ticks;
-  suspend->resume_block = resume_block;
-}
-
-extern "C" void LyraSuspendWait(
-    void* state, uint32_t resume_block, const void* triggers,
-    uint32_t num_triggers, uint32_t wait_site_id) {
-  FailIfSuspensionDisallowed("LyraSuspendWait");
-  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
-  ReleaseTriggerOverflow(suspend);  // Clean up any previous wait
-
-  suspend->tag = lyra::runtime::SuspendTag::kWait;
-  suspend->resume_block = resume_block;
-  suspend->wait_site_id = wait_site_id;
-  suspend->num_triggers = num_triggers;
-
-  // Always set triggers_ptr for invariant consistency (even if num_triggers ==
-  // 0)
-  if (num_triggers <= lyra::runtime::kInlineTriggerCapacity) {
-    suspend->triggers_ptr = suspend->inline_triggers.data();
-  } else {
-    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-    suspend->triggers_ptr = new lyra::runtime::WaitTriggerRecord[num_triggers];
-  }
-
-  if (num_triggers > 0) {
-    std::memcpy(
-        suspend->triggers_ptr, triggers,
-        num_triggers * sizeof(lyra::runtime::WaitTriggerRecord));
-  }
-}
-
-// Fast path for static-wait processes (e.g., always_ff with fixed triggers).
-// Called on re-suspend when the trigger set is identical to a previously-
-// installed wait site. Skips trigger array rebuild, memcpy, overflow
-// release, and DPI suspension check -- all unnecessary when the trigger
-// data in the SuspendRecord is already correct from the first activation.
-extern "C" void LyraSuspendWaitStatic(
-    void* state, uint32_t resume_block, uint32_t wait_site_id) {
-  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
-  suspend->tag = lyra::runtime::SuspendTag::kWait;
-  suspend->resume_block = resume_block;
-  suspend->wait_site_id = wait_site_id;
-}
-
-extern "C" void LyraSuspendWaitWithLateBound(
-    void* state, uint32_t resume_block, const void* triggers,
-    uint32_t num_triggers, const void* headers, uint32_t num_headers,
-    const void* plan_ops, uint32_t num_plan_ops, const void* dep_slots,
-    uint32_t num_dep_slots, uint32_t wait_site_id) {
-  FailIfSuspensionDisallowed("LyraSuspendWaitWithLateBound");
-  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
-  ReleaseTriggerOverflow(suspend);
-
-  suspend->tag = lyra::runtime::SuspendTag::kWait;
-  suspend->resume_block = resume_block;
-  suspend->wait_site_id = wait_site_id;
-  suspend->num_triggers = num_triggers;
-
-  if (num_triggers <= lyra::runtime::kInlineTriggerCapacity) {
-    suspend->triggers_ptr = suspend->inline_triggers.data();
-  } else {
-    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-    suspend->triggers_ptr = new lyra::runtime::WaitTriggerRecord[num_triggers];
-  }
-
-  if (num_triggers > 0) {
-    std::memcpy(
-        suspend->triggers_ptr, triggers,
-        num_triggers * sizeof(lyra::runtime::WaitTriggerRecord));
-  }
-
-  // NOLINTBEGIN(cppcoreguidelines-owning-memory)
-  suspend->num_late_bound = num_headers;
-  if (num_headers > 0 && headers != nullptr) {
-    suspend->late_bound_ptr = new lyra::runtime::LateBoundHeader[num_headers];
-    std::memcpy(
-        suspend->late_bound_ptr, headers,
-        num_headers * sizeof(lyra::runtime::LateBoundHeader));
-  } else {
-    suspend->late_bound_ptr = nullptr;
-  }
-
-  suspend->num_plan_ops = num_plan_ops;
-  if (num_plan_ops > 0 && plan_ops != nullptr) {
-    suspend->plan_ops_ptr = new lyra::runtime::IndexPlanOp[num_plan_ops];
-    std::memcpy(
-        suspend->plan_ops_ptr, plan_ops,
-        num_plan_ops * sizeof(lyra::runtime::IndexPlanOp));
-  } else {
-    suspend->plan_ops_ptr = nullptr;
-  }
-
-  suspend->num_dep_slots = num_dep_slots;
-  if (num_dep_slots > 0 && dep_slots != nullptr) {
-    suspend->dep_slots_ptr = new lyra::runtime::DepSignalRecord[num_dep_slots];
-    std::memcpy(
-        suspend->dep_slots_ptr, dep_slots,
-        num_dep_slots * sizeof(lyra::runtime::DepSignalRecord));
-  } else {
-    suspend->dep_slots_ptr = nullptr;
-  }
-  // NOLINTEND(cppcoreguidelines-owning-memory)
-}
-
-extern "C" void LyraSuspendRepeat(void* state) {
-  FailIfSuspensionDisallowed("LyraSuspendRepeat");
-  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
-  ReleaseTriggerOverflow(suspend);  // Clean up any previous wait
-  suspend->tag = lyra::runtime::SuspendTag::kRepeat;
-  suspend->resume_block = 0;
-}
-
-extern "C" void LyraSuspendWaitEvent(
-    void* state, uint32_t resume_block, uint32_t event_id) {
-  FailIfSuspensionDisallowed("LyraSuspendWaitEvent");
-  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
-  ReleaseTriggerOverflow(suspend);
-  suspend->tag = lyra::runtime::SuspendTag::kWaitEvent;
-  suspend->resume_block = resume_block;
-  suspend->event_id = event_id;
-}
 
 extern "C" void LyraTriggerEvent(
     void* engine_ptr, uint32_t instance_id, uint32_t local_event_id) {
@@ -308,56 +64,7 @@ extern "C" void LyraTriggerEvent(
   engine->TriggerInstanceEvent(inst, local_event_id);
 }
 
-extern "C" void LyraRunProcessSync(LyraProcessFunc process, void* state) {
-  // Entry block is always block 0 (ABI contract with process generation)
-  constexpr uint32_t kEntryBlock = 0;
-
-  // Reset suspend record and iteration limit before execution.
-  // LyraGetIterationLimit() returns the process-global configured limit.
-  // 0 = unlimited: set counter to UINT32_MAX so the guard never fires.
-  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
-  suspend->tag = lyra::runtime::SuspendTag::kFinished;
-  uint32_t limit = LyraGetIterationLimit();
-  LyraResetIterationLimit(limit > 0 ? limit : UINT32_MAX);
-
-  // Pointer-out ABI contract: caller owns the outcome buffer, callee must
-  // write exactly one valid ProcessOutcome before returning. Sentinel tag
-  // (UINT32_MAX) detects codegen bugs where a process path misses the write.
-  lyra::runtime::ProcessOutcome outcome{};
-  outcome.tag = UINT32_MAX;
-  process(state, kEntryBlock, &outcome);
-
-  switch (static_cast<lyra::runtime::ProcessExitCode>(outcome.tag)) {
-    case lyra::runtime::ProcessExitCode::kOk:
-      break;
-    case lyra::runtime::ProcessExitCode::kTrap:
-      lyra::PrintError(
-          std::format(
-              "init process trapped (reason={}, a={}, b={}), aborting",
-              outcome.reason, outcome.a, outcome.b));
-      std::abort();
-    default:
-      throw lyra::common::InternalError(
-          "LyraRunProcessSync",
-          std::format(
-              "process returned invalid exit tag {} (sentinel=codegen bug, "
-              "other=unknown tag)",
-              outcome.tag));
-  }
-
-  // Init processes must not suspend - they run to completion
-  if (suspend->tag != lyra::runtime::SuspendTag::kFinished) {
-    lyra::PrintError(
-        std::format(
-            "init process suspended (tag={}), aborting",
-            static_cast<int>(suspend->tag)));
-    std::abort();
-  }
-}
-
 namespace {
-
-using SharedBodyFn = lyra::runtime::SharedBodyFn;
 
 struct ProcessDispatchContext {
   std::span<LyraProcessFunc> connection_procs;
@@ -369,69 +76,9 @@ void DescriptorProcessDispatch(
     void* ctx, lyra::runtime::Engine& eng, lyra::runtime::ProcessHandle handle,
     lyra::runtime::ResumePoint resume) {
   auto* dctx = static_cast<ProcessDispatchContext*>(ctx);
-  uint32_t proc_idx = handle.process_id;
-  void* state = dctx->states[proc_idx];
-  auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
-
-  // Fast path: if the process is resuming from a static wait (no heap-
-  // allocated trigger data), skip the full 992-byte SuspendRecord zeroing.
-  // The body will call LyraSuspendWaitStatic which only writes 3 fields.
-  // For the first activation (resume_block=0) or non-wait states, fall
-  // through to full reset.
-  if (resume.block_index != 0 &&
-      suspend->tag == lyra::runtime::SuspendTag::kWait &&
-      suspend->triggers_ptr == suspend->inline_triggers.data()) {
-    // Lightweight reset: clear only the tag so that if the body exits
-    // without calling any suspend (e.g., $finish), ReconcilePostActivation
-    // sees kFinished and handles cleanup correctly.
-    suspend->tag = lyra::runtime::SuspendTag::kFinished;
-  } else {
-    SuspendReset(suspend);
-  }
-
-  lyra::runtime::ProcessOutcome outcome{};
-  outcome.tag = UINT32_MAX;
-
-  // Dispatch partition contract:
-  //   [0, num_connection) = connection processes (3-arg direct call)
-  //   [num_connection, num_processes) = module processes (frame-header
-  //   dispatch)
-  if (proc_idx < dctx->num_connection) {
-    dctx->connection_procs[proc_idx](state, resume.block_index, &outcome);
-  } else {
-    // Module process: 2-arg shared body call.
-    // Body pointer and all instance binding are in the frame header,
-    // populated at init time from descriptor data.
-    auto* header = static_cast<StateHeader*>(state);
-    header->outcome.tag = UINT32_MAX;
-    header->body(state, resume.block_index);
-    outcome = header->outcome;
-  }
-
-  switch (static_cast<lyra::runtime::ProcessExitCode>(outcome.tag)) {
-    case lyra::runtime::ProcessExitCode::kOk:
-      break;
-    case lyra::runtime::ProcessExitCode::kTrap: {
-      lyra::runtime::TrapPayload payload{
-          .reason = static_cast<lyra::runtime::TrapReason>(outcome.reason),
-          .a = outcome.a,
-          .b = outcome.b,
-      };
-      eng.HandleTrap(proc_idx, payload);
-      return;
-    }
-    default:
-      throw lyra::common::InternalError(
-          "DescriptorProcessDispatch",
-          std::format(
-              "process returned invalid exit tag {} (sentinel=codegen bug, "
-              "other=unknown tag)",
-              outcome.tag));
-  }
-
-  if (!eng.HasPostActivationReconciliation()) {
-    HandleSuspendRecord(eng, handle, suspend);
-  }
+  lyra::runtime::DispatchAndHandleActivation(
+      dctx->connection_procs, dctx->states, dctx->num_connection, eng, handle,
+      resume);
 }
 
 void SetupAndRunSimulation(
@@ -693,9 +340,8 @@ extern "C" void LyraRunSimulation(
     engine.InitTraceSelection();
   }
 
-  // Register suspend records for post-activation reconciliation.
-  // When both wait-site metadata and suspend records are present,
-  // HasPostActivationReconciliation() gates the new flow everywhere.
+  // Register suspend record pointers for observability (scheduler snapshot
+  // wait-kind classification). Not used by activation or reconciliation flow.
   if (abi != nullptr && abi->wait_site_words != nullptr &&
       abi->wait_site_word_count > 0) {
     std::vector<lyra::runtime::SuspendRecord*> suspend_ptrs;


### PR DESCRIPTION
## Summary

Introduces a process envelope boundary that isolates the raw suspend/resume protocol behind a single subsystem. The envelope owns all SuspendRecord protocol decoding, translates raw suspend state into semantic process request types, and orchestrates wait lifecycle via narrow engine primitives. This eliminates raw protocol leakage across the runtime, removes the observability back-channel through suspend_records_, and tightens the engine public API to true scheduling primitives only.

## Design

The envelope boundary is structured in layers:

**Process envelope** (process_envelope.cpp) owns all raw SuspendRecord protocol -- reset, body dispatch, decode to semantic requests, and wait lifecycle orchestration. The single public entry point is DispatchAndHandleActivation.

**Semantic request types** (process_requests.hpp) define DelayRequest, WaitRequest, RepeatRequest, EventWaitRequest as the vocabulary between envelope and engine. Late-bound rebind data (headers, plan_ops, dep_slots) is grouped into a coherent LateBoundData sub-object.

**Engine primitives** are narrowed to true scheduling operations (Delay, ScheduleNextDelta, HandleTrap) and subscription lifecycle operations (InstallTriggers, InstallWaitSite, RefreshInstalledSnapshots, ResetInstalledWait). Envelope-specific methods are private, accessed via ProcessEnvelopeAccess friend bridge.

**Observability** uses engine-owned ProcessWaitKind per-process state instead of reading raw SuspendRecord tags. The envelope sets this after each activation via SetProcessWaitKind.

Key invariants established:
- No engine or observability code reads raw SuspendRecord
- suspend_records_ and RegisterSuspendRecords are deleted
- Engine public API contains only true runtime/scheduling primitives
- Wait lifecycle orchestration is envelope-owned, not engine-owned

## Testing

All existing tests pass unchanged -- this is a pure boundary/ownership restructuring with no behavioral change.