### PR TITLE
Define operators and packed-types workstreams

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,22 +1,21 @@
 # Decisions
 
-Logged architectural decisions. Each entry records a decision with its date and rationale. Decisions
-are immutable once logged; superseded decisions are linked from the entry that supersedes them.
+Logged architectural decisions. Each entry records a decision with its rationale; the entry is
+immutable once accepted, and a superseding decision links back to the one it replaces.
+
+Decisions are reserved for choices with real trade-offs: rejected alternatives, load-bearing
+invariants, or constraints that bind the codebase going forward. Housekeeping notes (e.g., "this
+archive item is subsumed by an existing surface") do not warrant a decisions entry; record the
+reason inline at the point it matters.
 
 ## File Naming
 
-`YYYY-MM-DD-short-slug.md`, for example `2026-04-22-adopt-query-based-incremental.md`.
+`kebab-case.md`. The name describes the decision, not when it was made; the date lives inside the
+file. Existing example: `integral-representation.md`.
 
-## Entry Contents
+## Shape
 
-Each decision entry contains:
-
-- Title
-- Date
-- Status (accepted, superseded by <link>)
-- Context
-- Decision
-- Consequences
-
-Decisions are the only docs in this directory permitted to describe how a decision was reached.
-Architecture docs under `architecture/` describe the resulting permanent shape, not the process.
+There is no fixed template. The existing `integral-representation.md` is the reference for shape:
+title, date, status, the model or findings that shaped the decision, the decision itself, and the
+consequences that follow. Let the subject drive the structure; a decision with no rejected
+alternative or no load-bearing invariant probably should not be a decision entry.

--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -8,8 +8,8 @@ this file is deleted.
 
 An item is unchecked even when partial support already exists in the current build. Check off an
 item only when the corresponding archive tests can be reproduced -- or have been intentionally
-deprecated -- on the current architecture. "Intentionally deprecated" requires a `decisions/` entry;
-absent that, the item stays open.
+deprecated -- on the current architecture. Intentional deprecation is annotated inline with the
+reason; substantive architectural decisions go in `decisions/`.
 
 When a workstream has its own progress file (e.g. `control-flow.md`, `integral.md`), the granular
 sub-step tracking lives there. The corresponding archive items below remain a high-level inventory;
@@ -52,13 +52,13 @@ unique_priority_if, while).
 - [ ] datatypes/default_init
 - [ ] datatypes/enum
 - [ ] datatypes/general
-- [ ] datatypes/integral
-- [ ] datatypes/packed
+- [ ] datatypes/integral -- `integral.md`.
+- [ ] datatypes/packed -- `packed.md`.
 - [ ] datatypes/real
 - [ ] datatypes/representation
 - [ ] datatypes/string
 - [ ] datatypes/unpacked
-- [ ] datatypes/wide_integral
+- [ ] datatypes/wide_integral -- `integral.md`.
 
 ### directives
 
@@ -112,21 +112,21 @@ unique_priority_if, while).
 
 ### operators
 
-- [ ] operators/binary
+- [ ] operators/binary -- `integral.md`.
 - [ ] operators/binary_string
-- [ ] operators/case_equality
-- [ ] operators/comparison_value_temp
-- [ ] operators/compound_assignment
-- [ ] operators/concat
-- [ ] operators/inside
-- [ ] operators/replicate
-- [ ] operators/replication_patterns
-- [ ] operators/shift_overflow
-- [ ] operators/unary -- `++` / `--` is the remaining gap on integral operands; needs a new HIR/MIR
-      shape for SV side-effect ordering. The rest of the integral unary surface lives under
-      `integral.md`.
-- [ ] operators/value_temp_expansion
-- [ ] operators/wildcard_equality
+- [ ] operators/case_equality -- `operators.md`.
+- [ ] operators/comparison_value_temp -- subsumed by the binary-operator coverage in `integral.md`;
+      the archived `ValueTemp` IR shape does not exist on the current pipeline.
+- [ ] operators/compound_assignment -- `operators.md`.
+- [ ] operators/concat -- `operators.md`.
+- [ ] operators/inside -- `operators.md`.
+- [ ] operators/replicate -- `operators.md`.
+- [ ] operators/replication_patterns -- `packed.md`.
+- [ ] operators/shift_overflow -- `integral.md`.
+- [ ] operators/unary -- `integral.md` for the integral surface; `++` / `--` gap in `operators.md`.
+- [ ] operators/value_temp_expansion -- subsumed by the binary-operator coverage in `integral.md`;
+      the archived `ValueTemp` IR shape does not exist on the current pipeline.
+- [ ] operators/wildcard_equality -- `operators.md`.
 
 ### optimization
 

