### PR TITLE
Add HIR loop-generate support

### DIFF
--- a/include/lyra/hir/binary_op.hpp
+++ b/include/lyra/hir/binary_op.hpp
@@ -4,6 +4,7 @@ namespace lyra::hir {
 
 enum class BinaryOp {
   kAdd,
+  kLessThan,
 };
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/loop_var.hpp
+++ b/include/lyra/hir/loop_var.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+#include <string>
+
+namespace lyra::hir {
+
+struct LoopVarDeclId {
+  std::uint32_t value;
+
+  auto operator<=>(const LoopVarDeclId&) const
+      -> std::strong_ordering = default;
+};
+
+struct LoopVarDecl {
+  std::string name;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "lyra/hir/expr.hpp"
+#include "lyra/hir/loop_var.hpp"
 #include "lyra/hir/member_var.hpp"
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/subroutine.hpp"
@@ -46,7 +47,15 @@ struct CaseGenerate {
   std::optional<StructuralScopeId> default_scope;
 };
 
-using GenerateData = std::variant<IfGenerate, CaseGenerate>;
+struct LoopGenerate {
+  LoopVarDeclId loop_var;
+  ExprId initial;
+  ExprId stop;
+  ExprId iter;
+  StructuralScopeId body_scope;
+};
+
+using GenerateData = std::variant<IfGenerate, CaseGenerate, LoopGenerate>;
 
 struct Generate {
   GenerateData data;
@@ -71,12 +80,14 @@ class StructuralScope {
   }
 
   auto AddMemberVar(std::string name, TypeId type) -> MemberVarId;
+  auto AddLoopVarDecl(std::string name) -> LoopVarDeclId;
   auto AddExpr(Expr expr) -> ExprId;
   auto AddProcess(Process process) -> ProcessId;
   auto AddGenerate(Generate generate) -> GenerateId;
   auto AddSubroutine(UserSubroutineDecl decl) -> SubroutineId;
 
   [[nodiscard]] auto MemberVars() const -> const std::vector<MemberVar>&;
+  [[nodiscard]] auto LoopVarDecls() const -> const std::vector<LoopVarDecl>&;
   [[nodiscard]] auto Exprs() const -> const std::vector<Expr>&;
   [[nodiscard]] auto Processes() const -> const std::vector<Process>&;
   [[nodiscard]] auto Generates() const -> const std::vector<Generate>&;
@@ -84,6 +95,8 @@ class StructuralScope {
       -> const std::vector<UserSubroutineDecl>&;
 
   [[nodiscard]] auto GetMemberVar(MemberVarId id) const -> const MemberVar&;
+  [[nodiscard]] auto GetLoopVarDecl(LoopVarDeclId id) const
+      -> const LoopVarDecl&;
   [[nodiscard]] auto GetExpr(ExprId id) const -> const Expr&;
   [[nodiscard]] auto GetProcess(ProcessId id) const -> const Process&;
   [[nodiscard]] auto GetGenerate(GenerateId id) const -> const Generate&;
@@ -95,6 +108,7 @@ class StructuralScope {
 
   StructuralScopeId id_{};
   std::vector<MemberVar> member_vars_;
+  std::vector<LoopVarDecl> loop_var_decls_;
   std::vector<Expr> exprs_;
   std::vector<Process> processes_;
   std::vector<Generate> generates_;

--- a/include/lyra/hir/value_ref.hpp
+++ b/include/lyra/hir/value_ref.hpp
@@ -3,6 +3,7 @@
 #include <variant>
 
 #include "lyra/hir/local_var.hpp"
+#include "lyra/hir/loop_var.hpp"
 #include "lyra/hir/member_var.hpp"
 #include "lyra/hir/parent_scope_hops.hpp"
 
@@ -21,6 +22,13 @@ struct LocalVarRef {
   auto operator==(const LocalVarRef&) const -> bool = default;
 };
 
-using ValueRef = std::variant<MemberVarRef, LocalVarRef>;
+struct LoopVarRef {
+  ParentScopeHops parent_scope_hops;
+  LoopVarDeclId target;
+
+  auto operator==(const LoopVarRef&) const -> bool = default;
+};
+
+using ValueRef = std::variant<MemberVarRef, LocalVarRef, LoopVarRef>;
 
 }  // namespace lyra::hir

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -166,6 +166,8 @@ class HirDumper {
     switch (op) {
       case BinaryOp::kAdd:
         return "Add";
+      case BinaryOp::kLessThan:
+        return "LessThan";
     }
     throw support::InternalError("HirDumper: unknown BinaryOp");
   }
@@ -180,6 +182,11 @@ class HirDumper {
             },
             [](const LocalVarRef& r) -> std::string {
               return std::format("LocalVar[{}]", r.target.value);
+            },
+            [](const LoopVarRef& r) -> std::string {
+              return std::format(
+                  "LoopVar[{}](hops={})", r.target.value,
+                  r.parent_scope_hops.value);
             },
         },
         v);
@@ -298,6 +305,10 @@ class HirDumper {
           std::format(
               "MemberVar[{}] \"{}\" : Type[{}]", i, v.name, v.type.value));
     }
+    for (std::size_t i = 0; i < s.LoopVarDecls().size(); ++i) {
+      const auto& lv = s.LoopVarDecls()[i];
+      Line(std::format("LoopVarDecl[{}] \"{}\"", i, lv.name));
+    }
     for (std::size_t i = 0; i < s.Subroutines().size(); ++i) {
       const auto& d = s.Subroutines()[i];
       Line(
@@ -305,6 +316,14 @@ class HirDumper {
               "Subroutine[{}] {} \"{}\" : Type[{}]", i,
               d.kind == SubroutineKind::kTask ? "task" : "function", d.name,
               d.result_type.value));
+    }
+    if (!s.Exprs().empty()) {
+      Line("Exprs:");
+      Indent();
+      for (std::size_t i = 0; i < s.Exprs().size(); ++i) {
+        Line(std::format("Expr[{}] {}", i, FormatExprData(s.Exprs()[i].data)));
+      }
+      Dedent();
     }
     for (const auto& p : s.Processes()) {
       DumpProcess(p);
@@ -433,6 +452,20 @@ class HirDumper {
               } else {
                 Line("default_scope: <none>");
               }
+              Dedent();
+            },
+            [&](const LoopGenerate& lg) {
+              Line(
+                  std::format(
+                      "Generate LoopGenerate loop_var=LoopVar[{}] "
+                      "initial=Expr[{}] stop=Expr[{}] iter=Expr[{}]",
+                      lg.loop_var.value, lg.initial.value, lg.stop.value,
+                      lg.iter.value));
+              Indent();
+              Line("body_scope:");
+              Indent();
+              DumpScope(g.child_scopes.at(lg.body_scope.value));
+              Dedent();
               Dedent();
             },
         },

--- a/src/lyra/hir/structural_scope.cpp
+++ b/src/lyra/hir/structural_scope.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "lyra/hir/expr.hpp"
+#include "lyra/hir/loop_var.hpp"
 #include "lyra/hir/member_var.hpp"
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/subroutine.hpp"
@@ -23,6 +24,12 @@ auto StructuralScope::AddMemberVar(std::string name, TypeId type)
     -> MemberVarId {
   const MemberVarId id{static_cast<std::uint32_t>(member_vars_.size())};
   member_vars_.push_back(MemberVar{.name = std::move(name), .type = type});
+  return id;
+}
+
+auto StructuralScope::AddLoopVarDecl(std::string name) -> LoopVarDeclId {
+  const LoopVarDeclId id{static_cast<std::uint32_t>(loop_var_decls_.size())};
+  loop_var_decls_.push_back(LoopVarDecl{.name = std::move(name)});
   return id;
 }
 
@@ -54,6 +61,10 @@ auto StructuralScope::MemberVars() const -> const std::vector<MemberVar>& {
   return member_vars_;
 }
 
+auto StructuralScope::LoopVarDecls() const -> const std::vector<LoopVarDecl>& {
+  return loop_var_decls_;
+}
+
 auto StructuralScope::Exprs() const -> const std::vector<Expr>& {
   return exprs_;
 }
@@ -73,6 +84,11 @@ auto StructuralScope::Subroutines() const
 
 auto StructuralScope::GetMemberVar(MemberVarId id) const -> const MemberVar& {
   return member_vars_.at(id.value);
+}
+
+auto StructuralScope::GetLoopVarDecl(LoopVarDeclId id) const
+    -> const LoopVarDecl& {
+  return loop_var_decls_.at(id.value);
 }
 
 auto StructuralScope::GetExpr(ExprId id) const -> const Expr& {

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -13,6 +13,7 @@
 #include <slang/ast/SystemSubroutine.h>
 #include <slang/ast/expressions/AssignmentExpressions.h>
 #include <slang/ast/expressions/CallExpression.h>
+#include <slang/ast/expressions/ConversionExpression.h>
 #include <slang/ast/expressions/LiteralExpressions.h>
 #include <slang/ast/expressions/MiscExpressions.h>
 #include <slang/ast/expressions/OperatorExpressions.h>
@@ -316,6 +317,186 @@ auto LowerStructuralExpr(
           span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
           "this structural expression form is not supported yet",
           diag::UnsupportedCategory::kFeature);
+  }
+}
+
+namespace {
+
+auto TryResolveLoopHeaderVar(
+    ScopeLoweringState& scope_state, LoopHeaderState& loop_state,
+    const slang::ast::VariableSymbol& var)
+    -> std::optional<hir::LoopVarDeclId> {
+  if (!var.flags.has(slang::ast::VariableFlags::CompilerGenerated)) {
+    return std::nullopt;
+  }
+  if (var.name != loop_state.expected_name) {
+    return std::nullopt;
+  }
+  if (loop_state.synthetic_symbol != nullptr &&
+      loop_state.synthetic_symbol != &var) {
+    throw support::InternalError(
+        "loop-generate header resolved multiple synthetic loop variables");
+  }
+  loop_state.synthetic_symbol = &var;
+  if (!loop_state.loop_var_id.has_value()) {
+    loop_state.loop_var_id = scope_state.Scope().AddLoopVarDecl(
+        std::string{loop_state.expected_name});
+  }
+  return loop_state.loop_var_id;
+}
+
+auto MapLoopHeaderBinaryOp(slang::ast::BinaryOperator op)
+    -> std::optional<hir::BinaryOp> {
+  switch (op) {
+    case slang::ast::BinaryOperator::Add:
+      return hir::BinaryOp::kAdd;
+    case slang::ast::BinaryOperator::LessThan:
+      return hir::BinaryOp::kLessThan;
+    default:
+      return std::nullopt;
+  }
+}
+
+}  // namespace
+
+auto LowerLoopHeaderExpr(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ScopeLoweringState& scope_state, const ScopeStack& stack,
+    LoopHeaderState& loop_state, const slang::ast::Expression& expr)
+    -> diag::Result<hir::Expr> {
+  const auto& mapper = unit_facts.SourceMapper();
+  const auto span = mapper.SpanOf(expr.sourceRange);
+
+  auto lower_child = [&](const slang::ast::Expression& e) {
+    return LowerLoopHeaderExpr(
+        unit_facts, unit_state, scope_state, stack, loop_state, e);
+  };
+  auto add_child =
+      [&](const slang::ast::Expression& e) -> diag::Result<hir::ExprId> {
+    auto child = lower_child(e);
+    if (!child) return std::unexpected(std::move(child.error()));
+    return scope_state.AppendExpr(*std::move(child));
+  };
+  auto type_id_of =
+      [&](const slang::ast::Expression& e) -> diag::Result<hir::TypeId> {
+    auto td = LowerTypeData(*e.type, mapper.SpanOf(e.sourceRange));
+    if (!td) return std::unexpected(std::move(td.error()));
+    return unit_state.AddType(*std::move(td));
+  };
+
+  switch (expr.kind) {
+    case slang::ast::ExpressionKind::IntegerLiteral: {
+      auto v = LowerIntegerLiteralValue(
+          unit_facts, expr.as<slang::ast::IntegerLiteral>());
+      if (!v) return std::unexpected(std::move(v.error()));
+      return MakeLiteralExpr(*v);
+    }
+
+    case slang::ast::ExpressionKind::NamedValue: {
+      const auto& named = expr.as<slang::ast::NamedValueExpression>();
+      if (named.symbol.kind != slang::ast::SymbolKind::Variable) {
+        return diag::Unsupported(
+            mapper.SpanOf(named.sourceRange),
+            diag::DiagCode::kUnsupportedNonVariableNamedReference,
+            "reference to non-variable declaration is not supported",
+            diag::UnsupportedCategory::kFeature);
+      }
+      const auto& var = named.symbol.as<slang::ast::VariableSymbol>();
+      if (auto loop_var =
+              TryResolveLoopHeaderVar(scope_state, loop_state, var)) {
+        return MakeRefExpr(
+            hir::LoopVarRef{
+                .parent_scope_hops = hir::ParentScopeHops{.value = 0},
+                .target = *loop_var});
+      }
+      const auto binding = unit_state.LookupMemberVarBinding(var);
+      if (!binding.has_value()) {
+        throw support::InternalError(
+            "LowerLoopHeaderExpr: variable was not bound during scope "
+            "lowering");
+      }
+      const auto hops = stack.HopsTo(binding->home_frame);
+      if (!hops.has_value()) {
+        throw support::InternalError(
+            "LowerLoopHeaderExpr: variable home frame is not on the current "
+            "scope stack");
+      }
+      return MakeRefExpr(
+          hir::MemberVarRef{
+              .parent_scope_hops = *hops, .target = binding->local_id});
+    }
+
+    case slang::ast::ExpressionKind::Conversion: {
+      // Slang inserts implicit Conversion nodes when binding loop-header
+      // expressions against the genvar's integer type; unwrap them.
+      const auto& conv = expr.as<slang::ast::ConversionExpression>();
+      if (!conv.isImplicit()) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedExpressionForm,
+            "explicit casts are not supported yet",
+            diag::UnsupportedCategory::kOperation);
+      }
+      return lower_child(conv.operand());
+    }
+
+    case slang::ast::ExpressionKind::BinaryOp: {
+      const auto& bin = expr.as<slang::ast::BinaryExpression>();
+      auto op = MapLoopHeaderBinaryOp(bin.op);
+      if (!op.has_value()) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedBinaryOperator,
+            "this binary operator is not supported yet",
+            diag::UnsupportedCategory::kOperation);
+      }
+      auto lhs_id = add_child(bin.left());
+      if (!lhs_id) return std::unexpected(std::move(lhs_id.error()));
+      auto rhs_id = add_child(bin.right());
+      if (!rhs_id) return std::unexpected(std::move(rhs_id.error()));
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return hir::Expr{
+          .data = hir::BinaryExpr{
+              .op = *op, .lhs = *lhs_id, .rhs = *rhs_id, .type = *type_id}};
+    }
+
+    case slang::ast::ExpressionKind::Assignment: {
+      const auto& as = expr.as<slang::ast::AssignmentExpression>();
+      if (as.isNonBlocking()) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedNonBlockingAssignment,
+            "non-blocking assignments are not supported yet",
+            diag::UnsupportedCategory::kFeature);
+      }
+      if (as.op.has_value()) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedCompoundAssignment,
+            "compound assignments are not supported yet",
+            diag::UnsupportedCategory::kFeature);
+      }
+      auto lhs_expr = lower_child(as.left());
+      if (!lhs_expr) return std::unexpected(std::move(lhs_expr.error()));
+      if (!hir::AsAssignableRef(*lhs_expr).has_value()) {
+        return diag::Unsupported(
+            mapper.SpanOf(as.left().sourceRange),
+            diag::DiagCode::kUnsupportedAssignmentTarget,
+            "assignment target is not supported yet",
+            diag::UnsupportedCategory::kFeature);
+      }
+      const hir::ExprId lhs_id = scope_state.AppendExpr(*std::move(lhs_expr));
+      auto rhs_id = add_child(as.right());
+      if (!rhs_id) return std::unexpected(std::move(rhs_id.error()));
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return hir::Expr{
+          .data =
+              hir::AssignExpr{.lhs = lhs_id, .rhs = *rhs_id, .type = *type_id}};
+    }
+
+    default:
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "this expression form is not supported yet",
+          diag::UnsupportedCategory::kOperation);
   }
 }
 

