### PR TITLE
Wire scalar binary op tokens in cpp emit

### DIFF
--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -20,6 +20,10 @@ absent that, the item stays open.
 - [ ] R4 -- AOT execution path; runtime delivered as a static library.
 - [ ] R5 -- CLI subcommands for executing simulations: `run`, `compile`, `dump llvm`.
 - [ ] R6 -- Smoke, benchmark, and AOT CI jobs (currently `if: false`; see `../ci/README.md`).
+- [ ] R7 -- Test framework variable assertions (`expect.variables`). Archived tests assert
+      end-of-simulation values directly (`c: 30`, `r: "4'bx01x"`); the current framework supports
+      only `exit`/`stdout`/`stderr`, forcing every behavioral test to route through `$display`.
+      Blocks faithful reproduction of most feature tests under `archived/tests/sv_features/`.
 
 ## SystemVerilog Features
 

--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -1,0 +1,50 @@
+# Operators
+
+Tracks scalar expression-operator work against `backend::cpp`. Covers archive items that share the
+native render path (`RenderExprAsNative` in `src/lyra/backend/cpp/render_expr.cpp`):
+`operators/binary`, `operators/unary`, `operators/shift_overflow`. Each archive item checkbox in
+`architecture-reset.md` is checked when its `*.yaml` cases reproduce on the current pipeline.
+
+## Sub-Steps
+
+### Unary
+
+- [ ] U1 -- **High priority.** Scalar unary token wiring on `int`: `+`, `-`, `!`, `~`. Currently a
+      literal `-5` lowers to `UnaryMinus(IntegerLiteral 5)` and emits `Unsupported`, which means
+      writing a negative-literal anywhere in an SV test is blocked. Unblocks clean signed-arithmetic
+      tests and many other shapes. Mirrors B1's structure in `BinaryOpToken`.
+- [ ] U2 -- Pre/post increment `++`/`--`. Current `hir::UnaryOp`/`mir::UnaryOp` enums have no
+      inc/dec variant; needs HIR/MIR shape decision (statement-level vs expression-level given SV
+      side-effect ordering).
+- [ ] U3 -- Scalar reductions on `int` operand (`&a`, `|a`, `^a`, `~&a`, `~|a`, `~^a` when `a` is
+      `int`). Reduction unary works today only for packed lvalues via `RenderPackedReductionAssign`.
+- [ ] U4 -- 4-state unary X/Z propagation (`operators/unary/four_state.yaml`). Depends on
+      `logic`-operand unary path through the packed runtime.
+
+### Binary
+
+- [x] B1 -- Scalar token wiring for binary ops with direct C++ counterparts on `int`/`int -> int`:
+      `- * / % == != < <= > >= & | ^ && ||`. Extends `BinaryOpToken` in
+      `src/lyra/backend/cpp/render_expr.cpp`.
+- [ ] B2 -- Scalar `~^`/`^~` (bitwise XNOR): rewrite as `~(lhs ^ rhs)` in the native render path. No
+      new MIR shape.
+- [ ] B3 -- Scalar `->` (implication) and `<->` (equivalence): rewrite to `(!(lhs) || (rhs))` and
+      `(!(lhs)) == (!(rhs))`.
+- [ ] B4 -- Scalar shifts `<<`, `>>`, `>>>` with LRM overflow semantics (`x << n` with `n >= width`
+      yields 0; signed `>>>` is arithmetic). Closes `operators/shift_overflow` in
+      `architecture-reset.md` as a side-effect.
+- [ ] B5 -- Integer power `**`: runtime helper with LRM corner cases (`0**0 = 1`, negative exponent
+      yields 0).
+- [ ] B6 -- Mixed-width / packed-literal operands (`byte + int`, `32'h... < int`): route through the
+      packed top-level binary path, not native `int` token path. Closes archived cases
+      `addition_bit_and_int`, `comparison_signed_*`, `comparison_mixed_width_*`.
+- [ ] B7 -- 4-state X/Z propagation for binary ops (`operators/binary/four_state.yaml`). Depends on
+      a `logic`-operand binary path through the packed runtime.
+
+## Out of Scope
+
+- Case equality `===`/`!==` and wildcard equality `==?`/`!=?` -- separate archive items
+  (`operators/case_equality`, `operators/wildcard_equality`).
+- `operators/binary_string` -- string compare runtime helpers, separate item.
+- Concat, replicate, inside, compound assignment -- new MIR shapes; each is its own archive item and
+  its own workstream.

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -33,28 +33,42 @@ auto BinaryOpToken(mir::BinaryOp op) -> diag::Result<std::string_view> {
   switch (op) {
     case mir::BinaryOp::kAdd:
       return std::string_view{" + "};
+    case mir::BinaryOp::kSub:
+      return std::string_view{" - "};
+    case mir::BinaryOp::kMul:
+      return std::string_view{" * "};
+    case mir::BinaryOp::kDiv:
+      return std::string_view{" / "};
+    case mir::BinaryOp::kMod:
+      return std::string_view{" % "};
+    case mir::BinaryOp::kBitwiseAnd:
+      return std::string_view{" & "};
+    case mir::BinaryOp::kBitwiseOr:
+      return std::string_view{" | "};
+    case mir::BinaryOp::kBitwiseXor:
+      return std::string_view{" ^ "};
+    case mir::BinaryOp::kEquality:
+      return std::string_view{" == "};
+    case mir::BinaryOp::kInequality:
+      return std::string_view{" != "};
     case mir::BinaryOp::kLessThan:
       return std::string_view{" < "};
-    case mir::BinaryOp::kSub:
-    case mir::BinaryOp::kMul:
-    case mir::BinaryOp::kDiv:
-    case mir::BinaryOp::kMod:
+    case mir::BinaryOp::kLessEqual:
+      return std::string_view{" <= "};
+    case mir::BinaryOp::kGreaterThan:
+      return std::string_view{" > "};
+    case mir::BinaryOp::kGreaterEqual:
+      return std::string_view{" >= "};
+    case mir::BinaryOp::kLogicalAnd:
+      return std::string_view{" && "};
+    case mir::BinaryOp::kLogicalOr:
+      return std::string_view{" || "};
     case mir::BinaryOp::kPower:
-    case mir::BinaryOp::kBitwiseAnd:
-    case mir::BinaryOp::kBitwiseOr:
-    case mir::BinaryOp::kBitwiseXor:
     case mir::BinaryOp::kBitwiseXnor:
-    case mir::BinaryOp::kEquality:
-    case mir::BinaryOp::kInequality:
     case mir::BinaryOp::kCaseEquality:
     case mir::BinaryOp::kCaseInequality:
     case mir::BinaryOp::kWildcardEquality:
     case mir::BinaryOp::kWildcardInequality:
-    case mir::BinaryOp::kGreaterEqual:
-    case mir::BinaryOp::kGreaterThan:
-    case mir::BinaryOp::kLessEqual:
-    case mir::BinaryOp::kLogicalAnd:
-    case mir::BinaryOp::kLogicalOr:
     case mir::BinaryOp::kLogicalImplication:
     case mir::BinaryOp::kLogicalEquivalence:
     case mir::BinaryOp::kShiftLeft:

--- a/tests/cases/cpp/scalar_arithmetic_int/case.yaml
+++ b/tests/cases/cpp/scalar_arithmetic_int/case.yaml
@@ -1,0 +1,19 @@
+id: cpp.scalar_arithmetic_int
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      42
+      18
+      -18
+      35
+      -35
+      25
+      -25
+      2

--- a/tests/cases/cpp/scalar_arithmetic_int/main.sv
+++ b/tests/cases/cpp/scalar_arithmetic_int/main.sv
@@ -1,0 +1,19 @@
+module Top;
+  int a, b, c;
+  initial begin
+    a = 30; b = 12;
+    c = a + b; $display("%0d", c);
+    c = a - b; $display("%0d", c);
+    c = b - a; $display("%0d", c);
+    a = 5; b = 7;
+    c = a * b; $display("%0d", c);
+    a = b - 12;
+    c = a * b; $display("%0d", c);
+    a = 100; b = 4;
+    c = a / b; $display("%0d", c);
+    a = b - 104;
+    c = a / b; $display("%0d", c);
+    a = 17; b = 5;
+    c = a % b; $display("%0d", c);
+  end
+endmodule

--- a/tests/cases/cpp/scalar_bitwise_int/case.yaml
+++ b/tests/cases/cpp/scalar_bitwise_int/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.scalar_bitwise_int
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1
+      7
+      6

--- a/tests/cases/cpp/scalar_bitwise_int/main.sv
+++ b/tests/cases/cpp/scalar_bitwise_int/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  int a, b, c;
+  initial begin
+    a = 5; b = 3;
+    c = a & b; $display("%0d", c);
+    c = a | b; $display("%0d", c);
+    c = a ^ b; $display("%0d", c);
+  end
+endmodule

--- a/tests/cases/cpp/scalar_comparison_int/case.yaml
+++ b/tests/cases/cpp/scalar_comparison_int/case.yaml
@@ -1,0 +1,20 @@
+id: cpp.scalar_comparison_int
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      0
+      1
+      1
+      1
+      0
+      0
+      1
+      1
+      1

--- a/tests/cases/cpp/scalar_comparison_int/main.sv
+++ b/tests/cases/cpp/scalar_comparison_int/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  int a, b, c;
+  initial begin
+    a = 5; b = 10;
+    c = (a == b); $display("%0d", c);
+    c = (a != b); $display("%0d", c);
+    c = (a < b);  $display("%0d", c);
+    c = (a <= b); $display("%0d", c);
+    c = (a > b);  $display("%0d", c);
+    c = (a >= b); $display("%0d", c);
+    a = 5; b = 5;
+    c = (a == b); $display("%0d", c);
+    c = (a <= b); $display("%0d", c);
+    c = (a >= b); $display("%0d", c);
+  end
+endmodule

--- a/tests/cases/cpp/scalar_logical_int/case.yaml
+++ b/tests/cases/cpp/scalar_logical_int/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.scalar_logical_int
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      0
+      1
+      1
+      0

--- a/tests/cases/cpp/scalar_logical_int/main.sv
+++ b/tests/cases/cpp/scalar_logical_int/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  int a, b, c;
+  initial begin
+    a = 5; b = 0;
+    c = a && b; $display("%0d", c);
+    c = a || b; $display("%0d", c);
+    a = 5; b = 7;
+    c = a && b; $display("%0d", c);
+    a = 0; b = 0;
+    c = a || b; $display("%0d", c);
+  end
+endmodule

--- a/tests/cases/errors/cpp_emit_unsupported_binary_op/main.sv
+++ b/tests/cases/errors/cpp_emit_unsupported_binary_op/main.sv
@@ -2,6 +2,6 @@ module Top;
   int a;
   int b;
   initial begin
-    a = a - b;
+    a = a ** b;
   end
 endmodule


### PR DESCRIPTION
## Summary

Extends `backend::cpp::BinaryOpToken` from two ops (`+`, `<`) to sixteen by wiring direct C++ token mappings for arithmetic (`- * / %`), comparison (`== != <= > >=`), bitwise (`& | ^`), and logical (`&& ||`) binary operators on native `int`. The HIR->MIR lowering already maps all binary ops one-to-one; the only gap was scalar token emission, so this is pure rendering work with no new MIR shapes. Four behavioral test cases under `tests/cases/cpp/scalar_*_int/` cover each op family via `$display`-based stdout assertions; the existing `cpp_emit_unsupported_binary_op` diagnostic test swaps from `a - b` to `a ** b` to keep coverage on a still-unsupported op.

## Design

Two progress-tracking artifacts land alongside the code. `docs/progress/operators.md` splits the `operators/binary` and `operators/unary` archive items into seven binary sub-steps (B1-B7) and four unary sub-steps (U1-U4); this PR closes B1. U1 (scalar unary tokens for `+ - ! ~`) is flagged high priority because `a = -5` currently emits as `UnaryMinus(IntegerLiteral 5)` and hits the unary unsupported path, blocking negative-literal initialization in any new test. The B6 mixed-width / packed-literal cases (`addition_bit_and_int`, `comparison_signed_*`) are deliberately deferred since those operands route through the packed top-level path rather than native `int` token emission.

A new `R7` entry in `architecture-reset.md` records that the test framework supports only `exit`/`stdout`/`stderr` matchers; the archived feature tests all assert via `expect.variables`, so faithful reproduction of `archived/tests/sv_features/` is blocked until a behavioral-assertion form lands.

## Testing

`bazel test //...` -- 132 cpp cases plus diag render tests all pass. Format and policy checks (`clang-format`, `prettier`, `buildifier`, `check_architecture`/`check_ascii`/`check_cpp_style`/`check_exceptions`) clean.