### PR TITLE
Add always and always_ff process support

### DIFF
--- a/include/lyra/mir/process.hpp
+++ b/include/lyra/mir/process.hpp
@@ -16,10 +16,6 @@ struct ProcessId {
 enum class ProcessKind : std::uint8_t {
   kInitial,
   kFinal,
-  kAlways,
-  kAlwaysComb,
-  kAlwaysLatch,
-  kAlwaysFf,
 };
 
 struct Process {

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -131,18 +131,10 @@ struct BreakStmt {};
 
 struct ContinueStmt {};
 
-enum class AwaitKind : std::uint8_t {
-  kAlwaysBackedge,
-};
-
-struct AwaitStmt {
-  AwaitKind kind;
-};
-
 using StmtData = std::variant<
     EmptyStmt, ProceduralVarDeclStmt, ExprStmt, BlockStmt, IfStmt,
     ConstructOwnedObjectStmt, ForStmt, TimedStmt, WhileStmt, DoWhileStmt,
-    BreakStmt, ContinueStmt, AwaitStmt>;
+    BreakStmt, ContinueStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/include/lyra/runtime/process_kind.hpp
+++ b/include/lyra/runtime/process_kind.hpp
@@ -4,9 +4,6 @@ namespace lyra::runtime {
 
 enum class ProcessKind {
   kInitial,
-  kAlways,
-  kAlwaysComb,
-  kAlwaysFf,
   kFinal,
 };
 

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -96,12 +96,6 @@ auto RenderProcessMethod(
     const RenderContext* parent_struct_ctx, const mir::CompilationUnit& unit,
     const mir::StructuralScope& s, const mir::Process& process,
     std::size_t index, std::size_t indent) -> diag::Result<std::string> {
-  if (process.kind != mir::ProcessKind::kInitial &&
-      process.kind != mir::ProcessKind::kFinal) {
-    throw InternalError(
-        "RenderProcessMethod: C++ emit is not yet supported for this process "
-        "kind");
-  }
   std::string out;
   out += Indent(indent) + "auto " + RenderProcessMethodName(index) +
          "() -> lyra::runtime::ProcessCoroutine {\n";
@@ -124,13 +118,6 @@ auto RenderProcessKindLiteral(mir::ProcessKind kind) -> std::string {
       return "lyra::runtime::ProcessKind::kInitial";
     case mir::ProcessKind::kFinal:
       return "lyra::runtime::ProcessKind::kFinal";
-    case mir::ProcessKind::kAlways:
-    case mir::ProcessKind::kAlwaysComb:
-    case mir::ProcessKind::kAlwaysLatch:
-    case mir::ProcessKind::kAlwaysFf:
-      throw InternalError(
-          "RenderProcessKindLiteral: C++ emit is not yet supported for this "
-          "process kind");
   }
   throw InternalError("RenderProcessKindLiteral: unknown ProcessKind");
 }

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -317,10 +317,6 @@ auto RenderStmt(
           [&](const mir::ContinueStmt&) -> diag::Result<std::string> {
             return Indent(indent) + "continue;\n";
           },
-          [&](const mir::AwaitStmt&) -> diag::Result<std::string> {
-            throw InternalError(
-                "RenderStmt: AwaitStmt is not yet supported by C++ emit");
-          },
       },
       stmt.data);
   if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));

--- a/src/lyra/lowering/hir_to_mir/lower_process.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_process.cpp
@@ -13,62 +13,12 @@
 #include "lyra/lowering/hir_to_mir/lower_stmt.hpp"
 #include "lyra/lowering/hir_to_mir/procedural_scope_helpers.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
-#include "lyra/mir/expr.hpp"
-#include "lyra/mir/integral_constant.hpp"
 #include "lyra/mir/process.hpp"
 #include "lyra/mir/stmt.hpp"
