### PR TITLE
Align local test commands with CI

### DIFF
--- a/.claude/commands/commit-pr.md
+++ b/.claude/commands/commit-pr.md
@@ -1,6 +1,6 @@
 ---
 description: Create a commit and PR with auto-merge enabled
-allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git add:*), Bash(git branch:*), Bash(git switch:*), Bash(git log:*), Bash(git fetch:*), Bash(git rebase:*), Bash(git push:*), Bash(git rev-list:*), Bash(gh pr create:*), Bash(gh pr merge:*), Bash(clang-format:*), Bash(npx prettier:*), Bash(buildifier:*), Bash(find:*), Bash(python3 tools/policy/*)
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git add:*), Bash(git branch:*), Bash(git switch:*), Bash(git log:*), Bash(git fetch:*), Bash(git rebase:*), Bash(git push:*), Bash(git rev-list:*), Bash(gh pr create:*), Bash(gh pr merge:*), Bash(clang-format:*), Bash(npx prettier:*), Bash(buildifier:*), Bash(find:*), Bash(python3 tools/policy/*), Bash(bazel build:*), Bash(bazel test:*)
 ---
 
 # Commit and PR
@@ -63,24 +63,28 @@ Do NOT proceed with formatting or staging until you are on a feature branch.
 **Rule of thumb:** Local must mirror CI exactly. If CI runs it, the skill must run it. If `tools/policy/check_*.py` or `.github/workflows/` gain new entries, treat them as required even if this skill is out of date.
 
 1. **Check branch** - If on main, infer branch name from changes and create it
-2. **Format all files:**
+2. **Build and test** (mirrors CI):
+   - `bazel build //...`
+   - `bazel test //... --test_output=errors`
+   - Do not narrow `//...`. Fix failures before continuing.
+3. **Format all files:**
    - C++: `find src include tests -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i`
    - Markdown: `npx prettier --write "**/*.md"`
    - Bazel: `buildifier -r .`
-3. **Format-check** (mirrors CI):
+4. **Format-check** (mirrors CI):
    - `find src include tests -name '*.cpp' -o -name '*.hpp' | xargs clang-format --dry-run --Werror`
    - `buildifier -mode=check -r .`
    - `buildifier -mode=check -lint=warn -r .`
    - `npm run format:check`
-4. **Policy checks** (mirrors CI):
+5. **Policy checks** (mirrors CI):
    - `python3 tools/policy/check_architecture.py`
    - `python3 tools/policy/check_ascii.py --diff-base origin/main`
    - `python3 tools/policy/check_cpp_style.py`
    - `python3 tools/policy/check_exceptions.py --diff-base origin/main`
-5. **Sanity check** - `ls tools/policy/check_*.py` and `ls .github/workflows/`. If a new `check_*.py` exists that the skill does not run, run it anyway and tell the user the skill is out of date.
-6. **Check git status** - Formatters may modify files beyond your original changeset. Run `git status --short` to see all modified files before staging.
-7. **Stage files** with `git add <files>` (not `git add -A`)
-8. **Commit** with `git commit` (this will prompt for permission - your checkpoint to review)
+6. **Sanity check** - `ls tools/policy/check_*.py` and `ls .github/workflows/`. If a new `check_*.py` exists that the skill does not run, run it anyway and tell the user the skill is out of date.
+7. **Check git status** - Formatters may modify files beyond your original changeset. Run `git status --short` to see all modified files before staging.
+8. **Stage files** with `git add <files>` (not `git add -A`)
+9. **Commit** with `git commit` (this will prompt for permission - your checkpoint to review)
 
 ### Phase 2: PR
 

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,6 +1,6 @@
 ---
 description: Create a commit with a well-formatted message
-allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git add:*), Bash(git branch:*), Bash(git switch:*), Bash(git log:*), Bash(clang-format:*), Bash(npx prettier:*), Bash(buildifier:*), Bash(find:*), Bash(python3 tools/policy/*)
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git add:*), Bash(git branch:*), Bash(git switch:*), Bash(git log:*), Bash(clang-format:*), Bash(npx prettier:*), Bash(buildifier:*), Bash(find:*), Bash(python3 tools/policy/*), Bash(bazel build:*), Bash(bazel test:*)
 ---
 
 # Commit
@@ -29,6 +29,15 @@ Do NOT proceed with formatting or staging until you are on a feature branch.
 Before committing, format ALL files and run every check that CI runs.
 
 **Rule of thumb:** Local must mirror CI exactly. If CI runs it, the skill must run it. If a script in `tools/policy/` exists, it likely has a corresponding CI workflow under `.github/workflows/`.
+
+### Build and test (mirrors CI)
+
+```bash
+bazel build //...
+bazel test //... --test_output=errors
+```
+
+Same target set CI runs. Do not narrow `//...`. Fix failures before staging.
 
 ### Format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,31 +108,8 @@ Headers in `include/lyra/`, implementations in `src/lyra/`.
 YAML-based tests in `tests/sv_features/`. See `tests/suites.yaml` for suite definitions.
 
 ```bash
-bazel test //tests:jit_dev_tests --test_output=errors    # In-process ORC JIT tests
+bazel test //... --test_output=errors    # Same target set CI runs
 ```
-
-### Ad-Hoc Testing
-
-Run a specific test file without modifying suite definitions:
-
-```bash
-bazel test //tests:jit_dev_tests \
-  --test_arg=--test_file=operators/binary/two_state.yaml \
-  --test_arg=--backend=jit \
-  --test_output=errors
-```
-
-Path is relative to `tests/sv_features/`. `--backend` is required with `--test_file`.
-
-Run a single named test case (fastest reproducer path for failures):
-
-```bash
-bazel test //tests:jit_dev_tests \
-  --test_arg=--case=operators_binary_default_add \
-  --test_output=errors
-```
-
-Case name is the full qualified name from test output (e.g., `category_file_casename`).
 
 ## Benchmarks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,14 +69,11 @@ clang-tidy -p . <files>
 
 ## Tests
 
-YAML-based tests live in `tests/sv_features/`. Suite definitions are in `tests/suites.yaml`. For
-ad-hoc runs, use `--test_file` and `--backend`.
+YAML-based tests live in `tests/sv_features/`. Suite definitions are in `tests/suites.yaml`. CI runs
+`bazel test //...`; do the same locally before submitting.
 
 ```bash
-bazel test //tests:jit_dev_tests \
-  --test_arg=--test_file=operators/binary.yaml \
-  --test_arg=--backend=jit \
-  --test_output=errors
+bazel test //... --test_output=errors
 ```
 
 ## Documentation


### PR DESCRIPTION
## Summary

The `/commit` and `/commit-pr` skills declared "local must mirror CI exactly" but only ran format and policy checks — never `bazel build` or `bazel test`. CLAUDE.md and CONTRIBUTING.md pointed at `//tests:jit_dev_tests`, a target that no longer exists. Together, these gaps let a feature branch reach CI green-locally and red-on-CI. This PR closes the gap by adding a build-and-test gate to both skills and replacing the stale references with `bazel test //...` (the same target set CI's `Test` job runs).

## Design

`bazel test //...` is the natural aggregate — Bazel discovers every `cc_test` automatically, no `test_suite` indirection needed. Tests that need a special toolchain (e.g. host C++ compiler) are tagged at the `cc_test` level and CI excludes them via `--test_tag_filters`; this is orthogonal to which skill runs the command. The skills now run the same canonical command CI does, so any failure shows up before the commit lands instead of on the PR.