### PR TITLE
Unify filesystem-root contract across all backends

### DIFF
--- a/docs/execution-modes.md
+++ b/docs/execution-modes.md
@@ -27,10 +27,10 @@ MIR -> LLVM IR -> ORC JIT -> in-memory execution
 Both AOT and JIT consume compiled specialization artifacts. The codegen shape
 contract (init patterns, process functions, runtime calls) is identical across
 modes. LLVM compilation is per-specialization; realization produces the design-level
-tables. The only mode difference is `MainAbi`:
+tables. The only mode difference is `MainAbi`, which governs plusargs transport
+only. Filesystem-root semantics are identical across modes:
 
-- `kArgvForwarding` (AOT): `main(argc, argv)` forwards CLI args as plusargs,
-  resolves fs_base_dir from executable directory
+- `kArgvForwarding` (AOT): `main(argc, argv)` forwards `argv[1..]` as plusargs
 - `kEmbeddedPlusargs` (JIT): `main()` with plusargs baked into IR as global
   string constants
 
@@ -77,11 +77,30 @@ The Lyra runtime archive is linked into the binary by normal archive linking,
 so no shared library or rpath is needed. The binary still dynamically links
 libc, libstdc++, libm, and libpthread.
 
-fs_base_dir resolution for file I/O (`$readmemh`, etc.):
+## Filesystem root for runtime file I/O
 
-1. `LYRA_FS_BASE_DIR` env var (internal, set by `lyra run` for temp dirs)
-2. Directory of the executable (dirname of `argv[0]`)
-3. Current working directory (fallback)
+Relative runtime filesystem operations (`$fopen`, `$readmem*`, `$writemem*`,
+`--trace-signals=FILE`) resolve against an explicit filesystem root. There
+are two distinct launch modes:
+
+**Driver-controlled execution** -- `lyra run --backend=jit|aot|lli`:
+
+- **Project mode:** `fs_root = <directory containing lyra.toml>`.
+- **`--no-project` mode:** `fs_root = effective CWD after -C`.
+
+All backends consume the same driver-selected value. For JIT, the value is
+embedded in the IR. For AOT/LLI children, the driver passes the value to
+the child process through an explicit internal argv token, which the
+emitted `main` consumes before constructing the plusargs array.
+
+**Direct-run of a compiled binary** -- the user runs a `lyra compile`
+artifact directly, outside the Lyra driver:
+
+- `fs_root = launch-time CWD`.
+
+The emitted binary does not preserve any compile-time project root. There
+is no environment-variable, `argv[0]`, or executable-directory heuristic
+in either mode.
 
 ## JIT future directions
 

