### PR TITLE
Extend PackedArray operators to arbitrary bit width

### DIFF
--- a/docs/progress/integral.md
+++ b/docs/progress/integral.md
@@ -57,25 +57,29 @@ against `PackedArray`. The dispatch in `RenderExpr*` collapses to a single path.
 
 - [x] J6 -- Bitwise (`&`, `|`, `^`, `~^`, `~`) as member operators or method on `PackedArray`.
 - [x] J7 -- Arithmetic (`+`, `-`, `*`, `/`, `%`, `**`) with LRM corner cases (div-by-zero, power
-      semantics). Narrow (`<=64`) only; wide arithmetic still throws `InternalError`.
+      semantics).
 - [x] J8 -- Comparison (`==`, `!=`, `<`, `<=`, `>`, `>=`) returning a 1-bit `PackedArray`.
 - [x] J9 -- Shift (`<<`, `>>`, `>>>`) with LRM overflow (`amount >= bit_width` yields 0 /
       sign-fill).
 - [x] J10 -- Logical (`&&`, `||`, `!`, `->`, `<->`) returning a 1-bit `PackedArray`.
 - [x] J11 -- Reduction (`&a`, `|a`, `^a`, `~&a`, `~|a`, `~^a`) as `PackedArray` methods.
 - [x] J12 -- 4-state X/Z propagation across arithmetic, comparison, shift, power, logical, and unary
-      `-`. Bitwise / reduction already propagate via the view-based truth-table path. Narrow only.
-- [ ] J13 -- Archive sweep: reproduce `operators/binary/default.yaml`, `operators/unary/...`,
-      `operators/shift_overflow/...`, and their `four_state.yaml` companions.
+      `-`. Bitwise / reduction already propagate via the view-based truth-table path.
+- [x] J13 -- Wide (`>64`-bit) coverage on arithmetic, comparison, shift, divmod, and power via
+      multi-word algorithms (carry/borrow add/sub, 32x32 schoolbook multiply, top-word-first
+      compare, word+bit shift, bit-by-bit long division). 4-state X/Z propagation rides along.
+- [ ] J14 -- Archive sweep: reproduce `operators/binary/default.yaml`, `operators/unary/...`,
+      `operators/shift_overflow/...`, `datatypes/wide_integral/...`, and their `four_state.yaml`
+      companions.
 
 ### Cut 3 -- Expression dispatch consolidation
 
 Remove `RenderExprAsNative` / `RenderExprAsPackedTopLevel` split. Single `RenderExpr` path, single
 `ConversionExpr` arm.
 
-- [x] J14 -- One `RenderExpr` path. `IsPackedExplicit`, `NeedsRuntimeContainerInit`, the
+- [x] J15 -- One `RenderExpr` path. `IsPackedExplicit`, `NeedsRuntimeContainerInit`, the
       `MakeBitView` / `BitViewToInt64` bridges (if they exist by then) all retire.
-- [x] J15 -- `ConversionExpr` collapses to "construct a destination `PackedArray` from a source
+- [x] J16 -- `ConversionExpr` collapses to "construct a destination `PackedArray` from a source
       `PackedArray`" -- one case, handled by `PackedArray` itself.
 
 ## Cross-references
