### PR TITLE
Lower while loops end-to-end to C++ emit

### DIFF
--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -21,10 +21,10 @@ checked when its `*.yaml` cases reproduce on the current pipeline.
       no-default-no-match, empty body, nested) using integer-literal labels and integer selectors.
       Variants requiring an if/else-cascade lowering (non-constant labels, duplicate labels) are
       tracked in C15; enum/string selectors and labels are tracked in C16 and C17 respectively.
-- [ ] C4 -- `while` (procedural while-loop). `mir::WhileStmt` exists but
-      `src/lyra/backend/cpp/render_stmt.cpp:268-271` throws `InternalError`; needs HIR node, AST ->
-      HIR arm, HIR -> MIR arm, and render. Reproduces `control_flow/while/default.yaml` once C7
-      lands.
+- [x] C4 -- `while` (procedural while-loop). Reproduces every `control_flow/while/default.yaml` case
+      that does not depend on `break` (deferred to C7). Includes runtime-condition loops, countdown,
+      `while (0)` zero iterations, two-level nesting, and mixed nesting with `for` in both
+      directions.
 - [ ] C5 -- `repeat (N)`. Pure desugaring to `for (int __k = 0; __k < N; __k = __k + 1)` over the C2
       machinery. Counts as one PR after C2 land.
 - [ ] C6 -- `do_while`. Lowers to `while(true) { body; if (!cond) break; }` over C4 + C7.

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -75,6 +75,11 @@ struct ForStmt {
   StmtId body;
 };
 
+struct WhileStmt {
+  ExprId condition;
+  StmtId body;
+};
+
 struct DelayControl {
   ExprId duration;
 };
