### PR TITLE
Support packed variable RHS assignment and conversion

### DIFF
--- a/include/lyra/runtime/convert.hpp
+++ b/include/lyra/runtime/convert.hpp
@@ -300,4 +300,30 @@ auto ConvertToLogic(ConstLogicView src, Signedness src_signedness)
   return out;
 }
 
+template <PackedShape TargetShape, Signedness TargetSigned>
+auto ConvertToBit(BitView src, Signedness src_signedness)
+    -> Bit<TargetShape, TargetSigned> {
+  return ConvertToBit<TargetShape, TargetSigned>(src.AsConst(), src_signedness);
+}
+
+template <PackedShape TargetShape, Signedness TargetSigned>
+auto ConvertToBit(LogicView src, Signedness src_signedness)
+    -> Bit<TargetShape, TargetSigned> {
+  return ConvertToBit<TargetShape, TargetSigned>(src.AsConst(), src_signedness);
+}
+
+template <PackedShape TargetShape, Signedness TargetSigned>
+auto ConvertToLogic(BitView src, Signedness src_signedness)
+    -> Logic<TargetShape, TargetSigned> {
+  return ConvertToLogic<TargetShape, TargetSigned>(
+      src.AsConst(), src_signedness);
+}
+
+template <PackedShape TargetShape, Signedness TargetSigned>
+auto ConvertToLogic(LogicView src, Signedness src_signedness)
+    -> Logic<TargetShape, TargetSigned> {
+  return ConvertToLogic<TargetShape, TargetSigned>(
+      src.AsConst(), src_signedness);
+}
+
 }  // namespace lyra::runtime

--- a/tests/cases/cpp/packed_var_assign_basic/case.yaml
+++ b/tests/cases/cpp/packed_var_assign_basic/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.packed_var_assign_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "10xz0101\n10000101\n"

--- a/tests/cases/cpp/packed_var_assign_basic/main.sv
+++ b/tests/cases/cpp/packed_var_assign_basic/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  logic [7:0] a;
+  logic [7:0] b;
+  bit [7:0] c;
+
+  initial begin
+    a = 8'b10xz0101;
+    b = a;
+    c = a;
+    $display("%b", b);
+    $display("%b", c);
+  end
+endmodule

--- a/tests/cases/cpp/packed_var_assign_bit_to_logic/case.yaml
+++ b/tests/cases/cpp/packed_var_assign_bit_to_logic/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.packed_var_assign_bit_to_logic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "10100101\n"

--- a/tests/cases/cpp/packed_var_assign_bit_to_logic/main.sv
+++ b/tests/cases/cpp/packed_var_assign_bit_to_logic/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  bit [7:0] a;
+  logic [7:0] b;
+
+  initial begin
+    a = 8'b10100101;
+    b = a;
+    $display("%b", b);
+  end
+endmodule

--- a/tests/cases/cpp/packed_var_assign_local/case.yaml
+++ b/tests/cases/cpp/packed_var_assign_local/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.packed_var_assign_local
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "10100101\n"

--- a/tests/cases/cpp/packed_var_assign_local/main.sv
+++ b/tests/cases/cpp/packed_var_assign_local/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  logic [7:0] out;
+
+  initial begin
+    logic [7:0] tmp;
+    tmp = 8'b10100101;
+    out = tmp;
+    $display("%b", out);
+  end
+endmodule

--- a/tests/cases/cpp/packed_var_assign_signed_widen/case.yaml
+++ b/tests/cases/cpp/packed_var_assign_signed_widen/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.packed_var_assign_signed_widen
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "11111x01\n"

--- a/tests/cases/cpp/packed_var_assign_signed_widen/main.sv
+++ b/tests/cases/cpp/packed_var_assign_signed_widen/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  logic signed [3:0] s;
+  logic signed [7:0] w;
+
+  initial begin
+    s = 4'b1x01;
+    w = s;
+    $display("%b", w);
+  end
+endmodule

