### PR TITLE
Add simulation observability checkpoint for interrupt and flush

### DIFF
--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <deque>
@@ -947,6 +948,11 @@ class Engine {
   void ExecutePostponedRegion();
   void FlushDirtySlots();
 
+  // Long-run observability checkpoint: interrupt handling + periodic flush.
+  void HandleObservabilityCheckpoint();
+  void HandleInterruptRequestAtCheckpoint();
+  void HandlePeriodicStdoutFlushAtCheckpoint();
+
   // Decision settle-complete validation and diagnostics.
   void RunSettleCompleteChecks();
 
@@ -1679,6 +1685,19 @@ class Engine {
   std::vector<ProcessDeferredAssertionState> deferred_assertion_states_;
   std::vector<uint8_t> deferred_pending_flags_;
   std::vector<ProcessId> pending_deferred_processes_;
+
+  // Long-run observability: counter-gated periodic stdout flush.
+  struct ObservabilityConfig {
+    uint32_t clock_check_interval = 10000;
+    std::chrono::steady_clock::duration stdout_flush_period =
+        std::chrono::seconds(10);
+  };
+  ObservabilityConfig observability_config_{};
+  uint32_t observability_check_counter_ = 0;
+  std::chrono::steady_clock::time_point last_stdout_flush_time_{};
+  bool observability_initialized_ = false;
+
+  friend struct EngineTestAccess;
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/scheduler_snapshot.hpp
+++ b/include/lyra/runtime/scheduler_snapshot.hpp
@@ -17,6 +17,7 @@ enum class SimulationEndReason : uint8_t {
   kMaxTimeReached,
   kEmptyQueues,
   kTrap,
+  kInterrupted,
 };
 
 // Summary of one installed subscription for diagnostic rendering.

--- a/include/lyra/runtime/signal_interrupt.hpp
+++ b/include/lyra/runtime/signal_interrupt.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace lyra::runtime {
+
+// Install SIGINT/SIGTERM handlers that set a process-global interrupt flag.
+// Handlers only set the flag; they do not print or terminate.
+void InstallSimulationInterruptHandlers();
+
+// Restore the previous SIGINT/SIGTERM handlers and clear the flag.
+void RemoveSimulationInterruptHandlers();
+
+// Return true if an interrupt was requested since the last checkpoint and
+// clear the interrupt flag.
+auto ConsumeSimulationInterruptRequested() -> bool;
+
+}  // namespace lyra::runtime

--- a/src/lyra/runtime/engine_scheduler_activation.cpp
+++ b/src/lyra/runtime/engine_scheduler_activation.cpp
@@ -1,6 +1,10 @@
+#include <chrono>
 #include <cstdint>
+#include <cstdio>
 #include <format>
 #include <string>
+
+#include <fmt/core.h>
 
 #include "lyra/common/diagnostic/print.hpp"
 #include "lyra/common/internal_error.hpp"
@@ -9,6 +13,7 @@
 #include "lyra/runtime/engine_scheduler.hpp"
 #include "lyra/runtime/engine_types.hpp"
 #include "lyra/runtime/iteration_limit.hpp"
+#include "lyra/runtime/signal_interrupt.hpp"
 #include "lyra/runtime/trace_flush.hpp"
 
 namespace lyra::runtime {
@@ -307,6 +312,9 @@ void Engine::ExecuteTimeSlot() {
       static_cast<uint32_t>(Phase::kPostponed), std::memory_order_release);
   ExecutePostponedRegion();
   FlushDirtySlots();
+
+  HandleObservabilityCheckpoint();
+
   phase_.store(static_cast<uint32_t>(Phase::kIdle), std::memory_order_release);
 }
 
@@ -417,6 +425,44 @@ auto Engine::FormatProcess(uint32_t process_id) const -> std::string {
     return process_meta_.Format(process_id);
   }
   return std::format("<process {}>", process_id);
+}
+
+void Engine::HandleObservabilityCheckpoint() {
+  HandleInterruptRequestAtCheckpoint();
+  HandlePeriodicStdoutFlushAtCheckpoint();
+}
+
+void Engine::HandleInterruptRequestAtCheckpoint() {
+  if (!ConsumeSimulationInterruptRequested()) {
+    return;
+  }
+  fmt::print(stderr, "interrupted at sim time={}\n", current_time_);
+  std::fflush(stdout);
+  std::fflush(stderr);
+  finished_ = true;
+  end_reason_ = SimulationEndReason::kInterrupted;
+}
+
+void Engine::HandlePeriodicStdoutFlushAtCheckpoint() {
+  if (!observability_initialized_) {
+    last_stdout_flush_time_ = std::chrono::steady_clock::now();
+    observability_initialized_ = true;
+  }
+
+  if (++observability_check_counter_ <
+      observability_config_.clock_check_interval) {
+    return;
+  }
+  observability_check_counter_ = 0;
+
+  auto now = std::chrono::steady_clock::now();
+  if (now - last_stdout_flush_time_ <
+      observability_config_.stdout_flush_period) {
+    return;
+  }
+
+  std::fflush(stdout);
+  last_stdout_flush_time_ = now;
 }
 
 }  // namespace lyra::runtime

