### PR TITLE
Add any-change event control via Var<T> wrapper

### DIFF
--- a/docs/progress/integral.md
+++ b/docs/progress/integral.md
@@ -84,6 +84,21 @@ Remove `RenderExprAsNative` / `RenderExprAsPackedTopLevel` split. Single `Render
 - [x] J16 -- `ConversionExpr` collapses to "construct a destination `PackedArray` from a source
       `PackedArray`" -- one case, handled by `PackedArray` itself.
 
+### Cut 4 -- Equality family completion
+
+`==` (logical equality) is 4-state-propagating and returns a `PackedArray` that can be X. LRM gives
+two deterministic-bool equality forms for the cases `==` cannot answer: case equality (`===`) and
+wildcard equality (`==?`). Both were plumbed through HIR / MIR but rejected at cpp emit.
+
+- [x] J17 -- `PackedArray::IsCaseEqual` (LRM 11.4.5 `===`): bit-pattern compare across value and
+      unknown planes, returns deterministic `bool`. Wire `kCaseEquality` and `kCaseInequality` arms
+      in backend. Also consumed by `Var<T>` for event-control change detection (LRM 9.4.2 says
+      `@(x)` fires when the value "is not equal to its previous value" under bit-pattern equality;
+      that is `===` semantics).
+- [ ] J18 -- `PackedArray::WildcardEquals` (LRM 11.4.6 `==?` / `!=?`): bit-by-bit compare with the
+      RHS X/Z bits treated as don't-care; returns deterministic `bool`. Wire `kWildcardEquality` and
+      `kWildcardInequality` arms.
+
 ## Cross-references
 
 - Decision and findings: `../decisions/integral-representation.md`
@@ -100,5 +115,7 @@ Remove `RenderExprAsNative` / `RenderExprAsPackedTopLevel` split. Single `Render
 ## Remaining operator gap
 
 `++` / `--`: tracked as `operators.md` W12 (new HIR / MIR shape, statement and expression forms, LRM
-evaluate-target-once semantics). Every other binary / unary operator family on integral operands --
-including 4-state X / Z propagation -- lives here and is complete.
+evaluate-target-once semantics).
+
+`==?` / `!=?` wildcard equality: deterministic-bool form with RHS X/Z as don't-care (LRM 11.4.6).
+Plumbed through HIR / MIR; cpp emit rejects. Tracked as J18 in Cut 4 above.

--- a/include/lyra/backend/cpp/render_expr.hpp
+++ b/include/lyra/backend/cpp/render_expr.hpp
@@ -14,6 +14,12 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
 auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
     -> diag::Result<std::string>;
 
+// Bare field name (no `.Get()` wrap) for callsites that need the Var place
+// itself rather than its value, e.g. `co_await WaitChange(clk)`.
+auto RenderStructuralVarName(
+    const RenderContext& ctx, const mir::StructuralVarRef& ref)
+    -> diag::Result<std::string>;
+
 // Renders `expr` and, when its MIR type is a packed array, appends
 // `.IsTruthy()`. Used by every statement that consumes an expression as a C++
 // `bool` (`if`, `while`, `do`, `for` condition, etc.).

