### PR TITLE
Add runtime diagnostic channel and severity tasks

### DIFF
--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -11,21 +11,17 @@ operator runtime, string runtime); see the per-item **Depends on** lines and the
 
 ## Actionable
 
-Open items whose external dependencies are already in place and can be implemented today:
+No open items are currently actionable inside this workstream alone. Every remaining item depends on
+machinery owned by another workstream; the table below lists the blockers.
 
-- **C13** -- `unique` / `unique0` / `priority` qualifiers. Self-contained: needs only the runtime
-  warn helper and (for cascaded `if`) settle-epoch tracking, both of which live inside this
-  workstream.
-
-Open items currently blocked on other workstreams:
-
-| Item    | Blocked on                                                                                 |
-| ------- | ------------------------------------------------------------------------------------------ |
-| C9, C10 | `datatypes/unpacked` (procedural unpacked array vars + `arr[i]` element-select expr).      |
-| C11     | `operators/wildcard_equality` (masked-compare runtime helper for `==?` / `!=?`).           |
-| C12     | `operators/inside` (range patterns + set-membership runtime).                              |
-| C16     | `datatypes/enum`.                                                                          |
-| C17     | `datatypes/string` plus the string-equality runtime helper from `operators/binary_string`. |
+| Item    | Blocked on                                                                                                                                                                                                                                                                                                                                        |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C9, C10 | `datatypes/unpacked` (procedural unpacked array vars + `arr[i]` element-select expr).                                                                                                                                                                                                                                                             |
+| C11     | `operators/wildcard_equality` (masked-compare runtime helper for `==?` / `!=?`).                                                                                                                                                                                                                                                                  |
+| C12     | `operators/inside` (range patterns + set-membership runtime).                                                                                                                                                                                                                                                                                     |
+| C13     | A MIR action shape for deferred checks bound to the observed / reactive scheduling regions. The runtime reporting channel (severity, stderr routing, rate limit) is in place via the `$info` / `$warning` / `$error` work, so the remaining blocker is the deferred-callable machinery (and, when added, populating source locations end to end). |
+| C16     | `datatypes/enum`.                                                                                                                                                                                                                                                                                                                                 |
+| C17     | `datatypes/string` plus the string-equality runtime helper from `operators/binary_string`.                                                                                                                                                                                                                                                        |
 
 ## Sub-Steps
 
@@ -91,10 +87,17 @@ Open items currently blocked on other workstreams:
 - [ ] C12 -- `case (... inside ...)`. Range patterns (`[lo:hi]`) and `inside` membership; lower to
       if/else cascade with `inside` semantics. **Depends on** `operators/inside` for the
       set-membership runtime.
-- [ ] C13 -- `unique` / `unique0` / `priority` qualifiers on `if` and `case`. Needs the runtime warn
-      helper and (for cascaded `if`) settle-epoch tracking, both local to this workstream. Covers
-      archive items `unique_priority_if` and `unique_priority_case`. **Depends on** nothing
-      external; actionable now.
+- [ ] C13 -- `unique` / `unique0` / `priority` qualifiers on `if` and `case`. The qualifier itself
+      is a single HIR / MIR enum field; the hard part is producing the warning without false
+      positives during combinational settle. SV's intended model is a deferred check: the qualifier
+      site records an observation at evaluation time, and a drain step after the settle epoch
+      classifies the final observation and emits at most one report per site. Covers archive items
+      `unique_priority_if` and `unique_priority_case`. The runtime reporting channel (severity-based
+      routing, rate limiting) landed alongside `$info` / `$warning` / `$error`, so the remaining
+      **dependency** is a MIR action shape for deferred checks bound to the observed / reactive
+      scheduling regions (`mir.md` forbids representing deferred behavior as a flag or lowering-pass
+      side effect, so the check must be an explicit callable invoked by the scheduler). End-to-end
+      source-location propagation also needs to land before warnings can pinpoint the failing site.
 - [x] C15 -- `case` with labels that are not compile-time constants (`case (sel) some_expr: ...`)
       and `case` with duplicate labels ("first match wins"). The uniform HIR -> MIR cascade
       described in C3 handles both: non-constant labels render as runtime `==` comparisons, and

--- a/include/lyra/lowering/hir_to_mir/lower_diagnostic.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_diagnostic.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_span.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/process.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/support/system_subroutine.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// Lower a severity-bearing system subroutine call ($info, $warning, $error)
+// into a mir::Expr carrying a RuntimeCallExpr with RuntimeDiagnosticCall.
+// Shares format-item parsing with the print-task lowering, but routes through
+// the runtime diagnostic channel instead of the output channel.
+auto LowerDiagnosticSystemSubroutineCall(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_proc, const hir::CallExpr& call,
+    const support::SystemSubroutineDesc& desc,
+    const support::DiagnosticSystemSubroutineInfo& info, diag::SourceSpan span)
+    -> diag::Result<mir::Expr>;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/print_items.hpp
+++ b/include/lyra/lowering/hir_to_mir/print_items.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <vector>
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_span.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/process.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/runtime_print.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// Walks a system-subroutine call's argument list and produces the runtime
+// print-item sequence. If the first argument is a string literal, it is parsed
+// as a format string and remaining arguments are consumed by its directives;
+// otherwise each remaining argument is rendered with the default decimal
+// format. Shared by every system task that uses the LRM display-style format
+// (display / write / strobe / monitor / info / warning / error / fatal).
+auto BuildRuntimePrintItemsFromCallArgs(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_proc, const hir::CallExpr& call,
+    diag::SourceSpan call_span)
+    -> diag::Result<std::vector<mir::RuntimePrintItem>>;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -10,6 +10,7 @@
 #include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/integral_constant.hpp"
