### PR TITLE
Add bit-select read and lock down selector HIR shape

### DIFF
--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -1,9 +1,10 @@
 # Operators
 
 Tracks the operator surface that does not live in `integral.md`: set membership, wildcard / case
-equality, selectors (bit, range, indexed part-select) on both read and write sides, concatenation,
-replication, compound assignment, and the `++` / `--` family. Each archive item checkbox in
-`architecture-reset.md` is checked when its `*.yaml` cases reproduce on the current pipeline.
+equality, selectors (bit-select, non-indexed and indexed part-select) on both read and write sides,
+concatenation, replication, compound assignment, and the `++` / `--` family. Each archive item
+checkbox in `architecture-reset.md` is checked when its `*.yaml` cases reproduce on the current
+pipeline.
 
 Done when:
 
@@ -49,24 +50,176 @@ landed. Where a cut is independent the text says so.
 
 ### Selectors
 
-- [ ] W4 -- Bit-select read `v[idx]`. Introduce `hir::SelectExpr` / `mir::SelectExpr` whose payload
-      is a `Selector` variant. The variant arms are `kBit(index)`, `kRange(hi, lo)`,
-      `kIndexedAsc(base, width)`, and `kIndexedDesc(base, width)`; this cut wires only the `kBit`
-      arm end-to-end. Add `PackedArray::BitSelect(idx)` returning a 1-bit `PackedArray`.
-      Out-of-bounds or X / Z index yields `1'bx` (4-state) or `1'b0` (2-state) per LRM 11.5.1.
+LRM distinguishes two syntactically distinct selector operators with overlapping but **not
+identical** operand domains. HIR mirrors that distinction with **two separate expression variants**,
+not one merged node.
 
-- [ ] W5 -- Range-select read `v[hi:lo]`. Wire the `kRange` arm; both bounds must be constants. Add
-      `PackedArray::RangeSelect(hi, lo)` returning a `(hi - lo + 1)`-bit `PackedArray`.
-      Partially-out-of-range slices return X for the out-of-range bits when reading (LRM 11.5.1).
+**Element-select** `expr[idx]` -- single-bracket index. LRM names the result by operand type:
+"bit-select" on a 1D packed integral (1 bit, LRM 11.5.1); "single element" on multi-dim packed /
+unpacked / dynamic / queue arrays (LRM 7.4.5); byte on string (LRM 6.16); key-indexed element on
+associative arrays (LRM 7.8).
 
-- [ ] W6 -- Indexed part-select read `v[i+:w]` / `v[i-:w]`. Wire the `kIndexedAsc` and
-      `kIndexedDesc` arms; `width` is a constant positive integer, `base` is a runtime expression.
-      Add `PackedArray::IndexedPartSelect(base, width, direction)`. Out-of-range and X / Z base
-      follow the same LRM 11.5.1 rules as W4 / W5.
+**Range-select** `expr[hi:lo]` / `expr[base +: w]` / `expr[base -: w]`. LRM names the result
+"part-select" when the operand is a 1D packed array (bit-level, LRM 11.5.1) and "slice" when the
+operand is multi-dim packed / unpacked / dynamic / queue (element-level, LRM 7.4.5).
 
