### PR TITLE
Add inside operator and consistent per-kind dispatch

### DIFF
--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -20,13 +20,18 @@ landed. Where a cut is independent the text says so.
 
 ### Membership and equality
 
-- [ ] W1 -- `inside` set-membership. Add `hir::InsideExpr` / `mir::InsideExpr` carrying a left
-      operand and an item list, where each item is either a singular expression or a range
-      `(lo, hi)`. HIR -> MIR passes through; cpp emit lowers to a `PackedArray::Inside(...)` runtime
-      call. Value items compare with `==`; range items use `>= && <=`. Result is a 1-bit
-      `PackedArray` (4-state if any operand is 4-state). LRM 11.4.13 four-state corner -- "no match
-      but some compare X yields `1'bx`" -- is honored by the runtime helper. W1 alone closes
-      `operators/inside/default.yaml` and unblocks `control-flow.md` C12.
+- [x] W1 -- `inside` set-membership. Add `hir::InsideExpr` carrying a left operand and an item list,
+      where each item is either a singular expression or a range `(lo, hi)`. HIR -> MIR desugars to
+      a logical-OR chain of comparisons over the lowered left operand: value items compare with
+      `==`; range items use `(>= lo) && (<= hi)`. MIR gains no new variant, cpp emit gains no new
+      path, and the runtime gains no new helper -- the OR-chain rides on the existing `PackedArray`
+      binary operators. LRM 11.4.13 four-state corner ("no match but some compare X yields `1'bx`")
+      is satisfied automatically because `PackedArray::LogicalOr` already implements the LRM 11.4.7
+      truth table. The left operand is lowered once to a MIR `ExprId` referenced by each comparison;
+      cpp emit re-renders each reference, so plain var-refs read the variable repeatedly
+      (idempotent) while side-effecting left operands would re-evaluate -- the archive test surface
+      uses only var-refs. A procedural-temp snapshot pattern (see C3 case selector) covers the
+      side-effect case if it becomes necessary.
 
 - [ ] W2 -- Wildcard equality `==?` / `!=?`. Add `BinaryOp::kWildcardEq` / `kWildcardNeq` plus a
       `PackedArray::WildcardEquals` helper that treats X / Z in the right-hand operand as

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -53,9 +53,21 @@ struct CallExpr {
   std::vector<ExprId> arguments;
 };
 
+struct InsideRangePair {
+  ExprId lo;
+  ExprId hi;
+};
+
+using InsideItem = std::variant<ExprId, InsideRangePair>;
+
+struct InsideExpr {
+  ExprId lhs;
+  std::vector<InsideItem> items;
+};
+
 using ExprData = std::variant<
     PrimaryExpr, UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr, CallExpr,
-    ConversionExpr>;
+    ConversionExpr, InsideExpr>;
 
 struct Expr {
   TypeId type;

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -230,6 +230,30 @@ auto RenderPackedArrayIntegerLiteral(
       unknown_init, pa.BitWidth(), signed_lit, four_state_lit);
 }
 
+auto RenderIntegerLiteralExpr(
+    const RenderContext& ctx, const mir::Expr& expr,
+    const mir::IntegerLiteral& lit) -> diag::Result<std::string> {
+  const auto& ty = ctx.Unit().GetType(expr.type);
+  if (!ty.IsPackedArray()) {
+    throw InternalError(
+        "RenderExpr: IntegerLiteral not typed as PackedArrayType");
+  }
+  return RenderPackedArrayIntegerLiteral(ty.AsPackedArray(), lit.value);
+}
+
+auto RenderStructuralParamExpr(
+    const RenderContext& ctx, const mir::StructuralParamRef& r)
+    -> diag::Result<std::string> {
+  if (r.hops.value != 0) {
+    return diag::Unsupported(
+        diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+        "cross-scope structural parameter access is not yet implemented in "
+        "cpp emit",
+        diag::UnsupportedCategory::kFeature);
+  }
+  return ctx.StructuralScope().GetStructuralParam(r.param).name;
+}
+
 }  // namespace
 
 auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
@@ -246,23 +270,85 @@ auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
       target);
 }
 
+namespace {
+
 auto RenderClosureExpr(
     const RenderContext& ctx, const mir::ClosureExpr& closure)
     -> diag::Result<std::string>;
+
+auto RenderUnaryExpr(const RenderContext& ctx, const mir::UnaryExpr& u)
+    -> diag::Result<std::string> {
+  auto operand_or = RenderExpr(ctx, ctx.Expr(u.operand));
+  if (!operand_or) return std::unexpected(std::move(operand_or.error()));
+  return RenderUnaryOp(u.op, *operand_or);
+}
+
+auto RenderBinaryExprNode(const RenderContext& ctx, const mir::BinaryExpr& b)
+    -> diag::Result<std::string> {
+  auto lhs_or = RenderExpr(ctx, ctx.Expr(b.lhs));
+  if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+  auto rhs_or = RenderExpr(ctx, ctx.Expr(b.rhs));
+  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+  return RenderBinaryOp(b.op, *lhs_or, *rhs_or);
+}
+
+auto RenderConditionalExprNode(
+    const RenderContext& ctx, const mir::ConditionalExpr& c)
+    -> diag::Result<std::string> {
+  auto cond_or = RenderConditionAsBool(ctx, ctx.Expr(c.condition));
+  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+  auto then_or = RenderExpr(ctx, ctx.Expr(c.then_value));
+  if (!then_or) return std::unexpected(std::move(then_or.error()));
+  auto else_or = RenderExpr(ctx, ctx.Expr(c.else_value));
+  if (!else_or) return std::unexpected(std::move(else_or.error()));
+  return "(" + *cond_or + " ? " + *then_or + " : " + *else_or + ")";
+}
+
+auto RenderAssignExprNode(const RenderContext& ctx, const mir::AssignExpr& a)
+    -> diag::Result<std::string> {
+  auto target_or = RenderLvalue(ctx, a.target);
+  if (!target_or) return std::unexpected(std::move(target_or.error()));
+  auto value_or = RenderExpr(ctx, ctx.Expr(a.value));
+  if (!value_or) return std::unexpected(std::move(value_or.error()));
+  return "(" + *target_or + " = " + *value_or + ")";
+}
+
+auto RenderConversionExprNode(
+    const RenderContext& ctx, const mir::Expr& expr,
+    const mir::ConversionExpr& cv) -> diag::Result<std::string> {
+  const auto& src_expr = ctx.Expr(cv.operand);
+  auto operand_or = RenderExpr(ctx, src_expr);
+  if (!operand_or) return std::unexpected(std::move(operand_or.error()));
+  const auto& src_ty = ctx.Unit().GetType(src_expr.type);
+  const auto& dst_ty = ctx.Unit().GetType(expr.type);
+  // Same-shape conversion (slang's spurious promotions): pass through.
+  // Cross-shape: route through PackedArray::ConvertFrom.
+  if (src_ty.IsPackedArray() && dst_ty.IsPackedArray()) {
+    const auto& src_pa = src_ty.AsPackedArray();
+    const auto& dst_pa = dst_ty.AsPackedArray();
+    if (src_pa.BitWidth() == dst_pa.BitWidth() &&
+        src_pa.signedness == dst_pa.signedness && src_pa.atom == dst_pa.atom) {
+      return *operand_or;
+    }
+    const char* signed_lit =
+        dst_pa.signedness == mir::Signedness::kSigned ? "true" : "false";
+    const char* four_state_lit =
+        dst_pa.atom != mir::BitAtom::kBit ? "true" : "false";
+    return std::format(
+        "lyra::value::PackedArray::ConvertFrom({}, {}, {}, {})", *operand_or,
+        dst_pa.BitWidth(), signed_lit, four_state_lit);
+  }
+  return *operand_or;
+}
+
+}  // namespace
 
 auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
     -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
           [&](const mir::IntegerLiteral& lit) -> diag::Result<std::string> {
-            const auto& ty = ctx.Unit().GetType(expr.type);
-            if (!ty.IsPackedArray()) {
-              throw InternalError(
-                  "RenderExpr: IntegerLiteral not typed as "
-                  "PackedArrayType");
-            }
-            return RenderPackedArrayIntegerLiteral(
-                ty.AsPackedArray(), lit.value);
+            return RenderIntegerLiteralExpr(ctx, expr, lit);
           },
           [&](const mir::StringLiteral& s) -> diag::Result<std::string> {
             return RenderStdStringLiteral(s.value);
@@ -274,14 +360,7 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
                 diag::UnsupportedCategory::kFeature);
           },
           [&](const mir::StructuralParamRef& r) -> diag::Result<std::string> {
-            if (r.hops.value != 0) {
-              return diag::Unsupported(
-                  diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-                  "cross-scope structural parameter access is not yet "
-                  "implemented in cpp emit",
-                  diag::UnsupportedCategory::kFeature);
-            }
-            return ctx.StructuralScope().GetStructuralParam(r.param).name;
+            return RenderStructuralParamExpr(ctx, r);
           },
           [&](const mir::StructuralVarRef& m) -> diag::Result<std::string> {
             return RenderStructuralVarName(ctx, m);
@@ -290,65 +369,19 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
             return LookupProceduralVarName(ctx, l);
           },
           [&](const mir::UnaryExpr& u) -> diag::Result<std::string> {
-            auto operand_or = RenderExpr(ctx, ctx.Expr(u.operand));
-            if (!operand_or) {
-              return std::unexpected(std::move(operand_or.error()));
-            }
-            return RenderUnaryOp(u.op, *operand_or);
+            return RenderUnaryExpr(ctx, u);
           },
           [&](const mir::BinaryExpr& b) -> diag::Result<std::string> {
-            auto lhs_or = RenderExpr(ctx, ctx.Expr(b.lhs));
-            if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-            auto rhs_or = RenderExpr(ctx, ctx.Expr(b.rhs));
-            if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-            return RenderBinaryOp(b.op, *lhs_or, *rhs_or);
+            return RenderBinaryExprNode(ctx, b);
           },
           [&](const mir::ConditionalExpr& c) -> diag::Result<std::string> {
-            auto cond_or = RenderConditionAsBool(ctx, ctx.Expr(c.condition));
-            if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-            auto then_or = RenderExpr(ctx, ctx.Expr(c.then_value));
-            if (!then_or) return std::unexpected(std::move(then_or.error()));
-            auto else_or = RenderExpr(ctx, ctx.Expr(c.else_value));
-            if (!else_or) return std::unexpected(std::move(else_or.error()));
-            return "(" + *cond_or + " ? " + *then_or + " : " + *else_or + ")";
+            return RenderConditionalExprNode(ctx, c);
           },
           [&](const mir::AssignExpr& a) -> diag::Result<std::string> {
-            auto target_or = RenderLvalue(ctx, a.target);
-            if (!target_or) {
-              return std::unexpected(std::move(target_or.error()));
-            }
-            auto value_or = RenderExpr(ctx, ctx.Expr(a.value));
-            if (!value_or) return std::unexpected(std::move(value_or.error()));
-            return "(" + *target_or + " = " + *value_or + ")";
+            return RenderAssignExprNode(ctx, a);
           },
           [&](const mir::ConversionExpr& cv) -> diag::Result<std::string> {
-            const auto& src_expr = ctx.Expr(cv.operand);
-            auto operand_or = RenderExpr(ctx, src_expr);
-            if (!operand_or) {
-              return std::unexpected(std::move(operand_or.error()));
-            }
-            const auto& src_ty = ctx.Unit().GetType(src_expr.type);
-            const auto& dst_ty = ctx.Unit().GetType(expr.type);
-            // Same-shape conversion (slang's spurious promotions): pass
-            // through. Cross-shape: route through PackedArray::ConvertFrom.
-            if (src_ty.IsPackedArray() && dst_ty.IsPackedArray()) {
-              const auto& src_pa = src_ty.AsPackedArray();
-              const auto& dst_pa = dst_ty.AsPackedArray();
-              if (src_pa.BitWidth() == dst_pa.BitWidth() &&
-                  src_pa.signedness == dst_pa.signedness &&
-                  src_pa.atom == dst_pa.atom) {
-                return *operand_or;
-              }
-              const char* signed_lit =
-                  dst_pa.signedness == mir::Signedness::kSigned ? "true"
-                                                                : "false";
-              const char* four_state_lit =
-                  dst_pa.atom != mir::BitAtom::kBit ? "true" : "false";
-              return std::format(
-                  "lyra::value::PackedArray::ConvertFrom({}, {}, {}, {})",
-                  *operand_or, dst_pa.BitWidth(), signed_lit, four_state_lit);
-            }
-            return *operand_or;
+            return RenderConversionExprNode(ctx, expr, cv);
           },
           [](const mir::CallExpr&) -> diag::Result<std::string> {
             return diag::Unsupported(
@@ -365,6 +398,8 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
       },
       expr.data);
 }
+
+namespace {
 
 auto RenderClosureExpr(
     const RenderContext& ctx, const mir::ClosureExpr& closure)
@@ -409,6 +444,8 @@ auto RenderClosureExpr(
 
   return "[" + captures_text + "]() {\n" + *body_or + "}";
 }
+
+}  // namespace
 
 auto RenderConditionAsBool(const RenderContext& ctx, const mir::Expr& expr)
     -> diag::Result<std::string> {

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -52,6 +52,184 @@ auto RenderForInit(const RenderContext& ctx, const mir::ForInit& init)
       init);
 }
 