+#include "lyra/mir/runtime_diagnostic.hpp"
 #include "lyra/mir/runtime_finish.hpp"
 #include "lyra/mir/runtime_print.hpp"
 #include "lyra/mir/structural_param.hpp"
@@ -69,7 +70,8 @@ struct CallExpr {
   std::vector<ExprId> arguments;
 };
 
-using RuntimeCall = std::variant<RuntimePrintCall, RuntimeFinishCall>;
+using RuntimeCall =
+    std::variant<RuntimePrintCall, RuntimeDiagnosticCall, RuntimeFinishCall>;
 
 struct RuntimeCallExpr {
   RuntimeCall call;

--- a/include/lyra/mir/runtime_diagnostic.hpp
+++ b/include/lyra/mir/runtime_diagnostic.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "lyra/mir/runtime_print.hpp"
+
+namespace lyra::mir {
+
+enum class DiagnosticSeverity : std::uint8_t {
+  kInfo,
+  kWarning,
+  kError,
+};
+
+// Resolved source location of the diagnostic-emitting call. Carries plain
+// file:line:col so the backend can render a runtime literal without needing
+// the SourceManager at emit time. Absent when the lowering layer cannot
+// resolve the call's location.
+struct DiagnosticOrigin {
+  std::string file;
+  std::uint32_t line = 0;
+  std::uint32_t col = 0;
+};
+
+struct RuntimeDiagnosticCall {
+  DiagnosticSeverity severity;
+  std::optional<DiagnosticOrigin> origin;
+  std::vector<RuntimePrintItem> items;
+
+  RuntimeDiagnosticCall(
+      DiagnosticSeverity s, std::optional<DiagnosticOrigin> o,
+      std::vector<RuntimePrintItem> i)
+      : severity(s), origin(std::move(o)), items(std::move(i)) {
+  }
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/runtime/diagnostic.hpp
+++ b/include/lyra/runtime/diagnostic.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include "lyra/value/format.hpp"
+
+namespace lyra::runtime {
+
+class RuntimeServices;
+
+enum class Severity : std::uint8_t {
+  kInfo,
+  kWarning,
+  kError,
+};
+
+struct SourceLocation {
+  std::string file;
+  std::uint32_t line;
+  std::uint32_t col;
+
+  auto operator==(const SourceLocation&) const -> bool = default;
+};
+
+struct DiagnosticRecord {
+  Severity severity;
+  std::optional<SourceLocation> origin;
+  std::string body;
+};
+
+class DiagnosticDispatcher {
+ public:
+  using DiagnosticSink = std::function<void(std::string_view)>;
+
+  // Per-(file:line, severity) suppression after this many emits in one run.
+  // Zero disables rate limiting.
+  static constexpr std::uint32_t kDefaultRateLimit = 10;
+
+  explicit DiagnosticDispatcher(
+      DiagnosticSink sink, std::uint32_t rate_limit = kDefaultRateLimit);
+
+  void Emit(DiagnosticRecord record);
+
+ private:
+  struct CountKey {
+    std::string origin;
+    Severity severity;
+
+    auto operator==(const CountKey&) const -> bool = default;
+  };
+
+  struct CountKeyHash {
+    auto operator()(const CountKey& k) const noexcept -> std::size_t;
+  };
+
+  DiagnosticSink sink_;
+  std::uint32_t rate_limit_;
+  std::unordered_map<CountKey, std::uint32_t, CountKeyHash> emit_counts_;
+};
+
+// Formats `items` via value::FormatValue, builds a DiagnosticRecord, and emits
+// it through services.Diagnostic(). The body is fully formatted before being
+// handed to the dispatcher so the dispatcher can prepend its own envelope
+// (origin, severity prefix) without re-parsing user content.
+void LyraDiagnostic(
+    RuntimeServices& services, Severity severity,
+    std::optional<SourceLocation> origin,
+    std::span<const value::PrintItem> items);
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -9,9 +9,10 @@
 #include <vector>
 
 #include "lyra/base/time.hpp"
-#include "lyra/runtime/output_sink.hpp"
+#include "lyra/runtime/diagnostic.hpp"
 #include "lyra/runtime/runtime_scope.hpp"
 #include "lyra/runtime/runtime_services.hpp"
+#include "lyra/runtime/stream_dispatcher.hpp"
 #include "lyra/runtime/wait_request.hpp"
 
 namespace lyra::runtime {
@@ -33,7 +34,8 @@ enum class SchedulerPhase : std::uint8_t {
 };
 
 struct EngineOptions {
-  OutputDispatcher::OutputSink output_sink;
+  StreamDispatcher::StreamSink stream_sink;
+  DiagnosticDispatcher::DiagnosticSink diagnostic_sink;
 };
 
 [[nodiscard]] auto DefaultEngineOptions() -> EngineOptions;
@@ -43,7 +45,7 @@ class Engine {
   Engine();
   explicit Engine(EngineOptions options);
 
-  // services_ holds a pointer into output_; copying or moving Engine would
+  // services_ holds a pointer into stream_; copying or moving Engine would
   // dangle that pointer.
   Engine(const Engine&) = delete;
   auto operator=(const Engine&) -> Engine& = delete;
@@ -54,8 +56,8 @@ class Engine {
   void BindRoot(std::string root_name, Module& top);
   auto Run() -> int;
 
-  auto Output() -> OutputDispatcher& {
-    return output_;
+  auto Stream() -> StreamDispatcher& {
+    return stream_;
   }
 
   auto Services() -> RuntimeServices& {
@@ -118,8 +120,9 @@ class Engine {
   [[nodiscard]] static auto CheckedAdd(SimTime base, SimDuration delta)
       -> SimTime;
 
-  OutputDispatcher output_;
-  RuntimeServices services_{output_};
+  StreamDispatcher stream_;
+  DiagnosticDispatcher diagnostic_;
+  RuntimeServices services_{stream_, diagnostic_};
   std::unique_ptr<RuntimeScope> root_;
   SchedulerQueues queues_;
   SimTime now_ = 0;

--- a/include/lyra/runtime/runtime_services.hpp
+++ b/include/lyra/runtime/runtime_services.hpp
@@ -4,22 +4,32 @@
 
 namespace lyra::runtime {
 
-class OutputDispatcher;
+class StreamDispatcher;
+class DiagnosticDispatcher;
 
 class RuntimeServices {
  public:
-  explicit RuntimeServices(OutputDispatcher& output) : output_(&output) {
+  RuntimeServices(StreamDispatcher& stream, DiagnosticDispatcher& diagnostic)
+      : stream_(&stream), diagnostic_(&diagnostic) {
   }
 
-  auto Output() -> OutputDispatcher& {
-    if (output_ == nullptr) {
-      throw InternalError("RuntimeServices has no OutputDispatcher");
+  auto Stream() -> StreamDispatcher& {
+    if (stream_ == nullptr) {
+      throw InternalError("RuntimeServices has no StreamDispatcher");
     }
-    return *output_;
+    return *stream_;
+  }
+
+  auto Diagnostic() -> DiagnosticDispatcher& {
+    if (diagnostic_ == nullptr) {
+      throw InternalError("RuntimeServices has no DiagnosticDispatcher");
+    }
+    return *diagnostic_;
   }
 
  private:
-  OutputDispatcher* output_ = nullptr;
+  StreamDispatcher* stream_ = nullptr;
+  DiagnosticDispatcher* diagnostic_ = nullptr;
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/stream_dispatcher.hpp
+++ b/include/lyra/runtime/stream_dispatcher.hpp
@@ -6,11 +6,11 @@
 
 namespace lyra::runtime {
 
-class OutputDispatcher {
+class StreamDispatcher {
  public:
-  using OutputSink = std::function<void(std::string_view)>;
+  using StreamSink = std::function<void(std::string_view)>;
 
-  explicit OutputDispatcher(OutputSink sink);
+  explicit StreamDispatcher(StreamSink sink);
 
   void Append(std::string_view text);
   void FinishRecord(bool append_newline);
@@ -18,7 +18,7 @@ class OutputDispatcher {
 
  private:
   std::string pending_;
-  OutputSink sink_;
+  StreamSink sink_;
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -71,8 +71,19 @@ struct TerminationSystemSubroutineInfo {
   int default_level;
 };
 
-using SystemSubroutineSemantic =
-    std::variant<PrintSystemSubroutineInfo, TerminationSystemSubroutineInfo>;
+enum class DiagnosticSeverityKind : std::uint8_t {
+  kInfo,
+  kWarning,
+  kError,
+};
+
+struct DiagnosticSystemSubroutineInfo {
+  DiagnosticSeverityKind severity;
+};
+
+using SystemSubroutineSemantic = std::variant<
+    PrintSystemSubroutineInfo, TerminationSystemSubroutineInfo,
+    DiagnosticSystemSubroutineInfo>;
 
 struct SystemSubroutineDesc {
   SystemSubroutineId id;
@@ -154,6 +165,39 @@ inline constexpr std::array kSystemSubroutines = {
             TerminationSystemSubroutineInfo{
                 .kind = TerminationKind::kFinish, .default_level = 1},
     },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{5},
+        .name = "$info",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kFunction,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 255},
+        .semantic =
+            DiagnosticSystemSubroutineInfo{
+                .severity = DiagnosticSeverityKind::kInfo},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{6},
+        .name = "$warning",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kFunction,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 255},
+        .semantic =
+            DiagnosticSystemSubroutineInfo{
+                .severity = DiagnosticSeverityKind::kWarning},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{7},
+        .name = "$error",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kFunction,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 255},
+        .semantic =
+            DiagnosticSystemSubroutineInfo{
+                .severity = DiagnosticSeverityKind::kError},
+    },
 };
 
 }  // namespace detail
@@ -181,6 +225,11 @@ inline constexpr std::array kSystemSubroutines = {
 [[nodiscard]] inline auto GetPrintInfo(const SystemSubroutineDesc& desc)
     -> const PrintSystemSubroutineInfo* {
   return std::get_if<PrintSystemSubroutineInfo>(&desc.semantic);
+}
+
+[[nodiscard]] inline auto GetDiagnosticInfo(const SystemSubroutineDesc& desc)
+    -> const DiagnosticSystemSubroutineInfo* {
+  return std::get_if<DiagnosticSystemSubroutineInfo>(&desc.semantic);
 }
 
 }  // namespace lyra::support

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -1,6 +1,7 @@
 #include "lyra/backend/cpp/render_print.hpp"
 
 #include <format>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -16,6 +17,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/kind.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/mir/runtime_diagnostic.hpp"
 #include "lyra/mir/runtime_finish.hpp"
 #include "lyra/mir/runtime_print.hpp"
 #include "lyra/mir/type.hpp"
@@ -183,6 +185,66 @@ auto RenderRuntimeFinishCall(const mir::RuntimeFinishCall& call)
   return std::format("co_await lyra::runtime::Finish({})", call.level);
 }
 
+auto RenderRuntimeDiagnosticSeverity(mir::DiagnosticSeverity s)
+    -> std::string_view {
+  switch (s) {
+    case mir::DiagnosticSeverity::kInfo:
+      return "lyra::runtime::Severity::kInfo";
+    case mir::DiagnosticSeverity::kWarning:
+      return "lyra::runtime::Severity::kWarning";
+    case mir::DiagnosticSeverity::kError:
+      return "lyra::runtime::Severity::kError";
+  }
+  throw InternalError("RenderRuntimeDiagnosticSeverity: unknown severity");
+}
+
+auto RenderDiagnosticOriginInit(
+    const std::optional<mir::DiagnosticOrigin>& origin) -> std::string {
+  if (!origin.has_value()) {
+    return "std::optional<lyra::runtime::SourceLocation>{}";
+  }
+  return std::format(
+      "std::optional<lyra::runtime::SourceLocation>{{lyra::runtime::"
+      "SourceLocation{{.file = {}, .line = {}, .col = {}}}}}",
+      RenderCStringLiteral(origin->file), origin->line, origin->col);
+}
+
+auto RenderRuntimeDiagnosticCall(
+    const RenderContext& ctx, const mir::RuntimeDiagnosticCall& call)
+    -> diag::Result<std::string> {
+  const std::string_view sev_literal =
+      RenderRuntimeDiagnosticSeverity(call.severity);
+  const std::string origin_init = RenderDiagnosticOriginInit(call.origin);
+
+  if (call.items.empty()) {
+    return std::format(
+        "lyra::runtime::LyraDiagnostic(*services_, {}, {}, "
+        "std::span<const lyra::value::PrintItem>{{}})",
+        sev_literal, origin_init);
+  }
+
+  std::vector<std::string> item_inits;
+  item_inits.reserve(call.items.size());
+  for (const mir::RuntimePrintItem& item : call.items) {
+    auto init_or = RenderPrintItemInit(ctx, item);
+    if (!init_or) return std::unexpected(std::move(init_or.error()));
+    item_inits.push_back(*std::move(init_or));
+  }
+
+  std::string out = std::format(
+      "lyra::runtime::LyraDiagnostic(*services_, {}, {}, "
+      "std::array<lyra::value::PrintItem, {}>{{",
+      sev_literal, origin_init, call.items.size());
+  for (std::size_t i = 0; i < item_inits.size(); ++i) {
+    if (i != 0) {
+      out += ", ";
+    }
+    out += item_inits[i];
+  }
+  out += "})";
+  return out;
+}
+
 }  // namespace
 
 auto RenderRuntimeCallExpr(
@@ -192,6 +254,10 @@ auto RenderRuntimeCallExpr(
       Overloaded{
           [&](const mir::RuntimePrintCall& pc) -> diag::Result<std::string> {
             return RenderRuntimePrintCall(ctx, pc);
+          },
+          [&](const mir::RuntimeDiagnosticCall& dc)
+              -> diag::Result<std::string> {
+            return RenderRuntimeDiagnosticCall(ctx, dc);
           },
           [&](const mir::RuntimeFinishCall& fc) -> diag::Result<std::string> {
             return RenderRuntimeFinishCall(fc);

--- a/src/lyra/lowering/hir_to_mir/lower_diagnostic.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_diagnostic.cpp
@@ -1,12 +1,10 @@
-#include "lyra/lowering/hir_to_mir/lower_print.hpp"
+#include "lyra/lowering/hir_to_mir/lower_diagnostic.hpp"
 
 #include <expected>
-#include <format>
 #include <optional>
-#include <string>
 #include <utility>
 
-#include "lyra/diag/diag_code.hpp"
+#include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
@@ -14,41 +12,38 @@
 #include "lyra/lowering/hir_to_mir/print_items.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/expr.hpp"
-#include "lyra/mir/runtime_print.hpp"
+#include "lyra/mir/runtime_diagnostic.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
 namespace {
 
-auto ToMirPrintKind(const support::PrintSystemSubroutineInfo& info)
-    -> mir::PrintKind {
-  if (info.sink_kind == support::PrintSinkKind::kStdout) {
-    return info.append_newline ? mir::PrintKind::kDisplay
-                               : mir::PrintKind::kWrite;
+auto ToMirDiagnosticSeverity(support::DiagnosticSeverityKind k)
+    -> mir::DiagnosticSeverity {
+  switch (k) {
+    case support::DiagnosticSeverityKind::kInfo:
+      return mir::DiagnosticSeverity::kInfo;
+    case support::DiagnosticSeverityKind::kWarning:
+      return mir::DiagnosticSeverity::kWarning;
+    case support::DiagnosticSeverityKind::kError:
+      return mir::DiagnosticSeverity::kError;
   }
-  return info.append_newline ? mir::PrintKind::kFDisplay
-                             : mir::PrintKind::kFWrite;
+  throw InternalError("ToMirDiagnosticSeverity: unknown severity kind");
 }
 
 }  // namespace
 
-auto LowerPrintSystemSubroutineCall(
+auto LowerDiagnosticSystemSubroutineCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::Process& hir_proc, const hir::CallExpr& call,
     const support::SystemSubroutineDesc& desc,
-    const support::PrintSystemSubroutineInfo& print, diag::SourceSpan span)
+    const support::DiagnosticSystemSubroutineInfo& info, diag::SourceSpan span)
     -> diag::Result<mir::Expr> {
-  if (print.sink_kind == support::PrintSinkKind::kFile) {
-    return diag::Unsupported(
-        span, diag::DiagCode::kFileDisplayNotImplemented,
-        std::format(
-            "{} is not implemented in this build", std::string{desc.name}),
-        diag::UnsupportedCategory::kFeature);
-  }
+  (void)desc;
   auto items_or = BuildRuntimePrintItemsFromCallArgs(
       unit_state, scope_state, proc_state, proc_scope_state, hir_proc, call,
       span);
@@ -57,8 +52,9 @@ auto LowerPrintSystemSubroutineCall(
   return mir::Expr{
       .data =
           mir::RuntimeCallExpr{
-              .call = mir::RuntimePrintCall(
-                  ToMirPrintKind(print), std::nullopt, std::move(*items_or))},
+              .call = mir::RuntimeDiagnosticCall(
+                  ToMirDiagnosticSeverity(info.severity), std::nullopt,
+                  std::move(*items_or))},
       .type = unit_state.Builtins().void_type};
 }
 

--- a/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
@@ -7,6 +7,7 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
+#include "lyra/lowering/hir_to_mir/lower_diagnostic.hpp"
 #include "lyra/lowering/hir_to_mir/lower_finish.hpp"
 #include "lyra/lowering/hir_to_mir/lower_print.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
@@ -36,6 +37,12 @@ auto LowerSystemSubroutineCall(
               -> diag::Result<mir::Expr> {
             return LowerFinishSystemSubroutineCall(
                 unit_state, hir_proc, call, desc, term, span);
+          },
+          [&](const support::DiagnosticSystemSubroutineInfo& diag_info)
+              -> diag::Result<mir::Expr> {
+            return LowerDiagnosticSystemSubroutineCall(
+                unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+                call, desc, diag_info, span);
           },
       },
       desc.semantic);

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -1,0 +1,200 @@
+#include "lyra/lowering/hir_to_mir/print_items.hpp"
+
+#include <cstddef>
+#include <expected>
+#include <format>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_span.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/primary.hpp"
+#include "lyra/hir/process.hpp"
+#include "lyra/lowering/hir_to_mir/lower_expr.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/runtime_print.hpp"
+#include "lyra/support/format.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+namespace {
+
+auto SpecCharFor(support::FormatDirectiveKind k) -> std::string_view {
+  switch (k) {
+    case support::FormatDirectiveKind::kReal:
+      return "f";
+    case support::FormatDirectiveKind::kTime:
+      return "t";
+    case support::FormatDirectiveKind::kChar:
+      return "c";
+    default:
+      return "?";
+  }
+}
+
+auto ToMirFormatKind(support::FormatDirectiveKind k) -> mir::FormatKind {
+  switch (k) {
+    case support::FormatDirectiveKind::kDecimal:
+      return mir::FormatKind::kDecimal;
+    case support::FormatDirectiveKind::kHex:
+      return mir::FormatKind::kHex;
+    case support::FormatDirectiveKind::kBinary:
+      return mir::FormatKind::kBinary;
+    case support::FormatDirectiveKind::kOctal:
+      return mir::FormatKind::kOctal;
+    case support::FormatDirectiveKind::kString:
+      return mir::FormatKind::kString;
+    default:
+      throw InternalError("ToMirFormatKind: not an integral/string kind");
+  }
+}
+
+auto ToMirFormatModifiers(const support::FormatDirectiveModifiers& m)
+    -> mir::FormatModifiers {
+  return mir::FormatModifiers{
+      .width = m.width,
+      .precision = m.precision,
+      .zero_pad = m.zero_pad,
+      .left_align = m.left_align};
+}
+
+auto BuildPrintValueItem(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_proc, hir::ExprId hir_arg, mir::FormatSpec spec)
+    -> diag::Result<mir::RuntimePrintItem> {
+  auto lowered_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+      hir_proc.exprs.at(hir_arg.value));
+  if (!lowered_or) return std::unexpected(std::move(lowered_or.error()));
+  const mir::TypeId type = lowered_or->type;
+  const mir::ExprId value = proc_scope_state.AddExpr(*std::move(lowered_or));
+  return mir::RuntimePrintValue(value, type, std::move(spec));
+}
+
+auto BuildPrintItemFromDirective(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_proc,
+    const support::ParsedFormatDirective& directive,
+    std::span<const hir::ExprId> args, std::size_t& value_index,
+    diag::SourceSpan span) -> diag::Result<mir::RuntimePrintItem> {
+  switch (directive.kind) {
+    case support::FormatDirectiveKind::kLiteral:
+      return mir::RuntimePrintLiteral{.text = directive.literal};
+
+    case support::FormatDirectiveKind::kModulePath:
+      return diag::Unsupported(
+          span, diag::DiagCode::kFormatModulePathNotImplemented,
+          "format specifier %m is not implemented in this build",
+          diag::UnsupportedCategory::kFeature);
+
+    case support::FormatDirectiveKind::kReal:
+    case support::FormatDirectiveKind::kTime:
+    case support::FormatDirectiveKind::kChar:
+      return diag::Unsupported(
+          span, diag::DiagCode::kFormatSpecifierNotImplemented,
+          std::format(
+              "format specifier %{} is not implemented in this build",
+              SpecCharFor(directive.kind)),
+          diag::UnsupportedCategory::kFeature);
+
+    case support::FormatDirectiveKind::kDecimal:
+    case support::FormatDirectiveKind::kHex:
+    case support::FormatDirectiveKind::kBinary:
+    case support::FormatDirectiveKind::kOctal:
+    case support::FormatDirectiveKind::kString: {
+      if (value_index >= args.size()) {
+        return diag::Error(
+            span, diag::DiagCode::kDisplayMissingArg,
+            "format string consumes more arguments than provided");
+      }
+      const hir::ExprId hir_arg = args[value_index++];
+      return BuildPrintValueItem(
+          unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+          hir_arg,
+          mir::FormatSpec(
+              ToMirFormatKind(directive.kind),
+              ToMirFormatModifiers(directive.modifiers)));
+    }
+  }
+  throw InternalError(
+      "BuildPrintItemFromDirective: unreachable directive kind");
+}
+
+struct LiteralFormatStringRef {
+  std::string_view text;
+  diag::SourceSpan span;
+};
+
+auto TryGetHirStringLiteral(const hir::Process& proc, hir::ExprId expr_id)
+    -> std::optional<LiteralFormatStringRef> {
+  const auto& expr = proc.exprs.at(expr_id.value);
+  const auto* primary = std::get_if<hir::PrimaryExpr>(&expr.data);
+  if (primary == nullptr) return std::nullopt;
+  const auto* sl = std::get_if<hir::StringLiteral>(&primary->data);
+  if (sl == nullptr) return std::nullopt;
+  return LiteralFormatStringRef{.text = sl->value, .span = expr.span};
+}
+
+}  // namespace
+
+auto BuildRuntimePrintItemsFromCallArgs(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_proc, const hir::CallExpr& call,
+    diag::SourceSpan call_span)
+    -> diag::Result<std::vector<mir::RuntimePrintItem>> {
+  std::vector<mir::RuntimePrintItem> items;
+  const auto& args = call.arguments;
+  std::size_t cursor = 0;
+
+  if (cursor < args.size()) {
+    if (auto literal = TryGetHirStringLiteral(hir_proc, args[cursor])) {
+      auto parsed_or =
+          support::ParseLiteralFormatString(literal->text, literal->span);
+      if (!parsed_or) return std::unexpected(std::move(parsed_or.error()));
+      ++cursor;
+      auto value_index = cursor;
+      for (const auto& directive : *parsed_or) {
+        auto item_or = BuildPrintItemFromDirective(
+            unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+            directive, args, value_index, literal->span);
+        if (!item_or) return std::unexpected(std::move(item_or.error()));
+        items.push_back(std::move(*item_or));
+      }
+      cursor = value_index;
+    }
+  }
+
+  while (cursor < args.size()) {
+    if (!items.empty()) {
+      items.emplace_back(mir::RuntimePrintLiteral{.text = " "});
+    }
+    auto item_or = BuildPrintValueItem(
+        unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+        args[cursor],
+        mir::FormatSpec(mir::FormatKind::kDecimal, mir::FormatModifiers{}));
+    if (!item_or) return std::unexpected(std::move(item_or.error()));
+    items.push_back(*std::move(item_or));
+    ++cursor;
+  }
+  (void)call_span;
+  return items;
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -594,6 +594,9 @@ class MirDumper {
                   [&](const RuntimePrintCall& pc) {
                     DumpRuntimePrintCallItems(pc, scope);
                   },
+                  [&](const RuntimeDiagnosticCall& dc) {
+                    DumpRuntimeDiagnosticCallItems(dc, scope);
+                  },
                   [&](const RuntimeFinishCall& fc) {
                     Line(std::format("RuntimeFinishCall level={}", fc.level));
                   },
@@ -803,6 +806,25 @@ class MirDumper {
     Dedent();
   }
 
+  void DumpRuntimeDiagnosticCallItems(
+      const RuntimeDiagnosticCall& call, const ProceduralScope& enclosing) {
+    const std::string origin_text =
+        call.origin.has_value() ? std::format(
+                                      "{}:{}:{}", call.origin->file,
+                                      call.origin->line, call.origin->col)
+                                : std::string{"<none>"};
+    Line(
+        std::format(
+            "RuntimeDiagnosticCall severity={} origin={} items={}",
+            FormatMirDiagnosticSeverity(call.severity), origin_text,
+            call.items.size()));
+    Indent();
+    for (std::size_t i = 0; i < call.items.size(); ++i) {
+      DumpRuntimePrintItem(i, call.items[i], enclosing);
+    }
+    Dedent();
+  }
+
   void DumpRuntimePrintItem(
       std::size_t i, const RuntimePrintItem& item,
       const ProceduralScope& enclosing) {
@@ -835,6 +857,19 @@ class MirDumper {
             },
         },
         item);
+  }
+
+  static auto FormatMirDiagnosticSeverity(DiagnosticSeverity s)
+      -> std::string_view {
+    switch (s) {
+      case DiagnosticSeverity::kInfo:
+        return "kInfo";
+      case DiagnosticSeverity::kWarning:
+        return "kWarning";
+      case DiagnosticSeverity::kError:
+        return "kError";
+    }
+    throw InternalError("FormatMirDiagnosticSeverity: unknown severity");
   }
 
   static auto FormatMirPrintKind(PrintKind k) -> std::string_view {

--- a/src/lyra/runtime/diagnostic.cpp
+++ b/src/lyra/runtime/diagnostic.cpp
@@ -1,0 +1,111 @@
+#include "lyra/runtime/diagnostic.hpp"
+
+#include <cstdint>
+#include <format>
+#include <functional>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+
+#include "lyra/base/overloaded.hpp"
+#include "lyra/runtime/runtime_services.hpp"
+#include "lyra/value/format.hpp"
+
+namespace lyra::runtime {
+
+namespace {
+
+auto SeverityText(Severity s) -> std::string_view {
+  switch (s) {
+    case Severity::kInfo:
+      return "info";
+    case Severity::kWarning:
+      return "warning";
+    case Severity::kError:
+      return "error";
+  }
+  return "info";
+}
+
+auto FormatOrigin(const SourceLocation& loc) -> std::string {
+  return std::format("{}:{}:{}", loc.file, loc.line, loc.col);
+}
+
+}  // namespace
+
+auto DiagnosticDispatcher::CountKeyHash::operator()(
+    const CountKey& k) const noexcept -> std::size_t {
+  const std::size_t origin_hash = std::hash<std::string>{}(k.origin);
+  const std::size_t severity_hash =
+      std::hash<std::uint8_t>{}(static_cast<std::uint8_t>(k.severity));
+  return origin_hash ^ (severity_hash << 1U);
+}
+
+DiagnosticDispatcher::DiagnosticDispatcher(
+    DiagnosticSink sink, std::uint32_t rate_limit)
+    : sink_(std::move(sink)), rate_limit_(rate_limit) {
+}
+
+void DiagnosticDispatcher::Emit(DiagnosticRecord record) {
+  const std::string origin_text =
+      record.origin.has_value() ? FormatOrigin(*record.origin) : std::string{};
+
+  if (rate_limit_ > 0) {
+    const CountKey key{.origin = origin_text, .severity = record.severity};
+    auto& count = emit_counts_[key];
+    if (count >= rate_limit_) {
+      if (count == rate_limit_) {
+        ++count;
+        const std::string note = std::format(
+            "lyra: {}: further messages from this site suppressed after {} "
+            "occurrences\n",
+            SeverityText(record.severity), rate_limit_);
+        sink_(note);
+      } else {
+        ++count;
+      }
+      return;
+    }
+    ++count;
+  }
+
+  std::string line;
+  if (!origin_text.empty()) {
+    line += origin_text;
+    line += ": ";
+  }
+  line += SeverityText(record.severity);
+  line += ": ";
+  line += record.body;
+  line += "\n";
+  sink_(line);
+}
+
+void LyraDiagnostic(
+    RuntimeServices& services, Severity severity,
+    std::optional<SourceLocation> origin,
+    std::span<const value::PrintItem> items) {
+  std::string body;
+  for (const value::PrintItem& item : items) {
+    std::visit(
+        Overloaded{
+            [&](const value::PrintLiteralItem& lit) {
+              body.append(std::string_view{lit.data, lit.size});
+            },
+            [&](const value::PrintValueItem& v) {
+              body.append(value::FormatValue(v.spec, v.value));
+            },
+        },
+        item);
+  }
+  services.Diagnostic().Emit(
+      DiagnosticRecord{
+          .severity = severity,
+          .origin = std::move(origin),
+          .body = std::move(body)});
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -15,26 +15,28 @@
 #include "lyra/runtime/bind_context.hpp"
 #include "lyra/runtime/event.hpp"
 #include "lyra/runtime/module.hpp"
-#include "lyra/runtime/output_sink.hpp"
 #include "lyra/runtime/process_kind.hpp"
 #include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_scope.hpp"
 #include "lyra/runtime/runtime_scope_kind.hpp"
 #include "lyra/runtime/runtime_traversal.hpp"
+#include "lyra/runtime/stream_dispatcher.hpp"
 #include "lyra/runtime/wait_request.hpp"
 
 namespace lyra::runtime {
 
 auto DefaultEngineOptions() -> EngineOptions {
   return EngineOptions{
-      .output_sink = [](std::string_view text) { std::cout << text; }};
+      .stream_sink = [](std::string_view text) { std::cout << text; },
+      .diagnostic_sink = [](std::string_view text) { std::cerr << text; }};
 }
 
 Engine::Engine() : Engine(DefaultEngineOptions()) {
 }
 
 Engine::Engine(EngineOptions options)
-    : output_(std::move(options.output_sink)) {
+    : stream_(std::move(options.stream_sink)),
+      diagnostic_(std::move(options.diagnostic_sink)) {
 }
 
 void Engine::BindRoot(std::string root_name, Module& top) {
@@ -66,7 +68,7 @@ auto Engine::Run() -> int {
   ExecuteFinalProcesses();
 
   phase_ = SchedulerPhase::kIdle;
-  output_.Drain();
+  stream_.Drain();
   return 0;
 }
 

--- a/src/lyra/runtime/io.cpp
+++ b/src/lyra/runtime/io.cpp
@@ -5,8 +5,8 @@
 #include <variant>
 
 #include "lyra/base/overloaded.hpp"
-#include "lyra/runtime/output_sink.hpp"
 #include "lyra/runtime/runtime_services.hpp"
+#include "lyra/runtime/stream_dispatcher.hpp"
 #include "lyra/value/format.hpp"
 
 namespace lyra::runtime {
@@ -14,15 +14,15 @@ namespace lyra::runtime {
 void LyraPrint(
     RuntimeServices& services, value::PrintKind kind,
     std::span<const value::PrintItem> items) {
-  auto& output = services.Output();
+  auto& stream = services.Stream();
   for (const value::PrintItem& item : items) {
     std::visit(
         Overloaded{
             [&](const value::PrintLiteralItem& lit) {
-              output.Append(std::string_view{lit.data, lit.size});
+              stream.Append(std::string_view{lit.data, lit.size});
             },
             [&](const value::PrintValueItem& v) {
-              output.Append(value::FormatValue(v.spec, v.value));
+              stream.Append(value::FormatValue(v.spec, v.value));
             },
         },
         item);
@@ -30,7 +30,7 @@ void LyraPrint(
 
   const bool append_newline =
       kind == value::PrintKind::kDisplay || kind == value::PrintKind::kFDisplay;
-  output.FinishRecord(append_newline);
+  stream.FinishRecord(append_newline);
 }
 
 }  // namespace lyra::runtime

--- a/src/lyra/runtime/stream_dispatcher.cpp
+++ b/src/lyra/runtime/stream_dispatcher.cpp
@@ -1,18 +1,18 @@
-#include "lyra/runtime/output_sink.hpp"
+#include "lyra/runtime/stream_dispatcher.hpp"
 
 #include <string_view>
 #include <utility>
 
 namespace lyra::runtime {
 
-OutputDispatcher::OutputDispatcher(OutputSink sink) : sink_(std::move(sink)) {
+StreamDispatcher::StreamDispatcher(StreamSink sink) : sink_(std::move(sink)) {
 }
 
-void OutputDispatcher::Append(std::string_view text) {
+void StreamDispatcher::Append(std::string_view text) {
   pending_.append(text);
 }
 
-void OutputDispatcher::FinishRecord(bool append_newline) {
+void StreamDispatcher::FinishRecord(bool append_newline) {
   // FinishRecord(false) is a no-op: $write keeps content buffered.
   if (append_newline) {
     pending_.push_back('\n');
@@ -23,7 +23,7 @@ void OutputDispatcher::FinishRecord(bool append_newline) {
   }
 }
 
-void OutputDispatcher::Drain() {
+void StreamDispatcher::Drain() {
   if (!pending_.empty()) {
     if (sink_) {
       sink_(pending_);

--- a/tests/cases/cpp/diagnostic_rate_limit/case.yaml
+++ b/tests/cases/cpp/diagnostic_rate_limit/case.yaml
@@ -1,0 +1,22 @@
+id: cpp.diagnostic_rate_limit
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    exact: |
+      warning: repeating
+      warning: repeating
+      warning: repeating
+      warning: repeating
+      warning: repeating
+      warning: repeating
+      warning: repeating
+      warning: repeating
+      warning: repeating
+      warning: repeating
+      lyra: warning: further messages from this site suppressed after 10 occurrences

--- a/tests/cases/cpp/diagnostic_rate_limit/main.sv
+++ b/tests/cases/cpp/diagnostic_rate_limit/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  initial begin
+    for (int i = 0; i < 15; i = i + 1) begin
+      $warning("repeating");
+    end
+  end
+endmodule

--- a/tests/cases/cpp/diagnostic_separate_from_stdout/case.yaml
+++ b/tests/cases/cpp/diagnostic_separate_from_stdout/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.diagnostic_separate_from_stdout
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      on stdout
+      still on stdout
+  stderr:
+    exact: "warning: on stderr\n"

--- a/tests/cases/cpp/diagnostic_separate_from_stdout/main.sv
+++ b/tests/cases/cpp/diagnostic_separate_from_stdout/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  initial begin
+    $display("on stdout");
+    $warning("on stderr");
+    $display("still on stdout");
+  end
+endmodule

--- a/tests/cases/cpp/error_basic/case.yaml
+++ b/tests/cases/cpp/error_basic/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.error_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    exact: "error: something bad\n"

--- a/tests/cases/cpp/error_basic/main.sv
+++ b/tests/cases/cpp/error_basic/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  initial begin
+    $error("something bad");
+  end
+endmodule

--- a/tests/cases/cpp/info_basic/case.yaml
+++ b/tests/cases/cpp/info_basic/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.info_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    exact: "info: hello info\n"

--- a/tests/cases/cpp/info_basic/main.sv
+++ b/tests/cases/cpp/info_basic/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  initial begin
+    $info("hello info");
+  end
+endmodule

--- a/tests/cases/cpp/warning_with_format/case.yaml
+++ b/tests/cases/cpp/warning_with_format/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.warning_with_format
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    exact: "warning: value is 42\n"

--- a/tests/cases/cpp/warning_with_format/main.sv
+++ b/tests/cases/cpp/warning_with_format/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  initial begin
+    $warning("value is %0d", 42);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds a runtime diagnostic channel parallel to the existing stream channel, then wires `$info` / `$warning` / `$error` through it. The two channels reflect the LRM distinction between stream output tasks (LRM 21.2, user owns every byte, no severity) and severity tasks (LRM 20.10, user supplies body, simulator owns the envelope with severity / origin / filtering). Stream and diagnostic both live on `Engine` and are accessed via `RuntimeServices::Stream()` / `RuntimeServices::Diagnostic()`.

## Design

Two channels, not one, not three: `$display` / `$write` keep their byte-stream contract via `StreamDispatcher` (renamed from `OutputDispatcher` for symmetric naming); `$info` / `$warning` / `$error` go through the new `DiagnosticDispatcher`, which renders `<severity>: <body>` to stderr by default and rate-limits per (origin, severity) site at ten emits before suppressing. `$fatal` and source-location propagation are deferred -- `$fatal` needs multi-statement lowering and source locations need `SourceManager` plumbed through `UnitLoweringState`, both independently mergeable later.

The format-item builder is extracted into `print_items.hpp` so both the print and diagnostic lowering paths share it; the MIR `RuntimeCallExpr` variant gains `RuntimeDiagnosticCall` alongside `RuntimePrintCall` and `RuntimeFinishCall`; the C++ backend gets a third render arm.

## Testing

Five new `cpp_run` cases:
- `info_basic`, `warning_with_format`, `error_basic` -- each severity round-trips to stderr.
- `diagnostic_separate_from_stdout` -- proves the two channels route to independent sinks within one run.
- `diagnostic_rate_limit` -- 15 identical `$warning` calls produce 10 messages plus the suppression footer.