### PR TITLE
Implement selector lvalue writes with ScopedMutation envelope

### DIFF
--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -75,8 +75,7 @@ LRM operand-domain validity:
 The asymmetry on associative arrays and strings (element-select valid, range-select not) is the
 reason for two IR nodes rather than one merged variant. A single merged node would force every
 visitor that touches selectors to carry a cross-cutting validity check ("this arm is only legal on
-these operand types"). Two nodes keep name and validity domain in lockstep, and W7's lvalue-side
-extensions can be expressed without arm-by-arm guards.
+these operand types"). Two nodes keep name and validity domain in lockstep.
 
 HIR shapes:
 
@@ -98,12 +97,18 @@ struct RangeSelectExpr {
 };
 ```
 
-MIR shape mirrors HIR 1:1. Each bounds field stays an `ExprId`, so HIR -> MIR is structurally a
-pass-through (recursively lower each `ExprId`, repack into the same variant arm). No constant
-evaluation or direction normalization happens at lowering -- slang has already validated the LRM
-contract during AST construction (constants are constant, indexed widths are positive, simple-form
-direction matches the operand's declared range; partial-OOB stays in the AST as a warning), and the
-result `Expr.type` carries the slice's width, so render can read it directly.
+The IR keeps source-form positions verbatim and defers all positional arithmetic to render. No
+constant evaluation or direction normalization happens at lowering -- slang has already validated
+the LRM contract during AST construction (constants are constant, indexed widths are positive,
+simple-form direction matches the operand's declared range; partial-OOB stays in the AST as a
+warning), and the result `Expr.type` carries the slice's width. MIR mirrors HIR 1:1.
+
+The bit width of one element of the operand at any select layer is derived at render time from the
+operand's `PackedArrayType.dims` stack:
+`element_bw = operand.BitWidth() / operand.dims.front().ElementCount()`. For a 1D vector this is 1
+(the LRM 11.5.1 bit-select case); for a multi-dim packed operand it is the inner dimensions' total
+bit width. Render multiplies the source-form index/lsb by this factor to translate from
+element-space to the flat-bit storage offset. The IR does not duplicate this derived value.
 
 Naming:
 
@@ -111,94 +116,204 @@ Naming:
   `RangeSelectExpression`. LRM 7.4.5 vocabulary aligns with slang on these names. **Not**
   "BitSelect": whether the result is 1 bit is operand-derived, not an operator property.
 
+#### Write-side `Lvalue` shape
+
+A writable place is a root storage (var ref) plus an ordered chain of selectors that project into
+it. An empty chain is a whole-var write; one or more selectors describe nested partial writes that
+render flattens into a single LRM-bit-level partial assignment.
+
+```
+struct ElementLvalueSelector { ExprId index; };
+struct RangeLvalueSelector   { RangeBounds bounds; };
+using LvalueSelector = std::variant<ElementLvalueSelector, RangeLvalueSelector>;
+
+struct Lvalue {
+  std::variant<StructuralVarRef, ProceduralVarRef /* + LoopVarRef in HIR */> root;
+  std::vector<LvalueSelector> selectors;  // outer-first
+};
+```
+
+The chain shape (vector, not optional) reflects the LRM concept: a selector is a path into the root,
+and the path can have any number of layers. AST -> HIR walks the slang nested AST peeling
+outermost-first to build the chain. Per-layer element bit widths are not stored in the IR; render
+walks the root's `PackedArrayType.dims` stack alongside the chain (each Element selector pops one
+outer dim; each Range selector keeps the inner dims) to compute the factor when it needs one.
+
 #### Runtime `PackedArray` API
 
-The runtime exposes two read-side methods, named after the LRM 7.4.5 vocabulary ("element" /
-"slice") in verb form for symmetry with the rest of CS practice (Python / NumPy / Rust):
+`value::PackedArray` carries the source-level dim stack (`dims_`, outer-first) alongside its flat
+bit storage. The dim stack is the API contract; the underlying storage layout (flat bit planes
+today; potentially canonical-byte-aligned, vector-of-elements for huge outer dims, or any other
+shape once optimization work begins) is private. The whole API is element-level -- `ElementAt` and
+`Slice` take positions in the operand's outer-element units, and dispatch on `dims_` internally to
+turn them into bit offsets. Emit never bakes element-width arithmetic into call sites, so future
+storage refactors do not propagate beyond runtime internals. The chain API is uniformly method-style
+(no `operator[]` overload) so every layer of a selector chain reads the same way.
 
 ```
-auto Index(const PackedArray& index) const -> PackedArray;             // element-select (1 bit)
-auto Slice(const PackedArray& lsb_bit, std::uint32_t width) const -> PackedArray;  // range-select
+// Low-level bit-level primitives (chain leaves resolve here).
+auto ExtractBits(const PackedArray& lsb_bit, std::uint32_t bit_width) const
+    -> PackedArray;
+auto AssignSlice(const PackedArray& lsb_bit, std::uint32_t bit_width,
+                 const PackedArray& value) -> void;
+
+// Element-level chain entry points. Positions are in outer-element units;
+// the runtime scales by element bit width derived from `dims_`.
+auto ElementAt(const PackedArray& idx) -> PackedArrayRef;        // non-const
+auto ElementAt(const PackedArray& idx) const -> PackedArray;     // const
+auto Slice(const PackedArray& lsb_in_outer_elements,
+           std::uint32_t count_in_outer_elements) -> PackedArrayRef;       // non-const
+auto Slice(const PackedArray& lsb_in_outer_elements,
+           std::uint32_t count_in_outer_elements) const -> PackedArray;    // const
 ```
 
-`Slice` codifies LRM 7.4.5's contract directly: "The size of the part-select or slice shall be
-constant, but the position can be variable" -- `width` is compile-time `uint32_t`, `lsb_bit` is a
-runtime `PackedArray` (so X / Z propagation falls out for free). The MSB position is implicit at
-`lsb_bit + width - 1`; we do not surface it as a separate parameter because the LRM size constraint
-makes it derivable.
+For a 1D operand (`dims_.size() == 1`), one "element" is one bit, so `ElementAt` is the LRM 11.5.1
+bit-select and `Slice` is the LRM 11.5.1 part-select at bit-level. For multi-dim, one "element" is
+the inner subtype, and the runtime multiplies by the element bit width internally.
 
-`Slice` operates on a **canonical LSB-anchored bit address space**, dimension-agnostic at the API
-boundary. Element-vs-bit accounting lives one layer up in the MIR type system, not in PackedArray.
-For 1D operands element width is 1 bit, so source-form indices coincide with bit positions and
-render passes them through verbatim. For future multi-dim packed operands (`bit [N:0][M:0] arr`
-etc.), LRM 7.4.5 says slice applies to one dimension and the other dimensions are preserved --
-element-level source-form positions must be multiplied by the inner element's bit width at render
-time before reaching `Slice`. W5 only wires 1D; the multi-dim extension is part of the `packed.md`
-workstream.
+`PackedArrayRef` is a writable proxy carrying
+`(PackedArray* root, PackedArray bit_offset, uint32_t bit_width, vector<PackedRange> dims)`.
+Implicit `operator PackedArray()` materializes a fresh value via `root.ExtractBits`;
+`operator=(const PackedArray&)` routes through `root.AssignSlice`. The same two chain methods
+compose into another `PackedArrayRef` with the dim stack's outer popped (`ElementAt`) or its outer
+count replaced (`Slice`). `bit_offset` is kept in a canonical 64-bit signed 4-state shape so chained
+`+` / `*` between layers never collide on shape, and X/Z in any layer's index propagates to the
+final write (LRM 11.5.1 "X/Z position is a no-op").
 
-How `PackedArray` represents bits internally (flat word planes today; potentially sparse / pooled /
-chunked once optimization work begins) is an implementation detail that the `Index` / `Slice`
-contract is independent of. Both methods specify positions in the canonical bit address space and
-return a fresh `PackedArray` whose bits are the LRM-defined result; any future storage layout change
-must preserve this external contract.
+LRM 11.5.1 corner cases (X/Z position no-op, fully-OOB no-op, partial-OOB only in-range bits) live
+inside `AssignSlice` and `ExtractBits`. The proxy chain only accumulates; the final read or write
+call enforces the rules.
 
-`Index(idx)` is a convenience over `Slice(idx, 1)` for the 1-bit case, kept distinct so the call
-site preserves the LRM-level operator name (element-select vs slice).
+#### Observable-target write proxy
 
-Both methods return a fresh `PackedArray` by value -- no views, consistent with every other
-`PackedArray` op. Result is unsigned regardless of operand signedness (LRM 11.8; slang applies
-`makeUnsigned` on the `Expr.type` we read).
+`Var<T>` is deliberately a thin storage + subscriber wrapper. It exposes `Get()` for reads and is
+written through:
+
+- `runtime::WriteVar(services, var, value)` -- whole-var commit + change detection + event firing.
+- `var.Mutate(services)` -- partial commit. Returns a `ScopedMutation<T>` RAII handle that snapshots
+  the current value, forwards `ElementAt` / `Slice` to the snapshot so a normal chain composes, and
+  commits the (possibly mutated) snapshot through `WriteVar` in its destructor.
+
+`ScopedMutation<T>` is non-copyable and non-movable: the contract is that the handle lives only
+until the end of the constructing full expression. Returning it by value from `Var<T>::Mutate`
+relies on C++17 mandatory copy elision -- the prvalue is materialized in the caller's storage with
+no copy or move. The destructor runs at the statement's semicolon, after the chain has finished
+mutating the snapshot, and routes the result through `WriteVar` so subscribers fire on change.
+
+The selector chain itself stays on `value::PackedArray` / `PackedArrayRef`. `Var<T>` has no chain
+API of its own; `Mutate` is purely the envelope that turns "mutate a snapshot then commit" into a
+single chain expression. The shape `var.Mutate(svc).ElementAt(...).Slice(...) = rhs` is identical to
+a procedural-local chain except for the `Mutate(svc)` adapter and the implicit commit at the end of
+the statement.
 
 #### Render rules
 
-Width comes from the slice expression's MIR result type (`unit.GetType(expr.type).BitWidth()`),
-which slang has already pinned at AST construction.
+Render emits a chain of method calls; the runtime composes them. Render never computes element bit
+widths -- the runtime decides via the operand's `dims_`. The chain methods are simply `ElementAt`
+and `Slice`, both taking source-form outer-element positions:
 
-- `mir::ElementSelectExpr { base, index }` -> `(base).Index(<index rendered>)`.
-- `mir::RangeSelectExpr` with `RangeConstantBounds { msb_expr, lsb_expr }` ->
-  `(base).Slice(<lsb_expr rendered>, <width from result type>)`. `msb_expr` is preserved in MIR for
-  dump / debug symmetry with HIR; render does not consult it (the width via result type carries the
-  same information).
+Read (recursive compose -- each layer's render renders its `base_value` and appends its own method
+call):
+
+- `mir::ElementSelectExpr { base, index }` -> `(<base>).ElementAt(<index>)`.
+- `mir::RangeSelectExpr` with `RangeConstantBounds { msb, lsb }` ->
+  `(<base>).Slice(<lsb>, <count>U)` where `count = |msb - lsb| + 1` (slang elaborates msb and lsb to
+  integer literals; render extracts them).
 - `mir::RangeSelectExpr` with `RangeIndexedUpBounds { base_index, width }` ->
-  `(base).Slice(<base_index rendered>, <width from result type>)`.
+  `(<base>).Slice(<base_index>, <count>U)` where `count` = literal value of `width`.
 - `mir::RangeSelectExpr` with `RangeIndexedDownBounds { base_index, width }` ->
-  `(base).Slice((<base_index rendered>) - PackedArray::FromInt(<width - 1>, <base_index shape>), <width from result type>)`.
-  The literal `width - 1` is constructed to match `base_index`'s PackedArray shape so the runtime
-  subtraction does not need cross-shape promotion.
+  `(<base>).Slice((<base_index>) - <count-1 same-shape lit>, <count>U)`.
 
-#### LRM 11.5.1 / 7.4.5 corner-case rules (handled inside `PackedArray::Slice`)
+Write (iterative chain -- walk `lvalue.selectors`, append each layer's method call, end with
+`= rhs`):
+
+- Procedural-local target root: chain mutates the variable in place. Emit shape:
+  `<root>.ElementAt(<idx>).Slice(<lsb>, <count>U) = <rhs>;`.
+- Observable structural-var root: insert `.Mutate(*services_)` after the root so the
+  `ScopedMutation` temporary commits through `WriteVar` at end-of-statement. Emit shape:
+  `<root>.Mutate(*services_).ElementAt(<idx>).Slice(<lsb>, <count>U) = <rhs>;`.
+
+Both branches share `RenderSelectorMethodCall` per layer; the only difference is the single
+`.Mutate(*services_)` adapter inserted between the root and the first selector when the root is
+observable.
+
+#### Variable declaration emit
+
+`PackedArray` exposes two constructors: a 1D shorthand `(bit_width, signed, four_state)` and a
+dim-list `(initializer_list<PackedRange>, signed, four_state)`. Render emits the 1D form for
+single-dim packed types (`bit [N-1:0]`) and the dim-list form for multi-dim packed types
+(`bit [N-1:0][M-1:0]`...) so the runtime instance carries the correct `dims_` stack.
+
+#### LRM 11.5.1 / 7.4.5 corner-case rules (handled inside `PackedArray::ExtractBits` / `AssignSlice`)
+
+Read:
 
 - Any X / Z bit in the runtime `lsb_bit` propagates: result is all-X of `width` bits (4-state) or
   all-0 (2-state).
 - Fully out-of-range read returns all-X / all-0.
 - Partially out-of-range read returns in-range bits verbatim and X / 0 for the OOB bits.
-- Bit-select / part-select of a scalar or real variable is illegal; slang rejects at AST
-  construction, so HIR never sees the shape.
 
-- [x] W4 -- Element-select read `v[idx]` (scope: 1D integral operand; result is 1 bit per LRM
-      11.5.1). Wired end-to-end: `hir::ElementSelectExpr` -> `mir::ElementSelectExpr` ->
-      `PackedArray::Index(idx)`. HIR / MIR introduce all three `RangeBounds` arms at the same time
-      so the shape is locked across W4..W7; W5 wires `RangeSelectExpr` through HIR -> MIR and
-      render. Implements LRM 7.4.5 / 11.5.1 OOB and X / Z propagation rules on the runtime side
-      (`Slice` is the underlying helper; `Index(idx)` is `Slice(idx, 1)`).
+Write:
+
+- Any X / Z bit in `lsb_bit` makes the entire write a silent no-op (the LRM "no effect on the data
+  stored when written" rule).
+- Fully out-of-range write is a silent no-op.
+- Partially out-of-range write affects only the in-range bits; bits outside the operand's bounds are
+  silently discarded.
+
+Bit-select / part-select of a scalar or real variable is illegal; slang rejects at AST construction,
+so HIR never sees the shape.
+
+#### NBA on selector lvalues
+
+`data[i+:8] <= v` routes through the same closure-based NBA machinery as a whole-var NBA. Each
+`ExprId` reached through the selector chain is handled one of two ways:
+
+- **Integer literals** are cloned verbatim into the closure body's expr store -- no capture entry is
+  created, since the value cannot change between submit and fire.
+- **Non-literal expressions** are captured by value into a fresh procedural var binding via
+  `ByValueCapture`. Each capture gets a distinct name (`_lyra_nba_idx0`, `_lyra_nba_idx1`, ...)
+  drawn from a counter that advances only on non-literal snapshots, so the emitted capture list has
+  no collisions. The capture-name suffix is sequential among non-literal captures but may skip
+  indices implicitly when literals appear between them in the selector chain.
+
+Inside the closure body the chain is rebuilt with body-local refs (`ProceduralVarRef` for captures,
+`IntegerLiteral` clones for literals), so when the NBA region fires it re-evaluates none of the
+original outer-scope expressions -- the snapshotted values at submit time are what get written.
+
+If the NBA target is observable, the body's chain inserts `.Mutate(*services_)` after the root (same
+pattern as the blocking observable selector write) so the NBA-fired write commits through `WriteVar`
+when the `ScopedMutation` temporary tears down at end-of-statement and triggers subscribers. The
+closure stays a single lambda -- there is no nested mutation lambda.
+
+- [x] W4 -- Element-select read `v[idx]`. Wired end-to-end through `hir::ElementSelectExpr` ->
+      `mir::ElementSelectExpr` -> `PackedArray::Slice(<scaled>, ebw)`. Handles 1D bit-select (ebw=1)
+      and multi-dim element-select (ebw=N) uniformly: render derives `ebw` from the operand's
+      `PackedArrayType.dims` stack, so the IR carries no dim-derived duplicate. Chain composition is
+      via nested `Slice` calls on `base_value`. Implements LRM 7.4.5 / 11.5.1 OOB and X / Z
+      propagation rules on the runtime side.
 
 - [x] W5 -- Range-select read covering all three bounds forms: non-indexed constant `v[msb:lsb]`,
       indexed-up `v[base +: w]`, indexed-down `v[base -: w]`. Wire `mir::RangeSelectExpr` mirroring
-      HIR (three `RangeBounds` variants, all `ExprId` fields). HIR -> MIR is a pure structural
-      pass-through. cpp render dispatches on the MIR bounds variant and emits
-      `(base).Slice(lsb_bit, width)`; for indexed-down it constructs the LSB position as
-      `base_index - PackedArray(width - 1)`. Runtime reuses `PackedArray::Slice`. Width at render
-      comes from the result type, not from any MIR-side constant extraction. Closes
-      `datatypes/packed/indexed_part_select/default.yaml` for the read half.
+      HIR (three `RangeBounds` variants). HIR -> MIR is a pure structural pass-through. cpp render
+      derives the operand's element bit width from `PackedArrayType.dims`, dispatches on the MIR
+      bounds variant, scales positions, and emits a single `PackedArray::Slice` call. For multi-dim,
+      the scaling translates element-space positions to bit positions; for 1D (`ebw==1`) the scaling
+      is dropped. Runtime reuses `PackedArray::Slice`. Width at render comes from the result type.
 
-- [ ] W6 -- Selector lvalue (write side). Extend HIR / MIR `Lvalue` to carry a root `*Ref` plus an
-      optional selector kind (Element or Range, mirroring the read-side shapes; multi-layer
-      selectors are `packed.md`). Add `PackedArray::AssignSlice(lsb_bit, width, value)` /
-      `PackedArray::AssignIndex(idx, value)` parallel to the existing `AssignFrom` partial-write
-      convention. LRM 11.5.1 write rules: a fully-OOB write has **no effect** on the stored value
-      (silent no-op, not an error); a partially-OOB write affects **only the in-range bits**; an X /
-      Z position is treated as a fully-OOB write (no effect). Closes
-      `datatypes/packed/indexed_part_select/default.yaml` for the write half.
+- [x] W6 -- Selector lvalue (write side, including NBA + selector). Extended HIR / MIR `Lvalue` to
+      carry a root `*Ref` plus a `vector<LvalueSelector>` chain. Added
+      `PackedArray::AssignSlice(lsb_bit, width, value)` and the `ElementAt` / `Slice` chain entries
+      on `PackedArray` / `PackedArrayRef`. Observable selector writes route through
+      `Var<T>::Mutate(services)` which returns a `ScopedMutation<T>` RAII handle: it snapshots
+      `var.Get()`, forwards chain methods, and commits via `WriteVar` in its destructor (relying on
+      C++17 mandatory copy elision for the prvalue return). NBA on selector lvalues snapshots every
+      non-literal `ExprId` in the chain into the closure body via `ByValueCapture`; integer literals
+      are cloned verbatim. Render walks the chain and emits one method call per layer, with
+      `.Mutate(*services_)` inserted between root and first selector when the root is observable.
+      LRM 11.5.1 write rules (fully-OOB no-op, partial-OOB only in-range bits, X / Z position no-op)
+      live inside `AssignSlice`. Closes `datatypes/packed/indexed_part_select/default.yaml` for the
+      write half.
 
 ### Construction
 
@@ -215,8 +330,8 @@ which slang has already pinned at AST construction.
 
 - [ ] W10 -- Concatenation lvalue `{a, b, c} = ...`. Add a `ConcatLvalue` arm to `Lvalue` carrying
       an ordered list of sub-lvalues. HIR -> MIR snapshots the right-hand side into a `PackedArray`
-      temp and distributes its bits MSB-first into each sub-target via the same selector machinery
-      W7 provides.
+      temp and distributes its bits MSB-first into each sub-target via the same selector chain
+      machinery W6 provides.
 
 ### Assignment families
 
@@ -224,7 +339,7 @@ which slang has already pinned at AST construction.
       `hir::CompoundAssignStmt { Lvalue target; BinaryOp op; ExprId rhs }`. HIR -> MIR snapshots
       every index expression in `target` into fresh procedural temps before the read-modify-write so
       the target lvalue evaluates exactly once (LRM 11.4.1). Covers `arr[i++] += x` and
-      partial-target shapes such as `data[i+:4] |= v` once W7 is in.
+      partial-target shapes such as `data[i+:4] |= v` through the W6 selector chain.
 
 - [ ] W12 -- `++` / `--` (prefix and postfix). Add `hir::IncrDecrStmt` and `hir::IncrDecrExpr`
       (separate from `AssignExpr` because the expression form returns the pre- or post-value). HIR
@@ -240,5 +355,5 @@ which slang has already pinned at AST construction.
 - `integral.md` J14 archive sweep depends on W4..W6 for any binary / shift-overflow case that
   selects sub-bits before applying the operator.
 - `control-flow.md` C11 unblocked by W2; C12 unblocked by W1 (basic) and W2 (wildcard items).
-- `packed.md` P1..P5 extend W7's selector list to multi-layer and add field / variant selectors;
-  they assume W7 has landed.
+- `packed.md` P3..P5 use W6's selector chain shape and add field / variant selectors on top; multi-
+  dim packed array selectors are handled here, not in `packed.md`.

--- a/docs/progress/packed.md
+++ b/docs/progress/packed.md
@@ -1,39 +1,31 @@
 # Packed Types
 
-Tracks the type-side packed-aggregate surface: multi-dimensional packed arrays, packed structs,
-packed unions, and assignment patterns for packed types. The operator-side selector machinery
-(single-layer bit / range / indexed part-select read and write) lives in `operators.md` and is a
-prerequisite for everything here. Each archive item checkbox in `architecture-reset.md` is checked
-when its `*.yaml` cases reproduce on the current pipeline.
+Tracks the type-side packed-aggregate surface that is not subsumed by `operators.md`: packed
+structs, packed unions, and assignment patterns over packed types. Multi-dim packed array selectors
+(read and write, including chained selectors on `bit [N-1:0][W-1:0]` and deeper) are covered by
+`operators.md` W4..W6 and their `vector<LvalueSelector>` chain shape; this file picks up where the
+chain machinery leaves off -- field access, union views, and aggregate literal forms. Each archive
+item checkbox in `architecture-reset.md` is checked when its `*.yaml` cases reproduce on the current
+pipeline.
 
 Done when:
 
-- `datatypes/packed/packed_2d`, `packed_3d`, `packed_struct`, `packed_union`,
-  `assignment_pattern_fill`, `assignment_pattern_multibit`, `nested_aggregates`, and
-  `packed_integral_default` reproduce.
-- `datatypes/wide_integral/packed_2d` reproduces (a 2D-indexing case wrongly grouped under
-  `wide_integral` in the archive; it belongs to this workstream).
+- `datatypes/packed/packed_struct`, `packed_union`, `assignment_pattern_fill`,
+  `assignment_pattern_multibit`, `nested_aggregates`, and `packed_integral_default` reproduce.
 - `operators/replication_patterns` reproduces (`'{N{x}}` array-literal forms over packed types).
 
-The numeric IDs (P1..P5) are stable references and imply execution order.
+The numeric IDs (P3..P5) are stable references and imply execution order. The earlier P1 / P2
+(multi-dim 2D / 3D selectors) are deleted from this file because they now reproduce through the
+operators.md selector chain.
 
 ## Sub-Steps
 
-- [ ] P1 -- Multi-dim packed 2D element select. Type `bit [N-1:0][W-1:0] x` exposes `x[i]` as a
-      W-bit slice on both read and write. Extend the HIR / MIR `Lvalue` selector list from the
-      single-layer `optional<Selector>` introduced in `operators.md` W7 to `vector<Selector>`, and
-      extend `SelectExpr` analogously on the read side. `PackedArray` itself keeps a flat layout;
-      the type system carries the dimension stack so each selector picks the right contiguous bit
-      range. Closes `datatypes/packed/packed_2d` and `datatypes/wide_integral/packed_2d`.
-
-- [ ] P2 -- Multi-dim packed 3D. Same selector list machinery, exercised at depth three. Adds
-      out-of-range and X / Z index tests at every level. Closes `datatypes/packed/packed_3d`.
-
-- [ ] P3 -- Packed struct field access. Add a `kField(field_index)` arm to the `Selector` variant
-      (in addition to W4's bit / range / indexed arms). HIR resolves the slang
+- [ ] P3 -- Packed struct field access. Add a `kField(field_index)` arm to the `LvalueSelector` /
+      `SelectExpr` variants alongside the existing element / range arms. HIR resolves the slang
       `MemberAccessExpression` to a `(field_index)` payload; MIR carries `(offset, width)` after
-      layout. Reads and writes route through the same `PackedArray::ReadRange` / `WriteRange`
-      helpers as W5 / W7. Closes `datatypes/packed/packed_struct`.
+      layout. Reads and writes route through the same chain machinery W4 / W5 / W6 use, with the
+      field arm contributing a constant bit offset and constant width to the accumulator. Closes
+      `datatypes/packed/packed_struct`.
 
 - [ ] P4 -- Packed union. All members overlay the same underlying `PackedArray` bits; field access
       reads / writes the full union width and reinterprets per the accessed member's type. No new
@@ -42,17 +34,18 @@ The numeric IDs (P1..P5) are stable references and imply execution order.
 
 - [ ] P5 -- Assignment patterns over packed aggregates. Handles positional `'{a, b, c}`, default
       `'{default: v}`, named `'{i: v, j: v}`, and replication-pattern `'{N{x}}` literal forms.
-      Lowers to a sequence of selector-targeted writes through the W7 / P1 machinery; no new runtime
-      primitive is needed. Closes `datatypes/packed/assignment_pattern_fill`,
+      Lowers to a sequence of selector-targeted writes through the W6 / P3 chain machinery; no new
+      runtime primitive is needed. Closes `datatypes/packed/assignment_pattern_fill`,
       `assignment_pattern_multibit`, `nested_aggregates`, and `operators/replication_patterns`.
 
 ## Cross-references
 
 - LRM anchors: 7.2 (packed structs and unions), 7.4 (packed and unpacked arrays), 10.9 (assignment
   patterns), 11.5.1 (bit-select / part-select on packed arrays and structs).
-- Prerequisite: `operators.md` W4..W7 must land before P1. P3 additionally needs the `Selector`
-  variant to be open for extension; introduce the `kField` arm in P3 itself.
-- `datatypes/packed/indexed_part_select` and `operators/concat`, `operators/replicate`,
+- Prerequisite: `operators.md` W4..W6 must land before P3 (P3 extends the same selector chain shape
+  with a field arm).
+- `datatypes/packed/indexed_part_select`, `datatypes/packed/packed_2d`, `packed_3d`,
+  `datatypes/wide_integral/packed_2d`, and `operators/concat`, `operators/replicate`,
   `operators/compound_assignment` all live in `operators.md`, not here, even though the archive
   groups some of them under `datatypes/packed`. The split follows the type-vs-operator boundary, not
   archive directory layout.

--- a/include/lyra/backend/cpp/render_expr.hpp
+++ b/include/lyra/backend/cpp/render_expr.hpp
@@ -11,9 +11,6 @@ namespace lyra::backend::cpp {
 auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
     -> diag::Result<std::string>;
 
-auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
-    -> diag::Result<std::string>;
-
 // Bare field name (no `.Get()` wrap) for callsites that need the Var place
 // itself rather than its value, e.g. the trigger pointers inside `WaitAny`.
 auto RenderStructuralVarName(

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -8,11 +8,11 @@
 #include "lyra/hir/binary_op.hpp"
 #include "lyra/hir/conversion.hpp"
 #include "lyra/hir/expr_id.hpp"
+#include "lyra/hir/lvalue.hpp"
 #include "lyra/hir/primary.hpp"
+#include "lyra/hir/range_bounds.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
-#include "lyra/hir/type.hpp"
 #include "lyra/hir/unary_op.hpp"
-#include "lyra/hir/value_ref.hpp"
 
 namespace lyra::hir {
 
@@ -69,24 +69,6 @@ struct ElementSelectExpr {
   ExprId base_value;
   ExprId index;
 };
-
-struct RangeConstantBounds {
-  ExprId msb_expr;
-  ExprId lsb_expr;
-};
-
-struct RangeIndexedUpBounds {
-  ExprId base_index;
-  ExprId width;
-};
-
-struct RangeIndexedDownBounds {
-  ExprId base_index;
-  ExprId width;
-};
-
-using RangeBounds = std::variant<
-    RangeConstantBounds, RangeIndexedUpBounds, RangeIndexedDownBounds>;
 
 struct RangeSelectExpr {
   ExprId base_value;

--- a/include/lyra/hir/lvalue.hpp
+++ b/include/lyra/hir/lvalue.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <variant>
+#include <vector>
+
+#include "lyra/hir/expr_id.hpp"
+#include "lyra/hir/range_bounds.hpp"
+#include "lyra/hir/value_ref.hpp"
+
+namespace lyra::hir {
+
+struct ElementLvalueSelector {
+  ExprId index;
+};
+
+struct RangeLvalueSelector {
+  RangeBounds bounds;
+};
+
+using LvalueSelector = std::variant<ElementLvalueSelector, RangeLvalueSelector>;
+
+// Writable place: a root storage (var ref) plus a chain of selectors that
+// project into it. Empty chain = whole-var write; one or more selectors =
+// partial write at the accumulated bit offset. Chain order is outer-first
+// (closest to the root). Render walks the chain alongside the operand's
+// PackedArrayType dim stack to translate source-form positions into the
+// storage bit address space.
+//
+// `LoopVarRef` is reachable only via constructor-side lowering of the
+// generate-for header (where the induction variable is the only legal write
+// target). Process-side AST->HIR rejects LoopVarRef as an assignment target,
+// and HIR->MIR consequently never sees one in a process body.
+struct Lvalue {
+  std::variant<StructuralVarRef, ProceduralVarRef, LoopVarRef> root;
+  std::vector<LvalueSelector> selectors;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/range_bounds.hpp
+++ b/include/lyra/hir/range_bounds.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <variant>
+
+#include "lyra/hir/expr_id.hpp"
+
+namespace lyra::hir {
+
+struct RangeConstantBounds {
+  ExprId msb_expr;
+  ExprId lsb_expr;
+};
+
+struct RangeIndexedUpBounds {
+  ExprId base_index;
+  ExprId width;
+};
+
+struct RangeIndexedDownBounds {
+  ExprId base_index;
+  ExprId width;
+};
+
+using RangeBounds = std::variant<
+    RangeConstantBounds, RangeIndexedUpBounds, RangeIndexedDownBounds>;
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/value_ref.hpp
+++ b/include/lyra/hir/value_ref.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <variant>
-
 #include "lyra/hir/loop_var.hpp"
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/structural_hops.hpp"
@@ -28,12 +26,5 @@ struct LoopVarRef {
 
   auto operator==(const LoopVarRef&) const -> bool = default;
 };
-
-// Lvalue names a storage location. Same shape is used in both
-// assignment-target position (directly) and read position (wrapped in
-// LvalueRead). Validity of LoopVarRef as a write target depends on context
-// and is enforced at HIR-to-MIR (only the for-loop induction header may
-// write a loop variable).
-using Lvalue = std::variant<StructuralVarRef, ProceduralVarRef, LoopVarRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/mir/closure.hpp
+++ b/include/lyra/mir/closure.hpp
@@ -5,21 +5,21 @@
 #include <vector>
 
 #include "lyra/mir/expr_id.hpp"
+#include "lyra/mir/lvalue.hpp"
 #include "lyra/mir/procedural_var.hpp"
-#include "lyra/mir/value_ref.hpp"
 
 namespace lyra::mir {
 
 struct ProceduralScope;
 
 struct ByValueCapture {
-  ExprId value;
-  ProceduralVarId binding;
+  ExprId value{};
+  ProceduralVarId binding{};
 };
 
 struct ByReferenceCapture {
   Lvalue source;
-  ProceduralVarId binding;
+  ProceduralVarId binding{};
 };
 
 using Capture = std::variant<ByValueCapture, ByReferenceCapture>;

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -11,6 +11,8 @@
 #include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/integral_constant.hpp"
+#include "lyra/mir/lvalue.hpp"
+#include "lyra/mir/range_bounds.hpp"
 #include "lyra/mir/runtime_diagnostic.hpp"
 #include "lyra/mir/runtime_finish.hpp"
 #include "lyra/mir/runtime_print.hpp"
@@ -18,7 +20,6 @@
 #include "lyra/mir/structural_param.hpp"
 #include "lyra/mir/structural_subroutine.hpp"
 #include "lyra/mir/unary_op.hpp"
-#include "lyra/mir/value_ref.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::mir {
@@ -93,24 +94,6 @@ struct ElementSelectExpr {
   ExprId base_value;
   ExprId index;
 };
-
-struct RangeConstantBounds {
-  ExprId msb_expr;
-  ExprId lsb_expr;
-};
-
-struct RangeIndexedUpBounds {
-  ExprId base_index;
-  ExprId width;
-};
-
-struct RangeIndexedDownBounds {
-  ExprId base_index;
-  ExprId width;
-};
-
-using RangeBounds = std::variant<
-    RangeConstantBounds, RangeIndexedUpBounds, RangeIndexedDownBounds>;
 
 struct RangeSelectExpr {
   ExprId base_value;

--- a/include/lyra/mir/lvalue.hpp
+++ b/include/lyra/mir/lvalue.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <variant>
+#include <vector>
+
+#include "lyra/mir/expr_id.hpp"
+#include "lyra/mir/range_bounds.hpp"
+#include "lyra/mir/value_ref.hpp"
+
+namespace lyra::mir {
+
+struct ElementLvalueSelector {
+  ExprId index;
+};
+
+struct RangeLvalueSelector {
+  RangeBounds bounds;
+};
+
+using LvalueSelector = std::variant<ElementLvalueSelector, RangeLvalueSelector>;
+
+// Writable place: a root storage (var ref) plus a chain of selectors that
+// project into it. Empty chain = whole-var write; one or more selectors =
+// partial write at the accumulated bit offset. Chain order is outer-first
+// (closest to the root). Render walks the chain alongside the operand's
+// PackedArrayType dim stack to translate source-form positions into the
+// storage bit address space.
+struct Lvalue {
+  std::variant<StructuralVarRef, ProceduralVarRef> root;
+  std::vector<LvalueSelector> selectors;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/mir/range_bounds.hpp
+++ b/include/lyra/mir/range_bounds.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <variant>
+
+#include "lyra/mir/expr_id.hpp"
+
+namespace lyra::mir {
+
+struct RangeConstantBounds {
+  ExprId msb_expr;
+  ExprId lsb_expr;
+};
+
+struct RangeIndexedUpBounds {
+  ExprId base_index;
+  ExprId width;
+};
+
+struct RangeIndexedDownBounds {
+  ExprId base_index;
+  ExprId width;
+};
+
+using RangeBounds = std::variant<
+    RangeConstantBounds, RangeIndexedUpBounds, RangeIndexedDownBounds>;
+
+}  // namespace lyra::mir

--- a/include/lyra/mir/value_ref.hpp
+++ b/include/lyra/mir/value_ref.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <variant>
-
 #include "lyra/mir/procedural_hops.hpp"
 #include "lyra/mir/procedural_var.hpp"
 #include "lyra/mir/structural_hops.hpp"
@@ -18,7 +16,5 @@ struct ProceduralVarRef {
   ProceduralHops hops;
   ProceduralVarId var{};
 };
-
-using Lvalue = std::variant<StructuralVarRef, ProceduralVarRef>;
 
 }  // namespace lyra::mir

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -14,6 +14,7 @@
 #include "lyra/runtime/runtime_services.hpp"
 #include "lyra/runtime/trigger.hpp"
 #include "lyra/value/packed.hpp"
+#include "lyra/value/packed_array.hpp"
 
 namespace lyra::runtime {
 
@@ -118,10 +119,8 @@ concept CaseEqualComparable = requires(const T& a, const T& b) {
   { a.IsCaseEqual(b) } -> std::same_as<bool>;
 };
 
-template <typename T>
-concept HasLsb = requires(const T& a) {
-  { a.Lsb() } -> std::same_as<value::FourStateBit>;
-};
+template <CaseEqualComparable T>
+class ScopedMutation;
 
 template <CaseEqualComparable T>
 class Var : public Observable {
@@ -155,6 +154,15 @@ class Var : public Observable {
   [[nodiscard]] auto Get() const noexcept -> const T& {
     return value_;
   }
+
+  // RAII entry to partial-write context. Construct via `var.Mutate(services)`
+  // at the start of a chain; the returned handle snapshots the current value,
+  // forwards chain methods so `var.Mutate(svc)[idx].Slice(...) = v` works as a
+  // single expression, and commits the mutated snapshot through `WriteVar` in
+  // its destructor (fires subscribers on change). Lifetime is C++ standard
+  // full-expression temporary lifetime -- the handle is non-copyable and
+  // non-movable, so storing it past the statement is rejected at compile time.
+  auto Mutate(RuntimeServices& services) -> ScopedMutation<T>;
 
  private:
   T value_{};
@@ -211,13 +219,71 @@ inline auto WaitAny(std::initializer_list<Trigger> triggers)
   return EventControlAwaitable{std::vector<Trigger>(triggers)};
 }
 
-template <HasLsb T>
-void WriteVar(RuntimeServices& services, Var<T>& var, T new_val) {
+template <CaseEqualComparable T>
+inline void WriteVar(RuntimeServices& services, Var<T>& var, const T& new_val) {
   const value::FourStateBit old_lsb = var.Get().Lsb();
   const value::FourStateBit new_lsb = new_val.Lsb();
-  if (var.AssignIfChanged(std::move(new_val))) {
+  if (var.AssignIfChanged(new_val)) {
     services.TriggerValueChange(var, ClassifyEdge(old_lsb, new_lsb));
   }
+}
+
+// Non-template overload for the common Var<PackedArray> case. Lets the
+// emit-side pass a value::PackedArrayRef which implicitly converts to
+// const PackedArray& (template deduction would not trigger that conversion).
+inline void WriteVar(
+    RuntimeServices& services, Var<value::PackedArray>& var,
+    const value::PackedArray& new_val) {
+  const value::FourStateBit old_lsb = var.Get().Lsb();
+  const value::FourStateBit new_lsb = new_val.Lsb();
+  if (var.AssignIfChanged(new_val)) {
+    services.TriggerValueChange(var, ClassifyEdge(old_lsb, new_lsb));
+  }
+}
+
+// RAII handle that owns a snapshot of `var.Get()` for the lifetime of one
+// partial-write expression. Forwards chain methods to the snapshot so emitted
+// code reads like a normal `PackedArrayRef` chain. The destructor calls
+// `WriteVar` with the (possibly mutated) snapshot -- subscribers fire on
+// change. Non-copyable and non-movable: the contract is that it lives only
+// until the end of the constructing full expression. Returning it by value
+// from `Var<T>::Mutate` relies on C++17 mandatory copy elision (prvalues are
+// materialized in the caller's storage with no copy/move).
+template <CaseEqualComparable T>
+class ScopedMutation {
+ public:
+  ScopedMutation(RuntimeServices& services, Var<T>& var)
+      : services_(&services), var_(&var), snapshot_(var.Get()) {
+  }
+
+  ScopedMutation(const ScopedMutation&) = delete;
+  auto operator=(const ScopedMutation&) -> ScopedMutation& = delete;
+  ScopedMutation(ScopedMutation&&) = delete;
+  auto operator=(ScopedMutation&&) -> ScopedMutation& = delete;
+
+  ~ScopedMutation() {
+    WriteVar(*services_, *var_, std::move(snapshot_));
+  }
+
+  // Chain forwards. The returned `PackedArrayRef` holds a pointer into this
+  // ScopedMutation's snapshot_; both have the same full-expression lifetime,
+  // so the ref stays valid for the rest of the statement.
+  auto ElementAt(const value::PackedArray& idx) {
+    return snapshot_.ElementAt(idx);
+  }
+  auto Slice(const value::PackedArray& lsb, std::uint32_t count) {
+    return snapshot_.Slice(lsb, count);
+  }
+
+ private:
+  RuntimeServices* services_;
+  Var<T>* var_;
+  T snapshot_;
+};
+
+template <CaseEqualComparable T>
+auto Var<T>::Mutate(RuntimeServices& services) -> ScopedMutation<T> {
+  return ScopedMutation<T>{services, *this};
 }
 
 }  // namespace lyra::runtime

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -4,20 +4,58 @@
 #include <initializer_list>
 #include <span>
 #include <variant>
+#include <vector>
 
 #include "lyra/value/packed.hpp"
 
 namespace lyra::value {
 
+class PackedArrayRef;
+
+// Declared range of one packed dimension. Outermost dimension is dims[0]; the
+// inner element type's dim stack follows. For `bit [N-1:0]`: dims = [{N-1,
+// 0}] (1D, each element is one bit). For `bit [1:0][7:0]`: dims = [{1, 0},
+// {7, 0}] (2D, each outer element is `bit [7:0]`).
+//
+// This carries SystemVerilog's declared bounds. Storage layout is private --
+// PackedArray today uses flat-bit BitValue/LogicValue, but the API contract
+// is element-level (operator[] / Slice take outer-element positions), so
+// future storage optimizations (canonical byte alignment, vector-of-elements
+// for huge outer dims, etc.) change runtime internals without touching the
+// emit or this contract.
+struct PackedRange {
+  std::int64_t left;
+  std::int64_t right;
+
+  [[nodiscard]] auto ElementCount() const -> std::uint64_t {
+    return static_cast<std::uint64_t>(
+        (left >= right ? left - right : right - left) + 1);
+  }
+};
+
 // Unified integral value. Mirrors slang's `IntegralType` and the legacy
-// archive's `IntegralInfo`: one type, three attributes. `backend::cpp` emits
-// every SystemVerilog integral (`byte`, `shortint`, `int`, `longint`,
-// `integer`, `time`, `bit [N:0]`, `logic [N:0]`, `reg [N:0]`) as
-// `PackedArray`. Storage layout (inline word(s) versus heap) and the
-// presence of an unknown plane are private details chosen at construction
-// from `bit_width` and `is_four_state`.
+// archive's `IntegralInfo`: one type, three attributes plus a dim stack.
+// `backend::cpp` emits every SystemVerilog integral (`byte`, `shortint`,
+// `int`, `longint`, `integer`, `time`, `bit [N:0]`, `logic [N:0]`, `reg
+// [N:0]`, and multi-dim packed forms like `bit [N:0][M:0]`) as `PackedArray`.
+//
+// `dims_` carries the declared structure: 1D for vectors, multi-dim for
+// packed-of-packed. `operator[]` and `Slice` dispatch via `dims_` so the API
+// is element-level regardless of operand dimensionality -- the emitted C++
+// never bakes element-width arithmetic into call sites. Storage layout (flat
+// bit planes today; potentially canonical-byte-aligned or vector-of-elements
+// once optimization work begins) is private to PackedArray and disjoint from
+// the API contract.
 class PackedArray {
  public:
+  // Primary constructor: declared dim stack + sign + 4-state. Total bit
+  // width is the product of dim sizes (cached internally as `bit_width_`).
+  PackedArray(
+      std::initializer_list<PackedRange> dims, bool is_signed,
+      bool is_four_state);
+
+  // 1D shorthand for the common `bit [bit_width-1:0]` case. Equivalent to
+  // the dim-list constructor with `{{bit_width-1, 0}}`.
   PackedArray(std::uint64_t bit_width, bool is_signed, bool is_four_state);
 
   // Convenience factory for the default int shape (32-bit, signed, 2-state).
@@ -58,6 +96,9 @@ class PackedArray {
 
   [[nodiscard]] auto BitWidth() const -> std::uint64_t;
   [[nodiscard]] auto IsSigned() const -> bool;
+  // Declared dim stack, outermost first. Storage is flat regardless; this is
+  // an API-contract field that operator[] / Slice dispatch on.
+  [[nodiscard]] auto Dims() const -> std::span<const PackedRange>;
   [[nodiscard]] auto IsFourState() const -> bool;
 
   // LRM 11.4.5 `===` predicate form (host bool). Operator form: `CaseEqual`.
@@ -140,16 +181,40 @@ class PackedArray {
   [[nodiscard]] auto WildcardEquals(const PackedArray& other) const
       -> PackedArray;
 
-  // LRM 11.5.1 bit-select: extract the bit at `index` as a 1-bit PackedArray.
-  // Invalid (x/z or out-of-range) index yields x (4-state) or 0 (2-state).
-  [[nodiscard]] auto Index(const PackedArray& index) const -> PackedArray;
+  // Low-level bit-level primitives. `ExtractBits` reads `bit_width` contiguous
+  // bits starting at `lsb_bit`. `AssignSlice` writes those bits with the LRM
+  // 11.5.1 corner cases (X/Z lsb, fully-OOB lsb, lsb magnitude exceeding the
+  // 64-bit position carrier all collapse to a silent no-op; partial-OOB
+  // affects only in-range bits). Positions are in the canonical flat-bit
+  // address space, dimension-agnostic. The element-level chain methods below
+  // (`operator[]`, `Slice`) compose offsets in this address space and route
+  // here at the chain leaf.
+  [[nodiscard]] auto ExtractBits(
+      const PackedArray& lsb_bit, std::uint32_t bit_width) const -> PackedArray;
+  auto AssignSlice(
+      const PackedArray& lsb_bit, std::uint32_t bit_width,
+      const PackedArray& value) -> void;
 
-  // LRM 7.4.5 slice / 11.5.1 part-select: extract `width` contiguous bits whose
-  // LSB sits at `lsb_bit`. Per LRM 7.4.5 the size is constant (compile-time
-  // `width`) but the position may be runtime (`lsb_bit`). Bits outside the
-  // declared range yield x (4-state) or 0 (2-state).
+  // Proxy-chain entry points. Both methods take positions in the operand's
+  // outer-element units; PackedArray's `dims_` decides the element bit width
+  // internally. For a 1D operand (`dims_.size() == 1`), one "element" is one
+  // bit, so `ElementAt` is the LRM 11.5.1 bit-select and `Slice` is the LRM
+  // 11.5.1 part-select at bit level. For a multi-dim operand, one "element"
+  // is the inner subtype, and the API scales positions internally.
+  //
+  // Non-const overloads return a `PackedArrayRef` that composes further
+  // selectors and routes a final `operator=` through `AssignSlice`. Const
+  // overloads materialize the sub-slice as a fresh `PackedArray` for
+  // read-side use. Uniformly method-style (no `operator[]`) so a chain is
+  // visually consistent: `data.ElementAt(idx).Slice(lsb, count)`.
+  [[nodiscard]] auto ElementAt(const PackedArray& idx) -> PackedArrayRef;
+  [[nodiscard]] auto ElementAt(const PackedArray& idx) const -> PackedArray;
   [[nodiscard]] auto Slice(
-      const PackedArray& lsb_bit, std::uint32_t width) const -> PackedArray;
+      const PackedArray& lsb_in_outer_elements,
+      std::uint32_t count_in_outer_elements) -> PackedArrayRef;
+  [[nodiscard]] auto Slice(
+      const PackedArray& lsb_in_outer_elements,
+      std::uint32_t count_in_outer_elements) const -> PackedArray;
   [[nodiscard]] auto operator<(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator<=(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator>(const PackedArray& other) const -> PackedArray;
@@ -201,6 +266,46 @@ class PackedArray {
   bool is_signed_;
   bool is_four_state_;
   std::variant<BitValue, LogicValue> storage_;
+  std::vector<PackedRange> dims_;
+};
+
+// Writable reference into a sub-range of a PackedArray. Composes through
+// chained `operator[]` / `Slice` and triggers the LRM 11.5.1 partial-write
+// rules via `AssignSlice` on the root when assigned. Reading materializes
+// back to a fresh `PackedArray`.
+//
+// Carries a `dims_` stack mirroring the structural shape of this sub-view:
+// `dims_[0]` is the outer dim at the current chain layer; further chain
+// methods dispatch on it to compute element bit width and emit a
+// dimension-aware sub-Ref. The internal `bit_offset_` is kept in a canonical
+// 64-bit signed 4-state shape so chained `+` / `*` between layers do not
+// collide on shape, and X/Z in any layer's index/lsb propagates to the final
+// write (LRM "X/Z position is a no-op").
+class PackedArrayRef {
+ public:
+  PackedArrayRef(
+      PackedArray& root, const PackedArray& bit_offset, std::uint32_t bit_width,
+      std::vector<PackedRange> dims);
+
+  // Read-side: materialize the sub-slice.
+  [[nodiscard]] operator PackedArray()
+      const;  // NOLINT(google-explicit-constructor)
+
+  // Write-side: route through AssignSlice on root.
+  auto operator=(const PackedArray& value) -> PackedArrayRef&;
+
+  // Chain composition. Positions are in the current sub-view's outer-element
+  // units; the proxy scales internally based on `dims_`.
+  [[nodiscard]] auto ElementAt(const PackedArray& idx) const -> PackedArrayRef;
+  [[nodiscard]] auto Slice(
+      const PackedArray& lsb_in_outer_elements,
+      std::uint32_t count_in_outer_elements) const -> PackedArrayRef;
+
+ private:
+  PackedArray* root_;
+  PackedArray bit_offset_;
+  std::uint32_t bit_width_;
+  std::vector<PackedRange> dims_;
 };
 
 }  // namespace lyra::value

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -183,7 +183,11 @@ auto RenderStructuralVarName(
   return ctx.StructuralScope().GetStructuralVar(ref.var).name;
 }
 
-auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
+namespace {
+
+auto RenderLvalueRoot(
+    const RenderContext& ctx,
+    const std::variant<mir::StructuralVarRef, mir::ProceduralVarRef>& root)
     -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
@@ -194,10 +198,8 @@ auto RenderLvalue(const RenderContext& ctx, const mir::Lvalue& target)
             return LookupProceduralVarName(ctx, l);
           },
       },
-      target);
+      root);
 }
-
-namespace {
 
 // Read-side render for a structural var ref. Integral packed vars wrap in
 // `Var<PackedArray>` whose held value is observed via `.Get()`; all other
@@ -452,25 +454,6 @@ auto RenderConditionalExpr(
   return "(" + *cond_or + " ? " + *then_or + " : " + *else_or + ")";
 }
 
-auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
-    -> diag::Result<std::string> {
-  auto target_or = RenderLvalue(ctx, a.target);
-  if (!target_or) return std::unexpected(std::move(target_or.error()));
-  auto value_or = RenderExpr(ctx, ctx.Expr(a.value));
-  if (!value_or) return std::unexpected(std::move(value_or.error()));
-  // Writes to a `Var<T>`-wrapped structural var go through `WriteVar` so the
-  // runtime can fire value-change triggers. Raw fields (real-family, string)
-  // use plain C++ assignment.
-  if (const auto* svr = std::get_if<mir::StructuralVarRef>(&a.target)) {
-    const auto& var_decl = ctx.StructuralScope().GetStructuralVar(svr->var);
-    if (IsObservableScalarType(ctx.Unit().GetType(var_decl.type))) {
-      return "lyra::runtime::WriteVar(*services_, " + *target_or + ", " +
-             *value_or + ")";
-    }
-  }
-  return "(" + *target_or + " = " + *value_or + ")";
-}
-
 // SV LRM 6.12.1 + 6.22: real-family conversions are pure float-precision
 // reshape. `realtime` is a synonym for `real`, so both share `double`. The
 // only emit-time work is on shortreal <-> real: insert an explicit
@@ -676,57 +659,188 @@ auto RenderElementSelectExpr(
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   auto idx_or = RenderExpr(ctx, ctx.Expr(sel.index));
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
-  return std::format("({}).Index({})", *base_or, *idx_or);
+  return std::format("({}).ElementAt({})", *base_or, *idx_or);
+}
+
+// Constant integer extracted from a MIR expression. Caller is responsible for
+// ensuring the expression is a constant (slang guarantees this for constant
+// bounds and indexed widths per LRM 11.5.1).
+auto ConstantIntFromExpr(const mir::Expr& expr) -> std::int64_t {
+  if (const auto* lit = std::get_if<mir::IntegerLiteral>(&expr.data)) {
+    return IntegralConstantToInt64(lit->value);
+  }
+  throw InternalError(
+      "ConstantIntFromExpr: expression is not an IntegerLiteral");
+}
+
+// Emits the method-call suffix for a single selector layer applied to the
+// running chain. Positions are in the operand's outer-element units; the
+// runtime PackedArray / PackedArrayRef dispatches on its own dim stack to
+// turn them into bit offsets, so render never bakes element_bw into the
+// emitted call.
+auto RenderSelectorMethodCall(
+    const RenderContext& ctx, const mir::LvalueSelector& sel)
+    -> diag::Result<std::string> {
+  return std::visit(
+      Overloaded{
+          [&](const mir::ElementLvalueSelector& s)
+              -> diag::Result<std::string> {
+            auto idx = RenderExpr(ctx, ctx.Expr(s.index));
+            if (!idx) return std::unexpected(std::move(idx.error()));
+            return std::format(".ElementAt({})", *idx);
+          },
+          [&](const mir::RangeLvalueSelector& s) -> diag::Result<std::string> {
+            return std::visit(
+                Overloaded{
+                    [&](const mir::RangeConstantBounds& b)
+                        -> diag::Result<std::string> {
+                      auto lsb = RenderExpr(ctx, ctx.Expr(b.lsb_expr));
+                      if (!lsb) return std::unexpected(std::move(lsb.error()));
+                      const auto msb_val =
+                          ConstantIntFromExpr(ctx.Expr(b.msb_expr));
+                      const auto lsb_val =
+                          ConstantIntFromExpr(ctx.Expr(b.lsb_expr));
+                      const auto count = static_cast<std::uint32_t>(
+                          (msb_val >= lsb_val ? msb_val - lsb_val
+                                              : lsb_val - msb_val) +
+                          1);
+                      return std::format(".Slice({}, {}U)", *lsb, count);
+                    },
+                    [&](const mir::RangeIndexedUpBounds& b)
+                        -> diag::Result<std::string> {
+                      auto base = RenderExpr(ctx, ctx.Expr(b.base_index));
+                      if (!base) {
+                        return std::unexpected(std::move(base.error()));
+                      }
+                      const auto count = static_cast<std::uint32_t>(
+                          ConstantIntFromExpr(ctx.Expr(b.width)));
+                      return std::format(".Slice({}, {}U)", *base, count);
+                    },
+                    [&](const mir::RangeIndexedDownBounds& b)
+                        -> diag::Result<std::string> {
+                      const auto& base_mir = ctx.Expr(b.base_index);
+                      auto base = RenderExpr(ctx, base_mir);
+                      if (!base) {
+                        return std::unexpected(std::move(base.error()));
+                      }
+                      const auto& base_ty = ctx.Unit().GetType(base_mir.type);
+                      if (!base_ty.IsPackedArray()) {
+                        throw InternalError(
+                            "RenderSelectorMethodCall: IndexedDown base_index "
+                            "type is not PackedArrayType");
+                      }
+                      const auto count = static_cast<std::uint32_t>(
+                          ConstantIntFromExpr(ctx.Expr(b.width)));
+                      const auto sub_lit = RenderSameShapeLiteral(
+                          base_ty.AsPackedArray(),
+                          static_cast<std::int64_t>(count) - 1);
+                      const auto lsb =
+                          std::format("(({}) - {})", *base, sub_lit);
+                      return std::format(".Slice({}, {}U)", lsb, count);
+                    },
+                },
+                s.bounds);
+          },
+      },
+      sel);
+}
+
+auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
+    -> diag::Result<std::string> {
+  auto value_or = RenderExpr(ctx, ctx.Expr(a.value));
+  if (!value_or) return std::unexpected(std::move(value_or.error()));
+  auto root_or = RenderLvalueRoot(ctx, a.target.root);
+  if (!root_or) return std::unexpected(std::move(root_or.error()));
+
+  const bool observable = [&] {
+    const auto* svr = std::get_if<mir::StructuralVarRef>(&a.target.root);
+    if (svr == nullptr) return false;
+    const auto& var_decl = ctx.StructuralScope().GetStructuralVar(svr->var);
+    return IsObservableScalarType(ctx.Unit().GetType(var_decl.type));
+  }();
+
+  // Whole-var write: existing entry points (events / direct assign).
+  if (a.target.selectors.empty()) {
+    if (observable) {
+      return "lyra::runtime::WriteVar(*services_, " + *root_or + ", " +
+             *value_or + ")";
+    }
+    return "(" + *root_or + " = " + *value_or + ")";
+  }
+
+  // Selector chain: compose PackedArrayRef method calls. Per-layer element
+  // bit widths are derived by the runtime PackedArray / PackedArrayRef from
+  // their own dim stack; render emits source-form positions only.
+  //
+  // Procedural-local target: chain mutates the variable in place. Chain base
+  // is the variable name itself.
+  // Observable target: enter a partial-write scope via `Var<T>::Mutate(svc)`,
+  // which returns a `ScopedMutation` RAII handle that snapshots the current
+  // value. The chain runs against the snapshot via the same forwarding
+  // methods as on PackedArray; when the full expression ends, the handle's
+  // destructor commits the snapshot through `WriteVar` so subscribers fire.
+  // Same shape inside or outside an NBA closure body -- no nested lambda.
+  std::string chain = *root_or;
+  if (observable) {
+    chain += ".Mutate(*services_)";
+  }
+  for (const auto& sel : a.target.selectors) {
+    auto method = RenderSelectorMethodCall(ctx, sel);
+    if (!method) return std::unexpected(std::move(method.error()));
+    chain += *method;
+  }
+  return chain + " = " + *value_or;
 }
 
 auto RenderRangeSelectExpr(
     const RenderContext& ctx, const mir::Expr& expr,
     const mir::RangeSelectExpr& sel) -> diag::Result<std::string> {
-  auto base_or = RenderExpr(ctx, ctx.Expr(sel.base_value));
+  const auto& operand_expr = ctx.Expr(sel.base_value);
+  auto base_or = RenderExpr(ctx, operand_expr);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
 
   const auto& result_ty = ctx.Unit().GetType(expr.type);
   if (!result_ty.IsPackedArray()) {
     throw InternalError(
-        "RenderRangeSelectExpr: result type is not PackedArrayType");
+        "RenderRangeSelectExpr: result must be PackedArrayType");
   }
-  const auto width =
-      static_cast<std::uint32_t>(result_ty.AsPackedArray().BitWidth());
+  // The slice's element-count is the outer dim of the result type. For a
+  // 1D operand this is bit count; for a multi-dim operand it is the
+  // selected outer-element count. PackedArray's `Slice` scales internally.
+  if (result_ty.AsPackedArray().dims.empty()) {
+    throw InternalError(
+        "RenderRangeSelectExpr: result PackedArrayType has no dims");
+  }
+  const auto count = static_cast<std::uint32_t>(
+      result_ty.AsPackedArray().dims.front().ElementCount());
 
   return std::visit(
       Overloaded{
           [&](const mir::RangeConstantBounds& b) -> diag::Result<std::string> {
             auto lsb_or = RenderExpr(ctx, ctx.Expr(b.lsb_expr));
             if (!lsb_or) return std::unexpected(std::move(lsb_or.error()));
-            return std::format("({}).Slice({}, {})", *base_or, *lsb_or, width);
+            return std::format("({}).Slice({}, {}U)", *base_or, *lsb_or, count);
           },
           [&](const mir::RangeIndexedUpBounds& b) -> diag::Result<std::string> {
-            auto base_idx_or = RenderExpr(ctx, ctx.Expr(b.base_index));
-            if (!base_idx_or) {
-              return std::unexpected(std::move(base_idx_or.error()));
-            }
-            return std::format(
-                "({}).Slice({}, {})", *base_or, *base_idx_or, width);
+            auto base = RenderExpr(ctx, ctx.Expr(b.base_index));
+            if (!base) return std::unexpected(std::move(base.error()));
+            return std::format("({}).Slice({}, {}U)", *base_or, *base, count);
           },
           [&](const mir::RangeIndexedDownBounds& b)
               -> diag::Result<std::string> {
-            const auto& base_idx_expr = ctx.Expr(b.base_index);
-            auto base_idx_or = RenderExpr(ctx, base_idx_expr);
-            if (!base_idx_or) {
-              return std::unexpected(std::move(base_idx_or.error()));
-            }
-            const auto& base_idx_ty = ctx.Unit().GetType(base_idx_expr.type);
-            if (!base_idx_ty.IsPackedArray()) {
+            const auto& base_mir = ctx.Expr(b.base_index);
+            auto base = RenderExpr(ctx, base_mir);
+            if (!base) return std::unexpected(std::move(base.error()));
+            const auto& base_ty = ctx.Unit().GetType(base_mir.type);
+            if (!base_ty.IsPackedArray()) {
               throw InternalError(
-                  "RenderRangeSelectExpr: base_index type is not "
+                  "RenderRangeSelectExpr: IndexedDown base_index type is not "
                   "PackedArrayType");
             }
-            const auto width_minus_one = static_cast<std::int64_t>(width) - 1;
-            const auto offset_literal = RenderSameShapeLiteral(
-                base_idx_ty.AsPackedArray(), width_minus_one);
-            return std::format(
-                "({}).Slice(({}) - {}, {})", *base_or, *base_idx_or,
-                offset_literal, width);
+            const auto sub_lit = RenderSameShapeLiteral(
+                base_ty.AsPackedArray(), static_cast<std::int64_t>(count) - 1);
+            const auto lsb = std::format("(({}) - {})", *base, sub_lit);
+            return std::format("({}).Slice({}, {}U)", *base_or, lsb, count);
           },
       },
       sel.bounds);

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -1,5 +1,6 @@
 #include "lyra/backend/cpp/render_type.hpp"
 
+#include <cstddef>
 #include <format>
 #include <string>
 #include <utility>
@@ -18,8 +19,26 @@ auto RenderPackedArrayCtorArgs(const mir::PackedArrayType& pa) -> std::string {
   const char* signed_lit =
       pa.signedness == mir::Signedness::kSigned ? "true" : "false";
   const char* four_state_lit = pa.atom != mir::BitAtom::kBit ? "true" : "false";
-  return std::to_string(pa.BitWidth()) + ", " + signed_lit + ", " +
-         four_state_lit;
+
+  // 1D shorthand: emit `bit_width, signed, four_state` -- uses the
+  // PackedArray 3-arg constructor. The dim list ctor would produce the same
+  // shape but is less readable for the common case.
+  if (pa.dims.size() == 1) {
+    return std::to_string(pa.BitWidth()) + ", " + signed_lit + ", " +
+           four_state_lit;
+  }
+
+  // Multi-dim: emit `{{l0, r0}, {l1, r1}, ...}, signed, four_state` for the
+  // PackedArray initializer-list constructor. The runtime keeps the dim stack
+  // so operator[] / Slice dispatch on outer-element bit width.
+  std::string dim_list = "{";
+  for (std::size_t i = 0; i < pa.dims.size(); ++i) {
+    if (i != 0) dim_list += ", ";
+    dim_list +=
+        std::format("{{ {}LL, {}LL }}", pa.dims[i].left, pa.dims[i].right);
+  }
+  dim_list += "}";
+  return dim_list + ", " + signed_lit + ", " + four_state_lit;
 }
 
 auto RenderTypeDefaultCtorArgs(const mir::Type& ty) -> std::string {

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -304,7 +304,9 @@ class HirDumper {
     throw InternalError("HirDumper: unknown BinaryOp");
   }
 
-  static auto FormatLvalue(const Lvalue& v) -> std::string {
+  static auto FormatLvalueRoot(
+      const std::variant<StructuralVarRef, ProceduralVarRef, LoopVarRef>& root)
+      -> std::string {
     return std::visit(
         Overloaded{
             [](const StructuralVarRef& r) -> std::string {
@@ -319,7 +321,47 @@ class HirDumper {
                   "LoopVar[{}](hops={})", r.loop_var.value, r.hops.value);
             },
         },
-        v);
+        root);
+  }
+
+  static auto FormatLvalueSelector(const LvalueSelector& sel) -> std::string {
+    return std::visit(
+        Overloaded{
+            [](const ElementLvalueSelector& s) -> std::string {
+              return std::format("Element index=Expr[{}]", s.index.value);
+            },
+            [](const RangeLvalueSelector& s) -> std::string {
+              const auto bounds = std::visit(
+                  Overloaded{
+                      [](const RangeConstantBounds& b) -> std::string {
+                        return std::format(
+                            "const msb=Expr[{}] lsb=Expr[{}]", b.msb_expr.value,
+                            b.lsb_expr.value);
+                      },
+                      [](const RangeIndexedUpBounds& b) -> std::string {
+                        return std::format(
+                            "indexed_up base=Expr[{}] width=Expr[{}]",
+                            b.base_index.value, b.width.value);
+                      },
+                      [](const RangeIndexedDownBounds& b) -> std::string {
+                        return std::format(
+                            "indexed_down base=Expr[{}] width=Expr[{}]",
+                            b.base_index.value, b.width.value);
+                      },
+                  },
+                  s.bounds);
+              return std::format("Range {}", bounds);
+            },
+        },
+        sel);
+  }
+
+  static auto FormatLvalue(const Lvalue& v) -> std::string {
+    std::string out = FormatLvalueRoot(v.root);
+    for (const auto& sel : v.selectors) {
+      out += std::format(" [{}]", FormatLvalueSelector(sel));
+    }
+    return out;
   }
 
   static auto FormatTimeScale(TimeScale s) -> std::string_view {

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -304,12 +304,18 @@ auto MakeRefExpr(hir::Primary ref, hir::TypeId type, diag::SourceSpan span)
   };
 }
 
-// Project an Lvalue (write context) into a Primary (read context). Lvalue and
-// Primary share the underlying ref types verbatim, so the projection is just
-// "lift the variant alternative". No data conversion.
+// Project an Lvalue (write context) into a Primary (read context). Only
+// whole-var Lvalues (empty selector chain) can be projected directly; a
+// selector lvalue's read-context shape is an ElementSelectExpr or
+// RangeSelectExpr, which the caller must materialize separately.
 auto LvalueToPrimary(const hir::Lvalue& lvalue) -> hir::Primary {
+  if (!lvalue.selectors.empty()) {
+    throw InternalError(
+        "LvalueToPrimary: cannot project a selector lvalue into a Primary; "
+        "compound assignment to a selector target is not yet supported");
+  }
   return std::visit(
-      [](const auto& ref) -> hir::Primary { return ref; }, lvalue);
+      [](const auto& ref) -> hir::Primary { return ref; }, lvalue.root);
 }
 
 auto FromSlangSubroutineKind(slang::ast::SubroutineKind k)
@@ -818,13 +824,13 @@ auto LowerElementSelectExprProc(
     const slang::ast::ElementSelectExpression& sel,
     const slang::ast::Expression& expr, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  if (!sel.value().type->isIntegral() || expr.type->getBitWidth() != 1) {
+  if (!sel.value().type->isIntegral()) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedExpressionForm,
-        "element-select is only supported on a 1D integral operand with a "
-        "1-bit result (bit-select)",
+        "element-select on non-integral operand is not yet supported",
         diag::UnsupportedCategory::kOperation);
   }
+
   auto base_or = LowerProcExpr(
       unit_facts, unit_state, proc_state, stack, sel.value(),
       compound_lvalue_context);
@@ -857,6 +863,13 @@ auto LowerRangeSelectExprProc(
     const slang::ast::RangeSelectExpression& sel,
     const slang::ast::Expression& expr, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
+  if (!sel.value().type->isIntegral()) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "range-select on non-integral operand is not yet supported",
+        diag::UnsupportedCategory::kOperation);
+  }
+
   auto base_or = LowerProcExpr(
       unit_facts, unit_state, proc_state, stack, sel.value(),
       compound_lvalue_context);
@@ -1212,50 +1225,111 @@ auto LowerStructuralExpr(
   }
 }
 
-namespace {
-
-// Extract the Lvalue from a lowered Expr whose Primary names a writable
-// storage location, or emit the "assignment target not supported" diagnostic
-// otherwise (e.g. literal, function call, binary expression).
-auto LvalueFromLoweredExpr(hir::Expr lowered, diag::SourceSpan span)
-    -> diag::Result<hir::Lvalue> {
+// Build the Lvalue chain by recursive descent on the slang AST. Inside-out:
+// the leaf (NamedValue) yields the root var ref; each outer ElementSelect /
+// RangeSelect layer lowers its index / bounds expressions and pushes a
+// selector onto the chain returned by the inner call. No intermediate select
+// Expr is materialized in the process expr store -- only the index / bounds
+// ExprIds that the chain actually references.
+auto LowerProcLvalue(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const slang::ast::Expression& expr) -> diag::Result<hir::Lvalue> {
+  const auto& mapper = unit_facts.SourceMapper();
+  const auto span = mapper.SpanOf(expr.sourceRange);
   auto unsupported = [&] {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedAssignmentTarget,
         "assignment target is not supported yet",
         diag::UnsupportedCategory::kFeature);
   };
-  auto* primary = std::get_if<hir::PrimaryExpr>(&lowered.data);
+
+  if (expr.kind == slang::ast::ExpressionKind::ElementSelect) {
+    const auto& sel = expr.as<slang::ast::ElementSelectExpression>();
+    if (!sel.value().type->isIntegral()) {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedAssignmentTarget,
+          "element-select lvalue on non-integral operand is not yet supported",
+          diag::UnsupportedCategory::kFeature);
+    }
+    auto inner =
+        LowerProcLvalue(unit_facts, unit_state, proc_state, stack, sel.value());
+    if (!inner) return std::unexpected(std::move(inner.error()));
+    auto idx_or = LowerProcExpr(
+        unit_facts, unit_state, proc_state, stack, sel.selector(),
+        std::nullopt);
+    if (!idx_or) return std::unexpected(std::move(idx_or.error()));
+    const hir::ExprId idx_id = proc_state.AddExpr(*std::move(idx_or));
+    inner->selectors.emplace_back(hir::ElementLvalueSelector{.index = idx_id});
+    return std::move(*inner);
+  }
+
+  if (expr.kind == slang::ast::ExpressionKind::RangeSelect) {
+    const auto& sel = expr.as<slang::ast::RangeSelectExpression>();
+    if (!sel.value().type->isIntegral()) {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedAssignmentTarget,
+          "range-select lvalue on non-integral operand is not yet supported",
+          diag::UnsupportedCategory::kFeature);
+    }
+    auto inner =
+        LowerProcLvalue(unit_facts, unit_state, proc_state, stack, sel.value());
+    if (!inner) return std::unexpected(std::move(inner.error()));
+    auto left_or = LowerProcExpr(
+        unit_facts, unit_state, proc_state, stack, sel.left(), std::nullopt);
+    if (!left_or) return std::unexpected(std::move(left_or.error()));
+    const hir::ExprId left_id = proc_state.AddExpr(*std::move(left_or));
+    auto right_or = LowerProcExpr(
+        unit_facts, unit_state, proc_state, stack, sel.right(), std::nullopt);
+    if (!right_or) return std::unexpected(std::move(right_or.error()));
+    const hir::ExprId right_id = proc_state.AddExpr(*std::move(right_or));
+    hir::RangeBounds bounds = [&]() -> hir::RangeBounds {
+      switch (sel.getSelectionKind()) {
+        case slang::ast::RangeSelectionKind::Simple:
+          return hir::RangeConstantBounds{
+              .msb_expr = left_id, .lsb_expr = right_id};
+        case slang::ast::RangeSelectionKind::IndexedUp:
+          return hir::RangeIndexedUpBounds{
+              .base_index = left_id, .width = right_id};
+        case slang::ast::RangeSelectionKind::IndexedDown:
+          return hir::RangeIndexedDownBounds{
+              .base_index = left_id, .width = right_id};
+      }
+      throw InternalError("LowerProcLvalue: unknown slang RangeSelectionKind");
+    }();
+    inner->selectors.emplace_back(
+        hir::RangeLvalueSelector{.bounds = std::move(bounds)});
+    return std::move(*inner);
+  }
+
+  // Leaf: lower as a regular expression and extract the root var ref. The
+  // wrapper Expr is discarded (not added to the process), so no dead Expr
+  // pollutes the store.
+  auto leaf = LowerProcExpr(
+      unit_facts, unit_state, proc_state, stack, expr, std::nullopt);
+  if (!leaf) return std::unexpected(std::move(leaf.error()));
+  auto* primary = std::get_if<hir::PrimaryExpr>(&leaf->data);
   if (primary == nullptr) return unsupported();
   return std::visit(
       Overloaded{
-          [&](const hir::StructuralVarRef& r) -> diag::Result<hir::Lvalue> {
-            return r;
+          [](const hir::StructuralVarRef& r) -> diag::Result<hir::Lvalue> {
+            return hir::Lvalue{.root = r, .selectors = {}};
           },
-          [&](const hir::ProceduralVarRef& r) -> diag::Result<hir::Lvalue> {
-            return r;
+          [](const hir::ProceduralVarRef& r) -> diag::Result<hir::Lvalue> {
+            return hir::Lvalue{.root = r, .selectors = {}};
           },
-          [&](const hir::LoopVarRef& r) -> diag::Result<hir::Lvalue> {
-            return r;
+          // LoopVarRef is a generate-for induction variable, not storage. It
+          // cannot appear as an assignment target in a process body. Reject
+          // here so the user sees an Unsupported diagnostic instead of a
+          // downstream InternalError when HIR->MIR tries to translate it.
+          [&](const hir::LoopVarRef&) -> diag::Result<hir::Lvalue> {
+            return unsupported();
           },
           [&](const auto&) -> diag::Result<hir::Lvalue> {
             return unsupported();
           },
       },
       primary->data);
-}
-
-}  // namespace
-
-auto LowerProcLvalue(
-    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
-    ProcessLoweringState& proc_state, const ScopeStack& stack,
-    const slang::ast::Expression& expr) -> diag::Result<hir::Lvalue> {
-  auto lowered = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, expr, std::nullopt);
-  if (!lowered) return std::unexpected(std::move(lowered.error()));
-  return LvalueFromLoweredExpr(
-      *std::move(lowered), unit_facts.SourceMapper().SpanOf(expr.sourceRange));
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/generate.cpp
+++ b/src/lyra/lowering/ast_to_hir/generate.cpp
@@ -294,7 +294,10 @@ auto BuildLoopGenerate(
   const hir::ExprId stop_id = parent_state.AddExpr(*std::move(stop_expr));
 
   const hir::Lvalue loop_var_lvalue{
-      hir::LoopVarRef{.hops = hir::StructuralHops{0}, .loop_var = loop_var_id}};
+      .root =
+          hir::LoopVarRef{
+              .hops = hir::StructuralHops{0}, .loop_var = loop_var_id},
+      .selectors = {}};
   auto iter_expr = LowerLoopIterNextValue(
       unit_facts, unit_state, parent_state, stack, *array.iterExpression,
       loop_var_lvalue);

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -155,7 +155,7 @@ auto LowerType(
       return hir::TypeData{hir::PackedArrayType{
           .atom = LowerScalarAtom(scalar.scalarKind),
           .signedness = hir::Signedness::kUnsigned,
-          .dims = {},
+          .dims = {hir::PackedRange{.left = 0, .right = 0}},
           .form = hir::PackedArrayForm::kExplicit,
       }};
     }

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -378,7 +378,10 @@ auto LowerLoopGenerate(
       proc_scope_state.AddExpr(*std::move(step_value_or));
   const mir::ExprId step_id = proc_scope_state.AddExpr(
       mir::Expr{
-          .data = mir::AssignExpr{.target = loop_local, .value = step_value_id},
+          .data =
+              mir::AssignExpr{
+                  .target = mir::Lvalue{.root = loop_local, .selectors = {}},
+                  .value = step_value_id},
           .type = step_type});
 
   std::vector<mir::Expr> body_args;
@@ -449,7 +452,10 @@ auto LowerStructuralVarInitAsStmt(
       scope_state.TranslateStructuralVar(hir::StructuralHops{0}, hir_var_id);
   const mir::ExprId assign_id = proc_scope_state.AddExpr(
       mir::Expr{
-          .data = mir::AssignExpr{.target = target, .value = rhs_id},
+          .data =
+              mir::AssignExpr{
+                  .target = mir::Lvalue{.root = target, .selectors = {}},
+                  .value = rhs_id},
           .type = mir_type});
   return mir::Stmt{
       .label = std::nullopt,

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -1,6 +1,7 @@
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 
 #include <cstdint>
+#include <format>
 #include <memory>
 #include <utility>
 #include <variant>
@@ -222,26 +223,118 @@ auto LowerStructuralParamRefExpr(
       .type = type};
 }
 
-auto LowerHirLvalueProc(
+auto LowerHirLvalueRoot(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state, const hir::Lvalue& lvalue)
-    -> mir::Lvalue {
+    -> std::variant<mir::StructuralVarRef, mir::ProceduralVarRef> {
   return std::visit(
       Overloaded{
-          [&](const hir::StructuralVarRef& m) -> mir::Lvalue {
+          [&](const hir::StructuralVarRef& m)
+              -> std::variant<mir::StructuralVarRef, mir::ProceduralVarRef> {
             return scope_state.TranslateStructuralVar(m.hops, m.var);
           },
-          [&](const hir::ProceduralVarRef& l) -> mir::Lvalue {
+          [&](const hir::ProceduralVarRef& l)
+              -> std::variant<mir::StructuralVarRef, mir::ProceduralVarRef> {
             return proc_state.TranslateProceduralVar(l.var);
           },
-          [](const hir::LoopVarRef&) -> mir::Lvalue {
+          // `LoopVarRef` is rejected at AST->HIR as a process-body lvalue, so
+          // by the time we reach HIR->MIR's process-side lowering this arm is
+          // unreachable. It exists only because the HIR Lvalue variant must
+          // accept LoopVarRef for the constructor-side generate-for header.
+          [](const hir::LoopVarRef&)
+              -> std::variant<mir::StructuralVarRef, mir::ProceduralVarRef> {
             throw InternalError(
-                "LowerHirLvalueProc: HIR LoopVarRef must not appear as an "
-                "lvalue in a process body; the for-loop header is constructor-"
-                "side, not procedural");
+                "LowerHirLvalueRoot: HIR LoopVarRef reached process-side "
+                "lvalue lowering; AST->HIR should have rejected it");
           },
       },
-      lvalue);
+      lvalue.root);
+}
+
+auto LowerHirRangeBoundsProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, const hir::RangeBounds& bounds)
+    -> diag::Result<mir::RangeBounds> {
+  auto lower_one = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
+    auto lowered = LowerExpr(
+        unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+        hir_process.exprs.at(id.value));
+    if (!lowered) return std::unexpected(std::move(lowered.error()));
+    return proc_scope_state.AddExpr(*std::move(lowered));
+  };
+  return std::visit(
+      Overloaded{
+          [&](const hir::RangeConstantBounds& b)
+              -> diag::Result<mir::RangeBounds> {
+            auto msb = lower_one(b.msb_expr);
+            if (!msb) return std::unexpected(std::move(msb.error()));
+            auto lsb = lower_one(b.lsb_expr);
+            if (!lsb) return std::unexpected(std::move(lsb.error()));
+            return mir::RangeConstantBounds{.msb_expr = *msb, .lsb_expr = *lsb};
+          },
+          [&](const hir::RangeIndexedUpBounds& b)
+              -> diag::Result<mir::RangeBounds> {
+            auto base = lower_one(b.base_index);
+            if (!base) return std::unexpected(std::move(base.error()));
+            auto width = lower_one(b.width);
+            if (!width) return std::unexpected(std::move(width.error()));
+            return mir::RangeIndexedUpBounds{
+                .base_index = *base, .width = *width};
+          },
+          [&](const hir::RangeIndexedDownBounds& b)
+              -> diag::Result<mir::RangeBounds> {
+            auto base = lower_one(b.base_index);
+            if (!base) return std::unexpected(std::move(base.error()));
+            auto width = lower_one(b.width);
+            if (!width) return std::unexpected(std::move(width.error()));
+            return mir::RangeIndexedDownBounds{
+                .base_index = *base, .width = *width};
+          },
+      },
+      bounds);
+}
+
+auto LowerHirLvalueProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, const hir::Lvalue& lvalue)
+    -> diag::Result<mir::Lvalue> {
+  mir::Lvalue out{
+      .root = LowerHirLvalueRoot(scope_state, proc_state, lvalue),
+      .selectors = {}};
+  out.selectors.reserve(lvalue.selectors.size());
+  for (const auto& sel : lvalue.selectors) {
+    auto lowered_sel = std::visit(
+        Overloaded{
+            [&](const hir::ElementLvalueSelector& s)
+                -> diag::Result<mir::LvalueSelector> {
+              auto idx = LowerExpr(
+                  unit_state, scope_state, proc_state, proc_scope_state,
+                  hir_process, hir_process.exprs.at(s.index.value));
+              if (!idx) return std::unexpected(std::move(idx.error()));
+              const mir::ExprId idx_id =
+                  proc_scope_state.AddExpr(*std::move(idx));
+              return mir::ElementLvalueSelector{.index = idx_id};
+            },
+            [&](const hir::RangeLvalueSelector& s)
+                -> diag::Result<mir::LvalueSelector> {
+              auto bounds = LowerHirRangeBoundsProc(
+                  unit_state, scope_state, proc_state, proc_scope_state,
+                  hir_process, s.bounds);
+              if (!bounds) return std::unexpected(std::move(bounds.error()));
+              return mir::RangeLvalueSelector{.bounds = *std::move(bounds)};
+            },
+        },
+        sel);
+    if (!lowered_sel) return std::unexpected(std::move(lowered_sel.error()));
+    out.selectors.emplace_back(*std::move(lowered_sel));
+  }
+  return out;
 }
 
 auto LowerUserCallee(
@@ -380,24 +473,98 @@ auto LowerHirPrimaryStructural(
 // vehicle the NBA region invokes. The returned Expr has type `void` since the
 // closure value itself is consumed only by RuntimeSubmitNbaCall.
 auto BuildNbaSubmitClosureExpr(
-    const UnitLoweringState& unit_state, mir::Lvalue lhs_structural,
+    const UnitLoweringState& unit_state,
+    const ProceduralScopeLoweringState& outer_scope_state, mir::Lvalue lhs,
     mir::ExprId rhs_id_in_outer, mir::TypeId rhs_type) -> mir::Expr {
   ProceduralScopeLoweringState body;
-  const mir::ProceduralVarId snapshot_binding = body.AddProceduralVar(
+  std::vector<mir::Capture> captures;
+
+  const mir::ProceduralVarId rhs_binding = body.AddProceduralVar(
       mir::ProceduralVarDecl{.name = "_lyra_nba_rhs", .type = rhs_type});
-  const mir::ExprId snapshot_ref_id = body.AddExpr(
+  captures.emplace_back(
+      mir::ByValueCapture{.value = rhs_id_in_outer, .binding = rhs_binding});
+  const mir::ExprId rhs_ref_id = body.AddExpr(
       mir::Expr{
           .data =
               mir::ProceduralVarRef{
-                  .hops = mir::ProceduralHops{.value = 0},
-                  .var = snapshot_binding},
+                  .hops = mir::ProceduralHops{.value = 0}, .var = rhs_binding},
           .type = rhs_type});
+
+  // Each ExprId reached through the selector chain refers to an Expr in the
+  // outer procedural scope. The closure body has its own scope so we cannot
+  // share ExprIds. Two paths:
+  //   - Constant literals (IntegerLiteral) are cloned verbatim into the body
+  //     so downstream consumers (e.g. cpp render's constant extraction for
+  //     selector counts) keep seeing a literal. No capture entry is needed.
+  //   - Other expressions are captured by value into a fresh procedural var;
+  //     the body uses a ProceduralVarRef to that binding. Each snapshot gets
+  //     a distinct name so the emitted C++ closure capture list does not
+  //     collide.
+  std::uint32_t snapshot_counter = 0;
+  auto snapshot = [&](mir::ExprId outer_id) -> mir::ExprId {
+    const auto& outer_expr = outer_scope_state.GetExpr(outer_id);
+    if (std::holds_alternative<mir::IntegerLiteral>(outer_expr.data)) {
+      return body.AddExpr(outer_expr);
+    }
+    const auto binding = body.AddProceduralVar(
+        mir::ProceduralVarDecl{
+            .name = std::format("_lyra_nba_idx{}", snapshot_counter++),
+            .type = outer_expr.type});
+    captures.emplace_back(
+        mir::ByValueCapture{.value = outer_id, .binding = binding});
+    return body.AddExpr(
+        mir::Expr{
+            .data =
+                mir::ProceduralVarRef{
+                    .hops = mir::ProceduralHops{.value = 0}, .var = binding},
+            .type = outer_expr.type});
+  };
+
+  mir::Lvalue body_lhs{.root = lhs.root, .selectors = {}};
+  body_lhs.selectors.reserve(lhs.selectors.size());
+  for (const auto& sel : lhs.selectors) {
+    body_lhs.selectors.emplace_back(
+        std::visit(
+            Overloaded{
+                [&](const mir::ElementLvalueSelector& s)
+                    -> mir::LvalueSelector {
+                  return mir::ElementLvalueSelector{.index = snapshot(s.index)};
+                },
+                [&](const mir::RangeLvalueSelector& s) -> mir::LvalueSelector {
+                  mir::RangeBounds new_bounds = std::visit(
+                      Overloaded{
+                          [&](const mir::RangeConstantBounds& b)
+                              -> mir::RangeBounds {
+                            return mir::RangeConstantBounds{
+                                .msb_expr = snapshot(b.msb_expr),
+                                .lsb_expr = snapshot(b.lsb_expr)};
+                          },
+                          [&](const mir::RangeIndexedUpBounds& b)
+                              -> mir::RangeBounds {
+                            return mir::RangeIndexedUpBounds{
+                                .base_index = snapshot(b.base_index),
+                                .width = snapshot(b.width)};
+                          },
+                          [&](const mir::RangeIndexedDownBounds& b)
+                              -> mir::RangeBounds {
+                            return mir::RangeIndexedDownBounds{
+                                .base_index = snapshot(b.base_index),
+                                .width = snapshot(b.width)};
+                          },
+                      },
+                      s.bounds);
+                  return mir::RangeLvalueSelector{
+                      .bounds = std::move(new_bounds)};
+                },
+            },
+            sel));
+  }
+
   const mir::ExprId assign_id = body.AddExpr(
       mir::Expr{
           .data =
               mir::AssignExpr{
-                  .target = std::move(lhs_structural),
-                  .value = snapshot_ref_id},
+                  .target = std::move(body_lhs), .value = rhs_ref_id},
           .type = rhs_type});
   const mir::StmtId stmt_id = body.AddStmt(
       mir::Stmt{
@@ -407,9 +574,7 @@ auto BuildNbaSubmitClosureExpr(
   body.AddRootStmt(stmt_id);
 
   mir::ClosureExpr closure;
-  closure.captures.emplace_back(
-      mir::ByValueCapture{
-          .value = rhs_id_in_outer, .binding = snapshot_binding});
+  closure.captures = std::move(captures);
   closure.body = std::make_unique<mir::ProceduralScope>(body.Finish());
 
   return mir::Expr{
@@ -504,23 +669,27 @@ auto LowerHirAssignExprProc(
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const mir::TypeId rhs_type = (*rhs_or).type;
   const mir::ExprId rhs_id = proc_scope_state.AddExpr(*std::move(rhs_or));
-  auto lhs = LowerHirLvalueProc(scope_state, proc_state, a.lhs);
+  auto lhs_or = LowerHirLvalueProc(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      a.lhs);
+  if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+  mir::Lvalue lhs = *std::move(lhs_or);
 
   if (a.kind == hir::AssignKind::kBlocking) {
     return mir::Expr{
-        .data = mir::AssignExpr{.target = lhs, .value = rhs_id},
+        .data = mir::AssignExpr{.target = std::move(lhs), .value = rhs_id},
         .type = result_type};
   }
 
-  if (!std::holds_alternative<mir::StructuralVarRef>(lhs)) {
+  if (!std::holds_alternative<mir::StructuralVarRef>(lhs.root)) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedAssignmentTarget,
         "non-blocking assignment to procedural local is not supported yet",
         diag::UnsupportedCategory::kFeature);
   }
 
-  mir::Expr closure_expr =
-      BuildNbaSubmitClosureExpr(unit_state, std::move(lhs), rhs_id, rhs_type);
+  mir::Expr closure_expr = BuildNbaSubmitClosureExpr(
+      unit_state, proc_scope_state, std::move(lhs), rhs_id, rhs_type);
   const mir::ExprId closure_id =
       proc_scope_state.AddExpr(std::move(closure_expr));
   return mir::Expr{
@@ -779,64 +948,8 @@ auto LowerHirRangeSelectExprProc(
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = proc_scope_state.AddExpr(*std::move(base_or));
 
-  auto bounds_or = std::visit(
-      Overloaded{
-          [&](const hir::RangeConstantBounds& b)
-              -> diag::Result<mir::RangeBounds> {
-            auto msb_or = LowerExpr(
-                unit_state, scope_state, proc_state, proc_scope_state,
-                hir_process, hir_process.exprs.at(b.msb_expr.value));
-            if (!msb_or) return std::unexpected(std::move(msb_or.error()));
-            const mir::ExprId msb_id =
-                proc_scope_state.AddExpr(*std::move(msb_or));
-            auto lsb_or = LowerExpr(
-                unit_state, scope_state, proc_state, proc_scope_state,
-                hir_process, hir_process.exprs.at(b.lsb_expr.value));
-            if (!lsb_or) return std::unexpected(std::move(lsb_or.error()));
-            const mir::ExprId lsb_id =
-                proc_scope_state.AddExpr(*std::move(lsb_or));
-            return mir::RangeConstantBounds{
-                .msb_expr = msb_id, .lsb_expr = lsb_id};
-          },
-          [&](const hir::RangeIndexedUpBounds& b)
-              -> diag::Result<mir::RangeBounds> {
-            auto base_idx_or = LowerExpr(
-                unit_state, scope_state, proc_state, proc_scope_state,
-                hir_process, hir_process.exprs.at(b.base_index.value));
-            if (!base_idx_or) {
-              return std::unexpected(std::move(base_idx_or.error()));
-            }
-            const mir::ExprId base_idx_id =
-                proc_scope_state.AddExpr(*std::move(base_idx_or));
-            auto width_or = LowerExpr(
-                unit_state, scope_state, proc_state, proc_scope_state,
-                hir_process, hir_process.exprs.at(b.width.value));
-            if (!width_or) return std::unexpected(std::move(width_or.error()));
-            const mir::ExprId width_id =
-                proc_scope_state.AddExpr(*std::move(width_or));
-            return mir::RangeIndexedUpBounds{
-                .base_index = base_idx_id, .width = width_id};
-          },
-          [&](const hir::RangeIndexedDownBounds& b)
-              -> diag::Result<mir::RangeBounds> {
-            auto base_idx_or = LowerExpr(
-                unit_state, scope_state, proc_state, proc_scope_state,
-                hir_process, hir_process.exprs.at(b.base_index.value));
-            if (!base_idx_or) {
-              return std::unexpected(std::move(base_idx_or.error()));
-            }
-            const mir::ExprId base_idx_id =
-                proc_scope_state.AddExpr(*std::move(base_idx_or));
-            auto width_or = LowerExpr(
-                unit_state, scope_state, proc_state, proc_scope_state,
-                hir_process, hir_process.exprs.at(b.width.value));
-            if (!width_or) return std::unexpected(std::move(width_or.error()));
-            const mir::ExprId width_id =
-                proc_scope_state.AddExpr(*std::move(width_or));
-            return mir::RangeIndexedDownBounds{
-                .base_index = base_idx_id, .width = width_id};
-          },
-      },
+  auto bounds_or = LowerHirRangeBoundsProc(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
       sel.bounds);
   if (!bounds_or) return std::unexpected(std::move(bounds_or.error()));
 

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -645,8 +645,13 @@ auto LowerRepeatStmt(
       mir::Expr{
           .data =
               mir::AssignExpr{
-                  .target = mir::Lvalue{mir::ProceduralVarRef{
-                      .hops = mir::ProceduralHops{.value = 0}, .var = idx_var}},
+                  .target =
+                      mir::Lvalue{
+                          .root =
+                              mir::ProceduralVarRef{
+                                  .hops = mir::ProceduralHops{.value = 0},
+                                  .var = idx_var},
+                          .selectors = {}},
                   .value = add_id},
           .type = int_type});
 

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -335,7 +335,9 @@ class MirDumper {
     throw InternalError("MirDumper: unknown BinaryOp");
   }
 
-  [[nodiscard]] auto FormatLvalue(const Lvalue& l) const -> std::string {
+  [[nodiscard]] auto FormatLvalueRoot(
+      const std::variant<StructuralVarRef, ProceduralVarRef>& root) const
+      -> std::string {
     return std::visit(
         Overloaded{
             [this](const StructuralVarRef& r) -> std::string {
@@ -353,7 +355,48 @@ class MirDumper {
                   r.var.value, var.name);
             },
         },
-        l);
+        root);
+  }
+
+  [[nodiscard]] static auto FormatLvalueSelector(const LvalueSelector& sel)
+      -> std::string {
+    return std::visit(
+        Overloaded{
+            [](const ElementLvalueSelector& s) -> std::string {
+              return std::format("Element index=Expr[{}]", s.index.value);
+            },
+            [](const RangeLvalueSelector& s) -> std::string {
+              const auto bounds = std::visit(
+                  Overloaded{
+                      [](const RangeConstantBounds& b) -> std::string {
+                        return std::format(
+                            "const msb=Expr[{}] lsb=Expr[{}]", b.msb_expr.value,
+                            b.lsb_expr.value);
+                      },
+                      [](const RangeIndexedUpBounds& b) -> std::string {
+                        return std::format(
+                            "indexed_up base=Expr[{}] width=Expr[{}]",
+                            b.base_index.value, b.width.value);
+                      },
+                      [](const RangeIndexedDownBounds& b) -> std::string {
+                        return std::format(
+                            "indexed_down base=Expr[{}] width=Expr[{}]",
+                            b.base_index.value, b.width.value);
+                      },
+                  },
+                  s.bounds);
+              return std::format("Range {}", bounds);
+            },
+        },
+        sel);
+  }
+
+  [[nodiscard]] auto FormatLvalue(const Lvalue& l) const -> std::string {
+    std::string out = FormatLvalueRoot(l.root);
+    for (const auto& sel : l.selectors) {
+      out += std::format(" [{}]", FormatLvalueSelector(sel));
+    }
+    return out;
   }
 
   [[nodiscard]] auto FormatCallee(const Callee& callee) const -> std::string {

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -6,6 +6,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <variant>
 
 #include "lyra/base/internal_error.hpp"
@@ -60,14 +61,34 @@ auto ExpectSameShape(
   }
 }
 
+auto TotalBitWidthOf(std::span<const PackedRange> dims) -> std::uint64_t {
+  std::uint64_t total = 1;
+  for (const auto& d : dims) {
+    total *= d.ElementCount();
+  }
+  return total;
+}
+
 }  // namespace
+
+PackedArray::PackedArray(
+    std::initializer_list<PackedRange> dims, bool is_signed, bool is_four_state)
+    : bit_width_(TotalBitWidthOf(
+          std::span<const PackedRange>{dims.begin(), dims.size()})),
+      is_signed_(is_signed),
+      is_four_state_(is_four_state),
+      storage_(MakeStorage(bit_width_, is_four_state)),
+      dims_(dims) {
+}
 
 PackedArray::PackedArray(
     std::uint64_t bit_width, bool is_signed, bool is_four_state)
     : bit_width_(bit_width),
       is_signed_(is_signed),
       is_four_state_(is_four_state),
-      storage_(MakeStorage(bit_width, is_four_state)) {
+      storage_(MakeStorage(bit_width, is_four_state)),
+      dims_({PackedRange{
+          .left = static_cast<std::int64_t>(bit_width) - 1, .right = 0}}) {
 }
 
 auto PackedArray::Int(std::int32_t value) -> PackedArray {
@@ -158,6 +179,10 @@ auto PackedArray::IsSigned() const -> bool {
 
 auto PackedArray::IsFourState() const -> bool {
   return is_four_state_;
+}
+
+auto PackedArray::Dims() const -> std::span<const PackedRange> {
+  return std::span<const PackedRange>{dims_.data(), dims_.size()};
 }
 
 auto PackedArray::ValueWords() const -> std::span<const std::uint64_t> {
@@ -874,28 +899,24 @@ auto PackedArray::WildcardEquals(const PackedArray& other) const
   return OneBitResult(true, is_four_state_);
 }
 
-auto PackedArray::Index(const PackedArray& index) const -> PackedArray {
-  return Slice(index, 1U);
-}
-
-auto PackedArray::Slice(const PackedArray& lsb_bit, std::uint32_t width) const
-    -> PackedArray {
-  if (width == 0U) {
-    throw InternalError("PackedArray::Slice: width must be >= 1");
+auto PackedArray::ExtractBits(
+    const PackedArray& lsb_bit, std::uint32_t bit_width) const -> PackedArray {
+  if (bit_width == 0U) {
+    throw InternalError("PackedArray::ExtractBits: bit_width must be >= 1");
   }
   if (lsb_bit.HasUnknown() || lsb_bit.BitWidth() > 64U) {
     if (is_four_state_) {
-      return AllX(width, false);
+      return AllX(bit_width, false);
     }
-    return PackedArray{width, false, false};
+    return PackedArray{bit_width, false, false};
   }
   const std::int64_t start = lsb_bit.ToInt64();
   const auto src_value = ValueWords();
   const auto src_unknown = UnknownWords();
   const auto bw_signed = static_cast<std::int64_t>(bit_width_);
-  auto val_buf = MakeWordBuffer(width);
-  auto unk_buf = is_four_state_ ? MakeWordBuffer(width) : WordBuffer{};
-  for (std::uint32_t i = 0; i < width; ++i) {
+  auto val_buf = MakeWordBuffer(bit_width);
+  auto unk_buf = is_four_state_ ? MakeWordBuffer(bit_width) : WordBuffer{};
+  for (std::uint32_t i = 0; i < bit_width; ++i) {
     const std::int64_t pos = start + static_cast<std::int64_t>(i);
     const std::uint64_t out_mask = std::uint64_t{1} << (i % 64U);
     if (pos < 0 || pos >= bw_signed) {
@@ -916,11 +937,240 @@ auto PackedArray::Slice(const PackedArray& lsb_bit, std::uint32_t width) const
     }
   }
   return MakeFromWordPlanes(
-      width, false, is_four_state_,
+      bit_width, false, is_four_state_,
       std::span<const std::uint64_t>{val_buf.data(), val_buf.size()},
       is_four_state_
           ? std::span<const std::uint64_t>{unk_buf.data(), unk_buf.size()}
           : std::span<const std::uint64_t>{});
+}
+
+auto PackedArray::AssignSlice(
+    const PackedArray& lsb_bit, std::uint32_t bit_width,
+    const PackedArray& value) -> void {
+  if (bit_width == 0U) {
+    throw InternalError("PackedArray::AssignSlice: bit_width must be >= 1");
+  }
+  if (value.BitWidth() != bit_width) {
+    throw InternalError(
+        "PackedArray::AssignSlice: value width does not match slice width");
+  }
+  if (value.IsFourState() != is_four_state_) {
+    throw InternalError(
+        "PackedArray::AssignSlice: value state kind does not match target");
+  }
+  if (lsb_bit.HasUnknown() || lsb_bit.BitWidth() > 64U) {
+    return;
+  }
+  const std::int64_t start = lsb_bit.ToInt64();
+  const auto bw_signed = static_cast<std::int64_t>(bit_width_);
+  auto dst_value = std::visit(
+      [](auto& v) { return detail::PackedAccess::ValueWords(v.View()); },
+      storage_);
+  std::span<std::uint64_t> dst_unknown;
+  if (is_four_state_) {
+    auto& dst_lv = std::get<LogicValue>(storage_);
+    dst_unknown = detail::PackedAccess::UnknownWords(dst_lv.View());
+  }
+  const auto src_value = value.ValueWords();
+  const auto src_unknown = value.UnknownWords();
+  for (std::uint32_t i = 0; i < bit_width; ++i) {
+    const std::int64_t pos = start + static_cast<std::int64_t>(i);
+    if (pos < 0 || pos >= bw_signed) {
+      continue;
+    }
+    const auto dst_w = static_cast<std::size_t>(pos / 64);
+    const std::uint64_t dst_mask = std::uint64_t{1}
+                                   << (static_cast<std::uint64_t>(pos) % 64U);
+    const auto src_w = static_cast<std::size_t>(i / 64U);
+    const std::uint64_t src_mask = std::uint64_t{1} << (i % 64U);
+    if ((src_value[src_w] & src_mask) != 0U) {
+      dst_value[dst_w] |= dst_mask;
+    } else {
+      dst_value[dst_w] &= ~dst_mask;
+    }
+    if (is_four_state_) {
+      const bool src_unk_bit =
+          src_w < src_unknown.size() && (src_unknown[src_w] & src_mask) != 0U;
+      if (src_unk_bit) {
+        dst_unknown[dst_w] |= dst_mask;
+      } else {
+        dst_unknown[dst_w] &= ~dst_mask;
+      }
+    }
+  }
+}
+
+namespace {
+
+// Canonical shape for PackedArrayRef bit offsets: 64-bit signed 4-state.
+// Wide enough to hold any valid bit position, signed so negative-OOB indices
+// stay negative through arithmetic, 4-state so X/Z propagates from any layer
+// to the final write (LRM 11.5.1 "X/Z position is a no-op").
+constexpr std::uint64_t kOffsetBitWidth = 64;
+constexpr bool kOffsetSigned = true;
+constexpr bool kOffsetFourState = true;
+
+auto Canonicalize(const PackedArray& p) -> PackedArray {
+  if (p.BitWidth() == kOffsetBitWidth && p.IsSigned() == kOffsetSigned &&
+      p.IsFourState() == kOffsetFourState) {
+    return p;
+  }
+  return PackedArray::ConvertFrom(
+      p, kOffsetBitWidth, kOffsetSigned, kOffsetFourState);
+}
+
+// Bit width of one element of `dims_view`'s outer dim. Caller guarantees
+// `dims_view.size() >= 1` and `total_bit_width % outer_count == 0`.
+auto OuterElementBitWidth(
+    std::uint64_t total_bit_width, std::span<const PackedRange> dims_view)
+    -> std::uint32_t {
+  if (dims_view.empty()) {
+    throw InternalError(
+        "OuterElementBitWidth: empty dim stack (selector applied to a "
+        "scalar, which the frontend should reject)");
+  }
+  return static_cast<std::uint32_t>(
+      total_bit_width / dims_view.front().ElementCount());
+}
+
+// Pops the outer dim from `dims_view` and returns the remainder as a fresh
+// vector. For 1-element results (single-bit / element-select on innermost
+// dim) the result is empty -- subsequent chain ops on it are illegal and
+// the frontend rejects them, so this stays well-defined as long as we never
+// recurse into an empty dim stack.
+auto PopOuterDim(std::span<const PackedRange> dims_view)
+    -> std::vector<PackedRange> {
+  if (dims_view.empty()) {
+    throw InternalError(
+        "PopOuterDim: empty dim stack (selector applied to a scalar)");
+  }
+  return std::vector<PackedRange>{dims_view.begin() + 1, dims_view.end()};
+}
+
+// Replaces the outer dim's count with `new_count`, preserving inner dims.
+// Used by `Slice` to construct the slice result's dim stack.
+auto ReplaceOuterDimCount(
+    std::span<const PackedRange> dims_view, std::uint32_t new_count)
+    -> std::vector<PackedRange> {
+  if (dims_view.empty()) {
+    throw InternalError(
+        "ReplaceOuterDimCount: empty dim stack (range select on a scalar)");
+  }
+  std::vector<PackedRange> result;
+  result.reserve(dims_view.size());
+  result.push_back(
+      PackedRange{
+          .left = static_cast<std::int64_t>(new_count) - 1, .right = 0});
+  for (std::size_t i = 1; i < dims_view.size(); ++i) {
+    result.push_back(dims_view[i]);
+  }
+  return result;
+}
+
+}  // namespace
+
+auto PackedArray::ElementAt(const PackedArray& idx) -> PackedArrayRef {
+  const auto element_bw = OuterElementBitWidth(bit_width_, dims_);
+  return PackedArrayRef{
+      *this,
+      element_bw == 1U
+          ? Canonicalize(idx)
+          : (Canonicalize(idx) * PackedArray::FromInt(
+                                     static_cast<std::int64_t>(element_bw),
+                                     kOffsetBitWidth, kOffsetSigned,
+                                     kOffsetFourState)),
+      element_bw, PopOuterDim(dims_)};
+}
+
+auto PackedArray::ElementAt(const PackedArray& idx) const -> PackedArray {
+  const auto element_bw = OuterElementBitWidth(bit_width_, dims_);
+  const auto bit_offset =
+      element_bw == 1U
+          ? Canonicalize(idx)
+          : (Canonicalize(idx) * PackedArray::FromInt(
+                                     static_cast<std::int64_t>(element_bw),
+                                     kOffsetBitWidth, kOffsetSigned,
+                                     kOffsetFourState));
+  return ExtractBits(bit_offset, element_bw);
+}
+
+auto PackedArray::Slice(
+    const PackedArray& lsb_in_outer_elements,
+    std::uint32_t count_in_outer_elements) -> PackedArrayRef {
+  const auto element_bw = OuterElementBitWidth(bit_width_, dims_);
+  return PackedArrayRef{
+      *this,
+      element_bw == 1U
+          ? Canonicalize(lsb_in_outer_elements)
+          : (Canonicalize(lsb_in_outer_elements) *
+             PackedArray::FromInt(
+                 static_cast<std::int64_t>(element_bw), kOffsetBitWidth,
+                 kOffsetSigned, kOffsetFourState)),
+      count_in_outer_elements * element_bw,
+      ReplaceOuterDimCount(dims_, count_in_outer_elements)};
+}
+
+auto PackedArray::Slice(
+    const PackedArray& lsb_in_outer_elements,
+    std::uint32_t count_in_outer_elements) const -> PackedArray {
+  const auto element_bw = OuterElementBitWidth(bit_width_, dims_);
+  const auto bit_offset =
+      element_bw == 1U
+          ? Canonicalize(lsb_in_outer_elements)
+          : (Canonicalize(lsb_in_outer_elements) *
+             PackedArray::FromInt(
+                 static_cast<std::int64_t>(element_bw), kOffsetBitWidth,
+                 kOffsetSigned, kOffsetFourState));
+  return ExtractBits(bit_offset, count_in_outer_elements * element_bw);
+}
+
+PackedArrayRef::PackedArrayRef(
+    PackedArray& root, const PackedArray& bit_offset, std::uint32_t bit_width,
+    std::vector<PackedRange> dims)
+    : root_(&root),
+      bit_offset_(Canonicalize(bit_offset)),
+      bit_width_(bit_width),
+      dims_(std::move(dims)) {
+}
+
+PackedArrayRef::operator PackedArray() const {
+  return std::as_const(*root_).ExtractBits(bit_offset_, bit_width_);
+}
+
+auto PackedArrayRef::operator=(const PackedArray& value) -> PackedArrayRef& {
+  root_->AssignSlice(bit_offset_, bit_width_, value);
+  return *this;
+}
+
+auto PackedArrayRef::ElementAt(const PackedArray& idx) const -> PackedArrayRef {
+  const auto element_bw = OuterElementBitWidth(bit_width_, dims_);
+  return PackedArrayRef{
+      *root_,
+      element_bw == 1U
+          ? (bit_offset_ + Canonicalize(idx))
+          : (bit_offset_ +
+             (Canonicalize(idx) * PackedArray::FromInt(
+                                      static_cast<std::int64_t>(element_bw),
+                                      kOffsetBitWidth, kOffsetSigned,
+                                      kOffsetFourState))),
+      element_bw, PopOuterDim(dims_)};
+}
+
+auto PackedArrayRef::Slice(
+    const PackedArray& lsb_in_outer_elements,
+    std::uint32_t count_in_outer_elements) const -> PackedArrayRef {
+  const auto element_bw = OuterElementBitWidth(bit_width_, dims_);
+  return PackedArrayRef{
+      *root_,
+      element_bw == 1U
+          ? (bit_offset_ + Canonicalize(lsb_in_outer_elements))
+          : (bit_offset_ +
+             (Canonicalize(lsb_in_outer_elements) *
+              PackedArray::FromInt(
+                  static_cast<std::int64_t>(element_bw), kOffsetBitWidth,
+                  kOffsetSigned, kOffsetFourState))),
+      count_in_outer_elements * element_bw,
+      ReplaceOuterDimCount(dims_, count_in_outer_elements)};
 }
 
 auto PackedArray::operator<(const PackedArray& other) const -> PackedArray {

--- a/tests/cases/cpp/bit_select_write/case.yaml
+++ b/tests/cases/cpp/bit_select_write/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.bit_select_write
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    out_const: "8'b00001000"
+    out_var: "8'b00100000"
+    cleared: "8'b11111110"

--- a/tests/cases/cpp/bit_select_write/main.sv
+++ b/tests/cases/cpp/bit_select_write/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  bit [7:0] out_const;
+  bit [7:0] out_var;
+  bit [7:0] cleared;
+  initial begin
+    int idx;
+    out_const = 8'h00;
+    out_const[3] = 1'b1;
+    idx = 5;
+    out_var = 8'h00;
+    out_var[idx] = 1'b1;
+    cleared = 8'hFF;
+    cleared[0] = 1'b0;
+  end
+endmodule

--- a/tests/cases/cpp/multi_dim_select_read/case.yaml
+++ b/tests/cases/cpp/multi_dim_select_read/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.multi_dim_select_read
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    elem0: "8'hAB"
+    elem1: "8'hCD"
+    high_nibble_1: "4'hC"
+    bit_in_elem: "1'b1"

--- a/tests/cases/cpp/multi_dim_select_read/main.sv
+++ b/tests/cases/cpp/multi_dim_select_read/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  bit [7:0] elem0;
+  bit [7:0] elem1;
+  bit [3:0] high_nibble_1;
+  bit bit_in_elem;
+  initial begin
+    bit [1:0][7:0] data;
+    int idx;
+    data[0] = 8'hAB;
+    data[1] = 8'hCD;
+    elem0 = data[0];
+    elem1 = data[1];
+    idx = 4;
+    high_nibble_1 = data[1][idx+:4];
+    bit_in_elem = data[1][0];
+  end
+endmodule

--- a/tests/cases/cpp/multi_dim_select_write/case.yaml
+++ b/tests/cases/cpp/multi_dim_select_write/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.multi_dim_select_write
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    out_full: "16'hABCD"
+    out_partial: "16'hAB0D"
+    out_bit: "16'hAB02"
+    out_bit_clear: "16'hABCC"

--- a/tests/cases/cpp/multi_dim_select_write/main.sv
+++ b/tests/cases/cpp/multi_dim_select_write/main.sv
@@ -1,0 +1,29 @@
+module Top;
+  bit [15:0] out_full;
+  bit [15:0] out_partial;
+  bit [15:0] out_bit;
+  bit [15:0] out_bit_clear;
+  initial begin
+    bit [1:0][7:0] full_w;
+    bit [1:0][7:0] partial_w;
+    bit [1:0][7:0] bit_w;
+    bit [1:0][7:0] bit_w2;
+    int idx;
+    full_w[0] = 8'hCD;
+    full_w[1] = 8'hAB;
+    out_full = full_w;
+    partial_w[0] = 8'hCD;
+    partial_w[1] = 8'hAB;
+    idx = 4;
+    partial_w[0][idx+:4] = 4'h0;
+    out_partial = partial_w;
+    bit_w[0] = 8'h00;
+    bit_w[1] = 8'hAB;
+    bit_w[0][1] = 1'b1;
+    out_bit = bit_w;
+    bit_w2[0] = 8'hCD;
+    bit_w2[1] = 8'hAB;
+    bit_w2[0][0] = 1'b0;
+    out_bit_clear = bit_w2;
+  end
+endmodule

--- a/tests/cases/cpp/range_write_const/case.yaml
+++ b/tests/cases/cpp/range_write_const/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.range_write_const
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    data: "16'hABCD"
+    nibble_high: "16'hFBCD"
+    byte_low: "16'hABEF"

--- a/tests/cases/cpp/range_write_const/main.sv
+++ b/tests/cases/cpp/range_write_const/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  bit [15:0] data;
+  bit [15:0] nibble_high;
+  bit [15:0] byte_low;
+  initial begin
+    data = 16'hABCD;
+    nibble_high = 16'hABCD;
+    nibble_high[15:12] = 4'hF;
+    byte_low = 16'hABCD;
+    byte_low[7:0] = 8'hEF;
+  end
+endmodule

--- a/tests/cases/cpp/range_write_indexed_down/case.yaml
+++ b/tests/cases/cpp/range_write_indexed_down/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.range_write_indexed_down
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    out_const: "32'h0000AB00"
+    out_var: "32'h00CD0000"

--- a/tests/cases/cpp/range_write_indexed_down/main.sv
+++ b/tests/cases/cpp/range_write_indexed_down/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  bit [31:0] out_const;
+  bit [31:0] out_var;
+  initial begin
+    int idx;
+    out_const = 32'h00000000;
+    out_const[15-:8] = 8'hAB;
+    idx = 23;
+    out_var = 32'h00000000;
+    out_var[idx-:8] = 8'hCD;
+  end
+endmodule

--- a/tests/cases/cpp/range_write_indexed_up/case.yaml
+++ b/tests/cases/cpp/range_write_indexed_up/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.range_write_indexed_up
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    out0: "32'h000000FF"
+    out8: "32'h0000FF00"
+    out_var: "32'h0FF00000"

--- a/tests/cases/cpp/range_write_indexed_up/main.sv
+++ b/tests/cases/cpp/range_write_indexed_up/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  bit [31:0] out0;
+  bit [31:0] out8;
+  bit [31:0] out_var;
+  initial begin
+    int idx;
+    out0 = 32'h00000000;
+    out0[0+:8] = 8'hFF;
+    out8 = 32'h00000000;
+    out8[8+:8] = 8'hFF;
+    idx = 20;
+    out_var = 32'h00000000;
+    out_var[idx+:8] = 8'hFF;
+  end
+endmodule

--- a/tests/cases/cpp/range_write_nba/case.yaml
+++ b/tests/cases/cpp/range_write_nba/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.range_write_nba
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    final_data: "32'h0000EFCD"

--- a/tests/cases/cpp/range_write_nba/main.sv
+++ b/tests/cases/cpp/range_write_nba/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  bit [31:0] final_data;
+  initial begin
+    int idx;
+    final_data = 32'h0000ABCD;
+    idx = 8;
+    final_data[idx+:8] <= 8'hEF;
+    #1;
+  end
+endmodule

--- a/tests/cases/cpp/range_write_partial_oob_2state/case.yaml
+++ b/tests/cases/cpp/range_write_partial_oob_2state/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.range_write_partial_oob_2state
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    partial_high: "8'b00111111"
+    partial_low: "8'b11111100"
+    fully_oob: "8'b11111111"

--- a/tests/cases/cpp/range_write_partial_oob_2state/main.sv
+++ b/tests/cases/cpp/range_write_partial_oob_2state/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  bit [7:0] partial_high;
+  bit [7:0] partial_low;
+  bit [7:0] fully_oob;
+  initial begin
+    int idx;
+    partial_high = 8'hFF;
+    idx = 6;
+    partial_high[idx+:4] = 4'b0000;
+    partial_low = 8'hFF;
+    idx = -2;
+    partial_low[idx+:4] = 4'b0000;
+    fully_oob = 8'hFF;
+    idx = 100;
+    fully_oob[idx+:4] = 4'b0000;
+  end
+endmodule

--- a/tests/cases/cpp/range_write_partial_oob_4state/case.yaml
+++ b/tests/cases/cpp/range_write_partial_oob_4state/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.range_write_partial_oob_4state
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    partial_high: "8'b00111111"
+    partial_low: "8'b11111100"
+    fully_oob: "8'b11111111"

--- a/tests/cases/cpp/range_write_partial_oob_4state/main.sv
+++ b/tests/cases/cpp/range_write_partial_oob_4state/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  logic [7:0] partial_high;
+  logic [7:0] partial_low;
+  logic [7:0] fully_oob;
+  initial begin
+    int idx;
+    partial_high = 8'hFF;
+    idx = 6;
+    partial_high[idx+:4] = 4'b0000;
+    partial_low = 8'hFF;
+    idx = -2;
+    partial_low[idx+:4] = 4'b0000;
+    fully_oob = 8'hFF;
+    idx = 100;
+    fully_oob[idx+:4] = 4'b0000;
+  end
+endmodule

--- a/tests/cases/cpp/range_write_x_pos/case.yaml
+++ b/tests/cases/cpp/range_write_x_pos/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.range_write_x_pos
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    data: "8'b11111111"
+    one_bit: "8'b11111111"

--- a/tests/cases/cpp/range_write_x_pos/main.sv
+++ b/tests/cases/cpp/range_write_x_pos/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  logic [7:0] data;
+  logic [7:0] one_bit;
+  initial begin
+    logic [3:0] idx;
+    data = 8'hFF;
+    idx = 4'bxxxx;
+    data[idx+:4] = 4'b0000;
+    one_bit = 8'hFF;
+    one_bit[idx] = 1'b0;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds the write side of SystemVerilog selector expressions: bit-select, element-select, and the three range-select forms (`[hi:lo]`, `[base +: w]`, `[base -: w]`), on both blocking and NBA targets. Extends `hir::Lvalue` / `mir::Lvalue` to carry a root reference plus an ordered selector chain, runs LRM 11.5.1 partial-write rules (X/Z position no-op, fully-OOB no-op, partial-OOB only in-range bits) inside `PackedArray::AssignSlice`, and routes observable writes through a new `Var<T>::Mutate(services)` RAII envelope that commits the snapshot via `WriteVar` at end-of-statement so subscribers still fire.

## Design

`PackedArray` carries the source-level dim stack alongside its flat-bit storage. The chain API is uniformly method-style (`ElementAt` / `Slice`, no `operator[]`) on both `PackedArray` and `PackedArrayRef`; the runtime scales source-form positions by element bit width derived from `dims_`, so render never bakes element-width arithmetic into the emitted call sites. A future storage refactor (canonical-byte-aligned planes, vector-of-elements for huge outer dims, etc.) stays inside `PackedArray` without rippling out.

For observable selector writes, `Var<T>::Mutate(services)` returns a `ScopedMutation<T>` RAII handle that snapshots `var.Get()`, forwards `ElementAt` / `Slice` to the snapshot so a normal chain composes, and commits the result through `WriteVar` in its destructor. The handle is non-copyable and non-movable; lifetime is the constructing full expression, relying on C++17 mandatory copy elision for the prvalue return from `Mutate`. Blocking and NBA share the same emit shape -- the only difference is whether the chain runs inside the NBA closure body.

NBA on selector lvalues snapshots every non-literal `ExprId` in the chain into the closure body via `ByValueCapture`; integer literals are cloned verbatim so the closure body uses body-local refs and re-evaluates none of the original outer-scope expressions when the region fires.

## Testing

End-to-end SV YAML cases under `tests/cases/cpp/` cover bit-select read/write, multi-dim element select read/write, the three range-select bounds forms on both read and write sides, NBA on a selector lvalue, partial-OOB writes in 2-state and 4-state, and X-position no-op writes. All cases reproduce via the existing `bazel test //tests:cpp_tests` harness.