+auto RenderTimedStmt(
+    const RenderContext& ctx, const mir::TimedStmt& s, std::size_t indent)
+    -> diag::Result<std::string> {
+  std::string out;
+  std::visit(
+      Overloaded{
+          [&](const mir::DelayControl& d) {
+            out += Indent(indent) + "co_await lyra::runtime::Delay(" +
+                   std::to_string(d.duration) + ");\n";
+          },
+      },
+      s.timing);
+  auto inner_or =
+      RenderStmt(ctx, ctx.ProceduralScope().stmts.at(s.stmt.value), indent);
+  if (!inner_or) return std::unexpected(std::move(inner_or.error()));
+  out += *inner_or;
+  return out;
+}
+
+auto RenderProceduralVarDeclStmt(
+    const RenderContext& ctx, const mir::ProceduralVarDeclStmt& s,
+    std::size_t indent) -> diag::Result<std::string> {
+  const auto& lv =
+      ctx.ProceduralScopeAtHops(s.target.hops).vars.at(s.target.var.value);
+  auto type_or = RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), lv.type);
+  if (!type_or) return std::unexpected(std::move(type_or.error()));
+  const auto& ty = ctx.Unit().GetType(lv.type);
+  if (s.init.has_value()) {
+    const auto& init_expr = ctx.ProceduralScope().exprs.at(s.init->value);
+    auto init_or = RenderExpr(ctx, init_expr);
+    if (!init_or) return std::unexpected(std::move(init_or.error()));
+    return Indent(indent) + *type_or + " " + lv.name + " = " + *init_or + ";\n";
+  }
+  if (ty.IsPackedArray()) {
+    return Indent(indent) + *type_or + " " + lv.name + "{" +
+           RenderPackedArrayCtorArgs(ty.AsPackedArray()) + "};\n";
+  }
+  return Indent(indent) + *type_or + " " + lv.name + "{};\n";
+}
+
+auto RenderExprStmt(
+    const RenderContext& ctx, const mir::ExprStmt& s, std::size_t indent)
+    -> diag::Result<std::string> {
+  const auto& expr = ctx.ProceduralScope().exprs.at(s.expr.value);
+  auto rendered_or = RenderExpr(ctx, expr);
+  if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
+  return Indent(indent) + *rendered_or + ";\n";
+}
+
+auto RenderBlockStmtNode(
+    const RenderContext& ctx, const mir::Stmt& stmt, const mir::BlockStmt& s,
+    std::size_t indent) -> diag::Result<std::string> {
+  const auto& child = stmt.child_procedural_scopes.at(s.scope.value);
+  std::string result = Indent(indent) + "{\n";
+  auto child_or = RenderNestedProceduralScope(ctx, child, indent + 1);
+  if (!child_or) return std::unexpected(std::move(child_or.error()));
+  result += *child_or;
+  result += Indent(indent) + "}\n";
+  return result;
+}
+
+auto RenderIfStmtNode(
+    const RenderContext& ctx, const mir::Stmt& stmt, const mir::IfStmt& s,
+    std::size_t indent) -> diag::Result<std::string> {
+  const auto& cond_expr = ctx.ProceduralScope().exprs.at(s.condition.value);
+  const auto& then_scope = stmt.child_procedural_scopes.at(s.then_scope.value);
+  auto cond_or = RenderConditionAsBool(ctx, cond_expr);
+  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+  auto then_or = RenderNestedProceduralScope(ctx, then_scope, indent + 1);
+  if (!then_or) return std::unexpected(std::move(then_or.error()));
+  std::string result;
+  result += Indent(indent) + "if (" + *cond_or + ") {\n";
+  result += *then_or;
+  result += Indent(indent) + "}";
+  if (s.else_scope.has_value()) {
+    const auto& else_scope =
+        stmt.child_procedural_scopes.at(s.else_scope->value);
+    auto else_or = RenderNestedProceduralScope(ctx, else_scope, indent + 1);
+    if (!else_or) return std::unexpected(std::move(else_or.error()));
+    result += " else {\n";
+    result += *else_or;
+    result += Indent(indent) + "}";
+  }
+  result += "\n";
+  return result;
+}
+
+auto RenderConstructOwnedObjectStmt(
+    const RenderContext& ctx, const mir::ConstructOwnedObjectStmt& s,
+    std::size_t indent) -> diag::Result<std::string> {
+  const auto& var = ctx.StructuralScope().GetStructuralVar(s.target);
+  const auto& target_scope =
+      ctx.StructuralScope().GetChildStructuralScope(s.scope_id);
+  std::string args_str;
+  for (std::size_t i = 0; i < s.args.size(); ++i) {
+    if (i != 0) args_str += ", ";
+    auto arg_or = RenderExpr(ctx, ctx.Expr(s.args[i]));
+    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+    args_str += *arg_or;
+  }
+  const std::string make =
+      "std::make_unique<" + target_scope.name + ">(" + args_str + ")";
+  if (mir::IsVectorOfOwningObjectType(ctx.Unit(), var.type)) {
+    return Indent(indent) + var.name + ".push_back(" + make + ");\n";
+  }
+  if (mir::IsOwningObjectType(ctx.Unit(), var.type)) {
+    return Indent(indent) + var.name + " = " + make + ";\n";
+  }
+  throw InternalError(
+      "ConstructOwnedObjectStmt target is not an owning object var");
+}
+
+auto RenderForStmtNode(
+    const RenderContext& ctx, const mir::Stmt& stmt, const mir::ForStmt& s,
+    std::size_t indent) -> diag::Result<std::string> {
+  std::string init;
+  for (std::size_t i = 0; i < s.init.size(); ++i) {
+    if (i != 0) init += ", ";
+    auto init_or = RenderForInit(ctx, s.init[i]);
+    if (!init_or) return std::unexpected(std::move(init_or.error()));
+    init += *init_or;
+  }
+  std::string cond;
+  if (s.condition.has_value()) {
+    const auto& cond_expr = ctx.ProceduralScope().exprs.at(s.condition->value);
+    auto cond_or = RenderConditionAsBool(ctx, cond_expr);
+    if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+    cond = *std::move(cond_or);
+  }
+  std::string step;
+  for (std::size_t i = 0; i < s.step.size(); ++i) {
+    if (i != 0) step += ", ";
+    const auto& step_expr = ctx.ProceduralScope().exprs.at(s.step[i].value);
+    auto step_or = RenderExpr(ctx, step_expr);
+    if (!step_or) return std::unexpected(std::move(step_or.error()));
+    step += *step_or;
+  }
+  const auto& scope = stmt.child_procedural_scopes.at(s.scope.value);
+  auto body_or = RenderNestedProceduralScope(ctx, scope, indent + 1);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+  std::string result =
+      Indent(indent) + "for (" + init + "; " + cond + "; " + step + ") {\n";
+  result += *body_or;
+  result += Indent(indent) + "}\n";
+  return result;
+}
+
+auto RenderWhileStmtNode(
+    const RenderContext& ctx, const mir::Stmt& stmt, const mir::WhileStmt& s,
+    std::size_t indent) -> diag::Result<std::string> {
+  const auto& cond_expr = ctx.ProceduralScope().exprs.at(s.condition.value);
+  auto cond_or = RenderConditionAsBool(ctx, cond_expr);
+  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+  const auto& scope = stmt.child_procedural_scopes.at(s.scope.value);
+  auto body_or = RenderNestedProceduralScope(ctx, scope, indent + 1);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+  std::string result =
+      Indent(indent) + "while (" + *std::move(cond_or) + ") {\n";
+  result += *body_or;
+  result += Indent(indent) + "}\n";
+  return result;
+}
+
+auto RenderDoWhileStmtNode(
+    const RenderContext& ctx, const mir::Stmt& stmt, const mir::DoWhileStmt& s,
+    std::size_t indent) -> diag::Result<std::string> {
+  const auto& cond_expr = ctx.ProceduralScope().exprs.at(s.condition.value);
+  auto cond_or = RenderConditionAsBool(ctx, cond_expr);
+  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+  const auto& scope = stmt.child_procedural_scopes.at(s.scope.value);
+  auto body_or = RenderNestedProceduralScope(ctx, scope, indent + 1);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+  std::string result = Indent(indent) + "do {\n";
+  result += *body_or;
+  result += Indent(indent) + "} while (" + *std::move(cond_or) + ");\n";
+  return result;
+}
+
 }  // namespace
 
 auto RenderStmt(
@@ -67,194 +245,33 @@ auto RenderStmt(
             return Indent(indent) + ";\n";
           },
           [&](const mir::TimedStmt& s) -> diag::Result<std::string> {
-            std::string out;
-            std::visit(
-                Overloaded{
-                    [&](const mir::DelayControl& d) {
-                      out += Indent(indent) + "co_await lyra::runtime::Delay(" +
-                             std::to_string(d.duration) + ");\n";
-                    },
-                },
-                s.timing);
-            auto inner_or = RenderStmt(
-                ctx, ctx.ProceduralScope().stmts.at(s.stmt.value), indent);
-            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
-            out += *inner_or;
-            return out;
+            return RenderTimedStmt(ctx, s, indent);
           },
           [&](const mir::ProceduralVarDeclStmt& s)
               -> diag::Result<std::string> {
-            const auto& lv = ctx.ProceduralScopeAtHops(s.target.hops)
-                                 .vars.at(s.target.var.value);
-            auto type_or =
-                RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), lv.type);
-            if (!type_or) return std::unexpected(std::move(type_or.error()));
-            const auto& ty = ctx.Unit().GetType(lv.type);
-            if (s.init.has_value()) {
-              const auto& init_expr =
-                  ctx.ProceduralScope().exprs.at(s.init->value);
-              auto init_or = RenderExpr(ctx, init_expr);
-              if (!init_or) {
-                return std::unexpected(std::move(init_or.error()));
-              }
-              return Indent(indent) + *type_or + " " + lv.name + " = " +
-                     *init_or + ";\n";
-            }
-            if (ty.IsPackedArray()) {
-              return Indent(indent) + *type_or + " " + lv.name + "{" +
-                     RenderPackedArrayCtorArgs(ty.AsPackedArray()) + "};\n";
-            }
-            return Indent(indent) + *type_or + " " + lv.name + "{};\n";
+            return RenderProceduralVarDeclStmt(ctx, s, indent);
           },
           [&](const mir::ExprStmt& s) -> diag::Result<std::string> {
-            const auto& expr = ctx.ProceduralScope().exprs.at(s.expr.value);
-            auto rendered_or = RenderExpr(ctx, expr);
-            if (!rendered_or) {
-              return std::unexpected(std::move(rendered_or.error()));
-            }
-            return Indent(indent) + *rendered_or + ";\n";
+            return RenderExprStmt(ctx, s, indent);
           },
           [&](const mir::BlockStmt& s) -> diag::Result<std::string> {
-            const auto& child = stmt.child_procedural_scopes.at(s.scope.value);
-            std::string result = Indent(indent) + "{\n";
-            auto child_or = RenderNestedProceduralScope(ctx, child, indent + 1);
-            if (!child_or) return std::unexpected(std::move(child_or.error()));
-            result += *child_or;
-            result += Indent(indent) + "}\n";
-            return result;
+            return RenderBlockStmtNode(ctx, stmt, s, indent);
           },
           [&](const mir::IfStmt& s) -> diag::Result<std::string> {
-            const auto& cond_expr =
-                ctx.ProceduralScope().exprs.at(s.condition.value);
-            const auto& then_scope =
-                stmt.child_procedural_scopes.at(s.then_scope.value);
-            auto cond_or = RenderConditionAsBool(ctx, cond_expr);
-            if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-            auto then_or =
-                RenderNestedProceduralScope(ctx, then_scope, indent + 1);
-            if (!then_or) return std::unexpected(std::move(then_or.error()));
-            std::string result;
-            result += Indent(indent) + "if (" + *cond_or + ") {\n";
-            result += *then_or;
-            result += Indent(indent) + "}";
-            if (s.else_scope.has_value()) {
-              const auto& else_scope =
-                  stmt.child_procedural_scopes.at(s.else_scope->value);
-              auto else_or =
-                  RenderNestedProceduralScope(ctx, else_scope, indent + 1);
-              if (!else_or) return std::unexpected(std::move(else_or.error()));
-              result += " else {\n";
-              result += *else_or;
-              result += Indent(indent) + "}";
-            }
-            result += "\n";
-            return result;
+            return RenderIfStmtNode(ctx, stmt, s, indent);
           },
           [&](const mir::ConstructOwnedObjectStmt& s)
               -> diag::Result<std::string> {
-            const auto& var = ctx.StructuralScope().GetStructuralVar(s.target);
-            const auto& target_scope =
-                ctx.StructuralScope().GetChildStructuralScope(s.scope_id);
-            std::string args_str;
-            for (std::size_t i = 0; i < s.args.size(); ++i) {
-              if (i != 0) args_str += ", ";
-              auto arg_or = RenderExpr(ctx, ctx.Expr(s.args[i]));
-              if (!arg_or) return std::unexpected(std::move(arg_or.error()));
-              args_str += *arg_or;
-            }
-            const std::string make =
-                "std::make_unique<" + target_scope.name + ">(" + args_str + ")";
-            if (mir::IsVectorOfOwningObjectType(ctx.Unit(), var.type)) {
-              return Indent(indent) + var.name + ".push_back(" + make + ");\n";
-            }
-            if (mir::IsOwningObjectType(ctx.Unit(), var.type)) {
-              return Indent(indent) + var.name + " = " + make + ";\n";
-            }
-            throw InternalError(
-                "ConstructOwnedObjectStmt target is not an owning object var");
+            return RenderConstructOwnedObjectStmt(ctx, s, indent);
           },
           [&](const mir::ForStmt& s) -> diag::Result<std::string> {
-            std::string init;
-            for (std::size_t i = 0; i < s.init.size(); ++i) {
-              if (i != 0) {
-                init += ", ";
-              }
-              auto init_or = RenderForInit(ctx, s.init[i]);
-              if (!init_or) {
-                return std::unexpected(std::move(init_or.error()));
-              }
-              init += *init_or;
-            }
-            std::string cond;
-            if (s.condition.has_value()) {
-              const auto& cond_expr =
-                  ctx.ProceduralScope().exprs.at(s.condition->value);
-              auto cond_or = RenderConditionAsBool(ctx, cond_expr);
-              if (!cond_or) {
-                return std::unexpected(std::move(cond_or.error()));
-              }
-              cond = *std::move(cond_or);
-            }
-            std::string step;
-            for (std::size_t i = 0; i < s.step.size(); ++i) {
-              if (i != 0) {
-                step += ", ";
-              }
-              const auto& step_expr =
-                  ctx.ProceduralScope().exprs.at(s.step[i].value);
-              auto step_or = RenderExpr(ctx, step_expr);
-              if (!step_or) {
-                return std::unexpected(std::move(step_or.error()));
-              }
-              step += *step_or;
-            }
-            const auto& scope = stmt.child_procedural_scopes.at(s.scope.value);
-            auto rendered_for_or =
-                RenderNestedProceduralScope(ctx, scope, indent + 1);
-            if (!rendered_for_or) {
-              return std::unexpected(std::move(rendered_for_or.error()));
-            }
-            std::string result = Indent(indent) + "for (" + init + "; " + cond +
-                                 "; " + step + ") {\n";
-            result += *rendered_for_or;
-            result += Indent(indent) + "}\n";
-            return result;
+            return RenderForStmtNode(ctx, stmt, s, indent);
           },
           [&](const mir::WhileStmt& s) -> diag::Result<std::string> {
-            const auto& cond_expr =
-                ctx.ProceduralScope().exprs.at(s.condition.value);
-            auto cond_or = RenderConditionAsBool(ctx, cond_expr);
-            if (!cond_or) {
-              return std::unexpected(std::move(cond_or.error()));
-            }
-            const auto& scope = stmt.child_procedural_scopes.at(s.scope.value);
-            auto body_or = RenderNestedProceduralScope(ctx, scope, indent + 1);
-            if (!body_or) {
-              return std::unexpected(std::move(body_or.error()));
-            }
-            std::string result =
-                Indent(indent) + "while (" + *std::move(cond_or) + ") {\n";
-            result += *body_or;
-            result += Indent(indent) + "}\n";
-            return result;
+            return RenderWhileStmtNode(ctx, stmt, s, indent);
           },
           [&](const mir::DoWhileStmt& s) -> diag::Result<std::string> {
-            const auto& cond_expr =
-                ctx.ProceduralScope().exprs.at(s.condition.value);
-            auto cond_or = RenderConditionAsBool(ctx, cond_expr);
-            if (!cond_or) {
-              return std::unexpected(std::move(cond_or.error()));
-            }
-            const auto& scope = stmt.child_procedural_scopes.at(s.scope.value);
-            auto body_or = RenderNestedProceduralScope(ctx, scope, indent + 1);
-            if (!body_or) {
-              return std::unexpected(std::move(body_or.error()));
-            }
-            std::string result = Indent(indent) + "do {\n";
-            result += *body_or;
-            result +=
-                Indent(indent) + "} while (" + *std::move(cond_or) + ");\n";
-            return result;
+            return RenderDoWhileStmtNode(ctx, stmt, s, indent);
           },
           [&](const mir::BreakStmt&) -> diag::Result<std::string> {
             return Indent(indent) + "break;\n";

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -466,6 +466,26 @@ class HirDumper {
     return *scope_stack_[scope_stack_.size() - 1 - hops.value];
   }
 
+  static auto FormatInsideExprNode(const InsideExpr& in) -> std::string {
+    std::string items;
+    for (std::size_t i = 0; i < in.items.size(); ++i) {
+      if (i != 0) items += ", ";
+      items += std::visit(
+          Overloaded{
+              [](const ExprId& id) {
+                return std::format("Expr[{}]", id.value);
+              },
+              [](const InsideRangePair& r) {
+                return std::format(
+                    "[Expr[{}]:Expr[{}]]", r.lo.value, r.hi.value);
+              },
+          },
+          in.items[i]);
+    }
+    return std::format(
+        "InsideExpr lhs=Expr[{}] items=[{}]", in.lhs.value, items);
+  }
+
   [[nodiscard]] auto FormatExpr(const Expr& e) const -> std::string {
     std::string formatted = std::visit(
         Overloaded{
@@ -513,25 +533,7 @@ class HirDumper {
                   FormatConversionKind(cv.kind), cv.operand.value);
             },
             [](const InsideExpr& in) -> std::string {
-              std::string items;
-              for (std::size_t i = 0; i < in.items.size(); ++i) {
-                if (i != 0) {
-                  items += ", ";
-                }
-                items += std::visit(
-                    Overloaded{
-                        [](const ExprId& id) {
-                          return std::format("Expr[{}]", id.value);
-                        },
-                        [](const InsideRangePair& r) {
-                          return std::format(
-                              "[Expr[{}]:Expr[{}]]", r.lo.value, r.hi.value);
-                        },
-                    },
-                    in.items[i]);
-              }
-              return std::format(
-                  "InsideExpr lhs=Expr[{}] items=[{}]", in.lhs.value, items);
+              return FormatInsideExprNode(in);
             },
         },
         e.data);
@@ -655,6 +657,228 @@ class HirDumper {
     Dedent();
   }
 
+  void DumpVarDeclStmtNode(const Process& p, StmtId id, const VarDeclStmt& v) {
+    Line(
+        std::format(
+            "Stmt[{}] VarDeclStmt var=ProceduralVar[{}]", id.value,
+            v.var.value));
+    if (v.init.has_value()) {
+      Indent();
+      Line(
+          std::format(
+              "init: Expr[{}] {}", v.init->value, FormatProcExpr(p, *v.init)));
+      Dedent();
+    }
+  }
+
+  void DumpExprStmtNode(const Process& p, StmtId id, const ExprStmt& e) {
+    Line(
+        std::format("Stmt[{}] ExprStmt expr=Expr[{}]", id.value, e.expr.value));
+    Indent();
+    Line(std::format("Expr[{}] {}", e.expr.value, FormatProcExpr(p, e.expr)));
+    Dedent();
+  }
+
+  void DumpBlockStmtNode(const Process& p, StmtId id, const BlockStmt& b) {
+    Line(
+        std::format(
+            "Stmt[{}] BlockStmt (count={})", id.value, b.statements.size()));
+    Indent();
+    for (const auto child : b.statements) {
+      DumpStmt(p, child);
+    }
+    Dedent();
+  }
+
+  void DumpIfStmtNode(const Process& p, StmtId id, const IfStmt& i) {
+    Line(
+        std::format(
+            "Stmt[{}] IfStmt{} cond=Expr[{}]", id.value,
+            FormatUniquePriorityCheck(i.check), i.condition.value));
+    Indent();
+    Line(
+        std::format(
+            "Expr[{}] {}", i.condition.value, FormatProcExpr(p, i.condition)));
+    Line("then:");
+    Indent();
+    DumpStmt(p, i.then_stmt);
+    Dedent();
+    if (i.else_stmt.has_value()) {
+      Line("else:");
+      Indent();
+      DumpStmt(p, *i.else_stmt);
+      Dedent();
+    }
+    Dedent();
+  }
+
+  void DumpCaseStmtNode(const Process& p, StmtId id, const CaseStmt& c) {
+    Line(
+        std::format(
+            "Stmt[{}] CaseStmt{} cond=Expr[{}] (items={})", id.value,
+            FormatUniquePriorityCheck(c.check), c.condition.value,
+            c.items.size()));
+    Indent();
+    Line(
+        std::format(
+            "Expr[{}] {}", c.condition.value, FormatProcExpr(p, c.condition)));
+    for (std::size_t k = 0; k < c.items.size(); ++k) {
+      const auto& item = c.items[k];
+      std::string labels_str;
+      for (std::size_t m = 0; m < item.labels.size(); ++m) {
+        if (m != 0) labels_str += ", ";
+        labels_str += std::format("Expr[{}]", item.labels[m].value);
+      }
+      Line(std::format("item[{}] labels=[{}]", k, labels_str));
+      Indent();
+      for (const hir::ExprId label_id : item.labels) {
+        Line(
+            std::format(
+                "Expr[{}] {}", label_id.value, FormatProcExpr(p, label_id)));
+      }
+      Line("stmt:");
+      Indent();
+      DumpStmt(p, item.stmt);
+      Dedent();
+      Dedent();
+    }
+    if (c.default_stmt.has_value()) {
+      Line("default:");
+      Indent();
+      DumpStmt(p, *c.default_stmt);
+      Dedent();
+    }
+    Dedent();
+  }
+
+  void DumpForStmtNode(const Process& p, StmtId id, const ForStmt& f) {
+    Line(
+        std::format(
+            "Stmt[{}] ForStmt (init={}, step={})", id.value, f.init.size(),
+            f.step.size()));
+    Indent();
+    for (std::size_t k = 0; k < f.init.size(); ++k) {
+      std::visit(
+          Overloaded{
+              [&](const ForInitDecl& d) {
+                Line(
+                    std::format(
+                        "init[{}]: Decl var=ProceduralVar[{}]", k,
+                        d.var.value));
+                if (d.init.has_value()) {
+                  Indent();
+                  Line(
+                      std::format(
+                          "Expr[{}] {}", d.init->value,
+                          FormatProcExpr(p, *d.init)));
+                  Dedent();
+                }
+              },
+              [&](const ForInitExpr& e) {
+                Line(
+                    std::format(
+                        "init[{}]: Expr[{}] {}", k, e.expr.value,
+                        FormatProcExpr(p, e.expr)));
+              },
+          },
+          f.init[k]);
+    }
+    if (f.condition.has_value()) {
+      Line(
+          std::format(
+              "cond: Expr[{}] {}", f.condition->value,
+              FormatProcExpr(p, *f.condition)));
+    }
+    for (std::size_t k = 0; k < f.step.size(); ++k) {
+      Line(
+          std::format(
+              "step[{}]: Expr[{}] {}", k, f.step[k].value,
+              FormatProcExpr(p, f.step[k])));
+    }
+    Line("body:");
+    Indent();
+    DumpStmt(p, f.body);
+    Dedent();
+    Dedent();
+  }
+
+  void DumpWhileStmtNode(const Process& p, StmtId id, const WhileStmt& w) {
+    Line(
+        std::format(
+            "Stmt[{}] WhileStmt cond=Expr[{}]", id.value, w.condition.value));
+    Indent();
+    Line(
+        std::format(
+            "Expr[{}] {}", w.condition.value, FormatProcExpr(p, w.condition)));
+    Line("body:");
+    Indent();
+    DumpStmt(p, w.body);
+    Dedent();
+    Dedent();
+  }
+
+  void DumpRepeatStmtNode(const Process& p, StmtId id, const RepeatStmt& r) {
+    Line(
+        std::format(
+            "Stmt[{}] RepeatStmt count=Expr[{}]", id.value, r.count.value));
+    Indent();
+    Line(std::format("Expr[{}] {}", r.count.value, FormatProcExpr(p, r.count)));
+    Line("body:");
+    Indent();
+    DumpStmt(p, r.body);
+    Dedent();
+    Dedent();
+  }
+
+  void DumpDoWhileStmtNode(const Process& p, StmtId id, const DoWhileStmt& d) {
+    Line(
+        std::format(
+            "Stmt[{}] DoWhileStmt cond=Expr[{}]", id.value, d.condition.value));
+    Indent();
+    Line(
+        std::format(
+            "Expr[{}] {}", d.condition.value, FormatProcExpr(p, d.condition)));
+    Line("body:");
+    Indent();
+    DumpStmt(p, d.body);
+    Dedent();
+    Dedent();
+  }
+
+  void DumpForeverStmtNode(const Process& p, StmtId id, const ForeverStmt& f) {
+    Line(std::format("Stmt[{}] ForeverStmt", id.value));
+    Indent();
+    Line("body:");
+    Indent();
+    DumpStmt(p, f.body);
+    Dedent();
+    Dedent();
+  }
+
+  void DumpTimedStmtNode(const Process& p, StmtId id, const TimedStmt& t) {
+    Line(std::format("Stmt[{}] TimedStmt", id.value));
+    Indent();
+    Line(std::format("timing: {}", FormatTimingControlHeader(t.timing)));
+    Indent();
+    std::visit(
+        Overloaded{
+            [&](const DelayControl& d) {
+              Line(
+                  std::format(
+                      "Expr[{}] {}", d.duration.value,
+                      FormatProcExpr(p, d.duration)));
+            },
+            [](const EventControl&) {},
+        },
+        t.timing);
+    Dedent();
+    Line("stmt:");
+    Indent();
+    DumpStmt(p, t.stmt);
+    Dedent();
+    Dedent();
+  }
+
   void DumpStmt(const Process& p, StmtId id) {
     const auto& s = p.stmts.at(id.value);
     std::visit(
@@ -662,313 +886,99 @@ class HirDumper {
             [&](const EmptyStmt&) {
               Line(std::format("Stmt[{}] EmptyStmt", id.value));
             },
-            [&](const VarDeclStmt& v) {
-              Line(
-                  std::format(
-                      "Stmt[{}] VarDeclStmt var=ProceduralVar[{}]", id.value,
-                      v.var.value));
-              if (v.init.has_value()) {
-                Indent();
-                Line(
-                    std::format(
-                        "init: Expr[{}] {}", v.init->value,
-                        FormatProcExpr(p, *v.init)));
-                Dedent();
-              }
-            },
-            [&](const ExprStmt& e) {
-              Line(
-                  std::format(
-                      "Stmt[{}] ExprStmt expr=Expr[{}]", id.value,
-                      e.expr.value));
-              Indent();
-              Line(
-                  std::format(
-                      "Expr[{}] {}", e.expr.value, FormatProcExpr(p, e.expr)));
-              Dedent();
-            },
-            [&](const BlockStmt& b) {
-              Line(
-                  std::format(
-                      "Stmt[{}] BlockStmt (count={})", id.value,
-                      b.statements.size()));
-              Indent();
-              for (const auto child : b.statements) {
-                DumpStmt(p, child);
-              }
-              Dedent();
-            },
-            [&](const IfStmt& i) {
-              Line(
-                  std::format(
-                      "Stmt[{}] IfStmt{} cond=Expr[{}]", id.value,
-                      FormatUniquePriorityCheck(i.check), i.condition.value));
-              Indent();
-              Line(
-                  std::format(
-                      "Expr[{}] {}", i.condition.value,
-                      FormatProcExpr(p, i.condition)));
-              Line("then:");
-              Indent();
-              DumpStmt(p, i.then_stmt);
-              Dedent();
-              if (i.else_stmt.has_value()) {
-                Line("else:");
-                Indent();
-                DumpStmt(p, *i.else_stmt);
-                Dedent();
-              }
-              Dedent();
-            },
-            [&](const CaseStmt& c) {
-              Line(
-                  std::format(
-                      "Stmt[{}] CaseStmt{} cond=Expr[{}] (items={})", id.value,
-                      FormatUniquePriorityCheck(c.check), c.condition.value,
-                      c.items.size()));
-              Indent();
-              Line(
-                  std::format(
-                      "Expr[{}] {}", c.condition.value,
-                      FormatProcExpr(p, c.condition)));
-              for (std::size_t k = 0; k < c.items.size(); ++k) {
-                const auto& item = c.items[k];
-                std::string labels_str;
-                for (std::size_t m = 0; m < item.labels.size(); ++m) {
-                  if (m != 0) labels_str += ", ";
-                  labels_str += std::format("Expr[{}]", item.labels[m].value);
-                }
-                Line(std::format("item[{}] labels=[{}]", k, labels_str));
-                Indent();
-                for (const hir::ExprId label_id : item.labels) {
-                  Line(
-                      std::format(
-                          "Expr[{}] {}", label_id.value,
-                          FormatProcExpr(p, label_id)));
-                }
-                Line("stmt:");
-                Indent();
-                DumpStmt(p, item.stmt);
-                Dedent();
-                Dedent();
-              }
-              if (c.default_stmt.has_value()) {
-                Line("default:");
-                Indent();
-                DumpStmt(p, *c.default_stmt);
-                Dedent();
-              }
-              Dedent();
-            },
-            [&](const ForStmt& f) {
-              Line(
-                  std::format(
-                      "Stmt[{}] ForStmt (init={}, step={})", id.value,
-                      f.init.size(), f.step.size()));
-              Indent();
-              for (std::size_t k = 0; k < f.init.size(); ++k) {
-                std::visit(
-                    Overloaded{
-                        [&](const ForInitDecl& d) {
-                          Line(
-                              std::format(
-                                  "init[{}]: Decl var=ProceduralVar[{}]", k,
-                                  d.var.value));
-                          if (d.init.has_value()) {
-                            Indent();
-                            Line(
-                                std::format(
-                                    "Expr[{}] {}", d.init->value,
-                                    FormatProcExpr(p, *d.init)));
-                            Dedent();
-                          }
-                        },
-                        [&](const ForInitExpr& e) {
-                          Line(
-                              std::format(
-                                  "init[{}]: Expr[{}] {}", k, e.expr.value,
-                                  FormatProcExpr(p, e.expr)));
-                        },
-                    },
-                    f.init[k]);
-              }
-              if (f.condition.has_value()) {
-                Line(
-                    std::format(
-                        "cond: Expr[{}] {}", f.condition->value,
-                        FormatProcExpr(p, *f.condition)));
-              }
-              for (std::size_t k = 0; k < f.step.size(); ++k) {
-                Line(
-                    std::format(
-                        "step[{}]: Expr[{}] {}", k, f.step[k].value,
-                        FormatProcExpr(p, f.step[k])));
-              }
-              Line("body:");
-              Indent();
-              DumpStmt(p, f.body);
-              Dedent();
-              Dedent();
-            },
-            [&](const WhileStmt& w) {
-              Line(
-                  std::format(
-                      "Stmt[{}] WhileStmt cond=Expr[{}]", id.value,
-                      w.condition.value));
-              Indent();
-              Line(
-                  std::format(
-                      "Expr[{}] {}", w.condition.value,
-                      FormatProcExpr(p, w.condition)));
-              Line("body:");
-              Indent();
-              DumpStmt(p, w.body);
-              Dedent();
-              Dedent();
-            },
-            [&](const RepeatStmt& r) {
-              Line(
-                  std::format(
-                      "Stmt[{}] RepeatStmt count=Expr[{}]", id.value,
-                      r.count.value));
-              Indent();
-              Line(
-                  std::format(
-                      "Expr[{}] {}", r.count.value,
-                      FormatProcExpr(p, r.count)));
-              Line("body:");
-              Indent();
-              DumpStmt(p, r.body);
-              Dedent();
-              Dedent();
-            },
-            [&](const DoWhileStmt& d) {
-              Line(
-                  std::format(
-                      "Stmt[{}] DoWhileStmt cond=Expr[{}]", id.value,
-                      d.condition.value));
-              Indent();
-              Line(
-                  std::format(
-                      "Expr[{}] {}", d.condition.value,
-                      FormatProcExpr(p, d.condition)));
-              Line("body:");
-              Indent();
-              DumpStmt(p, d.body);
-              Dedent();
-              Dedent();
-            },
-            [&](const ForeverStmt& f) {
-              Line(std::format("Stmt[{}] ForeverStmt", id.value));
-              Indent();
-              Line("body:");
-              Indent();
-              DumpStmt(p, f.body);
-              Dedent();
-              Dedent();
-            },
+            [&](const VarDeclStmt& v) { DumpVarDeclStmtNode(p, id, v); },
+            [&](const ExprStmt& e) { DumpExprStmtNode(p, id, e); },
+            [&](const BlockStmt& b) { DumpBlockStmtNode(p, id, b); },
+            [&](const IfStmt& i) { DumpIfStmtNode(p, id, i); },
+            [&](const CaseStmt& c) { DumpCaseStmtNode(p, id, c); },
+            [&](const ForStmt& f) { DumpForStmtNode(p, id, f); },
+            [&](const WhileStmt& w) { DumpWhileStmtNode(p, id, w); },
+            [&](const RepeatStmt& r) { DumpRepeatStmtNode(p, id, r); },
+            [&](const DoWhileStmt& d) { DumpDoWhileStmtNode(p, id, d); },
+            [&](const ForeverStmt& f) { DumpForeverStmtNode(p, id, f); },
             [&](const BreakStmt&) {
               Line(std::format("Stmt[{}] BreakStmt", id.value));
             },
             [&](const ContinueStmt&) {
               Line(std::format("Stmt[{}] ContinueStmt", id.value));
             },
-            [&](const TimedStmt& t) {
-              Line(std::format("Stmt[{}] TimedStmt", id.value));
-              Indent();
-              Line(
-                  std::format(
-                      "timing: {}", FormatTimingControlHeader(t.timing)));
-              Indent();
-              std::visit(
-                  Overloaded{
-                      [&](const DelayControl& d) {
-                        Line(
-                            std::format(
-                                "Expr[{}] {}", d.duration.value,
-                                FormatProcExpr(p, d.duration)));
-                      },
-                      [](const EventControl&) {},
-                  },
-                  t.timing);
-              Dedent();
-              Line("stmt:");
-              Indent();
-              DumpStmt(p, t.stmt);
-              Dedent();
-              Dedent();
-            },
+            [&](const TimedStmt& t) { DumpTimedStmtNode(p, id, t); },
         },
         s.data);
+  }
+
+  void DumpIfGenerateNode(
+      const StructuralScope& owner, const Generate& g, const IfGenerate& ig) {
+    Line(
+        std::format(
+            "Generate IfGenerate cond={}",
+            FormatScopeExpr(owner, ig.condition)));
+    Indent();
+    Line("then_scope:");
+    Indent();
+    DumpScope(g.child_scopes.at(ig.then_scope.value));
+    Dedent();
+    if (ig.else_scope.has_value()) {
+      Line("else_scope:");
+      Indent();
+      DumpScope(g.child_scopes.at(ig.else_scope->value));
+      Dedent();
+    } else {
+      Line("else_scope: <none>");
+    }
+    Dedent();
+  }
+
+  void DumpCaseGenerateNode(
+      const StructuralScope& owner, const Generate& g, const CaseGenerate& cg) {
+    Line(
+        std::format(
+            "Generate CaseGenerate cond={}",
+            FormatScopeExpr(owner, cg.condition)));
+    Indent();
+    for (std::size_t i = 0; i < cg.items.size(); ++i) {
+      const auto& item = cg.items[i];
+      std::string labels;
+      for (std::size_t j = 0; j < item.labels.size(); ++j) {
+        if (j != 0) labels += ", ";
+        labels += FormatScopeExpr(owner, item.labels[j]);
+      }
+      Line(std::format("item[{}] labels=[{}]", i, labels));
+      Indent();
+      DumpScope(g.child_scopes.at(item.scope.value));
+      Dedent();
+    }
+    if (cg.default_scope.has_value()) {
+      Line("default_scope:");
+      Indent();
+      DumpScope(g.child_scopes.at(cg.default_scope->value));
+      Dedent();
+    } else {
+      Line("default_scope: <none>");
+    }
+    Dedent();
+  }
+
+  void DumpLoopGenerateNode(const Generate& g, const LoopGenerate& lg) {
+    Line(
+        std::format(
+            "Generate LoopGenerate loop_var=LoopVar[{}] initial=Expr[{}] "
+            "stop=Expr[{}] iter=Expr[{}]",
+            lg.loop_var.value, lg.initial.value, lg.stop.value, lg.iter.value));
+    Indent();
+    Line("scope:");
+    Indent();
+    DumpScope(g.child_scopes.at(lg.scope.value));
+    Dedent();
+    Dedent();
   }
 
   void DumpGenerate(const StructuralScope& owner, const Generate& g) {
     std::visit(
         Overloaded{
-            [&](const IfGenerate& ig) {
-              Line(
-                  std::format(
-                      "Generate IfGenerate cond={}",
-                      FormatScopeExpr(owner, ig.condition)));
-              Indent();
-              Line("then_scope:");
-              Indent();
-              DumpScope(g.child_scopes.at(ig.then_scope.value));
-              Dedent();
-              if (ig.else_scope.has_value()) {
-                Line("else_scope:");
-                Indent();
-                DumpScope(g.child_scopes.at(ig.else_scope->value));
-                Dedent();
-              } else {
-                Line("else_scope: <none>");
-              }
-              Dedent();
-            },
-            [&](const CaseGenerate& cg) {
-              Line(
-                  std::format(
-                      "Generate CaseGenerate cond={}",
-                      FormatScopeExpr(owner, cg.condition)));
-              Indent();
-              for (std::size_t i = 0; i < cg.items.size(); ++i) {
-                const auto& item = cg.items[i];
-                std::string labels;
-                for (std::size_t j = 0; j < item.labels.size(); ++j) {
-                  if (j != 0) {
-                    labels += ", ";
-                  }
-                  labels += FormatScopeExpr(owner, item.labels[j]);
-                }
-                Line(std::format("item[{}] labels=[{}]", i, labels));
-                Indent();
-                DumpScope(g.child_scopes.at(item.scope.value));
-                Dedent();
-              }
-              if (cg.default_scope.has_value()) {
-                Line("default_scope:");
-                Indent();
-                DumpScope(g.child_scopes.at(cg.default_scope->value));
-                Dedent();
-              } else {
-                Line("default_scope: <none>");
-              }
-              Dedent();
-            },
-            [&](const LoopGenerate& lg) {
-              Line(
-                  std::format(
-                      "Generate LoopGenerate loop_var=LoopVar[{}] "
-                      "initial=Expr[{}] stop=Expr[{}] iter=Expr[{}]",
-                      lg.loop_var.value, lg.initial.value, lg.stop.value,
-                      lg.iter.value));
-              Indent();
-              Line("scope:");
-              Indent();
-              DumpScope(g.child_scopes.at(lg.scope.value));
-              Dedent();
-              Dedent();
-            },
+            [&](const IfGenerate& ig) { DumpIfGenerateNode(owner, g, ig); },
+            [&](const CaseGenerate& cg) { DumpCaseGenerateNode(owner, g, cg); },
+            [&](const LoopGenerate& lg) { DumpLoopGenerateNode(g, lg); },
         },
         g.data);
   }

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -512,6 +512,27 @@ class HirDumper {
                   "ConversionExpr kind={} operand=Expr[{}]",
                   FormatConversionKind(cv.kind), cv.operand.value);
             },
