### PR TITLE
Add range-select read and split runtime Select into Index/Slice

### DIFF
--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -51,17 +51,14 @@ landed. Where a cut is independent the text says so.
 ### Selectors
 
 LRM distinguishes two syntactically distinct selector operators with overlapping but **not
-identical** operand domains. HIR mirrors that distinction with **two separate expression variants**,
-not one merged node.
+identical** operand domains. HIR and MIR mirror that distinction with **two separate expression
+variants**, not one merged node.
 
-**Element-select** `expr[idx]` -- single-bracket index. LRM names the result by operand type:
-"bit-select" on a 1D packed integral (1 bit, LRM 11.5.1); "single element" on multi-dim packed /
-unpacked / dynamic / queue arrays (LRM 7.4.5); byte on string (LRM 6.16); key-indexed element on
-associative arrays (LRM 7.8).
+**Element-select** `expr[idx]` -- single-bracket index. LRM 7.4.5 names this "element" of the array;
+LRM 11.5.1 specializes it to "bit-select" when the operand is a 1D vector (result is 1 bit).
 
-**Range-select** `expr[hi:lo]` / `expr[base +: w]` / `expr[base -: w]`. LRM names the result
-"part-select" when the operand is a 1D packed array (bit-level, LRM 11.5.1) and "slice" when the
-operand is multi-dim packed / unpacked / dynamic / queue (element-level, LRM 7.4.5).
+**Range-select** `expr[hi:lo]` / `expr[base +: w]` / `expr[base -: w]`. LRM 7.4.5 names this "slice"
+of the array; LRM 11.5.1 specializes it to "part-select" when the operand is a 1D vector.
 
 LRM operand-domain validity:
 
@@ -76,12 +73,12 @@ LRM operand-domain validity:
 | scalar `reg` / `logic` / `bit`          | illegal (LRM 11.5.1) | illegal (LRM 11.5.1)                           |
 
 The asymmetry on associative arrays and strings (element-select valid, range-select not) is the
