### PR TITLE
Add scheduling architecture and MIR closure vocabulary

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -19,14 +19,16 @@ Read top to bottom on first pass:
 5. `hir.md` -- source-near semantic IR
 6. `mir.md` -- object-oriented semantic IR (objects, members, callables)
 7. `lir.md` -- execution-oriented IR (CFG, basic blocks, storage)
-8. `hierarchy_and_generate.md` -- hierarchy and generate ownership
-9. `identity_and_ownership.md` -- identity rules and forbidden shapes
-10. `lowering_boundaries.md` -- what each lowering may and may not do
-11. `incremental_build.md` -- query-based incremental compilation and caching
-12. `testing_strategy.md` -- test categories and structure
+8. `scheduling.md` -- stratified event scheduler, regions, suspension protocol
+9. `hierarchy_and_generate.md` -- hierarchy and generate ownership
+10. `identity_and_ownership.md` -- identity rules and forbidden shapes
+11. `lowering_boundaries.md` -- what each lowering may and may not do
+12. `incremental_build.md` -- query-based incremental compilation and caching
+13. `testing_strategy.md` -- test categories and structure
 
-## Template
+## Document Shape
 
-Each architecture doc follows the fixed template defined in `../style.md`: Purpose, Owns, Does Not
-Own, Core Invariants, Boundary to Adjacent Layers, Forbidden Shapes, Notes / Examples. No section
-may be omitted.
+Type-contract docs (the IR layers, hierarchy, identity, ownership, lowering boundaries) follow the
+template defined in `../style.md`. Behavioral and decision-cluster docs (`scheduling.md`) find their
+own structure; the contract discipline still applies. See `../style.md` for which subjects use which
+shape.

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -1,0 +1,109 @@
+# Scheduling
+
+A lyra simulation runs as a set of coroutines coordinated by a stratified event scheduler. Each
+SystemVerilog process -- `initial`, `always*`, `final` -- compiles to a C++ coroutine. The scheduler
+pulls coroutines from time-slot region queues and resumes them; a coroutine runs until it yields
+with a named reason (delay, event wait, `$finish`), and the scheduler parks it on the queue matching
+that reason. Deferred effects (`<=` writes, `$strobe` prints) are not yields: the coroutine
+snapshots its inputs into a closure, hands the closure to the engine, and continues running. The
+engine invokes those closures when their owning region runs.
+
+This doc covers the decisions behind the engine itself: process model, suspension protocol, region
+structure, deferred work, `$finish` semantics, and the MIR boundary. Sensitivity tracking, change
+detection, and edge detection are separate runtime subsystems.
+
+## Processes are coroutines
+
+A process body compiles into a `ProcessCoroutine` whose `co_await` expressions hand a `WaitRequest`
+to the scheduler. The scheduler holds a `std::coroutine_handle` and calls `.resume()` to continue
+the body. Process state -- procedural locals, the implicit program counter -- lives in the coroutine
+frame, which the engine does not introspect.
+
+Fibers are rejected: per-process stacks would multiply memory by orders of magnitude for any
+nontrivial design. Coroutine frames hold only the locals live across suspension points. Hand-rolled
+state machines are rejected: they would force HIR-to-MIR lowering to thread resumption state through
+every statement that might suspend, defeating the structured form MIR is designed to carry.
+
+## Suspension is a named reason
+
+A coroutine surrenders control only by `co_await`-ing an awaitable that sets a `WaitRequest`.
+`WaitRequest` is a closed `std::variant` of the reasons the engine knows how to dispatch:
+`DelayWait`, `EventWait`, `FinishWait`. A new suspension kind is added by extending the variant;
+there is no implicit yield path.
+
+The engine sees nothing about a suspended coroutine beyond the reason it yielded with. There is no
+priority field the engine reads, no out-of-band hook for a process to leave notes for the scheduler.
+The reason is the protocol.
+
+## Deferred work is a closure submit, not a suspension
+
+When a process needs an effect to happen later in the same time slot -- a non-blocking write to a
+signal, a postponed `$strobe` print -- it does not yield. It snapshots its inputs into a closure
+(see `mir.md` for the MIR-level shape) and hands the closure to the engine via a region-specific
+submit call, then keeps running.
+
+Yield-based alternatives are rejected because they would entangle the deferred effect's commit time
+with the process's resumption schedule. A process that does `q <= d; #5; ...` should not be forced
+to suspend before `#5` just because the NBA write has not yet committed; the write commits in the
+NBA region of this same time slot regardless of where the process is by then.
+
+## Region structure
+
+A time slot runs regions in LRM §4.4 order: Preponed, Active, Inactive, NBA, Observed, Reactive,
+ReInactive, ReNBA, Postponed.
+
+The **active group** (Active, Inactive, NBA) iterates as a unit. Active drains, then Inactive
+promotes; Inactive drains, then NBA commits; if NBA's committed writes wake any sensitivity-bound
+processes, Active runs again. The cycle repeats until all three queues are empty. Without this
+iteration, a process woken by an NBA commit would be deferred to the next time slot, which is
+incorrect -- it belongs to the slot whose NBA woke it.
+
+The reactive group (Reactive, ReInactive, ReNBA) iterates by the same rule, for program-block work.
+The two groups are independent of each other.
+
+`#0` delays land in **Inactive**, not Active. A user writing `#0` is asking the engine to let other
+already-pending active work finish first, then come back at this same simulation time. Pushing
+`#0`-suspended processes to the back of Active would let them re-enter ahead of work that arrived
+earlier, defeating the intent.
+
+## `$finish`
+
+`$finish` yields a `FinishWait`. When the scheduler dispatches it, it sets a `finished_` flag and
+the time-slot loop exits without running further regions in the in-progress slot. Pending NBA writes
+for that slot do not commit; queued active processes do not resume.
+
+Registered `final` actions then run in registration order. A `$finish` raised from inside a `final`
+aborts the remaining finals. This three-cornered behavior (active shutdown, NBA discard, final
+abort) follows LRM §9.2.3.
+
+## Closure capture lifetime
+
+A closure's captures are either by-value or by-reference (see `mir.md` for the MIR-level shape). The
+two have different lifetime rules:
+
+- **By-value capture** is always safe. The snapshot lives inside the closure's storage; the engine
+  destroys it when the closure fires or when the closure is dropped without firing.
+- **By-reference capture of a `StructuralVarRef`** is always safe. Structural-scope storage
+  (module-level variables) lives for the entire simulation; any closure can hold a reference into it
+  indefinitely.
+- **By-reference capture of a `ProceduralVarRef`** is safe only if the closure fires while the
+  process's coroutine frame is still alive. The procedural frame is destroyed when the process body
+  returns or when `$finish` tears down the simulation; references into the frame are invalid after
+  either event.
+
+The third case is the one a lowering pass must reason about. A lowering that emits a closure
+capturing a procedural lvalue is responsible for establishing the fire-before-frame-dies guarantee,
+or it must refuse the capture.
+
+## MIR boundary: no pointers, only captures
+
+MIR carries no pointer type, no reference type, no `AddressOf`, no `Deref`. Where a runtime
+mechanism needs the shape of "this place, written later" -- NBA commit, postponed strobe, callback
+registration -- MIR expresses it as a closure whose capture list includes the place to write. The
+C++ backend renders by-reference captures as `&` lambda captures; the resulting C++ holds the
+reference directly.
+
+Pointers are not added to MIR. Captures already express the "hold a place for later" pattern in the
+shape a software engineer would write by hand, and a parallel pointer mechanism would split the same
+concept across two MIR vocabularies. Pointers would also invite storage-layout decisions to leak
+into MIR; the engine, not MIR, owns where storage lives.

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -49,7 +49,7 @@ NBA region of this same time slot regardless of where the process is by then.
 
 ## Region structure
 
