### PR TITLE
Add ternary conditional expression

### DIFF
--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -4,6 +4,31 @@ Tracks procedural control-flow constructs against `backend::cpp`. Covers archive
 `archived/tests/sv_features/control_flow/`. Each archive item checkbox in `architecture-reset.md` is
 checked when its `*.yaml` cases reproduce on the current pipeline.
 
+The numeric IDs (C1..C17) are stable references to archive items and do **not** imply execution
+order. Most of the remaining open items depend on workstreams outside control-flow (data types,
+operator runtime, string runtime); see the per-item **Depends on** lines and the
+[Actionable](#actionable) summary below for what can actually be picked up next.
+
+## Actionable
+
+Open items whose external dependencies are already in place and can be implemented today:
+
+- **C13** -- `unique` / `unique0` / `priority` qualifiers. Self-contained: needs only the runtime
+  warn helper and (for cascaded `if`) settle-epoch tracking, both of which live inside this
+  workstream.
+- **C15** -- `case` with non-constant / duplicate labels. Pure HIR -> MIR restructure on top of the
+  C3 machinery.
+
+Open items currently blocked on other workstreams:
+
+| Item    | Blocked on                                                                                 |
+| ------- | ------------------------------------------------------------------------------------------ |
+| C9, C10 | `datatypes/unpacked` (procedural unpacked array vars + `arr[i]` element-select expr).      |
+| C11     | `operators/wildcard_equality` (masked-compare runtime helper for `==?` / `!=?`).           |
+| C12     | `operators/inside` (range patterns + set-membership runtime).                              |
+| C16     | `datatypes/enum`.                                                                          |
+| C17     | `datatypes/string` plus the string-equality runtime helper from `operators/binary_string`. |
+
 ## Sub-Steps
 
 ### Statements
@@ -52,30 +77,42 @@ checked when its `*.yaml` cases reproduce on the current pipeline.
       renders this as `for (; ; ) { body }`, which loops until `break` or `$finish` exits. Coverage
       includes `$finish` termination, `break` termination, `continue`, single-statement body (no
       `begin`/`end`), nested forever with inner `break`, and `if`-guarded forever.
-- [ ] C9 -- `foreach` over fixed unpacked 1D arrays. Desugar to nested `for` over slang `loopDims`;
-      depends on C2.
-- [ ] C10 -- `foreach` multi-dim, skipped dimensions, dynamic-array, queue. Depends on C9 plus
-      runtime types for the dynamic variants.
-- [ ] C11 -- `casez` / `casex`. Cannot share `mir::SwitchStmt` (C++ `switch` does not support
-      wildcard match); lower to an if/else cascade with masked comparisons in HIR -> MIR.
+- [ ] C9 -- `foreach` over fixed unpacked 1D arrays. Desugar in HIR -> MIR to nested `for` over the
+      slang `loopDims`. **Depends on** `datatypes/unpacked`: needs a procedural unpacked-array
+      variable shape and an `arr[i]` element-select expression in both HIR and MIR (neither exists
+      today). Cannot start before that work.
+- [ ] C10 -- `foreach` multi-dim, skipped dimensions, dynamic-array, queue. **Depends on** C9 plus
+      `datatypes/general` (dynamic array, queue) and the `.size()` runtime query.
+- [ ] C11 -- `casez` / `casex`. Lower to an if/else cascade with masked comparisons in HIR -> MIR
+      (C++ `switch` does not support wildcard match). **Depends on** `operators/wildcard_equality`
+      for the `==?` / `!=?` runtime helper.
 - [ ] C12 -- `case (... inside ...)`. Range patterns (`[lo:hi]`) and `inside` membership; lower to
-      if/else cascade with `inside` semantics.
-- [ ] C13 -- `unique` / `unique0` / `priority` qualifiers on `if` and `case`. Needs runtime warn
-      helpers and (for cascaded `if`) settle-epoch tracking. Covers archive items
-      `unique_priority_if` and `unique_priority_case`.
+      if/else cascade with `inside` semantics. **Depends on** `operators/inside` for the
+      set-membership runtime.
+- [ ] C13 -- `unique` / `unique0` / `priority` qualifiers on `if` and `case`. Needs the runtime warn
+      helper and (for cascaded `if`) settle-epoch tracking, both local to this workstream. Covers
+      archive items `unique_priority_if` and `unique_priority_case`. **Depends on** nothing
+      external; actionable now.
 - [ ] C15 -- `case` with labels that are not compile-time constants (`case (sel) some_expr: ...`)
       and `case` with duplicate labels ("first match wins"). Neither can be expressed via C++
       `switch`; lower in HIR -> MIR to an if/else-if cascade. Covers archive cases
-      `case_constant_expression`, `case_first_match_wins`.
-- [ ] C16 -- `case` with enum-typed selectors and enum-value labels. Depends on the `datatypes/enum`
-      archive item landing.
-- [ ] C17 -- `case` with string selector / string labels. Needs the string-equality runtime helper
-      from `operators/binary_string`.
+      `case_constant_expression`, `case_first_match_wins`. **Depends on** nothing external;
+      actionable now (only the C3 machinery already in place).
+- [ ] C16 -- `case` with enum-typed selectors and enum-value labels. **Depends on**
+      `datatypes/enum`.
+- [ ] C17 -- `case` with string selector / string labels. **Depends on** `datatypes/string` plus the
+      string-equality runtime helper tracked under `operators/binary_string`.
 
 ### Expressions
 
-- [ ] C14 -- Ternary `cond ? a : b`. Pure expression node; independent of statement work. Adds
-      `hir::ConditionalExpr` + `mir::ConditionalExpr` and a one-line C++ render.
+- [x] C14 -- Ternary `cond ? a : b`. New `hir::ConditionalExpr` + `mir::ConditionalExpr` carry the
+      three sub-expressions; HIR -> MIR is a straight pass-through (no desugaring); the C++ backend
+      renders as `(cond ? then : else)` on the native (2-state integral) path. Multi-condition
+      (`&&&`) and `matches` pattern forms are rejected with `diag::Unsupported`. 4-state X/Z
+      propagation on the condition follows the broader 4-state work tracked under `operators` (B7 /
+      U4) and is out of scope. Coverage includes basic max-pick, nested chained, ternary embedded in
+      an arithmetic expression, literal-only arms, ternary feeding an `if` condition, and ternary
+      inside a `for`-loop body.
 
 ## Out of Scope
 

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -29,6 +29,12 @@ struct BinaryExpr {
   ExprId rhs;
 };
 
+struct ConditionalExpr {
+  ExprId condition;
+  ExprId then_value;
+  ExprId else_value;
+};
+
 struct AssignExpr {
   ExprId lhs;
   ExprId rhs;
@@ -40,7 +46,8 @@ struct CallExpr {
 };
 
 using ExprData = std::variant<
-    PrimaryExpr, UnaryExpr, BinaryExpr, AssignExpr, CallExpr, ConversionExpr>;
+    PrimaryExpr, UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr, CallExpr,
+    ConversionExpr>;
 
 struct Expr {
   TypeId type;

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -61,6 +61,12 @@ struct BinaryExpr {
   ExprId rhs;
 };
 
+struct ConditionalExpr {
+  ExprId condition;
+  ExprId then_value;
+  ExprId else_value;
+};
+
 struct AssignExpr {
   Lvalue target;
   ExprId value;
@@ -85,8 +91,8 @@ struct RuntimeCallExpr {
 
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, StructuralParamRef,
-    StructuralVarRef, ProceduralVarRef, UnaryExpr, BinaryExpr, AssignExpr,
-    CallExpr, RuntimeCallExpr, ConversionExpr>;
+    StructuralVarRef, ProceduralVarRef, UnaryExpr, BinaryExpr, ConditionalExpr,
+    AssignExpr, CallExpr, RuntimeCallExpr, ConversionExpr>;
 
 struct Expr {
   ExprData data;

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -601,6 +601,15 @@ auto RenderExprAsNative(const RenderContext& ctx, const mir::Expr& expr)
             if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
             return "(" + *lhs_or + std::string{*token_or} + *rhs_or + ")";
           },
+          [&](const mir::ConditionalExpr& c) -> diag::Result<std::string> {
+            auto cond_or = RenderExprAsNative(ctx, ctx.Expr(c.condition));
+            if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+            auto then_or = RenderExprAsNative(ctx, ctx.Expr(c.then_value));
+            if (!then_or) return std::unexpected(std::move(then_or.error()));
+            auto else_or = RenderExprAsNative(ctx, ctx.Expr(c.else_value));
+            if (!else_or) return std::unexpected(std::move(else_or.error()));
+            return "(" + *cond_or + " ? " + *then_or + " : " + *else_or + ")";
+          },
           [&](const mir::AssignExpr& a) -> diag::Result<std::string> {
             auto target_type_or = MirTypeOfLvalue(ctx, a.target);
             if (!target_type_or) {

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -423,6 +423,11 @@ class HirDumper {
                   "BinaryExpr op={} lhs=Expr[{}] rhs=Expr[{}]",
                   FormatBinaryOp(b.op), b.lhs.value, b.rhs.value);
             },
+            [](const ConditionalExpr& c) -> std::string {
+              return std::format(
+                  "ConditionalExpr cond=Expr[{}] then=Expr[{}] else=Expr[{}]",
+                  c.condition.value, c.then_value.value, c.else_value.value);
+            },
             [](const AssignExpr& a) -> std::string {
               return std::format(
                   "AssignExpr lhs=Expr[{}] rhs=Expr[{}]", a.lhs.value,

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -445,6 +445,41 @@ auto LowerProcExpr(
       };
     }
 
+    case slang::ast::ExpressionKind::ConditionalOp: {
+      const auto& cond = expr.as<slang::ast::ConditionalExpression>();
+      if (cond.conditions.size() != 1) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedExpressionForm,
+            "conditional operator with `&&&` multi-condition is not yet "
+            "supported",
+            diag::UnsupportedCategory::kFeature);
+      }
+      if (cond.conditions[0].pattern != nullptr) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedExpressionForm,
+            "conditional operator with `matches` pattern is not yet supported",
+            diag::UnsupportedCategory::kFeature);
+      }
+      auto cond_id = append_child(*cond.conditions[0].expr);
+      if (!cond_id) return std::unexpected(std::move(cond_id.error()));
+      auto then_id = append_child(cond.left());
+      if (!then_id) return std::unexpected(std::move(then_id.error()));
+      auto else_id = append_child(cond.right());
+      if (!else_id) return std::unexpected(std::move(else_id.error()));
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return hir::Expr{
+          .type = *type_id,
+          .data =
+              hir::ConditionalExpr{
+                  .condition = *cond_id,
+                  .then_value = *then_id,
+                  .else_value = *else_id,
+              },
+          .span = span,
+      };
+    }
+
     case slang::ast::ExpressionKind::Call: {
       const auto& call = expr.as<slang::ast::CallExpression>();
 
@@ -704,6 +739,41 @@ auto LowerStructuralExpr(
                   .op = LowerBinaryOp(bin.op),
                   .lhs = *lhs_id,
                   .rhs = *rhs_id,
+              },
+          .span = span,
+      };
+    }
+
+    case slang::ast::ExpressionKind::ConditionalOp: {
+      const auto& cond = expr.as<slang::ast::ConditionalExpression>();
+      if (cond.conditions.size() != 1) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
+            "conditional operator with `&&&` multi-condition is not yet "
+            "supported",
+            diag::UnsupportedCategory::kFeature);
+      }
+      if (cond.conditions[0].pattern != nullptr) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
+            "conditional operator with `matches` pattern is not yet supported",
+            diag::UnsupportedCategory::kFeature);
+      }
+      auto cond_id = add_child(*cond.conditions[0].expr);
+      if (!cond_id) return std::unexpected(std::move(cond_id.error()));
+      auto then_id = add_child(cond.left());
+      if (!then_id) return std::unexpected(std::move(then_id.error()));
+      auto else_id = add_child(cond.right());
+      if (!else_id) return std::unexpected(std::move(else_id.error()));
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return hir::Expr{
+          .type = *type_id,
+          .data =
+              hir::ConditionalExpr{
+                  .condition = *cond_id,
+                  .then_value = *then_id,
+                  .else_value = *else_id,
               },
           .span = span,
       };

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -439,6 +439,33 @@ auto LowerExpr(
                         .rhs = rhs_id},
                 .type = result_type};
           },