-- [ ] W7 -- Selector lvalue (write side). Extend HIR / MIR `Lvalue` from a bare `*Ref` variant to a
-      record carrying a root `*Ref` plus an optional `Selector` (multi-layer selectors are
-      `packed.md`). Add `PackedArray::WriteBit`, `WriteRange`, `WriteIndexedPartSelect`. Closes
+LRM operand-domain validity:
+
+| Operand type                            | element-select       | range-select                                   |
+| --------------------------------------- | -------------------- | ---------------------------------------------- |
+| 1D packed integral (vector)             | bit-select (1 bit)   | part-select (multi-bit)                        |
+| multi-dim packed, packed struct / union | element (sub-vector) | slice / part-select                            |
+| unpacked array, dynamic array, queue    | element              | slice                                          |
+| **associative array**                   | element (key-typed)  | **illegal** (LRM 7.4.6)                        |
+| **string**                              | byte (LRM 6.16)      | **illegal** (LRM 6.16 lists only `Str[index]`) |
+| real / shortreal                        | illegal (LRM 6.12)   | illegal (LRM 6.12)                             |
+| scalar `reg` / `logic` / `bit`          | illegal (LRM 11.5.1) | illegal (LRM 11.5.1)                           |
+
+The asymmetry on associative arrays and strings (element-select valid, range-select not) is the
+reason for two HIR nodes rather than one merged variant. A single merged node would force every
+visitor that touches selectors to carry a cross-cutting validity check ("this arm is only legal on
+these operand types"). Two nodes keep name and validity domain in lockstep, and W7's lvalue-side
+extensions can be expressed without arm-by-arm guards.
+
+HIR shapes (locked):
+
+```
+struct ElementSelectExpr {                       // expr[idx]
+  ExprId base_value;
+  ExprId index;
+};
+
+struct RangeConstantBounds    { ExprId msb_expr;   ExprId lsb_expr; };  // expr[hi:lo]
+struct RangeIndexedUpBounds   { ExprId base_index; ExprId width;    };  // expr[base +: w]
+struct RangeIndexedDownBounds { ExprId base_index; ExprId width;    };  // expr[base -: w]
+using RangeBounds = std::variant<
+    RangeConstantBounds, RangeIndexedUpBounds, RangeIndexedDownBounds>;
+
+struct RangeSelectExpr {
+  ExprId base_value;
+  RangeBounds bounds;
+};
+```
+
+Bound payloads carry source-form `ExprId`s rather than pre-resolved storage bit positions; the
+constant-evaluation and direction-resolution happen at HIR -> MIR, where the operand's MIR type is
+in hand. HIR is locked in shape but not forced to be storage-normalized.
+
+Naming:
+
+- `ElementSelectExpr` matches slang's `ElementSelectExpression` and LRM 7.4.6 "element of the
+  array". **Not** "BitSelect": whether the result is 1 bit is operand-derived, not an operator
+  property.
+- `RangeSelectExpr` matches slang's `RangeSelectExpression`. LRM uses different result names
+  ("part-select" / "slice") per operand; the HIR node stays operand-neutral.
+
+#### MIR: per-operator variants per storage class
+
+MIR mirrors HIR's split, but variants are organized by **(operator x storage class)** pair so that
+each MIR shape maps to exactly one runtime emit. For packed storage the operator distinction is
+preserved at MIR even though the runtime call (`PackedArray::Select(off, w)`) happens to be the same
+for both operators -- this keeps the operator-level intent visible in MIR dumps and prevents
+asymmetry once non-packed storage classes arrive.
+
+```
+struct ElementSelectExpr {       // mir, packed-storage element-select (W4 wires this)
+  ExprId base_value;
+  ExprId index;                  // mirrors HIR; the operand was v[index] in source
+};
+
+// W5/W6 will add (operator-form bounds, mirroring HIR but with constants resolved
+// to storage bit positions / widths where LRM requires constant operands):
+struct RangeConstantBoundsMir   { int32_t msb_bit; int32_t lsb_bit; };  // direction-resolved
+struct RangeIndexedUpBoundsMir  { ExprId base_index; uint32_t width; };
+struct RangeIndexedDownBoundsMir{ ExprId base_index; uint32_t width; };
+using RangeBoundsMir = std::variant<
+    RangeConstantBoundsMir, RangeIndexedUpBoundsMir, RangeIndexedDownBoundsMir>;
+
+struct RangeSelectExpr {         // mir, packed-storage range-select
+  ExprId base_value;
+  RangeBoundsMir bounds;
+};
+```
+
+MIR carries source-form operands (just like `BinaryExpr` keeps `lhs` / `rhs` rather than a
+pre-evaluated result). The derivation to the runtime call `Select(bit_offset, width)` happens at the
+cpp render boundary:
+
+- `mir::ElementSelectExpr { base, index }` on a packed-integral operand whose element type is
+  `width` bits wide: render emits `(base).Select(index * width, width)`. For 1D bit-select
+  (`width == 1`) this collapses to `(base).Select(index, 1)`; multi-dim packed materializes the
+  multiplication.
+- `mir::RangeSelectExpr` with `RangeConstantBoundsMir { msb_bit, lsb_bit }`: render emits
+  `(base).Select(lsb_bit, msb_bit - lsb_bit + 1)`.
+- `mir::RangeSelectExpr` with `RangeIndexedUpBoundsMir { base_index, width }`: render emits
+  `(base).Select(base_index, width)`.
+- `mir::RangeSelectExpr` with `RangeIndexedDownBoundsMir { base_index, width }`: render emits
+  `(base).Select(base_index - width + 1, width)`.
+
+Future non-packed storage classes get their own MIR variants reflecting different runtime models
+(e.g. `mir::UnpackedElementLoad { array_base, element_index }` for unpacked element-select via
+pointer + load, `mir::UnpackedSlice { ... }` for unpacked range-select, `mir::AssociativeLookup` for
+associative element-select). The naming pattern is `<Operator><Adjective>Expr` where the adjective
+distinguishes runtime model when needed.
+
+Conversions at HIR -> MIR (1D packed integral operand):
+
+- `hir::ElementSelectExpr { base, index }` -> `mir::ElementSelectExpr { base, index }`. Pure
+  pass-through; no derived fields computed at this boundary.
+- `hir::RangeSelectExpr` with `RangeConstantBounds { msb_expr, lsb_expr }` -> evaluate the
+  constants, resolve the operand's declared range direction, produce
+  `RangeConstantBoundsMir { msb_bit, lsb_bit }` (storage positions, `msb_bit >= lsb_bit`).
+- `hir::RangeSelectExpr` with `RangeIndexedUpBounds { base_index, width_expr }` -> evaluate
+  `width_expr` to `uint32_t`, produce `RangeIndexedUpBoundsMir { base_index, width }`.
+- `hir::RangeSelectExpr` with `RangeIndexedDownBounds { base_index, width_expr }` -> evaluate
+  `width_expr`, produce `RangeIndexedDownBoundsMir { base_index, width }`.
+
+For multi-dim packed (future `packed.md` workstream), the same MIR variants are reused; the
+operand's element-type width is queried at render time.
+
+#### LRM 11.5.1 / 7.4.5 corner-case rules (runtime helper-side)
+
+- Any X / Z bit in a runtime `bit_offset` propagates: read result is all-X of `width` bits (4-state)
+  or all-0 (2-state).
+- Fully out-of-range read returns all-X / all-0.
+- Partially out-of-range read returns in-range bits verbatim and X / 0 for the OOB bits.
+- The result of any selector is **unsigned** regardless of operand signedness (LRM 11.8; slang
+  applies `makeUnsigned`); AST -> HIR records this on the `Expr.type`.
+- Bit-select / part-select of a scalar or real variable is illegal; slang rejects at AST
+  construction, so HIR never sees the shape.
+
+- [x] W4 -- Bit-select read `v[idx]` (scope: 1D integral operand; result is 1 bit per LRM 11.5.1).
+      Introduce **both** HIR variants -- `hir::ElementSelectExpr` and `hir::RangeSelectExpr` with
+      all three `RangeBounds` arms -- so the HIR shape is locked across W4..W7 and later cuts only
+      wire MIR paths. Wire `hir::ElementSelectExpr` end-to-end through `mir::ElementSelectExpr` and
+      `PackedArray::Select(bit_offset, width)` (single read helper, named after LRM's "vector
+      bit-select and part-select" verb, matching the existing verb-form API style: `CaseEqual`,
+      `WildcardEquals`, `LogicalShiftRight`). `hir::RangeSelectExpr` is reachable from AST -> HIR
+      but HIR -> MIR rejects with `kUnsupportedExpressionForm` until W5 / W6 add
+      `mir::RangeSelectExpr`. Implements LRM 7.4.5 / 11.5.1 OOB and X / Z propagation rules on the
+      runtime side.
+
+- [ ] W5 -- Non-indexed (constant) part-select read `v[msb:lsb]`. Add `mir::RangeSelectExpr` and
+      wire HIR -> MIR for `hir::RangeSelectExpr` carrying `RangeConstantBounds`. AST -> HIR routing
+      is already in W4; this cut evaluates the bound constants, resolves the operand's declared
+      range direction (LRM 11.5.1 `b_vect[0:7]` for `logic [0:31] b_vect` example), and emits
+      `mir::RangeSelectExpr` with `RangeConstantBoundsMir`. Runtime path reuses
+      `PackedArray::Select`.
+
+- [ ] W6 -- Indexed part-select read `v[base +: width]` / `v[base -: width]`. Wire HIR -> MIR for
+      `hir::RangeSelectExpr` carrying `RangeIndexedUpBounds` / `RangeIndexedDownBounds`. `width`
+      must be a strictly positive constant integer expression (LRM 11.5.1); zero or negative widths
+      are rejected at HIR -> MIR. cpp render derives `bit_offset = base_index - width + 1` for the
+      down form. Runtime path reuses `PackedArray::Select` -- X / Z propagation on `base_index` and
+      partial-OOB rules follow the W4 path automatically.
+
+- [ ] W7 -- Selector lvalue (write side). Extend HIR / MIR `Lvalue` to carry a root `*Ref` plus an
+      optional selector kind (Element or Range, mirroring the read-side shapes; multi-layer
+      selectors are `packed.md`). Add `PackedArray::AssignSelect(bit_offset, width, value)` -- the
+      single write helper, parallel to the existing `AssignFrom` partial-write convention. LRM
+      11.5.1 write rules: a fully-OOB write has **no effect** on the stored value (silent no-op, not
+      an error); a partially-OOB write affects **only the in-range bits**; an X / Z `bit_offset` is
+      treated as a fully-OOB write (no effect). Closes
       `datatypes/packed/indexed_part_select/default.yaml` for both read and write halves.
 
 ### Construction
@@ -102,9 +255,10 @@ landed. Where a cut is independent the text says so.
 
 ## Cross-references
 
-- LRM anchors: 11.4.5 (case equality), 11.4.6 (wildcard equality), 11.4.10 (shift), 11.4.12 /
-  11.4.12.1 (concatenation, replication), 11.4.13 (set membership), 11.5.1 (bit-select / part-select
-  / indexed part-select).
+- LRM anchors: 7.4.5 (indexing and slicing of arrays: vocabulary, invalid-index rules), 11.4.5 (case
+  equality), 11.4.6 (wildcard equality), 11.4.10 (shift), 11.4.12 / 11.4.12.1 (concatenation,
+  replication), 11.4.13 (set membership), 11.5.1 (bit-select / part-select / indexed part-select on
+  packed).
 - `integral.md` J14 archive sweep depends on W4..W6 for any binary / shift-overflow case that
   selects sub-bits before applying the operator.
 - `control-flow.md` C11 unblocked by W2; C12 unblocked by W1 (basic) and W2 (wildcard items).

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -65,9 +65,37 @@ struct InsideExpr {
   std::vector<InsideItem> items;
 };
 
+struct ElementSelectExpr {
+  ExprId base_value;
+  ExprId index;
+};
+
+struct RangeConstantBounds {
+  ExprId msb_expr;
+  ExprId lsb_expr;
+};
+
+struct RangeIndexedUpBounds {
+  ExprId base_index;
+  ExprId width;
+};
+
+struct RangeIndexedDownBounds {
+  ExprId base_index;
+  ExprId width;
+};
+
+using RangeBounds = std::variant<
+    RangeConstantBounds, RangeIndexedUpBounds, RangeIndexedDownBounds>;
+
+struct RangeSelectExpr {
+  ExprId base_value;
+  RangeBounds bounds;
+};
+
 using ExprData = std::variant<
     PrimaryExpr, UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr, CallExpr,
-    ConversionExpr, InsideExpr>;
+    ConversionExpr, InsideExpr, ElementSelectExpr, RangeSelectExpr>;
 
 struct Expr {
   TypeId type;

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -79,10 +79,16 @@ struct RuntimeCallExpr {
   RuntimeCall call;
 };
 
+struct ElementSelectExpr {
+  ExprId base_value;
+  ExprId index;
+};
+
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, StructuralParamRef,
     StructuralVarRef, ProceduralVarRef, UnaryExpr, BinaryExpr, ConditionalExpr,
-    AssignExpr, CallExpr, RuntimeCallExpr, ConversionExpr, ClosureExpr>;
+    AssignExpr, CallExpr, RuntimeCallExpr, ConversionExpr, ClosureExpr,
+    ElementSelectExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -139,6 +139,11 @@ class PackedArray {
   // LRM 11.4.6: X/Z in `other` are wildcards; X/Z in `*this` are not.
   [[nodiscard]] auto WildcardEquals(const PackedArray& other) const
       -> PackedArray;
+
+  // LRM 7.4.5 / 11.5.1: extract `width` LSB-anchored bits at `bit_offset`;
+  // invalid (x/z or out-of-range) index gives x (4-state) or 0 (2-state).
+  [[nodiscard]] auto Select(
+      const PackedArray& bit_offset, std::uint32_t width) const -> PackedArray;
   [[nodiscard]] auto operator<(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator<=(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator>(const PackedArray& other) const -> PackedArray;

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -409,6 +409,13 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
           [&](const mir::ClosureExpr& cl) -> diag::Result<std::string> {
             return RenderClosureExpr(ctx, cl);
           },
+          [&](const mir::ElementSelectExpr& sel) -> diag::Result<std::string> {
+            auto base_or = RenderExpr(ctx, ctx.Expr(sel.base_value));
+            if (!base_or) return std::unexpected(std::move(base_or.error()));
+            auto idx_or = RenderExpr(ctx, ctx.Expr(sel.index));
+            if (!idx_or) return std::unexpected(std::move(idx_or.error()));
+            return std::format("({}).Select({}, 1)", *base_or, *idx_or);
+          },
       },
       expr.data);
 }

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -549,6 +549,38 @@ class HirDumper {
             [](const InsideExpr& in) -> std::string {
               return FormatInsideExprNode(in);
             },
+            [](const ElementSelectExpr& sel) -> std::string {
+              return std::format(
+                  "ElementSelectExpr base=Expr[{}] index=Expr[{}]",
+                  sel.base_value.value, sel.index.value);
+            },
+            [](const RangeSelectExpr& sel) -> std::string {
+              return std::visit(
+                  Overloaded{
+                      [&](const RangeConstantBounds& b) -> std::string {
+                        return std::format(
+                            "RangeSelectExpr base=Expr[{}] kind=Constant "
+                            "msb=Expr[{}] lsb=Expr[{}]",
+                            sel.base_value.value, b.msb_expr.value,
+                            b.lsb_expr.value);
+                      },
+                      [&](const RangeIndexedUpBounds& b) -> std::string {
+                        return std::format(
+                            "RangeSelectExpr base=Expr[{}] kind=IndexedUp "
+                            "base_index=Expr[{}] width=Expr[{}]",
+                            sel.base_value.value, b.base_index.value,
+                            b.width.value);
+                      },
+                      [&](const RangeIndexedDownBounds& b) -> std::string {
+                        return std::format(
+                            "RangeSelectExpr base=Expr[{}] kind=IndexedDown "
+                            "base_index=Expr[{}] width=Expr[{}]",
+                            sel.base_value.value, b.base_index.value,
+                            b.width.value);
+                      },
+                  },
+                  sel.bounds);
+            },
         },
         e.data);
     return std::format("type=Type[{}] {}", e.type.value, formatted);

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -17,6 +17,7 @@
 #include <slang/ast/expressions/LiteralExpressions.h>
 #include <slang/ast/expressions/MiscExpressions.h>
 #include <slang/ast/expressions/OperatorExpressions.h>
+#include <slang/ast/expressions/SelectExpressions.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/AllTypes.h>
@@ -768,6 +769,99 @@ auto LowerInsideExprProc(
   };
 }
 
