### PR TITLE
Lower break and continue to native C++ jumps

### DIFF
--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -38,9 +38,15 @@ checked when its `*.yaml` cases reproduce on the current pipeline.
       `do { body } while (cond);`. Coverage includes basic loops, `do {...} while (0)` (body still
       executes once), runtime conditions, nesting, single-statement body, and mixed nesting with
       `if`/`for`/`while`.
-- [ ] C7 -- Loop control: `break`, `continue`. New HIR/MIR statements + C++ render. Shared by C2
-      (for) / C4 (while) / C5 (repeat) / C6 (do-while) / C9 (foreach). Coroutine renderer must scope
-      the early-exit correctly inside nested control flow.
+- [x] C7 -- Loop control: `break`, `continue`. New HIR/MIR statements (no payload) lowered as
+      passthrough to the C++ backend, which renders `break;` and `continue;` directly. C++ scoping
+      already exits only the innermost surrounding loop, which matches SV semantics for every loop
+      shape we model -- including `repeat (N)`, where break/continue land inside the desugared inner
+      `for` (the surrounding count-snapshot block is not a loop). Coverage includes `for_break`,
+      `for_continue`, `for_break_inner_only`, `while_break`, `while_continue`, `do_while_break`,
+      `do_while_continue`, `repeat_break`, `repeat_continue`, and a mixed `break + continue` case.
+      Coroutine interaction (early-exit across `co_await` inside loop bodies) is not exercised
+      because timed bodies in loops are not yet supported; revisit when event-control loops land.
 - [ ] C8 -- `forever`. Lower to `for (;;) { body }` (already representable via `mir::ForStmt` with
       empty condition); needs `$finish` runtime support for the archive tests to terminate.
 - [ ] C9 -- `foreach` over fixed unpacked 1D arrays. Desugar to nested `for` over slang `loopDims`;

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -90,6 +90,10 @@ struct DoWhileStmt {
   StmtId body;
 };
 
+struct BreakStmt {};
+
+struct ContinueStmt {};
+
 struct DelayControl {
   ExprId duration;
 };