-A time slot runs regions in LRM §4.4 order: Preponed, Active, Inactive, NBA, Observed, Reactive,
+A time slot runs regions in LRM 4.4 order: Preponed, Active, Inactive, NBA, Observed, Reactive,
 ReInactive, ReNBA, Postponed.
 
 The **active group** (Active, Inactive, NBA) iterates as a unit. Active drains, then Inactive
@@ -74,7 +74,7 @@ for that slot do not commit; queued active processes do not resume.
 
 Registered `final` actions then run in registration order. A `$finish` raised from inside a `final`
 aborts the remaining finals. This three-cornered behavior (active shutdown, NBA discard, final
-abort) follows LRM §9.2.3.
+abort) follows LRM 9.2.3.
 
 ## Closure capture lifetime
 

--- a/docs/style.md
+++ b/docs/style.md
@@ -16,13 +16,30 @@ rules only. Formatting is enforced by Prettier; see the Formatting section at th
    architecture docs.
 6. **Explicit invariants and forbidden shapes.** Every architecture doc states what must hold and
    what is not allowed. Implicit behavior is a defect.
-7. **The template is the design check.** If a concept cannot be placed in the template's sections,
-   the design is incomplete. Do not widen or bypass the template; widen the design until the concept
-   fits.
+7. **Templates are tools, not laws.** The type-contract template (Purpose / Owns / Does Not Own /
+   Core Invariants / Boundary / Forbidden Shapes / Notes) fits subjects whose architecture is well
+   described by what types live in a layer and what shapes are forbidden. Behavioral, protocol, or
+   decision-cluster subjects find their own structure. Consistency comes from copying close existing
+   examples, not from forcing every subject through one section list.
 
 ## Architecture Docs Are Contracts
 