+            [](const InsideExpr& in) -> std::string {
+              std::string items;
+              for (std::size_t i = 0; i < in.items.size(); ++i) {
+                if (i != 0) {
+                  items += ", ";
+                }
+                items += std::visit(
+                    Overloaded{
+                        [](const ExprId& id) {
+                          return std::format("Expr[{}]", id.value);
+                        },
+                        [](const InsideRangePair& r) {
+                          return std::format(
+                              "[Expr[{}]:Expr[{}]]", r.lo.value, r.hi.value);
+                        },
+                    },
+                    in.items[i]);
+              }
+              return std::format(
+                  "InsideExpr lhs=Expr[{}] items=[{}]", in.lhs.value, items);
+            },
         },
         e.data);
     return std::format("type=Type[{}] {}", e.type.value, formatted);

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -673,6 +673,44 @@ auto LowerProcExpr(
       };
     }
 
+    case slang::ast::ExpressionKind::Inside: {
+      const auto& in = expr.as<slang::ast::InsideExpression>();
+      auto lhs_id = append_child(in.left());
+      if (!lhs_id) return std::unexpected(std::move(lhs_id.error()));
+
+      std::vector<hir::InsideItem> items;
+      items.reserve(in.rangeList().size());
+      for (const auto* item : in.rangeList()) {
+        if (item->kind == slang::ast::ExpressionKind::ValueRange) {
+          const auto& vr = item->as<slang::ast::ValueRangeExpression>();
+          if (vr.rangeKind != slang::ast::ValueRangeKind::Simple) {
+            return diag::Unsupported(
+                mapper.SpanOf(vr.sourceRange),
+                diag::DiagCode::kUnsupportedExpressionForm,
+                "tolerance-range form in inside operator is not yet supported",
+                diag::UnsupportedCategory::kFeature);
+          }
+          auto lo_id = append_child(vr.left());
+          if (!lo_id) return std::unexpected(std::move(lo_id.error()));
+          auto hi_id = append_child(vr.right());
+          if (!hi_id) return std::unexpected(std::move(hi_id.error()));
+          items.emplace_back(hir::InsideRangePair{.lo = *lo_id, .hi = *hi_id});
+        } else {
+          auto val_id = append_child(*item);
+          if (!val_id) return std::unexpected(std::move(val_id.error()));
+          items.emplace_back(*val_id);
+        }
+      }
+
+      auto type_id = type_id_of(expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return hir::Expr{
+          .type = *type_id,
+          .data = hir::InsideExpr{.lhs = *lhs_id, .items = std::move(items)},
+          .span = span,
+      };
+    }
+
     default:
       return diag::Unsupported(
           span, diag::DiagCode::kUnsupportedExpressionForm,

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -323,13 +323,29 @@ auto MakeReturnConventionType(
   throw InternalError("MakeReturnConventionType: unknown ReturnConvention");
 }
 
+auto TypeIdOfSlangExpr(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    const slang::ast::Expression& e) -> diag::Result<hir::TypeId> {
+  const auto& mapper = unit_facts.SourceMapper();
+  auto td = LowerType(*e.type, mapper.SpanOf(e.sourceRange), unit_state);
+  if (!td) return std::unexpected(std::move(td.error()));
+  return unit_state.AddType(*std::move(td));
+}
+
 auto LowerNamedValueProc(
-    const UnitLoweringFacts& unit_facts, const UnitLoweringState& unit_state,
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     const ProcessLoweringState& proc_state, const ScopeStack& stack,
     const slang::ast::NamedValueExpression& named) -> diag::Result<hir::Expr> {
   const auto& mapper = unit_facts.SourceMapper();
   const auto span = mapper.SpanOf(named.sourceRange);
   const auto& sym = named.symbol;
+
+  if (sym.kind == slang::ast::SymbolKind::EnumValue) {
+    auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, named);
+    if (!type_id) return std::unexpected(std::move(type_id.error()));
+    return MakeEnumValueExpr(
+        sym.as<slang::ast::EnumValueSymbol>(), *type_id, span);
+  }
 
   if (sym.kind == slang::ast::SymbolKind::Variable ||
       sym.kind == slang::ast::SymbolKind::Parameter) {
@@ -375,6 +391,511 @@ auto LowerNamedValueProc(
       binding->type, span);
 }
 
+auto LowerNamedValueStructural(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    const ScopeStack& stack, const slang::ast::NamedValueExpression& named)
+    -> diag::Result<hir::Expr> {
+  const auto& mapper = unit_facts.SourceMapper();
+  const auto span = mapper.SpanOf(named.sourceRange);
+  const auto& sym = named.symbol;
+  if (sym.kind == slang::ast::SymbolKind::EnumValue) {
+    auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, named);
+    if (!type_id) return std::unexpected(std::move(type_id.error()));
+    return MakeEnumValueExpr(
+        sym.as<slang::ast::EnumValueSymbol>(), *type_id, span);
+  }
+  if (sym.kind == slang::ast::SymbolKind::Variable ||
+      sym.kind == slang::ast::SymbolKind::Parameter) {
+    const auto& value_sym = sym.as<slang::ast::ValueSymbol>();
+    if (auto loop_binding = unit_state.LookupLoopVarBinding(value_sym)) {
+      const auto hops = stack.HopsTo(loop_binding->home_frame);
+      if (!hops.has_value()) {
+        throw InternalError(
+            "LowerStructuralExpr: loop-var binding home frame is not on "
+            "the current scope stack");
+      }
+      return MakeRefExpr(
+          hir::LoopVarRef{.hops = *hops, .loop_var = loop_binding->loop_var_id},
+          loop_binding->type, span);
+    }
+  }
+  if (sym.kind != slang::ast::SymbolKind::Variable) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedNonVariableNamedReference,
+        "reference to non-variable declaration is not supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  const auto& var = sym.as<slang::ast::VariableSymbol>();
+  const auto binding = unit_state.LookupStructuralVarBinding(var);
+  if (!binding.has_value()) {
+    throw InternalError(
+        "LowerStructuralExpr: variable was not bound during scope lowering");
+  }
+  const auto hops = stack.HopsTo(binding->home_frame);
+  if (!hops.has_value()) {
+    throw InternalError(
+        "LowerStructuralExpr: variable home frame is not on the current "
+        "scope stack");
+  }
+  return MakeRefExpr(
+      hir::StructuralVarRef{.hops = *hops, .var = binding->var_id},
+      binding->type, span);
+}
+
+auto LowerLValueReferenceExpr(
+    diag::SourceSpan span,
+    const std::optional<hir::Lvalue>& compound_lvalue_context,
+    diag::Result<hir::TypeId> type_id, const char* origin)
+    -> diag::Result<hir::Expr> {
+  if (!compound_lvalue_context.has_value()) {
+    throw InternalError(
+        std::string{origin} +
+        ": slang LValueReference encountered outside compound-assignment RHS");
+  }
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return MakeRefExpr(LvalueToPrimary(*compound_lvalue_context), *type_id, span);
+}
+
+auto LowerConversionExprProc(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const std::optional<hir::Lvalue>& compound_lvalue_context,
+    const slang::ast::ConversionExpression& conv,
+    const slang::ast::Expression& expr, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  auto operand_or = LowerProcExpr(
+      unit_facts, unit_state, proc_state, stack, conv.operand(),
+      compound_lvalue_context);
+  if (!operand_or) return std::unexpected(std::move(operand_or.error()));
+  const hir::ExprId operand_id = proc_state.AddExpr(*std::move(operand_or));
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::Expr{
+      .type = *type_id,
+      .data =
+          hir::ConversionExpr{
+              .operand = operand_id,
+              .kind = LowerConversionKind(conv.conversionKind),
+          },
+      .span = span,
+  };
+}
+
+auto LowerUnaryExprProc(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const std::optional<hir::Lvalue>& compound_lvalue_context,
+    const slang::ast::UnaryExpression& un, const slang::ast::Expression& expr,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  auto op_or = LowerUnaryOp(un.op, span);
+  if (!op_or) return std::unexpected(std::move(op_or.error()));
+  auto operand_or = LowerProcExpr(
+      unit_facts, unit_state, proc_state, stack, un.operand(),
+      compound_lvalue_context);
+  if (!operand_or) return std::unexpected(std::move(operand_or.error()));
+  const hir::ExprId operand_id = proc_state.AddExpr(*std::move(operand_or));
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::Expr{
+      .type = *type_id,
+      .data = hir::UnaryExpr{.op = *op_or, .operand = operand_id},
+      .span = span,
+  };
+}
+
+auto LowerBinaryExprProc(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const std::optional<hir::Lvalue>& compound_lvalue_context,
+    const slang::ast::BinaryExpression& bin, const slang::ast::Expression& expr,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  auto lhs_or = LowerProcExpr(
+      unit_facts, unit_state, proc_state, stack, bin.left(),
+      compound_lvalue_context);
+  if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+  const hir::ExprId lhs_id = proc_state.AddExpr(*std::move(lhs_or));
+  auto rhs_or = LowerProcExpr(
+      unit_facts, unit_state, proc_state, stack, bin.right(),
+      compound_lvalue_context);
+  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+  const hir::ExprId rhs_id = proc_state.AddExpr(*std::move(rhs_or));
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::Expr{
+      .type = *type_id,
+      .data =
+          hir::BinaryExpr{
+              .op = LowerBinaryOp(bin.op),
+              .lhs = lhs_id,
+              .rhs = rhs_id,
+          },
+      .span = span,
+  };
+}
+
+auto LowerConditionalExprProc(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const std::optional<hir::Lvalue>& compound_lvalue_context,
+    const slang::ast::ConditionalExpression& cond,
+    const slang::ast::Expression& expr, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  if (cond.conditions.size() != 1) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "conditional operator with `&&&` multi-condition is not yet "
+        "supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  if (cond.conditions[0].pattern != nullptr) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "conditional operator with `matches` pattern is not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  auto cond_or = LowerProcExpr(
+      unit_facts, unit_state, proc_state, stack, *cond.conditions[0].expr,
+      compound_lvalue_context);
+  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+  const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_or));
+  auto then_or = LowerProcExpr(
+      unit_facts, unit_state, proc_state, stack, cond.left(),
+      compound_lvalue_context);
+  if (!then_or) return std::unexpected(std::move(then_or.error()));
+  const hir::ExprId then_id = proc_state.AddExpr(*std::move(then_or));
+  auto else_or = LowerProcExpr(
+      unit_facts, unit_state, proc_state, stack, cond.right(),
+      compound_lvalue_context);
+  if (!else_or) return std::unexpected(std::move(else_or.error()));
+  const hir::ExprId else_id = proc_state.AddExpr(*std::move(else_or));
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::Expr{
+      .type = *type_id,
+      .data =
+          hir::ConditionalExpr{
+              .condition = cond_id,
+              .then_value = then_id,
+              .else_value = else_id,
+          },
+      .span = span,
+  };
+}
+
+auto LowerCallExprProc(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const std::optional<hir::Lvalue>& compound_lvalue_context,
+    const slang::ast::CallExpression& call, const slang::ast::Expression& expr,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  std::vector<hir::ExprId> arg_ids;
+  arg_ids.reserve(call.arguments().size());
+  for (const auto* arg : call.arguments()) {
+    auto arg_or = LowerProcExpr(
+        unit_facts, unit_state, proc_state, stack, *arg,
+        compound_lvalue_context);
+    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+    arg_ids.push_back(proc_state.AddExpr(*std::move(arg_or)));
+  }
+
+  if (call.isSystemCall()) {
+    const auto& info =
+        std::get<slang::ast::CallExpression::SystemCallInfo>(call.subroutine);
+    const std::string_view name = info.subroutine->name;
+
+    if (auto enum_method_kind = LowerEnumMethodName(name);
+        enum_method_kind.has_value() && !arg_ids.empty() &&
+        call.arguments()[0]->type->getCanonicalType().kind ==
+            slang::ast::SymbolKind::EnumType) {
+      auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return hir::Expr{
+          .type = *type_id,
+          .data =
+              hir::CallExpr{
+                  .callee = hir::BuiltinMethodRef{.kind = *enum_method_kind},
+                  .arguments = std::move(arg_ids),
+              },
+          .span = span,
+      };
+    }
+
+    const auto* desc = support::FindSystemSubroutine(name);
+    if (desc == nullptr) {
+      throw InternalError(
+          std::string{"AST->HIR call: unresolved system subroutine '"} +
+          std::string{name} + "' after slang resolution");
+    }
+    const auto frontend_kind = FromSlangSubroutineKind(info.subroutine->kind);
+    if (desc->kind != frontend_kind) {
+      throw InternalError(
+          std::string{"AST->HIR call: registry/frontend kind mismatch for '"} +
+          std::string{name} + "'");
+    }
+    if (!desc->arg_policy.Accepts(arg_ids.size())) {
+      throw InternalError(
+          std::string{
+              "AST->HIR call: arg count outside descriptor policy for '"} +
+          std::string{name} + "'");
+    }
+
+    const auto result_type =
+        MakeReturnConventionType(unit_state, desc->result_conv);
+    return hir::Expr{
+        .type = result_type,
+        .data =
+            hir::CallExpr{
+                .callee = hir::SystemSubroutineRef{.id = desc->id},
+                .arguments = std::move(arg_ids),
+            },
+        .span = span,
+    };
+  }
+
+  const auto* sym =
+      std::get<const slang::ast::SubroutineSymbol*>(call.subroutine);
+  if (sym == nullptr) {
+    throw InternalError(
+        "AST->HIR call: user call missing resolved SubroutineSymbol");
+  }
+  const auto binding = unit_state.LookupSubroutineBinding(*sym);
+  if (!binding.has_value()) {
+    throw InternalError(
+        "AST->HIR call: resolved user subroutine has no registered HIR "
+        "binding");
+  }
+  const auto hops = stack.HopsTo(binding->owner_frame);
+  if (!hops.has_value()) {
+    throw InternalError(
+        "AST->HIR call: user subroutine owner frame is not on the current "
+        "scope stack");
+  }
+  auto result_type = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!result_type) return std::unexpected(std::move(result_type.error()));
+  return hir::Expr{
+      .type = *result_type,
+      .data =
+          hir::CallExpr{
+              .callee =
+                  hir::StructuralSubroutineRef{
+                      .hops = *hops, .subroutine = binding->subroutine_id},
+              .arguments = std::move(arg_ids),
+          },
+      .span = span,
+  };
+}
+
+auto LowerAssignmentExprProc(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const slang::ast::AssignmentExpression& as,
+    const slang::ast::Expression& expr, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  const auto kind = as.isNonBlocking() ? hir::AssignKind::kNonBlocking
+                                       : hir::AssignKind::kBlocking;
+
+  auto lhs_or =
+      LowerProcLvalue(unit_facts, unit_state, proc_state, stack, as.left());
+  if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+
+  auto rhs_or = LowerProcExpr(
+      unit_facts, unit_state, proc_state, stack, as.right(), *lhs_or);
+  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+  const hir::ExprId rhs_id = proc_state.AddExpr(*std::move(rhs_or));
+
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::Expr{
+      .type = *type_id,
+      .data =
+          hir::AssignExpr{
+              .kind = kind, .lhs = *std::move(lhs_or), .rhs = rhs_id},
+      .span = span,
+  };
+}
+
+auto LowerInsideExprProc(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const std::optional<hir::Lvalue>& compound_lvalue_context,
+    const slang::ast::InsideExpression& in, const slang::ast::Expression& expr,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  const auto& mapper = unit_facts.SourceMapper();
+
+  auto lhs_or = LowerProcExpr(
+      unit_facts, unit_state, proc_state, stack, in.left(),
+      compound_lvalue_context);
+  if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+  const hir::ExprId lhs_id = proc_state.AddExpr(*std::move(lhs_or));
+
+  std::vector<hir::InsideItem> items;
+  items.reserve(in.rangeList().size());
+  for (const auto* item : in.rangeList()) {
+    if (item->kind == slang::ast::ExpressionKind::ValueRange) {
+      const auto& vr = item->as<slang::ast::ValueRangeExpression>();
+      if (vr.rangeKind != slang::ast::ValueRangeKind::Simple) {
+        return diag::Unsupported(
+            mapper.SpanOf(vr.sourceRange),
+            diag::DiagCode::kUnsupportedExpressionForm,
+            "tolerance-range form in inside operator is not yet supported",
+            diag::UnsupportedCategory::kFeature);
+      }
+      auto lo_or = LowerProcExpr(
+          unit_facts, unit_state, proc_state, stack, vr.left(),
+          compound_lvalue_context);
+      if (!lo_or) return std::unexpected(std::move(lo_or.error()));
+      const hir::ExprId lo_id = proc_state.AddExpr(*std::move(lo_or));
+      auto hi_or = LowerProcExpr(
+          unit_facts, unit_state, proc_state, stack, vr.right(),
+          compound_lvalue_context);
+      if (!hi_or) return std::unexpected(std::move(hi_or.error()));
+      const hir::ExprId hi_id = proc_state.AddExpr(*std::move(hi_or));
+      items.emplace_back(hir::InsideRangePair{.lo = lo_id, .hi = hi_id});
+    } else {
+      auto val_or = LowerProcExpr(
+          unit_facts, unit_state, proc_state, stack, *item,
+          compound_lvalue_context);
+      if (!val_or) return std::unexpected(std::move(val_or.error()));
+      const hir::ExprId val_id = proc_state.AddExpr(*std::move(val_or));
+      items.emplace_back(val_id);
+    }
+  }
+
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::Expr{
+      .type = *type_id,
+      .data = hir::InsideExpr{.lhs = lhs_id, .items = std::move(items)},
+      .span = span,
+  };
+}
+
+auto LowerConversionExprStructural(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ScopeLoweringState& scope_state, const ScopeStack& stack,
+    const std::optional<hir::Lvalue>& compound_lvalue_context,
+    const slang::ast::ConversionExpression& conv,
+    const slang::ast::Expression& expr, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  auto operand_or = LowerStructuralExpr(
+      unit_facts, unit_state, scope_state, stack, conv.operand(),
+      compound_lvalue_context);
+  if (!operand_or) return std::unexpected(std::move(operand_or.error()));
+  const hir::ExprId operand_id = scope_state.AddExpr(*std::move(operand_or));
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::Expr{
+      .type = *type_id,
+      .data =
+          hir::ConversionExpr{
+              .operand = operand_id,
+              .kind = LowerConversionKind(conv.conversionKind),
+          },
+      .span = span,
+  };
+}
+
+auto LowerUnaryExprStructural(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ScopeLoweringState& scope_state, const ScopeStack& stack,
+    const std::optional<hir::Lvalue>& compound_lvalue_context,
+    const slang::ast::UnaryExpression& un, const slang::ast::Expression& expr,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  auto op_or = LowerUnaryOp(un.op, span);
+  if (!op_or) return std::unexpected(std::move(op_or.error()));
+  auto operand_or = LowerStructuralExpr(
+      unit_facts, unit_state, scope_state, stack, un.operand(),
+      compound_lvalue_context);
+  if (!operand_or) return std::unexpected(std::move(operand_or.error()));
+  const hir::ExprId operand_id = scope_state.AddExpr(*std::move(operand_or));
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::Expr{
+      .type = *type_id,
+      .data = hir::UnaryExpr{.op = *op_or, .operand = operand_id},
+      .span = span,
+  };
+}
+
+auto LowerBinaryExprStructural(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ScopeLoweringState& scope_state, const ScopeStack& stack,
+    const std::optional<hir::Lvalue>& compound_lvalue_context,
+    const slang::ast::BinaryExpression& bin, const slang::ast::Expression& expr,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  auto lhs_or = LowerStructuralExpr(
+      unit_facts, unit_state, scope_state, stack, bin.left(),
+      compound_lvalue_context);
+  if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+  const hir::ExprId lhs_id = scope_state.AddExpr(*std::move(lhs_or));
+  auto rhs_or = LowerStructuralExpr(
+      unit_facts, unit_state, scope_state, stack, bin.right(),
+      compound_lvalue_context);
+  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+  const hir::ExprId rhs_id = scope_state.AddExpr(*std::move(rhs_or));
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::Expr{
+      .type = *type_id,
+      .data =
+          hir::BinaryExpr{
+              .op = LowerBinaryOp(bin.op),
+              .lhs = lhs_id,
+              .rhs = rhs_id,
+          },
+      .span = span,
+  };
+}
+
+auto LowerConditionalExprStructural(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ScopeLoweringState& scope_state, const ScopeStack& stack,
+    const std::optional<hir::Lvalue>& compound_lvalue_context,
+    const slang::ast::ConditionalExpression& cond,
+    const slang::ast::Expression& expr, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  if (cond.conditions.size() != 1) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
+        "conditional operator with `&&&` multi-condition is not yet "
+        "supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  if (cond.conditions[0].pattern != nullptr) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
+        "conditional operator with `matches` pattern is not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  auto cond_or = LowerStructuralExpr(
+      unit_facts, unit_state, scope_state, stack, *cond.conditions[0].expr,
+      compound_lvalue_context);
+  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+  const hir::ExprId cond_id = scope_state.AddExpr(*std::move(cond_or));
+  auto then_or = LowerStructuralExpr(
+      unit_facts, unit_state, scope_state, stack, cond.left(),
+      compound_lvalue_context);
+  if (!then_or) return std::unexpected(std::move(then_or.error()));
+  const hir::ExprId then_id = scope_state.AddExpr(*std::move(then_or));
+  auto else_or = LowerStructuralExpr(
+      unit_facts, unit_state, scope_state, stack, cond.right(),
+      compound_lvalue_context);
+  if (!else_or) return std::unexpected(std::move(else_or.error()));
+  const hir::ExprId else_id = scope_state.AddExpr(*std::move(else_or));
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::Expr{
+      .type = *type_id,
+      .data =
+          hir::ConditionalExpr{
+              .condition = cond_id,
+              .then_value = then_id,
+              .else_value = else_id,
+          },
+      .span = span,
+  };
+}
+
 }  // namespace
 
 auto LowerProcExpr(
@@ -386,33 +907,16 @@ auto LowerProcExpr(
   const auto& mapper = unit_facts.SourceMapper();
   const auto span = mapper.SpanOf(expr.sourceRange);
 
-  auto lower_child = [&](const slang::ast::Expression& e) {
-    return LowerProcExpr(
-        unit_facts, unit_state, proc_state, stack, e, compound_lvalue_context);
-  };
-  auto append_child =
-      [&](const slang::ast::Expression& e) -> diag::Result<hir::ExprId> {
-    auto child = lower_child(e);
-    if (!child) return std::unexpected(std::move(child.error()));
-    return proc_state.AddExpr(*std::move(child));
-  };
-  auto type_id_of =
-      [&](const slang::ast::Expression& e) -> diag::Result<hir::TypeId> {
-    auto td = LowerType(*e.type, mapper.SpanOf(e.sourceRange), unit_state);
-    if (!td) return std::unexpected(std::move(td.error()));
-    return unit_state.AddType(*std::move(td));
-  };
-
   switch (expr.kind) {
     case slang::ast::ExpressionKind::IntegerLiteral: {
-      auto type_id = type_id_of(expr);
+      auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return MakeIntegerLiteralExpr(
           expr.as<slang::ast::IntegerLiteral>(), *type_id, span);
     }
 
     case slang::ast::ExpressionKind::UnbasedUnsizedIntegerLiteral: {
-      auto type_id = type_id_of(expr);
+      auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return MakeUnbasedUnsizedLiteralExpr(
           expr.as<slang::ast::UnbasedUnsizedIntegerLiteral>(), *type_id, span);
@@ -420,296 +924,64 @@ auto LowerProcExpr(
 
     case slang::ast::ExpressionKind::StringLiteral: {
       const auto& sl = expr.as<slang::ast::StringLiteral>();
-      auto type_id = type_id_of(expr);
+      auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return MakeStringLiteralExpr(std::string{sl.getValue()}, *type_id, span);
     }
 
     case slang::ast::ExpressionKind::TimeLiteral: {
       const auto& tl = expr.as<slang::ast::TimeLiteral>();
-      auto type_id = type_id_of(expr);
+      auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return MakeTimeLiteralExpr(
           tl.getValue(), LowerTimeUnit(tl.getScale().base.unit), *type_id,
           span);
     }
 
-    case slang::ast::ExpressionKind::NamedValue: {
-      const auto& named = expr.as<slang::ast::NamedValueExpression>();
-      if (named.symbol.kind == slang::ast::SymbolKind::EnumValue) {
-        auto type_id = type_id_of(expr);
-        if (!type_id) return std::unexpected(std::move(type_id.error()));
-        return MakeEnumValueExpr(
-            named.symbol.as<slang::ast::EnumValueSymbol>(), *type_id, span);
-      }
+    case slang::ast::ExpressionKind::NamedValue:
       return LowerNamedValueProc(
-          unit_facts, unit_state, proc_state, stack, named);
-    }
+          unit_facts, unit_state, proc_state, stack,
+          expr.as<slang::ast::NamedValueExpression>());
 
-    case slang::ast::ExpressionKind::LValueReference: {
-      if (!compound_lvalue_context.has_value()) {
-        throw InternalError(
-            "LowerProcExpr: slang LValueReference encountered outside "
-            "compound-assignment RHS");
-      }
-      auto type_id = type_id_of(expr);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return MakeRefExpr(
-          LvalueToPrimary(*compound_lvalue_context), *type_id, span);
-    }
+    case slang::ast::ExpressionKind::LValueReference:
+      return LowerLValueReferenceExpr(
+          span, compound_lvalue_context,
+          TypeIdOfSlangExpr(unit_facts, unit_state, expr), "LowerProcExpr");
 
-    case slang::ast::ExpressionKind::Conversion: {
-      const auto& conv = expr.as<slang::ast::ConversionExpression>();
-      auto operand_id = append_child(conv.operand());
-      if (!operand_id) return std::unexpected(std::move(operand_id.error()));
-      auto type_id = type_id_of(expr);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return hir::Expr{
-          .type = *type_id,
-          .data =
-              hir::ConversionExpr{
-                  .operand = *operand_id,
-                  .kind = LowerConversionKind(conv.conversionKind),
-              },
-          .span = span,
-      };
-    }
+    case slang::ast::ExpressionKind::Conversion:
+      return LowerConversionExprProc(
+          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          expr.as<slang::ast::ConversionExpression>(), expr, span);
 
-    case slang::ast::ExpressionKind::UnaryOp: {
-      const auto& un = expr.as<slang::ast::UnaryExpression>();
-      auto op_or = LowerUnaryOp(un.op, span);
-      if (!op_or) return std::unexpected(std::move(op_or.error()));
-      auto operand_id = append_child(un.operand());
-      if (!operand_id) return std::unexpected(std::move(operand_id.error()));
-      auto type_id = type_id_of(expr);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return hir::Expr{
-          .type = *type_id,
-          .data = hir::UnaryExpr{.op = *op_or, .operand = *operand_id},
-          .span = span,
-      };
-    }
+    case slang::ast::ExpressionKind::UnaryOp:
+      return LowerUnaryExprProc(
+          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          expr.as<slang::ast::UnaryExpression>(), expr, span);
 
-    case slang::ast::ExpressionKind::BinaryOp: {
-      const auto& bin = expr.as<slang::ast::BinaryExpression>();
-      auto lhs_id = append_child(bin.left());
-      if (!lhs_id) return std::unexpected(std::move(lhs_id.error()));
-      auto rhs_id = append_child(bin.right());
-      if (!rhs_id) return std::unexpected(std::move(rhs_id.error()));
-      auto type_id = type_id_of(expr);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return hir::Expr{
-          .type = *type_id,
-          .data =
-              hir::BinaryExpr{
-                  .op = LowerBinaryOp(bin.op),
-                  .lhs = *lhs_id,
-                  .rhs = *rhs_id,
-              },
-          .span = span,
-      };
-    }
+    case slang::ast::ExpressionKind::BinaryOp:
+      return LowerBinaryExprProc(
+          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          expr.as<slang::ast::BinaryExpression>(), expr, span);
 
-    case slang::ast::ExpressionKind::ConditionalOp: {
-      const auto& cond = expr.as<slang::ast::ConditionalExpression>();
-      if (cond.conditions.size() != 1) {
-        return diag::Unsupported(
-            span, diag::DiagCode::kUnsupportedExpressionForm,
-            "conditional operator with `&&&` multi-condition is not yet "
-            "supported",
-            diag::UnsupportedCategory::kFeature);
-      }
-      if (cond.conditions[0].pattern != nullptr) {
-        return diag::Unsupported(
-            span, diag::DiagCode::kUnsupportedExpressionForm,
-            "conditional operator with `matches` pattern is not yet supported",
-            diag::UnsupportedCategory::kFeature);
-      }
-      auto cond_id = append_child(*cond.conditions[0].expr);
-      if (!cond_id) return std::unexpected(std::move(cond_id.error()));
-      auto then_id = append_child(cond.left());
-      if (!then_id) return std::unexpected(std::move(then_id.error()));
-      auto else_id = append_child(cond.right());
-      if (!else_id) return std::unexpected(std::move(else_id.error()));
-      auto type_id = type_id_of(expr);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return hir::Expr{
-          .type = *type_id,
-          .data =
-              hir::ConditionalExpr{
-                  .condition = *cond_id,
-                  .then_value = *then_id,
-                  .else_value = *else_id,
-              },
-          .span = span,
-      };
-    }
+    case slang::ast::ExpressionKind::ConditionalOp:
+      return LowerConditionalExprProc(
+          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          expr.as<slang::ast::ConditionalExpression>(), expr, span);
 
-    case slang::ast::ExpressionKind::Call: {
-      const auto& call = expr.as<slang::ast::CallExpression>();
+    case slang::ast::ExpressionKind::Call:
+      return LowerCallExprProc(
+          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          expr.as<slang::ast::CallExpression>(), expr, span);
 
-      std::vector<hir::ExprId> arg_ids;
-      arg_ids.reserve(call.arguments().size());
-      for (const auto* arg : call.arguments()) {
-        auto id = append_child(*arg);
-        if (!id) return std::unexpected(std::move(id.error()));
-        arg_ids.push_back(*id);
-      }
+    case slang::ast::ExpressionKind::Assignment:
+      return LowerAssignmentExprProc(
+          unit_facts, unit_state, proc_state, stack,
+          expr.as<slang::ast::AssignmentExpression>(), expr, span);
 
-      if (call.isSystemCall()) {
-        const auto& info = std::get<slang::ast::CallExpression::SystemCallInfo>(
-            call.subroutine);
-        const std::string_view name = info.subroutine->name;
-
-        if (auto enum_method_kind = LowerEnumMethodName(name);
-            enum_method_kind.has_value() && !arg_ids.empty() &&
-            call.arguments()[0]->type->getCanonicalType().kind ==
-                slang::ast::SymbolKind::EnumType) {
-          auto type_id = type_id_of(expr);
-          if (!type_id) return std::unexpected(std::move(type_id.error()));
-          return hir::Expr{
-              .type = *type_id,
-              .data =
-                  hir::CallExpr{
-                      .callee =
-                          hir::BuiltinMethodRef{.kind = *enum_method_kind},
-                      .arguments = std::move(arg_ids),
-                  },
-              .span = span,
-          };
-        }
-
-        const auto* desc = support::FindSystemSubroutine(name);
-        if (desc == nullptr) {
-          throw InternalError(
-              std::string{"AST->HIR call: unresolved system subroutine '"} +
-              std::string{name} + "' after slang resolution");
-        }
-        const auto frontend_kind =
-            FromSlangSubroutineKind(info.subroutine->kind);
-        if (desc->kind != frontend_kind) {
-          throw InternalError(
-              std::string{
-                  "AST->HIR call: registry/frontend kind mismatch for '"} +
-              std::string{name} + "'");
-        }
-        if (!desc->arg_policy.Accepts(arg_ids.size())) {
-          throw InternalError(
-              std::string{
-                  "AST->HIR call: arg count outside descriptor policy for '"} +
-              std::string{name} + "'");
-        }
-
-        const auto result_type =
-            MakeReturnConventionType(unit_state, desc->result_conv);
-        return hir::Expr{
-            .type = result_type,
-            .data =
-                hir::CallExpr{
-                    .callee = hir::SystemSubroutineRef{.id = desc->id},
-                    .arguments = std::move(arg_ids),
-                },
-            .span = span,
-        };
-      }
-
-      const auto* sym =
-          std::get<const slang::ast::SubroutineSymbol*>(call.subroutine);
-      if (sym == nullptr) {
-        throw InternalError(
-            "AST->HIR call: user call missing resolved SubroutineSymbol");
-      }
-      const auto binding = unit_state.LookupSubroutineBinding(*sym);
-      if (!binding.has_value()) {
-        throw InternalError(
-            "AST->HIR call: resolved user subroutine has no registered HIR "
-            "binding");
-      }
-      const auto hops = stack.HopsTo(binding->owner_frame);
-      if (!hops.has_value()) {
-        throw InternalError(
-            "AST->HIR call: user subroutine owner frame is not on the current "
-            "scope stack");
-      }
-      auto result_type = type_id_of(expr);
-      if (!result_type) {
-        return std::unexpected(std::move(result_type.error()));
-      }
-      return hir::Expr{
-          .type = *result_type,
-          .data =
-              hir::CallExpr{
-                  .callee =
-                      hir::StructuralSubroutineRef{
-                          .hops = *hops, .subroutine = binding->subroutine_id},
-                  .arguments = std::move(arg_ids),
-              },
-          .span = span,
-      };
-    }
-
-    case slang::ast::ExpressionKind::Assignment: {
-      const auto& as = expr.as<slang::ast::AssignmentExpression>();
-      const auto kind = as.isNonBlocking() ? hir::AssignKind::kNonBlocking
-                                           : hir::AssignKind::kBlocking;
-
-      auto lhs_or =
-          LowerProcLvalue(unit_facts, unit_state, proc_state, stack, as.left());
-      if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-
-      auto rhs_or = LowerProcExpr(
-          unit_facts, unit_state, proc_state, stack, as.right(), *lhs_or);
-      if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-      const hir::ExprId rhs_id = proc_state.AddExpr(*std::move(rhs_or));
-
-      auto type_id = type_id_of(expr);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return hir::Expr{
-          .type = *type_id,
-          .data =
-              hir::AssignExpr{
-                  .kind = kind, .lhs = *std::move(lhs_or), .rhs = rhs_id},
-          .span = span,
-      };
-    }
-
-    case slang::ast::ExpressionKind::Inside: {
-      const auto& in = expr.as<slang::ast::InsideExpression>();
-      auto lhs_id = append_child(in.left());
-      if (!lhs_id) return std::unexpected(std::move(lhs_id.error()));
-
-      std::vector<hir::InsideItem> items;
-      items.reserve(in.rangeList().size());
-      for (const auto* item : in.rangeList()) {
-        if (item->kind == slang::ast::ExpressionKind::ValueRange) {
-          const auto& vr = item->as<slang::ast::ValueRangeExpression>();
-          if (vr.rangeKind != slang::ast::ValueRangeKind::Simple) {
-            return diag::Unsupported(
-                mapper.SpanOf(vr.sourceRange),
-                diag::DiagCode::kUnsupportedExpressionForm,
-                "tolerance-range form in inside operator is not yet supported",
-                diag::UnsupportedCategory::kFeature);
-          }
-          auto lo_id = append_child(vr.left());
-          if (!lo_id) return std::unexpected(std::move(lo_id.error()));
-          auto hi_id = append_child(vr.right());
-          if (!hi_id) return std::unexpected(std::move(hi_id.error()));
-          items.emplace_back(hir::InsideRangePair{.lo = *lo_id, .hi = *hi_id});
-        } else {
-          auto val_id = append_child(*item);
-          if (!val_id) return std::unexpected(std::move(val_id.error()));
-          items.emplace_back(*val_id);
-        }
-      }
-
-      auto type_id = type_id_of(expr);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return hir::Expr{
-          .type = *type_id,
-          .data = hir::InsideExpr{.lhs = *lhs_id, .items = std::move(items)},
-          .span = span,
-      };
-    }
+    case slang::ast::ExpressionKind::Inside:
+      return LowerInsideExprProc(
+          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          expr.as<slang::ast::InsideExpression>(), expr, span);
 
     default:
       return diag::Unsupported(
@@ -728,186 +1000,51 @@ auto LowerStructuralExpr(
   const auto& mapper = unit_facts.SourceMapper();
   const auto span = mapper.SpanOf(expr.sourceRange);
 
-  auto lower_child = [&](const slang::ast::Expression& e) {
-    return LowerStructuralExpr(
-        unit_facts, unit_state, scope_state, stack, e, compound_lvalue_context);
-  };
-  auto add_child =
-      [&](const slang::ast::Expression& e) -> diag::Result<hir::ExprId> {
-    auto child = lower_child(e);
-    if (!child) return std::unexpected(std::move(child.error()));
-    return scope_state.AddExpr(*std::move(child));
-  };
-  auto type_id_of =
-      [&](const slang::ast::Expression& e) -> diag::Result<hir::TypeId> {
-    auto td = LowerType(*e.type, mapper.SpanOf(e.sourceRange), unit_state);
-    if (!td) return std::unexpected(std::move(td.error()));
-    return unit_state.AddType(*std::move(td));
-  };
-
   switch (expr.kind) {
     case slang::ast::ExpressionKind::IntegerLiteral: {
-      auto type_id = type_id_of(expr);
+      auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return MakeIntegerLiteralExpr(
           expr.as<slang::ast::IntegerLiteral>(), *type_id, span);
     }
 
     case slang::ast::ExpressionKind::UnbasedUnsizedIntegerLiteral: {
-      auto type_id = type_id_of(expr);
+      auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return MakeUnbasedUnsizedLiteralExpr(
           expr.as<slang::ast::UnbasedUnsizedIntegerLiteral>(), *type_id, span);
     }
 
-    case slang::ast::ExpressionKind::NamedValue: {
-      const auto& named = expr.as<slang::ast::NamedValueExpression>();
-      const auto& sym = named.symbol;
-      if (sym.kind == slang::ast::SymbolKind::EnumValue) {
-        auto type_id = type_id_of(expr);
-        if (!type_id) return std::unexpected(std::move(type_id.error()));
-        return MakeEnumValueExpr(
-            sym.as<slang::ast::EnumValueSymbol>(), *type_id, span);
-      }
-      if (sym.kind == slang::ast::SymbolKind::Variable ||
-          sym.kind == slang::ast::SymbolKind::Parameter) {
-        const auto& value_sym = sym.as<slang::ast::ValueSymbol>();
-        if (auto loop_binding = unit_state.LookupLoopVarBinding(value_sym)) {
-          const auto hops = stack.HopsTo(loop_binding->home_frame);
-          if (!hops.has_value()) {
-            throw InternalError(
-                "LowerStructuralExpr: loop-var binding home frame is not on "
-                "the current scope stack");
-          }
-          return MakeRefExpr(
-              hir::LoopVarRef{
-                  .hops = *hops, .loop_var = loop_binding->loop_var_id},
-              loop_binding->type, span);
-        }
-      }
-      if (sym.kind != slang::ast::SymbolKind::Variable) {
-        return diag::Unsupported(
-            mapper.SpanOf(named.sourceRange),
-            diag::DiagCode::kUnsupportedNonVariableNamedReference,
-            "reference to non-variable declaration is not supported",
-            diag::UnsupportedCategory::kFeature);
-      }
-      const auto& var = sym.as<slang::ast::VariableSymbol>();
-      const auto binding = unit_state.LookupStructuralVarBinding(var);
-      if (!binding.has_value()) {
-        throw InternalError(
-            "LowerStructuralExpr: variable was not bound during scope "
-            "lowering");
-      }
-      const auto hops = stack.HopsTo(binding->home_frame);
-      if (!hops.has_value()) {
-        throw InternalError(
-            "LowerStructuralExpr: variable home frame is not on the current "
-            "scope stack");
-      }
-      return MakeRefExpr(
-          hir::StructuralVarRef{.hops = *hops, .var = binding->var_id},
-          binding->type, span);
-    }
+    case slang::ast::ExpressionKind::NamedValue:
+      return LowerNamedValueStructural(
+          unit_facts, unit_state, stack,
+          expr.as<slang::ast::NamedValueExpression>());
 
-    case slang::ast::ExpressionKind::LValueReference: {
-      if (!compound_lvalue_context.has_value()) {
-        throw InternalError(
-            "LowerStructuralExpr: slang LValueReference encountered outside "
-            "compound-assignment RHS");
-      }
-      auto type_id = type_id_of(expr);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return MakeRefExpr(
-          LvalueToPrimary(*compound_lvalue_context), *type_id, span);
-    }
+    case slang::ast::ExpressionKind::LValueReference:
+      return LowerLValueReferenceExpr(
+          span, compound_lvalue_context,
+          TypeIdOfSlangExpr(unit_facts, unit_state, expr),
+          "LowerStructuralExpr");
 
-    case slang::ast::ExpressionKind::Conversion: {
-      const auto& conv = expr.as<slang::ast::ConversionExpression>();
-      auto operand_id = add_child(conv.operand());
-      if (!operand_id) return std::unexpected(std::move(operand_id.error()));
-      auto type_id = type_id_of(expr);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return hir::Expr{
-          .type = *type_id,
-          .data =
-              hir::ConversionExpr{
-                  .operand = *operand_id,
-                  .kind = LowerConversionKind(conv.conversionKind),
-              },
-          .span = span,
-      };
-    }
+    case slang::ast::ExpressionKind::Conversion:
+      return LowerConversionExprStructural(
+          unit_facts, unit_state, scope_state, stack, compound_lvalue_context,
+          expr.as<slang::ast::ConversionExpression>(), expr, span);
 
-    case slang::ast::ExpressionKind::UnaryOp: {
-      const auto& un = expr.as<slang::ast::UnaryExpression>();
-      auto op_or = LowerUnaryOp(un.op, span);
-      if (!op_or) return std::unexpected(std::move(op_or.error()));
-      auto operand_id = add_child(un.operand());
-      if (!operand_id) return std::unexpected(std::move(operand_id.error()));
-      auto type_id = type_id_of(expr);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return hir::Expr{
-          .type = *type_id,
-          .data = hir::UnaryExpr{.op = *op_or, .operand = *operand_id},
-          .span = span,
-      };
-    }
+    case slang::ast::ExpressionKind::UnaryOp:
+      return LowerUnaryExprStructural(
+          unit_facts, unit_state, scope_state, stack, compound_lvalue_context,
+          expr.as<slang::ast::UnaryExpression>(), expr, span);
 
-    case slang::ast::ExpressionKind::BinaryOp: {
-      const auto& bin = expr.as<slang::ast::BinaryExpression>();
-      auto lhs_id = add_child(bin.left());
-      if (!lhs_id) return std::unexpected(std::move(lhs_id.error()));
-      auto rhs_id = add_child(bin.right());
-      if (!rhs_id) return std::unexpected(std::move(rhs_id.error()));
-      auto type_id = type_id_of(expr);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return hir::Expr{
-          .type = *type_id,
-          .data =
-              hir::BinaryExpr{
-                  .op = LowerBinaryOp(bin.op),
-                  .lhs = *lhs_id,
-                  .rhs = *rhs_id,
-              },
-          .span = span,
-      };
-    }
+    case slang::ast::ExpressionKind::BinaryOp:
+      return LowerBinaryExprStructural(
+          unit_facts, unit_state, scope_state, stack, compound_lvalue_context,
+          expr.as<slang::ast::BinaryExpression>(), expr, span);
 
-    case slang::ast::ExpressionKind::ConditionalOp: {
-      const auto& cond = expr.as<slang::ast::ConditionalExpression>();
-      if (cond.conditions.size() != 1) {
-        return diag::Unsupported(
-            span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
-            "conditional operator with `&&&` multi-condition is not yet "
-            "supported",
-            diag::UnsupportedCategory::kFeature);
-      }
-      if (cond.conditions[0].pattern != nullptr) {
-        return diag::Unsupported(
-            span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
-            "conditional operator with `matches` pattern is not yet supported",
-            diag::UnsupportedCategory::kFeature);
-      }
-      auto cond_id = add_child(*cond.conditions[0].expr);
-      if (!cond_id) return std::unexpected(std::move(cond_id.error()));
-      auto then_id = add_child(cond.left());
-      if (!then_id) return std::unexpected(std::move(then_id.error()));
-      auto else_id = add_child(cond.right());
-      if (!else_id) return std::unexpected(std::move(else_id.error()));
-      auto type_id = type_id_of(expr);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return hir::Expr{
-          .type = *type_id,
-          .data =
-              hir::ConditionalExpr{
-                  .condition = *cond_id,
-                  .then_value = *then_id,
-                  .else_value = *else_id,
-              },
-          .span = span,
-      };
-    }
+    case slang::ast::ExpressionKind::ConditionalOp:
+      return LowerConditionalExprStructural(
+          unit_facts, unit_state, scope_state, stack, compound_lvalue_context,
+          expr.as<slang::ast::ConditionalExpression>(), expr, span);
 
     default:
       return diag::Unsupported(

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -72,6 +72,341 @@ auto LowerTimingControl(
   }
 }
 
+auto LowerEmptyStmt(diag::SourceSpan span) -> diag::Result<hir::Stmt> {
+  return hir::Stmt{
+      .label = std::nullopt, .data = hir::EmptyStmt{}, .span = span};
+}
+
+auto LowerTimedStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, ScopeStack& stack,
+    const slang::ast::TimedStatement& ts, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  auto timing = LowerTimingControl(
+      unit_facts, scope_state.UnitState(), proc_state, stack, ts.timing, span);
+  if (!timing) return std::unexpected(std::move(timing.error()));
+  auto inner_stmt =
+      LowerStatement(unit_facts, proc_state, scope_state, stack, ts.stmt);
+  if (!inner_stmt) return std::unexpected(std::move(inner_stmt.error()));
+  const hir::StmtId inner_id = proc_state.AddStmt(*std::move(inner_stmt));
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data = hir::TimedStmt{.timing = *std::move(timing), .stmt = inner_id},
+      .span = span};
+}
+
+auto LowerStatementListStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, ScopeStack& stack,
+    const slang::ast::StatementList& list, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  std::vector<hir::StmtId> kids;
+  kids.reserve(list.list.size());
+  for (const auto* child : list.list) {
+    auto child_stmt =
+        LowerStatement(unit_facts, proc_state, scope_state, stack, *child);
+    if (!child_stmt) return std::unexpected(std::move(child_stmt.error()));
+    kids.push_back(proc_state.AddStmt(*std::move(child_stmt)));
+  }
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data = hir::BlockStmt{.statements = std::move(kids)},
+      .span = span};
+}
+
+auto LowerBlockStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, ScopeStack& stack,
+    const slang::ast::BlockStatement& block, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  std::vector<hir::StmtId> kids;
+  if (block.body.kind == slang::ast::StatementKind::List) {
+    const auto& list = block.body.as<slang::ast::StatementList>();
+    kids.reserve(list.list.size());
+    for (const auto* child : list.list) {
+      auto child_stmt =
+          LowerStatement(unit_facts, proc_state, scope_state, stack, *child);
+      if (!child_stmt) return std::unexpected(std::move(child_stmt.error()));
+      kids.push_back(proc_state.AddStmt(*std::move(child_stmt)));
+    }
+  } else {
+    auto child_stmt =
+        LowerStatement(unit_facts, proc_state, scope_state, stack, block.body);
+    if (!child_stmt) return std::unexpected(std::move(child_stmt.error()));
+    kids.push_back(proc_state.AddStmt(*std::move(child_stmt)));
+  }
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data = hir::BlockStmt{.statements = std::move(kids)},
+      .span = span};
+}
+
+auto LowerVariableDeclStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, const ScopeStack& stack,
+    const slang::ast::VariableDeclStatement& vd, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  const auto& mapper = unit_facts.SourceMapper();
+  const auto& sym = vd.symbol;
+  auto type_data = LowerType(
+      sym.getType(), mapper.PointSpanOf(sym.location), scope_state.UnitState());
+  if (!type_data) return std::unexpected(std::move(type_data.error()));
+  const auto type_id = scope_state.UnitState().AddType(*std::move(type_data));
+  const auto local_id = proc_state.AddProceduralVar(sym, type_id);
+  std::optional<hir::ExprId> init_id;
+  if (const auto* init_expr = sym.getInitializer()) {
+    auto init_or = LowerProcExpr(
+        unit_facts, scope_state.UnitState(), proc_state, stack, *init_expr);
+    if (!init_or) return std::unexpected(std::move(init_or.error()));
+    init_id = proc_state.AddExpr(*std::move(init_or));
+  }
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data = hir::VarDeclStmt{.var = local_id, .init = init_id},
+      .span = span};
+}
+
+auto LowerExpressionStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, const ScopeStack& stack,
+    const slang::ast::ExpressionStatement& es, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  auto expr = LowerProcExpr(
+      unit_facts, scope_state.UnitState(), proc_state, stack, es.expr);
+  if (!expr) return std::unexpected(std::move(expr.error()));
+  const hir::ExprId id = proc_state.AddExpr(*std::move(expr));
+  return hir::Stmt{
+      .label = std::nullopt, .data = hir::ExprStmt{.expr = id}, .span = span};
+}
+
+auto LowerForLoopStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, ScopeStack& stack,
+    const slang::ast::ForLoopStatement& fs, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  // slang elaborates `for (int i = 0; ...)` as an independent preceding
+  // VariableDeclStatement plus a ForLoopStatement whose `initializers` is
+  // empty and `loopVars` only points at the already-declared symbol. The
+  // preceding VarDeclStatement carries the initializer, so loopVars is
+  // informational only and is ignored here.
+  std::vector<hir::ForInit> hir_init;
+  hir_init.reserve(fs.initializers.size());
+  for (const auto* init_expr : fs.initializers) {
+    auto init_or = LowerProcExpr(
+        unit_facts, scope_state.UnitState(), proc_state, stack, *init_expr);
+    if (!init_or) return std::unexpected(std::move(init_or.error()));
+    hir_init.emplace_back(
+        hir::ForInitExpr{.expr = proc_state.AddExpr(*std::move(init_or))});
+  }
+  std::optional<hir::ExprId> cond_id;
+  if (fs.stopExpr != nullptr) {
+    auto cond_or = LowerProcExpr(
+        unit_facts, scope_state.UnitState(), proc_state, stack, *fs.stopExpr);
+    if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+    cond_id = proc_state.AddExpr(*std::move(cond_or));
+  }
+  std::vector<hir::ExprId> step_ids;
+  step_ids.reserve(fs.steps.size());
+  for (const auto* step_expr : fs.steps) {
+    auto step_or = LowerProcExpr(
+        unit_facts, scope_state.UnitState(), proc_state, stack, *step_expr);
+    if (!step_or) return std::unexpected(std::move(step_or.error()));
+    step_ids.push_back(proc_state.AddExpr(*std::move(step_or)));
+  }
+  auto body_stmt =
+      LowerStatement(unit_facts, proc_state, scope_state, stack, fs.body);
+  if (!body_stmt) return std::unexpected(std::move(body_stmt.error()));
+  const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_stmt));
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data =
+          hir::ForStmt{
+              .init = std::move(hir_init),
+              .condition = cond_id,
+              .step = std::move(step_ids),
+              .body = body_id},
+      .span = span};
+}
+
+auto LowerWhileLoopStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, ScopeStack& stack,
+    const slang::ast::WhileLoopStatement& ws, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  auto cond_or = LowerProcExpr(
+      unit_facts, scope_state.UnitState(), proc_state, stack, ws.cond);
+  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+  const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_or));
+  auto body_or =
+      LowerStatement(unit_facts, proc_state, scope_state, stack, ws.body);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+  const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_or));
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data = hir::WhileStmt{.condition = cond_id, .body = body_id},
+      .span = span};
+}
+
+auto LowerRepeatLoopStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, ScopeStack& stack,
+    const slang::ast::RepeatLoopStatement& rs, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  auto count_or = LowerProcExpr(
+      unit_facts, scope_state.UnitState(), proc_state, stack, rs.count);
+  if (!count_or) return std::unexpected(std::move(count_or.error()));
+  const hir::ExprId count_id = proc_state.AddExpr(*std::move(count_or));
+  auto body_or =
+      LowerStatement(unit_facts, proc_state, scope_state, stack, rs.body);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+  const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_or));
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data = hir::RepeatStmt{.count = count_id, .body = body_id},
+      .span = span};
+}
+
+auto LowerDoWhileLoopStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, ScopeStack& stack,
+    const slang::ast::DoWhileLoopStatement& ds, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  auto body_or =
+      LowerStatement(unit_facts, proc_state, scope_state, stack, ds.body);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+  const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_or));
+  auto cond_or = LowerProcExpr(
+      unit_facts, scope_state.UnitState(), proc_state, stack, ds.cond);
+  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+  const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_or));
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data = hir::DoWhileStmt{.condition = cond_id, .body = body_id},
+      .span = span};
+}
+
+auto LowerForeverLoopStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, ScopeStack& stack,
+    const slang::ast::ForeverLoopStatement& fs, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  auto body_or =
+      LowerStatement(unit_facts, proc_state, scope_state, stack, fs.body);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+  const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_or));
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data = hir::ForeverStmt{.body = body_id},
+      .span = span};
+}
+
+auto LowerBreakStmt(diag::SourceSpan span) -> diag::Result<hir::Stmt> {
+  return hir::Stmt{
+      .label = std::nullopt, .data = hir::BreakStmt{}, .span = span};
+}
+
+auto LowerContinueStmt(diag::SourceSpan span) -> diag::Result<hir::Stmt> {
+  return hir::Stmt{
+      .label = std::nullopt, .data = hir::ContinueStmt{}, .span = span};
+}
+
+auto LowerCaseSlangStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, ScopeStack& stack,
+    const slang::ast::CaseStatement& cs, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  if (cs.condition != slang::ast::CaseStatementCondition::Normal) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedStatementForm,
+        "casez/casex/case-inside are not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  const auto case_check = LowerUniquePriorityCheck(cs.check);
+  auto cond_expr = LowerProcExpr(
+      unit_facts, scope_state.UnitState(), proc_state, stack, cs.expr);
+  if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
+  const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_expr));
+  std::vector<hir::CaseItem> items;
+  items.reserve(cs.items.size());
+  for (const auto& item : cs.items) {
+    std::vector<hir::ExprId> label_ids;
+    label_ids.reserve(item.expressions.size());
+    for (const auto* label_expr : item.expressions) {
+      auto label_or = LowerProcExpr(
+          unit_facts, scope_state.UnitState(), proc_state, stack, *label_expr);
+      if (!label_or) return std::unexpected(std::move(label_or.error()));
+      label_ids.push_back(proc_state.AddExpr(*std::move(label_or)));
+    }
+    auto item_stmt =
+        LowerStatement(unit_facts, proc_state, scope_state, stack, *item.stmt);
+    if (!item_stmt) return std::unexpected(std::move(item_stmt.error()));
+    const hir::StmtId item_id = proc_state.AddStmt(*std::move(item_stmt));
+    items.push_back(
+        hir::CaseItem{.labels = std::move(label_ids), .stmt = item_id});
+  }
+  std::optional<hir::StmtId> default_id;
+  if (cs.defaultCase != nullptr) {
+    auto default_stmt = LowerStatement(
+        unit_facts, proc_state, scope_state, stack, *cs.defaultCase);
+    if (!default_stmt) return std::unexpected(std::move(default_stmt.error()));
+    default_id = proc_state.AddStmt(*std::move(default_stmt));
+  }
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data =
+          hir::CaseStmt{
+              .condition = cond_id,
+              .items = std::move(items),
+              .default_stmt = default_id,
+              .check = case_check},
+      .span = span};
+}
+
+auto LowerConditionalSlangStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, ScopeStack& stack,
+    const slang::ast::ConditionalStatement& cs, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  const auto if_check = LowerUniquePriorityCheck(cs.check);
+  if (cs.conditions.size() != 1) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedStatementForm,
+        "multi-condition if expressions are not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  const auto& cond = cs.conditions.front();
+  if (cond.pattern != nullptr) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedStatementForm,
+        "pattern matching in if conditions is not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  auto cond_expr = LowerProcExpr(
+      unit_facts, scope_state.UnitState(), proc_state, stack, *cond.expr);
+  if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
+  const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_expr));
+  auto then_stmt =
+      LowerStatement(unit_facts, proc_state, scope_state, stack, cs.ifTrue);
+  if (!then_stmt) return std::unexpected(std::move(then_stmt.error()));
+  const hir::StmtId then_id = proc_state.AddStmt(*std::move(then_stmt));
+  std::optional<hir::StmtId> else_id;
+  if (cs.ifFalse != nullptr) {
+    auto else_stmt =
+        LowerStatement(unit_facts, proc_state, scope_state, stack, *cs.ifFalse);
+    if (!else_stmt) return std::unexpected(std::move(else_stmt.error()));
+    else_id = proc_state.AddStmt(*std::move(else_stmt));
+  }
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data =
+          hir::IfStmt{
+              .condition = cond_id,
+              .then_stmt = then_id,
+              .else_stmt = else_id,
+              .check = if_check},
+      .span = span};
+}
+
 }  // namespace
 
 auto LowerStatement(
@@ -81,314 +416,74 @@ auto LowerStatement(
   const auto& mapper = unit_facts.SourceMapper();
   const auto span = mapper.SpanOf(stmt.sourceRange);
   switch (stmt.kind) {
-    case slang::ast::StatementKind::Empty: {
-      return hir::Stmt{
-          .label = std::nullopt, .data = hir::EmptyStmt{}, .span = span};
-    }
+    case slang::ast::StatementKind::Empty:
+      return LowerEmptyStmt(span);
 
-    case slang::ast::StatementKind::Timed: {
-      const auto& ts = stmt.as<slang::ast::TimedStatement>();
-      auto timing = LowerTimingControl(
-          unit_facts, scope_state.UnitState(), proc_state, stack, ts.timing,
-          span);
-      if (!timing) return std::unexpected(std::move(timing.error()));
-      auto inner_stmt =
-          LowerStatement(unit_facts, proc_state, scope_state, stack, ts.stmt);
-      if (!inner_stmt) return std::unexpected(std::move(inner_stmt.error()));
-      const hir::StmtId inner_id = proc_state.AddStmt(*std::move(inner_stmt));
-      return hir::Stmt{
-          .label = std::nullopt,
-          .data =
-              hir::TimedStmt{.timing = *std::move(timing), .stmt = inner_id},
-          .span = span};
-    }
+    case slang::ast::StatementKind::Timed:
+      return LowerTimedStmt(
+          unit_facts, proc_state, scope_state, stack,
+          stmt.as<slang::ast::TimedStatement>(), span);
 
-    case slang::ast::StatementKind::List: {
-      const auto& list = stmt.as<slang::ast::StatementList>();
-      std::vector<hir::StmtId> kids;
-      kids.reserve(list.list.size());
-      for (const auto* child : list.list) {
-        auto child_stmt =
-            LowerStatement(unit_facts, proc_state, scope_state, stack, *child);
-        if (!child_stmt) return std::unexpected(std::move(child_stmt.error()));
-        kids.push_back(proc_state.AddStmt(*std::move(child_stmt)));
-      }
-      return hir::Stmt{
-          .label = std::nullopt,
-          .data = hir::BlockStmt{.statements = std::move(kids)},
-          .span = span};
-    }
+    case slang::ast::StatementKind::List:
+      return LowerStatementListStmt(
+          unit_facts, proc_state, scope_state, stack,
+          stmt.as<slang::ast::StatementList>(), span);
 
-    case slang::ast::StatementKind::Block: {
-      const auto& block = stmt.as<slang::ast::BlockStatement>();
-      std::vector<hir::StmtId> kids;
-      if (block.body.kind == slang::ast::StatementKind::List) {
-        const auto& list = block.body.as<slang::ast::StatementList>();
-        kids.reserve(list.list.size());
-        for (const auto* child : list.list) {
-          auto child_stmt = LowerStatement(
-              unit_facts, proc_state, scope_state, stack, *child);
-          if (!child_stmt)
-            return std::unexpected(std::move(child_stmt.error()));
-          kids.push_back(proc_state.AddStmt(*std::move(child_stmt)));
-        }
-      } else {
-        auto child_stmt = LowerStatement(
-            unit_facts, proc_state, scope_state, stack, block.body);
-        if (!child_stmt) return std::unexpected(std::move(child_stmt.error()));
-        kids.push_back(proc_state.AddStmt(*std::move(child_stmt)));
-      }
-      return hir::Stmt{
-          .label = std::nullopt,
-          .data = hir::BlockStmt{.statements = std::move(kids)},
-          .span = span};
-    }
+    case slang::ast::StatementKind::Block:
+      return LowerBlockStmt(
+          unit_facts, proc_state, scope_state, stack,
+          stmt.as<slang::ast::BlockStatement>(), span);
 
-    case slang::ast::StatementKind::VariableDeclaration: {
-      const auto& vd = stmt.as<slang::ast::VariableDeclStatement>();
-      const auto& sym = vd.symbol;
-      auto type_data = LowerType(
-          sym.getType(), mapper.PointSpanOf(sym.location),
-          scope_state.UnitState());
-      if (!type_data) return std::unexpected(std::move(type_data.error()));
-      const auto type_id =
-          scope_state.UnitState().AddType(*std::move(type_data));
-      const auto local_id = proc_state.AddProceduralVar(sym, type_id);
-      std::optional<hir::ExprId> init_id;
-      if (const auto* init_expr = sym.getInitializer()) {
-        auto init_or = LowerProcExpr(
-            unit_facts, scope_state.UnitState(), proc_state, stack, *init_expr);
-        if (!init_or) return std::unexpected(std::move(init_or.error()));
-        init_id = proc_state.AddExpr(*std::move(init_or));
-      }
-      return hir::Stmt{
-          .label = std::nullopt,
-          .data = hir::VarDeclStmt{.var = local_id, .init = init_id},
-          .span = span};
-    }
+    case slang::ast::StatementKind::VariableDeclaration:
+      return LowerVariableDeclStmt(
+          unit_facts, proc_state, scope_state, stack,
+          stmt.as<slang::ast::VariableDeclStatement>(), span);
 
-    case slang::ast::StatementKind::ExpressionStatement: {
-      const auto& es = stmt.as<slang::ast::ExpressionStatement>();
-      auto expr = LowerProcExpr(
-          unit_facts, scope_state.UnitState(), proc_state, stack, es.expr);
-      if (!expr) return std::unexpected(std::move(expr.error()));
-      const hir::ExprId id = proc_state.AddExpr(*std::move(expr));
-      return hir::Stmt{
-          .label = std::nullopt,
-          .data = hir::ExprStmt{.expr = id},
-          .span = span};
-    }
+    case slang::ast::StatementKind::ExpressionStatement:
+      return LowerExpressionStmt(
+          unit_facts, proc_state, scope_state, stack,
+          stmt.as<slang::ast::ExpressionStatement>(), span);
 
-    case slang::ast::StatementKind::ForLoop: {
-      const auto& fs = stmt.as<slang::ast::ForLoopStatement>();
-      // slang elaborates `for (int i = 0; ...)` as an independent preceding
-      // VariableDeclStatement plus a ForLoopStatement whose `initializers` is
-      // empty and `loopVars` only points at the already-declared symbol. The
-      // preceding VarDeclStatement carries the initializer, so loopVars is
-      // informational only and is ignored here.
-      std::vector<hir::ForInit> hir_init;
-      hir_init.reserve(fs.initializers.size());
-      for (const auto* init_expr : fs.initializers) {
-        auto init_or = LowerProcExpr(
-            unit_facts, scope_state.UnitState(), proc_state, stack, *init_expr);
-        if (!init_or) return std::unexpected(std::move(init_or.error()));
-        hir_init.emplace_back(
-            hir::ForInitExpr{.expr = proc_state.AddExpr(*std::move(init_or))});
-      }
-      std::optional<hir::ExprId> cond_id;
-      if (fs.stopExpr != nullptr) {
-        auto cond_or = LowerProcExpr(
-            unit_facts, scope_state.UnitState(), proc_state, stack,
-            *fs.stopExpr);
-        if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-        cond_id = proc_state.AddExpr(*std::move(cond_or));
-      }
-      std::vector<hir::ExprId> step_ids;
-      step_ids.reserve(fs.steps.size());
-      for (const auto* step_expr : fs.steps) {
-        auto step_or = LowerProcExpr(
-            unit_facts, scope_state.UnitState(), proc_state, stack, *step_expr);
-        if (!step_or) return std::unexpected(std::move(step_or.error()));
-        step_ids.push_back(proc_state.AddExpr(*std::move(step_or)));
-      }
-      auto body_stmt =
-          LowerStatement(unit_facts, proc_state, scope_state, stack, fs.body);
-      if (!body_stmt) return std::unexpected(std::move(body_stmt.error()));
-      const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_stmt));
-      return hir::Stmt{
-          .label = std::nullopt,
-          .data =
-              hir::ForStmt{
-                  .init = std::move(hir_init),
-                  .condition = cond_id,
-                  .step = std::move(step_ids),
-                  .body = body_id},
-          .span = span};
-    }
+    case slang::ast::StatementKind::ForLoop:
+      return LowerForLoopStmt(
+          unit_facts, proc_state, scope_state, stack,
+          stmt.as<slang::ast::ForLoopStatement>(), span);
 
-    case slang::ast::StatementKind::WhileLoop: {
-      const auto& ws = stmt.as<slang::ast::WhileLoopStatement>();
-      auto cond_or = LowerProcExpr(
-          unit_facts, scope_state.UnitState(), proc_state, stack, ws.cond);
-      if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-      const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_or));
-      auto body_or =
-          LowerStatement(unit_facts, proc_state, scope_state, stack, ws.body);
-      if (!body_or) return std::unexpected(std::move(body_or.error()));
-      const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_or));
-      return hir::Stmt{
-          .label = std::nullopt,
-          .data = hir::WhileStmt{.condition = cond_id, .body = body_id},
-          .span = span};
-    }
+    case slang::ast::StatementKind::WhileLoop:
+      return LowerWhileLoopStmt(
+          unit_facts, proc_state, scope_state, stack,
+          stmt.as<slang::ast::WhileLoopStatement>(), span);
 