+          [&](const hir::ConditionalExpr& c) -> diag::Result<mir::Expr> {
+            auto cond_or = LowerExpr(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, hir_process.exprs.at(c.condition.value));
+            if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+            const mir::ExprId cond_id =
+                proc_scope_state.AddExpr(*std::move(cond_or));
+            auto then_or = LowerExpr(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, hir_process.exprs.at(c.then_value.value));
+            if (!then_or) return std::unexpected(std::move(then_or.error()));
+            const mir::ExprId then_id =
+                proc_scope_state.AddExpr(*std::move(then_or));
+            auto else_or = LowerExpr(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, hir_process.exprs.at(c.else_value.value));
+            if (!else_or) return std::unexpected(std::move(else_or.error()));
+            const mir::ExprId else_id =
+                proc_scope_state.AddExpr(*std::move(else_or));
+            return mir::Expr{
+                .data =
+                    mir::ConditionalExpr{
+                        .condition = cond_id,
+                        .then_value = then_id,
+                        .else_value = else_id},
+                .type = result_type};
+          },
           [&](const hir::AssignExpr& a) -> diag::Result<mir::Expr> {
             const auto& lhs_expr = hir_process.exprs.at(a.lhs.value);
             const auto ref = hir::AsAssignableRef(lhs_expr);
@@ -564,6 +591,33 @@ auto LowerExprImpl(
                         .op = LowerBinaryOp(b.op),
                         .lhs = lhs_id,
                         .rhs = rhs_id},
+                .type = result_type};
+          },
+          [&](const hir::ConditionalExpr& c) -> diag::Result<mir::Expr> {
+            auto cond_or = LowerExprImpl(
+                unit_state, scope_state, ctor_state, proc_scope_state, scope,
+                scope.GetExpr(c.condition), loop_var_mode);
+            if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+            const mir::ExprId cond_id =
+                proc_scope_state.AddExpr(*std::move(cond_or));
+            auto then_or = LowerExprImpl(
+                unit_state, scope_state, ctor_state, proc_scope_state, scope,
+                scope.GetExpr(c.then_value), loop_var_mode);
+            if (!then_or) return std::unexpected(std::move(then_or.error()));
+            const mir::ExprId then_id =
+                proc_scope_state.AddExpr(*std::move(then_or));
+            auto else_or = LowerExprImpl(
+                unit_state, scope_state, ctor_state, proc_scope_state, scope,
+                scope.GetExpr(c.else_value), loop_var_mode);
+            if (!else_or) return std::unexpected(std::move(else_or.error()));
+            const mir::ExprId else_id =
+                proc_scope_state.AddExpr(*std::move(else_or));
+            return mir::Expr{
+                .data =
+                    mir::ConditionalExpr{
+                        .condition = cond_id,
+                        .then_value = then_id,
+                        .else_value = else_id},
                 .type = result_type};
           },
           [&](const hir::AssignExpr& a) -> diag::Result<mir::Expr> {

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -434,6 +434,11 @@ class MirDumper {
                   "BinaryExpr op={} lhs=Expr[{}] rhs=Expr[{}]",
                   FormatBinaryOp(b.op), b.lhs.value, b.rhs.value);
             },