-Every architecture doc must contain, in order:
+Every architecture doc is a binding contract for its subject: what holds, what is forbidden, what
+the boundaries are. Contracts are not narrative.
+
+A doc whose subject is a type-contract layer (HIR, MIR, LIR, hierarchy, identity, ownership) uses
+the template in the next section. The template forces the right discipline for those subjects.
+
+A doc whose subject is runtime behavior, a protocol between subsystems, or a cluster of related
+decisions finds its own structure. Open with the model, then state the decisions. Each decision
+earns its space with its reason; abstract principles without consequences do not.
+
+In both cases the rules under Core Principles still apply: no narrative framing, no "currently /
+historically / not yet / migration", no platitudes that are trivially true of any reasonable system.
+
+### Type-Contract Template
+
+A type-contract doc contains, in order:
 
 1. Title
 2. Purpose
@@ -35,6 +52,13 @@ Every architecture doc must contain, in order:
 
 Sections may be short, but none may be omitted. An empty section signals that the contract is not
 yet defined and must be filled before merge.
+
+### Behavioral and Decision-Cluster Docs
+
+These docs do not follow a fixed section list. Copy the shape of `architecture/scheduling.md` if the
+subject is similar (a runtime mechanism with a handful of load-bearing decisions). Otherwise let the
+subject drive the structure: state the mental model up front, then walk the decisions, each with the
+reason and any rejected alternative that is non-obvious.
 
 ## Architecture vs Other Docs
 

