### PR TITLE
Add string-mode concatenation and replication

### DIFF
--- a/docs/progress/datatypes.md
+++ b/docs/progress/datatypes.md
@@ -13,9 +13,9 @@ on the current pipeline.
 
 Real C1 / C2 / C3 / C4 are complete. Structural-var declaration initializers (SV LRM 6.8) are
 complete for the integral, enum, real, shortreal, and realtime families (SI1 below). String SC1
-(declaration with literal initializer plus equality and relational comparison) is complete; SC2
-(concat / replication) and SC3 (methods) remain. Other unfinished families: `datatypes/unpacked`,
-`datatypes/general`, `datatypes/default_init`, `datatypes/representation`.
+(declaration with literal initializer plus equality and relational comparison) and SC2 (string-mode
+concatenation and replication) are complete; SC3 (methods) remains. Other unfinished families:
+`datatypes/unpacked`, `datatypes/general`, `datatypes/default_init`, `datatypes/representation`.
 
 ## Enum
 
@@ -105,9 +105,13 @@ operand.
       relational uses lexicographic ordering. The literal-vs-literal case keeps the integral path
       per the LRM exception (no change required -- the frontend preserves bit-vector typing for that
       case).
-- [ ] SC2 -- Concatenation `{a, b, ...}` and replication `{N{s}}` in string mode (LRM 11.4.12.2):
-      when at least one operand is string-typed the entire expression evaluates to string. Covers
-      archive sub-folder `string_concat`.
+- [x] SC2 -- Concatenation `{a, b, ...}` and replication `{N{s}}` in string mode (LRM 11.4.12.2):
+      when the result type is `string` the entire expression evaluates to string. Replication
+      accepts a non-constant multiplier (LRM allows this for string mode), and a zero multiplier
+      yields the empty string. The literal-only form (`{"foo", "bar"}` where the frontend keeps the
+      integral result type and inserts an outer string conversion) is gated separately and stays
+      blocked behind `operators/concat` (integral-mode concatenation) plus the bit-vector-to-string
+      conversion path.
 - [ ] SC3 -- Built-in methods listed in LRM 6.16.1 -- 6.16.15: `.len()`, `.substr(i, j)`,
       `.compare(s)` / `.icompare(s)`, `.toupper()` / `.tolower()`, `.putc(i, c)` / `.getc(i)`, and
       the numeric conversion family (`.itoa()`, `.hextoa()`, `.atoi()`, `.atohex()`, ...).

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -75,9 +75,21 @@ struct RangeSelectExpr {
   RangeBounds bounds;
 };
 
+struct ConcatExpr {
+  std::vector<ExprId> operands;
+};
+
+// LRM 11.4.12 / 11.4.12.2: `{multiplier{...}}` is a replication built around
+// an inner concatenation. The inner ExprId always points to a ConcatExpr.
+struct ReplicationExpr {
+  ExprId count;
+  ExprId concat;
+};
+
 using ExprData = std::variant<
     PrimaryExpr, UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr, CallExpr,
