### PR TITLE
Wire scalar unary op tokens in cpp emit

### DIFF
--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -9,10 +9,9 @@ native render path (`RenderExprAsNative` in `src/lyra/backend/cpp/render_expr.cp
 
 ### Unary
 
-- [ ] U1 -- **High priority.** Scalar unary token wiring on `int`: `+`, `-`, `!`, `~`. Currently a
-      literal `-5` lowers to `UnaryMinus(IntegerLiteral 5)` and emits `Unsupported`, which means
-      writing a negative-literal anywhere in an SV test is blocked. Unblocks clean signed-arithmetic
-      tests and many other shapes. Mirrors B1's structure in `BinaryOpToken`.
+- [x] U1 -- Scalar unary token wiring on `int`: `+`, `-`, `!`, `~`. Mirrors B1's structure via
+      `UnaryOpToken` in `src/lyra/backend/cpp/render_expr.cpp`. Negative-literal shapes such as
+      `int a = -7;` now flow through cpp emit; reductions remain Unsupported (see U3).
 - [ ] U2 -- Pre/post increment `++`/`--`. Current `hir::UnaryOp`/`mir::UnaryOp` enums have no
       inc/dec variant; needs HIR/MIR shape decision (statement-level vs expression-level given SV
       side-effect ordering).

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -82,6 +82,30 @@ auto BinaryOpToken(mir::BinaryOp op) -> diag::Result<std::string_view> {
   throw InternalError("BinaryOpToken: unknown MIR BinaryOp");
 }
 
+auto UnaryOpToken(mir::UnaryOp op) -> diag::Result<std::string_view> {
+  switch (op) {
+    case mir::UnaryOp::kPlus:
+      return std::string_view{"+"};
+    case mir::UnaryOp::kMinus:
+      return std::string_view{"-"};
+    case mir::UnaryOp::kBitwiseNot:
+      return std::string_view{"~"};
+    case mir::UnaryOp::kLogicalNot:
+      return std::string_view{"!"};
+    case mir::UnaryOp::kReductionAnd:
+    case mir::UnaryOp::kReductionOr:
+    case mir::UnaryOp::kReductionXor:
+    case mir::UnaryOp::kReductionNand:
+    case mir::UnaryOp::kReductionNor:
+    case mir::UnaryOp::kReductionXnor:
+      return diag::Unsupported(
+          diag::DiagCode::kCppEmitUnaryOpNotImplemented,
+          "this unary operator is not yet implemented in cpp emit",
+          diag::UnsupportedCategory::kFeature);
+  }
+  throw InternalError("UnaryOpToken: unknown MIR UnaryOp");
+}
+
 auto LookupProceduralVarName(
     const RenderContext& ctx, const mir::ProceduralVarRef& ref)
     -> const std::string& {
@@ -555,11 +579,16 @@ auto RenderExprAsNative(const RenderContext& ctx, const mir::Expr& expr)
           [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
             return LookupProceduralVarName(ctx, l);
           },
-          [](const mir::UnaryExpr&) -> diag::Result<std::string> {
-            return diag::Unsupported(
-                diag::DiagCode::kCppEmitUnaryOpNotImplemented,
-                "this unary operator is not yet implemented in cpp emit",
-                diag::UnsupportedCategory::kFeature);
+          [&](const mir::UnaryExpr& u) -> diag::Result<std::string> {
+            auto token_or = UnaryOpToken(u.op);
+            if (!token_or) {
+              return std::unexpected(std::move(token_or.error()));
+            }
+            auto operand_or = RenderExprAsNative(ctx, ctx.Expr(u.operand));
+            if (!operand_or) {
+              return std::unexpected(std::move(operand_or.error()));
+            }
+            return "(" + std::string{*token_or} + *operand_or + ")";
           },
           [&](const mir::BinaryExpr& b) -> diag::Result<std::string> {
             auto token_or = BinaryOpToken(b.op);

--- a/tests/cases/cpp/scalar_unary_int/case.yaml
+++ b/tests/cases/cpp/scalar_unary_int/case.yaml
@@ -1,0 +1,18 @@
+id: cpp.scalar_unary_int
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      5
+      -5
+      -6
+      0
+      1
+      -42
+      -7

--- a/tests/cases/cpp/scalar_unary_int/main.sv
+++ b/tests/cases/cpp/scalar_unary_int/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  int a, b, c;
+  initial begin
+    a = 5;
+    b = +a; $display("%0d", b);
+    b = -a; $display("%0d", b);
+    b = ~a; $display("%0d", b);
+    b = !a; $display("%0d", b);
+    a = 0;
+    b = !a; $display("%0d", b);
+    c = -42; $display("%0d", c);
+    a = -7; $display("%0d", a);
+  end
+endmodule

--- a/tests/cases/errors/cpp_emit_unsupported_unary_op/main.sv
+++ b/tests/cases/errors/cpp_emit_unsupported_unary_op/main.sv
@@ -1,6 +1,7 @@
 module Top;
   int a;
+  int c;
   initial begin
-    a = -a;
+    c = &a;
   end
 endmodule


### PR DESCRIPTION
## Summary

Wires the scalar unary tokens `+`, `-`, `~`, `!` for native `int` operands in `backend::cpp`, mirroring the B1 cut for binary ops. Negative-literal shapes like `int a = -7;` and `c = -42;` now flow through cpp emit; before this change any unary on `int` returned `kCppEmitUnaryOpNotImplemented`, which blocked writing negative literals in any new SV test. Reductions on `int` operand remain Unsupported and are tracked as U3 in `docs/progress/operators.md`.

## Design

`UnaryOpToken` sits next to `BinaryOpToken` in `src/lyra/backend/cpp/render_expr.cpp` with the same shape: direct C++ counterparts return a token, every reduction returns `diag::Unsupported`. The `UnaryExpr` arm of `RenderExprAsNative` now recurses into the operand and renders `"(" + token + operand + ")"`, parallel to the `BinaryExpr` arm.

## Testing

`bazel test //... --test_output=errors` (cached, 82s previously). New `tests/cases/cpp/scalar_unary_int` covers `+`, `-`, `~`, `!`, and negative-literal initialization. The `cpp_emit_unsupported_unary_op` error case is repointed from `a = -a;` to `c = &a;` so the diagnostic stays covered by a still-unsupported reduction shape.