+            [](const ConditionalExpr& c) -> std::string {
+              return std::format(
+                  "ConditionalExpr cond=Expr[{}] then=Expr[{}] else=Expr[{}]",
+                  c.condition.value, c.then_value.value, c.else_value.value);
+            },
             [this](const AssignExpr& a) -> std::string {
               return std::format(
                   "AssignExpr target={} value=Expr[{}]", FormatLvalue(a.target),

--- a/tests/cases/cpp/ternary_basic/case.yaml
+++ b/tests/cases/cpp/ternary_basic/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.ternary_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a: 7
+    b: 3
+    larger: 7

--- a/tests/cases/cpp/ternary_basic/main.sv
+++ b/tests/cases/cpp/ternary_basic/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int a;
+  int b;
+  int larger;
+  initial begin
+    a = 7;
+    b = 3;
+    larger = (a > b) ? a : b;
+  end
+endmodule

--- a/tests/cases/cpp/ternary_in_arith/case.yaml
+++ b/tests/cases/cpp/ternary_in_arith/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.ternary_in_arith
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sel: 1
+    hi: 100
+    lo: 1
+    result: 210

--- a/tests/cases/cpp/ternary_in_arith/main.sv
+++ b/tests/cases/cpp/ternary_in_arith/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  int sel;
+  int hi;
+  int lo;
+  int result;
+  initial begin
+    sel = 1;
+    hi = 100;
+    lo = 1;
+    result = 10 + (sel == 1 ? hi : lo) * 2;
+  end
+endmodule

--- a/tests/cases/cpp/ternary_in_if_condition/case.yaml
+++ b/tests/cases/cpp/ternary_in_if_condition/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.ternary_in_if_condition
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sel: 0
+    a: 4
+    b: 11
+    taken: 1

--- a/tests/cases/cpp/ternary_in_if_condition/main.sv
+++ b/tests/cases/cpp/ternary_in_if_condition/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  int sel;
+  int a;
+  int b;
+  int taken;
+  initial begin
+    sel = 0;
+    a = 4;
+    b = 11;
+    taken = 0;
+    if ((sel ? a : b) > 5) begin
+      taken = 1;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/ternary_in_loop_body/case.yaml
+++ b/tests/cases/cpp/ternary_in_loop_body/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.ternary_in_loop_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    i: 7
+    sum_evens: 12
+    sum_odds: 9

--- a/tests/cases/cpp/ternary_in_loop_body/main.sv
+++ b/tests/cases/cpp/ternary_in_loop_body/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  int i;
+  int sum_evens;
+  int sum_odds;
+  initial begin
+    sum_evens = 0;
+    sum_odds = 0;
+    for (i = 1; i <= 6; i = i + 1) begin
+      sum_evens = sum_evens + (((i % 2) == 0) ? i : 0);
+      sum_odds = sum_odds + (((i % 2) != 0) ? i : 0);
+    end
+  end
+endmodule

--- a/tests/cases/cpp/ternary_nested/case.yaml
+++ b/tests/cases/cpp/ternary_nested/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.ternary_nested
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a: 4
+    b: 9
+    c: 6
+    max_abc: 9

--- a/tests/cases/cpp/ternary_nested/main.sv
+++ b/tests/cases/cpp/ternary_nested/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  int a;
+  int b;
+  int c;
+  int max_abc;
+  initial begin
+    a = 4;
+    b = 9;
+    c = 6;
+    max_abc = (a > b)
+                ? ((a > c) ? a : c)
+                : ((b > c) ? b : c);
+  end
+endmodule

--- a/tests/cases/cpp/ternary_with_literal/case.yaml
+++ b/tests/cases/cpp/ternary_with_literal/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.ternary_with_literal
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    flag: 1
+    picked_true: 42
+    picked_false: -1

--- a/tests/cases/cpp/ternary_with_literal/main.sv
+++ b/tests/cases/cpp/ternary_with_literal/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int flag;
+  int picked_true;
+  int picked_false;
+  initial begin
+    flag = 1;
+    picked_true = flag ? 42 : -1;
+    picked_false = (flag == 0) ? 42 : -1;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds the ternary `cond ? a : b` operator (C14). New `hir::ConditionalExpr` and `mir::ConditionalExpr` carry the three sub-expressions; HIR -> MIR is a straight pass-through and the C++ backend renders the native (2-state integral) path as `(cond ? then : else)`. Multi-condition (`&&&`) and `matches` pattern forms are rejected with `diag::Unsupported`.

Also restructures `docs/progress/control-flow.md` to surface what is actually actionable next: each open item now lists its true external `Depends on`, and a new Actionable section calls out C13/C15 (today's pickable work) and the blocked-on-data-types / blocked-on-operators items.

## Testing

Six `cpp_run` cases under `tests/cases/cpp/ternary_*` cover: basic max-pick, nested chained ternary, ternary embedded in an arithmetic expression, literal-only arms, ternary feeding an `if` condition, and ternary inside a `for`-loop body.