### PR TITLE
Lower repeat (N) loops via count snapshot

### DIFF
--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -25,8 +25,12 @@ checked when its `*.yaml` cases reproduce on the current pipeline.
       that does not depend on `break` (deferred to C7). Includes runtime-condition loops, countdown,
       `while (0)` zero iterations, two-level nesting, and mixed nesting with `for` in both
       directions.
-- [ ] C5 -- `repeat (N)`. Pure desugaring to `for (int __k = 0; __k < N; __k = __k + 1)` over the C2
-      machinery. Counts as one PR after C2 land.
+- [x] C5 -- `repeat (N)`. Reproduces every `control_flow/repeat/default.yaml` case that does not
+      depend on `break` (deferred to C7). HIR carries a faithful `RepeatStmt`; HIR -> MIR desugars
+      to a wrapper `BlockStmt` containing a count snapshot (preserves SV's "evaluate count once"
+      semantic for side-effecting count expressions) plus an `mir::ForStmt` over the C2 machinery.
+      Coverage includes literal counts, runtime counts, zero iterations, count-evaluated-once,
+      nesting, single-statement body, and mixed nesting with `if`/`for`/`while`.
 - [ ] C6 -- `do_while`. Lowers to `while(true) { body; if (!cond) break; }` over C4 + C7.
 - [ ] C7 -- Loop control: `break`, `continue`. New HIR/MIR statements + C++ render. Shared by C2
       (for) / C4 (while) / C5 (repeat) / C6 (do-while) / C9 (foreach). Coroutine renderer must scope

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -80,6 +80,11 @@ struct WhileStmt {
   StmtId body;
 };
 
+struct RepeatStmt {
+  ExprId count;
+  StmtId body;
+};
+
 struct DelayControl {
   ExprId duration;
 };
@@ -95,7 +100,7 @@ struct TimedStmt {
 
 using StmtData = std::variant<
     EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, IfStmt, CaseStmt, ForStmt,
-    WhileStmt, TimedStmt>;
+    WhileStmt, RepeatStmt, TimedStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -737,6 +737,22 @@ class HirDumper {
               Dedent();
               Dedent();
             },
+            [&](const RepeatStmt& r) {
+              Line(
+                  std::format(
+                      "Stmt[{}] RepeatStmt count=Expr[{}]", id.value,
+                      r.count.value));
+              Indent();
+              Line(
+                  std::format(
+                      "Expr[{}] {}", r.count.value,
+                      FormatProcExpr(p, r.count)));
+              Line("body:");
+              Indent();
+              DumpStmt(p, r.body);
+              Dedent();
+              Dedent();
+            },
             [&](const TimedStmt& t) {
               Line(std::format("Stmt[{}] TimedStmt", id.value));
               Indent();

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -224,6 +224,22 @@ auto LowerStatement(
           .span = span};
     }
 
+    case slang::ast::StatementKind::RepeatLoop: {
+      const auto& rs = stmt.as<slang::ast::RepeatLoopStatement>();
+      auto count_or = LowerProcExpr(
+          unit_facts, scope_state.UnitState(), proc_state, stack, rs.count);
+      if (!count_or) return std::unexpected(std::move(count_or.error()));
+      const hir::ExprId count_id = proc_state.AddExpr(*std::move(count_or));
+      auto body_or =
+          LowerStatement(unit_facts, proc_state, scope_state, stack, rs.body);
+      if (!body_or) return std::unexpected(std::move(body_or.error()));
+      const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_or));
+      return hir::Stmt{
+          .label = std::nullopt,
+          .data = hir::RepeatStmt{.count = count_id, .body = body_id},
+          .span = span};
+    }
+
     case slang::ast::StatementKind::Case: {
       const auto& cs = stmt.as<slang::ast::CaseStatement>();
       if (cs.condition != slang::ast::CaseStatementCondition::Normal) {

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -445,6 +445,166 @@ auto LowerStmt(
                         .condition = cond_id, .scope = body_scope_id},
                 .child_procedural_scopes = std::move(child_scopes)};
           },
