### PR TITLE
Support final blocks end-to-end

### DIFF
--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -1,0 +1,40 @@
+# Display
+
+Tracks `$display` / `$write` / `$strobe` format-specifier coverage and file-sink support against the
+runtime print pipeline (`src/lyra/runtime/integral_format.cpp`,
+`src/lyra/lowering/hir_to_mir/lower_print.cpp`). Each item is a single PR-sized step; the file is
+deleted when all sub-steps land.
+
+The format-specifier sub-steps gate the `expect.variables` shape of the R7 test-framework work
+(`architecture-reset.md`), since the test harness can only probe a variable whose type has an
+implemented specifier.
+
+## Sub-Steps
+
+- [ ] DI1 -- `%c` (char). Decode the low 7 bits of an integral arg as ASCII. `lower_print.cpp`
+      currently returns `kFormatSpecifierNotImplemented` for `kChar`.
+- [ ] DI2 -- `%t` (time). Format a time value against the active timescale. `lower_print.cpp`
+      currently returns `kFormatSpecifierNotImplemented` for `kTime`. Requires a time variant on
+      `RuntimeValueView` and time-unit awareness on the format spec.
+- [ ] DI3 -- `%f` / `%e` / `%g` (real). Format a real value. `lower_print.cpp` currently returns
+      `kFormatSpecifierNotImplemented` for `kReal`. Requires a real variant on `RuntimeValueView`
+      and a real path through HIR/MIR (no `real` type support today).
+- [ ] DI4 -- `%m` (hierarchical name). Requires runtime exposure of the current scope's hierarchical
+      path. `lower_print.cpp` currently returns `kFormatModulePathNotImplemented`. Shares its
+      underlying mechanism with the archive item `hierarchy/refs`, which the `expect.variables`
+      Phase 2 also depends on for hierarchical probe paths.
+- [ ] DI5 -- File sink (`$fdisplay`, `$fwrite`). `lower_print.cpp` currently returns
+      `kFileDisplayNotImplemented` for any non-stdout sink. Requires file-descriptor runtime state
+      (`$fopen` returning an MCD/FD, `$fclose`), per-descriptor output dispatch, and threading the
+      descriptor argument through `RuntimePrintCall`.
+- [ ] DI6 -- `$strobe` postponed-region semantics. `support::SystemSubroutineDesc` already carries
+      `is_strobe`, but `lower_print.cpp` lowers strobe identically to `$display`. Strobe must defer
+      its read-and-print to the postponed region of the same time slot.
+
+## Out of Scope
+
+- Format-string parse diagnostics (`kFormatStringTrailingPercent`, `kFormatStringMissingSpecifier`,
+  `kFormatStringWidthOverflow`, `kFormatStringUnknownSpecifier`) -- already implemented, not gaps.
+- `$monitor`. Not modelled today; add an entry when a concrete consumer needs it.
+- `%u` / `%z` (binary-packed unsigned/signed) and `%v` (strength). Not on the immediate roadmap; add
+  entries when concrete consumers appear.

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -73,13 +73,14 @@ class Engine {
     std::vector<NbaWorkItem> nba;
     std::vector<PostponedWorkItem> postponed;
     std::map<SimTime, std::vector<RuntimeProcess*>> delayed;
+    std::vector<RuntimeProcess*> finals;
   };
 
   static constexpr std::size_t kMaxCurrentTimeIterations = 10000;
   static constexpr std::size_t kMaxDeltaCyclesPerTimeSlot = 10000;
 
   void EnsureReadyToRun();
-  void EnqueueInitialProcesses();
+  void RegisterProcesses();
   void RunProcess(RuntimeProcess& process);
   void DrainRunnableQueue(std::deque<RuntimeProcess*>& queue);
 
