### PR TITLE
Clean up packed runtime core

### DIFF
--- a/include/lyra/runtime/bitwise.hpp
+++ b/include/lyra/runtime/bitwise.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
-#include <concepts>
 #include <cstdint>
 #include <span>
-#include <type_traits>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/runtime/packed.hpp"
@@ -12,27 +10,6 @@
 namespace lyra::runtime {
 
 namespace detail {
-
-template <typename V>
-concept BitViewLike = std::same_as<std::remove_cvref_t<V>, ConstBitView> ||
-                      std::same_as<std::remove_cvref_t<V>, BitView>;
-
-template <typename V>
-concept LogicViewLike = std::same_as<std::remove_cvref_t<V>, ConstLogicView> ||
-                        std::same_as<std::remove_cvref_t<V>, LogicView>;
-
-inline auto ToConstView(ConstBitView v) -> ConstBitView {
-  return v;
-}
-inline auto ToConstView(BitView v) -> ConstBitView {
-  return v.AsConst();
-}
-inline auto ToConstView(ConstLogicView v) -> ConstLogicView {
-  return v;
-}
-inline auto ToConstView(LogicView v) -> ConstLogicView {
-  return v.AsConst();
-}
 
 inline auto NotPlaneWords(
     std::span<std::uint64_t> dst, std::span<const std::uint64_t> src,
@@ -79,94 +56,94 @@ inline auto XnorPlaneWords(
   MaskUnusedTopBits(dst, width);
 }
 
-// 4-state encoding: s=0,v=0 -> 0; s=0,v=1 -> 1; s=1,v=0 -> Z; s=1,v=1 -> X.
+// 4-state encoding: u=0,v=0 -> 0; u=0,v=1 -> 1; u=1,v=0 -> Z; u=1,v=1 -> X.
 // Per IEEE 1800: ~0 -> 1, ~1 -> 0, ~X -> X, ~Z -> X.
 inline auto LogicNotWords(
-    std::span<std::uint64_t> dst_v, std::span<std::uint64_t> dst_s,
-    std::span<const std::uint64_t> src_v, std::span<const std::uint64_t> src_s,
+    std::span<std::uint64_t> dst_v, std::span<std::uint64_t> dst_u,
+    std::span<const std::uint64_t> src_v, std::span<const std::uint64_t> src_u,
     std::uint64_t width) -> void {
   for (std::size_t i = 0; i < dst_v.size(); ++i) {
-    dst_v[i] = (~src_v[i]) | src_s[i];
-    dst_s[i] = src_s[i];
+    dst_v[i] = (~src_v[i]) | src_u[i];
+    dst_u[i] = src_u[i];
   }
   MaskUnusedTopBits(dst_v, width);
-  MaskUnusedTopBits(dst_s, width);
+  MaskUnusedTopBits(dst_u, width);
 }
 
 // SV table: 0&_=0; 1&1=1; otherwise X.
 inline auto LogicAndWords(
-    std::span<std::uint64_t> dst_v, std::span<std::uint64_t> dst_s,
-    std::span<const std::uint64_t> av, std::span<const std::uint64_t> as,
-    std::span<const std::uint64_t> bv, std::span<const std::uint64_t> bs,
+    std::span<std::uint64_t> dst_v, std::span<std::uint64_t> dst_u,
+    std::span<const std::uint64_t> av, std::span<const std::uint64_t> au,
+    std::span<const std::uint64_t> bv, std::span<const std::uint64_t> bu,
     std::uint64_t width) -> void {
   for (std::size_t i = 0; i < dst_v.size(); ++i) {
-    const std::uint64_t a_zero = ~as[i] & ~av[i];
-    const std::uint64_t b_zero = ~bs[i] & ~bv[i];
-    const std::uint64_t a_one = ~as[i] & av[i];
-    const std::uint64_t b_one = ~bs[i] & bv[i];
+    const std::uint64_t a_zero = ~au[i] & ~av[i];
+    const std::uint64_t b_zero = ~bu[i] & ~bv[i];
+    const std::uint64_t a_one = ~au[i] & av[i];
+    const std::uint64_t b_one = ~bu[i] & bv[i];
     const std::uint64_t is_zero = a_zero | b_zero;
     const std::uint64_t is_one = a_one & b_one;
-    const std::uint64_t new_s = ~is_zero & ~is_one;
-    const std::uint64_t new_v = is_one | new_s;
+    const std::uint64_t new_u = ~is_zero & ~is_one;
+    const std::uint64_t new_v = is_one | new_u;
     dst_v[i] = new_v;
-    dst_s[i] = new_s;
+    dst_u[i] = new_u;
   }
   MaskUnusedTopBits(dst_v, width);
-  MaskUnusedTopBits(dst_s, width);
+  MaskUnusedTopBits(dst_u, width);
 }
 
 // SV table: 1|_=1; 0|0=0; otherwise X.
 inline auto LogicOrWords(
-    std::span<std::uint64_t> dst_v, std::span<std::uint64_t> dst_s,
-    std::span<const std::uint64_t> av, std::span<const std::uint64_t> as,
-    std::span<const std::uint64_t> bv, std::span<const std::uint64_t> bs,
+    std::span<std::uint64_t> dst_v, std::span<std::uint64_t> dst_u,
+    std::span<const std::uint64_t> av, std::span<const std::uint64_t> au,
+    std::span<const std::uint64_t> bv, std::span<const std::uint64_t> bu,
     std::uint64_t width) -> void {
   for (std::size_t i = 0; i < dst_v.size(); ++i) {
-    const std::uint64_t a_zero = ~as[i] & ~av[i];
-    const std::uint64_t b_zero = ~bs[i] & ~bv[i];
-    const std::uint64_t a_one = ~as[i] & av[i];
-    const std::uint64_t b_one = ~bs[i] & bv[i];
+    const std::uint64_t a_zero = ~au[i] & ~av[i];
+    const std::uint64_t b_zero = ~bu[i] & ~bv[i];
+    const std::uint64_t a_one = ~au[i] & av[i];
+    const std::uint64_t b_one = ~bu[i] & bv[i];
     const std::uint64_t is_one = a_one | b_one;
     const std::uint64_t is_zero = a_zero & b_zero;
-    const std::uint64_t new_s = ~is_zero & ~is_one;
-    const std::uint64_t new_v = is_one | new_s;
+    const std::uint64_t new_u = ~is_zero & ~is_one;
+    const std::uint64_t new_v = is_one | new_u;
     dst_v[i] = new_v;
-    dst_s[i] = new_s;
+    dst_u[i] = new_u;
   }
   MaskUnusedTopBits(dst_v, width);
-  MaskUnusedTopBits(dst_s, width);
+  MaskUnusedTopBits(dst_u, width);
 }
 
 // Any X/Z -> X; else dst_v_bit = av ^ bv.
 inline auto LogicXorWords(
-    std::span<std::uint64_t> dst_v, std::span<std::uint64_t> dst_s,
-    std::span<const std::uint64_t> av, std::span<const std::uint64_t> as,
-    std::span<const std::uint64_t> bv, std::span<const std::uint64_t> bs,
+    std::span<std::uint64_t> dst_v, std::span<std::uint64_t> dst_u,
+    std::span<const std::uint64_t> av, std::span<const std::uint64_t> au,
+    std::span<const std::uint64_t> bv, std::span<const std::uint64_t> bu,
     std::uint64_t width) -> void {
   for (std::size_t i = 0; i < dst_v.size(); ++i) {
-    const std::uint64_t new_s = as[i] | bs[i];
-    const std::uint64_t new_v = new_s | (av[i] ^ bv[i]);
+    const std::uint64_t new_u = au[i] | bu[i];
+    const std::uint64_t new_v = new_u | (av[i] ^ bv[i]);
     dst_v[i] = new_v;
-    dst_s[i] = new_s;
+    dst_u[i] = new_u;
   }
   MaskUnusedTopBits(dst_v, width);
-  MaskUnusedTopBits(dst_s, width);
+  MaskUnusedTopBits(dst_u, width);
 }
 
 // Any X/Z -> X; else dst_v_bit = ~(av ^ bv).
 inline auto LogicXnorWords(
-    std::span<std::uint64_t> dst_v, std::span<std::uint64_t> dst_s,
-    std::span<const std::uint64_t> av, std::span<const std::uint64_t> as,
-    std::span<const std::uint64_t> bv, std::span<const std::uint64_t> bs,
+    std::span<std::uint64_t> dst_v, std::span<std::uint64_t> dst_u,
+    std::span<const std::uint64_t> av, std::span<const std::uint64_t> au,
+    std::span<const std::uint64_t> bv, std::span<const std::uint64_t> bu,
     std::uint64_t width) -> void {
   for (std::size_t i = 0; i < dst_v.size(); ++i) {
-    const std::uint64_t new_s = as[i] | bs[i];
-    const std::uint64_t new_v = new_s | ~(av[i] ^ bv[i]);
+    const std::uint64_t new_u = au[i] | bu[i];
+    const std::uint64_t new_v = new_u | ~(av[i] ^ bv[i]);
     dst_v[i] = new_v;
-    dst_s[i] = new_s;
+    dst_u[i] = new_u;
   }
   MaskUnusedTopBits(dst_v, width);
-  MaskUnusedTopBits(dst_s, width);
+  MaskUnusedTopBits(dst_u, width);
 }
 
 template <PackedShape Shape, Signedness Signed>
@@ -176,8 +153,8 @@ auto BitwiseNotImpl(ConstBitView src) -> Bit<Shape, Signed> {
   }
   Bit<Shape, Signed> out;
   NotPlaneWords(
-      PlaneAccess::MutableValue(out), PlaneAccess::ValueWords(src),
-      Shape.TotalWidth());
+      PlaneAccess::AlignedMutableValueWords(out),
+      PlaneAccess::AlignedValueWords(src), Shape.TotalWidth());
   return out;
 }
 
@@ -188,9 +165,10 @@ auto BitwiseNotImpl(ConstLogicView src) -> Logic<Shape, Signed> {
   }
   Logic<Shape, Signed> out;
   LogicNotWords(
-      PlaneAccess::MutableValue(out), PlaneAccess::MutableState(out),
-      PlaneAccess::ValueWords(src), PlaneAccess::StateWords(src),
-      Shape.TotalWidth());
+      PlaneAccess::AlignedMutableValueWords(out),
+      PlaneAccess::AlignedMutableUnknownWords(out),
+      PlaneAccess::AlignedValueWords(src),
+      PlaneAccess::AlignedUnknownWords(src), Shape.TotalWidth());
   return out;
 }
 