+auto LowerElementSelectExprProc(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const std::optional<hir::Lvalue>& compound_lvalue_context,
+    const slang::ast::ElementSelectExpression& sel,
+    const slang::ast::Expression& expr, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  if (!sel.value().type->isIntegral() || expr.type->getBitWidth() != 1) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "element-select is only supported on a 1D integral operand with a "
+        "1-bit result (bit-select)",
+        diag::UnsupportedCategory::kOperation);
+  }
+  auto base_or = LowerProcExpr(
+      unit_facts, unit_state, proc_state, stack, sel.value(),
+      compound_lvalue_context);
+  if (!base_or) return std::unexpected(std::move(base_or.error()));
+  const hir::ExprId base_id = proc_state.AddExpr(*std::move(base_or));
+
+  auto idx_or = LowerProcExpr(
+      unit_facts, unit_state, proc_state, stack, sel.selector(),
+      compound_lvalue_context);
+  if (!idx_or) return std::unexpected(std::move(idx_or.error()));
+  const hir::ExprId idx_id = proc_state.AddExpr(*std::move(idx_or));
+
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::Expr{
+      .type = *type_id,
+      .data =
+          hir::ElementSelectExpr{
+              .base_value = base_id,
+              .index = idx_id,
+          },
+      .span = span,
+  };
+}
+
+auto LowerRangeSelectExprProc(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const std::optional<hir::Lvalue>& compound_lvalue_context,
+    const slang::ast::RangeSelectExpression& sel,
+    const slang::ast::Expression& expr, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  auto base_or = LowerProcExpr(
+      unit_facts, unit_state, proc_state, stack, sel.value(),
+      compound_lvalue_context);
+  if (!base_or) return std::unexpected(std::move(base_or.error()));
+  const hir::ExprId base_id = proc_state.AddExpr(*std::move(base_or));
+
+  auto left_or = LowerProcExpr(
+      unit_facts, unit_state, proc_state, stack, sel.left(),
+      compound_lvalue_context);
+  if (!left_or) return std::unexpected(std::move(left_or.error()));
+  const hir::ExprId left_id = proc_state.AddExpr(*std::move(left_or));
+
+  auto right_or = LowerProcExpr(
+      unit_facts, unit_state, proc_state, stack, sel.right(),
+      compound_lvalue_context);
+  if (!right_or) return std::unexpected(std::move(right_or.error()));
+  const hir::ExprId right_id = proc_state.AddExpr(*std::move(right_or));
+
+  hir::RangeBounds bounds = [&]() -> hir::RangeBounds {
+    switch (sel.getSelectionKind()) {
+      case slang::ast::RangeSelectionKind::Simple:
+        return hir::RangeConstantBounds{
+            .msb_expr = left_id, .lsb_expr = right_id};
+      case slang::ast::RangeSelectionKind::IndexedUp:
+        return hir::RangeIndexedUpBounds{
+            .base_index = left_id, .width = right_id};
+      case slang::ast::RangeSelectionKind::IndexedDown:
+        return hir::RangeIndexedDownBounds{
+            .base_index = left_id, .width = right_id};
+    }
+    throw InternalError(
+        "LowerRangeSelectExprProc: unknown slang RangeSelectionKind");
+  }();
+
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::Expr{
+      .type = *type_id,
+      .data =
+          hir::RangeSelectExpr{
+              .base_value = base_id,
+              .bounds = std::move(bounds),
+          },
+      .span = span,
+  };
+}
+
 auto LowerConversionExprStructural(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ScopeLoweringState& scope_state, const ScopeStack& stack,
@@ -980,6 +1074,16 @@ auto LowerProcExpr(
       return LowerInsideExprProc(
           unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
           expr.as<slang::ast::InsideExpression>(), expr, span);
+
+    case slang::ast::ExpressionKind::ElementSelect:
+      return LowerElementSelectExprProc(
+          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          expr.as<slang::ast::ElementSelectExpression>(), expr, span);
+
+    case slang::ast::ExpressionKind::RangeSelect:
+      return LowerRangeSelectExprProc(
+          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          expr.as<slang::ast::RangeSelectExpression>(), expr, span);
 
     default:
       return diag::Unsupported(

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -759,6 +759,34 @@ auto LowerHirInsideExprProc(
       .type = result_type};
 }
 
+auto LowerHirElementSelectExprProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, const hir::ElementSelectExpr& sel,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  auto base_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(sel.base_value.value));
+  if (!base_or) return std::unexpected(std::move(base_or.error()));
+  const mir::ExprId base_id = proc_scope_state.AddExpr(*std::move(base_or));
+
+  auto idx_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(sel.index.value));
+  if (!idx_or) return std::unexpected(std::move(idx_or.error()));
+  const mir::ExprId idx_id = proc_scope_state.AddExpr(*std::move(idx_or));
+
+  return mir::Expr{
+      .data =
+          mir::ElementSelectExpr{
+              .base_value = base_id,
+              .index = idx_id,
+          },
+      .type = result_type};
+}
+
 }  // namespace
 
 auto LowerExpr(
@@ -809,6 +837,18 @@ auto LowerExpr(
             return LowerHirInsideExprProc(
                 unit_state, scope_state, proc_state, proc_scope_state,
                 hir_process, in, result_type);
+          },
+          [&](const hir::ElementSelectExpr& sel) -> diag::Result<mir::Expr> {
+            return LowerHirElementSelectExprProc(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, sel, result_type);
+          },
+          [](const hir::RangeSelectExpr&) -> diag::Result<mir::Expr> {
+            return diag::Unsupported(
+                diag::DiagCode::kUnsupportedExpressionForm,
+                "range-select (part-select / indexed part-select) is not yet "
+                "wired through HIR -> MIR",
+                diag::UnsupportedCategory::kOperation);
           },
       },
       expr.data);
