### PR TITLE
Lower do-while loops to native C++ do-while

### DIFF
--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -31,7 +31,13 @@ checked when its `*.yaml` cases reproduce on the current pipeline.
       semantic for side-effecting count expressions) plus an `mir::ForStmt` over the C2 machinery.
       Coverage includes literal counts, runtime counts, zero iterations, count-evaluated-once,
       nesting, single-statement body, and mixed nesting with `if`/`for`/`while`.
-- [ ] C6 -- `do_while`. Lowers to `while(true) { body; if (!cond) break; }` over C4 + C7.
+- [x] C6 -- `do_while`. Reproduces every `control_flow/do_while/default.yaml` case that does not
+      depend on `break`/`continue` (deferred to C7). HIR carries a faithful `DoWhileStmt`; MIR
+      mirrors it with the condition stored in the enclosing procedural scope and the body in a child
+      scope (same shape as `WhileStmt`). The C++ backend renders directly to
+      `do { body } while (cond);`. Coverage includes basic loops, `do {...} while (0)` (body still
+      executes once), runtime conditions, nesting, single-statement body, and mixed nesting with
+      `if`/`for`/`while`.
 - [ ] C7 -- Loop control: `break`, `continue`. New HIR/MIR statements + C++ render. Shared by C2
       (for) / C4 (while) / C5 (repeat) / C6 (do-while) / C9 (foreach). Coroutine renderer must scope
       the early-exit correctly inside nested control flow.

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -85,6 +85,11 @@ struct RepeatStmt {
   StmtId body;
 };
 
+struct DoWhileStmt {
+  ExprId condition;
+  StmtId body;
+};
+
 struct DelayControl {
   ExprId duration;
 };
