### PR TITLE
Add call expression representation in HIR and MIR

### DIFF
--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -3,9 +3,11 @@
 #include <compare>
 #include <cstdint>
 #include <variant>
+#include <vector>
 
 #include "lyra/hir/binary_op.hpp"
 #include "lyra/hir/primary.hpp"
+#include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/type.hpp"
 
 namespace lyra::hir {
@@ -33,7 +35,13 @@ struct AssignExpr {
   TypeId type;
 };
 
-using ExprData = std::variant<PrimaryExpr, BinaryExpr, AssignExpr>;
+struct CallExpr {
+  SubroutineRef callee;
+  std::vector<ExprId> arguments;
+  TypeId result_type;
+};
+
+using ExprData = std::variant<PrimaryExpr, BinaryExpr, AssignExpr, CallExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -10,6 +10,7 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/member_var.hpp"
 #include "lyra/hir/process.hpp"
+#include "lyra/hir/subroutine.hpp"
 
 namespace lyra::hir {
 
@@ -73,16 +74,21 @@ class StructuralScope {
   auto AddExpr(Expr expr) -> ExprId;
   auto AddProcess(Process process) -> ProcessId;
   auto AddGenerate(Generate generate) -> GenerateId;
+  auto AddSubroutine(UserSubroutineDecl decl) -> SubroutineId;
 
   [[nodiscard]] auto MemberVars() const -> const std::vector<MemberVar>&;
   [[nodiscard]] auto Exprs() const -> const std::vector<Expr>&;
   [[nodiscard]] auto Processes() const -> const std::vector<Process>&;
   [[nodiscard]] auto Generates() const -> const std::vector<Generate>&;
+  [[nodiscard]] auto Subroutines() const
+      -> const std::vector<UserSubroutineDecl>&;
 
   [[nodiscard]] auto GetMemberVar(MemberVarId id) const -> const MemberVar&;
   [[nodiscard]] auto GetExpr(ExprId id) const -> const Expr&;
   [[nodiscard]] auto GetProcess(ProcessId id) const -> const Process&;
   [[nodiscard]] auto GetGenerate(GenerateId id) const -> const Generate&;
+  [[nodiscard]] auto GetSubroutine(SubroutineId id) const
+      -> const UserSubroutineDecl&;
 
  private:
   friend struct Generate;
@@ -92,6 +98,7 @@ class StructuralScope {
   std::vector<Expr> exprs_;
   std::vector<Process> processes_;
   std::vector<Generate> generates_;
+  std::vector<UserSubroutineDecl> subroutines_;
 };
 
 inline auto Generate::AddChildScope(StructuralScope scope)

--- a/include/lyra/hir/subroutine.hpp
+++ b/include/lyra/hir/subroutine.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+#include <string>
+
+#include "lyra/hir/type.hpp"
+
+namespace lyra::hir {
+
+struct SubroutineId {
+  std::uint32_t value;
+
+  auto operator<=>(const SubroutineId&) const -> std::strong_ordering = default;
+};
+
+enum class SubroutineKind : std::uint8_t {
+  kTask,
+  kFunction,
+};
+
+struct UserSubroutineDecl {
+  std::string name;
+  SubroutineKind kind;
+  TypeId result_type;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/subroutine_ref.hpp
+++ b/include/lyra/hir/subroutine_ref.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <variant>
+
+#include "lyra/hir/parent_scope_hops.hpp"
+#include "lyra/hir/subroutine.hpp"
+#include "lyra/support/system_subroutine.hpp"
+
+namespace lyra::hir {
+
+struct UserSubroutineRef {
+  ParentScopeHops parent_scope_hops;
+  SubroutineId id;
+};
+
+struct SystemSubroutineRef {
+  support::SystemSubroutineId id;
+};
+
+using SubroutineRef = std::variant<UserSubroutineRef, SystemSubroutineRef>;
+
+}  // namespace lyra::hir

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -9,6 +9,7 @@
 #include "lyra/hir/local_var.hpp"
 #include "lyra/hir/member_var.hpp"
 #include "lyra/hir/structural_scope.hpp"
+#include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/mir/class_decl_id.hpp"
 #include "lyra/mir/compilation_unit.hpp"
@@ -98,9 +99,32 @@ class ClassLoweringState {
         hir::ParentScopeHops{hops.value - 1}, hir_id);
   }
 
+  void BindUserSubroutine(
+      hir::SubroutineId hir_id, mir::UserSubroutineTargetId mir_id) {
+    if (hir_id.value >= user_subroutine_map_.size()) {
+      user_subroutine_map_.resize(hir_id.value + 1);
+    }
+    user_subroutine_map_[hir_id.value] = mir_id;
+  }
+
+  [[nodiscard]] auto LookupUserSubroutine(
+      hir::ParentScopeHops hops, hir::SubroutineId hir_id) const
+      -> mir::UserSubroutineTargetId {
+    if (hops.value == 0) {
+      return user_subroutine_map_.at(hir_id.value);
+    }
+    if (parent_ == nullptr) {
+      throw support::InternalError(
+          "ClassLoweringState::LookupUserSubroutine: hops out of class chain");
+    }
+    return parent_->LookupUserSubroutine(
+        hir::ParentScopeHops{hops.value - 1}, hir_id);
+  }
+
  private:
   const ClassLoweringState* parent_;
   std::vector<mir::MemberVarId> member_var_map_;
+  std::vector<mir::UserSubroutineTargetId> user_subroutine_map_;
 };
 
 class ProcessLoweringState {

--- a/include/lyra/mir/class_decl.hpp
+++ b/include/lyra/mir/class_decl.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "lyra/mir/class_decl_id.hpp"
+#include "lyra/mir/expr.hpp"
 #include "lyra/mir/member_var.hpp"
 #include "lyra/mir/process.hpp"
 #include "lyra/mir/stmt.hpp"
@@ -36,12 +37,20 @@ class ClassDecl {
   [[nodiscard]] auto GetClass(ClassDeclId id) const -> const ClassDecl&;
   auto AddClass(ClassDecl child) -> ClassDeclId;
 
+  [[nodiscard]] auto UserSubroutineTargets() const
+      -> const std::vector<UserSubroutineTarget>&;
+  [[nodiscard]] auto GetUserSubroutineTarget(UserSubroutineTargetId id) const
+      -> const UserSubroutineTarget&;
+  auto AddUserSubroutineTarget(UserSubroutineTarget target)
+      -> UserSubroutineTargetId;
+
  private:
   std::string name_;
   std::vector<MemberVar> member_vars_;
   Body constructor_;
   std::vector<Process> processes_;
   std::vector<ClassDecl> classes_;
+  std::vector<UserSubroutineTarget> user_subroutine_targets_;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -2,12 +2,15 @@
 
 #include <compare>
 #include <cstdint>
+#include <string>
 #include <variant>
+#include <vector>
 
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/local_var.hpp"
 #include "lyra/mir/member_var.hpp"
 #include "lyra/mir/type.hpp"
+#include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::mir {
 
@@ -44,8 +47,37 @@ struct AssignExpr {
   TypeId type;
 };
 
+struct PrintBuiltinInfo {
+  support::PrintRadix radix;
+  bool append_newline;
+  bool is_strobe;
+  support::PrintSinkKind sink_kind;
+};
+
+using BuiltinOp = std::variant<PrintBuiltinInfo>;
+
+struct UserSubroutineTargetId {
+  std::uint32_t value;
+
+  auto operator<=>(const UserSubroutineTargetId&) const
+      -> std::strong_ordering = default;
+};
+
+struct UserSubroutineTarget {
+  std::string name;
+};
+
+using Callee = std::variant<UserSubroutineTargetId, BuiltinOp>;
+
+struct CallExpr {
+  Callee callee;
+  std::vector<ExprId> arguments;
+  TypeId result_type;
+};
+
 using ExprData = std::variant<
-    IntegerLiteral, MemberVarRef, LocalVarRef, BinaryExpr, AssignExpr>;
+    IntegerLiteral, MemberVarRef, LocalVarRef, BinaryExpr, AssignExpr,
+    CallExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -1,0 +1,160 @@
+#pragma once
+
+#include <array>
+#include <compare>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string_view>
+#include <variant>
+
+#include "lyra/support/internal_error.hpp"
+
+namespace lyra::support {
+
+struct SystemSubroutineId {
+  std::uint16_t value;
+
+  auto operator<=>(const SystemSubroutineId&) const
+      -> std::strong_ordering = default;
+};
+
+enum class SystemSubroutineOrigin : std::uint8_t {
+  kLanguageBuiltin,
+  kLyraExtension,
+  kExternalExtension,
+};
+
+enum class SystemSubroutineKind : std::uint8_t {
+  kTask,
+  kFunction,
+};
+
+enum class ReturnConvention : std::uint8_t {
+  kVoid,
+};
+
+struct ArgCountPolicy {
+  std::uint16_t min_args;
+  std::uint16_t max_args;
+
+  [[nodiscard]] constexpr auto Accepts(std::size_t count) const -> bool {
+    return count >= min_args && count <= max_args;
+  }
+};
+
+enum class PrintRadix : std::uint8_t {
+  kDecimal,
+  kBinary,
+  kOctal,
+  kHex,
+};
+
+enum class PrintSinkKind : std::uint8_t {
+  kStdout,
+  kFile,
+};
+
+struct PrintSystemSubroutineInfo {
+  PrintRadix radix;
+  bool append_newline;
+  bool is_strobe;
+  PrintSinkKind sink_kind;
+};
+
+using SystemSubroutineSemantic = std::variant<PrintSystemSubroutineInfo>;
+
+struct SystemSubroutineDesc {
+  SystemSubroutineId id;
+  std::string_view name;
+  SystemSubroutineOrigin origin;
+  SystemSubroutineKind kind;
+  ReturnConvention result_conv;
+  ArgCountPolicy arg_policy;
+  SystemSubroutineSemantic semantic;
+};
+
+namespace detail {
+
+inline constexpr std::array kSystemSubroutines = {
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{0},
+        .name = "$display",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 255},
+        .semantic =
+            PrintSystemSubroutineInfo{
+                .radix = PrintRadix::kDecimal,
+                .append_newline = true,
+                .is_strobe = false,
+                .sink_kind = PrintSinkKind::kStdout},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{1},
+        .name = "$write",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 255},
+        .semantic =
+            PrintSystemSubroutineInfo{
+                .radix = PrintRadix::kDecimal,
+                .append_newline = false,
+                .is_strobe = false,
+                .sink_kind = PrintSinkKind::kStdout},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{2},
+        .name = "$fdisplay",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 1, .max_args = 255},
+        .semantic =
+            PrintSystemSubroutineInfo{
+                .radix = PrintRadix::kDecimal,
+                .append_newline = true,
+                .is_strobe = false,
+                .sink_kind = PrintSinkKind::kFile},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{3},
+        .name = "$fwrite",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 1, .max_args = 255},
+        .semantic =
+            PrintSystemSubroutineInfo{
+                .radix = PrintRadix::kDecimal,
+                .append_newline = false,
+                .is_strobe = false,
+                .sink_kind = PrintSinkKind::kFile},
+    },
+};
+
+}  // namespace detail
+
+[[nodiscard]] inline auto FindSystemSubroutine(std::string_view name)
+    -> const SystemSubroutineDesc* {
+  for (const auto& desc : detail::kSystemSubroutines) {
+    if (desc.name == name) {
+      return &desc;
+    }
+  }
+  return nullptr;
+}
+
+[[nodiscard]] inline auto LookupSystemSubroutine(SystemSubroutineId id)
+    -> const SystemSubroutineDesc& {
+  const std::span<const SystemSubroutineDesc> view{detail::kSystemSubroutines};
+  if (id.value >= view.size()) {
+    throw InternalError(
+        "LookupSystemSubroutine: SystemSubroutineId out of range");
+  }
+  return view[id.value];
+}
+
+}  // namespace lyra::support

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -64,6 +64,10 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
             return "(" + RenderLvalue(ctx, e.target) + " = " +
                    RenderExpr(ctx, rhs) + ")";
           },