-#include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
 namespace {
-
-auto LowerProcessKind(hir::ProcessKind hir_kind, diag::SourceSpan span)
-    -> diag::Result<mir::ProcessKind> {
-  switch (hir_kind) {
-    case hir::ProcessKind::kInitial:
-      return mir::ProcessKind::kInitial;
-    case hir::ProcessKind::kAlways:
-      return mir::ProcessKind::kAlways;
-    case hir::ProcessKind::kFinal:
-      return mir::ProcessKind::kFinal;
-    case hir::ProcessKind::kAlwaysComb:
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedProcessKindLowering,
-          "`always_comb` processes are not yet supported",
-          diag::UnsupportedCategory::kFeature);
-    case hir::ProcessKind::kAlwaysLatch:
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedProcessKindLowering,
-          "`always_latch` processes are not yet supported",
-          diag::UnsupportedCategory::kFeature);
-    case hir::ProcessKind::kAlwaysFf:
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedProcessKindLowering,
-          "`always_ff` processes are not yet supported",
-          diag::UnsupportedCategory::kFeature);
-  }
-  throw InternalError("LowerProcessKind: unknown HIR ProcessKind");
-}
-
-auto MakeTrueConditionExpr(
-    ProceduralScopeLoweringState& proc_scope_state, mir::TypeId bit1)
-    -> mir::ExprId {
-  return proc_scope_state.AddExpr(
-      mir::Expr{
-          .data =
-              mir::IntegerLiteral{
-                  .value =
-                      mir::IntegralConstant{
-                          .value_words = {1ULL},
-                          .state_words = {},
-                          .width = 1,
-                          .signedness = mir::Signedness::kUnsigned,
-                          .state_kind = mir::IntegralStateKind::kTwoState,
-                      }},
-          .type = bit1,
-      });
-}
 
 auto LowerStraightLineProcess(
     const UnitLoweringState& unit_state,
@@ -90,38 +40,34 @@ auto LowerAlwaysProcess(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state, const hir::Process& src,
     ProcessLoweringState& proc_state) -> diag::Result<mir::Process> {
-  ProceduralScopeLoweringState while_scope_state;
+  ProceduralScopeLoweringState body_scope_state;
   {
     ProceduralDepthGuard guard{proc_state};
     auto lowered = LowerStmt(
-        unit_state, scope_state, proc_state, while_scope_state, src,
+        unit_state, scope_state, proc_state, body_scope_state, src,
         src.stmts.at(src.root_stmt.value));
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    const mir::StmtId source_id =
-        while_scope_state.AddStmt(*std::move(lowered));
-    while_scope_state.AddRootStmt(source_id);
-    const mir::StmtId await_id = while_scope_state.AddStmt(
-        mir::Stmt{
-            .label = std::nullopt,
-            .data = mir::AwaitStmt{.kind = mir::AwaitKind::kAlwaysBackedge},
-            .child_procedural_scopes = {}});
-    while_scope_state.AddRootStmt(await_id);
+    const mir::StmtId body_id = body_scope_state.AddStmt(*std::move(lowered));
+    body_scope_state.AddRootStmt(body_id);
   }
 
   ProceduralScopeLoweringState process_scope_state;
-  const mir::ExprId cond_id =
-      MakeTrueConditionExpr(process_scope_state, unit_state.Builtins().bit1);
   std::vector<mir::ProceduralScope> child_scopes;
-  const mir::ProceduralScopeId while_scope_id =
-      AddChildProceduralScope(child_scopes, while_scope_state.Finish());
-  const mir::StmtId while_stmt_id = process_scope_state.AddStmt(
+  const mir::ProceduralScopeId body_scope_id =
+      AddChildProceduralScope(child_scopes, body_scope_state.Finish());
+  const mir::StmtId for_stmt_id = process_scope_state.AddStmt(
       mir::Stmt{
           .label = std::nullopt,
-          .data = mir::WhileStmt{.condition = cond_id, .scope = while_scope_id},
+          .data =
+              mir::ForStmt{
+                  .init = {},
+                  .condition = std::nullopt,
+                  .step = {},
+                  .scope = body_scope_id},
           .child_procedural_scopes = std::move(child_scopes)});
-  process_scope_state.AddRootStmt(while_stmt_id);
+  process_scope_state.AddRootStmt(for_stmt_id);
   return mir::Process{
-      .kind = mir::ProcessKind::kAlways,
+      .kind = mir::ProcessKind::kInitial,
       .root_procedural_scope = process_scope_state.Finish()};
 }
 
@@ -131,16 +77,29 @@ auto LowerProcess(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state, const hir::Process& src,
     TimeResolution time_resolution) -> diag::Result<mir::Process> {
-  auto kind_or = LowerProcessKind(src.kind, src.span);
-  if (!kind_or) return std::unexpected(std::move(kind_or.error()));
-
   ProcessLoweringState proc_state{time_resolution};
-  if (*kind_or == mir::ProcessKind::kInitial ||
-      *kind_or == mir::ProcessKind::kFinal) {
-    return LowerStraightLineProcess(
-        unit_state, scope_state, src, proc_state, *kind_or);
+  switch (src.kind) {
+    case hir::ProcessKind::kInitial:
+      return LowerStraightLineProcess(
+          unit_state, scope_state, src, proc_state, mir::ProcessKind::kInitial);
+    case hir::ProcessKind::kFinal:
+      return LowerStraightLineProcess(
+          unit_state, scope_state, src, proc_state, mir::ProcessKind::kFinal);
+    case hir::ProcessKind::kAlways:
+    case hir::ProcessKind::kAlwaysFf:
+      return LowerAlwaysProcess(unit_state, scope_state, src, proc_state);
+    case hir::ProcessKind::kAlwaysComb:
+      return diag::Unsupported(
+          src.span, diag::DiagCode::kUnsupportedProcessKindLowering,
+          "`always_comb` processes are not yet supported",
+          diag::UnsupportedCategory::kFeature);
+    case hir::ProcessKind::kAlwaysLatch:
+      return diag::Unsupported(
+          src.span, diag::DiagCode::kUnsupportedProcessKindLowering,
+          "`always_latch` processes are not yet supported",
+          diag::UnsupportedCategory::kFeature);
   }
-  return LowerAlwaysProcess(unit_state, scope_state, src, proc_state);
+  throw InternalError("LowerProcess: unknown HIR ProcessKind");
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -508,24 +508,8 @@ class MirDumper {
         return "Initial";
       case ProcessKind::kFinal:
         return "Final";
-      case ProcessKind::kAlways:
-        return "Always";
-      case ProcessKind::kAlwaysComb:
-        return "AlwaysComb";
-      case ProcessKind::kAlwaysLatch:
-        return "AlwaysLatch";
-      case ProcessKind::kAlwaysFf:
-        return "AlwaysFf";
     }
     throw InternalError("MirDumper: unknown ProcessKind");
-  }
-
-  static auto FormatAwaitKind(AwaitKind k) -> std::string_view {
-    switch (k) {
-      case AwaitKind::kAlwaysBackedge:
-        return "AlwaysBackedge";
-    }
-    throw InternalError("MirDumper: unknown AwaitKind");
   }
 
   void DumpStructuralScope(const StructuralScope& s) {
@@ -730,12 +714,6 @@ class MirDumper {
             },
             [&](const ContinueStmt&) {
               Line(std::format("Stmt[{}] ContinueStmt", id.value));
-            },
-            [&](const AwaitStmt& s) {
-              Line(
-                  std::format(
-                      "Stmt[{}] AwaitStmt kind={}", id.value,
-                      FormatAwaitKind(s.kind)));
             },
         },
         stmt.data);

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -94,10 +94,6 @@ void Engine::RegisterProcesses() {
         case ProcessKind::kFinal:
           queues_.finals.push_back(&process);
           break;
-        case ProcessKind::kAlways:
-        case ProcessKind::kAlwaysComb:
-        case ProcessKind::kAlwaysFf:
-          throw InternalError("Engine::Run: ProcessKind is not yet supported");
       }
     });
   });

