### PR TITLE
Lower generate-for body via slang loopVariable

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "slang", version = "10.0")
 git_override(
     module_name = "slang",
-    commit = "a9e580e7cae7c657688d56cf89671be0fb57fece",
+    commit = "a254c3d32d7182adefb44bf5880414533a106e32",
     remote = "https://github.com/hankhsu1996/slang.git",
 )
 

--- a/include/lyra/lowering/ast_to_hir/expression/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/lower.hpp
@@ -1,14 +1,9 @@
 #pragma once
 
-#include <optional>
-#include <string_view>
-
 #include <slang/ast/Expression.h>
-#include <slang/ast/symbols/VariableSymbols.h>
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/loop_var.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
 
@@ -21,23 +16,7 @@ auto LowerProcExpr(
 
 auto LowerStructuralExpr(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
-    const slang::ast::Expression& expr) -> diag::Result<hir::Expr>;
-
-// Short-lived state for lowering one loop-generate header's initial / stop
-// / iter expressions. The synthetic loop-variable identity (and its type)
-// is captured lazily on first reference, since slang exposes the
-// iteration-variable's type through the `VariableSymbol` it fabricates for
-// header expressions, not through the canonical genvar declaration symbol.
-struct LoopHeaderState {
-  std::string_view expected_name;
-  const slang::ast::VariableSymbol* synthetic_symbol = nullptr;
-  std::optional<hir::LoopVarDeclId> loop_var_id;
-};
-
-auto LowerLoopHeaderExpr(
-    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ScopeLoweringState& scope_state, const ScopeStack& stack,
-    LoopHeaderState& loop_state, const slang::ast::Expression& expr)
-    -> diag::Result<hir::Expr>;
+    const slang::ast::Expression& expr) -> diag::Result<hir::Expr>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/scope.hpp
+++ b/include/lyra/lowering/ast_to_hir/scope.hpp
@@ -1,17 +1,34 @@
 #pragma once
 
+#include <span>
+
 #include <slang/ast/Scope.h>
+#include <slang/ast/symbols/ValueSymbol.h>
 
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/loop_var.hpp"
 #include "lyra/hir/structural_scope.hpp"
+#include "lyra/hir/type.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
+// home_frame is the frame where the canonical hir::LoopVarDecl lives, not
+// the new scope's frame. For loop-generate body lowering, this is the loop
+// generate's parent frame, so body refs compute correct hops up to it.
+struct ScopeEntryLoopVarBinding {
+  const slang::ast::ValueSymbol* symbol;
+  ScopeFrameId home_frame;
+  hir::LoopVarDeclId loop_var;
+  hir::TypeId type;
+};
+
 auto LowerScopeInto(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     hir::StructuralScope& scope, const slang::ast::Scope& slang_scope,
-    ScopeStack& stack) -> diag::Result<void>;
+    ScopeStack& stack,
+    std::span<const ScopeEntryLoopVarBinding> entry_loop_var_bindings = {})
+    -> diag::Result<void>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -9,7 +9,9 @@
 #include <utility>
 #include <vector>
 
+#include <slang/ast/symbols/ParameterSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
+#include <slang/ast/symbols/ValueSymbol.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 
 #include "lyra/base/internal_error.hpp"