+          [](const mir::CallExpr&) -> std::string {
+            throw support::InternalError(
+                "RenderExpr: call lowering to C++ backend is not implemented");
+          },
       },
       expr.data);
 }

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -17,10 +17,13 @@
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/hir/structural_scope.hpp"
+#include "lyra/hir/subroutine.hpp"
+#include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/support/internal_error.hpp"
 #include "lyra/support/overloaded.hpp"
+#include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::hir {
 
@@ -195,7 +198,36 @@ class HirDumper {
         p);
   }
 
-  static auto FormatExprData(const ExprData& data) -> std::string {
+  [[nodiscard]] auto FormatSubroutineRef(const SubroutineRef& callee) const
+      -> std::string {
+    return std::visit(
+        support::Overloaded{
+            [this](const UserSubroutineRef& u) -> std::string {
+              const auto& owner = ResolveScope(u.parent_scope_hops);
+              const auto& decl = owner.GetSubroutine(u.id);
+              return std::format(
+                  "UserSubroutine[{}](hops={}) \"{}\"", u.id.value,
+                  u.parent_scope_hops.value, decl.name);
+            },
+            [](const SystemSubroutineRef& s) -> std::string {
+              const auto& desc = support::LookupSystemSubroutine(s.id);
+              return std::format(
+                  "SystemSubroutine[{}] \"{}\"", s.id.value, desc.name);
+            },
+        },
+        callee);
+  }
+
+  [[nodiscard]] auto ResolveScope(ParentScopeHops hops) const
+      -> const StructuralScope& {
+    if (hops.value >= scope_stack_.size()) {
+      throw support::InternalError(
+          "HirDumper::ResolveScope: ParentScopeHops out of range");
+    }
+    return *scope_stack_[scope_stack_.size() - 1 - hops.value];
+  }
+
+  [[nodiscard]] auto FormatExprData(const ExprData& data) const -> std::string {
     return std::visit(
         support::Overloaded{
             [](const PrimaryExpr& p) -> std::string {
@@ -211,15 +243,28 @@ class HirDumper {
                   "AssignExpr lhs=Expr[{}] rhs=Expr[{}] type=Type[{}]",
                   a.lhs.value, a.rhs.value, a.type.value);
             },
+            [this](const CallExpr& c) -> std::string {
+              std::string args;
+              for (std::size_t i = 0; i < c.arguments.size(); ++i) {
+                if (i != 0) {
+                  args += ", ";
+                }
+                args += std::format("Expr[{}]", c.arguments[i].value);
+              }
+              return std::format(
+                  "CallExpr callee={} args=[{}] type=Type[{}]",
+                  FormatSubroutineRef(c.callee), args, c.result_type.value);
+            },
         },
         data);
   }
 
-  static auto FormatProcExpr(const Process& p, ExprId id) -> std::string {
+  [[nodiscard]] auto FormatProcExpr(const Process& p, ExprId id) const
+      -> std::string {
     return FormatExprData(p.exprs.at(id.value).data);
   }
 
-  static auto FormatScopeExpr(const StructuralScope& s, ExprId id)
+  [[nodiscard]] auto FormatScopeExpr(const StructuralScope& s, ExprId id) const
       -> std::string {
     return FormatExprData(s.GetExpr(id).data);
   }
@@ -244,6 +289,7 @@ class HirDumper {
   }
 
   void DumpScope(const StructuralScope& s) {
+    scope_stack_.push_back(&s);
     Line("Scope:");
     Indent();
     for (std::size_t i = 0; i < s.MemberVars().size(); ++i) {
@@ -252,6 +298,14 @@ class HirDumper {
           std::format(
               "MemberVar[{}] \"{}\" : Type[{}]", i, v.name, v.type.value));
     }
+    for (std::size_t i = 0; i < s.Subroutines().size(); ++i) {
+      const auto& d = s.Subroutines()[i];
+      Line(
+          std::format(
+              "Subroutine[{}] {} \"{}\" : Type[{}]", i,
+              d.kind == SubroutineKind::kTask ? "task" : "function", d.name,
+              d.result_type.value));
+    }
     for (const auto& p : s.Processes()) {
       DumpProcess(p);
     }
@@ -259,6 +313,7 @@ class HirDumper {
       DumpGenerate(s, g);
     }
     Dedent();
+    scope_stack_.pop_back();
   }
 
   void DumpProcess(const Process& p) {
@@ -386,6 +441,7 @@ class HirDumper {
 
   std::string out_;
   int indent_ = 0;
+  std::vector<const StructuralScope*> scope_stack_;
 };
 
 }  // namespace

--- a/src/lyra/hir/structural_scope.cpp
+++ b/src/lyra/hir/structural_scope.cpp
@@ -8,6 +8,7 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/member_var.hpp"
 #include "lyra/hir/process.hpp"
+#include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/type.hpp"
 
 namespace lyra::hir {
@@ -43,6 +44,12 @@ auto StructuralScope::AddGenerate(Generate generate) -> GenerateId {
   return id;
 }
 
+auto StructuralScope::AddSubroutine(UserSubroutineDecl decl) -> SubroutineId {
+  const SubroutineId id{static_cast<std::uint32_t>(subroutines_.size())};
+  subroutines_.push_back(std::move(decl));
+  return id;
+}
+
 auto StructuralScope::MemberVars() const -> const std::vector<MemberVar>& {
   return member_vars_;
 }
@@ -59,6 +66,11 @@ auto StructuralScope::Generates() const -> const std::vector<Generate>& {
   return generates_;
 }
 
+auto StructuralScope::Subroutines() const
+    -> const std::vector<UserSubroutineDecl>& {
+  return subroutines_;
+}
+
 auto StructuralScope::GetMemberVar(MemberVarId id) const -> const MemberVar& {
   return member_vars_.at(id.value);
 }
@@ -73,6 +85,11 @@ auto StructuralScope::GetProcess(ProcessId id) const -> const Process& {
 
 auto StructuralScope::GetGenerate(GenerateId id) const -> const Generate& {
   return generates_.at(id.value);
+}
+
+auto StructuralScope::GetSubroutine(SubroutineId id) const
+    -> const UserSubroutineDecl& {
+  return subroutines_.at(id.value);
 }
 
 }  // namespace lyra::hir

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -2,14 +2,21 @@
 
 #include <cstdint>
 #include <expected>
+#include <string>
+#include <string_view>
 #include <utility>
+#include <vector>
 
 #include <slang/ast/Expression.h>
+#include <slang/ast/SemanticFacts.h>
 #include <slang/ast/Symbol.h>
+#include <slang/ast/SystemSubroutine.h>
 #include <slang/ast/expressions/AssignmentExpressions.h>
+#include <slang/ast/expressions/CallExpression.h>
 #include <slang/ast/expressions/LiteralExpressions.h>
 #include <slang/ast/expressions/MiscExpressions.h>
 #include <slang/ast/expressions/OperatorExpressions.h>
+#include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/numeric/SVInt.h>
 
@@ -21,8 +28,11 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/inspect.hpp"
 #include "lyra/hir/primary.hpp"
+#include "lyra/hir/subroutine_ref.hpp"
+#include "lyra/hir/type.hpp"
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/support/internal_error.hpp"
+#include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -50,6 +60,29 @@ auto MakeLiteralExpr(std::int64_t v) -> hir::Expr {
 auto MakeRefExpr(hir::ValueRef ref) -> hir::Expr {
   return hir::Expr{
       .data = hir::PrimaryExpr{.data = hir::RefExpr{.target = std::move(ref)}}};
+}
+
+auto FromSlangSubroutineKind(slang::ast::SubroutineKind k)
+    -> support::SystemSubroutineKind {
+  switch (k) {
+    case slang::ast::SubroutineKind::Function:
+      return support::SystemSubroutineKind::kFunction;
+    case slang::ast::SubroutineKind::Task:
+      return support::SystemSubroutineKind::kTask;
+  }
+  throw support::InternalError(
+      "FromSlangSubroutineKind: unknown SubroutineKind");
+}
+
+auto MakeReturnConventionType(
+    UnitLoweringState& unit_state, support::ReturnConvention conv)
+    -> hir::TypeId {
+  switch (conv) {
+    case support::ReturnConvention::kVoid:
+      return unit_state.AddType(hir::TypeData{hir::VoidType{}});
+  }
+  throw support::InternalError(
+      "MakeReturnConventionType: unknown ReturnConvention");
 }
 
 auto LowerNamedValueProc(
@@ -143,6 +176,83 @@ auto LowerProcExpr(
               .lhs = *lhs_id,
               .rhs = *rhs_id,
               .type = *type_id}};
+    }
+
+    case slang::ast::ExpressionKind::Call: {
+      const auto& call = expr.as<slang::ast::CallExpression>();
+
+      std::vector<hir::ExprId> arg_ids;
+      arg_ids.reserve(call.arguments().size());
+      for (const auto* arg : call.arguments()) {
+        auto id = append_child(*arg);
+        if (!id) return std::unexpected(std::move(id.error()));
+        arg_ids.push_back(*id);
+      }
+
+      if (call.isSystemCall()) {
+        const auto& info = std::get<slang::ast::CallExpression::SystemCallInfo>(
+            call.subroutine);
+        const std::string_view name = info.subroutine->name;
+
+        const auto* desc = support::FindSystemSubroutine(name);
+        if (desc == nullptr) {
+          throw support::InternalError(
+              std::string{"AST->HIR call: unresolved system subroutine '"} +
+              std::string{name} + "' after slang resolution");
+        }
+        const auto frontend_kind =
+            FromSlangSubroutineKind(info.subroutine->kind);
+        if (desc->kind != frontend_kind) {
+          throw support::InternalError(
+              std::string{
+                  "AST->HIR call: registry/frontend kind mismatch for '"} +
+              std::string{name} + "'");
+        }
+        if (!desc->arg_policy.Accepts(arg_ids.size())) {
+          throw support::InternalError(
+              std::string{
+                  "AST->HIR call: arg count outside descriptor policy for '"} +
+              std::string{name} + "'");
+        }
+
+        const auto result_type =
+            MakeReturnConventionType(unit_state, desc->result_conv);
+        return hir::Expr{
+            .data = hir::CallExpr{
+                .callee = hir::SystemSubroutineRef{.id = desc->id},
+                .arguments = std::move(arg_ids),
+                .result_type = result_type}};
+      }
+
+      const auto* sym =
+          std::get<const slang::ast::SubroutineSymbol*>(call.subroutine);
+      if (sym == nullptr) {
+        throw support::InternalError(
+            "AST->HIR call: user call missing resolved SubroutineSymbol");
+      }
+      const auto binding = unit_state.LookupSubroutineBinding(*sym);
+      if (!binding.has_value()) {
+        throw support::InternalError(
+            "AST->HIR call: resolved user subroutine has no registered HIR "
+            "binding");
+      }
+      const auto hops = stack.HopsTo(binding->owner_frame);
+      if (!hops.has_value()) {
+        throw support::InternalError(
+            "AST->HIR call: user subroutine owner frame is not on the current "
+            "scope stack");
+      }
+      auto result_type = type_id_of(expr);
+      if (!result_type) {
+        return std::unexpected(std::move(result_type.error()));
+      }
+      return hir::Expr{
+          .data = hir::CallExpr{
+              .callee =
+                  hir::UserSubroutineRef{
+                      .parent_scope_hops = *hops, .id = binding->local_id},
+              .arguments = std::move(arg_ids),
+              .result_type = *result_type}};
     }
 
     case slang::ast::ExpressionKind::Assignment: {

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -7,8 +7,10 @@
 #include <vector>
 
 #include <slang/ast/Scope.h>
+#include <slang/ast/SemanticFacts.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/BlockSymbols.h>
+#include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/syntax/SyntaxNode.h>
 
@@ -16,6 +18,8 @@
 #include "generate.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/structural_scope.hpp"
+#include "lyra/hir/subroutine.hpp"
+#include "lyra/hir/type.hpp"
 #include "lyra/support/internal_error.hpp"
 #include "process.hpp"
 #include "state.hpp"
@@ -24,6 +28,18 @@
 namespace lyra::lowering::ast_to_hir {
 
 namespace {
+
+auto FromSlangSubroutineKind(slang::ast::SubroutineKind k)
+    -> hir::SubroutineKind {
+  switch (k) {
+    case slang::ast::SubroutineKind::Function:
+      return hir::SubroutineKind::kFunction;
+    case slang::ast::SubroutineKind::Task:
+      return hir::SubroutineKind::kTask;
+  }
+  throw support::InternalError(
+      "FromSlangSubroutineKind: unknown SubroutineKind");
+}
 
 auto IsCaseConstruct(
     const std::vector<const slang::ast::GenerateBlockSymbol*>& siblings)
@@ -74,6 +90,25 @@ auto LowerScopeInto(
     }
     const auto type_id = unit_state.AddType(*std::move(type_data));
     scope_state.AddMemberVar(var, type_id);
+  }
+
+  for (const auto& member : slang_scope.members()) {
+    if (member.kind != slang::ast::SymbolKind::Subroutine) {
+      continue;
+    }
+    const auto& sym = member.as<slang::ast::SubroutineSymbol>();
+    auto return_type_data =
+        LowerTypeData(sym.getReturnType(), mapper.PointSpanOf(sym.location));
+    if (!return_type_data) {
+      return std::unexpected(std::move(return_type_data.error()));
+    }
+    const auto return_type_id =
+        unit_state.AddType(*std::move(return_type_data));
+    scope_state.AddSubroutine(
+        sym, hir::UserSubroutineDecl{
+                 .name = std::string{sym.name},
+                 .kind = FromSlangSubroutineKind(sym.subroutineKind),
+                 .result_type = return_type_id});
   }
 
   for (const auto& member : slang_scope.members()) {

--- a/src/lyra/lowering/ast_to_hir/state.hpp
+++ b/src/lyra/lowering/ast_to_hir/state.hpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 
 #include "lyra/hir/expr.hpp"
@@ -18,6 +19,7 @@
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/hir/structural_scope.hpp"
+#include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/support/internal_error.hpp"
 
@@ -38,6 +40,14 @@ struct MemberVarBinding {
 
 using MemberVarBindings =
     std::unordered_map<const slang::ast::VariableSymbol*, MemberVarBinding>;
+
+struct SubroutineBinding {
+  ScopeFrameId owner_frame;
+  hir::SubroutineId local_id;
+};
+
+using SubroutineBindings =
+    std::unordered_map<const slang::ast::SubroutineSymbol*, SubroutineBinding>;
 
 class UnitLoweringState {
  public:
@@ -73,6 +83,23 @@ class UnitLoweringState {
     return it->second;
   }
 
+  void RegisterSubroutineBinding(
+      const slang::ast::SubroutineSymbol& sym, ScopeFrameId owner_frame,
+      hir::SubroutineId local) {
+    subroutine_bindings_.emplace(
+        &sym, SubroutineBinding{.owner_frame = owner_frame, .local_id = local});
+  }
+
+  [[nodiscard]] auto LookupSubroutineBinding(
+      const slang::ast::SubroutineSymbol& sym) const
+      -> std::optional<SubroutineBinding> {
+    const auto it = subroutine_bindings_.find(&sym);
+    if (it == subroutine_bindings_.end()) {
+      return std::nullopt;
+    }
+    return it->second;
+  }
+
   auto MoveHirUnit() -> hir::ModuleUnit {
     return std::move(hir_unit_);
   }
@@ -80,6 +107,7 @@ class UnitLoweringState {
  private:
   hir::ModuleUnit hir_unit_;
   MemberVarBindings member_var_bindings_;
+  SubroutineBindings subroutine_bindings_;
 };
 
 class ScopeStack {
@@ -163,6 +191,14 @@ class ScopeLoweringState {
 
   auto AddGenerate(hir::Generate generate) -> hir::GenerateId {
     return scope_->AddGenerate(std::move(generate));
+  }
+
+  auto AddSubroutine(
+      const slang::ast::SubroutineSymbol& sym, hir::UserSubroutineDecl decl)
+      -> hir::SubroutineId {
+    const auto local = scope_->AddSubroutine(std::move(decl));
+    unit_state_->RegisterSubroutineBinding(sym, frame_, local);
+    return local;
   }
 
   [[nodiscard]] auto UnitState() -> UnitLoweringState& {

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -323,6 +323,14 @@ auto LowerScopeAsClass(
     class_state.BindMemberVar(hir_id, mir_id);
   }
 
+  for (std::size_t i = 0; i < scope.Subroutines().size(); ++i) {
+    const hir::SubroutineId hir_id{static_cast<std::uint32_t>(i)};
+    const auto& decl = scope.Subroutines()[i];
+    const mir::UserSubroutineTargetId mir_id = cls.AddUserSubroutineTarget(
+        mir::UserSubroutineTarget{.name = decl.name});
+    class_state.BindUserSubroutine(hir_id, mir_id);
+  }
+
   for (const auto& p : scope.Processes()) {
     cls.AddProcess(LowerProcess(unit_state, class_state, p));
   }

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -1,18 +1,23 @@
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 
+#include <utility>
 #include <variant>
+#include <vector>
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/binary_op.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/inspect.hpp"
 #include "lyra/hir/process.hpp"
+#include "lyra/hir/subroutine_ref.hpp"
+#include "lyra/hir/type.hpp"
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/support/internal_error.hpp"
 #include "lyra/support/overloaded.hpp"
+#include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -48,6 +53,37 @@ auto LowerRefAsLvalue(
           },
       },
       ref);
+}
+
+auto NormalizeSemanticToBuiltinOp(
+    const support::SystemSubroutineSemantic& semantic) -> mir::BuiltinOp {
+  return std::visit(
+      support::Overloaded{
+          [](const support::PrintSystemSubroutineInfo& info) -> mir::BuiltinOp {
+            return mir::PrintBuiltinInfo{
+                .radix = info.radix,
+                .append_newline = info.append_newline,
+                .is_strobe = info.is_strobe,
+                .sink_kind = info.sink_kind};
+          },
+      },
+      semantic);
+}
+
+auto LowerCallee(
+    const ClassLoweringState& class_state, const hir::SubroutineRef& callee)
+    -> mir::Callee {
+  return std::visit(
+      support::Overloaded{
+          [&](const hir::UserSubroutineRef& u) -> mir::Callee {
+            return class_state.LookupUserSubroutine(u.parent_scope_hops, u.id);
+          },
+          [](const hir::SystemSubroutineRef& s) -> mir::Callee {
+            const auto& desc = support::LookupSystemSubroutine(s.id);
+            return NormalizeSemanticToBuiltinOp(desc.semantic);
+          },
+      },
+      callee);
 }
 
 }  // namespace
@@ -104,6 +140,17 @@ auto LowerProcessExprData(
                 .value = body_state.TranslateExpr(a.rhs),
                 .type = unit_state.TranslateType(a.type)};
           },
+          [&](const hir::CallExpr& c) -> mir::ExprData {
+            std::vector<mir::ExprId> args;
+            args.reserve(c.arguments.size());
+            for (const auto arg : c.arguments) {
+              args.push_back(body_state.TranslateExpr(arg));
+            }
+            return mir::CallExpr{
+                .callee = LowerCallee(class_state, c.callee),
+                .arguments = std::move(args),
+                .result_type = unit_state.TranslateType(c.result_type)};
+          },
       },
       data);
 }
@@ -140,6 +187,12 @@ auto LowerStructuralExprData(const hir::ExprData& data)
             return diag::Unsupported(
                 diag::DiagCode::kUnsupportedStructuralExpressionForm,
                 "this structural expression form is not supported yet",
+                diag::UnsupportedCategory::kFeature);
+          },
+          [](const hir::CallExpr&) -> diag::Result<mir::ExprData> {
+            return diag::Unsupported(
+                diag::DiagCode::kUnsupportedStructuralExpressionForm,
+                "calls are not allowed in structural expressions",
                 diag::UnsupportedCategory::kFeature);
           },
       },