@@ -90,7 +95,7 @@ struct TimedStmt {
 
 using StmtData = std::variant<
     EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, IfStmt, CaseStmt, ForStmt,
-    TimedStmt>;
+    WhileStmt, TimedStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -148,7 +148,7 @@ auto RenderStmt(
                 ctx.ProceduralScope().exprs.at(s.condition.value);
             const auto& then_scope =
                 stmt.child_procedural_scopes.at(s.then_scope.value);
-            auto cond_or = RenderExpr(ctx, cond_expr);
+            auto cond_or = RenderExprAsNative(ctx, cond_expr);
             if (!cond_or) return std::unexpected(std::move(cond_or.error()));
             auto then_or =
                 RenderNestedProceduralScope(ctx, then_scope, indent + 1);
@@ -173,7 +173,7 @@ auto RenderStmt(
           [&](const mir::SwitchStmt& s) -> diag::Result<std::string> {
             const auto& cond_expr =
                 ctx.ProceduralScope().exprs.at(s.condition.value);
-            auto cond_or = RenderExpr(ctx, cond_expr);
+            auto cond_or = RenderExprAsNative(ctx, cond_expr);
             if (!cond_or) return std::unexpected(std::move(cond_or.error()));
             std::string result;
             result += Indent(indent) + "switch (" + *cond_or + ") {\n";
@@ -181,7 +181,7 @@ auto RenderStmt(
               for (std::size_t i = 0; i < c.labels.size(); ++i) {
                 const auto& label_expr =
                     ctx.ProceduralScope().exprs.at(c.labels[i].value);
-                auto label_or = RenderExpr(ctx, label_expr);
+                auto label_or = RenderExprAsNative(ctx, label_expr);
                 if (!label_or) {
                   return std::unexpected(std::move(label_or.error()));
                 }
@@ -284,9 +284,23 @@ auto RenderStmt(
             result += Indent(indent) + "}\n";
             return result;
           },
-          [&](const mir::WhileStmt&) -> diag::Result<std::string> {
-            throw InternalError(
-                "RenderStmt: WhileStmt is not yet supported by C++ emit");
+          [&](const mir::WhileStmt& s) -> diag::Result<std::string> {
+            const auto& cond_expr =
+                ctx.ProceduralScope().exprs.at(s.condition.value);
+            auto cond_or = RenderExprAsNative(ctx, cond_expr);
+            if (!cond_or) {
+              return std::unexpected(std::move(cond_or.error()));
+            }
+            const auto& scope = stmt.child_procedural_scopes.at(s.scope.value);
+            auto body_or = RenderNestedProceduralScope(ctx, scope, indent + 1);
+            if (!body_or) {
+              return std::unexpected(std::move(body_or.error()));
+            }
+            std::string result =
+                Indent(indent) + "while (" + *std::move(cond_or) + ") {\n";
+            result += *body_or;
+            result += Indent(indent) + "}\n";
+            return result;
           },
           [&](const mir::AwaitStmt&) -> diag::Result<std::string> {
             throw InternalError(

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -721,6 +721,22 @@ class HirDumper {
               Dedent();
               Dedent();
             },
+            [&](const WhileStmt& w) {
+              Line(
+                  std::format(
+                      "Stmt[{}] WhileStmt cond=Expr[{}]", id.value,
+                      w.condition.value));
+              Indent();
+              Line(
+                  std::format(
+                      "Expr[{}] {}", w.condition.value,
+                      FormatProcExpr(p, w.condition)));
+              Line("body:");
+              Indent();
+              DumpStmt(p, w.body);
+              Dedent();
+              Dedent();
+            },
             [&](const TimedStmt& t) {
               Line(std::format("Stmt[{}] TimedStmt", id.value));
               Indent();

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -208,6 +208,22 @@ auto LowerStatement(
           .span = span};
     }
 
+    case slang::ast::StatementKind::WhileLoop: {
+      const auto& ws = stmt.as<slang::ast::WhileLoopStatement>();
+      auto cond_or = LowerProcExpr(
+          unit_facts, scope_state.UnitState(), proc_state, stack, ws.cond);
+      if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+      const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_or));
+      auto body_or =
+          LowerStatement(unit_facts, proc_state, scope_state, stack, ws.body);
+      if (!body_or) return std::unexpected(std::move(body_or.error()));
+      const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_or));
+      return hir::Stmt{
+          .label = std::nullopt,
+          .data = hir::WhileStmt{.condition = cond_id, .body = body_id},
+          .span = span};
+    }
+
     case slang::ast::StatementKind::Case: {
       const auto& cs = stmt.as<slang::ast::CaseStatement>();
       if (cs.condition != slang::ast::CaseStatementCondition::Normal) {

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -412,6 +412,39 @@ auto LowerStmt(
                         .else_scope = else_scope_id},
                 .child_procedural_scopes = std::move(child_scopes)};
           },
+          [&](const hir::WhileStmt& w) -> diag::Result<mir::Stmt> {
+            auto cond_or = LowerExpr(
+                unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+                hir_proc.exprs.at(w.condition.value));
+            if (!cond_or) {
+              return std::unexpected(std::move(cond_or.error()));
+            }
+            const mir::ExprId cond_id =
+                proc_scope_state.AddExpr(*std::move(cond_or));
+
+            ProceduralScopeLoweringState body_state;
+            ProceduralDepthGuard depth_guard{proc_state};
+            const hir::Stmt& body_hir = hir_proc.stmts.at(w.body.value);
+            auto body_or = LowerStmt(
+                unit_state, scope_state, proc_state, body_state, hir_proc,
+                body_hir);
+            if (!body_or) {
+              return std::unexpected(std::move(body_or.error()));
+            }
+            const mir::StmtId body_id = body_state.AddStmt(*std::move(body_or));
+            body_state.AddRootStmt(body_id);
+
+            std::vector<mir::ProceduralScope> child_scopes;
+            const mir::ProceduralScopeId body_scope_id =
+                AddChildProceduralScope(child_scopes, body_state.Finish());
+
+            return mir::Stmt{
+                .label = stmt.label,
+                .data =
+                    mir::WhileStmt{
+                        .condition = cond_id, .scope = body_scope_id},
+                .child_procedural_scopes = std::move(child_scopes)};
+          },
           [&](const hir::TimedStmt& t) -> diag::Result<mir::Stmt> {
             auto timing_or =
                 LowerTimingControl(proc_state, hir_proc, t.timing, stmt.span);

--- a/tests/cases/cpp/while_loop_basic/case.yaml
+++ b/tests/cases/cpp/while_loop_basic/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.while_loop_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "i=5 sum=10\n"

--- a/tests/cases/cpp/while_loop_basic/main.sv
+++ b/tests/cases/cpp/while_loop_basic/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  initial begin
+    int i = 0;
+    int sum = 0;
+    while (i < 5) begin
+      sum = sum + i;
+      i = i + 1;
+    end
+    $display("i=%0d sum=%0d", i, sum);
+  end
+endmodule

--- a/tests/cases/cpp/while_loop_countdown/case.yaml
+++ b/tests/cases/cpp/while_loop_countdown/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.while_loop_countdown
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "i=0 product=24\n"

--- a/tests/cases/cpp/while_loop_countdown/main.sv
+++ b/tests/cases/cpp/while_loop_countdown/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  initial begin
+    int i = 4;
+    int product = 1;
+    while (i > 0) begin
+      product = product * i;
+      i = i - 1;
+    end
+    $display("i=%0d product=%0d", i, product);
+  end
+endmodule

--- a/tests/cases/cpp/while_loop_for_in_body/case.yaml
+++ b/tests/cases/cpp/while_loop_for_in_body/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.while_loop_for_in_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "total=12\n"

--- a/tests/cases/cpp/while_loop_for_in_body/main.sv
+++ b/tests/cases/cpp/while_loop_for_in_body/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  initial begin
+    int row = 0;
+    int total = 0;
+    while (row < 3) begin
+      for (int col = 0; col < 4; col = col + 1) begin
+        total = total + 1;
+      end
+      row = row + 1;
+    end
+    $display("total=%0d", total);
+  end
+endmodule

--- a/tests/cases/cpp/while_loop_if_in_body/case.yaml
+++ b/tests/cases/cpp/while_loop_if_in_body/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.while_loop_if_in_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "low=5 high=5\n"

--- a/tests/cases/cpp/while_loop_if_in_body/main.sv
+++ b/tests/cases/cpp/while_loop_if_in_body/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  initial begin
+    int i = 0;
+    int low = 0;
+    int high = 0;
+    while (i < 10) begin
+      if (i < 5)
+        low = low + 1;
+      else
+        high = high + 1;
+      i = i + 1;
+    end
+    $display("low=%0d high=%0d", low, high);
+  end
+endmodule

--- a/tests/cases/cpp/while_loop_in_for_body/case.yaml
+++ b/tests/cases/cpp/while_loop_in_for_body/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.while_loop_in_for_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "total=12\n"

--- a/tests/cases/cpp/while_loop_in_for_body/main.sv
+++ b/tests/cases/cpp/while_loop_in_for_body/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  initial begin
+    int total = 0;
+    for (int row = 0; row < 3; row = row + 1) begin
+      int col = 0;
+      while (col < 4) begin
+        total = total + 1;
+        col = col + 1;
+      end
+    end
+    $display("total=%0d", total);
+  end
+endmodule

--- a/tests/cases/cpp/while_loop_nested/case.yaml
+++ b/tests/cases/cpp/while_loop_nested/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.while_loop_nested
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "total=12\n"

--- a/tests/cases/cpp/while_loop_nested/main.sv
+++ b/tests/cases/cpp/while_loop_nested/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  initial begin
+    int i = 0;
+    int total = 0;
+    while (i < 3) begin
+      int j = 0;
+      while (j < 4) begin
+        total = total + 1;
+        j = j + 1;
+      end
+      i = i + 1;
+    end
+    $display("total=%0d", total);
+  end
+endmodule

--- a/tests/cases/cpp/while_loop_runtime_condition/case.yaml
+++ b/tests/cases/cpp/while_loop_runtime_condition/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.while_loop_runtime_condition
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "n=256 iters=8\n"

--- a/tests/cases/cpp/while_loop_runtime_condition/main.sv
+++ b/tests/cases/cpp/while_loop_runtime_condition/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  initial begin
+    int n = 1;
+    int iters = 0;
+    while (n != 256) begin
+      n = n * 2;
+      iters = iters + 1;
+    end
+    $display("n=%0d iters=%0d", n, iters);
+  end
+endmodule

--- a/tests/cases/cpp/while_loop_single_stmt/case.yaml
+++ b/tests/cases/cpp/while_loop_single_stmt/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.while_loop_single_stmt
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "i=7\n"

--- a/tests/cases/cpp/while_loop_single_stmt/main.sv
+++ b/tests/cases/cpp/while_loop_single_stmt/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  initial begin
+    int i = 0;
+    while (i < 7) i = i + 1;
+    $display("i=%0d", i);
+  end
+endmodule

--- a/tests/cases/cpp/while_loop_zero_iterations/case.yaml
+++ b/tests/cases/cpp/while_loop_zero_iterations/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.while_loop_zero_iterations
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "hits=0 i=5\n"

--- a/tests/cases/cpp/while_loop_zero_iterations/main.sv
+++ b/tests/cases/cpp/while_loop_zero_iterations/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  initial begin
+    int hits = 0;
+    int i = 5;
+    while (i < 0) begin
+      hits = hits + 1;
+      i = i + 1;
+    end
+    $display("hits=%0d i=%0d", hits, i);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds end-to-end support for SystemVerilog `while` loops through the HIR -> MIR -> backend::cpp pipeline. The new `hir::WhileStmt` lowers to the existing `mir::WhileStmt`, and the C++ backend now emits `while (cond) { body }` (previously threw `InternalError`). Also fixes a latent bug where `if`/`switch` conditions routed binary-comparison results through the packed-top-level render path, which is not yet implemented; predicate positions now uniformly use `RenderExprAsNative`, matching `for`/`while`. This unblocks `if (i < 5)` and `case (a + b)` shapes that no prior test happened to exercise.

## Testing

Nine `cpp_run` cases under `tests/cases/cpp/while_loop_*` cover: basic counter, countdown, `while (0)` zero iterations, runtime-condition exit, two-level nesting, if-in-body, single-statement body (no `begin`/`end`), and mixed nesting with `for` in both directions. `bazel test //...` passes all 160 cases.