@@ -51,6 +53,15 @@ struct SubroutineBinding {
 
 using SubroutineBindings =
     std::unordered_map<const slang::ast::SubroutineSymbol*, SubroutineBinding>;
+
+struct LoopVarBinding {
+  ScopeFrameId home_frame;
+  hir::LoopVarDeclId loop_var_id;
+  hir::TypeId type;
+};
+
+using LoopVarBindings =
+    std::unordered_map<const slang::ast::ValueSymbol*, LoopVarBinding>;
 
 class UnitLoweringState {
  public:
@@ -112,6 +123,28 @@ class UnitLoweringState {
     return it->second;
   }
 
+  void MapLoopVarBinding(
+      const slang::ast::ValueSymbol& sym, ScopeFrameId home_frame,
+      hir::LoopVarDeclId id, hir::TypeId type) {
+    const auto [_, inserted] = loop_var_bindings_.emplace(
+        &sym, LoopVarBinding{
+                  .home_frame = home_frame, .loop_var_id = id, .type = type});
+    if (!inserted) {
+      throw InternalError(
+          "UnitLoweringState::MapLoopVarBinding: loop variable symbol already "
+          "mapped");
+    }
+  }
+
+  [[nodiscard]] auto LookupLoopVarBinding(const slang::ast::ValueSymbol& sym)
+      const -> std::optional<LoopVarBinding> {
+    const auto it = loop_var_bindings_.find(&sym);
+    if (it == loop_var_bindings_.end()) {
+      return std::nullopt;
+    }
+    return it->second;
+  }
+
   auto MoveHirUnit() -> hir::ModuleUnit {
     return std::move(hir_unit_);
   }
@@ -120,6 +153,7 @@ class UnitLoweringState {
   hir::ModuleUnit hir_unit_;
   StructuralVarBindings structural_var_bindings_;
   SubroutineBindings subroutine_bindings_;
+  LoopVarBindings loop_var_bindings_;
 };
 
 class ScopeStack {
@@ -196,10 +230,13 @@ class ScopeLoweringState {
     return local;
   }
 
-  auto AddLoopVarDecl(hir::LoopVarDecl decl) -> hir::LoopVarDeclId {
+  auto AddLoopVarDecl(const slang::ast::ValueSymbol& sym, hir::TypeId type)
+      -> hir::LoopVarDeclId {
     const hir::LoopVarDeclId id{
         static_cast<std::uint32_t>(scope_->loop_var_decls.size())};
-    scope_->loop_var_decls.push_back(std::move(decl));
+    scope_->loop_var_decls.push_back(
+        hir::LoopVarDecl{.name = std::string{sym.name}, .type = type});
+    unit_state_->MapLoopVarBinding(sym, frame_, id, type);
     return id;
   }
 

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -286,13 +286,31 @@ auto LowerNamedValueProc(
     const slang::ast::NamedValueExpression& named) -> diag::Result<hir::Expr> {
   const auto& mapper = unit_facts.SourceMapper();
   const auto span = mapper.SpanOf(named.sourceRange);
-  if (named.symbol.kind != slang::ast::SymbolKind::Variable) {
+  const auto& sym = named.symbol;
+
+  if (sym.kind == slang::ast::SymbolKind::Variable ||
+      sym.kind == slang::ast::SymbolKind::Parameter) {
+    const auto& value_sym = sym.as<slang::ast::ValueSymbol>();
+    if (auto loop_binding = unit_state.LookupLoopVarBinding(value_sym)) {
+      const auto hops = stack.HopsTo(loop_binding->home_frame);
+      if (!hops.has_value()) {
+        throw InternalError(
+            "LowerProcExpr: loop-var binding home frame is not on the current "
+            "scope stack");
+      }
+      return MakeRefExpr(
+          hir::LoopVarRef{.hops = *hops, .loop_var = loop_binding->loop_var_id},
+          loop_binding->type, span);
+    }
+  }
+
+  if (sym.kind != slang::ast::SymbolKind::Variable) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedNonVariableNamedReference,
         "reference to non-variable declaration is not supported",
         diag::UnsupportedCategory::kFeature);
   }
-  const auto& var = named.symbol.as<slang::ast::VariableSymbol>();
+  const auto& var = sym.as<slang::ast::VariableSymbol>();
 
   if (auto local = proc_state.LookupProceduralVar(var)) {
     const hir::TypeId type_id = proc_state.GetProceduralVarType(*local);
@@ -559,81 +577,13 @@ auto LowerProcExpr(
 
 auto LowerStructuralExpr(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
-    const slang::ast::Expression& expr) -> diag::Result<hir::Expr> {
-  const auto& mapper = unit_facts.SourceMapper();
-  const auto span = mapper.SpanOf(expr.sourceRange);
-  auto type_id_of =
-      [&](const slang::ast::Expression& e) -> diag::Result<hir::TypeId> {
-    auto td = LowerTypeData(*e.type, mapper.SpanOf(e.sourceRange));
-    if (!td) return std::unexpected(std::move(td.error()));
-    return unit_state.AddType(*std::move(td));
-  };
-
-  switch (expr.kind) {
-    case slang::ast::ExpressionKind::IntegerLiteral: {
-      auto type_id = type_id_of(expr);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return MakeIntegerLiteralExpr(
-          expr.as<slang::ast::IntegerLiteral>(), *type_id, span);
-    }
-    case slang::ast::ExpressionKind::UnbasedUnsizedIntegerLiteral: {
-      auto type_id = type_id_of(expr);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return MakeUnbasedUnsizedLiteralExpr(
-          expr.as<slang::ast::UnbasedUnsizedIntegerLiteral>(), *type_id, span);
-    }
-    default:
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
-          "this structural expression form is not supported yet",
-          diag::UnsupportedCategory::kFeature);
-  }
-}
-
-namespace {
-
-auto TryResolveLoopHeaderVar(
-    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
-    ScopeLoweringState& scope_state, LoopHeaderState& loop_state,
-    const slang::ast::VariableSymbol& var)
-    -> diag::Result<std::optional<hir::LoopVarDeclId>> {
-  if (!var.flags.has(slang::ast::VariableFlags::CompilerGenerated)) {
-    return std::nullopt;
-  }
-  if (var.name != loop_state.expected_name) {
-    return std::nullopt;
-  }
-  if (loop_state.synthetic_symbol != nullptr &&
-      loop_state.synthetic_symbol != &var) {
-    throw InternalError(
-        "loop-generate header resolved multiple synthetic loop variables");
-  }
-  loop_state.synthetic_symbol = &var;
-  if (!loop_state.loop_var_id.has_value()) {
-    const auto var_span = unit_facts.SourceMapper().PointSpanOf(var.location);
-    auto type_data = LowerTypeData(var.getType(), var_span);
-    if (!type_data) return std::unexpected(std::move(type_data.error()));
-    const hir::TypeId type_id = unit_state.AddType(*std::move(type_data));
-    loop_state.loop_var_id = scope_state.AddLoopVarDecl(
-        hir::LoopVarDecl{
-            .name = std::string{loop_state.expected_name}, .type = type_id});
-  }
-  return loop_state.loop_var_id;
-}
-
-}  // namespace
-
-auto LowerLoopHeaderExpr(
-    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ScopeLoweringState& scope_state, const ScopeStack& stack,
-    LoopHeaderState& loop_state, const slang::ast::Expression& expr)
-    -> diag::Result<hir::Expr> {
+    const slang::ast::Expression& expr) -> diag::Result<hir::Expr> {
   const auto& mapper = unit_facts.SourceMapper();
   const auto span = mapper.SpanOf(expr.sourceRange);
 
   auto lower_child = [&](const slang::ast::Expression& e) {
-    return LowerLoopHeaderExpr(
-        unit_facts, unit_state, scope_state, stack, loop_state, e);
+    return LowerStructuralExpr(unit_facts, unit_state, scope_state, stack, e);
   };
   auto add_child =
       [&](const slang::ast::Expression& e) -> diag::Result<hir::ExprId> {
@@ -665,38 +615,41 @@ auto LowerLoopHeaderExpr(
 
     case slang::ast::ExpressionKind::NamedValue: {
       const auto& named = expr.as<slang::ast::NamedValueExpression>();
-      if (named.symbol.kind != slang::ast::SymbolKind::Variable) {
+      const auto& sym = named.symbol;
+      if (sym.kind == slang::ast::SymbolKind::Variable ||
+          sym.kind == slang::ast::SymbolKind::Parameter) {
+        const auto& value_sym = sym.as<slang::ast::ValueSymbol>();
+        if (auto loop_binding = unit_state.LookupLoopVarBinding(value_sym)) {
+          const auto hops = stack.HopsTo(loop_binding->home_frame);
+          if (!hops.has_value()) {
+            throw InternalError(
+                "LowerStructuralExpr: loop-var binding home frame is not on "
+                "the current scope stack");
+          }
+          return MakeRefExpr(
+              hir::LoopVarRef{
+                  .hops = *hops, .loop_var = loop_binding->loop_var_id},
+              loop_binding->type, span);
+        }
+      }
+      if (sym.kind != slang::ast::SymbolKind::Variable) {
         return diag::Unsupported(
             mapper.SpanOf(named.sourceRange),
             diag::DiagCode::kUnsupportedNonVariableNamedReference,
             "reference to non-variable declaration is not supported",
             diag::UnsupportedCategory::kFeature);
       }
-      const auto& var = named.symbol.as<slang::ast::VariableSymbol>();
-      auto loop_var_or = TryResolveLoopHeaderVar(
-          unit_facts, unit_state, scope_state, loop_state, var);
-      if (!loop_var_or) {
-        return std::unexpected(std::move(loop_var_or.error()));
-      }
-      if (loop_var_or->has_value()) {
-        const hir::TypeId type_id =
-            scope_state.GetLoopVarDeclType(**loop_var_or);
-        return MakeRefExpr(
-            hir::LoopVarRef{
-                .hops = hir::StructuralHops{.value = 0},
-                .loop_var = **loop_var_or},
-            type_id, span);
-      }
+      const auto& var = sym.as<slang::ast::VariableSymbol>();
       const auto binding = unit_state.LookupStructuralVarBinding(var);
       if (!binding.has_value()) {
         throw InternalError(
-            "LowerLoopHeaderExpr: variable was not bound during scope "
+            "LowerStructuralExpr: variable was not bound during scope "
             "lowering");
       }
       const auto hops = stack.HopsTo(binding->home_frame);
       if (!hops.has_value()) {
         throw InternalError(
-            "LowerLoopHeaderExpr: variable home frame is not on the current "
+            "LowerStructuralExpr: variable home frame is not on the current "
             "scope stack");
       }
       return MakeRefExpr(
@@ -793,9 +746,9 @@ auto LowerLoopHeaderExpr(
 
     default:
       return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedExpressionForm,
-          "this expression form is not supported yet",
-          diag::UnsupportedCategory::kOperation);
+          span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
+          "this structural expression form is not supported yet",
+          diag::UnsupportedCategory::kFeature);
   }
 }
 

--- a/src/lyra/lowering/ast_to_hir/generate.cpp
+++ b/src/lyra/lowering/ast_to_hir/generate.cpp
@@ -9,6 +9,7 @@
 #include <slang/ast/Expression.h>
 #include <slang/ast/symbols/BlockSymbols.h>
 #include <slang/ast/symbols/MemberSymbols.h>
+#include <slang/ast/symbols/ParameterSymbols.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
@@ -18,6 +19,7 @@
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/scope.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
+#include "lyra/lowering/ast_to_hir/type.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -30,6 +32,52 @@ auto AddChildStructuralScope(hir::Generate& gen, hir::StructuralScope scope)
   scope.id = id;
   gen.child_scopes.push_back(std::move(scope));
   return id;
+}
+
+// Derive the per-entry implicit-genvar ParameterSymbol that substitutes for
+// `array.loopVariable` inside the canonical entry body.
+//
+// Invariant: header refs to the loop variable use pointer identity to
+// `array.loopVariable`; body refs use this derived ParameterSymbol. Both are
+// registered as keys in UnitLoweringState's loop-var binding map and resolve
+// to the same hir::LoopVarDeclId.
+//
+// The derivation is necessary because slang gives no API connecting the
+// header `loopVariable` and an entry's implicit genvar parameter -- they
+// share name, source location, and the `isFromGenvar` flag, but are
+// independently allocated objects. See slang
+// source/ast/symbols/BlockSymbols.cpp:794-816 for the construction.
+//
+// Caller must guard array.entries.empty() before calling this helper.
+auto DeriveLoopVariableSubstitution(
+    const slang::ast::GenerateBlockArraySymbol& array,
+    const slang::ast::GenerateBlockSymbol& entry)
+    -> const slang::ast::ParameterSymbol* {
+  if (array.loopVariable == nullptr) {
+    throw InternalError("DeriveLoopVariableSubstitution: missing loopVariable");
+  }
+  if (entry.getParentScope() != &array) {
+    throw InternalError(
+        "DeriveLoopVariableSubstitution: entry is not a direct child of array");
+  }
+
+  const slang::ast::ParameterSymbol* found = nullptr;
+  for (const auto& param : entry.membersOfType<slang::ast::ParameterSymbol>()) {
+    if (!param.isFromGenvar()) continue;
+    if (param.location != array.loopVariable->location) continue;
+    if (param.name != array.loopVariable->name) continue;
+    if (found != nullptr) {
+      throw InternalError(
+          "DeriveLoopVariableSubstitution: ambiguous loop-variable "
+          "substitution");
+    }
+    found = &param;
+  }
+  if (found == nullptr) {
+    throw InternalError(
+        "DeriveLoopVariableSubstitution: missing loop-variable substitution");
+  }
+  return found;
 }
 
 auto AddChildScope(
@@ -70,18 +118,19 @@ auto BuildIfGenerate(
     throw InternalError(
         "BuildIfGenerate: if-generate group has no IfTrue branch");
   }
-  const auto* cond = then_block->conditionExpression;
+  const auto* cond = then_block->getConditionExpression();
   if (cond == nullptr) {
     throw InternalError(
         "BuildIfGenerate: IfTrue branch has no bound condition expression");
   }
-  if (else_block != nullptr && else_block->conditionExpression != cond) {
+  if (else_block != nullptr && else_block->getConditionExpression() != cond) {
     throw InternalError(
         "BuildIfGenerate: sibling branches have mismatched condition "
         "expressions");
   }
 
-  auto cond_expr = LowerStructuralExpr(unit_facts, unit_state, *cond);
+  auto cond_expr =
+      LowerStructuralExpr(unit_facts, unit_state, parent_state, stack, *cond);
   if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
   const hir::ExprId cond_id = parent_state.AddExpr(*std::move(cond_expr));
 
@@ -111,20 +160,21 @@ auto BuildCaseGenerate(
     throw InternalError(
         "BuildCaseGenerate: case-generate sibling group is empty");
   }
-  const auto* discriminator = siblings.front()->conditionExpression;
+  const auto* discriminator = siblings.front()->getConditionExpression();
   if (discriminator == nullptr) {
     throw InternalError(
         "BuildCaseGenerate: sibling has no condition expression");
   }
   for (const auto* block : siblings) {
-    if (block->conditionExpression != discriminator) {
+    if (block->getConditionExpression() != discriminator) {
       throw InternalError(
           "BuildCaseGenerate: siblings have mismatched condition "
           "expressions");
     }
   }
 
-  auto cond_expr = LowerStructuralExpr(unit_facts, unit_state, *discriminator);
+  auto cond_expr = LowerStructuralExpr(
+      unit_facts, unit_state, parent_state, stack, *discriminator);
   if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
   const hir::ExprId cond_id = parent_state.AddExpr(*std::move(cond_expr));
 
@@ -139,8 +189,8 @@ auto BuildCaseGenerate(
         std::vector<hir::ExprId> labels;
         labels.reserve(block->caseItemExpressions.size());
         for (const auto* label_expr : block->caseItemExpressions) {
-          auto label_expr_lowered =
-              LowerStructuralExpr(unit_facts, unit_state, *label_expr);
+          auto label_expr_lowered = LowerStructuralExpr(
+              unit_facts, unit_state, parent_state, stack, *label_expr);
           if (!label_expr_lowered)
             return std::unexpected(std::move(label_expr_lowered.error()));
           labels.push_back(
@@ -183,48 +233,63 @@ auto BuildLoopGenerate(
     ScopeLoweringState& parent_state, ScopeStack& stack,
     const slang::ast::GenerateBlockArraySymbol& array)
     -> diag::Result<hir::Generate> {
-  if (array.genvar == nullptr || array.initialExpression == nullptr ||
+  const auto* loop_var_sym = array.loopVariable;
+  if (loop_var_sym == nullptr || array.initialExpression == nullptr ||
       array.stopExpression == nullptr || array.iterExpression == nullptr) {
     throw InternalError(
-        "BuildLoopGenerate: GenerateBlockArraySymbol is missing bound "
-        "header expressions or canonical genvar");
+        "BuildLoopGenerate: GenerateBlockArraySymbol is missing loopVariable "
+        "or bound header expressions");
   }
 
-  LoopHeaderState loop_state{
-      .expected_name = array.genvar->name,
-      .synthetic_symbol = nullptr,
-      .loop_var_id = std::nullopt};
+  const auto var_span =
+      unit_facts.SourceMapper().PointSpanOf(loop_var_sym->location);
+  auto type_data = LowerTypeData(loop_var_sym->getType(), var_span);
+  if (!type_data) return std::unexpected(std::move(type_data.error()));
+  const hir::TypeId loop_var_type = unit_state.AddType(*std::move(type_data));
 
-  auto initial_expr = LowerLoopHeaderExpr(
-      unit_facts, unit_state, parent_state, stack, loop_state,
-      *array.initialExpression);
+  const hir::LoopVarDeclId loop_var_id =
+      parent_state.AddLoopVarDecl(*loop_var_sym, loop_var_type);
+
+  auto initial_expr = LowerStructuralExpr(
+      unit_facts, unit_state, parent_state, stack, *array.initialExpression);
   if (!initial_expr) return std::unexpected(std::move(initial_expr.error()));
   const hir::ExprId initial_id = parent_state.AddExpr(*std::move(initial_expr));
 
-  auto stop_expr = LowerLoopHeaderExpr(
-      unit_facts, unit_state, parent_state, stack, loop_state,
-      *array.stopExpression);
+  auto stop_expr = LowerStructuralExpr(
+      unit_facts, unit_state, parent_state, stack, *array.stopExpression);
   if (!stop_expr) return std::unexpected(std::move(stop_expr.error()));
   const hir::ExprId stop_id = parent_state.AddExpr(*std::move(stop_expr));
 
-  auto iter_expr = LowerLoopHeaderExpr(
-      unit_facts, unit_state, parent_state, stack, loop_state,
-      *array.iterExpression);
+  auto iter_expr = LowerStructuralExpr(
+      unit_facts, unit_state, parent_state, stack, *array.iterExpression);
   if (!iter_expr) return std::unexpected(std::move(iter_expr.error()));
   const hir::ExprId iter_id = parent_state.AddExpr(*std::move(iter_expr));
-
-  if (!loop_state.loop_var_id.has_value()) {
-    throw InternalError(
-        "BuildLoopGenerate: loop-generate header did not expose a "
-        "synthetic loop variable");
-  }
 
   hir::Generate gen{};
   const hir::StructuralScopeId loop_scope_id =
       AddChildStructuralScope(gen, hir::StructuralScope{});
 
+  if (!array.entries.empty()) {
+    const auto& canonical_entry = *array.entries.front();
+    const auto* body_param =
+        DeriveLoopVariableSubstitution(array, canonical_entry);
+
+    const ScopeEntryLoopVarBinding body_binding{
+        .symbol = body_param,
+        .home_frame = parent_state.Frame(),
+        .loop_var = loop_var_id,
+        .type = loop_var_type,
+    };
+
+    auto& loop_scope = gen.child_scopes.at(loop_scope_id.value);
+    auto r = LowerScopeInto(
+        unit_facts, unit_state, loop_scope, canonical_entry, stack,
+        std::span{&body_binding, 1});
+    if (!r) return std::unexpected(std::move(r.error()));
+  }
+
   gen.data = hir::LoopGenerate{
-      .loop_var = *loop_state.loop_var_id,
+      .loop_var = loop_var_id,
       .initial = initial_id,
       .stop = stop_id,
       .iter = iter_id,

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -1,5 +1,6 @@
 #include "lyra/lowering/ast_to_hir/scope.hpp"
 
+#include <cstdint>
 #include <expected>
 #include <unordered_set>
 #include <utility>
@@ -11,11 +12,12 @@
 #include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/BlockSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
+#include <slang/ast/symbols/ValueSymbol.h>
 #include <slang/ast/symbols/VariableSymbols.h>
-#include <slang/syntax/SyntaxNode.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/loop_var.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/type.hpp"
@@ -56,17 +58,12 @@ auto IsCaseConstruct(
   return false;
 }
 
-}  // namespace
-
-auto LowerScopeInto(
-    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
-    hir::StructuralScope& scope, const slang::ast::Scope& slang_scope,
-    ScopeStack& stack) -> diag::Result<void> {
+auto LowerScopeMembersInto(
+    const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
+    ScopeStack& stack, const slang::ast::Scope& slang_scope)
+    -> diag::Result<void> {
   const auto& mapper = unit_facts.SourceMapper();
-  const ScopeStackGuard guard(stack);
-  ScopeLoweringState scope_state(unit_state, scope, guard.Frame());
-
-  scope.time_resolution = ResolveTimeResolution(slang_scope.getTimeScale());
+  auto& unit_state = scope_state.UnitState();
 
   for (const auto& member : slang_scope.members()) {
     if (member.kind != slang::ast::SymbolKind::Variable) {
@@ -88,7 +85,7 @@ auto LowerScopeInto(
     // via a slang/Lyra integration bug.
     if (std::holds_alternative<hir::VoidType>(*type_data)) {
       throw InternalError(
-          "LowerScopeInto: variable declaration produced void type");
+          "LowerScopeMembersInto: variable declaration produced void type");
     }
     const auto type_id = unit_state.AddType(*std::move(type_data));
     scope_state.AddStructuralVar(var, type_id);
@@ -123,7 +120,11 @@ auto LowerScopeInto(
     scope_state.AddProcess(*std::move(p));
   }
 
-  std::unordered_set<const slang::syntax::SyntaxNode*> consumed;
+  // slang assigns constructIndex per direct generate construct in the
+  // containing scope (Scope.cpp:927-1033): incremented after each construct,
+  // shared across siblings of one if/case generate. So within this scope's
+  // members it is unique per construct and serves as the sibling-grouping key.
+  std::unordered_set<std::uint32_t> consumed_construct_indices;
   for (const auto& member : slang_scope.members()) {
     switch (member.kind) {
       case slang::ast::SymbolKind::GenerateBlockArray: {
@@ -137,12 +138,7 @@ auto LowerScopeInto(
 
       case slang::ast::SymbolKind::GenerateBlock: {
         const auto& block = member.as<slang::ast::GenerateBlockSymbol>();
-        const auto* syntax = block.generateConstructSyntax;
-        if (syntax == nullptr) {
-          throw InternalError(
-              "LowerScopeInto: generate block has no construct syntax");
-        }
-        if (!consumed.insert(syntax).second) {
+        if (!consumed_construct_indices.insert(block.constructIndex).second) {
           continue;
         }
 
@@ -152,7 +148,7 @@ auto LowerScopeInto(
             continue;
           }
           const auto& sibling = candidate.as<slang::ast::GenerateBlockSymbol>();
-          if (sibling.generateConstructSyntax == syntax) {
+          if (sibling.constructIndex == block.constructIndex) {
             siblings.push_back(&sibling);
           }
         }
@@ -177,6 +173,28 @@ auto LowerScopeInto(
   }
 
   return {};
+}
+
+}  // namespace
+
+auto LowerScopeInto(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    hir::StructuralScope& scope, const slang::ast::Scope& slang_scope,
+    ScopeStack& stack,
+    std::span<const ScopeEntryLoopVarBinding> entry_loop_var_bindings)
+    -> diag::Result<void> {
+  const ScopeStackGuard guard(stack);
+  ScopeLoweringState scope_state(unit_state, scope, guard.Frame());
+  scope.time_resolution = ResolveTimeResolution(slang_scope.getTimeScale());
+  for (const auto& binding : entry_loop_var_bindings) {
+    if (binding.symbol == nullptr) {
+      throw InternalError(
+          "LowerScopeInto: null scope-entry loop-var binding symbol");
+    }
+    unit_state.MapLoopVarBinding(
+        *binding.symbol, binding.home_frame, binding.loop_var, binding.type);
+  }
+  return LowerScopeMembersInto(unit_facts, scope_state, stack, slang_scope);
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/tests/cases/dump/loop_body_nested_generate/case.yaml
+++ b/tests/cases/dump/loop_body_nested_generate/case.yaml
@@ -1,0 +1,18 @@
+id: dump.loop_body_nested_generate
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - 'LoopVarDecl[0] "i"'
+      - "Generate LoopGenerate loop_var=LoopVar[0]"
+      - "RefExpr LoopVar[0](hops=1)"
+      - "BinaryExpr op=Equality"
+      - "Generate IfGenerate"
+      - "then_scope:"
+      - 'StructuralVar[0] "y"'

--- a/tests/cases/dump/loop_body_nested_generate/main.sv
+++ b/tests/cases/dump/loop_body_nested_generate/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  for (genvar i = 0; i < 2; i = i + 1) begin : g
+    if (i == 0) begin : h
+      int y;
+    end
+  end
+endmodule

--- a/tests/cases/dump/loop_body_process_using_loop_var/case.yaml
+++ b/tests/cases/dump/loop_body_process_using_loop_var/case.yaml
@@ -1,0 +1,17 @@
+id: dump.loop_body_process_using_loop_var
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - 'LoopVarDecl[0] "i"'
+      - "Generate LoopGenerate loop_var=LoopVar[0]"
+      - "Process (Initial)"
+      - 'ProceduralVar[0] "x"'
+      - "RefExpr LoopVar[0](hops=1)"
+      - "AssignExpr"

--- a/tests/cases/dump/loop_body_process_using_loop_var/main.sv
+++ b/tests/cases/dump/loop_body_process_using_loop_var/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  for (genvar i = 0; i < 2; i = i + 1) begin : g
+    initial begin
+      int x;
+      x = i;
+    end
+  end
+endmodule

--- a/tests/cases/dump/loop_body_structural_var/case.yaml
+++ b/tests/cases/dump/loop_body_structural_var/case.yaml
@@ -1,0 +1,16 @@
+id: dump.loop_body_structural_var
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - 'LoopVarDecl[0] "i"'
+      - "Generate LoopGenerate loop_var=LoopVar[0]"
+      - "RefExpr LoopVar[0](hops=0)"
+      - "scope:"
+      - 'StructuralVar[0] "x"'

--- a/tests/cases/dump/loop_body_structural_var/main.sv
+++ b/tests/cases/dump/loop_body_structural_var/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  for (genvar i = 0; i < 2; i = i + 1) begin : g
+    int x;
+  end
+endmodule

--- a/tests/cases/dump/loop_generate_empty/case.yaml
+++ b/tests/cases/dump/loop_generate_empty/case.yaml
@@ -1,0 +1,20 @@
+id: dump.loop_generate_empty
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - 'LoopVarDecl[0] "i"'
+      - "Generate LoopGenerate loop_var=LoopVar[0]"
+      - "scope:"
+    not_contains:
+      - "StructuralVar"
+      - "Process"
+      - "ProceduralVar"
+      - "Generate IfGenerate"
+      - "Generate CaseGenerate"

--- a/tests/cases/dump/loop_generate_empty/main.sv
+++ b/tests/cases/dump/loop_generate_empty/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  for (genvar i = 0; i < 0; i = i + 1) begin : g
+    int x;
+  end
+endmodule

--- a/tests/cases/dump/loop_generate_inline_and_external_genvar/case.yaml
+++ b/tests/cases/dump/loop_generate_inline_and_external_genvar/case.yaml
@@ -1,0 +1,17 @@
+id: dump.loop_generate_inline_and_external_genvar
+tags: [dump]
+input:
+  command: [dump, hir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - 'LoopVarDecl[0] "g"'
+      - 'LoopVarDecl[1] "i"'
+      - "Generate LoopGenerate loop_var=LoopVar[0]"
+      - "Generate LoopGenerate loop_var=LoopVar[1]"
+      - 'StructuralVar[0] "x"'
+      - 'StructuralVar[0] "y"'

--- a/tests/cases/dump/loop_generate_inline_and_external_genvar/main.sv
+++ b/tests/cases/dump/loop_generate_inline_and_external_genvar/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  genvar g;
+  for (g = 0; g < 2; g = g + 1) begin : a
+    int x;
+  end
+
+  for (genvar i = 0; i < 2; i = i + 1) begin : b
+    int y;
+  end
+endmodule

--- a/tests/cases/dump/mir_loop_body_structural_var/case.yaml
+++ b/tests/cases/dump/mir_loop_body_structural_var/case.yaml
@@ -1,0 +1,15 @@
+id: dump.mir_loop_body_structural_var
+tags: [dump]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - 'StructuralScope "gen0_loop"'
+      - '[0] "x"'
+      - "Stmt[0] ForStmt"
+      - "ConstructOwnedObjectStmt"

--- a/tests/cases/dump/mir_loop_body_structural_var/main.sv
+++ b/tests/cases/dump/mir_loop_body_structural_var/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  for (genvar i = 0; i < 2; i = i + 1) begin : g
+    int x;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Generate-for bodies were silently dropped at AST->HIR. `BuildLoopGenerate` appended a default-constructed empty `hir::StructuralScope` and never lowered the loop body, so any `int x;`, `initial`, or nested generate inside `for (genvar i ...) begin ... end` disappeared before HIR. This change brings the body in, replaces the old genvar name-matching heuristic with pointer-keyed loop-var bindings, and adopts slang's new `GenerateBlockArraySymbol::loopVariable` API.

The slang pin moves from `a9e580e7c` to `a254c3d32` on `feature/lyra-integration` (final form of upstream PR #1801, which renamed `genvar` to `loopVariable` and adds bound stop/iter expressions referencing it symbolically).

## Design

`UnitLoweringState` gains a `LoopVarBinding` map keyed by `const slang::ast::ValueSymbol*` (common base of `VariableSymbol` and `ParameterSymbol`). Two pointer keys map to the same `hir::LoopVarDeclId`:

- **Header refs** use pointer identity to `array.loopVariable` (slang gives this directly).
- **Body refs** use a derived per-entry implicit `ParameterSymbol` (`isFromGenvar()==true`, same name and source location, direct member of the canonical entry). The derivation is necessary because slang exposes no API connecting `loopVariable` and the entry's implicit param; they are independently allocated. The derived predicates are necessary and sufficient given slang's construction at `BlockSymbols.cpp:794-816`.

Both bindings record the loop-generate's parent scope frame as `home_frame`, so:

- Headers (lowered in parent scope): `LoopVarRef[hops=0, ...]`
- Body refs (in the loop child scope): `LoopVarRef[hops=1, ...]`
- Nested scopes under the body: `hops>=1`

`LowerScopeInto` now takes an optional `std::span<const ScopeEntryLoopVarBinding>` parameter so loop-generate body lowering can install its body substitution at scope-entry without a special wrapper API. The struct carries an explicit `home_frame` (rather than deriving from the new scope's frame) because the canonical `LoopVarDecl` lives in the parent scope, not the body.

The `LoopHeaderState`/`LowerLoopHeaderExpr`/`TryResolveLoopHeaderVar` heuristic is removed. `LowerStructuralExpr` now consults the binding map by pointer; `LowerNamedValueProc` does the same so process-body refs to the loop var produce a clean HIR shape (HIR->MIR rejection of `LoopVarRef` in process bodies is a separate follow-up).

`MapLoopVarBinding` rejects duplicate keys with `InternalError` to catch scope-model bugs early. `LowerScopeInto` rejects null binding symbols at the boundary.

A drive-by fixes the slang `generateConstructSyntax` removal: scope.cpp now groups sibling generate blocks by `constructIndex` (provably unique per direct generate construct in a containing scope per `slang/source/ast/Scope.cpp:927-1033`), and uses `getConditionExpression()` accessor instead of direct union access.

## Testing

Five new HIR dump cases plus one MIR dump case under `tests/cases/dump/`:

- `loop_body_structural_var` -- body `int x;` survives into the loop child scope
- `loop_body_process_using_loop_var` -- `initial begin x = i; end` produces `LoopVarRef[hops=1]` (HIR-only; HIR->MIR LoopVarRef-in-process is tracked as a follow-up)
- `loop_body_nested_generate` -- `if (i == 0) begin int y; end` resolves `i` via the body substitution
- `loop_generate_inline_and_external_genvar` -- both forms produce populated child scopes
- `loop_generate_empty` -- `for (i=0; i<0; ...)` yields a `LoopGenerate` with an empty child scope, no fabricated body substitution
- `mir_loop_body_structural_var` -- MIR `ForStmt` + `ConstructOwnedObjectStmt` + child `StructuralScope` containing the body var

`bazel build //...` and `bazel test //... --test_output=errors` are green; all policy checks pass.