### PR TITLE
Add string equality and relational compare

### DIFF
--- a/docs/progress/datatypes.md
+++ b/docs/progress/datatypes.md
@@ -12,9 +12,10 @@ on the current pipeline.
 ## Actionable
 
 Real C1 / C2 / C3 / C4 are complete. Structural-var declaration initializers (SV LRM 6.8) are
-complete for the integral, enum, real, shortreal, and realtime families (SI1 below). Remaining
-families: `datatypes/string`, `datatypes/unpacked`, `datatypes/general`, `datatypes/default_init`,
-`datatypes/representation`.
+complete for the integral, enum, real, shortreal, and realtime families (SI1 below). String SC1
+(declaration with literal initializer plus equality and relational comparison) is complete; SC2
+(concat / replication) and SC3 (methods) remain. Other unfinished families: `datatypes/unpacked`,
+`datatypes/general`, `datatypes/default_init`, `datatypes/representation`.
 
 ## Enum
 
@@ -77,13 +78,42 @@ by lowering the initializer onto the C++ field declaration.
       families. Covers `real_declaration_with_init` (real) plus new cases `int_structural_init`,
       `bit_structural_init`, `byte_structural_init`, `longint_structural_init`,
       `logic_structural_init`.
-- [ ] SI2 -- Initializer expressions that read a module parameter (`int i = N * 3;`) or contain a
-      string literal (`string s = "hello";`). Both are surfaced as `diag::Unsupported` today -- the
-      gap is in structural-expression lowering, not in the initializer mechanism, but it blocks the
-      natural parameter-driven init pattern.
+- [ ] SI2 -- Initializer expressions that read a module parameter (`int i = N * 3;`). Surfaced as
+      `diag::Unsupported` today; the gap is in structural-expression lowering's handling of
+      parameter references, not in the initializer mechanism, but it blocks the natural
+      parameter-driven init pattern. (The string-literal half of this gap was resolved alongside
+      SC1.)
 
 ### Cross-references
 
 - LRM 6.8 (Variable declarations -- "Setting the initial value of a static variable... shall occur
   before any initial or always procedures are started"); Table 6-7 (Default initial values, used
   when no initializer is present, tracked separately under `datatypes/default_init`).
+
+## String
+
+Covers archive item `datatypes/string` (sub-folder `string_concat`). Per LRM 6.16, `string` is a
+dynamic-length sequence of bytes with `""` as the default (LRM Table 6-7) and the operator set in
+LRM Table 6-9: equality, lexicographic comparison, concatenation, replication, indexing, and a
+dedicated method family. String literals carry a bit-vector type by default; the frontend inserts an
+implicit conversion when a literal participates in an expression that involves a `string`-typed
+operand.
+
+- [x] SC1 -- Declaration with literal initializer (`string s = "hello";`), assignment from a string
+      literal, equality (`==`, `!=`), and relational comparison (`<`, `<=`, `>`, `>=`) on
+      string-typed operands. Compare semantics match LRM Table 6-9: equality compares contents;
+      relational uses lexicographic ordering. The literal-vs-literal case keeps the integral path
+      per the LRM exception (no change required -- the frontend preserves bit-vector typing for that
+      case).
+- [ ] SC2 -- Concatenation `{a, b, ...}` and replication `{N{s}}` in string mode (LRM 11.4.12.2):
+      when at least one operand is string-typed the entire expression evaluates to string. Covers
+      archive sub-folder `string_concat`.
+- [ ] SC3 -- Built-in methods listed in LRM 6.16.1 -- 6.16.15: `.len()`, `.substr(i, j)`,
+      `.compare(s)` / `.icompare(s)`, `.toupper()` / `.tolower()`, `.putc(i, c)` / `.getc(i)`, and
+      the numeric conversion family (`.itoa()`, `.hextoa()`, `.atoi()`, `.atohex()`, ...).
+
+### Cross-references
+
+- LRM 6.16 (String data type), Table 6-9 (String operators), 6.16.1 -- 6.16.15 (String methods),
+  Table 6-7 (Default initial values).
+- Archive items: `datatypes/string/{string_concat}`.

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -234,6 +234,34 @@ auto WrapBoolAsResultShape(
       RenderPackedArrayCtorArgs(result_ty.AsIntegralPacked()));
 }
 
