### PR TITLE
Add cross-family real conversions and reject illegal real forms

### DIFF
--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -57,7 +57,7 @@ Granular tracking lives in `integral.md` (integral / packed / wide_integral) and
 - [ ] datatypes/general
 - [ ] datatypes/integral -- `integral.md`.
 - [ ] datatypes/packed -- `packed.md`.
-- [ ] datatypes/real
+- [x] datatypes/real
 - [ ] datatypes/representation
 - [ ] datatypes/string
 - [ ] datatypes/unpacked

--- a/docs/progress/datatypes.md
+++ b/docs/progress/datatypes.md
@@ -11,11 +11,8 @@ on the current pipeline.
 
 ## Actionable
 
-Real C1 (decls / assignment / `%f` / `%e` / `%g`) landed in PR #789. Real C2 (arithmetic /
-relational / equality / logical operators on real, plus shortreal <-> real conversions) is in
-flight. Remaining real work: C3 (real <-> integral conversion) and C4 (LRM-illegal-form rejection).
-Other families remaining: `datatypes/string`, `datatypes/unpacked`, `datatypes/general`,
-`datatypes/default_init`, `datatypes/representation`.
+Real C1 / C2 / C3 / C4 are complete. Other families remaining: `datatypes/string`,
+`datatypes/unpacked`, `datatypes/general`, `datatypes/default_init`, `datatypes/representation`.
 
 ## Enum
 
@@ -126,19 +123,31 @@ real variables.
       This is safe for real-family vars because they do not wrap in `Var<T>` and therefore do not
       need `services_`. Integral structural initializers remain a known gap (their
       `Var<PackedArray>` write path needs `services_`, which is not bound until `Bind()`).
