### PR TITLE
Add compound assignment with native op= emit

### DIFF
--- a/docs/progress/dev-ergonomics.md
+++ b/docs/progress/dev-ergonomics.md
@@ -1,0 +1,43 @@
+# Dev Ergonomics
+
+Tracks gaps in the developer feedback loop -- the things that slow down "I see weird behavior in one
+.sv file, I want to understand why". The pipeline today is HIR -> MIR -> C++ emit -> compile -> run,
+and the last two stages are buried inside the bazel test harness, so isolated debugging falls back
+on test-shaped YAML files plus a missing manual build recipe. Each item below is a single PR-sized
+change that pulls one of those hidden seams out into a first-class tool.
+
+The work is "done" when a developer can take a single `.sv` file, observe a divergence between Lyra
+and Verilator, and pinpoint the divergent IR layer without writing a YAML stanza.
+
+## Sub-Steps
+
+- [ ] D1 -- Restore `lyra run` with a backend selector. The archive's `lyra run` was the canonical
+      "go from .sv to executed simulation" command (`archived/docs/cli-design.md`), defaulting to
+      AOT and accepting `--backend=jit` for the dev path. The C++ pipeline that exists today on this
+      branch is exposed only as `emit cpp`, which leaves the user to compile + run the artifact
+      themselves. Re-introduce `run` as the project's primary execute command and make the existing
+      C++ pipeline a `--backend=cpp` choice (alongside the AOT / JIT backends that will return when
+      LLVM work resumes -- see `architecture-reset.md` R3 / R4). `lyra run` should accept the same
+      project / file inputs the dump and emit commands already take, and should stream stdout /
+      stderr through. The deliverable removes the "no command runs a .sv file" gap that pushes
+      developers toward ad-hoc YAML test cases.
+
+- [ ] D4 -- Self-contained build recipe for `emit cpp` output. `playground/out/main.cpp` is not
+      directly buildable today: `CMakePresets.json` was removed, and a hand-written `clang++`
+      invocation against `include/` fails because the emitted code transitively includes abseil
+      headers that are only reachable via bazel. The cleanest fix is for `emit cpp` itself to emit
+      the build system alongside the C++ -- a minimal `CMakeLists.txt` (or `Makefile`) that lists
+      the runtime include roots, links against the runtime static library, and produces a runnable
+      binary. The user runs one documented command (`cmake --build` or `make`) and gets
+      `playground/out/program`. The emitter is the right home for this because only it knows which
+      runtime headers the artifact actually pulls in. Once D1 lands and `lyra run` internalizes the
+      same recipe, D4's value is mostly "the C++ artifact is portable on its own" -- a developer can
+      hand the `out/` directory to someone else and they can build it.
+
+## Out of Scope
+
+- New SystemVerilog feature coverage. This file tracks the developer feedback loop, not language
+  features.
+- Verilator-side tooling. Comparison workflows that drive both Lyra and Verilator are a separate
+  workstream.
+- Performance instrumentation. `docs/profiling.md` already documents the callgrind workflow.

--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -335,16 +335,27 @@ closure stays a single lambda -- there is no nested mutation lambda.
 
 ### Assignment families
 
-- [ ] W11 -- Compound assignment `+= -= *= /= %= &= |= ^= <<= >>= <<<= >>>=`. Add
-      `hir::CompoundAssignStmt { Lvalue target; BinaryOp op; ExprId rhs }`. HIR -> MIR snapshots
-      every index expression in `target` into fresh procedural temps before the read-modify-write so
-      the target lvalue evaluates exactly once (LRM 11.4.1). Covers `arr[i++] += x` and
-      partial-target shapes such as `data[i+:4] |= v` through the W6 selector chain.
+- [x] W11 -- Compound assignment `+= -= *= /= %= &= |= ^= <<= >>= <<<= >>>=`. Compound stays as
+      compound through HIR and MIR: `AssignExpr` carries an `optional<BinaryOp> compound_op` field
+      that is `nullopt` for a simple `=` and set for `op=`. Slang's expanded
+      `BinaryOp(LValueRef,     user_rhs)` tree is consumed at AST -> HIR -- the helper extracts the
+      user-written rhs from the side that does not wrap `LValueReference`, then re-types it to the
+      lhs type so the runtime stays at one shape (slang's per-operand promotion Conversions become
+      elaboration artifacts that lowering does not reproduce). C++ emit produces `<chain> op= rhs`
+      directly: `PackedArray`, `PackedArrayRef`, and `ScopedMutation<PackedArray>` each overload the
+      arithmetic / bitwise compounds as `operator+=` etc., and the three shifts as `ShiftLeftAssign`
+      / `LogicalShiftRightAssign` / `ArithmeticShiftRightAssign`. The LRM 11.4.1 "evaluate target
+      only once" rule falls out of the C++ standard's eval-once rule on the compound assignment
+      expression; no HIR-level snapshot pass is needed. NBA + compound is rejected at slang parsing
+      (LRM A.6.2); InternalError catches grammar drift. Closes `operators/compound_assignment` for
+      whole-var, selector, and mixed-state target shapes (`x += y`, `x[7:4] |= v`, `x[i +: 4] += k`,
+      `int %= logic[3:0]`).
 
 - [ ] W12 -- `++` / `--` (prefix and postfix). Add `hir::IncrDecrStmt` and `hir::IncrDecrExpr`
-      (separate from `AssignExpr` because the expression form returns the pre- or post-value). HIR
-      -> MIR uses the same evaluate-target-once snapshot pattern as W11. Closes the `++` / `--` gap
-      noted in `architecture-reset.md` for `operators/unary`.
+      (separate from `AssignExpr` because the expression form returns the pre- or post-value). Once
+      `++` / `--` are accepted in index positions, the same eval-once rule will need explicit
+      handling at the read-modify-write level; the natural home for that work is LIR's address-once
+      lowering rather than an HIR snapshot pass.
 
 ## Cross-references
 

--- a/include/lyra/base/internal_error.hpp
+++ b/include/lyra/base/internal_error.hpp
@@ -8,6 +8,9 @@ namespace lyra {
 // Exception for compiler/runtime invariant violations: "impossible" states,
 // unimplemented paths the rest of the pipeline must not reach. User-source
 // errors must use diag::Diagnostic / diag::Result, not InternalError.
+// Callers pass the bare invariant message (typically `"FunctionName: short
+// detail"`); the constructor wraps it with an "Internal error:" prefix and
+// the bug-report URL so every site stays consistent.
 class InternalError final : public std::logic_error {
  public:
   explicit InternalError(std::string message);

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <variant>
 #include <vector>
 
@@ -42,9 +43,17 @@ enum class AssignKind : std::uint8_t {
   kNonBlocking,
 };
 
+// `compound_op.has_value()` marks a compound assignment (`+=`, `-=`, etc.):
+// the runtime reads the lvalue, combines with `rhs`, writes back -- the
+// LRM 11.4.1 "evaluate target only once" rule is delegated to the backend's
+// compound-op emit (the C++ proxy's `operator+=` etc.). `rhs` is already
+// typed to match `lhs`; AST -> HIR inserts a `ConversionExpr` if slang's
+// expansion required one. LRM A.6.2 forbids compound on non-blocking, so
+// `kind == kNonBlocking && compound_op.has_value()` is an InternalError.
 struct AssignExpr {
   AssignKind kind;
   Lvalue lhs;
+  std::optional<BinaryOp> compound_op = std::nullopt;
   ExprId rhs;
 };
 

--- a/include/lyra/lowering/ast_to_hir/expression/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/lower.hpp
@@ -1,35 +1,23 @@
 #pragma once
 
-#include <optional>
-
 #include <slang/ast/Expression.h>
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
-// `compound_lvalue_context`, when set, carries the lvalue currently being
-// assigned to. Slang materializes compound assignments (`a += b`) by binding
-// the original lvalue inside its resolved RHS subtree as a synthetic
-// `LValueReference`; lowering substitutes that node by wrapping the context
-// lvalue in `LvalueRead`.
 auto LowerProcExpr(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ProcessLoweringState& proc_state, const ScopeStack& stack,
-    const slang::ast::Expression& expr,
-    std::optional<hir::Lvalue> compound_lvalue_context = std::nullopt)
-    -> diag::Result<hir::Expr>;
+    const slang::ast::Expression& expr) -> diag::Result<hir::Expr>;
 
 auto LowerStructuralExpr(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ScopeLoweringState& scope_state, const ScopeStack& stack,
-    const slang::ast::Expression& expr,
-    std::optional<hir::Lvalue> compound_lvalue_context = std::nullopt)
-    -> diag::Result<hir::Expr>;
+    const slang::ast::Expression& expr) -> diag::Result<hir::Expr>;
 
 // Lower a slang assignment LHS into an HIR Lvalue. Process-side only:
 // structural code has no general assignment form. (Generate loop iteration

