### PR TITLE
Introduce XIR layer and per-compilation-unit model in architecture docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | `docs/architecture.md`             | Component relationships, data flow                       |
 | `docs/pipeline-contract.md`        | Layer responsibilities, boundaries, correctness          |
 | `docs/hir-design.md`               | HIR layer design (language semantics)                    |
-| `docs/mir-design.md`               | MIR layer design (execution semantics)                   |
+| `docs/xir-design.md`               | XIR layer design (execution model)                       |
+| `docs/mir-design.md`               | MIR layer design (control-flow plumbing)                 |
 | `docs/llvm-backend.md`             | MIR -> LLVM lowering strategy                            |
 | `docs/runtime.md`                  | Simulation engine, scheduling, backend-agnostic API      |
 | `docs/change-propagation.md`       | Dirty tracking, subscriptions, wakeup filtering          |
@@ -76,15 +77,19 @@ Lyra targets **IEEE 1800-2023** (SystemVerilog 2023). The slang frontend is conf
 
 ## Architecture
 
-SystemVerilog compiler with specialization-based compilation:
+SystemVerilog compiler with specialization-based compilation. The compilation unit is a module specialization, not an elaborated design.
 
 ```
-SV -> slang -> Elaboration Discovery
+SV -> slang -> Elaboration Discovery (frontend output)
                     |
-            Specialization Compilation (parallel per spec)
-              AST -> HIR -> MIR -> LLVM IR
+            Specialization Grouping (frontend world -> per-unit compiler world)
                     |
-            Design Realization (design-wide)
+            Per-Unit Compilation (parallel per specialization)
+              HIR -> XIR -> MIR -> LLVM IR
+                    |
+            Artifact Composition (compile-time, design-wide packaging)
+                    |
+            Constructor / Realization (runtime, per-instance)
                     |
             Execution
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,8 @@ Start here for an overview of Lyra's design and constraints.
 ## Language and Semantics
 
 - [hir-design.md](hir-design.md) - SystemVerilog semantic model
-- [mir-design.md](mir-design.md) - execution semantics and control flow
+- [xir-design.md](xir-design.md) - execution-model IR (closures, observers, wait models, object composition)
+- [mir-design.md](mir-design.md) - control-flow plumbing (basic blocks, terminators, Place/Operand)
 - [type-system.md](type-system.md) - type representation and interning
 - [string-types.md](string-types.md) - string handling
 - [assertions.md](assertions.md) - assertion architecture

--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -71,15 +71,23 @@ Strongly-typed IDs (`ModuleSpecId`, `SymbolId`, `TypeId`, etc.) serve two purpos
 - **Incrementality** -- stable identity across recompilation; downstream stages reference IDs, not pointers
 - **Correctness** -- type safety prevents mixing IDs from different domains; the type system catches misuse at compile time
 
+**Caution:** IDs that name a compilation unit (e.g., `ModuleSpecId`) must not become surrogate handles for recovering design-global architecture state. An ID names a unit or a construct within a unit. If code uses a unit ID to look up non-local information in design-global tables during per-unit lowering, the compilation-unit boundary is violated. IDs are for naming, not for escaping unit isolation.
+
 This follows from **incrementality** (stable keys) and **lifecycle** (strong invariants).
 
-### Specialization-Scoped IR, Instances at Realization/Runtime
+### Per-Compilation-Unit IR, Instances at Constructor/Runtime
 
-HIR, MIR, and LLVM IR are internal to specialization compilation and are specialization-scoped. No instance paths, no design-global slot IDs, no design-global allocation. Instance creation, storage allocation, and hierarchy wiring happen at realization/runtime. The IR never duplicates code for structurally identical instances.
+HIR, XIR, MIR, and LLVM IR are internal to per-unit compilation and are per-compilation-unit. No instance paths, no design-global slot IDs, no design-global allocation. After HIR establishes per-unit boundaries, all lowering proceeds per-unit without consulting design-global state. Instance creation, storage allocation, and hierarchy wiring happen at constructor/runtime time.
 
 Per-instance binding should not appear in LLVM function or global identity. Heavy LLVM codegen shape -- function count, global count, and optimization work -- should be determined by the number of unique specializations, not the number of instances. Instance-specific constants (base byte offset, instance ID, per-instance slot offsets) belong in runtime-owned data materialized at construction time.
 
 This follows from **the natural model** (instances are objects, not coordinates into a global arena), **parallelism** (IR scales with specializations), and **incrementality** (specialization changes do not cascade through instance graphs).
+
+### Compilation-Unit Isolation
+
+Per-unit lowering (HIR -> XIR -> MIR -> LLVM) must not consult design-global state beyond frozen shared read-only context (types, symbols). If a lowering step requires whole-design knowledge, either the compilation-unit boundary is violated or the information should be resolved at a different phase (elaboration, artifact composition, or constructor/realization).
+
+This follows from **parallelism** (units compile independently) and **incrementality** (changes within one unit do not force recompilation of others).
 
 ### Specialization-Local Optimizations Only
 
@@ -127,9 +135,11 @@ For any design change, ask in order:
 4. **Does it keep the scaling law right?** -- Does cost grow with specializations or with instances?
 5. **Are ownership and invariants enforced by structure?** -- Or does correctness depend on "be careful"?
 6. **Is it specialization-local?** -- Does it require cross-module or design-global knowledge?
+7. **Does it keep the compilation unit self-contained?** -- Does per-unit lowering need to consult design-global state beyond frozen read-only context?
+8. **Do IDs stay as names, not escape hatches?** -- Does any compilation-unit ID get used as a lookup key into design-global tables during lowering?
 
-7. **Does it avoid materializing final object identity at compile time?** -- Does it require knowing final instance count, object ordering, or target object identity during specialization compilation?
-8. **Does the backend reach per-instance data only through instance_ptr?** -- Backend codegen must not receive design-wide query APIs (ConstructionInput, body-group-to-objects maps) or scan construction-level tables to derive compile-time facts from one representative instance. Per-instance data is loaded at runtime from instance_ptr-reachable state, never baked as a compile-time constant derived from a design-topology scan.
+9. **Does it avoid materializing final object identity at compile time?** -- Does it require knowing final instance count, object ordering, or target object identity during per-unit compilation?
+10. **Does the backend reach per-instance data only through instance_ptr?** -- Backend codegen must not receive design-wide query APIs (ConstructionInput, body-group-to-objects maps) or scan construction-level tables to derive compile-time facts from one representative instance. Per-instance data is loaded at runtime from instance_ptr-reachable state, never baked as a compile-time constant derived from a design-topology scan.
 
 If a proposed change fails any of these questions, reconsider the design before proceeding.
 
@@ -137,12 +147,12 @@ If a proposed change fails any of these questions, reconsider the design before 
 
 How existing decisions follow from these principles:
 
-- **HIR/MIR as specialization-scoped IR** (not instance graphs) -> parallelism: compile per specialization
+- **HIR/XIR/MIR as specialization-scoped IR** (not instance graphs) -> parallelism: compile per specialization
 - **`this_base` + relative offset** for variable access -> performance: O(1) access without hierarchy traversal
 - **Strongly-typed IDs throughout the pipeline** -> incrementality + correctness: stable references, no cross-domain misuse
 - **Dirty-driven scheduling** -> performance: incremental work, not whole-design recomputation
 - **Single-owner mutable state** in runtime -> lifecycle: no aliasing bugs, clear write paths
-- **Strict pipeline layering** (HIR -> MIR -> LLVM) -> incrementality: each stage depends only on its input
+- **Strict pipeline layering** (HIR -> XIR -> MIR -> LLVM) -> incrementality: each stage depends only on its input
 - **Kernelization within specialization** -> performance: scheduler bypass without cross-module coupling
 - **Value-only parameters as instance constants** -> parallelism: 16 banks = 1 specialization, not 16
 - **Unpacked sizes as elaboration-time metadata** -> parallelism: `int a[4]` and `int a[8]` share compiled code

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,46 +17,62 @@ Internally: compiler logic is a library, orchestrator handles config, caching, a
 
 ## Compilation Model
 
-Lyra uses specialization-based compilation. The compilation unit is a **module specialization** (`ModuleSpecId`), not an elaborated design. See [compilation-model.md](compilation-model.md) for the full data model.
+Lyra uses specialization-based compilation. The compilation unit is a **module specialization** (`ModuleSpecId`), not an elaborated design or an instance. See [compilation-model.md](compilation-model.md) for the full data model.
 
 ```
 SV -> slang -> Elaboration Discovery
                     |
-         Specialization Compilation  (parallel per spec)
-           AST -> HIR -> MIR -> LLVM
+         Specialization Grouping
+           (frontend world -> per-unit compiler world)
                     |
