### PR TITLE
Route method calls through type-owned method tables

### DIFF
--- a/docs/progress/datatypes.md
+++ b/docs/progress/datatypes.md
@@ -11,11 +11,7 @@ on the current pipeline.
 
 ## Actionable
 
-| Item | Blocked on                                             |
-| ---- | ------------------------------------------------------ |
-| E3   | `datatypes/string` -- `name()` returns a string value. |
-
-E1 and E2 are actionable now.
+E2 and E3 are actionable now; no remaining dependencies on other workstreams.
 
 ## Enum
 
@@ -23,17 +19,26 @@ Covers archive item `datatypes/enum` (sub-folders `enum`, `enum_implicit_convers
 `enum_methods`). Slang models enum as `EnumType : public IntegralType, public Scope`. Our HIR
 mirrors that with a `hir::EnumType` carrying a `base_type` (a `PackedArrayType`) and an ordered
 member table. HIR -> MIR aliases the enum's MIR `TypeId` to its base type's so MIR and the cpp
-backend see only `lyra::value::PackedArray`. Enum methods are modelled as built-in class methods
-under a uniform `CallExpr` shape: a new `hir::BuiltinMethodRef` variant of `SubroutineRef` carries
-the method kind, and `CallExpr::arguments[0]` is the receiver (variadic for `next` / `prev`).
+backend see only `lyra::value::PackedArray`.
+
+Enum methods are modelled by the general "types own method tables" mechanism: `EnumType.methods`
+carries six `hir::Method` entries (each with `hir::BuiltinMethod` data), populated at AST -> HIR
+enum type construction. Call dispatch goes through `hir::MethodRef{receiver_type, method_id}` -- a
+`SubroutineRef` variant alternative that is the dot-syntax counterpart of `StructuralSubroutineRef`
+(free user calls) and `SystemSubroutineRef` (system tasks). The same mechanism is the path for
+future `string` / `queue` builtins and user class methods; only the `Method::data` variant
+alternative differs (`BuiltinMethod` for LRM intrinsics, `StructuralMethod` for user-defined
+bodies).
 
 - [x] E1 -- Type plumbing, member references, compile-time methods. `LowerType` recognises
-      `slang::ast::EnumType`; AST `NamedValueExpression` whose symbol kind is `EnumValue` lowers
-      directly to `hir::IntegerLiteral` of the backing type. `v.first()` / `v.last()` / `v.num()`
-      lower at AST -> HIR to
-      `CallExpr{callee=BuiltinMethodRef{kEnumFirst|kEnumLast|kEnumNum},     arguments=[receiver]}`
-      without folding; the fold happens at HIR -> MIR using the receiver's `hir::EnumType` member
-      table. HIR -> MIR's `TranslateTypeData` has an `EnumType` arm that copies the base's
+      `slang::ast::EnumType` and populates the enum type's six-entry method table (`first` / `last`
+      / `num` / `next` / `prev` / `name`). AST `NamedValueExpression` whose symbol kind is
+      `EnumValue` lowers directly to `hir::IntegerLiteral` of the backing type. `v.first()` /
+      `v.last()` / `v.num()` lower at AST -> HIR via a uniform call dispatch that looks up the
+      method by name on the receiver's type, producing
+      `CallExpr{callee=MethodRef{receiver_type, method_id}, arguments=[receiver]}` without folding;
+      the fold happens at HIR -> MIR's `LowerBuiltinMethodCall` using the receiver's `hir::EnumType`
+      member table. HIR -> MIR's `TranslateTypeData` has an `EnumType` arm that copies the base's
       translated `mir::TypeData`, so the orchestrator stays uniform. Conversions enum -> integral
       are transparent; integral -> enum requires explicit cast (LRM 6.19.3). Covers all 11 cases of
       `enum/default.yaml` (basic, sequential, explicit, mixed, comparison, arithmetic, explicit base
@@ -43,20 +48,27 @@ the method kind, and `CallExpr::arguments[0]` is the receiver (variadic for `nex
       `enum_methods/default.yaml` cases for `first` / `last` / `num` / `num_auto_values`. Also ships
       `enum_passed_to_system_function` as a regression guard for the AST -> HIR Call dispatch (an
       enum-typed first argument to a `$`-prefixed system call must fall through to the system
-      subroutine path, not the built-in method path). Unblocks C16 in `control-flow.md`. Methods
-      `next` / `prev` / `name` return `diag::Unsupported` at HIR -> MIR until E2 / E3.
-- [ ] E2 -- Runtime methods `next` / `prev` with optional step. AST -> HIR already produces
-      `CallExpr{callee=BuiltinMethodRef{kEnumNext|kEnumPrev}, arguments=[receiver, step?]}` (no
-      shape change). HIR -> MIR's `LowerBuiltinMethodCall` adds Next / Prev arms that lower each
-      call to a value-to-value mapping over the enum's declaration-order member table, wrapping at
-      the boundary. cpp emit emits one helper per enum type at the top of the translation unit; call
-      sites invoke it. Covers `enum_methods/default.yaml` cases `enum_next`, `enum_next_wrap`,
-      `enum_prev`, `enum_prev_wrap`, `enum_next_step`, `enum_next_step_wrap`, `enum_prev_step`,
-      `enum_prev_step_wrap`.
-- [ ] E3 -- Method `name()`. Returns the string name of the current value (empty string when the
-      value is not a member). **Depends on** `datatypes/string` for the runtime string type. HIR ->
-      MIR's `LowerBuiltinMethodCall` Name arm replaces the current `Unsupported` with a string
-      lookup; cpp emit emits a per-enum-type `value -> string` helper. Covers
+      subroutine path when no method of that name exists on the receiver). Unblocks C16 in
+      `control-flow.md`. Methods `next` / `prev` / `name` return `diag::Unsupported` at HIR -> MIR
+      until E2 / E3.
+- [ ] E2 -- Runtime methods `next` / `prev` with optional step (LRM 6.19.5.3 / 6.19.5.4). AST -> HIR
+      already produces `CallExpr{callee=MethodRef{...}, arguments=[receiver, step?]}` (no shape
+      change). HIR -> MIR's `LowerBuiltinMethodCall` replaces the current `Unsupported` arms for
+      `kEnumNext` / `kEnumPrev` with a nested `ConditionalExpr` chain over the enum's
+      declaration-order member table: each branch matches one member by equality and produces the
+      wrapped `(i +/- step) mod count` target value as an `IntegerLiteral`; the default branch is
+      the enum's default initial value (per LRM 6.19.5, Table 6-7, for non-member receivers). `step`
+      is typed `int unsigned` by slang at AST level and must be a literal in this cut; non-constant
+      step returns `diag::Unsupported`. Covers `enum_methods/default.yaml` cases `enum_next`,
+      `enum_next_wrap`, `enum_prev`, `enum_prev_wrap`, `enum_next_step`, `enum_next_step_wrap`,
+      `enum_prev_step`, `enum_prev_step_wrap`.
+- [ ] E3 -- Method `name()` (LRM 6.19.5.6). Returns the string name of the current value, empty
+      string when the value is not a member. HIR -> MIR's `LowerBuiltinMethodCall` Name arm replaces
+      the current `Unsupported` with a nested `ConditionalExpr` chain mapping each
+      `members[i].value` to `mir::StringLiteral{members[i].name}`, with default branch
+      `mir::StringLiteral{""}`. Uses only existing `mir::ConditionalExpr`,
+      `mir::BinaryExpr{kEquality}`, and `mir::StringLiteral` -- all already supported end-to-end
+      through the cpp backend; no dependency on the `datatypes/string` workstream. Covers
       `enum_methods/default.yaml` case `enum_name`.
 
 ### Cross-references

