### PR TITLE
Prebuild C++ runtime for generated-C++ tests

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,15 +1,7 @@
 load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
-
-filegroup(
-    name = "runtime_sources",
-    srcs = glob([
-        "src/lyra/runtime/*.cpp",
-        "src/lyra/base/*.cpp",
-    ]),
-    visibility = ["//visibility:public"],
-)
+load("@rules_cc//cc:cc_static_library.bzl", "cc_static_library")
 
 filegroup(
     name = "runtime_headers",
@@ -80,6 +72,12 @@ cc_library(
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [":base"],
+)
+
+cc_static_library(
+    name = "cpp_runtime",
+    visibility = ["//visibility:public"],
+    deps = [":runtime"],
 )
 
 cc_library(

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -30,8 +30,6 @@ cc_test(
     data = [
         "suites.yaml",
         "//:lyra",
-        "//:runtime_headers",
-        "//:runtime_sources",
     ] + glob(
         [
             "cases/**/*.yaml",
@@ -95,9 +93,9 @@ cc_test(
     name = "cli_run_tests",
     srcs = ["cli_run_test.cpp"],
     data = [
+        "//:cpp_runtime",
         "//:lyra",
         "//:runtime_headers",
-        "//:runtime_sources",
     ] + glob(
         ["cases/run/*.sv"],
         allow_empty = True,
@@ -118,9 +116,9 @@ cc_test(
     srcs = ["cli_emit_cpp_test.cpp"],
     data = [
         "suites.yaml",
+        "//:cpp_runtime",
         "//:lyra",
         "//:runtime_headers",
-        "//:runtime_sources",
     ] + glob(
         [
             "cases/**/*.yaml",

--- a/tests/cli_emit_cpp_test.cpp
+++ b/tests/cli_emit_cpp_test.cpp
@@ -40,12 +40,7 @@ auto ResolveEnv(Runfiles& rf) -> EmitCppEnv {
   env.cpp_paths.include_root =
       engine_hpp.parent_path().parent_path().parent_path();
 
-  const std::filesystem::path engine_cpp =
-      rf.Rlocation("_main/src/lyra/runtime/engine.cpp");
-  const std::filesystem::path base_cpp =
-      rf.Rlocation("_main/src/lyra/base/internal_error.cpp");
-  env.cpp_paths.runtime_src_dirs = {
-      engine_cpp.parent_path(), base_cpp.parent_path()};
+  env.cpp_paths.cpp_runtime = rf.Rlocation("_main/libcpp_runtime.a");
   return env;
 }
 

--- a/tests/cli_golden_test.cpp
+++ b/tests/cli_golden_test.cpp
@@ -34,18 +34,8 @@ auto ResolveEnv(Runfiles& rf) -> GoldenEnv {
   env.lyra_exe = rf.Rlocation("_main/lyra");
   env.cases_root = rf.Rlocation("_main/tests/cases");
   env.suites_yaml = rf.Rlocation("_main/tests/suites.yaml");
-
-  const std::filesystem::path engine_hpp =
-      rf.Rlocation("_main/include/lyra/runtime/engine.hpp");
-  env.cpp_paths.include_root =
-      engine_hpp.parent_path().parent_path().parent_path();
-
-  const std::filesystem::path engine_cpp =
-      rf.Rlocation("_main/src/lyra/runtime/engine.cpp");
-  const std::filesystem::path base_cpp =
-      rf.Rlocation("_main/src/lyra/base/internal_error.cpp");
-  env.cpp_paths.runtime_src_dirs = {
-      engine_cpp.parent_path(), base_cpp.parent_path()};
+  // cli_golden_tests erases all IsEmitCppCase cases below, so RunCppCase is
+  // never invoked and cpp_paths is unused. Leave it default-constructed.
   return env;
 }
 

--- a/tests/cli_run_test.cpp
+++ b/tests/cli_run_test.cpp
@@ -43,18 +43,10 @@ void RunSvCase(const std::string& sv_runfiles_path, RunOutcome& out) {
   const std::filesystem::path include_root =
       engine_hpp.parent_path().parent_path().parent_path();
 
-  const std::filesystem::path engine_cpp =
-      rf->Rlocation("_main/src/lyra/runtime/engine.cpp");
-  ASSERT_FALSE(engine_cpp.empty());
-  ASSERT_TRUE(std::filesystem::exists(engine_cpp)) << engine_cpp;
-
-  const std::filesystem::path base_cpp =
-      rf->Rlocation("_main/src/lyra/base/internal_error.cpp");
-  ASSERT_FALSE(base_cpp.empty());
-  ASSERT_TRUE(std::filesystem::exists(base_cpp)) << base_cpp;
-
-  const std::vector<std::filesystem::path> runtime_src_dirs = {
-      engine_cpp.parent_path(), base_cpp.parent_path()};
+  const std::filesystem::path cpp_runtime =
+      rf->Rlocation("_main/libcpp_runtime.a");
+  ASSERT_FALSE(cpp_runtime.empty());
+  ASSERT_TRUE(std::filesystem::exists(cpp_runtime)) << cpp_runtime;
 
   auto work_or = MakeTempCaseDir();
   ASSERT_TRUE(work_or) << work_or.error();
@@ -73,8 +65,7 @@ void RunSvCase(const std::string& sv_runfiles_path, RunOutcome& out) {
                                << emit.stdout_text << "\nstderr:\n"
                                << emit.stderr_text;
 
-  auto outcome =
-      BuildAndRunEmittedArtifacts(work, include_root, runtime_src_dirs);
+  auto outcome = BuildAndRunEmittedArtifacts(work, include_root, cpp_runtime);
   ASSERT_FALSE(outcome.error.has_value()) << *outcome.error;
   out.exit_code = outcome.exit_code;
   out.stdout_text = std::move(outcome.stdout_text);

--- a/tests/framework/build.cpp
+++ b/tests/framework/build.cpp
@@ -1,6 +1,5 @@
 #include "build.hpp"
 
-#include <algorithm>
 #include <cerrno>
 #include <chrono>
 #include <cstdlib>
@@ -83,25 +82,6 @@ auto ResolveCxxCompiler() -> std::expected<std::filesystem::path, std::string> {
       "override)");
 }
 
-auto CollectRuntimeSources(const std::filesystem::path& dir)
-    -> std::expected<std::vector<std::filesystem::path>, std::string> {
-  std::vector<std::filesystem::path> out;
-  std::error_code ec;
-  std::filesystem::directory_iterator it(dir, ec);
-  if (ec) {
-    return std::unexpected(
-        std::format(
-            "directory_iterator('{}') failed: {}", dir.string(), ec.message()));
-  }
-  for (const auto& entry : it) {
-    if (entry.is_regular_file() && entry.path().extension() == ".cpp") {
-      out.push_back(entry.path());
-    }
-  }
-  std::ranges::sort(out);
-  return out;
-}
-
 }  // namespace
 
 auto MakeTempCaseDir() -> std::expected<std::filesystem::path, std::string> {
@@ -118,8 +98,7 @@ auto MakeTempCaseDir() -> std::expected<std::filesystem::path, std::string> {
 auto BuildAndRunEmittedArtifacts(
     const std::filesystem::path& work_dir,
     const std::filesystem::path& include_root,
-    const std::vector<std::filesystem::path>& runtime_src_dirs)
-    -> BuildAndRunOutcome {
+    const std::filesystem::path& cpp_runtime) -> BuildAndRunOutcome {
   BuildAndRunOutcome outcome;
 
   auto cxx_or = ResolveCxxCompiler();
@@ -130,20 +109,9 @@ auto BuildAndRunEmittedArtifacts(
   }
   const auto& cxx = *cxx_or;
 
-  std::vector<std::filesystem::path> runtime_cpps;
-  for (const auto& dir : runtime_src_dirs) {
-    auto cpps_or = CollectRuntimeSources(dir);
-    if (!cpps_or) {
-      outcome.error =
-          std::format("runtime source enumeration failed: {}", cpps_or.error());
-      return outcome;
-    }
-    for (auto& path : *cpps_or) {
-      runtime_cpps.push_back(std::move(path));
-    }
-  }
-  if (runtime_cpps.empty()) {
-    outcome.error = "no runtime sources collected";
+  if (!std::filesystem::exists(cpp_runtime)) {
+    outcome.error = std::format(
+        "missing prebuilt C++ runtime at '{}'", cpp_runtime.string());
     return outcome;
   }
 
@@ -156,14 +124,18 @@ auto BuildAndRunEmittedArtifacts(
     return outcome;
   }
 
+  // The C++ runtime must follow main.cpp on the link line so the linker
+  // resolves main.cpp's references against runtime members.
   std::vector<std::string> compile_args = {
-      "-std=c++23", "-O0", "-I", include_root.string(), main_cpp.string(),
+      "-std=c++23",
+      "-O0",
+      "-I",
+      include_root.string(),
+      main_cpp.string(),
+      cpp_runtime.string(),
+      "-o",
+      program.string(),
   };
-  for (const auto& src : runtime_cpps) {
-    compile_args.push_back(src.string());
-  }
-  compile_args.emplace_back("-o");
-  compile_args.push_back(program.string());
 
   auto compile = RunChildProcess(cxx, compile_args, std::chrono::seconds{60});
   if (compile.termination != TerminationKind::kExitedNormally) {

--- a/tests/framework/build.hpp
+++ b/tests/framework/build.hpp
@@ -4,7 +4,6 @@
 #include <filesystem>
 #include <optional>
 #include <string>
-#include <vector>
 
 namespace lyra::test {
 
@@ -21,16 +20,15 @@ struct BuildAndRunOutcome {
   std::string stderr_text;
 };
 
-// Compile <work_dir>/main.cpp + <work_dir>/<top>.hpp against the runtime
-// sources collected from `runtime_src_dirs`, with includes rooted at
-// `include_root`, producing <work_dir>/program. Then run the program.
+// Compile <work_dir>/main.cpp against the prebuilt C++ runtime
+// `cpp_runtime`, with includes rooted at `include_root`, producing
+// <work_dir>/program. Then run the program.
 //
 // Uses RunChildProcess for both compile and run -- no new process helper.
 // Returns errors via BuildAndRunOutcome::error; never throws.
 auto BuildAndRunEmittedArtifacts(
     const std::filesystem::path& work_dir,
     const std::filesystem::path& include_root,
-    const std::vector<std::filesystem::path>& runtime_src_dirs)
-    -> BuildAndRunOutcome;
+    const std::filesystem::path& cpp_runtime) -> BuildAndRunOutcome;
 
 }  // namespace lyra::test

--- a/tests/framework/runner.cpp
+++ b/tests/framework/runner.cpp
@@ -290,7 +290,7 @@ auto RunCppCase(
   }
 
   auto outcome = BuildAndRunEmittedArtifacts(
-      work, cpp_paths.include_root, cpp_paths.runtime_src_dirs);
+      work, cpp_paths.include_root, cpp_paths.cpp_runtime);
   if (outcome.error.has_value()) {
     result.mismatch = "build+run failed: " + *outcome.error;
     return result;

--- a/tests/framework/runner.hpp
+++ b/tests/framework/runner.hpp
@@ -52,7 +52,7 @@ struct RunResult {
 // `[run, cpp]` command path in RunCase.
 struct CppRunPaths {
   std::filesystem::path include_root;
-  std::vector<std::filesystem::path> runtime_src_dirs;
+  std::filesystem::path cpp_runtime;
 };
 
 auto LoadCases(const std::filesystem::path& cases_root)


### PR DESCRIPTION
## Summary

Generated-C++ tests (`cli_emit_cpp_tests`, `cli_run_tests`) used to recompile the runtime and base sources for every test case, scanning `src/lyra/runtime/*.cpp` and `src/lyra/base/internal_error.cpp` at test runtime and feeding them into the host compiler each time. This change adds a `cc_static_library //:cpp_runtime` over the existing `:runtime` library so Bazel builds the runtime once, and reroutes the test framework to link the prebuilt artifact through runfiles. Per-case host-compiler invocations now compile a single translation unit (the emitted `main.cpp`) and link against `libcpp_runtime.a` instead of recompiling 9 runtime/base TUs.

The test framework's `BuildAndRunEmittedArtifacts` signature changes from a list of runtime source directories to a single runtime-library path, and `CppRunPaths::runtime_src_dirs` becomes `CppRunPaths::cpp_runtime`. The per-case enumeration helper `CollectRuntimeSources` is deleted along with the `//:runtime_sources` filegroup. `cli_golden_tests` never reaches the generated-C++ compile path (it erases all emit-cpp cases before dispatch), so its data list drops the runtime headers/sources entirely.

## Testing

- `bazel build //...`
- `bazel test //... --test_output=errors` (all 6 targets pass)
- `bazel test //tests:cli_emit_cpp_tests` (26 cases, ~1.0s each)
- `bazel test //tests:cli_run_tests` (11 cases, ~1.0s each)
- Format and policy mirrors of CI: `clang-format`, `buildifier`, `prettier`, `check_architecture.py`, `check_ascii.py`, `check_cpp_style.py`, `check_exceptions.py`