--- a/include/lyra/mir/closure.hpp
+++ b/include/lyra/mir/closure.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <memory>
+#include <variant>
+#include <vector>
+
+#include "lyra/mir/expr_id.hpp"
+#include "lyra/mir/procedural_var.hpp"
+#include "lyra/mir/value_ref.hpp"
+
+namespace lyra::mir {
+
+struct ProceduralScope;
+
+struct ByValueCapture {
+  ExprId value;
+  ProceduralVarId binding;
+};
+
+struct ByReferenceCapture {
+  Lvalue source;
+  ProceduralVarId binding;
+};
+
+using Capture = std::variant<ByValueCapture, ByReferenceCapture>;
+
+// A callable value with captured state and a procedural body.
+//
+// Closures are synthesized exclusively by HIR-to-MIR lowering. No SystemVerilog
+// source construct produces one directly; both the capture list and the body
+// statements are compiler-generated.
+//
+// Invariants enforced by lowering (violations are compiler-bug class):
+//   1. Each capture's binding is a ProceduralVarId valid in body.vars and is
+//      unique across the capture list.
+//   2. Writes inside body to a binding require that binding's capture to be
+//      ByReferenceCapture. ByValueCapture bindings are read-only inside body.
+//   3. ProceduralVarRef inside body uses hops bounded by body's own scope
+//      nesting and does not escape into the enclosing process scope. Outer
+//      procedural state reaches body only through captures.
+//
+// StructuralVarRef inside body may carry hops that reach module-scope storage
+// directly, the same way C++ lambdas may reference globals without capture.
+struct ClosureExpr {
+  std::vector<Capture> captures;
+  std::unique_ptr<ProceduralScope> body;
+
+  ClosureExpr();
+  ~ClosureExpr();
+  ClosureExpr(const ClosureExpr&);
+  auto operator=(const ClosureExpr&) -> ClosureExpr&;
+  ClosureExpr(ClosureExpr&&) noexcept;
+  auto operator=(ClosureExpr&&) noexcept -> ClosureExpr&;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -6,19 +6,17 @@
 #include <vector>
 
 #include "lyra/mir/binary_op.hpp"
+#include "lyra/mir/closure.hpp"
 #include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/integral_constant.hpp"
-#include "lyra/mir/procedural_hops.hpp"
-#include "lyra/mir/procedural_var.hpp"
 #include "lyra/mir/runtime_finish.hpp"
 #include "lyra/mir/runtime_print.hpp"
-#include "lyra/mir/structural_hops.hpp"
 #include "lyra/mir/structural_param.hpp"
 #include "lyra/mir/structural_subroutine.hpp"
-#include "lyra/mir/structural_var.hpp"
 #include "lyra/mir/type.hpp"
 #include "lyra/mir/unary_op.hpp"
+#include "lyra/mir/value_ref.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::mir {
@@ -37,18 +35,6 @@ struct TimeLiteral {
   double value;
   TimeScale scale;
 };
-
-struct StructuralVarRef {
-  StructuralHops hops;
-  StructuralVarId var;
-};
-
-struct ProceduralVarRef {
-  ProceduralHops hops;
-  ProceduralVarId var;
-};
-
-using Lvalue = std::variant<StructuralVarRef, ProceduralVarRef>;
 
 struct UnaryExpr {
   UnaryOp op;
@@ -92,7 +78,7 @@ struct RuntimeCallExpr {
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, StructuralParamRef,
     StructuralVarRef, ProceduralVarRef, UnaryExpr, BinaryExpr, ConditionalExpr,
-    AssignExpr, CallExpr, RuntimeCallExpr, ConversionExpr>;
+    AssignExpr, CallExpr, RuntimeCallExpr, ConversionExpr, ClosureExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/mir/value_ref.hpp
+++ b/include/lyra/mir/value_ref.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <variant>
+
+#include "lyra/mir/procedural_hops.hpp"
+#include "lyra/mir/procedural_var.hpp"
+#include "lyra/mir/structural_hops.hpp"
+#include "lyra/mir/structural_var.hpp"
+
+namespace lyra::mir {
+
+struct StructuralVarRef {
+  StructuralHops hops;
+  StructuralVarId var{};
+};
+
+struct ProceduralVarRef {
+  ProceduralHops hops;
+  ProceduralVarId var{};
+};
+
+using Lvalue = std::variant<StructuralVarRef, ProceduralVarRef>;
+
+}  // namespace lyra::mir

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -639,6 +639,12 @@ auto RenderExprAsNative(const RenderContext& ctx, const mir::Expr& expr)
           [&](const mir::RuntimeCallExpr& rc) -> diag::Result<std::string> {
             return RenderRuntimeCallExpr(ctx, rc);
           },
+          [](const mir::ClosureExpr&) -> diag::Result<std::string> {
+            return diag::Unsupported(
+                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+                "ClosureExpr is not yet implemented in cpp emit",
+                diag::UnsupportedCategory::kFeature);
+          },
       },
       expr.data);
 }

--- a/src/lyra/mir/closure.cpp
+++ b/src/lyra/mir/closure.cpp
@@ -1,0 +1,32 @@
+#include "lyra/mir/closure.hpp"
+
+#include <memory>
+
+#include "lyra/mir/stmt.hpp"
+
+namespace lyra::mir {
+
+ClosureExpr::ClosureExpr() = default;
+ClosureExpr::~ClosureExpr() = default;
+ClosureExpr::ClosureExpr(ClosureExpr&&) noexcept = default;
+auto ClosureExpr::operator=(ClosureExpr&&) noexcept -> ClosureExpr& = default;
+
+ClosureExpr::ClosureExpr(const ClosureExpr& other)
+    : captures(other.captures),
+      body(
+          other.body == nullptr
+              ? nullptr
+              : std::make_unique<ProceduralScope>(*other.body)) {
+}
+
+auto ClosureExpr::operator=(const ClosureExpr& other) -> ClosureExpr& {
+  if (this != &other) {
+    captures = other.captures;
+    body = other.body == nullptr
+               ? nullptr
+               : std::make_unique<ProceduralScope>(*other.body);
+  }
+  return *this;
+}
+
+}  // namespace lyra::mir

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -12,6 +12,7 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/mir/binary_op.hpp"
+#include "lyra/mir/closure.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/procedural_var.hpp"
@@ -463,6 +464,9 @@ class MirDumper {
                   "ConversionExpr kind={} operand=Expr[{}]",
                   FormatConversionKind(cv.kind), cv.operand.value);
             },
