### PR TITLE
Make RuntimeProcess own its metadata and thread it by reference

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -164,7 +164,7 @@ Classify every self-cost function into exactly one bucket. The bucket list is fi
 | actual logic           | Emitted process bodies (`body_*_proc_*`), descriptor dispatch trampoline (`__lyra_descriptor_dispatch`)                                         |
 | dirty tracking         | MarkSlotDirty, TouchSlot, MarkDirtyRange, ClearDelta                                                                                            |
 | subscriptions          | FlushSignalUpdates, FlushDirtySlot, FlushSlotEdgeGroups, FlushSlotChangeSubs, FlushSlotRebindSubs, FlushSlotContainerSubs, EnqueueProcessWakeup |
-| dispatch / reconcile   | ExecuteRegion, RunOneActivation, DescriptorProcessDispatch, ReconcilePostActivation, LyraSuspendWait, TraceWake, LyraResetIterationLimit        |
+| dispatch / reconcile   | ExecuteRegion, RunOneActivation, DispatchAndHandleActivation, ReconcilePostActivation, LyraSuspendWait, TraceWake, LyraResetIterationLimit      |
 | connection propagation | FlushAndPropagateConnections (connection phase)                                                                                                 |
 | comb propagation       | FlushAndPropagateConnections (comb phase), comb kernel functions                                                                                |
 | NBA lifecycle          | ScheduleNba, SmallByteBuffer, ApplyFullOverwriteNba, ApplyMaskedMergeNba                                                                        |

--- a/include/lyra/llvm_backend/codegen_session.hpp
+++ b/include/lyra/llvm_backend/codegen_session.hpp
@@ -327,8 +327,8 @@ auto CompileDesignProcesses(const LoweringInput& input)
 // parameter needed. Per-instance data (external ref slots) is loaded at
 // runtime from instance_ptr, not passed through the compilation session.
 auto CompileModuleSpecSession(
-    Context& context, const CompiledModuleSpecInput& input)
-    -> Result<CompiledModuleSpec>;
+    Context& context, const CuFacts& facts,
+    const CompiledModuleSpecInput& input) -> Result<CompiledModuleSpec>;
 
 // Backend phase: extract LLVM ownership from a completed session.
 auto FinalizeModule(CodegenSession session, LoweringReport report)

