### PR TITLE
Add always @* and 4-state edge handling

### DIFF
--- a/docs/progress/processes.md
+++ b/docs/progress/processes.md
@@ -43,21 +43,26 @@ order. Items in the [Actionable](#actionable) section can be picked up next; ite
       Pathological zero-delay loops (`always areg     = ~areg;`) are caught by the engine's
       `kMaxCurrentTimeIterations` settle limit. Covers `processes/initial` (always portion) and the
       `always_ff` body of `processes/wait_event`.
-- [x] P10 -- `always_comb` / `always_latch`. `slang::analysis::AnalysisManager` runs once per
-      compilation to compute the LRM 9.2.2.2.1 implicit sensitivity list (longest static prefix of
-      each read, excluding block-local declarations, also-written variables, and timing-control-only
-      identifiers; reads inside called functions are tracked). The resulting per-procedure
-      `ValueSymbol*` lists ride through `LowerCompilationFacts` into AST -> HIR, where they are
-      translated into `hir::SensitivityEntry` (StructuralVarRef + TypeId) and attached to
-      `hir::Process::implicit_sensitivity_list`. HIR -> MIR appends a synthesised `@(read_set)` tail
-      wait inside the existing `forever` body and emits `ProcessKind::kInitial` so the engine
-      schedules it on the active queue at time 0 (LRM 9.2.2.2: "automatically triggered once at time
-      zero"). `always_latch` lowers identically to `always_comb` (LRM 9.2.2.3: execution-equivalent;
-      only lint policy differs). Empty sensitivity lists (e.g. `always_comb     c = 7;`) degenerate
-      to once-at-time-zero. Select expressions in reads collapse to whole-variable subscription
-      until the runtime supports bit-level any-change. The single-driver restriction (LRM 9.2.2.2)
-      and forbidden-construct checks (no blocking timing, no fork-join) are enforced by slang's
-      frontend.
+- [x] P10 / P13 -- `always_comb` / `always_latch` (LRM 9.2.2.2.1) and `always @*` / `always @(*)`
+      (LRM 9.4.2.2). HIR follows slang's source-aligned shape; MIR abstracts to a single runtime
+      mental model. Harvest (`compile.cpp`): slang's `AnalysisManager` produces read sets via two
+      APIs (`getSensitivityList()` for the procedure and `getImplicitEventReadSets()` for each `@*`
+      region) -- both are stored in a single `ImplicitSensitivityReads` map keyed by
+      `slang::ast::Statement*` (the procedure's body statement for always_comb / always_latch; the
+      `@*`'s `TimedStatement` for `always @*`). HIR: `always_comb` / `always_latch` carry the
+      sensitivity on `hir::Process::implicit_sensitivity_list` while the body is a plain statement
+      (LRM 9.2.2.2.1 -- no `@*` token in source). `always @*` produces
+      `hir::TimedStmt{ timing: ImplicitEventControl{sensitivity}, stmt: body }` -- a wrapper that
+      mirrors slang's `TimedStatement(ImplicitEventControl, body)` 1:1. HIR -> MIR collapses both
+      forms onto MIR's `mir::SensitivityWaitStmt` leaf: always_comb / always_latch run
+      `forever { body; SensitivityWaitStmt; }` (body runs at time zero, then waits for changes per
+      LRM 9.2.2.2); `always @*` expands its TimedStmt into a
+      `mir::Block { SensitivityWaitStmt;     body; }` (waits first, no time-zero run per LRM
+      9.4.2.2.2). Empty sensitivity lists are legal (wait-forever). Select expressions in reads
+      collapse to whole-variable subscription until the runtime supports bit-level any-change. The
+      single-driver restriction and forbidden-construct checks (no blocking timing, no fork-join in
+      `always_comb`) are enforced by slang's frontend. Multiple `@*`s in one procedure each key by
+      their own TimedStatement and lower independently.
 
 ### Procedural assignments
 
@@ -75,9 +80,12 @@ order. Items in the [Actionable](#actionable) section can be picked up next; ite
 - [x] T2 -- Event control `@(x)` any-change. `mir::EventControl{triggers: [{signal, kAnyChange}]}`.
       `Var<T>` wrapper compares old vs new values and notifies the engine on any inequality. Covers
       `processes/event_triggers` (any-change subset).
-- [x] T3 -- Event control edge polarity `@(posedge clk)` / `@(negedge clk)`.
+- [x] T3 -- Event control edge polarity `@(posedge clk)` / `@(negedge clk)` / `@(edge clk)`.
       `EventEdge::{kPosedge,     kNegedge, kBothEdges, kAnyChange}` on each trigger;
-      `Observable::TakeMatchingWaiters` filters by edge per LRM Table 9-2. Covers
+      `Observable::TakeMatchingWaiters` filters by edge per LRM Table 9-2. `ClassifyEdge` in
+      `runtime/var.hpp` covers the full 4-state transition table: posedge fires on 0 -> {1, x, z}
+      and {x, z} -> 1; negedge fires on 1 -> {0, x, z} and {x, z} -> 0; x <-> z is `kChangeOnly`.
+      `kBothEdges` (the `edge` keyword) matches either posedge or negedge. Covers
       `processes/edge_trigger_bit_select` (whole-variable edges) and the edge subset of
       `processes/event_triggers`.
 - [x] T4 -- Event control event lists `@(posedge clk or negedge rst_n)` / comma form. A single

--- a/include/lyra/hir/process.hpp
+++ b/include/lyra/hir/process.hpp
@@ -2,14 +2,12 @@
 
 #include <compare>
 #include <cstdint>
-#include <utility>
 #include <vector>
 
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/stmt.hpp"
-#include "lyra/hir/value_ref.hpp"
 
 namespace lyra::hir {
 
@@ -28,18 +26,6 @@ enum class ProcessKind : std::uint8_t {
   kAlwaysFf,
 };
 
-// One entry of an always_comb / always_latch implicit sensitivity list
-// (LRM 9.2.2.2.1). Identity-only: which structural variable, which flat bit
-// range of its packed encoding. bit_range matches slang's selectable-width
-// representation; for packed types it is lossless w.r.t. longest static
-// prefix. The current runtime collapses to whole-variable subscription at
-// HIR -> MIR, but the precision is preserved here so the collapse can be
-// removed when the runtime gains bit-level Observable.
-struct SensitivityEntry {
-  StructuralVarRef ref;
-  std::pair<std::uint64_t, std::uint64_t> bit_range;
-};
-
 struct Process {
   ProcessKind kind = ProcessKind::kInitial;
   diag::SourceSpan span;
@@ -47,7 +33,9 @@ struct Process {
   std::vector<Expr> exprs;
   std::vector<Stmt> stmts;
   std::vector<ProceduralVarDecl> procedural_vars;
-  // LRM 9.2.2.2.1; non-empty only for always_comb / always_latch.
+  // LRM 9.2.2.2.1; non-empty only for always_comb / always_latch. `@*` carries
+  // its own sensitivity inside hir::ImplicitEventControl on the body's
+  // TimedStmt, so it does not populate this field.
   std::vector<SensitivityEntry> implicit_sensitivity_list;
 };
 

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -4,12 +4,14 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <utility>
 #include <variant>
 #include <vector>
 
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/procedural_var.hpp"
+#include "lyra/hir/value_ref.hpp"
 
 namespace lyra::hir {
 
@@ -126,7 +128,30 @@ struct EventControl {
   std::vector<EventTrigger> triggers;
 };
 
-using TimingControl = std::variant<DelayControl, EventControl>;
+// One entry of an implicit sensitivity list (LRM 9.2.2.2.1 for always_comb /
+// always_latch; 9.4.2.2 for `always @*`). Identity-only: which structural
+// variable, which flat bit range of its packed encoding. bit_range matches
+// slang's selectable-width representation; for packed types it is lossless
+// w.r.t. longest static prefix. The current runtime collapses to whole-variable
+// subscription at HIR -> MIR, but the precision is preserved here so the
+// collapse can be removed when the runtime gains bit-level Observable.
+struct SensitivityEntry {
+  StructuralVarRef ref;
+  std::pair<std::uint64_t, std::uint64_t> bit_range;
+};
+
+// LRM 9.4.2.2 `@*` / `@(*)`. Identity-shaped (distinct from EventControl's
+// expression-shaped triggers): the sensitivity list is derived by slang's
+// AnalysisManager from the controlled statement's reads, never reassembled
+// into expressions. HIR keeps the slang AST shape -- the TimedStmt wraps the
+// controlled body -- and HIR -> MIR expands this into the runtime-oriented
+// "wait then body" sequence at lowering time.
+struct ImplicitEventControl {
+  std::vector<SensitivityEntry> sensitivity_list;
+};
+
+using TimingControl =
+    std::variant<DelayControl, EventControl, ImplicitEventControl>;
 
 struct TimedStmt {
   TimingControl timing;

--- a/include/lyra/lowering/ast_to_hir/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/lower.hpp
@@ -12,28 +12,34 @@
 #include "lyra/hir/module_unit.hpp"
 
 namespace slang::ast {
-class ProceduralBlockSymbol;
+class Statement;
 class ValueSymbol;
 }  // namespace slang::ast
 
 namespace lyra::lowering::ast_to_hir {
 
-// One element of the precomputed implicit sensitivity list for a single
-// always_comb / always_latch procedural block. Mirrors slang's ReadRange:
-// `symbol` is the structural variable being read; `bit_range` is the flat
-// bit range within its selectable-width packed encoding. Multiple entries
-// for the same symbol with disjoint bit ranges are kept as-is so downstream
-// can preserve precision when the runtime supports bit-level subscription.
+// One element of the precomputed implicit sensitivity list. Mirrors slang's
+// ReadRange: `symbol` is the structural variable being read; `bit_range` is
+// the flat bit range within its selectable-width packed encoding. Multiple
+// entries for the same symbol with disjoint bit ranges are kept as-is so
+// downstream can preserve precision when the runtime supports bit-level
+// subscription.
 struct SensitivityRead {
   const slang::ast::ValueSymbol* symbol;
   std::pair<std::uint64_t, std::uint64_t> bit_range;
 };
 
-// Per-procedure implicit sensitivity list (LRM 9.2.2.2.1), computed once by
-// slang::analysis::AnalysisManager. Slang excludes block-local declarations,
+// Precomputed implicit sensitivity, keyed uniformly by the slang Statement
+// that LRM associates the list with:
+//   - LRM 9.2.2.2.1 (always_comb / always_latch): key = &proc.getBody(); the
+//     sensitivity attaches to the procedure body statement.
+//   - LRM 9.4.2.2 (`always @*` / `@(*)`): key = the TimedStatement holding
+//     the `@*`; multiple `@*`s in one procedure each get their own entry.
+// Both cases reduce to "reads in a statement", so one map per statement
+// pointer is enough. Slang already excludes block-local declarations,
 // also-written variables, and timing-control-only identifiers per the LRM.
 using ImplicitSensitivityReads = std::unordered_map<
-    const slang::ast::ProceduralBlockSymbol*, std::vector<SensitivityRead>>;
+    const slang::ast::Statement*, std::vector<SensitivityRead>>;
 
 class LowerCompilationFacts {
  public:

--- a/include/lyra/lowering/ast_to_hir/sensitivity.hpp
+++ b/include/lyra/lowering/ast_to_hir/sensitivity.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <vector>
+
+#include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/ast_to_hir/lower.hpp"
+
+namespace lyra::lowering::ast_to_hir {
+
+class ScopeStack;
+class UnitLoweringState;
+
+// Translates the slang-side read vector (ValueSymbol* + bit_range) into
+// HIR-side identity entries (StructuralVarRef + bit_range), resolving each
+// symbol through the unit's structural binding table and the active scope
+// stack. Reads that don't resolve to a visible structural variable are
+// silently skipped -- slang may surface reads whose home scope was not
+// elaborated into HIR (e.g. ports of an instance the caller is not in).
+auto TranslateSensitivityReads(
+    const std::vector<SensitivityRead>& reads,
+    const UnitLoweringState& unit_state, const ScopeStack& stack)
+    -> std::vector<hir::SensitivityEntry>;
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/hir_to_mir/sensitivity_wait.hpp
+++ b/include/lyra/lowering/hir_to_mir/sensitivity_wait.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <vector>
+
+#include "lyra/hir/stmt.hpp"
+#include "lyra/mir/stmt.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+class StructuralScopeLoweringState;
+
+// Materialises a mir::SensitivityWaitStmt from a HIR sensitivity entry list.
+// Identity-shaped end-to-end (distinct from mir::EventTrigger which carries
+// an expression for explicit `@(...)`). The single point where always_comb /
+// always_latch (LRM 9.2.2.2.1, procedure-attached) and `@*` (LRM 9.4.2.2,
+// TimedStmt-attached) converge onto the same MIR runtime construct.
+auto BuildSensitivityWaitStmt(
+    const StructuralScopeLoweringState& scope_state,
+    const std::vector<hir::SensitivityEntry>& sensitivity_list) -> mir::Stmt;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -17,10 +17,12 @@ namespace lyra::runtime {
 
 class RuntimeProcess;
 
-// Classification of a single value change by its LSB transition (LRM 9.4.2
-// Table 9-2). `kChangeOnly` covers transitions that move the full value but
-// don't cross 0 or 1 on the LSB (e.g. x->z, or upper bits changing while the
-// LSB stays the same).
+// Classification of a single value change by its LSB transition per LRM
+// 9.4.2 Table 9-2:
+//   - posedge: 0 -> {1, x, z}; {x, z} -> 1
+//   - negedge: 1 -> {0, x, z}; {x, z} -> 0
+//   - kChangeOnly: any other LSB-different change (x <-> z), or the full
+//     value moved but the LSB stayed the same (upper bits changing).
 enum class EdgeTransition : std::uint8_t {
   kChangeOnly,
   kPosedge,
@@ -30,12 +32,22 @@ enum class EdgeTransition : std::uint8_t {
 inline auto ClassifyEdge(
     value::FourStateBit old_lsb, value::FourStateBit new_lsb)
     -> EdgeTransition {
-  if (new_lsb == value::FourStateBit::kOne &&
-      old_lsb != value::FourStateBit::kOne) {
+  if (old_lsb == new_lsb) {
+    return EdgeTransition::kChangeOnly;
+  }
+  // Leaving 0 is posedge regardless of destination (1, x, or z).
+  if (old_lsb == value::FourStateBit::kZero) {
     return EdgeTransition::kPosedge;
   }
-  if (new_lsb == value::FourStateBit::kZero &&
-      old_lsb != value::FourStateBit::kZero) {
+  // Leaving 1 is negedge regardless of destination (0, x, or z).
+  if (old_lsb == value::FourStateBit::kOne) {
+    return EdgeTransition::kNegedge;
+  }
+  // Leaving x or z: only arrival at 0 or 1 counts; x <-> z is kChangeOnly.
+  if (new_lsb == value::FourStateBit::kOne) {
+    return EdgeTransition::kPosedge;
+  }
+  if (new_lsb == value::FourStateBit::kZero) {
     return EdgeTransition::kNegedge;
   }
   return EdgeTransition::kChangeOnly;

--- a/src/lyra/compiler/compile.cpp
+++ b/src/lyra/compiler/compile.cpp
@@ -1,16 +1,12 @@
 #include "lyra/compiler/compile.hpp"
 
-#include <cstddef>
-#include <cstdint>
 #include <format>
-#include <functional>
-#include <tuple>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include <slang/analysis/AnalysisManager.h>
 #include <slang/analysis/AnalyzedProcedure.h>
+#include <slang/ast/Statement.h>
 #include <slang/ast/symbols/BlockSymbols.h>
 #include <slang/ast/symbols/ValueSymbol.h>
 
@@ -25,6 +21,23 @@ namespace lyra::compiler {
 
 namespace {
 
+// Translates slang's ReadRange entries into lyra's SensitivityRead shape.
+// Slang already returns deduplicated sets per LRM 9.2.2.2.1 / 9.4.2.2, so
+// the conversion is a straight 1:1 copy. Multiple entries for the same
+// symbol with disjoint bit ranges (e.g. `bus[3] | bus[5]`) are preserved so
+// downstream can subscribe at bit-range granularity once the runtime
+// supports it.
+template <typename SlangReads>
+auto TranslateReads(const SlangReads& reads)
+    -> std::vector<lowering::ast_to_hir::SensitivityRead> {
+  std::vector<lowering::ast_to_hir::SensitivityRead> entries;
+  entries.reserve(reads.size());
+  for (const auto& read : reads) {
+    entries.push_back({.symbol = read.symbol, .bit_range = read.bitRange});
+  }
+  return entries;
+}
+
 auto ComputeImplicitSensitivityReads(slang::ast::Compilation& compilation)
     -> lowering::ast_to_hir::ImplicitSensitivityReads {
   lowering::ast_to_hir::ImplicitSensitivityReads out;
@@ -33,39 +46,21 @@ auto ComputeImplicitSensitivityReads(slang::ast::Compilation& compilation)
     const auto* proc =
         ap.analyzedSymbol->as_if<slang::ast::ProceduralBlockSymbol>();
     if (proc == nullptr) return;
-    if (proc->procedureKind != slang::ast::ProceduralBlockKind::AlwaysComb &&
-        proc->procedureKind != slang::ast::ProceduralBlockKind::AlwaysLatch) {
-      return;
-    }
-    const auto& sens = ap.getSensitivityList();
-    if (sens.kind != slang::analysis::SensitivityList::Kind::Implicit) return;
-    // Preserve every (symbol, bit_range) slang produced; the same symbol may
-    // appear several times with disjoint ranges (e.g. `bus[3] | bus[5]`),
-    // and that precision is needed once the runtime supports bit-level
-    // subscription. Dedup only by exact (symbol, bit_range) so a defensive
-    // caller is shielded from accidental slang-side duplicates.
-    using DedupKey = std::tuple<
-        const slang::ast::ValueSymbol*, std::uint64_t, std::uint64_t>;
-    struct DedupHash {
-      auto operator()(const DedupKey& k) const noexcept -> std::size_t {
-        const auto h1 =
-            std::hash<const slang::ast::ValueSymbol*>{}(std::get<0>(k));
-        const auto h2 = std::hash<std::uint64_t>{}(std::get<1>(k));
-        const auto h3 = std::hash<std::uint64_t>{}(std::get<2>(k));
-        return h1 ^ (h2 * 0x9E3779B97F4A7C15ULL) ^ (h3 << 1);
+    // LRM 9.2.2.2.1: for always_comb / always_latch the procedure-level
+    // sensitivity attaches to the body statement of the procedure.
+    if (proc->procedureKind == slang::ast::ProceduralBlockKind::AlwaysComb ||
+        proc->procedureKind == slang::ast::ProceduralBlockKind::AlwaysLatch) {
+      const auto& sens = ap.getSensitivityList();
+      if (sens.kind == slang::analysis::SensitivityList::Kind::Implicit) {
+        out.emplace(&proc->getBody(), TranslateReads(sens.reads));
       }
-    };
-    std::vector<lowering::ast_to_hir::SensitivityRead> entries;
-    std::unordered_set<DedupKey, DedupHash> seen;
-    for (const auto& read : sens.reads) {
-      const slang::ast::ValueSymbol* symbol = read.symbol;
-      if (!seen.insert({symbol, read.bitRange.first, read.bitRange.second})
-               .second) {
-        continue;
-      }
-      entries.push_back({.symbol = symbol, .bit_range = read.bitRange});
     }
-    out.emplace(proc, std::move(entries));
+    // LRM 9.4.2.2: each `@*` TimedStatement carries its own sensitivity.
+    // Slang surfaces this regardless of the overall SensitivityList::Kind,
+    // so the same procedure can contribute multiple statement-keyed entries.
+    for (const auto& region : ap.getImplicitEventReadSets()) {
+      out.emplace(region.statement, TranslateReads(region.reads));
+    }
   });
   manager.analyze(compilation);
   return out;

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -438,6 +438,19 @@ class HirDumper {
               out += "]";
               return out;
             },
+            [](const ImplicitEventControl& ie) -> std::string {
+              std::string out = "ImplicitEventControl sensitivity=[";
+              for (std::size_t i = 0; i < ie.sensitivity_list.size(); ++i) {
+                if (i != 0) out += ", ";
+                const auto& r = ie.sensitivity_list[i];
+                out += std::format(
+                    "{{hops={} var=StructuralVar[{}] bits=[{}:{}]}}",
+                    r.ref.hops.value, r.ref.var.value, r.bit_range.first,
+                    r.bit_range.second);
+              }
+              out += "]";
+              return out;
+            },
         },
         tc);
   }
@@ -939,6 +952,7 @@ class HirDumper {
                       FormatProcExpr(p, d.duration)));
             },
             [](const EventControl&) {},
+            [](const ImplicitEventControl&) {},
         },
         t.timing);
     Dedent();

--- a/src/lyra/lowering/ast_to_hir/process.cpp
+++ b/src/lyra/lowering/ast_to_hir/process.cpp
@@ -5,13 +5,12 @@
 #include <vector>
 
 #include <slang/ast/symbols/BlockSymbols.h>
-#include <slang/ast/symbols/ValueSymbol.h>
-#include <slang/ast/symbols/VariableSymbols.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/process.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
+#include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
 #include "lyra/lowering/ast_to_hir/statement/lower.hpp"
 
@@ -39,30 +38,18 @@ auto FromSlangProceduralBlockKind(slang::ast::ProceduralBlockKind kind)
       "ast_to_hir::FromSlangProceduralBlockKind: unknown ProceduralBlockKind");
 }
 
-// LRM 9.2.2.2.1 sensitivity is computed by slang::analysis::AnalysisManager;
-// here we translate the slang ValueSymbol pointers + bit ranges it produced
-// into the HIR StructuralVarRef + bit_range form used downstream.
-auto TranslateSensitivityEntries(
+// Looks up sensitivity for `key_stmt` from the precomputed slang analysis
+// and translates it into HIR identity entries. Empty result is legal (no
+// reads, or unknown key) -- a SensitivityWaitStmt with an empty list means
+// "wait forever", which is the correct degenerate behaviour.
+auto LookupSensitivityEntries(
     const UnitLoweringFacts& unit_facts, const UnitLoweringState& unit_state,
-    const ScopeStack& stack, const slang::ast::ProceduralBlockSymbol& proc)
+    const ScopeStack& stack, const slang::ast::Statement& key_stmt)
     -> std::vector<hir::SensitivityEntry> {
-  std::vector<hir::SensitivityEntry> out;
   const auto& reads_map = unit_facts.SensitivityReads();
-  const auto it = reads_map.find(&proc);
-  if (it == reads_map.end()) return out;
-  for (const auto& read : it->second) {
-    const auto* var = read.symbol->as_if<slang::ast::VariableSymbol>();
-    if (var == nullptr) continue;
-    const auto binding = unit_state.LookupStructuralVarBinding(*var);
-    if (!binding.has_value()) continue;
-    const auto hops = stack.HopsTo(binding->home_frame);
-    if (!hops.has_value()) continue;
-    out.push_back(
-        hir::SensitivityEntry{
-            .ref = hir::StructuralVarRef{.hops = *hops, .var = binding->var_id},
-            .bit_range = read.bit_range});
-  }
-  return out;
+  const auto it = reads_map.find(&key_stmt);
+  if (it == reads_map.end()) return {};
+  return TranslateSensitivityReads(it->second, unit_state, stack);
 }
 
 }  // namespace
@@ -85,8 +72,11 @@ auto LowerProcess(
   auto out = proc_state.Finalize(kind, span, root_stmt_id);
   if (kind == hir::ProcessKind::kAlwaysComb ||
       kind == hir::ProcessKind::kAlwaysLatch) {
-    out.implicit_sensitivity_list = TranslateSensitivityEntries(
-        unit_facts, scope_state.UnitState(), stack, proc);
+    // LRM 9.2.2.2.1: implicit sensitivity is a property of the always_comb /
+    // always_latch procedure itself (no `@*` token in source). Attach it to
+    // the Process; HIR -> MIR materialises the trailing wait stmt.
+    out.implicit_sensitivity_list = LookupSensitivityEntries(
+        unit_facts, scope_state.UnitState(), stack, proc.getBody());
   }
   return out;
 }

--- a/src/lyra/lowering/ast_to_hir/sensitivity.cpp
+++ b/src/lyra/lowering/ast_to_hir/sensitivity.cpp
@@ -1,0 +1,32 @@
+#include "lyra/lowering/ast_to_hir/sensitivity.hpp"
+
+#include <slang/ast/symbols/ValueSymbol.h>
+#include <slang/ast/symbols/VariableSymbols.h>
+
+#include "lyra/hir/value_ref.hpp"
+#include "lyra/lowering/ast_to_hir/state.hpp"
+
+namespace lyra::lowering::ast_to_hir {
+
+auto TranslateSensitivityReads(
+    const std::vector<SensitivityRead>& reads,
+    const UnitLoweringState& unit_state, const ScopeStack& stack)
+    -> std::vector<hir::SensitivityEntry> {
+  std::vector<hir::SensitivityEntry> out;
+  out.reserve(reads.size());
+  for (const auto& read : reads) {
+    const auto* var = read.symbol->as_if<slang::ast::VariableSymbol>();
+    if (var == nullptr) continue;
+    const auto binding = unit_state.LookupStructuralVarBinding(*var);
+    if (!binding.has_value()) continue;
+    const auto hops = stack.HopsTo(binding->home_frame);
+    if (!hops.has_value()) continue;
+    out.push_back(
+        hir::SensitivityEntry{
+            .ref = hir::StructuralVarRef{.hops = *hops, .var = binding->var_id},
+            .bit_range = read.bit_range});
+  }
+  return out;
+}
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -22,6 +22,7 @@
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/ast_to_hir/expression/lower.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
+#include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
 
 namespace lyra::lowering::ast_to_hir {
@@ -142,10 +143,10 @@ auto LowerTimingControl(
           hir::EventControl{.triggers = std::move(triggers)}};
     }
     case slang::ast::TimingControlKind::ImplicitEvent:
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedTimingControlKind,
-          "implicit event control (`@*`) is not yet supported",
-          diag::UnsupportedCategory::kFeature);
+      // `@*` / `@(*)` lowers to `hir::ImplicitEventControl`. The sensitivity
+      // list is filled in by LowerTimedStmt, which has access to the parent
+      // TimedStatement pointer needed for the slang-side lookup.
+      return hir::TimingControl{hir::ImplicitEventControl{}};
     case slang::ast::TimingControlKind::RepeatedEvent:
       return diag::Unsupported(
           span, diag::DiagCode::kUnsupportedTimingControlKind,
@@ -172,6 +173,18 @@ auto LowerTimedStmt(
   auto timing = LowerTimingControl(
       unit_facts, scope_state.UnitState(), proc_state, stack, ts.timing, span);
   if (!timing) return std::unexpected(std::move(timing.error()));
+  // LRM 9.4.2.2: `@*` carries its sensitivity from a slang side-channel
+  // keyed by this TimedStatement. The TimingControl shell came back empty
+  // from LowerTimingControl; fill it in here where we still have the
+  // parent statement pointer.
+  if (auto* ie = std::get_if<hir::ImplicitEventControl>(&*timing)) {
+    const auto& reads_map = unit_facts.SensitivityReads();
+    const auto it = reads_map.find(&ts);
+    if (it != reads_map.end()) {
+      ie->sensitivity_list =
+          TranslateSensitivityReads(it->second, scope_state.UnitState(), stack);
+    }
+  }
   auto inner_stmt =
       LowerStatement(unit_facts, proc_state, scope_state, stack, ts.stmt);
   if (!inner_stmt) return std::unexpected(std::move(inner_stmt.error()));

--- a/src/lyra/lowering/hir_to_mir/lower_process.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_process.cpp
@@ -11,6 +11,7 @@
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/lower_stmt.hpp"
 #include "lyra/lowering/hir_to_mir/procedural_scope_helpers.hpp"
+#include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/process.hpp"
 #include "lyra/mir/stmt.hpp"
@@ -35,10 +36,11 @@ auto LowerStraightLineProcess(
       .kind = kind, .root_procedural_scope = process_scope_state.Finish()};
 }
 
-// Lowers `src.root_stmt` into a forever-wrapped process. `tail_stmt`, if
-// present, is appended after the lowered body inside the loop -- carries a
-// SensitivityWaitStmt for always_comb / always_latch, nullopt for bare
-// always / always_ff. Composes during construction; no post-hoc mutation.
+// Wraps `src.root_stmt` in a `forever` loop. `tail_stmt`, if present, is
+// appended after the lowered body inside the loop -- carries the materialised
+// SensitivityWaitStmt for always_comb / always_latch (LRM 9.2.2.2.1), nullopt
+// for `always` / `always_ff` where the body itself carries any timing (e.g.
+// an explicit `@(...)` or `@*` wrapper).
 auto LowerForeverProcess(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state, const hir::Process& src,
@@ -77,27 +79,6 @@ auto LowerForeverProcess(
       .root_procedural_scope = process_scope_state.Finish()};
 }
 
-// Builds the tail stmt that gates an always_comb / always_latch on its LRM
-// 9.2.2.2.1 implicit sensitivity. Identity-shaped end-to-end -- distinct from
-// mir::EventTrigger (which carries an expression for explicit `@(...)`).
-auto BuildSensitivityWaitStmt(
-    const StructuralScopeLoweringState& scope_state, const hir::Process& src)
-    -> mir::Stmt {
-  std::vector<mir::SensitivityRead> reads;
-  reads.reserve(src.implicit_sensitivity_list.size());
-  for (const auto& entry : src.implicit_sensitivity_list) {
-    reads.push_back(
-        mir::SensitivityRead{
-            .ref = scope_state.TranslateStructuralVar(
-                entry.ref.hops, entry.ref.var),
-            .bit_range = entry.bit_range});
-  }
-  return mir::Stmt{
-      .label = std::nullopt,
-      .data = mir::SensitivityWaitStmt{.reads = std::move(reads)},
-      .child_procedural_scopes = {}};
-}
-
 }  // namespace
 
 auto LowerProcess(
@@ -120,7 +101,7 @@ auto LowerProcess(
     case hir::ProcessKind::kAlwaysLatch:
       return LowerForeverProcess(
           unit_state, scope_state, src, proc_state,
-          BuildSensitivityWaitStmt(scope_state, src));
+          BuildSensitivityWaitStmt(scope_state, src.implicit_sensitivity_list));
   }
   throw InternalError("LowerProcess: unknown HIR ProcessKind");
 }

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -20,6 +20,7 @@
 #include "lyra/lowering/hir_to_mir/lower_deferred_check.hpp"
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 #include "lyra/lowering/hir_to_mir/procedural_scope_helpers.hpp"
+#include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/procedural_hops.hpp"
 #include "lyra/mir/stmt.hpp"
@@ -119,6 +120,15 @@ auto LowerTimingControl(
             }
             return mir::TimingControl{
                 mir::EventControl{.triggers = std::move(triggers)}};
+          },
+          [](const hir::ImplicitEventControl&)
+              -> diag::Result<mir::TimingControl> {
+            // ImplicitEventControl never reaches the MIR TimingControl level:
+            // LowerTimedStmt intercepts it and expands the TimedStmt into a
+            // mir::Block { SensitivityWaitStmt; body; }.
+            throw InternalError(
+                "LowerTimingControl: ImplicitEventControl must be expanded by "
+                "LowerTimedStmt, not lowered as a MIR timing control");
           },
       },
       tc);
@@ -742,6 +752,38 @@ auto LowerContinueStmt(const hir::Stmt& stmt) -> diag::Result<mir::Stmt> {
       .child_procedural_scopes = {}};
 }
 
+// LRM 9.4.2.2: `@* body` -- the HIR TimedStmt with ImplicitEventControl
+// expands at HIR -> MIR into a Block { SensitivityWaitStmt; body; } inside a
+// fresh child scope. This is where HIR's slang-aligned wrapper structure
+// reduces to MIR's runtime-oriented "wait then body" sequencing.
+auto LowerImplicitEventTimedStmt(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    const hir::Stmt& stmt, const hir::TimedStmt& t,
+    const hir::ImplicitEventControl& ie) -> diag::Result<mir::Stmt> {
+  ProceduralScopeLoweringState child_proc_scope_state;
+  ProceduralDepthGuard depth_guard{proc_state};
+  child_proc_scope_state.AddRootStmt(child_proc_scope_state.AddStmt(
+      BuildSensitivityWaitStmt(scope_state, ie.sensitivity_list)));
+  const hir::Stmt& inner_hir = hir_proc.stmts.at(t.stmt.value);
+  auto inner_or = LowerStmt(
+      unit_state, scope_state, proc_state, child_proc_scope_state, hir_proc,
+      inner_hir);
+  if (!inner_or) {
+    return std::unexpected(std::move(inner_or.error()));
+  }
+  child_proc_scope_state.AddRootStmt(
+      child_proc_scope_state.AddStmt(*std::move(inner_or)));
+  std::vector<mir::ProceduralScope> child_scopes;
+  const mir::ProceduralScopeId scope_id =
+      AddChildProceduralScope(child_scopes, child_proc_scope_state.Finish());
+  return mir::Stmt{
+      .label = stmt.label,
+      .data = mir::BlockStmt{.scope = scope_id},
+      .child_procedural_scopes = std::move(child_scopes)};
+}
+
 auto LowerTimedStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
@@ -749,6 +791,10 @@ auto LowerTimedStmt(
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::Process& hir_proc, const hir::Stmt& stmt,
     const hir::TimedStmt& t) -> diag::Result<mir::Stmt> {
+  if (const auto* ie = std::get_if<hir::ImplicitEventControl>(&t.timing)) {
+    return LowerImplicitEventTimedStmt(
+        unit_state, scope_state, proc_state, hir_proc, stmt, t, *ie);
+  }
   auto timing_or = LowerTimingControl(
       unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
       t.timing);

--- a/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
+++ b/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
@@ -1,0 +1,30 @@
+#include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
+
+#include <utility>
+#include <vector>
+
+#include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/stmt.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+auto BuildSensitivityWaitStmt(
+    const StructuralScopeLoweringState& scope_state,
+    const std::vector<hir::SensitivityEntry>& sensitivity_list) -> mir::Stmt {
+  std::vector<mir::SensitivityRead> reads;
+  reads.reserve(sensitivity_list.size());
+  for (const auto& entry : sensitivity_list) {
+    reads.push_back(
+        mir::SensitivityRead{
+            .ref = scope_state.TranslateStructuralVar(
+                entry.ref.hops, entry.ref.var),
+            .bit_range = entry.bit_range});
+  }
+  return mir::Stmt{
+      .label = std::nullopt,
+      .data = mir::SensitivityWaitStmt{.reads = std::move(reads)},
+      .child_procedural_scopes = {}};
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/tests/cases/cpp/always_star_basic/case.yaml
+++ b/tests/cases/cpp/always_star_basic/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.always_star_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    c: 7

--- a/tests/cases/cpp/always_star_basic/main.sv
+++ b/tests/cases/cpp/always_star_basic/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  int a, b, c;
+
+  initial begin
+    a = 1;
+    b = 2;
+    #1;
+    a = 5;
+  end
+
+  always @* c = a + b;
+endmodule

--- a/tests/cases/cpp/always_star_block_body/case.yaml
+++ b/tests/cases/cpp/always_star_block_body/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.always_star_block_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sum: 9
+    diff: 5

--- a/tests/cases/cpp/always_star_block_body/main.sv
+++ b/tests/cases/cpp/always_star_block_body/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  int a, b, sum, diff;
+
+  initial begin
+    a = 1;
+    b = 0;
+    #1;
+    a = 7;
+    b = 2;
+    #1;
+  end
+
+  always @* begin
+    sum  = a + b;
+    diff = a - b;
+  end
+endmodule

--- a/tests/cases/cpp/always_star_paren_form/case.yaml
+++ b/tests/cases/cpp/always_star_paren_form/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.always_star_paren_form
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    c: 7

--- a/tests/cases/cpp/always_star_paren_form/main.sv
+++ b/tests/cases/cpp/always_star_paren_form/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  int a, b, c;
+
+  initial begin
+    a = 1;
+    b = 2;
+    #1;
+    a = 5;
+  end
+
+  always @(*) c = a + b;
+endmodule

--- a/tests/cases/cpp/always_star_reacts_to_change/case.yaml
+++ b/tests/cases/cpp/always_star_reacts_to_change/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.always_star_reacts_to_change
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    # result_at_t1 = 0 confirms LRM 9.4.2.2: `always @*` does NOT run at time
+    # zero, so it misses the initial-block writes that happen before its
+    # sensitivity subscription is in place.
+    result_at_t1: 0
+    result_after_a_change: 7
+    result_after_b_change: 15

--- a/tests/cases/cpp/always_star_reacts_to_change/main.sv
+++ b/tests/cases/cpp/always_star_reacts_to_change/main.sv
@@ -1,0 +1,21 @@
+module Top;
+  int a, b, sum;
+  int result_at_t1, result_after_a_change, result_after_b_change;
+
+  initial begin
+    a = 1;
+    b = 2;
+    #1;
+    // result_at_t1 captures sum BEFORE the @* body has run -- LRM 9.4.2.2
+    // says @* never runs at time zero, only on subsequent changes.
+    result_at_t1 = sum;
+    a = 5;
+    #1;
+    result_after_a_change = sum;
+    b = 10;
+    #1;
+    result_after_b_change = sum;
+  end
+
+  always @* sum = a + b;
+endmodule

--- a/tests/cases/cpp/event_negedge_from_x/case.yaml
+++ b/tests/cases/cpp/event_negedge_from_x/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.event_negedge_from_x
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    fired_on_x_to_0: 1
+    fired_on_1_to_x: 1

--- a/tests/cases/cpp/event_negedge_from_x/main.sv
+++ b/tests/cases/cpp/event_negedge_from_x/main.sv
@@ -1,0 +1,19 @@
+// LRM 9.4.2 Table 9-2: negedge fires on 1->{0,x,z} and {x,z}->0.
+module Top;
+  logic clk_a, clk_b;
+  int fired_on_1_to_x, fired_on_x_to_0;
+
+  initial begin
+    fired_on_1_to_x = 0;
+    fired_on_x_to_0 = 0;
+    clk_a = 1'b1;
+    clk_b = 1'bx;
+    #1;
+    clk_a = 1'bx;  // 1 -> x: should fire negedge
+    clk_b = 1'b0;  // x -> 0: should fire negedge
+    #1;
+  end
+
+  always @(negedge clk_a) fired_on_1_to_x = 1;
+  always @(negedge clk_b) fired_on_x_to_0 = 1;
+endmodule

--- a/tests/cases/cpp/event_posedge_from_x/case.yaml
+++ b/tests/cases/cpp/event_posedge_from_x/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.event_posedge_from_x
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    fired_on_x_to_1: 1
+    fired_on_0_to_x: 1

--- a/tests/cases/cpp/event_posedge_from_x/main.sv
+++ b/tests/cases/cpp/event_posedge_from_x/main.sv
@@ -1,0 +1,21 @@
+// LRM 9.4.2 Table 9-2: posedge fires on 0->{1,x,z} and {x,z}->1. This test
+// covers the 4-state corners (0->x and x->1) that pure-binary 0->1 edge
+// detection misses.
+module Top;
+  logic clk_a, clk_b;
+  int fired_on_0_to_x, fired_on_x_to_1;
+
+  initial begin
+    fired_on_0_to_x = 0;
+    fired_on_x_to_1 = 0;
+    clk_a = 1'b0;
+    clk_b = 1'bx;
+    #1;
+    clk_a = 1'bx;  // 0 -> x: should fire posedge
+    clk_b = 1'b1;  // x -> 1: should fire posedge
+    #1;
+  end
+
+  always @(posedge clk_a) fired_on_0_to_x = 1;
+  always @(posedge clk_b) fired_on_x_to_1 = 1;
+endmodule


### PR DESCRIPTION
## Summary

Wires `always @*` / `always @(*)` (LRM 9.4.2.2) end-to-end and fixes the 4-state edge detection table per LRM 9.4.2 Table 9-2 so posedge / negedge fire correctly when a signal transitions to or from `x` / `z`.

## Design

HIR mirrors slang's source-aligned shape: `always_comb` / `always_latch` keep the implicit sensitivity on `hir::Process::implicit_sensitivity_list` while the body is a plain statement (no `@*` token in source), whereas `always @*` produces a `hir::TimedStmt` whose timing is `hir::ImplicitEventControl{sensitivity_list}` wrapping the controlled body, mirroring slang's `TimedStatement(ImplicitEventControl, body)` 1:1. Both forms converge at HIR -> MIR onto the single `mir::SensitivityWaitStmt` leaf: `always_comb` / `always_latch` lower to `forever { body; SensitivityWaitStmt; }` (body runs at time zero, then waits), and `always @*` expands its TimedStmt into `forever { Block { SensitivityWaitStmt; body; } }` (waits first, no time-zero run). One statement-keyed `ImplicitSensitivityReads` map carries data for both forms.

`ClassifyEdge` in `runtime/var.hpp` is rewritten to cover the full 4-state transition table. Previously transitions from 0 or 1 to `x` / `z` were classified as `kChangeOnly`; per LRM Table 9-2 these are posedge (from 0) and negedge (from 1) respectively. `kBothEdges` (the `edge` keyword) already worked end-to-end and now correctly matches the broadened classification.

## Testing

- `bazel test //... --test_output=errors` (all green)
- New cases: `always_star_basic`, `always_star_paren_form`, `always_star_block_body`, `always_star_reacts_to_change`, `event_posedge_from_x`, `event_negedge_from_x`