### PR TITLE
Bump slang dep to v11.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,10 +11,10 @@ module(
 bazel_dep(name = "rules_cc", version = "0.1.1")
 
 # Slang SystemVerilog Compiler Library
-bazel_dep(name = "slang", version = "10.0")
+bazel_dep(name = "slang", version = "11.0")
 git_override(
     module_name = "slang",
-    commit = "a254c3d32d7182adefb44bf5880414533a106e32",
+    commit = "9943dd2788f35d0abe25d1832acfba5151f7360d",
     remote = "https://github.com/hankhsu1996/slang.git",
 )
 


### PR DESCRIPTION
## Summary

Bumps the slang SystemVerilog frontend pin from a v10-era commit (`a254c3d3`) to a v11.0-based integration commit (`9943dd27`). The new base unlocks the `slang::analysis::AnalyzedProcedure::getSensitivityList()` API, which is needed by upcoming `always_comb` / `always_latch` work to inherit slang's LRM-faithful implicit sensitivity inference (including reads inside called functions) instead of maintaining a parallel visitor in Lyra.

## Design

The fork's `feature/lyra-integration` branch was rebased onto upstream `v11.0`. The two Lyra-specific patches that previously sat on top (DPI export accessor and bound control expression preservation) are already upstream in v11.0, so the new integration branch carries only the Bazel build patch. The Bazel `source/BUILD.bazel` `outs` list gains `slang/diagnostics/DriverDiags.h` to match v11's new `Driver` diagnostic subsystem.

## Testing

`bazel build //...` and `bazel test //... --test_output=errors` both green on the new pin.