### PR TITLE
Propagate X/Z through packed integral operators

### DIFF
--- a/docs/progress/integral.md
+++ b/docs/progress/integral.md
@@ -11,9 +11,8 @@ Done when:
 - Every SystemVerilog integral type (`byte`, `shortint`, `int`, `longint`, `integer`, `time`, any
   `bit [N:0]`, any `logic [N:0]`, any `reg [N:0]`) emits as `lyra::value::PackedArray` and
   round-trips through `expect.variables`.
-- `RenderTypeAsCpp`, `RenderExprAsNative`, `RenderExprAsPackedTopLevel`,
-  `RenderRuntimeValueViewInit`, and related helpers no longer dispatch on `PackedArrayForm` or carry
-  separate native / container code paths.
+- `RenderTypeAsCpp`, the single `RenderExpr` path, `RenderRuntimeValueViewInit`, and related helpers
+  no longer dispatch on `PackedArrayForm` or carry separate native / container code paths.
 - The archive item set under `operators/binary`, `operators/unary`, `operators/shift_overflow`,
   `datatypes/integral`, `datatypes/packed`, `datatypes/wide_integral` reproduces.
 
@@ -39,13 +38,13 @@ emits `lyra::value::PackedArray` for every integral type. `RenderRuntimeValueVie
 `backend::cpp` continues to compile because variable declarations and `$display` are the only
 consumers that need PackedArray at this point.
 
-- [ ] J1 -- Add `lyra::value::PackedArray` class. Storage variant: inline word(s) for
+- [x] J1 -- Add `lyra::value::PackedArray` class. Storage variant: inline word(s) for
       `bit_width <= 64`, heap multi-word for `>64`; 4-state carries an unknown plane the same way.
-- [ ] J2 -- `RenderTypeAsCpp` returns `lyra::value::PackedArray` for every `PackedArrayType`,
+- [x] J2 -- `RenderTypeAsCpp` returns `lyra::value::PackedArray` for every `PackedArrayType`,
       regardless of `form`. Catch-all unrenderable type returns `diag::Unsupported`.
-- [ ] J3 -- Container init helper retires (only `PackedArray` exists; every integral declares with
+- [x] J3 -- Container init helper retires (only `PackedArray` exists; every integral declares with
       `{bit_width, is_signed, is_four_state}`).
-- [ ] J4 -- `RenderRuntimeValueViewInit` produces its `RuntimeValueView` from `PackedArray`.
+- [x] J4 -- `RenderRuntimeValueViewInit` produces its `RuntimeValueView` from `PackedArray`.
       `NarrowIntegral` / `FromBitView` / `FromLogicView` becomes one path.
 - [ ] J5 -- `tests/cases/cpp/` declaration cases for `byte` / `shortint` / `longint` / `time` /
       `integer` (with X/Z); update / replace any existing tests that asserted native-int output
@@ -56,16 +55,17 @@ consumers that need PackedArray at this point.
 Add operator overloads / methods so cpp emit can render `BinaryExpr` and `UnaryExpr` directly
 against `PackedArray`. The dispatch in `RenderExpr*` collapses to a single path.
 
-- [ ] J6 -- Bitwise (`&`, `|`, `^`, `~^`, `~`) as member operators or method on `PackedArray`.
-- [ ] J7 -- Arithmetic (`+`, `-`, `*`, `/`, `%`, `**`) with LRM corner cases (div-by-zero, power
-      semantics).
-- [ ] J8 -- Comparison (`==`, `!=`, `<`, `<=`, `>`, `>=`) returning a 1-bit `PackedArray`.
-- [ ] J9 -- Shift (`<<`, `>>`, `>>>`) with LRM overflow (`amount >= bit_width` yields 0 /
+- [x] J6 -- Bitwise (`&`, `|`, `^`, `~^`, `~`) as member operators or method on `PackedArray`.
+- [x] J7 -- Arithmetic (`+`, `-`, `*`, `/`, `%`, `**`) with LRM corner cases (div-by-zero, power
+      semantics). Narrow (`<=64`) only; wide arithmetic still throws `InternalError`.
+- [x] J8 -- Comparison (`==`, `!=`, `<`, `<=`, `>`, `>=`) returning a 1-bit `PackedArray`.
+- [x] J9 -- Shift (`<<`, `>>`, `>>>`) with LRM overflow (`amount >= bit_width` yields 0 /
       sign-fill).
-- [ ] J10 -- Logical (`&&`, `||`, `!`, `->`, `<->`) returning a 1-bit `PackedArray`.
-- [ ] J11 -- Reduction (`&a`, `|a`, `^a`, `~&a`, `~|a`, `~^a`) as `PackedArray` methods.
-- [ ] J12 -- 4-state X/Z propagation across all the above. (May land per op-family rather than all
-      at once.)
+- [x] J10 -- Logical (`&&`, `||`, `!`) returning a 1-bit `PackedArray`. `->` and `<->` are a
+      separate scalar-emit token wiring step tracked in `operators.md`.
+- [x] J11 -- Reduction (`&a`, `|a`, `^a`, `~&a`, `~|a`, `~^a`) as `PackedArray` methods.
+- [x] J12 -- 4-state X/Z propagation across arithmetic, comparison, shift, power, logical, and unary
+      `-`. Bitwise / reduction already propagate via the view-based truth-table path. Narrow only.
 - [ ] J13 -- Archive sweep: reproduce `operators/binary/default.yaml`, `operators/unary/...`,
       `operators/shift_overflow/...`, and their `four_state.yaml` companions.
 
@@ -74,9 +74,9 @@ against `PackedArray`. The dispatch in `RenderExpr*` collapses to a single path.
 Remove `RenderExprAsNative` / `RenderExprAsPackedTopLevel` split. Single `RenderExpr` path, single
 `ConversionExpr` arm.
 
-- [ ] J14 -- One `RenderExpr` path. `IsPackedExplicit`, `NeedsRuntimeContainerInit`, the
+- [x] J14 -- One `RenderExpr` path. `IsPackedExplicit`, `NeedsRuntimeContainerInit`, the
       `MakeBitView` / `BitViewToInt64` bridges (if they exist by then) all retire.
-- [ ] J15 -- `ConversionExpr` collapses to "construct a destination `PackedArray` from a source
+- [x] J15 -- `ConversionExpr` collapses to "construct a destination `PackedArray` from a source
       `PackedArray`" -- one case, handled by `PackedArray` itself.
 
 ## Cross-references
@@ -90,8 +90,9 @@ Remove `RenderExprAsNative` / `RenderExprAsPackedTopLevel` split. Single `Render
 - Slang reference: `slang/ast/types/AllTypes.h:IntegralType`.
 - Legacy archive reference: `archived/include/lyra/common/type.hpp:IntegralInfo`.
 