-- [ ] C3 -- Cross-family conversions: integral -> real (4-state x / z bits map to 0 per LRM 6.12.1)
-      and real -> integral (round-half-away-from-zero per LRM 6.12.1, _not_ truncate).
-      `int_literal_to_real` is the constant-folded subset; `int_to_real_conversion`,
-      `real_to_int_conversion`, `real_to_int_negative` exercise the runtime paths in
-      `real`/`shortreal`/`realtime` subfolders. Slang's `SVInt::fromDouble` already defaults
-      `round=true`, so the integer-side conversion needs only to invoke it; the bit-level `x/z -> 0`
-      step happens before promotion to double.
-- [ ] C4 -- LRM-illegal forms on real (LRM 6.12 + 11.3.1 / Table 11-1): edge event control
-      (`posedge` / `negedge` / `edge`) on real, bit-select / part-select of real, modulus `%` on
-      real, bitwise / reduction / shift / wildcard / case-equality on real. Reject in AST -> HIR
-      with `diag::Unsupported` carrying the LRM citation. No new behavior is enabled; this is solely
-      about producing a diagnostic instead of an `InternalError` for programs that compile under
-      slang but fall outside the legal real surface.
+- [x] C3 -- Cross-family conversions. cpp emit's `RenderConversionExpr` gains an integral -> real
+      arm (`static_cast<double>((operand).ToInt64())`; `PackedArray::ToInt64` collapses X / Z bits
+      to 0 per LRM 6.12.1) and a real -> integral arm
+      (`PackedArray::FromInt(std::llround(operand), <shape>)`; `std::llround`'s round-half-away-
+      from-zero rule matches LRM 6.12.1 exactly, contrasting with the archive's incorrect LLVM
+      `FPToSI` truncate path). Same-shape and unhandled-pair conversions fall through to the operand
+      unchanged: slang emits identity conversions (e.g., `string` -> `string`) and string-literal
+      lifts (`bit[N-1:0]` -> `string`) where the operand already renders as the destination's C++
+      type. Widths > 64 bits are caught by `PackedArray::FromInt` / `ToInt64`'s own width invariants
+      (follow-up: wide-int conversion via the FromWords path). Drive-by fix: `PackedArray::ToInt64`
+      previously read `ValueWords()` raw, leaving X / Z positions whatever bit pattern slang stored
+      in the value plane; it now masks by `~UnknownWords()` so its docstring's "X/Z bits map to 0"
+      promise actually holds. Tests: `int_to_real`, `int_to_real_negative`,
+      `real_to_int_round_down`, `real_to_int_round_up`, `real_to_int_half_positive`,
+      `real_to_int_half_negative`, `int_to_shortreal`, `shortreal_to_int`, `int_literal_to_real`,
+      `byte_to_real`, `longint_to_real`, `logic_xz_to_real`.
+- [x] C4 -- LRM-illegal forms on real (LRM 6.12 + 11.3.1 / Table 11-1). Slang filters 10 of 11 at
+      AST construction (edge event control on real, bit-select / part-select of real, real index in
+      bit-select, modulus `%`, bitwise / reduction / shift, wildcard `==?` / `!=?`, plus the
+      corresponding compound assignment forms). The one slang anomaly is case equality `===` / `!==`
+      on real (slang allows `bothNumeric` even though LRM Table 11-1 lists "Any except real and
+      shortreal"). That path falls through `RenderBinaryOpReal`'s default arm, which already returns
+      `diag::Unsupported` with an LRM 11.3.1 citation -- so the C2 defensive renderer is the
+      rejection mechanism with no additional code required. Negative test
+      `errors/real_case_equality_unsupported` guards this contract.
 
 ### Cross-references
 

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -501,6 +501,32 @@ auto RenderIntegralConversion(
   return body;
 }
 
+// LRM 6.12.1: integer-to-real implicit conversion treats X/Z bits as 0.
+// `PackedArray::ToInt64` already collapses X/Z bits to 0 (packed_array.hpp
+// docstring), so a plain `static_cast` to the destination real precision is
+// the full conversion. `shortreal` casts to `float`; `real` and `realtime`
+// (LRM 6.12 synonyms) cast to `double`.
+auto RenderIntegralToRealConversion(
+    std::string operand, const mir::Type& dst_ty) -> std::string {
+  const auto* cpp_ty =
+      dst_ty.Kind() == mir::TypeKind::kShortReal ? "float" : "double";
+  return std::format("static_cast<{}>(({}).ToInt64())", cpp_ty, operand);
+}
+
+// LRM 6.12.1: real-to-integer implicit conversion rounds the real to the
+// nearest integer with ties rounded away from zero (35.5 -> 36, -1.5 -> -2).
+// `std::llround` is the standard library function with exactly that rounding
+// rule; it returns `long long` (>= 64 bits), which feeds `PackedArray::FromInt`
+// to land the rounded value into the destination shape. Destination widths >
+// 64 bits would need a wide-int conversion path; that is currently caught by
+// `FromInt`'s own width invariant.
+auto RenderRealToIntegralConversion(
+    std::string operand, const mir::PackedArrayType& dst_pa) -> std::string {
+  return std::format(
+      "lyra::value::PackedArray::FromInt(std::llround({}), {})", operand,
+      RenderPackedArrayCtorArgs(dst_pa));
+}
+
 auto RenderConversionExpr(
     const RenderContext& ctx, const mir::Expr& expr,
     const mir::ConversionExpr& cv) -> diag::Result<std::string> {
@@ -517,6 +543,18 @@ auto RenderConversionExpr(
         ctx, expr.type, *std::move(operand_or), src_ty.AsIntegralPacked(),
         dst_ty.AsIntegralPacked(), src_ty.IsEnum(), dst_ty.IsEnum());
   }
+  if (src_ty.IsIntegralPacked() && IsRealFamilyType(dst_ty)) {
+    return RenderIntegralToRealConversion(*std::move(operand_or), dst_ty);
+  }
+  if (IsRealFamilyType(src_ty) && dst_ty.IsIntegralPacked()) {
+    return RenderRealToIntegralConversion(
+        *std::move(operand_or), dst_ty.AsIntegralPacked());
+  }
+  // Fall-through covers conversions whose source and destination already share
+  // a compatible C++ representation, so no transformation is needed at this
+  // boundary: same-kind identity conversions (e.g., string -> string), and
+  // slang's narrow `bit[N-1:0]` string-literal -> `string` lift where the
+  // operand already renders as the C++ string literal.
   return *std::move(operand_or);
 }
 

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -299,7 +299,13 @@ auto PackedArray::ToInt64() const -> std::int64_t {
   if (bit_width_ > 64U) {
     throw InternalError("PackedArray::ToInt64: bit_width > 64");
   }
-  const auto raw = ValueWords()[0] & MaskForWidth(bit_width_);
+  // LRM 6.12.1 / 6.19: when a 4-state value is read into a 2-state context,
+  // X/Z bits collapse to 0. The unknown plane marks those positions, so the
+  // value plane is masked by `~unknown` before any further interpretation.
+  const auto value = ValueWords()[0];
+  const auto unk =
+      UnknownWords().empty() ? std::uint64_t{0} : UnknownWords()[0];
+  const auto raw = (value & ~unk) & MaskForWidth(bit_width_);
   return is_signed_ ? SignExtendToInt64(raw, bit_width_)
                     : static_cast<std::int64_t>(raw);
 }