-    ConversionExpr, InsideExpr, ElementSelectExpr, RangeSelectExpr>;
+    ConversionExpr, InsideExpr, ElementSelectExpr, RangeSelectExpr, ConcatExpr,
+    ReplicationExpr>;
 
 struct Expr {
   TypeId type;

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -100,11 +100,22 @@ struct RangeSelectExpr {
   RangeBounds bounds;
 };
 
+struct ConcatExpr {
+  std::vector<ExprId> operands;
+};
+
+// LRM 11.4.12 / 11.4.12.2: `{multiplier{...}}`. `concat` always points to a
+// ConcatExpr; mirrors the hir::ReplicationExpr shape.
+struct ReplicationExpr {
+  ExprId count;
+  ExprId concat;
+};
+
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, StructuralParamRef,
     StructuralVarRef, ProceduralVarRef, UnaryExpr, BinaryExpr, ConditionalExpr,
     AssignExpr, CallExpr, RuntimeCallExpr, ConversionExpr, ClosureExpr,
-    ElementSelectExpr, RangeSelectExpr>;
+    ElementSelectExpr, RangeSelectExpr, ConcatExpr, ReplicationExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/value/string_op.hpp
+++ b/include/lyra/value/string_op.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace lyra::value {
+
+// LRM 11.4.12.2: when at least one inner operand is string-typed or the
+// multiplier is non-constant, `{multiplier{...}}` shall yield M concatenated
+// copies of the inner concatenation. A multiplier of zero yields the empty
+// string. The multiplier is unsigned in SystemVerilog; we still accept signed
+// here and treat negative as zero for defence-in-depth.
+inline auto ReplicateString(std::string_view operand, std::int64_t count)
+    -> std::string {
+  if (count <= 0) return {};
+  std::string out;
+  out.reserve(operand.size() * static_cast<std::size_t>(count));
+  for (std::int64_t i = 0; i < count; ++i) {
+    out.append(operand);
+  }
+  return out;
+}
+
+}  // namespace lyra::value

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -280,6 +280,7 @@ auto RenderScopeHeaderFile(
   out += "#include \"lyra/value/packed_bitwise.hpp\"\n";
   out += "#include \"lyra/value/packed_convert.hpp\"\n";
   out += "#include \"lyra/value/packed_reduction.hpp\"\n";
+  out += "#include \"lyra/value/string_op.hpp\"\n";
   out += "\n";
   bool any_enum = false;
   for (std::size_t i = 0; i < unit.types.size(); ++i) {

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -962,6 +962,44 @@ auto RenderClosureExpr(
   return "[" + captures_text + "]() {\n" + *body_or + "}";
 }
 
+auto RenderConcatExpr(const RenderContext& ctx, const mir::ConcatExpr& c)
+    -> diag::Result<std::string> {
+  // SC2 guarantee: lowering rejects integral-mode concatenation, so by the
+  // time we reach the renderer every operand is std::string-typed and
+  // operator+ over std::string matches LRM 6.16 Table 6-9 contents-join.
+  if (c.operands.empty()) {
+    throw InternalError("RenderConcatExpr: hir lowering produced empty concat");
+  }
+  std::string out = "(";
+  for (std::size_t i = 0; i < c.operands.size(); ++i) {
+    auto rendered = RenderExpr(ctx, ctx.Expr(c.operands[i]));
+    if (!rendered) return std::unexpected(std::move(rendered.error()));
+    if (i != 0) out += " + ";
+    out += *rendered;
+  }
+  out += ")";
+  return out;
+}
+
+auto RenderReplicationExpr(
+    const RenderContext& ctx, const mir::ReplicationExpr& r)
+    -> diag::Result<std::string> {
+  auto count = RenderExpr(ctx, ctx.Expr(r.count));
+  if (!count) return std::unexpected(std::move(count.error()));
+  auto concat = RenderExpr(ctx, ctx.Expr(r.concat));
+  if (!concat) return std::unexpected(std::move(concat.error()));
+  // The count operand is a SystemVerilog integral expression; the runtime
+  // helper takes int64_t. Convert via PackedArray::ToInt() if needed; for
+  // simple int/byte etc. that already render as PackedArray values, the .To*
+  // accessor handles it.
+  const auto& count_ty = ctx.Unit().GetType(ctx.Expr(r.count).type);
+  std::string count_text = count_ty.IsIntegralPacked()
+                               ? std::format("({}).ToInt64()", *count)
+                               : *count;
+  return std::format(
+      "lyra::value::ReplicateString({}, {})", *concat, count_text);
+}
+
 }  // namespace
 
 auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
@@ -1021,6 +1059,12 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
           },
           [&](const mir::RangeSelectExpr& sel) -> diag::Result<std::string> {
             return RenderRangeSelectExpr(ctx, expr, sel);
+          },
+          [&](const mir::ConcatExpr& c) -> diag::Result<std::string> {
+            return RenderConcatExpr(ctx, c);
+          },
+          [&](const mir::ReplicationExpr& r) -> diag::Result<std::string> {
+            return RenderReplicationExpr(ctx, r);
           },
       },
       expr.data);

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -660,6 +660,21 @@ class HirDumper {
                   },
                   sel.bounds);
             },