@@ -976,6 +1016,19 @@ auto LowerExprImpl(
             return diag::Unsupported(
                 diag::DiagCode::kUnsupportedStructuralExpressionForm,
                 "inside operator is not allowed in constructor expressions",
+                diag::UnsupportedCategory::kFeature);
+          },
+          [](const hir::ElementSelectExpr&) -> diag::Result<mir::Expr> {
+            return diag::Unsupported(
+                diag::DiagCode::kUnsupportedStructuralExpressionForm,
+                "element-select in constructor expressions is not yet "
+                "supported",
+                diag::UnsupportedCategory::kFeature);
+          },
+          [](const hir::RangeSelectExpr&) -> diag::Result<mir::Expr> {
+            return diag::Unsupported(
+                diag::DiagCode::kUnsupportedStructuralExpressionForm,
+                "range-select in constructor expressions is not yet supported",
                 diag::UnsupportedCategory::kFeature);
           },
       },

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -493,6 +493,11 @@ class MirDumper {
             [](const ClosureExpr& cl) -> std::string {
               return std::format("ClosureExpr captures={}", cl.captures.size());
             },
+            [](const ElementSelectExpr& sel) -> std::string {
+              return std::format(
+                  "ElementSelectExpr base=Expr[{}] index=Expr[{}]",
+                  sel.base_value.value, sel.index.value);
+            },
         },
         e.data);
     return std::format("{} type=Type[{}]", formatted, e.type.value);

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -874,6 +874,51 @@ auto PackedArray::WildcardEquals(const PackedArray& other) const
   return OneBitResult(true, is_four_state_);
 }
 
