### PR TITLE
Add structured diagnostic codes and in-process test harness

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -148,17 +148,33 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "compiler",
+    srcs = ["src/lyra/compiler/compile.cpp"],
+    hdrs = ["include/lyra/compiler/compile.hpp"],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ast_to_hir",
+        ":diag",
+        ":frontend",
+        ":hir",
+        ":hir_to_mir",
+        ":mir",
+        ":support",
+    ],
+)
+
 cc_binary(
     name = "lyra",
     srcs = ["src/lyra/driver/cli.cpp"],
     visibility = ["//visibility:public"],
     deps = [
-        ":ast_to_hir",
         ":backend_cpp",
+        ":compiler",
         ":diag",
         ":frontend",
         ":hir",
-        ":hir_to_mir",
         ":mir",
         ":support",
         "@argparse",

--- a/include/lyra/compiler/compile.hpp
+++ b/include/lyra/compiler/compile.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "lyra/diag/sink.hpp"
+#include "lyra/frontend/load.hpp"
+#include "lyra/hir/module_unit.hpp"
+#include "lyra/mir/compilation_unit.hpp"
+
+namespace lyra::compiler {
+
+enum class StopAfter : std::uint8_t { kParse, kHir, kMir };
+
+// Move-only owning bag of artifacts produced by Compile. Each optional is
+// std::nullopt unless the corresponding stage ran and produced a value.
+// ParseResult owns the slang Compilation and the SourceManager that
+// diagnostics' SourceSpans refer to; callers must keep the artifacts alive
+// for the duration of any Diagnostic-resolution work.
+struct CompileArtifacts {
+  std::optional<frontend::ParseResult> parse;
+  std::optional<std::vector<hir::ModuleUnit>> hir_units;
+  std::optional<mir::CompilationUnit> mir_unit;
+
+  CompileArtifacts() = default;
+  CompileArtifacts(const CompileArtifacts&) = delete;
+  auto operator=(const CompileArtifacts&) -> CompileArtifacts& = delete;
+  CompileArtifacts(CompileArtifacts&&) = default;
+  auto operator=(CompileArtifacts&&) -> CompileArtifacts& = default;
+  ~CompileArtifacts() = default;
+};
+
+// Lyra-owned errors flow through `sink`; slang parse/elaboration errors
+// are reported via `slang_ok`. Successful compile requires both
+// `!sink.HasErrors()` and `slang_ok`.
+struct CompileResult {
+  CompileArtifacts artifacts;
+  bool slang_ok = true;
+};
+
+auto Compile(
+    const frontend::CompilationInput& input, diag::DiagnosticSink& sink,
+    StopAfter stop_after = StopAfter::kMir) -> CompileResult;
+
+}  // namespace lyra::compiler

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+#include "lyra/diag/kind.hpp"
+
+namespace lyra::diag {
+
+// Stable identity for primary diagnostics. Notes have no code.
+enum class DiagCode : std::uint32_t {
+  kUnsupportedPackedArrayElementType,
+  kUnsupportedPackedStructType,
+  kUnsupportedPackedUnionType,
+  kUnsupportedEnumType,
+  kUnsupportedFixedSizeUnpackedArrayType,
+  kUnsupportedDynamicArrayType,
+  kUnsupportedQueueType,
+  kUnsupportedAssociativeArrayType,
+  kUnsupportedUnpackedStructType,
+  kUnsupportedUnpackedUnionType,
+  kUnsupportedTypeKind,
+
+  kUnsupportedNonStaticVariableLifetime,
+  kUnsupportedNonInitialProcedure,
+  kUnsupportedForGenerate,
+  kUnsupportedDeclInGenerate,
+  kUnsupportedProcessInGenerate,
+  kUnsupportedStatementForm,
+  kUnsupportedExpressionForm,
+  kUnsupportedStructuralExpressionForm,
+  kUnsupportedIntegerLiteralWidth,
+  kUnsupportedNonVariableNamedReference,
+  kUnsupportedNonBlockingAssignment,
+  kUnsupportedCompoundAssignment,
+  kUnsupportedAssignmentTarget,
+  kUnsupportedBinaryOperator,
+
+  kHostInvalidCliArgs,
+  kHostProjectModeUnimplemented,
+  kHostNoInputFiles,
+  kHostIoError,
+  kHostExpectedSingleTopModule,
+
+  kWarningPedantic,
+};
+
+struct DiagCodeInfo {
+  DiagKind kind;
+  std::optional<UnsupportedCategory> category;
+  std::string_view name;
+};
+
+auto Info(DiagCode code) -> const DiagCodeInfo&;
+auto DiagCodeName(DiagCode code) -> std::string_view;
+auto DiagCodeKind(DiagCode code) -> DiagKind;
+auto DiagCodeCategory(DiagCode code) -> std::optional<UnsupportedCategory>;
+auto ParseDiagCode(std::string_view text) -> std::optional<DiagCode>;
+
+}  // namespace lyra::diag

--- a/include/lyra/diag/diagnostic.hpp
+++ b/include/lyra/diag/diagnostic.hpp
@@ -1,31 +1,43 @@
 #pragma once
 
-#include <cstdint>
 #include <expected>
+#include <format>
 #include <optional>
 #include <string>
 #include <utility>
 #include <variant>
 #include <vector>
 
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/kind.hpp"
 #include "lyra/diag/source_span.hpp"
+#include "lyra/support/internal_error.hpp"
 
 namespace lyra::diag {
 
-enum class DiagKind : std::uint8_t {
-  kError,
-  kUnsupported,
-  kHostError,
-  kWarning,
-  kNote,
-};
+namespace detail {
 
-// Set iff DiagItem::kind == kUnsupported.
-enum class UnsupportedCategory : std::uint8_t {
-  kType,
-  kOperation,
-  kFeature,
-};
+inline void RequireKind(DiagCode code, DiagKind expected) {
+  if (DiagCodeKind(code) != expected) {
+    throw lyra::support::InternalError(
+        std::format(
+            "Diagnostic factory: code '{}' is not of the expected kind",
+            DiagCodeName(code)));
+  }
+}
+
+inline void RequireCategory(
+    DiagCode code, std::optional<UnsupportedCategory> expected) {
+  if (DiagCodeCategory(code) != expected) {
+    throw lyra::support::InternalError(
+        std::format(
+            "Diagnostic factory: code '{}' has a different category than the "
+            "factory call site claims",
+            DiagCodeName(code)));
+  }
+}
+
+}  // namespace detail
 
 struct UnknownSpan {
   auto operator==(const UnknownSpan&) const -> bool = default;
@@ -33,26 +45,40 @@ struct UnknownSpan {
 
 using DiagSpan = std::variant<SourceSpan, UnknownSpan>;
 
-struct DiagItem {
+// A primary diagnostic body. Always has a stable DiagCode identity.
+struct PrimaryDiagItem {
   DiagKind kind;
   DiagSpan span;
+  DiagCode code;
   std::string message;
   std::optional<UnsupportedCategory> category;
 
-  auto operator==(const DiagItem&) const -> bool = default;
+  auto operator==(const PrimaryDiagItem&) const -> bool = default;
+};
+
+// A note attached to a primary diagnostic. Notes have no independent
+// identity; they exist solely as supplementary text/location.
+struct NoteDiagItem {
+  DiagSpan span;
+  std::string message;
+
+  auto operator==(const NoteDiagItem&) const -> bool = default;
 };
 
 struct Diagnostic {
-  DiagItem primary;
-  std::vector<DiagItem> notes;
+  PrimaryDiagItem primary;
+  std::vector<NoteDiagItem> notes;
 
   auto operator==(const Diagnostic&) const -> bool = default;
 
-  static auto Error(SourceSpan span, std::string msg) -> Diagnostic {
+  static auto Error(SourceSpan span, DiagCode code, std::string msg)
+      -> Diagnostic {
+    detail::RequireKind(code, DiagKind::kError);
     return Diagnostic{
         .primary =
             {.kind = DiagKind::kError,
              .span = span,
+             .code = code,
              .message = std::move(msg),
              .category = std::nullopt},
         .notes = {},
@@ -60,56 +86,71 @@ struct Diagnostic {
   }
 
   static auto Unsupported(
-      SourceSpan span, std::string msg, UnsupportedCategory cat) -> Diagnostic {
-    return Diagnostic{
-        .primary =
-            {.kind = DiagKind::kUnsupported,
-             .span = span,
-             .message = std::move(msg),
-             .category = cat},
-        .notes = {},
-    };
-  }
-
-  static auto Unsupported(std::string msg, UnsupportedCategory cat)
+      SourceSpan span, DiagCode code, std::string msg, UnsupportedCategory cat)
       -> Diagnostic {
+    detail::RequireKind(code, DiagKind::kUnsupported);
+    detail::RequireCategory(code, cat);
     return Diagnostic{
         .primary =
             {.kind = DiagKind::kUnsupported,
-             .span = UnknownSpan{},
+             .span = span,
+             .code = code,
              .message = std::move(msg),
              .category = cat},
         .notes = {},
     };
   }
 
-  static auto HostError(std::string msg) -> Diagnostic {
+  static auto Unsupported(
+      DiagCode code, std::string msg, UnsupportedCategory cat) -> Diagnostic {
+    detail::RequireKind(code, DiagKind::kUnsupported);
+    detail::RequireCategory(code, cat);
+    return Diagnostic{
+        .primary =
+            {.kind = DiagKind::kUnsupported,
+             .span = UnknownSpan{},
+             .code = code,
+             .message = std::move(msg),
+             .category = cat},
+        .notes = {},
+    };
+  }
+
+  static auto HostError(DiagCode code, std::string msg) -> Diagnostic {
+    detail::RequireKind(code, DiagKind::kHostError);
     return Diagnostic{
         .primary =
             {.kind = DiagKind::kHostError,
              .span = UnknownSpan{},
+             .code = code,
              .message = std::move(msg),
              .category = std::nullopt},
         .notes = {},
     };
   }
 
-  static auto HostError(SourceSpan span, std::string msg) -> Diagnostic {
+  static auto HostError(SourceSpan span, DiagCode code, std::string msg)
+      -> Diagnostic {
+    detail::RequireKind(code, DiagKind::kHostError);
     return Diagnostic{
         .primary =
             {.kind = DiagKind::kHostError,
              .span = span,
+             .code = code,
              .message = std::move(msg),
              .category = std::nullopt},
         .notes = {},
     };
   }
 
-  static auto Warning(SourceSpan span, std::string msg) -> Diagnostic {
+  static auto Warning(SourceSpan span, DiagCode code, std::string msg)
+      -> Diagnostic {
+    detail::RequireKind(code, DiagKind::kWarning);
     return Diagnostic{
         .primary =
             {.kind = DiagKind::kWarning,
              .span = span,
+             .code = code,
              .message = std::move(msg),
              .category = std::nullopt},
         .notes = {},
@@ -117,24 +158,13 @@ struct Diagnostic {
   }
 
   auto WithNote(SourceSpan span, std::string msg) && -> Diagnostic {
-    notes.push_back(
-        DiagItem{
-            .kind = DiagKind::kNote,
-            .span = span,
-            .message = std::move(msg),
-            .category = std::nullopt,
-        });
+    notes.push_back(NoteDiagItem{.span = span, .message = std::move(msg)});
     return std::move(*this);
   }
 
   auto WithNote(std::string msg) && -> Diagnostic {
     notes.push_back(
-        DiagItem{
-            .kind = DiagKind::kNote,
-            .span = UnknownSpan{},
-            .message = std::move(msg),
-            .category = std::nullopt,
-        });
+        NoteDiagItem{.span = UnknownSpan{}, .message = std::move(msg)});
     return std::move(*this);
   }
 };
@@ -146,28 +176,30 @@ using Result = std::expected<T, Diagnostic>;
 // lowering call sites read `return diag::Unsupported(...)` instead of
 // `return std::unexpected(diag::Diagnostic::Unsupported(...))`.
 inline auto Unsupported(
-    SourceSpan span, std::string msg, UnsupportedCategory cat)
+    SourceSpan span, DiagCode code, std::string msg, UnsupportedCategory cat)
     -> std::unexpected<Diagnostic> {
-  return std::unexpected(Diagnostic::Unsupported(span, std::move(msg), cat));
+  return std::unexpected(
+      Diagnostic::Unsupported(span, code, std::move(msg), cat));
 }
 
-inline auto Unsupported(std::string msg, UnsupportedCategory cat)
+inline auto Unsupported(DiagCode code, std::string msg, UnsupportedCategory cat)
     -> std::unexpected<Diagnostic> {
-  return std::unexpected(Diagnostic::Unsupported(std::move(msg), cat));
+  return std::unexpected(Diagnostic::Unsupported(code, std::move(msg), cat));
 }
 
-inline auto Error(SourceSpan span, std::string msg)
+inline auto Error(SourceSpan span, DiagCode code, std::string msg)
     -> std::unexpected<Diagnostic> {
-  return std::unexpected(Diagnostic::Error(span, std::move(msg)));
+  return std::unexpected(Diagnostic::Error(span, code, std::move(msg)));
 }
 
-inline auto HostError(std::string msg) -> std::unexpected<Diagnostic> {
-  return std::unexpected(Diagnostic::HostError(std::move(msg)));
+inline auto HostError(DiagCode code, std::string msg)
+    -> std::unexpected<Diagnostic> {
+  return std::unexpected(Diagnostic::HostError(code, std::move(msg)));
 }
 
-inline auto HostError(SourceSpan span, std::string msg)
+inline auto HostError(SourceSpan span, DiagCode code, std::string msg)
     -> std::unexpected<Diagnostic> {
-  return std::unexpected(Diagnostic::HostError(span, std::move(msg)));
+  return std::unexpected(Diagnostic::HostError(span, code, std::move(msg)));
 }
 
 }  // namespace lyra::diag

--- a/include/lyra/diag/kind.hpp
+++ b/include/lyra/diag/kind.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+
+namespace lyra::diag {
+
+enum class DiagKind : std::uint8_t {
+  kError,
+  kUnsupported,
+  kHostError,
+  kWarning,
+  kNote,
+};
+
+// Set iff PrimaryDiagItem::kind == kUnsupported.
+enum class UnsupportedCategory : std::uint8_t {
+  kType,
+  kOperation,
+  kFeature,
+};
+
+}  // namespace lyra::diag

--- a/include/lyra/diag/sink.hpp
+++ b/include/lyra/diag/sink.hpp
@@ -20,16 +20,18 @@ class DiagnosticSink {
     diagnostics_.push_back(std::move(diag));
   }
 
-  void Error(SourceSpan span, std::string msg) {
-    Report(Diagnostic::Error(span, std::move(msg)));
+  void Error(SourceSpan span, DiagCode code, std::string msg) {
+    Report(Diagnostic::Error(span, code, std::move(msg)));
   }
 
-  void Unsupported(SourceSpan span, std::string msg, UnsupportedCategory cat) {
-    Report(Diagnostic::Unsupported(span, std::move(msg), cat));
+  void Unsupported(
+      SourceSpan span, DiagCode code, std::string msg,
+      UnsupportedCategory cat) {
+    Report(Diagnostic::Unsupported(span, code, std::move(msg), cat));
   }
 
-  void Warning(SourceSpan span, std::string msg) {
-    Report(Diagnostic::Warning(span, std::move(msg)));
+  void Warning(SourceSpan span, DiagCode code, std::string msg) {
+    Report(Diagnostic::Warning(span, code, std::move(msg)));
   }
 
   [[nodiscard]] auto HasErrors() const -> bool {

--- a/include/lyra/frontend/load.hpp
+++ b/include/lyra/frontend/load.hpp
@@ -42,4 +42,9 @@ auto LoadFiles(const CompilationInput& input, diag::DiagnosticSink& sink)
 auto RenderSlangDiagnostics(
     ParseResult& parse, bool use_color, std::string& out_text) -> bool;
 
+// Returns true iff slang reported any error-severity parse/elaboration
+// diagnostic. `parse` is non-const because slang's getAllDiagnostics is
+// non-const. Use this to surface frontend status without rendering text.
+auto HasSlangErrors(ParseResult& parse) -> bool;
+
 }  // namespace lyra::frontend

--- a/src/lyra/compiler/compile.cpp
+++ b/src/lyra/compiler/compile.cpp
@@ -1,0 +1,72 @@
+#include "lyra/compiler/compile.hpp"
+
+#include <format>
+#include <utility>
+
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/sink.hpp"
+#include "lyra/frontend/load.hpp"
+#include "lyra/lowering/ast_to_hir/lower.hpp"
+#include "lyra/lowering/hir_to_mir/lower_module_unit.hpp"
+
+namespace lyra::compiler {
+
+auto Compile(
+    const frontend::CompilationInput& input, diag::DiagnosticSink& sink,
+    StopAfter stop_after) -> CompileResult {
+  CompileResult result;
+
+  auto parse = frontend::LoadFiles(input, sink);
+  if (!parse) {
+    return result;
+  }
+  result.artifacts.parse = std::move(*parse);
+
+  // Stop early if slang reports parse/elaboration errors; running
+  // AST->HIR over a broken AST would emit confusing follow-on errors.
+  result.slang_ok = !frontend::HasSlangErrors(*result.artifacts.parse);
+  if (!result.slang_ok) {
+    return result;
+  }
+
+  if (stop_after == StopAfter::kParse) {
+    return result;
+  }
+
+  auto hir = lowering::ast_to_hir::LowerCompilation(
+      lowering::ast_to_hir::LowerCompilationFacts(
+          *result.artifacts.parse->compilation,
+          result.artifacts.parse->source_mapper));
+  if (!hir) {
+    sink.Report(std::move(hir.error()));
+    return result;
+  }
+  result.artifacts.hir_units = std::move(*hir);
+
+  if (stop_after == StopAfter::kHir) {
+    return result;
+  }
+
+  if (result.artifacts.hir_units->size() != 1) {
+    sink.Report(
+        diag::Diagnostic::HostError(
+            diag::DiagCode::kHostExpectedSingleTopModule,
+            std::format(
+                "expected exactly one top module, got {}",
+                result.artifacts.hir_units->size())));
+    return result;
+  }
+
+  auto mir = lowering::hir_to_mir::LowerModuleUnit(
+      result.artifacts.hir_units->front());
+  if (!mir) {
+    sink.Report(std::move(mir.error()));
+    return result;
+  }
+  result.artifacts.mir_unit = std::move(*mir);
+
+  return result;
+}
+
+}  // namespace lyra::compiler

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -1,0 +1,233 @@
+#include "lyra/diag/diag_code.hpp"
+
+#include <array>
+#include <optional>
+#include <string_view>
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/support/internal_error.hpp"
+
+namespace lyra::diag {
+namespace {
+
+constexpr std::array kEntries{
+    std::pair{
+        DiagCode::kUnsupportedPackedArrayElementType,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kType,
+            .name = "unsupported_packed_array_element_type"}},
+    std::pair{
+        DiagCode::kUnsupportedPackedStructType,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kType,
+            .name = "unsupported_packed_struct_type"}},
+    std::pair{
+        DiagCode::kUnsupportedPackedUnionType,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kType,
+            .name = "unsupported_packed_union_type"}},
+    std::pair{
+        DiagCode::kUnsupportedEnumType,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kType,
+            .name = "unsupported_enum_type"}},
+    std::pair{
+        DiagCode::kUnsupportedFixedSizeUnpackedArrayType,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kType,
+            .name = "unsupported_fixed_size_unpacked_array_type"}},
+    std::pair{
+        DiagCode::kUnsupportedDynamicArrayType,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kType,
+            .name = "unsupported_dynamic_array_type"}},
+    std::pair{
+        DiagCode::kUnsupportedQueueType,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kType,
+            .name = "unsupported_queue_type"}},
+    std::pair{
+        DiagCode::kUnsupportedAssociativeArrayType,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kType,
+            .name = "unsupported_associative_array_type"}},
+    std::pair{
+        DiagCode::kUnsupportedUnpackedStructType,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kType,
+            .name = "unsupported_unpacked_struct_type"}},
+    std::pair{
+        DiagCode::kUnsupportedUnpackedUnionType,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kType,
+            .name = "unsupported_unpacked_union_type"}},
+    std::pair{
+        DiagCode::kUnsupportedTypeKind,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kType,
+            .name = "unsupported_type_kind"}},
+
+    std::pair{
+        DiagCode::kUnsupportedNonStaticVariableLifetime,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_non_static_variable_lifetime"}},
+    std::pair{
+        DiagCode::kUnsupportedNonInitialProcedure,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_non_initial_procedure"}},
+    std::pair{
+        DiagCode::kUnsupportedForGenerate,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_for_generate"}},
+    std::pair{
+        DiagCode::kUnsupportedDeclInGenerate,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_decl_in_generate"}},
+    std::pair{
+        DiagCode::kUnsupportedProcessInGenerate,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_process_in_generate"}},
+    std::pair{
+        DiagCode::kUnsupportedStatementForm,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_statement_form"}},
+    std::pair{
+        DiagCode::kUnsupportedExpressionForm,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kOperation,
+            .name = "unsupported_expression_form"}},
+    std::pair{
+        DiagCode::kUnsupportedStructuralExpressionForm,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_structural_expression_form"}},
+    std::pair{
+        DiagCode::kUnsupportedIntegerLiteralWidth,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_integer_literal_width"}},
+    std::pair{
+        DiagCode::kUnsupportedNonVariableNamedReference,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_non_variable_named_reference"}},
+    std::pair{
+        DiagCode::kUnsupportedNonBlockingAssignment,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_non_blocking_assignment"}},
+    std::pair{
+        DiagCode::kUnsupportedCompoundAssignment,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_compound_assignment"}},
+    std::pair{
+        DiagCode::kUnsupportedAssignmentTarget,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_assignment_target"}},
+    std::pair{
+        DiagCode::kUnsupportedBinaryOperator,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kOperation,
+            .name = "unsupported_binary_operator"}},
+
+    std::pair{
+        DiagCode::kHostInvalidCliArgs,
+        DiagCodeInfo{
+            .kind = DiagKind::kHostError,
+            .category = std::nullopt,
+            .name = "host_invalid_cli_args"}},
+    std::pair{
+        DiagCode::kHostProjectModeUnimplemented,
+        DiagCodeInfo{
+            .kind = DiagKind::kHostError,
+            .category = std::nullopt,
+            .name = "host_project_mode_unimplemented"}},
+    std::pair{
+        DiagCode::kHostNoInputFiles,
+        DiagCodeInfo{
+            .kind = DiagKind::kHostError,
+            .category = std::nullopt,
+            .name = "host_no_input_files"}},
+    std::pair{
+        DiagCode::kHostIoError,
+        DiagCodeInfo{
+            .kind = DiagKind::kHostError,
+            .category = std::nullopt,
+            .name = "host_io_error"}},
+    std::pair{
+        DiagCode::kHostExpectedSingleTopModule,
+        DiagCodeInfo{
+            .kind = DiagKind::kHostError,
+            .category = std::nullopt,
+            .name = "host_expected_single_top_module"}},
+
+    std::pair{
+        DiagCode::kWarningPedantic,
+        DiagCodeInfo{
+            .kind = DiagKind::kWarning,
+            .category = std::nullopt,
+            .name = "warning_pedantic"}},
+};
+
+}  // namespace
+
+auto Info(DiagCode code) -> const DiagCodeInfo& {
+  for (const auto& [c, info] : kEntries) {
+    if (c == code) return info;
+  }
+  throw lyra::support::InternalError("diag::Info: unknown DiagCode value");
+}
+
+auto DiagCodeName(DiagCode code) -> std::string_view {
+  return Info(code).name;
+}
+
+auto DiagCodeKind(DiagCode code) -> DiagKind {
+  return Info(code).kind;
+}
+
+auto DiagCodeCategory(DiagCode code) -> std::optional<UnsupportedCategory> {
+  return Info(code).category;
+}
+
+auto ParseDiagCode(std::string_view text) -> std::optional<DiagCode> {
+  for (const auto& [c, info] : kEntries) {
+    if (info.name == text) return c;
+  }
+  return std::nullopt;
+}
+
+}  // namespace lyra::diag

--- a/src/lyra/diag/render.cpp
+++ b/src/lyra/diag/render.cpp
@@ -96,39 +96,40 @@ auto ResolveLine(const SourceManager& mgr, const SourceSpan& span)
   };
 }
 
-auto SpanOf(const DiagItem& item) -> std::optional<SourceSpan> {
+auto SpanOf(const DiagSpan& diag_span) -> std::optional<SourceSpan> {
   std::optional<SourceSpan> out;
   std::visit(
       support::Overloaded{
           [&](const SourceSpan& s) { out = s; },
           [&](UnknownSpan) {},
       },
-      item.span);
+      diag_span);
   return out;
 }
 
 void AppendHeader(
-    std::string& out, const DiagItem& item, const SourceManager* mgr,
+    std::string& out, DiagKind kind, const DiagSpan& diag_span,
+    const std::string& message, const SourceManager* mgr,
     const RenderOptions& opts, fmt::text_style msg_style) {
   std::string location;
-  if (auto span = SpanOf(item); span && mgr != nullptr) {
+  if (auto span = SpanOf(diag_span); span && mgr != nullptr) {
     location = FormatSourceLocation(*span, *mgr);
   }
 
-  const auto label = KindLabel(item.kind);
-  const auto label_style = Style(opts, KindStyle(item.kind));
+  const auto label = KindLabel(kind);
+  const auto label_style = Style(opts, KindStyle(kind));
   const auto applied_msg_style = Style(opts, msg_style);
 
   if (location.empty()) {
     out += fmt::format(
         "{}: {} {}\n", fmt::styled("lyra", Style(opts, kToolStyle)),
         fmt::styled(label, label_style),
-        fmt::styled(item.message, applied_msg_style));
+        fmt::styled(message, applied_msg_style));
   } else {
     out += fmt::format(
         "{}: {} {}\n", fmt::styled(location, Style(opts, fmt::emphasis::bold)),
         fmt::styled(label, label_style),
-        fmt::styled(item.message, applied_msg_style));
+        fmt::styled(message, applied_msg_style));
   }
 }
 
@@ -169,21 +170,24 @@ void AppendSnippet(
 }
 
 void AppendPrimary(
-    std::string& out, const DiagItem& item, const SourceManager* mgr,
+    std::string& out, const PrimaryDiagItem& item, const SourceManager* mgr,
     const RenderOptions& opts) {
-  AppendHeader(out, item, mgr, opts, fmt::emphasis::bold);
+  AppendHeader(
+      out, item.kind, item.span, item.message, mgr, opts, fmt::emphasis::bold);
   if (!opts.show_source_snippet || mgr == nullptr) {
     return;
   }
-  if (auto span = SpanOf(item)) {
+  if (auto span = SpanOf(item.span)) {
     AppendSnippet(out, *span, *mgr, opts);
   }
 }
 
 void AppendNote(
-    std::string& out, const DiagItem& item, const SourceManager* mgr,
+    std::string& out, const NoteDiagItem& note, const SourceManager* mgr,
     const RenderOptions& opts) {
-  AppendHeader(out, item, mgr, opts, fmt::text_style{});
+  AppendHeader(
+      out, DiagKind::kNote, note.span, note.message, mgr, opts,
+      fmt::text_style{});
 }
 
 }  // namespace

--- a/src/lyra/driver/cli.cpp
+++ b/src/lyra/driver/cli.cpp
@@ -15,14 +15,14 @@
 
 #include "lyra/backend/cpp/api.hpp"
 #include "lyra/backend/cpp/artifact.hpp"
+#include "lyra/compiler/compile.hpp"
+#include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/render.hpp"
 #include "lyra/diag/sink.hpp"
 #include "lyra/diag/source_manager.hpp"
 #include "lyra/frontend/load.hpp"
 #include "lyra/hir/dump.hpp"
-#include "lyra/lowering/ast_to_hir/lower.hpp"
-#include "lyra/lowering/hir_to_mir/lower_module_unit.hpp"
 #include "lyra/mir/dump.hpp"
 #include "lyra/support/internal_error.hpp"
 
@@ -181,7 +181,9 @@ auto main(int argc, char** argv) -> int {
     };
 
     if (!parsed) {
-      report(lyra::diag::Diagnostic::HostError(parsed.error()));
+      report(
+          lyra::diag::Diagnostic::HostError(
+              lyra::diag::DiagCode::kHostInvalidCliArgs, parsed.error()));
       return 1;
     }
     auto& args = *parsed;
@@ -189,71 +191,56 @@ auto main(int argc, char** argv) -> int {
     if (!args.no_project) {
       report(
           lyra::diag::Diagnostic::HostError(
+              lyra::diag::DiagCode::kHostProjectModeUnimplemented,
               "project mode is not implemented yet; pass --no-project to "
               "run in direct file mode"));
       return 1;
     }
     if (args.input.files.empty()) {
-      report(lyra::diag::Diagnostic::HostError("no input files"));
+      report(
+          lyra::diag::Diagnostic::HostError(
+              lyra::diag::DiagCode::kHostNoInputFiles, "no input files"));
       return 1;
     }
 
     lyra::diag::DiagnosticSink sink;
-    auto parse = lyra::frontend::LoadFiles(args.input, sink);
-    if (!parse) {
-      if (!sink.Diagnostics().empty()) {
-        fmt::print(
-            stderr, "{}",
-            lyra::diag::RenderDiagnostics(sink, nullptr, render_opts));
-      }
-      return 1;
-    }
-    {
+    const auto stop_after = args.cmd == CommandKind::kDumpHir
+                                ? lyra::compiler::StopAfter::kHir
+                                : lyra::compiler::StopAfter::kMir;
+    auto result = lyra::compiler::Compile(args.input, sink, stop_after);
+
+    if (result.artifacts.parse) {
       std::string slang_text;
-      const bool slang_ok =
-          lyra::frontend::RenderSlangDiagnostics(*parse, use_color, slang_text);
+      lyra::frontend::RenderSlangDiagnostics(
+          *result.artifacts.parse, use_color, slang_text);
       if (!slang_text.empty()) {
         fmt::print(stderr, "{}", slang_text);
       }
-      if (!slang_ok) {
-        return 1;
-      }
     }
 
-    auto hir_units = lyra::lowering::ast_to_hir::LowerCompilation(
-        lyra::lowering::ast_to_hir::LowerCompilationFacts(
-            *parse->compilation, parse->source_mapper));
-    if (!hir_units) {
-      report(hir_units.error(), &parse->diag_sources);
+    if (sink.HasErrors()) {
+      const lyra::diag::SourceManager* mgr =
+          result.artifacts.parse ? &result.artifacts.parse->diag_sources
+                                 : nullptr;
+      fmt::print(
+          stderr, "{}", lyra::diag::RenderDiagnostics(sink, mgr, render_opts));
+      return 1;
+    }
+    if (!result.slang_ok) {
       return 1;
     }
 
     if (args.cmd == CommandKind::kDumpHir) {
-      fmt::print("{}", lyra::hir::DumpHir(*hir_units));
+      fmt::print("{}", lyra::hir::DumpHir(*result.artifacts.hir_units));
       return 0;
-    }
-
-    if (hir_units->size() != 1) {
-      report(
-          lyra::diag::Diagnostic::HostError(
-              std::format(
-                  "expected exactly one top module, got {}",
-                  hir_units->size())));
-      return 1;
-    }
-    auto mir_unit =
-        lyra::lowering::hir_to_mir::LowerModuleUnit(hir_units->front());
-    if (!mir_unit) {
-      report(mir_unit.error(), &parse->diag_sources);
-      return 1;
     }
 
     switch (args.cmd) {
       case CommandKind::kDumpMir:
-        fmt::print("{}", lyra::mir::DumpMir(*mir_unit));
+        fmt::print("{}", lyra::mir::DumpMir(*result.artifacts.mir_unit));
         return 0;
       case CommandKind::kEmitCpp: {
-        auto set = lyra::backend::cpp::EmitCpp(*mir_unit);
+        auto set = lyra::backend::cpp::EmitCpp(*result.artifacts.mir_unit);
         if (args.emit_out_dir.empty()) {
           for (const auto& file : set.files) {
             fmt::print("=== {} ===\n{}", file.relpath, file.content);

--- a/src/lyra/frontend/load.cpp
+++ b/src/lyra/frontend/load.cpp
@@ -67,4 +67,16 @@ auto RenderSlangDiagnostics(
   return diag_engine.getNumErrors() == 0;
 }
 
+auto HasSlangErrors(ParseResult& parse) -> bool {
+  auto diagnostics = parse.compilation->getAllDiagnostics();
+  if (diagnostics.empty()) {
+    return false;
+  }
+  slang::DiagnosticEngine diag_engine(*parse.source_manager);
+  for (const auto& d : diagnostics) {
+    diag_engine.issue(d);
+  }
+  return diag_engine.getNumErrors() > 0;
+}
+
 }  // namespace lyra::frontend

--- a/src/lyra/frontend/parse_unit.cpp
+++ b/src/lyra/frontend/parse_unit.cpp
@@ -68,6 +68,7 @@ auto ExecuteParseUnit(
           if (!buffer_or) {
             sink.Report(
                 diag::Diagnostic::HostError(
+                    diag::DiagCode::kHostIoError,
                     fmt::format("cannot read '{}'", u.file)));
             return false;
           }
@@ -93,6 +94,7 @@ auto ExecuteParseUnit(
             if (!buffer_or) {
               sink.Report(
                   diag::Diagnostic::HostError(
+                      diag::DiagCode::kHostIoError,
                       fmt::format("cannot read '{}'", file)));
               return false;
             }

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -35,6 +35,7 @@ auto LowerIntegerLiteralValue(
   if (!value.has_value()) {
     return diag::Unsupported(
         unit_facts.SourceMapper().SpanOf(literal.sourceRange),
+        diag::DiagCode::kUnsupportedIntegerLiteralWidth,
         "integer literal does not fit in a 64-bit signed integer",
         diag::UnsupportedCategory::kFeature);
   }
@@ -59,6 +60,7 @@ auto LowerNamedValueProc(
   if (named.symbol.kind != slang::ast::SymbolKind::Variable) {
     return diag::Unsupported(
         mapper.SpanOf(named.sourceRange),
+        diag::DiagCode::kUnsupportedNonVariableNamedReference,
         "reference to non-variable declaration is not supported",
         diag::UnsupportedCategory::kFeature);
   }
@@ -125,7 +127,8 @@ auto LowerProcExpr(
       const auto& bin = expr.as<slang::ast::BinaryExpression>();
       if (bin.op != slang::ast::BinaryOperator::Add) {
         return diag::Unsupported(
-            span, "only `+` is supported in this cut",
+            span, diag::DiagCode::kUnsupportedBinaryOperator,
+            "only `+` is supported in this cut",
             diag::UnsupportedCategory::kOperation);
       }
       auto lhs_id = append_child(bin.left());
@@ -146,12 +149,14 @@ auto LowerProcExpr(
       const auto& as = expr.as<slang::ast::AssignmentExpression>();
       if (as.isNonBlocking()) {
         return diag::Unsupported(
-            span, "non-blocking assignments are not supported yet",
+            span, diag::DiagCode::kUnsupportedNonBlockingAssignment,
+            "non-blocking assignments are not supported yet",
             diag::UnsupportedCategory::kFeature);
       }
       if (as.op.has_value()) {
         return diag::Unsupported(
-            span, "compound assignments are not supported yet",
+            span, diag::DiagCode::kUnsupportedCompoundAssignment,
+            "compound assignments are not supported yet",
             diag::UnsupportedCategory::kFeature);
       }
 
@@ -160,6 +165,7 @@ auto LowerProcExpr(
       if (!hir::AsAssignableRef(*lhs_expr).has_value()) {
         return diag::Unsupported(
             mapper.SpanOf(as.left().sourceRange),
+            diag::DiagCode::kUnsupportedAssignmentTarget,
             "assignment target is not supported yet",
             diag::UnsupportedCategory::kFeature);
       }
@@ -176,7 +182,8 @@ auto LowerProcExpr(
 
     default:
       return diag::Unsupported(
-          span, "this expression form is not supported yet",
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "this expression form is not supported yet",
           diag::UnsupportedCategory::kOperation);
   }
 }
@@ -196,7 +203,8 @@ auto LowerStructuralExpr(
     }
     default:
       return diag::Unsupported(
-          span, "this structural expression form is not supported yet",
+          span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
+          "this structural expression form is not supported yet",
           diag::UnsupportedCategory::kFeature);
   }
 }

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -58,6 +58,7 @@ auto LowerScopeInto(
     if (var.lifetime != slang::ast::VariableLifetime::Static) {
       return diag::Unsupported(
           mapper.PointSpanOf(var.location),
+          diag::DiagCode::kUnsupportedNonStaticVariableLifetime,
           "only static variables are supported",
           diag::UnsupportedCategory::kFeature);
     }
@@ -83,6 +84,7 @@ auto LowerScopeInto(
     if (proc.procedureKind != slang::ast::ProceduralBlockKind::Initial) {
       return diag::Unsupported(
           mapper.PointSpanOf(proc.location),
+          diag::DiagCode::kUnsupportedNonInitialProcedure,
           "only `initial` procedural blocks are supported",
           diag::UnsupportedCategory::kFeature);
     }
@@ -97,6 +99,7 @@ auto LowerScopeInto(
       case slang::ast::SymbolKind::GenerateBlockArray:
         return diag::Unsupported(
             mapper.PointSpanOf(member.location),
+            diag::DiagCode::kUnsupportedForGenerate,
             "for-generate is not supported yet",
             diag::UnsupportedCategory::kFeature);
 

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -94,6 +94,7 @@ auto LowerStatement(
     default:
       return diag::Unsupported(
           mapper.SpanOf(stmt.sourceRange),
+          diag::DiagCode::kUnsupportedStatementForm,
           "this statement form is not supported yet",
           diag::UnsupportedCategory::kFeature);
   }

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -98,7 +98,8 @@ auto LowerExplicitPackedArray(
   }
   if (cur->kind != slang::ast::SymbolKind::ScalarType) {
     return diag::Unsupported(
-        decl_span, "packed array element must be a bit, logic, or reg scalar",
+        decl_span, diag::DiagCode::kUnsupportedPackedArrayElementType,
+        "packed array element must be a bit, logic, or reg scalar",
         diag::UnsupportedCategory::kType);
   }
   const auto& scalar = cur->as<slang::ast::ScalarType>();
@@ -162,43 +163,51 @@ auto LowerTypeData(const slang::ast::Type& type, diag::SourceSpan decl_span)
       return hir::TypeData{hir::VoidType{}};
     case slang::ast::SymbolKind::PackedStructType:
       return diag::Unsupported(
-          decl_span, "packed struct types are not supported",
+          decl_span, diag::DiagCode::kUnsupportedPackedStructType,
+          "packed struct types are not supported",
           diag::UnsupportedCategory::kType);
     case slang::ast::SymbolKind::PackedUnionType:
       return diag::Unsupported(
-          decl_span, "packed union types are not supported",
+          decl_span, diag::DiagCode::kUnsupportedPackedUnionType,
+          "packed union types are not supported",
           diag::UnsupportedCategory::kType);
     case slang::ast::SymbolKind::EnumType:
       return diag::Unsupported(
-          decl_span, "enum types are not supported",
-          diag::UnsupportedCategory::kType);
+          decl_span, diag::DiagCode::kUnsupportedEnumType,
+          "enum types are not supported", diag::UnsupportedCategory::kType);
     case slang::ast::SymbolKind::FixedSizeUnpackedArrayType:
       return diag::Unsupported(
-          decl_span, "unpacked array types are not supported",
+          decl_span, diag::DiagCode::kUnsupportedFixedSizeUnpackedArrayType,
+          "unpacked array types are not supported",
           diag::UnsupportedCategory::kType);
     case slang::ast::SymbolKind::DynamicArrayType:
       return diag::Unsupported(
-          decl_span, "dynamic array types are not supported",
+          decl_span, diag::DiagCode::kUnsupportedDynamicArrayType,
+          "dynamic array types are not supported",
           diag::UnsupportedCategory::kType);
     case slang::ast::SymbolKind::QueueType:
       return diag::Unsupported(
-          decl_span, "queue types are not supported",
-          diag::UnsupportedCategory::kType);
+          decl_span, diag::DiagCode::kUnsupportedQueueType,
+          "queue types are not supported", diag::UnsupportedCategory::kType);
     case slang::ast::SymbolKind::AssociativeArrayType:
       return diag::Unsupported(
-          decl_span, "associative array types are not supported",
+          decl_span, diag::DiagCode::kUnsupportedAssociativeArrayType,
+          "associative array types are not supported",
           diag::UnsupportedCategory::kType);
     case slang::ast::SymbolKind::UnpackedStructType:
       return diag::Unsupported(
-          decl_span, "unpacked struct types are not supported",
+          decl_span, diag::DiagCode::kUnsupportedUnpackedStructType,
+          "unpacked struct types are not supported",
           diag::UnsupportedCategory::kType);
     case slang::ast::SymbolKind::UnpackedUnionType:
       return diag::Unsupported(
-          decl_span, "unpacked union types are not supported",
+          decl_span, diag::DiagCode::kUnsupportedUnpackedUnionType,
+          "unpacked union types are not supported",
           diag::UnsupportedCategory::kType);
     default:
       return diag::Unsupported(
-          decl_span, "unsupported type kind", diag::UnsupportedCategory::kType);
+          decl_span, diag::DiagCode::kUnsupportedTypeKind,
+          "unsupported type kind", diag::UnsupportedCategory::kType);
   }
 }
 

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -162,11 +162,13 @@ auto LowerChildScopeIntoBody(
     -> diag::Result<void> {
   if (!child.MemberVars().empty()) {
     return diag::Unsupported(
+        diag::DiagCode::kUnsupportedDeclInGenerate,
         "declarations inside generate scopes are not supported yet",
         diag::UnsupportedCategory::kFeature);
   }
   if (!child.Processes().empty()) {
     return diag::Unsupported(
+        diag::DiagCode::kUnsupportedProcessInGenerate,
         "processes inside generate scopes are not supported yet",
         diag::UnsupportedCategory::kFeature);
   }

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -130,6 +130,7 @@ auto LowerStructuralExprData(const hir::ExprData& data)
                     },
                     [](const hir::RefExpr&) -> diag::Result<mir::ExprData> {
                       return diag::Unsupported(
+                          diag::DiagCode::kUnsupportedStructuralExpressionForm,
                           "this structural expression form is not "
                           "supported yet",
                           diag::UnsupportedCategory::kFeature);
@@ -139,11 +140,13 @@ auto LowerStructuralExprData(const hir::ExprData& data)
           },
           [](const hir::BinaryExpr&) -> diag::Result<mir::ExprData> {
             return diag::Unsupported(
+                diag::DiagCode::kUnsupportedStructuralExpressionForm,
                 "this structural expression form is not supported yet",
                 diag::UnsupportedCategory::kFeature);
           },
           [](const hir::AssignExpr&) -> diag::Result<mir::ExprData> {
             return diag::Unsupported(
+                diag::DiagCode::kUnsupportedStructuralExpressionForm,
                 "this structural expression form is not supported yet",
                 diag::UnsupportedCategory::kFeature);
           },

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -12,6 +12,18 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "diag_framework",
+    srcs = glob(["diag_framework/*.cpp"]),
+    hdrs = glob(["diag_framework/*.hpp"]),
+    visibility = ["//tests:__subpackages__"],
+    deps = [
+        ":framework",
+        "//:diag",
+        "@yaml-cpp//:yaml-cpp",
+    ],
+)
+
 cc_test(
     name = "cli_golden_tests",
     srcs = ["cli_golden_test.cpp"],
@@ -39,6 +51,41 @@ cc_test(
     deps = [
         "//:diag",
         "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "diag_framework_tests",
+    srcs = ["diag_framework_test.cpp"],
+    deps = [
+        ":diag_framework",
+        "//:diag",
+        "@googletest//:gtest_main",
+        "@yaml-cpp//:yaml-cpp",
+    ],
+)
+
+cc_test(
+    name = "diag_struct_tests",
+    srcs = ["diag_struct_test.cpp"],
+    data = [
+        "suites.yaml",
+    ] + glob(
+        [
+            "cases/**/*.yaml",
+            "cases/**/*.sv",
+        ],
+        allow_empty = True,
+    ),
+    deps = [
+        ":diag_framework",
+        ":framework",
+        "//:compiler",
+        "//:diag",
+        "//:frontend",
+        "@bazel_tools//tools/cpp/runfiles",
+        "@fmt",
+        "@googletest//:gtest",
     ],
 )
 

--- a/tests/cases/errors/unsupported_type/case.yaml
+++ b/tests/cases/errors/unsupported_type/case.yaml
@@ -1,5 +1,5 @@
 id: errors.unsupported_type
-tags: [errors, diag]
+tags: [errors, diag, diag-struct]
 input:
   command: [emit, cpp]
   project: false
@@ -17,3 +17,9 @@ expect:
     not_contains:
       - "internal error"
       - "\x1b["
+  diagnostics:
+    - code: unsupported_queue_type
+      kind: unsupported
+      category: type
+      file: main.sv
+      line: 2

--- a/tests/diag/render_test.cpp
+++ b/tests/diag/render_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <string>
 
+#include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/sink.hpp"
 #include "lyra/diag/source_manager.hpp"
@@ -19,15 +20,17 @@ auto Has(const std::string& s, const std::string& needle) -> bool {
 
 TEST(DiagRender, HostErrorPlain) {
   const auto out = lyra::diag::RenderDiagnostic(
-      lyra::diag::Diagnostic::HostError("no input files"), nullptr,
-      lyra::diag::RenderOptions{.use_color = false});
+      lyra::diag::Diagnostic::HostError(
+          lyra::diag::DiagCode::kHostNoInputFiles, "no input files"),
+      nullptr, lyra::diag::RenderOptions{.use_color = false});
   EXPECT_EQ(out, "lyra: error: no input files\n");
 }
 
 TEST(DiagRender, HostErrorColored) {
   const auto out = lyra::diag::RenderDiagnostic(
-      lyra::diag::Diagnostic::HostError("boom"), nullptr,
-      lyra::diag::RenderOptions{.use_color = true});
+      lyra::diag::Diagnostic::HostError(
+          lyra::diag::DiagCode::kHostIoError, "boom"),
+      nullptr, lyra::diag::RenderOptions{.use_color = true});
   EXPECT_TRUE(Has(out, "lyra"));
   EXPECT_TRUE(Has(out, "error:"));
   EXPECT_TRUE(Has(out, "boom"));
@@ -41,6 +44,7 @@ TEST(DiagRender, InternalErrorIsAlwaysPlain) {
 
 TEST(DiagRender, UnsupportedWithUnknownSpan) {
   const auto diag = lyra::diag::Diagnostic::Unsupported(
+      lyra::diag::DiagCode::kUnsupportedForGenerate,
       "for-generate is not supported yet",
       lyra::diag::UnsupportedCategory::kFeature);
   const auto out = lyra::diag::RenderDiagnostic(
@@ -58,7 +62,8 @@ TEST(DiagRender, ErrorWithSpanIncludesSnippetAndLocation) {
   const lyra::diag::SourceSpan span{.file_id = fid, .begin = begin, .end = end};
 
   const auto diag = lyra::diag::Diagnostic::Unsupported(
-      span, "only `int` and `logic` types are supported",
+      span, lyra::diag::DiagCode::kUnsupportedTypeKind,
+      "only `int` and `logic` types are supported",
       lyra::diag::UnsupportedCategory::kType);
   const auto out = lyra::diag::RenderDiagnostic(
       diag, &mgr, lyra::diag::RenderOptions{.use_color = false});
@@ -77,8 +82,9 @@ TEST(DiagRender, ColoredOutputContainsAnsi) {
   const lyra::diag::SourceSpan span{.file_id = fid, .begin = 0, .end = 3};
 
   const auto out = lyra::diag::RenderDiagnostic(
-      lyra::diag::Diagnostic::Error(span, "boom"), &mgr,
-      lyra::diag::RenderOptions{.use_color = true});
+      lyra::diag::Diagnostic::HostError(
+          span, lyra::diag::DiagCode::kHostIoError, "boom"),
+      &mgr, lyra::diag::RenderOptions{.use_color = true});
 
   EXPECT_NE(out.find(kAnsiEsc), std::string::npos);
 }
@@ -88,7 +94,9 @@ TEST(DiagRender, NoSnippetWhenDisabled) {
   const auto fid = mgr.AddFile("main.sv", "int x;\n");
   const lyra::diag::SourceSpan span{.file_id = fid, .begin = 0, .end = 3};
   const auto out = lyra::diag::RenderDiagnostic(
-      lyra::diag::Diagnostic::Error(span, "boom"), &mgr,
+      lyra::diag::Diagnostic::HostError(
+          span, lyra::diag::DiagCode::kHostIoError, "boom"),
+      &mgr,
       lyra::diag::RenderOptions{
           .use_color = false, .show_source_snippet = false});
   EXPECT_TRUE(Has(out, "main.sv:1:1:"));
@@ -101,11 +109,16 @@ TEST(DiagRender, SinkSummaryAggregatesCounts) {
   lyra::diag::DiagnosticSink sink;
   sink.Report(
       lyra::diag::Diagnostic::Unsupported(
+          lyra::diag::DiagCode::kUnsupportedForGenerate,
           "feature A is not supported yet",
           lyra::diag::UnsupportedCategory::kFeature));
-  sink.Report(lyra::diag::Diagnostic::HostError("cannot read 'foo.sv'"));
   sink.Report(
-      lyra::diag::Diagnostic::Warning(lyra::diag::SourceSpan{}, "pedantic"));
+      lyra::diag::Diagnostic::HostError(
+          lyra::diag::DiagCode::kHostIoError, "cannot read 'foo.sv'"));
+  sink.Report(
+      lyra::diag::Diagnostic::Warning(
+          lyra::diag::SourceSpan{}, lyra::diag::DiagCode::kWarningPedantic,
+          "pedantic"));
 
   const auto out = lyra::diag::RenderDiagnostics(
       sink, nullptr, lyra::diag::RenderOptions{.use_color = false});
@@ -123,6 +136,7 @@ TEST(DiagRender, SinkEmptyHasNoSummary) {
 TEST(DiagRender, NoteAttachesAfterPrimary) {
   auto diag =
       lyra::diag::Diagnostic::Unsupported(
+          lyra::diag::DiagCode::kUnsupportedForGenerate,
           "feature is not supported", lyra::diag::UnsupportedCategory::kFeature)
           .WithNote("see related design discussion");
   const auto out = lyra::diag::RenderDiagnostic(
@@ -136,38 +150,43 @@ TEST(DiagRender, NoteAttachesAfterPrimary) {
 
 TEST(DiagRender, UnsupportedCategoryPreservedAcrossKinds) {
   const auto type_diag = lyra::diag::Diagnostic::Unsupported(
-      lyra::diag::SourceSpan{}, "wide types not supported",
-      lyra::diag::UnsupportedCategory::kType);
+      lyra::diag::SourceSpan{}, lyra::diag::DiagCode::kUnsupportedTypeKind,
+      "wide types not supported", lyra::diag::UnsupportedCategory::kType);
   ASSERT_TRUE(type_diag.primary.category.has_value());
   EXPECT_EQ(
       *type_diag.primary.category, lyra::diag::UnsupportedCategory::kType);
 
   const auto op_diag = lyra::diag::Diagnostic::Unsupported(
-      "weird expression form", lyra::diag::UnsupportedCategory::kOperation);
+      lyra::diag::DiagCode::kUnsupportedExpressionForm, "weird expression form",
+      lyra::diag::UnsupportedCategory::kOperation);
   ASSERT_TRUE(op_diag.primary.category.has_value());
   EXPECT_EQ(
       *op_diag.primary.category, lyra::diag::UnsupportedCategory::kOperation);
 
   const auto feature_diag = lyra::diag::Diagnostic::Unsupported(
-      "language feature gap", lyra::diag::UnsupportedCategory::kFeature);
+      lyra::diag::DiagCode::kUnsupportedForGenerate, "language feature gap",
+      lyra::diag::UnsupportedCategory::kFeature);
   ASSERT_TRUE(feature_diag.primary.category.has_value());
   EXPECT_EQ(
       *feature_diag.primary.category,
       lyra::diag::UnsupportedCategory::kFeature);
 
   EXPECT_FALSE(
-      lyra::diag::Diagnostic::Error(lyra::diag::SourceSpan{}, "bug")
+      lyra::diag::Diagnostic::HostError(
+          lyra::diag::DiagCode::kHostIoError, "io")
           .primary.category.has_value());
   EXPECT_FALSE(
-      lyra::diag::Diagnostic::HostError("io").primary.category.has_value());
-  EXPECT_FALSE(
-      lyra::diag::Diagnostic::Warning(lyra::diag::SourceSpan{}, "warn")
+      lyra::diag::Diagnostic::Warning(
+          lyra::diag::SourceSpan{}, lyra::diag::DiagCode::kWarningPedantic,
+          "warn")
           .primary.category.has_value());
 
+  // Notes carry only span+message; they have no category field by design.
   auto with_note = lyra::diag::Diagnostic::Unsupported(
-                       "x", lyra::diag::UnsupportedCategory::kFeature)
+                       lyra::diag::DiagCode::kUnsupportedForGenerate, "x",
+                       lyra::diag::UnsupportedCategory::kFeature)
                        .WithNote("y");
-  EXPECT_FALSE(with_note.notes.front().category.has_value());
+  EXPECT_EQ(with_note.notes.front().message, "y");
 }
 
 }  // namespace

--- a/tests/diag_framework/diag_matcher.cpp
+++ b/tests/diag_framework/diag_matcher.cpp
@@ -1,0 +1,177 @@
+#include "tests/diag_framework/diag_matcher.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <filesystem>
+#include <format>
+#include <numeric>
+#include <optional>
+#include <span>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/render.hpp"
+#include "lyra/diag/source_manager.hpp"
+#include "lyra/diag/source_span.hpp"
+
+namespace lyra::test {
+namespace {
+
+auto Specificity(const ExpectedDiag& e) -> int {
+  // code is always present and is the primary identity, so it does not
+  // contribute to relative specificity.
+  return 0 + (e.kind ? 4 : 0) + (e.category ? 2 : 0) + (e.file ? 2 : 0) +
+         (e.line ? 1 : 0);
+}
+
+auto FormatExpected(const ExpectedDiag& e) -> std::string {
+  std::string s = std::format("code={}", diag::DiagCodeName(e.code));
+  if (e.kind) s += std::format(", kind={}", static_cast<int>(*e.kind));
+  if (e.category) {
+    s += std::format(", category={}", static_cast<int>(*e.category));
+  }
+  if (e.file) s += std::format(", file={}", *e.file);
+  if (e.line) s += std::format(", line={}", *e.line);
+  return s;
+}
+
+auto MatchExpectedAt(
+    std::size_t k, std::span<const diag::Diagnostic> actuals,
+    std::span<const ExpectedDiag> expecteds, std::span<const std::size_t> order,
+    std::vector<bool>& used, const MatchContext& ctx) -> bool {
+  if (k == order.size()) {
+    return true;
+  }
+  const auto& e = expecteds[order[k]];
+  for (std::size_t i = 0; i < actuals.size(); ++i) {
+    if (used[i]) continue;
+    if (!MatchOne(actuals[i], e, ctx)) continue;
+    used[i] = true;
+    if (MatchExpectedAt(k + 1, actuals, expecteds, order, used, ctx)) {
+      return true;
+    }
+    used[i] = false;
+  }
+  return false;
+}
+
+}  // namespace
+
+auto NormalizeCasePath(
+    const std::filesystem::path& abs_path,
+    const std::filesystem::path& case_dir) -> std::string {
+  // Use lexically_relative to compare path strings directly, without
+  // filesystem canonicalization. std::filesystem::relative resolves
+  // symlinks asymmetrically when the two arguments traverse different
+  // sets of symlinks (e.g. runfiles trees vs. source-tree symlinks),
+  // which produces misleading results in a Bazel sandbox.
+  auto rel = abs_path.lexically_normal().lexically_relative(
+      case_dir.lexically_normal());
+  if (!rel.empty() && !rel.native().starts_with("..")) {
+    return rel.generic_string();
+  }
+  std::error_code ec;
+  auto canon = std::filesystem::weakly_canonical(abs_path, ec);
+  if (ec) return abs_path.generic_string();
+  return canon.generic_string();
+}
+
+auto MatchOne(
+    const diag::Diagnostic& actual, const ExpectedDiag& expected,
+    const MatchContext& ctx) -> bool {
+  const auto& primary = actual.primary;
+  if (primary.code != expected.code) {
+    return false;
+  }
+  if (expected.kind && primary.kind != *expected.kind) {
+    return false;
+  }
+  if (expected.category && primary.category != expected.category) {
+    return false;
+  }
+  if (expected.file || expected.line) {
+    if (!std::holds_alternative<diag::SourceSpan>(primary.span)) {
+      return false;
+    }
+    const auto& span = std::get<diag::SourceSpan>(primary.span);
+    if (ctx.mgr == nullptr) return false;
+    const auto* info = ctx.mgr->GetFile(span.file_id);
+    if (info == nullptr) return false;
+    if (expected.file) {
+      const auto actual_rel = NormalizeCasePath(info->path, ctx.case_dir);
+      if (actual_rel != *expected.file) return false;
+    }
+    if (expected.line) {
+      const auto lc = ctx.mgr->OffsetToLineCol(span.file_id, span.begin);
+      if (static_cast<int>(lc.line) != *expected.line) return false;
+    }
+  }
+  return true;
+}
+
+auto MatchAll(
+    std::span<const diag::Diagnostic> actuals,
+    std::span<const ExpectedDiag> expecteds, const MatchContext& ctx)
+    -> std::optional<std::string> {
+  std::vector<std::size_t> order(expecteds.size());
+  std::ranges::iota(order, std::size_t{0});
+  std::ranges::sort(order, [&](std::size_t a, std::size_t b) {
+    const int sa = Specificity(expecteds[a]);
+    const int sb = Specificity(expecteds[b]);
+    return sa != sb ? sa > sb : a < b;
+  });
+
+  std::vector<bool> used(actuals.size(), false);
+  if (MatchExpectedAt(0, actuals, expecteds, order, used, ctx)) {
+    return std::nullopt;
+  }
+
+  std::string msg = "structured diagnostic match failed.\nexpected:\n";
+  for (std::size_t i = 0; i < expecteds.size(); ++i) {
+    msg += std::format("  [{}] {}\n", i, FormatExpected(expecteds[i]));
+  }
+  msg += "actual:\n";
+  msg += FormatDiagnosticsForDebug(actuals, ctx);
+  return msg;
+}
+
+auto FormatDiagnosticsForDebug(
+    std::span<const diag::Diagnostic> diags, const MatchContext& ctx)
+    -> std::string {
+  std::string out;
+  if (diags.empty()) {
+    out += "  (no diagnostics)\n";
+    return out;
+  }
+  const diag::RenderOptions opts{
+      .use_color = false, .show_source_snippet = false};
+  for (std::size_t i = 0; i < diags.size(); ++i) {
+    const auto& primary = diags[i].primary;
+    out += std::format("  [{}] kind={}", i, static_cast<int>(primary.kind));
+    if (primary.category) {
+      out += std::format(", category={}", static_cast<int>(*primary.category));
+    }
+    out += std::format(", code={}", diag::DiagCodeName(primary.code));
+    if (std::holds_alternative<diag::SourceSpan>(primary.span) &&
+        ctx.mgr != nullptr) {
+      const auto& span = std::get<diag::SourceSpan>(primary.span);
+      const auto* info = ctx.mgr->GetFile(span.file_id);
+      if (info != nullptr) {
+        out += std::format(
+            ", file={}", NormalizeCasePath(info->path, ctx.case_dir));
+      }
+      const auto lc = ctx.mgr->OffsetToLineCol(span.file_id, span.begin);
+      out += std::format(", line={}", lc.line);
+    }
+    out += '\n';
+    out += "      ";
+    out += diag::RenderDiagnostic(diags[i], ctx.mgr, opts);
+    if (out.empty() || out.back() != '\n') out += '\n';
+  }
+  return out;
+}
+
+}  // namespace lyra::test

--- a/tests/diag_framework/diag_matcher.hpp
+++ b/tests/diag_framework/diag_matcher.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <span>
+#include <string>
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_manager.hpp"
+#include "tests/diag_framework/expected_diag.hpp"
+
+namespace lyra::test {
+
+struct MatchContext {
+  const diag::SourceManager* mgr = nullptr;
+  std::filesystem::path case_dir;
+};
+
+auto NormalizeCasePath(
+    const std::filesystem::path& abs_path,
+    const std::filesystem::path& case_dir) -> std::string;
+
+auto MatchOne(
+    const diag::Diagnostic& actual, const ExpectedDiag& expected,
+    const MatchContext& ctx) -> bool;
+
+auto MatchAll(
+    std::span<const diag::Diagnostic> actuals,
+    std::span<const ExpectedDiag> expecteds, const MatchContext& ctx)
+    -> std::optional<std::string>;
+
+auto FormatDiagnosticsForDebug(
+    std::span<const diag::Diagnostic> diags, const MatchContext& ctx)
+    -> std::string;
+
+}  // namespace lyra::test

--- a/tests/diag_framework/expected_diag.hpp
+++ b/tests/diag_framework/expected_diag.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
+
+namespace lyra::test {
+
+struct ExpectedDiag {
+  explicit ExpectedDiag(diag::DiagCode c) : code(c) {
+  }
+
+  diag::DiagCode code;
+  std::optional<diag::DiagKind> kind;
+  std::optional<diag::UnsupportedCategory> category;
+  std::optional<std::string> file;
+  std::optional<int> line;
+};
+
+}  // namespace lyra::test

--- a/tests/diag_framework/yaml_parser.cpp
+++ b/tests/diag_framework/yaml_parser.cpp
@@ -1,0 +1,106 @@
+#include "tests/diag_framework/yaml_parser.hpp"
+
+#include <filesystem>
+#include <format>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <yaml-cpp/yaml.h>
+
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
+
+namespace lyra::test {
+namespace {
+
+auto ParseKind(const std::string& s) -> diag::DiagKind {
+  if (s == "error") return diag::DiagKind::kError;
+  if (s == "unsupported") return diag::DiagKind::kUnsupported;
+  if (s == "host_error") return diag::DiagKind::kHostError;
+  if (s == "warning") return diag::DiagKind::kWarning;
+  throw std::runtime_error(
+      std::format("expect.diagnostics: unknown kind '{}'", s));
+}
+
+auto ParseCategory(const std::string& s) -> diag::UnsupportedCategory {
+  if (s == "type") return diag::UnsupportedCategory::kType;
+  if (s == "operation") return diag::UnsupportedCategory::kOperation;
+  if (s == "feature") return diag::UnsupportedCategory::kFeature;
+  throw std::runtime_error(
+      std::format("expect.diagnostics: unknown category '{}'", s));
+}
+
+}  // namespace
+
+auto ParseExpectedDiag(const YAML::Node& node) -> ExpectedDiag {
+  if (!node || !node.IsMap()) {
+    throw std::runtime_error("expect.diagnostics entry must be a map");
+  }
+
+  if (!node["code"]) {
+    throw std::runtime_error("expect.diagnostics: 'code' is required");
+  }
+  const auto code_text = node["code"].as<std::string>();
+  auto resolved = diag::ParseDiagCode(code_text);
+  if (!resolved) {
+    throw std::runtime_error(
+        std::format("expect.diagnostics: unknown code '{}'", code_text));
+  }
+  ExpectedDiag out(*resolved);
+
+  if (node["kind"]) {
+    out.kind = ParseKind(node["kind"].as<std::string>());
+  }
+
+  if (node["category"]) {
+    if (out.kind && *out.kind != diag::DiagKind::kUnsupported) {
+      throw std::runtime_error(
+          "expect.diagnostics: 'category' is only valid when kind=unsupported");
+    }
+    out.category = ParseCategory(node["category"].as<std::string>());
+  }
+
+  if (node["file"]) {
+    out.file = node["file"].as<std::string>();
+  }
+
+  if (node["line"]) {
+    const auto v = node["line"].as<int>();
+    if (v <= 0) {
+      throw std::runtime_error(
+          std::format("expect.diagnostics: 'line' must be > 0 (got {})", v));
+    }
+    out.line = v;
+  }
+
+  return out;
+}
+
+auto ParseExpectedDiagList(const YAML::Node& seq) -> std::vector<ExpectedDiag> {
+  std::vector<ExpectedDiag> out;
+  if (!seq) return out;
+  if (!seq.IsSequence()) {
+    throw std::runtime_error("expect.diagnostics must be a sequence");
+  }
+  out.reserve(seq.size());
+  for (const auto& item : seq) {
+    out.push_back(ParseExpectedDiag(item));
+  }
+  return out;
+}
+
+auto LoadExpectedDiagnostics(const std::filesystem::path& case_yaml_path)
+    -> std::vector<ExpectedDiag> {
+  YAML::Node root = YAML::LoadFile(case_yaml_path.string());
+  const auto& expect = root["expect"];
+  if (!expect || !expect.IsMap()) {
+    return {};
+  }
+  return ParseExpectedDiagList(expect["diagnostics"]);
+}
+
+auto LoadExpectedDiagnostics(const TestCase& tc) -> std::vector<ExpectedDiag> {
+  return LoadExpectedDiagnostics(tc.case_yaml_path);
+}
+
+}  // namespace lyra::test

--- a/tests/diag_framework/yaml_parser.hpp
+++ b/tests/diag_framework/yaml_parser.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <filesystem>
+#include <vector>
+#include <yaml-cpp/yaml.h>
+
+#include "tests/diag_framework/expected_diag.hpp"
+#include "tests/framework/runner.hpp"
+
+namespace lyra::test {
+
+auto ParseExpectedDiag(const YAML::Node& node) -> ExpectedDiag;
+auto ParseExpectedDiagList(const YAML::Node& seq) -> std::vector<ExpectedDiag>;
+
+auto LoadExpectedDiagnostics(const TestCase& tc) -> std::vector<ExpectedDiag>;
+
+auto LoadExpectedDiagnostics(const std::filesystem::path& case_yaml_path)
+    -> std::vector<ExpectedDiag>;
+
+}  // namespace lyra::test

--- a/tests/diag_framework_test.cpp
+++ b/tests/diag_framework_test.cpp
@@ -1,0 +1,295 @@
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <yaml-cpp/yaml.h>
+
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_manager.hpp"
+#include "lyra/diag/source_span.hpp"
+#include "tests/diag_framework/diag_matcher.hpp"
+#include "tests/diag_framework/expected_diag.hpp"
+#include "tests/diag_framework/yaml_parser.hpp"
+
+namespace {
+
+using lyra::diag::DiagCode;
+using lyra::diag::DiagKind;
+using lyra::diag::Diagnostic;
+using lyra::diag::SourceManager;
+using lyra::diag::SourceSpan;
+using lyra::diag::UnsupportedCategory;
+using lyra::test::ExpectedDiag;
+using lyra::test::MatchAll;
+using lyra::test::MatchContext;
+using lyra::test::MatchOne;
+using lyra::test::NormalizeCasePath;
+
+auto MakeUnsupported(
+    SourceSpan span, DiagCode code, std::string msg, UnsupportedCategory cat)
+    -> Diagnostic {
+  return Diagnostic::Unsupported(span, code, std::move(msg), cat);
+}
+
+TEST(DiagMatcher, CodeMustMatch) {
+  SourceManager mgr;
+  const MatchContext ctx{.mgr = &mgr, .case_dir = "/case"};
+  const auto actual = MakeUnsupported(
+      SourceSpan{}, DiagCode::kUnsupportedQueueType, "msg",
+      UnsupportedCategory::kType);
+
+  EXPECT_TRUE(
+      MatchOne(actual, ExpectedDiag(DiagCode::kUnsupportedQueueType), ctx));
+  EXPECT_FALSE(
+      MatchOne(actual, ExpectedDiag(DiagCode::kUnsupportedEnumType), ctx));
+}
+
+TEST(DiagMatcher, KindOptional) {
+  SourceManager mgr;
+  const MatchContext ctx{.mgr = &mgr, .case_dir = "/case"};
+  const auto actual = MakeUnsupported(
+      SourceSpan{}, DiagCode::kUnsupportedQueueType, "msg",
+      UnsupportedCategory::kType);
+
+  EXPECT_TRUE(
+      MatchOne(actual, ExpectedDiag(DiagCode::kUnsupportedQueueType), ctx));
+
+  ExpectedDiag exp_match(DiagCode::kUnsupportedQueueType);
+  exp_match.kind = DiagKind::kUnsupported;
+  EXPECT_TRUE(MatchOne(actual, exp_match, ctx));
+
+  ExpectedDiag exp_wrong(DiagCode::kUnsupportedQueueType);
+  exp_wrong.kind = DiagKind::kError;
+  EXPECT_FALSE(MatchOne(actual, exp_wrong, ctx));
+}
+
+TEST(DiagMatcher, CategoryMustMatchWhenSet) {
+  SourceManager mgr;
+  const MatchContext ctx{.mgr = &mgr, .case_dir = "/case"};
+  const auto actual = MakeUnsupported(
+      SourceSpan{}, DiagCode::kUnsupportedQueueType, "msg",
+      UnsupportedCategory::kType);
+
+  ExpectedDiag exp_match(DiagCode::kUnsupportedQueueType);
+  exp_match.category = UnsupportedCategory::kType;
+  EXPECT_TRUE(MatchOne(actual, exp_match, ctx));
+
+  ExpectedDiag exp_wrong(DiagCode::kUnsupportedQueueType);
+  exp_wrong.category = UnsupportedCategory::kFeature;
+  EXPECT_FALSE(MatchOne(actual, exp_wrong, ctx));
+}
+
+TEST(DiagMatcher, FileLineRequireSourceSpan) {
+  SourceManager mgr;
+  const MatchContext ctx{.mgr = &mgr, .case_dir = "/case"};
+  const auto unknown_span_actual = MakeUnsupported(
+      SourceSpan{}, DiagCode::kUnsupportedQueueType, "msg",
+      UnsupportedCategory::kType);
+
+  ExpectedDiag exp_file(DiagCode::kUnsupportedQueueType);
+  exp_file.file = "x.sv";
+  EXPECT_FALSE(MatchOne(unknown_span_actual, exp_file, ctx));
+
+  ExpectedDiag exp_line(DiagCode::kUnsupportedQueueType);
+  exp_line.line = 1;
+  EXPECT_FALSE(MatchOne(unknown_span_actual, exp_line, ctx));
+}
+
+TEST(DiagMatcher, FileAndLineMatch) {
+  SourceManager mgr;
+  const std::string content = "module M;\n  bit q [$];\nendmodule\n";
+  const auto fid = mgr.AddFile("/case/main.sv", content);
+  const auto begin = static_cast<std::uint32_t>(content.find("bit q [$]"));
+  const SourceSpan span{.file_id = fid, .begin = begin, .end = begin + 9};
+  const MatchContext ctx{.mgr = &mgr, .case_dir = "/case"};
+
+  const auto actual = MakeUnsupported(
+      span, DiagCode::kUnsupportedQueueType, "queue",
+      UnsupportedCategory::kType);
+
+  ExpectedDiag exp_match(DiagCode::kUnsupportedQueueType);
+  exp_match.file = "main.sv";
+  exp_match.line = 2;
+  EXPECT_TRUE(MatchOne(actual, exp_match, ctx));
+
+  ExpectedDiag exp_wrong_line(DiagCode::kUnsupportedQueueType);
+  exp_wrong_line.line = 1;
+  EXPECT_FALSE(MatchOne(actual, exp_wrong_line, ctx));
+
+  ExpectedDiag exp_wrong_file(DiagCode::kUnsupportedQueueType);
+  exp_wrong_file.file = "other.sv";
+  EXPECT_FALSE(MatchOne(actual, exp_wrong_file, ctx));
+}
+
+TEST(DiagMatchAll, EmptyExpectedAlwaysPasses) {
+  SourceManager mgr;
+  const MatchContext ctx{.mgr = &mgr, .case_dir = "/case"};
+  std::vector<Diagnostic> actuals;
+  std::vector<ExpectedDiag> expecteds;
+  EXPECT_FALSE(MatchAll(actuals, expecteds, ctx).has_value());
+
+  actuals.push_back(MakeUnsupported(
+      SourceSpan{}, DiagCode::kUnsupportedQueueType, "msg",
+      UnsupportedCategory::kType));
+  EXPECT_FALSE(MatchAll(actuals, expecteds, ctx).has_value());
+}
+
+TEST(DiagMatchAll, SubsetUnordered) {
+  SourceManager mgr;
+  const MatchContext ctx{.mgr = &mgr, .case_dir = "/case"};
+  std::vector<Diagnostic> actuals;
+  actuals.push_back(MakeUnsupported(
+      SourceSpan{}, DiagCode::kUnsupportedEnumType, "enum",
+      UnsupportedCategory::kType));
+  actuals.push_back(MakeUnsupported(
+      SourceSpan{}, DiagCode::kUnsupportedQueueType, "queue",
+      UnsupportedCategory::kType));
+
+  std::vector<ExpectedDiag> expecteds{
+      ExpectedDiag(DiagCode::kUnsupportedQueueType),
+  };
+  EXPECT_FALSE(MatchAll(actuals, expecteds, ctx).has_value());
+}
+
+TEST(DiagMatchAll, BacktrackingFindsAssignment) {
+  SourceManager mgr;
+  const MatchContext ctx{.mgr = &mgr, .case_dir = "/case"};
+
+  const std::string content = "a\nb\nc\n";
+  const auto fid = mgr.AddFile("/case/x.sv", content);
+  const SourceSpan span_line1{.file_id = fid, .begin = 0, .end = 1};
+  const SourceSpan span_line2{.file_id = fid, .begin = 2, .end = 3};
+
+  std::vector<Diagnostic> actuals;
+  actuals.push_back(MakeUnsupported(
+      span_line1, DiagCode::kUnsupportedQueueType, "q",
+      UnsupportedCategory::kType));
+  actuals.push_back(MakeUnsupported(
+      span_line2, DiagCode::kUnsupportedQueueType, "q",
+      UnsupportedCategory::kType));
+
+  ExpectedDiag strong(DiagCode::kUnsupportedQueueType);
+  strong.file = "x.sv";
+  strong.line = 2;
+
+  std::vector<ExpectedDiag> expecteds{
+      ExpectedDiag(DiagCode::kUnsupportedQueueType),  // weak
+      strong,
+  };
+  EXPECT_FALSE(MatchAll(actuals, expecteds, ctx).has_value());
+}
+
+TEST(DiagMatchAll, FailsWhenNoAssignmentExists) {
+  SourceManager mgr;
+  const MatchContext ctx{.mgr = &mgr, .case_dir = "/case"};
+  std::vector<Diagnostic> actuals;
+  actuals.push_back(MakeUnsupported(
+      SourceSpan{}, DiagCode::kUnsupportedQueueType, "queue",
+      UnsupportedCategory::kType));
+
+  std::vector<ExpectedDiag> expecteds{
+      ExpectedDiag(DiagCode::kUnsupportedQueueType),
+      ExpectedDiag(DiagCode::kUnsupportedEnumType),
+  };
+  const auto result = MatchAll(actuals, expecteds, ctx);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NE(
+      result->find("structured diagnostic match failed"), std::string::npos);
+}
+
+TEST(NormalizeCasePathFn, RelativeUnderCaseDir) {
+  EXPECT_EQ(NormalizeCasePath("/case/sub/main.sv", "/case"), "sub/main.sv");
+  EXPECT_EQ(NormalizeCasePath("/case/main.sv", "/case"), "main.sv");
+}
+
+TEST(NormalizeCasePathFn, OutsideCaseDirFallsBack) {
+  const auto out = NormalizeCasePath("/elsewhere/main.sv", "/case");
+  EXPECT_FALSE(out.starts_with(".."));
+}
+
+TEST(YamlParserFn, ValidMinimal) {
+  YAML::Node n = YAML::Load("code: unsupported_queue_type");
+  const auto e = lyra::test::ParseExpectedDiag(n);
+  EXPECT_EQ(e.code, DiagCode::kUnsupportedQueueType);
+  EXPECT_FALSE(e.kind.has_value());
+  EXPECT_FALSE(e.category.has_value());
+  EXPECT_FALSE(e.file.has_value());
+  EXPECT_FALSE(e.line.has_value());
+}
+
+TEST(YamlParserFn, ValidFull) {
+  const auto* yaml = R"(
+code: unsupported_queue_type
+kind: unsupported
+category: type
+file: main.sv
+line: 7
+)";
+  YAML::Node n = YAML::Load(yaml);
+  const auto e = lyra::test::ParseExpectedDiag(n);
+  EXPECT_EQ(e.code, DiagCode::kUnsupportedQueueType);
+  ASSERT_TRUE(e.kind.has_value());
+  EXPECT_EQ(*e.kind, DiagKind::kUnsupported);
+  ASSERT_TRUE(e.category.has_value());
+  EXPECT_EQ(*e.category, UnsupportedCategory::kType);
+  EXPECT_EQ(e.file, "main.sv");
+  EXPECT_EQ(e.line, 7);
+}
+
+TEST(YamlParserFn, MissingCodeThrows) {
+  YAML::Node n = YAML::Load("kind: error");
+  EXPECT_THROW(lyra::test::ParseExpectedDiag(n), std::runtime_error);
+}
+
+TEST(YamlParserFn, BadKindThrows) {
+  YAML::Node n = YAML::Load("code: unsupported_queue_type\nkind: not_a_kind");
+  EXPECT_THROW(lyra::test::ParseExpectedDiag(n), std::runtime_error);
+}
+
+TEST(YamlParserFn, NoteKindRejected) {
+  YAML::Node n = YAML::Load("code: unsupported_queue_type\nkind: note");
+  EXPECT_THROW(lyra::test::ParseExpectedDiag(n), std::runtime_error);
+}
+
+TEST(YamlParserFn, CategoryWithExplicitNonUnsupportedKindThrows) {
+  YAML::Node n =
+      YAML::Load("code: unsupported_queue_type\nkind: error\ncategory: type");
+  EXPECT_THROW(lyra::test::ParseExpectedDiag(n), std::runtime_error);
+}
+
+TEST(YamlParserFn, CategoryWithoutKindIsAllowed) {
+  YAML::Node n = YAML::Load("code: unsupported_queue_type\ncategory: type");
+  const auto e = lyra::test::ParseExpectedDiag(n);
+  EXPECT_FALSE(e.kind.has_value());
+  ASSERT_TRUE(e.category.has_value());
+  EXPECT_EQ(*e.category, UnsupportedCategory::kType);
+}
+
+TEST(YamlParserFn, BadCategoryThrows) {
+  YAML::Node n = YAML::Load("code: unsupported_queue_type\ncategory: weird");
+  EXPECT_THROW(lyra::test::ParseExpectedDiag(n), std::runtime_error);
+}
+
+TEST(YamlParserFn, ZeroLineThrows) {
+  YAML::Node n = YAML::Load("code: unsupported_queue_type\nline: 0");
+  EXPECT_THROW(lyra::test::ParseExpectedDiag(n), std::runtime_error);
+}
+
+TEST(YamlParserFn, NegativeLineThrows) {
+  YAML::Node n = YAML::Load("code: unsupported_queue_type\nline: -3");
+  EXPECT_THROW(lyra::test::ParseExpectedDiag(n), std::runtime_error);
+}
+
+TEST(YamlParserFn, BadCodeThrows) {
+  YAML::Node n = YAML::Load("code: nonexistent_code");
+  EXPECT_THROW(lyra::test::ParseExpectedDiag(n), std::runtime_error);
+}
+
+TEST(YamlParserFn, NonMapEntryThrows) {
+  YAML::Node n = YAML::Load("just a string");
+  EXPECT_THROW(lyra::test::ParseExpectedDiag(n), std::runtime_error);
+}
+
+}  // namespace

--- a/tests/diag_struct_test.cpp
+++ b/tests/diag_struct_test.cpp
@@ -1,0 +1,155 @@
+#include <cstddef>
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+#include <fmt/core.h>
+
+#include "lyra/compiler/compile.hpp"
+#include "lyra/diag/sink.hpp"
+#include "lyra/frontend/load.hpp"
+#include "tests/diag_framework/diag_matcher.hpp"
+#include "tests/diag_framework/expected_diag.hpp"
+#include "tests/diag_framework/yaml_parser.hpp"
+#include "tests/framework/runner.hpp"
+#include "tools/cpp/runfiles/runfiles.h"
+
+using bazel::tools::cpp::runfiles::Runfiles;
+using lyra::test::ExpectedDiag;
+using lyra::test::FilterCases;
+using lyra::test::FormatDiagnosticsForDebug;
+using lyra::test::LoadCases;
+using lyra::test::LoadExpectedDiagnostics;
+using lyra::test::LoadSuite;
+using lyra::test::MatchAll;
+using lyra::test::MatchContext;
+using lyra::test::TestCase;
+
+namespace {
+
+struct StructEnv {
+  std::filesystem::path cases_root;
+  std::filesystem::path suites_yaml;
+};
+
+auto ResolveEnv(Runfiles& rf) -> StructEnv {
+  StructEnv env;
+  env.cases_root = rf.Rlocation("_main/tests/cases");
+  env.suites_yaml = rf.Rlocation("_main/tests/suites.yaml");
+  return env;
+}
+
+const std::unordered_set<std::string> kAllowedArgs = {"--no-color"};
+
+class DiagStructTest : public testing::Test {
+ public:
+  explicit DiagStructTest(const TestCase& c) : case_(&c) {
+  }
+
+ protected:
+  void TestBody() override {
+    for (const auto& a : case_->input.extra_args) {
+      if (kAllowedArgs.contains(a)) continue;
+      ADD_FAILURE() << case_->id
+                    << ": diag_struct_tests does not support CLI-only arg: "
+                    << a;
+      return;
+    }
+
+    lyra::frontend::CompilationInput input;
+    if (case_->input.top.has_value()) {
+      input.top = *case_->input.top;
+    }
+    for (const auto& f : case_->input.files) {
+      input.files.push_back((case_->case_dir / f).string());
+    }
+
+    std::vector<ExpectedDiag> expected;
+    try {
+      expected = LoadExpectedDiagnostics(*case_);
+    } catch (const std::exception& e) {
+      ADD_FAILURE() << case_->id
+                    << ": failed to parse expect.diagnostics: " << e.what();
+      return;
+    }
+
+    lyra::diag::DiagnosticSink sink;
+    auto result = lyra::compiler::Compile(input, sink);
+
+    if (!result.artifacts.parse) {
+      ADD_FAILURE() << case_->id
+                    << ": compile produced no ParseResult; cannot match Lyra "
+                       "diagnostics. sink:\n"
+                    << FormatDiagnosticsForDebug(
+                           sink.Diagnostics(), MatchContext{
+                                                   .mgr = nullptr,
+                                                   .case_dir = case_->case_dir,
+                                               });
+      return;
+    }
+
+    if (!result.slang_ok) {
+      ADD_FAILURE()
+          << case_->id
+          << ": frontend produced slang diagnostics; diag_struct_tests "
+             "only matches Lyra-owned diagnostics. Use cli_golden_tests "
+             "for slang diagnostic cases.";
+      return;
+    }
+
+    const MatchContext ctx{
+        .mgr = &result.artifacts.parse->diag_sources,
+        .case_dir = case_->case_dir,
+    };
+
+    if (auto mm = MatchAll(sink.Diagnostics(), expected, ctx)) {
+      ADD_FAILURE() << case_->id << ": " << *mm;
+    }
+  }
+
+ private:
+  const TestCase* case_;
+};
+
+}  // namespace
+
+auto main(int argc, char** argv) -> int {
+  testing::InitGoogleTest(&argc, argv);
+
+  std::string err;
+  std::unique_ptr<Runfiles> runfiles{Runfiles::CreateForTest(&err)};
+  if (!runfiles) {
+    fmt::print(stderr, "failed to create runfiles: {}\n", err);
+    return 1;
+  }
+  static const StructEnv kEnv = ResolveEnv(*runfiles);
+
+  const std::span<char* const> args{argv, static_cast<std::size_t>(argc)};
+  std::string suite_name = "architecture_diag_struct";
+  for (std::size_t i = 1; i + 1 < args.size(); ++i) {
+    if (std::string_view(args[i]) == "--suite") {
+      suite_name = args[i + 1];
+    }
+  }
+
+  static const std::vector<TestCase> kCases = [&] {
+    auto loaded = LoadCases(kEnv.cases_root);
+    auto suite = LoadSuite(kEnv.suites_yaml, suite_name);
+    return FilterCases(loaded, suite);
+  }();
+
+  // NOLINTBEGIN(cppcoreguidelines-owning-memory)
+  for (const auto& c : kCases) {
+    testing::RegisterTest(
+        "DiagStruct", c.id.c_str(), nullptr, nullptr, __FILE__, __LINE__,
+        [&c]() -> testing::Test* { return new DiagStructTest(c); });
+  }
+  // NOLINTEND(cppcoreguidelines-owning-memory)
+
+  return RUN_ALL_TESTS();
+}

--- a/tests/framework/runner.cpp
+++ b/tests/framework/runner.cpp
@@ -48,6 +48,7 @@ auto ParseCase(
 
   TestCase c;
   c.case_dir = case_dir;
+  c.case_yaml_path = yaml_path;
 
   if (!root["id"]) {
     throw std::runtime_error(

--- a/tests/framework/runner.hpp
+++ b/tests/framework/runner.hpp
@@ -31,6 +31,7 @@ struct TestCase {
   std::string id;
   std::vector<std::string> tags;
   std::filesystem::path case_dir;
+  std::filesystem::path case_yaml_path;
   CaseInput input;
   CaseExpect expect;
 };

--- a/tests/suites.yaml
+++ b/tests/suites.yaml
@@ -2,3 +2,6 @@ suites:
   architecture_reset:
     include_tags: [emit, dump, errors]
     exclude: []
+  architecture_diag_struct:
+    include_tags: [diag-struct]
+    exclude: []


### PR DESCRIPTION
## Summary

This PR introduces a structured-identity layer for primary diagnostics and a parallel in-process test harness, while leaving CLI rendering and the existing CLI golden-test pipeline untouched. The goal is to let tests assert `Diagnostic` objects by stable `DiagCode` rather than by stderr substring matching.

Production-side changes:
- Every primary diagnostic now carries a required `DiagCode`. The taxonomy lives in `include/lyra/diag/diag_code.hpp`, and a single canonical `DiagCodeInfo` table in `src/lyra/diag/diag_code.cpp` owns the kind/category/name for each code. All 25+ existing emission sites in AST->HIR, HIR->MIR, frontend, and CLI host paths now thread codes through the factory APIs.
- `DiagItem` is split into `PrimaryDiagItem` (kind, span, code, message, optional category) and `NoteDiagItem` (span, message). Notes have no independent identity, so they no longer require a fake `kNote` sentinel code.
- Diagnostic factories enforce that `DiagCodeKind(code)` (and `DiagCodeCategory(code)` for `Unsupported`) match the factory's claim, throwing `InternalError` on mismatch.
- The compile pipeline is factored out of the CLI into a new `lyra::compiler` library (`include/lyra/compiler/compile.hpp`, `cc_library(:compiler)`). `Compile(input, sink, StopAfter)` returns a `CompileResult { CompileArtifacts artifacts; bool slang_ok; }`. Lyra-owned errors flow through the sink; slang parse/elaboration status is reported separately via `slang_ok`.

Test-side changes:
- New `tests:diag_framework` library (`expected_diag.hpp`, `yaml_parser.{hpp,cpp}`, `diag_matcher.{hpp,cpp}`) implements `ExpectedDiag(code)` (explicit constructor; no default), an unordered-subset matcher with specificity-sorted backtracking, and case-relative path normalization that survives Bazel sandbox symlinks via `lexically_relative`.
- New `cc_test(:diag_struct_tests)` runs `compiler::Compile` in-process and matches `sink.Diagnostics()` structurally. Slang-failed cases are routed back to `cli_golden_tests` with a clear framework error.
- New `cc_test(:diag_framework_tests)` covers the matcher and YAML parser with focused unit tests.
- One existing case (`tests/cases/errors/unsupported_type`) is converted end-to-end with the `diag-struct` tag; its existing `stderr` assertions are preserved.

## Design

The two test layers are deliberately disjoint:
- `cli_golden_tests` (subprocess of `lyra`) owns CLI contract: exit codes, stdout/stderr text, flag semantics.
- `diag_struct_tests` (in-process via `compiler::Compile`) owns compiler diagnostic semantics: structured `Diagnostic` identity.

The existing `tests:framework` library does not gain compile-pipeline deps. The new `tests:diag_framework` depends on `framework` one-way.

`DiagCodeInfo` metadata is exposed via `DiagCodeKind`, `DiagCodeCategory`, `DiagCodeName`, `ParseDiagCode`. The YAML schema for `expect.diagnostics` is anchored on `code` (required); `kind`, `category`, `file`, `line` are independent refinements. There is intentionally no `message` field in the structured schema.

`DiagKind` and `UnsupportedCategory` live in `include/lyra/diag/kind.hpp` so `diag_code.hpp` can include them directly without forward declarations.

## Testing

- [x] `bazel build //...`
- [x] `bazel test //tests:cli_golden_tests` (CLI contract preserved end-to-end)
- [x] `bazel test //tests:diag_render_tests` (renderer regression)
- [x] `bazel test //tests:diag_struct_tests` (new structured matcher)
- [x] `bazel test //tests:diag_framework_tests` (matcher + parser unit tests)
- [x] Negative-mutation check on the converted case: changing `code:` produces a clear structured failure showing expected vs actual.