### PR TITLE
Lower procedural case statement through HIR and MIR

### DIFF
--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -11,6 +11,10 @@ item only when the corresponding archive tests can be reproduced -- or have been
 deprecated -- on the current architecture. "Intentionally deprecated" requires a `decisions/` entry;
 absent that, the item stays open.
 
+When a workstream has its own progress file (e.g. `operators.md`, `control-flow.md`), the granular
+sub-step tracking lives there. The corresponding archive items below remain a high-level inventory;
+the dedicated file is the source of truth for "what is done, in what order, what is blocked".
+
 ## Pipeline Surfaces
 
 - [ ] R1 -- LIR layer implementation. Contract in `../architecture/lir.md`; no source under
@@ -39,19 +43,9 @@ absent that, the item stays open.
 
 ### control_flow
 
-- [ ] control_flow/case
-- [ ] control_flow/case_inside
-- [ ] control_flow/conditional
-- [ ] control_flow/do_while
-- [ ] control_flow/for
-- [ ] control_flow/foreach
-- [ ] control_flow/foreach_2d
-- [ ] control_flow/forever
-- [ ] control_flow/repeat
-- [ ] control_flow/ternary
-- [ ] control_flow/unique_priority_case
-- [ ] control_flow/unique_priority_if
-- [ ] control_flow/while
+Tracked in `control-flow.md`. Covers all `control_flow/*` archive items (case, case_inside,
+conditional, do_while, for, foreach, foreach_2d, forever, repeat, ternary, unique_priority_case,
+unique_priority_if, while).
 
 ### datatypes
 
@@ -118,19 +112,11 @@ absent that, the item stays open.
 
 ### operators
 
-- [ ] operators/binary
-- [ ] operators/binary_string
-- [ ] operators/case_equality
-- [ ] operators/comparison_value_temp
-- [ ] operators/compound_assignment
-- [ ] operators/concat
-- [ ] operators/inside
-- [ ] operators/replicate
-- [ ] operators/replication_patterns
-- [ ] operators/shift_overflow
-- [ ] operators/unary
-- [ ] operators/value_temp_expansion
-- [ ] operators/wildcard_equality
+Tracked in `operators.md`. Covers `operators/binary`, `operators/binary_string`,
+`operators/case_equality`, `operators/comparison_value_temp`, `operators/compound_assignment`,
+`operators/concat`, `operators/inside`, `operators/replicate`, `operators/replication_patterns`,
+`operators/shift_overflow`, `operators/unary`, `operators/value_temp_expansion`,
+`operators/wildcard_equality`.
 
 ### optimization
 