--- a/src/lyra/lowering/ast_to_hir/expression/lower.hpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.hpp
@@ -1,11 +1,16 @@
 #pragma once
 
+#include <optional>
+#include <string_view>
+
 #include <slang/ast/Expression.h>
+#include <slang/ast/symbols/VariableSymbols.h>
 
 #include "../facts.hpp"
 #include "../state.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
+#include "lyra/hir/loop_var.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -16,6 +21,21 @@ auto LowerProcExpr(
 
 auto LowerStructuralExpr(
     const UnitLoweringFacts& unit_facts, const slang::ast::Expression& expr)
+    -> diag::Result<hir::Expr>;
+
+// Short-lived state for lowering one loop-generate header's initial / stop
+// / iter expressions. The synthetic loop-variable identity is captured
+// lazily on first reference.
+struct LoopHeaderState {
+  std::string_view expected_name;
+  const slang::ast::VariableSymbol* synthetic_symbol = nullptr;
+  std::optional<hir::LoopVarDeclId> loop_var_id;
+};
+
+auto LowerLoopHeaderExpr(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ScopeLoweringState& scope_state, const ScopeStack& stack,
+    LoopHeaderState& loop_state, const slang::ast::Expression& expr)
     -> diag::Result<hir::Expr>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/generate.cpp
