### PR TITLE
Add real-family operators and structural variable initializers

### DIFF
--- a/docs/progress/datatypes.md
+++ b/docs/progress/datatypes.md
@@ -11,8 +11,11 @@ on the current pipeline.
 
 ## Actionable
 
-No enum work remaining. Next family: pick from `datatypes/string`, `datatypes/unpacked`,
-`datatypes/general`, `datatypes/real`, `datatypes/default_init`, `datatypes/representation`.
+Real C1 (decls / assignment / `%f` / `%e` / `%g`) landed in PR #789. Real C2 (arithmetic /
+relational / equality / logical operators on real, plus shortreal <-> real conversions) is in
+flight. Remaining real work: C3 (real <-> integral conversion) and C4 (LRM-illegal-form rejection).
+Other families remaining: `datatypes/string`, `datatypes/unpacked`, `datatypes/general`,
+`datatypes/default_init`, `datatypes/representation`.
 
 ## Enum
 
@@ -86,3 +89,63 @@ expansion vs runtime ops library is documented in `enum-method-architecture.md` 
 - Unblocks: C16 (enum-typed `case` selectors) in `control-flow.md`.
 - Slang reference: `slang/include/slang/ast/types/AllTypes.h` -- `EnumType`, `EnumValueSymbol`.
 - Legacy archive reference: `archived/include/lyra/common/type.hpp` -- `EnumInfo`, `EnumMember`.
+
+## Real
+
+Covers archive item `datatypes/real` (sub-folders `real_types`, `shortreal_types`,
+`realtime_types`). Per LRM 6.12, `real` is C `double`, `shortreal` is C `float`, and `realtime` is
+synonymous with `real`. Three runtime variants on `RuntimeValueView` (`Real64ValueView`,
+`Real32ValueView`) plus IEEE 754 round-trip-precision literal rendering (17 sig-digits for double, 9
+for float). Real values bypass the `Var<T>` wrapper because LRM 6.12 forbids edge event controls on
+real variables.
+
+- [x] C1 -- Declarations, blocking assignment, and `$display` formatting (`%f` / `%e` / `%g`). HIR
+      `RealLiteral` and MIR `RealLiteral` carry a `double` value; cpp emit renders `real` and
+      `realtime` to `double`, `shortreal` to `float`. `support::FormatDirectiveKind` and
+      `mir::FormatKind` split into `kRealDecimal` / `kRealExponential` / `kRealGeneral` so each
+      conversion specifier is a distinct semantic kind. `lower_print.cpp` routes the three real
+      kinds through `RuntimeValueView` real variants; `value::FormatValue` formats them via
+      `std::format` with `{:.{}f}`, `{:.{}e}`, `{:.{}g}` and default precision 6 (matches printf and
+      LRM Table 21-2). Covers the declaration / assignment / display cases across all three archive
+      subfolders (`real_declaration_*`, `*_local_variable`, `*_assignment` for
+      `real`/`shortreal`/`realtime`).
+- [x] C2 -- Operators legal on real per LRM 11.3.1 plus structural-level initializers
+      (`real a = 1.5;` at module scope). cpp emit splits `RenderBinaryOp` / `RenderUnaryOp` into
+      integral and real renderers. Real arithmetic uses native C++ ops; `**` uses `std::pow` (C++
+      overload resolution picks `(float, float) -> float` and `(double, double) -> double`, matching
+      LRM 11.3.1 result typing). The C++ bool result of a real relational / equality / logical op is
+      wrapped in `lyra::value::PackedArray::FromInt(..., 1, false, false)` so the runtime sees the
+      1-bit integral shape the rest of the pipeline expects. shortreal <-> real conversions go
+      through `ConversionExpr`: same-precision is pass-through; cross-precision emits
+      `static_cast<float>` / `static_cast<double>` so C++ never sees an implicit narrowing.
+      `<cmath>` joins the emit prologue. Structural-level initializers are wired end-to-end:
+      `hir::StructuralVarDecl` carries an optional `initializer` ExprId; AST -> HIR extracts
+      `var.getInitializer()` for real-family types via `LowerStructuralExpr`; HIR -> MIR appends an
+      `ExprStmt(AssignExpr)` per initialized var into the scope's `constructor_scope`; cpp emit's
+      existing fall-through `(target = value)` arm lands the assignment in the C++ constructor body.
+      This is safe for real-family vars because they do not wrap in `Var<T>` and therefore do not
+      need `services_`. Integral structural initializers remain a known gap (their
+      `Var<PackedArray>` write path needs `services_`, which is not bound until `Bind()`).
+- [ ] C3 -- Cross-family conversions: integral -> real (4-state x / z bits map to 0 per LRM 6.12.1)
+      and real -> integral (round-half-away-from-zero per LRM 6.12.1, _not_ truncate).
+      `int_literal_to_real` is the constant-folded subset; `int_to_real_conversion`,
+      `real_to_int_conversion`, `real_to_int_negative` exercise the runtime paths in
+      `real`/`shortreal`/`realtime` subfolders. Slang's `SVInt::fromDouble` already defaults
+      `round=true`, so the integer-side conversion needs only to invoke it; the bit-level `x/z -> 0`
+      step happens before promotion to double.
+- [ ] C4 -- LRM-illegal forms on real (LRM 6.12 + 11.3.1 / Table 11-1): edge event control
+      (`posedge` / `negedge` / `edge`) on real, bit-select / part-select of real, modulus `%` on
+      real, bitwise / reduction / shift / wildcard / case-equality on real. Reject in AST -> HIR
+      with `diag::Unsupported` carrying the LRM citation. No new behavior is enabled; this is solely
+      about producing a diagnostic instead of an `InternalError` for programs that compile under
+      slang but fall outside the legal real surface.
+
+### Cross-references
+
+- LRM 6.12 (Real, shortreal, realtime), 6.12.1 (Conversion), 11.3.1 (Operators with real operands),
+  Table 11-1 (Operators and data types), 11.4.3 (Arithmetic), 11.4.4 (Relational), 11.4.5
+  (Equality), 11.4.7 (Logical), 11.4.11 (Conditional), 21.2 / Table 21-2 (Format specifiers).
+- Archive items: `datatypes/real/{real_types,shortreal_types,realtime_types}`.
+- Display sub-step `display.md` DI3 (`%f` / `%e` / `%g`) lands together with C1.
+- IEEE 754 round-trip widths (17 / 9) keep emitted constants bit-identical across recompile;
+  documented inline in `render_expr.cpp`.

--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -16,9 +16,11 @@ implemented specifier.
 - [ ] DI2 -- `%t` (time). Format a time value against the active timescale. `lower_print.cpp`
       currently returns `kFormatSpecifierNotImplemented` for `kTime`. Requires a time variant on
       `RuntimeValueView` and time-unit awareness on the format spec.
-- [ ] DI3 -- `%f` / `%e` / `%g` (real). Format a real value. `lower_print.cpp` currently returns
-      `kFormatSpecifierNotImplemented` for `kReal`. Requires a real variant on `RuntimeValueView`
-      and a real path through HIR/MIR (no `real` type support today).
+- [x] DI3 -- `%f` / `%e` / `%g` (real). Shipped via real-types C1 in PR #789. `FormatKind` split
+      into `kRealDecimal` / `kRealExponential` / `kRealGeneral`; `RuntimeValueView` gained
+      `Real64ValueView` and `Real32ValueView`; `value::FormatValue` dispatches each kind through
+      `std::format` (`{:.{}f}`, `{:.{}e}`, `{:.{}g}`) with default precision 6 per LRM Table 21-2.
+      Coverage tracked under `datatypes.md` "Real" -> C1.
 - [ ] DI4 -- `%m` (hierarchical name). Requires runtime exposure of the current scope's hierarchical
       path. `lower_print.cpp` currently returns `kFormatModulePathNotImplemented`. Shares its
       underlying mechanism with the archive item `hierarchy/refs`, which the `expect.variables`

--- a/include/lyra/hir/structural_var.hpp
+++ b/include/lyra/hir/structural_var.hpp
@@ -2,9 +2,11 @@
 
 #include <compare>
 #include <cstdint>
+#include <optional>
 #include <string>
 
