### PR TITLE
Add $finish system task with coroutine-based shutdown

### DIFF
--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -48,7 +48,9 @@ checked when its `*.yaml` cases reproduce on the current pipeline.
       Coroutine interaction (early-exit across `co_await` inside loop bodies) is not exercised
       because timed bodies in loops are not yet supported; revisit when event-control loops land.
 - [ ] C8 -- `forever`. Lower to `for (;;) { body }` (already representable via `mir::ForStmt` with
-      empty condition); needs `$finish` runtime support for the archive tests to terminate.
+      empty condition). `$finish` runtime support has landed (handled as a termination system
+      subroutine that lowers to `co_await lyra::runtime::Finish(<level>)`), so the archive tests can
+      now terminate.
 - [ ] C9 -- `foreach` over fixed unpacked 1D arrays. Desugar to nested `for` over slang `loopDims`;
       depends on C2.
 - [ ] C10 -- `foreach` multi-dim, skipped dimensions, dynamic-array, queue. Depends on C9 plus

--- a/include/lyra/lowering/hir_to_mir/lower_finish.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_finish.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_span.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/process.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/support/system_subroutine.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// Lower a termination system subroutine call ($finish) into a `mir::Expr`
+// carrying a `mir::RuntimeCallExpr` with a `RuntimeFinishCall` payload.
+// Resolves the optional level argument from the call's literal integer arg
+// (falling back to the descriptor's default_level when omitted). Returns a
+// user diagnostic if the level arg is non-literal or out of range.
+auto LowerFinishSystemSubroutineCall(
+    const UnitLoweringState& unit_state, const hir::Process& hir_proc,
+    const hir::CallExpr& call, const support::SystemSubroutineDesc& desc,
+    const support::TerminationSystemSubroutineInfo& info, diag::SourceSpan span)
+    -> diag::Result<mir::Expr>;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -11,6 +11,7 @@
 #include "lyra/mir/integral_constant.hpp"
 #include "lyra/mir/procedural_hops.hpp"
 #include "lyra/mir/procedural_var.hpp"
+#include "lyra/mir/runtime_finish.hpp"
 #include "lyra/mir/runtime_print.hpp"
 #include "lyra/mir/structural_hops.hpp"
 #include "lyra/mir/structural_param.hpp"
@@ -76,8 +77,10 @@ struct CallExpr {
   std::vector<ExprId> arguments;
 };
 
+using RuntimeCall = std::variant<RuntimePrintCall, RuntimeFinishCall>;
+
 struct RuntimeCallExpr {
-  RuntimePrintCall print;
+  RuntimeCall call;
 };
 
 using ExprData = std::variant<