-## Supersedes
+## Relationship to `operators.md`
 
-`operators.md` -- its B1-B7 / U1-U4 sub-steps were scoped to the narrow native path; the work plan
-here covers the whole integral surface and subsumes them. `operators.md` will be deleted as part of
-Cut 1's first PR.
+`operators.md` now tracks the scalar-emit residue that the integral runtime does not own: items that
+need either a new HIR/MIR shape (`++`/`--`) or a cpp-emit token rewrite (`~^` / `^~` binary, `->`,
+`<->`, scalar reductions on `int`). The runtime side of every other binary / unary operator family,
+including 4-state X/Z propagation, lives here.

--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -1,44 +1,35 @@
 # Operators
 
-Tracks scalar expression-operator work against `backend::cpp`. Covers archive items that share the
-native render path (`RenderExprAsNative` in `src/lyra/backend/cpp/render_expr.cpp`):
-`operators/binary`, `operators/unary`, `operators/shift_overflow`. Each archive item checkbox in
-`architecture-reset.md` is checked when its `*.yaml` cases reproduce on the current pipeline.
+Tracks scalar emit-token wiring and HIR/MIR shape work for operators that the unified
+`lyra::value::PackedArray` runtime does not by itself cover. The integral runtime side --
+arithmetic, comparison, shift, power, logical, reduction, bitwise, including 4-state X/Z propagation
+-- is tracked in `integral.md`. This file is the home for the items that need either a new MIR shape
+or a cpp-emit token rewrite. Each archive item checkbox in `architecture-reset.md` is checked when
+its `*.yaml` cases reproduce on the current pipeline.
 
 ## Sub-Steps
 
 ### Unary
 
-- [x] U1 -- Scalar unary token wiring on `int`: `+`, `-`, `!`, `~`. Mirrors B1's structure via
-      `UnaryOpToken` in `src/lyra/backend/cpp/render_expr.cpp`. Negative-literal shapes such as
-      `int a = -7;` now flow through cpp emit; reductions remain Unsupported (see U3).
+- [x] U1 -- Scalar unary token wiring on `int`: `+`, `-`, `!`, `~`. Via `UnaryOpToken` in
+      `src/lyra/backend/cpp/render_expr.cpp`.
 - [ ] U2 -- Pre/post increment `++`/`--`. Current `hir::UnaryOp`/`mir::UnaryOp` enums have no
       inc/dec variant; needs HIR/MIR shape decision (statement-level vs expression-level given SV
       side-effect ordering).
 - [ ] U3 -- Scalar reductions on `int` operand (`&a`, `|a`, `^a`, `~&a`, `~|a`, `~^a` when `a` is
-      `int`). Reduction unary works today only for packed lvalues via `RenderPackedReductionAssign`.
-- [ ] U4 -- 4-state unary X/Z propagation (`operators/unary/four_state.yaml`). Depends on
-      `logic`-operand unary path through the packed runtime.
+      `int`). The reduction method exists on `PackedArray`; only the cpp-emit token mapping for the
+      narrow `int` shape needs to route through it.
 
 ### Binary
 
 - [x] B1 -- Scalar token wiring for binary ops with direct C++ counterparts on `int`/`int -> int`:
       `- * / % == != < <= > >= & | ^ && ||`. Extends `BinaryOpToken` in
       `src/lyra/backend/cpp/render_expr.cpp`.
