### PR TITLE
Add wait (cond) level-sensitive control

### DIFF
--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -159,7 +159,7 @@ synchronisation primitives (named events, `wait`, `fork`/`join_*`).
 - [x] processes/initial -- `processes.md` P1.
 - [ ] processes/named_event -- `processes.md` P9.
 - [x] processes/non_blocking -- `processes.md` P4.
-- [ ] processes/wait_event -- `processes.md` P11.
+- [x] processes/wait_event -- `processes.md` P11.
 
 ### scheduling
 

--- a/docs/progress/processes.md
+++ b/docs/progress/processes.md
@@ -10,9 +10,9 @@ order. Items in the [Actionable](#actionable) section can be picked up next; ite
 
 ## Actionable
 
-| Item | Notes                                                                                             |
-| ---- | ------------------------------------------------------------------------------------------------- |
-| P11  | `wait (expr)` level-sensitive control. Needs a re-arm primitive over the existing change channel. |
+| Item | Notes                                                                  |
+| ---- | ---------------------------------------------------------------------- |
+| -    | No procedural-block items left in this workstream's actionable column. |
 
 ## Blocked
 
@@ -43,25 +43,14 @@ order. Items in the [Actionable](#actionable) section can be picked up next; ite
       `kMaxCurrentTimeIterations` settle limit. Covers `processes/initial` (always portion) and the
       `always_ff` body of `processes/wait_event`.
 - [x] P10 / P13 -- `always_comb` / `always_latch` (LRM 9.2.2.2.1) and `always @*` / `always @(*)`
-      (LRM 9.4.2.2). HIR follows slang's source-aligned shape; MIR abstracts to a single runtime
-      mental model. Harvest (`compile.cpp`): slang's `AnalysisManager` produces read sets via two
-      APIs (`getSensitivityList()` for the procedure and `getImplicitEventReadSets()` for each `@*`
-      region) -- both are stored in a single `ImplicitSensitivityReads` map keyed by
-      `slang::ast::Statement*` (the procedure's body statement for always_comb / always_latch; the
-      `@*`'s `TimedStatement` for `always @*`). HIR: `always_comb` / `always_latch` carry the
-      sensitivity on `hir::Process::implicit_sensitivity_list` while the body is a plain statement
-      (LRM 9.2.2.2.1 -- no `@*` token in source). `always @*` produces
-      `hir::TimedStmt{ timing: ImplicitEventControl{sensitivity}, stmt: body }` -- a wrapper that
-      mirrors slang's `TimedStatement(ImplicitEventControl, body)` 1:1. HIR -> MIR collapses both
-      forms onto MIR's `mir::SensitivityWaitStmt` leaf: always_comb / always_latch run
-      `forever { body; SensitivityWaitStmt; }` (body runs at time zero, then waits for changes per
-      LRM 9.2.2.2); `always @*` expands its TimedStmt into a
-      `mir::Block { SensitivityWaitStmt;     body; }` (waits first, no time-zero run per LRM
-      9.4.2.2.2). Empty sensitivity lists are legal (wait-forever). Select expressions in reads
-      collapse to whole-variable subscription until the runtime supports bit-level any-change. The
-      single-driver restriction and forbidden-construct checks (no blocking timing, no fork-join in
-      `always_comb`) are enforced by slang's frontend. Multiple `@*`s in one procedure each key by
-      their own TimedStatement and lower independently.
+      (LRM 9.4.2.2). Slang's `AnalysisManager` produces read sets (per-procedure for always_comb /
+      always_latch, per-region for `@*`), stored in `ImplicitSensitivityReads` keyed by
+      `slang::ast::Statement*`. HIR carries them on `Process::implicit_sensitivity_list` for the
+      always_comb / always_latch forms and on `ImplicitEventControl::sensitivity_list` for `@*`. HIR
+      -> MIR: always_comb / always_latch run `forever { body; SensitivityWaitStmt; }` (body at t=0
+      then wait per LRM 9.2.2.2); `@*` expands to `Block { SensitivityWaitStmt; body; }` (wait first
+      per LRM 9.4.2.2.2). Reads collapse to whole-variable subscription until the runtime supports
+      bit-level any-change.
 
 ### Procedural assignments
 
@@ -96,25 +85,20 @@ order. Items in the [Actionable](#actionable) section can be picked up next; ite
 
 ### Synchronisation primitives
 
-- [x] P9 -- Named events: `event e;` declaration, `-> e;` trigger, `@e;` await, `e.triggered` query
-      (LRM 15.5). HIR mirrors slang's source-aligned structure: a new `hir::EventTriggerStmt` for
-      `-> e;` and a new `hir::TimingControl::NamedEventControl` variant for `@e;`. HIR -> MIR
-      collapses both onto method calls on the `lyra::runtime::NamedEvent` runtime type by way of
-      `mir::BuiltinMethodKind::{kNamedEventTrigger,kNamedEventAwait,kNamedEventTriggered}` -- no new
-      MIR statement kinds and no new timing-control variant. `NamedEvent` is a pure data type: it
-      owns a `RuntimeEvent` (waiters list) and a `std::optional<SimTime> last_triggered_at_`.
-      `Trigger(services)` records `services.Now()` and wakes every waiter via
-      `services.ScheduleProcess`; `Triggered(services)` is a `last_triggered_at_ == services.Now()`
-      comparison, so LRM 15.5.3 "triggered persists for the current time step" emerges from a
-      timestamp comparison rather than a flag the engine has to clear. The engine has no
-      event-specific code -- no `TriggerEvent` member, no slot-persistent flag, no event wait
-      dispatch. `e.triggered` returns a 1-bit `PackedArray` so it composes with the rest of the
-      value pipeline. The `->>` non-blocking trigger, `wait_order(...)`, event aliasing (`e1 = e2`),
-      event nullness, and event comparison are not in this cut.
-- [ ] P11 -- `wait (expr)` level-sensitive control. Suspends the coroutine, subscribes to every
-      signal read in `expr`, re-evaluates on any change, resumes when the expression becomes true.
-      Distinct from `@(expr)` because it is level-sensitive (LRM 9.4.3): if `expr` is already true
-      on entry, no suspension occurs. Closes `processes/wait_event`.
+- [x] P9 -- Named events (LRM 15.5): `event e;` declaration, `-> e;` trigger, `@e;` await,
+      `e.triggered` query. HIR carries `EventTriggerStmt` for `-> e;` and
+      `TimingControl::NamedEventControl` for `@e;`; HIR -> MIR collapses both onto method calls on
+      the `lyra::runtime::NamedEvent` data type, which records `last_triggered_at_` (LRM 15.5.3
+      same-time-step persistence falls out of `last_triggered_at_ == services.Now()`) and wakes its
+      waiter list. `e.triggered` returns a 1-bit `PackedArray`. `->>` non-blocking trigger,
+      `wait_order(...)`, event aliasing / nullness / comparison are out of scope.
+- [x] P11 -- `wait (cond) body` level-sensitive control (LRM 9.4.3). HIR carries
+      `WaitStmt {cond, body, sensitivity_list}`; the sensitivity is collected locally at the
+      `LowerWaitStmt` site by a small ASTVisitor over `cond` (no upstream manager pass, since slang
+      owns no DFA for wait conditions). HIR -> MIR lowers to
+      `Block { While { !cond, SensitivityWait(reads) }; body }` -- the LRM 9.4.3 "skip suspend if
+      cond is already true" semantic falls out of the while-loop shape. `wait fork;` (9.6.1) and
+      `wait_order(...)` (15.6) are out of scope. Closes `processes/wait_event`.
 
 ### Concurrency
 

--- a/include/lyra/hir/process.hpp
+++ b/include/lyra/hir/process.hpp
@@ -33,9 +33,10 @@ struct Process {
   std::vector<Expr> exprs;
   std::vector<Stmt> stmts;
   std::vector<ProceduralVarDecl> procedural_vars;
-  // LRM 9.2.2.2.1; non-empty only for always_comb / always_latch. `@*` carries
-  // its own sensitivity inside hir::ImplicitEventControl on the body's
-  // TimedStmt, so it does not populate this field.
+  // LRM 9.2.2.2.1 implicit sensitivity for always_comb / always_latch
+  // (procedure-level; the body is a plain statement). Empty for every other
+  // process kind -- `always @*` carries its sensitivity inside
+  // hir::ImplicitEventControl on the body's TimedStmt instead.
   std::vector<SensitivityEntry> implicit_sensitivity_list;
 };
 

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -129,23 +129,19 @@ struct EventControl {
 };
 
 // One entry of an implicit sensitivity list (LRM 9.2.2.2.1 for always_comb /
-// always_latch; 9.4.2.2 for `always @*`). Identity-only: which structural
-// variable, which flat bit range of its packed encoding. bit_range matches
-// slang's selectable-width representation; for packed types it is lossless
-// w.r.t. longest static prefix. The current runtime collapses to whole-variable
-// subscription at HIR -> MIR, but the precision is preserved here so the
-// collapse can be removed when the runtime gains bit-level Observable.
+// always_latch; 9.4.2.2 for `@*`; 9.4.3 for `wait (expr)`). Identity-only:
+// which structural variable, which flat bit range of its packed encoding.
+// The current runtime collapses to whole-variable subscription at HIR ->
+// MIR; bit_range is preserved here so the collapse can be lifted once the
+// runtime gains bit-level Observable.
 struct SensitivityEntry {
   StructuralVarRef ref;
   std::pair<std::uint64_t, std::uint64_t> bit_range;
 };
 
-// LRM 9.4.2.2 `@*` / `@(*)`. Identity-shaped (distinct from EventControl's
-// expression-shaped triggers): the sensitivity list is derived by slang's
-// AnalysisManager from the controlled statement's reads, never reassembled
-// into expressions. HIR keeps the slang AST shape -- the TimedStmt wraps the
-// controlled body -- and HIR -> MIR expands this into the runtime-oriented
-// "wait then body" sequence at lowering time.
+// LRM 9.4.2.2 `@*` / `@(*)`. Sensitivity for the controlled body is
+// computed by slang's AnalysisManager (write-before-read exclusion via
+// must-def) and looked up at AST -> HIR via the precomputed read-set facts.
 struct ImplicitEventControl {
   std::vector<SensitivityEntry> sensitivity_list;
 };
@@ -175,10 +171,20 @@ struct EventTriggerStmt {
   ExprId event;
 };
 
+// LRM 9.4.3 level-sensitive `wait (cond) body`. `sensitivity_list` is the
+// precomputed read set of `cond`, populated at AST -> HIR from a slang-side
+// ASTVisitor over WaitStatement.cond -- symmetric with how `@*` and
+// always_comb carry slang-derived sensitivity.
+struct WaitStmt {
+  ExprId cond;
+  StmtId body;
+  std::vector<SensitivityEntry> sensitivity_list;
+};
+
 using StmtData = std::variant<
     EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, IfStmt, CaseStmt, ForStmt,
     WhileStmt, RepeatStmt, DoWhileStmt, ForeverStmt, BreakStmt, ContinueStmt,
-    TimedStmt, EventTriggerStmt>;
+    TimedStmt, EventTriggerStmt, WaitStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/include/lyra/lowering/ast_to_hir/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/lower.hpp
@@ -18,26 +18,21 @@ class ValueSymbol;
 
 namespace lyra::lowering::ast_to_hir {
 
-// One element of the precomputed implicit sensitivity list. Mirrors slang's
-// ReadRange: `symbol` is the structural variable being read; `bit_range` is
-// the flat bit range within its selectable-width packed encoding. Multiple
-// entries for the same symbol with disjoint bit ranges are kept as-is so
-// downstream can preserve precision when the runtime supports bit-level
-// subscription.
+// Mirrors slang's ReadRange. Multiple entries for the same symbol with
+// disjoint bit ranges are kept as-is so downstream can preserve precision
+// when the runtime supports bit-level subscription.
 struct SensitivityRead {
   const slang::ast::ValueSymbol* symbol;
   std::pair<std::uint64_t, std::uint64_t> bit_range;
 };
 
-// Precomputed implicit sensitivity, keyed uniformly by the slang Statement
-// that LRM associates the list with:
-//   - LRM 9.2.2.2.1 (always_comb / always_latch): key = &proc.getBody(); the
-//     sensitivity attaches to the procedure body statement.
-//   - LRM 9.4.2.2 (`always @*` / `@(*)`): key = the TimedStatement holding
-//     the `@*`; multiple `@*`s in one procedure each get their own entry.
-// Both cases reduce to "reads in a statement", so one map per statement
-// pointer is enough. Slang already excludes block-local declarations,
-// also-written variables, and timing-control-only identifiers per the LRM.
+// Slang-derived sensitivity precomputed via slang's AnalysisManager, keyed
+// by the slang Statement that LRM associates the list with:
+//   - LRM 9.2.2.2.1 (always_comb / always_latch): key = &proc.getBody().
+//   - LRM 9.4.2.2 (`@*` / `@(*)`): key = the TimedStatement holding `@*`.
+// Forms whose read set we derive ourselves (wait, future wait_order) walk
+// their own expression locally at the lowering site and do not use this
+// map.
 using ImplicitSensitivityReads = std::unordered_map<
     const slang::ast::Statement*, std::vector<SensitivityRead>>;
 

--- a/src/lyra/compiler/compile.cpp
+++ b/src/lyra/compiler/compile.cpp
@@ -21,12 +21,9 @@ namespace lyra::compiler {
 
 namespace {
 
-// Translates slang's ReadRange entries into lyra's SensitivityRead shape.
-// Slang already returns deduplicated sets per LRM 9.2.2.2.1 / 9.4.2.2, so
-// the conversion is a straight 1:1 copy. Multiple entries for the same
-// symbol with disjoint bit ranges (e.g. `bus[3] | bus[5]`) are preserved so
-// downstream can subscribe at bit-range granularity once the runtime
-// supports it.
+// Deduplicated `ReadRange`-shaped list from slang's DFA maps 1:1. Disjoint
+// bit ranges for the same symbol are preserved so the runtime can subscribe
+// at bit-range granularity once Observable gains that resolution.
 template <typename SlangReads>
 auto TranslateReads(const SlangReads& reads)
     -> std::vector<lowering::ast_to_hir::SensitivityRead> {
@@ -38,6 +35,10 @@ auto TranslateReads(const SlangReads& reads)
   return entries;
 }
 
+// Harvests slang's procedure-level and per-`@*` read sets via the
+// AnalysisManager listener. Other forms (wait, future wait_order, etc.)
+// run their own walkers locally at the lowering site and do not pass
+// through this listener.
 auto ComputeImplicitSensitivityReads(slang::ast::Compilation& compilation)
     -> lowering::ast_to_hir::ImplicitSensitivityReads {
   lowering::ast_to_hir::ImplicitSensitivityReads out;
@@ -56,8 +57,6 @@ auto ComputeImplicitSensitivityReads(slang::ast::Compilation& compilation)
       }
     }
     // LRM 9.4.2.2: each `@*` TimedStatement carries its own sensitivity.
-    // Slang surfaces this regardless of the overall SensitivityList::Kind,
-    // so the same procedure can contribute multiple statement-keyed entries.
     for (const auto& region : ap.getImplicitEventReadSets()) {
       out.emplace(region.statement, TranslateReads(region.reads));
     }

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -1054,6 +1054,28 @@ class HirDumper {
                       "Stmt[{}] EventTriggerStmt event=Expr[{}]", id.value,
                       et.event.value));
             },
+            [&](const WaitStmt& w) {
+              std::string sens = "sensitivity=[";
+              for (std::size_t i = 0; i < w.sensitivity_list.size(); ++i) {
+                if (i != 0) sens += ", ";
+                const auto& r = w.sensitivity_list[i];
+                sens += std::format(
+                    "{{hops={} var=StructuralVar[{}] bits=[{}:{}]}}",
+                    r.ref.hops.value, r.ref.var.value, r.bit_range.first,
+                    r.bit_range.second);
+              }
+              sens += "]";
+              Line(
+                  std::format(
+                      "Stmt[{}] WaitStmt cond=Expr[{}] {}", id.value,
+                      w.cond.value, sens));
+              Indent();
+              Line("body:");
+              Indent();
+              DumpStmt(p, w.body);
+              Dedent();
+              Dedent();
+            },
         },
         s.data);
   }

