### PR TITLE
Execute packed reduction operators in C++ backend

### DIFF
--- a/include/lyra/runtime/reduction.hpp
+++ b/include/lyra/runtime/reduction.hpp
@@ -1,0 +1,259 @@
+#pragma once
+
+#include <bit>
+#include <concepts>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <utility>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/runtime/packed.hpp"
+#include "lyra/runtime/packed_words.hpp"
+
+namespace lyra::runtime {
+
+namespace detail {
+
+template <typename V>
+concept ReductionBitViewLike =
+    std::same_as<std::remove_cvref_t<V>, ConstBitView> ||
+    std::same_as<std::remove_cvref_t<V>, BitView>;
+
+template <typename V>
+concept ReductionLogicViewLike =
+    std::same_as<std::remove_cvref_t<V>, ConstLogicView> ||
+    std::same_as<std::remove_cvref_t<V>, LogicView>;
+
+inline auto ToConstBitView(ConstBitView v) -> ConstBitView {
+  return v;
+}
+inline auto ToConstBitView(BitView v) -> ConstBitView {
+  return v.AsConst();
+}
+inline auto ToConstLogicView(ConstLogicView v) -> ConstLogicView {
+  return v;
+}
+inline auto ToConstLogicView(LogicView v) -> ConstLogicView {
+  return v.AsConst();
+}
+
+constexpr auto ValidMaskForWord(std::size_t word_index, std::uint64_t width)
+    -> std::uint64_t {
+  constexpr std::uint64_t kWordBits = 64U;
+  if (static_cast<std::uint64_t>(word_index) >
+      std::numeric_limits<std::uint64_t>::max() / kWordBits) {
+    throw InternalError("packed reduction: word index overflow");
+  }
+  const auto consumed = static_cast<std::uint64_t>(word_index) * kWordBits;
+  if (consumed >= width) {
+    throw InternalError("packed reduction: word index out of range");
+  }
+  const auto remaining = width - consumed;
+  if (remaining >= kWordBits) {
+    return ~std::uint64_t{0};
+  }
+  return (std::uint64_t{1} << remaining) - 1U;
+}
+
+inline auto MakeScalarBit(bool value)
+    -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
+  Bit<PackedShape<0>{}, Signedness::kUnsigned> out;
+  PlaneAccess::MutableValue(out)[0] =
+      value ? std::uint64_t{1} : std::uint64_t{0};
+  return out;
+}
+
+inline auto MakeScalarLogicKnown(bool value)
+    -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
+  Logic<PackedShape<0>{}, Signedness::kUnsigned> out;
+  PlaneAccess::MutableValue(out)[0] =
+      value ? std::uint64_t{1} : std::uint64_t{0};
+  PlaneAccess::MutableState(out)[0] = std::uint64_t{0};
+  return out;
+}
+
+inline auto MakeScalarLogicUnknown()
+    -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
+  Logic<PackedShape<0>{}, Signedness::kUnsigned> out;
+  PlaneAccess::MutableValue(out)[0] = std::uint64_t{1};
+  PlaneAccess::MutableState(out)[0] = std::uint64_t{1};
+  return out;
+}
+
+inline auto NotScalar(Bit<PackedShape<0>{}, Signedness::kUnsigned> in)
+    -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
+  const auto view = std::as_const(in).View();
+  const auto bit = PlaneAccess::ValueWords(view)[0] & std::uint64_t{1};
+  return MakeScalarBit(bit == 0U);
+}
+
+inline auto NotScalar(Logic<PackedShape<0>{}, Signedness::kUnsigned> in)
+    -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
+  const auto view = std::as_const(in).View();
+  const auto state = PlaneAccess::StateWords(view)[0] & std::uint64_t{1};
+  if (state != 0U) {
+    return MakeScalarLogicUnknown();
+  }
+  const auto value = PlaneAccess::ValueWords(view)[0] & std::uint64_t{1};
+  return MakeScalarLogicKnown(value == 0U);
+}
+
+}  // namespace detail
+
+template <detail::ReductionBitViewLike V>
+auto ReductionAnd(V src) -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
+  const auto v = detail::ToConstBitView(src);
+  const auto words = detail::PlaneAccess::ValueWords(v);
+  const auto width = v.Width();
+  bool all_one = true;
+  for (std::size_t i = 0; i < words.size(); ++i) {
+    const auto mask = detail::ValidMaskForWord(i, width);
+    if ((words[i] & mask) != mask) {
+      all_one = false;
+      break;
+    }
+  }
+  return detail::MakeScalarBit(all_one);
+}
+
+template <detail::ReductionBitViewLike V>
+auto ReductionOr(V src) -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
+  const auto v = detail::ToConstBitView(src);
+  const auto words = detail::PlaneAccess::ValueWords(v);
+  const auto width = v.Width();
+  bool any_one = false;
+  for (std::size_t i = 0; i < words.size(); ++i) {
+    const auto mask = detail::ValidMaskForWord(i, width);
+    if ((words[i] & mask) != 0U) {
+      any_one = true;
+      break;
+    }
+  }
+  return detail::MakeScalarBit(any_one);
+}
+
+template <detail::ReductionBitViewLike V>
+auto ReductionXor(V src) -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
+  const auto v = detail::ToConstBitView(src);
+  const auto words = detail::PlaneAccess::ValueWords(v);
+  const auto width = v.Width();
+  std::uint64_t parity_acc = 0;
+  for (std::size_t i = 0; i < words.size(); ++i) {
+    const auto mask = detail::ValidMaskForWord(i, width);
+    parity_acc ^= static_cast<std::uint64_t>(std::popcount(words[i] & mask));
+  }
+  return detail::MakeScalarBit((parity_acc & std::uint64_t{1}) != 0U);
+}
+
+template <detail::ReductionBitViewLike V>
+auto ReductionNand(V src) -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
+  return detail::NotScalar(ReductionAnd(src));
+}
+
+template <detail::ReductionBitViewLike V>
+auto ReductionNor(V src) -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
+  return detail::NotScalar(ReductionOr(src));
+}
+
+template <detail::ReductionBitViewLike V>
+auto ReductionXnor(V src) -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
+  return detail::NotScalar(ReductionXor(src));
+}
+
+template <detail::ReductionLogicViewLike V>
+auto ReductionAnd(V src) -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
+  const auto v = detail::ToConstLogicView(src);
+  const auto val_w = detail::PlaneAccess::ValueWords(v);
+  const auto state_w = detail::PlaneAccess::StateWords(v);
+  const auto width = v.Width();
+  bool any_known_zero = false;
+  bool any_unknown = false;
+  for (std::size_t i = 0; i < val_w.size(); ++i) {
+    const auto mask = detail::ValidMaskForWord(i, width);
+    const auto state = state_w[i] & mask;
+    const auto value = val_w[i] & mask;
+    const auto known_zero_bits = (~value) & (~state) & mask;
+    if (state != 0U) {
+      any_unknown = true;
+    }
+    if (known_zero_bits != 0U) {
+      any_known_zero = true;
+      break;
+    }
+  }
+  if (any_known_zero) {
+    return detail::MakeScalarLogicKnown(false);
+  }
+  if (any_unknown) {
+    return detail::MakeScalarLogicUnknown();
+  }
+  return detail::MakeScalarLogicKnown(true);
+}
+
+template <detail::ReductionLogicViewLike V>
+auto ReductionOr(V src) -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
+  const auto v = detail::ToConstLogicView(src);
+  const auto val_w = detail::PlaneAccess::ValueWords(v);
+  const auto state_w = detail::PlaneAccess::StateWords(v);
+  const auto width = v.Width();
+  bool any_known_one = false;
+  bool any_unknown = false;
+  for (std::size_t i = 0; i < val_w.size(); ++i) {
+    const auto mask = detail::ValidMaskForWord(i, width);
+    const auto state = state_w[i] & mask;
+    const auto value = val_w[i] & mask;
+    const auto known_one_bits = value & (~state) & mask;
+    if (state != 0U) {
+      any_unknown = true;
+    }
+    if (known_one_bits != 0U) {
+      any_known_one = true;
+      break;
+    }
+  }
+  if (any_known_one) {
+    return detail::MakeScalarLogicKnown(true);
+  }
+  if (any_unknown) {
+    return detail::MakeScalarLogicUnknown();
+  }
+  return detail::MakeScalarLogicKnown(false);
+}
+
+template <detail::ReductionLogicViewLike V>
+auto ReductionXor(V src) -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
+  const auto v = detail::ToConstLogicView(src);
+  const auto val_w = detail::PlaneAccess::ValueWords(v);
+  const auto state_w = detail::PlaneAccess::StateWords(v);
+  const auto width = v.Width();
+  std::uint64_t parity_acc = 0;
+  for (std::size_t i = 0; i < val_w.size(); ++i) {
+    const auto mask = detail::ValidMaskForWord(i, width);
+    const auto state = state_w[i] & mask;
+    const auto value = val_w[i] & mask;
+    if (state != 0U) {
+      return detail::MakeScalarLogicUnknown();
+    }
+    const auto known_one_bits = value & (~state) & mask;
+    parity_acc ^= static_cast<std::uint64_t>(std::popcount(known_one_bits));
+  }
+  return detail::MakeScalarLogicKnown((parity_acc & std::uint64_t{1}) != 0U);
+}
+
+template <detail::ReductionLogicViewLike V>
+auto ReductionNand(V src) -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
+  return detail::NotScalar(ReductionAnd(src));
+}
+
+template <detail::ReductionLogicViewLike V>
+auto ReductionNor(V src) -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
+  return detail::NotScalar(ReductionOr(src));
+}
+
+template <detail::ReductionLogicViewLike V>
+auto ReductionXnor(V src) -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
+  return detail::NotScalar(ReductionXor(src));
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -188,6 +188,7 @@ auto RenderClassHeaderFile(
   out += "#include \"lyra/runtime/packed.hpp\"\n";
   out += "#include \"lyra/runtime/process.hpp\"\n";
   out += "#include \"lyra/runtime/process_kind.hpp\"\n";
+  out += "#include \"lyra/runtime/reduction.hpp\"\n";
   out += "#include \"lyra/runtime/runtime_scope_kind.hpp\"\n";
   out += "#include \"lyra/runtime/runtime_services.hpp\"\n";
   out += "\n";

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -210,20 +210,121 @@ auto IsPackedExplicitMatching(
          opa.BitWidth() == result_pa.BitWidth();
 }
 
-auto RenderPackedBitwiseUnaryCall(
+auto IsPackedRuntimeUnaryOp(mir::UnaryOp op) -> bool {
+  switch (op) {
+    case mir::UnaryOp::kBitwiseNot:
+    case mir::UnaryOp::kReductionAnd:
+    case mir::UnaryOp::kReductionOr:
+    case mir::UnaryOp::kReductionXor:
+    case mir::UnaryOp::kReductionNand:
+    case mir::UnaryOp::kReductionNor:
+    case mir::UnaryOp::kReductionXnor:
+      return true;
+    case mir::UnaryOp::kPlus:
+    case mir::UnaryOp::kMinus:
+    case mir::UnaryOp::kLogicalNot:
+      return false;
+  }
+  throw InternalError("IsPackedRuntimeUnaryOp: unknown MIR UnaryOp");
+}
+
+auto IsReductionUnaryOp(mir::UnaryOp op) -> bool {
+  switch (op) {
+    case mir::UnaryOp::kReductionAnd:
+    case mir::UnaryOp::kReductionOr:
+    case mir::UnaryOp::kReductionXor:
+    case mir::UnaryOp::kReductionNand:
+    case mir::UnaryOp::kReductionNor:
+    case mir::UnaryOp::kReductionXnor:
+      return true;
+    case mir::UnaryOp::kBitwiseNot:
+    case mir::UnaryOp::kPlus:
+    case mir::UnaryOp::kMinus:
+    case mir::UnaryOp::kLogicalNot:
+      return false;
+  }
+  throw InternalError("IsReductionUnaryOp: unknown MIR UnaryOp");
+}
+
+auto ReductionRuntimeFunctionName(mir::UnaryOp op) -> std::string_view {
+  switch (op) {
+    case mir::UnaryOp::kReductionAnd:
+      return "lyra::runtime::ReductionAnd";
+    case mir::UnaryOp::kReductionOr:
+      return "lyra::runtime::ReductionOr";
+    case mir::UnaryOp::kReductionXor:
+      return "lyra::runtime::ReductionXor";
+    case mir::UnaryOp::kReductionNand:
+      return "lyra::runtime::ReductionNand";
+    case mir::UnaryOp::kReductionNor:
+      return "lyra::runtime::ReductionNor";
+    case mir::UnaryOp::kReductionXnor:
+      return "lyra::runtime::ReductionXnor";
+    case mir::UnaryOp::kBitwiseNot:
+    case mir::UnaryOp::kPlus:
+    case mir::UnaryOp::kMinus:
+    case mir::UnaryOp::kLogicalNot:
+      throw InternalError(
+          "ReductionRuntimeFunctionName: not a reduction unary op");
+  }
+  throw InternalError("ReductionRuntimeFunctionName: unknown MIR UnaryOp");
+}
+
+auto IsPackedRuntimeReductionShape(
+    const mir::CompilationUnit& unit, mir::TypeId operand_type,
+    const mir::PackedArrayType& result_pa) -> bool {
+  if (!result_pa.dims.empty()) {
+    return false;
+  }
+  if (result_pa.BitWidth() != 1U) {
+    return false;
+  }
+  const auto& ot = unit.GetType(operand_type);
+  if (!ot.IsPackedArray()) {
+    return false;
+  }
+  const auto& opa = ot.AsPackedArray();
+  if (opa.form != mir::PackedArrayForm::kExplicit) {
+    return false;
+  }
+  return opa.IsFourState() == result_pa.IsFourState();
+}
+
+auto RenderPackedRuntimeUnaryCall(
     const RenderContext& ctx, mir::TypeId result_type, mir::UnaryOp op,
     const mir::Expr& operand) -> diag::Result<std::string> {
-  if (op != mir::UnaryOp::kBitwiseNot) {
-    throw InternalError("RenderPackedBitwiseUnaryCall: non-bitwise unary op");
+  if (!IsPackedRuntimeUnaryOp(op)) {
+    throw InternalError(
+        "RenderPackedRuntimeUnaryCall: not a packed runtime unary op");
+  }
+  if (!IsPackedRuntime(ctx.Unit(), operand.type)) {
+    throw InternalError(
+        "RenderPackedRuntimeUnaryCall: operand not packed runtime");
   }
   if (!IsPackedRuntime(ctx.Unit(), result_type)) {
     throw InternalError(
-        "RenderPackedBitwiseUnaryCall: result not packed runtime");
+        "RenderPackedRuntimeUnaryCall: result not packed runtime");
   }
   const auto& result_pa = ctx.Unit().GetType(result_type).AsPackedArray();
+
+  if (IsReductionUnaryOp(op)) {
+    if (!IsPackedRuntimeReductionShape(ctx.Unit(), operand.type, result_pa)) {
+      throw InternalError(
+          "RenderPackedRuntimeUnaryCall: reduction result must be a scalar "
+          "1-bit packed type whose state-kind matches the operand");
+    }
+    auto operand_view_or = RenderExprAsRuntimeView(ctx, operand);
+    if (!operand_view_or) {
+      return std::unexpected(std::move(operand_view_or.error()));
+    }
+    return std::format(
+        "{}({})", ReductionRuntimeFunctionName(op), *operand_view_or);
+  }
+
+  // Bitwise-not: operand and result must share the same explicit packed shape.
   if (!IsPackedExplicitMatching(ctx.Unit(), operand.type, result_pa)) {
     throw InternalError(
-        "RenderPackedBitwiseUnaryCall: operand type not normalized to result");
+        "RenderPackedRuntimeUnaryCall: operand type not normalized to result");
   }
   const std::string shape = RenderPackedShapeLiteral(result_pa.dims);
   const std::string_view signedness = SignednessLiteral(result_pa.signedness);
@@ -418,7 +519,7 @@ auto RenderExprAsRuntimeView(const RenderContext& ctx, const mir::Expr& expr)
             return std::format("{}.View()", *inner_or);
           },
           [&](const mir::UnaryExpr& u) -> diag::Result<std::string> {
-            if (u.op != mir::UnaryOp::kBitwiseNot ||
+            if (!IsPackedRuntimeUnaryOp(u.op) ||
                 !IsPackedRuntime(ctx.Unit(), expr.type)) {
               return diag::Unsupported(
                   diag::DiagCode::kCppEmitExpressionFormNotImplemented,
@@ -426,7 +527,7 @@ auto RenderExprAsRuntimeView(const RenderContext& ctx, const mir::Expr& expr)
                   "view in cpp emit",
                   diag::UnsupportedCategory::kFeature);
             }
-            auto inner_or = RenderPackedBitwiseUnaryCall(
+            auto inner_or = RenderPackedRuntimeUnaryCall(
                 ctx, expr.type, u.op, ctx.Expr(u.operand));
             if (!inner_or) return std::unexpected(std::move(inner_or.error()));
             return std::format("{}.View()", *inner_or);

--- a/tests/cases/cpp/packed_reduction_bit_ops/case.yaml
+++ b/tests/cases/cpp/packed_reduction_bit_ops/case.yaml
@@ -1,0 +1,25 @@
+id: cpp.packed_reduction_bit_ops
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1
+      0
+      0
+      1
+      0
+      1
+      0
+      0
+      1
+      1
+      0
+      1
+      0
+      1

--- a/tests/cases/cpp/packed_reduction_bit_ops/main.sv
+++ b/tests/cases/cpp/packed_reduction_bit_ops/main.sv
@@ -1,0 +1,25 @@
+module Top;
+  bit [3:0] a;
+
+  initial begin
+    a = 4'b1111; $display("%b", &a);
+    a = 4'b1011; $display("%b", &a);
+
+    a = 4'b0000; $display("%b", |a);
+    a = 4'b0100; $display("%b", |a);
+
+    a = 4'b0000; $display("%b", ^a);
+    a = 4'b0001; $display("%b", ^a);
+    a = 4'b0011; $display("%b", ^a);
+
+    a = 4'b1111; $display("%b", ~&a);
+    a = 4'b1011; $display("%b", ~&a);
+
+    a = 4'b0000; $display("%b", ~|a);
+    a = 4'b0100; $display("%b", ~|a);
+
+    a = 4'b0000; $display("%b", ~^a);
+    a = 4'b0001; $display("%b", ~^a);
+    a = 4'b0011; $display("%b", ~^a);
+  end
+endmodule

--- a/tests/cases/cpp/packed_reduction_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_reduction_logic_ops/case.yaml
@@ -1,0 +1,32 @@
+id: cpp.packed_reduction_logic_ops
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1
+      x
+      0
+      0
+      x
+      1
+      0
+      1
+      x
+      0
+      x
+      1
+      1
+      x
+      0
+      1
+      0
+      x
+      x
+      x
+      1

--- a/tests/cases/cpp/packed_reduction_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_reduction_logic_ops/main.sv
@@ -1,0 +1,33 @@
+module Top;
+  logic [3:0] a;
+
+  initial begin
+    a = 4'b1111; $display("%b", &a);
+    a = 4'b11x1; $display("%b", &a);
+    a = 4'b10x1; $display("%b", &a);
+
+    a = 4'b0000; $display("%b", |a);
+    a = 4'b00x0; $display("%b", |a);
+    a = 4'b01x0; $display("%b", |a);
+
+    a = 4'b0011; $display("%b", ^a);
+    a = 4'b0001; $display("%b", ^a);
+    a = 4'b00x1; $display("%b", ^a);
+
+    a = 4'b1111; $display("%b", ~&a);
+    a = 4'b11x1; $display("%b", ~&a);
+    a = 4'b10x1; $display("%b", ~&a);
+
+    a = 4'b0000; $display("%b", ~|a);
+    a = 4'b00x0; $display("%b", ~|a);
+    a = 4'b01x0; $display("%b", ~|a);
+
+    a = 4'b0011; $display("%b", ~^a);
+    a = 4'b0001; $display("%b", ~^a);
+    a = 4'b00x1; $display("%b", ~^a);
+
+    a = 4'b11z1; $display("%b", &a);
+    a = 4'b00z0; $display("%b", |a);
+    a = 4'b10z1; $display("%b", ~&a);
+  end
+endmodule

--- a/tests/cases/cpp/packed_reduction_reg_alias_ops/case.yaml
+++ b/tests/cases/cpp/packed_reduction_reg_alias_ops/case.yaml
@@ -1,0 +1,17 @@
+id: cpp.packed_reduction_reg_alias_ops
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      x
+      x
+      x
+      1
+      0
+      0

--- a/tests/cases/cpp/packed_reduction_reg_alias_ops/main.sv
+++ b/tests/cases/cpp/packed_reduction_reg_alias_ops/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  reg [3:0] a;
+
+  initial begin
+    a = 4'b11x1; $display("%b", &a);
+    a = 4'b00x0; $display("%b", |a);
+    a = 4'b00x1; $display("%b", ^a);
+    a = 4'b10x1; $display("%b", ~&a);
+    a = 4'b01x0; $display("%b", ~|a);
+    a = 4'b0001; $display("%b", ~^a);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds end-to-end execution of SystemVerilog packed reduction operators (`&`, `|`, `^`, `~&`, `~|`, `~^`) through the C++ backend. HIR and MIR already modeled the unary forms; this lands the runtime primitives, the emit dispatch, and the SV tests that exercise the path.

## Design

- New `include/lyra/runtime/reduction.hpp` contains the six reduction primitives with `Bit` and `Logic` overloads, returning a scalar `PackedShape<0>` result. View concepts and the const-view normalizer are local to the header so reduction does not develop a header dependency on `bitwise.hpp`.
- `RenderPackedBitwiseUnaryCall` is generalized to `RenderPackedRuntimeUnaryCall`. It routes bitwise-not (templated on shape and signedness) and the six reductions (untemplated, dispatched by view kind) through one helper. Reduction invariants (scalar 1-bit result, matching state-kind between operand and result) are enforced as `InternalError`, since a malformed reduction expression is a HIR/MIR bug.
- `MakeScalarLogicUnknown()` writes both planes explicitly with `value=1, state=1`, matching the canonical `FourStateBit::kUnknown` encoding used by the rest of the runtime.

## Testing

- `bazel test //... --test_output=errors` (all 6 targets pass).
- New SV E2E cases: `packed_reduction_bit_ops` (2-state coverage including parity), `packed_reduction_logic_ops` (4-state with `x` and `z` inputs proving Z propagates as unknown), `packed_reduction_reg_alias_ops` (`reg` shares the 4-state path).