--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -1,0 +1,65 @@
+# Control Flow
+
+Tracks procedural control-flow constructs against `backend::cpp`. Covers archive items under
+`archived/tests/sv_features/control_flow/`. Each archive item checkbox in `architecture-reset.md` is
+checked when its `*.yaml` cases reproduce on the current pipeline.
+
+## Sub-Steps
+
+### Statements
+
+- [x] C1 -- `if`/`else` (procedural conditional). Reproduces
+      `control_flow/conditional/default.yaml`. Multi-condition lists, patterns, and
+      `unique`/`priority` qualifiers are rejected with `diag::Unsupported`; the qualifier work lives
+      under `unique_priority_if` (see C13).
+- [x] C2 -- `for` (procedural for-loop, no break/continue). Reproduces every
+      `control_flow/for/default.yaml` case except the two `break`-bearing ones (deferred to C7).
+      Includes inline `for (int i = 0; ...)`, external `for (i = 0; ...)`, multi-init / multi-step,
+      countdown, zero-iteration, and `if`-in-body composition.
+- [x] C3 -- `case` (plain, normal condition only) with literal labels. Reproduces the core
+      plain-case subset of `control_flow/case/default.yaml` (basic match, default, multi-label,
+      no-default-no-match, empty body, nested) using integer-literal labels and integer selectors.
+      Variants requiring an if/else-cascade lowering (non-constant labels, duplicate labels) are
+      tracked in C15; enum/string selectors and labels are tracked in C16 and C17 respectively.
+- [ ] C4 -- `while` (procedural while-loop). `mir::WhileStmt` exists but
+      `src/lyra/backend/cpp/render_stmt.cpp:268-271` throws `InternalError`; needs HIR node, AST ->
+      HIR arm, HIR -> MIR arm, and render. Reproduces `control_flow/while/default.yaml` once C7
+      lands.
+- [ ] C5 -- `repeat (N)`. Pure desugaring to `for (int __k = 0; __k < N; __k = __k + 1)` over the C2
+      machinery. Counts as one PR after C2 land.
+- [ ] C6 -- `do_while`. Lowers to `while(true) { body; if (!cond) break; }` over C4 + C7.
+- [ ] C7 -- Loop control: `break`, `continue`. New HIR/MIR statements + C++ render. Shared by C2
+      (for) / C4 (while) / C5 (repeat) / C6 (do-while) / C9 (foreach). Coroutine renderer must scope
+      the early-exit correctly inside nested control flow.
+- [ ] C8 -- `forever`. Lower to `for (;;) { body }` (already representable via `mir::ForStmt` with
+      empty condition); needs `$finish` runtime support for the archive tests to terminate.
+- [ ] C9 -- `foreach` over fixed unpacked 1D arrays. Desugar to nested `for` over slang `loopDims`;
+      depends on C2.
+- [ ] C10 -- `foreach` multi-dim, skipped dimensions, dynamic-array, queue. Depends on C9 plus
+      runtime types for the dynamic variants.
+- [ ] C11 -- `casez` / `casex`. Cannot share `mir::SwitchStmt` (C++ `switch` does not support
+      wildcard match); lower to an if/else cascade with masked comparisons in HIR -> MIR.
+- [ ] C12 -- `case (... inside ...)`. Range patterns (`[lo:hi]`) and `inside` membership; lower to
+      if/else cascade with `inside` semantics.
+- [ ] C13 -- `unique` / `unique0` / `priority` qualifiers on `if` and `case`. Needs runtime warn
+      helpers and (for cascaded `if`) settle-epoch tracking. Covers archive items
+      `unique_priority_if` and `unique_priority_case`.
+- [ ] C15 -- `case` with labels that are not compile-time constants (`case (sel) some_expr: ...`)
+      and `case` with duplicate labels ("first match wins"). Neither can be expressed via C++
+      `switch`; lower in HIR -> MIR to an if/else-if cascade. Covers archive cases
+      `case_constant_expression`, `case_first_match_wins`.
+- [ ] C16 -- `case` with enum-typed selectors and enum-value labels. Depends on the `datatypes/enum`
+      archive item landing.
+- [ ] C17 -- `case` with string selector / string labels. Needs the string-equality runtime helper
+      from `operators/binary_string`.
+
+### Expressions
+
+- [ ] C14 -- Ternary `cond ? a : b`. Pure expression node; independent of statement work. Adds
+      `hir::ConditionalExpr` + `mir::ConditionalExpr` and a one-line C++ render.
+
+## Out of Scope
+
+- `fork` / `join_any` / `join_none` -- scheduling primitives tracked under `processes`.
+- `wait` / `wait_event` / `@(event)` -- event control, not pure control flow.
+- Assertion control statements (`disable`, `restart`) -- tracked under `assertions`.

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -46,6 +46,17 @@ struct IfStmt {
   std::optional<StmtId> else_stmt;
 };
 
+struct CaseItem {
+  std::vector<ExprId> labels;
+  StmtId stmt;
+};
+
+struct CaseStmt {
+  ExprId condition;
+  std::vector<CaseItem> items;
+  std::optional<StmtId> default_stmt;
+};
+
 struct ForInitDecl {
   ProceduralVarId var = {};
   std::optional<ExprId> init;
@@ -78,7 +89,8 @@ struct TimedStmt {
 };
 
 using StmtData = std::variant<
-    EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, IfStmt, ForStmt, TimedStmt>;
+    EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, IfStmt, CaseStmt, ForStmt,
+    TimedStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -632,6 +632,45 @@ class HirDumper {
               }
               Dedent();
             },