--- a/tests/cases/cpp/always_basic_loop/case.yaml
+++ b/tests/cases/cpp/always_basic_loop/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.always_basic_loop
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    iters: 3

--- a/tests/cases/cpp/always_basic_loop/main.sv
+++ b/tests/cases/cpp/always_basic_loop/main.sv
@@ -1,0 +1,21 @@
+module Top;
+  bit clk;
+  int iters;
+
+  initial begin
+    clk = 0;
+    iters = 0;
+  end
+
+  always @(posedge clk) begin
+    iters = iters + 1;
+    if (iters == 3) $finish;
+  end
+
+  initial begin
+    #1; clk = 1; #1; clk = 0;
+    #1; clk = 1; #1; clk = 0;
+    #1; clk = 1; #1; clk = 0;
+    #1; clk = 1;
+  end
+endmodule

--- a/tests/cases/cpp/always_clock_generator/case.yaml
+++ b/tests/cases/cpp/always_clock_generator/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.always_clock_generator
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    edges: 4

--- a/tests/cases/cpp/always_clock_generator/main.sv
+++ b/tests/cases/cpp/always_clock_generator/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  bit clk;
+  int edges;
+
+  initial begin
+    clk = 0;
+    edges = 0;
+  end
+
+  always #5 clk = ~clk;
+
+  initial begin
+    repeat (4) @(posedge clk) edges = edges + 1;
+    $finish;
+  end
+endmodule