+++ b/src/lyra/lowering/ast_to_hir/generate.cpp
@@ -9,6 +9,7 @@
 
 #include <slang/ast/Expression.h>
 #include <slang/ast/symbols/BlockSymbols.h>
+#include <slang/ast/symbols/MemberSymbols.h>
 
 #include "expression/lower.hpp"
 #include "facts.hpp"
@@ -166,6 +167,60 @@ auto BuildCaseGenerate(
       .condition = cond_id,
       .items = std::move(items),
       .default_scope = default_id};
+  return gen;
+}
+
+auto BuildLoopGenerate(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ScopeLoweringState& parent_state, ScopeStack& stack,
+    const slang::ast::GenerateBlockArraySymbol& array)
+    -> diag::Result<hir::Generate> {
+  if (array.genvar == nullptr || array.initialExpression == nullptr ||
+      array.stopExpression == nullptr || array.iterExpression == nullptr) {
+    throw support::InternalError(
+        "BuildLoopGenerate: GenerateBlockArraySymbol is missing bound "
+        "header expressions or canonical genvar");
+  }
+
+  LoopHeaderState loop_state{
+      .expected_name = array.genvar->name,
+      .synthetic_symbol = nullptr,
+      .loop_var_id = std::nullopt};
+
+  auto initial_expr = LowerLoopHeaderExpr(
+      unit_facts, unit_state, parent_state, stack, loop_state,
+      *array.initialExpression);
+  if (!initial_expr) return std::unexpected(std::move(initial_expr.error()));
+  const hir::ExprId initial_id =
+      parent_state.AppendExpr(*std::move(initial_expr));
+
+  auto stop_expr = LowerLoopHeaderExpr(
+      unit_facts, unit_state, parent_state, stack, loop_state,
+      *array.stopExpression);
+  if (!stop_expr) return std::unexpected(std::move(stop_expr.error()));
+  const hir::ExprId stop_id = parent_state.AppendExpr(*std::move(stop_expr));
+
+  auto iter_expr = LowerLoopHeaderExpr(
+      unit_facts, unit_state, parent_state, stack, loop_state,
+      *array.iterExpression);
+  if (!iter_expr) return std::unexpected(std::move(iter_expr.error()));
+  const hir::ExprId iter_id = parent_state.AppendExpr(*std::move(iter_expr));
+
+  if (!loop_state.loop_var_id.has_value()) {
+    throw support::InternalError(
+        "BuildLoopGenerate: loop-generate header did not expose a "
+        "synthetic loop variable");
+  }
+
+  hir::Generate gen{};
+  const hir::StructuralScopeId body_scope_id =
+      gen.AddChildScope(hir::StructuralScope{});
+  gen.data = hir::LoopGenerate{
+      .loop_var = *loop_state.loop_var_id,
+      .initial = initial_id,
+      .stop = stop_id,
+      .iter = iter_id,
+      .body_scope = body_scope_id};
   return gen;
 }
 