--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -17,8 +17,8 @@ machinery owned by another workstream; the table below lists the blockers.
 | Item    | Blocked on                                                                                 |
 | ------- | ------------------------------------------------------------------------------------------ |
 | C9, C10 | `datatypes/unpacked` (procedural unpacked array vars + `arr[i]` element-select expr).      |
-| C11     | `operators/wildcard_equality` (masked-compare runtime helper for `==?` / `!=?`).           |
-| C12     | `operators/inside` (range patterns + set-membership runtime).                              |
+| C11     | `operators.md` W2 (`==?` / `!=?` masked-compare runtime helper).                           |
+| C12     | `operators.md` W1 (basic `inside`) and W2 (wildcard items in the range list).              |
 | C16     | `datatypes/enum`.                                                                          |
 | C17     | `datatypes/string` plus the string-equality runtime helper from `operators/binary_string`. |
 
@@ -81,11 +81,11 @@ machinery owned by another workstream; the table below lists the blockers.
 - [ ] C10 -- `foreach` multi-dim, skipped dimensions, dynamic-array, queue. **Depends on** C9 plus
       `datatypes/general` (dynamic array, queue) and the `.size()` runtime query.
 - [ ] C11 -- `casez` / `casex`. Lower to an if/else cascade with masked comparisons in HIR -> MIR
-      (C++ `switch` does not support wildcard match). **Depends on** `operators/wildcard_equality`
-      for the `==?` / `!=?` runtime helper.
+      (C++ `switch` does not support wildcard match). **Depends on** `operators.md` W2 for the `==?`
+      / `!=?` runtime helper.
 - [ ] C12 -- `case (... inside ...)`. Range patterns (`[lo:hi]`) and `inside` membership; lower to
-      if/else cascade with `inside` semantics. **Depends on** `operators/inside` for the
-      set-membership runtime.
+      an if/else cascade whose conditions reuse the `InsideExpr` lowering. **Depends on**
+      `operators.md` W1 (basic `inside`) and W2 (wildcard items in the range list).
 - [x] C13 -- `unique` / `unique0` / `priority` qualifiers on `if` and `case`. HIR carries the
       qualifier as an optional `UniquePriorityCheck` field on `IfStmt` / `CaseStmt`. HIR -> MIR
       desugars the site into a `BlockStmt` that snapshots each branch's predicate into a fresh

--- a/docs/progress/integral.md
+++ b/docs/progress/integral.md
@@ -70,7 +70,9 @@ against `PackedArray`. The dispatch in `RenderExpr*` collapses to a single path.
       compare, word+bit shift, bit-by-bit long division). 4-state X/Z propagation rides along.
 - [ ] J14 -- Archive sweep: reproduce `operators/binary/default.yaml`, `operators/unary/...`,
       `operators/shift_overflow/...`, `datatypes/wide_integral/...`, and their `four_state.yaml`
-      companions.
+      companions. **Prerequisite:** `operators.md` W4..W6 (bit-select / range-select / indexed
+      part-select reads); many archive cases select sub-bits of a packed value before applying the
+      operator under test.
 
 ### Cut 3 -- Expression dispatch consolidation
 