--- a/tests/cases/cpp/always_counter/case.yaml
+++ b/tests/cases/cpp/always_counter/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.always_counter
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    count: 5

--- a/tests/cases/cpp/always_counter/main.sv
+++ b/tests/cases/cpp/always_counter/main.sv
@@ -1,0 +1,19 @@
+module Top;
+  bit clk;
+  int count;
+
+  initial begin
+    clk = 0;
+    count = 0;
+  end
+
+  always @(posedge clk) count = count + 1;
+
+  initial begin
+    repeat (5) begin
+      #5 clk = 1;
+      #5 clk = 0;
+    end
+    $finish;
+  end
+endmodule

--- a/tests/cases/cpp/always_ff_async_reset/case.yaml
+++ b/tests/cases/cpp/always_ff_async_reset/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.always_ff_async_reset
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q: 3

--- a/tests/cases/cpp/always_ff_async_reset/main.sv
+++ b/tests/cases/cpp/always_ff_async_reset/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  bit clk;
+  bit rst_n;
+  int q;
+
+  always_ff @(posedge clk or negedge rst_n) begin
+    if (!rst_n) q <= 0;
+    else        q <= q + 1;
+  end
+
+  initial begin
+    clk = 0;
+    rst_n = 0;
+    #1 rst_n = 1;
+    #5 clk = 1; #5 clk = 0;
+    #5 clk = 1; #5 clk = 0;
+    #5 clk = 1; #5 clk = 0;
+    $finish;
+  end
+endmodule

--- a/tests/cases/cpp/always_ff_keyword_equivalent/case.yaml
+++ b/tests/cases/cpp/always_ff_keyword_equivalent/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.always_ff_keyword_equivalent
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a: 3
+    b: 3

--- a/tests/cases/cpp/always_ff_keyword_equivalent/main.sv
+++ b/tests/cases/cpp/always_ff_keyword_equivalent/main.sv
@@ -1,0 +1,18 @@
+module Top;
+  bit clk;
+  int a;
+  int b;
+
+  always    @(posedge clk) a <= a + 1;
+  always_ff @(posedge clk) b <= b + 1;
+
+  initial begin
+    clk = 0;
+    a = 0;
+    b = 0;
+    #5 clk = 1; #5 clk = 0;
+    #5 clk = 1; #5 clk = 0;
+    #5 clk = 1; #5 clk = 0;
+    $finish;
+  end
+endmodule

--- a/tests/cases/cpp/always_ff_pipeline/case.yaml
+++ b/tests/cases/cpp/always_ff_pipeline/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.always_ff_pipeline
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q1: 10
+    q2: 10

--- a/tests/cases/cpp/always_ff_pipeline/main.sv
+++ b/tests/cases/cpp/always_ff_pipeline/main.sv
@@ -1,0 +1,19 @@
+module Top;
+  bit clk;
+  int d;
+  int q1;
+  int q2;
+
+  always_ff @(posedge clk) begin
+    q1 <= d;
+    q2 <= q1;
+  end
+
+  initial begin
+    clk = 0;
+    d = 10;
+    #5 clk = 1; #5 clk = 0;
+    #5 clk = 1; #5 clk = 0;
+    $finish;
+  end
+endmodule

