### PR TITLE
Lower procedural if/else through HIR and MIR

### DIFF
--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -37,6 +37,12 @@ struct BlockStmt {
   std::vector<StmtId> statements;
 };
 
+struct IfStmt {
+  ExprId condition;
+  StmtId then_stmt;
+  std::optional<StmtId> else_stmt;
+};
+
 struct DelayControl {
   ExprId duration;
 };
@@ -50,8 +56,8 @@ struct TimedStmt {
   StmtId stmt;
 };
 
-using StmtData =
-    std::variant<EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, TimedStmt>;
+using StmtData = std::variant<
+    EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, IfStmt, TimedStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -602,6 +602,28 @@ class HirDumper {
               }
               Dedent();
             },
+            [&](const IfStmt& i) {
+              Line(
+                  std::format(
+                      "Stmt[{}] IfStmt cond=Expr[{}]", id.value,
+                      i.condition.value));
+              Indent();
+              Line(
+                  std::format(
+                      "Expr[{}] {}", i.condition.value,
+                      FormatProcExpr(p, i.condition)));
+              Line("then:");
+              Indent();
+              DumpStmt(p, i.then_stmt);
+              Dedent();
+              if (i.else_stmt.has_value()) {
+                Line("else:");
+                Indent();
+                DumpStmt(p, *i.else_stmt);
+                Dedent();
+              }
+              Dedent();
+            },
             [&](const TimedStmt& t) {
               Line(std::format("Stmt[{}] TimedStmt", id.value));
               Indent();

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -9,6 +9,7 @@
 #include <slang/ast/Statement.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/TimingControl.h>
+#include <slang/ast/statements/ConditionalStatements.h>
 #include <slang/ast/statements/MiscStatements.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 
@@ -149,6 +150,52 @@ auto LowerStatement(
       return hir::Stmt{
           .label = std::nullopt,
           .data = hir::ExprStmt{.expr = id},
+          .span = span};
+    }
+
+    case slang::ast::StatementKind::Conditional: {
+      const auto& cs = stmt.as<slang::ast::ConditionalStatement>();
+      if (cs.check != slang::ast::UniquePriorityCheck::None) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedStatementForm,
+            "unique/priority qualifiers on if are not yet supported",
+            diag::UnsupportedCategory::kFeature);
+      }
+      if (cs.conditions.size() != 1) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedStatementForm,
+            "multi-condition if expressions are not yet supported",
+            diag::UnsupportedCategory::kFeature);
+      }
+      const auto& cond = cs.conditions.front();
+      if (cond.pattern != nullptr) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedStatementForm,
+            "pattern matching in if conditions is not yet supported",
+            diag::UnsupportedCategory::kFeature);
+      }
+      auto cond_expr = LowerProcExpr(
+          unit_facts, scope_state.UnitState(), proc_state, stack, *cond.expr);
+      if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
+      const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_expr));
+      auto then_stmt =
+          LowerStatement(unit_facts, proc_state, scope_state, stack, cs.ifTrue);
+      if (!then_stmt) return std::unexpected(std::move(then_stmt.error()));
+      const hir::StmtId then_id = proc_state.AddStmt(*std::move(then_stmt));
+      std::optional<hir::StmtId> else_id;
+      if (cs.ifFalse != nullptr) {
+        auto else_stmt = LowerStatement(
+            unit_facts, proc_state, scope_state, stack, *cs.ifFalse);
+        if (!else_stmt) return std::unexpected(std::move(else_stmt.error()));
+        else_id = proc_state.AddStmt(*std::move(else_stmt));
+      }
+      return hir::Stmt{
+          .label = std::nullopt,
+          .data =
+              hir::IfStmt{
+                  .condition = cond_id,
+                  .then_stmt = then_id,
+                  .else_stmt = else_id},
           .span = span};
     }
 

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -167,6 +167,58 @@ auto LowerStmt(
                 .data = mir::BlockStmt{.scope = scope_id},
                 .child_procedural_scopes = std::move(child_scopes)};
           },