+            [](const ConcatExpr& c) -> std::string {
+              std::string operands;
+              for (std::size_t i = 0; i < c.operands.size(); ++i) {
+                if (i != 0) {
+                  operands += ", ";
+                }
+                operands += std::format("Expr[{}]", c.operands[i].value);
+              }
+              return std::format("ConcatExpr operands=[{}]", operands);
+            },
+            [](const ReplicationExpr& r) -> std::string {
+              return std::format(
+                  "ReplicationExpr count=Expr[{}] concat=Expr[{}]",
+                  r.count.value, r.concat.value);
+            },
         },
         e.data);
     return std::format("type=Type[{}] {}", e.type.value, formatted);

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -916,6 +916,66 @@ auto LowerRangeSelectExprProc(
   };
 }
 
+auto LowerConcatExprProc(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const slang::ast::ConcatenationExpression& cc,
+    const slang::ast::Expression& expr, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  if (unit_state.GetType(*type_id).Kind() != hir::TypeKind::kString) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "integral-mode concatenation is not yet supported (LRM 11.4.12); "
+        "see operators/concat",
+        diag::UnsupportedCategory::kOperation);
+  }
+  std::vector<hir::ExprId> operand_ids;
+  operand_ids.reserve(cc.operands().size());
+  for (const auto* op : cc.operands()) {
+    auto operand_or =
+        LowerProcExpr(unit_facts, unit_state, proc_state, stack, *op, {});
+    if (!operand_or) return std::unexpected(std::move(operand_or.error()));
+    operand_ids.push_back(proc_state.AddExpr(*std::move(operand_or)));
+  }
+  return hir::Expr{
+      .type = *type_id,
+      .data = hir::ConcatExpr{.operands = std::move(operand_ids)},
+      .span = span,
+  };
+}
+
+auto LowerReplicationExprProc(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const slang::ast::ReplicationExpression& rp,
+    const slang::ast::Expression& expr, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  if (unit_state.GetType(*type_id).Kind() != hir::TypeKind::kString) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "integral-mode replication is not yet supported (LRM 11.4.12.1); "
+        "see operators/replicate",
+        diag::UnsupportedCategory::kOperation);
+  }
+  auto count_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, rp.count(), {});
+  if (!count_or) return std::unexpected(std::move(count_or.error()));
+  const hir::ExprId count_id = proc_state.AddExpr(*std::move(count_or));
+  auto concat_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, rp.concat(), {});
+  if (!concat_or) return std::unexpected(std::move(concat_or.error()));
+  const hir::ExprId concat_id = proc_state.AddExpr(*std::move(concat_or));
+  return hir::Expr{
+      .type = *type_id,
+      .data = hir::ReplicationExpr{.count = count_id, .concat = concat_id},
+      .span = span,
+  };
+}
+
 auto LowerConversionExprStructural(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ScopeLoweringState& scope_state, const ScopeStack& stack,
@@ -1145,6 +1205,16 @@ auto LowerProcExpr(
       return LowerRangeSelectExprProc(
           unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
           expr.as<slang::ast::RangeSelectExpression>(), expr, span);
+
+    case slang::ast::ExpressionKind::Concatenation:
+      return LowerConcatExprProc(
+          unit_facts, unit_state, proc_state, stack,
+          expr.as<slang::ast::ConcatenationExpression>(), expr, span);
+
+    case slang::ast::ExpressionKind::Replication:
+      return LowerReplicationExprProc(
+          unit_facts, unit_state, proc_state, stack,
+          expr.as<slang::ast::ReplicationExpression>(), expr, span);
 
     default:
       return diag::Unsupported(

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -962,6 +962,49 @@ auto LowerHirRangeSelectExprProc(
       .type = result_type};
 }
 
+auto LowerHirConcatExprProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, const hir::ConcatExpr& c,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  std::vector<mir::ExprId> operand_ids;
+  operand_ids.reserve(c.operands.size());
+  for (const auto& id : c.operands) {
+    auto lowered = LowerExpr(
+        unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+        hir_process.exprs.at(id.value));
+    if (!lowered) return std::unexpected(std::move(lowered.error()));
+    operand_ids.push_back(proc_scope_state.AddExpr(*std::move(lowered)));
+  }
+  return mir::Expr{
+      .data = mir::ConcatExpr{.operands = std::move(operand_ids)},
+      .type = result_type};
+}
+
+auto LowerHirReplicationExprProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, const hir::ReplicationExpr& r,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  auto count_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(r.count.value));
+  if (!count_or) return std::unexpected(std::move(count_or.error()));
+  const mir::ExprId count_id = proc_scope_state.AddExpr(*std::move(count_or));
+  auto concat_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(r.concat.value));
+  if (!concat_or) return std::unexpected(std::move(concat_or.error()));
+  const mir::ExprId concat_id = proc_scope_state.AddExpr(*std::move(concat_or));
+  return mir::Expr{
+      .data = mir::ReplicationExpr{.count = count_id, .concat = concat_id},
+      .type = result_type};
+}
+
 }  // namespace
 
 auto LowerExpr(
@@ -1022,6 +1065,16 @@ auto LowerExpr(
             return LowerHirRangeSelectExprProc(
                 unit_state, scope_state, proc_state, proc_scope_state,
                 hir_process, sel, result_type);
+          },
+          [&](const hir::ConcatExpr& c) -> diag::Result<mir::Expr> {
+            return LowerHirConcatExprProc(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, c, result_type);
+          },
+          [&](const hir::ReplicationExpr& r) -> diag::Result<mir::Expr> {
+            return LowerHirReplicationExprProc(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, r, result_type);
           },
       },
       expr.data);
