### PR TITLE
Add explicit external-read boundary for hierarchical references

### DIFF
--- a/include/lyra/lowering/hir_to_mir/builder.hpp
+++ b/include/lyra/lowering/hir_to_mir/builder.hpp
@@ -127,6 +127,11 @@ class MirBuilder {
   // Emit an AssocOp instruction (associative array operation).
   void EmitAssocOp(mir::AssocOp op);
 
+  // Emit an external read: read from a non-local external location,
+  // producing a normal value temp. This is the canonical read boundary
+  // for hierarchical references.
+  auto EmitExternalRead(TypeId type, mir::ExternalRefId ref) -> mir::Operand;
+
   // Emit a unary operation and materialize to temp.
   auto EmitUnary(mir::UnaryOp op, mir::Operand operand, TypeId result_type)
       -> mir::Operand;

--- a/include/lyra/mir/operand.hpp
+++ b/include/lyra/mir/operand.hpp
@@ -4,7 +4,6 @@
 
 #include "lyra/common/constant.hpp"
 #include "lyra/common/type.hpp"
-#include "lyra/mir/external_ref.hpp"
 #include "lyra/mir/handle.hpp"
 
 namespace lyra::mir {
@@ -39,15 +38,14 @@ struct TempId {
   }
 };
 
-using OperandPayload = std::variant<Constant, PlaceId, TempId, ExternalRefId>;
+using OperandPayload = std::variant<Constant, PlaceId, TempId>;
 
 struct Operand {
   enum class Kind {
-    kConst,        // constant value
-    kUse,          // read from a Place (implicit read)
-    kUseTemp,      // read from an SSA temp (block param or statement result)
-    kPoison,       // invalid / unreachable value
-    kExternalRef,  // read from a non-local external reference (recipe handle)
+    kConst,    // constant value
+    kUse,      // read from a Place (implicit read)
+    kUseTemp,  // read from an SSA temp (block param or statement result)
+    kPoison,   // invalid / unreachable value
   };
 
   Kind kind;
@@ -69,10 +67,6 @@ struct Operand {
 
   static auto Poison() -> Operand {
     return {.kind = Kind::kPoison, .payload = {}};
-  }
-
-  static auto ExternalRef(ExternalRefId id) -> Operand {
-    return {.kind = Kind::kExternalRef, .payload = id};
   }
 };
 

--- a/include/lyra/mir/rvalue.hpp
+++ b/include/lyra/mir/rvalue.hpp
@@ -13,6 +13,7 @@
 #include "lyra/common/type.hpp"
 #include "lyra/mir/builtin.hpp"
 #include "lyra/mir/effect.hpp"
+#include "lyra/mir/external_ref.hpp"
 #include "lyra/mir/handle.hpp"
 #include "lyra/mir/operand.hpp"
 #include "lyra/mir/operator.hpp"
@@ -187,6 +188,15 @@ struct SystemCmdRvalueInfo {
   std::optional<TypedOperand> command;  // nullopt = system(NULL)
 };
 
+// ExternalRead: read the current value from a non-local external location.
+// Produces a normal value from the external reference described by ref.
+// This is the explicit read boundary for hierarchical references --
+// external locations must cross this boundary to enter value flow.
+// No operands: the location is fully described by the recipe.
+struct ExternalReadRvalueInfo {
+  ExternalRefId ref;
+};
+
 // Select: conditional value selection for direct two-state scalar values.
 // This rvalue is currently restricted to decision bookkeeping payloads
 // (i8 / i16 / bit) and is not a generic four-state or aggregate select.
@@ -205,7 +215,7 @@ using RvalueInfo = std::variant<
     ReplicateRvalueInfo, SFormatRvalueInfo, TestPlusargsRvalueInfo,
     FopenRvalueInfo, RuntimeQueryRvalueInfo, MathCallRvalueInfo,
     SystemTfRvalueInfo, ArrayQueryRvalueInfo, SystemCmdRvalueInfo,
-    SelectRvalueInfo>;
+    SelectRvalueInfo, ExternalReadRvalueInfo>;
 
 struct Rvalue {
   std::vector<Operand> operands;
@@ -257,6 +267,8 @@ inline auto GetRvalueKind(const RvalueInfo& info) -> const char* {
           return "system_cmd";
         } else if constexpr (std::is_same_v<T, SelectRvalueInfo>) {
           return "select";
+        } else if constexpr (std::is_same_v<T, ExternalReadRvalueInfo>) {
+          return "external_read";
         } else {
           static_assert(false, "unhandled RvalueInfo kind");
         }

--- a/include/lyra/mir/verify.hpp
+++ b/include/lyra/mir/verify.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 #include <string_view>
 
 #include "lyra/common/type_arena.hpp"
@@ -12,31 +13,34 @@ namespace lyra::mir {
 
 struct CompiledModuleBody;
 
-// Phase-aware verification context. Controls what operand/statement
-// forms are legal and how external refs are resolved.
+// Phase-aware verification context. Controls what statement forms are
+// legal and provides external-ref recipe lookup.
 struct VerifyContext {
   enum class Phase : uint8_t {
-    // Pre-backend: ExternalRefId is legal. Resolved through
-    // body->external_refs.
+    // Pre-backend: ExternalRefId write targets are legal.
     kPreBackend,
-    // Backend-ready: ExternalRefId is illegal. body may be null.
+    // Backend-ready: ExternalRefId write targets are illegal.
     kBackendReady,
   };
 
-  const CompiledModuleBody* body = nullptr;
   const TypeArena* types = nullptr;
   Phase phase = Phase::kBackendReady;
+
+  // External-ref recipe table for validating ExternalReadRvalueInfo
+  // and WriteTarget ExternalRefId references. Populated from either
+  // ModuleBody::external_refs or CompiledModuleBody::external_refs.
+  std::span<const ExternalAccessRecipe> external_refs;
 
   // Body-local named event count. Used to validate EventId operands
   // in WaitEvent/TriggerEvent. 0 when event info is unavailable.
   uint32_t num_events = 0;
 };
 
-// Canonical external-ref recipe resolver. Validates ref_id is in range,
-// table position matches, and type is valid. Throws InternalError on failure.
+// Validate an ExternalRefId against a recipe table. Throws InternalError
+// if ref_id is out of range, mismatched, or has invalid type.
 auto RequireExternalRefRecipe(
-    const CompiledModuleBody& body, ExternalRefId id, const char* where)
-    -> const ExternalAccessRecipe&;
+    std::span<const ExternalAccessRecipe> recipes, ExternalRefId id,
+    const char* where) -> const ExternalAccessRecipe&;
 
 // Verify MIR function invariants. Throws InternalError on failure.
 // label: descriptive name for error messages (e.g., "top.u_alu: func foo").
@@ -68,23 +72,20 @@ void VerifyProcess(
     const Process& proc, const Arena& arena, const VerifyContext& cx,
     std::string_view label = "process");
 
-// Phase-aware MIR verification.
+// Phase-aware MIR verification for CompiledModuleBody.
 //
-// Pre-backend MIR: ExternalRefId is legal. Operand::kExternalRef and
-// WriteTarget containing ExternalRefId are valid. The verifier resolves
-// ExternalRefId types through body.external_refs.
+// Pre-backend: ExternalRefId write targets are legal. ExternalReadRvalueInfo
+// is validated against external_refs recipes.
 //
-// Backend-ready MIR: ExternalRefId must not appear anywhere. All external
-// refs must have been lowered/bound before this point.
+// Backend-ready: ExternalRefId write targets are illegal.
 
-// Verify pre-backend MIR body. ExternalRefId is legal and must resolve
-// through body.external_refs. Throws InternalError on failure.
+// Verify pre-backend MIR body. Validates external_refs table integrity,
+// ExternalRefId write targets, and ExternalReadRvalueInfo recipes.
 void VerifyPreBackendBody(
     const CompiledModuleBody& body, const TypeArena& types,
     std::string_view label = "body");
 
-// Verify backend-ready MIR body. No ExternalRefId may appear in any
-// operand or write target. Throws InternalError if any are found.
+// Verify backend-ready MIR body. No ExternalRefId write targets allowed.
 void VerifyBackendReadyBody(
     const CompiledModuleBody& body, std::string_view label = "body");
 

--- a/src/lyra/llvm_backend/compute/compute.cpp
+++ b/src/lyra/llvm_backend/compute/compute.cpp
@@ -16,6 +16,7 @@
 #include "lyra/llvm_backend/compute/builtin.hpp"
 #include "lyra/llvm_backend/compute/cast.hpp"
 #include "lyra/llvm_backend/compute/driver.hpp"
+#include "lyra/llvm_backend/compute/four_state_ops.hpp"
 #include "lyra/llvm_backend/compute/math.hpp"
 #include "lyra/llvm_backend/compute/operand.hpp"
 #include "lyra/llvm_backend/compute/real.hpp"
@@ -222,6 +223,18 @@ auto LowerRvalue(
             auto* result = builder.CreateSelect(
                 cond_i1, *true_or_err, *false_or_err, "select");
             return RvalueValue::TwoState(result);
+          },
+          [&](const mir::ExternalReadRvalueInfo& info) -> Result<RvalueValue> {
+            auto val_or_err = context.LoadExternalRef(info.ref);
+            if (!val_or_err) return std::unexpected(val_or_err.error());
+            llvm::Value* raw = *val_or_err;
+            TypeId ref_type = context.GetExternalRefType(info.ref);
+            const Type& type = types[ref_type];
+            if (IsPacked(type) && context.IsPackedFourState(type)) {
+              auto fs = ExtractFourState(context.GetBuilder(), raw);
+              return RvalueValue::FourState(fs.value, fs.unknown);
+            }
+            return RvalueValue::TwoState(raw);
           },
           [&](const mir::SystemCmdRvalueInfo& info) -> Result<RvalueValue> {
             auto& builder = context.GetBuilder();

--- a/src/lyra/llvm_backend/compute/operand.cpp
+++ b/src/lyra/llvm_backend/compute/operand.cpp
@@ -242,9 +242,6 @@ auto LowerOperandRaw(
             const auto& tv = context.ReadTempValue(temp_id.value);
             return BuildRawValueFromTempValue(context.GetBuilder(), tv);
           },
-          [&context](mir::ExternalRefId ref_id) -> Result<llvm::Value*> {
-            return context.LoadExternalRef(ref_id);
-          },
       },
       operand.payload);
 }
@@ -291,16 +288,13 @@ auto ResolveOperandPlace(Context& /*context*/, const mir::Operand& operand)
           [](mir::TempId) -> std::optional<mir::PlaceId> {
             return std::nullopt;
           },
-          [&](mir::ExternalRefId) -> std::optional<mir::PlaceId> {
-            return std::nullopt;
-          },
       },
       operand.payload);
 }
 
 auto GetOperandTypeId(Context& context, const mir::Operand& operand) -> TypeId {
   const auto& types = context.GetTypeArena();
-  // Place-backed operands (PlaceId, ExternalRefId): derive from Place.
+  // Place-backed operands: derive from Place.
   auto place = ResolveOperandPlace(context, operand);
   if (place.has_value()) {
     return mir::TypeOfPlace(types, context.LookupPlace(*place));
@@ -316,9 +310,6 @@ auto GetOperandTypeId(Context& context, const mir::Operand& operand) -> TypeId {
             throw common::InternalError(
                 "GetOperandTypeId",
                 "PlaceId not handled by ResolveOperandPlace");
-          },
-          [&context](mir::ExternalRefId ref_id) -> TypeId {
-            return context.GetExternalRefType(ref_id);
           },
       },
       operand.payload);