+auto PackedArray::Select(
+    const PackedArray& bit_offset, std::uint32_t width) const -> PackedArray {
+  if (width == 0U) {
+    throw InternalError("PackedArray::Select: width must be >= 1");
+  }
+  if (bit_offset.HasUnknown() || bit_offset.BitWidth() > 64U) {
+    if (is_four_state_) {
+      return AllX(width, false);
+    }
+    return PackedArray{width, false, false};
+  }
+  const std::int64_t start = bit_offset.ToInt64();
+  const auto src_value = ValueWords();
+  const auto src_unknown = UnknownWords();
+  const auto bw_signed = static_cast<std::int64_t>(bit_width_);
+  auto val_buf = MakeWordBuffer(width);
+  auto unk_buf = is_four_state_ ? MakeWordBuffer(width) : WordBuffer{};
+  for (std::uint32_t i = 0; i < width; ++i) {
+    const std::int64_t pos = start + static_cast<std::int64_t>(i);
+    const std::uint64_t out_mask = std::uint64_t{1} << (i % 64U);
+    if (pos < 0 || pos >= bw_signed) {
+      if (is_four_state_) {
+        val_buf[i / 64U] |= out_mask;
+        unk_buf[i / 64U] |= out_mask;
+      }
+      continue;
+    }
+    const auto w_idx = static_cast<std::size_t>(pos / 64);
+    const auto b_idx = static_cast<std::uint64_t>(pos % 64);
+    if (((src_value[w_idx] >> b_idx) & 1U) != 0U) {
+      val_buf[i / 64U] |= out_mask;
+    }
+    if (is_four_state_ && w_idx < src_unknown.size() &&
+        ((src_unknown[w_idx] >> b_idx) & 1U) != 0U) {
+      unk_buf[i / 64U] |= out_mask;
+    }
+  }
+  return MakeFromWordPlanes(
+      width, false, is_four_state_,
+      std::span<const std::uint64_t>{val_buf.data(), val_buf.size()},
+      is_four_state_
+          ? std::span<const std::uint64_t>{unk_buf.data(), unk_buf.size()}
+          : std::span<const std::uint64_t>{});
+}
+
 auto PackedArray::operator<(const PackedArray& other) const -> PackedArray {
   ExpectSameShape(*this, other, "operator<");
   if (HasUnknown() || other.HasUnknown()) {

--- a/tests/cases/cpp/bit_select_const_idx/case.yaml
+++ b/tests/cases/cpp/bit_select_const_idx/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.bit_select_const_idx
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    bit0: 1
+    bit1: 0
+    bit2: 1
+    bit3: 1
+    bit7: 0

--- a/tests/cases/cpp/bit_select_const_idx/main.sv
+++ b/tests/cases/cpp/bit_select_const_idx/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  bit bit0;
+  bit bit1;
+  bit bit2;
+  bit bit3;
+  bit bit7;
+  initial begin
+    bit [7:0] data;
+    data = 8'b0000_1101;
+    bit0 = data[0];
+    bit1 = data[1];
+    bit2 = data[2];
+    bit3 = data[3];
+    bit7 = data[7];
+  end
+endmodule

--- a/tests/cases/cpp/bit_select_oob/case.yaml
+++ b/tests/cases/cpp/bit_select_oob/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.bit_select_oob
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    const_oob_2state: 0
+    runtime_oob_2state: 0
+    negative_idx_2state: 0

--- a/tests/cases/cpp/bit_select_oob/main.sv
+++ b/tests/cases/cpp/bit_select_oob/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  bit const_oob_2state;
+  bit runtime_oob_2state;
+  bit negative_idx_2state;
+  initial begin
+    bit [7:0] data;
+    int idx;
+    data = 8'b1111_1111;
+    const_oob_2state = data[8];
+    idx = 8; runtime_oob_2state = data[idx];
+    idx = -1; negative_idx_2state = data[idx];
+  end
+endmodule

--- a/tests/cases/cpp/bit_select_signed/case.yaml
+++ b/tests/cases/cpp/bit_select_signed/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.bit_select_signed
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    msb: 1
+    near_msb: 0
+    via_int: 1

--- a/tests/cases/cpp/bit_select_signed/main.sv
+++ b/tests/cases/cpp/bit_select_signed/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  bit msb;
+  bit near_msb;
+  int via_int;
+  initial begin
+    bit signed [7:0] s;
+    s = 8'sb1000_0001;
+    msb = s[7];
+    near_msb = s[6];
+    via_int = s[7];
+  end
+endmodule

--- a/tests/cases/cpp/bit_select_var_idx/case.yaml
+++ b/tests/cases/cpp/bit_select_var_idx/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.bit_select_var_idx
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    at0: 1
+    at1: 0
+    at2: 1
+    at3: 1

--- a/tests/cases/cpp/bit_select_var_idx/main.sv
+++ b/tests/cases/cpp/bit_select_var_idx/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  bit at0;
+  bit at1;
+  bit at2;
+  bit at3;
+  initial begin
+    bit [7:0] data;
+    int idx;
+    data = 8'b0000_1101;
+    idx = 0; at0 = data[idx];
+    idx = 1; at1 = data[idx];
+    idx = 2; at2 = data[idx];
+    idx = 3; at3 = data[idx];
+  end
+endmodule

--- a/tests/cases/cpp/bit_select_wide/case.yaml
+++ b/tests/cases/cpp/bit_select_wide/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.bit_select_wide
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    lo: 1
+    mid_low: 0
+    mid_high: 1
+    hi: 1

--- a/tests/cases/cpp/bit_select_wide/main.sv
+++ b/tests/cases/cpp/bit_select_wide/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  bit lo;
+  bit mid_low;
+  bit mid_high;
+  bit hi;
+  initial begin
+    bit [127:0] w;
+    w = 128'h8000_0000_0000_0001_0000_0000_0000_0001;
+    lo = w[0];
+    mid_low = w[63];
+    mid_high = w[64];
+    hi = w[127];
+  end
+endmodule

--- a/tests/cases/cpp/bit_select_x_index/case.yaml
+++ b/tests/cases/cpp/bit_select_x_index/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.bit_select_x_index
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    const_oob_4state: "1'bx"
+    x_index_4state: "1'bx"
+    z_index_4state: "1'bx"
+    inrange_known_idx: 1

--- a/tests/cases/cpp/bit_select_x_index/main.sv
+++ b/tests/cases/cpp/bit_select_x_index/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  logic const_oob_4state;
+  logic x_index_4state;
+  logic z_index_4state;
+  logic inrange_known_idx;
+  initial begin
+    logic [7:0] data;
+    integer idx;
+    data = 8'b1111_1111;
+    const_oob_4state = data[8];
+    idx = 'x; x_index_4state = data[idx];
+    idx = 'z; z_index_4state = data[idx];
+    idx = 3; inrange_known_idx = data[idx];
+  end
+endmodule


### PR DESCRIPTION
## Summary

Wires 1D bit-select (`v[idx]`) end-to-end through the cpp backend, and uses the cut to lock down the HIR shape for the full selector family so later work only extends MIR/render.

## Design

HIR carries two separate expression variants -- `ElementSelectExpr` for `v[idx]` and `RangeSelectExpr` for `v[hi:lo]` / `v[base +: w]` / `v[base -: w]` -- rather than one merged node. LRM (7.4.5 / 7.4.6 / 6.16 / 7.8) gives element-select a strictly wider operand domain than range-select: associative arrays and strings accept the former but not the latter. Merging would force every visitor that touches selectors to carry a cross-cutting validity guard; splitting keeps name and operand-domain in lockstep, and W7's lvalue side can extend cleanly.

Both HIR nodes carry source-form `ExprId` operands (no pre-resolved storage bit positions). MIR mirrors the split: `mir::ElementSelectExpr { base, index }` is the W4 wiring; `mir::RangeSelectExpr` will be added in W5/W6 with operator-form bounds. The derivation from operator-form operands to the runtime call `Select(bit_offset, width)` happens at cpp render, matching how other MIR nodes (`BinaryExpr`, `ConversionExpr`) preserve source-form rather than pre-computing target-level shapes. `mir::SelectExpr` (W4-only, packed-storage) was renamed to `mir::ElementSelectExpr` to make scope explicit; future non-packed storage classes get their own MIR variants (e.g. `mir::UnpackedElementLoad`).

`PackedArray::Select(bit_offset, width)` is the single read helper for the W4..W6 family. It encodes LRM 11.5.1 / 7.4.5 corner cases on the runtime side: X/Z in the runtime offset, fully and partially out-of-range reads, and the unsigned-result invariant.

## Testing

Six end-to-end YAML cases under `tests/cases/cpp/bit_select_*/` cover constant index, runtime variable index, signed operand (result unsigned), wide (128-bit, cross-word) operand, out-of-bounds (constant / runtime / negative), and X/Z runtime index on a 4-state operand. `bazel test //...` passes; `tools/policy/check_*.py` clean.