--- a/src/lyra/lowering/ast_to_hir/generate.hpp
+++ b/src/lyra/lowering/ast_to_hir/generate.hpp
@@ -23,4 +23,10 @@ auto BuildCaseGenerate(
     std::span<const slang::ast::GenerateBlockSymbol* const> siblings)
     -> diag::Result<hir::Generate>;
 
+auto BuildLoopGenerate(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ScopeLoweringState& parent_state, ScopeStack& stack,
+    const slang::ast::GenerateBlockArraySymbol& array)
+    -> diag::Result<hir::Generate>;
+
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -131,12 +131,14 @@ auto LowerScopeInto(
   std::unordered_set<const slang::syntax::SyntaxNode*> consumed;
   for (const auto& member : slang_scope.members()) {
     switch (member.kind) {
-      case slang::ast::SymbolKind::GenerateBlockArray:
-        return diag::Unsupported(
-            mapper.PointSpanOf(member.location),
-            diag::DiagCode::kUnsupportedForGenerate,
-            "for-generate is not supported yet",
-            diag::UnsupportedCategory::kFeature);
+      case slang::ast::SymbolKind::GenerateBlockArray: {
+        const auto& array = member.as<slang::ast::GenerateBlockArraySymbol>();
+        auto g = BuildLoopGenerate(
+            unit_facts, unit_state, scope_state, stack, array);
+        if (!g) return std::unexpected(std::move(g.error()));
+        scope_state.AddGenerate(*std::move(g));
+        break;
+      }
 
       case slang::ast::SymbolKind::GenerateBlock: {
         const auto& block = member.as<slang::ast::GenerateBlockSymbol>();

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -100,6 +100,10 @@ auto EnumerateGenerateChildSpecs(
                    .class_name = ChildClassNameFor(gen_index, "default")});
             }
           },
+          [](const hir::LoopGenerate&) {
+            // Loop-generate is rejected at LowerGenerateAsStmt with a clean
+            // diagnostic; no child classes need to be installed here.
+          },
       },
       gen.data);
   return specs;