@@ -348,11 +339,6 @@ auto IsOperandFourState(Context& context, const mir::Operand& operand) -> bool {
             throw common::InternalError(
                 "IsOperandFourState",
                 "PlaceId not handled by ResolveOperandPlace");
-          },
-          [&context, &types](mir::ExternalRefId ref_id) -> bool {
-            TypeId type_id = context.GetExternalRefType(ref_id);
-            const Type& type = types[type_id];
-            return IsPacked(type) && context.IsPackedFourState(type);
           },
       },
       operand.payload);

--- a/src/lyra/llvm_backend/layout/layout.cpp
+++ b/src/lyra/llvm_backend/layout/layout.cpp
@@ -604,7 +604,8 @@ void CollectPlacesFromRvalue(
             std::is_same_v<T, mir::MathCallRvalueInfo> ||
             std::is_same_v<T, mir::SystemTfRvalueInfo> ||
             std::is_same_v<T, mir::ArrayQueryRvalueInfo> ||
-            std::is_same_v<T, mir::SelectRvalueInfo>) {
+            std::is_same_v<T, mir::SelectRvalueInfo> ||
+            std::is_same_v<T, mir::ExternalReadRvalueInfo>) {
           // These RvalueInfo types have no embedded PlaceIds or Operands
           // beyond what's in Rvalue::operands (already collected above)
         } else {

--- a/src/lyra/llvm_backend/process.cpp
+++ b/src/lyra/llvm_backend/process.cpp
@@ -2324,7 +2324,8 @@ struct PlaceCollector {
               std::is_same_v<T, mir::MathCallRvalueInfo> ||
               std::is_same_v<T, mir::SystemTfRvalueInfo> ||
               std::is_same_v<T, mir::ArrayQueryRvalueInfo> ||
-              std::is_same_v<T, mir::SelectRvalueInfo>) {
+              std::is_same_v<T, mir::SelectRvalueInfo> ||
+              std::is_same_v<T, mir::ExternalReadRvalueInfo>) {
             // These RvalueInfo types have no embedded PlaceIds or Operands
             // beyond what's in Rvalue::operands (already collected above)
           } else {

--- a/src/lyra/lowering/hir_to_mir/builder.cpp
+++ b/src/lyra/lowering/hir_to_mir/builder.cpp
@@ -336,6 +336,15 @@ auto MirBuilder::EmitValueTemp(TypeId type, mir::Rvalue value) -> mir::Operand {
   return mir::Operand::UseTemp(temp_id);
 }
 
+auto MirBuilder::EmitExternalRead(TypeId type, mir::ExternalRefId ref)
+    -> mir::Operand {
+  mir::Rvalue rv{
+      .operands = {},
+      .info = mir::ExternalReadRvalueInfo{.ref = ref},
+  };
+  return EmitValueTemp(type, std::move(rv));
+}
+
 auto MirBuilder::EmitValueTempAssign(TypeId type, mir::Operand source)
     -> mir::Operand {
   int temp_id = ctx_->AllocValueTemp(type);

--- a/src/lyra/lowering/hir_to_mir/expression.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression.cpp
@@ -2682,7 +2682,7 @@ auto LowerExpressionImpl(
           }
           auto ref = ctx.LowerHierarchicalRefToExternalRef(
               data, expr.type, mir::ExternalAccessKind::kRead);
-          return mir::Operand::ExternalRef(ref.ref_id);
+          return builder.EmitExternalRead(expr.type, ref.ref_id);
         } else if constexpr (std::is_same_v<T, hir::MathCallExpressionData>) {
           return LowerMathCall(data, expr, builder, cache);
         } else if constexpr (std::is_same_v<

--- a/src/lyra/lowering/hir_to_mir/lower.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower.cpp
@@ -4,6 +4,7 @@
 #include <expected>
 #include <format>
 #include <memory>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -56,13 +57,12 @@ void VerifyLoweredMir(
             [&](const mir::Module& mod) {
               const auto& body = *mod.body;
               const auto& arena = body.arena;
-              // Module bodies use kBackendReady because they are still
-              // mir::ModuleBody (old type, cannot contain ExternalRefId).
-              // When Phase 2 migrates to CompiledModuleBody, this call site
-              // switches to VerifyPreBackendBody(compiled_body, ...).
               mir::VerifyContext cx{
                   .types = &type_arena,
                   .phase = mir::VerifyContext::Phase::kBackendReady,
+                  .external_refs =
+                      std::span<const mir::ExternalAccessRecipe>{
+                          body.external_refs},
                   .num_events = static_cast<uint32_t>(body.events.size()),
               };
               std::string_view module_path =
@@ -91,6 +91,7 @@ void VerifyLoweredMir(
               mir::VerifyContext cx{
                   .types = &type_arena,
                   .phase = mir::VerifyContext::Phase::kBackendReady,
+                  .external_refs = {},
               };
               for (size_t fi = 0; fi < pkg.functions.size(); ++fi) {
                 std::string label =

--- a/src/lyra/lowering/hir_to_mir/statement.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement.cpp
@@ -1100,10 +1100,6 @@ auto ResolveLoweredOperandType(const mir::Operand& op, const Context& ctx)
     case mir::Operand::Kind::kPoison:
       throw common::InternalError(
           "ResolveLoweredOperandType", "poison operand in deferred capture");
-    case mir::Operand::Kind::kExternalRef:
-      throw common::InternalError(
-          "ResolveLoweredOperandType",
-          "external ref operand in deferred capture");
   }
   throw common::InternalError(
       "ResolveLoweredOperandType", "unknown operand kind");
@@ -2004,6 +2000,34 @@ auto BuildIndexPlan(
   }
 }
 
+// Typed trigger-source result: either a local design place or an unresolved
+// external ref handle. HIR syntax discrimination is isolated here so that
+// LowerEventWait consumes a typed result rather than branching on expression
+// kind inline.
+using TriggerSource = std::variant<mir::PlaceId, mir::ExternalRefId>;
+
+auto LowerEventTriggerSource(hir::ExpressionId expr_id, MirBuilder& builder)
+    -> Result<TriggerSource> {
+  auto& ctx = builder.GetContext();
+  const auto& expr = (*ctx.hir_arena)[expr_id];
+  if (expr.kind == hir::ExpressionKind::kHierarchicalRef &&
+      ctx.external_refs != nullptr) {
+    const auto& href_data =
+        std::get<hir::HierarchicalRefExpressionData>(expr.data);
+    auto ref = ctx.LowerHierarchicalRefToExternalRef(
+        href_data, expr.type, mir::ExternalAccessKind::kRead);
+    return TriggerSource{ref.ref_id};
+  }
+  auto op_result = LowerExpression(expr_id, builder);
+  if (!op_result) return std::unexpected(op_result.error());
+  if (op_result->kind != mir::Operand::Kind::kUse) {
+    throw common::InternalError(
+        "LowerEventTriggerSource",
+        "event trigger signal must be a design variable");
+  }
+  return TriggerSource{std::get<mir::PlaceId>(op_result->payload)};
+}
+
 auto LowerEventWait(
     const hir::EventWaitStatementData& data, MirBuilder& builder)
     -> Result<void> {
@@ -2633,13 +2657,11 @@ auto LowerEventWait(
                                  .width = 1,
                                  .element_type = hir_expr.type}});
     } else {
-      auto signal_result = LowerExpression(hir_trigger.signal, builder);
-      if (!signal_result) return std::unexpected(signal_result.error());
-      mir::Operand signal_op = std::move(*signal_result);
-      if (signal_op.kind == mir::Operand::Kind::kExternalRef) {
-        // Carry unresolved external ref trigger. Resolved at backend
-        // normalization (FillTriggerArray) using ResolvedExternalRefBinding.
-        auto ref_id = std::get<mir::ExternalRefId>(signal_op.payload);
+      auto source = LowerEventTriggerSource(hir_trigger.signal, builder);
+      if (!source) return std::unexpected(source.error());
+      if (const auto* ref_id = std::get_if<mir::ExternalRefId>(&*source)) {
+        // External ref trigger: carry unresolved handle for backend
+        // normalization (FillTriggerArray).
         common::EdgeKind edge = common::EdgeKind::kAnyChange;
         switch (hir_trigger.edge) {
           case hir::EventEdgeKind::kNone:
@@ -2657,13 +2679,13 @@ auto LowerEventWait(
                  .edge = common::EdgeKind::kPosedge,
                  .observed_place = std::nullopt,
                  .late_bound = std::nullopt,
-                 .unresolved_external_ref = ref_id});
+                 .unresolved_external_ref = *ref_id});
             triggers.push_back(
                 {.signal = {},
                  .edge = common::EdgeKind::kNegedge,
                  .observed_place = std::nullopt,
                  .late_bound = std::nullopt,
-                 .unresolved_external_ref = ref_id});
+                 .unresolved_external_ref = *ref_id});
             continue;
         }
         triggers.push_back(
@@ -2671,16 +2693,10 @@ auto LowerEventWait(
              .edge = edge,
              .observed_place = std::nullopt,
              .late_bound = std::nullopt,
-             .unresolved_external_ref = ref_id});
+             .unresolved_external_ref = *ref_id});
         continue;
       }
