### PR TITLE
Lower structural-var initializers to C++ field init

### DIFF
--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -24,10 +24,9 @@ the dedicated file is the source of truth for "what is done, in what order, what
 - [ ] R4 -- AOT execution path; runtime delivered as a static library.
 - [ ] R5 -- CLI subcommands for executing simulations: `run`, `compile`, `dump llvm`.
 - [ ] R6 -- Smoke, benchmark, and AOT CI jobs (currently `if: false`; see `../ci/README.md`).
-- [ ] R7 -- Test framework variable assertions (`expect.variables`). Archived tests assert
-      end-of-simulation values directly (`c: 30`, `r: "4'bx01x"`); the current framework supports
-      only `exit`/`stdout`/`stderr`, forcing every behavioral test to route through `$display`.
-      Blocks faithful reproduction of most feature tests under `archived/tests/sv_features/`.
+- [x] R7 -- Test framework variable assertions (`expect.variables`). `tests/framework/runner.cpp`
+      rewrites the source with a synthetic `final` probe block keyed on sentinel markers in stdout
+      and matches each entry against scalar / SV-literal expectations.
 
 ## SystemVerilog Features
 

--- a/docs/progress/datatypes.md
+++ b/docs/progress/datatypes.md
@@ -1,160 +1,89 @@
 # Datatypes
 
 Tracks SystemVerilog data type coverage on the current pipeline. The integral family (`int`, `byte`,
-`shortint`, `longint`, `time`, `integer`, `bit [N:0]`, `logic [N:0]`) lives in `integral.md` because
-its work is a single PackedArray-runtime cut sequence. This file covers every other family:
-`datatypes/enum`, `datatypes/string`, `datatypes/unpacked`, `datatypes/general` (dynamic array /
-queue / associative), `datatypes/real`, `datatypes/default_init`, `datatypes/representation`.
+`shortint`, `longint`, `time`, `integer`, `bit [N:0]`, `logic [N:0]`) lives in `integral.md`. This
+file covers every other family: `datatypes/enum`, `datatypes/string`, `datatypes/unpacked`,
+`datatypes/general` (dynamic array / queue / associative), `datatypes/real`,
+`datatypes/default_init`, `datatypes/representation`.
 
 Each archive item checkbox in `architecture-reset.md` is checked when its `*.yaml` cases reproduce
 on the current pipeline.
 
 ## Actionable
 
-Real C1 / C2 / C3 / C4 are complete. Other families remaining: `datatypes/string`,
-`datatypes/unpacked`, `datatypes/general`, `datatypes/default_init`, `datatypes/representation`.
+Real C1 / C2 / C3 / C4 are complete. Structural-var declaration initializers (SV LRM 6.8) are
+complete for the integral, enum, real, shortreal, and realtime families (SI1 below). Remaining
+families: `datatypes/string`, `datatypes/unpacked`, `datatypes/general`, `datatypes/default_init`,
+`datatypes/representation`.
 
 ## Enum
 
 Covers archive item `datatypes/enum` (sub-folders `enum`, `enum_implicit_conversion`,
-`enum_methods`). Slang models enum as `EnumType : public IntegralType, public Scope`. Our HIR
-mirrors that with a `hir::EnumType` carrying a `base_type` (a `PackedArrayType`) and an ordered
-member table. HIR -> MIR aliases the enum's MIR `TypeId` to its base type's so MIR and the cpp
-backend see only `lyra::value::PackedArray`.
+`enum_methods`). LRM 6.19 semantics: enum types are a labelled subset of an integral base type; enum
+-> integral conversion is implicit, integral -> enum requires an explicit cast.
 
