### PR TITLE
Introduce runtime scope tree for hierarchy and DPI

### DIFF
--- a/include/lyra/common/hierarchy_node.hpp
+++ b/include/lyra/common/hierarchy_node.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <string>
+
+namespace lyra::common {
+
+// One node in the runtime scope hierarchy. Covers both module instances
+// (kInstance) and generate scopes (kGenerate). Built at AST->HIR time from
+// the slang instance tree, threaded through to the construction program
+// emitter. Strict construction order: parents appear before children.
+// Child ordering within each parent follows structural (declaration) order.
+struct HierarchyNode {
+  enum Kind : uint8_t { kInstance, kGenerate };
+  Kind kind = kInstance;
+  // Index of parent node in hierarchy_nodes. UINT32_MAX for root.
+  uint32_t parent_node_index = UINT32_MAX;
+  // Display label relative to parent (e.g., "u", "blk[0]", "gen_true").
+  // Derived from authoritative frontend path, not synthesized.
+  std::string label;
+  // Full hierarchical path from authoritative frontend source.
+  std::string full_path;
+  // For kInstance: index into instance payload tables (objects,
+  // instance_table). NOT a child position. UINT32_MAX for generate scopes.
+  uint32_t instance_index = UINT32_MAX;
+};
+
+// Canonical helper: count earlier siblings under the same parent to get
+// the child's ordinal in hierarchy_nodes tree order. This is the ONLY
+// valid child-position concept for runtime scope tree addressing.
+inline auto ComputeOrdinalInParent(
+    std::span<const HierarchyNode> nodes, uint32_t child_idx) -> uint32_t {
+  auto parent = nodes[child_idx].parent_node_index;
+  uint32_t ord = 0;
+  for (uint32_t i = 0; i < child_idx; ++i) {
+    if (nodes[i].parent_node_index == parent) ++ord;
+  }
+  return ord;
+}
+
+// Find the nearest enclosing instance node for a given node. Walks up
+// parent_node_index chain until an instance is found.
+inline auto FindEnclosingInstanceNode(
+    std::span<const HierarchyNode> nodes, uint32_t node_idx) -> uint32_t {
+  uint32_t current = nodes[node_idx].parent_node_index;
+  while (current != UINT32_MAX) {
+    if (nodes[current].kind == HierarchyNode::kInstance) return current;
+    current = nodes[current].parent_node_index;
+  }
+  return UINT32_MAX;
+}
+
+}  // namespace lyra::common

--- a/include/lyra/llvm_backend/codegen_session.hpp
+++ b/include/lyra/llvm_backend/codegen_session.hpp
@@ -243,10 +243,17 @@ struct ConstructionProgramData {
   std::vector<common::SerializedExtRefBinding> ext_ref_binding_pool;
   std::vector<uint32_t> ext_ref_binding_offsets;
   std::vector<uint32_t> ext_ref_binding_counts;
-  // Flat pool of coord steps for structural child edge metadata.
-  // Each entry's coord_offset/coord_count indexes into this pool.
-  // Steps are packed as (kind_u32, construct_index, alt_index) triples.
-  std::vector<uint32_t> coord_steps_pool;
+  // LLVM emission helper only. Per-body mapping from body-local
+  // child_site_index (ChildBindingSiteId) to tree-relative
+  // ordinal_in_parent in the runtime scope tree. Produced and consumed
+  // strictly during descriptor emission to bake the tree-relative
+  // ExprConnChildDesc::child_ordinal into emitted LLVM globals. It must
+  // not appear in any runtime ABI struct, C ABI boundary, or constructor
+  // replay consumer. If a runtime-side component needs this mapping,
+  // the design is wrong and the child-site concept should be replaced
+  // at its source, not re-exposed through a second bridge.
+  // Indexed by body_group; each inner vector is parallel to child_sites.
+  std::vector<std::vector<uint32_t>> child_site_to_tree_ordinal;
 };
 
 // Design-derived inputs for the realization/assembly phase, extracted during

--- a/include/lyra/llvm_backend/emit_descriptor_utils.hpp
+++ b/include/lyra/llvm_backend/emit_descriptor_utils.hpp
@@ -81,7 +81,8 @@ struct BodyDescriptorPackageEmission {
 // Body descriptor emission (emit_body_descriptors.cpp).
 auto EmitBodyRealizationDescs(
     Context& context, const Layout& layout,
-    std::span<const CodegenSession::BodyCompiledFuncs> body_compiled_funcs)
+    std::span<const CodegenSession::BodyCompiledFuncs> body_compiled_funcs,
+    std::span<const std::vector<uint32_t>> child_site_to_tree_ordinal)
     -> std::vector<BodyDescriptorPackageEmission>;
 
 // Connection descriptor emission (emit_connection_descriptors.cpp).

--- a/include/lyra/lowering/ast_to_hir/design.hpp
+++ b/include/lyra/lowering/ast_to_hir/design.hpp
@@ -4,6 +4,7 @@
 
 #include "lyra/common/body_timescale.hpp"
 #include "lyra/common/child_coord_map.hpp"
+#include "lyra/common/hierarchy_node.hpp"
 #include "lyra/common/module_identity.hpp"
 #include "lyra/hir/design.hpp"
 #include "lyra/lowering/ast_to_hir/port_binding.hpp"