@@ -91,6 +92,7 @@ class Engine {
   void ExecuteObservedRegion();
   void ExecuteReactiveRegion();
   void ExecutePostponedRegion();
+  void ExecuteFinalProcesses();
 
   void AdvanceToNextTime();
   void AdvanceDeltaCycle();

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -91,10 +91,11 @@ auto RenderProcessMethod(
     const RenderContext* parent_struct_ctx, const mir::CompilationUnit& unit,
     const mir::StructuralScope& s, const mir::Process& process,
     std::size_t index, std::size_t indent) -> diag::Result<std::string> {
-  if (process.kind != mir::ProcessKind::kInitial) {
+  if (process.kind != mir::ProcessKind::kInitial &&
+      process.kind != mir::ProcessKind::kFinal) {
     throw InternalError(
-        "RenderProcessMethod: C++ emit is not yet supported for non-initial "
-        "processes");
+        "RenderProcessMethod: C++ emit is not yet supported for this process "
+        "kind");
   }
   std::string out;
   out += Indent(indent) + "auto " + RenderProcessMethodName(index) +
@@ -117,13 +118,14 @@ auto RenderProcessKindLiteral(mir::ProcessKind kind) -> std::string {
     case mir::ProcessKind::kInitial:
       return "lyra::runtime::ProcessKind::kInitial";
     case mir::ProcessKind::kFinal:
+      return "lyra::runtime::ProcessKind::kFinal";
     case mir::ProcessKind::kAlways:
     case mir::ProcessKind::kAlwaysComb:
     case mir::ProcessKind::kAlwaysLatch:
     case mir::ProcessKind::kAlwaysFf:
       throw InternalError(
-          "RenderProcessKindLiteral: C++ emit is not yet supported for "
-          "non-initial processes");
+          "RenderProcessKindLiteral: C++ emit is not yet supported for this "
+          "process kind");
   }
   throw InternalError("RenderProcessKindLiteral: unknown ProcessKind");
 }

--- a/src/lyra/lowering/hir_to_mir/lower_process.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_process.cpp
@@ -31,10 +31,7 @@ auto LowerProcessKind(hir::ProcessKind hir_kind, diag::SourceSpan span)
     case hir::ProcessKind::kAlways:
       return mir::ProcessKind::kAlways;
     case hir::ProcessKind::kFinal:
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedProcessKindLowering,
-          "`final` processes are not yet supported",
-          diag::UnsupportedCategory::kFeature);
+      return mir::ProcessKind::kFinal;
     case hir::ProcessKind::kAlwaysComb:
       return diag::Unsupported(
           span, diag::DiagCode::kUnsupportedProcessKindLowering,
@@ -73,10 +70,11 @@ auto MakeTrueConditionExpr(
       });
 }
 