--- a/src/lyra/lowering/ast_to_hir/process.cpp
+++ b/src/lyra/lowering/ast_to_hir/process.cpp
@@ -38,10 +38,10 @@ auto FromSlangProceduralBlockKind(slang::ast::ProceduralBlockKind kind)
       "ast_to_hir::FromSlangProceduralBlockKind: unknown ProceduralBlockKind");
 }
 
-// Looks up sensitivity for `key_stmt` from the precomputed slang analysis
-// and translates it into HIR identity entries. Empty result is legal (no
-// reads, or unknown key) -- a SensitivityWaitStmt with an empty list means
-// "wait forever", which is the correct degenerate behaviour.
+// Slang's procedure-body sensitivity for always_comb / always_latch
+// (LRM 9.2.2.2.1). Empty result is legal -- a SensitivityWaitStmt with an
+// empty list means "wait forever", which is the correct degenerate
+// behaviour for a procedure body with no external reads.
 auto LookupSensitivityEntries(
     const UnitLoweringFacts& unit_facts, const UnitLoweringState& unit_state,
     const ScopeStack& stack, const slang::ast::Statement& key_stmt)

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include <slang/ast/ASTVisitor.h>
 #include <slang/ast/Expression.h>
 #include <slang/ast/Statement.h>
 #include <slang/ast/Symbol.h>