-    case slang::ast::StatementKind::RepeatLoop: {
-      const auto& rs = stmt.as<slang::ast::RepeatLoopStatement>();
-      auto count_or = LowerProcExpr(
-          unit_facts, scope_state.UnitState(), proc_state, stack, rs.count);
-      if (!count_or) return std::unexpected(std::move(count_or.error()));
-      const hir::ExprId count_id = proc_state.AddExpr(*std::move(count_or));
-      auto body_or =
-          LowerStatement(unit_facts, proc_state, scope_state, stack, rs.body);
-      if (!body_or) return std::unexpected(std::move(body_or.error()));
-      const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_or));
-      return hir::Stmt{
-          .label = std::nullopt,
-          .data = hir::RepeatStmt{.count = count_id, .body = body_id},
-          .span = span};
-    }
+    case slang::ast::StatementKind::RepeatLoop:
+      return LowerRepeatLoopStmt(
+          unit_facts, proc_state, scope_state, stack,
+          stmt.as<slang::ast::RepeatLoopStatement>(), span);
 
-    case slang::ast::StatementKind::DoWhileLoop: {
-      const auto& ds = stmt.as<slang::ast::DoWhileLoopStatement>();
-      auto body_or =
-          LowerStatement(unit_facts, proc_state, scope_state, stack, ds.body);
-      if (!body_or) return std::unexpected(std::move(body_or.error()));
-      const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_or));
-      auto cond_or = LowerProcExpr(
-          unit_facts, scope_state.UnitState(), proc_state, stack, ds.cond);
-      if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-      const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_or));
-      return hir::Stmt{
-          .label = std::nullopt,
-          .data = hir::DoWhileStmt{.condition = cond_id, .body = body_id},
-          .span = span};
-    }
+    case slang::ast::StatementKind::DoWhileLoop:
+      return LowerDoWhileLoopStmt(
+          unit_facts, proc_state, scope_state, stack,
+          stmt.as<slang::ast::DoWhileLoopStatement>(), span);
 