@@ -201,8 +179,9 @@ auto BitwiseAndImpl(ConstBitView lhs, ConstBitView rhs) -> Bit<Shape, Signed> {
   }
   Bit<Shape, Signed> out;
   AndPlaneWords(
-      PlaneAccess::MutableValue(out), PlaneAccess::ValueWords(lhs),
-      PlaneAccess::ValueWords(rhs), Shape.TotalWidth());
+      PlaneAccess::AlignedMutableValueWords(out),
+      PlaneAccess::AlignedValueWords(lhs), PlaneAccess::AlignedValueWords(rhs),
+      Shape.TotalWidth());
   return out;
 }
 
@@ -214,10 +193,12 @@ auto BitwiseAndImpl(ConstLogicView lhs, ConstLogicView rhs)
   }
   Logic<Shape, Signed> out;
   LogicAndWords(
-      PlaneAccess::MutableValue(out), PlaneAccess::MutableState(out),
-      PlaneAccess::ValueWords(lhs), PlaneAccess::StateWords(lhs),
-      PlaneAccess::ValueWords(rhs), PlaneAccess::StateWords(rhs),
-      Shape.TotalWidth());
+      PlaneAccess::AlignedMutableValueWords(out),
+      PlaneAccess::AlignedMutableUnknownWords(out),
+      PlaneAccess::AlignedValueWords(lhs),
+      PlaneAccess::AlignedUnknownWords(lhs),
+      PlaneAccess::AlignedValueWords(rhs),
+      PlaneAccess::AlignedUnknownWords(rhs), Shape.TotalWidth());
   return out;
 }
 
@@ -228,8 +209,9 @@ auto BitwiseOrImpl(ConstBitView lhs, ConstBitView rhs) -> Bit<Shape, Signed> {
   }
   Bit<Shape, Signed> out;
   OrPlaneWords(
-      PlaneAccess::MutableValue(out), PlaneAccess::ValueWords(lhs),
-      PlaneAccess::ValueWords(rhs), Shape.TotalWidth());
+      PlaneAccess::AlignedMutableValueWords(out),
+      PlaneAccess::AlignedValueWords(lhs), PlaneAccess::AlignedValueWords(rhs),
+      Shape.TotalWidth());
   return out;
 }
 
@@ -241,10 +223,12 @@ auto BitwiseOrImpl(ConstLogicView lhs, ConstLogicView rhs)
   }
   Logic<Shape, Signed> out;
   LogicOrWords(
-      PlaneAccess::MutableValue(out), PlaneAccess::MutableState(out),
-      PlaneAccess::ValueWords(lhs), PlaneAccess::StateWords(lhs),
-      PlaneAccess::ValueWords(rhs), PlaneAccess::StateWords(rhs),
-      Shape.TotalWidth());
+      PlaneAccess::AlignedMutableValueWords(out),
+      PlaneAccess::AlignedMutableUnknownWords(out),
+      PlaneAccess::AlignedValueWords(lhs),
+      PlaneAccess::AlignedUnknownWords(lhs),
+      PlaneAccess::AlignedValueWords(rhs),
+      PlaneAccess::AlignedUnknownWords(rhs), Shape.TotalWidth());
   return out;
 }
 
@@ -255,8 +239,9 @@ auto BitwiseXorImpl(ConstBitView lhs, ConstBitView rhs) -> Bit<Shape, Signed> {
   }
   Bit<Shape, Signed> out;
   XorPlaneWords(
-      PlaneAccess::MutableValue(out), PlaneAccess::ValueWords(lhs),
-      PlaneAccess::ValueWords(rhs), Shape.TotalWidth());
+      PlaneAccess::AlignedMutableValueWords(out),
+      PlaneAccess::AlignedValueWords(lhs), PlaneAccess::AlignedValueWords(rhs),
+      Shape.TotalWidth());
   return out;
 }
 
@@ -268,10 +253,12 @@ auto BitwiseXorImpl(ConstLogicView lhs, ConstLogicView rhs)
   }
   Logic<Shape, Signed> out;
   LogicXorWords(
-      PlaneAccess::MutableValue(out), PlaneAccess::MutableState(out),
-      PlaneAccess::ValueWords(lhs), PlaneAccess::StateWords(lhs),
-      PlaneAccess::ValueWords(rhs), PlaneAccess::StateWords(rhs),
-      Shape.TotalWidth());
+      PlaneAccess::AlignedMutableValueWords(out),
+      PlaneAccess::AlignedMutableUnknownWords(out),
+      PlaneAccess::AlignedValueWords(lhs),
+      PlaneAccess::AlignedUnknownWords(lhs),
+      PlaneAccess::AlignedValueWords(rhs),
+      PlaneAccess::AlignedUnknownWords(rhs), Shape.TotalWidth());
   return out;
 }
 