@@ -1202,6 +1255,18 @@ auto LowerExprImpl(
             return diag::Unsupported(
                 diag::DiagCode::kUnsupportedStructuralExpressionForm,
                 "range-select in constructor expressions is not yet supported",
+                diag::UnsupportedCategory::kFeature);
+          },
+          [](const hir::ConcatExpr&) -> diag::Result<mir::Expr> {
+            return diag::Unsupported(
+                diag::DiagCode::kUnsupportedStructuralExpressionForm,
+                "concatenation in constructor expressions is not yet supported",
+                diag::UnsupportedCategory::kFeature);
+          },
+          [](const hir::ReplicationExpr&) -> diag::Result<mir::Expr> {
+            return diag::Unsupported(
+                diag::DiagCode::kUnsupportedStructuralExpressionForm,
+                "replication in constructor expressions is not yet supported",
                 diag::UnsupportedCategory::kFeature);
           },
       },

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -588,6 +588,21 @@ class MirDumper {
                   "RangeSelectExpr base=Expr[{}] {}", sel.base_value.value,
                   bounds);
             },
+            [](const ConcatExpr& c) -> std::string {
+              std::string operands;
+              for (std::size_t i = 0; i < c.operands.size(); ++i) {
+                if (i != 0) {
+                  operands += ", ";
+                }
+                operands += std::format("Expr[{}]", c.operands[i].value);
+              }
+              return std::format("ConcatExpr operands=[{}]", operands);
+            },
+            [](const ReplicationExpr& r) -> std::string {
+              return std::format(
+                  "ReplicationExpr count=Expr[{}] concat=Expr[{}]",
+                  r.count.value, r.concat.value);
+            },
         },
         e.data);
     return std::format("{} type=Type[{}]", formatted, e.type.value);