@@ -24,6 +25,9 @@ struct DesignLoweringResult {
   // Built from DefinitionRepertoireDesc during AST-to-HIR. Consumed by
   // design_lower.cpp for durable child-site identity.
   common::ChildCoordMap child_coord_map;
+  // Full scope hierarchy including generate scopes. Built from slang AST
+  // during instance collection. Threaded through to construction program.
+  std::vector<common::HierarchyNode> hierarchy_nodes;
 };
 
 auto LowerDesign(

--- a/include/lyra/lowering/ast_to_hir/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/lower.hpp
@@ -9,6 +9,7 @@
 #include "lyra/common/child_coord_map.hpp"
 #include "lyra/common/constant_arena.hpp"
 #include "lyra/common/diagnostic/diagnostic_sink.hpp"
+#include "lyra/common/hierarchy_node.hpp"
 #include "lyra/common/module_identity.hpp"
 #include "lyra/common/source_manager.hpp"
 #include "lyra/common/symbol.hpp"
@@ -18,6 +19,7 @@
 #include "lyra/lowering/ast_to_hir/options.hpp"
 #include "lyra/lowering/ast_to_hir/port_binding.hpp"
 #include "lyra/lowering/ast_to_hir/source_mapper.hpp"
+#include "lyra/mir/construction_input.hpp"
 #include "lyra/mir/instance.hpp"
 
 namespace lyra::lowering::ast_to_hir {
@@ -44,6 +46,7 @@ struct LoweringResult {
   int8_t global_precision_power = -9;
   std::vector<common::BodyTimeScale> body_timescales;
   common::ChildCoordMap child_coord_map;
+  std::vector<common::HierarchyNode> hierarchy_nodes;
 };
 
 auto LowerAstToHir(

--- a/include/lyra/lowering/hir_to_mir/lower.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower.hpp
@@ -8,6 +8,7 @@
 #include "lyra/common/child_coord_map.hpp"
 #include "lyra/common/constant_arena.hpp"
 #include "lyra/common/diagnostic/diagnostic.hpp"
+#include "lyra/common/hierarchy_node.hpp"
 #include "lyra/common/module_identity.hpp"
 #include "lyra/common/symbol.hpp"
 #include "lyra/common/type_arena.hpp"
@@ -46,6 +47,8 @@ struct LoweringInput {
   // Per-body timescale table from AST->HIR. Parallel to spec groups.
   // Consumed during Phase 2 assembly to set timescale on mir::ModuleBody.
   const std::vector<common::BodyTimeScale>* body_timescales = nullptr;
+  // Full scope hierarchy including generate scopes. Built at AST->HIR time.
+  const std::vector<common::HierarchyNode>* hierarchy_nodes = nullptr;
 };
 
 // Statistics collected during HIR->MIR lowering (for --stats output).

--- a/include/lyra/mir/construction_input.hpp
+++ b/include/lyra/mir/construction_input.hpp
@@ -8,7 +8,6 @@
 #include "lyra/common/integral_constant.hpp"
 #include "lyra/common/module_identity.hpp"
 #include "lyra/common/symbol_types.hpp"
-#include "lyra/mir/external_ref.hpp"
 #include "lyra/mir/instance.hpp"
 
 namespace lyra::mir {
@@ -51,21 +50,6 @@ struct ConstructionInput {
   InstanceTable instance_table;
   std::vector<InstanceConstBlock> const_blocks;
   std::vector<ObjectRecord> objects;
-
-  // Per-instance parent index. Parallel to objects.
-  // parent_instance_indices[i] = parent's object index, or UINT32_MAX for
-  // top-level instances. Populated from BoundHierarchyIndex::parent_of
-  // during design lowering. Transport-only: consumed by the constructor
-  // to resolve live parent pointers during RunProgram ingestion.
-  std::vector<uint32_t> parent_instance_indices;
-
-  // Per-instance structural child identity. Parallel to objects.
-  // child_durable_ids[i] = DurableChildId of instance i within its parent.
-  // Default-constructed for top-level instances (empty coord, ordinal 0).
-  // Populated from oi_to_durable_child during design lowering.
-  // Transport-only: consumed by the constructor to populate structural
-  // child edges on RuntimeInstance during RunProgram ingestion.
-  std::vector<DurableChildId> child_durable_ids;
 
   // Per-instance resolved external-ref runtime bindings.
   // Parallel to objects. Each inner vector has one binding per ext-ref recipe

--- a/include/lyra/mir/construction_input.hpp
+++ b/include/lyra/mir/construction_input.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "lyra/common/ext_ref_binding.hpp"
+#include "lyra/common/hierarchy_node.hpp"
 #include "lyra/common/integral_constant.hpp"
 #include "lyra/common/module_identity.hpp"
 #include "lyra/common/symbol_types.hpp"
@@ -72,6 +73,13 @@ struct ConstructionInput {
   // Computed by BuildPerInstanceExtRefRuntimeBindings during design lowering.
   std::vector<std::vector<common::SerializedExtRefBinding>>
       instance_ext_ref_bindings;
+
+  // Full scope hierarchy including generate scopes. Strict construction
+  // order: parents before children. Module instances and generate scopes
+  // interleaved. Built at AST->HIR time, threaded through MIR lowering.
+  // Consumed by construction program emitter to produce scope-aware
+  // runtime hierarchy.
+  std::vector<common::HierarchyNode> hierarchy_nodes;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/runtime/body_realization_desc.hpp
+++ b/include/lyra/runtime/body_realization_desc.hpp
@@ -98,12 +98,10 @@ struct BodyRealizationDesc {
   // expression suffix. Parallel ExprConnChildDesc provides child binding
   // metadata for each.
   const ExprConnChildDesc* expr_conn_child_descs = nullptr;
-  const uint32_t* expr_conn_coord_words = nullptr;
-  uint32_t num_expr_conn_coord_words = 0;
   uint32_t num_expr_connections = 0;
 };
 
-static_assert(sizeof(BodyRealizationDesc) == 96);
+static_assert(sizeof(BodyRealizationDesc) == 88);
 static_assert(offsetof(BodyRealizationDesc, num_processes) == 0);
 static_assert(offsetof(BodyRealizationDesc, slot_count) == 4);
 static_assert(offsetof(BodyRealizationDesc, inline_state_size_bytes) == 8);
@@ -117,9 +115,7 @@ static_assert(offsetof(BodyRealizationDesc, num_inline_slot_offsets) == 48);
 static_assert(offsetof(BodyRealizationDesc, port_entries) == 56);
 static_assert(offsetof(BodyRealizationDesc, num_port_entries) == 64);
 static_assert(offsetof(BodyRealizationDesc, expr_conn_child_descs) == 72);
-static_assert(offsetof(BodyRealizationDesc, expr_conn_coord_words) == 80);
-static_assert(offsetof(BodyRealizationDesc, num_expr_conn_coord_words) == 88);
-static_assert(offsetof(BodyRealizationDesc, num_expr_connections) == 92);
+static_assert(offsetof(BodyRealizationDesc, num_expr_connections) == 80);
 static_assert(std::is_trivially_copyable_v<BodyRealizationDesc>);
 static_assert(std::is_standard_layout_v<BodyRealizationDesc>);
 
@@ -132,11 +128,11 @@ static_assert(std::is_standard_layout_v<BodyRealizationDesc>);
 // resolution (port sym -> local slot -> byte offset) is constructor work,
 // using the child's own emitted body descriptor.
 struct ExprConnChildDesc {
-  // Structural child identity: RepertoireCoord encoded as 3 uint32_t words
-  // per SelectionStepDesc {kind, construct_index, alt_index} in a flat pool.
-  // Encoding matches ConstructionProgramEntry (constructor_.cpp:35-59).
-  uint32_t coord_word_offset = 0;
-  uint32_t coord_step_count = 0;
+  // Tree-relative direct child position in the parent runtime scope's
+  // children vector. Includes generate scopes and module instances in a
+  // single unified ordinal space. Resolved at runtime by direct indexing
+  // into parent->scope.children. Not instance-table order, not
+  // child-site order, not coord-based identity.
   uint32_t child_ordinal = 0;
   // Symbolic child public port identity. Constructor resolves this to
   // concrete local slot and byte offset using the child's emitted port
@@ -148,12 +144,10 @@ struct ExprConnChildDesc {
   uint32_t binding_byte_offset = 0;
 };
 
-static_assert(sizeof(ExprConnChildDesc) == 20);
-static_assert(offsetof(ExprConnChildDesc, coord_word_offset) == 0);
-static_assert(offsetof(ExprConnChildDesc, coord_step_count) == 4);
-static_assert(offsetof(ExprConnChildDesc, child_ordinal) == 8);
-static_assert(offsetof(ExprConnChildDesc, child_port_sym_value) == 12);
-static_assert(offsetof(ExprConnChildDesc, binding_byte_offset) == 16);
+static_assert(sizeof(ExprConnChildDesc) == 12);
+static_assert(offsetof(ExprConnChildDesc, child_ordinal) == 0);
+static_assert(offsetof(ExprConnChildDesc, child_port_sym_value) == 4);
+static_assert(offsetof(ExprConnChildDesc, binding_byte_offset) == 8);
 static_assert(std::is_trivially_copyable_v<ExprConnChildDesc>);
 static_assert(std::is_standard_layout_v<ExprConnChildDesc>);
 

--- a/include/lyra/runtime/construction_program_abi.hpp
+++ b/include/lyra/runtime/construction_program_abi.hpp
@@ -9,38 +9,59 @@
 
 namespace lyra::runtime {
 
-// Construction program entry: one per module instance, in strict ModuleIndex
-// order. This entire type is emitted LLVM transport for constructor
-// ingestion only. It is never a runtime semantic carrier. All fields
-// are consumed exactly once in LyraConstructorRunProgram and do not
-// survive into any runtime-facing struct or API.
+// Runtime scope tree node kind carried in ConstructionProgramEntry.
+// Typed at the C++ source-of-truth; emitted and consumed through an i32
+// at the LLVM ABI boundary. Underlying type is fixed so struct layout
+// and LLVM struct type stay in lockstep.
+enum class ConstructionNodeKind : uint32_t {
+  kInstance = 0,
+  kGenerate = 1,
+};
+
+// Construction program entry: one per scope node (module instance or
+// generate scope), in strict parent-before-child order. Emitted LLVM
+// transport for constructor ingestion only. All fields are consumed
+// exactly once in LyraConstructorRunProgram and do not survive into
+// any runtime-facing struct or API.
+//
+// Hierarchical paths are NOT transported. The constructor derives each
+// scope's path from its parent's path_storage + label via BuildScopePath,
+// so only the parent-relative label is needed here.
 struct ConstructionProgramEntry {
+  ConstructionNodeKind node_kind;
+  // Body group index (kInstance only; 0 for kGenerate).
   uint32_t body_group;
-  uint32_t path_offset;
+  // Scope label (relative to parent) offset into path_pool.
+  uint32_t label_offset;
+  // Parameter data (kInstance only; 0/0 for kGenerate).
   uint32_t param_offset;
   uint32_t param_size;
+  // Parent scope index in entry order. UINT32_MAX for root.
+  uint32_t parent_scope_index;
+  // Ordinal of this node among parent's children.
+  uint32_t ordinal_in_parent;
+  // For kInstance: compile-time object_index (sorted all_instances position).
+  // Used as owner_ordinal so result.instances[object_index] matches the
+  // compile-time model. 0 for kGenerate.
+  uint32_t instance_index;
+  // Realized storage sizes (kInstance only; 0/0 for kGenerate).
   uint64_t realized_inline_size;
   uint64_t realized_appendix_size;
-  // Parent instance index in construction order. UINT32_MAX for top-level.
-  // Transport-only: consumed in LyraConstructorRunProgram to resolve a
-  // live RuntimeInstance* parent pointer. Does not survive into any
-  // runtime carrier after ingestion.
-  uint32_t parent_instance_index;
-  // Structural child edge metadata. Transport-only: consumed in
-  // LyraConstructorRunProgram to populate RuntimeInstance::ChildEdge.
-  // These are edge metadata for structural relation materialization,
-  // not runtime object identity or a general-purpose query key.
-  uint32_t child_ordinal_in_coord;
-  // Offset and count into the coord_steps pool for this child's
-  // RepertoireCoord. UINT32_MAX offset = empty coord (non-generate).
-  uint32_t coord_offset;
-  uint32_t coord_count;
-  // Local instance name offset into path_pool (e.g. "u0").
-  // Presentation input for path derivation during assembly.
-  // Originates from InstanceEntry::inst_name at compile time -- not
-  // recovered from full path strings. Not stored on RuntimeInstance.
-  uint32_t inst_name_offset;
 };
+
+// Verify struct layout matches the LLVM emission in
+// emit_realization_descriptors.cpp.
+static_assert(offsetof(ConstructionProgramEntry, node_kind) == 0);
+static_assert(offsetof(ConstructionProgramEntry, body_group) == 4);
+static_assert(offsetof(ConstructionProgramEntry, label_offset) == 8);
+static_assert(offsetof(ConstructionProgramEntry, param_offset) == 12);
+static_assert(offsetof(ConstructionProgramEntry, param_size) == 16);
+static_assert(offsetof(ConstructionProgramEntry, parent_scope_index) == 20);
+static_assert(offsetof(ConstructionProgramEntry, ordinal_in_parent) == 24);
+static_assert(offsetof(ConstructionProgramEntry, instance_index) == 28);
+static_assert(offsetof(ConstructionProgramEntry, realized_inline_size) == 32);
+static_assert(offsetof(ConstructionProgramEntry, realized_appendix_size) == 40);
+static_assert(sizeof(ConstructionProgramEntry) == 48);
 
 // Flat POD reference to one body descriptor package. Mirrors the data
 // passed to LyraConstructorBeginBody as individual pointer+count C ABI

--- a/include/lyra/runtime/constructor_.hpp
+++ b/include/lyra/runtime/constructor_.hpp
@@ -182,6 +182,10 @@ struct ConstructionResult {
   // Lifetime: owned by this result, outlives simulation.
   std::vector<std::unique_ptr<RuntimeInstance>> instances;
 
+  // Constructor-produced generate scope objects.
+  // Lifetime: owned by this result, outlives simulation.
+  std::vector<std::unique_ptr<RuntimeGenerateScope>> generate_scopes;
+
   // R4 prep: per-instance metadata bundles alongside existing flat handoff.
   // Each bundle binds one module instance to its shared body template.
   // Validated: bundle[i].instance_id == i.
@@ -276,27 +280,26 @@ class Constructor {
   // meta.entries.size().
   void BeginBody(const BodyDescriptorPackage& package);
 
-  // Create one child instance of the current body in parent context.
-  // Structural relation and derived path are established inside this
-  // method: parent->children gains a typed ChildEdge, and child->parent
-  // points back. Path is derived from parent path + inst_name.
-  //
-  // parent: parent instance, or nullptr for top-level (root) instances.
-  // edge_coord: generate-scope context for the child edge (empty for
-  //   non-generate instances). Structural edge metadata for relation
-  //   materialization, not runtime object identity or query key.
-  //   Ownership transferred into the stored child edge (moved).
-  // edge_ordinal: child ordinal within the coord context. Same role
-  //   as edge_coord -- structural edge metadata, not identity.
-  // inst_name: local instance name for path derivation (e.g. "u0").
-  //   Consumed during assembly, not stored on the instance.
-  // param_data/param_data_size: pre-lowered canonical storage bytes for
-  //   parameter initialization. nullptr/0 if no params.
+  // Create a generate scope node in parent scope context.
+  // Hierarchy-only: no storage, no body, no processes.
+  // The full hierarchical path is derived inside the constructor from
+  // parent_scope->path_storage + label; callers must not transport it.
+  auto CreateScope(
+      RuntimeScope* parent_scope, const char* label, uint32_t ordinal_in_parent)
+      -> RuntimeScope*;
+
+  // Create one child instance of the current body in parent scope context.
+  // parent_scope: parent scope, or nullptr for top-level (root) instances.
+  // instance_index: compile-time object_index (sorted all_instances position).
+  //   Used as owner_ordinal for stable indexing.
+  // label: scope label for path derivation (e.g. "u0"). The full
+  //   hierarchical path is derived from parent_scope + label by the
+  //   constructor; callers must not transport full paths.
+  // param_data/param_data_size: pre-lowered canonical storage bytes.
   // Returns the created instance (owned by the constructor).
-  // Fails immediately if no active body.
-  auto CreateChild(
-      RuntimeInstance* parent, common::RepertoireCoord edge_coord,
-      uint32_t edge_ordinal, const char* inst_name, const void* param_data,
+  auto CreateChildInstance(
+      RuntimeScope* parent_scope, uint32_t ordinal_in_parent,
+      uint32_t instance_index, const char* label, const void* param_data,
       uint32_t param_data_size, uint64_t realized_inline_size,
       uint64_t realized_appendix_size) -> RuntimeInstance*;
 
@@ -370,9 +373,12 @@ class Constructor {
   std::deque<StableBodyTemplate> body_desc_storage_;
 
   std::vector<StagedProcess> staged_;
-  // Constructor-owned RuntimeInstance objects created during AddInstance.
-  // Moved into ConstructionResult at Finalize.
+  // Constructor-owned RuntimeInstance objects created during
+  // CreateChildInstance. Moved into ConstructionResult at Finalize.
   std::vector<std::unique_ptr<RuntimeInstance>> staged_instances_;
+  // Constructor-owned generate scope objects created during CreateScope.
+  // Moved into ConstructionResult at Finalize.
+  std::vector<std::unique_ptr<RuntimeGenerateScope>> staged_generate_scopes_;
   // R4 prep: per-instance metadata bundles. Moved into ConstructionResult
   // at Finalize.
   std::vector<InstanceMetadataBundle> staged_bundles_;
@@ -494,8 +500,7 @@ void LyraConstructorRunProgram(
     uint32_t body_desc_count, const char* path_pool, uint32_t path_pool_size,
     const uint8_t* param_pool, uint32_t param_pool_size,
     const lyra::runtime::ConstructionProgramEntry* entries,
-    uint32_t entry_count, const uint32_t* coord_steps_pool,
-    uint32_t coord_steps_word_count);
+    uint32_t entry_count);
 
 auto LyraConstructorFinalize(void* ctor) -> void*;
 

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -629,32 +629,36 @@ class Engine {
   // Validate an svScope handle against the authoritative registry.
   // Returns nullptr for null scope. Throws InternalError for non-null
   // handles that are not registered (prevents dangling pointer use).
+  // svScope is any scope node (module instance or generate scope);
+  // callers that need module-instance semantics narrow with
+  // ScopeAsInstanceChecked.
   [[nodiscard]] auto ValidateScopeHandle(svScope scope) const
-      -> const RuntimeInstance*;
+      -> const RuntimeScope*;
 
   // Non-throwing scope handle validity check.
-  // Returns true if inst is registered in the DPI scope registry.
-  [[nodiscard]] auto IsScopeHandleValid(const RuntimeInstance* inst) const
+  // Returns true if scope is registered in the DPI scope registry.
+  [[nodiscard]] auto IsScopeHandleValid(const RuntimeScope* scope) const
       -> bool;
 
-  // Resolve a hierarchical path to an instance scope handle.
+  // Resolve a hierarchical path to a scope handle.
   // Returns nullptr if path is not found.
   [[nodiscard]] auto ResolveScopeByPath(std::string_view path) const
-      -> const RuntimeInstance*;
+      -> const RuntimeScope*;
 
   // Get the canonical hierarchical path for a scope handle.
-  // Returns nullptr for null inst. Throws InternalError for unregistered inst.
-  [[nodiscard]] auto GetScopePath(const RuntimeInstance* inst) const -> const
+  // Returns nullptr for null scope. Throws InternalError for unregistered
+  // scope.
+  [[nodiscard]] auto GetScopePath(const RuntimeScope* scope) const -> const
       char*;
 
   // Per-scope user-data storage (svPutUserData/svGetUserData).
   // Returns 0 on success, -1 on error (null scope or null key).
-  auto PutScopeUserData(const RuntimeInstance* inst, void* key, void* data)
+  auto PutScopeUserData(const RuntimeScope* scope, void* key, void* data)
       -> int;
 
   // Returns nullptr on error (null scope, null key, or key not found).
   [[nodiscard]] auto GetScopeUserData(
-      const RuntimeInstance* inst, void* key) const -> void*;
+      const RuntimeScope* scope, void* key) const -> void*;
 
   // D6d: Per-instance time metadata, populated from BodyRealizationDesc.
   static void InitInstanceTimeMetadata(
@@ -669,12 +673,14 @@ class Engine {
       -> SimulationTimeSemantics;
 
   // D6d: Scope-aware time unit/precision queries.
-  // null inst -> simulation-level semantics.
-  // non-null inst -> per-instance metadata from body descriptor.
-  [[nodiscard]] auto GetScopeTimeUnitPower(const RuntimeInstance* inst) const
+  // null scope -> simulation-level semantics.
+  // non-null scope -> per-enclosing-instance metadata from body descriptor.
+  // For generate scopes, metadata is inherited from the nearest enclosing
+  // module instance (per IEEE 1800 generate block timescale rules).
+  [[nodiscard]] auto GetScopeTimeUnitPower(const RuntimeScope* scope) const
       -> int32_t;
-  [[nodiscard]] auto GetScopeTimePrecisionPower(
-      const RuntimeInstance* inst) const -> int32_t;
+  [[nodiscard]] auto GetScopeTimePrecisionPower(const RuntimeScope* scope) const
+      -> int32_t;
 
   // Plusargs query interface for $test$plusargs and $value$plusargs.
   // Returns 1 if prefix matches any plusarg, 0 otherwise.
@@ -1636,16 +1642,18 @@ class Engine {
   std::vector<PendingModuleProcessMeta> pending_module_process_meta_;
 
   // DPI scope registry (D6b). Built once by BuildDpiScopeRegistry().
-  // Authoritative membership set for scope handle validation.
-  std::unordered_set<const RuntimeInstance*> valid_scopes_;
-  // Reverse path -> instance lookup for svGetScopeFromName.
-  std::unordered_map<std::string_view, const RuntimeInstance*> scope_path_map_;
-  // Reverse instance -> canonical path for svGetNameFromScope.
-  std::unordered_map<const RuntimeInstance*, const char*> scope_inst_path_map_;
+  // Keyed by RuntimeScope* so the registry covers the full runtime scope
+  // tree (module instances and generate scopes alike). Callers that need
+  // module-instance semantics narrow each scope with ScopeAsInstanceChecked.
+  std::unordered_set<const RuntimeScope*> valid_scopes_;
+  // Reverse path -> scope lookup for svGetScopeFromName.
+  std::unordered_map<std::string_view, const RuntimeScope*> scope_path_map_;
+  // Reverse scope -> canonical path for svGetNameFromScope.
+  std::unordered_map<const RuntimeScope*, const char*> scope_path_by_ptr_;
   // Per-scope user-data storage for svPutUserData/svGetUserData.
-  // Outer key: instance pointer. Inner key: user-provided void* key.
+  // Outer key: scope pointer. Inner key: user-provided void* key.
   mutable std::unordered_map<
-      const RuntimeInstance*, std::unordered_map<void*, void*>>
+      const RuntimeScope*, std::unordered_map<void*, void*>>
       scope_user_data_;
 
   // Immutable per-owner decision metadata tables. Indexed by owner_id.

--- a/include/lyra/runtime/runtime_instance.hpp
+++ b/include/lyra/runtime/runtime_instance.hpp
@@ -3,14 +3,14 @@
 #include <cstddef>
 #include <cstdint>
 #include <span>
-#include <string>
 #include <vector>
 
+#include "lyra/common/internal_error.hpp"
 #include "lyra/common/local_slot_id.hpp"
-#include "lyra/common/selection_step.hpp"
 #include "lyra/runtime/instance_event_state.hpp"
 #include "lyra/runtime/instance_observability.hpp"
 #include "lyra/runtime/process_frame.hpp"
+#include "lyra/runtime/runtime_scope.hpp"
 #include "lyra/runtime/signal_coord.hpp"
 
 namespace lyra::runtime {
@@ -209,7 +209,14 @@ struct RuntimeInstance {
 
   // --- Non-contract fields (invisible to codegen) ---
 
-  const char* path_c_str = nullptr;
+  // Hierarchy identity. Owns parent/child edges, hierarchical path, and
+  // scope kind. Shared structural shape with RuntimeGenerateScope.
+  RuntimeScope scope;
+
+  // Instance payload index. Matches the compile-time object_index
+  // (sorted all_instances position). Used for indexing into
+  // result.instances, instance_bundles, and instance_ptrs.
+  // Instance-specific, not generic scope identity.
   uint32_t owner_ordinal = 0;
 
   // Canonical per-instance attached-process carrier.
@@ -218,30 +225,6 @@ struct RuntimeInstance {
   // Parallel to per-body process ordinals (body-local index i
   // corresponds to attached_processes[i]).
   std::vector<RuntimeProcess*> attached_processes;
-
-  // Primary structural hierarchy (not part of binary contract with codegen).
-  // Established during constructor assembly: CreateChild sets parent and
-  // appends a typed RuntimeChildEdge to parent->children in a single
-  // creation path.
-  RuntimeInstance* parent = nullptr;
-
-  // Typed structural child edges. Each edge carries structural metadata
-  // (generate-scope context + ordinal within that context) for procedural
-  // walking by compile-time path recipes. These are edge metadata, not
-  // object identity -- they enable navigation without key lookup.
-  struct ChildEdge {
-    common::RepertoireCoord coord;
-    uint32_t child_ordinal_in_coord = 0;
-    RuntimeInstance* child = nullptr;
-  };
-  std::vector<ChildEdge> children;
-
-  // Instance-owned hierarchical path string. Derived from structural
-  // position during assembly (parent path + child display label).
-  // The display label is consumed during assembly and not stored.
-  // Owns the storage that path_c_str points into.
-  // Not part of the binary contract with codegen.
-  std::string path_storage;
 
   // Backing storage for resolved ext-ref bindings.
   // ext_ref_bindings (binary contract ptr) points into this vector.
@@ -347,5 +330,37 @@ auto AllocateOwnedInlineStorage(uint64_t size) -> uint8_t*;
 
 // Allocate zero-initialized owned storage for an instance's appendix region.
 auto AllocateOwnedAppendixStorage(uint64_t size) -> uint8_t*;
+
+// container_of: recover RuntimeInstance* from its embedded RuntimeScope*.
+// Checked precondition: scope != nullptr and scope->kind == kInstance.
+// Standard-layout is required for offsetof on the containing type.
+static_assert(std::is_standard_layout_v<RuntimeInstance>);
+
+inline auto ScopeAsInstanceChecked(RuntimeScope* scope) -> RuntimeInstance* {
+  if (scope == nullptr) {
+    throw common::InternalError("ScopeAsInstanceChecked", "null RuntimeScope*");
+  }
+  if (scope->kind != RuntimeScopeKind::kInstance) {
+    throw common::InternalError(
+        "ScopeAsInstanceChecked",
+        "scope is not kInstance; cannot recover RuntimeInstance*");
+  }
+  return reinterpret_cast<RuntimeInstance*>(
+      reinterpret_cast<char*>(scope) - offsetof(RuntimeInstance, scope));
+}
+
+inline auto ScopeAsInstanceChecked(const RuntimeScope* scope)
+    -> const RuntimeInstance* {
+  if (scope == nullptr) {
+    throw common::InternalError("ScopeAsInstanceChecked", "null RuntimeScope*");
+  }
+  if (scope->kind != RuntimeScopeKind::kInstance) {
+    throw common::InternalError(
+        "ScopeAsInstanceChecked",
+        "scope is not kInstance; cannot recover RuntimeInstance*");
+  }
+  return reinterpret_cast<const RuntimeInstance*>(
+      reinterpret_cast<const char*>(scope) - offsetof(RuntimeInstance, scope));
+}
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_scope.hpp
+++ b/include/lyra/runtime/runtime_scope.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace lyra::runtime {
+
+struct RuntimeScope;
+
+enum class RuntimeScopeKind : uint8_t {
+  kInstance,
+  kGenerate,
+};
+
+struct RuntimeChildEdge {
+  uint32_t ordinal_in_parent = 0;
+  RuntimeScope* child = nullptr;
+};
+
+// Common hierarchy base for all runtime scope nodes (module instances and
+// generate scopes). Not a base class -- embedded as a member in
+// RuntimeInstance and RuntimeGenerateScope. No virtual dispatch.
+//
+// Owns hierarchical path string, parent/child edges, and scope identity.
+// Instance-specific payload (storage, body, processes, observability) lives
+// on RuntimeInstance, not here.
+struct RuntimeScope {
+  RuntimeScopeKind kind = RuntimeScopeKind::kInstance;
+  RuntimeScope* parent = nullptr;
+  std::vector<RuntimeChildEdge> children;
+  std::string path_storage;
+  const char* path_c_str = nullptr;
+  uint32_t ordinal_in_parent = 0;
+};
+
+// Generate scope node: pure hierarchy intermediate with no storage, body,
+// processes, or observability. Exists only to give generate scopes a real
+// runtime identity and correct hierarchical path.
+struct RuntimeGenerateScope {
+  RuntimeScope scope;
+};
+
+// Lock down embedded-scope representation across both node kinds.
+// RuntimeInstance asserts the same property in runtime_instance.hpp once
+// its layout is visible. Together these guarantee that scope is always
+// the first member of its enclosing struct and container_of recovery is
+// well-defined.
+static_assert(std::is_standard_layout_v<RuntimeScope>);
+static_assert(std::is_standard_layout_v<RuntimeGenerateScope>);
+
+// Recover the containing RuntimeInstance from an instance-kind scope
+// pointer. Uses the standard container_of pattern. Checks the precondition
+// scope != nullptr && scope->kind == kInstance on entry. Defined inline
+// in runtime_instance.hpp once RuntimeInstance layout is visible.
+struct RuntimeInstance;
+auto ScopeAsInstanceChecked(RuntimeScope* scope) -> RuntimeInstance*;
+auto ScopeAsInstanceChecked(const RuntimeScope* scope)
+    -> const RuntimeInstance*;
+
+}  // namespace lyra::runtime

--- a/src/lyra/driver/dump.cpp
+++ b/src/lyra/driver/dump.cpp
@@ -117,6 +117,7 @@ auto DumpMir(const CompilationInput& input) -> int {
       .specialization_map = &hir_result.specialization_map,
       .child_coord_map = &hir_result.child_coord_map,
       .body_timescales = &hir_result.body_timescales,
+      .hierarchy_nodes = &hir_result.hierarchy_nodes,
   };
   std::expected<lowering::hir_to_mir::LoweringResult, Diagnostic> mir_result;
   {
@@ -188,6 +189,7 @@ auto DumpDpiHeader(const CompilationInput& input) -> int {
       .specialization_map = &hir_result.specialization_map,
       .child_coord_map = &hir_result.child_coord_map,
       .body_timescales = &hir_result.body_timescales,
+      .hierarchy_nodes = &hir_result.hierarchy_nodes,
   };
   std::expected<lowering::hir_to_mir::LoweringResult, Diagnostic> mir_result;
   {
@@ -257,6 +259,7 @@ auto DumpLlvm(const CompilationInput& input) -> int {
       .specialization_map = &hir_result.specialization_map,
       .child_coord_map = &hir_result.child_coord_map,
       .body_timescales = &hir_result.body_timescales,
+      .hierarchy_nodes = &hir_result.hierarchy_nodes,
   };
   std::expected<lowering::hir_to_mir::LoweringResult, Diagnostic> mir_result;
   {

--- a/src/lyra/driver/pipeline.cpp
+++ b/src/lyra/driver/pipeline.cpp
@@ -63,6 +63,7 @@ auto CompileToMir(const CompilationInput& input, CompilationOutput& output)
       .specialization_map = &hir_result.specialization_map,
       .child_coord_map = &hir_result.child_coord_map,
       .body_timescales = &hir_result.body_timescales,
+      .hierarchy_nodes = &hir_result.hierarchy_nodes,
   };
 
   std::expected<lowering::hir_to_mir::LoweringResult, Diagnostic> mir_result;

--- a/src/lyra/llvm_backend/dpi_abi.cpp
+++ b/src/lyra/llvm_backend/dpi_abi.cpp
@@ -27,6 +27,7 @@
 #include "lyra/llvm_backend/value_repr.hpp"
 #include "lyra/mir/dpi_verify.hpp"
 #include "lyra/runtime/dpi_export_context.hpp"
+#include "lyra/runtime/runtime_instance.hpp"
 
 namespace lyra::lowering::mir_to_llvm::dpi {
 
@@ -1101,9 +1102,22 @@ static_assert(
     "BuildDpiResolvedModuleBindingType");
 
 // All other contexts (package scope, compilation-unit scope) get null.
+// svScope is a RuntimeScope* at the ABI boundary: for module instances,
+// that is &inst->scope (the RuntimeScope embedded inside RuntimeInstance),
+// not the instance container pointer. We emit a byte-GEP to reach the
+// scope offset within the instance. Host and target layouts match for
+// this binary, so offsetof is authoritative at codegen time.
 auto ResolveDpiCallerScope(Context& context) -> llvm::Value* {
   if (llvm::Value* inst = context.GetInstancePointer()) {
-    return inst;
+    auto& llvm_ctx = context.GetLlvmContext();
+    auto& builder = context.GetBuilder();
+    auto* i8_ty = llvm::Type::getInt8Ty(llvm_ctx);
+    auto* i64_ty = llvm::Type::getInt64Ty(llvm_ctx);
+    auto offset =
+        static_cast<int64_t>(offsetof(lyra::runtime::RuntimeInstance, scope));
+    if (offset == 0) return inst;
+    return builder.CreateInBoundsGEP(
+        i8_ty, inst, llvm::ConstantInt::get(i64_ty, offset), "dpi.scope.ptr");
   }
   auto* ptr_ty = llvm::PointerType::getUnqual(context.GetLlvmContext());
   return llvm::ConstantPointerNull::get(ptr_ty);

--- a/src/lyra/llvm_backend/emit_body_descriptors.cpp
+++ b/src/lyra/llvm_backend/emit_body_descriptors.cpp
@@ -37,7 +37,9 @@ struct DecisionTableEmission {
 auto EmitBodyRealizationDescs(
     Context& context, const Layout& layout,
     std::span<const lowering::mir_to_llvm::CodegenSession::BodyCompiledFuncs>
-        body_compiled_funcs) -> std::vector<BodyDescriptorPackageEmission> {
+        body_compiled_funcs,
+    std::span<const std::vector<uint32_t>> child_site_to_tree_ordinal)
+    -> std::vector<BodyDescriptorPackageEmission> {
   auto& ctx = context.GetLlvmContext();
   auto& mod = context.GetModule();
   auto* i16_ty = llvm::Type::getInt16Ty(ctx);
@@ -53,19 +55,18 @@ auto EmitBodyRealizationDescs(
             body_compiled_funcs.size(), layout.body_realization_infos.size()));
   }
 
-  // BodyRealizationDesc ABI (96 bytes):
+  // BodyRealizationDesc ABI (88 bytes):
   //   {u32 num_processes, u32 slot_count,
   //    u64 inline_state_size_bytes, u64 appendix_state_size_bytes,
   //    u64 total_state_size_bytes, i8 time_unit_power, i8 time_precision_power,
   //    [2 x i8 pad], u32 event_count,
   //    ptr inline_slot_offsets, u32 num_inline_slot_offsets, [4 x pad],
   //    ptr port_entries, u32 num_port_entries, [4 x pad],
-  //    ptr expr_conn_child_descs, ptr expr_conn_coord_words,
-  //    u32 num_expr_conn_coord_words, u32 num_expr_connections}
+  //    ptr expr_conn_child_descs, u32 num_expr_connections, [4 x pad]}
   auto* i8_ty = llvm::Type::getInt8Ty(ctx);
   auto* header_type = llvm::StructType::get(
       ctx, {i32_ty, i32_ty, i64_ty, i64_ty, i64_ty, i8_ty, i8_ty, i32_ty,
-            ptr_ty, i32_ty, ptr_ty, i32_ty, ptr_ty, ptr_ty, i32_ty, i32_ty});
+            ptr_ty, i32_ty, ptr_ty, i32_ty, ptr_ty, i32_ty});
   // BodyProcessEntry ABI: {ptr shared_body_fn, u32 schema_index, u32 pad}
   auto* entry_type = llvm::StructType::get(ctx, {ptr_ty, i32_ty, i32_ty});
 
@@ -174,21 +175,16 @@ auto EmitBodyRealizationDescs(
               llvm::ConstantInt::get(i32_ty, 0)});
     }
 
-    // Expression connection child descriptor and coord pool emission.
+    // Expression connection child descriptor emission.
     llvm::Constant* expr_child_descs_ptr = null_ptr;
-    llvm::Constant* expr_coord_words_ptr = null_ptr;
-    uint32_t expr_coord_word_count = 0;
     uint32_t num_expr_connections = info.num_expr_connections;
 
     if (num_expr_connections > 0 && info.body != nullptr) {
       const auto& body = *info.body;
-      // ExprConnChildDesc ABI: {u32 coord_word_offset, u32 coord_step_count,
-      //   u32 child_ordinal, u32 child_port_sym_value, u32 binding_byte_offset}
-      auto* desc_type =
-          llvm::StructType::get(ctx, {i32_ty, i32_ty, i32_ty, i32_ty, i32_ty});
+      // ExprConnChildDesc ABI: {u32 child_ordinal,
+      //   u32 child_port_sym_value, u32 binding_byte_offset}
+      auto* desc_type = llvm::StructType::get(ctx, {i32_ty, i32_ty, i32_ty});
 
-      // Build coord word pool and descriptor constants.
-      std::vector<uint32_t> coord_pool;
       std::vector<llvm::Constant*> desc_consts;
       desc_consts.reserve(num_expr_connections);
 
@@ -205,17 +201,6 @@ auto EmitBodyRealizationDescs(
                   "body {} expr conn {} has invalid child_port_sym", body_group,
                   ci));
         }
-        const auto& site = body.child_sites[tmpl.child_site.value];
-        const auto& durable_id = site.id;
-
-        // Encode coord into flat pool.
-        auto word_offset = static_cast<uint32_t>(coord_pool.size());
-        auto step_count = static_cast<uint32_t>(durable_id.coord.size());
-        for (const auto& step : durable_id.coord) {
-          coord_pool.push_back(static_cast<uint32_t>(step.kind));
-          coord_pool.push_back(step.construct_index);
-          coord_pool.push_back(step.alt_index);
-        }
 
         // Schema / binding offset lookup.
         uint32_t proc_ordinal = num_ordinary_nonfinal + ci;
@@ -223,12 +208,20 @@ auto EmitBodyRealizationDescs(
         uint32_t binding_off =
             layout.state_schemas[schema_idx].expr_conn_binding_byte_offset;
 
+        // child_ordinal is the tree-relative ordinal_in_parent: the
+        // direct child position in parent->scope.children including
+        // generate scopes. Resolved by direct tree indexing at runtime.
+        uint32_t tree_ordinal = tmpl.child_site.value;
+        if (body_group < child_site_to_tree_ordinal.size() &&
+            tmpl.child_site.value <
+                child_site_to_tree_ordinal[body_group].size()) {
+          tree_ordinal =
+              child_site_to_tree_ordinal[body_group][tmpl.child_site.value];
+        }
         desc_consts.push_back(
             llvm::ConstantStruct::get(
                 desc_type,
-                {llvm::ConstantInt::get(i32_ty, word_offset),
-                 llvm::ConstantInt::get(i32_ty, step_count),
-                 llvm::ConstantInt::get(i32_ty, durable_id.child_ordinal),
+                {llvm::ConstantInt::get(i32_ty, tree_ordinal),
                  llvm::ConstantInt::get(i32_ty, tmpl.child_port_sym.value),
                  llvm::ConstantInt::get(i32_ty, binding_off)}));
       }
@@ -247,28 +240,6 @@ auto EmitBodyRealizationDescs(
           llvm::ArrayRef<llvm::Constant*>{
               llvm::ConstantInt::get(i32_ty, 0),
               llvm::ConstantInt::get(i32_ty, 0)});
-
-      // Emit coord word pool.
-      expr_coord_word_count = static_cast<uint32_t>(coord_pool.size());
-      if (!coord_pool.empty()) {
-        std::vector<llvm::Constant*> pool_consts;
-        pool_consts.reserve(coord_pool.size());
-        for (uint32_t w : coord_pool) {
-          pool_consts.push_back(llvm::ConstantInt::get(i32_ty, w));
-        }
-        auto pool_name =
-            std::format("__lyra_body_desc_{}_expr_conn_coord", body_group);
-        auto* pool_array_type = llvm::ArrayType::get(i32_ty, coord_pool.size());
-        auto* pool_global = new llvm::GlobalVariable(
-            mod, pool_array_type, true, llvm::GlobalValue::InternalLinkage,
-            llvm::ConstantArray::get(pool_array_type, pool_consts), pool_name);
-        pool_global->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
-        expr_coord_words_ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(
-            pool_array_type, pool_global,
-            llvm::ArrayRef<llvm::Constant*>{
-                llvm::ConstantInt::get(i32_ty, 0),
-                llvm::ConstantInt::get(i32_ty, 0)});
-      }
     }
 
     auto* header_val = llvm::ConstantStruct::get(
@@ -284,8 +255,7 @@ auto EmitBodyRealizationDescs(
          inline_slot_offsets_ptr,
          llvm::ConstantInt::get(i32_ty, num_inline_slot_offsets),
          port_entries_ptr, llvm::ConstantInt::get(i32_ty, num_port_entries),
-         expr_child_descs_ptr, expr_coord_words_ptr,
-         llvm::ConstantInt::get(i32_ty, expr_coord_word_count),
+         expr_child_descs_ptr,
          llvm::ConstantInt::get(i32_ty, num_expr_connections)});
     auto* header_global = new llvm::GlobalVariable(
         mod, header_type, true, llvm::GlobalValue::InternalLinkage, header_val,

--- a/src/lyra/llvm_backend/emit_realization_descriptors.cpp
+++ b/src/lyra/llvm_backend/emit_realization_descriptors.cpp
@@ -51,9 +51,14 @@ auto GetConstructionProgramEntryType(llvm::LLVMContext& ctx)
     -> llvm::StructType* {
   auto* i32_ty = llvm::Type::getInt32Ty(ctx);
   auto* i64_ty = llvm::Type::getInt64Ty(ctx);
+  // Must match ConstructionProgramEntry field order:
+  // node_kind(i32), body_group(i32), label_offset(i32),
+  // param_offset(i32), param_size(i32), parent_scope_index(i32),
+  // ordinal_in_parent(i32), instance_index(i32),
+  // realized_inline_size(i64), realized_appendix_size(i64)
   return llvm::StructType::get(
-      ctx, {i32_ty, i32_ty, i32_ty, i32_ty, i64_ty, i64_ty, i32_ty, i32_ty,
-            i32_ty, i32_ty, i32_ty});
+      ctx, {i32_ty, i32_ty, i32_ty, i32_ty, i32_ty, i32_ty, i32_ty, i32_ty,
+            i64_ty, i64_ty});
 }
 
 // Encode one ConstructionProgramEntry as an LLVM constant.
@@ -63,17 +68,16 @@ auto EncodeConstructionProgramEntry(
   auto* i32_ty = llvm::Type::getInt32Ty(ctx);
   auto* i64_ty = llvm::Type::getInt64Ty(ctx);
   return llvm::ConstantStruct::get(
-      ty, {llvm::ConstantInt::get(i32_ty, e.body_group),
-           llvm::ConstantInt::get(i32_ty, e.path_offset),
+      ty, {llvm::ConstantInt::get(i32_ty, static_cast<uint32_t>(e.node_kind)),
+           llvm::ConstantInt::get(i32_ty, e.body_group),
+           llvm::ConstantInt::get(i32_ty, e.label_offset),
            llvm::ConstantInt::get(i32_ty, e.param_offset),
            llvm::ConstantInt::get(i32_ty, e.param_size),
+           llvm::ConstantInt::get(i32_ty, e.parent_scope_index),
+           llvm::ConstantInt::get(i32_ty, e.ordinal_in_parent),
+           llvm::ConstantInt::get(i32_ty, e.instance_index),
            llvm::ConstantInt::get(i64_ty, e.realized_inline_size),
-           llvm::ConstantInt::get(i64_ty, e.realized_appendix_size),
-           llvm::ConstantInt::get(i32_ty, e.parent_instance_index),
-           llvm::ConstantInt::get(i32_ty, e.child_ordinal_in_coord),
-           llvm::ConstantInt::get(i32_ty, e.coord_offset),
-           llvm::ConstantInt::get(i32_ty, e.coord_count),
-           llvm::ConstantInt::get(i32_ty, e.inst_name_offset)});
+           llvm::ConstantInt::get(i64_ty, e.realized_appendix_size)});
 }
 
 // Canonical LLVM struct type for runtime::BodyDescriptorRef.
@@ -448,7 +452,7 @@ auto DeclareConstructorRuntimeFuncs(Context& context)
       .run_program = declare(
           "LyraConstructorRunProgram", void_ty,
           {ptr_ty, ptr_ty, i32_ty, ptr_ty, i32_ty, ptr_ty, i32_ty, ptr_ty,
-           i32_ty, ptr_ty, i32_ty}),
+           i32_ty}),
       .finalize = declare("LyraConstructorFinalize", ptr_ty, {ptr_ty}),
       .result_get_states =
           declare("LyraConstructionResultGetStates", ptr_ty, {ptr_ty}),
@@ -604,32 +608,8 @@ auto EmitConstructorFunction(
       EmitConstructionProgramGlobal(ctx, context.GetModule(), prog.entries);
   auto entry_count = static_cast<uint32_t>(prog.entries.size());
 
-  // Emit coord steps pool for structural child edge metadata.
-  auto coord_pool_word_count =
-      static_cast<uint32_t>(prog.coord_steps_pool.size());
-  llvm::Constant* coord_pool_ptr = nullptr;
-  if (prog.coord_steps_pool.empty()) {
-    coord_pool_ptr =
-        llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptr_ty));
-  } else {
-    std::vector<llvm::Constant*> coord_words;
-    coord_words.reserve(prog.coord_steps_pool.size());
-    for (auto w : prog.coord_steps_pool) {
-      coord_words.push_back(llvm::ConstantInt::get(i32_ty, w));
-    }
-    auto* arr_ty = llvm::ArrayType::get(i32_ty, coord_words.size());
-    auto* init = llvm::ConstantArray::get(arr_ty, coord_words);
-    auto* global = new llvm::GlobalVariable(
-        context.GetModule(), arr_ty, true, llvm::GlobalValue::InternalLinkage,
-        init, "__lyra_coord_steps_pool");
-    global->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
-    auto* zero = llvm::ConstantInt::get(i32_ty, 0);
-    coord_pool_ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(
-        arr_ty, global, llvm::ArrayRef<llvm::Constant*>{zero, zero});
-  }
-
   // Replay the construction program: the runtime iterates entries in
-  // ModuleIndex order, calling CreateChild as needed.
+  // parent-before-child order, creating scope nodes and instances.
   auto path_pool_size = static_cast<uint32_t>(prog.path_pool.size());
   auto param_pool_size = static_cast<uint32_t>(prog.param_pool.size());
   builder.CreateCall(
@@ -638,8 +618,7 @@ auto EmitConstructorFunction(
        llvm::ConstantInt::get(i32_ty, body_desc_count), path_pool_ptr,
        llvm::ConstantInt::get(i32_ty, path_pool_size), param_pool_ptr,
        llvm::ConstantInt::get(i32_ty, param_pool_size), program_ptr,
-       llvm::ConstantInt::get(i32_ty, entry_count), coord_pool_ptr,
-       llvm::ConstantInt::get(i32_ty, coord_pool_word_count)});
+       llvm::ConstantInt::get(i32_ty, entry_count)});
 
   // Finalize: returns a single constructor-owned result handle.
   auto* result = builder.CreateCall(rt.finalize, {ctor}, "ctor_result");
@@ -677,11 +656,13 @@ auto EmitConstructorFunction(
         llvm::ConstantDataArray::get(ctx, prog.ext_ref_binding_counts),
         "__lyra_ext_ref_binding_counts");
 
+    auto instance_count =
+        static_cast<uint32_t>(prog.ext_ref_binding_offsets.size());
     builder.CreateCall(
         rt.result_set_ext_ref_bindings,
         {result, pool_global, llvm::ConstantInt::get(i32_ty, pool_count),
          offsets_global, counts_global,
-         llvm::ConstantInt::get(i32_ty, entry_count)});
+         llvm::ConstantInt::get(i32_ty, instance_count)});
   }
 
   // Extract states, counts, and process metadata from the result.
@@ -785,8 +766,9 @@ auto EmitRealizationAndConstructor(
 
   // Emit constructor-side definition artifacts.
   auto* slot_offsets_ptr = EmitSlotByteOffsets(context, layout);
-  auto body_descs =
-      EmitBodyRealizationDescs(context, layout, body_compiled_funcs);
+  auto body_descs = EmitBodyRealizationDescs(
+      context, layout, body_compiled_funcs,
+      construction_program.child_site_to_tree_ordinal);
   auto* conn_descs_ptr =
       EmitConnectionRealizationDescs(context, layout, process_funcs, num_init);
   auto conn_meta = EmitConnectionMetaTemplate(context, layout);

--- a/src/lyra/llvm_backend/runtime_data_extraction.cpp
+++ b/src/lyra/llvm_backend/runtime_data_extraction.cpp
@@ -13,6 +13,7 @@
 #include <variant>
 #include <vector>
 
+#include "lyra/common/hierarchy_node.hpp"
 #include "lyra/common/internal_error.hpp"
 #include "lyra/llvm_backend/init_descriptor_utils.hpp"
 #include "lyra/llvm_backend/layout/storage_contract.hpp"
@@ -233,103 +234,130 @@ auto BuildParamPayloads(
 auto BuildConstructionProgram(
     std::span<const uint32_t> instance_body_group,
     std::span<const Layout::InstanceStorageSizes> instance_storage_sizes,
-    const mir::InstanceTable& instance_table,
     std::span<const std::vector<uint8_t>> param_payloads,
     const std::vector<std::vector<common::SerializedExtRefBinding>>&
         instance_ext_ref_bindings,
     std::span<const Layout::BodyRealizationInfo> body_realization_infos,
-    std::span<const uint32_t> parent_instance_indices,
-    std::span<const mir::DurableChildId> child_durable_ids)
+    std::span<const common::HierarchyNode> hierarchy_nodes)
     -> ConstructionProgramData {
   auto instance_count = static_cast<uint32_t>(instance_body_group.size());
+  auto node_count = static_cast<uint32_t>(hierarchy_nodes.size());
   ConstructionProgramData prog;
-  prog.entries.reserve(instance_count);
-  prog.ext_ref_binding_offsets.reserve(instance_count);
-  prog.ext_ref_binding_counts.reserve(instance_count);
+  prog.entries.reserve(node_count);
+  // Pre-size ext-ref arrays to instance_count so entries can be placed
+  // at their instance_index position (matching SetExtRefBindings indexing).
+  prog.ext_ref_binding_offsets.assign(instance_count, UINT32_MAX);
+  prog.ext_ref_binding_counts.assign(instance_count, 0);
 
-  for (uint32_t mi = 0; mi < instance_count; ++mi) {
+  for (uint32_t ni = 0; ni < node_count; ++ni) {
+    const auto& node = hierarchy_nodes[ni];
     runtime::ConstructionProgramEntry entry{};
 
-    entry.body_group = instance_body_group[mi];
-    entry.parent_instance_index = (mi < parent_instance_indices.size())
-                                      ? parent_instance_indices[mi]
-                                      : UINT32_MAX;
+    entry.node_kind = node.kind == common::HierarchyNode::kInstance
+                          ? runtime::ConstructionNodeKind::kInstance
+                          : runtime::ConstructionNodeKind::kGenerate;
+    entry.parent_scope_index = node.parent_node_index;
 
-    const auto& path = instance_table.entries[mi].full_path;
-    entry.path_offset = static_cast<uint32_t>(prog.path_pool.size());
-    prog.path_pool.insert(prog.path_pool.end(), path.begin(), path.end());
+    // Parent-relative scope label into path pool. Runtime derives full
+    // path from parent's scope path_storage + label via BuildScopePath.
+    entry.label_offset = static_cast<uint32_t>(prog.path_pool.size());
+    prog.path_pool.insert(
+        prog.path_pool.end(), node.label.begin(), node.label.end());
     prog.path_pool.push_back(0);
 
-    // Structural child edge metadata from compile-time DurableChildId.
-    if (mi < child_durable_ids.size()) {
-      const auto& durable = child_durable_ids[mi];
-      entry.child_ordinal_in_coord = durable.child_ordinal;
-      if (durable.coord.empty()) {
-        entry.coord_offset = UINT32_MAX;
-        entry.coord_count = 0;
-      } else {
-        entry.coord_offset =
-            static_cast<uint32_t>(prog.coord_steps_pool.size());
-        entry.coord_count = static_cast<uint32_t>(durable.coord.size());
-        for (const auto& step : durable.coord) {
-          prog.coord_steps_pool.push_back(static_cast<uint32_t>(step.kind));
-          prog.coord_steps_pool.push_back(step.construct_index);
-          prog.coord_steps_pool.push_back(step.alt_index);
+    // Compute ordinal among parent's children.
+    entry.ordinal_in_parent = 0;
+    if (node.parent_node_index != UINT32_MAX) {
+      uint32_t ordinal = 0;
+      for (uint32_t j = 0; j < ni; ++j) {
+        if (hierarchy_nodes[j].parent_node_index == node.parent_node_index) {
+          ++ordinal;
         }
       }
-    } else {
-      entry.child_ordinal_in_coord = 0;
-      entry.coord_offset = UINT32_MAX;
-      entry.coord_count = 0;
+      entry.ordinal_in_parent = ordinal;
     }
 
-    // Canonical local child display label from InstanceEntry::display_name
-    // (populated from slang Symbol::name at AST-to-HIR time).
-    // Emitted as a separate pool entry. Not derived from full path.
-    const auto& label = instance_table.entries[mi].inst_name;
-    if (!label.empty()) {
-      entry.inst_name_offset = static_cast<uint32_t>(prog.path_pool.size());
-      prog.path_pool.insert(prog.path_pool.end(), label.begin(), label.end());
-      prog.path_pool.push_back(0);
-    } else {
-      // Top-level instance: use full path as its own display label.
-      entry.inst_name_offset = entry.path_offset;
-    }
+    if (node.kind == common::HierarchyNode::kInstance) {
+      uint32_t mi = node.instance_index;
 
-    const auto& payload = param_payloads[mi];
-    if (!payload.empty()) {
-      entry.param_offset = static_cast<uint32_t>(prog.param_pool.size());
-      entry.param_size = static_cast<uint32_t>(payload.size());
-      prog.param_pool.insert(
-          prog.param_pool.end(), payload.begin(), payload.end());
-    }
+      entry.instance_index = mi;
+      entry.body_group = instance_body_group[mi];
 
-    const auto& sizes = instance_storage_sizes[mi];
-    entry.realized_inline_size = sizes.inline_bytes;
-    entry.realized_appendix_size = sizes.appendix_bytes;
-
-    // Pack per-instance ext-ref binding records into flat pool.
-    // Compute target_byte_offset from the target body's layout.
-    if (mi < instance_ext_ref_bindings.size() &&
-        !instance_ext_ref_bindings[mi].empty()) {
-      auto offset = static_cast<uint32_t>(prog.ext_ref_binding_pool.size());
-      prog.ext_ref_binding_offsets.push_back(offset);
-      prog.ext_ref_binding_counts.push_back(
-          static_cast<uint32_t>(instance_ext_ref_bindings[mi].size()));
-      for (auto b : instance_ext_ref_bindings[mi]) {
-        auto target_bg = instance_body_group[b.target_instance_id];
-        const auto& target_layout =
-            body_realization_infos[target_bg].body_layout;
-        b.target_byte_offset =
-            target_layout.inline_offsets[b.target_local_signal.value].value;
-        prog.ext_ref_binding_pool.push_back(b);
+      const auto& payload = param_payloads[mi];
+      if (!payload.empty()) {
+        entry.param_offset = static_cast<uint32_t>(prog.param_pool.size());
+        entry.param_size = static_cast<uint32_t>(payload.size());
+        prog.param_pool.insert(
+            prog.param_pool.end(), payload.begin(), payload.end());
       }
-    } else {
-      prog.ext_ref_binding_offsets.push_back(UINT32_MAX);
-      prog.ext_ref_binding_counts.push_back(0);
+
+      const auto& sizes = instance_storage_sizes[mi];
+      entry.realized_inline_size = sizes.inline_bytes;
+      entry.realized_appendix_size = sizes.appendix_bytes;
+
+      // Pack per-instance ext-ref binding records into flat pool.
+      // Place at instance_index (mi) position so SetExtRefBindings
+      // indexing matches result.instances ordering.
+      if (mi < instance_ext_ref_bindings.size() &&
+          !instance_ext_ref_bindings[mi].empty()) {
+        auto offset = static_cast<uint32_t>(prog.ext_ref_binding_pool.size());
+        prog.ext_ref_binding_offsets[mi] = offset;
+        prog.ext_ref_binding_counts[mi] =
+            static_cast<uint32_t>(instance_ext_ref_bindings[mi].size());
+        for (auto b : instance_ext_ref_bindings[mi]) {
+          auto target_bg = instance_body_group[b.target_instance_id];
+          const auto& target_layout =
+              body_realization_infos[target_bg].body_layout;
+          b.target_byte_offset =
+              target_layout.inline_offsets[b.target_local_signal.value].value;
+          prog.ext_ref_binding_pool.push_back(b);
+        }
+      }
     }
 
     prog.entries.push_back(entry);
+  }
+
+  // Build per-body child_site_to_tree_ordinal mapping.
+  // For each parent body, maps the body-local child_site_index (sorted
+  // path position among instance children) to tree-relative ordinal
+  // (position among ALL children including generate scopes).
+  auto num_bodies = static_cast<uint32_t>(body_realization_infos.size());
+  prog.child_site_to_tree_ordinal.resize(num_bodies);
+
+  for (uint32_t ni = 0; ni < node_count; ++ni) {
+    const auto& node = hierarchy_nodes[ni];
+    if (node.kind != common::HierarchyNode::kInstance) continue;
+    // For each instance node that has children, build the mapping.
+    // Collect child instance nodes sorted by instance_index (matching
+    // child_sites ordering).
+    struct ChildEntry {
+      uint32_t instance_index;
+      uint32_t tree_ordinal;
+    };
+    std::vector<ChildEntry> instance_children;
+    uint32_t tree_ordinal = 0;
+    for (uint32_t ci = 0; ci < node_count; ++ci) {
+      if (hierarchy_nodes[ci].parent_node_index != ni) continue;
+      if (hierarchy_nodes[ci].kind == common::HierarchyNode::kInstance) {
+        instance_children.push_back(
+            {hierarchy_nodes[ci].instance_index, tree_ordinal});
+      }
+      ++tree_ordinal;
+    }
+    if (instance_children.empty()) continue;
+    // Sort by instance_index to match child_sites ordering.
+    std::ranges::sort(instance_children, [](const auto& a, const auto& b) {
+      return a.instance_index < b.instance_index;
+    });
+    uint32_t body_group = instance_body_group[node.instance_index];
+    auto& mapping = prog.child_site_to_tree_ordinal[body_group];
+    if (mapping.empty()) {
+      mapping.resize(instance_children.size());
+      for (uint32_t k = 0; k < instance_children.size(); ++k) {
+        mapping[k] = instance_children[k].tree_ordinal;
+      }
+    }
   }
 
   return prog;
@@ -1084,18 +1112,46 @@ void ExtractBodyInitDescriptors(
                 instance_body_group[mi], num_body_groups));
       }
     }
+
+    // Pipeline-boundary invariant: the runtime scope tree must be
+    // materialized before construction emission. If any instance exists,
+    // the hierarchy node table must be non-empty and carry exactly one
+    // kInstance node per instance_table entry. A missing hierarchy_nodes
+    // input causes silent downstream failures (empty construction
+    // program, crashes during cleanup), so fail loudly here.
+    if (instance_count > 0 && construction.hierarchy_nodes.empty()) {
+      throw common::InternalError(
+          "ExtractBodyInitDescriptors",
+          std::format(
+              "{} instances present but hierarchy_nodes is empty -- "
+              "pipeline forgot to thread AST->HIR scope tree into "
+              "construction input",
+              instance_count));
+    }
+    uint32_t kinstance_count = 0;
+    for (const auto& node : construction.hierarchy_nodes) {
+      if (node.kind == common::HierarchyNode::kInstance) ++kinstance_count;
+    }
+    if (kinstance_count != instance_count) {
+      throw common::InternalError(
+          "ExtractBodyInitDescriptors",
+          std::format(
+              "hierarchy_nodes has {} kInstance nodes but instance_table "
+              "has {} entries -- scope tree / instance table disagree",
+              kinstance_count, instance_count));
+    }
   }
 
   construction_program = BuildConstructionProgram(
-      instance_body_group, instance_storage_sizes, construction.instance_table,
-      param_payloads, construction.instance_ext_ref_bindings,
-      body_realization_infos, construction.parent_instance_indices,
-      construction.child_durable_ids);
+      instance_body_group, instance_storage_sizes, param_payloads,
+      construction.instance_ext_ref_bindings, body_realization_infos,
+      construction.hierarchy_nodes);
 
-  // Validate construction program.
+  // Validate construction program: instance entries must have valid body_group.
   for (size_t i = 0; i < construction_program.entries.size(); ++i) {
     const auto& e = construction_program.entries[i];
-    if (e.body_group >= body_realization_infos.size()) {
+    if (e.node_kind == runtime::ConstructionNodeKind::kInstance &&
+        e.body_group >= body_realization_infos.size()) {
       throw common::InternalError(
           "ExtractBodyInitDescriptors",
           std::format(

--- a/src/lyra/lowering/ast_to_hir/design.cpp
+++ b/src/lyra/lowering/ast_to_hir/design.cpp
@@ -621,6 +621,100 @@ void CollectInstancesFromScope(
   }
 }
 
+// Build the hierarchy-node table from slang AST, emitting both generate
+// scope nodes and instance nodes. The instance list (all_instances) must
+// already be populated and sorted. This function produces a parallel
+// table of hierarchy nodes in strict parent-before-child order.
+// Emit hierarchy nodes in structural (declaration) order. This is the
+// authoritative child ordering for the runtime scope tree. Instance
+// children carry instance_index as a payload lookup key only -- it
+// does NOT determine child position. The tree order is structural.
+
+// Derive parent-relative label from authoritative full hierarchical
+// paths. One strict policy for all scope kinds (instances and generate
+// scopes): strip the parent's full_path + '.' prefix. Root nodes have
+// empty parent_full and their label equals their full_path. Non-root
+// nodes whose full_path does not start with parent_full + '.' violate
+// the hierarchy invariant and fail loudly -- no silent fallback.
+auto DeriveRelativeLabel(
+    std::string_view full_path, std::string_view parent_full) -> std::string {
+  if (parent_full.empty()) return std::string(full_path);
+  if (!full_path.starts_with(parent_full) ||
+      full_path.size() <= parent_full.size() + 1 ||
+      full_path[parent_full.size()] != '.') {
+    throw common::InternalError(
+        "DeriveRelativeLabel",
+        std::format(
+            "full_path '{}' is not under parent '{}'", full_path, parent_full));
+  }
+  return std::string(full_path.substr(parent_full.size() + 1));
+}
+
+void BuildHierarchyNodes(
+    const slang::ast::Scope& scope, uint32_t parent_node_index,
+    const std::vector<const slang::ast::InstanceSymbol*>& all_instances,
+    const std::unordered_map<const slang::ast::InstanceSymbol*, uint32_t>&
+        instance_to_index,
+    std::vector<common::HierarchyNode>& nodes) {
+  // Copy parent full_path by value: nodes may reallocate during push_back
+  // below, which would invalidate any string_view into nodes[parent].
+  std::string parent_full = parent_node_index != UINT32_MAX
+                                ? nodes[parent_node_index].full_path
+                                : std::string{};
+  for (const auto& member : scope.members()) {
+    if (member.kind == slang::ast::SymbolKind::Instance) {
+      const auto& child = member.as<slang::ast::InstanceSymbol>();
+      auto it = instance_to_index.find(&child);
+      if (it == instance_to_index.end()) continue;
+      auto child_idx = static_cast<uint32_t>(nodes.size());
+      std::string full_path = std::string(child.getHierarchicalPath());
+      std::string label = DeriveRelativeLabel(full_path, parent_full);
+      nodes.push_back(
+          common::HierarchyNode{
+              .kind = common::HierarchyNode::kInstance,
+              .parent_node_index = parent_node_index,
+              .label = std::move(label),
+              .full_path = full_path,
+              .instance_index = it->second,
+          });
+      BuildHierarchyNodes(
+          child.body, child_idx, all_instances, instance_to_index, nodes);
+    } else if (member.kind == slang::ast::SymbolKind::GenerateBlock) {
+      const auto& block = member.as<slang::ast::GenerateBlockSymbol>();
+      if (block.isUninstantiated) continue;
+      auto scope_idx = static_cast<uint32_t>(nodes.size());
+      std::string full_path = std::string(block.getHierarchicalPath());
+      std::string label = DeriveRelativeLabel(full_path, parent_full);
+      nodes.push_back(
+          common::HierarchyNode{
+              .kind = common::HierarchyNode::kGenerate,
+              .parent_node_index = parent_node_index,
+              .label = std::move(label),
+              .full_path = full_path,
+          });
+      BuildHierarchyNodes(
+          block, scope_idx, all_instances, instance_to_index, nodes);
+    } else if (member.kind == slang::ast::SymbolKind::GenerateBlockArray) {
+      const auto& array = member.as<slang::ast::GenerateBlockArraySymbol>();
+      for (const auto* entry : array.entries) {
+        if (entry->isUninstantiated) continue;
+        auto scope_idx = static_cast<uint32_t>(nodes.size());
+        std::string full_path = std::string(entry->getHierarchicalPath());
+        std::string label = DeriveRelativeLabel(full_path, parent_full);
+        nodes.push_back(
+            common::HierarchyNode{
+                .kind = common::HierarchyNode::kGenerate,
+                .parent_node_index = parent_node_index,
+                .label = std::move(label),
+                .full_path = full_path,
+            });
+        BuildHierarchyNodes(
+            *entry, scope_idx, all_instances, instance_to_index, nodes);
+      }
+    }
+  }
+}
+
 // Prepare ownership-shaped lowering inputs from structural discovery.
 // One CollectScopeMembers walk per instance, then immediate partitioning
 // into behavioral (body) and registration (instance) inputs.
@@ -717,6 +811,34 @@ auto LowerDesign(
   std::ranges::sort(all_instances, [](const auto* a, const auto* b) {
     return a->getHierarchicalPath() < b->getHierarchicalPath();
   });
+
+  // Build instance-to-sorted-index map for hierarchy node building.
+  std::unordered_map<const slang::ast::InstanceSymbol*, uint32_t>
+      instance_to_sorted_index;
+  for (uint32_t i = 0; i < all_instances.size(); ++i) {
+    instance_to_sorted_index[all_instances[i]] = i;
+  }
+
+  // Build hierarchy-node table from slang AST. This captures both
+  // generate scope nodes and instance nodes in parent-before-child order.
+  // Root instance labels equal their full_path (parent is empty).
+  std::vector<common::HierarchyNode> hierarchy_nodes;
+  for (const auto* inst : root.topInstances) {
+    auto top_idx = static_cast<uint32_t>(hierarchy_nodes.size());
+    std::string full_path = std::string(inst->getHierarchicalPath());
+    std::string label = DeriveRelativeLabel(full_path, {});
+    hierarchy_nodes.push_back(
+        common::HierarchyNode{
+            .kind = common::HierarchyNode::kInstance,
+            .parent_node_index = UINT32_MAX,
+            .label = std::move(label),
+            .full_path = full_path,
+            .instance_index = instance_to_sorted_index.at(inst),
+        });
+    BuildHierarchyNodes(
+        inst->body, top_idx, all_instances, instance_to_sorted_index,
+        hierarchy_nodes);
+  }
 
   // Build specialization groups from compile-owned body facts.
   // No parameter classification -- grouping is self-contained.
@@ -972,6 +1094,7 @@ auto LowerDesign(
       .instance_table = std::move(instance_table),
       .body_timescales = std::move(body_timescale_table),
       .child_coord_map = std::move(child_coord_map),
+      .hierarchy_nodes = std::move(hierarchy_nodes),
   };
 }
 

--- a/src/lyra/lowering/ast_to_hir/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/lower.cpp
@@ -85,6 +85,7 @@ auto LowerAstToHir(
       .global_precision_power = global_precision,
       .body_timescales = std::move(design_result.body_timescales),
       .child_coord_map = std::move(design_result.child_coord_map),
+      .hierarchy_nodes = std::move(design_result.hierarchy_nodes),
   };
 }
 

--- a/src/lyra/lowering/hir_to_mir/design_lower.cpp
+++ b/src/lyra/lowering/hir_to_mir/design_lower.cpp
@@ -579,6 +579,9 @@ auto LowerDesign(
   if (input.instance_table != nullptr) {
     construction.instance_table = *input.instance_table;
   }
+  if (input.hierarchy_nodes != nullptr) {
+    construction.hierarchy_nodes = *input.hierarchy_nodes;
+  }
 
   uint32_t next_placement_base = decls.num_package_slots;
   uint32_t module_index = 0;

--- a/src/lyra/lowering/hir_to_mir/design_lower.cpp
+++ b/src/lyra/lowering/hir_to_mir/design_lower.cpp
@@ -1141,18 +1141,6 @@ auto LowerDesign(
       construction, parent_to_children, body_to_representative,
       oi_to_durable_child);
 
-  // Copy parent topology into construction input for constructor use.
-  construction.parent_instance_indices = topo.parent_of;
-
-  // Build per-instance structural child identity from oi_to_durable_child.
-  auto instance_count = construction.objects.size();
-  construction.child_durable_ids.resize(instance_count);
-  for (const auto& [oi, durable_id] : oi_to_durable_child) {
-    if (oi < instance_count) {
-      construction.child_durable_ids[oi] = durable_id;
-    }
-  }
-
   FinalizeExternalRefTargetSlots(
       result, provisionals_by_body, body_local_slots_by_body, topo,
       construction,

--- a/src/lyra/runtime/constructor_.cpp
+++ b/src/lyra/runtime/constructor_.cpp
@@ -1,17 +1,18 @@
 // NOTE: See constructor_.hpp for why this file has a trailing underscore.
 #include "lyra/runtime/constructor_.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <format>
 #include <memory>
 #include <span>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 
 #include "lyra/common/ext_ref_binding.hpp"
 #include "lyra/common/internal_error.hpp"
-#include "lyra/common/selection_step.hpp"
 #include "lyra/runtime/expr_connection_frame.hpp"
 #include "lyra/runtime/frame_allocator.hpp"
 #include "lyra/runtime/owned_storage_handle.hpp"
@@ -23,72 +24,12 @@
 
 namespace lyra::runtime {
 
-// Derive hierarchical path from parent structural context + local
-// instance name. All path construction policy lives here.
-auto BuildInstancePath(const RuntimeInstance* parent, const char* inst_name)
+// Derive hierarchical path from parent scope context + local scope label.
+// All path construction policy lives here.
+auto BuildScopePath(const RuntimeScope* parent, const char* label)
     -> std::string {
-  if (parent == nullptr) return {inst_name};
-  return std::string(parent->path_storage) + "." + inst_name;
-}
-
-// Decode a RepertoireCoord from the flat coord_steps transport pool.
-// Each step is packed as 3 consecutive uint32_t words:
-// (kind, construct_index, alt_index).
-auto DecodeRepertoireCoord(
-    const runtime::ConstructionProgramEntry& entry,
-    std::span<const uint32_t> coord_pool) -> common::RepertoireCoord {
-  if (entry.coord_count == 0 || entry.coord_offset == UINT32_MAX) {
-    return {};
-  }
-  uint32_t word_start = entry.coord_offset;
-  uint32_t words_needed = entry.coord_count * 3;
-  if (word_start + words_needed > coord_pool.size()) {
-    throw common::InternalError(
-        "DecodeRepertoireCoord",
-        std::format(
-            "coord range [{}, {}) exceeds pool size {}", word_start,
-            word_start + words_needed, coord_pool.size()));
-  }
-  common::RepertoireCoord coord;
-  coord.reserve(entry.coord_count);
-  for (uint32_t ci = 0; ci < entry.coord_count; ++ci) {
-    auto base = word_start + (ci * 3);
-    coord.push_back(
-        common::SelectionStepDesc{
-            .kind = static_cast<common::SelectionStepKind>(coord_pool[base]),
-            .construct_index = coord_pool[base + 1],
-            .alt_index = coord_pool[base + 2],
-        });
-  }
-  return coord;
-}
-
-// Decode a RepertoireCoord from an ExprConnChildDesc's coord pool.
-auto DecodeExprConnCoord(
-    const ExprConnChildDesc& desc, std::span<const uint32_t> coord_pool)
-    -> common::RepertoireCoord {
-  if (desc.coord_step_count == 0) return {};
-  uint32_t word_start = desc.coord_word_offset;
-  uint32_t words_needed = desc.coord_step_count * 3;
-  if (word_start + words_needed > coord_pool.size()) {
-    throw common::InternalError(
-        "DecodeExprConnCoord",
-        std::format(
-            "coord range [{}, {}) exceeds pool size {}", word_start,
-            word_start + words_needed, coord_pool.size()));
-  }
-  common::RepertoireCoord coord;
-  coord.reserve(desc.coord_step_count);
-  for (uint32_t ci = 0; ci < desc.coord_step_count; ++ci) {
-    auto base = word_start + (ci * 3);
-    coord.push_back(
-        common::SelectionStepDesc{
-            .kind = static_cast<common::SelectionStepKind>(coord_pool[base]),
-            .construct_index = coord_pool[base + 1],
-            .alt_index = coord_pool[base + 2],
-        });
-  }
-  return coord;
+  if (parent == nullptr) return {label};
+  return std::string(parent->path_storage) + "." + label;
 }
 
 ConstructionResult::~ConstructionResult() {
@@ -101,6 +42,7 @@ ConstructionResult::ConstructionResult(ConstructionResult&& other) noexcept
       num_total(std::exchange(other.num_total, 0)),
       num_connection(std::exchange(other.num_connection, 0)),
       instances(std::move(other.instances)),
+      generate_scopes(std::move(other.generate_scopes)),
       instance_bundles(std::move(other.instance_bundles)),
       body_desc_storage(std::move(other.body_desc_storage)),
       process_meta(std::move(other.process_meta)),
@@ -119,6 +61,7 @@ auto ConstructionResult::operator=(ConstructionResult&& other) noexcept
     num_total = std::exchange(other.num_total, 0);
     num_connection = std::exchange(other.num_connection, 0);
     instances = std::move(other.instances);
+    generate_scopes = std::move(other.generate_scopes);
     instance_bundles = std::move(other.instance_bundles);
     body_desc_storage = std::move(other.body_desc_storage);
     process_meta = std::move(other.process_meta);
@@ -673,49 +616,67 @@ void Constructor::BeginBody(const BodyDescriptorPackage& package) {
   current_body_package_ = &body_desc_storage_.back().package;
 }
 
-auto Constructor::CreateChild(
-    RuntimeInstance* parent, common::RepertoireCoord edge_coord,
-    uint32_t edge_ordinal, const char* inst_name, const void* param_data,
+auto Constructor::CreateScope(
+    RuntimeScope* parent_scope, const char* label, uint32_t ordinal_in_parent)
+    -> RuntimeScope* {
+  CheckNotFinalized("Constructor::CreateScope");
+  auto gen = std::make_unique<RuntimeGenerateScope>();
+  gen->scope.kind = RuntimeScopeKind::kGenerate;
+  gen->scope.parent = parent_scope;
+  gen->scope.ordinal_in_parent = ordinal_in_parent;
+  gen->scope.path_storage = BuildScopePath(parent_scope, label);
+  gen->scope.path_c_str = gen->scope.path_storage.c_str();
+
+  if (parent_scope != nullptr) {
+    parent_scope->children.push_back(
+        RuntimeChildEdge{
+            .ordinal_in_parent = ordinal_in_parent,
+            .child = &gen->scope,
+        });
+  }
+
+  auto* result = &gen->scope;
+  staged_generate_scopes_.push_back(std::move(gen));
+  return result;
+}
+
+auto Constructor::CreateChildInstance(
+    RuntimeScope* parent_scope, uint32_t ordinal_in_parent,
+    uint32_t instance_index, const char* label, const void* param_data,
     uint32_t param_data_size, uint64_t realized_inline_size,
     uint64_t realized_appendix_size) -> RuntimeInstance* {
-  CheckNotFinalized("Constructor::CreateChild");
-  if (inst_name == nullptr) {
-    throw common::InternalError("Constructor::CreateChild", "null inst_name");
+  CheckNotFinalized("Constructor::CreateChildInstance");
+  if (label == nullptr) {
+    throw common::InternalError(
+        "Constructor::CreateChildInstance", "null label");
   }
   if (!body_.active || current_body_package_ == nullptr) {
     throw common::InternalError(
-        "Constructor::CreateChild",
+        "Constructor::CreateChildInstance",
         "no active body package (call BeginBody first)");
   }
   if ((param_data == nullptr) != (param_data_size == 0)) {
     throw common::InternalError(
-        "Constructor::CreateChild",
+        "Constructor::CreateChildInstance",
         "param_data and param_data_size must be both empty or both present");
   }
   connections_finalized_ = true;
 
-  uint32_t instance_ord = next_module_instance_ordinal_;
   auto instance = std::make_unique<RuntimeInstance>();
-  instance->owner_ordinal = instance_ord;
+  instance->scope.kind = RuntimeScopeKind::kInstance;
+  instance->owner_ordinal = instance_index;
+  instance->scope.ordinal_in_parent = ordinal_in_parent;
+  instance->scope.parent = parent_scope;
+  instance->scope.path_storage = BuildScopePath(parent_scope, label);
+  instance->scope.path_c_str = instance->scope.path_storage.c_str();
 
-  // Structural relation established inside child creation.
-  // The typed child edge carries structural metadata (generate-scope
-  // context + ordinal) for procedural walking by compile-time path
-  // recipes. These are edge metadata, not object identity. Ownership
-  // of edge_coord is transferred into the stored child edge.
-  instance->parent = parent;
-  if (parent != nullptr) {
-    parent->children.push_back(
-        RuntimeInstance::ChildEdge{
-            .coord = std::move(edge_coord),
-            .child_ordinal_in_coord = edge_ordinal,
-            .child = instance.get(),
+  if (parent_scope != nullptr) {
+    parent_scope->children.push_back(
+        RuntimeChildEdge{
+            .ordinal_in_parent = ordinal_in_parent,
+            .child = &instance->scope,
         });
   }
-
-  // Derived presentation path from structural position.
-  instance->path_storage = BuildInstancePath(parent, inst_name);
-  instance->path_c_str = instance->path_storage.c_str();
 
   instance->storage.inline_base =
       AllocateOwnedInlineStorage(realized_inline_size);
@@ -735,7 +696,7 @@ auto Constructor::CreateChild(
         body_.init_recipe.num_child_indices != 0 ||
         !body_.init_params.slots.empty() || param_data_size != 0) {
       throw common::InternalError(
-          "Constructor::CreateChild",
+          "Constructor::CreateChildInstance",
           "zero-slot body must not carry instance-state init descriptors "
           "or param data");
     }
@@ -747,8 +708,12 @@ auto Constructor::CreateChild(
   ApplyParamInitToInstance(
       *instance, body_.init_params.slots, param_data, param_data_size);
 
-  auto instance_index = static_cast<uint32_t>(staged_instances_.size());
-  staged_instances_.push_back(std::move(instance));
+  // Place instance at its compile-time object_index position so
+  // result.instances[object_index] matches the compile-time model.
+  if (instance_index >= staged_instances_.size()) {
+    staged_instances_.resize(instance_index + 1);
+  }
+  staged_instances_[instance_index] = std::move(instance);
 
   // Stage module processes. The last num_expr_connections entries are
   // expression connections that need child binding at finalize time.
@@ -756,7 +721,7 @@ auto Constructor::CreateChild(
   uint32_t num_expr = current_body_package_->desc->num_expr_connections;
   if (num_expr > num_entries) {
     throw common::InternalError(
-        "Constructor::CreateChild",
+        "Constructor::CreateChildInstance",
         std::format(
             "num_expr_connections {} > num_entries {}", num_expr, num_entries));
   }
@@ -765,7 +730,7 @@ auto Constructor::CreateChild(
   if (num_expr > 0) {
     if (current_body_package_->desc->expr_conn_child_descs == nullptr) {
       throw common::InternalError(
-          "Constructor::CreateChild",
+          "Constructor::CreateChildInstance",
           "num_expr_connections > 0 but expr_conn_child_descs is null");
     }
     expr_child_descs = std::span<const ExprConnChildDesc>(
@@ -779,7 +744,7 @@ auto Constructor::CreateChild(
 
     if (body_fn == nullptr) {
       throw common::InternalError(
-          "Constructor::CreateChild",
+          "Constructor::CreateChildInstance",
           std::format(
               "body entry {} has null shared_body_fn "
               "(emitted function pointer is zero)",
@@ -805,7 +770,8 @@ auto Constructor::CreateChild(
   ++next_module_instance_ordinal_;
 
   // Use the instance's stable path for the design-global observable walk.
-  const char* instance_path = staged_instances_[instance_index]->path_c_str;
+  const char* instance_path =
+      staged_instances_[instance_index]->scope.path_c_str;
 
   // R4: Module-instance process meta, trigger, comb, instance-owned slot,
   // and instance-owned trace metadata are all engine-derived from bundles.
@@ -819,7 +785,7 @@ auto Constructor::CreateChild(
       for (const auto& entry : body_.observable_descriptors.entries) {
         if ((entry.flags & kObservableFlagStorageAbsolute) == 0) {
           throw common::InternalError(
-              "Constructor::CreateChild",
+              "Constructor::CreateChildInstance",
               "body-relative observable entry in instance with no "
               "local storage");
         }
@@ -857,24 +823,26 @@ auto Constructor::CreateChild(
     }
   }
 
-  // R4 prep: record per-instance metadata bundle alongside existing flat
-  // metadata. instance_path is already stable (owned by the instance).
-  staged_bundles_.push_back(
-      InstanceMetadataBundle{
-          .instance = staged_instances_[instance_index].get(),
-          .body_desc = nullptr,
-          .body_key = current_body_package_->desc,
-          .instance_path = instance_path,
-      });
+  // R4 prep: record per-instance metadata bundle at the same position as
+  // the instance (instance_index). Must be parallel to staged_instances_.
+  if (instance_index >= staged_bundles_.size()) {
+    staged_bundles_.resize(instance_index + 1);
+  }
+  staged_bundles_[instance_index] = InstanceMetadataBundle{
+      .instance = staged_instances_[instance_index].get(),
+      .body_desc = nullptr,
+      .body_key = current_body_package_->desc,
+      .instance_path = instance_path,
+  };
 
   uint32_t new_slot_base = next_slot_base_ + body_.slot_count;
   if (new_slot_base < next_slot_base_) {
     throw common::InternalError(
-        "Constructor::CreateChild", "slot base overflow");
+        "Constructor::CreateChildInstance", "slot base overflow");
   }
   if (body_.slot_count > 0 && new_slot_base > slot_byte_offsets_.size()) {
     throw common::InternalError(
-        "Constructor::CreateChild",
+        "Constructor::CreateChildInstance",
         std::format(
             "post-increment slot base {} exceeds layout oracle size {}",
             new_slot_base, slot_byte_offsets_.size()));
@@ -952,17 +920,41 @@ auto Constructor::Finalize() -> ConstructionResult {
             num_connection_, conn_triggers_.proc_ranges.size()));
   }
 
-  // Process-index identity verification.
-  // Instance ordinals are dense and match staged_instances_ position:
-  // staged_instances_[ordinal]->owner_ordinal == ordinal.
+  // Invariant wall for sparse-indexed staging.
+  // CreateChildInstance resizes staged_instances_ / staged_bundles_ to
+  // the maximum instance_index and places each instance at its index
+  // slot. If any index was skipped, we would have a null hole that
+  // fails silently at dereference time. Validate density and
+  // cross-array consistency before any downstream use.
+  if (staged_bundles_.size() != staged_instances_.size()) {
+    throw common::InternalError(
+        "Constructor::Finalize",
+        std::format(
+            "staged_bundles_ size {} != staged_instances_ size {}",
+            staged_bundles_.size(), staged_instances_.size()));
+  }
   for (uint32_t li = 0; li < staged_instances_.size(); ++li) {
+    if (staged_instances_[li] == nullptr) {
+      throw common::InternalError(
+          "Constructor::Finalize",
+          std::format(
+              "staged_instances_[{}] is null -- instance_index was "
+              "skipped during CreateChildInstance staging",
+              li));
+    }
     if (staged_instances_[li]->owner_ordinal != li) {
       throw common::InternalError(
           "Constructor::Finalize",
           std::format(
-              "instance ordinal mismatch: entry {} has "
+              "instance ordinal mismatch: staged_instances_[{}] has "
               "owner_ordinal {}",
               li, staged_instances_[li]->owner_ordinal));
+    }
+    if (staged_bundles_[li].instance != staged_instances_[li].get()) {
+      throw common::InternalError(
+          "Constructor::Finalize",
+          std::format(
+              "staged_bundles_[{}].instance != staged_instances_[{}]", li, li));
     }
   }
 
@@ -987,6 +979,18 @@ auto Constructor::Finalize() -> ConstructionResult {
     result.trace_signal_meta = std::move(realized_trace_meta_);
     return result;
   }
+
+  // Sort module processes by instance_index to match the engine's bundle
+  // ordering. Connection processes (indices 0..num_connection_-1) stay in
+  // place; module processes (num_connection_..end) are sorted by the
+  // instance_index they were staged with. This decouples the hierarchy
+  // tree order (structural/declaration) from the payload/bundle order
+  // (sorted instance_index).
+  std::stable_sort(
+      staged_.begin() + num_connection_, staged_.end(),
+      [](const StagedProcess& a, const StagedProcess& b) {
+        return a.instance_index < b.instance_index;
+      });
 
   std::vector<uint32_t> schema_indices;
   schema_indices.reserve(num_total);
@@ -1016,6 +1020,7 @@ auto Constructor::Finalize() -> ConstructionResult {
   result.num_total = num_total;
   result.num_connection = num_connection_;
   result.instances = std::move(staged_instances_);
+  result.generate_scopes = std::move(staged_generate_scopes_);
   result.process_meta = std::move(realized_meta_);
   result.trigger_meta = std::move(realized_triggers_);
   result.slot_meta = std::move(realized_slot_meta_);
@@ -1078,7 +1083,8 @@ auto Constructor::Finalize() -> ConstructionResult {
 
     // Re-validate bundle instance_path against the instance's stable
     // path pointer (set in CreateChild, still valid after unique_ptr move).
-    result.instance_bundles[i].instance_path = result.instances[i]->path_c_str;
+    result.instance_bundles[i].instance_path =
+        result.instances[i]->scope.path_c_str;
   }
 
   // Expression connection child binding resolution.
@@ -1091,33 +1097,28 @@ auto Constructor::Finalize() -> ConstructionResult {
     const auto* desc = proc.expr_conn_child_desc;
     auto* parent = result.instances[proc.instance_index].get();
 
-    // Validate parent bundle before reading coord pool.
-    const auto& parent_bundle = result.instance_bundles[proc.instance_index];
-    if (parent_bundle.body_desc == nullptr) {
+    // Resolve child by tree-relative ordinal_in_parent. child_ordinal
+    // is the direct child position in parent->scope.children (tree
+    // order, including generate scopes).
+    if (desc->child_ordinal >= parent->scope.children.size()) {
       throw common::InternalError(
           "Constructor::Finalize",
-          "expr conn parent bundle has null body_desc");
+          std::format(
+              "expr conn child_ordinal {} out of range for parent '{}' "
+              "(children={})",
+              desc->child_ordinal, parent->scope.path_c_str,
+              parent->scope.children.size()));
     }
-    const auto* parent_body_desc = parent_bundle.body_desc->desc;
-    std::span<const uint32_t> coord_words(
-        parent_body_desc->expr_conn_coord_words,
-        parent_body_desc->num_expr_conn_coord_words);
-    auto coord = DecodeExprConnCoord(*desc, coord_words);
-
-    // Resolve child by structural identity walk on parent->children.
-    RuntimeInstance* child = nullptr;
-    for (const auto& edge : parent->children) {
-      if (edge.coord == coord &&
-          edge.child_ordinal_in_coord == desc->child_ordinal) {
-        child = edge.child;
-        break;
-      }
-    }
-    if (child == nullptr) {
+    auto* child_scope = parent->scope.children[desc->child_ordinal].child;
+    if (child_scope->kind != RuntimeScopeKind::kInstance) {
       throw common::InternalError(
           "Constructor::Finalize",
-          "expr conn child not found by structural identity");
+          std::format(
+              "expr conn child_ordinal {} in parent '{}' is a generate "
+              "scope, not an instance",
+              desc->child_ordinal, parent->scope.path_c_str));
     }
+    RuntimeInstance* child = ScopeAsInstanceChecked(child_scope);
 
     // Validate child ordinal and bundle before dereferencing.
     if (child->owner_ordinal >= result.instance_bundles.size()) {
@@ -1577,12 +1578,8 @@ void LyraConstructorAddInstance(
   ValidateHandle(ctor, "LyraConstructorAddInstance");
   ValidateAbiArray(
       param_data, param_data_size, "param_data", "LyraConstructorAddInstance");
-  // Legacy per-call API: creates a root instance (no parent, empty
-  // coord, ordinal 0). instance_path is treated as the root inst_name.
-  // The batched RunProgram path is the active entry point; this
-  // API exists only for the C ABI declaration.
-  static_cast<lyra::runtime::Constructor*>(ctor)->CreateChild(
-      nullptr, {}, 0, instance_path, param_data, param_data_size,
+  static_cast<lyra::runtime::Constructor*>(ctor)->CreateChildInstance(
+      nullptr, 0, 0, instance_path, param_data, param_data_size,
       realized_inline_size, realized_appendix_size);
 }
 
@@ -1591,8 +1588,7 @@ void LyraConstructorRunProgram(
     uint32_t body_desc_count, const char* path_pool, uint32_t path_pool_size,
     const uint8_t* param_pool, uint32_t param_pool_size,
     const lyra::runtime::ConstructionProgramEntry* entries,
-    uint32_t entry_count, const uint32_t* coord_steps_pool,
-    uint32_t coord_steps_word_count) {
+    uint32_t entry_count) {
   ValidateHandle(ctor_raw, "LyraConstructorRunProgram");
   auto& ctor = *static_cast<lyra::runtime::Constructor*>(ctor_raw);
 
@@ -1608,89 +1604,87 @@ void LyraConstructorRunProgram(
   auto path_span = std::span(path_pool, path_pool_size);
   auto param_span = std::span(param_pool, param_pool_size);
 
-  // Transient transport-resolution table: converts flat
-  // parent_instance_index from the emitted program into live pointers
-  // during ingestion. Consumed only within this loop.
-  std::vector<lyra::runtime::RuntimeInstance*> created_instances;
-  created_instances.reserve(entry_count);
+  // Transient scope-resolution table: converts flat parent_scope_index
+  // from the emitted program into live scope pointers during ingestion.
+  std::vector<lyra::runtime::RuntimeScope*> created_scopes;
+  created_scopes.reserve(entry_count);
 
   for (uint32_t i = 0; i < entry_count; ++i) {
     const auto& e = entry_span[i];
 
-    if (e.body_group >= body_desc_count) {
+    // Resolve parent scope from transport index.
+    lyra::runtime::RuntimeScope* parent_scope = nullptr;
+    if (e.parent_scope_index != UINT32_MAX) {
+      if (e.parent_scope_index >= created_scopes.size()) {
+        throw lyra::common::InternalError(
+            "LyraConstructorRunProgram",
+            std::format(
+                "entry {} parent_scope_index {} >= created count {}", i,
+                e.parent_scope_index, created_scopes.size()));
+      }
+      parent_scope = created_scopes[e.parent_scope_index];
+    }
+
+    // Read parent-relative scope label from path pool. The constructor
+    // derives the full hierarchical path from parent_scope + label.
+    if (e.label_offset >= path_pool_size) {
       throw lyra::common::InternalError(
           "LyraConstructorRunProgram",
           std::format(
-              "entry {} body_group {} >= body_desc_count {}", i, e.body_group,
-              body_desc_count));
+              "entry {} label_offset {} >= path_pool_size {}", i,
+              e.label_offset, path_pool_size));
     }
+    const char* label = &path_span[e.label_offset];
 
-    if (e.body_group != last_body_group) {
-      ctor.BeginBody(
-          MakeBodyDescriptorPackageView(body_desc_span[e.body_group]));
-      last_body_group = e.body_group;
-    }
-
-    // Canonical local child display label from compile-time Symbol::name.
-    // Transported via inst_name_offset in the path pool. Presentation
-    // input for path derivation during assembly -- not stored on the
-    // instance, not recovered from full path strings.
-    if (e.inst_name_offset >= path_pool_size) {
-      throw lyra::common::InternalError(
-          "LyraConstructorRunProgram",
-          std::format(
-              "entry {} inst_name_offset {} >= path_pool_size {}", i,
-              e.inst_name_offset, path_pool_size));
-    }
-    const char* inst_name = &path_span[e.inst_name_offset];
-
-    // Decode structural child edge metadata from flat transport pool.
-    auto edge_coord = lyra::runtime::DecodeRepertoireCoord(
-        e, std::span(coord_steps_pool, coord_steps_word_count));
-
-    // Resolve parent from transport index to live pointer.
-    // parent_instance_index is transport-only: consumed here to resolve
-    // a live RuntimeInstance* parent. Does not survive past this loop.
-    lyra::runtime::RuntimeInstance* parent = nullptr;
-    if (e.parent_instance_index != UINT32_MAX) {
-      if (e.parent_instance_index >= created_instances.size()) {
+    if (e.node_kind == lyra::runtime::ConstructionNodeKind::kGenerate) {
+      // Generate scope node: hierarchy-only, no body/storage/processes.
+      auto* scope = ctor.CreateScope(parent_scope, label, e.ordinal_in_parent);
+      created_scopes.push_back(scope);
+    } else {
+      // Module instance node.
+      if (e.body_group >= body_desc_count) {
         throw lyra::common::InternalError(
             "LyraConstructorRunProgram",
             std::format(
-                "entry {} parent_instance_index {} >= created count {}", i,
-                e.parent_instance_index, created_instances.size()));
+                "entry {} body_group {} >= body_desc_count {}", i, e.body_group,
+                body_desc_count));
       }
-      parent = created_instances[e.parent_instance_index];
-    }
 
-    const void* param_data = nullptr;
-    uint32_t param_size = e.param_size;
-    if (param_size != 0) {
-      if (param_pool == nullptr) {
-        throw lyra::common::InternalError(
-            "LyraConstructorRunProgram",
-            std::format(
-                "entry {} has param_size {} but param_pool is null", i,
-                param_size));
+      if (e.body_group != last_body_group) {
+        ctor.BeginBody(
+            MakeBodyDescriptorPackageView(body_desc_span[e.body_group]));
+        last_body_group = e.body_group;
       }
-      if (e.param_offset > param_pool_size ||
-          param_size > param_pool_size - e.param_offset) {
-        throw lyra::common::InternalError(
-            "LyraConstructorRunProgram",
-            std::format(
-                "entry {} param range [{}, {}) exceeds param_pool_size {}", i,
-                e.param_offset,
-                static_cast<uint64_t>(e.param_offset) + param_size,
-                param_pool_size));
-      }
-      param_data = &param_span[e.param_offset];
-    }
 
-    auto* child = ctor.CreateChild(
-        parent, std::move(edge_coord), e.child_ordinal_in_coord, inst_name,
-        param_data, param_size, e.realized_inline_size,
-        e.realized_appendix_size);
-    created_instances.push_back(child);
+      const void* param_data = nullptr;
+      uint32_t param_size = e.param_size;
+      if (param_size != 0) {
+        if (param_pool == nullptr) {
+          throw lyra::common::InternalError(
+              "LyraConstructorRunProgram",
+              std::format(
+                  "entry {} has param_size {} but param_pool is null", i,
+                  param_size));
+        }
+        if (e.param_offset > param_pool_size ||
+            param_size > param_pool_size - e.param_offset) {
+          throw lyra::common::InternalError(
+              "LyraConstructorRunProgram",
+              std::format(
+                  "entry {} param range [{}, {}) exceeds param_pool_size {}", i,
+                  e.param_offset,
+                  static_cast<uint64_t>(e.param_offset) + param_size,
+                  param_pool_size));
+        }
+        param_data = &param_span[e.param_offset];
+      }
+
+      auto* inst = ctor.CreateChildInstance(
+          parent_scope, e.ordinal_in_parent, e.instance_index, label,
+          param_data, param_size, e.realized_inline_size,
+          e.realized_appendix_size);
+      created_scopes.push_back(&inst->scope);
+    }
   }
 }
 

--- a/src/lyra/runtime/dpi_export_context.cpp
+++ b/src/lyra/runtime/dpi_export_context.cpp
@@ -91,8 +91,11 @@ extern "C" void LyraResolveModuleInstanceBinding(
     LyraFailMissingModuleExportScope();
   }
   auto* engine = static_cast<lyra::runtime::Engine*>(ctx->engine);
-  auto* inst = const_cast<lyra::runtime::RuntimeInstance*>(
+  // Validate the scope handle, then narrow to an instance -- DPI module
+  // exports only bind to module instances, not generate scopes.
+  auto* scope = const_cast<lyra::runtime::RuntimeScope*>(
       engine->ValidateScopeHandle(ctx->active_scope));
+  auto* inst = lyra::runtime::ScopeAsInstanceChecked(scope);
   out->design_state = ctx->design_state;
   out->engine = ctx->engine;
   out->this_ptr = inst->storage.inline_base;

--- a/src/lyra/runtime/engine_bundle_init.cpp
+++ b/src/lyra/runtime/engine_bundle_init.cpp
@@ -861,7 +861,7 @@ void Engine::InitModuleInstancesFromBundles(
                     "local comb trigger id {} >= local_comb_trigger_map "
                     "size {} for instance '{}'",
                     local_id, obs.local_comb_trigger_map.size(),
-                    inst->path_c_str));
+                    inst->scope.path_c_str));
           }
           obs.local_comb_trigger_map[local_id] = {
               .start = start, .count = count};

--- a/src/lyra/runtime/engine_dpi_scope.cpp
+++ b/src/lyra/runtime/engine_dpi_scope.cpp
@@ -1,4 +1,7 @@
 #include <format>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
 
 #include "lyra/common/internal_error.hpp"
 #include "lyra/runtime/engine.hpp"
@@ -6,14 +9,59 @@
 
 namespace lyra::runtime {
 
+namespace {
+
+// Walk the runtime scope subtree rooted at `scope` and register every node
+// (both instance and generate) into the DPI scope registry. The full
+// scope tree is the authoritative membership set for svScope handles;
+// any scope with a hierarchical path is a valid handle.
+void RegisterScopeSubtree(
+    const RuntimeScope* scope,
+    std::unordered_set<const RuntimeScope*>& valid_scopes,
+    std::unordered_map<std::string_view, const RuntimeScope*>& scope_path_map,
+    std::unordered_map<const RuntimeScope*, const char*>& scope_path_by_ptr) {
+  if (scope == nullptr) return;
+  if (scope->path_c_str == nullptr) {
+    throw common::InternalError(
+        "BuildDpiScopeRegistry",
+        "null path_c_str on runtime scope during subtree registration");
+  }
+  if (!valid_scopes.insert(scope).second) {
+    throw common::InternalError(
+        "BuildDpiScopeRegistry",
+        std::format(
+            "duplicate RuntimeScope pointer at path '{}'", scope->path_c_str));
+  }
+  if (!scope_path_map.emplace(std::string_view(scope->path_c_str), scope)
+           .second) {
+    throw common::InternalError(
+        "BuildDpiScopeRegistry",
+        std::format("duplicate scope path '{}'", scope->path_c_str));
+  }
+  if (!scope_path_by_ptr.emplace(scope, scope->path_c_str).second) {
+    throw common::InternalError(
+        "BuildDpiScopeRegistry",
+        "duplicate RuntimeScope in DPI reverse path map");
+  }
+  for (const auto& edge : scope->children) {
+    RegisterScopeSubtree(
+        edge.child, valid_scopes, scope_path_map, scope_path_by_ptr);
+  }
+}
+
+}  // namespace
+
 void Engine::BuildDpiScopeRegistry() {
   valid_scopes_.clear();
   scope_path_map_.clear();
-  scope_inst_path_map_.clear();
+  scope_path_by_ptr_.clear();
   scope_user_data_.clear();
   if (instances_.empty()) {
     return;
   }
+  // Walk the runtime scope tree from each root instance. Generate scopes
+  // and nested instances are reached via scope.children edges. This is
+  // the authoritative source of valid svScope handles.
   for (uint32_t i = 0; i < instances_.size(); ++i) {
     const RuntimeInstance* inst = instances_[i];
     if (inst == nullptr) {
@@ -21,48 +69,30 @@ void Engine::BuildDpiScopeRegistry() {
           "BuildDpiScopeRegistry",
           std::format("null RuntimeInstance at index {}", i));
     }
-    if (inst->path_c_str == nullptr) {
-      throw common::InternalError(
-          "BuildDpiScopeRegistry",
-          std::format("null path_c_str on instance at index {}", i));
-    }
-    valid_scopes_.insert(inst);
-    auto [path_it, path_inserted] =
-        scope_path_map_.emplace(std::string_view(inst->path_c_str), inst);
-    if (!path_inserted) {
-      throw common::InternalError(
-          "BuildDpiScopeRegistry",
-          std::format("duplicate instance path '{}'", inst->path_c_str));
-    }
-    auto [inst_it, inst_inserted] =
-        scope_inst_path_map_.emplace(inst, inst->path_c_str);
-    if (!inst_inserted) {
-      throw common::InternalError(
-          "BuildDpiScopeRegistry",
-          "duplicate RuntimeInstance in DPI scope registry");
-    }
+    if (inst->scope.parent != nullptr) continue;
+    RegisterScopeSubtree(
+        &inst->scope, valid_scopes_, scope_path_map_, scope_path_by_ptr_);
   }
 }
 
-auto Engine::ValidateScopeHandle(svScope scope) const
-    -> const RuntimeInstance* {
+auto Engine::ValidateScopeHandle(svScope scope) const -> const RuntimeScope* {
   if (scope == nullptr) {
     return nullptr;
   }
-  const auto* inst = static_cast<const RuntimeInstance*>(scope);
-  if (!valid_scopes_.contains(inst)) {
+  const auto* rs = static_cast<const RuntimeScope*>(scope);
+  if (!valid_scopes_.contains(rs)) {
     throw common::InternalError(
         "ValidateScopeHandle", "invalid svScope handle");
   }
-  return inst;
+  return rs;
 }
 
-auto Engine::IsScopeHandleValid(const RuntimeInstance* inst) const -> bool {
-  return valid_scopes_.contains(inst);
+auto Engine::IsScopeHandleValid(const RuntimeScope* scope) const -> bool {
+  return valid_scopes_.contains(scope);
 }
 
 auto Engine::ResolveScopeByPath(std::string_view path) const
-    -> const RuntimeInstance* {
+    -> const RuntimeScope* {
   auto it = scope_path_map_.find(path);
   if (it == scope_path_map_.end()) {
     return nullptr;
@@ -70,45 +100,45 @@ auto Engine::ResolveScopeByPath(std::string_view path) const
   return it->second;
 }
 
-auto Engine::GetScopePath(const RuntimeInstance* inst) const -> const char* {
-  if (inst == nullptr) {
+auto Engine::GetScopePath(const RuntimeScope* scope) const -> const char* {
+  if (scope == nullptr) {
     return nullptr;
   }
-  if (!valid_scopes_.contains(inst)) {
+  if (!valid_scopes_.contains(scope)) {
     throw common::InternalError(
         "GetScopePath", "scope is not registered in DPI scope registry");
   }
-  auto it = scope_inst_path_map_.find(inst);
-  if (it == scope_inst_path_map_.end()) {
+  auto it = scope_path_by_ptr_.find(scope);
+  if (it == scope_path_by_ptr_.end()) {
     throw common::InternalError(
         "GetScopePath", "registered scope missing reverse path entry");
   }
   return it->second;
 }
 
-auto Engine::PutScopeUserData(
-    const RuntimeInstance* inst, void* key, void* data) -> int {
-  if (inst == nullptr || key == nullptr) {
+auto Engine::PutScopeUserData(const RuntimeScope* scope, void* key, void* data)
+    -> int {
+  if (scope == nullptr || key == nullptr) {
     return -1;
   }
-  if (!valid_scopes_.contains(inst)) {
+  if (!valid_scopes_.contains(scope)) {
     throw common::InternalError(
         "PutScopeUserData", "scope is not registered in DPI scope registry");
   }
-  scope_user_data_[inst][key] = data;
+  scope_user_data_[scope][key] = data;
   return 0;
 }
 
-auto Engine::GetScopeUserData(const RuntimeInstance* inst, void* key) const
+auto Engine::GetScopeUserData(const RuntimeScope* scope, void* key) const
     -> void* {
-  if (inst == nullptr || key == nullptr) {
+  if (scope == nullptr || key == nullptr) {
     return nullptr;
   }
-  if (!valid_scopes_.contains(inst)) {
+  if (!valid_scopes_.contains(scope)) {
     throw common::InternalError(
         "GetScopeUserData", "scope is not registered in DPI scope registry");
   }
-  auto scope_it = scope_user_data_.find(inst);
+  auto scope_it = scope_user_data_.find(scope);
   if (scope_it == scope_user_data_.end()) {
     return nullptr;
   }
@@ -126,20 +156,36 @@ auto Engine::GetSimulationTimeSemantics() const -> SimulationTimeSemantics {
   };
 }
 
-auto Engine::GetScopeTimeUnitPower(const RuntimeInstance* inst) const
-    -> int32_t {
-  if (inst == nullptr) {
+auto Engine::GetScopeTimeUnitPower(const RuntimeScope* scope) const -> int32_t {
+  if (scope == nullptr) {
     return GetSimulationTimeSemantics().unit_power;
   }
-  return inst->scope_time_metadata.time_unit_power;
+  // Time metadata lives on the enclosing module instance. Walk up for
+  // generate scopes. Per IEEE 1800, generate blocks inherit timescale
+  // from their enclosing module.
+  const RuntimeScope* cur = scope;
+  while (cur != nullptr && cur->kind != RuntimeScopeKind::kInstance) {
+    cur = cur->parent;
+  }
+  if (cur == nullptr) {
+    return GetSimulationTimeSemantics().unit_power;
+  }
+  return ScopeAsInstanceChecked(cur)->scope_time_metadata.time_unit_power;
 }
 
-auto Engine::GetScopeTimePrecisionPower(const RuntimeInstance* inst) const
+auto Engine::GetScopeTimePrecisionPower(const RuntimeScope* scope) const
     -> int32_t {
-  if (inst == nullptr) {
+  if (scope == nullptr) {
     return GetSimulationTimeSemantics().precision_power;
   }
-  return inst->scope_time_metadata.time_precision_power;
+  const RuntimeScope* cur = scope;
+  while (cur != nullptr && cur->kind != RuntimeScopeKind::kInstance) {
+    cur = cur->parent;
+  }
+  if (cur == nullptr) {
+    return GetSimulationTimeSemantics().precision_power;
+  }
+  return ScopeAsInstanceChecked(cur)->scope_time_metadata.time_precision_power;
 }
 
 }  // namespace lyra::runtime

--- a/src/lyra/runtime/engine_scheduler_fixpoint.cpp
+++ b/src/lyra/runtime/engine_scheduler_fixpoint.cpp
@@ -147,7 +147,7 @@ void Engine::InitConnectionBatch(
                   "trigger local_id {} >= local_conn_trigger_map size {} "
                   "for instance '{}'",
                   local_id, obs.local_conn_trigger_map.size(),
-                  inst->path_c_str));
+                  inst->scope.path_c_str));
         }
         obs.local_conn_trigger_map[local_id] = {
             .start = start, .count = conn_base + i - start};
@@ -382,7 +382,7 @@ void Engine::InitCombKernels(
                   "local comb trigger id {} >= local_comb_trigger_map "
                   "size {} for instance '{}'",
                   local_id, obs.local_comb_trigger_map.size(),
-                  inst->path_c_str));
+                  inst->scope.path_c_str));
         }
         obs.local_comb_trigger_map[local_id] = {.start = start, .count = count};
         obs.local_comb_trigger_slots.push_back(LocalSignalId{local_id});

--- a/src/lyra/runtime/engine_subscriptions_install.cpp
+++ b/src/lyra/runtime/engine_subscriptions_install.cpp
@@ -60,7 +60,7 @@ auto ValidateCrossInstanceLocal(
                    "cross-instance local_id {} >= local_signal_count {} "
                    "for instance {}",
                    lid.value, inst->observability.local_signal_count,
-                   inst->path_c_str));
+                   inst->scope.path_c_str));
   }
   return LocalSignalRef{.instance = inst, .signal = lid};
 }

--- a/src/lyra/runtime/instance_observability.cpp
+++ b/src/lyra/runtime/instance_observability.cpp
@@ -78,8 +78,9 @@ auto ComposeHierarchicalTraceName(
     const RuntimeInstance& inst, LocalSignalId local_signal,
     const BodyObservableLayout& layout) -> std::string {
   auto local_name = layout.TraceLocalName(local_signal);
-  std::string_view path =
-      inst.path_c_str != nullptr ? inst.path_c_str : std::string_view{};
+  std::string_view path = inst.scope.path_c_str != nullptr
+                              ? inst.scope.path_c_str
+                              : std::string_view{};
   if (path.empty()) {
     return std::string(local_name);
   }

--- a/src/lyra/runtime/io.cpp
+++ b/src/lyra/runtime/io.cpp
@@ -481,7 +481,7 @@ extern "C" void LyraPrintModulePath(void* engine_ptr, void* instance_raw) {
   const auto* inst =
       static_cast<const lyra::runtime::RuntimeInstance*>(instance_raw);
   engine->Output().AppendSimOutputFragment(
-      inst->path_c_str != nullptr ? inst->path_c_str : "");
+      inst->scope.path_c_str != nullptr ? inst->scope.path_c_str : "");
 }
 
 extern "C" void LyraWritemem(

--- a/src/lyra/runtime/slot_meta.cpp
+++ b/src/lyra/runtime/slot_meta.cpp
@@ -244,10 +244,11 @@ void SlotMetaRegistry::DumpSummary(OutputDispatcher& out) const {
           "design_base_off={} total_bytes={}",
           i, KindName(slot.kind), slot.design_base_off, slot.total_bytes);
     } else {
-      const char* display_path = (slot.owner_instance != nullptr &&
-                                  slot.owner_instance->path_c_str != nullptr)
-                                     ? slot.owner_instance->path_c_str
-                                     : "<null>";
+      const char* display_path =
+          (slot.owner_instance != nullptr &&
+           slot.owner_instance->scope.path_c_str != nullptr)
+              ? slot.owner_instance->scope.path_c_str
+              : "<null>";
       line = std::format(
           "__LYRA_SLOT_META__: slot={} domain=instance kind={} "
           "owner_instance='{}' instance_rel_off={} total_bytes={}",

--- a/src/lyra/runtime/svdpi_runtime.cpp
+++ b/src/lyra/runtime/svdpi_runtime.cpp
@@ -326,8 +326,8 @@ extern "C" svScope svSetScope(const svScope scope) {
 extern "C" const char* svGetNameFromScope(const svScope scope) {
   auto* ctx = GetActiveDpiContextOrAbort();
   auto* engine = static_cast<const lyra::runtime::Engine*>(ctx->engine);
-  const auto* inst = engine->ValidateScopeHandle(scope);
-  return engine->GetScopePath(inst);
+  const auto* rs = engine->ValidateScopeHandle(scope);
+  return engine->GetScopePath(rs);
 }
 
 extern "C" svScope svGetScopeFromName(const char* scopeName) {
@@ -336,29 +336,29 @@ extern "C" svScope svGetScopeFromName(const char* scopeName) {
     return nullptr;
   }
   auto* engine = static_cast<const lyra::runtime::Engine*>(ctx->engine);
-  const auto* inst = engine->ResolveScopeByPath(scopeName);
-  return const_cast<lyra::runtime::RuntimeInstance*>(inst);
+  const auto* rs = engine->ResolveScopeByPath(scopeName);
+  return const_cast<lyra::runtime::RuntimeScope*>(rs);
 }
 
 extern "C" int svPutUserData(
     const svScope scope, void* userKey, void* userData) {
   auto* ctx = GetActiveDpiContextOrAbort();
   auto* engine = static_cast<lyra::runtime::Engine*>(ctx->engine);
-  const auto* inst = engine->ValidateScopeHandle(scope);
-  if (inst == nullptr || userKey == nullptr) {
+  const auto* rs = engine->ValidateScopeHandle(scope);
+  if (rs == nullptr || userKey == nullptr) {
     return -1;
   }
-  return engine->PutScopeUserData(inst, userKey, userData);
+  return engine->PutScopeUserData(rs, userKey, userData);
 }
 
 extern "C" void* svGetUserData(const svScope scope, void* userKey) {
   auto* ctx = GetActiveDpiContextOrAbort();
   auto* engine = static_cast<const lyra::runtime::Engine*>(ctx->engine);
-  const auto* inst = engine->ValidateScopeHandle(scope);
-  if (inst == nullptr || userKey == nullptr) {
+  const auto* rs = engine->ValidateScopeHandle(scope);
+  if (rs == nullptr || userKey == nullptr) {
     return nullptr;
   }
-  return engine->GetScopeUserData(inst, userKey);
+  return engine->GetScopeUserData(rs, userKey);
 }
 
 // NOLINTEND(cppcoreguidelines-pro-type-const-cast)
@@ -383,18 +383,18 @@ static void EncodeVendoredSvTimeValFromTicks(svTimeVal& out, uint64_t ticks) {
 // - no package-context inference from active_scope when argument is null
 
 // Validate scope for D6d time APIs. Returns nullptr for null scope,
-// validated instance for non-null scope, aborts for invalid non-null scope.
+// validated scope for non-null scope, aborts for invalid non-null scope.
 // Uses abort (not throw) to stay safe across extern "C" boundary.
 auto ValidateOptionalScopeOrAbort(
     const lyra::runtime::Engine* engine, svScope scope)
-    -> const lyra::runtime::RuntimeInstance* {
+    -> const lyra::runtime::RuntimeScope* {
   if (scope == nullptr) return nullptr;
-  auto* inst = static_cast<const lyra::runtime::RuntimeInstance*>(scope);
-  if (!engine->IsScopeHandleValid(inst)) {
+  const auto* rs = static_cast<const lyra::runtime::RuntimeScope*>(scope);
+  if (!engine->IsScopeHandleValid(rs)) {
     std::fputs("fatal: invalid svScope handle\n", stderr);
     std::abort();
   }
-  return inst;
+  return rs;
 }
 
 extern "C" int svGetTime(const svScope scope, svTimeVal* time) {
@@ -410,8 +410,8 @@ extern "C" int svGetTimeUnit(const svScope scope, int32_t* time_unit) {
   if (time_unit == nullptr) return -1;
   auto* ctx = GetActiveDpiContextOrAbort();
   auto* engine = static_cast<const lyra::runtime::Engine*>(ctx->engine);
-  const auto* inst = ValidateOptionalScopeOrAbort(engine, scope);
-  *time_unit = engine->GetScopeTimeUnitPower(inst);
+  const auto* rs = ValidateOptionalScopeOrAbort(engine, scope);
+  *time_unit = engine->GetScopeTimeUnitPower(rs);
   return 0;
 }
 
@@ -420,8 +420,8 @@ extern "C" int svGetTimePrecision(
   if (time_precision == nullptr) return -1;
   auto* ctx = GetActiveDpiContextOrAbort();
   auto* engine = static_cast<const lyra::runtime::Engine*>(ctx->engine);
-  const auto* inst = ValidateOptionalScopeOrAbort(engine, scope);
-  *time_precision = engine->GetScopeTimePrecisionPower(inst);
+  const auto* rs = ValidateOptionalScopeOrAbort(engine, scope);
+  *time_precision = engine->GetScopeTimePrecisionPower(rs);
   return 0;
 }
 

--- a/src/lyra/runtime/trace_flush.cpp
+++ b/src/lyra/runtime/trace_flush.cpp
@@ -210,7 +210,7 @@ void FlushLocalDirtySlotsToTrace(
             std::format(
                 "instance '{}' has dirty local signals but "
                 "local_signal_count=0",
-                inst->path_c_str));
+                inst->scope.path_c_str));
       }
       continue;
     }
@@ -220,7 +220,7 @@ void FlushLocalDirtySlotsToTrace(
           "FlushLocalDirtySlotsToTrace",
           std::format(
               "instance '{}' has local signals but no observability layout",
-              inst->path_c_str));
+              inst->scope.path_c_str));
     }
 
     if (obs.trace_select.size() != obs.local_signal_count) {
@@ -228,7 +228,7 @@ void FlushLocalDirtySlotsToTrace(
           "FlushLocalDirtySlotsToTrace",
           std::format(
               "instance '{}' trace_select size {} != local_signal_count {}",
-              inst->path_c_str, obs.trace_select.size(),
+              inst->scope.path_c_str, obs.trace_select.size(),
               obs.local_signal_count));
     }
 
@@ -238,7 +238,7 @@ void FlushLocalDirtySlotsToTrace(
             "FlushLocalDirtySlotsToTrace",
             std::format(
                 "instance '{}' dirty local signal {} out of range {}",
-                inst->path_c_str, lid.value, obs.local_signal_count));
+                inst->scope.path_c_str, lid.value, obs.local_signal_count));
       }
 
       if (obs.trace_select[lid.value] == 0) continue;

--- a/src/lyra/trace/summary_trace_sink.cpp
+++ b/src/lyra/trace/summary_trace_sink.cpp
@@ -54,7 +54,7 @@ void SummaryTraceSink::PrintSummary(
         std::format(
             "__LYRA_TRACE_SLOT__: instance='{}' local={} value_changes={} "
             "memory_dirty={}\n",
-            key.instance->path_c_str, key.signal_id, counts.value_changes,
+            key.instance->scope.path_c_str, key.signal_id, counts.value_changes,
             counts.memory_dirty));
   }
 }

--- a/src/lyra/trace/text_trace_sink.cpp
+++ b/src/lyra/trace/text_trace_sink.cpp
@@ -155,15 +155,17 @@ void TextTraceSink::HandleLocalValueChange(const LocalValueChange& vc) {
     throw common::InternalError(
         "TextTraceSink::HandleLocalValueChange",
         std::format(
-            "instance '{}' has no observability layout", inst->path_c_str));
+            "instance '{}' has no observability layout",
+            inst->scope.path_c_str));
   }
 
   if (vc.signal_id.value >= layout->trace_meta.size()) {
     throw common::InternalError(
         "TextTraceSink::HandleLocalValueChange",
         std::format(
-            "instance '{}' local signal {} out of range {}", inst->path_c_str,
-            vc.signal_id.value, layout->trace_meta.size()));
+            "instance '{}' local signal {} out of range {}",
+            inst->scope.path_c_str, vc.signal_id.value,
+            layout->trace_meta.size()));
   }
 
   auto name =

--- a/tests/framework/llvm_common.cpp
+++ b/tests/framework/llvm_common.cpp
@@ -276,6 +276,7 @@ auto PrepareLlvmModule(
       .specialization_map = &hir_result.specialization_map,
       .child_coord_map = &hir_result.child_coord_map,
       .body_timescales = &hir_result.body_timescales,
+      .hierarchy_nodes = &hir_result.hierarchy_nodes,
   };
   auto mir_result = lowering::hir_to_mir::LowerHirToMir(mir_input);
   if (!mir_result) {

--- a/tests/sv_features/dpi/svdpi_runtime/default.yaml
+++ b/tests/sv_features/dpi/svdpi_runtime/default.yaml
@@ -316,3 +316,31 @@ cases:
     expect:
       variables:
         result: 1
+
+  - name: generate_scope_registration
+    description: >
+      Generate-block scopes are first-class in the DPI scope registry.
+      svGetScopeFromName resolves "Test.blk[0]", the handle round-trips
+      through svGetNameFromScope, svPutUserData/svGetUserData accept the
+      generate-scope handle, and the nested instance path is also
+      registered. This exercises Cut 5's scope-tree-wide registry, not
+      just instance scopes.
+    dpi_sources:
+      - dpi_helpers/svdpi_utils.c
+    sv: |
+      module Leaf;
+      endmodule
+
+      module Test;
+        for (genvar i = 0; i < 2; i++) begin : blk
+          Leaf u();
+        end
+        import "DPI-C" function int test_generate_scope_registration();
+        int result;
+        initial begin
+          result = test_generate_scope_registration();
+        end
+      endmodule
+    expect:
+      variables:
+        result: 1

--- a/tests/sv_features/dpi/svdpi_runtime/dpi_helpers/svdpi_utils.c
+++ b/tests/sv_features/dpi/svdpi_runtime/dpi_helpers/svdpi_utils.c
@@ -1,5 +1,6 @@
 /* DPI companion C code exercising svdpi.h runtime utility functions. */
 
+#include <string.h>
 #include <svdpi.h>
 
 int test_svdpi_version(void) {
@@ -391,6 +392,37 @@ int test_size_helpers(void) {
   if (svSizeOfLogicPackedArr(33) != 16) return 0;
   if (svSizeOfLogicPackedArr(64) != 16) return 0;
   if (svSizeOfLogicPackedArr(65) != 24) return 0;
+
+  return 1;
+}
+
+/* Verify that generate-scope paths are registered and reachable via the
+ * DPI scope registry. This exercises the full scope tree, not just the
+ * instance-backed subset. Covers four properties:
+ *   1. svGetScopeFromName("Test.blk[0]") returns a non-null handle.
+ *   2. svGetNameFromScope round-trips the path.
+ *   3. svPutUserData/svGetUserData accept the generate-scope handle.
+ *   4. The inner instance "Test.blk[0].u" is also registered.
+ */
+int test_generate_scope_registration(void) {
+  svScope gen = svGetScopeFromName("Test.blk[0]");
+  if (gen == 0) return 0;
+
+  const char* name = svGetNameFromScope(gen);
+  if (name == 0) return 0;
+  if (strcmp(name, "Test.blk[0]") != 0) return 0;
+
+  static int key;
+  static int data = 42;
+  if (svPutUserData(gen, &key, &data) != 0) return 0;
+  int* got = (int*)svGetUserData(gen, &key);
+  if (got == 0 || *got != 42) return 0;
+
+  svScope inner = svGetScopeFromName("Test.blk[0].u");
+  if (inner == 0) return 0;
+  const char* inner_name = svGetNameFromScope(inner);
+  if (inner_name == 0) return 0;
+  if (strcmp(inner_name, "Test.blk[0].u") != 0) return 0;
 
   return 1;
 }

--- a/tests/sv_features/generate/generate/default.yaml
+++ b/tests/sv_features/generate/generate/default.yaml
@@ -339,3 +339,22 @@ cases:
       endmodule
     expect:
       stdout: "outer.x=10\nouter.inner[0].y=100 outer.inner[1].y=200\n"
+
+  - name: for_generate_module_instantiation
+    description: Module instantiation inside for-generate loop
+    sv: |
+      module Leaf #(parameter int ID = 0);
+        initial $display("leaf %0d", ID);
+      endmodule
+
+      module Test;
+        genvar i;
+        for (i = 0; i < 3; i++) begin : blk
+          Leaf #(.ID(i)) u();
+        end
+      endmodule
+    expect:
+      stdout: |
+        leaf 0
+        leaf 1
+        leaf 2


### PR DESCRIPTION
## Summary

Promote generate scopes and module instances to a single runtime scope tree (`RuntimeScope` + `RuntimeGenerateScope`) and route every hierarchy consumer through it. Paths are no longer transported as pre-baked strings -- the constructor derives each scope's path from its parent plus a relative label, and the DPI scope registry walks the full tree so `svGetScopeFromName` resolves generate scopes as first-class handles. The previous flat parent-index / durable-child coord transport that the runtime never read is deleted.

## Design

The shape is a hierarchy base embedded in each payload type, not an inheritance hierarchy. `RuntimeScope` lives as the first member of `RuntimeInstance` and is the sole member of `RuntimeGenerateScope`; both types are `standard_layout`, so `ScopeAsInstanceChecked` recovers the containing instance via `offsetof(RuntimeInstance, scope)` with a kind assertion. Nothing virtual, nothing allocated separately.

`HierarchyNode` is authored in `lyra::common` during AST->HIR from slang's hierarchical paths (the authoritative frontend source) and threaded as a compile-time input through MIR to the construction program emitter. At the ABI boundary, `ConstructionProgramEntry` carries a typed `ConstructionNodeKind`, a parent-relative label offset, a parent entry index, and an `ordinal_in_parent`. The constructor rebuilds paths with `BuildScopePath(parent, label)` and wires children into `scope.children` in declaration order. Strict `DeriveRelativeLabel` throws on any prefix mismatch rather than falling back silently.

DPI is the primary consumer of the new model. `svScope` is now `RuntimeScope*` end-to-end: codegen emits `&inst->scope` via an `i8`-GEP with `offsetof(RuntimeInstance, scope)` instead of pushing the instance pointer, the scope registry is populated by a recursive subtree walk rooted at every root instance (so generate scopes are reachable by name), and time-metadata queries walk up from an arbitrary scope to the nearest enclosing instance before reading `scope_time_metadata`.

With paths derived rather than transported, several ABI fields become dead weight. `ConstructionProgramEntry` loses `path_offset` (48 bytes), `BodyRealizationDesc` loses `expr_conn_coord_words`/`num_expr_conn_coord_words` (88 bytes), and `ExprConnChildDesc` collapses to a single tree-relative `child_ordinal` that indexes directly into `parent->scope.children` (12 bytes). `ConstructionInput` drops `parent_instance_indices` and `child_durable_ids`; both were transport-only and no runtime reader existed.

### What did not change

`RuntimeInstance` still owns all instance-scoped payload -- storage regions, `attached_processes`, observability state, dedup/fixpoint workspaces, event state, ext-ref bindings, time metadata. Processes and declarations that originate inside generate scopes remain attached to the enclosing instance; the new scope tree is hierarchy and path identity only, not a relocation of semantic ownership.

## Testing

`bazel test //tests:jit_dev_tests` (2234 cases) passes. Two new validation tests exercise the ABI:

- `tests/sv_features/dpi/svdpi_runtime/default.yaml::generate_scope_registration` -- `svGetScopeFromName("Test.blk[0]")` round-trips, accepts per-scope user data, and descends into nested instances under a generate scope.
- `tests/sv_features/generate/generate/default.yaml` -- new case confirms hierarchy emission covers generate scopes without regressing existing cases.