--- a/include/lyra/lowering/ast_to_hir/expression/slang_atoms.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/slang_atoms.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <optional>
+#include <string_view>
+
+#include <slang/ast/Expression.h>
+#include <slang/ast/SemanticFacts.h>
+#include <slang/ast/expressions/Operator.h>
+#include <slang/numeric/Time.h>
+#include <slang/syntax/SyntaxNode.h>
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_span.hpp"
+#include "lyra/hir/binary_op.hpp"
+#include "lyra/hir/conversion.hpp"
+#include "lyra/hir/method.hpp"
+#include "lyra/hir/primary.hpp"
+#include "lyra/hir/unary_op.hpp"
+#include "lyra/support/system_subroutine.hpp"
+
+// Stateless slang -> HIR translators. Each function is a pure 1:1 mapping
+// from a slang AST atom to its HIR counterpart, with no recursion and no
+// lowering state. They live here (separate from the recursive lowering
+// machinery in `expression/lower.cpp`) so the "encapsulate slang's quirks"
+// concern stays distinct from the "walk the AST and produce HIR" concern.
+namespace lyra::lowering::ast_to_hir {
+
+auto LowerSlangLiteralBase(const slang::syntax::SyntaxNode* syntax)
+    -> hir::IntegerLiteralBase;
+
+auto LowerConversionKind(slang::ast::ConversionKind k) -> hir::ConversionKind;
+
+auto LowerBinaryOp(slang::ast::BinaryOperator op) -> hir::BinaryOp;
+
+auto LowerUnaryOp(slang::ast::UnaryOperator op, diag::SourceSpan span)
+    -> diag::Result<hir::UnaryOp>;
+
+auto LowerTimeUnit(slang::TimeUnit u) -> hir::TimeScale;
+
+auto FromSlangSubroutineKind(slang::ast::SubroutineKind k)
+    -> support::SystemSubroutineKind;
+
+auto LowerEnumMethodName(std::string_view name)
+    -> std::optional<hir::BuiltinMethodKind>;
+
+// Recover the original user-written rhs from slang's compound expansion:
+// slang lowers `lhs op= e` to `right = Conv(lhs.type) { BinaryOp(op) {
+// Conv(common, LValueRef), Conv(common, e) } }`. This helper peels the
+// outer Conversion (if any), finds which BinaryOp operand wraps the
+// LValueRef placeholder, and unwraps the other operand's promotion
+// Conversion (if any) to expose the original `e`. Slang's invariant is at
+// most one Conversion at each wrap site; an InternalError surfaces if
+// that invariant is ever violated.
+auto BareCompoundUserRhs(const slang::ast::Expression& slang_expanded_rhs)
+    -> const slang::ast::Expression&;
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <variant>
 #include <vector>
@@ -60,8 +61,11 @@ struct ConditionalExpr {
   ExprId else_value;
 };
 
+// `compound_op.has_value()` marks the assignment as `target op= value`;
+// `nullopt` is a simple write. `value` is already typed to match `target`.
 struct AssignExpr {
   Lvalue target;
+  std::optional<BinaryOp> compound_op = std::nullopt;
   ExprId value;
 };
 

--- a/include/lyra/runtime/process.hpp
+++ b/include/lyra/runtime/process.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <coroutine>
+#include <exception>
 #include <utility>
 
 #include "lyra/base/internal_error.hpp"
@@ -14,7 +15,11 @@ class ProcessCoroutine {
   // C++20 coroutine protocol names are spelled by the standard.
   // NOLINTNEXTLINE(readability-identifier-naming)
   struct promise_type {
-    bool failed = false;
+    // Captures any exception that escapes the coroutine body. `Resume`
+    // rethrows it so the original `what()` and type reach the engine
+    // unchanged, instead of being collapsed into a generic "coroutine
+    // failed" message.
+    std::exception_ptr pending_exception;
     // Back-pointer set by RuntimeProcess construction so awaitables can
     // reach the owning RuntimeProcess from `await_suspend` (e.g. to
     // subscribe it to a named event's waiter list, or to look up the
@@ -39,7 +44,7 @@ class ProcessCoroutine {
     }
     // NOLINTNEXTLINE(readability-identifier-naming)
     void unhandled_exception() noexcept {
-      failed = true;
+      pending_exception = std::current_exception();
     }
 
     [[nodiscard]] auto Process() const -> RuntimeProcess& {
@@ -81,10 +86,9 @@ class ProcessCoroutine {
       return true;
     }
     handle_.resume();
-    if (handle_.promise().failed) {
-      handle_.promise().failed = false;
-      throw InternalError(
-          "lyra::runtime::ProcessCoroutine::Resume: process coroutine failed");
+    if (auto exc =
+            std::exchange(handle_.promise().pending_exception, nullptr)) {
+      std::rethrow_exception(exc);
     }
     return handle_.done();
   }

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -275,6 +275,59 @@ class ScopedMutation {
     return snapshot_.Slice(lsb, count);
   }
 
+  // LRM 11.4 whole-var compound. Mirrors `x op= rhs` directly: snapshot is
+  // mutated through the underlying type's own `op=`, and the destructor
+  // commits via WriteVar. Keeping the emit shape `x.Mutate(svc) op= rhs`
+  // (instead of expanding to `WriteVar(svc, x, x.Get() op rhs)`) preserves
+  // the compound intent end-to-end and mirrors the selector form
+  // `x.Mutate(svc).Chain(...) op= rhs`.
+  auto operator+=(const value::PackedArray& rhs) -> ScopedMutation& {
+    snapshot_ += rhs;
+    return *this;
+  }
+  auto operator-=(const value::PackedArray& rhs) -> ScopedMutation& {
+    snapshot_ -= rhs;
+    return *this;
+  }
+  auto operator*=(const value::PackedArray& rhs) -> ScopedMutation& {
+    snapshot_ *= rhs;
+    return *this;
+  }
+  auto operator/=(const value::PackedArray& rhs) -> ScopedMutation& {
+    snapshot_ /= rhs;
+    return *this;
+  }
+  auto operator%=(const value::PackedArray& rhs) -> ScopedMutation& {
+    snapshot_ %= rhs;
+    return *this;
+  }
+  auto operator&=(const value::PackedArray& rhs) -> ScopedMutation& {
+    snapshot_ &= rhs;
+    return *this;
+  }
+  auto operator|=(const value::PackedArray& rhs) -> ScopedMutation& {
+    snapshot_ |= rhs;
+    return *this;
+  }
+  auto operator^=(const value::PackedArray& rhs) -> ScopedMutation& {
+    snapshot_ ^= rhs;
+    return *this;
+  }
+  auto ShiftLeftAssign(const value::PackedArray& rhs) -> ScopedMutation& {
+    snapshot_.ShiftLeftAssign(rhs);
+    return *this;
+  }
+  auto LogicalShiftRightAssign(const value::PackedArray& rhs)
+      -> ScopedMutation& {
+    snapshot_.LogicalShiftRightAssign(rhs);
+    return *this;
+  }
+  auto ArithmeticShiftRightAssign(const value::PackedArray& rhs)
+      -> ScopedMutation& {
+    snapshot_.ArithmeticShiftRightAssign(rhs);
+    return *this;
+  }
+
  private:
   RuntimeServices* services_;
   Var<T>* var_;

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -175,6 +175,45 @@ class PackedArray {
   [[nodiscard]] auto operator|(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator^(const PackedArray& other) const -> PackedArray;
 
+  // LRM 11.4 compound assignments. Each is `*this = *this op rhs`; the
+  // binary `op` already enforces operand-shape compatibility, so frontends
+  // must hand both operands at the same shape (typically via a Conversion
+  // on the rhs to lhs.type at HIR construction). Shift compounds are
+  // method-style because the binary form is method-style too.
+  auto operator+=(const PackedArray& rhs) -> PackedArray& {
+    return *this = *this + rhs;
+  }
+  auto operator-=(const PackedArray& rhs) -> PackedArray& {
+    return *this = *this - rhs;
+  }
+  auto operator*=(const PackedArray& rhs) -> PackedArray& {
+    return *this = *this * rhs;
+  }
+  auto operator/=(const PackedArray& rhs) -> PackedArray& {
+    return *this = *this / rhs;
+  }
+  auto operator%=(const PackedArray& rhs) -> PackedArray& {
+    return *this = *this % rhs;
+  }
+  auto operator&=(const PackedArray& rhs) -> PackedArray& {
+    return *this = *this & rhs;
+  }
+  auto operator|=(const PackedArray& rhs) -> PackedArray& {
+    return *this = *this | rhs;
+  }
+  auto operator^=(const PackedArray& rhs) -> PackedArray& {
+    return *this = *this ^ rhs;
+  }
+  auto ShiftLeftAssign(const PackedArray& rhs) -> PackedArray& {
+    return *this = ShiftLeft(rhs);
+  }
+  auto LogicalShiftRightAssign(const PackedArray& rhs) -> PackedArray& {
+    return *this = LogicalShiftRight(rhs);
+  }
+  auto ArithmeticShiftRightAssign(const PackedArray& rhs) -> PackedArray& {
+    return *this = ArithmeticShiftRight(rhs);
+  }
+
   [[nodiscard]] auto operator==(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator!=(const PackedArray& other) const -> PackedArray;
   // LRM 11.4.6: X/Z in `other` are wildcards; X/Z in `*this` are not.
@@ -293,6 +332,46 @@ class PackedArrayRef {
 
   // Write-side: route through AssignSlice on root.
   auto operator=(const PackedArray& value) -> PackedArrayRef&;
+
+  // LRM 11.4 compound assignments. Read the current sub-slice once, combine
+  // with `rhs` (frontend converts rhs to lhs.type), write back through
+  // `AssignSlice`. The fixed `bit_offset_` / `bit_width_` on the proxy are
+  // the eval-once mechanism: the lvalue chain is constructed once by the
+  // caller, the proxy captures the position, and both the read and write
+  // here use that same position with no re-evaluation of indices.
+  auto operator+=(const PackedArray& rhs) -> PackedArrayRef& {
+    return *this = PackedArray(*this) + rhs;
+  }
+  auto operator-=(const PackedArray& rhs) -> PackedArrayRef& {
+    return *this = PackedArray(*this) - rhs;
+  }
+  auto operator*=(const PackedArray& rhs) -> PackedArrayRef& {
+    return *this = PackedArray(*this) * rhs;
+  }
+  auto operator/=(const PackedArray& rhs) -> PackedArrayRef& {
+    return *this = PackedArray(*this) / rhs;
+  }
+  auto operator%=(const PackedArray& rhs) -> PackedArrayRef& {
+    return *this = PackedArray(*this) % rhs;
+  }
+  auto operator&=(const PackedArray& rhs) -> PackedArrayRef& {
+    return *this = PackedArray(*this) & rhs;
+  }
+  auto operator|=(const PackedArray& rhs) -> PackedArrayRef& {
+    return *this = PackedArray(*this) | rhs;
+  }
+  auto operator^=(const PackedArray& rhs) -> PackedArrayRef& {
+    return *this = PackedArray(*this) ^ rhs;
+  }
+  auto ShiftLeftAssign(const PackedArray& rhs) -> PackedArrayRef& {
+    return *this = PackedArray(*this).ShiftLeft(rhs);
+  }
+  auto LogicalShiftRightAssign(const PackedArray& rhs) -> PackedArrayRef& {
+    return *this = PackedArray(*this).LogicalShiftRight(rhs);
+  }
+  auto ArithmeticShiftRightAssign(const PackedArray& rhs) -> PackedArrayRef& {
+    return *this = PackedArray(*this).ArithmeticShiftRight(rhs);
+  }
 
   // Chain composition. Positions are in the current sub-view's outer-element
   // units; the proxy scales internally based on `dims_`.

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -337,6 +337,9 @@ auto RenderScopeHeaderFile(
 
 auto RenderHostMain(const mir::StructuralScope& entry) -> std::string {
   std::string out;
+  out += "#include <exception>\n";
+  out += "#include <iostream>\n";
+  out += "\n";
   out += "#include \"lyra/runtime/engine.hpp\"\n";
   out += "#include \"" + entry.name + ".hpp\"\n";
   out += "\n";
@@ -344,7 +347,12 @@ auto RenderHostMain(const mir::StructuralScope& entry) -> std::string {
   out += "  " + entry.name + " top;\n";
   out += "  lyra::runtime::Engine engine;\n";
   out += "  engine.BindRoot(\"top\", top);\n";
-  out += "  return engine.Run();\n";
+  out += "  try {\n";
+  out += "    return engine.Run();\n";
+  out += "  } catch (const std::exception& e) {\n";
+  out += "    std::cerr << e.what() << \"\\n\";\n";
+  out += "    return 1;\n";
+  out += "  }\n";
   out += "}\n";
   return out;
 }

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -817,6 +817,48 @@ auto RenderSelectorMethodCall(
       sel);
 }
 
+// Render a compound op suffix for the SV `op=` family. Arithmetic /
+// bitwise compounds use the C++ operator tokens directly because
+// `PackedArray`/`PackedArrayRef`/`ScopedMutation` overload `operator+=`,
+// etc. Shifts route through method-style `XxxAssign(rhs)` calls because
+// the binary form is already method-style (no native C++ token for SV's
+// arithmetic / logical shift distinction). Returns either the operator
+// token (e.g. " += ") with caller-supplied rhs appended, or the full
+// method form `.XxxAssign(rhs)`.
+auto RenderCompoundAssign(
+    mir::BinaryOp op, const std::string& chain, const std::string& rhs)
+    -> std::string {
+  switch (op) {
+    case mir::BinaryOp::kAdd:
+      return chain + " += " + rhs;
+    case mir::BinaryOp::kSub:
+      return chain + " -= " + rhs;
+    case mir::BinaryOp::kMul:
+      return chain + " *= " + rhs;
+    case mir::BinaryOp::kDiv:
+      return chain + " /= " + rhs;
+    case mir::BinaryOp::kMod:
+      return chain + " %= " + rhs;
+    case mir::BinaryOp::kBitwiseAnd:
+      return chain + " &= " + rhs;
+    case mir::BinaryOp::kBitwiseOr:
+      return chain + " |= " + rhs;
+    case mir::BinaryOp::kBitwiseXor:
+      return chain + " ^= " + rhs;
+    case mir::BinaryOp::kShiftLeft:
+      return chain + ".ShiftLeftAssign(" + rhs + ")";
+    case mir::BinaryOp::kLogicalShiftRight:
+      return chain + ".LogicalShiftRightAssign(" + rhs + ")";
+    case mir::BinaryOp::kArithmeticShiftRight:
+      return chain + ".ArithmeticShiftRightAssign(" + rhs + ")";
+    default:
+      throw InternalError(
+          "RenderCompoundAssign: BinaryOp is not a legal SV compound "
+          "assignment operator (LRM 11.4 only allows arithmetic, bitwise, "
+          "and shift compounds)");
+  }
+}
+
 auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
     -> diag::Result<std::string> {
   auto value_or = RenderExpr(ctx, ctx.Expr(a.value));
@@ -833,6 +875,16 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
 
   // Whole-var write: existing entry points (events / direct assign).
   if (a.target.selectors.empty()) {
+    if (a.compound_op.has_value()) {
+      // For observable whole-var compound we still route through Mutate so
+      // the destructor commit fires subscribers exactly once -- the
+      // ScopedMutation overloads `op=` to mutate the snapshot in place.
+      // Procedural-local compounds operate on the underlying PackedArray
+      // directly via its own `op=` overloads.
+      const std::string chain =
+          observable ? *root_or + ".Mutate(*services_)" : *root_or;
+      return "(" + RenderCompoundAssign(*a.compound_op, chain, *value_or) + ")";
+    }
     if (observable) {
       return "lyra::runtime::WriteVar(*services_, " + *root_or + ", " +
              *value_or + ")";
@@ -860,6 +912,9 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
     auto method = RenderSelectorMethodCall(ctx, sel);
     if (!method) return std::unexpected(std::move(method.error()));
     chain += *method;
+  }
+  if (a.compound_op.has_value()) {
+    return "(" + RenderCompoundAssign(*a.compound_op, chain, *value_or) + ")";
   }
   return chain + " = " + *value_or;
 }

--- a/src/lyra/base/internal_error.cpp
+++ b/src/lyra/base/internal_error.cpp
@@ -6,7 +6,10 @@
 namespace lyra {
 
 InternalError::InternalError(std::string message)
-    : std::logic_error(std::move(message)) {
+    : std::logic_error(
+          "Internal error: " + std::move(message) +
+          "\nThis is a bug in Lyra. Please report at: "
+          "https://github.com/hankhsu1996/lyra/issues") {
 }
 
 }  // namespace lyra

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -604,8 +604,12 @@ class HirDumper {
               const auto* kind_str = a.kind == AssignKind::kNonBlocking
                                          ? "nonblocking"
                                          : "blocking";
+              const std::string op_str =
+                  a.compound_op.has_value()
+                      ? std::format(" op={}", FormatBinaryOp(*a.compound_op))
+                      : std::string{};
               return std::format(
-                  "AssignExpr kind={} lhs={} rhs=Expr[{}]", kind_str,
+                  "AssignExpr kind={}{} lhs={} rhs=Expr[{}]", kind_str, op_str,
                   FormatLvalue(a.lhs), a.rhs.value);
             },
             [this](const CallExpr& c) -> std::string {

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -29,14 +29,13 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/diag/diagnostic.hpp"
-#include "lyra/hir/binary_op.hpp"
 #include "lyra/hir/conversion.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/type.hpp"
-#include "lyra/hir/unary_op.hpp"
 #include "lyra/hir/value_ref.hpp"
+#include "lyra/lowering/ast_to_hir/expression/slang_atoms.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
@@ -45,138 +44,6 @@
 namespace lyra::lowering::ast_to_hir {
 
 namespace {
-
-auto LowerSlangLiteralBase(const slang::syntax::SyntaxNode* syntax)
-    -> hir::IntegerLiteralBase {
-  if (syntax != nullptr &&
-      syntax->kind == slang::syntax::SyntaxKind::IntegerVectorExpression) {
-    const auto& iv = syntax->as<slang::syntax::IntegerVectorExpressionSyntax>();
-    switch (iv.base.numericFlags().base()) {
-      case slang::LiteralBase::Binary:
-        return hir::IntegerLiteralBase::kBinary;
-      case slang::LiteralBase::Octal:
-        return hir::IntegerLiteralBase::kOctal;
-      case slang::LiteralBase::Decimal:
-        return hir::IntegerLiteralBase::kDecimal;
-      case slang::LiteralBase::Hex:
-        return hir::IntegerLiteralBase::kHexadecimal;
-    }
-  }
-  return hir::IntegerLiteralBase::kDecimal;
-}
-
-auto LowerConversionKind(slang::ast::ConversionKind k) -> hir::ConversionKind {
-  switch (k) {
-    case slang::ast::ConversionKind::Implicit:
-      return hir::ConversionKind::kImplicit;
-    case slang::ast::ConversionKind::Propagated:
-      return hir::ConversionKind::kPropagated;
-    case slang::ast::ConversionKind::StreamingConcat:
-      return hir::ConversionKind::kStreamingConcat;
-    case slang::ast::ConversionKind::Explicit:
-      return hir::ConversionKind::kExplicit;
-    case slang::ast::ConversionKind::BitstreamCast:
-      return hir::ConversionKind::kBitstreamCast;
-  }
-  throw InternalError("LowerConversionKind: unknown slang ConversionKind");
-}
-
-auto LowerBinaryOp(slang::ast::BinaryOperator op) -> hir::BinaryOp {
-  switch (op) {
-    case slang::ast::BinaryOperator::Add:
-      return hir::BinaryOp::kAdd;
-    case slang::ast::BinaryOperator::Subtract:
-      return hir::BinaryOp::kSub;
-    case slang::ast::BinaryOperator::Multiply:
-      return hir::BinaryOp::kMul;
-    case slang::ast::BinaryOperator::Divide:
-      return hir::BinaryOp::kDiv;
-    case slang::ast::BinaryOperator::Mod:
-      return hir::BinaryOp::kMod;
-    case slang::ast::BinaryOperator::Power:
-      return hir::BinaryOp::kPower;
-    case slang::ast::BinaryOperator::BinaryAnd:
-      return hir::BinaryOp::kBitwiseAnd;
-    case slang::ast::BinaryOperator::BinaryOr:
-      return hir::BinaryOp::kBitwiseOr;
-    case slang::ast::BinaryOperator::BinaryXor:
-      return hir::BinaryOp::kBitwiseXor;
-    case slang::ast::BinaryOperator::BinaryXnor:
-      return hir::BinaryOp::kBitwiseXnor;
-    case slang::ast::BinaryOperator::Equality:
-      return hir::BinaryOp::kEquality;
-    case slang::ast::BinaryOperator::Inequality:
-      return hir::BinaryOp::kInequality;
-    case slang::ast::BinaryOperator::CaseEquality:
-      return hir::BinaryOp::kCaseEquality;
-    case slang::ast::BinaryOperator::CaseInequality:
-      return hir::BinaryOp::kCaseInequality;
-    case slang::ast::BinaryOperator::WildcardEquality:
-      return hir::BinaryOp::kWildcardEquality;
-    case slang::ast::BinaryOperator::WildcardInequality:
-      return hir::BinaryOp::kWildcardInequality;
-    case slang::ast::BinaryOperator::GreaterThanEqual:
-      return hir::BinaryOp::kGreaterEqual;
-    case slang::ast::BinaryOperator::GreaterThan:
-      return hir::BinaryOp::kGreaterThan;
-    case slang::ast::BinaryOperator::LessThanEqual:
-      return hir::BinaryOp::kLessEqual;
-    case slang::ast::BinaryOperator::LessThan:
-      return hir::BinaryOp::kLessThan;
-    case slang::ast::BinaryOperator::LogicalAnd:
-      return hir::BinaryOp::kLogicalAnd;
-    case slang::ast::BinaryOperator::LogicalOr:
-      return hir::BinaryOp::kLogicalOr;
-    case slang::ast::BinaryOperator::LogicalImplication:
-      return hir::BinaryOp::kLogicalImplication;
-    case slang::ast::BinaryOperator::LogicalEquivalence:
-      return hir::BinaryOp::kLogicalEquivalence;
-    case slang::ast::BinaryOperator::LogicalShiftLeft:
-      return hir::BinaryOp::kLogicalShiftLeft;
-    case slang::ast::BinaryOperator::LogicalShiftRight:
-      return hir::BinaryOp::kLogicalShiftRight;
-    case slang::ast::BinaryOperator::ArithmeticShiftLeft:
-      return hir::BinaryOp::kArithmeticShiftLeft;
-    case slang::ast::BinaryOperator::ArithmeticShiftRight:
-      return hir::BinaryOp::kArithmeticShiftRight;
-  }
-  throw InternalError("LowerBinaryOp: unknown slang BinaryOperator");
-}
-
-auto LowerUnaryOp(slang::ast::UnaryOperator op, diag::SourceSpan span)
-    -> diag::Result<hir::UnaryOp> {
-  switch (op) {
-    case slang::ast::UnaryOperator::Plus:
-      return hir::UnaryOp::kPlus;
-    case slang::ast::UnaryOperator::Minus:
-      return hir::UnaryOp::kMinus;
-    case slang::ast::UnaryOperator::BitwiseNot:
-      return hir::UnaryOp::kBitwiseNot;
-    case slang::ast::UnaryOperator::LogicalNot:
-      return hir::UnaryOp::kLogicalNot;
-    case slang::ast::UnaryOperator::BitwiseAnd:
-      return hir::UnaryOp::kReductionAnd;
-    case slang::ast::UnaryOperator::BitwiseOr:
-      return hir::UnaryOp::kReductionOr;
-    case slang::ast::UnaryOperator::BitwiseXor:
-      return hir::UnaryOp::kReductionXor;
-    case slang::ast::UnaryOperator::BitwiseNand:
-      return hir::UnaryOp::kReductionNand;
-    case slang::ast::UnaryOperator::BitwiseNor:
-      return hir::UnaryOp::kReductionNor;
-    case slang::ast::UnaryOperator::BitwiseXnor:
-      return hir::UnaryOp::kReductionXnor;
-    case slang::ast::UnaryOperator::Preincrement:
-    case slang::ast::UnaryOperator::Predecrement:
-    case slang::ast::UnaryOperator::Postincrement:
-    case slang::ast::UnaryOperator::Postdecrement:
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedExpressionForm,
-          "increment and decrement expressions are not supported yet",
-          diag::UnsupportedCategory::kOperation);
-  }
-  throw InternalError("LowerUnaryOp: unknown slang UnaryOperator");
-}
 
 auto MakeIntegerLiteralExpr(
     const slang::ast::IntegerLiteral& lit, hir::TypeId type,
@@ -244,35 +111,6 @@ auto MakeStringLiteralExpr(
   };
 }
 
-auto LowerEnumMethodName(std::string_view name)
-    -> std::optional<hir::BuiltinMethodKind> {
-  if (name == "first") return hir::BuiltinMethodKind::kEnumFirst;
-  if (name == "last") return hir::BuiltinMethodKind::kEnumLast;
-  if (name == "num") return hir::BuiltinMethodKind::kEnumNum;
-  if (name == "next") return hir::BuiltinMethodKind::kEnumNext;
-  if (name == "prev") return hir::BuiltinMethodKind::kEnumPrev;
-  if (name == "name") return hir::BuiltinMethodKind::kEnumName;
-  return std::nullopt;
-}
-
-auto LowerTimeUnit(slang::TimeUnit u) -> hir::TimeScale {
-  switch (u) {
-    case slang::TimeUnit::Femtoseconds:
-      return hir::TimeScale::kFs;
-    case slang::TimeUnit::Picoseconds:
-      return hir::TimeScale::kPs;
-    case slang::TimeUnit::Nanoseconds:
-      return hir::TimeScale::kNs;
-    case slang::TimeUnit::Microseconds:
-      return hir::TimeScale::kUs;
-    case slang::TimeUnit::Milliseconds:
-      return hir::TimeScale::kMs;
-    case slang::TimeUnit::Seconds:
-      return hir::TimeScale::kS;
-  }
-  throw InternalError("LowerTimeUnit: unknown slang TimeUnit");
-}
-
 auto MakeTimeLiteralExpr(
     double value, hir::TimeScale scale, hir::TypeId type, diag::SourceSpan span)
     -> hir::Expr {
@@ -301,31 +139,6 @@ auto MakeRefExpr(hir::Primary ref, hir::TypeId type, diag::SourceSpan span)
       .data = hir::PrimaryExpr{.data = std::move(ref)},
       .span = span,
   };
-}
-
-// Project an Lvalue (write context) into a Primary (read context). Only
-// whole-var Lvalues (empty selector chain) can be projected directly; a
-// selector lvalue's read-context shape is an ElementSelectExpr or
-// RangeSelectExpr, which the caller must materialize separately.
-auto LvalueToPrimary(const hir::Lvalue& lvalue) -> hir::Primary {
-  if (!lvalue.selectors.empty()) {
-    throw InternalError(
-        "LvalueToPrimary: cannot project a selector lvalue into a Primary; "
-        "compound assignment to a selector target is not yet supported");
-  }
-  return std::visit(
-      [](const auto& ref) -> hir::Primary { return ref; }, lvalue.root);
-}
-
-auto FromSlangSubroutineKind(slang::ast::SubroutineKind k)
-    -> support::SystemSubroutineKind {
-  switch (k) {
-    case slang::ast::SubroutineKind::Function:
-      return support::SystemSubroutineKind::kFunction;
-    case slang::ast::SubroutineKind::Task:
-      return support::SystemSubroutineKind::kTask;
-  }
-  throw InternalError("FromSlangSubroutineKind: unknown SubroutineKind");
 }
 
 auto MakeReturnConventionType(
@@ -455,30 +268,14 @@ auto LowerNamedValueStructural(
       binding->type, span);
 }
 
-auto LowerLValueReferenceExpr(
-    diag::SourceSpan span,
-    const std::optional<hir::Lvalue>& compound_lvalue_context,
-    diag::Result<hir::TypeId> type_id, const char* origin)
-    -> diag::Result<hir::Expr> {
-  if (!compound_lvalue_context.has_value()) {
-    throw InternalError(
-        std::string{origin} +
-        ": slang LValueReference encountered outside compound-assignment RHS");
-  }
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-  return MakeRefExpr(LvalueToPrimary(*compound_lvalue_context), *type_id, span);
-}
-
 auto LowerConversionExprProc(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ProcessLoweringState& proc_state, const ScopeStack& stack,
-    const std::optional<hir::Lvalue>& compound_lvalue_context,
     const slang::ast::ConversionExpression& conv,
     const slang::ast::Expression& expr, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  auto operand_or = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, conv.operand(),
-      compound_lvalue_context);
+  auto operand_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, conv.operand());
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
   const hir::ExprId operand_id = proc_state.AddExpr(*std::move(operand_or));
   auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
@@ -497,14 +294,12 @@ auto LowerConversionExprProc(
 auto LowerUnaryExprProc(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ProcessLoweringState& proc_state, const ScopeStack& stack,
-    const std::optional<hir::Lvalue>& compound_lvalue_context,
     const slang::ast::UnaryExpression& un, const slang::ast::Expression& expr,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
   auto op_or = LowerUnaryOp(un.op, span);
   if (!op_or) return std::unexpected(std::move(op_or.error()));
-  auto operand_or = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, un.operand(),
-      compound_lvalue_context);
+  auto operand_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, un.operand());
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
   const hir::ExprId operand_id = proc_state.AddExpr(*std::move(operand_or));
   auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
@@ -519,17 +314,14 @@ auto LowerUnaryExprProc(
 auto LowerBinaryExprProc(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ProcessLoweringState& proc_state, const ScopeStack& stack,
-    const std::optional<hir::Lvalue>& compound_lvalue_context,
     const slang::ast::BinaryExpression& bin, const slang::ast::Expression& expr,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto lhs_or = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, bin.left(),
-      compound_lvalue_context);
+  auto lhs_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, bin.left());
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const hir::ExprId lhs_id = proc_state.AddExpr(*std::move(lhs_or));
-  auto rhs_or = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, bin.right(),
-      compound_lvalue_context);
+  auto rhs_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, bin.right());
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const hir::ExprId rhs_id = proc_state.AddExpr(*std::move(rhs_or));
   auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
@@ -549,7 +341,6 @@ auto LowerBinaryExprProc(
 auto LowerConditionalExprProc(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ProcessLoweringState& proc_state, const ScopeStack& stack,
-    const std::optional<hir::Lvalue>& compound_lvalue_context,
     const slang::ast::ConditionalExpression& cond,
     const slang::ast::Expression& expr, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
@@ -567,18 +358,15 @@ auto LowerConditionalExprProc(
         diag::UnsupportedCategory::kFeature);
   }
   auto cond_or = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, *cond.conditions[0].expr,
-      compound_lvalue_context);
+      unit_facts, unit_state, proc_state, stack, *cond.conditions[0].expr);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
   const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_or));
-  auto then_or = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, cond.left(),
-      compound_lvalue_context);
+  auto then_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, cond.left());
   if (!then_or) return std::unexpected(std::move(then_or.error()));
   const hir::ExprId then_id = proc_state.AddExpr(*std::move(then_or));
-  auto else_or = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, cond.right(),
-      compound_lvalue_context);
+  auto else_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, cond.right());
   if (!else_or) return std::unexpected(std::move(else_or.error()));
   const hir::ExprId else_id = proc_state.AddExpr(*std::move(else_or));
   auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
@@ -598,7 +386,6 @@ auto LowerConditionalExprProc(
 auto LowerCallExprProc(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ProcessLoweringState& proc_state, const ScopeStack& stack,
-    const std::optional<hir::Lvalue>& compound_lvalue_context,
     const slang::ast::CallExpression& call, const slang::ast::Expression& expr,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
   std::vector<hir::ExprId> arg_ids;
@@ -606,8 +393,7 @@ auto LowerCallExprProc(
   std::optional<hir::TypeId> receiver_type;
   for (std::size_t i = 0; i < call.arguments().size(); ++i) {
     auto arg_or = LowerProcExpr(
-        unit_facts, unit_state, proc_state, stack, *call.arguments()[i],
-        compound_lvalue_context);
+        unit_facts, unit_state, proc_state, stack, *call.arguments()[i]);
     if (!arg_or) return std::unexpected(std::move(arg_or.error()));
     if (i == 0) {
       receiver_type = arg_or->type;
@@ -737,25 +523,63 @@ auto LowerAssignmentExprProc(
     const slang::ast::AssignmentExpression& as,
     const slang::ast::Expression& expr, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  const auto kind = as.isNonBlocking() ? hir::AssignKind::kNonBlocking
-                                       : hir::AssignKind::kBlocking;
-
   auto lhs_or =
       LowerProcLvalue(unit_facts, unit_state, proc_state, stack, as.left());
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
 
-  auto rhs_or = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, as.right(), *lhs_or);
-  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  const hir::ExprId rhs_id = proc_state.AddExpr(*std::move(rhs_or));
-
   auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
+
+  const auto kind = as.isNonBlocking() ? hir::AssignKind::kNonBlocking
+                                       : hir::AssignKind::kBlocking;
+
+  if (!as.op.has_value()) {
+    auto rhs_or =
+        LowerProcExpr(unit_facts, unit_state, proc_state, stack, as.right());
+    if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+    const hir::ExprId rhs_id = proc_state.AddExpr(*std::move(rhs_or));
+    return hir::Expr{
+        .type = *type_id,
+        .data =
+            hir::AssignExpr{
+                .kind = kind,
+                .lhs = *std::move(lhs_or),
+                .compound_op = std::nullopt,
+                .rhs = rhs_id},
+        .span = span,
+    };
+  }
+
+  if (as.isNonBlocking()) {
+    throw InternalError(
+        "LowerAssignmentExprProc: compound assignment with non-blocking "
+        "operator is not a legal SV form (LRM A.6.2 grammar)");
+  }
+
+  const auto& bare_user_rhs = BareCompoundUserRhs(as.right());
+  auto rhs_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, bare_user_rhs);
+  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+  hir::Expr rhs_expr = *std::move(rhs_or);
+  if (rhs_expr.type.value != type_id->value) {
+    const hir::ExprId inner_id = proc_state.AddExpr(std::move(rhs_expr));
+    rhs_expr = hir::Expr{
+        .type = *type_id,
+        .data =
+            hir::ConversionExpr{
+                .operand = inner_id, .kind = hir::ConversionKind::kImplicit},
+        .span = span,
+    };
+  }
+  const hir::ExprId rhs_id = proc_state.AddExpr(std::move(rhs_expr));
   return hir::Expr{
       .type = *type_id,
       .data =
           hir::AssignExpr{
-              .kind = kind, .lhs = *std::move(lhs_or), .rhs = rhs_id},
+              .kind = kind,
+              .lhs = *std::move(lhs_or),
+              .compound_op = LowerBinaryOp(*as.op),
+              .rhs = rhs_id},
       .span = span,
   };
 }
@@ -763,14 +587,12 @@ auto LowerAssignmentExprProc(
 auto LowerInsideExprProc(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ProcessLoweringState& proc_state, const ScopeStack& stack,
-    const std::optional<hir::Lvalue>& compound_lvalue_context,
     const slang::ast::InsideExpression& in, const slang::ast::Expression& expr,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
   const auto& mapper = unit_facts.SourceMapper();
 
-  auto lhs_or = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, in.left(),
-      compound_lvalue_context);
+  auto lhs_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, in.left());
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const hir::ExprId lhs_id = proc_state.AddExpr(*std::move(lhs_or));
 
@@ -786,21 +608,18 @@ auto LowerInsideExprProc(
             "tolerance-range form in inside operator is not yet supported",
             diag::UnsupportedCategory::kFeature);
       }
-      auto lo_or = LowerProcExpr(
-          unit_facts, unit_state, proc_state, stack, vr.left(),
-          compound_lvalue_context);
+      auto lo_or =
+          LowerProcExpr(unit_facts, unit_state, proc_state, stack, vr.left());
       if (!lo_or) return std::unexpected(std::move(lo_or.error()));
       const hir::ExprId lo_id = proc_state.AddExpr(*std::move(lo_or));
-      auto hi_or = LowerProcExpr(
-          unit_facts, unit_state, proc_state, stack, vr.right(),
-          compound_lvalue_context);
+      auto hi_or =
+          LowerProcExpr(unit_facts, unit_state, proc_state, stack, vr.right());
       if (!hi_or) return std::unexpected(std::move(hi_or.error()));
       const hir::ExprId hi_id = proc_state.AddExpr(*std::move(hi_or));
       items.emplace_back(hir::InsideRangePair{.lo = lo_id, .hi = hi_id});
     } else {
-      auto val_or = LowerProcExpr(
-          unit_facts, unit_state, proc_state, stack, *item,
-          compound_lvalue_context);
+      auto val_or =
+          LowerProcExpr(unit_facts, unit_state, proc_state, stack, *item);
       if (!val_or) return std::unexpected(std::move(val_or.error()));
       const hir::ExprId val_id = proc_state.AddExpr(*std::move(val_or));
       items.emplace_back(val_id);
@@ -819,7 +638,6 @@ auto LowerInsideExprProc(
 auto LowerElementSelectExprProc(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ProcessLoweringState& proc_state, const ScopeStack& stack,
-    const std::optional<hir::Lvalue>& compound_lvalue_context,
     const slang::ast::ElementSelectExpression& sel,
     const slang::ast::Expression& expr, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
@@ -830,15 +648,13 @@ auto LowerElementSelectExprProc(
         diag::UnsupportedCategory::kOperation);
   }
 
-  auto base_or = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, sel.value(),
-      compound_lvalue_context);
+  auto base_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, sel.value());
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const hir::ExprId base_id = proc_state.AddExpr(*std::move(base_or));
 
-  auto idx_or = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, sel.selector(),
-      compound_lvalue_context);
+  auto idx_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, sel.selector());
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const hir::ExprId idx_id = proc_state.AddExpr(*std::move(idx_or));
 