+            [](const ClosureExpr& cl) -> std::string {
+              return std::format("ClosureExpr captures={}", cl.captures.size());
+            },
         },
         e.data);
     return std::format("{} type=Type[{}]", formatted, e.type.value);
@@ -597,6 +601,11 @@ class MirDumper {
               rc->call);
           Dedent();
         }
+        if (const auto* cl = std::get_if<ClosureExpr>(&expr.data)) {
+          Indent();
+          DumpClosureExpr(*cl, scope);
+          Dedent();
+        }
       }
       Dedent();
     }
@@ -724,6 +733,57 @@ class MirDumper {
     DumpStmt(enclosing, t.stmt);
     Dedent();
     Dedent();
+  }
+
+  void DumpClosureExpr(
+      const ClosureExpr& closure, const ProceduralScope& enclosing) {
+    if (closure.captures.empty()) {
+      Line("captures: (none)");
+    } else {
+      Line("captures:");
+      Indent();
+      for (std::size_t i = 0; i < closure.captures.size(); ++i) {
+        DumpCapture(i, closure.captures[i], enclosing);
+      }
+      Dedent();
+    }
+    if (closure.body == nullptr) {
+      Line("body: <null>");
+    } else {
+      Line("body:");
+      Indent();
+      DumpProceduralScope(*closure.body);
+      Dedent();
+    }
+  }
+
+  void DumpCapture(
+      std::size_t index, const Capture& capture,
+      const ProceduralScope& enclosing) {
+    std::visit(
+        Overloaded{
+            [&](const ByValueCapture& bv) {
+              Line(
+                  std::format(
+                      "[{}] ByValueCapture value=Expr[{}] binding="
+                      "ProceduralVarId{{{}}}",
+                      index, bv.value.value, bv.binding.value));
+              Indent();
+              Line(
+                  std::format(
+                      "Expr[{}] {}", bv.value.value,
+                      FormatExpr(enclosing, bv.value)));
+              Dedent();
+            },
+            [&](const ByReferenceCapture& br) {
+              Line(
+                  std::format(
+                      "[{}] ByReferenceCapture source={} binding="
+                      "ProceduralVarId{{{}}}",
+                      index, FormatLvalue(br.source), br.binding.value));
+            },
+        },
+        capture);
   }
 
   void DumpRuntimePrintCallItems(


### PR DESCRIPTION
## Summary

Establish the foundation for the simulation engine's next stage of work by writing the scheduling architecture contract and introducing MIR closure vocabulary that future work (NBA, postponed strobe, sensitivity callbacks) will build on. No behavior change to the running compiler: `ClosureExpr` has no producer yet, so the new variant arm is exercised only by the dumper.

## Design

`docs/architecture/scheduling.md` documents the engine model: processes are C++ coroutines, suspension is a closed `WaitRequest` variant, deferred effects are closures submitted to region queues rather than process yields, and the active group iterates to fixpoint because NBA commits can wake new active work. The doc also pins down the closure capture lifetime rules and the decision to keep MIR free of pointer / address-of / deref primitives.

The MIR closure shape mirrors a C++ lambda: a capture list of `ByValueCapture` (snapshot any `Expr` into a binding) and `ByReferenceCapture` (bind a binding to an `Lvalue` for read/write), plus a `ProceduralScope` body owned through `std::unique_ptr` to break the recursive type cycle. Out-of-line rule-of-five lives in `src/lyra/mir/closure.cpp` to keep the unique_ptr destructor instantiation behind a complete `ProceduralScope`. `StructuralVarRef` / `ProceduralVarRef` / `Lvalue` move from `expr.hpp` into a new `value_ref.hpp` so closure types can include them without a header cycle.

`docs/style.md` and `docs/architecture/README.md` split the architecture-doc contract into two shapes: the existing IR-template still applies to type-contract layers, while behavioral / decision-cluster docs (scheduling and future runtime docs) find their own structure as long as the contract discipline still holds.

## Testing

- `bazel build //...`
- `bazel test //... --test_output=errors`
- `clang-format`, `prettier`, `buildifier` format-checks
- `check_architecture.py`, `check_ascii.py`, `check_cpp_style.py`, `check_exceptions.py`