-         Design Realization  (design-wide)
+         Per-Unit Compilation  (parallel per specialization)
+           HIR -> XIR -> MIR -> LLVM
+                    |
+         Artifact Composition  (compile-time, design-wide)
+                    |
+         Constructor / Realization  (runtime, per-instance)
                     |
          Execution
 ```
 
 ### Elaboration Discovery
 
-- slang parses SystemVerilog, produces AST
-- Performs legality checks, name resolution, type checking
-- Determines the instance graph, connectivity, and required specializations
-- Does NOT produce compiled artifacts
+The frontend library (slang) parses, elaborates, and type-checks the full design. This produces the frontend's view of the world: an instance graph, connectivity, and parameter assignments.
 
-### Specialization Compilation (Parallel)
+Elaboration output is **input to the compiler**, not the compiler's own compilation world. The compiler does not adopt the frontend's instance-centric model.
 
-Each specialization is compiled independently:
+### Specialization Grouping
 
-- **HIR**: Decouples from slang AST. Preserves SystemVerilog semantics. Specialization-scoped.
-- **MIR**: Place/Value model with basic blocks. Fixes all execution semantics. Specialization-scoped.
+At the AST-to-HIR boundary, the compiler breaks the frontend's whole-design output into per-specialization compilation units. Instances with identical compile-owned facts (packed layout, compiled code shape) share a single compilation unit. The compiler's world after this point is per-unit, not per-design.
+
+### Per-Unit Compilation (Parallel)
+
+Each compilation unit is compiled independently through four IR layers:
+
+- **HIR**: Semantic/source-oriented IR. Decouples from slang AST. Owns all data. See [hir-design.md](hir-design.md).
+- **XIR**: Execution-model IR. Makes executable structure explicit (closures, observers, wait models, structured control flow, object composition). XIR exists because execution-model shape must be reviewable -- it is projectable into a C++ object/behavior model as a methodology tool. See [xir-design.md](xir-design.md).
+- **MIR**: Control-flow/plumbing IR. Lowers execution structure to basic blocks, terminators, Place/Operand. See [mir-design.md](mir-design.md).
 - **LLVM IR**: Per-specialization LLVM module. Runtime library calls for simulation primitives.
 
-HIR and MIR are internal to specialization compilation. They contain no instance paths, no design-global slot IDs, and no design-global allocation. See [hir-design.md](hir-design.md) and [mir-design.md](mir-design.md).
+All IRs are per-compilation-unit. They contain no instance paths, no design-global slot IDs, and no design-global allocation. Lowering after HIR proceeds per-unit without consulting design-global state.
 
-### Design Realization
+### Artifact Composition
 
-Constructs the runtime object graph from compiled specializations + elaborated design topology:
+After per-unit compilation, a compile-time design-wide pass packages the per-unit artifacts into a deliverable. This is artifact composition, not semantic elaboration. It combines compiled specialization artifacts with elaborated design topology metadata into the form the constructor needs.
+
+Artifact composition does not recompile specialization code, re-run LLVM optimization, or return to semantic elaboration.
+
+### Constructor / Realization
+
+At runtime (or at load time for AOT), the constructor builds the object graph from compiled specialization artifacts and the elaborated design topology:
 
 - Instance construction (per-instance storage from body-shaped SpecLayout)
 - Connectivity wiring (port bindings, connection descriptors)
 - Per-instance constant blocks (value-only parameters)
+- Generate-driven structure selection (which artifacts to install per instance)
 - Debug tables (instance paths for `%m`)
 
-Realization does not recompile specialization code. See [compilation-model.md](compilation-model.md).
+This is object construction, not compilation. See [compilation-model.md](compilation-model.md).
 
 ### Execution
 
@@ -67,12 +83,13 @@ Event-driven simulation engine. Processes run as behavior on instance objects wi
 ```
 include/lyra/
   common/        # shared types, utilities, diagnostics
-  hir/           # language semantic IR (specialization-scoped)
-  mir/           # executable semantic IR (specialization-scoped)
+  hir/           # language semantic IR (per-compilation-unit)
+  xir/           # execution-model IR (per-compilation-unit)
+  mir/           # control-flow IR (per-compilation-unit)
   llvm_backend/  # MIR -> LLVM IR (per-specialization)
-  realization/   # design realization (bindings, metadata, main emission)
+  realization/   # artifact composition and constructor data
   runtime/       # simulation runtime (scheduler, signals)
-  lowering/      # AST->HIR, HIR->MIR lowering
+  lowering/      # AST->HIR, HIR->XIR, XIR->MIR lowering
   semantic/      # semantic utilities
 ```
 
@@ -84,12 +101,15 @@ Headers in `include/lyra/`, implementations in `src/lyra/`.
 
 ## Data Flow
 
-1. Source files -> `SlangFrontend` -> AST
-2. AST -> `AstToHir` -> HIR (owns all data, slang can be released)
-3. HIR -> `HirToMir` -> MIR (executable semantics)
-4. MIR -> `MirToLlvm` -> LLVM IR -> executable (per specialization)
+```
+1. Source files -> SlangFrontend -> AST  (whole-design frontend output)
+2. AST -> Specialization Grouping -> per-unit HIR bodies  (compiler unit boundary)
+3. Per unit: HIR -> XIR -> MIR -> LLVM IR  (independent per compilation unit)
+4. All units: Artifact Composition -> deliverable  (compile-time, design-wide)
+5. Constructor -> runtime object graph  (runtime, per-instance)
+```
 
-Each stage is independent and testable. The HIR stage creates a clean boundary where slang resources can be released.
+Step 2 is the key boundary: the compiler leaves the frontend's whole-design world and enters its own per-compilation-unit world. Steps 3 onward do not return to design-global semantic elaboration.
 
 ## Slang Data Ownership
 

--- a/docs/compilation-model.md
+++ b/docs/compilation-model.md
@@ -8,21 +8,27 @@ For architectural motivation, see [architecture-principles.md](architecture-prin
 
 ## Pipeline Phases
 
-Four distinct phases with clear boundaries:
+Five distinct phases with clear boundaries:
 
-1. **Elaboration** -- discover the design: module definitions, instances, parameters, hierarchy, connectivity
-2. **Specialization Compilation** -- compile reusable behavior units, one per `ModuleSpecId`, parallelizable
-3. **Design Realization** -- materialize the executable runtime image from compiled specializations + elaborated design topology
-4. **Execution** -- run the simulation
+1. **Elaboration** -- the frontend discovers the design: module definitions, instances, parameters, hierarchy, connectivity. This is frontend output, not the compiler's own compilation world.
+2. **Per-Unit Compilation** -- compile one compilation unit per `ModuleSpecId`, parallelizable. Each unit passes through HIR (semantic), XIR (execution model), MIR (control flow), and LLVM IR (backend). Per-unit lowering does not consult design-global state.
+3. **Artifact Composition** -- a compile-time design-wide pass that packages per-unit artifacts with elaborated design topology metadata into the form the constructor needs. This is packaging, not semantic elaboration.
+4. **Constructor / Realization** -- at runtime (or load time for AOT), the constructor builds the object graph: instance construction, connectivity wiring, generate-driven structure selection. This is where instances become concrete objects.
+5. **Execution** -- run the simulation.
 
 Each phase answers a different question:
 
-- Elaboration: _What is the design?_
-- Specialization Compilation: _How does each reusable behavior class execute?_
-- Design Realization: _How does this particular design become a runnable image?_
+- Elaboration: _What is the design?_ (frontend output)
+- Per-Unit Compilation: _How does each reusable behavior class execute?_ (compiler's per-unit world)
+- Artifact Composition: _How do the per-unit artifacts combine with topology?_ (compile-time packaging)
+- Constructor / Realization: _How does this particular design become a running object graph?_ (runtime construction)
 - Execution: _Run it._
 
-**Compile time** covers elaboration and specialization compilation. These produce design-independent, cacheable artifacts. **Design realization** is a distinct phase that takes compiled specializations and the elaborated design topology and materializes the executable runtime image -- instance placement, connectivity binding, container sizing, metadata construction. It is not compile time (it requires the full design graph) and not execution (the simulation has not started). **Execution** is the simulation itself.
+**Compile time** covers elaboration, per-unit compilation, and artifact composition. Per-unit compilation produces design-independent, cacheable artifacts. Artifact composition packages those artifacts with topology metadata but does not recompile or re-derive semantics. **Constructor / realization** builds the runtime object graph at runtime (or load time). It is not compile time (it requires the full design graph and creates per-instance state) and not execution (the simulation has not started). **Execution** is the simulation itself.
+
+### Compilation Unit Boundary
+
+The transition from the frontend's whole-design world to the compiler's per-unit world happens at the AST-to-HIR boundary. The frontend may elaborate thousands of instances, but the compiler groups them into a much smaller number of specializations. Each specialization becomes one compilation unit that proceeds independently through the IR pipeline.
 
 ## Compilation Unit: Module Specialization
 
@@ -37,7 +43,7 @@ ModuleSpecId = (ModuleDefId, BehaviorFingerprint)
 | `ModuleDefId`         | Source-level module definition identity                      |
 | `BehaviorFingerprint` | Hash of all inputs that affect the compiled artifact's shape |
 
-A specialization produces a self-contained, cacheable artifact: `CompiledSpecialization`.
+A specialization is the compiler's real compilation unit. It produces a self-contained, cacheable artifact: `CompiledSpecialization`. `ModuleSpecId` names this unit. It is not a lookup handle for recovering design-global state -- it identifies an independently compiled artifact.
 
 ### The Natural Correspondence
 
@@ -294,7 +300,7 @@ Parent-side connection source classification is limited to exactly three compile
 
 | Component           | Description                                                               |
 | ------------------- | ------------------------------------------------------------------------- |
-| Specialization IR   | HIR and MIR for all artifacts, pointer-free, ID-based                     |
+| Specialization IR   | HIR, XIR, and MIR for all artifacts, pointer-free, ID-based               |
 | SpecLayout          | Slot list with sizes, alignments, offsets relative to `this_base`         |
 | Code artifacts      | LLVM IR (or machine code) for all process/kernel artifacts in the library |
 | InstanceConstSchema | Types and positions of value-only parameters in the const block           |
@@ -375,9 +381,26 @@ this_base + specialization_constant_offset
 
 Where `this_base` is an instance-specific runtime pointer and offsets are constants from `SpecLayout`.
 
-## Design Realization
+## Artifact Composition
 
-Realization takes compiled specializations + the elaborated design graph and materializes a runnable design image without recompiling specialization code.
+After per-unit compilation, a compile-time design-wide pass packages the per-unit artifacts with elaborated design topology metadata into the form the constructor needs.
+
+Artifact composition is packaging, not semantic elaboration. It must NOT:
+
+- Recompile specialization code or re-run LLVM optimization
+- Re-derive semantic facts from the elaborated design
+- Merge or flatten per-unit IRs
+- Return to design-global lowering
+
+Artifact composition may:
+
+- Combine per-unit artifacts into a deliverable
+- Attach topology metadata (instance graph, connectivity graph, parameter assignments)
+- Produce constructor input data structures
+
+## Constructor / Realization
+
+At runtime (or load time for AOT), the constructor builds the object graph from compiled specialization artifacts and the elaborated design topology.
 
 ### Inputs
 
@@ -397,19 +420,20 @@ Realization takes compiled specializations + the elaborated design graph and mat
 
 ### Realization constraints
 
-Realization must NOT:
+The constructor must NOT:
 
 - Re-run LLVM optimization or regenerate kernel bodies
 - Depend on full design flattening to create new IR
 - Modify specialization code
 - Generate per-instance LLVM functions, globals, or types
 
-Realization may:
+The constructor may:
 
 - Sort and build index tables
 - Compute instance memory placements
 - Create runtime lookup structures
 - Build per-instance descriptors that reference shared compiled code
+- Execute generate-driven structure selection (which artifacts to install per instance)
 
 ### Construction Instruction Model
 

--- a/docs/hir-design.md
+++ b/docs/hir-design.md
@@ -5,48 +5,73 @@ HIR (High-level IR) is the semantic model of SystemVerilog.
 ## Pipeline Position
 
 ```