+            [&](const CaseStmt& c) {
+              Line(
+                  std::format(
+                      "Stmt[{}] CaseStmt cond=Expr[{}] (items={})", id.value,
+                      c.condition.value, c.items.size()));
+              Indent();
+              Line(
+                  std::format(
+                      "Expr[{}] {}", c.condition.value,
+                      FormatProcExpr(p, c.condition)));
+              for (std::size_t k = 0; k < c.items.size(); ++k) {
+                const auto& item = c.items[k];
+                std::string labels_str;
+                for (std::size_t m = 0; m < item.labels.size(); ++m) {
+                  if (m != 0) labels_str += ", ";
+                  labels_str += std::format("Expr[{}]", item.labels[m].value);
+                }
+                Line(std::format("item[{}] labels=[{}]", k, labels_str));
+                Indent();
+                for (const hir::ExprId label_id : item.labels) {
+                  Line(
+                      std::format(
+                          "Expr[{}] {}", label_id.value,
+                          FormatProcExpr(p, label_id)));
+                }
+                Line("stmt:");
+                Indent();
+                DumpStmt(p, item.stmt);
+                Dedent();
+                Dedent();
+              }
+              if (c.default_stmt.has_value()) {
+                Line("default:");
+                Indent();
+                DumpStmt(p, *c.default_stmt);
+                Dedent();
+              }
+              Dedent();
+            },
             [&](const ForStmt& f) {
               Line(
                   std::format(

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -208,6 +208,62 @@ auto LowerStatement(
           .span = span};
     }
 
+    case slang::ast::StatementKind::Case: {
+      const auto& cs = stmt.as<slang::ast::CaseStatement>();
+      if (cs.condition != slang::ast::CaseStatementCondition::Normal) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedStatementForm,
+            "casez/casex/case-inside are not yet supported",
+            diag::UnsupportedCategory::kFeature);
+      }
+      if (cs.check != slang::ast::UniquePriorityCheck::None) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedStatementForm,
+            "unique/priority qualifiers on case are not yet supported",
+            diag::UnsupportedCategory::kFeature);
+      }
+      auto cond_expr = LowerProcExpr(
+          unit_facts, scope_state.UnitState(), proc_state, stack, cs.expr);
+      if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
+      const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_expr));
+      std::vector<hir::CaseItem> items;
+      items.reserve(cs.items.size());
+      for (const auto& item : cs.items) {
+        std::vector<hir::ExprId> label_ids;
+        label_ids.reserve(item.expressions.size());
+        for (const auto* label_expr : item.expressions) {
+          auto label_or = LowerProcExpr(
+              unit_facts, scope_state.UnitState(), proc_state, stack,
+              *label_expr);
+          if (!label_or) return std::unexpected(std::move(label_or.error()));
+          label_ids.push_back(proc_state.AddExpr(*std::move(label_or)));
+        }
+        auto item_stmt = LowerStatement(
+            unit_facts, proc_state, scope_state, stack, *item.stmt);
+        if (!item_stmt) return std::unexpected(std::move(item_stmt.error()));
+        const hir::StmtId item_id = proc_state.AddStmt(*std::move(item_stmt));
+        items.push_back(
+            hir::CaseItem{.labels = std::move(label_ids), .stmt = item_id});
+      }
+      std::optional<hir::StmtId> default_id;
+      if (cs.defaultCase != nullptr) {
+        auto default_stmt = LowerStatement(
+            unit_facts, proc_state, scope_state, stack, *cs.defaultCase);
+        if (!default_stmt) {
+          return std::unexpected(std::move(default_stmt.error()));
+        }
+        default_id = proc_state.AddStmt(*std::move(default_stmt));
+      }
+      return hir::Stmt{
+          .label = std::nullopt,
+          .data =
+              hir::CaseStmt{
+                  .condition = cond_id,
+                  .items = std::move(items),
+                  .default_stmt = default_id},
+          .span = span};
+    }
+
     case slang::ast::StatementKind::Conditional: {
       const auto& cs = stmt.as<slang::ast::ConditionalStatement>();
       if (cs.check != slang::ast::UniquePriorityCheck::None) {

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -286,6 +286,80 @@ auto LowerStmt(
                         .scope = body_scope_id},
                 .child_procedural_scopes = std::move(child_scopes)};
           },