--- a/include/lyra/backend/cpp/render_type.hpp
+++ b/include/lyra/backend/cpp/render_type.hpp
@@ -23,4 +23,9 @@ namespace lyra::backend::cpp {
 [[nodiscard]] auto RenderPackedArrayCtorArgs(const mir::PackedArrayType& pa)
     -> std::string;
 
+// True iff a structural field of this type is emitted as `Var<T>` (and writes
+// go through `lyra::runtime::WriteVar`). Today: only integral types via
+// `PackedArray`. The set grows as more SV value types gain `IsCaseEqual`.
+[[nodiscard]] auto IsObservableScalarType(const mir::Type& ty) -> bool;
+
 }  // namespace lyra::backend::cpp

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -31,6 +31,8 @@ enum class DiagCode : std::uint32_t {
   kUnsupportedBinaryOperator,
   kUnsupportedTimingControlKind,
   kUnsupportedDelayExpressionForm,
+  kUnsupportedEventEdge,
+  kUnsupportedEventTriggerForm,
 
   kDelayValueOutOfRange,
   kFormatStringTrailingPercent,

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -110,7 +110,18 @@ struct DelayControl {
   ExprId duration;
 };
 
-struct EventControl {};
+enum class EventEdge : std::uint8_t {
+  kAnyChange,
+};
+
+struct EventTrigger {
+  ExprId signal;
+  EventEdge edge;
+};
+
+struct EventControl {
+  std::vector<EventTrigger> triggers;
+};
 
 using TimingControl = std::variant<DelayControl, EventControl>;
 

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -94,7 +94,20 @@ struct DelayControl {
   SimDuration duration;
 };
 
-using TimingControl = std::variant<DelayControl>;
+enum class EventEdge : std::uint8_t {
+  kAnyChange,
+};
+
+struct EventTrigger {
+  ExprId signal;
+  EventEdge edge;
+};
+
+struct EventControl {
+  std::vector<EventTrigger> triggers;
+};
+
+using TimingControl = std::variant<DelayControl, EventControl>;
 
 struct TimedStmt {
   TimingControl timing;

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -19,6 +19,7 @@
 namespace lyra::runtime {
 
 class Module;
+class Observable;
 class RuntimeEvent;
 class RuntimeProcess;
 
@@ -67,6 +68,8 @@ class Engine {
 
   void SubmitNba(std::function<void()> closure);
 
+  void TriggerValueChange(Observable& observable);
+
  private:
   struct PostponedWorkItem {};
 
@@ -111,6 +114,8 @@ class Engine {
   void ScheduleWait(RuntimeProcess& process, WaitRequest wait);
   void ScheduleDelayWait(RuntimeProcess& process, DelayWait wait);
   static void ScheduleEventWait(RuntimeProcess& process, EventWait wait);
+  static void ScheduleValueChangeWait(
+      RuntimeProcess& process, ValueChangeWait wait);
 
   void ScheduleActive(RuntimeProcess& process);
   void ScheduleInactive(RuntimeProcess& process);

--- a/include/lyra/runtime/runtime_services.hpp
+++ b/include/lyra/runtime/runtime_services.hpp
@@ -9,6 +9,7 @@ namespace lyra::runtime {
 class StreamDispatcher;
 class DiagnosticDispatcher;
 class Engine;
+class Observable;
 
 class RuntimeServices {
  public:
@@ -33,6 +34,8 @@ class RuntimeServices {
   }
 
   void SubmitNba(std::function<void()> closure);
+
+  void TriggerValueChange(Observable& observable);
 
  private:
   StreamDispatcher* stream_ = nullptr;

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <concepts>
+#include <coroutine>
+#include <utility>
+#include <vector>
+
+#include "lyra/runtime/process.hpp"
+#include "lyra/runtime/runtime_services.hpp"
+#include "lyra/runtime/wait_request.hpp"
+
+namespace lyra::runtime {
+
+class RuntimeProcess;
+
+class Observable {
+ public:
+  Observable() = default;
+  Observable(const Observable&) = delete;
+  auto operator=(const Observable&) -> Observable& = delete;
+  Observable(Observable&&) = delete;
+  auto operator=(Observable&&) -> Observable& = delete;
+  ~Observable() = default;
+
+  void Subscribe(RuntimeProcess& p) {
+    waiters_.push_back(&p);
+  }
+
+  [[nodiscard]] auto TakeWaiters() -> std::vector<RuntimeProcess*> {
+    return std::exchange(waiters_, {});
+  }
+
+ private:
+  std::vector<RuntimeProcess*> waiters_;
+};
+
+template <typename T>
+concept CaseEqualComparable = requires(const T& a, const T& b) {
+  { a.IsCaseEqual(b) } -> std::same_as<bool>;
+};
+
+template <CaseEqualComparable T>
+class Var : public Observable {
+ public:
+  Var() = default;
+
+  template <typename... Args>
+  explicit Var(Args&&... args) : value_(std::forward<Args>(args)...) {
+  }
+
+  Var(const Var&) = delete;
+  auto operator=(const Var&) -> Var& = delete;
+  Var(Var&&) = delete;
+  auto operator=(Var&&) -> Var& = delete;
+  ~Var() = default;
+
+  // Returns true iff `v` is bit-pattern-different (LRM 9.4.2 `===` semantics
+  // for @() detection, not 4-state `==`); caller dispatches on the result.
+  auto AssignIfChanged(const T& v) -> bool {
+    if (value_.IsCaseEqual(v)) return false;
+    value_ = v;
+    return true;
+  }
+
+  auto AssignIfChanged(T&& v) -> bool {
+    if (value_.IsCaseEqual(v)) return false;
+    value_ = std::move(v);
+    return true;
+  }
+
+  // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+  operator const T&() const noexcept {
+    return value_;
+  }
+
+  [[nodiscard]] auto Get() const noexcept -> const T& {
+    return value_;
+  }
+
+ private:
+  T value_{};
+};
+
+class ValueChangeAwaitable {
+ public:
+  explicit ValueChangeAwaitable(Observable& observable)
+      : observable_(&observable) {
+  }
+
+  // NOLINTNEXTLINE(readability-identifier-naming,readability-convert-member-functions-to-static)
+  [[nodiscard]] auto await_ready() const noexcept -> bool {
+    return false;
+  }
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  void await_suspend(
+      std::coroutine_handle<ProcessCoroutine::promise_type> handle) noexcept {
+    handle.promise().SetWaitRequest(ValueChangeWait{.observable = observable_});
+  }
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  void await_resume() const noexcept {
+  }
+
+ private:
+  Observable* observable_;
+};
+
+template <typename T>
+auto WaitChange(Var<T>& var) -> ValueChangeAwaitable {
+  return ValueChangeAwaitable{var};
+}
+
+template <typename T>
+void WriteVar(RuntimeServices& services, Var<T>& var, T new_val) {
+  if (var.AssignIfChanged(std::move(new_val))) {
+    services.TriggerValueChange(var);
+  }
+}
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/wait_request.hpp
+++ b/include/lyra/runtime/wait_request.hpp
@@ -10,6 +10,7 @@
 namespace lyra::runtime {
 
 class RuntimeEvent;
+class Observable;
 
 struct DelayWait {
   SimDuration duration;
@@ -19,11 +20,16 @@ struct EventWait {
   RuntimeEvent* event = nullptr;
 };
 
+struct ValueChangeWait {
+  Observable* observable = nullptr;
+};
+
 struct FinishWait {
   int level;
 };
 
-using WaitRequest = std::variant<DelayWait, EventWait, FinishWait>;
+using WaitRequest =
+    std::variant<DelayWait, EventWait, ValueChangeWait, FinishWait>;
 
 class ProcessRunResult {
  public:

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -60,6 +60,13 @@ class PackedArray {
   [[nodiscard]] auto IsSigned() const -> bool;
   [[nodiscard]] auto IsFourState() const -> bool;
 
+  // LRM 11.4.5 `===` predicate form (host bool). Operator form: `CaseEqual`.
+  [[nodiscard]] auto IsCaseEqual(const PackedArray& other) const -> bool;
+
+  // LRM 11.4.5 `===` operator form (1-bit PackedArray); `==` returns 4-state
+  // and propagates X, this returns deterministic 0 or 1.
+  [[nodiscard]] auto CaseEqual(const PackedArray& other) const -> PackedArray;
+
   // Word-level access for `RuntimeValueView` construction and intra-runtime
   // interop. The spans alias the PackedArray's storage and stay valid for
   // the object's lifetime.

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -27,8 +27,14 @@ auto RenderField(
     -> diag::Result<std::string> {
   auto type_or = RenderTypeAsCpp(unit, owner_scope, var.type);
   if (!type_or) return std::unexpected(std::move(type_or.error()));
-  std::string init;
   const auto& ty = unit.GetType(var.type);
+  if (IsObservableScalarType(ty)) {
+    std::string init = "{" + *type_or + "{" +
+                       RenderPackedArrayCtorArgs(ty.AsPackedArray()) + "}}";
+    return Indent(indent) + "lyra::runtime::Var<" + *type_or + "> " + var.name +
+           init + ";\n";
+  }
+  std::string init;
   if (ty.IsPackedArray()) {
     init = "{" + RenderPackedArrayCtorArgs(ty.AsPackedArray()) + "}";
   }
@@ -224,14 +230,16 @@ auto RenderScopeAsClass(
     out += "\n";
   }
 
-  out += Indent(indent + 1) + "lyra::runtime::RuntimeServices* services_{};\n";
-  out += "\n";
-
   auto ctor_or = RenderConstructor(this_anchor, s, indent + 1);
   if (!ctor_or) return std::unexpected(std::move(ctor_or.error()));
   out += *ctor_or;
   out += "\n";
   out += RenderBind(unit, s, indent + 1, is_top_level);
+
+  out += "\n";
+  out += Indent(indent) + " private:\n";
+  out += Indent(indent + 1) + "lyra::runtime::RuntimeServices* services_{};\n";
+  out += "\n";
 
   for (std::size_t i = 0; i < s.processes.size(); ++i) {
     out += "\n";
@@ -265,6 +273,7 @@ auto RenderScopeHeaderFile(
   out += "#include \"lyra/runtime/process_kind.hpp\"\n";
   out += "#include \"lyra/runtime/runtime_scope_kind.hpp\"\n";
   out += "#include \"lyra/runtime/runtime_services.hpp\"\n";
+  out += "#include \"lyra/runtime/var.hpp\"\n";
   out += "#include \"lyra/value/format.hpp\"\n";
   out += "#include \"lyra/value/packed.hpp\"\n";
   out += "#include \"lyra/value/packed_array.hpp\"\n";

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -12,6 +12,7 @@
 #include "lyra/backend/cpp/render_context.hpp"
 #include "lyra/backend/cpp/render_print.hpp"
 #include "lyra/backend/cpp/render_stmt.hpp"
+#include "lyra/backend/cpp/render_type.hpp"
 #include "lyra/backend/cpp/string_literal.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
@@ -95,12 +96,15 @@ auto RenderBinaryOp(
     case mir::BinaryOp::kLogicalEquivalence:
       return "(" + lhs + ").LogicalEquivalence(" + rhs + ")";
     case mir::BinaryOp::kCaseEquality:
+      return "(" + lhs + ").CaseEqual(" + rhs + ")";
     case mir::BinaryOp::kCaseInequality:
+      return "(" + lhs + ").CaseEqual(" + rhs + ").LogicalNot()";
     case mir::BinaryOp::kWildcardEquality:
     case mir::BinaryOp::kWildcardInequality:
       return diag::Unsupported(
           diag::DiagCode::kCppEmitBinaryOpNotImplemented,
-          "this binary operator is not yet implemented in cpp emit",
+          "wildcard equality operators (`==?` / `!=?`) are not yet "
+          "implemented in cpp emit",
           diag::UnsupportedCategory::kFeature);
   }
   return "(" + lhs + std::string{tok} + rhs + ")";
@@ -137,19 +141,6 @@ auto LookupProceduralVarName(
     const RenderContext& ctx, const mir::ProceduralVarRef& ref)
     -> const std::string& {
   return ctx.ProceduralScopeAtHops(ref.hops).vars.at(ref.var.value).name;
-}
-
-auto RenderStructuralVarName(
-    const RenderContext& ctx, const mir::StructuralVarRef& ref)
-    -> diag::Result<std::string> {
-  if (ref.hops.value != 0) {
-    return diag::Unsupported(
-        diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-        "cross-scope structural var access is not yet implemented in cpp "
-        "emit",
-        diag::UnsupportedCategory::kFeature);
-  }
-  return ctx.StructuralScope().GetStructuralVar(ref.var).name;
 }
 
 auto IntegralConstantToInt64(const mir::IntegralConstant& c) -> std::int64_t {
@@ -256,6 +247,19 @@ auto RenderStructuralParamExpr(
 
 }  // namespace
 
+auto RenderStructuralVarName(
+    const RenderContext& ctx, const mir::StructuralVarRef& ref)
+    -> diag::Result<std::string> {
+  if (ref.hops.value != 0) {
+    return diag::Unsupported(
+        diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+        "cross-scope structural var access is not yet implemented in cpp "
+        "emit",
+        diag::UnsupportedCategory::kFeature);
+  }
+  return ctx.StructuralScope().GetStructuralVar(ref.var).name;
+}
+
 auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
     -> diag::Result<std::string> {
   return std::visit(
@@ -310,6 +314,13 @@ auto RenderAssignExprNode(const RenderContext& ctx, const mir::AssignExpr& a)
   if (!target_or) return std::unexpected(std::move(target_or.error()));
   auto value_or = RenderExpr(ctx, ctx.Expr(a.value));
   if (!value_or) return std::unexpected(std::move(value_or.error()));
+  if (const auto* svr = std::get_if<mir::StructuralVarRef>(&a.target)) {
+    const auto& var_decl = ctx.StructuralScope().GetStructuralVar(svr->var);
+    if (IsObservableScalarType(ctx.Unit().GetType(var_decl.type))) {
+      return "lyra::runtime::WriteVar(*services_, " + *target_or + ", " +
+             *value_or + ")";
+    }
+  }
   return "(" + *target_or + " = " + *value_or + ")";
 }
 
@@ -363,7 +374,13 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
             return RenderStructuralParamExpr(ctx, r);
           },
           [&](const mir::StructuralVarRef& m) -> diag::Result<std::string> {
-            return RenderStructuralVarName(ctx, m);
+            auto name_or = RenderStructuralVarName(ctx, m);
+            if (!name_or) return std::unexpected(std::move(name_or.error()));
+            const auto& ty = ctx.Unit().GetType(expr.type);
+            if (ty.IsPackedArray()) {
+              return *name_or + ".Get()";
+            }
+            return *name_or;
           },
           [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
             return LookupProceduralVarName(ctx, l);

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -55,15 +55,35 @@ auto RenderForInit(const RenderContext& ctx, const mir::ForInit& init)
 auto RenderTimedStmt(
     const RenderContext& ctx, const mir::TimedStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
-  std::string out;
-  std::visit(
+  auto timing_or = std::visit(
       Overloaded{
-          [&](const mir::DelayControl& d) {
-            out += Indent(indent) + "co_await lyra::runtime::Delay(" +
+          [&](const mir::DelayControl& d) -> diag::Result<std::string> {
+            return Indent(indent) + "co_await lyra::runtime::Delay(" +
                    std::to_string(d.duration) + ");\n";
+          },
+          [&](const mir::EventControl& e) -> diag::Result<std::string> {
+            if (e.triggers.size() != 1) {
+              throw InternalError(
+                  "RenderTimedStmt: event control with multiple triggers "
+                  "should have been rejected at HIR lowering");
+            }
+            const auto& sig_expr = ctx.Expr(e.triggers[0].signal);
+            const auto* svr =
+                std::get_if<mir::StructuralVarRef>(&sig_expr.data);
+            if (svr == nullptr) {
+              throw InternalError(
+                  "RenderTimedStmt: event-control trigger is not a "
+                  "StructuralVarRef (should be rejected at HIR lowering)");
+            }
+            auto name_or = RenderStructuralVarName(ctx, *svr);
+            if (!name_or) return std::unexpected(std::move(name_or.error()));
+            return Indent(indent) + "co_await lyra::runtime::WaitChange(" +
+                   *name_or + ");\n";
           },
       },
       s.timing);
+  if (!timing_or) return std::unexpected(std::move(timing_or.error()));
+  std::string out = *std::move(timing_or);
   auto inner_or =
       RenderStmt(ctx, ctx.ProceduralScope().stmts.at(s.stmt.value), indent);
   if (!inner_or) return std::unexpected(std::move(inner_or.error()));

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -21,6 +21,10 @@ auto RenderPackedArrayCtorArgs(const mir::PackedArrayType& pa) -> std::string {
          four_state_lit;
 }
 
+auto IsObservableScalarType(const mir::Type& ty) -> bool {
+  return ty.IsPackedArray();
+}
+
 auto RenderTypeAsCpp(
     const mir::CompilationUnit& unit, const mir::StructuralScope& owner_scope,
     mir::TypeId type_id) -> diag::Result<std::string> {

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -132,6 +132,18 @@ constexpr std::array kEntries{
             .kind = DiagKind::kUnsupported,
             .category = UnsupportedCategory::kFeature,
             .name = "unsupported_delay_expression_form"}},
+    std::pair{
+        DiagCode::kUnsupportedEventEdge,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_event_edge"}},
+    std::pair{
+        DiagCode::kUnsupportedEventTriggerForm,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_event_trigger_form"}},
 
     std::pair{
         DiagCode::kDelayValueOutOfRange,

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -392,7 +392,23 @@ class HirDumper {
               return std::format(
                   "DelayControl duration=Expr[{}]", d.duration.value);
             },
-            [](const EventControl&) -> std::string { return "EventControl"; },
+            [](const EventControl& e) -> std::string {
+              std::string out = "EventControl triggers=[";
+              for (std::size_t i = 0; i < e.triggers.size(); ++i) {
+                if (i != 0) out += ", ";
+                const char* edge = "any";
+                switch (e.triggers[i].edge) {
+                  case EventEdge::kAnyChange:
+                    edge = "any";
+                    break;
+                }
+                out += std::format(
+                    "{{signal=Expr[{}] edge={}}}", e.triggers[i].signal.value,
+                    edge);
+              }
+              out += "]";
+              return out;
+            },
         },
         tc);
   }

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -45,6 +45,53 @@ auto LowerUniquePriorityCheck(slang::ast::UniquePriorityCheck check)
       "LowerUniquePriorityCheck: unknown slang UniquePriorityCheck value");
 }
 
+auto LowerSignalEventTrigger(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const slang::ast::SignalEventControl& sig, diag::SourceSpan span)
+    -> diag::Result<hir::EventTrigger> {
+  if (sig.edge != slang::ast::EdgeKind::None) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedEventEdge,
+        "edge specifiers (posedge/negedge/edge) are not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  if (sig.iffCondition != nullptr) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedEventTriggerForm,
+        "`iff` qualifier on event control is not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+
+  auto expr_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, sig.expr);
+  if (!expr_or) return std::unexpected(std::move(expr_or.error()));
+  const hir::Expr& lowered = *expr_or;
+
+  const auto* primary = std::get_if<hir::PrimaryExpr>(&lowered.data);
+  if (primary == nullptr ||
+      !std::holds_alternative<hir::StructuralVarRef>(primary->data)) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedEventTriggerForm,
+        "event trigger must be a plain structural variable reference; "
+        "bit-selects, member access, named events, and hierarchical refs are "
+        "not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  if (!unit_state.GetType(lowered.type).IsPackedArray()) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedEventTriggerForm,
+        "event trigger must reference an integral signal; non-integral "
+        "trigger types are not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+
+  return hir::EventTrigger{
+      .signal = proc_state.AddExpr(*std::move(expr_or)),
+      .edge = hir::EventEdge::kAnyChange,
+  };
+}
+
 auto LowerTimingControl(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ProcessLoweringState& proc_state, const ScopeStack& stack,
@@ -59,11 +106,29 @@ auto LowerTimingControl(
       return hir::TimingControl{hir::DelayControl{
           .duration = proc_state.AddExpr(*std::move(duration))}};
     }
-    case slang::ast::TimingControlKind::SignalEvent:
+    case slang::ast::TimingControlKind::SignalEvent: {
+      const auto& sig = tc.as<slang::ast::SignalEventControl>();
+      auto trigger_or = LowerSignalEventTrigger(
+          unit_facts, unit_state, proc_state, stack, sig, span);
+      if (!trigger_or) return std::unexpected(std::move(trigger_or.error()));
+      return hir::TimingControl{
+          hir::EventControl{.triggers = {*std::move(trigger_or)}}};
+    }
     case slang::ast::TimingControlKind::EventList:
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedTimingControlKind,
+          "event lists (`@(a or b)`) are not yet supported",
+          diag::UnsupportedCategory::kFeature);
     case slang::ast::TimingControlKind::ImplicitEvent:
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedTimingControlKind,
+          "implicit event control (`@*`) is not yet supported",
+          diag::UnsupportedCategory::kFeature);
     case slang::ast::TimingControlKind::RepeatedEvent:
-      return hir::TimingControl{hir::EventControl{}};
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedTimingControlKind,
+          "repeated event control (`repeat (N) @(...)`) is not yet supported",
+          diag::UnsupportedCategory::kFeature);
     default:
       return diag::Unsupported(
           span, diag::DiagCode::kUnsupportedTimingControlKind,

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -70,8 +70,11 @@ auto ResolveDelayDuration(
 }
 
 auto LowerTimingControl(
-    const ProcessLoweringState& proc_state, const hir::Process& hir_proc,
-    const hir::TimingControl& tc, diag::SourceSpan span)
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_proc, const hir::TimingControl& tc)
     -> diag::Result<mir::TimingControl> {
   return std::visit(
       Overloaded{
@@ -84,11 +87,29 @@ auto LowerTimingControl(
             }
             return mir::TimingControl{mir::DelayControl{.duration = *ticks_or}};
           },
-          [&](const hir::EventControl&) -> diag::Result<mir::TimingControl> {
-            return diag::Unsupported(
-                span, diag::DiagCode::kUnsupportedTimingControlKind,
-                "event-control timing is not yet supported",
-                diag::UnsupportedCategory::kFeature);
+          [&](const hir::EventControl& e) -> diag::Result<mir::TimingControl> {
+            std::vector<mir::EventTrigger> triggers;
+            triggers.reserve(e.triggers.size());
+            for (const auto& t : e.triggers) {
+              auto signal_or = LowerExpr(
+                  unit_state, scope_state, proc_state, proc_scope_state,
+                  hir_proc, hir_proc.exprs.at(t.signal.value));
+              if (!signal_or) {
+                return std::unexpected(std::move(signal_or.error()));
+              }
+              const mir::ExprId signal_id =
+                  proc_scope_state.AddExpr(*std::move(signal_or));
+              mir::EventEdge edge = mir::EventEdge::kAnyChange;
+              switch (t.edge) {
+                case hir::EventEdge::kAnyChange:
+                  edge = mir::EventEdge::kAnyChange;
+                  break;
+              }
+              triggers.push_back(
+                  mir::EventTrigger{.signal = signal_id, .edge = edge});
+            }
+            return mir::TimingControl{
+                mir::EventControl{.triggers = std::move(triggers)}};
           },
       },
       tc);
@@ -719,8 +740,9 @@ auto LowerTimedStmt(
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::Process& hir_proc, const hir::Stmt& stmt,
     const hir::TimedStmt& t) -> diag::Result<mir::Stmt> {
-  auto timing_or =
-      LowerTimingControl(proc_state, hir_proc, t.timing, stmt.span);
+  auto timing_or = LowerTimingControl(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+      t.timing);
   if (!timing_or) {
     return std::unexpected(std::move(timing_or.error()));
   }

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -204,6 +204,23 @@ class MirDumper {
             [](const DelayControl& d) -> std::string {
               return std::format("DelayControl ticks={}", d.duration);
             },
+            [](const EventControl& e) -> std::string {
+              std::string out = "EventControl triggers=[";
+              for (std::size_t i = 0; i < e.triggers.size(); ++i) {
+                if (i != 0) out += ", ";
+                const char* edge = "any";
+                switch (e.triggers[i].edge) {
+                  case EventEdge::kAnyChange:
+                    edge = "any";
+                    break;
+                }
+                out += std::format(
+                    "{{signal=Expr[{}] edge={}}}", e.triggers[i].signal.value,
+                    edge);
+              }
+              out += "]";
+              return out;
+            },
         },
         tc);
   }

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -21,6 +21,7 @@
 #include "lyra/runtime/runtime_scope_kind.hpp"
 #include "lyra/runtime/runtime_traversal.hpp"
 #include "lyra/runtime/stream_dispatcher.hpp"
+#include "lyra/runtime/var.hpp"
 #include "lyra/runtime/wait_request.hpp"
 
 namespace lyra::runtime {
@@ -275,6 +276,7 @@ void Engine::ScheduleWait(RuntimeProcess& process, WaitRequest wait) {
       Overloaded{
           [&](DelayWait d) { ScheduleDelayWait(process, d); },
           [&](EventWait e) { ScheduleEventWait(process, e); },
+          [&](ValueChangeWait v) { ScheduleValueChangeWait(process, v); },
           [&](FinishWait) { finished_ = true; },
       },
       wait);
@@ -297,6 +299,21 @@ void Engine::ScheduleEventWait(RuntimeProcess& process, EventWait wait) {
 
 void Engine::TriggerEvent(RuntimeEvent& event) {
   for (RuntimeProcess* p : event.TakeWaiters()) {
+    ScheduleNextDelta(*p);
+  }
+}
+
+void Engine::ScheduleValueChangeWait(
+    RuntimeProcess& process, ValueChangeWait wait) {
+  if (wait.observable == nullptr) {
+    throw InternalError(
+        "Engine::ScheduleValueChangeWait: observable pointer is null");
+  }
+  wait.observable->Subscribe(process);
+}
+
+void Engine::TriggerValueChange(Observable& observable) {
+  for (RuntimeProcess* p : observable.TakeWaiters()) {
     ScheduleNextDelta(*p);
   }
 }

--- a/src/lyra/runtime/runtime_services.cpp
+++ b/src/lyra/runtime/runtime_services.cpp
@@ -15,4 +15,11 @@ void RuntimeServices::SubmitNba(std::function<void()> closure) {
   engine_->SubmitNba(std::move(closure));
 }
 
+void RuntimeServices::TriggerValueChange(Observable& observable) {
+  if (engine_ == nullptr) {
+    throw InternalError("RuntimeServices::TriggerValueChange: no Engine bound");
+  }
+  engine_->TriggerValueChange(observable);
+}
+
 }  // namespace lyra::runtime

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -175,6 +175,20 @@ auto PackedArray::UnknownWords() const -> std::span<const std::uint64_t> {
   return {};
 }
 
+auto PackedArray::IsCaseEqual(const PackedArray& other) const -> bool {
+  if (bit_width_ != other.bit_width_) return false;
+  if (is_four_state_ != other.is_four_state_) return false;
+  const auto vw_a = ValueWords();
+  const auto vw_b = other.ValueWords();
+  if (vw_a.size() != vw_b.size()) return false;
+  if (!std::ranges::equal(vw_a, vw_b)) return false;
+  return std::ranges::equal(UnknownWords(), other.UnknownWords());
+}
+
+auto PackedArray::CaseEqual(const PackedArray& other) const -> PackedArray {
+  return FromInt(IsCaseEqual(other) ? 1 : 0, 1, false, false);
+}
+
 auto PackedArray::AsBitView() -> BitView {
   auto* bv = std::get_if<BitValue>(&storage_);
   if (bv == nullptr) {

--- a/tests/cases/cpp/case_equality_basic/case.yaml
+++ b/tests/cases/cpp/case_equality_basic/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.case_equality_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    eq_same: 1
+    eq_diff: 0
+    eq_xz: 1
+    neq_same: 0

--- a/tests/cases/cpp/case_equality_basic/main.sv
+++ b/tests/cases/cpp/case_equality_basic/main.sv
@@ -1,0 +1,21 @@
+module Top;
+  logic [3:0] a;
+  logic [3:0] b;
+  int         eq_same;
+  int         eq_diff;
+  int         eq_xz;
+  int         neq_same;
+  initial begin
+    a = 4'b10x1;
+    b = 4'b10x1;
+    eq_same = (a === b) ? 1 : 0;
+    neq_same = (a !== b) ? 1 : 0;
+
+    b = 4'b1011;
+    eq_diff = (a === b) ? 1 : 0;
+
+    a = 4'bxxxx;
+    b = 4'bxxxx;
+    eq_xz = (a === b) ? 1 : 0;
+  end
+endmodule

--- a/tests/cases/cpp/event_multi_bit_signal/case.yaml
+++ b/tests/cases/cpp/event_multi_bit_signal/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.event_multi_bit_signal
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    seen: 1

--- a/tests/cases/cpp/event_multi_bit_signal/main.sv
+++ b/tests/cases/cpp/event_multi_bit_signal/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  logic [7:0] data;
+  int   seen;
+  initial begin
+    data = 8'h00;
+    seen = 0;
+    @(data);
+    seen = 1;
+  end
+  initial begin
+    #5;
+    data = 8'h42;
+  end
+endmodule

--- a/tests/cases/cpp/event_multi_waiters/case.yaml
+++ b/tests/cases/cpp/event_multi_waiters/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.event_multi_waiters
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a: 1
+    b: 2

--- a/tests/cases/cpp/event_multi_waiters/main.sv
+++ b/tests/cases/cpp/event_multi_waiters/main.sv
@@ -1,0 +1,22 @@
+module Top;
+  logic clk;
+  int   a;
+  int   b;
+  initial begin
+    clk = 0;
+    a = 0;
+    b = 0;
+  end
+  initial begin
+    @(clk);
+    a = 1;
+  end
+  initial begin
+    @(clk);
+    b = 2;
+  end
+  initial begin
+    #5;
+    clk = 1;
+  end
+endmodule

--- a/tests/cases/cpp/event_no_wake_on_same_value/case.yaml
+++ b/tests/cases/cpp/event_no_wake_on_same_value/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.event_no_wake_on_same_value
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    wake_count: 3

--- a/tests/cases/cpp/event_no_wake_on_same_value/main.sv
+++ b/tests/cases/cpp/event_no_wake_on_same_value/main.sv
@@ -1,0 +1,24 @@
+module Top;
+  logic clk;
+  int   wake_count;
+  initial begin
+    clk = 0;
+    wake_count = 0;
+    repeat (3) begin
+      @(clk);
+      wake_count = wake_count + 1;
+    end
+  end
+  initial begin
+    #5;
+    clk = 0;
+    #5;
+    clk = 1;
+    #5;
+    clk = 1;
+    #5;
+    clk = 0;
+    #5;
+    clk = 1;
+  end
+endmodule

--- a/tests/cases/cpp/event_wake_on_change/case.yaml
+++ b/tests/cases/cpp/event_wake_on_change/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.event_wake_on_change
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    done: 1

--- a/tests/cases/cpp/event_wake_on_change/main.sv
+++ b/tests/cases/cpp/event_wake_on_change/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  logic clk;
+  int   done;
+  initial begin
+    clk = 0;
+    done = 0;
+    @(clk);
+    done = 1;
+  end
+  initial begin
+    #5;
+    clk = 1;
+  end
+endmodule

--- a/tests/cases/cpp/event_with_nba/case.yaml
+++ b/tests/cases/cpp/event_with_nba/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.event_with_nba
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q: 42

--- a/tests/cases/cpp/event_with_nba/main.sv
+++ b/tests/cases/cpp/event_with_nba/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  logic clk;
+  int   d;
+  int   q;
+  initial begin
+    clk = 0;
+    d   = 42;
+    q   = 0;
+    @(clk);
+    q <= d;
+  end
+  initial begin
+    #5;
+    clk = 1;
+  end
+endmodule

--- a/tests/cases/errors/cpp_emit_unsupported_binary_op/main.sv
+++ b/tests/cases/errors/cpp_emit_unsupported_binary_op/main.sv
@@ -1,8 +1,8 @@
 module Top;
-  int a;
-  int b;
-  int r;
+  logic [3:0] a;
+  logic [3:0] b;
+  int         r;
   initial begin
-    r = (a === b);
+    r = (a ==? b) ? 1 : 0;
   end
 endmodule

--- a/tests/cases/errors/event_bit_select_unsupported/case.yaml
+++ b/tests/cases/errors/event_bit_select_unsupported/case.yaml
@@ -1,7 +1,7 @@
-id: errors.cpp_emit_unsupported_binary_op
+id: errors.event_bit_select_unsupported
 tags: [errors, diag]
 input:
-  command: [emit, cpp]
+  command: [dump, hir]
   project: false
   top: Top
   files: [main.sv]
@@ -10,7 +10,7 @@ expect:
   exit: 1
   stderr:
     contains:
+      - "main.sv:4:"
       - "unsupported:"
-      - "wildcard equality operators"
     not_contains:
       - "internal error"

--- a/tests/cases/errors/event_bit_select_unsupported/main.sv
+++ b/tests/cases/errors/event_bit_select_unsupported/main.sv
@@ -1,0 +1,6 @@
+module Top;
+  logic [7:0] data;
+  initial begin
+    @(data[3]);
+  end
+endmodule

--- a/tests/cases/errors/event_list_unsupported/case.yaml
+++ b/tests/cases/errors/event_list_unsupported/case.yaml
@@ -1,7 +1,7 @@
-id: errors.cpp_emit_unsupported_binary_op
+id: errors.event_list_unsupported
 tags: [errors, diag]
 input:
-  command: [emit, cpp]
+  command: [dump, hir]
   project: false
   top: Top
   files: [main.sv]
@@ -10,7 +10,8 @@ expect:
   exit: 1
   stderr:
     contains:
+      - "main.sv:5:"
       - "unsupported:"
-      - "wildcard equality operators"
+      - "event lists"
     not_contains:
       - "internal error"

--- a/tests/cases/errors/event_list_unsupported/main.sv
+++ b/tests/cases/errors/event_list_unsupported/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  logic a;
+  logic b;
+  initial begin
+    @(a or b);
+  end
+endmodule

--- a/tests/cases/errors/event_named_event_unsupported/case.yaml
+++ b/tests/cases/errors/event_named_event_unsupported/case.yaml
@@ -1,7 +1,7 @@
-id: errors.cpp_emit_unsupported_binary_op
+id: errors.event_named_event_unsupported
 tags: [errors, diag]
 input:
-  command: [emit, cpp]
+  command: [dump, hir]
   project: false
   top: Top
   files: [main.sv]
@@ -10,7 +10,7 @@ expect:
   exit: 1
   stderr:
     contains:
+      - "main.sv:"
       - "unsupported:"
-      - "wildcard equality operators"
     not_contains:
       - "internal error"

--- a/tests/cases/errors/event_named_event_unsupported/main.sv
+++ b/tests/cases/errors/event_named_event_unsupported/main.sv
@@ -1,0 +1,6 @@
+module Top;
+  event e;
+  initial begin
+    @(e);
+  end
+endmodule

--- a/tests/cases/errors/event_posedge_unsupported/case.yaml
+++ b/tests/cases/errors/event_posedge_unsupported/case.yaml
@@ -1,7 +1,7 @@
-id: errors.cpp_emit_unsupported_binary_op
+id: errors.event_posedge_unsupported
 tags: [errors, diag]
 input:
-  command: [emit, cpp]
+  command: [dump, hir]
   project: false
   top: Top
   files: [main.sv]
@@ -10,7 +10,8 @@ expect:
   exit: 1
   stderr:
     contains:
+      - "main.sv:4:"
       - "unsupported:"
-      - "wildcard equality operators"
+      - "edge specifiers"
     not_contains:
       - "internal error"

--- a/tests/cases/errors/event_posedge_unsupported/main.sv
+++ b/tests/cases/errors/event_posedge_unsupported/main.sv
@@ -1,0 +1,6 @@
+module Top;
+  logic clk;
+  initial begin
+    @(posedge clk);
+  end
+endmodule

--- a/tools/policy/check_cpp_style.py
+++ b/tools/policy/check_cpp_style.py
@@ -25,6 +25,14 @@ Rules:
         later cut". User-visible "not yet supported" wording is the
         correct replacement. Scope: every .cpp/.hpp under src/, include/.
 
+  S004  Include style: C++ stdlib headers must use angle brackets
+        (`#include <vector>`), and lyra project headers must use double
+        quotes (`#include "lyra/..."`). 3rd-party libraries follow their
+        upstream convention (e.g. fmt uses `<fmt/...>`, absl uses
+        `"absl/..."` because of Bazel's `-iquote` exposure) and are not
+        policed by this rule.
+        Scope: every .cpp/.hpp under src/, include/, tests/.
+
 Usage:
   python3 tools/policy/check_cpp_style.py
 """
@@ -57,6 +65,33 @@ STAGE_LANGUAGE_PATTERNS = [
     (re.compile(r"(?i)\bdeferred\s+to\s+a\s+(?:later|future)\b"),
      "deferred to a later/future"),
 ]
+
+# S004: C++ stdlib headers (always angle-bracket form). This list is the
+# universal portion of the standard library; we intentionally do not police
+# 3rd-party libraries because each tracks its upstream convention (e.g.
+# bazel-imported absl uses `"absl/..."` per its `-iquote` exposure, while
+# fmt uses `<fmt/...>`).
+STDLIB_HEADERS = frozenset({
+    "algorithm", "array", "atomic", "bit", "bitset", "cassert", "ccomplex",
+    "cctype", "cerrno", "cfenv", "cfloat", "charconv", "chrono", "cinttypes",
+    "climits", "clocale", "cmath", "compare", "complex", "concepts",
+    "condition_variable", "coroutine", "csetjmp", "csignal", "cstdarg",
+    "cstdbool", "cstddef", "cstdint", "cstdio", "cstdlib", "cstring", "ctime",
+    "cuchar", "cwchar", "cwctype", "deque", "exception", "execution",
+    "expected", "filesystem", "format", "forward_list", "fstream",
+    "functional", "future", "initializer_list", "iomanip", "ios", "iosfwd",
+    "iostream", "istream", "iterator", "latch", "limits", "list", "locale",
+    "map", "memory", "memory_resource", "mutex", "new", "numbers", "numeric",
+    "optional", "ostream", "queue", "random", "ranges", "ratio", "regex",
+    "scoped_allocator", "semaphore", "set", "shared_mutex", "source_location",
+    "span", "sstream", "stack", "stdexcept", "stop_token", "streambuf",
+    "string", "string_view", "syncstream", "system_error", "thread", "tuple",
+    "type_traits", "typeindex", "typeinfo", "unordered_map", "unordered_set",
+    "utility", "valarray", "variant", "vector", "version",
+})
+
+INCLUDE_QUOTE_PATTERN = re.compile(r'^\s*#\s*include\s*"([^"]+)"')
+INCLUDE_ANGLE_PATTERN = re.compile(r'^\s*#\s*include\s*<([^>]+)>')
 
 
 def iter_cpp_files(repo_root: Path, roots=("src", "include", "tests")):
@@ -127,6 +162,27 @@ def check_s003(repo_root: Path) -> list[str]:
     return errors
 
 
+def check_s004(repo_root: Path) -> list[str]:
+    errors = []
+    for path, rel in iter_cpp_files(repo_root):
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if (m := INCLUDE_QUOTE_PATTERN.match(line)):
+                inc = m.group(1)
+                if inc in STDLIB_HEADERS:
+                    errors.append(
+                        f"  {rel}:{lineno}: S004 stdlib header "
+                        f'"{inc}" must use angle brackets'
+                    )
+            elif (m := INCLUDE_ANGLE_PATTERN.match(line)):
+                inc = m.group(1)
+                if inc.startswith("lyra/"):
+                    errors.append(
+                        f"  {rel}:{lineno}: S004 lyra header <{inc}> "
+                        f'must use double quotes'
+                    )
+    return errors
+
+
 def run_self_tests() -> bool:
     def expect(cond, msg):
         if not cond:
@@ -161,6 +217,19 @@ def run_self_tests() -> bool:
     ok &= expect(not hits("scope is the lookup unit"),
                  "S003 'scope' unrelated bare")
     ok &= expect(not hits("// to cut the loop short"), "S003 'cut' unrelated")
+
+    def quote_inc(text):
+        m = INCLUDE_QUOTE_PATTERN.match(text)
+        return m.group(1) if m else None
+
+    def angle_inc(text):
+        m = INCLUDE_ANGLE_PATTERN.match(text)
+        return m.group(1) if m else None
+
+    ok &= expect(quote_inc('#include "vector"') == "vector", "S004 quote")
+    ok &= expect(angle_inc("#include <vector>") == "vector", "S004 angle")
+    ok &= expect("vector" in STDLIB_HEADERS, "S004 vector is stdlib")
+    ok &= expect("absl/x.h" not in STDLIB_HEADERS, "S004 absl not stdlib")
     return ok
 
 
@@ -169,6 +238,7 @@ CHECKS = [
      check_s001),
     ("S002 header files under src/", check_s002),
     ("S003 migration-progress / development-stage language", check_s003),
+    ("S004 include style (stdlib <>, lyra \"\")", check_s004),
 ]
 
 


### PR DESCRIPTION
## Summary

Adds `@(signal)` any-change event control end-to-end. Structural integral fields are emitted as `lyra::runtime::Var<T>` wrappers that carry waiter lists; writes flow through a services-mediated `WriteVar` helper that compares the new value against the previous bit pattern and dispatches a change notification. Process bodies suspend on `co_await WaitChange(var)` and resume in the next delta when any subscribed observable fires.

## Design

`Var<T>` is pure data: it stores the value and a waiter list, with no engine pointer. Dispatch lives on `RuntimeServices::TriggerValueChange` (mirroring `SubmitNba` / `Print`), keeping the Var primitive decoupled from scheduling. The change predicate is LRM 11.4.5 case equality (`PackedArray::IsCaseEqual`), since SV `==` returns X on unknowns and cannot answer "did the value change". The same `IsCaseEqual` underlies a new backend `===` / `!==` operator render and the new `CaseEqual` SV operator form returning a 1-bit `PackedArray`.

Out of scope for this PR: edge polarity (posedge / negedge / edge), event lists `@(a or b)`, `@*`, named events, `wait(expr)`, and `always_ff` / `always_comb`. Rejected at AST->HIR with targeted diagnostics. Wildcard equality (`==?` / `!=?`) is also deferred and tracked as J18 in `integral.md`.

## Testing

- 5 cpp run tests covering wake-on-change, no-wake-on-same-value, multi-waiter, multi-bit signal, and NBA-through-event combos
- 1 cpp run test for `===` / `!==` case equality
- 4 error tests for the rejected event-control forms
- New `S004` policy check (stdlib `<>`, lyra `""`) covers the include style convention