### PR TITLE
Tighten lowering map invariants and strengthen MIR dump

### DIFF
--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -90,9 +90,14 @@ class UnitLoweringState {
   void MapStructuralVarBinding(
       const slang::ast::VariableSymbol& var, ScopeFrameId home_frame,
       hir::StructuralVarId local, hir::TypeId type) {
-    structural_var_bindings_.emplace(
+    const auto [_, inserted] = structural_var_bindings_.emplace(
         &var, StructuralVarBinding{
                   .home_frame = home_frame, .var_id = local, .type = type});
+    if (!inserted) {
+      throw InternalError(
+          "UnitLoweringState::MapStructuralVarBinding: structural variable "
+          "symbol already mapped");
+    }
   }
 
   [[nodiscard]] auto LookupStructuralVarBinding(
@@ -108,9 +113,14 @@ class UnitLoweringState {
   void MapSubroutineBinding(
       const slang::ast::SubroutineSymbol& sym, ScopeFrameId owner_frame,
       hir::StructuralSubroutineId local) {
-    subroutine_bindings_.emplace(
+    const auto [_, inserted] = subroutine_bindings_.emplace(
         &sym,
         SubroutineBinding{.owner_frame = owner_frame, .subroutine_id = local});
+    if (!inserted) {
+      throw InternalError(
+          "UnitLoweringState::MapSubroutineBinding: subroutine symbol already "
+          "mapped");
+    }
   }
 
   [[nodiscard]] auto LookupSubroutineBinding(
@@ -317,7 +327,12 @@ class ProcessLoweringState {
         static_cast<std::uint32_t>(hir_process_.procedural_vars.size())};
     hir_process_.procedural_vars.push_back(
         hir::ProceduralVarDecl{.name = std::string{var.name}, .type = type});
-    procedural_var_bindings_.emplace(&var, id);
+    const auto [_, inserted] = procedural_var_bindings_.emplace(&var, id);
+    if (!inserted) {
+      throw InternalError(
+          "ProcessLoweringState::AddProceduralVar: procedural variable symbol "
+          "already mapped");
+    }
     return id;
   }
 

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -84,10 +84,12 @@ class UnitLoweringState {
   }
 
   void MapType(hir::TypeId hir_id, mir::TypeId mir_id) {
-    if (hir_id.value >= type_map_.size()) {
-      type_map_.resize(hir_id.value + 1);
+    if (hir_id.value != type_map_.size()) {
+      throw InternalError(
+          "UnitLoweringState::MapType: HIR types must be mapped in HIR id "
+          "order");
     }
-    type_map_[hir_id.value] = mir_id;
+    type_map_.emplace_back(mir_id);
   }
 
   [[nodiscard]] auto Builtins() const -> const BuiltinMirTypes& {
@@ -175,15 +177,12 @@ class StructuralScopeLoweringState {
 
   void MapStructuralVar(
       hir::StructuralVarId hir_id, mir::StructuralVarId mir_id) {
-    if (hir_id.value >= structural_var_map_.size()) {
-      structural_var_map_.resize(hir_id.value + 1);
-    }
-    if (structural_var_map_[hir_id.value].has_value()) {
+    if (hir_id.value != structural_var_map_.size()) {
       throw InternalError(
-          "StructuralScopeLoweringState::MapStructuralVar: HIR structural var "
-          "already mapped");
+          "StructuralScopeLoweringState::MapStructuralVar: HIR structural "
+          "vars must be mapped in HIR id order");
     }
-    structural_var_map_[hir_id.value] = mir_id;
+    structural_var_map_.push_back(mir_id);
   }
 
   // Walk the scope chain `hops` levels outward and look up `hir_id` in the
@@ -236,15 +235,12 @@ class StructuralScopeLoweringState {
 
   void MapStructuralSubroutine(
       hir::StructuralSubroutineId hir_id, mir::StructuralSubroutineId mir_id) {
-    if (hir_id.value >= structural_subroutine_map_.size()) {
-      structural_subroutine_map_.resize(hir_id.value + 1);
-    }
-    if (structural_subroutine_map_[hir_id.value].has_value()) {
+    if (hir_id.value != structural_subroutine_map_.size()) {
       throw InternalError(
           "StructuralScopeLoweringState::MapStructuralSubroutine: HIR "
-          "structural subroutine already mapped");
+          "structural subroutines must be mapped in HIR id order");
     }
-    structural_subroutine_map_[hir_id.value] = mir_id;
+    structural_subroutine_map_.push_back(mir_id);
   }
 
   [[nodiscard]] auto TranslateStructuralSubroutine(
@@ -261,13 +257,12 @@ class StructuralScopeLoweringState {
       hir::StructuralHops hops, hir::StructuralVarId hir_id) const
       -> mir::StructuralVarId {
     if (hops.value == 0) {
-      if (hir_id.value >= structural_var_map_.size() ||
-          !structural_var_map_[hir_id.value].has_value()) {
+      if (hir_id.value >= structural_var_map_.size()) {
         throw InternalError(
             "StructuralScopeLoweringState::TranslateStructuralVar: unmapped "
             "HIR structural var");
       }
-      return *structural_var_map_[hir_id.value];
+      return structural_var_map_[hir_id.value];
     }
     if (parent_ == nullptr) {
       throw InternalError(
@@ -303,13 +298,12 @@ class StructuralScopeLoweringState {
       hir::StructuralHops hops, hir::StructuralSubroutineId hir_id) const
       -> mir::StructuralSubroutineId {
     if (hops.value == 0) {
-      if (hir_id.value >= structural_subroutine_map_.size() ||
-          !structural_subroutine_map_[hir_id.value].has_value()) {
+      if (hir_id.value >= structural_subroutine_map_.size()) {
         throw InternalError(
             "StructuralScopeLoweringState::TranslateStructuralSubroutine: "
             "unmapped HIR subroutine");
       }
-      return *structural_subroutine_map_[hir_id.value];
+      return structural_subroutine_map_[hir_id.value];
     }
     if (parent_ == nullptr) {
       throw InternalError(
@@ -322,10 +316,9 @@ class StructuralScopeLoweringState {
 
   const StructuralScopeLoweringState* parent_;
   mir::StructuralScope* scope_;
-  std::vector<std::optional<mir::StructuralVarId>> structural_var_map_;
+  std::vector<mir::StructuralVarId> structural_var_map_;
   std::vector<std::optional<mir::StructuralParamId>> structural_param_map_;
-  std::vector<std::optional<mir::StructuralSubroutineId>>
-      structural_subroutine_map_;
+  std::vector<mir::StructuralSubroutineId> structural_subroutine_map_;
 };
 
 struct ProceduralVarBinding {
@@ -359,26 +352,22 @@ class ProcessLoweringState {
 
   void MapProceduralVar(
       hir::ProceduralVarId hir_id, ProceduralVarBinding binding) {
-    if (hir_id.value >= bindings_.size()) {
-      bindings_.resize(hir_id.value + 1);
-    }
-    if (bindings_[hir_id.value].has_value()) {
+    if (hir_id.value != bindings_.size()) {
       throw InternalError(
-          "ProcessLoweringState::MapProceduralVar: HIR ProceduralVarId "
-          "already mapped (duplicate VarDeclStmt for the same declaration)");
+          "ProcessLoweringState::MapProceduralVar: HIR procedural vars must "
+          "be mapped in HIR id order");
     }
-    bindings_[hir_id.value] = binding;
+    bindings_.push_back(binding);
   }
 
   [[nodiscard]] auto LookupProceduralVar(hir::ProceduralVarId hir_id) const
       -> const ProceduralVarBinding& {
-    if (hir_id.value >= bindings_.size() ||
-        !bindings_[hir_id.value].has_value()) {
+    if (hir_id.value >= bindings_.size()) {
       throw InternalError(
           "ProcessLoweringState::LookupProceduralVar: unmapped HIR "
           "procedural var");
     }
-    return *bindings_[hir_id.value];
+    return bindings_[hir_id.value];
   }
 
   [[nodiscard]] auto TranslateProceduralVar(hir::ProceduralVarId hir_id) const
@@ -401,7 +390,7 @@ class ProcessLoweringState {
  private:
   TimeResolution time_resolution_;
   std::uint32_t procedural_depth_ = 0;
-  std::vector<std::optional<ProceduralVarBinding>> bindings_;
+  std::vector<ProceduralVarBinding> bindings_;
 };
 
 class ProceduralDepthGuard {
@@ -426,16 +415,19 @@ class ProceduralDepthGuard {
 class ConstructorLoweringState {
  public:
   void MapLoopVar(hir::LoopVarDeclId hir_id, mir::ProceduralVarRef ref) {
-    if (hir_id.value >= map_.size()) {
-      map_.resize(hir_id.value + 1);
+    if (hir_id.value != map_.size()) {
+      throw InternalError(
+          "ConstructorLoweringState::MapLoopVar: HIR loop vars must be mapped "
+          "in HIR id order");
     }
-    map_[hir_id.value] = ref;
+    map_.push_back(ref);
   }
 
   [[nodiscard]] auto TranslateLoopVar(hir::LoopVarDeclId hir_id) const
       -> mir::ProceduralVarRef {
     if (hir_id.value >= map_.size()) {
-      throw InternalError("TranslateLoopVar: unmapped HIR loop var");
+      throw InternalError(
+          "ConstructorLoweringState::TranslateLoopVar: unmapped HIR loop var");
     }
     return map_[hir_id.value];
   }

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -83,7 +83,7 @@ struct ConstructOwnedObjectStmt {
 };
 
 struct ForInitDecl {
-  ProceduralVarRef local = {};
+  ProceduralVarRef induction_var = {};
   std::optional<ExprId> init;
 };
 

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -25,8 +25,8 @@ auto RenderForInit(const RenderContext& ctx, const mir::ForInit& init)
   return std::visit(
       Overloaded{
           [&](const mir::ForInitDecl& d) -> diag::Result<std::string> {
-            const auto& lv = ctx.ProceduralScopeAtHops(d.local.hops)
-                                 .vars.at(d.local.var.value);
+            const auto& lv = ctx.ProceduralScopeAtHops(d.induction_var.hops)
+                                 .vars.at(d.induction_var.var.value);
             std::string out =
                 RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), lv.type) +
                 " " + lv.name;

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -380,7 +380,7 @@ auto LowerGenerateAsStmt(
                 .data =
                     mir::ForStmt{
                         .init = {mir::ForInitDecl{
-                            .local = loop_local, .init = init_id}},
+                            .induction_var = loop_local, .init = init_id}},
                         .condition = cond_id,
                         .step = {step_id},
                         .scope = loop_scope_id},

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -293,18 +293,22 @@ class MirDumper {
     throw InternalError("MirDumper: unknown BinaryOp");
   }
 
-  static auto FormatLvalue(const Lvalue& l) -> std::string {
+  [[nodiscard]] auto FormatLvalue(const Lvalue& l) const -> std::string {
     return std::visit(
         Overloaded{
-            [](const StructuralVarRef& r) -> std::string {
+            [this](const StructuralVarRef& r) -> std::string {
+              const auto& owner = ResolveScopeAtHops(r.hops.value);
+              const auto& var = owner.GetStructuralVar(r.var);
               return std::format(
-                  "StructuralVarRef[hops={}, var={}]", r.hops.value,
-                  r.var.value);
+                  "StructuralVarRef[hops={}, var={}] \"{}\"", r.hops.value,
+                  r.var.value, var.name);
             },
-            [](const ProceduralVarRef& r) -> std::string {
+            [this](const ProceduralVarRef& r) -> std::string {
+              const auto& owner = ResolveProceduralScopeAtHops(r.hops.value);
+              const auto& var = owner.vars.at(r.var.value);
               return std::format(
-                  "ProceduralVarRef[hops={}, var={}]", r.hops.value,
-                  r.var.value);
+                  "ProceduralVarRef[hops={}, var={}] \"{}\"", r.hops.value,
+                  r.var.value, var.name);
             },
         },
         l);
@@ -333,6 +337,15 @@ class MirDumper {
       throw InternalError("MirDumper::ResolveScopeAtHops: hops out of range");
     }
     return *scope_stack_[scope_stack_.size() - 1 - hops];
+  }
+
+  [[nodiscard]] auto ResolveProceduralScopeAtHops(std::uint32_t hops) const
+      -> const ProceduralScope& {
+    if (hops >= procedural_scope_stack_.size()) {
+      throw InternalError(
+          "MirDumper::ResolveProceduralScopeAtHops: hops out of range");
+    }
+    return *procedural_scope_stack_[procedural_scope_stack_.size() - 1 - hops];
   }
 
   static auto FormatIntegralConstant(const IntegralConstant& c) -> std::string {
@@ -397,15 +410,19 @@ class MirDumper {
                   "StructuralParamRef[hops={}, param={}] \"{}\"", r.hops.value,
                   r.param.value, param.name);
             },
-            [](const StructuralVarRef& r) -> std::string {
+            [this](const StructuralVarRef& r) -> std::string {
+              const auto& owner = ResolveScopeAtHops(r.hops.value);
+              const auto& var = owner.GetStructuralVar(r.var);
               return std::format(
-                  "StructuralVarRef[hops={}, var={}]", r.hops.value,
-                  r.var.value);
+                  "StructuralVarRef[hops={}, var={}] \"{}\"", r.hops.value,
+                  r.var.value, var.name);
             },
-            [](const ProceduralVarRef& r) -> std::string {
+            [this](const ProceduralVarRef& r) -> std::string {
+              const auto& owner = ResolveProceduralScopeAtHops(r.hops.value);
+              const auto& var = owner.vars.at(r.var.value);
               return std::format(
-                  "ProceduralVarRef[hops={}, var={}]", r.hops.value,
-                  r.var.value);
+                  "ProceduralVarRef[hops={}, var={}] \"{}\"", r.hops.value,
+                  r.var.value, var.name);
             },
             [](const UnaryExpr& u) -> std::string {
               return std::format(
@@ -417,7 +434,7 @@ class MirDumper {
                   "BinaryExpr op={} lhs=Expr[{}] rhs=Expr[{}]",
                   FormatBinaryOp(b.op), b.lhs.value, b.rhs.value);
             },
-            [](const AssignExpr& a) -> std::string {
+            [this](const AssignExpr& a) -> std::string {
               return std::format(
                   "AssignExpr target={} value=Expr[{}]", FormatLvalue(a.target),
                   a.value.value);
@@ -541,6 +558,7 @@ class MirDumper {
   }
 
   void DumpProceduralScope(const ProceduralScope& scope) {
+    procedural_scope_stack_.push_back(&scope);
     if (!scope.vars.empty()) {
       Line("Vars:");
       Indent();
@@ -580,6 +598,7 @@ class MirDumper {
       }
     }
     Dedent();
+    procedural_scope_stack_.pop_back();
   }
 
   void DumpStmt(const ProceduralScope& enclosing, StmtId id) {
@@ -593,11 +612,15 @@ class MirDumper {
               Line(std::format("Stmt[{}] EmptyStmt", id.value));
             },
             [&](const ProceduralVarDeclStmt& s) {
+              const auto& owner =
+                  ResolveProceduralScopeAtHops(s.target.hops.value);
+              const auto& var = owner.vars.at(s.target.var.value);
               Line(
                   std::format(
                       "Stmt[{}] ProceduralVarDeclStmt "
-                      "target=ProceduralVarRef[hops={}, var={}]",
-                      id.value, s.target.hops.value, s.target.var.value));
+                      "target=ProceduralVarRef[hops={}, var={}] \"{}\"",
+                      id.value, s.target.hops.value, s.target.var.value,
+                      var.name));
             },
             [&](const ExprStmt& s) { DumpExprStmt(s, enclosing, id); },
             [&](const BlockStmt& s) { DumpBlockStmt(stmt, s, id); },
@@ -783,11 +806,14 @@ class MirDumper {
                       " = Expr[{}] {}", d.init->value,
                       FormatExpr(enclosing, *d.init));
                 }
+                const auto& owner =
+                    ResolveProceduralScopeAtHops(d.induction_var.hops.value);
+                const auto& var = owner.vars.at(d.induction_var.var.value);
                 Line(
                     std::format(
-                        "[{}] decl ProceduralVarRef[hops={}, var={}]{}", i,
-                        d.induction_var.hops.value, d.induction_var.var.value,
-                        init_str));
+                        "[{}] decl ProceduralVarRef[hops={}, var={}] \"{}\"{}",
+                        i, d.induction_var.hops.value,
+                        d.induction_var.var.value, var.name, init_str));
               },
               [&](const ForInitExpr& e) {
                 Line(
@@ -914,6 +940,7 @@ class MirDumper {
   std::string out_;
   int indent_ = 0;
   std::vector<const StructuralScope*> scope_stack_;
+  std::vector<const ProceduralScope*> procedural_scope_stack_;
 };
 
 }  // namespace

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -786,7 +786,8 @@ class MirDumper {
                 Line(
                     std::format(
                         "[{}] decl ProceduralVarRef[hops={}, var={}]{}", i,
-                        d.local.hops.value, d.local.var.value, init_str));
+                        d.induction_var.hops.value, d.induction_var.var.value,
+                        init_str));
               },
               [&](const ForInitExpr& e) {
                 Line(

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -89,7 +89,7 @@ auto Type::AsPackedArray() const -> const PackedArrayType& {
 
 namespace {
 
-auto AsObjectClass(const CompilationUnit& unit, TypeId type)
+auto AsObjectScope(const CompilationUnit& unit, TypeId type)
     -> std::optional<StructuralScopeId> {
   const auto* obj = std::get_if<ObjectType>(&unit.GetType(type).data);
   if (obj == nullptr) {
@@ -105,7 +105,7 @@ auto IsOwningObjectType(const CompilationUnit& unit, TypeId type) -> bool {
   if (owning == nullptr) {
     return false;
   }
-  return AsObjectClass(unit, owning->pointee).has_value();
+  return AsObjectScope(unit, owning->pointee).has_value();
 }
 
 auto IsVectorOfOwningObjectType(const CompilationUnit& unit, TypeId type)
@@ -121,12 +121,12 @@ auto GetOwnedObjectTarget(const CompilationUnit& unit, TypeId type)
     -> std::optional<StructuralScopeId> {
   const auto& data = unit.GetType(type).data;
   if (const auto* owning = std::get_if<OwningPtrType>(&data)) {
-    return AsObjectClass(unit, owning->pointee);
+    return AsObjectScope(unit, owning->pointee);
   }
   if (const auto* vec = std::get_if<VectorType>(&data)) {
     if (const auto* owning =
             std::get_if<OwningPtrType>(&unit.GetType(vec->element).data)) {
-      return AsObjectClass(unit, owning->pointee);
+      return AsObjectScope(unit, owning->pointee);
     }
   }
   return std::nullopt;

--- a/tests/cases/dump/mir_always_loop/case.yaml
+++ b/tests/cases/dump/mir_always_loop/case.yaml
@@ -16,5 +16,5 @@ expect:
       - "scope (ProceduralScopeId=0):"
       - "BlockStmt scope=ProceduralScopeId{0}"
       - "ProceduralVar[0] \"x\""
-      - "ProceduralVarDeclStmt target=ProceduralVarRef[hops=0, var=0]"
+      - "ProceduralVarDeclStmt target=ProceduralVarRef[hops=0, var=0] \"x\""
       - "AwaitStmt kind=AlwaysBackedge"

--- a/tests/cases/dump/mir_generate_structural_var/case.yaml
+++ b/tests/cases/dump/mir_generate_structural_var/case.yaml
@@ -9,4 +9,4 @@ expect:
   exit: 0
   stdout:
     contains:
-      - "AssignExpr target=StructuralVarRef[hops=1, var=0]"
+      - "AssignExpr target=StructuralVarRef[hops=1, var=0] \"x\""

--- a/tests/cases/dump/mir_local_assign/case.yaml
+++ b/tests/cases/dump/mir_local_assign/case.yaml
@@ -11,9 +11,9 @@ expect:
     contains:
       - "Process[0] Initial"
       - "ProceduralVar[0] \"x\""
-      - "ProceduralVarDeclStmt target=ProceduralVarRef[hops=0, var=0]"
+      - "ProceduralVarDeclStmt target=ProceduralVarRef[hops=0, var=0] \"x\""
       - "ExprStmt"
-      - "AssignExpr target=ProceduralVarRef[hops=0, var=0]"
+      - "AssignExpr target=ProceduralVarRef[hops=0, var=0] \"x\""
       - "BinaryExpr op=Add"
       - "IntegerLiteral(32's{value=0x1})"
       - "IntegerLiteral(32's{value=0x2})"

--- a/tests/cases/dump/mir_mixed_structural_and_procedural_hops/case.yaml
+++ b/tests/cases/dump/mir_mixed_structural_and_procedural_hops/case.yaml
@@ -1,0 +1,13 @@
+id: dump.mir_mixed_structural_and_procedural_hops
+tags: [dump]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "StructuralVarRef[hops=1, var=0] \"root_x\""
+      - "ProceduralVarRef[hops=1, var=0] \"local_x\""

--- a/tests/cases/dump/mir_mixed_structural_and_procedural_hops/main.sv
+++ b/tests/cases/dump/mir_mixed_structural_and_procedural_hops/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  int root_x;
+  if (1) begin : g
+    initial begin
+      int local_x;
+      begin
+        int y;
+        y = root_x + local_x;
+      end
+    end
+  end
+endmodule

--- a/tests/cases/dump/mir_nested_block_local/case.yaml
+++ b/tests/cases/dump/mir_nested_block_local/case.yaml
@@ -11,5 +11,5 @@ expect:
     contains:
       - "ProceduralVar[0] \"x\""
       - "BlockStmt scope=ProceduralScopeId{0}"
-      - "AssignExpr target=ProceduralVarRef[hops=1, var=0]"
+      - "AssignExpr target=ProceduralVarRef[hops=1, var=0] \"x\""
       - "IntegerLiteral(32's{value=0x1})"

--- a/tests/cases/dump/mir_procedural_var_read_two_levels/case.yaml
+++ b/tests/cases/dump/mir_procedural_var_read_two_levels/case.yaml
@@ -1,4 +1,4 @@
-id: dump.mir_generate_structural_var_two_levels
+id: dump.mir_procedural_var_read_two_levels
 tags: [dump]
 input:
   command: [dump, mir]
@@ -9,4 +9,4 @@ expect:
   exit: 0
   stdout:
     contains:
-      - "AssignExpr target=StructuralVarRef[hops=2, var=0] \"x\""
+      - "ProceduralVarRef[hops=2, var=0] \"x\""

--- a/tests/cases/dump/mir_procedural_var_read_two_levels/main.sv
+++ b/tests/cases/dump/mir_procedural_var_read_two_levels/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  initial begin
+    int x;
+    begin
+      begin
+        int y;
+        y = x;
+      end
+    end
+  end
+endmodule

--- a/tests/cases/dump/mir_process_in_generate_mixed_refs/case.yaml
+++ b/tests/cases/dump/mir_process_in_generate_mixed_refs/case.yaml
@@ -10,5 +10,5 @@ expect:
   stdout:
     contains:
       - "ProceduralVar[0] \"y\""
-      - "AssignExpr target=ProceduralVarRef[hops=0, var=0]"
-      - "AssignExpr target=StructuralVarRef[hops=1, var=0]"
+      - "AssignExpr target=ProceduralVarRef[hops=0, var=0] \"y\""
+      - "AssignExpr target=StructuralVarRef[hops=1, var=0] \"x\""

--- a/tests/cases/dump/mir_structural_param_read_one_level/case.yaml
+++ b/tests/cases/dump/mir_structural_param_read_one_level/case.yaml
@@ -1,4 +1,4 @@
-id: dump.mir_generate_structural_var_two_levels
+id: dump.mir_structural_param_read_one_level
 tags: [dump]
 input:
   command: [dump, mir]
@@ -9,4 +9,4 @@ expect:
   exit: 0
   stdout:
     contains:
-      - "AssignExpr target=StructuralVarRef[hops=2, var=0] \"x\""
+      - "StructuralParamRef[hops=1, param=0] \"i\""

--- a/tests/cases/dump/mir_structural_param_read_one_level/main.sv
+++ b/tests/cases/dump/mir_structural_param_read_one_level/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  for (genvar i = 0; i < 2; i = i + 1) begin : g
+    if (1) begin : h
+      initial begin
+        int x;
+        x = i;
+      end
+    end
+  end
+endmodule

--- a/tests/cases/dump/mir_structural_var_read_two_levels/case.yaml
+++ b/tests/cases/dump/mir_structural_var_read_two_levels/case.yaml
@@ -1,4 +1,4 @@
-id: dump.mir_generate_structural_var_two_levels
+id: dump.mir_structural_var_read_two_levels
 tags: [dump]
 input:
   command: [dump, mir]
@@ -9,4 +9,5 @@ expect:
   exit: 0
   stdout:
     contains:
-      - "AssignExpr target=StructuralVarRef[hops=2, var=0] \"x\""
+      - "ProceduralVar[0] \"y\""
+      - "StructuralVarRef[hops=2, var=0] \"root_x\""

--- a/tests/cases/dump/mir_structural_var_read_two_levels/main.sv
+++ b/tests/cases/dump/mir_structural_var_read_two_levels/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  int root_x;
+  if (1) begin : a
+    if (1) begin : b
+      initial begin
+        int y;
+        y = root_x;
+      end
+    end
+  end
+endmodule


### PR DESCRIPTION
## Summary

Two small hardening cuts on top of the recent structural/procedural scope vocabulary reset. The first commit tightens the duplicate-key discipline across every lowering map and cleans two residual MIR naming inconsistencies. The second commit makes MIR dump consistently resolve variable names for every ref type and adds the test coverage that was missing for non-trivial hops cases.

No lowering semantics or backend C++ object model changed. The MIR shape on disk is unchanged.

## Tighten lowering map invariants and clean MIR naming

The pre-reset audit flagged five Map* helpers that silently accepted duplicate keys (three first-wins on unordered_map, two silent overwrites on indexed vectors). All five now reject duplicates explicitly. AST-to-HIR symbol-pointer maps (`MapStructuralVarBinding`, `MapSubroutineBinding`, the procedural-var symbol map inside `AddProceduralVar`) check the `inserted` flag from `emplace` and throw `InternalError` on duplicates. HIR-to-MIR id maps (`MapType`, `MapStructuralVar`, `MapStructuralSubroutine`, `MapProceduralVar`, `ConstructorLoweringState::MapLoopVar`) now use plain `vector<T>` with an append-order invariant: `hir_id.value` must equal the current map size, and the value is appended via `push_back`. Because lowering visits HIR ids in order, this rules out gaps, overwrite, and out-of-order insertion in one shape. The previously-compliant maps that used `vector<optional<T>>` were converted to the same shape; only `MapLoopVarAsStructuralParam` keeps `vector<optional<>>` because its keys come from the parent scope and are sparse.

Two small naming cleanups: `mir::ForInitDecl::local` becomes `induction_var` to match the rest of the MIR id-naming convention, and the file-local helper `AsObjectClass` in `src/lyra/mir/type.cpp` becomes `AsObjectScope` to match the surrounding `ObjectType`/`StructuralScopeId` vocabulary.

## Resolve names in MIR ref dumps and add hops coverage

`MirDumper` previously resolved names for `StructuralParamRef` and `StructuralSubroutineRef` (which walk a structural scope stack) but printed only raw ids for `StructuralVarRef` and `ProceduralVarRef`. This commit adds a parallel `procedural_scope_stack_` plus `ResolveProceduralScopeAtHops` helper, threaded through `DumpProceduralScope` push/pop so the chain stays in sync as nested begin/end blocks are dumped. Both ref kinds now emit `[hops=N, var=K] "name"`. `ProceduralVarDeclStmt` and `ForInitDecl::induction_var` print sites are updated to the same shape. Six existing dump tests were updated to match the resolved-name output.

Four new dump tests cover the cross-axis hops cases that the post-reset matrix was missing: `mir_structural_var_read_two_levels` exercises `StructuralVarRef[hops=2]`, `mir_procedural_var_read_two_levels` exercises `ProceduralVarRef[hops=2]` from a doubly-nested begin/end, `mir_mixed_structural_and_procedural_hops` puts both `hops>0` ref kinds in the same expression body, and `mir_structural_param_read_one_level` confirms `StructuralParamRef[hops=1]` is representable from inside a nested if-generate sitting inside a for-generate.

## Testing

`bazel build //...` and `bazel test //... --test_output=errors` pass. All four new dump cases are picked up by the `dump`-tagged suite registered in `tests/suites.yaml`.