@@ -282,8 +269,9 @@ auto BitwiseXnorImpl(ConstBitView lhs, ConstBitView rhs) -> Bit<Shape, Signed> {
   }
   Bit<Shape, Signed> out;
   XnorPlaneWords(
-      PlaneAccess::MutableValue(out), PlaneAccess::ValueWords(lhs),
-      PlaneAccess::ValueWords(rhs), Shape.TotalWidth());
+      PlaneAccess::AlignedMutableValueWords(out),
+      PlaneAccess::AlignedValueWords(lhs), PlaneAccess::AlignedValueWords(rhs),
+      Shape.TotalWidth());
   return out;
 }
 
@@ -295,10 +283,12 @@ auto BitwiseXnorImpl(ConstLogicView lhs, ConstLogicView rhs)
   }
   Logic<Shape, Signed> out;
   LogicXnorWords(
-      PlaneAccess::MutableValue(out), PlaneAccess::MutableState(out),
-      PlaneAccess::ValueWords(lhs), PlaneAccess::StateWords(lhs),
-      PlaneAccess::ValueWords(rhs), PlaneAccess::StateWords(rhs),
-      Shape.TotalWidth());
+      PlaneAccess::AlignedMutableValueWords(out),
+      PlaneAccess::AlignedMutableUnknownWords(out),
+      PlaneAccess::AlignedValueWords(lhs),
+      PlaneAccess::AlignedUnknownWords(lhs),
+      PlaneAccess::AlignedValueWords(rhs),
+      PlaneAccess::AlignedUnknownWords(rhs), Shape.TotalWidth());
   return out;
 }
 