-reason for two HIR nodes rather than one merged variant. A single merged node would force every
+reason for two IR nodes rather than one merged variant. A single merged node would force every
 visitor that touches selectors to carry a cross-cutting validity check ("this arm is only legal on
 these operand types"). Two nodes keep name and validity domain in lockstep, and W7's lvalue-side
 extensions can be expressed without arm-by-arm guards.
 
-HIR shapes (locked):
+HIR shapes:
 
 ```
 struct ElementSelectExpr {                       // expr[idx]
@@ -101,126 +98,107 @@ struct RangeSelectExpr {
 };
 ```
 
-Bound payloads carry source-form `ExprId`s rather than pre-resolved storage bit positions; the
-constant-evaluation and direction-resolution happen at HIR -> MIR, where the operand's MIR type is
-in hand. HIR is locked in shape but not forced to be storage-normalized.
+MIR shape mirrors HIR 1:1. Each bounds field stays an `ExprId`, so HIR -> MIR is structurally a
+pass-through (recursively lower each `ExprId`, repack into the same variant arm). No constant
+evaluation or direction normalization happens at lowering -- slang has already validated the LRM
+contract during AST construction (constants are constant, indexed widths are positive, simple-form
+direction matches the operand's declared range; partial-OOB stays in the AST as a warning), and the
+result `Expr.type` carries the slice's width, so render can read it directly.
 
 Naming:
 
-- `ElementSelectExpr` matches slang's `ElementSelectExpression` and LRM 7.4.6 "element of the
-  array". **Not** "BitSelect": whether the result is 1 bit is operand-derived, not an operator
-  property.
-- `RangeSelectExpr` matches slang's `RangeSelectExpression`. LRM uses different result names
-  ("part-select" / "slice") per operand; the HIR node stays operand-neutral.
+- `ElementSelectExpr` / `RangeSelectExpr` match slang's `ElementSelectExpression` /
+  `RangeSelectExpression`. LRM 7.4.5 vocabulary aligns with slang on these names. **Not**
+  "BitSelect": whether the result is 1 bit is operand-derived, not an operator property.
 
-#### MIR: per-operator variants per storage class
+#### Runtime `PackedArray` API
 
-MIR mirrors HIR's split, but variants are organized by **(operator x storage class)** pair so that
-each MIR shape maps to exactly one runtime emit. For packed storage the operator distinction is
-preserved at MIR even though the runtime call (`PackedArray::Select(off, w)`) happens to be the same
-for both operators -- this keeps the operator-level intent visible in MIR dumps and prevents
-asymmetry once non-packed storage classes arrive.
+The runtime exposes two read-side methods, named after the LRM 7.4.5 vocabulary ("element" /
+"slice") in verb form for symmetry with the rest of CS practice (Python / NumPy / Rust):
 
 ```
-struct ElementSelectExpr {       // mir, packed-storage element-select (W4 wires this)
-  ExprId base_value;
-  ExprId index;                  // mirrors HIR; the operand was v[index] in source
-};
-
-// W5/W6 will add (operator-form bounds, mirroring HIR but with constants resolved
-// to storage bit positions / widths where LRM requires constant operands):
-struct RangeConstantBoundsMir   { int32_t msb_bit; int32_t lsb_bit; };  // direction-resolved
-struct RangeIndexedUpBoundsMir  { ExprId base_index; uint32_t width; };
-struct RangeIndexedDownBoundsMir{ ExprId base_index; uint32_t width; };
-using RangeBoundsMir = std::variant<
-    RangeConstantBoundsMir, RangeIndexedUpBoundsMir, RangeIndexedDownBoundsMir>;
-
-struct RangeSelectExpr {         // mir, packed-storage range-select
-  ExprId base_value;
-  RangeBoundsMir bounds;
-};
+auto Index(const PackedArray& index) const -> PackedArray;             // element-select (1 bit)
+auto Slice(const PackedArray& lsb_bit, std::uint32_t width) const -> PackedArray;  // range-select
 ```
 
-MIR carries source-form operands (just like `BinaryExpr` keeps `lhs` / `rhs` rather than a
-pre-evaluated result). The derivation to the runtime call `Select(bit_offset, width)` happens at the
-cpp render boundary:
+`Slice` codifies LRM 7.4.5's contract directly: "The size of the part-select or slice shall be
+constant, but the position can be variable" -- `width` is compile-time `uint32_t`, `lsb_bit` is a
+runtime `PackedArray` (so X / Z propagation falls out for free). The MSB position is implicit at
+`lsb_bit + width - 1`; we do not surface it as a separate parameter because the LRM size constraint
+makes it derivable.
 
-- `mir::ElementSelectExpr { base, index }` on a packed-integral operand whose element type is
-  `width` bits wide: render emits `(base).Select(index * width, width)`. For 1D bit-select
-  (`width == 1`) this collapses to `(base).Select(index, 1)`; multi-dim packed materializes the
-  multiplication.
-- `mir::RangeSelectExpr` with `RangeConstantBoundsMir { msb_bit, lsb_bit }`: render emits
-  `(base).Select(lsb_bit, msb_bit - lsb_bit + 1)`.
-- `mir::RangeSelectExpr` with `RangeIndexedUpBoundsMir { base_index, width }`: render emits
-  `(base).Select(base_index, width)`.
-- `mir::RangeSelectExpr` with `RangeIndexedDownBoundsMir { base_index, width }`: render emits
-  `(base).Select(base_index - width + 1, width)`.
+`Slice` operates on a **canonical LSB-anchored bit address space**, dimension-agnostic at the API
+boundary. Element-vs-bit accounting lives one layer up in the MIR type system, not in PackedArray.
+For 1D operands element width is 1 bit, so source-form indices coincide with bit positions and
+render passes them through verbatim. For future multi-dim packed operands (`bit [N:0][M:0] arr`
+etc.), LRM 7.4.5 says slice applies to one dimension and the other dimensions are preserved --
+element-level source-form positions must be multiplied by the inner element's bit width at render
+time before reaching `Slice`. W5 only wires 1D; the multi-dim extension is part of the `packed.md`
+workstream.
 
-Future non-packed storage classes get their own MIR variants reflecting different runtime models
-(e.g. `mir::UnpackedElementLoad { array_base, element_index }` for unpacked element-select via
-pointer + load, `mir::UnpackedSlice { ... }` for unpacked range-select, `mir::AssociativeLookup` for
-associative element-select). The naming pattern is `<Operator><Adjective>Expr` where the adjective
-distinguishes runtime model when needed.
+How `PackedArray` represents bits internally (flat word planes today; potentially sparse / pooled /
+chunked once optimization work begins) is an implementation detail that the `Index` / `Slice`
+contract is independent of. Both methods specify positions in the canonical bit address space and
+return a fresh `PackedArray` whose bits are the LRM-defined result; any future storage layout change
+must preserve this external contract.
 
-Conversions at HIR -> MIR (1D packed integral operand):
+`Index(idx)` is a convenience over `Slice(idx, 1)` for the 1-bit case, kept distinct so the call
+site preserves the LRM-level operator name (element-select vs slice).
 
-- `hir::ElementSelectExpr { base, index }` -> `mir::ElementSelectExpr { base, index }`. Pure
-  pass-through; no derived fields computed at this boundary.
-- `hir::RangeSelectExpr` with `RangeConstantBounds { msb_expr, lsb_expr }` -> evaluate the
-  constants, resolve the operand's declared range direction, produce
-  `RangeConstantBoundsMir { msb_bit, lsb_bit }` (storage positions, `msb_bit >= lsb_bit`).
-- `hir::RangeSelectExpr` with `RangeIndexedUpBounds { base_index, width_expr }` -> evaluate
-  `width_expr` to `uint32_t`, produce `RangeIndexedUpBoundsMir { base_index, width }`.
-- `hir::RangeSelectExpr` with `RangeIndexedDownBounds { base_index, width_expr }` -> evaluate
-  `width_expr`, produce `RangeIndexedDownBoundsMir { base_index, width }`.
+Both methods return a fresh `PackedArray` by value -- no views, consistent with every other
+`PackedArray` op. Result is unsigned regardless of operand signedness (LRM 11.8; slang applies
+`makeUnsigned` on the `Expr.type` we read).
 
-For multi-dim packed (future `packed.md` workstream), the same MIR variants are reused; the
-operand's element-type width is queried at render time.
+#### Render rules
 
-#### LRM 11.5.1 / 7.4.5 corner-case rules (runtime helper-side)
+Width comes from the slice expression's MIR result type (`unit.GetType(expr.type).BitWidth()`),
+which slang has already pinned at AST construction.
 
-- Any X / Z bit in a runtime `bit_offset` propagates: read result is all-X of `width` bits (4-state)
-  or all-0 (2-state).
+- `mir::ElementSelectExpr { base, index }` -> `(base).Index(<index rendered>)`.
+- `mir::RangeSelectExpr` with `RangeConstantBounds { msb_expr, lsb_expr }` ->
+  `(base).Slice(<lsb_expr rendered>, <width from result type>)`. `msb_expr` is preserved in MIR for
+  dump / debug symmetry with HIR; render does not consult it (the width via result type carries the
+  same information).
+- `mir::RangeSelectExpr` with `RangeIndexedUpBounds { base_index, width }` ->
+  `(base).Slice(<base_index rendered>, <width from result type>)`.
+- `mir::RangeSelectExpr` with `RangeIndexedDownBounds { base_index, width }` ->
+  `(base).Slice((<base_index rendered>) - PackedArray::FromInt(<width - 1>, <base_index shape>), <width from result type>)`.
+  The literal `width - 1` is constructed to match `base_index`'s PackedArray shape so the runtime
+  subtraction does not need cross-shape promotion.
+
+#### LRM 11.5.1 / 7.4.5 corner-case rules (handled inside `PackedArray::Slice`)
+
+- Any X / Z bit in the runtime `lsb_bit` propagates: result is all-X of `width` bits (4-state) or
+  all-0 (2-state).
 - Fully out-of-range read returns all-X / all-0.
 - Partially out-of-range read returns in-range bits verbatim and X / 0 for the OOB bits.
-- The result of any selector is **unsigned** regardless of operand signedness (LRM 11.8; slang
-  applies `makeUnsigned`); AST -> HIR records this on the `Expr.type`.
 - Bit-select / part-select of a scalar or real variable is illegal; slang rejects at AST
   construction, so HIR never sees the shape.
 
-- [x] W4 -- Bit-select read `v[idx]` (scope: 1D integral operand; result is 1 bit per LRM 11.5.1).
-      Introduce **both** HIR variants -- `hir::ElementSelectExpr` and `hir::RangeSelectExpr` with
-      all three `RangeBounds` arms -- so the HIR shape is locked across W4..W7 and later cuts only
-      wire MIR paths. Wire `hir::ElementSelectExpr` end-to-end through `mir::ElementSelectExpr` and
-      `PackedArray::Select(bit_offset, width)` (single read helper, named after LRM's "vector
-      bit-select and part-select" verb, matching the existing verb-form API style: `CaseEqual`,
-      `WildcardEquals`, `LogicalShiftRight`). `hir::RangeSelectExpr` is reachable from AST -> HIR
-      but HIR -> MIR rejects with `kUnsupportedExpressionForm` until W5 / W6 add
-      `mir::RangeSelectExpr`. Implements LRM 7.4.5 / 11.5.1 OOB and X / Z propagation rules on the
-      runtime side.
+- [x] W4 -- Element-select read `v[idx]` (scope: 1D integral operand; result is 1 bit per LRM
+      11.5.1). Wired end-to-end: `hir::ElementSelectExpr` -> `mir::ElementSelectExpr` ->
+      `PackedArray::Index(idx)`. HIR / MIR introduce all three `RangeBounds` arms at the same time
+      so the shape is locked across W4..W7; W5 wires `RangeSelectExpr` through HIR -> MIR and
+      render. Implements LRM 7.4.5 / 11.5.1 OOB and X / Z propagation rules on the runtime side
+      (`Slice` is the underlying helper; `Index(idx)` is `Slice(idx, 1)`).
 
-- [ ] W5 -- Non-indexed (constant) part-select read `v[msb:lsb]`. Add `mir::RangeSelectExpr` and
-      wire HIR -> MIR for `hir::RangeSelectExpr` carrying `RangeConstantBounds`. AST -> HIR routing
-      is already in W4; this cut evaluates the bound constants, resolves the operand's declared
-      range direction (LRM 11.5.1 `b_vect[0:7]` for `logic [0:31] b_vect` example), and emits
-      `mir::RangeSelectExpr` with `RangeConstantBoundsMir`. Runtime path reuses
-      `PackedArray::Select`.
+- [x] W5 -- Range-select read covering all three bounds forms: non-indexed constant `v[msb:lsb]`,
+      indexed-up `v[base +: w]`, indexed-down `v[base -: w]`. Wire `mir::RangeSelectExpr` mirroring
+      HIR (three `RangeBounds` variants, all `ExprId` fields). HIR -> MIR is a pure structural
+      pass-through. cpp render dispatches on the MIR bounds variant and emits
+      `(base).Slice(lsb_bit, width)`; for indexed-down it constructs the LSB position as
+      `base_index - PackedArray(width - 1)`. Runtime reuses `PackedArray::Slice`. Width at render
+      comes from the result type, not from any MIR-side constant extraction. Closes
+      `datatypes/packed/indexed_part_select/default.yaml` for the read half.
 
-- [ ] W6 -- Indexed part-select read `v[base +: width]` / `v[base -: width]`. Wire HIR -> MIR for
-      `hir::RangeSelectExpr` carrying `RangeIndexedUpBounds` / `RangeIndexedDownBounds`. `width`
-      must be a strictly positive constant integer expression (LRM 11.5.1); zero or negative widths
-      are rejected at HIR -> MIR. cpp render derives `bit_offset = base_index - width + 1` for the
-      down form. Runtime path reuses `PackedArray::Select` -- X / Z propagation on `base_index` and
-      partial-OOB rules follow the W4 path automatically.
-
-- [ ] W7 -- Selector lvalue (write side). Extend HIR / MIR `Lvalue` to carry a root `*Ref` plus an
+- [ ] W6 -- Selector lvalue (write side). Extend HIR / MIR `Lvalue` to carry a root `*Ref` plus an
       optional selector kind (Element or Range, mirroring the read-side shapes; multi-layer
-      selectors are `packed.md`). Add `PackedArray::AssignSelect(bit_offset, width, value)` -- the
-      single write helper, parallel to the existing `AssignFrom` partial-write convention. LRM
-      11.5.1 write rules: a fully-OOB write has **no effect** on the stored value (silent no-op, not
-      an error); a partially-OOB write affects **only the in-range bits**; an X / Z `bit_offset` is
-      treated as a fully-OOB write (no effect). Closes
-      `datatypes/packed/indexed_part_select/default.yaml` for both read and write halves.
+      selectors are `packed.md`). Add `PackedArray::AssignSlice(lsb_bit, width, value)` /
+      `PackedArray::AssignIndex(idx, value)` parallel to the existing `AssignFrom` partial-write
+      convention. LRM 11.5.1 write rules: a fully-OOB write has **no effect** on the stored value
+      (silent no-op, not an error); a partially-OOB write affects **only the in-range bits**; an X /
+      Z position is treated as a fully-OOB write (no effect). Closes
+      `datatypes/packed/indexed_part_select/default.yaml` for the write half.
 
 ### Construction
 

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -84,11 +84,34 @@ struct ElementSelectExpr {
   ExprId index;
 };
 
+struct RangeConstantBounds {
+  ExprId msb_expr;
+  ExprId lsb_expr;
+};
+
+struct RangeIndexedUpBounds {
+  ExprId base_index;
+  ExprId width;
+};
+
+struct RangeIndexedDownBounds {
+  ExprId base_index;
+  ExprId width;
+};
+
+using RangeBounds = std::variant<
+    RangeConstantBounds, RangeIndexedUpBounds, RangeIndexedDownBounds>;
+
+struct RangeSelectExpr {
+  ExprId base_value;
+  RangeBounds bounds;
+};
+
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, StructuralParamRef,
     StructuralVarRef, ProceduralVarRef, UnaryExpr, BinaryExpr, ConditionalExpr,
     AssignExpr, CallExpr, RuntimeCallExpr, ConversionExpr, ClosureExpr,
-    ElementSelectExpr>;
+    ElementSelectExpr, RangeSelectExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -140,10 +140,16 @@ class PackedArray {
   [[nodiscard]] auto WildcardEquals(const PackedArray& other) const
       -> PackedArray;
 
-  // LRM 7.4.5 / 11.5.1: extract `width` LSB-anchored bits at `bit_offset`;
-  // invalid (x/z or out-of-range) index gives x (4-state) or 0 (2-state).
-  [[nodiscard]] auto Select(
-      const PackedArray& bit_offset, std::uint32_t width) const -> PackedArray;
+  // LRM 11.5.1 bit-select: extract the bit at `index` as a 1-bit PackedArray.
+  // Invalid (x/z or out-of-range) index yields x (4-state) or 0 (2-state).
+  [[nodiscard]] auto Index(const PackedArray& index) const -> PackedArray;
+
+  // LRM 7.4.5 slice / 11.5.1 part-select: extract `width` contiguous bits whose
+  // LSB sits at `lsb_bit`. Per LRM 7.4.5 the size is constant (compile-time
+  // `width`) but the position may be runtime (`lsb_bit`). Bits outside the
+  // declared range yield x (4-state) or 0 (2-state).
+  [[nodiscard]] auto Slice(
+      const PackedArray& lsb_bit, std::uint32_t width) const -> PackedArray;
   [[nodiscard]] auto operator<(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator<=(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator>(const PackedArray& other) const -> PackedArray;

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -321,6 +321,70 @@ auto RenderAssignExprNode(const RenderContext& ctx, const mir::AssignExpr& a)
   return "(" + *target_or + " = " + *value_or + ")";
 }
 
+auto RenderSameShapeLiteral(
+    const mir::PackedArrayType& shape, std::int64_t value) -> std::string {
+  const char* signed_lit =
+      shape.signedness == mir::Signedness::kSigned ? "true" : "false";
+  const char* four_state_lit =
+      shape.atom != mir::BitAtom::kBit ? "true" : "false";
+  return std::format(
+      "lyra::value::PackedArray::FromInt({}LL, {}, {}, {})", value,
+      shape.BitWidth(), signed_lit, four_state_lit);
+}
+
+auto RenderRangeSelectExpr(
+    const RenderContext& ctx, const mir::Expr& expr,
+    const mir::RangeSelectExpr& sel) -> diag::Result<std::string> {
+  auto base_or = RenderExpr(ctx, ctx.Expr(sel.base_value));
+  if (!base_or) return std::unexpected(std::move(base_or.error()));
+
+  const auto& result_ty = ctx.Unit().GetType(expr.type);
+  if (!result_ty.IsPackedArray()) {
+    throw InternalError(
+        "RenderRangeSelectExpr: result type is not PackedArrayType");
+  }
+  const auto width =
+      static_cast<std::uint32_t>(result_ty.AsPackedArray().BitWidth());
+
+  return std::visit(
+      Overloaded{
+          [&](const mir::RangeConstantBounds& b) -> diag::Result<std::string> {
+            auto lsb_or = RenderExpr(ctx, ctx.Expr(b.lsb_expr));
+            if (!lsb_or) return std::unexpected(std::move(lsb_or.error()));
+            return std::format("({}).Slice({}, {})", *base_or, *lsb_or, width);
+          },
+          [&](const mir::RangeIndexedUpBounds& b) -> diag::Result<std::string> {
+            auto base_idx_or = RenderExpr(ctx, ctx.Expr(b.base_index));
+            if (!base_idx_or) {
+              return std::unexpected(std::move(base_idx_or.error()));
+            }
+            return std::format(
+                "({}).Slice({}, {})", *base_or, *base_idx_or, width);
+          },
+          [&](const mir::RangeIndexedDownBounds& b)
+              -> diag::Result<std::string> {
+            const auto& base_idx_expr = ctx.Expr(b.base_index);
+            auto base_idx_or = RenderExpr(ctx, base_idx_expr);
+            if (!base_idx_or) {
+              return std::unexpected(std::move(base_idx_or.error()));
+            }
+            const auto& base_idx_ty = ctx.Unit().GetType(base_idx_expr.type);
+            if (!base_idx_ty.IsPackedArray()) {
+              throw InternalError(
+                  "RenderRangeSelectExpr: base_index type is not "
+                  "PackedArrayType");
+            }
+            const auto width_minus_one = static_cast<std::int64_t>(width) - 1;
+            const auto offset_literal = RenderSameShapeLiteral(
+                base_idx_ty.AsPackedArray(), width_minus_one);
+            return std::format(
+                "({}).Slice(({}) - {}, {})", *base_or, *base_idx_or,
+                offset_literal, width);
+          },
+      },
+      sel.bounds);
+}
+
 auto RenderConversionExprNode(
     const RenderContext& ctx, const mir::Expr& expr,
     const mir::ConversionExpr& cv) -> diag::Result<std::string> {
@@ -414,7 +478,10 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
             if (!base_or) return std::unexpected(std::move(base_or.error()));
             auto idx_or = RenderExpr(ctx, ctx.Expr(sel.index));
             if (!idx_or) return std::unexpected(std::move(idx_or.error()));
-            return std::format("({}).Select({}, 1)", *base_or, *idx_or);
+            return std::format("({}).Index({})", *base_or, *idx_or);
+          },
+          [&](const mir::RangeSelectExpr& sel) -> diag::Result<std::string> {
+            return RenderRangeSelectExpr(ctx, expr, sel);
           },
       },
       expr.data);

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -787,6 +787,89 @@ auto LowerHirElementSelectExprProc(
       .type = result_type};
 }
 
+auto LowerHirRangeSelectExprProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, const hir::RangeSelectExpr& sel,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  auto base_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(sel.base_value.value));
+  if (!base_or) return std::unexpected(std::move(base_or.error()));
+  const mir::ExprId base_id = proc_scope_state.AddExpr(*std::move(base_or));
+
+  auto bounds_or = std::visit(
+      Overloaded{
+          [&](const hir::RangeConstantBounds& b)
+              -> diag::Result<mir::RangeBounds> {
+            auto msb_or = LowerExpr(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, hir_process.exprs.at(b.msb_expr.value));
+            if (!msb_or) return std::unexpected(std::move(msb_or.error()));
+            const mir::ExprId msb_id =
+                proc_scope_state.AddExpr(*std::move(msb_or));
+            auto lsb_or = LowerExpr(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, hir_process.exprs.at(b.lsb_expr.value));
+            if (!lsb_or) return std::unexpected(std::move(lsb_or.error()));
+            const mir::ExprId lsb_id =
+                proc_scope_state.AddExpr(*std::move(lsb_or));
+            return mir::RangeConstantBounds{
+                .msb_expr = msb_id, .lsb_expr = lsb_id};
+          },
+          [&](const hir::RangeIndexedUpBounds& b)
+              -> diag::Result<mir::RangeBounds> {
+            auto base_idx_or = LowerExpr(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, hir_process.exprs.at(b.base_index.value));
+            if (!base_idx_or) {
+              return std::unexpected(std::move(base_idx_or.error()));
+            }
+            const mir::ExprId base_idx_id =
+                proc_scope_state.AddExpr(*std::move(base_idx_or));
+            auto width_or = LowerExpr(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, hir_process.exprs.at(b.width.value));
+            if (!width_or) return std::unexpected(std::move(width_or.error()));
+            const mir::ExprId width_id =
+                proc_scope_state.AddExpr(*std::move(width_or));
+            return mir::RangeIndexedUpBounds{
+                .base_index = base_idx_id, .width = width_id};
+          },
+          [&](const hir::RangeIndexedDownBounds& b)
+              -> diag::Result<mir::RangeBounds> {
+            auto base_idx_or = LowerExpr(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, hir_process.exprs.at(b.base_index.value));
+            if (!base_idx_or) {
+              return std::unexpected(std::move(base_idx_or.error()));
+            }
+            const mir::ExprId base_idx_id =
+                proc_scope_state.AddExpr(*std::move(base_idx_or));
+            auto width_or = LowerExpr(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, hir_process.exprs.at(b.width.value));
+            if (!width_or) return std::unexpected(std::move(width_or.error()));
+            const mir::ExprId width_id =
+                proc_scope_state.AddExpr(*std::move(width_or));
+            return mir::RangeIndexedDownBounds{
+                .base_index = base_idx_id, .width = width_id};
+          },
+      },
+      sel.bounds);
+  if (!bounds_or) return std::unexpected(std::move(bounds_or.error()));
+
+  return mir::Expr{
+      .data =
+          mir::RangeSelectExpr{
+              .base_value = base_id,
+              .bounds = *std::move(bounds_or),
+          },
+      .type = result_type};
+}
+
 }  // namespace
 
 auto LowerExpr(
@@ -843,12 +926,10 @@ auto LowerExpr(
                 unit_state, scope_state, proc_state, proc_scope_state,
                 hir_process, sel, result_type);
           },
