### PR TITLE
Execute packed bitwise ops in C++ backend

### DIFF
--- a/include/lyra/runtime/bitwise.hpp
+++ b/include/lyra/runtime/bitwise.hpp
@@ -1,0 +1,376 @@
+#pragma once
+
+#include <concepts>
+#include <cstdint>
+#include <span>
+#include <type_traits>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/runtime/packed.hpp"
+#include "lyra/runtime/packed_words.hpp"
+
+namespace lyra::runtime {
+
+namespace detail {
+
+template <typename V>
+concept BitViewLike = std::same_as<std::remove_cvref_t<V>, ConstBitView> ||
+                      std::same_as<std::remove_cvref_t<V>, BitView>;
+
+template <typename V>
+concept LogicViewLike = std::same_as<std::remove_cvref_t<V>, ConstLogicView> ||
+                        std::same_as<std::remove_cvref_t<V>, LogicView>;
+
+inline auto ToConstView(ConstBitView v) -> ConstBitView {
+  return v;
+}
+inline auto ToConstView(BitView v) -> ConstBitView {
+  return v.AsConst();
+}
+inline auto ToConstView(ConstLogicView v) -> ConstLogicView {
+  return v;
+}
+inline auto ToConstView(LogicView v) -> ConstLogicView {
+  return v.AsConst();
+}
+
+inline auto NotPlaneWords(
+    std::span<std::uint64_t> dst, std::span<const std::uint64_t> src,
+    std::uint64_t width) -> void {
+  for (std::size_t i = 0; i < dst.size(); ++i) {
+    dst[i] = ~src[i];
+  }
+  MaskUnusedTopBits(dst, width);
+}
+
+inline auto AndPlaneWords(
+    std::span<std::uint64_t> dst, std::span<const std::uint64_t> a,
+    std::span<const std::uint64_t> b, std::uint64_t width) -> void {
+  for (std::size_t i = 0; i < dst.size(); ++i) {
+    dst[i] = a[i] & b[i];
+  }
+  MaskUnusedTopBits(dst, width);
+}
+
+inline auto OrPlaneWords(
+    std::span<std::uint64_t> dst, std::span<const std::uint64_t> a,
+    std::span<const std::uint64_t> b, std::uint64_t width) -> void {
+  for (std::size_t i = 0; i < dst.size(); ++i) {
+    dst[i] = a[i] | b[i];
+  }
+  MaskUnusedTopBits(dst, width);
+}
+
+inline auto XorPlaneWords(
+    std::span<std::uint64_t> dst, std::span<const std::uint64_t> a,
+    std::span<const std::uint64_t> b, std::uint64_t width) -> void {
+  for (std::size_t i = 0; i < dst.size(); ++i) {
+    dst[i] = a[i] ^ b[i];
+  }
+  MaskUnusedTopBits(dst, width);
+}
+
+inline auto XnorPlaneWords(
+    std::span<std::uint64_t> dst, std::span<const std::uint64_t> a,
+    std::span<const std::uint64_t> b, std::uint64_t width) -> void {
+  for (std::size_t i = 0; i < dst.size(); ++i) {
+    dst[i] = ~(a[i] ^ b[i]);
+  }
+  MaskUnusedTopBits(dst, width);
+}
+
+// 4-state encoding: s=0,v=0 -> 0; s=0,v=1 -> 1; s=1,v=0 -> Z; s=1,v=1 -> X.
+// Per IEEE 1800: ~0 -> 1, ~1 -> 0, ~X -> X, ~Z -> X.
+inline auto LogicNotWords(
+    std::span<std::uint64_t> dst_v, std::span<std::uint64_t> dst_s,
+    std::span<const std::uint64_t> src_v, std::span<const std::uint64_t> src_s,
+    std::uint64_t width) -> void {
+  for (std::size_t i = 0; i < dst_v.size(); ++i) {
+    dst_v[i] = (~src_v[i]) | src_s[i];
+    dst_s[i] = src_s[i];
+  }
+  MaskUnusedTopBits(dst_v, width);
+  MaskUnusedTopBits(dst_s, width);
+}
+
+// SV table: 0&_=0; 1&1=1; otherwise X.
+inline auto LogicAndWords(
+    std::span<std::uint64_t> dst_v, std::span<std::uint64_t> dst_s,
+    std::span<const std::uint64_t> av, std::span<const std::uint64_t> as,
+    std::span<const std::uint64_t> bv, std::span<const std::uint64_t> bs,
+    std::uint64_t width) -> void {
+  for (std::size_t i = 0; i < dst_v.size(); ++i) {
+    const std::uint64_t a_zero = ~as[i] & ~av[i];
+    const std::uint64_t b_zero = ~bs[i] & ~bv[i];
+    const std::uint64_t a_one = ~as[i] & av[i];
+    const std::uint64_t b_one = ~bs[i] & bv[i];
+    const std::uint64_t is_zero = a_zero | b_zero;
+    const std::uint64_t is_one = a_one & b_one;
+    const std::uint64_t new_s = ~is_zero & ~is_one;
+    const std::uint64_t new_v = is_one | new_s;
+    dst_v[i] = new_v;
+    dst_s[i] = new_s;
+  }
+  MaskUnusedTopBits(dst_v, width);
+  MaskUnusedTopBits(dst_s, width);
+}
+
+// SV table: 1|_=1; 0|0=0; otherwise X.
+inline auto LogicOrWords(
+    std::span<std::uint64_t> dst_v, std::span<std::uint64_t> dst_s,
+    std::span<const std::uint64_t> av, std::span<const std::uint64_t> as,
+    std::span<const std::uint64_t> bv, std::span<const std::uint64_t> bs,
+    std::uint64_t width) -> void {
+  for (std::size_t i = 0; i < dst_v.size(); ++i) {
+    const std::uint64_t a_zero = ~as[i] & ~av[i];
+    const std::uint64_t b_zero = ~bs[i] & ~bv[i];
+    const std::uint64_t a_one = ~as[i] & av[i];
+    const std::uint64_t b_one = ~bs[i] & bv[i];
+    const std::uint64_t is_one = a_one | b_one;
+    const std::uint64_t is_zero = a_zero & b_zero;
+    const std::uint64_t new_s = ~is_zero & ~is_one;
+    const std::uint64_t new_v = is_one | new_s;
+    dst_v[i] = new_v;
+    dst_s[i] = new_s;
+  }
+  MaskUnusedTopBits(dst_v, width);
+  MaskUnusedTopBits(dst_s, width);
+}
+
+// Any X/Z -> X; else dst_v_bit = av ^ bv.
+inline auto LogicXorWords(
+    std::span<std::uint64_t> dst_v, std::span<std::uint64_t> dst_s,
+    std::span<const std::uint64_t> av, std::span<const std::uint64_t> as,
+    std::span<const std::uint64_t> bv, std::span<const std::uint64_t> bs,
+    std::uint64_t width) -> void {
+  for (std::size_t i = 0; i < dst_v.size(); ++i) {
+    const std::uint64_t new_s = as[i] | bs[i];
+    const std::uint64_t new_v = new_s | (av[i] ^ bv[i]);
+    dst_v[i] = new_v;
+    dst_s[i] = new_s;
+  }
+  MaskUnusedTopBits(dst_v, width);
+  MaskUnusedTopBits(dst_s, width);
+}
+
+// Any X/Z -> X; else dst_v_bit = ~(av ^ bv).
+inline auto LogicXnorWords(
+    std::span<std::uint64_t> dst_v, std::span<std::uint64_t> dst_s,
+    std::span<const std::uint64_t> av, std::span<const std::uint64_t> as,
+    std::span<const std::uint64_t> bv, std::span<const std::uint64_t> bs,
+    std::uint64_t width) -> void {
+  for (std::size_t i = 0; i < dst_v.size(); ++i) {
+    const std::uint64_t new_s = as[i] | bs[i];
+    const std::uint64_t new_v = new_s | ~(av[i] ^ bv[i]);
+    dst_v[i] = new_v;
+    dst_s[i] = new_s;
+  }
+  MaskUnusedTopBits(dst_v, width);
+  MaskUnusedTopBits(dst_s, width);
+}
+
+template <PackedShape Shape, Signedness Signed>
+auto BitwiseNotImpl(ConstBitView src) -> Bit<Shape, Signed> {
+  if (src.Width() != Shape.TotalWidth()) {
+    throw InternalError("BitwiseNot: width mismatch");
+  }
+  Bit<Shape, Signed> out;
+  NotPlaneWords(
+      PlaneAccess::MutableValue(out), PlaneAccess::ValueWords(src),
+      Shape.TotalWidth());
+  return out;
+}
+
+template <PackedShape Shape, Signedness Signed>
+auto BitwiseNotImpl(ConstLogicView src) -> Logic<Shape, Signed> {
+  if (src.Width() != Shape.TotalWidth()) {
+    throw InternalError("BitwiseNot: width mismatch");
+  }
+  Logic<Shape, Signed> out;
+  LogicNotWords(
+      PlaneAccess::MutableValue(out), PlaneAccess::MutableState(out),
+      PlaneAccess::ValueWords(src), PlaneAccess::StateWords(src),
+      Shape.TotalWidth());
+  return out;
+}
+
+template <PackedShape Shape, Signedness Signed>
+auto BitwiseAndImpl(ConstBitView lhs, ConstBitView rhs) -> Bit<Shape, Signed> {
+  if (lhs.Width() != Shape.TotalWidth() || rhs.Width() != Shape.TotalWidth()) {
+    throw InternalError("BitwiseAnd: width mismatch");
+  }
+  Bit<Shape, Signed> out;
+  AndPlaneWords(
+      PlaneAccess::MutableValue(out), PlaneAccess::ValueWords(lhs),
+      PlaneAccess::ValueWords(rhs), Shape.TotalWidth());
+  return out;
+}
+
+template <PackedShape Shape, Signedness Signed>
+auto BitwiseAndImpl(ConstLogicView lhs, ConstLogicView rhs)
+    -> Logic<Shape, Signed> {
+  if (lhs.Width() != Shape.TotalWidth() || rhs.Width() != Shape.TotalWidth()) {
+    throw InternalError("BitwiseAnd: width mismatch");
+  }
+  Logic<Shape, Signed> out;
+  LogicAndWords(
+      PlaneAccess::MutableValue(out), PlaneAccess::MutableState(out),
+      PlaneAccess::ValueWords(lhs), PlaneAccess::StateWords(lhs),
+      PlaneAccess::ValueWords(rhs), PlaneAccess::StateWords(rhs),
+      Shape.TotalWidth());
+  return out;
+}
+
+template <PackedShape Shape, Signedness Signed>
+auto BitwiseOrImpl(ConstBitView lhs, ConstBitView rhs) -> Bit<Shape, Signed> {
+  if (lhs.Width() != Shape.TotalWidth() || rhs.Width() != Shape.TotalWidth()) {
+    throw InternalError("BitwiseOr: width mismatch");
+  }
+  Bit<Shape, Signed> out;
+  OrPlaneWords(
+      PlaneAccess::MutableValue(out), PlaneAccess::ValueWords(lhs),
+      PlaneAccess::ValueWords(rhs), Shape.TotalWidth());
+  return out;
+}
+
+template <PackedShape Shape, Signedness Signed>
+auto BitwiseOrImpl(ConstLogicView lhs, ConstLogicView rhs)
+    -> Logic<Shape, Signed> {
+  if (lhs.Width() != Shape.TotalWidth() || rhs.Width() != Shape.TotalWidth()) {
+    throw InternalError("BitwiseOr: width mismatch");
+  }
+  Logic<Shape, Signed> out;
+  LogicOrWords(
+      PlaneAccess::MutableValue(out), PlaneAccess::MutableState(out),
+      PlaneAccess::ValueWords(lhs), PlaneAccess::StateWords(lhs),
+      PlaneAccess::ValueWords(rhs), PlaneAccess::StateWords(rhs),
+      Shape.TotalWidth());
+  return out;
+}
+
+template <PackedShape Shape, Signedness Signed>
+auto BitwiseXorImpl(ConstBitView lhs, ConstBitView rhs) -> Bit<Shape, Signed> {
+  if (lhs.Width() != Shape.TotalWidth() || rhs.Width() != Shape.TotalWidth()) {
+    throw InternalError("BitwiseXor: width mismatch");
+  }
+  Bit<Shape, Signed> out;
+  XorPlaneWords(
+      PlaneAccess::MutableValue(out), PlaneAccess::ValueWords(lhs),
+      PlaneAccess::ValueWords(rhs), Shape.TotalWidth());
+  return out;
+}
+
+template <PackedShape Shape, Signedness Signed>
+auto BitwiseXorImpl(ConstLogicView lhs, ConstLogicView rhs)
+    -> Logic<Shape, Signed> {
+  if (lhs.Width() != Shape.TotalWidth() || rhs.Width() != Shape.TotalWidth()) {
+    throw InternalError("BitwiseXor: width mismatch");
+  }
+  Logic<Shape, Signed> out;
+  LogicXorWords(
+      PlaneAccess::MutableValue(out), PlaneAccess::MutableState(out),
+      PlaneAccess::ValueWords(lhs), PlaneAccess::StateWords(lhs),
+      PlaneAccess::ValueWords(rhs), PlaneAccess::StateWords(rhs),
+      Shape.TotalWidth());
+  return out;
+}
+
+template <PackedShape Shape, Signedness Signed>
+auto BitwiseXnorImpl(ConstBitView lhs, ConstBitView rhs) -> Bit<Shape, Signed> {
+  if (lhs.Width() != Shape.TotalWidth() || rhs.Width() != Shape.TotalWidth()) {
+    throw InternalError("BitwiseXnor: width mismatch");
+  }
+  Bit<Shape, Signed> out;
+  XnorPlaneWords(
+      PlaneAccess::MutableValue(out), PlaneAccess::ValueWords(lhs),
+      PlaneAccess::ValueWords(rhs), Shape.TotalWidth());
+  return out;
+}
+
+template <PackedShape Shape, Signedness Signed>
+auto BitwiseXnorImpl(ConstLogicView lhs, ConstLogicView rhs)
+    -> Logic<Shape, Signed> {
+  if (lhs.Width() != Shape.TotalWidth() || rhs.Width() != Shape.TotalWidth()) {
+    throw InternalError("BitwiseXnor: width mismatch");
+  }
+  Logic<Shape, Signed> out;
+  LogicXnorWords(
+      PlaneAccess::MutableValue(out), PlaneAccess::MutableState(out),
+      PlaneAccess::ValueWords(lhs), PlaneAccess::StateWords(lhs),
+      PlaneAccess::ValueWords(rhs), PlaneAccess::StateWords(rhs),
+      Shape.TotalWidth());
+  return out;
+}
+
+}  // namespace detail
+
+template <PackedShape Shape, Signedness Signed, detail::BitViewLike V>
+auto BitwiseNot(V src) -> Bit<Shape, Signed> {
+  return detail::BitwiseNotImpl<Shape, Signed>(detail::ToConstView(src));
+}
+template <PackedShape Shape, Signedness Signed, detail::LogicViewLike V>
+auto BitwiseNot(V src) -> Logic<Shape, Signed> {
+  return detail::BitwiseNotImpl<Shape, Signed>(detail::ToConstView(src));
+}
+
+template <
+    PackedShape Shape, Signedness Signed, detail::BitViewLike L,
+    detail::BitViewLike R>
+auto BitwiseAnd(L lhs, R rhs) -> Bit<Shape, Signed> {
+  return detail::BitwiseAndImpl<Shape, Signed>(
+      detail::ToConstView(lhs), detail::ToConstView(rhs));
+}
+template <
+    PackedShape Shape, Signedness Signed, detail::LogicViewLike L,
+    detail::LogicViewLike R>
+auto BitwiseAnd(L lhs, R rhs) -> Logic<Shape, Signed> {
+  return detail::BitwiseAndImpl<Shape, Signed>(
+      detail::ToConstView(lhs), detail::ToConstView(rhs));
+}
+
+template <
+    PackedShape Shape, Signedness Signed, detail::BitViewLike L,
+    detail::BitViewLike R>
+auto BitwiseOr(L lhs, R rhs) -> Bit<Shape, Signed> {
+  return detail::BitwiseOrImpl<Shape, Signed>(
+      detail::ToConstView(lhs), detail::ToConstView(rhs));
+}
+template <
+    PackedShape Shape, Signedness Signed, detail::LogicViewLike L,
+    detail::LogicViewLike R>
+auto BitwiseOr(L lhs, R rhs) -> Logic<Shape, Signed> {
+  return detail::BitwiseOrImpl<Shape, Signed>(
+      detail::ToConstView(lhs), detail::ToConstView(rhs));
+}
+
+template <
+    PackedShape Shape, Signedness Signed, detail::BitViewLike L,
+    detail::BitViewLike R>
+auto BitwiseXor(L lhs, R rhs) -> Bit<Shape, Signed> {
+  return detail::BitwiseXorImpl<Shape, Signed>(
+      detail::ToConstView(lhs), detail::ToConstView(rhs));
+}
+template <
+    PackedShape Shape, Signedness Signed, detail::LogicViewLike L,
+    detail::LogicViewLike R>
+auto BitwiseXor(L lhs, R rhs) -> Logic<Shape, Signed> {
+  return detail::BitwiseXorImpl<Shape, Signed>(
+      detail::ToConstView(lhs), detail::ToConstView(rhs));
+}
+
+template <
+    PackedShape Shape, Signedness Signed, detail::BitViewLike L,
+    detail::BitViewLike R>
+auto BitwiseXnor(L lhs, R rhs) -> Bit<Shape, Signed> {
+  return detail::BitwiseXnorImpl<Shape, Signed>(
+      detail::ToConstView(lhs), detail::ToConstView(rhs));
+}
+template <
+    PackedShape Shape, Signedness Signed, detail::LogicViewLike L,
+    detail::LogicViewLike R>
+auto BitwiseXnor(L lhs, R rhs) -> Logic<Shape, Signed> {
+  return detail::BitwiseXnorImpl<Shape, Signed>(
+      detail::ToConstView(lhs), detail::ToConstView(rhs));
+}
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/convert.hpp
+++ b/include/lyra/runtime/convert.hpp
@@ -4,8 +4,8 @@
 #include <cstdint>
 #include <span>
 
-#include "lyra/base/internal_error.hpp"
 #include "lyra/runtime/packed.hpp"
+#include "lyra/runtime/packed_words.hpp"
 
 namespace lyra::runtime {
 
@@ -15,19 +15,6 @@ inline auto ZeroBits(std::span<std::uint64_t> dst) -> void {
   for (auto& w : dst) {
     w = 0U;
   }
-}
-
-inline auto MaskUnusedTopBits(std::span<std::uint64_t> dst, std::uint64_t width)
-    -> void {
-  if (dst.empty()) {
-    return;
-  }
-  const std::uint64_t tail = width % 64U;
-  if (tail == 0U) {
-    return;
-  }
-  const std::uint64_t mask = (std::uint64_t{1} << tail) - 1U;
-  dst.back() &= mask;
 }
 
 inline auto CopyLowBits(
@@ -171,48 +158,6 @@ inline auto ConvertPackedBits(ConversionTarget dst, ConversionSource src)
     MaskUnusedTopBits(dst.state, dst.width);
   }
 }
-
-struct PlaneAccess {
-  template <PackedShape Shape, Signedness Signed>
-  static auto MutableValue(Bit<Shape, Signed>& b) -> std::span<std::uint64_t> {
-    return b.MutableValueWordsForConvert();
-  }
-  template <PackedShape Shape, Signedness Signed>
-  static auto MutableValue(Logic<Shape, Signed>& l)
-      -> std::span<std::uint64_t> {
-    return l.MutableValueWordsForConvert();
-  }
-  template <PackedShape Shape, Signedness Signed>
-  static auto MutableState(Logic<Shape, Signed>& l)
-      -> std::span<std::uint64_t> {
-    return l.MutableStateWordsForConvert();
-  }
-
-  static auto ValueWords(ConstBitView v) -> std::span<const std::uint64_t> {
-    if (v.BitOffsetForConvert() != 0U) {
-      throw InternalError(
-          "PlaneAccess::ValueWords: ConstBitView with non-zero bit_offset is "
-          "not supported");
-    }
-    return v.WordsForConvert();
-  }
-  static auto ValueWords(ConstLogicView v) -> std::span<const std::uint64_t> {
-    if (v.BitOffsetForConvert() != 0U) {
-      throw InternalError(
-          "PlaneAccess::ValueWords: ConstLogicView with non-zero bit_offset "
-          "is not supported");
-    }
-    return v.ValueWordsForConvert();
-  }
-  static auto StateWords(ConstLogicView v) -> std::span<const std::uint64_t> {
-    if (v.BitOffsetForConvert() != 0U) {
-      throw InternalError(
-          "PlaneAccess::StateWords: ConstLogicView with non-zero bit_offset "
-          "is not supported");
-    }
-    return v.StateWordsForConvert();
-  }
-};
 
 }  // namespace detail
 