@@ -105,7 +109,7 @@ struct TimedStmt {
 
 using StmtData = std::variant<
     EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, IfStmt, CaseStmt, ForStmt,
-    WhileStmt, RepeatStmt, DoWhileStmt, TimedStmt>;
+    WhileStmt, RepeatStmt, DoWhileStmt, BreakStmt, ContinueStmt, TimedStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -122,6 +122,10 @@ struct DoWhileStmt {
   ProceduralScopeId scope;
 };
 
+struct BreakStmt {};
+
+struct ContinueStmt {};
+
 enum class AwaitKind : std::uint8_t {
   kAlwaysBackedge,
 };
@@ -133,7 +137,7 @@ struct AwaitStmt {
 using StmtData = std::variant<
     EmptyStmt, ProceduralVarDeclStmt, ExprStmt, BlockStmt, IfStmt, SwitchStmt,
     ConstructOwnedObjectStmt, ForStmt, TimedStmt, WhileStmt, DoWhileStmt,
-    AwaitStmt>;
+    BreakStmt, ContinueStmt, AwaitStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -320,6 +320,12 @@ auto RenderStmt(
                 Indent(indent) + "} while (" + *std::move(cond_or) + ");\n";
             return result;
           },
+          [&](const mir::BreakStmt&) -> diag::Result<std::string> {
+            return Indent(indent) + "break;\n";
+          },
+          [&](const mir::ContinueStmt&) -> diag::Result<std::string> {
+            return Indent(indent) + "continue;\n";
+          },
           [&](const mir::AwaitStmt&) -> diag::Result<std::string> {
             throw InternalError(
                 "RenderStmt: AwaitStmt is not yet supported by C++ emit");

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -769,6 +769,12 @@ class HirDumper {
               Dedent();
               Dedent();
             },
+            [&](const BreakStmt&) {
+              Line(std::format("Stmt[{}] BreakStmt", id.value));
+            },
+            [&](const ContinueStmt&) {
+              Line(std::format("Stmt[{}] ContinueStmt", id.value));
+            },
             [&](const TimedStmt& t) {
               Line(std::format("Stmt[{}] TimedStmt", id.value));
               Indent();

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -256,6 +256,16 @@ auto LowerStatement(
           .span = span};
     }
 
+    case slang::ast::StatementKind::Break: {
+      return hir::Stmt{
+          .label = std::nullopt, .data = hir::BreakStmt{}, .span = span};
+    }
+
+    case slang::ast::StatementKind::Continue: {
+      return hir::Stmt{
+          .label = std::nullopt, .data = hir::ContinueStmt{}, .span = span};
+    }
+
     case slang::ast::StatementKind::Case: {
       const auto& cs = stmt.as<slang::ast::CaseStatement>();
       if (cs.condition != slang::ast::CaseStatementCondition::Normal) {

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -641,6 +641,18 @@ auto LowerStmt(
                         .condition = cond_id, .scope = body_scope_id},
                 .child_procedural_scopes = std::move(child_scopes)};
           },
+          [&](const hir::BreakStmt&) -> diag::Result<mir::Stmt> {
+            return mir::Stmt{
+                .label = stmt.label,
+                .data = mir::BreakStmt{},
+                .child_procedural_scopes = {}};
+          },
+          [&](const hir::ContinueStmt&) -> diag::Result<mir::Stmt> {
+            return mir::Stmt{
+                .label = stmt.label,
+                .data = mir::ContinueStmt{},
+                .child_procedural_scopes = {}};
+          },
           [&](const hir::TimedStmt& t) -> diag::Result<mir::Stmt> {
             auto timing_or =
                 LowerTimingControl(proc_state, hir_proc, t.timing, stmt.span);

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -655,6 +655,12 @@ class MirDumper {
             [&](const DoWhileStmt& s) {
               DumpDoWhileStmt(stmt, s, enclosing, id);
             },
+            [&](const BreakStmt&) {
+              Line(std::format("Stmt[{}] BreakStmt", id.value));
+            },
+            [&](const ContinueStmt&) {
+              Line(std::format("Stmt[{}] ContinueStmt", id.value));
+            },
             [&](const AwaitStmt& s) {
               Line(
                   std::format(

--- a/tests/cases/cpp/break_continue_mixed/case.yaml
+++ b/tests/cases/cpp/break_continue_mixed/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.break_continue_mixed
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sum: 8

--- a/tests/cases/cpp/break_continue_mixed/main.sv
+++ b/tests/cases/cpp/break_continue_mixed/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  int sum;
+  initial begin
+    sum = 0;
+    for (int k = 0; k < 10; k = k + 1) begin
+      if (k == 5) break;
+      if (k == 2) continue;
+      sum = sum + k;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/do_while_break/case.yaml
+++ b/tests/cases/cpp/do_while_break/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.do_while_break
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: 2

--- a/tests/cases/cpp/do_while_break/main.sv
+++ b/tests/cases/cpp/do_while_break/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int x;
+  initial begin
+    x = 0;
+    do begin
+      x = x + 1;
+      if (x == 2) break;
+    end while (1);
+  end
+endmodule

--- a/tests/cases/cpp/do_while_continue/case.yaml
+++ b/tests/cases/cpp/do_while_continue/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.do_while_continue
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sum: 9

--- a/tests/cases/cpp/do_while_continue/main.sv
+++ b/tests/cases/cpp/do_while_continue/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  int sum;
+  initial begin
+    int i;
+    i = 0;
+    sum = 0;
+    do begin
+      i = i + 1;
+      if (i == 2) continue;
+      if (i == 4) continue;
+      sum = sum + i;
+    end while (i < 5);
+  end
+endmodule

--- a/tests/cases/cpp/for_break/case.yaml
+++ b/tests/cases/cpp/for_break/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.for_break
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    i: 4

--- a/tests/cases/cpp/for_break/main.sv
+++ b/tests/cases/cpp/for_break/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  int i;
+  initial begin
+    for (i = 0; i < 10; i = i + 1) begin
+      if (i == 4) break;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/for_break_inner_only/case.yaml
+++ b/tests/cases/cpp/for_break_inner_only/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.for_break_inner_only
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    count: 2

--- a/tests/cases/cpp/for_break_inner_only/main.sv
+++ b/tests/cases/cpp/for_break_inner_only/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  int count;
+  initial begin
+    count = 0;
+    for (int i = 0; i < 2; i = i + 1) begin
+      int j = 0;
+      while (j < 3) begin
+        if (j == 1) break;
+        count = count + 1;
+        j = j + 1;
+      end
+    end
+  end
+endmodule

--- a/tests/cases/cpp/for_continue/case.yaml
+++ b/tests/cases/cpp/for_continue/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.for_continue
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sum: 8

--- a/tests/cases/cpp/for_continue/main.sv
+++ b/tests/cases/cpp/for_continue/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int sum;
+  initial begin
+    sum = 0;
+    for (int k = 0; k < 5; k = k + 1) begin
+      if (k == 2) continue;
+      sum = sum + k;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/repeat_break/case.yaml
+++ b/tests/cases/cpp/repeat_break/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.repeat_break
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    i: 3

--- a/tests/cases/cpp/repeat_break/main.sv
+++ b/tests/cases/cpp/repeat_break/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int i;
+  initial begin
+    i = 0;
+    repeat (10) begin
+      if (i == 3) break;
+      i = i + 1;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/repeat_continue/case.yaml
+++ b/tests/cases/cpp/repeat_continue/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.repeat_continue
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sum: 9

--- a/tests/cases/cpp/repeat_continue/main.sv
+++ b/tests/cases/cpp/repeat_continue/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  int sum;
+  initial begin
+    int i;
+    i = 0;
+    sum = 0;
+    repeat (5) begin
+      i = i + 1;
+      if (i == 2) continue;
+      if (i == 4) continue;
+      sum = sum + i;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/while_break/case.yaml
+++ b/tests/cases/cpp/while_break/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.while_break
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    i: 3

--- a/tests/cases/cpp/while_break/main.sv
+++ b/tests/cases/cpp/while_break/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int i;
+  initial begin
+    i = 0;
+    while (1) begin
+      if (i == 3) break;
+      i = i + 1;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/while_continue/case.yaml
+++ b/tests/cases/cpp/while_continue/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.while_continue
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sum: 9

--- a/tests/cases/cpp/while_continue/main.sv
+++ b/tests/cases/cpp/while_continue/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  int sum;
+  initial begin
+    int i;
+    i = 0;
+    sum = 0;
+    while (i < 5) begin
+      i = i + 1;
+      if (i == 2) continue;
+      if (i == 4) continue;
+      sum = sum + i;
+    end
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds `break` and `continue` end-to-end through HIR -> MIR -> C++ emit. Both are empty statement nodes in HIR and MIR, lowered as passthrough, and rendered directly as `break;` / `continue;` by the C++ backend. This unblocks the break-bearing archive cases that were previously deferred from C2 (for), C4 (while), C5 (repeat), and C6 (do-while).

## Design

C++ scoping semantics for `break`/`continue` already match SV: each jumps out of (or to the next iteration of) the innermost surrounding loop. This holds for every loop shape we model -- including `repeat (N)`, where `break` inside the body lands in the desugared inner `for` rather than the count-snapshot wrapper block (a wrapper `{}` is not a loop in C++). So no special routing or labeled break is needed.

The progress doc noted a concern about coroutine scoping for early-exit across `co_await`. Timed bodies inside loops are not yet supported, so that interaction is not exercised here; the doc has been updated to flag it for whenever event-control loops land.

## Testing

10 cases under `tests/cases/cpp/`:

- `for_break`, `for_continue`, `for_break_inner_only`
- `while_break`, `while_continue`
- `do_while_break`, `do_while_continue`
- `repeat_break`, `repeat_continue`
- `break_continue_mixed` (both in the same loop)

All use `expect.variables:` assertions (matching the archive yaml style). Closes C7. `bazel test //...` clean.