-          [](const hir::RangeSelectExpr&) -> diag::Result<mir::Expr> {
-            return diag::Unsupported(
-                diag::DiagCode::kUnsupportedExpressionForm,
-                "range-select (part-select / indexed part-select) is not yet "
-                "wired through HIR -> MIR",
-                diag::UnsupportedCategory::kOperation);
+          [&](const hir::RangeSelectExpr& sel) -> diag::Result<mir::Expr> {
+            return LowerHirRangeSelectExprProc(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, sel, result_type);
           },
       },
       expr.data);

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -498,6 +498,30 @@ class MirDumper {
                   "ElementSelectExpr base=Expr[{}] index=Expr[{}]",
                   sel.base_value.value, sel.index.value);
             },
+            [](const RangeSelectExpr& sel) -> std::string {
+              const auto bounds = std::visit(
+                  Overloaded{
+                      [](const RangeConstantBounds& b) -> std::string {
+                        return std::format(
+                            "const msb=Expr[{}] lsb=Expr[{}]", b.msb_expr.value,
+                            b.lsb_expr.value);
+                      },
+                      [](const RangeIndexedUpBounds& b) -> std::string {
+                        return std::format(
+                            "indexed_up base=Expr[{}] width=Expr[{}]",
+                            b.base_index.value, b.width.value);
+                      },
+                      [](const RangeIndexedDownBounds& b) -> std::string {
+                        return std::format(
+                            "indexed_down base=Expr[{}] width=Expr[{}]",
+                            b.base_index.value, b.width.value);
+                      },
+                  },
+                  sel.bounds);
+              return std::format(
+                  "RangeSelectExpr base=Expr[{}] {}", sel.base_value.value,
+                  bounds);
+            },
         },
         e.data);
     return std::format("{} type=Type[{}]", formatted, e.type.value);

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -874,18 +874,22 @@ auto PackedArray::WildcardEquals(const PackedArray& other) const
   return OneBitResult(true, is_four_state_);
 }
 