@@ -86,8 +90,8 @@ Remove `RenderExprAsNative` / `RenderExprAsPackedTopLevel` split. Single `Render
   (expression evaluation rules, 11.8.4 for x/z handling).
 - Archive items this workstream targets: `operators/binary`, `operators/unary`,
   `operators/shift_overflow`, `datatypes/integral`, `datatypes/packed`, `datatypes/wide_integral`.
-  Closes when J13 lands; `datatypes/wide_integral` additionally requires >64-bit arithmetic on
-  `PackedArray`.
+  Closes when J14 lands. `datatypes/wide_integral/packed_2d` belongs to `datatypes/packed` (2D
+  element index / slice), not this workstream.
 - Slang reference: `slang/ast/types/AllTypes.h:IntegralType`.
 - Legacy archive reference: `archived/include/lyra/common/type.hpp:IntegralInfo`.
 

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -303,14 +303,6 @@ auto PackedArray::ConvertFrom(
 
 namespace {
 
-auto WidthOnlyNarrow(const PackedArray& v, std::string_view op) -> void {
-  if (v.BitWidth() > 64U) {
-    throw InternalError(
-        std::string{op} +
-        ": wide (>64-bit) packed integral operator not yet implemented");
-  }
-}
-
 auto NarrowWordOf(const PackedArray& v) -> std::uint64_t {
   return v.ValueWords()[0] & MaskForWidth(v.BitWidth());
 }
@@ -325,6 +317,246 @@ auto OneBitResult(bool flag, bool is_four_state) -> PackedArray {
 // unknown plane all-1, which is the all-X value.
 auto AllX(std::uint64_t bit_width, bool is_signed) -> PackedArray {
   return PackedArray{bit_width, is_signed, true};
+}
+
+using WordBuffer =
+    absl::InlinedVector<std::uint64_t, kPackedWordsInlineCapacity>;
+
+auto MakeWordBuffer(std::uint64_t bit_width) -> WordBuffer {
+  return WordBuffer(WordCountForBits(bit_width), std::uint64_t{0});
+}
+
+auto AddWordsInto(
+    std::span<const std::uint64_t> a, std::span<const std::uint64_t> b,
+    std::span<std::uint64_t> dst, std::uint64_t bit_width) -> void {
+  std::uint64_t carry = 0;
+  for (std::size_t i = 0; i < dst.size(); ++i) {
+    const std::uint64_t aw = i < a.size() ? a[i] : 0U;
+    const std::uint64_t bw = i < b.size() ? b[i] : 0U;
+    const std::uint64_t s1 = aw + bw;
+    const std::uint64_t c1 = s1 < aw ? 1U : 0U;
+    const std::uint64_t s2 = s1 + carry;
+    const std::uint64_t c2 = s2 < s1 ? 1U : 0U;
+    dst[i] = s2;
+    carry = c1 + c2;
+  }
+  MaskUnusedTopBits(dst, bit_width);
+}
+
+auto SubWordsInto(
+    std::span<const std::uint64_t> a, std::span<const std::uint64_t> b,
+    std::span<std::uint64_t> dst, std::uint64_t bit_width) -> void {
+  std::uint64_t borrow = 0;
+  for (std::size_t i = 0; i < dst.size(); ++i) {
+    const std::uint64_t aw = i < a.size() ? a[i] : 0U;
+    const std::uint64_t bw = i < b.size() ? b[i] : 0U;
+    const std::uint64_t d1 = aw - bw;
+    const std::uint64_t b1 = aw < bw ? 1U : 0U;
+    const std::uint64_t d2 = d1 - borrow;
+    const std::uint64_t b2 = d1 < borrow ? 1U : 0U;
+    dst[i] = d2;
+    borrow = b1 + b2;
+  }
+  MaskUnusedTopBits(dst, bit_width);
+}
+
+auto Mul64x64(std::uint64_t a, std::uint64_t b)
+    -> std::pair<std::uint64_t, std::uint64_t> {
+  const std::uint64_t a_lo = a & 0xFFFFFFFFULL;
+  const std::uint64_t a_hi = a >> 32U;
+  const std::uint64_t b_lo = b & 0xFFFFFFFFULL;
+  const std::uint64_t b_hi = b >> 32U;
+  const std::uint64_t ll = a_lo * b_lo;
+  const std::uint64_t lh = a_lo * b_hi;
+  const std::uint64_t hl = a_hi * b_lo;
+  const std::uint64_t hh = a_hi * b_hi;
+  const std::uint64_t mid =
+      (ll >> 32U) + (lh & 0xFFFFFFFFULL) + (hl & 0xFFFFFFFFULL);
+  const std::uint64_t low = (ll & 0xFFFFFFFFULL) | (mid << 32U);
+  const std::uint64_t high = hh + (lh >> 32U) + (hl >> 32U) + (mid >> 32U);
+  return {low, high};
+}
+
+auto MulWordsInto(
+    std::span<const std::uint64_t> a, std::span<const std::uint64_t> b,
+    std::span<std::uint64_t> dst, std::uint64_t bit_width) -> void {
+  std::ranges::fill(dst, std::uint64_t{0});
+  for (std::size_t i = 0; i < a.size() && i < dst.size(); ++i) {
+    std::uint64_t carry = 0;
+    for (std::size_t j = 0; i + j < dst.size(); ++j) {
+      if (j >= b.size() && carry == 0U) {
+        break;
+      }
+      const std::uint64_t bw = j < b.size() ? b[j] : 0U;
+      const auto [lo, hi] = Mul64x64(a[i], bw);
+      const std::uint64_t s1 = dst[i + j] + lo;
+      const std::uint64_t c1 = s1 < lo ? 1U : 0U;
+      const std::uint64_t s2 = s1 + carry;
+      const std::uint64_t c2 = s2 < s1 ? 1U : 0U;
+      dst[i + j] = s2;
+      carry = hi + c1 + c2;
+    }
+  }
+  MaskUnusedTopBits(dst, bit_width);
+}
+
+auto UnsignedCompare(
+    std::span<const std::uint64_t> a, std::span<const std::uint64_t> b) -> int {
+  for (std::size_t i = a.size(); i-- > 0;) {
+    const std::uint64_t aw = a[i];
+    const std::uint64_t bw = i < b.size() ? b[i] : 0U;
+    if (aw != bw) {
+      return aw < bw ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+auto SignedCompare(
+    std::span<const std::uint64_t> a, std::span<const std::uint64_t> b,
+    std::uint64_t bit_width) -> int {
+  if (a.empty()) {
+    return 0;
+  }
+  const std::uint64_t rem = bit_width % 64U;
+  const std::uint64_t sign_bit =
+      rem == 0U ? std::uint64_t{1} << 63U : std::uint64_t{1} << (rem - 1U);
+  const std::uint64_t a_top = a.back() ^ sign_bit;
+  const std::uint64_t b_top = b.back() ^ sign_bit;
+  if (a_top != b_top) {
+    return a_top < b_top ? -1 : 1;
+  }
+  for (std::size_t i = a.size() - 1U; i-- > 0;) {
+    const std::uint64_t aw = a[i];
+    const std::uint64_t bw = i < b.size() ? b[i] : 0U;
+    if (aw != bw) {
+      return aw < bw ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+auto BitAt(std::span<const std::uint64_t> words, std::uint64_t pos)
+    -> std::uint64_t {
+  const auto idx = static_cast<std::size_t>(pos / 64U);
+  if (idx >= words.size()) {
+    return 0U;
+  }
+  return (words[idx] >> (pos % 64U)) & std::uint64_t{1};
+}
+
+auto ShiftLeftWordsInto(
+    std::span<const std::uint64_t> src, std::uint64_t amount,
+    std::span<std::uint64_t> dst, std::uint64_t bit_width) -> void {
+  std::ranges::fill(dst, std::uint64_t{0});
+  if (amount >= bit_width) {
+    return;
+  }
+  const std::uint64_t word_shift = amount / 64U;
+  const std::uint64_t bit_shift = amount % 64U;
+  if (bit_shift == 0U) {
+    for (std::size_t i = 0; i < src.size() && (i + word_shift) < dst.size();
+         ++i) {
+      dst[i + word_shift] = src[i];
+    }
+  } else {
+    const std::uint64_t rev = 64U - bit_shift;
+    std::uint64_t prev_high = 0U;
+    for (std::size_t i = 0; i < src.size() && (i + word_shift) < dst.size();
+         ++i) {
+      const std::uint64_t cur = src[i];
+      dst[i + word_shift] = (cur << bit_shift) | prev_high;
+      prev_high = cur >> rev;
+    }
+  }
+  MaskUnusedTopBits(dst, bit_width);
+}
+
+auto LogicalShiftRightWordsInto(
+    std::span<const std::uint64_t> src, std::uint64_t amount,
+    std::span<std::uint64_t> dst, std::uint64_t bit_width) -> void {
+  std::ranges::fill(dst, std::uint64_t{0});
+  if (amount >= bit_width) {
+    return;
+  }
+  const std::uint64_t word_shift = amount / 64U;
+  const std::uint64_t bit_shift = amount % 64U;
+  if (bit_shift == 0U) {
+    for (std::size_t i = word_shift; i < src.size(); ++i) {
+      dst[i - word_shift] = src[i];
+    }
+  } else {
+    const std::uint64_t rev = 64U - bit_shift;
+    for (std::size_t i = word_shift; i < src.size(); ++i) {
+      const std::uint64_t cur = src[i];
+      const std::uint64_t next = (i + 1U) < src.size() ? src[i + 1U] : 0U;
+      dst[i - word_shift] = (cur >> bit_shift) | (next << rev);
+    }
+  }
+  MaskUnusedTopBits(dst, bit_width);
+}
+
+auto SetBitAt(std::span<std::uint64_t> words, std::uint64_t pos) -> void {
+  const auto idx = static_cast<std::size_t>(pos / 64U);
+  words[idx] |= std::uint64_t{1} << (pos % 64U);
+}
+
+auto IsZero(std::span<const std::uint64_t> words) -> bool {
+  return std::ranges::all_of(words, [](std::uint64_t w) { return w == 0U; });
+}
+
+auto ShiftLeftOneInPlace(
+    std::span<std::uint64_t> words, std::uint64_t bit_width) -> void {
+  std::uint64_t carry = 0;
+  for (auto& w : words) {
+    const std::uint64_t new_carry = w >> 63U;
+    w = (w << 1U) | carry;
+    carry = new_carry;
+  }
+  MaskUnusedTopBits(words, bit_width);
+}
+
+// Bit-by-bit unsigned long division. `numerator` and `divisor` are read-only
+// word arrays of width `bit_width`. `divisor` must be non-zero (caller
+// handles div-by-zero). Writes quotient to `quot` and remainder to `rem`.
+auto LongDivideUnsigned(
+    std::span<const std::uint64_t> numerator,
+    std::span<const std::uint64_t> divisor, std::span<std::uint64_t> quot,
+    std::span<std::uint64_t> rem, std::uint64_t bit_width) -> void {
+  std::ranges::fill(quot, std::uint64_t{0});
+  std::ranges::fill(rem, std::uint64_t{0});
+  for (std::uint64_t pos = bit_width; pos-- > 0;) {
+    ShiftLeftOneInPlace(rem, bit_width);
+    rem[0] |= BitAt(numerator, pos);
+    if (UnsignedCompare(rem, divisor) >= 0) {
+      SubWordsInto(rem, divisor, rem, bit_width);
+      SetBitAt(quot, pos);
+    }
+  }
+}
+
+auto FillTopBits(
+    std::span<std::uint64_t> dst, std::uint64_t bit_width, std::uint64_t amount)
+    -> void {
+  if (amount == 0U) {
+    return;
+  }
+  if (amount >= bit_width) {
+    std::ranges::fill(dst, ~std::uint64_t{0});
+    MaskUnusedTopBits(dst, bit_width);
+    return;
+  }
+  const std::uint64_t start = bit_width - amount;
+  auto i = static_cast<std::size_t>(start / 64U);
+  const std::uint64_t bit_offset = start % 64U;
+  if (bit_offset != 0U) {
+    dst[i] |= ~((std::uint64_t{1} << bit_offset) - 1U);
+    ++i;
+  }
+  for (; i < dst.size(); ++i) {
+    dst[i] = ~std::uint64_t{0};
+  }
+  MaskUnusedTopBits(dst, bit_width);
 }
 
 enum class Truthiness : std::uint8_t { kKnownZero, kKnownNonzero, kUnknown };
@@ -352,83 +584,117 @@ auto TruthinessOf(const PackedArray& v) -> Truthiness {
 
 auto PackedArray::operator+(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator+");
-  WidthOnlyNarrow(*this, "operator+");
   if (HasUnknown() || other.HasUnknown()) {
     return AllX(bit_width_, is_signed_);
   }
-  const auto mask = MaskForWidth(bit_width_);
-  const auto sum = (NarrowWordOf(*this) + NarrowWordOf(other)) & mask;
-  return FromInt(
-      static_cast<std::int64_t>(sum), bit_width_, is_signed_, is_four_state_);
+  auto buf = MakeWordBuffer(bit_width_);
+  AddWordsInto(ValueWords(), other.ValueWords(), buf, bit_width_);
+  return MakeFromWordPlanes(
+      bit_width_, is_signed_, is_four_state_,
+      std::span<const std::uint64_t>{buf.data(), buf.size()}, {});
 }
 
 auto PackedArray::operator-(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator-");
-  WidthOnlyNarrow(*this, "operator-");
   if (HasUnknown() || other.HasUnknown()) {
     return AllX(bit_width_, is_signed_);
   }
-  const auto mask = MaskForWidth(bit_width_);
-  const auto diff = (NarrowWordOf(*this) - NarrowWordOf(other)) & mask;
-  return FromInt(
-      static_cast<std::int64_t>(diff), bit_width_, is_signed_, is_four_state_);
+  auto buf = MakeWordBuffer(bit_width_);
+  SubWordsInto(ValueWords(), other.ValueWords(), buf, bit_width_);
+  return MakeFromWordPlanes(
+      bit_width_, is_signed_, is_four_state_,
+      std::span<const std::uint64_t>{buf.data(), buf.size()}, {});
 }
 
 auto PackedArray::operator*(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator*");
-  WidthOnlyNarrow(*this, "operator*");
   if (HasUnknown() || other.HasUnknown()) {
     return AllX(bit_width_, is_signed_);
   }
-  const auto mask = MaskForWidth(bit_width_);
-  const auto product = (NarrowWordOf(*this) * NarrowWordOf(other)) & mask;
-  return FromInt(
-      static_cast<std::int64_t>(product), bit_width_, is_signed_,
-      is_four_state_);
+  auto buf = MakeWordBuffer(bit_width_);
+  MulWordsInto(ValueWords(), other.ValueWords(), buf, bit_width_);
+  return MakeFromWordPlanes(
+      bit_width_, is_signed_, is_four_state_,
+      std::span<const std::uint64_t>{buf.data(), buf.size()}, {});
 }
 
 auto PackedArray::operator/(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator/");
-  WidthOnlyNarrow(*this, "operator/");
   if (HasUnknown() || other.HasUnknown()) {
     return AllX(bit_width_, is_signed_);
   }
-  const auto rhs = other.ToInt64();
-  if (rhs == 0) {
+  if (IsZero(other.ValueWords())) {
     // SV LRM 11.4.4: integer division by zero on 4-state yields X for every
     // bit; on 2-state it is implementation-defined and we pick zero. The
     // default ctor encodes both directly: LogicValue defaults to all-X
     // (matching the SV `logic` default), BitValue defaults to all-zero.
     return PackedArray{bit_width_, is_signed_, is_four_state_};
   }
-  if (is_signed_) {
-    return FromInt(ToInt64() / rhs, bit_width_, true, is_four_state_);
+  const bool neg_a = is_signed_ && BitAt(ValueWords(), bit_width_ - 1U) != 0U;
+  const bool neg_b =
+      is_signed_ && BitAt(other.ValueWords(), bit_width_ - 1U) != 0U;
+  auto a_abs = MakeWordBuffer(bit_width_);
+  auto b_abs = MakeWordBuffer(bit_width_);
+  if (neg_a) {
+    SubWordsInto({}, ValueWords(), a_abs, bit_width_);
+  } else {
+    std::ranges::copy(ValueWords(), a_abs.begin());
   }
-  const auto au = NarrowWordOf(*this);
-  const auto bu = static_cast<std::uint64_t>(rhs);
-  return FromInt(
-      static_cast<std::int64_t>(au / bu), bit_width_, false, is_four_state_);
+  if (neg_b) {
+    SubWordsInto({}, other.ValueWords(), b_abs, bit_width_);
+  } else {
+    std::ranges::copy(other.ValueWords(), b_abs.begin());
+  }
+  auto quot = MakeWordBuffer(bit_width_);
+  auto rem = MakeWordBuffer(bit_width_);
+  LongDivideUnsigned(a_abs, b_abs, quot, rem, bit_width_);
+  if (neg_a != neg_b) {
+    auto neg_quot = MakeWordBuffer(bit_width_);
+    SubWordsInto({}, quot, neg_quot, bit_width_);
+    quot = std::move(neg_quot);
+  }
+  return MakeFromWordPlanes(
+      bit_width_, is_signed_, is_four_state_,
+      std::span<const std::uint64_t>{quot.data(), quot.size()}, {});
 }
 
 auto PackedArray::operator%(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator%");
-  WidthOnlyNarrow(*this, "operator%");
   if (HasUnknown() || other.HasUnknown()) {
     return AllX(bit_width_, is_signed_);
   }
-  const auto rhs = other.ToInt64();
-  if (rhs == 0) {
+  if (IsZero(other.ValueWords())) {
     // See operator/'s div-by-zero note: deliberate use of the default ctor's
     // shape-default (all-X for 4-state, zero for 2-state).
     return PackedArray{bit_width_, is_signed_, is_four_state_};
   }
-  if (is_signed_) {
-    return FromInt(ToInt64() % rhs, bit_width_, true, is_four_state_);
+  const bool neg_a = is_signed_ && BitAt(ValueWords(), bit_width_ - 1U) != 0U;
+  const bool neg_b =
+      is_signed_ && BitAt(other.ValueWords(), bit_width_ - 1U) != 0U;
+  auto a_abs = MakeWordBuffer(bit_width_);
+  auto b_abs = MakeWordBuffer(bit_width_);
+  if (neg_a) {
+    SubWordsInto({}, ValueWords(), a_abs, bit_width_);
+  } else {
+    std::ranges::copy(ValueWords(), a_abs.begin());
   }
-  const auto au = NarrowWordOf(*this);
-  const auto bu = static_cast<std::uint64_t>(rhs);
-  return FromInt(
-      static_cast<std::int64_t>(au % bu), bit_width_, false, is_four_state_);
+  if (neg_b) {
+    SubWordsInto({}, other.ValueWords(), b_abs, bit_width_);
+  } else {
+    std::ranges::copy(other.ValueWords(), b_abs.begin());
+  }
+  auto quot = MakeWordBuffer(bit_width_);
+  auto rem = MakeWordBuffer(bit_width_);
+  LongDivideUnsigned(a_abs, b_abs, quot, rem, bit_width_);
+  // SV/C truncated modulo: remainder takes the sign of the dividend.
+  if (neg_a) {
+    auto neg_rem = MakeWordBuffer(bit_width_);
+    SubWordsInto({}, rem, neg_rem, bit_width_);
+    rem = std::move(neg_rem);
+  }
+  return MakeFromWordPlanes(
+      bit_width_, is_signed_, is_four_state_,
+      std::span<const std::uint64_t>{rem.data(), rem.size()}, {});
 }
 
 auto PackedArray::operator&(const PackedArray& other) const -> PackedArray {
@@ -529,85 +795,75 @@ auto PackedArray::BitwiseXnor(const PackedArray& other) const -> PackedArray {
 
 auto PackedArray::operator==(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator==");
-  WidthOnlyNarrow(*this, "operator==");
   if (HasUnknown() || other.HasUnknown()) {
     return AllX(1U, false);
   }
   return OneBitResult(
-      NarrowWordOf(*this) == NarrowWordOf(other), is_four_state_);
+      UnsignedCompare(ValueWords(), other.ValueWords()) == 0, is_four_state_);
 }
 
 auto PackedArray::operator!=(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator!=");
-  WidthOnlyNarrow(*this, "operator!=");
   if (HasUnknown() || other.HasUnknown()) {
     return AllX(1U, false);
   }
   return OneBitResult(
-      NarrowWordOf(*this) != NarrowWordOf(other), is_four_state_);
+      UnsignedCompare(ValueWords(), other.ValueWords()) != 0, is_four_state_);
 }
 
 auto PackedArray::operator<(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator<");
-  WidthOnlyNarrow(*this, "operator<");
   if (HasUnknown() || other.HasUnknown()) {
     return AllX(1U, false);
   }
-  if (is_signed_) {
-    return OneBitResult(ToInt64() < other.ToInt64(), is_four_state_);
-  }
-  return OneBitResult(
-      NarrowWordOf(*this) < NarrowWordOf(other), is_four_state_);
+  const int cmp =
+      is_signed_ ? SignedCompare(ValueWords(), other.ValueWords(), bit_width_)
+                 : UnsignedCompare(ValueWords(), other.ValueWords());
+  return OneBitResult(cmp < 0, is_four_state_);
 }
 
 auto PackedArray::operator<=(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator<=");
-  WidthOnlyNarrow(*this, "operator<=");
   if (HasUnknown() || other.HasUnknown()) {
     return AllX(1U, false);
   }
-  if (is_signed_) {
-    return OneBitResult(ToInt64() <= other.ToInt64(), is_four_state_);
-  }
-  return OneBitResult(
-      NarrowWordOf(*this) <= NarrowWordOf(other), is_four_state_);
+  const int cmp =
+      is_signed_ ? SignedCompare(ValueWords(), other.ValueWords(), bit_width_)
+                 : UnsignedCompare(ValueWords(), other.ValueWords());
+  return OneBitResult(cmp <= 0, is_four_state_);
 }
 
 auto PackedArray::operator>(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator>");
-  WidthOnlyNarrow(*this, "operator>");
   if (HasUnknown() || other.HasUnknown()) {
     return AllX(1U, false);
   }
-  if (is_signed_) {
-    return OneBitResult(ToInt64() > other.ToInt64(), is_four_state_);
-  }
-  return OneBitResult(
-      NarrowWordOf(*this) > NarrowWordOf(other), is_four_state_);
+  const int cmp =
+      is_signed_ ? SignedCompare(ValueWords(), other.ValueWords(), bit_width_)
+                 : UnsignedCompare(ValueWords(), other.ValueWords());
+  return OneBitResult(cmp > 0, is_four_state_);
 }
 
 auto PackedArray::operator>=(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator>=");
-  WidthOnlyNarrow(*this, "operator>=");
   if (HasUnknown() || other.HasUnknown()) {
     return AllX(1U, false);
   }
-  if (is_signed_) {
-    return OneBitResult(ToInt64() >= other.ToInt64(), is_four_state_);
-  }
-  return OneBitResult(
-      NarrowWordOf(*this) >= NarrowWordOf(other), is_four_state_);
+  const int cmp =
+      is_signed_ ? SignedCompare(ValueWords(), other.ValueWords(), bit_width_)
+                 : UnsignedCompare(ValueWords(), other.ValueWords());
+  return OneBitResult(cmp >= 0, is_four_state_);
 }
 
 auto PackedArray::operator-() const -> PackedArray {
-  WidthOnlyNarrow(*this, "operator- (unary)");
   if (HasUnknown()) {
     return AllX(bit_width_, is_signed_);
   }
-  const auto mask = MaskForWidth(bit_width_);
-  return FromInt(
-      static_cast<std::int64_t>((-NarrowWordOf(*this)) & mask), bit_width_,
-      is_signed_, is_four_state_);
+  auto buf = MakeWordBuffer(bit_width_);
+  SubWordsInto({}, ValueWords(), buf, bit_width_);
+  return MakeFromWordPlanes(
+      bit_width_, is_signed_, is_four_state_,
+      std::span<const std::uint64_t>{buf.data(), buf.size()}, {});
 }
 
 auto PackedArray::operator~() const -> PackedArray {
@@ -695,60 +951,67 @@ auto PackedArray::LogicalEquivalence(const PackedArray& other) const
 
 namespace {
 
+// Capacity-saturating fold of a shift amount to a single word. Any amount
+// at or beyond `bit_width` of the operand becomes a no-op (`amt >=
+// bit_width` -> zero result), so saturating to ~0 for wide-amount values is
+// safe: callers only compare against `bit_width`.
 auto ShiftAmountAsUint(const PackedArray& amount) -> std::uint64_t {
-  if (amount.BitWidth() <= 64U) {
-    return amount.ValueWords()[0] & MaskForWidth(amount.BitWidth());
+  const auto words = amount.ValueWords();
+  for (std::size_t i = 1; i < words.size(); ++i) {
+    if (words[i] != 0U) {
+      return ~std::uint64_t{0};
+    }
   }
-  return ~std::uint64_t{0};
+  return words.empty() ? 0U : words[0];
 }
 
 }  // namespace
 
 auto PackedArray::ShiftLeft(const PackedArray& amount) const -> PackedArray {
-  WidthOnlyNarrow(*this, "ShiftLeft");
   // LRM 11.4.10: X/Z in the amount yields an all-X result; X/Z in the
   // value rides along by shifting the unknown plane in parallel.
   if (amount.HasUnknown()) {
     return AllX(bit_width_, is_signed_);
   }
   const auto amt = ShiftAmountAsUint(amount);
-  if (amt >= bit_width_) {
-    return FromInt(0, bit_width_, is_signed_, is_four_state_);
-  }
-  const auto mask = MaskForWidth(bit_width_);
-  const auto new_value = (NarrowWordOf(*this) << amt) & mask;
+  auto value_buf = MakeWordBuffer(bit_width_);
+  ShiftLeftWordsInto(ValueWords(), amt, value_buf, bit_width_);
   if (!is_four_state_) {
-    return FromInt(
-        static_cast<std::int64_t>(new_value), bit_width_, is_signed_, false);
+    return MakeFromWordPlanes(
+        bit_width_, is_signed_, false,
+        std::span<const std::uint64_t>{value_buf.data(), value_buf.size()}, {});
   }
-  const auto unk_word = UnknownWords()[0] & mask;
-  const auto new_unknown = (unk_word << amt) & mask;
-  return FromWords({new_value}, {new_unknown}, bit_width_, is_signed_, true);
+  auto unk_buf = MakeWordBuffer(bit_width_);
+  ShiftLeftWordsInto(UnknownWords(), amt, unk_buf, bit_width_);
+  return MakeFromWordPlanes(
+      bit_width_, is_signed_, true,
+      std::span<const std::uint64_t>{value_buf.data(), value_buf.size()},
+      std::span<const std::uint64_t>{unk_buf.data(), unk_buf.size()});
 }
 
 auto PackedArray::LogicalShiftRight(const PackedArray& amount) const
     -> PackedArray {
-  WidthOnlyNarrow(*this, "LogicalShiftRight");
   if (amount.HasUnknown()) {
     return AllX(bit_width_, is_signed_);
   }
   const auto amt = ShiftAmountAsUint(amount);
-  if (amt >= bit_width_) {
-    return FromInt(0, bit_width_, is_signed_, is_four_state_);
-  }
-  const auto new_value = NarrowWordOf(*this) >> amt;
+  auto value_buf = MakeWordBuffer(bit_width_);
+  LogicalShiftRightWordsInto(ValueWords(), amt, value_buf, bit_width_);
   if (!is_four_state_) {
-    return FromInt(
-        static_cast<std::int64_t>(new_value), bit_width_, is_signed_, false);
+    return MakeFromWordPlanes(
+        bit_width_, is_signed_, false,
+        std::span<const std::uint64_t>{value_buf.data(), value_buf.size()}, {});
   }
-  const auto unk_word = UnknownWords()[0] & MaskForWidth(bit_width_);
-  const auto new_unknown = unk_word >> amt;
-  return FromWords({new_value}, {new_unknown}, bit_width_, is_signed_, true);
+  auto unk_buf = MakeWordBuffer(bit_width_);
+  LogicalShiftRightWordsInto(UnknownWords(), amt, unk_buf, bit_width_);
+  return MakeFromWordPlanes(
+      bit_width_, is_signed_, true,
+      std::span<const std::uint64_t>{value_buf.data(), value_buf.size()},
+      std::span<const std::uint64_t>{unk_buf.data(), unk_buf.size()});
 }
 
 auto PackedArray::ArithmeticShiftRight(const PackedArray& amount) const
     -> PackedArray {
-  WidthOnlyNarrow(*this, "ArithmeticShiftRight");
   if (!is_signed_) {
     return LogicalShiftRight(amount);
   }
@@ -756,64 +1019,83 @@ auto PackedArray::ArithmeticShiftRight(const PackedArray& amount) const
     return AllX(bit_width_, is_signed_);
   }
   const auto amt = ShiftAmountAsUint(amount);