--- a/include/lyra/mir/runtime_finish.hpp
+++ b/include/lyra/mir/runtime_finish.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace lyra::mir {
+
+struct RuntimeFinishCall {
+  int level;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -127,6 +127,7 @@ class Engine {
   std::size_t current_delta_ = 0;
   bool bound_ = false;
   bool ran_ = false;
+  bool finished_ = false;
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/finish.hpp
+++ b/include/lyra/runtime/finish.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <coroutine>
+
+#include "lyra/runtime/process.hpp"
+#include "lyra/runtime/wait_request.hpp"
+
+namespace lyra::runtime {
+
+class FinishAwaitable {
+ public:
+  explicit FinishAwaitable(int level) : level_(level) {
+  }
+
+  // NOLINTNEXTLINE(readability-identifier-naming,readability-convert-member-functions-to-static)
+  [[nodiscard]] auto await_ready() const noexcept -> bool {
+    return false;
+  }
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  void await_suspend(
+      std::coroutine_handle<ProcessCoroutine::promise_type> handle) noexcept {
+    handle.promise().SetWaitRequest(FinishWait{.level = level_});
+  }
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  void await_resume() const noexcept {
+  }
+
+ private:
+  int level_;
+};
+
+inline auto Finish(int level) -> FinishAwaitable {
+  return FinishAwaitable{level};
+}
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/wait_request.hpp
+++ b/include/lyra/runtime/wait_request.hpp
@@ -19,7 +19,11 @@ struct EventWait {
   RuntimeEvent* event = nullptr;
 };
 
-using WaitRequest = std::variant<DelayWait, EventWait>;
+struct FinishWait {
+  int level;
+};
+
+using WaitRequest = std::variant<DelayWait, EventWait, FinishWait>;
 
 class ProcessRunResult {
  public:

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -62,7 +62,17 @@ struct PrintSystemSubroutineInfo {
   PrintSinkKind sink_kind;
 };
 
-using SystemSubroutineSemantic = std::variant<PrintSystemSubroutineInfo>;
+enum class TerminationKind : std::uint8_t {
+  kFinish,
+};
+
+struct TerminationSystemSubroutineInfo {
+  TerminationKind kind;
+  int default_level;
+};
+
+using SystemSubroutineSemantic =
+    std::variant<PrintSystemSubroutineInfo, TerminationSystemSubroutineInfo>;
 
 struct SystemSubroutineDesc {
   SystemSubroutineId id;
@@ -132,6 +142,17 @@ inline constexpr std::array kSystemSubroutines = {
                 .append_newline = false,
                 .is_strobe = false,
                 .sink_kind = PrintSinkKind::kFile},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{4},
+        .name = "$finish",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 1},
+        .semantic =
+            TerminationSystemSubroutineInfo{
+                .kind = TerminationKind::kFinish, .default_level = 1},
     },
 };
 

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -259,6 +259,7 @@ auto RenderScopeHeaderFile(
   out += "#include <vector>\n";
   out += "#include \"lyra/runtime/bind_context.hpp\"\n";
   out += "#include \"lyra/runtime/delay.hpp\"\n";
+  out += "#include \"lyra/runtime/finish.hpp\"\n";
   out += "#include \"lyra/runtime/io.hpp\"\n";
   out += "#include \"lyra/runtime/module.hpp\"\n";
   out += "#include \"lyra/runtime/process.hpp\"\n";

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -17,6 +17,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/kind.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/mir/runtime_finish.hpp"
 #include "lyra/mir/runtime_print.hpp"
 #include "lyra/mir/type.hpp"
 
@@ -145,10 +146,11 @@ auto RenderPrintItemInit(
 
 }  // namespace
 
-auto RenderRuntimeCallExpr(
-    const RenderContext& ctx, const mir::RuntimeCallExpr& expr)
+namespace {
+
+auto RenderRuntimePrintCall(
+    const RenderContext& ctx, const mir::RuntimePrintCall& call)
     -> diag::Result<std::string> {
-  const mir::RuntimePrintCall& call = expr.print;
   if (call.descriptor.has_value()) {
     return diag::Unsupported(
         diag::DiagCode::kCppEmitExpressionFormNotImplemented,
@@ -191,6 +193,28 @@ auto RenderRuntimeCallExpr(
   }
   out += "})";
   return out;
+}
+
+auto RenderRuntimeFinishCall(const mir::RuntimeFinishCall& call)
+    -> std::string {
+  return std::format("co_await lyra::runtime::Finish({})", call.level);
+}
+
+}  // namespace
+
+auto RenderRuntimeCallExpr(
+    const RenderContext& ctx, const mir::RuntimeCallExpr& expr)
+    -> diag::Result<std::string> {
+  return std::visit(
+      Overloaded{
+          [&](const mir::RuntimePrintCall& pc) -> diag::Result<std::string> {
+            return RenderRuntimePrintCall(ctx, pc);
+          },
+          [&](const mir::RuntimeFinishCall& fc) -> diag::Result<std::string> {
+            return RenderRuntimeFinishCall(fc);
+          },
+      },
+      expr.call);
 }
 
 }  // namespace lyra::backend::cpp

--- a/src/lyra/lowering/hir_to_mir/lower_finish.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_finish.cpp
@@ -1,0 +1,69 @@
+#include "lyra/lowering/hir_to_mir/lower_finish.hpp"
+
+#include <cstdint>
+#include <format>
+#include <optional>
+#include <string>
+#include <variant>
+
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/integral_constant.hpp"
+#include "lyra/hir/primary.hpp"
+#include "lyra/hir/process.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/runtime_finish.hpp"
+#include "lyra/support/system_subroutine.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+namespace {
+
+auto TryExtractLiteralInt(const hir::Expr& expr)
+    -> std::optional<std::int64_t> {
+  const auto* primary = std::get_if<hir::PrimaryExpr>(&expr.data);
+  if (primary == nullptr) return std::nullopt;
+  const auto* lit = std::get_if<hir::IntegerLiteral>(&primary->data);
+  if (lit == nullptr) return std::nullopt;
+  const auto& c = lit->value;
+  if (c.state_kind == hir::IntegralStateKind::kFourState) return std::nullopt;
+  if (c.value_words.empty()) return 0;
+  return static_cast<std::int64_t>(c.value_words[0]);
+}
+
+}  // namespace
+
+auto LowerFinishSystemSubroutineCall(
+    const UnitLoweringState& unit_state, const hir::Process& hir_proc,
+    const hir::CallExpr& call, const support::SystemSubroutineDesc& desc,
+    const support::TerminationSystemSubroutineInfo& info, diag::SourceSpan span)
+    -> diag::Result<mir::Expr> {
+  int level = info.default_level;
+  if (!call.arguments.empty()) {
+    const hir::ExprId arg_id = call.arguments.front();
+    const hir::Expr& arg_expr = hir_proc.exprs.at(arg_id.value);
+    const auto literal = TryExtractLiteralInt(arg_expr);
+    if (!literal.has_value()) {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          std::format(
+              "{} argument must be an integer literal in this build",
+              std::string{desc.name}),
+          diag::UnsupportedCategory::kFeature);
+    }
+    if (*literal != 0 && *literal != 1 && *literal != 2) {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          std::format("{} argument must be 0, 1, or 2", std::string{desc.name}),
+          diag::UnsupportedCategory::kFeature);
+    }
+    level = static_cast<int>(*literal);
+  }
+  return mir::Expr{
+      .data =
+          mir::RuntimeCallExpr{.call = mir::RuntimeFinishCall{.level = level}},
+      .type = unit_state.Builtins().void_type};
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/lower_print.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_print.cpp
@@ -233,7 +233,7 @@ auto LowerPrintSystemSubroutineCall(
   return mir::Expr{
       .data =
           mir::RuntimeCallExpr{
-              .print = mir::RuntimePrintCall(
+              .call = mir::RuntimePrintCall(
                   ToMirPrintKind(print), std::nullopt, std::move(*items_or))},
       .type = unit_state.Builtins().void_type};
 }

--- a/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
@@ -7,6 +7,7 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
+#include "lyra/lowering/hir_to_mir/lower_finish.hpp"
 #include "lyra/lowering/hir_to_mir/lower_print.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/expr.hpp"
@@ -30,6 +31,11 @@ auto LowerSystemSubroutineCall(
             return LowerPrintSystemSubroutineCall(
                 unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
                 call, desc, print, span);
+          },
+          [&](const support::TerminationSystemSubroutineInfo& term)
+              -> diag::Result<mir::Expr> {
+            return LowerFinishSystemSubroutineCall(
+                unit_state, hir_proc, call, desc, term, span);
           },
       },
       desc.semantic);

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -580,7 +580,16 @@ class MirDumper {
         const auto& expr = scope.exprs[i];
         if (const auto* rc = std::get_if<RuntimeCallExpr>(&expr.data)) {
           Indent();
-          DumpRuntimePrintCallItems(rc->print, scope);
+          std::visit(
+              Overloaded{
+                  [&](const RuntimePrintCall& pc) {
+                    DumpRuntimePrintCallItems(pc, scope);
+                  },
+                  [&](const RuntimeFinishCall& fc) {
+                    Line(std::format("RuntimeFinishCall level={}", fc.level));
+                  },
+              },
+              rc->call);
           Dedent();
         }
       }

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -52,8 +52,11 @@ auto Engine::Run() -> int {
   EnsureReadyToRun();
   RegisterProcesses();
 
-  while (HasScheduledWork()) {
+  while (HasScheduledWork() && !finished_) {
     ExecuteCurrentTimeSlot();
+    if (finished_) {
+      break;
+    }
     if (!HasFutureTimedWork()) {
       break;
     }
@@ -164,11 +167,19 @@ void Engine::ExecuteFinalProcesses() {
   phase_ = SchedulerPhase::kPostponed;
   for (RuntimeProcess* p : queues_.finals) {
     auto result = p->Resume();
-    if (!result.IsCompleted()) {
-      throw InternalError(
-          "Engine::ExecuteFinalProcesses: final block suspended; "
-          "time-controlling statements are not allowed inside `final`");
+    if (result.IsCompleted()) {
+      continue;
     }
+    auto wait = result.TakeWait();
+    // LRM 9.2.3: $finish inside a final procedure ends simulation
+    // immediately -- subsequent queued finals shall not run.
+    if (std::holds_alternative<FinishWait>(wait)) {
+      finished_ = true;
+      break;
+    }
+    throw InternalError(
+        "Engine::ExecuteFinalProcesses: final block suspended; "
+        "time-controlling statements are not allowed inside `final`");
   }
   queues_.finals.clear();
 }
@@ -221,6 +232,10 @@ auto Engine::IsRunnablePhase() const -> bool {
 }
 
 void Engine::RunProcess(RuntimeProcess& process) {
+  // Sole gate for post-$finish user code; finals bypass via their own path.
+  if (finished_) {
+    return;
+  }
   if (!IsRunnablePhase()) {
     throw InternalError(
         "Engine::RunProcess: process resumed outside runnable phase");
@@ -237,6 +252,7 @@ void Engine::ScheduleWait(RuntimeProcess& process, WaitRequest wait) {
       Overloaded{
           [&](DelayWait d) { ScheduleDelayWait(process, d); },
           [&](EventWait e) { ScheduleEventWait(process, e); },
+          [&](FinishWait) { finished_ = true; },
       },
       wait);
 }

--- a/tests/cases/cpp/finish_after_delay/case.yaml
+++ b/tests/cases/cpp/finish_after_delay/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.finish_after_delay
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: 1

--- a/tests/cases/cpp/finish_after_delay/main.sv
+++ b/tests/cases/cpp/finish_after_delay/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int x;
+  initial begin
+    x = 0;
+    #10;
+    x = 1;
+    $finish;
+    x = 2;
+  end
+endmodule

--- a/tests/cases/cpp/finish_in_while_loop/case.yaml
+++ b/tests/cases/cpp/finish_in_while_loop/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.finish_in_while_loop
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    counter: 5

--- a/tests/cases/cpp/finish_in_while_loop/main.sv
+++ b/tests/cases/cpp/finish_in_while_loop/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int counter;
+  initial begin
+    counter = 0;
+    while (1) begin
+      counter = counter + 1;
+      if (counter >= 5) $finish(0);
+    end
+  end
+endmodule

--- a/tests/cases/cpp/finish_inside_final/case.yaml
+++ b/tests/cases/cpp/finish_inside_final/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.finish_inside_final
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "before-finish\n"

--- a/tests/cases/cpp/finish_inside_final/main.sv
+++ b/tests/cases/cpp/finish_inside_final/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  final begin
+    $display("before-finish");
+    $finish;
+    $display("after-finish");
+  end
+endmodule

--- a/tests/cases/cpp/finish_level_0/case.yaml
+++ b/tests/cases/cpp/finish_level_0/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.finish_level_0
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: 42

--- a/tests/cases/cpp/finish_level_0/main.sv
+++ b/tests/cases/cpp/finish_level_0/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  int x;
+  initial begin
+    x = 42;
+    $finish(0);
+  end
+endmodule

--- a/tests/cases/cpp/finish_level_2/case.yaml
+++ b/tests/cases/cpp/finish_level_2/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.finish_level_2
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: 7

--- a/tests/cases/cpp/finish_level_2/main.sv
+++ b/tests/cases/cpp/finish_level_2/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  int x;
+  initial begin
+    x = 7;
+    $finish(2);
+  end
+endmodule

--- a/tests/cases/cpp/finish_runs_user_final/case.yaml
+++ b/tests/cases/cpp/finish_runs_user_final/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.finish_runs_user_final
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: 1
+    y: 99

--- a/tests/cases/cpp/finish_runs_user_final/main.sv
+++ b/tests/cases/cpp/finish_runs_user_final/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  int x;
+  int y;
+  initial begin
+    x = 1;
+    $finish;
+    x = 2;
+  end
+  final begin
+    y = 99;
+  end
+endmodule

--- a/tests/cases/cpp/finish_skips_remaining/case.yaml
+++ b/tests/cases/cpp/finish_skips_remaining/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.finish_skips_remaining
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: 1

--- a/tests/cases/cpp/finish_skips_remaining/main.sv
+++ b/tests/cases/cpp/finish_skips_remaining/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  int x;
+  initial begin
+    x = 1;
+    $finish;
+    x = 2;
+  end
+endmodule

--- a/tests/cases/cpp/finish_stops_sibling_initial/case.yaml
+++ b/tests/cases/cpp/finish_stops_sibling_initial/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.finish_stops_sibling_initial
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a: 1
+    b: 0

--- a/tests/cases/cpp/finish_stops_sibling_initial/main.sv
+++ b/tests/cases/cpp/finish_stops_sibling_initial/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  int a;
+  int b;
+  initial begin
+    a = 1;
+    $finish;
+  end
+  initial begin
+    b = 99;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds the SV `$finish[(n)]` system task end-to-end. `$finish` flows through the existing system-subroutine pathway (not a bespoke statement node): a new `TerminationSystemSubroutineInfo` semantic in the support table, a new `RuntimeFinishCall` alternative in `mir::RuntimeCallExpr`, lowered to `co_await lyra::runtime::Finish(level);`. Runtime side: `FinishWait` joins the existing `WaitRequest` variant, and the engine gates all non-final user-code dispatch through a single check in `RunProcess`.

## Design

- **IR shape**: `$finish` is a system task call, so HIR keeps it as `hir::CallExpr { SystemSubroutineRef }` -- identical to `$display`. MIR refactors `RuntimeCallExpr.print` to `RuntimeCallExpr.call: variant<RuntimePrintCall, RuntimeFinishCall>` so the family stays symmetric.
- **Coroutine integration**: `$finish` emits as `co_await lyra::runtime::Finish(level)`. The awaiter suspends with `FinishWait`; the engine sees that wait kind, sets `finished_`, and never reschedules the process. Picked `co_await` over throwing because suspending-with-payload is the coroutine primitive designed for exactly this; throwing across coroutine boundaries for non-error control flow would be an anti-pattern.
- **Single correctness gate**: `RunProcess` is the sole entry point for non-final user-code execution, so one `if (finished_) return;` at its top covers every dispatch path. No per-region / per-queue checks needed.
- **Finals**: `Run()` always calls `ExecuteFinalProcesses()` after the main loop, so finals run after `$finish` (LRM 9.2.3). `$finish` inside a final aborts remaining queued finals via `break` -- LRM 9.2.3 explicitly mandates "shall cause the simulation to end immediately."

## Testing

Eight cpp_run cases under `tests/cases/cpp/`:

- `finish_skips_remaining` -- post-`$finish` statements do not execute
- `finish_level_0`, `finish_level_2` -- level arg parsed for all three values (default 1 covered by other cases)
- `finish_after_delay` -- works after `#10`
- `finish_runs_user_final` -- user `final` block fires after `$finish` in initial
- `finish_in_while_loop` -- `$finish` terminates an otherwise-infinite loop
- `finish_stops_sibling_initial` -- a sibling `initial` queued after the `$finish`-calling one does not run (validates the `RunProcess` gate)
- `finish_inside_final` -- `$finish` inside a `final` aborts the finals loop (LRM 9.2.3); stdout-based assertion because the test framework's variable-extraction final is itself a casualty of the LRM-correct break

`bazel test //...` clean. Unblocks `$finish`-dependent archive cases for C8 forever.