--- a/include/lyra/runtime/convert.hpp
+++ b/include/lyra/runtime/convert.hpp
@@ -100,7 +100,7 @@ inline auto TestBit(std::span<const std::uint64_t> words, std::uint64_t index)
 
 struct ConversionSource {
   std::span<const std::uint64_t> value;
-  std::span<const std::uint64_t> state;
+  std::span<const std::uint64_t> unknown;
   std::uint64_t width;
   Signedness signedness;
   bool four_state;
@@ -108,7 +108,7 @@ struct ConversionSource {
 
 struct ConversionTarget {
   std::span<std::uint64_t> value;
-  std::span<std::uint64_t> state;
+  std::span<std::uint64_t> unknown;
   std::uint64_t width;
   bool four_state;
 };
@@ -117,45 +117,45 @@ inline auto ConvertPackedBits(ConversionTarget dst, ConversionSource src)
     -> void {
   ZeroBits(dst.value);
   if (dst.four_state) {
-    ZeroBits(dst.state);
+    ZeroBits(dst.unknown);
   }
 
   const std::uint64_t copy_width = std::min(dst.width, src.width);
 
   if (src.four_state && !dst.four_state) {
-    // Logic -> Bit flattens X/Z by clearing where state is 1.
+    // Logic -> Bit flattens X/Z by clearing where unknown is 1.
     CopyLowBits(dst.value, src.value, copy_width);
-    AndNotLowBits(dst.value, src.state, copy_width);
+    AndNotLowBits(dst.value, src.unknown, copy_width);
   } else {
     CopyLowBits(dst.value, src.value, copy_width);
     if (dst.four_state && src.four_state) {
-      CopyLowBits(dst.state, src.state, copy_width);
+      CopyLowBits(dst.unknown, src.unknown, copy_width);
     }
   }
 
   if (dst.width > src.width && src.width > 0U &&
       src.signedness == Signedness::kSigned) {
     bool sign_value = false;
-    bool sign_state = false;
+    bool sign_unknown = false;
     if (src.four_state && !dst.four_state) {
-      sign_value = !TestBit(src.state, src.width - 1U) &&
+      sign_value = !TestBit(src.unknown, src.width - 1U) &&
                    TestBit(src.value, src.width - 1U);
     } else {
       sign_value = TestBit(src.value, src.width - 1U);
       if (src.four_state) {
         // Logic -> Logic preserves an X or Z sign bit on widening.
-        sign_state = TestBit(src.state, src.width - 1U);
+        sign_unknown = TestBit(src.unknown, src.width - 1U);
       }
     }
     FillBitRange(dst.value, src.width, dst.width, sign_value);
     if (dst.four_state) {
-      FillBitRange(dst.state, src.width, dst.width, sign_state);
+      FillBitRange(dst.unknown, src.width, dst.width, sign_unknown);
     }
   }
 
   MaskUnusedTopBits(dst.value, dst.width);
   if (dst.four_state) {
-    MaskUnusedTopBits(dst.state, dst.width);
+    MaskUnusedTopBits(dst.unknown, dst.width);
   }
 }
 
@@ -167,14 +167,14 @@ auto ConvertToBit(ConstBitView src, Signedness src_signedness)
   Bit<TargetShape, TargetSigned> out;
   detail::ConvertPackedBits(
       detail::ConversionTarget{
-          .value = detail::PlaneAccess::MutableValue(out),
-          .state = {},
+          .value = detail::PlaneAccess::AlignedMutableValueWords(out),
+          .unknown = {},
           .width = TargetShape.TotalWidth(),
           .four_state = false,
       },
       detail::ConversionSource{
-          .value = detail::PlaneAccess::ValueWords(src),
-          .state = {},
+          .value = detail::PlaneAccess::AlignedValueWords(src),
+          .unknown = {},
           .width = src.Width(),
           .signedness = src_signedness,
           .four_state = false,
@@ -188,14 +188,14 @@ auto ConvertToBit(ConstLogicView src, Signedness src_signedness)
   Bit<TargetShape, TargetSigned> out;
   detail::ConvertPackedBits(
       detail::ConversionTarget{
-          .value = detail::PlaneAccess::MutableValue(out),
-          .state = {},
+          .value = detail::PlaneAccess::AlignedMutableValueWords(out),
+          .unknown = {},
           .width = TargetShape.TotalWidth(),
           .four_state = false,
       },
       detail::ConversionSource{
-          .value = detail::PlaneAccess::ValueWords(src),
-          .state = detail::PlaneAccess::StateWords(src),
+          .value = detail::PlaneAccess::AlignedValueWords(src),
+          .unknown = detail::PlaneAccess::AlignedUnknownWords(src),
           .width = src.Width(),
           .signedness = src_signedness,
           .four_state = true,
@@ -209,14 +209,14 @@ auto ConvertToLogic(ConstBitView src, Signedness src_signedness)
   Logic<TargetShape, TargetSigned> out;
   detail::ConvertPackedBits(
       detail::ConversionTarget{
-          .value = detail::PlaneAccess::MutableValue(out),
-          .state = detail::PlaneAccess::MutableState(out),
+          .value = detail::PlaneAccess::AlignedMutableValueWords(out),
+          .unknown = detail::PlaneAccess::AlignedMutableUnknownWords(out),
           .width = TargetShape.TotalWidth(),
           .four_state = true,
       },
       detail::ConversionSource{
-          .value = detail::PlaneAccess::ValueWords(src),
-          .state = {},
+          .value = detail::PlaneAccess::AlignedValueWords(src),
+          .unknown = {},
           .width = src.Width(),
           .signedness = src_signedness,
           .four_state = false,
@@ -230,14 +230,14 @@ auto ConvertToLogic(ConstLogicView src, Signedness src_signedness)
   Logic<TargetShape, TargetSigned> out;
   detail::ConvertPackedBits(
       detail::ConversionTarget{
-          .value = detail::PlaneAccess::MutableValue(out),
-          .state = detail::PlaneAccess::MutableState(out),
+          .value = detail::PlaneAccess::AlignedMutableValueWords(out),
+          .unknown = detail::PlaneAccess::AlignedMutableUnknownWords(out),
           .width = TargetShape.TotalWidth(),
           .four_state = true,
       },
       detail::ConversionSource{
-          .value = detail::PlaneAccess::ValueWords(src),
-          .state = detail::PlaneAccess::StateWords(src),
+          .value = detail::PlaneAccess::AlignedValueWords(src),
+          .unknown = detail::PlaneAccess::AlignedUnknownWords(src),
           .width = src.Width(),
           .signedness = src_signedness,
           .four_state = true,

--- a/include/lyra/runtime/format.hpp
+++ b/include/lyra/runtime/format.hpp
@@ -46,19 +46,19 @@ struct FormatSpec {
 // Two integral storage planes coexist:
 //   - Narrow integral (bit_width <= 64): the value lives inline in
 //   `inline_word`,
-//     and (for four-state) the state plane lives inline in
-//     `inline_state_word`. `value_words` / `state_words` are null. The whole
-//     view is built inline at a `LyraPrint` call site with no externally
-//     owned storage.
+//     and (for four-state) the unknown plane lives inline in
+//     `inline_unknown_word`. `value_words` / `unknown_words` are null. The
+//     whole view is built inline at a `LyraPrint` call site with no
+//     externally owned storage.
 //   - Wide integral (bit_width > 64): caller owns `uint64_t[word_count]`
-//     arrays for value and (for four-state) state, passed via `value_words`
-//     and `state_words`.
+//     arrays for value and (for four-state) unknown, passed via
+//     `value_words` and `unknown_words`.
 struct IntegralValueView {
   IntegralStateKind state = IntegralStateKind::kTwoState;
   std::uint64_t inline_word = 0;
-  std::uint64_t inline_state_word = 0;
+  std::uint64_t inline_unknown_word = 0;
   const std::uint64_t* value_words = nullptr;
-  const std::uint64_t* state_words = nullptr;
+  const std::uint64_t* unknown_words = nullptr;
   std::uint32_t word_count = 0;
   std::uint32_t bit_width = 0;
   bool is_signed = false;

--- a/include/lyra/runtime/packed.hpp
+++ b/include/lyra/runtime/packed.hpp
@@ -135,12 +135,12 @@ inline auto ValidateBitRange(
 }
 
 inline auto ValidateLogicRange(
-    std::size_t value_word_count, std::size_t state_word_count,
+    std::size_t value_word_count, std::size_t unknown_word_count,
     std::uint64_t bit_offset, std::uint64_t width, std::string_view where)
     -> void {
-  if (value_word_count != state_word_count) {
+  if (value_word_count != unknown_word_count) {
     throw InternalError(
-        std::string(where) + ": value and state span sizes differ");
+        std::string(where) + ": value and unknown span sizes differ");
   }
   ValidateBitRange(value_word_count, bit_offset, width, where);
 }
@@ -341,14 +341,14 @@ class ConstLogicView {
  public:
   ConstLogicView(
       std::span<const std::uint64_t> value_words,
-      std::span<const std::uint64_t> state_words, std::uint64_t bit_offset,
+      std::span<const std::uint64_t> unknown_words, std::uint64_t bit_offset,
       std::uint64_t width)
       : value_words_(value_words),
-        state_words_(state_words),
+        unknown_words_(unknown_words),
         bit_offset_(bit_offset),
         width_(width) {
     detail::ValidateLogicRange(
-        value_words_.size(), state_words_.size(), bit_offset_, width_,
+        value_words_.size(), unknown_words_.size(), bit_offset_, width_,
         "ConstLogicView");
   }
 
@@ -362,8 +362,8 @@ class ConstLogicView {
     }
     const std::uint64_t bp = bit_offset_ + offset;
     const bool v = ((value_words_[bp / 64U] >> (bp % 64U)) & 1U) != 0U;
-    const bool s = ((state_words_[bp / 64U] >> (bp % 64U)) & 1U) != 0U;
-    if (!s) {
+    const bool u = ((unknown_words_[bp / 64U] >> (bp % 64U)) & 1U) != 0U;
+    if (!u) {
       return v ? FourStateBit::kOne : FourStateBit::kZero;
     }
     return v ? FourStateBit::kUnknown : FourStateBit::kHighImpedance;
@@ -385,14 +385,14 @@ class ConstLogicView {
     return out;
   }
 
-  [[nodiscard]] auto PackStateLowWord() const -> std::uint64_t {
+  [[nodiscard]] auto PackUnknownLowWord() const -> std::uint64_t {
     if (width_ > 64U) {
-      throw InternalError("ConstLogicView::PackStateLowWord: width > 64");
+      throw InternalError("ConstLogicView::PackUnknownLowWord: width > 64");
     }
     std::uint64_t out = 0;
     for (std::uint64_t i = 0; i < width_; ++i) {
       const std::uint64_t bp = bit_offset_ + i;
-      if (((state_words_[bp / 64U] >> (bp % 64U)) & 1U) != 0U) {
+      if (((unknown_words_[bp / 64U] >> (bp % 64U)) & 1U) != 0U) {
         out |= std::uint64_t{1} << i;
       }
     }
@@ -406,16 +406,16 @@ class ConstLogicView {
       -> std::span<const std::uint64_t> {
     return value_words_;
   }
-  [[nodiscard]] auto StateWordsForPackedOps() const
+  [[nodiscard]] auto UnknownWordsForPackedOps() const
       -> std::span<const std::uint64_t> {
-    return state_words_;
+    return unknown_words_;
   }
   [[nodiscard]] auto BitOffsetForPackedOps() const -> std::uint64_t {
     return bit_offset_;
   }
 
   std::span<const std::uint64_t> value_words_;
-  std::span<const std::uint64_t> state_words_;
+  std::span<const std::uint64_t> unknown_words_;
   std::uint64_t bit_offset_;
   std::uint64_t width_;
 };
@@ -424,14 +424,14 @@ class LogicView {
  public:
   LogicView(
       std::span<std::uint64_t> value_words,
-      std::span<std::uint64_t> state_words, std::uint64_t bit_offset,
+      std::span<std::uint64_t> unknown_words, std::uint64_t bit_offset,
       std::uint64_t width)
       : value_words_(value_words),
-        state_words_(state_words),
+        unknown_words_(unknown_words),
         bit_offset_(bit_offset),
         width_(width) {
     detail::ValidateLogicRange(
-        value_words_.size(), state_words_.size(), bit_offset_, width_,
+        value_words_.size(), unknown_words_.size(), bit_offset_, width_,
         "LogicView");
   }
 
@@ -460,19 +460,19 @@ class LogicView {
     switch (value) {
       case FourStateBit::kZero:
         write(value_words_, false);
-        write(state_words_, false);
+        write(unknown_words_, false);
         break;
       case FourStateBit::kOne:
         write(value_words_, true);
-        write(state_words_, false);
+        write(unknown_words_, false);
         break;
       case FourStateBit::kHighImpedance:
         write(value_words_, false);
-        write(state_words_, true);
+        write(unknown_words_, true);
         break;
       case FourStateBit::kUnknown:
         write(value_words_, true);
-        write(state_words_, true);
+        write(unknown_words_, true);
         break;
     }
   }
@@ -514,18 +514,18 @@ class LogicView {
   }
 
   [[nodiscard]] auto AsConst() const -> ConstLogicView {
-    return ConstLogicView{value_words_, state_words_, bit_offset_, width_};
+    return ConstLogicView{value_words_, unknown_words_, bit_offset_, width_};
   }
   [[nodiscard]] auto PackValueLowWord() const -> std::uint64_t {
     return AsConst().PackValueLowWord();
   }
-  [[nodiscard]] auto PackStateLowWord() const -> std::uint64_t {
-    return AsConst().PackStateLowWord();
+  [[nodiscard]] auto PackUnknownLowWord() const -> std::uint64_t {
+    return AsConst().PackUnknownLowWord();
   }
 
  private:
   std::span<std::uint64_t> value_words_;
-  std::span<std::uint64_t> state_words_;
+  std::span<std::uint64_t> unknown_words_;
   std::uint64_t bit_offset_;
   std::uint64_t width_;
 };
@@ -608,11 +608,12 @@ class Logic {
 
   [[nodiscard]] auto View() -> LogicView {
     return LogicView{
-        value_.MutableWordsForView(), state_.MutableWordsForView(), 0U, kWidth};
+        value_.MutableWordsForView(), unknown_.MutableWordsForView(), 0U,
+        kWidth};
   }
   [[nodiscard]] auto View() const -> ConstLogicView {
     return ConstLogicView{
-        value_.WordsForView(), state_.WordsForView(), 0U, kWidth};
+        value_.WordsForView(), unknown_.WordsForView(), 0U, kWidth};
   }
   [[nodiscard]] auto View(std::uint64_t offset, std::uint64_t width)
       -> LogicView {
@@ -621,7 +622,7 @@ class Logic {
       throw InternalError("Logic::View: invalid view range");
     }
     return LogicView{
-        value_.MutableWordsForView(), state_.MutableWordsForView(), offset,
+        value_.MutableWordsForView(), unknown_.MutableWordsForView(), offset,
         width};
   }
   [[nodiscard]] auto View(std::uint64_t offset, std::uint64_t width) const
@@ -631,30 +632,30 @@ class Logic {
       throw InternalError("Logic::View: invalid view range");
     }
     return ConstLogicView{
-        value_.WordsForView(), state_.WordsForView(), offset, width};
+        value_.WordsForView(), unknown_.WordsForView(), offset, width};
   }
 
   auto SetZero() -> void {
     value_.SetZero();
-    state_.SetZero();
+    unknown_.SetZero();
   }
   auto SetOne() -> void {
     value_.SetOne();
-    state_.SetZero();
+    unknown_.SetZero();
   }
   auto SetHighImpedance() -> void {
     value_.SetZero();
-    state_.SetOne();
+    unknown_.SetOne();
   }
   auto SetUnknown() -> void {
     value_.SetOne();
-    state_.SetOne();
+    unknown_.SetOne();
   }
 
   [[nodiscard]] auto GetBit(std::uint64_t offset) const -> FourStateBit {
     const bool v = value_.GetBit(offset);
-    const bool s = state_.GetBit(offset);
-    if (!s) {
+    const bool u = unknown_.GetBit(offset);
+    if (!u) {
       return v ? FourStateBit::kOne : FourStateBit::kZero;
     }
     return v ? FourStateBit::kUnknown : FourStateBit::kHighImpedance;
@@ -663,19 +664,19 @@ class Logic {
     switch (value) {
       case FourStateBit::kZero:
         value_.SetBit(offset, false);
-        state_.SetBit(offset, false);
+        unknown_.SetBit(offset, false);
         break;
       case FourStateBit::kOne:
         value_.SetBit(offset, true);
-        state_.SetBit(offset, false);
+        unknown_.SetBit(offset, false);
         break;
       case FourStateBit::kHighImpedance:
         value_.SetBit(offset, false);
-        state_.SetBit(offset, true);
+        unknown_.SetBit(offset, true);
         break;
       case FourStateBit::kUnknown:
         value_.SetBit(offset, true);
-        state_.SetBit(offset, true);
+        unknown_.SetBit(offset, true);
         break;
     }
   }
@@ -695,13 +696,13 @@ class Logic {
       -> std::span<std::uint64_t> {
     return value_.MutableWordsForView();
   }
-  [[nodiscard]] auto MutableStateWordsForPackedOps()
+  [[nodiscard]] auto MutableUnknownWordsForPackedOps()
       -> std::span<std::uint64_t> {
-    return state_.MutableWordsForView();
+    return unknown_.MutableWordsForView();
   }
 
   detail::BitPlane<kWidth> value_{};
-  detail::BitPlane<kWidth> state_{};
+  detail::BitPlane<kWidth> unknown_{};
 };
 
 template <PackedShape Shape, Signedness Signed = Signedness::kUnsigned>

--- a/include/lyra/runtime/packed_words.hpp
+++ b/include/lyra/runtime/packed_words.hpp
@@ -1,8 +1,12 @@
 #pragma once
 
+#include <concepts>
 #include <cstdint>
+#include <limits>
 #include <span>
 #include <string>
+#include <type_traits>
+#include <utility>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/runtime/packed.hpp"
@@ -22,46 +26,141 @@ inline auto MaskUnusedTopBits(std::span<std::uint64_t> dst, std::uint64_t width)
   dst.back() &= mask;
 }
 
+constexpr auto ValidBitsMaskForWord(std::uint64_t width, std::size_t word_index)
+    -> std::uint64_t {
+  constexpr std::uint64_t kWordBits = 64U;
+  if (static_cast<std::uint64_t>(word_index) >
+      std::numeric_limits<std::uint64_t>::max() / kWordBits) {
+    throw InternalError("ValidBitsMaskForWord: word index overflow");
+  }
+  const auto consumed = static_cast<std::uint64_t>(word_index) * kWordBits;
+  if (consumed >= width) {
+    throw InternalError("ValidBitsMaskForWord: word index out of range");
+  }
+  const auto remaining = width - consumed;
+  if (remaining >= kWordBits) {
+    return ~std::uint64_t{0};
+  }
+  return (std::uint64_t{1} << remaining) - 1U;
+}
+
+template <typename V>
+concept BitViewLike = std::same_as<std::remove_cvref_t<V>, ConstBitView> ||
+                      std::same_as<std::remove_cvref_t<V>, BitView>;
+
+template <typename V>
+concept LogicViewLike = std::same_as<std::remove_cvref_t<V>, ConstLogicView> ||
+                        std::same_as<std::remove_cvref_t<V>, LogicView>;
+
+inline auto ToConstView(ConstBitView v) -> ConstBitView {
+  return v;
+}
+inline auto ToConstView(BitView v) -> ConstBitView {
+  return v.AsConst();
+}
+inline auto ToConstView(ConstLogicView v) -> ConstLogicView {
+  return v;
+}
+inline auto ToConstView(LogicView v) -> ConstLogicView {
+  return v.AsConst();
+}
+
 struct PlaneAccess {
   template <PackedShape Shape, Signedness Signed>
-  static auto MutableValue(Bit<Shape, Signed>& b) -> std::span<std::uint64_t> {
+  static auto AlignedMutableValueWords(Bit<Shape, Signed>& b)
+      -> std::span<std::uint64_t> {
     return b.MutableValueWordsForPackedOps();
   }
   template <PackedShape Shape, Signedness Signed>
-  static auto MutableValue(Logic<Shape, Signed>& l)
+  static auto AlignedMutableValueWords(Logic<Shape, Signed>& l)
       -> std::span<std::uint64_t> {
     return l.MutableValueWordsForPackedOps();
   }
   template <PackedShape Shape, Signedness Signed>
-  static auto MutableState(Logic<Shape, Signed>& l)
+  static auto AlignedMutableUnknownWords(Logic<Shape, Signed>& l)
       -> std::span<std::uint64_t> {
-    return l.MutableStateWordsForPackedOps();
+    return l.MutableUnknownWordsForPackedOps();
   }
 
-  static auto ValueWords(ConstBitView v) -> std::span<const std::uint64_t> {
+  static auto AlignedValueWords(ConstBitView v)
+      -> std::span<const std::uint64_t> {
     if (v.BitOffsetForPackedOps() != 0U) {
       throw InternalError(
-          "PlaneAccess::ValueWords: ConstBitView with non-zero bit_offset is "
-          "not supported");
+          "PlaneAccess::AlignedValueWords: ConstBitView with non-zero "
+          "bit_offset is not supported");
     }
     return v.WordsForPackedOps();
   }
-  static auto ValueWords(ConstLogicView v) -> std::span<const std::uint64_t> {
+  static auto AlignedValueWords(ConstLogicView v)
+      -> std::span<const std::uint64_t> {
     if (v.BitOffsetForPackedOps() != 0U) {
       throw InternalError(
-          "PlaneAccess::ValueWords: ConstLogicView with non-zero bit_offset "
-          "is not supported");
+          "PlaneAccess::AlignedValueWords: ConstLogicView with non-zero "
+          "bit_offset is not supported");
     }
     return v.ValueWordsForPackedOps();
   }
-  static auto StateWords(ConstLogicView v) -> std::span<const std::uint64_t> {
+  static auto AlignedUnknownWords(ConstLogicView v)
+      -> std::span<const std::uint64_t> {
     if (v.BitOffsetForPackedOps() != 0U) {
       throw InternalError(
-          "PlaneAccess::StateWords: ConstLogicView with non-zero bit_offset "
-          "is not supported");
+          "PlaneAccess::AlignedUnknownWords: ConstLogicView with non-zero "
+          "bit_offset is not supported");
     }
-    return v.StateWordsForPackedOps();
+    return v.UnknownWordsForPackedOps();
   }
 };
+
+using ScalarShape = PackedShape<0>;
+
+inline auto MakeScalarBit(bool value)
+    -> Bit<ScalarShape{}, Signedness::kUnsigned> {
+  Bit<ScalarShape{}, Signedness::kUnsigned> out;
+  PlaneAccess::AlignedMutableValueWords(out)[0] =
+      value ? std::uint64_t{1} : std::uint64_t{0};
+  return out;
+}
+
+inline auto MakeScalarLogicKnown(bool value)
+    -> Logic<ScalarShape{}, Signedness::kUnsigned> {
+  Logic<ScalarShape{}, Signedness::kUnsigned> out;
+  PlaneAccess::AlignedMutableValueWords(out)[0] =
+      value ? std::uint64_t{1} : std::uint64_t{0};
+  PlaneAccess::AlignedMutableUnknownWords(out)[0] = std::uint64_t{0};
+  return out;
+}
+
+inline auto MakeScalarLogicX() -> Logic<ScalarShape{}, Signedness::kUnsigned> {
+  Logic<ScalarShape{}, Signedness::kUnsigned> out;
+  PlaneAccess::AlignedMutableValueWords(out)[0] = std::uint64_t{1};
+  PlaneAccess::AlignedMutableUnknownWords(out)[0] = std::uint64_t{1};
+  return out;
+}
+
+inline auto MakeScalarLogicZ() -> Logic<ScalarShape{}, Signedness::kUnsigned> {
+  Logic<ScalarShape{}, Signedness::kUnsigned> out;
+  PlaneAccess::AlignedMutableValueWords(out)[0] = std::uint64_t{0};
+  PlaneAccess::AlignedMutableUnknownWords(out)[0] = std::uint64_t{1};
+  return out;
+}
+
+inline auto NotScalar(Bit<ScalarShape{}, Signedness::kUnsigned> in)
+    -> Bit<ScalarShape{}, Signedness::kUnsigned> {
+  const auto view = std::as_const(in).View();
+  const auto bit = PlaneAccess::AlignedValueWords(view)[0] & std::uint64_t{1};
+  return MakeScalarBit(bit == 0U);
+}
+
+inline auto NotScalar(Logic<ScalarShape{}, Signedness::kUnsigned> in)
+    -> Logic<ScalarShape{}, Signedness::kUnsigned> {
+  const auto view = std::as_const(in).View();
+  const auto unknown =
+      PlaneAccess::AlignedUnknownWords(view)[0] & std::uint64_t{1};
+  if (unknown != 0U) {
+    return MakeScalarLogicX();
+  }
+  const auto value = PlaneAccess::AlignedValueWords(view)[0] & std::uint64_t{1};
+  return MakeScalarLogicKnown(value == 0U);
+}
 
 }  // namespace lyra::runtime::detail

--- a/include/lyra/runtime/reduction.hpp
+++ b/include/lyra/runtime/reduction.hpp
@@ -1,114 +1,21 @@
 #pragma once
 
 #include <bit>
-#include <concepts>
 #include <cstdint>
-#include <limits>
-#include <type_traits>
-#include <utility>
 
-#include "lyra/base/internal_error.hpp"
 #include "lyra/runtime/packed.hpp"
 #include "lyra/runtime/packed_words.hpp"
 
 namespace lyra::runtime {
 
-namespace detail {
-
-template <typename V>
-concept ReductionBitViewLike =
-    std::same_as<std::remove_cvref_t<V>, ConstBitView> ||
-    std::same_as<std::remove_cvref_t<V>, BitView>;
-
-template <typename V>
-concept ReductionLogicViewLike =
-    std::same_as<std::remove_cvref_t<V>, ConstLogicView> ||
-    std::same_as<std::remove_cvref_t<V>, LogicView>;
-
-inline auto ToConstBitView(ConstBitView v) -> ConstBitView {
-  return v;
-}
-inline auto ToConstBitView(BitView v) -> ConstBitView {
-  return v.AsConst();
-}
-inline auto ToConstLogicView(ConstLogicView v) -> ConstLogicView {
-  return v;
-}
-inline auto ToConstLogicView(LogicView v) -> ConstLogicView {
-  return v.AsConst();
-}
-
-constexpr auto ValidMaskForWord(std::size_t word_index, std::uint64_t width)
-    -> std::uint64_t {
-  constexpr std::uint64_t kWordBits = 64U;
-  if (static_cast<std::uint64_t>(word_index) >
-      std::numeric_limits<std::uint64_t>::max() / kWordBits) {
-    throw InternalError("packed reduction: word index overflow");
-  }
-  const auto consumed = static_cast<std::uint64_t>(word_index) * kWordBits;
-  if (consumed >= width) {
-    throw InternalError("packed reduction: word index out of range");
-  }
-  const auto remaining = width - consumed;
-  if (remaining >= kWordBits) {
-    return ~std::uint64_t{0};
-  }
-  return (std::uint64_t{1} << remaining) - 1U;
-}
-
-inline auto MakeScalarBit(bool value)
-    -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
-  Bit<PackedShape<0>{}, Signedness::kUnsigned> out;
-  PlaneAccess::MutableValue(out)[0] =
-      value ? std::uint64_t{1} : std::uint64_t{0};
-  return out;
-}
-
-inline auto MakeScalarLogicKnown(bool value)
-    -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
-  Logic<PackedShape<0>{}, Signedness::kUnsigned> out;
-  PlaneAccess::MutableValue(out)[0] =
-      value ? std::uint64_t{1} : std::uint64_t{0};
-  PlaneAccess::MutableState(out)[0] = std::uint64_t{0};
-  return out;
-}
-
-inline auto MakeScalarLogicUnknown()
-    -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
-  Logic<PackedShape<0>{}, Signedness::kUnsigned> out;
-  PlaneAccess::MutableValue(out)[0] = std::uint64_t{1};
-  PlaneAccess::MutableState(out)[0] = std::uint64_t{1};
-  return out;
-}
-
-inline auto NotScalar(Bit<PackedShape<0>{}, Signedness::kUnsigned> in)
-    -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
-  const auto view = std::as_const(in).View();
-  const auto bit = PlaneAccess::ValueWords(view)[0] & std::uint64_t{1};
-  return MakeScalarBit(bit == 0U);
-}
-
-inline auto NotScalar(Logic<PackedShape<0>{}, Signedness::kUnsigned> in)
-    -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
-  const auto view = std::as_const(in).View();
-  const auto state = PlaneAccess::StateWords(view)[0] & std::uint64_t{1};
-  if (state != 0U) {
-    return MakeScalarLogicUnknown();
-  }
-  const auto value = PlaneAccess::ValueWords(view)[0] & std::uint64_t{1};
-  return MakeScalarLogicKnown(value == 0U);
-}
-
-}  // namespace detail
-
-template <detail::ReductionBitViewLike V>
-auto ReductionAnd(V src) -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
-  const auto v = detail::ToConstBitView(src);
-  const auto words = detail::PlaneAccess::ValueWords(v);
+template <detail::BitViewLike V>
+auto ReductionAnd(V src) -> Bit<detail::ScalarShape{}, Signedness::kUnsigned> {
+  const auto v = detail::ToConstView(src);
+  const auto words = detail::PlaneAccess::AlignedValueWords(v);
   const auto width = v.Width();
   bool all_one = true;
   for (std::size_t i = 0; i < words.size(); ++i) {
-    const auto mask = detail::ValidMaskForWord(i, width);
+    const auto mask = detail::ValidBitsMaskForWord(width, i);
     if ((words[i] & mask) != mask) {
       all_one = false;
       break;
@@ -117,14 +24,14 @@ auto ReductionAnd(V src) -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
   return detail::MakeScalarBit(all_one);
 }
 
-template <detail::ReductionBitViewLike V>
-auto ReductionOr(V src) -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
-  const auto v = detail::ToConstBitView(src);
-  const auto words = detail::PlaneAccess::ValueWords(v);
+template <detail::BitViewLike V>
+auto ReductionOr(V src) -> Bit<detail::ScalarShape{}, Signedness::kUnsigned> {
+  const auto v = detail::ToConstView(src);
+  const auto words = detail::PlaneAccess::AlignedValueWords(v);
   const auto width = v.Width();
   bool any_one = false;
   for (std::size_t i = 0; i < words.size(); ++i) {
-    const auto mask = detail::ValidMaskForWord(i, width);
+    const auto mask = detail::ValidBitsMaskForWord(width, i);
     if ((words[i] & mask) != 0U) {
       any_one = true;
       break;
@@ -133,48 +40,49 @@ auto ReductionOr(V src) -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
   return detail::MakeScalarBit(any_one);
 }
 
-template <detail::ReductionBitViewLike V>
-auto ReductionXor(V src) -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
-  const auto v = detail::ToConstBitView(src);
-  const auto words = detail::PlaneAccess::ValueWords(v);
+template <detail::BitViewLike V>
+auto ReductionXor(V src) -> Bit<detail::ScalarShape{}, Signedness::kUnsigned> {
+  const auto v = detail::ToConstView(src);
+  const auto words = detail::PlaneAccess::AlignedValueWords(v);
   const auto width = v.Width();
   std::uint64_t parity_acc = 0;
   for (std::size_t i = 0; i < words.size(); ++i) {
-    const auto mask = detail::ValidMaskForWord(i, width);
+    const auto mask = detail::ValidBitsMaskForWord(width, i);
     parity_acc ^= static_cast<std::uint64_t>(std::popcount(words[i] & mask));
   }
   return detail::MakeScalarBit((parity_acc & std::uint64_t{1}) != 0U);
 }
 
-template <detail::ReductionBitViewLike V>
-auto ReductionNand(V src) -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
+template <detail::BitViewLike V>
+auto ReductionNand(V src) -> Bit<detail::ScalarShape{}, Signedness::kUnsigned> {
   return detail::NotScalar(ReductionAnd(src));
 }
 
-template <detail::ReductionBitViewLike V>
-auto ReductionNor(V src) -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
+template <detail::BitViewLike V>
+auto ReductionNor(V src) -> Bit<detail::ScalarShape{}, Signedness::kUnsigned> {
   return detail::NotScalar(ReductionOr(src));
 }
 
-template <detail::ReductionBitViewLike V>
-auto ReductionXnor(V src) -> Bit<PackedShape<0>{}, Signedness::kUnsigned> {
+template <detail::BitViewLike V>
+auto ReductionXnor(V src) -> Bit<detail::ScalarShape{}, Signedness::kUnsigned> {
   return detail::NotScalar(ReductionXor(src));
 }
 
-template <detail::ReductionLogicViewLike V>
-auto ReductionAnd(V src) -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
-  const auto v = detail::ToConstLogicView(src);
-  const auto val_w = detail::PlaneAccess::ValueWords(v);
-  const auto state_w = detail::PlaneAccess::StateWords(v);
+template <detail::LogicViewLike V>
+auto ReductionAnd(V src)
+    -> Logic<detail::ScalarShape{}, Signedness::kUnsigned> {
+  const auto v = detail::ToConstView(src);
+  const auto val_w = detail::PlaneAccess::AlignedValueWords(v);
+  const auto unknown_w = detail::PlaneAccess::AlignedUnknownWords(v);
   const auto width = v.Width();
   bool any_known_zero = false;
   bool any_unknown = false;
   for (std::size_t i = 0; i < val_w.size(); ++i) {
-    const auto mask = detail::ValidMaskForWord(i, width);
-    const auto state = state_w[i] & mask;
+    const auto mask = detail::ValidBitsMaskForWord(width, i);
+    const auto unknown = unknown_w[i] & mask;
     const auto value = val_w[i] & mask;
-    const auto known_zero_bits = (~value) & (~state) & mask;
-    if (state != 0U) {
+    const auto known_zero_bits = (~value) & (~unknown) & mask;
+    if (unknown != 0U) {
       any_unknown = true;
     }
     if (known_zero_bits != 0U) {
@@ -186,25 +94,25 @@ auto ReductionAnd(V src) -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
     return detail::MakeScalarLogicKnown(false);
   }
   if (any_unknown) {
-    return detail::MakeScalarLogicUnknown();
+    return detail::MakeScalarLogicX();
   }
   return detail::MakeScalarLogicKnown(true);
 }
 
-template <detail::ReductionLogicViewLike V>
-auto ReductionOr(V src) -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
-  const auto v = detail::ToConstLogicView(src);
-  const auto val_w = detail::PlaneAccess::ValueWords(v);
-  const auto state_w = detail::PlaneAccess::StateWords(v);
+template <detail::LogicViewLike V>
+auto ReductionOr(V src) -> Logic<detail::ScalarShape{}, Signedness::kUnsigned> {
+  const auto v = detail::ToConstView(src);
+  const auto val_w = detail::PlaneAccess::AlignedValueWords(v);
+  const auto unknown_w = detail::PlaneAccess::AlignedUnknownWords(v);
   const auto width = v.Width();
   bool any_known_one = false;
   bool any_unknown = false;
   for (std::size_t i = 0; i < val_w.size(); ++i) {
-    const auto mask = detail::ValidMaskForWord(i, width);
-    const auto state = state_w[i] & mask;
+    const auto mask = detail::ValidBitsMaskForWord(width, i);
+    const auto unknown = unknown_w[i] & mask;
     const auto value = val_w[i] & mask;
-    const auto known_one_bits = value & (~state) & mask;
-    if (state != 0U) {
+    const auto known_one_bits = value & (~unknown) & mask;
+    if (unknown != 0U) {
       any_unknown = true;
     }
     if (known_one_bits != 0U) {
@@ -216,43 +124,47 @@ auto ReductionOr(V src) -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
     return detail::MakeScalarLogicKnown(true);
   }
   if (any_unknown) {
-    return detail::MakeScalarLogicUnknown();
+    return detail::MakeScalarLogicX();
   }
   return detail::MakeScalarLogicKnown(false);
 }
 
-template <detail::ReductionLogicViewLike V>
-auto ReductionXor(V src) -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
-  const auto v = detail::ToConstLogicView(src);
-  const auto val_w = detail::PlaneAccess::ValueWords(v);
-  const auto state_w = detail::PlaneAccess::StateWords(v);
+template <detail::LogicViewLike V>
+auto ReductionXor(V src)
+    -> Logic<detail::ScalarShape{}, Signedness::kUnsigned> {
+  const auto v = detail::ToConstView(src);
+  const auto val_w = detail::PlaneAccess::AlignedValueWords(v);
+  const auto unknown_w = detail::PlaneAccess::AlignedUnknownWords(v);
   const auto width = v.Width();
   std::uint64_t parity_acc = 0;
   for (std::size_t i = 0; i < val_w.size(); ++i) {
-    const auto mask = detail::ValidMaskForWord(i, width);
-    const auto state = state_w[i] & mask;
+    const auto mask = detail::ValidBitsMaskForWord(width, i);
+    const auto unknown = unknown_w[i] & mask;
     const auto value = val_w[i] & mask;
-    if (state != 0U) {
-      return detail::MakeScalarLogicUnknown();
+    if (unknown != 0U) {
+      return detail::MakeScalarLogicX();
     }
-    const auto known_one_bits = value & (~state) & mask;
+    const auto known_one_bits = value & (~unknown) & mask;
     parity_acc ^= static_cast<std::uint64_t>(std::popcount(known_one_bits));
   }
   return detail::MakeScalarLogicKnown((parity_acc & std::uint64_t{1}) != 0U);
 }
 
-template <detail::ReductionLogicViewLike V>
-auto ReductionNand(V src) -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
+template <detail::LogicViewLike V>
+auto ReductionNand(V src)
+    -> Logic<detail::ScalarShape{}, Signedness::kUnsigned> {
   return detail::NotScalar(ReductionAnd(src));
 }
 
-template <detail::ReductionLogicViewLike V>
-auto ReductionNor(V src) -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
+template <detail::LogicViewLike V>
+auto ReductionNor(V src)
+    -> Logic<detail::ScalarShape{}, Signedness::kUnsigned> {
   return detail::NotScalar(ReductionOr(src));
 }
 
-template <detail::ReductionLogicViewLike V>
-auto ReductionXnor(V src) -> Logic<PackedShape<0>{}, Signedness::kUnsigned> {
+template <detail::LogicViewLike V>
+auto ReductionXnor(V src)
+    -> Logic<detail::ScalarShape{}, Signedness::kUnsigned> {
   return detail::NotScalar(ReductionXor(src));
 }
 

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -167,23 +167,23 @@ auto RenderIntegerLiteralAsView(
       "{{{}}};\n",
       target_words, value_init);
   if (target_4state) {
-    std::string state_init;
+    std::string unknown_init;
     for (std::size_t i = 0; i < target_words; ++i) {
-      if (i != 0) state_init += ", ";
+      if (i != 0) unknown_init += ", ";
       const std::uint64_t w =
           (c.state_kind == mir::IntegralStateKind::kFourState &&
            i < c.state_words.size())
               ? c.state_words[i]
               : 0U;
-      state_init += std::format("0x{:x}ULL", w);
+      unknown_init += std::format("0x{:x}ULL", w);
     }
     out += std::format(
-        "  static constexpr std::array<std::uint64_t, {}> kStateWords = "
+        "  static constexpr std::array<std::uint64_t, {}> kUnknownWords = "
         "{{{}}};\n",
-        target_words, state_init);
+        target_words, unknown_init);
     out += std::format(
-        "  return lyra::runtime::ConstLogicView{{kValueWords, kStateWords, 0, "
-        "{}}};\n",
+        "  return lyra::runtime::ConstLogicView{{kValueWords, kUnknownWords, "
+        "0, {}}};\n",
         target_width);
   } else {
     out += std::format(

--- a/src/lyra/runtime/format.cpp
+++ b/src/lyra/runtime/format.cpp
@@ -129,9 +129,9 @@ auto FormatIntegralFourStateNarrow(
   for (std::int32_t i = static_cast<std::int32_t>(v.bit_width) - 1; i >= 0;
        --i) {
     const bool value = ((v.inline_word >> i) & 1U) != 0U;
-    const bool state = ((v.inline_state_word >> i) & 1U) != 0U;
+    const bool unknown = ((v.inline_unknown_word >> i) & 1U) != 0U;
     char ch = '0';
-    if (state) {
+    if (unknown) {
       ch = value ? 'x' : 'z';
     } else {
       ch = value ? '1' : '0';
@@ -195,7 +195,7 @@ auto RuntimeValueView::FromLogicView(ConstLogicView v, bool is_signed)
       .data = IntegralValueView{
           .state = IntegralStateKind::kFourState,
           .inline_word = v.PackValueLowWord(),
-          .inline_state_word = v.PackStateLowWord(),
+          .inline_unknown_word = v.PackUnknownLowWord(),
           .word_count = 1,
           .bit_width = static_cast<std::uint32_t>(v.Width()),
           .is_signed = is_signed,


### PR DESCRIPTION
## Summary

Foundational cleanup of the packed runtime in preparation for upcoming packed operators (equality, shifts, arithmetic). No SV-semantic, runtime, or generated-code behavior changes -- this cut is naming consistency and shared-helper extraction.

The second 4-state plane is renamed `state` -> `unknown` across `ConstLogicView`, `LogicView`, `Logic<>` (members, methods, locals), conversion-internal structs, and the runtime print API. The name now reflects what the plane actually marks (bits not known 0/1, the same axis as SystemVerilog `$isunknown`) and removes collision with unrelated state-like fields (`IntegralStateKind`, `IntegralValueView::state`, `runtime_process::state_`). The 4-state encoding is unchanged: `value=0,unknown=0`->0, `value=1,unknown=0`->1, `value=0,unknown=1`->Z, `value=1,unknown=1`->X.

`packed_words.hpp` now holds the shared substrate that `bitwise.hpp` and `reduction.hpp` previously duplicated: `BitViewLike` / `LogicViewLike` concepts, `ToConstView` overloads, `MaskUnusedTopBits`, the renamed `ValidBitsMaskForWord`, the `PlaneAccess` API renamed to `Aligned*` to make its bit_offset==0 contract obvious, and the canonical scalar vocabulary (`MakeScalarBit`, `MakeScalarLogicKnown`, `MakeScalarLogicX`, `MakeScalarLogicZ`, `NotScalar`). `bitwise.hpp` and `reduction.hpp` are slimmed to their semantic kernels and public templates only.

`render_expr.cpp` emits `kUnknownWords` (was `kStateWords`) so generated C++ stays in sync with the runtime API surface.

## Testing

- `bazel build //...`
- `bazel test //... --test_output=errors` (cpp_tests + diag_render_tests pass)
- `clang-format`, `buildifier`, `prettier` all clean
- Architecture, ASCII, C++ style, and exception policy checks all pass