+          [&](const hir::IfStmt& i) -> diag::Result<mir::Stmt> {
+            auto cond_expr_or = LowerExpr(
+                unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+                hir_proc.exprs.at(i.condition.value));
+            if (!cond_expr_or) {
+              return std::unexpected(std::move(cond_expr_or.error()));
+            }
+            const mir::ExprId cond_id =
+                proc_scope_state.AddExpr(*std::move(cond_expr_or));
+
+            auto lower_branch = [&](hir::StmtId branch_hir_id)
+                -> diag::Result<std::pair<mir::ProceduralScope, mir::StmtId>> {
+              ProceduralScopeLoweringState branch_state;
+              ProceduralDepthGuard depth_guard{proc_state};
+              const hir::Stmt& branch_hir =
+                  hir_proc.stmts.at(branch_hir_id.value);
+              auto branch_or = LowerStmt(
+                  unit_state, scope_state, proc_state, branch_state, hir_proc,
+                  branch_hir);
+              if (!branch_or) {
+                return std::unexpected(std::move(branch_or.error()));
+              }
+              const mir::StmtId stmt_id =
+                  branch_state.AddStmt(*std::move(branch_or));
+              branch_state.AddRootStmt(stmt_id);
+              return std::pair{branch_state.Finish(), stmt_id};
+            };
+
+            std::vector<mir::ProceduralScope> child_scopes;
+            auto then_or = lower_branch(i.then_stmt);
+            if (!then_or) return std::unexpected(std::move(then_or.error()));
+            const mir::ProceduralScopeId then_scope_id =
+                AddChildProceduralScope(
+                    child_scopes, std::move(then_or->first));
+
+            std::optional<mir::ProceduralScopeId> else_scope_id;
+            if (i.else_stmt.has_value()) {
+              auto else_or = lower_branch(*i.else_stmt);
+              if (!else_or) return std::unexpected(std::move(else_or.error()));
+              else_scope_id = AddChildProceduralScope(
+                  child_scopes, std::move(else_or->first));
+            }
+
+            return mir::Stmt{
+                .label = stmt.label,
+                .data =
+                    mir::IfStmt{
+                        .condition = cond_id,
+                        .then_scope = then_scope_id,
+                        .else_scope = else_scope_id},
+                .child_procedural_scopes = std::move(child_scopes)};
+          },
           [&](const hir::TimedStmt& t) -> diag::Result<mir::Stmt> {
             auto timing_or =
                 LowerTimingControl(proc_state, hir_proc, t.timing, stmt.span);

--- a/tests/cases/cpp/conditional_literal/case.yaml
+++ b/tests/cases/cpp/conditional_literal/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.conditional_literal
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "a=42\n"

--- a/tests/cases/cpp/conditional_literal/main.sv
+++ b/tests/cases/cpp/conditional_literal/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  initial begin
+    int a;
+    if (1) a = 42;
+    else   a = 0;
+    $display("a=%0d", a);
+  end
+endmodule

--- a/tests/cases/cpp/conditional_nested/case.yaml
+++ b/tests/cases/cpp/conditional_nested/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.conditional_nested
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "out=22\n"

--- a/tests/cases/cpp/conditional_nested/main.sv
+++ b/tests/cases/cpp/conditional_nested/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  initial begin
+    int flag_a;
+    int flag_b;
+    int out;
+    flag_a = 0;
+    flag_b = 1;
+    if (flag_a)
+      out = 10;
+    else if (flag_b)
+      out = 22;
+    else
+      out = 30;
+    $display("out=%0d", out);
+  end
+endmodule

--- a/tests/cases/cpp/conditional_no_else/case.yaml
+++ b/tests/cases/cpp/conditional_no_else/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.conditional_no_else
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      a=7
+      b=0

--- a/tests/cases/cpp/conditional_no_else/main.sv
+++ b/tests/cases/cpp/conditional_no_else/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  initial begin
+    int a;
+    int b;
+    a = 0;
+    b = 0;
+    if (1) a = 7;
+    if (0) b = 9;
+    $display("a=%0d", a);
+    $display("b=%0d", b);
+  end
+endmodule

--- a/tests/cases/cpp/conditional_runtime/case.yaml
+++ b/tests/cases/cpp/conditional_runtime/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.conditional_runtime
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      a=1
+      b=2

--- a/tests/cases/cpp/conditional_runtime/main.sv
+++ b/tests/cases/cpp/conditional_runtime/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  initial begin
+    int yes;
+    int no_;
+    int a;
+    int b;
+    yes = 5;
+    no_ = 0;
+    if (yes) a = 1;
+    else     a = 2;
+    if (no_) b = 1;
+    else     b = 2;
+    $display("a=%0d", a);
+    $display("b=%0d", b);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds support for procedural `if (cond) ... else ...` statements end-to-end through HIR, MIR, and the C++ backend. Before this change, the AST-to-HIR lowering returned `kUnsupportedStatementForm` on any procedural conditional; only structural `if`-generate already had a path through.

## Design

The MIR `IfStmt` and the C++ backend render were already in place (used by `if`-generate), so this change extends the upstream layers to feed them from procedural code:

- `include/lyra/hir/stmt.hpp` -- new `hir::IfStmt { ExprId condition, StmtId then_stmt, optional<StmtId> else_stmt }`; added to `StmtData`.
- `src/lyra/lowering/ast_to_hir/statement/lower.cpp` -- new arm for `slang::ast::StatementKind::Conditional`. Rejects `unique`/`unique0`/`priority` qualifiers, multi-condition lists, and pattern matching with `diag::Unsupported` (those land separately under their own progress entries).
- `src/lyra/lowering/hir_to_mir/lower_stmt.cpp` -- new `Overloaded` arm for `hir::IfStmt`. Each branch is lowered into its own `mir::ProceduralScope` (single root stmt), mirroring how `BlockStmt` already builds child scopes and how the generate-if path builds them in `lower_constructor.cpp`.
- `src/lyra/hir/dump.cpp` -- pretty-prints the new node with `then:` / `else:` sub-trees.

`mir::IfStmt`, the C++ backend render at `render_stmt.cpp:127-153`, and the MIR dump are unchanged.

## Testing

Behavioral coverage under `tests/cases/cpp/`:

- `conditional_literal` -- `if (1) a = 42; else a = 0;`
- `conditional_runtime` -- truthy variable conditions for both then-taken and else-taken paths
- `conditional_no_else` -- if without else, on truthy and falsy literals
- `conditional_nested` -- `else if` cascade with else fall-through

Each case compiles the emitted C++ and asserts on `$display` output. Shape-pinning dump/emit goldens were intentionally omitted; behavior is the contract.

## Notes

While writing the runtime-condition test, packed binary comparison operators (`>`, `==`) on `int` operands surface `"this packed expression form is not yet supported in cpp emit"` from the C++ backend. That gap maps to `operators/binary` in `docs/progress/architecture-reset.md` and is unchanged by this PR; the test was rewritten to use the supported truthy-conversion path.