-#include "lyra/hir/type.hpp"
+#include "lyra/hir/expr_id.hpp"
+#include "lyra/hir/type_id.hpp"
 
 namespace lyra::hir {
 
@@ -15,9 +17,14 @@ struct StructuralVarId {
       -> std::strong_ordering = default;
 };
 
+// SV LRM 10.4 + 6.21: structural variable declarations may carry an
+// initializer expression evaluated at construction time (before any process
+// runs). The initializer lives in the enclosing scope's `exprs` table; we
+// reference it by id so the decl stays a flat row alongside other vars.
 struct StructuralVarDecl {
   std::string name;
   TypeId type;
+  std::optional<ExprId> initializer;
 };
 
 }  // namespace lyra::hir

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -255,12 +255,17 @@ class ScopeLoweringState {
       : unit_state_(&unit_state), scope_(&scope), frame_(frame) {
   }
 
-  auto AddStructuralVar(const slang::ast::VariableSymbol& var, hir::TypeId type)
+  auto AddStructuralVar(
+      const slang::ast::VariableSymbol& var, hir::TypeId type,
+      std::optional<hir::ExprId> initializer = std::nullopt)
       -> hir::StructuralVarId {
     const hir::StructuralVarId local{
         static_cast<std::uint32_t>(scope_->structural_vars.size())};
     scope_->structural_vars.push_back(
-        hir::StructuralVarDecl{.name = std::string{var.name}, .type = type});
+        hir::StructuralVarDecl{
+            .name = std::string{var.name},
+            .type = type,
+            .initializer = initializer});
     unit_state_->MapStructuralVarBinding(var, frame_, local, type);
     return local;
   }

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -246,6 +246,7 @@ auto RenderScopeHeaderFile(
   std::string out;
   out += "#pragma once\n";
   out += "#include <array>\n";
+  out += "#include <cmath>\n";
   out += "#include <cstdint>\n";
   out += "#include <memory>\n";
   out += "#include <span>\n";

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -31,7 +31,260 @@ namespace lyra::backend::cpp {
 
 namespace {
 
-auto RenderBinaryOp(
+// Type-kind predicate. `real`, `shortreal`, and `realtime` (LRM 6.12)
+// collectively form the "real family"; arithmetic / relational / logical
+// operator dispatch all branch on this. Taking the full `mir::Type` instead
+// of `TypeKind` keeps the call-site spelling consistent with `IsIntegralPacked`
+// / `IsEnum` on `mir::Type` itself.
+auto IsRealFamilyType(const mir::Type& ty) -> bool {
+  return ty.Kind() == mir::TypeKind::kReal ||
+         ty.Kind() == mir::TypeKind::kShortReal ||
+         ty.Kind() == mir::TypeKind::kRealTime;
+}
+
+auto IntegralConstantToInt64(const mir::IntegralConstant& c) -> std::int64_t {
+  if (c.width == 0U) {
+    throw InternalError("IntegralConstantToInt64: zero width");
+  }
+  if (c.width > 64U) {
+    throw InternalError(
+        "IntegralConstantToInt64: width > 64 not yet implemented");
+  }
+  std::uint64_t raw = c.value_words.empty() ? 0U : c.value_words[0];
+  // 4-state X/Z bits collapse to 0 in the numeric int64 form.
+  if (!c.state_words.empty()) {
+    raw &= ~c.state_words[0];
+  }
+  const std::uint64_t mask =
+      c.width >= 64U ? ~std::uint64_t{0} : (std::uint64_t{1} << c.width) - 1U;
+  const std::uint64_t masked = raw & mask;
+  if (c.signedness == mir::Signedness::kSigned && c.width < 64U) {
+    const std::uint64_t sign_bit = std::uint64_t{1} << (c.width - 1U);
+    if ((masked & sign_bit) != 0U) {
+      return static_cast<std::int64_t>(masked | ~mask);
+    }
+  }
+  return static_cast<std::int64_t>(masked);
+}
+
+auto RenderWordList(std::span<const std::uint64_t> words, std::size_t n)
+    -> std::string {
+  std::string out = "{";
+  for (std::size_t i = 0; i < n; ++i) {
+    if (i != 0U) {
+      out += ", ";
+    }
+    const std::uint64_t w = i < words.size() ? words[i] : std::uint64_t{0};
+    out += std::format("0x{:x}ULL", w);
+  }
+  out += "}";
+  return out;
+}
+
+auto RenderPackedArrayIntegerLiteral(
+    const mir::PackedArrayType& pa, const mir::IntegralConstant& c)
+    -> std::string {
+  // Narrow + no X/Z fits a single int64 carrier and reads better as
+  // PackedArray::Int / FromInt. Wide literals or X/Z-bearing literals must
+  // round-trip through explicit value/unknown word planes via FromWords.
+  const bool literal_has_xz = !c.state_words.empty() && c.state_words[0] != 0U;
+  const bool needs_word_planes = c.width > 64U || literal_has_xz;
+
+  if (!needs_word_planes) {
+    const auto value = IntegralConstantToInt64(c);
+    if (pa.BitWidth() == 32U && pa.signedness == mir::Signedness::kSigned &&
+        pa.atom == mir::BitAtom::kBit) {
+      return std::format("lyra::value::PackedArray::Int({})", value);
+    }
+    return std::format(
+        "lyra::value::PackedArray::FromInt({}LL, {})", value,
+        RenderPackedArrayCtorArgs(pa));
+  }
+
+  const bool is_four_state = pa.atom != mir::BitAtom::kBit;
+  if (literal_has_xz && !is_four_state) {
+    throw InternalError(
+        "RenderPackedArrayIntegerLiteral: 2-state PackedArray cannot hold "
+        "X/Z literal");
+  }
+  const std::size_t n = (pa.BitWidth() + 63U) / 64U;
+  const std::string value_init = RenderWordList(c.value_words, n);
+  const std::string unknown_init =
+      is_four_state ? RenderWordList(c.state_words, n) : std::string{"{}"};
+  return std::format(
+      "lyra::value::PackedArray::FromWords({}, {}, {})", value_init,
+      unknown_init, RenderPackedArrayCtorArgs(pa));
+}
+
+auto RenderIntegerLiteralExpr(
+    const RenderContext& ctx, const mir::Expr& expr,
+    const mir::IntegerLiteral& lit) -> diag::Result<std::string> {
+  const auto& ty = ctx.Unit().GetType(expr.type);
+  if (!ty.IsIntegralPacked()) {
+    throw InternalError(
+        "RenderIntegerLiteralExpr: IntegerLiteral not typed as "
+        "PackedArrayType or EnumType");
+  }
+  auto body = RenderPackedArrayIntegerLiteral(ty.AsIntegralPacked(), lit.value);
+  if (ty.IsEnum()) {
+    return std::format(
+        "{}{{{}}}", RenderEnumClassName(ctx.StructuralScope(), expr.type),
+        body);
+  }
+  return body;
+}
+
+auto RenderRealLiteralExpr(
+    const RenderContext& ctx, const mir::Expr& expr, const mir::RealLiteral& r)
+    -> std::string {
+  // `std::format` with `{:.{}g}` and precision=17 round-trips a double;
+  // precision=9 round-trips a float (IEEE 754 minimum representable-pair
+  // widths). The trailing 'f' suffix on the float form keeps the C++ literal
+  // type matched to the destination `float` so overload resolution and
+  // initialization both land on the shortreal path.
+  const auto& ty = ctx.Unit().GetType(expr.type);
+  if (ty.Kind() == mir::TypeKind::kShortReal) {
+    return std::format("{:.9g}f", r.value);
+  }
+  return std::format("{:.17g}", r.value);
+}
+
+auto RenderStructuralParamExpr(
+    const RenderContext& ctx, const mir::StructuralParamRef& r)
+    -> diag::Result<std::string> {
+  if (r.hops.value != 0) {
+    return diag::Unsupported(
+        diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+        "cross-scope structural parameter access is not yet implemented in "
+        "cpp emit",
+        diag::UnsupportedCategory::kFeature);
+  }
+  return ctx.StructuralScope().GetStructuralParam(r.param).name;
+}
+
+auto LookupProceduralVarName(
+    const RenderContext& ctx, const mir::ProceduralVarRef& ref)
+    -> const std::string& {
+  return ctx.ProceduralScopeAtHops(ref.hops).vars.at(ref.var.value).name;
+}
+
+}  // namespace
+
+auto RenderStructuralVarName(
+    const RenderContext& ctx, const mir::StructuralVarRef& ref)
+    -> diag::Result<std::string> {
+  if (ref.hops.value != 0) {
+    return diag::Unsupported(
+        diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+        "cross-scope structural var access is not yet implemented in cpp "
+        "emit",
+        diag::UnsupportedCategory::kFeature);
+  }
+  return ctx.StructuralScope().GetStructuralVar(ref.var).name;
+}
+
+auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
+    -> diag::Result<std::string> {
+  return std::visit(
+      Overloaded{
+          [&](const mir::StructuralVarRef& m) -> diag::Result<std::string> {
+            return RenderStructuralVarName(ctx, m);
+          },
+          [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
+            return LookupProceduralVarName(ctx, l);
+          },
+      },
+      target);
+}
+
+namespace {
+
+// Read-side render for a structural var ref. Integral packed vars wrap in
+// `Var<PackedArray>` whose held value is observed via `.Get()`; all other
+// storage types (real-family, string, ObjectType) expose the value directly,
+// so the bare field name is the C++ read expression. Writes use
+// `RenderStructuralVarName` directly (no `.Get()`); the read/write split is
+// intentional and lives at this boundary.
+auto RenderStructuralVarReadExpr(
+    const RenderContext& ctx, const mir::Expr& expr,
+    const mir::StructuralVarRef& m) -> diag::Result<std::string> {
+  auto name_or = RenderStructuralVarName(ctx, m);
+  if (!name_or) return std::unexpected(std::move(name_or.error()));
+  if (ctx.Unit().GetType(expr.type).IsIntegralPacked()) {
+    return *name_or + ".Get()";
+  }
+  return *name_or;
+}
+
+// Builds the C++ literal that materializes a 1-bit PackedArray of the SV-typed
+// shape carried by `result_ty`. Used to wrap the C++ `bool` result of a
+// real-operand relational / equality / logical operator into the 1-bit
+// integral PackedArray result type LRM 11.3.1 prescribes.
+auto WrapBoolAsResultShape(
+    const mir::Type& result_ty, std::string_view bool_expr) -> std::string {
+  if (!result_ty.IsIntegralPacked()) {
+    throw InternalError(
+        "WrapBoolAsResultShape: real comparison / logical result type is "
+        "not an integral PackedArray; MIR invariant violated");
+  }
+  return std::format(
+      "lyra::value::PackedArray::FromInt(({}) ? 1LL : 0LL, {})", bool_expr,
+      RenderPackedArrayCtorArgs(result_ty.AsIntegralPacked()));
+}
+
+auto RenderBinaryOpReal(
+    mir::BinaryOp op, const std::string& lhs, const std::string& rhs,
+    const mir::Type& result_ty) -> diag::Result<std::string> {
+  // LRM 11.3.1 + Table 11-1: arithmetic on real produces real; relational /
+  // logical / equality produce a 1-bit integral that the runtime sees as a
+  // PackedArray view. `std::pow` overload resolution picks (float, float) ->
+  // float and (double, double) -> double, matching LRM 11.3.1's result type
+  // for shortreal-only vs any-real expressions.
+  switch (op) {
+    case mir::BinaryOp::kAdd:
+      return "(" + lhs + " + " + rhs + ")";
+    case mir::BinaryOp::kSub:
+      return "(" + lhs + " - " + rhs + ")";
+    case mir::BinaryOp::kMul:
+      return "(" + lhs + " * " + rhs + ")";
+    case mir::BinaryOp::kDiv:
+      return "(" + lhs + " / " + rhs + ")";
+    case mir::BinaryOp::kPower:
+      return "std::pow(" + lhs + ", " + rhs + ")";
+    case mir::BinaryOp::kLessThan:
+      return WrapBoolAsResultShape(result_ty, lhs + " < " + rhs);
+    case mir::BinaryOp::kLessEqual:
+      return WrapBoolAsResultShape(result_ty, lhs + " <= " + rhs);
+    case mir::BinaryOp::kGreaterThan:
+      return WrapBoolAsResultShape(result_ty, lhs + " > " + rhs);
+    case mir::BinaryOp::kGreaterEqual:
+      return WrapBoolAsResultShape(result_ty, lhs + " >= " + rhs);
+    case mir::BinaryOp::kEquality:
+      return WrapBoolAsResultShape(result_ty, lhs + " == " + rhs);
+    case mir::BinaryOp::kInequality:
+      return WrapBoolAsResultShape(result_ty, lhs + " != " + rhs);
+    case mir::BinaryOp::kLogicalAnd:
+      return WrapBoolAsResultShape(
+          result_ty, "bool(" + lhs + ") && bool(" + rhs + ")");
+    case mir::BinaryOp::kLogicalOr:
+      return WrapBoolAsResultShape(
+          result_ty, "bool(" + lhs + ") || bool(" + rhs + ")");
+    case mir::BinaryOp::kLogicalImplication:
+      return WrapBoolAsResultShape(
+          result_ty, "!bool(" + lhs + ") || bool(" + rhs + ")");
+    case mir::BinaryOp::kLogicalEquivalence:
+      return WrapBoolAsResultShape(
+          result_ty, "bool(" + lhs + ") == bool(" + rhs + ")");
+    default:
+      break;
+  }
+  return diag::Unsupported(
+      diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+      "binary operator is not legal on real operands per LRM 11.3.1",
+      diag::UnsupportedCategory::kFeature);
+}
+
+auto RenderBinaryOpIntegral(
     mir::BinaryOp op, const std::string& lhs, const std::string& rhs)
     -> diag::Result<std::string> {
   std::string_view tok;
@@ -108,7 +361,26 @@ auto RenderBinaryOp(
   return "(" + lhs + std::string{tok} + rhs + ")";
 }
 
-auto RenderUnaryOp(mir::UnaryOp op, const std::string& operand)
+auto RenderUnaryOpReal(
+    mir::UnaryOp op, const std::string& operand, const mir::Type& result_ty)
+    -> diag::Result<std::string> {
+  switch (op) {
+    case mir::UnaryOp::kPlus:
+      return "(" + operand + ")";
+    case mir::UnaryOp::kMinus:
+      return "(-(" + operand + "))";
+    case mir::UnaryOp::kLogicalNot:
+      return WrapBoolAsResultShape(result_ty, "!bool(" + operand + ")");
+    default:
+      break;
+  }
+  return diag::Unsupported(
+      diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+      "unary operator is not legal on real operands per LRM 11.3.1",
+      diag::UnsupportedCategory::kFeature);
+}
+
+auto RenderUnaryOpIntegral(mir::UnaryOp op, const std::string& operand)
     -> diag::Result<std::string> {
   switch (op) {
     case mir::UnaryOp::kPlus:
@@ -132,176 +404,43 @@ auto RenderUnaryOp(mir::UnaryOp op, const std::string& operand)
     case mir::UnaryOp::kReductionXnor:
       return "(" + operand + ").ReductionXnor()";
   }
-  throw InternalError("RenderUnaryOp: unknown MIR UnaryOp");
+  throw InternalError("RenderUnaryOpIntegral: unknown MIR UnaryOp");
 }
 
-auto LookupProceduralVarName(
-    const RenderContext& ctx, const mir::ProceduralVarRef& ref)
-    -> const std::string& {
-  return ctx.ProceduralScopeAtHops(ref.hops).vars.at(ref.var.value).name;
-}
-
-auto IntegralConstantToInt64(const mir::IntegralConstant& c) -> std::int64_t {
-  if (c.width == 0U) {
-    throw InternalError("IntegralConstantToInt64: zero width");
-  }
-  if (c.width > 64U) {
-    throw InternalError(
-        "IntegralConstantToInt64: width > 64 not yet implemented");
-  }
-  std::uint64_t raw = c.value_words.empty() ? 0U : c.value_words[0];
-  // 4-state X/Z bits collapse to 0 in the numeric int64 form.
-  if (!c.state_words.empty()) {
-    raw &= ~c.state_words[0];
-  }
-  const std::uint64_t mask =
-      c.width >= 64U ? ~std::uint64_t{0} : (std::uint64_t{1} << c.width) - 1U;
-  const std::uint64_t masked = raw & mask;
-  if (c.signedness == mir::Signedness::kSigned && c.width < 64U) {
-    const std::uint64_t sign_bit = std::uint64_t{1} << (c.width - 1U);
-    if ((masked & sign_bit) != 0U) {
-      return static_cast<std::int64_t>(masked | ~mask);
-    }
-  }
-  return static_cast<std::int64_t>(masked);
-}
-
-auto RenderWordList(std::span<const std::uint64_t> words, std::size_t n)
-    -> std::string {
-  std::string out = "{";
-  for (std::size_t i = 0; i < n; ++i) {
-    if (i != 0U) {
-      out += ", ";
-    }
-    const std::uint64_t w = i < words.size() ? words[i] : std::uint64_t{0};
-    out += std::format("0x{:x}ULL", w);
-  }
-  out += "}";
-  return out;
-}
-
-auto RenderPackedArrayIntegerLiteral(
-    const mir::PackedArrayType& pa, const mir::IntegralConstant& c)
-    -> std::string {
-  const bool is_four_state = pa.atom != mir::BitAtom::kBit;
-  const char* signed_lit =
-      pa.signedness == mir::Signedness::kSigned ? "true" : "false";
-  const char* four_state_lit = is_four_state ? "true" : "false";
-
-  // Narrow + no X/Z fits a single int64 carrier and reads better as
-  // PackedArray::Int / FromInt. Wide literals or X/Z-bearing literals must
-  // round-trip through explicit value/unknown word planes via FromWords.
-  const bool literal_has_xz = !c.state_words.empty() && c.state_words[0] != 0U;
-  const bool needs_word_planes = c.width > 64U || literal_has_xz;
-
-  if (!needs_word_planes) {
-    const auto value = IntegralConstantToInt64(c);
-    if (pa.BitWidth() == 32U && pa.signedness == mir::Signedness::kSigned &&
-        pa.atom == mir::BitAtom::kBit) {
-      return std::format("lyra::value::PackedArray::Int({})", value);
-    }
-    return std::format(
-        "lyra::value::PackedArray::FromInt({}LL, {}, {}, {})", value,
-        pa.BitWidth(), signed_lit, four_state_lit);
-  }
-
-  if (literal_has_xz && !is_four_state) {
-    throw InternalError(
-        "RenderPackedArrayIntegerLiteral: 2-state PackedArray cannot hold "
-        "X/Z literal");
-  }
-  const std::size_t n = (pa.BitWidth() + 63U) / 64U;
-  const std::string value_init = RenderWordList(c.value_words, n);
-  const std::string unknown_init =
-      is_four_state ? RenderWordList(c.state_words, n) : std::string{"{}"};
-  return std::format(
-      "lyra::value::PackedArray::FromWords({}, {}, {}, {}, {})", value_init,
-      unknown_init, pa.BitWidth(), signed_lit, four_state_lit);
-}
-
-auto RenderIntegerLiteralExpr(
-    const RenderContext& ctx, const mir::Expr& expr,
-    const mir::IntegerLiteral& lit) -> diag::Result<std::string> {
-  const auto& ty = ctx.Unit().GetType(expr.type);
-  if (!ty.IsIntegralPacked()) {
-    throw InternalError(
-        "RenderExpr: IntegerLiteral not typed as PackedArrayType or "
-        "EnumType");
-  }
-  auto body = RenderPackedArrayIntegerLiteral(ty.AsIntegralPacked(), lit.value);
-  if (ty.IsEnum()) {
-    return std::format(
-        "{}{{{}}}", RenderEnumClassName(ctx.StructuralScope(), expr.type),
-        body);
-  }
-  return body;
-}
-
-auto RenderStructuralParamExpr(
-    const RenderContext& ctx, const mir::StructuralParamRef& r)
+auto RenderUnaryExpr(
+    const RenderContext& ctx, const mir::Expr& expr, const mir::UnaryExpr& u)
     -> diag::Result<std::string> {
-  if (r.hops.value != 0) {
-    return diag::Unsupported(
-        diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-        "cross-scope structural parameter access is not yet implemented in "
-        "cpp emit",
-        diag::UnsupportedCategory::kFeature);
-  }
-  return ctx.StructuralScope().GetStructuralParam(r.param).name;
-}
-
-}  // namespace
-
-auto RenderStructuralVarName(
-    const RenderContext& ctx, const mir::StructuralVarRef& ref)
-    -> diag::Result<std::string> {
-  if (ref.hops.value != 0) {
-    return diag::Unsupported(
-        diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-        "cross-scope structural var access is not yet implemented in cpp "
-        "emit",
-        diag::UnsupportedCategory::kFeature);
-  }
-  return ctx.StructuralScope().GetStructuralVar(ref.var).name;
-}
-
-auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
-    -> diag::Result<std::string> {
-  return std::visit(
-      Overloaded{
-          [&](const mir::StructuralVarRef& m) -> diag::Result<std::string> {
-            return RenderStructuralVarName(ctx, m);
-          },
-          [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
-            return LookupProceduralVarName(ctx, l);
-          },
-      },
-      target);
-}
-
-namespace {
-
-auto RenderClosureExpr(
-    const RenderContext& ctx, const mir::ClosureExpr& closure)
-    -> diag::Result<std::string>;
-
-auto RenderUnaryExpr(const RenderContext& ctx, const mir::UnaryExpr& u)
-    -> diag::Result<std::string> {
-  auto operand_or = RenderExpr(ctx, ctx.Expr(u.operand));
+  const auto& operand_expr = ctx.Expr(u.operand);
+  auto operand_or = RenderExpr(ctx, operand_expr);
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-  return RenderUnaryOp(u.op, *operand_or);
+  if (IsRealFamilyType(ctx.Unit().GetType(operand_expr.type))) {
+    return RenderUnaryOpReal(u.op, *operand_or, ctx.Unit().GetType(expr.type));
+  }
+  return RenderUnaryOpIntegral(u.op, *operand_or);
 }
 
-auto RenderBinaryExprNode(const RenderContext& ctx, const mir::BinaryExpr& b)
+auto RenderBinaryExpr(
+    const RenderContext& ctx, const mir::Expr& expr, const mir::BinaryExpr& b)
     -> diag::Result<std::string> {
-  auto lhs_or = RenderExpr(ctx, ctx.Expr(b.lhs));
+  const auto& lhs_expr = ctx.Expr(b.lhs);
+  const auto& rhs_expr = ctx.Expr(b.rhs);
+  auto lhs_or = RenderExpr(ctx, lhs_expr);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  auto rhs_or = RenderExpr(ctx, ctx.Expr(b.rhs));
+  auto rhs_or = RenderExpr(ctx, rhs_expr);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  return RenderBinaryOp(b.op, *lhs_or, *rhs_or);
+  // Slang inserts a propagated `ConversionExpr` on the narrower operand so by
+  // the time we reach a binary op both sides are the same real precision. If
+  // either side is real-family, dispatch to the real renderer.
+  const bool is_real = IsRealFamilyType(ctx.Unit().GetType(lhs_expr.type)) ||
+                       IsRealFamilyType(ctx.Unit().GetType(rhs_expr.type));
+  if (is_real) {
+    return RenderBinaryOpReal(
+        b.op, *lhs_or, *rhs_or, ctx.Unit().GetType(expr.type));
+  }
+  return RenderBinaryOpIntegral(b.op, *lhs_or, *rhs_or);
 }
 
-auto RenderConditionalExprNode(
+auto RenderConditionalExpr(
     const RenderContext& ctx, const mir::ConditionalExpr& c)
     -> diag::Result<std::string> {
   auto cond_or = RenderConditionAsBool(ctx, ctx.Expr(c.condition));
@@ -313,12 +452,15 @@ auto RenderConditionalExprNode(
   return "(" + *cond_or + " ? " + *then_or + " : " + *else_or + ")";
 }
 
-auto RenderAssignExprNode(const RenderContext& ctx, const mir::AssignExpr& a)
+auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
     -> diag::Result<std::string> {
   auto target_or = RenderLvalue(ctx, a.target);
   if (!target_or) return std::unexpected(std::move(target_or.error()));
   auto value_or = RenderExpr(ctx, ctx.Expr(a.value));
   if (!value_or) return std::unexpected(std::move(value_or.error()));
+  // Writes to a `Var<T>`-wrapped structural var go through `WriteVar` so the
+  // runtime can fire value-change triggers. Raw fields (real-family, string)
+  // use plain C++ assignment.
   if (const auto* svr = std::get_if<mir::StructuralVarRef>(&a.target)) {
     const auto& var_decl = ctx.StructuralScope().GetStructuralVar(svr->var);
     if (IsObservableScalarType(ctx.Unit().GetType(var_decl.type))) {
@@ -329,15 +471,176 @@ auto RenderAssignExprNode(const RenderContext& ctx, const mir::AssignExpr& a)
   return "(" + *target_or + " = " + *value_or + ")";
 }
 
+// SV LRM 6.12.1 + 6.22: real-family conversions are pure float-precision
+// reshape. `realtime` is a synonym for `real`, so both share `double`. The
+// only emit-time work is on shortreal <-> real: insert an explicit
+// `static_cast` so the C++ compiler does not flag the narrowing direction.
+auto RenderRealConversion(
+    std::string operand, const mir::Type& src_ty, const mir::Type& dst_ty)
+    -> std::string {
+  const bool src_is_short = src_ty.Kind() == mir::TypeKind::kShortReal;
+  const bool dst_is_short = dst_ty.Kind() == mir::TypeKind::kShortReal;
+  if (src_is_short == dst_is_short) {
+    return operand;
+  }
+  return std::format(
+      "static_cast<{}>({})", dst_is_short ? "float" : "double", operand);
+}
+
+// Integral-to-integral conversions reshape a PackedArray to a possibly-
+// different width / signedness / state. Same-shape is pass-through (slang
+// emits spurious self-conversions). Enum endpoints layer two extra wraps on
+// top of the integral body so the C++ static type matches LRM 6.19.3's
+// explicit-cast requirement: integral -> enum wraps with the enum class's
+// converting ctor; enum -> integral slices the enum subobject into a plain
+// PackedArray for downstream template deduction.
+auto RenderIntegralConversion(
+    const RenderContext& ctx, mir::TypeId dst_type_id, std::string operand,
+    const mir::PackedArrayType& src_pa, const mir::PackedArrayType& dst_pa,
+    bool src_is_enum, bool dst_is_enum) -> std::string {
+  std::string body;
+  if (src_pa.BitWidth() == dst_pa.BitWidth() &&
+      src_pa.signedness == dst_pa.signedness && src_pa.atom == dst_pa.atom) {
+    body = std::move(operand);
+  } else {
+    body = std::format(
+        "lyra::value::PackedArray::ConvertFrom({}, {})", operand,
+        RenderPackedArrayCtorArgs(dst_pa));
+  }
+  if (dst_is_enum) {
+    return std::format(
+        "{}{{{}}}", RenderEnumClassName(ctx.StructuralScope(), dst_type_id),
+        body);
+  }
+  if (src_is_enum) {
+    return std::format("lyra::value::PackedArray{{{}}}", body);
+  }
+  return body;
+}
+
+auto RenderConversionExpr(
+    const RenderContext& ctx, const mir::Expr& expr,
+    const mir::ConversionExpr& cv) -> diag::Result<std::string> {
+  const auto& src_expr = ctx.Expr(cv.operand);
+  auto operand_or = RenderExpr(ctx, src_expr);
+  if (!operand_or) return std::unexpected(std::move(operand_or.error()));
+  const auto& src_ty = ctx.Unit().GetType(src_expr.type);
+  const auto& dst_ty = ctx.Unit().GetType(expr.type);
+  if (IsRealFamilyType(src_ty) && IsRealFamilyType(dst_ty)) {
+    return RenderRealConversion(*std::move(operand_or), src_ty, dst_ty);
+  }
+  if (src_ty.IsIntegralPacked() && dst_ty.IsIntegralPacked()) {
+    return RenderIntegralConversion(
+        ctx, expr.type, *std::move(operand_or), src_ty.AsIntegralPacked(),
+        dst_ty.AsIntegralPacked(), src_ty.IsEnum(), dst_ty.IsEnum());
+  }
+  return *std::move(operand_or);
+}
+
+auto BuiltinMethodMemberName(mir::BuiltinMethodKind kind) -> std::string_view {
+  switch (kind) {
+    case mir::BuiltinMethodKind::kEnumFirst:
+      return "First";
+    case mir::BuiltinMethodKind::kEnumLast:
+      return "Last";
+    case mir::BuiltinMethodKind::kEnumNum:
+      return "Num";
+    case mir::BuiltinMethodKind::kEnumName:
+      return "Name";
+    case mir::BuiltinMethodKind::kEnumNext:
+      return "Next";
+    case mir::BuiltinMethodKind::kEnumPrev:
+      return "Prev";
+  }
+  throw InternalError(
+      "BuiltinMethodMemberName: unknown mir::BuiltinMethodKind");
+}
+
+auto RenderCallExpr(const RenderContext& ctx, const mir::CallExpr& call)
+    -> diag::Result<std::string> {
+  return std::visit(
+      Overloaded{
+          [](const mir::SystemSubroutineCallee&) -> diag::Result<std::string> {
+            return diag::Unsupported(
+                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+                "system subroutine call as expression is not yet implemented "
+                "in cpp emit",
+                diag::UnsupportedCategory::kFeature);
+          },
+          [](const mir::StructuralSubroutineRef&) -> diag::Result<std::string> {
+            return diag::Unsupported(
+                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+                "user subroutine call is not yet implemented in cpp emit",
+                diag::UnsupportedCategory::kFeature);
+          },
+          [&](const mir::BuiltinMethodCallee& b) -> diag::Result<std::string> {
+            const auto class_name =
+                RenderEnumClassName(ctx.StructuralScope(), b.receiver_type);
+            const auto member = BuiltinMethodMemberName(b.kind);
+            // first / last / num are static methods on the enum class; the
+            // remaining methods (name / next / prev) dispatch on the receiver.
+            const bool is_static =
+                b.kind == mir::BuiltinMethodKind::kEnumFirst ||
+                b.kind == mir::BuiltinMethodKind::kEnumLast ||
+                b.kind == mir::BuiltinMethodKind::kEnumNum;
+            const bool takes_step =
+                b.kind == mir::BuiltinMethodKind::kEnumNext ||
+                b.kind == mir::BuiltinMethodKind::kEnumPrev;
+            std::string raw_call;
+            if (is_static) {
+              raw_call = std::format("{}::{}()", class_name, member);
+            } else {
+              if (call.arguments.empty()) {
+                throw InternalError(
+                    "RenderCallExpr: BuiltinMethodCallee expects a receiver "
+                    "argument");
+              }
+              auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
+              if (!receiver_or) {
+                return std::unexpected(std::move(receiver_or.error()));
+              }
+              // next / prev have an optional step. Omitted at the SV call
+              // site -> omit at the C++ call site too; the Enum<Derived>
+              // method's default argument supplies 1.
+              std::string step_arg;
+              if (takes_step && call.arguments.size() >= 2) {
+                auto step_or = RenderExpr(ctx, ctx.Expr(call.arguments[1]));
+                if (!step_or) {
+                  return std::unexpected(std::move(step_or.error()));
+                }
+                step_arg = std::format(
+                    "static_cast<unsigned>(({}).ToInt64())", *step_or);
+              }
+              raw_call =
+                  std::format("({}).{}({})", *receiver_or, member, step_arg);
+            }
+            // name() returns std::string; first/last/next/prev return the
+            // enum class directly (a PackedArray subclass). num() returns
+            // std::int32_t and needs wrapping into the SV `int` shape.
+            if (b.kind == mir::BuiltinMethodKind::kEnumNum) {
+              return std::format("lyra::value::PackedArray::Int({})", raw_call);
+            }
+            return raw_call;
+          },
+      },
+      call.callee);
+}
+
 auto RenderSameShapeLiteral(
     const mir::PackedArrayType& shape, std::int64_t value) -> std::string {
-  const char* signed_lit =
-      shape.signedness == mir::Signedness::kSigned ? "true" : "false";
-  const char* four_state_lit =
-      shape.atom != mir::BitAtom::kBit ? "true" : "false";
   return std::format(
-      "lyra::value::PackedArray::FromInt({}LL, {}, {}, {})", value,
-      shape.BitWidth(), signed_lit, four_state_lit);
+      "lyra::value::PackedArray::FromInt({}LL, {})", value,
+      RenderPackedArrayCtorArgs(shape));
+}
+
+auto RenderElementSelectExpr(
+    const RenderContext& ctx, const mir::ElementSelectExpr& sel)
+    -> diag::Result<std::string> {
+  auto base_or = RenderExpr(ctx, ctx.Expr(sel.base_value));
+  if (!base_or) return std::unexpected(std::move(base_or.error()));
+  auto idx_or = RenderExpr(ctx, ctx.Expr(sel.index));
+  if (!idx_or) return std::unexpected(std::move(idx_or.error()));
+  return std::format("({}).Index({})", *base_or, *idx_or);
 }
 
 auto RenderRangeSelectExpr(
@@ -393,226 +696,6 @@ auto RenderRangeSelectExpr(
       sel.bounds);
 }
 
-auto RenderConversionExprNode(
-    const RenderContext& ctx, const mir::Expr& expr,
-    const mir::ConversionExpr& cv) -> diag::Result<std::string> {
-  const auto& src_expr = ctx.Expr(cv.operand);
-  auto operand_or = RenderExpr(ctx, src_expr);
-  if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-  const auto& src_ty = ctx.Unit().GetType(src_expr.type);
-  const auto& dst_ty = ctx.Unit().GetType(expr.type);
-  // Same-shape conversion (slang's spurious promotions): pass through.
-  // Cross-shape: route through PackedArray::ConvertFrom.
-  if (src_ty.IsIntegralPacked() && dst_ty.IsIntegralPacked()) {
-    const auto& src_pa = src_ty.AsIntegralPacked();
-    const auto& dst_pa = dst_ty.AsIntegralPacked();
-    std::string body;
-    if (src_pa.BitWidth() == dst_pa.BitWidth() &&
-        src_pa.signedness == dst_pa.signedness && src_pa.atom == dst_pa.atom) {
-      body = *operand_or;
-    } else {
-      const char* signed_lit =
-          dst_pa.signedness == mir::Signedness::kSigned ? "true" : "false";
-      const char* four_state_lit =
-          dst_pa.atom != mir::BitAtom::kBit ? "true" : "false";
-      body = std::format(
-          "lyra::value::PackedArray::ConvertFrom({}, {}, {}, {})", *operand_or,
-          dst_pa.BitWidth(), signed_lit, four_state_lit);
-    }
-    // LRM 6.19.3: integral-to-enum requires an explicit cast. The emitted
-    // enum class is a PackedArray subclass with an explicit PackedArray ctor;
-    // wrap the integral body with that ctor so the C++ result type matches the
-    // destination enum class.
-    if (dst_ty.IsEnum()) {
-      return std::format(
-          "{}{{{}}}", RenderEnumClassName(ctx.StructuralScope(), expr.type),
-          body);
-    }
-    // Enum-to-integral: slice the enum subobject into a fresh PackedArray so
-    // the C++ result type matches PackedArray-typed consumers (template
-    // deduction sees PackedArray, not the enum class).
-    if (src_ty.IsEnum() && !dst_ty.IsEnum()) {
-      return std::format("lyra::value::PackedArray{{{}}}", body);
-    }
-    return body;
-  }
-  return *operand_or;
-}
-
-auto BuiltinMethodMemberName(mir::BuiltinMethodKind kind) -> std::string_view {
-  switch (kind) {
-    case mir::BuiltinMethodKind::kEnumFirst:
-      return "First";
-    case mir::BuiltinMethodKind::kEnumLast:
-      return "Last";
-    case mir::BuiltinMethodKind::kEnumNum:
-      return "Num";
-    case mir::BuiltinMethodKind::kEnumName:
-      return "Name";
-    case mir::BuiltinMethodKind::kEnumNext:
-      return "Next";
-    case mir::BuiltinMethodKind::kEnumPrev:
-      return "Prev";
-  }
-  throw InternalError(
-      "BuiltinMethodMemberName: unknown mir::BuiltinMethodKind");
-}
-
-auto RenderCallExprNode(const RenderContext& ctx, const mir::CallExpr& call)
-    -> diag::Result<std::string> {
-  return std::visit(
-      Overloaded{
-          [](const mir::SystemSubroutineCallee&) -> diag::Result<std::string> {
-            return diag::Unsupported(
-                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-                "system subroutine call as expression is not yet implemented "
-                "in cpp emit",
-                diag::UnsupportedCategory::kFeature);
-          },
-          [](const mir::StructuralSubroutineRef&) -> diag::Result<std::string> {
-            return diag::Unsupported(
-                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-                "user subroutine call is not yet implemented in cpp emit",
-                diag::UnsupportedCategory::kFeature);
-          },
-          [&](const mir::BuiltinMethodCallee& b) -> diag::Result<std::string> {
-            const auto class_name =
-                RenderEnumClassName(ctx.StructuralScope(), b.receiver_type);
-            const auto member = BuiltinMethodMemberName(b.kind);
-            // first / last / num are static methods on the enum class; the
-            // remaining methods (name / next / prev) dispatch on the receiver.
-            const bool is_static =
-                b.kind == mir::BuiltinMethodKind::kEnumFirst ||
-                b.kind == mir::BuiltinMethodKind::kEnumLast ||
-                b.kind == mir::BuiltinMethodKind::kEnumNum;
-            const bool takes_step =
-                b.kind == mir::BuiltinMethodKind::kEnumNext ||
-                b.kind == mir::BuiltinMethodKind::kEnumPrev;
-            std::string raw_call;
-            if (is_static) {
-              raw_call = std::format("{}::{}()", class_name, member);
-            } else {
-              if (call.arguments.empty()) {
-                throw InternalError(
-                    "RenderCallExprNode: BuiltinMethodCallee expects a "
-                    "receiver argument");
-              }
-              auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
-              if (!receiver_or) {
-                return std::unexpected(std::move(receiver_or.error()));
-              }
-              // next / prev have an optional step. Omitted at the SV call
-              // site -> omit at the C++ call site too; the Enum<Derived>
-              // method's default argument supplies 1.
-              std::string step_arg;
-              if (takes_step && call.arguments.size() >= 2) {
-                auto step_or = RenderExpr(ctx, ctx.Expr(call.arguments[1]));
-                if (!step_or) {
-                  return std::unexpected(std::move(step_or.error()));
-                }
-                step_arg = std::format(
-                    "static_cast<unsigned>(({}).ToInt64())", *step_or);
-              }
-              raw_call =
-                  std::format("({}).{}({})", *receiver_or, member, step_arg);
-            }
-            // name() returns std::string; first/last/next/prev return the
-            // enum class directly (a PackedArray subclass). num() returns
-            // std::int32_t and needs wrapping into the SV `int` shape.
-            if (b.kind == mir::BuiltinMethodKind::kEnumNum) {
-              return std::format("lyra::value::PackedArray::Int({})", raw_call);
-            }
-            return raw_call;
-          },
-      },
-      call.callee);
-}
-
-}  // namespace
-
-auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
-    -> diag::Result<std::string> {
-  return std::visit(
-      Overloaded{
-          [&](const mir::IntegerLiteral& lit) -> diag::Result<std::string> {
-            return RenderIntegerLiteralExpr(ctx, expr, lit);
-          },
-          [&](const mir::StringLiteral& s) -> diag::Result<std::string> {
-            return RenderStdStringLiteral(s.value);
-          },
-          [](const mir::TimeLiteral&) -> diag::Result<std::string> {
-            return diag::Unsupported(
-                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-                "TimeLiteral is not yet implemented in cpp emit",
-                diag::UnsupportedCategory::kFeature);
-          },
-          [&](const mir::RealLiteral& r) -> diag::Result<std::string> {
-            const auto& ty = ctx.Unit().GetType(expr.type);
-            const bool is_short = ty.Kind() == mir::TypeKind::kShortReal;
-            // `std::format` with `{:.{}g}` and precision=17 round-trips a
-            // double; precision=9 round-trips a float (IEEE 754 minimum
-            // representable-pair widths). Trailing 'f' suffix on float
-            // literals keeps the C++ literal type matched to the variable.
-            if (is_short) {
-              return std::format("{:.9g}f", r.value);
-            }
-            return std::format("{:.17g}", r.value);
-          },
-          [&](const mir::StructuralParamRef& r) -> diag::Result<std::string> {
-            return RenderStructuralParamExpr(ctx, r);
-          },
-          [&](const mir::StructuralVarRef& m) -> diag::Result<std::string> {
-            auto name_or = RenderStructuralVarName(ctx, m);
-            if (!name_or) return std::unexpected(std::move(name_or.error()));
-            const auto& ty = ctx.Unit().GetType(expr.type);
-            if (ty.IsIntegralPacked()) {
-              return *name_or + ".Get()";
-            }
-            return *name_or;
-          },
-          [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
-            return LookupProceduralVarName(ctx, l);
-          },
-          [&](const mir::UnaryExpr& u) -> diag::Result<std::string> {
-            return RenderUnaryExpr(ctx, u);
-          },
-          [&](const mir::BinaryExpr& b) -> diag::Result<std::string> {
-            return RenderBinaryExprNode(ctx, b);
-          },
-          [&](const mir::ConditionalExpr& c) -> diag::Result<std::string> {
-            return RenderConditionalExprNode(ctx, c);
-          },
-          [&](const mir::AssignExpr& a) -> diag::Result<std::string> {
-            return RenderAssignExprNode(ctx, a);
-          },
-          [&](const mir::ConversionExpr& cv) -> diag::Result<std::string> {
-            return RenderConversionExprNode(ctx, expr, cv);
-          },
-          [&](const mir::CallExpr& call) -> diag::Result<std::string> {
-            return RenderCallExprNode(ctx, call);
-          },
-          [&](const mir::RuntimeCallExpr& rc) -> diag::Result<std::string> {
-            return RenderRuntimeCallExpr(ctx, rc);
-          },
-          [&](const mir::ClosureExpr& cl) -> diag::Result<std::string> {
-            return RenderClosureExpr(ctx, cl);
-          },
-          [&](const mir::ElementSelectExpr& sel) -> diag::Result<std::string> {
-            auto base_or = RenderExpr(ctx, ctx.Expr(sel.base_value));
-            if (!base_or) return std::unexpected(std::move(base_or.error()));
-            auto idx_or = RenderExpr(ctx, ctx.Expr(sel.index));
-            if (!idx_or) return std::unexpected(std::move(idx_or.error()));
-            return std::format("({}).Index({})", *base_or, *idx_or);
-          },
-          [&](const mir::RangeSelectExpr& sel) -> diag::Result<std::string> {
-            return RenderRangeSelectExpr(ctx, expr, sel);
-          },
-      },
-      expr.data);
-}
-
-namespace {
-
 auto RenderClosureExpr(
     const RenderContext& ctx, const mir::ClosureExpr& closure)
     -> diag::Result<std::string> {
@@ -659,12 +742,73 @@ auto RenderClosureExpr(
 
 }  // namespace
 
+auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
+    -> diag::Result<std::string> {
+  return std::visit(
+      Overloaded{
+          [&](const mir::IntegerLiteral& lit) -> diag::Result<std::string> {
+            return RenderIntegerLiteralExpr(ctx, expr, lit);
+          },
+          [&](const mir::StringLiteral& s) -> diag::Result<std::string> {
+            return RenderStdStringLiteral(s.value);
+          },
+          [](const mir::TimeLiteral&) -> diag::Result<std::string> {
+            return diag::Unsupported(
+                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+                "TimeLiteral is not yet implemented in cpp emit",
+                diag::UnsupportedCategory::kFeature);
+          },
+          [&](const mir::RealLiteral& r) -> diag::Result<std::string> {
+            return RenderRealLiteralExpr(ctx, expr, r);
+          },
+          [&](const mir::StructuralParamRef& r) -> diag::Result<std::string> {
+            return RenderStructuralParamExpr(ctx, r);
+          },
+          [&](const mir::StructuralVarRef& m) -> diag::Result<std::string> {
+            return RenderStructuralVarReadExpr(ctx, expr, m);
+          },
+          [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
+            return LookupProceduralVarName(ctx, l);
+          },
+          [&](const mir::UnaryExpr& u) -> diag::Result<std::string> {
+            return RenderUnaryExpr(ctx, expr, u);
+          },
+          [&](const mir::BinaryExpr& b) -> diag::Result<std::string> {
+            return RenderBinaryExpr(ctx, expr, b);
+          },
+          [&](const mir::ConditionalExpr& c) -> diag::Result<std::string> {
+            return RenderConditionalExpr(ctx, c);
+          },
+          [&](const mir::AssignExpr& a) -> diag::Result<std::string> {
+            return RenderAssignExpr(ctx, a);
+          },
+          [&](const mir::ConversionExpr& cv) -> diag::Result<std::string> {
+            return RenderConversionExpr(ctx, expr, cv);
+          },
+          [&](const mir::CallExpr& call) -> diag::Result<std::string> {
+            return RenderCallExpr(ctx, call);
+          },
+          [&](const mir::RuntimeCallExpr& rc) -> diag::Result<std::string> {
+            return RenderRuntimeCallExpr(ctx, rc);
+          },
+          [&](const mir::ClosureExpr& cl) -> diag::Result<std::string> {
+            return RenderClosureExpr(ctx, cl);
+          },
+          [&](const mir::ElementSelectExpr& sel) -> diag::Result<std::string> {
+            return RenderElementSelectExpr(ctx, sel);
+          },
+          [&](const mir::RangeSelectExpr& sel) -> diag::Result<std::string> {
+            return RenderRangeSelectExpr(ctx, expr, sel);
+          },
+      },
+      expr.data);
+}
+
 auto RenderConditionAsBool(const RenderContext& ctx, const mir::Expr& expr)
     -> diag::Result<std::string> {
   auto text_or = RenderExpr(ctx, expr);
   if (!text_or) return std::unexpected(std::move(text_or.error()));
-  const auto& ty = ctx.Unit().GetType(expr.type);
-  if (ty.IsIntegralPacked()) {
+  if (ctx.Unit().GetType(expr.type).IsIntegralPacked()) {
     return "(" + *text_or + ").IsTruthy()";
   }
   return *text_or;

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -649,9 +649,14 @@ class HirDumper {
     Indent();
     for (std::size_t i = 0; i < s.structural_vars.size(); ++i) {
       const auto& v = s.structural_vars[i];
+      std::string init_suffix;
+      if (v.initializer.has_value()) {
+        init_suffix = std::format(" init=Expr[{}]", v.initializer->value);
+      }
       Line(
           std::format(
-              "StructuralVar[{}] \"{}\" : Type[{}]", i, v.name, v.type.value));
+              "StructuralVar[{}] \"{}\" : Type[{}]{}", i, v.name, v.type.value,
+              init_suffix));
     }
     for (std::size_t i = 0; i < s.loop_var_decls.size(); ++i) {
       const auto& lv = s.loop_var_decls[i];

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -1142,6 +1142,13 @@ auto LowerStructuralExpr(
           expr.as<slang::ast::UnbasedUnsizedIntegerLiteral>(), *type_id, span);
     }
 
+    case slang::ast::ExpressionKind::RealLiteral: {
+      const auto& rl = expr.as<slang::ast::RealLiteral>();
+      auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return MakeRealLiteralExpr(rl.getValue(), *type_id, span);
+    }
+
     case slang::ast::ExpressionKind::NamedValue:
       return LowerNamedValueStructural(
           unit_facts, unit_state, stack,

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -21,6 +21,7 @@
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/type.hpp"
+#include "lyra/lowering/ast_to_hir/expression/lower.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/generate.hpp"
 #include "lyra/lowering/ast_to_hir/process.hpp"
@@ -70,9 +71,30 @@ auto LowerTypeAliasMemberInto(
   return {};
 }
 
+// SV LRM 10.4 + 6.21: a structural variable declaration may carry an
+// initializer (`real a = 1.5;`) that is conceptually evaluated once at time 0
+// before any process runs. Slang exposes the initializer via
+// `VariableSymbol::getInitializer()`; we lower it through the structural
+// expression path (the same path that handles parameter expressions) and
+// attach the resulting ExprId to the var decl. HIR -> MIR turns it into an
+// AssignExpr ExprStmt in the enclosing scope's constructor_scope.
+//
+// For now this path is only taken for real-family-typed vars. Integral-typed
+// structural vars wrap in `Var<PackedArray>`, whose runtime assign goes
+// through `WriteVar(*services_, ...)` -- but `services_` is bound by `Bind()`,
+// which the C++ constructor body precedes, so a naive constructor-body
+// assignment would dereference a null pointer. Integral structural-init
+// support is tracked as a separate gap.
+auto IsRealFamilyType(const hir::Type& ty) -> bool {
+  return ty.Kind() == hir::TypeKind::kReal ||
+         ty.Kind() == hir::TypeKind::kShortReal ||
+         ty.Kind() == hir::TypeKind::kRealTime;
+}
+
 auto LowerVariableMemberInto(
     const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
-    const slang::ast::VariableSymbol& var) -> diag::Result<void> {
+    ScopeStack& stack, const slang::ast::VariableSymbol& var)
+    -> diag::Result<void> {
   const auto& mapper = unit_facts.SourceMapper();
   auto& unit_state = scope_state.UnitState();
   if (var.lifetime != slang::ast::VariableLifetime::Static) {
@@ -93,7 +115,15 @@ auto LowerVariableMemberInto(
     throw InternalError(
         "LowerVariableMemberInto: variable declaration produced void type");
   }
-  scope_state.AddStructuralVar(var, *type_id_or);
+  std::optional<hir::ExprId> initializer_id;
+  if (const auto* init = var.getInitializer();
+      init != nullptr && IsRealFamilyType(unit_state.GetType(*type_id_or))) {
+    auto init_or =
+        LowerStructuralExpr(unit_facts, unit_state, scope_state, stack, *init);
+    if (!init_or) return std::unexpected(std::move(init_or.error()));
+    initializer_id = scope_state.AddExpr(*std::move(init_or));
+  }
+  scope_state.AddStructuralVar(var, *type_id_or, initializer_id);
   return {};
 }
 
@@ -172,7 +202,8 @@ auto LowerScopeMemberInto(
           unit_facts, scope_state, member.as<slang::ast::TypeAliasType>());
     case slang::ast::SymbolKind::Variable:
       return LowerVariableMemberInto(
-          unit_facts, scope_state, member.as<slang::ast::VariableSymbol>());
+          unit_facts, scope_state, stack,
+          member.as<slang::ast::VariableSymbol>());
     case slang::ast::SymbolKind::Subroutine:
       return LowerSubroutineMemberInto(
           unit_facts, scope_state, member.as<slang::ast::SubroutineSymbol>());

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -429,7 +429,35 @@ auto LowerGenerateAsStmt(
       gen.data);
 }
 
-auto LowerGenerateConstruction(
+// Lowers a single SV LRM 10.4 / 6.21 structural-var time-0 initializer into
+// an `ExprStmt(AssignExpr)` for the enclosing scope's constructor. The
+// returned stmt is added to the constructor's proc-scope by the caller.
+auto LowerStructuralVarInitAsStmt(
+    UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const hir::StructuralScope& scope,
+    ProceduralScopeLoweringState& proc_scope_state,
+    hir::StructuralVarId hir_var_id, hir::ExprId init_expr_id)
+    -> diag::Result<mir::Stmt> {
+  auto init_or = LowerStructuralExpr(
+      unit_state, scope_state, proc_scope_state, scope,
+      scope.GetExpr(init_expr_id));
+  if (!init_or) return std::unexpected(std::move(init_or.error()));
+  const mir::TypeId mir_type = (*init_or).type;
+  const mir::ExprId rhs_id = proc_scope_state.AddExpr(*std::move(init_or));
+  const mir::StructuralVarRef target =
+      scope_state.TranslateStructuralVar(hir::StructuralHops{0}, hir_var_id);
+  const mir::ExprId assign_id = proc_scope_state.AddExpr(
+      mir::Expr{
+          .data = mir::AssignExpr{.target = target, .value = rhs_id},
+          .type = mir_type});
+  return mir::Stmt{
+      .label = std::nullopt,
+      .data = mir::ExprStmt{.expr = assign_id},
+      .child_procedural_scopes = {}};
+}
+
+auto LowerConstructor(
     UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
     const hir::StructuralScope& scope,
@@ -441,6 +469,19 @@ auto LowerGenerateConstruction(
     const auto& gen_bindings = bindings_by_generate.at(i);
     auto stmt = LowerGenerateAsStmt(
         unit_state, scope_state, scope, gen, gen_bindings, proc_scope_state);
+    if (!stmt) return std::unexpected(std::move(stmt.error()));
+    const mir::StmtId sid = proc_scope_state.AddStmt(*std::move(stmt));
+    proc_scope_state.AddRootStmt(sid);
+  }
+  // Var inits run after generate construction so the structure is fully
+  // realized before any init expression evaluates -- matters when an init
+  // refers to a constructed child object; harmless otherwise.
+  for (std::size_t i = 0; i < scope.structural_vars.size(); ++i) {
+    const auto& hv = scope.structural_vars[i];
+    if (!hv.initializer.has_value()) continue;
+    auto stmt = LowerStructuralVarInitAsStmt(
+        unit_state, scope_state, scope, proc_scope_state,
+        hir::StructuralVarId{static_cast<std::uint32_t>(i)}, *hv.initializer);
     if (!stmt) return std::unexpected(std::move(stmt.error()));
     const mir::StmtId sid = proc_scope_state.AddStmt(*std::move(stmt));
     proc_scope_state.AddRootStmt(sid);
@@ -549,8 +590,7 @@ auto LowerStructuralScope(
       InstallGenerateOwnedChildScopes(unit_state, scope_state, stack, scope);
   if (!bindings_r) return std::unexpected(std::move(bindings_r.error()));
 
-  auto ctor_r =
-      LowerGenerateConstruction(unit_state, scope_state, scope, *bindings_r);
+  auto ctor_r = LowerConstructor(unit_state, scope_state, scope, *bindings_r);
   if (!ctor_r) return std::unexpected(std::move(ctor_r.error()));
   scope_state.SetConstructorScope(*std::move(ctor_r));
 

--- a/tests/cases/cpp/real_add/case.yaml
+++ b/tests/cases/cpp/real_add/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_add
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      4.000000

--- a/tests/cases/cpp/real_add/main.sv
+++ b/tests/cases/cpp/real_add/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  real a = 1.5;
+  real b = 2.5;
+  real c;
+  initial begin
+    c = a + b;
+    $display("%f", c);
+  end
+endmodule

--- a/tests/cases/cpp/real_as_condition_nonzero/case.yaml
+++ b/tests/cases/cpp/real_as_condition_nonzero/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_as_condition_nonzero
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      nonzero

--- a/tests/cases/cpp/real_as_condition_nonzero/main.sv
+++ b/tests/cases/cpp/real_as_condition_nonzero/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  real x = 1.5;
+  initial begin
+    if (x)
+      $display("nonzero");
+    else
+      $display("zero");
+  end
+endmodule

--- a/tests/cases/cpp/real_as_condition_zero/case.yaml
+++ b/tests/cases/cpp/real_as_condition_zero/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_as_condition_zero
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      zero

--- a/tests/cases/cpp/real_as_condition_zero/main.sv
+++ b/tests/cases/cpp/real_as_condition_zero/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  real x = 0.0;
+  initial begin
+    if (x)
+      $display("nonzero");
+    else
+      $display("zero");
+  end
+endmodule

--- a/tests/cases/cpp/real_complex_expression/case.yaml
+++ b/tests/cases/cpp/real_complex_expression/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_complex_expression
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      20.000000

--- a/tests/cases/cpp/real_complex_expression/main.sv
+++ b/tests/cases/cpp/real_complex_expression/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  real a = 2.0;
+  real b = 3.0;
+  real c = 4.0;
+  real result;
+  initial begin
+    result = (a + b) * c;
+    $display("%f", result);
+  end
+endmodule

--- a/tests/cases/cpp/real_declaration_with_init/main.sv
+++ b/tests/cases/cpp/real_declaration_with_init/main.sv
@@ -1,7 +1,4 @@
 module Top;
-  real x;
-  initial begin
-    x = 3.14;
-    $display("%f", x);
-  end
+  real x = 3.14;
+  initial $display("%f", x);
 endmodule

--- a/tests/cases/cpp/real_divide/case.yaml
+++ b/tests/cases/cpp/real_divide/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_divide
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      3.000000

--- a/tests/cases/cpp/real_divide/main.sv
+++ b/tests/cases/cpp/real_divide/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  real a = 7.5;
+  real b = 2.5;
+  real c;
+  initial begin
+    c = a / b;
+    $display("%f", c);
+  end
+endmodule

--- a/tests/cases/cpp/real_equal_false/case.yaml
+++ b/tests/cases/cpp/real_equal_false/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_equal_false
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      0

--- a/tests/cases/cpp/real_equal_false/main.sv
+++ b/tests/cases/cpp/real_equal_false/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  real a = 2.5;
+  real b = 3.5;
+  initial $display("%d", a == b);
+endmodule

--- a/tests/cases/cpp/real_equal_true/case.yaml
+++ b/tests/cases/cpp/real_equal_true/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_equal_true
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1

--- a/tests/cases/cpp/real_equal_true/main.sv
+++ b/tests/cases/cpp/real_equal_true/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  real a = 2.5;
+  real b = 2.5;
+  initial $display("%d", a == b);
+endmodule

--- a/tests/cases/cpp/real_greater_than/case.yaml
+++ b/tests/cases/cpp/real_greater_than/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_greater_than
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1

--- a/tests/cases/cpp/real_greater_than/main.sv
+++ b/tests/cases/cpp/real_greater_than/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  real a = 3.5;
+  real b = 2.5;
+  initial $display("%d", a > b);
+endmodule

--- a/tests/cases/cpp/real_in_conditional/case.yaml
+++ b/tests/cases/cpp/real_in_conditional/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_in_conditional
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      greater

--- a/tests/cases/cpp/real_in_conditional/main.sv
+++ b/tests/cases/cpp/real_in_conditional/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  real x = 2.5;
+  initial begin
+    if (x > 2.0)
+      $display("greater");
+    else
+      $display("not greater");
+  end
+endmodule

--- a/tests/cases/cpp/real_less_equal/case.yaml
+++ b/tests/cases/cpp/real_less_equal/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_less_equal
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1

--- a/tests/cases/cpp/real_less_equal/main.sv
+++ b/tests/cases/cpp/real_less_equal/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  real a = 2.5;
+  real b = 2.5;
+  initial $display("%d", a <= b);
+endmodule

--- a/tests/cases/cpp/real_less_than_false/case.yaml
+++ b/tests/cases/cpp/real_less_than_false/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_less_than_false
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      0

--- a/tests/cases/cpp/real_less_than_false/main.sv
+++ b/tests/cases/cpp/real_less_than_false/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  real a = 3.5;
+  real b = 2.5;
+  initial $display("%d", a < b);
+endmodule

--- a/tests/cases/cpp/real_less_than_true/case.yaml
+++ b/tests/cases/cpp/real_less_than_true/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_less_than_true
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1

--- a/tests/cases/cpp/real_less_than_true/main.sv
+++ b/tests/cases/cpp/real_less_than_true/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  real a = 1.5;
+  real b = 2.5;
+  initial $display("%d", a < b);
+endmodule

--- a/tests/cases/cpp/real_logical_and_false/case.yaml
+++ b/tests/cases/cpp/real_logical_and_false/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_logical_and_false
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      0

--- a/tests/cases/cpp/real_logical_and_false/main.sv
+++ b/tests/cases/cpp/real_logical_and_false/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  real a = 1.5;
+  real b = 0.0;
+  initial $display("%d", a && b);
+endmodule

--- a/tests/cases/cpp/real_logical_and_true/case.yaml
+++ b/tests/cases/cpp/real_logical_and_true/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_logical_and_true
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1

--- a/tests/cases/cpp/real_logical_and_true/main.sv
+++ b/tests/cases/cpp/real_logical_and_true/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  real a = 1.5;
+  real b = 2.5;
+  initial $display("%d", a && b);
+endmodule

--- a/tests/cases/cpp/real_logical_not_nonzero/case.yaml
+++ b/tests/cases/cpp/real_logical_not_nonzero/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_logical_not_nonzero
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      0

--- a/tests/cases/cpp/real_logical_not_nonzero/main.sv
+++ b/tests/cases/cpp/real_logical_not_nonzero/main.sv
@@ -1,0 +1,4 @@
+module Top;
+  real a = 2.5;
+  initial $display("%d", !a);
+endmodule

--- a/tests/cases/cpp/real_logical_not_zero/case.yaml
+++ b/tests/cases/cpp/real_logical_not_zero/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_logical_not_zero
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1

--- a/tests/cases/cpp/real_logical_not_zero/main.sv
+++ b/tests/cases/cpp/real_logical_not_zero/main.sv
@@ -1,0 +1,4 @@
+module Top;
+  real a = 0.0;
+  initial $display("%d", !a);
+endmodule

--- a/tests/cases/cpp/real_logical_or_true/case.yaml
+++ b/tests/cases/cpp/real_logical_or_true/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_logical_or_true
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1

--- a/tests/cases/cpp/real_logical_or_true/main.sv
+++ b/tests/cases/cpp/real_logical_or_true/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  real a = 0.0;
+  real b = 2.5;
+  initial $display("%d", a || b);
+endmodule

--- a/tests/cases/cpp/real_multiply/case.yaml
+++ b/tests/cases/cpp/real_multiply/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_multiply
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      10.000000

--- a/tests/cases/cpp/real_multiply/main.sv
+++ b/tests/cases/cpp/real_multiply/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  real a = 2.5;
+  real b = 4.0;
+  real c;
+  initial begin
+    c = a * b;
+    $display("%f", c);
+  end
+endmodule

--- a/tests/cases/cpp/real_not_equal/case.yaml
+++ b/tests/cases/cpp/real_not_equal/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_not_equal
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1

--- a/tests/cases/cpp/real_not_equal/main.sv
+++ b/tests/cases/cpp/real_not_equal/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  real a = 2.5;
+  real b = 3.5;
+  initial $display("%d", a != b);
+endmodule

--- a/tests/cases/cpp/real_power/case.yaml
+++ b/tests/cases/cpp/real_power/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_power
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      8.000000

--- a/tests/cases/cpp/real_power/main.sv
+++ b/tests/cases/cpp/real_power/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  real a = 2.0;
+  real b = 3.0;
+  real c;
+  initial begin
+    c = a ** b;
+    $display("%f", c);
+  end
+endmodule

--- a/tests/cases/cpp/real_shortreal_multiply/case.yaml
+++ b/tests/cases/cpp/real_shortreal_multiply/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_shortreal_multiply
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      10.000000

--- a/tests/cases/cpp/real_shortreal_multiply/main.sv
+++ b/tests/cases/cpp/real_shortreal_multiply/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  real a = 2.5;
+  shortreal b = 4.0;
+  real c;
+  initial begin
+    c = a * b;
+    $display("%f", c);
+  end
+endmodule

--- a/tests/cases/cpp/real_subtract/case.yaml
+++ b/tests/cases/cpp/real_subtract/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_subtract
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      3.500000

--- a/tests/cases/cpp/real_subtract/main.sv
+++ b/tests/cases/cpp/real_subtract/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  real a = 5.5;
+  real b = 2.0;
+  real c;
+  initial begin
+    c = a - b;
+    $display("%f", c);
+  end
+endmodule

--- a/tests/cases/cpp/real_to_shortreal_conversion/case.yaml
+++ b/tests/cases/cpp/real_to_shortreal_conversion/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_to_shortreal_conversion
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      3.141593

--- a/tests/cases/cpp/real_to_shortreal_conversion/main.sv
+++ b/tests/cases/cpp/real_to_shortreal_conversion/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  real r = 3.14159265358979;
+  shortreal s;
+  initial begin
+    s = r;
+    $display("%f", s);
+  end
+endmodule

--- a/tests/cases/cpp/real_unary_minus/case.yaml
+++ b/tests/cases/cpp/real_unary_minus/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_unary_minus
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      -3.500000

--- a/tests/cases/cpp/real_unary_minus/main.sv
+++ b/tests/cases/cpp/real_unary_minus/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  real a = 3.5;
+  real b;
+  initial begin
+    b = -a;
+    $display("%f", b);
+  end
+endmodule

--- a/tests/cases/cpp/realtime_add/case.yaml
+++ b/tests/cases/cpp/realtime_add/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.realtime_add
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      4.000000

--- a/tests/cases/cpp/realtime_add/main.sv
+++ b/tests/cases/cpp/realtime_add/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  realtime a = 1.5;
+  realtime b = 2.5;
+  realtime c;
+  initial begin
+    c = a + b;
+    $display("%f", c);
+  end
+endmodule

--- a/tests/cases/cpp/realtime_compare/case.yaml
+++ b/tests/cases/cpp/realtime_compare/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.realtime_compare
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1

--- a/tests/cases/cpp/realtime_compare/main.sv
+++ b/tests/cases/cpp/realtime_compare/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  realtime a = 1.5;
+  realtime b = 2.5;
+  initial $display("%d", a < b);
+endmodule

--- a/tests/cases/cpp/realtime_declaration_with_init/main.sv
+++ b/tests/cases/cpp/realtime_declaration_with_init/main.sv
@@ -1,7 +1,4 @@
 module Top;
-  realtime x;
-  initial begin
-    x = 1.25;
-    $display("%f", x);
-  end
+  realtime x = 1.25;
+  initial $display("%f", x);
 endmodule

--- a/tests/cases/cpp/shortreal_add/case.yaml
+++ b/tests/cases/cpp/shortreal_add/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.shortreal_add
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      4.000000

--- a/tests/cases/cpp/shortreal_add/main.sv
+++ b/tests/cases/cpp/shortreal_add/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  shortreal a = 1.5;
+  shortreal b = 2.5;
+  shortreal c;
+  initial begin
+    c = a + b;
+    $display("%f", c);
+  end
+endmodule

--- a/tests/cases/cpp/shortreal_declaration_with_init/main.sv
+++ b/tests/cases/cpp/shortreal_declaration_with_init/main.sv
@@ -1,7 +1,4 @@
 module Top;
-  shortreal x;
-  initial begin
-    x = 2.5;
-    $display("%f", x);
-  end
+  shortreal x = 2.5;
+  initial $display("%f", x);
 endmodule

--- a/tests/cases/cpp/shortreal_logical_not/case.yaml
+++ b/tests/cases/cpp/shortreal_logical_not/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.shortreal_logical_not
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1

--- a/tests/cases/cpp/shortreal_logical_not/main.sv
+++ b/tests/cases/cpp/shortreal_logical_not/main.sv
@@ -1,0 +1,4 @@
+module Top;
+  shortreal a = 0.0;
+  initial $display("%d", !a);
+endmodule

--- a/tests/cases/cpp/shortreal_power/case.yaml
+++ b/tests/cases/cpp/shortreal_power/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.shortreal_power
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      8.000000

--- a/tests/cases/cpp/shortreal_power/main.sv
+++ b/tests/cases/cpp/shortreal_power/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  shortreal a = 2.0;
+  shortreal b = 3.0;
+  shortreal c;
+  initial begin
+    c = a ** b;
+    $display("%f", c);
+  end
+endmodule

--- a/tests/cases/cpp/shortreal_real_add/case.yaml
+++ b/tests/cases/cpp/shortreal_real_add/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.shortreal_real_add
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      4.000000

--- a/tests/cases/cpp/shortreal_real_add/main.sv
+++ b/tests/cases/cpp/shortreal_real_add/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  shortreal a = 1.5;
+  real b = 2.5;
+  real c;
+  initial begin
+    c = a + b;
+    $display("%f", c);
+  end
+endmodule

--- a/tests/cases/cpp/shortreal_real_comparison/case.yaml
+++ b/tests/cases/cpp/shortreal_real_comparison/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.shortreal_real_comparison
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1

--- a/tests/cases/cpp/shortreal_real_comparison/main.sv
+++ b/tests/cases/cpp/shortreal_real_comparison/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  shortreal a = 1.5;
+  real b = 2.5;
+  initial $display("%d", a < b);
+endmodule

--- a/tests/cases/cpp/shortreal_to_real_conversion/case.yaml
+++ b/tests/cases/cpp/shortreal_to_real_conversion/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.shortreal_to_real_conversion
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      3.140000

--- a/tests/cases/cpp/shortreal_to_real_conversion/main.sv
+++ b/tests/cases/cpp/shortreal_to_real_conversion/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  shortreal s = 3.14;
+  real r;
+  initial begin
+    r = s;
+    $display("%f", r);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds the full real-operator surface (arithmetic / relational / equality / logical, plus shortreal <-> real conversion) to the cpp emit pipeline, and wires structural-level variable initializers (`real a = 1.5;` at module scope) end-to-end. cpp emit now dispatches each binary / unary op by operand type, emits native C++ for real arithmetic, routes `**` through `std::pow`, wraps the C++ `bool` from relational / equality / logical real operators into the SV-typed 1-bit `PackedArray` shape, and handles shortreal <-> real `ConversionExpr` via `static_cast`. `hir::StructuralVarDecl` gained an optional `initializer`; AST -> HIR extracts `var.getInitializer()` for real-family types; HIR -> MIR appends one `ExprStmt(AssignExpr)` per initialized var into the scope's `constructor_scope`, where the existing fall-through assignment arm lands it in the emitted C++ constructor body. Integral structural initializers remain a known gap because `Var<PackedArray>` writes go through `WriteVar(*services_, ...)` and `services_` is only bound in `Bind()`, which runs after the C++ constructor.

## Design

`render_expr.cpp` splits the operator-dispatch surface into `RenderBinaryOpReal` / `RenderBinaryOpIntegral` (and the matching unary pair). The real path is intentionally minimal: native operators for arithmetic, `std::pow` for `**` (C++ overload resolution naturally picks `(float, float) -> float` and `(double, double) -> double`, which matches LRM 11.3.1's result-type rule for shortreal-only vs any-real expressions), and `PackedArray::FromInt(..., 1, false, false)` to wrap relational / logical / equality bool results into the 1-bit integral shape MIR carries. `RenderConversionExpr` splits into `RenderRealConversion` (same-precision pass-through, cross-precision `static_cast`) and `RenderIntegralConversion`. The same cut also does a holistic clean-up of the file: drops the `Node` suffix from helper names so all per-variant renderers spell as `Render<Variant>Expr`, extracts the previously-inline `RealLiteral` / `StructuralVarRef` / `ElementSelectExpr` visitor arms into named helpers, reuses `RenderPackedArrayCtorArgs` to dedupe the `signed_lit / four_state_lit / BitWidth` triple in three places, and reorders helpers thematically with the public `RenderExpr` at the bottom.

Structural-init lowering follows the existing `LowerGenerateAsStmt` shape: `LowerStructuralVarInitAsStmt` returns a single `mir::Stmt`, and the loop in `LowerConstructor` (renamed from `LowerGenerateConstruction` since it now handles both generates and var inits) calls `AddStmt` + `AddRootStmt`. This keeps the `Lower*` / `Add*` boundary that architecture policy A012 enforces. Var inits run after generate construction so the structure is fully realized before any init expression evaluates.

## Testing

29 new cpp_run cases cover arithmetic, relational, equality, logical, and conditional forms across `real`, `shortreal`, and `realtime`; cross-precision (`shortreal + real`, `shortreal < real`); same-family conversion (`real <-> shortreal`); and a `realtime` regression set. The three existing C1 declaration-init tests revert from the procedural-init workaround back to `real x = 3.14;` declaration form now that the structural-init gap is closed.