-SystemVerilog -> Slang AST -> HIR -> MIR -> LLVM IR
+                        per compilation unit
+                   +---------------------------------+
+frontend output -> | HIR -> XIR -> MIR -> LLVM IR    | -> per-unit artifact
+                   +---------------------------------+
 ```
 
-The frontend (slang) is used only during lowering, then discarded. HIR freezes _what the language means_, not _how it runs_.
+The frontend (slang) elaborates the full design, but the compiler does not adopt that whole-design world. At the AST-to-HIR boundary, the compiler establishes its own per-specialization compilation units. HIR freezes _what the language means_, not _how it executes_.
 
 ## Scope
 
-HIR is **specialization-scoped**. It represents a single module specialization, not an elaborated design. No instance paths, no design-global slot IDs, no design-global allocation. See [compilation-model.md](compilation-model.md).
+HIR is **per-compilation-unit**. The AST-to-HIR boundary is where the compiler breaks the frontend's whole-design output into per-specialization compilation units.
+
+### Structure
+
+HIR consists of two parts:
+
+- **Design shell**: A thin container for unavoidable design-level facts (package/global state, type arenas, symbol tables). This is frozen shared read-only context, not a mutable whole-design compilation environment.
+- **Per-specialization bodies**: The real compiler-owned compilation units. Each body contains the processes, functions, tasks, and local declarations for one specialization. Each body owns its own arena and constant pool.
+
+The design shell exists because some facts (package functions, global types) are shared across compilation units. It does not drive lowering. All substantive compilation work operates on per-specialization bodies.
 
 ### AST Boundary
 
-AST -> HIR lowering is the **error boundary** for user-facing diagnostics:
+AST -> HIR lowering is both the **error boundary** for user-facing diagnostics and the **compilation unit boundary** where the compiler's per-specialization world begins:
 
 | Responsibility                                     | Where                            |
 | -------------------------------------------------- | -------------------------------- |
 | User errors (unsupported features, invalid code)   | AST -> HIR only                  |
+| Specialization grouping and unit establishment     | AST -> HIR boundary              |
 | Source locations (slang ranges -> SourceSpan)      | Converted at boundary            |
 | Data ownership (slang string_view -> owned string) | Copied at boundary               |
 | Compiler bugs after HIR                            | Internal errors, not diagnostics |
 
-After HIR construction, slang resources may be released. Any error in subsequent stages (HIR -> MIR, codegen) indicates a compiler bug, not a user error.
+After HIR construction, slang resources may be released. Any error in subsequent stages (HIR -> XIR, XIR -> MIR, codegen) indicates a compiler bug, not a user error.
 
 See [error-handling.md](error-handling.md) for error type details.
 
 Guiding question when designing HIR:
 
-> Is this describing language semantics, or execution strategy?
+> Is this describing language semantics, or execution structure?
 
 ## Core Principles
 
 These are hard rules, not guidelines:
 
-| Rule                                | Rationale                                          |
-| ----------------------------------- | -------------------------------------------------- |
-| No frontend pointers                | HIR owns all data; slang lifetime must not leak    |
-| No temporaries                      | Temporaries are execution artifacts                |
-| No SSA or basic blocks              | These model execution, not meaning                 |
-| No mode flags for semantic variants | Use distinct node types, not flags on shared nodes |
-| Syntactic differences may disappear | `begin/end` vs `{}` are the same in HIR            |
-| Semantic differences must not       | Blocking vs non-blocking must remain distinct      |
+| Rule                                | Rationale                                                       |
+| ----------------------------------- | --------------------------------------------------------------- |
+| No frontend pointers                | HIR owns all data; slang lifetime must not leak                 |
+| No temporaries                      | Temporaries are execution artifacts                             |
+| No SSA or basic blocks              | These model execution, not meaning                              |
+| No mode flags for semantic variants | Use distinct node types, not flags on shared nodes              |
+| Syntactic differences may disappear | `begin/end` vs `{}` are the same in HIR                         |
+| Semantic differences must not       | Blocking vs non-blocking must remain distinct                   |
+| Per-unit bodies are self-contained  | Each body is independently lowerable with frozen shared context |
 
 HIR correctness is defined by invariants (typing, binding, scoping). If those invariants hold, HIR correctly represents the program's meaning.
+
+### Execution-Relevant Semantic Shaping
+
+HIR is primarily semantic, but some execution-relevant shaping is appropriate where it preserves language-level meaning that downstream layers need:
+
+- **Capture classification**: Deferred assertion actions carry explicit value/ref/const-ref capture semantics. This is language meaning (LRM 16.4 defines capture timing), not execution strategy.
+- **System subroutine classification**: Pure/Effect/State roles are language-level semantic facts.
+- **Assignment target canonicalization**: Root + projection paths encode lvalue semantics, not execution layout.
+- **Process kind preservation**: Distinct `always_comb/ff/latch` kinds carry semantic constraints (sensitivity rules, synthesis semantics).
+
+These are not execution structure -- they are semantic facts that XIR and MIR need. The execution-model structure built from these facts belongs in XIR. See [xir-design.md](xir-design.md).
 
 ## Core IDs and Arenas
 
@@ -58,6 +83,8 @@ Three orthogonal axes identify every construct:
 | **Symbol** | Who it is         | `SymbolId` via `SymbolTable` |
 | **Scope**  | Where it is valid | `ScopeId` via `Scope` tree   |
 
+TypeArena and SymbolTable are shared across compilation units as frozen read-only context. They are part of the design shell, not per-unit mutable state. Per-unit bodies have their own arenas for expressions, statements, and constants.
+
 ### TypeId / TypeArena
 
 Every language type has a corresponding HIR type. Types are interned for structural sharing and pointer equality comparison. These are _language types_, not LLVM or runtime types.
@@ -68,11 +95,11 @@ A symbol is a named language entity: variable, net, parameter, function, event. 
 
 ### ScopeId / Scope
 
-Represents semantic visibility. Module, function, and block each introduce a new scope. ScopeId and SymbolId are independent - a symbol exists in a scope, but the ID spaces don't overlap.
+Represents semantic visibility. Module, function, and block each introduce a new scope. ScopeId and SymbolId are independent -- a symbol exists in a scope, but the ID spaces don't overlap.
 
 ### ConstId / ConstantPool
 
-Constants are frontend-known, deduplicable entities - first-class citizens like TypeId. The ConstantPool interns constants for deduplication and consistent identity.
+Constants are frontend-known, deduplicable entities -- first-class citizens like TypeId. The ConstantPool interns constants for deduplication and consistent identity. Each per-specialization body owns its own constant pool.
 
 Supported payload kinds:
 
@@ -82,7 +109,7 @@ Supported payload kinds:
 - Struct (vector of ConstIds)
 - Array (vector of ConstIds)
 
-Constants only provide data; types determine layout. A constant's identity (ConstId) is fixed in HIR; MIR and backends only reference or materialize it.
+Constants only provide data; types determine layout. A constant's identity (ConstId) is fixed in HIR; XIR, MIR, and backends only reference or materialize it.
 
 ## Type System
 
@@ -95,7 +122,7 @@ HIR must represent all SystemVerilog type semantics:
 | Aggregate | struct, union (with packed qualifier)               |
 | Other     | string, event, real, time                           |
 
-**Qualifiers** (signed, unsigned, packed, const) are canonical type attributes, part of the TypeArena interning key. This is distinct from "mode flags" - qualifiers don't represent semantic variants; they define distinct types.
+**Qualifiers** (signed, unsigned, packed, const) are canonical type attributes, part of the TypeArena interning key. This is distinct from "mode flags" -- qualifiers don't represent semantic variants; they define distinct types.
 
 ## Constant vs Expression
 
@@ -108,7 +135,7 @@ This distinction is fundamental:
 
 Rule: _A value is a Constant; any construction process is an Expression._
 
-Struct initialization and array initialization are expressions, not constants - even if all elements are constant. The construction process is semantic information.
+Struct initialization and array initialization are expressions, not constants -- even if all elements are constant. The construction process is semantic information.
 
 ## Statement Model
 
@@ -136,7 +163,7 @@ HIR represents all process forms with a single `Process` construct and a `Proces
 | `ProcessKind::kAlwaysLatch` | `always_latch` | Latch inference                     |
 | `ProcessKind::kFinal`       | `final`        | Runs once at simulation end         |
 