-      if (signal_op.kind == mir::Operand::Kind::kUse) {
-        place_id = std::get<mir::PlaceId>(signal_op.payload);
-      } else {
-        throw common::InternalError(
-            "LowerEventWait",
-            "event trigger signal must be a design variable or external ref");
-      }
+      place_id = std::get<mir::PlaceId>(*source);
     }
 
     const auto& place = (*ctx.mir_arena)[place_id];

--- a/src/lyra/mir/dumper.cpp
+++ b/src/lyra/mir/dumper.cpp
@@ -52,9 +52,6 @@ auto FormatTermOperand(const Operand& op) -> std::string {
       return std::format("$t{}", std::get<TempId>(op.payload).value);
     case Operand::Kind::kConst:
       return "const";
-    case Operand::Kind::kExternalRef:
-      return std::format(
-          "ext_ref({})", std::get<ExternalRefId>(op.payload).value);
     case Operand::Kind::kPoison:
       return "poison";
   }
@@ -475,9 +472,6 @@ auto Dumper::FormatIndexOperand(const Operand& op) const -> std::string {
       TempId temp_id = std::get<TempId>(op.payload);
       return std::format("#t{}", temp_id.value);
     }
-    case Operand::Kind::kExternalRef:
-      return std::format(
-          "ext_ref({})", std::get<ExternalRefId>(op.payload).value);
     case Operand::Kind::kPoison:
       return "poison";
   }
