### PR TITLE
Add coroutine-based C++ runtime and host emit

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,21 @@ load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
+filegroup(
+    name = "runtime_sources",
+    srcs = glob(["src/lyra/runtime/*.cpp"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "runtime_headers",
+    srcs = glob([
+        "include/lyra/runtime/*.hpp",
+        "include/lyra/support/*.hpp",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
 refresh_compile_commands(
     name = "refresh_compile_commands",
     exclude_external_sources = True,
@@ -39,6 +54,15 @@ cc_library(
         ":diag",
         "@slang",
     ],
+)
+
+cc_library(
+    name = "runtime",
+    srcs = glob(["src/lyra/runtime/*.cpp"]),
+    hdrs = glob(["include/lyra/runtime/*.hpp"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [":support"],
 )
 
 cc_library(

--- a/include/lyra/backend/cpp/api.hpp
+++ b/include/lyra/backend/cpp/api.hpp
@@ -1,15 +1,14 @@
 #pragma once
 
-#include <string>
-
+#include "lyra/backend/cpp/artifact.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 
 namespace lyra::backend::cpp {
 
-// Emit a MIR compilation unit as C++ code. Each class in unit.Classes()
-// becomes one C++ class declaration in order: members emit as fields, the
-// class constructor body emits as an inline constructor, and each process
-// emits as a method.
-auto EmitCpp(const mir::CompilationUnit& unit) -> std::string;
+// Emit a MIR compilation unit as a set of C++ artifact files. The unit must
+// contain exactly one class for this cut; the result contains:
+//   <ClassName>.hpp -- the class declaration inheriting lyra::runtime::Module
+//   main.cpp        -- a host driver that constructs the class and runs it
+auto EmitCpp(const mir::CompilationUnit& unit) -> CppArtifactSet;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/backend/cpp/artifact.hpp
+++ b/include/lyra/backend/cpp/artifact.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace lyra::backend::cpp {
+
+struct CppArtifact {
+  std::string relpath;
+  std::string content;
+};
+
+struct CppArtifactSet {
+  std::vector<CppArtifact> files;
+};
+
+}  // namespace lyra::backend::cpp

--- a/include/lyra/hir/process.hpp
+++ b/include/lyra/hir/process.hpp
@@ -2,7 +2,6 @@
 
 #include <compare>
 #include <cstdint>
-#include <variant>
 #include <vector>
 
 #include "lyra/hir/expr.hpp"
@@ -16,14 +15,11 @@ struct ProcessId {
   auto operator<=>(const ProcessId&) const -> std::strong_ordering = default;
 };
 
-struct Initial {
-  StmtId body;
-};
-
-using ProcessData = std::variant<Initial>;
+enum class ProcessKind { kInitial };
 
 struct Process {
-  ProcessData data;
+  ProcessKind kind = ProcessKind::kInitial;
+  StmtId body{};
   std::vector<Expr> exprs;
   std::vector<Stmt> stmts;
 };

--- a/include/lyra/mir/process.hpp
+++ b/include/lyra/mir/process.hpp
@@ -2,7 +2,6 @@
 
 #include <compare>
 #include <cstdint>
-#include <variant>
 
 #include "lyra/mir/stmt.hpp"
 
@@ -14,12 +13,10 @@ struct ProcessId {
   auto operator<=>(const ProcessId&) const -> std::strong_ordering = default;
 };
 
-struct Initial {};
-
-using ProcessData = std::variant<Initial>;
+enum class ProcessKind { kInitial };
 
 struct Process {
-  ProcessData data;
+  ProcessKind kind;
   Body body;
 };
 

--- a/include/lyra/runtime/bind_context.hpp
+++ b/include/lyra/runtime/bind_context.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "lyra/runtime/process.hpp"
+#include "lyra/runtime/process_kind.hpp"
+
+namespace lyra::runtime {
+
+class Engine;
+class RuntimeScope;
+
+class RuntimeBindContext {
+ public:
+  RuntimeBindContext(Engine& engine, RuntimeScope& scope);
+
+  auto CurrentScope() -> RuntimeScope&;
+  void AddProcess(ProcessKind kind, Process process);
+
+ private:
+  Engine* engine_ = nullptr;
+  RuntimeScope* scope_ = nullptr;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <deque>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "lyra/runtime/bind_context.hpp"
+#include "lyra/runtime/process.hpp"
+#include "lyra/runtime/process_kind.hpp"
+#include "lyra/runtime/runtime_process.hpp"
+#include "lyra/runtime/runtime_scope.hpp"
+
+namespace lyra::runtime {
+
+class Module;
+
+class Engine {
+ public:
+  void BindRoot(std::string root_name, Module& top);
+  auto Run() -> int;
+
+  void AddProcess(RuntimeScope& owner, ProcessKind kind, Process process);
+
+ private:
+  std::vector<std::unique_ptr<RuntimeScope>> scopes_;
+  std::vector<RuntimeProcess> processes_;
+  std::deque<RuntimeProcess*> active_queue_;
+  bool bound_ = false;
+  bool ran_ = false;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/module.hpp
+++ b/include/lyra/runtime/module.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace lyra::runtime {
+
+class RuntimeBindContext;
+
+class Module {
+ public:
+  Module() = default;
+  virtual ~Module() = default;
+  Module(const Module&) = delete;
+  auto operator=(const Module&) -> Module& = delete;
+  Module(Module&&) = delete;
+  auto operator=(Module&&) -> Module& = delete;
+
+  virtual void Bind(RuntimeBindContext& ctx) = 0;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/process.hpp
+++ b/include/lyra/runtime/process.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <coroutine>
+#include <utility>
+
+#include "lyra/support/internal_error.hpp"
+
+namespace lyra::runtime {
+
+class Process {
+ public:
+  // C++20 coroutine protocol names are spelled by the standard.
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  struct promise_type {
+    bool failed = false;
+
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    auto get_return_object() -> Process {
+      return Process{std::coroutine_handle<promise_type>::from_promise(*this)};
+    }
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    static auto initial_suspend() noexcept -> std::suspend_always {
+      return {};
+    }
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    static auto final_suspend() noexcept -> std::suspend_always {
+      return {};
+    }
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    static void return_void() {
+    }
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    void unhandled_exception() noexcept {
+      failed = true;
+    }
+  };
+
+  Process() = default;
+  Process(const Process&) = delete;
+  auto operator=(const Process&) -> Process& = delete;
+
+  Process(Process&& other) noexcept
+      : handle_(std::exchange(other.handle_, {})) {
+  }
+  auto operator=(Process&& other) noexcept -> Process& {
+    if (handle_) {
+      handle_.destroy();
+    }
+    handle_ = std::exchange(other.handle_, {});
+    return *this;
+  }
+  ~Process() {
+    if (handle_) {
+      handle_.destroy();
+    }
+  }
+
+  void Resume() {
+    if (!handle_) {
+      throw support::InternalError(
+          "lyra::runtime::Process::Resume on empty handle");
+    }
+    if (handle_.done()) {
+      throw support::InternalError(
+          "lyra::runtime::Process::Resume on already-done coroutine");
+    }
+    handle_.resume();
+    if (handle_.promise().failed) {
+      handle_.promise().failed = false;
+      throw support::InternalError("lyra::runtime::Process body failed");
+    }
+  }
+
+  [[nodiscard]] auto Done() const -> bool {
+    return !handle_ || handle_.done();
+  }
+
+ private:
+  explicit Process(std::coroutine_handle<promise_type> h) : handle_(h) {
+  }
+
+  std::coroutine_handle<promise_type> handle_;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/process_kind.hpp
+++ b/include/lyra/runtime/process_kind.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace lyra::runtime {
+
+enum class ProcessKind {
+  kInitial,
+  kAlways,
+  kAlwaysComb,
+  kAlwaysFf,
+  kFinal,
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_process.hpp
+++ b/include/lyra/runtime/runtime_process.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "lyra/runtime/process.hpp"
+#include "lyra/runtime/process_kind.hpp"
+
+namespace lyra::runtime {
+
+class RuntimeScope;
+
+class RuntimeProcess {
+ public:
+  RuntimeProcess(RuntimeScope& owner, ProcessKind kind, Process process);
+
+  RuntimeProcess(const RuntimeProcess&) = delete;
+  auto operator=(const RuntimeProcess&) -> RuntimeProcess& = delete;
+  RuntimeProcess(RuntimeProcess&&) noexcept = default;
+  auto operator=(RuntimeProcess&&) noexcept -> RuntimeProcess& = default;
+  ~RuntimeProcess() = default;
+
+  auto Owner() -> RuntimeScope&;
+  [[nodiscard]] auto Kind() const -> ProcessKind;
+  void Run();
+
+ private:
+  RuntimeScope* owner_ = nullptr;
+  ProcessKind kind_;
+  Process process_;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_scope.hpp
+++ b/include/lyra/runtime/runtime_scope.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "lyra/runtime/runtime_scope_kind.hpp"
+
+namespace lyra::runtime {
+
+class RuntimeScope {
+ public:
+  RuntimeScope(RuntimeScope* parent, std::string name, RuntimeScopeKind kind);
+
+  auto Parent() -> RuntimeScope*;
+  [[nodiscard]] auto Name() const -> std::string_view;
+  [[nodiscard]] auto Kind() const -> RuntimeScopeKind;
+
+  void AddChild(RuntimeScope& child);
+  [[nodiscard]] auto Children() const -> std::span<RuntimeScope* const>;
+
+ private:
+  RuntimeScope* parent_ = nullptr;
+  std::string name_;
+  RuntimeScopeKind kind_;
+  std::vector<RuntimeScope*> children_;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_scope_kind.hpp
+++ b/include/lyra/runtime/runtime_scope_kind.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace lyra::runtime {
+
+enum class RuntimeScopeKind {
+  kModule,
+  kGenerate,
+};
+
+}  // namespace lyra::runtime

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -3,10 +3,12 @@
 
 #include "formatting.hpp"
 #include "lyra/backend/cpp/api.hpp"
+#include "lyra/backend/cpp/artifact.hpp"
 #include "lyra/mir/class_decl.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/member.hpp"
 #include "lyra/mir/process.hpp"
+#include "lyra/support/internal_error.hpp"
 #include "render_stmt.hpp"
 #include "render_type.hpp"
 
@@ -40,15 +42,51 @@ auto RenderProcessMethod(
     const mir::ClassDecl& c, const mir::Process& process, std::size_t index)
     -> std::string {
   std::string out;
-  out += Indent(1) + "void " + RenderProcessMethodName(index) + "() {\n";
+  out += Indent(1) + "auto " + RenderProcessMethodName(index) +
+         "() -> lyra::runtime::Process {\n";
   out += RenderBody(c, process.body, 2);
+  // This cut only handles zero-time `initial` bodies. Every body terminates
+  // by falling off the end, so we always emit a trailing `co_return;` to make
+  // the function a valid coroutine even when the MIR body is empty. When
+  // delay/wait/event awaiters land, this trailing emission stays put; bodies
+  // with `co_await` simply have suspension points before it.
+  out += Indent(2) + "co_return;\n";
   out += Indent(1) + "}\n";
   return out;
 }
 
-auto RenderClass(const mir::ClassDecl& c) -> std::string {
+auto RenderProcessKindLiteral(mir::ProcessKind kind) -> std::string {
+  switch (kind) {
+    case mir::ProcessKind::kInitial:
+      return "lyra::runtime::ProcessKind::kInitial";
+  }
+  throw support::InternalError("RenderProcessKindLiteral: unknown ProcessKind");
+}
+
+auto RenderBind(const mir::ClassDecl& c) -> std::string {
   std::string out;
-  out += "class " + c.Name() + " {\n";
+  out += Indent(1) +
+         "void Bind(lyra::runtime::RuntimeBindContext& ctx) override {\n";
+  for (std::size_t i = 0; i < c.Processes().size(); ++i) {
+    const auto& p = c.Processes()[i];
+    out += Indent(2) + "ctx.AddProcess(\n";
+    out += Indent(3) + RenderProcessKindLiteral(p.kind) + ",\n";
+    out += Indent(3) + RenderProcessMethodName(i) + "());\n";
+  }
+  out += Indent(1) + "}\n";
+  return out;
+}
+
+auto RenderClassHeader(const mir::ClassDecl& c) -> std::string {
+  std::string out;
+  out += "#pragma once\n";
+  out += "#include \"lyra/runtime/bind_context.hpp\"\n";
+  out += "#include \"lyra/runtime/engine.hpp\"\n";
+  out += "#include \"lyra/runtime/module.hpp\"\n";
+  out += "#include \"lyra/runtime/process.hpp\"\n";
+  out += "#include \"lyra/runtime/process_kind.hpp\"\n";
+  out += "\n";
+  out += "class " + c.Name() + " final : public lyra::runtime::Module {\n";
   out += " public:\n";
 
   for (const auto& m : c.Members()) {
@@ -59,6 +97,8 @@ auto RenderClass(const mir::ClassDecl& c) -> std::string {
   }
 
   out += RenderConstructor(c);
+  out += "\n";
+  out += RenderBind(c);
 
   for (std::size_t i = 0; i < c.Processes().size(); ++i) {
     out += "\n";
@@ -69,19 +109,31 @@ auto RenderClass(const mir::ClassDecl& c) -> std::string {
   return out;
 }
 
+auto RenderHostMain(const mir::ClassDecl& cls) -> std::string {
+  std::string out;
+  out += "#include \"" + cls.Name() + ".hpp\"\n";
+  out += "\n";
+  out += "auto main() -> int {\n";
+  out += "  " + cls.Name() + " top;\n";
+  out += "  lyra::runtime::Engine engine;\n";
+  out += "  engine.BindRoot(\"top\", top);\n";
+  out += "  return engine.Run();\n";
+  out += "}\n";
+  return out;
+}
+
 }  // namespace
 
-auto EmitCpp(const mir::CompilationUnit& unit) -> std::string {
-  std::string out;
-  bool first = true;
-  for (const auto& cls : unit.Classes()) {
-    if (!first) {
-      out += "\n";
-    }
-    out += RenderClass(cls);
-    first = false;
+auto EmitCpp(const mir::CompilationUnit& unit) -> CppArtifactSet {
+  if (unit.Classes().size() != 1) {
+    throw support::InternalError(
+        "EmitCpp: this cut requires exactly one class in the unit");
   }
-  return out;
+  CppArtifactSet set;
+  const auto& cls = unit.Classes().front();
+  set.files.push_back({cls.Name() + ".hpp", RenderClassHeader(cls)});
+  set.files.push_back({"main.cpp", RenderHostMain(cls)});
+  return set;
 }
 
 }  // namespace lyra::backend::cpp

--- a/src/lyra/driver/cli.cpp
+++ b/src/lyra/driver/cli.cpp
@@ -2,8 +2,11 @@
 #include <cstdio>
 #include <exception>
 #include <expected>
+#include <filesystem>
 #include <format>
+#include <fstream>
 #include <string>
+#include <system_error>
 #include <unistd.h>
 #include <utility>
 #include <vector>
@@ -11,6 +14,7 @@
 #include <fmt/core.h>
 
 #include "lyra/backend/cpp/api.hpp"
+#include "lyra/backend/cpp/artifact.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/render.hpp"
 #include "lyra/diag/sink.hpp"
@@ -32,6 +36,7 @@ struct ParsedArgs {
   bool no_color = false;
   bool force_color = false;
   lyra::frontend::CompilationInput input;
+  std::string emit_out_dir;
 };
 
 void AddCompilationFlags(argparse::ArgumentParser& cmd) {
@@ -104,6 +109,9 @@ auto ParseArgs(int argc, char** argv)
   argparse::ArgumentParser emit_cmd("emit");
   argparse::ArgumentParser emit_cpp_cmd("cpp");
   AddCompilationFlags(emit_cpp_cmd);
+  emit_cpp_cmd.add_argument("-o", "--out-dir")
+      .help("write C++ artifacts to this directory")
+      .default_value(std::string{});
   emit_cmd.add_subparser(emit_cpp_cmd);
 
   program.add_subparser(dump_cmd);
@@ -133,6 +141,7 @@ auto ParseArgs(int argc, char** argv)
     if (emit_cmd.is_subcommand_used("cpp")) {
       out.cmd = CommandKind::kEmitCpp;
       BindCompilationFlags(emit_cpp_cmd, out);
+      out.emit_out_dir = emit_cpp_cmd.get<std::string>("--out-dir");
     } else {
       return std::unexpected(
           std::format("emit requires 'cpp'\n{}", emit_cmd.help().str()));
@@ -243,9 +252,51 @@ auto main(int argc, char** argv) -> int {
       case CommandKind::kDumpMir:
         fmt::print("{}", lyra::mir::DumpMir(*mir_unit));
         return 0;
-      case CommandKind::kEmitCpp:
-        fmt::print("{}", lyra::backend::cpp::EmitCpp(*mir_unit));
+      case CommandKind::kEmitCpp: {
+        auto set = lyra::backend::cpp::EmitCpp(*mir_unit);
+        if (args.emit_out_dir.empty()) {
+          for (const auto& file : set.files) {
+            fmt::print("=== {} ===\n{}", file.relpath, file.content);
+            if (!file.content.empty() && file.content.back() != '\n') {
+              fmt::print("\n");
+            }
+          }
+        } else {
+          std::error_code ec;
+          std::filesystem::create_directories(args.emit_out_dir, ec);
+          if (ec) {
+            throw lyra::support::InternalError(
+                std::format(
+                    "emit cpp: failed to create out-dir '{}': {}",
+                    args.emit_out_dir, ec.message()));
+          }
+          for (const auto& file : set.files) {
+            const auto path =
+                std::filesystem::path(args.emit_out_dir) / file.relpath;
+            std::filesystem::create_directories(path.parent_path(), ec);
+            if (ec) {
+              throw lyra::support::InternalError(
+                  std::format(
+                      "emit cpp: failed to create '{}': {}",
+                      path.parent_path().string(), ec.message()));
+            }
+            std::ofstream out_stream(path);
+            if (!out_stream) {
+              throw lyra::support::InternalError(
+                  std::format(
+                      "emit cpp: failed to open '{}' for write",
+                      path.string()));
+            }
+            out_stream << file.content;
+            out_stream.flush();
+            if (!out_stream) {
+              throw lyra::support::InternalError(
+                  std::format("emit cpp: failed to write '{}'", path.string()));
+            }
+          }
+        }
         return 0;
+      }
       case CommandKind::kDumpHir:
         break;
     }

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -150,16 +150,14 @@ class HirDumper {
   }
 
   void DumpProcess(const Process& p) {
-    std::visit(
-        support::Overloaded{
-            [&](const Initial& init) {
-              Line("Process (Initial)");
-              Indent();
-              DumpStmt(p, init.body);
-              Dedent();
-            },
-        },
-        p.data);
+    switch (p.kind) {
+      case ProcessKind::kInitial:
+        Line("Process (Initial)");
+        break;
+    }
+    Indent();
+    DumpStmt(p, p.body);
+    Dedent();
   }
 
   void DumpStmt(const Process& p, StmtId id) {

--- a/src/lyra/lowering/ast_to_hir/process.cpp
+++ b/src/lyra/lowering/ast_to_hir/process.cpp
@@ -24,7 +24,7 @@ auto LowerProcess(
   if (!body) return std::unexpected(std::move(body.error()));
   const hir::StmtId body_id = proc_state.AppendStmt(*std::move(body));
 
-  return proc_state.Finalize(hir::Initial{.body = body_id});
+  return proc_state.Finalize(hir::ProcessKind::kInitial, body_id);
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/state.hpp
+++ b/src/lyra/lowering/ast_to_hir/state.hpp
@@ -200,8 +200,9 @@ class ProcessLoweringState {
     return id;
   }
 
-  auto Finalize(hir::ProcessData data) -> hir::Process {
-    hir_process_.data = std::move(data);
+  auto Finalize(hir::ProcessKind kind, hir::StmtId body) -> hir::Process {
+    hir_process_.kind = kind;
+    hir_process_.body = body;
     return std::move(hir_process_);
   }
 

--- a/src/lyra/lowering/hir_to_mir/lower_process.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_process.cpp
@@ -15,10 +15,19 @@
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/process.hpp"
 #include "lyra/mir/stmt.hpp"
+#include "lyra/support/internal_error.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
 namespace {
+
+auto LowerProcessKind(hir::ProcessKind kind) -> mir::ProcessKind {
+  switch (kind) {
+    case hir::ProcessKind::kInitial:
+      return mir::ProcessKind::kInitial;
+  }
+  throw support::InternalError("LowerProcessKind: unknown HIR ProcessKind");
+}
 
 void LowerStmtIntoBody(
     const UnitLoweringFacts& unit_facts, const UnitLoweringState& unit_state,
@@ -59,10 +68,10 @@ auto LowerProcess(
                         unit_facts, unit_state, stack, src.exprs[i].data)});
   }
 
-  const auto& init = std::get<hir::Initial>(src.data);
-  LowerStmtIntoBody(unit_facts, unit_state, src, init.body, body_state, stack);
+  LowerStmtIntoBody(unit_facts, unit_state, src, src.body, body_state, stack);
 
-  return mir::Process{.data = mir::Initial{}, .body = body_state.Finish()};
+  return mir::Process{
+      .kind = LowerProcessKind(src.kind), .body = body_state.Finish()};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -74,11 +74,11 @@ class MirDumper {
   }
 
   static auto FormatProcessKind(const Process& p) -> std::string {
-    return std::visit(
-        support::Overloaded{
-            [](const Initial&) -> std::string { return "Initial"; },
-        },
-        p.data);
+    switch (p.kind) {
+      case ProcessKind::kInitial:
+        return "Initial";
+    }
+    throw support::InternalError("MirDumper: unknown ProcessKind");
   }
 
   void DumpClass(const ClassDecl& c) {

--- a/src/lyra/runtime/bind_context.cpp
+++ b/src/lyra/runtime/bind_context.cpp
@@ -1,0 +1,24 @@
+#include "lyra/runtime/bind_context.hpp"
+
+#include <utility>
+
+#include "lyra/runtime/engine.hpp"
+#include "lyra/runtime/process.hpp"
+#include "lyra/runtime/process_kind.hpp"
+#include "lyra/runtime/runtime_scope.hpp"
+
+namespace lyra::runtime {
+
+RuntimeBindContext::RuntimeBindContext(Engine& engine, RuntimeScope& scope)
+    : engine_(&engine), scope_(&scope) {
+}
+
+auto RuntimeBindContext::CurrentScope() -> RuntimeScope& {
+  return *scope_;
+}
+
+void RuntimeBindContext::AddProcess(ProcessKind kind, Process process) {
+  engine_->AddProcess(*scope_, kind, std::move(process));
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -1,0 +1,64 @@
+#include "lyra/runtime/engine.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "lyra/runtime/bind_context.hpp"
+#include "lyra/runtime/module.hpp"
+#include "lyra/runtime/process.hpp"
+#include "lyra/runtime/process_kind.hpp"
+#include "lyra/runtime/runtime_process.hpp"
+#include "lyra/runtime/runtime_scope.hpp"
+#include "lyra/runtime/runtime_scope_kind.hpp"
+#include "lyra/support/internal_error.hpp"
+
+namespace lyra::runtime {
+
+void Engine::BindRoot(std::string root_name, Module& top) {
+  if (bound_) {
+    throw support::InternalError("Engine::BindRoot called more than once");
+  }
+  bound_ = true;
+  scopes_.push_back(
+      std::make_unique<RuntimeScope>(
+          nullptr, std::move(root_name), RuntimeScopeKind::kModule));
+  RuntimeBindContext ctx(*this, *scopes_.front());
+  top.Bind(ctx);
+}
+
+void Engine::AddProcess(
+    RuntimeScope& owner, ProcessKind kind, Process process) {
+  processes_.emplace_back(owner, kind, std::move(process));
+}
+
+auto Engine::Run() -> int {
+  if (!bound_) {
+    throw support::InternalError("Engine::Run called before BindRoot");
+  }
+  if (ran_) {
+    throw support::InternalError("Engine::Run called more than once");
+  }
+  ran_ = true;
+  for (auto& proc : processes_) {
+    switch (proc.Kind()) {
+      case ProcessKind::kInitial:
+        active_queue_.push_back(&proc);
+        break;
+      case ProcessKind::kAlways:
+      case ProcessKind::kAlwaysComb:
+      case ProcessKind::kAlwaysFf:
+      case ProcessKind::kFinal:
+        throw support::InternalError(
+            "Engine::Run: unsupported runtime ProcessKind in this cut");
+    }
+  }
+  while (!active_queue_.empty()) {
+    auto* proc = active_queue_.front();
+    active_queue_.pop_front();
+    proc->Run();
+  }
+  return 0;
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/runtime/runtime_process.cpp
+++ b/src/lyra/runtime/runtime_process.cpp
@@ -1,0 +1,34 @@
+#include "lyra/runtime/runtime_process.hpp"
+
+#include <utility>
+
+#include "lyra/runtime/process.hpp"
+#include "lyra/runtime/process_kind.hpp"
+#include "lyra/runtime/runtime_scope.hpp"
+#include "lyra/support/internal_error.hpp"
+
+namespace lyra::runtime {
+
+RuntimeProcess::RuntimeProcess(
+    RuntimeScope& owner, ProcessKind kind, Process process)
+    : owner_(&owner), kind_(kind), process_(std::move(process)) {
+}
+
+auto RuntimeProcess::Owner() -> RuntimeScope& {
+  return *owner_;
+}
+
+auto RuntimeProcess::Kind() const -> ProcessKind {
+  return kind_;
+}
+
+void RuntimeProcess::Run() {
+  process_.Resume();
+  if (!process_.Done()) {
+    throw support::InternalError(
+        "RuntimeProcess::Run: process suspended without completing; this "
+        "cut has no awaitables, so Done() must hold after Resume");
+  }
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/runtime/runtime_scope.cpp
+++ b/src/lyra/runtime/runtime_scope.cpp
@@ -1,0 +1,37 @@
+#include "lyra/runtime/runtime_scope.hpp"
+
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "lyra/runtime/runtime_scope_kind.hpp"
+
+namespace lyra::runtime {
+
+RuntimeScope::RuntimeScope(
+    RuntimeScope* parent, std::string name, RuntimeScopeKind kind)
+    : parent_(parent), name_(std::move(name)), kind_(kind) {
+}
+
+auto RuntimeScope::Parent() -> RuntimeScope* {
+  return parent_;
+}
+
+auto RuntimeScope::Name() const -> std::string_view {
+  return name_;
+}
+
+auto RuntimeScope::Kind() const -> RuntimeScopeKind {
+  return kind_;
+}
+
+void RuntimeScope::AddChild(RuntimeScope& child) {
+  children_.push_back(&child);
+}
+
+auto RuntimeScope::Children() const -> std::span<RuntimeScope* const> {
+  return children_;
+}
+
+}  // namespace lyra::runtime

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -51,6 +51,11 @@ cc_test(
         "//:runtime_headers",
         "//:runtime_sources",
     ],
+    # Compiles emitted artifacts with the host C++ compiler. Skipped from
+    # `bazel test //...` until a host C++ toolchain is wired into CI; mirrors
+    # the disabled aot-full job in .github/workflows/bazel-build.yml. Run
+    # locally with `bazel test //tests:cli_run_tests`.
+    tags = ["manual"],
     deps = [
         ":framework",
         "@bazel_tools//tools/cpp/runfiles",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -41,3 +41,19 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "cli_run_tests",
+    srcs = ["cli_run_test.cpp"],
+    data = [
+        "cases/run/blocking_assign.sv",
+        "//:lyra",
+        "//:runtime_headers",
+        "//:runtime_sources",
+    ],
+    deps = [
+        ":framework",
+        "@bazel_tools//tools/cpp/runfiles",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/tests/cases/emit/generate_if/case.yaml
+++ b/tests/cases/emit/generate_if/case.yaml
@@ -9,11 +9,17 @@ expect:
   exit: 0
   stdout:
     contains:
-      - "class Top"
+      - "=== Top.hpp ==="
+      - "=== main.cpp ==="
+      - "class Top final : public lyra::runtime::Module"
       - "Top() {"
       - "if (1) {"
       - "switch (1) {"
       - "case 0:"
       - "default:"
-      - "void process_0()"
+      - "auto process_0() -> lyra::runtime::Process"
+      - "co_return;"
       - "x = 1;"
+      - "ctx.AddProcess("
+      - "lyra::runtime::ProcessKind::kInitial"
+      - "process_0()"

--- a/tests/cases/emit/tiny_module/case.yaml
+++ b/tests/cases/emit/tiny_module/case.yaml
@@ -8,4 +8,15 @@ input:
 expect:
   exit: 0
   stdout:
-    contains: ["class Top", "public:", "int x;", "int y;", "Top() {}"]
+    contains:
+      - "=== Top.hpp ==="
+      - "=== main.cpp ==="
+      - "class Top final : public lyra::runtime::Module"
+      - "public:"
+      - "int x;"
+      - "int y;"
+      - "Top() {}"
+      - "void Bind(lyra::runtime::RuntimeBindContext& ctx) override"
+      - "auto main() -> int"
+      - 'engine.BindRoot("top", top)'
+      - "return engine.Run()"

--- a/tests/cases/run/blocking_assign.sv
+++ b/tests/cases/run/blocking_assign.sv
@@ -1,0 +1,6 @@
+module Top;
+  int x;
+  initial begin
+    x = 1;
+  end
+endmodule

--- a/tests/cli_run_test.cpp
+++ b/tests/cli_run_test.cpp
@@ -1,0 +1,71 @@
+#include <chrono>
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "tests/framework/build.hpp"
+#include "tests/framework/process.hpp"
+#include "tools/cpp/runfiles/runfiles.h"
+
+using bazel::tools::cpp::runfiles::Runfiles;
+using lyra::test::BuildAndRunEmittedArtifacts;
+using lyra::test::MakeTempCaseDir;
+using lyra::test::RunChildProcess;
+using lyra::test::TerminationKind;
+
+namespace {
+
+TEST(CliRun, BlockingAssign) {
+  std::string err;
+  std::unique_ptr<Runfiles> rf{Runfiles::CreateForTest(&err)};
+  ASSERT_TRUE(rf) << err;
+
+  const std::filesystem::path lyra_exe = rf->Rlocation("_main/lyra");
+  ASSERT_FALSE(lyra_exe.empty());
+  ASSERT_TRUE(std::filesystem::exists(lyra_exe)) << lyra_exe;
+
+  const std::filesystem::path sv_path =
+      rf->Rlocation("_main/tests/cases/run/blocking_assign.sv");
+  ASSERT_FALSE(sv_path.empty());
+  ASSERT_TRUE(std::filesystem::exists(sv_path)) << sv_path;
+
+  const std::filesystem::path engine_hpp =
+      rf->Rlocation("_main/include/lyra/runtime/engine.hpp");
+  ASSERT_FALSE(engine_hpp.empty());
+  ASSERT_TRUE(std::filesystem::exists(engine_hpp)) << engine_hpp;
+  const std::filesystem::path include_root =
+      engine_hpp.parent_path().parent_path().parent_path();
+
+  const std::filesystem::path engine_cpp =
+      rf->Rlocation("_main/src/lyra/runtime/engine.cpp");
+  ASSERT_FALSE(engine_cpp.empty());
+  ASSERT_TRUE(std::filesystem::exists(engine_cpp)) << engine_cpp;
+  const std::filesystem::path runtime_src_dir = engine_cpp.parent_path();
+
+  auto work_or = MakeTempCaseDir();
+  ASSERT_TRUE(work_or) << work_or.error();
+  const auto& work = *work_or;
+
+  // Step 1: emit. argv is argv[1..]; lyra_exe becomes argv[0] inside
+  // RunChildProcess.
+  const std::vector<std::string> emit_argv = {
+      "emit", "cpp",       "--no-project", "--top",
+      "Top",  "--out-dir", work.string(),  sv_path.string(),
+  };
+  auto emit = RunChildProcess(lyra_exe, emit_argv, std::chrono::seconds{30});
+  ASSERT_EQ(emit.termination, TerminationKind::kExitedNormally)
+      << "emit failed:\nstdout:\n"
+      << emit.stdout_text << "\nstderr:\n"
+      << emit.stderr_text;
+
+  // Step 2: build + run.
+  auto outcome =
+      BuildAndRunEmittedArtifacts(work, include_root, runtime_src_dir);
+  ASSERT_FALSE(outcome.error.has_value()) << *outcome.error;
+  EXPECT_EQ(outcome.exit_code, 0)
+      << "stdout=" << outcome.stdout_text << " stderr=" << outcome.stderr_text;
+}
+
+}  // namespace

--- a/tests/framework/build.cpp
+++ b/tests/framework/build.cpp
@@ -1,0 +1,177 @@
+#include "build.hpp"
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <expected>
+#include <filesystem>
+#include <format>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+#include <vector>
+
+#include "process.hpp"
+
+namespace lyra::test {
+
+namespace {
+
+auto IsExecutableFile(const std::filesystem::path& path) -> bool {
+  std::error_code ec;
+  if (!std::filesystem::is_regular_file(path, ec) || ec) {
+    return false;
+  }
+  return access(path.c_str(), X_OK) == 0;
+}
+
+auto FindOnPath(std::string_view name)
+    -> std::expected<std::filesystem::path, std::string> {
+  const std::filesystem::path candidate(name);
+  if (candidate.is_absolute() || candidate.has_parent_path()) {
+    auto absolute = std::filesystem::absolute(candidate);
+    if (IsExecutableFile(absolute)) {
+      return absolute;
+    }
+    return std::unexpected(
+        std::format("'{}' is not an executable file", absolute.string()));
+  }
+  const char* path_env = std::getenv("PATH");
+  if (path_env == nullptr) {
+    return std::unexpected("PATH is unset");
+  }
+  std::string_view path(path_env);
+  while (!path.empty()) {
+    const auto sep = path.find(':');
+    const auto entry = path.substr(0, sep);
+    if (!entry.empty()) {
+      auto full = std::filesystem::path(entry) / candidate;
+      if (IsExecutableFile(full)) {
+        return full;
+      }
+    }
+    if (sep == std::string_view::npos) {
+      break;
+    }
+    path.remove_prefix(sep + 1);
+  }
+  return std::unexpected(
+      std::format("'{}' not found on PATH", candidate.string()));
+}
+
+auto ResolveCxxCompiler() -> std::expected<std::filesystem::path, std::string> {
+  const char* env = std::getenv("CXX");
+  if (env != nullptr) {
+    const std::string_view sv(env);
+    if (!sv.empty()) {
+      return FindOnPath(sv);
+    }
+  }
+  return FindOnPath("clang++");
+}
+
+auto CollectRuntimeSources(const std::filesystem::path& dir)
+    -> std::expected<std::vector<std::filesystem::path>, std::string> {
+  std::vector<std::filesystem::path> out;
+  std::error_code ec;
+  std::filesystem::directory_iterator it(dir, ec);
+  if (ec) {
+    return std::unexpected(
+        std::format(
+            "directory_iterator('{}') failed: {}", dir.string(), ec.message()));
+  }
+  for (const auto& entry : it) {
+    if (entry.is_regular_file() && entry.path().extension() == ".cpp") {
+      out.push_back(entry.path());
+    }
+  }
+  std::ranges::sort(out);
+  return out;
+}
+
+}  // namespace
+
+auto MakeTempCaseDir() -> std::expected<std::filesystem::path, std::string> {
+  const auto base = std::filesystem::temp_directory_path() / "lyra-XXXXXX";
+  std::string templ = base.string();
+  if (mkdtemp(templ.data()) == nullptr) {
+    return std::unexpected(
+        std::format(
+            "mkdtemp('{}') failed: {}", base.string(), std::strerror(errno)));
+  }
+  return std::filesystem::path(templ);
+}
+
+auto BuildAndRunEmittedArtifacts(
+    const std::filesystem::path& work_dir,
+    const std::filesystem::path& include_root,
+    const std::filesystem::path& runtime_src_dir) -> BuildAndRunOutcome {
+  BuildAndRunOutcome outcome;
+
+  auto cxx_or = ResolveCxxCompiler();
+  if (!cxx_or) {
+    outcome.error =
+        std::format("compiler resolution failed: {}", cxx_or.error());
+    return outcome;
+  }
+  const auto& cxx = *cxx_or;
+
+  auto runtime_cpps_or = CollectRuntimeSources(runtime_src_dir);
+  if (!runtime_cpps_or) {
+    outcome.error = std::format(
+        "runtime source enumeration failed: {}", runtime_cpps_or.error());
+    return outcome;
+  }
+  const auto& runtime_cpps = *runtime_cpps_or;
+  if (runtime_cpps.empty()) {
+    outcome.error =
+        std::format("no runtime sources under '{}'", runtime_src_dir.string());
+    return outcome;
+  }
+
+  const auto main_cpp = work_dir / "main.cpp";
+  const auto program = work_dir / "program";
+
+  if (!std::filesystem::exists(main_cpp)) {
+    outcome.error =
+        std::format("missing emitted main.cpp at '{}'", main_cpp.string());
+    return outcome;
+  }
+
+  std::vector<std::string> compile_args = {
+      "-std=c++23", "-O0", "-I", include_root.string(), main_cpp.string(),
+  };
+  for (const auto& src : runtime_cpps) {
+    compile_args.push_back(src.string());
+  }
+  compile_args.emplace_back("-o");
+  compile_args.push_back(program.string());
+
+  auto compile = RunChildProcess(cxx, compile_args, std::chrono::seconds{60});
+  if (compile.termination != TerminationKind::kExitedNormally) {
+    outcome.error = std::format(
+        "compile failed (termination={}, exit={}):\nstdout:\n{}\nstderr:\n{}",
+        static_cast<int>(compile.termination), compile.exit_code,
+        compile.stdout_text, compile.stderr_text);
+    return outcome;
+  }
+
+  auto run = RunChildProcess(program, {}, std::chrono::seconds{30});
+  if (run.termination != TerminationKind::kExitedNormally &&
+      run.termination != TerminationKind::kExitedNonZero) {
+    outcome.error = std::format(
+        "program did not exit normally (termination={}, signal={}):\n"
+        "stdout:\n{}\nstderr:\n{}",
+        static_cast<int>(run.termination), run.signal_number, run.stdout_text,
+        run.stderr_text);
+    return outcome;
+  }
+  outcome.exit_code = run.exit_code;
+  outcome.stdout_text = std::move(run.stdout_text);
+  outcome.stderr_text = std::move(run.stderr_text);
+  return outcome;
+}
+
+}  // namespace lyra::test

--- a/tests/framework/build.hpp
+++ b/tests/framework/build.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+
+namespace lyra::test {
+
+// Create a unique temp directory using mkdtemp. Returns the absolute path on
+// success, or an error description on failure. Never throws.
+auto MakeTempCaseDir() -> std::expected<std::filesystem::path, std::string>;
+
+struct BuildAndRunOutcome {
+  // Plumbing failure (compile failed, spawn failed, timed out, etc.). When
+  // set, the numeric fields below are unspecified.
+  std::optional<std::string> error;
+  int exit_code = 0;
+  std::string stdout_text;
+  std::string stderr_text;
+};
+
+// Compile <work_dir>/main.cpp + <work_dir>/<top>.hpp against the runtime
+// sources in runtime_src_dir, with includes rooted at include_root, producing
+// <work_dir>/program. Then run the program.
+//
+// Uses RunChildProcess for both compile and run -- no new process helper.
+// Returns errors via BuildAndRunOutcome::error; never throws.
+auto BuildAndRunEmittedArtifacts(
+    const std::filesystem::path& work_dir,
+    const std::filesystem::path& include_root,
+    const std::filesystem::path& runtime_src_dir) -> BuildAndRunOutcome;
+
+}  // namespace lyra::test


### PR DESCRIPTION
## Summary

Lands the first runnable C++ runtime cut. The compiler now emits a `Top.hpp` plus `main.cpp` artifact pair that compiles against a small `lyra::runtime` library and runs to completion. Generated process bodies are C++20 coroutines returning `lyra::runtime::Process`; the host driver constructs the module, calls `engine.BindRoot("top", top)`, and dispatches `kInitial` processes from an active queue. This replaces the prior single-string emit with a `CppArtifactSet` and adds a `--out-dir` flag so emitted artifacts can be written to disk for compile/run flows.

## Design

The runtime library lives under `include/lyra/runtime/` and `src/lyra/runtime/`. `Module` is the abstract base every emitted class inherits; the renderer emits a `Bind(RuntimeBindContext&)` override that dispatches `mir::ProcessKind` to the runtime enum via an exhaustive switch and calls `ctx.AddProcess(kind, process_<i>())`. `Process` is a move-only RAII wrapper around `std::coroutine_handle`; it captures coroutine failures via a bool flag on the promise and re-raises them as `support::InternalError` outside any coroutine context, keeping the runtime error policy narrow. `Engine` guards `BindRoot` and `Run` against double calls and rejects non-initial process kinds with `InternalError` until the next cut adds awaiters.

HIR and MIR `Process` migrated from a one-arm `std::variant<Initial>` to an explicit `ProcessKind` enum plus flat `body` field. `LowerProcess` routes through a `LowerProcessKind` mapper rather than hardcoding `kInitial`, so adding `always`/`final` later only extends the mapper and the runtime switch. The single-class invariant in the host emitter is asserted at the public `EmitCpp` boundary; `RenderHostMain` takes a `ClassDecl&` directly. Top selection from `unit.Classes().front()` is a known temporary boundary -- the next cut moves selection to the driver layer.

## Testing

- `bazel build //:runtime //:lyra //tests:cli_golden_tests //tests:cli_run_tests` -- clean.
- `bazel test //tests:cli_golden_tests //tests:cli_run_tests` -- both pass; updated emit goldens cover the new artifact-set shape, the new `cli_run_tests` target exercises emit -> compile (clang++ via `posix_spawn` with PATH-resolved compiler) -> run on a single hardcoded blocking-assignment design and asserts exit 0.
- `tools/policy/check_exceptions.py` and `tools/policy/check_ascii.py` -- clean.
- Manual: `lyra emit cpp --out-dir playground/out tests/cases/run/blocking_assign.sv`, `clang++ ... playground/out/main.cpp src/lyra/runtime/*.cpp -o playground/out/program`, `playground/out/program` -- exit 0.