-HIR preserves distinct kinds because `always_comb/ff/latch` have semantic constraints beyond repetition (sensitivity rules, synthesis semantics). The distinction matters for validation and backend lowering.
+HIR preserves distinct kinds because `always_comb/ff/latch` have semantic constraints beyond repetition (sensitivity rules, synthesis semantics). The distinction matters for validation and downstream lowering.
 
 ## System Subroutine Classification
 
@@ -148,9 +175,9 @@ HIR must classify system subroutines into exactly three semantic roles:
 | Effect | Immediate observable effect      | `$display`, `$write`, `$monitor` |
 | State  | Terminates or suspends process   | `$finish`, `$stop`, `$fatal`     |
 
-This classification is fixed and does not grow with the number of system APIs. MIR mirrors these roles as distinct statement categories.
+This classification is fixed and does not grow with the number of system APIs. XIR and MIR mirror these roles as distinct categories.
 
-**Unknown syscalls**: Unrecognized system subroutines are rejected at AST->HIR with a user-facing diagnostic. This is not a runtime error - it's a compile-time "unsupported" error.
+**Unknown syscalls**: Unrecognized system subroutines are rejected at AST->HIR with a user-facing diagnostic. This is not a runtime error -- it's a compile-time "unsupported" error.
 
 Rule: Classify by _what the subroutine does semantically_, not by its name or argument count.
 
@@ -158,27 +185,30 @@ Rule: Classify by _what the subroutine does semantically_, not by its name or ar
 
 All timing constructs unify as "wait for something":
 
-- **Delay**: `wait(duration_expr)` - pause for a time value
-- **Event wait**: `wait(trigger_spec)` - pause until condition occurs
+- **Delay**: `wait(duration_expr)` -- pause for a time value
+- **Event wait**: `wait(trigger_spec)` -- pause until condition occurs
 
 Trigger specifications include: posedge, negedge, level, named event, OR-list.
 
 HIR expresses: _"Execution pauses here until this semantic condition occurs."_
 
-HIR does **not** express scheduling, queues, or execution order. Those are MIR concerns.
+HIR does **not** express execution-model structure for waits. The execution model (late-bound subscriptions, rebinding plans, observation narrowing) belongs in XIR. See [xir-design.md](xir-design.md).
 
 ## What Must NOT Appear in HIR
 
-| Excluded           | Belongs in    |
-| ------------------ | ------------- |
-| Temporaries        | MIR           |
-| Place              | MIR           |
-| SSA / basic blocks | MIR           |
-| Runtime values     | Interpreter   |
-| LLVM intrinsics    | LLVM lowering |
-| Execution flags    | MIR           |
+| Excluded                     | Belongs in                                  |
+| ---------------------------- | ------------------------------------------- |
+| Temporaries                  | MIR                                         |
+| Place / Operand              | MIR                                         |
+| SSA / basic blocks           | MIR                                         |
+| Execution-model structure    | XIR                                         |
+| Closure dispatch / thunk ABI | XIR or MIR                                  |
+| Runtime values               | Runtime                                     |
+| LLVM intrinsics              | LLVM lowering                               |
+| Execution flags              | MIR                                         |
+| Design-wide lowering state   | Never -- per-unit bodies are self-contained |
 
-If you find yourself adding any of these to HIR, step back - you're modeling execution, not semantics.
+If you find yourself adding execution-model structure to HIR, step back -- you should be modeling it in XIR. If you're adding CFG plumbing, that belongs in MIR. If you're consulting design-global state during per-unit body lowering, the compilation-unit boundary is violated.
 
 ## Source Information
 
@@ -190,6 +220,6 @@ HIR maintains source locations for diagnostics:
 
 ## Summary
 
-**HIR is SystemVerilog with syntax sugar stripped away, leaving only semantic facts.**
+**HIR is SystemVerilog with syntax sugar stripped away, leaving only semantic facts.** It is the layer where the compiler establishes its per-specialization compilation units from the frontend's whole-design output. Each per-unit body is independently lowerable. The design shell provides frozen shared context but does not drive lowering.
 
-If you're thinking about "how this executes" while designing HIR, you've crossed the boundary into MIR territory.
+If you're thinking about "how this executes" while designing HIR, you've crossed the boundary into XIR territory. If you're thinking about CFG plumbing, you've crossed into MIR territory.

--- a/docs/llvm-backend.md
+++ b/docs/llvm-backend.md
@@ -7,12 +7,12 @@ Design decisions for MIR -> LLVM IR lowering.
 ## Pipeline Position
 
 ```
-HIR -> MIR -> LLVM IR -> executable
-              |
-              +-> Runtime library (Lyra*)
+HIR -> XIR -> MIR -> LLVM IR -> executable
+                      |
+                      +-> Runtime library (Lyra*)
 ```
 
-MIR fixes all execution semantics. The LLVM backend only translates--it does not interpret SystemVerilog rules.
+XIR fixes execution-model structure. MIR lowers it to control-flow plumbing. The LLVM backend only translates MIR -- it does not interpret SystemVerilog rules or execution-model semantics.
 
 ## Scope
 

--- a/docs/mir-design.md
+++ b/docs/mir-design.md
@@ -1,61 +1,62 @@
 # MIR Design
 
-MIR (Mid-level IR) fixes all process-local SystemVerilog execution semantics.
+MIR (Mid-level IR) lowers execution structure to control-flow plumbing: basic blocks, terminators, Place/Operand separation, and effect sequencing.
 
 ## Pipeline Position
 
 ```
-SystemVerilog -> Slang AST -> HIR -> MIR -> LLVM IR
+                        per compilation unit
+                   +---------------------------------+
+frontend output -> | HIR -> XIR -> MIR -> LLVM IR    | -> per-unit artifact
+                   +---------------------------------+
 ```
 
-HIR freezes _what the language means_.
-MIR freezes _how the language must be executed_, while remaining platform-independent.
+XIR freezes _what the execution model is_.
+MIR freezes _how that model maps to control flow and data flow_, while remaining platform-independent.
 
 ## Scope
 
-MIR is **specialization-scoped**. All Places reference specialization-local storage. No instance paths, no design-global slot IDs, no design-global allocation. See [compilation-model.md](compilation-model.md).
+MIR is **per-compilation-unit**. Each MIR artifact represents one module specialization. All Places reference specialization-local storage. No instance paths, no design-global slot IDs, no design-global allocation. See [compilation-model.md](compilation-model.md).
+
+MIR lowering proceeds per-unit without consulting design-global state. Frozen shared context (types, symbols) is read-only input, not a mutable design-wide environment.
 
 Guiding question when designing MIR:
 
-> If a backend still needs to "understand SystemVerilog rules" to run correctly, then MIR has failed to fully fix the semantics.
+> Does the backend still need to understand execution-model concepts to run correctly?
 
-MIR is correct when execution behavior is no longer inferable, only executable.
+If yes, those concepts should already be formalized in XIR. MIR's job is to lower XIR's execution structure into explicit control flow, not to invent new execution concepts. MIR is correct when all control flow and data flow are explicit and no execution-model interpretation remains.
 
-"Executable" means semantics are fully determined, not that constructs are expanded into implementation patterns. Language-level constructs with specific control-flow or diagnostic semantics should remain first-class MIR concepts. Implementation strategies - boolean materialization, temporary allocation, branch structuring - belong in backend lowering, not HIR-to-MIR.
+"Explicit" means control flow is fully determined, not that constructs are expanded into implementation patterns. Language-level constructs with specific control-flow or diagnostic semantics should remain first-class MIR concepts. Implementation strategies -- boolean materialization, temporary allocation, branch structuring -- belong in backend lowering, not XIR-to-MIR.
 
 ## Core Principles
 
 These are hard rules, not guidelines:
 
-| Rule                                    | Rationale                                               |
-| --------------------------------------- | ------------------------------------------------------- |
-| Place and Operand are strictly separate | Computation uses Operand; writes occur through Place    |
-| Every basic block has one terminator    | Control flow is explicit and complete                   |
-| Suspension operations are terminators   | Delay/Wait yield control; they cannot be statements     |
-| System subroutines classified by role   | Three semantic categories, not per-API statements       |
-| TypeId shared with type arena           | MIR annotates Operands with types; does not create them |
-| No frontend object dependencies         | No AST pointers; no slang lifetime leakage              |
-| No LLVM/ABI details                     | Platform-independent; backends handle lowering          |
-| No scheduling or execution policy       | Runtime strategy is backend responsibility              |
-| Semantic constructs are first-class     | Language control-flow semantics become MIR primitives   |
+| Rule                                    | Rationale                                                               |
+| --------------------------------------- | ----------------------------------------------------------------------- |
+| Place and Operand are strictly separate | Computation uses Operand; writes occur through Place                    |
+| Every basic block has one terminator    | Control flow is explicit and complete                                   |
+| Suspension operations are terminators   | Delay/Wait yield control; they cannot be statements                     |
+| System subroutines classified by role   | Three semantic categories, not per-API statements                       |
+| TypeId shared with type arena           | MIR annotates Operands with types; does not create them                 |
+| No frontend object dependencies         | No AST pointers; no slang lifetime leakage                              |
+| No LLVM/ABI details                     | Platform-independent; backends handle lowering                          |
+| No scheduling or execution policy       | Runtime strategy is backend responsibility                              |
+| Semantic constructs are first-class     | Language control-flow semantics become MIR primitives                   |
+| No execution-model invention            | Execution concepts must be formalized in XIR before MIR lowers them     |
+| Per-unit artifact                       | Each MIR unit is independently producible; no design-wide MIR container |
 
 ## Structure
 
+A MIR compilation unit contains:
+
 ```
-Design
-  -> DesignElement* (Module | Package)
-       -> Process* / Function*
-            -> BasicBlock*
-                 -> Statement*
-                 -> Terminator (exactly one)
+CompilationUnit (one per specialization)
+  -> Process* / Function*
+       -> BasicBlock*
+            -> Statement*
+            -> Terminator (exactly one)
 ```
