### PR TITLE
Capture all pure unary/binary operators in HIR and MIR

### DIFF
--- a/include/lyra/backend/cpp/api.hpp
+++ b/include/lyra/backend/cpp/api.hpp
@@ -3,18 +3,19 @@
 #include <vector>
 
 #include "lyra/backend/cpp/artifact.hpp"
+#include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/class_decl.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 
 namespace lyra::backend::cpp {
 
 auto EmitCppDeclarations(const mir::CompilationUnit& unit)
-    -> std::vector<CppArtifact>;
+    -> diag::Result<std::vector<CppArtifact>>;
 
 auto EmitCppHostMain(const mir::ClassDecl& entry_class) -> CppArtifact;
 
 auto EmitCpp(
     const mir::CompilationUnit& unit, const mir::ClassDecl& entry_class)
-    -> CppArtifactSet;
+    -> diag::Result<CppArtifactSet>;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/backend/cpp/render_expr.hpp
+++ b/include/lyra/backend/cpp/render_expr.hpp
@@ -3,21 +3,23 @@
 #include <string>
 
 #include "lyra/backend/cpp/render_context.hpp"
+#include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/expr.hpp"
 
 namespace lyra::backend::cpp {
 
 // Auto-picks `RenderExprAsNative` or `RenderExprAsRuntimeView` per variant.
 // Call sites with a known target context should use the explicit forms.
-auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr) -> std::string;
+auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
+    -> diag::Result<std::string>;
 
 auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
     -> std::string;
 
 auto RenderExprAsNative(const RenderContext& ctx, const mir::Expr& expr)
-    -> std::string;
+    -> diag::Result<std::string>;
 
 auto RenderExprAsRuntimeView(const RenderContext& ctx, const mir::Expr& expr)
-    -> std::string;
+    -> diag::Result<std::string>;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/backend/cpp/render_print.hpp
+++ b/include/lyra/backend/cpp/render_print.hpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "lyra/backend/cpp/render_context.hpp"
+#include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/expr.hpp"
 
 namespace lyra::backend::cpp {
@@ -11,6 +12,7 @@ namespace lyra::backend::cpp {
 // RenderExpr's RuntimeCallExpr arm; the surrounding RenderStmt::ExprStmt path
 // adds the trailing `;` like for any other expression.
 auto RenderRuntimeCallExpr(
-    const RenderContext& ctx, const mir::RuntimeCallExpr& expr) -> std::string;
+    const RenderContext& ctx, const mir::RuntimeCallExpr& expr)
+    -> diag::Result<std::string>;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/backend/cpp/render_stmt.hpp
+++ b/include/lyra/backend/cpp/render_stmt.hpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "lyra/backend/cpp/render_context.hpp"
+#include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/class_decl.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/stmt.hpp"
@@ -12,10 +13,10 @@ namespace lyra::backend::cpp {
 
 auto RenderBody(
     const mir::CompilationUnit& unit, const mir::ClassDecl& class_decl,
-    const mir::Body& body, std::size_t indent) -> std::string;
+    const mir::Body& body, std::size_t indent) -> diag::Result<std::string>;
 
 auto RenderStmt(
     const RenderContext& ctx, const mir::Stmt& stmt, std::size_t indent)
-    -> std::string;
+    -> diag::Result<std::string>;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -46,6 +46,10 @@ enum class DiagCode : std::uint32_t {
   kFormatSpecifierNotImplemented,
   kSystemSubroutineExecutionNotImplemented,
 
+  kCppEmitBinaryOpNotImplemented,
+  kCppEmitUnaryOpNotImplemented,
+  kCppEmitExpressionFormNotImplemented,
+
   kHostInvalidCliArgs,
   kHostProjectModeUnimplemented,
   kHostNoInputFiles,

--- a/include/lyra/hir/binary_op.hpp
+++ b/include/lyra/hir/binary_op.hpp
@@ -4,7 +4,33 @@ namespace lyra::hir {
 
 enum class BinaryOp {
   kAdd,
+  kSub,
+  kMul,
+  kDiv,
+  kMod,
+  kPower,
+  kBitwiseAnd,
+  kBitwiseOr,
+  kBitwiseXor,
+  kBitwiseXnor,
+  kEquality,
+  kInequality,
+  kCaseEquality,
+  kCaseInequality,
+  kWildcardEquality,
+  kWildcardInequality,
+  kGreaterEqual,
+  kGreaterThan,
+  kLessEqual,
   kLessThan,
+  kLogicalAnd,
+  kLogicalOr,
+  kLogicalImplication,
+  kLogicalEquivalence,
+  kLogicalShiftLeft,
+  kLogicalShiftRight,
+  kArithmeticShiftLeft,
+  kArithmeticShiftRight,
 };
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -10,11 +10,17 @@
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/type.hpp"
+#include "lyra/hir/unary_op.hpp"
 
 namespace lyra::hir {
 
 struct PrimaryExpr {
   Primary data;
+};
+
+struct UnaryExpr {
+  UnaryOp op;
+  ExprId operand;
 };
 
 struct BinaryExpr {
@@ -33,8 +39,8 @@ struct CallExpr {
   std::vector<ExprId> arguments;
 };
 
-using ExprData =
-    std::variant<PrimaryExpr, BinaryExpr, AssignExpr, CallExpr, ConversionExpr>;
+using ExprData = std::variant<
+    PrimaryExpr, UnaryExpr, BinaryExpr, AssignExpr, CallExpr, ConversionExpr>;
 
 struct Expr {
   TypeId type;

--- a/include/lyra/hir/unary_op.hpp
+++ b/include/lyra/hir/unary_op.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace lyra::hir {
+
+enum class UnaryOp {
+  kPlus,
+  kMinus,
+  kBitwiseNot,
+  kLogicalNot,
+  kReductionAnd,
+  kReductionOr,
+  kReductionXor,
+  kReductionNand,
+  kReductionNor,
+  kReductionXnor,
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/lowering/hir_to_mir/lower_expr.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_expr.hpp
@@ -1,12 +1,10 @@
 #pragma once
 
 #include "lyra/diag/diagnostic.hpp"
-#include "lyra/hir/binary_op.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
-#include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/expr.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -32,7 +30,5 @@ auto LowerExpr(
     const ConstructorLoweringState& ctor_state, BodyLoweringState& body_state,
     const hir::StructuralScope& scope, const hir::Expr& expr)
     -> diag::Result<mir::Expr>;
-
-auto LowerBinaryOp(hir::BinaryOp op) -> mir::BinaryOp;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/binary_op.hpp
+++ b/include/lyra/mir/binary_op.hpp
@@ -4,7 +4,32 @@ namespace lyra::mir {
 
 enum class BinaryOp {
   kAdd,
+  kSub,
+  kMul,
+  kDiv,
+  kMod,
+  kPower,
+  kBitwiseAnd,
+  kBitwiseOr,
+  kBitwiseXor,
+  kBitwiseXnor,
+  kEquality,
+  kInequality,
+  kCaseEquality,
+  kCaseInequality,
+  kWildcardEquality,
+  kWildcardInequality,
+  kGreaterEqual,
+  kGreaterThan,
+  kLessEqual,
   kLessThan,
+  kLogicalAnd,
+  kLogicalOr,
+  kLogicalImplication,
+  kLogicalEquivalence,
+  kShiftLeft,
+  kLogicalShiftRight,
+  kArithmeticShiftRight,
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -14,6 +14,7 @@
 #include "lyra/mir/member_var.hpp"
 #include "lyra/mir/runtime_print.hpp"
 #include "lyra/mir/type.hpp"
+#include "lyra/mir/unary_op.hpp"
 
 namespace lyra::mir {
 
@@ -42,6 +43,11 @@ struct LocalVarRef {
 };
 
 using Lvalue = std::variant<MemberVarRef, LocalVarRef>;
+
+struct UnaryExpr {
+  UnaryOp op;
+  ExprId operand;
+};
 
 struct BinaryExpr {
   BinaryOp op;
@@ -78,7 +84,8 @@ struct RuntimeCallExpr {
 
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, MemberVarRef, LocalVarRef,
-    BinaryExpr, AssignExpr, CallExpr, RuntimeCallExpr, ConversionExpr>;
+    UnaryExpr, BinaryExpr, AssignExpr, CallExpr, RuntimeCallExpr,
+    ConversionExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/mir/unary_op.hpp
+++ b/include/lyra/mir/unary_op.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace lyra::mir {
+
+enum class UnaryOp {
+  kPlus,
+  kMinus,
+  kBitwiseNot,
+  kLogicalNot,
+  kReductionAnd,
+  kReductionOr,
+  kReductionXor,
+  kReductionNand,
+  kReductionNor,
+  kReductionXnor,
+};
+
+}  // namespace lyra::mir

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -1,5 +1,6 @@
 #include <cstddef>
 #include <string>
+#include <utility>
 
 #include "lyra/backend/cpp/api.hpp"
 #include "lyra/backend/cpp/artifact.hpp"
@@ -7,6 +8,7 @@
 #include "lyra/backend/cpp/render_stmt.hpp"
 #include "lyra/backend/cpp/render_type.hpp"
 #include "lyra/base/internal_error.hpp"
+#include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/class_decl.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/member_var.hpp"
@@ -26,14 +28,16 @@ auto RenderField(
 
 auto RenderConstructor(
     const mir::CompilationUnit& unit, const mir::ClassDecl& c,
-    std::size_t indent) -> std::string {
+    std::size_t indent) -> diag::Result<std::string> {
   const auto& body = c.constructor;
   if (body.root_stmts.empty()) {
     return Indent(indent) + c.name + "() {}\n";
   }
   std::string out;
   out += Indent(indent) + c.name + "() {\n";
-  out += RenderBody(unit, c, body, indent + 1);
+  auto body_or = RenderBody(unit, c, body, indent + 1);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+  out += *body_or;
   out += Indent(indent) + "}\n";
   return out;
 }
@@ -45,11 +49,13 @@ auto RenderProcessMethodName(std::size_t index) -> std::string {
 auto RenderProcessMethod(
     const mir::CompilationUnit& unit, const mir::ClassDecl& c,
     const mir::Process& process, std::size_t index, std::size_t indent)
-    -> std::string {
+    -> diag::Result<std::string> {
   std::string out;
   out += Indent(indent) + "auto " + RenderProcessMethodName(index) +
          "() -> lyra::runtime::ProcessCoroutine {\n";
-  out += RenderBody(unit, c, process.body, indent + 1);
+  auto body_or = RenderBody(unit, c, process.body, indent + 1);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+  out += *body_or;
   out += Indent(indent + 1) + "co_return;\n";
   out += Indent(indent) + "}\n";
   return out;
@@ -115,7 +121,7 @@ auto RenderBind(
 
 auto RenderClassDecl(
     const mir::CompilationUnit& unit, const mir::ClassDecl& c,
-    std::size_t indent, bool is_top_level) -> std::string {
+    std::size_t indent, bool is_top_level) -> diag::Result<std::string> {
   std::string out;
   out += Indent(indent) + "class " + c.name;
   if (is_top_level) {
@@ -125,7 +131,9 @@ auto RenderClassDecl(
   out += Indent(indent) + " public:\n";
 
   for (const auto& child : c.classes) {
-    out += RenderClassDecl(unit, child, indent + 1, false);
+    auto child_or = RenderClassDecl(unit, child, indent + 1, false);
+    if (!child_or) return std::unexpected(std::move(child_or.error()));
+    out += *child_or;
   }
   if (!c.classes.empty()) {
     out += "\n";
@@ -141,13 +149,18 @@ auto RenderClassDecl(
   out += Indent(indent + 1) + "lyra::runtime::RuntimeServices* services_{};\n";
   out += "\n";
 
-  out += RenderConstructor(unit, c, indent + 1);
+  auto ctor_or = RenderConstructor(unit, c, indent + 1);
+  if (!ctor_or) return std::unexpected(std::move(ctor_or.error()));
+  out += *ctor_or;
   out += "\n";
   out += RenderBind(unit, c, indent + 1, is_top_level);
 
   for (std::size_t i = 0; i < c.processes.size(); ++i) {
     out += "\n";
-    out += RenderProcessMethod(unit, c, c.processes[i], i, indent + 1);
+    auto method_or =
+        RenderProcessMethod(unit, c, c.processes[i], i, indent + 1);
+    if (!method_or) return std::unexpected(std::move(method_or.error()));
+    out += *method_or;
   }
 
   out += Indent(indent) + "};\n";
@@ -155,7 +168,8 @@ auto RenderClassDecl(
 }
 
 auto RenderClassHeaderFile(
-    const mir::CompilationUnit& unit, const mir::ClassDecl& c) -> std::string {
+    const mir::CompilationUnit& unit, const mir::ClassDecl& c)
+    -> diag::Result<std::string> {
   std::string out;
   out += "#pragma once\n";
   out += "#include <array>\n";
@@ -176,7 +190,9 @@ auto RenderClassHeaderFile(
   out += "#include \"lyra/runtime/runtime_scope_kind.hpp\"\n";
   out += "#include \"lyra/runtime/runtime_services.hpp\"\n";
   out += "\n";
-  out += RenderClassDecl(unit, c, 0, true);
+  auto class_or = RenderClassDecl(unit, c, 0, true);
+  if (!class_or) return std::unexpected(std::move(class_or.error()));
+  out += *class_or;
   return out;
 }
 
@@ -197,13 +213,14 @@ auto RenderHostMain(const mir::ClassDecl& entry) -> std::string {
 }  // namespace
 
 auto EmitCppDeclarations(const mir::CompilationUnit& unit)
-    -> std::vector<CppArtifact> {
+    -> diag::Result<std::vector<CppArtifact>> {
   std::vector<CppArtifact> headers;
   headers.reserve(unit.classes.size());
   for (const auto& cls : unit.classes) {
+    auto content_or = RenderClassHeaderFile(unit, cls);
+    if (!content_or) return std::unexpected(std::move(content_or.error()));
     headers.push_back(
-        {.relpath = cls.name + ".hpp",
-         .content = RenderClassHeaderFile(unit, cls)});
+        {.relpath = cls.name + ".hpp", .content = *std::move(content_or)});
   }
   return headers;
 }
@@ -214,10 +231,11 @@ auto EmitCppHostMain(const mir::ClassDecl& entry_class) -> CppArtifact {
 
 auto EmitCpp(
     const mir::CompilationUnit& unit, const mir::ClassDecl& entry_class)
-    -> CppArtifactSet {
+    -> diag::Result<CppArtifactSet> {
   CppArtifactSet set;
-  auto headers = EmitCppDeclarations(unit);
-  for (auto& h : headers) {
+  auto headers_or = EmitCppDeclarations(unit);
+  if (!headers_or) return std::unexpected(std::move(headers_or.error()));
+  for (auto& h : *headers_or) {
     set.files.push_back(std::move(h));
   }
   set.files.push_back(EmitCppHostMain(entry_class));

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -13,6 +13,9 @@
 #include "lyra/backend/cpp/string_literal.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/kind.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr.hpp"
@@ -23,14 +26,43 @@ namespace lyra::backend::cpp {
 
 namespace {
 
-auto BinaryOpToken(mir::BinaryOp op) -> std::string_view {
+auto BinaryOpToken(mir::BinaryOp op) -> diag::Result<std::string_view> {
   switch (op) {
     case mir::BinaryOp::kAdd:
-      return " + ";
+      return std::string_view{" + "};
     case mir::BinaryOp::kLessThan:
-      return " < ";
+      return std::string_view{" < "};
+    case mir::BinaryOp::kSub:
+    case mir::BinaryOp::kMul:
+    case mir::BinaryOp::kDiv:
+    case mir::BinaryOp::kMod:
+    case mir::BinaryOp::kPower:
+    case mir::BinaryOp::kBitwiseAnd:
+    case mir::BinaryOp::kBitwiseOr:
+    case mir::BinaryOp::kBitwiseXor:
+    case mir::BinaryOp::kBitwiseXnor:
+    case mir::BinaryOp::kEquality:
+    case mir::BinaryOp::kInequality:
+    case mir::BinaryOp::kCaseEquality:
+    case mir::BinaryOp::kCaseInequality:
+    case mir::BinaryOp::kWildcardEquality:
+    case mir::BinaryOp::kWildcardInequality:
+    case mir::BinaryOp::kGreaterEqual:
+    case mir::BinaryOp::kGreaterThan:
+    case mir::BinaryOp::kLessEqual:
+    case mir::BinaryOp::kLogicalAnd:
+    case mir::BinaryOp::kLogicalOr:
+    case mir::BinaryOp::kLogicalImplication:
+    case mir::BinaryOp::kLogicalEquivalence:
+    case mir::BinaryOp::kShiftLeft:
+    case mir::BinaryOp::kLogicalShiftRight:
+    case mir::BinaryOp::kArithmeticShiftRight:
+      return diag::Unsupported(
+          diag::DiagCode::kCppEmitBinaryOpNotImplemented,
+          "this binary operator is not yet implemented in cpp emit",
+          diag::UnsupportedCategory::kFeature);
   }
-  throw InternalError("RenderExpr: unsupported MIR BinaryOp");
+  throw InternalError("BinaryOpToken: unknown MIR BinaryOp");
 }
 
 auto LookupLocalName(const mir::Body& body, const mir::LocalVarRef& ref)
@@ -167,7 +199,7 @@ auto RenderIntegerLiteralAsView(
 
 auto RenderConversionCall(
     const RenderContext& ctx, mir::TypeId target_type,
-    const mir::ConversionExpr& conv) -> std::string {
+    const mir::ConversionExpr& conv) -> diag::Result<std::string> {
   const auto& target = ctx.Unit().GetType(target_type).AsPackedArray();
   const auto& operand_expr = ctx.Expr(conv.operand);
   const auto& source_type = ctx.Unit().GetType(operand_expr.type);
@@ -179,14 +211,17 @@ auto RenderConversionCall(
   }
   const auto& source = source_type.AsPackedArray();
 
-  const std::string operand_view = RenderExprAsRuntimeView(ctx, operand_expr);
+  auto operand_view_or = RenderExprAsRuntimeView(ctx, operand_expr);
+  if (!operand_view_or) {
+    return std::unexpected(std::move(operand_view_or.error()));
+  }
   const std::string target_shape = RenderPackedShapeLiteral(target.dims);
 
   const char* fn = target.IsFourState() ? "lyra::runtime::ConvertToLogic"
                                         : "lyra::runtime::ConvertToBit";
   return std::format(
       "{}<{}, {}>({}, {})", fn, target_shape,
-      SignednessLiteral(target.signedness), operand_view,
+      SignednessLiteral(target.signedness), *operand_view_or,
       SignednessLiteral(source.signedness));
 }
 
@@ -207,50 +242,68 @@ auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
 }
 
 auto RenderExprAsNative(const RenderContext& ctx, const mir::Expr& expr)
-    -> std::string {
+    -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
-          [&](const mir::IntegerLiteral& lit) -> std::string {
+          [&](const mir::IntegerLiteral& lit) -> diag::Result<std::string> {
             return RenderNativeIntegerLiteral(lit.value);
           },
-          [&](const mir::StringLiteral& s) -> std::string {
+          [&](const mir::StringLiteral& s) -> diag::Result<std::string> {
             return RenderStdStringLiteral(s.value);
           },
-          [](const mir::TimeLiteral&) -> std::string {
-            throw InternalError(
-                "backend cpp: TimeLiteral is not yet supported by the C++ "
-                "emitter");
+          [](const mir::TimeLiteral&) -> diag::Result<std::string> {
+            return diag::Unsupported(
+                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+                "TimeLiteral is not yet implemented in cpp emit",
+                diag::UnsupportedCategory::kFeature);
           },
-          [&](const mir::MemberVarRef& m) -> std::string {
+          [&](const mir::MemberVarRef& m) -> diag::Result<std::string> {
             return ctx.Class().GetMemberVar(m.target).name;
           },
-          [&](const mir::LocalVarRef& l) -> std::string {
+          [&](const mir::LocalVarRef& l) -> diag::Result<std::string> {
             return LookupLocalName(ctx.Body(), l);
           },
-          [&](const mir::BinaryExpr& b) -> std::string {
-            return "(" + RenderExprAsNative(ctx, ctx.Expr(b.lhs)) +
-                   std::string{BinaryOpToken(b.op)} +
-                   RenderExprAsNative(ctx, ctx.Expr(b.rhs)) + ")";
+          [](const mir::UnaryExpr&) -> diag::Result<std::string> {
+            return diag::Unsupported(
+                diag::DiagCode::kCppEmitUnaryOpNotImplemented,
+                "this unary operator is not yet implemented in cpp emit",
+                diag::UnsupportedCategory::kFeature);
           },
-          [&](const mir::AssignExpr& a) -> std::string {
+          [&](const mir::BinaryExpr& b) -> diag::Result<std::string> {
+            auto token_or = BinaryOpToken(b.op);
+            if (!token_or) {
+              return std::unexpected(std::move(token_or.error()));
+            }
+            auto lhs_or = RenderExprAsNative(ctx, ctx.Expr(b.lhs));
+            if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+            auto rhs_or = RenderExprAsNative(ctx, ctx.Expr(b.rhs));
+            if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+            return "(" + *lhs_or + std::string{*token_or} + *rhs_or + ")";
+          },
+          [&](const mir::AssignExpr& a) -> diag::Result<std::string> {
             const auto target_type = MirTypeOfLvalue(ctx, a.target);
             if (IsPackedRuntime(ctx.Unit(), target_type)) {
+              auto value_or = RenderExprAsRuntimeView(ctx, ctx.Expr(a.value));
+              if (!value_or) {
+                return std::unexpected(std::move(value_or.error()));
+              }
               return std::format(
-                  "{}.Assign({})", RenderLvalue(ctx, a.target),
-                  RenderExprAsRuntimeView(ctx, ctx.Expr(a.value)));
+                  "{}.Assign({})", RenderLvalue(ctx, a.target), *value_or);
             }
-            return "(" + RenderLvalue(ctx, a.target) + " = " +
-                   RenderExprAsNative(ctx, ctx.Expr(a.value)) + ")";
+            auto value_or = RenderExprAsNative(ctx, ctx.Expr(a.value));
+            if (!value_or) return std::unexpected(std::move(value_or.error()));
+            return "(" + RenderLvalue(ctx, a.target) + " = " + *value_or + ")";
           },
-          [&](const mir::ConversionExpr& cv) -> std::string {
+          [&](const mir::ConversionExpr& cv) -> diag::Result<std::string> {
             return RenderExprAsNative(ctx, ctx.Expr(cv.operand));
           },
-          [](const mir::CallExpr&) -> std::string {
-            throw InternalError(
-                "RenderExprAsNative: mir::CallExpr lowering to C++ is not "
-                "implemented");
+          [](const mir::CallExpr&) -> diag::Result<std::string> {
+            return diag::Unsupported(
+                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+                "user subroutine call is not yet implemented in cpp emit",
+                diag::UnsupportedCategory::kFeature);
           },
-          [&](const mir::RuntimeCallExpr& rc) -> std::string {
+          [&](const mir::RuntimeCallExpr& rc) -> diag::Result<std::string> {
             return RenderRuntimeCallExpr(ctx, rc);
           },
       },
@@ -258,64 +311,69 @@ auto RenderExprAsNative(const RenderContext& ctx, const mir::Expr& expr)
 }
 
 auto RenderExprAsRuntimeView(const RenderContext& ctx, const mir::Expr& expr)
-    -> std::string {
+    -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
-          [&](const mir::IntegerLiteral& lit) -> std::string {
+          [&](const mir::IntegerLiteral& lit) -> diag::Result<std::string> {
             return RenderIntegerLiteralAsView(ctx.Unit(), expr.type, lit.value);
           },
-          [&](const mir::MemberVarRef& m) -> std::string {
+          [&](const mir::MemberVarRef& m) -> diag::Result<std::string> {
             return std::format(
                 "{}.View()", ctx.Class().GetMemberVar(m.target).name);
           },
-          [&](const mir::LocalVarRef& l) -> std::string {
+          [&](const mir::LocalVarRef& l) -> diag::Result<std::string> {
             return std::format("{}.View()", LookupLocalName(ctx.Body(), l));
           },
-          [&](const mir::ConversionExpr& cv) -> std::string {
-            return std::format(
-                "{}.View()", RenderConversionCall(ctx, expr.type, cv));
+          [&](const mir::ConversionExpr& cv) -> diag::Result<std::string> {
+            auto inner_or = RenderConversionCall(ctx, expr.type, cv);
+            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
+            return std::format("{}.View()", *inner_or);
           },
-          [](const mir::AssignExpr&) -> std::string {
-            throw InternalError(
-                "RenderExprAsRuntimeView: AssignExpr in a runtime-view "
-                "context is not yet supported");
+          [](const mir::AssignExpr&) -> diag::Result<std::string> {
+            return diag::Unsupported(
+                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+                "AssignExpr in a runtime-view context is not yet implemented "
+                "in cpp emit",
+                diag::UnsupportedCategory::kFeature);
           },
-          [](const auto&) -> std::string {
-            throw InternalError(
-                "RenderExprAsRuntimeView: expression form is not renderable "
-                "as a runtime view");
+          [](const auto&) -> diag::Result<std::string> {
+            return diag::Unsupported(
+                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+                "this expression form is not yet renderable as a runtime view "
+                "in cpp emit",
+                diag::UnsupportedCategory::kFeature);
           },
       },
       expr.data);
 }
 
 auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
-    -> std::string {
+    -> diag::Result<std::string> {
   // Some expressions slang types as packed but read as native rvalues
   // (e.g. comparisons over native-int operands). Mode is picked per-variant.
   return std::visit(
       Overloaded{
-          [&](const mir::IntegerLiteral&) -> std::string {
+          [&](const mir::IntegerLiteral&) -> diag::Result<std::string> {
             return IsPackedRuntime(ctx.Unit(), expr.type)
                        ? RenderExprAsRuntimeView(ctx, expr)
                        : RenderExprAsNative(ctx, expr);
           },
-          [&](const mir::MemberVarRef&) -> std::string {
+          [&](const mir::MemberVarRef&) -> diag::Result<std::string> {
             return IsPackedRuntime(ctx.Unit(), expr.type)
                        ? RenderExprAsRuntimeView(ctx, expr)
                        : RenderExprAsNative(ctx, expr);
           },
-          [&](const mir::LocalVarRef&) -> std::string {
+          [&](const mir::LocalVarRef&) -> diag::Result<std::string> {
             return IsPackedRuntime(ctx.Unit(), expr.type)
                        ? RenderExprAsRuntimeView(ctx, expr)
                        : RenderExprAsNative(ctx, expr);
           },
-          [&](const mir::ConversionExpr&) -> std::string {
+          [&](const mir::ConversionExpr&) -> diag::Result<std::string> {
             return IsPackedRuntime(ctx.Unit(), expr.type)
                        ? RenderExprAsRuntimeView(ctx, expr)
                        : RenderExprAsNative(ctx, expr);
           },
-          [&](const auto&) -> std::string {
+          [&](const auto&) -> diag::Result<std::string> {
             return RenderExprAsNative(ctx, expr);
           },
       },

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -12,6 +12,9 @@
 #include "lyra/backend/cpp/string_literal.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/kind.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/runtime_print.hpp"
 #include "lyra/mir/type.hpp"
@@ -64,14 +67,17 @@ auto RenderFormatSpecInit(const mir::FormatSpec& spec) -> std::string {
 }
 
 auto RenderRuntimeValueViewInit(
-    const RenderContext& ctx, const mir::RuntimePrintValue& v) -> std::string {
+    const RenderContext& ctx, const mir::RuntimePrintValue& v)
+    -> diag::Result<std::string> {
   const auto& type = ctx.Unit().GetType(v.type);
 
   // `%s` operands are typed as packed bit vectors by slang but reach the
   // runtime as a string_view. Dispatch on format kind, not just type.
   if (v.spec.kind == mir::FormatKind::kString) {
-    const std::string operand = RenderExprAsNative(ctx, ctx.Expr(v.value));
-    return std::format("lyra::runtime::RuntimeValueView::String({})", operand);
+    auto operand_or = RenderExprAsNative(ctx, ctx.Expr(v.value));
+    if (!operand_or) return std::unexpected(std::move(operand_or.error()));
+    return std::format(
+        "lyra::runtime::RuntimeValueView::String({})", *operand_or);
   }
 
   if (type.IsPackedArray()) {
@@ -81,33 +87,39 @@ auto RenderRuntimeValueViewInit(
 
     if (pa.form == mir::PackedArrayForm::kInt ||
         pa.form == mir::PackedArrayForm::kInteger) {
-      const std::string operand = RenderExprAsNative(ctx, ctx.Expr(v.value));
+      auto operand_or = RenderExprAsNative(ctx, ctx.Expr(v.value));
+      if (!operand_or) return std::unexpected(std::move(operand_or.error()));
       return std::format(
           "lyra::runtime::RuntimeValueView::NarrowIntegral("
           "static_cast<std::uint64_t>({}), {}, {})",
-          operand, bit_width, BoolLiteral(is_signed));
+          *operand_or, bit_width, BoolLiteral(is_signed));
     }
 
     if (pa.form == mir::PackedArrayForm::kExplicit) {
       if (bit_width > 64) {
-        throw InternalError(
-            "RenderRuntimeValueViewInit: wide integral display is not yet "
-            "supported");
+        return diag::Unsupported(
+            diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+            "wide integral display is not yet implemented in cpp emit",
+            diag::UnsupportedCategory::kFeature);
       }
-      const std::string operand_view =
-          RenderExprAsRuntimeView(ctx, ctx.Expr(v.value));
+      auto operand_view_or = RenderExprAsRuntimeView(ctx, ctx.Expr(v.value));
+      if (!operand_view_or) {
+        return std::unexpected(std::move(operand_view_or.error()));
+      }
       const char* factory =
           pa.IsFourState() ? "lyra::runtime::RuntimeValueView::FromLogicView"
                            : "lyra::runtime::RuntimeValueView::FromBitView";
       return std::format(
-          "{}({}, {})", factory, operand_view, BoolLiteral(is_signed));
+          "{}({}, {})", factory, *operand_view_or, BoolLiteral(is_signed));
     }
     throw InternalError(
         "RenderRuntimeValueViewInit: unsupported PackedArrayForm");
   }
   if (type.Kind() == mir::TypeKind::kString) {
-    const std::string operand = RenderExprAsNative(ctx, ctx.Expr(v.value));
-    return std::format("lyra::runtime::RuntimeValueView::String({})", operand);
+    auto operand_or = RenderExprAsNative(ctx, ctx.Expr(v.value));
+    if (!operand_or) return std::unexpected(std::move(operand_or.error()));
+    return std::format(
+        "lyra::runtime::RuntimeValueView::String({})", *operand_or);
   }
   throw InternalError(
       "RenderRuntimeValueViewInit: unsupported display operand type");
@@ -115,19 +127,21 @@ auto RenderRuntimeValueViewInit(
 
 auto RenderPrintItemInit(
     const RenderContext& ctx, const mir::RuntimePrintItem& item)
-    -> std::string {
+    -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
-          [&](const mir::RuntimePrintLiteral& lit) -> std::string {
+          [&](const mir::RuntimePrintLiteral& lit)
+              -> diag::Result<std::string> {
             return std::format(
                 "lyra::runtime::PrintLiteralItem{{{}, {}}}",
                 RenderCStringLiteral(lit.text), lit.text.size());
           },
-          [&](const mir::RuntimePrintValue& v) -> std::string {
+          [&](const mir::RuntimePrintValue& v) -> diag::Result<std::string> {
+            auto view_or = RenderRuntimeValueViewInit(ctx, v);
+            if (!view_or) return std::unexpected(std::move(view_or.error()));
             return std::format(
                 "lyra::runtime::PrintValueItem{{{}, {}}}",
-                RenderFormatSpecInit(v.spec),
-                RenderRuntimeValueViewInit(ctx, v));
+                RenderFormatSpecInit(v.spec), *view_or);
           },
       },
       item);
@@ -136,12 +150,14 @@ auto RenderPrintItemInit(
 }  // namespace
 
 auto RenderRuntimeCallExpr(
-    const RenderContext& ctx, const mir::RuntimeCallExpr& expr) -> std::string {
+    const RenderContext& ctx, const mir::RuntimeCallExpr& expr)
+    -> diag::Result<std::string> {
   const mir::RuntimePrintCall& call = expr.print;
   if (call.descriptor.has_value()) {
-    throw InternalError(
-        "RenderRuntimeCallExpr: descriptor present but file output is not "
-        "implemented");
+    return diag::Unsupported(
+        diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+        "file-output runtime print is not yet implemented in cpp emit",
+        diag::UnsupportedCategory::kFeature);
   }
   const std::string_view kind_literal = RenderRuntimePrintKind(call.kind);
 
@@ -162,7 +178,9 @@ auto RenderRuntimeCallExpr(
   std::vector<std::string> item_inits;
   item_inits.reserve(call.items.size());
   for (const mir::RuntimePrintItem& item : call.items) {
-    item_inits.push_back(RenderPrintItemInit(ctx, item));
+    auto init_or = RenderPrintItemInit(ctx, item);
+    if (!init_or) return std::unexpected(std::move(init_or.error()));
+    item_inits.push_back(*std::move(init_or));
   }
 
   std::string out = std::format(

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <string>
+#include <utility>
 #include <variant>
 
 #include "lyra/backend/cpp/formatting.hpp"
@@ -10,6 +11,7 @@
 #include "lyra/backend/cpp/render_type.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
+#include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/class_decl.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/stmt.hpp"
@@ -20,10 +22,10 @@ namespace lyra::backend::cpp {
 namespace {
 
 auto RenderForInit(const RenderContext& ctx, const mir::ForInit& init)
-    -> std::string {
+    -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
-          [&](const mir::ForInitDecl& d) -> std::string {
+          [&](const mir::ForInitDecl& d) -> diag::Result<std::string> {
             const auto& lv = ctx.Body()
                                  .local_scopes.at(d.local.scope.value)
                                  .locals.at(d.local.local.value);
@@ -32,11 +34,15 @@ auto RenderForInit(const RenderContext& ctx, const mir::ForInit& init)
                 lv.name;
             if (d.init.has_value()) {
               const auto& v = ctx.Body().exprs.at(d.init->value);
-              out += " = " + RenderExpr(ctx, v);
+              auto rendered_or = RenderExpr(ctx, v);
+              if (!rendered_or) {
+                return std::unexpected(std::move(rendered_or.error()));
+              }
+              out += " = " + *rendered_or;
             }
             return out;
           },
-          [&](const mir::ForInitExpr& e) -> std::string {
+          [&](const mir::ForInitExpr& e) -> diag::Result<std::string> {
             const auto& expr = ctx.Body().exprs.at(e.expr.value);
             return RenderExpr(ctx, expr);
           },
@@ -48,17 +54,17 @@ auto RenderForInit(const RenderContext& ctx, const mir::ForInit& init)
 
 auto RenderStmt(
     const RenderContext& ctx, const mir::Stmt& stmt, std::size_t indent)
-    -> std::string {
+    -> diag::Result<std::string> {
   std::string out;
   if (stmt.label.has_value()) {
     out += Indent(indent) + *stmt.label + ":\n";
   }
-  out += std::visit(
+  auto body_or = std::visit(
       Overloaded{
-          [&](const mir::EmptyStmt&) -> std::string {
+          [&](const mir::EmptyStmt&) -> diag::Result<std::string> {
             return Indent(indent) + ";\n";
           },
-          [&](const mir::TimedStmt& s) -> std::string {
+          [&](const mir::TimedStmt& s) -> diag::Result<std::string> {
             std::string out;
             std::visit(
                 Overloaded{
@@ -68,10 +74,13 @@ auto RenderStmt(
                     },
                 },
                 s.timing);
-            out += RenderStmt(ctx, ctx.Body().stmts.at(s.body.value), indent);
+            auto inner_or =
+                RenderStmt(ctx, ctx.Body().stmts.at(s.body.value), indent);
+            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
+            out += *inner_or;
             return out;
           },
-          [&](const mir::LocalVarDeclStmt& s) -> std::string {
+          [&](const mir::LocalVarDeclStmt& s) -> diag::Result<std::string> {
             const auto& lv = ctx.Body()
                                  .local_scopes.at(s.target.scope.value)
                                  .locals.at(s.target.local.value);
@@ -79,70 +88,94 @@ auto RenderStmt(
                    RenderTypeAsCpp(ctx.Unit(), ctx.Class(), lv.type) + " " +
                    lv.name + "{};\n";
           },
-          [&](const mir::ExprStmt& s) -> std::string {
+          [&](const mir::ExprStmt& s) -> diag::Result<std::string> {
             const auto& expr = ctx.Body().exprs.at(s.expr.value);
-            return Indent(indent) + RenderExpr(ctx, expr) + ";\n";
+            auto rendered_or = RenderExpr(ctx, expr);
+            if (!rendered_or) {
+              return std::unexpected(std::move(rendered_or.error()));
+            }
+            return Indent(indent) + *rendered_or + ";\n";
           },
-          [&](const mir::BlockStmt& s) -> std::string {
+          [&](const mir::BlockStmt& s) -> diag::Result<std::string> {
             std::string result = Indent(indent) + "{\n";
             for (const auto child_id : s.statements) {
-              result += RenderStmt(
+              auto child_or = RenderStmt(
                   ctx, ctx.Body().stmts.at(child_id.value), indent + 1);
+              if (!child_or) {
+                return std::unexpected(std::move(child_or.error()));
+              }
+              result += *child_or;
             }
             result += Indent(indent) + "}\n";
             return result;
           },
-          [&](const mir::IfStmt& s) -> std::string {
+          [&](const mir::IfStmt& s) -> diag::Result<std::string> {
             const auto& cond_expr = ctx.Body().exprs.at(s.condition.value);
             const auto& then_body = stmt.child_bodies.at(s.then_body.value);
-            std::string result;
-            result +=
-                Indent(indent) + "if (" + RenderExpr(ctx, cond_expr) + ") {\n";
-            result +=
+            auto cond_or = RenderExpr(ctx, cond_expr);
+            if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+            auto then_or =
                 RenderBody(ctx.Unit(), ctx.Class(), then_body, indent + 1);
+            if (!then_or) return std::unexpected(std::move(then_or.error()));
+            std::string result;
+            result += Indent(indent) + "if (" + *cond_or + ") {\n";
+            result += *then_or;
             result += Indent(indent) + "}";
             if (s.else_body.has_value()) {
               const auto& else_body = stmt.child_bodies.at(s.else_body->value);
-              result += " else {\n";
-              result +=
+              auto else_or =
                   RenderBody(ctx.Unit(), ctx.Class(), else_body, indent + 1);
+              if (!else_or) return std::unexpected(std::move(else_or.error()));
+              result += " else {\n";
+              result += *else_or;
               result += Indent(indent) + "}";
             }
             result += "\n";
             return result;
           },
-          [&](const mir::SwitchStmt& s) -> std::string {
+          [&](const mir::SwitchStmt& s) -> diag::Result<std::string> {
             const auto& cond_expr = ctx.Body().exprs.at(s.condition.value);
+            auto cond_or = RenderExpr(ctx, cond_expr);
+            if (!cond_or) return std::unexpected(std::move(cond_or.error()));
             std::string result;
-            result += Indent(indent) + "switch (" + RenderExpr(ctx, cond_expr) +
-                      ") {\n";
+            result += Indent(indent) + "switch (" + *cond_or + ") {\n";
             for (const auto& c : s.cases) {
               for (std::size_t i = 0; i < c.labels.size(); ++i) {
                 const auto& label_expr = ctx.Body().exprs.at(c.labels[i].value);
+                auto label_or = RenderExpr(ctx, label_expr);
+                if (!label_or) {
+                  return std::unexpected(std::move(label_or.error()));
+                }
                 const bool is_last = (i + 1 == c.labels.size());
-                result += Indent(indent + 1) + "case " +
-                          RenderExpr(ctx, label_expr) +
+                result += Indent(indent + 1) + "case " + *label_or +
                           (is_last ? ": {\n" : ":\n");
               }
               const auto& case_body = stmt.child_bodies.at(c.body.value);
-              result +=
+              auto case_or =
                   RenderBody(ctx.Unit(), ctx.Class(), case_body, indent + 2);
+              if (!case_or) return std::unexpected(std::move(case_or.error()));
+              result += *case_or;
               result += Indent(indent + 2) + "break;\n";
               result += Indent(indent + 1) + "}\n";
             }
             if (s.default_body.has_value()) {
               const auto& default_body =
                   stmt.child_bodies.at(s.default_body->value);
-              result += Indent(indent + 1) + "default: {\n";
-              result +=
+              auto default_or =
                   RenderBody(ctx.Unit(), ctx.Class(), default_body, indent + 2);
+              if (!default_or) {
+                return std::unexpected(std::move(default_or.error()));
+              }
+              result += Indent(indent + 1) + "default: {\n";
+              result += *default_or;
               result += Indent(indent + 2) + "break;\n";
               result += Indent(indent + 1) + "}\n";
             }
             result += Indent(indent) + "}\n";
             return result;
           },
-          [&](const mir::ConstructOwnedObjectStmt& s) -> std::string {
+          [&](const mir::ConstructOwnedObjectStmt& s)
+              -> diag::Result<std::string> {
             const auto& member = ctx.Class().GetMemberVar(s.target);
             const auto& target_class = ctx.Class().GetClass(s.class_id);
             const std::string make =
@@ -158,18 +191,26 @@ auto RenderStmt(
                 "ConstructOwnedObjectStmt target is not an owning object "
                 "member");
           },
-          [&](const mir::ForStmt& s) -> std::string {
+          [&](const mir::ForStmt& s) -> diag::Result<std::string> {
             std::string init;
             for (std::size_t i = 0; i < s.init.size(); ++i) {
               if (i != 0) {
                 init += ", ";
               }
-              init += RenderForInit(ctx, s.init[i]);
+              auto init_or = RenderForInit(ctx, s.init[i]);
+              if (!init_or) {
+                return std::unexpected(std::move(init_or.error()));
+              }
+              init += *init_or;
             }
             std::string cond;
             if (s.condition.has_value()) {
               const auto& cond_expr = ctx.Body().exprs.at(s.condition->value);
-              cond = RenderExpr(ctx, cond_expr);
+              auto cond_or = RenderExpr(ctx, cond_expr);
+              if (!cond_or) {
+                return std::unexpected(std::move(cond_or.error()));
+              }
+              cond = *std::move(cond_or);
             }
             std::string step;
             for (std::size_t i = 0; i < s.step.size(); ++i) {
@@ -177,27 +218,38 @@ auto RenderStmt(
                 step += ", ";
               }
               const auto& step_expr = ctx.Body().exprs.at(s.step[i].value);
-              step += RenderExpr(ctx, step_expr);
+              auto step_or = RenderExpr(ctx, step_expr);
+              if (!step_or) {
+                return std::unexpected(std::move(step_or.error()));
+              }
+              step += *step_or;
             }
             const auto& body = stmt.child_bodies.at(s.body.value);
+            auto body_or =
+                RenderBody(ctx.Unit(), ctx.Class(), body, indent + 1);
+            if (!body_or) return std::unexpected(std::move(body_or.error()));
             std::string result = Indent(indent) + "for (" + init + "; " + cond +
                                  "; " + step + ") {\n";
-            result += RenderBody(ctx.Unit(), ctx.Class(), body, indent + 1);
+            result += *body_or;
             result += Indent(indent) + "}\n";
             return result;
           },
       },
       stmt.data);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+  out += *body_or;
   return out;
 }
 
 auto RenderBody(
     const mir::CompilationUnit& unit, const mir::ClassDecl& class_decl,
-    const mir::Body& body, std::size_t indent) -> std::string {
+    const mir::Body& body, std::size_t indent) -> diag::Result<std::string> {
   const RenderContext ctx{unit, class_decl, body};
   std::string out;
   for (const auto& sid : body.root_stmts) {
-    out += RenderStmt(ctx, body.stmts.at(sid.value), indent);
+    auto rendered_or = RenderStmt(ctx, body.stmts.at(sid.value), indent);
+    if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
+    out += *rendered_or;
   }
   return out;
 }

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -213,6 +213,25 @@ constexpr std::array kEntries{
             .name = "system_subroutine_execution_not_implemented"}},
 
     std::pair{
+        DiagCode::kCppEmitBinaryOpNotImplemented,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "cpp_emit_binary_op_not_implemented"}},
+    std::pair{
+        DiagCode::kCppEmitUnaryOpNotImplemented,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "cpp_emit_unary_op_not_implemented"}},
+    std::pair{
+        DiagCode::kCppEmitExpressionFormNotImplemented,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "cpp_emit_expression_form_not_implemented"}},
+
+    std::pair{
         DiagCode::kHostInvalidCliArgs,
         DiagCodeInfo{
             .kind = DiagKind::kHostError,

--- a/src/lyra/driver/cli.cpp
+++ b/src/lyra/driver/cli.cpp
@@ -254,8 +254,16 @@ auto main(int argc, char** argv) -> int {
                   "emit cpp: top class '{}' not found in compilation unit",
                   args.input.top));
         }
-        auto set =
+        auto set_or =
             lyra::backend::cpp::EmitCpp(*result.artifacts.mir_unit, *entry);
+        if (!set_or) {
+          const lyra::diag::SourceManager* mgr =
+              result.artifacts.parse ? &result.artifacts.parse->diag_sources
+                                     : nullptr;
+          report(std::move(set_or.error()), mgr);
+          return 1;
+        }
+        const auto& set = *set_or;
         if (args.emit_out_dir.empty()) {
           for (const auto& file : set.files) {
             fmt::print("=== {} ===\n{}", file.relpath, file.content);

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -22,6 +22,7 @@
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/type.hpp"
+#include "lyra/hir/unary_op.hpp"
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
@@ -161,12 +162,90 @@ class HirDumper {
         t.data);
   }
 
+  static auto FormatUnaryOp(UnaryOp op) -> std::string {
+    switch (op) {
+      case UnaryOp::kPlus:
+        return "Plus";
+      case UnaryOp::kMinus:
+        return "Minus";
+      case UnaryOp::kBitwiseNot:
+        return "BitwiseNot";
+      case UnaryOp::kLogicalNot:
+        return "LogicalNot";
+      case UnaryOp::kReductionAnd:
+        return "ReductionAnd";
+      case UnaryOp::kReductionOr:
+        return "ReductionOr";
+      case UnaryOp::kReductionXor:
+        return "ReductionXor";
+      case UnaryOp::kReductionNand:
+        return "ReductionNand";
+      case UnaryOp::kReductionNor:
+        return "ReductionNor";
+      case UnaryOp::kReductionXnor:
+        return "ReductionXnor";
+    }
+    throw InternalError("HirDumper: unknown UnaryOp");
+  }
+
   static auto FormatBinaryOp(BinaryOp op) -> std::string {
     switch (op) {
       case BinaryOp::kAdd:
         return "Add";
+      case BinaryOp::kSub:
+        return "Sub";
+      case BinaryOp::kMul:
+        return "Mul";
+      case BinaryOp::kDiv:
+        return "Div";
+      case BinaryOp::kMod:
+        return "Mod";
+      case BinaryOp::kPower:
+        return "Power";
+      case BinaryOp::kBitwiseAnd:
+        return "BitwiseAnd";
+      case BinaryOp::kBitwiseOr:
+        return "BitwiseOr";
+      case BinaryOp::kBitwiseXor:
+        return "BitwiseXor";
+      case BinaryOp::kBitwiseXnor:
+        return "BitwiseXnor";
+      case BinaryOp::kEquality:
+        return "Equality";
+      case BinaryOp::kInequality:
+        return "Inequality";
+      case BinaryOp::kCaseEquality:
+        return "CaseEquality";
+      case BinaryOp::kCaseInequality:
+        return "CaseInequality";
+      case BinaryOp::kWildcardEquality:
+        return "WildcardEquality";
+      case BinaryOp::kWildcardInequality:
+        return "WildcardInequality";
+      case BinaryOp::kGreaterEqual:
+        return "GreaterEqual";
+      case BinaryOp::kGreaterThan:
+        return "GreaterThan";
+      case BinaryOp::kLessEqual:
+        return "LessEqual";
       case BinaryOp::kLessThan:
         return "LessThan";
+      case BinaryOp::kLogicalAnd:
+        return "LogicalAnd";
+      case BinaryOp::kLogicalOr:
+        return "LogicalOr";
+      case BinaryOp::kLogicalImplication:
+        return "LogicalImplication";
+      case BinaryOp::kLogicalEquivalence:
+        return "LogicalEquivalence";
+      case BinaryOp::kLogicalShiftLeft:
+        return "LogicalShiftLeft";
+      case BinaryOp::kLogicalShiftRight:
+        return "LogicalShiftRight";
+      case BinaryOp::kArithmeticShiftLeft:
+        return "ArithmeticShiftLeft";
+      case BinaryOp::kArithmeticShiftRight:
+        return "ArithmeticShiftRight";
     }
     throw InternalError("HirDumper: unknown BinaryOp");
   }
@@ -333,6 +412,11 @@ class HirDumper {
         Overloaded{
             [](const PrimaryExpr& p) -> std::string {
               return FormatPrimary(p.data);
+            },
+            [](const UnaryExpr& u) -> std::string {
+              return std::format(
+                  "UnaryExpr op={} operand=Expr[{}]", FormatUnaryOp(u.op),
+                  u.operand.value);
             },
             [](const BinaryExpr& b) -> std::string {
               return std::format(

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -31,6 +31,7 @@
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/type.hpp"
+#include "lyra/hir/unary_op.hpp"
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
@@ -75,6 +76,103 @@ auto LowerConversionKind(slang::ast::ConversionKind k) -> hir::ConversionKind {
       return hir::ConversionKind::kBitstreamCast;
   }
   throw InternalError("LowerConversionKind: unknown slang ConversionKind");
+}
+
+auto LowerBinaryOp(slang::ast::BinaryOperator op) -> hir::BinaryOp {
+  switch (op) {
+    case slang::ast::BinaryOperator::Add:
+      return hir::BinaryOp::kAdd;
+    case slang::ast::BinaryOperator::Subtract:
+      return hir::BinaryOp::kSub;
+    case slang::ast::BinaryOperator::Multiply:
+      return hir::BinaryOp::kMul;
+    case slang::ast::BinaryOperator::Divide:
+      return hir::BinaryOp::kDiv;
+    case slang::ast::BinaryOperator::Mod:
+      return hir::BinaryOp::kMod;
+    case slang::ast::BinaryOperator::Power:
+      return hir::BinaryOp::kPower;
+    case slang::ast::BinaryOperator::BinaryAnd:
+      return hir::BinaryOp::kBitwiseAnd;
+    case slang::ast::BinaryOperator::BinaryOr:
+      return hir::BinaryOp::kBitwiseOr;
+    case slang::ast::BinaryOperator::BinaryXor:
+      return hir::BinaryOp::kBitwiseXor;
+    case slang::ast::BinaryOperator::BinaryXnor:
+      return hir::BinaryOp::kBitwiseXnor;
+    case slang::ast::BinaryOperator::Equality:
+      return hir::BinaryOp::kEquality;
+    case slang::ast::BinaryOperator::Inequality:
+      return hir::BinaryOp::kInequality;
+    case slang::ast::BinaryOperator::CaseEquality:
+      return hir::BinaryOp::kCaseEquality;
+    case slang::ast::BinaryOperator::CaseInequality:
+      return hir::BinaryOp::kCaseInequality;
+    case slang::ast::BinaryOperator::WildcardEquality:
+      return hir::BinaryOp::kWildcardEquality;
+    case slang::ast::BinaryOperator::WildcardInequality:
+      return hir::BinaryOp::kWildcardInequality;
+    case slang::ast::BinaryOperator::GreaterThanEqual:
+      return hir::BinaryOp::kGreaterEqual;
+    case slang::ast::BinaryOperator::GreaterThan:
+      return hir::BinaryOp::kGreaterThan;
+    case slang::ast::BinaryOperator::LessThanEqual:
+      return hir::BinaryOp::kLessEqual;
+    case slang::ast::BinaryOperator::LessThan:
+      return hir::BinaryOp::kLessThan;
+    case slang::ast::BinaryOperator::LogicalAnd:
+      return hir::BinaryOp::kLogicalAnd;
+    case slang::ast::BinaryOperator::LogicalOr:
+      return hir::BinaryOp::kLogicalOr;
+    case slang::ast::BinaryOperator::LogicalImplication:
+      return hir::BinaryOp::kLogicalImplication;
+    case slang::ast::BinaryOperator::LogicalEquivalence:
+      return hir::BinaryOp::kLogicalEquivalence;
+    case slang::ast::BinaryOperator::LogicalShiftLeft:
+      return hir::BinaryOp::kLogicalShiftLeft;
+    case slang::ast::BinaryOperator::LogicalShiftRight:
+      return hir::BinaryOp::kLogicalShiftRight;
+    case slang::ast::BinaryOperator::ArithmeticShiftLeft:
+      return hir::BinaryOp::kArithmeticShiftLeft;
+    case slang::ast::BinaryOperator::ArithmeticShiftRight:
+      return hir::BinaryOp::kArithmeticShiftRight;
+  }
+  throw InternalError("LowerBinaryOp: unknown slang BinaryOperator");
+}
+
+auto LowerUnaryOp(slang::ast::UnaryOperator op, diag::SourceSpan span)
+    -> diag::Result<hir::UnaryOp> {
+  switch (op) {
+    case slang::ast::UnaryOperator::Plus:
+      return hir::UnaryOp::kPlus;
+    case slang::ast::UnaryOperator::Minus:
+      return hir::UnaryOp::kMinus;
+    case slang::ast::UnaryOperator::BitwiseNot:
+      return hir::UnaryOp::kBitwiseNot;
+    case slang::ast::UnaryOperator::LogicalNot:
+      return hir::UnaryOp::kLogicalNot;
+    case slang::ast::UnaryOperator::BitwiseAnd:
+      return hir::UnaryOp::kReductionAnd;
+    case slang::ast::UnaryOperator::BitwiseOr:
+      return hir::UnaryOp::kReductionOr;
+    case slang::ast::UnaryOperator::BitwiseXor:
+      return hir::UnaryOp::kReductionXor;
+    case slang::ast::UnaryOperator::BitwiseNand:
+      return hir::UnaryOp::kReductionNand;
+    case slang::ast::UnaryOperator::BitwiseNor:
+      return hir::UnaryOp::kReductionNor;
+    case slang::ast::UnaryOperator::BitwiseXnor:
+      return hir::UnaryOp::kReductionXnor;
+    case slang::ast::UnaryOperator::Preincrement:
+    case slang::ast::UnaryOperator::Predecrement:
+    case slang::ast::UnaryOperator::Postincrement:
+    case slang::ast::UnaryOperator::Postdecrement:
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "increment and decrement expressions are not supported yet",
+          diag::UnsupportedCategory::kOperation);
+  }
+  throw InternalError("LowerUnaryOp: unknown slang UnaryOperator");
 }
 
 auto MakeIntegerLiteralExpr(
@@ -295,14 +393,23 @@ auto LowerProcExpr(
       };
     }
 
+    case slang::ast::ExpressionKind::UnaryOp: {
+      const auto& un = expr.as<slang::ast::UnaryExpression>();
+      auto op_or = LowerUnaryOp(un.op, span);
+      if (!op_or) return std::unexpected(std::move(op_or.error()));
+      auto operand_id = append_child(un.operand());
+      if (!operand_id) return std::unexpected(std::move(operand_id.error()));
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return hir::Expr{
+          .type = *type_id,
+          .data = hir::UnaryExpr{.op = *op_or, .operand = *operand_id},
+          .span = span,
+      };
+    }
+
     case slang::ast::ExpressionKind::BinaryOp: {
       const auto& bin = expr.as<slang::ast::BinaryExpression>();
-      if (bin.op != slang::ast::BinaryOperator::Add) {
-        return diag::Unsupported(
-            span, diag::DiagCode::kUnsupportedBinaryOperator,
-            "only `+` is currently supported",
-            diag::UnsupportedCategory::kOperation);
-      }
       auto lhs_id = append_child(bin.left());
       if (!lhs_id) return std::unexpected(std::move(lhs_id.error()));
       auto rhs_id = append_child(bin.right());
@@ -313,7 +420,7 @@ auto LowerProcExpr(
           .type = *type_id,
           .data =
               hir::BinaryExpr{
-                  .op = hir::BinaryOp::kAdd,
+                  .op = LowerBinaryOp(bin.op),
                   .lhs = *lhs_id,
                   .rhs = *rhs_id,
               },
@@ -515,18 +622,6 @@ auto TryResolveLoopHeaderVar(
   return loop_state.loop_var_id;
 }
 
-auto MapLoopHeaderBinaryOp(slang::ast::BinaryOperator op)
-    -> std::optional<hir::BinaryOp> {
-  switch (op) {
-    case slang::ast::BinaryOperator::Add:
-      return hir::BinaryOp::kAdd;
-    case slang::ast::BinaryOperator::LessThan:
-      return hir::BinaryOp::kLessThan;
-    default:
-      return std::nullopt;
-  }
-}
-
 }  // namespace
 
 auto LowerLoopHeaderExpr(
@@ -628,15 +723,23 @@ auto LowerLoopHeaderExpr(
       };
     }
 
+    case slang::ast::ExpressionKind::UnaryOp: {
+      const auto& un = expr.as<slang::ast::UnaryExpression>();
+      auto op_or = LowerUnaryOp(un.op, span);
+      if (!op_or) return std::unexpected(std::move(op_or.error()));
+      auto operand_id = add_child(un.operand());
+      if (!operand_id) return std::unexpected(std::move(operand_id.error()));
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return hir::Expr{
+          .type = *type_id,
+          .data = hir::UnaryExpr{.op = *op_or, .operand = *operand_id},
+          .span = span,
+      };
+    }
+
     case slang::ast::ExpressionKind::BinaryOp: {
       const auto& bin = expr.as<slang::ast::BinaryExpression>();
-      auto op = MapLoopHeaderBinaryOp(bin.op);
-      if (!op.has_value()) {
-        return diag::Unsupported(
-            span, diag::DiagCode::kUnsupportedBinaryOperator,
-            "this binary operator is not supported yet",
-            diag::UnsupportedCategory::kOperation);
-      }
       auto lhs_id = add_child(bin.left());
       if (!lhs_id) return std::unexpected(std::move(lhs_id.error()));
       auto rhs_id = add_child(bin.right());
@@ -645,7 +748,12 @@ auto LowerLoopHeaderExpr(
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return hir::Expr{
           .type = *type_id,
-          .data = hir::BinaryExpr{.op = *op, .lhs = *lhs_id, .rhs = *rhs_id},
+          .data =
+              hir::BinaryExpr{
+                  .op = LowerBinaryOp(bin.op),
+                  .lhs = *lhs_id,
+                  .rhs = *rhs_id,
+              },
           .span = span,
       };
     }

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -17,6 +17,7 @@
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/type.hpp"
+#include "lyra/hir/unary_op.hpp"
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/hir_to_mir/lower_system_subroutine.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
@@ -24,17 +25,97 @@
 #include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/integral_constant.hpp"
+#include "lyra/mir/unary_op.hpp"
 
 namespace lyra::lowering::hir_to_mir {
+
+namespace {
 
 auto LowerBinaryOp(hir::BinaryOp op) -> mir::BinaryOp {
   switch (op) {
     case hir::BinaryOp::kAdd:
       return mir::BinaryOp::kAdd;
+    case hir::BinaryOp::kSub:
+      return mir::BinaryOp::kSub;
+    case hir::BinaryOp::kMul:
+      return mir::BinaryOp::kMul;
+    case hir::BinaryOp::kDiv:
+      return mir::BinaryOp::kDiv;
+    case hir::BinaryOp::kMod:
+      return mir::BinaryOp::kMod;
+    case hir::BinaryOp::kPower:
+      return mir::BinaryOp::kPower;
+    case hir::BinaryOp::kBitwiseAnd:
+      return mir::BinaryOp::kBitwiseAnd;
+    case hir::BinaryOp::kBitwiseOr:
+      return mir::BinaryOp::kBitwiseOr;
+    case hir::BinaryOp::kBitwiseXor:
+      return mir::BinaryOp::kBitwiseXor;
+    case hir::BinaryOp::kBitwiseXnor:
+      return mir::BinaryOp::kBitwiseXnor;
+    case hir::BinaryOp::kEquality:
+      return mir::BinaryOp::kEquality;
+    case hir::BinaryOp::kInequality:
+      return mir::BinaryOp::kInequality;
+    case hir::BinaryOp::kCaseEquality:
+      return mir::BinaryOp::kCaseEquality;
+    case hir::BinaryOp::kCaseInequality:
+      return mir::BinaryOp::kCaseInequality;
+    case hir::BinaryOp::kWildcardEquality:
+      return mir::BinaryOp::kWildcardEquality;
+    case hir::BinaryOp::kWildcardInequality:
+      return mir::BinaryOp::kWildcardInequality;
+    case hir::BinaryOp::kGreaterEqual:
+      return mir::BinaryOp::kGreaterEqual;
+    case hir::BinaryOp::kGreaterThan:
+      return mir::BinaryOp::kGreaterThan;
+    case hir::BinaryOp::kLessEqual:
+      return mir::BinaryOp::kLessEqual;
     case hir::BinaryOp::kLessThan:
       return mir::BinaryOp::kLessThan;
+    case hir::BinaryOp::kLogicalAnd:
+      return mir::BinaryOp::kLogicalAnd;
+    case hir::BinaryOp::kLogicalOr:
+      return mir::BinaryOp::kLogicalOr;
+    case hir::BinaryOp::kLogicalImplication:
+      return mir::BinaryOp::kLogicalImplication;
+    case hir::BinaryOp::kLogicalEquivalence:
+      return mir::BinaryOp::kLogicalEquivalence;
+    case hir::BinaryOp::kLogicalShiftLeft:
+    case hir::BinaryOp::kArithmeticShiftLeft:
+      return mir::BinaryOp::kShiftLeft;
+    case hir::BinaryOp::kLogicalShiftRight:
+      return mir::BinaryOp::kLogicalShiftRight;
+    case hir::BinaryOp::kArithmeticShiftRight:
+      return mir::BinaryOp::kArithmeticShiftRight;
   }
   throw InternalError("LowerBinaryOp: unknown HIR BinaryOp");
+}
+
+auto LowerUnaryOp(hir::UnaryOp op) -> mir::UnaryOp {
+  switch (op) {
+    case hir::UnaryOp::kPlus:
+      return mir::UnaryOp::kPlus;
+    case hir::UnaryOp::kMinus:
+      return mir::UnaryOp::kMinus;
+    case hir::UnaryOp::kBitwiseNot:
+      return mir::UnaryOp::kBitwiseNot;
+    case hir::UnaryOp::kLogicalNot:
+      return mir::UnaryOp::kLogicalNot;
+    case hir::UnaryOp::kReductionAnd:
+      return mir::UnaryOp::kReductionAnd;
+    case hir::UnaryOp::kReductionOr:
+      return mir::UnaryOp::kReductionOr;
+    case hir::UnaryOp::kReductionXor:
+      return mir::UnaryOp::kReductionXor;
+    case hir::UnaryOp::kReductionNand:
+      return mir::UnaryOp::kReductionNand;
+    case hir::UnaryOp::kReductionNor:
+      return mir::UnaryOp::kReductionNor;
+    case hir::UnaryOp::kReductionXnor:
+      return mir::UnaryOp::kReductionXnor;
+  }
+  throw InternalError("LowerUnaryOp: unknown HIR UnaryOp");
 }
 
 auto LowerTimeScale(hir::TimeScale s) -> mir::TimeScale {
@@ -54,8 +135,6 @@ auto LowerTimeScale(hir::TimeScale s) -> mir::TimeScale {
   }
   throw InternalError("LowerTimeScale: unknown HIR TimeScale");
 }
-
-namespace {
 
 auto LowerSignedness(hir::Signedness s) -> mir::Signedness {
   switch (s) {
@@ -286,6 +365,21 @@ auto LowerExpr(
             return LowerPrimaryExpr(
                 unit_state, class_state, proc_state, p, result_type);
           },
+          [&](const hir::UnaryExpr& u) -> diag::Result<mir::Expr> {
+            auto operand_or = LowerExpr(
+                unit_state, class_state, proc_state, body_state, hir_process,
+                hir_process.exprs.at(u.operand.value));
+            if (!operand_or) {
+              return std::unexpected(std::move(operand_or.error()));
+            }
+            const mir::ExprId operand_id =
+                body_state.AddExpr(*std::move(operand_or));
+            return mir::Expr{
+                .data =
+                    mir::UnaryExpr{
+                        .op = LowerUnaryOp(u.op), .operand = operand_id},
+                .type = result_type};
+          },
           [&](const hir::BinaryExpr& b) -> diag::Result<mir::Expr> {
             auto lhs_or = LowerExpr(
                 unit_state, class_state, proc_state, body_state, hir_process,
@@ -387,6 +481,21 @@ auto LowerExpr(
           [&](const hir::PrimaryExpr& p) -> diag::Result<mir::Expr> {
             return LowerPrimaryExpr(
                 unit_state, class_state, ctor_state, p, result_type);
+          },
+          [&](const hir::UnaryExpr& u) -> diag::Result<mir::Expr> {
+            auto operand_or = LowerExpr(
+                unit_state, class_state, ctor_state, body_state, scope,
+                scope.GetExpr(u.operand));
+            if (!operand_or) {
+              return std::unexpected(std::move(operand_or.error()));
+            }
+            const mir::ExprId operand_id =
+                body_state.AddExpr(*std::move(operand_or));
+            return mir::Expr{
+                .data =
+                    mir::UnaryExpr{
+                        .op = LowerUnaryOp(u.op), .operand = operand_id},
+                .type = result_type};
           },
           [&](const hir::BinaryExpr& b) -> diag::Result<mir::Expr> {
             auto lhs_or = LowerExpr(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -20,6 +20,7 @@
 #include "lyra/mir/process.hpp"
 #include "lyra/mir/stmt.hpp"
 #include "lyra/mir/type.hpp"
+#include "lyra/mir/unary_op.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::mir {
@@ -208,12 +209,88 @@ class MirDumper {
         tc);
   }
 
+  static auto FormatUnaryOp(UnaryOp op) -> std::string {
+    switch (op) {
+      case UnaryOp::kPlus:
+        return "Plus";
+      case UnaryOp::kMinus:
+        return "Minus";
+      case UnaryOp::kBitwiseNot:
+        return "BitwiseNot";
+      case UnaryOp::kLogicalNot:
+        return "LogicalNot";
+      case UnaryOp::kReductionAnd:
+        return "ReductionAnd";
+      case UnaryOp::kReductionOr:
+        return "ReductionOr";
+      case UnaryOp::kReductionXor:
+        return "ReductionXor";
+      case UnaryOp::kReductionNand:
+        return "ReductionNand";
+      case UnaryOp::kReductionNor:
+        return "ReductionNor";
+      case UnaryOp::kReductionXnor:
+        return "ReductionXnor";
+    }
+    throw InternalError("MirDumper: unknown UnaryOp");
+  }
+
   static auto FormatBinaryOp(BinaryOp op) -> std::string {
     switch (op) {
       case BinaryOp::kAdd:
         return "Add";
+      case BinaryOp::kSub:
+        return "Sub";
+      case BinaryOp::kMul:
+        return "Mul";
+      case BinaryOp::kDiv:
+        return "Div";
+      case BinaryOp::kMod:
+        return "Mod";
+      case BinaryOp::kPower:
+        return "Power";
+      case BinaryOp::kBitwiseAnd:
+        return "BitwiseAnd";
+      case BinaryOp::kBitwiseOr:
+        return "BitwiseOr";
+      case BinaryOp::kBitwiseXor:
+        return "BitwiseXor";
+      case BinaryOp::kBitwiseXnor:
+        return "BitwiseXnor";
+      case BinaryOp::kEquality:
+        return "Equality";
+      case BinaryOp::kInequality:
+        return "Inequality";
+      case BinaryOp::kCaseEquality:
+        return "CaseEquality";
+      case BinaryOp::kCaseInequality:
+        return "CaseInequality";
+      case BinaryOp::kWildcardEquality:
+        return "WildcardEquality";
+      case BinaryOp::kWildcardInequality:
+        return "WildcardInequality";
+      case BinaryOp::kGreaterEqual:
+        return "GreaterEqual";
+      case BinaryOp::kGreaterThan:
+        return "GreaterThan";
+      case BinaryOp::kLessEqual:
+        return "LessEqual";
       case BinaryOp::kLessThan:
         return "LessThan";
+      case BinaryOp::kLogicalAnd:
+        return "LogicalAnd";
+      case BinaryOp::kLogicalOr:
+        return "LogicalOr";
+      case BinaryOp::kLogicalImplication:
+        return "LogicalImplication";
+      case BinaryOp::kLogicalEquivalence:
+        return "LogicalEquivalence";
+      case BinaryOp::kShiftLeft:
+        return "ShiftLeft";
+      case BinaryOp::kLogicalShiftRight:
+        return "LogicalShiftRight";
+      case BinaryOp::kArithmeticShiftRight:
+        return "ArithmeticShiftRight";
     }
     throw InternalError("MirDumper: unknown BinaryOp");
   }
@@ -325,6 +402,11 @@ class MirDumper {
               return std::format(
                   "LocalVarRef(scope={}, local={})", r.scope.value,
                   r.local.value);
+            },
+            [](const UnaryExpr& u) -> std::string {
+              return std::format(
+                  "UnaryExpr op={} operand=Expr[{}]", FormatUnaryOp(u.op),
+                  u.operand.value);
             },
             [](const BinaryExpr& b) -> std::string {
               return std::format(

--- a/tests/cases/dump/hir_binary_arith/case.yaml
+++ b/tests/cases/dump/hir_binary_arith/case.yaml
@@ -1,0 +1,17 @@
+id: dump.hir_binary_arith
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "BinaryExpr op=Add"
+      - "BinaryExpr op=Sub"
+      - "BinaryExpr op=Mul"
+      - "BinaryExpr op=Div"
+      - "BinaryExpr op=Mod"
+      - "BinaryExpr op=Power"

--- a/tests/cases/dump/hir_binary_arith/main.sv
+++ b/tests/cases/dump/hir_binary_arith/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  logic [7:0] a;
+  logic [7:0] b;
+  logic [7:0] y;
+  initial begin
+    y = a + b;
+    y = a - b;
+    y = a * b;
+    y = a / b;
+    y = a % b;
+    y = a ** b;
+  end
+endmodule

--- a/tests/cases/dump/hir_binary_bitwise/case.yaml
+++ b/tests/cases/dump/hir_binary_bitwise/case.yaml
@@ -1,0 +1,15 @@
+id: dump.hir_binary_bitwise
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "BinaryExpr op=BitwiseAnd"
+      - "BinaryExpr op=BitwiseOr"
+      - "BinaryExpr op=BitwiseXor"
+      - "BinaryExpr op=BitwiseXnor"

--- a/tests/cases/dump/hir_binary_bitwise/main.sv
+++ b/tests/cases/dump/hir_binary_bitwise/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  logic [7:0] a;
+  logic [7:0] b;
+  logic [7:0] y;
+  initial begin
+    y = a & b;
+    y = a | b;
+    y = a ^ b;
+    y = a ~^ b;
+  end
+endmodule

--- a/tests/cases/dump/hir_binary_compare/case.yaml
+++ b/tests/cases/dump/hir_binary_compare/case.yaml
@@ -1,0 +1,21 @@
+id: dump.hir_binary_compare
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "BinaryExpr op=Equality"
+      - "BinaryExpr op=Inequality"
+      - "BinaryExpr op=CaseEquality"
+      - "BinaryExpr op=CaseInequality"
+      - "BinaryExpr op=WildcardEquality"
+      - "BinaryExpr op=WildcardInequality"
+      - "BinaryExpr op=GreaterEqual"
+      - "BinaryExpr op=GreaterThan"
+      - "BinaryExpr op=LessEqual"
+      - "BinaryExpr op=LessThan"

--- a/tests/cases/dump/hir_binary_compare/main.sv
+++ b/tests/cases/dump/hir_binary_compare/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  logic [7:0] a;
+  logic [7:0] b;
+  logic y;
+  initial begin
+    y = a == b;
+    y = a != b;
+    y = a === b;
+    y = a !== b;
+    y = a ==? b;
+    y = a !=? b;
+    y = a >= b;
+    y = a > b;
+    y = a <= b;
+    y = a < b;
+  end
+endmodule

--- a/tests/cases/dump/hir_binary_conversion/case.yaml
+++ b/tests/cases/dump/hir_binary_conversion/case.yaml
@@ -1,0 +1,13 @@
+id: dump.hir_binary_conversion
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "ConversionExpr kind=propagated"
+      - "BinaryExpr op=Add"

--- a/tests/cases/dump/hir_binary_conversion/main.sv
+++ b/tests/cases/dump/hir_binary_conversion/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  logic [3:0] a;
+  logic [7:0] b;
+  logic [7:0] y;
+  initial begin
+    y = a + b;
+  end
+endmodule

--- a/tests/cases/dump/hir_binary_logical/case.yaml
+++ b/tests/cases/dump/hir_binary_logical/case.yaml
@@ -1,0 +1,15 @@
+id: dump.hir_binary_logical
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "BinaryExpr op=LogicalAnd"
+      - "BinaryExpr op=LogicalOr"
+      - "BinaryExpr op=LogicalImplication"
+      - "BinaryExpr op=LogicalEquivalence"

--- a/tests/cases/dump/hir_binary_logical/main.sv
+++ b/tests/cases/dump/hir_binary_logical/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  logic a;
+  logic b;
+  logic y;
+  initial begin
+    y = a && b;
+    y = a || b;
+    y = a -> b;
+    y = a <-> b;
+  end
+endmodule

--- a/tests/cases/dump/hir_binary_shift/case.yaml
+++ b/tests/cases/dump/hir_binary_shift/case.yaml
@@ -1,0 +1,15 @@
+id: dump.hir_binary_shift
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "BinaryExpr op=LogicalShiftLeft"
+      - "BinaryExpr op=ArithmeticShiftLeft"
+      - "BinaryExpr op=LogicalShiftRight"
+      - "BinaryExpr op=ArithmeticShiftRight"

--- a/tests/cases/dump/hir_binary_shift/main.sv
+++ b/tests/cases/dump/hir_binary_shift/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  logic signed [7:0] a;
+  logic [2:0] s;
+  logic [7:0] y;
+  initial begin
+    y = a << s;
+    y = a <<< s;
+    y = a >> s;
+    y = a >>> s;
+  end
+endmodule

--- a/tests/cases/dump/hir_unary_pure/case.yaml
+++ b/tests/cases/dump/hir_unary_pure/case.yaml
@@ -1,0 +1,21 @@
+id: dump.hir_unary_pure
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "UnaryExpr op=Plus"
+      - "UnaryExpr op=Minus"
+      - "UnaryExpr op=BitwiseNot"
+      - "UnaryExpr op=LogicalNot"
+      - "UnaryExpr op=ReductionAnd"
+      - "UnaryExpr op=ReductionOr"
+      - "UnaryExpr op=ReductionXor"
+      - "UnaryExpr op=ReductionNand"
+      - "UnaryExpr op=ReductionNor"
+      - "UnaryExpr op=ReductionXnor"

--- a/tests/cases/dump/hir_unary_pure/main.sv
+++ b/tests/cases/dump/hir_unary_pure/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  logic [3:0] a;
+  logic y;
+  initial begin
+    y = +a;
+    y = -a;
+    y = ~a;
+    y = !a;
+    y = &a;
+    y = |a;
+    y = ^a;
+    y = ~&a;
+    y = ~|a;
+    y = ~^a;
+  end
+endmodule

--- a/tests/cases/dump/mir_binary_arith/case.yaml
+++ b/tests/cases/dump/mir_binary_arith/case.yaml
@@ -1,0 +1,17 @@
+id: dump.mir_binary_arith
+tags: [dump]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "BinaryExpr op=Add"
+      - "BinaryExpr op=Sub"
+      - "BinaryExpr op=Mul"
+      - "BinaryExpr op=Div"
+      - "BinaryExpr op=Mod"
+      - "BinaryExpr op=Power"

--- a/tests/cases/dump/mir_binary_arith/main.sv
+++ b/tests/cases/dump/mir_binary_arith/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  logic [7:0] a;
+  logic [7:0] b;
+  logic [7:0] y;
+  initial begin
+    y = a + b;
+    y = a - b;
+    y = a * b;
+    y = a / b;
+    y = a % b;
+    y = a ** b;
+  end
+endmodule

--- a/tests/cases/dump/mir_binary_bitwise/case.yaml
+++ b/tests/cases/dump/mir_binary_bitwise/case.yaml
@@ -1,0 +1,15 @@
+id: dump.mir_binary_bitwise
+tags: [dump]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "BinaryExpr op=BitwiseAnd"
+      - "BinaryExpr op=BitwiseOr"
+      - "BinaryExpr op=BitwiseXor"
+      - "BinaryExpr op=BitwiseXnor"

--- a/tests/cases/dump/mir_binary_bitwise/main.sv
+++ b/tests/cases/dump/mir_binary_bitwise/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  logic [7:0] a;
+  logic [7:0] b;
+  logic [7:0] y;
+  initial begin
+    y = a & b;
+    y = a | b;
+    y = a ^ b;
+    y = a ~^ b;
+  end
+endmodule

--- a/tests/cases/dump/mir_binary_compare/case.yaml
+++ b/tests/cases/dump/mir_binary_compare/case.yaml
@@ -1,0 +1,21 @@
+id: dump.mir_binary_compare
+tags: [dump]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "BinaryExpr op=Equality"
+      - "BinaryExpr op=Inequality"
+      - "BinaryExpr op=CaseEquality"
+      - "BinaryExpr op=CaseInequality"
+      - "BinaryExpr op=WildcardEquality"
+      - "BinaryExpr op=WildcardInequality"
+      - "BinaryExpr op=GreaterEqual"
+      - "BinaryExpr op=GreaterThan"
+      - "BinaryExpr op=LessEqual"
+      - "BinaryExpr op=LessThan"

--- a/tests/cases/dump/mir_binary_compare/main.sv
+++ b/tests/cases/dump/mir_binary_compare/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  logic [7:0] a;
+  logic [7:0] b;
+  logic y;
+  initial begin
+    y = a == b;
+    y = a != b;
+    y = a === b;
+    y = a !== b;
+    y = a ==? b;
+    y = a !=? b;
+    y = a >= b;
+    y = a > b;
+    y = a <= b;
+    y = a < b;
+  end
+endmodule

--- a/tests/cases/dump/mir_binary_conversion/case.yaml
+++ b/tests/cases/dump/mir_binary_conversion/case.yaml
@@ -1,0 +1,13 @@
+id: dump.mir_binary_conversion
+tags: [dump]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "ConversionExpr kind=propagated"
+      - "BinaryExpr op=Add"

--- a/tests/cases/dump/mir_binary_conversion/main.sv
+++ b/tests/cases/dump/mir_binary_conversion/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  logic [3:0] a;
+  logic [7:0] b;
+  logic [7:0] y;
+  initial begin
+    y = a + b;
+  end
+endmodule

--- a/tests/cases/dump/mir_binary_logical/case.yaml
+++ b/tests/cases/dump/mir_binary_logical/case.yaml
@@ -1,0 +1,15 @@
+id: dump.mir_binary_logical
+tags: [dump]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "BinaryExpr op=LogicalAnd"
+      - "BinaryExpr op=LogicalOr"
+      - "BinaryExpr op=LogicalImplication"
+      - "BinaryExpr op=LogicalEquivalence"

--- a/tests/cases/dump/mir_binary_logical/main.sv
+++ b/tests/cases/dump/mir_binary_logical/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  logic a;
+  logic b;
+  logic y;
+  initial begin
+    y = a && b;
+    y = a || b;
+    y = a -> b;
+    y = a <-> b;
+  end
+endmodule

--- a/tests/cases/dump/mir_binary_shift/case.yaml
+++ b/tests/cases/dump/mir_binary_shift/case.yaml
@@ -1,0 +1,17 @@
+id: dump.mir_binary_shift
+tags: [dump]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "BinaryExpr op=ShiftLeft"
+      - "BinaryExpr op=LogicalShiftRight"
+      - "BinaryExpr op=ArithmeticShiftRight"
+    not_contains:
+      - "LogicalShiftLeft"
+      - "ArithmeticShiftLeft"

--- a/tests/cases/dump/mir_binary_shift/main.sv
+++ b/tests/cases/dump/mir_binary_shift/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  logic signed [7:0] a;
+  logic [2:0] s;
+  logic [7:0] y;
+  initial begin
+    y = a << s;
+    y = a <<< s;
+    y = a >> s;
+    y = a >>> s;
+  end
+endmodule

--- a/tests/cases/dump/mir_unary_pure/case.yaml
+++ b/tests/cases/dump/mir_unary_pure/case.yaml
@@ -1,0 +1,21 @@
+id: dump.mir_unary_pure
+tags: [dump]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "UnaryExpr op=Plus"
+      - "UnaryExpr op=Minus"
+      - "UnaryExpr op=BitwiseNot"
+      - "UnaryExpr op=LogicalNot"
+      - "UnaryExpr op=ReductionAnd"
+      - "UnaryExpr op=ReductionOr"
+      - "UnaryExpr op=ReductionXor"
+      - "UnaryExpr op=ReductionNand"
+      - "UnaryExpr op=ReductionNor"
+      - "UnaryExpr op=ReductionXnor"

--- a/tests/cases/dump/mir_unary_pure/main.sv
+++ b/tests/cases/dump/mir_unary_pure/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  logic [3:0] a;
+  logic y;
+  initial begin
+    y = +a;
+    y = -a;
+    y = ~a;
+    y = !a;
+    y = &a;
+    y = |a;
+    y = ^a;
+    y = ~&a;
+    y = ~|a;
+    y = ~^a;
+  end
+endmodule

--- a/tests/cases/errors/cpp_emit_unsupported_binary_op/case.yaml
+++ b/tests/cases/errors/cpp_emit_unsupported_binary_op/case.yaml
@@ -1,0 +1,16 @@
+id: errors.cpp_emit_unsupported_binary_op
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "this binary operator is not yet implemented in cpp emit"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/cpp_emit_unsupported_binary_op/main.sv
+++ b/tests/cases/errors/cpp_emit_unsupported_binary_op/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  int a;
+  int b;
+  initial begin
+    a = a - b;
+  end
+endmodule

--- a/tests/cases/errors/cpp_emit_unsupported_unary_op/case.yaml
+++ b/tests/cases/errors/cpp_emit_unsupported_unary_op/case.yaml
@@ -1,0 +1,16 @@
+id: errors.cpp_emit_unsupported_unary_op
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "this unary operator is not yet implemented in cpp emit"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/cpp_emit_unsupported_unary_op/main.sv
+++ b/tests/cases/errors/cpp_emit_unsupported_unary_op/main.sv
@@ -1,0 +1,6 @@
+module Top;
+  int a;
+  initial begin
+    a = -a;
+  end
+endmodule

--- a/tests/cases/errors/unsupported_binary_op/case.yaml
+++ b/tests/cases/errors/unsupported_binary_op/case.yaml
@@ -12,7 +12,7 @@ expect:
     contains:
       - "main.sv:4:"
       - "unsupported:"
-      - "only `+` is currently supported"
-      - "a = a - 1;"
+      - "compound assignments are not supported yet"
+      - "a += 1;"
     not_contains:
       - "internal error"

--- a/tests/cases/errors/unsupported_binary_op/main.sv
+++ b/tests/cases/errors/unsupported_binary_op/main.sv
@@ -1,6 +1,6 @@
 module Top;
   int a;
   initial begin
-    a = a - 1;
+    a += 1;
   end
 endmodule

--- a/tests/cases/errors/unsupported_expr/case.yaml
+++ b/tests/cases/errors/unsupported_expr/case.yaml
@@ -13,6 +13,5 @@ expect:
       - "main.sv:4:"
       - "unsupported:"
       - "this expression form is not supported yet"
-      - "a = !a;"
     not_contains:
       - "internal error"

--- a/tests/cases/errors/unsupported_expr/main.sv
+++ b/tests/cases/errors/unsupported_expr/main.sv
@@ -1,6 +1,6 @@
 module Top;
   int a;
   initial begin
-    a = !a;
+    a = {1'b1, 1'b0};
   end
 endmodule


### PR DESCRIPTION
## Summary

Pure unary and binary operators are now captured end-to-end through SV -> HIR -> MIR, validated by `dump hir` / `dump mir` golden tests. HIR preserves SystemVerilog distinctions (e.g. `<<` vs `<<<`); MIR collapses to executable semantics (left-shift -> single op). Backend cpp emit now returns `diag::Result` so not-yet-implemented operators surface as structured `unsupported:` diagnostics instead of `internal error`.

## Design

- **HIR layer:** new `UnaryOp` and `UnaryExpr`; `BinaryOp` covers the full slang `BinaryOperator` set. Inc/Dec are deliberately excluded from pure `UnaryExpr` and rejected at AST-to-HIR with `kUnsupportedExpressionForm` -- they are lvalue side-effect operations that need a separate expression form.
- **MIR layer:** parallel `UnaryOp` enum; `BinaryOp` collapses `LogicalShiftLeft` and `ArithmeticShiftLeft` into `kShiftLeft`. Right shifts stay distinct.
- **AST -> HIR:** anonymous-namespace `LowerBinaryOp(slang::ast::BinaryOperator)` and `LowerUnaryOp(slang::ast::UnaryOperator, span)` helpers; `LowerProcExpr` and `LowerLoopHeaderExpr` route through them. The narrow `MapLoopHeaderBinaryOp` parallel helper is removed.
- **HIR -> MIR:** mapping helpers stay TU-private (anonymous namespace); the previously-leaked public `LowerBinaryOp` declaration is removed -- normalization policy is implementation detail of the lowering layer, not API surface.
- **Backend cpp emit:** `BinaryOpToken`, `RenderExprAsNative`, `RenderExprAsRuntimeView`, `RenderExpr`, `RenderStmt`, `RenderBody`, `RenderConstructor`, `RenderProcessMethod`, `RenderClassDecl`, `RenderClassHeaderFile`, `EmitCpp`, etc. now return `diag::Result<T>`. Three new DiagCodes -- `kCppEmitBinaryOpNotImplemented`, `kCppEmitUnaryOpNotImplemented`, `kCppEmitExpressionFormNotImplemented`, all `kind=kUnsupported`/`category=kFeature` -- carry the structured "not yet implemented in cpp emit" framing. `InternalError` is reserved for true compiler-invariant violations (enum exhaustiveness fallthrough, IR contract breaks).

## Testing

- Seven HIR + MIR dump-test pairs covering unary, arith, bitwise, comparison, logical, shift (with `not_contains` asserting MIR shift collapse), and conversion-preservation.
- Two new error tests (`cpp_emit_unsupported_binary_op`, `cpp_emit_unsupported_unary_op`) lock in `unsupported:` framing and `not_contains: ["internal error"]`.
- Two pre-existing error tests (`unsupported_binary_op`, `unsupported_expr`) repurposed to compound assignment and concatenation -- their old "only `+` is currently supported" / unary-not-supported assumptions no longer apply.
- `bazel test //... --test_output=errors`: all 6 targets pass.