--- a/tests/cases/cpp/always_ff_register/case.yaml
+++ b/tests/cases/cpp/always_ff_register/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.always_ff_register
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q: 99

--- a/tests/cases/cpp/always_ff_register/main.sv
+++ b/tests/cases/cpp/always_ff_register/main.sv
@@ -1,0 +1,18 @@
+module Top;
+  bit clk;
+  int d;
+  int q;
+
+  always_ff @(posedge clk) q <= d;
+
+  initial begin
+    clk = 0;
+    d = 42;
+    #5 clk = 1;
+    #5 clk = 0;
+    d = 99;
+    #5 clk = 1;
+    #5 clk = 0;
+    $finish;
+  end
+endmodule

--- a/tests/cases/cpp/always_ff_register_enable/case.yaml
+++ b/tests/cases/cpp/always_ff_register_enable/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.always_ff_register_enable
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q: 99

--- a/tests/cases/cpp/always_ff_register_enable/main.sv
+++ b/tests/cases/cpp/always_ff_register_enable/main.sv
@@ -1,0 +1,26 @@
+module Top;
+  bit clk;
+  bit en;
+  int d;
+  int q;
+
+  always_ff @(posedge clk) begin
+    if (en) q <= d;
+  end
+
+  initial begin
+    clk = 0;
+    en = 1;
+    d = 42;
+    #5 clk = 1;
+    #5 clk = 0;
+    d = 99;
+    #5 clk = 1;
+    #5 clk = 0;
+    en = 0;
+    d = 7;
+    #5 clk = 1;
+    #5 clk = 0;
+    $finish;
+  end
+endmodule

--- a/tests/cases/cpp/always_negedge_register/case.yaml
+++ b/tests/cases/cpp/always_negedge_register/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.always_negedge_register
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q: 77

--- a/tests/cases/cpp/always_negedge_register/main.sv
+++ b/tests/cases/cpp/always_negedge_register/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  bit clk;
+  int d;
+  int q;
+
+  always_ff @(negedge clk) q <= d;
+
+  initial begin
+    clk = 1;
+    d = 11;
+    #5 clk = 0; #5 clk = 1;
+    d = 77;
+    #5 clk = 0; #5 clk = 1;
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds support for `always` and `always_ff` procedures by desugaring at HIR to MIR. The body is wrapped in `ForStmt(empty, nullopt, empty, body)` (the same shape that `forever {...}` already lowers to), so the resulting MIR is a regular `kInitial`-scheduled process whose body happens to contain an infinite loop. The runtime sees no new construct; `Engine::RegisterProcesses` no longer throws for `always`.

## Design

`mir::ProcessKind` collapses from six variants to `{kInitial, kFinal}`. At MIR the only surviving distinction is scheduling lifecycle (sim-start vs sim-end), since all four `always*` flavors and `initial` share the same scheduling slot. The `always_ff` lint constraints (exactly one event control, no blocking timing controls per LRM 9.2.2.4) are HIR concerns and are not encoded structurally at MIR. `runtime::ProcessKind` follows the same collapse for symmetry with the queue model. The unused `mir::AwaitStmt` / `kAlwaysBackedge` placeholder is removed; the new lowering has no need for an explicit backedge marker since the for-loop already expresses re-entry and the engine's settle limit catches no-timing-control deadlocks (LRM 9.2.2.1).

`always_comb` and `always_latch` still emit `kUnsupportedProcessKindLowering`. They require read-set sensitivity inference at HIR to MIR (insert an explicit `EventControlStmt` around the body) and are deferred to a follow-up.

## Testing

Nine end-to-end cases under `tests/cases/cpp/always_*` cover the re-entry primitive: basic loop iteration, clock generator (`always #5 clk = ~clk`), counter increment, `always_ff` register, register with enable, async reset (`@(posedge clk or negedge rst_n)`), two-stage NBA pipeline, negedge-triggered register, and `always` vs `always_ff` equivalence. The existing `process_kind_unsupported` error test continues to cover `always_comb`.