### PR TITLE
Lower forever loops to empty for-statement

### DIFF
--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -47,10 +47,11 @@ checked when its `*.yaml` cases reproduce on the current pipeline.
       `do_while_continue`, `repeat_break`, `repeat_continue`, and a mixed `break + continue` case.
       Coroutine interaction (early-exit across `co_await` inside loop bodies) is not exercised
       because timed bodies in loops are not yet supported; revisit when event-control loops land.
-- [ ] C8 -- `forever`. Lower to `for (;;) { body }` (already representable via `mir::ForStmt` with
-      empty condition). `$finish` runtime support has landed (handled as a termination system
-      subroutine that lowers to `co_await lyra::runtime::Finish(<level>)`), so the archive tests can
-      now terminate.
+- [x] C8 -- `forever`. HIR carries a faithful `ForeverStmt` (mirrors the other loop nodes); HIR ->
+      MIR desugars to `mir::ForStmt` with no init, no condition, and no step. The C++ backend
+      renders this as `for (; ; ) { body }`, which loops until `break` or `$finish` exits. Coverage
+      includes `$finish` termination, `break` termination, `continue`, single-statement body (no
+      `begin`/`end`), nested forever with inner `break`, and `if`-guarded forever.
 - [ ] C9 -- `foreach` over fixed unpacked 1D arrays. Desugar to nested `for` over slang `loopDims`;
       depends on C2.
 - [ ] C10 -- `foreach` multi-dim, skipped dimensions, dynamic-array, queue. Depends on C9 plus

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -90,6 +90,10 @@ struct DoWhileStmt {
   StmtId body;
 };
 
+struct ForeverStmt {
+  StmtId body;
+};
+
 struct BreakStmt {};
 
 struct ContinueStmt {};
@@ -109,7 +113,8 @@ struct TimedStmt {
 
 using StmtData = std::variant<
     EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, IfStmt, CaseStmt, ForStmt,
-    WhileStmt, RepeatStmt, DoWhileStmt, BreakStmt, ContinueStmt, TimedStmt>;
+    WhileStmt, RepeatStmt, DoWhileStmt, ForeverStmt, BreakStmt, ContinueStmt,
+    TimedStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -769,6 +769,15 @@ class HirDumper {
               Dedent();
               Dedent();
             },
+            [&](const ForeverStmt& f) {
+              Line(std::format("Stmt[{}] ForeverStmt", id.value));
+              Indent();
+              Line("body:");
+              Indent();
+              DumpStmt(p, f.body);
+              Dedent();
+              Dedent();
+            },
             [&](const BreakStmt&) {
               Line(std::format("Stmt[{}] BreakStmt", id.value));
             },

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -256,6 +256,18 @@ auto LowerStatement(
           .span = span};
     }
 
+    case slang::ast::StatementKind::ForeverLoop: {
+      const auto& fs = stmt.as<slang::ast::ForeverLoopStatement>();
+      auto body_or =
+          LowerStatement(unit_facts, proc_state, scope_state, stack, fs.body);
+      if (!body_or) return std::unexpected(std::move(body_or.error()));
+      const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_or));
+      return hir::Stmt{
+          .label = std::nullopt,
+          .data = hir::ForeverStmt{.body = body_id},
+          .span = span};
+    }
+
     case slang::ast::StatementKind::Break: {
       return hir::Stmt{
           .label = std::nullopt, .data = hir::BreakStmt{}, .span = span};

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -641,6 +641,36 @@ auto LowerStmt(
                         .condition = cond_id, .scope = body_scope_id},
                 .child_procedural_scopes = std::move(child_scopes)};
           },