@@ -97,7 +99,6 @@ Remove `RenderExprAsNative` / `RenderExprAsPackedTopLevel` split. Single `Render
 
 ## Remaining operator gap
 
-`++` / `--`: requires a new HIR/MIR shape (statement-level vs expression-level given SV side-effect
-ordering); tracked directly under `operators/unary` in `architecture-reset.md`. Every other binary /
-unary operator family on integral operands -- including 4-state X/Z propagation -- lives here and is
-complete.
+`++` / `--`: tracked as `operators.md` W12 (new HIR / MIR shape, statement and expression forms, LRM
+evaluate-target-once semantics). Every other binary / unary operator family on integral operands --
+including 4-state X / Z propagation -- lives here and is complete.

--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -1,0 +1,104 @@
+# Operators
+
+Tracks the operator surface that does not live in `integral.md`: set membership, wildcard / case
+equality, selectors (bit, range, indexed part-select) on both read and write sides, concatenation,
+replication, compound assignment, and the `++` / `--` family. Each archive item checkbox in
+`architecture-reset.md` is checked when its `*.yaml` cases reproduce on the current pipeline.
+
+Done when:
+
+- `operators/inside`, `operators/wildcard_equality`, `operators/case_equality`, `operators/concat`,
+  `operators/replicate`, `operators/compound_assignment`, and the `++` / `--` portion of
+  `operators/unary` reproduce.
+- `datatypes/packed/indexed_part_select` reproduces (the selector surface lives here even though the
+  archive groups it under `datatypes/packed`).
+
+The numeric IDs (W1..W12) imply execution order: each later cut assumes the earlier cuts have
+landed. Where a cut is independent the text says so.
+
+## Sub-Steps
+
+### Membership and equality
+
+- [ ] W1 -- `inside` set-membership. Add `hir::InsideExpr` / `mir::InsideExpr` carrying a left
+      operand and an item list, where each item is either a singular expression or a range
+      `(lo, hi)`. HIR -> MIR passes through; cpp emit lowers to a `PackedArray::Inside(...)` runtime
+      call. Value items compare with `==`; range items use `>= && <=`. Result is a 1-bit
+      `PackedArray` (4-state if any operand is 4-state). LRM 11.4.13 four-state corner -- "no match
+      but some compare X yields `1'bx`" -- is honored by the runtime helper. W1 alone closes
+      `operators/inside/default.yaml` and unblocks `control-flow.md` C12.
+
+- [ ] W2 -- Wildcard equality `==?` / `!=?`. Add `BinaryOp::kWildcardEq` / `kWildcardNeq` plus a
+      `PackedArray::WildcardEquals` helper that treats X / Z in the right-hand operand as
+      do-not-care while still letting X / Z in the left-hand operand mismatch (LRM 11.4.6, 11.4.13).
+      W1's value-item path retrofits to use `WildcardEquals` so wildcard items in `inside` work.
+      Closes `operators/wildcard_equality/four_state.yaml` and `operators/inside/four_state.yaml`,
+      and unblocks `control-flow.md` C11.
+
+- [ ] W3 -- Case equality `===` / `!==`. Add `BinaryOp::kCaseEq` / `kCaseNeq` plus a
+      `PackedArray::CaseEquals` helper (bit-exact 4-state compare, X matches X). Independent of W1
+      and W2. Closes `operators/case_equality/default.yaml`.
+
+### Selectors
+
+- [ ] W4 -- Bit-select read `v[idx]`. Introduce `hir::SelectExpr` / `mir::SelectExpr` whose payload
+      is a `Selector` variant. The variant arms are `kBit(index)`, `kRange(hi, lo)`,
+      `kIndexedAsc(base, width)`, and `kIndexedDesc(base, width)`; this cut wires only the `kBit`
+      arm end-to-end. Add `PackedArray::BitSelect(idx)` returning a 1-bit `PackedArray`.
+      Out-of-bounds or X / Z index yields `1'bx` (4-state) or `1'b0` (2-state) per LRM 11.5.1.
+
+- [ ] W5 -- Range-select read `v[hi:lo]`. Wire the `kRange` arm; both bounds must be constants. Add
+      `PackedArray::RangeSelect(hi, lo)` returning a `(hi - lo + 1)`-bit `PackedArray`.
+      Partially-out-of-range slices return X for the out-of-range bits when reading (LRM 11.5.1).
+
+- [ ] W6 -- Indexed part-select read `v[i+:w]` / `v[i-:w]`. Wire the `kIndexedAsc` and
+      `kIndexedDesc` arms; `width` is a constant positive integer, `base` is a runtime expression.
+      Add `PackedArray::IndexedPartSelect(base, width, direction)`. Out-of-range and X / Z base
+      follow the same LRM 11.5.1 rules as W4 / W5.
+
+- [ ] W7 -- Selector lvalue (write side). Extend HIR / MIR `Lvalue` from a bare `*Ref` variant to a
+      record carrying a root `*Ref` plus an optional `Selector` (multi-layer selectors are
+      `packed.md`). Add `PackedArray::WriteBit`, `WriteRange`, `WriteIndexedPartSelect`. Closes
+      `datatypes/packed/indexed_part_select/default.yaml` for both read and write halves.
+
+### Construction
+
+- [ ] W8 -- Concatenation read `{a, b, c}`. Add `hir::ConcatExpr` / `mir::ConcatExpr` with an
+      ordered operand list. Signed operands contribute raw bits; unsized literals are rejected at
+      slang frontend already (LRM 11.4.12). 4-state operands propagate by concatenating both value
+      and unknown planes in lockstep. Add `PackedArray::Concat(span<view>)`.
+
+- [ ] W9 -- Replication `{N{x}}`. Add `hir::ReplicationExpr` / `mir::ReplicationExpr`; multiplier
+      must be a constant non-negative non-X/Z value (LRM 11.4.12.1). Zero multiplier collapses to
+      empty and is legal only when nested inside a `ConcatExpr` with at least one positive-sized
+      sibling. Add `PackedArray::Replicate(view, n)`. String replication is deferred to the string
+      workstream.
+
+- [ ] W10 -- Concatenation lvalue `{a, b, c} = ...`. Add a `ConcatLvalue` arm to `Lvalue` carrying
+      an ordered list of sub-lvalues. HIR -> MIR snapshots the right-hand side into a `PackedArray`
+      temp and distributes its bits MSB-first into each sub-target via the same selector machinery
+      W7 provides.
+
+### Assignment families
+
+- [ ] W11 -- Compound assignment `+= -= *= /= %= &= |= ^= <<= >>= <<<= >>>=`. Add
+      `hir::CompoundAssignStmt { Lvalue target; BinaryOp op; ExprId rhs }`. HIR -> MIR snapshots
+      every index expression in `target` into fresh procedural temps before the read-modify-write so
+      the target lvalue evaluates exactly once (LRM 11.4.1). Covers `arr[i++] += x` and
+      partial-target shapes such as `data[i+:4] |= v` once W7 is in.
+
+- [ ] W12 -- `++` / `--` (prefix and postfix). Add `hir::IncrDecrStmt` and `hir::IncrDecrExpr`
+      (separate from `AssignExpr` because the expression form returns the pre- or post-value). HIR
+      -> MIR uses the same evaluate-target-once snapshot pattern as W11. Closes the `++` / `--` gap
+      noted in `architecture-reset.md` for `operators/unary`.
+
+## Cross-references
+
+- LRM anchors: 11.4.5 (case equality), 11.4.6 (wildcard equality), 11.4.10 (shift), 11.4.12 /
+  11.4.12.1 (concatenation, replication), 11.4.13 (set membership), 11.5.1 (bit-select / part-select
+  / indexed part-select).
+- `integral.md` J14 archive sweep depends on W4..W6 for any binary / shift-overflow case that
+  selects sub-bits before applying the operator.
+- `control-flow.md` C11 unblocked by W2; C12 unblocked by W1 (basic) and W2 (wildcard items).
+- `packed.md` P1..P5 extend W7's selector list to multi-layer and add field / variant selectors;
+  they assume W7 has landed.