@@ -12,7 +13,9 @@
 #include <slang/ast/statements/ConditionalStatements.h>
 #include <slang/ast/statements/LoopStatements.h>
 #include <slang/ast/statements/MiscStatements.h>
+#include <slang/ast/symbols/ValueSymbol.h>
 #include <slang/ast/symbols/VariableSymbols.h>
+#include <slang/ast/types/Type.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
@@ -190,9 +193,6 @@ auto LowerTimingControl(
           hir::EventControl{.triggers = std::move(triggers)}};
     }
     case slang::ast::TimingControlKind::ImplicitEvent:
-      // `@*` / `@(*)` lowers to `hir::ImplicitEventControl`. The sensitivity
-      // list is filled in by LowerTimedStmt, which has access to the parent
-      // TimedStatement pointer needed for the slang-side lookup.
       return hir::TimingControl{hir::ImplicitEventControl{}};
     case slang::ast::TimingControlKind::RepeatedEvent:
       return diag::Unsupported(
@@ -456,7 +456,7 @@ auto LowerContinueStmt(diag::SourceSpan span) -> diag::Result<hir::Stmt> {
       .label = std::nullopt, .data = hir::ContinueStmt{}, .span = span};
 }
 
-auto LowerCaseSlangStmt(
+auto LowerCaseStmt(
     const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
     ScopeLoweringState& scope_state, ScopeStack& stack,
     const slang::ast::CaseStatement& cs, diag::SourceSpan span)
@@ -508,7 +508,7 @@ auto LowerCaseSlangStmt(
       .span = span};
 }
 