+          [&](const hir::CaseStmt& c) -> diag::Result<mir::Stmt> {
+            auto cond_or = LowerExpr(
+                unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+                hir_proc.exprs.at(c.condition.value));
+            if (!cond_or) {
+              return std::unexpected(std::move(cond_or.error()));
+            }
+            const mir::ExprId cond_id =
+                proc_scope_state.AddExpr(*std::move(cond_or));
+
+            auto lower_branch = [&](hir::StmtId branch_hir_id)
+                -> diag::Result<mir::ProceduralScope> {
+              ProceduralScopeLoweringState branch_state;
+              ProceduralDepthGuard depth_guard{proc_state};
+              const hir::Stmt& branch_hir =
+                  hir_proc.stmts.at(branch_hir_id.value);
+              auto branch_or = LowerStmt(
+                  unit_state, scope_state, proc_state, branch_state, hir_proc,
+                  branch_hir);
+              if (!branch_or) {
+                return std::unexpected(std::move(branch_or.error()));
+              }
+              const mir::StmtId stmt_id =
+                  branch_state.AddStmt(*std::move(branch_or));
+              branch_state.AddRootStmt(stmt_id);
+              return branch_state.Finish();
+            };
+
+            std::vector<mir::ProceduralScope> child_scopes;
+            std::vector<mir::SwitchCase> cases;
+            cases.reserve(c.items.size());
+            for (const auto& item : c.items) {
+              std::vector<mir::ExprId> labels;
+              labels.reserve(item.labels.size());
+              for (const hir::ExprId label_hid : item.labels) {
+                auto label_or = LowerExpr(
+                    unit_state, scope_state, proc_state, proc_scope_state,
+                    hir_proc, hir_proc.exprs.at(label_hid.value));
+                if (!label_or) {
+                  return std::unexpected(std::move(label_or.error()));
+                }
+                labels.push_back(
+                    proc_scope_state.AddExpr(*std::move(label_or)));
+              }
+              auto branch_or = lower_branch(item.stmt);
+              if (!branch_or) {
+                return std::unexpected(std::move(branch_or.error()));
+              }
+              const mir::ProceduralScopeId item_scope_id =
+                  AddChildProceduralScope(child_scopes, std::move(*branch_or));
+              cases.push_back(
+                  mir::SwitchCase{
+                      .labels = std::move(labels), .scope = item_scope_id});
+            }
+
+            std::optional<mir::ProceduralScopeId> default_scope_id;
+            if (c.default_stmt.has_value()) {
+              auto default_or = lower_branch(*c.default_stmt);
+              if (!default_or) {
+                return std::unexpected(std::move(default_or.error()));
+              }
+              default_scope_id =
+                  AddChildProceduralScope(child_scopes, std::move(*default_or));
+            }
+
+            return mir::Stmt{
+                .label = stmt.label,
+                .data =
+                    mir::SwitchStmt{
+                        .condition = cond_id,
+                        .cases = std::move(cases),
+                        .default_scope = default_scope_id},
+                .child_procedural_scopes = std::move(child_scopes)};
+          },
           [&](const hir::IfStmt& i) -> diag::Result<mir::Stmt> {
             auto cond_expr_or = LowerExpr(
                 unit_state, scope_state, proc_state, proc_scope_state, hir_proc,

--- a/tests/cases/cpp/case_basic/case.yaml
+++ b/tests/cases/cpp/case_basic/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.case_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      single=100
+      multi=22
+      defaulted=100
+      unchanged=99

--- a/tests/cases/cpp/case_basic/main.sv
+++ b/tests/cases/cpp/case_basic/main.sv
@@ -1,0 +1,36 @@
+module Top;
+  initial begin
+    int single = 0;
+    int multi = 0;
+    int defaulted = 0;
+    int unchanged = 99;
+
+    case (3)
+      3: single = 100;
+      default: single = 999;
+    endcase
+
+    case (2)
+      0: multi = 1;
+      1, 2: multi = 22;
+      3: multi = 3;
+      default: multi = 999;
+    endcase
+
+    case (5)
+      0: defaulted = 1;
+      1: defaulted = 2;
+      default: defaulted = 100;
+    endcase
+
+    case (5)
+      0: unchanged = 1;
+      1: unchanged = 2;
+    endcase
+
+    $display("single=%0d", single);
+    $display("multi=%0d", multi);
+    $display("defaulted=%0d", defaulted);
+    $display("unchanged=%0d", unchanged);
+  end
+endmodule

--- a/tests/cases/cpp/case_empty_body/case.yaml
+++ b/tests/cases/cpp/case_empty_body/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.case_empty_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "result=1\n"

--- a/tests/cases/cpp/case_empty_body/main.sv
+++ b/tests/cases/cpp/case_empty_body/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  initial begin
+    int val = 2;
+    int result = 0;
+    case (val)
+      1: result = 10;
+      2: ;
+      3: result = 30;
+    endcase
+    result = result + 1;
+    $display("result=%0d", result);
+  end
+endmodule

--- a/tests/cases/cpp/case_in_for_body/case.yaml
+++ b/tests/cases/cpp/case_in_for_body/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.case_in_for_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      zero=1
+      pair=2
+      three=1
+      other=1

--- a/tests/cases/cpp/case_in_for_body/main.sv
+++ b/tests/cases/cpp/case_in_for_body/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  initial begin
+    int zero = 0;
+    int pair = 0;
+    int three = 0;
+    int other = 0;
+    for (int i = 0; i < 5; i = i + 1) begin
+      case (i)
+        0:    zero  = zero  + 1;
+        1, 2: pair  = pair  + 1;
+        3:    three = three + 1;
+        default: other = other + 1;
+      endcase
+    end
+    $display("zero=%0d", zero);
+    $display("pair=%0d", pair);
+    $display("three=%0d", three);
+    $display("other=%0d", other);
+  end
+endmodule

--- a/tests/cases/cpp/case_nested/case.yaml
+++ b/tests/cases/cpp/case_nested/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.case_nested
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "result=12\n"

--- a/tests/cases/cpp/case_nested/main.sv
+++ b/tests/cases/cpp/case_nested/main.sv
@@ -1,0 +1,24 @@
+module Top;
+  initial begin
+    int x = 1;
+    int y = 2;
+    int result = 0;
+    case (x)
+      1: begin
+        case (y)
+          1: result = 11;
+          2: result = 12;
+          default: result = 19;
+        endcase
+      end
+      2: begin
+        case (y)
+          1: result = 21;
+          2: result = 22;
+        endcase
+      end
+      default: result = 99;
+    endcase
+    $display("result=%0d", result);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Extends the AST -> HIR -> MIR -> backend::cpp pipeline to lower plain procedural `case` statements with integer-literal labels. The MIR `SwitchStmt` and the C++ backend render are unchanged -- this PR fills in the upstream layers that were previously only reachable from generate-case.

## Design

Adds `hir::CaseStmt` and `hir::CaseItem` mirroring the MIR shape. The AST -> HIR arm reads slang's `CaseStatement.expr`, `items`, and `defaultCase`; each item's expressions become the labels and its statement becomes the branch body (lowered recursively). HIR -> MIR wraps each branch body in its own `mir::ProceduralScope`, exactly as the generate-case path in `lower_constructor.cpp` already does. The dumper prints the new node with one line per item plus an optional `default:` block.

`casez` / `casex` / `case ... inside`, the `unique` / `unique0` / `priority` qualifiers, and `PatternCaseStatement` are all rejected up front with `diag::Unsupported`. Each of these gates a separate sub-step in `control-flow.md`.

## Documentation

Introduces `docs/progress/control-flow.md` as the dedicated workstream file for procedural control flow (C1-C17). C1 (if/else), C2 (for), and C3 (case, this PR) are checked; remaining sub-steps cover while, repeat, do-while, foreach, forever, loop control (break/continue), casez/casex, case-inside, unique/priority qualifiers, ternary, plus three case variants that need an if/else-cascade lowering (non-constant labels, duplicate labels, enum/string selectors).

`docs/progress/architecture-reset.md` is simplified: the `### control_flow` and `### operators` sections collapse to a single pointer at their respective dedicated files, matching the pattern operators.md already established. A new rule in the intro states that when a workstream has its own progress file, the granular sub-step tracking lives there and the archive-item inventory below is high-level only.

## Testing

Four behavioral cases under `tests/cases/cpp/`:

- `case_basic` -- single-label hit, multi-label (`1, 2`) hit, default fires, no-default-no-match leaves the variable untouched.
- `case_in_for_body` -- case selector is a for-loop counter; verifies the case body is re-evaluated each iteration and composes with the for-loop machinery from the previous PR.
- `case_nested` -- `case (x)` whose branch body contains another `case (y)`.
- `case_empty_body` -- `2: ;` empty-statement body parses and renders.

`bazel test //...` is green; clang-format, buildifier, prettier, and all four policy checks pass.

## Notes

Case completion estimate: the core plain-case machinery is end-to-end (~100% of the lowering scaffolding), covering roughly 80% of the most common SV plain-case usage. Total SV `case` spec coverage is ~40%: casez/casex (heavily used in hardware decoders), case-inside, non-constant labels, duplicate labels, enum/string selectors, and the unique/priority qualifiers are all separate workstreams tracked in `control-flow.md`. None of those leak into the plain-case path -- they are clean extensions on top of this base.