-Enum methods are modelled by the general "types own method tables" mechanism: `EnumType.methods`
-carries six `hir::Method` entries (each with `hir::BuiltinMethod` data), populated at AST -> HIR
-enum type construction. Call dispatch goes through `hir::MethodRef{receiver_type, method_id}` -- a
-`SubroutineRef` variant alternative that is the dot-syntax counterpart of `StructuralSubroutineRef`
-(free user calls) and `SystemSubroutineRef` (system tasks). The same mechanism is the path for
-future `string` / `queue` builtins and user class methods; only the `Method::data` variant
-alternative differs (`BuiltinMethod` for LRM intrinsics, `StructuralMethod` for user-defined
-bodies).
-
-Behavior lives in the runtime SDK (`include/lyra/value/enum_ops.hpp`): six hand-written `inline`
-functions (`EnumFirst` / `EnumLast` / `EnumNum` / `EnumName` / `EnumNext` / `EnumPrev`) operating on
-a generic `EnumMetadata{members, is_four_state}`. HIR -> MIR translates `MethodRef` to a
-`mir::BuiltinMethodCallee{enum_metadata_id, kind}` callee and populates a per-enum-type
-`EnumMetadata` entry on `mir::CompilationUnit::enum_metadata` (cached by HIR `TypeId`). cpp emit
-walks `enum_metadata` to emit `inline constexpr lyra::value::EnumMember[]` plus an
-`inline constexpr lyra::value::EnumMetadata` global per entry at TU top, and renders each call site
-as `lyra::value::Enum<Method>(lyra_enum_metadata_N, ...)`. The architecture choice between inline
-expansion vs runtime ops library is documented in `enum-method-architecture.md` (root).
-
-- [x] E1 -- Type plumbing, member references, method dispatch. `LowerType` recognises
-      `slang::ast::EnumType` and populates the enum type's six-entry method table (`first` / `last`
-      / `num` / `next` / `prev` / `name`). AST `NamedValueExpression` whose symbol kind is
-      `EnumValue` lowers directly to `hir::IntegerLiteral` of the backing type. `v.first()` /
-      `v.last()` / `v.num()` lower at AST -> HIR via a uniform call dispatch that looks up the
-      method by name on the receiver's type, producing
-      `CallExpr{callee=MethodRef{receiver_type, method_id}, arguments=[receiver]}`. HIR -> MIR
-      translates each `MethodRef` to a `mir::BuiltinMethodCallee` referring to the receiver type's
-      `EnumMetadata`. HIR -> MIR's `TranslateTypeData` has an `EnumType` arm that copies the base's
-      translated `mir::TypeData`, so the orchestrator stays uniform. Conversions enum -> integral
-      are transparent; integral -> enum requires explicit cast (LRM 6.19.3). Covers all 11 cases of
+- [x] E1 -- Declarations, member references, comparisons, arithmetic, and conversions. Covers
       `enum/default.yaml` (basic, sequential, explicit, mixed, comparison, arithmetic, explicit base
-      type, display, range count, range bounds, range mixed);
-      `enum_implicit_conversion/default.yaml` cases that are legal under LRM 6.19.3
-      (`explicit_cast_works`, `enum_to_int_unchanged` via `enum_arithmetic`); and
-      `enum_methods/default.yaml` cases for `first` / `last` / `num` / `num_auto_values`. Also ships
-      `enum_passed_to_system_function` as a regression guard for the AST -> HIR Call dispatch (an
-      enum-typed first argument to a `$`-prefixed system call must fall through to the system
-      subroutine path when no method of that name exists on the receiver). Unblocks C16 in
-      `control-flow.md`.
-- [x] E2 -- Runtime methods `next` / `prev` with optional step (LRM 6.19.5.3 / 6.19.5.4). AST -> HIR
-      produces `CallExpr{callee=MethodRef{...}, arguments=[receiver, step?]}`; AST -> HIR fills in
-      the default `1` for the missing step (each enum's method table carries the formal parameter
-      with its default `IntegralConstant`). HIR -> MIR translates `MethodRef` to a
-      `BuiltinMethodCallee` referencing the type's `EnumMetadata` plus the method kind. cpp emit
-      renders the call as `lyra::value::EnumNext(metadata, receiver_value, step)` /
-      `lyra::value::EnumPrev(metadata, receiver_value, step)` and wraps the `std::int64_t` result in
-      a `PackedArray` of the enum's base shape. Non-member receivers fall through the runtime lookup
-      to a zero default (Table 6-7 4-state X behavior is a runtime gap tracked separately). Covers
-      `enum_methods/default.yaml` cases `enum_next`, `enum_next_wrap`, `enum_prev`,
-      `enum_prev_wrap`, `enum_next_step`, `enum_next_step_wrap`, `enum_prev_step`,
-      `enum_prev_step_wrap`, plus `enum_next_runtime_step` as a regression guard for non-literal
-      step.
-- [x] E3 -- Method `name()` (LRM 6.19.5.6). Returns the string name of the current value, empty
-      string when the value is not a member. cpp emit renders the call as
-      `lyra::value::EnumName(metadata, receiver_value)`; the SDK function returns `std::string`
-      directly. Covers `enum_methods/default.yaml` case `enum_name`.
+      type, display, range count / bounds / mixed); legal cases in
+      `enum_implicit_conversion/default.yaml`; and the `first` / `last` / `num` / `num_auto_values`
+      cases in `enum_methods/default.yaml`.
+- [x] E2 -- `next` / `prev` methods with optional step argument (LRM 6.19.5.3 / 6.19.5.4). Covers
+      the `enum_next*`, `enum_prev*`, and `enum_next_runtime_step` cases in
+      `enum_methods/default.yaml`. Non-member receivers fall back to a zero default; LRM Table 6-7
+      4-state `'x` behaviour is tracked under `datatypes/default_init`.
+- [x] E3 -- `name()` method (LRM 6.19.5.6); empty string for non-member values. Covers `enum_name`
+      in `enum_methods/default.yaml`.
 
 ### Cross-references
 
 - LRM 6.19 (Enumerations), 6.19.3 (conversions), 6.19.5 (methods).
 - Archive items: `datatypes/enum/{enum,enum_implicit_conversion,enum_methods}`.
 - Unblocks: C16 (enum-typed `case` selectors) in `control-flow.md`.