@@ -604,9 +598,6 @@ auto Dumper::FormatOperand(const Operand& op) const -> std::string {
       TempId temp_id = std::get<TempId>(op.payload);
       return std::format("use(#t{})", temp_id.value);
     }
-    case Operand::Kind::kExternalRef:
-      return std::format(
-          "ext_ref({})", std::get<ExternalRefId>(op.payload).value);
     case Operand::Kind::kPoison:
       return "poison";
   }
@@ -767,6 +758,9 @@ auto Dumper::FormatRvalue(const Rvalue& rv) const -> std::string {
             return std::string("$system()");
           },
           [](const SelectRvalueInfo&) { return std::string("select"); },
+          [](const ExternalReadRvalueInfo& info) {
+            return std::format("external_read({})", info.ref.value);
+          },
       },
       rv.info);
 

--- a/src/lyra/mir/sensitivity.cpp
+++ b/src/lyra/mir/sensitivity.cpp
@@ -161,11 +161,8 @@ void CollectReadsFromOperand(
     CollectReadsFromPlace(place_id, arena[place_id], arena, must_def, obs);
     return;
   }
-  if (op.kind == Operand::Kind::kExternalRef) {
-    auto ref_id = std::get<ExternalRefId>(op.payload);
-    obs.pending_external_refs.push_back(ref_id);
-    return;
-  }
+  // ExternalRefId reads are now explicit ExternalReadRvalueInfo rvalues,
+  // handled in CollectReadsFromRhs via the rvalue path.
 }
 
 void CollectReadsFromRhs(
@@ -216,6 +213,9 @@ void CollectReadsFromRvalue(
           [](const SystemTfRvalueInfo&) {},
           [](const ArrayQueryRvalueInfo&) {},
           [](const SelectRvalueInfo&) {},
+          [&](const ExternalReadRvalueInfo& info) {
+            obs.pending_external_refs.push_back(info.ref);
+          },
           [&](const SystemCmdRvalueInfo& info) {
             if (info.command) {
               CollectReadsFromOperand(

--- a/src/lyra/mir/verify.cpp
+++ b/src/lyra/mir/verify.cpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <format>
+#include <span>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -32,18 +33,24 @@
 namespace lyra::mir {
 
 auto RequireExternalRefRecipe(
-    const CompiledModuleBody& body, ExternalRefId id, const char* where)
-    -> const ExternalAccessRecipe& {
-  const auto* recipe = body.GetExternalAccessRecipe(id);
-  if (recipe == nullptr || !(recipe->ref_id == id)) {
+    std::span<const ExternalAccessRecipe> recipes, ExternalRefId id,
+    const char* where) -> const ExternalAccessRecipe& {
+  if (id.value >= recipes.size()) {
     throw common::InternalError(
-        where, std::format("invalid ExternalRefId {}", id.value));
+        where, std::format(
+                   "ExternalRefId {} out of range (table has {})", id.value,
+                   recipes.size()));
   }
-  if (recipe->type.value == 0) {
+  const auto& recipe = recipes[id.value];
+  if (!(recipe.ref_id == id)) {
+    throw common::InternalError(
+        where, std::format("ExternalRefId {} position mismatch", id.value));
+  }
+  if (recipe.type.value == 0) {
     throw common::InternalError(
         where, std::format("ExternalRefId {} has invalid type", id.value));
   }
-  return *recipe;
+  return recipe;
 }
 
 namespace {
@@ -340,8 +347,7 @@ auto IsSelectorType(const Type& type) -> bool {
 }
 
 // Get the TypeId for an operand (for type checking edge args).
-// Phase-aware: in kPreBackend, ExternalRefId resolves through the body's
-// external_refs table. In kBackendReady, ExternalRefId is illegal.
+// Operands are value-only: Constant, PlaceId, or TempId.
 auto GetOperandType(
     const Operand& op, [[maybe_unused]] const std::vector<BasicBlock>& blocks,
     const Arena& arena, const VerifyContext& cx,
@@ -361,15 +367,6 @@ auto GetOperandType(
             }
             // Temp not found - this will be caught by VerifyUseTempDefined
             return TypeId{0};
-          },
-          [&](ExternalRefId id) -> TypeId {
-            if (cx.phase == VerifyContext::Phase::kPreBackend) {
-              const auto& recipe =
-                  RequireExternalRefRecipe(*cx.body, id, "GetOperandType");
-              return recipe.type;
-            }
-            throw common::InternalError(
-                "MIR verify", "ExternalRefId in backend-ready MIR");
           },
       },
       op.payload);
@@ -647,9 +644,9 @@ void VerifyStatementOwnership(
     if (const auto* pid = std::get_if<PlaceId>(&target)) {
       verify_place(*pid, ctx);
     } else if (cx.phase == VerifyContext::Phase::kPreBackend) {
-      // Validate ExternalRefId resolves in pre-backend mode
       auto ext_id = std::get<ExternalRefId>(target);
-      RequireExternalRefRecipe(*cx.body, ext_id, "VerifyStatementOwnership");
+      RequireExternalRefRecipe(
+          cx.external_refs, ext_id, "VerifyStatementOwnership");
     }
   };
 
@@ -968,6 +965,29 @@ void VerifyBlockParamsAndEdgeArgs(
                       routine_kind, i, j));
             }
           }
+          // ExternalReadRvalueInfo: no operands, valid recipe ref,
+          // recipe type must match DefineTemp result type
+          if (const auto* ext =
+                  std::get_if<ExternalReadRvalueInfo>(&rv->info)) {
+            if (!rv->operands.empty()) {
+              throw common::InternalError(
+                  "MIR verify",
+                  std::format(
+                      "{}: block {} stmt {}: ExternalReadRvalueInfo must "
+                      "have 0 operands, got {}",
+                      routine_kind, i, j, rv->operands.size()));
+            }
+            const auto& recipe = RequireExternalRefRecipe(
+                cx.external_refs, ext->ref, "VerifyExternalReadRvalue");
+            if (!(recipe.type == dt->type)) {
+              throw common::InternalError(
+                  "MIR verify",
+                  std::format(
+                      "{}: block {} stmt {}: ExternalReadRvalueInfo recipe "
+                      "type ({}) != DefineTemp result type ({})",
+                      routine_kind, i, j, recipe.type.value, dt->type.value));
+            }
+          }
         }
       }
 
@@ -1142,15 +1162,17 @@ void VerifyProcess(
 void VerifyPreBackendBody(
     const CompiledModuleBody& body, const TypeArena& types,
     std::string_view label) {
+  std::span<const ExternalAccessRecipe> ext_refs{body.external_refs};
   VerifyContext cx{
-      .body = &body,
       .types = &types,
       .phase = VerifyContext::Phase::kPreBackend,
+      .external_refs = ext_refs,
   };
 
   // Verify external_refs table integrity.
   for (uint32_t i = 0; i < body.external_refs.size(); ++i) {
-    RequireExternalRefRecipe(body, ExternalRefId{i}, "VerifyPreBackendBody");
+    RequireExternalRefRecipe(
+        ext_refs, ExternalRefId{i}, "VerifyPreBackendBody");
   }
 
   // Walk all processes and functions through the common verifier.
@@ -1165,22 +1187,13 @@ void VerifyPreBackendBody(
         std::format("{}:func[{}]", label, i));
   }
 
-  // Verify all ExternalRefId operands and write targets reference valid
-  // entries. Uses the generic walkers for complete coverage.
-  auto check_blocks = [&](const std::vector<BasicBlock>& blocks,
-                          std::string_view routine_label) {
-    for (size_t bi = 0; bi < blocks.size(); ++bi) {
-      auto block_ctx = std::format("{}:block[{}]", routine_label, bi);
-      for (const auto& stmt : blocks[bi].statements) {
-        ForEachOperand(stmt.data, [&](const Operand& op) {
-          if (op.kind == Operand::Kind::kExternalRef) {
-            auto id = std::get<ExternalRefId>(op.payload);
-            RequireExternalRefRecipe(body, id, "VerifyPreBackendBody");
-          }
-        });
+  // Verify all ExternalRefId write targets reference valid entries.
+  auto check_blocks = [&](const std::vector<BasicBlock>& blocks) {
+    for (const auto& block : blocks) {
+      for (const auto& stmt : block.statements) {
         ForEachWriteTarget(stmt.data, [&](const WriteTarget& t) {
           if (const auto* ext = std::get_if<ExternalRefId>(&t)) {
-            RequireExternalRefRecipe(body, *ext, "VerifyPreBackendBody");
+            RequireExternalRefRecipe(ext_refs, *ext, "VerifyPreBackendBody");
           }
         });
       }
@@ -1189,32 +1202,23 @@ void VerifyPreBackendBody(
 
   for (size_t i = 0; i < body.processes.size(); ++i) {
     const auto& proc = body.arena[body.processes[i]];
-    check_blocks(proc.blocks, std::format("{}:proc[{}]", label, i));
+    check_blocks(proc.blocks);
   }
   for (size_t i = 0; i < body.functions.size(); ++i) {
     const auto& func = body.arena[body.functions[i]];
-    check_blocks(func.blocks, std::format("{}:func[{}]", label, i));
+    check_blocks(func.blocks);
   }
 }
 
 void VerifyBackendReadyBody(
     const CompiledModuleBody& body, std::string_view label) {
-  // Backend-ready MIR must contain no ExternalRefId in any operand or
-  // write target. Uses the generic walkers for complete coverage.
+  // Backend-ready MIR must contain no ExternalRefId write targets.
+  // Operands are value-only and never carry ExternalRefId.
+  // External reads are explicit ExternalReadRvalueInfo rvalues.
   auto check_blocks = [&](const std::vector<BasicBlock>& blocks,
                           std::string_view routine_label) {
     for (size_t bi = 0; bi < blocks.size(); ++bi) {
       for (const auto& stmt : blocks[bi].statements) {
-        ForEachOperand(stmt.data, [&](const Operand& op) {
-          if (op.kind == Operand::Kind::kExternalRef) {
-            throw common::InternalError(
-                "VerifyBackendReadyBody",
-                std::format(
-                    "{}: {}:block[{}]: ExternalRefId operand in "
-                    "backend-ready MIR",
-                    label, routine_label, bi));
-          }
-        });
         ForEachWriteTarget(stmt.data, [&](const WriteTarget& t) {
           if (IsExternalWrite(t)) {
             throw common::InternalError(

--- a/tests/framework/llvm_common.cpp
+++ b/tests/framework/llvm_common.cpp
@@ -39,6 +39,7 @@
 #include "lyra/lowering/diagnostic_context.hpp"
 #include "lyra/lowering/hir_to_mir/lower.hpp"
 #include "lyra/lowering/origin_map_lookup.hpp"
+#include "lyra/mir/dumper.hpp"
 #include "lyra/runtime/artifact_names.hpp"
 #include "lyra/runtime/feature_flags.hpp"
 #include "tests/framework/runner_common.hpp"
@@ -283,6 +284,14 @@ auto PrepareLlvmModule(
 
   if (test_case.dump_dpi_header && !mir_result->dpi_header.empty()) {
     compiler_output += mir_result->dpi_header;
+  }
+
+  if (test_case.dump_mir) {
+    std::ostringstream mir_out;
+    mir::Dumper dumper(
+        mir_result->design_arena.get(), hir_result.type_arena.get(), &mir_out);
+    dumper.Dump(mir_result->design);
+    compiler_output += mir_out.str();
   }
 
   double mir_lower_seconds =

--- a/tests/framework/test_case.hpp
+++ b/tests/framework/test_case.hpp
@@ -60,6 +60,7 @@ struct TestCase {
   bool dump_repertoire = false;          // Dump generate repertoire observation
   bool dump_repertoire_desc = false;     // Dump repertoire descriptor
   bool dump_dpi_header = false;          // Dump generated DPI-C header
+  bool dump_mir = false;                 // Dump MIR to compiler_output
   bool dump_llvm_ir = false;             // Dump LLVM IR module
   std::optional<std::vector<uint64_t>> expected_cover_hits;
   // NBA routing boundary assertions: {generic_queue: N, deferred_local: N}

--- a/tests/framework/test_case_loader.cpp
+++ b/tests/framework/test_case_loader.cpp
@@ -330,6 +330,7 @@ auto LoadTestCasesFromYaml(const std::string& path) -> std::vector<TestCase> {
          "dump_repertoire",
          "dump_repertoire_desc",
          "dump_dpi_header",
+         "dump_mir",
          "dump_llvm_ir",
          "disable_assertions",
          "single_unit",
@@ -419,6 +420,9 @@ auto LoadTestCasesFromYaml(const std::string& path) -> std::vector<TestCase> {
     }
     if (node["dump_dpi_header"]) {
       test_case.dump_dpi_header = node["dump_dpi_header"].as<bool>();
+    }
+    if (node["dump_mir"]) {
+      test_case.dump_mir = node["dump_mir"].as<bool>();
     }
     if (node["dump_llvm_ir"]) {
       test_case.dump_llvm_ir = node["dump_llvm_ir"].as<bool>();

--- a/tests/sv_features/hierarchy/refs/hierarchical_refs/default.yaml
+++ b/tests/sv_features/hierarchy/refs/hierarchical_refs/default.yaml
@@ -109,6 +109,162 @@ cases:
       stdout:
         contains: ["value = 99"]
 
+  - name: simple_assign_ref
+    description: Continuous assign from hierarchical ref (external_read boundary)
+    sv: |
+      module Child;
+        logic [7:0] value;
+        initial value = 8'hAB;
+      endmodule
+
+      module Top;
+        Child u_child();
+        logic [7:0] x;
+
+        assign x = u_child.value;
+
+        initial begin
+          #1;
+          $display("x = %h", x);
+        end
+      endmodule
+    expect:
+      stdout:
+        contains: ["x = ab"]
+
+  - name: binary_op_ref
+    description: Hierarchical ref as binary op operand (external_read + value temp)
+    sv: |
+      module Child;
+        logic [7:0] value;
+        initial value = 8'h10;
+      endmodule
+
+      module Top;
+        Child u_child();
+        logic [7:0] x;
+
+        assign x = u_child.value + 8'h01;
+
+        initial begin
+          #1;
+          $display("x = %h", x);
+        end
+      endmodule
+    expect:
+      stdout:
+        contains: ["x = 11"]
+
+  - name: call_arg_ref
+    description: Hierarchical ref as function argument (external_read materialized before call)
+    sv: |
+      module Child;
+        int value;
+        initial value = 10;
+      endmodule
+
+      module Top;
+        Child u_child();
+        int result;
+
+        function automatic int double_it(int v);
+          return v * 2;
+        endfunction
+
+        assign result = double_it(u_child.value);
+
+        initial begin
+          #1;
+          $display("result = %0d", result);
+        end
+      endmodule
+    expect:
+      stdout:
+        contains: ["result = 20"]
+
+  - name: ternary_ref
+    description: Hierarchical ref used in ternary expression (external_read per arm, value edge args)
+    sv: |
+      module Child;
+        logic [7:0] value;
+        initial value = 8'hAB;
+      endmodule
+
+      module Top;
+        Child u_child();
+        logic sel;
+        logic [7:0] result;
+
+        assign result = sel ? u_child.value : 8'h00;
+
+        initial begin
+          sel = 1;
+          #1;
+          $display("result = %h", result);
+        end
+      endmodule
+    expect:
+      stdout:
+        contains: ["result = ab"]
+
+  - name: ternary_both_refs
+    description: Ternary with both branches being hierarchical refs
+    sv: |
+      module Child;
+        logic [7:0] a, b;
+        initial begin
+          a = 8'hAA;
+          b = 8'hBB;
+        end
+      endmodule
+
+      module Top;
+        Child u_child();
+        logic sel;
+        logic [7:0] result;
+
+        assign result = sel ? u_child.a : u_child.b;
+
+        initial begin
+          sel = 0;
+          #1;
+          $display("result = %h", result);
+        end
+      endmodule
+    expect:
+      stdout:
+        contains: ["result = bb"]
+
+  - name: if_else_ref
+    description: Hierarchical ref in if-else with value merging across blocks
+    sv: |
+      module Child;
+        int x;
+        initial x = 42;
+      endmodule
+
+      module Top;
+        Child u_child();
+        int result;
+        logic cond;
+
+        always_comb begin
+          if (cond)
+            result = u_child.x + 1;
+          else
+            result = u_child.x - 1;
+        end
+
+        initial begin
+          cond = 1;
+          #1;
+          $display("result = %0d", result);
+        end
+      endmodule
+    expect:
+      stdout:
+        contains: ["result = 43"]
+
   - name: parameter_ref
     description: Read a child module parameter via hierarchical path
     sv: |

--- a/tests/sv_features/hierarchy/refs/hierarchical_refs/mir_shape.yaml
+++ b/tests/sv_features/hierarchy/refs/hierarchical_refs/mir_shape.yaml
@@ -1,0 +1,122 @@
+feature: hierarchical_refs_mir_shape
+description: MIR shape assertions for external_read boundary
+
+cases:
+  - name: simple_assign_mir
+    description: Continuous assign from hierarchical ref produces external_read rvalue
+    dump_mir: true
+    sv: |
+      module Child;
+        logic [7:0] value;
+        initial value = 8'hAB;
+      endmodule
+
+      module Top;
+        Child u_child();
+        logic [7:0] x;
+
+        assign x = u_child.value;
+
+        initial begin
+          #1;
+          $display("x = %h", x);
+        end
+      endmodule
+    expect:
+      stdout:
+        contains: ["x = ab"]
+      compiler_output:
+        contains: ["external_read("]
+        not_contains: ["ext_ref("]
+
+  - name: binary_op_mir
+    description: Hierarchical ref in binary op produces external_read before computation
+    dump_mir: true
+    sv: |
+      module Child;
+        logic [7:0] value;
+        initial value = 8'h10;
+      endmodule
+
+      module Top;
+        Child u_child();
+        logic [7:0] x;
+
+        assign x = u_child.value + 8'h01;
+
+        initial begin
+          #1;
+          $display("x = %h", x);
+        end
+      endmodule
+    expect:
+      stdout:
+        contains: ["x = 11"]
+      compiler_output:
+        contains: ["external_read("]
+        not_contains: ["ext_ref("]
+
+  - name: call_arg_mir
+    description: Hierarchical ref as call argument produces external_read before call
+    dump_mir: true
+    sv: |
+      module Child;
+        int value;
+        initial value = 10;
+      endmodule
+
+      module Top;
+        Child u_child();
+        int result;
+
+        function automatic int double_it(int v);
+          return v * 2;
+        endfunction
+
+        assign result = double_it(u_child.value);
+
+        initial begin
+          #1;
+          $display("result = %0d", result);
+        end
+      endmodule
+    expect:
+      stdout:
+        contains: ["result = 20"]
+      compiler_output:
+        contains: ["external_read("]
+        not_contains: ["ext_ref("]
+
+  - name: ternary_mir
+    description: Ternary with hierarchical refs produces external_read per arm, value edge args
+    dump_mir: true
+    sv: |
+      module Child;
+        logic [7:0] a, b;
+        initial begin
+          a = 8'hAA;
+          b = 8'hBB;
+        end
+      endmodule
+
+      module Top;
+        Child u_child();
+        logic sel;
+        logic [7:0] x;
+
+        assign x = sel ? u_child.a : u_child.b;
+
+        initial begin
+          sel = 1;
+          #1;
+          $display("x = %h", x);
+        end
+      endmodule
+    expect:
+      stdout:
+        contains: ["x = aa"]
+      compiler_output:
+        contains:
+          - "external_read("
+          - "jump bb3($t"
+        not_contains: ["ext_ref("]


### PR DESCRIPTION
## Summary

Removes ExternalRefId from the generic Operand type and introduces ExternalReadRvalueInfo as an explicit MIR rvalue for reading from non-local external locations. Hierarchical read expressions now cross a canonical read boundary at HIR-to-MIR lowering time, producing ordinary value temps that flow through all generic value positions (edge args, call args, rvalue operands) without carrying location handles.

This fixes the Ibex compilation crash ("ExternalRefId in backend-ready MIR") where a ternary expression with hierarchical ref arms put external-location handles into block edge args, triggering a verifier rejection. The root cause was a category confusion: the old Operand variant conflated location handles with computed values, allowing external refs to leak into SSA value flow without an explicit read boundary.

## Design

The read/write split is now symmetric:
- **Write side**: WriteTarget = variant<PlaceId, ExternalRefId> (unchanged)
- **Read side**: ExternalReadRvalueInfo rvalue produces a value temp via EmitExternalRead

ExternalRefId survives only in explicit external-location categories: write targets, wait-trigger unresolved refs, connection/trigger recipes, and the new ExternalReadRvalueInfo. Backend operand dispatch (LowerOperandRaw) no longer performs implicit reads.

Verifier changes: VerifyContext now holds a direct span<const ExternalAccessRecipe> instead of a CompiledModuleBody pointer, so ModuleBody verification validates external-read recipes and write targets against the real table. ExternalReadRvalueInfo validation proves recipe existence and type match against the DefineTemp result type.

Event-trigger lowering is factored into a LowerEventTriggerSource helper that returns variant<PlaceId, ExternalRefId>, isolating HIR syntax discrimination from the event-wait control flow.

## Testing

- 4 new MIR-shape tests (dump_mir + compiler_output assertions) pin the architectural invariant: MIR contains external_read(...), never operand-side ext_ref(...), ternary edge args are value temps
- 3 new runtime tests (simple assign, binary op, call arg with hierarchical refs)
- All 557 jit_dev_tests pass
- Ibex passes MIR verification (hits a separate pre-existing backend bug in array init)