-  const auto signed_value = ToInt64();
-  if (amt >= bit_width_) {
-    return FromInt(signed_value < 0 ? -1 : 0, bit_width_, true, is_four_state_);
-  }
-  if (!is_four_state_) {
-    return FromInt(signed_value >> amt, bit_width_, true, false);
-  }
   // Each plane shifts with its own MSB as the fill, so an X at the top
   // extends down into the new top bits instead of degenerating to the
   // value-plane sign.
-  const auto mask = MaskForWidth(bit_width_);
-  const auto value_shifted =
-      static_cast<std::uint64_t>(signed_value >> amt) & mask;
-  const auto unk_word = UnknownWords()[0] & mask;
-  std::uint64_t unk_shifted = unk_word >> amt;
-  if ((unk_word >> (bit_width_ - 1U)) != 0U) {
-    const auto fill_mask = mask & ~MaskForWidth(bit_width_ - amt);
-    unk_shifted |= fill_mask;
+  const std::uint64_t value_sign = BitAt(ValueWords(), bit_width_ - 1U);
+  auto value_buf = MakeWordBuffer(bit_width_);
+  LogicalShiftRightWordsInto(ValueWords(), amt, value_buf, bit_width_);
+  if (value_sign != 0U) {
+    FillTopBits(value_buf, bit_width_, std::min(amt, bit_width_));
   }
-  unk_shifted &= mask;
-  return FromWords({value_shifted}, {unk_shifted}, bit_width_, true, true);
+  if (!is_four_state_) {
+    return MakeFromWordPlanes(
+        bit_width_, true, false,
+        std::span<const std::uint64_t>{value_buf.data(), value_buf.size()}, {});
+  }
+  const std::uint64_t unk_sign = BitAt(UnknownWords(), bit_width_ - 1U);
+  auto unk_buf = MakeWordBuffer(bit_width_);
+  LogicalShiftRightWordsInto(UnknownWords(), amt, unk_buf, bit_width_);
+  if (unk_sign != 0U) {
+    FillTopBits(unk_buf, bit_width_, std::min(amt, bit_width_));
+  }
+  return MakeFromWordPlanes(
+      bit_width_, true, true,
+      std::span<const std::uint64_t>{value_buf.data(), value_buf.size()},
+      std::span<const std::uint64_t>{unk_buf.data(), unk_buf.size()});
 }
 
 auto PackedArray::Power(const PackedArray& exponent) const -> PackedArray {
-  WidthOnlyNarrow(*this, "Power");
-  WidthOnlyNarrow(exponent, "Power");
   // The exponent is checked before the base so that `X ** 0 = 1` wins
   // over X-propagation from the base (LRM 11.4.10).
   if (exponent.HasUnknown()) {
     return AllX(bit_width_, is_signed_);
   }
-  const auto exp = exponent.ToInt64();
+  const auto exp_words = exponent.ValueWords();
+  for (std::size_t i = 1; i < exp_words.size(); ++i) {
+    if (exp_words[i] != 0U && exp_words[i] != ~std::uint64_t{0}) {
+      throw InternalError(
+          "PackedArray::Power: exponent magnitude exceeds 64 bits");
+    }
+  }
+  const std::uint64_t exp_low = exp_words.empty() ? 0U : exp_words[0];
+  const std::int64_t exp = exponent.IsSigned()
+                               ? SignExtendToInt64(exp_low, exponent.BitWidth())
+                               : static_cast<std::int64_t>(exp_low);
   if (exp == 0) {
     return FromInt(1, bit_width_, is_signed_, is_four_state_);
   }
   if (HasUnknown()) {
     return AllX(bit_width_, is_signed_);
   }
-  const auto base = ToInt64();
   if (exp < 0) {
-    if (base == 1) return FromInt(1, bit_width_, is_signed_, is_four_state_);
-    if (base == -1) {
-      return FromInt(
-          (exp & 1) != 0 ? -1 : 1, bit_width_, is_signed_, is_four_state_);
+    // Negative exp on integer base rounds to zero except for base == +-1.
+    const auto one = FromInt(1, bit_width_, is_signed_, is_four_state_);
+    if (UnsignedCompare(ValueWords(), one.ValueWords()) == 0) {
+      return one;
+    }
+    if (is_signed_) {
+      const auto neg_one = FromInt(-1, bit_width_, true, is_four_state_);
+      if (UnsignedCompare(ValueWords(), neg_one.ValueWords()) == 0) {
+        return FromInt(
+            (exp & 1) != 0 ? -1 : 1, bit_width_, is_signed_, is_four_state_);
+      }
     }
     return FromInt(0, bit_width_, is_signed_, is_four_state_);
   }
-  std::int64_t result = 1;
-  std::int64_t b = base;
+  PackedArray result = FromInt(1, bit_width_, is_signed_, is_four_state_);
+  PackedArray base = *this;
   std::int64_t e = exp;
   while (e > 0) {
     if ((e & 1) != 0) {
-      result *= b;
+      result = result * base;
     }
-    b *= b;
     e >>= 1;
+    if (e > 0) {
+      base = base * base;
+    }
   }
-  return FromInt(result, bit_width_, is_signed_, is_four_state_);
+  return result;
 }
 
 auto PackedArray::ReductionAnd() const -> PackedArray {

--- a/tests/cases/cpp/wide_integral_arithmetic_basic/case.yaml
+++ b/tests/cases/cpp/wide_integral_arithmetic_basic/case.yaml
@@ -1,0 +1,19 @@
+id: cpp.wide_integral_arithmetic_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a65: "65'h75bcd15"
+    sum65: "65'h12c"
+    a96: "96'h24cb016ea"
+    sum128: "128'h2ba7def3000"
+    diff128: "128'h2ba7def3000"
+    mul_max: "128'hfffffffffffffffe0000000000000001"
+    a200: "200'h2a"
+    neg_signed: "32'shffffffe2"
+    neg_wide: "128'shffffffffffffffffffffffffffffff9c"

--- a/tests/cases/cpp/wide_integral_arithmetic_basic/main.sv
+++ b/tests/cases/cpp/wide_integral_arithmetic_basic/main.sv
@@ -1,0 +1,45 @@
+module Top;
+  bit [64:0] a65;
+  bit [64:0] sum65;
+  bit [95:0] a96;
+  bit [127:0] sum128;
+  bit [127:0] diff128;
+  bit [127:0] mul_max;
+  bit [199:0] a200;
+  bit signed [31:0] neg_signed;
+  bit signed [127:0] neg_wide;
+
+  initial begin
+    bit [64:0] lhs65;
+    bit [64:0] rhs65;
+    bit [127:0] lhs128;
+    bit [127:0] rhs128;
+    bit [127:0] all_ones;
+
+    a65 = 65'd123456789;
+
+    lhs65 = 65'd100;
+    rhs65 = 65'd200;
+    sum65 = lhs65 + rhs65;
+
+    a96 = 96'd9876543210;
+
+    lhs128 = 128'd1000000000000;
+    rhs128 = 128'd2000000000000;
+    sum128 = lhs128 + rhs128;
+
+    lhs128 = 128'd5000000000000;
+    rhs128 = 128'd2000000000000;
+    diff128 = lhs128 - rhs128;
+
+    all_ones = 128'hFFFFFFFFFFFFFFFF;
+    mul_max = all_ones * all_ones;
+
+    a200 = 200'd42;
+
+    neg_signed = -30;
+
+    lhs128 = 128'd100;
+    neg_wide = -lhs128;
+  end
+endmodule

--- a/tests/cases/cpp/wide_integral_compare/case.yaml
+++ b/tests/cases/cpp/wide_integral_compare/case.yaml
@@ -1,0 +1,22 @@
+id: cpp.wide_integral_compare
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    u_eq: 1
+    u_neq: 1
+    u_lt_low: 1
+    u_lt_high: 1
+    u_gt_top: 1
+    u_le_equal: 1
+    u_ge_equal: 1
+    s_neg_lt_pos: 1
+    s_neg_gt_neg: 1
+    s_neg_le_neg: 1
+    s_pos_ge_pos: 1
+    cross_word_lt: 1

--- a/tests/cases/cpp/wide_integral_compare/main.sv
+++ b/tests/cases/cpp/wide_integral_compare/main.sv
@@ -1,0 +1,56 @@
+module Top;
+  bit u_eq;
+  bit u_neq;
+  bit u_lt_low;
+  bit u_lt_high;
+  bit u_gt_top;
+  bit u_le_equal;
+  bit u_ge_equal;
+  bit s_neg_lt_pos;
+  bit s_neg_gt_neg;
+  bit s_neg_le_neg;
+  bit s_pos_ge_pos;
+  bit cross_word_lt;
+
+  initial begin
+    bit [127:0] a;
+    bit [127:0] b;
+    bit signed [127:0] sa;
+    bit signed [127:0] sb;
+
+    a = 128'h0000_0000_0000_0001_FFFF_FFFF_FFFF_FFFF;
+    b = 128'h0000_0000_0000_0001_FFFF_FFFF_FFFF_FFFF;
+    u_eq = (a == b);
+
+    b = 128'h0000_0000_0000_0001_FFFF_FFFF_FFFF_FFFE;
+    u_neq = (a != b);
+    u_lt_low = (b < a);
+
+    a = 128'h0000_0000_0000_0002_0000_0000_0000_0000;
+    b = 128'h0000_0000_0000_0001_FFFF_FFFF_FFFF_FFFF;
+    u_lt_high = (b < a);
+    u_gt_top = (a > b);
+
+    a = 128'd42;
+    b = 128'd42;
+    u_le_equal = (a <= b);
+    u_ge_equal = (a >= b);
+
+    sa = -128'sd1;
+    sb = 128'sd1;
+    s_neg_lt_pos = (sa < sb);
+
+    sa = -128'sd1;
+    sb = -128'sd2;
+    s_neg_gt_neg = (sa > sb);
+    s_neg_le_neg = (sb <= sa);
+
+    sa = 128'sd1000;
+    sb = 128'sd1000;
+    s_pos_ge_pos = (sa >= sb);
+
+    a = 128'h0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF;
+    b = 128'h0000_0000_0000_0001_0000_0000_0000_0000;
+    cross_word_lt = (a < b);
+  end
+endmodule

--- a/tests/cases/cpp/wide_integral_divmod/case.yaml
+++ b/tests/cases/cpp/wide_integral_divmod/case.yaml
@@ -1,0 +1,21 @@
+id: cpp.wide_integral_divmod
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    div_small: "128'h2"
+    div_cross_word: "128'h10000000000000000"
+    div_max_by_two: "128'h7fffffffffffffffffffffffffffffff"
+    mod_small: "128'h2"
+    mod_cross_word: "128'h0"
+    div_signed_neg: "128'shfffffffffffffffffffffffffffffffe"
+    mod_signed_neg: "128'sh0"
+    div_signed_quot_pos: "128'sh8"
+    div_by_zero_2state: "128'h0"
+    mod_by_zero_2state: "128'h0"
+    div_by_zero_4state: "128'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/tests/cases/cpp/wide_integral_divmod/main.sv
+++ b/tests/cases/cpp/wide_integral_divmod/main.sv
@@ -1,0 +1,55 @@
+module Top;
+  bit [127:0] div_small;
+  bit [127:0] div_cross_word;
+  bit [127:0] div_max_by_two;
+  bit [127:0] mod_small;
+  bit [127:0] mod_cross_word;
+  bit signed [127:0] div_signed_neg;
+  bit signed [127:0] mod_signed_neg;
+  bit signed [127:0] div_signed_quot_pos;
+  bit [127:0] div_by_zero_2state;
+  bit [127:0] mod_by_zero_2state;
+  logic [127:0] div_by_zero_4state;
+
+  initial begin
+    bit [127:0] a;
+    bit [127:0] b;
+    bit [127:0] zero;
+    bit signed [127:0] sa;
+    bit signed [127:0] sb;
+    logic [127:0] la;
+    logic [127:0] lzero;
+
+    a = 128'd10;
+    b = 128'd4;
+    div_small = a / b;
+    mod_small = a % b;
+
+    a = 128'h2_0000_0000_0000_0000;
+    b = 128'h2;
+    div_cross_word = a / b;
+    mod_cross_word = a % b;
+
+    a = 128'hFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
+    b = 128'd2;
+    div_max_by_two = a / b;
+
+    sa = -128'sd6;
+    sb = 128'sd3;
+    div_signed_neg = sa / sb;
+    mod_signed_neg = sa % sb;
+
+    sa = -128'sd40;
+    sb = -128'sd5;
+    div_signed_quot_pos = sa / sb;
+
+    a = 128'd42;
+    zero = 128'd0;
+    div_by_zero_2state = a / zero;
+    mod_by_zero_2state = a % zero;
+
+    la = 128'd42;
+    lzero = 128'd0;
+    div_by_zero_4state = la / lzero;
+  end
+endmodule

--- a/tests/cases/cpp/wide_integral_power/case.yaml
+++ b/tests/cases/cpp/wide_integral_power/case.yaml
@@ -1,0 +1,18 @@
+id: cpp.wide_integral_power
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    pow_small: "128'h51"
+    pow_two_64: "128'h10000000000000000"
+    pow_two_127: "128'h80000000000000000000000000000000"
+    pow_two_128_wraps: "128'h0"
+    pow_neg_one_even: "128'sh1"
+    pow_neg_one_odd: "128'shffffffffffffffffffffffffffffffff"
+    pow_base_zero_exp_zero: "128'h1"
+    pow_base_zero_exp_pos: "128'h0"

--- a/tests/cases/cpp/wide_integral_power/main.sv
+++ b/tests/cases/cpp/wide_integral_power/main.sv
@@ -1,0 +1,44 @@
+module Top;
+  bit [127:0] pow_small;
+  bit [127:0] pow_two_64;
+  bit [127:0] pow_two_127;
+  bit [127:0] pow_two_128_wraps;
+  bit signed [127:0] pow_neg_one_even;
+  bit signed [127:0] pow_neg_one_odd;
+  bit [127:0] pow_base_zero_exp_zero;
+  bit [127:0] pow_base_zero_exp_pos;
+
+  initial begin
+    bit [127:0] base;
+    int exp;
+    bit signed [127:0] sbase;
+
+    base = 128'd3;
+    exp = 4;
+    pow_small = base ** exp;
+
+    base = 128'd2;
+    exp = 64;
+    pow_two_64 = base ** exp;
+
+    exp = 127;
+    pow_two_127 = base ** exp;
+
+    exp = 128;
+    pow_two_128_wraps = base ** exp;
+
+    sbase = -128'sd1;
+    exp = 10;
+    pow_neg_one_even = sbase ** exp;
+
+    exp = 11;
+    pow_neg_one_odd = sbase ** exp;
+
+    base = 128'd0;
+    exp = 0;
+    pow_base_zero_exp_zero = base ** exp;
+
+    exp = 5;
+    pow_base_zero_exp_pos = base ** exp;
+  end
+endmodule

--- a/tests/cases/cpp/wide_integral_shift/case.yaml
+++ b/tests/cases/cpp/wide_integral_shift/case.yaml
@@ -1,0 +1,20 @@
+id: cpp.wide_integral_shift
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    shl_small: "128'h10"
+    shl_cross_word: "128'h10000000000000000"
+    shl_large: "128'h10000000000000000000000000"
+    shl_amount_overflow: "128'h0"
+    shr_small: "128'h10"
+    shr_cross_word: "128'h1"
+    shr_chain: "128'h100000000"
+    sar_unsigned: "128'h7fffffffffffffffffffffffffffffff"
+    sar_signed_neg: "128'shffffffffffffffffffffffffffffffe0"
+    sar_signed_neg_top: "128'shffffffffffffffffffffffffffffffff"

--- a/tests/cases/cpp/wide_integral_shift/main.sv
+++ b/tests/cases/cpp/wide_integral_shift/main.sv
@@ -1,0 +1,43 @@
+module Top;
+  bit [127:0] shl_small;
+  bit [127:0] shl_cross_word;
+  bit [127:0] shl_large;
+  bit [127:0] shl_amount_overflow;
+  bit [127:0] shr_small;
+  bit [127:0] shr_cross_word;
+  bit [127:0] shr_chain;
+  bit [127:0] sar_unsigned;
+  bit signed [127:0] sar_signed_neg;
+  bit signed [127:0] sar_signed_neg_top;
+
+  initial begin
+    bit [127:0] a;
+    bit [127:0] tmp;
+    bit signed [127:0] sa;
+
+    a = 128'd1;
+    shl_small = a << 4;
+    shl_cross_word = a << 64;
+    shl_large = a << 100;
+    shl_amount_overflow = a << 200;
+
+    a = 128'd256;
+    shr_small = a >> 4;
+
+    a = 128'h1_00000000_00000000;
+    shr_cross_word = a >> 64;
+
+    a = 128'd1;
+    tmp = a << 64;
+    shr_chain = tmp >> 32;
+
+    a = 128'hFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
+    sar_unsigned = a >>> 1;
+
+    sa = -128'sd64;
+    sar_signed_neg = sa >>> 1;
+
+    sa = -128'sd1;
+    sar_signed_neg_top = sa >>> 100;
+  end
+endmodule

--- a/tests/cases/cpp/wide_integral_xz/case.yaml
+++ b/tests/cases/cpp/wide_integral_xz/case.yaml
@@ -1,0 +1,18 @@
+id: cpp.wide_integral_xz
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    add_xz: "128'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    sub_xz: "128'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    mul_xz: "128'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    neg_xz: "128'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    shl_xz: "128'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx0000"
+    shr_xz_amt: "128'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    cmp_xz: "1'bx"
+    shl_xz_partial: "128'h000000000000000ff000000000000000"

--- a/tests/cases/cpp/wide_integral_xz/main.sv
+++ b/tests/cases/cpp/wide_integral_xz/main.sv
@@ -1,0 +1,30 @@
+module Top;
+  logic [127:0] add_xz;
+  logic [127:0] sub_xz;
+  logic [127:0] mul_xz;
+  logic [127:0] neg_xz;
+  logic [127:0] shl_xz;
+  logic [127:0] shr_xz_amt;
+  logic cmp_xz;
+  logic [127:0] shl_xz_partial;
+
+  initial begin
+    logic [127:0] a_known;
+    logic [127:0] a_xz;
+    logic [127:0] partial;
+
+    a_known = 128'd100;
+    a_xz = 128'bxxxx;
+
+    add_xz = a_known + a_xz;
+    sub_xz = a_known - a_xz;
+    mul_xz = a_known * a_xz;
+    neg_xz = -a_xz;
+    shl_xz = a_xz << 4;
+    shr_xz_amt = a_known >> a_xz;
+    cmp_xz = (a_known < a_xz);
+
+    partial = 128'hff;
+    shl_xz_partial = partial << 60;
+  end
+endmodule

--- a/tests/framework/sv_literal.cpp
+++ b/tests/framework/sv_literal.cpp
@@ -7,6 +7,7 @@
 #include <expected>
 #include <format>
 #include <optional>
+#include <ranges>
 #include <span>
 #include <string>
 #include <string_view>
@@ -170,8 +171,7 @@ auto ParseBinaryFamilyBody(
   }
 
   std::uint64_t bit_pos = 0;
-  for (auto it = chars.rbegin(); it != chars.rend(); ++it) {
-    const char c = *it;
+  for (const char c : std::ranges::reverse_view(chars)) {
     if (c == 'x' || c == 'X' || c == 'z' || c == 'Z') {
       // Runtime 4-state encoding (see runtime/integral_format.cpp):
       //   X bit: value=1, unknown=1
@@ -314,15 +314,18 @@ auto ExpectedValue::BuildView() const -> value::RuntimeValueView {
     }
     case ExpectedValueKind::kSvLiteral: {
       if (value_words.size() == 1) {
+        const std::uint64_t unk = unknown_words.empty() ? 0U : unknown_words[0];
         return value::RuntimeValueView{
             .data = value::IntegralValueView::Narrow(
-                value_words[0], unknown_words[0], bit_width, state_kind,
-                is_signed)};
+                value_words[0], unk, bit_width, state_kind, is_signed)};
       }
+      const std::span<const std::uint64_t> unk_span =
+          state_kind == value::IntegralStateKind::kTwoState
+              ? std::span<const std::uint64_t>{}
+              : std::span<const std::uint64_t>(unknown_words);
       return value::RuntimeValueView{
           .data = value::IntegralValueView::Wide(
-              std::span<const std::uint64_t>(value_words),
-              std::span<const std::uint64_t>(unknown_words), bit_width,
+              std::span<const std::uint64_t>(value_words), unk_span, bit_width,
               state_kind, is_signed)};
     }
     case ExpectedValueKind::kStringScalar:


### PR DESCRIPTION
## Summary

Lifts every PackedArray integer operator off the 64-bit fast path so they work uniformly at any width. Multi-word add/sub/multiply/unary-/compare/shift use carry-chain or word+bit-shift loops; division and modulo use bit-by-bit long division with sign correction; power's squaring loop now drives PackedArray multiply instead of an int64 accumulator. The narrow case falls out as the N=1 word path, so the previous `WidthOnlyNarrow` gate is gone.

## Design

The single-word fast path was load-bearing for the previous 64-bit ceiling: every arithmetic operator did `NarrowWordOf(a) <op> NarrowWordOf(b)` masked to width, and signed compare went through `ToInt64`. Two ways to lift the ceiling are (1) keep the narrow fast path and bolt on a wide path beside it, or (2) write only the multi-word algorithm and let N=1 be the trivial instance. This PR takes (2): one implementation per operator, dispatch only on the shape of the result (2-state vs 4-state for sign-fill paths). The narrow case naturally allocates an `InlinedVector` with inline capacity 1, so there is no heap traffic for ordinary `int` / `longint`.

Algorithms were picked for clarity over peak throughput:

- Multiply: 32x32->64 schoolbook over the existing 64-bit words. No `__int128` (not standard C++, not used anywhere else in the codebase) and no platform builtins.
- Compare: top-word-first; signed flips the top word's sign bit and falls through to unsigned compare.
- Divide / modulo: restoring bit-by-bit long division (`bit_width` iterations of shift + compare + subtract). Knuth Algorithm D is faster but harder to read; archive yamls cap at 200 bits and this loop is plenty fast there.
- Shift: word-shift then bit-shift; 4-state value and unknown planes shift in lockstep so X/Z bits track. Arithmetic right shift uses each plane's own MSB as the fill bit, matching the existing narrow behavior where an X at the top extends down into vacated bits instead of degenerating to the value-plane sign.
- Power: squaring loop that calls `PackedArray::operator*` for both `base *= base` and the accumulator multiply.

X/Z propagation rides on `HasUnknown()` and was already width-generic at the source-or-result level; no special wide path needed beyond the operator implementations themselves.

## Testing

Six new cases under `tests/cases/cpp/wide_integral_*` cover the algorithmic surface at 65/96/128/200-bit widths: arithmetic (including 2^128 wrap on the (2^64-1)^2 multiply), compare (signed/unsigned, cross-word, edges), shift (left/right/arithmetic with sign extension), X/Z propagation through every operator, divmod (signed, div-by-zero on 2-state vs 4-state), and power (2^n up to 2^127, (-1)^n parity, base-zero edges).

One test framework bug surfaced and was fixed in passing: `IntegralValueView::Wide` rejects a zero-filled `unknown_words` for 2-state shapes, but the SV-literal parser populated one regardless. The narrow path went through `Narrow(..., unknown_words[0], ...)` so it never tripped; the bug was latent until the first wide 2-state expect literal. Parser now hands an empty span for 2-state.

The `WidthOnlyNarrow` helper has no remaining callers and is deleted.