### PR TITLE
Adopt scoped Body model with BodyHops in MIR

### DIFF
--- a/include/lyra/backend/cpp/render_context.hpp
+++ b/include/lyra/backend/cpp/render_context.hpp
@@ -5,8 +5,12 @@
 #include <string>
 #include <string_view>
 
+#include "lyra/base/internal_error.hpp"
+#include "lyra/mir/body_hops.hpp"
 #include "lyra/mir/class_decl.hpp"
 #include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/stmt.hpp"
 
 namespace lyra::backend::cpp {
@@ -16,8 +20,28 @@ class RenderContext {
   RenderContext(
       const mir::CompilationUnit& unit, const mir::ClassDecl& class_decl,
       const mir::Body& body)
-      : unit_(&unit), class_decl_(&class_decl), body_(&body) {
+      : unit_(&unit),
+        class_decl_(&class_decl),
+        body_(&body),
+        parent_(nullptr),
+        temp_counter_(&owned_temp_counter_) {
   }
+
+  RenderContext(
+      const mir::CompilationUnit& unit, const mir::ClassDecl& class_decl,
+      const mir::Body& body, const RenderContext& parent)
+      : unit_(&unit),
+        class_decl_(&class_decl),
+        body_(&body),
+        parent_(&parent),
+        temp_counter_(parent.temp_counter_) {
+  }
+
+  RenderContext(const RenderContext&) = delete;
+  auto operator=(const RenderContext&) -> RenderContext& = delete;
+  RenderContext(RenderContext&&) = delete;
+  auto operator=(RenderContext&&) -> RenderContext& = delete;
+  ~RenderContext() = default;
 
   [[nodiscard]] auto Unit() const -> const mir::CompilationUnit& {
     return *unit_;
@@ -31,23 +55,32 @@ class RenderContext {
     return *body_;
   }
 
+  [[nodiscard]] auto BodyAtHops(mir::BodyHops hops) const -> const mir::Body& {
+    if (hops.value == 0) {
+      return *body_;
+    }
+    if (parent_ == nullptr) {
+      throw InternalError("RenderContext::BodyAtHops: hops out of range");
+    }
+    return parent_->BodyAtHops(mir::BodyHops{.value = hops.value - 1});
+  }
+
   [[nodiscard]] auto Expr(mir::ExprId id) const -> const mir::Expr& {
     return body_->GetExpr(id);
   }
 
-  // Allocate a unique temp-name suffix. Mutable because the counter is a
-  // logical-const supply, not part of the rendering context's observable
-  // shape. Single-threaded emission today.
   [[nodiscard]] auto AllocateTemp(std::string_view prefix) const
       -> std::string {
-    return std::format("{}_{}", prefix, next_temp_++);
+    return std::format("{}_{}", prefix, (*temp_counter_)++);
   }
 
  private:
   const mir::CompilationUnit* unit_;
   const mir::ClassDecl* class_decl_;
   const mir::Body* body_;
-  mutable std::size_t next_temp_ = 0;
+  const RenderContext* parent_;
+  std::size_t* temp_counter_;
+  mutable std::size_t owned_temp_counter_ = 0;
 };
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/backend/cpp/render_stmt.hpp
+++ b/include/lyra/backend/cpp/render_stmt.hpp
@@ -13,7 +13,8 @@ namespace lyra::backend::cpp {
 
 auto RenderBody(
     const mir::CompilationUnit& unit, const mir::ClassDecl& class_decl,
-    const mir::Body& body, std::size_t indent) -> diag::Result<std::string>;
+    const mir::Body& body, std::size_t indent,
+    const RenderContext* parent = nullptr) -> diag::Result<std::string>;
 
 auto RenderStmt(
     const RenderContext& ctx, const mir::Stmt& stmt, std::size_t indent)

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -23,7 +23,7 @@ enum class DiagCode : std::uint32_t {
   kUnsupportedTypeKind,
 
   kUnsupportedNonStaticVariableLifetime,
-  kUnsupportedNonInitialProcedure,
+  kUnsupportedProcessKindLowering,
   kUnsupportedStatementForm,
   kUnsupportedExpressionForm,
   kUnsupportedStructuralExpressionForm,

--- a/include/lyra/hir/process.hpp
+++ b/include/lyra/hir/process.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/local_var.hpp"
 #include "lyra/hir/stmt.hpp"
@@ -16,10 +17,18 @@ struct ProcessId {
   auto operator<=>(const ProcessId&) const -> std::strong_ordering = default;
 };
 
-enum class ProcessKind { kInitial };
+enum class ProcessKind : std::uint8_t {
+  kInitial,
+  kFinal,
+  kAlways,
+  kAlwaysComb,
+  kAlwaysLatch,
+  kAlwaysFf,
+};
 
 struct Process {
   ProcessKind kind = ProcessKind::kInitial;
+  diag::SourceSpan span;
   StmtId body{};
   std::vector<Expr> exprs;
   std::vector<Stmt> stmts;

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include "lyra/diag/source_span.hpp"
-#include "lyra/hir/expr.hpp"
+#include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/local_var.hpp"
 
 namespace lyra::hir {
@@ -40,7 +40,9 @@ struct DelayControl {
   ExprId duration;
 };
 
-using TimingControl = std::variant<DelayControl>;
+struct EventControl {};
+
+using TimingControl = std::variant<DelayControl, EventControl>;
 
 struct TimedStmt {
   TimingControl timing;

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -13,6 +13,7 @@
 #include <slang/ast/symbols/VariableSymbols.h>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/local_var.hpp"
 #include "lyra/hir/member_var.hpp"
@@ -294,8 +295,10 @@ class ProcessLoweringState {
     return hir_process_.local_vars.at(id.value).type;
   }
 
-  auto Finalize(hir::ProcessKind kind, hir::StmtId body) -> hir::Process {
+  auto Finalize(hir::ProcessKind kind, diag::SourceSpan span, hir::StmtId body)
+      -> hir::Process {
     hir_process_.kind = kind;
+    hir_process_.span = span;
     hir_process_.body = body;
     return std::move(hir_process_);
   }

--- a/include/lyra/lowering/hir_to_mir/body_helpers.hpp
+++ b/include/lyra/lowering/hir_to_mir/body_helpers.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "lyra/mir/stmt.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+inline auto AddChildBody(std::vector<mir::Body>& bodies, mir::Body body)
+    -> mir::BodyId {
+  const mir::BodyId id{static_cast<std::uint32_t>(bodies.size())};
+  bodies.push_back(std::move(body));
+  return id;
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/lower_stmt.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_stmt.hpp
@@ -10,7 +10,7 @@ namespace lyra::lowering::hir_to_mir {
 
 auto LowerStmt(
     const UnitLoweringState& unit_state, const ClassLoweringState& class_state,
-    const ProcessLoweringState& proc_state, BodyLoweringState& body_state,
+    ProcessLoweringState& proc_state, BodyLoweringState& body_state,
     const hir::Process& hir_proc, const hir::Stmt& stmt)
     -> diag::Result<mir::Stmt>;
 

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -27,6 +27,7 @@ namespace lyra::lowering::hir_to_mir {
 
 struct BuiltinMirTypes {
   mir::TypeId int32;
+  mir::TypeId bit1;
   mir::TypeId string;
   mir::TypeId void_type;
   mir::TypeId realtime;
@@ -42,6 +43,12 @@ class UnitLoweringState {
                 .signedness = mir::Signedness::kSigned,
                 .dims = {mir::PackedRange{.left = 31, .right = 0}},
                 .form = mir::PackedArrayForm::kInt}}),
+        .bit1 = AddType(
+            mir::TypeData{mir::PackedArrayType{
+                .atom = mir::BitAtom::kBit,
+                .signedness = mir::Signedness::kUnsigned,
+                .dims = {mir::PackedRange{.left = 0, .right = 0}},
+                .form = mir::PackedArrayForm::kExplicit}}),
         .string = AddType(mir::TypeData{mir::StringType{}}),
         .void_type = AddType(mir::TypeData{mir::VoidType{}}),
         .realtime = AddType(mir::TypeData{mir::RealTimeType{}})};
@@ -235,10 +242,11 @@ class ClassLoweringState {
   std::vector<mir::UserSubroutineTargetId> user_subroutine_map_;
 };
 
-// Process-body lowering state: maps HIR LocalVarId -> MIR LocalVarRef and
-// carries the active time resolution for delay scaling. The MIR locals
-// themselves live in the in-flight body's local scopes (see
-// BodyLoweringState).
+struct LocalBinding {
+  std::uint32_t declaration_body_depth;
+  mir::LocalVarId local;
+};
+
 class ProcessLoweringState {
  public:
   explicit ProcessLoweringState(TimeResolution time_resolution)
@@ -249,29 +257,83 @@ class ProcessLoweringState {
     return time_resolution_;
   }
 
-  void MapLocalVar(hir::LocalVarId hir_id, mir::LocalVarRef ref) {
-    if (hir_id.value >= map_.size()) {
-      map_.resize(hir_id.value + 1);
+  void EnterBody() {
+    ++body_depth_;
+  }
+  void LeaveBody() {
+    if (body_depth_ == 0) {
+      throw InternalError(
+          "ProcessLoweringState::LeaveBody: body-depth underflow");
     }
-    map_[hir_id.value] = ref;
+    --body_depth_;
+  }
+  [[nodiscard]] auto CurrentBodyDepth() const -> std::uint32_t {
+    return body_depth_;
+  }
+
+  void MapLocalVar(hir::LocalVarId hir_id, LocalBinding binding) {
+    if (hir_id.value >= bindings_.size()) {
+      bindings_.resize(hir_id.value + 1);
+    }
+    if (bindings_[hir_id.value].has_value()) {
+      throw InternalError(
+          "ProcessLoweringState::MapLocalVar: HIR LocalVarId already mapped "
+          "(duplicate VarDeclStmt for the same declaration)");
+    }
+    bindings_[hir_id.value] = binding;
+  }
+
+  [[nodiscard]] auto LookupLocalVar(hir::LocalVarId hir_id) const
+      -> const LocalBinding& {
+    if (hir_id.value >= bindings_.size() ||
+        !bindings_[hir_id.value].has_value()) {
+      throw InternalError(
+          "ProcessLoweringState::LookupLocalVar: unmapped HIR local var");
+    }
+    return *bindings_[hir_id.value];
   }
 
   [[nodiscard]] auto TranslateLocalVar(hir::LocalVarId hir_id) const
       -> mir::LocalVarRef {
-    if (hir_id.value >= map_.size()) {
-      throw InternalError("TranslateLocalVar: unmapped HIR local var");
+    const auto& binding = LookupLocalVar(hir_id);
+    if (binding.declaration_body_depth > body_depth_) {
+      throw InternalError(
+          "ProcessLoweringState::TranslateLocalVar: declaration body depth "
+          "exceeds current depth (forward reference into a child body)");
     }
-    return map_[hir_id.value];
+    return mir::LocalVarRef{
+        .body_hops =
+            mir::BodyHops{
+                .value = body_depth_ - binding.declaration_body_depth},
+        .local = binding.local,
+    };
   }
 
  private:
   TimeResolution time_resolution_;
-  std::vector<mir::LocalVarRef> map_;
+  std::uint32_t body_depth_ = 0;
+  std::vector<std::optional<LocalBinding>> bindings_;
 };
 
-// Constructor-body lowering state: maps HIR LoopVarDeclId -> MIR LocalVarRef
-// for the genvar of an enclosing for-generate. The MIR locals themselves live
-// in the in-flight body's local scopes.
+class BodyDepthGuard {
+ public:
+  explicit BodyDepthGuard(ProcessLoweringState& state) : state_(&state) {
+    state_->EnterBody();
+  }
+
+  ~BodyDepthGuard() {
+    state_->LeaveBody();
+  }
+
+  BodyDepthGuard(const BodyDepthGuard&) = delete;
+  auto operator=(const BodyDepthGuard&) -> BodyDepthGuard& = delete;
+  BodyDepthGuard(BodyDepthGuard&&) = delete;
+  auto operator=(BodyDepthGuard&&) -> BodyDepthGuard& = delete;
+
+ private:
+  ProcessLoweringState* state_;
+};
+
 class ConstructorLoweringState {
  public:
   void MapLoopVar(hir::LoopVarDeclId hir_id, mir::LocalVarRef ref) {
@@ -295,34 +357,17 @@ class ConstructorLoweringState {
 
 class BodyLoweringState {
  public:
-  BodyLoweringState() {
-    body_.root_scope = AddLocalScope(std::nullopt);
-  }
+  BodyLoweringState() = default;
 
-  [[nodiscard]] auto RootScope() const -> mir::LocalScopeId {
-    return body_.root_scope;
-  }
-
-  auto AddLocalScope(std::optional<mir::LocalScopeId> parent)
-      -> mir::LocalScopeId {
-    const mir::LocalScopeId id{
-        static_cast<std::uint32_t>(body_.local_scopes.size())};
-    body_.local_scopes.push_back(
-        mir::LocalScope{.parent = parent, .locals = {}});
+  auto AddLocal(mir::LocalVar local) -> mir::LocalVarId {
+    const mir::LocalVarId id{static_cast<std::uint32_t>(body_.locals.size())};
+    body_.locals.push_back(std::move(local));
     return id;
   }
 
-  auto AddLocal(mir::LocalScopeId scope, mir::LocalVar local)
-      -> mir::LocalVarId {
-    auto& s = body_.local_scopes.at(scope.value);
-    const mir::LocalVarId id{static_cast<std::uint32_t>(s.locals.size())};
-    s.locals.push_back(std::move(local));
-    return id;
-  }
-
-  [[nodiscard]] auto GetLocalVar(mir::LocalVarRef ref) const
+  [[nodiscard]] auto GetLocal(mir::LocalVarId id) const
       -> const mir::LocalVar& {
-    return body_.local_scopes.at(ref.scope.value).locals.at(ref.local.value);
+    return body_.locals.at(id.value);
   }
 
   auto AddExpr(mir::Expr expr) -> mir::ExprId {

--- a/include/lyra/mir/body_hops.hpp
+++ b/include/lyra/mir/body_hops.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace lyra::mir {
+
+struct BodyHops {
+  std::uint32_t value = 0;
+
+  auto operator<=>(const BodyHops&) const -> std::strong_ordering = default;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "lyra/mir/binary_op.hpp"
+#include "lyra/mir/body_hops.hpp"
 #include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/integral_constant.hpp"
@@ -38,7 +39,7 @@ struct MemberVarRef {
 };
 
 struct LocalVarRef {
-  LocalScopeId scope;
+  BodyHops body_hops;
   LocalVarId local;
 };
 

--- a/include/lyra/mir/local_var.hpp
+++ b/include/lyra/mir/local_var.hpp
@@ -2,9 +2,7 @@
 
 #include <compare>
 #include <cstdint>
-#include <optional>
 #include <string>
-#include <vector>
 
 #include "lyra/mir/type.hpp"
 
@@ -16,20 +14,9 @@ struct LocalVarId {
   auto operator<=>(const LocalVarId&) const -> std::strong_ordering = default;
 };
 
-struct LocalScopeId {
-  std::uint32_t value;
-
-  auto operator<=>(const LocalScopeId&) const -> std::strong_ordering = default;
-};
-
 struct LocalVar {
   std::string name;
   TypeId type;
-};
-
-struct LocalScope {
-  std::optional<LocalScopeId> parent;
-  std::vector<LocalVar> locals;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/process.hpp
+++ b/include/lyra/mir/process.hpp
@@ -13,10 +13,17 @@ struct ProcessId {
   auto operator<=>(const ProcessId&) const -> std::strong_ordering = default;
 };
 
-enum class ProcessKind { kInitial };
+enum class ProcessKind : std::uint8_t {
+  kInitial,
+  kFinal,
+  kAlways,
+  kAlwaysComb,
+  kAlwaysLatch,
+  kAlwaysFf,
+};
 
 struct Process {
-  ProcessKind kind;
+  ProcessKind kind = ProcessKind::kInitial;
   Body body;
 };
 

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -30,9 +30,7 @@ struct BodyId {
 };
 
 struct Body {
-  std::vector<LocalScope> local_scopes;
-  LocalScopeId root_scope;
-
+  std::vector<LocalVar> locals;
   std::vector<Expr> exprs;
   std::vector<Stmt> stmts;
   std::vector<StmtId> root_stmts;
@@ -57,7 +55,7 @@ struct ExprStmt {
 };
 
 struct BlockStmt {
-  std::vector<StmtId> statements;
+  BodyId body;
 };
 
 struct IfStmt {
@@ -94,7 +92,6 @@ struct ForInitExpr {
 using ForInit = std::variant<ForInitDecl, ForInitExpr>;
 
 struct ForStmt {
-  LocalScopeId scope;
   std::vector<ForInit> init;
   std::optional<ExprId> condition;
   std::vector<ExprId> step;
@@ -112,9 +109,22 @@ struct TimedStmt {
   StmtId body;
 };
 
+struct WhileStmt {
+  ExprId condition;
+  BodyId body;
+};
+
+enum class AwaitKind : std::uint8_t {
+  kAlwaysBackedge,
+};
+
+struct AwaitStmt {
+  AwaitKind kind;
+};
+
 using StmtData = std::variant<
     EmptyStmt, LocalVarDeclStmt, ExprStmt, BlockStmt, IfStmt, SwitchStmt,
-    ConstructOwnedObjectStmt, ForStmt, TimedStmt>;
+    ConstructOwnedObjectStmt, ForStmt, TimedStmt, WhileStmt, AwaitStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -50,6 +50,11 @@ auto RenderProcessMethod(
     const mir::CompilationUnit& unit, const mir::ClassDecl& c,
     const mir::Process& process, std::size_t index, std::size_t indent)
     -> diag::Result<std::string> {
+  if (process.kind != mir::ProcessKind::kInitial) {
+    throw InternalError(
+        "RenderProcessMethod: C++ emit is not yet supported for non-initial "
+        "processes");
+  }
   std::string out;
   out += Indent(indent) + "auto " + RenderProcessMethodName(index) +
          "() -> lyra::runtime::ProcessCoroutine {\n";
@@ -65,6 +70,14 @@ auto RenderProcessKindLiteral(mir::ProcessKind kind) -> std::string {
   switch (kind) {
     case mir::ProcessKind::kInitial:
       return "lyra::runtime::ProcessKind::kInitial";
+    case mir::ProcessKind::kFinal:
+    case mir::ProcessKind::kAlways:
+    case mir::ProcessKind::kAlwaysComb:
+    case mir::ProcessKind::kAlwaysLatch:
+    case mir::ProcessKind::kAlwaysFf:
+      throw InternalError(
+          "RenderProcessKindLiteral: C++ emit is not yet supported for "
+          "non-initial processes");
   }
   throw InternalError("RenderProcessKindLiteral: unknown ProcessKind");
 }

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -65,9 +65,9 @@ auto BinaryOpToken(mir::BinaryOp op) -> diag::Result<std::string_view> {
   throw InternalError("BinaryOpToken: unknown MIR BinaryOp");
 }
 
-auto LookupLocalName(const mir::Body& body, const mir::LocalVarRef& ref)
+auto LookupLocalName(const RenderContext& ctx, const mir::LocalVarRef& ref)
     -> const std::string& {
-  return body.local_scopes.at(ref.scope.value).locals.at(ref.local.value).name;
+  return ctx.BodyAtHops(ref.body_hops).locals.at(ref.local.value).name;
 }
 
 auto SignednessLiteral(mir::Signedness s) -> std::string_view {
@@ -95,10 +95,7 @@ auto MirTypeOfLvalue(const RenderContext& ctx, const mir::Lvalue& lv)
             return ctx.Class().GetMemberVar(m.target).type;
           },
           [&](const mir::LocalVarRef& l) -> mir::TypeId {
-            return ctx.Body()
-                .local_scopes.at(l.scope.value)
-                .locals.at(l.local.value)
-                .type;
+            return ctx.BodyAtHops(l.body_hops).locals.at(l.local.value).type;
           },
       },
       lv);
@@ -424,7 +421,7 @@ auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
             return ctx.Class().GetMemberVar(m.target).name;
           },
           [&](const mir::LocalVarRef& l) -> std::string {
-            return LookupLocalName(ctx.Body(), l);
+            return LookupLocalName(ctx, l);
           },
       },
       target);
@@ -450,7 +447,7 @@ auto RenderExprAsNative(const RenderContext& ctx, const mir::Expr& expr)
             return ctx.Class().GetMemberVar(m.target).name;
           },
           [&](const mir::LocalVarRef& l) -> diag::Result<std::string> {
-            return LookupLocalName(ctx.Body(), l);
+            return LookupLocalName(ctx, l);
           },
           [](const mir::UnaryExpr&) -> diag::Result<std::string> {
             return diag::Unsupported(
@@ -511,7 +508,7 @@ auto RenderExprAsRuntimeView(const RenderContext& ctx, const mir::Expr& expr)
                 "{}.View()", ctx.Class().GetMemberVar(m.target).name);
           },
           [&](const mir::LocalVarRef& l) -> diag::Result<std::string> {
-            return std::format("{}.View()", LookupLocalName(ctx.Body(), l));
+            return std::format("{}.View()", LookupLocalName(ctx, l));
           },
           [&](const mir::ConversionExpr& cv) -> diag::Result<std::string> {
             auto inner_or = RenderConversionCall(ctx, expr.type, cv);

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -26,8 +26,7 @@ auto RenderForInit(const RenderContext& ctx, const mir::ForInit& init)
   return std::visit(
       Overloaded{
           [&](const mir::ForInitDecl& d) -> diag::Result<std::string> {
-            const auto& lv = ctx.Body()
-                                 .local_scopes.at(d.local.scope.value)
+            const auto& lv = ctx.BodyAtHops(d.local.body_hops)
                                  .locals.at(d.local.local.value);
             std::string out =
                 RenderTypeAsCpp(ctx.Unit(), ctx.Class(), lv.type) + " " +
@@ -81,8 +80,7 @@ auto RenderStmt(
             return out;
           },
           [&](const mir::LocalVarDeclStmt& s) -> diag::Result<std::string> {
-            const auto& lv = ctx.Body()
-                                 .local_scopes.at(s.target.scope.value)
+            const auto& lv = ctx.BodyAtHops(s.target.body_hops)
                                  .locals.at(s.target.local.value);
             return Indent(indent) +
                    RenderTypeAsCpp(ctx.Unit(), ctx.Class(), lv.type) + " " +
@@ -97,15 +95,12 @@ auto RenderStmt(
             return Indent(indent) + *rendered_or + ";\n";
           },
           [&](const mir::BlockStmt& s) -> diag::Result<std::string> {
+            const auto& child = stmt.child_bodies.at(s.body.value);
             std::string result = Indent(indent) + "{\n";
-            for (const auto child_id : s.statements) {
-              auto child_or = RenderStmt(
-                  ctx, ctx.Body().stmts.at(child_id.value), indent + 1);
-              if (!child_or) {
-                return std::unexpected(std::move(child_or.error()));
-              }
-              result += *child_or;
-            }
+            auto child_or =
+                RenderBody(ctx.Unit(), ctx.Class(), child, indent + 1, &ctx);
+            if (!child_or) return std::unexpected(std::move(child_or.error()));
+            result += *child_or;
             result += Indent(indent) + "}\n";
             return result;
           },
@@ -114,8 +109,8 @@ auto RenderStmt(
             const auto& then_body = stmt.child_bodies.at(s.then_body.value);
             auto cond_or = RenderExpr(ctx, cond_expr);
             if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-            auto then_or =
-                RenderBody(ctx.Unit(), ctx.Class(), then_body, indent + 1);
+            auto then_or = RenderBody(
+                ctx.Unit(), ctx.Class(), then_body, indent + 1, &ctx);
             if (!then_or) return std::unexpected(std::move(then_or.error()));
             std::string result;
             result += Indent(indent) + "if (" + *cond_or + ") {\n";
@@ -123,8 +118,8 @@ auto RenderStmt(
             result += Indent(indent) + "}";
             if (s.else_body.has_value()) {
               const auto& else_body = stmt.child_bodies.at(s.else_body->value);
-              auto else_or =
-                  RenderBody(ctx.Unit(), ctx.Class(), else_body, indent + 1);
+              auto else_or = RenderBody(
+                  ctx.Unit(), ctx.Class(), else_body, indent + 1, &ctx);
               if (!else_or) return std::unexpected(std::move(else_or.error()));
               result += " else {\n";
               result += *else_or;
@@ -151,8 +146,8 @@ auto RenderStmt(
                           (is_last ? ": {\n" : ":\n");
               }
               const auto& case_body = stmt.child_bodies.at(c.body.value);
-              auto case_or =
-                  RenderBody(ctx.Unit(), ctx.Class(), case_body, indent + 2);
+              auto case_or = RenderBody(
+                  ctx.Unit(), ctx.Class(), case_body, indent + 2, &ctx);
               if (!case_or) return std::unexpected(std::move(case_or.error()));
               result += *case_or;
               result += Indent(indent + 2) + "break;\n";
@@ -161,8 +156,8 @@ auto RenderStmt(
             if (s.default_body.has_value()) {
               const auto& default_body =
                   stmt.child_bodies.at(s.default_body->value);
-              auto default_or =
-                  RenderBody(ctx.Unit(), ctx.Class(), default_body, indent + 2);
+              auto default_or = RenderBody(
+                  ctx.Unit(), ctx.Class(), default_body, indent + 2, &ctx);
               if (!default_or) {
                 return std::unexpected(std::move(default_or.error()));
               }
@@ -226,13 +221,21 @@ auto RenderStmt(
             }
             const auto& body = stmt.child_bodies.at(s.body.value);
             auto body_or =
-                RenderBody(ctx.Unit(), ctx.Class(), body, indent + 1);
+                RenderBody(ctx.Unit(), ctx.Class(), body, indent + 1, &ctx);
             if (!body_or) return std::unexpected(std::move(body_or.error()));
             std::string result = Indent(indent) + "for (" + init + "; " + cond +
                                  "; " + step + ") {\n";
             result += *body_or;
             result += Indent(indent) + "}\n";
             return result;
+          },
+          [&](const mir::WhileStmt&) -> diag::Result<std::string> {
+            throw InternalError(
+                "RenderStmt: WhileStmt is not yet supported by C++ emit");
+          },
+          [&](const mir::AwaitStmt&) -> diag::Result<std::string> {
+            throw InternalError(
+                "RenderStmt: AwaitStmt is not yet supported by C++ emit");
           },
       },
       stmt.data);
@@ -243,13 +246,23 @@ auto RenderStmt(
 
 auto RenderBody(
     const mir::CompilationUnit& unit, const mir::ClassDecl& class_decl,
-    const mir::Body& body, std::size_t indent) -> diag::Result<std::string> {
-  const RenderContext ctx{unit, class_decl, body};
+    const mir::Body& body, std::size_t indent, const RenderContext* parent)
+    -> diag::Result<std::string> {
   std::string out;
-  for (const auto& sid : body.root_stmts) {
-    auto rendered_or = RenderStmt(ctx, body.stmts.at(sid.value), indent);
-    if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
-    out += *rendered_or;
+  if (parent == nullptr) {
+    const RenderContext ctx{unit, class_decl, body};
+    for (const auto& sid : body.root_stmts) {
+      auto rendered_or = RenderStmt(ctx, body.stmts.at(sid.value), indent);
+      if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
+      out += *rendered_or;
+    }
+  } else {
+    const RenderContext ctx{unit, class_decl, body, *parent};
+    for (const auto& sid : body.root_stmts) {
+      auto rendered_or = RenderStmt(ctx, body.stmts.at(sid.value), indent);
+      if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
+      out += *rendered_or;
+    }
   }
   return out;
 }

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -85,11 +85,11 @@ constexpr std::array kEntries{
             .category = UnsupportedCategory::kFeature,
             .name = "unsupported_non_static_variable_lifetime"}},
     std::pair{
-        DiagCode::kUnsupportedNonInitialProcedure,
+        DiagCode::kUnsupportedProcessKindLowering,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
             .category = UnsupportedCategory::kFeature,
-            .name = "unsupported_non_initial_procedure"}},
+            .name = "unsupported_process_kind_lowering"}},
     std::pair{
         DiagCode::kUnsupportedStatementForm,
         DiagCodeInfo{

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -358,6 +358,7 @@ class HirDumper {
               return std::format(
                   "DelayControl duration=Expr[{}]", d.duration.value);
             },
+            [](const EventControl&) -> std::string { return "EventControl"; },
         },
         tc);
   }
@@ -526,6 +527,21 @@ class HirDumper {
       case ProcessKind::kInitial:
         Line("Process (Initial)");
         break;
+      case ProcessKind::kFinal:
+        Line("Process (Final)");
+        break;
+      case ProcessKind::kAlways:
+        Line("Process (Always)");
+        break;
+      case ProcessKind::kAlwaysComb:
+        Line("Process (AlwaysComb)");
+        break;
+      case ProcessKind::kAlwaysLatch:
+        Line("Process (AlwaysLatch)");
+        break;
+      case ProcessKind::kAlwaysFf:
+        Line("Process (AlwaysFf)");
+        break;
     }
     Indent();
     if (!p.local_vars.empty()) {
@@ -601,6 +617,7 @@ class HirDumper {
                                 "Expr[{}] {}", d.duration.value,
                                 FormatProcExpr(p, d.duration)));
                       },
+                      [](const EventControl&) {},
                   },
                   t.timing);
               Dedent();

--- a/src/lyra/lowering/ast_to_hir/process.cpp
+++ b/src/lyra/lowering/ast_to_hir/process.cpp
@@ -5,6 +5,7 @@
 
 #include <slang/ast/symbols/BlockSymbols.h>
 
+#include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/process.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
@@ -12,6 +13,30 @@
 #include "lyra/lowering/ast_to_hir/statement/lower.hpp"
 
 namespace lyra::lowering::ast_to_hir {
+
+namespace {
+
+auto FromSlangProceduralBlockKind(slang::ast::ProceduralBlockKind kind)
+    -> hir::ProcessKind {
+  switch (kind) {
+    case slang::ast::ProceduralBlockKind::Initial:
+      return hir::ProcessKind::kInitial;
+    case slang::ast::ProceduralBlockKind::Final:
+      return hir::ProcessKind::kFinal;
+    case slang::ast::ProceduralBlockKind::Always:
+      return hir::ProcessKind::kAlways;
+    case slang::ast::ProceduralBlockKind::AlwaysComb:
+      return hir::ProcessKind::kAlwaysComb;
+    case slang::ast::ProceduralBlockKind::AlwaysLatch:
+      return hir::ProcessKind::kAlwaysLatch;
+    case slang::ast::ProceduralBlockKind::AlwaysFF:
+      return hir::ProcessKind::kAlwaysFf;
+  }
+  throw InternalError(
+      "ast_to_hir::FromSlangProceduralBlockKind: unknown ProceduralBlockKind");
+}
+
+}  // namespace
 
 auto LowerProcess(
     const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
@@ -24,7 +49,10 @@ auto LowerProcess(
   if (!body) return std::unexpected(std::move(body.error()));
   const hir::StmtId body_id = proc_state.AddStmt(*std::move(body));
 
-  return proc_state.Finalize(hir::ProcessKind::kInitial, body_id);
+  const auto& mapper = unit_facts.SourceMapper();
+  const auto span = mapper.PointSpanOf(proc.location);
+  return proc_state.Finalize(
+      FromSlangProceduralBlockKind(proc.procedureKind), span, body_id);
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -118,13 +118,6 @@ auto LowerScopeInto(
       continue;
     }
     const auto& proc = member.as<slang::ast::ProceduralBlockSymbol>();
-    if (proc.procedureKind != slang::ast::ProceduralBlockKind::Initial) {
-      return diag::Unsupported(
-          mapper.PointSpanOf(proc.location),
-          diag::DiagCode::kUnsupportedNonInitialProcedure,
-          "only `initial` procedural blocks are supported",
-          diag::UnsupportedCategory::kFeature);
-    }
     auto p = LowerProcess(unit_facts, scope_state, stack, proc);
     if (!p) return std::unexpected(std::move(p.error()));
     scope_state.AddProcess(*std::move(p));

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -31,18 +31,26 @@ auto LowerTimingControl(
     ProcessLoweringState& proc_state, const ScopeStack& stack,
     const slang::ast::TimingControl& tc, diag::SourceSpan span)
     -> diag::Result<hir::TimingControl> {
-  if (tc.kind == slang::ast::TimingControlKind::Delay) {
-    const auto& delay = tc.as<slang::ast::DelayControl>();
-    auto duration =
-        LowerProcExpr(unit_facts, unit_state, proc_state, stack, delay.expr);
-    if (!duration) return std::unexpected(std::move(duration.error()));
-    return hir::TimingControl{hir::DelayControl{
-        .duration = proc_state.AddExpr(*std::move(duration))}};
+  switch (tc.kind) {
+    case slang::ast::TimingControlKind::Delay: {
+      const auto& delay = tc.as<slang::ast::DelayControl>();
+      auto duration =
+          LowerProcExpr(unit_facts, unit_state, proc_state, stack, delay.expr);
+      if (!duration) return std::unexpected(std::move(duration.error()));
+      return hir::TimingControl{hir::DelayControl{
+          .duration = proc_state.AddExpr(*std::move(duration))}};
+    }
+    case slang::ast::TimingControlKind::SignalEvent:
+    case slang::ast::TimingControlKind::EventList:
+    case slang::ast::TimingControlKind::ImplicitEvent:
+    case slang::ast::TimingControlKind::RepeatedEvent:
+      return hir::TimingControl{hir::EventControl{}};
+    default:
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedTimingControlKind,
+          "this timing control kind is not yet supported",
+          diag::UnsupportedCategory::kFeature);
   }
-  return diag::Unsupported(
-      span, diag::DiagCode::kUnsupportedTimingControlKind,
-      "this timing control kind is not yet supported",
-      diag::UnsupportedCategory::kFeature);
 }
 
 }  // namespace

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -16,6 +16,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/structural_scope.hpp"
+#include "lyra/lowering/hir_to_mir/body_helpers.hpp"
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 #include "lyra/lowering/hir_to_mir/lower_process.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
@@ -173,13 +174,6 @@ auto BuildGenerateArmBody(
   return body_state.Finish();
 }
 
-auto AddChildBody(std::vector<mir::Body>& bodies, mir::Body body)
-    -> mir::BodyId {
-  const mir::BodyId id{static_cast<std::uint32_t>(bodies.size())};
-  bodies.push_back(std::move(body));
-  return id;
-}
-
 auto LowerGenerateAsStmt(
     UnitLoweringState& unit_state, const ClassLoweringState& class_state,
     const hir::StructuralScope& enclosing_scope, const hir::Generate& gen,
@@ -276,13 +270,10 @@ auto LowerGenerateAsStmt(
             const mir::TypeId genvar_type =
                 unit_state.TranslateType(var_decl.type);
 
-            const mir::LocalScopeId for_scope =
-                body_state.AddLocalScope(body_state.RootScope());
             const mir::LocalVarId loop_local_id = body_state.AddLocal(
-                for_scope,
                 mir::LocalVar{.name = var_decl.name, .type = genvar_type});
             const mir::LocalVarRef loop_local{
-                .scope = for_scope, .local = loop_local_id};
+                .body_hops = mir::BodyHops{.value = 0}, .local = loop_local_id};
 
             ConstructorLoweringState ctor_state;
             ctor_state.MapLoopVar(loop.loop_var, loop_local);
@@ -315,7 +306,6 @@ auto LowerGenerateAsStmt(
                 .label = std::nullopt,
                 .data =
                     mir::ForStmt{
-                        .scope = for_scope,
                         .init = {mir::ForInitDecl{
                             .local = loop_local, .init = init_id}},
                         .condition = cond_id,

--- a/src/lyra/lowering/hir_to_mir/lower_process.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_process.cpp
@@ -1,31 +1,131 @@
 #include "lyra/lowering/hir_to_mir/lower_process.hpp"
 
-#include <cstddef>
 #include <cstdint>
+#include <expected>
+#include <optional>
 #include <utility>
+#include <vector>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/time.hpp"
+#include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
-#include "lyra/hir/local_var.hpp"
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/body_helpers.hpp"
 #include "lyra/lowering/hir_to_mir/lower_stmt.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/body_hops.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/integral_constant.hpp"
 #include "lyra/mir/local_var.hpp"
 #include "lyra/mir/process.hpp"
 #include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
 namespace {
 
-auto LowerProcessKind(hir::ProcessKind kind) -> mir::ProcessKind {
-  switch (kind) {
+auto LowerProcessKind(hir::ProcessKind hir_kind, diag::SourceSpan span)
+    -> diag::Result<mir::ProcessKind> {
+  switch (hir_kind) {
     case hir::ProcessKind::kInitial:
       return mir::ProcessKind::kInitial;
+    case hir::ProcessKind::kAlways:
+      return mir::ProcessKind::kAlways;
+    case hir::ProcessKind::kFinal:
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedProcessKindLowering,
+          "`final` processes are not yet supported",
+          diag::UnsupportedCategory::kFeature);
+    case hir::ProcessKind::kAlwaysComb:
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedProcessKindLowering,
+          "`always_comb` processes are not yet supported",
+          diag::UnsupportedCategory::kFeature);
+    case hir::ProcessKind::kAlwaysLatch:
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedProcessKindLowering,
+          "`always_latch` processes are not yet supported",
+          diag::UnsupportedCategory::kFeature);
+    case hir::ProcessKind::kAlwaysFf:
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedProcessKindLowering,
+          "`always_ff` processes are not yet supported",
+          diag::UnsupportedCategory::kFeature);
   }
   throw InternalError("LowerProcessKind: unknown HIR ProcessKind");
+}
+
+auto MakeTrueConditionExpr(BodyLoweringState& body_state, mir::TypeId bit1)
+    -> mir::ExprId {
+  return body_state.AddExpr(
+      mir::Expr{
+          .data =
+              mir::IntegerLiteral{
+                  .value =
+                      mir::IntegralConstant{
+                          .value_words = {1ULL},
+                          .state_words = {},
+                          .width = 1,
+                          .signedness = mir::Signedness::kUnsigned,
+                          .state_kind = mir::IntegralStateKind::kTwoState,
+                      }},
+          .type = bit1,
+      });
+}
+
+auto LowerInitialProcess(
+    const UnitLoweringState& unit_state, const ClassLoweringState& class_state,
+    const hir::Process& src, ProcessLoweringState& proc_state)
+    -> diag::Result<mir::Process> {
+  BodyLoweringState process_body_state;
+  auto lowered = LowerStmt(
+      unit_state, class_state, proc_state, process_body_state, src,
+      src.stmts.at(src.body.value));
+  if (!lowered) return std::unexpected(std::move(lowered.error()));
+  const mir::StmtId root_id = process_body_state.AddStmt(*std::move(lowered));
+  process_body_state.AddRootStmt(root_id);
+  return mir::Process{
+      .kind = mir::ProcessKind::kInitial, .body = process_body_state.Finish()};
+}
+
+auto LowerAlwaysProcess(
+    const UnitLoweringState& unit_state, const ClassLoweringState& class_state,
+    const hir::Process& src, ProcessLoweringState& proc_state)
+    -> diag::Result<mir::Process> {
+  BodyLoweringState while_body_state;
+  {
+    BodyDepthGuard guard{proc_state};
+    auto lowered = LowerStmt(
+        unit_state, class_state, proc_state, while_body_state, src,
+        src.stmts.at(src.body.value));
+    if (!lowered) return std::unexpected(std::move(lowered.error()));
+    const mir::StmtId source_id = while_body_state.AddStmt(*std::move(lowered));
+    while_body_state.AddRootStmt(source_id);
+    const mir::StmtId await_id = while_body_state.AddStmt(
+        mir::Stmt{
+            .label = std::nullopt,
+            .data = mir::AwaitStmt{.kind = mir::AwaitKind::kAlwaysBackedge},
+            .child_bodies = {}});
+    while_body_state.AddRootStmt(await_id);
+  }
+
+  BodyLoweringState process_body_state;
+  const mir::ExprId cond_id =
+      MakeTrueConditionExpr(process_body_state, unit_state.Builtins().bit1);
+  std::vector<mir::Body> child_bodies;
+  const mir::BodyId while_body_id =
+      AddChildBody(child_bodies, while_body_state.Finish());
+  const mir::StmtId while_stmt_id = process_body_state.AddStmt(
+      mir::Stmt{
+          .label = std::nullopt,
+          .data = mir::WhileStmt{.condition = cond_id, .body = while_body_id},
+          .child_bodies = std::move(child_bodies)});
+  process_body_state.AddRootStmt(while_stmt_id);
+  return mir::Process{
+      .kind = mir::ProcessKind::kAlways, .body = process_body_state.Finish()};
 }
 
 }  // namespace
@@ -34,31 +134,14 @@ auto LowerProcess(
     const UnitLoweringState& unit_state, const ClassLoweringState& class_state,
     const hir::Process& src, TimeResolution time_resolution)
     -> diag::Result<mir::Process> {
+  auto kind_or = LowerProcessKind(src.kind, src.span);
+  if (!kind_or) return std::unexpected(std::move(kind_or.error()));
+
   ProcessLoweringState proc_state{time_resolution};
-  BodyLoweringState body_state;
-
-  const mir::LocalScopeId root_scope = body_state.RootScope();
-  for (std::size_t i = 0; i < src.local_vars.size(); ++i) {
-    const hir::LocalVarId hir_id{static_cast<std::uint32_t>(i)};
-    const auto& hir_local = src.local_vars[i];
-    const mir::LocalVarId local_id = body_state.AddLocal(
-        root_scope, mir::LocalVar{
-                        .name = hir_local.name,
-                        .type = unit_state.TranslateType(hir_local.type)});
-    proc_state.MapLocalVar(
-        hir_id, mir::LocalVarRef{.scope = root_scope, .local = local_id});
+  if (*kind_or == mir::ProcessKind::kInitial) {
+    return LowerInitialProcess(unit_state, class_state, src, proc_state);
   }
-
-  const hir::Stmt& root = src.stmts.at(src.body.value);
-  auto lowered_root_or =
-      LowerStmt(unit_state, class_state, proc_state, body_state, src, root);
-  if (!lowered_root_or) {
-    return std::unexpected(std::move(lowered_root_or.error()));
-  }
-  body_state.AddRootStmt(body_state.AddStmt(*std::move(lowered_root_or)));
-
-  return mir::Process{
-      .kind = LowerProcessKind(src.kind), .body = body_state.Finish()};
+  return LowerAlwaysProcess(unit_state, class_state, src, proc_state);
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -14,9 +14,11 @@
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/body_helpers.hpp"
 #include "lyra/lowering/hir_to_mir/delay_time_resolver.hpp"
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/body_hops.hpp"
 #include "lyra/mir/stmt.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -66,7 +68,8 @@ auto ResolveDelayDuration(
 
 auto LowerTimingControl(
     const ProcessLoweringState& proc_state, const hir::Process& hir_proc,
-    const hir::TimingControl& tc) -> diag::Result<mir::TimingControl> {
+    const hir::TimingControl& tc, diag::SourceSpan span)
+    -> diag::Result<mir::TimingControl> {
   return std::visit(
       Overloaded{
           [&](const hir::DelayControl& d) -> diag::Result<mir::TimingControl> {
@@ -78,6 +81,12 @@ auto LowerTimingControl(
             }
             return mir::TimingControl{mir::DelayControl{.duration = *ticks_or}};
           },
+          [&](const hir::EventControl&) -> diag::Result<mir::TimingControl> {
+            return diag::Unsupported(
+                span, diag::DiagCode::kUnsupportedTimingControlKind,
+                "event-control timing is not yet supported",
+                diag::UnsupportedCategory::kFeature);
+          },
       },
       tc);
 }
@@ -86,45 +95,77 @@ auto LowerTimingControl(
 
 auto LowerStmt(
     const UnitLoweringState& unit_state, const ClassLoweringState& class_state,
-    const ProcessLoweringState& proc_state, BodyLoweringState& body_state,
+    ProcessLoweringState& proc_state, BodyLoweringState& body_state,
     const hir::Process& hir_proc, const hir::Stmt& stmt)
     -> diag::Result<mir::Stmt> {
-  auto data = std::visit(
+  return std::visit(
       Overloaded{
-          [](const hir::EmptyStmt&) -> diag::Result<mir::StmtData> {
-            return mir::EmptyStmt{};
+          [&](const hir::EmptyStmt&) -> diag::Result<mir::Stmt> {
+            return mir::Stmt{
+                .label = stmt.label,
+                .data = mir::EmptyStmt{},
+                .child_bodies = {}};
           },
-          [&](const hir::VarDeclStmt& v) -> diag::Result<mir::StmtData> {
-            return mir::LocalVarDeclStmt{
-                .target = proc_state.TranslateLocalVar(v.local_var)};
+          [&](const hir::VarDeclStmt& v) -> diag::Result<mir::Stmt> {
+            const auto& hir_local = hir_proc.local_vars.at(v.local_var.value);
+            const mir::TypeId type = unit_state.TranslateType(hir_local.type);
+            const mir::LocalVarId local_id = body_state.AddLocal(
+                mir::LocalVar{.name = hir_local.name, .type = type});
+            proc_state.MapLocalVar(
+                v.local_var,
+                LocalBinding{
+                    .declaration_body_depth = proc_state.CurrentBodyDepth(),
+                    .local = local_id});
+            return mir::Stmt{
+                .label = stmt.label,
+                .data =
+                    mir::LocalVarDeclStmt{
+                        .target =
+                            mir::LocalVarRef{
+                                .body_hops = mir::BodyHops{.value = 0},
+                                .local = local_id}},
+                .child_bodies = {}};
           },
-          [&](const hir::ExprStmt& e) -> diag::Result<mir::StmtData> {
+          [&](const hir::ExprStmt& e) -> diag::Result<mir::Stmt> {
             auto expr_or = LowerExpr(
                 unit_state, class_state, proc_state, body_state, hir_proc,
                 hir_proc.exprs.at(e.expr.value));
             if (!expr_or) {
               return std::unexpected(std::move(expr_or.error()));
             }
-            return mir::ExprStmt{
-                .expr = body_state.AddExpr(*std::move(expr_or))};
+            return mir::Stmt{
+                .label = stmt.label,
+                .data =
+                    mir::ExprStmt{
+                        .expr = body_state.AddExpr(*std::move(expr_or))},
+                .child_bodies = {}};
           },
-          [&](const hir::BlockStmt& b) -> diag::Result<mir::StmtData> {
-            std::vector<mir::StmtId> children;
-            children.reserve(b.statements.size());
-            for (const hir::StmtId child_id : b.statements) {
-              const hir::Stmt& child = hir_proc.stmts.at(child_id.value);
-              auto lowered_child = LowerStmt(
-                  unit_state, class_state, proc_state, body_state, hir_proc,
-                  child);
-              if (!lowered_child) {
-                return std::unexpected(std::move(lowered_child.error()));
+          [&](const hir::BlockStmt& b) -> diag::Result<mir::Stmt> {
+            BodyLoweringState child_body_state;
+            BodyDepthGuard depth_guard{proc_state};
+            for (const hir::StmtId child_hir_id : b.statements) {
+              const hir::Stmt& child = hir_proc.stmts.at(child_hir_id.value);
+              auto lowered = LowerStmt(
+                  unit_state, class_state, proc_state, child_body_state,
+                  hir_proc, child);
+              if (!lowered) {
+                return std::unexpected(std::move(lowered.error()));
               }
-              children.push_back(body_state.AddStmt(*std::move(lowered_child)));
+              const mir::StmtId child_id =
+                  child_body_state.AddStmt(*std::move(lowered));
+              child_body_state.AddRootStmt(child_id);
             }
-            return mir::BlockStmt{.statements = std::move(children)};
+            std::vector<mir::Body> child_bodies;
+            const mir::BodyId body_id =
+                AddChildBody(child_bodies, child_body_state.Finish());
+            return mir::Stmt{
+                .label = stmt.label,
+                .data = mir::BlockStmt{.body = body_id},
+                .child_bodies = std::move(child_bodies)};
           },
-          [&](const hir::TimedStmt& t) -> diag::Result<mir::StmtData> {
-            auto timing_or = LowerTimingControl(proc_state, hir_proc, t.timing);
+          [&](const hir::TimedStmt& t) -> diag::Result<mir::Stmt> {
+            auto timing_or =
+                LowerTimingControl(proc_state, hir_proc, t.timing, stmt.span);
             if (!timing_or) {
               return std::unexpected(std::move(timing_or.error()));
             }
@@ -136,14 +177,15 @@ auto LowerStmt(
               return std::unexpected(std::move(body_or.error()));
             }
             const mir::StmtId body_id = body_state.AddStmt(*std::move(body_or));
-            return mir::TimedStmt{
-                .timing = *std::move(timing_or), .body = body_id};
+            return mir::Stmt{
+                .label = stmt.label,
+                .data =
+                    mir::TimedStmt{
+                        .timing = *std::move(timing_or), .body = body_id},
+                .child_bodies = {}};
           },
       },
       stmt.data);
-  if (!data) return std::unexpected(std::move(data.error()));
-  return mir::Stmt{
-      .label = stmt.label, .data = *std::move(data), .child_bodies = {}};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -303,7 +303,8 @@ class MirDumper {
             },
             [](const LocalVarRef& r) -> std::string {
               return std::format(
-                  "LocalVar[scope={}, local={}]", r.scope.value, r.local.value);
+                  "LocalVar[body_hops={}, local={}]", r.body_hops.value,
+                  r.local.value);
             },
         },
         l);
@@ -400,7 +401,7 @@ class MirDumper {
             },
             [](const LocalVarRef& r) -> std::string {
               return std::format(
-                  "LocalVarRef(scope={}, local={})", r.scope.value,
+                  "LocalVarRef(body_hops={}, local={})", r.body_hops.value,
                   r.local.value);
             },
             [](const UnaryExpr& u) -> std::string {
@@ -450,8 +451,26 @@ class MirDumper {
     switch (p.kind) {
       case ProcessKind::kInitial:
         return "Initial";
+      case ProcessKind::kFinal:
+        return "Final";
+      case ProcessKind::kAlways:
+        return "Always";
+      case ProcessKind::kAlwaysComb:
+        return "AlwaysComb";
+      case ProcessKind::kAlwaysLatch:
+        return "AlwaysLatch";
+      case ProcessKind::kAlwaysFf:
+        return "AlwaysFf";
     }
     throw InternalError("MirDumper: unknown ProcessKind");
+  }
+
+  static auto FormatAwaitKind(AwaitKind k) -> std::string_view {
+    switch (k) {
+      case AwaitKind::kAlwaysBackedge:
+        return "AlwaysBackedge";
+    }
+    throw InternalError("MirDumper: unknown AwaitKind");
   }
 
   void DumpClass(const ClassDecl& c) {
@@ -511,23 +530,17 @@ class MirDumper {
   }
 
   void DumpBody(const Body& body) {
-    Line(std::format("LocalScopes (root={}):", body.root_scope.value));
-    Indent();
-    for (std::size_t i = 0; i < body.local_scopes.size(); ++i) {
-      const auto& s = body.local_scopes[i];
-      const std::string parent_str =
-          s.parent.has_value() ? std::format("{}", s.parent->value) : "<none>";
-      Line(std::format("Scope[{}] parent={}", i, parent_str));
+    if (!body.locals.empty()) {
+      Line("Locals:");
       Indent();
-      for (std::size_t j = 0; j < s.locals.size(); ++j) {
-        const auto& lv = s.locals[j];
+      for (std::size_t i = 0; i < body.locals.size(); ++i) {
+        const auto& lv = body.locals[i];
         Line(
             std::format(
-                "LocalVar[{}] \"{}\" : Type[{}]", j, lv.name, lv.type.value));
+                "LocalVar[{}] \"{}\" : Type[{}]", i, lv.name, lv.type.value));
       }
       Dedent();
     }
-    Dedent();
     if (!body.exprs.empty()) {
       Line("Exprs:");
       Indent();
@@ -568,12 +581,13 @@ class MirDumper {
             [&](const LocalVarDeclStmt& s) {
               Line(
                   std::format(
-                      "Stmt[{}] LocalVarDeclStmt target=LocalVar[scope={}, "
+                      "Stmt[{}] LocalVarDeclStmt target=LocalVar[body_hops={}, "
                       "local={}]",
-                      id.value, s.target.scope.value, s.target.local.value));
+                      id.value, s.target.body_hops.value,
+                      s.target.local.value));
             },
             [&](const ExprStmt& s) { DumpExprStmt(s, enclosing, id); },
-            [&](const BlockStmt& s) { DumpBlockStmt(s, enclosing, id); },
+            [&](const BlockStmt& s) { DumpBlockStmt(stmt, s, id); },
             [&](const IfStmt& s) { DumpIfStmt(stmt, s, enclosing, id); },
             [&](const SwitchStmt& s) {
               DumpSwitchStmt(stmt, s, enclosing, id);
@@ -587,8 +601,31 @@ class MirDumper {
             },
             [&](const ForStmt& s) { DumpForStmt(stmt, s, enclosing, id); },
             [&](const TimedStmt& t) { DumpTimedStmt(t, enclosing, id); },
+            [&](const WhileStmt& s) { DumpWhileStmt(stmt, s, enclosing, id); },
+            [&](const AwaitStmt& s) {
+              Line(
+                  std::format(
+                      "Stmt[{}] AwaitStmt kind={}", id.value,
+                      FormatAwaitKind(s.kind)));
+            },
         },
         stmt.data);
+  }
+
+  void DumpWhileStmt(
+      const Stmt& parent, const WhileStmt& s, const Body& enclosing,
+      StmtId id) {
+    Line(std::format("Stmt[{}] WhileStmt", id.value));
+    Indent();
+    Line(
+        std::format(
+            "condition: Expr[{}] {}", s.condition.value,
+            FormatExpr(enclosing, s.condition)));
+    Line(std::format("body (BodyId={}):", s.body.value));
+    Indent();
+    DumpBody(parent.child_bodies.at(s.body.value));
+    Dedent();
+    Dedent();
   }
 
   void DumpTimedStmt(const TimedStmt& t, const Body& enclosing, StmtId id) {
@@ -710,9 +747,7 @@ class MirDumper {
 
   void DumpForStmt(
       const Stmt& parent, const ForStmt& s, const Body& enclosing, StmtId id) {
-    Line(
-        std::format(
-            "Stmt[{}] ForStmt scope=Scope[{}]", id.value, s.scope.value));
+    Line(std::format("Stmt[{}] ForStmt", id.value));
     Indent();
     Line("init:");
     Indent();
@@ -728,8 +763,9 @@ class MirDumper {
                 }
                 Line(
                     std::format(
-                        "[{}] decl LocalVar[scope={}, local={}]{}", i,
-                        d.local.scope.value, d.local.local.value, init_str));
+                        "[{}] decl LocalVar[body_hops={}, local={}]{}", i,
+                        d.local.body_hops.value, d.local.local.value,
+                        init_str));
               },
               [&](const ForInitExpr& e) {
                 Line(
@@ -765,14 +801,12 @@ class MirDumper {
     Dedent();
   }
 
-  void DumpBlockStmt(const BlockStmt& s, const Body& enclosing, StmtId id) {
+  void DumpBlockStmt(const Stmt& parent, const BlockStmt& s, StmtId id) {
     Line(
         std::format(
-            "Stmt[{}] BlockStmt (count={})", id.value, s.statements.size()));
+            "Stmt[{}] BlockStmt body=BodyId{{{}}}", id.value, s.body.value));
     Indent();
-    for (const auto child : s.statements) {
-      DumpStmt(enclosing, child);
-    }
+    DumpBody(parent.child_bodies.at(s.body.value));
     Dedent();
   }
 

--- a/tests/cases/dump/hir_process_kinds/case.yaml
+++ b/tests/cases/dump/hir_process_kinds/case.yaml
@@ -1,0 +1,18 @@
+id: dump.hir_process_kinds
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "Process (Initial)"
+      - "Process (Final)"
+      - "Process (Always)"
+      - "Process (AlwaysComb)"
+      - "Process (AlwaysLatch)"
+      - "Process (AlwaysFf)"
+      - "EventControl"

--- a/tests/cases/dump/hir_process_kinds/main.sv
+++ b/tests/cases/dump/hir_process_kinds/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  logic clk;
+
+  initial begin end
+  final begin end
+  always begin end
+  always_comb begin end
+  always_latch begin end
+  always_ff @(posedge clk) begin end
+endmodule

--- a/tests/cases/dump/mir_always_loop/case.yaml
+++ b/tests/cases/dump/mir_always_loop/case.yaml
@@ -1,0 +1,20 @@
+id: dump.mir_always_loop
+tags: [dump]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "Process[0] Always"
+      - "WhileStmt"
+      - "condition: Expr["
+      - "IntegerLiteral"
+      - "body (BodyId=0):"
+      - "BlockStmt body=BodyId{0}"
+      - "LocalVar[0] \"x\""
+      - "LocalVarDeclStmt target=LocalVar[body_hops=0, local=0]"
+      - "AwaitStmt kind=AlwaysBackedge"

--- a/tests/cases/dump/mir_always_loop/main.sv
+++ b/tests/cases/dump/mir_always_loop/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  always begin
+    int x;
+    #1;
+    x = x + 1;
+  end
+endmodule

--- a/tests/cases/dump/mir_local_assign/case.yaml
+++ b/tests/cases/dump/mir_local_assign/case.yaml
@@ -11,9 +11,9 @@ expect:
     contains:
       - "Process[0] Initial"
       - "LocalVar[0] \"x\""
-      - "LocalVarDeclStmt target=LocalVar[scope=0, local=0]"
+      - "LocalVarDeclStmt target=LocalVar[body_hops=0, local=0]"
       - "ExprStmt"
-      - "AssignExpr target=LocalVar[scope=0, local=0]"
+      - "AssignExpr target=LocalVar[body_hops=0, local=0]"
       - "BinaryExpr op=Add"
       - "IntegerLiteral(32's{value=0x1})"
       - "IntegerLiteral(32's{value=0x2})"

--- a/tests/cases/dump/mir_nested_block_local/case.yaml
+++ b/tests/cases/dump/mir_nested_block_local/case.yaml
@@ -1,0 +1,15 @@
+id: dump.mir_nested_block_local
+tags: [dump]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "LocalVar[0] \"x\""
+      - "BlockStmt body=BodyId{0}"
+      - "AssignExpr target=LocalVar[body_hops=1, local=0]"
+      - "IntegerLiteral(32's{value=0x1})"

--- a/tests/cases/dump/mir_nested_block_local/main.sv
+++ b/tests/cases/dump/mir_nested_block_local/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  initial begin
+    int x;
+    begin
+      x = 1;
+    end
+  end
+endmodule

--- a/tests/cases/dump/mir_timed/case.yaml
+++ b/tests/cases/dump/mir_timed/case.yaml
@@ -15,4 +15,4 @@ expect:
       - "Item[0] Literal \"x\""
       - "Item[0] Literal \"ns\""
       - "Item[0] Literal \"block\""
-      - "BlockStmt (count="
+      - "BlockStmt body=BodyId{"

--- a/tests/cases/errors/process_kind_unsupported/case.yaml
+++ b/tests/cases/errors/process_kind_unsupported/case.yaml
@@ -1,0 +1,17 @@
+id: errors.process_kind_unsupported
+tags: [errors, diag]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "main.sv:2:"
+      - "unsupported:"
+      - "are not yet supported"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/process_kind_unsupported/main.sv
+++ b/tests/cases/errors/process_kind_unsupported/main.sv
@@ -1,0 +1,3 @@
+module Top;
+  final begin end
+endmodule

--- a/tests/diag/render_test.cpp
+++ b/tests/diag/render_test.cpp
@@ -44,7 +44,7 @@ TEST(DiagRender, InternalErrorIsAlwaysPlain) {
 
 TEST(DiagRender, UnsupportedWithUnknownSpan) {
   const auto diag = lyra::diag::Diagnostic::Unsupported(
-      lyra::diag::DiagCode::kUnsupportedNonInitialProcedure,
+      lyra::diag::DiagCode::kUnsupportedProcessKindLowering,
       "for-generate is not supported yet",
       lyra::diag::UnsupportedCategory::kFeature);
   const auto out = lyra::diag::RenderDiagnostic(
@@ -109,7 +109,7 @@ TEST(DiagRender, SinkSummaryAggregatesCounts) {
   lyra::diag::DiagnosticSink sink;
   sink.Report(
       lyra::diag::Diagnostic::Unsupported(
-          lyra::diag::DiagCode::kUnsupportedNonInitialProcedure,
+          lyra::diag::DiagCode::kUnsupportedProcessKindLowering,
           "feature A is not supported yet",
           lyra::diag::UnsupportedCategory::kFeature));
   sink.Report(
@@ -136,7 +136,7 @@ TEST(DiagRender, SinkEmptyHasNoSummary) {
 TEST(DiagRender, NoteAttachesAfterPrimary) {
   auto diag =
       lyra::diag::Diagnostic::Unsupported(
-          lyra::diag::DiagCode::kUnsupportedNonInitialProcedure,
+          lyra::diag::DiagCode::kUnsupportedProcessKindLowering,
           "feature is not supported", lyra::diag::UnsupportedCategory::kFeature)
           .WithNote("see related design discussion");
   const auto out = lyra::diag::RenderDiagnostic(
@@ -164,7 +164,7 @@ TEST(DiagRender, UnsupportedCategoryPreservedAcrossKinds) {
       *op_diag.primary.category, lyra::diag::UnsupportedCategory::kOperation);
 
   const auto feature_diag = lyra::diag::Diagnostic::Unsupported(
-      lyra::diag::DiagCode::kUnsupportedNonInitialProcedure,
+      lyra::diag::DiagCode::kUnsupportedProcessKindLowering,
       "language feature gap", lyra::diag::UnsupportedCategory::kFeature);
   ASSERT_TRUE(feature_diag.primary.category.has_value());
   EXPECT_EQ(
@@ -183,7 +183,7 @@ TEST(DiagRender, UnsupportedCategoryPreservedAcrossKinds) {
 
   // Notes carry only span+message; they have no category field by design.
   auto with_note = lyra::diag::Diagnostic::Unsupported(
-                       lyra::diag::DiagCode::kUnsupportedNonInitialProcedure,
+                       lyra::diag::DiagCode::kUnsupportedProcessKindLowering,
                        "x", lyra::diag::UnsupportedCategory::kFeature)
                        .WithNote("y");
   EXPECT_EQ(with_note.notes.front().message, "y");


### PR DESCRIPTION
## Summary

Establishes `mir::Body` as the procedural lexical scope, replacing the parallel `LocalScope`/`LocalScopeId` layer. Local references now use `mir::LocalVarRef { BodyHops body_hops; LocalVarId local; }`, the procedural mirror of `hir::ParentScopeHops`. `BlockStmt` becomes `{ BodyId body }`, and new `WhileStmt`/`AwaitStmt` constructs let `always` lower to `while (true) { <body>; await kAlwaysBackedge; }`. The HIR/MIR process taxonomy is extended to all six SV kinds (`initial`, `final`, `always`, `always_comb`, `always_latch`, `always_ff`); `kInitial` and `kAlways` get executable lowering, the rest return `diag::Unsupported` from HIR-to-MIR. Generate-for genvar is migrated to the unified flat-locals model.

## Design

`mir::Body` carries flat `locals`, `exprs`, `stmts`, and `root_stmts` arenas; the old `LocalScope` machinery and `ForStmt::scope` are deleted. `ProcessLoweringState` tracks a body-depth counter (RAII via `BodyDepthGuard`); `MapLocalVar` records the declaration depth, and `TranslateLocalVar` computes `body_hops = current - declaration` at use sites. `RenderContext` carries a parent chain with `BodyAtHops()` for ancestor walks and a shared temp counter so nested rendering does not duplicate names. A new `bit1` builtin (1-bit, 2-state, unsigned packed) types the synthesised `while (true)` condition. `hir::EventControl` is added so `always_ff @(posedge clk)` survives AST-to-HIR for dump coverage; HIR-to-MIR rejects it cleanly.

## Testing

- `bazel build //...`
- New goldens: `dump/hir_process_kinds`, `dump/mir_always_loop`, `dump/mir_nested_block_local`, `errors/process_kind_unsupported`.
- Existing `dump/mir_local_assign` and `dump/mir_timed` updated for the `LocalVar[body_hops=N, local=N]` and `BlockStmt body=BodyId{N}` formats.