### PR TITLE
Lower unique/priority if/case via deferred Observed-region check

### DIFF
--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -14,14 +14,13 @@ operator runtime, string runtime); see the per-item **Depends on** lines and the
 No open items are currently actionable inside this workstream alone. Every remaining item depends on
 machinery owned by another workstream; the table below lists the blockers.
 
-| Item    | Blocked on                                                                                                                                                                                                                                                                                                                                        |
-| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| C9, C10 | `datatypes/unpacked` (procedural unpacked array vars + `arr[i]` element-select expr).                                                                                                                                                                                                                                                             |
-| C11     | `operators/wildcard_equality` (masked-compare runtime helper for `==?` / `!=?`).                                                                                                                                                                                                                                                                  |
-| C12     | `operators/inside` (range patterns + set-membership runtime).                                                                                                                                                                                                                                                                                     |
-| C13     | A MIR action shape for deferred checks bound to the observed / reactive scheduling regions. The runtime reporting channel (severity, stderr routing, rate limit) is in place via the `$info` / `$warning` / `$error` work, so the remaining blocker is the deferred-callable machinery (and, when added, populating source locations end to end). |
-| C16     | `datatypes/enum`.                                                                                                                                                                                                                                                                                                                                 |
-| C17     | `datatypes/string` plus the string-equality runtime helper from `operators/binary_string`.                                                                                                                                                                                                                                                        |
+| Item    | Blocked on                                                                                 |
+| ------- | ------------------------------------------------------------------------------------------ |
+| C9, C10 | `datatypes/unpacked` (procedural unpacked array vars + `arr[i]` element-select expr).      |
+| C11     | `operators/wildcard_equality` (masked-compare runtime helper for `==?` / `!=?`).           |
+| C12     | `operators/inside` (range patterns + set-membership runtime).                              |
+| C16     | `datatypes/enum`.                                                                          |
+| C17     | `datatypes/string` plus the string-equality runtime helper from `operators/binary_string`. |
 
 ## Sub-Steps
 
@@ -87,17 +86,19 @@ machinery owned by another workstream; the table below lists the blockers.
 - [ ] C12 -- `case (... inside ...)`. Range patterns (`[lo:hi]`) and `inside` membership; lower to
       if/else cascade with `inside` semantics. **Depends on** `operators/inside` for the
       set-membership runtime.
-- [ ] C13 -- `unique` / `unique0` / `priority` qualifiers on `if` and `case`. The qualifier itself
-      is a single HIR / MIR enum field; the hard part is producing the warning without false
-      positives during combinational settle. SV's intended model is a deferred check: the qualifier
-      site records an observation at evaluation time, and a drain step after the settle epoch
-      classifies the final observation and emits at most one report per site. Covers archive items
-      `unique_priority_if` and `unique_priority_case`. The runtime reporting channel (severity-based
-      routing, rate limiting) landed alongside `$info` / `$warning` / `$error`, so the remaining
-      **dependency** is a MIR action shape for deferred checks bound to the observed / reactive
-      scheduling regions (`mir.md` forbids representing deferred behavior as a flag or lowering-pass
-      side effect, so the check must be an explicit callable invoked by the scheduler). End-to-end
-      source-location propagation also needs to land before warnings can pinpoint the failing site.
+- [x] C13 -- `unique` / `unique0` / `priority` qualifiers on `if` and `case`. HIR carries the
+      qualifier as an optional `UniquePriorityCheck` field on `IfStmt` / `CaseStmt`. HIR -> MIR
+      desugars the site into a `BlockStmt` that snapshots each branch's predicate into a fresh
+      procvar, hands a closure to the Observed region via `RuntimeSubmitObservedCall`, and renders
+      the original cascade as a plain `if`/`else if` chain reading the snapshots. The closure body
+      counts truthy snapshots and emits a warning through the existing `RuntimeDiagnosticCall` /
+      `LyraDiagnostic` path when the qualifier-specific predicate fires (`unique`: count != 1;
+      `unique0`: count > 1; `priority`: count == 0). The runtime drains `Module::observed_pending_`
+      per-object during `Engine::ExecuteObservedRegion`; re-submits at the same site within one time
+      slot collapse via vector-slot replacement, suppressing glitch-driven false positives. Covers
+      archive items `unique_priority_if` and `unique_priority_case`. Source-location propagation
+      still feeds `origin = nullopt`; the warning text reports the violation kind and the matched
+      count but not the file/line of the offending statement -- to be plumbed in a follow-up.
 - [x] C15 -- `case` with labels that are not compile-time constants (`case (sel) some_expr: ...`)
       and `case` with duplicate labels ("first match wins"). The uniform HIR -> MIR cascade
       described in C3 handles both: non-constant labels render as runtime `==` comparisons, and

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -40,10 +40,17 @@ struct BlockStmt {
   std::vector<StmtId> statements;
 };
 