-auto LowerConditionalSlangStmt(
+auto LowerConditionalStmt(
     const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
     ScopeLoweringState& scope_state, ScopeStack& stack,
     const slang::ast::ConditionalStatement& cs, diag::SourceSpan span)
@@ -557,7 +557,7 @@ auto LowerConditionalSlangStmt(
 
 // LRM 15.5.1 `-> e;`. Source-aligned with slang's EventTriggerStatement. The
 // `->>` non-blocking form and any delay-or-event-control prefix are deferred.
-auto LowerEventTriggerSlangStmt(
+auto LowerEventTriggerStmt(
     const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
     ScopeLoweringState& scope_state, const ScopeStack& stack,
     const slang::ast::EventTriggerStatement& et, diag::SourceSpan span)
@@ -595,6 +595,67 @@ auto LowerEventTriggerSlangStmt(
       .span = span};
 }
 
+// Walks the cond of a `wait (cond)` (LRM 9.4.3), recording every value
+// reference as a read. Slang's `IsSelectExpr` concept closes the set of
+// leaves that produce a read (`NamedValueExpression` /
+// `HierarchicalValueExpression` here; the other three select wrappers
+// recurse via visitDefault to a leaf). Lvalue tracking is unnecessary
+// because LRM 11.3.6 forbids assignment operators inside timing-control
+// expressions, so every value reference in `cond` is a read.
+struct WaitCondReadCollector
+    : slang::ast::ASTVisitor<
+          WaitCondReadCollector, slang::ast::VisitFlags::Expressions> {
+  std::vector<SensitivityRead> out;
+
+  void handle(const slang::ast::NamedValueExpression& e) {
+    Record(e.symbol);
+    visitDefault(e);
+  }
+
+  void handle(const slang::ast::HierarchicalValueExpression& e) {
+    Record(e.symbol);
+    visitDefault(e);
+  }
+
+ private:
+  void Record(const slang::ast::ValueSymbol& sym) {
+    const auto width = sym.getType().getSelectableWidth();
+    out.push_back(
+        SensitivityRead{
+            .symbol = &sym, .bit_range = {0, width > 0 ? width - 1 : 0}});
+  }
+};
+
+// LRM 9.4.3 `wait (cond) body`. Sensitivity is derived locally by walking
+// `cond` -- no upstream `AnalysisManager` listener needed, since slang owns
+// no DFA for wait conditions.
+auto LowerWaitStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, ScopeStack& stack,
+    const slang::ast::WaitStatement& w, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  auto cond_or = LowerProcExpr(
+      unit_facts, scope_state.UnitState(), proc_state, stack, w.cond);
+  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+  const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_or));
+  auto body_or =
+      LowerStatement(unit_facts, proc_state, scope_state, stack, w.stmt);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+  const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_or));
+  WaitCondReadCollector collector;
+  w.cond.visit(collector);
+  auto sensitivity =
+      TranslateSensitivityReads(collector.out, scope_state.UnitState(), stack);
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data =
+          hir::WaitStmt{
+              .cond = cond_id,
+              .body = body_id,
+              .sensitivity_list = std::move(sensitivity)},
+      .span = span};
+}
+
 auto LowerStatement(
     const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
     ScopeLoweringState& scope_state, ScopeStack& stack,
@@ -606,9 +667,14 @@ auto LowerStatement(
       return LowerEmptyStmt(span);
 
     case slang::ast::StatementKind::EventTrigger:
-      return LowerEventTriggerSlangStmt(
+      return LowerEventTriggerStmt(
           unit_facts, proc_state, scope_state, stack,
           stmt.as<slang::ast::EventTriggerStatement>(), span);
+
+    case slang::ast::StatementKind::Wait:
+      return LowerWaitStmt(
+          unit_facts, proc_state, scope_state, stack,
+          stmt.as<slang::ast::WaitStatement>(), span);
 
     case slang::ast::StatementKind::Timed:
       return LowerTimedStmt(
@@ -667,12 +733,12 @@ auto LowerStatement(
       return LowerContinueStmt(span);
 
     case slang::ast::StatementKind::Case:
-      return LowerCaseSlangStmt(
+      return LowerCaseStmt(
           unit_facts, proc_state, scope_state, stack,
           stmt.as<slang::ast::CaseStatement>(), span);
 
     case slang::ast::StatementKind::Conditional:
-      return LowerConditionalSlangStmt(
+      return LowerConditionalStmt(
           unit_facts, proc_state, scope_state, stack,
           stmt.as<slang::ast::ConditionalStatement>(), span);
 

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -858,10 +858,12 @@ auto LowerNamedEventTimedStmt(
       .child_procedural_scopes = std::move(child_scopes)};
 }
 
-// LRM 9.4.2.2: `@* body` -- the HIR TimedStmt with ImplicitEventControl
-// expands at HIR -> MIR into a Block { SensitivityWaitStmt; body; } inside a
-// fresh child scope. This is where HIR's slang-aligned wrapper structure
-// reduces to MIR's runtime-oriented "wait then body" sequencing.
+// LRM 9.4.2.2 `@* body` expands to:
+//
+//   child_scope {
+//     SensitivityWaitStmt(ie.sensitivity_list)
+//     body
+//   }
 auto LowerImplicitEventTimedStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
@@ -888,6 +890,77 @@ auto LowerImplicitEventTimedStmt(
       .label = stmt.label,
       .data = mir::BlockStmt{.scope = scope_id},
       .child_procedural_scopes = std::move(child_scopes)};
+}
+
+// LRM 9.4.3 `wait (cond) body` expands to:
+//
+//   wrapper_scope {
+//     while (!cond) {
+//       inner_scope { SensitivityWaitStmt(reads(cond)) }
+//     }
+//     body
+//   }
+//
+// The level-sensitive "skip suspend if cond is already true" semantic falls
+// out of the while-loop: an entry-true cond never enters the body.
+auto LowerWaitStmt(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    const hir::Stmt& stmt, const hir::WaitStmt& w) -> diag::Result<mir::Stmt> {
+  ProceduralScopeLoweringState wrapper_state;
+  ProceduralDepthGuard wrapper_depth_guard{proc_state};
+
+  const hir::Expr& hir_cond = hir_proc.exprs.at(w.cond.value);
+  auto cond_or = LowerExpr(
+      unit_state, scope_state, proc_state, wrapper_state, hir_proc, hir_cond);
+  if (!cond_or) {
+    return std::unexpected(std::move(cond_or.error()));
+  }
+  const mir::ExprId cond_id = wrapper_state.AddExpr(*std::move(cond_or));
+  const mir::TypeId cond_type = wrapper_state.GetExpr(cond_id).type;
+
+  const mir::ExprId not_cond_id = wrapper_state.AddExpr(
+      mir::Expr{
+          .data =
+              mir::UnaryExpr{
+                  .op = mir::UnaryOp::kLogicalNot, .operand = cond_id},
+          .type = cond_type});
+
+  const auto& reads = w.sensitivity_list;
+
+  ProceduralScopeLoweringState inner_state;
+  ProceduralDepthGuard inner_depth_guard{proc_state};
+  inner_state.AddRootStmt(
+      inner_state.AddStmt(BuildSensitivityWaitStmt(scope_state, reads)));
+
+  std::vector<mir::ProceduralScope> wrapper_child_scopes;
+  const mir::ProceduralScopeId inner_scope_id =
+      AddChildProceduralScope(wrapper_child_scopes, inner_state.Finish());
+
+  wrapper_state.AddRootStmt(wrapper_state.AddStmt(
+      mir::Stmt{
+          .label = std::nullopt,
+          .data =
+              mir::WhileStmt{.condition = not_cond_id, .scope = inner_scope_id},
+          .child_procedural_scopes = std::move(wrapper_child_scopes)}));
+
+  const hir::Stmt& body_hir = hir_proc.stmts.at(w.body.value);
+  auto body_or = LowerStmt(
+      unit_state, scope_state, proc_state, wrapper_state, hir_proc, body_hir);
+  if (!body_or) {
+    return std::unexpected(std::move(body_or.error()));
+  }
+  wrapper_state.AddRootStmt(wrapper_state.AddStmt(*std::move(body_or)));
+
+  std::vector<mir::ProceduralScope> outer_child_scopes;
+  const mir::ProceduralScopeId wrapper_scope_id =
+      AddChildProceduralScope(outer_child_scopes, wrapper_state.Finish());
+
+  return mir::Stmt{
+      .label = stmt.label,
+      .data = mir::BlockStmt{.scope = wrapper_scope_id},
+      .child_procedural_scopes = std::move(outer_child_scopes)};
 }
 
 auto LowerTimedStmt(
@@ -1012,6 +1085,10 @@ auto LowerStmt(
             return LowerEventTriggerStmt(
                 unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
                 stmt, et);
+          },
+          [&](const hir::WaitStmt& w) {
+            return LowerWaitStmt(
+                unit_state, scope_state, proc_state, hir_proc, stmt, w);
           },
       },
       stmt.data);

--- a/tests/cases/cpp/wait_level_already_true/case.yaml
+++ b/tests/cases/cpp/wait_level_already_true/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.wait_level_already_true
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    marker: 1
+    ready: 1

--- a/tests/cases/cpp/wait_level_already_true/main.sv
+++ b/tests/cases/cpp/wait_level_already_true/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  bit ready;
+  int marker;
+
+  initial begin
+    ready = 1;
+    marker = 0;
+    // LRM 9.4.3: if `ready` is already true on entry, the wait does not
+    // suspend; the body runs in the same time step.
+    wait (ready) marker = 1;
+  end
+endmodule

--- a/tests/cases/cpp/wait_level_blocks_until_change/case.yaml
+++ b/tests/cases/cpp/wait_level_blocks_until_change/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.wait_level_blocks_until_change
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    marker: 1
+    ready: 1

--- a/tests/cases/cpp/wait_level_blocks_until_change/main.sv
+++ b/tests/cases/cpp/wait_level_blocks_until_change/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  bit ready;
+  int marker;
+
+  initial begin
+    ready = 0;
+    marker = 0;
+    // LRM 9.4.3: cond is false on entry, so the process subscribes to the
+    // read set of cond (here just `ready`) and re-evaluates on any change.
+    wait (ready) marker = 1;
+  end
+
+  initial begin
+    #5;
+    ready = 1;
+  end
+endmodule

--- a/tests/cases/cpp/wait_level_compound_cond/case.yaml
+++ b/tests/cases/cpp/wait_level_compound_cond/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.wait_level_compound_cond
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    marker: 1
+    a: 1
+    b: 1

--- a/tests/cases/cpp/wait_level_compound_cond/main.sv
+++ b/tests/cases/cpp/wait_level_compound_cond/main.sv
@@ -1,0 +1,21 @@
+module Top;
+  bit a, b;
+  int marker;
+
+  initial begin
+    a = 0;
+    b = 0;
+    marker = 0;
+    // Compound condition exercises the walker's BinaryExpr recursion: both
+    // `a` and `b` are picked up as reads, so a transition on either kicks
+    // re-evaluation of `a && b`.
+    wait (a && b) marker = 1;
+  end
+
+  initial begin
+    #5;
+    a = 1;
+    #5;
+    b = 1;
+  end
+endmodule

--- a/tests/cases/cpp/wait_level_null_body/case.yaml
+++ b/tests/cases/cpp/wait_level_null_body/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.wait_level_null_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    after_wait: 1
+    ready: 1

--- a/tests/cases/cpp/wait_level_null_body/main.sv
+++ b/tests/cases/cpp/wait_level_null_body/main.sv
@@ -1,0 +1,19 @@
+module Top;
+  bit ready;
+  int after_wait;
+
+  initial begin
+    ready = 0;
+    after_wait = 0;
+    // Source `wait (cond);` -- statement_or_null is the empty form. The body
+    // lowers to a hir::EmptyStmt; the wait still suspends until `ready`
+    // becomes truthy, then control falls through to the next statement.
+    wait (ready);
+    after_wait = 1;
+  end
+
+  initial begin
+    #5;
+    ready = 1;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements P11 (LRM 9.4.3 `wait (cond) body`): a `WaitStatement` lowers to `hir::WaitStmt {cond, body, sensitivity_list}` and HIR -> MIR expands it to `Block { While { !cond, SensitivityWait(reads) }; body }`. The level-sensitive "skip suspend if cond is already true" semantic falls out of the while-loop shape; the existing `SensitivityWaitStmt` MIR primitive, Observable subscription path, and backend awaitable are reused unchanged.

## Design

The cond read set is collected locally at `LowerWaitStmt` by a small `ASTVisitor` (`WaitCondReadCollector`) that intercepts `NamedValueExpression` / `HierarchicalValueExpression` leaves and lets `visitDefault` recurse through every other expression shape. Slang's `IsSelectExpr` concept closes the set of value-reference leaves, so the visitor is bounded. Lvalue tracking is unnecessary because LRM 11.3.6 forbids assignment operators inside timing-control expressions.

This walker lives next to its only caller (`statement/lower.cpp`) rather than in the `AnalysisManager` listener. Slang owns no DFA for wait conditions, so there is no reason to share machinery with the `always_comb` / `@*` paths that genuinely need it -- the manager listener now only harvests slang-derived sensitivity (procedure-level for always_comb / always_latch, per-region for `@*`), and forms whose reads we derive ourselves walk locally at the lowering site.

`wait fork;` (LRM 9.6.1) and `wait_order(...)` (LRM 15.6) are out of scope.

## Testing

- [x] `bazel build //...`
- [x] `bazel test //...` -- 4 new cpp_run cases under `tests/cases/cpp/wait_level_*` covering entry-already-true, blocks-until-change, compound cond (`a && b`), and null body.