--- a/src/lyra/runtime/engine_scheduler_observability.cpp
+++ b/src/lyra/runtime/engine_scheduler_observability.cpp
@@ -358,6 +358,8 @@ auto EndReasonLabel(SimulationEndReason reason) -> std::string_view {
       return "empty event queues (no $finish)";
     case SimulationEndReason::kTrap:
       return "process trap";
+    case SimulationEndReason::kInterrupted:
+      return "interrupted by signal";
   }
   return "unknown";
 }

--- a/src/lyra/runtime/signal_interrupt.cpp
+++ b/src/lyra/runtime/signal_interrupt.cpp
@@ -1,0 +1,57 @@
+#include "lyra/runtime/signal_interrupt.hpp"
+
+#include <csignal>
+
+namespace lyra::runtime {
+
+namespace {
+
+struct SavedInterruptHandlers {
+  struct sigaction sigint_old{};
+  struct sigaction sigterm_old{};
+  bool installed = false;
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+volatile sig_atomic_t g_interrupt_requested = 0;
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+SavedInterruptHandlers g_saved{};
+
+void OnSimulationInterruptSignal(int /*signo*/) {
+  g_interrupt_requested = 1;
+}
+
+}  // namespace
+
+void InstallSimulationInterruptHandlers() {
+  g_interrupt_requested = 0;
+
+  struct sigaction sa{};
+  sa.sa_handler = OnSimulationInterruptSignal;
+  sa.sa_flags = SA_RESTART;
+  sigemptyset(&sa.sa_mask);
+
+  sigaction(SIGINT, &sa, &g_saved.sigint_old);
+  sigaction(SIGTERM, &sa, &g_saved.sigterm_old);
+  g_saved.installed = true;
+}
+
+void RemoveSimulationInterruptHandlers() {
+  if (g_saved.installed) {
+    sigaction(SIGINT, &g_saved.sigint_old, nullptr);
+    sigaction(SIGTERM, &g_saved.sigterm_old, nullptr);
+    g_saved.installed = false;
+  }
+  g_interrupt_requested = 0;
+}
+
+auto ConsumeSimulationInterruptRequested() -> bool {
+  if (g_interrupt_requested == 0) {
+    return false;
+  }
+  g_interrupt_requested = 0;
+  return true;
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -33,6 +33,7 @@
 #include "lyra/runtime/reporting.hpp"
 #include "lyra/runtime/runtime_instance.hpp"
 #include "lyra/runtime/signal_dump.hpp"
+#include "lyra/runtime/signal_interrupt.hpp"
 #include "lyra/runtime/slot_meta.hpp"
 #include "lyra/runtime/string.hpp"
 #include "lyra/runtime/trace_signal_meta.hpp"
@@ -53,6 +54,24 @@ auto FinalTime() -> uint64_t& {
   static uint64_t value = 0;
   return value;
 }
+
+// Minimal scope-exit guard for cleanup on all exit paths.
+template <typename F>
+class ScopeExit {
+ public:
+  explicit ScopeExit(F fn) : fn_(std::move(fn)) {
+  }
+  ~ScopeExit() noexcept {
+    fn_();
+  }
+  ScopeExit(const ScopeExit&) = delete;
+  ScopeExit(ScopeExit&&) = delete;
+  auto operator=(const ScopeExit&) -> ScopeExit& = delete;
+  auto operator=(ScopeExit&&) -> ScopeExit& = delete;
+
+ private:
+  F fn_;
+};
 
 }  // namespace
 
@@ -365,8 +384,13 @@ extern "C" void LyraRunSimulation(
     engine.GetTraceManager().SetEnabled(true);
   }
 
-  // Install SIGUSR1 dump handler for last-resort visibility
+  // Install signal handlers for simulation lifecycle.
   lyra::runtime::InstallSignalDumpHandler(&engine);
+  lyra::runtime::InstallSimulationInterruptHandlers();
+  ScopeExit signal_cleanup([] {
+    lyra::runtime::RemoveSimulationInterruptHandlers();
+    lyra::runtime::RemoveSignalDumpHandler();
+  });
 
   // Install DPI export-call context so export wrappers can borrow
   // DesignState* and Engine* during simulation.
@@ -378,8 +402,6 @@ extern "C" void LyraRunSimulation(
   lyra::runtime::ScopedDpiExportCallContext export_scope(export_ctx);
 
   SetupAndRunSimulation(engine, states, num_processes, num_connection);
-
-  lyra::runtime::RemoveSignalDumpHandler();
 
   if (HasFlag(flags, FeatureFlag::kEnableTraceSummary)) {
     engine.GetTraceManager().PrintSummary(engine.Output());

--- a/tests/framework/engine_test_access.hpp
+++ b/tests/framework/engine_test_access.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+#include "lyra/runtime/engine.hpp"
+
+namespace lyra::runtime {
+
+// Test-only access to Engine internals. Friended by Engine.
+struct EngineTestAccess {
+  static void SetObservabilityConfig(
+      Engine& engine, uint32_t clock_check_interval,
+      std::chrono::steady_clock::duration stdout_flush_period) {
+    engine.observability_config_.clock_check_interval = clock_check_interval;
+    engine.observability_config_.stdout_flush_period = stdout_flush_period;
+  }
+};
+
+}  // namespace lyra::runtime


### PR DESCRIPTION
## Summary

Long-running simulations had two observability gaps: stdout output from $display was invisible when redirected to a file (fully buffered, only flushed on $finish), and Ctrl-C/SIGTERM killed the process immediately with no indication of how far the simulation had progressed.

This adds a single scheduler-owned observability checkpoint that runs once per completed time step at the quiescent boundary after the postponed region. The checkpoint handles two concerns in order: pending interrupt requests, then periodic stdout flush. Both JIT and AOT get this automatically through the shared runtime path.

## Design

Signal handlers only set a process-global `volatile sig_atomic_t` flag. The checkpoint in `Engine::ExecuteTimeSlot()` reads the flag and terminates cleanly by setting `finished_ = true` with a new `kInterrupted` end reason, printing `interrupted at sim time=<time>` to stderr. Previous signal handlers are saved on install and restored exactly on removal, with RAII scope-exit ensuring cleanup on all exit paths.

The periodic flush uses a counter-gated wall-clock check: one integer increment per time step, clock read only every 10K steps, `fflush(stdout)` only every ~10 seconds. Hot-path overhead is one increment and branch per time step.

## Testing

- `jit_dev_tests` pass (checkpoint runs every time step without breaking scheduling)
- Manual SIGINT verification: sim prints `interrupted at sim time=<time>` and exits cleanly
- Manual flush verification: redirected $display output appears within ~10s without `stdbuf`
- Exception, ASCII, and LLVM boundary policy checks pass