--- a/tests/cases/cpp/string_concat_empty_string/case.yaml
+++ b/tests/cases/cpp/string_concat_empty_string/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_concat_empty_string
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s: "prefixsuffix"

--- a/tests/cases/cpp/string_concat_empty_string/main.sv
+++ b/tests/cases/cpp/string_concat_empty_string/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  string empty;
+  string s;
+
+  initial begin
+    empty = "";
+    s = {"prefix", empty, "suffix"};
+  end
+endmodule

--- a/tests/cases/cpp/string_concat_multiple/case.yaml
+++ b/tests/cases/cpp/string_concat_multiple/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_concat_multiple
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s: "one-two-three"

--- a/tests/cases/cpp/string_concat_multiple/main.sv
+++ b/tests/cases/cpp/string_concat_multiple/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  string a;
+  string b;
+  string c;
+  string s;
+
+  initial begin
+    a = "one";
+    b = "two";
+    c = "three";
+    s = {a, "-", b, "-", c};
+  end
+endmodule

--- a/tests/cases/cpp/string_concat_nested/case.yaml
+++ b/tests/cases/cpp/string_concat_nested/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_concat_nested
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s: "a-b-c-d"

--- a/tests/cases/cpp/string_concat_nested/main.sv
+++ b/tests/cases/cpp/string_concat_nested/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  string a;
+  string b;
+  string c;
+  string d;
+  string inner;
+  string s;
+
+  initial begin
+    a = "a";
+    b = "b";
+    c = "c";
+    d = "d";
+    inner = {b, "-", c};
+    s = {a, "-", inner, "-", d};
+  end
+endmodule

--- a/tests/cases/cpp/string_concat_var_literal/case.yaml
+++ b/tests/cases/cpp/string_concat_var_literal/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_concat_var_literal
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s: "hi there"

--- a/tests/cases/cpp/string_concat_var_literal/main.sv
+++ b/tests/cases/cpp/string_concat_var_literal/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  string a;
+  string s;
+
+  initial begin
+    a = "hi";
+    s = {a, " there"};
+  end
+endmodule

--- a/tests/cases/cpp/string_concat_var_var/case.yaml
+++ b/tests/cases/cpp/string_concat_var_var/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_concat_var_var
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s: "hello world"

--- a/tests/cases/cpp/string_concat_var_var/main.sv
+++ b/tests/cases/cpp/string_concat_var_var/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  string a;
+  string b;
+  string s;
+
+  initial begin
+    a = "hello";
+    b = " world";
+    s = {a, b};
+  end
+endmodule

--- a/tests/cases/cpp/string_replicate_concat_inside/case.yaml
+++ b/tests/cases/cpp/string_replicate_concat_inside/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_replicate_concat_inside
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s: "abababab"

--- a/tests/cases/cpp/string_replicate_concat_inside/main.sv
+++ b/tests/cases/cpp/string_replicate_concat_inside/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  string a;
+  string b;
+  string s;
+
+  initial begin
+    a = "a";
+    b = "b";
+    s = {4{a, b}};
+  end
+endmodule

--- a/tests/cases/cpp/string_replicate_const/case.yaml
+++ b/tests/cases/cpp/string_replicate_const/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_replicate_const
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s: "abcabcabc"

--- a/tests/cases/cpp/string_replicate_const/main.sv
+++ b/tests/cases/cpp/string_replicate_const/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  string base;
+  string s;
+
+  initial begin
+    base = "abc";
+    s = {3{base}};
+  end
+endmodule

--- a/tests/cases/cpp/string_replicate_one/case.yaml
+++ b/tests/cases/cpp/string_replicate_one/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_replicate_one
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s: "hello"

