### PR TITLE
Shard cpp_tests across 16 parallel runners

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -44,6 +44,7 @@ cc_test(
         ],
         allow_empty = True,
     ),
+    shard_count = 16,
     # cpp-backend cases compile emitted artifacts with the host C++ compiler.
     # CI's `Test` job passes `--test_tag_filters=-requires-host-cxx` so this
     # target is excluded; run locally with `bazel test //tests:cpp_tests`.


### PR DESCRIPTION
## Summary

The `cpp_tests` gtest binary runs all ~110 cases serially within a single process, which means each case's `lyra emit cpp` + `clang++ -std=c++23 -O0` + run subprocess chain happens one after the other. On a 20-core machine that's ~150s wall with one core busy and 19 idle. Setting `shard_count = 16` lets Bazel split the gtest binary into 16 shards and run them in parallel up to `--local_test_jobs` (default = host CPUs).

## Design

`shard_count` is a static upper bound on parallelism; Bazel caps actual concurrency at `local_test_jobs`. So 16 works well across machine sizes:

- 20-core desktop: all 16 shards run concurrently, wall ~26s (~5.5x speedup).
- 4-core laptop: Bazel runs 4 at a time across 4 rounds, wall ~60s (vs ~150s sequential).

Per-developer tuning (e.g. limiting CPU use on a laptop) goes in personal `.bazelrc` via `test --local_test_jobs=N`, not in this checked-in setting.

The gtest sharding is hash-based so case-to-shard distribution is uneven (the heavier packed_format cases cluster), but the variance is small enough that it doesn't dominate.