-- Slang reference: `slang/include/slang/ast/types/AllTypes.h` -- `EnumType`, `EnumValueSymbol`.
-- Legacy archive reference: `archived/include/lyra/common/type.hpp` -- `EnumInfo`, `EnumMember`.
 
 ## Real
 
 Covers archive item `datatypes/real` (sub-folders `real_types`, `shortreal_types`,
-`realtime_types`). Per LRM 6.12, `real` is C `double`, `shortreal` is C `float`, and `realtime` is
-synonymous with `real`. Three runtime variants on `RuntimeValueView` (`Real64ValueView`,
-`Real32ValueView`) plus IEEE 754 round-trip-precision literal rendering (17 sig-digits for double, 9
-for float). Real values bypass the `Var<T>` wrapper because LRM 6.12 forbids edge event controls on
-real variables.
+`realtime_types`). Per LRM 6.12, `real` is IEEE 754 double, `shortreal` is IEEE 754 single, and
+`realtime` is synonymous with `real`. LRM 6.12 forbids edge event controls on real variables.
 
-- [x] C1 -- Declarations, blocking assignment, and `$display` formatting (`%f` / `%e` / `%g`). HIR
-      `RealLiteral` and MIR `RealLiteral` carry a `double` value; cpp emit renders `real` and
-      `realtime` to `double`, `shortreal` to `float`. `support::FormatDirectiveKind` and
-      `mir::FormatKind` split into `kRealDecimal` / `kRealExponential` / `kRealGeneral` so each
-      conversion specifier is a distinct semantic kind. `lower_print.cpp` routes the three real
-      kinds through `RuntimeValueView` real variants; `value::FormatValue` formats them via
-      `std::format` with `{:.{}f}`, `{:.{}e}`, `{:.{}g}` and default precision 6 (matches printf and
-      LRM Table 21-2). Covers the declaration / assignment / display cases across all three archive
-      subfolders (`real_declaration_*`, `*_local_variable`, `*_assignment` for
-      `real`/`shortreal`/`realtime`).
-- [x] C2 -- Operators legal on real per LRM 11.3.1 plus structural-level initializers
-      (`real a = 1.5;` at module scope). cpp emit splits `RenderBinaryOp` / `RenderUnaryOp` into
-      integral and real renderers. Real arithmetic uses native C++ ops; `**` uses `std::pow` (C++
-      overload resolution picks `(float, float) -> float` and `(double, double) -> double`, matching
-      LRM 11.3.1 result typing). The C++ bool result of a real relational / equality / logical op is
-      wrapped in `lyra::value::PackedArray::FromInt(..., 1, false, false)` so the runtime sees the
-      1-bit integral shape the rest of the pipeline expects. shortreal <-> real conversions go
-      through `ConversionExpr`: same-precision is pass-through; cross-precision emits
-      `static_cast<float>` / `static_cast<double>` so C++ never sees an implicit narrowing.
-      `<cmath>` joins the emit prologue. Structural-level initializers are wired end-to-end:
-      `hir::StructuralVarDecl` carries an optional `initializer` ExprId; AST -> HIR extracts
-      `var.getInitializer()` for real-family types via `LowerStructuralExpr`; HIR -> MIR appends an
-      `ExprStmt(AssignExpr)` per initialized var into the scope's `constructor_scope`; cpp emit's
-      existing fall-through `(target = value)` arm lands the assignment in the C++ constructor body.
-      This is safe for real-family vars because they do not wrap in `Var<T>` and therefore do not
-      need `services_`. Integral structural initializers remain a known gap (their
-      `Var<PackedArray>` write path needs `services_`, which is not bound until `Bind()`).
-- [x] C3 -- Cross-family conversions. cpp emit's `RenderConversionExpr` gains an integral -> real
-      arm (`static_cast<double>((operand).ToInt64())`; `PackedArray::ToInt64` collapses X / Z bits
-      to 0 per LRM 6.12.1) and a real -> integral arm
-      (`PackedArray::FromInt(std::llround(operand), <shape>)`; `std::llround`'s round-half-away-
-      from-zero rule matches LRM 6.12.1 exactly, contrasting with the archive's incorrect LLVM
-      `FPToSI` truncate path). Same-shape and unhandled-pair conversions fall through to the operand
-      unchanged: slang emits identity conversions (e.g., `string` -> `string`) and string-literal
-      lifts (`bit[N-1:0]` -> `string`) where the operand already renders as the destination's C++
-      type. Widths > 64 bits are caught by `PackedArray::FromInt` / `ToInt64`'s own width invariants
-      (follow-up: wide-int conversion via the FromWords path). Drive-by fix: `PackedArray::ToInt64`
-      previously read `ValueWords()` raw, leaving X / Z positions whatever bit pattern slang stored
-      in the value plane; it now masks by `~UnknownWords()` so its docstring's "X/Z bits map to 0"
-      promise actually holds. Tests: `int_to_real`, `int_to_real_negative`,
-      `real_to_int_round_down`, `real_to_int_round_up`, `real_to_int_half_positive`,
-      `real_to_int_half_negative`, `int_to_shortreal`, `shortreal_to_int`, `int_literal_to_real`,
-      `byte_to_real`, `longint_to_real`, `logic_xz_to_real`.
-- [x] C4 -- LRM-illegal forms on real (LRM 6.12 + 11.3.1 / Table 11-1). Slang filters 10 of 11 at
-      AST construction (edge event control on real, bit-select / part-select of real, real index in
-      bit-select, modulus `%`, bitwise / reduction / shift, wildcard `==?` / `!=?`, plus the
-      corresponding compound assignment forms). The one slang anomaly is case equality `===` / `!==`
-      on real (slang allows `bothNumeric` even though LRM Table 11-1 lists "Any except real and
-      shortreal"). That path falls through `RenderBinaryOpReal`'s default arm, which already returns
-      `diag::Unsupported` with an LRM 11.3.1 citation -- so the C2 defensive renderer is the
-      rejection mechanism with no additional code required. Negative test
-      `errors/real_case_equality_unsupported` guards this contract.
+- [x] C1 -- Declarations, blocking assignment, and `$display` formatting (`%f` / `%e` / `%g` with
+      LRM Table 21-2 default precision). Covers the declaration / assignment / display cases across
+      all three archive sub-folders.
+- [x] C2 -- Operators legal on real per LRM 11.3.1 (arithmetic, relational, equality, logical,
+      conditional), plus `**` via the LRM 11.4.3 result-typing rule, plus shortreal <-> real
+      conversion.
+- [x] C3 -- Cross-family conversions: integral -> real treats `'x` / `'z` bits as 0 per LRM 6.12.1;
+      real -> integral rounds half-away-from-zero per LRM 6.12.1 (not truncate).
+- [x] C4 -- LRM-illegal real forms (LRM 6.12 + 11.3.1 / Table 11-1) -- edge event controls,
+      bit-select / part-select, real-indexed bit-select, modulus, bitwise, reduction, shift,
+      wildcard equality, and case equality on real -- diagnose as `diag::Unsupported` with an LRM
+      citation. The slang frontend filters all but case equality (`===` / `!==`) at AST
+      construction; the case-equality path is guarded by `errors/real_case_equality_unsupported`.
 
 ### Cross-references
 
 - LRM 6.12 (Real, shortreal, realtime), 6.12.1 (Conversion), 11.3.1 (Operators with real operands),
-  Table 11-1 (Operators and data types), 11.4.3 (Arithmetic), 11.4.4 (Relational), 11.4.5
-  (Equality), 11.4.7 (Logical), 11.4.11 (Conditional), 21.2 / Table 21-2 (Format specifiers).
+  Table 11-1 (Operators and data types).
 - Archive items: `datatypes/real/{real_types,shortreal_types,realtime_types}`.
-- Display sub-step `display.md` DI3 (`%f` / `%e` / `%g`) lands together with C1.
-- IEEE 754 round-trip widths (17 / 9) keep emitted constants bit-identical across recompile;
-  documented inline in `render_expr.cpp`.
+
+## Structural Initializers
+
+Covers SV LRM 6.8: a static-lifetime variable declaration may carry an initializer expression
+(`int i = 42;`, `real r = 1.5;`, `logic [7:0] l = 8'hAA;`). The LRM requires the initial-value
+assignment to run before any `initial` / `always` procedure starts, which the emitted code satisfies
+by lowering the initializer onto the C++ field declaration.
+
+- [x] SI1 -- Declaration initializers for the integral, enum, real, shortreal, and realtime
+      families. Covers `real_declaration_with_init` (real) plus new cases `int_structural_init`,
+      `bit_structural_init`, `byte_structural_init`, `longint_structural_init`,
+      `logic_structural_init`.
+- [ ] SI2 -- Initializer expressions that read a module parameter (`int i = N * 3;`) or contain a
+      string literal (`string s = "hello";`). Both are surfaced as `diag::Unsupported` today -- the
+      gap is in structural-expression lowering, not in the initializer mechanism, but it blocks the
+      natural parameter-driven init pattern.
+
+### Cross-references
+
+- LRM 6.8 (Variable declarations -- "Setting the initial value of a static variable... shall occur
+  before any initial or always procedures are started"); Table 6-7 (Default initial values, used
+  when no initializer is present, tracked separately under `datatypes/default_init`).

--- a/include/lyra/hir/structural_var.hpp
+++ b/include/lyra/hir/structural_var.hpp
@@ -17,10 +17,6 @@ struct StructuralVarId {
       -> std::strong_ordering = default;
 };
 
-// SV LRM 10.4 + 6.21: structural variable declarations may carry an
-// initializer expression evaluated at construction time (before any process
-// runs). The initializer lives in the enclosing scope's `exprs` table; we
-// reference it by id so the decl stays a flat row alongside other vars.
 struct StructuralVarDecl {
   std::string name;
   TypeId type;

--- a/include/lyra/mir/structural_var.hpp
+++ b/include/lyra/mir/structural_var.hpp
@@ -2,9 +2,11 @@
 
 #include <compare>
 #include <cstdint>
+#include <optional>
 #include <string>
 
-#include "lyra/mir/type.hpp"
+#include "lyra/mir/expr_id.hpp"
+#include "lyra/mir/type_id.hpp"
 
 namespace lyra::mir {
 
@@ -18,6 +20,7 @@ struct StructuralVarId {
 struct StructuralVarDecl {
   std::string name;
   TypeId type;
+  std::optional<ExprId> initializer;
 };
 
 }  // namespace lyra::mir

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -8,6 +8,7 @@
 #include "lyra/backend/cpp/artifact.hpp"
 #include "lyra/backend/cpp/formatting.hpp"
 #include "lyra/backend/cpp/render_context.hpp"
+#include "lyra/backend/cpp/render_expr.hpp"
 #include "lyra/backend/cpp/render_stmt.hpp"
 #include "lyra/backend/cpp/render_type.hpp"
 #include "lyra/backend/cpp/string_literal.hpp"
@@ -24,20 +25,28 @@ namespace lyra::backend::cpp {
 
 namespace {
 
+auto RenderFieldCtorArgs(
+    const RenderContext& ctor_ctx, const mir::StructuralVarDecl& var,
+    const mir::Type& ty) -> diag::Result<std::string> {
+  if (var.initializer.has_value()) {
+    return RenderExpr(ctor_ctx, ctor_ctx.Expr(*var.initializer));
+  }
+  return RenderTypeDefaultCtorArgs(ty);
+}
+
 auto RenderField(
-    const mir::CompilationUnit& unit, const mir::StructuralScope& owner_scope,
-    const mir::StructuralVarDecl& var, std::size_t indent)
-    -> diag::Result<std::string> {
-  auto type_or = RenderTypeAsCpp(unit, owner_scope, var.type);
+    const RenderContext& ctor_ctx, const mir::StructuralVarDecl& var,
+    std::size_t indent) -> diag::Result<std::string> {
+  const auto& unit = ctor_ctx.Unit();
+  auto type_or = RenderTypeAsCpp(unit, ctor_ctx.StructuralScope(), var.type);
   if (!type_or) return std::unexpected(std::move(type_or.error()));
   const auto& ty = unit.GetType(var.type);
   const auto storage_type = IsObservableScalarType(ty)
                                 ? "lyra::runtime::Var<" + *type_or + ">"
                                 : *type_or;
-  // Var<T>'s variadic ctor forwards to T's ctor; raw T uses the same args
-  // directly. Either way the brace-list shape is the same.
-  const auto ctor_args = RenderTypeDefaultCtorArgs(ty);
-  return Indent(indent) + storage_type + " " + var.name + "{" + ctor_args +
+  auto args_or = RenderFieldCtorArgs(ctor_ctx, var, ty);
+  if (!args_or) return std::unexpected(std::move(args_or.error()));
+  return Indent(indent) + storage_type + " " + var.name + "{" + *args_or +
          "};\n";
 }
 
@@ -209,7 +218,7 @@ auto RenderScopeAsClass(
   }
 
   for (const auto& v : s.structural_vars) {
-    auto field_or = RenderField(unit, s, v, indent + 1);
+    auto field_or = RenderField(this_anchor, v, indent + 1);
     if (!field_or) return std::unexpected(std::move(field_or.error()));
     out += *field_or;
   }

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -71,26 +71,6 @@ auto LowerTypeAliasMemberInto(
   return {};
 }
 
-// SV LRM 10.4 + 6.21: a structural variable declaration may carry an
-// initializer (`real a = 1.5;`) that is conceptually evaluated once at time 0
-// before any process runs. Slang exposes the initializer via
-// `VariableSymbol::getInitializer()`; we lower it through the structural
-// expression path (the same path that handles parameter expressions) and
-// attach the resulting ExprId to the var decl. HIR -> MIR turns it into an
-// AssignExpr ExprStmt in the enclosing scope's constructor_scope.
-//
-// For now this path is only taken for real-family-typed vars. Integral-typed
-// structural vars wrap in `Var<PackedArray>`, whose runtime assign goes
-// through `WriteVar(*services_, ...)` -- but `services_` is bound by `Bind()`,
-// which the C++ constructor body precedes, so a naive constructor-body
-// assignment would dereference a null pointer. Integral structural-init
-// support is tracked as a separate gap.
-auto IsRealFamilyType(const hir::Type& ty) -> bool {
-  return ty.Kind() == hir::TypeKind::kReal ||
-         ty.Kind() == hir::TypeKind::kShortReal ||
-         ty.Kind() == hir::TypeKind::kRealTime;
-}
-
 auto LowerVariableMemberInto(
     const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
     ScopeStack& stack, const slang::ast::VariableSymbol& var)
@@ -116,8 +96,7 @@ auto LowerVariableMemberInto(
         "LowerVariableMemberInto: variable declaration produced void type");
   }
   std::optional<hir::ExprId> initializer_id;
-  if (const auto* init = var.getInitializer();
-      init != nullptr && IsRealFamilyType(unit_state.GetType(*type_id_or))) {
+  if (const auto* init = var.getInitializer(); init != nullptr) {
     auto init_or =
         LowerStructuralExpr(unit_facts, unit_state, scope_state, stack, *init);
     if (!init_or) return std::unexpected(std::move(init_or.error()));

--- a/src/lyra/lowering/hir_to_mir/case_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/case_cascade.cpp
@@ -34,8 +34,13 @@ auto AppendCaseSnapshot(
       mir::Expr{
           .data =
               mir::AssignExpr{
-                  .target = mir::Lvalue{mir::ProceduralVarRef{
-                      .hops = mir::ProceduralHops{.value = 0}, .var = sel_var}},
+                  .target =
+                      mir::Lvalue{
+                          .root =
+                              mir::ProceduralVarRef{
+                                  .hops = mir::ProceduralHops{.value = 0},
+                                  .var = sel_var},
+                          .selectors = {}},
                   .value = cond_expr_id},
           .type = sel_type});
   const mir::StmtId sel_assign_stmt_id = wrapper_state.AddStmt(

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -432,69 +432,6 @@ auto LowerGenerateAsStmt(
       gen.data);
 }
 
-// Lowers a single SV LRM 10.4 / 6.21 structural-var time-0 initializer into
-// an `ExprStmt(AssignExpr)` for the enclosing scope's constructor. The
-// returned stmt is added to the constructor's proc-scope by the caller.
-auto LowerStructuralVarInitAsStmt(
-    UnitLoweringState& unit_state,
-    const StructuralScopeLoweringState& scope_state,
-    const hir::StructuralScope& scope,
-    ProceduralScopeLoweringState& proc_scope_state,
-    hir::StructuralVarId hir_var_id, hir::ExprId init_expr_id)
-    -> diag::Result<mir::Stmt> {
-  auto init_or = LowerStructuralExpr(
-      unit_state, scope_state, proc_scope_state, scope,
-      scope.GetExpr(init_expr_id));
-  if (!init_or) return std::unexpected(std::move(init_or.error()));
-  const mir::TypeId mir_type = (*init_or).type;
-  const mir::ExprId rhs_id = proc_scope_state.AddExpr(*std::move(init_or));
-  const mir::StructuralVarRef target =
-      scope_state.TranslateStructuralVar(hir::StructuralHops{0}, hir_var_id);
-  const mir::ExprId assign_id = proc_scope_state.AddExpr(
-      mir::Expr{
-          .data =
-              mir::AssignExpr{
-                  .target = mir::Lvalue{.root = target, .selectors = {}},
-                  .value = rhs_id},
-          .type = mir_type});
-  return mir::Stmt{
-      .label = std::nullopt,
-      .data = mir::ExprStmt{.expr = assign_id},
-      .child_procedural_scopes = {}};
-}
-
-auto LowerConstructor(
-    UnitLoweringState& unit_state,
-    const StructuralScopeLoweringState& scope_state,
-    const hir::StructuralScope& scope,
-    const std::vector<GenerateBindings>& bindings_by_generate)
-    -> diag::Result<mir::ProceduralScope> {
-  ProceduralScopeLoweringState proc_scope_state;
-  for (std::size_t i = 0; i < scope.generates.size(); ++i) {
-    const auto& gen = scope.generates[i];
-    const auto& gen_bindings = bindings_by_generate.at(i);
-    auto stmt = LowerGenerateAsStmt(
-        unit_state, scope_state, scope, gen, gen_bindings, proc_scope_state);
-    if (!stmt) return std::unexpected(std::move(stmt.error()));
-    const mir::StmtId sid = proc_scope_state.AddStmt(*std::move(stmt));
-    proc_scope_state.AddRootStmt(sid);
-  }
-  // Var inits run after generate construction so the structure is fully
-  // realized before any init expression evaluates -- matters when an init
-  // refers to a constructed child object; harmless otherwise.
-  for (std::size_t i = 0; i < scope.structural_vars.size(); ++i) {
-    const auto& hv = scope.structural_vars[i];
-    if (!hv.initializer.has_value()) continue;
-    auto stmt = LowerStructuralVarInitAsStmt(
-        unit_state, scope_state, scope, proc_scope_state,
-        hir::StructuralVarId{static_cast<std::uint32_t>(i)}, *hv.initializer);
-    if (!stmt) return std::unexpected(std::move(stmt.error()));
-    const mir::StmtId sid = proc_scope_state.AddStmt(*std::move(stmt));
-    proc_scope_state.AddRootStmt(sid);
-  }
-  return proc_scope_state.Finish();
-}
-
 auto InstallGenerateOwnedChildScopes(
     UnitLoweringState& unit_state, StructuralScopeLoweringState& scope_state,
     ScopeStack& stack, const hir::StructuralScope& scope)
@@ -524,7 +461,10 @@ auto InstallGenerateOwnedChildScopes(
           spec.is_repeated ? MakeVectorOfOwnedObjectType(unit_state, child_id)
                            : MakeOwnedObjectType(unit_state, child_id);
       const mir::StructuralVarId var_id = scope_state.AddStructuralVar(
-          mir::StructuralVarDecl{.name = companion_name, .type = var_type});
+          mir::StructuralVarDecl{
+              .name = companion_name,
+              .type = var_type,
+              .initializer = std::nullopt});
 
       gen_bindings.by_scope_id.at(spec.scope_id.value) =
           ChildStructuralScopeBinding{.scope_id = child_id, .var_id = var_id};
@@ -567,12 +507,23 @@ auto LowerStructuralScope(
     scope_state.MapLoopVarAsStructuralParam(binding.source_loop_var, mir_id);
   }
 
+  ProceduralScopeLoweringState ctor_scope_state;
   for (std::size_t i = 0; i < scope.structural_vars.size(); ++i) {
     const hir::StructuralVarId hir_id{static_cast<std::uint32_t>(i)};
     const auto& d = scope.structural_vars[i];
+    std::optional<mir::ExprId> mir_init;
+    if (d.initializer.has_value()) {
+      auto init_or = LowerStructuralExpr(
+          unit_state, scope_state, ctor_scope_state, scope,
+          scope.GetExpr(*d.initializer));
+      if (!init_or) return std::unexpected(std::move(init_or.error()));
+      mir_init = ctor_scope_state.AddExpr(*std::move(init_or));
+    }
     const mir::StructuralVarId mir_id = scope_state.AddStructuralVar(
         mir::StructuralVarDecl{
-            .name = d.name, .type = unit_state.TranslateType(d.type)});
+            .name = d.name,
+            .type = unit_state.TranslateType(d.type),
+            .initializer = mir_init});
     scope_state.MapStructuralVar(hir_id, mir_id);
   }
 
@@ -596,9 +547,15 @@ auto LowerStructuralScope(
       InstallGenerateOwnedChildScopes(unit_state, scope_state, stack, scope);
   if (!bindings_r) return std::unexpected(std::move(bindings_r.error()));
 
-  auto ctor_r = LowerConstructor(unit_state, scope_state, scope, *bindings_r);
-  if (!ctor_r) return std::unexpected(std::move(ctor_r.error()));
-  scope_state.SetConstructorScope(*std::move(ctor_r));
+  for (std::size_t i = 0; i < scope.generates.size(); ++i) {
+    auto stmt = LowerGenerateAsStmt(
+        unit_state, scope_state, scope, scope.generates[i], bindings_r->at(i),
+        ctor_scope_state);
+    if (!stmt) return std::unexpected(std::move(stmt.error()));
+    const mir::StmtId sid = ctor_scope_state.AddStmt(*std::move(stmt));
+    ctor_scope_state.AddRootStmt(sid);
+  }
+  scope_state.SetConstructorScope(ctor_scope_state.Finish());
 
   return mir_scope;
 }

--- a/src/lyra/lowering/hir_to_mir/lower_deferred_check.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_deferred_check.cpp
@@ -147,9 +147,13 @@ auto SnapshotPredicate(
       mir::Expr{
           .data =
               mir::AssignExpr{
-                  .target = mir::Lvalue{mir::ProceduralVarRef{
-                      .hops = mir::ProceduralHops{.value = 0},
-                      .var = snap_var}},
+                  .target =
+                      mir::Lvalue{
+                          .root =
+                              mir::ProceduralVarRef{
+                                  .hops = mir::ProceduralHops{.value = 0},
+                                  .var = snap_var},
+                          .selectors = {}},
                   .value = predicate_expr_id},
           .type = predicate_type});
   const mir::StmtId assign_stmt_id = wrapper_state.AddStmt(
@@ -289,14 +293,19 @@ auto BuildUniqueCheckClosure(
                           .rhs = cond_value},
                   .type = int32_type});
     const mir::ExprId assign = AppendExpr(
-        body, mir::Expr{
-                  .data =
-                      mir::AssignExpr{
-                          .target = mir::Lvalue{mir::ProceduralVarRef{
-                              .hops = mir::ProceduralHops{.value = 0},
-                              .var = count_var}},
-                          .value = added},
-                  .type = int32_type});
+        body,
+        mir::Expr{
+            .data =
+                mir::AssignExpr{
+                    .target =
+                        mir::Lvalue{
+                            .root =
+                                mir::ProceduralVarRef{
+                                    .hops = mir::ProceduralHops{.value = 0},
+                                    .var = count_var},
+                            .selectors = {}},
+                    .value = added},
+            .type = int32_type});
     const mir::StmtId step_id = AppendStmt(
         body, mir::Stmt{
                   .label = std::nullopt,

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -636,7 +636,14 @@ class MirDumper {
     Indent();
     for (std::size_t i = 0; i < s.structural_vars.size(); ++i) {
       const auto& v = s.structural_vars[i];
-      Line(std::format("[{}] \"{}\" : {}", i, v.name, FormatVarType(v.type)));
+      std::string init_suffix;
+      if (v.initializer.has_value()) {
+        init_suffix = std::format(" init=Expr[{}]", v.initializer->value);
+      }
+      Line(
+          std::format(
+              "[{}] \"{}\" : {}{}", i, v.name, FormatVarType(v.type),
+              init_suffix));
     }
     Dedent();
 

--- a/tests/cases/cpp/bit_structural_init/case.yaml
+++ b/tests/cases/cpp/bit_structural_init/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.bit_structural_init
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    b: "4'b1010"

--- a/tests/cases/cpp/bit_structural_init/main.sv
+++ b/tests/cases/cpp/bit_structural_init/main.sv
@@ -1,0 +1,3 @@
+module Top;
+  bit [3:0] b = 4'b1010;
+endmodule

--- a/tests/cases/cpp/byte_structural_init/case.yaml
+++ b/tests/cases/cpp/byte_structural_init/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.byte_structural_init
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    by: 100

--- a/tests/cases/cpp/byte_structural_init/main.sv
+++ b/tests/cases/cpp/byte_structural_init/main.sv
@@ -1,0 +1,3 @@
+module Top;
+  byte by = 8'sd100;
+endmodule

--- a/tests/cases/cpp/int_structural_init/case.yaml
+++ b/tests/cases/cpp/int_structural_init/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.int_structural_init
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    i: 42

--- a/tests/cases/cpp/int_structural_init/main.sv
+++ b/tests/cases/cpp/int_structural_init/main.sv
@@ -1,0 +1,3 @@
+module Top;
+  int i = 42;
+endmodule

--- a/tests/cases/cpp/logic_structural_init/case.yaml
+++ b/tests/cases/cpp/logic_structural_init/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.logic_structural_init
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    l: "8'hAA"

--- a/tests/cases/cpp/logic_structural_init/main.sv
+++ b/tests/cases/cpp/logic_structural_init/main.sv
@@ -1,0 +1,3 @@
+module Top;
+  logic [7:0] l = 8'hAA;
+endmodule

--- a/tests/cases/cpp/longint_structural_init/case.yaml
+++ b/tests/cases/cpp/longint_structural_init/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.longint_structural_init
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    l: "64'sd9876543210"

--- a/tests/cases/cpp/longint_structural_init/main.sv
+++ b/tests/cases/cpp/longint_structural_init/main.sv
@@ -1,0 +1,3 @@
+module Top;
+  longint l = 64'sd9876543210;
+endmodule


### PR DESCRIPTION
## Summary

Wires up SV LRM 6.8 declaration initializers end-to-end for integral, enum, real, shortreal, and realtime structural variables (`int i = 42;`, `logic [7:0] l = 8'hAA;`, etc.). The initializer expression is captured at AST -> HIR, threaded through HIR -> MIR onto the var decl, and lowered by cpp emit as the C++ brace-init ctor args on the emitted field. Field initializers run before the C++ constructor body, which itself runs before `Bind()` -- satisfying LRM 6.8's "shall occur before any initial or always procedures are started" with no scheduler involvement.

## Design

`mir::StructuralVarDecl` gains `std::optional<ExprId> initializer`. HIR -> MIR `LowerStructuralScope` owns one constructor-scope state across both var-init and generate lowering, so each MIR var is built with its init in a single `AddStructuralVar` call -- no setter, no post-construction mutation. cpp emit's `RenderField` delegates to one helper for the user-init vs. type-default dispatch and otherwise renders uniformly. Real-family initializers, previously routed through an assignment statement in the constructor body, now ride the same path as integral.

Drive-by: drop three pre-existing `-Wmissing-field-initializers` warnings on `mir::Lvalue` struct-init sites; tick `architecture-reset.md` R7 (the `expect.variables` framework already exists); add the `Progress Docs`, `Comments`, and `Post-edit Context Cleanup` rules to `CLAUDE.local.md` to keep prose-vs-code drift under control.

## Testing

New cpp_run cases assert variable values directly via `expect.variables` (no `$display` wrapper): `int_structural_init`, `bit_structural_init`, `byte_structural_init`, `longint_structural_init`, `logic_structural_init`. Existing `real_declaration_with_init` continues to pass as a regression guard for the real-family path.