### PR TITLE
Add HIR/MIR timed statement support for delay control

### DIFF
--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -33,6 +33,7 @@ enum class DiagCode : std::uint32_t {
   kUnsupportedCompoundAssignment,
   kUnsupportedAssignmentTarget,
   kUnsupportedBinaryOperator,
+  kUnsupportedTimingControlKind,
 
   kFormatStringTrailingPercent,
   kFormatStringMissingSpecifier,

--- a/include/lyra/hir/primary.hpp
+++ b/include/lyra/hir/primary.hpp
@@ -8,12 +8,19 @@
 
 namespace lyra::hir {
 
+enum class TimeScale : std::uint8_t { kFs, kPs, kNs, kUs, kMs, kS };
+
 struct IntegerLiteral {
   std::int64_t value;
 };
 
 struct StringLiteral {
   std::string value;
+};
+
+struct TimeLiteral {
+  double value;
+  TimeScale scale;
 };
 
 // Per IEEE 1800 SystemVerilog grammar, `primary` includes both
@@ -24,6 +31,7 @@ struct RefExpr {
   ValueRef target;
 };
 
-using Primary = std::variant<IntegerLiteral, StringLiteral, RefExpr>;
+using Primary =
+    std::variant<IntegerLiteral, StringLiteral, TimeLiteral, RefExpr>;
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -19,6 +19,8 @@ struct StmtId {
   auto operator<=>(const StmtId&) const -> std::strong_ordering = default;
 };
 
+struct EmptyStmt {};
+
 // VarDeclStmt has ordering semantics in HIR -- its position in the statement
 // stream marks the SystemVerilog point of declaration. The actual storage is
 // allocated on Process.local_vars; LocalVarId.value indexes into that vector.
@@ -34,7 +36,19 @@ struct BlockStmt {
   std::vector<StmtId> statements;
 };
 
-using StmtData = std::variant<VarDeclStmt, ExprStmt, BlockStmt>;
+struct DelayControl {
+  ExprId duration;
+};
+
+using TimingControl = std::variant<DelayControl>;
+
+struct TimedStmt {
+  TimingControl timing;
+  StmtId body;
+};
+
+using StmtData =
+    std::variant<EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, TimedStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -28,6 +28,7 @@ struct BuiltinMirTypes {
   mir::TypeId int32;
   mir::TypeId string;
   mir::TypeId void_type;
+  mir::TypeId realtime;
 };
 
 class UnitLoweringState {
@@ -41,7 +42,8 @@ class UnitLoweringState {
                 .dims = {mir::PackedRange{.left = 31, .right = 0}},
                 .form = mir::PackedArrayForm::kInt}}),
         .string = AddType(mir::TypeData{mir::StringType{}}),
-        .void_type = AddType(mir::TypeData{mir::VoidType{}})};
+        .void_type = AddType(mir::TypeData{mir::VoidType{}}),
+        .realtime = AddType(mir::TypeData{mir::RealTimeType{}})};
   }
 
   [[nodiscard]] auto Unit() const -> const mir::CompilationUnit& {

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -15,12 +15,19 @@
 
 namespace lyra::mir {
 
+enum class TimeScale : std::uint8_t { kFs, kPs, kNs, kUs, kMs, kS };
+
 struct IntegerLiteral {
   std::int64_t value;
 };
 
 struct StringLiteral {
   std::string value;
+};
+
+struct TimeLiteral {
+  double value;
+  TimeScale scale;
 };
 
 struct MemberVarRef {
@@ -68,8 +75,8 @@ struct RuntimeCallExpr {
 };
 
 using ExprData = std::variant<
-    IntegerLiteral, StringLiteral, MemberVarRef, LocalVarRef, BinaryExpr,
-    AssignExpr, CallExpr, RuntimeCallExpr>;
+    IntegerLiteral, StringLiteral, TimeLiteral, MemberVarRef, LocalVarRef,
+    BinaryExpr, AssignExpr, CallExpr, RuntimeCallExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -45,6 +45,8 @@ struct Body {
   }
 };
 
+struct EmptyStmt {};
+
 struct LocalVarDeclStmt {
   LocalVarRef target;
 };
@@ -80,7 +82,7 @@ struct ConstructOwnedObjectStmt {
 };
 
 struct ForInitDecl {
-  LocalVarRef local;
+  LocalVarRef local = {};
   std::optional<ExprId> init;
 };
 
@@ -98,9 +100,20 @@ struct ForStmt {
   BodyId body;
 };
 
+struct DelayControl {
+  ExprId duration;
+};
+
+using TimingControl = std::variant<DelayControl>;
+
+struct TimedStmt {
+  TimingControl timing;
+  StmtId body;
+};
+
 using StmtData = std::variant<
-    LocalVarDeclStmt, ExprStmt, BlockStmt, IfStmt, SwitchStmt,
-    ConstructOwnedObjectStmt, ForStmt>;
+    EmptyStmt, LocalVarDeclStmt, ExprStmt, BlockStmt, IfStmt, SwitchStmt,
+    ConstructOwnedObjectStmt, ForStmt, TimedStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -58,6 +58,11 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
           [](const mir::StringLiteral& e) -> std::string {
             return RenderStdStringLiteral(e.value);
           },
+          [](const mir::TimeLiteral&) -> std::string {
+            throw InternalError(
+                "backend cpp: TimeLiteral is not yet supported by the C++ "
+                "emitter");
+          },
           [&](const mir::MemberVarRef& e) -> std::string {
             return ctx.Class().GetMemberVar(e.target).name;
           },

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -55,6 +55,14 @@ auto RenderStmt(
   }
   out += std::visit(
       Overloaded{
+          [&](const mir::EmptyStmt&) -> std::string {
+            return Indent(indent) + ";\n";
+          },
+          [](const mir::TimedStmt&) -> std::string {
+            throw InternalError(
+                "backend cpp: TimedStmt is not yet supported by the C++ "
+                "emitter");
+          },
           [&](const mir::LocalVarDeclStmt& s) -> std::string {
             const auto& lv = ctx.Body()
                                  .local_scopes.at(s.target.scope.value)

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -144,6 +144,12 @@ constexpr std::array kEntries{
             .kind = DiagKind::kUnsupported,
             .category = UnsupportedCategory::kOperation,
             .name = "unsupported_binary_operator"}},
+    std::pair{
+        DiagCode::kUnsupportedTimingControlKind,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_timing_control_kind"}},
 
     std::pair{
         DiagCode::kFormatStringTrailingPercent,

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -191,6 +191,24 @@ class HirDumper {
         v);
   }
 
+  static auto FormatTimeScale(TimeScale s) -> std::string_view {
+    switch (s) {
+      case TimeScale::kFs:
+        return "fs";
+      case TimeScale::kPs:
+        return "ps";
+      case TimeScale::kNs:
+        return "ns";
+      case TimeScale::kUs:
+        return "us";
+      case TimeScale::kMs:
+        return "ms";
+      case TimeScale::kS:
+        return "s";
+    }
+    throw InternalError("HirDumper::FormatTimeScale: unknown TimeScale");
+  }
+
   static auto FormatPrimary(const Primary& p) -> std::string {
     return std::visit(
         Overloaded{
@@ -200,11 +218,28 @@ class HirDumper {
             [](const StringLiteral& lit) -> std::string {
               return std::format("StringLiteral(\"{}\")", lit.value);
             },
+            [](const TimeLiteral& lit) -> std::string {
+              return std::format(
+                  "TimeLiteral(value={}, scale={})", lit.value,
+                  FormatTimeScale(lit.scale));
+            },
             [](const RefExpr& r) -> std::string {
               return std::format("RefExpr {}", FormatValueRef(r.target));
             },
         },
         p);
+  }
+
+  static auto FormatTimingControlHeader(const TimingControl& tc)
+      -> std::string {
+    return std::visit(
+        Overloaded{
+            [](const DelayControl& d) -> std::string {
+              return std::format(
+                  "DelayControl duration=Expr[{}]", d.duration.value);
+            },
+        },
+        tc);
   }
 
   [[nodiscard]] auto FormatSubroutineRef(const SubroutineRef& callee) const
@@ -373,6 +408,9 @@ class HirDumper {
     const auto& s = p.stmts.at(id.value);
     std::visit(
         Overloaded{
+            [&](const EmptyStmt&) {
+              Line(std::format("Stmt[{}] EmptyStmt", id.value));
+            },
             [&](const VarDeclStmt& v) {
               Line(
                   std::format(
@@ -399,6 +437,30 @@ class HirDumper {
               for (const auto child : b.statements) {
                 DumpStmt(p, child);
               }
+              Dedent();
+            },
+            [&](const TimedStmt& t) {
+              Line(std::format("Stmt[{}] TimedStmt", id.value));
+              Indent();
+              Line(
+                  std::format(
+                      "timing: {}", FormatTimingControlHeader(t.timing)));
+              Indent();
+              std::visit(
+                  Overloaded{
+                      [&](const DelayControl& d) {
+                        Line(
+                            std::format(
+                                "Expr[{}] {}", d.duration.value,
+                                FormatProcExpr(p, d.duration)));
+                      },
+                  },
+                  t.timing);
+              Dedent();
+              Line("body:");
+              Indent();
+              DumpStmt(p, t.body);
+              Dedent();
               Dedent();
             },
         },

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -20,6 +20,7 @@
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/numeric/SVInt.h>
+#include <slang/numeric/Time.h>
 
 #include "../facts.hpp"
 #include "../state.hpp"
@@ -65,6 +66,33 @@ auto MakeStringLiteralExpr(std::string text, diag::SourceSpan span)
       .data =
           hir::PrimaryExpr{
               .data = hir::StringLiteral{.value = std::move(text)}},
+      .span = span};
+}
+
+auto LowerTimeUnit(slang::TimeUnit u) -> hir::TimeScale {
+  switch (u) {
+    case slang::TimeUnit::Femtoseconds:
+      return hir::TimeScale::kFs;
+    case slang::TimeUnit::Picoseconds:
+      return hir::TimeScale::kPs;
+    case slang::TimeUnit::Nanoseconds:
+      return hir::TimeScale::kNs;
+    case slang::TimeUnit::Microseconds:
+      return hir::TimeScale::kUs;
+    case slang::TimeUnit::Milliseconds:
+      return hir::TimeScale::kMs;
+    case slang::TimeUnit::Seconds:
+      return hir::TimeScale::kS;
+  }
+  throw InternalError("LowerTimeUnit: unknown slang TimeUnit");
+}
+
+auto MakeTimeLiteralExpr(
+    double value, hir::TimeScale scale, diag::SourceSpan span) -> hir::Expr {
+  return hir::Expr{
+      .data =
+          hir::PrimaryExpr{
+              .data = hir::TimeLiteral{.value = value, .scale = scale}},
       .span = span};
 }
 
@@ -167,6 +195,12 @@ auto LowerProcExpr(
       return MakeStringLiteralExpr(std::string{sl.getValue()}, span);
     }
 
+    case slang::ast::ExpressionKind::TimeLiteral: {
+      const auto& tl = expr.as<slang::ast::TimeLiteral>();
+      return MakeTimeLiteralExpr(
+          tl.getValue(), LowerTimeUnit(tl.getScale().base.unit), span);
+    }
+
     case slang::ast::ExpressionKind::NamedValue:
       return LowerNamedValueProc(
           unit_facts, unit_state, proc_state, stack,
@@ -177,7 +211,7 @@ auto LowerProcExpr(
       if (bin.op != slang::ast::BinaryOperator::Add) {
         return diag::Unsupported(
             span, diag::DiagCode::kUnsupportedBinaryOperator,
-            "only `+` is supported in this cut",
+            "only `+` is currently supported",
             diag::UnsupportedCategory::kOperation);
       }
       auto lhs_id = append_child(bin.left());

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -8,6 +8,7 @@
 #include <slang/ast/Expression.h>
 #include <slang/ast/Statement.h>
 #include <slang/ast/Symbol.h>
+#include <slang/ast/TimingControl.h>
 #include <slang/ast/statements/MiscStatements.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 
@@ -15,11 +16,36 @@
 #include "../facts.hpp"
 #include "../state.hpp"
 #include "../type.hpp"
+#include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/kind.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/stmt.hpp"
 
 namespace lyra::lowering::ast_to_hir {
+
+namespace {
+
+auto LowerTimingControl(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const slang::ast::TimingControl& tc, diag::SourceSpan span)
+    -> diag::Result<hir::TimingControl> {
+  if (tc.kind == slang::ast::TimingControlKind::Delay) {
+    const auto& delay = tc.as<slang::ast::DelayControl>();
+    auto duration =
+        LowerProcExpr(unit_facts, unit_state, proc_state, stack, delay.expr);
+    if (!duration) return std::unexpected(std::move(duration.error()));
+    return hir::TimingControl{hir::DelayControl{
+        .duration = proc_state.AddExpr(*std::move(duration))}};
+  }
+  return diag::Unsupported(
+      span, diag::DiagCode::kUnsupportedTimingControlKind,
+      "this timing control kind is not yet supported",
+      diag::UnsupportedCategory::kFeature);
+}
+
+}  // namespace
 
 auto LowerStatement(
     const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
@@ -28,6 +54,27 @@ auto LowerStatement(
   const auto& mapper = unit_facts.SourceMapper();
   const auto span = mapper.SpanOf(stmt.sourceRange);
   switch (stmt.kind) {
+    case slang::ast::StatementKind::Empty: {
+      return hir::Stmt{
+          .label = std::nullopt, .data = hir::EmptyStmt{}, .span = span};
+    }
+
+    case slang::ast::StatementKind::Timed: {
+      const auto& ts = stmt.as<slang::ast::TimedStatement>();
+      auto timing = LowerTimingControl(
+          unit_facts, scope_state.UnitState(), proc_state, stack, ts.timing,
+          span);
+      if (!timing) return std::unexpected(std::move(timing.error()));
+      auto body_stmt =
+          LowerStatement(unit_facts, proc_state, scope_state, stack, ts.stmt);
+      if (!body_stmt) return std::unexpected(std::move(body_stmt.error()));
+      const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_stmt));
+      return hir::Stmt{
+          .label = std::nullopt,
+          .data = hir::TimedStmt{.timing = *std::move(timing), .body = body_id},
+          .span = span};
+    }
+
     case slang::ast::StatementKind::List: {
       const auto& list = stmt.as<slang::ast::StatementList>();
       std::vector<hir::StmtId> kids;

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -33,6 +33,24 @@ auto LowerBinaryOp(hir::BinaryOp op) -> mir::BinaryOp {
   throw InternalError("LowerBinaryOp: unknown HIR BinaryOp");
 }
 
+auto LowerTimeScale(hir::TimeScale s) -> mir::TimeScale {
+  switch (s) {
+    case hir::TimeScale::kFs:
+      return mir::TimeScale::kFs;
+    case hir::TimeScale::kPs:
+      return mir::TimeScale::kPs;
+    case hir::TimeScale::kNs:
+      return mir::TimeScale::kNs;
+    case hir::TimeScale::kUs:
+      return mir::TimeScale::kUs;
+    case hir::TimeScale::kMs:
+      return mir::TimeScale::kMs;
+    case hir::TimeScale::kS:
+      return mir::TimeScale::kS;
+  }
+  throw InternalError("LowerTimeScale: unknown HIR TimeScale");
+}
+
 namespace {
 
 auto LowerMemberVarRefExpr(
@@ -128,6 +146,13 @@ auto LowerPrimaryExpr(
                 .data = mir::StringLiteral{.value = s.value},
                 .type = unit_state.Builtins().string};
           },
+          [&](const hir::TimeLiteral& t) -> mir::Expr {
+            return mir::Expr{
+                .data =
+                    mir::TimeLiteral{
+                        .value = t.value, .scale = LowerTimeScale(t.scale)},
+                .type = unit_state.Builtins().realtime};
+          },
           [&](const hir::RefExpr& r) -> mir::Expr {
             return std::visit(
                 Overloaded{
@@ -165,6 +190,13 @@ auto LowerPrimaryExpr(
             return mir::Expr{
                 .data = mir::StringLiteral{.value = s.value},
                 .type = unit_state.Builtins().string};
+          },
+          [&](const hir::TimeLiteral& t) -> diag::Result<mir::Expr> {
+            return mir::Expr{
+                .data =
+                    mir::TimeLiteral{
+                        .value = t.value, .scale = LowerTimeScale(t.scale)},
+                .type = unit_state.Builtins().realtime};
           },
           [&](const hir::RefExpr& r) -> diag::Result<mir::Expr> {
             return std::visit(

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -15,6 +15,29 @@
 
 namespace lyra::lowering::hir_to_mir {
 
+namespace {
+
+auto LowerTimingControl(
+    const UnitLoweringState& unit_state, const ClassLoweringState& class_state,
+    const ProcessLoweringState& proc_state, BodyLoweringState& body_state,
+    const hir::Process& hir_proc, const hir::TimingControl& tc)
+    -> diag::Result<mir::TimingControl> {
+  return std::visit(
+      Overloaded{
+          [&](const hir::DelayControl& d) -> diag::Result<mir::TimingControl> {
+            auto expr_or = LowerExpr(
+                unit_state, class_state, proc_state, body_state, hir_proc,
+                hir_proc.exprs.at(d.duration.value));
+            if (!expr_or) return std::unexpected(std::move(expr_or.error()));
+            return mir::TimingControl{mir::DelayControl{
+                .duration = body_state.AddExpr(*std::move(expr_or))}};
+          },
+      },
+      tc);
+}
+
+}  // namespace
+
 auto LowerStmt(
     const UnitLoweringState& unit_state, const ClassLoweringState& class_state,
     const ProcessLoweringState& proc_state, BodyLoweringState& body_state,
@@ -22,6 +45,9 @@ auto LowerStmt(
     -> diag::Result<mir::Stmt> {
   auto data = std::visit(
       Overloaded{
+          [](const hir::EmptyStmt&) -> diag::Result<mir::StmtData> {
+            return mir::EmptyStmt{};
+          },
           [&](const hir::VarDeclStmt& v) -> diag::Result<mir::StmtData> {
             return mir::LocalVarDeclStmt{
                 .target = proc_state.TranslateLocalVar(v.local_var)};
@@ -50,6 +76,24 @@ auto LowerStmt(
               children.push_back(body_state.AddStmt(*std::move(lowered_child)));
             }
             return mir::BlockStmt{.statements = std::move(children)};
+          },
+          [&](const hir::TimedStmt& t) -> diag::Result<mir::StmtData> {
+            auto timing_or = LowerTimingControl(
+                unit_state, class_state, proc_state, body_state, hir_proc,
+                t.timing);
+            if (!timing_or) {
+              return std::unexpected(std::move(timing_or.error()));
+            }
+            const hir::Stmt& body_hir = hir_proc.stmts.at(t.body.value);
+            auto body_or = LowerStmt(
+                unit_state, class_state, proc_state, body_state, hir_proc,
+                body_hir);
+            if (!body_or) {
+              return std::unexpected(std::move(body_or.error()));
+            }
+            const mir::StmtId body_id = body_state.AddStmt(*std::move(body_or));
+            return mir::TimedStmt{
+                .timing = *std::move(timing_or), .body = body_id};
           },
       },
       stmt.data);

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -180,6 +180,35 @@ class MirDumper {
         t.data);
   }
 
+  static auto FormatTimeScale(TimeScale s) -> std::string_view {
+    switch (s) {
+      case TimeScale::kFs:
+        return "fs";
+      case TimeScale::kPs:
+        return "ps";
+      case TimeScale::kNs:
+        return "ns";
+      case TimeScale::kUs:
+        return "us";
+      case TimeScale::kMs:
+        return "ms";
+      case TimeScale::kS:
+        return "s";
+    }
+    throw InternalError("MirDumper::FormatTimeScale: unknown TimeScale");
+  }
+
+  static auto FormatTimingControl(const TimingControl& tc) -> std::string {
+    return std::visit(
+        Overloaded{
+            [](const DelayControl& d) -> std::string {
+              return std::format(
+                  "DelayControl duration=Expr[{}]", d.duration.value);
+            },
+        },
+        tc);
+  }
+
   static auto FormatBinaryOp(BinaryOp op) -> std::string {
     switch (op) {
       case BinaryOp::kAdd:
@@ -245,6 +274,11 @@ class MirDumper {
             },
             [](const StringLiteral& lit) -> std::string {
               return std::format("StringLiteral(\"{}\")", lit.value);
+            },
+            [](const TimeLiteral& lit) -> std::string {
+              return std::format(
+                  "TimeLiteral(value={}, scale={})", lit.value,
+                  FormatTimeScale(lit.scale));
             },
             [](const MemberVarRef& r) -> std::string {
               return std::format("MemberVarRef(MemberVar[{}])", r.target.value);
@@ -403,6 +437,9 @@ class MirDumper {
     }
     std::visit(
         Overloaded{
+            [&](const EmptyStmt&) {
+              Line(std::format("Stmt[{}] EmptyStmt", id.value));
+            },
             [&](const LocalVarDeclStmt& s) {
               Line(
                   std::format(
@@ -424,8 +461,20 @@ class MirDumper {
                       id.value, s.target.value, s.class_id.value));
             },
             [&](const ForStmt& s) { DumpForStmt(stmt, s, enclosing, id); },
+            [&](const TimedStmt& t) { DumpTimedStmt(t, enclosing, id); },
         },
         stmt.data);
+  }
+
+  void DumpTimedStmt(const TimedStmt& t, const Body& enclosing, StmtId id) {
+    Line(std::format("Stmt[{}] TimedStmt", id.value));
+    Indent();
+    Line(std::format("timing: {}", FormatTimingControl(t.timing)));
+    Line("body:");
+    Indent();
+    DumpStmt(enclosing, t.body);
+    Dedent();
+    Dedent();
   }
 
   void DumpRuntimePrintCallItems(

--- a/tests/cases/dump/hir_timed/case.yaml
+++ b/tests/cases/dump/hir_timed/case.yaml
@@ -1,0 +1,20 @@
+id: dump.hir_timed
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "TimedStmt"
+      - "DelayControl duration=Expr["
+      - "EmptyStmt"
+      - "IntegerLiteral(5)"
+      - "TimeLiteral(value=5, scale=ns)"
+      - "StringLiteral(\"x\")"
+      - "StringLiteral(\"ns\")"
+      - "StringLiteral(\"block\")"
+      - "BlockStmt (count="

--- a/tests/cases/dump/hir_timed/main.sv
+++ b/tests/cases/dump/hir_timed/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  initial #5;
+
+  initial #5 $display("x");
+
+  initial #5ns $display("ns");
+
+  initial begin
+    #5 begin
+      $display("block");
+    end
+  end
+endmodule

--- a/tests/cases/dump/mir_timed/case.yaml
+++ b/tests/cases/dump/mir_timed/case.yaml
@@ -1,0 +1,21 @@
+id: dump.mir_timed
+tags: [dump]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "TimedStmt"
+      - "DelayControl duration=Expr["
+      - "EmptyStmt"
+      - "IntegerLiteral(5)"
+      - "TimeLiteral(value=5, scale=ns)"
+      - "Item[0] Literal \"x\""
+      - "Item[0] Literal \"ns\""
+      - "Item[0] Literal \"block\""
+      - "BlockStmt (count="
+

--- a/tests/cases/dump/mir_timed/main.sv
+++ b/tests/cases/dump/mir_timed/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  initial #5;
+
+  initial #5 $display("x");
+
+  initial #5ns $display("ns");
+
+  initial begin
+    #5 begin
+      $display("block");
+    end
+  end
+endmodule

--- a/tests/cases/errors/unsupported_binary_op/case.yaml
+++ b/tests/cases/errors/unsupported_binary_op/case.yaml
@@ -12,7 +12,7 @@ expect:
     contains:
       - "main.sv:4:"
       - "unsupported:"
-      - "only `+` is supported in this cut"
+      - "only `+` is currently supported"
       - "a = a - 1;"
     not_contains:
       - "internal error"


### PR DESCRIPTION
## Summary

Introduces a wrapper-shaped representation of SystemVerilog timing-controlled statements at HIR and MIR. Slang's `TimedStatement` lowers to `TimedStmt { TimingControl timing; StmtId body; }`, where `TimingControl` is a `std::variant` that today holds only `DelayControl { ExprId duration }`. This first slice lowers `slang::ast::DelayControl` end-to-end through the dump pipeline; other timing kinds (event, cycle, one-step, implicit, repeated event) return a clear `kUnsupportedTimingControlKind` diagnostic.

Time literals get first-class HIR and MIR support: `TimeLiteral { double value; TimeScale scale }` is added to the primary/literal variant alongside `IntegerLiteral` and `StringLiteral`. `#5` stays an integer literal; `#5ns` becomes a `TimeLiteral`. The authored unit is preserved without canonicalization to ticks. Empty statements are also lifted out as a first-class `EmptyStmt` variant rather than collapsed to an empty `BlockStmt`, since slang elaborates `#5;` as `Timed { Delay, Empty }`.

The C++ backend reaches `TimedStmt` and `TimeLiteral` only via `InternalError` guards consistent with the existing pattern for `mir::CallExpr`. `EmptyStmt` emits a no-op `;`. No runtime, scheduler, or `co_await` work in this slice.

## Testing

- `bazel build //...`
- `bazel test //... --test_output=errors` -- 6/6 targets pass
- New dump fixtures under `tests/cases/dump/hir_timed/` and `tests/cases/dump/mir_timed/` cover `#5;`, `#5 expr;`, `#5ns expr;`, and `#5 begin ... end`, including the ownership invariant that `TimedStmt::body` is reached only by following the wrapper (the body never appears flat in any sibling list).