--- a/include/lyra/runtime/packed.hpp
+++ b/include/lyra/runtime/packed.hpp
@@ -113,7 +113,7 @@ template <PackedShape Shape, Signedness Signed = Signedness::kUnsigned>
 class Logic;
 
 namespace detail {
-struct PlaneAccess;  // defined in convert.hpp
+struct PlaneAccess;
 }  // namespace detail
 
 namespace detail {
@@ -252,10 +252,11 @@ class ConstBitView {
  private:
   friend struct detail::PlaneAccess;
 
-  [[nodiscard]] auto WordsForConvert() const -> std::span<const std::uint64_t> {
+  [[nodiscard]] auto WordsForPackedOps() const
+      -> std::span<const std::uint64_t> {
     return words_;
   }
-  [[nodiscard]] auto BitOffsetForConvert() const -> std::uint64_t {
+  [[nodiscard]] auto BitOffsetForPackedOps() const -> std::uint64_t {
     return bit_offset_;
   }
 
@@ -401,15 +402,15 @@ class ConstLogicView {
  private:
   friend struct detail::PlaneAccess;
 
-  [[nodiscard]] auto ValueWordsForConvert() const
+  [[nodiscard]] auto ValueWordsForPackedOps() const
       -> std::span<const std::uint64_t> {
     return value_words_;
   }
-  [[nodiscard]] auto StateWordsForConvert() const
+  [[nodiscard]] auto StateWordsForPackedOps() const
       -> std::span<const std::uint64_t> {
     return state_words_;
   }
-  [[nodiscard]] auto BitOffsetForConvert() const -> std::uint64_t {
+  [[nodiscard]] auto BitOffsetForPackedOps() const -> std::uint64_t {
     return bit_offset_;
   }
 
@@ -586,7 +587,8 @@ class Bit {
  private:
   friend struct detail::PlaneAccess;
 
-  [[nodiscard]] auto MutableValueWordsForConvert() -> std::span<std::uint64_t> {
+  [[nodiscard]] auto MutableValueWordsForPackedOps()
+      -> std::span<std::uint64_t> {
     return bits_.MutableWordsForView();
   }
 
@@ -689,10 +691,12 @@ class Logic {
  private:
   friend struct detail::PlaneAccess;
 
-  [[nodiscard]] auto MutableValueWordsForConvert() -> std::span<std::uint64_t> {
+  [[nodiscard]] auto MutableValueWordsForPackedOps()
+      -> std::span<std::uint64_t> {
     return value_.MutableWordsForView();
   }
-  [[nodiscard]] auto MutableStateWordsForConvert() -> std::span<std::uint64_t> {
+  [[nodiscard]] auto MutableStateWordsForPackedOps()
+      -> std::span<std::uint64_t> {
     return state_.MutableWordsForView();
   }
 

--- a/include/lyra/runtime/packed_words.hpp
+++ b/include/lyra/runtime/packed_words.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <string>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/runtime/packed.hpp"
+
+namespace lyra::runtime::detail {
+
+inline auto MaskUnusedTopBits(std::span<std::uint64_t> dst, std::uint64_t width)
+    -> void {
+  if (dst.empty()) {
+    return;
+  }
+  const std::uint64_t tail = width % 64U;
+  if (tail == 0U) {
+    return;
+  }
+  const std::uint64_t mask = (std::uint64_t{1} << tail) - 1U;
+  dst.back() &= mask;
+}
+
+struct PlaneAccess {
+  template <PackedShape Shape, Signedness Signed>
+  static auto MutableValue(Bit<Shape, Signed>& b) -> std::span<std::uint64_t> {
+    return b.MutableValueWordsForPackedOps();
+  }
+  template <PackedShape Shape, Signedness Signed>
+  static auto MutableValue(Logic<Shape, Signed>& l)
+      -> std::span<std::uint64_t> {
+    return l.MutableValueWordsForPackedOps();
+  }
+  template <PackedShape Shape, Signedness Signed>
+  static auto MutableState(Logic<Shape, Signed>& l)
+      -> std::span<std::uint64_t> {
+    return l.MutableStateWordsForPackedOps();
+  }
+
+  static auto ValueWords(ConstBitView v) -> std::span<const std::uint64_t> {
+    if (v.BitOffsetForPackedOps() != 0U) {
+      throw InternalError(
+          "PlaneAccess::ValueWords: ConstBitView with non-zero bit_offset is "
+          "not supported");
+    }
+    return v.WordsForPackedOps();
+  }
+  static auto ValueWords(ConstLogicView v) -> std::span<const std::uint64_t> {
+    if (v.BitOffsetForPackedOps() != 0U) {
+      throw InternalError(
+          "PlaneAccess::ValueWords: ConstLogicView with non-zero bit_offset "
+          "is not supported");
+    }
+    return v.ValueWordsForPackedOps();
+  }
+  static auto StateWords(ConstLogicView v) -> std::span<const std::uint64_t> {
+    if (v.BitOffsetForPackedOps() != 0U) {
+      throw InternalError(
+          "PlaneAccess::StateWords: ConstLogicView with non-zero bit_offset "
+          "is not supported");
+    }
+    return v.StateWordsForPackedOps();
+  }
+};
+
+}  // namespace lyra::runtime::detail

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -179,6 +179,7 @@ auto RenderClassHeaderFile(
   out += "#include <string>\n";
   out += "#include <vector>\n";
   out += "#include \"lyra/runtime/bind_context.hpp\"\n";
+  out += "#include \"lyra/runtime/bitwise.hpp\"\n";
   out += "#include \"lyra/runtime/convert.hpp\"\n";
   out += "#include \"lyra/runtime/delay.hpp\"\n";
   out += "#include \"lyra/runtime/format.hpp\"\n";

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -197,6 +197,94 @@ auto RenderIntegerLiteralAsView(
   return out;
 }
 
+auto IsPackedExplicitMatching(
+    const mir::CompilationUnit& unit, mir::TypeId operand_type,
+    const mir::PackedArrayType& result_pa) -> bool {
+  const auto& ot = unit.GetType(operand_type);
+  if (!ot.IsPackedArray()) {
+    return false;
+  }
+  const auto& opa = ot.AsPackedArray();
+  return opa.form == mir::PackedArrayForm::kExplicit &&
+         opa.IsFourState() == result_pa.IsFourState() &&
+         opa.BitWidth() == result_pa.BitWidth();
+}
+
+auto RenderPackedBitwiseUnaryCall(
+    const RenderContext& ctx, mir::TypeId result_type, mir::UnaryOp op,
+    const mir::Expr& operand) -> diag::Result<std::string> {
+  if (op != mir::UnaryOp::kBitwiseNot) {
+    throw InternalError("RenderPackedBitwiseUnaryCall: non-bitwise unary op");
+  }
+  if (!IsPackedRuntime(ctx.Unit(), result_type)) {
+    throw InternalError(
+        "RenderPackedBitwiseUnaryCall: result not packed runtime");
+  }
+  const auto& result_pa = ctx.Unit().GetType(result_type).AsPackedArray();
+  if (!IsPackedExplicitMatching(ctx.Unit(), operand.type, result_pa)) {
+    throw InternalError(
+        "RenderPackedBitwiseUnaryCall: operand type not normalized to result");
+  }
+  const std::string shape = RenderPackedShapeLiteral(result_pa.dims);
+  const std::string_view signedness = SignednessLiteral(result_pa.signedness);
+  auto operand_view_or = RenderExprAsRuntimeView(ctx, operand);
+  if (!operand_view_or) {
+    return std::unexpected(std::move(operand_view_or.error()));
+  }
+  return std::format(
+      "lyra::runtime::BitwiseNot<{}, {}>({})", shape, signedness,
+      *operand_view_or);
+}
+
+auto RenderPackedBitwiseBinaryCall(
+    const RenderContext& ctx, mir::TypeId result_type, mir::BinaryOp op,
+    const mir::Expr& lhs, const mir::Expr& rhs) -> diag::Result<std::string> {
+  const char* fn = nullptr;
+  switch (op) {
+    case mir::BinaryOp::kBitwiseAnd:
+      fn = "BitwiseAnd";
+      break;
+    case mir::BinaryOp::kBitwiseOr:
+      fn = "BitwiseOr";
+      break;
+    case mir::BinaryOp::kBitwiseXor:
+      fn = "BitwiseXor";
+      break;
+    case mir::BinaryOp::kBitwiseXnor:
+      fn = "BitwiseXnor";
+      break;
+    default:
+      throw InternalError(
+          "RenderPackedBitwiseBinaryCall: non-bitwise binary op");
+  }
+  if (!IsPackedRuntime(ctx.Unit(), result_type)) {
+    throw InternalError(
+        "RenderPackedBitwiseBinaryCall: result not packed runtime");
+  }
+  const auto& result_pa = ctx.Unit().GetType(result_type).AsPackedArray();
+  if (!IsPackedExplicitMatching(ctx.Unit(), lhs.type, result_pa)) {
+    throw InternalError(
+        "RenderPackedBitwiseBinaryCall: lhs not normalized to result");
+  }
+  if (!IsPackedExplicitMatching(ctx.Unit(), rhs.type, result_pa)) {
+    throw InternalError(
+        "RenderPackedBitwiseBinaryCall: rhs not normalized to result");
+  }
+  const std::string shape = RenderPackedShapeLiteral(result_pa.dims);
+  const std::string_view signedness = SignednessLiteral(result_pa.signedness);
+  auto lhs_view_or = RenderExprAsRuntimeView(ctx, lhs);
+  if (!lhs_view_or) {
+    return std::unexpected(std::move(lhs_view_or.error()));
+  }
+  auto rhs_view_or = RenderExprAsRuntimeView(ctx, rhs);
+  if (!rhs_view_or) {
+    return std::unexpected(std::move(rhs_view_or.error()));
+  }
+  return std::format(
+      "lyra::runtime::{}<{}, {}>({}, {})", fn, shape, signedness, *lhs_view_or,
+      *rhs_view_or);
+}
+
 auto RenderConversionCall(
     const RenderContext& ctx, mir::TypeId target_type,
     const mir::ConversionExpr& conv) -> diag::Result<std::string> {
@@ -329,6 +417,48 @@ auto RenderExprAsRuntimeView(const RenderContext& ctx, const mir::Expr& expr)
             if (!inner_or) return std::unexpected(std::move(inner_or.error()));
             return std::format("{}.View()", *inner_or);
           },
+          [&](const mir::UnaryExpr& u) -> diag::Result<std::string> {
+            if (u.op != mir::UnaryOp::kBitwiseNot ||
+                !IsPackedRuntime(ctx.Unit(), expr.type)) {
+              return diag::Unsupported(
+                  diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+                  "this unary expression is not yet renderable as a runtime "
+                  "view in cpp emit",
+                  diag::UnsupportedCategory::kFeature);
+            }
+            auto inner_or = RenderPackedBitwiseUnaryCall(
+                ctx, expr.type, u.op, ctx.Expr(u.operand));
+            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
+            return std::format("{}.View()", *inner_or);
+          },
+          [&](const mir::BinaryExpr& b) -> diag::Result<std::string> {
+            switch (b.op) {
+              case mir::BinaryOp::kBitwiseAnd:
+              case mir::BinaryOp::kBitwiseOr:
+              case mir::BinaryOp::kBitwiseXor:
+              case mir::BinaryOp::kBitwiseXnor: {
+                if (!IsPackedRuntime(ctx.Unit(), expr.type)) {
+                  return diag::Unsupported(
+                      diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+                      "this binary expression is not yet renderable as a "
+                      "runtime view in cpp emit",
+                      diag::UnsupportedCategory::kFeature);
+                }
+                auto inner_or = RenderPackedBitwiseBinaryCall(
+                    ctx, expr.type, b.op, ctx.Expr(b.lhs), ctx.Expr(b.rhs));
+                if (!inner_or) {
+                  return std::unexpected(std::move(inner_or.error()));
+                }
+                return std::format("{}.View()", *inner_or);
+              }
+              default:
+                return diag::Unsupported(
+                    diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+                    "this binary expression is not yet renderable as a "
+                    "runtime view in cpp emit",
+                    diag::UnsupportedCategory::kFeature);
+            }
+          },
           [](const mir::AssignExpr&) -> diag::Result<std::string> {
             return diag::Unsupported(
                 diag::DiagCode::kCppEmitExpressionFormNotImplemented,
@@ -369,6 +499,16 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
                        : RenderExprAsNative(ctx, expr);
           },
           [&](const mir::ConversionExpr&) -> diag::Result<std::string> {
+            return IsPackedRuntime(ctx.Unit(), expr.type)
+                       ? RenderExprAsRuntimeView(ctx, expr)
+                       : RenderExprAsNative(ctx, expr);
+          },
+          [&](const mir::UnaryExpr&) -> diag::Result<std::string> {
+            return IsPackedRuntime(ctx.Unit(), expr.type)
+                       ? RenderExprAsRuntimeView(ctx, expr)
+                       : RenderExprAsNative(ctx, expr);
+          },
+          [&](const mir::BinaryExpr&) -> diag::Result<std::string> {
             return IsPackedRuntime(ctx.Unit(), expr.type)
                        ? RenderExprAsRuntimeView(ctx, expr)
                        : RenderExprAsNative(ctx, expr);

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -206,7 +206,7 @@ auto RenderStmt(
             std::string cond;
             if (s.condition.has_value()) {
               const auto& cond_expr = ctx.Body().exprs.at(s.condition->value);
-              auto cond_or = RenderExpr(ctx, cond_expr);
+              auto cond_or = RenderExprAsNative(ctx, cond_expr);
               if (!cond_or) {
                 return std::unexpected(std::move(cond_or.error()));
               }

--- a/tests/cases/cpp/packed_bitwise_bit_ops/case.yaml
+++ b/tests/cases/cpp/packed_bitwise_bit_ops/case.yaml
@@ -1,0 +1,17 @@
+id: cpp.packed_bitwise_bit_ops
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      00110101
+      10001000
+      11101110
+      01100110
+      10011001
+      10011001

--- a/tests/cases/cpp/packed_bitwise_bit_ops/main.sv
+++ b/tests/cases/cpp/packed_bitwise_bit_ops/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  bit [7:0] a;
+  bit [7:0] b;
+  bit [7:0] y;
+  initial begin
+    a = 8'b11001010;
+    b = 8'b10101100;
+    y = ~a;     $display("%b", y);
+    y = a & b;  $display("%b", y);
+    y = a | b;  $display("%b", y);
+    y = a ^ b;  $display("%b", y);
+    y = a ~^ b; $display("%b", y);
+    y = a ^~ b; $display("%b", y);
+  end
+endmodule

--- a/tests/cases/cpp/packed_bitwise_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_bitwise_logic_ops/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.packed_bitwise_logic_ops
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      0011xxxx
+      1000xxx0
+      11x01x1x
+      01x0xxxx
+      10x1xxxx

--- a/tests/cases/cpp/packed_bitwise_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_bitwise_logic_ops/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  logic [7:0] a;
+  logic [7:0] b;
+  logic [7:0] y;
+  initial begin
+    a = 8'b1100xxzz;
+    b = 8'b10z01x10;
+    y = ~a;     $display("%b", y);
+    y = a & b;  $display("%b", y);
+    y = a | b;  $display("%b", y);
+    y = a ^ b;  $display("%b", y);
+    y = a ~^ b; $display("%b", y);
+  end
+endmodule

--- a/tests/cases/cpp/packed_bitwise_reg_alias_ops/case.yaml
+++ b/tests/cases/cpp/packed_bitwise_reg_alias_ops/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.packed_bitwise_reg_alias_ops
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1000
+      01x0

--- a/tests/cases/cpp/packed_bitwise_reg_alias_ops/main.sv
+++ b/tests/cases/cpp/packed_bitwise_reg_alias_ops/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  reg [3:0] a;
+  reg [3:0] b;
+  reg [3:0] y;
+  initial begin
+    a = 4'b10x1;
+    b = 4'b1100;
+    y = a & b;  $display("%b", y);
+    y = ~a;     $display("%b", y);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements end-to-end packed bitwise operator execution for the C++ backend: unary `~` and binary `& | ^ ~^` (and the `^~` spelling) over packed `bit`/`logic`/`reg`. HIR/MIR already carried these operators; this lands the runtime primitive layer, the emit-side routing, and three SystemVerilog E2E cases that exercise the whole pipeline.

## Design

Three layers:

- **Shared substrate** in `include/lyra/runtime/packed_words.hpp`: extracted `detail::PlaneAccess` and `detail::MaskUnusedTopBits` out of `convert.hpp` so neither conversion nor bitwise depends on the other. Underlying accessors renamed `*ForConvert` -> `*ForPackedOps` so the substrate's API name no longer leaks conversion semantics.
- **Bitwise primitives** in `include/lyra/runtime/bitwise.hpp`: word-level helpers (`NotPlaneWords`/`AndPlaneWords`/...) for 2-state and `LogicNotWords`/`LogicAndWords`/... for 4-state IEEE 1800 X/Z propagation, const-input core impls, and concept-gated public forwarders `BitwiseNot/And/Or/Xor/Xnor`. One public template per (op, kind) accepts any const/mutable view of the matching kind via `detail::ToConstView`. Width invariant guards throw `InternalError`.
- **C++ emit routing** in `src/lyra/backend/cpp/render_expr.cpp`: `RenderExpr` dispatcher routes any packed `mir::UnaryExpr`/`mir::BinaryExpr` through `RenderExprAsRuntimeView`; non-bitwise ops surface as `kCppEmitExpressionFormNotImplemented`. The new `RenderPackedBitwiseUnaryCall` / `RenderPackedBitwiseBinaryCall` helpers verify operand-type invariants (same packed-explicit kind, same width, same 4-state-ness) and throw `InternalError` if lowering fed unconverted operands. The for-loop-condition site in `render_stmt.cpp` now calls `RenderExprAsNative` directly (it emits a native C++ control-flow rvalue).

## Testing

- New E2E cases under `tests/cases/cpp/`:
  - `packed_bitwise_bit_ops` exercises all five operators on `bit [7:0]`, including both `~^` and `^~` XNOR spellings.
  - `packed_bitwise_logic_ops` exercises all five operators on `logic [7:0]` with X/Z literals; expected stdout matches IEEE 1800 4-state propagation tables.
  - `packed_bitwise_reg_alias_ops` smoke-tests the `reg = logic` alias path.
- `bazel test //...` green; all 6 test targets pass.