-
-### DesignElement
-
-A variant over Module and Package. Currently supports:
-
-- `Module` - contains processes and functions
-- `Package` - placeholder for package contents
 
 ### Process
 
@@ -63,8 +64,8 @@ A coroutine unit that may suspend and resume. Composed of basic blocks with an e
 
 Two kinds (HIR's 6 process kinds normalize to these 2 during lowering):
 
-- `kOnce` - `initial`, `final`
-- `kLooping` - `always`, `always_comb`, `always_ff`, `always_latch`
+- `kOnce` -- `initial`, `final`
+- `kLooping` -- `always`, `always_comb`, `always_ff`, `always_latch`
 
 Looping processes are **not** expanded to `while(true)` in MIR. Repetition is expressed via process semantics and the `Repeat` terminator.
 
@@ -117,7 +118,7 @@ A readable operand. Three kinds only:
 - **Use**: read from a Place (implicit load)
 - **Poison**: invalid / unreachable value (trap policy: any use is an internal error)
 
-Place-read is implicit - there is no explicit Load statement. Reading a Place produces an Operand directly. This is the **implicit read model**: `Operand::Use(place)` means "the current value stored at place."
+Place-read is implicit -- there is no explicit Load statement. Reading a Place produces an Operand directly. This is the **implicit read model**: `Operand::Use(place)` means "the current value stored at place."
 
 All computation results are assigned to Places (often temporaries). To use a result, you read from that Place. This avoids the need for value numbering or SSA.
 
@@ -192,16 +193,6 @@ System functions that produce values use Rvalue info structs. Classification:
 - Additional invariants must be enforced beyond operand count
 - Special resource/lifetime handling is involved
 
-**Example: `$fopen` uses `FopenRvalueInfo`**
-
-`$fopen` requires dedicated representation because:
-
-1. Arguments are `TypedOperand` (not plain `Operand`) for packed-to-string coercion
-2. Mode is optional with semantic meaning (MCD vs FD mode)
-3. Call sites use `info.mode.has_value()` instead of magic `operands.size() == 2`
-
-This makes MIR self-documenting and removes magic-number decoding from backends.
-
 ## Terminator Categories
 
 Terminators end a basic block and determine the next control state.
@@ -247,18 +238,21 @@ Not expanded into a loop at MIR level. Backend decides the implementation strate
 
 ## What MIR Does NOT Contain
 
-| Excluded                   | Belongs in     |
-| -------------------------- | -------------- |
-| LLVM instructions          | LLVM lowering  |
-| ABI details                | Backend        |
-| Scheduling/queues          | Runtime        |
-| Pointer arithmetic         | Backend        |
-| Frontend pointers          | Never          |
-| SSA/phi nodes              | LLVM if needed |
-| Elaborated instances       | Runtime        |
-| Synthesized implementation | Backend        |
+| Excluded                                      | Belongs in               |
+| --------------------------------------------- | ------------------------ |
+| LLVM instructions                             | LLVM lowering            |
+| ABI details                                   | Backend                  |
+| Scheduling/queues                             | Runtime                  |
+| Pointer arithmetic                            | Backend                  |
+| Frontend pointers                             | Never                    |
+| SSA/phi nodes                                 | LLVM if needed           |
+| Elaborated instances                          | Runtime                  |
+| Synthesized implementation                    | Backend                  |
+| Structured control flow                       | XIR                      |
+| Execution-model objects (closures, observers) | XIR                      |
+| Design-wide container                         | Never -- MIR is per-unit |
 
-"Synthesized implementation" means expanding a semantic construct into a pattern of primitives. If a language feature has specific evaluation or diagnostic rules, those rules should be expressed as MIR metadata or a dedicated construct - not as a procedural recipe of boolean operations, temporaries, and branches.
+"Synthesized implementation" means expanding a semantic construct into a pattern of primitives. If a language feature has specific evaluation or diagnostic rules, those rules should be expressed as MIR metadata or a dedicated construct -- not as a procedural recipe of boolean operations, temporaries, and branches.
 
 ## Invariants
 
@@ -269,6 +263,7 @@ These must hold for well-formed MIR:
 - Every basic block has exactly one terminator
 - All control flow is explicit; no implicit fallthrough
 - After lowering, no unsealed blocks remain
+- Each MIR unit is per-compilation-unit; no design-wide MIR container
 
 **Operand Discipline:**
 
@@ -280,7 +275,7 @@ These must hold for well-formed MIR:
 **Index Projections:**
 
 - IndexProjection stores 0-based storage offset, not declaration-space index
-- HIR->MIR lowering normalizes array indices (e.g., `arr[2]` for `int arr[2:5]` becomes offset 0)
+- Lowering normalizes array indices (e.g., `arr[2]` for `int arr[2:5]` becomes offset 0)
 - IndexValidity retains logical bounds for diagnostic purposes
 
 **System Subroutines:**
@@ -297,18 +292,18 @@ These must hold for well-formed MIR:
 **Abstraction Level:**
 
 - Language constructs with specific semantics remain first-class MIR concepts
-- Implementation strategy is backend responsibility, not HIR-to-MIR lowering
-- MIR expresses intent declaratively; backends choose how to implement
+- Implementation strategy is backend responsibility, not lowering
+- Execution-model concepts should already be formalized in XIR; MIR lowers them
 
 **Error Policy:**
 
-- Lowering assumes HIR invariants are satisfied
+- Lowering assumes input invariants are satisfied
 - Violations during lowering produce internal errors, not user diagnostics
 - MIR does not emit user-facing error messages
 
 ## Summary
 
-**MIR structure:** Design -> DesignElement (Module|Package) -> Process/Function -> BasicBlock -> Statement + Terminator
+**MIR structure:** CompilationUnit -> Process/Function -> BasicBlock -> Statement + Terminator
 
 **Operand model:** Place (writable location) and Operand (readable: Const/Use/Poison)
 
@@ -316,7 +311,9 @@ These must hold for well-formed MIR:
 
 **Core fixed semantics:**
 
-- Statement writes RightHandSide to Place (no explicit Load - Use is implicit)
+- Statement writes RightHandSide to Place (no explicit Load -- Use is implicit)
 - Delay and Wait as suspension terminators
 - System subroutines as Pure, Effect, or State
 - Looping behavior as process repetition
+- Execution-model structure formalized in XIR, lowered here to control flow
+- Each MIR unit is a concrete per-compilation-unit artifact

--- a/docs/natural-model.md
+++ b/docs/natural-model.md
@@ -8,30 +8,32 @@ For how this model drives design decisions, see [architecture-principles.md](arc
 
 ## Core Definitions
 
-A module is a type. An instance is an object of that type. Signals are its members. Processes are its behavior.
+A module is a type. An instance is an object of that type. Signals are its members. Processes are its behavior. A specialization is the compiler's real compilation unit.
 
 | Term              | Definition                                                            |
 | ----------------- | --------------------------------------------------------------------- |
 | Module definition | Type definition. Describes shape, members, and behavior.              |
-| Specialization    | Compiled type. One per distinct compiled artifact shape.              |
+| Specialization    | Compiled type and compilation unit. One per distinct artifact shape.  |
 | Instance          | Object. Owns its state. Addressed via object pointer + local offset.  |
 | Signal / variable | Member of an instance. Object-local storage.                          |
 | Process           | Behavior attached to an instance. Runs against that instance's state. |
 | Constructor       | Builds instances from compiled specializations + design topology.     |
 | Runtime execution | Processes running on their instances' state.                          |
 
+The frontend may elaborate thousands of instances, but the compiler works per-specialization, not per-instance. Specialization is not merely a grouping concept -- it is the compiler's real unit of compilation, producing a concrete independently-compiled artifact.
+
 ## Ownership Phases
 
 Three distinct ownership phases. Each produces facts for the next.
 
-**Compile-time facts** (per-specialization, body-shaped):
+**Compile-time facts** (per-compilation-unit, body-shaped):
 
 - Packed layout, arithmetic representation, compiled code shape
 - Static member offsets (SpecLayout)
 - Process and kernel compiled code
 - Body-local slot descriptors, storage specs
 
-These facts describe the type. They are stable across all instances of the same specialization.
+These facts belong to the compilation unit. They are the concrete output of per-unit compilation. They are stable across all instances of the same specialization.
 
 **Construction-time facts** (per-instance, resolved from design topology):
 
@@ -70,11 +72,11 @@ The rule: design-global systems coordinate instances but do not define what an i
 
 Member access within the natural model falls into two categories with fundamentally different resolution timing.
 
-**Self-local access** is a process reading or writing a member of its own instance. This is `this->member` -- object pointer + local offset. The offset is a compile-time constant from SpecLayout. Self-local access is fully resolved during specialization compilation.
+**Self-local access** is a process reading or writing a member of its own instance. This is `this->member` -- object pointer + local offset. The offset is a compile-time constant from SpecLayout. Self-local access is fully resolved within the compilation unit because it stays within the unit's own state.
 
 **Non-local access** is a process reading or writing a member of a different instance (parent, child, ancestor, or any other instance in the hierarchy). This includes hierarchical references (`child.signal`, `ancestor.value`) and port connection sources/targets.
 
-Non-local access cannot be resolved during specialization compilation because the target instance does not yet exist. The target is created during construction, and its identity (which object, at what address) is a construction-time fact. Specialization compilation must represent non-local access as an **externally-bound handle** -- a typed reference that the body code can use, but that only acquires a concrete target when construction binds it.
+Non-local access cannot be resolved during per-unit compilation because it crosses the compilation-unit boundary: the target belongs to a different instance, which is created during construction. The target's identity (which object, at what address) is a construction-time fact. Per-unit compilation must represent non-local access as an **externally-bound handle** -- a typed reference that the body code can use, but that only acquires a concrete target when construction binds it.
 
 The mental model is closure capture: the body code captures a typed external reference slot. The constructor fills it with a concrete binding when the instance and its neighbors are materialized. The body code never names the target directly.
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -41,9 +41,9 @@ Compilation unit is the module specialization (`ModuleSpecId`), not the elaborat
 
 Compile-time elaboration via slang: hierarchy resolution, legality checks, name resolution, type checking. Elaboration determines which specializations are needed and the instance graph.
 
-### HIR/MIR as Specialization-Scoped IR
+### HIR/XIR/MIR as Specialization-Scoped IR
 
-HIR/MIR are internal to specialization compilation. They contain no instance paths, no design-global slot IDs. See [architecture-principles.md](architecture-principles.md).
+HIR, XIR, and MIR are internal to specialization compilation. They contain no instance paths, no design-global slot IDs. See [architecture-principles.md](architecture-principles.md).
 
 ### Event-Driven Simulation (Default)
 

--- a/docs/pipeline-contract.md
+++ b/docs/pipeline-contract.md
@@ -2,47 +2,83 @@
 
 > Before editing, see [documentation-guidelines.md](documentation-guidelines.md). Architecture docs describe the target, not history. No "current state," migration plans, or queue references.
 
-This document defines the behavioral boundaries between pipeline stages. It is not an architecture doc (which describes structure) - it enforces rules and guardrails.
+This document defines the behavioral boundaries between pipeline stages. It is not an architecture doc (which describes structure) -- it enforces rules and guardrails.
 
 ## Correctness Authority
 
-**MIR is the semantic truth.**
+Four layers of truth, each freezing a different concern:
 
-If MIR is correct, the language semantics are correct. LLVM IR and other backends are translators, not interpreters of SystemVerilog.
+| Layer   | What it freezes                                    | Authority scope       |
+| ------- | -------------------------------------------------- | --------------------- |
+| HIR     | What the language means (semantic facts)           | Source-level meaning  |
+| XIR     | What the execution model is (executable structure) | Execution-model truth |
+| MIR     | How execution maps to control flow (CFG plumbing)  | Control-flow truth    |
+| LLVM IR | How control flow maps to machine execution         | Platform translation  |
+
+If XIR correctly represents the executable structure and MIR correctly lowers it to control flow, the language semantics are correct. LLVM IR and other backends are translators, not interpreters of SystemVerilog.
 
 ## Scope Authority
 
-**All IR is specialization-scoped.**
+**All IR is per-compilation-unit.**
 
-HIR and MIR represent a single module specialization. No design-global slot IDs, no instance paths, no BFS instance ordering. See [compilation-model.md](compilation-model.md).
+HIR, XIR, and MIR each represent a single module specialization -- the compiler's compilation unit. No design-global slot IDs, no instance paths, no BFS instance ordering. See [compilation-model.md](compilation-model.md).
+
+The compiler does not adopt the frontend's whole-design elaboration world. At the AST-to-HIR boundary, the frontend output is broken into per-specialization compilation units. After that boundary, lowering proceeds per-unit without consulting design-global state.
+
+## Compilation Unit Boundary
+
+The AST-to-HIR boundary is where the compiler establishes its own compilation units:
+
+| Happens here                                         | Does NOT happen here          |
+| ---------------------------------------------------- | ----------------------------- |
+| Frontend output broken into per-specialization units | Design-global lowering        |
+| Stable IDs replace frontend pointers                 | Instance-specific compilation |
+| Data ownership transferred to compiler               | Topology-dependent decisions  |
+| User errors diagnosed (last chance)                  | Execution-model structure     |
+
+After this boundary, the compiler's world is per-unit. Design-global facts (package/global state, type arenas, symbol tables) exist as frozen shared read-only context, not as a mutable whole-design compilation environment.
 
 ## Layer Responsibilities
 
-### AST -> HIR
+### AST -> HIR (per unit)
 
-| Must Resolve           | Must NOT Do              |
-| ---------------------- | ------------------------ |
-| Syntax normalization   | Execution semantics      |
-| Type resolution        | Control flow lowering    |
-| Symbol binding         | Temporary introduction   |
-| Source span capture    | Basic block construction |
-| User error diagnostics | Design-global allocation |
+| Must Resolve                      | Must NOT Do              |
+| --------------------------------- | ------------------------ |
+| Syntax normalization              | Execution structure      |
+| Type resolution                   | Control flow lowering    |
+| Symbol binding                    | Temporary introduction   |
+| Source span capture               | Basic block construction |
+| User error diagnostics            | Design-global allocation |
+| Specialization unit establishment |                          |
 
-HIR should still "look like SV", just cleaned and normalized.
+HIR should still "look like SV", just cleaned and normalized. HIR owns stable IDs and data independent from frontend memory. Some execution-relevant semantic shaping (capture classification, system call classification, assignment target canonicalization) is appropriate where it preserves language-level meaning that downstream layers need.
 
-### HIR -> MIR
+### HIR -> XIR (per unit)
 
-| Must Resolve                     | Must NOT Do                |
-| -------------------------------- | -------------------------- |
-| Execution order                  | Re-interpret syntax        |
-| Data flow (temporaries)          | Emit user diagnostics      |
-| Control flow (basic blocks)      | Platform-specific lowering |
-| Place/Value separation           | Design-global allocation   |
-| System subroutine classification |                            |
+| Must Resolve                                        | Must NOT Do                     |
+| --------------------------------------------------- | ------------------------------- |
+| Execution-model structure                           | CFG / basic block construction  |
+| Closure/capture models for deferred actions         | Place/Operand separation        |
+| Observer lifecycles (setup/check/teardown)          | Temporary introduction          |
+| Wait/trigger execution models                       | Scheduling / runtime policy     |
+| Structured executable control flow                  | Design-global consultation      |
+| Object composition (subobject sites, external refs) | Thunk dispatch / payload layout |
 
-MIR defines how the program executes. All semantic questions are answered here.
+XIR makes execution structure explicit and first-class. All execution-model concepts have a formal home here. The compilation unit is a self-contained executable object description. XIR must be projectable into a C++ object/behavior model for architectural review; if the projection must invent structure, XIR is incomplete. See [xir-design.md](xir-design.md).
 
-### MIR -> LLVM IR
+### XIR -> MIR (per unit)
+
+| Must Resolve                                     | Must NOT Do                   |
+| ------------------------------------------------ | ----------------------------- |
+| Control flow (basic blocks, terminators)         | Re-interpret execution model  |
+| Data flow (temporaries)                          | Emit user diagnostics         |
+| Place/Operand separation                         | Platform-specific lowering    |
+| Suspension mechanics (Delay/Wait as terminators) | Design-global consultation    |
+| Effect and side-effect plumbing                  | Invent new execution concepts |
+
+MIR defines how structured execution maps to control-flow plumbing. All execution concepts should already be formalized in XIR; MIR lowers them to CFG form. See [mir-design.md](mir-design.md).
+
+### MIR -> LLVM IR (per unit)
 
 | Must Do                            | Must NOT Do              |
 | ---------------------------------- | ------------------------ |
@@ -51,29 +87,31 @@ MIR defines how the program executes. All semantic questions are answered here.
 | Layout based on TypeId             | Create new types         |
 |                                    | Emit user diagnostics    |
 
-LLVM IR is not where language semantics live.
+LLVM IR is not where language semantics or execution-model structure live.
 
-### Specialization -> Realization
+### Per-Unit Compilation -> Artifact Composition
 
-| Must Do                                       | Must NOT Do                                           |
-| --------------------------------------------- | ----------------------------------------------------- |
-| Produce self-contained CompiledSpecialization | Reference design-global slot IDs                      |
-| Use specialization-constant offsets only      | Embed instance paths in code                          |
-| Classify parameters (structural vs value)     | Depend on instance count or ordering                  |
-| Export SpecLayout, metadata, process info     | Require design-global knowledge                       |
-| Keep heavy LLVM codegen specialization-scoped | Encode per-instance binding in LLVM functions/globals |
+| Must Do                                          | Must NOT Do                    |
+| ------------------------------------------------ | ------------------------------ |
+| Package per-unit artifacts into deliverable      | Recompile specialization code  |
+| Combine with elaborated design topology metadata | Re-run LLVM optimization       |
+| Produce constructor input data                   | Return to semantic elaboration |
+| Keep per-unit boundaries intact                  | Merge or flatten per-unit IRs  |
 
-The specialization boundary is the key architectural invariant. Violations here break parallelism and incrementality. Per-instance binding should not appear in LLVM function or global identity. Heavy LLVM codegen shape should be determined by the number of unique specializations, not the number of instances.
+Artifact composition is a compile-time design-wide pass. It packages per-unit outputs with topology metadata for the constructor. It is not a return to semantic elaboration or a new link-time compilation engine.
 
-### Realization -> Runtime
+### Constructor / Realization -> Runtime
 
-| Must Do                             | Must NOT Do                   |
-| ----------------------------------- | ----------------------------- |
-| Bind instances to specializations   | Recompile specialization code |
-| Compute design state allocation     | Re-run LLVM optimization      |
-| Build connectivity / trigger tables | Modify compiled kernels       |
-| Construct per-instance const blocks | Depend on design flattening   |
-| Produce instance path debug tables  |                               |
+| Must Do                                     | Must NOT Do                   |
+| ------------------------------------------- | ----------------------------- |
+| Bind instances to specializations           | Recompile specialization code |
+| Construct per-instance storage              | Re-run LLVM optimization      |
+| Build connectivity / trigger tables         | Modify compiled artifacts     |
+| Construct per-instance const blocks         | Depend on design flattening   |
+| Execute generate-driven structure selection |                               |
+| Produce instance path debug tables          |                               |
+
+The constructor builds the runtime object graph at runtime (or load time for AOT). Generate-driven structural realization happens here, not at compile time. This is object construction, not compilation.
 
 ### Codegen -> Runtime
 
@@ -94,54 +132,59 @@ These must flow end-to-end through the pipeline:
 | ----------- | ---------- | -------------------------------- |
 | SourceSpan  | AST -> HIR | Diagnostics, debugging           |
 | TypeId      | HIR        | All stages (read-only after HIR) |
-| ConstId     | HIR        | MIR, LLVM (materialization)      |
-| SymbolId    | HIR        | MIR (variable resolution)        |
-| ValueId     | HIR -> MIR | MIR, LLVM (temp mapping)         |
+| ConstId     | HIR        | XIR, MIR, LLVM (materialization) |
+| SymbolId    | HIR        | XIR, MIR (variable resolution)   |
 
 ## Forbidden Cross-Layer Behavior
 
-| Violation                           | Why It's Wrong                                                  |
-| ----------------------------------- | --------------------------------------------------------------- |
-| LLVM fixes SV semantics             | Semantics must be fixed in MIR                                  |
-| MIR re-interprets syntax            | Syntax interpretation is HIR's job                              |
-| HIR encodes execution               | Execution semantics belong in MIR                               |
-| Post-HIR user diagnostics           | All user errors caught at AST -> HIR boundary                   |
-| Backend creates types               | Types are language-level, owned by HIR                          |
-| Backend manages storage             | Instance storage is owned by runtime                            |
-| Backend invents scheduling          | Scheduling semantics belong in runtime                          |
-| Design-global IDs in specialization | Breaks parallelism and incrementality                           |
-| Instance paths in compiled code     | Instance binding belongs to design realization, not compilation |
+| Violation                                      | Why It's Wrong                                                                  |
+| ---------------------------------------------- | ------------------------------------------------------------------------------- |
+| LLVM fixes SV semantics                        | Semantics must be fixed before LLVM                                             |
+| MIR invents execution concepts                 | Execution model belongs in XIR                                                  |
+| MIR re-interprets execution structure          | XIR is the execution-model truth                                                |
+| XIR encodes CFG plumbing                       | CFG lowering belongs in MIR                                                     |
+| HIR encodes execution structure                | Execution structure belongs in XIR                                              |
+| Post-HIR user diagnostics                      | All user errors caught at AST -> HIR boundary                                   |
+| Backend creates types                          | Types are language-level, owned by HIR                                          |
+| Backend manages storage                        | Instance storage is owned by runtime                                            |
+| Backend invents scheduling                     | Scheduling semantics belong in runtime                                          |
+| Design-global IDs in per-unit IR               | Breaks compilation-unit isolation                                               |
+| Instance paths in compiled code                | Instance binding belongs to constructor, not compilation                        |
+| Per-unit lowering consults design-global state | Breaks per-unit independence; only frozen read-only shared context is permitted |
 
 ## Forbidden Representation Shapes
 
-These are concrete anti-models. Any design that produces these shapes is architecturally invalid, even if it passes tests. They represent the specific ways the flat design-global model re-emerges.
+These are concrete anti-models. Any design that produces these shapes is architecturally invalid, even if it passes tests.
 
-| Forbidden Shape                                                                                                      | Why It Is Wrong                                                                                                                                                                                      |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Resolving hierarchical refs to `kDesignGlobal` places during specialization compilation                              | Non-local targets are construction-time facts. Specialization code must use typed external-ref handles, not design-global slots.                                                                     |
-| Resolving connections to final object endpoints (object_index, design-global slot) during specialization compilation | Connection targets are construction-time facts. Connections must be recipes referencing body-local identities (child binding site + local slot), not final topology coordinates.                     |
-| Using design-global slot IDs as the semantic source of truth for non-local access                                    | Design-global slot IDs are an implementation detail of the runtime orchestration layer. They must not appear in compiled specialization artifacts or drive correctness of lowering.                  |
-| Backend reconstruction of connection semantics by cloning body-local MIR into design-global processes                | If the backend must rebuild the old representation from the new one, the new representation is not yet the source of truth. The backend must consume recipes/artifacts directly.                     |
-| Any representation whose correctness depends on final object ordering or topology materialization during compile     | Adding or removing instances must not invalidate compiled specialization artifacts. If it does, the representation has leaked topology into compilation.                                             |
-| Representing non-local access as a parent-hop count or path of instance symbols                                      | Hop-count and symbol-path representations bake hierarchy shape into compiled code. Non-local access must use a single typed handle that is bound at construction time regardless of hierarchy depth. |
-
-When evaluating a proposed design, check this table explicitly. The most common failure mode is a representation that uses the right vocabulary ("recipe", "deferred", "body-local") but still encodes final object identity internally.
+| Forbidden Shape                                                                       | Why It Is Wrong                                                                                                                                                 |
+| ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Resolving hierarchical refs to `kDesignGlobal` places during per-unit compilation     | Non-local targets are construction-time facts. Per-unit code must use typed external-ref handles, not design-global slots.                                      |
+| Resolving connections to final object endpoints during per-unit compilation           | Connection targets are construction-time facts. Connections must be recipes referencing body-local identities.                                                  |
+| Using design-global slot IDs as the semantic source of truth for non-local access     | Design-global slot IDs are an implementation detail of the runtime orchestration layer. They must not appear in compiled per-unit artifacts.                    |
+| Per-unit lowering code consulting design-global orchestration tables                  | If lowering requires whole-design state beyond frozen read-only context (types, symbols), the compilation-unit boundary is violated.                            |
+| Lowering code inventing execution-model structure without XIR representation          | If an execution concept (closure, observer, wait model) is synthesized during MIR lowering without first being named in XIR, the pipeline is missing structure. |
+| Any representation whose correctness depends on final object ordering or topology     | Adding or removing instances must not invalidate compiled per-unit artifacts.                                                                                   |
+| Compilation-unit IDs used as lookup handles into design-global tables during lowering | IDs like ModuleSpecId name a unit. They must not become surrogate handles for recovering design-global architecture state.                                      |
+| Representing non-local access as a parent-hop count or path of instance symbols       | Non-local access must use a single typed handle bound at construction time.                                                                                     |
+| Artifact composition that re-enters semantic elaboration                              | Post-compilation design-wide passes must package, not recompile or re-derive semantics.                                                                         |
 
 ## Error Boundaries
 
 | Stage       | User Errors         | Compiler Bugs |
 | ----------- | ------------------- | ------------- |
 | AST -> HIR  | DiagnosticException | InternalError |
-| HIR -> MIR  | N/A                 | InternalError |
+| HIR -> XIR  | N/A                 | InternalError |
+| XIR -> MIR  | N/A                 | InternalError |
 | MIR -> LLVM | N/A                 | InternalError |
 
 See [error-handling.md](error-handling.md) for details.
 
 ## Debugging Philosophy
 
-- **Debug starts at MIR** - If MIR is correct, look at LLVM lowering
+- **Debug starts at XIR** -- If XIR correctly represents execution structure, look at MIR lowering
+- **Then MIR** -- If MIR is correct, look at LLVM lowering
 - **LLVM is assumed correct** unless proven otherwise
-- **Always be able to dump**: HIR, MIR, LLVM IR
+- **Always be able to dump**: HIR, XIR, MIR, LLVM IR
 
 ## Guiding Principle
 

--- a/docs/queues/specialization.md
+++ b/docs/queues/specialization.md
@@ -36,7 +36,12 @@ For the stable architecture: see [compilation-model.md](../compilation-model.md)
 - [ ] F2 -- Specialization caching
 - [x] I1 -- Constructor-time container construction recipes
 - [ ] Compilation unit isolation enforcement (I-1 through I-5)
-- [ ] Documentation: natural model, ownership boundaries, and runtime model docs need alignment
+- [ ] X -- XIR layer introduction (execution-model IR between HIR and MIR)
+  - [ ] X1 -- XIR design: define core types, compilation-unit structure, C++ projection contract
+  - [ ] X2 -- XIR vertical slice: one representative feature (e.g., deferred assertions) through HIR -> XIR -> MIR
+  - [ ] X3 -- XIR validation: C++ projection proves execution-model shape for the slice
+  - [ ] X4 -- Layer rename: XIR -> MIR, current MIR -> LIR (after shape is proven)
+- [x] Documentation: XIR introduction, per-compilation-unit model, four-layer pipeline across architecture docs
 - [ ] CI policy gates: specialization invariants and natural model regression checks
 
 ## Dependency Shape
@@ -56,6 +61,16 @@ B1 is prerequisite-free (investigation + type boundary). B2 depends on B1 (compi
 - Flat/global runtime transport for instance-owned state remains a later migration surface.
 
 - **T1 (validation)** runs after C1, the R-series, V3a-V3d, and V4.
+
+## X: XIR layer introduction
+
+XIR is a new execution-model IR between HIR and the current MIR. It exists because the current pipeline has no formal home for execution-model concepts (closures, observers, wait models, object composition), so lowering code invents them ad-hoc and the results drift toward design-global tables and ID-based orchestration.
+
+**Temporary naming:** XIR is a working name. The long-term plan is to rename XIR -> MIR and current MIR -> LIR, establishing the four-layer pipeline (HIR / MIR / LIR / LLVM IR). The rename happens after the XIR shape is proven on at least one vertical slice (X2/X3). Architecture docs use whichever name is current at each rename.
+
+**Dependency:** X1 is prerequisite-free (design work). X2 depends on X1. X3 depends on X2. X4 depends on X3 proving the shape. X is independent of the V-series and F-series.
+
+**Methodology anchor:** XIR must be projectable into a C++ object model (module ~ class, process ~ bound behavior, signal ~ member, hierarchy ~ subobjects). The C++ projection is a methodology tool and design oracle, not a product backend. If an execution concept cannot project cleanly, the XIR shape is wrong.
 
 ## C1: Remove per-instance emitted constructor IR/globals
 

--- a/docs/xir-design.md
+++ b/docs/xir-design.md
@@ -1,0 +1,142 @@
+# XIR Design
+
+XIR (eXecution IR) is the execution-model IR. It makes all executable structure explicit and first-class before lower IRs commit to CFG plumbing.
+
+## Pipeline Position
+
+```
+                        per compilation unit
+                   +---------------------------------+
+frontend output -> | HIR -> XIR -> MIR -> LLVM IR    | -> per-unit artifact
+                   +---------------------------------+
+```
+
+HIR freezes _what the language means_.
+XIR freezes _what the execution model is_ -- the object-level executable structure.
+MIR freezes _how that structure maps to control flow and plumbing_.
+
+## Scope
+
+XIR is **per-compilation-unit**. Each XIR artifact describes one module specialization. No instance paths, no design-global slot IDs, no design-global allocation. See [compilation-model.md](compilation-model.md).
+
+XIR is not merely "specialization-scoped" as a naming convention. It is a concrete artifact boundary: each specialization's XIR is independently producible and consumable, not a fragment of a larger design-wide XIR. No XIR lowering step consults design-global state. Frozen shared context (types, symbols) is read-only input, not a design-global compilation environment.
+
+## Guiding Question
+
+> Can this XIR be projected into a readable C++ class without adding new semantic interpretation during projection?
+
+If projection requires the renderer to invent execution structure, reinterpret meaning, or consult external tables, the XIR is incomplete. The projection renders; it does not interpret.
+
+## Why XIR Exists
+
+HIR preserves source-level semantic structure. MIR commits to CFG-level plumbing (basic blocks, terminators, Place/Operand). Between these two layers, many execution-model concepts have no formal home:
+
+- Closure/capture models for deferred actions
+- Observer lifecycles (persistent change-triggered programs)
+- Wait/trigger execution models (late-bound subscription, rebinding)
+- Structured control flow at the execution level (not source-shaped, not yet CFG)
+- Object composition (subobject ownership, constructor-time assembly)
+
+Without a dedicated layer, these concepts are invented ad-hoc during lowering. Each feature re-derives its own execution structure, and the results drift toward design-global tables and ID-based orchestration because those are the available coordination mechanisms.
+
+XIR exists so that execution-model concepts have a formal, reviewable, projectable home.
+
+## Core Principles
+
+These are hard rules, not guidelines:
+
+| Rule                                       | Rationale                                                                         |
+| ------------------------------------------ | --------------------------------------------------------------------------------- |
+| Execution concepts are first-class objects | Closures, observers, wait models are named XIR constructs, not lowering artifacts |
+| Structured control flow, not CFG           | XIR preserves executable structure; basic blocks and terminators belong in MIR    |
+| Object-local ownership                     | State belongs to the compilation unit; no design-global lookup for owned data     |
+| No design-global IDs or tables             | No BodyId, ModuleSpecId, InstanceId as architecture-bearing lookup keys           |
+| Per-unit artifact boundary                 | Each XIR unit is independently producible; no design-wide XIR container           |
+| Projectable to C++ object model            | Module ~ class, process ~ bound behavior, signal ~ member, hierarchy ~ subobjects |
+| Projection renders, does not interpret     | If C++ projection must invent structure, XIR is incomplete                        |
+| No scheduling or runtime policy            | Scheduling strategy is runtime's responsibility                                   |
+| No LLVM/ABI details                        | Platform-independent; backends handle lowering                                    |
+
+## Key Structural Concepts
+
+### Compilation Unit as Object Description
+
+A XIR compilation unit describes one specialization as an executable object:
+
+- Member state (signals, variables, containers)
+- Processes (object-bound behavior with lifetime and scheduling semantics)
+- Subroutines (callable behavior, parameter passing, return)
+- Subobject sites (child instantiation points with typed port contracts)
+- External references (typed handles for non-local access, bound at construction time)
+- Connection recipes (data-flow rules using object-local identities)
+
+This is not an abstract grouping concept. It is a concrete artifact that the next layer (MIR) consumes as its sole input for one compilation unit.
+
+### Structured Control Flow
+
+XIR preserves structured control flow: if/else, case, loops, sequential blocks. These are execution-level structures, not source-level syntax preservation (that is HIR's job) and not CFG expansion (that is MIR's job).
+
+The distinction: HIR preserves source shape for fidelity. XIR preserves execution shape for projectability. MIR lowers to basic blocks for backend consumption.
+
+### Closure and Capture Models
+
+Deferred actions, observer programs, and any construct that captures state for later execution are first-class XIR objects with explicit capture lists, callee identity, and invocation semantics.
+
+A deferred assertion action in XIR is a closure: it names what it captures (by value or by reference), what it calls, and under what disposition. The lowering to thunk dispatch, payload layout, and ABI happens in MIR, not XIR.
+
+### Wait and Trigger Models
+
+Event sensitivity, delay, and subscription models are first-class XIR constructs. A wait specifies what signals are monitored, with what edge, and what happens on trigger -- as structured executable objects, not as CFG terminators with resume-block metadata.
+
+The lowering to bytecode index plans, subscription slot tracking, and trigger installation happens in MIR, not XIR.
+
+### Observer Lifecycles
+
+Persistent observers ($monitor, $strobe) are first-class XIR objects with explicit setup/check/teardown lifecycle, snapshot semantics, and change-detection contracts. They are not synthesized as pairs of anonymous functions during lowering.
+
+## The C++ Projection
+
+The C++ projection is a methodology tool, not a product backend. Its purpose is to make XIR's architectural shape visible and reviewable.
+
+A well-formed XIR compilation unit should project into something resembling:
+
+- A class declaration (member state, process methods, subroutine methods)
+- Closure objects for deferred actions (captured state, invocation)
+- Structured control flow in method bodies (if/else, loops, case)
+- Subobject members for child instantiation sites
+- Typed handle members for external references
+
+If XIR contains a concept that does not project cleanly, that is evidence the XIR shape is wrong. The projection is the architectural oracle.
+
+The projection is not a second product backend. It does not need to compile or execute. It needs to be readable and to make architectural shape visible.
+
+## What Must NOT Appear in XIR
+
+| Excluded                                | Belongs in               |
+| --------------------------------------- | ------------------------ |
+| Basic blocks / CFG edges                | MIR                      |
+| Terminators (Jump, Branch, Switch)      | MIR                      |
+| Place/Operand separation                | MIR                      |
+| Temporaries / SSA / value numbering     | MIR                      |
+| LLVM intrinsics / ABI details           | LLVM lowering            |
+| Scheduling queues / execution policy    | Runtime                  |
+| Design-global IDs as lookup keys        | Never in per-unit IR     |
+| Frontend pointers                       | Never                    |
+| Thunk dispatch / payload layout         | MIR or backend           |
+| Bytecode plans / subscription tracking  | MIR or backend           |
+| Design-wide container of multiple units | Never -- XIR is per-unit |
+
+If you find yourself adding CFG-level plumbing to XIR, step back -- you are modeling implementation, not execution structure. If you find yourself adding a design-wide XIR container, step back -- the compilation unit is the artifact boundary.
+
+## Relationship to Other Layers
+
+| Layer   | Freezes                                            | Key representation                       |
+| ------- | -------------------------------------------------- | ---------------------------------------- |
+| HIR     | What the language means (semantic)                 | Source-shaped, owned, normalized         |
+| XIR     | What the execution model is (executable structure) | Object-shaped, structured, projectable   |
+| MIR     | How it maps to control flow and plumbing           | CFG, Place/Operand, terminators, effects |
+| LLVM IR | How it maps to machine execution                   | SSA, intrinsics, ABI                     |
+
+## Summary
+
+XIR is the execution-model IR. It sits between semantic HIR and plumbing-oriented MIR. Its job is to make executable structure -- closures, observers, wait models, object composition, structured control flow -- explicit, named, and projectable into a C++ object model. Each XIR unit is a concrete per-compilation-unit artifact. If a concept cannot be projected cleanly, the XIR shape is wrong.


### PR DESCRIPTION
## Summary

Introduces the XIR (eXecution IR) layer into the architecture documentation and rewrites the documentation set to reflect a per-compilation-unit model instead of a whole-design compilation model.

The core architectural changes documented here:

**Four-layer IR pipeline.** The docs now describe HIR (semantic) -> XIR (execution model) -> MIR (control-flow plumbing) -> LLVM IR (backend), replacing the previous two-layer HIR -> MIR model. XIR exists because the pipeline previously had no formal home for execution-model concepts (closures, observers, wait models, object composition), causing lowering code to invent them ad-hoc.

**Per-compilation-unit model.** All docs now describe the compiler's world as per-specialization after the AST-to-HIR boundary. The frontend's whole-design elaboration is explicitly described as frontend output, not the compiler's own compilation world. Lowering after HIR proceeds per-unit without consulting design-global state.

**Five-phase pipeline.** The previous three-phase model (Elaboration -> Specialization Compilation -> Design Realization) is replaced by five phases: Elaboration -> Specialization Grouping -> Per-Unit Compilation -> Artifact Composition -> Constructor/Realization. "Design Realization" is split into compile-time artifact composition (packaging) and runtime constructor/realization (object construction).

**C++ projection as methodology tool.** XIR is documented as projectable into a C++ object/behavior model for architectural review. The projection renders, it does not interpret -- if it must invent structure, the XIR shape is wrong.

Files changed: CLAUDE.md, docs/xir-design.md (new), docs/pipeline-contract.md, docs/hir-design.md, docs/mir-design.md, docs/architecture.md, docs/compilation-model.md, docs/natural-model.md, docs/architecture-principles.md, docs/philosophy.md, docs/llvm-backend.md, docs/README.md, docs/queues/specialization.md.