--- a/include/lyra/llvm_backend/context.hpp
+++ b/include/lyra/llvm_backend/context.hpp
@@ -760,34 +760,36 @@ class Context {
   [[nodiscard]] auto SaveExecutionContractState() -> ExecutionContractState;
   void RestoreExecutionContractState(const ExecutionContractState& state);
 
-  // Emit GEPs and loads to extract design_ptr, engine_ptr, and frame_ptr from
-  // the process state argument, then cache them in the context via the setters
-  // below. Must be called once per process function entry block.
-  void EmitProcessStateSetup(llvm::Value* state_arg);
+  // Bind per-process state (frame GEP) and cache explicit body arguments
+  // for the current function: engine, design, decision-owner id. Must be
+  // called once per process function entry block.
+  void EmitProcessStateSetup(
+      llvm::Value* state_arg, llvm::Value* engine_arg, llvm::Value* design_arg,
+      llvm::Value* decision_owner_id_arg);
 
-  // Load realized instance binding from the frame header for shared bodies.
-  // Loads instance pointer, then derives storage base and instance_id
-  // from the RuntimeInstance object.
-  // Called after EmitProcessStateSetup by shared body generation only.
-  void EmitSharedBodyBindingSetup(llvm::Value* state_arg);
+  // Bind the instance pointer argument and derive its inline-base pointer
+  // (this_ptr). Called after EmitProcessStateSetup by shared body
+  // generation only.
+  void EmitSharedBodyBindingSetup(llvm::Value* instance_arg);
 
-  // Canonical typed header-field accessors. All typed process-header field
-  // access in llvm backend code must go through these methods. Callers never
-  // pass raw field indices or choose LLVM result types for header fields.
-  auto EmitLoadEnginePtr(llvm::Value* state_arg) -> llvm::Value*;
-  auto EmitLoadDesignPtr(llvm::Value* state_arg) -> llvm::Value*;
-  auto EmitLoadDecisionOwnerId(llvm::Value* state_arg) -> llvm::Value*;
-  auto EmitLoadInstancePtr(llvm::Value* state_arg) -> llvm::Value*;
-  auto EmitLoadInstanceInlineBase(llvm::Value* instance_ptr) -> llvm::Value*;
-  void EmitStoreDesignPtr(llvm::Value* state_arg, llvm::Value* value);
+  // Init-kind entry setup: caches state/frame pointers and the explicit
+  // design argument. No engine/instance/decision-owner binding.
+  void EmitInitProcessStateSetup(
+      llvm::Value* state_arg, llvm::Value* design_arg);
+
+  // Canonical typed header-field accessors. Only the outcome slot and the
+  // frame GEP derive from the process-state pointer; every other runtime
+  // binding (engine, design, instance, decision-owner id) is threaded as
+  // an explicit body argument.
   auto EmitOutcomePtr(llvm::Value* state_arg) -> llvm::Value*;
+  auto EmitLoadInstanceInlineBase(llvm::Value* instance_ptr) -> llvm::Value*;
 
   // Cached pointers (computed in entry block, reused for all place accesses)
   // state_ptr: the function argument pointing to ProcessStateN
   void SetStatePointer(llvm::Value* state_ptr);
   [[nodiscard]] auto GetStatePointer() -> llvm::Value*;
 
-  // design_ptr: loaded from state->header.design, points to shared DesignState
+  // design_ptr: body argument; points to the shared DesignState base.
   void SetDesignPointer(llvm::Value* design_ptr);
   [[nodiscard]] auto GetDesignPointer() -> llvm::Value*;
 
@@ -795,13 +797,12 @@ class Context {
   void SetFramePointer(llvm::Value* frame_ptr);
   [[nodiscard]] auto GetFramePointer() -> llvm::Value*;
 
-  // engine_ptr: loaded from state->header.engine, points to shared Engine
+  // engine_ptr: body argument; points to the shared Engine.
   void SetEnginePointer(llvm::Value* engine_ptr);
   [[nodiscard]] auto GetEnginePointer() -> llvm::Value*;
 
-  // decision_owner_id: loaded from state->header.process_id, i32 identity.
-  // The process frame field stays process-named; the codegen layer interprets
-  // it as the decision owner for the process-backed owner path.
+  // decision_owner_id: body argument; dense owner id used by decision
+  // observation helpers. Init-kind bodies leave this null.
   void SetCurrentDecisionOwnerId(llvm::Value* decision_owner_id);
   [[nodiscard]] auto GetCurrentDecisionOwnerId() -> llvm::Value*;
 

--- a/include/lyra/llvm_backend/instruction/decision.hpp
+++ b/include/lyra/llvm_backend/instruction/decision.hpp
@@ -17,7 +17,7 @@ class SlotAccessResolver;
 // accidentally read ambient nullable state.
 
 auto LowerRecordDecisionObservation(
-    Context& ctx, const CuFacts& facts, llvm::Value* decision_owner_id,
+    Context& ctx, llvm::Value* decision_owner_id,
     const mir::RecordDecisionObservation& obs) -> Result<void>;
 
 auto LowerRecordDecisionObservationDynamic(

--- a/include/lyra/mir/instance.hpp
+++ b/include/lyra/mir/instance.hpp
@@ -18,7 +18,7 @@ struct InstanceEntry {
 };
 
 // Table of all module instances in the design, indexed by instance_id.
-// The instance_id is used in ProcessHandle to enable %m formatting.
+// The instance_id is used at runtime to enable %m formatting.
 struct InstanceTable {
   std::vector<InstanceEntry> entries;
 

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -132,30 +132,6 @@ struct DetailedRuntimeStats {
   uint64_t prop_pending_slots_total = 0;
 };
 
-// Per-process wakeup/activation counters. Collected when kDetailedStats is
-// enabled. Allows post-simulation analysis of which processes are hot,
-// what wakes them, and what kind of work each activation does.
-struct ProcessWakeStats {
-  // Wake attempts by cause (includes deduped).
-  uint64_t wake_edge = 0;
-  uint64_t wake_change = 0;
-  uint64_t wake_container = 0;
-  uint64_t wake_delay = 0;
-  uint64_t wake_initial = 0;
-  uint64_t wake_other = 0;
-  // Deduped wake attempts (process already enqueued).
-  uint64_t wake_deduped = 0;
-  // Actual activations (process body executed).
-  uint64_t runs = 0;
-  // Total distinct slots dirtied (direct MarkSlotDirty) across all runs.
-  uint64_t total_slots_dirtied = 0;
-  // Activations with no direct dirty marks. These are typically always_ff
-  // processes that write only via NBA (nonblocking assignment). NOT a
-  // wasted-wakeup indicator: always_ff processes legitimately schedule
-  // NBAs without calling MarkSlotDirty during their body.
-  uint64_t nba_only_runs = 0;
-};
-
 // Composite runtime stats: core (always-on) + detailed (opt-in).
 struct RuntimeStats {
   CoreRuntimeStats core;
@@ -226,18 +202,12 @@ class Engine {
             static_cast<FeatureFlag>(feature_flags_),
             FeatureFlag::kEnableActivationTrace)) {
       activation_trace_.emplace();
-      wake_trace_.resize(num_processes);
     }
     detailed_stats_enabled_ = HasFlag(
         static_cast<FeatureFlag>(feature_flags_), FeatureFlag::kDetailedStats);
-    if (detailed_stats_enabled_) {
-      per_process_stats_.resize(num_processes);
-    }
     decision_owner_tables_.resize(num_processes);
     decision_owner_states_.resize(num_processes);
     decision_owner_pending_flags_.resize(num_processes, 0);
-    deferred_assertion_states_.resize(num_processes);
-    deferred_pending_flags_.resize(num_processes, 0);
   }
 
   ~Engine() = default;
@@ -1018,8 +988,8 @@ class Engine {
       uint8_t disposition, const void* payload_ptr, uint32_t payload_size,
       const DeferredAssertionRefBindingAbi* ref_ptr, uint32_t ref_count);
   void FlushDeferredAssertionsForProcess(ProcessId pid) {
-    if (pid.Index() >= deferred_assertion_states_.size()) return;
-    deferred_assertion_states_[pid.Index()].flush_generation++;
+    if (pid.Index() >= processes_.size()) return;
+    processes_[pid.Index()].deferred_assertion_state.flush_generation++;
   }
   void MatureAndExecuteObservedDeferredAssertions();
 
@@ -1143,7 +1113,8 @@ class Engine {
   // Trace helpers: append event + live stderr print.
   // TraceWake is called at the single point where an activation becomes
   // runnable (ExecuteRegion kActive), not at producer-side queue insertion.
-  // Reads trace-only fields (cause, trigger_slot) from wake_trace_.
+  // Reads trace-only fields (cause, trigger_slot) from
+  // RuntimeProcess::wake_trace.
   void TraceWake(const WakeupEntry& entry);
   void TraceRun(const WakeupEntry& entry);
 
@@ -1212,41 +1183,41 @@ class Engine {
   void EnqueueProcessWakeup(
       uint32_t process_id, uint32_t resume_block, uint32_t trigger_slot,
       WakeCause cause) {
+    auto& proc = processes_[process_id];
     if (detailed_stats_enabled_) {
       ++stats_.detailed.wakeup_attempts;
-      auto& ps = per_process_stats_[process_id];
       switch (cause) {
         case WakeCause::kEdge:
-          ++ps.wake_edge;
+          ++proc.wake_stats.wake_edge;
           break;
         case WakeCause::kChange:
-          ++ps.wake_change;
+          ++proc.wake_stats.wake_change;
           break;
         case WakeCause::kContainer:
-          ++ps.wake_container;
+          ++proc.wake_stats.wake_container;
           break;
         case WakeCause::kDelay:
-          ++ps.wake_delay;
+          ++proc.wake_stats.wake_delay;
           break;
         case WakeCause::kInitial:
-          ++ps.wake_initial;
+          ++proc.wake_stats.wake_initial;
           break;
         default:
-          ++ps.wake_other;
+          ++proc.wake_stats.wake_other;
           break;
       }
     }
-    if (processes_[process_id].is_enqueued) {
+    if (proc.is_enqueued) {
       if (detailed_stats_enabled_) {
         ++stats_.detailed.wakeup_deduped;
-        ++per_process_stats_[process_id].wake_deduped;
+        ++proc.wake_stats.wake_deduped;
       }
       return;
     }
     next_delta_queue_.push_back({process_id, resume_block});
-    processes_[process_id].is_enqueued = true;
+    proc.is_enqueued = true;
     if (activation_trace_.has_value()) {
-      wake_trace_[process_id] = {.cause = cause, .trigger_slot = trigger_slot};
+      proc.wake_trace = {.cause = cause, .trigger_slot = trigger_slot};
     }
   }
 
@@ -1283,11 +1254,6 @@ class Engine {
 
   // Next-delta queue: events scheduled for the next delta cycle
   std::vector<WakeupEntry> next_delta_queue_;
-
-  // Per-process trace annotations (only populated when tracing enabled).
-  // Indexed by process_id. Safe because each process is enqueued at most
-  // once per delta (dedup guard prevents overwrite).
-  std::vector<WakeTraceInfo> wake_trace_;
 
   // NBA queue: deferred writes committed in ExecuteRegion(kNBA).
   // Generic fallback for global, masked, canonical-packed, container,
@@ -1609,10 +1575,6 @@ class Engine {
   // Execution-discipline counters (accumulated during Run).
   RuntimeStats stats_;
 
-  // Per-process wakeup/activation counters (opt-in, kDetailedStats).
-  // Indexed by process_id. Empty when detailed stats are disabled.
-  std::vector<ProcessWakeStats> per_process_stats_;
-
   // Static connection batch shape (populated once in InitConnectionBatch).
   uint32_t conn_full_slot_count_ = 0;
   uint32_t conn_narrow_count_ = 0;
@@ -1743,25 +1705,9 @@ class Engine {
       nullptr;
   uint32_t num_deferred_assertion_sites_ = 0;
 
-  struct DeferredAssertionRecord {
-    uint32_t enqueue_generation = 0;
-    uint32_t site_id = 0;
-    uint8_t disposition = 0;
-    RuntimeInstance* instance = nullptr;
-    uint32_t payload_size = 0;
-    SmallByteBuffer payload;
-    // ref_bindings[i] corresponds 1:1 to the ith kLiveRef entry in the
-    // site's realization actual_plan. Runtime preserves order and never
-    // interprets entries.
-    std::vector<DeferredAssertionRefBindingAbi> ref_bindings;
-  };
-  struct ProcessDeferredAssertionState {
-    uint32_t flush_generation = 0;
-    std::vector<DeferredAssertionRecord> pending;
-  };
-  std::vector<ProcessDeferredAssertionState> deferred_assertion_states_;
-  std::vector<uint8_t> deferred_pending_flags_;
-  std::vector<ProcessId> pending_deferred_processes_;
+  // Sparse list of processes with pending deferred assertion records.
+  // Dedup via RuntimeProcess::deferred_pending.
+  std::vector<RuntimeProcess*> pending_deferred_processes_;
 
   // Long-run observability: counter-gated periodic stdout flush.
   struct ObservabilityConfig {

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -886,7 +886,7 @@ class Engine {
   }
 
   // Post-activation reconciliation: engine-owned dispatch after process runs.
-  void ReconcilePostActivation(ProcessHandle handle);
+  void ReconcilePostActivation(RuntimeProcess& proc);
 
   // Inline fast path for static-wait reconciliation. Returns true if the
   // common case was handled (no work needed), false if the caller must
@@ -898,10 +898,11 @@ class Engine {
   //   3. No blocking writes dirtied any signal in the current delta
   // When these hold, subscription baselines are already correct from the
   // prior flush and no refresh or reinstall is needed.
-  [[nodiscard]] auto TryFastReconcile(uint32_t process_id) -> bool {
-    auto* suspend = processes_[process_id].suspend_record;
+  [[nodiscard]] auto TryFastReconcile(const RuntimeProcess& proc) const
+      -> bool {
+    const auto* suspend = proc.suspend_record;
     if (suspend->tag != SuspendTag::kWait) return false;
-    const auto& installed = processes_[process_id].installed_wait;
+    const auto& installed = proc.installed_wait;
     if (!installed.valid || installed.wait_site_id != suspend->wait_site_id ||
         !installed.can_refresh_snapshot) {
       return false;
@@ -924,7 +925,8 @@ class Engine {
   }
 
   // Format process identity for diagnostics (normal code path).
-  [[nodiscard]] auto FormatProcess(uint32_t process_id) const -> std::string;
+  [[nodiscard]] auto FormatProcess(const RuntimeProcess& proc) const
+      -> std::string;
 
   // Format decision owner identity for diagnostics.
   // First cut: delegates to FormatProcess (1:1 owner-to-process mapping).
@@ -941,7 +943,7 @@ class Engine {
   }
 
   // Handle a trap raised by generated code (loop budget exceeded, etc.).
-  void HandleTrap(uint32_t process_id, const TrapPayload& payload);
+  void HandleTrap(const RuntimeProcess& proc, const TrapPayload& payload);
 
   // Record a decision observation for an explicit owner.
   // Called from LyraRecordDecisionObservation (extern "C" ABI boundary).

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -805,8 +805,13 @@ class Engine {
   void TriggerInstanceEvent(RuntimeInstance& inst, uint32_t local_event_id) {
     auto waiters = inst.event_state.ConsumeWaiters(local_event_id);
     for (const auto& w : waiters) {
+      if (w.process == nullptr) {
+        throw common::InternalError(
+            "Engine::TriggerInstanceEvent",
+            "EventWaiter has null process pointer");
+      }
       EnqueueProcessWakeup(
-          w.process_id, w.resume_block, local_event_id, WakeCause::kEvent);
+          *w.process, w.resume_block, local_event_id, WakeCause::kEvent);
     }
   }
 
@@ -1197,7 +1202,13 @@ class Engine {
   void EnqueueProcessWakeup(
       uint32_t process_id, uint32_t resume_block, uint32_t trigger_slot,
       WakeCause cause) {
-    auto& proc = processes_[process_id];
+    EnqueueProcessWakeup(
+        processes_[process_id], resume_block, trigger_slot, cause);
+  }
+
+  void EnqueueProcessWakeup(
+      RuntimeProcess& proc, uint32_t resume_block, uint32_t trigger_slot,
+      WakeCause cause) {
     if (detailed_stats_enabled_) {
       ++stats_.detailed.wakeup_attempts;
       switch (cause) {

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -1016,7 +1016,7 @@ class Engine {
       const RuntimeProcess& proc, WaitSiteId wait_site_id) -> bool;
   [[nodiscard]] auto HasPendingDirtyState() const -> bool;
   void ResetInstalledWait(RuntimeProcess& proc);
-  void InstallTriggers(ProcessHandle handle, const WaitRequest& req);
+  void InstallTriggers(RuntimeProcess& proc, const WaitRequest& req);
   void InstallWaitSite(RuntimeProcess& proc, const WaitRequest& req);
   auto RefreshInstalledSnapshots(RuntimeProcess& proc) -> bool;
   void ClearInstalledSubscriptions(RuntimeProcess& proc);
@@ -1062,41 +1062,41 @@ class Engine {
   // R5: Domain-split subscribe helpers. Top boundary dispatches once
   // via std::visit on SignalRef, then routes to one of these.
   auto SubscribeGlobalEdge(
-      ProcessHandle handle, ResumePoint resume, GlobalSignalId signal,
+      RuntimeProcess& proc, ResumePoint resume, GlobalSignalId signal,
       common::EdgeKind edge, uint32_t byte_offset, uint32_t byte_size,
       uint8_t bit_index, bool initially_active) -> uint32_t;
   auto SubscribeLocalEdge(
-      ProcessHandle handle, ResumePoint resume, LocalSignalRef signal,
+      RuntimeProcess& proc, ResumePoint resume, LocalSignalRef signal,
       common::EdgeKind edge, uint32_t byte_offset, uint32_t byte_size,
       uint8_t bit_index, bool initially_active) -> uint32_t;
   auto SubscribeGlobalChange(
-      ProcessHandle handle, ResumePoint resume, GlobalSignalId signal,
+      RuntimeProcess& proc, ResumePoint resume, GlobalSignalId signal,
       uint32_t byte_offset, uint32_t byte_size, bool initially_active)
       -> uint32_t;
   auto SubscribeLocalChange(
-      ProcessHandle handle, ResumePoint resume, LocalSignalRef signal,
+      RuntimeProcess& proc, ResumePoint resume, LocalSignalRef signal,
       uint32_t byte_offset, uint32_t byte_size, bool initially_active)
       -> uint32_t;
   auto SubscribeGlobalContainerElement(
-      ProcessHandle handle, ResumePoint resume, GlobalSignalId signal,
+      RuntimeProcess& proc, ResumePoint resume, GlobalSignalId signal,
       common::EdgeKind edge, int64_t sv_index, uint32_t elem_stride,
       bool initially_active) -> uint32_t;
   auto SubscribeLocalContainerElement(
-      ProcessHandle handle, ResumePoint resume, LocalSignalRef signal,
+      RuntimeProcess& proc, ResumePoint resume, LocalSignalRef signal,
       common::EdgeKind edge, int64_t sv_index, uint32_t elem_stride,
       bool initially_active) -> uint32_t;
   void ValidateRebindDepSignals(std::span<const SignalRef> dep_signals) const;
   void InstallRebindDepWatchers(
-      ProcessHandle handle, uint32_t edge_target_id,
+      RuntimeProcess& proc, uint32_t edge_target_id,
       std::span<const SignalRef> dep_signals);
   void SubscribeGlobalRebind(
-      ProcessHandle handle, uint32_t edge_target_id,
+      RuntimeProcess& proc, uint32_t edge_target_id,
       GlobalSignalId target_signal, SubKind target_kind, uint32_t target_index,
       uint8_t target_edge_group, EdgeBucket target_edge_bucket,
       std::span<const IndexPlanOp> plan, BitTargetMapping mapping,
       std::span<const SignalRef> dep_signals);
   void SubscribeLocalRebind(
-      ProcessHandle handle, uint32_t edge_target_id,
+      RuntimeProcess& proc, uint32_t edge_target_id,
       LocalSignalRef target_signal, SubKind target_kind, uint32_t target_index,
       uint8_t target_edge_group, EdgeBucket target_edge_bucket,
       std::span<const IndexPlanOp> plan, BitTargetMapping mapping,

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -389,6 +389,9 @@ class Engine {
   void SetDesignStateBase(void* base) {
     design_state_base_ = base;
   }
+  [[nodiscard]] auto GetDesignStateBase() const -> void* {
+    return design_state_base_;
+  }
 
   // Set the instance list for slot storage resolution and observability.
   // Engine copies the pointers and owns the canonical mutable list.
@@ -1436,10 +1439,11 @@ class Engine {
   };
   std::vector<CombKernel> comb_kernels_;
 
-  // Canonical comb-kernel construction. Populates instance from the
-  // process frame header.
-  static auto BuildCombKernel(uint32_t proc_idx, void* frame, uint32_t flags)
-      -> CombKernel;
+  // Canonical comb-kernel construction. Sources body and instance from the
+  // owning RuntimeProcess; frame is the per-process state pointer.
+  static auto BuildCombKernel(
+      const RuntimeProcess& proc, uint32_t proc_idx, void* frame,
+      uint32_t flags) -> CombKernel;
 
   // Shared reactive trigger model: one backing array + one trigger map
   // feeds fixpoint re-evaluation for every reactive consumer kind that

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -218,14 +218,14 @@ class Engine {
   auto operator=(Engine&&) -> Engine& = delete;
 
   // Schedule a process to start at time 0 (for initial blocks).
-  void ScheduleInitial(ProcessHandle handle);
+  void ScheduleInitial(RuntimeProcess& proc);
 
   // Schedule a process to resume after a delay.
   // Called by interpreter/codegen when process hits a Delay terminator.
-  void Delay(ProcessHandle handle, ResumePoint resume, SimTime ticks);
+  void Delay(RuntimeProcess& proc, ResumePoint resume, SimTime ticks);
 
   // Schedule to inactive region (same time slot, #0 delay).
-  void DelayZero(ProcessHandle handle, ResumePoint resume);
+  void DelayZero(RuntimeProcess& proc, ResumePoint resume);
 
   // Subscribe to signal edge. Process resumes when signal changes.
   // R5: Subscribe with typed signal identity. Dispatches once at the top
@@ -259,7 +259,7 @@ class Engine {
 
   // Schedule process to resume in the next delta cycle (same time).
   // Used for kRepeat terminator.
-  void ScheduleNextDelta(ProcessHandle handle, ResumePoint resume);
+  void ScheduleNextDelta(RuntimeProcess& proc, ResumePoint resume);
 
   // Enqueue onto generic nba_queue_ for later commit in the NBA region.
   // Only for non-instance-owned targets (global, package, cross-instance).
@@ -454,6 +454,13 @@ class Engine {
           std::format("process {} has no owning instance", process_id));
     }
     return *inst;
+  }
+
+  // Resolve a RuntimeProcess by its dense process index. Mirrors
+  // GetProcessInstance for direct object access at boundaries that
+  // intrinsically iterate by integer (e.g. simulation init).
+  [[nodiscard]] auto GetProcess(uint32_t process_id) -> RuntimeProcess& {
+    return processes_[process_id];
   }
 
   // Validate that all kInstanceOwned slot-meta entries reference valid
@@ -1183,9 +1190,10 @@ class Engine {
   // enqueued. Shared by edge, change, and container flush paths.
   //
   // Fully inline: the hot path (already enqueued) is a single load + branch.
-  // The cold path (first enqueue) constructs an 8-byte WakeupEntry and
-  // pushes to the pre-reserved queue. Trace-only fields (cause, trigger_slot)
-  // are stored per-process only when activation tracing is enabled.
+  // The cold path (first enqueue) constructs a WakeupEntry carrying the
+  // process pointer directly and pushes to the pre-reserved queue. Trace-only
+  // fields (cause, trigger_slot) are stored per-process only when activation
+  // tracing is enabled.
   void EnqueueProcessWakeup(
       uint32_t process_id, uint32_t resume_block, uint32_t trigger_slot,
       WakeCause cause) {
@@ -1220,7 +1228,7 @@ class Engine {
       }
       return;
     }
-    next_delta_queue_.push_back({process_id, resume_block});
+    next_delta_queue_.push_back({&proc, resume_block});
     proc.is_enqueued = true;
     if (activation_trace_.has_value()) {
       proc.wake_trace = {.cause = cause, .trigger_slot = trigger_slot};

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -865,22 +865,21 @@ class Engine {
     return trace_selection_;
   }
 
-  // Register suspend record pointers for post-activation reconciliation.
-  void RegisterSuspendRecords(std::span<SuspendRecord*> records);
-
   // Bind each RuntimeProcess to its frame/state storage. Called once at
   // simulation setup, after process states are allocated and before any
   // process activation runs.
   void RegisterFrameStates(std::span<void*> states);
 
-  // Single source of truth for whether the engine uses post-activation
-  // reconciliation (new path) vs legacy HandleSuspendRecord (old path).
-  // True when both wait-site metadata and suspend records are registered.
-  [[nodiscard]] auto HasPostActivationReconciliation() const -> bool {
-    return wait_site_meta_.IsPopulated() && suspend_records_registered_;
+  // Whether the engine uses post-activation reconciliation for wait-lifecycle
+  // management. Currently always false: the reconcile path exists in the
+  // codebase but is not wired up for any caller. The envelope handles the
+  // wait lifecycle inline inside HandleProcessRequest.
+  [[nodiscard]] static auto HasPostActivationReconciliation() -> bool {
+    return false;
   }
 
   // Post-activation reconciliation: engine-owned dispatch after process runs.
+  // Currently dormant; retained for future activation.
   void ReconcilePostActivation(RuntimeProcess& proc);
 
   // Inline fast path for static-wait reconciliation. Returns true if the
@@ -893,9 +892,12 @@ class Engine {
   //   3. No blocking writes dirtied any signal in the current delta
   // When these hold, subscription baselines are already correct from the
   // prior flush and no refresh or reinstall is needed.
+  //
+  // Currently dormant with the reconcile path itself; retained for future
+  // activation.
   [[nodiscard]] auto TryFastReconcile(const RuntimeProcess& proc) const
       -> bool {
-    const auto* suspend = proc.suspend_record;
+    const auto* suspend = static_cast<const SuspendRecord*>(proc.frame_state);
     if (suspend->tag != SuspendTag::kWait) return false;
     const auto& installed = proc.installed_wait;
     if (!installed.valid || installed.wait_site_id != suspend->wait_site_id ||
@@ -1333,14 +1335,9 @@ class Engine {
   uint32_t cached_iteration_limit_ = 0;
   uint32_t* cached_iteration_limit_ptr_ = nullptr;
 
-  // Set by RegisterSuspendRecords when all process suspend records are
-  // registered. Used by HasPostActivationReconciliation() as a capability
-  // flag rather than probing individual process records.
-  bool suspend_records_registered_ = false;
-
   // Precomputed run-invariant: true when post-activation reconciliation
-  // path is active (both wait-site metadata and suspend records present).
-  // Set once at Run() entry from HasPostActivationReconciliation().
+  // path is active. Set once at Run() entry from
+  // HasPostActivationReconciliation(); currently always false.
   bool post_activation_reconcile_ = false;
 
   // R5: Number of design-global (non-instance-owned) slots. Set during

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -231,14 +231,14 @@ class Engine {
   // R5: Subscribe with typed signal identity. Dispatches once at the top
   // boundary, then routes to domain-specific helpers. No `is_local` below.
   auto Subscribe(
-      ProcessHandle handle, ResumePoint resume, SignalRef signal,
+      RuntimeProcess& proc, ResumePoint resume, SignalRef signal,
       common::EdgeKind edge, bool initially_active = true) -> uint32_t;
   auto Subscribe(
-      ProcessHandle handle, ResumePoint resume, SignalRef signal,
+      RuntimeProcess& proc, ResumePoint resume, SignalRef signal,
       common::EdgeKind edge, uint32_t byte_offset, uint32_t byte_size,
       uint8_t bit_index, bool initially_active = true) -> uint32_t;
   auto SubscribeContainerElement(
-      ProcessHandle handle, ResumePoint resume, SignalRef signal,
+      RuntimeProcess& proc, ResumePoint resume, SignalRef signal,
       common::EdgeKind edge, int64_t sv_index, uint32_t elem_stride,
       bool initially_active = true) -> uint32_t;
 
@@ -252,7 +252,7 @@ class Engine {
   // into instance observability. dep_slots values are global slot_ids or
   // local signal_ids matching the target's domain.
   void SubscribeRebind(
-      ProcessHandle handle, uint32_t edge_target_id, SignalRef target_signal,
+      RuntimeProcess& proc, uint32_t edge_target_id, SignalRef target_signal,
       SubKind target_kind, uint32_t target_index, uint8_t target_edge_group,
       EdgeBucket target_edge_bucket, std::span<const IndexPlanOp> plan,
       BitTargetMapping mapping, std::span<const SignalRef> dep_signals);

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -46,7 +46,6 @@
 #include "lyra/runtime/scheduler_snapshot.hpp"
 #include "lyra/runtime/signal_coord.hpp"
 #include "lyra/runtime/slot_meta.hpp"
-#include "lyra/runtime/small_byte_buffer.hpp"
 #include "lyra/runtime/trace_selection.hpp"
 #include "lyra/runtime/trace_signal_meta.hpp"
 #include "lyra/runtime/trap.hpp"
@@ -873,6 +872,11 @@ class Engine {
 
   // Register suspend record pointers for post-activation reconciliation.
   void RegisterSuspendRecords(std::span<SuspendRecord*> records);
+
+  // Bind each RuntimeProcess to its frame/state storage. Called once at
+  // simulation setup, after process states are allocated and before any
+  // process activation runs.
+  void RegisterFrameStates(std::span<void*> states);
 
   // Single source of truth for whether the engine uses post-activation
   // reconciliation (new path) vs legacy HandleSuspendRecord (old path).

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -1012,16 +1012,16 @@ class Engine {
   [[nodiscard]] auto UsesWaitSiteLifecycle() const -> bool {
     return wait_site_meta_.IsPopulated();
   }
-  [[nodiscard]] auto CanRefreshInstalledWait(
-      ProcessHandle handle, WaitSiteId wait_site_id) const -> bool;
+  [[nodiscard]] static auto CanRefreshInstalledWait(
+      const RuntimeProcess& proc, WaitSiteId wait_site_id) -> bool;
   [[nodiscard]] auto HasPendingDirtyState() const -> bool;
-  void ResetInstalledWait(ProcessHandle handle);
+  void ResetInstalledWait(RuntimeProcess& proc);
   void InstallTriggers(ProcessHandle handle, const WaitRequest& req);
-  void InstallWaitSite(ProcessHandle handle, const WaitRequest& req);
-  auto RefreshInstalledSnapshots(ProcessHandle handle) -> bool;
-  void ClearInstalledSubscriptions(ProcessHandle handle);
-  void InvalidateInstalledWait(ProcessHandle handle);
-  void ClearProcessSubscriptions(ProcessHandle handle);
+  void InstallWaitSite(RuntimeProcess& proc, const WaitRequest& req);
+  auto RefreshInstalledSnapshots(RuntimeProcess& proc) -> bool;
+  void ClearInstalledSubscriptions(RuntimeProcess& proc);
+  static void InvalidateInstalledWait(RuntimeProcess& proc);
+  void ClearProcessSubscriptions(RuntimeProcess& proc);
 
   // Typed cold pool management.
   auto AllocEdgeCold() -> uint32_t;

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -58,17 +58,6 @@ namespace lyra::runtime {
 
 class OutputDispatcher;
 
-// Explicit process dispatch ABI for the hot path.
-// fn is required (must not be nullptr). ctx is non-owning and must outlive
-// Engine::Run().
-using ProcessDispatchFn = void (*)(
-    void* ctx, Engine& engine, ProcessHandle handle, ResumePoint resume);
-
-struct ProcessDispatch {
-  ProcessDispatchFn fn = nullptr;
-  void* ctx = nullptr;
-};
-
 // Always-on summary counters: one increment per major event.
 struct CoreRuntimeStats {
   uint64_t total_activations = 0;
@@ -171,7 +160,7 @@ class InstanceIdResolver {
 };
 
 // Usage:
-// 1. Create engine with a ProcessDispatch callback
+// 1. Create engine
 // 2. Schedule initial processes with ScheduleInitial()
 // 3. Call Run() to execute until completion or time limit
 class Engine {
@@ -179,19 +168,13 @@ class Engine {
 
  public:
   explicit Engine(
-      ProcessDispatch process_dispatch, OutputDispatcher& output,
-      uint32_t num_processes = 0, std::span<const std::string> plusargs = {},
-      uint32_t feature_flags = 0)
-      : process_dispatch_(process_dispatch),
-        output_(output),
+      OutputDispatcher& output, uint32_t num_processes = 0,
+      std::span<const std::string> plusargs = {}, uint32_t feature_flags = 0)
+      : output_(output),
         num_processes_(num_processes),
         processes_(num_processes),
         plusargs_(plusargs.begin(), plusargs.end()),
         feature_flags_(feature_flags) {
-    if (process_dispatch_.fn == nullptr) {
-      throw common::InternalError(
-          "Engine::Engine", "process_dispatch.fn must not be null");
-    }
     // Pre-reserve wakeup queue to avoid reallocation during flush.
     // Each process can be enqueued at most once per delta (dedup by
     // is_enqueued), so num_processes is a tight upper bound.
@@ -1200,13 +1183,6 @@ class Engine {
   // fields (cause, trigger_slot) are stored per-process only when activation
   // tracing is enabled.
   void EnqueueProcessWakeup(
-      uint32_t process_id, uint32_t resume_block, uint32_t trigger_slot,
-      WakeCause cause) {
-    EnqueueProcessWakeup(
-        processes_[process_id], resume_block, trigger_slot, cause);
-  }
-
-  void EnqueueProcessWakeup(
       RuntimeProcess& proc, uint32_t resume_block, uint32_t trigger_slot,
       WakeCause cause) {
     if (detailed_stats_enabled_) {
@@ -1260,7 +1236,6 @@ class Engine {
   void ClearLocalUpdatesDelta();
   void ClearLocalUpdates();
 
-  ProcessDispatch process_dispatch_;
   OutputDispatcher& output_;  // Borrowed from RunSession
   uint32_t num_processes_ = 0;
   std::vector<RuntimeProcess> processes_;

--- a/include/lyra/runtime/engine_process_envelope_access.hpp
+++ b/include/lyra/runtime/engine_process_envelope_access.hpp
@@ -32,8 +32,8 @@ class ProcessEnvelopeAccess {
   }
 
   static void InstallTriggers(
-      Engine& engine, ProcessHandle handle, const WaitRequest& req) {
-    engine.InstallTriggers(handle, req);
+      Engine& engine, RuntimeProcess& proc, const WaitRequest& req) {
+    engine.InstallTriggers(proc, req);
   }
 
   static void InstallWaitSite(

--- a/include/lyra/runtime/engine_process_envelope_access.hpp
+++ b/include/lyra/runtime/engine_process_envelope_access.hpp
@@ -46,6 +46,11 @@ class ProcessEnvelopeAccess {
       -> bool {
     return engine.RefreshInstalledSnapshots(handle);
   }
+
+  static auto GetProcess(Engine& engine, ProcessHandle handle)
+      -> RuntimeProcess& {
+    return engine.processes_[handle.process_id];
+  }
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/engine_process_envelope_access.hpp
+++ b/include/lyra/runtime/engine_process_envelope_access.hpp
@@ -45,11 +45,6 @@ class ProcessEnvelopeAccess {
       -> bool {
     return engine.RefreshInstalledSnapshots(proc);
   }
-
-  static auto GetProcess(Engine& engine, ProcessHandle handle)
-      -> RuntimeProcess& {
-    return engine.processes_[handle.process_id];
-  }
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/engine_process_envelope_access.hpp
+++ b/include/lyra/runtime/engine_process_envelope_access.hpp
@@ -19,17 +19,16 @@ class ProcessEnvelopeAccess {
   }
 
   static auto CanRefreshInstalledWait(
-      const Engine& engine, ProcessHandle handle, WaitSiteId wait_site_id)
-      -> bool {
-    return engine.CanRefreshInstalledWait(handle, wait_site_id);
+      const RuntimeProcess& proc, WaitSiteId wait_site_id) -> bool {
+    return Engine::CanRefreshInstalledWait(proc, wait_site_id);
   }
 
   static auto HasPendingDirtyState(const Engine& engine) -> bool {
     return engine.HasPendingDirtyState();
   }
 
-  static void ResetInstalledWait(Engine& engine, ProcessHandle handle) {
-    engine.ResetInstalledWait(handle);
+  static void ResetInstalledWait(Engine& engine, RuntimeProcess& proc) {
+    engine.ResetInstalledWait(proc);
   }
 
   static void InstallTriggers(
@@ -38,13 +37,13 @@ class ProcessEnvelopeAccess {
   }
 
   static void InstallWaitSite(
-      Engine& engine, ProcessHandle handle, const WaitRequest& req) {
-    engine.InstallWaitSite(handle, req);
+      Engine& engine, RuntimeProcess& proc, const WaitRequest& req) {
+    engine.InstallWaitSite(proc, req);
   }
 
-  static auto RefreshInstalledSnapshots(Engine& engine, ProcessHandle handle)
+  static auto RefreshInstalledSnapshots(Engine& engine, RuntimeProcess& proc)
       -> bool {
-    return engine.RefreshInstalledSnapshots(handle);
+    return engine.RefreshInstalledSnapshots(proc);
   }
 
   static auto GetProcess(Engine& engine, ProcessHandle handle)

--- a/include/lyra/runtime/engine_scheduler.hpp
+++ b/include/lyra/runtime/engine_scheduler.hpp
@@ -22,25 +22,11 @@ enum class Region : uint8_t {
 
 // Hot queue entry for process wakeup (8 bytes). Contains only the fields
 // needed for dispatch. Trace-only fields (cause, trigger_slot) are stored
-// per-process in wake_trace_ when activation tracing is enabled.
+// per-process on RuntimeProcess::wake_trace when activation tracing is
+// enabled.
 struct WakeupEntry {
   uint32_t process_id;
   uint32_t resume_block;
-};
-
-// Trace-only wakeup annotation. Stored per-process (indexed by process_id),
-// populated at enqueue time only when activation tracing is enabled.
-//
-// Per-process storage is safe because each process has at most one pending
-// wake source at a time:
-//   - Delay/DelayZero/ScheduleNextDelta: called after ResetInstalledWait
-//     clears all subscriptions, so flush cannot race with EnqueueProcessWakeup.
-//   - EnqueueProcessWakeup: is_enqueued dedup prevents multiple writes
-//     per delta.
-//   - ScheduleInitial: one-time at startup, before any flush activity.
-struct WakeTraceInfo {
-  WakeCause cause = WakeCause::kDelay;
-  uint32_t trigger_slot = kNoTriggerSlot;
 };
 
 // Typed NBA payloads. Each mode has its own struct with exactly the fields

--- a/include/lyra/runtime/engine_scheduler.hpp
+++ b/include/lyra/runtime/engine_scheduler.hpp
@@ -11,6 +11,7 @@
 namespace lyra::runtime {
 
 struct RuntimeInstance;
+struct RuntimeProcess;
 
 // IEEE 1800 simulation regions (simplified).
 // Active -> Inactive -> NBA is the core loop for RTL simulation.
@@ -20,13 +21,13 @@ enum class Region : uint8_t {
   kNBA,       // Nonblocking assignment updates
 };
 
-// Hot queue entry for process wakeup (8 bytes). Contains only the fields
-// needed for dispatch. Trace-only fields (cause, trigger_slot) are stored
-// per-process on RuntimeProcess::wake_trace when activation tracing is
-// enabled.
+// Hot queue entry for process wakeup. Carries process identity directly as
+// a RuntimeProcess pointer; no integer indirection on the dispatch path.
+// Trace-only fields (cause, trigger_slot) are stored per-process on
+// RuntimeProcess::wake_trace when activation tracing is enabled.
 struct WakeupEntry {
-  uint32_t process_id;
-  uint32_t resume_block;
+  RuntimeProcess* process = nullptr;
+  uint32_t resume_block = 0;
 };
 
 // Typed NBA payloads. Each mode has its own struct with exactly the fields

--- a/include/lyra/runtime/engine_subscriptions.hpp
+++ b/include/lyra/runtime/engine_subscriptions.hpp
@@ -14,6 +14,7 @@
 namespace lyra::runtime {
 
 struct RuntimeInstance;
+struct RuntimeProcess;
 
 // Reference into a process's IndexPlanPool.
 struct IndexPlanRef {
@@ -173,13 +174,13 @@ struct ContainerCold {
   uint32_t last_rebind_epoch = 0;
 };
 
-// Dense hot-path record for edge wakeup (24B).
+// Dense hot-path record for edge wakeup.
 // Contains only process wakeup identity and cold-path linkage.
 // Observation-point state (byte_offset, bit_index, last_bit) is owned by
 // the enclosing EdgeWatchGroup. Polarity (posedge/negedge) is implicit in
 // which bucket the sub lives in.
 struct EdgeSub {
-  uint32_t process_id = 0;
+  RuntimeProcess* process = nullptr;
   uint32_t resume_block = 0;
   uint8_t flags = 0;  // kActive=0x01, kHasCold=0x02
   std::array<uint8_t, 3> padding = {};
@@ -187,7 +188,7 @@ struct EdgeSub {
       0;                  // index in owning local_sub_refs/global_sub_refs
   uint32_t cold_idx = 0;  // UINT32_MAX = no cold state (edge_cold_pool_)
 };
-static_assert(sizeof(EdgeSub) == 20);
+static_assert(sizeof(EdgeSub) == 24);
 
 // Observation-point group for edge subscriptions.
 // Groups all edge watchers on a slot that observe the same (byte_offset,
@@ -202,11 +203,11 @@ struct EdgeWatchGroup {
   std::vector<EdgeSub> negedge_subs;
 };
 
-// Dense record for kAnyChange subscribers (48B).
+// Dense record for kAnyChange subscribers.
 // Has a different hot path from edge detection -- splitting from EdgeSub
 // keeps the dominant clock-edge path smaller.
 struct ChangeSub {
-  uint32_t process_id = 0;
+  RuntimeProcess* process = nullptr;
   uint32_t resume_block = 0;
   uint32_t byte_offset = 0;
   uint32_t byte_size = 0;
@@ -221,22 +222,25 @@ struct ChangeSub {
   uint8_t flags = 0;  // kActive=0x01
   std::array<uint8_t, 3> padding{};
 };
-static_assert(sizeof(ChangeSub) == 44);
+static_assert(sizeof(ChangeSub) == 48);
 
-// Dense record for rebind watchers (pass 1 only) (24B).
+// Dense record for rebind watchers (pass 1 only).
 // Logically a different pass -- lives in its own dense array so
 // pass 2 never branches over them.
+//
+// process is read only on swap-and-pop backpatch during sub removal;
+// the flush hot path itself does not consume it.
 struct RebindWatcherSub {
-  uint32_t process_id = 0;
+  RuntimeProcess* process = nullptr;
   uint32_t byte_offset = 0;
   uint32_t byte_size = 0;
   uint32_t process_sub_idx = 0;
   uint32_t cold_idx = 0;  // always valid (watcher_cold_pool_)
   uint32_t flags = 0;     // kActive=0x01
 };
-static_assert(sizeof(RebindWatcherSub) == 24);
+static_assert(sizeof(RebindWatcherSub) == 32);
 
-// Dense record for container element subscriptions (24B).
+// Dense record for container element subscriptions.
 // Container subscriptions are rare and structurally different.
 //
 // Observation model: container subs observe bit 0 of byte 0 of the selected
@@ -245,7 +249,7 @@ static_assert(sizeof(RebindWatcherSub) == 24);
 // defined over the LSB of the element, matching the scalar edge semantics.
 // Multi-bit or multi-byte element observation is not supported.
 struct ContainerSub {
-  uint32_t process_id = 0;
+  RuntimeProcess* process = nullptr;
   uint32_t resume_block = 0;
   uint32_t process_sub_idx = 0;
   uint32_t cold_idx = 0;  // always valid (container_cold_pool_)
@@ -254,7 +258,7 @@ struct ContainerSub {
   uint8_t flags = 0;     // kActive=0x01
   uint8_t padding = 0;
 };
-static_assert(sizeof(ContainerSub) == 20);
+static_assert(sizeof(ContainerSub) == 24);
 
 // Flag constants for sub flags fields.
 inline constexpr uint8_t kSubActive = 0x01;

--- a/include/lyra/runtime/engine_types.hpp
+++ b/include/lyra/runtime/engine_types.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <functional>
 #include <limits>
 #include <variant>
 
@@ -18,20 +17,6 @@ using SimTime = uint64_t;
 // Constant representing unlimited simulation time.
 // Use as max_time argument to Run() for "run until natural completion".
 inline constexpr SimTime kNoTimeLimit = std::numeric_limits<SimTime>::max();
-
-// Unique identifier for a process activation.
-struct ProcessHandle {
-  uint32_t process_id = 0;
-
-  auto operator==(const ProcessHandle&) const -> bool = default;
-};
-
-// Hash function for ProcessHandle (for use in unordered containers).
-struct ProcessHandleHash {
-  auto operator()(const ProcessHandle& h) const noexcept -> size_t {
-    return std::hash<uint32_t>{}(h.process_id);
-  }
-};
 
 // Resume point within a process (block index + instruction index).
 // Allows processes to suspend and resume at arbitrary points.

--- a/include/lyra/runtime/instance_event_state.hpp
+++ b/include/lyra/runtime/instance_event_state.hpp
@@ -6,11 +6,12 @@
 namespace lyra::runtime {
 
 struct RuntimeInstance;
+struct RuntimeProcess;
 
 // Waiter record for a named event. Stored per-event-slot on the owning
 // instance. Consumed (moved out) when the event is triggered.
 struct EventWaiter {
-  uint32_t process_id = 0;
+  RuntimeProcess* process = nullptr;
   RuntimeInstance* instance = nullptr;
   uint32_t resume_block = 0;
 };

--- a/include/lyra/runtime/process_envelope.hpp
+++ b/include/lyra/runtime/process_envelope.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "lyra/runtime/engine_types.hpp"
 
 namespace lyra::runtime {
@@ -13,8 +15,11 @@ struct RuntimeProcess;
 // narrow engine scheduling primitives (Delay, InstallTriggers, HandleTrap,
 // etc.) to act on the result. All protocol details are confined to this
 // function's scope. The frame state and SuspendRecord are reached through
-// the process object's pre-bound back-pointers.
+// the process object's pre-bound back-pointers. The caller passes the
+// dense process id so the envelope can forward it to the body as the
+// decision-owner id.
 void DispatchAndHandleActivation(
-    Engine& engine, RuntimeProcess& proc, ResumePoint resume);
+    Engine& engine, RuntimeProcess& proc, uint32_t process_id,
+    ResumePoint resume);
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/process_envelope.hpp
+++ b/include/lyra/runtime/process_envelope.hpp
@@ -1,21 +1,20 @@
 #pragma once
 
-#include <span>
-
 #include "lyra/runtime/engine_types.hpp"
 
 namespace lyra::runtime {
 
 class Engine;
+struct RuntimeProcess;
 
 // Dispatch a process activation and handle the result.
 // Envelope-owned orchestration: resets SuspendRecord, invokes the process
 // body, decodes the raw suspend protocol into semantic requests, then calls
 // narrow engine scheduling primitives (Delay, InstallTriggers, HandleTrap,
-// etc.) to act on the result. All protocol details and borrowed spans are
-// confined to this function's scope.
+// etc.) to act on the result. All protocol details are confined to this
+// function's scope. The frame state and SuspendRecord are reached through
+// the process object's pre-bound back-pointers.
 void DispatchAndHandleActivation(
-    std::span<void*> states, Engine& engine, ProcessHandle handle,
-    ResumePoint resume);
+    Engine& engine, RuntimeProcess& proc, ResumePoint resume);
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/process_frame.hpp
+++ b/include/lyra/runtime/process_frame.hpp
@@ -10,86 +10,49 @@ namespace lyra::runtime {
 
 struct RuntimeInstance;
 
-// 2-arg shared body function signature (frame, resume).
-// Instance binding lives in the process frame header, not in the call
-// surface. This is the long-term call contract.
-using SharedBodyFn = void (*)(void*, uint32_t);
+// Simulation-process body ABI. Invoked by the envelope on every activation.
+//
+// Parameters:
+//   state             - per-process state pointer (ProcessState*); the first
+//                       field is a ProcessFrameHeader whose SuspendRecord
+//                       prefix is the suspend protocol state and whose
+//                       ProcessOutcome slot is written before return.
+//   resume_block      - resume target index
+//   engine            - opaque Engine* for runtime helper calls
+//   design            - design state base pointer
+//   instance          - RuntimeInstance* execution anchor for this process
+//   decision_owner_id - dense owner id for decision observation helpers
+using SharedBodyFn = void (*)(
+    void* state, uint32_t resume_block, void* engine, void* design,
+    RuntimeInstance* instance, uint32_t decision_owner_id);
 
-// Canonical process frame header layout.
+// Minimal process frame prefix. The backing object passed to every compiled
+// body begins with this prefix; everything else in per-process runtime state
+// lives on RuntimeProcess.
+//
+//   suspend - SuspendRecord at offset 0 (suspend protocol backing)
+//   outcome - ProcessOutcome slot written by the body on every call
 //
 // Binary contract between codegen (BuildHeaderType in layout.cpp) and
-// runtime (simulation.cpp, engine_scheduler_fixpoint.cpp). Both sides
-// must agree on field order and size. Hard assertions below enforce this.
-//
-// The header is the runtime-owned binding anchor for a realized process.
-//
-// Ownership domains:
-//   Init-process headers are codegen-private ephemeral stack objects.
-//   Codegen allocates, populates (including design_ptr), and passes them
-//   to LyraRunProcessSync. They are not part of persistent runtime state.
-//
-//   Simulation-process headers are runtime-owned persistent state.
-//   Runtime is the sole initializer of all binding fields:
-//     design_ptr: cached binding derived from ABI design_state (source of
-//       truth). Written by runtime before simulation dispatch.
-//     engine_ptr: written by runtime before simulation dispatch.
-//     body: written by runtime from constructor data.
-//     instance: RuntimeInstance* execution anchor, written by runtime from
-//       constructor data. Null for connection/init processes.
-//     outcome: live per-call state, written by shared body on every call.
-//
-// After init, no field is written by codegen. The descriptor table is
-// consumed only at init time to populate these fields. All dispatch
-// paths (process and comb) read from the header, not from descriptors.
-//
-// For standalone (connection/init) processes, the instance field is null.
-// Standalone processes use the 3-arg LyraProcessFunc path and do not
-// dispatch through shared bodies.
+// runtime (process_envelope.cpp). Both sides must agree on field order
+// and size. Hard assertions below enforce this.
 struct ProcessFrameHeader {
   SuspendRecord suspend;
-  SharedBodyFn body = nullptr;
-  void* engine_ptr = nullptr;
-  void* design_ptr = nullptr;
-  RuntimeInstance* instance = nullptr;
   ProcessOutcome outcome = {};
-  // Runtime-assigned process identity. Set during constructor realization.
-  // Used by generated code (decision observation recording, etc.) to
-  // identify the process without ambient engine state.
-  uint32_t process_id = 0;
 };
 
 // Strongly typed field indices matching the LLVM struct type emitted by
-// BuildHeaderType. Used by codegen GEP indices and runtime offsetof
-// checks. This is the single canonical source of field ordering.
+// BuildHeaderType. Used by codegen GEP indices and runtime offsetof checks.
 enum class ProcessFrameHeaderField : unsigned {
   kSuspend = 0,
-  kBody = 1,
-  kEnginePtr = 2,
-  kDesignPtr = 3,
-  kInstance = 4,
-  kOutcome = 5,
-  kProcessId = 6,
-  kFieldCount = 7,
+  kOutcome = 1,
+  kFieldCount = 2,
 };
 
 // Hard binary contract assertions. If the struct layout changes, these
 // fail at compile time rather than manifesting as runtime SIGILL in
 // AOT binaries.
-static_assert(offsetof(ProcessFrameHeader, body) == sizeof(SuspendRecord));
-static_assert(
-    offsetof(ProcessFrameHeader, engine_ptr) ==
-    offsetof(ProcessFrameHeader, body) + sizeof(SharedBodyFn));
-static_assert(
-    offsetof(ProcessFrameHeader, design_ptr) ==
-    offsetof(ProcessFrameHeader, engine_ptr) + sizeof(void*));
-static_assert(
-    offsetof(ProcessFrameHeader, instance) ==
-    offsetof(ProcessFrameHeader, design_ptr) + sizeof(void*));
-static_assert(
-    offsetof(ProcessFrameHeader, outcome) ==
-    offsetof(ProcessFrameHeader, instance) + sizeof(RuntimeInstance*));
-static_assert(
-    offsetof(ProcessFrameHeader, process_id) ==
-    offsetof(ProcessFrameHeader, outcome) + sizeof(ProcessOutcome));
+static_assert(offsetof(ProcessFrameHeader, suspend) == 0);
+static_assert(offsetof(ProcessFrameHeader, outcome) == sizeof(SuspendRecord));
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_process.hpp
+++ b/include/lyra/runtime/runtime_process.hpp
@@ -11,8 +11,6 @@
 
 namespace lyra::runtime {
 
-struct SuspendRecord;
-
 // Trace-only wakeup annotation. Populated at enqueue time only when
 // activation tracing is enabled.
 //
@@ -77,7 +75,6 @@ struct RuntimeProcess {
   RuntimeInstance* instance = nullptr;
 
   bool is_enqueued = false;
-  SuspendRecord* suspend_record = nullptr;
   bool is_comb_kernel = false;
 
   size_t subscription_count = 0;
@@ -101,9 +98,8 @@ struct RuntimeProcess {
 
   // Back-pointer to this process's frame/state storage. Written once during
   // engine setup (Engine::RegisterFrameStates) and never mutated afterward.
-  // Lets runtime code that already holds a RuntimeProcess reach frame-backed
-  // state without going through process-id indexing or frame-header
-  // round-trips.
+  // The backing object begins with a SuspendRecord and is the single
+  // runtime source of suspend state for this process.
   void* frame_state = nullptr;
 };
 

--- a/include/lyra/runtime/runtime_process.hpp
+++ b/include/lyra/runtime/runtime_process.hpp
@@ -98,6 +98,13 @@ struct RuntimeProcess {
 
   // Dedup flag indicating this process is in pending_deferred_processes_.
   bool deferred_pending = false;
+
+  // Back-pointer to this process's frame/state storage. Written once during
+  // engine setup (Engine::RegisterFrameStates) and never mutated afterward.
+  // Lets runtime code that already holds a RuntimeProcess reach frame-backed
+  // state without going through process-id indexing or frame-header
+  // round-trips.
+  void* frame_state = nullptr;
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_process.hpp
+++ b/include/lyra/runtime/runtime_process.hpp
@@ -7,6 +7,7 @@
 #include "lyra/common/deferred_assertion_abi.hpp"
 #include "lyra/runtime/activation_trace.hpp"
 #include "lyra/runtime/engine_subscriptions.hpp"
+#include "lyra/runtime/process_frame.hpp"
 #include "lyra/runtime/small_byte_buffer.hpp"
 
 namespace lyra::runtime {
@@ -73,6 +74,11 @@ struct ProcessDeferredAssertionState {
 // in Engine::processes_.
 struct RuntimeProcess {
   RuntimeInstance* instance = nullptr;
+
+  // Compiled body function for this process. Written once during constructor
+  // realization and never mutated afterward. Null for standalone connection
+  // and init processes (which dispatch through LyraRunProcessSync instead).
+  SharedBodyFn body = nullptr;
 
   bool is_enqueued = false;
   bool is_comb_kernel = false;

--- a/include/lyra/runtime/runtime_process.hpp
+++ b/include/lyra/runtime/runtime_process.hpp
@@ -1,13 +1,74 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
+#include "lyra/common/deferred_assertion_abi.hpp"
+#include "lyra/runtime/activation_trace.hpp"
 #include "lyra/runtime/engine_subscriptions.hpp"
+#include "lyra/runtime/small_byte_buffer.hpp"
 
 namespace lyra::runtime {
 
 struct SuspendRecord;
+
+// Trace-only wakeup annotation. Populated at enqueue time only when
+// activation tracing is enabled.
+//
+// Per-process storage is safe because each process has at most one pending
+// wake source at a time:
+//   - Delay/DelayZero/ScheduleNextDelta: called after ResetInstalledWait
+//     clears all subscriptions, so flush cannot race with EnqueueProcessWakeup.
+//   - EnqueueProcessWakeup: is_enqueued dedup prevents multiple writes
+//     per delta.
+//   - ScheduleInitial: one-time at startup, before any flush activity.
+struct WakeTraceInfo {
+  WakeCause cause = WakeCause::kDelay;
+  uint32_t trigger_slot = kNoTriggerSlot;
+};
+
+// Per-process wakeup/activation counters. Collected when kDetailedStats is
+// enabled. Allows post-simulation analysis of which processes are hot,
+// what wakes them, and what kind of work each activation does.
+struct ProcessWakeStats {
+  // Wake attempts by cause (includes deduped).
+  uint64_t wake_edge = 0;
+  uint64_t wake_change = 0;
+  uint64_t wake_container = 0;
+  uint64_t wake_delay = 0;
+  uint64_t wake_initial = 0;
+  uint64_t wake_other = 0;
+  // Deduped wake attempts (process already enqueued).
+  uint64_t wake_deduped = 0;
+  // Actual activations (process body executed).
+  uint64_t runs = 0;
+  // Total distinct slots dirtied (direct MarkSlotDirty) across all runs.
+  uint64_t total_slots_dirtied = 0;
+  // Activations with no direct dirty marks. These are typically always_ff
+  // processes that write only via NBA (nonblocking assignment). NOT a
+  // wasted-wakeup indicator: always_ff processes legitimately schedule
+  // NBAs without calling MarkSlotDirty during their body.
+  uint64_t nba_only_runs = 0;
+};
+
+struct DeferredAssertionRecord {
+  uint32_t enqueue_generation = 0;
+  uint32_t site_id = 0;
+  uint8_t disposition = 0;
+  RuntimeInstance* instance = nullptr;
+  uint32_t payload_size = 0;
+  SmallByteBuffer payload;
+  // ref_bindings[i] corresponds 1:1 to the ith kLiveRef entry in the
+  // site's realization actual_plan. Runtime preserves order and never
+  // interprets entries.
+  std::vector<DeferredAssertionRefBindingAbi> ref_bindings;
+};
+
+struct ProcessDeferredAssertionState {
+  uint32_t flush_generation = 0;
+  std::vector<DeferredAssertionRecord> pending;
+};
 
 // First-class runtime process object.
 // Single owner of all per-process runtime state. Indexed by process_id
@@ -24,6 +85,19 @@ struct RuntimeProcess {
   std::vector<GlobalSubRef> global_sub_refs;
   IndexPlanPool plan_pool;
   InstalledWaitState installed_wait;
+
+  // Trace-only annotation set when an activation enters a queue. Mutated
+  // only when activation tracing is enabled.
+  WakeTraceInfo wake_trace{};
+
+  // Wake/activation counters mutated only when kDetailedStats is enabled.
+  ProcessWakeStats wake_stats{};
+
+  // Pending deferred immediate assertion records produced by this process.
+  ProcessDeferredAssertionState deferred_assertion_state{};
+
+  // Dedup flag indicating this process is in pending_deferred_processes_.
+  bool deferred_pending = false;
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/simulation.hpp
+++ b/include/lyra/runtime/simulation.hpp
@@ -29,21 +29,23 @@ struct ProcessOutcome {
 }  // namespace lyra::runtime
 
 // Process function signature for LLVM-generated code.
-// - state: pointer to ProcessState (contains SuspendRecord at offset 0, then
-// slots)
+// - state: pointer to ProcessState (SuspendRecord at offset 0, then frame)
 // - resume_block: which basic block to start execution from
+// - design_state: design state base pointer (for design-global slot access)
 // - out: caller-owned buffer for the process outcome
 // Pointer-out ABI: callee writes exactly one valid ProcessOutcome before
 // returning. No struct return across JIT boundary, no TLS, no longjmp.
 using LyraProcessFunc = void (*)(
-    void* state, uint32_t resume_block, lyra::runtime::ProcessOutcome* out);
+    void* state, uint32_t resume_block, void* design_state,
+    lyra::runtime::ProcessOutcome* out);
 
 extern "C" {
 
 // Run a process synchronously to completion (for init processes).
 // The process must not suspend; if it does, this aborts.
 // Encapsulates the entry block number (ABI detail).
-void LyraRunProcessSync(LyraProcessFunc process, void* state);
+void LyraRunProcessSync(
+    LyraProcessFunc process, void* state, void* design_state);
 
 // Run simulation with multiple processes sharing a single engine.
 // All processes are scheduled at time=0, delta=0.

--- a/src/lyra/llvm_backend/context.cpp
+++ b/src/lyra/llvm_backend/context.cpp
@@ -563,44 +563,6 @@ void Context::SetSpecSlotInfo(const SpecSlotInfo* info) {
   spec_slot_info_ = info;
 }
 
-// Low-level header-field GEP. Returns a pointer to the specified field
-// within the process frame header. This is the only place in codegen that
-// knows how to navigate from process state to header field address.
-auto EmitHeaderFieldGep(
-    Context& ctx, llvm::Value* state_arg,
-    lyra::runtime::ProcessFrameHeaderField field, llvm::StringRef name)
-    -> llvm::Value* {
-  auto& builder = ctx.GetBuilder();
-  auto* header_ptr = builder.CreateStructGEP(
-      ctx.GetProcessStateType(), state_arg, 0, "header_ptr");
-  return builder.CreateStructGEP(
-      ctx.GetHeaderType(), header_ptr, static_cast<unsigned>(field), name);
-}
-
-auto Context::EmitLoadEnginePtr(llvm::Value* state_arg) -> llvm::Value* {
-  using F = lyra::runtime::ProcessFrameHeaderField;
-  auto* ptr =
-      EmitHeaderFieldGep(*this, state_arg, F::kEnginePtr, "engine_ptr_ptr");
-  return builder_.CreateLoad(
-      llvm::PointerType::getUnqual(*llvm_context_), ptr, "engine_ptr");
-}
-
-auto Context::EmitLoadDesignPtr(llvm::Value* state_arg) -> llvm::Value* {
-  using F = lyra::runtime::ProcessFrameHeaderField;
-  auto* ptr =
-      EmitHeaderFieldGep(*this, state_arg, F::kDesignPtr, "design_ptr_ptr");
-  return builder_.CreateLoad(
-      llvm::PointerType::getUnqual(*llvm_context_), ptr, "design_ptr");
-}
-
-auto Context::EmitLoadInstancePtr(llvm::Value* state_arg) -> llvm::Value* {
-  using F = lyra::runtime::ProcessFrameHeaderField;
-  auto* ptr =
-      EmitHeaderFieldGep(*this, state_arg, F::kInstance, "instance_ptr_ptr");
-  return builder_.CreateLoad(
-      llvm::PointerType::getUnqual(*llvm_context_), ptr, "instance_ptr");
-}
-
 auto Context::EmitLoadInstanceInlineBase(llvm::Value* instance_ptr)
     -> llvm::Value* {
   using IF = lyra::runtime::RuntimeInstanceField;
@@ -616,43 +578,41 @@ auto Context::EmitLoadInstanceInlineBase(llvm::Value* instance_ptr)
       "inline_base");
 }
 
-void Context::EmitStoreDesignPtr(llvm::Value* state_arg, llvm::Value* value) {
-  using F = lyra::runtime::ProcessFrameHeaderField;
-  auto* ptr =
-      EmitHeaderFieldGep(*this, state_arg, F::kDesignPtr, "design_ptr_ptr");
-  builder_.CreateStore(value, ptr);
-}
-
 auto Context::EmitOutcomePtr(llvm::Value* state_arg) -> llvm::Value* {
   using F = lyra::runtime::ProcessFrameHeaderField;
-  return EmitHeaderFieldGep(*this, state_arg, F::kOutcome, "outcome_ptr");
+  auto& builder = GetBuilder();
+  auto* header_ptr = builder.CreateStructGEP(
+      GetProcessStateType(), state_arg, 0, "header_ptr");
+  return builder.CreateStructGEP(
+      GetHeaderType(), header_ptr, static_cast<unsigned>(F::kOutcome),
+      "outcome_ptr");
 }
 
-auto Context::EmitLoadDecisionOwnerId(llvm::Value* state_arg) -> llvm::Value* {
-  using F = lyra::runtime::ProcessFrameHeaderField;
-  // The process frame header field stays process-named (kProcessId); the
-  // codegen layer interprets it as the decision owner for process-backed paths.
-  auto* ptr =
-      EmitHeaderFieldGep(*this, state_arg, F::kProcessId, "decision_owner_ptr");
-  return builder_.CreateLoad(
-      llvm::Type::getInt32Ty(*llvm_context_), ptr, "decision_owner_id");
-}
-
-void Context::EmitProcessStateSetup(llvm::Value* state_arg) {
+void Context::EmitProcessStateSetup(
+    llvm::Value* state_arg, llvm::Value* engine_arg, llvm::Value* design_arg,
+    llvm::Value* decision_owner_id_arg) {
   SetStatePointer(state_arg);
-  SetEnginePointer(EmitLoadEnginePtr(state_arg));
-  SetDesignPointer(EmitLoadDesignPtr(state_arg));
-  SetCurrentDecisionOwnerId(EmitLoadDecisionOwnerId(state_arg));
+  SetEnginePointer(engine_arg);
+  SetDesignPointer(design_arg);
+  SetCurrentDecisionOwnerId(decision_owner_id_arg);
 
   auto* frame_ptr = builder_.CreateStructGEP(
       GetProcessStateType(), state_arg, 1, "frame_ptr");
   SetFramePointer(frame_ptr);
 }
 
-void Context::EmitSharedBodyBindingSetup(llvm::Value* state_arg) {
-  auto* inst = EmitLoadInstancePtr(state_arg);
-  SetInstancePointer(inst);
-  SetThisPointer(EmitLoadInstanceInlineBase(inst));
+void Context::EmitSharedBodyBindingSetup(llvm::Value* instance_arg) {
+  SetInstancePointer(instance_arg);
+  SetThisPointer(EmitLoadInstanceInlineBase(instance_arg));
+}
+
+void Context::EmitInitProcessStateSetup(
+    llvm::Value* state_arg, llvm::Value* design_arg) {
+  SetStatePointer(state_arg);
+  SetDesignPointer(design_arg);
+  auto* frame_ptr = builder_.CreateStructGEP(
+      GetProcessStateType(), state_arg, 1, "frame_ptr");
+  SetFramePointer(frame_ptr);
 }
 
 void Context::SetStatePointer(llvm::Value* state_ptr) {

--- a/src/lyra/llvm_backend/context_runtime.cpp
+++ b/src/lyra/llvm_backend/context_runtime.cpp
@@ -386,10 +386,10 @@ auto Context::GetLyraDestroyProcessStates() -> llvm::Function* {
 
 auto Context::GetLyraRunProcessSync() -> llvm::Function* {
   if (lyra_run_process_sync_ == nullptr) {
-    // void LyraRunProcessSync(ptr process, ptr state)
+    // void LyraRunProcessSync(ptr process, ptr state, ptr design)
     auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
     auto* fn_type = llvm::FunctionType::get(
-        llvm::Type::getVoidTy(*llvm_context_), {ptr_ty, ptr_ty}, false);
+        llvm::Type::getVoidTy(*llvm_context_), {ptr_ty, ptr_ty, ptr_ty}, false);
     lyra_run_process_sync_ = llvm::Function::Create(
         fn_type, llvm::Function::ExternalLinkage, "LyraRunProcessSync",
         llvm_module_.get());

--- a/src/lyra/llvm_backend/emit_design_main.cpp
+++ b/src/lyra/llvm_backend/emit_design_main.cpp
@@ -113,7 +113,7 @@ void InitializeProcessState(
   bool force_two_state = facts.force_two_state;
 
   EmitMemsetZero(context, process_state, state_type);
-  context.EmitStoreDesignPtr(process_state, design_state);
+  (void)design_state;
 
   if (force_two_state) return;
 
@@ -247,7 +247,8 @@ void EmitInitProcesses(
         context, facts, process_state, design_state, proc_layout);
 
     builder.CreateCall(
-        context.GetLyraRunProcessSync(), {process_funcs[i], process_state});
+        context.GetLyraRunProcessSync(),
+        {process_funcs[i], process_state, design_state});
   }
 }
 

--- a/src/lyra/llvm_backend/instruction/decision.cpp
+++ b/src/lyra/llvm_backend/instruction/decision.cpp
@@ -15,7 +15,7 @@
 namespace lyra::lowering::mir_to_llvm {
 
 auto LowerRecordDecisionObservation(
-    Context& ctx, const CuFacts& facts, llvm::Value* decision_owner_id,
+    Context& ctx, llvm::Value* decision_owner_id,
     const mir::RecordDecisionObservation& obs) -> Result<void> {
   if (decision_owner_id == nullptr) {
     throw common::InternalError(

--- a/src/lyra/llvm_backend/instruction/effect.cpp
+++ b/src/lyra/llvm_backend/instruction/effect.cpp
@@ -613,7 +613,7 @@ auto LowerEffectOp(
                       UnsupportedCategory::kFeature));
             }
             return LowerRecordDecisionObservation(
-                context, facts, mode.decision_owner_id, obs);
+                context, mode.decision_owner_id, obs);
           },
           [&](const mir::RecordDecisionObservationDynamic& obs)
               -> Result<void> {

--- a/src/lyra/llvm_backend/layout/layout.cpp
+++ b/src/lyra/llvm_backend/layout/layout.cpp
@@ -941,20 +941,18 @@ auto BuildSuspendRecordType(llvm::LLVMContext& ctx) -> llvm::StructType* {
   return llvm::StructType::create(ctx, {payload}, "SuspendRecord");
 }
 
-// Build ProcessStateHeader with realized instance binding.
+// Build ProcessStateHeader as the minimal {suspend, outcome} prefix.
 // Field order and count must match ProcessFrameHeader and
 // ProcessFrameHeaderField in process_frame.hpp.
 auto BuildHeaderType(llvm::LLVMContext& ctx, llvm::StructType* suspend_type)
     -> llvm::StructType* {
-  auto* ptr_ty = llvm::PointerType::getUnqual(ctx);
   auto* i32_ty = llvm::Type::getInt32Ty(ctx);
   auto* outcome_ty =
       llvm::StructType::get(ctx, {i32_ty, i32_ty, i32_ty, i32_ty});
-  // { suspend, body, engine_ptr, design_ptr, instance, outcome, process_id }
+  // { suspend, outcome }
   using F = lyra::runtime::ProcessFrameHeaderField;
   constexpr auto kFieldCount = static_cast<size_t>(F::kFieldCount);
-  std::array<llvm::Type*, kFieldCount> fields = {
-      suspend_type, ptr_ty, ptr_ty, ptr_ty, ptr_ty, outcome_ty, i32_ty};
+  std::array<llvm::Type*, kFieldCount> fields = {suspend_type, outcome_ty};
   return llvm::StructType::create(ctx, fields, "ProcessStateHeader");
 }
 

--- a/src/lyra/llvm_backend/process.cpp
+++ b/src/lyra/llvm_backend/process.cpp
@@ -1814,12 +1814,18 @@ auto GenerateProcessFunction(
   auto& llvm_ctx = context.GetLlvmContext();
   auto& module = context.GetModule();
 
-  // Create function type: void(ptr %state, i32 %resume_block, ptr %out)
+  // Function type:
+  //   init:       void(ptr state, i32 resume_block, ptr design, ptr out)
+  //   simulation: void(ptr state, i32 resume_block, ptr design, ptr out)
+  //               standalone simulation bodies also take the design arg;
+  //               engine/instance/decision-owner are not threaded here --
+  //               standalone simulation is limited to connection/init-style
+  //               code that does not need them.
   auto* ptr_ty = llvm::PointerType::getUnqual(llvm_ctx);
   auto* i32_ty = llvm::Type::getInt32Ty(llvm_ctx);
   auto* void_ty = llvm::Type::getVoidTy(llvm_ctx);
   auto* fn_type =
-      llvm::FunctionType::get(void_ty, {ptr_ty, i32_ty, ptr_ty}, false);
+      llvm::FunctionType::get(void_ty, {ptr_ty, i32_ty, ptr_ty, ptr_ty}, false);
 
   auto* func = llvm::Function::Create(
       fn_type, llvm::Function::InternalLinkage, name, &module);
@@ -1827,9 +1833,11 @@ auto GenerateProcessFunction(
   // Name the arguments
   auto* state_arg = func->getArg(0);
   auto* resume_block_arg = func->getArg(1);
-  auto* out_arg = func->getArg(2);
+  auto* design_arg = func->getArg(2);
+  auto* out_arg = func->getArg(3);
   state_arg->setName("state");
   resume_block_arg->setName("resume_block");
+  design_arg->setName("design");
   out_arg->setName("out");
 
   // Create blocks
@@ -1853,17 +1861,10 @@ auto GenerateProcessFunction(
   // Entry block: set up cached pointers and dispatch
   builder.SetInsertPoint(entry_block);
 
-  if (is_simulation) {
-    // Simulation contract: load all state pointers including engine.
-    context.EmitProcessStateSetup(state_arg);
-  } else {
-    // Init contract: load design_ptr and frame_ptr only. No engine.
-    context.SetStatePointer(state_arg);
-    context.SetDesignPointer(context.EmitLoadDesignPtr(state_arg));
-    auto* frame_ptr = builder.CreateStructGEP(
-        context.GetProcessStateType(), state_arg, 1, "frame_ptr");
-    context.SetFramePointer(frame_ptr);
-  }
+  // Init-kind and legacy standalone-simulation bodies alike: bind state and
+  // design only. Engine/instance/decision-owner remain null; code that
+  // would need them is not emitted on these paths.
+  context.EmitInitProcessStateSetup(state_arg, design_arg);
 
   // Process bodies always have an active decision owner.
   ActiveExecutionMode exec_mode{
@@ -2038,18 +2039,31 @@ auto GenerateSharedProcessFunction(
   auto& llvm_ctx = context.GetLlvmContext();
   auto& module = context.GetModule();
 
-  // Shared body call contract: void(ptr frame, i32 resume).
-  // Instance binding is loaded from the frame header at entry.
+  // Shared simulation body ABI: runtime bindings travel as explicit
+  // function arguments, never loaded from the backing object.
+  //   void(ptr state, i32 resume_block, ptr engine, ptr design,
+  //        ptr instance, i32 decision_owner_id)
   auto* ptr_ty = llvm::PointerType::getUnqual(llvm_ctx);
   auto* i32_ty = llvm::Type::getInt32Ty(llvm_ctx);
   auto* void_ty = llvm::Type::getVoidTy(llvm_ctx);
-  auto* fn_type = llvm::FunctionType::get(void_ty, {ptr_ty, i32_ty}, false);
+  auto* fn_type = llvm::FunctionType::get(
+      void_ty, {ptr_ty, i32_ty, ptr_ty, ptr_ty, ptr_ty, i32_ty}, false);
 
   auto* func = llvm::Function::Create(
       fn_type, llvm::Function::InternalLinkage, name, &module);
 
-  func->getArg(0)->setName("frame");
-  func->getArg(1)->setName("resume_block");
+  auto* state_arg = func->getArg(0);
+  auto* resume_block_arg = func->getArg(1);
+  auto* engine_arg = func->getArg(2);
+  auto* design_arg = func->getArg(3);
+  auto* instance_arg = func->getArg(4);
+  auto* decision_owner_id_arg = func->getArg(5);
+  state_arg->setName("state");
+  resume_block_arg->setName("resume_block");
+  engine_arg->setName("engine");
+  design_arg->setName("design");
+  instance_arg->setName("instance");
+  decision_owner_id_arg->setName("decision_owner_id");
 
   auto* entry_block = llvm::BasicBlock::Create(llvm_ctx, "entry", func);
   auto* exit_block = llvm::BasicBlock::Create(llvm_ctx, "exit", func);
@@ -2064,7 +2078,8 @@ auto GenerateSharedProcessFunction(
   auto& builder = context.GetBuilder();
   builder.SetInsertPoint(entry_block);
 
-  context.EmitProcessStateSetup(func->getArg(0));
+  context.EmitProcessStateSetup(
+      state_arg, engine_arg, design_arg, decision_owner_id_arg);
   ActiveExecutionMode exec_mode{
       .decision_owner_id = context.GetCurrentDecisionOwnerId()};
 
@@ -2075,12 +2090,10 @@ auto GenerateSharedProcessFunction(
     return std::unexpected(shared_alloca_result.error());
   }
 
-  // Load realized instance binding from the frame header.
-  // Module slots accessed via this_ptr + spec_slot_layout (stable offsets
-  // are compile-time constants; unstable offsets loaded from header).
-  // Signal coordination via typed identity (local signals are body-local).
+  // Instance binding comes directly from the function argument; module
+  // slots are accessed via this_ptr + spec_slot_layout.
   context.SetSlotAddressingMode(SlotAddressingMode::kSpecializationLocal);
-  context.EmitSharedBodyBindingSetup(func->getArg(0));
+  context.EmitSharedBodyBindingSetup(instance_arg);
 
   // Create activation-local managed slot storage.
   // Must be after slot addressing setup (this_ptr, instance binding).

--- a/src/lyra/llvm_backend/spec_session.cpp
+++ b/src/lyra/llvm_backend/spec_session.cpp
@@ -58,8 +58,7 @@ auto CaptureDeferredCalleeInfoForBody(
 
 auto CompileModuleSpecSession(
     Context& context, const CuFacts& facts,
-    const CompiledModuleSpecInput& input,
-    const mir::ConstructionInput* construction) -> Result<CompiledModuleSpec> {
+    const CompiledModuleSpecInput& input) -> Result<CompiledModuleSpec> {
   const auto& body = *input.body;
   Context::ArenaScope arena_scope(context, &body.arena);
 
@@ -278,8 +277,7 @@ auto CompileSpecializations(
     input_with_bases.wait_site_base_index = running_wait_base;
     input_with_bases.back_edge_site_base_index = running_back_edge_base;
 
-    auto product = CompileModuleSpecSession(
-        context, facts, input_with_bases, input.construction);
+    auto product = CompileModuleSpecSession(context, facts, input_with_bases);
     if (!product) return std::unexpected(product.error());
 
     running_wait_base += static_cast<uint32_t>(product->wait_sites.size());

--- a/src/lyra/runtime/assertions.cpp
+++ b/src/lyra/runtime/assertions.cpp
@@ -44,12 +44,12 @@ void Engine::EnqueueDeferredAssertion(
     uint32_t process_id, RuntimeInstance* instance, uint32_t site_id,
     uint8_t disposition, const void* payload_ptr, uint32_t payload_size,
     const DeferredAssertionRefBindingAbi* ref_ptr, uint32_t ref_count) {
-  if (process_id >= deferred_assertion_states_.size()) {
+  if (process_id >= processes_.size()) {
     throw common::InternalError(
         "Engine::EnqueueDeferredAssertion",
         std::format(
             "process_id {} out of range (num_processes={})", process_id,
-            deferred_assertion_states_.size()));
+            processes_.size()));
   }
   if (site_id >= num_deferred_assertion_sites_) {
     throw common::InternalError(
@@ -65,7 +65,8 @@ void Engine::EnqueueDeferredAssertion(
         std::format("unknown disposition {}", disposition));
   }
 
-  auto& state = deferred_assertion_states_[process_id];
+  auto& proc = processes_[process_id];
+  auto& state = proc.deferred_assertion_state;
   DeferredAssertionRecord rec{
       .enqueue_generation = state.flush_generation,
       .site_id = site_id,
@@ -83,17 +84,17 @@ void Engine::EnqueueDeferredAssertion(
   }
   state.pending.push_back(std::move(rec));
 
-  if (deferred_pending_flags_[process_id] == 0) {
-    deferred_pending_flags_[process_id] = 1;
-    pending_deferred_processes_.push_back(ProcessId::FromIndex(process_id));
+  if (!proc.deferred_pending) {
+    proc.deferred_pending = true;
+    pending_deferred_processes_.push_back(&proc);
   }
 }
 
 void Engine::MatureAndExecuteObservedDeferredAssertions() {
   using Disp = DeferredAssertionDispositionAbi;
 
-  for (ProcessId pid : pending_deferred_processes_) {
-    auto& state = deferred_assertion_states_[pid.Index()];
+  for (RuntimeProcess* proc : pending_deferred_processes_) {
+    auto& state = proc->deferred_assertion_state;
 
     for (const auto& rec : state.pending) {
       if (rec.enqueue_generation != state.flush_generation) continue;
@@ -181,7 +182,7 @@ void Engine::MatureAndExecuteObservedDeferredAssertions() {
     }
 
     state.pending.clear();
-    deferred_pending_flags_[pid.Index()] = 0;
+    proc->deferred_pending = false;
   }
   pending_deferred_processes_.clear();
 }

--- a/src/lyra/runtime/constructor_.cpp
+++ b/src/lyra/runtime/constructor_.cpp
@@ -979,18 +979,6 @@ auto Constructor::Finalize() -> ConstructionResult {
   void* packed_buffer = AllocateProcessFrames(
       std::span(states), std::span(schema_indices), schemas_);
 
-  for (uint32_t i = 0; i < num_total; ++i) {
-    auto* header = static_cast<ProcessFrameHeader*>(states[i]);
-    header->design_ptr = design_state_.data();
-    header->process_id = i;
-
-    const auto& proc = staged_[i];
-    if (proc.is_module) {
-      header->body = proc.body;
-      header->instance = staged_instances_[proc.instance_index].get();
-    }
-  }
-
   ConstructionResult result;
   result.states = std::move(states);
   result.packed_buffer = packed_buffer;

--- a/src/lyra/runtime/decision.cpp
+++ b/src/lyra/runtime/decision.cpp
@@ -58,7 +58,7 @@ void Engine::RecordDecisionObservation(
 
 auto Engine::FormatDecisionOwner(DecisionOwnerId owner_id) const
     -> std::string {
-  return FormatProcess(owner_id.Index());
+  return FormatProcess(processes_[owner_id.Index()]);
 }
 
 auto Engine::BuildDecisionViolationMessage(

--- a/src/lyra/runtime/engine_bundle_init.cpp
+++ b/src/lyra/runtime/engine_bundle_init.cpp
@@ -290,6 +290,7 @@ void Engine::InitModuleInstancesFromBundles(
   pending_module_process_meta_.clear();
   for (auto& proc : processes_) {
     proc.instance = nullptr;
+    proc.body = nullptr;
   }
   slot_meta_registry_ = SlotMetaRegistry{};
   comb_kernels_.clear();
@@ -511,6 +512,11 @@ void Engine::InitModuleInstancesFromBundles(
       uint32_t proc_idx = proc_map.GlobalIndex(bi, p);
       if (proc_idx < num_processes_) {
         processes_[proc_idx].instance = bundle.instance;
+        SharedBodyFn body_fn{};
+        std::memcpy(
+            &body_fn, &bundle.body_desc->entries[p].shared_body_fn,
+            sizeof(body_fn));
+        processes_[proc_idx].body = body_fn;
         bundle.instance->attached_processes.push_back(&processes_[proc_idx]);
       }
     }
@@ -641,7 +647,8 @@ void Engine::InitModuleInstancesFromBundles(
 
         auto* state_ptr = proc_states[proc_idx];
         auto comb_idx = static_cast<uint32_t>(comb_kernels_.size());
-        comb_kernels_.push_back(BuildCombKernel(proc_idx, state_ptr, flags));
+        comb_kernels_.push_back(
+            BuildCombKernel(processes_[proc_idx], proc_idx, state_ptr, flags));
 
         proc->is_comb_kernel = true;
         bool kernel_self_edge = (flags & CombKernel::kSelfEdge) != 0;

--- a/src/lyra/runtime/engine_bundle_init.cpp
+++ b/src/lyra/runtime/engine_bundle_init.cpp
@@ -948,6 +948,19 @@ void Engine::InitModuleInstancesFromBundles(
   }
 }
 
+void Engine::RegisterFrameStates(std::span<void*> states) {
+  if (states.size() != processes_.size()) {
+    throw common::InternalError(
+        "Engine::RegisterFrameStates",
+        std::format(
+            "states size {} != processes_ size {}", states.size(),
+            processes_.size()));
+  }
+  for (size_t i = 0; i < states.size(); ++i) {
+    processes_[i].frame_state = states[i];
+  }
+}
+
 void Engine::InitInstanceTimeMetadata(
     std::span<const InstanceMetadataBundle> bundles) {
   for (const auto& b : bundles) {

--- a/src/lyra/runtime/engine_scheduler_activation.cpp
+++ b/src/lyra/runtime/engine_scheduler_activation.cpp
@@ -29,7 +29,7 @@ void Engine::ScheduleInitial(ProcessHandle handle) {
 
   active_queue_.push_back({handle.process_id, /*resume_block=*/0});
   if (activation_trace_.has_value()) {
-    wake_trace_[handle.process_id] = {
+    processes_[handle.process_id].wake_trace = {
         .cause = WakeCause::kInitial, .trigger_slot = kNoTriggerSlot};
   }
 }
@@ -45,7 +45,7 @@ void Engine::Delay(ProcessHandle handle, ResumePoint resume, SimTime ticks) {
   SimTime wake_time = current_time_ + ticks;
   delay_queue_[wake_time].push_back({handle.process_id, resume.block_index});
   if (activation_trace_.has_value()) {
-    wake_trace_[handle.process_id] = {
+    processes_[handle.process_id].wake_trace = {
         .cause = WakeCause::kDelay, .trigger_slot = kNoTriggerSlot};
   }
 }
@@ -53,7 +53,7 @@ void Engine::Delay(ProcessHandle handle, ResumePoint resume, SimTime ticks) {
 void Engine::DelayZero(ProcessHandle handle, ResumePoint resume) {
   inactive_queue_.push({handle.process_id, resume.block_index});
   if (activation_trace_.has_value()) {
-    wake_trace_[handle.process_id] = {
+    processes_[handle.process_id].wake_trace = {
         .cause = WakeCause::kDelayZero, .trigger_slot = kNoTriggerSlot};
   }
 }
@@ -61,7 +61,7 @@ void Engine::DelayZero(ProcessHandle handle, ResumePoint resume) {
 void Engine::ScheduleNextDelta(ProcessHandle handle, ResumePoint resume) {
   next_delta_queue_.push_back({handle.process_id, resume.block_index});
   if (activation_trace_.has_value()) {
-    wake_trace_[handle.process_id] = {
+    processes_[handle.process_id].wake_trace = {
         .cause = WakeCause::kRepeat, .trigger_slot = kNoTriggerSlot};
   }
 }
@@ -141,7 +141,7 @@ void Engine::RunOneActivation(const WakeupEntry& entry) {
     ++stats_.core.activations_nba_only;
   }
   if (detailed_stats_enabled_) {
-    auto& ps = per_process_stats_[pid];
+    auto& ps = processes_[pid].wake_stats;
     ++ps.runs;
     ps.total_slots_dirtied += activation_ctx_.dirty_count;
     if (activation_ctx_.dirty_count == 0) {

--- a/src/lyra/runtime/engine_scheduler_activation.cpp
+++ b/src/lyra/runtime/engine_scheduler_activation.cpp
@@ -14,6 +14,7 @@
 #include "lyra/runtime/engine_scheduler.hpp"
 #include "lyra/runtime/engine_types.hpp"
 #include "lyra/runtime/iteration_limit.hpp"
+#include "lyra/runtime/process_envelope.hpp"
 #include "lyra/runtime/signal_interrupt.hpp"
 #include "lyra/runtime/trace_flush.hpp"
 
@@ -131,9 +132,8 @@ void Engine::RunOneActivation(const WakeupEntry& entry) {
   // Reset iteration limit: direct TLS write from cached values.
   *cached_iteration_limit_ptr_ = cached_iteration_limit_;
 
-  ProcessHandle handle{.process_id = pid};
   ResumePoint resume{.block_index = entry.resume_block, .instruction_index = 0};
-  process_dispatch_.fn(process_dispatch_.ctx, *this, handle, resume);
+  DispatchAndHandleActivation(*this, proc, resume);
 
   // End activation context.
   activation_ctx_.active = false;

--- a/src/lyra/runtime/engine_scheduler_activation.cpp
+++ b/src/lyra/runtime/engine_scheduler_activation.cpp
@@ -19,22 +19,21 @@
 
 namespace lyra::runtime {
 
-void Engine::ScheduleInitial(ProcessHandle handle) {
+void Engine::ScheduleInitial(RuntimeProcess& proc) {
   // Skip comb kernel processes - they are evaluated inline during flush,
   // not through the normal scheduler activation path.
-  if (handle.process_id < processes_.size() &&
-      processes_[handle.process_id].is_comb_kernel) {
+  if (proc.is_comb_kernel) {
     return;
   }
 
-  active_queue_.push_back({handle.process_id, /*resume_block=*/0});
+  active_queue_.push_back({&proc, /*resume_block=*/0});
   if (activation_trace_.has_value()) {
-    processes_[handle.process_id].wake_trace = {
+    proc.wake_trace = {
         .cause = WakeCause::kInitial, .trigger_slot = kNoTriggerSlot};
   }
 }
 
-void Engine::Delay(ProcessHandle handle, ResumePoint resume, SimTime ticks) {
+void Engine::Delay(RuntimeProcess& proc, ResumePoint resume, SimTime ticks) {
   // Checked addition to prevent overflow
   if (ticks > kNoTimeLimit - current_time_) {
     throw common::InternalError(
@@ -43,25 +42,25 @@ void Engine::Delay(ProcessHandle handle, ResumePoint resume, SimTime ticks) {
                              current_time_, ticks));
   }
   SimTime wake_time = current_time_ + ticks;
-  delay_queue_[wake_time].push_back({handle.process_id, resume.block_index});
+  delay_queue_[wake_time].push_back({&proc, resume.block_index});
   if (activation_trace_.has_value()) {
-    processes_[handle.process_id].wake_trace = {
+    proc.wake_trace = {
         .cause = WakeCause::kDelay, .trigger_slot = kNoTriggerSlot};
   }
 }
 
-void Engine::DelayZero(ProcessHandle handle, ResumePoint resume) {
-  inactive_queue_.push({handle.process_id, resume.block_index});
+void Engine::DelayZero(RuntimeProcess& proc, ResumePoint resume) {
+  inactive_queue_.push({&proc, resume.block_index});
   if (activation_trace_.has_value()) {
-    processes_[handle.process_id].wake_trace = {
+    proc.wake_trace = {
         .cause = WakeCause::kDelayZero, .trigger_slot = kNoTriggerSlot};
   }
 }
 
-void Engine::ScheduleNextDelta(ProcessHandle handle, ResumePoint resume) {
-  next_delta_queue_.push_back({handle.process_id, resume.block_index});
+void Engine::ScheduleNextDelta(RuntimeProcess& proc, ResumePoint resume) {
+  next_delta_queue_.push_back({&proc, resume.block_index});
   if (activation_trace_.has_value()) {
-    processes_[handle.process_id].wake_trace = {
+    proc.wake_trace = {
         .cause = WakeCause::kRepeat, .trigger_slot = kNoTriggerSlot};
   }
 }
@@ -103,7 +102,8 @@ void Engine::SetMonitorEnabled(bool enabled) {
 }
 
 void Engine::RunOneActivation(const WakeupEntry& entry) {
-  uint32_t pid = entry.process_id;
+  auto& proc = *entry.process;
+  const auto pid = static_cast<uint32_t>(&proc - processes_.data());
 
   // Update progress counters (signal-safe reads by SIGUSR1 handler).
   // last_process_id_ and phase_ are always written (cheap stores, useful
@@ -131,7 +131,7 @@ void Engine::RunOneActivation(const WakeupEntry& entry) {
   // Reset iteration limit: direct TLS write from cached values.
   *cached_iteration_limit_ptr_ = cached_iteration_limit_;
 
-  ProcessHandle handle{.process_id = entry.process_id};
+  ProcessHandle handle{.process_id = pid};
   ResumePoint resume{.block_index = entry.resume_block, .instruction_index = 0};
   process_dispatch_.fn(process_dispatch_.ctx, *this, handle, resume);
 
@@ -141,7 +141,7 @@ void Engine::RunOneActivation(const WakeupEntry& entry) {
     ++stats_.core.activations_nba_only;
   }
   if (detailed_stats_enabled_) {
-    auto& ps = processes_[pid].wake_stats;
+    auto& ps = proc.wake_stats;
     ++ps.runs;
     ps.total_slots_dirtied += activation_ctx_.dirty_count;
     if (activation_ctx_.dirty_count == 0) {
@@ -185,16 +185,8 @@ void Engine::ExecuteActiveRegion() {
         break;
       }
 
-      if (num_processes_ > 0) {
-        if (entry.process_id >= num_processes_) {
-          throw common::InternalError(
-              "Engine::ExecuteRegion",
-              std::format(
-                  "process_id {} exceeds num_processes {}", entry.process_id,
-                  num_processes_));
-        }
-        processes_[entry.process_id].is_enqueued = false;
-      }
+      auto& proc = *entry.process;
+      proc.is_enqueued = false;
 
       if (activation_trace_.has_value()) {
         TraceWake(entry);
@@ -205,10 +197,10 @@ void Engine::ExecuteActiveRegion() {
       // wait/delay resume uses the non-zero block set by LyraSuspendWait/Delay.
       if (entry.resume_block != 0) {
         FlushDeferredAssertionsForProcess(
-            ProcessId::FromIndex(entry.process_id));
+            ProcessId::FromIndex(
+                static_cast<uint32_t>(&proc - processes_.data())));
       }
 
-      auto& proc = processes_[entry.process_id];
       if (!post_activation_reconcile_) {
         ClearProcessSubscriptions(proc);
       }

--- a/src/lyra/runtime/engine_scheduler_activation.cpp
+++ b/src/lyra/runtime/engine_scheduler_activation.cpp
@@ -208,9 +208,9 @@ void Engine::ExecuteActiveRegion() {
             ProcessId::FromIndex(entry.process_id));
       }
 
-      ProcessHandle handle{.process_id = entry.process_id};
+      auto& proc = processes_[entry.process_id];
       if (!post_activation_reconcile_) {
-        ClearProcessSubscriptions(handle);
+        ClearProcessSubscriptions(proc);
       }
       // Activation handling (scheduling, subscription install/refresh)
       // is performed by the process envelope inside the dispatch callback.
@@ -218,7 +218,6 @@ void Engine::ExecuteActiveRegion() {
       // semantic requests and calls engine primitives directly.
       RunOneActivation(entry);
       if (!finished_ && post_activation_reconcile_) {
-        auto& proc = processes_[entry.process_id];
         if (!TryFastReconcile(proc)) {
           ReconcilePostActivation(proc);
         }

--- a/src/lyra/runtime/engine_scheduler_activation.cpp
+++ b/src/lyra/runtime/engine_scheduler_activation.cpp
@@ -218,8 +218,9 @@ void Engine::ExecuteActiveRegion() {
       // semantic requests and calls engine primitives directly.
       RunOneActivation(entry);
       if (!finished_ && post_activation_reconcile_) {
-        if (!TryFastReconcile(entry.process_id)) {
-          ReconcilePostActivation(handle);
+        auto& proc = processes_[entry.process_id];
+        if (!TryFastReconcile(proc)) {
+          ReconcilePostActivation(proc);
         }
       }
     }
@@ -387,10 +388,11 @@ void Engine::FlushDirtySlots() {
   ClearLocalUpdates();
 }
 
-void Engine::HandleTrap(uint32_t process_id, const TrapPayload& payload) {
+void Engine::HandleTrap(
+    const RuntimeProcess& proc, const TrapPayload& payload) {
   switch (payload.reason) {
     case TrapReason::kIterationLimitExceeded: {
-      std::string proc_str = FormatProcess(process_id);
+      std::string proc_str = FormatProcess(proc);
       std::string loc_str;
       if (back_edge_site_meta_.IsPopulated() &&
           payload.a < back_edge_site_meta_.Size()) {
@@ -411,7 +413,7 @@ void Engine::HandleTrap(uint32_t process_id, const TrapPayload& payload) {
     }
     case TrapReason::kUserFatal:
     case TrapReason::kInternalError:
-      lyra::PrintError(std::format("trap in {}", FormatProcess(process_id)));
+      lyra::PrintError(std::format("trap in {}", FormatProcess(proc)));
       finished_ = true;
       break;
   }
@@ -440,11 +442,12 @@ void Engine::OnMutation(const common::MutationEvent& event) {
   // HeapObjId: NYI -- future heap-level UpdateSet tracking.
 }
 
-auto Engine::FormatProcess(uint32_t process_id) const -> std::string {
+auto Engine::FormatProcess(const RuntimeProcess& proc) const -> std::string {
+  const auto pid = static_cast<uint32_t>(&proc - processes_.data());
   if (process_meta_.IsPopulated()) {
-    return process_meta_.Format(process_id);
+    return process_meta_.Format(pid);
   }
-  return std::format("<process {}>", process_id);
+  return std::format("<process {}>", pid);
 }
 
 void Engine::HandleObservabilityCheckpoint() {

--- a/src/lyra/runtime/engine_scheduler_activation.cpp
+++ b/src/lyra/runtime/engine_scheduler_activation.cpp
@@ -133,7 +133,7 @@ void Engine::RunOneActivation(const WakeupEntry& entry) {
   *cached_iteration_limit_ptr_ = cached_iteration_limit_;
 
   ResumePoint resume{.block_index = entry.resume_block, .instruction_index = 0};
-  DispatchAndHandleActivation(*this, proc, resume);
+  DispatchAndHandleActivation(*this, proc, pid, resume);
 
   // End activation context.
   activation_ctx_.active = false;

--- a/src/lyra/runtime/engine_scheduler_fixpoint.cpp
+++ b/src/lyra/runtime/engine_scheduler_fixpoint.cpp
@@ -242,12 +242,11 @@ void Engine::InitCombKernels(
       has_any_self_edge_comb_ = true;
     }
 
-    const auto* header =
-        static_cast<const ProcessFrameHeader*>(proc_states[proc_idx]);
+    const auto& proc = processes_[proc_idx];
 
     auto comb_idx = static_cast<uint32_t>(comb_kernels_.size());
     comb_kernels_.push_back(
-        BuildCombKernel(proc_idx, proc_states[proc_idx], flags));
+        BuildCombKernel(proc, proc_idx, proc_states[proc_idx], flags));
 
     processes_[proc_idx].is_comb_kernel = true;
 
@@ -264,7 +263,7 @@ void Engine::InitCombKernels(
       uint32_t local_id = 0;
       uint32_t global_id = trigger_slot;
       if (is_local) {
-        if (header->instance == nullptr) {
+        if (proc.instance == nullptr) {
           throw common::InternalError(
               "Engine::InitCombKernels",
               std::format(
@@ -272,7 +271,7 @@ void Engine::InitCombKernels(
                   "process {}",
                   proc_idx));
         }
-        trigger_inst = header->instance;
+        trigger_inst = proc.instance;
         local_id = trigger_slot;
       }
 
@@ -523,34 +522,34 @@ void Engine::EvaluateInstalledComputations() {
   }
 }
 
-auto Engine::BuildCombKernel(uint32_t proc_idx, void* frame, uint32_t flags)
+auto Engine::BuildCombKernel(
+    const RuntimeProcess& proc, uint32_t proc_idx, void* frame, uint32_t flags)
     -> CombKernel {
   if (frame == nullptr) {
     throw common::InternalError(
         "Engine::BuildCombKernel",
         std::format("null proc state for comb proc_idx {}", proc_idx));
   }
-  const auto* header = static_cast<const ProcessFrameHeader*>(frame);
-  if (header->body == nullptr) {
+  if (proc.body == nullptr) {
     throw common::InternalError(
         "Engine::BuildCombKernel",
         std::format(
             "comb kernel proc_idx {} has null body function pointer "
-            "(shared_body_fn not set by constructor)",
+            "(RuntimeProcess::body not set)",
             proc_idx));
   }
-  if (header->instance == nullptr) {
+  if (proc.instance == nullptr) {
     throw common::InternalError(
         "Engine::BuildCombKernel",
         std::format(
             "comb kernel proc_idx {} has null instance pointer", proc_idx));
   }
   return CombKernel{
-      .body = header->body,
+      .body = proc.body,
       .frame = frame,
       .process_index = proc_idx,
       .flags = flags,
-      .instance = header->instance,
+      .instance = proc.instance,
   };
 }
 
@@ -901,7 +900,9 @@ void Engine::FlushAndPropagateConnections() {
               const auto& ck = comb_kernels_[entry.owner_idx];
               FlushDeferredAssertionsForProcess(
                   ProcessId::FromIndex(ck.process_index));
-              ck.body(ck.frame, 0);
+              ck.body(
+                  ck.frame, 0, this, design_state_base_, ck.instance,
+                  ck.process_index);
               break;
             }
             case ReactiveTriggerEntry::Kind::kInstallableComputation: {
@@ -936,7 +937,9 @@ void Engine::FlushAndPropagateConnections() {
                 const auto& ck = comb_kernels_[entry.owner_idx];
                 FlushDeferredAssertionsForProcess(
                     ProcessId::FromIndex(ck.process_index));
-                ck.body(ck.frame, 0);
+                ck.body(
+                    ck.frame, 0, this, design_state_base_, ck.instance,
+                    ck.process_index);
                 break;
               }
               case ReactiveTriggerEntry::Kind::kInstallableComputation: {

--- a/src/lyra/runtime/engine_scheduler_observability.cpp
+++ b/src/lyra/runtime/engine_scheduler_observability.cpp
@@ -308,11 +308,13 @@ void Engine::DumpSchedulerStatusAsyncSignalSafe(int fd) const {
 
 void Engine::TraceWake(const WakeupEntry& entry) {
   if (!activation_trace_.has_value()) return;
-  const auto& trace = processes_[entry.process_id].wake_trace;
+  const auto& proc = *entry.process;
+  const auto pid = static_cast<uint32_t>(&proc - processes_.data());
+  const auto& trace = proc.wake_trace;
   ActivationEvent ae{
       .time = current_time_,
       .delta = current_delta_,
-      .process_id = entry.process_id,
+      .process_id = pid,
       .trigger_slot = trace.trigger_slot,
       .resume_block = entry.resume_block,
       .kind = ActivationEventKind::kWake,
@@ -325,11 +327,13 @@ void Engine::TraceWake(const WakeupEntry& entry) {
 
 void Engine::TraceRun(const WakeupEntry& entry) {
   if (!activation_trace_.has_value()) return;
-  const auto& trace = processes_[entry.process_id].wake_trace;
+  const auto& proc = *entry.process;
+  const auto pid = static_cast<uint32_t>(&proc - processes_.data());
+  const auto& trace = proc.wake_trace;
   ActivationEvent ae{
       .time = current_time_,
       .delta = current_delta_,
-      .process_id = entry.process_id,
+      .process_id = pid,
       .trigger_slot = trace.trigger_slot,
       .resume_block = entry.resume_block,
       .kind = ActivationEventKind::kRun,
@@ -456,9 +460,10 @@ auto Engine::TakeSchedulerSnapshot() const -> SchedulerSnapshot {
   std::vector<bool> in_delay(num_processes_, false);
   for (const auto& [time, entries] : delay_queue_) {
     for (const auto& entry : entries) {
-      if (entry.process_id < num_processes_) {
-        in_delay[entry.process_id] = true;
-        delay_target[entry.process_id] = time;
+      const auto pid = static_cast<uint32_t>(entry.process - processes_.data());
+      if (pid < num_processes_) {
+        in_delay[pid] = true;
+        delay_target[pid] = time;
       }
     }
   }
@@ -466,10 +471,12 @@ auto Engine::TakeSchedulerSnapshot() const -> SchedulerSnapshot {
   // Build ready-queue membership.
   std::vector<bool> is_ready(num_processes_, false);
   for (const auto& e : active_queue_) {
-    if (e.process_id < num_processes_) is_ready[e.process_id] = true;
+    const auto pid = static_cast<uint32_t>(e.process - processes_.data());
+    if (pid < num_processes_) is_ready[pid] = true;
   }
   for (const auto& e : next_delta_queue_) {
-    if (e.process_id < num_processes_) is_ready[e.process_id] = true;
+    const auto pid = static_cast<uint32_t>(e.process - processes_.data());
+    if (pid < num_processes_) is_ready[pid] = true;
   }
 
   uint32_t current_running =

--- a/src/lyra/runtime/engine_scheduler_observability.cpp
+++ b/src/lyra/runtime/engine_scheduler_observability.cpp
@@ -164,32 +164,25 @@ void Engine::DumpRuntimeStats(FILE* sink) const {
     //                 always_ff and is NOT a wasted-wakeup indicator.
     //   no_effect:    runs - direct_dirty - nba_only (should be 0;
     //                 nonzero means accounting bug)
-    if (!per_process_stats_.empty()) {
+    if (detailed_stats_enabled_ && !processes_.empty()) {
       // Build sorted index by total wake attempts (descending).
-      std::vector<uint32_t> order(per_process_stats_.size());
+      std::vector<uint32_t> order(processes_.size());
       std::ranges::iota(order, 0U);
       std::ranges::sort(order, [&](uint32_t a, uint32_t b) {
-        auto total_a = per_process_stats_[a].wake_edge +
-                       per_process_stats_[a].wake_change +
-                       per_process_stats_[a].wake_container +
-                       per_process_stats_[a].wake_delay +
-                       per_process_stats_[a].wake_initial +
-                       per_process_stats_[a].wake_other;
-        auto total_b = per_process_stats_[b].wake_edge +
-                       per_process_stats_[b].wake_change +
-                       per_process_stats_[b].wake_container +
-                       per_process_stats_[b].wake_delay +
-                       per_process_stats_[b].wake_initial +
-                       per_process_stats_[b].wake_other;
+        const auto& sa = processes_[a].wake_stats;
+        const auto& sb = processes_[b].wake_stats;
+        auto total_a = sa.wake_edge + sa.wake_change + sa.wake_container +
+                       sa.wake_delay + sa.wake_initial + sa.wake_other;
+        auto total_b = sb.wake_edge + sb.wake_change + sb.wake_container +
+                       sb.wake_delay + sb.wake_initial + sb.wake_other;
         return total_a > total_b;
       });
 
       fmt::print(
-          sink, "[lyra][stats][per_process] {} processes\n",
-          per_process_stats_.size());
+          sink, "[lyra][stats][per_process] {} processes\n", processes_.size());
 
       for (uint32_t pid : order) {
-        const auto& ps = per_process_stats_[pid];
+        const auto& ps = processes_[pid].wake_stats;
         uint64_t total_wakes = ps.wake_edge + ps.wake_change +
                                ps.wake_container + ps.wake_delay +
                                ps.wake_initial + ps.wake_other;
@@ -315,7 +308,7 @@ void Engine::DumpSchedulerStatusAsyncSignalSafe(int fd) const {
 
 void Engine::TraceWake(const WakeupEntry& entry) {
   if (!activation_trace_.has_value()) return;
-  const auto& trace = wake_trace_[entry.process_id];
+  const auto& trace = processes_[entry.process_id].wake_trace;
   ActivationEvent ae{
       .time = current_time_,
       .delta = current_delta_,
@@ -332,7 +325,7 @@ void Engine::TraceWake(const WakeupEntry& entry) {
 
 void Engine::TraceRun(const WakeupEntry& entry) {
   if (!activation_trace_.has_value()) return;
-  const auto& trace = wake_trace_[entry.process_id];
+  const auto& trace = processes_[entry.process_id].wake_trace;
   ActivationEvent ae{
       .time = current_time_,
       .delta = current_delta_,

--- a/src/lyra/runtime/engine_scheduler_observability.cpp
+++ b/src/lyra/runtime/engine_scheduler_observability.cpp
@@ -20,6 +20,7 @@
 #include "lyra/runtime/runtime_instance.hpp"
 #include "lyra/runtime/scheduler_snapshot.hpp"
 #include "lyra/runtime/slot_meta.hpp"
+#include "lyra/runtime/suspend_record.hpp"
 #include "lyra/runtime/trace_signal_meta.hpp"
 
 namespace lyra::runtime {
@@ -511,9 +512,12 @@ auto Engine::TakeSchedulerSnapshot() const -> SchedulerSnapshot {
     } else if (is_ready[pid] || processes_[pid].is_enqueued) {
       kind = ProcessWaitKind::kReady;
     } else if (
-        pid < processes_.size() && processes_[pid].suspend_record != nullptr) {
-      // Use SuspendRecord::tag as the canonical authority.
-      switch (processes_[pid].suspend_record->tag) {
+        pid < processes_.size() && processes_[pid].frame_state != nullptr) {
+      // Use SuspendRecord::tag from the process's frame-state backing as the
+      // canonical authority.
+      const auto* suspend =
+          static_cast<const SuspendRecord*>(processes_[pid].frame_state);
+      switch (suspend->tag) {
         case SuspendTag::kFinished:
           kind = ProcessWaitKind::kFinished;
           break;

--- a/src/lyra/runtime/engine_subscriptions_flush.cpp
+++ b/src/lyra/runtime/engine_subscriptions_flush.cpp
@@ -62,7 +62,7 @@ inline void UpdateMovedEdgeTargetPosition(
 // Shared edge group migration logic. Extracts the sub from its old group,
 // finds or creates the new group, inserts the sub, and updates all
 // bookkeeping (process sub refs, cold snapshots, target handle position).
-// BackpatchFn: (uint32_t process_id, uint32_t process_sub_idx,
+// BackpatchFn: (RuntimeProcess& proc, uint32_t process_sub_idx,
 //               uint32_t new_idx, uint32_t new_group) -> void
 template <typename HandleT, typename BackpatchFn>
 void RebindEdgeGroupMigration(
@@ -105,7 +105,7 @@ void RebindEdgeGroupMigration(
       rm_vec[target.index] = rm_vec[rm_last];
       auto& moved = rm_vec[target.index];
       backpatch(
-          moved.process_id, moved.process_sub_idx, target.index,
+          *moved.process, moved.process_sub_idx, target.index,
           target.edge_group, target.edge_bucket);
       if (moved.cold_idx != UINT32_MAX) {
         auto& moved_cold = edge_cold_pool[moved.cold_idx];
@@ -178,7 +178,7 @@ void RebindEdgeGroupMigration(
 
   // Update sub ref.
   backpatch(
-      sub_copy.process_id, sub_copy.process_sub_idx, new_index, new_group_idx,
+      *sub_copy.process, sub_copy.process_sub_idx, new_index, new_group_idx,
       target.edge_bucket);
 
   // Update target handle position.
@@ -207,7 +207,7 @@ void Engine::RebindLocalSubscription(uint32_t idx) {
   IndexPlanRef plan_ref;
   BitTargetMapping mapping;
   uint32_t* epoch_ptr = nullptr;
-  uint32_t target_process_id = 0;
+  RuntimeProcess* target_process = nullptr;
 
   if (target.kind == SubKind::kEdge) {
     auto& g = target_subs.edge_groups[target.edge_group];
@@ -219,27 +219,25 @@ void Engine::RebindLocalSubscription(uint32_t idx) {
     plan_ref = ecold.plan_ref;
     mapping = ecold.rebind_mapping;
     epoch_ptr = &ecold.last_rebind_epoch;
-    target_process_id = esub.process_id;
+    target_process = esub.process;
   } else {
     auto& csub = target_subs.container_subs[target.index];
     auto& ccold = container_cold_pool_[csub.cold_idx];
     plan_ref = ccold.plan_ref;
     mapping = ccold.rebind_mapping;
     epoch_ptr = &ccold.last_rebind_epoch;
-    target_process_id = csub.process_id;
+    target_process = csub.process;
   }
 
   if (*epoch_ptr == flush_epoch_) return;
   *epoch_ptr = flush_epoch_;
 
-  if (target_process_id >= num_processes_) {
+  if (target_process == nullptr) {
     throw common::InternalError(
         "Engine::RebindLocalSubscription",
-        std::format(
-            "process_id {} exceeds num_processes {}", target_process_id,
-            num_processes_));
+        "rebind target subscription has null process pointer");
   }
-  auto& proc_state = processes_[target_process_id];
+  auto& proc_state = *target_process;
   auto all_ops = std::span<const IndexPlanOp>(proc_state.plan_pool.ops);
   auto plan_span = all_ops.subspan(plan_ref.start, plan_ref.count);
 
@@ -321,10 +319,9 @@ void Engine::RebindLocalSubscription(uint32_t idx) {
   RebindEdgeGroupMigration(
       target, target_subs, edge_cold_pool_, local_edge_target_table_,
       global_edge_target_table_, slot_storage, new_byte_offset, new_bit_index,
-      [this](
-          uint32_t pid, uint32_t psi, uint32_t new_idx, uint32_t grp,
-          EdgeBucket bkt) {
-        auto& mr = processes_[pid].local_sub_refs[psi];
+      [](RuntimeProcess& proc, uint32_t psi, uint32_t new_idx, uint32_t grp,
+         EdgeBucket bkt) {
+        auto& mr = proc.local_sub_refs[psi];
         mr.index = new_idx;
         mr.edge_group = grp;
         mr.edge_bucket = bkt;
@@ -347,7 +344,7 @@ void Engine::RebindGlobalSubscription(uint32_t idx) {
   IndexPlanRef plan_ref;
   BitTargetMapping mapping;
   uint32_t* epoch_ptr = nullptr;
-  uint32_t target_process_id = 0;
+  RuntimeProcess* target_process = nullptr;
 
   if (target.kind == SubKind::kEdge) {
     auto& g = target_subs.edge_groups[target.edge_group];
@@ -359,27 +356,25 @@ void Engine::RebindGlobalSubscription(uint32_t idx) {
     plan_ref = ecold.plan_ref;
     mapping = ecold.rebind_mapping;
     epoch_ptr = &ecold.last_rebind_epoch;
-    target_process_id = esub.process_id;
+    target_process = esub.process;
   } else {
     auto& csub = target_subs.container_subs[target.index];
     auto& ccold = container_cold_pool_[csub.cold_idx];
     plan_ref = ccold.plan_ref;
     mapping = ccold.rebind_mapping;
     epoch_ptr = &ccold.last_rebind_epoch;
-    target_process_id = csub.process_id;
+    target_process = csub.process;
   }
 
   if (*epoch_ptr == flush_epoch_) return;
   *epoch_ptr = flush_epoch_;
 
-  if (target_process_id >= num_processes_) {
+  if (target_process == nullptr) {
     throw common::InternalError(
         "Engine::RebindGlobalSubscription",
-        std::format(
-            "process_id {} exceeds num_processes {}", target_process_id,
-            num_processes_));
+        "rebind target subscription has null process pointer");
   }
-  auto& proc_state = processes_[target_process_id];
+  auto& proc_state = *target_process;
   auto all_ops = std::span<const IndexPlanOp>(proc_state.plan_pool.ops);
   auto plan_span = all_ops.subspan(plan_ref.start, plan_ref.count);
 
@@ -462,10 +457,9 @@ void Engine::RebindGlobalSubscription(uint32_t idx) {
   RebindEdgeGroupMigration(
       target, target_subs, edge_cold_pool_, local_edge_target_table_,
       global_edge_target_table_, slot_storage, new_byte_offset, new_bit_index,
-      [this](
-          uint32_t pid, uint32_t psi, uint32_t new_idx, uint32_t grp,
-          EdgeBucket bkt) {
-        auto& mr = processes_[pid].global_sub_refs[psi];
+      [](RuntimeProcess& proc, uint32_t psi, uint32_t new_idx, uint32_t grp,
+         EdgeBucket bkt) {
+        auto& mr = proc.global_sub_refs[psi];
         mr.index = new_idx;
         mr.edge_group = grp;
         mr.edge_bucket = bkt;
@@ -526,7 +520,7 @@ void Engine::FlushContainerSub(
 
   if (should_wake) {
     EnqueueProcessWakeup(
-        sub.process_id, sub.resume_block, slot_id, WakeCause::kContainer);
+        *sub.process, sub.resume_block, slot_id, WakeCause::kContainer);
   }
 }
 
@@ -594,7 +588,7 @@ void Engine::FlushSlotEdgeGroups(
       if (detailed) ++stats_.detailed.edge_sub_checks;
       if (detailed) ++stats_.detailed.edge_sub_wakeups;
       EnqueueProcessWakeup(
-          sub.process_id, sub.resume_block, slot_id, WakeCause::kEdge);
+          *sub.process, sub.resume_block, slot_id, WakeCause::kEdge);
     }
 
     group.last_bit = current_bit;
@@ -627,7 +621,7 @@ void Engine::FlushSlotChangeSubs(
       if (detailed) ++stats_.detailed.change_sub_wakeups;
       std::memcpy(snapshot, current, sub.byte_size);
       EnqueueProcessWakeup(
-          sub.process_id, sub.resume_block, slot_id, WakeCause::kChange);
+          *sub.process, sub.resume_block, slot_id, WakeCause::kChange);
     }
   }
 }

--- a/src/lyra/runtime/engine_subscriptions_install.cpp
+++ b/src/lyra/runtime/engine_subscriptions_install.cpp
@@ -424,15 +424,10 @@ void Engine::RemoveGlobalContainerSub(const GlobalSubRef& ref) {
   UpdateGlobalObserverFlag(ref.signal);
 }
 
-void Engine::ClearInstalledSubscriptions(ProcessHandle handle) {
-  if (handle.process_id >= num_processes_) {
-    return;
-  }
-  auto& proc_state = processes_[handle.process_id];
-
+void Engine::ClearInstalledSubscriptions(RuntimeProcess& proc) {
   // Iterate in reverse so swap-and-pop doesn't invalidate earlier indices
   // belonging to this same process (they'll be removed too).
-  for (const auto& ref : std::views::reverse(proc_state.local_sub_refs)) {
+  for (const auto& ref : std::views::reverse(proc.local_sub_refs)) {
     switch (ref.kind) {
       case SubKind::kEdge:
         RemoveLocalEdgeSub(ref);
@@ -454,7 +449,7 @@ void Engine::ClearInstalledSubscriptions(ProcessHandle handle) {
     }
     --live_subscription_count_;
   }
-  for (const auto& ref : std::views::reverse(proc_state.global_sub_refs)) {
+  for (const auto& ref : std::views::reverse(proc.global_sub_refs)) {
     switch (ref.kind) {
       case SubKind::kEdge:
         RemoveGlobalEdgeSub(ref);
@@ -477,25 +472,23 @@ void Engine::ClearInstalledSubscriptions(ProcessHandle handle) {
     --live_subscription_count_;
   }
 
-  proc_state.local_sub_refs.clear();
-  proc_state.global_sub_refs.clear();
-  proc_state.subscription_count = 0;
-  proc_state.plan_pool.ops.clear();
+  proc.local_sub_refs.clear();
+  proc.global_sub_refs.clear();
+  proc.subscription_count = 0;
+  proc.plan_pool.ops.clear();
 }
 
-void Engine::InvalidateInstalledWait(ProcessHandle handle) {
-  if (handle.process_id >= num_processes_) return;
-  auto& proc_state = processes_[handle.process_id];
-  proc_state.installed_wait = InstalledWaitState{};
+void Engine::InvalidateInstalledWait(RuntimeProcess& proc) {
+  proc.installed_wait = InstalledWaitState{};
 }
 
-void Engine::ResetInstalledWait(ProcessHandle handle) {
-  ClearInstalledSubscriptions(handle);
-  InvalidateInstalledWait(handle);
+void Engine::ResetInstalledWait(RuntimeProcess& proc) {
+  ClearInstalledSubscriptions(proc);
+  InvalidateInstalledWait(proc);
 }
 
-void Engine::ClearProcessSubscriptions(ProcessHandle handle) {
-  ResetInstalledWait(handle);
+void Engine::ClearProcessSubscriptions(RuntimeProcess& proc) {
+  ResetInstalledWait(proc);
 }
 
 // Refresh installed edge/change baselines for subscriptions whose slots
@@ -510,11 +503,7 @@ void Engine::ClearProcessSubscriptions(ProcessHandle handle) {
 // Only called on the can_refresh path (WaitShapeKind::kStatic), so all
 // sub_refs are snapshot-bearing (kEdge or kChange). Rebind watchers and
 // container subs are structurally impossible here.
-auto Engine::RefreshInstalledSnapshots(ProcessHandle handle) -> bool {
-  if (handle.process_id >= num_processes_) return false;
-
-  auto& proc_state = processes_[handle.process_id];
-
+auto Engine::RefreshInstalledSnapshots(RuntimeProcess& proc) -> bool {
   // R5: Domain-split watermark skip. Check both global and local
   // freshness to determine if any new dirty marks appeared since the
   // last refresh. Skip if both domains are unchanged.
@@ -522,12 +511,11 @@ auto Engine::RefreshInstalledSnapshots(ProcessHandle handle) -> bool {
   auto current_global_dirty =
       static_cast<uint32_t>(update_set_.DeltaDirtySlots().size());
   bool global_unchanged =
-      (current_global_epoch ==
-           proc_state.installed_wait.last_global_refresh_epoch &&
+      (current_global_epoch == proc.installed_wait.last_global_refresh_epoch &&
        current_global_dirty ==
-           proc_state.installed_wait.last_global_refresh_dirty_count);
+           proc.installed_wait.last_global_refresh_dirty_count);
   bool local_unchanged = true;
-  for (const auto& stamp : proc_state.installed_wait.local_refresh_epochs) {
+  for (const auto& stamp : proc.installed_wait.local_refresh_epochs) {
     if (stamp.instance == nullptr) {
       throw common::InternalError(
           "Engine::RefreshInstalledSnapshots",
@@ -545,7 +533,7 @@ auto Engine::RefreshInstalledSnapshots(ProcessHandle handle) -> bool {
   bool needs_reinstall = false;
 
   // Local sub refresh -- direct instance pointer, no InstanceId lookup.
-  for (const auto& ref : proc_state.local_sub_refs) {
+  for (const auto& ref : proc.local_sub_refs) {
     if (ref.instance == nullptr) {
       throw common::InternalError(
           "Engine::RefreshInstalledSnapshots",
@@ -596,19 +584,19 @@ auto Engine::RefreshInstalledSnapshots(ProcessHandle handle) -> bool {
         throw common::InternalError(
             "Engine::RefreshInstalledSnapshots",
             std::format(
-                "process {} has rebind watcher on static refresh path",
-                handle.process_id));
+                "{} has rebind watcher on static refresh path",
+                FormatProcess(proc)));
       case SubKind::kContainer:
         throw common::InternalError(
             "Engine::RefreshInstalledSnapshots",
             std::format(
-                "process {} has container sub on static refresh path",
-                handle.process_id));
+                "{} has container sub on static refresh path",
+                FormatProcess(proc)));
     }
   }
 
   // Global sub refresh.
-  for (const auto& ref : proc_state.global_sub_refs) {
+  for (const auto& ref : proc.global_sub_refs) {
     if (!update_set_.IsDeltaDirty(ref.signal.value)) continue;
     const auto& meta = slot_meta_registry_.Get(ref.signal.value);
     auto storage = std::span(
@@ -653,22 +641,21 @@ auto Engine::RefreshInstalledSnapshots(ProcessHandle handle) -> bool {
         throw common::InternalError(
             "Engine::RefreshInstalledSnapshots",
             std::format(
-                "process {} has rebind watcher on static refresh path",
-                handle.process_id));
+                "{} has rebind watcher on static refresh path",
+                FormatProcess(proc)));
       case SubKind::kContainer:
         throw common::InternalError(
             "Engine::RefreshInstalledSnapshots",
             std::format(
-                "process {} has container sub on static refresh path",
-                handle.process_id));
+                "{} has container sub on static refresh path",
+                FormatProcess(proc)));
     }
   }
 
   // Update watermark after refresh.
-  proc_state.installed_wait.last_global_refresh_epoch = current_global_epoch;
-  proc_state.installed_wait.last_global_refresh_dirty_count =
-      current_global_dirty;
-  for (auto& stamp : proc_state.installed_wait.local_refresh_epochs) {
+  proc.installed_wait.last_global_refresh_epoch = current_global_epoch;
+  proc.installed_wait.last_global_refresh_dirty_count = current_global_dirty;
+  for (auto& stamp : proc.installed_wait.local_refresh_epochs) {
     if (stamp.instance == nullptr) {
       throw common::InternalError(
           "Engine::RefreshInstalledSnapshots",
@@ -941,25 +928,25 @@ void Engine::InstallTriggers(ProcessHandle handle, const WaitRequest& req) {
   }
 }
 
-void Engine::InstallWaitSite(ProcessHandle handle, const WaitRequest& req) {
+void Engine::InstallWaitSite(RuntimeProcess& proc, const WaitRequest& req) {
   const auto& descriptor = wait_site_meta_.Get(req.wait_site_id);
   // Validate compiled-vs-runtime agreement before any installation work.
   if (descriptor.resume_block != req.resume.block_index) {
     throw common::InternalError(
         "Engine::InstallWaitSite",
         std::format(
-            "process {} wait_site {} resume_block mismatch: "
+            "{} wait_site {} resume_block mismatch: "
             "descriptor={} vs request={}",
-            handle.process_id, descriptor.id, descriptor.resume_block,
+            FormatProcess(proc), descriptor.id, descriptor.resume_block,
             req.resume.block_index));
   }
   if (descriptor.num_triggers != static_cast<uint32_t>(req.triggers.size())) {
     throw common::InternalError(
         "Engine::InstallWaitSite",
         std::format(
-            "process {} wait_site {} num_triggers mismatch: "
+            "{} wait_site {} num_triggers mismatch: "
             "descriptor={} vs request={}",
-            handle.process_id, descriptor.id, descriptor.num_triggers,
+            FormatProcess(proc), descriptor.id, descriptor.num_triggers,
             req.triggers.size()));
   }
 
@@ -970,37 +957,39 @@ void Engine::InstallWaitSite(ProcessHandle handle, const WaitRequest& req) {
     throw common::InternalError(
         "Engine::InstallWaitSite",
         std::format(
-            "process {} wait_site {}: has_late_bound mismatch: "
+            "{} wait_site {}: has_late_bound mismatch: "
             "descriptor={} vs request={}",
-            handle.process_id, descriptor.id, descriptor.has_late_bound,
+            FormatProcess(proc), descriptor.id, descriptor.has_late_bound,
             has_late_bound));
   }
 
-  InstallTriggers(handle, req);
+  InstallTriggers(
+      ProcessHandle{
+          .process_id = static_cast<uint32_t>(&proc - processes_.data())},
+      req);
 
   // Install-time realized-state invariant: when the compiled shape is
   // kStatic, the installed subscription set must contain only
   // snapshot-bearing triggers (kEdge/kChange). This is expected because
   // static waits have no late-bound indices, so InstallTriggers should not
   // produce rebind watcher or container subs for this shape.
-  auto& proc_state = processes_[handle.process_id];
   if (descriptor.shape == WaitShapeKind::kStatic) {
     auto is_snapshot_bearing = [](const auto& ref) {
       return ref.kind == SubKind::kEdge || ref.kind == SubKind::kChange;
     };
-    if (!std::ranges::all_of(proc_state.local_sub_refs, is_snapshot_bearing) ||
-        !std::ranges::all_of(proc_state.global_sub_refs, is_snapshot_bearing)) {
+    if (!std::ranges::all_of(proc.local_sub_refs, is_snapshot_bearing) ||
+        !std::ranges::all_of(proc.global_sub_refs, is_snapshot_bearing)) {
       throw common::InternalError(
           "Engine::InstallWaitSite",
           std::format(
-              "process {} wait_site {}: kStatic shape but installed "
+              "{} wait_site {}: kStatic shape but installed "
               "non-snapshot-bearing sub_refs",
-              handle.process_id, descriptor.id));
+              FormatProcess(proc), descriptor.id));
     }
   }
 
   // Publish install-time state with derived policy.
-  proc_state.installed_wait = InstalledWaitState{
+  proc.installed_wait = InstalledWaitState{
       .wait_site_id = descriptor.id,
       .valid = true,
       .can_refresh_snapshot = (descriptor.shape == WaitShapeKind::kStatic),
@@ -1008,28 +997,27 @@ void Engine::InstallWaitSite(ProcessHandle handle, const WaitRequest& req) {
 
   // Snapshots are fresh from install -- set domain-split watermark.
   // Global watermark from update_set_.
-  proc_state.installed_wait.last_global_refresh_epoch =
-      update_set_.DeltaEpoch();
-  proc_state.installed_wait.last_global_refresh_dirty_count =
+  proc.installed_wait.last_global_refresh_epoch = update_set_.DeltaEpoch();
+  proc.installed_wait.last_global_refresh_dirty_count =
       static_cast<uint32_t>(update_set_.DeltaDirtySlots().size());
   // Local watermark: track only instances this wait site depends on.
   // Iterate local_sub_refs only -- global subs have no instance dependency.
-  proc_state.installed_wait.local_refresh_epochs.clear();
-  for (const auto& ref : proc_state.local_sub_refs) {
+  proc.installed_wait.local_refresh_epochs.clear();
+  for (const auto& ref : proc.local_sub_refs) {
     if (ref.instance == nullptr) {
       throw common::InternalError(
           "Engine::InstallWaitSite", "local sub ref has null instance");
     }
     // Deduplicate by instance pointer (small sets, linear scan fine).
     bool already_tracked = false;
-    for (const auto& stamp : proc_state.installed_wait.local_refresh_epochs) {
+    for (const auto& stamp : proc.installed_wait.local_refresh_epochs) {
       if (stamp.instance == ref.instance) {
         already_tracked = true;
         break;
       }
     }
     if (!already_tracked) {
-      proc_state.installed_wait.local_refresh_epochs.push_back(
+      proc.installed_wait.local_refresh_epochs.push_back(
           InstalledWaitState::LocalRefreshStamp{
               .instance = ref.instance,
               .epoch = ref.instance->observability.local_flush_epoch});
@@ -1038,9 +1026,8 @@ void Engine::InstallWaitSite(ProcessHandle handle, const WaitRequest& req) {
 }
 
 auto Engine::CanRefreshInstalledWait(
-    ProcessHandle handle, WaitSiteId wait_site_id) const -> bool {
-  if (handle.process_id >= processes_.size()) return false;
-  const auto& installed = processes_[handle.process_id].installed_wait;
+    const RuntimeProcess& proc, WaitSiteId wait_site_id) -> bool {
+  const auto& installed = proc.installed_wait;
   return installed.valid && installed.wait_site_id == wait_site_id &&
          installed.can_refresh_snapshot;
 }
@@ -1102,8 +1089,8 @@ void Engine::ReconcilePostActivation(RuntimeProcess& proc) {
         "Engine::ReconcilePostActivation",
         "called without post-activation reconciliation capability");
   }
-  const auto pid = static_cast<uint32_t>(&proc - processes_.data());
-  ProcessHandle handle{.process_id = pid};
+  const ProcessHandle handle{
+      .process_id = static_cast<uint32_t>(&proc - processes_.data())};
   auto* suspend = proc.suspend_record;
 
   auto resume =
@@ -1111,11 +1098,11 @@ void Engine::ReconcilePostActivation(RuntimeProcess& proc) {
 
   switch (suspend->tag) {
     case SuspendTag::kFinished:
-      ResetInstalledWait(handle);
+      ResetInstalledWait(proc);
       break;
 
     case SuspendTag::kDelay:
-      ResetInstalledWait(handle);
+      ResetInstalledWait(proc);
       Delay(handle, resume, suspend->delay_ticks);
       break;
 
@@ -1124,16 +1111,16 @@ void Engine::ReconcilePostActivation(RuntimeProcess& proc) {
         throw common::InternalError(
             "Engine::ReconcilePostActivation",
             std::format(
-                "process {} suspended with kWait but wait_site_id is invalid",
-                pid));
+                "{} suspended with kWait but wait_site_id is invalid",
+                FormatProcess(proc)));
       }
 
       if (!proc.installed_wait.valid ||
           proc.installed_wait.wait_site_id != suspend->wait_site_id ||
           !proc.installed_wait.can_refresh_snapshot) {
         // Reinstall required: different wait site or non-static shape.
-        ResetInstalledWait(handle);
-        InstallWaitSite(handle, BuildWaitRequest(suspend));
+        ResetInstalledWait(proc);
+        InstallWaitSite(proc, BuildWaitRequest(suspend));
         break;
       }
 
@@ -1158,34 +1145,35 @@ void Engine::ReconcilePostActivation(RuntimeProcess& proc) {
         break;
       }
 
-      if (RefreshInstalledSnapshots(handle)) {
+      if (RefreshInstalledSnapshots(proc)) {
         // A same-delta blocking write changed an observed edge bit.
         // group.last_bit is shared state and cannot be updated here.
         // Fall back to full reinstall to get a fresh group baseline.
-        ResetInstalledWait(handle);
-        InstallWaitSite(handle, BuildWaitRequest(suspend));
+        ResetInstalledWait(proc);
+        InstallWaitSite(proc, BuildWaitRequest(suspend));
       }
       break;
     }
 
     case SuspendTag::kRepeat:
-      ResetInstalledWait(handle);
+      ResetInstalledWait(proc);
       ScheduleNextDelta(handle, ResumePoint{.block_index = 0});
       break;
 
     case SuspendTag::kWaitEvent: {
-      ResetInstalledWait(handle);
+      ResetInstalledWait(proc);
       auto* inst = proc.instance;
       if (inst == nullptr) {
         throw common::InternalError(
             "Engine::ReconcilePostActivation",
             std::format(
-                "kWaitEvent for process {} has no owning instance", pid));
+                "kWaitEvent for {} has no owning instance",
+                FormatProcess(proc)));
       }
       AddInstanceEventWaiter(
           *inst, suspend->event_id,
           EventWaiter{
-              .process_id = pid,
+              .process_id = handle.process_id,
               .instance = inst,
               .resume_block = suspend->resume_block,
           });

--- a/src/lyra/runtime/engine_subscriptions_install.cpp
+++ b/src/lyra/runtime/engine_subscriptions_install.cpp
@@ -1096,20 +1096,15 @@ auto BuildWaitRequest(const SuspendRecord* suspend) -> WaitRequest {
 }
 }  // namespace
 
-void Engine::ReconcilePostActivation(ProcessHandle handle) {
+void Engine::ReconcilePostActivation(RuntimeProcess& proc) {
   if (!HasPostActivationReconciliation()) {
     throw common::InternalError(
         "Engine::ReconcilePostActivation",
         "called without post-activation reconciliation capability");
   }
-  if (handle.process_id >= processes_.size()) {
-    throw common::InternalError(
-        "Engine::ReconcilePostActivation",
-        std::format(
-            "process_id {} >= processes_ size {}", handle.process_id,
-            processes_.size()));
-  }
-  auto* suspend = processes_[handle.process_id].suspend_record;
+  const auto pid = static_cast<uint32_t>(&proc - processes_.data());
+  ProcessHandle handle{.process_id = pid};
+  auto* suspend = proc.suspend_record;
 
   auto resume =
       ResumePoint{.block_index = suspend->resume_block, .instruction_index = 0};
@@ -1130,14 +1125,12 @@ void Engine::ReconcilePostActivation(ProcessHandle handle) {
             "Engine::ReconcilePostActivation",
             std::format(
                 "process {} suspended with kWait but wait_site_id is invalid",
-                handle.process_id));
+                pid));
       }
 
-      auto& proc_state = processes_[handle.process_id];
-
-      if (!proc_state.installed_wait.valid ||
-          proc_state.installed_wait.wait_site_id != suspend->wait_site_id ||
-          !proc_state.installed_wait.can_refresh_snapshot) {
+      if (!proc.installed_wait.valid ||
+          proc.installed_wait.wait_site_id != suspend->wait_site_id ||
+          !proc.installed_wait.can_refresh_snapshot) {
         // Reinstall required: different wait site or non-static shape.
         ResetInstalledWait(handle);
         InstallWaitSite(handle, BuildWaitRequest(suspend));
@@ -1182,18 +1175,17 @@ void Engine::ReconcilePostActivation(ProcessHandle handle) {
 
     case SuspendTag::kWaitEvent: {
       ResetInstalledWait(handle);
-      auto* inst = processes_[handle.process_id].instance;
+      auto* inst = proc.instance;
       if (inst == nullptr) {
         throw common::InternalError(
             "Engine::ReconcilePostActivation",
             std::format(
-                "kWaitEvent for process {} has no owning instance",
-                handle.process_id));
+                "kWaitEvent for process {} has no owning instance", pid));
       }
       AddInstanceEventWaiter(
           *inst, suspend->event_id,
           EventWaiter{
-              .process_id = handle.process_id,
+              .process_id = pid,
               .instance = inst,
               .resume_block = suspend->resume_block,
           });

--- a/src/lyra/runtime/engine_subscriptions_install.cpp
+++ b/src/lyra/runtime/engine_subscriptions_install.cpp
@@ -666,10 +666,12 @@ auto Engine::RefreshInstalledSnapshots(RuntimeProcess& proc) -> bool {
   return needs_reinstall;
 }
 
-void Engine::InstallTriggers(ProcessHandle handle, const WaitRequest& req) {
+void Engine::InstallTriggers(RuntimeProcess& proc, const WaitRequest& req) {
   auto resume = req.resume;
   auto triggers = req.triggers;
   const auto& late_bound = req.late_bound;
+  const ProcessHandle handle{
+      .process_id = static_cast<uint32_t>(&proc - processes_.data())};
   // Track created subscription info for late-bound rebinding.
   // Invariant: created_subs[i] records the dense vector index assigned
   // to trigger i at creation time. These indices remain stable within
@@ -717,13 +719,13 @@ void Engine::InstallTriggers(ProcessHandle handle, const WaitRequest& req) {
           LocalSignalId{trigger.target_local_signal_id},
           "Engine::InstallTriggers");
     } else if (is_local) {
-      auto* inst = processes_[handle.process_id].instance;
+      auto* inst = proc.instance;
       if (inst == nullptr) {
         throw common::InternalError(
             "Engine::InstallTriggers",
             std::format(
-                "local trigger for process {} has no owning instance",
-                handle.process_id));
+                "local trigger for {} has no owning instance",
+                FormatProcess(proc)));
       }
       sig_ref = LocalSignalRef{
           .instance = inst, .signal = LocalSignalId{trigger.signal_id}};
@@ -826,13 +828,12 @@ void Engine::InstallTriggers(ProcessHandle handle, const WaitRequest& req) {
           .index = sub_idx,
           .is_local = is_local};
       if (sub_kind == SubKind::kEdge && sub_idx != UINT32_MAX) {
-        auto& ps = processes_[handle.process_id];
         if (is_local) {
-          auto& last_ref = ps.local_sub_refs.back();
+          auto& last_ref = proc.local_sub_refs.back();
           cs.edge_group = last_ref.edge_group;
           cs.edge_bucket = last_ref.edge_bucket;
         } else {
-          auto& last_ref = ps.global_sub_refs.back();
+          auto& last_ref = proc.global_sub_refs.back();
           cs.edge_group = last_ref.edge_group;
           cs.edge_bucket = last_ref.edge_bucket;
         }
@@ -882,13 +883,12 @@ void Engine::InstallTriggers(ProcessHandle handle, const WaitRequest& req) {
     auto hdr_plan =
         late_bound.plan_ops.subspan(hdr.plan_ops_start, hdr.plan_ops_count);
 
-    auto* rebind_inst = processes_[handle.process_id].instance;
+    auto* rebind_inst = proc.instance;
     if (rebind_inst == nullptr) {
       throw common::InternalError(
           "Engine::InstallTriggers",
           std::format(
-              "rebind for process {} has no owning instance",
-              handle.process_id));
+              "rebind for {} has no owning instance", FormatProcess(proc)));
     }
 
     // Decode each dep record into a typed SignalRef.
@@ -963,10 +963,7 @@ void Engine::InstallWaitSite(RuntimeProcess& proc, const WaitRequest& req) {
             has_late_bound));
   }
 
-  InstallTriggers(
-      ProcessHandle{
-          .process_id = static_cast<uint32_t>(&proc - processes_.data())},
-      req);
+  InstallTriggers(proc, req);
 
   // Install-time realized-state invariant: when the compiled shape is
   // kStatic, the installed subscription set must contain only
@@ -1222,7 +1219,7 @@ auto FindOrCreateEdgeGroupInSlot(
 }  // namespace
 
 auto Engine::SubscribeGlobalChange(
-    ProcessHandle handle, ResumePoint resume, GlobalSignalId signal,
+    RuntimeProcess& proc, ResumePoint resume, GlobalSignalId signal,
     uint32_t byte_offset, uint32_t byte_size, bool initially_active)
     -> uint32_t {
   if (finished_) return UINT32_MAX;
@@ -1234,15 +1231,7 @@ auto Engine::SubscribeGlobalChange(
     throw common::InternalError(
         "Engine::SubscribeGlobalChange", "Subscribe before InitSlotMeta");
   }
-  if (handle.process_id >= num_processes_) {
-    throw common::InternalError(
-        "Engine::SubscribeGlobalChange",
-        std::format(
-            "process_id {} exceeds num_processes {}", handle.process_id,
-            num_processes_));
-  }
-  auto& proc_state = processes_[handle.process_id];
-  if (!CheckSubscriptionLimits(proc_state)) return UINT32_MAX;
+  if (!CheckSubscriptionLimits(proc)) return UINT32_MAX;
 
   const auto& meta = slot_meta_registry_.Get(signal.value);
   if (byte_size == 0 || byte_offset + byte_size > meta.total_bytes) {
@@ -1252,10 +1241,10 @@ auto Engine::SubscribeGlobalChange(
 
   auto& slot = signal_subs_[signal.value];
   auto sub_idx = static_cast<uint32_t>(slot.change_subs.size());
-  auto proc_sub_idx = static_cast<uint32_t>(proc_state.global_sub_refs.size());
+  auto proc_sub_idx = static_cast<uint32_t>(proc.global_sub_refs.size());
 
   ChangeSub sub{};
-  sub.process_id = handle.process_id;
+  sub.process_id = static_cast<uint32_t>(&proc - processes_.data());
   sub.resume_block = resume.block_index;
   sub.byte_offset = byte_offset;
   sub.byte_size = byte_size;
@@ -1277,29 +1266,21 @@ auto Engine::SubscribeGlobalChange(
   }
 
   slot.change_subs.push_back(sub);
-  proc_state.global_sub_refs.push_back(
+  proc.global_sub_refs.push_back(
       GlobalSubRef{
           .signal = signal, .index = sub_idx, .kind = SubKind::kChange});
-  ++proc_state.subscription_count;
+  ++proc.subscription_count;
   ++live_subscription_count_;
   global_has_observers_[signal.value] = 1;
   return sub_idx;
 }
 
 auto Engine::SubscribeLocalChange(
-    ProcessHandle handle, ResumePoint resume, LocalSignalRef signal,
+    RuntimeProcess& proc, ResumePoint resume, LocalSignalRef signal,
     uint32_t byte_offset, uint32_t byte_size, bool initially_active)
     -> uint32_t {
   if (finished_) return UINT32_MAX;
-  if (handle.process_id >= num_processes_) {
-    throw common::InternalError(
-        "Engine::SubscribeLocalChange",
-        std::format(
-            "process_id {} exceeds num_processes {}", handle.process_id,
-            num_processes_));
-  }
-  auto& proc_state = processes_[handle.process_id];
-  if (!CheckSubscriptionLimits(proc_state)) return UINT32_MAX;
+  if (!CheckSubscriptionLimits(proc)) return UINT32_MAX;
 
   if (signal.instance == nullptr) {
     throw common::InternalError(
@@ -1315,10 +1296,10 @@ auto Engine::SubscribeLocalChange(
 
   auto& slot = inst.observability.local_signal_subs[signal.signal.value];
   auto sub_idx = static_cast<uint32_t>(slot.change_subs.size());
-  auto proc_sub_idx = static_cast<uint32_t>(proc_state.local_sub_refs.size());
+  auto proc_sub_idx = static_cast<uint32_t>(proc.local_sub_refs.size());
 
   ChangeSub sub{};
-  sub.process_id = handle.process_id;
+  sub.process_id = static_cast<uint32_t>(&proc - processes_.data());
   sub.resume_block = resume.block_index;
   sub.byte_offset = byte_offset;
   sub.byte_size = byte_size;
@@ -1339,20 +1320,20 @@ auto Engine::SubscribeLocalChange(
   }
 
   slot.change_subs.push_back(sub);
-  proc_state.local_sub_refs.push_back(
+  proc.local_sub_refs.push_back(
       LocalSubRef{
           .instance = &inst,
           .signal = signal.signal,
           .index = sub_idx,
           .kind = SubKind::kChange});
-  ++proc_state.subscription_count;
+  ++proc.subscription_count;
   ++live_subscription_count_;
   inst.observability.local_has_observers[signal.signal.value] = 1;
   return sub_idx;
 }
 
 auto Engine::SubscribeGlobalEdge(
-    ProcessHandle handle, ResumePoint resume, GlobalSignalId signal,
+    RuntimeProcess& proc, ResumePoint resume, GlobalSignalId signal,
     common::EdgeKind edge, uint32_t byte_offset, uint32_t byte_size,
     uint8_t bit_index, bool initially_active) -> uint32_t {
   if (finished_) return UINT32_MAX;
@@ -1373,15 +1354,7 @@ auto Engine::SubscribeGlobalEdge(
     throw common::InternalError(
         "Engine::SubscribeGlobalEdge", "Subscribe before InitSlotMeta");
   }
-  if (handle.process_id >= num_processes_) {
-    throw common::InternalError(
-        "Engine::SubscribeGlobalEdge",
-        std::format(
-            "process_id {} exceeds num_processes {}", handle.process_id,
-            num_processes_));
-  }
-  auto& proc_state = processes_[handle.process_id];
-  if (!CheckSubscriptionLimits(proc_state)) return UINT32_MAX;
+  if (!CheckSubscriptionLimits(proc)) return UINT32_MAX;
 
   const auto& meta = slot_meta_registry_.Get(signal.value);
   if (byte_offset + byte_size > meta.total_bytes) {
@@ -1390,7 +1363,7 @@ auto Engine::SubscribeGlobalEdge(
   }
 
   auto& slot = signal_subs_[signal.value];
-  auto proc_sub_idx = static_cast<uint32_t>(proc_state.global_sub_refs.size());
+  auto proc_sub_idx = static_cast<uint32_t>(proc.global_sub_refs.size());
 
   auto storage = std::span(
       runtime::ResolveGlobalSlotBase(meta, design_state_base_),
@@ -1408,28 +1381,28 @@ auto Engine::SubscribeGlobalEdge(
   auto sub_idx = static_cast<uint32_t>(target_vec.size());
 
   EdgeSub sub{};
-  sub.process_id = handle.process_id;
+  sub.process_id = static_cast<uint32_t>(&proc - processes_.data());
   sub.resume_block = resume.block_index;
   sub.flags = initially_active ? kSubActive : 0;
   sub.process_sub_idx = proc_sub_idx;
   sub.cold_idx = UINT32_MAX;
 
   target_vec.push_back(sub);
-  proc_state.global_sub_refs.push_back(
+  proc.global_sub_refs.push_back(
       GlobalSubRef{
           .signal = signal,
           .index = sub_idx,
           .kind = SubKind::kEdge,
           .edge_bucket = bucket,
           .edge_group = group_idx});
-  ++proc_state.subscription_count;
+  ++proc.subscription_count;
   ++live_subscription_count_;
   global_has_observers_[signal.value] = 1;
   return sub_idx;
 }
 
 auto Engine::SubscribeLocalEdge(
-    ProcessHandle handle, ResumePoint resume, LocalSignalRef signal,
+    RuntimeProcess& proc, ResumePoint resume, LocalSignalRef signal,
     common::EdgeKind edge, uint32_t byte_offset, uint32_t byte_size,
     uint8_t bit_index, bool initially_active) -> uint32_t {
   if (finished_) return UINT32_MAX;
@@ -1441,15 +1414,7 @@ auto Engine::SubscribeLocalEdge(
     throw common::InternalError(
         "Engine::SubscribeLocalEdge", "bit_index must be in [0,7]");
   }
-  if (handle.process_id >= num_processes_) {
-    throw common::InternalError(
-        "Engine::SubscribeLocalEdge",
-        std::format(
-            "process_id {} exceeds num_processes {}", handle.process_id,
-            num_processes_));
-  }
-  auto& proc_state = processes_[handle.process_id];
-  if (!CheckSubscriptionLimits(proc_state)) return UINT32_MAX;
+  if (!CheckSubscriptionLimits(proc)) return UINT32_MAX;
 
   if (signal.instance == nullptr) {
     throw common::InternalError("Engine::SubscribeLocalEdge", "null instance");
@@ -1463,7 +1428,7 @@ auto Engine::SubscribeLocalEdge(
   }
 
   auto& slot = inst.observability.local_signal_subs[signal.signal.value];
-  auto proc_sub_idx = static_cast<uint32_t>(proc_state.local_sub_refs.size());
+  auto proc_sub_idx = static_cast<uint32_t>(proc.local_sub_refs.size());
 
   auto storage = std::span(
       ResolveInstanceSlotBase(inst, signal.signal), inst_meta.total_bytes);
@@ -1480,14 +1445,14 @@ auto Engine::SubscribeLocalEdge(
   auto sub_idx = static_cast<uint32_t>(target_vec.size());
 
   EdgeSub sub{};
-  sub.process_id = handle.process_id;
+  sub.process_id = static_cast<uint32_t>(&proc - processes_.data());
   sub.resume_block = resume.block_index;
   sub.flags = initially_active ? kSubActive : 0;
   sub.process_sub_idx = proc_sub_idx;
   sub.cold_idx = UINT32_MAX;
 
   target_vec.push_back(sub);
-  proc_state.local_sub_refs.push_back(
+  proc.local_sub_refs.push_back(
       LocalSubRef{
           .instance = &inst,
           .signal = signal.signal,
@@ -1495,7 +1460,7 @@ auto Engine::SubscribeLocalEdge(
           .kind = SubKind::kEdge,
           .edge_bucket = bucket,
           .edge_group = group_idx});
-  ++proc_state.subscription_count;
+  ++proc.subscription_count;
   ++live_subscription_count_;
   inst.observability.local_has_observers[signal.signal.value] = 1;
   return sub_idx;
@@ -1505,6 +1470,7 @@ auto Engine::SubscribeLocalEdge(
 auto Engine::Subscribe(
     ProcessHandle handle, ResumePoint resume, SignalRef signal_ref,
     common::EdgeKind edge, bool initially_active) -> uint32_t {
+  auto& proc = processes_[handle.process_id];
   return std::visit(
       [&](auto sig) -> uint32_t {
         using T = std::decay_t<decltype(sig)>;
@@ -1518,10 +1484,10 @@ auto Engine::Subscribe(
               (edge == common::EdgeKind::kAnyChange) ? meta.total_bytes : 1;
           if (edge == common::EdgeKind::kAnyChange) {
             return SubscribeGlobalChange(
-                handle, resume, sig, 0, obs_size, initially_active);
+                proc, resume, sig, 0, obs_size, initially_active);
           }
           return SubscribeGlobalEdge(
-              handle, resume, sig, edge, 0, obs_size, 0, initially_active);
+              proc, resume, sig, edge, 0, obs_size, 0, initially_active);
         } else {
           const auto& inst_meta =
               sig.instance->observability.layout->slot_meta[sig.signal.value];
@@ -1530,10 +1496,10 @@ auto Engine::Subscribe(
                                   : 1;
           if (edge == common::EdgeKind::kAnyChange) {
             return SubscribeLocalChange(
-                handle, resume, sig, 0, obs_size, initially_active);
+                proc, resume, sig, 0, obs_size, initially_active);
           }
           return SubscribeLocalEdge(
-              handle, resume, sig, edge, 0, obs_size, 0, initially_active);
+              proc, resume, sig, edge, 0, obs_size, 0, initially_active);
         }
       },
       signal_ref);
@@ -1543,24 +1509,25 @@ auto Engine::Subscribe(
     ProcessHandle handle, ResumePoint resume, SignalRef signal_ref,
     common::EdgeKind edge, uint32_t byte_offset, uint32_t byte_size,
     uint8_t bit_index, bool initially_active) -> uint32_t {
+  auto& proc = processes_[handle.process_id];
   return std::visit(
       [&](auto sig) -> uint32_t {
         using T = std::decay_t<decltype(sig)>;
         if constexpr (std::is_same_v<T, GlobalSignalId>) {
           if (edge == common::EdgeKind::kAnyChange) {
             return SubscribeGlobalChange(
-                handle, resume, sig, byte_offset, byte_size, initially_active);
+                proc, resume, sig, byte_offset, byte_size, initially_active);
           }
           return SubscribeGlobalEdge(
-              handle, resume, sig, edge, byte_offset, byte_size, bit_index,
+              proc, resume, sig, edge, byte_offset, byte_size, bit_index,
               initially_active);
         } else {
           if (edge == common::EdgeKind::kAnyChange) {
             return SubscribeLocalChange(
-                handle, resume, sig, byte_offset, byte_size, initially_active);
+                proc, resume, sig, byte_offset, byte_size, initially_active);
           }
           return SubscribeLocalEdge(
-              handle, resume, sig, edge, byte_offset, byte_size, bit_index,
+              proc, resume, sig, edge, byte_offset, byte_size, bit_index,
               initially_active);
         }
       },
@@ -1571,17 +1538,16 @@ auto Engine::SubscribeContainerElement(
     ProcessHandle handle, ResumePoint resume, SignalRef signal_ref,
     common::EdgeKind edge, int64_t sv_index, uint32_t elem_stride,
     bool initially_active) -> uint32_t {
+  auto& proc = processes_[handle.process_id];
   return std::visit(
       [&](auto sig) -> uint32_t {
         using T = std::decay_t<decltype(sig)>;
         if constexpr (std::is_same_v<T, GlobalSignalId>) {
           return SubscribeGlobalContainerElement(
-              handle, resume, sig, edge, sv_index, elem_stride,
-              initially_active);
+              proc, resume, sig, edge, sv_index, elem_stride, initially_active);
         } else {
           return SubscribeLocalContainerElement(
-              handle, resume, sig, edge, sv_index, elem_stride,
-              initially_active);
+              proc, resume, sig, edge, sv_index, elem_stride, initially_active);
         }
       },
       signal_ref);
@@ -1627,7 +1593,7 @@ void InitContainerSubState(
 }  // namespace
 
 auto Engine::SubscribeGlobalContainerElement(
-    ProcessHandle handle, ResumePoint resume, GlobalSignalId signal,
+    RuntimeProcess& proc, ResumePoint resume, GlobalSignalId signal,
     common::EdgeKind edge, int64_t sv_index, uint32_t elem_stride,
     bool initially_active) -> uint32_t {
   if (finished_) return UINT32_MAX;
@@ -1641,19 +1607,11 @@ auto Engine::SubscribeGlobalContainerElement(
         "Engine::SubscribeGlobalContainerElement",
         "Subscribe before InitSlotMeta");
   }
-  if (handle.process_id >= num_processes_) {
-    throw common::InternalError(
-        "Engine::SubscribeGlobalContainerElement",
-        std::format(
-            "process_id {} exceeds num_processes {}", handle.process_id,
-            num_processes_));
-  }
   if (elem_stride == 0) {
     throw common::InternalError(
         "Engine::SubscribeGlobalContainerElement", "elem_stride must be > 0");
   }
-  auto& proc_state = processes_[handle.process_id];
-  if (!CheckSubscriptionLimits(proc_state)) return UINT32_MAX;
+  if (!CheckSubscriptionLimits(proc)) return UINT32_MAX;
 
   const auto& meta = slot_meta_registry_.Get(signal.value);
   auto& slot = signal_subs_[signal.value];
@@ -1661,11 +1619,11 @@ auto Engine::SubscribeGlobalContainerElement(
       runtime::ResolveGlobalSlotBase(meta, design_state_base_);
 
   auto sub_idx = static_cast<uint32_t>(slot.container_subs.size());
-  auto proc_sub_idx = static_cast<uint32_t>(proc_state.global_sub_refs.size());
+  auto proc_sub_idx = static_cast<uint32_t>(proc.global_sub_refs.size());
   uint32_t cold_idx = AllocContainerCold();
 
   ContainerSub sub{};
-  sub.process_id = handle.process_id;
+  sub.process_id = static_cast<uint32_t>(&proc - processes_.data());
   sub.resume_block = resume.block_index;
   sub.process_sub_idx = proc_sub_idx;
   sub.cold_idx = cold_idx;
@@ -1678,33 +1636,25 @@ auto Engine::SubscribeGlobalContainerElement(
       initially_active, slot_base);
 
   slot.container_subs.push_back(sub);
-  proc_state.global_sub_refs.push_back(
+  proc.global_sub_refs.push_back(
       GlobalSubRef{
           .signal = signal, .index = sub_idx, .kind = SubKind::kContainer});
-  ++proc_state.subscription_count;
+  ++proc.subscription_count;
   ++live_subscription_count_;
   global_has_observers_[signal.value] = 1;
   return sub_idx;
 }
 
 auto Engine::SubscribeLocalContainerElement(
-    ProcessHandle handle, ResumePoint resume, LocalSignalRef signal,
+    RuntimeProcess& proc, ResumePoint resume, LocalSignalRef signal,
     common::EdgeKind edge, int64_t sv_index, uint32_t elem_stride,
     bool initially_active) -> uint32_t {
   if (finished_) return UINT32_MAX;
-  if (handle.process_id >= num_processes_) {
-    throw common::InternalError(
-        "Engine::SubscribeLocalContainerElement",
-        std::format(
-            "process_id {} exceeds num_processes {}", handle.process_id,
-            num_processes_));
-  }
   if (elem_stride == 0) {
     throw common::InternalError(
         "Engine::SubscribeLocalContainerElement", "elem_stride must be > 0");
   }
-  auto& proc_state = processes_[handle.process_id];
-  if (!CheckSubscriptionLimits(proc_state)) return UINT32_MAX;
+  if (!CheckSubscriptionLimits(proc)) return UINT32_MAX;
 
   if (signal.instance == nullptr) {
     throw common::InternalError(
@@ -1715,11 +1665,11 @@ auto Engine::SubscribeLocalContainerElement(
   const auto* slot_base = ResolveInstanceSlotBase(inst, signal.signal);
 
   auto sub_idx = static_cast<uint32_t>(slot.container_subs.size());
-  auto proc_sub_idx = static_cast<uint32_t>(proc_state.local_sub_refs.size());
+  auto proc_sub_idx = static_cast<uint32_t>(proc.local_sub_refs.size());
   uint32_t cold_idx = AllocContainerCold();
 
   ContainerSub sub{};
-  sub.process_id = handle.process_id;
+  sub.process_id = static_cast<uint32_t>(&proc - processes_.data());
   sub.resume_block = resume.block_index;
   sub.process_sub_idx = proc_sub_idx;
   sub.cold_idx = cold_idx;
@@ -1732,13 +1682,13 @@ auto Engine::SubscribeLocalContainerElement(
       elem_stride, initially_active, slot_base);
 
   slot.container_subs.push_back(sub);
-  proc_state.local_sub_refs.push_back(
+  proc.local_sub_refs.push_back(
       LocalSubRef{
           .instance = &inst,
           .signal = signal.signal,
           .index = sub_idx,
           .kind = SubKind::kContainer});
-  ++proc_state.subscription_count;
+  ++proc.subscription_count;
   ++live_subscription_count_;
   inst.observability.local_has_observers[signal.signal.value] = 1;
   return sub_idx;
@@ -1803,17 +1753,18 @@ void Engine::SubscribeRebind(
     SubKind target_kind, uint32_t target_index, uint8_t target_edge_group,
     EdgeBucket target_edge_bucket, std::span<const IndexPlanOp> plan,
     BitTargetMapping mapping, std::span<const SignalRef> dep_signals) {
+  auto& proc = processes_[handle.process_id];
   std::visit(
       [&](const auto& target) {
         using T = std::decay_t<decltype(target)>;
         if constexpr (std::is_same_v<T, GlobalSignalId>) {
           SubscribeGlobalRebind(
-              handle, edge_target_id, target, target_kind, target_index,
+              proc, edge_target_id, target, target_kind, target_index,
               target_edge_group, target_edge_bucket, plan, mapping,
               dep_signals);
         } else {
           SubscribeLocalRebind(
-              handle, edge_target_id, target, target_kind, target_index,
+              proc, edge_target_id, target, target_kind, target_index,
               target_edge_group, target_edge_bucket, plan, mapping,
               dep_signals);
         }
@@ -1824,9 +1775,8 @@ void Engine::SubscribeRebind(
 // Shared dep-watcher installation. Called from both domain-specific rebind
 // functions after the target cold entry and edge_target_id are established.
 void Engine::InstallRebindDepWatchers(
-    ProcessHandle handle, uint32_t edge_target_id,
+    RuntimeProcess& proc, uint32_t edge_target_id,
     std::span<const SignalRef> dep_signals) {
-  auto& proc_state = processes_[handle.process_id];
   for (const auto& dep : dep_signals) {
     std::visit(
         [&](const auto& sig) {
@@ -1860,7 +1810,7 @@ void Engine::InstallRebindDepWatchers(
           std::memcpy(wcold.snapshot.data(), dep_base, dep_total_bytes);
 
           RebindWatcherSub watcher{};
-          watcher.process_id = handle.process_id;
+          watcher.process_id = static_cast<uint32_t>(&proc - processes_.data());
           watcher.byte_offset = 0;
           watcher.byte_size = dep_total_bytes;
           watcher.cold_idx = watcher_cold;
@@ -1868,9 +1818,9 @@ void Engine::InstallRebindDepWatchers(
 
           if constexpr (std::is_same_v<T, LocalSignalRef>) {
             watcher.process_sub_idx =
-                static_cast<uint32_t>(proc_state.local_sub_refs.size());
+                static_cast<uint32_t>(proc.local_sub_refs.size());
             dep_subs->rebind_subs.push_back(watcher);
-            proc_state.local_sub_refs.push_back(
+            proc.local_sub_refs.push_back(
                 LocalSubRef{
                     .instance = dep_inst,
                     .signal = sig.signal,
@@ -1879,16 +1829,16 @@ void Engine::InstallRebindDepWatchers(
             UpdateLocalObserverFlag(*dep_inst, sig.signal);
           } else {
             watcher.process_sub_idx =
-                static_cast<uint32_t>(proc_state.global_sub_refs.size());
+                static_cast<uint32_t>(proc.global_sub_refs.size());
             dep_subs->rebind_subs.push_back(watcher);
-            proc_state.global_sub_refs.push_back(
+            proc.global_sub_refs.push_back(
                 GlobalSubRef{
                     .signal = sig,
                     .index = watcher_idx,
                     .kind = SubKind::kRebindWatcher});
             UpdateGlobalObserverFlag(sig);
           }
-          ++proc_state.subscription_count;
+          ++proc.subscription_count;
           ++live_subscription_count_;
         },
         dep);
@@ -1896,7 +1846,7 @@ void Engine::InstallRebindDepWatchers(
 }
 
 void Engine::SubscribeGlobalRebind(
-    ProcessHandle handle, uint32_t edge_target_id, GlobalSignalId target_signal,
+    RuntimeProcess& proc, uint32_t edge_target_id, GlobalSignalId target_signal,
     SubKind target_kind, uint32_t target_index, uint8_t target_edge_group,
     EdgeBucket target_edge_bucket, std::span<const IndexPlanOp> plan,
     BitTargetMapping mapping, std::span<const SignalRef> dep_signals) {
@@ -1909,13 +1859,6 @@ void Engine::SubscribeGlobalRebind(
   if (!slot_meta_registry_.IsPopulated()) {
     throw common::InternalError(
         "Engine::SubscribeGlobalRebind", "SubscribeRebind before InitSlotMeta");
-  }
-  if (handle.process_id >= num_processes_) {
-    throw common::InternalError(
-        "Engine::SubscribeGlobalRebind",
-        std::format(
-            "process_id {} exceeds num_processes {}", handle.process_id,
-            num_processes_));
   }
   if (target_kind != SubKind::kEdge && target_kind != SubKind::kContainer) {
     throw common::InternalError(
@@ -1954,8 +1897,7 @@ void Engine::SubscribeGlobalRebind(
 
   ValidateRebindDepSignals(dep_signals);
 
-  auto& proc_state = processes_[handle.process_id];
-  auto total_after = proc_state.subscription_count + dep_signals.size();
+  auto total_after = proc.subscription_count + dep_signals.size();
   auto global_after = live_subscription_count_ + dep_signals.size();
   if (max_total_subscriptions_ > 0 && global_after > max_total_subscriptions_) {
     TerminateWithResourceError(
@@ -1967,13 +1909,12 @@ void Engine::SubscribeGlobalRebind(
       total_after > max_subscriptions_per_process_) {
     TerminateWithResourceError(
         "per-process subscription limit exceeded (rebind batch)",
-        proc_state.subscription_count, max_subscriptions_per_process_);
+        proc.subscription_count, max_subscriptions_per_process_);
     return;
   }
 
-  auto plan_start = static_cast<uint32_t>(proc_state.plan_pool.ops.size());
-  proc_state.plan_pool.ops.insert(
-      proc_state.plan_pool.ops.end(), plan.begin(), plan.end());
+  auto plan_start = static_cast<uint32_t>(proc.plan_pool.ops.size());
+  proc.plan_pool.ops.insert(proc.plan_pool.ops.end(), plan.begin(), plan.end());
   IndexPlanRef plan_ref = {
       .start = plan_start, .count = static_cast<uint16_t>(plan.size())};
 
@@ -2023,23 +1964,16 @@ void Engine::SubscribeGlobalRebind(
     }
   }
 
-  InstallRebindDepWatchers(handle, edge_target_id, dep_signals);
+  InstallRebindDepWatchers(proc, edge_target_id, dep_signals);
   RebindSubscription(edge_target_id);
 }
 
 void Engine::SubscribeLocalRebind(
-    ProcessHandle handle, uint32_t edge_target_id, LocalSignalRef target_signal,
+    RuntimeProcess& proc, uint32_t edge_target_id, LocalSignalRef target_signal,
     SubKind target_kind, uint32_t target_index, uint8_t target_edge_group,
     EdgeBucket target_edge_bucket, std::span<const IndexPlanOp> plan,
     BitTargetMapping mapping, std::span<const SignalRef> dep_signals) {
   if (finished_) return;
-  if (handle.process_id >= num_processes_) {
-    throw common::InternalError(
-        "Engine::SubscribeLocalRebind",
-        std::format(
-            "process_id {} exceeds num_processes {}", handle.process_id,
-            num_processes_));
-  }
   if (target_kind != SubKind::kEdge && target_kind != SubKind::kContainer) {
     throw common::InternalError(
         "Engine::SubscribeLocalRebind",
@@ -2083,8 +2017,7 @@ void Engine::SubscribeLocalRebind(
 
   ValidateRebindDepSignals(dep_signals);
 
-  auto& proc_state = processes_[handle.process_id];
-  auto total_after = proc_state.subscription_count + dep_signals.size();
+  auto total_after = proc.subscription_count + dep_signals.size();
   auto global_after = live_subscription_count_ + dep_signals.size();
   if (max_total_subscriptions_ > 0 && global_after > max_total_subscriptions_) {
     TerminateWithResourceError(
@@ -2096,13 +2029,12 @@ void Engine::SubscribeLocalRebind(
       total_after > max_subscriptions_per_process_) {
     TerminateWithResourceError(
         "per-process subscription limit exceeded (rebind batch)",
-        proc_state.subscription_count, max_subscriptions_per_process_);
+        proc.subscription_count, max_subscriptions_per_process_);
     return;
   }
 
-  auto plan_start = static_cast<uint32_t>(proc_state.plan_pool.ops.size());
-  proc_state.plan_pool.ops.insert(
-      proc_state.plan_pool.ops.end(), plan.begin(), plan.end());
+  auto plan_start = static_cast<uint32_t>(proc.plan_pool.ops.size());
+  proc.plan_pool.ops.insert(proc.plan_pool.ops.end(), plan.begin(), plan.end());
   IndexPlanRef plan_ref = {
       .start = plan_start, .count = static_cast<uint16_t>(plan.size())};
 
@@ -2154,7 +2086,7 @@ void Engine::SubscribeLocalRebind(
     }
   }
 
-  InstallRebindDepWatchers(handle, edge_target_id, dep_signals);
+  InstallRebindDepWatchers(proc, edge_target_id, dep_signals);
   RebindSubscription(edge_target_id);
 }
 

--- a/src/lyra/runtime/engine_subscriptions_install.cpp
+++ b/src/lyra/runtime/engine_subscriptions_install.cpp
@@ -670,8 +670,6 @@ void Engine::InstallTriggers(RuntimeProcess& proc, const WaitRequest& req) {
   auto resume = req.resume;
   auto triggers = req.triggers;
   const auto& late_bound = req.late_bound;
-  const ProcessHandle handle{
-      .process_id = static_cast<uint32_t>(&proc - processes_.data())};
   // Track created subscription info for late-bound rebinding.
   // Invariant: created_subs[i] records the dense vector index assigned
   // to trigger i at creation time. These indices remain stable within
@@ -778,7 +776,7 @@ void Engine::InstallTriggers(RuntimeProcess& proc, const WaitRequest& req) {
         int64_t sv_index =
             initially_active ? static_cast<int64_t>(trigger.byte_offset) : -1;
         sub_idx = SubscribeContainerElement(
-            handle, resume, sig_ref, edge, sv_index,
+            proc, resume, sig_ref, edge, sv_index,
             trigger.container_elem_stride, initially_active);
         sub_kind = SubKind::kContainer;
         break;
@@ -793,10 +791,10 @@ void Engine::InstallTriggers(RuntimeProcess& proc, const WaitRequest& req) {
         }
         if (trigger.byte_size > 0) {
           sub_idx = Subscribe(
-              handle, resume, sig_ref, edge, trigger.byte_offset,
+              proc, resume, sig_ref, edge, trigger.byte_offset,
               trigger.byte_size, trigger.bit_index, initially_active);
         } else {
-          sub_idx = Subscribe(handle, resume, sig_ref, edge, initially_active);
+          sub_idx = Subscribe(proc, resume, sig_ref, edge, initially_active);
         }
         sub_kind = SubKind::kChange;
         break;
@@ -811,10 +809,10 @@ void Engine::InstallTriggers(RuntimeProcess& proc, const WaitRequest& req) {
         }
         if (trigger.byte_size > 0) {
           sub_idx = Subscribe(
-              handle, resume, sig_ref, edge, trigger.byte_offset,
+              proc, resume, sig_ref, edge, trigger.byte_offset,
               trigger.byte_size, trigger.bit_index, initially_active);
         } else {
-          sub_idx = Subscribe(handle, resume, sig_ref, edge, initially_active);
+          sub_idx = Subscribe(proc, resume, sig_ref, edge, initially_active);
         }
         sub_kind = SubKind::kEdge;
         break;
@@ -923,7 +921,7 @@ void Engine::InstallTriggers(RuntimeProcess& proc, const WaitRequest& req) {
                               .signal = LocalSignalId{target.signal_id}}}
                         : SignalRef{GlobalSignalId{target.signal_id}};
     SubscribeRebind(
-        handle, UINT32_MAX, rebind_target, target.kind, target.index,
+        proc, UINT32_MAX, rebind_target, target.kind, target.index,
         target.edge_group, target.edge_bucket, hdr_plan, mapping, dep_signals);
   }
 }
@@ -1468,9 +1466,8 @@ auto Engine::SubscribeLocalEdge(
 
 // R5: SignalRef top boundary -- dispatch once, then domain-specific internals.
 auto Engine::Subscribe(
-    ProcessHandle handle, ResumePoint resume, SignalRef signal_ref,
+    RuntimeProcess& proc, ResumePoint resume, SignalRef signal_ref,
     common::EdgeKind edge, bool initially_active) -> uint32_t {
-  auto& proc = processes_[handle.process_id];
   return std::visit(
       [&](auto sig) -> uint32_t {
         using T = std::decay_t<decltype(sig)>;
@@ -1506,10 +1503,9 @@ auto Engine::Subscribe(
 }
 
 auto Engine::Subscribe(
-    ProcessHandle handle, ResumePoint resume, SignalRef signal_ref,
+    RuntimeProcess& proc, ResumePoint resume, SignalRef signal_ref,
     common::EdgeKind edge, uint32_t byte_offset, uint32_t byte_size,
     uint8_t bit_index, bool initially_active) -> uint32_t {
-  auto& proc = processes_[handle.process_id];
   return std::visit(
       [&](auto sig) -> uint32_t {
         using T = std::decay_t<decltype(sig)>;
@@ -1535,10 +1531,9 @@ auto Engine::Subscribe(
 }
 
 auto Engine::SubscribeContainerElement(
-    ProcessHandle handle, ResumePoint resume, SignalRef signal_ref,
+    RuntimeProcess& proc, ResumePoint resume, SignalRef signal_ref,
     common::EdgeKind edge, int64_t sv_index, uint32_t elem_stride,
     bool initially_active) -> uint32_t {
-  auto& proc = processes_[handle.process_id];
   return std::visit(
       [&](auto sig) -> uint32_t {
         using T = std::decay_t<decltype(sig)>;
@@ -1749,11 +1744,10 @@ void Engine::ValidateRebindDepSignals(
 
 // R5: Thin boundary wrapper -- dispatch to domain-specific rebind.
 void Engine::SubscribeRebind(
-    ProcessHandle handle, uint32_t edge_target_id, SignalRef target_signal,
+    RuntimeProcess& proc, uint32_t edge_target_id, SignalRef target_signal,
     SubKind target_kind, uint32_t target_index, uint8_t target_edge_group,
     EdgeBucket target_edge_bucket, std::span<const IndexPlanOp> plan,
     BitTargetMapping mapping, std::span<const SignalRef> dep_signals) {
-  auto& proc = processes_[handle.process_id];
   std::visit(
       [&](const auto& target) {
         using T = std::decay_t<decltype(target)>;

--- a/src/lyra/runtime/engine_subscriptions_install.cpp
+++ b/src/lyra/runtime/engine_subscriptions_install.cpp
@@ -1022,20 +1022,6 @@ auto Engine::CanRefreshInstalledWait(
          installed.can_refresh_snapshot;
 }
 
-void Engine::RegisterSuspendRecords(std::span<SuspendRecord*> records) {
-  if (records.size() != processes_.size()) {
-    throw common::InternalError(
-        "Engine::RegisterSuspendRecords",
-        std::format(
-            "records size {} != processes_ size {}", records.size(),
-            processes_.size()));
-  }
-  for (size_t i = 0; i < records.size(); ++i) {
-    processes_[i].suspend_record = records[i];
-  }
-  suspend_records_registered_ = true;
-}
-
 auto Engine::HasPendingDirtyState() const -> bool {
   return !update_set_.DeltaDirtySlots().empty() ||
          !delta_dirty_instances_.empty();
@@ -1079,7 +1065,7 @@ void Engine::ReconcilePostActivation(RuntimeProcess& proc) {
         "Engine::ReconcilePostActivation",
         "called without post-activation reconciliation capability");
   }
-  auto* suspend = proc.suspend_record;
+  auto* suspend = static_cast<SuspendRecord*>(proc.frame_state);
 
   auto resume =
       ResumePoint{.block_index = suspend->resume_block, .instruction_index = 0};

--- a/src/lyra/runtime/engine_subscriptions_install.cpp
+++ b/src/lyra/runtime/engine_subscriptions_install.cpp
@@ -1084,8 +1084,6 @@ void Engine::ReconcilePostActivation(RuntimeProcess& proc) {
         "Engine::ReconcilePostActivation",
         "called without post-activation reconciliation capability");
   }
-  const ProcessHandle handle{
-      .process_id = static_cast<uint32_t>(&proc - processes_.data())};
   auto* suspend = proc.suspend_record;
 
   auto resume =
@@ -1098,7 +1096,7 @@ void Engine::ReconcilePostActivation(RuntimeProcess& proc) {
 
     case SuspendTag::kDelay:
       ResetInstalledWait(proc);
-      Delay(handle, resume, suspend->delay_ticks);
+      Delay(proc, resume, suspend->delay_ticks);
       break;
 
     case SuspendTag::kWait: {
@@ -1152,7 +1150,7 @@ void Engine::ReconcilePostActivation(RuntimeProcess& proc) {
 
     case SuspendTag::kRepeat:
       ResetInstalledWait(proc);
-      ScheduleNextDelta(handle, ResumePoint{.block_index = 0});
+      ScheduleNextDelta(proc, ResumePoint{.block_index = 0});
       break;
 
     case SuspendTag::kWaitEvent: {
@@ -1168,7 +1166,7 @@ void Engine::ReconcilePostActivation(RuntimeProcess& proc) {
       AddInstanceEventWaiter(
           *inst, suspend->event_id,
           EventWaiter{
-              .process_id = handle.process_id,
+              .process_id = static_cast<uint32_t>(&proc - processes_.data()),
               .instance = inst,
               .resume_block = suspend->resume_block,
           });

--- a/src/lyra/runtime/engine_subscriptions_install.cpp
+++ b/src/lyra/runtime/engine_subscriptions_install.cpp
@@ -1166,7 +1166,7 @@ void Engine::ReconcilePostActivation(RuntimeProcess& proc) {
       AddInstanceEventWaiter(
           *inst, suspend->event_id,
           EventWaiter{
-              .process_id = static_cast<uint32_t>(&proc - processes_.data()),
+              .process = &proc,
               .instance = inst,
               .resume_block = suspend->resume_block,
           });

--- a/src/lyra/runtime/engine_subscriptions_install.cpp
+++ b/src/lyra/runtime/engine_subscriptions_install.cpp
@@ -153,16 +153,14 @@ namespace {
 
 // Backpatch a moved subscription's LocalSubRef after swap-and-pop removal.
 void BackpatchMovedLocalSubRef(
-    std::vector<RuntimeProcess>& processes, uint32_t process_id,
-    uint32_t process_sub_idx, uint32_t new_index) {
-  processes[process_id].local_sub_refs[process_sub_idx].index = new_index;
+    RuntimeProcess& proc, uint32_t process_sub_idx, uint32_t new_index) {
+  proc.local_sub_refs[process_sub_idx].index = new_index;
 }
 
 // Backpatch a moved subscription's GlobalSubRef after swap-and-pop removal.
 void BackpatchMovedGlobalSubRef(
-    std::vector<RuntimeProcess>& processes, uint32_t process_id,
-    uint32_t process_sub_idx, uint32_t new_index) {
-  processes[process_id].global_sub_refs[process_sub_idx].index = new_index;
+    RuntimeProcess& proc, uint32_t process_sub_idx, uint32_t new_index) {
+  proc.global_sub_refs[process_sub_idx].index = new_index;
 }
 
 }  // namespace
@@ -250,8 +248,7 @@ void RemoveEdgeSubCore(
     vec[index] = vec[last];
     auto& moved = vec[index];
     backpatch(
-        moved.process_id, moved.process_sub_idx, index, edge_group,
-        edge_bucket);
+        *moved.process, moved.process_sub_idx, index, edge_group, edge_bucket);
     if (moved.cold_idx != UINT32_MAX) {
       auto& moved_cold = edge_cold_pool[moved.cold_idx];
       if (moved_cold.edge_target_id != UINT32_MAX) {
@@ -274,10 +271,9 @@ void Engine::RemoveLocalEdgeSub(const LocalSubRef& ref) {
       subs, ref.edge_group, ref.edge_bucket, ref.index, edge_cold_pool_,
       local_edge_target_table_, global_edge_target_table_, free_target,
       free_cold,
-      [this](
-          uint32_t pid, uint32_t psi, uint32_t new_idx, uint32_t grp,
-          EdgeBucket bkt) {
-        auto& mr = processes_[pid].local_sub_refs[psi];
+      [](RuntimeProcess& proc, uint32_t psi, uint32_t new_idx, uint32_t grp,
+         EdgeBucket bkt) {
+        auto& mr = proc.local_sub_refs[psi];
         mr.index = new_idx;
         mr.edge_group = grp;
         mr.edge_bucket = bkt;
@@ -293,10 +289,9 @@ void Engine::RemoveGlobalEdgeSub(const GlobalSubRef& ref) {
       subs, ref.edge_group, ref.edge_bucket, ref.index, edge_cold_pool_,
       local_edge_target_table_, global_edge_target_table_, free_target,
       free_cold,
-      [this](
-          uint32_t pid, uint32_t psi, uint32_t new_idx, uint32_t grp,
-          EdgeBucket bkt) {
-        auto& mr = processes_[pid].global_sub_refs[psi];
+      [](RuntimeProcess& proc, uint32_t psi, uint32_t new_idx, uint32_t grp,
+         EdgeBucket bkt) {
+        auto& mr = proc.global_sub_refs[psi];
         mr.index = new_idx;
         mr.edge_group = grp;
         mr.edge_bucket = bkt;
@@ -314,7 +309,7 @@ void Engine::RemoveLocalChangeSub(const LocalSubRef& ref) {
   if (index != last) {
     vec[index] = vec[last];
     BackpatchMovedLocalSubRef(
-        processes_, vec[index].process_id, vec[index].process_sub_idx, index);
+        *vec[index].process, vec[index].process_sub_idx, index);
   }
   vec.pop_back();
   UpdateLocalObserverFlag(*ref.instance, ref.signal);
@@ -330,7 +325,7 @@ void Engine::RemoveGlobalChangeSub(const GlobalSubRef& ref) {
   if (index != last) {
     vec[index] = vec[last];
     BackpatchMovedGlobalSubRef(
-        processes_, vec[index].process_id, vec[index].process_sub_idx, index);
+        *vec[index].process, vec[index].process_sub_idx, index);
   }
   vec.pop_back();
   UpdateGlobalObserverFlag(ref.signal);
@@ -346,7 +341,7 @@ void Engine::RemoveLocalRebindWatcherSub(const LocalSubRef& ref) {
   if (index != last) {
     vec[index] = vec[last];
     BackpatchMovedLocalSubRef(
-        processes_, vec[index].process_id, vec[index].process_sub_idx, index);
+        *vec[index].process, vec[index].process_sub_idx, index);
   }
   vec.pop_back();
   UpdateLocalObserverFlag(*ref.instance, ref.signal);
@@ -362,7 +357,7 @@ void Engine::RemoveGlobalRebindWatcherSub(const GlobalSubRef& ref) {
   if (index != last) {
     vec[index] = vec[last];
     BackpatchMovedGlobalSubRef(
-        processes_, vec[index].process_id, vec[index].process_sub_idx, index);
+        *vec[index].process, vec[index].process_sub_idx, index);
   }
   vec.pop_back();
   UpdateGlobalObserverFlag(ref.signal);
@@ -382,7 +377,7 @@ void Engine::RemoveLocalContainerSub(const LocalSubRef& ref) {
   if (index != last) {
     vec[index] = vec[last];
     BackpatchMovedLocalSubRef(
-        processes_, vec[index].process_id, vec[index].process_sub_idx, index);
+        *vec[index].process, vec[index].process_sub_idx, index);
     if (vec[index].cold_idx != UINT32_MAX) {
       auto& moved_cold = container_cold_pool_[vec[index].cold_idx];
       if (moved_cold.edge_target_id != UINT32_MAX) {
@@ -410,7 +405,7 @@ void Engine::RemoveGlobalContainerSub(const GlobalSubRef& ref) {
   if (index != last) {
     vec[index] = vec[last];
     BackpatchMovedGlobalSubRef(
-        processes_, vec[index].process_id, vec[index].process_sub_idx, index);
+        *vec[index].process, vec[index].process_sub_idx, index);
     if (vec[index].cold_idx != UINT32_MAX) {
       auto& moved_cold = container_cold_pool_[vec[index].cold_idx];
       if (moved_cold.edge_target_id != UINT32_MAX) {
@@ -1240,7 +1235,7 @@ auto Engine::SubscribeGlobalChange(
   auto proc_sub_idx = static_cast<uint32_t>(proc.global_sub_refs.size());
 
   ChangeSub sub{};
-  sub.process_id = static_cast<uint32_t>(&proc - processes_.data());
+  sub.process = &proc;
   sub.resume_block = resume.block_index;
   sub.byte_offset = byte_offset;
   sub.byte_size = byte_size;
@@ -1295,7 +1290,7 @@ auto Engine::SubscribeLocalChange(
   auto proc_sub_idx = static_cast<uint32_t>(proc.local_sub_refs.size());
 
   ChangeSub sub{};
-  sub.process_id = static_cast<uint32_t>(&proc - processes_.data());
+  sub.process = &proc;
   sub.resume_block = resume.block_index;
   sub.byte_offset = byte_offset;
   sub.byte_size = byte_size;
@@ -1377,7 +1372,7 @@ auto Engine::SubscribeGlobalEdge(
   auto sub_idx = static_cast<uint32_t>(target_vec.size());
 
   EdgeSub sub{};
-  sub.process_id = static_cast<uint32_t>(&proc - processes_.data());
+  sub.process = &proc;
   sub.resume_block = resume.block_index;
   sub.flags = initially_active ? kSubActive : 0;
   sub.process_sub_idx = proc_sub_idx;
@@ -1441,7 +1436,7 @@ auto Engine::SubscribeLocalEdge(
   auto sub_idx = static_cast<uint32_t>(target_vec.size());
 
   EdgeSub sub{};
-  sub.process_id = static_cast<uint32_t>(&proc - processes_.data());
+  sub.process = &proc;
   sub.resume_block = resume.block_index;
   sub.flags = initially_active ? kSubActive : 0;
   sub.process_sub_idx = proc_sub_idx;
@@ -1616,7 +1611,7 @@ auto Engine::SubscribeGlobalContainerElement(
   uint32_t cold_idx = AllocContainerCold();
 
   ContainerSub sub{};
-  sub.process_id = static_cast<uint32_t>(&proc - processes_.data());
+  sub.process = &proc;
   sub.resume_block = resume.block_index;
   sub.process_sub_idx = proc_sub_idx;
   sub.cold_idx = cold_idx;
@@ -1662,7 +1657,7 @@ auto Engine::SubscribeLocalContainerElement(
   uint32_t cold_idx = AllocContainerCold();
 
   ContainerSub sub{};
-  sub.process_id = static_cast<uint32_t>(&proc - processes_.data());
+  sub.process = &proc;
   sub.resume_block = resume.block_index;
   sub.process_sub_idx = proc_sub_idx;
   sub.cold_idx = cold_idx;
@@ -1802,7 +1797,7 @@ void Engine::InstallRebindDepWatchers(
           std::memcpy(wcold.snapshot.data(), dep_base, dep_total_bytes);
 
           RebindWatcherSub watcher{};
-          watcher.process_id = static_cast<uint32_t>(&proc - processes_.data());
+          watcher.process = &proc;
           watcher.byte_offset = 0;
           watcher.byte_size = dep_total_bytes;
           watcher.cold_idx = watcher_cold;

--- a/src/lyra/runtime/process_envelope.cpp
+++ b/src/lyra/runtime/process_envelope.cpp
@@ -270,11 +270,12 @@ void HandleProcessRequest(
               Access::GetProcess(engine, handle), v.resume);
 
         } else if constexpr (std::is_same_v<T, EventWaitRequest>) {
+          auto& proc = Access::GetProcess(engine, handle);
           auto& inst = engine.GetProcessInstance(handle.process_id);
           Engine::AddInstanceEventWaiter(
               inst, v.event_id,
               EventWaiter{
-                  .process_id = handle.process_id,
+                  .process = &proc,
                   .instance = &inst,
                   .resume_block = v.resume.block_index,
               });

--- a/src/lyra/runtime/process_envelope.cpp
+++ b/src/lyra/runtime/process_envelope.cpp
@@ -212,9 +212,10 @@ void HandleWaitRequest(
             handle.process_id));
   }
 
-  if (!Access::CanRefreshInstalledWait(engine, handle, req.wait_site_id)) {
-    Access::ResetInstalledWait(engine, handle);
-    Access::InstallWaitSite(engine, handle, req);
+  auto& proc = Access::GetProcess(engine, handle);
+  if (!Access::CanRefreshInstalledWait(proc, req.wait_site_id)) {
+    Access::ResetInstalledWait(engine, proc);
+    Access::InstallWaitSite(engine, proc, req);
     return;
   }
 
@@ -222,9 +223,9 @@ void HandleWaitRequest(
     return;
   }
 
-  if (Access::RefreshInstalledSnapshots(engine, handle)) {
-    Access::ResetInstalledWait(engine, handle);
-    Access::InstallWaitSite(engine, handle, req);
+  if (Access::RefreshInstalledSnapshots(engine, proc)) {
+    Access::ResetInstalledWait(engine, proc);
+    Access::InstallWaitSite(engine, proc, req);
   }
 }
 
@@ -245,7 +246,7 @@ void HandleProcessRequest(
   if (Access::UsesWaitSiteLifecycle(engine) &&
       !Access::HasPostActivationReconciliation(engine) &&
       NeedsWaitReset(request)) {
-    Access::ResetInstalledWait(engine, handle);
+    Access::ResetInstalledWait(engine, Access::GetProcess(engine, handle));
   }
 
   std::visit(

--- a/src/lyra/runtime/process_envelope.cpp
+++ b/src/lyra/runtime/process_envelope.cpp
@@ -260,13 +260,14 @@ void HandleProcessRequest(
           engine.HandleTrap(Access::GetProcess(engine, handle), v.payload);
 
         } else if constexpr (std::is_same_v<T, DelayRequest>) {
-          engine.Delay(handle, v.resume, v.ticks);
+          engine.Delay(Access::GetProcess(engine, handle), v.resume, v.ticks);
 
         } else if constexpr (std::is_same_v<T, WaitRequest>) {
           HandleWaitRequest(engine, handle, v);
 
         } else if constexpr (std::is_same_v<T, RepeatRequest>) {
-          engine.ScheduleNextDelta(handle, v.resume);
+          engine.ScheduleNextDelta(
+              Access::GetProcess(engine, handle), v.resume);
 
         } else if constexpr (std::is_same_v<T, EventWaitRequest>) {
           auto& inst = engine.GetProcessInstance(handle.process_id);

--- a/src/lyra/runtime/process_envelope.cpp
+++ b/src/lyra/runtime/process_envelope.cpp
@@ -139,16 +139,15 @@ auto DecodeSuspendRecord(lyra::runtime::SuspendRecord* suspend)
 
 // Dispatch a process body and decode the raw protocol into a ProcessRequest.
 auto DispatchProcess(
-    std::span<void*> states, lyra::runtime::ProcessHandle handle,
-    lyra::runtime::ResumePoint resume) -> ProcessRequest {
+    lyra::runtime::RuntimeProcess& proc, lyra::runtime::ResumePoint resume)
+    -> ProcessRequest {
   using lyra::runtime::ProcessExitCode;
   using lyra::runtime::ProcessOutcome;
   using lyra::runtime::SuspendRecord;
   using lyra::runtime::SuspendTag;
   using lyra::runtime::TrapReason;
 
-  uint32_t proc_idx = handle.process_id;
-  void* state = states[proc_idx];
+  void* state = proc.frame_state;
   auto* suspend = static_cast<SuspendRecord*>(state);
 
   if (resume.block_index != 0 && suspend->tag == SuspendTag::kWait &&
@@ -191,7 +190,7 @@ auto DispatchProcess(
 // Envelope-owned wait lifecycle orchestration. Decides whether to do a
 // direct trigger install, a full wait-site install, or an in-place refresh.
 void HandleWaitRequest(
-    lyra::runtime::Engine& engine, lyra::runtime::ProcessHandle handle,
+    lyra::runtime::Engine& engine, lyra::runtime::RuntimeProcess& proc,
     const lyra::runtime::WaitRequest& req) {
   // When post-activation reconciliation is active, the engine handles
   // wait lifecycle after the activation returns. The envelope must not
@@ -199,7 +198,6 @@ void HandleWaitRequest(
   if (Access::HasPostActivationReconciliation(engine)) {
     return;
   }
-  auto& proc = Access::GetProcess(engine, handle);
   if (!Access::UsesWaitSiteLifecycle(engine)) {
     Access::InstallTriggers(engine, proc, req);
     return;
@@ -209,8 +207,8 @@ void HandleWaitRequest(
     throw lyra::common::InternalError(
         "HandleWaitRequest",
         std::format(
-            "process {} suspended with kWait but wait_site_id is invalid",
-            handle.process_id));
+            "{} suspended with kWait but wait_site_id is invalid",
+            engine.FormatProcess(proc)));
   }
 
   if (!Access::CanRefreshInstalledWait(proc, req.wait_site_id)) {
@@ -231,7 +229,7 @@ void HandleWaitRequest(
 
 // Handle the decoded process request by calling narrow engine primitives.
 void HandleProcessRequest(
-    lyra::runtime::Engine& engine, lyra::runtime::ProcessHandle handle,
+    lyra::runtime::Engine& engine, lyra::runtime::RuntimeProcess& proc,
     const ProcessRequest& request) {
   using lyra::runtime::DelayRequest;
   using lyra::runtime::Engine;
@@ -246,7 +244,7 @@ void HandleProcessRequest(
   if (Access::UsesWaitSiteLifecycle(engine) &&
       !Access::HasPostActivationReconciliation(engine) &&
       NeedsWaitReset(request)) {
-    Access::ResetInstalledWait(engine, Access::GetProcess(engine, handle));
+    Access::ResetInstalledWait(engine, proc);
   }
 
   std::visit(
@@ -257,26 +255,30 @@ void HandleProcessRequest(
           // No scheduling action needed.
 
         } else if constexpr (std::is_same_v<T, TrapRequest>) {
-          engine.HandleTrap(Access::GetProcess(engine, handle), v.payload);
+          engine.HandleTrap(proc, v.payload);
 
         } else if constexpr (std::is_same_v<T, DelayRequest>) {
-          engine.Delay(Access::GetProcess(engine, handle), v.resume, v.ticks);
+          engine.Delay(proc, v.resume, v.ticks);
 
         } else if constexpr (std::is_same_v<T, WaitRequest>) {
-          HandleWaitRequest(engine, handle, v);
+          HandleWaitRequest(engine, proc, v);
 
         } else if constexpr (std::is_same_v<T, RepeatRequest>) {
-          engine.ScheduleNextDelta(
-              Access::GetProcess(engine, handle), v.resume);
+          engine.ScheduleNextDelta(proc, v.resume);
 
         } else if constexpr (std::is_same_v<T, EventWaitRequest>) {
-          auto& proc = Access::GetProcess(engine, handle);
-          auto& inst = engine.GetProcessInstance(handle.process_id);
+          if (proc.instance == nullptr) {
+            throw lyra::common::InternalError(
+                "HandleProcessRequest",
+                std::format(
+                    "EventWaitRequest for {} has no owning instance",
+                    engine.FormatProcess(proc)));
+          }
           Engine::AddInstanceEventWaiter(
-              inst, v.event_id,
+              *proc.instance, v.event_id,
               EventWaiter{
                   .process = &proc,
-                  .instance = &inst,
+                  .instance = proc.instance,
                   .resume_block = v.resume.block_index,
               });
         }
@@ -289,10 +291,9 @@ void HandleProcessRequest(
 namespace lyra::runtime {
 
 void DispatchAndHandleActivation(
-    std::span<void*> states, Engine& engine, ProcessHandle handle,
-    ResumePoint resume) {
-  auto request = DispatchProcess(states, handle, resume);
-  HandleProcessRequest(engine, handle, request);
+    Engine& engine, RuntimeProcess& proc, ResumePoint resume) {
+  auto request = DispatchProcess(proc, resume);
+  HandleProcessRequest(engine, proc, request);
 }
 
 }  // namespace lyra::runtime

--- a/src/lyra/runtime/process_envelope.cpp
+++ b/src/lyra/runtime/process_envelope.cpp
@@ -10,6 +10,7 @@
 #include "lyra/common/diagnostic/print.hpp"
 #include "lyra/common/internal_error.hpp"
 #include "lyra/runtime/dpi_export_context.hpp"
+#include "lyra/runtime/engine.hpp"
 #include "lyra/runtime/engine_process_envelope_access.hpp"
 #include "lyra/runtime/instance_event_state.hpp"
 #include "lyra/runtime/iteration_limit.hpp"
@@ -151,8 +152,8 @@ auto DecodeSuspendRecord(lyra::runtime::SuspendRecord* suspend)
 
 // Dispatch a process body and decode the raw protocol into a ProcessRequest.
 auto DispatchProcess(
-    lyra::runtime::RuntimeProcess& proc, lyra::runtime::ResumePoint resume)
-    -> ProcessRequest {
+    lyra::runtime::Engine& engine, lyra::runtime::RuntimeProcess& proc,
+    uint32_t process_id, lyra::runtime::ResumePoint resume) -> ProcessRequest {
   using lyra::runtime::ProcessExitCode;
   using lyra::runtime::ProcessOutcome;
   using lyra::runtime::SuspendTag;
@@ -168,14 +169,17 @@ auto DispatchProcess(
     SuspendReset(suspend);
   }
 
-  ProcessOutcome outcome{};
-  outcome.tag = UINT32_MAX;
+  if (proc.body == nullptr) {
+    throw lyra::common::InternalError(
+        "DispatchProcess", "RuntimeProcess has null body function");
+  }
 
-  // Uniform shared-body dispatch for all processes.
   auto* header = static_cast<StateHeader*>(state);
   header->outcome.tag = UINT32_MAX;
-  header->body(state, resume.block_index);
-  outcome = header->outcome;
+  proc.body(
+      state, resume.block_index, &engine, engine.GetDesignStateBase(),
+      proc.instance, process_id);
+  ProcessOutcome outcome = header->outcome;
 
   switch (static_cast<ProcessExitCode>(outcome.tag)) {
     case ProcessExitCode::kOk:
@@ -302,8 +306,9 @@ void HandleProcessRequest(
 namespace lyra::runtime {
 
 void DispatchAndHandleActivation(
-    Engine& engine, RuntimeProcess& proc, ResumePoint resume) {
-  auto request = DispatchProcess(proc, resume);
+    Engine& engine, RuntimeProcess& proc, uint32_t process_id,
+    ResumePoint resume) {
+  auto request = DispatchProcess(engine, proc, process_id, resume);
   HandleProcessRequest(engine, proc, request);
 }
 
@@ -439,7 +444,8 @@ extern "C" void LyraSuspendWaitEvent(
   suspend->event_id = event_id;
 }
 
-extern "C" void LyraRunProcessSync(LyraProcessFunc process, void* state) {
+extern "C" void LyraRunProcessSync(
+    LyraProcessFunc process, void* state, void* design_state) {
   constexpr uint32_t kEntryBlock = 0;
 
   auto* suspend = static_cast<lyra::runtime::SuspendRecord*>(state);
@@ -449,7 +455,7 @@ extern "C" void LyraRunProcessSync(LyraProcessFunc process, void* state) {
 
   lyra::runtime::ProcessOutcome outcome{};
   outcome.tag = UINT32_MAX;
-  process(state, kEntryBlock, &outcome);
+  process(state, kEntryBlock, design_state, &outcome);
 
   switch (static_cast<lyra::runtime::ProcessExitCode>(outcome.tag)) {
     case lyra::runtime::ProcessExitCode::kOk:

--- a/src/lyra/runtime/process_envelope.cpp
+++ b/src/lyra/runtime/process_envelope.cpp
@@ -52,6 +52,18 @@ void FailIfSuspensionDisallowed(const char* api) {
   }
 }
 
+// Single runtime accessor for the SuspendRecord backing a process. The
+// process's frame_state points to the frame whose first object is a
+// SuspendRecord; this is the one live source of suspend state.
+auto GetSuspendRecord(lyra::runtime::RuntimeProcess& proc)
+    -> lyra::runtime::SuspendRecord* {
+  if (proc.frame_state == nullptr) {
+    throw lyra::common::InternalError(
+        "GetSuspendRecord", "RuntimeProcess has null frame_state");
+  }
+  return static_cast<lyra::runtime::SuspendRecord*>(proc.frame_state);
+}
+
 // Envelope-internal process request variant. Never exposed publicly.
 struct CompletedRequest {};
 struct TrapRequest {
@@ -143,12 +155,11 @@ auto DispatchProcess(
     -> ProcessRequest {
   using lyra::runtime::ProcessExitCode;
   using lyra::runtime::ProcessOutcome;
-  using lyra::runtime::SuspendRecord;
   using lyra::runtime::SuspendTag;
   using lyra::runtime::TrapReason;
 
+  auto* suspend = GetSuspendRecord(proc);
   void* state = proc.frame_state;
-  auto* suspend = static_cast<SuspendRecord*>(state);
 
   if (resume.block_index != 0 && suspend->tag == SuspendTag::kWait &&
       suspend->triggers_ptr == suspend->inline_triggers.data()) {

--- a/src/lyra/runtime/process_envelope.cpp
+++ b/src/lyra/runtime/process_envelope.cpp
@@ -199,8 +199,9 @@ void HandleWaitRequest(
   if (Access::HasPostActivationReconciliation(engine)) {
     return;
   }
+  auto& proc = Access::GetProcess(engine, handle);
   if (!Access::UsesWaitSiteLifecycle(engine)) {
-    Access::InstallTriggers(engine, handle, req);
+    Access::InstallTriggers(engine, proc, req);
     return;
   }
 
@@ -212,7 +213,6 @@ void HandleWaitRequest(
             handle.process_id));
   }
 
-  auto& proc = Access::GetProcess(engine, handle);
   if (!Access::CanRefreshInstalledWait(proc, req.wait_site_id)) {
     Access::ResetInstalledWait(engine, proc);
     Access::InstallWaitSite(engine, proc, req);

--- a/src/lyra/runtime/process_envelope.cpp
+++ b/src/lyra/runtime/process_envelope.cpp
@@ -256,7 +256,7 @@ void HandleProcessRequest(
           // No scheduling action needed.
 
         } else if constexpr (std::is_same_v<T, TrapRequest>) {
-          engine.HandleTrap(handle.process_id, v.payload);
+          engine.HandleTrap(Access::GetProcess(engine, handle), v.payload);
 
         } else if constexpr (std::is_same_v<T, DelayRequest>) {
           engine.Delay(handle, v.resume, v.ticks);

--- a/src/lyra/runtime/process_trigger_registry.cpp
+++ b/src/lyra/runtime/process_trigger_registry.cpp
@@ -166,7 +166,7 @@ void Engine::InitProcessTriggerRegistry(
   // Relocate body-local trigger entries to dense coordination coordinates.
   // Body-local entries carry kFlagBodyLocal in the word table. Re-read
   // the flags from the word table to apply instance-based relocation.
-  auto proc_states = std::span(states, num_processes_);
+  (void)states;
   if (!words.empty()) {
     uint32_t num_entries = words[0];
     for (uint32_t i = 0; i < num_entries && i < descriptors.size(); ++i) {
@@ -188,9 +188,8 @@ void Engine::InitProcessTriggerRegistry(
                   "body-local trigger entry {} targets invalid process {}", i,
                   proc_idx));
         }
-        const auto* header =
-            static_cast<const ProcessFrameHeader*>(proc_states[proc_idx]);
-        if (header == nullptr || header->instance == nullptr) {
+        auto* owner = processes_[proc_idx].instance;
+        if (owner == nullptr) {
           throw common::InternalError(
               "InitProcessTriggerRegistry",
               std::format(
@@ -200,16 +199,15 @@ void Engine::InitProcessTriggerRegistry(
         }
         // Keep body-local slot_id as LocalSignalId, populate owning
         // instance pointer for typed subscription install.
-        descriptors[i].instance = header->instance;
-        if (descriptors[i].slot_id >=
-            header->instance->observability.local_signal_count) {
+        descriptors[i].instance = owner;
+        if (descriptors[i].slot_id >= owner->observability.local_signal_count) {
           throw common::InternalError(
               "InitProcessTriggerRegistry",
               std::format(
                   "body-local slot_id {} exceeds local_signal_count {} "
                   "in entry {}",
                   descriptors[i].slot_id,
-                  header->instance->observability.local_signal_count, i));
+                  owner->observability.local_signal_count, i));
         }
       }
     }

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -100,6 +100,10 @@ auto SetupAndRunSimulation(
     header->engine_ptr = &engine;
   }
 
+  // Bind RuntimeProcess -> frame state back-pointer once per simulation,
+  // covering both connection and module processes uniformly.
+  engine.RegisterFrameStates(states);
+
   // Set design state base for flush-based trace snapshots.
   // Codegen invariant: all process states share the same DesignState pointer.
   if (!states.empty()) {

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -27,7 +27,6 @@
 #include "lyra/runtime/iteration_limit.hpp"
 #include "lyra/runtime/nba_stats_hook.hpp"
 #include "lyra/runtime/output_sink.hpp"
-#include "lyra/runtime/process_frame.hpp"
 #include "lyra/runtime/process_meta.hpp"
 #include "lyra/runtime/reporting.hpp"
 #include "lyra/runtime/runtime_instance.hpp"
@@ -39,10 +38,6 @@
 #include "lyra/trace/text_trace_sink.hpp"
 
 namespace {
-
-// Process state header layout. Must match ProcessFrameHeader in
-// process_frame.hpp and the LLVM struct emitted by BuildHeaderType.
-using StateHeader = lyra::runtime::ProcessFrameHeader;
 
 auto FinalTime() -> uint64_t& {
   static uint64_t value = 0;
@@ -80,37 +75,16 @@ namespace {
 
 auto SetupAndRunSimulation(
     lyra::runtime::Engine& engine, std::span<void*> states,
-    uint32_t num_processes,
+    uint32_t num_processes, void* design_state_base,
     const lyra::runtime::ConstructionResult* construction_result) -> uint64_t {
-  // Store engine pointer in each process state header
-  for (auto* state : states) {
-    auto* header = static_cast<StateHeader*>(state);
-    header->engine_ptr = &engine;
-  }
-
   // Bind RuntimeProcess -> frame state back-pointer once per simulation,
   // covering both connection and module processes uniformly.
   engine.RegisterFrameStates(states);
 
-  // Set design state base for flush-based trace snapshots.
-  // Codegen invariant: all process states share the same DesignState pointer.
-  if (!states.empty()) {
-    const auto* first_header = static_cast<const StateHeader*>(states[0]);
-    void* design_base = first_header->design_ptr;
-
-    for (size_t i = 1; i < states.size(); ++i) {
-      const auto* header = static_cast<const StateHeader*>(states[i]);
-      if (header->design_ptr != design_base) {
-        throw lyra::common::InternalError(
-            "SetupAndRunSimulation",
-            std::format(
-                "design_ptr mismatch: states[0]={} vs states[{}]={}",
-                design_base, i, header->design_ptr));
-      }
-    }
-
-    engine.SetDesignStateBase(design_base);
-  }
+  // Engine-owned design state base pointer. The design state is a single
+  // allocation external to the process backing objects; process bodies
+  // receive it as an explicit argument at dispatch time.
+  engine.SetDesignStateBase(design_state_base);
 
   for (uint32_t i = 0; i < num_processes; ++i) {
     engine.ScheduleInitial(engine.GetProcess(i));
@@ -367,8 +341,8 @@ extern "C" void LyraRunSimulation(
   const auto* construction_result =
       static_cast<const lyra::runtime::ConstructionResult*>(
           abi->construction_result);
-  FinalTime() =
-      SetupAndRunSimulation(engine, states, num_processes, construction_result);
+  FinalTime() = SetupAndRunSimulation(
+      engine, states, num_processes, abi->design_state, construction_result);
 
   if (HasFlag(flags, FeatureFlag::kEnableTraceSummary)) {
     engine.GetTraceManager().PrintSummary(engine.Output());

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -125,7 +125,7 @@ auto SetupAndRunSimulation(
   }
 
   for (uint32_t i = 0; i < num_processes; ++i) {
-    engine.ScheduleInitial(lyra::runtime::ProcessHandle{.process_id = i});
+    engine.ScheduleInitial(engine.GetProcess(i));
   }
 
   // Load installable computations from the construction result handed in

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -27,7 +27,6 @@
 #include "lyra/runtime/iteration_limit.hpp"
 #include "lyra/runtime/nba_stats_hook.hpp"
 #include "lyra/runtime/output_sink.hpp"
-#include "lyra/runtime/process_envelope.hpp"
 #include "lyra/runtime/process_frame.hpp"
 #include "lyra/runtime/process_meta.hpp"
 #include "lyra/runtime/reporting.hpp"
@@ -78,17 +77,6 @@ extern "C" void LyraTriggerEvent(
 }
 
 namespace {
-
-struct ProcessDispatchContext {
-  std::span<void*> states;
-};
-
-void DescriptorProcessDispatch(
-    void* ctx, lyra::runtime::Engine& eng, lyra::runtime::ProcessHandle handle,
-    lyra::runtime::ResumePoint resume) {
-  auto* dctx = static_cast<ProcessDispatchContext*>(ctx);
-  lyra::runtime::DispatchAndHandleActivation(dctx->states, eng, handle, resume);
-}
 
 auto SetupAndRunSimulation(
     lyra::runtime::Engine& engine, std::span<void*> states,
@@ -192,13 +180,8 @@ extern "C" void LyraRunSimulation(
     throw lyra::common::InternalError("LyraRunSimulation", "abi is null");
   }
 
-  ProcessDispatchContext dispatch_ctx{
-      .states = states,
-  };
   auto* session = static_cast<lyra::runtime::RunSession*>(run_session_ptr);
   lyra::runtime::Engine engine(
-      lyra::runtime::ProcessDispatch{
-          .fn = DescriptorProcessDispatch, .ctx = &dispatch_ctx},
       session->output, num_processes, std::span(plusargs_vec), feature_flags);
 
   if (abi != nullptr) {


### PR DESCRIPTION
## Summary

Reshape the runtime-process seam from an ID-keyed, table-lookup model into an object-owned model. `RuntimeProcess` now owns the per-process state that previously lived in parallel engine-side vectors (wake stats, wake trace, deferred-assertion state, body pointer, frame back-pointer). Engine helpers, wait-lifecycle helpers, subscription/install paths, the scheduler's `WakeupEntry`, `EventWaiter`, and all four subscription carriers take or store `RuntimeProcess&`/`RuntimeProcess*` instead of a bare `uint32_t` process id. `ProcessHandle` as a dispatch indirection is gone, and the shared-body ABI prefix (`ProcessFrameHeader`) shrinks from seven fields to just `{suspend, outcome}` with engine/design/instance threaded as explicit body arguments instead.

## Design

The prior shape was hybrid: a `process_id` would flow through helpers and carriers, then each layer would go back to an engine-owned table (`processes_[id]`, `per_process_stats_`, `wake_trace_`, `deferred_assertion_states_`, the suspend-record vector) to recover what it needed. That double-hop is the symptom of an identity-first model in a place where an object-first model fits: every one of those lookups resolved to the same `RuntimeProcess`, and each extra table was one more thing to keep in sync with process lifetime.

This PR inverts it. The process is the object; the id is only a dense index for iteration and boundary APIs. Three forces drove the series:

- **Put state next to identity.** Moving wake stats, wake trace, deferred-assertion state, the shared body pointer, and the frame back-pointer onto `RuntimeProcess` removes four engine-side vectors and the need to cross-reference them. The `RegisterFrameStates` batch initializer wires the `frame_state` back-pointer once at setup, which is what lets later commits reach `SuspendRecord` through the process (not through a parallel `suspend_record` field) and delete the orphaned registration path.
- **Thread the object, not the id.** `InstallTriggers`, the `Subscribe*` family, `InstallWaitSite`, the wait-lifecycle helpers, `HandleTrap`, `TryFastReconcile`, `ReconcilePostActivation`, and `FormatProcess` all take `RuntimeProcess&`. Subscription carriers, `WakeupEntry`, and `EventWaiter` store `RuntimeProcess*` directly. The `processes_[id]` indexing that used to appear inside each helper is gone, and so are the local `ProcessHandle` reconstructions the old call sites needed to bridge back to object semantics.
- **Collapse dispatch indirection.** `ProcessHandle` existed only to route activation through a dispatch ABI; with `RuntimeProcess&` available end-to-end, `DispatchAndHandleActivation` is called directly and the handle/ABI pair is deleted. That makes the shrunk `ProcessFrameHeader` coherent: the body no longer needs engine/design/instance/body/process_id embedded in the frame, because the envelope passes them as explicit arguments and the body itself lives on `RuntimeProcess`.

### What didn't change

The dense `uint32_t` process index is still the canonical iteration key and still appears at well-defined boundaries (`Engine::GetProcess(uint32_t)`, scheduler fairness counters, descriptor-emitted identities). The point isn't to erase ids, it's to stop using them as the *carrier* between subsystems that already have an object to point at. Identity domains (`DecisionOwnerId`, process index, instance index) and the compile-side realization pipeline are untouched.

Two small housekeeping commits are bundled because they sit on the same files: dropping the unused `CuFacts` from static decision lowering, and removing a dead `ConstructionInput*` parameter from the spec session. They are behavior-preserving and do not introduce new surface.

## Testing

- `bazel test //tests:jit_dev_tests --test_output=errors`