+auto RenderBinaryOpString(
+    mir::BinaryOp op, const std::string& lhs, const std::string& rhs,
+    const mir::Type& result_ty) -> diag::Result<std::string> {
+  // LRM 6.16 Table 6-9: equality compares contents; relational ops use
+  // lexicographic ordering (str.compare semantics). std::string's operator==
+  // and operator< match these directly.
+  switch (op) {
+    case mir::BinaryOp::kEquality:
+      return WrapBoolAsResultShape(result_ty, lhs + " == " + rhs);
+    case mir::BinaryOp::kInequality:
+      return WrapBoolAsResultShape(result_ty, lhs + " != " + rhs);
+    case mir::BinaryOp::kLessThan:
+      return WrapBoolAsResultShape(result_ty, lhs + " < " + rhs);
+    case mir::BinaryOp::kLessEqual:
+      return WrapBoolAsResultShape(result_ty, lhs + " <= " + rhs);
+    case mir::BinaryOp::kGreaterThan:
+      return WrapBoolAsResultShape(result_ty, lhs + " > " + rhs);
+    case mir::BinaryOp::kGreaterEqual:
+      return WrapBoolAsResultShape(result_ty, lhs + " >= " + rhs);
+    default:
+      break;
+  }
+  return diag::Unsupported(
+      diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+      "binary operator is not legal on string operands per LRM 6.16",
+      diag::UnsupportedCategory::kFeature);
+}
+
 auto RenderBinaryOpReal(
     mir::BinaryOp op, const std::string& lhs, const std::string& rhs,
     const mir::Type& result_ty) -> diag::Result<std::string> {
@@ -431,12 +459,18 @@ auto RenderBinaryExpr(
   auto rhs_or = RenderExpr(ctx, rhs_expr);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   // Slang inserts a propagated `ConversionExpr` on the narrower operand so by
-  // the time we reach a binary op both sides are the same real precision. If
-  // either side is real-family, dispatch to the real renderer.
-  const bool is_real = IsRealFamilyType(ctx.Unit().GetType(lhs_expr.type)) ||
-                       IsRealFamilyType(ctx.Unit().GetType(rhs_expr.type));
-  if (is_real) {
+  // the time we reach a binary op both sides share a precision class. Dispatch
+  // by operand kind: real-family (LRM 11.3.1), string (LRM 6.16 Table 6-9),
+  // else integral PackedArray ops.
+  const auto& lhs_ty = ctx.Unit().GetType(lhs_expr.type);
+  const auto& rhs_ty = ctx.Unit().GetType(rhs_expr.type);
+  if (IsRealFamilyType(lhs_ty) || IsRealFamilyType(rhs_ty)) {
     return RenderBinaryOpReal(
+        b.op, *lhs_or, *rhs_or, ctx.Unit().GetType(expr.type));
+  }
+  if (lhs_ty.Kind() == mir::TypeKind::kString &&
+      rhs_ty.Kind() == mir::TypeKind::kString) {
+    return RenderBinaryOpString(
         b.op, *lhs_or, *rhs_or, ctx.Unit().GetType(expr.type));
   }
   return RenderBinaryOpIntegral(b.op, *lhs_or, *rhs_or);

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -40,7 +40,6 @@
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
-#include "lyra/lowering/ast_to_hir/type.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::ast_to_hir {
@@ -1184,6 +1183,13 @@ auto LowerStructuralExpr(
       auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return MakeRealLiteralExpr(rl.getValue(), *type_id, span);
+    }
+
+    case slang::ast::ExpressionKind::StringLiteral: {
+      const auto& sl = expr.as<slang::ast::StringLiteral>();
+      auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return MakeStringLiteralExpr(std::string{sl.getValue()}, *type_id, span);
     }
 
     case slang::ast::ExpressionKind::NamedValue:

--- a/tests/cases/cpp/string_compare_empty/case.yaml
+++ b/tests/cases/cpp/string_compare_empty/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_compare_empty
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 1

--- a/tests/cases/cpp/string_compare_empty/main.sv
+++ b/tests/cases/cpp/string_compare_empty/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  string a;
+  string b;
+  bit r;
+
+  initial begin
+    a = "";
+    b = "x";
+    r = (a < b);
+  end
+endmodule

--- a/tests/cases/cpp/string_eq_in_if/case.yaml
+++ b/tests/cases/cpp/string_eq_in_if/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_eq_in_if
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 1

--- a/tests/cases/cpp/string_eq_in_if/main.sv
+++ b/tests/cases/cpp/string_eq_in_if/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  string s;
+  bit r;
+
+  initial begin
+    s = "hi";
+    if (s == "hi") r = 1;
+  end
+endmodule

--- a/tests/cases/cpp/string_eq_var_literal/case.yaml
+++ b/tests/cases/cpp/string_eq_var_literal/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_eq_var_literal
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 1

--- a/tests/cases/cpp/string_eq_var_literal/main.sv
+++ b/tests/cases/cpp/string_eq_var_literal/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  string a;
+  bit r;
+
+  initial begin
+    a = "hi";
+    r = (a == "hi");
+  end
+endmodule

--- a/tests/cases/cpp/string_eq_var_var/case.yaml
+++ b/tests/cases/cpp/string_eq_var_var/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_eq_var_var
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 1

--- a/tests/cases/cpp/string_eq_var_var/main.sv
+++ b/tests/cases/cpp/string_eq_var_var/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  string a;
+  string b;
+  bit r;
+
+  initial begin
+    a = "foo";
+    b = "foo";
+    r = (a == b);
+  end
+endmodule

--- a/tests/cases/cpp/string_ge_equal/case.yaml
+++ b/tests/cases/cpp/string_ge_equal/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_ge_equal
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 1

--- a/tests/cases/cpp/string_ge_equal/main.sv
+++ b/tests/cases/cpp/string_ge_equal/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  string a;
+  bit r;
+
+  initial begin
+    a = "x";
+    r = (a >= "x");
+  end
+endmodule

--- a/tests/cases/cpp/string_lt_lexical/case.yaml
+++ b/tests/cases/cpp/string_lt_lexical/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_lt_lexical
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 1

--- a/tests/cases/cpp/string_lt_lexical/main.sv
+++ b/tests/cases/cpp/string_lt_lexical/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  string a;
+  string b;
+  bit r;
+
+  initial begin
+    a = "abc";
+    b = "abd";
+    r = (a < b);
+  end
+endmodule

--- a/tests/cases/cpp/string_lt_prefix/case.yaml
+++ b/tests/cases/cpp/string_lt_prefix/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_lt_prefix
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 1

--- a/tests/cases/cpp/string_lt_prefix/main.sv
+++ b/tests/cases/cpp/string_lt_prefix/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  string a;
+  string b;
+  bit r;
+
+  initial begin
+    a = "ab";
+    b = "abc";
+    r = (a < b);
+  end
+endmodule

--- a/tests/cases/cpp/string_neq/case.yaml
+++ b/tests/cases/cpp/string_neq/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_neq
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 1

--- a/tests/cases/cpp/string_neq/main.sv
+++ b/tests/cases/cpp/string_neq/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  string a;
+  string b;
+  bit r;
+
+  initial begin
+    a = "foo";
+    b = "bar";
+    r = (a != b);
+  end
+endmodule

--- a/tests/cases/cpp/string_structural_init/case.yaml
+++ b/tests/cases/cpp/string_structural_init/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_structural_init
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s: "hello"

--- a/tests/cases/cpp/string_structural_init/main.sv
+++ b/tests/cases/cpp/string_structural_init/main.sv
@@ -1,0 +1,3 @@
+module Top;
+  string s = "hello";
+endmodule

--- a/tests/cases/cpp/string_structural_init_empty/case.yaml
+++ b/tests/cases/cpp/string_structural_init_empty/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_structural_init_empty
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s: ""

--- a/tests/cases/cpp/string_structural_init_empty/main.sv
+++ b/tests/cases/cpp/string_structural_init_empty/main.sv
@@ -1,0 +1,3 @@
+module Top;
+  string s = "";
+endmodule


### PR DESCRIPTION
## Summary

Adds string-typed `==`, `!=`, `<`, `<=`, `>`, `>=` comparison and lets `string s = "hello";` work at structural scope, closing SC1 in `docs/progress/datatypes.md`. The frontend already inserts the implicit conversion from string literals to `string`-typed operands per LRM 6.16; the cpp backend's binary-op dispatch now recognises a third operand class (string) alongside real-family and integral, mapping the six comparison operators onto `std::string`'s native operators and wrapping the bool result into the 1-bit PackedArray shape callers expect. Structural-expression lowering grows the missing `StringLiteral` arm so the same lowering path handles initializers like `string s = "hello";`. The literal-vs-literal case (`"foo" == "bar"`) keeps the integral path because the frontend preserves bit-vector typing for that case, matching LRM Table 6-9's exception.

## Testing

Ten new `cpp_run` cases assert string equality, inequality, lexicographic comparison (including prefix and empty-string edges), comparison inside an `if`, and structural-scope declaration initializers (both `"hello"` and `""`). All ten previously failed at either structural lowering or C++ compile (raw `bool` vs `Var<PackedArray>` mismatch); they pass after this change. Full `bazel test //...` is green.