### PR TITLE
Harden runtime output API and improve test crash diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,16 @@ bazel test //tests:jit_dev_tests \
 
 Path is relative to `tests/sv_features/`. `--backend` is required with `--test_file`.
 
+Run a single named test case (fastest reproducer path for failures):
+
+```bash
+bazel test //tests:jit_dev_tests \
+  --test_arg=--case=operators_binary_default_add \
+  --test_output=errors
+```
+
+Case name is the full qualified name from test output (e.g., `category_file_casename`).
+
 ## Benchmarks
 
 Benchmark runner: `tools/bench/run_benchmarks.py`. Fixtures in `tools/bench/fixtures/`.

--- a/include/lyra/common/timescale_format.hpp
+++ b/include/lyra/common/timescale_format.hpp
@@ -6,8 +6,6 @@
 
 namespace lyra {
 
-constexpr int kDefaultTimeScalePower = -12;  // 1ps (IEEE 1800 default)
-
 /// Convert power of 10 to human-readable time unit string.
 /// Examples: -9 -> "1ns", -8 -> "10ns", -10 -> "100ps"
 inline auto PowerToString(int power) -> std::string {

--- a/include/lyra/llvm_backend/context.hpp
+++ b/include/lyra/llvm_backend/context.hpp
@@ -315,6 +315,8 @@ class Context {
   [[nodiscard]] auto GetLyraInitRuntime() -> llvm::Function*;
   [[nodiscard]] auto GetLyraResolveBaseDir() -> llvm::Function*;
   [[nodiscard]] auto GetLyraReportTime() -> llvm::Function*;
+  [[nodiscard]] auto GetLyraCreateRunSession() -> llvm::Function*;
+  [[nodiscard]] auto GetLyraDestroyRunSession() -> llvm::Function*;
   [[nodiscard]] auto GetLyraDynArrayNew() -> llvm::Function*;
   [[nodiscard]] auto GetLyraDynArrayNewCopy() -> llvm::Function*;
   [[nodiscard]] auto GetLyraDynArraySize() -> llvm::Function*;
@@ -1081,6 +1083,8 @@ class Context {
   llvm::Function* lyra_init_runtime_ = nullptr;
   llvm::Function* lyra_resolve_base_dir_ = nullptr;
   llvm::Function* lyra_report_time_ = nullptr;
+  llvm::Function* lyra_create_run_session_ = nullptr;
+  llvm::Function* lyra_destroy_run_session_ = nullptr;
   llvm::Function* lyra_iteration_limit_ptr_ = nullptr;
   llvm::Function* lyra_dynarray_new_ = nullptr;
   llvm::Function* lyra_dynarray_new_copy_ = nullptr;

--- a/include/lyra/llvm_backend/execution.hpp
+++ b/include/lyra/llvm_backend/execution.hpp
@@ -11,6 +11,10 @@
 #include "lyra/common/opt_level.hpp"
 #include "lyra/llvm_backend/lower.hpp"
 
+namespace lyra::runtime {
+struct RunSession;
+}  // namespace lyra::runtime
+
 namespace lyra::lowering::mir_to_llvm {
 
 enum class LinkProgressPhase : uint8_t {
@@ -108,7 +112,8 @@ class JitSession {
   auto operator=(JitSession&&) noexcept -> JitSession&;
 
   // Run the compiled simulation. Returns exit code.
-  auto Run() -> int;
+  // Caller provides a RunSession with output sink already installed.
+  auto Run(runtime::RunSession& session) -> int;
 
   // Sub-phase timings from JIT compilation.
   [[nodiscard]] auto Timings() const -> const JitCompileTimings&;

--- a/include/lyra/llvm_backend/lower.hpp
+++ b/include/lyra/llvm_backend/lower.hpp
@@ -73,7 +73,7 @@ class SimulationHooks {
   // Variable inspection is backend-owned via GetTrackedVariables().
   virtual void EmitPostSimulationReports(
       Context& /*context*/, llvm::Value* /*design_state*/,
-      llvm::Value* /*abi_ptr*/) {
+      llvm::Value* /*abi_ptr*/, llvm::Value* /*run_session_ptr*/) {
   }
 };
 
@@ -134,9 +134,10 @@ auto DumpLlvmIr(const llvm::Module& module) -> std::string;
 // Type metadata is pre-resolved at plan-building time.
 void EmitVariableInspection(
     Context& context, const CuFacts& facts, const InspectionPlan& plan,
-    llvm::Value* design_state, llvm::Value* abi_ptr);
+    llvm::Value* design_state, llvm::Value* abi_ptr,
+    llvm::Value* run_session_ptr);
 
 // Emit time report call for test harness.
-void EmitTimeReport(Context& context);
+void EmitTimeReport(Context& context, llvm::Value* run_session_ptr);
 
 }  // namespace lyra::lowering::mir_to_llvm

--- a/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
@@ -12,9 +12,15 @@ namespace lyra::lowering::ast_to_hir {
 
 /// Per-scope state for AST->HIR lowering.
 /// Immutable after construction; safe for parallel lowering.
+///
+/// Timescale fields are mixed-axis by design:
+///   unit_power           -- scope-local: what #1 means in this module
+///   global_precision_power -- compilation-wide: what one simulation tick means
+/// DelayScaler uses both to compute ratio = 10^(unit - global_precision).
 struct LoweringFrame {
-  int unit_power;  // Scope's timeunit as power of 10 (e.g., -9 for 1ns)
-  int global_precision_power;  // Compilation-wide finest precision
+  int unit_power = 0;  // Scope's timeunit as power of 10 (e.g., -9 for 1ns)
+  int global_precision_power =
+      0;  // Compilation-wide finest precision (not this scope's precision)
   // The slang instance being lowered. Used by hierarchical reference path
   // extraction to determine whether a path element is an ancestor
   // self-reference or a real child traversal step. Null for package lowering.

--- a/include/lyra/lowering/ast_to_hir/timescale.hpp
+++ b/include/lyra/lowering/ast_to_hir/timescale.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <limits>
 #include <optional>
@@ -10,9 +11,30 @@
 #include <slang/ast/symbols/InstanceSymbols.h>
 #include <slang/numeric/Time.h>
 
-#include "lyra/common/timescale_format.hpp"
-
 namespace lyra::lowering::ast_to_hir {
+
+/// Resolved timescale for a scope: unit and precision as powers of 10.
+/// Uses int for computation ergonomics. Downstream storage and ABI carriers
+/// narrow to int8_t (valid range [-15, 0]) at explicit storage boundaries.
+struct ResolvedTimeScale {
+  int unit_power;
+  int precision_power;
+};
+
+/// Canonical resolver for an optional slang TimeScale.
+/// Accepts the value returned by Scope::getTimeScale() or similar APIs.
+/// If the optional has a value, converts its base/precision to powers.
+/// If nullopt (no timescale in scope), maps to Lyra's canonical
+/// missing-timescale contract: 1ns/1ns, matching the IEEE 1800 default
+/// and slang's TimeLiteral fallback (TimeScale default constructor).
+/// All missing-timescale resolution in Lyra must go through this helper.
+inline auto ResolveScopeTimeScale(std::optional<slang::TimeScale> ts)
+    -> ResolvedTimeScale;
+
+/// Convenience projections -- delegate to ResolveScopeTimeScale.
+inline auto ResolveScopeUnitPower(std::optional<slang::TimeScale> ts) -> int;
+inline auto ResolveScopePrecisionPower(std::optional<slang::TimeScale> ts)
+    -> int;
 
 /// Compute 10^exponent with overflow checking.
 /// Returns std::nullopt on overflow or negative exponent.
@@ -70,6 +92,35 @@ inline auto TimeScaleValueToPower(const slang::TimeScaleValue& tsv) -> int {
   return base + magnitude_offset;
 }
 
+// IEEE 1800 default timescale when no `timescale directive is present.
+// Matches slang's TimeScaleValue default constructor (1ns) and the
+// TimeScale default constructor (1ns/1ns) used by TimeLiteral::fromSyntax.
+constexpr int kDefaultTimeUnitPower = -9;       // 1ns
+constexpr int kDefaultTimePrecisionPower = -9;  // 1ns
+
+inline auto ResolveScopeTimeScale(std::optional<slang::TimeScale> ts)
+    -> ResolvedTimeScale {
+  if (!ts) {
+    return {
+        .unit_power = kDefaultTimeUnitPower,
+        .precision_power = kDefaultTimePrecisionPower,
+    };
+  }
+  return {
+      .unit_power = TimeScaleValueToPower(ts->base),
+      .precision_power = TimeScaleValueToPower(ts->precision),
+  };
+}
+
+inline auto ResolveScopeUnitPower(std::optional<slang::TimeScale> ts) -> int {
+  return ResolveScopeTimeScale(ts).unit_power;
+}
+
+inline auto ResolveScopePrecisionPower(std::optional<slang::TimeScale> ts)
+    -> int {
+  return ResolveScopeTimeScale(ts).precision_power;
+}
+
 namespace detail {
 
 // Forward declaration for mutual recursion
@@ -81,10 +132,8 @@ inline void CollectMinPrecision(
   auto ts = inst.body.getTimeScale();
   if (ts) {
     int prec = TimeScaleValueToPower(ts->precision);
-    if (!found || prec < min_power) {
-      min_power = prec;
-      found = true;
-    }
+    min_power = found ? std::min(min_power, prec) : prec;
+    found = true;
   }
   CollectMinPrecisionFromScope(inst.body, min_power, found);
 }
@@ -117,13 +166,17 @@ inline void CollectMinPrecisionFromScope(
 }  // namespace detail
 
 /// Compute the global precision (finest timeprecision across all instances).
+/// Scans all instances for explicit timescales and returns the finest
+/// precision found. If no instance has an explicit timescale, returns
+/// the canonical default (1ns) via ResolveScopeTimeScale(nullopt).
 inline auto ComputeGlobalPrecision(slang::ast::Compilation& comp) -> int {
   int min_power = 0;
   bool found = false;
   for (const auto* inst : comp.getRoot().topInstances) {
     detail::CollectMinPrecision(*inst, min_power, found);
   }
-  return found ? min_power : kDefaultTimeScalePower;
+  return found ? min_power
+               : ResolveScopeTimeScale(std::nullopt).precision_power;
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -54,6 +54,8 @@
 
 namespace lyra::runtime {
 
+class OutputDispatcher;
+
 // Explicit process dispatch ABI for the hot path.
 // fn is required (must not be nullptr). ctx is non-owning and must outlive
 // Engine::Run().
@@ -194,10 +196,11 @@ class Engine {
 
  public:
   explicit Engine(
-      ProcessDispatch process_dispatch, uint32_t num_processes = 0,
-      std::span<const std::string> plusargs = {},
+      ProcessDispatch process_dispatch, OutputDispatcher& output,
+      uint32_t num_processes = 0, std::span<const std::string> plusargs = {},
       std::vector<std::string> instance_paths = {}, uint32_t feature_flags = 0)
       : process_dispatch_(process_dispatch),
+        output_(output),
         num_processes_(num_processes),
         process_states_(num_processes),
         plusargs_(plusargs.begin(), plusargs.end()),
@@ -346,6 +349,14 @@ class Engine {
   // Get current simulation time.
   [[nodiscard]] auto CurrentTime() const -> SimTime {
     return current_time_;
+  }
+
+  // Access the run-session-owned output dispatcher (borrowed, not owned).
+  [[nodiscard]] auto Output() -> OutputDispatcher& {
+    return output_;
+  }
+  [[nodiscard]] auto Output() const -> const OutputDispatcher& {
+    return output_;
   }
 
   // Set global precision power (called once at simulation init).
@@ -1190,6 +1201,7 @@ class Engine {
   void ClearLocalUpdates();
 
   ProcessDispatch process_dispatch_;
+  OutputDispatcher& output_;  // Borrowed from RunSession
   uint32_t num_processes_ = 0;
   std::vector<ProcessState> process_states_;
   SimTime current_time_ = 0;

--- a/include/lyra/runtime/io.hpp
+++ b/include/lyra/runtime/io.hpp
@@ -136,10 +136,10 @@ void LyraReadmemGlobal(
     uint32_t global_slot_id);
 
 void LyraReadmemNoNotify(
-    void* engine_ptr, LyraStringHandle filename, void* target,
-    int32_t element_width, int32_t stride_bytes, int32_t value_size_bytes,
-    int32_t element_count, int64_t min_addr, int64_t current_addr,
-    int64_t final_addr, int64_t step, bool is_hex, int32_t element_kind);
+    LyraStringHandle filename, void* target, int32_t element_width,
+    int32_t stride_bytes, int32_t value_size_bytes, int32_t element_count,
+    int64_t min_addr, int64_t current_addr, int64_t final_addr, int64_t step,
+    bool is_hex, int32_t element_kind);
 
 // $writememh/$writememb: write array to memory file
 // Parameters match LyraReadmem, but source is read-only.

--- a/include/lyra/runtime/io.hpp
+++ b/include/lyra/runtime/io.hpp
@@ -13,14 +13,15 @@ enum class MemElementKind : int32_t {
 extern "C" {
 
 // Print a literal string (FormatKind::kLiteral only)
-void LyraPrintLiteral(const char* str);
+void LyraPrintLiteral(void* engine, const char* str);
 
 // Rate-limited warning: prints first N occurrences (per call site), then
 // suppresses. counter_ptr points to a per-site uint32_t global (init 0).
-void LyraWarnRateLimited(const char* msg, uint32_t* counter_ptr);
+void LyraWarnRateLimited(void* engine, const char* msg, uint32_t* counter_ptr);
 
 // Print a formatted value (all FormatKind except kLiteral)
-// - engine: pointer to Engine (required for kTime, can be nullptr for others)
+// - engine: pointer to Engine (required, must not be null; routes output
+//   through the run-session-owned OutputDispatcher borrowed by Engine)
 // - format: FormatKind cast to int32_t (how to render)
 // - value_kind: RuntimeValueKind cast to int32_t (how to interpret bytes)
 // - data: pointer to value bits
@@ -45,7 +46,7 @@ void LyraPrintValue(
     const void* z_mask, int8_t module_timeunit_power);
 
 // Finalize output: newline for kDisplay (0), nothing for kWrite (1)
-void LyraPrintEnd(int32_t kind);
+void LyraPrintEnd(void* engine, int32_t kind);
 
 // Register a variable for snapshot. Called at program init.
 // kind: 0 = integral, 1 = real
@@ -56,7 +57,8 @@ void LyraRegisterVar(
     bool is_four_state);
 
 // Output all registered variables. Called before exit.
-void LyraSnapshotVars();
+// run_session_ptr: opaque pointer to lyra::runtime::RunSession.
+void LyraSnapshotVars(void* run_session_ptr);
 
 // $fopen with mode (FD mode) - returns int32, 0 on failure
 // engine: opaque pointer to lyra::runtime::Engine

--- a/include/lyra/runtime/marshal.hpp
+++ b/include/lyra/runtime/marshal.hpp
@@ -34,8 +34,8 @@ enum class RuntimeValueKind : int32_t {
 //   output_width: field width (-1 = auto, 0 = minimal, >0 = explicit)
 //   precision: decimal precision for reals (-1 = default)
 //   zero_pad, left_align: formatting flags
-//   engine_ptr: pointer to Engine (required for kTime, can be nullptr for
-//     others)
+//   engine_ptr: pointer to Engine (required for kTime; nullable for pure
+//     formatting paths like $sformat where caller explicitly passes null)
 //   module_timeunit_power: timeunit of the value (for kTime: e.g., -9 for ns)
 //   unknown_data: pointer to unknown plane (null for 2-state). When set, bit i
 //     is X if unknown[i]=1 && data[i]=0, Z if unknown[i]=1 && data[i]=1.
@@ -44,7 +44,7 @@ enum class RuntimeValueKind : int32_t {
 inline auto FormatRuntimeValue(
     FormatKind kind, RuntimeValueKind value_kind, const void* data,
     int32_t width, bool is_signed, int32_t output_width, int32_t precision,
-    bool zero_pad, bool left_align, void* engine_ptr = nullptr,
+    bool zero_pad, bool left_align, void* engine_ptr,
     int8_t module_timeunit_power = -9, const void* unknown_data = nullptr)
     -> std::string {
   // Handle string specially - data IS the string pointer

--- a/include/lyra/runtime/output_sink.hpp
+++ b/include/lyra/runtime/output_sink.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <string>
 #include <string_view>
 #include <utility>
 
@@ -9,25 +10,57 @@ namespace lyra::runtime {
 // Output sink callback type: receives text to be output.
 using OutputSink = std::function<void(std::string_view)>;
 
-// Set global output sink. Pass nullptr to restore default (stdout).
-// Not thread-safe: set before starting simulation, restore after.
-void SetOutputSink(OutputSink sink);
+// Owns simulation output state: sink callback and pending fragment buffer.
+// One instance per run session, borrowed by Engine during simulation.
+class OutputDispatcher {
+ public:
+  // Append one fragment of a user-facing simulation record.
+  void AppendSimOutputFragment(std::string_view text);
 
-// Get current output sink (may be empty if default stdout is active).
-auto GetOutputSink() -> OutputSink;
+  // Complete one user-facing simulation record (append newline, write, clear).
+  void FinishSimOutputRecord();
 
-// Write to current output sink (stdout if no sink set).
-void WriteOutput(std::string_view text);
+  // Drain pending $write fragments without newline. Call before protocol
+  // emission or termination to preserve stream ordering.
+  void DrainSimOutputBuffer();
 
-// RAII guard for output sink. Restores previous sink on destruction.
-// Use this instead of raw SetOutputSink() to ensure cleanup on early returns.
+  // Emit one complete machine-readable protocol/data record.
+  void WriteProtocolRecord(std::string_view text);
+
+  // Install or clear the output sink.
+  void SetSink(OutputSink sink) {
+    sink_ = std::move(sink);
+  }
+
+  // Get the current output sink (may be empty).
+  [[nodiscard]] auto GetSink() const -> const OutputSink& {
+    return sink_;
+  }
+
+ private:
+  OutputSink sink_;
+  std::string pending_sim_output_;
+
+  // Write text to the current sink, or stdout if no sink is set.
+  void WriteTo(std::string_view text);
+};
+
+// Run-lifetime session. Owns services that must survive through
+// simulation + epilogue. Currently: output dispatch only.
+struct RunSession {
+  OutputDispatcher output;
+};
+
+// RAII guard for output sink on a specific OutputDispatcher.
+// Installs the sink on construction, restores the previous sink on destruction.
 class OutputSinkScope {
  public:
-  explicit OutputSinkScope(OutputSink sink) : prev_(GetOutputSink()) {
-    SetOutputSink(std::move(sink));
+  OutputSinkScope(OutputDispatcher& target, OutputSink sink)
+      : target_(target), prev_(target.GetSink()) {
+    target_.SetSink(std::move(sink));
   }
   ~OutputSinkScope() {
-    SetOutputSink(std::move(prev_));
+    target_.SetSink(std::move(prev_));
   }
 
   OutputSinkScope(const OutputSinkScope&) = delete;
@@ -36,6 +69,7 @@ class OutputSinkScope {
   auto operator=(OutputSinkScope&&) -> OutputSinkScope& = delete;
 
  private:
+  OutputDispatcher& target_;
   OutputSink prev_;
 };
 

--- a/include/lyra/runtime/process_meta.hpp
+++ b/include/lyra/runtime/process_meta.hpp
@@ -6,6 +6,8 @@
 
 namespace lyra::runtime {
 
+class OutputDispatcher;
+
 enum class ProcessKind : uint8_t {
   kInitial,
   kAlways,
@@ -52,8 +54,8 @@ class ProcessMetaRegistry {
   // Signal-safe: writes one line to fd via write(2). No allocation.
   void WriteAsyncSignalSafe(int fd, uint32_t process_id) const;
 
-  // Debug dump to stdout.
-  void DumpSummary() const;
+  // Debug dump via output dispatcher.
+  void DumpSummary(OutputDispatcher& out) const;
 
   // Access a NUL-terminated string from the pool by offset.
   // Returns "" for offset 0 or out-of-range.

--- a/include/lyra/runtime/simulation.hpp
+++ b/include/lyra/runtime/simulation.hpp
@@ -63,7 +63,8 @@ void LyraRunProcessSync(LyraProcessFunc process, void* state);
 void LyraRunSimulation(
     LyraProcessFunc* connection_funcs, void** states, uint32_t num_processes,
     const char** plusargs, uint32_t num_plusargs, const char** instance_paths,
-    uint32_t num_instance_paths, const LyraRuntimeAbi* abi);
+    uint32_t num_instance_paths, const LyraRuntimeAbi* abi,
+    void* run_session_ptr);
 
 // $test$plusargs: prefix match against plusargs.
 // Query is LyraStringHandle (matches SV string operand lowering).
@@ -144,7 +145,8 @@ auto LyraResolveBaseDir(const char* argv0) -> const char*;
 void LyraInitRuntime(const char* fs_base_dir, uint32_t iteration_limit);
 
 // Print final simulation time as __LYRA_TIME__=<N> for test harness.
-void LyraReportTime();
+// run_session_ptr: opaque pointer to lyra::runtime::RunSession.
+void LyraReportTime(void* run_session_ptr);
 
 // Monitor check program type: uses canonical MonitorCheckProgramFn from
 // observer.hpp.

--- a/include/lyra/runtime/slot_meta.hpp
+++ b/include/lyra/runtime/slot_meta.hpp
@@ -8,6 +8,8 @@
 
 namespace lyra::runtime {
 
+class OutputDispatcher;
+
 // Storage layout classification for a design slot.
 // These are STORAGE categories, not SV syntax categories:
 //   kPacked2:   snapshotable bytes, one plane, no unknown plane
@@ -133,9 +135,10 @@ class SlotMetaRegistry {
   // to build the registry from structured inputs instead of word tables.
   void AppendSlot(SlotMeta meta);
 
-  // Machine-stable dump to WriteOutput. Includes version and count header.
+  // Machine-stable dump via WriteProtocolRecord. Includes version and count
+  // header.
   // Called right after registry construction, before simulation runs.
-  void DumpSummary() const;
+  void DumpSummary(OutputDispatcher& out) const;
 
  private:
   [[noreturn]] void ThrowOutOfRange(uint32_t slot_id) const;

--- a/include/lyra/runtime/string.hpp
+++ b/include/lyra/runtime/string.hpp
@@ -49,7 +49,8 @@ void LyraStringRelease(LyraStringHandle handle);
 // Does NOT retain - reads immediately; handle must be valid for call duration.
 // spec: pointer to format specification (width, alignment, etc.)
 void LyraPrintString(
-    LyraStringHandle handle, const lyra::runtime::LyraFormatSpec* spec);
+    void* engine, LyraStringHandle handle,
+    const lyra::runtime::LyraFormatSpec* spec);
 
 // Get a non-owning view of string data (ptr + len).
 // Does NOT transfer ownership. Returned pointer valid while handle is valid.

--- a/include/lyra/trace/summary_trace_sink.hpp
+++ b/include/lyra/trace/summary_trace_sink.hpp
@@ -7,6 +7,10 @@
 #include "lyra/runtime/signal_coord.hpp"
 #include "lyra/trace/trace_sink.hpp"
 
+namespace lyra::runtime {
+class OutputDispatcher;
+}  // namespace lyra::runtime
+
 namespace lyra::trace {
 
 // Default summary sink for --trace compatibility output.
@@ -20,7 +24,7 @@ class SummaryTraceSink : public TraceSink {
  public:
   void OnEvent(const TraceEvent& event) override;
 
-  void PrintSummary() const;
+  void PrintSummary(lyra::runtime::OutputDispatcher& out) const;
 
   // Reset all counters to zero. Called by TraceManager when starting a
   // new trace session (false->true enable transition).

--- a/include/lyra/trace/text_trace_sink.hpp
+++ b/include/lyra/trace/text_trace_sink.hpp
@@ -9,6 +9,10 @@
 #include "lyra/trace/instance_trace_resolver.hpp"
 #include "lyra/trace/trace_sink.hpp"
 
+namespace lyra::runtime {
+class OutputDispatcher;
+}  // namespace lyra::runtime
+
 namespace lyra::trace {
 
 // Text signal trace sink: emits compact one-line value-change output.
@@ -36,8 +40,10 @@ namespace lyra::trace {
 // not a silently dropped event.
 class TextTraceSink : public TraceSink {
  public:
-  // Borrow stdout for output.
-  explicit TextTraceSink(const runtime::TraceSignalMetaRegistry* meta);
+  // Borrow stdout for output via explicit dispatcher.
+  TextTraceSink(
+      const runtime::TraceSignalMetaRegistry* meta,
+      runtime::OutputDispatcher* output_dispatcher);
 
   // Own a file at the given path for output.
   TextTraceSink(
@@ -75,6 +81,7 @@ class TextTraceSink : public TraceSink {
 
   const runtime::TraceSignalMetaRegistry* meta_;
   const InstanceTraceResolver* resolver_ = nullptr;
+  runtime::OutputDispatcher* output_dispatcher_ = nullptr;
   std::unique_ptr<FILE, FileCloser> output_;
   uint64_t current_time_ = 0;
   uint32_t current_delta_ = 0;

--- a/include/lyra/trace/trace_manager.hpp
+++ b/include/lyra/trace/trace_manager.hpp
@@ -98,7 +98,7 @@ class TraceManager {
 
   // Print the most recent session's summary to stdout. Delegates to the
   // built-in summary sink. If tracing was never enabled, prints zeros.
-  void PrintSummary() const;
+  void PrintSummary(lyra::runtime::OutputDispatcher& out) const;
 
  private:
   void Dispatch(const TraceEvent& event);

--- a/src/lyra/driver/run_jit.cpp
+++ b/src/lyra/driver/run_jit.cpp
@@ -20,6 +20,7 @@
 #include "lyra/lowering/origin_map_lookup.hpp"
 #include "lyra/runtime/artifact_names.hpp"
 #include "lyra/runtime/feature_flags.hpp"
+#include "lyra/runtime/output_sink.hpp"
 #include "pipeline.hpp"
 #include "process_stats.hpp"
 #include "runtime_path.hpp"
@@ -233,7 +234,8 @@ auto RunJit(const ValidatedCompilationInput& input) -> int {
   int exit_code = 0;
   {
     PhaseTimer timer(output, Phase::kSim, HeartbeatPolicy::kEnabled);
-    exit_code = session->Run();
+    lyra::runtime::RunSession run_session;
+    exit_code = session->Run(run_session);
   }
   output.Flush();
   return exit_code;

--- a/src/lyra/hir/dumper.cpp
+++ b/src/lyra/hir/dumper.cpp
@@ -175,6 +175,7 @@ void Dumper::Dump(ProcessId id) {
       case ProcessKind::kFinal:
         return "final";
     }
+    return "unknown";
   }();
 
   *out_ << kind_str << " ";
@@ -540,6 +541,14 @@ void Dumper::Dump(StatementId id) {
       }
       break;
     }
+
+    case StatementKind::kNamedEventWait:
+      *out_ << "@(named_event);\n";
+      break;
+
+    case StatementKind::kEventTrigger:
+      *out_ << "-> event;\n";
+      break;
   }
 }
 
@@ -779,6 +788,7 @@ void Dumper::Dump(ExpressionId id) {
                   case Severity::kError:
                     return "$error";
                 }
+                return "$unknown";
               }();
               *out_ << name << "(";
               bool first = true;

--- a/src/lyra/llvm_backend/context_runtime.cpp
+++ b/src/lyra/llvm_backend/context_runtime.cpp
@@ -10,10 +10,10 @@ namespace lyra::lowering::mir_to_llvm {
 
 auto Context::GetLyraPrintLiteral() -> llvm::Function* {
   if (lyra_print_literal_ == nullptr) {
-    // void LyraPrintLiteral(const char* str)
+    // void LyraPrintLiteral(void* engine, const char* str)
+    auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
     auto* fn_type = llvm::FunctionType::get(
-        llvm::Type::getVoidTy(*llvm_context_),
-        {llvm::PointerType::getUnqual(*llvm_context_)}, false);
+        llvm::Type::getVoidTy(*llvm_context_), {ptr_ty, ptr_ty}, false);
     lyra_print_literal_ = llvm::Function::Create(
         fn_type, llvm::Function::ExternalLinkage, "LyraPrintLiteral",
         llvm_module_.get());
@@ -23,10 +23,10 @@ auto Context::GetLyraPrintLiteral() -> llvm::Function* {
 
 auto Context::GetLyraWarnRateLimited() -> llvm::Function* {
   if (lyra_warn_rate_limited_ == nullptr) {
-    // void LyraWarnRateLimited(const char* msg, uint32_t* counter_ptr)
+    // void LyraWarnRateLimited(void* engine, const char* msg, uint32_t* ctr)
     auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
     auto* fn_type = llvm::FunctionType::get(
-        llvm::Type::getVoidTy(*llvm_context_), {ptr_ty, ptr_ty}, false);
+        llvm::Type::getVoidTy(*llvm_context_), {ptr_ty, ptr_ty, ptr_ty}, false);
     lyra_warn_rate_limited_ = llvm::Function::Create(
         fn_type, llvm::Function::ExternalLinkage, "LyraWarnRateLimited",
         llvm_module_.get());
@@ -141,10 +141,10 @@ auto Context::GetFormatSpecType() -> llvm::StructType* {
 
 auto Context::GetLyraPrintString() -> llvm::Function* {
   if (lyra_print_string_ == nullptr) {
-    // void LyraPrintString(void* handle, const LyraFormatSpec* spec)
+    // void LyraPrintString(void* engine, void* handle, const LyraFormatSpec*)
     auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
     auto* fn_type = llvm::FunctionType::get(
-        llvm::Type::getVoidTy(*llvm_context_), {ptr_ty, ptr_ty}, false);
+        llvm::Type::getVoidTy(*llvm_context_), {ptr_ty, ptr_ty, ptr_ty}, false);
     lyra_print_string_ = llvm::Function::Create(
         fn_type, llvm::Function::ExternalLinkage, "LyraPrintString",
         llvm_module_.get());
@@ -154,10 +154,11 @@ auto Context::GetLyraPrintString() -> llvm::Function* {
 
 auto Context::GetLyraPrintEnd() -> llvm::Function* {
   if (lyra_print_end_ == nullptr) {
-    // void LyraPrintEnd(int32_t kind)
+    // void LyraPrintEnd(void* engine, int32_t kind)
+    auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
+    auto* i32_ty = llvm::Type::getInt32Ty(*llvm_context_);
     auto* fn_type = llvm::FunctionType::get(
-        llvm::Type::getVoidTy(*llvm_context_),
-        {llvm::Type::getInt32Ty(*llvm_context_)}, false);
+        llvm::Type::getVoidTy(*llvm_context_), {ptr_ty, i32_ty}, false);
     lyra_print_end_ = llvm::Function::Create(
         fn_type, llvm::Function::ExternalLinkage, "LyraPrintEnd",
         llvm_module_.get());
@@ -183,8 +184,10 @@ auto Context::GetLyraRegisterVar() -> llvm::Function* {
 
 auto Context::GetLyraSnapshotVars() -> llvm::Function* {
   if (lyra_snapshot_vars_ == nullptr) {
-    auto* fn_type =
-        llvm::FunctionType::get(llvm::Type::getVoidTy(*llvm_context_), false);
+    // void LyraSnapshotVars(void* run_session_ptr)
+    auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
+    auto* fn_type = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*llvm_context_), {ptr_ty}, false);
     lyra_snapshot_vars_ = llvm::Function::Create(
         fn_type, llvm::Function::ExternalLinkage, "LyraSnapshotVars",
         llvm_module_.get());
@@ -327,12 +330,14 @@ auto Context::GetLyraRunSimulation() -> llvm::Function* {
     // void LyraRunSimulation(ptr* processes, ptr* states, uint32_t num,
     //                        const char** plusargs, uint32_t num_plusargs,
     //                        const char** instance_paths, uint32_t num_paths,
-    //                        const LyraRuntimeAbi* abi)
+    //                        const LyraRuntimeAbi* abi,
+    //                        void* run_session_ptr)
     auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
     auto* i32_ty = llvm::Type::getInt32Ty(*llvm_context_);
     auto* fn_type = llvm::FunctionType::get(
         llvm::Type::getVoidTy(*llvm_context_),
-        {ptr_ty, ptr_ty, i32_ty, ptr_ty, i32_ty, ptr_ty, i32_ty, ptr_ty},
+        {ptr_ty, ptr_ty, i32_ty, ptr_ty, i32_ty, ptr_ty, i32_ty, ptr_ty,
+         ptr_ty},
         false);
     lyra_run_simulation_ = llvm::Function::Create(
         fn_type, llvm::Function::ExternalLinkage, "LyraRunSimulation",
@@ -985,13 +990,40 @@ auto Context::GetLyraResolveBaseDir() -> llvm::Function* {
 
 auto Context::GetLyraReportTime() -> llvm::Function* {
   if (lyra_report_time_ == nullptr) {
-    auto* fn_type =
-        llvm::FunctionType::get(llvm::Type::getVoidTy(*llvm_context_), false);
+    // void LyraReportTime(void* run_session_ptr)
+    auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
+    auto* fn_type = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*llvm_context_), {ptr_ty}, false);
     lyra_report_time_ = llvm::Function::Create(
         fn_type, llvm::Function::ExternalLinkage, "LyraReportTime",
         llvm_module_.get());
   }
   return lyra_report_time_;
+}
+
+auto Context::GetLyraCreateRunSession() -> llvm::Function* {
+  if (lyra_create_run_session_ == nullptr) {
+    // void* LyraCreateRunSession()
+    auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
+    auto* fn_type = llvm::FunctionType::get(ptr_ty, false);
+    lyra_create_run_session_ = llvm::Function::Create(
+        fn_type, llvm::Function::ExternalLinkage, "LyraCreateRunSession",
+        llvm_module_.get());
+  }
+  return lyra_create_run_session_;
+}
+
+auto Context::GetLyraDestroyRunSession() -> llvm::Function* {
+  if (lyra_destroy_run_session_ == nullptr) {
+    // void LyraDestroyRunSession(void* session)
+    auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
+    auto* fn_type = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*llvm_context_), {ptr_ty}, false);
+    lyra_destroy_run_session_ = llvm::Function::Create(
+        fn_type, llvm::Function::ExternalLinkage, "LyraDestroyRunSession",
+        llvm_module_.get());
+  }
+  return lyra_destroy_run_session_;
 }
 
 auto Context::GetLyraDynArrayNew() -> llvm::Function* {

--- a/src/lyra/llvm_backend/context_runtime.cpp
+++ b/src/lyra/llvm_backend/context_runtime.cpp
@@ -1536,10 +1536,11 @@ auto Context::GetLyraReadmemNoNotify() -> llvm::Function* {
     auto* i64_ty = llvm::Type::getInt64Ty(*llvm_context_);
     auto* i1_ty = llvm::Type::getInt1Ty(*llvm_context_);
     auto* void_ty = llvm::Type::getVoidTy(*llvm_context_);
+    // No engine_ptr parameter: this variant does not notify.
     auto* fn_type = llvm::FunctionType::get(
         void_ty,
-        {ptr_ty, ptr_ty, ptr_ty, i32_ty, i32_ty, i32_ty, i32_ty, i64_ty, i64_ty,
-         i64_ty, i64_ty, i1_ty, i32_ty},
+        {ptr_ty, ptr_ty, i32_ty, i32_ty, i32_ty, i32_ty, i64_ty, i64_ty, i64_ty,
+         i64_ty, i1_ty, i32_ty},
         false);
     lyra_readmem_no_notify_ = llvm::Function::Create(
         fn_type, llvm::Function::ExternalLinkage, "LyraReadmemNoNotify",

--- a/src/lyra/llvm_backend/emit_design_main.cpp
+++ b/src/lyra/llvm_backend/emit_design_main.cpp
@@ -142,6 +142,7 @@ struct MainFunctionSetup {
   llvm::Function* main_func = nullptr;
   llvm::BasicBlock* exit_block = nullptr;
   llvm::Value* design_state = nullptr;
+  llvm::Value* run_session_ptr = nullptr;
 };
 
 auto CreateMainFunction(
@@ -155,14 +156,21 @@ auto CreateMainFunction(
 
   llvm::FunctionType* main_type = nullptr;
   if (argv_forwarding) {
+    // AOT: int main(int argc, char** argv)
     auto* i32_ty = llvm::Type::getInt32Ty(ctx);
     auto* ptr_ty = llvm::PointerType::getUnqual(ctx);
     main_type = llvm::FunctionType::get(i32_ty, {i32_ty, ptr_ty}, false);
   } else {
-    main_type = llvm::FunctionType::get(llvm::Type::getInt32Ty(ctx), false);
+    // JIT: int main(void* run_session_ptr)
+    auto* ptr_ty = llvm::PointerType::getUnqual(ctx);
+    main_type =
+        llvm::FunctionType::get(llvm::Type::getInt32Ty(ctx), {ptr_ty}, false);
   }
+  // JIT uses "lyra_entry" to avoid C runtime interference with "main".
+  // AOT uses "main" as the real program entry point.
+  const char* entry_name = argv_forwarding ? "main" : "lyra_entry";
   auto* main_func = llvm::Function::Create(
-      main_type, llvm::Function::ExternalLinkage, "main", &mod);
+      main_type, llvm::Function::ExternalLinkage, entry_name, &mod);
 
   auto* entry = llvm::BasicBlock::Create(ctx, "entry", main_func);
   auto* exit_block = llvm::BasicBlock::Create(ctx, "exit", main_func);
@@ -172,10 +180,23 @@ auto CreateMainFunction(
   auto* arena_ty = llvm::ArrayType::get(i8_ty, context.GetDesignArenaSize());
   auto* design_state = builder.CreateAlloca(arena_ty, nullptr, "design_state");
 
+  // RunSession lifetime:
+  //   JIT: caller provides run_session_ptr as main's argument
+  //   AOT: main creates RunSession via LyraCreateRunSession()
+  llvm::Value* run_session_ptr = nullptr;
+  if (argv_forwarding) {
+    run_session_ptr = builder.CreateCall(
+        context.GetLyraCreateRunSession(), {}, "run_session");
+  } else {
+    run_session_ptr = main_func->getArg(0);
+    run_session_ptr->setName("run_session_ptr");
+  }
+
   return {
       .main_func = main_func,
       .exit_block = exit_block,
       .design_state = design_state,
+      .run_session_ptr = run_session_ptr,
   };
 }
 
@@ -594,22 +615,21 @@ void EmitRunSimulation(
     Context& context, llvm::Constant* funcs_array, llvm::Value* states_array,
     llvm::Value* num_processes, const PlusargsSetup& plusargs,
     const RealizationEmissionResult::ObservationMeta& observation_meta,
-    llvm::Value* abi_alloca) {
+    llvm::Value* abi_alloca, llvm::Value* run_session_ptr) {
   auto& builder = context.GetBuilder();
 
-  // Instance paths now come from constructor result, not compile-time globals.
   builder.CreateCall(
       context.GetLyraRunSimulation(),
       {funcs_array, states_array, num_processes, plusargs.array, plusargs.count,
        observation_meta.instance_paths, observation_meta.instance_path_count,
-       abi_alloca});
+       abi_alloca, run_session_ptr});
 }
 
 void EmitMainExit(
     Context& context, const CuFacts& facts, llvm::Value* design_state,
     const EmitDesignMainInput& input, llvm::BasicBlock* exit_block,
     llvm::Value* abi_alloca, const RealizationEmissionResult& ctor_result,
-    const InspectionPlan& inspection_plan) {
+    const InspectionPlan& inspection_plan, llvm::Value* run_session_ptr) {
   auto& builder = context.GetBuilder();
   auto& ctx = context.GetLlvmContext();
 
@@ -622,15 +642,23 @@ void EmitMainExit(
   // Backend-owned variable inspection from typed placement descriptors.
   if (!inspection_plan.IsEmpty()) {
     EmitVariableInspection(
-        context, facts, inspection_plan, design_state, abi_alloca);
+        context, facts, inspection_plan, design_state, abi_alloca,
+        run_session_ptr);
   }
 
   if (input.hooks != nullptr) {
-    input.hooks->EmitPostSimulationReports(context, design_state, abi_alloca);
+    input.hooks->EmitPostSimulationReports(
+        context, design_state, abi_alloca, run_session_ptr);
   }
 
   if (ctor_result.result_handle != nullptr) {
     builder.CreateCall(ctor_result.destroy_fn, {ctor_result.result_handle});
+  }
+
+  // AOT: destroy the RunSession we created in CreateMainFunction.
+  // JIT: caller owns the RunSession, no cleanup needed here.
+  if (input.main_abi == lowering::mir_to_llvm::MainAbi::kArgvForwarding) {
+    builder.CreateCall(context.GetLyraDestroyRunSession(), {run_session_ptr});
   }
 
   builder.CreateRet(llvm::ConstantInt::get(ctx, llvm::APInt(32, 0)));
@@ -668,7 +696,7 @@ auto EmitDesignMain(
   size_t num_init = session.num_init_processes;
   const auto& realization = session.realization;
 
-  auto [main_func, exit_block, design_state] =
+  auto [main_func, exit_block, design_state, run_session_ptr] =
       CreateMainFunction(context, input.main_abi);
 
   EmitDesignStateZero(context, design_state);
@@ -802,7 +830,7 @@ auto EmitDesignMain(
 
     EmitRunSimulation(
         context, connection_funcs, states_array, num_total_val, plusargs,
-        observation_meta_for_abi, abi_alloca);
+        observation_meta_for_abi, abi_alloca, run_session_ptr);
 
   } else {
     // No simulation processes or kernelized connections. Still need
@@ -835,7 +863,7 @@ auto EmitDesignMain(
 
   EmitMainExit(
       context, facts, design_state, input, exit_block, abi_for_exit,
-      ctor_result, inspection_plan);
+      ctor_result, inspection_plan, run_session_ptr);
 
   return LoweringReport{
       .forwarding_analysis = std::move(forwarding_report),

--- a/src/lyra/llvm_backend/execution.cpp
+++ b/src/lyra/llvm_backend/execution.cpp
@@ -32,12 +32,13 @@
 #include "lyra/common/opt_level.hpp"
 #include "lyra/llvm_backend/ir_optimize.hpp"
 #include "lyra/llvm_backend/lower.hpp"
+#include "lyra/runtime/output_sink.hpp"
 
 namespace lyra::lowering::mir_to_llvm {
 
 struct JitSession::Impl {
   std::unique_ptr<llvm::orc::LLJIT> jit;
-  int (*entry_fn)() = nullptr;
+  int (*entry_fn)(void*) = nullptr;
   JitCompileTimings timings;
   JitOrcStats orc_stats;
 };
@@ -47,8 +48,8 @@ JitSession::~JitSession() = default;
 JitSession::JitSession(JitSession&&) noexcept = default;
 auto JitSession::operator=(JitSession&&) noexcept -> JitSession& = default;
 
-auto JitSession::Run() -> int {
-  return impl_->entry_fn();
+auto JitSession::Run(runtime::RunSession& session) -> int {
+  return impl_->entry_fn(&session);
 }
 
 auto JitSession::Timings() const -> const JitCompileTimings& {
@@ -301,7 +302,7 @@ void InitializeLlvm() {
 // Caller is responsible for wrapping into JitSession.
 struct CompileResult {
   std::unique_ptr<llvm::orc::LLJIT> jit;
-  int (*entry_fn)() = nullptr;
+  int (*entry_fn)(void*) = nullptr;
   JitCompileTimings timings;
   JitOrcStats orc_stats;
 };
@@ -470,7 +471,7 @@ auto CompileJitImpl(
     });
   }
 
-  auto main_sym = (*jit)->lookup("main");
+  auto main_sym = (*jit)->lookup("lyra_entry");
 
   if (progress) {
     progress->stop.store(true, std::memory_order_relaxed);
@@ -480,7 +481,7 @@ auto CompileJitImpl(
   if (!main_sym) {
     return std::unexpected(
         std::format(
-            "symbol 'main' not found: {}",
+            "symbol 'lyra_entry' not found: {}",
             llvm::toString(main_sym.takeError())));
   }
 
@@ -540,7 +541,7 @@ auto CompileJitImpl(
 
   return CompileResult{
       .jit = std::move(*jit),
-      .entry_fn = main_sym->toPtr<int()>(),
+      .entry_fn = main_sym->toPtr<int(void*)>(),
       .timings = timings,
       .orc_stats = std::move(orc_stats),
   };
@@ -582,7 +583,8 @@ auto ExecuteWithOrcJit(
     const JitCompileOptions& options) -> std::expected<int, std::string> {
   auto session = CompileJit(result, runtime_path, options);
   if (!session) return std::unexpected(session.error());
-  return session->Run();
+  runtime::RunSession run_session;
+  return session->Run(run_session);
 }
 
 auto ExecuteWithOrcJitInProcess(
@@ -590,7 +592,8 @@ auto ExecuteWithOrcJitInProcess(
     -> std::expected<int, std::string> {
   auto session = CompileJitInProcess(result, options);
   if (!session) return std::unexpected(session.error());
-  return session->Run();
+  runtime::RunSession run_session;
+  return session->Run(run_session);
 }
 
 }  // namespace lyra::lowering::mir_to_llvm

--- a/src/lyra/llvm_backend/instruction/display.cpp
+++ b/src/lyra/llvm_backend/instruction/display.cpp
@@ -123,6 +123,11 @@ auto EmitStoreNarrowToTemp(
 void LowerLiteralOp(
     llvm::IRBuilder<>& builder, llvm::Value* engine_ptr,
     llvm::Function* print_literal_fn, const mir::FormatOp& op) {
+  if (engine_ptr == nullptr) {
+    throw common::InternalError(
+        "LowerLiteralOp",
+        "engine pointer must be available for LyraPrintLiteral");
+  }
   auto* str_const = builder.CreateGlobalStringPtr(op.literal);
   builder.CreateCall(print_literal_fn, {engine_ptr, str_const});
 }
@@ -138,6 +143,11 @@ void LowerModulePathOp(Context& context) {
 
   auto& builder = context.GetBuilder();
   auto* engine_ptr = context.GetEnginePointer();
+  if (engine_ptr == nullptr) {
+    throw common::InternalError(
+        "LowerModulePathOp",
+        "engine pointer must be available for LyraPrintModulePath");
+  }
   auto* instance_id = context.GetDynamicInstanceId();
 
   builder.CreateCall(
@@ -220,6 +230,11 @@ auto LowerTimeOp(
   }
 
   auto* engine_ptr = context.GetEnginePointer();
+  if (engine_ptr == nullptr) {
+    throw common::InternalError(
+        "LowerTimeOp",
+        "engine pointer must be available for LyraPrintValue (kTime)");
+  }
   builder.CreateCall(
       context.GetLyraPrintValue(),
       {engine_ptr,
@@ -411,6 +426,11 @@ auto LowerDisplayEffect(
     if (!desc_or) return std::unexpected(desc_or.error());
 
     auto* engine = context.GetEnginePointer();
+    if (engine == nullptr) {
+      throw common::InternalError(
+          "LowerDisplayEffect",
+          "engine pointer must be available for LyraFWrite");
+    }
     auto* add_newline = llvm::ConstantInt::get(
         llvm::Type::getInt1Ty(context.GetLlvmContext()),
         display.print_kind == PrintKind::kDisplay ? 1 : 0);
@@ -427,10 +447,15 @@ auto LowerDisplayEffect(
 
   auto& builder = context.GetBuilder();
   auto* i32_ty = llvm::Type::getInt32Ty(context.GetLlvmContext());
+  auto* engine_ptr = context.GetEnginePointer();
+  if (engine_ptr == nullptr) {
+    throw common::InternalError(
+        "LowerDisplayEffect",
+        "engine pointer must be available for LyraPrintEnd");
+  }
   auto* kind_val =
       llvm::ConstantInt::get(i32_ty, static_cast<int32_t>(display.print_kind));
-  builder.CreateCall(
-      context.GetLyraPrintEnd(), {context.GetEnginePointer(), kind_val});
+  builder.CreateCall(context.GetLyraPrintEnd(), {engine_ptr, kind_val});
   return {};
 }
 

--- a/src/lyra/llvm_backend/instruction/display.cpp
+++ b/src/lyra/llvm_backend/instruction/display.cpp
@@ -121,10 +121,10 @@ auto EmitStoreNarrowToTemp(
 }
 
 void LowerLiteralOp(
-    llvm::IRBuilder<>& builder, llvm::Function* print_literal_fn,
-    const mir::FormatOp& op) {
+    llvm::IRBuilder<>& builder, llvm::Value* engine_ptr,
+    llvm::Function* print_literal_fn, const mir::FormatOp& op) {
   auto* str_const = builder.CreateGlobalStringPtr(op.literal);
-  builder.CreateCall(print_literal_fn, {str_const});
+  builder.CreateCall(print_literal_fn, {engine_ptr, str_const});
 }
 
 void LowerModulePathOp(Context& context) {
@@ -187,7 +187,9 @@ auto LowerStringOp(
   return WithStringHandle(
       context, facts, resolver, *op.value, op.type,
       [&](llvm::Value* h) -> Result<void> {
-        builder.CreateCall(context.GetLyraPrintString(), {h, spec_alloca});
+        builder.CreateCall(
+            context.GetLyraPrintString(),
+            {context.GetEnginePointer(), h, spec_alloca});
         return {};
       });
 }
@@ -329,9 +331,16 @@ auto LowerValueOp(
     }
   }
 
+  auto* engine_ptr = context.GetEnginePointer();
+  if (engine_ptr == nullptr) {
+    throw common::InternalError(
+        "LowerValueOp", "engine pointer must be available for LyraPrintValue");
+  }
+
   builder.CreateCall(
       context.GetLyraPrintValue(),
-      {null_ptr, llvm::ConstantInt::get(i32_ty, static_cast<int32_t>(op.kind)),
+      {engine_ptr,
+       llvm::ConstantInt::get(i32_ty, static_cast<int32_t>(op.kind)),
        llvm::ConstantInt::get(i32_ty, static_cast<int32_t>(value_kind)),
        data_ptr, llvm::ConstantInt::get(i32_ty, width),
        llvm::ConstantInt::get(i1_ty, is_signed ? 1 : 0),
@@ -351,7 +360,9 @@ auto LowerFormatOps(
     Result<void> result;
     switch (op.kind) {
       case FormatKind::kLiteral:
-        LowerLiteralOp(context.GetBuilder(), context.GetLyraPrintLiteral(), op);
+        LowerLiteralOp(
+            context.GetBuilder(), context.GetEnginePointer(),
+            context.GetLyraPrintLiteral(), op);
         break;
       case FormatKind::kString:
         result = LowerStringOp(context, facts, resolver, op);
@@ -418,7 +429,8 @@ auto LowerDisplayEffect(
   auto* i32_ty = llvm::Type::getInt32Ty(context.GetLlvmContext());
   auto* kind_val =
       llvm::ConstantInt::get(i32_ty, static_cast<int32_t>(display.print_kind));
-  builder.CreateCall(context.GetLyraPrintEnd(), {kind_val});
+  builder.CreateCall(
+      context.GetLyraPrintEnd(), {context.GetEnginePointer(), kind_val});
   return {};
 }
 

--- a/src/lyra/llvm_backend/instruction/effect.cpp
+++ b/src/lyra/llvm_backend/instruction/effect.cpp
@@ -528,7 +528,11 @@ auto LowerMemIOEffect(
             args.push_back(readmem_slot_expr->Emit(builder));
             builder.CreateCall(context.GetLyraReadmemGlobal(), args);
           } else {
-            builder.CreateCall(context.GetLyraReadmemNoNotify(), common_args);
+            // NoNotify has no engine_ptr parameter: skip common_args[0].
+            std::vector<llvm::Value*> no_notify_args(
+                common_args.begin() + 1, common_args.end());
+            builder.CreateCall(
+                context.GetLyraReadmemNoNotify(), no_notify_args);
           }
         } else {
           std::vector<llvm::Value*> args = {

--- a/src/lyra/llvm_backend/lower.cpp
+++ b/src/lyra/llvm_backend/lower.cpp
@@ -382,7 +382,8 @@ auto FinalizeModule(CodegenSession session, LoweringReport report)
 
 void EmitVariableInspection(
     Context& context, const CuFacts& facts, const InspectionPlan& plan,
-    llvm::Value* design_state, llvm::Value* abi_ptr) {
+    llvm::Value* design_state, llvm::Value* abi_ptr,
+    llvm::Value* run_session_ptr) {
   if (plan.IsEmpty()) {
     return;
   }
@@ -438,11 +439,12 @@ void EmitVariableInspection(
     builder.SetInsertPoint(skip_bb);
   }
 
-  builder.CreateCall(context.GetLyraSnapshotVars());
+  builder.CreateCall(context.GetLyraSnapshotVars(), {run_session_ptr});
 }
 
-void EmitTimeReport(Context& context) {
-  context.GetBuilder().CreateCall(context.GetLyraReportTime());
+void EmitTimeReport(Context& context, llvm::Value* run_session_ptr) {
+  context.GetBuilder().CreateCall(
+      context.GetLyraReportTime(), {run_session_ptr});
 }
 
 auto DumpLlvmIr(const llvm::Module& module) -> std::string {

--- a/src/lyra/lowering/ast_to_hir/design.cpp
+++ b/src/lyra/lowering/ast_to_hir/design.cpp
@@ -29,7 +29,6 @@
 #include "lyra/common/module_identity.hpp"
 #include "lyra/common/source_span.hpp"
 #include "lyra/common/symbol.hpp"
-#include "lyra/common/timescale_format.hpp"
 #include "lyra/common/type.hpp"
 #include "lyra/hir/arena.hpp"
 #include "lyra/hir/design.hpp"
@@ -819,16 +818,13 @@ auto LowerDesign(
 
     // Extract timescale from the representative instance's scope.
     uint32_t rep_idx = spec_map.groups[g].instance_indices[0];
-    auto ts = all_instances[rep_idx]->body.getTimeScale();
+    auto resolved =
+        ResolveScopeTimeScale(all_instances[rep_idx]->body.getTimeScale());
     body_timescale_table.push_back(
         common::BodyTimeScale{
             .body_id = body_id.value,
-            .unit_power =
-                ts ? static_cast<int8_t>(TimeScaleValueToPower(ts->base))
-                   : static_cast<int8_t>(kDefaultTimeScalePower),
-            .precision_power =
-                ts ? static_cast<int8_t>(TimeScaleValueToPower(ts->precision))
-                   : static_cast<int8_t>(kDefaultTimeScalePower),
+            .unit_power = static_cast<int8_t>(resolved.unit_power),
+            .precision_power = static_cast<int8_t>(resolved.precision_power),
         });
 
     // Map all instance body scopes in this group to the same body index.

--- a/src/lyra/lowering/ast_to_hir/module.cpp
+++ b/src/lyra/lowering/ast_to_hir/module.cpp
@@ -231,6 +231,7 @@ auto LowerModuleBody(
               .functions = std::move(functions),
               .tasks = std::move(tasks),
               .dpi_imports = std::move(dpi_imports),
+              .dpi_exports = {},
               .arena = std::move(body_arena),
               .constant_arena = std::move(body_constant_arena),
           },

--- a/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
@@ -3,10 +3,8 @@
 #include <cstdint>
 
 #include "lyra/common/internal_error.hpp"
-#include "lyra/common/timescale_format.hpp"
 #include "lyra/lowering/ast_to_hir/context.hpp"
 #include "lyra/lowering/ast_to_hir/delay_scaler.hpp"
-#include "lyra/lowering/ast_to_hir/symbol_registrar.hpp"
 #include "lyra/lowering/ast_to_hir/timescale.hpp"
 
 namespace lyra::lowering::ast_to_hir {
@@ -17,13 +15,7 @@ auto ComputeFrame(Context& ctx, const slang::ast::Scope& scope)
     -> LoweringFrame {
   LoweringFrame frame{};
 
-  // Compute scope's timeunit
-  auto ts = scope.getTimeScale();
-  if (ts) {
-    frame.unit_power = TimeScaleValueToPower(ts->base);
-  } else {
-    frame.unit_power = kDefaultTimeScalePower;
-  }
+  frame.unit_power = ResolveScopeUnitPower(scope.getTimeScale());
 
   // Get global precision (computed once per compilation, cached in Context)
   if (!ctx.cached_global_precision) {

--- a/src/lyra/lowering/ast_to_hir/package.cpp
+++ b/src/lyra/lowering/ast_to_hir/package.cpp
@@ -170,6 +170,7 @@ auto LowerPackage(
       .variables = std::move(variables),
       .functions = std::move(functions),
       .dpi_imports = std::move(dpi_imports),
+      .dpi_exports = {},
       .init_process = init_process,
   };
 }

--- a/src/lyra/lowering/ast_to_hir/statement.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement.cpp
@@ -198,7 +198,10 @@ auto LowerAndNormalizeActionBranch(
     -> LoweredActionBranch {
   // Step 1: absent branch.
   if (slang_action == nullptr) {
-    return {.kind = LoweredActionBranchKind::kAbsent};
+    return {
+        .kind = LoweredActionBranchKind::kAbsent,
+        .statement_id = std::nullopt,
+        .call_expr_id = hir::kInvalidExpressionId};
   }
 
   // Step 2: lower the child statement.
@@ -207,10 +210,16 @@ auto LowerAndNormalizeActionBranch(
     // LowerStatement returns nullopt for Empty statements (no-op).
     // slang emits Empty as ifTrue for bare `assert #0 (cond);` with
     // no user action. Treat as absent, not as a lowering error.
-    return {.kind = LoweredActionBranchKind::kAbsent};
+    return {
+        .kind = LoweredActionBranchKind::kAbsent,
+        .statement_id = std::nullopt,
+        .call_expr_id = hir::kInvalidExpressionId};
   }
   if (!*result) {
-    return {.kind = LoweredActionBranchKind::kInvalid};
+    return {
+        .kind = LoweredActionBranchKind::kInvalid,
+        .statement_id = std::nullopt,
+        .call_expr_id = hir::kInvalidExpressionId};
   }
   hir::StatementId stmt_id = *result;
 

--- a/src/lyra/lowering/ast_to_hir/system_call.cpp
+++ b/src/lyra/lowering/ast_to_hir/system_call.cpp
@@ -47,7 +47,7 @@ auto GetModuleTimeunitPower(const ExpressionLoweringView& view) -> int8_t {
   if (view.frame != nullptr) {
     return static_cast<int8_t>(view.frame->unit_power);
   }
-  return static_cast<int8_t>(kDefaultTimeScalePower);
+  return static_cast<int8_t>(ResolveScopeUnitPower(std::nullopt));
 }
 
 // Convert PrintRadix to default FormatKind
@@ -1129,8 +1129,8 @@ struct LowerVisitor {
         std::get<slang::ast::CallExpression::SystemCallInfo>(call->subroutine);
 
     std::string scope_name;
-    int unit_power = kDefaultTimeScalePower;
-    int prec_power = kDefaultTimeScalePower;
+    int unit_power = 0;
+    int prec_power = 0;
 
     if (call->arguments().empty()) {
       const auto* body = sys_info.scope->getContainingInstance();
@@ -1140,11 +1140,9 @@ struct LowerVisitor {
         return hir::kInvalidExpressionId;
       }
       scope_name = body->getDefinition().name;
-      auto ts = body->getTimeScale();
-      if (ts) {
-        unit_power = TimeScaleValueToPower(ts->base);
-        prec_power = TimeScaleValueToPower(ts->precision);
-      }
+      auto resolved = ResolveScopeTimeScale(body->getTimeScale());
+      unit_power = resolved.unit_power;
+      prec_power = resolved.precision_power;
     } else {
       const auto* arg_expr = call->arguments()[0];
       if (arg_expr->kind != slang::ast::ExpressionKind::ArbitrarySymbol) {
@@ -1169,21 +1167,18 @@ struct LowerVisitor {
           break;
         case slang::ast::SymbolKind::CompilationUnit: {
           scope_name = "$unit";
-          auto ts = sym.as<slang::ast::CompilationUnitSymbol>().getTimeScale();
-          if (ts) {
-            unit_power = TimeScaleValueToPower(ts->base);
-            prec_power = TimeScaleValueToPower(ts->precision);
-          }
+          auto resolved = ResolveScopeTimeScale(
+              sym.as<slang::ast::CompilationUnitSymbol>().getTimeScale());
+          unit_power = resolved.unit_power;
+          prec_power = resolved.precision_power;
           break;
         }
         case slang::ast::SymbolKind::Instance: {
           const auto& inst = sym.as<slang::ast::InstanceSymbol>();
           scope_name = inst.name;
-          auto ts = inst.body.getTimeScale();
-          if (ts) {
-            unit_power = TimeScaleValueToPower(ts->base);
-            prec_power = TimeScaleValueToPower(ts->precision);
-          }
+          auto resolved = ResolveScopeTimeScale(inst.body.getTimeScale());
+          unit_power = resolved.unit_power;
+          prec_power = resolved.precision_power;
           break;
         }
         default:

--- a/src/lyra/lowering/ast_to_hir/system_function_desugar.cpp
+++ b/src/lyra/lowering/ast_to_hir/system_function_desugar.cpp
@@ -27,7 +27,6 @@
 #include "lyra/common/math_fn.hpp"
 #include "lyra/common/overloaded.hpp"
 #include "lyra/common/source_span.hpp"
-#include "lyra/common/timescale_format.hpp"
 #include "lyra/common/type.hpp"
 #include "lyra/hir/arena.hpp"
 #include "lyra/hir/expression.hpp"
@@ -827,19 +826,13 @@ auto LowerDesugarableSystemFunction(
                 std::get<slang::ast::CallExpression::SystemCallInfo>(
                     call.subroutine);
 
-            auto extract_power = [&](std::optional<slang::TimeScale> ts) {
-              if (!ts) {
-                return kDefaultTimeScalePower;
-              }
-              return TimeScaleValueToPower(
-                  kind == TimeScaleSysFnKind::kTimeunit ? ts->base
-                                                        : ts->precision);
-            };
+            // Resolve the scope argument into an optional<TimeScale>.
+            // Shared across both paths: argument validation and $root.
+            std::optional<slang::TimeScale> scope_ts;
+            bool is_root = false;
 
-            int power = kDefaultTimeScalePower;
             if (call.arguments().empty()) {
-              auto ts = sys_info.scope->getTimeScale();
-              power = extract_power(ts);
+              scope_ts = sys_info.scope->getTimeScale();
             } else {
               const auto* arg_expr = call.arguments()[0];
               if (arg_expr->kind !=
@@ -855,19 +848,30 @@ auto LowerDesugarableSystemFunction(
               const auto& sym = *arg.symbol;
 
               if (sym.kind == slang::ast::SymbolKind::Root) {
-                power =
-                    ComputeGlobalPrecision(sys_info.scope->getCompilation());
+                is_root = true;
               } else if (sym.kind == slang::ast::SymbolKind::CompilationUnit) {
-                auto ts = sym.as<CompilationUnitSymbol>().getTimeScale();
-                power = extract_power(ts);
+                scope_ts = sym.as<CompilationUnitSymbol>().getTimeScale();
               } else if (sym.kind == slang::ast::SymbolKind::Instance) {
-                auto ts = sym.as<InstanceSymbol>().body.getTimeScale();
-                power = extract_power(ts);
+                scope_ts = sym.as<InstanceSymbol>().body.getTimeScale();
               } else {
                 ctx->ErrorFmt(
                     span, "{}() unexpected symbol kind in argument",
                     call.getSubroutineName());
                 return hir::kInvalidExpressionId;
+              }
+            }
+
+            int power = 0;
+            if (is_root) {
+              power = ComputeGlobalPrecision(sys_info.scope->getCompilation());
+            } else {
+              switch (kind) {
+                case TimeScaleSysFnKind::kTimeunit:
+                  power = ResolveScopeUnitPower(scope_ts);
+                  break;
+                case TimeScaleSysFnKind::kTimeprecision:
+                  power = ResolveScopePrecisionPower(scope_ts);
+                  break;
               }
             }
 

--- a/src/lyra/mir/dpi_verify.cpp
+++ b/src/lyra/mir/dpi_verify.cpp
@@ -100,6 +100,7 @@ void ValidateDpiCallContract(
         }
         break;
       case ParameterDirection::kRef:
+      case ParameterDirection::kConstRef:
         throw common::InternalError(
             caller, std::format("param {}: ref not supported in DPI", i));
     }

--- a/src/lyra/runtime/activation_trace_format.cpp
+++ b/src/lyra/runtime/activation_trace_format.cpp
@@ -22,6 +22,8 @@ auto WakeCauseLabel(WakeCause cause) -> const char* {
       return "initial";
     case WakeCause::kRepeat:
       return "repeat";
+    case WakeCause::kEvent:
+      return "event";
   }
   return "unknown";
 }

--- a/src/lyra/runtime/assertions.cpp
+++ b/src/lyra/runtime/assertions.cpp
@@ -72,6 +72,7 @@ void Engine::EnqueueDeferredAssertion(
       .instance_id = instance_id,
       .payload_size = payload_size,
       .payload = {},
+      .ref_bindings = {},
   };
   if (payload_ptr != nullptr && payload_size > 0) {
     rec.payload.AssignCopy(payload_ptr, payload_size);

--- a/src/lyra/runtime/assoc_array.cpp
+++ b/src/lyra/runtime/assoc_array.cpp
@@ -75,7 +75,8 @@ auto CanonicalizeKeyString(const char* str_data, uint32_t str_len)
     -> CanonResult {
   return CanonResult{
       .status = KeyStatus::kOk,
-      .payload = CanonKeyPayload{.str_value = std::string(str_data, str_len)}};
+      .payload = CanonKeyPayload{
+          .int_words = {}, .str_value = std::string(str_data, str_len)}};
 }
 
 auto CanonicalizeKeyRaw(
@@ -107,7 +108,8 @@ auto CanonicalizeKeyRaw(
 
   return CanonResult{
       .status = KeyStatus::kOk,
-      .payload = CanonKeyPayload{.int_words = std::move(words)}};
+      .payload =
+          CanonKeyPayload{.int_words = std::move(words), .str_value = {}}};
 }
 
 auto CanonicalizeKey(const RuntimeValue& value, const KeySpec& spec)

--- a/src/lyra/runtime/io.cpp
+++ b/src/lyra/runtime/io.cpp
@@ -15,6 +15,8 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/core.h>
+
 #include "lyra/common/binary_pack.hpp"
 #include "lyra/common/diagnostic/print.hpp"
 #include "lyra/common/format.hpp"
@@ -97,45 +99,28 @@ auto ReadPackedIntegralFromSlot(
   return lyra::semantic::MakeIntegralWide(value_words.data(), num_words, width);
 }
 
-void SnapshotIntegralSemantic(const VarEntry& var) {
-  // ABI layer: build RuntimeValue from memory
-  auto value = ReadPackedIntegralFromSlot(
-      var.addr, static_cast<uint32_t>(var.width), var.is_four_state);
-
-  // Format layer: get SV literal (FormatAsSvLiteral owns all N'...
-  // construction)
-  std::string literal = lyra::semantic::FormatAsSvLiteral(value);
-
-  // New protocol: v:i:name=literal
-  lyra::runtime::WriteOutput(
-      std::format("__LYRA_VAR:v:i:{}={}\n", var.name, literal));
-}
-
-void SnapshotReal(const VarEntry& var) {
-  double value = 0.0;
-  std::memcpy(&value, var.addr, sizeof(double));
-  // New protocol: v:r:name=value (plain decimal, not SV literal)
-  // Use max_digits10 (17 for double) to ensure round-trip precision
-  lyra::runtime::WriteOutput(
-      std::format(
-          "__LYRA_VAR:v:r:{}={:.{}g}\n", var.name, value,
-          std::numeric_limits<double>::max_digits10));
-}
-
 }  // namespace
 
-extern "C" void LyraPrintLiteral(const char* str) {
-  lyra::runtime::WriteOutput(str);
+extern "C" void LyraPrintLiteral(void* engine_ptr, const char* str) {
+  auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
+  engine->Output().AppendSimOutputFragment(str);
 }
 
-extern "C" void LyraWarnRateLimited(const char* msg, uint32_t* counter_ptr) {
+extern "C" void LyraWarnRateLimited(
+    void* engine_ptr, const char* msg, uint32_t* counter_ptr) {
   constexpr uint32_t kMaxWarnings = 10;
   uint32_t count = *counter_ptr;
   if (count >= kMaxWarnings) return;
   *counter_ptr = count + 1;
-  lyra::runtime::WriteOutput(msg);
+  auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
+  auto& out = engine->Output();
+  std::string_view sv{msg};
+  if (!sv.empty() && sv.back() == '\n') sv.remove_suffix(1);
+  out.AppendSimOutputFragment(sv);
+  out.FinishSimOutputRecord();
   if (count + 1 == kMaxWarnings) {
-    lyra::runtime::WriteOutput("  (further identical warnings suppressed)\n");
+    out.AppendSimOutputFragment("  (further identical warnings suppressed)");
+    out.FinishSimOutputRecord();
   }
 }
 
@@ -144,19 +129,24 @@ extern "C" void LyraPrintValue(
     int32_t width, bool is_signed, int32_t output_width, int32_t precision,
     bool zero_pad, bool left_align, const void* unknown_data,
     const void* /*z_mask*/, int8_t module_timeunit_power) {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraPrintValue", "engine_ptr must not be null");
+  }
   std::string formatted = lyra::runtime::FormatRuntimeValue(
       static_cast<lyra::FormatKind>(format),
       static_cast<lyra::runtime::RuntimeValueKind>(value_kind), data, width,
       is_signed, output_width, precision, zero_pad, left_align, engine_ptr,
       module_timeunit_power, unknown_data);
-  lyra::runtime::WriteOutput(formatted);
+  auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
+  engine->Output().AppendSimOutputFragment(formatted);
 }
 
-extern "C" void LyraPrintEnd(int32_t kind) {
+extern "C" void LyraPrintEnd(void* engine_ptr, int32_t kind) {
   if (kind == static_cast<int32_t>(lyra::PrintKind::kDisplay)) {
-    lyra::runtime::WriteOutput("\n");
+    auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
+    engine->Output().FinishSimOutputRecord();
   }
-  // No flush here - flush only at simulation end
 }
 
 extern "C" void LyraRegisterVar(
@@ -167,15 +157,28 @@ extern "C" void LyraRegisterVar(
        is_four_state});
 }
 
-extern "C" void LyraSnapshotVars() {
+extern "C" void LyraSnapshotVars(void* run_session_ptr) {
+  auto* session = static_cast<lyra::runtime::RunSession*>(run_session_ptr);
+  session->output.DrainSimOutputBuffer();
   for (const auto& var : g_registered_vars) {
     switch (var.kind) {
-      case VarKind::kIntegral:
-        SnapshotIntegralSemantic(var);
+      case VarKind::kIntegral: {
+        auto value = ReadPackedIntegralFromSlot(
+            var.addr, static_cast<uint32_t>(var.width), var.is_four_state);
+        std::string literal = lyra::semantic::FormatAsSvLiteral(value);
+        session->output.WriteProtocolRecord(
+            std::format("__LYRA_VAR:v:i:{}={}\n", var.name, literal));
         break;
-      case VarKind::kReal:
-        SnapshotReal(var);
+      }
+      case VarKind::kReal: {
+        double value = 0.0;
+        std::memcpy(&value, var.addr, sizeof(double));
+        session->output.WriteProtocolRecord(
+            std::format(
+                "__LYRA_VAR:v:r:{}={:.{}g}\n", var.name, value,
+                std::numeric_limits<double>::max_digits10));
         break;
+      }
     }
   }
   g_registered_vars.clear();
@@ -251,8 +254,8 @@ extern "C" void LyraFWrite(
   std::string_view msg{ptr, len};
 
   if (targets.include_stdout) {
-    lyra::runtime::WriteOutput(msg);
-    if (add_newline) lyra::runtime::WriteOutput("\n");
+    engine->Output().AppendSimOutputFragment(msg);
+    if (add_newline) engine->Output().FinishSimOutputRecord();
   }
   for (int i = 0; i < targets.file_stream_count; ++i) {
     *targets.file_streams.at(i) << msg;
@@ -407,7 +410,7 @@ extern "C" void LyraReadmemNoNotify(
 
 extern "C" void LyraPrintModulePath(void* engine_ptr, uint32_t instance_id) {
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
-  lyra::runtime::WriteOutput(
+  engine->Output().AppendSimOutputFragment(
       engine->GetInstancePath(lyra::runtime::InstanceId{instance_id}));
 }
 

--- a/src/lyra/runtime/io.cpp
+++ b/src/lyra/runtime/io.cpp
@@ -102,6 +102,10 @@ auto ReadPackedIntegralFromSlot(
 }  // namespace
 
 extern "C" void LyraPrintLiteral(void* engine_ptr, const char* str) {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraPrintLiteral", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   engine->Output().AppendSimOutputFragment(str);
 }
@@ -112,6 +116,10 @@ extern "C" void LyraWarnRateLimited(
   uint32_t count = *counter_ptr;
   if (count >= kMaxWarnings) return;
   *counter_ptr = count + 1;
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraWarnRateLimited", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   auto& out = engine->Output();
   std::string_view sv{msg};
@@ -143,6 +151,10 @@ extern "C" void LyraPrintValue(
 }
 
 extern "C" void LyraPrintEnd(void* engine_ptr, int32_t kind) {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraPrintEnd", "engine_ptr must not be null");
+  }
   if (kind == static_cast<int32_t>(lyra::PrintKind::kDisplay)) {
     auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
     engine->Output().FinishSimOutputRecord();
@@ -158,6 +170,10 @@ extern "C" void LyraRegisterVar(
 }
 
 extern "C" void LyraSnapshotVars(void* run_session_ptr) {
+  if (run_session_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraSnapshotVars", "run_session_ptr must not be null");
+  }
   auto* session = static_cast<lyra::runtime::RunSession*>(run_session_ptr);
   session->output.DrainSimOutputBuffer();
   for (const auto& var : g_registered_vars) {
@@ -187,6 +203,10 @@ extern "C" void LyraSnapshotVars(void* run_session_ptr) {
 extern "C" auto LyraFopenFd(
     void* engine_ptr, LyraStringHandle filename_handle,
     LyraStringHandle mode_handle) -> int32_t {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraFopenFd", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   std::string filename{LyraStringAsView(filename_handle)};
   std::string mode{LyraStringAsView(mode_handle)};
@@ -195,23 +215,39 @@ extern "C" auto LyraFopenFd(
 
 extern "C" auto LyraFopenMcd(void* engine_ptr, LyraStringHandle filename_handle)
     -> int32_t {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraFopenMcd", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   std::string filename{LyraStringAsView(filename_handle)};
   return engine->GetFileManager().FopenMcd(filename);
 }
 
 extern "C" void LyraFclose(void* engine_ptr, int32_t descriptor) {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraFclose", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   engine->GetFileManager().Fclose(descriptor);
 }
 
 extern "C" auto LyraFgetc(void* engine_ptr, int32_t descriptor) -> int32_t {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraFgetc", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   return engine->GetFileManager().Fgetc(descriptor);
 }
 
 extern "C" auto LyraUngetc(
     void* engine_ptr, int32_t character, int32_t descriptor) -> int32_t {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraUngetc", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   return engine->GetFileManager().Ungetc(character, descriptor);
 }
@@ -219,6 +255,10 @@ extern "C" auto LyraUngetc(
 extern "C" auto LyraFgets(
     void* engine_ptr, int32_t descriptor, LyraStringHandle* str_out)
     -> int32_t {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraFgets", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   std::string result;
   int32_t count = engine->GetFileManager().Fgets(descriptor, result);
@@ -229,6 +269,10 @@ extern "C" auto LyraFgets(
 
 extern "C" void LyraFflush(
     void* engine_ptr, bool has_desc, int32_t descriptor) {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraFflush", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   if (has_desc) {
     engine->GetFileManager().Fflush(descriptor);
@@ -242,6 +286,10 @@ extern "C" void LyraFWrite(
     bool add_newline) {
   if (descriptor == 0) return;
 
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraFWrite", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   lyra::runtime::StreamTargets targets =
       engine->GetFileManager().CollectStreams(descriptor);
@@ -361,11 +409,15 @@ extern "C" void LyraReadmemLocal(
     int32_t element_count, int64_t min_addr, int64_t current_addr,
     int64_t final_addr, int64_t step, bool is_hex, int32_t element_kind,
     void* instance_ptr, uint32_t local_signal_id) {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraReadmemLocal", "engine_ptr must not be null");
+  }
   bool wrote = ReadmemImpl(
       filename_handle, target, element_width, stride_bytes, value_size_bytes,
       element_count, min_addr, current_addr, final_addr, step, is_hex,
       element_kind);
-  if (wrote && engine_ptr != nullptr) {
+  if (wrote) {
     if (instance_ptr == nullptr) {
       throw lyra::common::InternalError(
           "LyraReadmemLocal",
@@ -387,21 +439,25 @@ extern "C" void LyraReadmemGlobal(
     int32_t element_count, int64_t min_addr, int64_t current_addr,
     int64_t final_addr, int64_t step, bool is_hex, int32_t element_kind,
     uint32_t global_slot_id) {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraReadmemGlobal", "engine_ptr must not be null");
+  }
   bool wrote = ReadmemImpl(
       filename_handle, target, element_width, stride_bytes, value_size_bytes,
       element_count, min_addr, current_addr, final_addr, step, is_hex,
       element_kind);
-  if (wrote && engine_ptr != nullptr) {
+  if (wrote) {
     auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
     engine->MarkDirty(lyra::runtime::GlobalSignalId{global_slot_id});
   }
 }
 
 extern "C" void LyraReadmemNoNotify(
-    void* /*engine_ptr*/, LyraStringHandle filename_handle, void* target,
-    int32_t element_width, int32_t stride_bytes, int32_t value_size_bytes,
-    int32_t element_count, int64_t min_addr, int64_t current_addr,
-    int64_t final_addr, int64_t step, bool is_hex, int32_t element_kind) {
+    LyraStringHandle filename_handle, void* target, int32_t element_width,
+    int32_t stride_bytes, int32_t value_size_bytes, int32_t element_count,
+    int64_t min_addr, int64_t current_addr, int64_t final_addr, int64_t step,
+    bool is_hex, int32_t element_kind) {
   ReadmemImpl(
       filename_handle, target, element_width, stride_bytes, value_size_bytes,
       element_count, min_addr, current_addr, final_addr, step, is_hex,
@@ -409,6 +465,10 @@ extern "C" void LyraReadmemNoNotify(
 }
 
 extern "C" void LyraPrintModulePath(void* engine_ptr, uint32_t instance_id) {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraPrintModulePath", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   engine->Output().AppendSimOutputFragment(
       engine->GetInstancePath(lyra::runtime::InstanceId{instance_id}));
@@ -561,6 +621,10 @@ extern "C" auto LyraFreadLocal(
     int32_t stride_bytes, int32_t is_memory, int64_t start_index,
     int64_t max_count, int64_t element_count, void* instance_ptr,
     uint32_t local_signal_id) -> int32_t {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraFreadLocal", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   int32_t bytes = FreadImpl(
       engine, descriptor, target, element_width, stride_bytes, is_memory,
@@ -586,6 +650,10 @@ extern "C" auto LyraFreadGlobal(
     int32_t stride_bytes, int32_t is_memory, int64_t start_index,
     int64_t max_count, int64_t element_count, uint32_t global_slot_id)
     -> int32_t {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraFreadGlobal", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   int32_t bytes = FreadImpl(
       engine, descriptor, target, element_width, stride_bytes, is_memory,
@@ -600,6 +668,10 @@ extern "C" auto LyraFreadNoNotify(
     void* engine_ptr, int32_t descriptor, void* target, int32_t element_width,
     int32_t stride_bytes, int32_t is_memory, int64_t start_index,
     int64_t max_count, int64_t element_count) -> int32_t {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraFreadNoNotify", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   return FreadImpl(
       engine, descriptor, target, element_width, stride_bytes, is_memory,
@@ -609,6 +681,10 @@ extern "C" auto LyraFreadNoNotify(
 extern "C" auto LyraFscanf(
     void* engine_ptr, int32_t descriptor, LyraStringHandle format,
     int32_t output_count, void** output_ptrs) -> int32_t {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraFscanf", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   auto& file_manager = engine->GetFileManager();
 

--- a/src/lyra/runtime/output_sink.cpp
+++ b/src/lyra/runtime/output_sink.cpp
@@ -1,5 +1,6 @@
 #include "lyra/runtime/output_sink.hpp"
 
+#include <cstdio>
 #include <functional>
 #include <string_view>
 
@@ -28,6 +29,7 @@ void WriteOutput(std::string_view text) {
     g_output_sink(text);
   } else {
     fmt::print("{}", text);
+    std::fflush(stdout);
   }
 }
 

--- a/src/lyra/runtime/output_sink.cpp
+++ b/src/lyra/runtime/output_sink.cpp
@@ -1,36 +1,60 @@
 #include "lyra/runtime/output_sink.hpp"
 
 #include <cstdio>
-#include <functional>
+#include <memory>
 #include <string_view>
 
 #include <fmt/core.h>
 
 namespace lyra::runtime {
 
-namespace {
-
-// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
-OutputSink g_output_sink;
-// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
-
-}  // namespace
-
-void SetOutputSink(OutputSink sink) {
-  g_output_sink = std::move(sink);
-}
-
-auto GetOutputSink() -> OutputSink {
-  return g_output_sink;
-}
-
-void WriteOutput(std::string_view text) {
-  if (g_output_sink) {
-    g_output_sink(text);
-  } else {
-    fmt::print("{}", text);
-    std::fflush(stdout);
+void OutputDispatcher::WriteTo(std::string_view text) {
+  if (sink_) {
+    sink_(text);
+    return;
   }
+  fmt::print("{}", text);
+}
+
+void OutputDispatcher::AppendSimOutputFragment(std::string_view text) {
+  if (sink_) {
+    sink_(text);
+    return;
+  }
+  pending_sim_output_.append(text);
+}
+
+void OutputDispatcher::FinishSimOutputRecord() {
+  if (sink_) {
+    sink_("\n");
+    return;
+  }
+  pending_sim_output_.push_back('\n');
+  WriteTo(pending_sim_output_);
+  pending_sim_output_.clear();
+}
+
+void OutputDispatcher::DrainSimOutputBuffer() {
+  if (sink_) {
+    return;
+  }
+  if (pending_sim_output_.empty()) {
+    return;
+  }
+  WriteTo(pending_sim_output_);
+  pending_sim_output_.clear();
+}
+
+void OutputDispatcher::WriteProtocolRecord(std::string_view text) {
+  WriteTo(text);
+}
+
+extern "C" auto LyraCreateRunSession() -> void* {
+  return std::make_unique<RunSession>().release();
+}
+
+extern "C" void LyraDestroyRunSession(void* ptr) {
+  std::unique_ptr<RunSession>(static_cast<RunSession*>(ptr));
 }
 
 }  // namespace lyra::runtime

--- a/src/lyra/runtime/process_meta.cpp
+++ b/src/lyra/runtime/process_meta.cpp
@@ -206,14 +206,15 @@ void ProcessMetaRegistry::WriteAsyncSignalSafe(
   }
 }
 
-void ProcessMetaRegistry::DumpSummary() const {
-  WriteOutput(
+void ProcessMetaRegistry::DumpSummary(OutputDispatcher& out) const {
+  out.DrainSimOutputBuffer();
+  out.WriteProtocolRecord(
       std::format(
           "__LYRA_PROCESS_META__: version={} count={}\n",
           process_meta_abi::kVersion, metas_.size()));
 
   for (uint32_t i = 0; i < metas_.size(); ++i) {
-    WriteOutput(
+    out.WriteProtocolRecord(
         std::format("__LYRA_PROCESS_META__: process={} {}\n", i, Format(i)));
   }
 }

--- a/src/lyra/runtime/reporting.cpp
+++ b/src/lyra/runtime/reporting.cpp
@@ -23,8 +23,8 @@ void EmitReport(Engine* engine, const ReportRequest& req) {
   }
   text += ReportPrefix(req.kind, req.severity);
   text += req.message;
-  text += "\n";
-  WriteOutput(text);
+  engine->Output().AppendSimOutputFragment(text);
+  engine->Output().FinishSimOutputRecord();
   if (req.action == ReportAction::kFinish) {
     engine->Finish();
   }

--- a/src/lyra/runtime/reporting.cpp
+++ b/src/lyra/runtime/reporting.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <string_view>
 
+#include "lyra/common/internal_error.hpp"
 #include "lyra/common/severity.hpp"
 #include "lyra/runtime/engine.hpp"
 #include "lyra/runtime/output_sink.hpp"
@@ -55,6 +56,10 @@ auto DecodeAbiReportPayload(const AbiReportPayload& abi) -> ReportRequest {
 
 extern "C" void LyraEmitReport(
     void* engine_ptr, const lyra::runtime::AbiReportPayload* payload) {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraEmitReport", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   auto req = lyra::runtime::DecodeAbiReportPayload(*payload);
   lyra::runtime::EmitReport(engine, req);

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -491,6 +491,10 @@ extern "C" void LyraRegisterStrobe(
 extern "C" void LyraTerminate(
     void* engine_ptr, uint32_t kind, int32_t level,
     LyraStringHandle /*message*/) {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraTerminate", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   uint64_t time = engine->CurrentTime();
 
@@ -601,6 +605,10 @@ auto GetFsBaseDir() -> const std::filesystem::path& {
 }  // namespace lyra::runtime
 
 extern "C" void LyraReportTime(void* run_session_ptr) {
+  if (run_session_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraReportTime", "run_session_ptr must not be null");
+  }
   auto* session = static_cast<lyra::runtime::RunSession*>(run_session_ptr);
   session->output.DrainSimOutputBuffer();
   session->output.WriteProtocolRecord(

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -151,7 +151,7 @@ extern "C" void LyraRunSimulation(
     LyraProcessFunc* connection_funcs, void** states_raw,
     uint32_t num_processes, const char** plusargs_raw, uint32_t num_plusargs,
     const char** instance_paths_raw, uint32_t num_instance_paths,
-    const LyraRuntimeAbi* abi) {
+    const LyraRuntimeAbi* abi, void* run_session_ptr) {
   if (num_processes > 0 && states_raw == nullptr) {
     throw lyra::common::InternalError(
         "LyraRunSimulation", "states_raw is null");
@@ -205,11 +205,12 @@ extern "C" void LyraRunSimulation(
       .states = states,
       .num_connection = num_connection,
   };
+  auto* session = static_cast<lyra::runtime::RunSession*>(run_session_ptr);
   lyra::runtime::Engine engine(
       lyra::runtime::ProcessDispatch{
           .fn = DescriptorProcessDispatch, .ctx = &dispatch_ctx},
-      num_processes, std::span(plusargs_vec), std::move(instance_paths_vec),
-      feature_flags);
+      session->output, num_processes, std::span(plusargs_vec),
+      std::move(instance_paths_vec), feature_flags);
 
   if (abi != nullptr) {
     if (abi->version != kRuntimeAbiVersion) {
@@ -340,10 +341,10 @@ extern "C" void LyraRunSimulation(
   }
 
   if (HasFlag(flags, FeatureFlag::kDumpSlotMeta)) {
-    engine.GetSlotMetaRegistry().DumpSummary();
+    engine.GetSlotMetaRegistry().DumpSummary(engine.Output());
   }
   if (HasFlag(flags, FeatureFlag::kDumpProcessMeta)) {
-    engine.GetProcessMetaRegistry().DumpSummary();
+    engine.GetProcessMetaRegistry().DumpSummary(engine.Output());
   }
   // Register trace sinks before enabling TraceManager.
   if (HasFlag(flags, FeatureFlag::kEnableSignalTrace)) {
@@ -353,7 +354,8 @@ extern "C" void LyraRunSimulation(
       text_sink = std::make_unique<lyra::trace::TextTraceSink>(
           meta, std::string(abi->signal_trace_path));
     } else {
-      text_sink = std::make_unique<lyra::trace::TextTraceSink>(meta);
+      text_sink =
+          std::make_unique<lyra::trace::TextTraceSink>(meta, &engine.Output());
     }
     text_sink->SetInstanceResolver(&engine.GetInstanceTraceResolver());
     engine.GetTraceManager().AddSink(std::move(text_sink));
@@ -380,7 +382,7 @@ extern "C" void LyraRunSimulation(
   lyra::runtime::RemoveSignalDumpHandler();
 
   if (HasFlag(flags, FeatureFlag::kEnableTraceSummary)) {
-    engine.GetTraceManager().PrintSummary();
+    engine.GetTraceManager().PrintSummary(engine.Output());
   }
 
   if (HasFlag(flags, FeatureFlag::kDumpRuntimeStats)) {
@@ -492,14 +494,18 @@ extern "C" void LyraTerminate(
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   uint64_t time = engine->CurrentTime();
 
+  auto& out = engine->Output();
+  out.DrainSimOutputBuffer();
+
   // Negative level treated as silent
   if (level >= 1) {
     // Out-of-range kind defaults to kFinish behavior
     switch (kind) {
       case 0:  // kFinish
       default:
-        lyra::runtime::WriteOutput(
-            std::format("$finish called at time {}\n", time));
+        out.AppendSimOutputFragment(
+            std::format("$finish called at time {}", time));
+        out.FinishSimOutputRecord();
         break;
       case 1:
         throw lyra::common::InternalError(
@@ -507,13 +513,15 @@ extern "C" void LyraTerminate(
             "kFatal must be lowered via LyraEmitReport, not LyraTerminate");
       case 2:  // kStop
         // MVP: same as finish. Future: may pause for interactive debugger.
-        lyra::runtime::WriteOutput(
-            std::format("$stop called at time {}\n", time));
+        out.AppendSimOutputFragment(
+            std::format("$stop called at time {}", time));
+        out.FinishSimOutputRecord();
         break;
       case 3:  // kExit
         // MVP: same as finish. Future: may have program-block semantics.
-        lyra::runtime::WriteOutput(
-            std::format("$exit called at time {}\n", time));
+        out.AppendSimOutputFragment(
+            std::format("$exit called at time {}", time));
+        out.FinishSimOutputRecord();
         break;
     }
     std::fflush(stdout);
@@ -592,8 +600,11 @@ auto GetFsBaseDir() -> const std::filesystem::path& {
 
 }  // namespace lyra::runtime
 
-extern "C" void LyraReportTime() {
-  lyra::runtime::WriteOutput(std::format("__LYRA_TIME__={}\n", FinalTime()));
+extern "C" void LyraReportTime(void* run_session_ptr) {
+  auto* session = static_cast<lyra::runtime::RunSession*>(run_session_ptr);
+  session->output.DrainSimOutputBuffer();
+  session->output.WriteProtocolRecord(
+      std::format("__LYRA_TIME__={}\n", FinalTime()));
   std::fflush(stdout);
 }
 

--- a/src/lyra/runtime/slot_meta.cpp
+++ b/src/lyra/runtime/slot_meta.cpp
@@ -219,8 +219,9 @@ void SlotMetaRegistry::ThrowOutOfRange(uint32_t slot_id) const {
       std::format("slot_id {} out of range (size {})", slot_id, slots_.size()));
 }
 
-void SlotMetaRegistry::DumpSummary() const {
-  WriteOutput(
+void SlotMetaRegistry::DumpSummary(OutputDispatcher& out) const {
+  out.DrainSimOutputBuffer();
+  out.WriteProtocolRecord(
       std::format(
           "__LYRA_SLOT_META__: version={} count={}\n", slot_meta_abi::kVersion,
           slots_.size()));
@@ -249,7 +250,7 @@ void SlotMetaRegistry::DumpSummary() const {
     }
 
     line += "\n";
-    WriteOutput(line);
+    out.WriteProtocolRecord(line);
   }
 }
 

--- a/src/lyra/runtime/string.cpp
+++ b/src/lyra/runtime/string.cpp
@@ -222,14 +222,15 @@ extern "C" auto LyraStringGetCStr(LyraStringHandle handle) -> const char* {
 }
 
 extern "C" void LyraPrintString(
-    LyraStringHandle handle, const lyra::runtime::LyraFormatSpec* spec) {
+    void* engine_ptr, LyraStringHandle handle,
+    const lyra::runtime::LyraFormatSpec* spec) {
   if (handle == nullptr) {
     return;
   }
+  auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   auto* str = static_cast<LyraStringData*>(handle);
   std::string str_value(str->data, str->len);
 
-  // Decode ABI format spec to semantic format spec
   lyra::semantic::FormatSpec decoded{
       .kind = static_cast<lyra::FormatKind>(spec->kind),
       .width = spec->width >= 0 ? std::optional(spec->width) : std::nullopt,
@@ -240,7 +241,7 @@ extern "C" void LyraPrintString(
   };
   std::string formatted = lyra::semantic::FormatValue(
       lyra::semantic::MakeString(std::move(str_value)), decoded, false);
-  lyra::runtime::WriteOutput(formatted);
+  engine->Output().AppendSimOutputFragment(formatted);
 }
 
 // Internal buffer for string formatting

--- a/src/lyra/runtime/string.cpp
+++ b/src/lyra/runtime/string.cpp
@@ -227,6 +227,10 @@ extern "C" void LyraPrintString(
   if (handle == nullptr) {
     return;
   }
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraPrintString", "engine_ptr must not be null");
+  }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   auto* str = static_cast<LyraStringData*>(handle);
   std::string str_value(str->data, str->len);

--- a/src/lyra/trace/summary_trace_sink.cpp
+++ b/src/lyra/trace/summary_trace_sink.cpp
@@ -34,21 +34,23 @@ void SummaryTraceSink::OnEvent(const TraceEvent& event) {
       event);
 }
 
-void SummaryTraceSink::PrintSummary() const {
-  lyra::runtime::WriteOutput(
+void SummaryTraceSink::PrintSummary(
+    lyra::runtime::OutputDispatcher& out) const {
+  out.DrainSimOutputBuffer();
+  out.WriteProtocolRecord(
       std::format(
           "__LYRA_TRACE__: time_advances={} value_changes={} memory_dirty={}\n",
           time_advances_, value_changes_, memory_dirty_));
 
   for (const auto& [signal_id, counts] : global_counts_) {
-    lyra::runtime::WriteOutput(
+    out.WriteProtocolRecord(
         std::format(
             "__LYRA_TRACE_SLOT__: slot={} value_changes={} memory_dirty={}\n",
             signal_id, counts.value_changes, counts.memory_dirty));
   }
 
   for (const auto& [key, counts] : local_counts_) {
-    lyra::runtime::WriteOutput(
+    out.WriteProtocolRecord(
         std::format(
             "__LYRA_TRACE_SLOT__: instance={} local={} value_changes={} "
             "memory_dirty={}\n",

--- a/src/lyra/trace/text_trace_sink.cpp
+++ b/src/lyra/trace/text_trace_sink.cpp
@@ -16,8 +16,10 @@
 
 namespace lyra::trace {
 
-TextTraceSink::TextTraceSink(const runtime::TraceSignalMetaRegistry* meta)
-    : meta_(meta) {
+TextTraceSink::TextTraceSink(
+    const runtime::TraceSignalMetaRegistry* meta,
+    runtime::OutputDispatcher* output_dispatcher)
+    : meta_(meta), output_dispatcher_(output_dispatcher) {
 }
 
 TextTraceSink::TextTraceSink(
@@ -135,7 +137,8 @@ void TextTraceSink::HandleGlobalValueChange(const GlobalValueChange& vc) {
   if (output_) {
     std::fwrite(line.data(), 1, line.size(), output_.get());
   } else {
-    runtime::WriteOutput(line);
+    output_dispatcher_->DrainSimOutputBuffer();
+    output_dispatcher_->WriteProtocolRecord(line);
   }
 }
 
@@ -179,7 +182,8 @@ void TextTraceSink::HandleLocalValueChange(const LocalValueChange& vc) {
   if (output_) {
     std::fwrite(line.data(), 1, line.size(), output_.get());
   } else {
-    runtime::WriteOutput(line);
+    output_dispatcher_->DrainSimOutputBuffer();
+    output_dispatcher_->WriteProtocolRecord(line);
   }
 }
 

--- a/src/lyra/trace/trace_manager.cpp
+++ b/src/lyra/trace/trace_manager.cpp
@@ -86,8 +86,8 @@ void TraceManager::SetSignalMeta(const runtime::TraceSignalMetaRegistry* meta) {
   signal_meta_ = meta;
 }
 
-void TraceManager::PrintSummary() const {
-  summary_sink_.PrintSummary();
+void TraceManager::PrintSummary(lyra::runtime::OutputDispatcher& out) const {
+  summary_sink_.PrintSummary(out);
 }
 
 void TraceManager::Dispatch(const TraceEvent& event) {

--- a/tests/framework/aot_backend.cpp
+++ b/tests/framework/aot_backend.cpp
@@ -31,7 +31,9 @@ auto RunAotBackend(
   CaseExecutionResult result;
 
   // Prepare LLVM module (AST -> HIR -> MIR -> LLVM)
-  auto prep_result = PrepareLlvmModule(test_case, work_directory);
+  auto prep_result = PrepareLlvmModule(
+      test_case, work_directory, false,
+      lowering::mir_to_llvm::MainAbi::kArgvForwarding);
   if (!prep_result) {
     result.execution.outcome = ExecutionOutcome::kFrontendError;
     result.execution.error_message = prep_result.error();

--- a/tests/framework/arg_parse.cpp
+++ b/tests/framework/arg_parse.cpp
@@ -64,6 +64,7 @@ auto ParseArgs(std::span<char*> argv)
         TryParseFlag(arg, next_arg, "backend", args.backend, consumed_next) ||
         TryParseFlag(
             arg, next_arg, "test_file", args.test_file, consumed_next) ||
+        TryParseFlag(arg, next_arg, "case", args.case_filter, consumed_next) ||
         TryParseFlag(
             arg, next_arg, "shard_count", args.shard_count, consumed_next) ||
         TryParseFlag(

--- a/tests/framework/case_runner.cpp
+++ b/tests/framework/case_runner.cpp
@@ -2,10 +2,12 @@
 
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <exception>
 #include <format>
 #include <map>
+#include <print>
 #include <string>
 #include <string_view>
 #include <unistd.h>
@@ -239,12 +241,31 @@ auto InterpretForkOutcome(const ProcessOutcome& proc) -> CaseExecutionResult {
 
 }  // namespace
 
+// Terminate handler for fork children. Prints the current exception's what()
+// to stderr so the parent can capture it via the stderr pipe.
+[[noreturn]] void ChildTerminateHandler() {
+  auto eptr = std::current_exception();
+  if (eptr != nullptr) {
+    try {
+      std::rethrow_exception(eptr);
+    } catch (const std::exception& e) {
+      std::print(stderr, "terminate: {}\n", e.what());
+    } catch (...) {
+      std::print(stderr, "terminate: unknown exception\n");
+    }
+  } else {
+    std::print(stderr, "terminate called without active exception\n");
+  }
+  std::abort();
+}
+
 // Fork-isolated execution for JIT backend.
 auto RunIsolatedCase(
     const TestCase& test_case, BackendKind backend, bool force_two_state,
     std::chrono::seconds timeout) -> CaseExecutionResult {
   auto proc = RunInFork(
       [&](int result_fd) {
+        std::set_terminate(ChildTerminateHandler);
         auto case_result = ExecuteTestCase(test_case, backend, force_two_state);
         WriteCaseResult(result_fd, case_result);
       },

--- a/tests/framework/case_runner.cpp
+++ b/tests/framework/case_runner.cpp
@@ -6,8 +6,8 @@
 #include <cstring>
 #include <exception>
 #include <format>
+#include <iostream>
 #include <map>
-#include <print>
 #include <string>
 #include <string_view>
 #include <unistd.h>
@@ -249,12 +249,12 @@ auto InterpretForkOutcome(const ProcessOutcome& proc) -> CaseExecutionResult {
     try {
       std::rethrow_exception(eptr);
     } catch (const std::exception& e) {
-      std::print(stderr, "terminate: {}\n", e.what());
+      std::cerr << std::format("terminate: {}\n", e.what());
     } catch (...) {
-      std::print(stderr, "terminate: unknown exception\n");
+      std::cerr << "terminate: unknown exception\n";
     }
   } else {
-    std::print(stderr, "terminate called without active exception\n");
+    std::cerr << "terminate called without active exception\n";
   }
   std::abort();
 }

--- a/tests/framework/jit_backend.cpp
+++ b/tests/framework/jit_backend.cpp
@@ -83,15 +83,15 @@ auto RunJitBackend(
     return result;
   }
 
-  // Execute the compiled simulation.
-  // OutputSinkScope captures JIT output and restores previous sink on exit.
-  // CoverHitCallbackScope captures per-site cover hit counts.
+  // RunSession owns the OutputDispatcher for the entire run lifetime
+  // (simulation + epilogue). OutputSinkScope installs the capture callback.
   auto t_exec = Clock::now();
   int exit_code = 0;
   std::vector<uint64_t> cover_hits;
   {
+    runtime::RunSession run_session;
     runtime::OutputSinkScope sink_scope(
-        [&captured_output](std::string_view text) {
+        run_session.output, [&captured_output](std::string_view text) {
           captured_output.append(text);
         });
     runtime::CoverHitCallbackScope cover_scope(
@@ -104,7 +104,7 @@ auto RunJitBackend(
           nba_stats.deferred_local = stats.deferred_local;
           nba_stats.captured = true;
         });
-    exit_code = session->Run();
+    exit_code = session->Run(run_session);
   }
   result.artifacts.timings.execute =
       std::chrono::duration<double>(Clock::now() - t_exec).count();

--- a/tests/framework/lli_backend.cpp
+++ b/tests/framework/lli_backend.cpp
@@ -28,7 +28,9 @@ auto RunLliBackend(
   CaseExecutionResult result;
 
   // Prepare LLVM module (AST -> HIR -> MIR -> LLVM)
-  auto prep_result = PrepareLlvmModule(test_case, work_directory);
+  auto prep_result = PrepareLlvmModule(
+      test_case, work_directory, false,
+      lowering::mir_to_llvm::MainAbi::kArgvForwarding);
   if (!prep_result) {
     result.execution.outcome = ExecutionOutcome::kFrontendError;
     result.execution.error_message = prep_result.error();

--- a/tests/framework/llvm_common.cpp
+++ b/tests/framework/llvm_common.cpp
@@ -68,9 +68,9 @@ class TestSimulationHooks : public lowering::mir_to_llvm::SimulationHooks {
 
   void EmitPostSimulationReports(
       lowering::mir_to_llvm::Context& context, llvm::Value* /*design_state*/,
-      llvm::Value* /*abi_ptr*/) override {
+      llvm::Value* /*abi_ptr*/, llvm::Value* run_session_ptr) override {
     if (emit_time_report_) {
-      lowering::mir_to_llvm::EmitTimeReport(context);
+      lowering::mir_to_llvm::EmitTimeReport(context, run_session_ptr);
     }
   }
 

--- a/tests/framework/llvm_common.cpp
+++ b/tests/framework/llvm_common.cpp
@@ -182,7 +182,8 @@ auto FindRuntimeLibrary(std::string_view lib_name)
 
 auto PrepareLlvmModule(
     const TestCase& test_case, const std::filesystem::path& work_directory,
-    bool force_two_state) -> std::expected<LlvmPreparationResult, std::string> {
+    bool force_two_state, lowering::mir_to_llvm::MainAbi main_abi)
+    -> std::expected<LlvmPreparationResult, std::string> {
   using Clock = std::chrono::steady_clock;
 
   // Parse test case using slang
@@ -373,6 +374,8 @@ auto PrepareLlvmModule(
       .signal_trace_path = {},
       .iteration_limit = 0,
       .force_two_state = force_two_state,
+      .collect_forwarding_analysis = false,
+      .main_abi = main_abi,
       .dpi_export_wrappers = &mir_result->dpi_export_wrappers,
       .bound_connections = &mir_result->bound_connections,
       .expr_connections = &mir_result->expr_connections,

--- a/tests/framework/llvm_common.hpp
+++ b/tests/framework/llvm_common.hpp
@@ -64,7 +64,9 @@ struct LlvmPreparationResult {
 // inspection. work_directory is used for file I/O tests.
 auto PrepareLlvmModule(
     const TestCase& test_case, const std::filesystem::path& work_directory,
-    bool force_two_state = false)
+    bool force_two_state = false,
+    lowering::mir_to_llvm::MainAbi main_abi =
+        lowering::mir_to_llvm::MainAbi::kEmbeddedPlusargs)
     -> std::expected<LlvmPreparationResult, std::string>;
 
 }  // namespace lyra::test

--- a/tests/framework/test_discovery.hpp
+++ b/tests/framework/test_discovery.hpp
@@ -20,6 +20,7 @@ struct CommandLineArgs {
   //   JIT: whole-case timeout (fork-isolated, covers frontend+execution)
   //   AOT/LLI: simulation subprocess timeout only (frontend/lowering/link
   //     are not covered; runs direct for performance)
+  std::string case_filter;  // Run only this exact case name (empty = all)
   int timeout_seconds = 0;
   bool two_state = false;  // Force two-state mode (--test_file only)
 };

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -113,6 +113,9 @@ auto main(int argc, char** argv) -> int {
       ++timed_out;
       std::cout << std::format(
           "[ TIMEOUT  ] {} ({}s)\n", tc.name, timeout_seconds);
+      if (!result.execution.stderr_text.empty()) {
+        std::cout << "  stderr: " << result.execution.stderr_text << "\n";
+      }
     } else if (
         result.execution.outcome == lyra::test::ExecutionOutcome::kCrashed &&
         !tc.expected_runtime_fatal.has_value()) {
@@ -120,6 +123,9 @@ auto main(int argc, char** argv) -> int {
       std::cout << std::format(
           "[  CRASH   ] {} (signal={})\n", tc.name,
           result.execution.signal_number);
+      if (!result.execution.stderr_text.empty()) {
+        std::cout << "  stderr: " << result.execution.stderr_text << "\n";
+      }
     } else {
       ++failed;
       std::cout << std::format("[  FAILED  ] {}\n", tc.name);

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -6,6 +6,7 @@
 //   AOT/LLI: direct execution (subprocess timeout only, no fork overhead)
 // Evaluates expectations and prints per-case progress.
 
+#include <algorithm>
 #include <chrono>
 #include <cstdlib>
 #include <exception>
@@ -14,6 +15,7 @@
 #include <iostream>
 #include <span>
 #include <string>
+#include <utility>
 
 #include "tests/framework/arg_parse.hpp"
 #include "tests/framework/case_runner.hpp"
@@ -58,6 +60,20 @@ auto main(int argc, char** argv) -> int {
   } catch (const std::exception& e) {
     std::cerr << std::format("supervisor: {}\n", e.what());
     return 1;
+  }
+
+  // Apply --case filter: run only the named case.
+  if (!args.case_filter.empty()) {
+    auto it = std::ranges::find(
+        manifest.cases, args.case_filter, &lyra::test::TestCase::name);
+    if (it == manifest.cases.end()) {
+      std::cerr << std::format(
+          "supervisor: case '{}' not found in manifest\n", args.case_filter);
+      return 1;
+    }
+    lyra::test::TestCase single = std::move(*it);
+    manifest.cases.clear();
+    manifest.cases.push_back(std::move(single));
   }
 
   auto timeout = std::chrono::seconds{timeout_seconds};

--- a/tests/sv_features/directives/timescale/default.yaml
+++ b/tests/sv_features/directives/timescale/default.yaml
@@ -165,17 +165,43 @@ cases:
         st: 999999
         ft: 999999
 
-  # No timescale directive - uses default (1ps/1ps)
+  # No timescale directive - uses default (1ns/1ns)
   - name: no_timescale_uses_default
-    description: Without directive, default is 1ps/1ps (no scaling)
+    description: Without directive, default is 1ns/1ns (no scaling)
     sv: |
       module Test;
         initial begin
-          #25;  // 25ps with default 1ps/1ps
+          #25;  // 25 time units = 25ns with default 1ns/1ns
         end
       endmodule
     expect:
       time: 25
+
+  # No timescale - verify all query paths agree on the same default.
+  # This is a regression test: delay scaling, $timeunit, $timeprecision,
+  # and $printtimescale must all reflect 1ns/1ns when no directive exists.
+  - name: no_timescale_consistency
+    description: All no-timescale queries agree (1ns/1ns default)
+    sv: |
+      module Test;
+        int u;
+        int p;
+        initial begin
+          u = $timeunit;
+          p = $timeprecision;
+          $printtimescale();
+          #10ns;
+          $display("delay_time=%0t", $time);
+          $display("unit=%0d prec=%0d", u, p);
+          $finish;
+        end
+      endmodule
+    expect:
+      stdout:
+        contains:
+          - "Time scale of 'Test' is 1ns / 1ns"
+          - "delay_time=10"
+          - "unit=-9 prec=-9"
 
   # Multi-module with different timescales
   - name: multi_module_different_timescales

--- a/tests/sv_features/system_tf/effect/printtimescale/default.yaml
+++ b/tests/sv_features/system_tf/effect/printtimescale/default.yaml
@@ -2,9 +2,9 @@ feature: printtimescale
 description: Tests for $printtimescale system task (IEEE 1800-2023 Section 20.4.2)
 
 cases:
-  # Basic tests with default timescale (1ps / 1ps when no `timescale directive)
+  # Basic tests with default timescale (1ns / 1ns, IEEE 1800 default)
   - name: printtimescale_default
-    description: $printtimescale() with default timescale (1ps / 1ps)
+    description: $printtimescale() with default timescale (1ns / 1ns)
     sv: |
       module Test;
         initial begin
@@ -15,7 +15,7 @@ cases:
       time: 0
       stdout:
         contains:
-          - "Time scale of 'Test' is 1ps / 1ps"
+          - "Time scale of 'Test' is 1ns / 1ns"
 
   # Explicit timescale 1ns / 1ps
   - name: printtimescale_1ns_1ps
@@ -82,7 +82,7 @@ cases:
           - "Time scale of 'Test' is 100ps / 1ps"
 
   # $printtimescale($root) - prints global precision
-  # Global precision is 1ps (finest precision, default)
+  # Global precision is 1ns (default, IEEE 1800)
   - name: printtimescale_root_default
     description: $printtimescale($root) with default timescale
     sv: |
@@ -95,7 +95,7 @@ cases:
       time: 0
       stdout:
         contains:
-          - "Time scale of '$root' is 1ps / 1ps"
+          - "Time scale of '$root' is 1ns / 1ns"
 
   # $printtimescale($root) with explicit timescale
   # Global precision should be 1ns (the timeprecision)

--- a/tests/sv_features/system_tf/pure/timeunit/default.yaml
+++ b/tests/sv_features/system_tf/pure/timeunit/default.yaml
@@ -137,10 +137,10 @@ cases:
         contains:
           - "timeunit=-9, timeprecision=-12"
 
-  # Default timescale tests (Lyra default is 1ps/1ps)
+  # Default timescale tests (IEEE 1800 default is 1ns/1ns, matching slang)
 
   - name: timeunit_default
-    description: Without timescale directive, returns default unit (1ps = -12)
+    description: Without timescale directive, returns default unit (1ns = -9)
     sv: |
       module Test;
         int u;
@@ -150,10 +150,10 @@ cases:
       endmodule
     expect:
       variables:
-        u: -12
+        u: -9
 
   - name: timeprecision_default
-    description: Without timescale directive, returns default precision (1ps = -12)
+    description: Without timescale directive, returns default precision (1ns = -9)
     sv: |
       module Test;
         int p;
@@ -163,7 +163,7 @@ cases:
       endmodule
     expect:
       variables:
-        p: -12
+        p: -9
 
   # $root argument tests - returns global simulation precision
 
@@ -394,7 +394,7 @@ cases:
           - "root_prec=-11"
 
   - name: root_no_timescale
-    description: $root returns default -12 when no module has explicit timescale
+    description: $root returns default -9 when no module has explicit timescale
     sv: |
       module Test;
         initial begin
@@ -404,7 +404,7 @@ cases:
     expect:
       stdout:
         contains:
-          - "unit=-12, prec=-12"
+          - "unit=-9, prec=-9"
 
   # Hierarchical path argument tests - query timescale of specific instance
 

--- a/tests/trace_manager_test.cpp
+++ b/tests/trace_manager_test.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "lyra/runtime/output_sink.hpp"
 #include "lyra/runtime/signal_coord.hpp"
 #include "lyra/trace/trace_event.hpp"
 #include "lyra/trace/trace_sink.hpp"
@@ -135,13 +136,15 @@ TEST(TraceManagerTest, DisableAfterEnableFreezesSummary) {
       PackedSnapshot{.byte_size = 1, .bytes = {0x02}});
 
   // PrintSummary should still work (prints frozen session state).
-  tm.PrintSummary();
+  runtime::OutputDispatcher out;
+  tm.PrintSummary(out);
 }
 
 TEST(TraceManagerTest, PrintSummaryBeforeEnableProducesZeros) {
   TraceManager tm;
   // Should not crash. Prints zeros (never-enabled session).
-  tm.PrintSummary();
+  runtime::OutputDispatcher out;
+  tm.PrintSummary(out);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Null `engine_ptr` at the C ABI boundary caused silent SIGSEGV with no useful diagnostic -- the test framework would only report `[  CRASH   ] signal=11`. This PR closes the observability gap from both ends: runtime contract hardening to fail fast, and test infrastructure improvements to surface the failure clearly.

## Fix default timescale to 1ns/1ns and centralize resolver

The timescale fallback when no directive is present was 1ps, which disagreed with the IEEE 1800 default and slang's own `TimeScale` default constructor (1ns/1ns). This introduced a `ResolveScopeTimeScale` canonical resolver that all missing-timescale paths now go through, replacing the scattered `kDefaultTimeScalePower` reads across `design.cpp`, `module_lowerer.cpp`, `system_call.cpp`, and `system_function_desugar.cpp`. The `$timeunit` and `$timeprecision` lowering paths were previously merged through a lambda that selected unit-vs-precision at extraction time; they are now split into separate branches through `ResolveScopeUnitPower` and `ResolveScopePrecisionPower` projections. A `std::fflush(stdout)` was added after the default output path to prevent `$display` output loss when the process is killed before libc flushes.

## Replace global output sink with RunSession ownership

`OutputDispatcher` was a process-global singleton (`SetOutputSink`/`GetOutputSink`/`WriteOutput`). This replaced it with a value member of a new `RunSession` struct that represents run-lifetime scope. `Engine` now takes `OutputDispatcher&` in its constructor and borrows it for the duration of the simulation. Epilogue output (`LyraSnapshotVars`, `LyraReportTime`) routes through an explicit `run_session_ptr` parameter emitted by the LLVM backend, rather than reaching back through the global. The process-global staging/adoption path was deleted entirely. The test framework's `OutputSinkScope` was updated to bind to a specific `OutputDispatcher&` instance. This commit also added the `--case=` filter to the test runner for single-case execution.

## Add fail-fast null checks to runtime output API

Every effectful C ABI entry point that dereferences `Engine*` or `RunSession*` now validates the pointer up front and throws `InternalError` with a named function and reason -- 19 functions in `io.cpp`, plus `reporting.cpp`, `simulation.cpp`, and `string.cpp`. The `LyraReadmemLocal` and `LyraReadmemGlobal` functions previously silently skipped dirty notification when `engine_ptr` was null; this is now a hard error. The unused `engine_ptr` parameter was removed from `LyraReadmemNoNotify` (declaration, definition, LLVM function type, and call site). The misleading default `engine_ptr = nullptr` was removed from `FormatRuntimeValue` so callers must make an explicit choice. Codegen-time assertions were added at all five display-lowering sites in `display.cpp` to catch null engine pointers during IR generation rather than at runtime.

## Surface child stderr on crash/timeout in test output

The test framework's fork-per-case model already captures child stderr via a dedicated pipe, but the reporting layer in `main.cpp` discarded it for crash and timeout cases -- printing only `[  CRASH   ] name (signal=N)` with no further context. This now prints the captured stderr on the line below when non-empty. A custom `std::terminate_handler` is installed in the fork child before running the test action. When an `InternalError` thrown from a runtime C function crosses JIT frames that lack unwind tables, `std::terminate` is called; the custom handler prints the exception's `what()` to stderr before aborting, ensuring the message reaches the parent via the pipe. The `trace_manager_test` was updated for the new `PrintSummary(OutputDispatcher&)` signature.