### PR TITLE
Add runtime packed value types and wire MIR packed to C++ emit

### DIFF
--- a/include/lyra/runtime/format.hpp
+++ b/include/lyra/runtime/format.hpp
@@ -1,12 +1,11 @@
 #pragma once
 
 #include <cstdint>
-#include <limits>
 #include <string>
 #include <string_view>
 #include <variant>
 
-#include "lyra/base/internal_error.hpp"
+#include "lyra/runtime/packed.hpp"
 
 namespace lyra::runtime {
 
@@ -25,9 +24,12 @@ enum class FormatKind : std::uint8_t {
   kString,
 };
 
-enum class RuntimeValueKind : std::uint8_t {
-  kIntegral,
-  kString,
+// Two-state vs four-state lives on the integral axis, not as a top-level
+// value kind: it's a representation/semantics dimension of integral, in the
+// same way `string` is a value category. The two enums are orthogonal.
+enum class IntegralStateKind : std::uint8_t {
+  kTwoState,
+  kFourState,
 };
 
 struct FormatSpec {
@@ -39,50 +41,62 @@ struct FormatSpec {
   std::int32_t timeunit_power = 0;
 };
 
-// Non-owning view of a value passed into the runtime print API.
+// Non-owning view payloads passed into the runtime print API.
 //
 // Two integral storage planes coexist:
-//   - Narrow integral (bit_width <= 64): the word lives inline in
-//   `inline_word`.
-//     `value_words` is null. Construction needs no externally-owned storage,
-//     so the whole view can be built inline at a `LyraPrint` call site.
-//   - Wide integral (bit_width > 64): caller owns a `uint64_t[word_count]`
-//     array and passes a pointer via `value_words`. Not used by this cut.
-//
-// String values reference external character storage (e.g. a `std::string`
-// kept alive for the duration of the LyraPrint call) via `string_data` /
-// `string_size`. The `String(string_view)` factory captures the view directly.
-struct RuntimeValueView {
-  RuntimeValueKind kind = RuntimeValueKind::kIntegral;
+//   - Narrow integral (bit_width <= 64): the value lives inline in
+//   `inline_word`,
+//     and (for four-state) the state plane lives inline in
+//     `inline_state_word`. `value_words` / `state_words` are null. The whole
+//     view is built inline at a `LyraPrint` call site with no externally
+//     owned storage.
+//   - Wide integral (bit_width > 64): caller owns `uint64_t[word_count]`
+//     arrays for value and (for four-state) state, passed via `value_words`
+//     and `state_words`. Not used by this cut.
+struct IntegralValueView {
+  IntegralStateKind state = IntegralStateKind::kTwoState;
   std::uint64_t inline_word = 0;
+  std::uint64_t inline_state_word = 0;
   const std::uint64_t* value_words = nullptr;
-  const std::uint64_t* unknown_words = nullptr;
+  const std::uint64_t* state_words = nullptr;
   std::uint32_t word_count = 0;
   std::uint32_t bit_width = 0;
   bool is_signed = false;
+};
 
-  const char* string_data = nullptr;
-  std::uint32_t string_size = 0;
+// String values reference external character storage (e.g. a `std::string`
+// kept alive for the duration of the LyraPrint call) via `data` / `size`.
+// The `String(string_view)` factory captures the view directly.
+struct StringValueView {
+  const char* data = nullptr;
+  std::uint32_t size = 0;
+};
 
-  static auto NarrowIntegral(
+// Wrapper over the variant payload so factories live on the value type
+// itself rather than scattered in a sub-namespace. Adding a new category
+// requires a new alternative + a new visitor arm; std::visit on `data`
+// gives compile-time exhaustiveness via Overloaded.
+struct RuntimeValueView {
+  std::variant<IntegralValueView, StringValueView> data;
+
+  [[nodiscard]] static auto NarrowIntegral(
       std::uint64_t word, std::uint32_t bit_width, bool is_signed)
+      -> RuntimeValueView;
+
+  [[nodiscard]] static auto String(std::string_view sv) -> RuntimeValueView;
+
+  [[nodiscard]] static auto FromBitView(ConstBitView v, bool is_signed)
+      -> RuntimeValueView;
+  [[nodiscard]] static auto FromBitView(BitView v, bool is_signed)
       -> RuntimeValueView {
-    return RuntimeValueView{
-        .kind = RuntimeValueKind::kIntegral,
-        .inline_word = word,
-        .word_count = 1,
-        .bit_width = bit_width,
-        .is_signed = is_signed};
+    return FromBitView(v.AsConst(), is_signed);
   }
 
-  static auto String(std::string_view sv) -> RuntimeValueView {
-    if (sv.size() > std::numeric_limits<std::uint32_t>::max()) {
-      throw InternalError("RuntimeValueView::String: string too large");
-    }
-    return RuntimeValueView{
-        .kind = RuntimeValueKind::kString,
-        .string_data = sv.data(),
-        .string_size = static_cast<std::uint32_t>(sv.size())};
+  [[nodiscard]] static auto FromLogicView(ConstLogicView v, bool is_signed)
+      -> RuntimeValueView;
+  [[nodiscard]] static auto FromLogicView(LogicView v, bool is_signed)
+      -> RuntimeValueView {
+    return FromLogicView(v.AsConst(), is_signed);
   }
 };
 

--- a/include/lyra/runtime/packed.hpp
+++ b/include/lyra/runtime/packed.hpp
@@ -1,0 +1,648 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "lyra/base/internal_error.hpp"
+
+namespace lyra::runtime {
+
+enum class Signedness : std::uint8_t { kSigned, kUnsigned };
+enum class TwoStateBit : std::uint8_t { kZero, kOne };
+enum class FourStateBit : std::uint8_t {
+  kZero,
+  kOne,
+  kHighImpedance,
+  kUnknown
+};
+
+struct PackedDim {
+  std::int64_t left{};
+  std::int64_t right{};
+
+  [[nodiscard]] constexpr auto Size() const -> std::uint64_t {
+    const std::int64_t span = (left >= right) ? (left - right) : (right - left);
+    return static_cast<std::uint64_t>(span) + 1U;
+  }
+  [[nodiscard]] constexpr auto Contains(std::int64_t index) const -> bool {
+    const std::int64_t lo = (left < right) ? left : right;
+    const std::int64_t hi = (left < right) ? right : left;
+    return index >= lo && index <= hi;
+  }
+  [[nodiscard]] auto LinearOffset(std::int64_t index) const -> std::uint64_t {
+    if (!Contains(index)) {
+      throw InternalError("PackedDim::LinearOffset: index out of range");
+    }
+    return left >= right ? static_cast<std::uint64_t>(left - index)
+                         : static_cast<std::uint64_t>(index - left);
+  }
+
+  auto operator==(const PackedDim&) const -> bool = default;
+};
+
+// Rank-parametric structural shape used as a class-template NTTP. Rank lives
+// in the type so scalar (PackedShape<0>) and one-bit-range
+// (PackedShape<1>{{0,0}}) are distinct declared shapes even though both have
+// width 1, and there is no artificial maximum rank. std::array<T,0> is a
+// valid empty array, so PackedShape<0>{} works without a special case.
+//
+// TotalWidth() is constexpr (not consteval) so semantic queries on shape
+// metadata work in both compile-time and runtime contexts -- e.g. a runtime
+// `kShape.TotalWidth()` call from tests or future runtime code. Overflow and
+// zero-width are guarded with `throw InternalError(...)`: at runtime the
+// exception propagates normally, in constant evaluation the call simply
+// stops being a constant expression and the compiler reports the error.
+//
+// StorageWidth() stays consteval because it drives the BitPlane<> template
+// argument and must produce a usable std::size_t at compile time.
+template <std::size_t Rank>
+struct PackedShape {
+  std::array<PackedDim, Rank> dims{};
+
+  [[nodiscard]] static constexpr auto RankValue() -> std::size_t {
+    return Rank;
+  }
+
+  [[nodiscard]] constexpr auto TotalWidth() const -> std::uint64_t {
+    std::uint64_t width = 1;
+    for (const auto& dim : dims) {
+      const std::uint64_t size = dim.Size();
+      if (size != 0U &&
+          width > std::numeric_limits<std::uint64_t>::max() / size) {
+        throw InternalError(
+            "PackedShape::TotalWidth: width overflows uint64_t");
+      }
+      width *= size;
+    }
+    if (width == 0U) {
+      throw InternalError("PackedShape::TotalWidth: zero width");
+    }
+    return width;
+  }
+
+  [[nodiscard]] consteval auto StorageWidth() const -> std::size_t {
+    const std::uint64_t width = TotalWidth();
+    if (width >
+        static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+      throw InternalError("PackedShape::StorageWidth: width overflows size_t");
+    }
+    return static_cast<std::size_t>(width);
+  }
+
+  [[nodiscard]] auto Dim(std::size_t index) const -> PackedDim {
+    if (index >= Rank) {
+      throw InternalError("PackedShape::Dim: index out of range");
+    }
+    return dims[index];
+  }
+
+  auto operator==(const PackedShape&) const -> bool = default;
+};
+
+// Forward declarations so detail::BitPlane can grant them friendship for
+// raw-words access.
+template <PackedShape Shape, Signedness Signed = Signedness::kUnsigned>
+class Bit;
+template <PackedShape Shape, Signedness Signed = Signedness::kUnsigned>
+class Logic;
+
+namespace detail {
+
+inline auto ValidateBitRange(
+    std::size_t word_count, std::uint64_t bit_offset, std::uint64_t width,
+    std::string_view where) -> void {
+  if (width == 0U) {
+    throw InternalError(std::string(where) + ": zero-width view");
+  }
+  if (static_cast<std::uint64_t>(word_count) >
+      std::numeric_limits<std::uint64_t>::max() / 64U) {
+    throw InternalError(std::string(where) + ": plane bit count overflows");
+  }
+  const auto plane_bits = static_cast<std::uint64_t>(word_count) * 64U;
+  if (bit_offset > plane_bits || width > plane_bits - bit_offset) {
+    throw InternalError(std::string(where) + ": range exceeds plane");
+  }
+}
+
+inline auto ValidateLogicRange(
+    std::size_t value_word_count, std::size_t state_word_count,
+    std::uint64_t bit_offset, std::uint64_t width, std::string_view where)
+    -> void {
+  if (value_word_count != state_word_count) {
+    throw InternalError(
+        std::string(where) + ": value and state span sizes differ");
+  }
+  ValidateBitRange(value_word_count, bit_offset, width, where);
+}
+
+// Internal storage primitive. Lives in detail because raw words are an
+// implementation detail of the Bit/Logic value types -- public runtime API
+// is Bit/Logic + views + typed operations. Bit/Logic are friended so they
+// can build views over their owned plane(s) without exposing words_.
+template <std::size_t Width>
+class BitPlane {
+ public:
+  static_assert(Width > 0, "BitPlane width must be positive");
+  static constexpr std::size_t kWordCount = (Width + 63U) / 64U;
+
+  BitPlane() = default;
+
+  auto SetZero() -> void {
+    words_.fill(0U);
+  }
+
+  auto SetOne() -> void {
+    words_.fill(~std::uint64_t{0});
+    constexpr std::uint64_t kTailBits = Width % 64U;
+    if constexpr (kTailBits != 0U) {
+      const std::uint64_t mask = (std::uint64_t{1} << kTailBits) - 1U;
+      words_[kWordCount - 1U] &= mask;
+    }
+  }
+
+  [[nodiscard]] auto GetBit(std::uint64_t offset) const -> bool {
+    if (offset >= Width) {
+      throw InternalError("BitPlane::GetBit: offset out of range");
+    }
+    return ((words_[offset / 64U] >> (offset % 64U)) & 1U) != 0U;
+  }
+
+  auto SetBit(std::uint64_t offset, bool value) -> void {
+    if (offset >= Width) {
+      throw InternalError("BitPlane::SetBit: offset out of range");
+    }
+    const std::uint64_t mask = std::uint64_t{1} << (offset % 64U);
+    if (value) {
+      words_[offset / 64U] |= mask;
+    } else {
+      words_[offset / 64U] &= ~mask;
+    }
+  }
+
+  [[nodiscard]] static constexpr auto BitWidth() -> std::uint64_t {
+    return Width;
+  }
+
+ private:
+  template <PackedShape S, Signedness Sg>
+  friend class lyra::runtime::Bit;
+  template <PackedShape S, Signedness Sg>
+  friend class lyra::runtime::Logic;
+
+  [[nodiscard]] auto MutableWordsForView() -> std::span<std::uint64_t> {
+    return words_;
+  }
+  [[nodiscard]] auto WordsForView() const -> std::span<const std::uint64_t> {
+    return words_;
+  }
+
+  std::array<std::uint64_t, kWordCount> words_{};
+};
+
+}  // namespace detail
+
+class ConstBitView {
+ public:
+  ConstBitView(
+      std::span<const std::uint64_t> words, std::uint64_t bit_offset,
+      std::uint64_t width)
+      : words_(words), bit_offset_(bit_offset), width_(width) {
+    detail::ValidateBitRange(
+        words_.size(), bit_offset_, width_, "ConstBitView");
+  }
+
+  [[nodiscard]] auto Width() const -> std::uint64_t {
+    return width_;
+  }
+
+  [[nodiscard]] auto GetBit(std::uint64_t offset) const -> TwoStateBit {
+    if (offset >= width_) {
+      throw InternalError("ConstBitView::GetBit: offset out of range");
+    }
+    const std::uint64_t bp = bit_offset_ + offset;
+    const bool bit = ((words_[bp / 64U] >> (bp % 64U)) & 1U) != 0U;
+    return bit ? TwoStateBit::kOne : TwoStateBit::kZero;
+  }
+
+  // Pack the view's logical bits 0..width_-1 into a single uint64 (LSB at bit
+  // 0). Walks bits so non-zero bit_offset_ is honored.
+  [[nodiscard]] auto PackLowWord() const -> std::uint64_t {
+    if (width_ > 64U) {
+      throw InternalError("ConstBitView::PackLowWord: width > 64");
+    }
+    std::uint64_t out = 0;
+    for (std::uint64_t i = 0; i < width_; ++i) {
+      if (GetBit(i) == TwoStateBit::kOne) {
+        out |= std::uint64_t{1} << i;
+      }
+    }
+    return out;
+  }
+
+ private:
+  std::span<const std::uint64_t> words_;
+  std::uint64_t bit_offset_;
+  std::uint64_t width_;
+};
+
+class BitView {
+ public:
+  BitView(
+      std::span<std::uint64_t> words, std::uint64_t bit_offset,
+      std::uint64_t width)
+      : words_(words), bit_offset_(bit_offset), width_(width) {
+    detail::ValidateBitRange(words_.size(), bit_offset_, width_, "BitView");
+  }
+
+  [[nodiscard]] auto Width() const -> std::uint64_t {
+    return width_;
+  }
+
+  [[nodiscard]] auto GetBit(std::uint64_t offset) const -> TwoStateBit {
+    return AsConst().GetBit(offset);
+  }
+
+  auto SetBit(std::uint64_t offset, TwoStateBit value) -> void {
+    if (offset >= width_) {
+      throw InternalError("BitView::SetBit: offset out of range");
+    }
+    const std::uint64_t bp = bit_offset_ + offset;
+    const std::uint64_t mask = std::uint64_t{1} << (bp % 64U);
+    if (value == TwoStateBit::kOne) {
+      words_[bp / 64U] |= mask;
+    } else {
+      words_[bp / 64U] &= ~mask;
+    }
+  }
+
+  auto SetZero() -> void {
+    for (std::uint64_t i = 0; i < width_; ++i) {
+      SetBit(i, TwoStateBit::kZero);
+    }
+  }
+
+  auto SetOne() -> void {
+    for (std::uint64_t i = 0; i < width_; ++i) {
+      SetBit(i, TwoStateBit::kOne);
+    }
+  }
+
+  // Overlap-safe: SystemVerilog assignment semantics evaluate the RHS fully
+  // before updating the LHS. Reading bits straight into a fresh buffer and
+  // then writing handles the same-owner overlap case correctly.
+  auto CopyFromSameWidth(ConstBitView src) -> void {
+    if (src.Width() != width_) {
+      throw InternalError("BitView::CopyFromSameWidth: width mismatch");
+    }
+    std::vector<TwoStateBit> tmp;
+    tmp.reserve(width_);
+    for (std::uint64_t i = 0; i < width_; ++i) {
+      tmp.push_back(src.GetBit(i));
+    }
+    for (std::uint64_t i = 0; i < width_; ++i) {
+      SetBit(i, tmp[i]);
+    }
+  }
+
+  [[nodiscard]] auto AsConst() const -> ConstBitView {
+    return ConstBitView{words_, bit_offset_, width_};
+  }
+  [[nodiscard]] auto PackLowWord() const -> std::uint64_t {
+    return AsConst().PackLowWord();
+  }
+
+ private:
+  std::span<std::uint64_t> words_;
+  std::uint64_t bit_offset_;
+  std::uint64_t width_;
+};
+
+class ConstLogicView {
+ public:
+  ConstLogicView(
+      std::span<const std::uint64_t> value_words,
+      std::span<const std::uint64_t> state_words, std::uint64_t bit_offset,
+      std::uint64_t width)
+      : value_words_(value_words),
+        state_words_(state_words),
+        bit_offset_(bit_offset),
+        width_(width) {
+    detail::ValidateLogicRange(
+        value_words_.size(), state_words_.size(), bit_offset_, width_,
+        "ConstLogicView");
+  }
+
+  [[nodiscard]] auto Width() const -> std::uint64_t {
+    return width_;
+  }
+
+  [[nodiscard]] auto GetBit(std::uint64_t offset) const -> FourStateBit {
+    if (offset >= width_) {
+      throw InternalError("ConstLogicView::GetBit: offset out of range");
+    }
+    const std::uint64_t bp = bit_offset_ + offset;
+    const bool v = ((value_words_[bp / 64U] >> (bp % 64U)) & 1U) != 0U;
+    const bool s = ((state_words_[bp / 64U] >> (bp % 64U)) & 1U) != 0U;
+    if (!s) {
+      return v ? FourStateBit::kOne : FourStateBit::kZero;
+    }
+    return v ? FourStateBit::kUnknown : FourStateBit::kHighImpedance;
+  }
+
+  // Pack the value plane's view bits into a uint64 (LSB at bit 0). Walks bits
+  // so non-zero bit_offset_ is honored.
+  [[nodiscard]] auto PackValueLowWord() const -> std::uint64_t {
+    if (width_ > 64U) {
+      throw InternalError("ConstLogicView::PackValueLowWord: width > 64");
+    }
+    std::uint64_t out = 0;
+    for (std::uint64_t i = 0; i < width_; ++i) {
+      const std::uint64_t bp = bit_offset_ + i;
+      if (((value_words_[bp / 64U] >> (bp % 64U)) & 1U) != 0U) {
+        out |= std::uint64_t{1} << i;
+      }
+    }
+    return out;
+  }
+
+  [[nodiscard]] auto PackStateLowWord() const -> std::uint64_t {
+    if (width_ > 64U) {
+      throw InternalError("ConstLogicView::PackStateLowWord: width > 64");
+    }
+    std::uint64_t out = 0;
+    for (std::uint64_t i = 0; i < width_; ++i) {
+      const std::uint64_t bp = bit_offset_ + i;
+      if (((state_words_[bp / 64U] >> (bp % 64U)) & 1U) != 0U) {
+        out |= std::uint64_t{1} << i;
+      }
+    }
+    return out;
+  }
+
+ private:
+  std::span<const std::uint64_t> value_words_;
+  std::span<const std::uint64_t> state_words_;
+  std::uint64_t bit_offset_;
+  std::uint64_t width_;
+};
+
+class LogicView {
+ public:
+  LogicView(
+      std::span<std::uint64_t> value_words,
+      std::span<std::uint64_t> state_words, std::uint64_t bit_offset,
+      std::uint64_t width)
+      : value_words_(value_words),
+        state_words_(state_words),
+        bit_offset_(bit_offset),
+        width_(width) {
+    detail::ValidateLogicRange(
+        value_words_.size(), state_words_.size(), bit_offset_, width_,
+        "LogicView");
+  }
+
+  [[nodiscard]] auto Width() const -> std::uint64_t {
+    return width_;
+  }
+
+  [[nodiscard]] auto GetBit(std::uint64_t offset) const -> FourStateBit {
+    return AsConst().GetBit(offset);
+  }
+
+  auto SetBit(std::uint64_t offset, FourStateBit value) -> void {
+    if (offset >= width_) {
+      throw InternalError("LogicView::SetBit: offset out of range");
+    }
+    const std::uint64_t bp = bit_offset_ + offset;
+    const std::uint64_t mask = std::uint64_t{1} << (bp % 64U);
+    const std::size_t widx = bp / 64U;
+    const auto write = [&](std::span<std::uint64_t> arr, bool bit) {
+      if (bit) {
+        arr[widx] |= mask;
+      } else {
+        arr[widx] &= ~mask;
+      }
+    };
+    switch (value) {
+      case FourStateBit::kZero:
+        write(value_words_, false);
+        write(state_words_, false);
+        break;
+      case FourStateBit::kOne:
+        write(value_words_, true);
+        write(state_words_, false);
+        break;
+      case FourStateBit::kHighImpedance:
+        write(value_words_, false);
+        write(state_words_, true);
+        break;
+      case FourStateBit::kUnknown:
+        write(value_words_, true);
+        write(state_words_, true);
+        break;
+    }
+  }
+
+  auto SetZero() -> void {
+    for (std::uint64_t i = 0; i < width_; ++i) {
+      SetBit(i, FourStateBit::kZero);
+    }
+  }
+  auto SetOne() -> void {
+    for (std::uint64_t i = 0; i < width_; ++i) {
+      SetBit(i, FourStateBit::kOne);
+    }
+  }
+  auto SetUnknown() -> void {
+    for (std::uint64_t i = 0; i < width_; ++i) {
+      SetBit(i, FourStateBit::kUnknown);
+    }
+  }
+  auto SetHighImpedance() -> void {
+    for (std::uint64_t i = 0; i < width_; ++i) {
+      SetBit(i, FourStateBit::kHighImpedance);
+    }
+  }
+
+  // Overlap-safe: see BitView::CopyFromSameWidth.
+  auto CopyFromSameWidth(ConstLogicView src) -> void {
+    if (src.Width() != width_) {
+      throw InternalError("LogicView::CopyFromSameWidth: width mismatch");
+    }
+    std::vector<FourStateBit> tmp;
+    tmp.reserve(width_);
+    for (std::uint64_t i = 0; i < width_; ++i) {
+      tmp.push_back(src.GetBit(i));
+    }
+    for (std::uint64_t i = 0; i < width_; ++i) {
+      SetBit(i, tmp[i]);
+    }
+  }
+
+  [[nodiscard]] auto AsConst() const -> ConstLogicView {
+    return ConstLogicView{value_words_, state_words_, bit_offset_, width_};
+  }
+  [[nodiscard]] auto PackValueLowWord() const -> std::uint64_t {
+    return AsConst().PackValueLowWord();
+  }
+  [[nodiscard]] auto PackStateLowWord() const -> std::uint64_t {
+    return AsConst().PackStateLowWord();
+  }
+
+ private:
+  std::span<std::uint64_t> value_words_;
+  std::span<std::uint64_t> state_words_;
+  std::uint64_t bit_offset_;
+  std::uint64_t width_;
+};
+
+template <PackedShape Shape, Signedness Signed>
+class Bit {
+ public:
+  static constexpr auto kShape = Shape;
+  static constexpr Signedness kSignedness = Signed;
+  static constexpr std::size_t kWidth = Shape.StorageWidth();
+
+  Bit() = default;
+
+  [[nodiscard]] auto View() -> BitView {
+    return BitView{bits_.MutableWordsForView(), 0U, kWidth};
+  }
+  [[nodiscard]] auto View() const -> ConstBitView {
+    return ConstBitView{bits_.WordsForView(), 0U, kWidth};
+  }
+  [[nodiscard]] auto View(std::uint64_t offset, std::uint64_t width)
+      -> BitView {
+    const auto kw = static_cast<std::uint64_t>(kWidth);
+    if (width == 0U || offset > kw || width > kw - offset) {
+      throw InternalError("Bit::View: invalid view range");
+    }
+    return BitView{bits_.MutableWordsForView(), offset, width};
+  }
+  [[nodiscard]] auto View(std::uint64_t offset, std::uint64_t width) const
+      -> ConstBitView {
+    const auto kw = static_cast<std::uint64_t>(kWidth);
+    if (width == 0U || offset > kw || width > kw - offset) {
+      throw InternalError("Bit::View: invalid view range");
+    }
+    return ConstBitView{bits_.WordsForView(), offset, width};
+  }
+
+  auto SetZero() -> void {
+    bits_.SetZero();
+  }
+  auto SetOne() -> void {
+    bits_.SetOne();
+  }
+
+  [[nodiscard]] auto GetBit(std::uint64_t offset) const -> TwoStateBit {
+    return bits_.GetBit(offset) ? TwoStateBit::kOne : TwoStateBit::kZero;
+  }
+  auto SetBit(std::uint64_t offset, TwoStateBit value) -> void {
+    bits_.SetBit(offset, value == TwoStateBit::kOne);
+  }
+
+ private:
+  detail::BitPlane<kWidth> bits_{};
+};
+
+template <PackedShape Shape, Signedness Signed>
+class Logic {
+ public:
+  static constexpr auto kShape = Shape;
+  static constexpr Signedness kSignedness = Signed;
+  static constexpr std::size_t kWidth = Shape.StorageWidth();
+
+  Logic() {
+    SetUnknown();
+  }
+
+  [[nodiscard]] auto View() -> LogicView {
+    return LogicView{
+        value_.MutableWordsForView(), state_.MutableWordsForView(), 0U, kWidth};
+  }
+  [[nodiscard]] auto View() const -> ConstLogicView {
+    return ConstLogicView{
+        value_.WordsForView(), state_.WordsForView(), 0U, kWidth};
+  }
+  [[nodiscard]] auto View(std::uint64_t offset, std::uint64_t width)
+      -> LogicView {
+    const auto kw = static_cast<std::uint64_t>(kWidth);
+    if (width == 0U || offset > kw || width > kw - offset) {
+      throw InternalError("Logic::View: invalid view range");
+    }
+    return LogicView{
+        value_.MutableWordsForView(), state_.MutableWordsForView(), offset,
+        width};
+  }
+  [[nodiscard]] auto View(std::uint64_t offset, std::uint64_t width) const
+      -> ConstLogicView {
+    const auto kw = static_cast<std::uint64_t>(kWidth);
+    if (width == 0U || offset > kw || width > kw - offset) {
+      throw InternalError("Logic::View: invalid view range");
+    }
+    return ConstLogicView{
+        value_.WordsForView(), state_.WordsForView(), offset, width};
+  }
+
+  auto SetZero() -> void {
+    value_.SetZero();
+    state_.SetZero();
+  }
+  auto SetOne() -> void {
+    value_.SetOne();
+    state_.SetZero();
+  }
+  auto SetHighImpedance() -> void {
+    value_.SetZero();
+    state_.SetOne();
+  }
+  auto SetUnknown() -> void {
+    value_.SetOne();
+    state_.SetOne();
+  }
+
+  [[nodiscard]] auto GetBit(std::uint64_t offset) const -> FourStateBit {
+    const bool v = value_.GetBit(offset);
+    const bool s = state_.GetBit(offset);
+    if (!s) {
+      return v ? FourStateBit::kOne : FourStateBit::kZero;
+    }
+    return v ? FourStateBit::kUnknown : FourStateBit::kHighImpedance;
+  }
+  auto SetBit(std::uint64_t offset, FourStateBit value) -> void {
+    switch (value) {
+      case FourStateBit::kZero:
+        value_.SetBit(offset, false);
+        state_.SetBit(offset, false);
+        break;
+      case FourStateBit::kOne:
+        value_.SetBit(offset, true);
+        state_.SetBit(offset, false);
+        break;
+      case FourStateBit::kHighImpedance:
+        value_.SetBit(offset, false);
+        state_.SetBit(offset, true);
+        break;
+      case FourStateBit::kUnknown:
+        value_.SetBit(offset, true);
+        state_.SetBit(offset, true);
+        break;
+    }
+  }
+
+ private:
+  detail::BitPlane<kWidth> value_{};
+  detail::BitPlane<kWidth> state_{};
+};
+
+template <PackedShape Shape, Signedness Signed = Signedness::kUnsigned>
+using Reg = Logic<Shape, Signed>;
+
+}  // namespace lyra::runtime

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -169,6 +169,7 @@ auto RenderClassHeaderFile(
   out += "#include \"lyra/runtime/format.hpp\"\n";
   out += "#include \"lyra/runtime/io.hpp\"\n";
   out += "#include \"lyra/runtime/module.hpp\"\n";
+  out += "#include \"lyra/runtime/packed.hpp\"\n";
   out += "#include \"lyra/runtime/process.hpp\"\n";
   out += "#include \"lyra/runtime/process_kind.hpp\"\n";
   out += "#include \"lyra/runtime/runtime_scope_kind.hpp\"\n";

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -64,9 +64,11 @@ auto RenderFormatSpecInit(const mir::FormatSpec& spec) -> std::string {
 }
 
 // Render a value operand into an inline `RuntimeValueView` constructor call.
-// Narrow integrals embed the word inside the view (no pointer); strings pass
-// the operand expression as a string_view (full-expression lifetime covers
-// the LyraPrint call).
+// `int`/`integer` (which render as native std::int32_t) take the inline-word
+// `NarrowIntegral` factory. Explicit packed `bit`/`logic`/`reg` (which render
+// as runtime Bit<...>/Logic<...>) take the view-based factories so the print
+// path goes through the runtime type's own `View()` API rather than casting
+// the value to uint64_t.
 auto RenderRuntimeValueViewInit(
     const RenderContext& ctx, const mir::RuntimePrintValue& v) -> std::string {
   const auto& type = ctx.Unit().GetType(v.type);
@@ -80,10 +82,24 @@ auto RenderRuntimeValueViewInit(
           "RenderRuntimeValueViewInit: wide integrals not implemented");
     }
     const bool is_signed = pa.signedness == mir::Signedness::kSigned;
-    return std::format(
-        "lyra::runtime::RuntimeValueView::NarrowIntegral("
-        "static_cast<std::uint64_t>({}), {}, {})",
-        operand, bit_width, BoolLiteral(is_signed));
+
+    if (pa.form == mir::PackedArrayForm::kInt ||
+        pa.form == mir::PackedArrayForm::kInteger) {
+      return std::format(
+          "lyra::runtime::RuntimeValueView::NarrowIntegral("
+          "static_cast<std::uint64_t>({}), {}, {})",
+          operand, bit_width, BoolLiteral(is_signed));
+    }
+
+    if (pa.form == mir::PackedArrayForm::kExplicit) {
+      const char* factory =
+          pa.IsFourState() ? "lyra::runtime::RuntimeValueView::FromLogicView"
+                           : "lyra::runtime::RuntimeValueView::FromBitView";
+      return std::format(
+          "{}({}.View(), {})", factory, operand, BoolLiteral(is_signed));
+    }
+    throw InternalError(
+        "RenderRuntimeValueViewInit: unsupported PackedArrayForm");
   }
   if (type.Kind() == mir::TypeKind::kString) {
     return std::format("lyra::runtime::RuntimeValueView::String({})", operand);

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -1,7 +1,10 @@
 #include "render_type.hpp"
 
+#include <cstddef>
+#include <format>
 #include <string>
 #include <variant>
+#include <vector>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
@@ -11,15 +14,71 @@
 
 namespace lyra::backend::cpp {
 
+namespace {
+
+auto RenderPackedShapeLiteral(const std::vector<mir::PackedRange>& dims)
+    -> std::string {
+  if (dims.empty()) {
+    return "lyra::runtime::PackedShape<0>{}";
+  }
+  // Explicit `std::array<PackedDim, N>{...}` so the dims member's array type
+  // is unambiguous: a bare `.dims = {...}` relies on brace-elision through
+  // std::array's wrapper, which is allowed but easy to get wrong.
+  std::string out = std::format(
+      "lyra::runtime::PackedShape<{}>{{ .dims = "
+      "std::array<lyra::runtime::PackedDim, {}>{{",
+      dims.size(), dims.size());
+  for (std::size_t i = 0; i < dims.size(); ++i) {
+    if (i != 0) {
+      out += ", ";
+    }
+    out += std::format(
+        "lyra::runtime::PackedDim{{.left = {}, .right = {}}}", dims[i].left,
+        dims[i].right);
+  }
+  // Two closes: inner `std::array<...>{...}` and outer `PackedShape<...>{...}`.
+  out += "} }";
+  return out;
+}
+
+}  // namespace
+
 auto RenderTypeAsCpp(
     const mir::CompilationUnit& unit, const mir::ClassDecl& owner_class,
     mir::TypeId type_id) -> std::string {
   return std::visit(
       Overloaded{
           [](const mir::PackedArrayType& p) -> std::string {
+            // `int`/`integer` retain native std::int32_t because current
+            // expression lowering uses raw C++ operators; switching them to
+            // runtime Bit<...> requires operator overloads, which belong to
+            // the packed-operations cut. `integer`'s 4-state semantics are
+            // not blessed correct here -- the mapping is preserved only to
+            // keep current tests green; runtime typing of `integer` is
+            // unresolved.
             if (p.form == mir::PackedArrayForm::kInt ||
                 p.form == mir::PackedArrayForm::kInteger) {
               return "std::int32_t";
+            }
+            if (p.form == mir::PackedArrayForm::kExplicit) {
+              const char* signed_token =
+                  (p.signedness == mir::Signedness::kSigned)
+                      ? "lyra::runtime::Signedness::kSigned"
+                      : "lyra::runtime::Signedness::kUnsigned";
+              const std::string shape = RenderPackedShapeLiteral(p.dims);
+              switch (p.atom) {
+                case mir::BitAtom::kBit:
+                  return std::format(
+                      "lyra::runtime::Bit<{}, {}>", shape, signed_token);
+                case mir::BitAtom::kLogic:
+                  return std::format(
+                      "lyra::runtime::Logic<{}, {}>", shape, signed_token);
+                case mir::BitAtom::kReg:
+                  return std::format(
+                      "lyra::runtime::Reg<{}, {}>", shape, signed_token);
+              }
+              throw InternalError(
+                  "RenderTypeAsCpp: unknown BitAtom in kExplicit form");
             }
             throw InternalError(
                 "RenderTypeAsCpp: unsupported MIR type for current C++ render "

--- a/src/lyra/runtime/format.cpp
+++ b/src/lyra/runtime/format.cpp
@@ -2,10 +2,14 @@
 
 #include <cstdint>
 #include <format>
+#include <limits>
 #include <string>
+#include <string_view>
 #include <utility>
+#include <variant>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/base/overloaded.hpp"
 
 namespace lyra::runtime {
 
@@ -53,7 +57,7 @@ auto FormatDecimalUnsigned(std::uint64_t raw) -> std::string {
 }
 
 auto ResolveAutoWidth(
-    const FormatSpec& spec, const RuntimeValueView& v, FormatKind kind)
+    const FormatSpec& spec, const IntegralValueView& v, FormatKind kind)
     -> std::int32_t {
   if (spec.width >= 0) return spec.width;
   // Auto-width when no explicit width specified (-1 sentinel).
@@ -84,12 +88,10 @@ auto FormatOctal(std::uint64_t raw, std::int32_t width) -> std::string {
       "{:0{}o}", raw, width > 0 ? static_cast<std::size_t>(width) : 0);
 }
 
-auto FormatIntegralNarrow(const FormatSpec& spec, const RuntimeValueView& v)
+auto FormatIntegralNarrow(const FormatSpec& spec, const IntegralValueView& v)
     -> std::string {
-  if (v.unknown_words != nullptr && *v.unknown_words != 0) {
-    throw InternalError(
-        "FormatIntegralNarrow: 4-state X/Z formatting not implemented");
-  }
+  // 4-state values route through FormatIntegralFourStateNarrow before
+  // reaching this function, so this path always sees pure 2-state input.
   const std::uint64_t raw = v.inline_word & MaskFor(v.bit_width);
   std::string body;
   switch (spec.kind) {
@@ -110,32 +112,121 @@ auto FormatIntegralNarrow(const FormatSpec& spec, const RuntimeValueView& v)
       throw InternalError(
           "FormatIntegralNarrow: backend emitted unsupported FormatKind");
   }
-  // Auto-width already applied for radix kinds; for kDecimal apply spec.width.
-  if (spec.kind == FormatKind::kDecimal) {
-    return ApplyWidth(std::move(body), spec);
+  return ApplyWidth(std::move(body), spec);
+}
+
+// Binary-only 4-state narrow formatter: walks each bit MSB->LSB and emits
+// '0'/'1'/'x'/'z' from the (value, state) plane pair. Decimal/hex/octal of
+// 4-state runtime packed values are not implemented in this cut and throw
+// until a separate formatting investigation defines exact behavior.
+auto FormatIntegralFourStateNarrow(
+    const FormatSpec& spec, const IntegralValueView& v) -> std::string {
+  if (spec.kind != FormatKind::kBinary) {
+    throw InternalError(
+        "FormatIntegralFourStateNarrow: only binary supported in this cut");
   }
-  // Apply spec.width if explicitly larger than the rendered body.
+  std::string body;
+  body.reserve(v.bit_width);
+  for (std::int32_t i = static_cast<std::int32_t>(v.bit_width) - 1; i >= 0;
+       --i) {
+    const bool value = ((v.inline_word >> i) & 1U) != 0U;
+    const bool state = ((v.inline_state_word >> i) & 1U) != 0U;
+    char ch = '0';
+    if (state) {
+      ch = value ? 'x' : 'z';
+    } else {
+      ch = value ? '1' : '0';
+    }
+    body.push_back(ch);
+  }
   return ApplyWidth(std::move(body), spec);
 }
 
 }  // namespace
 
+auto RuntimeValueView::NarrowIntegral(
+    std::uint64_t word, std::uint32_t bit_width, bool is_signed)
+    -> RuntimeValueView {
+  return RuntimeValueView{
+      .data = IntegralValueView{
+          .state = IntegralStateKind::kTwoState,
+          .inline_word = word,
+          .word_count = 1,
+          .bit_width = bit_width,
+          .is_signed = is_signed,
+      }};
+}
+
+auto RuntimeValueView::String(std::string_view sv) -> RuntimeValueView {
+  if (sv.size() > std::numeric_limits<std::uint32_t>::max()) {
+    throw InternalError("RuntimeValueView::String: string too large");
+  }
+  return RuntimeValueView{
+      .data = StringValueView{
+          .data = sv.data(),
+          .size = static_cast<std::uint32_t>(sv.size()),
+      }};
+}
+
+auto RuntimeValueView::FromBitView(ConstBitView v, bool is_signed)
+    -> RuntimeValueView {
+  if (v.Width() > 64U) {
+    throw InternalError(
+        "RuntimeValueView::FromBitView: wide widths (>64) not supported in "
+        "this cut");
+  }
+  return RuntimeValueView{
+      .data = IntegralValueView{
+          .state = IntegralStateKind::kTwoState,
+          .inline_word = v.PackLowWord(),
+          .word_count = 1,
+          .bit_width = static_cast<std::uint32_t>(v.Width()),
+          .is_signed = is_signed,
+      }};
+}
+
+auto RuntimeValueView::FromLogicView(ConstLogicView v, bool is_signed)
+    -> RuntimeValueView {
+  if (v.Width() > 64U) {
+    throw InternalError(
+        "RuntimeValueView::FromLogicView: wide widths (>64) not supported in "
+        "this cut");
+  }
+  return RuntimeValueView{
+      .data = IntegralValueView{
+          .state = IntegralStateKind::kFourState,
+          .inline_word = v.PackValueLowWord(),
+          .inline_state_word = v.PackStateLowWord(),
+          .word_count = 1,
+          .bit_width = static_cast<std::uint32_t>(v.Width()),
+          .is_signed = is_signed,
+      }};
+}
+
 auto FormatValue(const FormatSpec& spec, const RuntimeValueView& value)
     -> std::string {
-  switch (value.kind) {
-    case RuntimeValueKind::kIntegral:
-      if (value.word_count > 1) {
-        throw InternalError(
-            "FormatValue: wide integrals not implemented in this cut");
-      }
-      return FormatIntegralNarrow(spec, value);
-    case RuntimeValueKind::kString: {
-      std::string body(value.string_data, value.string_size);
-      return ApplyWidth(std::move(body), spec);
-    }
-  }
-  throw InternalError(
-      "FormatValue: backend emitted unsupported RuntimeValueKind");
+  return std::visit(
+      Overloaded{
+          [&](const IntegralValueView& v) -> std::string {
+            if (v.word_count > 1) {
+              throw InternalError(
+                  "FormatValue: wide integrals not implemented in this cut");
+            }
+            switch (v.state) {
+              case IntegralStateKind::kTwoState:
+                return FormatIntegralNarrow(spec, v);
+              case IntegralStateKind::kFourState:
+                return FormatIntegralFourStateNarrow(spec, v);
+            }
+            throw InternalError(
+                "FormatValue: backend emitted unsupported IntegralStateKind");
+          },
+          [&](const StringValueView& v) -> std::string {
+            std::string body(v.data, v.size);
+            return ApplyWidth(std::move(body), spec);
+          },
+      },
+      value.data);
 }
 
 }  // namespace lyra::runtime

--- a/tests/cases/cpp/bit_8_default/case.yaml
+++ b/tests/cases/cpp/bit_8_default/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.bit_8_default
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "00000000\n"

--- a/tests/cases/cpp/bit_8_default/main.sv
+++ b/tests/cases/cpp/bit_8_default/main.sv
@@ -1,0 +1,6 @@
+module Top;
+  bit [7:0] x;
+  initial begin
+    $display("%b", x);
+  end
+endmodule

--- a/tests/cases/cpp/bit_default/case.yaml
+++ b/tests/cases/cpp/bit_default/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.bit_default
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "0\n"

--- a/tests/cases/cpp/bit_default/main.sv
+++ b/tests/cases/cpp/bit_default/main.sv
@@ -1,0 +1,6 @@
+module Top;
+  bit x;
+  initial begin
+    $display("%b", x);
+  end
+endmodule

--- a/tests/cases/cpp/logic_8_default/case.yaml
+++ b/tests/cases/cpp/logic_8_default/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.logic_8_default
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "xxxxxxxx\n"

--- a/tests/cases/cpp/logic_8_default/main.sv
+++ b/tests/cases/cpp/logic_8_default/main.sv
@@ -1,0 +1,6 @@
+module Top;
+  logic [7:0] x;
+  initial begin
+    $display("%b", x);
+  end
+endmodule

--- a/tests/cases/cpp/logic_default/case.yaml
+++ b/tests/cases/cpp/logic_default/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.logic_default
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "x\n"

--- a/tests/cases/cpp/logic_default/main.sv
+++ b/tests/cases/cpp/logic_default/main.sv
@@ -1,0 +1,6 @@
+module Top;
+  logic x;
+  initial begin
+    $display("%b", x);
+  end
+endmodule

--- a/tests/cases/cpp/reg_8_default/case.yaml
+++ b/tests/cases/cpp/reg_8_default/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.reg_8_default
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "xxxxxxxx\n"

--- a/tests/cases/cpp/reg_8_default/main.sv
+++ b/tests/cases/cpp/reg_8_default/main.sv
@@ -1,0 +1,6 @@
+module Top;
+  reg [7:0] x;
+  initial begin
+    $display("%b", x);
+  end
+endmodule

--- a/tests/cases/errors/emit_unrenderable_type/main.sv
+++ b/tests/cases/errors/emit_unrenderable_type/main.sv
@@ -1,3 +1,3 @@
 module Top;
-  logic l;
+  byte l;
 endmodule


### PR DESCRIPTION
## Summary

Introduces real owning runtime value types -- `Bit<Shape, Signed>`, `Logic<Shape, Signed>`, `Reg<Shape, Signed>` -- with two-state and four-state dense plane storage and view-based access. The MIR-to-C++ backend now renders `bit`, `logic`, and `reg` packed declarations to those runtime types instead of throwing, and `$display` flows through the runtime via view-based `RuntimeValueView` factories.

## Design

Declared SV packed dimensions are preserved on the type via a rank-parametric structural `PackedShape<Rank>` used as a class-template NTTP -- no fixed maximum rank, and scalar (`PackedShape<0>{}`) is a distinct declared shape from one-bit-range (`PackedShape<1>{{0,0}}`). Storage hides behind `detail::BitPlane<Width>` with friend access to `Bit`/`Logic` only. Views are non-owning with overflow-safe range validation, zero-width rejection, and overlap-safe same-width copy. `RuntimeValueView` is a wrapper over `std::variant<IntegralValueView, StringValueView>` with on-type factories (`FromBitView`, `FromLogicView`, `String`, `NarrowIntegral`); `IntegralStateKind` carries two-state vs four-state as an axis orthogonal to the value category. `int` and `integer` retain the native `std::int32_t` mapping until packed-operator support lands; `integer`'s 4-state semantics are explicitly marked unresolved.

## Testing

End-to-end SV cases `tests/cases/cpp/{bit,logic,reg}{_,_8_}default` pin compile-run-display behavior; `bazel test //...` passes all 6 targets.