+enum class UniquePriorityCheck : std::uint8_t {
+  kUnique,
+  kUnique0,
+  kPriority,
+};
+
 struct IfStmt {
   ExprId condition;
   StmtId then_stmt;
   std::optional<StmtId> else_stmt;
+  std::optional<UniquePriorityCheck> check;
 };
 
 struct CaseItem {
@@ -55,6 +62,7 @@ struct CaseStmt {
   ExprId condition;
   std::vector<CaseItem> items;
   std::optional<StmtId> default_stmt;
+  std::optional<UniquePriorityCheck> check;
 };
 
 struct ForInitDecl {

--- a/include/lyra/lowering/hir_to_mir/lower_deferred_check.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_deferred_check.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/process.hpp"
+#include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/stmt.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+struct DeferredCheckBranch {
+  mir::ExprId predicate;
+  mir::ProceduralScope body;
+};
+
+// Snapshots predicates into wrapper_state so the deferred closure body captures
+// stable, side-effect-free values rather than re-evaluating the source
+// expressions later. Caller stages wrapper_state with any prelude it needs
+// (case puts its selector snapshot there; unique-if passes a fresh wrapper)
+// and pre-lowers each body with the depth guards the cascade nesting requires.
+auto BuildDeferredCheckCascade(
+    const UnitLoweringState& unit_state,
+    ProceduralScopeLoweringState wrapper_state,
+    std::vector<DeferredCheckBranch> branches,
+    std::optional<mir::ProceduralScope> tail_else,
+    hir::UniquePriorityCheck check, std::optional<std::string> outer_label)
+    -> mir::Stmt;
+
+auto LowerUniqueIfStmt(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    const hir::Stmt& stmt, const hir::IfStmt& root) -> diag::Result<mir::Stmt>;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/lower_stmt.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_stmt.hpp
@@ -16,4 +16,15 @@ auto LowerStmt(
     const hir::Process& hir_proc, const hir::Stmt& stmt)
     -> diag::Result<mir::Stmt>;
 
+// Lowers a single HIR stmt into its own fresh ProceduralScope: pushes a
+// ProceduralDepthGuard so procvar refs inside see the correct hop count,
+// recursively invokes LowerStmt, and packages the result as the new scope's
+// sole root stmt. Used wherever a control-flow node needs a body / branch
+// scope (for, while, repeat, do-while, forever, if branches, case items).
+auto LowerStmtIntoChildScope(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    hir::StmtId hir_stmt_id) -> diag::Result<mir::ProceduralScope>;
+
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -18,6 +18,7 @@
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/procedural_var.hpp"
+#include "lyra/mir/runtime_submit.hpp"
 #include "lyra/mir/stmt.hpp"
 #include "lyra/mir/structural_hops.hpp"
 #include "lyra/mir/structural_param.hpp"
@@ -94,6 +95,16 @@ class UnitLoweringState {
 
   [[nodiscard]] auto Builtins() const -> const BuiltinMirTypes& {
     return builtins_;
+  }
+
+  // Allocates a fresh class-local DeferredCheckSiteId from the underlying
+  // CompilationUnit's counter. The method is const because UnitLoweringState's
+  // observable lowering state (type map, builtins) is unaffected; the counter
+  // lives on the unit and is mutated through the non-const pointer the wrapper
+  // already holds.
+  [[nodiscard]] auto AllocateDeferredCheckSiteId() const
+      -> mir::DeferredCheckSiteId {
+    return unit_->AllocateDeferredCheckSiteId();
   }
 
  private:

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -1,18 +1,30 @@
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
+#include "lyra/mir/runtime_submit.hpp"
 #include "lyra/mir/structural_scope.hpp"
 #include "lyra/mir/type.hpp"
 
 namespace lyra::mir {
 
+struct DeferredCheckSite {};
+
 struct CompilationUnit {
   std::vector<Type> types;
   StructuralScope structural_scope;
+  std::vector<DeferredCheckSite> deferred_check_sites;
 
   [[nodiscard]] auto GetType(TypeId id) const -> const Type& {
     return types.at(id.value);
+  }
+
+  // Backing-vector position is the id, matching TypeId / ProceduralVarId.
+  auto AllocateDeferredCheckSiteId() -> DeferredCheckSiteId {
+    const auto id = static_cast<std::uint32_t>(deferred_check_sites.size());
+    deferred_check_sites.push_back({});
+    return DeferredCheckSiteId{id};
   }
 };
 

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -13,6 +13,7 @@
 #include "lyra/mir/runtime_diagnostic.hpp"
 #include "lyra/mir/runtime_finish.hpp"
 #include "lyra/mir/runtime_print.hpp"
+#include "lyra/mir/runtime_submit.hpp"
 #include "lyra/mir/structural_param.hpp"
 #include "lyra/mir/structural_subroutine.hpp"
 #include "lyra/mir/type.hpp"
@@ -70,8 +71,9 @@ struct CallExpr {
   std::vector<ExprId> arguments;
 };
 
-using RuntimeCall =
-    std::variant<RuntimePrintCall, RuntimeDiagnosticCall, RuntimeFinishCall>;
+using RuntimeCall = std::variant<
+    RuntimePrintCall, RuntimeDiagnosticCall, RuntimeFinishCall,
+    RuntimeSubmitObservedCall>;
 
 struct RuntimeCallExpr {
   RuntimeCall call;

--- a/include/lyra/mir/runtime_submit.hpp
+++ b/include/lyra/mir/runtime_submit.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+#include "lyra/mir/expr_id.hpp"
+
+namespace lyra::mir {
+
+struct DeferredCheckSiteId {
+  std::uint32_t value;
+
+  auto operator<=>(const DeferredCheckSiteId&) const
+      -> std::strong_ordering = default;
+};
+
+// Re-submits at the same site_id within one time slot replace the prior
+// closure; this last-write-wins is the glitch-suppression mechanism for
+// deferred checks during combinational settle.
+struct RuntimeSubmitObservedCall {
+  DeferredCheckSiteId site_id;
+  ExprId closure;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -125,6 +125,7 @@ class Engine {
   RuntimeServices services_{stream_, diagnostic_};
   std::unique_ptr<RuntimeScope> root_;
   SchedulerQueues queues_;
+  std::vector<Module*> registered_modules_;
   SimTime now_ = 0;
   SchedulerPhase phase_ = SchedulerPhase::kIdle;
   std::size_t current_delta_ = 0;

--- a/include/lyra/runtime/module.hpp
+++ b/include/lyra/runtime/module.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <vector>
+
 namespace lyra::runtime {
 
 class RuntimeBindContext;
@@ -14,6 +18,16 @@ class Module {
   auto operator=(Module&&) -> Module& = delete;
 
   virtual void Bind(RuntimeBindContext& ctx) = 0;
+
+  // Last-write-wins per site within a time slot: re-submit at the same site
+  // overwrites the prior closure, which suppresses settle-time glitches.
+  void SubmitObserved(std::uint32_t site_id, std::function<void()> fn);
+
+  void DrainObserved();
+
+ private:
+  // Empty std::function == clean slot; no parallel dirty bitmap needed.
+  std::vector<std::function<void()>> observed_pending_;
 };
 
 }  // namespace lyra::runtime

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -11,6 +11,7 @@
 
 #include "lyra/backend/cpp/render_context.hpp"
 #include "lyra/backend/cpp/render_print.hpp"
+#include "lyra/backend/cpp/render_stmt.hpp"
 #include "lyra/backend/cpp/string_literal.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
@@ -243,6 +244,10 @@ auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
       target);
 }
 
+auto RenderClosureExpr(
+    const RenderContext& ctx, const mir::ClosureExpr& closure)
+    -> diag::Result<std::string>;
+
 auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
     -> diag::Result<std::string> {
   return std::visit(
@@ -352,14 +357,55 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
           [&](const mir::RuntimeCallExpr& rc) -> diag::Result<std::string> {
             return RenderRuntimeCallExpr(ctx, rc);
           },
-          [](const mir::ClosureExpr&) -> diag::Result<std::string> {
-            return diag::Unsupported(
-                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-                "ClosureExpr is not yet implemented in cpp emit",
-                diag::UnsupportedCategory::kFeature);
+          [&](const mir::ClosureExpr& cl) -> diag::Result<std::string> {
+            return RenderClosureExpr(ctx, cl);
           },
       },
       expr.data);
+}
+
+auto RenderClosureExpr(
+    const RenderContext& ctx, const mir::ClosureExpr& closure)
+    -> diag::Result<std::string> {
+  if (closure.body == nullptr) {
+    throw InternalError("RenderClosureExpr: closure has no body");
+  }
+
+  // Always capture `this` so the closure body can reach module-scope members
+  // (the emitted module class's services_ pointer, structural vars, the
+  // SubmitObserved / DrainObserved interface on the Module base). The
+  // explicit by-value captures from the MIR list go after.
+  std::string captures_text = "this";
+  for (std::size_t i = 0; i < closure.captures.size(); ++i) {
+    captures_text += ", ";
+    auto rendered_or = std::visit(
+        Overloaded{
+            [&](const mir::ByValueCapture& bv) -> diag::Result<std::string> {
+              const std::string& bind_name =
+                  closure.body->vars.at(bv.binding.value).name;
+              auto value_or = RenderExpr(ctx, ctx.Expr(bv.value));
+              if (!value_or) {
+                return std::unexpected(std::move(value_or.error()));
+              }
+              return bind_name + " = " + *value_or;
+            },
+            [](const mir::ByReferenceCapture&) -> diag::Result<std::string> {
+              return diag::Unsupported(
+                  diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+                  "by-reference capture is not yet implemented in cpp emit",
+                  diag::UnsupportedCategory::kFeature);
+            }},
+        closure.captures[i]);
+    if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
+    captures_text += *rendered_or;
+  }
+
+  const RenderContext body_ctx =
+      RenderContext::ForRoot(ctx.Unit(), ctx.StructuralScope(), *closure.body);
+  auto body_or = RenderProceduralScopeStatements(body_ctx, 1);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+
+  return "[" + captures_text + "]() {\n" + *body_or + "}";
 }
 
 auto RenderConditionAsBool(const RenderContext& ctx, const mir::Expr& expr)

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -254,6 +254,15 @@ auto RenderRuntimeCallExpr(
           [&](const mir::RuntimeFinishCall& fc) -> diag::Result<std::string> {
             return RenderRuntimeFinishCall(fc);
           },
+          [&](const mir::RuntimeSubmitObservedCall& sc)
+              -> diag::Result<std::string> {
+            auto closure_or = RenderExpr(ctx, ctx.Expr(sc.closure));
+            if (!closure_or) {
+              return std::unexpected(std::move(closure_or.error()));
+            }
+            return std::format(
+                "this->SubmitObserved({}, {})", sc.site_id.value, *closure_or);
+          },
       },
       expr.call);
 }

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <format>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -70,6 +71,20 @@ class HirDumper {
 
   static auto FormatSignedness(Signedness s) -> std::string_view {
     return s == Signedness::kSigned ? "signed" : "unsigned";
+  }
+
+  static auto FormatUniquePriorityCheck(
+      std::optional<UniquePriorityCheck> check) -> std::string {
+    if (!check.has_value()) return "";
+    switch (*check) {
+      case UniquePriorityCheck::kUnique:
+        return "[unique]";
+      case UniquePriorityCheck::kUnique0:
+        return "[unique0]";
+      case UniquePriorityCheck::kPriority:
+        return "[priority]";
+    }
+    throw InternalError("HirDumper::FormatUniquePriorityCheck: unknown check");
   }
 
   static auto FormatPackedForm(PackedArrayForm f) -> std::string_view {
@@ -626,8 +641,8 @@ class HirDumper {
             [&](const IfStmt& i) {
               Line(
                   std::format(
-                      "Stmt[{}] IfStmt cond=Expr[{}]", id.value,
-                      i.condition.value));
+                      "Stmt[{}] IfStmt{} cond=Expr[{}]", id.value,
+                      FormatUniquePriorityCheck(i.check), i.condition.value));
               Indent();
               Line(
                   std::format(
@@ -648,8 +663,9 @@ class HirDumper {
             [&](const CaseStmt& c) {
               Line(
                   std::format(
-                      "Stmt[{}] CaseStmt cond=Expr[{}] (items={})", id.value,
-                      c.condition.value, c.items.size()));
+                      "Stmt[{}] CaseStmt{} cond=Expr[{}] (items={})", id.value,
+                      FormatUniquePriorityCheck(c.check), c.condition.value,
+                      c.items.size()));
               Indent();
               Line(
                   std::format(

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -14,6 +14,7 @@
 #include <slang/ast/statements/MiscStatements.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 
+#include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/kind.hpp"
@@ -27,6 +28,22 @@
 namespace lyra::lowering::ast_to_hir {
 
 namespace {
+
+auto LowerUniquePriorityCheck(slang::ast::UniquePriorityCheck check)
+    -> std::optional<hir::UniquePriorityCheck> {
+  switch (check) {
+    case slang::ast::UniquePriorityCheck::None:
+      return std::nullopt;
+    case slang::ast::UniquePriorityCheck::Unique:
+      return hir::UniquePriorityCheck::kUnique;
+    case slang::ast::UniquePriorityCheck::Unique0:
+      return hir::UniquePriorityCheck::kUnique0;
+    case slang::ast::UniquePriorityCheck::Priority:
+      return hir::UniquePriorityCheck::kPriority;
+  }
+  throw InternalError(
+      "LowerUniquePriorityCheck: unknown slang UniquePriorityCheck value");
+}
 
 auto LowerTimingControl(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
@@ -286,12 +303,7 @@ auto LowerStatement(
             "casez/casex/case-inside are not yet supported",
             diag::UnsupportedCategory::kFeature);
       }
-      if (cs.check != slang::ast::UniquePriorityCheck::None) {
-        return diag::Unsupported(
-            span, diag::DiagCode::kUnsupportedStatementForm,
-            "unique/priority qualifiers on case are not yet supported",
-            diag::UnsupportedCategory::kFeature);
-      }
+      const auto case_check = LowerUniquePriorityCheck(cs.check);
       auto cond_expr = LowerProcExpr(
           unit_facts, scope_state.UnitState(), proc_state, stack, cs.expr);
       if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
@@ -330,18 +342,14 @@ auto LowerStatement(
               hir::CaseStmt{
                   .condition = cond_id,
                   .items = std::move(items),
-                  .default_stmt = default_id},
+                  .default_stmt = default_id,
+                  .check = case_check},
           .span = span};
     }
 
     case slang::ast::StatementKind::Conditional: {
       const auto& cs = stmt.as<slang::ast::ConditionalStatement>();
-      if (cs.check != slang::ast::UniquePriorityCheck::None) {
-        return diag::Unsupported(
-            span, diag::DiagCode::kUnsupportedStatementForm,
-            "unique/priority qualifiers on if are not yet supported",
-            diag::UnsupportedCategory::kFeature);
-      }
+      const auto if_check = LowerUniquePriorityCheck(cs.check);
       if (cs.conditions.size() != 1) {
         return diag::Unsupported(
             span, diag::DiagCode::kUnsupportedStatementForm,
@@ -376,7 +384,8 @@ auto LowerStatement(
               hir::IfStmt{
                   .condition = cond_id,
                   .then_stmt = then_id,
-                  .else_stmt = else_id},
+                  .else_stmt = else_id,
+                  .check = if_check},
           .span = span};
     }
 

--- a/src/lyra/lowering/hir_to_mir/lower_deferred_check.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_deferred_check.cpp
@@ -10,13 +10,11 @@
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
-#include "lyra/hir/expr.hpp"
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 #include "lyra/lowering/hir_to_mir/lower_stmt.hpp"
 #include "lyra/lowering/hir_to_mir/procedural_scope_helpers.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/closure.hpp"
-#include "lyra/mir/expr.hpp"
 #include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/integral_constant.hpp"
 #include "lyra/mir/procedural_hops.hpp"
@@ -126,15 +124,11 @@ auto AppendStmt(mir::ProceduralScope& scope, mir::Stmt stmt) -> mir::StmtId {
 
 auto SnapshotPredicate(
     ProceduralScopeLoweringState& wrapper_state, std::size_t index,
-    mir::TypeId int32_type, mir::ExprId predicate_expr_id)
+    mir::TypeId predicate_type, mir::ExprId predicate_expr_id)
     -> mir::ProceduralVarId {
-  // int32 (not bit) so the assign can take a BinaryExpr source -- cpp emit's
-  // RenderPackedExprAsView rejects non-Ref/non-Literal sources, but the
-  // native int path accepts arbitrary expressions and the implicit
-  // bool->int conversion preserves truthiness.
   const std::string var_name = std::format("_lyra_unique_cond_{}", index);
   const mir::ProceduralVarId snap_var = wrapper_state.AddProceduralVar(
-      mir::ProceduralVarDecl{.name = var_name, .type = int32_type});
+      mir::ProceduralVarDecl{.name = var_name, .type = predicate_type});
 
   const mir::StmtId decl_id = wrapper_state.AddStmt(
       mir::Stmt{
@@ -157,7 +151,7 @@ auto SnapshotPredicate(
                       .hops = mir::ProceduralHops{.value = 0},
                       .var = snap_var}},
                   .value = predicate_expr_id},
-          .type = int32_type});
+          .type = predicate_type});
   const mir::StmtId assign_stmt_id = wrapper_state.AddStmt(
       mir::Stmt{
           .label = std::nullopt,
@@ -175,7 +169,7 @@ auto BuildDiagnosticThenScope(
   mir::ProceduralScope scope;
 
   std::vector<mir::RuntimePrintItem> items;
-  items.push_back(mir::RuntimePrintLiteral{.text = verdict.prefix_text});
+  items.emplace_back(mir::RuntimePrintLiteral{.text = verdict.prefix_text});
   if (verdict.include_count_value) {
     const mir::ExprId count_read_id = AppendExpr(
         scope,
@@ -184,12 +178,12 @@ auto BuildDiagnosticThenScope(
                 mir::ProceduralVarRef{
                     .hops = mir::ProceduralHops{.value = 1}, .var = count_var},
             .type = int32_type});
-    items.push_back(
+    items.emplace_back(
         mir::RuntimePrintValue(
             count_read_id, int32_type,
             mir::FormatSpec(
                 mir::FormatKind::kDecimal, mir::FormatModifiers{})));
-    items.push_back(mir::RuntimePrintLiteral{.text = verdict.suffix_text});
+    items.emplace_back(mir::RuntimePrintLiteral{.text = verdict.suffix_text});
   }
 
   const mir::ExprId diag_call_id = AppendExpr(
@@ -209,7 +203,7 @@ auto BuildDiagnosticThenScope(
   return scope;
 }
 
-auto BuildClosure(
+auto BuildUniqueCheckClosure(
     ProceduralScopeLoweringState& wrapper_state, mir::TypeId int32_type,
     mir::TypeId void_type, hir::UniquePriorityCheck check,
     const std::vector<mir::ProceduralVarId>& snapshot_vars)
@@ -221,20 +215,21 @@ auto BuildClosure(
   std::vector<mir::ExprId> inner_reads;
   inner_reads.reserve(snapshot_vars.size());
   for (std::size_t i = 0; i < snapshot_vars.size(); ++i) {
+    const mir::TypeId snap_type =
+        wrapper_state.GetProceduralVar(snapshot_vars[i]).type;
     const mir::ExprId outer_read_id = wrapper_state.AddExpr(
         mir::Expr{
             .data =
                 mir::ProceduralVarRef{
                     .hops = mir::ProceduralHops{.value = 0},
                     .var = snapshot_vars[i]},
-            .type = int32_type});
+            .type = snap_type});
 
     const mir::ProceduralVarId binding{
         static_cast<std::uint32_t>(body.vars.size())};
-    body.vars.push_back(
+    body.vars.emplace_back(
         mir::ProceduralVarDecl{
-            .name = std::format("_lyra_unique_bind_{}", i),
-            .type = int32_type});
+            .name = std::format("_lyra_unique_bind_{}", i), .type = snap_type});
     closure.captures.emplace_back(
         mir::ByValueCapture{.value = outer_read_id, .binding = binding});
 
@@ -244,7 +239,7 @@ auto BuildClosure(
             .data =
                 mir::ProceduralVarRef{
                     .hops = mir::ProceduralHops{.value = 0}, .var = binding},
-            .type = int32_type});
+            .type = snap_type});
     inner_reads.push_back(inner_read_id);
   }
 
@@ -366,12 +361,14 @@ auto BuildDeferredCheckCascade(
   std::vector<mir::ProceduralVarId> snapshot_vars;
   snapshot_vars.reserve(branches.size());
   for (std::size_t i = 0; i < branches.size(); ++i) {
-    snapshot_vars.push_back(
-        SnapshotPredicate(wrapper_state, i, int32_type, branches[i].predicate));
+    const mir::TypeId predicate_type =
+        wrapper_state.GetExpr(branches[i].predicate).type;
+    snapshot_vars.push_back(SnapshotPredicate(
+        wrapper_state, i, predicate_type, branches[i].predicate));
   }
 
-  mir::ClosureExpr closure =
-      BuildClosure(wrapper_state, int32_type, void_type, check, snapshot_vars);
+  mir::ClosureExpr closure = BuildUniqueCheckClosure(
+      wrapper_state, int32_type, void_type, check, snapshot_vars);
   const mir::ExprId closure_expr_id = wrapper_state.AddExpr(
       mir::Expr{.data = std::move(closure), .type = void_type});
 

--- a/src/lyra/lowering/hir_to_mir/lower_deferred_check.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_deferred_check.cpp
@@ -1,0 +1,531 @@
+#include "lyra/lowering/hir_to_mir/lower_deferred_check.hpp"
+
+#include <cstdint>
+#include <expected>
+#include <format>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/lowering/hir_to_mir/lower_expr.hpp"
+#include "lyra/lowering/hir_to_mir/lower_stmt.hpp"
+#include "lyra/lowering/hir_to_mir/procedural_scope_helpers.hpp"
+#include "lyra/mir/binary_op.hpp"
+#include "lyra/mir/closure.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/expr_id.hpp"
+#include "lyra/mir/integral_constant.hpp"
+#include "lyra/mir/procedural_hops.hpp"
+#include "lyra/mir/procedural_var.hpp"
+#include "lyra/mir/runtime_diagnostic.hpp"
+#include "lyra/mir/runtime_print.hpp"
+#include "lyra/mir/runtime_submit.hpp"
+#include "lyra/mir/stmt.hpp"
+#include "lyra/mir/value_ref.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+namespace {
+
+struct UniqueIfCascade {
+  std::vector<hir::ExprId> conditions;
+  std::vector<hir::StmtId> bodies;
+  std::optional<hir::StmtId> tail_else;
+};
+
+auto FlattenUniqueCascade(const hir::Process& proc, const hir::IfStmt& root)
+    -> UniqueIfCascade {
+  UniqueIfCascade out;
+  out.conditions.push_back(root.condition);
+  out.bodies.push_back(root.then_stmt);
+  std::optional<hir::StmtId> cur_else = root.else_stmt;
+  while (cur_else.has_value()) {
+    const hir::Stmt& s = proc.stmts.at(cur_else->value);
+    const auto* nested = std::get_if<hir::IfStmt>(&s.data);
+    if (nested == nullptr || nested->check.has_value()) {
+      out.tail_else = cur_else;
+      break;
+    }
+    out.conditions.push_back(nested->condition);
+    out.bodies.push_back(nested->then_stmt);
+    cur_else = nested->else_stmt;
+  }
+  return out;
+}
+
+struct CheckVerdict {
+  mir::BinaryOp violation_op;
+  std::uint64_t expected;
+  std::string prefix_text;
+  bool include_count_value;
+  std::string suffix_text;
+};
+
+auto VerdictFor(hir::UniquePriorityCheck check, std::size_t branch_count)
+    -> CheckVerdict {
+  switch (check) {
+    case hir::UniquePriorityCheck::kUnique:
+      return {
+          .violation_op = mir::BinaryOp::kInequality,
+          .expected = 1,
+          .prefix_text = "unique check failed: matched ",
+          .include_count_value = true,
+          .suffix_text = std::format(" of {} conditions", branch_count)};
+    case hir::UniquePriorityCheck::kUnique0:
+      return {
+          .violation_op = mir::BinaryOp::kGreaterThan,
+          .expected = 1,
+          .prefix_text = "unique0 check failed: matched ",
+          .include_count_value = true,
+          .suffix_text = std::format(" of {} conditions", branch_count)};
+    case hir::UniquePriorityCheck::kPriority:
+      return {
+          .violation_op = mir::BinaryOp::kEquality,
+          .expected = 0,
+          .prefix_text = "priority check failed: no condition matched",
+          .include_count_value = false,
+          .suffix_text = ""};
+  }
+  throw InternalError("VerdictFor: unknown HIR UniquePriorityCheck");
+}
+
+auto AppendInt32Literal(
+    mir::ProceduralScope& scope, mir::TypeId int32_type, std::uint64_t value)
+    -> mir::ExprId {
+  const mir::ExprId id{static_cast<std::uint32_t>(scope.exprs.size())};
+  scope.exprs.push_back(
+      mir::Expr{
+          .data =
+              mir::IntegerLiteral{
+                  .value =
+                      mir::IntegralConstant{
+                          .value_words = {value},
+                          .state_words = {},
+                          .width = 32,
+                          .signedness = mir::Signedness::kSigned,
+                          .state_kind = mir::IntegralStateKind::kTwoState}},
+          .type = int32_type});
+  return id;
+}
+
+auto AppendExpr(mir::ProceduralScope& scope, mir::Expr expr) -> mir::ExprId {
+  const mir::ExprId id{static_cast<std::uint32_t>(scope.exprs.size())};
+  scope.exprs.push_back(std::move(expr));
+  return id;
+}
+
+auto AppendStmt(mir::ProceduralScope& scope, mir::Stmt stmt) -> mir::StmtId {
+  const mir::StmtId id{static_cast<std::uint32_t>(scope.stmts.size())};
+  scope.stmts.push_back(std::move(stmt));
+  return id;
+}
+
+auto SnapshotPredicate(
+    ProceduralScopeLoweringState& wrapper_state, std::size_t index,
+    mir::TypeId int32_type, mir::ExprId predicate_expr_id)
+    -> mir::ProceduralVarId {
+  // int32 (not bit) so the assign can take a BinaryExpr source -- cpp emit's
+  // RenderPackedExprAsView rejects non-Ref/non-Literal sources, but the
+  // native int path accepts arbitrary expressions and the implicit
+  // bool->int conversion preserves truthiness.
+  const std::string var_name = std::format("_lyra_unique_cond_{}", index);
+  const mir::ProceduralVarId snap_var = wrapper_state.AddProceduralVar(
+      mir::ProceduralVarDecl{.name = var_name, .type = int32_type});
+
+  const mir::StmtId decl_id = wrapper_state.AddStmt(
+      mir::Stmt{
+          .label = std::nullopt,
+          .data =
+              mir::ProceduralVarDeclStmt{
+                  .target =
+                      mir::ProceduralVarRef{
+                          .hops = mir::ProceduralHops{.value = 0},
+                          .var = snap_var},
+                  .init = std::nullopt},
+          .child_procedural_scopes = {}});
+  wrapper_state.AddRootStmt(decl_id);
+
+  const mir::ExprId assign_id = wrapper_state.AddExpr(
+      mir::Expr{
+          .data =
+              mir::AssignExpr{
+                  .target = mir::Lvalue{mir::ProceduralVarRef{
+                      .hops = mir::ProceduralHops{.value = 0},
+                      .var = snap_var}},
+                  .value = predicate_expr_id},
+          .type = int32_type});
+  const mir::StmtId assign_stmt_id = wrapper_state.AddStmt(
+      mir::Stmt{
+          .label = std::nullopt,
+          .data = mir::ExprStmt{.expr = assign_id},
+          .child_procedural_scopes = {}});
+  wrapper_state.AddRootStmt(assign_stmt_id);
+
+  return snap_var;
+}
+
+auto BuildDiagnosticThenScope(
+    mir::ProceduralVarId count_var, mir::TypeId int32_type,
+    mir::TypeId void_type, const CheckVerdict& verdict)
+    -> mir::ProceduralScope {
+  mir::ProceduralScope scope;
+
+  std::vector<mir::RuntimePrintItem> items;
+  items.push_back(mir::RuntimePrintLiteral{.text = verdict.prefix_text});
+  if (verdict.include_count_value) {
+    const mir::ExprId count_read_id = AppendExpr(
+        scope,
+        mir::Expr{
+            .data =
+                mir::ProceduralVarRef{
+                    .hops = mir::ProceduralHops{.value = 1}, .var = count_var},
+            .type = int32_type});
+    items.push_back(
+        mir::RuntimePrintValue(
+            count_read_id, int32_type,
+            mir::FormatSpec(
+                mir::FormatKind::kDecimal, mir::FormatModifiers{})));
+    items.push_back(mir::RuntimePrintLiteral{.text = verdict.suffix_text});
+  }
+
+  const mir::ExprId diag_call_id = AppendExpr(
+      scope, mir::Expr{
+                 .data =
+                     mir::RuntimeCallExpr{
+                         .call = mir::RuntimeDiagnosticCall(
+                             mir::DiagnosticSeverity::kWarning, std::nullopt,
+                             std::move(items))},
+                 .type = void_type});
+  const mir::StmtId diag_stmt_id = AppendStmt(
+      scope, mir::Stmt{
+                 .label = std::nullopt,
+                 .data = mir::ExprStmt{.expr = diag_call_id},
+                 .child_procedural_scopes = {}});
+  scope.root_stmts.push_back(diag_stmt_id);
+  return scope;
+}
+
+auto BuildClosure(
+    ProceduralScopeLoweringState& wrapper_state, mir::TypeId int32_type,
+    mir::TypeId void_type, hir::UniquePriorityCheck check,
+    const std::vector<mir::ProceduralVarId>& snapshot_vars)
+    -> mir::ClosureExpr {
+  mir::ClosureExpr closure;
+  closure.body = std::make_unique<mir::ProceduralScope>();
+  auto& body = *closure.body;
+
+  std::vector<mir::ExprId> inner_reads;
+  inner_reads.reserve(snapshot_vars.size());
+  for (std::size_t i = 0; i < snapshot_vars.size(); ++i) {
+    const mir::ExprId outer_read_id = wrapper_state.AddExpr(
+        mir::Expr{
+            .data =
+                mir::ProceduralVarRef{
+                    .hops = mir::ProceduralHops{.value = 0},
+                    .var = snapshot_vars[i]},
+            .type = int32_type});
+
+    const mir::ProceduralVarId binding{
+        static_cast<std::uint32_t>(body.vars.size())};
+    body.vars.push_back(
+        mir::ProceduralVarDecl{
+            .name = std::format("_lyra_unique_bind_{}", i),
+            .type = int32_type});
+    closure.captures.emplace_back(
+        mir::ByValueCapture{.value = outer_read_id, .binding = binding});
+
+    const mir::ExprId inner_read_id = AppendExpr(
+        body,
+        mir::Expr{
+            .data =
+                mir::ProceduralVarRef{
+                    .hops = mir::ProceduralHops{.value = 0}, .var = binding},
+            .type = int32_type});
+    inner_reads.push_back(inner_read_id);
+  }
+
+  const mir::ProceduralVarId count_var{
+      static_cast<std::uint32_t>(body.vars.size())};
+  body.vars.push_back(
+      mir::ProceduralVarDecl{.name = "_lyra_unique_count", .type = int32_type});
+
+  const mir::ExprId zero_init_id = AppendInt32Literal(body, int32_type, 0);
+  const mir::StmtId count_decl_id = AppendStmt(
+      body, mir::Stmt{
+                .label = std::nullopt,
+                .data =
+                    mir::ProceduralVarDeclStmt{
+                        .target =
+                            mir::ProceduralVarRef{
+                                .hops = mir::ProceduralHops{.value = 0},
+                                .var = count_var},
+                        .init = zero_init_id},
+                .child_procedural_scopes = {}});
+  body.root_stmts.push_back(count_decl_id);
+
+  for (const mir::ExprId bit_read : inner_reads) {
+    const mir::ExprId one_lit = AppendInt32Literal(body, int32_type, 1);
+    const mir::ExprId zero_lit = AppendInt32Literal(body, int32_type, 0);
+    const mir::ExprId cond_value = AppendExpr(
+        body, mir::Expr{
+                  .data =
+                      mir::ConditionalExpr{
+                          .condition = bit_read,
+                          .then_value = one_lit,
+                          .else_value = zero_lit},
+                  .type = int32_type});
+    const mir::ExprId count_read = AppendExpr(
+        body,
+        mir::Expr{
+            .data =
+                mir::ProceduralVarRef{
+                    .hops = mir::ProceduralHops{.value = 0}, .var = count_var},
+            .type = int32_type});
+    const mir::ExprId added = AppendExpr(
+        body, mir::Expr{
+                  .data =
+                      mir::BinaryExpr{
+                          .op = mir::BinaryOp::kAdd,
+                          .lhs = count_read,
+                          .rhs = cond_value},
+                  .type = int32_type});
+    const mir::ExprId assign = AppendExpr(
+        body, mir::Expr{
+                  .data =
+                      mir::AssignExpr{
+                          .target = mir::Lvalue{mir::ProceduralVarRef{
+                              .hops = mir::ProceduralHops{.value = 0},
+                              .var = count_var}},
+                          .value = added},
+                  .type = int32_type});
+    const mir::StmtId step_id = AppendStmt(
+        body, mir::Stmt{
+                  .label = std::nullopt,
+                  .data = mir::ExprStmt{.expr = assign},
+                  .child_procedural_scopes = {}});
+    body.root_stmts.push_back(step_id);
+  }
+
+  const CheckVerdict verdict = VerdictFor(check, snapshot_vars.size());
+
+  const mir::ExprId final_count_read = AppendExpr(
+      body,
+      mir::Expr{
+          .data =
+              mir::ProceduralVarRef{
+                  .hops = mir::ProceduralHops{.value = 0}, .var = count_var},
+          .type = int32_type});
+  const mir::ExprId expected_lit =
+      AppendInt32Literal(body, int32_type, verdict.expected);
+  const mir::ExprId predicate_id = AppendExpr(
+      body, mir::Expr{
+                .data =
+                    mir::BinaryExpr{
+                        .op = verdict.violation_op,
+                        .lhs = final_count_read,
+                        .rhs = expected_lit},
+                .type = int32_type});
+
+  mir::ProceduralScope diag_scope =
+      BuildDiagnosticThenScope(count_var, int32_type, void_type, verdict);
+
+  std::vector<mir::ProceduralScope> if_children;
+  const mir::ProceduralScopeId diag_scope_id =
+      AddChildProceduralScope(if_children, std::move(diag_scope));
+
+  const mir::StmtId if_stmt_id = AppendStmt(
+      body, mir::Stmt{
+                .label = std::nullopt,
+                .data =
+                    mir::IfStmt{
+                        .condition = predicate_id,
+                        .then_scope = diag_scope_id,
+                        .else_scope = std::nullopt},
+                .child_procedural_scopes = std::move(if_children)});
+  body.root_stmts.push_back(if_stmt_id);
+
+  return closure;
+}
+
+}  // namespace
+
+auto BuildDeferredCheckCascade(
+    const UnitLoweringState& unit_state,
+    ProceduralScopeLoweringState wrapper_state,
+    std::vector<DeferredCheckBranch> branches,
+    std::optional<mir::ProceduralScope> tail_else,
+    hir::UniquePriorityCheck check, std::optional<std::string> outer_label)
+    -> mir::Stmt {
+  const mir::TypeId void_type = unit_state.Builtins().void_type;
+  const mir::TypeId int32_type = unit_state.Builtins().int32;
+
+  std::vector<mir::ProceduralVarId> snapshot_vars;
+  snapshot_vars.reserve(branches.size());
+  for (std::size_t i = 0; i < branches.size(); ++i) {
+    snapshot_vars.push_back(
+        SnapshotPredicate(wrapper_state, i, int32_type, branches[i].predicate));
+  }
+
+  mir::ClosureExpr closure =
+      BuildClosure(wrapper_state, int32_type, void_type, check, snapshot_vars);
+  const mir::ExprId closure_expr_id = wrapper_state.AddExpr(
+      mir::Expr{.data = std::move(closure), .type = void_type});
+
+  const mir::DeferredCheckSiteId site_id =
+      unit_state.AllocateDeferredCheckSiteId();
+  const mir::ExprId submit_expr_id = wrapper_state.AddExpr(
+      mir::Expr{
+          .data =
+              mir::RuntimeCallExpr{
+                  .call =
+                      mir::RuntimeSubmitObservedCall{
+                          .site_id = site_id, .closure = closure_expr_id}},
+          .type = void_type});
+  const mir::StmtId submit_stmt_id = wrapper_state.AddStmt(
+      mir::Stmt{
+          .label = std::nullopt,
+          .data = mir::ExprStmt{.expr = submit_expr_id},
+          .child_procedural_scopes = {}});
+  wrapper_state.AddRootStmt(submit_stmt_id);
+
+  // Cascade level i sits i scopes deeper than wrapper, so the read uses hops=i.
+  std::optional<mir::ProceduralScope> tail = std::move(tail_else);
+  for (std::size_t i = branches.size(); i-- > 1;) {
+    ProceduralScopeLoweringState level_state;
+    const mir::ExprId cond_read = level_state.AddExpr(
+        mir::Expr{
+            .data =
+                mir::ProceduralVarRef{
+                    .hops =
+                        mir::ProceduralHops{
+                            .value = static_cast<std::uint32_t>(i)},
+                    .var = snapshot_vars[i]},
+            .type = int32_type});
+
+    std::vector<mir::ProceduralScope> if_child_scopes;
+    const mir::ProceduralScopeId body_scope_id =
+        AddChildProceduralScope(if_child_scopes, std::move(branches[i].body));
+    std::optional<mir::ProceduralScopeId> else_scope_id;
+    if (tail.has_value()) {
+      else_scope_id =
+          AddChildProceduralScope(if_child_scopes, std::move(*tail));
+    }
+
+    const mir::StmtId if_id = level_state.AddStmt(
+        mir::Stmt{
+            .label = std::nullopt,
+            .data =
+                mir::IfStmt{
+                    .condition = cond_read,
+                    .then_scope = body_scope_id,
+                    .else_scope = else_scope_id},
+            .child_procedural_scopes = std::move(if_child_scopes)});
+    level_state.AddRootStmt(if_id);
+    tail = level_state.Finish();
+  }
+
+  if (!branches.empty()) {
+    const mir::ExprId cond_read0 = wrapper_state.AddExpr(
+        mir::Expr{
+            .data =
+                mir::ProceduralVarRef{
+                    .hops = mir::ProceduralHops{.value = 0},
+                    .var = snapshot_vars[0]},
+            .type = int32_type});
+
+    std::vector<mir::ProceduralScope> if0_child_scopes;
+    const mir::ProceduralScopeId body0_id =
+        AddChildProceduralScope(if0_child_scopes, std::move(branches[0].body));
+    std::optional<mir::ProceduralScopeId> else0_id;
+    if (tail.has_value()) {
+      else0_id = AddChildProceduralScope(if0_child_scopes, std::move(*tail));
+    }
+
+    const mir::StmtId if0_id = wrapper_state.AddStmt(
+        mir::Stmt{
+            .label = std::nullopt,
+            .data =
+                mir::IfStmt{
+                    .condition = cond_read0,
+                    .then_scope = body0_id,
+                    .else_scope = else0_id},
+            .child_procedural_scopes = std::move(if0_child_scopes)});
+    wrapper_state.AddRootStmt(if0_id);
+  }
+
+  std::vector<mir::ProceduralScope> outer_child_scopes;
+  const mir::ProceduralScopeId wrapper_scope_id =
+      AddChildProceduralScope(outer_child_scopes, wrapper_state.Finish());
+
+  return mir::Stmt{
+      .label = std::move(outer_label),
+      .data = mir::BlockStmt{.scope = wrapper_scope_id},
+      .child_procedural_scopes = std::move(outer_child_scopes)};
+}
+
+auto LowerUniqueIfStmt(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    const hir::Stmt& stmt, const hir::IfStmt& root) -> diag::Result<mir::Stmt> {
+  const auto cascade = FlattenUniqueCascade(hir_proc, root);
+
+  ProceduralScopeLoweringState wrapper_state;
+  ProceduralDepthGuard wrapper_depth_guard{proc_state};
+
+  // Lower each branch condition into wrapper_state; these are the predicates
+  // that BuildDeferredCheckCascade will snapshot.
+  std::vector<mir::ExprId> predicates;
+  predicates.reserve(cascade.conditions.size());
+  for (const hir::ExprId hir_cond : cascade.conditions) {
+    auto cond_or = LowerExpr(
+        unit_state, scope_state, proc_state, wrapper_state, hir_proc,
+        hir_proc.exprs.at(hir_cond.value));
+    if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+    predicates.push_back(wrapper_state.AddExpr(*std::move(cond_or)));
+  }
+
+  // Lower each body into its own child scope, with depth guards mirroring
+  // the cascade structure (level i sits i scopes deeper than wrapper).
+  auto with_extra_depth = [&](std::size_t extras, auto fn) {
+    std::vector<std::unique_ptr<ProceduralDepthGuard>> guards;
+    guards.reserve(extras);
+    for (std::size_t i = 0; i < extras; ++i) {
+      guards.push_back(std::make_unique<ProceduralDepthGuard>(proc_state));
+    }
+    return fn();
+  };
+
+  std::vector<DeferredCheckBranch> branches;
+  branches.reserve(cascade.bodies.size());
+  for (std::size_t i = 0; i < cascade.bodies.size(); ++i) {
+    auto body_or = with_extra_depth(i, [&] {
+      return LowerStmtIntoChildScope(
+          unit_state, scope_state, proc_state, hir_proc, cascade.bodies[i]);
+    });
+    if (!body_or) return std::unexpected(std::move(body_or.error()));
+    branches.push_back(
+        DeferredCheckBranch{
+            .predicate = predicates[i], .body = std::move(*body_or)});
+  }
+
+  std::optional<mir::ProceduralScope> tail_scope;
+  if (cascade.tail_else.has_value()) {
+    auto tail_or = with_extra_depth(cascade.bodies.size(), [&] {
+      return LowerStmtIntoChildScope(
+          unit_state, scope_state, proc_state, hir_proc, *cascade.tail_else);
+    });
+    if (!tail_or) return std::unexpected(std::move(tail_or.error()));
+    tail_scope = std::move(*tail_or);
+  }
+
+  return BuildDeferredCheckCascade(
+      unit_state, std::move(wrapper_state), std::move(branches),
+      std::move(tail_scope), *root.check, stmt.label);
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -17,6 +17,7 @@
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/case_cascade.hpp"
 #include "lyra/lowering/hir_to_mir/delay_time_resolver.hpp"
+#include "lyra/lowering/hir_to_mir/lower_deferred_check.hpp"
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 #include "lyra/lowering/hir_to_mir/procedural_scope_helpers.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
@@ -91,29 +92,6 @@ auto LowerTimingControl(
           },
       },
       tc);
-}
-
-// Lowers a single HIR stmt into its own fresh ProceduralScope: pushes a
-// ProceduralDepthGuard so procvar refs inside see the correct hop count,
-// recursively invokes LowerStmt, and packages the result as the new scope's
-// sole root stmt. Used wherever a control-flow node needs a body / branch
-// scope (for, while, repeat, do-while, forever, if branches, case items).
-auto LowerStmtIntoChildScope(
-    const UnitLoweringState& unit_state,
-    const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
-    hir::StmtId hir_stmt_id) -> diag::Result<mir::ProceduralScope> {
-  ProceduralScopeLoweringState child_state;
-  ProceduralDepthGuard depth_guard{proc_state};
-  const hir::Stmt& hir_stmt = hir_proc.stmts.at(hir_stmt_id.value);
-  auto lowered = LowerStmt(
-      unit_state, scope_state, proc_state, child_state, hir_proc, hir_stmt);
-  if (!lowered) {
-    return std::unexpected(std::move(lowered.error()));
-  }
-  const mir::StmtId stmt_id = child_state.AddStmt(*std::move(lowered));
-  child_state.AddRootStmt(stmt_id);
-  return child_state.Finish();
 }
 
 auto LowerEmptyStmt(const hir::Stmt& stmt) -> diag::Result<mir::Stmt> {
@@ -215,6 +193,10 @@ auto LowerIfStmt(
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::Process& hir_proc, const hir::Stmt& stmt, const hir::IfStmt& i)
     -> diag::Result<mir::Stmt> {
+  if (i.check.has_value()) {
+    return LowerUniqueIfStmt(
+        unit_state, scope_state, proc_state, hir_proc, stmt, i);
+  }
   auto cond_expr_or = LowerExpr(
       unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
       hir_proc.exprs.at(i.condition.value));
@@ -317,6 +299,40 @@ auto LowerCaseStmt(
       return std::unexpected(std::move(def_or.error()));
     }
     default_scope = std::move(*def_or);
+  }
+
+  if (c.check.has_value()) {
+    // All predicates live at wrapper depth (sel_hops=0); bodies were lowered
+    // with the per-level depth guards above.
+    std::vector<mir::ExprId> predicates;
+    predicates.reserve(c.items.size());
+    for (std::size_t i = 0; i < c.items.size(); ++i) {
+      auto pred_or = BuildEqualityChain(
+          wrapper_state, snapshot, bit_type, 0, c.items[i].labels.size(),
+          [&](ProceduralScopeLoweringState& es,
+              std::size_t li) -> diag::Result<mir::ExprId> {
+            auto lab_or = LowerExpr(
+                unit_state, scope_state, proc_state, es, hir_proc,
+                hir_proc.exprs.at(c.items[i].labels[li].value));
+            if (!lab_or) {
+              return std::unexpected(std::move(lab_or.error()));
+            }
+            return es.AddExpr(*std::move(lab_or));
+          });
+      if (!pred_or) return std::unexpected(std::move(pred_or.error()));
+      predicates.push_back(*pred_or);
+    }
+
+    std::vector<DeferredCheckBranch> branches;
+    branches.reserve(c.items.size());
+    for (std::size_t i = 0; i < c.items.size(); ++i) {
+      branches.push_back(
+          DeferredCheckBranch{
+              .predicate = predicates[i], .body = std::move(body_scopes[i])});
+    }
+    return BuildDeferredCheckCascade(
+        unit_state, std::move(wrapper_state), std::move(branches),
+        std::move(default_scope), *c.check, stmt.label);
   }
 
   auto build_predicate = [&](ProceduralScopeLoweringState& enc,
@@ -723,6 +739,24 @@ auto LowerTimedStmt(
 }
 
 }  // namespace
+
+auto LowerStmtIntoChildScope(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    hir::StmtId hir_stmt_id) -> diag::Result<mir::ProceduralScope> {
+  ProceduralScopeLoweringState child_state;
+  ProceduralDepthGuard depth_guard{proc_state};
+  const hir::Stmt& hir_stmt = hir_proc.stmts.at(hir_stmt_id.value);
+  auto lowered = LowerStmt(
+      unit_state, scope_state, proc_state, child_state, hir_proc, hir_stmt);
+  if (!lowered) {
+    return std::unexpected(std::move(lowered.error()));
+  }
+  const mir::StmtId stmt_id = child_state.AddStmt(*std::move(lowered));
+  child_state.AddRootStmt(stmt_id);
+  return child_state.Finish();
+}
 
 auto LowerStmt(
     const UnitLoweringState& unit_state,

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -600,6 +600,13 @@ class MirDumper {
                   [&](const RuntimeFinishCall& fc) {
                     Line(std::format("RuntimeFinishCall level={}", fc.level));
                   },
+                  [&](const RuntimeSubmitObservedCall& sc) {
+                    Line(
+                        std::format(
+                            "RuntimeSubmitObservedCall site={} "
+                            "closure=Expr[{}]",
+                            sc.site_id.value, sc.closure.value));
+                  },
               },
               rc->call);
           Dedent();

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -46,6 +46,7 @@ void Engine::BindRoot(std::string root_name, Module& top) {
   bound_ = true;
   root_ = std::make_unique<RuntimeScope>(
       nullptr, std::move(root_name), RuntimeScopeKind::kModuleInstance);
+  registered_modules_.push_back(&top);
   RuntimeBindContext ctx(*root_, services_);
   top.Bind(ctx);
 }
@@ -155,6 +156,9 @@ void Engine::ExecuteNbaRegion() {
 
 void Engine::ExecuteObservedRegion() {
   phase_ = SchedulerPhase::kObserved;
+  for (Module* m : registered_modules_) {
+    m->DrainObserved();
+  }
 }
 
 void Engine::ExecuteReactiveRegion() {

--- a/src/lyra/runtime/module.cpp
+++ b/src/lyra/runtime/module.cpp
@@ -1,0 +1,25 @@
+#include "lyra/runtime/module.hpp"
+
+#include <cstdint>
+#include <functional>
+#include <utility>
+
+namespace lyra::runtime {
+
+void Module::SubmitObserved(std::uint32_t site_id, std::function<void()> fn) {
+  if (site_id >= observed_pending_.size()) {
+    observed_pending_.resize(site_id + 1);
+  }
+  observed_pending_[site_id] = std::move(fn);
+}
+
+void Module::DrainObserved() {
+  for (auto& fn : observed_pending_) {
+    if (fn) {
+      fn();
+      fn = nullptr;
+    }
+  }
+}
+
+}  // namespace lyra::runtime

--- a/tests/cases/cpp/priority_case_violation_no_match/case.yaml
+++ b/tests/cases/cpp/priority_case_violation_no_match/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.priority_case_violation_no_match
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    exact: "warning: priority check failed: no condition matched\n"

--- a/tests/cases/cpp/priority_case_violation_no_match/main.sv
+++ b/tests/cases/cpp/priority_case_violation_no_match/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int a;
+  initial begin
+    a = 0;
+    priority case (a)
+      1: ;
+      2: ;
+    endcase
+  end
+endmodule

--- a/tests/cases/cpp/priority_if_match_ok/case.yaml
+++ b/tests/cases/cpp/priority_if_match_ok/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.priority_if_match_ok
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    exact: ""

--- a/tests/cases/cpp/priority_if_match_ok/main.sv
+++ b/tests/cases/cpp/priority_if_match_ok/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  int a;
+  initial begin
+    a = 1;
+    priority if (a == 1) ;
+    else if (a == 2) ;
+  end
+endmodule

--- a/tests/cases/cpp/priority_if_violation_no_match/case.yaml
+++ b/tests/cases/cpp/priority_if_violation_no_match/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.priority_if_violation_no_match
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    exact: "warning: priority check failed: no condition matched\n"

--- a/tests/cases/cpp/priority_if_violation_no_match/main.sv
+++ b/tests/cases/cpp/priority_if_violation_no_match/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  int a;
+  initial begin
+    a = 0;
+    priority if (a == 1) ;
+    else if (a == 2) ;
+  end
+endmodule

--- a/tests/cases/cpp/unique0_case_no_match_ok/case.yaml
+++ b/tests/cases/cpp/unique0_case_no_match_ok/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.unique0_case_no_match_ok
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    exact: ""

--- a/tests/cases/cpp/unique0_case_no_match_ok/main.sv
+++ b/tests/cases/cpp/unique0_case_no_match_ok/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int a;
+  initial begin
+    a = 99;
+    unique0 case (a)
+      1: ;
+      2: ;
+    endcase
+  end
+endmodule

--- a/tests/cases/cpp/unique0_if_no_match_ok/case.yaml
+++ b/tests/cases/cpp/unique0_if_no_match_ok/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.unique0_if_no_match_ok
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    exact: ""

--- a/tests/cases/cpp/unique0_if_no_match_ok/main.sv
+++ b/tests/cases/cpp/unique0_if_no_match_ok/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  int a;
+  initial begin
+    a = 99;
+    unique0 if (a == 1) ;
+    else if (a == 2) ;
+  end
+endmodule

--- a/tests/cases/cpp/unique0_if_violation_multi/case.yaml
+++ b/tests/cases/cpp/unique0_if_violation_multi/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.unique0_if_violation_multi
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    exact: "warning: unique0 check failed: matched 2 of 2 conditions\n"

--- a/tests/cases/cpp/unique0_if_violation_multi/main.sv
+++ b/tests/cases/cpp/unique0_if_violation_multi/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  int a;
+  initial begin
+    a = 10;
+    unique0 if (a > 0) ;
+    else if (a > 5) ;
+  end
+endmodule

--- a/tests/cases/cpp/unique_case_single_match_ok/case.yaml
+++ b/tests/cases/cpp/unique_case_single_match_ok/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.unique_case_single_match_ok
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    exact: ""

--- a/tests/cases/cpp/unique_case_single_match_ok/main.sv
+++ b/tests/cases/cpp/unique_case_single_match_ok/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  int a;
+  initial begin
+    a = 2;
+    unique case (a)
+      1: ;
+      2: ;
+      3: ;
+    endcase
+  end
+endmodule

--- a/tests/cases/cpp/unique_case_violation_no_match/case.yaml
+++ b/tests/cases/cpp/unique_case_violation_no_match/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.unique_case_violation_no_match
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    exact: "warning: unique check failed: matched 0 of 2 conditions\n"

--- a/tests/cases/cpp/unique_case_violation_no_match/main.sv
+++ b/tests/cases/cpp/unique_case_violation_no_match/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int a;
+  initial begin
+    a = 99;
+    unique case (a)
+      1: ;
+      2: ;
+    endcase
+  end
+endmodule

--- a/tests/cases/cpp/unique_if_single_match_ok/case.yaml
+++ b/tests/cases/cpp/unique_if_single_match_ok/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.unique_if_single_match_ok
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    exact: ""

--- a/tests/cases/cpp/unique_if_single_match_ok/main.sv
+++ b/tests/cases/cpp/unique_if_single_match_ok/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  int a;
+  initial begin
+    a = 2;
+    unique if (a == 1) ;
+    else if (a == 2) ;
+  end
+endmodule

--- a/tests/cases/cpp/unique_if_violation_multi/case.yaml
+++ b/tests/cases/cpp/unique_if_violation_multi/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.unique_if_violation_multi
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    exact: "warning: unique check failed: matched 3 of 3 conditions\n"

--- a/tests/cases/cpp/unique_if_violation_multi/main.sv
+++ b/tests/cases/cpp/unique_if_violation_multi/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  int a;
+  initial begin
+    a = 5;
+    unique if (a > 0) ;
+    else if (a > 3) ;
+    else if (a > 4) ;
+  end
+endmodule

--- a/tests/cases/cpp/unique_if_violation_no_match/case.yaml
+++ b/tests/cases/cpp/unique_if_violation_no_match/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.unique_if_violation_no_match
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stderr:
+    exact: "warning: unique check failed: matched 0 of 2 conditions\n"

--- a/tests/cases/cpp/unique_if_violation_no_match/main.sv
+++ b/tests/cases/cpp/unique_if_violation_no_match/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  int a;
+  initial begin
+    a = 3;
+    unique if (a == 1) ;
+    else if (a == 2) ;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds end-to-end support for SystemVerilog `unique` / `unique0` / `priority` qualifiers on `if` and `case`. HIR carries the qualifier; HIR-to-MIR desugars the site into a snapshot-and-submit pattern that hands a closure to the Observed region; the closure body counts truthy snapshots and emits a warning through the existing diagnostic channel when the qualifier-specific predicate fires. Re-submits at the same site within one time slot collapse via vector-slot replacement, suppressing settle-time glitches.

## Design

`BuildDeferredCheckCascade` is a shared helper consumed by both unique-if (caller flattens the source if-chain) and unique-case (caller produces OR-chain predicates from the case selector). Caller supplies pre-lowered predicate `ExprId`s plus pre-lowered body scopes; the helper handles snapshot synthesis, closure body construction, submit-call insertion, and the plain if-cascade reading from snapshots. Snapshot vars take the predicate's own lowered type rather than being forced to a uniform type.

Runtime keeps the dirty model simple: every `Module` instance holds an `observed_pending_` vector; `Engine` records all modules at `BindRoot` and iterates them once per Observed region. No back-pointer from `Module` to `Engine`, no per-module dirty-registered flag, no engine-side dirty list. Clean modules pay one empty-vector check per drain.

The classification logic (count truthy / compare against qualifier-specific constant / emit warning) lives in MIR as ordinary primitives plus a call to `RuntimeDiagnosticCall`, reusing the existing `LyraDiagnostic` infrastructure. No new runtime helper.

## Testing

11 cpp_run cases under `tests/cases/cpp/` cover the three qualifiers cross-producted with if/case forms and match / no-match / multi-match outcomes. All existing tests still pass.