--- a/tests/cases/cpp/string_replicate_one/main.sv
+++ b/tests/cases/cpp/string_replicate_one/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  string base;
+  int n;
+  string s;
+
+  initial begin
+    base = "hello";
+    n = 1;
+    s = {n{base}};
+  end
+endmodule

--- a/tests/cases/cpp/string_replicate_runtime/case.yaml
+++ b/tests/cases/cpp/string_replicate_runtime/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_replicate_runtime
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s: "xyxyxyxy"

--- a/tests/cases/cpp/string_replicate_runtime/main.sv
+++ b/tests/cases/cpp/string_replicate_runtime/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  string base;
+  int n;
+  string s;
+
+  initial begin
+    base = "xy";
+    n = 4;
+    s = {n{base}};
+  end
+endmodule

--- a/tests/cases/cpp/string_replicate_zero/case.yaml
+++ b/tests/cases/cpp/string_replicate_zero/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_replicate_zero
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s: ""

--- a/tests/cases/cpp/string_replicate_zero/main.sv
+++ b/tests/cases/cpp/string_replicate_zero/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  string base;
+  int n;
+  string s;
+
+  initial begin
+    base = "hello";
+    n = 0;
+    s = {n{base}};
+  end
+endmodule

--- a/tests/cases/errors/string_concat_integral_mode_unsupported/case.yaml
+++ b/tests/cases/errors/string_concat_integral_mode_unsupported/case.yaml
@@ -1,0 +1,13 @@
+id: errors.string_concat_integral_mode_unsupported
+tags: [errors]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "integral-mode concatenation"

--- a/tests/cases/errors/string_concat_integral_mode_unsupported/main.sv
+++ b/tests/cases/errors/string_concat_integral_mode_unsupported/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  bit [15:0] joined;
+
+  initial begin
+    joined = {8'hAB, 8'hCD};
+  end
+endmodule

--- a/tests/cases/errors/unsupported_expr/case.yaml
+++ b/tests/cases/errors/unsupported_expr/case.yaml
@@ -12,6 +12,6 @@ expect:
     contains:
       - "main.sv:4:"
       - "unsupported:"
-      - "this expression form is not supported yet"
+      - "integral-mode concatenation is not yet supported"
     not_contains:
       - "internal error"


### PR DESCRIPTION
## Summary

Adds string-mode `{a, b, ...}` and `{N{s}}` per LRM 6.16 Table 6-9 / 11.4.12.2. Both forms get new `ConcatExpr` and `ReplicationExpr` nodes in HIR and MIR, with a 1-1 lowering through the pipeline. Replication wraps its inner concatenation as a dedicated child, mirroring slang's AST shape so the lowering stays a structural rewrite.

The cpp backend renders concat as `(a + b + ...)` over `std::string` and replication via a new `lyra::value::ReplicateString` helper in `include/lyra/value/string_op.hpp`. Non-constant multipliers are allowed (LRM permits them in string mode) and a zero multiplier yields the empty string.

Scope is strictly the cases slang gives us as `Concatenation`/`Replication` of result type `string`. The literal-only form (`{"foo", "bar"}` where the frontend keeps an integral result type and wraps it in an outer string conversion) is rejected with a `diag::Unsupported` that points at the existing `operators/concat` workstream; that path needs integral-mode concatenation plus a bit-vector-to-string conversion lowering, neither of which belongs in SC2.

## Testing

Ten new `cpp_run` cases under `tests/cases/cpp/string_{concat,replicate}_*` cover variable-only concat, mixed variable/literal concat, multi-operand concat, empty-string operand, nested concat, constant / runtime / zero / one multipliers, and a `{N{a, b}}` replication-of-concat. One `errors/` case pins the unsupported integral-mode message. The existing `errors/unsupported_expr` case is updated because its `{1'b1, 1'b0}` example now reaches the more specific integral-mode rejection rather than the generic "expression form not supported" branch.

Full `bazel test //...` is green.