### PR TITLE
Preserve SV integer literals and lower conversions to runtime

### DIFF
--- a/include/lyra/backend/cpp/render_expr.hpp
+++ b/include/lyra/backend/cpp/render_expr.hpp
@@ -7,9 +7,17 @@
 
 namespace lyra::backend::cpp {
 
+// Auto-picks `RenderExprAsNative` or `RenderExprAsRuntimeView` per variant.
+// Call sites with a known target context should use the explicit forms.
 auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr) -> std::string;
 
 auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
+    -> std::string;
+
+auto RenderExprAsNative(const RenderContext& ctx, const mir::Expr& expr)
+    -> std::string;
+
+auto RenderExprAsRuntimeView(const RenderContext& ctx, const mir::Expr& expr)
     -> std::string;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/backend/cpp/render_type.hpp
+++ b/include/lyra/backend/cpp/render_type.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "lyra/mir/class_decl.hpp"
 #include "lyra/mir/compilation_unit.hpp"
@@ -14,5 +15,8 @@ namespace lyra::backend::cpp {
 [[nodiscard]] auto RenderTypeAsCpp(
     const mir::CompilationUnit& unit, const mir::ClassDecl& owner_class,
     mir::TypeId type_id) -> std::string;
+
+[[nodiscard]] auto RenderPackedShapeLiteral(
+    const std::vector<mir::PackedRange>& dims) -> std::string;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -27,7 +27,6 @@ enum class DiagCode : std::uint32_t {
   kUnsupportedStatementForm,
   kUnsupportedExpressionForm,
   kUnsupportedStructuralExpressionForm,
-  kUnsupportedIntegerLiteralWidth,
   kUnsupportedNonVariableNamedReference,
   kUnsupportedNonBlockingAssignment,
   kUnsupportedCompoundAssignment,

--- a/include/lyra/hir/conversion.hpp
+++ b/include/lyra/hir/conversion.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstdint>
+
+#include "lyra/hir/expr_id.hpp"
+
+namespace lyra::hir {
+
+enum class ConversionKind : std::uint8_t {
+  kImplicit,
+  kPropagated,
+  kStreamingConcat,
+  kExplicit,
+  kBitstreamCast,
+};
+
+// Diagnostic metadata; never drives simulation behavior.
+enum class IntegerLiteralBase : std::uint8_t {
+  kBinary,
+  kOctal,
+  kDecimal,
+  kHexadecimal,
+  kUnbased,
+};
+
+struct ConversionExpr {
+  ExprId operand;
+  ConversionKind kind;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -1,23 +1,17 @@
 #pragma once
 
-#include <compare>
-#include <cstdint>
 #include <variant>
 #include <vector>
 
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/binary_op.hpp"
+#include "lyra/hir/conversion.hpp"
+#include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/type.hpp"
 
 namespace lyra::hir {
-
-struct ExprId {
-  std::uint32_t value;
-
-  auto operator<=>(const ExprId&) const -> std::strong_ordering = default;
-};
 
 struct PrimaryExpr {
   Primary data;
@@ -27,24 +21,23 @@ struct BinaryExpr {
   BinaryOp op;
   ExprId lhs;
   ExprId rhs;
-  TypeId type;
 };
 
 struct AssignExpr {
   ExprId lhs;
   ExprId rhs;
-  TypeId type;
 };
 
 struct CallExpr {
   SubroutineRef callee;
   std::vector<ExprId> arguments;
-  TypeId result_type;
 };
 
-using ExprData = std::variant<PrimaryExpr, BinaryExpr, AssignExpr, CallExpr>;
+using ExprData =
+    std::variant<PrimaryExpr, BinaryExpr, AssignExpr, CallExpr, ConversionExpr>;
 
 struct Expr {
+  TypeId type;
   ExprData data;
   diag::SourceSpan span;
 };

--- a/include/lyra/hir/expr_id.hpp
+++ b/include/lyra/hir/expr_id.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace lyra::hir {
+
+struct ExprId {
+  std::uint32_t value;
+
+  auto operator<=>(const ExprId&) const -> std::strong_ordering = default;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/integral_constant.hpp
+++ b/include/lyra/hir/integral_constant.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "lyra/hir/type.hpp"
+
+namespace lyra::hir {
+
+enum class IntegralStateKind : std::uint8_t {
+  kTwoState,
+  kFourState,
+};
+
+// Word layout is LSB-first; top word's unused high bits are zero-masked.
+// state_words is empty for 2-state, otherwise same length as value_words.
+// 4-state encoding: (v=0,s=0)=0, (v=1,s=0)=1, (v=0,s=1)=Z, (v=1,s=1)=X.
+struct IntegralConstant {
+  std::vector<std::uint64_t> value_words;
+  std::vector<std::uint64_t> state_words;
+  std::uint32_t width = 0;
+  Signedness signedness = Signedness::kUnsigned;
+  IntegralStateKind state_kind = IntegralStateKind::kTwoState;
+
+  auto operator==(const IntegralConstant&) const -> bool = default;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/primary.hpp
+++ b/include/lyra/hir/primary.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <cstdint>
 #include <string>
 #include <variant>
 
+#include "lyra/hir/conversion.hpp"
+#include "lyra/hir/integral_constant.hpp"
 #include "lyra/hir/value_ref.hpp"
 
 namespace lyra::hir {
@@ -11,7 +12,9 @@ namespace lyra::hir {
 enum class TimeScale : std::uint8_t { kFs, kPs, kNs, kUs, kMs, kS };
 
 struct IntegerLiteral {
-  std::int64_t value;
+  IntegralConstant value;
+  IntegerLiteralBase base = IntegerLiteralBase::kDecimal;
+  bool declared_unsized = false;
 };
 
 struct StringLiteral {

--- a/include/lyra/lowering/ast_to_hir/expression/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/lower.hpp
@@ -20,8 +20,8 @@ auto LowerProcExpr(
     const slang::ast::Expression& expr) -> diag::Result<hir::Expr>;
 
 auto LowerStructuralExpr(
-    const UnitLoweringFacts& unit_facts, const slang::ast::Expression& expr)
-    -> diag::Result<hir::Expr>;
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    const slang::ast::Expression& expr) -> diag::Result<hir::Expr>;
 
 // Short-lived state for lowering one loop-generate header's initial / stop
 // / iter expressions. The synthetic loop-variable identity (and its type)

--- a/include/lyra/lowering/ast_to_hir/integral_constant.hpp
+++ b/include/lyra/lowering/ast_to_hir/integral_constant.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <slang/numeric/SVInt.h>
+
+#include "lyra/hir/integral_constant.hpp"
+
+namespace lyra::lowering::ast_to_hir {
+
+// Convert a slang SVInt into Lyra's canonical IntegralConstant. Performs the
+// X/Z plane swap once at this boundary: slang encodes X=(value=0,unknown=1)
+// and Z=(value=1,unknown=1); Lyra encodes Z=(value=0,state=1) and
+// X=(value=1,state=1).
+auto LowerSVIntToIntegralConstant(const slang::SVInt& sv)
+    -> hir::IntegralConstant;
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -36,6 +36,7 @@ struct ScopeFrameId {
 struct MemberVarBinding {
   ScopeFrameId home_frame;
   hir::MemberVarId local_id;
+  hir::TypeId type;
 };
 
 using MemberVarBindings =
@@ -75,9 +76,10 @@ class UnitLoweringState {
 
   void MapMemberVarBinding(
       const slang::ast::VariableSymbol& var, ScopeFrameId home_frame,
-      hir::MemberVarId local) {
+      hir::MemberVarId local, hir::TypeId type) {
     member_var_bindings_.emplace(
-        &var, MemberVarBinding{.home_frame = home_frame, .local_id = local});
+        &var, MemberVarBinding{
+                  .home_frame = home_frame, .local_id = local, .type = type});
   }
 
   [[nodiscard]] auto LookupMemberVarBinding(
@@ -187,7 +189,7 @@ class ScopeLoweringState {
         static_cast<std::uint32_t>(scope_->member_vars.size())};
     scope_->member_vars.push_back(
         hir::MemberVar{.name = std::string{var.name}, .type = type});
-    unit_state_->MapMemberVarBinding(var, frame_, local);
+    unit_state_->MapMemberVarBinding(var, frame_, local, type);
     return local;
   }
 
@@ -196,6 +198,11 @@ class ScopeLoweringState {
         static_cast<std::uint32_t>(scope_->loop_var_decls.size())};
     scope_->loop_var_decls.push_back(std::move(decl));
     return id;
+  }
+
+  [[nodiscard]] auto GetLoopVarDeclType(hir::LoopVarDeclId id) const
+      -> hir::TypeId {
+    return scope_->loop_var_decls.at(id.value).type;
   }
 
   auto AddExpr(hir::Expr expr) -> hir::ExprId {
@@ -281,6 +288,10 @@ class ProcessLoweringState {
       return std::nullopt;
     }
     return it->second;
+  }
+
+  [[nodiscard]] auto GetLocalVarType(hir::LocalVarId id) const -> hir::TypeId {
+    return hir_process_.local_vars.at(id.value).type;
   }
 
   auto Finalize(hir::ProcessKind kind, hir::StmtId body) -> hir::Process {

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -101,7 +101,7 @@ struct ChildClassBinding {
 // Bindings produced by `InstallGenerateOwnedChildClasses` for a single
 // `hir::Generate`. Indexed by `hir::StructuralScopeId.value`. Phase-local to
 // constructor lowering: `LowerConstructorBody` consumes them and they then
-// go out of scope. They are not part of `ClassLoweringState`.
+// go away. They are not part of `ClassLoweringState`.
 struct GenerateBindings {
   std::vector<ChildClassBinding> by_scope_id;
 };

--- a/include/lyra/mir/conversion.hpp
+++ b/include/lyra/mir/conversion.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+
+#include "lyra/mir/expr_id.hpp"
+
+namespace lyra::mir {
+
+enum class ConversionKind : std::uint8_t {
+  kImplicit,
+  kPropagated,
+  kStreamingConcat,
+  kExplicit,
+  kBitstreamCast,
+};
+
+struct ConversionExpr {
+  ExprId operand;
+  ConversionKind kind;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -7,7 +7,9 @@
 #include <vector>
 
 #include "lyra/mir/binary_op.hpp"
+#include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr_id.hpp"
+#include "lyra/mir/integral_constant.hpp"
 #include "lyra/mir/local_var.hpp"
 #include "lyra/mir/member_var.hpp"
 #include "lyra/mir/runtime_print.hpp"
@@ -18,7 +20,7 @@ namespace lyra::mir {
 enum class TimeScale : std::uint8_t { kFs, kPs, kNs, kUs, kMs, kS };
 
 struct IntegerLiteral {
-  std::int64_t value;
+  IntegralConstant value;
 };
 
 struct StringLiteral {
@@ -76,7 +78,7 @@ struct RuntimeCallExpr {
 
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, MemberVarRef, LocalVarRef,
-    BinaryExpr, AssignExpr, CallExpr, RuntimeCallExpr>;
+    BinaryExpr, AssignExpr, CallExpr, RuntimeCallExpr, ConversionExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/mir/integral_constant.hpp
+++ b/include/lyra/mir/integral_constant.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "lyra/mir/type.hpp"
+
+namespace lyra::mir {
+
+enum class IntegralStateKind : std::uint8_t {
+  kTwoState,
+  kFourState,
+};
+
+// Word layout is LSB-first; top word's unused high bits are zero-masked.
+// state_words is empty for 2-state, otherwise same length as value_words.
+// 4-state encoding: (v=0,s=0)=0, (v=1,s=0)=1, (v=0,s=1)=Z, (v=1,s=1)=X.
+struct IntegralConstant {
+  std::vector<std::uint64_t> value_words;
+  std::vector<std::uint64_t> state_words;
+  std::uint32_t width = 0;
+  Signedness signedness = Signedness::kUnsigned;
+  IntegralStateKind state_kind = IntegralStateKind::kTwoState;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/runtime/convert.hpp
+++ b/include/lyra/runtime/convert.hpp
@@ -1,0 +1,303 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <span>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/runtime/packed.hpp"
+
+namespace lyra::runtime {
+
+namespace detail {
+
+inline auto ZeroBits(std::span<std::uint64_t> dst) -> void {
+  for (auto& w : dst) {
+    w = 0U;
+  }
+}
+
+inline auto MaskUnusedTopBits(std::span<std::uint64_t> dst, std::uint64_t width)
+    -> void {
+  if (dst.empty()) {
+    return;
+  }
+  const std::uint64_t tail = width % 64U;
+  if (tail == 0U) {
+    return;
+  }
+  const std::uint64_t mask = (std::uint64_t{1} << tail) - 1U;
+  dst.back() &= mask;
+}
+
+inline auto CopyLowBits(
+    std::span<std::uint64_t> dst, std::span<const std::uint64_t> src,
+    std::uint64_t bit_count) -> void {
+  if (bit_count == 0U) {
+    return;
+  }
+  const std::uint64_t full_words = bit_count / 64U;
+  const std::uint64_t tail = bit_count % 64U;
+  for (std::uint64_t i = 0; i < full_words; ++i) {
+    dst[i] = src[i];
+  }
+  if (tail != 0U) {
+    const std::uint64_t mask = (std::uint64_t{1} << tail) - 1U;
+    dst[full_words] = (dst[full_words] & ~mask) | (src[full_words] & mask);
+  }
+}
+
+inline auto AndNotLowBits(
+    std::span<std::uint64_t> dst, std::span<const std::uint64_t> src,
+    std::uint64_t bit_count) -> void {
+  if (bit_count == 0U) {
+    return;
+  }
+  const std::uint64_t full_words = bit_count / 64U;
+  const std::uint64_t tail = bit_count % 64U;
+  for (std::uint64_t i = 0; i < full_words; ++i) {
+    dst[i] &= ~src[i];
+  }
+  if (tail != 0U) {
+    const std::uint64_t mask = (std::uint64_t{1} << tail) - 1U;
+    dst[full_words] = (dst[full_words] & ~mask) |
+                      ((dst[full_words] & ~src[full_words]) & mask);
+  }
+}
+
+inline auto FillBitRange(
+    std::span<std::uint64_t> dst, std::uint64_t begin, std::uint64_t end,
+    bool bit_value) -> void {
+  if (begin >= end) {
+    return;
+  }
+  const std::uint64_t fill_word = bit_value ? ~std::uint64_t{0} : 0U;
+
+  const std::uint64_t first_word = begin / 64U;
+  const std::uint64_t last_inclusive = (end - 1U) / 64U;
+  const std::uint64_t first_offset = begin % 64U;
+  const std::uint64_t last_bits = end - (last_inclusive * 64U);
+
+  if (first_word == last_inclusive) {
+    const std::uint64_t low_mask = (std::uint64_t{1} << first_offset) - 1U;
+    const std::uint64_t high_mask = last_bits == 64U
+                                        ? ~std::uint64_t{0}
+                                        : (std::uint64_t{1} << last_bits) - 1U;
+    const std::uint64_t mask = high_mask & ~low_mask;
+    dst[first_word] = (dst[first_word] & ~mask) | (fill_word & mask);
+    return;
+  }
+
+  if (first_offset != 0U) {
+    const std::uint64_t low_mask = (std::uint64_t{1} << first_offset) - 1U;
+    dst[first_word] = (dst[first_word] & low_mask) | (fill_word & ~low_mask);
+  } else {
+    dst[first_word] = fill_word;
+  }
+  for (std::uint64_t w = first_word + 1U; w < last_inclusive; ++w) {
+    dst[w] = fill_word;
+  }
+  if (last_bits == 64U) {
+    dst[last_inclusive] = fill_word;
+  } else {
+    const std::uint64_t high_mask = (std::uint64_t{1} << last_bits) - 1U;
+    dst[last_inclusive] =
+        (dst[last_inclusive] & ~high_mask) | (fill_word & high_mask);
+  }
+}
+
+inline auto TestBit(std::span<const std::uint64_t> words, std::uint64_t index)
+    -> bool {
+  return ((words[index / 64U] >> (index % 64U)) & 1U) != 0U;
+}
+
+struct ConversionSource {
+  std::span<const std::uint64_t> value;
+  std::span<const std::uint64_t> state;
+  std::uint64_t width;
+  Signedness signedness;
+  bool four_state;
+};
+
+struct ConversionTarget {
+  std::span<std::uint64_t> value;
+  std::span<std::uint64_t> state;
+  std::uint64_t width;
+  bool four_state;
+};
+
+inline auto ConvertPackedBits(ConversionTarget dst, ConversionSource src)
+    -> void {
+  ZeroBits(dst.value);
+  if (dst.four_state) {
+    ZeroBits(dst.state);
+  }
+
+  const std::uint64_t copy_width = std::min(dst.width, src.width);
+
+  if (src.four_state && !dst.four_state) {
+    // Logic -> Bit flattens X/Z by clearing where state is 1.
+    CopyLowBits(dst.value, src.value, copy_width);
+    AndNotLowBits(dst.value, src.state, copy_width);
+  } else {
+    CopyLowBits(dst.value, src.value, copy_width);
+    if (dst.four_state && src.four_state) {
+      CopyLowBits(dst.state, src.state, copy_width);
+    }
+  }
+
+  if (dst.width > src.width && src.width > 0U &&
+      src.signedness == Signedness::kSigned) {
+    bool sign_value = false;
+    bool sign_state = false;
+    if (src.four_state && !dst.four_state) {
+      sign_value = !TestBit(src.state, src.width - 1U) &&
+                   TestBit(src.value, src.width - 1U);
+    } else {
+      sign_value = TestBit(src.value, src.width - 1U);
+      if (src.four_state) {
+        // Logic -> Logic preserves an X or Z sign bit on widening.
+        sign_state = TestBit(src.state, src.width - 1U);
+      }
+    }
+    FillBitRange(dst.value, src.width, dst.width, sign_value);
+    if (dst.four_state) {
+      FillBitRange(dst.state, src.width, dst.width, sign_state);
+    }
+  }
+
+  MaskUnusedTopBits(dst.value, dst.width);
+  if (dst.four_state) {
+    MaskUnusedTopBits(dst.state, dst.width);
+  }
+}
+
+struct PlaneAccess {
+  template <PackedShape Shape, Signedness Signed>
+  static auto MutableValue(Bit<Shape, Signed>& b) -> std::span<std::uint64_t> {
+    return b.MutableValueWordsForConvert();
+  }
+  template <PackedShape Shape, Signedness Signed>
+  static auto MutableValue(Logic<Shape, Signed>& l)
+      -> std::span<std::uint64_t> {
+    return l.MutableValueWordsForConvert();
+  }
+  template <PackedShape Shape, Signedness Signed>
+  static auto MutableState(Logic<Shape, Signed>& l)
+      -> std::span<std::uint64_t> {
+    return l.MutableStateWordsForConvert();
+  }
+
+  static auto ValueWords(ConstBitView v) -> std::span<const std::uint64_t> {
+    if (v.BitOffsetForConvert() != 0U) {
+      throw InternalError(
+          "PlaneAccess::ValueWords: ConstBitView with non-zero bit_offset is "
+          "not supported");
+    }
+    return v.WordsForConvert();
+  }
+  static auto ValueWords(ConstLogicView v) -> std::span<const std::uint64_t> {
+    if (v.BitOffsetForConvert() != 0U) {
+      throw InternalError(
+          "PlaneAccess::ValueWords: ConstLogicView with non-zero bit_offset "
+          "is not supported");
+    }
+    return v.ValueWordsForConvert();
+  }
+  static auto StateWords(ConstLogicView v) -> std::span<const std::uint64_t> {
+    if (v.BitOffsetForConvert() != 0U) {
+      throw InternalError(
+          "PlaneAccess::StateWords: ConstLogicView with non-zero bit_offset "
+          "is not supported");
+    }
+    return v.StateWordsForConvert();
+  }
+};
+
+}  // namespace detail
+
+template <PackedShape TargetShape, Signedness TargetSigned>
+auto ConvertToBit(ConstBitView src, Signedness src_signedness)
+    -> Bit<TargetShape, TargetSigned> {
+  Bit<TargetShape, TargetSigned> out;
+  detail::ConvertPackedBits(
+      detail::ConversionTarget{
+          .value = detail::PlaneAccess::MutableValue(out),
+          .state = {},
+          .width = TargetShape.TotalWidth(),
+          .four_state = false,
+      },
+      detail::ConversionSource{
+          .value = detail::PlaneAccess::ValueWords(src),
+          .state = {},
+          .width = src.Width(),
+          .signedness = src_signedness,
+          .four_state = false,
+      });
+  return out;
+}
+
+template <PackedShape TargetShape, Signedness TargetSigned>
+auto ConvertToBit(ConstLogicView src, Signedness src_signedness)
+    -> Bit<TargetShape, TargetSigned> {
+  Bit<TargetShape, TargetSigned> out;
+  detail::ConvertPackedBits(
+      detail::ConversionTarget{
+          .value = detail::PlaneAccess::MutableValue(out),
+          .state = {},
+          .width = TargetShape.TotalWidth(),
+          .four_state = false,
+      },
+      detail::ConversionSource{
+          .value = detail::PlaneAccess::ValueWords(src),
+          .state = detail::PlaneAccess::StateWords(src),
+          .width = src.Width(),
+          .signedness = src_signedness,
+          .four_state = true,
+      });
+  return out;
+}
+
+template <PackedShape TargetShape, Signedness TargetSigned>
+auto ConvertToLogic(ConstBitView src, Signedness src_signedness)
+    -> Logic<TargetShape, TargetSigned> {
+  Logic<TargetShape, TargetSigned> out;
+  detail::ConvertPackedBits(
+      detail::ConversionTarget{
+          .value = detail::PlaneAccess::MutableValue(out),
+          .state = detail::PlaneAccess::MutableState(out),
+          .width = TargetShape.TotalWidth(),
+          .four_state = true,
+      },
+      detail::ConversionSource{
+          .value = detail::PlaneAccess::ValueWords(src),
+          .state = {},
+          .width = src.Width(),
+          .signedness = src_signedness,
+          .four_state = false,
+      });
+  return out;
+}
+
+template <PackedShape TargetShape, Signedness TargetSigned>
+auto ConvertToLogic(ConstLogicView src, Signedness src_signedness)
+    -> Logic<TargetShape, TargetSigned> {
+  Logic<TargetShape, TargetSigned> out;
+  detail::ConvertPackedBits(
+      detail::ConversionTarget{
+          .value = detail::PlaneAccess::MutableValue(out),
+          .state = detail::PlaneAccess::MutableState(out),
+          .width = TargetShape.TotalWidth(),
+          .four_state = true,
+      },
+      detail::ConversionSource{
+          .value = detail::PlaneAccess::ValueWords(src),
+          .state = detail::PlaneAccess::StateWords(src),
+          .width = src.Width(),
+          .signedness = src_signedness,
+          .four_state = true,
+      });
+  return out;
+}
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/format.hpp
+++ b/include/lyra/runtime/format.hpp
@@ -52,7 +52,7 @@ struct FormatSpec {
 //     owned storage.
 //   - Wide integral (bit_width > 64): caller owns `uint64_t[word_count]`
 //     arrays for value and (for four-state) state, passed via `value_words`
-//     and `state_words`. Not used by this cut.
+//     and `state_words`.
 struct IntegralValueView {
   IntegralStateKind state = IntegralStateKind::kTwoState;
   std::uint64_t inline_word = 0;

--- a/include/lyra/runtime/packed.hpp
+++ b/include/lyra/runtime/packed.hpp
@@ -113,6 +113,10 @@ template <PackedShape Shape, Signedness Signed = Signedness::kUnsigned>
 class Logic;
 
 namespace detail {
+struct PlaneAccess;  // defined in convert.hpp
+}  // namespace detail
+
+namespace detail {
 
 inline auto ValidateBitRange(
     std::size_t word_count, std::uint64_t bit_offset, std::uint64_t width,
@@ -246,6 +250,15 @@ class ConstBitView {
   }
 
  private:
+  friend struct detail::PlaneAccess;
+
+  [[nodiscard]] auto WordsForConvert() const -> std::span<const std::uint64_t> {
+    return words_;
+  }
+  [[nodiscard]] auto BitOffsetForConvert() const -> std::uint64_t {
+    return bit_offset_;
+  }
+
   std::span<const std::uint64_t> words_;
   std::uint64_t bit_offset_;
   std::uint64_t width_;
@@ -386,6 +399,20 @@ class ConstLogicView {
   }
 
  private:
+  friend struct detail::PlaneAccess;
+
+  [[nodiscard]] auto ValueWordsForConvert() const
+      -> std::span<const std::uint64_t> {
+    return value_words_;
+  }
+  [[nodiscard]] auto StateWordsForConvert() const
+      -> std::span<const std::uint64_t> {
+    return state_words_;
+  }
+  [[nodiscard]] auto BitOffsetForConvert() const -> std::uint64_t {
+    return bit_offset_;
+  }
+
   std::span<const std::uint64_t> value_words_;
   std::span<const std::uint64_t> state_words_;
   std::uint64_t bit_offset_;
@@ -548,7 +575,21 @@ class Bit {
     bits_.SetBit(offset, value == TwoStateBit::kOne);
   }
 
+  // Same-width copy; conversion goes through `ConvertToBit`/`ConvertToLogic`.
+  auto Assign(ConstBitView rhs) -> void {
+    View().CopyFromSameWidth(rhs);
+  }
+  auto Assign(BitView rhs) -> void {
+    Assign(rhs.AsConst());
+  }
+
  private:
+  friend struct detail::PlaneAccess;
+
+  [[nodiscard]] auto MutableValueWordsForConvert() -> std::span<std::uint64_t> {
+    return bits_.MutableWordsForView();
+  }
+
   detail::BitPlane<kWidth> bits_{};
 };
 
@@ -637,7 +678,24 @@ class Logic {
     }
   }
 
+  // Same-width copy; conversion goes through `ConvertToLogic`.
+  auto Assign(ConstLogicView rhs) -> void {
+    View().CopyFromSameWidth(rhs);
+  }
+  auto Assign(LogicView rhs) -> void {
+    Assign(rhs.AsConst());
+  }
+
  private:
+  friend struct detail::PlaneAccess;
+
+  [[nodiscard]] auto MutableValueWordsForConvert() -> std::span<std::uint64_t> {
+    return value_.MutableWordsForView();
+  }
+  [[nodiscard]] auto MutableStateWordsForConvert() -> std::span<std::uint64_t> {
+    return state_.MutableWordsForView();
+  }
+
   detail::BitPlane<kWidth> value_{};
   detail::BitPlane<kWidth> state_{};
 };

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -76,12 +76,12 @@ auto RenderBind(
     out += Indent(indent + 2) + RenderProcessKindLiteral(p.kind) + ",\n";
     out += Indent(indent + 2) + RenderProcessMethodName(i) + "());\n";
   }
-  // This cut treats every owning-object member (`OwningPtr<Object<T>>` or
-  // `Vector<OwningPtr<Object<T>>>`) as a runtime-bindable child scope. That
-  // assumption holds because the only producer of these types today is
-  // generate-arm child class installation. When other producers of `ObjectType`
-  // appear (e.g. owned process/module objects), bind eligibility must come
-  // from explicit class metadata, not from storage type structure alone.
+  // Every owning-object member (`OwningPtr<Object<T>>` or
+  // `Vector<OwningPtr<Object<T>>>`) is treated as a runtime-bindable child
+  // scope. The only producer of these types today is generate-arm child
+  // class installation. When other producers of `ObjectType` appear
+  // (e.g. owned process/module objects), bind eligibility must come from
+  // explicit class metadata, not from storage type structure alone.
   for (const auto& m : c.member_vars) {
     const auto target = mir::GetOwnedObjectTarget(unit, m.type);
     if (!target.has_value()) {
@@ -165,6 +165,7 @@ auto RenderClassHeaderFile(
   out += "#include <string>\n";
   out += "#include <vector>\n";
   out += "#include \"lyra/runtime/bind_context.hpp\"\n";
+  out += "#include \"lyra/runtime/convert.hpp\"\n";
   out += "#include \"lyra/runtime/delay.hpp\"\n";
   out += "#include \"lyra/runtime/format.hpp\"\n";
   out += "#include \"lyra/runtime/io.hpp\"\n";

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1,5 +1,7 @@
 #include "lyra/backend/cpp/render_expr.hpp"
 
+#include <cstddef>
+#include <cstdint>
 #include <format>
 #include <string>
 #include <string_view>
@@ -7,11 +9,15 @@
 
 #include "lyra/backend/cpp/render_context.hpp"
 #include "lyra/backend/cpp/render_print.hpp"
+#include "lyra/backend/cpp/render_type.hpp"
 #include "lyra/backend/cpp/string_literal.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/mir/binary_op.hpp"
+#include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/mir/integral_constant.hpp"
+#include "lyra/mir/type.hpp"
 
 namespace lyra::backend::cpp {
 
@@ -32,6 +38,158 @@ auto LookupLocalName(const mir::Body& body, const mir::LocalVarRef& ref)
   return body.local_scopes.at(ref.scope.value).locals.at(ref.local.value).name;
 }
 
+auto SignednessLiteral(mir::Signedness s) -> std::string_view {
+  switch (s) {
+    case mir::Signedness::kSigned:
+      return "lyra::runtime::Signedness::kSigned";
+    case mir::Signedness::kUnsigned:
+      return "lyra::runtime::Signedness::kUnsigned";
+  }
+  throw InternalError("SignednessLiteral: unknown MIR Signedness");
+}
+
+auto IsPackedRuntime(const mir::CompilationUnit& unit, mir::TypeId type_id)
+    -> bool {
+  const auto& t = unit.GetType(type_id);
+  return t.IsPackedArray() &&
+         t.AsPackedArray().form == mir::PackedArrayForm::kExplicit;
+}
+
+auto MirTypeOfLvalue(const RenderContext& ctx, const mir::Lvalue& lv)
+    -> mir::TypeId {
+  return std::visit(
+      Overloaded{
+          [&](const mir::MemberVarRef& m) -> mir::TypeId {
+            return ctx.Class().GetMemberVar(m.target).type;
+          },
+          [&](const mir::LocalVarRef& l) -> mir::TypeId {
+            return ctx.Body()
+                .local_scopes.at(l.scope.value)
+                .locals.at(l.local.value)
+                .type;
+          },
+      },
+      lv);
+}
+
+auto IntegralConstantToInt32(const mir::IntegralConstant& c) -> std::int32_t {
+  if (c.state_kind == mir::IntegralStateKind::kFourState) {
+    throw InternalError(
+        "IntegralConstantToInt32: 4-state literal targeting native int");
+  }
+  if (c.width == 0U || c.width > 32U) {
+    throw InternalError(
+        "IntegralConstantToInt32: invalid native int literal width");
+  }
+  if (c.value_words.empty()) {
+    throw InternalError(
+        "IntegralConstantToInt32: integral constant has no value word");
+  }
+  const std::uint64_t raw = c.value_words[0];
+  if (c.signedness == mir::Signedness::kSigned && c.width < 32U) {
+    const std::uint32_t sign_bit = 1U << (c.width - 1U);
+    const std::uint32_t low =
+        static_cast<std::uint32_t>(raw) & ((std::uint32_t{1} << c.width) - 1U);
+    if ((low & sign_bit) != 0U) {
+      const std::uint32_t fill = ~((1U << c.width) - 1U);
+      return static_cast<std::int32_t>(low | fill);
+    }
+    return static_cast<std::int32_t>(low);
+  }
+  return static_cast<std::int32_t>(static_cast<std::uint32_t>(raw));
+}
+
+auto RenderNativeIntegerLiteral(const mir::IntegralConstant& c) -> std::string {
+  return std::format("{}", IntegralConstantToInt32(c));
+}
+
+auto RenderIntegerLiteralAsView(
+    const mir::CompilationUnit& unit, mir::TypeId type_id,
+    const mir::IntegralConstant& c) -> std::string {
+  const auto& pa = unit.GetType(type_id).AsPackedArray();
+  const bool target_4state = pa.IsFourState();
+  const std::uint64_t target_width = pa.BitWidth();
+
+  if (c.width != static_cast<std::uint32_t>(target_width)) {
+    throw InternalError(
+        "RenderIntegerLiteralAsView: literal width does not match target "
+        "type width");
+  }
+  if (!target_4state && c.state_kind == mir::IntegralStateKind::kFourState) {
+    throw InternalError(
+        "RenderIntegerLiteralAsView: 4-state literal targeting 2-state type");
+  }
+
+  const std::size_t target_words =
+      (static_cast<std::size_t>(target_width) + 63U) / 64U;
+
+  std::string value_init;
+  for (std::size_t i = 0; i < target_words; ++i) {
+    if (i != 0) value_init += ", ";
+    const std::uint64_t w = i < c.value_words.size() ? c.value_words[i] : 0U;
+    value_init += std::format("0x{:x}ULL", w);
+  }
+
+  std::string out = "([&]() -> lyra::runtime::";
+  out += target_4state ? "ConstLogicView" : "ConstBitView";
+  out += " {\n";
+  out += std::format(
+      "  static constexpr std::array<std::uint64_t, {}> kValueWords = "
+      "{{{}}};\n",
+      target_words, value_init);
+  if (target_4state) {
+    std::string state_init;
+    for (std::size_t i = 0; i < target_words; ++i) {
+      if (i != 0) state_init += ", ";
+      const std::uint64_t w =
+          (c.state_kind == mir::IntegralStateKind::kFourState &&
+           i < c.state_words.size())
+              ? c.state_words[i]
+              : 0U;
+      state_init += std::format("0x{:x}ULL", w);
+    }
+    out += std::format(
+        "  static constexpr std::array<std::uint64_t, {}> kStateWords = "
+        "{{{}}};\n",
+        target_words, state_init);
+    out += std::format(
+        "  return lyra::runtime::ConstLogicView{{kValueWords, kStateWords, 0, "
+        "{}}};\n",
+        target_width);
+  } else {
+    out += std::format(
+        "  return lyra::runtime::ConstBitView{{kValueWords, 0, {}}};\n",
+        target_width);
+  }
+  out += "}())";
+  return out;
+}
+
+auto RenderConversionCall(
+    const RenderContext& ctx, mir::TypeId target_type,
+    const mir::ConversionExpr& conv) -> std::string {
+  const auto& target = ctx.Unit().GetType(target_type).AsPackedArray();
+  const auto& operand_expr = ctx.Expr(conv.operand);
+  const auto& source_type = ctx.Unit().GetType(operand_expr.type);
+  if (!source_type.IsPackedArray() ||
+      source_type.AsPackedArray().form != mir::PackedArrayForm::kExplicit) {
+    throw InternalError(
+        "RenderConversionCall: ConversionExpr operand must be a packed "
+        "explicit type");
+  }
+  const auto& source = source_type.AsPackedArray();
+
+  const std::string operand_view = RenderExprAsRuntimeView(ctx, operand_expr);
+  const std::string target_shape = RenderPackedShapeLiteral(target.dims);
+
+  const char* fn = target.IsFourState() ? "lyra::runtime::ConvertToLogic"
+                                        : "lyra::runtime::ConvertToBit";
+  return std::format(
+      "{}<{}, {}>({}, {})", fn, target_shape,
+      SignednessLiteral(target.signedness), operand_view,
+      SignednessLiteral(source.signedness));
+}
+
 }  // namespace
 
 auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
@@ -48,42 +206,117 @@ auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
       target);
 }
 
-auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
+auto RenderExprAsNative(const RenderContext& ctx, const mir::Expr& expr)
     -> std::string {
   return std::visit(
       Overloaded{
-          [](const mir::IntegerLiteral& e) -> std::string {
-            return std::format("{}", e.value);
+          [&](const mir::IntegerLiteral& lit) -> std::string {
+            return RenderNativeIntegerLiteral(lit.value);
           },
-          [](const mir::StringLiteral& e) -> std::string {
-            return RenderStdStringLiteral(e.value);
+          [&](const mir::StringLiteral& s) -> std::string {
+            return RenderStdStringLiteral(s.value);
           },
           [](const mir::TimeLiteral&) -> std::string {
             throw InternalError(
                 "backend cpp: TimeLiteral is not yet supported by the C++ "
                 "emitter");
           },
-          [&](const mir::MemberVarRef& e) -> std::string {
-            return ctx.Class().GetMemberVar(e.target).name;
+          [&](const mir::MemberVarRef& m) -> std::string {
+            return ctx.Class().GetMemberVar(m.target).name;
           },
-          [&](const mir::LocalVarRef& e) -> std::string {
-            return LookupLocalName(ctx.Body(), e);
+          [&](const mir::LocalVarRef& l) -> std::string {
+            return LookupLocalName(ctx.Body(), l);
           },
-          [&](const mir::BinaryExpr& e) -> std::string {
-            return "(" + RenderExpr(ctx, ctx.Expr(e.lhs)) +
-                   std::string{BinaryOpToken(e.op)} +
-                   RenderExpr(ctx, ctx.Expr(e.rhs)) + ")";
+          [&](const mir::BinaryExpr& b) -> std::string {
+            return "(" + RenderExprAsNative(ctx, ctx.Expr(b.lhs)) +
+                   std::string{BinaryOpToken(b.op)} +
+                   RenderExprAsNative(ctx, ctx.Expr(b.rhs)) + ")";
           },
-          [&](const mir::AssignExpr& e) -> std::string {
-            return "(" + RenderLvalue(ctx, e.target) + " = " +
-                   RenderExpr(ctx, ctx.Expr(e.value)) + ")";
+          [&](const mir::AssignExpr& a) -> std::string {
+            const auto target_type = MirTypeOfLvalue(ctx, a.target);
+            if (IsPackedRuntime(ctx.Unit(), target_type)) {
+              return std::format(
+                  "{}.Assign({})", RenderLvalue(ctx, a.target),
+                  RenderExprAsRuntimeView(ctx, ctx.Expr(a.value)));
+            }
+            return "(" + RenderLvalue(ctx, a.target) + " = " +
+                   RenderExprAsNative(ctx, ctx.Expr(a.value)) + ")";
+          },
+          [&](const mir::ConversionExpr& cv) -> std::string {
+            return RenderExprAsNative(ctx, ctx.Expr(cv.operand));
           },
           [](const mir::CallExpr&) -> std::string {
             throw InternalError(
-                "RenderExpr: mir::CallExpr lowering to C++ is not implemented");
+                "RenderExprAsNative: mir::CallExpr lowering to C++ is not "
+                "implemented");
           },
           [&](const mir::RuntimeCallExpr& rc) -> std::string {
             return RenderRuntimeCallExpr(ctx, rc);
+          },
+      },
+      expr.data);
+}
+
+auto RenderExprAsRuntimeView(const RenderContext& ctx, const mir::Expr& expr)
+    -> std::string {
+  return std::visit(
+      Overloaded{
+          [&](const mir::IntegerLiteral& lit) -> std::string {
+            return RenderIntegerLiteralAsView(ctx.Unit(), expr.type, lit.value);
+          },
+          [&](const mir::MemberVarRef& m) -> std::string {
+            return std::format(
+                "{}.View()", ctx.Class().GetMemberVar(m.target).name);
+          },
+          [&](const mir::LocalVarRef& l) -> std::string {
+            return std::format("{}.View()", LookupLocalName(ctx.Body(), l));
+          },
+          [&](const mir::ConversionExpr& cv) -> std::string {
+            return std::format(
+                "{}.View()", RenderConversionCall(ctx, expr.type, cv));
+          },
+          [](const mir::AssignExpr&) -> std::string {
+            throw InternalError(
+                "RenderExprAsRuntimeView: AssignExpr in a runtime-view "
+                "context is not yet supported");
+          },
+          [](const auto&) -> std::string {
+            throw InternalError(
+                "RenderExprAsRuntimeView: expression form is not renderable "
+                "as a runtime view");
+          },
+      },
+      expr.data);
+}
+
+auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
+    -> std::string {
+  // Some expressions slang types as packed but read as native rvalues
+  // (e.g. comparisons over native-int operands). Mode is picked per-variant.
+  return std::visit(
+      Overloaded{
+          [&](const mir::IntegerLiteral&) -> std::string {
+            return IsPackedRuntime(ctx.Unit(), expr.type)
+                       ? RenderExprAsRuntimeView(ctx, expr)
+                       : RenderExprAsNative(ctx, expr);
+          },
+          [&](const mir::MemberVarRef&) -> std::string {
+            return IsPackedRuntime(ctx.Unit(), expr.type)
+                       ? RenderExprAsRuntimeView(ctx, expr)
+                       : RenderExprAsNative(ctx, expr);
+          },
+          [&](const mir::LocalVarRef&) -> std::string {
+            return IsPackedRuntime(ctx.Unit(), expr.type)
+                       ? RenderExprAsRuntimeView(ctx, expr)
+                       : RenderExprAsNative(ctx, expr);
+          },
+          [&](const mir::ConversionExpr&) -> std::string {
+            return IsPackedRuntime(ctx.Unit(), expr.type)
+                       ? RenderExprAsRuntimeView(ctx, expr)
+                       : RenderExprAsNative(ctx, expr);
+          },
+          [&](const auto&) -> std::string {
+            return RenderExprAsNative(ctx, expr);
           },
       },
       expr.data);

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -63,28 +63,25 @@ auto RenderFormatSpecInit(const mir::FormatSpec& spec) -> std::string {
       BoolLiteral(spec.modifiers.left_align), spec.timeunit_power);
 }
 
-// Render a value operand into an inline `RuntimeValueView` constructor call.
-// `int`/`integer` (which render as native std::int32_t) take the inline-word
-// `NarrowIntegral` factory. Explicit packed `bit`/`logic`/`reg` (which render
-// as runtime Bit<...>/Logic<...>) take the view-based factories so the print
-// path goes through the runtime type's own `View()` API rather than casting
-// the value to uint64_t.
 auto RenderRuntimeValueViewInit(
     const RenderContext& ctx, const mir::RuntimePrintValue& v) -> std::string {
   const auto& type = ctx.Unit().GetType(v.type);
-  const std::string operand = RenderExpr(ctx, ctx.Expr(v.value));
+
+  // `%s` operands are typed as packed bit vectors by slang but reach the
+  // runtime as a string_view. Dispatch on format kind, not just type.
+  if (v.spec.kind == mir::FormatKind::kString) {
+    const std::string operand = RenderExprAsNative(ctx, ctx.Expr(v.value));
+    return std::format("lyra::runtime::RuntimeValueView::String({})", operand);
+  }
 
   if (type.IsPackedArray()) {
     const auto& pa = type.AsPackedArray();
     const std::uint64_t bit_width = pa.BitWidth();
-    if (bit_width > 64) {
-      throw InternalError(
-          "RenderRuntimeValueViewInit: wide integrals not implemented");
-    }
     const bool is_signed = pa.signedness == mir::Signedness::kSigned;
 
     if (pa.form == mir::PackedArrayForm::kInt ||
         pa.form == mir::PackedArrayForm::kInteger) {
+      const std::string operand = RenderExprAsNative(ctx, ctx.Expr(v.value));
       return std::format(
           "lyra::runtime::RuntimeValueView::NarrowIntegral("
           "static_cast<std::uint64_t>({}), {}, {})",
@@ -92,16 +89,24 @@ auto RenderRuntimeValueViewInit(
     }
 
     if (pa.form == mir::PackedArrayForm::kExplicit) {
+      if (bit_width > 64) {
+        throw InternalError(
+            "RenderRuntimeValueViewInit: wide integral display is not yet "
+            "supported");
+      }
+      const std::string operand_view =
+          RenderExprAsRuntimeView(ctx, ctx.Expr(v.value));
       const char* factory =
           pa.IsFourState() ? "lyra::runtime::RuntimeValueView::FromLogicView"
                            : "lyra::runtime::RuntimeValueView::FromBitView";
       return std::format(
-          "{}({}.View(), {})", factory, operand, BoolLiteral(is_signed));
+          "{}({}, {})", factory, operand_view, BoolLiteral(is_signed));
     }
     throw InternalError(
         "RenderRuntimeValueViewInit: unsupported PackedArrayForm");
   }
   if (type.Kind() == mir::TypeKind::kString) {
+    const std::string operand = RenderExprAsNative(ctx, ctx.Expr(v.value));
     return std::format("lyra::runtime::RuntimeValueView::String({})", operand);
   }
   throw InternalError(

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -14,8 +14,6 @@
 
 namespace lyra::backend::cpp {
 
-namespace {
-
 auto RenderPackedShapeLiteral(const std::vector<mir::PackedRange>& dims)
     -> std::string {
   if (dims.empty()) {
@@ -40,8 +38,6 @@ auto RenderPackedShapeLiteral(const std::vector<mir::PackedRange>& dims)
   out += "} }";
   return out;
 }
-
-}  // namespace
 
 auto RenderTypeAsCpp(
     const mir::CompilationUnit& unit, const mir::ClassDecl& owner_class,

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -109,12 +109,6 @@ constexpr std::array kEntries{
             .category = UnsupportedCategory::kFeature,
             .name = "unsupported_structural_expression_form"}},
     std::pair{
-        DiagCode::kUnsupportedIntegerLiteralWidth,
-        DiagCodeInfo{
-            .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
-            .name = "unsupported_integer_literal_width"}},
-    std::pair{
         DiagCode::kUnsupportedNonVariableNamedReference,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -209,11 +209,52 @@ class HirDumper {
     throw InternalError("HirDumper::FormatTimeScale: unknown TimeScale");
   }
 
+  static auto FormatLiteralBase(IntegerLiteralBase b) -> std::string_view {
+    switch (b) {
+      case IntegerLiteralBase::kBinary:
+        return "b";
+      case IntegerLiteralBase::kOctal:
+        return "o";
+      case IntegerLiteralBase::kDecimal:
+        return "d";
+      case IntegerLiteralBase::kHexadecimal:
+        return "h";
+      case IntegerLiteralBase::kUnbased:
+        return "unbased";
+    }
+    throw InternalError("HirDumper::FormatLiteralBase: unknown base");
+  }
+
+  static auto FormatIntegralConstant(const IntegralConstant& c) -> std::string {
+    std::string out = std::format(
+        "{}'{}", c.width, c.signedness == Signedness::kSigned ? 's' : 'u');
+    if (c.state_kind == IntegralStateKind::kFourState) {
+      out += "(four-state)";
+    }
+    out += "{value=";
+    for (std::size_t i = 0; i < c.value_words.size(); ++i) {
+      if (i != 0) out += ',';
+      out += std::format("0x{:x}", c.value_words[i]);
+    }
+    if (c.state_kind == IntegralStateKind::kFourState) {
+      out += ", state=";
+      for (std::size_t i = 0; i < c.state_words.size(); ++i) {
+        if (i != 0) out += ',';
+        out += std::format("0x{:x}", c.state_words[i]);
+      }
+    }
+    out += "}";
+    return out;
+  }
+
   static auto FormatPrimary(const Primary& p) -> std::string {
     return std::visit(
         Overloaded{
             [](const IntegerLiteral& lit) -> std::string {
-              return std::format("IntegerLiteral({})", lit.value);
+              return std::format(
+                  "IntegerLiteral(base={}, unsized={}, {})",
+                  FormatLiteralBase(lit.base), lit.declared_unsized,
+                  FormatIntegralConstant(lit.value));
             },
             [](const StringLiteral& lit) -> std::string {
               return std::format("StringLiteral(\"{}\")", lit.value);
@@ -240,6 +281,22 @@ class HirDumper {
             },
         },
         tc);
+  }
+
+  static auto FormatConversionKind(ConversionKind k) -> std::string_view {
+    switch (k) {
+      case ConversionKind::kImplicit:
+        return "implicit";
+      case ConversionKind::kPropagated:
+        return "propagated";
+      case ConversionKind::kStreamingConcat:
+        return "streaming-concat";
+      case ConversionKind::kExplicit:
+        return "explicit";
+      case ConversionKind::kBitstreamCast:
+        return "bitstream-cast";
+    }
+    throw InternalError("HirDumper::FormatConversionKind: unknown kind");
   }
 
   [[nodiscard]] auto FormatSubroutineRef(const SubroutineRef& callee) const
@@ -271,21 +328,21 @@ class HirDumper {
     return *scope_stack_[scope_stack_.size() - 1 - hops.value];
   }
 
-  [[nodiscard]] auto FormatExprData(const ExprData& data) const -> std::string {
-    return std::visit(
+  [[nodiscard]] auto FormatExpr(const Expr& e) const -> std::string {
+    std::string body = std::visit(
         Overloaded{
             [](const PrimaryExpr& p) -> std::string {
               return FormatPrimary(p.data);
             },
             [](const BinaryExpr& b) -> std::string {
               return std::format(
-                  "BinaryExpr op={} lhs=Expr[{}] rhs=Expr[{}] type=Type[{}]",
-                  FormatBinaryOp(b.op), b.lhs.value, b.rhs.value, b.type.value);
+                  "BinaryExpr op={} lhs=Expr[{}] rhs=Expr[{}]",
+                  FormatBinaryOp(b.op), b.lhs.value, b.rhs.value);
             },
             [](const AssignExpr& a) -> std::string {
               return std::format(
-                  "AssignExpr lhs=Expr[{}] rhs=Expr[{}] type=Type[{}]",
-                  a.lhs.value, a.rhs.value, a.type.value);
+                  "AssignExpr lhs=Expr[{}] rhs=Expr[{}]", a.lhs.value,
+                  a.rhs.value);
             },
             [this](const CallExpr& c) -> std::string {
               std::string args;
@@ -296,21 +353,27 @@ class HirDumper {
                 args += std::format("Expr[{}]", c.arguments[i].value);
               }
               return std::format(
-                  "CallExpr callee={} args=[{}] type=Type[{}]",
-                  FormatSubroutineRef(c.callee), args, c.result_type.value);
+                  "CallExpr callee={} args=[{}]", FormatSubroutineRef(c.callee),
+                  args);
+            },
+            [](const ConversionExpr& cv) -> std::string {
+              return std::format(
+                  "ConversionExpr kind={} operand=Expr[{}]",
+                  FormatConversionKind(cv.kind), cv.operand.value);
             },
         },
-        data);
+        e.data);
+    return std::format("type=Type[{}] {}", e.type.value, body);
   }
 
   [[nodiscard]] auto FormatProcExpr(const Process& p, ExprId id) const
       -> std::string {
-    return FormatExprData(p.exprs.at(id.value).data);
+    return FormatExpr(p.exprs.at(id.value));
   }
 
   [[nodiscard]] auto FormatScopeExpr(const StructuralScope& s, ExprId id) const
       -> std::string {
-    return FormatExprData(s.GetExpr(id).data);
+    return FormatExpr(s.GetExpr(id));
   }
 
   void DumpUnit(const ModuleUnit& u) {
@@ -360,7 +423,7 @@ class HirDumper {
       Line("Exprs:");
       Indent();
       for (std::size_t i = 0; i < s.exprs.size(); ++i) {
-        Line(std::format("Expr[{}] {}", i, FormatExprData(s.exprs[i].data)));
+        Line(std::format("Expr[{}] {}", i, FormatExpr(s.exprs[i])));
       }
       Dedent();
     }
@@ -396,7 +459,7 @@ class HirDumper {
       Line("Exprs:");
       Indent();
       for (std::size_t i = 0; i < p.exprs.size(); ++i) {
-        Line(std::format("Expr[{}] {}", i, FormatExprData(p.exprs[i].data)));
+        Line(std::format("Expr[{}] {}", i, FormatExpr(p.exprs[i])));
       }
       Dedent();
     }

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -1,6 +1,5 @@
 #include "lyra/lowering/ast_to_hir/expression/lower.hpp"
 
-#include <cstdint>
 #include <expected>
 #include <string>
 #include <string_view>
@@ -21,10 +20,12 @@
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/numeric/SVInt.h>
 #include <slang/numeric/Time.h>
+#include <slang/syntax/AllSyntax.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/binary_op.hpp"
+#include "lyra/hir/conversion.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/inspect.hpp"
 #include "lyra/hir/primary.hpp"
@@ -32,6 +33,7 @@
 #include "lyra/hir/type.hpp"
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
+#include "lyra/lowering/ast_to_hir/integral_constant.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
 #include "lyra/lowering/ast_to_hir/type.hpp"
 #include "lyra/support/system_subroutine.hpp"
@@ -40,33 +42,84 @@ namespace lyra::lowering::ast_to_hir {
 
 namespace {
 
-auto LowerIntegerLiteralValue(
-    const UnitLoweringFacts& unit_facts,
-    const slang::ast::IntegerLiteral& literal) -> diag::Result<std::int64_t> {
-  const auto value = literal.getValue().as<std::int64_t>();
-  if (!value.has_value()) {
-    return diag::Unsupported(
-        unit_facts.SourceMapper().SpanOf(literal.sourceRange),
-        diag::DiagCode::kUnsupportedIntegerLiteralWidth,
-        "integer literal does not fit in a 64-bit signed integer",
-        diag::UnsupportedCategory::kFeature);
+auto LowerSlangLiteralBase(const slang::syntax::SyntaxNode* syntax)
+    -> hir::IntegerLiteralBase {
+  if (syntax != nullptr &&
+      syntax->kind == slang::syntax::SyntaxKind::IntegerVectorExpression) {
+    const auto& iv = syntax->as<slang::syntax::IntegerVectorExpressionSyntax>();
+    switch (iv.base.numericFlags().base()) {
+      case slang::LiteralBase::Binary:
+        return hir::IntegerLiteralBase::kBinary;
+      case slang::LiteralBase::Octal:
+        return hir::IntegerLiteralBase::kOctal;
+      case slang::LiteralBase::Decimal:
+        return hir::IntegerLiteralBase::kDecimal;
+      case slang::LiteralBase::Hex:
+        return hir::IntegerLiteralBase::kHexadecimal;
+    }
   }
-  return *value;
+  return hir::IntegerLiteralBase::kDecimal;
 }
 
-auto MakeLiteralExpr(std::int64_t v, diag::SourceSpan span) -> hir::Expr {
-  return hir::Expr{
-      .data = hir::PrimaryExpr{.data = hir::IntegerLiteral{.value = v}},
-      .span = span};
+auto LowerConversionKind(slang::ast::ConversionKind k) -> hir::ConversionKind {
+  switch (k) {
+    case slang::ast::ConversionKind::Implicit:
+      return hir::ConversionKind::kImplicit;
+    case slang::ast::ConversionKind::Propagated:
+      return hir::ConversionKind::kPropagated;
+    case slang::ast::ConversionKind::StreamingConcat:
+      return hir::ConversionKind::kStreamingConcat;
+    case slang::ast::ConversionKind::Explicit:
+      return hir::ConversionKind::kExplicit;
+    case slang::ast::ConversionKind::BitstreamCast:
+      return hir::ConversionKind::kBitstreamCast;
+  }
+  throw InternalError("LowerConversionKind: unknown slang ConversionKind");
 }
 
-auto MakeStringLiteralExpr(std::string text, diag::SourceSpan span)
-    -> hir::Expr {
+auto MakeIntegerLiteralExpr(
+    const slang::ast::IntegerLiteral& lit, hir::TypeId type,
+    diag::SourceSpan span) -> hir::Expr {
   return hir::Expr{
+      .type = type,
+      .data =
+          hir::PrimaryExpr{
+              .data =
+                  hir::IntegerLiteral{
+                      .value = LowerSVIntToIntegralConstant(lit.getValue()),
+                      .base = LowerSlangLiteralBase(lit.syntax),
+                      .declared_unsized = lit.isDeclaredUnsized,
+                  }},
+      .span = span,
+  };
+}
+
+auto MakeUnbasedUnsizedLiteralExpr(
+    const slang::ast::UnbasedUnsizedIntegerLiteral& lit, hir::TypeId type,
+    diag::SourceSpan span) -> hir::Expr {
+  return hir::Expr{
+      .type = type,
+      .data =
+          hir::PrimaryExpr{
+              .data =
+                  hir::IntegerLiteral{
+                      .value = LowerSVIntToIntegralConstant(lit.getValue()),
+                      .base = hir::IntegerLiteralBase::kUnbased,
+                      .declared_unsized = true,
+                  }},
+      .span = span,
+  };
+}
+
+auto MakeStringLiteralExpr(
+    std::string text, hir::TypeId type, diag::SourceSpan span) -> hir::Expr {
+  return hir::Expr{
+      .type = type,
       .data =
           hir::PrimaryExpr{
               .data = hir::StringLiteral{.value = std::move(text)}},
-      .span = span};
+      .span = span,
+  };
 }
 
 auto LowerTimeUnit(slang::TimeUnit u) -> hir::TimeScale {
@@ -88,18 +141,24 @@ auto LowerTimeUnit(slang::TimeUnit u) -> hir::TimeScale {
 }
 
 auto MakeTimeLiteralExpr(
-    double value, hir::TimeScale scale, diag::SourceSpan span) -> hir::Expr {
+    double value, hir::TimeScale scale, hir::TypeId type, diag::SourceSpan span)
+    -> hir::Expr {
   return hir::Expr{
+      .type = type,
       .data =
           hir::PrimaryExpr{
               .data = hir::TimeLiteral{.value = value, .scale = scale}},
-      .span = span};
+      .span = span,
+  };
 }
 
-auto MakeRefExpr(hir::ValueRef ref, diag::SourceSpan span) -> hir::Expr {
+auto MakeRefExpr(hir::ValueRef ref, hir::TypeId type, diag::SourceSpan span)
+    -> hir::Expr {
   return hir::Expr{
+      .type = type,
       .data = hir::PrimaryExpr{.data = hir::RefExpr{.target = std::move(ref)}},
-      .span = span};
+      .span = span,
+  };
 }
 
 auto FromSlangSubroutineKind(slang::ast::SubroutineKind k)
@@ -125,7 +184,7 @@ auto MakeReturnConventionType(
 
 auto LowerNamedValueProc(
     const UnitLoweringFacts& unit_facts, const UnitLoweringState& unit_state,
-    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const ProcessLoweringState& proc_state, const ScopeStack& stack,
     const slang::ast::NamedValueExpression& named) -> diag::Result<hir::Expr> {
   const auto& mapper = unit_facts.SourceMapper();
   const auto span = mapper.SpanOf(named.sourceRange);
@@ -138,7 +197,8 @@ auto LowerNamedValueProc(
   const auto& var = named.symbol.as<slang::ast::VariableSymbol>();
 
   if (auto local = proc_state.LookupLocalVar(var)) {
-    return MakeRefExpr(hir::LocalVarRef{.target = *local}, span);
+    const hir::TypeId type_id = proc_state.GetLocalVarType(*local);
+    return MakeRefExpr(hir::LocalVarRef{.target = *local}, type_id, span);
   }
 
   const auto binding = unit_state.LookupMemberVarBinding(var);
@@ -154,7 +214,7 @@ auto LowerNamedValueProc(
   return MakeRefExpr(
       hir::MemberVarRef{
           .parent_scope_hops = *hops, .target = binding->local_id},
-      span);
+      binding->type, span);
 }
 
 }  // namespace
@@ -184,27 +244,56 @@ auto LowerProcExpr(
 
   switch (expr.kind) {
     case slang::ast::ExpressionKind::IntegerLiteral: {
-      auto v = LowerIntegerLiteralValue(
-          unit_facts, expr.as<slang::ast::IntegerLiteral>());
-      if (!v) return std::unexpected(std::move(v.error()));
-      return MakeLiteralExpr(*v, span);
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return MakeIntegerLiteralExpr(
+          expr.as<slang::ast::IntegerLiteral>(), *type_id, span);
+    }
+
+    case slang::ast::ExpressionKind::UnbasedUnsizedIntegerLiteral: {
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return MakeUnbasedUnsizedLiteralExpr(
+          expr.as<slang::ast::UnbasedUnsizedIntegerLiteral>(), *type_id, span);
     }
 
     case slang::ast::ExpressionKind::StringLiteral: {
       const auto& sl = expr.as<slang::ast::StringLiteral>();
-      return MakeStringLiteralExpr(std::string{sl.getValue()}, span);
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return MakeStringLiteralExpr(std::string{sl.getValue()}, *type_id, span);
     }
 
     case slang::ast::ExpressionKind::TimeLiteral: {
       const auto& tl = expr.as<slang::ast::TimeLiteral>();
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
       return MakeTimeLiteralExpr(
-          tl.getValue(), LowerTimeUnit(tl.getScale().base.unit), span);
+          tl.getValue(), LowerTimeUnit(tl.getScale().base.unit), *type_id,
+          span);
     }
 
     case slang::ast::ExpressionKind::NamedValue:
       return LowerNamedValueProc(
           unit_facts, unit_state, proc_state, stack,
           expr.as<slang::ast::NamedValueExpression>());
+
+    case slang::ast::ExpressionKind::Conversion: {
+      const auto& conv = expr.as<slang::ast::ConversionExpression>();
+      auto operand_id = append_child(conv.operand());
+      if (!operand_id) return std::unexpected(std::move(operand_id.error()));
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return hir::Expr{
+          .type = *type_id,
+          .data =
+              hir::ConversionExpr{
+                  .operand = *operand_id,
+                  .kind = LowerConversionKind(conv.conversionKind),
+              },
+          .span = span,
+      };
+    }
 
     case slang::ast::ExpressionKind::BinaryOp: {
       const auto& bin = expr.as<slang::ast::BinaryExpression>();
@@ -221,13 +310,15 @@ auto LowerProcExpr(
       auto type_id = type_id_of(expr);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return hir::Expr{
+          .type = *type_id,
           .data =
               hir::BinaryExpr{
                   .op = hir::BinaryOp::kAdd,
                   .lhs = *lhs_id,
                   .rhs = *rhs_id,
-                  .type = *type_id},
-          .span = span};
+              },
+          .span = span,
+      };
     }
 
     case slang::ast::ExpressionKind::Call: {
@@ -270,12 +361,14 @@ auto LowerProcExpr(
         const auto result_type =
             MakeReturnConventionType(unit_state, desc->result_conv);
         return hir::Expr{
+            .type = result_type,
             .data =
                 hir::CallExpr{
                     .callee = hir::SystemSubroutineRef{.id = desc->id},
                     .arguments = std::move(arg_ids),
-                    .result_type = result_type},
-            .span = span};
+                },
+            .span = span,
+        };
       }
 
       const auto* sym =
@@ -301,14 +394,16 @@ auto LowerProcExpr(
         return std::unexpected(std::move(result_type.error()));
       }
       return hir::Expr{
+          .type = *result_type,
           .data =
               hir::CallExpr{
                   .callee =
                       hir::UserSubroutineRef{
                           .parent_scope_hops = *hops, .id = binding->local_id},
                   .arguments = std::move(arg_ids),
-                  .result_type = *result_type},
-          .span = span};
+              },
+          .span = span,
+      };
     }
 
     case slang::ast::ExpressionKind::Assignment: {
@@ -342,9 +437,10 @@ auto LowerProcExpr(
       auto type_id = type_id_of(expr);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return hir::Expr{
-          .data =
-              hir::AssignExpr{.lhs = lhs_id, .rhs = *rhs_id, .type = *type_id},
-          .span = span};
+          .type = *type_id,
+          .data = hir::AssignExpr{.lhs = lhs_id, .rhs = *rhs_id},
+          .span = span,
+      };
     }
 
     default:
@@ -356,17 +452,29 @@ auto LowerProcExpr(
 }
 
 auto LowerStructuralExpr(
-    const UnitLoweringFacts& unit_facts, const slang::ast::Expression& expr)
-    -> diag::Result<hir::Expr> {
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    const slang::ast::Expression& expr) -> diag::Result<hir::Expr> {
   const auto& mapper = unit_facts.SourceMapper();
   const auto span = mapper.SpanOf(expr.sourceRange);
+  auto type_id_of =
+      [&](const slang::ast::Expression& e) -> diag::Result<hir::TypeId> {
+    auto td = LowerTypeData(*e.type, mapper.SpanOf(e.sourceRange));
+    if (!td) return std::unexpected(std::move(td.error()));
+    return unit_state.AddType(*std::move(td));
+  };
 
   switch (expr.kind) {
     case slang::ast::ExpressionKind::IntegerLiteral: {
-      auto v = LowerIntegerLiteralValue(
-          unit_facts, expr.as<slang::ast::IntegerLiteral>());
-      if (!v) return std::unexpected(std::move(v.error()));
-      return MakeLiteralExpr(*v, span);
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return MakeIntegerLiteralExpr(
+          expr.as<slang::ast::IntegerLiteral>(), *type_id, span);
+    }
+    case slang::ast::ExpressionKind::UnbasedUnsizedIntegerLiteral: {
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return MakeUnbasedUnsizedLiteralExpr(
+          expr.as<slang::ast::UnbasedUnsizedIntegerLiteral>(), *type_id, span);
     }
     default:
       return diag::Unsupported(
@@ -448,10 +556,17 @@ auto LowerLoopHeaderExpr(
 
   switch (expr.kind) {
     case slang::ast::ExpressionKind::IntegerLiteral: {
-      auto v = LowerIntegerLiteralValue(
-          unit_facts, expr.as<slang::ast::IntegerLiteral>());
-      if (!v) return std::unexpected(std::move(v.error()));
-      return MakeLiteralExpr(*v, span);
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return MakeIntegerLiteralExpr(
+          expr.as<slang::ast::IntegerLiteral>(), *type_id, span);
+    }
+
+    case slang::ast::ExpressionKind::UnbasedUnsizedIntegerLiteral: {
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return MakeUnbasedUnsizedLiteralExpr(
+          expr.as<slang::ast::UnbasedUnsizedIntegerLiteral>(), *type_id, span);
     }
 
     case slang::ast::ExpressionKind::NamedValue: {
@@ -470,11 +585,13 @@ auto LowerLoopHeaderExpr(
         return std::unexpected(std::move(loop_var_or.error()));
       }
       if (loop_var_or->has_value()) {
+        const hir::TypeId type_id =
+            scope_state.GetLoopVarDeclType(**loop_var_or);
         return MakeRefExpr(
             hir::LoopVarRef{
                 .parent_scope_hops = hir::ParentScopeHops{.value = 0},
                 .target = **loop_var_or},
-            span);
+            type_id, span);
       }
       const auto binding = unit_state.LookupMemberVarBinding(var);
       if (!binding.has_value()) {
@@ -491,20 +608,24 @@ auto LowerLoopHeaderExpr(
       return MakeRefExpr(
           hir::MemberVarRef{
               .parent_scope_hops = *hops, .target = binding->local_id},
-          span);
+          binding->type, span);
     }
 
     case slang::ast::ExpressionKind::Conversion: {
-      // Slang inserts implicit Conversion nodes when binding loop-header
-      // expressions against the genvar's integer type; unwrap them.
       const auto& conv = expr.as<slang::ast::ConversionExpression>();
-      if (!conv.isImplicit()) {
-        return diag::Unsupported(
-            span, diag::DiagCode::kUnsupportedExpressionForm,
-            "explicit casts are not supported yet",
-            diag::UnsupportedCategory::kOperation);
-      }
-      return lower_child(conv.operand());
+      auto operand_id = add_child(conv.operand());
+      if (!operand_id) return std::unexpected(std::move(operand_id.error()));
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return hir::Expr{
+          .type = *type_id,
+          .data =
+              hir::ConversionExpr{
+                  .operand = *operand_id,
+                  .kind = LowerConversionKind(conv.conversionKind),
+              },
+          .span = span,
+      };
     }
 
     case slang::ast::ExpressionKind::BinaryOp: {
@@ -523,10 +644,10 @@ auto LowerLoopHeaderExpr(
       auto type_id = type_id_of(expr);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return hir::Expr{
-          .data =
-              hir::BinaryExpr{
-                  .op = *op, .lhs = *lhs_id, .rhs = *rhs_id, .type = *type_id},
-          .span = span};
+          .type = *type_id,
+          .data = hir::BinaryExpr{.op = *op, .lhs = *lhs_id, .rhs = *rhs_id},
+          .span = span,
+      };
     }
 
     case slang::ast::ExpressionKind::Assignment: {
@@ -558,9 +679,10 @@ auto LowerLoopHeaderExpr(
       auto type_id = type_id_of(expr);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return hir::Expr{
-          .data =
-              hir::AssignExpr{.lhs = lhs_id, .rhs = *rhs_id, .type = *type_id},
-          .span = span};
+          .type = *type_id,
+          .data = hir::AssignExpr{.lhs = lhs_id, .rhs = *rhs_id},
+          .span = span,
+      };
     }
 
     default:

--- a/src/lyra/lowering/ast_to_hir/generate.cpp
+++ b/src/lyra/lowering/ast_to_hir/generate.cpp
@@ -81,7 +81,7 @@ auto BuildIfGenerate(
         "expressions");
   }
 
-  auto cond_expr = LowerStructuralExpr(unit_facts, *cond);
+  auto cond_expr = LowerStructuralExpr(unit_facts, unit_state, *cond);
   if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
   const hir::ExprId cond_id = parent_state.AddExpr(*std::move(cond_expr));
 
@@ -124,7 +124,7 @@ auto BuildCaseGenerate(
     }
   }
 
-  auto cond_expr = LowerStructuralExpr(unit_facts, *discriminator);
+  auto cond_expr = LowerStructuralExpr(unit_facts, unit_state, *discriminator);
   if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
   const hir::ExprId cond_id = parent_state.AddExpr(*std::move(cond_expr));
 
@@ -140,7 +140,7 @@ auto BuildCaseGenerate(
         labels.reserve(block->caseItemExpressions.size());
         for (const auto* label_expr : block->caseItemExpressions) {
           auto label_expr_lowered =
-              LowerStructuralExpr(unit_facts, *label_expr);
+              LowerStructuralExpr(unit_facts, unit_state, *label_expr);
           if (!label_expr_lowered)
             return std::unexpected(std::move(label_expr_lowered.error()));
           labels.push_back(

--- a/src/lyra/lowering/ast_to_hir/integral_constant.cpp
+++ b/src/lyra/lowering/ast_to_hir/integral_constant.cpp
@@ -1,0 +1,75 @@
+#include "lyra/lowering/ast_to_hir/integral_constant.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "lyra/base/internal_error.hpp"
+
+namespace lyra::lowering::ast_to_hir {
+
+namespace {
+
+constexpr auto WordCount(std::uint32_t width) -> std::size_t {
+  return (static_cast<std::size_t>(width) + 63U) / 64U;
+}
+
+auto MaskTopWord(std::vector<std::uint64_t>& words, std::uint32_t width)
+    -> void {
+  if (words.empty()) {
+    return;
+  }
+  const std::uint32_t tail = width % 64U;
+  if (tail == 0U) {
+    return;
+  }
+  const std::uint64_t mask = (std::uint64_t{1} << tail) - 1U;
+  words.back() &= mask;
+}
+
+}  // namespace
+
+auto LowerSVIntToIntegralConstant(const slang::SVInt& sv)
+    -> hir::IntegralConstant {
+  const std::uint32_t width = sv.getBitWidth();
+  if (width == 0U) {
+    throw InternalError("LowerSVIntToIntegralConstant: zero-width SVInt");
+  }
+  const std::size_t words = WordCount(width);
+  const bool four_state = sv.hasUnknown();
+
+  hir::IntegralConstant out{
+      .value_words = std::vector<std::uint64_t>(words, 0U),
+      .state_words = four_state ? std::vector<std::uint64_t>(words, 0U)
+                                : std::vector<std::uint64_t>{},
+      .width = width,
+      .signedness =
+          sv.isSigned() ? hir::Signedness::kSigned : hir::Signedness::kUnsigned,
+      .state_kind = four_state ? hir::IntegralStateKind::kFourState
+                               : hir::IntegralStateKind::kTwoState,
+  };
+
+  const std::size_t total_words = four_state ? 2U * words : words;
+  const std::span<const std::uint64_t> raw{sv.getRawPtr(), total_words};
+  for (std::size_t i = 0; i < words; ++i) {
+    out.value_words[i] = raw[i];
+  }
+  if (four_state) {
+    // Slang's (v=0,u=1)=X, (v=1,u=1)=Z encoding becomes Lyra's
+    // (v=0,s=1)=Z, (v=1,s=1)=X by XOR-ing value with the unknown plane.
+    for (std::size_t i = 0; i < words; ++i) {
+      const std::uint64_t slang_unknown = raw[words + i];
+      out.state_words[i] = slang_unknown;
+      out.value_words[i] ^= slang_unknown;
+    }
+  }
+
+  MaskTopWord(out.value_words, width);
+  if (four_state) {
+    MaskTopWord(out.state_words, width);
+  }
+  return out;
+}
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -9,8 +9,10 @@
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/binary_op.hpp"
+#include "lyra/hir/conversion.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/inspect.hpp"
+#include "lyra/hir/integral_constant.hpp"
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
@@ -19,7 +21,9 @@
 #include "lyra/lowering/hir_to_mir/lower_system_subroutine.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/binary_op.hpp"
+#include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/mir/integral_constant.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -53,29 +57,73 @@ auto LowerTimeScale(hir::TimeScale s) -> mir::TimeScale {
 
 namespace {
 
+auto LowerSignedness(hir::Signedness s) -> mir::Signedness {
+  switch (s) {
+    case hir::Signedness::kSigned:
+      return mir::Signedness::kSigned;
+    case hir::Signedness::kUnsigned:
+      return mir::Signedness::kUnsigned;
+  }
+  throw InternalError("LowerSignedness: unknown HIR Signedness");
+}
+
+auto LowerStateKind(hir::IntegralStateKind k) -> mir::IntegralStateKind {
+  switch (k) {
+    case hir::IntegralStateKind::kTwoState:
+      return mir::IntegralStateKind::kTwoState;
+    case hir::IntegralStateKind::kFourState:
+      return mir::IntegralStateKind::kFourState;
+  }
+  throw InternalError("LowerStateKind: unknown HIR IntegralStateKind");
+}
+
+auto LowerHirIntegralConstant(const hir::IntegralConstant& c)
+    -> mir::IntegralConstant {
+  return mir::IntegralConstant{
+      .value_words = c.value_words,
+      .state_words = c.state_words,
+      .width = c.width,
+      .signedness = LowerSignedness(c.signedness),
+      .state_kind = LowerStateKind(c.state_kind),
+  };
+}
+
+auto LowerHirConversionKind(hir::ConversionKind k) -> mir::ConversionKind {
+  switch (k) {
+    case hir::ConversionKind::kImplicit:
+      return mir::ConversionKind::kImplicit;
+    case hir::ConversionKind::kPropagated:
+      return mir::ConversionKind::kPropagated;
+    case hir::ConversionKind::kStreamingConcat:
+      return mir::ConversionKind::kStreamingConcat;
+    case hir::ConversionKind::kExplicit:
+      return mir::ConversionKind::kExplicit;
+    case hir::ConversionKind::kBitstreamCast:
+      return mir::ConversionKind::kBitstreamCast;
+  }
+  throw InternalError("LowerHirConversionKind: unknown HIR ConversionKind");
+}
+
 auto LowerMemberVarRefExpr(
-    const ClassLoweringState& class_state, const hir::MemberVarRef& m)
-    -> mir::Expr {
+    const ClassLoweringState& class_state, const hir::MemberVarRef& m,
+    mir::TypeId type) -> mir::Expr {
   const mir::MemberVarId mir_id =
       class_state.TranslateMemberVar(m.parent_scope_hops, m.target);
-  const auto& member = class_state.GetMemberVar(m.parent_scope_hops, mir_id);
-  return mir::Expr{
-      .data = mir::MemberVarRef{.target = mir_id}, .type = member.type};
+  return mir::Expr{.data = mir::MemberVarRef{.target = mir_id}, .type = type};
 }
 
 auto LowerLocalVarRefExpr(
-    const ProcessLoweringState& proc_state, const BodyLoweringState& body_state,
-    const hir::LocalVarRef& l) -> mir::Expr {
+    const ProcessLoweringState& proc_state, const hir::LocalVarRef& l,
+    mir::TypeId type) -> mir::Expr {
   const mir::LocalVarRef ref = proc_state.TranslateLocalVar(l.target);
-  return mir::Expr{.data = ref, .type = body_state.GetLocalVar(ref).type};
+  return mir::Expr{.data = ref, .type = type};
 }
 
 auto LowerLoopVarRefExpr(
-    const ConstructorLoweringState& ctor_state,
-    const BodyLoweringState& body_state, const hir::LoopVarRef& lv)
-    -> mir::Expr {
+    const ConstructorLoweringState& ctor_state, const hir::LoopVarRef& lv,
+    mir::TypeId type) -> mir::Expr {
   const mir::LocalVarRef ref = ctor_state.TranslateLoopVar(lv.target);
-  return mir::Expr{.data = ref, .type = body_state.GetLocalVar(ref).type};
+  return mir::Expr{.data = ref, .type = type};
 }
 
 auto LowerRefAsLvalue(
@@ -132,19 +180,20 @@ auto LowerUserCallee(
 
 auto LowerPrimaryExpr(
     const UnitLoweringState& unit_state, const ClassLoweringState& class_state,
-    const ProcessLoweringState& proc_state, const BodyLoweringState& body_state,
-    const hir::PrimaryExpr& p) -> mir::Expr {
+    const ProcessLoweringState& proc_state, const hir::PrimaryExpr& p,
+    mir::TypeId type) -> mir::Expr {
   return std::visit(
       Overloaded{
           [&](const hir::IntegerLiteral& i) -> mir::Expr {
             return mir::Expr{
-                .data = mir::IntegerLiteral{.value = i.value},
-                .type = unit_state.Builtins().int32};
+                .data =
+                    mir::IntegerLiteral{
+                        .value = LowerHirIntegralConstant(i.value)},
+                .type = type};
           },
           [&](const hir::StringLiteral& s) -> mir::Expr {
             return mir::Expr{
-                .data = mir::StringLiteral{.value = s.value},
-                .type = unit_state.Builtins().string};
+                .data = mir::StringLiteral{.value = s.value}, .type = type};
           },
           [&](const hir::TimeLiteral& t) -> mir::Expr {
             return mir::Expr{
@@ -157,10 +206,10 @@ auto LowerPrimaryExpr(
             return std::visit(
                 Overloaded{
                     [&](const hir::MemberVarRef& m) -> mir::Expr {
-                      return LowerMemberVarRefExpr(class_state, m);
+                      return LowerMemberVarRefExpr(class_state, m, type);
                     },
                     [&](const hir::LocalVarRef& l) -> mir::Expr {
-                      return LowerLocalVarRefExpr(proc_state, body_state, l);
+                      return LowerLocalVarRefExpr(proc_state, l, type);
                     },
                     [](const hir::LoopVarRef&) -> mir::Expr {
                       throw InternalError(
@@ -172,24 +221,25 @@ auto LowerPrimaryExpr(
           },
       },
       p.data);
+  (void)unit_state;
 }
 
 auto LowerPrimaryExpr(
     const UnitLoweringState& unit_state, const ClassLoweringState& class_state,
-    const ConstructorLoweringState& ctor_state,
-    const BodyLoweringState& body_state, const hir::PrimaryExpr& p)
-    -> diag::Result<mir::Expr> {
+    const ConstructorLoweringState& ctor_state, const hir::PrimaryExpr& p,
+    mir::TypeId type) -> diag::Result<mir::Expr> {
   return std::visit(
       Overloaded{
           [&](const hir::IntegerLiteral& i) -> diag::Result<mir::Expr> {
             return mir::Expr{
-                .data = mir::IntegerLiteral{.value = i.value},
-                .type = unit_state.Builtins().int32};
+                .data =
+                    mir::IntegerLiteral{
+                        .value = LowerHirIntegralConstant(i.value)},
+                .type = type};
           },
           [&](const hir::StringLiteral& s) -> diag::Result<mir::Expr> {
             return mir::Expr{
-                .data = mir::StringLiteral{.value = s.value},
-                .type = unit_state.Builtins().string};
+                .data = mir::StringLiteral{.value = s.value}, .type = type};
           },
           [&](const hir::TimeLiteral& t) -> diag::Result<mir::Expr> {
             return mir::Expr{
@@ -202,7 +252,7 @@ auto LowerPrimaryExpr(
             return std::visit(
                 Overloaded{
                     [&](const hir::MemberVarRef& m) -> diag::Result<mir::Expr> {
-                      return LowerMemberVarRefExpr(class_state, m);
+                      return LowerMemberVarRefExpr(class_state, m, type);
                     },
                     [](const hir::LocalVarRef&) -> diag::Result<mir::Expr> {
                       return diag::Unsupported(
@@ -212,13 +262,14 @@ auto LowerPrimaryExpr(
                           diag::UnsupportedCategory::kFeature);
                     },
                     [&](const hir::LoopVarRef& lv) -> diag::Result<mir::Expr> {
-                      return LowerLoopVarRefExpr(ctor_state, body_state, lv);
+                      return LowerLoopVarRefExpr(ctor_state, lv, type);
                     },
                 },
                 r.target);
           },
       },
       p.data);
+  (void)unit_state;
 }
 
 }  // namespace
@@ -228,11 +279,12 @@ auto LowerExpr(
     const ProcessLoweringState& proc_state, BodyLoweringState& body_state,
     const hir::Process& hir_process, const hir::Expr& expr)
     -> diag::Result<mir::Expr> {
+  const mir::TypeId result_type = unit_state.TranslateType(expr.type);
   return std::visit(
       Overloaded{
           [&](const hir::PrimaryExpr& p) -> diag::Result<mir::Expr> {
             return LowerPrimaryExpr(
-                unit_state, class_state, proc_state, body_state, p);
+                unit_state, class_state, proc_state, p, result_type);
           },
           [&](const hir::BinaryExpr& b) -> diag::Result<mir::Expr> {
             auto lhs_or = LowerExpr(
@@ -251,7 +303,7 @@ auto LowerExpr(
                         .op = LowerBinaryOp(b.op),
                         .lhs = lhs_id,
                         .rhs = rhs_id},
-                .type = unit_state.TranslateType(b.type)};
+                .type = result_type};
           },
           [&](const hir::AssignExpr& a) -> diag::Result<mir::Expr> {
             const auto& lhs_expr = hir_process.exprs.at(a.lhs.value);
@@ -271,7 +323,23 @@ auto LowerExpr(
                         .target = LowerRefAsLvalue(
                             class_state, proc_state, ref->get().target),
                         .value = rhs_id},
-                .type = unit_state.TranslateType(a.type)};
+                .type = result_type};
+          },
+          [&](const hir::ConversionExpr& cv) -> diag::Result<mir::Expr> {
+            auto operand_or = LowerExpr(
+                unit_state, class_state, proc_state, body_state, hir_process,
+                hir_process.exprs.at(cv.operand.value));
+            if (!operand_or) {
+              return std::unexpected(std::move(operand_or.error()));
+            }
+            const mir::ExprId operand_id =
+                body_state.AddExpr(*std::move(operand_or));
+            return mir::Expr{
+                .data =
+                    mir::ConversionExpr{
+                        .operand = operand_id,
+                        .kind = LowerHirConversionKind(cv.kind)},
+                .type = result_type};
           },
           [&](const hir::CallExpr& c) -> diag::Result<mir::Expr> {
             return std::visit(
@@ -299,7 +367,7 @@ auto LowerExpr(
                               mir::CallExpr{
                                   .callee = LowerUserCallee(class_state, usr),
                                   .arguments = std::move(args)},
-                          .type = unit_state.TranslateType(c.result_type)};
+                          .type = result_type};
                     },
                 },
                 c.callee);
@@ -313,11 +381,12 @@ auto LowerExpr(
     const ConstructorLoweringState& ctor_state, BodyLoweringState& body_state,
     const hir::StructuralScope& scope, const hir::Expr& expr)
     -> diag::Result<mir::Expr> {
+  const mir::TypeId result_type = unit_state.TranslateType(expr.type);
   return std::visit(
       Overloaded{
           [&](const hir::PrimaryExpr& p) -> diag::Result<mir::Expr> {
             return LowerPrimaryExpr(
-                unit_state, class_state, ctor_state, body_state, p);
+                unit_state, class_state, ctor_state, p, result_type);
           },
           [&](const hir::BinaryExpr& b) -> diag::Result<mir::Expr> {
             auto lhs_or = LowerExpr(
@@ -336,7 +405,7 @@ auto LowerExpr(
                         .op = LowerBinaryOp(b.op),
                         .lhs = lhs_id,
                         .rhs = rhs_id},
-                .type = unit_state.TranslateType(b.type)};
+                .type = result_type};
           },
           [&](const hir::AssignExpr& a) -> diag::Result<mir::Expr> {
             const auto& lhs_expr = scope.GetExpr(a.lhs);
@@ -356,7 +425,23 @@ auto LowerExpr(
                         .target = LowerRefAsLvalue(
                             class_state, ctor_state, ref->get().target),
                         .value = rhs_id},
-                .type = unit_state.TranslateType(a.type)};
+                .type = result_type};
+          },
+          [&](const hir::ConversionExpr& cv) -> diag::Result<mir::Expr> {
+            auto operand_or = LowerExpr(
+                unit_state, class_state, ctor_state, body_state, scope,
+                scope.GetExpr(cv.operand));
+            if (!operand_or) {
+              return std::unexpected(std::move(operand_or.error()));
+            }
+            const mir::ExprId operand_id =
+                body_state.AddExpr(*std::move(operand_or));
+            return mir::Expr{
+                .data =
+                    mir::ConversionExpr{
+                        .operand = operand_id,
+                        .kind = LowerHirConversionKind(cv.kind)},
+                .type = result_type};
           },
           [](const hir::CallExpr&) -> diag::Result<mir::Expr> {
             return diag::Unsupported(

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -5,10 +5,12 @@
 #include <variant>
 #include <vector>
 
+#include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
+#include "lyra/hir/integral_constant.hpp"
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/stmt.hpp"
@@ -21,13 +23,35 @@ namespace lyra::lowering::hir_to_mir {
 
 namespace {
 
+auto IntegralConstantToInt64(const hir::IntegralConstant& c) -> std::int64_t {
+  if (c.state_kind == hir::IntegralStateKind::kFourState) {
+    throw InternalError(
+        "IntegralConstantToInt64: 4-state literal in integer-delay context");
+  }
+  if (c.value_words.empty()) {
+    return 0;
+  }
+  const std::uint64_t raw = c.value_words[0];
+  if (c.signedness == hir::Signedness::kSigned && c.width > 0U &&
+      c.width < 64U) {
+    const std::uint64_t sign_bit = std::uint64_t{1} << (c.width - 1U);
+    if ((raw & sign_bit) != 0U) {
+      const std::uint64_t fill =
+          ~((std::uint64_t{1} << c.width) - std::uint64_t{1});
+      return static_cast<std::int64_t>(raw | fill);
+    }
+  }
+  return static_cast<std::int64_t>(raw);
+}
+
 auto ResolveDelayDuration(
     const DelayTimeResolver& resolver, const hir::Expr& duration)
     -> diag::Result<SimDuration> {
   if (const auto* primary = std::get_if<hir::PrimaryExpr>(&duration.data)) {
     if (const auto* int_lit =
             std::get_if<hir::IntegerLiteral>(&primary->data)) {
-      return resolver.ResolveIntegerDelay(int_lit->value, duration.span);
+      return resolver.ResolveIntegerDelay(
+          IntegralConstantToInt64(int_lit->value), duration.span);
     }
     if (const auto* time_lit = std::get_if<hir::TimeLiteral>(&primary->data)) {
       return resolver.ResolveTimeLiteral(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -263,13 +263,52 @@ class MirDumper {
     return std::format("UserSubroutine[{}] \"{}\"", callee.value, target.name);
   }
 
+  static auto FormatIntegralConstant(const IntegralConstant& c) -> std::string {
+    std::string out = std::format(
+        "{}'{}", c.width, c.signedness == Signedness::kSigned ? 's' : 'u');
+    if (c.state_kind == IntegralStateKind::kFourState) {
+      out += "(four-state)";
+    }
+    out += "{value=";
+    for (std::size_t i = 0; i < c.value_words.size(); ++i) {
+      if (i != 0) out += ',';
+      out += std::format("0x{:x}", c.value_words[i]);
+    }
+    if (c.state_kind == IntegralStateKind::kFourState) {
+      out += ", state=";
+      for (std::size_t i = 0; i < c.state_words.size(); ++i) {
+        if (i != 0) out += ',';
+        out += std::format("0x{:x}", c.state_words[i]);
+      }
+    }
+    out += "}";
+    return out;
+  }
+
+  static auto FormatConversionKind(ConversionKind k) -> std::string_view {
+    switch (k) {
+      case ConversionKind::kImplicit:
+        return "implicit";
+      case ConversionKind::kPropagated:
+        return "propagated";
+      case ConversionKind::kStreamingConcat:
+        return "streaming-concat";
+      case ConversionKind::kExplicit:
+        return "explicit";
+      case ConversionKind::kBitstreamCast:
+        return "bitstream-cast";
+    }
+    throw InternalError("MirDumper::FormatConversionKind: unknown kind");
+  }
+
   [[nodiscard]] auto FormatExpr(const Body& body, ExprId id) const
       -> std::string {
     const auto& e = body.exprs.at(id.value);
     std::string body_str = std::visit(
         Overloaded{
             [](const IntegerLiteral& lit) -> std::string {
-              return std::format("IntegerLiteral({})", lit.value);
+              return std::format(
+                  "IntegerLiteral({})", FormatIntegralConstant(lit.value));
             },
             [](const StringLiteral& lit) -> std::string {
               return std::format("StringLiteral(\"{}\")", lit.value);
@@ -310,6 +349,11 @@ class MirDumper {
             },
             [](const RuntimeCallExpr&) -> std::string {
               return "RuntimeCallExpr";
+            },
+            [](const ConversionExpr& cv) -> std::string {
+              return std::format(
+                  "ConversionExpr kind={} operand=Expr[{}]",
+                  FormatConversionKind(cv.kind), cv.operand.value);
             },
         },
         e.data);

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -81,8 +81,7 @@ void Engine::EnqueueInitialProcesses(RuntimeScope& root) {
         case ProcessKind::kAlwaysComb:
         case ProcessKind::kAlwaysFf:
         case ProcessKind::kFinal:
-          throw InternalError(
-              "Engine::Run: unsupported runtime ProcessKind in this cut");
+          throw InternalError("Engine::Run: ProcessKind is not yet supported");
       }
     });
   });

--- a/src/lyra/runtime/format.cpp
+++ b/src/lyra/runtime/format.cpp
@@ -117,13 +117,12 @@ auto FormatIntegralNarrow(const FormatSpec& spec, const IntegralValueView& v)
 
 // Binary-only 4-state narrow formatter: walks each bit MSB->LSB and emits
 // '0'/'1'/'x'/'z' from the (value, state) plane pair. Decimal/hex/octal of
-// 4-state runtime packed values are not implemented in this cut and throw
-// until a separate formatting investigation defines exact behavior.
+// 4-state runtime packed values are not yet implemented.
 auto FormatIntegralFourStateNarrow(
     const FormatSpec& spec, const IntegralValueView& v) -> std::string {
   if (spec.kind != FormatKind::kBinary) {
     throw InternalError(
-        "FormatIntegralFourStateNarrow: only binary supported in this cut");
+        "FormatIntegralFourStateNarrow: only binary is supported");
   }
   std::string body;
   body.reserve(v.bit_width);
@@ -172,8 +171,8 @@ auto RuntimeValueView::FromBitView(ConstBitView v, bool is_signed)
     -> RuntimeValueView {
   if (v.Width() > 64U) {
     throw InternalError(
-        "RuntimeValueView::FromBitView: wide widths (>64) not supported in "
-        "this cut");
+        "RuntimeValueView::FromBitView: wide widths (>64) are not yet "
+        "supported");
   }
   return RuntimeValueView{
       .data = IntegralValueView{
@@ -189,8 +188,8 @@ auto RuntimeValueView::FromLogicView(ConstLogicView v, bool is_signed)
     -> RuntimeValueView {
   if (v.Width() > 64U) {
     throw InternalError(
-        "RuntimeValueView::FromLogicView: wide widths (>64) not supported in "
-        "this cut");
+        "RuntimeValueView::FromLogicView: wide widths (>64) are not yet "
+        "supported");
   }
   return RuntimeValueView{
       .data = IntegralValueView{
@@ -210,7 +209,7 @@ auto FormatValue(const FormatSpec& spec, const RuntimeValueView& value)
           [&](const IntegralValueView& v) -> std::string {
             if (v.word_count > 1) {
               throw InternalError(
-                  "FormatValue: wide integrals not implemented in this cut");
+                  "FormatValue: wide integrals are not yet implemented");
             }
             switch (v.state) {
               case IntegralStateKind::kTwoState:

--- a/tests/cases/cpp/literal_bit_8/case.yaml
+++ b/tests/cases/cpp/literal_bit_8/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.literal_bit_8
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "10101010\n"

--- a/tests/cases/cpp/literal_bit_8/main.sv
+++ b/tests/cases/cpp/literal_bit_8/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  bit [7:0] b;
+  initial begin
+    b = 8'b10101010;
+    $display("%b", b);
+  end
+endmodule

--- a/tests/cases/cpp/literal_bit_8_flatten/case.yaml
+++ b/tests/cases/cpp/literal_bit_8_flatten/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.literal_bit_8_flatten
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "10000101\n"

--- a/tests/cases/cpp/literal_bit_8_flatten/main.sv
+++ b/tests/cases/cpp/literal_bit_8_flatten/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  bit [7:0] b;
+  initial begin
+    b = 8'b10xz0101;
+    $display("%b", b);
+  end
+endmodule

--- a/tests/cases/cpp/literal_logic_8_four_state/case.yaml
+++ b/tests/cases/cpp/literal_logic_8_four_state/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.literal_logic_8_four_state
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "10xz0101\n"

--- a/tests/cases/cpp/literal_logic_8_four_state/main.sv
+++ b/tests/cases/cpp/literal_logic_8_four_state/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  logic [7:0] l;
+  initial begin
+    l = 8'b10xz0101;
+    $display("%b", l);
+  end
+endmodule

--- a/tests/cases/cpp/literal_logic_packed_2d/case.yaml
+++ b/tests/cases/cpp/literal_logic_packed_2d/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.literal_logic_packed_2d
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "11011110101011011011111011101111\n"

--- a/tests/cases/cpp/literal_logic_packed_2d/main.sv
+++ b/tests/cases/cpp/literal_logic_packed_2d/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  logic [3:0][7:0] p;
+  initial begin
+    p = 32'hdeadbeef;
+    $display("%b", p);
+  end
+endmodule

--- a/tests/cases/cpp/literal_reg_8_four_state/case.yaml
+++ b/tests/cases/cpp/literal_reg_8_four_state/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.literal_reg_8_four_state
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "xxzz0011\n"

--- a/tests/cases/cpp/literal_reg_8_four_state/main.sv
+++ b/tests/cases/cpp/literal_reg_8_four_state/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  reg [7:0] r;
+  initial begin
+    r = 8'bxxzz0011;
+    $display("%b", r);
+  end
+endmodule

--- a/tests/cases/cpp/literal_unbased_unsized/case.yaml
+++ b/tests/cases/cpp/literal_unbased_unsized/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.literal_unbased_unsized
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "00000000\n11111111\nxxxxxxxx\nzzzzzzzz\n"

--- a/tests/cases/cpp/literal_unbased_unsized/main.sv
+++ b/tests/cases/cpp/literal_unbased_unsized/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  logic [7:0] a;
+  logic [7:0] b;
+  logic [7:0] c;
+  logic [7:0] d;
+  initial begin
+    a = '0;
+    b = '1;
+    c = 'x;
+    d = 'z;
+    $display("%b", a);
+    $display("%b", b);
+    $display("%b", c);
+    $display("%b", d);
+  end
+endmodule

--- a/tests/cases/dump/hir_local_assign/case.yaml
+++ b/tests/cases/dump/hir_local_assign/case.yaml
@@ -16,5 +16,5 @@ expect:
       - "AssignExpr"
       - "BinaryExpr op=Add"
       - "RefExpr LocalVar[0]"
-      - "IntegerLiteral(1)"
-      - "IntegerLiteral(2)"
+      - "IntegerLiteral(base=d, unsized=true, 32's{value=0x1})"
+      - "IntegerLiteral(base=d, unsized=true, 32's{value=0x2})"

--- a/tests/cases/dump/hir_timed/case.yaml
+++ b/tests/cases/dump/hir_timed/case.yaml
@@ -12,7 +12,7 @@ expect:
       - "TimedStmt"
       - "DelayControl duration=Expr["
       - "EmptyStmt"
-      - "IntegerLiteral(5)"
+      - "IntegerLiteral(base=d, unsized=true, 32's{value=0x5})"
       - "TimeLiteral(value=5, scale=ns)"
       - "StringLiteral(\"x\")"
       - "StringLiteral(\"ns\")"

--- a/tests/cases/dump/mir_local_assign/case.yaml
+++ b/tests/cases/dump/mir_local_assign/case.yaml
@@ -15,5 +15,5 @@ expect:
       - "ExprStmt"
       - "AssignExpr target=LocalVar[scope=0, local=0]"
       - "BinaryExpr op=Add"
-      - "IntegerLiteral(1)"
-      - "IntegerLiteral(2)"
+      - "IntegerLiteral(32's{value=0x1})"
+      - "IntegerLiteral(32's{value=0x2})"

--- a/tools/policy/check_cpp_style.py
+++ b/tools/policy/check_cpp_style.py
@@ -16,6 +16,15 @@ Rules:
         each other's structure.
         Scope: every header file under src/.
 
+  S003  No migration-progress / development-stage language in comments
+        or string literals. Source must describe its current semantics,
+        never the process by which it was written or its development
+        cadence. Forbidden phrases include "in this cut", "this cut",
+        "future cut", "later cut", "next cut", "previous cut", "Cut N",
+        "sub-commit N", "out of scope", "out-of-scope", "deferred to a
+        later cut". User-visible "not yet supported" wording is the
+        correct replacement. Scope: every .cpp/.hpp under src/, include/.
+
 Usage:
   python3 tools/policy/check_cpp_style.py
 """
@@ -31,9 +40,27 @@ SKIP_PREFIXES = ("archived/", "external/", "bazel-")
 # Match /*name=*/ (parameter label) and /*name*/ (unused-parameter comment).
 PARAM_COMMENT_PATTERN = re.compile(r"/\*[A-Za-z_][A-Za-z0-9_]*=?\*/")
 
+# Forbidden migration-progress / development-stage phrases.
+#
+# `(?i)` -> case-insensitive. `\b` boundaries make the matches token-aware
+# so unrelated words ("scope" alone, "cut" alone) do not trip. The phrases
+# here are the ones called out in CLAUDE.local.md.
+STAGE_LANGUAGE_PATTERNS = [
+    (re.compile(r"(?i)\bin\s+this\s+cut\b"), "in this cut"),
+    (re.compile(r"(?i)\bfor\s+this\s+cut\b"), "for this cut"),
+    (re.compile(r"(?i)\bthis\s+cut\b"), "this cut"),
+    (re.compile(r"(?i)\b(?:future|next|later|previous|earlier)\s+cuts?\b"),
+     "future/later/next/previous/earlier cut"),
+    (re.compile(r"(?i)\bcut\s+\d+\b"), "Cut N"),
+    (re.compile(r"(?i)\bsub-?commit\s+\d+\b"), "sub-commit N"),
+    (re.compile(r"(?i)\bout[\s-]of[\s-]scope\b"), "out of scope"),
+    (re.compile(r"(?i)\bdeferred\s+to\s+a\s+(?:later|future)\b"),
+     "deferred to a later/future"),
+]
 
-def iter_cpp_files(repo_root: Path):
-    for root in ("src", "include", "tests"):
+
+def iter_cpp_files(repo_root: Path, roots=("src", "include", "tests")):
+    for root in roots:
         base = repo_root / root
         if not base.exists():
             continue
@@ -75,6 +102,31 @@ def check_s002(repo_root: Path) -> list[str]:
     return errors
 
 
+def check_s003(repo_root: Path) -> list[str]:
+    """Forbid migration-progress language in src/ and include/.
+
+    Tests are excluded: golden expectations may legitimately mention these
+    phrases when they appear in test fixtures.
+    """
+    errors = []
+    seen_per_line = set()
+    for path, rel in iter_cpp_files(repo_root, roots=("src", "include")):
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            for pattern, label in STAGE_LANGUAGE_PATTERNS:
+                m = pattern.search(line)
+                if m is None:
+                    continue
+                key = (rel, lineno, label)
+                if key in seen_per_line:
+                    continue
+                seen_per_line.add(key)
+                errors.append(
+                    f"  {rel}:{lineno}: S003 stage-language phrase '{m.group(0)}' "
+                    f"(forbidden: {label})"
+                )
+    return errors
+
+
 def run_self_tests() -> bool:
     def expect(cond, msg):
         if not cond:
@@ -90,6 +142,25 @@ def run_self_tests() -> bool:
                  "S001 prose")
     ok &= expect(not PARAM_COMMENT_PATTERN.search("/* a b */"),
                  "S001 multi-token")
+
+    def hits(text):
+        return any(p.search(text) for p, _ in STAGE_LANGUAGE_PATTERNS)
+
+    ok &= expect(hits("not supported in this cut"), "S003 'in this cut'")
+    ok &= expect(hits("for this cut: ..."), "S003 'for this cut'")
+    ok &= expect(hits("a future cut may"), "S003 'future cut'")
+    ok &= expect(hits("// later cuts extend this"), "S003 'later cuts'")
+    ok &= expect(hits("// Cut 1 materializes only X"), "S003 'Cut 1'")
+    ok &= expect(hits("// sub-commit 6 flips the allocator"),
+                 "S003 'sub-commit 6'")
+    ok &= expect(hits("is out of scope"), "S003 'out of scope'")
+    ok &= expect(hits("// out-of-scope"), "S003 'out-of-scope'")
+    ok &= expect(hits("// deferred to a later cut"),
+                 "S003 'deferred to a later cut'")
+    ok &= expect(not hits("// describes a scope"), "S003 'scope' unrelated")
+    ok &= expect(not hits("scope is the lookup unit"),
+                 "S003 'scope' unrelated bare")
+    ok &= expect(not hits("// to cut the loop short"), "S003 'cut' unrelated")
     return ok
 
 
@@ -97,6 +168,7 @@ CHECKS = [
     ("S001 block-comment parameter labels / unused-parameter comments",
      check_s001),
     ("S002 header files under src/", check_s002),
+    ("S003 migration-progress / development-stage language", check_s003),
 ]
 
 


### PR DESCRIPTION
## Summary

The literal pipeline now carries the full slang `SVInt` semantics — width, signedness, two-state vs four-state, X/Z digits — through HIR and MIR instead of collapsing every literal to `int64_t`. `slang::ast::ConversionExpression` is a first-class IR node in both layers; the C++ backend renders packed conversions through new runtime helpers (`ConvertToBit` / `ConvertToLogic`) that operate word-level on `ConstBitView` / `ConstLogicView`. Packed assignments emit as `target.Assign(view)` rather than the previous broken `target = native_int` form.

## Design

- HIR adopts MIR-style wrapper-typed `Expr { type, data, span }`; per-variant type fields collapse into the wrapper. New `IntegralConstant`, `ConversionExpr`, and `IntegerLiteralBase` live per-layer (no shared `common`); the slang↔Lyra X/Z encoding swap happens once in `LowerSVIntToIntegralConstant` at the AST-to-HIR boundary.
- Runtime conversion is the value-operation boundary. `ConvertToBit` / `ConvertToLogic` use word-level helpers (`CopyLowBits`, `AndNotLowBits`, `FillBitRange`, `MaskUnusedTopBits`); per-bit access is reserved for the single sign-bit read. Logic→Logic signed widening replicates four-state sign bits (X/Z extend as X/Z), Logic→Bit flattens X/Z via `value &= ~state`, Bit→Logic clears the state plane.
- C++ emit is context-aware: `RenderLvalue`, `RenderExprAsNative`, and `RenderExprAsRuntimeView` are explicit modes; assignment dispatches on target type; the print path explicitly picks a mode by format kind so `%s` operands route through `RuntimeValueView::String` even when slang types them as packed bit vectors.
- New `tools/policy/check_cpp_style.py` rule **S003** bans migration-progress phrasing (`in this cut`, `future cut`, `out of scope`, `Cut N`, `sub-commit N`, etc.) in `src/`/`include/`. Wired into the existing `cpp-style.yml` workflow.

## Testing

- `bazel test //...` — all six test targets PASSED (cli_emit_cpp_tests, cli_run_tests, cli_golden_tests, three diag suites).
- New SV cases under `tests/cases/cpp/`: `literal_bit_8`, `literal_logic_8_four_state`, `literal_reg_8_four_state`, `literal_logic_packed_2d`, `literal_bit_8_flatten`, `literal_unbased_unsized`.
- Updated dump goldens (`hir_local_assign`, `mir_local_assign`, `hir_timed`) for the richer IntegerLiteral format.
- All policy checks pass: architecture, ASCII, C++ style (S001/S002/S003), exceptions.