@@ -858,7 +674,6 @@ auto LowerElementSelectExprProc(
 auto LowerRangeSelectExprProc(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ProcessLoweringState& proc_state, const ScopeStack& stack,
-    const std::optional<hir::Lvalue>& compound_lvalue_context,
     const slang::ast::RangeSelectExpression& sel,
     const slang::ast::Expression& expr, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
@@ -869,21 +684,18 @@ auto LowerRangeSelectExprProc(
         diag::UnsupportedCategory::kOperation);
   }
 
-  auto base_or = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, sel.value(),
-      compound_lvalue_context);
+  auto base_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, sel.value());
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const hir::ExprId base_id = proc_state.AddExpr(*std::move(base_or));
 
-  auto left_or = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, sel.left(),
-      compound_lvalue_context);
+  auto left_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, sel.left());
   if (!left_or) return std::unexpected(std::move(left_or.error()));
   const hir::ExprId left_id = proc_state.AddExpr(*std::move(left_or));
 
-  auto right_or = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, sel.right(),
-      compound_lvalue_context);
+  auto right_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, sel.right());
   if (!right_or) return std::unexpected(std::move(right_or.error()));
   const hir::ExprId right_id = proc_state.AddExpr(*std::move(right_or));
 
@@ -935,7 +747,7 @@ auto LowerConcatExprProc(
   operand_ids.reserve(cc.operands().size());
   for (const auto* op : cc.operands()) {
     auto operand_or =
-        LowerProcExpr(unit_facts, unit_state, proc_state, stack, *op, {});
+        LowerProcExpr(unit_facts, unit_state, proc_state, stack, *op);
     if (!operand_or) return std::unexpected(std::move(operand_or.error()));
     operand_ids.push_back(proc_state.AddExpr(*std::move(operand_or)));
   }
@@ -962,11 +774,11 @@ auto LowerReplicationExprProc(
         diag::UnsupportedCategory::kOperation);
   }
   auto count_or =
