### PR TITLE
Emit SV enums as CRTP class wrappers and route methods through them

### DIFF
--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -53,7 +53,7 @@ Granular tracking lives in `integral.md` (integral / packed / wide_integral) and
 (every other family). The list below remains a high-level inventory.
 
 - [ ] datatypes/default_init
-- [ ] datatypes/enum
+- [x] datatypes/enum
 - [ ] datatypes/general
 - [ ] datatypes/integral -- `integral.md`.
 - [ ] datatypes/packed -- `packed.md`.

--- a/docs/progress/datatypes.md
+++ b/docs/progress/datatypes.md
@@ -11,7 +11,8 @@ on the current pipeline.
 
 ## Actionable
 
-E2 and E3 are actionable now; no remaining dependencies on other workstreams.
+No enum work remaining. Next family: pick from `datatypes/string`, `datatypes/unpacked`,
+`datatypes/general`, `datatypes/real`, `datatypes/default_init`, `datatypes/representation`.
 
 ## Enum
 
@@ -30,15 +31,25 @@ future `string` / `queue` builtins and user class methods; only the `Method::dat
 alternative differs (`BuiltinMethod` for LRM intrinsics, `StructuralMethod` for user-defined
 bodies).
 
-- [x] E1 -- Type plumbing, member references, compile-time methods. `LowerType` recognises
+Behavior lives in the runtime SDK (`include/lyra/value/enum_ops.hpp`): six hand-written `inline`
+functions (`EnumFirst` / `EnumLast` / `EnumNum` / `EnumName` / `EnumNext` / `EnumPrev`) operating on
+a generic `EnumMetadata{members, is_four_state}`. HIR -> MIR translates `MethodRef` to a
+`mir::BuiltinMethodCallee{enum_metadata_id, kind}` callee and populates a per-enum-type
+`EnumMetadata` entry on `mir::CompilationUnit::enum_metadata` (cached by HIR `TypeId`). cpp emit
+walks `enum_metadata` to emit `inline constexpr lyra::value::EnumMember[]` plus an
+`inline constexpr lyra::value::EnumMetadata` global per entry at TU top, and renders each call site
+as `lyra::value::Enum<Method>(lyra_enum_metadata_N, ...)`. The architecture choice between inline
+expansion vs runtime ops library is documented in `enum-method-architecture.md` (root).
+
+- [x] E1 -- Type plumbing, member references, method dispatch. `LowerType` recognises
       `slang::ast::EnumType` and populates the enum type's six-entry method table (`first` / `last`
       / `num` / `next` / `prev` / `name`). AST `NamedValueExpression` whose symbol kind is
       `EnumValue` lowers directly to `hir::IntegerLiteral` of the backing type. `v.first()` /
       `v.last()` / `v.num()` lower at AST -> HIR via a uniform call dispatch that looks up the
       method by name on the receiver's type, producing
-      `CallExpr{callee=MethodRef{receiver_type, method_id}, arguments=[receiver]}` without folding;
-      the fold happens at HIR -> MIR's `LowerBuiltinMethodCall` using the receiver's `hir::EnumType`
-      member table. HIR -> MIR's `TranslateTypeData` has an `EnumType` arm that copies the base's
+      `CallExpr{callee=MethodRef{receiver_type, method_id}, arguments=[receiver]}`. HIR -> MIR
+      translates each `MethodRef` to a `mir::BuiltinMethodCallee` referring to the receiver type's
+      `EnumMetadata`. HIR -> MIR's `TranslateTypeData` has an `EnumType` arm that copies the base's
       translated `mir::TypeData`, so the orchestrator stays uniform. Conversions enum -> integral
       are transparent; integral -> enum requires explicit cast (LRM 6.19.3). Covers all 11 cases of
       `enum/default.yaml` (basic, sequential, explicit, mixed, comparison, arithmetic, explicit base
@@ -49,27 +60,24 @@ bodies).
       `enum_passed_to_system_function` as a regression guard for the AST -> HIR Call dispatch (an
       enum-typed first argument to a `$`-prefixed system call must fall through to the system
       subroutine path when no method of that name exists on the receiver). Unblocks C16 in
-      `control-flow.md`. Methods `next` / `prev` / `name` return `diag::Unsupported` at HIR -> MIR
-      until E2 / E3.
-- [ ] E2 -- Runtime methods `next` / `prev` with optional step (LRM 6.19.5.3 / 6.19.5.4). AST -> HIR
-      already produces `CallExpr{callee=MethodRef{...}, arguments=[receiver, step?]}` (no shape
-      change). HIR -> MIR's `LowerBuiltinMethodCall` replaces the current `Unsupported` arms for
-      `kEnumNext` / `kEnumPrev` with a nested `ConditionalExpr` chain over the enum's
-      declaration-order member table: each branch matches one member by equality and produces the
-      wrapped `(i +/- step) mod count` target value as an `IntegerLiteral`; the default branch is
-      the enum's default initial value (per LRM 6.19.5, Table 6-7, for non-member receivers). `step`
-      is typed `int unsigned` by slang at AST level and must be a literal in this cut; non-constant
-      step returns `diag::Unsupported`. Covers `enum_methods/default.yaml` cases `enum_next`,
-      `enum_next_wrap`, `enum_prev`, `enum_prev_wrap`, `enum_next_step`, `enum_next_step_wrap`,
-      `enum_prev_step`, `enum_prev_step_wrap`.
-- [ ] E3 -- Method `name()` (LRM 6.19.5.6). Returns the string name of the current value, empty
-      string when the value is not a member. HIR -> MIR's `LowerBuiltinMethodCall` Name arm replaces
-      the current `Unsupported` with a nested `ConditionalExpr` chain mapping each
-      `members[i].value` to `mir::StringLiteral{members[i].name}`, with default branch
-      `mir::StringLiteral{""}`. Uses only existing `mir::ConditionalExpr`,
-      `mir::BinaryExpr{kEquality}`, and `mir::StringLiteral` -- all already supported end-to-end
-      through the cpp backend; no dependency on the `datatypes/string` workstream. Covers
-      `enum_methods/default.yaml` case `enum_name`.
+      `control-flow.md`.
+- [x] E2 -- Runtime methods `next` / `prev` with optional step (LRM 6.19.5.3 / 6.19.5.4). AST -> HIR
+      produces `CallExpr{callee=MethodRef{...}, arguments=[receiver, step?]}`; AST -> HIR fills in
+      the default `1` for the missing step (each enum's method table carries the formal parameter
+      with its default `IntegralConstant`). HIR -> MIR translates `MethodRef` to a
+      `BuiltinMethodCallee` referencing the type's `EnumMetadata` plus the method kind. cpp emit
+      renders the call as `lyra::value::EnumNext(metadata, receiver_value, step)` /
+      `lyra::value::EnumPrev(metadata, receiver_value, step)` and wraps the `std::int64_t` result in
+      a `PackedArray` of the enum's base shape. Non-member receivers fall through the runtime lookup
+      to a zero default (Table 6-7 4-state X behavior is a runtime gap tracked separately). Covers
+      `enum_methods/default.yaml` cases `enum_next`, `enum_next_wrap`, `enum_prev`,
+      `enum_prev_wrap`, `enum_next_step`, `enum_next_step_wrap`, `enum_prev_step`,
+      `enum_prev_step_wrap`, plus `enum_next_runtime_step` as a regression guard for non-literal
+      step.
+- [x] E3 -- Method `name()` (LRM 6.19.5.6). Returns the string name of the current value, empty
+      string when the value is not a member. cpp emit renders the call as
+      `lyra::value::EnumName(metadata, receiver_value)`; the SDK function returns `std::string`
+      directly. Covers `enum_methods/default.yaml` case `enum_name`.
 
 ### Cross-references
 

--- a/include/lyra/backend/cpp/render_type.hpp
+++ b/include/lyra/backend/cpp/render_type.hpp
@@ -23,6 +23,25 @@ namespace lyra::backend::cpp {
 [[nodiscard]] auto RenderPackedArrayCtorArgs(const mir::PackedArrayType& pa)
     -> std::string;
 
+// Returns the constructor-argument list for a default-shaped instance of
+// `ty`, comma-separated. Drives both `T name{<args>}` (raw declaration) and
+// `Var<T> name{<args>}` (Var's variadic ctor forwards to T's). Empty when T
+// has a no-arg default ctor (enum classes via kBase, anything with a usable
+// default ctor).
+[[nodiscard]] auto RenderTypeDefaultCtorArgs(const mir::Type& ty)
+    -> std::string;
+
+// Renders the emitted C++ class name for a MIR enum type. The name is
+// derived from the first TypeAlias declaration targeting `id` in
+// `owner_scope` (so a `typedef enum {...} foo;` makes the class `foo`);
+// when no alias is found, falls back to a numeric internal name.
+//
+// EnumType itself carries no name (an enum and its typedef are orthogonal:
+// an anonymous enum has none, a multi-typedef enum has many). Lookup lives
+// here, not on the type.
+[[nodiscard]] auto RenderEnumClassName(
+    const mir::StructuralScope& owner_scope, mir::TypeId id) -> std::string;
+
 // True iff a structural field of this type is emitted as `Var<T>` (and writes
 // go through `lyra::runtime::WriteVar`). Today: only integral types via
 // `PackedArray`. The set grows as more SV value types gain `IsCaseEqual`.

--- a/include/lyra/hir/method.hpp
+++ b/include/lyra/hir/method.hpp
@@ -1,12 +1,6 @@
 #pragma once
 
-#include <compare>
 #include <cstdint>
-#include <string>
-#include <variant>
-
-#include "lyra/hir/subroutine_id.hpp"
-#include "lyra/hir/type_id.hpp"
 
 namespace lyra::hir {
 
@@ -19,30 +13,8 @@ enum class BuiltinMethodKind : std::uint8_t {
   kEnumName,
 };
 
-struct StructuralMethod {
-  StructuralSubroutineId subroutine;
-};
-
-struct BuiltinMethod {
+struct BuiltinMethodRef {
   BuiltinMethodKind kind;
-};
-
-using MethodData = std::variant<StructuralMethod, BuiltinMethod>;
-
-struct Method {
-  std::string name;
-  MethodData data;
-};
-
-struct MethodId {
-  std::uint32_t value;
-
-  auto operator<=>(const MethodId&) const -> std::strong_ordering = default;
-};
-
-struct MethodRef {
-  TypeId receiver_type;
-  MethodId method;
 };
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -12,6 +12,7 @@
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/structural_var.hpp"
 #include "lyra/hir/subroutine.hpp"
+#include "lyra/hir/type_alias.hpp"
 
 namespace lyra::hir {
 
@@ -74,6 +75,7 @@ struct StructuralScope {
   std::vector<Process> processes;
   std::vector<Generate> generates;
   std::vector<StructuralSubroutineDecl> structural_subroutines;
+  std::vector<TypeAliasDecl> type_aliases;
 
   [[nodiscard]] auto GetStructuralVar(StructuralVarId id) const
       -> const StructuralVarDecl& {

--- a/include/lyra/hir/subroutine_ref.hpp
+++ b/include/lyra/hir/subroutine_ref.hpp
@@ -18,7 +18,7 @@ struct SystemSubroutineRef {
   support::SystemSubroutineId id;
 };
 
-using SubroutineRef =
-    std::variant<StructuralSubroutineRef, SystemSubroutineRef, MethodRef>;
+using SubroutineRef = std::variant<
+    StructuralSubroutineRef, SystemSubroutineRef, BuiltinMethodRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/type.hpp
+++ b/include/lyra/hir/type.hpp
@@ -2,14 +2,11 @@
 
 #include <cstdint>
 #include <optional>
-#include <span>
 #include <string>
-#include <string_view>
 #include <variant>
 #include <vector>
 
 #include "lyra/hir/integral_constant.hpp"
-#include "lyra/hir/method.hpp"
 #include "lyra/hir/type_id.hpp"
 
 namespace lyra::hir {
@@ -64,6 +61,7 @@ struct PackedArrayType {
 
   [[nodiscard]] auto BitWidth() const -> std::uint64_t;
   [[nodiscard]] auto IsFourState() const -> bool;
+  [[nodiscard]] auto DefaultInitialValue() const -> IntegralConstant;
 };
 
 struct EnumMember {
@@ -74,7 +72,6 @@ struct EnumMember {
 struct EnumType {
   TypeId base_type;
   std::vector<EnumMember> members;
-  std::vector<Method> methods;
 };
 
 struct UnpackedRange {
@@ -122,11 +119,6 @@ struct Type {
   [[nodiscard]] auto AsPackedArray() const -> const PackedArrayType&;
   [[nodiscard]] auto IsEnum() const -> bool;
   [[nodiscard]] auto AsEnum() const -> const EnumType&;
-
-  [[nodiscard]] auto GetMethods() const -> std::span<const Method>;
-  [[nodiscard]] auto GetMethod(MethodId id) const -> const Method&;
-  [[nodiscard]] auto LookupMethod(std::string_view name) const
-      -> std::optional<MethodId>;
 };
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/type_alias.hpp
+++ b/include/lyra/hir/type_alias.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+#include "lyra/hir/type_id.hpp"
+
+namespace lyra::hir {
+
+// Records a SystemVerilog `typedef <target> <name>;` declaration. Multiple
+// aliases may share the same target TypeId (alias-of-alias collapses to the
+// canonical type via UnitLoweringState::GetTypeId). The first alias
+// encountered for a given target supplies the type's emitted-class name; all
+// remaining aliases are emitted as plain `using` declarations.
+struct TypeAliasDecl {
+  std::string name;
+  TypeId target;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -13,8 +13,10 @@
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/ValueSymbol.h>
 #include <slang/ast/symbols/VariableSymbols.h>
+#include <slang/ast/types/Type.h>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/module_unit.hpp"
@@ -67,6 +69,17 @@ class UnitLoweringState {
  public:
   explicit UnitLoweringState(std::string name)
       : hir_unit_{.name = std::move(name), .types = {}, .root_scope = {}} {
+    // Intrinsic types are pre-registered so callers reference them by a
+    // stable id rather than re-adding entries on demand. Extend this section
+    // when more synthesized types accumulate (1-bit logic, etc.).
+    void_type_id_ = AddType(hir::TypeData{hir::VoidType{}});
+  }
+
+  // Canonical id for the synthesized `void` type (system-call sinks, lvalue
+  // refs used in non-value context, etc.). Single source of truth so the
+  // unit never holds more than one VoidType entry.
+  [[nodiscard]] auto VoidTypeId() const -> hir::TypeId {
+    return void_type_id_;
   }
 
   [[nodiscard]] auto HirUnit() const -> const hir::ModuleUnit& {
@@ -77,11 +90,12 @@ class UnitLoweringState {
     return hir_unit_;
   }
 
-  auto AddType(hir::TypeData data) -> hir::TypeId {
-    const hir::TypeId id{static_cast<std::uint32_t>(hir_unit_.types.size())};
-    hir_unit_.types.push_back(hir::Type{.data = std::move(data)});
-    return id;
-  }
+  // Canonical entry point for slang-driven types. Same slang canonical type
+  // always returns the same hir::TypeId by going through a canonical-pointer
+  // cache; callers never raw-add slang-backed types. Defined in type.cpp so
+  // the body lives next to LowerType.
+  auto GetTypeId(const slang::ast::Type& type, diag::SourceSpan span)
+      -> diag::Result<hir::TypeId>;
 
   [[nodiscard]] auto GetType(hir::TypeId id) const -> const hir::Type& {
     return hir_unit_.GetType(id);
@@ -160,10 +174,21 @@ class UnitLoweringState {
   }
 
  private:
+  // Adds a freshly-built TypeData entry and returns its id. Used internally
+  // by the ctor (intrinsic types) and GetTypeId (after a cache miss); no
+  // outside caller raw-adds types, so dedup invariants stay enforced.
+  auto AddType(hir::TypeData data) -> hir::TypeId {
+    const hir::TypeId id{static_cast<std::uint32_t>(hir_unit_.types.size())};
+    hir_unit_.types.push_back(hir::Type{.data = std::move(data)});
+    return id;
+  }
+
   hir::ModuleUnit hir_unit_;
   StructuralVarBindings structural_var_bindings_;
   SubroutineBindings subroutine_bindings_;
   LoopVarBindings loop_var_bindings_;
+  std::unordered_map<const slang::ast::Type*, hir::TypeId> type_cache_;
+  hir::TypeId void_type_id_{};
 };
 
 class ScopeStack {
@@ -238,6 +263,10 @@ class ScopeLoweringState {
         hir::StructuralVarDecl{.name = std::string{var.name}, .type = type});
     unit_state_->MapStructuralVarBinding(var, frame_, local, type);
     return local;
+  }
+
+  void AddTypeAlias(hir::TypeAliasDecl decl) {
+    scope_->type_aliases.push_back(std::move(decl));
   }
 
   auto AddLoopVarDecl(const slang::ast::ValueSymbol& sym, hir::TypeId type)

--- a/include/lyra/mir/builtin_method_kind.hpp
+++ b/include/lyra/mir/builtin_method_kind.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+
+namespace lyra::mir {
+
+enum class BuiltinMethodKind : std::uint8_t {
+  kEnumFirst,
+  kEnumLast,
+  kEnumNum,
+  kEnumNext,
+  kEnumPrev,
+  kEnumName,
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "lyra/mir/binary_op.hpp"
+#include "lyra/mir/builtin_method_kind.hpp"
 #include "lyra/mir/closure.hpp"
 #include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr_id.hpp"
@@ -16,7 +17,6 @@
 #include "lyra/mir/runtime_submit.hpp"
 #include "lyra/mir/structural_param.hpp"
 #include "lyra/mir/structural_subroutine.hpp"
-#include "lyra/mir/type.hpp"
 #include "lyra/mir/unary_op.hpp"
 #include "lyra/mir/value_ref.hpp"
 #include "lyra/support/system_subroutine.hpp"
@@ -64,7 +64,13 @@ struct SystemSubroutineCallee {
   support::SystemSubroutineId id;
 };
 
-using Callee = std::variant<SystemSubroutineCallee, StructuralSubroutineRef>;
+struct BuiltinMethodCallee {
+  TypeId receiver_type;
+  BuiltinMethodKind kind;
+};
+
+using Callee = std::variant<
+    SystemSubroutineCallee, StructuralSubroutineRef, BuiltinMethodCallee>;
 
 struct CallExpr {
   Callee callee;

--- a/include/lyra/mir/structural_scope.hpp
+++ b/include/lyra/mir/structural_scope.hpp
@@ -9,6 +9,7 @@
 #include "lyra/mir/structural_scope_id.hpp"
 #include "lyra/mir/structural_subroutine.hpp"
 #include "lyra/mir/structural_var.hpp"
+#include "lyra/mir/type_alias.hpp"
 
 namespace lyra::mir {
 
@@ -20,6 +21,7 @@ struct StructuralScope {
   std::vector<Process> processes;
   std::vector<StructuralScope> child_structural_scopes;
   std::vector<StructuralSubroutineDecl> structural_subroutines;
+  std::vector<TypeAliasDecl> type_aliases;
 
   [[nodiscard]] auto GetStructuralParam(StructuralParamId id) const
       -> const StructuralParamDecl& {

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -1,23 +1,19 @@
 #pragma once
 
-#include <compare>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <variant>
 #include <vector>
 
 #include "lyra/mir/structural_scope_id.hpp"
+#include "lyra/mir/type_id.hpp"
 
 namespace lyra::mir {
 
-struct TypeId {
-  std::uint32_t value;
-
-  auto operator<=>(const TypeId&) const -> std::strong_ordering = default;
-};
-
 enum class TypeKind {
   kPackedArray,
+  kEnum,
   kUnpackedArray,
   kDynamicArray,
   kQueue,
@@ -75,6 +71,16 @@ struct PackedArrayType {
   [[nodiscard]] auto IsFourState() const -> bool;
 };
 
+struct EnumMember {
+  std::string name;
+  std::int64_t value;
+};
+
+struct EnumType {
+  PackedArrayType base;
+  std::vector<EnumMember> members;
+};
+
 struct UnpackedRange {
   std::int64_t left;
   std::int64_t right;
@@ -126,7 +132,7 @@ struct VectorType {
 };
 
 using TypeData = std::variant<
-    PackedArrayType, UnpackedArrayType, DynamicArrayType, QueueType,
+    PackedArrayType, EnumType, UnpackedArrayType, DynamicArrayType, QueueType,
     AssociativeArrayType, StringType, EventType, RealType, ShortRealType,
     RealTimeType, ChandleType, VoidType, ObjectType, OwningPtrType, VectorType>;
 
@@ -136,6 +142,14 @@ struct Type {
   [[nodiscard]] auto Kind() const -> TypeKind;
   [[nodiscard]] auto IsPackedArray() const -> bool;
   [[nodiscard]] auto AsPackedArray() const -> const PackedArrayType&;
+  [[nodiscard]] auto IsEnum() const -> bool;
+  [[nodiscard]] auto AsEnum() const -> const EnumType&;
+  // True for PackedArrayType or EnumType (since enum's value-level shape is
+  // its base PackedArray). Sites that treat enum as its integral
+  // representation use this predicate; sites that need to distinguish enum
+  // from packed should match on the variant directly.
+  [[nodiscard]] auto IsIntegralPacked() const -> bool;
+  [[nodiscard]] auto AsIntegralPacked() const -> const PackedArrayType&;
 };
 
 class CompilationUnit;

--- a/include/lyra/mir/type_alias.hpp
+++ b/include/lyra/mir/type_alias.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+#include "lyra/mir/type_id.hpp"
+
+namespace lyra::mir {
+
+// Mirror of `hir::TypeAliasDecl`. Carried through MIR so backends can render
+// SystemVerilog `typedef` declarations as backend-native aliases (e.g., C++
+// `using <name> = <target>;`).
+struct TypeAliasDecl {
+  std::string name;
+  TypeId target;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/mir/type_id.hpp
+++ b/include/lyra/mir/type_id.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace lyra::mir {
+
+struct TypeId {
+  std::uint32_t value;
+
+  auto operator<=>(const TypeId&) const -> std::strong_ordering = default;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/value/enum.hpp
+++ b/include/lyra/value/enum.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/value/packed_array.hpp"
+
+namespace lyra::value {
+
+struct EnumMember {
+  std::string_view name;
+  std::int64_t value;
+};
+
+// CRTP base implementing every SystemVerilog enum's intrinsic methods (LRM
+// 6.19.5) once. Each emitted enum class supplies only what truly varies per
+// type: its base PackedType (`kBase`) and its member table (`kMembers`).
+//
+// Public inheritance models LRM 6.19.3: enum values auto-cast to their base
+// integral type; integral-to-enum requires an explicit cast (the explicit
+// PackedArray ctor below). The enum's storage is the inherited PackedArray
+// subobject -- the same representation Lyra uses for all integrals.
+template <typename Derived>
+class Enum : public PackedArray {
+ public:
+  Enum()
+      : PackedArray(
+            static_cast<std::uint64_t>(Derived::kBase.width),
+            Derived::kBase.is_signed, Derived::kBase.is_four_state) {
+    AssertWellFormed();
+  }
+
+  explicit Enum(PackedArray v) : PackedArray(std::move(v)) {
+    AssertWellFormed();
+    if (BitWidth() != static_cast<std::uint64_t>(Derived::kBase.width) ||
+        IsSigned() != Derived::kBase.is_signed ||
+        IsFourState() != Derived::kBase.is_four_state) {
+      throw InternalError(
+          "Enum<Derived>: PackedArray value's shape does not match kBase "
+          "(emit is expected to convert before constructing the enum)");
+    }
+  }
+
+  [[nodiscard]] auto Name() const -> std::string {
+    if (HasUnknown()) return {};
+    const auto v = ToInt64();
+    for (const auto& m : Derived::kMembers) {
+      if (m.value == v) return std::string{m.name};
+    }
+    return {};
+  }
+
+  [[nodiscard]] auto Next(unsigned step = 1) const -> Derived {
+    return StepBy(static_cast<std::int64_t>(step));
+  }
+
+  [[nodiscard]] auto Prev(unsigned step = 1) const -> Derived {
+    return StepBy(-static_cast<std::int64_t>(step));
+  }
+
+  static auto First() -> Derived {
+    return Derived{MakeFromInt64(Derived::kMembers[0].value)};
+  }
+
+  static auto Last() -> Derived {
+    constexpr std::size_t kLastIdx = std::size(Derived::kMembers) - 1;
+    return Derived{MakeFromInt64(Derived::kMembers[kLastIdx].value)};
+  }
+
+  static constexpr auto Num() -> std::int32_t {
+    return static_cast<std::int32_t>(std::size(Derived::kMembers));
+  }
+
+ private:
+  // Single source of truth for compile-time invariants on Derived. Called
+  // from every ctor so the assertion fires no matter which path is used.
+  static constexpr void AssertWellFormed() {
+    static_assert(
+        std::size(Derived::kMembers) > 0,
+        "Enum<Derived>: kMembers must be non-empty (SV does not allow "
+        "empty enumerations)");
+  }
+
+  static auto MakeFromInt64(std::int64_t v) -> PackedArray {
+    return PackedArray::FromInt(
+        v, static_cast<std::uint64_t>(Derived::kBase.width),
+        Derived::kBase.is_signed, Derived::kBase.is_four_state);
+  }
+
+  // LRM 6.19.5.3/4: if the current value is not a member of the enumeration
+  // (including any X/Z bits in a 4-state base), next/prev return the enum's
+  // default initial value. The default ctor of PackedArray already produces
+  // that: all-X for 4-state, 0 for 2-state (Table 6-7).
+  [[nodiscard]] auto StepBy(std::int64_t delta) const -> Derived {
+    if (HasUnknown()) return Derived{};
+
+    const std::int64_t cur = ToInt64();
+    const auto n = static_cast<std::int64_t>(std::size(Derived::kMembers));
+    std::int64_t idx = -1;
+    for (std::int64_t i = 0; i < n; ++i) {
+      if (Derived::kMembers[i].value == cur) {
+        idx = i;
+        break;
+      }
+    }
+    if (idx < 0) return Derived{};
+
+    const std::int64_t stepped = ((idx + delta) % n + n) % n;
+    return Derived{MakeFromInt64(Derived::kMembers[stepped].value)};
+  }
+};
+
+}  // namespace lyra::value

--- a/include/lyra/value/packed_type.hpp
+++ b/include/lyra/value/packed_type.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+
+namespace lyra::value {
+
+// Compile-time description of a PackedArray's shape: width, signedness, and
+// state domain. Used to declare the base type of any value that lives in a
+// PackedArray (e.g., enum base types). PackedArray itself stores the same
+// triple as runtime members; this struct is the constexpr-friendly form for
+// generated code to declare its base type once.
+struct PackedType {
+  std::int32_t width;
+  bool is_signed;
+  bool is_four_state;
+};
+
+}  // namespace lyra::value

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -1,6 +1,8 @@
 #include <cstddef>
+#include <format>
 #include <string>
 #include <utility>
+#include <variant>
 
 #include "lyra/backend/cpp/api.hpp"
 #include "lyra/backend/cpp/artifact.hpp"
@@ -8,6 +10,7 @@
 #include "lyra/backend/cpp/render_context.hpp"
 #include "lyra/backend/cpp/render_stmt.hpp"
 #include "lyra/backend/cpp/render_type.hpp"
+#include "lyra/backend/cpp/string_literal.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/compilation_unit.hpp"
@@ -28,17 +31,14 @@ auto RenderField(
   auto type_or = RenderTypeAsCpp(unit, owner_scope, var.type);
   if (!type_or) return std::unexpected(std::move(type_or.error()));
   const auto& ty = unit.GetType(var.type);
-  if (IsObservableScalarType(ty)) {
-    std::string init = "{" + *type_or + "{" +
-                       RenderPackedArrayCtorArgs(ty.AsPackedArray()) + "}}";
-    return Indent(indent) + "lyra::runtime::Var<" + *type_or + "> " + var.name +
-           init + ";\n";
-  }
-  std::string init;
-  if (ty.IsPackedArray()) {
-    init = "{" + RenderPackedArrayCtorArgs(ty.AsPackedArray()) + "}";
-  }
-  return Indent(indent) + *type_or + " " + var.name + init + ";\n";
+  const auto storage_type = IsObservableScalarType(ty)
+                                ? "lyra::runtime::Var<" + *type_or + ">"
+                                : *type_or;
+  // Var<T>'s variadic ctor forwards to T's ctor; raw T uses the same args
+  // directly. Either way the brace-list shape is the same.
+  const auto ctor_args = RenderTypeDefaultCtorArgs(ty);
+  return Indent(indent) + storage_type + " " + var.name + "{" + ctor_args +
+         "};\n";
 }
 
 auto RenderParamField(
@@ -261,13 +261,62 @@ auto RenderScopeHeaderFile(
   out += "#include \"lyra/runtime/runtime_scope_kind.hpp\"\n";
   out += "#include \"lyra/runtime/runtime_services.hpp\"\n";
   out += "#include \"lyra/runtime/var.hpp\"\n";
+  out += "#include \"lyra/value/enum.hpp\"\n";
   out += "#include \"lyra/value/format.hpp\"\n";
+  out += "#include \"lyra/value/packed_type.hpp\"\n";
   out += "#include \"lyra/value/packed.hpp\"\n";
   out += "#include \"lyra/value/packed_array.hpp\"\n";
   out += "#include \"lyra/value/packed_bitwise.hpp\"\n";
   out += "#include \"lyra/value/packed_convert.hpp\"\n";
   out += "#include \"lyra/value/packed_reduction.hpp\"\n";
   out += "\n";
+  bool any_enum = false;
+  for (std::size_t i = 0; i < unit.types.size(); ++i) {
+    const auto* enum_type = std::get_if<mir::EnumType>(&unit.types[i].data);
+    if (enum_type == nullptr) continue;
+    any_enum = true;
+    const auto class_name =
+        RenderEnumClassName(s, mir::TypeId{static_cast<std::uint32_t>(i)});
+    const auto& base = enum_type->base;
+    const char* signed_lit =
+        base.signedness == mir::Signedness::kSigned ? "true" : "false";
+    const char* four_state_lit =
+        base.atom != mir::BitAtom::kBit ? "true" : "false";
+    out += std::format(
+        "class {} final : public lyra::value::Enum<{}> {{\n", class_name,
+        class_name);
+    out += " public:\n";
+    out += "  using Enum::Enum;\n";
+    out += std::format(
+        "  static constexpr lyra::value::PackedType kBase{{.width = {}, "
+        ".is_signed = {}, .is_four_state = {}}};\n",
+        base.BitWidth(), signed_lit, four_state_lit);
+    out += "  static constexpr lyra::value::EnumMember kMembers[] = {\n";
+    for (const auto& member : enum_type->members) {
+      out += std::format(
+          "      {{{}, {}}},\n", RenderCStringLiteral(member.name),
+          member.value);
+    }
+    out += "  };\n";
+    out += "};\n";
+  }
+  if (any_enum) {
+    out += "\n";
+  }
+  // SV `typedef <target> <alias>;` -> C++ `using <alias> = <target>;`. Skip
+  // aliases whose name already matches the emitted class (the first typedef
+  // for a given target supplies the class name itself).
+  bool any_alias = false;
+  for (const auto& alias : s.type_aliases) {
+    auto target_or = RenderTypeAsCpp(unit, s, alias.target);
+    if (!target_or) return std::unexpected(std::move(target_or.error()));
+    if (alias.name == *target_or) continue;
+    out += std::format("using {} = {};\n", alias.name, *target_or);
+    any_alias = true;
+  }
+  if (any_alias) {
+    out += "\n";
+  }
   auto class_or = RenderScopeAsClass(unit, s, 0, true, nullptr);
   if (!class_or) return std::unexpected(std::move(class_or.error()));
   out += *class_or;

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -20,6 +20,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/kind.hpp"
 #include "lyra/mir/binary_op.hpp"
+#include "lyra/mir/builtin_method_kind.hpp"
 #include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/integral_constant.hpp"
@@ -222,11 +223,18 @@ auto RenderIntegerLiteralExpr(
     const RenderContext& ctx, const mir::Expr& expr,
     const mir::IntegerLiteral& lit) -> diag::Result<std::string> {
   const auto& ty = ctx.Unit().GetType(expr.type);
-  if (!ty.IsPackedArray()) {
+  if (!ty.IsIntegralPacked()) {
     throw InternalError(
-        "RenderExpr: IntegerLiteral not typed as PackedArrayType");
+        "RenderExpr: IntegerLiteral not typed as PackedArrayType or "
+        "EnumType");
   }
-  return RenderPackedArrayIntegerLiteral(ty.AsPackedArray(), lit.value);
+  auto body = RenderPackedArrayIntegerLiteral(ty.AsIntegralPacked(), lit.value);
+  if (ty.IsEnum()) {
+    return std::format(
+        "{}{{{}}}", RenderEnumClassName(ctx.StructuralScope(), expr.type),
+        body);
+  }
+  return body;
 }
 
 auto RenderStructuralParamExpr(
@@ -395,22 +403,129 @@ auto RenderConversionExprNode(
   const auto& dst_ty = ctx.Unit().GetType(expr.type);
   // Same-shape conversion (slang's spurious promotions): pass through.
   // Cross-shape: route through PackedArray::ConvertFrom.
-  if (src_ty.IsPackedArray() && dst_ty.IsPackedArray()) {
-    const auto& src_pa = src_ty.AsPackedArray();
-    const auto& dst_pa = dst_ty.AsPackedArray();
+  if (src_ty.IsIntegralPacked() && dst_ty.IsIntegralPacked()) {
+    const auto& src_pa = src_ty.AsIntegralPacked();
+    const auto& dst_pa = dst_ty.AsIntegralPacked();
+    std::string body;
     if (src_pa.BitWidth() == dst_pa.BitWidth() &&
         src_pa.signedness == dst_pa.signedness && src_pa.atom == dst_pa.atom) {
-      return *operand_or;
+      body = *operand_or;
+    } else {
+      const char* signed_lit =
+          dst_pa.signedness == mir::Signedness::kSigned ? "true" : "false";
+      const char* four_state_lit =
+          dst_pa.atom != mir::BitAtom::kBit ? "true" : "false";
+      body = std::format(
+          "lyra::value::PackedArray::ConvertFrom({}, {}, {}, {})", *operand_or,
+          dst_pa.BitWidth(), signed_lit, four_state_lit);
     }
-    const char* signed_lit =
-        dst_pa.signedness == mir::Signedness::kSigned ? "true" : "false";
-    const char* four_state_lit =
-        dst_pa.atom != mir::BitAtom::kBit ? "true" : "false";
-    return std::format(
-        "lyra::value::PackedArray::ConvertFrom({}, {}, {}, {})", *operand_or,
-        dst_pa.BitWidth(), signed_lit, four_state_lit);
+    // LRM 6.19.3: integral-to-enum requires an explicit cast. The emitted
+    // enum class is a PackedArray subclass with an explicit PackedArray ctor;
+    // wrap the integral body with that ctor so the C++ result type matches the
+    // destination enum class.
+    if (dst_ty.IsEnum()) {
+      return std::format(
+          "{}{{{}}}", RenderEnumClassName(ctx.StructuralScope(), expr.type),
+          body);
+    }
+    // Enum-to-integral: slice the enum subobject into a fresh PackedArray so
+    // the C++ result type matches PackedArray-typed consumers (template
+    // deduction sees PackedArray, not the enum class).
+    if (src_ty.IsEnum() && !dst_ty.IsEnum()) {
+      return std::format("lyra::value::PackedArray{{{}}}", body);
+    }
+    return body;
   }
   return *operand_or;
+}
+
+auto BuiltinMethodMemberName(mir::BuiltinMethodKind kind) -> std::string_view {
+  switch (kind) {
+    case mir::BuiltinMethodKind::kEnumFirst:
+      return "First";
+    case mir::BuiltinMethodKind::kEnumLast:
+      return "Last";
+    case mir::BuiltinMethodKind::kEnumNum:
+      return "Num";
+    case mir::BuiltinMethodKind::kEnumName:
+      return "Name";
+    case mir::BuiltinMethodKind::kEnumNext:
+      return "Next";
+    case mir::BuiltinMethodKind::kEnumPrev:
+      return "Prev";
+  }
+  throw InternalError(
+      "BuiltinMethodMemberName: unknown mir::BuiltinMethodKind");
+}
+
+auto RenderCallExprNode(const RenderContext& ctx, const mir::CallExpr& call)
+    -> diag::Result<std::string> {
+  return std::visit(
+      Overloaded{
+          [](const mir::SystemSubroutineCallee&) -> diag::Result<std::string> {
+            return diag::Unsupported(
+                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+                "system subroutine call as expression is not yet implemented "
+                "in cpp emit",
+                diag::UnsupportedCategory::kFeature);
+          },
+          [](const mir::StructuralSubroutineRef&) -> diag::Result<std::string> {
+            return diag::Unsupported(
+                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+                "user subroutine call is not yet implemented in cpp emit",
+                diag::UnsupportedCategory::kFeature);
+          },
+          [&](const mir::BuiltinMethodCallee& b) -> diag::Result<std::string> {
+            const auto class_name =
+                RenderEnumClassName(ctx.StructuralScope(), b.receiver_type);
+            const auto member = BuiltinMethodMemberName(b.kind);
+            // first / last / num are static methods on the enum class; the
+            // remaining methods (name / next / prev) dispatch on the receiver.
+            const bool is_static =
+                b.kind == mir::BuiltinMethodKind::kEnumFirst ||
+                b.kind == mir::BuiltinMethodKind::kEnumLast ||
+                b.kind == mir::BuiltinMethodKind::kEnumNum;
+            const bool takes_step =
+                b.kind == mir::BuiltinMethodKind::kEnumNext ||
+                b.kind == mir::BuiltinMethodKind::kEnumPrev;
+            std::string raw_call;
+            if (is_static) {
+              raw_call = std::format("{}::{}()", class_name, member);
+            } else {
+              if (call.arguments.empty()) {
+                throw InternalError(
+                    "RenderCallExprNode: BuiltinMethodCallee expects a "
+                    "receiver argument");
+              }
+              auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
+              if (!receiver_or) {
+                return std::unexpected(std::move(receiver_or.error()));
+              }
+              // next / prev have an optional step. Omitted at the SV call
+              // site -> omit at the C++ call site too; the Enum<Derived>
+              // method's default argument supplies 1.
+              std::string step_arg;
+              if (takes_step && call.arguments.size() >= 2) {
+                auto step_or = RenderExpr(ctx, ctx.Expr(call.arguments[1]));
+                if (!step_or) {
+                  return std::unexpected(std::move(step_or.error()));
+                }
+                step_arg = std::format(
+                    "static_cast<unsigned>(({}).ToInt64())", *step_or);
+              }
+              raw_call =
+                  std::format("({}).{}({})", *receiver_or, member, step_arg);
+            }
+            // name() returns std::string; first/last/next/prev return the
+            // enum class directly (a PackedArray subclass). num() returns
+            // std::int32_t and needs wrapping into the SV `int` shape.
+            if (b.kind == mir::BuiltinMethodKind::kEnumNum) {
+              return std::format("lyra::value::PackedArray::Int({})", raw_call);
+            }
+            return raw_call;
+          },
+      },
+      call.callee);
 }
 
 }  // namespace
@@ -438,7 +553,7 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
             auto name_or = RenderStructuralVarName(ctx, m);
             if (!name_or) return std::unexpected(std::move(name_or.error()));
             const auto& ty = ctx.Unit().GetType(expr.type);
-            if (ty.IsPackedArray()) {
+            if (ty.IsIntegralPacked()) {
               return *name_or + ".Get()";
             }
             return *name_or;
@@ -461,11 +576,8 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
           [&](const mir::ConversionExpr& cv) -> diag::Result<std::string> {
             return RenderConversionExprNode(ctx, expr, cv);
           },
-          [](const mir::CallExpr&) -> diag::Result<std::string> {
-            return diag::Unsupported(
-                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-                "user subroutine call is not yet implemented in cpp emit",
-                diag::UnsupportedCategory::kFeature);
+          [&](const mir::CallExpr& call) -> diag::Result<std::string> {
+            return RenderCallExprNode(ctx, call);
           },
           [&](const mir::RuntimeCallExpr& rc) -> diag::Result<std::string> {
             return RenderRuntimeCallExpr(ctx, rc);
@@ -540,7 +652,7 @@ auto RenderConditionAsBool(const RenderContext& ctx, const mir::Expr& expr)
   auto text_or = RenderExpr(ctx, expr);
   if (!text_or) return std::unexpected(std::move(text_or.error()));
   const auto& ty = ctx.Unit().GetType(expr.type);
-  if (ty.IsPackedArray()) {
+  if (ty.IsIntegralPacked()) {
     return "(" + *text_or + ").IsTruthy()";
   }
   return *text_or;

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -84,7 +84,7 @@ auto RenderRuntimeValueViewInit(
         "lyra::value::RuntimeValueView::String({})", *operand_or);
   }
 
-  if (type.IsPackedArray()) {
+  if (type.IsIntegralPacked()) {
     auto operand_or = RenderExpr(ctx, ctx.Expr(v.value));
     if (!operand_or) return std::unexpected(std::move(operand_or.error()));
     return std::format(

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -40,8 +40,8 @@ auto RenderForInit(const RenderContext& ctx, const mir::ForInit& init)
                 return std::unexpected(std::move(rendered_or.error()));
               }
               out += " = " + *rendered_or;
-            } else if (ty.IsPackedArray()) {
-              out += "{" + RenderPackedArrayCtorArgs(ty.AsPackedArray()) + "}";
+            } else {
+              out += "{" + RenderTypeDefaultCtorArgs(ty) + "}";
             }
             return out;
           },
@@ -123,11 +123,8 @@ auto RenderProceduralVarDeclStmt(
     if (!init_or) return std::unexpected(std::move(init_or.error()));
     return Indent(indent) + *type_or + " " + lv.name + " = " + *init_or + ";\n";
   }
-  if (ty.IsPackedArray()) {
-    return Indent(indent) + *type_or + " " + lv.name + "{" +
-           RenderPackedArrayCtorArgs(ty.AsPackedArray()) + "};\n";
-  }
-  return Indent(indent) + *type_or + " " + lv.name + "{};\n";
+  return Indent(indent) + *type_or + " " + lv.name + "{" +
+         RenderTypeDefaultCtorArgs(ty) + "};\n";
 }
 
 auto RenderExprStmt(

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -1,5 +1,6 @@
 #include "lyra/backend/cpp/render_type.hpp"
 
+#include <format>
 #include <string>
 #include <utility>
 #include <variant>
@@ -21,8 +22,31 @@ auto RenderPackedArrayCtorArgs(const mir::PackedArrayType& pa) -> std::string {
          four_state_lit;
 }
 
+auto RenderTypeDefaultCtorArgs(const mir::Type& ty) -> std::string {
+  // Enum classes default-construct via their static `kBase`, so no shape
+  // arguments are needed at the call site. PackedArray has no default ctor;
+  // its shape (width, signedness, state domain) must be supplied.
+  if (ty.IsEnum()) return {};
+  if (ty.IsIntegralPacked()) {
+    return RenderPackedArrayCtorArgs(ty.AsIntegralPacked());
+  }
+  return {};
+}
+
 auto IsObservableScalarType(const mir::Type& ty) -> bool {
-  return ty.IsPackedArray();
+  return ty.IsIntegralPacked();
+}
+
+auto RenderEnumClassName(
+    const mir::StructuralScope& owner_scope, mir::TypeId id) -> std::string {
+  // First TypeAlias targeting `id` supplies the canonical class name. SV
+  // identifiers are valid C++ identifiers, so the alias name flows directly.
+  for (const auto& alias : owner_scope.type_aliases) {
+    if (alias.target == id) {
+      return alias.name;
+    }
+  }
+  return std::format("lyra_anon_enum_{}", id.value);
 }
 
 auto RenderTypeAsCpp(
@@ -32,6 +56,9 @@ auto RenderTypeAsCpp(
       Overloaded{
           [](const mir::PackedArrayType&) -> diag::Result<std::string> {
             return std::string{"lyra::value::PackedArray"};
+          },
+          [&](const mir::EnumType&) -> diag::Result<std::string> {
+            return RenderEnumClassName(owner_scope, type_id);
           },
           [](const mir::StringType&) -> diag::Result<std::string> {
             return std::string{"std::string"};

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -88,6 +88,25 @@ class HirDumper {
     throw InternalError("HirDumper::FormatUniquePriorityCheck: unknown check");
   }
 
+  static auto FormatBuiltinMethodKind(BuiltinMethodKind k) -> std::string_view {
+    switch (k) {
+      case BuiltinMethodKind::kEnumFirst:
+        return "first";
+      case BuiltinMethodKind::kEnumLast:
+        return "last";
+      case BuiltinMethodKind::kEnumNum:
+        return "num";
+      case BuiltinMethodKind::kEnumNext:
+        return "next";
+      case BuiltinMethodKind::kEnumPrev:
+        return "prev";
+      case BuiltinMethodKind::kEnumName:
+        return "name";
+    }
+    throw InternalError(
+        "HirDumper::FormatBuiltinMethodKind: unknown BuiltinMethodKind");
+  }
+
   static auto FormatPackedForm(PackedArrayForm f) -> std::string_view {
     switch (f) {
       case PackedArrayForm::kExplicit:
@@ -149,14 +168,9 @@ class HirDumper {
                     "{}={}", e.members[i].name,
                     FormatIntegralConstant(e.members[i].value));
               }
-              std::string methods;
-              for (std::size_t i = 0; i < e.methods.size(); ++i) {
-                if (i > 0) methods += ", ";
-                methods += e.methods[i].name;
-              }
               return std::format(
-                  "Enum(base=Type[{}], members=[{}], methods=[{}])",
-                  e.base_type.value, members, methods);
+                  "Enum(base=Type[{}], members=[{}])", e.base_type.value,
+                  members);
             },
             [](const UnpackedArrayType& u) -> std::string {
               return std::format(
@@ -460,12 +474,9 @@ class HirDumper {
               return std::format(
                   "SystemSubroutine[{}] \"{}\"", s.id.value, desc.name);
             },
-            [this](const MethodRef& m) -> std::string {
-              const auto& method =
-                  unit_->GetType(m.receiver_type).GetMethod(m.method);
+            [](const BuiltinMethodRef& b) -> std::string {
               return std::format(
-                  "Method[{}] \"{}\" on Type[{}]", m.method.value, method.name,
-                  m.receiver_type.value);
+                  "BuiltinMethod \"{}\"", FormatBuiltinMethodKind(b.kind));
             },
         },
         callee);

--- a/src/lyra/hir/type.cpp
+++ b/src/lyra/hir/type.cpp
@@ -3,14 +3,10 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <optional>
-#include <span>
-#include <string_view>
 #include <variant>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
-#include "lyra/hir/method.hpp"
 
 namespace lyra::hir {
 
@@ -52,6 +48,35 @@ auto PackedArrayType::BitWidth() const -> std::uint64_t {
 
 auto PackedArrayType::IsFourState() const -> bool {
   return atom == BitAtom::kLogic || atom == BitAtom::kReg;
+}
+
+auto PackedArrayType::DefaultInitialValue() const -> IntegralConstant {
+  const auto width = static_cast<std::uint32_t>(BitWidth());
+  const std::size_t words = (static_cast<std::size_t>(width) + 63U) / 64U;
+  if (!IsFourState()) {
+    return IntegralConstant{
+        .value_words = std::vector<std::uint64_t>(words, 0U),
+        .state_words = {},
+        .width = width,
+        .signedness = signedness,
+        .state_kind = IntegralStateKind::kTwoState,
+    };
+  }
+  std::vector<std::uint64_t> v(words, ~std::uint64_t{0});
+  std::vector<std::uint64_t> s(words, ~std::uint64_t{0});
+  const std::uint32_t tail = width % 64U;
+  if (tail != 0U && !v.empty()) {
+    const std::uint64_t mask = (std::uint64_t{1} << tail) - 1U;
+    v.back() &= mask;
+    s.back() &= mask;
+  }
+  return IntegralConstant{
+      .value_words = std::move(v),
+      .state_words = std::move(s),
+      .width = width,
+      .signedness = signedness,
+      .state_kind = IntegralStateKind::kFourState,
+  };
 }
 
 auto Type::Kind() const -> TypeKind {
@@ -96,36 +121,6 @@ auto Type::AsEnum() const -> const EnumType& {
     return *e;
   }
   throw InternalError("Type::AsEnum called on non-enum type");
-}
-
-auto Type::GetMethods() const -> std::span<const Method> {
-  return std::visit(
-      Overloaded{
-          [](const EnumType& e) -> std::span<const Method> {
-            return e.methods;
-          },
-          [](const auto&) -> std::span<const Method> { return {}; },
-      },
-      data);
-}
-
-auto Type::GetMethod(MethodId id) const -> const Method& {
-  const auto methods = GetMethods();
-  if (id.value >= methods.size()) {
-    throw InternalError("Type::GetMethod: MethodId out of range");
-  }
-  return methods[id.value];
-}
-
-auto Type::LookupMethod(std::string_view name) const
-    -> std::optional<MethodId> {
-  const auto methods = GetMethods();
-  for (std::size_t i = 0; i < methods.size(); ++i) {
-    if (methods[i].name == name) {
-      return MethodId{static_cast<std::uint32_t>(i)};
-    }
-  }
-  return std::nullopt;
 }
 
 }  // namespace lyra::hir

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -245,6 +245,17 @@ auto MakeStringLiteralExpr(
   };
 }
 
+auto LowerEnumMethodName(std::string_view name)
+    -> std::optional<hir::BuiltinMethodKind> {
+  if (name == "first") return hir::BuiltinMethodKind::kEnumFirst;
+  if (name == "last") return hir::BuiltinMethodKind::kEnumLast;
+  if (name == "num") return hir::BuiltinMethodKind::kEnumNum;
+  if (name == "next") return hir::BuiltinMethodKind::kEnumNext;
+  if (name == "prev") return hir::BuiltinMethodKind::kEnumPrev;
+  if (name == "name") return hir::BuiltinMethodKind::kEnumName;
+  return std::nullopt;
+}
+
 auto LowerTimeUnit(slang::TimeUnit u) -> hir::TimeScale {
   switch (u) {
     case slang::TimeUnit::Femtoseconds:
@@ -308,7 +319,7 @@ auto MakeReturnConventionType(
     -> hir::TypeId {
   switch (conv) {
     case support::ReturnConvention::kVoid:
-      return unit_state.AddType(hir::TypeData{hir::VoidType{}});
+      return unit_state.VoidTypeId();
   }
   throw InternalError("MakeReturnConventionType: unknown ReturnConvention");
 }
@@ -317,9 +328,7 @@ auto TypeIdOfSlangExpr(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     const slang::ast::Expression& e) -> diag::Result<hir::TypeId> {
   const auto& mapper = unit_facts.SourceMapper();
-  auto td = LowerType(*e.type, mapper.SpanOf(e.sourceRange), unit_state);
-  if (!td) return std::unexpected(std::move(td.error()));
-  return unit_state.AddType(*std::move(td));
+  return unit_state.GetTypeId(*e.type, mapper.SpanOf(e.sourceRange));
 }
 
 auto LowerNamedValueProc(
@@ -597,21 +606,21 @@ auto LowerCallExprProc(
         std::get<slang::ast::CallExpression::SystemCallInfo>(call.subroutine);
     const std::string_view name = info.subroutine->name;
 
-    if (receiver_type.has_value()) {
-      if (auto method_id =
-              unit_state.GetType(*receiver_type).LookupMethod(name);
-          method_id.has_value()) {
+    if (receiver_type.has_value() &&
+        unit_state.GetType(*receiver_type).IsEnum()) {
+      if (auto kind = LowerEnumMethodName(name); kind.has_value()) {
+        // `next` / `prev` have an optional `int unsigned step = 1` (LRM
+        // 6.19.5.3/4). When the user omits the step, the lowering hands the
+        // backend a single-argument call and lets the backend's intrinsic
+        // mechanism supply the default (C++ default-argument; LLVM constant
+        // 1; etc.). No synthesized literal is injected at the HIR boundary.
         auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
         if (!type_id) return std::unexpected(std::move(type_id.error()));
         return hir::Expr{
             .type = *type_id,
             .data =
                 hir::CallExpr{
-                    .callee =
-                        hir::MethodRef{
-                            .receiver_type = *receiver_type,
-                            .method = *method_id,
-                        },
+                    .callee = hir::BuiltinMethodRef{.kind = *kind},
                     .arguments = std::move(arg_ids),
                 },
             .span = span,

--- a/src/lyra/lowering/ast_to_hir/generate.cpp
+++ b/src/lyra/lowering/ast_to_hir/generate.cpp
@@ -20,7 +20,6 @@
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/scope.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
-#include "lyra/lowering/ast_to_hir/type.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -275,12 +274,14 @@ auto BuildLoopGenerate(
 
   const auto var_span =
       unit_facts.SourceMapper().PointSpanOf(loop_var_sym->location);
-  auto type_data = LowerType(loop_var_sym->getType(), var_span, unit_state);
-  if (!type_data) return std::unexpected(std::move(type_data.error()));
-  const hir::TypeId loop_var_type = unit_state.AddType(*std::move(type_data));
+  auto loop_var_type_or =
+      unit_state.GetTypeId(loop_var_sym->getType(), var_span);
+  if (!loop_var_type_or) {
+    return std::unexpected(std::move(loop_var_type_or.error()));
+  }
 
   const hir::LoopVarDeclId loop_var_id =
-      parent_state.AddLoopVarDecl(*loop_var_sym, loop_var_type);
+      parent_state.AddLoopVarDecl(*loop_var_sym, *loop_var_type_or);
 
   auto initial_expr = LowerStructuralExpr(
       unit_facts, unit_state, parent_state, stack, *array.initialExpression);
@@ -313,7 +314,7 @@ auto BuildLoopGenerate(
         .symbol = body_param,
         .home_frame = parent_state.Frame(),
         .loop_var = loop_var_id,
-        .type = loop_var_type,
+        .type = *loop_var_type_or,
     };
 
     auto& loop_scope = gen.child_scopes.at(loop_scope_id.value);

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -13,6 +13,7 @@
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/ValueSymbol.h>
 #include <slang/ast/symbols/VariableSymbols.h>
+#include <slang/ast/types/AllTypes.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
@@ -25,7 +26,6 @@
 #include "lyra/lowering/ast_to_hir/process.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
 #include "lyra/lowering/ast_to_hir/time_resolution.hpp"
-#include "lyra/lowering/ast_to_hir/type.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -57,120 +57,162 @@ auto IsCaseConstruct(
   return false;
 }
 
+auto LowerTypeAliasMemberInto(
+    const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
+    const slang::ast::TypeAliasType& alias) -> diag::Result<void> {
+  const auto& mapper = unit_facts.SourceMapper();
+  auto target_or = scope_state.UnitState().GetTypeId(
+      alias.targetType.getType(), mapper.PointSpanOf(alias.location));
+  if (!target_or) return std::unexpected(std::move(target_or.error()));
+  scope_state.AddTypeAlias(
+      hir::TypeAliasDecl{
+          .name = std::string{alias.name}, .target = *target_or});
+  return {};
+}
+
+auto LowerVariableMemberInto(
+    const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
+    const slang::ast::VariableSymbol& var) -> diag::Result<void> {
+  const auto& mapper = unit_facts.SourceMapper();
+  auto& unit_state = scope_state.UnitState();
+  if (var.lifetime != slang::ast::VariableLifetime::Static) {
+    return diag::Unsupported(
+        mapper.PointSpanOf(var.location),
+        diag::DiagCode::kUnsupportedNonStaticVariableLifetime,
+        "only static variables are supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  auto type_id_or =
+      unit_state.GetTypeId(var.getType(), mapper.PointSpanOf(var.location));
+  if (!type_id_or) return std::unexpected(std::move(type_id_or.error()));
+  // Slang rejects `void` in any variable-declaration position before
+  // elaboration, so a void-typed VariableSymbol can only reach this path
+  // via a slang/Lyra integration bug.
+  if (std::holds_alternative<hir::VoidType>(
+          unit_state.GetType(*type_id_or).data)) {
+    throw InternalError(
+        "LowerVariableMemberInto: variable declaration produced void type");
+  }
+  scope_state.AddStructuralVar(var, *type_id_or);
+  return {};
+}
+
+auto LowerSubroutineMemberInto(
+    const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
+    const slang::ast::SubroutineSymbol& sym) -> diag::Result<void> {
+  const auto& mapper = unit_facts.SourceMapper();
+  auto return_type_id_or = scope_state.UnitState().GetTypeId(
+      sym.getReturnType(), mapper.PointSpanOf(sym.location));
+  if (!return_type_id_or) {
+    return std::unexpected(std::move(return_type_id_or.error()));
+  }
+  scope_state.AddStructuralSubroutine(
+      sym, hir::StructuralSubroutineDecl{
+               .name = std::string{sym.name},
+               .kind = FromSlangSubroutineKind(sym.subroutineKind),
+               .result_type = *return_type_id_or});
+  return {};
+}
+
+auto LowerProceduralBlockMemberInto(
+    const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
+    ScopeStack& stack, const slang::ast::ProceduralBlockSymbol& proc)
+    -> diag::Result<void> {
+  auto p = LowerProcess(unit_facts, scope_state, stack, proc);
+  if (!p) return std::unexpected(std::move(p.error()));
+  scope_state.AddProcess(*std::move(p));
+  return {};
+}
+
+auto LowerLoopGenerateMemberInto(
+    const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
+    ScopeStack& stack, const slang::ast::GenerateBlockArraySymbol& array)
+    -> diag::Result<void> {
+  auto g = BuildLoopGenerate(
+      unit_facts, scope_state.UnitState(), scope_state, stack, array);
+  if (!g) return std::unexpected(std::move(g.error()));
+  scope_state.AddGenerate(*std::move(g));
+  return {};
+}
+
+auto LowerIfOrCaseGenerateMemberInto(
+    const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
+    ScopeStack& stack, const slang::ast::GenerateBlockSymbol& block,
+    const slang::ast::Scope& slang_scope) -> diag::Result<void> {
+  // slang assigns constructIndex per direct generate construct in the
+  // containing scope (Scope.cpp:927-1033): incremented after each construct,
+  // shared across siblings of one if/case generate. The sibling-collect loop
+  // below groups the members that belong to the same construct.
+  std::vector<const slang::ast::GenerateBlockSymbol*> siblings;
+  for (const auto& candidate : slang_scope.members()) {
+    if (candidate.kind != slang::ast::SymbolKind::GenerateBlock) continue;
+    const auto& sibling = candidate.as<slang::ast::GenerateBlockSymbol>();
+    if (sibling.constructIndex == block.constructIndex) {
+      siblings.push_back(&sibling);
+    }
+  }
+  auto g = IsCaseConstruct(siblings) ? BuildCaseGenerate(
+                                           unit_facts, scope_state.UnitState(),
+                                           scope_state, stack, siblings)
+                                     : BuildIfGenerate(
+                                           unit_facts, scope_state.UnitState(),
+                                           scope_state, stack, siblings);
+  if (!g) return std::unexpected(std::move(g.error()));
+  scope_state.AddGenerate(*std::move(g));
+  return {};
+}
+
+auto LowerScopeMemberInto(
+    const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
+    ScopeStack& stack, const slang::ast::Symbol& member,
+    const slang::ast::Scope& slang_scope) -> diag::Result<void> {
+  switch (member.kind) {
+    case slang::ast::SymbolKind::TypeAlias:
+      return LowerTypeAliasMemberInto(
+          unit_facts, scope_state, member.as<slang::ast::TypeAliasType>());
+    case slang::ast::SymbolKind::Variable:
+      return LowerVariableMemberInto(
+          unit_facts, scope_state, member.as<slang::ast::VariableSymbol>());
+    case slang::ast::SymbolKind::Subroutine:
+      return LowerSubroutineMemberInto(
+          unit_facts, scope_state, member.as<slang::ast::SubroutineSymbol>());
+    case slang::ast::SymbolKind::ProceduralBlock:
+      return LowerProceduralBlockMemberInto(
+          unit_facts, scope_state, stack,
+          member.as<slang::ast::ProceduralBlockSymbol>());
+    case slang::ast::SymbolKind::GenerateBlockArray:
+      return LowerLoopGenerateMemberInto(
+          unit_facts, scope_state, stack,
+          member.as<slang::ast::GenerateBlockArraySymbol>());
+    case slang::ast::SymbolKind::GenerateBlock:
+      return LowerIfOrCaseGenerateMemberInto(
+          unit_facts, scope_state, stack,
+          member.as<slang::ast::GenerateBlockSymbol>(), slang_scope);
+    default:
+      return {};
+  }
+}
+
 auto LowerScopeMembersInto(
     const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
     ScopeStack& stack, const slang::ast::Scope& slang_scope)
     -> diag::Result<void> {
-  const auto& mapper = unit_facts.SourceMapper();
-  auto& unit_state = scope_state.UnitState();
-
-  for (const auto& member : slang_scope.members()) {
-    if (member.kind != slang::ast::SymbolKind::Variable) {
-      continue;
-    }
-    const auto& var = member.as<slang::ast::VariableSymbol>();
-    if (var.lifetime != slang::ast::VariableLifetime::Static) {
-      return diag::Unsupported(
-          mapper.PointSpanOf(var.location),
-          diag::DiagCode::kUnsupportedNonStaticVariableLifetime,
-          "only static variables are supported",
-          diag::UnsupportedCategory::kFeature);
-    }
-    auto type_data =
-        LowerType(var.getType(), mapper.PointSpanOf(var.location), unit_state);
-    if (!type_data) return std::unexpected(std::move(type_data.error()));
-    // Slang rejects `void` in any variable-declaration position before
-    // elaboration, so a void-typed VariableSymbol can only reach this path
-    // via a slang/Lyra integration bug.
-    if (std::holds_alternative<hir::VoidType>(*type_data)) {
-      throw InternalError(
-          "LowerScopeMembersInto: variable declaration produced void type");
-    }
-    const auto type_id = unit_state.AddType(*std::move(type_data));
-    scope_state.AddStructuralVar(var, type_id);
-  }
-
-  for (const auto& member : slang_scope.members()) {
-    if (member.kind != slang::ast::SymbolKind::Subroutine) {
-      continue;
-    }
-    const auto& sym = member.as<slang::ast::SubroutineSymbol>();
-    auto return_type_data = LowerType(
-        sym.getReturnType(), mapper.PointSpanOf(sym.location), unit_state);
-    if (!return_type_data) {
-      return std::unexpected(std::move(return_type_data.error()));
-    }
-    const auto return_type_id =
-        unit_state.AddType(*std::move(return_type_data));
-    scope_state.AddStructuralSubroutine(
-        sym, hir::StructuralSubroutineDecl{
-                 .name = std::string{sym.name},
-                 .kind = FromSlangSubroutineKind(sym.subroutineKind),
-                 .result_type = return_type_id});
-  }
-
-  for (const auto& member : slang_scope.members()) {
-    if (member.kind != slang::ast::SymbolKind::ProceduralBlock) {
-      continue;
-    }
-    const auto& proc = member.as<slang::ast::ProceduralBlockSymbol>();
-    auto p = LowerProcess(unit_facts, scope_state, stack, proc);
-    if (!p) return std::unexpected(std::move(p.error()));
-    scope_state.AddProcess(*std::move(p));
-  }
-
-  // slang assigns constructIndex per direct generate construct in the
-  // containing scope (Scope.cpp:927-1033): incremented after each construct,
-  // shared across siblings of one if/case generate. So within this scope's
-  // members it is unique per construct and serves as the sibling-grouping key.
+  // GenerateBlock siblings of one if/case generate share a constructIndex
+  // (slang Scope.cpp:927-1033); we hand the dispatcher only the first sibling
+  // and skip the rest, so the per-construct sibling-collect loop inside
+  // LowerIfOrCaseGenerateMemberInto runs exactly once per construct.
   std::unordered_set<std::uint32_t> consumed_construct_indices;
   for (const auto& member : slang_scope.members()) {
-    switch (member.kind) {
-      case slang::ast::SymbolKind::GenerateBlockArray: {
-        const auto& array = member.as<slang::ast::GenerateBlockArraySymbol>();
-        auto g = BuildLoopGenerate(
-            unit_facts, unit_state, scope_state, stack, array);
-        if (!g) return std::unexpected(std::move(g.error()));
-        scope_state.AddGenerate(*std::move(g));
-        break;
+    if (member.kind == slang::ast::SymbolKind::GenerateBlock) {
+      const auto& block = member.as<slang::ast::GenerateBlockSymbol>();
+      if (!consumed_construct_indices.insert(block.constructIndex).second) {
+        continue;
       }
-
-      case slang::ast::SymbolKind::GenerateBlock: {
-        const auto& block = member.as<slang::ast::GenerateBlockSymbol>();
-        if (!consumed_construct_indices.insert(block.constructIndex).second) {
-          continue;
-        }
-
-        std::vector<const slang::ast::GenerateBlockSymbol*> siblings;
-        for (const auto& candidate : slang_scope.members()) {
-          if (candidate.kind != slang::ast::SymbolKind::GenerateBlock) {
-            continue;
-          }
-          const auto& sibling = candidate.as<slang::ast::GenerateBlockSymbol>();
-          if (sibling.constructIndex == block.constructIndex) {
-            siblings.push_back(&sibling);
-          }
-        }
-
-        if (IsCaseConstruct(siblings)) {
-          auto g = BuildCaseGenerate(
-              unit_facts, unit_state, scope_state, stack, siblings);
-          if (!g) return std::unexpected(std::move(g.error()));
-          scope_state.AddGenerate(*std::move(g));
-        } else {
-          auto g = BuildIfGenerate(
-              unit_facts, unit_state, scope_state, stack, siblings);
-          if (!g) return std::unexpected(std::move(g.error()));
-          scope_state.AddGenerate(*std::move(g));
-        }
-        break;
-      }
-
-      default:
-        break;
     }
+    auto r =
+        LowerScopeMemberInto(unit_facts, scope_state, stack, member, slang_scope);
+    if (!r) return std::unexpected(std::move(r.error()));
   }
-
   return {};
 }
 

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -209,8 +209,8 @@ auto LowerScopeMembersInto(
         continue;
       }
     }
-    auto r =
-        LowerScopeMemberInto(unit_facts, scope_state, stack, member, slang_scope);
+    auto r = LowerScopeMemberInto(
+        unit_facts, scope_state, stack, member, slang_scope);
     if (!r) return std::unexpected(std::move(r.error()));
   }
   return {};

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -23,7 +23,6 @@
 #include "lyra/lowering/ast_to_hir/expression/lower.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
-#include "lyra/lowering/ast_to_hir/type.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -74,9 +73,8 @@ auto LowerSignalEventTrigger(
   auto expr_or =
       LowerProcExpr(unit_facts, unit_state, proc_state, stack, sig.expr);
   if (!expr_or) return std::unexpected(std::move(expr_or.error()));
-  const hir::Expr& lowered = *expr_or;
 
-  const auto* primary = std::get_if<hir::PrimaryExpr>(&lowered.data);
+  const auto* primary = std::get_if<hir::PrimaryExpr>(&expr_or->data);
   if (primary == nullptr ||
       !std::holds_alternative<hir::StructuralVarRef>(primary->data)) {
     return diag::Unsupported(
@@ -86,7 +84,7 @@ auto LowerSignalEventTrigger(
         "not yet supported",
         diag::UnsupportedCategory::kFeature);
   }
-  if (!unit_state.GetType(lowered.type).IsPackedArray()) {
+  if (!unit_state.GetType(expr_or->type).IsPackedArray()) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedEventTriggerForm,
         "event trigger must reference an integral signal; non-integral "
@@ -237,11 +235,10 @@ auto LowerVariableDeclStmt(
     -> diag::Result<hir::Stmt> {
   const auto& mapper = unit_facts.SourceMapper();
   const auto& sym = vd.symbol;
-  auto type_data = LowerType(
-      sym.getType(), mapper.PointSpanOf(sym.location), scope_state.UnitState());
-  if (!type_data) return std::unexpected(std::move(type_data.error()));
-  const auto type_id = scope_state.UnitState().AddType(*std::move(type_data));
-  const auto local_id = proc_state.AddProceduralVar(sym, type_id);
+  auto type_id_or = scope_state.UnitState().GetTypeId(
+      sym.getType(), mapper.PointSpanOf(sym.location));
+  if (!type_id_or) return std::unexpected(std::move(type_id_or.error()));
+  const auto local_id = proc_state.AddProceduralVar(sym, *type_id_or);
   std::optional<hir::ExprId> init_id;
   if (const auto* init_expr = sym.getInitializer()) {
     auto init_or = LowerProcExpr(

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -1,9 +1,7 @@
 #include "lyra/lowering/ast_to_hir/type.hpp"
 
 #include <cstdint>
-#include <initializer_list>
 #include <string>
-#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -17,7 +15,6 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/integral_constant.hpp"
-#include "lyra/hir/method.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
@@ -125,11 +122,8 @@ auto LowerExplicitPackedArray(
 auto LowerEnum(
     const slang::ast::EnumType& enum_type, diag::SourceSpan decl_span,
     UnitLoweringState& state) -> diag::Result<hir::EnumType> {
-  auto base_data = LowerType(enum_type.baseType, decl_span, state);
-  if (!base_data.has_value()) {
-    return std::unexpected(std::move(base_data.error()));
-  }
-  const hir::TypeId base_id = state.AddType(*std::move(base_data));
+  auto base_id_or = state.GetTypeId(enum_type.baseType, decl_span);
+  if (!base_id_or) return std::unexpected(std::move(base_id_or.error()));
   std::vector<hir::EnumMember> members;
   for (const auto& value_sym : enum_type.values()) {
     const auto& cv = value_sym.getValue();
@@ -142,27 +136,9 @@ auto LowerEnum(
             .value = LowerSVIntToIntegralConstant(cv.integer()),
         });
   }
-  std::vector<hir::Method> methods;
-  methods.reserve(6);
-  for (const auto [name, kind] : std::initializer_list<
-           std::pair<std::string_view, hir::BuiltinMethodKind>>{
-           {"first", hir::BuiltinMethodKind::kEnumFirst},
-           {"last", hir::BuiltinMethodKind::kEnumLast},
-           {"num", hir::BuiltinMethodKind::kEnumNum},
-           {"next", hir::BuiltinMethodKind::kEnumNext},
-           {"prev", hir::BuiltinMethodKind::kEnumPrev},
-           {"name", hir::BuiltinMethodKind::kEnumName},
-       }) {
-    methods.push_back(
-        hir::Method{
-            .name = std::string{name},
-            .data = hir::BuiltinMethod{.kind = kind},
-        });
-  }
   return hir::EnumType{
-      .base_type = base_id,
+      .base_type = *base_id_or,
       .members = std::move(members),
-      .methods = std::move(methods),
   };
 }
 
@@ -268,6 +244,21 @@ auto LowerType(
           decl_span, diag::DiagCode::kUnsupportedTypeKind,
           "unsupported type kind", diag::UnsupportedCategory::kType);
   }
+}
+
+auto UnitLoweringState::GetTypeId(
+    const slang::ast::Type& type, diag::SourceSpan span)
+    -> diag::Result<hir::TypeId> {
+  const auto* canonical = &type.getCanonicalType();
+  const auto it = type_cache_.find(canonical);
+  if (it != type_cache_.end()) {
+    return it->second;
+  }
+  auto data_or = LowerType(type, span, *this);
+  if (!data_or) return std::unexpected(std::move(data_or.error()));
+  const hir::TypeId id = AddType(*std::move(data_or));
+  type_cache_.emplace(canonical, id);
+  return id;
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/hir_to_mir/delay_time_resolver.cpp
+++ b/src/lyra/lowering/hir_to_mir/delay_time_resolver.cpp
@@ -74,15 +74,14 @@ auto DelayTimeResolver::ResolveIntegerDelay(
         span, diag::DiagCode::kDelayValueOutOfRange,
         "delay value overflows internal tick representation");
   }
-  const std::uint64_t ratio = *ratio_or;
   const auto unsigned_value = static_cast<std::uint64_t>(value);
-  if (ratio != 0 &&
-      unsigned_value > std::numeric_limits<std::uint64_t>::max() / ratio) {
+  if (*ratio_or != 0 &&
+      unsigned_value > std::numeric_limits<std::uint64_t>::max() / *ratio_or) {
     return diag::Error(
         span, diag::DiagCode::kDelayValueOutOfRange,
         "delay value overflows internal tick representation");
   }
-  return static_cast<SimDuration>(unsigned_value * ratio);
+  return static_cast<SimDuration>(unsigned_value * *ratio_or);
 }
 
 auto DelayTimeResolver::ResolveTimeLiteral(

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -503,7 +503,14 @@ auto LowerStructuralScope(
       .constructor_scope = {},
       .processes = {},
       .child_structural_scopes = {},
-      .structural_subroutines = {}};
+      .structural_subroutines = {},
+      .type_aliases = {}};
+  for (const auto& alias : scope.type_aliases) {
+    mir_scope.type_aliases.push_back(
+        mir::TypeAliasDecl{
+            .name = alias.name,
+            .target = unit_state.TranslateType(alias.target)});
+  }
   StructuralScopeLoweringState scope_state(parent_scope_state, mir_scope);
   const ScopeStackGuard guard(stack, scope);
 

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -17,7 +17,6 @@
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
-#include "lyra/hir/type.hpp"
 #include "lyra/hir/unary_op.hpp"
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/hir_to_mir/lower_system_subroutine.hpp"
@@ -258,69 +257,23 @@ auto LowerHirIntegerLiteral(const hir::IntegerLiteral& i, mir::TypeId type)
       .type = type};
 }
 
-auto LowerBuiltinMethodCall(
-    const UnitLoweringState& unit_state, const hir::Process& hir_process,
-    hir::BuiltinMethodKind kind, const std::vector<hir::ExprId>& arguments,
-    mir::TypeId result_type, diag::SourceSpan span) -> diag::Result<mir::Expr> {
-  if (arguments.empty()) {
-    throw InternalError(
-        "LowerBuiltinMethodCall: built-in method call has no receiver");
-  }
-  const hir::TypeId receiver_type_id =
-      hir_process.exprs.at(arguments[0].value).type;
-  const auto& receiver_type = unit_state.GetHirType(receiver_type_id);
-  if (!receiver_type.IsEnum()) {
-    throw InternalError(
-        "LowerBuiltinMethodCall: enum builtin method on non-enum receiver");
-  }
-  const auto& enum_type = receiver_type.AsEnum();
-
+auto LowerBuiltinMethodKind(hir::BuiltinMethodKind kind)
+    -> mir::BuiltinMethodKind {
   switch (kind) {
     case hir::BuiltinMethodKind::kEnumFirst:
-    case hir::BuiltinMethodKind::kEnumLast: {
-      if (enum_type.members.empty()) {
-        throw InternalError("LowerBuiltinMethodCall: enum has no members");
-      }
-      const hir::EnumMember& picked =
-          (kind == hir::BuiltinMethodKind::kEnumFirst)
-              ? enum_type.members.front()
-              : enum_type.members.back();
-      return mir::Expr{
-          .data =
-              mir::IntegerLiteral{
-                  .value = LowerHirIntegralConstant(picked.value)},
-          .type = result_type};
-    }
-    case hir::BuiltinMethodKind::kEnumNum: {
-      const auto count = static_cast<std::uint32_t>(enum_type.members.size());
-      hir::IntegralConstant value{
-          .value_words = {static_cast<std::uint64_t>(count)},
-          .state_words = {},
-          .width = 32U,
-          .signedness = hir::Signedness::kSigned,
-          .state_kind = hir::IntegralStateKind::kTwoState,
-      };
-      return mir::Expr{
-          .data = mir::IntegerLiteral{.value = LowerHirIntegralConstant(value)},
-          .type = result_type};
-    }
+      return mir::BuiltinMethodKind::kEnumFirst;
+    case hir::BuiltinMethodKind::kEnumLast:
+      return mir::BuiltinMethodKind::kEnumLast;
+    case hir::BuiltinMethodKind::kEnumNum:
+      return mir::BuiltinMethodKind::kEnumNum;
     case hir::BuiltinMethodKind::kEnumNext:
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedExpressionForm,
-          "enum method 'next' is not yet supported",
-          diag::UnsupportedCategory::kOperation);
+      return mir::BuiltinMethodKind::kEnumNext;
     case hir::BuiltinMethodKind::kEnumPrev:
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedExpressionForm,
-          "enum method 'prev' is not yet supported",
-          diag::UnsupportedCategory::kOperation);
+      return mir::BuiltinMethodKind::kEnumPrev;
     case hir::BuiltinMethodKind::kEnumName:
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedExpressionForm,
-          "enum method 'name' is not yet supported",
-          diag::UnsupportedCategory::kOperation);
+      return mir::BuiltinMethodKind::kEnumName;
   }
-  throw InternalError("LowerBuiltinMethodCall: unknown BuiltinMethodKind");
+  throw InternalError("LowerBuiltinMethodKind: unknown hir::BuiltinMethodKind");
 }
 
 auto LowerHirStringLiteral(const hir::StringLiteral& s, mir::TypeId type)
@@ -614,26 +567,35 @@ auto LowerHirCallExprProc(
                         .arguments = std::move(args)},
                 .type = result_type};
           },
-          [&](const hir::MethodRef& m) -> diag::Result<mir::Expr> {
-            const auto& method =
-                unit_state.GetHirType(m.receiver_type).GetMethod(m.method);
-            return std::visit(
-                Overloaded{
-                    [&](const hir::BuiltinMethod& b)
-                        -> diag::Result<mir::Expr> {
-                      return LowerBuiltinMethodCall(
-                          unit_state, hir_process, b.kind, c.arguments,
-                          result_type, span);
-                    },
-                    [&](const hir::StructuralMethod&)
-                        -> diag::Result<mir::Expr> {
-                      throw InternalError(
-                          "MethodRef -> StructuralMethod lowering: "
-                          "user-defined methods are not yet wired into HIR/MIR "
-                          "call dispatch");
-                    },
-                },
-                method.data);
+          [&](const hir::BuiltinMethodRef& b) -> diag::Result<mir::Expr> {
+            if (c.arguments.empty()) {
+              throw InternalError(
+                  "BuiltinMethodRef call has no receiver argument");
+            }
+            const hir::TypeId hir_receiver_type =
+                hir_process.exprs.at(c.arguments.front().value).type;
+            std::vector<mir::ExprId> args;
+            args.reserve(c.arguments.size());
+            for (const auto arg : c.arguments) {
+              auto arg_or = LowerExpr(
+                  unit_state, scope_state, proc_state, proc_scope_state,
+                  hir_process, hir_process.exprs.at(arg.value));
+              if (!arg_or) {
+                return std::unexpected(std::move(arg_or.error()));
+              }
+              args.push_back(proc_scope_state.AddExpr(*std::move(arg_or)));
+            }
+            return mir::Expr{
+                .data =
+                    mir::CallExpr{
+                        .callee =
+                            mir::BuiltinMethodCallee{
+                                .receiver_type =
+                                    unit_state.TranslateType(hir_receiver_type),
+                                .kind = LowerBuiltinMethodKind(b.kind),
+                            },
+                        .arguments = std::move(args)},
+                .type = result_type};
           },
       },
       c.callee);

--- a/src/lyra/lowering/hir_to_mir/lower_type.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_type.cpp
@@ -86,10 +86,33 @@ auto TranslateTypeData(
             };
           },
           [&](const hir::EnumType& src) -> mir::TypeData {
-            // Enum erases to its base type in MIR: copy the base's translated
-            // mir::TypeData. (MIR has no enum concept; backends see
-            // PackedArray.)
-            return state.GetType(state.TranslateType(src.base_type)).data;
+            // Enum is kept as a distinct mir::EnumType wrapping its base
+            // PackedArray plus the member table. Value-level operations
+            // unwrap via Type::AsIntegralPacked(); method dispatch reads the
+            // members from this struct directly.
+            const auto& base_mir_data =
+                state.GetType(state.TranslateType(src.base_type)).data;
+            const auto* base_pa =
+                std::get_if<mir::PackedArrayType>(&base_mir_data);
+            if (base_pa == nullptr) {
+              throw InternalError(
+                  "TranslateTypeData: enum base did not lower to a "
+                  "PackedArrayType");
+            }
+            std::vector<mir::EnumMember> members;
+            members.reserve(src.members.size());
+            for (const auto& m : src.members) {
+              const std::int64_t value =
+                  m.value.value_words.empty()
+                      ? 0
+                      : static_cast<std::int64_t>(m.value.value_words[0]);
+              members.push_back(
+                  mir::EnumMember{.name = m.name, .value = value});
+            }
+            return mir::EnumType{
+                .base = *base_pa,
+                .members = std::move(members),
+            };
           },
           [&](const hir::UnpackedArrayType& src) -> mir::TypeData {
             return mir::UnpackedArrayType{

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -131,6 +131,21 @@ class MirDumper {
                   FormatBitAtom(p.atom), FormatSignedness(p.signedness),
                   FormatPackedDims(p.dims), FormatPackedForm(p.form));
             },
+            [](const EnumType& e) -> std::string {
+              std::string members;
+              for (std::size_t i = 0; i < e.members.size(); ++i) {
+                if (i > 0) members += ", ";
+                members +=
+                    std::format("{}={}", e.members[i].name, e.members[i].value);
+              }
+              return std::format(
+                  "Enum(base=PackedArray(atom={}, signed={}, dims={}, "
+                  "form={}), members=[{}])",
+                  FormatBitAtom(e.base.atom),
+                  FormatSignedness(e.base.signedness),
+                  FormatPackedDims(e.base.dims), FormatPackedForm(e.base.form),
+                  members);
+            },
             [](const UnpackedArrayType& u) -> std::string {
               return std::format(
                   "UnpackedArray(elem=Type[{}], dims={})", u.element_type.value,
@@ -353,6 +368,11 @@ class MirDumper {
               return std::format(
                   "StructuralSubroutineRef[hops={}, subroutine={}] \"{}\"",
                   r.hops.value, r.subroutine.value, target.name);
+            },
+            [](const BuiltinMethodCallee& b) -> std::string {
+              return std::format(
+                  "BuiltinMethodCallee[receiver_type=Type[{}], kind={}]",
+                  b.receiver_type.value, static_cast<int>(b.kind));
             },
         },
         callee);

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -56,6 +56,7 @@ auto Type::Kind() const -> TypeKind {
   return std::visit(
       Overloaded{
           [](const PackedArrayType&) { return TypeKind::kPackedArray; },
+          [](const EnumType&) { return TypeKind::kEnum; },
           [](const UnpackedArrayType&) { return TypeKind::kUnpackedArray; },
           [](const DynamicArrayType&) { return TypeKind::kDynamicArray; },
           [](const QueueType&) { return TypeKind::kQueue; },
@@ -85,6 +86,34 @@ auto Type::AsPackedArray() const -> const PackedArrayType& {
     return *p;
   }
   throw InternalError("Type::AsPackedArray called on non-packed-array type");
+}
+
+auto Type::IsEnum() const -> bool {
+  return std::holds_alternative<EnumType>(data);
+}
+
+auto Type::AsEnum() const -> const EnumType& {
+  if (const auto* e = std::get_if<EnumType>(&data)) {
+    return *e;
+  }
+  throw InternalError("Type::AsEnum called on non-enum type");
+}
+
+auto Type::IsIntegralPacked() const -> bool {
+  return std::holds_alternative<PackedArrayType>(data) ||
+         std::holds_alternative<EnumType>(data);
+}
+
+auto Type::AsIntegralPacked() const -> const PackedArrayType& {
+  if (const auto* p = std::get_if<PackedArrayType>(&data)) {
+    return *p;
+  }
+  if (const auto* e = std::get_if<EnumType>(&data)) {
+    return e->base;
+  }
+  throw InternalError(
+      "Type::AsIntegralPacked called on non-integral type (expected "
+      "PackedArrayType or EnumType)");
 }
 
 namespace {

--- a/tests/cases/cpp/enum_logic_4state/case.yaml
+++ b/tests/cases/cpp/enum_logic_4state/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.enum_logic_4state
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      [][RUN][]

--- a/tests/cases/cpp/enum_logic_4state/main.sv
+++ b/tests/cases/cpp/enum_logic_4state/main.sv
@@ -1,0 +1,22 @@
+module Top;
+  // 4-state base: default initial value is all-X. name() on X returns "";
+  // next() on a non-member returns the default initial value (all-X), which
+  // is itself not a member, so subsequent name() still returns "".
+  typedef enum logic [1:0] {IDLE = 2'b01, RUN = 2'b10, STOP = 2'b11} state_t;
+  state_t s_default;
+  state_t s_member;
+  string n_default;
+  string n_member;
+  string n_x_next;
+  initial begin
+    // Variable default is all-X.
+    n_default = s_default.name();
+    // Member case.
+    s_member = RUN;
+    n_member = s_member.name();
+    // next() on the X-valued default: returns default initial value (X),
+    // whose name() is "".
+    n_x_next = s_default.next().name();
+    $display("[%s][%s][%s]", n_default, n_member, n_x_next);
+  end
+endmodule

--- a/tests/cases/cpp/enum_name/case.yaml
+++ b/tests/cases/cpp/enum_name/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.enum_name
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      RUN

--- a/tests/cases/cpp/enum_name/main.sv
+++ b/tests/cases/cpp/enum_name/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  typedef enum {IDLE, RUN, STOP} state_t;
+  state_t s;
+  string name;
+  initial begin
+    s = RUN;
+    name = s.name();
+    $display("%s", name);
+  end
+endmodule

--- a/tests/cases/cpp/enum_next/case.yaml
+++ b/tests/cases/cpp/enum_next/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.enum_next
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 5

--- a/tests/cases/cpp/enum_next/main.sv
+++ b/tests/cases/cpp/enum_next/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  typedef enum {A = 0, B = 5, C = 10} t;
+  t v;
+  int r;
+  initial begin
+    v = A;
+    v = v.next();
+    r = v;
+  end
+endmodule

--- a/tests/cases/cpp/enum_next_runtime_step/case.yaml
+++ b/tests/cases/cpp/enum_next_runtime_step/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.enum_next_runtime_step
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 15

--- a/tests/cases/cpp/enum_next_runtime_step/main.sv
+++ b/tests/cases/cpp/enum_next_runtime_step/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  typedef enum {A = 0, B = 5, C = 10, D = 15, E = 20} t;
+  t v;
+  int unsigned step;
+  int r;
+  initial begin
+    v = A;
+    step = 3;
+    v = v.next(step);
+    r = v;
+  end
+endmodule

--- a/tests/cases/cpp/enum_next_step/case.yaml
+++ b/tests/cases/cpp/enum_next_step/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.enum_next_step
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 10

--- a/tests/cases/cpp/enum_next_step/main.sv
+++ b/tests/cases/cpp/enum_next_step/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  typedef enum {A = 0, B = 5, C = 10, D = 15, E = 20} t;
+  t v;
+  int r;
+  initial begin
+    v = A;
+    v = v.next(2);
+    r = v;
+  end
+endmodule

--- a/tests/cases/cpp/enum_next_step_wrap/case.yaml
+++ b/tests/cases/cpp/enum_next_step_wrap/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.enum_next_step_wrap
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 5

--- a/tests/cases/cpp/enum_next_step_wrap/main.sv
+++ b/tests/cases/cpp/enum_next_step_wrap/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  typedef enum {A = 0, B = 5, C = 10, D = 15, E = 20} t;
+  t v;
+  int r;
+  initial begin
+    v = D;
+    v = v.next(3);
+    r = v;
+  end
+endmodule

--- a/tests/cases/cpp/enum_next_wrap/case.yaml
+++ b/tests/cases/cpp/enum_next_wrap/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.enum_next_wrap
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 0

--- a/tests/cases/cpp/enum_next_wrap/main.sv
+++ b/tests/cases/cpp/enum_next_wrap/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  typedef enum {A = 0, B = 5, C = 10} t;
+  t v;
+  int r;
+  initial begin
+    v = C;
+    v = v.next();
+    r = v;
+  end
+endmodule

--- a/tests/cases/cpp/enum_prev/case.yaml
+++ b/tests/cases/cpp/enum_prev/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.enum_prev
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 5

--- a/tests/cases/cpp/enum_prev/main.sv
+++ b/tests/cases/cpp/enum_prev/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  typedef enum {A = 0, B = 5, C = 10} t;
+  t v;
+  int r;
+  initial begin
+    v = C;
+    v = v.prev();
+    r = v;
+  end
+endmodule

--- a/tests/cases/cpp/enum_prev_step/case.yaml
+++ b/tests/cases/cpp/enum_prev_step/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.enum_prev_step
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 10

--- a/tests/cases/cpp/enum_prev_step/main.sv
+++ b/tests/cases/cpp/enum_prev_step/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  typedef enum {A = 0, B = 5, C = 10, D = 15, E = 20} t;
+  t v;
+  int r;
+  initial begin
+    v = E;
+    v = v.prev(2);
+    r = v;
+  end
+endmodule

--- a/tests/cases/cpp/enum_prev_step_wrap/case.yaml
+++ b/tests/cases/cpp/enum_prev_step_wrap/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.enum_prev_step_wrap
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 15

--- a/tests/cases/cpp/enum_prev_step_wrap/main.sv
+++ b/tests/cases/cpp/enum_prev_step_wrap/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  typedef enum {A = 0, B = 5, C = 10, D = 15, E = 20} t;
+  t v;
+  int r;
+  initial begin
+    v = B;
+    v = v.prev(3);
+    r = v;
+  end
+endmodule

--- a/tests/cases/cpp/enum_prev_wrap/case.yaml
+++ b/tests/cases/cpp/enum_prev_wrap/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.enum_prev_wrap
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 10

--- a/tests/cases/cpp/enum_prev_wrap/main.sv
+++ b/tests/cases/cpp/enum_prev_wrap/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  typedef enum {A = 0, B = 5, C = 10} t;
+  t v;
+  int r;
+  initial begin
+    v = A;
+    v = v.prev();
+    r = v;
+  end
+endmodule

--- a/tests/cases/cpp/enum_procedural_var/case.yaml
+++ b/tests/cases/cpp/enum_procedural_var/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.enum_procedural_var
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      B

--- a/tests/cases/cpp/enum_procedural_var/main.sv
+++ b/tests/cases/cpp/enum_procedural_var/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  typedef enum {A, B, C} state_t;
+  initial begin
+    state_t local_s;
+    local_s = B;
+    $display("%s", local_s.name());
+  end
+endmodule

--- a/tests/cases/cpp/enum_typedef_alias/case.yaml
+++ b/tests/cases/cpp/enum_typedef_alias/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.enum_typedef_alias
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      [A][B]

--- a/tests/cases/cpp/enum_typedef_alias/main.sv
+++ b/tests/cases/cpp/enum_typedef_alias/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  typedef enum {A, B, C} primary_t;
+  typedef primary_t alias_t;
+  primary_t v1;
+  alias_t v2;
+  initial begin
+    v1 = A;
+    v2 = B;
+    $display("[%s][%s]", v1.name(), v2.name());
+  end
+endmodule


### PR DESCRIPTION
## Summary

Replaces the type-owned method-table dispatch for SystemVerilog enums with a CRTP class wrapper in the runtime SDK. Each emitted enum becomes a `class T final : public lyra::value::Enum<T>` whose only per-enum content is a `static constexpr PackedType kBase` and a `static constexpr EnumMember kMembers[]`; the six LRM 6.19.5 methods (`First` / `Last` / `Num` / `Next` / `Prev` / `Name`) live once on the base. SV `typedef` declarations lower to scope-level `TypeAliasDecl` and emit as C++ `using`, so SV's typedef chain shows up 1:1 in the generated code.

## Design

- `lyra::value::Enum<Derived>` (CRTP, publicly inherits `PackedArray`) implements all six methods using only `Derived::kBase` and `Derived::kMembers`. X/Z and non-member receivers fall back to the default initial value per LRM Table 6-7.
- `hir::EnumType` and `mir::EnumType` carry no name -- types and aliases are orthogonal. Class naming derives from the first `TypeAliasDecl` targeting the type; anonymous inline enums fall back to `lyra_anon_enum_<id>`.
- IR method-table machinery (`Method`, `MethodParam`, `BuiltinMethod`, `MethodRef`, `Type::LookupMethod`/`GetMethods`/`GetMethod`) is removed. The HIR callee variant is just `BuiltinMethodRef{kind}`; the receiver is `arguments[0]`.
- `UnitLoweringState::GetTypeId` is the single entry for slang-derived types (canonical-pointer dedup); raw `AddType` is private. `VoidType` is pre-registered once at unit init.
- `RenderField` / `RenderProceduralVarDeclStmt` route through `RenderTypeDefaultCtorArgs(ty)`, eliminating the if-cascade between `Var<T>` and raw `T` declarations.
- `LowerScopeMembersInto` switches to single-pass member dispatcher (`LowerScopeMemberInto`); per-kind handlers are tail-return helpers consistent with `LowerStatement`.

## Testing

- `bazel build //...`
- `bazel test //... --test_output=errors`
- 14 new `cpp_run` cases covering `First`/`Last`/`Num`/`Name`/`Next`/`Prev` (with and without step, wrap), 4-state `enum logic [1:0]` (X/Z `Name` and `Next` defaults), procedural-scope enum variable declarations, and `typedef foo bar;` alias emission.