--- a/docs/progress/packed.md
+++ b/docs/progress/packed.md
@@ -1,0 +1,58 @@
+# Packed Types
+
+Tracks the type-side packed-aggregate surface: multi-dimensional packed arrays, packed structs,
+packed unions, and assignment patterns for packed types. The operator-side selector machinery
+(single-layer bit / range / indexed part-select read and write) lives in `operators.md` and is a
+prerequisite for everything here. Each archive item checkbox in `architecture-reset.md` is checked
+when its `*.yaml` cases reproduce on the current pipeline.
+
+Done when:
+
+- `datatypes/packed/packed_2d`, `packed_3d`, `packed_struct`, `packed_union`,
+  `assignment_pattern_fill`, `assignment_pattern_multibit`, `nested_aggregates`, and
+  `packed_integral_default` reproduce.
+- `datatypes/wide_integral/packed_2d` reproduces (a 2D-indexing case wrongly grouped under
+  `wide_integral` in the archive; it belongs to this workstream).
+- `operators/replication_patterns` reproduces (`'{N{x}}` array-literal forms over packed types).
+
+The numeric IDs (P1..P5) are stable references and imply execution order.
+
+## Sub-Steps
+
+- [ ] P1 -- Multi-dim packed 2D element select. Type `bit [N-1:0][W-1:0] x` exposes `x[i]` as a
+      W-bit slice on both read and write. Extend the HIR / MIR `Lvalue` selector list from the
+      single-layer `optional<Selector>` introduced in `operators.md` W7 to `vector<Selector>`, and
+      extend `SelectExpr` analogously on the read side. `PackedArray` itself keeps a flat layout;
+      the type system carries the dimension stack so each selector picks the right contiguous bit
+      range. Closes `datatypes/packed/packed_2d` and `datatypes/wide_integral/packed_2d`.
+
+- [ ] P2 -- Multi-dim packed 3D. Same selector list machinery, exercised at depth three. Adds
+      out-of-range and X / Z index tests at every level. Closes `datatypes/packed/packed_3d`.
+
+- [ ] P3 -- Packed struct field access. Add a `kField(field_index)` arm to the `Selector` variant
+      (in addition to W4's bit / range / indexed arms). HIR resolves the slang
+      `MemberAccessExpression` to a `(field_index)` payload; MIR carries `(offset, width)` after
+      layout. Reads and writes route through the same `PackedArray::ReadRange` / `WriteRange`
+      helpers as W5 / W7. Closes `datatypes/packed/packed_struct`.
+
+- [ ] P4 -- Packed union. All members overlay the same underlying `PackedArray` bits; field access
+      reads / writes the full union width and reinterprets per the accessed member's type. No new
+      storage primitive needed; the type system distinguishes the view. Closes
+      `datatypes/packed/packed_union`.
+
+- [ ] P5 -- Assignment patterns over packed aggregates. Handles positional `'{a, b, c}`, default
+      `'{default: v}`, named `'{i: v, j: v}`, and replication-pattern `'{N{x}}` literal forms.
+      Lowers to a sequence of selector-targeted writes through the W7 / P1 machinery; no new runtime
+      primitive is needed. Closes `datatypes/packed/assignment_pattern_fill`,
+      `assignment_pattern_multibit`, `nested_aggregates`, and `operators/replication_patterns`.
+
+## Cross-references
+
+- LRM anchors: 7.2 (packed structs and unions), 7.4 (packed and unpacked arrays), 10.9 (assignment
+  patterns), 11.5.1 (bit-select / part-select on packed arrays and structs).
+- Prerequisite: `operators.md` W4..W7 must land before P1. P3 additionally needs the `Selector`
+  variant to be open for extension; introduce the `kField` arm in P3 itself.
+- `datatypes/packed/indexed_part_select` and `operators/concat`, `operators/replicate`,
+  `operators/compound_assignment` all live in `operators.md`, not here, even though the archive
+  groups some of them under `datatypes/packed`. The split follows the type-vs-operator boundary, not
+  archive directory layout.


### PR DESCRIPTION
## Summary

Carves out two new workstream files for the operator surface that is not owned by `integral.md`. `operators.md` (W1..W12) covers `inside`, wildcard / case equality, bit / range / indexed part-select on read and write sides, concatenation, replication, compound assignment, and `++` / `--`. `packed.md` (P1..P5) covers multi-dimensional packed arrays, packed structs, packed unions, and assignment patterns. The two files state their execution order, the LRM anchors that bind each cut, and which downstream items unblock (`integral.md` J14 archive sweep, `control-flow.md` C11 and C12). Cross-references in `integral.md` and `control-flow.md` are updated to point at the new workstream IDs, and `architecture-reset.md` annotates each `operators/*` and `datatypes/*` item with its owning workstream.

## Design

The split between `operators.md` and `packed.md` follows a type-vs-operator boundary rather than the archive directory layout: `datatypes/packed/indexed_part_select` lives in `operators.md` because indexed part-select is an operator on `PackedArray` values, while multi-dim packed types and packed structs live in `packed.md` because they are type-system extensions that change the shape of the selector list. The W7 selector-lvalue cut introduces a single-layer `optional<Selector>` field on `Lvalue`; P1 extends that to a `vector<Selector>` for multi-dim element access. This keeps each cut narrow.

While restructuring, two writing-guideline issues surfaced and are fixed in the same change. `docs/decisions/README.md` prescribed a `YYYY-MM-DD-slug.md` filename and a six-section template that the only existing decision file (`integral-representation.md`) did not follow; the README now matches reality (kebab-case names, no fixed template, subject drives shape). `architecture-reset.md`'s rule that intentional deprecation requires a `decisions/` entry forced housekeeping items into the wrong directory; the rule now allows inline annotation and reserves `decisions/` for substantive choices with real trade-offs. The `comparison_value_temp` and `value_temp_expansion` archive items, which exercised a pre-reset `ValueTemp` IR shape that no longer exists, are now annotated inline.