-- [ ] B2 -- Scalar `~^`/`^~` (bitwise XNOR): rewrite as `~(lhs ^ rhs)` in the native render path. No
-      new MIR shape.
+- [ ] B2 -- Scalar `~^`/`^~` (bitwise XNOR) as a binary operator (reductions of these tokens already
+      work). The runtime side is `PackedArray::BitwiseXnor`; only the emit-token mapping from
+      `mir::BinaryOp` is missing.
 - [ ] B3 -- Scalar `->` (implication) and `<->` (equivalence): rewrite to `(!(lhs) || (rhs))` and
-      `(!(lhs)) == (!(rhs))`.
-- [ ] B4 -- Scalar shifts `<<`, `>>`, `>>>` with LRM overflow semantics (`x << n` with `n >= width`
-      yields 0; signed `>>>` is arithmetic). Closes `operators/shift_overflow` in
-      `architecture-reset.md` as a side-effect.
-- [ ] B5 -- Integer power `**`: runtime helper with LRM corner cases (`0**0 = 1`, negative exponent
-      yields 0).
-- [ ] B6 -- Mixed-width / packed-literal operands (`byte + int`, `32'h... < int`): route through the
-      packed top-level binary path, not native `int` token path. Closes archived cases
-      `addition_bit_and_int`, `comparison_signed_*`, `comparison_mixed_width_*`.
-- [ ] B7 -- 4-state X/Z propagation for binary ops (`operators/binary/four_state.yaml`). Depends on
-      a `logic`-operand binary path through the packed runtime.
+      `(!(lhs)) == (!(rhs))` in cpp emit, or add dedicated methods on `PackedArray`.
 
 ## Out of Scope
 