-    case slang::ast::StatementKind::ForeverLoop: {
-      const auto& fs = stmt.as<slang::ast::ForeverLoopStatement>();
-      auto body_or =
-          LowerStatement(unit_facts, proc_state, scope_state, stack, fs.body);
-      if (!body_or) return std::unexpected(std::move(body_or.error()));
-      const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_or));
-      return hir::Stmt{
-          .label = std::nullopt,
-          .data = hir::ForeverStmt{.body = body_id},
-          .span = span};
-    }
+    case slang::ast::StatementKind::ForeverLoop:
+      return LowerForeverLoopStmt(
+          unit_facts, proc_state, scope_state, stack,
+          stmt.as<slang::ast::ForeverLoopStatement>(), span);
 
-    case slang::ast::StatementKind::Break: {
-      return hir::Stmt{
-          .label = std::nullopt, .data = hir::BreakStmt{}, .span = span};
-    }
+    case slang::ast::StatementKind::Break:
+      return LowerBreakStmt(span);
 
-    case slang::ast::StatementKind::Continue: {
-      return hir::Stmt{
-          .label = std::nullopt, .data = hir::ContinueStmt{}, .span = span};
-    }
+    case slang::ast::StatementKind::Continue:
+      return LowerContinueStmt(span);
 
-    case slang::ast::StatementKind::Case: {
-      const auto& cs = stmt.as<slang::ast::CaseStatement>();
-      if (cs.condition != slang::ast::CaseStatementCondition::Normal) {
-        return diag::Unsupported(
-            span, diag::DiagCode::kUnsupportedStatementForm,
-            "casez/casex/case-inside are not yet supported",
-            diag::UnsupportedCategory::kFeature);
-      }
-      const auto case_check = LowerUniquePriorityCheck(cs.check);
-      auto cond_expr = LowerProcExpr(
-          unit_facts, scope_state.UnitState(), proc_state, stack, cs.expr);
-      if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
-      const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_expr));
-      std::vector<hir::CaseItem> items;
-      items.reserve(cs.items.size());
-      for (const auto& item : cs.items) {
-        std::vector<hir::ExprId> label_ids;
-        label_ids.reserve(item.expressions.size());
-        for (const auto* label_expr : item.expressions) {
-          auto label_or = LowerProcExpr(
-              unit_facts, scope_state.UnitState(), proc_state, stack,
-              *label_expr);
-          if (!label_or) return std::unexpected(std::move(label_or.error()));
-          label_ids.push_back(proc_state.AddExpr(*std::move(label_or)));
-        }
-        auto item_stmt = LowerStatement(
-            unit_facts, proc_state, scope_state, stack, *item.stmt);
-        if (!item_stmt) return std::unexpected(std::move(item_stmt.error()));
-        const hir::StmtId item_id = proc_state.AddStmt(*std::move(item_stmt));
-        items.push_back(
-            hir::CaseItem{.labels = std::move(label_ids), .stmt = item_id});
-      }
-      std::optional<hir::StmtId> default_id;
-      if (cs.defaultCase != nullptr) {
-        auto default_stmt = LowerStatement(
-            unit_facts, proc_state, scope_state, stack, *cs.defaultCase);
-        if (!default_stmt) {
-          return std::unexpected(std::move(default_stmt.error()));
-        }
-        default_id = proc_state.AddStmt(*std::move(default_stmt));
-      }
-      return hir::Stmt{
-          .label = std::nullopt,
-          .data =
-              hir::CaseStmt{
-                  .condition = cond_id,
-                  .items = std::move(items),
-                  .default_stmt = default_id,
-                  .check = case_check},
-          .span = span};
-    }
+    case slang::ast::StatementKind::Case:
+      return LowerCaseSlangStmt(
+          unit_facts, proc_state, scope_state, stack,
+          stmt.as<slang::ast::CaseStatement>(), span);
 