--- a/include/lyra/llvm_backend/context.hpp
+++ b/include/lyra/llvm_backend/context.hpp
@@ -311,7 +311,7 @@ class Context {
   [[nodiscard]] auto GetLyraTerminate() -> llvm::Function*;
   [[nodiscard]] auto GetLyraGetTime() -> llvm::Function*;
   [[nodiscard]] auto GetLyraInitRuntime() -> llvm::Function*;
-  [[nodiscard]] auto GetLyraResolveBaseDir() -> llvm::Function*;
+  [[nodiscard]] auto GetLyraLaunchParseArgs() -> llvm::Function*;
   [[nodiscard]] auto GetLyraReportTime() -> llvm::Function*;
   [[nodiscard]] auto GetLyraCreateRunSession() -> llvm::Function*;
   [[nodiscard]] auto GetLyraDestroyRunSession() -> llvm::Function*;
@@ -1081,7 +1081,7 @@ class Context {
   llvm::Function* lyra_terminate_ = nullptr;
   llvm::Function* lyra_get_time_ = nullptr;
   llvm::Function* lyra_init_runtime_ = nullptr;
-  llvm::Function* lyra_resolve_base_dir_ = nullptr;
+  llvm::Function* lyra_launch_parse_args_ = nullptr;
   llvm::Function* lyra_report_time_ = nullptr;
   llvm::Function* lyra_create_run_session_ = nullptr;
   llvm::Function* lyra_destroy_run_session_ = nullptr;

--- a/include/lyra/llvm_backend/emit_design_main.hpp
+++ b/include/lyra/llvm_backend/emit_design_main.hpp
@@ -32,7 +32,7 @@ struct EmitDesignMainInput {
   const BodyOriginProvenance* origin_provenance = nullptr;
   SimulationHooks* hooks = nullptr;
   MainAbi main_abi = MainAbi::kEmbeddedPlusargs;
-  std::string fs_base_dir;
+  std::string fs_root;
   std::vector<std::string> plusargs;
   uint32_t feature_flags = 0;
   std::string signal_trace_path;

--- a/include/lyra/llvm_backend/lower.hpp
+++ b/include/lyra/llvm_backend/lower.hpp
@@ -78,14 +78,21 @@ class SimulationHooks {
   }
 };
 
-// How the synthesized main() receives plusargs.
+// How the synthesized main() receives its launch inputs (fs_root + plusargs).
+//
+// MainAbi selects the source for those inputs; it does not define separate
+// filesystem-resolution policies.
 enum class MainAbi {
-  // JIT/test mode: plusargs are baked into IR as global string constants.
-  // main() takes no arguments: int main().
+  // In-process driver execution (JIT, dump, test framework with JIT).
+  // fs_root and plusargs are both known at lowering time and embedded into
+  // IR as globals. main() takes no arguments: int main(void* run_session).
   kEmbeddedPlusargs,
 
-  // AOT mode: main(argc, argv) forwards argv[1:] as plusargs.
-  // fs_base_dir uses CWD at runtime instead of compile-time value.
+  // Standalone-launchable emitted binary (AOT, LLI).
+  // main(argc, argv) consumes an internal `--lyra-fs-root=<path>` transport
+  // token (when driver-launched) and forwards the remaining argv entries as
+  // plusargs. If the transport token is absent (direct-run standalone),
+  // fs_root falls back to launch-time CWD.
   kArgvForwarding,
 };
 
@@ -100,8 +107,13 @@ struct LoweringInput {
   // Per-body origin provenance for body-local diagnostic resolution.
   // Keyed by body pointer. Nullable (diagnostics degrade gracefully).
   const lowering::BodyOriginProvenance* origin_provenance = nullptr;
-  SimulationHooks* hooks = nullptr;   // Optional instrumentation (nullable)
-  std::string fs_base_dir;            // Base directory for file I/O (absolute)
+  SimulationHooks* hooks = nullptr;  // Optional instrumentation (nullable)
+  // Driver-selected filesystem root for relative runtime file operations
+  // under driver-controlled execution. Absolute, normalized. In
+  // kEmbeddedPlusargs, this value is embedded into IR. In kArgvForwarding,
+  // it is NOT embedded; the driver transports it to the emitted binary via
+  // the `--lyra-fs-root=...` argv token at launch time.
+  std::string fs_root;
   std::vector<std::string> plusargs;  // Command-line plusargs for $plusargs
   uint32_t feature_flags = 0;         // FeatureFlag bitmask for runtime
   // Text signal trace output path: empty = stdout, non-empty = file path.

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -342,14 +342,14 @@ class Engine {
     return time_format_;
   }
 
-  // Set the filesystem base directory for relative path resolution.
-  void SetFsBaseDir(std::filesystem::path dir) {
-    fs_base_dir_ = std::move(dir);
+  // Set the filesystem root for relative runtime file operations.
+  void SetFsRoot(std::filesystem::path dir) {
+    fs_root_ = std::move(dir);
   }
 
-  // Get the filesystem base directory for relative path resolution.
-  [[nodiscard]] auto GetFsBaseDir() const -> const std::filesystem::path& {
-    return fs_base_dir_;
+  // Get the filesystem root for relative runtime file operations.
+  [[nodiscard]] auto GetFsRoot() const -> const std::filesystem::path& {
+    return fs_root_;
   }
 
   // Get file manager for $fopen/$fclose operations.
@@ -1302,8 +1302,8 @@ class Engine {
   // Termination state
   std::optional<std::string> termination_reason_;
 
-  // Filesystem base directory for relative path resolution in file I/O.
-  std::filesystem::path fs_base_dir_;
+  // Filesystem root for relative runtime file operations (driver-selected).
+  std::filesystem::path fs_root_;
 
   // File manager for $fopen/$fclose
   FileManager file_manager_;

--- a/include/lyra/runtime/file_manager.hpp
+++ b/include/lyra/runtime/file_manager.hpp
@@ -15,6 +15,16 @@
 
 namespace lyra::runtime {
 
+// Canonical path resolver for runtime file operations. Every relative path
+// opened by simulation-side code ($fopen, $readmem*, $writemem*, trace
+// output, etc.) MUST go through this helper so filesystem semantics stay
+// uniform across backends and bypasses are impossible.
+//   - absolute paths are returned normalized
+//   - relative paths are joined against fs_root and normalized
+auto ResolveRuntimePath(
+    const std::filesystem::path& fs_root, const std::filesystem::path& path)
+    -> std::filesystem::path;
+
 // Result of CollectStreams: identifies which output streams a descriptor
 // targets.
 struct StreamTargets {
@@ -72,15 +82,15 @@ class FileManager {
   auto operator=(FileManager&&) -> FileManager& = delete;
 
   // MCD mode: returns (1 << bit_index), bit_index in [1,30]. Returns 0 on
-  // failure. base_dir: filesystem base for relative path resolution.
+  // failure. fs_root: driver-selected root for relative paths.
   auto FopenMcd(
-      const std::filesystem::path& base_dir, const std::string& filename)
+      const std::filesystem::path& fs_root, const std::string& filename)
       -> int32_t;
 
   // FD mode: returns (kFdBit | index), index in [3,...]. Returns 0 on failure.
-  // base_dir: filesystem base for relative path resolution.
+  // fs_root: driver-selected root for relative paths.
   auto FopenFd(
-      const std::filesystem::path& base_dir, const std::string& filename,
+      const std::filesystem::path& fs_root, const std::string& filename,
       const std::string& mode) -> int32_t;
 
   // Close descriptor. MCD: iterates set bits. FD: closes single file. Invalid:
@@ -145,13 +155,6 @@ class FileManager {
 
   static auto ParseMode(const std::string& mode)
       -> std::optional<std::ios_base::openmode>;
-
-  // Resolve filename against an explicit base directory.
-  // Absolute paths returned as-is (normalized); relative paths joined with
-  // base.
-  static auto ResolvePath(
-      const std::filesystem::path& base_dir, const std::string& filename)
-      -> std::string;
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/io.hpp
+++ b/include/lyra/runtime/io.hpp
@@ -146,10 +146,10 @@ void LyraReadmemGlobal(
     uint32_t global_slot_id);
 
 void LyraReadmemNoNotify(
-    LyraStringHandle filename, void* target, int32_t element_width,
-    int32_t stride_bytes, int32_t value_size_bytes, int32_t element_count,
-    int64_t min_addr, int64_t current_addr, int64_t final_addr, int64_t step,
-    bool is_hex, int32_t element_kind);
+    void* engine_ptr, LyraStringHandle filename, void* target,
+    int32_t element_width, int32_t stride_bytes, int32_t value_size_bytes,
+    int32_t element_count, int64_t min_addr, int64_t current_addr,
+    int64_t final_addr, int64_t step, bool is_hex, int32_t element_kind);
 
 // $writememh/$writememb: write array to memory file
 // - engine_ptr: pointer to Engine (for base directory resolution)

--- a/include/lyra/runtime/runtime_abi.hpp
+++ b/include/lyra/runtime/runtime_abi.hpp
@@ -77,8 +77,11 @@ struct RuntimeInstance;
 // v22: A2 deferred assertion site metadata table.
 // v23: A2e deferred assertion thunk pointers + payload sizes in site metadata.
 // v24: L8a named event count for runtime event registry sizing.
-// v25: fs_base_dir moved from LyraInitRuntime hidden static to ABI struct.
-//      Engine owns the filesystem base directory explicitly.
+// v25: fs_root (filesystem root for relative runtime file operations)
+//      carried in the ABI struct. Engine owns it explicitly. For
+//      kEmbeddedPlusargs the string is set by codegen; for kArgvForwarding
+//      it is resolved at launch time by LyraLaunchParseArgs (either the
+//      driver-supplied `--lyra-fs-root=<path>` token, or launch-time CWD).
 // v26: construction_result pointer added. Runtime reads installable
 //      computations from the finalized ConstructionResult via this
 //      explicit ABI field; replaces the g_pending_result global handoff.
@@ -166,9 +169,11 @@ struct LyraRuntimeAbi {
   uint32_t num_events;
   uint32_t pad_events;
 
-  // v25: Filesystem base directory for relative path resolution.
-  // Owned by Engine after construction. Null = current working directory.
-  const char* fs_base_dir;
+  // v25: Filesystem root for relative runtime file operations.
+  // Absolute path. Owned by Engine after construction. Populated either from
+  // a compile-time embedded string (kEmbeddedPlusargs) or from LaunchArgs
+  // parsing at main() entry (kArgvForwarding). See LyraLaunchParseArgs.
+  const char* fs_root;
 
   // v26: Finalized ConstructionResult pointer.
   // Borrowed for the duration of LyraRunSimulation. Used to extract
@@ -191,5 +196,5 @@ static_assert(offsetof(LyraRuntimeAbi, global_precision_power) == 240);
 static_assert(offsetof(LyraRuntimeAbi, deferred_assertion_site_meta) == 248);
 static_assert(offsetof(LyraRuntimeAbi, num_deferred_assertion_sites) == 256);
 static_assert(offsetof(LyraRuntimeAbi, num_events) == 264);
-static_assert(offsetof(LyraRuntimeAbi, fs_base_dir) == 272);
+static_assert(offsetof(LyraRuntimeAbi, fs_root) == 272);
 static_assert(offsetof(LyraRuntimeAbi, construction_result) == 280);

--- a/include/lyra/runtime/simulation.hpp
+++ b/include/lyra/runtime/simulation.hpp
@@ -125,15 +125,35 @@ void LyraSetTimeFormat(
     void* engine_ptr, int8_t units, int32_t precision, const char* suffix,
     int32_t min_width);
 
-// Resolve the base directory for relative file I/O.
-// Checks LYRA_FS_BASE_DIR env var first, then derives from argv[0]
-// (dirname(realpath(argv0))). Returns a pointer to static storage
-// (valid until next call).
-auto LyraResolveBaseDir(const char* argv0) -> const char*;
-
 // Initialize runtime state (call before running processes).
 // iteration_limit: per-activation back-edge limit (0 = unlimited).
 void LyraInitRuntime(uint32_t iteration_limit);
+
+// Parse the launch-time argv of an emitted `main(argc, argv)` entry point.
+//
+// `--lyra-fs-root=<absolute path>` is an internal driver-to-child transport
+// token, NOT a public CLI flag of the emitted binary. The Lyra driver
+// prepends it when spawning AOT/LLI children so the child inherits the
+// driver-selected fs_root. It is not documented as a user-facing override
+// of the direct-run contract (fs_root = launch-time CWD).
+//
+// Parsing rules:
+// - If the token is present, its value must be non-empty and absolute;
+//   otherwise an InternalError is thrown. The token is consumed and never
+//   appears in the plusargs array.
+// - If the token is absent, fs_root resolves to the launch-time CWD. A
+//   failure to read the CWD is fatal (InternalError), never a "." fallback.
+//
+// Output contract:
+// - `*fs_root_out`   : nul-terminated absolute path, valid for the process
+//                      lifetime (backed by internal static storage).
+// - `plusargs_out`   : caller-provided array, space for at least
+//                      max(argc - 1, 0) entries; populated with user plusargs
+//                      only.
+// - return value     : number of user plusargs written to plusargs_out.
+auto LyraLaunchParseArgs(
+    int argc, char** argv, const char** fs_root_out, const char** plusargs_out)
+    -> uint32_t;
 
 // Print final simulation time as __LYRA_TIME__=<N> for test harness.
 // run_session_ptr: opaque pointer to lyra::runtime::RunSession.

--- a/src/lyra/driver/compile.cpp
+++ b/src/lyra/driver/compile.cpp
@@ -84,7 +84,7 @@ auto Compile(
       .source_manager = compilation.hir.source_manager.get(),
       .origin_provenance = &origin_provenance,
       .hooks = nullptr,
-      .fs_base_dir = input.input.fs_base_dir.string(),
+      .fs_root = input.input.fs_root.string(),
       .plusargs = {},
       .feature_flags = feature_flags,
       .signal_trace_path = input.input.trace_signals_output.value_or(""),

--- a/src/lyra/driver/dump.cpp
+++ b/src/lyra/driver/dump.cpp
@@ -289,7 +289,7 @@ auto DumpLlvm(const CompilationInput& input) -> int {
       .diag_ctx = &diag_ctx,
       .source_manager = hir_result.source_manager.get(),
       .origin_provenance = &origin_provenance,
-      .fs_base_dir = input.fs_base_dir.string(),
+      .fs_root = input.fs_root.string(),
       .plusargs = {},
       .feature_flags = 0,
       .signal_trace_path = {},

--- a/src/lyra/driver/frontend.hpp
+++ b/src/lyra/driver/frontend.hpp
@@ -24,7 +24,14 @@ struct CompilationInput {
   std::vector<std::string> defines;
   std::vector<std::string> warnings;
   std::vector<std::string> param_overrides;
-  std::filesystem::path fs_base_dir;
+  // Driver-selected filesystem root for relative runtime file operations
+  // under driver-controlled execution (`lyra run --backend=jit|aot|lli`).
+  // Project mode: config root. --no-project mode: effective CWD after -C.
+  // For JIT, this value is embedded in the IR. For AOT/LLI children, the
+  // driver transports it to the child via the internal `--lyra-fs-root=...`
+  // argv token. Direct-run emitted binaries do not inherit this value;
+  // they anchor to launch-time CWD.
+  std::filesystem::path fs_root;
   std::vector<std::string> plusargs;
   OptLevel opt_level = OptLevel::kO2;
   bool pedantic = false;

--- a/src/lyra/driver/input.cpp
+++ b/src/lyra/driver/input.cpp
@@ -446,26 +446,27 @@ auto PrepareInput(const argparse::ArgumentParser& cmd, bool no_project)
   auto effective_cwd = fs::absolute(fs::current_path()).lexically_normal();
 
   std::optional<ProjectConfig> config;
-  fs::path fs_base_dir;
+  fs::path fs_root;
 
   if (no_project) {
-    // Ad-hoc mode: use effective CWD as base dir, no config required
-    fs_base_dir = effective_cwd;
+    // Ad-hoc mode: fs_root = effective CWD after -C, no config required.
+    fs_root = effective_cwd;
   } else {
-    // Project mode: require lyra.toml
+    // Project mode: require lyra.toml; fs_root = config root.
     auto config_result = LoadProjectConfig();
     if (!config_result) {
       return std::unexpected(config_result.error());
     }
     config = std::move(*config_result);
-    fs_base_dir = fs::absolute(config->root_dir).lexically_normal();
+    fs_root = fs::absolute(config->root_dir).lexically_normal();
   }
 
   auto input = BuildInput(cmd, config);
   if (!input) {
     return std::unexpected(input.error());
   }
-  input->fs_base_dir = fs_base_dir;
+  // Single semantic anchor for relative runtime file I/O, backend-agnostic.
+  input->fs_root = fs_root;
 
   return input;
 }

--- a/src/lyra/driver/input.hpp
+++ b/src/lyra/driver/input.hpp
@@ -38,8 +38,12 @@ auto LoadProjectConfig() -> lyra::Result<ProjectConfig>;
 
 // Prepare a fully-populated CompilationInput for a command.
 // Handles both project mode (require lyra.toml) and ad-hoc mode (no_project).
-// - In project mode: fs_base_dir = project root (lyra.toml directory)
-// - In ad-hoc mode: fs_base_dir = effective CWD
+// Sets CompilationInput::fs_root -- the driver-selected anchor for relative
+// runtime filesystem operations under driver-controlled execution.
+// - In project mode: fs_root = project/config root (lyra.toml directory)
+// - In ad-hoc mode:  fs_root = effective CWD after -C
+// Direct-run of `lyra compile` artifacts uses launch-time CWD instead and
+// is not governed by this value.
 auto PrepareInput(const argparse::ArgumentParser& cmd, bool no_project)
     -> lyra::Result<CompilationInput>;
 

--- a/src/lyra/driver/run_aot.cpp
+++ b/src/lyra/driver/run_aot.cpp
@@ -1,7 +1,6 @@
 #include "run_aot.hpp"
 
 #include <cerrno>
-#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <format>
@@ -50,8 +49,13 @@ auto RunAot(const ValidatedCompilationInput& input) -> int {
 
   auto exe_path = *compile_result;
 
+  // Driver-to-child launch contract: transport the driver-selected fs_root
+  // as the first post-argv[0] token. Emitted `main` consumes it before
+  // building the user plusargs array, so it never reaches $plusargs.
   std::vector<std::string> args;
   args.push_back(exe_path.string());
+  args.push_back(
+      std::format("--lyra-fs-root={}", input.input.fs_root.string()));
   for (const auto& plusarg : input.input.plusargs) {
     args.push_back(plusarg);
   }
@@ -63,13 +67,9 @@ auto RunAot(const ValidatedCompilationInput& input) -> int {
   }
   argv.push_back(nullptr);
 
-  setenv("LYRA_FS_BASE_DIR", input.input.fs_base_dir.string().c_str(), 1);
-
   pid_t pid = 0;
   int spawn_result = posix_spawnp(
       &pid, exe_path.c_str(), nullptr, nullptr, argv.data(), environ);
-
-  unsetenv("LYRA_FS_BASE_DIR");
 
   if (spawn_result != 0) {
     output.PrintError(

--- a/src/lyra/driver/run_jit.cpp
+++ b/src/lyra/driver/run_jit.cpp
@@ -126,7 +126,7 @@ auto RunJit(const ValidatedCompilationInput& input) -> int {
       .diag_ctx = &diag_ctx,
       .source_manager = compilation.hir.source_manager.get(),
       .origin_provenance = &origin_provenance,
-      .fs_base_dir = input.input.fs_base_dir.string(),
+      .fs_root = input.input.fs_root.string(),
       .plusargs = input.input.plusargs,
       .feature_flags = feature_flags,
       .signal_trace_path = input.input.trace_signals_output.value_or(""),

--- a/src/lyra/driver/run_lli.cpp
+++ b/src/lyra/driver/run_lli.cpp
@@ -68,7 +68,9 @@ auto CreateTempFile(const std::string& suffix) -> std::string {
 
 auto SpawnLli(
     const std::string& runtime_path, const std::string& ir_path,
-    std::span<const std::filesystem::path> dpi_link_inputs) -> int {
+    std::span<const std::filesystem::path> dpi_link_inputs,
+    const std::string& fs_root, std::span<const std::string> user_plusargs)
+    -> int {
   // Runtime is loaded via --dlopen so lli can resolve Lyra* symbols.
   std::vector<std::string> dlopen_args;
   dlopen_args.push_back(std::format("--dlopen={}", runtime_path));
@@ -79,6 +81,13 @@ auto SpawnLli(
     dlopen_args.push_back(std::format("--dlopen={}", input.string()));
   }
 
+  // Driver-to-child launch contract (same as AOT): prepend the fs_root
+  // transport token, then user plusargs. lli treats argv after the IR path
+  // as the loaded program's argv[1..].
+  std::string fs_root_arg = std::format("--lyra-fs-root={}", fs_root);
+  std::vector<std::string> plusarg_copies(
+      user_plusargs.begin(), user_plusargs.end());
+
   std::vector<char*> argv;
   std::string lli_cmd = "lli";
   argv.push_back(lli_cmd.data());
@@ -87,6 +96,10 @@ auto SpawnLli(
   }
   std::string ir_path_copy = ir_path;
   argv.push_back(ir_path_copy.data());
+  argv.push_back(fs_root_arg.data());
+  for (auto& arg : plusarg_copies) {
+    argv.push_back(arg.data());
+  }
   argv.push_back(nullptr);
 
   pid_t pid = 0;
@@ -141,7 +154,7 @@ auto RunLli(const ValidatedCompilationInput& input) -> int {
       .diag_ctx = &diag_ctx,
       .source_manager = compilation.hir.source_manager.get(),
       .origin_provenance = &origin_provenance,
-      .fs_base_dir = input.input.fs_base_dir.string(),
+      .fs_root = input.input.fs_root.string(),
       .plusargs = input.input.plusargs,
       .feature_flags = 0,
       .signal_trace_path = input.input.trace_signals_output.value_or(""),
@@ -211,8 +224,9 @@ auto RunLli(const ValidatedCompilationInput& input) -> int {
   int exit_code = 0;
   {
     PhaseTimer timer(output, Phase::kSim, HeartbeatPolicy::kEnabled);
-    exit_code =
-        SpawnLli(runtime_path.string(), ir_path, input.input.dpi_link_inputs);
+    exit_code = SpawnLli(
+        runtime_path.string(), ir_path, input.input.dpi_link_inputs,
+        input.input.fs_root.string(), input.input.plusargs);
   }
   if (exit_code == -1) {
     output.PrintError(

--- a/src/lyra/llvm_backend/context_runtime.cpp
+++ b/src/lyra/llvm_backend/context_runtime.cpp
@@ -971,16 +971,20 @@ auto Context::GetLyraInitRuntime() -> llvm::Function* {
   return lyra_init_runtime_;
 }
 
-auto Context::GetLyraResolveBaseDir() -> llvm::Function* {
-  if (lyra_resolve_base_dir_ == nullptr) {
-    // const char* LyraResolveBaseDir(const char* argv0)
+auto Context::GetLyraLaunchParseArgs() -> llvm::Function* {
+  if (lyra_launch_parse_args_ == nullptr) {
+    // uint32_t LyraLaunchParseArgs(int argc, char** argv,
+    //                              const char** fs_root_out,
+    //                              const char** plusargs_out)
+    auto* i32_ty = llvm::Type::getInt32Ty(*llvm_context_);
     auto* ptr_ty = llvm::PointerType::getUnqual(*llvm_context_);
-    auto* fn_type = llvm::FunctionType::get(ptr_ty, {ptr_ty}, false);
-    lyra_resolve_base_dir_ = llvm::Function::Create(
-        fn_type, llvm::Function::ExternalLinkage, "LyraResolveBaseDir",
+    auto* fn_type = llvm::FunctionType::get(
+        i32_ty, {i32_ty, ptr_ty, ptr_ty, ptr_ty}, false);
+    lyra_launch_parse_args_ = llvm::Function::Create(
+        fn_type, llvm::Function::ExternalLinkage, "LyraLaunchParseArgs",
         llvm_module_.get());
   }
-  return lyra_resolve_base_dir_;
+  return lyra_launch_parse_args_;
 }
 
 auto Context::GetLyraReportTime() -> llvm::Function* {
@@ -1529,11 +1533,13 @@ auto Context::GetLyraReadmemNoNotify() -> llvm::Function* {
     auto* i64_ty = llvm::Type::getInt64Ty(*llvm_context_);
     auto* i1_ty = llvm::Type::getInt1Ty(*llvm_context_);
     auto* void_ty = llvm::Type::getVoidTy(*llvm_context_);
-    // No engine_ptr parameter: this variant does not notify.
+    // engine_ptr required: needed to resolve the filename against fs_root
+    // before opening. "NoNotify" refers only to the absence of signal
+    // invalidation; it does not mean the op bypasses runtime fs_root.
     auto* fn_type = llvm::FunctionType::get(
         void_ty,
-        {ptr_ty, ptr_ty, i32_ty, i32_ty, i32_ty, i32_ty, i64_ty, i64_ty, i64_ty,
-         i64_ty, i1_ty, i32_ty},
+        {ptr_ty, ptr_ty, ptr_ty, i32_ty, i32_ty, i32_ty, i32_ty, i64_ty, i64_ty,
+         i64_ty, i64_ty, i1_ty, i32_ty},
         false);
     lyra_readmem_no_notify_ = llvm::Function::Create(
         fn_type, llvm::Function::ExternalLinkage, "LyraReadmemNoNotify",

--- a/src/lyra/llvm_backend/emit_design_main.cpp
+++ b/src/lyra/llvm_backend/emit_design_main.cpp
@@ -206,29 +206,83 @@ void EmitDesignStateZero(Context& context, llvm::Value* design_state) {
   EmitMemsetZero(context, design_state, arena_ty);
 }
 
+// Emits runtime init and captures the two values whose source differs by
+// launch mode: the filesystem root and the user plusargs array. MainAbi
+// selects the source; the downstream runtime contract is identical.
+//
+//   kEmbeddedPlusargs (driver-controlled in-process execution):
+//     fs_root  = compile-time driver-selected string, embedded as a global
+//     plusargs = compile-time driver-supplied vector, embedded as globals
+//
+//   kArgvForwarding (driver-controlled AOT/LLI child OR standalone direct-run):
+//     fs_root  = extracted from `--lyra-fs-root=<abs path>` argv token if
+//                present (driver-controlled launch), else launch-time CWD
+//                (standalone direct-run). Decision is runtime-side.
+//     plusargs = argv entries that remain after the internal transport
+//                token is consumed.
+struct LaunchSetup {
+  llvm::Value* fs_root_str = nullptr;
+  llvm::Value* plusargs_array = nullptr;
+  llvm::Value* plusargs_count = nullptr;
+};
+
 auto EmitRuntimeInit(
     Context& context, llvm::Function* main_func,
-    const EmitDesignMainInput& input) -> llvm::Value* {
+    const EmitDesignMainInput& input) -> LaunchSetup {
   auto& builder = context.GetBuilder();
   auto& ctx = context.GetLlvmContext();
-  bool argv_forwarding =
-      input.main_abi == lowering::mir_to_llvm::MainAbi::kArgvForwarding;
-
-  llvm::Value* fs_base_dir_str = nullptr;
-  if (argv_forwarding) {
-    auto* argv0 = builder.CreateLoad(
-        llvm::PointerType::getUnqual(ctx), main_func->getArg(1), "argv0");
-    fs_base_dir_str =
-        builder.CreateCall(context.GetLyraResolveBaseDir(), {argv0});
-  } else {
-    fs_base_dir_str =
-        builder.CreateGlobalStringPtr(input.fs_base_dir, "fs_base_dir");
-  }
   auto* i32_ty = llvm::Type::getInt32Ty(ctx);
+  auto* ptr_ty = llvm::PointerType::getUnqual(ctx);
+
   builder.CreateCall(
       context.GetLyraInitRuntime(),
       {llvm::ConstantInt::get(i32_ty, input.iteration_limit)});
-  return fs_base_dir_str;
+
+  LaunchSetup setup;
+
+  if (input.main_abi == lowering::mir_to_llvm::MainAbi::kArgvForwarding) {
+    auto* argc_val = main_func->getArg(0);
+    auto* argv_val = main_func->getArg(1);
+
+    // Max user plusargs = argc (loose bound; runtime writes only what it
+    // needs, caller reads only plusargs_count entries).
+    auto* plusargs_array = builder.CreateAlloca(ptr_ty, argc_val, "plusargs");
+    auto* fs_root_slot = builder.CreateAlloca(ptr_ty, nullptr, "fs_root_slot");
+    builder.CreateStore(
+        llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptr_ty)),
+        fs_root_slot);
+
+    auto* plusargs_count = builder.CreateCall(
+        context.GetLyraLaunchParseArgs(),
+        {argc_val, argv_val, fs_root_slot, plusargs_array}, "num_plusargs");
+    auto* fs_root_str = builder.CreateLoad(ptr_ty, fs_root_slot, "fs_root");
+
+    setup.fs_root_str = fs_root_str;
+    setup.plusargs_array = plusargs_array;
+    setup.plusargs_count = plusargs_count;
+    return setup;
+  }
+
+  // kEmbeddedPlusargs: fs_root and plusargs are both compile-time.
+  setup.fs_root_str = builder.CreateGlobalStringPtr(input.fs_root, "fs_root");
+
+  auto num_plusargs = static_cast<uint32_t>(input.plusargs.size());
+  setup.plusargs_count = llvm::ConstantInt::get(i32_ty, num_plusargs);
+  if (num_plusargs > 0) {
+    auto* array = builder.CreateAlloca(
+        ptr_ty, llvm::ConstantInt::get(i32_ty, num_plusargs), "plusargs");
+    for (uint32_t i = 0; i < num_plusargs; ++i) {
+      auto* plusarg_str = builder.CreateGlobalStringPtr(
+          input.plusargs[i], std::format("plusarg_{}", i));
+      auto* slot = builder.CreateGEP(ptr_ty, array, {builder.getInt32(i)});
+      builder.CreateStore(plusarg_str, slot);
+    }
+    setup.plusargs_array = array;
+  } else {
+    setup.plusargs_array =
+        llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptr_ty));
+  }
+  return setup;
 }
 
 void EmitInitProcesses(
@@ -250,55 +304,6 @@ void EmitInitProcesses(
         context.GetLyraRunProcessSync(),
         {process_funcs[i], process_state, design_state});
   }
-}
-
-struct PlusargsSetup {
-  llvm::Value* array = nullptr;
-  llvm::Value* count = nullptr;
-};
-
-auto BuildPlusargs(
-    Context& context, llvm::Function* main_func,
-    const EmitDesignMainInput& input) -> PlusargsSetup {
-  auto& builder = context.GetBuilder();
-  auto& ctx = context.GetLlvmContext();
-  auto* ptr_ty = llvm::PointerType::getUnqual(ctx);
-  auto* i32_ty = llvm::Type::getInt32Ty(ctx);
-  bool argv_forwarding =
-      input.main_abi == lowering::mir_to_llvm::MainAbi::kArgvForwarding;
-
-  if (argv_forwarding) {
-    auto* argc_val = main_func->getArg(0);
-    auto* argv_val = main_func->getArg(1);
-    auto* argc_minus_1 =
-        builder.CreateSub(argc_val, llvm::ConstantInt::get(i32_ty, 1));
-    auto* is_positive =
-        builder.CreateICmpSGT(argc_minus_1, llvm::ConstantInt::get(i32_ty, 0));
-    auto* count = builder.CreateSelect(
-        is_positive, argc_minus_1, llvm::ConstantInt::get(i32_ty, 0),
-        "num_plusargs");
-    auto* array = builder.CreateGEP(
-        ptr_ty, argv_val, {llvm::ConstantInt::get(i32_ty, 1)}, "plusargs");
-    return {.array = array, .count = count};
-  }
-
-  auto num_plusargs = static_cast<uint32_t>(input.plusargs.size());
-  auto* count = llvm::ConstantInt::get(i32_ty, num_plusargs);
-  if (num_plusargs > 0) {
-    auto* array = builder.CreateAlloca(
-        ptr_ty, llvm::ConstantInt::get(i32_ty, num_plusargs), "plusargs");
-    for (uint32_t i = 0; i < num_plusargs; ++i) {
-      auto* plusarg_str = builder.CreateGlobalStringPtr(
-          input.plusargs[i], std::format("plusarg_{}", i));
-      auto* slot = builder.CreateGEP(ptr_ty, array, {builder.getInt32(i)});
-      builder.CreateStore(plusarg_str, slot);
-    }
-    return {.array = array, .count = count};
-  }
-
-  auto* null_array =
-      llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptr_ty));
-  return {.array = null_array, .count = count};
 }
 
 // Metadata-building outputs: emitted metadata globals plus structured
@@ -500,7 +505,7 @@ auto BuildRuntimeAbi(
     uint32_t num_immediate_cover_sites, int8_t global_precision_power,
     llvm::Constant* deferred_site_meta_global,
     uint32_t num_deferred_assertion_sites, uint32_t num_events,
-    llvm::Value* fs_base_dir_str, llvm::Value* conn_desc_ptr,
+    llvm::Value* fs_root_str, llvm::Value* conn_desc_ptr,
     llvm::Value* conn_desc_count, llvm::Value* construction_result_ptr)
     -> llvm::Value* {
   auto& builder = context.GetBuilder();
@@ -598,8 +603,8 @@ auto BuildRuntimeAbi(
   store_field(38, llvm::ConstantInt::get(i32_ty, num_events));
   store_field(39, llvm::ConstantInt::get(i32_ty, 0));
 
-  // v25: Filesystem base directory.
-  store_field(40, fs_base_dir_str);
+  // v25: Driver-selected filesystem root.
+  store_field(40, fs_root_str);
 
   // v26: Finalized construction result pointer (null if no constructor).
   store_field(
@@ -611,14 +616,14 @@ auto BuildRuntimeAbi(
 
 void EmitRunSimulation(
     Context& context, llvm::Value* states_array, llvm::Value* num_processes,
-    const PlusargsSetup& plusargs, llvm::Value* abi_alloca,
+    const LaunchSetup& setup, llvm::Value* abi_alloca,
     llvm::Value* run_session_ptr) {
   auto& builder = context.GetBuilder();
 
   builder.CreateCall(
       context.GetLyraRunSimulation(),
-      {states_array, num_processes, plusargs.array, plusargs.count, abi_alloca,
-       run_session_ptr});
+      {states_array, num_processes, setup.plusargs_array, setup.plusargs_count,
+       abi_alloca, run_session_ptr});
 }
 
 void EmitMainExit(
@@ -672,7 +677,7 @@ auto BuildEmitDesignMainInput(const lowering::mir_to_llvm::LoweringInput& input)
       .origin_provenance = input.origin_provenance,
       .hooks = input.hooks,
       .main_abi = input.main_abi,
-      .fs_base_dir = input.fs_base_dir,
+      .fs_root = input.fs_root,
       .plusargs = input.plusargs,
       .feature_flags = input.feature_flags,
       .signal_trace_path = input.signal_trace_path,
@@ -723,9 +728,10 @@ auto EmitDesignMain(
       num_total_val = ctor_result.num_total;
     }
 
-    // Runtime init and init processes run AFTER constructor (which owns
-    // design-state init) but BEFORE simulation.
-    auto* fs_base_dir_str = EmitRuntimeInit(context, main_func, input);
+    // Runtime init resolves the filesystem root and the user plusargs array
+    // in one shot (their sources depend on MainAbi; the downstream runtime
+    // contract is identical).
+    auto launch_setup = EmitRuntimeInit(context, main_func, input);
 
     if (input.hooks != nullptr) {
       input.hooks->OnAfterInitializeDesignState(context, design_state);
@@ -738,8 +744,6 @@ auto EmitDesignMain(
     if (input.hooks != nullptr) {
       input.hooks->OnBeforeRunSimulation(context, design_state);
     }
-
-    auto plusargs = BuildPlusargs(context, main_func, input);
 
     auto metadata_outputs = BuildDesignMetadataOutputs(
         context, layout, input, session.back_edge_origins);
@@ -849,17 +853,19 @@ auto EmitDesignMain(
         input.design->global_precision_power, deferred_site_meta_global,
         static_cast<uint32_t>(input.design->deferred_assertion_sites.size()),
         static_cast<uint32_t>(input.design->max_body_local_events),
-        fs_base_dir_str, conn_ptr, conn_count, ctor_result.result_handle);
+        launch_setup.fs_root_str, conn_ptr, conn_count,
+        ctor_result.result_handle);
     abi_for_exit = abi_alloca;
 
     EmitRunSimulation(
-        context, states_array, num_total_val, plusargs, abi_alloca,
+        context, states_array, num_total_val, launch_setup, abi_alloca,
         run_session_ptr);
 
   } else {
     // No simulation processes or kernelized connections. Still need
-    // runtime init and init process execution.
-    EmitRuntimeInit(context, main_func, input);
+    // runtime init and init process execution. The returned LaunchSetup is
+    // unused because the run_simulation / ABI build paths are skipped.
+    (void)EmitRuntimeInit(context, main_func, input);
 
     if (input.hooks != nullptr) {
       input.hooks->OnAfterInitializeDesignState(context, design_state);

--- a/src/lyra/llvm_backend/instruction/effect.cpp
+++ b/src/lyra/llvm_backend/instruction/effect.cpp
@@ -527,11 +527,10 @@ auto LowerMemIOEffect(
             args.push_back(readmem_slot_expr->Emit(builder));
             builder.CreateCall(context.GetLyraReadmemGlobal(), args);
           } else {
-            // NoNotify has no engine_ptr parameter: skip common_args[0].
-            std::vector<llvm::Value*> no_notify_args(
-                common_args.begin() + 1, common_args.end());
-            builder.CreateCall(
-                context.GetLyraReadmemNoNotify(), no_notify_args);
+            // NoNotify takes the same engine_ptr + filename signature as the
+            // local/global variants; the "NoNotify" name refers only to the
+            // absence of signal invalidation after the write.
+            builder.CreateCall(context.GetLyraReadmemNoNotify(), common_args);
           }
         } else {
           std::vector<llvm::Value*> args = {

--- a/src/lyra/llvm_backend/runtime_abi_codegen.cpp
+++ b/src/lyra/llvm_backend/runtime_abi_codegen.cpp
@@ -72,7 +72,7 @@ auto GetRuntimeAbiStructType(llvm::LLVMContext& ctx) -> llvm::StructType* {
       // L8a: named event count (i32 count, i32 pad)
       i32_ty,
       i32_ty,
-      // v25: fs_base_dir (ptr)
+      // v25: fs_root (ptr)
       ptr_ty,
       // v26: construction_result (ptr)
       ptr_ty,

--- a/src/lyra/runtime/file_manager.cpp
+++ b/src/lyra/runtime/file_manager.cpp
@@ -14,14 +14,13 @@
 
 namespace lyra::runtime {
 
-auto FileManager::ResolvePath(
-    const std::filesystem::path& base_dir, const std::string& filename)
-    -> std::string {
-  std::filesystem::path p(filename);
-  if (p.is_absolute()) {
-    return p.lexically_normal().string();
+auto ResolveRuntimePath(
+    const std::filesystem::path& fs_root, const std::filesystem::path& path)
+    -> std::filesystem::path {
+  if (path.is_absolute()) {
+    return path.lexically_normal();
   }
-  return (base_dir / p).lexically_normal().string();
+  return (fs_root / path).lexically_normal();
 }
 
 FileManager::~FileManager() {
@@ -30,9 +29,9 @@ FileManager::~FileManager() {
 }
 
 auto FileManager::FopenMcd(
-    const std::filesystem::path& base_dir, const std::string& filename)
+    const std::filesystem::path& fs_root, const std::string& filename)
     -> int32_t {
-  auto resolved = ResolvePath(base_dir, filename);
+  auto resolved = ResolveRuntimePath(fs_root, filename);
   // Find first unused MCD bit in [1, 30]
   for (int bit = 1; bit <= kMaxMcdBit; ++bit) {
     if (!mcd_channels_.contains(bit)) {
@@ -49,14 +48,14 @@ auto FileManager::FopenMcd(
 }
 
 auto FileManager::FopenFd(
-    const std::filesystem::path& base_dir, const std::string& filename,
+    const std::filesystem::path& fs_root, const std::string& filename,
     const std::string& mode) -> int32_t {
   auto flags = ParseMode(mode);
   if (!flags) {
     return 0;
   }
 
-  auto resolved = ResolvePath(base_dir, filename);
+  auto resolved = ResolveRuntimePath(fs_root, filename);
   auto stream = std::make_unique<std::fstream>(resolved, *flags);
   if (!stream->is_open()) {
     return 0;

--- a/src/lyra/runtime/io.cpp
+++ b/src/lyra/runtime/io.cpp
@@ -216,8 +216,7 @@ extern "C" auto LyraFopenFd(
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   std::string filename{LyraStringAsView(filename_handle)};
   std::string mode{LyraStringAsView(mode_handle)};
-  return engine->GetFileManager().FopenFd(
-      engine->GetFsBaseDir(), filename, mode);
+  return engine->GetFileManager().FopenFd(engine->GetFsRoot(), filename, mode);
 }
 
 extern "C" auto LyraFopenMcd(void* engine_ptr, LyraStringHandle filename_handle)
@@ -228,7 +227,7 @@ extern "C" auto LyraFopenMcd(void* engine_ptr, LyraStringHandle filename_handle)
   }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   std::string filename{LyraStringAsView(filename_handle)};
-  return engine->GetFileManager().FopenMcd(engine->GetFsBaseDir(), filename);
+  return engine->GetFileManager().FopenMcd(engine->GetFsRoot(), filename);
 }
 
 extern "C" void LyraFclose(void* engine_ptr, int32_t descriptor) {
@@ -320,7 +319,7 @@ extern "C" void LyraFWrite(
 
 // Common readmem implementation. Returns true if any element was written.
 auto ReadmemImpl(
-    const std::filesystem::path& base_dir, LyraStringHandle filename_handle,
+    const std::filesystem::path& fs_root, LyraStringHandle filename_handle,
     void* target, int32_t element_width, int32_t stride_bytes,
     int32_t value_size_bytes, int32_t element_count, int64_t min_addr,
     int64_t current_addr, int64_t final_addr, int64_t step, bool is_hex,
@@ -348,11 +347,7 @@ auto ReadmemImpl(
   }
 
   std::string filename{LyraStringAsView(filename_handle)};
-
-  std::filesystem::path path{filename};
-  if (path.is_relative()) {
-    path = base_dir / path;
-  }
+  auto path = lyra::runtime::ResolveRuntimePath(fs_root, filename);
 
   std::ifstream file(path);
   if (!file) {
@@ -423,9 +418,9 @@ extern "C" void LyraReadmemLocal(
   }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   bool wrote = ReadmemImpl(
-      engine->GetFsBaseDir(), filename_handle, target, element_width,
-      stride_bytes, value_size_bytes, element_count, min_addr, current_addr,
-      final_addr, step, is_hex, element_kind);
+      engine->GetFsRoot(), filename_handle, target, element_width, stride_bytes,
+      value_size_bytes, element_count, min_addr, current_addr, final_addr, step,
+      is_hex, element_kind);
   if (wrote) {
     if (instance_ptr == nullptr) {
       throw lyra::common::InternalError(
@@ -453,23 +448,28 @@ extern "C" void LyraReadmemGlobal(
   }
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   bool wrote = ReadmemImpl(
-      engine->GetFsBaseDir(), filename_handle, target, element_width,
-      stride_bytes, value_size_bytes, element_count, min_addr, current_addr,
-      final_addr, step, is_hex, element_kind);
+      engine->GetFsRoot(), filename_handle, target, element_width, stride_bytes,
+      value_size_bytes, element_count, min_addr, current_addr, final_addr, step,
+      is_hex, element_kind);
   if (wrote) {
     engine->MarkDirty(lyra::runtime::GlobalSignalId{global_slot_id});
   }
 }
 
 extern "C" void LyraReadmemNoNotify(
-    LyraStringHandle filename_handle, void* target, int32_t element_width,
-    int32_t stride_bytes, int32_t value_size_bytes, int32_t element_count,
-    int64_t min_addr, int64_t current_addr, int64_t final_addr, int64_t step,
-    bool is_hex, int32_t element_kind) {
+    void* engine_ptr, LyraStringHandle filename_handle, void* target,
+    int32_t element_width, int32_t stride_bytes, int32_t value_size_bytes,
+    int32_t element_count, int64_t min_addr, int64_t current_addr,
+    int64_t final_addr, int64_t step, bool is_hex, int32_t element_kind) {
+  if (engine_ptr == nullptr) {
+    throw lyra::common::InternalError(
+        "LyraReadmemNoNotify", "engine_ptr must not be null");
+  }
+  auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
   ReadmemImpl(
-      std::filesystem::path{}, filename_handle, target, element_width,
-      stride_bytes, value_size_bytes, element_count, min_addr, current_addr,
-      final_addr, step, is_hex, element_kind);
+      engine->GetFsRoot(), filename_handle, target, element_width, stride_bytes,
+      value_size_bytes, element_count, min_addr, current_addr, final_addr, step,
+      is_hex, element_kind);
 }
 
 extern "C" void LyraPrintModulePath(void* engine_ptr, void* instance_raw) {
@@ -515,12 +515,8 @@ extern "C" void LyraWritemem(
 
   std::string filename{LyraStringAsView(filename_handle)};
 
-  // Resolve path relative to engine-owned fs_base_dir
   auto* engine = static_cast<lyra::runtime::Engine*>(engine_ptr);
-  std::filesystem::path path{filename};
-  if (path.is_relative()) {
-    path = engine->GetFsBaseDir() / path;
-  }
+  auto path = lyra::runtime::ResolveRuntimePath(engine->GetFsRoot(), filename);
 
   std::ofstream file(path);
   if (!file) {

--- a/src/lyra/runtime/simulation.cpp
+++ b/src/lyra/runtime/simulation.cpp
@@ -167,14 +167,17 @@ extern "C" void LyraRunSimulation(
               kRuntimeAbiVersion));
     }
 
-    // v25: Filesystem base directory for relative path resolution.
-    if (abi->fs_base_dir != nullptr) {
-      std::filesystem::path base(abi->fs_base_dir);
-      if (!base.is_absolute()) {
+    // v25: Filesystem root for relative runtime file operations. Either a
+    // driver-selected embedded string (kEmbeddedPlusargs) or the result of
+    // launch-time argv parsing (kArgvForwarding). Runtime neither derives
+    // it from environment nor from argv[0]; see LyraLaunchParseArgs.
+    if (abi->fs_root != nullptr) {
+      std::filesystem::path root(abi->fs_root);
+      if (!root.is_absolute()) {
         throw lyra::common::InternalError(
-            "LyraRunSimulation", "fs_base_dir must be absolute");
+            "LyraRunSimulation", "fs_root must be absolute");
       }
-      engine.SetFsBaseDir(base.lexically_normal());
+      engine.SetFsRoot(root.lexically_normal());
     }
 
     // D6d: Set simulation-global precision from emitted ABI.
@@ -308,8 +311,13 @@ extern "C" void LyraRunSimulation(
     const auto* meta = engine.GetTraceManager().GetSignalMeta();
     std::unique_ptr<lyra::trace::TextTraceSink> text_sink;
     if (abi != nullptr && abi->signal_trace_path != nullptr) {
-      text_sink = std::make_unique<lyra::trace::TextTraceSink>(
-          meta, std::string(abi->signal_trace_path));
+      // Resolve relative trace output path against the driver-selected
+      // fs_root so runtime-generated file output obeys the same anchor as
+      // runtime-consumed file input.
+      auto resolved = lyra::runtime::ResolveRuntimePath(
+          engine.GetFsRoot(), abi->signal_trace_path);
+      text_sink =
+          std::make_unique<lyra::trace::TextTraceSink>(meta, resolved.string());
     } else {
       text_sink =
           std::make_unique<lyra::trace::TextTraceSink>(meta, &engine.Output());
@@ -514,41 +522,67 @@ extern "C" void LyraSetTimeFormat(
       units, precision, suffix != nullptr ? suffix : "", min_width);
 }
 
-extern "C" auto LyraResolveBaseDir(const char* argv0) -> const char* {
-  static std::string resolved;
-
-  // Priority 1: explicit env var (set by `lyra run` for temp-dir bundles)
-  if (const char* env = std::getenv("LYRA_FS_BASE_DIR");
-      env != nullptr && std::string_view(env) != "") {
-    resolved = env;
-    return resolved.c_str();
-  }
-
-  // Priority 2: derive from executable directory
-  // Layout: <dir>/<name> (produced by `lyra compile`)
-  if (argv0 != nullptr && std::string_view(argv0) != "") {
-    std::error_code ec;
-    auto exe_path = std::filesystem::canonical(argv0, ec);
-    if (ec) {
-      // canonical requires the file to exist; try absolute as fallback
-      // (handles relative argv0 in PATH-resolved scenarios)
-      exe_path = std::filesystem::absolute(argv0, ec);
-    }
-    if (!ec) {
-      resolved = exe_path.parent_path().string();
-      return resolved.c_str();
-    }
-  }
-
-  // Fallback: current working directory
-  std::error_code ec;
-  auto cwd = std::filesystem::current_path(ec);
-  resolved = ec ? "." : cwd.string();
-  return resolved.c_str();
-}
-
 extern "C" void LyraInitRuntime(uint32_t iteration_limit) {
   LyraSetIterationLimit(iteration_limit);
+}
+
+extern "C" auto LyraLaunchParseArgs(
+    int argc, char** argv, const char** fs_root_out, const char** plusargs_out)
+    -> uint32_t {
+  static std::string fs_root_storage;
+  static constexpr std::string_view kFsRootPrefix = "--lyra-fs-root=";
+
+  auto argc_u = static_cast<uint32_t>(argc > 0 ? argc : 0);
+  std::span<char*> argv_span(argv, argc_u);
+  std::span<const char*> plusargs_span(
+      plusargs_out, argc_u > 0 ? argc_u - 1 : 0);
+
+  bool fs_root_found = false;
+  uint32_t plusargs_count = 0;
+
+  for (uint32_t i = 1; i < argc_u; ++i) {
+    std::string_view arg(argv_span[i]);
+    if (!fs_root_found && arg.starts_with(kFsRootPrefix)) {
+      auto value = arg.substr(kFsRootPrefix.size());
+      if (value.empty()) {
+        throw lyra::common::InternalError(
+            "LyraLaunchParseArgs", "--lyra-fs-root= value must not be empty");
+      }
+      std::filesystem::path path_val(value);
+      if (!path_val.is_absolute()) {
+        throw lyra::common::InternalError(
+            "LyraLaunchParseArgs",
+            std::format(
+                "--lyra-fs-root={} must be an absolute path",
+                std::string(value)));
+      }
+      fs_root_storage = path_val.lexically_normal().string();
+      fs_root_found = true;
+      continue;
+    }
+    plusargs_span[plusargs_count++] = argv_span[i];
+  }
+
+  if (fs_root_found) {
+    *fs_root_out = fs_root_storage.c_str();
+  } else {
+    // Direct-run default: anchor to launch-time CWD. current_path() returning
+    // an error is a process-level failure (e.g. deleted CWD) and must abort
+    // rather than silently produce a relative root.
+    std::error_code ec;
+    auto cwd = std::filesystem::current_path(ec);
+    if (ec) {
+      throw lyra::common::InternalError(
+          "LyraLaunchParseArgs",
+          std::format(
+              "unable to read current working directory for fs_root: {}",
+              ec.message()));
+    }
+    fs_root_storage = cwd.lexically_normal().string();
+    *fs_root_out = fs_root_storage.c_str();
+  }
+
+  return plusargs_count;
 }
 
 extern "C" void LyraReportTime(void* run_session_ptr) {

--- a/tests/framework/aot_backend.cpp
+++ b/tests/framework/aot_backend.cpp
@@ -113,9 +113,27 @@ auto RunAotBackend(
     ld_path += existing;
   }
 
-  std::vector<std::string> no_args;
+  // Driver-to-child launch contract: prepend the fs_root transport token,
+  // then any test-case user plusargs. Emitted main strips the token before
+  // the plusargs array is visible to $plusargs/$value$plusargs.
+  std::vector<std::string> child_args;
+  child_args.reserve(1 + test_case.plusargs.size());
+  auto fs_root_arg =
+      work_directory.empty()
+          ? std::format(
+                "--lyra-fs-root={}",
+                std::filesystem::absolute(std::filesystem::current_path())
+                    .string())
+          : std::format(
+                "--lyra-fs-root={}",
+                std::filesystem::absolute(work_directory).string());
+  child_args.push_back(std::move(fs_root_arg));
+  for (const auto& plusarg : test_case.plusargs) {
+    child_args.push_back(plusarg);
+  }
+
   EnvOverrides env = {{"LD_LIBRARY_PATH", ld_path}};
-  auto proc = RunChildProcess(link_result->exe_path, no_args, env, timeout);
+  auto proc = RunChildProcess(link_result->exe_path, child_args, env, timeout);
   result.artifacts.timings.execute =
       std::chrono::duration<double>(Clock::now() - t_exec).count();
 

--- a/tests/framework/lli_backend.cpp
+++ b/tests/framework/lli_backend.cpp
@@ -90,6 +90,24 @@ auto RunLliBackend(
     lli_args.push_back(std::format("--dlopen={}", dpi.string()));
   }
   lli_args.push_back(ir_path.string());
+
+  // Driver-to-child launch contract (same as AOT): prepend the fs_root
+  // transport token, then user plusargs. lli treats argv after the IR path
+  // as the loaded program's argv[1..].
+  auto fs_root_arg =
+      work_directory.empty()
+          ? std::format(
+                "--lyra-fs-root={}",
+                std::filesystem::absolute(std::filesystem::current_path())
+                    .string())
+          : std::format(
+                "--lyra-fs-root={}",
+                std::filesystem::absolute(work_directory).string());
+  lli_args.push_back(std::move(fs_root_arg));
+  for (const auto& plusarg : test_case.plusargs) {
+    lli_args.push_back(plusarg);
+  }
+
   auto proc = RunChildProcess("lli", lli_args, {}, timeout);
   result.artifacts.timings.execute =
       std::chrono::duration<double>(Clock::now() - t_exec).count();

--- a/tests/framework/llvm_common.cpp
+++ b/tests/framework/llvm_common.cpp
@@ -336,8 +336,9 @@ auto PrepareLlvmModule(
 
   // Lower MIR to LLVM IR
   auto t_llvm = Clock::now();
-  // Use work_directory for file I/O tests, otherwise fall back to CWD
-  auto fs_base_dir =
+  // Test-framework analog of driver-selected fs_root: use work_directory when
+  // the test has auxiliary files; otherwise anchor to the test process CWD.
+  auto fs_root =
       work_directory.empty()
           ? std::filesystem::absolute(std::filesystem::current_path()).string()
           : std::filesystem::absolute(work_directory).string();
@@ -370,7 +371,7 @@ auto PrepareLlvmModule(
       .source_manager = hir_result.source_manager.get(),
       .origin_provenance = &origin_provenance,
       .hooks = g_hooks_holder->hooks.get(),
-      .fs_base_dir = fs_base_dir,
+      .fs_root = fs_root,
       .plusargs = test_case.plusargs,
       .feature_flags = feature_flags,
       .signal_trace_path = {},

--- a/tests/sv_features/system_tf/effect/readmem_2state/default.yaml
+++ b/tests/sv_features/system_tf/effect/readmem_2state/default.yaml
@@ -217,3 +217,37 @@ cases:
   # Note: Descending array ranges (e.g., [8:5]) are not supported in MVP.
   # The storage layout for descending arrays uses left-based indexing,
   # but MVP readmem uses min-based indexing for simplicity.
+
+  - name: readmemh_into_function_local_array
+    description: |
+      $readmemh into an array declared inside a function (automatic,
+      function-local). Reads four bytes and sums them; verifies the filename
+      is resolved against the runtime filesystem root even when the target
+      memory is not a module-level signal.
+    files:
+      - name: test.sv
+        content: |
+          module Test;
+            bit [7:0] sum;
+            function automatic bit [7:0] read_and_sum();
+              bit [7:0] local_mem [0:3];
+              bit [7:0] acc = 0;
+              $readmemh("mem.hex", local_mem);
+              for (int i = 0; i < 4; i++) acc = acc + local_mem[i];
+              return acc;
+            endfunction
+            initial begin
+              sum = read_and_sum();
+            end
+          endmodule
+      - name: mem.hex
+        content: |
+          00
+          01
+          0a
+          ff
+    expect:
+      variables:
+        # 0 + 1 + 10 + 255 = 266, truncated to 8 bits = 10
+        sum: 10
+


### PR DESCRIPTION
## Summary

The filesystem root used for relative runtime file operations (`$fopen`, `$readmem*`, `$writemem*`, `--trace-signals=FILE`) was split across four inconsistent mechanisms: a driver-computed `fs_base_dir`, a compile-time IR constant baked only in `kEmbeddedPlusargs` mode, an `argv[0]`-based heuristic in `kArgvForwarding` mode, and a `LYRA_FS_BASE_DIR` env var patched in by `run_aot.cpp`. JIT happened to work; AOT lost the driver value at every launch and then got it back via an env-var hack; LLI got neither; direct-run compiled binaries silently fell back to the executable directory. This produced 42 failing AOT file I/O tests on `main`.

This change replaces the whole arrangement with one contract. The driver chooses `fs_root` once in `PrepareInput` (project mode: config root; `--no-project` mode: effective CWD after `-C`). For JIT the value is embedded in the IR. For AOT and LLI, the driver transports it to the child process as the first argv token (`--lyra-fs-root=<abs path>`); the emitted `main(argc, argv)` consumes that token via a new runtime helper `LyraLaunchParseArgs`, which also filters it out of the plusargs array. Direct-run of a compiled binary resolves `fs_root` to launch-time CWD. `LyraResolveBaseDir`, `LYRA_FS_BASE_DIR`, the `argv[0]` heuristic, and the executable-directory fallback are all removed.

On the runtime side, every relative file operation now funnels through one helper, `ResolveRuntimePath(fs_root, path)`. That replaces the old `FileManager::ResolvePath` plus inline "if relative, join" logic duplicated across `$fopen`, `$readmem*`, and `$writemem*`. The `LyraReadmemNoNotify` variant, which previously passed an empty base_dir and silently anchored relative paths to CWD, now takes `engine_ptr` and uses the same resolver as every other readmem call site; its codegen signature is updated accordingly. Signal trace output (`--trace-signals=FILE`) is also routed through `ResolveRuntimePath` so runtime-generated output obeys the same anchor as runtime-consumed input. `LyraLaunchParseArgs` rejects malformed transport tokens (non-empty + absolute) with `InternalError` before handing anything to `LyraRunSimulation`, and refuses to fall back to `.` on CWD failure. `MainAbi` is narrowed in code and comments to govern plusargs transport only; filesystem semantics no longer differ by mode.

The `fs_base_dir` name is gone throughout: `CompilationInput`, `LoweringInput`, `EmitDesignMainInput`, the runtime ABI struct, and `Engine::SetFsBaseDir`/`GetFsBaseDir` are all renamed to `fs_root`/`SetFsRoot`/`GetFsRoot`. Driver-side behavior (config loading, `-o`, `--stats-out`, DPI link input resolution) is unchanged.

## Testing

- `//tests:jit_dev_tests` passes.
- `//tests:aot_dev_tests` passes. All 42 originally-failing file I/O and plusargs cases now green, including the plusargs forwarding gap that the test framework previously had (child argv was empty).
- `//tests:jit_two_state_tests` passes.
- New YAML regression `readmemh_into_function_local_array` in `tests/sv_features/system_tf/effect/readmem_2state/default.yaml` exercises the `$readmemh`-into-function-local-array path (the one that previously bypassed the runtime root), proving all backends converge on the same fs_root resolution.
- LLI `dpi_export_general_*` still fail with exit 127 in local runs; they predate this refactor and are disjoint from the fs_root contract (`--dlopen` behavior, no fs_root/plusargs interaction).