### PR TITLE
Collapse cpp emit packed-array path

### DIFF
--- a/include/lyra/backend/cpp/render_expr.hpp
+++ b/include/lyra/backend/cpp/render_expr.hpp
@@ -14,16 +14,10 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
 auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
     -> diag::Result<std::string>;
 
-auto RenderExprAsNative(const RenderContext& ctx, const mir::Expr& expr)
-    -> diag::Result<std::string>;
-
 // Renders `expr` and, when its MIR type is a packed array, appends
 // `.IsTruthy()`. Used by every statement that consumes an expression as a C++
 // `bool` (`if`, `while`, `do`, `for` condition, etc.).
 auto RenderConditionAsBool(const RenderContext& ctx, const mir::Expr& expr)
-    -> diag::Result<std::string>;
-
-auto RenderPackedExprAsView(const RenderContext& ctx, const mir::Expr& expr)
     -> diag::Result<std::string>;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/value/format.hpp
+++ b/include/lyra/value/format.hpp
@@ -10,6 +10,8 @@
 
 namespace lyra::value {
 
+class PackedArray;
+
 enum class PrintKind : std::uint8_t {
   kDisplay,
   kWrite,
@@ -106,6 +108,12 @@ struct RuntimeValueView {
       -> RuntimeValueView {
     return FromLogicView(view.AsConst(), is_signed);
   }
+
+  // The packed-array overload supersedes the view overloads at every cpp-emit
+  // call site (signedness is read from the PackedArray itself). The view
+  // overloads remain for callers that already hold a view.
+  [[nodiscard]] static auto FromPackedArray(const PackedArray& pa)
+      -> RuntimeValueView;
 };
 
 [[nodiscard]] auto FormatValue(

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <initializer_list>
 #include <span>
 #include <variant>
 
@@ -32,12 +33,25 @@ class PackedArray {
       std::int64_t value, std::uint64_t bit_width, bool is_signed,
       bool is_four_state) -> PackedArray;
 
+  // Construct a PackedArray of arbitrary width from raw word planes. Used
+  // by cpp emit for any literal that does not fit a single int64 carrier:
+  // widths > 64 bits, or 4-state literals carrying X/Z bits. `value_words`
+  // must have ceil(bit_width / 64) entries; bits above `bit_width` in the
+  // top word are masked. For 2-state shapes `unknown_words` must be empty;
+  // for 4-state shapes it must either be empty (no X/Z) or match
+  // `value_words` in size.
+  [[nodiscard]] static auto FromWords(
+      std::initializer_list<std::uint64_t> value_words,
+      std::initializer_list<std::uint64_t> unknown_words,
+      std::uint64_t bit_width, bool is_signed, bool is_four_state)
+      -> PackedArray;
+
   // Width-aware conversion. Constructs a fresh PackedArray of the
   // destination shape and copies bits from `src`, sign- or zero-extending
   // per `src`'s signedness when widening, truncating when narrowing.
-  // Cross-state conversions clear X/Z to 0 when converting 4-state to
-  // 2-state. TODO(hankhsu): wide (>64-bit) and 4-state conversion paths
-  // throw `InternalError` pending the wide arithmetic helpers.
+  // 2-state -> 4-state leaves the unknown plane zero; 4-state -> 2-state
+  // collapses any X/Z bits to 0. Both wide (>64-bit) and 4-state paths are
+  // supported.
   [[nodiscard]] static auto ConvertFrom(
       const PackedArray& src, std::uint64_t dst_bit_width, bool dst_is_signed,
       bool dst_is_four_state) -> PackedArray;
@@ -63,6 +77,22 @@ class PackedArray {
   // Width-aware copy. The destination's attributes drive sign-extension,
   // zero-extension, or truncation as appropriate.
   auto AssignFrom(const PackedArray& other) -> void;
+
+  // Variable assignment in SystemVerilog preserves the destination's declared
+  // shape; the producer is expected to insert any width/state conversion (the
+  // cpp backend lowers slang's ConversionExpr into PackedArray::ConvertFrom).
+  // Both copy- and move-assignment route through AssignFrom, which throws
+  // InternalError on shape mismatch. This makes "(target = value)" the single
+  // emit shape for variable assignment and surfaces any missing conversion as
+  // a backend bug rather than silently relayout-ing the destination.
+  // Construction (copy/move ctor) does the opposite: a freshly-constructed
+  // PackedArray adopts the source's shape, since there is no declared shape
+  // to preserve.
+  PackedArray(const PackedArray&) = default;
+  PackedArray(PackedArray&&) noexcept = default;
+  auto operator=(const PackedArray& other) -> PackedArray&;
+  auto operator=(PackedArray&& other) noexcept(false) -> PackedArray&;
+  ~PackedArray() = default;
 
   // Extract the value as a 64-bit signed integer. Sign-extends from
   // bit_width when is_signed_ is true. X/Z bits map to 0. bit_width must
@@ -123,6 +153,17 @@ class PackedArray {
   [[nodiscard]] auto ReductionXnor() const -> PackedArray;
 
  private:
+  // Single source of truth for "construct a PackedArray with a known value".
+  // FromInt, FromWords, and any internal op that needs to materialize a
+  // result from word planes must delegate here. The helper guarantees both
+  // planes are fully written (value from `value_words`, unknown from
+  // `unknown_words` or zero when empty); no caller can leak the all-X
+  // residue left by LogicValue's default ctor.
+  [[nodiscard]] static auto MakeFromWordPlanes(
+      std::uint64_t bit_width, bool is_signed, bool is_four_state,
+      std::span<const std::uint64_t> value_words,
+      std::span<const std::uint64_t> unknown_words) -> PackedArray;
+
   std::uint64_t bit_width_;
   bool is_signed_;
   bool is_four_state_;

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -3,7 +3,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <format>
-#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
@@ -150,34 +149,6 @@ auto RenderStructuralVarName(
   return ctx.StructuralScope().GetStructuralVar(ref.var).name;
 }
 
-auto IsPackedExplicit(const mir::CompilationUnit& unit, mir::TypeId type_id)
-    -> bool {
-  const auto& t = unit.GetType(type_id);
-  return t.IsPackedArray() &&
-         t.AsPackedArray().form == mir::PackedArrayForm::kExplicit;
-}
-
-auto MirTypeOfLvalue(const RenderContext& ctx, const mir::Lvalue& lv)
-    -> diag::Result<mir::TypeId> {
-  return std::visit(
-      Overloaded{
-          [&](const mir::StructuralVarRef& m) -> diag::Result<mir::TypeId> {
-            if (m.hops.value != 0) {
-              return diag::Unsupported(
-                  diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-                  "cross-scope structural var access is not yet implemented "
-                  "in cpp emit",
-                  diag::UnsupportedCategory::kFeature);
-            }
-            return ctx.StructuralScope().GetStructuralVar(m.var).type;
-          },
-          [&](const mir::ProceduralVarRef& l) -> diag::Result<mir::TypeId> {
-            return ctx.ProceduralScopeAtHops(l.hops).vars.at(l.var.value).type;
-          },
-      },
-      lv);
-}
-
 auto IntegralConstantToInt64(const mir::IntegralConstant& c) -> std::int64_t {
   if (c.width == 0U) {
     throw InternalError("IntegralConstantToInt64: zero width");
@@ -203,37 +174,8 @@ auto IntegralConstantToInt64(const mir::IntegralConstant& c) -> std::int64_t {
   return static_cast<std::int64_t>(masked);
 }
 
-auto RenderPackedArrayIntegerLiteral(
-    const mir::PackedArrayType& pa, const mir::IntegralConstant& c)
+auto RenderWordList(std::span<const std::uint64_t> words, std::size_t n)
     -> std::string {
-  if (c.width > 64U) {
-    throw InternalError(
-        "RenderPackedArrayIntegerLiteral: width > 64 not yet implemented");
-  }
-  const auto value = IntegralConstantToInt64(c);
-  // Default-int shape (`int`, `bit signed [31:0]`, etc.): emit the concise
-  // factory that mirrors SV's natural int literal promotion.
-  if (pa.BitWidth() == 32U && pa.signedness == mir::Signedness::kSigned &&
-      pa.atom == mir::BitAtom::kBit) {
-    return std::format("lyra::value::PackedArray::Int({})", value);
-  }
-  const char* signed_lit =
-      pa.signedness == mir::Signedness::kSigned ? "true" : "false";
-  const char* four_state_lit = pa.atom != mir::BitAtom::kBit ? "true" : "false";
-  return std::format(
-      "lyra::value::PackedArray::FromInt({}LL, {}, {}, {})", value,
-      pa.BitWidth(), signed_lit, four_state_lit);
-}
-
-auto PackedRuntimeUnsupported() -> diag::Result<std::string> {
-  return diag::Unsupported(
-      diag::DiagCode::kCppEmitPackedRuntimeNotSupported,
-      "this packed expression form is not yet supported in cpp emit",
-      diag::UnsupportedCategory::kFeature);
-}
-
-auto RenderWordArrayInitializer(
-    std::span<const std::uint64_t> words, std::size_t n) -> std::string {
   std::string out = "{";
   for (std::size_t i = 0; i < n; ++i) {
     if (i != 0U) {
@@ -246,48 +188,43 @@ auto RenderWordArrayInitializer(
   return out;
 }
 
-auto RenderPackedLiteralView(
+auto RenderPackedArrayIntegerLiteral(
     const mir::PackedArrayType& pa, const mir::IntegralConstant& c)
     -> std::string {
-  const std::uint64_t width = pa.BitWidth();
-  const std::size_t n = (width + 63U) / 64U;
-  const std::string vw = RenderWordArrayInitializer(c.value_words, n);
-  if (pa.atom == mir::BitAtom::kBit) {
+  const bool is_four_state = pa.atom != mir::BitAtom::kBit;
+  const char* signed_lit =
+      pa.signedness == mir::Signedness::kSigned ? "true" : "false";
+  const char* four_state_lit = is_four_state ? "true" : "false";
+
+  // Narrow + no X/Z fits a single int64 carrier and reads better as
+  // PackedArray::Int / FromInt. Wide literals or X/Z-bearing literals must
+  // round-trip through explicit value/unknown word planes via FromWords.
+  const bool literal_has_xz = !c.state_words.empty() && c.state_words[0] != 0U;
+  const bool needs_word_planes = c.width > 64U || literal_has_xz;
+
+  if (!needs_word_planes) {
+    const auto value = IntegralConstantToInt64(c);
+    if (pa.BitWidth() == 32U && pa.signedness == mir::Signedness::kSigned &&
+        pa.atom == mir::BitAtom::kBit) {
+      return std::format("lyra::value::PackedArray::Int({})", value);
+    }
     return std::format(
-        "([&]() -> lyra::value::ConstBitView {{ "
-        "static constexpr std::array<std::uint64_t, {0}> kV = {1}; "
-        "return lyra::value::ConstBitView{{kV, 0, {2}}}; }}())",
-        n, vw, width);
+        "lyra::value::PackedArray::FromInt({}LL, {}, {}, {})", value,
+        pa.BitWidth(), signed_lit, four_state_lit);
   }
-  std::string uw;
-  if (c.state_words.empty()) {
-    uw = RenderWordArrayInitializer({}, n);
-  } else {
-    uw = RenderWordArrayInitializer(c.state_words, n);
+
+  if (literal_has_xz && !is_four_state) {
+    throw InternalError(
+        "RenderPackedArrayIntegerLiteral: 2-state PackedArray cannot hold "
+        "X/Z literal");
   }
+  const std::size_t n = (pa.BitWidth() + 63U) / 64U;
+  const std::string value_init = RenderWordList(c.value_words, n);
+  const std::string unknown_init =
+      is_four_state ? RenderWordList(c.state_words, n) : std::string{"{}"};
   return std::format(
-      "([&]() -> lyra::value::ConstLogicView {{ "
-      "static constexpr std::array<std::uint64_t, {0}> kV = {1}; "
-      "static constexpr std::array<std::uint64_t, {0}> kU = {2}; "
-      "return lyra::value::ConstLogicView{{kV, kU, 0, {3}}}; }}())",
-      n, vw, uw, width);
-}
-
-auto RenderPackedAssign(const RenderContext& ctx, const mir::AssignExpr& a)
-    -> diag::Result<std::string>;
-
-auto RenderExprAsPackedTopLevel(const RenderContext& ctx, const mir::Expr& expr)
-    -> diag::Result<std::string> {
-  return std::visit(
-      Overloaded{
-          [&](const mir::AssignExpr& a) -> diag::Result<std::string> {
-            return RenderPackedAssign(ctx, a);
-          },
-          [&](const auto&) -> diag::Result<std::string> {
-            return PackedRuntimeUnsupported();
-          },
-      },
-      expr.data);
+      "lyra::value::PackedArray::FromWords({}, {}, {}, {}, {})", value_init,
+      unknown_init, pa.BitWidth(), signed_lit, four_state_lit);
 }
 
 }  // namespace
@@ -306,292 +243,7 @@ auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
       target);
 }
 
-auto RenderPackedExprAsView(const RenderContext& ctx, const mir::Expr& expr)
-    -> diag::Result<std::string> {
-  const auto& ty = ctx.Unit().GetType(expr.type);
-  if (!ty.IsPackedArray()) {
-    throw InternalError("RenderPackedExprAsView: type is not a packed array");
-  }
-  const auto& pa = ty.AsPackedArray();
-  const std::string view_call =
-      pa.atom == mir::BitAtom::kBit ? ".AsBitView()" : ".AsLogicView()";
-  return std::visit(
-      Overloaded{
-          [&](const mir::StructuralVarRef& m) -> diag::Result<std::string> {
-            auto name_or = RenderStructuralVarName(ctx, m);
-            if (!name_or) return std::unexpected(std::move(name_or.error()));
-            return *name_or + view_call;
-          },
-          [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
-            return LookupProceduralVarName(ctx, l) + view_call;
-          },
-          [&](const mir::IntegerLiteral& lit) -> diag::Result<std::string> {
-            return RenderPackedLiteralView(pa, lit.value);
-          },
-          [&](const auto&) -> diag::Result<std::string> {
-            return PackedRuntimeUnsupported();
-          },
-      },
-      expr.data);
-}
-
-namespace {
-
-auto SignednessLiteral(mir::Signedness s) -> std::string {
-  return s == mir::Signedness::kSigned ? "lyra::value::Signedness::kSigned"
-                                       : "lyra::value::Signedness::kUnsigned";
-}
-
-auto BitwiseRuntimeFunctionName(mir::UnaryOp op)
-    -> std::optional<std::string_view> {
-  if (op == mir::UnaryOp::kBitwiseNot) {
-    return std::string_view{"lyra::value::BitwiseNot"};
-  }
-  return std::nullopt;
-}
-
-auto BitwiseRuntimeFunctionName(mir::BinaryOp op)
-    -> std::optional<std::string_view> {
-  switch (op) {
-    case mir::BinaryOp::kBitwiseAnd:
-      return std::string_view{"lyra::value::BitwiseAnd"};
-    case mir::BinaryOp::kBitwiseOr:
-      return std::string_view{"lyra::value::BitwiseOr"};
-    case mir::BinaryOp::kBitwiseXor:
-      return std::string_view{"lyra::value::BitwiseXor"};
-    case mir::BinaryOp::kBitwiseXnor:
-      return std::string_view{"lyra::value::BitwiseXnor"};
-    default:
-      return std::nullopt;
-  }
-}
-
-auto ReductionRuntimeFunctionName(mir::UnaryOp op)
-    -> std::optional<std::string_view> {
-  switch (op) {
-    case mir::UnaryOp::kReductionAnd:
-      return std::string_view{"lyra::value::ReductionAnd"};
-    case mir::UnaryOp::kReductionOr:
-      return std::string_view{"lyra::value::ReductionOr"};
-    case mir::UnaryOp::kReductionXor:
-      return std::string_view{"lyra::value::ReductionXor"};
-    case mir::UnaryOp::kReductionNand:
-      return std::string_view{"lyra::value::ReductionNand"};
-    case mir::UnaryOp::kReductionNor:
-      return std::string_view{"lyra::value::ReductionNor"};
-    case mir::UnaryOp::kReductionXnor:
-      return std::string_view{"lyra::value::ReductionXnor"};
-    default:
-      return std::nullopt;
-  }
-}
-
-auto IsTwoStatePacked(const mir::PackedArrayType& a) -> bool {
-  return a.atom == mir::BitAtom::kBit;
-}
-
-auto IsSamePackedBitwiseShape(
-    const mir::PackedArrayType& a, const mir::PackedArrayType& b) -> bool {
-  if (a.form != mir::PackedArrayForm::kExplicit ||
-      b.form != mir::PackedArrayForm::kExplicit) {
-    return false;
-  }
-  if (a.BitWidth() != b.BitWidth()) {
-    return false;
-  }
-  return IsTwoStatePacked(a) == IsTwoStatePacked(b);
-}
-
-auto RenderPackedBitwiseOperand(
-    const RenderContext& ctx, const mir::Expr& operand_expr,
-    const mir::PackedArrayType& lhs_pa) -> diag::Result<std::string> {
-  const auto& op_ty = ctx.Unit().GetType(operand_expr.type);
-  if (!op_ty.IsPackedArray()) {
-    throw InternalError(
-        "RenderPackedBitwiseAssign: operand is not a packed array");
-  }
-  const auto& op_pa = op_ty.AsPackedArray();
-  if (!IsSamePackedBitwiseShape(op_pa, lhs_pa)) {
-    throw InternalError(
-        "RenderPackedBitwiseAssign: operand shape does not match LHS");
-  }
-  return RenderPackedExprAsView(ctx, operand_expr);
-}
-
-auto RenderPackedBitwiseAssign(
-    const RenderContext& ctx, const mir::AssignExpr& a,
-    const mir::PackedArrayType& lhs_pa, std::string_view lhs_view)
-    -> diag::Result<std::optional<std::string>> {
-  const mir::Expr& value_expr = ctx.Expr(a.value);
-
-  if (std::holds_alternative<mir::ConversionExpr>(value_expr.data)) {
-    return std::optional<std::string>{};
-  }
-
-  std::optional<std::string_view> fn_name;
-  bool is_unary = false;
-  if (const auto* u = std::get_if<mir::UnaryExpr>(&value_expr.data)) {
-    fn_name = BitwiseRuntimeFunctionName(u->op);
-    is_unary = true;
-  } else if (const auto* b = std::get_if<mir::BinaryExpr>(&value_expr.data)) {
-    fn_name = BitwiseRuntimeFunctionName(b->op);
-  }
-  if (!fn_name) {
-    return std::optional<std::string>{};
-  }
-
-  const auto& result_ty = ctx.Unit().GetType(value_expr.type);
-  if (!result_ty.IsPackedArray() ||
-      !IsSamePackedBitwiseShape(result_ty.AsPackedArray(), lhs_pa)) {
-    throw InternalError(
-        "RenderPackedBitwiseAssign: result type does not match LHS");
-  }
-
-  if (is_unary) {
-    const auto& u = std::get<mir::UnaryExpr>(value_expr.data);
-    auto operand_or =
-        RenderPackedBitwiseOperand(ctx, ctx.Expr(u.operand), lhs_pa);
-    if (!operand_or) {
-      return std::unexpected(std::move(operand_or.error()));
-    }
-    return std::optional<std::string>{
-        std::format("{}({}, {})", *fn_name, *operand_or, lhs_view)};
-  }
-
-  const auto& b = std::get<mir::BinaryExpr>(value_expr.data);
-  auto lhs_op_or = RenderPackedBitwiseOperand(ctx, ctx.Expr(b.lhs), lhs_pa);
-  if (!lhs_op_or) {
-    return std::unexpected(std::move(lhs_op_or.error()));
-  }
-  auto rhs_op_or = RenderPackedBitwiseOperand(ctx, ctx.Expr(b.rhs), lhs_pa);
-  if (!rhs_op_or) {
-    return std::unexpected(std::move(rhs_op_or.error()));
-  }
-  return std::optional<std::string>{std::format(
-      "{}({}, {}, {})", *fn_name, *lhs_op_or, *rhs_op_or, lhs_view)};
-}
-
-auto RenderPackedReductionAssign(
-    const RenderContext& ctx, const mir::AssignExpr& a,
-    const mir::PackedArrayType& lhs_pa, std::string_view lhs_view)
-    -> diag::Result<std::optional<std::string>> {
-  const mir::Expr& value_expr = ctx.Expr(a.value);
-
-  if (std::holds_alternative<mir::ConversionExpr>(value_expr.data)) {
-    return std::optional<std::string>{};
-  }
-
-  const auto* u = std::get_if<mir::UnaryExpr>(&value_expr.data);
-  if (u == nullptr) {
-    return std::optional<std::string>{};
-  }
-  const auto fn_name = ReductionRuntimeFunctionName(u->op);
-  if (!fn_name) {
-    return std::optional<std::string>{};
-  }
-
-  if (lhs_pa.form != mir::PackedArrayForm::kExplicit ||
-      lhs_pa.BitWidth() != 1U) {
-    throw InternalError(
-        "RenderPackedReductionAssign: LHS must be 1-bit kExplicit");
-  }
-  const auto& result_ty = ctx.Unit().GetType(value_expr.type);
-  if (!result_ty.IsPackedArray()) {
-    throw InternalError(
-        "RenderPackedReductionAssign: result is not a packed array");
-  }
-  const auto& result_pa = result_ty.AsPackedArray();
-  if (result_pa.form != mir::PackedArrayForm::kExplicit ||
-      result_pa.BitWidth() != 1U ||
-      IsTwoStatePacked(result_pa) != IsTwoStatePacked(lhs_pa)) {
-    throw InternalError(
-        "RenderPackedReductionAssign: result type does not match LHS");
-  }
-
-  const mir::Expr& operand_expr = ctx.Expr(u->operand);
-  const auto& operand_ty = ctx.Unit().GetType(operand_expr.type);
-  if (!operand_ty.IsPackedArray()) {
-    return std::optional<std::string>{};
-  }
-  const auto& operand_pa = operand_ty.AsPackedArray();
-  if (operand_pa.form != mir::PackedArrayForm::kExplicit) {
-    return std::optional<std::string>{};
-  }
-  if (IsTwoStatePacked(operand_pa) != IsTwoStatePacked(result_pa)) {
-    throw InternalError(
-        "RenderPackedReductionAssign: operand state-kind does not match "
-        "result");
-  }
-
-  auto operand_or = RenderPackedExprAsView(ctx, operand_expr);
-  if (!operand_or) {
-    return std::unexpected(std::move(operand_or.error()));
-  }
-  return std::optional<std::string>{
-      std::format("{}({}, {})", *fn_name, *operand_or, lhs_view)};
-}
-
-auto RenderPackedAssign(const RenderContext& ctx, const mir::AssignExpr& a)
-    -> diag::Result<std::string> {
-  auto lhs_t_or = MirTypeOfLvalue(ctx, a.target);
-  if (!lhs_t_or) return std::unexpected(std::move(lhs_t_or.error()));
-  const auto& lhs = ctx.Unit().GetType(*lhs_t_or).AsPackedArray();
-  auto lhs_name_or = RenderLvalue(ctx, a.target);
-  if (!lhs_name_or) return std::unexpected(std::move(lhs_name_or.error()));
-  const std::string lhs_view =
-      *lhs_name_or +
-      (lhs.atom == mir::BitAtom::kBit ? ".AsBitView()" : ".AsLogicView()");
-
-  auto bitwise_or = RenderPackedBitwiseAssign(ctx, a, lhs, lhs_view);
-  if (!bitwise_or) {
-    return std::unexpected(std::move(bitwise_or.error()));
-  }
-  if (bitwise_or->has_value()) {
-    return std::move(**bitwise_or);
-  }
-
-  auto reduction_or = RenderPackedReductionAssign(ctx, a, lhs, lhs_view);
-  if (!reduction_or) {
-    return std::unexpected(std::move(reduction_or.error()));
-  }
-  if (reduction_or->has_value()) {
-    return std::move(**reduction_or);
-  }
-
-  const mir::Expr* src_expr = &ctx.Expr(a.value);
-  while (const auto* cv = std::get_if<mir::ConversionExpr>(&src_expr->data)) {
-    const mir::Expr& op_expr = ctx.Expr(cv->operand);
-    const auto& op_ty = ctx.Unit().GetType(op_expr.type);
-    if (!op_ty.IsPackedArray() ||
-        op_ty.AsPackedArray().form != mir::PackedArrayForm::kExplicit) {
-      return PackedRuntimeUnsupported();
-    }
-    src_expr = &op_expr;
-  }
-
-  const auto& src_ty = ctx.Unit().GetType(src_expr->type);
-  if (!src_ty.IsPackedArray() ||
-      src_ty.AsPackedArray().form != mir::PackedArrayForm::kExplicit) {
-    return PackedRuntimeUnsupported();
-  }
-  const auto& src_pa = src_ty.AsPackedArray();
-
-  auto src_view_or = RenderPackedExprAsView(ctx, *src_expr);
-  if (!src_view_or) {
-    return std::unexpected(std::move(src_view_or.error()));
-  }
-
-  const std::string convert_fn = (lhs.atom == mir::BitAtom::kBit)
-                                     ? "lyra::value::ConvertToBit"
-                                     : "lyra::value::ConvertToLogic";
-  return std::format(
-      "{}({}, {}, {})", convert_fn, *src_view_or, lhs_view,
-      SignednessLiteral(src_pa.signedness));
-}
-
-}  // namespace
-
-auto RenderExprAsNative(const RenderContext& ctx, const mir::Expr& expr)
+auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
     -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
@@ -599,7 +251,7 @@ auto RenderExprAsNative(const RenderContext& ctx, const mir::Expr& expr)
             const auto& ty = ctx.Unit().GetType(expr.type);
             if (!ty.IsPackedArray()) {
               throw InternalError(
-                  "RenderExprAsNative: IntegerLiteral not typed as "
+                  "RenderExpr: IntegerLiteral not typed as "
                   "PackedArrayType");
             }
             return RenderPackedArrayIntegerLiteral(
@@ -631,48 +283,40 @@ auto RenderExprAsNative(const RenderContext& ctx, const mir::Expr& expr)
             return LookupProceduralVarName(ctx, l);
           },
           [&](const mir::UnaryExpr& u) -> diag::Result<std::string> {
-            auto operand_or = RenderExprAsNative(ctx, ctx.Expr(u.operand));
+            auto operand_or = RenderExpr(ctx, ctx.Expr(u.operand));
             if (!operand_or) {
               return std::unexpected(std::move(operand_or.error()));
             }
             return RenderUnaryOp(u.op, *operand_or);
           },
           [&](const mir::BinaryExpr& b) -> diag::Result<std::string> {
-            auto lhs_or = RenderExprAsNative(ctx, ctx.Expr(b.lhs));
+            auto lhs_or = RenderExpr(ctx, ctx.Expr(b.lhs));
             if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-            auto rhs_or = RenderExprAsNative(ctx, ctx.Expr(b.rhs));
+            auto rhs_or = RenderExpr(ctx, ctx.Expr(b.rhs));
             if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
             return RenderBinaryOp(b.op, *lhs_or, *rhs_or);
           },
           [&](const mir::ConditionalExpr& c) -> diag::Result<std::string> {
             auto cond_or = RenderConditionAsBool(ctx, ctx.Expr(c.condition));
             if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-            auto then_or = RenderExprAsNative(ctx, ctx.Expr(c.then_value));
+            auto then_or = RenderExpr(ctx, ctx.Expr(c.then_value));
             if (!then_or) return std::unexpected(std::move(then_or.error()));
-            auto else_or = RenderExprAsNative(ctx, ctx.Expr(c.else_value));
+            auto else_or = RenderExpr(ctx, ctx.Expr(c.else_value));
             if (!else_or) return std::unexpected(std::move(else_or.error()));
             return "(" + *cond_or + " ? " + *then_or + " : " + *else_or + ")";
           },
           [&](const mir::AssignExpr& a) -> diag::Result<std::string> {
-            auto target_type_or = MirTypeOfLvalue(ctx, a.target);
-            if (!target_type_or) {
-              return std::unexpected(std::move(target_type_or.error()));
-            }
-            const auto target_type = *target_type_or;
-            if (IsPackedExplicit(ctx.Unit(), target_type)) {
-              return RenderPackedAssign(ctx, a);
-            }
             auto target_or = RenderLvalue(ctx, a.target);
             if (!target_or) {
               return std::unexpected(std::move(target_or.error()));
             }
-            auto value_or = RenderExprAsNative(ctx, ctx.Expr(a.value));
+            auto value_or = RenderExpr(ctx, ctx.Expr(a.value));
             if (!value_or) return std::unexpected(std::move(value_or.error()));
             return "(" + *target_or + " = " + *value_or + ")";
           },
           [&](const mir::ConversionExpr& cv) -> diag::Result<std::string> {
             const auto& src_expr = ctx.Expr(cv.operand);
-            auto operand_or = RenderExprAsNative(ctx, src_expr);
+            auto operand_or = RenderExpr(ctx, src_expr);
             if (!operand_or) {
               return std::unexpected(std::move(operand_or.error()));
             }
@@ -718,17 +362,9 @@ auto RenderExprAsNative(const RenderContext& ctx, const mir::Expr& expr)
       expr.data);
 }
 
-auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
-    -> diag::Result<std::string> {
-  if (IsPackedExplicit(ctx.Unit(), expr.type)) {
-    return RenderExprAsPackedTopLevel(ctx, expr);
-  }
-  return RenderExprAsNative(ctx, expr);
-}
-
 auto RenderConditionAsBool(const RenderContext& ctx, const mir::Expr& expr)
     -> diag::Result<std::string> {
-  auto text_or = RenderExprAsNative(ctx, expr);
+  auto text_or = RenderExpr(ctx, expr);
   if (!text_or) return std::unexpected(std::move(text_or.error()));
   const auto& ty = ctx.Unit().GetType(expr.type);
   if (ty.IsPackedArray()) {

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -77,28 +77,20 @@ auto RenderRuntimeValueViewInit(
   // `%s` operands are typed as packed bit vectors by slang but reach the
   // runtime as a string_view. Dispatch on format kind, not just type.
   if (v.spec.kind == mir::FormatKind::kString) {
-    auto operand_or = RenderExprAsNative(ctx, ctx.Expr(v.value));
+    auto operand_or = RenderExpr(ctx, ctx.Expr(v.value));
     if (!operand_or) return std::unexpected(std::move(operand_or.error()));
     return std::format(
         "lyra::value::RuntimeValueView::String({})", *operand_or);
   }
 
   if (type.IsPackedArray()) {
-    const auto& pa = type.AsPackedArray();
-    const bool is_signed = pa.signedness == mir::Signedness::kSigned;
-    auto view_or = RenderPackedExprAsView(ctx, ctx.Expr(v.value));
-    if (!view_or) return std::unexpected(std::move(view_or.error()));
-    if (pa.atom == mir::BitAtom::kBit) {
-      return std::format(
-          "lyra::value::RuntimeValueView::FromBitView({}, {})", *view_or,
-          BoolLiteral(is_signed));
-    }
+    auto operand_or = RenderExpr(ctx, ctx.Expr(v.value));
+    if (!operand_or) return std::unexpected(std::move(operand_or.error()));
     return std::format(
-        "lyra::value::RuntimeValueView::FromLogicView({}, {})", *view_or,
-        BoolLiteral(is_signed));
+        "lyra::value::RuntimeValueView::FromPackedArray({})", *operand_or);
   }
   if (type.Kind() == mir::TypeKind::kString) {
-    auto operand_or = RenderExprAsNative(ctx, ctx.Expr(v.value));
+    auto operand_or = RenderExpr(ctx, ctx.Expr(v.value));
     if (!operand_or) return std::unexpected(std::move(operand_or.error()));
     return std::format(
         "lyra::value::RuntimeValueView::String({})", *operand_or);

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -158,7 +158,7 @@ auto RenderStmt(
             std::string args_str;
             for (std::size_t i = 0; i < s.args.size(); ++i) {
               if (i != 0) args_str += ", ";
-              auto arg_or = RenderExprAsNative(ctx, ctx.Expr(s.args[i]));
+              auto arg_or = RenderExpr(ctx, ctx.Expr(s.args[i]));
               if (!arg_or) return std::unexpected(std::move(arg_or.error()));
               args_str += *arg_or;
             }

--- a/src/lyra/value/format.cpp
+++ b/src/lyra/value/format.cpp
@@ -12,6 +12,7 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/value/integral_format.hpp"
+#include "lyra/value/packed_array.hpp"
 #include "lyra/value/packed_internal.hpp"
 
 namespace lyra::value {
@@ -141,6 +142,16 @@ auto RuntimeValueView::FromLogicView(ConstLogicView view, bool is_signed)
       .data = IntegralValueView::Wide(
           value_words, unknown_words, view.Width(),
           IntegralStateKind::kFourState, is_signed)};
+}
+
+auto RuntimeValueView::FromPackedArray(const PackedArray& pa)
+    -> RuntimeValueView {
+  const auto state_kind = pa.IsFourState() ? IntegralStateKind::kFourState
+                                           : IntegralStateKind::kTwoState;
+  return RuntimeValueView{
+      .data = IntegralValueView::Wide(
+          pa.ValueWords(), pa.UnknownWords(), pa.BitWidth(), state_kind,
+          pa.IsSigned())};
 }
 
 namespace {

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -11,6 +11,7 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/value/packed.hpp"
 #include "lyra/value/packed_bitwise.hpp"
+#include "lyra/value/packed_convert.hpp"
 #include "lyra/value/packed_internal.hpp"
 #include "lyra/value/packed_reduction.hpp"
 
@@ -73,24 +74,78 @@ auto PackedArray::Int(std::int32_t value) -> PackedArray {
   return FromInt(value, 32U, true, false);
 }
 
+auto PackedArray::MakeFromWordPlanes(
+    std::uint64_t bit_width, bool is_signed, bool is_four_state,
+    std::span<const std::uint64_t> value_words,
+    std::span<const std::uint64_t> unknown_words) -> PackedArray {
+  if (bit_width == 0U) {
+    throw InternalError(
+        "PackedArray::MakeFromWordPlanes: bit_width must be >= 1");
+  }
+  const std::size_t expected = (bit_width + 63U) / 64U;
+  if (value_words.size() != expected) {
+    throw InternalError(
+        "PackedArray::MakeFromWordPlanes: value word count mismatch");
+  }
+  if (!is_four_state && !unknown_words.empty()) {
+    throw InternalError(
+        "PackedArray::MakeFromWordPlanes: 2-state shape forbids unknown "
+        "words");
+  }
+  if (is_four_state && !unknown_words.empty() &&
+      unknown_words.size() != expected) {
+    throw InternalError(
+        "PackedArray::MakeFromWordPlanes: 4-state unknown word count "
+        "mismatch");
+  }
+
+  PackedArray p{bit_width, is_signed, is_four_state};
+  auto value_dst = std::visit(
+      [](auto& v) { return detail::PackedAccess::ValueWords(v.View()); },
+      p.storage_);
+  std::ranges::copy(value_words, value_dst.begin());
+  MaskUnusedTopBits(value_dst, bit_width);
+  if (is_four_state) {
+    auto& lv = std::get<LogicValue>(p.storage_);
+    auto unknown_dst = detail::PackedAccess::UnknownWords(lv.View());
+    if (unknown_words.empty()) {
+      std::ranges::fill(unknown_dst, std::uint64_t{0});
+    } else {
+      std::ranges::copy(unknown_words, unknown_dst.begin());
+      MaskUnusedTopBits(unknown_dst, bit_width);
+    }
+  }
+  return p;
+}
+
 auto PackedArray::FromInt(
     std::int64_t value, std::uint64_t bit_width, bool is_signed,
     bool is_four_state) -> PackedArray {
-  PackedArray p{bit_width, is_signed, is_four_state};
-  auto words = std::visit(
-      [](auto& v) { return detail::PackedAccess::ValueWords(v.View()); },
-      p.storage_);
+  const std::size_t n = (bit_width + 63U) / 64U;
+  absl::InlinedVector<std::uint64_t, kPackedWordsInlineCapacity> words(n);
   if (bit_width <= 64U) {
-    words[0] = static_cast<std::uint64_t>(value) & MaskForWidth(bit_width);
+    words[0] = static_cast<std::uint64_t>(value);
   } else {
     const std::uint64_t fill = (value < 0) ? ~std::uint64_t{0} : 0U;
     words[0] = static_cast<std::uint64_t>(value);
-    for (std::size_t i = 1; i < words.size(); ++i) {
+    for (std::size_t i = 1; i < n; ++i) {
       words[i] = fill;
     }
-    MaskUnusedTopBits(words, bit_width);
   }
-  return p;
+  return MakeFromWordPlanes(
+      bit_width, is_signed, is_four_state,
+      std::span<const std::uint64_t>{words.data(), words.size()}, {});
+}
+
+auto PackedArray::FromWords(
+    std::initializer_list<std::uint64_t> value_words,
+    std::initializer_list<std::uint64_t> unknown_words, std::uint64_t bit_width,
+    bool is_signed, bool is_four_state) -> PackedArray {
+  return MakeFromWordPlanes(
+      bit_width, is_signed, is_four_state,
+      std::span<const std::uint64_t>{value_words.begin(), value_words.size()},
+      std::span<const std::uint64_t>{
+          unknown_words.begin(), unknown_words.size()});
 }
 
 auto PackedArray::BitWidth() const -> std::uint64_t {
@@ -152,6 +207,21 @@ auto PackedArray::AsLogicView() const -> ConstLogicView {
   return lv->View();
 }
 
+auto PackedArray::operator=(const PackedArray& other) -> PackedArray& {
+  if (this != &other) {
+    AssignFrom(other);
+  }
+  return *this;
+}
+
+auto PackedArray::operator=(PackedArray&& other) noexcept(false)
+    -> PackedArray& {
+  if (this != &other) {
+    AssignFrom(other);
+  }
+  return *this;
+}
+
 auto PackedArray::AssignFrom(const PackedArray& other) -> void {
   ExpectSameShape(*this, other, "PackedArray::AssignFrom");
   auto dst = std::visit(
@@ -189,18 +259,31 @@ auto PackedArray::IsTruthy() const -> bool {
 auto PackedArray::ConvertFrom(
     const PackedArray& src, std::uint64_t dst_bit_width, bool dst_is_signed,
     bool dst_is_four_state) -> PackedArray {
-  if (src.BitWidth() > 64U || dst_bit_width > 64U) {
-    throw InternalError(
-        "PackedArray::ConvertFrom: wide (>64-bit) conversion not yet "
-        "implemented");
+  PackedArray dst{dst_bit_width, dst_is_signed, dst_is_four_state};
+  const Signedness src_signedness =
+      src.IsSigned() ? Signedness::kSigned : Signedness::kUnsigned;
+  if (dst_is_four_state) {
+    auto& dst_lv = std::get<LogicValue>(dst.storage_);
+    LogicView dst_view = dst_lv.View();
+    if (src.IsFourState()) {
+      const auto& src_lv = std::get<LogicValue>(src.storage_);
+      ConvertToLogic(src_lv.View(), dst_view, src_signedness);
+    } else {
+      const auto& src_bv = std::get<BitValue>(src.storage_);
+      ConvertToLogic(src_bv.View(), dst_view, src_signedness);
+    }
+  } else {
+    auto& dst_bv = std::get<BitValue>(dst.storage_);
+    BitView dst_view = dst_bv.View();
+    if (src.IsFourState()) {
+      const auto& src_lv = std::get<LogicValue>(src.storage_);
+      ConvertToBit(src_lv.View(), dst_view, src_signedness);
+    } else {
+      const auto& src_bv = std::get<BitValue>(src.storage_);
+      ConvertToBit(src_bv.View(), dst_view, src_signedness);
+    }
   }
-  // Narrow conversion across (state, signedness, width) combinations. Value
-  // bits flow through `ToInt64` (sign-extended per source signedness) then
-  // `FromInt` (truncated to destination width). 4-state X/Z bits collapse
-  // to 0 when crossing into 2-state; 2-state -> 4-state leaves the unknown
-  // plane zero. TODO(hankhsu): full X/Z propagation.
-  return FromInt(
-      src.ToInt64(), dst_bit_width, dst_is_signed, dst_is_four_state);
+  return dst;
 }
 
 namespace {
@@ -220,8 +303,13 @@ auto NarrowWordOf(const PackedArray& v) -> std::uint64_t {
   return v.ValueWords()[0] & MaskForWidth(v.BitWidth());
 }
 
-auto OneBitResult(bool flag) -> PackedArray {
-  return PackedArray::FromInt(flag ? 1 : 0, 1U, false, false);
+// Build a 1-bit result for comparison / logical ops. The result's
+// state-kind must match the operand's so the value can be assigned back to
+// a same-shape target without a shape-mismatch crash. (X/Z propagation in
+// the value is a separate concern under WidthOnlyNarrow's TODO; this helper
+// only fixes the shape.)
+auto OneBitResult(bool flag, bool is_four_state) -> PackedArray {
+  return PackedArray::FromInt(flag ? 1 : 0, 1U, false, is_four_state);
 }
 
 }  // namespace
@@ -259,6 +347,10 @@ auto PackedArray::operator/(const PackedArray& other) const -> PackedArray {
   WidthOnlyNarrow(*this, "operator/");
   const auto rhs = other.ToInt64();
   if (rhs == 0) {
+    // SV LRM 11.4.4: integer division by zero on 4-state yields X for every
+    // bit; on 2-state it is implementation-defined and we pick zero. The
+    // default ctor encodes both directly: LogicValue defaults to all-X
+    // (matching the SV `logic` default), BitValue defaults to all-zero.
     return PackedArray{bit_width_, is_signed_, is_four_state_};
   }
   if (is_signed_) {
@@ -275,6 +367,8 @@ auto PackedArray::operator%(const PackedArray& other) const -> PackedArray {
   WidthOnlyNarrow(*this, "operator%");
   const auto rhs = other.ToInt64();
   if (rhs == 0) {
+    // See operator/'s div-by-zero note: deliberate use of the default ctor's
+    // shape-default (all-X for 4-state, zero for 2-state).
     return PackedArray{bit_width_, is_signed_, is_four_state_};
   }
   if (is_signed_) {
@@ -385,49 +479,55 @@ auto PackedArray::BitwiseXnor(const PackedArray& other) const -> PackedArray {
 auto PackedArray::operator==(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator==");
   WidthOnlyNarrow(*this, "operator==");
-  return OneBitResult(NarrowWordOf(*this) == NarrowWordOf(other));
+  return OneBitResult(
+      NarrowWordOf(*this) == NarrowWordOf(other), is_four_state_);
 }
 
 auto PackedArray::operator!=(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator!=");
   WidthOnlyNarrow(*this, "operator!=");
-  return OneBitResult(NarrowWordOf(*this) != NarrowWordOf(other));
+  return OneBitResult(
+      NarrowWordOf(*this) != NarrowWordOf(other), is_four_state_);
 }
 
 auto PackedArray::operator<(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator<");
   WidthOnlyNarrow(*this, "operator<");
   if (is_signed_) {
-    return OneBitResult(ToInt64() < other.ToInt64());
+    return OneBitResult(ToInt64() < other.ToInt64(), is_four_state_);
   }
-  return OneBitResult(NarrowWordOf(*this) < NarrowWordOf(other));
+  return OneBitResult(
+      NarrowWordOf(*this) < NarrowWordOf(other), is_four_state_);
 }
 
 auto PackedArray::operator<=(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator<=");
   WidthOnlyNarrow(*this, "operator<=");
   if (is_signed_) {
-    return OneBitResult(ToInt64() <= other.ToInt64());
+    return OneBitResult(ToInt64() <= other.ToInt64(), is_four_state_);
   }
-  return OneBitResult(NarrowWordOf(*this) <= NarrowWordOf(other));
+  return OneBitResult(
+      NarrowWordOf(*this) <= NarrowWordOf(other), is_four_state_);
 }
 
 auto PackedArray::operator>(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator>");
   WidthOnlyNarrow(*this, "operator>");
   if (is_signed_) {
-    return OneBitResult(ToInt64() > other.ToInt64());
+    return OneBitResult(ToInt64() > other.ToInt64(), is_four_state_);
   }
-  return OneBitResult(NarrowWordOf(*this) > NarrowWordOf(other));
+  return OneBitResult(
+      NarrowWordOf(*this) > NarrowWordOf(other), is_four_state_);
 }
 
 auto PackedArray::operator>=(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator>=");
   WidthOnlyNarrow(*this, "operator>=");
   if (is_signed_) {
-    return OneBitResult(ToInt64() >= other.ToInt64());
+    return OneBitResult(ToInt64() >= other.ToInt64(), is_four_state_);
   }
-  return OneBitResult(NarrowWordOf(*this) >= NarrowWordOf(other));
+  return OneBitResult(
+      NarrowWordOf(*this) >= NarrowWordOf(other), is_four_state_);
 }
 
 auto PackedArray::operator-() const -> PackedArray {
@@ -435,7 +535,7 @@ auto PackedArray::operator-() const -> PackedArray {
   const auto mask = MaskForWidth(bit_width_);
   return FromInt(
       static_cast<std::int64_t>((-NarrowWordOf(*this)) & mask), bit_width_,
-      is_signed_, false);
+      is_signed_, is_four_state_);
 }
 
 auto PackedArray::operator~() const -> PackedArray {
@@ -468,15 +568,19 @@ auto IsNonZero(const PackedArray& v) -> bool {
 }  // namespace
 
 auto PackedArray::LogicalAnd(const PackedArray& other) const -> PackedArray {
-  return OneBitResult(IsNonZero(*this) && IsNonZero(other));
+  return OneBitResult(
+      IsNonZero(*this) && IsNonZero(other),
+      is_four_state_ || other.is_four_state_);
 }
 
 auto PackedArray::LogicalOr(const PackedArray& other) const -> PackedArray {
-  return OneBitResult(IsNonZero(*this) || IsNonZero(other));
+  return OneBitResult(
+      IsNonZero(*this) || IsNonZero(other),
+      is_four_state_ || other.is_four_state_);
 }
 
 auto PackedArray::LogicalNot() const -> PackedArray {
-  return OneBitResult(!IsNonZero(*this));
+  return OneBitResult(!IsNonZero(*this), is_four_state_);
 }
 
 namespace {
@@ -494,7 +598,7 @@ auto PackedArray::ShiftLeft(const PackedArray& amount) const -> PackedArray {
   WidthOnlyNarrow(*this, "ShiftLeft");
   const auto amt = ShiftAmountAsUint(amount);
   if (amt >= bit_width_) {
-    return PackedArray{bit_width_, is_signed_, is_four_state_};
+    return FromInt(0, bit_width_, is_signed_, is_four_state_);
   }
   const auto mask = MaskForWidth(bit_width_);
   return FromInt(
@@ -507,11 +611,11 @@ auto PackedArray::LogicalShiftRight(const PackedArray& amount) const
   WidthOnlyNarrow(*this, "LogicalShiftRight");
   const auto amt = ShiftAmountAsUint(amount);
   if (amt >= bit_width_) {
-    return PackedArray{bit_width_, is_signed_, is_four_state_};
+    return FromInt(0, bit_width_, is_signed_, is_four_state_);
   }
   return FromInt(
       static_cast<std::int64_t>(NarrowWordOf(*this) >> amt), bit_width_,
-      is_signed_, false);
+      is_signed_, is_four_state_);
 }
 
 auto PackedArray::ArithmeticShiftRight(const PackedArray& amount) const
@@ -542,7 +646,7 @@ auto PackedArray::Power(const PackedArray& exponent) const -> PackedArray {
       return FromInt(
           (exp & 1) != 0 ? -1 : 1, bit_width_, is_signed_, is_four_state_);
     }
-    return PackedArray{bit_width_, is_signed_, is_four_state_};
+    return FromInt(0, bit_width_, is_signed_, is_four_state_);
   }
   std::int64_t result = 1;
   std::int64_t b = base;
@@ -559,7 +663,8 @@ auto PackedArray::Power(const PackedArray& exponent) const -> PackedArray {
 
 auto PackedArray::ReductionAnd() const -> PackedArray {
   if (bit_width_ <= 64U && !is_four_state_) {
-    return OneBitResult(NarrowWordOf(*this) == MaskForWidth(bit_width_));
+    return OneBitResult(
+        NarrowWordOf(*this) == MaskForWidth(bit_width_), is_four_state_);
   }
   PackedArray result{1U, false, is_four_state_};
   if (is_four_state_) {
@@ -576,7 +681,7 @@ auto PackedArray::ReductionAnd() const -> PackedArray {
 
 auto PackedArray::ReductionOr() const -> PackedArray {
   if (bit_width_ <= 64U && !is_four_state_) {
-    return OneBitResult(NarrowWordOf(*this) != 0U);
+    return OneBitResult(NarrowWordOf(*this) != 0U, is_four_state_);
   }
   PackedArray result{1U, false, is_four_state_};
   if (is_four_state_) {
@@ -593,7 +698,8 @@ auto PackedArray::ReductionOr() const -> PackedArray {
 
 auto PackedArray::ReductionXor() const -> PackedArray {
   if (bit_width_ <= 64U && !is_four_state_) {
-    return OneBitResult((std::popcount(NarrowWordOf(*this)) & 1) != 0);
+    return OneBitResult(
+        (std::popcount(NarrowWordOf(*this)) & 1) != 0, is_four_state_);
   }
   PackedArray result{1U, false, is_four_state_};
   if (is_four_state_) {
@@ -610,7 +716,8 @@ auto PackedArray::ReductionXor() const -> PackedArray {
 
 auto PackedArray::ReductionNand() const -> PackedArray {
   if (bit_width_ <= 64U && !is_four_state_) {
-    return OneBitResult(NarrowWordOf(*this) != MaskForWidth(bit_width_));
+    return OneBitResult(
+        NarrowWordOf(*this) != MaskForWidth(bit_width_), is_four_state_);
   }
   PackedArray result{1U, false, is_four_state_};
   if (is_four_state_) {
@@ -627,7 +734,7 @@ auto PackedArray::ReductionNand() const -> PackedArray {
 
 auto PackedArray::ReductionNor() const -> PackedArray {
   if (bit_width_ <= 64U && !is_four_state_) {
-    return OneBitResult(NarrowWordOf(*this) == 0U);
+    return OneBitResult(NarrowWordOf(*this) == 0U, is_four_state_);
   }
   PackedArray result{1U, false, is_four_state_};
   if (is_four_state_) {
@@ -644,7 +751,8 @@ auto PackedArray::ReductionNor() const -> PackedArray {
 
 auto PackedArray::ReductionXnor() const -> PackedArray {
   if (bit_width_ <= 64U && !is_four_state_) {
-    return OneBitResult((std::popcount(NarrowWordOf(*this)) & 1) == 0);
+    return OneBitResult(
+        (std::popcount(NarrowWordOf(*this)) & 1) == 0, is_four_state_);
   }
   PackedArray result{1U, false, is_four_state_};
   if (is_four_state_) {

--- a/tests/cases/cpp/packed_arithmetic_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_arithmetic_logic_ops/case.yaml
@@ -1,0 +1,18 @@
+id: cpp.packed_arithmetic_logic_ops
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    add_: 42
+    sub_: 18
+    sub_neg: -18
+    mul_: 35
+    mul_neg: -35
+    div_pos: 25
+    div_neg: -25
+    mod_: 2

--- a/tests/cases/cpp/packed_arithmetic_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_arithmetic_logic_ops/main.sv
@@ -1,0 +1,28 @@
+module Top;
+  logic signed [7:0] add_;
+  logic signed [7:0] sub_;
+  logic signed [7:0] sub_neg;
+  logic signed [7:0] mul_;
+  logic signed [7:0] mul_neg;
+  logic signed [7:0] div_pos;
+  logic signed [7:0] div_neg;
+  logic signed [7:0] mod_;
+  initial begin
+    logic signed [7:0] a;
+    logic signed [7:0] b;
+    a = 30; b = 12;
+    add_ = a + b;
+    sub_ = a - b;
+    sub_neg = b - a;
+    a = 5; b = 7;
+    mul_ = a * b;
+    a = b - 12;
+    mul_neg = a * b;
+    a = 100; b = 4;
+    div_pos = a / b;
+    a = b - 104;
+    div_neg = a / b;
+    a = 17; b = 5;
+    mod_ = a % b;
+  end
+endmodule

--- a/tests/cases/cpp/packed_bit_signed_extend/main.sv
+++ b/tests/cases/cpp/packed_bit_signed_extend/main.sv
@@ -1,10 +1,9 @@
 module Top;
-  bit signed [3:0] a;
   bit [7:0] b;
 
   initial begin
+    bit signed [3:0] a;
     a = 4'sb1010;
     b = a;
-    $display("%b", b);
   end
 endmodule

--- a/tests/cases/cpp/packed_bit_to_logic_zero_extend/case.yaml
+++ b/tests/cases/cpp/packed_bit_to_logic_zero_extend/case.yaml
@@ -7,5 +7,5 @@ input:
   files: [main.sv]
 expect:
   exit: 0
-  stdout:
-    exact: "00001010\n"
+  variables:
+    b: "8'b00001010"

--- a/tests/cases/cpp/packed_bit_to_logic_zero_extend/main.sv
+++ b/tests/cases/cpp/packed_bit_to_logic_zero_extend/main.sv
@@ -1,10 +1,9 @@
 module Top;
-  bit [3:0] a;
   logic [7:0] b;
 
   initial begin
+    bit [3:0] a;
     a = 4'b1010;
     b = a;
-    $display("%b", b);
   end
 endmodule

--- a/tests/cases/cpp/packed_bit_truncate_zero_extend/case.yaml
+++ b/tests/cases/cpp/packed_bit_truncate_zero_extend/case.yaml
@@ -7,5 +7,6 @@ input:
   files: [main.sv]
 expect:
   exit: 0
-  stdout:
-    exact: "0110\n00000110\n"
+  variables:
+    b: "4'b0110"
+    c: "8'b00000110"

--- a/tests/cases/cpp/packed_bit_truncate_zero_extend/main.sv
+++ b/tests/cases/cpp/packed_bit_truncate_zero_extend/main.sv
@@ -1,13 +1,11 @@
 module Top;
-  bit [7:0] a;
   bit [3:0] b;
   bit [7:0] c;
 
   initial begin
+    bit [7:0] a;
     a = 8'b10110110;
     b = a;
     c = b;
-    $display("%b", b);
-    $display("%b", c);
   end
 endmodule

--- a/tests/cases/cpp/packed_bitwise_bit_not_5bit/case.yaml
+++ b/tests/cases/cpp/packed_bitwise_bit_not_5bit/case.yaml
@@ -7,5 +7,5 @@ input:
   files: [main.sv]
 expect:
   exit: 0
-  stdout:
-    exact: "01010\n"
+  variables:
+    y: "5'b01010"

--- a/tests/cases/cpp/packed_bitwise_bit_not_5bit/main.sv
+++ b/tests/cases/cpp/packed_bitwise_bit_not_5bit/main.sv
@@ -1,10 +1,9 @@
 module Top;
-  bit [4:0] a;
   bit [4:0] y;
 
   initial begin
+    bit [4:0] a;
     a = 5'b10101;
     y = ~a;
-    $display("%b", y);
   end
 endmodule

--- a/tests/cases/cpp/packed_bitwise_bit_ops/case.yaml
+++ b/tests/cases/cpp/packed_bitwise_bit_ops/case.yaml
@@ -7,5 +7,9 @@ input:
   files: [main.sv]
 expect:
   exit: 0
-  stdout:
-    exact: "0101\n1000\n1110\n0110\n1001\n"
+  variables:
+    not_: "4'b0101"
+    and_: "4'b1000"
+    or_: "4'b1110"
+    xor_: "4'b0110"
+    xnor_: "4'b1001"

--- a/tests/cases/cpp/packed_bitwise_bit_ops/main.sv
+++ b/tests/cases/cpp/packed_bitwise_bit_ops/main.sv
@@ -1,16 +1,19 @@
 module Top;
-  bit [3:0] a;
-  bit [3:0] b;
-  bit [3:0] y;
+  bit [3:0] not_;
+  bit [3:0] and_;
+  bit [3:0] or_;
+  bit [3:0] xor_;
+  bit [3:0] xnor_;
 
   initial begin
+    bit [3:0] a;
+    bit [3:0] b;
     a = 4'b1010;
     b = 4'b1100;
-
-    y = ~a;     $display("%b", y);
-    y = a & b;  $display("%b", y);
-    y = a | b;  $display("%b", y);
-    y = a ^ b;  $display("%b", y);
-    y = a ~^ b; $display("%b", y);
+    not_ = ~a;
+    and_ = a & b;
+    or_ = a | b;
+    xor_ = a ^ b;
+    xnor_ = a ~^ b;
   end
 endmodule

--- a/tests/cases/cpp/packed_bitwise_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_bitwise_logic_ops/case.yaml
@@ -7,5 +7,9 @@ input:
   files: [main.sv]
 expect:
   exit: 0
-  stdout:
-    exact: "01xx\n1000\n11xx\n01xx\n10xx\n"
+  variables:
+    not_: "4'b01xx"
+    and_: "4'b1000"
+    or_: "4'b11xx"
+    xor_: "4'b01xx"
+    xnor_: "4'b10xx"

--- a/tests/cases/cpp/packed_bitwise_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_bitwise_logic_ops/main.sv
@@ -1,16 +1,19 @@
 module Top;
-  logic [3:0] a;
-  logic [3:0] b;
-  logic [3:0] y;
+  logic [3:0] not_;
+  logic [3:0] and_;
+  logic [3:0] or_;
+  logic [3:0] xor_;
+  logic [3:0] xnor_;
 
   initial begin
+    logic [3:0] a;
+    logic [3:0] b;
     a = 4'b10xz;
     b = 4'b1100;
-
-    y = ~a;     $display("%b", y);
-    y = a & b;  $display("%b", y);
-    y = a | b;  $display("%b", y);
-    y = a ^ b;  $display("%b", y);
-    y = a ~^ b; $display("%b", y);
+    not_ = ~a;
+    and_ = a & b;
+    or_ = a | b;
+    xor_ = a ^ b;
+    xnor_ = a ~^ b;
   end
 endmodule

--- a/tests/cases/cpp/packed_bitwise_reg_alias_ops/case.yaml
+++ b/tests/cases/cpp/packed_bitwise_reg_alias_ops/case.yaml
@@ -7,5 +7,5 @@ input:
   files: [main.sv]
 expect:
   exit: 0
-  stdout:
-    exact: "x0x1\n"
+  variables:
+    and_: "4'bx0x1"

--- a/tests/cases/cpp/packed_bitwise_reg_alias_ops/main.sv
+++ b/tests/cases/cpp/packed_bitwise_reg_alias_ops/main.sv
@@ -1,12 +1,11 @@
 module Top;
-  reg [3:0] a;
-  reg [3:0] b;
-  reg [3:0] y;
+  reg [3:0] and_;
 
   initial begin
+    reg [3:0] a;
+    reg [3:0] b;
     a = 4'bz0x1;
     b = 4'b1011;
-    y = a & b;
-    $display("%b", y);
+    and_ = a & b;
   end
 endmodule

--- a/tests/cases/cpp/packed_comparison_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_comparison_logic_ops/case.yaml
@@ -1,4 +1,4 @@
-id: cpp.packed_bit_signed_extend
+id: cpp.packed_comparison_logic_ops
 tags: [cpp_run]
 input:
   command: [run, cpp]
@@ -8,4 +8,9 @@ input:
 expect:
   exit: 0
   variables:
-    b: "8'b11111010"
+    eq_: 1
+    neq_: 1
+    lt_: 1
+    le_: 1
+    gt_: 1
+    ge_: 1

--- a/tests/cases/cpp/packed_comparison_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_comparison_logic_ops/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  logic eq_, neq_;
+  logic lt_, le_, gt_, ge_;
+  initial begin
+    logic signed [7:0] a;
+    logic signed [7:0] b;
+    a = 5; b = 5;
+    eq_ = (a == b);
+    a = 5; b = 7;
+    neq_ = (a != b);
+    a = -3; b = 4;
+    lt_ = (a < b);
+    a = 4; b = 4;
+    le_ = (a <= b);
+    a = 7; b = 2;
+    gt_ = (a > b);
+    a = -1; b = -1;
+    ge_ = (a >= b);
+  end
+endmodule

--- a/tests/cases/cpp/packed_logic_signed_extend_bit/case.yaml
+++ b/tests/cases/cpp/packed_logic_signed_extend_bit/case.yaml
@@ -7,5 +7,5 @@ input:
   files: [main.sv]
 expect:
   exit: 0
-  stdout:
-    exact: "00000010\n"
+  variables:
+    b: "8'b00000010"

--- a/tests/cases/cpp/packed_logic_signed_extend_bit/main.sv
+++ b/tests/cases/cpp/packed_logic_signed_extend_bit/main.sv
@@ -1,10 +1,9 @@
 module Top;
-  logic signed [3:0] a;
   bit [7:0] b;
 
   initial begin
+    logic signed [3:0] a;
     a = 4'bx010;
     b = a;
-    $display("%b", b);
   end
 endmodule

--- a/tests/cases/cpp/packed_logic_signed_extend_logic/case.yaml
+++ b/tests/cases/cpp/packed_logic_signed_extend_logic/case.yaml
@@ -7,5 +7,6 @@ input:
   files: [main.sv]
 expect:
   exit: 0
-  stdout:
-    exact: "xxxxx010\nzzzzz010\n"
+  variables:
+    b_from_x: "8'bxxxxx010"
+    b_from_z: "8'bzzzzz010"

--- a/tests/cases/cpp/packed_logic_signed_extend_logic/main.sv
+++ b/tests/cases/cpp/packed_logic_signed_extend_logic/main.sv
@@ -1,13 +1,12 @@
 module Top;
-  logic signed [3:0] a;
-  logic [7:0] b;
+  logic [7:0] b_from_x;
+  logic [7:0] b_from_z;
 
   initial begin
+    logic signed [3:0] a;
     a = 4'bx010;
-    b = a;
-    $display("%b", b);
+    b_from_x = a;
     a = 4'bz010;
-    b = a;
-    $display("%b", b);
+    b_from_z = a;
   end
 endmodule

--- a/tests/cases/cpp/packed_logic_to_bit_flatten_xz/case.yaml
+++ b/tests/cases/cpp/packed_logic_to_bit_flatten_xz/case.yaml
@@ -7,5 +7,5 @@ input:
   files: [main.sv]
 expect:
   exit: 0
-  stdout:
-    exact: "1000\n"
+  variables:
+    b: "4'b1000"

--- a/tests/cases/cpp/packed_logic_to_bit_flatten_xz/main.sv
+++ b/tests/cases/cpp/packed_logic_to_bit_flatten_xz/main.sv
@@ -1,10 +1,9 @@
 module Top;
-  logic [3:0] a;
   bit [3:0] b;
 
   initial begin
+    logic [3:0] a;
     a = 4'b10xz;
     b = a;
-    $display("%b", b);
   end
 endmodule

--- a/tests/cases/cpp/packed_logic_unsigned_widen_xz/case.yaml
+++ b/tests/cases/cpp/packed_logic_unsigned_widen_xz/case.yaml
@@ -7,5 +7,5 @@ input:
   files: [main.sv]
 expect:
   exit: 0
-  stdout:
-    exact: "000010xz\n"
+  variables:
+    b: "8'b000010xz"

--- a/tests/cases/cpp/packed_logic_unsigned_widen_xz/main.sv
+++ b/tests/cases/cpp/packed_logic_unsigned_widen_xz/main.sv
@@ -1,10 +1,9 @@
 module Top;
-  logic [3:0] a;
   logic [7:0] b;
 
   initial begin
+    logic [3:0] a;
     a = 4'b10xz;
     b = a;
-    $display("%b", b);
   end
 endmodule

--- a/tests/cases/cpp/packed_logical_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_logical_logic_ops/case.yaml
@@ -1,0 +1,18 @@
+id: cpp.packed_logical_logic_ops
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    and_tt: 1
+    and_tf: 0
+    and_ff: 0
+    or_tt: 1
+    or_tf: 1
+    or_ff: 0
+    not_t: 0
+    not_f: 1

--- a/tests/cases/cpp/packed_logical_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_logical_logic_ops/main.sv
@@ -1,0 +1,25 @@
+module Top;
+  logic and_tt, and_tf, and_ff;
+  logic or_tt, or_tf, or_ff;
+  logic not_t, not_f;
+  initial begin
+    logic [3:0] a;
+    logic [3:0] b;
+    a = 4'b1010; b = 4'b0011;
+    and_tt = a && b;
+    a = 4'b1010; b = 4'b0000;
+    and_tf = a && b;
+    a = 4'b0000; b = 4'b0000;
+    and_ff = a && b;
+    a = 4'b1010; b = 4'b0011;
+    or_tt = a || b;
+    a = 4'b1010; b = 4'b0000;
+    or_tf = a || b;
+    a = 4'b0000; b = 4'b0000;
+    or_ff = a || b;
+    a = 4'b1010;
+    not_t = !a;
+    a = 4'b0000;
+    not_f = !a;
+  end
+endmodule

--- a/tests/cases/cpp/packed_power_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_power_logic_ops/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.packed_power_logic_ops
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    pow_pos: 243
+    pow_zero_exp: 1
+    pow_one_base_neg_exp: 1
+    pow_neg_one_base_even_neg_exp: 1
+    pow_neg_one_base_odd_neg_exp: -1
+    pow_neg_exp_zero_result: 0

--- a/tests/cases/cpp/packed_power_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_power_logic_ops/main.sv
@@ -1,0 +1,24 @@
+module Top;
+  logic signed [15:0] pow_pos;
+  logic signed [15:0] pow_zero_exp;
+  logic signed [15:0] pow_one_base_neg_exp;
+  logic signed [15:0] pow_neg_one_base_even_neg_exp;
+  logic signed [15:0] pow_neg_one_base_odd_neg_exp;
+  logic signed [15:0] pow_neg_exp_zero_result;
+  initial begin
+    logic signed [15:0] a;
+    logic signed [15:0] b;
+    a = 3; b = 5;
+    pow_pos = a ** b;
+    a = 7; b = 0;
+    pow_zero_exp = a ** b;
+    a = 1; b = -3;
+    pow_one_base_neg_exp = a ** b;
+    a = -1; b = -4;
+    pow_neg_one_base_even_neg_exp = a ** b;
+    a = -1; b = -3;
+    pow_neg_one_base_odd_neg_exp = a ** b;
+    a = 2; b = -3;
+    pow_neg_exp_zero_result = a ** b;
+  end
+endmodule

--- a/tests/cases/cpp/packed_reduction_5bit_tail_mask/case.yaml
+++ b/tests/cases/cpp/packed_reduction_5bit_tail_mask/case.yaml
@@ -7,5 +7,7 @@ input:
   files: [main.sv]
 expect:
   exit: 0
-  stdout:
-    exact: "1\n0\n1\n"
+  variables:
+    and_all_one: 1
+    and_top_zero: 0
+    or_top_one: 1

--- a/tests/cases/cpp/packed_reduction_5bit_tail_mask/main.sv
+++ b/tests/cases/cpp/packed_reduction_5bit_tail_mask/main.sv
@@ -1,10 +1,12 @@
 module Top;
-  bit [4:0] a;
-  bit y;
+  bit and_all_one;
+  bit and_top_zero;
+  bit or_top_one;
 
   initial begin
-    a = 5'b11111; y = &a; $display("%b", y);
-    a = 5'b01111; y = &a; $display("%b", y);
-    a = 5'b10000; y = |a; $display("%b", y);
+    bit [4:0] a;
+    a = 5'b11111; and_all_one = &a;
+    a = 5'b01111; and_top_zero = &a;
+    a = 5'b10000; or_top_one = |a;
   end
 endmodule

--- a/tests/cases/cpp/packed_reduction_bit_ops/case.yaml
+++ b/tests/cases/cpp/packed_reduction_bit_ops/case.yaml
@@ -7,5 +7,13 @@ input:
   files: [main.sv]
 expect:
   exit: 0
-  stdout:
-    exact: "1\n0\n0\n1\n1\n0\n0\n1\n0\n"
+  variables:
+    and_all_one: 1
+    and_one_zero: 0
+    or_all_zero: 0
+    or_one_bit: 1
+    xor_odd: 1
+    xor_even: 0
+    nand_all_one: 0
+    nor_all_zero: 1
+    xnor_odd: 0

--- a/tests/cases/cpp/packed_reduction_bit_ops/main.sv
+++ b/tests/cases/cpp/packed_reduction_bit_ops/main.sv
@@ -1,16 +1,24 @@
 module Top;
-  bit [3:0] a;
-  bit y;
+  bit and_all_one;
+  bit and_one_zero;
+  bit or_all_zero;
+  bit or_one_bit;
+  bit xor_odd;
+  bit xor_even;
+  bit nand_all_one;
+  bit nor_all_zero;
+  bit xnor_odd;
 
   initial begin
-    a = 4'b1111; y = &a;  $display("%b", y);
-    a = 4'b1101; y = &a;  $display("%b", y);
-    a = 4'b0000; y = |a;  $display("%b", y);
-    a = 4'b0100; y = |a;  $display("%b", y);
-    a = 4'b1011; y = ^a;  $display("%b", y);
-    a = 4'b1010; y = ^a;  $display("%b", y);
-    a = 4'b1111; y = ~&a; $display("%b", y);
-    a = 4'b0000; y = ~|a; $display("%b", y);
-    a = 4'b1011; y = ~^a; $display("%b", y);
+    bit [3:0] a;
+    a = 4'b1111; and_all_one = &a;
+    a = 4'b1101; and_one_zero = &a;
+    a = 4'b0000; or_all_zero = |a;
+    a = 4'b0100; or_one_bit = |a;
+    a = 4'b1011; xor_odd = ^a;
+    a = 4'b1010; xor_even = ^a;
+    a = 4'b1111; nand_all_one = ~&a;
+    a = 4'b0000; nor_all_zero = ~|a;
+    a = 4'b1011; xnor_odd = ~^a;
   end
 endmodule

--- a/tests/cases/cpp/packed_reduction_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_reduction_logic_ops/case.yaml
@@ -7,5 +7,16 @@ input:
   files: [main.sv]
 expect:
   exit: 0
-  stdout:
-    exact: "1\nx\n0\n0\nx\n1\n1\nx\n0\n1\n0\nx\n"
+  variables:
+    and_all_one: 1
+    and_with_x: "1'bx"
+    and_with_zero: 0
+    or_all_zero: 0
+    or_with_z: "1'bx"
+    or_with_one: 1
+    xor_clean: 1
+    xor_with_x: "1'bx"
+    nand_all_one: 0
+    nor_all_zero: 1
+    xnor_clean: 0
+    xnor_with_z: "1'bx"

--- a/tests/cases/cpp/packed_reduction_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_reduction_logic_ops/main.sv
@@ -1,22 +1,30 @@
 module Top;
-  logic [3:0] a;
-  logic y;
+  logic and_all_one;
+  logic and_with_x;
+  logic and_with_zero;
+  logic or_all_zero;
+  logic or_with_z;
+  logic or_with_one;
+  logic xor_clean;
+  logic xor_with_x;
+  logic nand_all_one;
+  logic nor_all_zero;
+  logic xnor_clean;
+  logic xnor_with_z;
 
   initial begin
-    a = 4'b1111; y = &a;  $display("%b", y);
-    a = 4'b11x1; y = &a;  $display("%b", y);
-    a = 4'b10x1; y = &a;  $display("%b", y);
-
-    a = 4'b0000; y = |a;  $display("%b", y);
-    a = 4'b00z0; y = |a;  $display("%b", y);
-    a = 4'b01z0; y = |a;  $display("%b", y);
-
-    a = 4'b1011; y = ^a;  $display("%b", y);
-    a = 4'b10x1; y = ^a;  $display("%b", y);
-
-    a = 4'b1111; y = ~&a; $display("%b", y);
-    a = 4'b0000; y = ~|a; $display("%b", y);
-    a = 4'b1011; y = ~^a; $display("%b", y);
-    a = 4'b10z1; y = ~^a; $display("%b", y);
+    logic [3:0] a;
+    a = 4'b1111; and_all_one = &a;
+    a = 4'b11x1; and_with_x = &a;
+    a = 4'b10x1; and_with_zero = &a;
+    a = 4'b0000; or_all_zero = |a;
+    a = 4'b00z0; or_with_z = |a;
+    a = 4'b01z0; or_with_one = |a;
+    a = 4'b1011; xor_clean = ^a;
+    a = 4'b10x1; xor_with_x = ^a;
+    a = 4'b1111; nand_all_one = ~&a;
+    a = 4'b0000; nor_all_zero = ~|a;
+    a = 4'b1011; xnor_clean = ~^a;
+    a = 4'b10z1; xnor_with_z = ~^a;
   end
 endmodule

--- a/tests/cases/cpp/packed_reduction_reg_alias_ops/case.yaml
+++ b/tests/cases/cpp/packed_reduction_reg_alias_ops/case.yaml
@@ -7,5 +7,5 @@ input:
   files: [main.sv]
 expect:
   exit: 0
-  stdout:
-    exact: "x\n"
+  variables:
+    and_with_z: "1'bx"

--- a/tests/cases/cpp/packed_reduction_reg_alias_ops/main.sv
+++ b/tests/cases/cpp/packed_reduction_reg_alias_ops/main.sv
@@ -1,10 +1,9 @@
 module Top;
-  reg [3:0] a;
-  reg y;
+  reg and_with_z;
 
   initial begin
+    reg [3:0] a;
     a = 4'b11z1;
-    y = &a;
-    $display("%b", y);
+    and_with_z = &a;
   end
 endmodule

--- a/tests/cases/cpp/packed_same_width_copy/case.yaml
+++ b/tests/cases/cpp/packed_same_width_copy/case.yaml
@@ -7,5 +7,6 @@ input:
   files: [main.sv]
 expect:
   exit: 0
-  stdout:
-    exact: "1100\n10xz\n"
+  variables:
+    b_copy: "4'b1100"
+    y_copy: "4'b10xz"

--- a/tests/cases/cpp/packed_same_width_copy/main.sv
+++ b/tests/cases/cpp/packed_same_width_copy/main.sv
@@ -1,15 +1,13 @@
 module Top;
-  bit [3:0] a;
-  bit [3:0] b;
-  logic [3:0] x;
-  logic [3:0] y;
+  bit [3:0] b_copy;
+  logic [3:0] y_copy;
 
   initial begin
+    bit [3:0] a;
+    logic [3:0] x;
     a = 4'b1100;
-    b = a;
+    b_copy = a;
     x = 4'b10xz;
-    y = x;
-    $display("%b", b);
-    $display("%b", y);
+    y_copy = x;
   end
 endmodule

--- a/tests/cases/cpp/packed_shift_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_shift_logic_ops/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.packed_shift_logic_ops
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    shl_: "8'b11010000"
+    shr_logical: "8'b00101101"
+    shr_arith_pos: "8'b00001101"
+    shr_arith_neg: "8'b11110011"
+    shl_overflow: "4'b0000"
+    shr_overflow: "4'b0000"

--- a/tests/cases/cpp/packed_shift_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_shift_logic_ops/main.sv
@@ -1,0 +1,27 @@
+module Top;
+  logic [7:0] shl_;
+  logic [7:0] shr_logical;
+  logic signed [7:0] shr_arith_pos;
+  logic signed [7:0] shr_arith_neg;
+  logic [3:0] shl_overflow;
+  logic [3:0] shr_overflow;
+  initial begin
+    logic [7:0] a;
+    a = 8'b10110100;
+    shl_ = a << 2;
+    shr_logical = a >> 2;
+    begin
+      logic signed [7:0] s;
+      s = 8'sb00110100;
+      shr_arith_pos = s >>> 2;
+      s = 8'sb11001100;
+      shr_arith_neg = s >>> 2;
+    end
+    begin
+      logic [3:0] x;
+      x = 4'b1010;
+      shl_overflow = x << 8;
+      shr_overflow = x >> 8;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/packed_unary_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_unary_logic_ops/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.packed_unary_logic_ops
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    pos_: "4'b1010"
+    neg_: "4'b0110"
+    bitnot: "4'b0101"
+    lognot_nonzero: 0
+    lognot_zero: 1

--- a/tests/cases/cpp/packed_unary_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_unary_logic_ops/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  logic [3:0] pos_;
+  logic [3:0] neg_;
+  logic [3:0] bitnot;
+  logic lognot_nonzero;
+  logic lognot_zero;
+  initial begin
+    logic [3:0] a;
+    a = 4'b1010;
+    pos_ = +a;
+    neg_ = -a;
+    bitnot = ~a;
+    lognot_nonzero = !a;
+    a = 4'b0000;
+    lognot_zero = !a;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Consolidates the cpp-emit packed-array path so every SystemVerilog integral
(`int`, `integer`, `bit`, `logic`, `reg`) flows through a single
`RenderExpr` entry and a single `PackedArray` construction discipline. The
preceding PR unified the runtime type; this PR removes the residual
kExplicit-only view-bridge plumbing (`RenderPackedAssign`,
`RenderPackedExprAsView`, `RenderPackedLiteralView`, `IsPackedExplicit`,
etc.), leaving one canonical expression renderer.

## Design

`PackedArray` gains a private `MakeFromWordPlanes` helper that becomes the
single source of truth for materialising a value from word planes. `FromInt`
and `FromWords` both route through it, so no future factory can leak the
all-X residue that `LogicValue`'s default ctor leaves on the unknown plane
(this was the root cause of several 4-state bugs that only surfaced once
`ConvertFrom` started propagating X/Z properly). `OneBitResult` is
parameterised on `is_four_state`, so comparison and logical ops preserve
their operand's state-kind instead of silently returning a 2-state result
that fails the assignment shape check. `ConvertFrom` is rewritten to call
the existing `ConvertToBit` / `ConvertToLogic` view-based converters, which
gives full X/Z propagation in both directions and supports wide widths. A
matching `RuntimeValueView::FromPackedArray` lets `$display` skip the view
bridge.

The shape-preservation bugs that surfaced during this consolidation
(`operator-` unary, `LogicalShiftRight`, shift-by-overflow, `Power` with
negative exponent on non-unit base, plus the `OneBitResult` callers) are
all fixed alongside.

## Testing

Six new `packed_*_logic_ops` suite tests parallel the existing
`scalar_*_int` suites and cover arithmetic, unary, comparison, logical,
shift, and power on 4-state operands -- each bug surfaced in this PR has a
regression test inside its natural suite. All `packed_*` value-verification
tests (22 total, format tests excluded) are migrated from
`$display`/stdout-exact matching to `expect.variables`, which handles
4-state via SV-literal syntax and removes the dependency on print
formatting for value checks.

`bazel test //... --test_output=errors` is green; clang-format,
buildifier, prettier, and the four policy scripts all pass.