@@ -100,7 +105,7 @@ struct TimedStmt {
 
 using StmtData = std::variant<
     EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, IfStmt, CaseStmt, ForStmt,
-    WhileStmt, RepeatStmt, TimedStmt>;
+    WhileStmt, RepeatStmt, DoWhileStmt, TimedStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -117,6 +117,11 @@ struct WhileStmt {
   ProceduralScopeId scope;
 };
 
+struct DoWhileStmt {
+  ExprId condition;
+  ProceduralScopeId scope;
+};
+
 enum class AwaitKind : std::uint8_t {
   kAlwaysBackedge,
 };
@@ -127,7 +132,8 @@ struct AwaitStmt {
 
 using StmtData = std::variant<
     EmptyStmt, ProceduralVarDeclStmt, ExprStmt, BlockStmt, IfStmt, SwitchStmt,
-    ConstructOwnedObjectStmt, ForStmt, TimedStmt, WhileStmt, AwaitStmt>;
+    ConstructOwnedObjectStmt, ForStmt, TimedStmt, WhileStmt, DoWhileStmt,
+    AwaitStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -302,6 +302,24 @@ auto RenderStmt(
             result += Indent(indent) + "}\n";
             return result;
           },
+          [&](const mir::DoWhileStmt& s) -> diag::Result<std::string> {
+            const auto& cond_expr =
+                ctx.ProceduralScope().exprs.at(s.condition.value);
+            auto cond_or = RenderExprAsNative(ctx, cond_expr);
+            if (!cond_or) {
+              return std::unexpected(std::move(cond_or.error()));
+            }
+            const auto& scope = stmt.child_procedural_scopes.at(s.scope.value);
+            auto body_or = RenderNestedProceduralScope(ctx, scope, indent + 1);
+            if (!body_or) {
+              return std::unexpected(std::move(body_or.error()));
+            }
+            std::string result = Indent(indent) + "do {\n";
+            result += *body_or;
+            result +=
+                Indent(indent) + "} while (" + *std::move(cond_or) + ");\n";
+            return result;
+          },
           [&](const mir::AwaitStmt&) -> diag::Result<std::string> {
             throw InternalError(
                 "RenderStmt: AwaitStmt is not yet supported by C++ emit");

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -753,6 +753,22 @@ class HirDumper {
               Dedent();
               Dedent();
             },
+            [&](const DoWhileStmt& d) {
+              Line(
+                  std::format(
+                      "Stmt[{}] DoWhileStmt cond=Expr[{}]", id.value,
+                      d.condition.value));
+              Indent();
+              Line(
+                  std::format(
+                      "Expr[{}] {}", d.condition.value,
+                      FormatProcExpr(p, d.condition)));
+              Line("body:");
+              Indent();
+              DumpStmt(p, d.body);
+              Dedent();
+              Dedent();
+            },
             [&](const TimedStmt& t) {
               Line(std::format("Stmt[{}] TimedStmt", id.value));
               Indent();

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -240,6 +240,22 @@ auto LowerStatement(
           .span = span};
     }
 
+    case slang::ast::StatementKind::DoWhileLoop: {
+      const auto& ds = stmt.as<slang::ast::DoWhileLoopStatement>();
+      auto body_or =
+          LowerStatement(unit_facts, proc_state, scope_state, stack, ds.body);
+      if (!body_or) return std::unexpected(std::move(body_or.error()));
+      const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_or));
+      auto cond_or = LowerProcExpr(
+          unit_facts, scope_state.UnitState(), proc_state, stack, ds.cond);
+      if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+      const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_or));
+      return hir::Stmt{
+          .label = std::nullopt,
+          .data = hir::DoWhileStmt{.condition = cond_id, .body = body_id},
+          .span = span};
+    }
+
     case slang::ast::StatementKind::Case: {
       const auto& cs = stmt.as<slang::ast::CaseStatement>();
       if (cs.condition != slang::ast::CaseStatementCondition::Normal) {

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -605,6 +605,42 @@ auto LowerStmt(
                 .data = mir::BlockStmt{.scope = wrapper_scope_id},
                 .child_procedural_scopes = std::move(child_scopes)};
           },
+          [&](const hir::DoWhileStmt& d) -> diag::Result<mir::Stmt> {
+            ProceduralScopeLoweringState body_state;
+            {
+              ProceduralDepthGuard body_depth_guard{proc_state};
+              const hir::Stmt& body_hir = hir_proc.stmts.at(d.body.value);
+              auto body_or = LowerStmt(
+                  unit_state, scope_state, proc_state, body_state, hir_proc,
+                  body_hir);
+              if (!body_or) {
+                return std::unexpected(std::move(body_or.error()));
+              }
+              const mir::StmtId body_id =
+                  body_state.AddStmt(*std::move(body_or));
+              body_state.AddRootStmt(body_id);
+            }
+
+            auto cond_or = LowerExpr(
+                unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+                hir_proc.exprs.at(d.condition.value));
+            if (!cond_or) {
+              return std::unexpected(std::move(cond_or.error()));
+            }
+            const mir::ExprId cond_id =
+                proc_scope_state.AddExpr(*std::move(cond_or));
+
+            std::vector<mir::ProceduralScope> child_scopes;
+            const mir::ProceduralScopeId body_scope_id =
+                AddChildProceduralScope(child_scopes, body_state.Finish());
+
+            return mir::Stmt{
+                .label = stmt.label,
+                .data =
+                    mir::DoWhileStmt{
+                        .condition = cond_id, .scope = body_scope_id},
+                .child_procedural_scopes = std::move(child_scopes)};
+          },
           [&](const hir::TimedStmt& t) -> diag::Result<mir::Stmt> {
             auto timing_or =
                 LowerTimingControl(proc_state, hir_proc, t.timing, stmt.span);

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -652,6 +652,9 @@ class MirDumper {
             [&](const ForStmt& s) { DumpForStmt(stmt, s, enclosing, id); },
             [&](const TimedStmt& t) { DumpTimedStmt(t, enclosing, id); },
             [&](const WhileStmt& s) { DumpWhileStmt(stmt, s, enclosing, id); },
+            [&](const DoWhileStmt& s) {
+              DumpDoWhileStmt(stmt, s, enclosing, id);
+            },
             [&](const AwaitStmt& s) {
               Line(
                   std::format(
@@ -666,6 +669,22 @@ class MirDumper {
       const Stmt& parent, const WhileStmt& s, const ProceduralScope& enclosing,
       StmtId id) {
     Line(std::format("Stmt[{}] WhileStmt", id.value));
+    Indent();
+    Line(
+        std::format(
+            "condition: Expr[{}] {}", s.condition.value,
+            FormatExpr(enclosing, s.condition)));
+    Line(std::format("scope (ProceduralScopeId={}):", s.scope.value));
+    Indent();
+    DumpProceduralScope(parent.child_procedural_scopes.at(s.scope.value));
+    Dedent();
+    Dedent();
+  }
+
+  void DumpDoWhileStmt(
+      const Stmt& parent, const DoWhileStmt& s,
+      const ProceduralScope& enclosing, StmtId id) {
+    Line(std::format("Stmt[{}] DoWhileStmt", id.value));
     Indent();
     Line(
         std::format(

--- a/tests/cases/cpp/do_while_basic/case.yaml
+++ b/tests/cases/cpp/do_while_basic/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.do_while_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "counter=5 sum=10\n"

--- a/tests/cases/cpp/do_while_basic/main.sv
+++ b/tests/cases/cpp/do_while_basic/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  initial begin
+    int counter = 0;
+    int sum = 0;
+    do begin
+      sum = sum + counter;
+      counter = counter + 1;
+    end while (counter < 5);
+    $display("counter=%0d sum=%0d", counter, sum);
+  end
+endmodule

--- a/tests/cases/cpp/do_while_false_condition/case.yaml
+++ b/tests/cases/cpp/do_while_false_condition/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.do_while_false_condition
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "x=20\n"

--- a/tests/cases/cpp/do_while_false_condition/main.sv
+++ b/tests/cases/cpp/do_while_false_condition/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  initial begin
+    int x = 10;
+    do begin
+      x = 20;
+    end while (0);
+    $display("x=%0d", x);
+  end
+endmodule

--- a/tests/cases/cpp/do_while_if_in_body/case.yaml
+++ b/tests/cases/cpp/do_while_if_in_body/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.do_while_if_in_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "i=5 odd=3\n"

--- a/tests/cases/cpp/do_while_if_in_body/main.sv
+++ b/tests/cases/cpp/do_while_if_in_body/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  initial begin
+    int i = 0;
+    int odd = 0;
+    do begin
+      i = i + 1;
+      if (i < 4)
+        odd = odd + 1;
+    end while (i < 5);
+    $display("i=%0d odd=%0d", i, odd);
+  end
+endmodule

--- a/tests/cases/cpp/do_while_in_for_body/case.yaml
+++ b/tests/cases/cpp/do_while_in_for_body/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.do_while_in_for_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "total=12\n"

--- a/tests/cases/cpp/do_while_in_for_body/main.sv
+++ b/tests/cases/cpp/do_while_in_for_body/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  initial begin
+    int total = 0;
+    for (int i = 0; i < 3; i = i + 1) begin
+      int k = 0;
+      do begin
+        total = total + 1;
+        k = k + 1;
+      end while (k < 4);
+    end
+    $display("total=%0d", total);
+  end
+endmodule

--- a/tests/cases/cpp/do_while_in_while_body/case.yaml
+++ b/tests/cases/cpp/do_while_in_while_body/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.do_while_in_while_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "outer=3 total=9\n"

--- a/tests/cases/cpp/do_while_in_while_body/main.sv
+++ b/tests/cases/cpp/do_while_in_while_body/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  initial begin
+    int outer = 0;
+    int total = 0;
+    while (outer < 3) begin
+      int k = 0;
+      do begin
+        total = total + 1;
+        k = k + 1;
+      end while (k < 3);
+      outer = outer + 1;
+    end
+    $display("outer=%0d total=%0d", outer, total);
+  end
+endmodule

--- a/tests/cases/cpp/do_while_nested/case.yaml
+++ b/tests/cases/cpp/do_while_nested/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.do_while_nested
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "i=3 j=2 sum=6\n"

--- a/tests/cases/cpp/do_while_nested/main.sv
+++ b/tests/cases/cpp/do_while_nested/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  initial begin
+    int i = 0;
+    int j = 0;
+    int sum = 0;
+    do begin
+      j = 0;
+      do begin
+        sum = sum + 1;
+        j = j + 1;
+      end while (j < 2);
+      i = i + 1;
+    end while (i < 3);
+    $display("i=%0d j=%0d sum=%0d", i, j, sum);
+  end
+endmodule

--- a/tests/cases/cpp/do_while_single_stmt/case.yaml
+++ b/tests/cases/cpp/do_while_single_stmt/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.do_while_single_stmt
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "x=4\n"

--- a/tests/cases/cpp/do_while_single_stmt/main.sv
+++ b/tests/cases/cpp/do_while_single_stmt/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  initial begin
+    int x = 0;
+    do x = x + 1; while (x < 4);
+    $display("x=%0d", x);
+  end
+endmodule

--- a/tests/cases/cpp/do_while_variable_condition/case.yaml
+++ b/tests/cases/cpp/do_while_variable_condition/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.do_while_variable_condition
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "i=0 result=6\n"

--- a/tests/cases/cpp/do_while_variable_condition/main.sv
+++ b/tests/cases/cpp/do_while_variable_condition/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  initial begin
+    int i = 3;
+    int result = 0;
+    do begin
+      result = result + i;
+      i = i - 1;
+    end while (i > 0);
+    $display("i=%0d result=%0d", i, result);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds SV `do { body } while (cond);` end-to-end through HIR -> MIR -> C++ emit. HIR carries a faithful `DoWhileStmt`; MIR mirrors the same shape as `WhileStmt` (condition lives in the enclosing scope, body in a child scope). The C++ backend renders directly to native `do { body } while (cond);` -- no break-based desugaring is needed since C++ has the construct natively.

## Design

`hir::DoWhileStmt { ExprId condition, StmtId body }` mirrors `slang::ast::DoWhileLoopStatement`. The HIR -> MIR arm scopes the body depth guard so the condition is lowered at the outer depth (where it lives in MIR), then emits `mir::DoWhileStmt { ExprId condition, ProceduralScopeId scope }`.

The progress doc previously described a `while(true) { body; if (!cond) break; }` lowering over C4 + C7. That plan is dropped: it depends on C7 (not yet landed) and is strictly worse than emitting native C++ `do-while`. Doc updated accordingly.

## Testing

8 cases under `tests/cases/cpp/do_while_*`:

- `do_while_basic`, `do_while_variable_condition`, `do_while_nested`, `do_while_single_stmt`
- `do_while_false_condition` exercises `do {...} while (0)` -- body still runs once
- `do_while_if_in_body`, `do_while_in_for_body`, `do_while_in_while_body` for mixed composition

Closes C6 in `docs/progress/control-flow.md`. `bazel test //...` clean.