@@ -248,6 +252,12 @@ auto LowerGenerateAsStmt(
                         .cases = std::move(cases),
                         .default_body = default_body},
                 .child_bodies = std::move(child_bodies)};
+          },
+          [](const hir::LoopGenerate&) -> diag::Result<mir::Stmt> {
+            return diag::Unsupported(
+                diag::DiagCode::kUnsupportedForGenerate,
+                "for-generate lowering is not supported yet",
+                diag::UnsupportedCategory::kFeature);
           },
       },
       gen.data);

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -25,6 +25,10 @@ auto LowerBinaryOp(hir::BinaryOp op) -> mir::BinaryOp {
   switch (op) {
     case hir::BinaryOp::kAdd:
       return mir::BinaryOp::kAdd;
+    case hir::BinaryOp::kLessThan:
+      throw support::InternalError(
+          "LowerBinaryOp: kLessThan only appears in loop-generate header "
+          "expressions, which are rejected before HIR-to-MIR");
   }
   throw support::InternalError("LowerBinaryOp: unknown HIR BinaryOp");
 }
@@ -50,6 +54,12 @@ auto LowerRefAsLvalue(
           [&](const hir::LocalVarRef& l) -> mir::Lvalue {
             return mir::LocalVarRef{
                 .target = proc_state.TranslateLocalVar(l.target)};
+          },
+          [](const hir::LoopVarRef&) -> mir::Lvalue {
+            throw support::InternalError(
+                "LowerRefAsLvalue: loop-variable references only appear in "
+                "loop-generate header expressions, which are rejected before "
+                "HIR-to-MIR");
           },
       },
       ref);