--- a/tests/cases/cpp/packed_var_assign_width/case.yaml
+++ b/tests/cases/cpp/packed_var_assign_width/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.packed_var_assign_width
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "000010xz\n10xz\n"

--- a/tests/cases/cpp/packed_var_assign_width/main.sv
+++ b/tests/cases/cpp/packed_var_assign_width/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  logic [3:0] sml;
+  logic [7:0] wide;
+  logic [3:0] narrow;
+
+  initial begin
+    sml = 4'b10xz;
+    wide = sml;
+    narrow = wide;
+    $display("%b", wide);
+    $display("%b", narrow);
+  end
+endmodule

--- a/tests/cli_emit_cpp_test.cpp
+++ b/tests/cli_emit_cpp_test.cpp
@@ -101,6 +101,17 @@ auto main(int argc, char** argv) -> int {
     return filtered;
   }();
 
+  if (kCases.empty()) {
+    fmt::print(
+        stderr,
+        "cli_emit_cpp_tests: zero cases registered for suite '{}'. "
+        "Either no case.yaml has `command: [run, cpp]`, or the suite "
+        "filter excludes all of them. Refusing to report PASS on empty "
+        "coverage.\n",
+        suite_name);
+    return 1;
+  }
+
   // NOLINTBEGIN(cppcoreguidelines-owning-memory)
   for (const auto& c : kCases) {
     testing::RegisterTest(

--- a/tests/cli_golden_test.cpp
+++ b/tests/cli_golden_test.cpp
@@ -102,6 +102,16 @@ auto main(int argc, char** argv) -> int {
     return filtered;
   }();
 
+  if (kCases.empty()) {
+    fmt::print(
+        stderr,
+        "cli_golden_tests: zero cases registered for suite '{}'. The case "
+        "loader, suite filter, or emit-cpp erasure left nothing behind. "
+        "Refusing to report PASS on empty coverage.\n",
+        suite_name);
+    return 1;
+  }
+
   // NOLINTBEGIN(cppcoreguidelines-owning-memory) -- gtest's RegisterTest
   // factory API mandates heap-allocated Test subclasses; the test framework
   // takes ownership and destroys them after the test completes.


### PR DESCRIPTION
## Summary

Closes the runtime overload gap that blocked variable-RHS packed assignment when a `ConversionExpr` was inserted by slang. `Bit::View()` and `Logic::View()` return mutable views, but `ConvertToBit` / `ConvertToLogic` previously declared only const-view overloads, so generated C++ for `bit[7:0] c; logic[7:0] a; c = a;` failed to compile with `no known conversion from 'LogicView' to 'ConstLogicView'`. Adds four mutable-view forwarding overloads in `include/lyra/runtime/convert.hpp` that delegate via `AsConst()`, mirroring the existing `Bit::Assign(BitView)` / `Logic::Assign(LogicView)` bridge. The conversion core (`ConvertPackedBits`) is unchanged.

Also adds five SV end-to-end cases under `tests/cases/cpp/packed_var_assign_*/` covering same-state copy, cross-state conversion in both directions, unsigned widening / truncation, signed widening with a four-state value (X/Z sign-bit replication), and local packed declarations. Every `expect.stdout.exact` is pinned from a real captured run, not a hand-derivation.

Both `cli_golden_tests` and `cli_emit_cpp_tests` mains now refuse to report `PASSED` when zero cases register for the requested suite. This catches the silent-zero-coverage failure mode where a misrouted suite or filter quietly excluded everything.

## Testing

- `bazel build //...`
- `bazel test //... --test_output=errors` -- all 6 test targets pass.
- Verified the new zero-coverage assertion fires with `bazel run //tests:cli_emit_cpp_tests -- --suite architecture_diag_struct` (exits non-zero with a clear diagnostic).
- All five new cases pass under `cli_emit_cpp_tests` alongside the existing `literal_*` cases.