### PR TITLE
Add non-blocking assignment via closure submit

### DIFF
--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -28,7 +28,6 @@ enum class DiagCode : std::uint32_t {
   kUnsupportedExpressionForm,
   kUnsupportedStructuralExpressionForm,
   kUnsupportedNonVariableNamedReference,
-  kUnsupportedNonBlockingAssignment,
   kUnsupportedAssignmentTarget,
   kUnsupportedBinaryOperator,
   kUnsupportedTimingControlKind,

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <variant>
 #include <vector>
 
@@ -36,7 +37,13 @@ struct ConditionalExpr {
   ExprId else_value;
 };
 
+enum class AssignKind : std::uint8_t {
+  kBlocking,
+  kNonBlocking,
+};
+
 struct AssignExpr {
+  AssignKind kind;
   Lvalue lhs;
   ExprId rhs;
 };

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -73,7 +73,7 @@ struct CallExpr {
 
 using RuntimeCall = std::variant<
     RuntimePrintCall, RuntimeDiagnosticCall, RuntimeFinishCall,
-    RuntimeSubmitObservedCall>;
+    RuntimeSubmitObservedCall, RuntimeSubmitNbaCall>;
 
 struct RuntimeCallExpr {
   RuntimeCall call;

--- a/include/lyra/mir/runtime_submit.hpp
+++ b/include/lyra/mir/runtime_submit.hpp
@@ -22,4 +22,10 @@ struct RuntimeSubmitObservedCall {
   ExprId closure;
 };
 
+// Append-only submit to the engine's global NBA queue; the closure commits
+// in the slot's NBA region in enqueue order (LRM 4.4.2).
+struct RuntimeSubmitNbaCall {
+  ExprId closure;
+};
+
 }  // namespace lyra::mir

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <deque>
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
@@ -64,15 +65,16 @@ class Engine {
     return services_;
   }
 
+  void SubmitNba(std::function<void()> closure);
+
  private:
-  struct NbaWorkItem {};
   struct PostponedWorkItem {};
 
   struct SchedulerQueues {
     std::deque<RuntimeProcess*> active;
     std::deque<RuntimeProcess*> inactive;
     std::vector<RuntimeProcess*> next_delta;
-    std::vector<NbaWorkItem> nba;
+    std::vector<std::function<void()>> nba;
     std::vector<PostponedWorkItem> postponed;
     std::map<SimTime, std::vector<RuntimeProcess*>> delayed;
     std::vector<RuntimeProcess*> finals;
@@ -122,7 +124,7 @@ class Engine {
 
   StreamDispatcher stream_;
   DiagnosticDispatcher diagnostic_;
-  RuntimeServices services_{stream_, diagnostic_};
+  RuntimeServices services_{stream_, diagnostic_, *this};
   std::unique_ptr<RuntimeScope> root_;
   SchedulerQueues queues_;
   std::vector<Module*> registered_modules_;

--- a/include/lyra/runtime/runtime_services.hpp
+++ b/include/lyra/runtime/runtime_services.hpp
@@ -1,16 +1,21 @@
 #pragma once
 
+#include <functional>
+
 #include "lyra/base/internal_error.hpp"
 
 namespace lyra::runtime {
 
 class StreamDispatcher;
 class DiagnosticDispatcher;
+class Engine;
 
 class RuntimeServices {
  public:
-  RuntimeServices(StreamDispatcher& stream, DiagnosticDispatcher& diagnostic)
-      : stream_(&stream), diagnostic_(&diagnostic) {
+  RuntimeServices(
+      StreamDispatcher& stream, DiagnosticDispatcher& diagnostic,
+      Engine& engine)
+      : stream_(&stream), diagnostic_(&diagnostic), engine_(&engine) {
   }
 
   auto Stream() -> StreamDispatcher& {
@@ -27,9 +32,12 @@ class RuntimeServices {
     return *diagnostic_;
   }
 
+  void SubmitNba(std::function<void()> closure);
+
  private:
   StreamDispatcher* stream_ = nullptr;
   DiagnosticDispatcher* diagnostic_ = nullptr;
+  Engine* engine_ = nullptr;
 };
 
 }  // namespace lyra::runtime

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -20,6 +20,7 @@
 #include "lyra/mir/runtime_diagnostic.hpp"
 #include "lyra/mir/runtime_finish.hpp"
 #include "lyra/mir/runtime_print.hpp"
+#include "lyra/mir/runtime_submit.hpp"
 #include "lyra/mir/type.hpp"
 
 namespace lyra::backend::cpp {
@@ -262,6 +263,14 @@ auto RenderRuntimeCallExpr(
             }
             return std::format(
                 "this->SubmitObserved({}, {})", sc.site_id.value, *closure_or);
+          },
+          [&](const mir::RuntimeSubmitNbaCall& nc)
+              -> diag::Result<std::string> {
+            auto closure_or = RenderExpr(ctx, ctx.Expr(nc.closure));
+            if (!closure_or) {
+              return std::unexpected(std::move(closure_or.error()));
+            }
+            return std::format("services_->SubmitNba({})", *closure_or);
           },
       },
       expr.call);

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -115,12 +115,6 @@ constexpr std::array kEntries{
             .category = UnsupportedCategory::kFeature,
             .name = "unsupported_non_variable_named_reference"}},
     std::pair{
-        DiagCode::kUnsupportedNonBlockingAssignment,
-        DiagCodeInfo{
-            .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
-            .name = "unsupported_non_blocking_assignment"}},
-    std::pair{
         DiagCode::kUnsupportedAssignmentTarget,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -452,9 +452,12 @@ class HirDumper {
                   c.condition.value, c.then_value.value, c.else_value.value);
             },
             [](const AssignExpr& a) -> std::string {
+              const auto* kind_str = a.kind == AssignKind::kNonBlocking
+                                         ? "nonblocking"
+                                         : "blocking";
               return std::format(
-                  "AssignExpr lhs={} rhs=Expr[{}]", FormatLvalue(a.lhs),
-                  a.rhs.value);
+                  "AssignExpr kind={} lhs={} rhs=Expr[{}]", kind_str,
+                  FormatLvalue(a.lhs), a.rhs.value);
             },
             [this](const CallExpr& c) -> std::string {
               std::string args;

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -590,12 +590,8 @@ auto LowerProcExpr(
 
     case slang::ast::ExpressionKind::Assignment: {
       const auto& as = expr.as<slang::ast::AssignmentExpression>();
-      if (as.isNonBlocking()) {
-        return diag::Unsupported(
-            span, diag::DiagCode::kUnsupportedNonBlockingAssignment,
-            "non-blocking assignments are not supported yet",
-            diag::UnsupportedCategory::kFeature);
-      }
+      const auto kind = as.isNonBlocking() ? hir::AssignKind::kNonBlocking
+                                           : hir::AssignKind::kBlocking;
 
       auto lhs_or =
           LowerProcLvalue(unit_facts, unit_state, proc_state, stack, as.left());
@@ -610,7 +606,9 @@ auto LowerProcExpr(
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return hir::Expr{
           .type = *type_id,
-          .data = hir::AssignExpr{.lhs = *std::move(lhs_or), .rhs = rhs_id},
+          .data =
+              hir::AssignExpr{
+                  .kind = kind, .lhs = *std::move(lhs_or), .rhs = rhs_id},
           .span = span,
       };
     }

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -1,6 +1,7 @@
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -244,38 +245,6 @@ auto LowerHirLvalueProc(
       lvalue);
 }
 
-auto LowerHirLvalueStructural(
-    const StructuralScopeLoweringState& scope_state,
-    const ConstructorLoweringState* ctor_state, const hir::Lvalue& lvalue,
-    LoopVarLoweringMode loop_var_mode) -> mir::Lvalue {
-  return std::visit(
-      Overloaded{
-          [&](const hir::StructuralVarRef& m) -> mir::Lvalue {
-            return scope_state.TranslateStructuralVar(m.hops, m.var);
-          },
-          [](const hir::ProceduralVarRef&) -> mir::Lvalue {
-            throw InternalError(
-                "LowerRefAsLvalue (constructor): HIR ProceduralVarRef does "
-                "not appear in constructor bodies");
-          },
-          [&](const hir::LoopVarRef& lv) -> mir::Lvalue {
-            if (loop_var_mode != LoopVarLoweringMode::kProceduralInduction) {
-              throw InternalError(
-                  "LowerHirLvalueStructural: HIR LoopVarRef as lvalue is only "
-                  "valid in for-stmt header context (kProceduralInduction); "
-                  "StructuralParamRef is immutable");
-            }
-            if (ctor_state == nullptr) {
-              throw InternalError(
-                  "LowerHirLvalueStructural: kProceduralInduction mode "
-                  "requires a non-null ConstructorLoweringState");
-            }
-            return ctor_state->TranslateLoopVar(lv.loop_var);
-          },
-      },
-      lvalue);
-}
-
 auto LowerUserCallee(
     const StructuralScopeLoweringState& scope_state,
     const hir::StructuralSubroutineRef& u) -> mir::Callee {
@@ -371,6 +340,47 @@ auto LowerHirPrimaryStructural(
       p);
 }
 
+// Builds a ClosureExpr that snapshots the RHS by value into the body and writes
+// the snapshot to the structural target. The closure is the deferred-write
+// vehicle the NBA region invokes. The returned Expr has type `void` since the
+// closure value itself is consumed only by RuntimeSubmitNbaCall.
+auto BuildNbaSubmitClosureExpr(
+    const UnitLoweringState& unit_state, mir::Lvalue lhs_structural,
+    mir::ExprId rhs_id_in_outer, mir::TypeId rhs_type) -> mir::Expr {
+  ProceduralScopeLoweringState body;
+  const mir::ProceduralVarId snapshot_binding = body.AddProceduralVar(
+      mir::ProceduralVarDecl{.name = "_lyra_nba_rhs", .type = rhs_type});
+  const mir::ExprId snapshot_ref_id = body.AddExpr(
+      mir::Expr{
+          .data =
+              mir::ProceduralVarRef{
+                  .hops = mir::ProceduralHops{.value = 0},
+                  .var = snapshot_binding},
+          .type = rhs_type});
+  const mir::ExprId assign_id = body.AddExpr(
+      mir::Expr{
+          .data =
+              mir::AssignExpr{
+                  .target = std::move(lhs_structural),
+                  .value = snapshot_ref_id},
+          .type = rhs_type});
+  const mir::StmtId stmt_id = body.AddStmt(
+      mir::Stmt{
+          .label = std::nullopt,
+          .data = mir::ExprStmt{.expr = assign_id},
+          .child_procedural_scopes = {}});
+  body.AddRootStmt(stmt_id);
+
+  mir::ClosureExpr closure;
+  closure.captures.emplace_back(
+      mir::ByValueCapture{
+          .value = rhs_id_in_outer, .binding = snapshot_binding});
+  closure.body = std::make_unique<mir::ProceduralScope>(body.Finish());
+
+  return mir::Expr{
+      .data = std::move(closure), .type = unit_state.Builtins().void_type};
+}
+
 }  // namespace
 
 auto LowerExpr(
@@ -455,15 +465,35 @@ auto LowerExpr(
                 unit_state, scope_state, proc_state, proc_scope_state,
                 hir_process, hir_process.exprs.at(a.rhs.value));
             if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+            const mir::TypeId rhs_type = (*rhs_or).type;
             const mir::ExprId rhs_id =
                 proc_scope_state.AddExpr(*std::move(rhs_or));
+            auto lhs = LowerHirLvalueProc(scope_state, proc_state, a.lhs);
+
+            if (a.kind == hir::AssignKind::kBlocking) {
+              return mir::Expr{
+                  .data = mir::AssignExpr{.target = lhs, .value = rhs_id},
+                  .type = result_type};
+            }
+
+            if (!std::holds_alternative<mir::StructuralVarRef>(lhs)) {
+              return diag::Unsupported(
+                  expr.span, diag::DiagCode::kUnsupportedAssignmentTarget,
+                  "non-blocking assignment to procedural local is not "
+                  "supported yet",
+                  diag::UnsupportedCategory::kFeature);
+            }
+
+            mir::Expr closure_expr = BuildNbaSubmitClosureExpr(
+                unit_state, std::move(lhs), rhs_id, rhs_type);
+            const mir::ExprId closure_id =
+                proc_scope_state.AddExpr(std::move(closure_expr));
             return mir::Expr{
                 .data =
-                    mir::AssignExpr{
-                        .target =
-                            LowerHirLvalueProc(scope_state, proc_state, a.lhs),
-                        .value = rhs_id},
-                .type = result_type};
+                    mir::RuntimeCallExpr{
+                        .call =
+                            mir::RuntimeSubmitNbaCall{.closure = closure_id}},
+                .type = unit_state.Builtins().void_type};
           },
           [&](const hir::ConversionExpr& cv) -> diag::Result<mir::Expr> {
             auto operand_or = LowerExpr(
@@ -598,20 +628,11 @@ auto LowerExprImpl(
                         .else_value = else_id},
                 .type = result_type};
           },
-          [&](const hir::AssignExpr& a) -> diag::Result<mir::Expr> {
-            auto rhs_or = LowerExprImpl(
-                unit_state, scope_state, ctor_state, proc_scope_state, scope,
-                scope.GetExpr(a.rhs), loop_var_mode);
-            if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-            const mir::ExprId rhs_id =
-                proc_scope_state.AddExpr(*std::move(rhs_or));
-            return mir::Expr{
-                .data =
-                    mir::AssignExpr{
-                        .target = LowerHirLvalueStructural(
-                            scope_state, ctor_state, a.lhs, loop_var_mode),
-                        .value = rhs_id},
-                .type = result_type};
+          [&](const hir::AssignExpr&) -> diag::Result<mir::Expr> {
+            throw InternalError(
+                "LowerExprImpl (structural): HIR AssignExpr does not appear "
+                "in constructor-side expressions; structural code has no "
+                "general assignment");
           },
           [&](const hir::ConversionExpr& cv) -> diag::Result<mir::Expr> {
             auto operand_or = LowerExprImpl(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -607,6 +607,12 @@ class MirDumper {
                             "closure=Expr[{}]",
                             sc.site_id.value, sc.closure.value));
                   },
+                  [&](const RuntimeSubmitNbaCall& nc) {
+                    Line(
+                        std::format(
+                            "RuntimeSubmitNbaCall closure=Expr[{}]",
+                            nc.closure.value));
+                  },
               },
               rc->call);
           Dedent();

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -152,6 +152,23 @@ void Engine::FlushRuntimeUpdates() {
 
 void Engine::ExecuteNbaRegion() {
   phase_ = SchedulerPhase::kCommitNba;
+  // Swap-then-drain: SubmitNba called during commit (re-entrancy) is rejected
+  // upstream; this swap also protects against accidental iterator invalidation
+  // if any closure does run a SubmitNba via a future path.
+  auto pending = std::move(queues_.nba);
+  queues_.nba.clear();
+  for (auto& closure : pending) {
+    closure();
+  }
+}
+
+void Engine::SubmitNba(std::function<void()> closure) {
+  if (phase_ == SchedulerPhase::kCommitNba) {
+    throw InternalError(
+        "Engine::SubmitNba: re-entrant NBA submission during NBA region "
+        "is not supported");
+  }
+  queues_.nba.push_back(std::move(closure));
 }
 
 void Engine::ExecuteObservedRegion() {

--- a/src/lyra/runtime/runtime_services.cpp
+++ b/src/lyra/runtime/runtime_services.cpp
@@ -1,0 +1,18 @@
+#include "lyra/runtime/runtime_services.hpp"
+
+#include <functional>
+#include <utility>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/runtime/engine.hpp"
+
+namespace lyra::runtime {
+
+void RuntimeServices::SubmitNba(std::function<void()> closure) {
+  if (engine_ == nullptr) {
+    throw InternalError("RuntimeServices::SubmitNba: no Engine bound");
+  }
+  engine_->SubmitNba(std::move(closure));
+}
+
+}  // namespace lyra::runtime

--- a/tests/cases/cpp/nba_basic/case.yaml
+++ b/tests/cases/cpp/nba_basic/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.nba_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q: 1

--- a/tests/cases/cpp/nba_basic/main.sv
+++ b/tests/cases/cpp/nba_basic/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  int q;
+  initial begin
+    q = 0;
+    q <= 1;
+    #1;
+  end
+endmodule

--- a/tests/cases/cpp/nba_interleaved/case.yaml
+++ b/tests/cases/cpp/nba_interleaved/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.nba_interleaved
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q: 2

--- a/tests/cases/cpp/nba_interleaved/main.sv
+++ b/tests/cases/cpp/nba_interleaved/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  int q;
+  initial begin
+    q = 1;
+    q <= 2;
+    q = 3;
+    #1;
+  end
+endmodule

--- a/tests/cases/cpp/nba_last_write_wins/case.yaml
+++ b/tests/cases/cpp/nba_last_write_wins/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.nba_last_write_wins
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q: 3

--- a/tests/cases/cpp/nba_last_write_wins/main.sv
+++ b/tests/cases/cpp/nba_last_write_wins/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  int q;
+  initial begin
+    q <= 1;
+    q <= 2;
+    q <= 3;
+    #1;
+  end
+endmodule

--- a/tests/cases/cpp/nba_self_reference/case.yaml
+++ b/tests/cases/cpp/nba_self_reference/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.nba_self_reference
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q: 15

--- a/tests/cases/cpp/nba_self_reference/main.sv
+++ b/tests/cases/cpp/nba_self_reference/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  int q;
+  initial begin
+    q = 5;
+    q <= q + 10;
+    q = 100;
+    #1;
+  end
+endmodule

--- a/tests/cases/cpp/nba_snapshot/case.yaml
+++ b/tests/cases/cpp/nba_snapshot/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.nba_snapshot
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q: 6
+    t: 5

--- a/tests/cases/cpp/nba_snapshot/main.sv
+++ b/tests/cases/cpp/nba_snapshot/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  int q;
+  int t;
+  initial begin
+    q = 5;
+    t = q;
+    q = 10;
+    q <= t + 1;
+    q = 100;
+    #1;
+  end
+endmodule

--- a/tests/cases/errors/nba_to_procedural_local/case.yaml
+++ b/tests/cases/errors/nba_to_procedural_local/case.yaml
@@ -1,0 +1,17 @@
+id: errors.nba_to_procedural_local
+tags: [errors, diag]
+input:
+  command: [dump, mir]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "main.sv:4:"
+      - "unsupported:"
+      - "non-blocking assignment to procedural local"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/nba_to_procedural_local/main.sv
+++ b/tests/cases/errors/nba_to_procedural_local/main.sv
@@ -1,0 +1,6 @@
+module Top;
+  initial begin
+    int local_q;
+    local_q <= 5;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Lower `<=` in `initial`/`final` to a closure submitted to the engine's global NBA queue. HIR carries an `AssignKind` tag on `AssignExpr`; HIR-to-MIR splits blocking (direct `mir::AssignExpr`) from non-blocking (`RuntimeSubmitNbaCall` wrapping a `ClosureExpr` that snapshots the RHS by value). cpp render emits `services_->SubmitNba(...)` since the NBA queue is engine-global, not per-module.

## Design

NBA semantics is global ordering per LRM 4.4.2, so the queue lives on `Engine`. `RuntimeServices` exposes `SubmitNba` as a forwarding hook (Module reaches Engine via its services pointer, matching how `LyraPrint` reaches `StreamDispatcher`). This is intentionally asymmetric with `RuntimeSubmitObservedCall`, where per-site last-write-wins state belongs on `Module`. The invariant: submit lives where the state lives.

Closure body uses by-value capture for the RHS snapshot; the LHS is a `StructuralVarRef` reached through `this` (lambda implicit-this capture), no `ByReferenceCapture` needed yet. NBA to a procedural local rejects with `kUnsupportedAssignmentTarget` since the process frame can die before the NBA region fires.

## Testing

- `cpp/nba_basic` -- commit timing across `#1`
- `cpp/nba_snapshot` -- RHS evaluated at submit time
- `cpp/nba_last_write_wins` -- multiple NBAs to same LHS
- `cpp/nba_interleaved` -- blocking and NBA interleaved
- `cpp/nba_self_reference` -- `q <= q + N` captures old `q`
- `errors/nba_to_procedural_local` -- diagnostic for unsupported target