@@ -113,6 +123,13 @@ auto LowerProcessExprData(
                                 return mir::LocalVarRef{
                                     .target =
                                         proc_state.TranslateLocalVar(l.target)};
+                              },
+                              [](const hir::LoopVarRef&) -> mir::ExprData {
+                                throw support::InternalError(
+                                    "LowerProcessExprData: loop-variable "
+                                    "references only appear in loop-generate "
+                                    "header expressions, which are rejected "
+                                    "before HIR-to-MIR");
                               },
                           },
                           r.target);

--- a/tests/cases/dump/loop_generate_external/case.yaml
+++ b/tests/cases/dump/loop_generate_external/case.yaml
@@ -1,0 +1,18 @@
+id: dump.loop_generate_external
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - 'LoopVarDecl[0] "j"'
+      - "Generate LoopGenerate loop_var=LoopVar[0]"
+      - "BinaryExpr op=LessThan"
+      - "RefExpr LoopVar[0](hops=0)"
+      - "AssignExpr"
+      - "BinaryExpr op=Add"
+      - "body_scope:"

--- a/tests/cases/dump/loop_generate_external/main.sv
+++ b/tests/cases/dump/loop_generate_external/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  genvar j;
+  for (j = 0; j < 2; j = j + 1) begin : h
+  end
+endmodule