--- a/src/lyra/mir/class_decl.cpp
+++ b/src/lyra/mir/class_decl.cpp
@@ -73,4 +73,22 @@ auto ClassDecl::AddClass(ClassDecl child) -> ClassDeclId {
   return id;
 }
 
+auto ClassDecl::UserSubroutineTargets() const
+    -> const std::vector<UserSubroutineTarget>& {
+  return user_subroutine_targets_;
+}
+
+auto ClassDecl::GetUserSubroutineTarget(UserSubroutineTargetId id) const
+    -> const UserSubroutineTarget& {
+  return user_subroutine_targets_.at(id.value);
+}
+
+auto ClassDecl::AddUserSubroutineTarget(UserSubroutineTarget target)
+    -> UserSubroutineTargetId {
+  const UserSubroutineTargetId id{
+      static_cast<std::uint32_t>(user_subroutine_targets_.size())};
+  user_subroutine_targets_.push_back(std::move(target));
+  return id;
+}
+
 }  // namespace lyra::mir

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -20,6 +20,7 @@
 #include "lyra/mir/type.hpp"
 #include "lyra/support/internal_error.hpp"
 #include "lyra/support/overloaded.hpp"
+#include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::mir {
 
@@ -191,7 +192,63 @@ class MirDumper {
         l);
   }
 