--- a/tests/cases/cpp/byte_to_real/case.yaml
+++ b/tests/cases/cpp/byte_to_real/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.byte_to_real
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      50.000000

--- a/tests/cases/cpp/byte_to_real/main.sv
+++ b/tests/cases/cpp/byte_to_real/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  byte b;
+  real r;
+  initial begin
+    b = 50;
+    r = b;
+    $display("%f", r);
+  end
+endmodule

--- a/tests/cases/cpp/int_literal_to_real/case.yaml
+++ b/tests/cases/cpp/int_literal_to_real/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.int_literal_to_real
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      100.000000

--- a/tests/cases/cpp/int_literal_to_real/main.sv
+++ b/tests/cases/cpp/int_literal_to_real/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  real r;
+  initial begin
+    r = 100;
+    $display("%f", r);
+  end
+endmodule

--- a/tests/cases/cpp/int_to_real/case.yaml
+++ b/tests/cases/cpp/int_to_real/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.int_to_real
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      42.000000

--- a/tests/cases/cpp/int_to_real/main.sv
+++ b/tests/cases/cpp/int_to_real/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  int i;
+  real r;
+  initial begin
+    i = 42;
+    r = i;
+    $display("%f", r);
+  end
+endmodule

--- a/tests/cases/cpp/int_to_real_negative/case.yaml
+++ b/tests/cases/cpp/int_to_real_negative/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.int_to_real_negative
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      -42.000000

--- a/tests/cases/cpp/int_to_real_negative/main.sv
+++ b/tests/cases/cpp/int_to_real_negative/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  int i;
+  real r;
+  initial begin
+    i = -42;
+    r = i;
+    $display("%f", r);
+  end
+endmodule

--- a/tests/cases/cpp/int_to_shortreal/case.yaml
+++ b/tests/cases/cpp/int_to_shortreal/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.int_to_shortreal
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      42.000000

--- a/tests/cases/cpp/int_to_shortreal/main.sv
+++ b/tests/cases/cpp/int_to_shortreal/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  int i;
+  shortreal r;
+  initial begin
+    i = 42;
+    r = i;
+    $display("%f", r);
+  end
+endmodule

--- a/tests/cases/cpp/logic_xz_to_real/case.yaml
+++ b/tests/cases/cpp/logic_xz_to_real/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.logic_xz_to_real
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      129.000000

--- a/tests/cases/cpp/logic_xz_to_real/main.sv
+++ b/tests/cases/cpp/logic_xz_to_real/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  logic [7:0] x;
+  real r;
+  initial begin
+    x = 8'b1xxx_0001;
+    r = x;
+    $display("%f", r);
+  end
+endmodule

--- a/tests/cases/cpp/longint_to_real/case.yaml
+++ b/tests/cases/cpp/longint_to_real/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.longint_to_real
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      1000000.000000

--- a/tests/cases/cpp/longint_to_real/main.sv
+++ b/tests/cases/cpp/longint_to_real/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  longint x;
+  real r;
+  initial begin
+    x = 1000000;
+    r = x;
+    $display("%f", r);
+  end
+endmodule

--- a/tests/cases/cpp/real_to_int_half_negative/case.yaml
+++ b/tests/cases/cpp/real_to_int_half_negative/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_to_int_half_negative
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      -2

--- a/tests/cases/cpp/real_to_int_half_negative/main.sv
+++ b/tests/cases/cpp/real_to_int_half_negative/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  real r = -1.5;
+  int i;
+  initial begin
+    i = r;
+    $display("%d", i);
+  end
+endmodule