-    case slang::ast::StatementKind::Conditional: {
-      const auto& cs = stmt.as<slang::ast::ConditionalStatement>();
-      const auto if_check = LowerUniquePriorityCheck(cs.check);
-      if (cs.conditions.size() != 1) {
-        return diag::Unsupported(
-            span, diag::DiagCode::kUnsupportedStatementForm,
-            "multi-condition if expressions are not yet supported",
-            diag::UnsupportedCategory::kFeature);
-      }
-      const auto& cond = cs.conditions.front();
-      if (cond.pattern != nullptr) {
-        return diag::Unsupported(
-            span, diag::DiagCode::kUnsupportedStatementForm,
-            "pattern matching in if conditions is not yet supported",
-            diag::UnsupportedCategory::kFeature);
-      }
-      auto cond_expr = LowerProcExpr(
-          unit_facts, scope_state.UnitState(), proc_state, stack, *cond.expr);
-      if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
-      const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_expr));
-      auto then_stmt =
-          LowerStatement(unit_facts, proc_state, scope_state, stack, cs.ifTrue);
-      if (!then_stmt) return std::unexpected(std::move(then_stmt.error()));
-      const hir::StmtId then_id = proc_state.AddStmt(*std::move(then_stmt));
-      std::optional<hir::StmtId> else_id;
-      if (cs.ifFalse != nullptr) {
-        auto else_stmt = LowerStatement(
-            unit_facts, proc_state, scope_state, stack, *cs.ifFalse);
-        if (!else_stmt) return std::unexpected(std::move(else_stmt.error()));
-        else_id = proc_state.AddStmt(*std::move(else_stmt));
-      }
-      return hir::Stmt{
-          .label = std::nullopt,
-          .data =
-              hir::IfStmt{
-                  .condition = cond_id,
-                  .then_stmt = then_id,
-                  .else_stmt = else_id,
-                  .check = if_check},
-          .span = span};
-    }
+    case slang::ast::StatementKind::Conditional:
+      return LowerConditionalSlangStmt(
+          unit_facts, proc_state, scope_state, stack,
+          stmt.as<slang::ast::ConditionalStatement>(), span);
 
     default:
       return diag::Unsupported(

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -616,6 +616,103 @@ auto LowerExpr(
                 },
                 c.callee);
           },
+          [&](const hir::InsideExpr& in) -> diag::Result<mir::Expr> {
+            auto lower_id = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
+              auto lowered = LowerExpr(
+                  unit_state, scope_state, proc_state, proc_scope_state,
+                  hir_process, hir_process.exprs.at(id.value));
+              if (!lowered) {
+                return std::unexpected(std::move(lowered.error()));
+              }
+              return proc_scope_state.AddExpr(*std::move(lowered));
+            };
+
+            auto lhs_id = lower_id(in.lhs);
+            if (!lhs_id) return std::unexpected(std::move(lhs_id.error()));
+
+            // Build per-item 1-bit predicate expressions and OR them together.
+            // Value item: lhs == item. Range item: (lhs >= lo) && (lhs <= hi).
+            std::vector<mir::ExprId> predicates;
+            predicates.reserve(in.items.size());
+            for (const auto& item : in.items) {
+              auto pred_or = std::visit(
+                  Overloaded{
+                      [&](const hir::ExprId& val_id)
+                          -> diag::Result<mir::ExprId> {
+                        auto v = lower_id(val_id);
+                        if (!v) return std::unexpected(std::move(v.error()));
+                        return proc_scope_state.AddExpr(
+                            mir::Expr{
+                                .data =
+                                    mir::BinaryExpr{
+                                        .op = mir::BinaryOp::kEquality,
+                                        .lhs = *lhs_id,
+                                        .rhs = *v},
+                                .type = result_type});
+                      },
+                      [&](const hir::InsideRangePair& r)
+                          -> diag::Result<mir::ExprId> {
+                        auto lo = lower_id(r.lo);
+                        if (!lo) return std::unexpected(std::move(lo.error()));
+                        auto hi = lower_id(r.hi);
+                        if (!hi) return std::unexpected(std::move(hi.error()));
+                        const mir::ExprId ge_id = proc_scope_state.AddExpr(
+                            mir::Expr{
+                                .data =
+                                    mir::BinaryExpr{
+                                        .op = mir::BinaryOp::kGreaterEqual,
+                                        .lhs = *lhs_id,
+                                        .rhs = *lo},
+                                .type = result_type});
+                        const mir::ExprId le_id = proc_scope_state.AddExpr(
+                            mir::Expr{
+                                .data =
+                                    mir::BinaryExpr{
+                                        .op = mir::BinaryOp::kLessEqual,
+                                        .lhs = *lhs_id,
+                                        .rhs = *hi},
+                                .type = result_type});
+                        return proc_scope_state.AddExpr(
+                            mir::Expr{
+                                .data =
+                                    mir::BinaryExpr{
+                                        .op = mir::BinaryOp::kLogicalAnd,
+                                        .lhs = ge_id,
+                                        .rhs = le_id},
+                                .type = result_type});
+                      },
+                  },
+                  item);
+              if (!pred_or) return std::unexpected(std::move(pred_or.error()));
+              predicates.push_back(*pred_or);
+            }
+
+            if (predicates.empty()) {
+              throw InternalError(
+                  "LowerExpr: hir::InsideExpr has empty item list");
+            }
+            if (predicates.size() == 1) {
+              return mir::Expr{proc_scope_state.GetExpr(predicates.front())};
+            }
+            mir::ExprId acc = predicates.front();
+            for (std::size_t i = 1; i + 1 < predicates.size(); ++i) {
+              acc = proc_scope_state.AddExpr(
+                  mir::Expr{
+                      .data =
+                          mir::BinaryExpr{
+                              .op = mir::BinaryOp::kLogicalOr,
+                              .lhs = acc,
+                              .rhs = predicates[i]},
+                      .type = result_type});
+            }
+            return mir::Expr{
+                .data =
+                    mir::BinaryExpr{
+                        .op = mir::BinaryOp::kLogicalOr,
+                        .lhs = acc,
+                        .rhs = predicates.back()},
+                .type = result_type};
+          },
       },
       expr.data);
 }
