### PR TITLE
Lay final scheduler skeleton on Engine

### DIFF
--- a/include/lyra/runtime/delay.hpp
+++ b/include/lyra/runtime/delay.hpp
@@ -21,7 +21,7 @@ class DelayAwaitable {
   // NOLINTNEXTLINE(readability-identifier-naming)
   void await_suspend(
       std::coroutine_handle<ProcessCoroutine::promise_type> handle) noexcept {
-    handle.promise().SetWaitRequest(DelayRequest{.duration = duration_});
+    handle.promise().SetWaitRequest(DelayWait{.duration = duration_});
   }
 
   // NOLINTNEXTLINE(readability-identifier-naming)

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <deque>
 #include <map>
 #include <memory>
@@ -10,11 +12,25 @@
 #include "lyra/runtime/output_sink.hpp"
 #include "lyra/runtime/runtime_scope.hpp"
 #include "lyra/runtime/runtime_services.hpp"
+#include "lyra/runtime/wait_request.hpp"
 
 namespace lyra::runtime {
 
 class Module;
+class RuntimeEvent;
 class RuntimeProcess;
+
+enum class SchedulerPhase : std::uint8_t {
+  kIdle,
+  kActive,
+  kInactive,
+  kFlushUpdates,
+  kCommitNba,
+  kObserved,
+  kReactive,
+  kPostponed,
+  kAdvanceTime,
+};
 
 struct EngineOptions {
   OutputDispatcher::OutputSink output_sink;
@@ -47,19 +63,66 @@ class Engine {
   }
 
  private:
-  void EnqueueInitialProcesses(RuntimeScope& root);
-  void DrainActiveQueue();
-  void MoveInactiveToActive();
-  void MoveNextDelayedTimeToActive();
-  void ScheduleDelay(RuntimeProcess& proc, SimDuration duration);
+  struct NbaWorkItem {};
+  struct PostponedWorkItem {};
+
+  struct SchedulerQueues {
+    std::deque<RuntimeProcess*> active;
+    std::deque<RuntimeProcess*> inactive;
+    std::vector<RuntimeProcess*> next_delta;
+    std::vector<NbaWorkItem> nba;
+    std::vector<PostponedWorkItem> postponed;
+    std::map<SimTime, std::vector<RuntimeProcess*>> delayed;
+  };
+
+  static constexpr std::size_t kMaxCurrentTimeIterations = 10000;
+  static constexpr std::size_t kMaxDeltaCyclesPerTimeSlot = 10000;
+
+  void EnsureReadyToRun();
+  void EnqueueInitialProcesses();
+  void RunProcess(RuntimeProcess& process);
+  void DrainRunnableQueue(std::deque<RuntimeProcess*>& queue);
+
+  void ExecuteCurrentTimeSlot();
+  void ExecuteActiveRegion();
+  void ExecuteInactiveRegion();
+  void FlushRuntimeUpdates();
+  void ExecuteNbaRegion();
+  void ExecuteObservedRegion();
+  void ExecuteReactiveRegion();
+  void ExecutePostponedRegion();
+
+  void AdvanceToNextTime();
+  void AdvanceDeltaCycle();
+  void PromoteNextDeltaToActive();
+
+  [[nodiscard]] auto HasCurrentTimeWork() const -> bool;
+  [[nodiscard]] auto HasFutureTimedWork() const -> bool;
+  [[nodiscard]] auto HasScheduledWork() const -> bool;
+  [[nodiscard]] auto HasNextDeltaWork() const -> bool;
+  [[nodiscard]] auto IsRunnablePhase() const -> bool;
+
+  void ScheduleWait(RuntimeProcess& process, WaitRequest wait);
+  void ScheduleDelayWait(RuntimeProcess& process, DelayWait wait);
+  static void ScheduleEventWait(RuntimeProcess& process, EventWait wait);
+
+  void ScheduleActive(RuntimeProcess& process);
+  void ScheduleInactive(RuntimeProcess& process);
+  void ScheduleNextDelta(RuntimeProcess& process);
+  void ScheduleDelayed(SimTime wake_time, RuntimeProcess& process);
+
+  void TriggerEvent(RuntimeEvent& event);
+
+  [[nodiscard]] static auto CheckedAdd(SimTime base, SimDuration delta)
+      -> SimTime;
 
   OutputDispatcher output_;
   RuntimeServices services_{output_};
   std::unique_ptr<RuntimeScope> root_;
+  SchedulerQueues queues_;
   SimTime now_ = 0;
-  std::deque<RuntimeProcess*> active_queue_;
-  std::deque<RuntimeProcess*> inactive_queue_;
-  std::map<SimTime, std::vector<RuntimeProcess*>> delay_queue_;
+  SchedulerPhase phase_ = SchedulerPhase::kIdle;
+  std::size_t current_delta_ = 0;
   bool bound_ = false;
   bool ran_ = false;
 };

--- a/include/lyra/runtime/event.hpp
+++ b/include/lyra/runtime/event.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <vector>
+
+namespace lyra::runtime {
+
+class RuntimeProcess;
+
+class RuntimeEvent {
+ public:
+  RuntimeEvent() = default;
+
+  RuntimeEvent(const RuntimeEvent&) = delete;
+  auto operator=(const RuntimeEvent&) -> RuntimeEvent& = delete;
+  RuntimeEvent(RuntimeEvent&&) = delete;
+  auto operator=(RuntimeEvent&&) -> RuntimeEvent& = delete;
+  ~RuntimeEvent() = default;
+
+  void AddWaiter(RuntimeProcess& process);
+  [[nodiscard]] auto TakeWaiters() -> std::vector<RuntimeProcess*>;
+
+ private:
+  std::vector<RuntimeProcess*> waiters_;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_process.hpp
+++ b/include/lyra/runtime/runtime_process.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "lyra/runtime/process.hpp"
 #include "lyra/runtime/process_kind.hpp"
 #include "lyra/runtime/wait_request.hpp"
@@ -7,6 +9,13 @@
 namespace lyra::runtime {
 
 class RuntimeScope;
+
+enum class ProcessState : std::uint8_t {
+  kCreated,
+  kRunning,
+  kWaiting,
+  kCompleted,
+};
 
 class RuntimeProcess {
  public:
@@ -21,12 +30,16 @@ class RuntimeProcess {
 
   auto Owner() -> RuntimeScope&;
   [[nodiscard]] auto Kind() const -> ProcessKind;
+  [[nodiscard]] auto State() const -> ProcessState {
+    return state_;
+  }
   auto Resume() -> ProcessRunResult;
 
  private:
   RuntimeScope* owner_ = nullptr;
   ProcessKind kind_;
   ProcessCoroutine coroutine_;
+  ProcessState state_ = ProcessState::kCreated;
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/wait_request.hpp
+++ b/include/lyra/runtime/wait_request.hpp
@@ -9,11 +9,17 @@
 
 namespace lyra::runtime {
 
-struct DelayRequest {
+class RuntimeEvent;
+
+struct DelayWait {
   SimDuration duration;
 };
 
-using WaitRequest = std::variant<DelayRequest>;
+struct EventWait {
+  RuntimeEvent* event = nullptr;
+};
+
+using WaitRequest = std::variant<DelayWait, EventWait>;
 
 class ProcessRunResult {
  public:

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -1,5 +1,6 @@
 #include "lyra/runtime/engine.hpp"
 
+#include <cstddef>
 #include <iostream>
 #include <limits>
 #include <memory>
@@ -9,8 +10,10 @@
 #include <variant>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/base/overloaded.hpp"
 #include "lyra/base/time.hpp"
 #include "lyra/runtime/bind_context.hpp"
+#include "lyra/runtime/event.hpp"
 #include "lyra/runtime/module.hpp"
 #include "lyra/runtime/output_sink.hpp"
 #include "lyra/runtime/process_kind.hpp"
@@ -46,6 +49,23 @@ void Engine::BindRoot(std::string root_name, Module& top) {
 }
 
 auto Engine::Run() -> int {
+  EnsureReadyToRun();
+  EnqueueInitialProcesses();
+
+  while (HasScheduledWork()) {
+    ExecuteCurrentTimeSlot();
+    if (!HasFutureTimedWork()) {
+      break;
+    }
+    AdvanceToNextTime();
+  }
+
+  phase_ = SchedulerPhase::kIdle;
+  output_.Drain();
+  return 0;
+}
+
+void Engine::EnsureReadyToRun() {
   if (!bound_) {
     throw InternalError("Engine::Run called before BindRoot");
   }
@@ -53,29 +73,14 @@ auto Engine::Run() -> int {
     throw InternalError("Engine::Run called more than once");
   }
   ran_ = true;
-  EnqueueInitialProcesses(*root_);
-  while (!active_queue_.empty() || !inactive_queue_.empty() ||
-         !delay_queue_.empty()) {
-    while (!active_queue_.empty() || !inactive_queue_.empty()) {
-      DrainActiveQueue();
-      if (active_queue_.empty() && !inactive_queue_.empty()) {
-        MoveInactiveToActive();
-      }
-    }
-    if (!delay_queue_.empty()) {
-      MoveNextDelayedTimeToActive();
-    }
-  }
-  output_.Drain();
-  return 0;
 }
 
-void Engine::EnqueueInitialProcesses(RuntimeScope& root) {
-  WalkScopePreOrder(root, [this](RuntimeScope& scope) {
+void Engine::EnqueueInitialProcesses() {
+  WalkScopePreOrder(*root_, [this](RuntimeScope& scope) {
     scope.ForEachProcess([this](RuntimeProcess& process) {
       switch (process.Kind()) {
         case ProcessKind::kInitial:
-          active_queue_.push_back(&process);
+          ScheduleActive(process);
           break;
         case ProcessKind::kAlways:
         case ProcessKind::kAlwaysComb:
@@ -87,51 +92,180 @@ void Engine::EnqueueInitialProcesses(RuntimeScope& root) {
   });
 }
 
-void Engine::DrainActiveQueue() {
-  while (!active_queue_.empty()) {
-    auto* proc = active_queue_.front();
-    active_queue_.pop_front();
-    auto result = proc->Resume();
-    if (result.IsCompleted()) {
-      continue;
+void Engine::ExecuteCurrentTimeSlot() {
+  current_delta_ = 0;
+  std::size_t current_work_iterations = 0;
+  while (true) {
+    while (!queues_.active.empty() || !queues_.inactive.empty()) {
+      if (++current_work_iterations > kMaxCurrentTimeIterations) {
+        throw InternalError("Engine: current time slot did not settle");
+      }
+      ExecuteActiveRegion();
+      ExecuteInactiveRegion();
     }
-    auto wait = result.TakeWait();
-    if (auto* delay = std::get_if<DelayRequest>(&wait)) {
-      ScheduleDelay(*proc, delay->duration);
-      continue;
+    FlushRuntimeUpdates();
+    ExecuteNbaRegion();
+    FlushRuntimeUpdates();
+    ExecuteObservedRegion();
+    ExecuteReactiveRegion();
+    if (!HasNextDeltaWork()) {
+      break;
     }
-    throw InternalError("Engine::DrainActiveQueue: unsupported wait request");
+    AdvanceDeltaCycle();
+    PromoteNextDeltaToActive();
+  }
+  ExecutePostponedRegion();
+}
+
+void Engine::ExecuteActiveRegion() {
+  phase_ = SchedulerPhase::kActive;
+  DrainRunnableQueue(queues_.active);
+}
+
+void Engine::ExecuteInactiveRegion() {
+  phase_ = SchedulerPhase::kInactive;
+  DrainRunnableQueue(queues_.inactive);
+}
+
+void Engine::DrainRunnableQueue(std::deque<RuntimeProcess*>& queue) {
+  const std::size_t snapshot_size = queue.size();
+  for (std::size_t i = 0; i < snapshot_size; ++i) {
+    RuntimeProcess* process = queue.front();
+    queue.pop_front();
+    RunProcess(*process);
   }
 }
 
-void Engine::MoveInactiveToActive() {
-  while (!inactive_queue_.empty()) {
-    active_queue_.push_back(inactive_queue_.front());
-    inactive_queue_.pop_front();
+void Engine::FlushRuntimeUpdates() {
+  phase_ = SchedulerPhase::kFlushUpdates;
+}
+
+void Engine::ExecuteNbaRegion() {
+  phase_ = SchedulerPhase::kCommitNba;
+}
+
+void Engine::ExecuteObservedRegion() {
+  phase_ = SchedulerPhase::kObserved;
+}
+
+void Engine::ExecuteReactiveRegion() {
+  phase_ = SchedulerPhase::kReactive;
+}
+
+void Engine::ExecutePostponedRegion() {
+  phase_ = SchedulerPhase::kPostponed;
+}
+
+void Engine::AdvanceDeltaCycle() {
+  ++current_delta_;
+  if (current_delta_ > kMaxDeltaCyclesPerTimeSlot) {
+    throw InternalError("Engine: delta cycle limit exceeded");
   }
 }
 
-void Engine::MoveNextDelayedTimeToActive() {
-  auto it = delay_queue_.begin();
-  if (it == delay_queue_.end()) {
-    return;
+void Engine::PromoteNextDeltaToActive() {
+  for (RuntimeProcess* p : queues_.next_delta) {
+    ScheduleActive(*p);
   }
+  queues_.next_delta.clear();
+}
+
+void Engine::AdvanceToNextTime() {
+  phase_ = SchedulerPhase::kAdvanceTime;
+  auto it = queues_.delayed.begin();
   now_ = it->first;
-  for (auto* proc : it->second) {
-    active_queue_.push_back(proc);
+  for (RuntimeProcess* p : it->second) {
+    ScheduleActive(*p);
   }
-  delay_queue_.erase(it);
+  queues_.delayed.erase(it);
 }
 
-void Engine::ScheduleDelay(RuntimeProcess& proc, SimDuration duration) {
-  if (duration == 0) {
-    inactive_queue_.push_back(&proc);
+auto Engine::HasCurrentTimeWork() const -> bool {
+  return !queues_.active.empty() || !queues_.inactive.empty() ||
+         !queues_.next_delta.empty();
+}
+
+auto Engine::HasFutureTimedWork() const -> bool {
+  return !queues_.delayed.empty();
+}
+
+auto Engine::HasScheduledWork() const -> bool {
+  return HasCurrentTimeWork() || HasFutureTimedWork();
+}
+
+auto Engine::HasNextDeltaWork() const -> bool {
+  return !queues_.next_delta.empty();
+}
+
+auto Engine::IsRunnablePhase() const -> bool {
+  return phase_ == SchedulerPhase::kActive ||
+         phase_ == SchedulerPhase::kInactive ||
+         phase_ == SchedulerPhase::kReactive;
+}
+
+void Engine::RunProcess(RuntimeProcess& process) {
+  if (!IsRunnablePhase()) {
+    throw InternalError(
+        "Engine::RunProcess: process resumed outside runnable phase");
+  }
+  auto result = process.Resume();
+  if (result.IsCompleted()) {
     return;
   }
-  if (duration > std::numeric_limits<SimTime>::max() - now_) {
-    throw InternalError("Engine::ScheduleDelay: wake time overflow");
+  ScheduleWait(process, result.TakeWait());
+}
+
+void Engine::ScheduleWait(RuntimeProcess& process, WaitRequest wait) {
+  std::visit(
+      Overloaded{
+          [&](DelayWait d) { ScheduleDelayWait(process, d); },
+          [&](EventWait e) { ScheduleEventWait(process, e); },
+      },
+      wait);
+}
+
+void Engine::ScheduleDelayWait(RuntimeProcess& process, DelayWait wait) {
+  if (wait.duration == 0) {
+    ScheduleInactive(process);
+    return;
   }
-  delay_queue_[now_ + duration].push_back(&proc);
+  ScheduleDelayed(CheckedAdd(now_, wait.duration), process);
+}
+
+void Engine::ScheduleEventWait(RuntimeProcess& process, EventWait wait) {
+  if (wait.event == nullptr) {
+    throw InternalError("Engine::ScheduleEventWait: event pointer is null");
+  }
+  wait.event->AddWaiter(process);
+}
+
+void Engine::TriggerEvent(RuntimeEvent& event) {
+  for (RuntimeProcess* p : event.TakeWaiters()) {
+    ScheduleNextDelta(*p);
+  }
+}
+
+void Engine::ScheduleActive(RuntimeProcess& process) {
+  queues_.active.push_back(&process);
+}
+
+void Engine::ScheduleInactive(RuntimeProcess& process) {
+  queues_.inactive.push_back(&process);
+}
+
+void Engine::ScheduleNextDelta(RuntimeProcess& process) {
+  queues_.next_delta.push_back(&process);
+}
+
+void Engine::ScheduleDelayed(SimTime wake_time, RuntimeProcess& process) {
+  queues_.delayed[wake_time].push_back(&process);
+}
+
+auto Engine::CheckedAdd(SimTime base, SimDuration delta) -> SimTime {
+  if (delta > std::numeric_limits<SimTime>::max() - base) {
+    throw InternalError("Engine::CheckedAdd: wake time overflow");
+  }
+  return base + delta;
 }
 
 }  // namespace lyra::runtime

--- a/src/lyra/runtime/event.cpp
+++ b/src/lyra/runtime/event.cpp
@@ -1,0 +1,16 @@
+#include "lyra/runtime/event.hpp"
+
+#include <utility>
+#include <vector>
+
+namespace lyra::runtime {
+
+void RuntimeEvent::AddWaiter(RuntimeProcess& process) {
+  waiters_.push_back(&process);
+}
+
+auto RuntimeEvent::TakeWaiters() -> std::vector<RuntimeProcess*> {
+  return std::exchange(waiters_, {});
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/runtime/runtime_process.cpp
+++ b/src/lyra/runtime/runtime_process.cpp
@@ -2,6 +2,7 @@
 
 #include <utility>
 
+#include "lyra/base/internal_error.hpp"
 #include "lyra/runtime/process.hpp"
 #include "lyra/runtime/process_kind.hpp"
 #include "lyra/runtime/runtime_scope.hpp"
@@ -23,7 +24,21 @@ auto RuntimeProcess::Kind() const -> ProcessKind {
 }
 
 auto RuntimeProcess::Resume() -> ProcessRunResult {
-  return coroutine_.Resume();
+  if (state_ == ProcessState::kCompleted) {
+    throw InternalError(
+        "RuntimeProcess::Resume: cannot resume completed process");
+  }
+  if (state_ == ProcessState::kRunning) {
+    throw InternalError("RuntimeProcess::Resume: reentrant resume");
+  }
+  state_ = ProcessState::kRunning;
+  auto result = coroutine_.Resume();
+  if (result.IsCompleted()) {
+    state_ = ProcessState::kCompleted;
+    return result;
+  }
+  state_ = ProcessState::kWaiting;
+  return result;
 }
 
 }  // namespace lyra::runtime

--- a/tests/cases/run/delay_chained_zero.sv
+++ b/tests/cases/run/delay_chained_zero.sv
@@ -1,0 +1,12 @@
+module Top;
+  initial begin
+    $display("a");
+    #0;
+    $display("b");
+    #0;
+    $display("c");
+  end
+  initial begin
+    $display("d");
+  end
+endmodule

--- a/tests/cases/run/delay_multi_time_ordering.sv
+++ b/tests/cases/run/delay_multi_time_ordering.sv
@@ -1,0 +1,6 @@
+module Top;
+  timeunit 1ns;
+  timeprecision 1ps;
+  initial begin #10ns; $display("late"); end
+  initial begin #5ns; $display("early"); end
+endmodule

--- a/tests/cases/run/delay_same_time_ordering.sv
+++ b/tests/cases/run/delay_same_time_ordering.sv
@@ -1,0 +1,7 @@
+module Top;
+  timeunit 1ns;
+  timeprecision 1ps;
+  initial begin #5ns; $display("a"); end
+  initial begin #5ns; $display("b"); end
+  initial begin #5ns; $display("c"); end
+endmodule

--- a/tests/cli_run_test.cpp
+++ b/tests/cli_run_test.cpp
@@ -132,4 +132,19 @@ TEST(CliRun, DelayZeroInactive) {
       "_main/tests/cases/run/delay_zero_inactive.sv", "a\nc\nb\n");
 }
 
+TEST(CliRun, DelaySameTimeOrdering) {
+  RunOneCaseExpectingStdout(
+      "_main/tests/cases/run/delay_same_time_ordering.sv", "a\nb\nc\n");
+}
+
+TEST(CliRun, DelayMultiTimeOrdering) {
+  RunOneCaseExpectingStdout(
+      "_main/tests/cases/run/delay_multi_time_ordering.sv", "early\nlate\n");
+}
+
+TEST(CliRun, DelayChainedZero) {
+  RunOneCaseExpectingStdout(
+      "_main/tests/cases/run/delay_chained_zero.sv", "a\nd\nb\nc\n");
+}
+
 }  // namespace


### PR DESCRIPTION
## Summary

Replaces the ad hoc active/inactive/delay loop in `Engine::Run` with the long-term scheduler shape, before any of the future consumers (NBA, event control, observed/reactive regions) exist. The point is to make every future cut a slot-fill, not a scheduler rewrite. NBA / observed / reactive / postponed regions exist as real methods with empty bodies; the variant alternative for event waits is type-checked but has no producer yet.

## Design

`Engine::Run` is now structured around `EnsureReadyToRun` -> `EnqueueInitialProcesses` -> `while (HasScheduledWork) { ExecuteCurrentTimeSlot; if (no future work) break; AdvanceToNextTime; }`. The per-time-slot body has explicit `ExecuteActiveRegion`, `ExecuteInactiveRegion`, `FlushRuntimeUpdates`, `ExecuteNbaRegion`, `ExecuteObservedRegion`, `ExecuteReactiveRegion`, `ExecutePostponedRegion`, plus the delta-cycle slot via `AdvanceDeltaCycle` + `PromoteNextDeltaToActive`. A single shared `DrainRunnableQueue` does the dequeue-and-resume; each region helper wraps it with the right `phase_` value. Phase hygiene is enforced by `RunProcess` asserting `IsRunnablePhase()`.

Queues are owned by one private nested `SchedulerQueues` struct (active, inactive, next_delta, nba, postponed, delayed). Every raw queue mutation goes through one of four `Schedule*` helpers (`ScheduleActive`, `ScheduleInactive`, `ScheduleNextDelta`, `ScheduleDelayed`) — when queue policy changes later, there is one place per queue to update. Two named limits guard runaway: `kMaxCurrentTimeIterations` for the active+inactive settle loop and `kMaxDeltaCyclesPerTimeSlot` for next-delta promotions.

`WaitRequest` becomes `std::variant<DelayWait, EventWait>` (renamed from `DelayRequest`; no alias). `RuntimeEvent` lives in its own header, is non-copyable AND non-movable, and stores waiters by raw pointer. `EventWait` and `Engine::TriggerEvent` are compile-time skeleton only — there is no SV producer in this cut. `RuntimeProcess` gains a durable `ProcessState { kCreated, kRunning, kWaiting, kCompleted }` lifecycle; `Resume()` rejects re-entry and post-completion.

No emit-side changes. No new `cc_test`. No CLI/output trailer. No `Now()` accessor without a consumer.

## Testing

All four existing run tests still pass with no expected-stdout changes. Three new fixtures cover scheduler shape: `delay_same_time_ordering` (same-bucket FIFO), `delay_multi_time_ordering` (`std::map` advances by smallest key), and `delay_chained_zero` (each `#0` yields rather than completing in one resume).

`bazel build //...` clean; `bazel test //... --test_output=errors` clean (6/6 test targets pass); policy + format checks clean.