--- a/include/lyra/hir/method.hpp
+++ b/include/lyra/hir/method.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+#include <string>
+#include <variant>
+
+#include "lyra/hir/subroutine_id.hpp"
+#include "lyra/hir/type_id.hpp"
+
+namespace lyra::hir {
+
+enum class BuiltinMethodKind : std::uint8_t {
+  kEnumFirst,
+  kEnumLast,
+  kEnumNum,
+  kEnumNext,
+  kEnumPrev,
+  kEnumName,
+};
+
+struct StructuralMethod {
+  StructuralSubroutineId subroutine;
+};
+
+struct BuiltinMethod {
+  BuiltinMethodKind kind;
+};
+
+using MethodData = std::variant<StructuralMethod, BuiltinMethod>;
+
+struct Method {
+  std::string name;
+  MethodData data;
+};
+
+struct MethodId {
+  std::uint32_t value;
+
+  auto operator<=>(const MethodId&) const -> std::strong_ordering = default;
+};
+
+struct MethodRef {
+  TypeId receiver_type;
+  MethodId method;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/module_unit.hpp
+++ b/include/lyra/hir/module_unit.hpp
@@ -5,6 +5,7 @@
 
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/type.hpp"
+#include "lyra/hir/type_id.hpp"
 
 namespace lyra::hir {
 

--- a/include/lyra/hir/subroutine.hpp
+++ b/include/lyra/hir/subroutine.hpp
@@ -1,19 +1,12 @@
 #pragma once
 
-#include <compare>
 #include <cstdint>
 #include <string>
 
-#include "lyra/hir/type.hpp"
+#include "lyra/hir/subroutine_id.hpp"
+#include "lyra/hir/type_id.hpp"
 
 namespace lyra::hir {
-
-struct StructuralSubroutineId {
-  std::uint32_t value;
-
-  auto operator<=>(const StructuralSubroutineId&) const
-      -> std::strong_ordering = default;
-};
 
 enum class SubroutineKind : std::uint8_t {
   kTask,

--- a/include/lyra/hir/subroutine_id.hpp
+++ b/include/lyra/hir/subroutine_id.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace lyra::hir {
+
+struct StructuralSubroutineId {
+  std::uint32_t value;
+
+  auto operator<=>(const StructuralSubroutineId&) const
+      -> std::strong_ordering = default;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/subroutine_ref.hpp
+++ b/include/lyra/hir/subroutine_ref.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <cstdint>
 #include <variant>
 
+#include "lyra/hir/method.hpp"
 #include "lyra/hir/structural_hops.hpp"
-#include "lyra/hir/subroutine.hpp"
+#include "lyra/hir/subroutine_id.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::hir {
@@ -18,20 +18,7 @@ struct SystemSubroutineRef {
   support::SystemSubroutineId id;
 };
 
-enum class BuiltinMethodKind : std::uint8_t {
-  kEnumFirst,
-  kEnumLast,
-  kEnumNum,
-  kEnumNext,
-  kEnumPrev,
-  kEnumName,
-};
-
-struct BuiltinMethodRef {
-  BuiltinMethodKind kind;
-};
-
-using SubroutineRef = std::variant<
-    StructuralSubroutineRef, SystemSubroutineRef, BuiltinMethodRef>;
+using SubroutineRef =
+    std::variant<StructuralSubroutineRef, SystemSubroutineRef, MethodRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/type.hpp
+++ b/include/lyra/hir/type.hpp
@@ -1,21 +1,18 @@
 #pragma once
 
-#include <compare>
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <string>
+#include <string_view>
 #include <variant>
 #include <vector>
 
 #include "lyra/hir/integral_constant.hpp"
+#include "lyra/hir/method.hpp"
+#include "lyra/hir/type_id.hpp"
 
 namespace lyra::hir {
-
-struct TypeId {
-  std::uint32_t value;
-
-  auto operator<=>(const TypeId&) const -> std::strong_ordering = default;
-};
 
 enum class TypeKind {
   kPackedArray,
@@ -77,6 +74,7 @@ struct EnumMember {
 struct EnumType {
   TypeId base_type;
   std::vector<EnumMember> members;
+  std::vector<Method> methods;
 };
 
 struct UnpackedRange {
@@ -124,6 +122,11 @@ struct Type {
   [[nodiscard]] auto AsPackedArray() const -> const PackedArrayType&;
   [[nodiscard]] auto IsEnum() const -> bool;
   [[nodiscard]] auto AsEnum() const -> const EnumType&;
+
+  [[nodiscard]] auto GetMethods() const -> std::span<const Method>;
+  [[nodiscard]] auto GetMethod(MethodId id) const -> const Method&;
+  [[nodiscard]] auto LookupMethod(std::string_view name) const
+      -> std::optional<MethodId>;
 };
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/type_id.hpp
+++ b/include/lyra/hir/type_id.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace lyra::hir {
+
+struct TypeId {
+  std::uint32_t value;
+
+  auto operator<=>(const TypeId&) const -> std::strong_ordering = default;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -14,7 +14,6 @@
 #include "lyra/hir/structural_hops.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/structural_var.hpp"
-#include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -13,6 +13,7 @@
 #include "lyra/base/overloaded.hpp"
 #include "lyra/hir/binary_op.hpp"
 #include "lyra/hir/expr.hpp"
+#include "lyra/hir/method.hpp"
 #include "lyra/hir/module_unit.hpp"
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/procedural_var.hpp"
@@ -148,9 +149,14 @@ class HirDumper {
                     "{}={}", e.members[i].name,
                     FormatIntegralConstant(e.members[i].value));
               }
+              std::string methods;
+              for (std::size_t i = 0; i < e.methods.size(); ++i) {
+                if (i > 0) methods += ", ";
+                methods += e.methods[i].name;
+              }
               return std::format(
-                  "Enum(base=Type[{}], members=[{}])", e.base_type.value,
-                  members);
+                  "Enum(base=Type[{}], members=[{}], methods=[{}])",
+                  e.base_type.value, members, methods);
             },
             [](const UnpackedArrayType& u) -> std::string {
               return std::format(
@@ -445,29 +451,12 @@ class HirDumper {
               return std::format(
                   "SystemSubroutine[{}] \"{}\"", s.id.value, desc.name);
             },
-            [](const BuiltinMethodRef& b) -> std::string {
-              std::string_view name;
-              switch (b.kind) {
-                case BuiltinMethodKind::kEnumFirst:
-                  name = "enum.first";
-                  break;
-                case BuiltinMethodKind::kEnumLast:
-                  name = "enum.last";
-                  break;
-                case BuiltinMethodKind::kEnumNum:
-                  name = "enum.num";
-                  break;
-                case BuiltinMethodKind::kEnumNext:
-                  name = "enum.next";
-                  break;
-                case BuiltinMethodKind::kEnumPrev:
-                  name = "enum.prev";
-                  break;
-                case BuiltinMethodKind::kEnumName:
-                  name = "enum.name";
-                  break;
-              }
-              return std::format("BuiltinMethod \"{}\"", name);
+            [this](const MethodRef& m) -> std::string {
+              const auto& method =
+                  unit_->GetType(m.receiver_type).GetMethod(m.method);
+              return std::format(
+                  "Method[{}] \"{}\" on Type[{}]", m.method.value, method.name,
+                  m.receiver_type.value);
             },
         },
         callee);
@@ -567,6 +556,7 @@ class HirDumper {
   }
 
   void DumpUnit(const ModuleUnit& u) {
+    unit_ = &u;
     Line(std::format("ModuleUnit \"{}\"", u.name));
     Indent();
 
@@ -1002,6 +992,7 @@ class HirDumper {
   std::string out_;
   int indent_ = 0;
   std::vector<const StructuralScope*> scope_stack_;
+  const ModuleUnit* unit_ = nullptr;
 };
 
 }  // namespace

--- a/src/lyra/hir/type.cpp
+++ b/src/lyra/hir/type.cpp
@@ -1,11 +1,16 @@
 #include "lyra/hir/type.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
+#include <optional>
+#include <span>
+#include <string_view>
 #include <variant>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
+#include "lyra/hir/method.hpp"
 
 namespace lyra::hir {
 
@@ -91,6 +96,36 @@ auto Type::AsEnum() const -> const EnumType& {
     return *e;
   }
   throw InternalError("Type::AsEnum called on non-enum type");
+}
+
+auto Type::GetMethods() const -> std::span<const Method> {
+  return std::visit(
+      Overloaded{
+          [](const EnumType& e) -> std::span<const Method> {
+            return e.methods;
+          },
+          [](const auto&) -> std::span<const Method> { return {}; },
+      },
+      data);
+}
+
+auto Type::GetMethod(MethodId id) const -> const Method& {
+  const auto methods = GetMethods();
+  if (id.value >= methods.size()) {
+    throw InternalError("Type::GetMethod: MethodId out of range");
+  }
+  return methods[id.value];
+}
+
+auto Type::LookupMethod(std::string_view name) const
+    -> std::optional<MethodId> {
+  const auto methods = GetMethods();
+  for (std::size_t i = 0; i < methods.size(); ++i) {
+    if (methods[i].name == name) {
+      return MethodId{static_cast<std::uint32_t>(i)};
+    }
+  }
+  return std::nullopt;
 }
 
 }  // namespace lyra::hir

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -143,17 +143,6 @@ auto LowerBinaryOp(slang::ast::BinaryOperator op) -> hir::BinaryOp {
   throw InternalError("LowerBinaryOp: unknown slang BinaryOperator");
 }
 
-auto LowerEnumMethodName(std::string_view name)
-    -> std::optional<hir::BuiltinMethodKind> {
-  if (name == "first") return hir::BuiltinMethodKind::kEnumFirst;
-  if (name == "last") return hir::BuiltinMethodKind::kEnumLast;
-  if (name == "num") return hir::BuiltinMethodKind::kEnumNum;
-  if (name == "next") return hir::BuiltinMethodKind::kEnumNext;
-  if (name == "prev") return hir::BuiltinMethodKind::kEnumPrev;
-  if (name == "name") return hir::BuiltinMethodKind::kEnumName;
-  return std::nullopt;
-}
-
 auto LowerUnaryOp(slang::ast::UnaryOperator op, diag::SourceSpan span)
     -> diag::Result<hir::UnaryOp> {
   switch (op) {
@@ -590,11 +579,15 @@ auto LowerCallExprProc(
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
   std::vector<hir::ExprId> arg_ids;
   arg_ids.reserve(call.arguments().size());
-  for (const auto* arg : call.arguments()) {
+  std::optional<hir::TypeId> receiver_type;
+  for (std::size_t i = 0; i < call.arguments().size(); ++i) {
     auto arg_or = LowerProcExpr(
-        unit_facts, unit_state, proc_state, stack, *arg,
+        unit_facts, unit_state, proc_state, stack, *call.arguments()[i],
         compound_lvalue_context);
     if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+    if (i == 0) {
+      receiver_type = arg_or->type;
+    }
     arg_ids.push_back(proc_state.AddExpr(*std::move(arg_or)));
   }
 
@@ -603,21 +596,26 @@ auto LowerCallExprProc(
         std::get<slang::ast::CallExpression::SystemCallInfo>(call.subroutine);
     const std::string_view name = info.subroutine->name;
 
-    if (auto enum_method_kind = LowerEnumMethodName(name);
-        enum_method_kind.has_value() && !arg_ids.empty() &&
-        call.arguments()[0]->type->getCanonicalType().kind ==
-            slang::ast::SymbolKind::EnumType) {
-      auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return hir::Expr{
-          .type = *type_id,
-          .data =
-              hir::CallExpr{
-                  .callee = hir::BuiltinMethodRef{.kind = *enum_method_kind},
-                  .arguments = std::move(arg_ids),
-              },
-          .span = span,
-      };
+    if (receiver_type.has_value()) {
+      if (auto method_id =
+              unit_state.GetType(*receiver_type).LookupMethod(name);
+          method_id.has_value()) {
+        auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+        if (!type_id) return std::unexpected(std::move(type_id.error()));
+        return hir::Expr{
+            .type = *type_id,
+            .data =
+                hir::CallExpr{
+                    .callee =
+                        hir::MethodRef{
+                            .receiver_type = *receiver_type,
+                            .method = *method_id,
+                        },
+                    .arguments = std::move(arg_ids),
+                },
+            .span = span,
+        };
+      }
     }
 
     const auto* desc = support::FindSystemSubroutine(name);

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -1,7 +1,9 @@
 #include "lyra/lowering/ast_to_hir/type.hpp"
 
 #include <cstdint>
+#include <initializer_list>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -15,6 +17,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/integral_constant.hpp"
+#include "lyra/hir/method.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
@@ -139,9 +142,27 @@ auto LowerEnum(
             .value = LowerSVIntToIntegralConstant(cv.integer()),
         });
   }
+  std::vector<hir::Method> methods;
+  methods.reserve(6);
+  for (const auto [name, kind] : std::initializer_list<
+           std::pair<std::string_view, hir::BuiltinMethodKind>>{
+           {"first", hir::BuiltinMethodKind::kEnumFirst},
+           {"last", hir::BuiltinMethodKind::kEnumLast},
+           {"num", hir::BuiltinMethodKind::kEnumNum},
+           {"next", hir::BuiltinMethodKind::kEnumNext},
+           {"prev", hir::BuiltinMethodKind::kEnumPrev},
+           {"name", hir::BuiltinMethodKind::kEnumName},
+       }) {
+    methods.push_back(
+        hir::Method{
+            .name = std::string{name},
+            .data = hir::BuiltinMethod{.kind = kind},
+        });
+  }
   return hir::EnumType{
       .base_type = base_id,
       .members = std::move(members),
+      .methods = std::move(methods),
   };
 }
 

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -260,9 +260,8 @@ auto LowerHirIntegerLiteral(const hir::IntegerLiteral& i, mir::TypeId type)
 
 auto LowerBuiltinMethodCall(
     const UnitLoweringState& unit_state, const hir::Process& hir_process,
-    const hir::BuiltinMethodRef& callee,
-    const std::vector<hir::ExprId>& arguments, mir::TypeId result_type,
-    diag::SourceSpan span) -> diag::Result<mir::Expr> {
+    hir::BuiltinMethodKind kind, const std::vector<hir::ExprId>& arguments,
+    mir::TypeId result_type, diag::SourceSpan span) -> diag::Result<mir::Expr> {
   if (arguments.empty()) {
     throw InternalError(
         "LowerBuiltinMethodCall: built-in method call has no receiver");
@@ -276,14 +275,14 @@ auto LowerBuiltinMethodCall(
   }
   const auto& enum_type = receiver_type.AsEnum();
 
-  switch (callee.kind) {
+  switch (kind) {
     case hir::BuiltinMethodKind::kEnumFirst:
     case hir::BuiltinMethodKind::kEnumLast: {
       if (enum_type.members.empty()) {
         throw InternalError("LowerBuiltinMethodCall: enum has no members");
       }
       const hir::EnumMember& picked =
-          (callee.kind == hir::BuiltinMethodKind::kEnumFirst)
+          (kind == hir::BuiltinMethodKind::kEnumFirst)
               ? enum_type.members.front()
               : enum_type.members.back();
       return mir::Expr{
@@ -615,9 +614,26 @@ auto LowerHirCallExprProc(
                         .arguments = std::move(args)},
                 .type = result_type};
           },
-          [&](const hir::BuiltinMethodRef& bm) -> diag::Result<mir::Expr> {
-            return LowerBuiltinMethodCall(
-                unit_state, hir_process, bm, c.arguments, result_type, span);
+          [&](const hir::MethodRef& m) -> diag::Result<mir::Expr> {
+            const auto& method =
+                unit_state.GetHirType(m.receiver_type).GetMethod(m.method);
+            return std::visit(
+                Overloaded{
+                    [&](const hir::BuiltinMethod& b)
+                        -> diag::Result<mir::Expr> {
+                      return LowerBuiltinMethodCall(
+                          unit_state, hir_process, b.kind, c.arguments,
+                          result_type, span);
+                    },
+                    [&](const hir::StructuralMethod&)
+                        -> diag::Result<mir::Expr> {
+                      throw InternalError(
+                          "MethodRef -> StructuralMethod lowering: "
+                          "user-defined methods are not yet wired into HIR/MIR "
+                          "call dispatch");
+                    },
+                },
+                method.data);
           },
       },
       c.callee);


### PR DESCRIPTION
## Summary

Replaces the enum-specific `hir::BuiltinMethodRef` with a generic "types own method tables" mechanism. Every `hir::Type` exposes `GetMethods()` / `GetMethod(MethodId)` / `LookupMethod(name)`; call dispatch goes through a uniform `hir::MethodRef{receiver_type, method_id}` variant alternative of `SubroutineRef`. Enum types populate six `BuiltinMethod` entries at AST -> HIR construction; AST -> HIR call dispatch is no longer enum-aware.

## Design

`hir::Method` is the table entry, with `MethodData = variant<StructuralMethod, BuiltinMethod>` -- the former for future user-defined class methods (currently no producer; HIR -> MIR throws `InternalError` if reached), the latter for LRM intrinsics. This is the path the future `string` / `queue` builtins and user class methods will share; only the variant alternative differs.

Headers split: `TypeId` lives in a new `type_id.hpp`, `StructuralSubroutineId` in `subroutine_id.hpp`. This breaks the cycle that would otherwise arise once `type.hpp` includes `method.hpp` (`EnumType.methods` requires `Method` to be complete).

`docs/progress/datatypes.md` reflects the new shape and drops the false dependency of E3 (`name()`) on the string workstream -- it folds via existing `ConditionalExpr` + `StringLiteral` primitives.

## Testing

- `bazel test //...` -- all green
- HIR dump verified on playground enum: `Enum(... methods=[first, last, num, next, prev, name])`, call site shows `Method[N] "<name>" on Type[T]`
- clang-format, prettier, buildifier, and all four `tools/policy/check_*.py` checks pass