### PR TITLE
Move runtime process ownership from Engine to RuntimeScope

### DIFF
--- a/include/lyra/runtime/bind_context.hpp
+++ b/include/lyra/runtime/bind_context.hpp
@@ -8,24 +8,24 @@
 
 namespace lyra::runtime {
 
-class Engine;
+class RuntimeProcess;
 class RuntimeScope;
+class RuntimeServices;
 
 class RuntimeBindContext {
  public:
-  RuntimeBindContext(Engine& engine, RuntimeScope& scope);
+  RuntimeBindContext(RuntimeScope& scope, RuntimeServices& services);
 
   auto CurrentScope() -> RuntimeScope&;
-  auto GetEngine() -> Engine& {
-    return *engine_;
-  }
-  void AddProcess(ProcessKind kind, Process process);
+  auto Services() -> RuntimeServices&;
+
+  auto AddProcess(ProcessKind kind, Process process) -> RuntimeProcess&;
   auto CreateChildScope(std::string name, RuntimeScopeKind kind)
       -> RuntimeBindContext;
 
  private:
-  Engine* engine_ = nullptr;
   RuntimeScope* scope_ = nullptr;
+  RuntimeServices* services_ = nullptr;
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -3,18 +3,15 @@
 #include <deque>
 #include <memory>
 #include <string>
-#include <vector>
 
-#include "lyra/runtime/bind_context.hpp"
 #include "lyra/runtime/output_sink.hpp"
-#include "lyra/runtime/process.hpp"
-#include "lyra/runtime/process_kind.hpp"
-#include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_scope.hpp"
+#include "lyra/runtime/runtime_services.hpp"
 
 namespace lyra::runtime {
 
 class Module;
+class RuntimeProcess;
 
 struct EngineOptions {
   OutputDispatcher::OutputSink output_sink;
@@ -27,22 +24,31 @@ class Engine {
   Engine();
   explicit Engine(EngineOptions options);
 
+  // services_ holds a pointer into output_; copying or moving Engine would
+  // dangle that pointer.
+  Engine(const Engine&) = delete;
+  auto operator=(const Engine&) -> Engine& = delete;
+  Engine(Engine&&) = delete;
+  auto operator=(Engine&&) -> Engine& = delete;
+  ~Engine() = default;
+
   void BindRoot(std::string root_name, Module& top);
   auto Run() -> int;
-
-  void AddProcess(RuntimeScope& owner, ProcessKind kind, Process process);
-  auto CreateChildScope(
-      RuntimeScope& parent, std::string name, RuntimeScopeKind kind)
-      -> RuntimeScope&;
 
   auto Output() -> OutputDispatcher& {
     return output_;
   }
 
+  auto Services() -> RuntimeServices& {
+    return services_;
+  }
+
  private:
+  void EnqueueInitialProcesses(RuntimeScope& root);
+
   OutputDispatcher output_;
-  std::vector<std::unique_ptr<RuntimeScope>> scopes_;
-  std::vector<RuntimeProcess> processes_;
+  RuntimeServices services_{output_};
+  std::unique_ptr<RuntimeScope> root_;
   std::deque<RuntimeProcess*> active_queue_;
   bool bound_ = false;
   bool ran_ = false;

--- a/include/lyra/runtime/io.hpp
+++ b/include/lyra/runtime/io.hpp
@@ -6,12 +6,13 @@
 
 namespace lyra::runtime {
 
-class Engine;
+class RuntimeServices;
 
 // Single high-level runtime print API. The compiler emits one call per
 // $display/$write/...; the runtime walks the items, formats values via
 // FormatValue, and finalizes the record (newline for kDisplay/kFDisplay).
 void LyraPrint(
-    Engine& engine, PrintKind kind, std::span<const PrintItem> items);
+    RuntimeServices& services, PrintKind kind,
+    std::span<const PrintItem> items);
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_scope.hpp
+++ b/include/lyra/runtime/runtime_scope.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
-#include <span>
+#include <memory>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
+#include "lyra/runtime/process.hpp"
+#include "lyra/runtime/process_kind.hpp"
+#include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_scope_kind.hpp"
 
 namespace lyra::runtime {
@@ -13,18 +17,50 @@ class RuntimeScope {
  public:
   RuntimeScope(RuntimeScope* parent, std::string name, RuntimeScopeKind kind);
 
-  auto Parent() -> RuntimeScope*;
+  [[nodiscard]] auto Parent() const -> RuntimeScope*;
   [[nodiscard]] auto Name() const -> std::string_view;
   [[nodiscard]] auto Kind() const -> RuntimeScopeKind;
 
-  void AddChild(RuntimeScope& child);
-  [[nodiscard]] auto Children() const -> std::span<RuntimeScope* const>;
+  auto AddChildScope(std::string name, RuntimeScopeKind kind) -> RuntimeScope&;
+  auto AddProcess(ProcessKind kind, Process process) -> RuntimeProcess&;
+
+  template <typename Fn>
+  void ForEachChild(Fn&& fn) {
+    auto&& f = std::forward<Fn>(fn);
+    for (auto& child : children_) {
+      f(*child);
+    }
+  }
+  template <typename Fn>
+  void ForEachChild(Fn&& fn) const {
+    auto&& f = std::forward<Fn>(fn);
+    for (const auto& child : children_) {
+      const RuntimeScope& ref = *child;
+      f(ref);
+    }
+  }
+  template <typename Fn>
+  void ForEachProcess(Fn&& fn) {
+    auto&& f = std::forward<Fn>(fn);
+    for (auto& process : processes_) {
+      f(*process);
+    }
+  }
+  template <typename Fn>
+  void ForEachProcess(Fn&& fn) const {
+    auto&& f = std::forward<Fn>(fn);
+    for (const auto& process : processes_) {
+      const RuntimeProcess& ref = *process;
+      f(ref);
+    }
+  }
 
  private:
   RuntimeScope* parent_ = nullptr;
   std::string name_;
   RuntimeScopeKind kind_;
-  std::vector<RuntimeScope*> children_;
+  std::vector<std::unique_ptr<RuntimeScope>> children_;
+  std::vector<std::unique_ptr<RuntimeProcess>> processes_;
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_scope_kind.hpp
+++ b/include/lyra/runtime/runtime_scope_kind.hpp
@@ -3,8 +3,8 @@
 namespace lyra::runtime {
 
 enum class RuntimeScopeKind {
-  kModule,
-  kGenerate,
+  kModuleInstance,
+  kGenerateScope,
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_services.hpp
+++ b/include/lyra/runtime/runtime_services.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "lyra/base/internal_error.hpp"
+
+namespace lyra::runtime {
+
+class OutputDispatcher;
+
+class RuntimeServices {
+ public:
+  explicit RuntimeServices(OutputDispatcher& output) : output_(&output) {
+  }
+
+  auto Output() -> OutputDispatcher& {
+    if (output_ == nullptr) {
+      throw InternalError("RuntimeServices has no OutputDispatcher");
+    }
+    return *output_;
+  }
+
+ private:
+  OutputDispatcher* output_ = nullptr;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_traversal.hpp
+++ b/include/lyra/runtime/runtime_traversal.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <utility>
+
+#include "lyra/runtime/runtime_scope.hpp"
+
+namespace lyra::runtime {
+
+namespace detail {
+
+template <typename Fn>
+void WalkScopePreOrderImpl(RuntimeScope& root, Fn& fn) {
+  fn(root);
+  root.ForEachChild(
+      [&fn](RuntimeScope& child) { WalkScopePreOrderImpl(child, fn); });
+}
+
+template <typename Fn>
+void WalkScopePreOrderImpl(const RuntimeScope& root, Fn& fn) {
+  fn(root);
+  root.ForEachChild(
+      [&fn](const RuntimeScope& child) { WalkScopePreOrderImpl(child, fn); });
+}
+
+}  // namespace detail
+
+template <typename Fn>
+void WalkScopePreOrder(RuntimeScope& root, Fn&& fn) {
+  auto&& f = std::forward<Fn>(fn);
+  detail::WalkScopePreOrderImpl(root, f);
+}
+
+template <typename Fn>
+void WalkScopePreOrder(const RuntimeScope& root, Fn&& fn) {
+  auto&& f = std::forward<Fn>(fn);
+  detail::WalkScopePreOrderImpl(root, f);
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -69,7 +69,7 @@ auto RenderBind(
   std::string out;
   out += Indent(indent) + "void Bind(lyra::runtime::RuntimeBindContext& ctx)" +
          (is_top_level ? " override {\n" : " {\n");
-  out += Indent(indent + 1) + "engine_ = &ctx.GetEngine();\n";
+  out += Indent(indent + 1) + "services_ = &ctx.Services();\n";
   for (std::size_t i = 0; i < c.processes.size(); ++i) {
     const auto& p = c.processes[i];
     out += Indent(indent + 1) + "ctx.AddProcess(\n";
@@ -95,16 +95,16 @@ auto RenderBind(
       out += Indent(indent + 2) + "auto child = ctx.CreateChildScope(\n";
       out += Indent(indent + 3) + "\"" + child_class.name +
              "[\" + std::to_string(idx) + \"]\",\n";
-      out +=
-          Indent(indent + 3) + "lyra::runtime::RuntimeScopeKind::kGenerate);\n";
+      out += Indent(indent + 3) +
+             "lyra::runtime::RuntimeScopeKind::kGenerateScope);\n";
       out += Indent(indent + 2) + m.name + "[idx]->Bind(child);\n";
       out += Indent(indent + 1) + "}\n";
     } else {
       out += Indent(indent + 1) + "if (" + m.name + ") {\n";
       out += Indent(indent + 2) + "auto child = ctx.CreateChildScope(\n";
       out += Indent(indent + 3) + "\"" + child_class.name + "\",\n";
-      out +=
-          Indent(indent + 3) + "lyra::runtime::RuntimeScopeKind::kGenerate);\n";
+      out += Indent(indent + 3) +
+             "lyra::runtime::RuntimeScopeKind::kGenerateScope);\n";
       out += Indent(indent + 2) + m.name + "->Bind(child);\n";
       out += Indent(indent + 1) + "}\n";
     }
@@ -138,7 +138,7 @@ auto RenderClassDecl(
     out += "\n";
   }
 
-  out += Indent(indent + 1) + "lyra::runtime::Engine* engine_{};\n";
+  out += Indent(indent + 1) + "lyra::runtime::RuntimeServices* services_{};\n";
   out += "\n";
 
   out += RenderConstructor(unit, c, indent + 1);
@@ -165,7 +165,6 @@ auto RenderClassHeaderFile(
   out += "#include <string>\n";
   out += "#include <vector>\n";
   out += "#include \"lyra/runtime/bind_context.hpp\"\n";
-  out += "#include \"lyra/runtime/engine.hpp\"\n";
   out += "#include \"lyra/runtime/format.hpp\"\n";
   out += "#include \"lyra/runtime/io.hpp\"\n";
   out += "#include \"lyra/runtime/module.hpp\"\n";
@@ -173,6 +172,7 @@ auto RenderClassHeaderFile(
   out += "#include \"lyra/runtime/process.hpp\"\n";
   out += "#include \"lyra/runtime/process_kind.hpp\"\n";
   out += "#include \"lyra/runtime/runtime_scope_kind.hpp\"\n";
+  out += "#include \"lyra/runtime/runtime_services.hpp\"\n";
   out += "\n";
   out += RenderClassDecl(unit, c, 0, true);
   return out;
@@ -180,6 +180,7 @@ auto RenderClassHeaderFile(
 
 auto RenderHostMain(const mir::ClassDecl& entry) -> std::string {
   std::string out;
+  out += "#include \"lyra/runtime/engine.hpp\"\n";
   out += "#include \"" + entry.name + ".hpp\"\n";
   out += "\n";
   out += "auto main() -> int {\n";

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -145,7 +145,7 @@ auto RenderRuntimeCallExpr(
   // legal but a fragile spelling to depend on.
   if (call.items.empty()) {
     return std::format(
-        "lyra::runtime::LyraPrint(*engine_, {}, "
+        "lyra::runtime::LyraPrint(*services_, {}, "
         "std::span<const lyra::runtime::PrintItem>{{}})",
         kind_literal);
   }
@@ -161,7 +161,7 @@ auto RenderRuntimeCallExpr(
   }
 
   std::string out = std::format(
-      "lyra::runtime::LyraPrint(*engine_, {}, "
+      "lyra::runtime::LyraPrint(*services_, {}, "
       "std::array<lyra::runtime::PrintItem, {}>{{",
       kind_literal, call.items.size());
   for (std::size_t i = 0; i < item_inits.size(); ++i) {

--- a/src/lyra/runtime/bind_context.cpp
+++ b/src/lyra/runtime/bind_context.cpp
@@ -1,31 +1,46 @@
 #include "lyra/runtime/bind_context.hpp"
 
+#include <string>
 #include <utility>
 
-#include "lyra/runtime/engine.hpp"
+#include "lyra/base/internal_error.hpp"
 #include "lyra/runtime/process.hpp"
 #include "lyra/runtime/process_kind.hpp"
+#include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_scope.hpp"
+#include "lyra/runtime/runtime_scope_kind.hpp"
+#include "lyra/runtime/runtime_services.hpp"
 
 namespace lyra::runtime {
 
-RuntimeBindContext::RuntimeBindContext(Engine& engine, RuntimeScope& scope)
-    : engine_(&engine), scope_(&scope) {
+RuntimeBindContext::RuntimeBindContext(
+    RuntimeScope& scope, RuntimeServices& services)
+    : scope_(&scope), services_(&services) {
 }
 
 auto RuntimeBindContext::CurrentScope() -> RuntimeScope& {
+  if (scope_ == nullptr) {
+    throw InternalError("RuntimeBindContext has no current scope");
+  }
   return *scope_;
 }
 
-void RuntimeBindContext::AddProcess(ProcessKind kind, Process process) {
-  engine_->AddProcess(*scope_, kind, std::move(process));
+auto RuntimeBindContext::Services() -> RuntimeServices& {
+  if (services_ == nullptr) {
+    throw InternalError("RuntimeBindContext has no runtime services");
+  }
+  return *services_;
+}
+
+auto RuntimeBindContext::AddProcess(ProcessKind kind, Process process)
+    -> RuntimeProcess& {
+  return CurrentScope().AddProcess(kind, std::move(process));
 }
 
 auto RuntimeBindContext::CreateChildScope(
     std::string name, RuntimeScopeKind kind) -> RuntimeBindContext {
-  RuntimeScope& child =
-      engine_->CreateChildScope(*scope_, std::move(name), kind);
-  return {*engine_, child};
+  RuntimeScope& child = CurrentScope().AddChildScope(std::move(name), kind);
+  return {child, Services()};
 }
 
 }  // namespace lyra::runtime

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -10,11 +10,11 @@
 #include "lyra/runtime/bind_context.hpp"
 #include "lyra/runtime/module.hpp"
 #include "lyra/runtime/output_sink.hpp"
-#include "lyra/runtime/process.hpp"
 #include "lyra/runtime/process_kind.hpp"
 #include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_scope.hpp"
 #include "lyra/runtime/runtime_scope_kind.hpp"
+#include "lyra/runtime/runtime_traversal.hpp"
 
 namespace lyra::runtime {
 
@@ -35,26 +35,10 @@ void Engine::BindRoot(std::string root_name, Module& top) {
     throw InternalError("Engine::BindRoot called more than once");
   }
   bound_ = true;
-  scopes_.push_back(
-      std::make_unique<RuntimeScope>(
-          nullptr, std::move(root_name), RuntimeScopeKind::kModule));
-  RuntimeBindContext ctx(*this, *scopes_.front());
+  root_ = std::make_unique<RuntimeScope>(
+      nullptr, std::move(root_name), RuntimeScopeKind::kModuleInstance);
+  RuntimeBindContext ctx(*root_, services_);
   top.Bind(ctx);
-}
-
-void Engine::AddProcess(
-    RuntimeScope& owner, ProcessKind kind, Process process) {
-  processes_.emplace_back(owner, kind, std::move(process));
-}
-
-auto Engine::CreateChildScope(
-    RuntimeScope& parent, std::string name, RuntimeScopeKind kind)
-    -> RuntimeScope& {
-  scopes_.push_back(
-      std::make_unique<RuntimeScope>(&parent, std::move(name), kind));
-  RuntimeScope& child = *scopes_.back();
-  parent.AddChild(child);
-  return child;
 }
 
 auto Engine::Run() -> int {
@@ -65,19 +49,7 @@ auto Engine::Run() -> int {
     throw InternalError("Engine::Run called more than once");
   }
   ran_ = true;
-  for (auto& proc : processes_) {
-    switch (proc.Kind()) {
-      case ProcessKind::kInitial:
-        active_queue_.push_back(&proc);
-        break;
-      case ProcessKind::kAlways:
-      case ProcessKind::kAlwaysComb:
-      case ProcessKind::kAlwaysFf:
-      case ProcessKind::kFinal:
-        throw InternalError(
-            "Engine::Run: unsupported runtime ProcessKind in this cut");
-    }
-  }
+  EnqueueInitialProcesses(*root_);
   while (!active_queue_.empty()) {
     auto* proc = active_queue_.front();
     active_queue_.pop_front();
@@ -85,6 +57,24 @@ auto Engine::Run() -> int {
   }
   output_.Drain();
   return 0;
+}
+
+void Engine::EnqueueInitialProcesses(RuntimeScope& root) {
+  WalkScopePreOrder(root, [this](RuntimeScope& scope) {
+    scope.ForEachProcess([this](RuntimeProcess& process) {
+      switch (process.Kind()) {
+        case ProcessKind::kInitial:
+          active_queue_.push_back(&process);
+          break;
+        case ProcessKind::kAlways:
+        case ProcessKind::kAlwaysComb:
+        case ProcessKind::kAlwaysFf:
+        case ProcessKind::kFinal:
+          throw InternalError(
+              "Engine::Run: unsupported runtime ProcessKind in this cut");
+      }
+    });
+  });
 }
 
 }  // namespace lyra::runtime

--- a/src/lyra/runtime/io.cpp
+++ b/src/lyra/runtime/io.cpp
@@ -5,22 +5,24 @@
 #include <variant>
 
 #include "lyra/base/overloaded.hpp"
-#include "lyra/runtime/engine.hpp"
 #include "lyra/runtime/format.hpp"
 #include "lyra/runtime/output_sink.hpp"
+#include "lyra/runtime/runtime_services.hpp"
 
 namespace lyra::runtime {
 
 void LyraPrint(
-    Engine& engine, PrintKind kind, std::span<const PrintItem> items) {
+    RuntimeServices& services, PrintKind kind,
+    std::span<const PrintItem> items) {
+  auto& output = services.Output();
   for (const PrintItem& item : items) {
     std::visit(
         Overloaded{
             [&](const PrintLiteralItem& lit) {
-              engine.Output().Append(std::string_view{lit.data, lit.size});
+              output.Append(std::string_view{lit.data, lit.size});
             },
             [&](const PrintValueItem& v) {
-              engine.Output().Append(FormatValue(v.spec, v.value));
+              output.Append(FormatValue(v.spec, v.value));
             },
         },
         item);
@@ -28,7 +30,7 @@ void LyraPrint(
 
   const bool append_newline =
       kind == PrintKind::kDisplay || kind == PrintKind::kFDisplay;
-  engine.Output().FinishRecord(append_newline);
+  output.FinishRecord(append_newline);
 }
 
 }  // namespace lyra::runtime

--- a/src/lyra/runtime/runtime_scope.cpp
+++ b/src/lyra/runtime/runtime_scope.cpp
@@ -1,10 +1,13 @@
 #include "lyra/runtime/runtime_scope.hpp"
 
-#include <span>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <utility>
 
+#include "lyra/runtime/process.hpp"
+#include "lyra/runtime/process_kind.hpp"
+#include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_scope_kind.hpp"
 
 namespace lyra::runtime {
@@ -14,7 +17,7 @@ RuntimeScope::RuntimeScope(
     : parent_(parent), name_(std::move(name)), kind_(kind) {
 }
 
-auto RuntimeScope::Parent() -> RuntimeScope* {
+auto RuntimeScope::Parent() const -> RuntimeScope* {
   return parent_;
 }
 
@@ -26,12 +29,18 @@ auto RuntimeScope::Kind() const -> RuntimeScopeKind {
   return kind_;
 }
 
-void RuntimeScope::AddChild(RuntimeScope& child) {
-  children_.push_back(&child);
+auto RuntimeScope::AddChildScope(std::string name, RuntimeScopeKind kind)
+    -> RuntimeScope& {
+  children_.push_back(
+      std::make_unique<RuntimeScope>(this, std::move(name), kind));
+  return *children_.back();
 }
 
-auto RuntimeScope::Children() const -> std::span<RuntimeScope* const> {
-  return children_;
+auto RuntimeScope::AddProcess(ProcessKind kind, Process process)
+    -> RuntimeProcess& {
+  processes_.push_back(
+      std::make_unique<RuntimeProcess>(*this, kind, std::move(process)));
+  return *processes_.back();
 }
 
 }  // namespace lyra::runtime

--- a/tests/cases/cpp/generate_scope_initial/case.yaml
+++ b/tests/cases/cpp/generate_scope_initial/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.generate_scope_initial
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "top\nchild\n"

--- a/tests/cases/cpp/generate_scope_initial/main.sv
+++ b/tests/cases/cpp/generate_scope_initial/main.sv
@@ -1,0 +1,6 @@
+module Top;
+  if (1) begin : g
+    initial $display("child");
+  end
+  initial $display("top");
+endmodule

--- a/tests/cases/emit/generate_if/case.yaml
+++ b/tests/cases/emit/generate_if/case.yaml
@@ -30,7 +30,7 @@ expect:
       - "void Bind(lyra::runtime::RuntimeBindContext& ctx) override"
       - "ctx.CreateChildScope("
       - '"gen0_then"'
-      - "lyra::runtime::RuntimeScopeKind::kGenerate"
+      - "lyra::runtime::RuntimeScopeKind::kGenerateScope"
       - "if (gen0_then_obj) {"
       - "gen0_then_obj->Bind(child)"
       - "auto process_0() -> lyra::runtime::Process"

--- a/tests/cases/emit/loop_generate_basic/case.yaml
+++ b/tests/cases/emit/loop_generate_basic/case.yaml
@@ -20,5 +20,5 @@ expect:
       - "void Bind(lyra::runtime::RuntimeBindContext& ctx) override"
       - "for (std::size_t idx = 0; idx < gen0_body_obj.size(); ++idx) {"
       - "ctx.CreateChildScope("
-      - "lyra::runtime::RuntimeScopeKind::kGenerate"
+      - "lyra::runtime::RuntimeScopeKind::kGenerateScope"
       - "gen0_body_obj[idx]->Bind(child)"


### PR DESCRIPTION
## Summary

Today `Engine` is both a scheduler and the flat owner of every `RuntimeProcess` and `RuntimeScope` in the design. Generated classes also stash an `Engine*` from the bind context just so `$display` lowering has somewhere to call. This shape conflates "I am the scheduler" with "I am the design's storage", and it is the wrong base for upcoming per-instance scheduling, hierarchical reset, and scope-keyed debug dumps.

This refactor moves all hierarchical runtime contents into `RuntimeScope`, leaves `Engine` as a pure scheduler over the root scope, and replaces the generated `Engine*` stash with a narrow `RuntimeServices` capability handle so generated code never reaches the scheduler.

## Design

The cut establishes these invariants:

1. `RuntimeScope` owns its child scopes and processes; storage is hidden behind `ForEachChild` / `ForEachProcess` template helpers (no `unique_ptr` / span leaks in the public API).
2. `Engine` owns the scheduler queue, scheduling policy, and the design's runtime services. It owns the root scope but no flat process or scope list. Copy and move are deleted because `RuntimeServices` holds a pointer into `OutputDispatcher`.
3. `RuntimeBindContext` carries `(RuntimeScope&, RuntimeServices&)` only; `GetEngine()` is gone.
4. Generated modules store `RuntimeServices*`; system-task lowering (`LyraPrint` today, `$urandom` / `$time` tomorrow) takes `RuntimeServices&`.
5. Hierarchical traversal is one shared template, `WalkScopePreOrder`, in `runtime_traversal.hpp`. `Engine::EnqueueInitialProcesses` is now a small lambda body on top of that helper -- future scheduling, reset, and debug policies will reuse the same walk.

`RuntimeScopeKind` is renamed to `kModuleInstance` / `kGenerateScope` to reflect runtime concepts rather than syntax. The C++ emitter today emits `kGenerateScope` for every owning-object child member; per the long-standing comment in `emit_cpp.cpp`, the only producer is generate-arm child-class installation, so the rename preserves current semantics. Module-instance children of the emitter (a future capability) will pick up `kModuleInstance` when the MIR-level distinction lands.

Out of scope: delay/event control, always/final lowering, coroutine awaitables, scheduling-semantics changes.

## Testing

- `bazel build //...` and `bazel test //... --test_output=errors` clean; existing emit and run tests cover the unchanged emitted shape (apart from the documented `services_` / `kGenerateScope` swaps, captured in the updated `tests/cases/emit/*` snapshots).
- New regression: `tests/cases/cpp/generate_scope_initial/`. Registers an `initial` inside a generate-if child scope and asserts both the root-scope and child-scope outputs are reached. The assertion is a scheduler-traversal regression (output order reflects the pre-order walk), not a SystemVerilog scheduling-order guarantee. This is the load-bearing test for the refactor: it can only pass if processes are stored on their owning scopes and the scheduler walks the tree.