+          [&](const hir::RepeatStmt& r) -> diag::Result<mir::Stmt> {
+            const mir::TypeId int_type = unit_state.Builtins().int32;
+            const mir::TypeId bit_type = unit_state.Builtins().bit1;
+
+            ProceduralScopeLoweringState wrapper_state;
+            ProceduralDepthGuard wrapper_depth_guard{proc_state};
+
+            auto count_or = LowerExpr(
+                unit_state, scope_state, proc_state, wrapper_state, hir_proc,
+                hir_proc.exprs.at(r.count.value));
+            if (!count_or) {
+              return std::unexpected(std::move(count_or.error()));
+            }
+            mir::ExprId count_expr_id =
+                wrapper_state.AddExpr(*std::move(count_or));
+            if (wrapper_state.GetExpr(count_expr_id).type != int_type) {
+              count_expr_id = wrapper_state.AddExpr(
+                  mir::Expr{
+                      .data =
+                          mir::ConversionExpr{
+                              .operand = count_expr_id,
+                              .kind = mir::ConversionKind::kImplicit},
+                      .type = int_type});
+            }
+
+            const mir::ProceduralVarId count_var =
+                wrapper_state.AddProceduralVar(
+                    mir::ProceduralVarDecl{
+                        .name = "_lyra_repeat_count", .type = int_type});
+
+            const mir::StmtId count_decl_id = wrapper_state.AddStmt(
+                mir::Stmt{
+                    .label = std::nullopt,
+                    .data =
+                        mir::ProceduralVarDeclStmt{
+                            .target =
+                                mir::ProceduralVarRef{
+                                    .hops = mir::ProceduralHops{.value = 0},
+                                    .var = count_var},
+                            .init = count_expr_id},
+                    .child_procedural_scopes = {}});
+            wrapper_state.AddRootStmt(count_decl_id);
+
+            const mir::ProceduralVarId idx_var = wrapper_state.AddProceduralVar(
+                mir::ProceduralVarDecl{
+                    .name = "_lyra_repeat_index", .type = int_type});
+
+            auto make_int32_literal = [&](std::uint64_t v) -> mir::ExprId {
+              return wrapper_state.AddExpr(
+                  mir::Expr{
+                      .data =
+                          mir::IntegerLiteral{
+                              .value =
+                                  mir::IntegralConstant{
+                                      .value_words = {v},
+                                      .state_words = {},
+                                      .width = 32,
+                                      .signedness = mir::Signedness::kSigned,
+                                      .state_kind =
+                                          mir::IntegralStateKind::kTwoState}},
+                      .type = int_type});
+            };
+
+            const mir::ExprId zero_id = make_int32_literal(0);
+            const mir::ExprId one_id = make_int32_literal(1);
+
+            const mir::ExprId idx_ref_cond = wrapper_state.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::ProceduralVarRef{
+                            .hops = mir::ProceduralHops{.value = 0},
+                            .var = idx_var},
+                    .type = int_type});
+            const mir::ExprId count_ref_cond = wrapper_state.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::ProceduralVarRef{
+                            .hops = mir::ProceduralHops{.value = 0},
+                            .var = count_var},
+                    .type = int_type});
+            const mir::ExprId cond_id = wrapper_state.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::BinaryExpr{
+                            .op = mir::BinaryOp::kLessThan,
+                            .lhs = idx_ref_cond,
+                            .rhs = count_ref_cond},
+                    .type = bit_type});
+
+            const mir::ExprId idx_ref_step = wrapper_state.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::ProceduralVarRef{
+                            .hops = mir::ProceduralHops{.value = 0},
+                            .var = idx_var},
+                    .type = int_type});
+            const mir::ExprId add_id = wrapper_state.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::BinaryExpr{
+                            .op = mir::BinaryOp::kAdd,
+                            .lhs = idx_ref_step,
+                            .rhs = one_id},
+                    .type = int_type});
+            const mir::ExprId step_id = wrapper_state.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::AssignExpr{
+                            .target = mir::Lvalue{mir::ProceduralVarRef{
+                                .hops = mir::ProceduralHops{.value = 0},
+                                .var = idx_var}},
+                            .value = add_id},
+                    .type = int_type});
+
+            ProceduralScopeLoweringState body_state;
+            ProceduralDepthGuard body_depth_guard{proc_state};
+            const hir::Stmt& body_hir = hir_proc.stmts.at(r.body.value);
+            auto body_or = LowerStmt(
+                unit_state, scope_state, proc_state, body_state, hir_proc,
+                body_hir);
+            if (!body_or) {
+              return std::unexpected(std::move(body_or.error()));
+            }
+            const mir::StmtId body_id = body_state.AddStmt(*std::move(body_or));
+            body_state.AddRootStmt(body_id);
+
+            std::vector<mir::ProceduralScope> for_child_scopes;
+            const mir::ProceduralScopeId body_scope_id =
+                AddChildProceduralScope(for_child_scopes, body_state.Finish());
+
+            std::vector<mir::ForInit> for_init;
+            for_init.emplace_back(
+                mir::ForInitDecl{
+                    .induction_var =
+                        mir::ProceduralVarRef{
+                            .hops = mir::ProceduralHops{.value = 0},
+                            .var = idx_var},
+                    .init = zero_id});
+
+            const mir::StmtId for_stmt_id = wrapper_state.AddStmt(
+                mir::Stmt{
+                    .label = std::nullopt,
+                    .data =
+                        mir::ForStmt{
+                            .init = std::move(for_init),
+                            .condition = cond_id,
+                            .step = {step_id},
+                            .scope = body_scope_id},
+                    .child_procedural_scopes = std::move(for_child_scopes)});
+            wrapper_state.AddRootStmt(for_stmt_id);
+
+            std::vector<mir::ProceduralScope> child_scopes;
+            const mir::ProceduralScopeId wrapper_scope_id =
+                AddChildProceduralScope(child_scopes, wrapper_state.Finish());
+
+            return mir::Stmt{
+                .label = stmt.label,
+                .data = mir::BlockStmt{.scope = wrapper_scope_id},
+                .child_procedural_scopes = std::move(child_scopes)};
+          },
           [&](const hir::TimedStmt& t) -> diag::Result<mir::Stmt> {
             auto timing_or =
                 LowerTimingControl(proc_state, hir_proc, t.timing, stmt.span);

--- a/tests/cases/cpp/repeat_basic/case.yaml
+++ b/tests/cases/cpp/repeat_basic/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.repeat_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "sum=10\n"

--- a/tests/cases/cpp/repeat_basic/main.sv
+++ b/tests/cases/cpp/repeat_basic/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  initial begin
+    int sum = 0;
+    int i = 0;
+    repeat (5) begin
+      sum = sum + i;
+      i = i + 1;
+    end
+    $display("sum=%0d", sum);
+  end
+endmodule

--- a/tests/cases/cpp/repeat_count_evaluated_once/case.yaml
+++ b/tests/cases/cpp/repeat_count_evaluated_once/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.repeat_count_evaluated_once
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "iters=3 final=0\n"

--- a/tests/cases/cpp/repeat_count_evaluated_once/main.sv
+++ b/tests/cases/cpp/repeat_count_evaluated_once/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  initial begin
+    int n = 3;
+    int iters = 0;
+    repeat (n) begin
+      iters = iters + 1;
+      n = n - 1;
+    end
+    $display("iters=%0d final=%0d", iters, n);
+  end
+endmodule

--- a/tests/cases/cpp/repeat_for_in_body/case.yaml
+++ b/tests/cases/cpp/repeat_for_in_body/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.repeat_for_in_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "total=18\n"

--- a/tests/cases/cpp/repeat_for_in_body/main.sv
+++ b/tests/cases/cpp/repeat_for_in_body/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  initial begin
+    int total = 0;
+    repeat (3) begin
+      for (int j = 0; j < 3; j = j + 1) begin
+        total = total + (j + 1);
+      end
+    end
+    $display("total=%0d", total);
+  end
+endmodule

--- a/tests/cases/cpp/repeat_if_in_body/case.yaml
+++ b/tests/cases/cpp/repeat_if_in_body/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.repeat_if_in_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "evens=3 i=6\n"

--- a/tests/cases/cpp/repeat_if_in_body/main.sv
+++ b/tests/cases/cpp/repeat_if_in_body/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  initial begin
+    int i = 0;
+    int evens = 0;
+    repeat (6) begin
+      if (i < 3)
+        evens = evens + 1;
+      i = i + 1;
+    end
+    $display("evens=%0d i=%0d", evens, i);
+  end
+endmodule

--- a/tests/cases/cpp/repeat_in_for_body/case.yaml
+++ b/tests/cases/cpp/repeat_in_for_body/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.repeat_in_for_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "count=12\n"

--- a/tests/cases/cpp/repeat_in_for_body/main.sv
+++ b/tests/cases/cpp/repeat_in_for_body/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  initial begin
+    int count = 0;
+    for (int i = 0; i < 4; i = i + 1) begin
+      repeat (3) begin
+        count = count + 1;
+      end
+    end
+    $display("count=%0d", count);
+  end
+endmodule

--- a/tests/cases/cpp/repeat_in_while_body/case.yaml
+++ b/tests/cases/cpp/repeat_in_while_body/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.repeat_in_while_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "count=10\n"

--- a/tests/cases/cpp/repeat_in_while_body/main.sv
+++ b/tests/cases/cpp/repeat_in_while_body/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  initial begin
+    int i = 0;
+    int count = 0;
+    while (i < 5) begin
+      repeat (2) begin
+        count = count + 1;
+      end
+      i = i + 1;
+    end
+    $display("count=%0d", count);
+  end
+endmodule

--- a/tests/cases/cpp/repeat_nested/case.yaml
+++ b/tests/cases/cpp/repeat_nested/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.repeat_nested
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "count=6\n"

--- a/tests/cases/cpp/repeat_nested/main.sv
+++ b/tests/cases/cpp/repeat_nested/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  initial begin
+    int count = 0;
+    repeat (3) begin
+      repeat (2) begin
+        count = count + 1;
+      end
+    end
+    $display("count=%0d", count);
+  end
+endmodule

--- a/tests/cases/cpp/repeat_single_stmt/case.yaml
+++ b/tests/cases/cpp/repeat_single_stmt/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.repeat_single_stmt
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "x=4\n"

--- a/tests/cases/cpp/repeat_single_stmt/main.sv
+++ b/tests/cases/cpp/repeat_single_stmt/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  initial begin
+    int x = 0;
+    repeat (4) x = x + 1;
+    $display("x=%0d", x);
+  end
+endmodule

--- a/tests/cases/cpp/repeat_variable_count/case.yaml
+++ b/tests/cases/cpp/repeat_variable_count/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.repeat_variable_count
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "sum=21\n"

--- a/tests/cases/cpp/repeat_variable_count/main.sv
+++ b/tests/cases/cpp/repeat_variable_count/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  initial begin
+    int n = 6;
+    int sum = 0;
+    int i = 1;
+    repeat (n) begin
+      sum = sum + i;
+      i = i + 1;
+    end
+    $display("sum=%0d", sum);
+  end
+endmodule

--- a/tests/cases/cpp/repeat_zero_iterations/case.yaml
+++ b/tests/cases/cpp/repeat_zero_iterations/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.repeat_zero_iterations
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "sum=0\n"

--- a/tests/cases/cpp/repeat_zero_iterations/main.sv
+++ b/tests/cases/cpp/repeat_zero_iterations/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  initial begin
+    int sum = 0;
+    repeat (0) begin
+      sum = sum + 1;
+    end
+    $display("sum=%0d", sum);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds SV `repeat (N) body` end-to-end through HIR -> MIR -> C++ emit. HIR carries a faithful `RepeatStmt`. HIR -> MIR desugars to a wrapper `BlockStmt` that snapshots the count expression into a local before iterating, so the SV "evaluate count once" semantic holds even when the body mutates variables referenced by the count expression. The lowering reuses `mir::ForStmt`; no new MIR variant and no backend changes.

## Design

`hir::RepeatStmt { ExprId count, StmtId body }` mirrors `slang::ast::RepeatLoopStatement`. The HIR -> MIR arm emits:

```
{
  std::int32_t _lyra_repeat_count = <count>;
  for (std::int32_t _lyra_repeat_index = 0;
       _lyra_repeat_index < _lyra_repeat_count;
       _lyra_repeat_index = _lyra_repeat_index + 1) {
    body
  }
}
```

The wrapper block scopes both synthetic vars. Implicit conversion is inserted if the count expression's type is not `int32`.

## Testing

10 cases under `tests/cases/cpp/repeat_*`:

- `repeat_basic`, `repeat_zero_iterations`, `repeat_variable_count`, `repeat_single_stmt`, `repeat_nested`
- `repeat_count_evaluated_once` proves the snapshot semantic (count var mutated inside body, iter count unchanged)
- `repeat_if_in_body`, `repeat_for_in_body`, `repeat_in_for_body`, `repeat_in_while_body` for mixed composition

Closes C5 in `docs/progress/control-flow.md`. `bazel test //...` clean.