+          [&](const hir::ForeverStmt& f) -> diag::Result<mir::Stmt> {
+            ProceduralScopeLoweringState body_state;
+            {
+              ProceduralDepthGuard body_depth_guard{proc_state};
+              const hir::Stmt& body_hir = hir_proc.stmts.at(f.body.value);
+              auto body_or = LowerStmt(
+                  unit_state, scope_state, proc_state, body_state, hir_proc,
+                  body_hir);
+              if (!body_or) {
+                return std::unexpected(std::move(body_or.error()));
+              }
+              const mir::StmtId body_id =
+                  body_state.AddStmt(*std::move(body_or));
+              body_state.AddRootStmt(body_id);
+            }
+
+            std::vector<mir::ProceduralScope> child_scopes;
+            const mir::ProceduralScopeId body_scope_id =
+                AddChildProceduralScope(child_scopes, body_state.Finish());
+
+            return mir::Stmt{
+                .label = stmt.label,
+                .data =
+                    mir::ForStmt{
+                        .init = {},
+                        .condition = std::nullopt,
+                        .step = {},
+                        .scope = body_scope_id},
+                .child_procedural_scopes = std::move(child_scopes)};
+          },
           [&](const hir::BreakStmt&) -> diag::Result<mir::Stmt> {
             return mir::Stmt{
                 .label = stmt.label,

--- a/tests/cases/cpp/forever_continue/case.yaml
+++ b/tests/cases/cpp/forever_continue/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.forever_continue
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    i: 7
+    evens: 12

--- a/tests/cases/cpp/forever_continue/main.sv
+++ b/tests/cases/cpp/forever_continue/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  int i;
+  int evens;
+  initial begin
+    i = 0;
+    evens = 0;
+    forever begin
+      i = i + 1;
+      if (i > 6) break;
+      if ((i % 2) == 1) continue;
+      evens = evens + i;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/forever_in_if_body/case.yaml
+++ b/tests/cases/cpp/forever_in_if_body/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.forever_in_if_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    gate: 1
+    count: 4

--- a/tests/cases/cpp/forever_in_if_body/main.sv
+++ b/tests/cases/cpp/forever_in_if_body/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  int gate;
+  int count;
+  initial begin
+    gate = 1;
+    count = 0;
+    if (gate == 1) begin
+      forever begin
+        count = count + 1;
+        if (count == 4) break;
+      end
+    end
+  end
+endmodule

--- a/tests/cases/cpp/forever_nested_break/case.yaml
+++ b/tests/cases/cpp/forever_nested_break/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.forever_nested_break
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    outer: 3
+    inner_total: 6

--- a/tests/cases/cpp/forever_nested_break/main.sv
+++ b/tests/cases/cpp/forever_nested_break/main.sv
@@ -1,0 +1,19 @@
+module Top;
+  int outer;
+  int inner_total;
+  initial begin
+    outer = 0;
+    inner_total = 0;
+    forever begin
+      int inner;
+      outer = outer + 1;
+      inner = 0;
+      forever begin
+        inner = inner + 1;
+        if (inner == 2) break;
+      end
+      inner_total = inner_total + inner;
+      if (outer == 3) break;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/forever_single_stmt/case.yaml
+++ b/tests/cases/cpp/forever_single_stmt/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.forever_single_stmt
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    i: 3

--- a/tests/cases/cpp/forever_single_stmt/main.sv
+++ b/tests/cases/cpp/forever_single_stmt/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  int i;
+  initial begin
+    i = 0;
+    forever if (i == 3) break; else i = i + 1;
+  end
+endmodule

--- a/tests/cases/cpp/forever_with_break/case.yaml
+++ b/tests/cases/cpp/forever_with_break/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.forever_with_break
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: 3

--- a/tests/cases/cpp/forever_with_break/main.sv
+++ b/tests/cases/cpp/forever_with_break/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int x;
+  initial begin
+    x = 0;
+    forever begin
+      x = x + 1;
+      if (x == 3) break;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/forever_with_finish/case.yaml
+++ b/tests/cases/cpp/forever_with_finish/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.forever_with_finish
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    counter: 5

--- a/tests/cases/cpp/forever_with_finish/main.sv
+++ b/tests/cases/cpp/forever_with_finish/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int counter;
+  initial begin
+    counter = 0;
+    forever begin
+      counter = counter + 1;
+      if (counter >= 5) $finish;
+    end
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds `forever` to the supported control-flow set (C8). HIR carries a faithful `ForeverStmt` mirroring the source; HIR -> MIR desugars to `mir::ForStmt` with no init, no condition, and no step. The C++ backend already renders that as `for (; ; ) { body }`, so the loop terminates via `break` or `$finish`.

## Testing

Six `cpp_run` cases under `tests/cases/cpp/forever_*` cover: `$finish` termination, `break`, `continue`, single-statement body (no `begin`/`end`), nested forever with inner `break`, and an `if`-guarded forever.