--- a/tests/cases/dump/loop_generate_inline/case.yaml
+++ b/tests/cases/dump/loop_generate_inline/case.yaml
@@ -1,0 +1,18 @@
+id: dump.loop_generate_inline
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - 'LoopVarDecl[0] "i"'
+      - "Generate LoopGenerate loop_var=LoopVar[0]"
+      - "BinaryExpr op=LessThan"
+      - "RefExpr LoopVar[0](hops=0)"
+      - "AssignExpr"
+      - "BinaryExpr op=Add"
+      - "body_scope:"

--- a/tests/cases/dump/loop_generate_inline/main.sv
+++ b/tests/cases/dump/loop_generate_inline/main.sv
@@ -1,0 +1,4 @@
+module Top;
+  for (genvar i = 0; i < 4; i = i + 1) begin : g
+  end
+endmodule

--- a/tests/cases/errors/loop_generate_unsupported/case.yaml
+++ b/tests/cases/errors/loop_generate_unsupported/case.yaml
@@ -1,0 +1,16 @@
+id: errors.loop_generate_unsupported
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "for-generate lowering is not supported yet"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/loop_generate_unsupported/main.sv
+++ b/tests/cases/errors/loop_generate_unsupported/main.sv
@@ -1,0 +1,4 @@
+module Top;
+  for (genvar i = 0; i < 4; i = i + 1) begin : g
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds HIR-only support for SystemVerilog loop-generate (`for (genvar i = 0; i < N; i = i + 1) begin ... end`). Slang's `GenerateBlockArraySymbol` is now lowered into a new `hir::LoopGenerate` variant rather than being rejected at the AST-to-HIR boundary. Loop-generate is still rejected cleanly at HIR-to-MIR; this PR establishes the HIR shape and the lazy loop-variable identity discovery, leaving runtime/emit support for a follow-up.

## Design

`LoopVarDecl` and `LoopVarRef` are added as distinct concepts from `MemberVar`/`LocalVar` and live on the owning `StructuralScope`. The synthetic loop variable that slang fabricates inside `stopExpression`/`iterExpression` is captured lazily on first reference during loop-header lowering: a small `LoopHeaderState` lives only on `BuildLoopGenerate`'s stack and the first NamedValueExpression whose `VariableSymbol` is `CompilerGenerated` and whose name matches `array.genvar->name` triggers a single `AddLoopVarDecl`. Subsequent references in the same header reuse that id and assert pointer identity. There is no pre-scan, no global loop-var binding map, and no `GenvarDecl`/`GenvarRef` concept.

## Testing

- `dump hir` golden tests for inline (`for (genvar i = 0; ...)`) and external (`genvar j; for (j = 0; ...)`) forms, asserting `LoopVarDecl`, `LoopGenerate`, `LoopVarRef`, and the `BinaryExpr op=LessThan` / `AssignExpr` shape of the lowered header.
- `emit cpp` error test confirming a clean unsupported diagnostic at HIR-to-MIR with no internal error.
- `bazel build //:lyra` clean; `bazel test //tests/...` (excluding `manual`) all four targets pass.