@@ -726,6 +823,12 @@ auto LowerExprImpl(
             return diag::Unsupported(
                 diag::DiagCode::kUnsupportedStructuralExpressionForm,
                 "calls are not allowed in constructor expressions",
+                diag::UnsupportedCategory::kFeature);
+          },
+          [](const hir::InsideExpr&) -> diag::Result<mir::Expr> {
+            return diag::Unsupported(
+                diag::DiagCode::kUnsupportedStructuralExpressionForm,
+                "inside operator is not allowed in constructor expressions",
                 diag::UnsupportedCategory::kFeature);
           },
       },

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -447,6 +447,302 @@ auto BuildNbaSubmitClosureExpr(
       .data = std::move(closure), .type = unit_state.Builtins().void_type};
 }
 
+auto LowerHirUnaryExprProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, const hir::UnaryExpr& u,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  auto operand_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(u.operand.value));
+  if (!operand_or) {
+    return std::unexpected(std::move(operand_or.error()));
+  }
+  const mir::ExprId operand_id =
+      proc_scope_state.AddExpr(*std::move(operand_or));
+  return mir::Expr{
+      .data = mir::UnaryExpr{.op = LowerUnaryOp(u.op), .operand = operand_id},
+      .type = result_type};
+}
+
+auto LowerHirBinaryExprProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, const hir::BinaryExpr& b,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  auto lhs_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(b.lhs.value));
+  if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+  const mir::ExprId lhs_id = proc_scope_state.AddExpr(*std::move(lhs_or));
+  auto rhs_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(b.rhs.value));
+  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+  const mir::ExprId rhs_id = proc_scope_state.AddExpr(*std::move(rhs_or));
+  return mir::Expr{
+      .data =
+          mir::BinaryExpr{
+              .op = LowerBinaryOp(b.op), .lhs = lhs_id, .rhs = rhs_id},
+      .type = result_type};
+}
+
+auto LowerHirConditionalExprProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, const hir::ConditionalExpr& c,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  auto cond_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(c.condition.value));
+  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+  const mir::ExprId cond_id = proc_scope_state.AddExpr(*std::move(cond_or));
+  auto then_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(c.then_value.value));
+  if (!then_or) return std::unexpected(std::move(then_or.error()));
+  const mir::ExprId then_id = proc_scope_state.AddExpr(*std::move(then_or));
+  auto else_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(c.else_value.value));
+  if (!else_or) return std::unexpected(std::move(else_or.error()));
+  const mir::ExprId else_id = proc_scope_state.AddExpr(*std::move(else_or));
+  return mir::Expr{
+      .data =
+          mir::ConditionalExpr{
+              .condition = cond_id,
+              .then_value = then_id,
+              .else_value = else_id},
+      .type = result_type};
+}
+
+auto LowerHirAssignExprProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, const hir::AssignExpr& a,
+    diag::SourceSpan span, mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  auto rhs_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(a.rhs.value));
+  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+  const mir::TypeId rhs_type = (*rhs_or).type;
+  const mir::ExprId rhs_id = proc_scope_state.AddExpr(*std::move(rhs_or));
+  auto lhs = LowerHirLvalueProc(scope_state, proc_state, a.lhs);
+
+  if (a.kind == hir::AssignKind::kBlocking) {
+    return mir::Expr{
+        .data = mir::AssignExpr{.target = lhs, .value = rhs_id},
+        .type = result_type};
+  }
+
+  if (!std::holds_alternative<mir::StructuralVarRef>(lhs)) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedAssignmentTarget,
+        "non-blocking assignment to procedural local is not supported yet",
+        diag::UnsupportedCategory::kFeature);
+  }
+
+  mir::Expr closure_expr =
+      BuildNbaSubmitClosureExpr(unit_state, std::move(lhs), rhs_id, rhs_type);
+  const mir::ExprId closure_id =
+      proc_scope_state.AddExpr(std::move(closure_expr));
+  return mir::Expr{
+      .data =
+          mir::RuntimeCallExpr{
+              .call = mir::RuntimeSubmitNbaCall{.closure = closure_id}},
+      .type = unit_state.Builtins().void_type};
+}
+
+auto LowerHirConversionExprProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, const hir::ConversionExpr& cv,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  auto operand_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(cv.operand.value));
+  if (!operand_or) {
+    return std::unexpected(std::move(operand_or.error()));
+  }
+  const mir::ExprId operand_id =
+      proc_scope_state.AddExpr(*std::move(operand_or));
+  return mir::Expr{
+      .data =
+          mir::ConversionExpr{
+              .operand = operand_id, .kind = LowerHirConversionKind(cv.kind)},
+      .type = result_type};
+}
+
+auto LowerHirCallExprProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, const hir::CallExpr& c,
+    diag::SourceSpan span, mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  return std::visit(
+      Overloaded{
+          [&](const hir::SystemSubroutineRef& sys) -> diag::Result<mir::Expr> {
+            return LowerSystemSubroutineCall(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, c, sys, span);
+          },
+          [&](const hir::StructuralSubroutineRef& usr)
+              -> diag::Result<mir::Expr> {
+            std::vector<mir::ExprId> args;
+            args.reserve(c.arguments.size());
+            for (const auto arg : c.arguments) {
+              auto arg_or = LowerExpr(
+                  unit_state, scope_state, proc_state, proc_scope_state,
+                  hir_process, hir_process.exprs.at(arg.value));
+              if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+              args.push_back(proc_scope_state.AddExpr(*std::move(arg_or)));
+            }
+            return mir::Expr{
+                .data =
+                    mir::CallExpr{
+                        .callee = LowerUserCallee(scope_state, usr),
+                        .arguments = std::move(args)},
+                .type = result_type};
+          },
+          [&](const hir::BuiltinMethodRef& bm) -> diag::Result<mir::Expr> {
+            return LowerBuiltinMethodCall(
+                unit_state, hir_process, bm, c.arguments, result_type, span);
+          },
+      },
+      c.callee);
+}
+
+// Builds the 1-bit MIR predicate ExprId for one inside-operator item, comparing
+// against the already-lowered LHS. Value items use `==`; range items use
+// `(>= lo) && (<= hi)`. The returned ExprId references a freshly added MIR
+// expression in `proc_scope_state`.
+auto BuildHirInsideItemPredicateProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, mir::ExprId lhs_id,
+    const hir::InsideItem& item, mir::TypeId result_type)
+    -> diag::Result<mir::ExprId> {
+  auto lower_id = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
+    auto lowered = LowerExpr(
+        unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+        hir_process.exprs.at(id.value));
+    if (!lowered) {
+      return std::unexpected(std::move(lowered.error()));
+    }
+    return proc_scope_state.AddExpr(*std::move(lowered));
+  };
+
+  return std::visit(
+      Overloaded{
+          [&](const hir::ExprId& val_id) -> diag::Result<mir::ExprId> {
+            auto v = lower_id(val_id);
+            if (!v) return std::unexpected(std::move(v.error()));
+            return proc_scope_state.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::BinaryExpr{
+                            .op = mir::BinaryOp::kEquality,
+                            .lhs = lhs_id,
+                            .rhs = *v},
+                    .type = result_type});
+          },
+          [&](const hir::InsideRangePair& r) -> diag::Result<mir::ExprId> {
+            auto lo = lower_id(r.lo);
+            if (!lo) return std::unexpected(std::move(lo.error()));
+            auto hi = lower_id(r.hi);
+            if (!hi) return std::unexpected(std::move(hi.error()));
+            const mir::ExprId ge_id = proc_scope_state.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::BinaryExpr{
+                            .op = mir::BinaryOp::kGreaterEqual,
+                            .lhs = lhs_id,
+                            .rhs = *lo},
+                    .type = result_type});
+            const mir::ExprId le_id = proc_scope_state.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::BinaryExpr{
+                            .op = mir::BinaryOp::kLessEqual,
+                            .lhs = lhs_id,
+                            .rhs = *hi},
+                    .type = result_type});
+            return proc_scope_state.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::BinaryExpr{
+                            .op = mir::BinaryOp::kLogicalAnd,
+                            .lhs = ge_id,
+                            .rhs = le_id},
+                    .type = result_type});
+          },
+      },
+      item);
+}
+
+auto LowerHirInsideExprProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, const hir::InsideExpr& in,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  auto lhs_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(in.lhs.value));
+  if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+  const mir::ExprId lhs_id = proc_scope_state.AddExpr(*std::move(lhs_or));
+
+  std::vector<mir::ExprId> predicates;
+  predicates.reserve(in.items.size());
+  for (const auto& item : in.items) {
+    auto pred_or = BuildHirInsideItemPredicateProc(
+        unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+        lhs_id, item, result_type);
+    if (!pred_or) return std::unexpected(std::move(pred_or.error()));
+    predicates.push_back(*pred_or);
+  }
+
+  if (predicates.empty()) {
+    throw InternalError(
+        "LowerHirInsideExprProc: hir::InsideExpr has empty item list");
+  }
+  if (predicates.size() == 1) {
+    return mir::Expr{proc_scope_state.GetExpr(predicates.front())};
+  }
+  mir::ExprId acc = predicates.front();
+  for (std::size_t i = 1; i + 1 < predicates.size(); ++i) {
+    acc = proc_scope_state.AddExpr(
+        mir::Expr{
+            .data =
+                mir::BinaryExpr{
+                    .op = mir::BinaryOp::kLogicalOr,
+                    .lhs = acc,
+                    .rhs = predicates[i]},
+            .type = result_type});
+  }
+  return mir::Expr{
+      .data =
+          mir::BinaryExpr{
+              .op = mir::BinaryOp::kLogicalOr,
+              .lhs = acc,
+              .rhs = predicates.back()},
+      .type = result_type};
+}
+
 }  // namespace
 
 auto LowerExpr(
@@ -464,260 +760,154 @@ auto LowerExpr(
                 unit_state, scope_state, proc_state, p.data, result_type);
           },
           [&](const hir::UnaryExpr& u) -> diag::Result<mir::Expr> {
-            auto operand_or = LowerExpr(
+            return LowerHirUnaryExprProc(
                 unit_state, scope_state, proc_state, proc_scope_state,
-                hir_process, hir_process.exprs.at(u.operand.value));
-            if (!operand_or) {
-              return std::unexpected(std::move(operand_or.error()));
-            }
-            const mir::ExprId operand_id =
-                proc_scope_state.AddExpr(*std::move(operand_or));
-            return mir::Expr{
-                .data =
-                    mir::UnaryExpr{
-                        .op = LowerUnaryOp(u.op), .operand = operand_id},
-                .type = result_type};
+                hir_process, u, result_type);
           },
           [&](const hir::BinaryExpr& b) -> diag::Result<mir::Expr> {
-            auto lhs_or = LowerExpr(
+            return LowerHirBinaryExprProc(
                 unit_state, scope_state, proc_state, proc_scope_state,
-                hir_process, hir_process.exprs.at(b.lhs.value));
-            if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-            const mir::ExprId lhs_id =
-                proc_scope_state.AddExpr(*std::move(lhs_or));
-            auto rhs_or = LowerExpr(
-                unit_state, scope_state, proc_state, proc_scope_state,
-                hir_process, hir_process.exprs.at(b.rhs.value));
-            if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-            const mir::ExprId rhs_id =
-                proc_scope_state.AddExpr(*std::move(rhs_or));
-            return mir::Expr{
-                .data =
-                    mir::BinaryExpr{
-                        .op = LowerBinaryOp(b.op),
-                        .lhs = lhs_id,
-                        .rhs = rhs_id},
-                .type = result_type};
+                hir_process, b, result_type);
           },
           [&](const hir::ConditionalExpr& c) -> diag::Result<mir::Expr> {
-            auto cond_or = LowerExpr(
+            return LowerHirConditionalExprProc(
                 unit_state, scope_state, proc_state, proc_scope_state,
-                hir_process, hir_process.exprs.at(c.condition.value));
-            if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-            const mir::ExprId cond_id =
-                proc_scope_state.AddExpr(*std::move(cond_or));
-            auto then_or = LowerExpr(
-                unit_state, scope_state, proc_state, proc_scope_state,
-                hir_process, hir_process.exprs.at(c.then_value.value));
-            if (!then_or) return std::unexpected(std::move(then_or.error()));
-            const mir::ExprId then_id =
-                proc_scope_state.AddExpr(*std::move(then_or));
-            auto else_or = LowerExpr(
-                unit_state, scope_state, proc_state, proc_scope_state,
-                hir_process, hir_process.exprs.at(c.else_value.value));
-            if (!else_or) return std::unexpected(std::move(else_or.error()));
-            const mir::ExprId else_id =
-                proc_scope_state.AddExpr(*std::move(else_or));
-            return mir::Expr{
-                .data =
-                    mir::ConditionalExpr{
-                        .condition = cond_id,
-                        .then_value = then_id,
-                        .else_value = else_id},
-                .type = result_type};
+                hir_process, c, result_type);
           },
           [&](const hir::AssignExpr& a) -> diag::Result<mir::Expr> {
-            auto rhs_or = LowerExpr(
+            return LowerHirAssignExprProc(
                 unit_state, scope_state, proc_state, proc_scope_state,
-                hir_process, hir_process.exprs.at(a.rhs.value));
-            if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-            const mir::TypeId rhs_type = (*rhs_or).type;
-            const mir::ExprId rhs_id =
-                proc_scope_state.AddExpr(*std::move(rhs_or));
-            auto lhs = LowerHirLvalueProc(scope_state, proc_state, a.lhs);
-
-            if (a.kind == hir::AssignKind::kBlocking) {
-              return mir::Expr{
-                  .data = mir::AssignExpr{.target = lhs, .value = rhs_id},
-                  .type = result_type};
-            }
-
-            if (!std::holds_alternative<mir::StructuralVarRef>(lhs)) {
-              return diag::Unsupported(
-                  expr.span, diag::DiagCode::kUnsupportedAssignmentTarget,
-                  "non-blocking assignment to procedural local is not "
-                  "supported yet",
-                  diag::UnsupportedCategory::kFeature);
-            }
-
-            mir::Expr closure_expr = BuildNbaSubmitClosureExpr(
-                unit_state, std::move(lhs), rhs_id, rhs_type);
-            const mir::ExprId closure_id =
-                proc_scope_state.AddExpr(std::move(closure_expr));
-            return mir::Expr{
-                .data =
-                    mir::RuntimeCallExpr{
-                        .call =
-                            mir::RuntimeSubmitNbaCall{.closure = closure_id}},
-                .type = unit_state.Builtins().void_type};
+                hir_process, a, expr.span, result_type);
           },
           [&](const hir::ConversionExpr& cv) -> diag::Result<mir::Expr> {
-            auto operand_or = LowerExpr(
+            return LowerHirConversionExprProc(
                 unit_state, scope_state, proc_state, proc_scope_state,
-                hir_process, hir_process.exprs.at(cv.operand.value));
-            if (!operand_or) {
-              return std::unexpected(std::move(operand_or.error()));
-            }
-            const mir::ExprId operand_id =
-                proc_scope_state.AddExpr(*std::move(operand_or));
-            return mir::Expr{
-                .data =
-                    mir::ConversionExpr{
-                        .operand = operand_id,
-                        .kind = LowerHirConversionKind(cv.kind)},
-                .type = result_type};
+                hir_process, cv, result_type);
           },
           [&](const hir::CallExpr& c) -> diag::Result<mir::Expr> {
-            return std::visit(
-                Overloaded{
-                    [&](const hir::SystemSubroutineRef& sys)
-                        -> diag::Result<mir::Expr> {
-                      return LowerSystemSubroutineCall(
-                          unit_state, scope_state, proc_state, proc_scope_state,
-                          hir_process, c, sys, expr.span);
-                    },
-                    [&](const hir::StructuralSubroutineRef& usr)
-                        -> diag::Result<mir::Expr> {
-                      std::vector<mir::ExprId> args;
-                      args.reserve(c.arguments.size());
-                      for (const auto arg : c.arguments) {
-                        auto arg_or = LowerExpr(
-                            unit_state, scope_state, proc_state,
-                            proc_scope_state, hir_process,
-                            hir_process.exprs.at(arg.value));
-                        if (!arg_or)
-                          return std::unexpected(std::move(arg_or.error()));
-                        args.push_back(
-                            proc_scope_state.AddExpr(*std::move(arg_or)));
-                      }
-                      return mir::Expr{
-                          .data =
-                              mir::CallExpr{
-                                  .callee = LowerUserCallee(scope_state, usr),
-                                  .arguments = std::move(args)},
-                          .type = result_type};
-                    },
-                    [&](const hir::BuiltinMethodRef& bm)
-                        -> diag::Result<mir::Expr> {
-                      return LowerBuiltinMethodCall(
-                          unit_state, hir_process, bm, c.arguments, result_type,
-                          expr.span);
-                    },
-                },
-                c.callee);
+            return LowerHirCallExprProc(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, c, expr.span, result_type);
           },
           [&](const hir::InsideExpr& in) -> diag::Result<mir::Expr> {
-            auto lower_id = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
-              auto lowered = LowerExpr(
-                  unit_state, scope_state, proc_state, proc_scope_state,
-                  hir_process, hir_process.exprs.at(id.value));
-              if (!lowered) {
-                return std::unexpected(std::move(lowered.error()));
-              }
-              return proc_scope_state.AddExpr(*std::move(lowered));
-            };
-
-            auto lhs_id = lower_id(in.lhs);
-            if (!lhs_id) return std::unexpected(std::move(lhs_id.error()));
-
-            // Build per-item 1-bit predicate expressions and OR them together.
-            // Value item: lhs == item. Range item: (lhs >= lo) && (lhs <= hi).
-            std::vector<mir::ExprId> predicates;
-            predicates.reserve(in.items.size());
-            for (const auto& item : in.items) {
-              auto pred_or = std::visit(
-                  Overloaded{
-                      [&](const hir::ExprId& val_id)
-                          -> diag::Result<mir::ExprId> {
-                        auto v = lower_id(val_id);
-                        if (!v) return std::unexpected(std::move(v.error()));
-                        return proc_scope_state.AddExpr(
-                            mir::Expr{
-                                .data =
-                                    mir::BinaryExpr{
-                                        .op = mir::BinaryOp::kEquality,
-                                        .lhs = *lhs_id,
-                                        .rhs = *v},
-                                .type = result_type});
-                      },
-                      [&](const hir::InsideRangePair& r)
-                          -> diag::Result<mir::ExprId> {
-                        auto lo = lower_id(r.lo);
-                        if (!lo) return std::unexpected(std::move(lo.error()));
-                        auto hi = lower_id(r.hi);
-                        if (!hi) return std::unexpected(std::move(hi.error()));
-                        const mir::ExprId ge_id = proc_scope_state.AddExpr(
-                            mir::Expr{
-                                .data =
-                                    mir::BinaryExpr{
-                                        .op = mir::BinaryOp::kGreaterEqual,
-                                        .lhs = *lhs_id,
-                                        .rhs = *lo},
-                                .type = result_type});
-                        const mir::ExprId le_id = proc_scope_state.AddExpr(
-                            mir::Expr{
-                                .data =
-                                    mir::BinaryExpr{
-                                        .op = mir::BinaryOp::kLessEqual,
-                                        .lhs = *lhs_id,
-                                        .rhs = *hi},
-                                .type = result_type});
-                        return proc_scope_state.AddExpr(
-                            mir::Expr{
-                                .data =
-                                    mir::BinaryExpr{
-                                        .op = mir::BinaryOp::kLogicalAnd,
-                                        .lhs = ge_id,
-                                        .rhs = le_id},
-                                .type = result_type});
-                      },
-                  },
-                  item);
-              if (!pred_or) return std::unexpected(std::move(pred_or.error()));
-              predicates.push_back(*pred_or);
-            }
-
-            if (predicates.empty()) {
-              throw InternalError(
-                  "LowerExpr: hir::InsideExpr has empty item list");
-            }
-            if (predicates.size() == 1) {
-              return mir::Expr{proc_scope_state.GetExpr(predicates.front())};
-            }
-            mir::ExprId acc = predicates.front();
-            for (std::size_t i = 1; i + 1 < predicates.size(); ++i) {
-              acc = proc_scope_state.AddExpr(
-                  mir::Expr{
-                      .data =
-                          mir::BinaryExpr{
-                              .op = mir::BinaryOp::kLogicalOr,
-                              .lhs = acc,
-                              .rhs = predicates[i]},
-                      .type = result_type});
-            }
-            return mir::Expr{
-                .data =
-                    mir::BinaryExpr{
-                        .op = mir::BinaryOp::kLogicalOr,
-                        .lhs = acc,
-                        .rhs = predicates.back()},
-                .type = result_type};
+            return LowerHirInsideExprProc(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, in, result_type);
           },
       },
       expr.data);
 }
 
 namespace {
+
+auto LowerExprImpl(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ConstructorLoweringState* ctor_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::StructuralScope& scope, const hir::Expr& expr,
+    LoopVarLoweringMode loop_var_mode) -> diag::Result<mir::Expr>;
+
+auto LowerHirUnaryExprStructural(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ConstructorLoweringState* ctor_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::StructuralScope& scope, const hir::UnaryExpr& u,
+    LoopVarLoweringMode loop_var_mode, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
+  auto operand_or = LowerExprImpl(
+      unit_state, scope_state, ctor_state, proc_scope_state, scope,
+      scope.GetExpr(u.operand), loop_var_mode);
+  if (!operand_or) {
+    return std::unexpected(std::move(operand_or.error()));
+  }
+  const mir::ExprId operand_id =
+      proc_scope_state.AddExpr(*std::move(operand_or));
+  return mir::Expr{
+      .data = mir::UnaryExpr{.op = LowerUnaryOp(u.op), .operand = operand_id},
+      .type = result_type};
+}
+
+auto LowerHirBinaryExprStructural(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ConstructorLoweringState* ctor_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::StructuralScope& scope, const hir::BinaryExpr& b,
+    LoopVarLoweringMode loop_var_mode, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
+  auto lhs_or = LowerExprImpl(
+      unit_state, scope_state, ctor_state, proc_scope_state, scope,
+      scope.GetExpr(b.lhs), loop_var_mode);
+  if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+  const mir::ExprId lhs_id = proc_scope_state.AddExpr(*std::move(lhs_or));
+  auto rhs_or = LowerExprImpl(
+      unit_state, scope_state, ctor_state, proc_scope_state, scope,
+      scope.GetExpr(b.rhs), loop_var_mode);
+  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+  const mir::ExprId rhs_id = proc_scope_state.AddExpr(*std::move(rhs_or));
+  return mir::Expr{
+      .data =
+          mir::BinaryExpr{
+              .op = LowerBinaryOp(b.op), .lhs = lhs_id, .rhs = rhs_id},
+      .type = result_type};
+}
+
+auto LowerHirConditionalExprStructural(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ConstructorLoweringState* ctor_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::StructuralScope& scope, const hir::ConditionalExpr& c,
+    LoopVarLoweringMode loop_var_mode, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
+  auto cond_or = LowerExprImpl(
+      unit_state, scope_state, ctor_state, proc_scope_state, scope,
+      scope.GetExpr(c.condition), loop_var_mode);
+  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+  const mir::ExprId cond_id = proc_scope_state.AddExpr(*std::move(cond_or));
+  auto then_or = LowerExprImpl(
+      unit_state, scope_state, ctor_state, proc_scope_state, scope,
+      scope.GetExpr(c.then_value), loop_var_mode);
+  if (!then_or) return std::unexpected(std::move(then_or.error()));
+  const mir::ExprId then_id = proc_scope_state.AddExpr(*std::move(then_or));
+  auto else_or = LowerExprImpl(
+      unit_state, scope_state, ctor_state, proc_scope_state, scope,
+      scope.GetExpr(c.else_value), loop_var_mode);
+  if (!else_or) return std::unexpected(std::move(else_or.error()));
+  const mir::ExprId else_id = proc_scope_state.AddExpr(*std::move(else_or));
+  return mir::Expr{
+      .data =
+          mir::ConditionalExpr{
+              .condition = cond_id,
+              .then_value = then_id,
+              .else_value = else_id},
+      .type = result_type};
+}
+
+auto LowerHirConversionExprStructural(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ConstructorLoweringState* ctor_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::StructuralScope& scope, const hir::ConversionExpr& cv,
+    LoopVarLoweringMode loop_var_mode, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
+  auto operand_or = LowerExprImpl(
+      unit_state, scope_state, ctor_state, proc_scope_state, scope,
+      scope.GetExpr(cv.operand), loop_var_mode);
+  if (!operand_or) {
+    return std::unexpected(std::move(operand_or.error()));
+  }
+  const mir::ExprId operand_id =
+      proc_scope_state.AddExpr(*std::move(operand_or));
+  return mir::Expr{
+      .data =
+          mir::ConversionExpr{
+              .operand = operand_id, .kind = LowerHirConversionKind(cv.kind)},
+      .type = result_type};
+}
 
 auto LowerExprImpl(
     const UnitLoweringState& unit_state,
@@ -735,89 +925,30 @@ auto LowerExprImpl(
                 loop_var_mode);
           },
           [&](const hir::UnaryExpr& u) -> diag::Result<mir::Expr> {
-            auto operand_or = LowerExprImpl(
-                unit_state, scope_state, ctor_state, proc_scope_state, scope,
-                scope.GetExpr(u.operand), loop_var_mode);
-            if (!operand_or) {
-              return std::unexpected(std::move(operand_or.error()));
-            }
-            const mir::ExprId operand_id =
-                proc_scope_state.AddExpr(*std::move(operand_or));
-            return mir::Expr{
-                .data =
-                    mir::UnaryExpr{
-                        .op = LowerUnaryOp(u.op), .operand = operand_id},
-                .type = result_type};
+            return LowerHirUnaryExprStructural(
+                unit_state, scope_state, ctor_state, proc_scope_state, scope, u,
+                loop_var_mode, result_type);
           },
           [&](const hir::BinaryExpr& b) -> diag::Result<mir::Expr> {
-            auto lhs_or = LowerExprImpl(
-                unit_state, scope_state, ctor_state, proc_scope_state, scope,
-                scope.GetExpr(b.lhs), loop_var_mode);
-            if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-            const mir::ExprId lhs_id =
-                proc_scope_state.AddExpr(*std::move(lhs_or));
-            auto rhs_or = LowerExprImpl(
-                unit_state, scope_state, ctor_state, proc_scope_state, scope,
-                scope.GetExpr(b.rhs), loop_var_mode);
-            if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-            const mir::ExprId rhs_id =
-                proc_scope_state.AddExpr(*std::move(rhs_or));
-            return mir::Expr{
-                .data =
-                    mir::BinaryExpr{
-                        .op = LowerBinaryOp(b.op),
-                        .lhs = lhs_id,
-                        .rhs = rhs_id},
-                .type = result_type};
+            return LowerHirBinaryExprStructural(
+                unit_state, scope_state, ctor_state, proc_scope_state, scope, b,
+                loop_var_mode, result_type);
           },
           [&](const hir::ConditionalExpr& c) -> diag::Result<mir::Expr> {
-            auto cond_or = LowerExprImpl(
-                unit_state, scope_state, ctor_state, proc_scope_state, scope,
-                scope.GetExpr(c.condition), loop_var_mode);
-            if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-            const mir::ExprId cond_id =
-                proc_scope_state.AddExpr(*std::move(cond_or));
-            auto then_or = LowerExprImpl(
-                unit_state, scope_state, ctor_state, proc_scope_state, scope,
-                scope.GetExpr(c.then_value), loop_var_mode);
-            if (!then_or) return std::unexpected(std::move(then_or.error()));
-            const mir::ExprId then_id =
-                proc_scope_state.AddExpr(*std::move(then_or));
-            auto else_or = LowerExprImpl(
-                unit_state, scope_state, ctor_state, proc_scope_state, scope,
-                scope.GetExpr(c.else_value), loop_var_mode);
-            if (!else_or) return std::unexpected(std::move(else_or.error()));
-            const mir::ExprId else_id =
-                proc_scope_state.AddExpr(*std::move(else_or));
-            return mir::Expr{
-                .data =
-                    mir::ConditionalExpr{
-                        .condition = cond_id,
-                        .then_value = then_id,
-                        .else_value = else_id},
-                .type = result_type};
+            return LowerHirConditionalExprStructural(
+                unit_state, scope_state, ctor_state, proc_scope_state, scope, c,
+                loop_var_mode, result_type);
           },
-          [&](const hir::AssignExpr&) -> diag::Result<mir::Expr> {
+          [](const hir::AssignExpr&) -> diag::Result<mir::Expr> {
             throw InternalError(
                 "LowerExprImpl (structural): HIR AssignExpr does not appear "
                 "in constructor-side expressions; structural code has no "
                 "general assignment");
           },
           [&](const hir::ConversionExpr& cv) -> diag::Result<mir::Expr> {
-            auto operand_or = LowerExprImpl(
+            return LowerHirConversionExprStructural(
                 unit_state, scope_state, ctor_state, proc_scope_state, scope,
-                scope.GetExpr(cv.operand), loop_var_mode);
-            if (!operand_or) {
-              return std::unexpected(std::move(operand_or.error()));
-            }
-            const mir::ExprId operand_id =
-                proc_scope_state.AddExpr(*std::move(operand_or));
-            return mir::Expr{
-                .data =
-                    mir::ConversionExpr{
-                        .operand = operand_id,
-                        .kind = LowerHirConversionKind(cv.kind)},
-                .type = result_type};
+                cv, loop_var_mode, result_type);
           },
           [](const hir::CallExpr&) -> diag::Result<mir::Expr> {
             return diag::Unsupported(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -640,6 +640,40 @@ class MirDumper {
     procedural_scope_stack_.pop_back();
   }
 
+  void DumpProceduralVarDeclStmt(
+      const ProceduralScope& enclosing, StmtId id,
+      const ProceduralVarDeclStmt& s) {
+    const auto& owner = ResolveProceduralScopeAtHops(s.target.hops.value);
+    const auto& var = owner.vars.at(s.target.var.value);
+    Line(
+        std::format(
+            "Stmt[{}] ProceduralVarDeclStmt "
+            "target=ProceduralVarRef[hops={}, var={}] \"{}\"",
+            id.value, s.target.hops.value, s.target.var.value, var.name));
+    if (s.init.has_value()) {
+      Indent();
+      Line(
+          std::format(
+              "init: Expr[{}] {}", s.init->value,
+              FormatExpr(enclosing, *s.init)));
+      Dedent();
+    }
+  }
+
+  void DumpConstructOwnedObjectStmt(
+      StmtId id, const ConstructOwnedObjectStmt& s) {
+    std::string args_str;
+    for (std::size_t i = 0; i < s.args.size(); ++i) {
+      if (i != 0) args_str += ", ";
+      args_str += std::format("Expr[{}]", s.args[i].value);
+    }
+    Line(
+        std::format(
+            "Stmt[{}] ConstructOwnedObjectStmt target=StructuralVar[{}] "
+            "scope=StructuralScope[{}] args=[{}]",
+            id.value, s.target.value, s.scope_id.value, args_str));
+  }
+
   void DumpStmt(const ProceduralScope& enclosing, StmtId id) {
     const auto& stmt = enclosing.stmts.at(id.value);
     if (stmt.label.has_value()) {
@@ -651,39 +685,13 @@ class MirDumper {
               Line(std::format("Stmt[{}] EmptyStmt", id.value));
             },
             [&](const ProceduralVarDeclStmt& s) {
-              const auto& owner =
-                  ResolveProceduralScopeAtHops(s.target.hops.value);
-              const auto& var = owner.vars.at(s.target.var.value);
-              Line(
-                  std::format(
-                      "Stmt[{}] ProceduralVarDeclStmt "
-                      "target=ProceduralVarRef[hops={}, var={}] \"{}\"",
-                      id.value, s.target.hops.value, s.target.var.value,
-                      var.name));
-              if (s.init.has_value()) {
-                Indent();
-                Line(
-                    std::format(
-                        "init: Expr[{}] {}", s.init->value,
-                        FormatExpr(enclosing, *s.init)));
-                Dedent();
-              }
+              DumpProceduralVarDeclStmt(enclosing, id, s);
             },
             [&](const ExprStmt& s) { DumpExprStmt(s, enclosing, id); },
             [&](const BlockStmt& s) { DumpBlockStmt(stmt, s, id); },
             [&](const IfStmt& s) { DumpIfStmt(stmt, s, enclosing, id); },
             [&](const ConstructOwnedObjectStmt& s) {
-              std::string args_str;
-              for (std::size_t i = 0; i < s.args.size(); ++i) {
-                if (i != 0) args_str += ", ";
-                args_str += std::format("Expr[{}]", s.args[i].value);
-              }
-              Line(
-                  std::format(
-                      "Stmt[{}] ConstructOwnedObjectStmt "
-                      "target=StructuralVar[{}] "
-                      "scope=StructuralScope[{}] args=[{}]",
-                      id.value, s.target.value, s.scope_id.value, args_str));
+              DumpConstructOwnedObjectStmt(id, s);
             },
             [&](const ForStmt& s) { DumpForStmt(stmt, s, enclosing, id); },
             [&](const TimedStmt& t) { DumpTimedStmt(t, enclosing, id); },

--- a/tests/cases/cpp/operator_inside_as_expression/case.yaml
+++ b/tests/cases/cpp/operator_inside_as_expression/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.operator_inside_as_expression
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sum_one_match: 1
+    sum_both_match: 2
+    sum_no_match: 0
+    ternary_branch_taken: 100
+    ternary_branch_not_taken: 200

--- a/tests/cases/cpp/operator_inside_as_expression/main.sv
+++ b/tests/cases/cpp/operator_inside_as_expression/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  int sum_one_match;
+  int sum_both_match;
+  int sum_no_match;
+  int ternary_branch_taken;
+  int ternary_branch_not_taken;
+  initial begin
+    int v;
+    v = 3;
+    sum_one_match = (v inside {1, 2, 3}) + (v inside {4, 5, 6});
+    v = 5;
+    sum_both_match = (v inside {[1:10]}) + (v inside {[3:7]});
+    v = 50;
+    sum_no_match = (v inside {1, 2, 3}) + (v inside {4, 5, 6});
+    v = 5;
+    ternary_branch_taken = (v inside {[1:10]}) ? 100 : 200;
+    v = 50;
+    ternary_branch_not_taken = (v inside {[1:10]}) ? 100 : 200;
+  end
+endmodule

--- a/tests/cases/cpp/operator_inside_basic/case.yaml
+++ b/tests/cases/cpp/operator_inside_basic/case.yaml
@@ -1,0 +1,18 @@
+id: cpp.operator_inside_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    match_first: 1
+    match_middle: 1
+    match_last: 1
+    no_match_below: 0
+    no_match_between: 0
+    no_match_above: 0
+    single_item_match: 1
+    single_item_no_match: 0

--- a/tests/cases/cpp/operator_inside_basic/main.sv
+++ b/tests/cases/cpp/operator_inside_basic/main.sv
@@ -1,0 +1,21 @@
+module Top;
+  int match_first;
+  int match_middle;
+  int match_last;
+  int no_match_below;
+  int no_match_between;
+  int no_match_above;
+  int single_item_match;
+  int single_item_no_match;
+  initial begin
+    int v;
+    v = 1; match_first = (v inside {1, 5, 9}) ? 1 : 0;
+    v = 5; match_middle = (v inside {1, 5, 9}) ? 1 : 0;
+    v = 9; match_last = (v inside {1, 5, 9}) ? 1 : 0;
+    v = 0; no_match_below = (v inside {1, 5, 9}) ? 1 : 0;
+    v = 3; no_match_between = (v inside {1, 5, 9}) ? 1 : 0;
+    v = 12; no_match_above = (v inside {1, 5, 9}) ? 1 : 0;
+    v = 42; single_item_match = (v inside {42}) ? 1 : 0;
+    v = 42; single_item_no_match = (v inside {43}) ? 1 : 0;
+  end
+endmodule

--- a/tests/cases/cpp/operator_inside_range/case.yaml
+++ b/tests/cases/cpp/operator_inside_range/case.yaml
@@ -1,0 +1,20 @@
+id: cpp.operator_inside_range
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    in_range: 1
+    at_lo: 1
+    at_hi: 1
+    just_below_lo: 0
+    just_above_hi: 0
+    range_no_match: 0
+    mixed_value_hits: 1
+    mixed_range_hits: 1
+    mixed_no_match: 0
+    multi_range_hits_second: 1

--- a/tests/cases/cpp/operator_inside_range/main.sv
+++ b/tests/cases/cpp/operator_inside_range/main.sv
@@ -1,0 +1,25 @@
+module Top;
+  int in_range;
+  int at_lo;
+  int at_hi;
+  int just_below_lo;
+  int just_above_hi;
+  int range_no_match;
+  int mixed_value_hits;
+  int mixed_range_hits;
+  int mixed_no_match;
+  int multi_range_hits_second;
+  initial begin
+    int v;
+    v = 5;  in_range = (v inside {[1:10]}) ? 1 : 0;
+    v = 1;  at_lo = (v inside {[1:10]}) ? 1 : 0;
+    v = 10; at_hi = (v inside {[1:10]}) ? 1 : 0;
+    v = 0;  just_below_lo = (v inside {[1:10]}) ? 1 : 0;
+    v = 11; just_above_hi = (v inside {[1:10]}) ? 1 : 0;
+    v = 15; range_no_match = (v inside {[1:10]}) ? 1 : 0;
+    v = 1;  mixed_value_hits = (v inside {1, [5:10], 20}) ? 1 : 0;
+    v = 7;  mixed_range_hits = (v inside {1, [5:10], 20}) ? 1 : 0;
+    v = 30; mixed_no_match = (v inside {1, [5:10], 20}) ? 1 : 0;
+    v = 25; multi_range_hits_second = (v inside {[1:5], [20:30]}) ? 1 : 0;
+  end
+endmodule

--- a/tests/cases/cpp/operator_inside_signed/case.yaml
+++ b/tests/cases/cpp/operator_inside_signed/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.operator_inside_signed
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    neg_value_match: 1
+    neg_range_match: 1
+    neg_range_at_lo: 1
+    neg_range_at_hi: 1
+    pos_outside_neg_range: 0

--- a/tests/cases/cpp/operator_inside_signed/main.sv
+++ b/tests/cases/cpp/operator_inside_signed/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  int neg_value_match;
+  int neg_range_match;
+  int neg_range_at_lo;
+  int neg_range_at_hi;
+  int pos_outside_neg_range;
+  initial begin
+    int v;
+    v = -5;  neg_value_match = (v inside {-1, -5, -9}) ? 1 : 0;
+    v = -5;  neg_range_match = (v inside {[-10:-1]}) ? 1 : 0;
+    v = -10; neg_range_at_lo = (v inside {[-10:-1]}) ? 1 : 0;
+    v = -1;  neg_range_at_hi = (v inside {[-10:-1]}) ? 1 : 0;
+    v = 1;   pos_outside_neg_range = (v inside {[-10:-1]}) ? 1 : 0;
+  end
+endmodule

--- a/tests/cases/cpp/operator_inside_variable_item/case.yaml
+++ b/tests/cases/cpp/operator_inside_variable_item/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.operator_inside_variable_item
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    var_item_match: 1
+    var_item_no_match: 0
+    var_range_match: 1
+    var_range_no_match: 0

--- a/tests/cases/cpp/operator_inside_variable_item/main.sv
+++ b/tests/cases/cpp/operator_inside_variable_item/main.sv
@@ -1,0 +1,21 @@
+module Top;
+  int var_item_match;
+  int var_item_no_match;
+  int var_range_match;
+  int var_range_no_match;
+  initial begin
+    int v;
+    int a;
+    int b;
+    int lo;
+    int hi;
+    a = 5; b = 7; v = 5;
+    var_item_match = (v inside {a, b}) ? 1 : 0;
+    v = 6;
+    var_item_no_match = (v inside {a, b}) ? 1 : 0;
+    lo = 10; hi = 20; v = 15;
+    var_range_match = (v inside {[lo:hi]}) ? 1 : 0;
+    v = 5;
+    var_range_no_match = (v inside {[lo:hi]}) ? 1 : 0;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Lands the `inside` set-membership operator end-to-end and then refactors every variant-visitor dispatcher in the lowering and cpp emit layers (plus the HIR/MIR dumps) so that each kind's handling is a named function called from a thin dispatcher.

## Design

### Inside operator (W1)

`hir::InsideExpr` carries the source-level set-membership shape with an item list whose entries are either a singular `ExprId` or an `InsideRangePair{lo, hi}`. HIR-to-MIR desugars to a logical-OR chain over the lowered left operand: value items lower to `lhs == item`; range items lower to `(lhs >= lo) && (lhs <= hi)`. MIR gains no new variant, cpp emit gains no new path, and the runtime gains no new helper -- the OR-chain rides on the existing `PackedArray` binary operators. The LRM 11.4.13 four-state corner ("no match but some compare X yields `1'bx`") is honored automatically because `PackedArray::LogicalOr` already implements the LRM 11.4.7 truth table. The left operand is lowered once to a MIR `ExprId` and referenced by each comparison; the archive test surface uses only var-refs as the left operand, so the repeated render is idempotent.

### Per-kind dispatcher refactor

Every visitor that previously inlined per-variant logic in std::visit lambdas (or in switch-case blocks) is now a thin dispatcher that calls a named function per kind. Applies to `LowerExpr` and `LowerExprImpl` in HIR-to-MIR, `LowerProcExpr`/`LowerStructuralExpr` and `LowerStatement` in AST-to-HIR, `RenderExpr` and `RenderStmt` in cpp emit, `DumpStmt`/`DumpGenerate`/the `InsideExpr` formatter arm in HIR dump, and the two remaining inline arms in MIR DumpStmt. Trivial arms (single-line, no logic) stay inline; anything with real per-kind logic is extracted.

In ast-to-hir expression lowering each kind handler now does the explicit two-step `LowerProcExpr` (or `LowerStructuralExpr`) followed by `proc_state.AddExpr` / `scope_state.AddExpr`, matching the architecture policy that semantic lowering returns data and storage helpers only place already-lowered objects.

## Testing

New `tests/cases/cpp/operator_inside_{basic,range,signed,variable_item,as_expression}` covers value items, range items including boundaries, signed values and negative ranges, runtime variables as both items and range bounds, and `inside` in arithmetic / ternary position. Full `bazel test //... --test_output=errors` passes.