-auto PackedArray::Select(
-    const PackedArray& bit_offset, std::uint32_t width) const -> PackedArray {
+auto PackedArray::Index(const PackedArray& index) const -> PackedArray {
+  return Slice(index, 1U);
+}
+
+auto PackedArray::Slice(const PackedArray& lsb_bit, std::uint32_t width) const
+    -> PackedArray {
   if (width == 0U) {
-    throw InternalError("PackedArray::Select: width must be >= 1");
+    throw InternalError("PackedArray::Slice: width must be >= 1");
   }
-  if (bit_offset.HasUnknown() || bit_offset.BitWidth() > 64U) {
+  if (lsb_bit.HasUnknown() || lsb_bit.BitWidth() > 64U) {
     if (is_four_state_) {
       return AllX(width, false);
     }
     return PackedArray{width, false, false};
   }
-  const std::int64_t start = bit_offset.ToInt64();
+  const std::int64_t start = lsb_bit.ToInt64();
   const auto src_value = ValueWords();
   const auto src_unknown = UnknownWords();
   const auto bw_signed = static_cast<std::int64_t>(bit_width_);

--- a/tests/cases/cpp/range_select_const_basic/case.yaml
+++ b/tests/cases/cpp/range_select_const_basic/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.range_select_const_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    low_nibble: "4'hD"
+    high_nibble: "4'hA"
+    low_byte: "8'hCD"
+    high_byte: "8'hAB"

--- a/tests/cases/cpp/range_select_const_basic/main.sv
+++ b/tests/cases/cpp/range_select_const_basic/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  bit [3:0] low_nibble;
+  bit [3:0] high_nibble;
+  bit [7:0] low_byte;
+  bit [7:0] high_byte;
+  initial begin
+    bit [15:0] data;
+    data = 16'hABCD;
+    low_nibble = data[3:0];
+    high_nibble = data[15:12];
+    low_byte = data[7:0];
+    high_byte = data[15:8];
+  end
+endmodule

--- a/tests/cases/cpp/range_select_indexed_down/case.yaml
+++ b/tests/cases/cpp/range_select_indexed_down/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.range_select_indexed_down
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    slice_top: "4'hA"
+    slice_mid: "4'hC"
+    slice_lo: "4'hD"

--- a/tests/cases/cpp/range_select_indexed_down/main.sv
+++ b/tests/cases/cpp/range_select_indexed_down/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  bit [3:0] slice_top;
+  bit [3:0] slice_mid;
+  bit [3:0] slice_lo;
+  initial begin
+    bit [15:0] data;
+    int idx;
+    data = 16'hABCD;
+    idx = 15; slice_top = data[idx -: 4];
+    idx = 7;  slice_mid = data[idx -: 4];
+    idx = 3;  slice_lo  = data[idx -: 4];
+  end
+endmodule

--- a/tests/cases/cpp/range_select_indexed_up/case.yaml
+++ b/tests/cases/cpp/range_select_indexed_up/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.range_select_indexed_up
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    slice_lo: "4'hD"
+    slice_mid: "4'hC"
+    slice_hi: "4'hA"

--- a/tests/cases/cpp/range_select_indexed_up/main.sv
+++ b/tests/cases/cpp/range_select_indexed_up/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  bit [3:0] slice_lo;
+  bit [3:0] slice_mid;
+  bit [3:0] slice_hi;
+  initial begin
+    bit [15:0] data;
+    int idx;
+    data = 16'hABCD;
+    idx = 0;  slice_lo  = data[idx +: 4];
+    idx = 4;  slice_mid = data[idx +: 4];
+    idx = 12; slice_hi  = data[idx +: 4];
+  end
+endmodule

--- a/tests/cases/cpp/range_select_partial_oob_2state/case.yaml
+++ b/tests/cases/cpp/range_select_partial_oob_2state/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.range_select_partial_oob_2state
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    partial_high: "4'h3"
+    partial_low: "4'hC"

--- a/tests/cases/cpp/range_select_partial_oob_2state/main.sv
+++ b/tests/cases/cpp/range_select_partial_oob_2state/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  bit [3:0] partial_high;
+  bit [3:0] partial_low;
+  initial begin
+    bit [7:0] data;
+    int idx;
+    data = 8'b1111_1111;
+    idx = 6;  partial_high = data[idx +: 4];
+    idx = -2; partial_low  = data[idx +: 4];
+  end
+endmodule

--- a/tests/cases/cpp/range_select_partial_oob_4state/case.yaml
+++ b/tests/cases/cpp/range_select_partial_oob_4state/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.range_select_partial_oob_4state
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    partial_high: "4'bxx11"
+    partial_low: "4'b11xx"

--- a/tests/cases/cpp/range_select_partial_oob_4state/main.sv
+++ b/tests/cases/cpp/range_select_partial_oob_4state/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  logic [3:0] partial_high;
+  logic [3:0] partial_low;
+  initial begin
+    logic [7:0] data;
+    integer idx;
+    data = 8'b1111_1111;
+    idx = 6;  partial_high = data[idx +: 4];
+    idx = -2; partial_low  = data[idx +: 4];
+  end
+endmodule

--- a/tests/cases/cpp/range_select_signed/case.yaml
+++ b/tests/cases/cpp/range_select_signed/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.range_select_signed
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    low_nibble: "4'h1"
+    high_nibble: "4'h8"

--- a/tests/cases/cpp/range_select_signed/main.sv
+++ b/tests/cases/cpp/range_select_signed/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  bit [3:0] low_nibble;
+  bit [3:0] high_nibble;
+  initial begin
+    bit signed [7:0] s;
+    s = 8'sb1000_0001;
+    low_nibble = s[3:0];
+    high_nibble = s[7:4];
+  end
+endmodule

--- a/tests/cases/cpp/range_select_single_bit/case.yaml
+++ b/tests/cases/cpp/range_select_single_bit/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.range_select_single_bit
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    one_bit_high: 1
+    one_bit_low: 0

--- a/tests/cases/cpp/range_select_single_bit/main.sv
+++ b/tests/cases/cpp/range_select_single_bit/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  bit [0:0] one_bit_high;
+  bit [0:0] one_bit_low;
+  initial begin
+    bit [7:0] data;
+    data = 8'b0000_1000;
+    one_bit_high = data[3:3];
+    one_bit_low  = data[2:2];
+  end
+endmodule

--- a/tests/cases/cpp/range_select_wide/case.yaml
+++ b/tests/cases/cpp/range_select_wide/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.range_select_wide
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    low32: "32'hDDEEFF00"
+    high32: "32'h11223344"
+    middle64: "64'h55667788_99AABBCC"

--- a/tests/cases/cpp/range_select_wide/main.sv
+++ b/tests/cases/cpp/range_select_wide/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  bit [31:0] low32;
+  bit [31:0] high32;
+  bit [63:0] middle64;
+  initial begin
+    bit [127:0] w;
+    w = 128'h11223344_55667788_99AABBCC_DDEEFF00;
+    low32 = w[31:0];
+    high32 = w[127:96];
+    middle64 = w[95:32];
+  end
+endmodule


### PR DESCRIPTION
## Summary

Wires range-select read end-to-end and splits the runtime selector API into two LRM-named methods. `hir::RangeSelectExpr` now lowers through `mir::RangeSelectExpr` (three bounds variants mirroring HIR: constant `[hi:lo]`, indexed-up `+:`, indexed-down `-:`) to a `PackedArray::Slice(lsb_bit, width)` call. The single-bit `PackedArray::Select(bit_offset, width)` is replaced by two distinct methods: `Index(idx)` for element-select and `Slice(lsb_bit, width)` for range-select, matching the LRM 7.4.5 vocabulary ("element" / "slice").

## Design

HIR / MIR keep `ElementSelectExpr` and `RangeSelectExpr` as separate variants because LRM operand-domain validity differs (range-select is illegal on associative arrays and strings, element-select is not). MIR mirrors HIR structurally: each bounds field stays an `ExprId`, HIR -> MIR is a pure recursive lowering with no constant evaluation or direction normalization. The width at render time comes from the slice expression's MIR result type, which slang has already pinned at AST construction.

The runtime split follows LRM 7.4.5 vocabulary: `Index` for single-position access, `Slice` for contiguous ranges. `Slice` codifies the LRM size-constant-position-variable contract in its signature (`width` is `uint32_t`, `lsb_bit` is `PackedArray`), so X/Z propagation on the position falls out for free. The API operates on a canonical LSB-anchored bit address space; how `PackedArray` represents bits internally is an implementation detail. `Index(idx)` is currently a thin wrapper over `Slice(idx, 1)` -- specializing for 1-bit hot paths is deferred until benchmarks are operational.

The cpp render dispatches on the MIR bounds variant: `Slice(lsb_expr, width)` for the constant form; `Slice(base_index, width)` for indexed-up; `Slice(base_index - PackedArray(width - 1), width)` for indexed-down, where the literal is constructed to match `base_index`'s shape so the runtime subtraction avoids cross-shape promotion.

## Testing

Eight new YAML cases under `tests/cases/cpp/range_select_*`: constant basic (16-bit nibble / byte slices), wide (128-bit), signed (result unsigned per LRM 11.8), indexed-up and indexed-down with runtime base, partial-OOB in both 2-state (OOB bits read as 0) and 4-state (OOB bits read as X), and a 1-wide range-select (`v[3:3]`) covering the syntactic-range-but-1-bit-result edge. All existing W4 element-select cases continue to pass after the runtime rename.