@@ -47,3 +38,5 @@ native render path (`RenderExprAsNative` in `src/lyra/backend/cpp/render_expr.cp
 - `operators/binary_string` -- string compare runtime helpers, separate item.
 - Concat, replicate, inside, compound assignment -- new MIR shapes; each is its own archive item and
   its own workstream.
+- Mixed-width and shift/power/4-state correctness on the integral runtime -- tracked in
+  `integral.md`.

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -104,11 +104,14 @@ class PackedArray {
   // `while`, and ternary conditions emitted as `if (cond.IsTruthy())`.
   [[nodiscard]] auto IsTruthy() const -> bool;
 
-  // Binary operators. Operands are assumed to share the same
-  // `(bit_width, is_signed, is_four_state)` shape (slang's promotion
-  // contract). Comparison and logical operators produce a 1-bit 2-state
-  // result. Shift operators take the amount as a separate PackedArray;
-  // the amount's attributes are self-determined per LRM 11.6.
+  // Drives LRM 11.4 X/Z propagation: arithmetic, comparison, shift, and
+  // power return all-X (or 1-bit X) when any operand has HasUnknown().
+  [[nodiscard]] auto HasUnknown() const -> bool;
+
+  // Operands are assumed to share the same shape (slang's promotion
+  // contract). Comparison / logical results are 1-bit, 4-state when any
+  // operand is 4-state (so they can carry an X under LRM 11.4
+  // propagation). Shift amounts are self-determined per LRM 11.6.
   [[nodiscard]] auto operator+(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator-(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator*(const PackedArray& other) const -> PackedArray;

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -252,8 +252,23 @@ auto PackedArray::ToInt64() const -> std::int64_t {
 }
 
 auto PackedArray::IsTruthy() const -> bool {
+  // LRM 12.4: X/Z bits do not count as truthy; only a definitively-one
+  // bit (value=1 with unknown=0) makes an `if`/`while`/ternary take its
+  // true branch.
+  const auto vw = ValueWords();
+  const auto uw = UnknownWords();
+  for (std::size_t i = 0; i < vw.size(); ++i) {
+    const std::uint64_t unk = i < uw.size() ? uw[i] : 0U;
+    if ((vw[i] & ~unk) != 0U) {
+      return true;
+    }
+  }
+  return false;
+}
+
+auto PackedArray::HasUnknown() const -> bool {
   return std::ranges::any_of(
-      ValueWords(), [](std::uint64_t w) { return w != 0U; });
+      UnknownWords(), [](std::uint64_t w) { return w != 0U; });
 }
 
 auto PackedArray::ConvertFrom(
@@ -294,22 +309,43 @@ auto WidthOnlyNarrow(const PackedArray& v, std::string_view op) -> void {
         std::string{op} +
         ": wide (>64-bit) packed integral operator not yet implemented");
   }
-  // 4-state narrow arithmetic runs on the value plane only; if the unknown
-  // plane is non-zero, the result loses X/Z semantics. TODO(hankhsu): add
-  // full X/Z propagation for narrow 4-state arithmetic.
 }
 
 auto NarrowWordOf(const PackedArray& v) -> std::uint64_t {
   return v.ValueWords()[0] & MaskForWidth(v.BitWidth());
 }
 
-// Build a 1-bit result for comparison / logical ops. The result's
-// state-kind must match the operand's so the value can be assigned back to
-// a same-shape target without a shape-mismatch crash. (X/Z propagation in
-// the value is a separate concern under WidthOnlyNarrow's TODO; this helper
-// only fixes the shape.)
+// Encodes a known 0/1 only; for results that must be X under LRM 11.4
+// propagation, use AllX(1U, false) instead.
 auto OneBitResult(bool flag, bool is_four_state) -> PackedArray {
   return PackedArray::FromInt(flag ? 1 : 0, 1U, false, is_four_state);
+}
+
+// LRM 11.4 X/Z propagation result: a 4-state default ctor leaves the
+// unknown plane all-1, which is the all-X value.
+auto AllX(std::uint64_t bit_width, bool is_signed) -> PackedArray {
+  return PackedArray{bit_width, is_signed, true};
+}
+
+enum class Truthiness : std::uint8_t { kKnownZero, kKnownNonzero, kUnknown };
+
+// LRM 11.4.7 truth value. kKnownNonzero requires a definitively-one bit
+// (no other 1 dominates), so `(1, X, X, X)` is kKnownNonzero but
+// `(X, X, X, X)` is kUnknown.
+auto TruthinessOf(const PackedArray& v) -> Truthiness {
+  const auto vw = v.ValueWords();
+  const auto uw = v.UnknownWords();
+  bool has_unknown_bit = false;
+  for (std::size_t i = 0; i < vw.size(); ++i) {
+    const std::uint64_t unk = i < uw.size() ? uw[i] : 0U;
+    if ((vw[i] & ~unk) != 0U) {
+      return Truthiness::kKnownNonzero;
+    }
+    if (unk != 0U) {
+      has_unknown_bit = true;
+    }
+  }
+  return has_unknown_bit ? Truthiness::kUnknown : Truthiness::kKnownZero;
 }
 
 }  // namespace
@@ -317,6 +353,9 @@ auto OneBitResult(bool flag, bool is_four_state) -> PackedArray {
 auto PackedArray::operator+(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator+");
   WidthOnlyNarrow(*this, "operator+");
+  if (HasUnknown() || other.HasUnknown()) {
+    return AllX(bit_width_, is_signed_);
+  }
   const auto mask = MaskForWidth(bit_width_);
   const auto sum = (NarrowWordOf(*this) + NarrowWordOf(other)) & mask;
   return FromInt(
@@ -326,6 +365,9 @@ auto PackedArray::operator+(const PackedArray& other) const -> PackedArray {
 auto PackedArray::operator-(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator-");
   WidthOnlyNarrow(*this, "operator-");
+  if (HasUnknown() || other.HasUnknown()) {
+    return AllX(bit_width_, is_signed_);
+  }
   const auto mask = MaskForWidth(bit_width_);
   const auto diff = (NarrowWordOf(*this) - NarrowWordOf(other)) & mask;
   return FromInt(
@@ -335,6 +377,9 @@ auto PackedArray::operator-(const PackedArray& other) const -> PackedArray {
 auto PackedArray::operator*(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator*");
   WidthOnlyNarrow(*this, "operator*");
+  if (HasUnknown() || other.HasUnknown()) {
+    return AllX(bit_width_, is_signed_);
+  }
   const auto mask = MaskForWidth(bit_width_);
   const auto product = (NarrowWordOf(*this) * NarrowWordOf(other)) & mask;
   return FromInt(
@@ -345,6 +390,9 @@ auto PackedArray::operator*(const PackedArray& other) const -> PackedArray {
 auto PackedArray::operator/(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator/");
   WidthOnlyNarrow(*this, "operator/");
+  if (HasUnknown() || other.HasUnknown()) {
+    return AllX(bit_width_, is_signed_);
+  }
   const auto rhs = other.ToInt64();
   if (rhs == 0) {
     // SV LRM 11.4.4: integer division by zero on 4-state yields X for every
@@ -365,6 +413,9 @@ auto PackedArray::operator/(const PackedArray& other) const -> PackedArray {
 auto PackedArray::operator%(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator%");
   WidthOnlyNarrow(*this, "operator%");
+  if (HasUnknown() || other.HasUnknown()) {
+    return AllX(bit_width_, is_signed_);
+  }
   const auto rhs = other.ToInt64();
   if (rhs == 0) {
     // See operator/'s div-by-zero note: deliberate use of the default ctor's
@@ -479,6 +530,9 @@ auto PackedArray::BitwiseXnor(const PackedArray& other) const -> PackedArray {
 auto PackedArray::operator==(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator==");
   WidthOnlyNarrow(*this, "operator==");
+  if (HasUnknown() || other.HasUnknown()) {
+    return AllX(1U, false);
+  }
   return OneBitResult(
       NarrowWordOf(*this) == NarrowWordOf(other), is_four_state_);
 }
@@ -486,6 +540,9 @@ auto PackedArray::operator==(const PackedArray& other) const -> PackedArray {
 auto PackedArray::operator!=(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator!=");
   WidthOnlyNarrow(*this, "operator!=");
+  if (HasUnknown() || other.HasUnknown()) {
+    return AllX(1U, false);
+  }
   return OneBitResult(
       NarrowWordOf(*this) != NarrowWordOf(other), is_four_state_);
 }
@@ -493,6 +550,9 @@ auto PackedArray::operator!=(const PackedArray& other) const -> PackedArray {
 auto PackedArray::operator<(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator<");
   WidthOnlyNarrow(*this, "operator<");
+  if (HasUnknown() || other.HasUnknown()) {
+    return AllX(1U, false);
+  }
   if (is_signed_) {
     return OneBitResult(ToInt64() < other.ToInt64(), is_four_state_);
   }
@@ -503,6 +563,9 @@ auto PackedArray::operator<(const PackedArray& other) const -> PackedArray {
 auto PackedArray::operator<=(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator<=");
   WidthOnlyNarrow(*this, "operator<=");
+  if (HasUnknown() || other.HasUnknown()) {
+    return AllX(1U, false);
+  }
   if (is_signed_) {
     return OneBitResult(ToInt64() <= other.ToInt64(), is_four_state_);
   }
@@ -513,6 +576,9 @@ auto PackedArray::operator<=(const PackedArray& other) const -> PackedArray {
 auto PackedArray::operator>(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator>");
   WidthOnlyNarrow(*this, "operator>");
+  if (HasUnknown() || other.HasUnknown()) {
+    return AllX(1U, false);
+  }
   if (is_signed_) {
     return OneBitResult(ToInt64() > other.ToInt64(), is_four_state_);
   }
@@ -523,6 +589,9 @@ auto PackedArray::operator>(const PackedArray& other) const -> PackedArray {
 auto PackedArray::operator>=(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator>=");
   WidthOnlyNarrow(*this, "operator>=");
+  if (HasUnknown() || other.HasUnknown()) {
+    return AllX(1U, false);
+  }
   if (is_signed_) {
     return OneBitResult(ToInt64() >= other.ToInt64(), is_four_state_);
   }
@@ -532,6 +601,9 @@ auto PackedArray::operator>=(const PackedArray& other) const -> PackedArray {
 
 auto PackedArray::operator-() const -> PackedArray {
   WidthOnlyNarrow(*this, "operator- (unary)");
+  if (HasUnknown()) {
+    return AllX(bit_width_, is_signed_);
+  }
   const auto mask = MaskForWidth(bit_width_);
   return FromInt(
       static_cast<std::int64_t>((-NarrowWordOf(*this)) & mask), bit_width_,
@@ -558,29 +630,42 @@ auto PackedArray::operator~() const -> PackedArray {
   return result;
 }
 
-namespace {
-
-auto IsNonZero(const PackedArray& v) -> bool {
-  return std::ranges::any_of(
-      v.ValueWords(), [](std::uint64_t w) { return w != 0U; });
-}
-
-}  // namespace
-
 auto PackedArray::LogicalAnd(const PackedArray& other) const -> PackedArray {
-  return OneBitResult(
-      IsNonZero(*this) && IsNonZero(other),
-      is_four_state_ || other.is_four_state_);
+  const auto a = TruthinessOf(*this);
+  const auto b = TruthinessOf(other);
+  const bool result_four_state = is_four_state_ || other.is_four_state_;
+  if (a == Truthiness::kKnownZero || b == Truthiness::kKnownZero) {
+    return OneBitResult(false, result_four_state);
+  }
+  if (a == Truthiness::kKnownNonzero && b == Truthiness::kKnownNonzero) {
+    return OneBitResult(true, result_four_state);
+  }
+  return AllX(1U, false);
 }
 
 auto PackedArray::LogicalOr(const PackedArray& other) const -> PackedArray {
-  return OneBitResult(
-      IsNonZero(*this) || IsNonZero(other),
-      is_four_state_ || other.is_four_state_);
+  const auto a = TruthinessOf(*this);
+  const auto b = TruthinessOf(other);
+  const bool result_four_state = is_four_state_ || other.is_four_state_;
+  if (a == Truthiness::kKnownNonzero || b == Truthiness::kKnownNonzero) {
+    return OneBitResult(true, result_four_state);
+  }
+  if (a == Truthiness::kKnownZero && b == Truthiness::kKnownZero) {
+    return OneBitResult(false, result_four_state);
+  }
+  return AllX(1U, false);
 }
 
 auto PackedArray::LogicalNot() const -> PackedArray {
-  return OneBitResult(!IsNonZero(*this), is_four_state_);
+  switch (TruthinessOf(*this)) {
+    case Truthiness::kKnownZero:
+      return OneBitResult(true, is_four_state_);
+    case Truthiness::kKnownNonzero:
+      return OneBitResult(false, is_four_state_);
+    case Truthiness::kUnknown:
+      return AllX(1U, false);
+  }
+  throw InternalError("LogicalNot: unhandled Truthiness");
 }
 
 namespace {
@@ -596,26 +681,44 @@ auto ShiftAmountAsUint(const PackedArray& amount) -> std::uint64_t {
 
 auto PackedArray::ShiftLeft(const PackedArray& amount) const -> PackedArray {
   WidthOnlyNarrow(*this, "ShiftLeft");
+  // LRM 11.4.10: X/Z in the amount yields an all-X result; X/Z in the
+  // value rides along by shifting the unknown plane in parallel.
+  if (amount.HasUnknown()) {
+    return AllX(bit_width_, is_signed_);
+  }
   const auto amt = ShiftAmountAsUint(amount);
   if (amt >= bit_width_) {
     return FromInt(0, bit_width_, is_signed_, is_four_state_);
   }
   const auto mask = MaskForWidth(bit_width_);
-  return FromInt(
-      static_cast<std::int64_t>((NarrowWordOf(*this) << amt) & mask),
-      bit_width_, is_signed_, is_four_state_);
+  const auto new_value = (NarrowWordOf(*this) << amt) & mask;
+  if (!is_four_state_) {
+    return FromInt(
+        static_cast<std::int64_t>(new_value), bit_width_, is_signed_, false);
+  }
+  const auto unk_word = UnknownWords()[0] & mask;
+  const auto new_unknown = (unk_word << amt) & mask;
+  return FromWords({new_value}, {new_unknown}, bit_width_, is_signed_, true);
 }
 
 auto PackedArray::LogicalShiftRight(const PackedArray& amount) const
     -> PackedArray {
   WidthOnlyNarrow(*this, "LogicalShiftRight");
+  if (amount.HasUnknown()) {
+    return AllX(bit_width_, is_signed_);
+  }
   const auto amt = ShiftAmountAsUint(amount);
   if (amt >= bit_width_) {
     return FromInt(0, bit_width_, is_signed_, is_four_state_);
   }
-  return FromInt(
-      static_cast<std::int64_t>(NarrowWordOf(*this) >> amt), bit_width_,
-      is_signed_, is_four_state_);
+  const auto new_value = NarrowWordOf(*this) >> amt;
+  if (!is_four_state_) {
+    return FromInt(
+        static_cast<std::int64_t>(new_value), bit_width_, is_signed_, false);
+  }
+  const auto unk_word = UnknownWords()[0] & MaskForWidth(bit_width_);
+  const auto new_unknown = unk_word >> amt;
+  return FromWords({new_value}, {new_unknown}, bit_width_, is_signed_, true);
 }
 
 auto PackedArray::ArithmeticShiftRight(const PackedArray& amount) const
@@ -624,22 +727,49 @@ auto PackedArray::ArithmeticShiftRight(const PackedArray& amount) const
   if (!is_signed_) {
     return LogicalShiftRight(amount);
   }
+  if (amount.HasUnknown()) {
+    return AllX(bit_width_, is_signed_);
+  }
   const auto amt = ShiftAmountAsUint(amount);
   const auto signed_value = ToInt64();
   if (amt >= bit_width_) {
     return FromInt(signed_value < 0 ? -1 : 0, bit_width_, true, is_four_state_);
   }
-  return FromInt(signed_value >> amt, bit_width_, true, is_four_state_);
+  if (!is_four_state_) {
+    return FromInt(signed_value >> amt, bit_width_, true, false);
+  }
+  // Each plane shifts with its own MSB as the fill, so an X at the top
+  // extends down into the new top bits instead of degenerating to the
+  // value-plane sign.
+  const auto mask = MaskForWidth(bit_width_);
+  const auto value_shifted =
+      static_cast<std::uint64_t>(signed_value >> amt) & mask;
+  const auto unk_word = UnknownWords()[0] & mask;
+  std::uint64_t unk_shifted = unk_word >> amt;
+  if ((unk_word >> (bit_width_ - 1U)) != 0U) {
+    const auto fill_mask = mask & ~MaskForWidth(bit_width_ - amt);
+    unk_shifted |= fill_mask;
+  }
+  unk_shifted &= mask;
+  return FromWords({value_shifted}, {unk_shifted}, bit_width_, true, true);
 }
 
 auto PackedArray::Power(const PackedArray& exponent) const -> PackedArray {
   WidthOnlyNarrow(*this, "Power");
   WidthOnlyNarrow(exponent, "Power");
-  const auto base = ToInt64();
+  // The exponent is checked before the base so that `X ** 0 = 1` wins
+  // over X-propagation from the base (LRM 11.4.10).
+  if (exponent.HasUnknown()) {
+    return AllX(bit_width_, is_signed_);
+  }
   const auto exp = exponent.ToInt64();
   if (exp == 0) {
     return FromInt(1, bit_width_, is_signed_, is_four_state_);
   }
+  if (HasUnknown()) {
+    return AllX(bit_width_, is_signed_);
+  }
+  const auto base = ToInt64();
   if (exp < 0) {
     if (base == 1) return FromInt(1, bit_width_, is_signed_, is_four_state_);
     if (base == -1) {

--- a/tests/cases/cpp/packed_arithmetic_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_arithmetic_logic_ops/case.yaml
@@ -16,3 +16,8 @@ expect:
     div_pos: 25
     div_neg: -25
     mod_: 2
+    add_xz: "8'bxxxxxxxx"
+    sub_xz: "8'bxxxxxxxx"
+    mul_xz: "8'bxxxxxxxx"
+    div_xz: "8'bxxxxxxxx"
+    mod_xz: "8'bxxxxxxxx"

--- a/tests/cases/cpp/packed_arithmetic_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_arithmetic_logic_ops/main.sv
@@ -7,6 +7,11 @@ module Top;
   logic signed [7:0] div_pos;
   logic signed [7:0] div_neg;
   logic signed [7:0] mod_;
+  logic signed [7:0] add_xz;
+  logic signed [7:0] sub_xz;
+  logic signed [7:0] mul_xz;
+  logic signed [7:0] div_xz;
+  logic signed [7:0] mod_xz;
   initial begin
     logic signed [7:0] a;
     logic signed [7:0] b;
@@ -24,5 +29,11 @@ module Top;
     div_neg = a / b;
     a = 17; b = 5;
     mod_ = a % b;
+    a = 8'b000000xz; b = 8'b00000010;
+    add_xz = a + b;
+    sub_xz = a - b;
+    mul_xz = a * b;
+    div_xz = a / b;
+    mod_xz = a % b;
   end
 endmodule

--- a/tests/cases/cpp/packed_comparison_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_comparison_logic_ops/case.yaml
@@ -14,3 +14,9 @@ expect:
     le_: 1
     gt_: 1
     ge_: 1
+    eq_xz: "1'bx"
+    neq_xz: "1'bx"
+    lt_xz: "1'bx"
+    le_xz: "1'bx"
+    gt_xz: "1'bx"
+    ge_xz: "1'bx"

--- a/tests/cases/cpp/packed_comparison_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_comparison_logic_ops/main.sv
@@ -1,6 +1,8 @@
 module Top;
   logic eq_, neq_;
   logic lt_, le_, gt_, ge_;
+  logic eq_xz, neq_xz;
+  logic lt_xz, le_xz, gt_xz, ge_xz;
   initial begin
     logic signed [7:0] a;
     logic signed [7:0] b;
@@ -16,5 +18,12 @@ module Top;
     gt_ = (a > b);
     a = -1; b = -1;
     ge_ = (a >= b);
+    a = 8'b000000xz; b = 8'b00000010;
+    eq_xz = (a == b);
+    neq_xz = (a != b);
+    lt_xz = (a < b);
+    le_xz = (a <= b);
+    gt_xz = (a > b);
+    ge_xz = (a >= b);
   end
 endmodule

--- a/tests/cases/cpp/packed_logical_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_logical_logic_ops/case.yaml
@@ -16,3 +16,10 @@ expect:
     or_ff: 0
     not_t: 0
     not_f: 1
+    and_zero_dominates: 0
+    and_one_with_x: "1'bx"
+    and_x_x: "1'bx"
+    or_one_dominates: 1
+    or_zero_with_x: "1'bx"
+    or_x_x: "1'bx"
+    not_x: "1'bx"

--- a/tests/cases/cpp/packed_logical_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_logical_logic_ops/main.sv
@@ -2,6 +2,9 @@ module Top;
   logic and_tt, and_tf, and_ff;
   logic or_tt, or_tf, or_ff;
   logic not_t, not_f;
+  logic and_zero_dominates, and_one_with_x, and_x_x;
+  logic or_one_dominates, or_zero_with_x, or_x_x;
+  logic not_x;
   initial begin
     logic [3:0] a;
     logic [3:0] b;
@@ -21,5 +24,19 @@ module Top;
     not_t = !a;
     a = 4'b0000;
     not_f = !a;
+    a = 4'b0000; b = 4'bxxxx;
+    and_zero_dominates = a && b;
+    a = 4'b0001; b = 4'bxxxx;
+    and_one_with_x = a && b;
+    a = 4'bxxxx; b = 4'bxxxx;
+    and_x_x = a && b;
+    a = 4'b0001; b = 4'bxxxx;
+    or_one_dominates = a || b;
+    a = 4'b0000; b = 4'bxxxx;
+    or_zero_with_x = a || b;
+    a = 4'bxxxx; b = 4'bxxxx;
+    or_x_x = a || b;
+    a = 4'bxxxx;
+    not_x = !a;
   end
 endmodule

--- a/tests/cases/cpp/packed_power_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_power_logic_ops/case.yaml
@@ -14,3 +14,6 @@ expect:
     pow_neg_one_base_even_neg_exp: 1
     pow_neg_one_base_odd_neg_exp: -1
     pow_neg_exp_zero_result: 0
+    pow_base_x: "16'bxxxxxxxxxxxxxxxx"
+    pow_exp_x: "16'bxxxxxxxxxxxxxxxx"
+    pow_x_to_zero: 1

--- a/tests/cases/cpp/packed_power_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_power_logic_ops/main.sv
@@ -5,6 +5,9 @@ module Top;
   logic signed [15:0] pow_neg_one_base_even_neg_exp;
   logic signed [15:0] pow_neg_one_base_odd_neg_exp;
   logic signed [15:0] pow_neg_exp_zero_result;
+  logic signed [15:0] pow_base_x;
+  logic signed [15:0] pow_exp_x;
+  logic signed [15:0] pow_x_to_zero;
   initial begin
     logic signed [15:0] a;
     logic signed [15:0] b;
@@ -20,5 +23,11 @@ module Top;
     pow_neg_one_base_odd_neg_exp = a ** b;
     a = 2; b = -3;
     pow_neg_exp_zero_result = a ** b;
+    a = 16'bxxxxxxxxxxxxxxxx; b = 2;
+    pow_base_x = a ** b;
+    a = 2; b = 16'bxxxxxxxxxxxxxxxx;
+    pow_exp_x = a ** b;
+    a = 16'bxxxxxxxxxxxxxxxx; b = 0;
+    pow_x_to_zero = a ** b;
   end
 endmodule

--- a/tests/cases/cpp/packed_shift_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_shift_logic_ops/case.yaml
@@ -14,3 +14,8 @@ expect:
     shr_arith_neg: "8'b11110011"
     shl_overflow: "4'b0000"
     shr_overflow: "4'b0000"
+    shl_amt_xz: "8'bxxxxxxxx"
+    shl_val_xz: "8'b011xx000"
+    shr_val_xz: "8'b01011xx0"
+    ashr_val_xz_neg: "8'b11011xx0"
+    ashr_msb_x: "8'bxxx00011"

--- a/tests/cases/cpp/packed_shift_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_shift_logic_ops/main.sv
@@ -5,6 +5,11 @@ module Top;
   logic signed [7:0] shr_arith_neg;
   logic [3:0] shl_overflow;
   logic [3:0] shr_overflow;
+  logic [7:0] shl_amt_xz;
+  logic [7:0] shl_val_xz;
+  logic [7:0] shr_val_xz;
+  logic signed [7:0] ashr_val_xz_neg;
+  logic signed [7:0] ashr_msb_x;
   initial begin
     logic [7:0] a;
     a = 8'b10110100;
@@ -22,6 +27,23 @@ module Top;
       x = 4'b1010;
       shl_overflow = x << 8;
       shr_overflow = x >> 8;
+    end
+    begin
+      logic [7:0] v;
+      logic [3:0] amt;
+      v = 8'b00000001;
+      amt = 4'bxxxx;
+      shl_amt_xz = v << amt;
+      v = 8'b1011xx00;
+      shl_val_xz = v << 1;
+      shr_val_xz = v >> 1;
+    end
+    begin
+      logic signed [7:0] s;
+      s = 8'sb1011xx00;
+      ashr_val_xz_neg = s >>> 1;
+      s = 8'sbx0001110;
+      ashr_msb_x = s >>> 2;
     end
   end
 endmodule

--- a/tests/cases/cpp/packed_unary_logic_ops/case.yaml
+++ b/tests/cases/cpp/packed_unary_logic_ops/case.yaml
@@ -13,3 +13,5 @@ expect:
     bitnot: "4'b0101"
     lognot_nonzero: 0
     lognot_zero: 1
+    neg_xz: "4'bxxxx"
+    lognot_xz: "1'bx"

--- a/tests/cases/cpp/packed_unary_logic_ops/main.sv
+++ b/tests/cases/cpp/packed_unary_logic_ops/main.sv
@@ -4,6 +4,8 @@ module Top;
   logic [3:0] bitnot;
   logic lognot_nonzero;
   logic lognot_zero;
+  logic [3:0] neg_xz;
+  logic lognot_xz;
   initial begin
     logic [3:0] a;
     a = 4'b1010;
@@ -13,5 +15,8 @@ module Top;
     lognot_nonzero = !a;
     a = 4'b0000;
     lognot_zero = !a;
+    a = 4'b00xx;
+    neg_xz = -a;
+    lognot_xz = !a;
   end
 endmodule


### PR DESCRIPTION
## Summary

Extends `lyra::value::PackedArray` so arithmetic, comparison, shift, power, and logical operators honor LRM 11.4 X/Z propagation rules. `HasUnknown()` is a new public predicate; operators short-circuit to all-X (or 1-bit X) when any operand carries an X or Z. Shifts also propagate X/Z bits through the value by shifting the unknown plane in parallel, with arithmetic right shift using each plane's own MSB as the fill. Logical AND/OR/NOT switch to a 3-valued truthiness with dominating-value rules. `IsTruthy()` -- used by emitted `if`/`while`/ternary conditions -- is fixed to ignore X/Z bits per LRM 12.4.

## Testing

Six `tests/cases/cpp/packed_*_logic_ops` suites grow X/Z cases for each op family (27 new variables total), driven by TDD: each case was written to fail before the implementation landed. Full `bazel test //...` is green.

## Doc updates

`docs/progress/integral.md` is brought current: J1-J4, J6-J12, J14-J15 are now checked; J5 (declaration tests) and J13 (archive sweep) remain. `docs/progress/operators.md` is reframed as the scalar-emit residue file -- it now tracks only the items the integral runtime does not own (`++`/`--`, `~^`/`^~` binary, `->`/`<->`, `int`-operand reductions).