-      LowerProcExpr(unit_facts, unit_state, proc_state, stack, rp.count(), {});
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, rp.count());
   if (!count_or) return std::unexpected(std::move(count_or.error()));
   const hir::ExprId count_id = proc_state.AddExpr(*std::move(count_or));
   auto concat_or =
-      LowerProcExpr(unit_facts, unit_state, proc_state, stack, rp.concat(), {});
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, rp.concat());
   if (!concat_or) return std::unexpected(std::move(concat_or.error()));
   const hir::ExprId concat_id = proc_state.AddExpr(*std::move(concat_or));
   return hir::Expr{
@@ -979,13 +791,11 @@ auto LowerReplicationExprProc(
 auto LowerConversionExprStructural(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ScopeLoweringState& scope_state, const ScopeStack& stack,
-    const std::optional<hir::Lvalue>& compound_lvalue_context,
     const slang::ast::ConversionExpression& conv,
     const slang::ast::Expression& expr, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
   auto operand_or = LowerStructuralExpr(
-      unit_facts, unit_state, scope_state, stack, conv.operand(),
-      compound_lvalue_context);
+      unit_facts, unit_state, scope_state, stack, conv.operand());
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
   const hir::ExprId operand_id = scope_state.AddExpr(*std::move(operand_or));
   auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
@@ -1004,14 +814,12 @@ auto LowerConversionExprStructural(
 auto LowerUnaryExprStructural(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ScopeLoweringState& scope_state, const ScopeStack& stack,
-    const std::optional<hir::Lvalue>& compound_lvalue_context,
     const slang::ast::UnaryExpression& un, const slang::ast::Expression& expr,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
   auto op_or = LowerUnaryOp(un.op, span);
   if (!op_or) return std::unexpected(std::move(op_or.error()));
   auto operand_or = LowerStructuralExpr(
-      unit_facts, unit_state, scope_state, stack, un.operand(),
-      compound_lvalue_context);
+      unit_facts, unit_state, scope_state, stack, un.operand());
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
   const hir::ExprId operand_id = scope_state.AddExpr(*std::move(operand_or));
   auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
@@ -1026,17 +834,14 @@ auto LowerUnaryExprStructural(
 auto LowerBinaryExprStructural(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ScopeLoweringState& scope_state, const ScopeStack& stack,
-    const std::optional<hir::Lvalue>& compound_lvalue_context,
     const slang::ast::BinaryExpression& bin, const slang::ast::Expression& expr,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
   auto lhs_or = LowerStructuralExpr(
-      unit_facts, unit_state, scope_state, stack, bin.left(),
-      compound_lvalue_context);
+      unit_facts, unit_state, scope_state, stack, bin.left());
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const hir::ExprId lhs_id = scope_state.AddExpr(*std::move(lhs_or));
   auto rhs_or = LowerStructuralExpr(
-      unit_facts, unit_state, scope_state, stack, bin.right(),
-      compound_lvalue_context);
+      unit_facts, unit_state, scope_state, stack, bin.right());
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const hir::ExprId rhs_id = scope_state.AddExpr(*std::move(rhs_or));
   auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
@@ -1056,7 +861,6 @@ auto LowerBinaryExprStructural(
 auto LowerConditionalExprStructural(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ScopeLoweringState& scope_state, const ScopeStack& stack,
-    const std::optional<hir::Lvalue>& compound_lvalue_context,
     const slang::ast::ConditionalExpression& cond,
     const slang::ast::Expression& expr, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
@@ -1074,18 +878,15 @@ auto LowerConditionalExprStructural(
         diag::UnsupportedCategory::kFeature);
   }
   auto cond_or = LowerStructuralExpr(
-      unit_facts, unit_state, scope_state, stack, *cond.conditions[0].expr,
-      compound_lvalue_context);
+      unit_facts, unit_state, scope_state, stack, *cond.conditions[0].expr);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
   const hir::ExprId cond_id = scope_state.AddExpr(*std::move(cond_or));
   auto then_or = LowerStructuralExpr(
-      unit_facts, unit_state, scope_state, stack, cond.left(),
-      compound_lvalue_context);
+      unit_facts, unit_state, scope_state, stack, cond.left());
   if (!then_or) return std::unexpected(std::move(then_or.error()));
   const hir::ExprId then_id = scope_state.AddExpr(*std::move(then_or));
   auto else_or = LowerStructuralExpr(
-      unit_facts, unit_state, scope_state, stack, cond.right(),
-      compound_lvalue_context);
+      unit_facts, unit_state, scope_state, stack, cond.right());
   if (!else_or) return std::unexpected(std::move(else_or.error()));
   const hir::ExprId else_id = scope_state.AddExpr(*std::move(else_or));
   auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
@@ -1107,9 +908,7 @@ auto LowerConditionalExprStructural(
 auto LowerProcExpr(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ProcessLoweringState& proc_state, const ScopeStack& stack,
-    const slang::ast::Expression& expr,
-    std::optional<hir::Lvalue> compound_lvalue_context)
-    -> diag::Result<hir::Expr> {
+    const slang::ast::Expression& expr) -> diag::Result<hir::Expr> {
   const auto& mapper = unit_facts.SourceMapper();
   const auto span = mapper.SpanOf(expr.sourceRange);
 
@@ -1157,33 +956,35 @@ auto LowerProcExpr(
           expr.as<slang::ast::NamedValueExpression>());
 
     case slang::ast::ExpressionKind::LValueReference:
-      return LowerLValueReferenceExpr(
-          span, compound_lvalue_context,
-          TypeIdOfSlangExpr(unit_facts, unit_state, expr), "LowerProcExpr");
+      throw InternalError(
+          "LowerProcExpr: slang LValueReference must not reach HIR; "
+          "compound assignment is lowered as a single AssignExpr with "
+          "compound_op, and the LValueReference-bearing BinaryOp tree slang "
+          "constructed is discarded at AST -> HIR");
 
     case slang::ast::ExpressionKind::Conversion:
       return LowerConversionExprProc(
-          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          unit_facts, unit_state, proc_state, stack,
           expr.as<slang::ast::ConversionExpression>(), expr, span);
 
     case slang::ast::ExpressionKind::UnaryOp:
       return LowerUnaryExprProc(
-          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          unit_facts, unit_state, proc_state, stack,
           expr.as<slang::ast::UnaryExpression>(), expr, span);
 
     case slang::ast::ExpressionKind::BinaryOp:
       return LowerBinaryExprProc(
-          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          unit_facts, unit_state, proc_state, stack,
           expr.as<slang::ast::BinaryExpression>(), expr, span);
 
     case slang::ast::ExpressionKind::ConditionalOp:
       return LowerConditionalExprProc(
-          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          unit_facts, unit_state, proc_state, stack,
           expr.as<slang::ast::ConditionalExpression>(), expr, span);
 
     case slang::ast::ExpressionKind::Call:
       return LowerCallExprProc(
-          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          unit_facts, unit_state, proc_state, stack,
           expr.as<slang::ast::CallExpression>(), expr, span);
 
     case slang::ast::ExpressionKind::Assignment:
@@ -1193,17 +994,17 @@ auto LowerProcExpr(
 
     case slang::ast::ExpressionKind::Inside:
       return LowerInsideExprProc(
-          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          unit_facts, unit_state, proc_state, stack,
           expr.as<slang::ast::InsideExpression>(), expr, span);
 
     case slang::ast::ExpressionKind::ElementSelect:
       return LowerElementSelectExprProc(
-          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          unit_facts, unit_state, proc_state, stack,
           expr.as<slang::ast::ElementSelectExpression>(), expr, span);
 
     case slang::ast::ExpressionKind::RangeSelect:
       return LowerRangeSelectExprProc(
-          unit_facts, unit_state, proc_state, stack, compound_lvalue_context,
+          unit_facts, unit_state, proc_state, stack,
           expr.as<slang::ast::RangeSelectExpression>(), expr, span);
 
     case slang::ast::ExpressionKind::Concatenation:
@@ -1227,9 +1028,7 @@ auto LowerProcExpr(
 auto LowerStructuralExpr(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ScopeLoweringState& scope_state, const ScopeStack& stack,
-    const slang::ast::Expression& expr,
-    std::optional<hir::Lvalue> compound_lvalue_context)
-    -> diag::Result<hir::Expr> {
+    const slang::ast::Expression& expr) -> diag::Result<hir::Expr> {
   const auto& mapper = unit_facts.SourceMapper();
   const auto span = mapper.SpanOf(expr.sourceRange);
 
@@ -1268,29 +1067,29 @@ auto LowerStructuralExpr(
           expr.as<slang::ast::NamedValueExpression>());
 
     case slang::ast::ExpressionKind::LValueReference:
-      return LowerLValueReferenceExpr(
-          span, compound_lvalue_context,
-          TypeIdOfSlangExpr(unit_facts, unit_state, expr),
-          "LowerStructuralExpr");
+      throw InternalError(
+          "LowerStructuralExpr: slang LValueReference must not reach HIR; "
+          "generate-iter compound is rewritten as the next-value BinaryExpr "
+          "directly");
 
     case slang::ast::ExpressionKind::Conversion:
       return LowerConversionExprStructural(
-          unit_facts, unit_state, scope_state, stack, compound_lvalue_context,
+          unit_facts, unit_state, scope_state, stack,
           expr.as<slang::ast::ConversionExpression>(), expr, span);
 
     case slang::ast::ExpressionKind::UnaryOp:
       return LowerUnaryExprStructural(
-          unit_facts, unit_state, scope_state, stack, compound_lvalue_context,
+          unit_facts, unit_state, scope_state, stack,
           expr.as<slang::ast::UnaryExpression>(), expr, span);
 
     case slang::ast::ExpressionKind::BinaryOp:
       return LowerBinaryExprStructural(
-          unit_facts, unit_state, scope_state, stack, compound_lvalue_context,
+          unit_facts, unit_state, scope_state, stack,
           expr.as<slang::ast::BinaryExpression>(), expr, span);
 
     case slang::ast::ExpressionKind::ConditionalOp:
       return LowerConditionalExprStructural(
-          unit_facts, unit_state, scope_state, stack, compound_lvalue_context,
+          unit_facts, unit_state, scope_state, stack,
           expr.as<slang::ast::ConditionalExpression>(), expr, span);
 
     default:
@@ -1332,8 +1131,7 @@ auto LowerProcLvalue(
         LowerProcLvalue(unit_facts, unit_state, proc_state, stack, sel.value());
     if (!inner) return std::unexpected(std::move(inner.error()));
     auto idx_or = LowerProcExpr(
-        unit_facts, unit_state, proc_state, stack, sel.selector(),
-        std::nullopt);
+        unit_facts, unit_state, proc_state, stack, sel.selector());
     if (!idx_or) return std::unexpected(std::move(idx_or.error()));
     const hir::ExprId idx_id = proc_state.AddExpr(*std::move(idx_or));
     inner->selectors.emplace_back(hir::ElementLvalueSelector{.index = idx_id});
@@ -1351,12 +1149,12 @@ auto LowerProcLvalue(
     auto inner =
         LowerProcLvalue(unit_facts, unit_state, proc_state, stack, sel.value());
     if (!inner) return std::unexpected(std::move(inner.error()));
-    auto left_or = LowerProcExpr(
-        unit_facts, unit_state, proc_state, stack, sel.left(), std::nullopt);
+    auto left_or =
+        LowerProcExpr(unit_facts, unit_state, proc_state, stack, sel.left());
     if (!left_or) return std::unexpected(std::move(left_or.error()));
     const hir::ExprId left_id = proc_state.AddExpr(*std::move(left_or));
-    auto right_or = LowerProcExpr(
-        unit_facts, unit_state, proc_state, stack, sel.right(), std::nullopt);
+    auto right_or =
+        LowerProcExpr(unit_facts, unit_state, proc_state, stack, sel.right());
     if (!right_or) return std::unexpected(std::move(right_or.error()));
     const hir::ExprId right_id = proc_state.AddExpr(*std::move(right_or));
     hir::RangeBounds bounds = [&]() -> hir::RangeBounds {
@@ -1381,8 +1179,7 @@ auto LowerProcLvalue(
   // Leaf: lower as a regular expression and extract the root var ref. The
   // wrapper Expr is discarded (not added to the process), so no dead Expr
   // pollutes the store.
-  auto leaf = LowerProcExpr(
-      unit_facts, unit_state, proc_state, stack, expr, std::nullopt);
+  auto leaf = LowerProcExpr(unit_facts, unit_state, proc_state, stack, expr);
   if (!leaf) return std::unexpected(std::move(leaf.error()));
   auto* primary = std::get_if<hir::PrimaryExpr>(&leaf->data);
   if (primary == nullptr) return unsupported();

--- a/src/lyra/lowering/ast_to_hir/expression/slang_atoms.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/slang_atoms.cpp
@@ -1,0 +1,227 @@
+#include "lyra/lowering/ast_to_hir/expression/slang_atoms.hpp"
+
+#include <slang/ast/expressions/ConversionExpression.h>
+#include <slang/ast/expressions/LiteralExpressions.h>
+#include <slang/ast/expressions/MiscExpressions.h>
+#include <slang/ast/expressions/OperatorExpressions.h>
+#include <slang/syntax/AllSyntax.h>
+
+#include "lyra/base/internal_error.hpp"
+
+namespace lyra::lowering::ast_to_hir {
+
+auto LowerSlangLiteralBase(const slang::syntax::SyntaxNode* syntax)
+    -> hir::IntegerLiteralBase {
+  if (syntax != nullptr &&
+      syntax->kind == slang::syntax::SyntaxKind::IntegerVectorExpression) {
+    const auto& iv = syntax->as<slang::syntax::IntegerVectorExpressionSyntax>();
+    switch (iv.base.numericFlags().base()) {
+      case slang::LiteralBase::Binary:
+        return hir::IntegerLiteralBase::kBinary;
+      case slang::LiteralBase::Octal:
+        return hir::IntegerLiteralBase::kOctal;
+      case slang::LiteralBase::Decimal:
+        return hir::IntegerLiteralBase::kDecimal;
+      case slang::LiteralBase::Hex:
+        return hir::IntegerLiteralBase::kHexadecimal;
+    }
+  }
+  return hir::IntegerLiteralBase::kDecimal;
+}
+
+auto LowerConversionKind(slang::ast::ConversionKind k) -> hir::ConversionKind {
+  switch (k) {
+    case slang::ast::ConversionKind::Implicit:
+      return hir::ConversionKind::kImplicit;
+    case slang::ast::ConversionKind::Propagated:
+      return hir::ConversionKind::kPropagated;
+    case slang::ast::ConversionKind::StreamingConcat:
+      return hir::ConversionKind::kStreamingConcat;
+    case slang::ast::ConversionKind::Explicit:
+      return hir::ConversionKind::kExplicit;
+    case slang::ast::ConversionKind::BitstreamCast:
+      return hir::ConversionKind::kBitstreamCast;
+  }
+  throw InternalError("LowerConversionKind: unknown slang ConversionKind");
+}
+
+auto LowerBinaryOp(slang::ast::BinaryOperator op) -> hir::BinaryOp {
+  switch (op) {
+    case slang::ast::BinaryOperator::Add:
+      return hir::BinaryOp::kAdd;
+    case slang::ast::BinaryOperator::Subtract:
+      return hir::BinaryOp::kSub;
+    case slang::ast::BinaryOperator::Multiply:
+      return hir::BinaryOp::kMul;
+    case slang::ast::BinaryOperator::Divide:
+      return hir::BinaryOp::kDiv;
+    case slang::ast::BinaryOperator::Mod:
+      return hir::BinaryOp::kMod;
+    case slang::ast::BinaryOperator::Power:
+      return hir::BinaryOp::kPower;
+    case slang::ast::BinaryOperator::BinaryAnd:
+      return hir::BinaryOp::kBitwiseAnd;
+    case slang::ast::BinaryOperator::BinaryOr:
+      return hir::BinaryOp::kBitwiseOr;
+    case slang::ast::BinaryOperator::BinaryXor:
+      return hir::BinaryOp::kBitwiseXor;
+    case slang::ast::BinaryOperator::BinaryXnor:
+      return hir::BinaryOp::kBitwiseXnor;
+    case slang::ast::BinaryOperator::Equality:
+      return hir::BinaryOp::kEquality;
+    case slang::ast::BinaryOperator::Inequality:
+      return hir::BinaryOp::kInequality;
+    case slang::ast::BinaryOperator::CaseEquality:
+      return hir::BinaryOp::kCaseEquality;
+    case slang::ast::BinaryOperator::CaseInequality:
+      return hir::BinaryOp::kCaseInequality;
+    case slang::ast::BinaryOperator::WildcardEquality:
+      return hir::BinaryOp::kWildcardEquality;
+    case slang::ast::BinaryOperator::WildcardInequality:
+      return hir::BinaryOp::kWildcardInequality;
+    case slang::ast::BinaryOperator::GreaterThanEqual:
+      return hir::BinaryOp::kGreaterEqual;
+    case slang::ast::BinaryOperator::GreaterThan:
+      return hir::BinaryOp::kGreaterThan;
+    case slang::ast::BinaryOperator::LessThanEqual:
+      return hir::BinaryOp::kLessEqual;
+    case slang::ast::BinaryOperator::LessThan:
+      return hir::BinaryOp::kLessThan;
+    case slang::ast::BinaryOperator::LogicalAnd:
+      return hir::BinaryOp::kLogicalAnd;
+    case slang::ast::BinaryOperator::LogicalOr:
+      return hir::BinaryOp::kLogicalOr;
+    case slang::ast::BinaryOperator::LogicalImplication:
+      return hir::BinaryOp::kLogicalImplication;
+    case slang::ast::BinaryOperator::LogicalEquivalence:
+      return hir::BinaryOp::kLogicalEquivalence;
+    case slang::ast::BinaryOperator::LogicalShiftLeft:
+      return hir::BinaryOp::kLogicalShiftLeft;
+    case slang::ast::BinaryOperator::LogicalShiftRight:
+      return hir::BinaryOp::kLogicalShiftRight;
+    case slang::ast::BinaryOperator::ArithmeticShiftLeft:
+      return hir::BinaryOp::kArithmeticShiftLeft;
+    case slang::ast::BinaryOperator::ArithmeticShiftRight:
+      return hir::BinaryOp::kArithmeticShiftRight;
+  }
+  throw InternalError("LowerBinaryOp: unknown slang BinaryOperator");
+}
+
+auto LowerUnaryOp(slang::ast::UnaryOperator op, diag::SourceSpan span)
+    -> diag::Result<hir::UnaryOp> {
+  switch (op) {
+    case slang::ast::UnaryOperator::Plus:
+      return hir::UnaryOp::kPlus;
+    case slang::ast::UnaryOperator::Minus:
+      return hir::UnaryOp::kMinus;
+    case slang::ast::UnaryOperator::BitwiseNot:
+      return hir::UnaryOp::kBitwiseNot;
+    case slang::ast::UnaryOperator::LogicalNot:
+      return hir::UnaryOp::kLogicalNot;
+    case slang::ast::UnaryOperator::BitwiseAnd:
+      return hir::UnaryOp::kReductionAnd;
+    case slang::ast::UnaryOperator::BitwiseOr:
+      return hir::UnaryOp::kReductionOr;
+    case slang::ast::UnaryOperator::BitwiseXor:
+      return hir::UnaryOp::kReductionXor;
+    case slang::ast::UnaryOperator::BitwiseNand:
+      return hir::UnaryOp::kReductionNand;
+    case slang::ast::UnaryOperator::BitwiseNor:
+      return hir::UnaryOp::kReductionNor;
+    case slang::ast::UnaryOperator::BitwiseXnor:
+      return hir::UnaryOp::kReductionXnor;
+    case slang::ast::UnaryOperator::Preincrement:
+    case slang::ast::UnaryOperator::Predecrement:
+    case slang::ast::UnaryOperator::Postincrement:
+    case slang::ast::UnaryOperator::Postdecrement:
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "increment and decrement expressions are not supported yet",
+          diag::UnsupportedCategory::kOperation);
+  }
+  throw InternalError("LowerUnaryOp: unknown slang UnaryOperator");
+}
+
+auto LowerTimeUnit(slang::TimeUnit u) -> hir::TimeScale {
+  switch (u) {
+    case slang::TimeUnit::Femtoseconds:
+      return hir::TimeScale::kFs;
+    case slang::TimeUnit::Picoseconds:
+      return hir::TimeScale::kPs;
+    case slang::TimeUnit::Nanoseconds:
+      return hir::TimeScale::kNs;
+    case slang::TimeUnit::Microseconds:
+      return hir::TimeScale::kUs;
+    case slang::TimeUnit::Milliseconds:
+      return hir::TimeScale::kMs;
+    case slang::TimeUnit::Seconds:
+      return hir::TimeScale::kS;
+  }
+  throw InternalError("LowerTimeUnit: unknown slang TimeUnit");
+}
+
+auto FromSlangSubroutineKind(slang::ast::SubroutineKind k)
+    -> support::SystemSubroutineKind {
+  switch (k) {
+    case slang::ast::SubroutineKind::Function:
+      return support::SystemSubroutineKind::kFunction;
+    case slang::ast::SubroutineKind::Task:
+      return support::SystemSubroutineKind::kTask;
+  }
+  throw InternalError("FromSlangSubroutineKind: unknown SubroutineKind");
+}
+
+auto LowerEnumMethodName(std::string_view name)
+    -> std::optional<hir::BuiltinMethodKind> {
+  if (name == "first") return hir::BuiltinMethodKind::kEnumFirst;
+  if (name == "last") return hir::BuiltinMethodKind::kEnumLast;
+  if (name == "num") return hir::BuiltinMethodKind::kEnumNum;
+  if (name == "next") return hir::BuiltinMethodKind::kEnumNext;
+  if (name == "prev") return hir::BuiltinMethodKind::kEnumPrev;
+  if (name == "name") return hir::BuiltinMethodKind::kEnumName;
+  return std::nullopt;
+}
+
+auto BareCompoundUserRhs(const slang::ast::Expression& slang_expanded_rhs)
+    -> const slang::ast::Expression& {
+  // Slang's `convertAssignment` adds at most one outer Conversion when the
+  // BinaryOp result type differs from the lhs type; it never nests, so a
+  // single conditional peel is exact (not defensive). An extra Conversion
+  // here would mean slang changed its emission invariant.
+  const auto& binop_layer =
+      slang_expanded_rhs.kind == slang::ast::ExpressionKind::Conversion
+          ? slang_expanded_rhs.as<slang::ast::ConversionExpression>().operand()
+          : slang_expanded_rhs;
+  if (binop_layer.kind != slang::ast::ExpressionKind::BinaryOp) {
+    throw InternalError(
+        "BareCompoundUserRhs: expected BinaryOp under slang's compound "
+        "expansion; slang's invariant (zero or one Conversion above a "
+        "BinaryOp via convertAssignment) has changed");
+  }
+  const auto& bin = binop_layer.as<slang::ast::BinaryExpression>();
+
+  // `BinaryExpression::fromComponents` adds at most one promotion
+  // Conversion per operand. Peel exactly one conditionally; one side is
+  // the synthetic LValueReference, the other is the user's rhs.
+  const auto peel_one =
+      [](const slang::ast::Expression& e) -> const slang::ast::Expression& {
+    return e.kind == slang::ast::ExpressionKind::Conversion
+               ? e.as<slang::ast::ConversionExpression>().operand()
+               : e;
+  };
+  const auto& left = peel_one(bin.left());
+  const auto& right = peel_one(bin.right());
+
+  const bool left_is_ref =
+      left.kind == slang::ast::ExpressionKind::LValueReference;
+  const bool right_is_ref =
+      right.kind == slang::ast::ExpressionKind::LValueReference;
+  if (left_is_ref == right_is_ref) {
+    throw InternalError(
+        "BareCompoundUserRhs: expected exactly one LValueReference operand "
+        "in slang's compound expansion");
+  }
+  return left_is_ref ? right : left;
+}
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/generate.cpp
+++ b/src/lyra/lowering/ast_to_hir/generate.cpp
@@ -17,6 +17,7 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/ast_to_hir/expression/lower.hpp"
+#include "lyra/lowering/ast_to_hir/expression/slang_atoms.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/scope.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
@@ -231,32 +232,50 @@ auto BuildCaseGenerate(
 // Lower the iter expression of a loop_generate header into the loop's
 // next-value expression for its loop variable. Per LRM 27.5,
 // genvar_iteration is restricted to: `i = e`, `i op= e`, `++i`, `i++`, `--i`,
-// `i--`. All four forms compute exactly one new value for THE loop variable;
-// HIR stores that next-value, not an assignment. The loop's iteration write
-// is owned by the loop semantic, not by a general assignment.
+// `i--`. All four forms compute exactly one new value for THE loop variable.
+// Compound is rebuilt as `BinaryExpr{op, ReadOfLvalue, user_rhs}`; the genvar
+// is a constant-elaborated parameter so its read is trivial and slang's
+// promotion Conversions are no-ops at int <-> int.
 auto LowerLoopIterNextValue(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ScopeLoweringState& parent_state, const ScopeStack& stack,
-    const slang::ast::Expression& iter, const hir::Lvalue& loop_var_lvalue)
-    -> diag::Result<hir::Expr> {
+    const slang::ast::Expression& iter) -> diag::Result<hir::Expr> {
   const auto& mapper = unit_facts.SourceMapper();
   const auto span = mapper.SpanOf(iter.sourceRange);
 
-  if (iter.kind == slang::ast::ExpressionKind::Assignment) {
-    const auto& assign = iter.as<slang::ast::AssignmentExpression>();
-    // For simple `i = e`, slang.right() is `e` (no LValueReference).
-    // For compound `i op= e`, slang.right() is the synthetic
-    // BinaryOp{op, LValueRef, e_resolved}; passing the loop-var lvalue as
-    // compound context resolves LValueRef to a read of the loop var.
-    return LowerStructuralExpr(
-        unit_facts, unit_state, parent_state, stack, assign.right(),
-        loop_var_lvalue);
+  if (iter.kind != slang::ast::ExpressionKind::Assignment) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
+        "this generate iteration form is not supported yet",
+        diag::UnsupportedCategory::kFeature);
   }
 
-  return diag::Unsupported(
-      span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
-      "this generate iteration form is not supported yet",
-      diag::UnsupportedCategory::kFeature);
+  const auto& assign = iter.as<slang::ast::AssignmentExpression>();
+  if (!assign.op.has_value()) {
+    return LowerStructuralExpr(
+        unit_facts, unit_state, parent_state, stack, assign.right());
+  }
+
+  auto read = LowerStructuralExpr(
+      unit_facts, unit_state, parent_state, stack, assign.left());
+  if (!read) return std::unexpected(std::move(read.error()));
+  const hir::ExprId read_id = parent_state.AddExpr(*std::move(read));
+
+  const auto& bare_rhs = BareCompoundUserRhs(assign.right());
+  auto rhs = LowerStructuralExpr(
+      unit_facts, unit_state, parent_state, stack, bare_rhs);
+  if (!rhs) return std::unexpected(std::move(rhs.error()));
+  const hir::ExprId rhs_id = parent_state.AddExpr(*std::move(rhs));
+
+  auto type_id = unit_state.GetTypeId(*iter.type, span);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::Expr{
+      .type = *type_id,
+      .data =
+          hir::BinaryExpr{
+              .op = LowerBinaryOp(*assign.op), .lhs = read_id, .rhs = rhs_id},
+      .span = span,
+  };
 }
 
 auto BuildLoopGenerate(
@@ -293,14 +312,8 @@ auto BuildLoopGenerate(
   if (!stop_expr) return std::unexpected(std::move(stop_expr.error()));
   const hir::ExprId stop_id = parent_state.AddExpr(*std::move(stop_expr));
 
-  const hir::Lvalue loop_var_lvalue{
-      .root =
-          hir::LoopVarRef{
-              .hops = hir::StructuralHops{0}, .loop_var = loop_var_id},
-      .selectors = {}};
   auto iter_expr = LowerLoopIterNextValue(
-      unit_facts, unit_state, parent_state, stack, *array.iterExpression,
-      loop_var_lvalue);
+      unit_facts, unit_state, parent_state, stack, *array.iterExpression);
   if (!iter_expr) return std::unexpected(std::move(iter_expr.error()));
   const hir::ExprId iter_id = parent_state.AddExpr(*std::move(iter_expr));
 

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -676,9 +676,22 @@ auto LowerHirAssignExprProc(
   mir::Lvalue lhs = *std::move(lhs_or);
 
   if (a.kind == hir::AssignKind::kBlocking) {
+    const std::optional<mir::BinaryOp> compound_op =
+        a.compound_op.has_value() ? std::optional{LowerBinaryOp(*a.compound_op)}
+                                  : std::nullopt;
     return mir::Expr{
-        .data = mir::AssignExpr{.target = std::move(lhs), .value = rhs_id},
+        .data =
+            mir::AssignExpr{
+                .target = std::move(lhs),
+                .compound_op = compound_op,
+                .value = rhs_id},
         .type = result_type};
+  }
+
+  if (a.compound_op.has_value()) {
+    throw InternalError(
+        "LowerHirAssignExprProc: compound assignment with non-blocking kind "
+        "is not a legal SV form (LRM A.6.2 grammar)");
   }
 
   if (!std::holds_alternative<mir::StructuralVarRef>(lhs.root)) {

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -533,9 +533,13 @@ class MirDumper {
                   c.condition.value, c.then_value.value, c.else_value.value);
             },
             [this](const AssignExpr& a) -> std::string {
+              const std::string op_str =
+                  a.compound_op.has_value()
+                      ? std::format(" op={}", FormatBinaryOp(*a.compound_op))
+                      : std::string{};
               return std::format(
-                  "AssignExpr target={} value=Expr[{}]", FormatLvalue(a.target),
-                  a.value.value);
+                  "AssignExpr target={}{} value=Expr[{}]",
+                  FormatLvalue(a.target), op_str, a.value.value);
             },
             [this](const CallExpr& c) -> std::string {
               std::string args;

--- a/tests/cases/cpp/compound_assign_element_select/case.yaml
+++ b/tests/cases/cpp/compound_assign_element_select/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.compound_assign_element_select
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    set_bit_const: 0x08
+    clear_bit_const: 0xDF
+    set_bit_dynamic: 0x08
+    add_dynamic_range: 0x0050

--- a/tests/cases/cpp/compound_assign_element_select/main.sv
+++ b/tests/cases/cpp/compound_assign_element_select/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  logic [7:0] set_bit_const;
+  logic [7:0] clear_bit_const;
+  logic [7:0] set_bit_dynamic;
+  logic [15:0] add_dynamic_range;
+
+  initial begin
+    set_bit_const = 8'b00000000;
+    set_bit_const[3] |= 1'b1;
+
+    clear_bit_const = 8'b11111111;
+    clear_bit_const[5] &= 1'b0;
+
+    set_bit_dynamic = 8'b00000000;
+    set_bit_dynamic[3] |= 1'b1;
+
+    add_dynamic_range = 16'h0000;
+    add_dynamic_range[4 +: 4] += 4'd5;
+  end
+endmodule

--- a/tests/cases/cpp/compound_assign_mixed_type/case.yaml
+++ b/tests/cases/cpp/compound_assign_mixed_type/case.yaml
@@ -1,0 +1,17 @@
+id: cpp.compound_assign_mixed_type
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    # x had 0xFFFFFF0F, y zero-extends to 32'h0000_000A, AND yields 0x0000_000A.
+    mixed_and_result: 0x0A
+    # x was 0, w zero-extends to 32'h0000_0003, OR yields 0x0000_0003.
+    mixed_or_result: 0x03
+    # narrowed_add[7:0] = 0x10 + (0x0123 narrowed to 0x23) = 0x33.
+    # High byte (0x00) unchanged -> 0x0033.
+    narrowed_add: 0x0033

--- a/tests/cases/cpp/compound_assign_mixed_type/main.sv
+++ b/tests/cases/cpp/compound_assign_mixed_type/main.sv
@@ -1,0 +1,28 @@
+module Top;
+  int          mixed_and_result;
+  int          mixed_or_result;
+  logic [15:0] narrowed_add;
+
+  initial begin
+    logic [3:0] y;
+    logic [7:0] w;
+    int         x;
+
+    // 4-state operand widens to int via slang's per-operand Conversion.
+    // Frontend rebuilds rhs typed to lhs.type so runtime stays at one shape.
+    x = 32'hFFFF_FF0F;
+    y = 4'b1010;
+    x &= y;
+    mixed_and_result = x;
+
+    x = 32'h0000_0000;
+    w = 8'b0000_0011;
+    x |= w;
+    mixed_or_result = x;
+
+    // Wider literal on the rhs side; assignment narrows back to slice width
+    // via the inserted ConversionExpr at the frontend.
+    narrowed_add = 16'h0010;
+    narrowed_add[7:0] += 16'h0123;
+  end
+endmodule

--- a/tests/cases/cpp/compound_assign_range_select/case.yaml
+++ b/tests/cases/cpp/compound_assign_range_select/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.compound_assign_range_select
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    add_const_range: 0x0080
+    or_const_range: 0x00B0
+    xor_indexed_up: 0xAA5A
+    sub_indexed_down: 0x00E0

--- a/tests/cases/cpp/compound_assign_range_select/main.sv
+++ b/tests/cases/cpp/compound_assign_range_select/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  logic [15:0] add_const_range;
+  logic [15:0] or_const_range;
+  logic [15:0] xor_indexed_up;
+  logic [15:0] sub_indexed_down;
+
+  initial begin
+    add_const_range = 16'h0050;
+    add_const_range[7:4] += 4'd3;
+
+    or_const_range = 16'h0030;
+    or_const_range[7:4] |= 4'b1010;
+
+    xor_indexed_up = 16'hAAAA;
+    xor_indexed_up[4 +: 4] ^= 4'hF;
+
+    sub_indexed_down = 16'h00F0;
+    sub_indexed_down[7 -: 4] -= 4'd1;
+  end
+endmodule

--- a/tests/cases/cpp/compound_assign_shift/case.yaml
+++ b/tests/cases/cpp/compound_assign_shift/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.compound_assign_shift
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    lshift_logical: 0x0010
+    rshift_logical: 0x0F00
+    lshift_arith: 16
+    rshift_arith: -4

--- a/tests/cases/cpp/compound_assign_shift/main.sv
+++ b/tests/cases/cpp/compound_assign_shift/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  logic [15:0] lshift_logical;
+  logic [15:0] rshift_logical;
+  int          lshift_arith;
+  int          rshift_arith;
+
+  initial begin
+    lshift_logical = 16'h0001;
+    lshift_logical <<= 4;
+
+    rshift_logical = 16'hF000;
+    rshift_logical >>= 4;
+
+    lshift_arith = 32'sd1;
+    lshift_arith <<<= 4;
+
+    rshift_arith = -32'sd16;
+    rshift_arith >>>= 2;
+  end
+endmodule

--- a/tests/framework/sv_literal.cpp
+++ b/tests/framework/sv_literal.cpp
@@ -345,14 +345,32 @@ auto ParseExpectedValue(std::string_view text, bool node_is_integer)
     ExpectedValue out;
     out.kind = ExpectedValueKind::kIntegerScalar;
     std::int64_t value = 0;
-    auto result = std::from_chars(
-        text.data(), text.data() + text.size(), value, 10);  // NOLINT
-    if (result.ec != std::errc{} || result.ptr != text.data() + text.size()) {
+    // yaml-cpp delivers the raw lexeme regardless of base prefix when
+    // node_is_integer is true. Honor the C/SV-style `0x` / `0X` prefix (and
+    // optional leading minus) so hex expectations like `0x08` work without
+    // forcing every yaml author to hand-convert to decimal. Bare unprefixed
+    // text parses as base 10 to match yaml's IntegerScalar contract.
+    std::string_view body = text;
+    bool negative = false;
+    if (!body.empty() && body.front() == '-') {
+      negative = true;
+      body.remove_prefix(1);
+    }
+    int base = 10;
+    if (body.size() >= 2 && body.front() == '0' &&
+        (body[1] == 'x' || body[1] == 'X')) {
+      base = 16;
+      body.remove_prefix(2);
+    }
+    auto result =
+        std::from_chars(body.data(), body.data() + body.size(), value, base);
+    if (result.ec != std::errc{} || result.ptr != body.data() + body.size()) {
       return std::unexpected(
           std::format(
               "expect.variables: cannot parse integer '{}'",
               std::string{text}));
     }
+    if (negative) value = -value;
     out.integer_value = value;
     out.bit_width = 32;
     out.is_signed = true;


### PR DESCRIPTION
## Summary

Adds full compound assignment support (`+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`, `<<<=`, `>>>=`) end-to-end. Compound is treated as a first-class IR concept: `AssignExpr` carries an optional `compound_op` field that survives unchanged through HIR -> MIR -> emit, and the C++ backend renders it directly as `op=` rather than expanding to a read-modify-write at lowering time. LRM 11.4.1 "evaluate target only once" is delegated to the C++ standard's eval-once guarantee on the lvalue chain expression.

## Design

The runtime gains `operator+=` (etc.) overloads on three proxy types -- `PackedArray` for procedural locals, `PackedArrayRef` for selector partial writes, and `ScopedMutation<PackedArray>` for whole-var observable writes. Each forwards to `*this = *this op rhs` over the existing binary operators, so the LRM operand-type rules (4-state propagation, narrowing on store) ride on the same machinery as simple binary ops. Whole-var observable compound emits `x.Mutate(svc) op= rhs`, mirroring the selector form `x.Mutate(svc).Chain(...) op= rhs` so the two shapes are visually symmetric.

Slang's compound expansion wraps the user's rhs inside `Conversion(lhs.type) { BinaryOp(op) { Conv(common, LValueRef), Conv(common, user_rhs) } }`. AST -> HIR discards that expansion entirely: `BareCompoundUserRhs` walks past slang's outer Conversion to find the `BinaryOp`, identifies which operand wraps the synthetic `LValueReference`, returns the user-written rhs from the other operand, and the frontend re-wraps it in a single `ConversionExpr(lhs.type)` if needed so the runtime stays at one shape. Slang's invariant of at-most-one Conversion per wrap site is asserted via conditional peels rather than `while` loops, so any future slang change surfaces as a loud `InternalError` rather than a silent miscompile.

Generate iteration (`for (genvar i = ...; ...; i op= ...)`) is rewritten to a direct `BinaryExpr{op, ReadOfLvalue, BareUserRhs}` at AST -> HIR, since the loop header consumes a next-value expression, not a runtime mutation.

The slang-to-HIR atomic translators (`LowerBinaryOp`, `LowerConversionKind`, `LowerUnaryOp`, `LowerTimeUnit`, `BareCompoundUserRhs`, etc.) move out of `expression/lower.cpp` into a new `expression/slang_atoms.{hpp,cpp}`. The recursive lowering pipeline now lives alone in `lower.cpp` with a single anonymous namespace, and slang-specific quirk handling has a dedicated home for future additions.

## Other changes

- `ProcessCoroutine::Resume` now preserves the original `what()` via `std::exception_ptr` so a runtime crash surfaces the underlying invariant (e.g. `PackedArray::Modulo: operand state-kind mismatch`) instead of a generic "coroutine failed" message. The emitted `main()` wraps `engine.Run()` in a `std::exception` catch that prints `e.what()` directly.
- `InternalError`'s constructor now wraps the caller-supplied message with `Internal error:` and the GitHub bug-report URL, matching the archive's framing.
- `expect.variables` accepts `0x` / `0X` hex prefixes (and a leading `-`) so SV-style hex expectations no longer need hand conversion to decimal.

## Testing

- `tests/cases/cpp/compound_assign_shift` -- 4 shift compounds (logical / arithmetic, both directions).
- `tests/cases/cpp/compound_assign_range_select` -- range-select compounds with constant, indexed-up, indexed-down bounds.
- `tests/cases/cpp/compound_assign_element_select` -- element-select compounds with constant and dynamic indices.
- `tests/cases/cpp/compound_assign_mixed_type` -- cross-type compounds (`int &= logic[3:0]`, slice narrowing) exercising the explicit-conversion-to-lhs-type path.