-  static auto FormatExpr(const Body& body, ExprId id) -> std::string {
+  static auto FormatPrintRadix(support::PrintRadix r) -> std::string_view {
+    switch (r) {
+      case support::PrintRadix::kDecimal:
+        return "decimal";
+      case support::PrintRadix::kBinary:
+        return "binary";
+      case support::PrintRadix::kOctal:
+        return "octal";
+      case support::PrintRadix::kHex:
+        return "hex";
+    }
+    throw support::InternalError(
+        "MirDumper::FormatPrintRadix: unknown PrintRadix");
+  }
+
+  static auto FormatPrintSinkKind(support::PrintSinkKind s)
+      -> std::string_view {
+    switch (s) {
+      case support::PrintSinkKind::kStdout:
+        return "stdout";
+      case support::PrintSinkKind::kFile:
+        return "file";
+    }
+    throw support::InternalError(
+        "MirDumper::FormatPrintSinkKind: unknown PrintSinkKind");
+  }
+
+  static auto FormatBuiltinOp(const BuiltinOp& op) -> std::string {
+    return std::visit(
+        support::Overloaded{
+            [](const PrintBuiltinInfo& p) -> std::string {
+              return std::format(
+                  "Print(radix={}, newline={}, strobe={}, sink={})",
+                  FormatPrintRadix(p.radix), p.append_newline, p.is_strobe,
+                  FormatPrintSinkKind(p.sink_kind));
+            },
+        },
+        op);
+  }
+
+  [[nodiscard]] auto FormatCallee(const Callee& callee) const -> std::string {
+    return std::visit(
+        support::Overloaded{
+            [this](const UserSubroutineTargetId& id) -> std::string {
+              const auto& target = current_class_->GetUserSubroutineTarget(id);
+              return std::format(
+                  "UserSubroutine[{}] \"{}\"", id.value, target.name);
+            },
+            [](const BuiltinOp& op) -> std::string {
+              return std::format("Builtin({})", FormatBuiltinOp(op));
+            },
+        },
+        callee);
+  }
+
+  [[nodiscard]] auto FormatExpr(const Body& body, ExprId id) const
+      -> std::string {
     const auto& e = body.exprs.at(id.value);
     return std::visit(
         support::Overloaded{
@@ -213,6 +270,18 @@ class MirDumper {
               return std::format(
                   "AssignExpr target={} value=Expr[{}] type=Type[{}]",
                   FormatLvalue(a.target), a.value.value, a.type.value);
+            },
+            [this](const CallExpr& c) -> std::string {
+              std::string args;
+              for (std::size_t i = 0; i < c.arguments.size(); ++i) {
+                if (i != 0) {
+                  args += ", ";
+                }
+                args += std::format("Expr[{}]", c.arguments[i].value);
+              }
+              return std::format(
+                  "CallExpr callee={} args=[{}] type=Type[{}]",
+                  FormatCallee(c.callee), args, c.result_type.value);
             },
         },
         e.data);
@@ -240,6 +309,8 @@ class MirDumper {
   }
 
   void DumpClass(const ClassDecl& c) {
+    const ClassDecl* saved = current_class_;
+    current_class_ = &c;
     Line(std::format("Class \"{}\"", c.Name()));
     Indent();
 
@@ -262,6 +333,14 @@ class MirDumper {
     }
     Dedent();
 
+    Line("UserSubroutineTargets:");
+    Indent();
+    for (std::size_t i = 0; i < c.UserSubroutineTargets().size(); ++i) {
+      const auto& t = c.UserSubroutineTargets()[i];
+      Line(std::format("[{}] \"{}\"", i, t.name));
+    }
+    Dedent();
+
     Line("Constructor:");
     Indent();
     DumpBody(c.Constructor());
@@ -275,6 +354,7 @@ class MirDumper {
     Dedent();
 
     Dedent();
+    current_class_ = saved;
   }
 
   void DumpProcess(const Process& p, std::size_t index) {
@@ -430,6 +510,7 @@ class MirDumper {
 
   std::string out_;
   int indent_ = 0;
+  const ClassDecl* current_class_ = nullptr;
 };
 
 }  // namespace

--- a/tests/cases/dump/hir_call_system/case.yaml
+++ b/tests/cases/dump/hir_call_system/case.yaml
@@ -1,0 +1,17 @@
+id: dump.hir_call_system
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "Process (Initial)"
+      - "CallExpr callee=SystemSubroutine[0] \"$display\""
+      - "CallExpr callee=SystemSubroutine[1] \"$write\""
+      - "CallExpr callee=SystemSubroutine[2] \"$fdisplay\""
+      - "CallExpr callee=SystemSubroutine[3] \"$fwrite\""
+      - "VoidType"

--- a/tests/cases/dump/hir_call_system/main.sv
+++ b/tests/cases/dump/hir_call_system/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  int x;
+  initial begin
+    $display(x);
+    $write(x);
+    $fdisplay(1, x);
+    $fwrite(1, x);
+  end
+endmodule

--- a/tests/cases/dump/hir_call_user/case.yaml
+++ b/tests/cases/dump/hir_call_user/case.yaml
@@ -1,0 +1,16 @@
+id: dump.hir_call_user
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "Process (Initial)"
+      - "Subroutine[0] function \"add\""
+      - "Subroutine[1] task \"do_thing\""
+      - "CallExpr callee=UserSubroutine[0](hops=0) \"add\" args=[Expr[1], Expr[2]]"
+      - "CallExpr callee=UserSubroutine[1](hops=0) \"do_thing\" args=[Expr[5]]"

--- a/tests/cases/dump/hir_call_user/main.sv
+++ b/tests/cases/dump/hir_call_user/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  function automatic int add(int a, int b);
+    return a + b;
+  endfunction
+
+  task automatic do_thing(int a);
+  endtask
+
+  int x;
+  initial begin
+    x = add(1, 2);
+    do_thing(x);
+  end
+endmodule

--- a/tests/cases/dump/mir_call_system/case.yaml
+++ b/tests/cases/dump/mir_call_system/case.yaml
@@ -1,0 +1,16 @@
+id: dump.mir_call_system
+tags: [dump]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "Builtin(Print(radix=decimal, newline=true, strobe=false, sink=stdout))"
+      - "Builtin(Print(radix=decimal, newline=false, strobe=false, sink=stdout))"
+      - "Builtin(Print(radix=decimal, newline=true, strobe=false, sink=file))"
+      - "Builtin(Print(radix=decimal, newline=false, strobe=false, sink=file))"
+      - "VoidType"

--- a/tests/cases/dump/mir_call_system/main.sv
+++ b/tests/cases/dump/mir_call_system/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  int x;
+  initial begin
+    $display(x);
+    $write(x);
+    $fdisplay(1, x);
+    $fwrite(1, x);
+  end
+endmodule

--- a/tests/cases/dump/mir_call_user/case.yaml
+++ b/tests/cases/dump/mir_call_user/case.yaml
@@ -1,0 +1,13 @@
+id: dump.mir_call_user
+tags: [dump]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "CallExpr callee=UserSubroutine[0] \"add\" args=[Expr[1], Expr[2]]"
+      - "CallExpr callee=UserSubroutine[1] \"do_thing\" args=[Expr[5]]"

--- a/tests/cases/dump/mir_call_user/main.sv
+++ b/tests/cases/dump/mir_call_user/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  function automatic int add(int a, int b);
+    return a + b;
+  endfunction
+
+  task automatic do_thing(int a);
+  endtask
+
+  int x;
+  initial begin
+    x = add(1, 2);
+    do_thing(x);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds HIR and MIR representations for SystemVerilog subroutine calls, with the system-subroutine family (`$display`, `$write`, `$fdisplay`, `$fwrite`) normalized into builtin semantic ops at the HIR->MIR boundary. The endpoint of this cut is representation plus dump support, not execution; the C++ backend's `CallExpr` arm is an explicit `InternalError`. The motivation is to seat the system-subroutine pipeline early so that display-style output can become first-class test infrastructure later, without committing to a richer user-subroutine model up front.

## Design

### HIR side: lexical references

HIR adds `CallExpr { SubroutineRef callee, vector<ExprId> arguments, TypeId result_type }`. `SubroutineRef` is `variant<UserSubroutineRef, SystemSubroutineRef>`. User refs carry `{ ParentScopeHops, SubroutineId }`, mirroring how `MemberVarRef` already represents lexical references to scope-owned declarations. `UserSubroutineDecl` is owned by `hir::StructuralScope`, alongside member vars, processes, and generates -- subroutines are lexical declarations, not flat module artifacts. AST->HIR walks `slang::ast::SymbolKind::Subroutine` members during scope lowering, registers a binding `(SubroutineSymbol* -> {ScopeFrameId, SubroutineId})`, and at call sites resolves hops via `ScopeStack::HopsTo(owner_frame)`.

System calls go through a centralized IR-agnostic descriptor table in `support/system_subroutine.hpp`. `SystemSubroutineId` is an opaque handle (`uint16_t`); the descriptor row carries name, origin, kind, return convention, arg-count policy, and a `SystemSubroutineSemantic` variant payload. AST->HIR runs invariant checks against the descriptor (registry lookup, kind agreement with slang, arg-count policy) -- all `InternalError`, since slang already validates user-facing legality.

### MIR side: class-owned absolute targets

MIR is self-contained: no HIR includes, no HIR types in MIR variants. `mir::CallExpr` carries `Callee = variant<UserSubroutineTargetId, BuiltinOp>`. `UserSubroutineTarget` is owned by `mir::ClassDecl` -- the same class that owns member vars and child classes after #720's class-oriented MIR refactor. HIR->MIR lowers user calls by registering each `scope.Subroutines()` entry into the corresponding `mir::ClassDecl` inside `LowerScopeAsClass`, binding `(hir::SubroutineId -> mir::UserSubroutineTargetId)` in `ClassLoweringState`. Call-site resolution uses `ClassLoweringState::LookupUserSubroutine(hops, id)`, which walks `parent_` exactly like `LookupMemberVar`.

System calls collapse to `BuiltinOp` at the HIR->MIR boundary: the descriptor's semantic variant is normalized into `PrintBuiltinInfo { radix, append_newline, is_strobe, sink_kind }`, so `$display` and `$fdisplay` differ only in `sink_kind`, and `$display` vs `$write` only in `append_newline`. The outer `CallExpr` skeleton stays structurally identical between HIR and MIR; only the inner callee variant changes.

### What did not get rebuilt

No unit-global pointer-keyed translation table for user subroutines. No frontend `slang::ast::*` types in MIR. No split between system-call statements and user-call expressions. No `BuiltinFamily` enum running parallel to `BuiltinOp`. The descriptor table is the single source of truth for system-call surface identity.

### What is intentionally not in this cut

Backend C++ rendering for `CallExpr` throws `InternalError("call lowering to C++ backend is not implemented")`. Runtime/IO support for `PrintBuiltinInfo` does not exist yet. `UserSubroutineDecl` carries only `{ name, kind, result_type }` and `UserSubroutineTarget` carries only `{ name }` -- enough to keep the call infrastructure structurally honest, not enough to execute a user call. These are deliberately thin shells; the next cut will make builtin-print executable so observable SV output can replace fragile IR-spelling assertions.

## Testing

Four new dump cases under `tests/cases/dump/`: HIR and MIR for both system-call and user-call shapes. `mir_call_user` asserts the callee renders as `UserSubroutine[N] "name"` (class-local target id resolved through `current_class_`). `mir_call_system` asserts `Builtin(Print(...))` with the expected `radix/newline/strobe/sink` payload.