--- a/tests/cases/cpp/real_to_int_half_positive/case.yaml
+++ b/tests/cases/cpp/real_to_int_half_positive/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_to_int_half_positive
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      36

--- a/tests/cases/cpp/real_to_int_half_positive/main.sv
+++ b/tests/cases/cpp/real_to_int_half_positive/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  real r = 35.5;
+  int i;
+  initial begin
+    i = r;
+    $display("%d", i);
+  end
+endmodule

--- a/tests/cases/cpp/real_to_int_round_down/case.yaml
+++ b/tests/cases/cpp/real_to_int_round_down/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_to_int_round_down
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      3

--- a/tests/cases/cpp/real_to_int_round_down/main.sv
+++ b/tests/cases/cpp/real_to_int_round_down/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  real r = 3.2;
+  int i;
+  initial begin
+    i = r;
+    $display("%d", i);
+  end
+endmodule

--- a/tests/cases/cpp/real_to_int_round_up/case.yaml
+++ b/tests/cases/cpp/real_to_int_round_up/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.real_to_int_round_up
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      4

--- a/tests/cases/cpp/real_to_int_round_up/main.sv
+++ b/tests/cases/cpp/real_to_int_round_up/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  real r = 3.7;
+  int i;
+  initial begin
+    i = r;
+    $display("%d", i);
+  end
+endmodule

--- a/tests/cases/cpp/shortreal_to_int/case.yaml
+++ b/tests/cases/cpp/shortreal_to_int/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.shortreal_to_int
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      3

--- a/tests/cases/cpp/shortreal_to_int/main.sv
+++ b/tests/cases/cpp/shortreal_to_int/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  shortreal r = 2.7;
+  int i;
+  initial begin
+    i = r;
+    $display("%d", i);
+  end
+endmodule

--- a/tests/cases/errors/real_case_equality_unsupported/case.yaml
+++ b/tests/cases/errors/real_case_equality_unsupported/case.yaml
@@ -1,0 +1,16 @@
+id: errors.real_case_equality_unsupported
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "real"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/real_case_equality_unsupported/main.sv
+++ b/tests/cases/errors/real_case_equality_unsupported/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  real a, b;
+  bit r;
+  initial r = (a === b);
+endmodule


### PR DESCRIPTION
## Summary

Lower SystemVerilog integral <-> real conversions per LRM 6.12.1 and close the case-equality-on-real gap that slang itself does not filter. cpp emit's `RenderConversionExpr` gains two new arms: integral -> real produces `static_cast<double|float>((operand).ToInt64())`, and real -> integral produces `lyra::value::PackedArray::FromInt(std::llround(operand), <shape>)`. `std::llround` is the standard library function with exactly LRM 6.12.1's round-half-away-from-zero rule (35.5 -> 36, -1.5 -> -2), in contrast to the archive's incorrect LLVM `FPToSI` truncate path.

The integral -> real arm depends on `PackedArray::ToInt64` collapsing X / Z bits to 0 per LRM 6.12.1 / 6.19, which the docstring already promised but the implementation did not honor; this PR masks the value plane by `~UnknownWords()` so the contract holds.

For C4 (illegal forms on real), slang already filters 10 of 11 prohibited constructions at AST construction. The one anomaly is case equality `===` / `!==` on real, which slang allows under `bothNumeric` despite LRM Table 11-1 listing "Any except real and shortreal". That path falls through `RenderBinaryOpReal`'s default arm, which already returns `diag::Unsupported` with an LRM 11.3.1 citation -- so no new code is required; a negative test `errors/real_case_equality_unsupported` guards the contract.

## Testing

Twelve new `cpp_run` cases exercise both conversion directions across `int` / `byte` / `longint` / `shortreal` / `logic [7:0]` sources, the LRM rounding boundary (`real_to_int_round_down` / `_round_up` / `_half_positive` / `_half_negative`), and X / Z masking (`logic_xz_to_real`). One new `errors` case (`real_case_equality_unsupported`) asserts that `real a, b; r = (a === b);` exits with a `diag::Unsupported` diagnostic citing LRM 11.3.1.