-auto LowerInitialProcess(
+auto LowerStraightLineProcess(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state, const hir::Process& src,
-    ProcessLoweringState& proc_state) -> diag::Result<mir::Process> {
+    ProcessLoweringState& proc_state, mir::ProcessKind kind)
+    -> diag::Result<mir::Process> {
   ProceduralScopeLoweringState process_scope_state;
   auto lowered = LowerStmt(
       unit_state, scope_state, proc_state, process_scope_state, src,
@@ -85,8 +83,7 @@ auto LowerInitialProcess(
   const mir::StmtId root_id = process_scope_state.AddStmt(*std::move(lowered));
   process_scope_state.AddRootStmt(root_id);
   return mir::Process{
-      .kind = mir::ProcessKind::kInitial,
-      .root_procedural_scope = process_scope_state.Finish()};
+      .kind = kind, .root_procedural_scope = process_scope_state.Finish()};
 }
 
 auto LowerAlwaysProcess(
@@ -138,8 +135,10 @@ auto LowerProcess(
   if (!kind_or) return std::unexpected(std::move(kind_or.error()));
 
   ProcessLoweringState proc_state{time_resolution};
-  if (*kind_or == mir::ProcessKind::kInitial) {
-    return LowerInitialProcess(unit_state, scope_state, src, proc_state);
+  if (*kind_or == mir::ProcessKind::kInitial ||
+      *kind_or == mir::ProcessKind::kFinal) {
+    return LowerStraightLineProcess(
+        unit_state, scope_state, src, proc_state, *kind_or);
   }
   return LowerAlwaysProcess(unit_state, scope_state, src, proc_state);
 }

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -50,7 +50,7 @@ void Engine::BindRoot(std::string root_name, Module& top) {
 
 auto Engine::Run() -> int {
   EnsureReadyToRun();
-  EnqueueInitialProcesses();
+  RegisterProcesses();
 
   while (HasScheduledWork()) {
     ExecuteCurrentTimeSlot();
@@ -59,6 +59,8 @@ auto Engine::Run() -> int {
     }
     AdvanceToNextTime();
   }
+
+  ExecuteFinalProcesses();
 
   phase_ = SchedulerPhase::kIdle;
   output_.Drain();
@@ -75,17 +77,19 @@ void Engine::EnsureReadyToRun() {
   ran_ = true;
 }
 
-void Engine::EnqueueInitialProcesses() {
+void Engine::RegisterProcesses() {
   WalkScopePreOrder(*root_, [this](RuntimeScope& scope) {
     scope.ForEachProcess([this](RuntimeProcess& process) {
       switch (process.Kind()) {
         case ProcessKind::kInitial:
           ScheduleActive(process);
           break;
+        case ProcessKind::kFinal:
+          queues_.finals.push_back(&process);
+          break;
         case ProcessKind::kAlways:
         case ProcessKind::kAlwaysComb:
         case ProcessKind::kAlwaysFf:
-        case ProcessKind::kFinal:
           throw InternalError("Engine::Run: ProcessKind is not yet supported");
       }
     });
@@ -154,6 +158,19 @@ void Engine::ExecuteReactiveRegion() {
 
 void Engine::ExecutePostponedRegion() {
   phase_ = SchedulerPhase::kPostponed;
+}
+
+void Engine::ExecuteFinalProcesses() {
+  phase_ = SchedulerPhase::kPostponed;
+  for (RuntimeProcess* p : queues_.finals) {
+    auto result = p->Resume();
+    if (!result.IsCompleted()) {
+      throw InternalError(
+          "Engine::ExecuteFinalProcesses: final block suspended; "
+          "time-controlling statements are not allowed inside `final`");
+    }
+  }
+  queues_.finals.clear();
 }
 
 void Engine::AdvanceDeltaCycle() {

--- a/tests/cases/cpp/final_after_initial/case.yaml
+++ b/tests/cases/cpp/final_after_initial/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.final_after_initial
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      initial x=1
+      final x=2

--- a/tests/cases/cpp/final_after_initial/main.sv
+++ b/tests/cases/cpp/final_after_initial/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  int x;
+
+  initial begin
+    x = 1;
+    $display("initial x=%0d", x);
+    x = 2;
+  end
+
+  final begin
+    $display("final x=%0d", x);
+  end
+endmodule

--- a/tests/cases/cpp/final_basic/case.yaml
+++ b/tests/cases/cpp/final_basic/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.final_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "final ran\n"

--- a/tests/cases/cpp/final_basic/main.sv
+++ b/tests/cases/cpp/final_basic/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  final begin
+    $display("final ran");
+  end
+endmodule

--- a/tests/cases/errors/process_kind_unsupported/main.sv
+++ b/tests/cases/errors/process_kind_unsupported/main.sv
@@ -1,3 +1,3 @@
 module Top;
-  final begin end
+  always_comb begin end
 endmodule


### PR DESCRIPTION
## Summary

Wire `final` blocks through the whole pipeline so they actually run at end of simulation. HIR
already recognised `kFinal`; MIR lowering returned an `Unsupported` diagnostic, the cpp backend
threw on non-initial processes, and the runtime engine threw `kFinal not yet supported` during
process registration. After this change, `final` is a real language feature: lowered, emitted,
scheduled, and executed once when `engine.Run()` returns from the main loop.

## Design

- `LowerInitialProcess` is renamed to `LowerStraightLineProcess` and now takes a `kind`
  parameter, since `final` shares its lowering shape with `initial` (no implicit `while(1)` loop,
  no `AwaitStmt` epilogue) and only differs in `mir::ProcessKind`.
- `cpp` backend treats `kFinal` identically to `kInitial` at the C++ method shape level, and
  emits `lyra::runtime::ProcessKind::kFinal` for the `AddProcess` call.
- The runtime engine collects `kFinal` processes into a separate `finals` queue at registration,
  then drains them in `ExecuteFinalProcesses` after the main time-slot loop exits. Phase is set
  to `kPostponed` for that drain. Final blocks that try to suspend (illegal per LRM 9.2.3) raise
  `InternalError`.
- The `errors.process_kind_unsupported` case is repointed at `always_comb` so it still exercises
  the unsupported-kind path now that `final` is supported.

Also adds `docs/progress/display.md` tracking the `%c` / `%t` / `%f` / `%m` / file-sink / strobe
gaps in `lower_print.cpp`, since those are the next dependencies on the path to R7.

## Testing

- `cpp.final_basic` -- standalone `final` block prints once
- `cpp.final_after_initial` -- final observes state left by initial; orders correctly
- Existing `dump.hir_process_kinds` already pinned `"Process (Final)"`
- `errors.process_kind_unsupported` still passes against `always_comb`
- `bazel test //...` green