### PR TITLE
Add continuous assignment and unify sensitivity inference

### DIFF
--- a/docs/decisions/read-set-inference.md
+++ b/docs/decisions/read-set-inference.md
@@ -1,0 +1,325 @@
+# Read-Set Inference via slang Flow Analysis
+
+## Date
+
+2026-05-29
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+Several SystemVerilog features require a read set -- the set of symbols whose change should
+re-trigger evaluation of a procedural fragment:
+
+- `always_comb` / `always_latch` body (LRM 9.2.2.2.1)
+- `always @*` region (LRM 9.4.2.2)
+- `assign lhs = rhs;` continuous assignment (LRM 10.3)
+- `wait (cond)` cond expression (LRM 9.4.3)
+- (future) concurrent assertions and properties (LRM 16)
+- (future) `wait_order(...)` (LRM 15.6)
+
+Each of these features asks the same underlying question and -- absent a load-bearing architectural
+rule -- has historically each grown its own answer. `always_comb` already routes through slang's
+`AnalysisManager` (the listener path in `compile.cpp`). The first cut of `wait` and the first cut of
+continuous assignment both grew hand-coded `ASTVisitor`-derived walkers that duplicated parts of
+slang's leaf-set logic.
+
+The cost of getting the answer wrong is not a behavioural bug. Naive walkers do not under-collect --
+they over-collect, by recording symbols that slang's data-flow analysis would have excluded
+(must-def writes, locally-declared helpers, lvalue positions inside calls). The wrong-shaped read
+set causes spurious wake-ups, which causes redundant body re-evaluation, which is exactly the gap
+separating us from production simulators. The project principle is that **performance is
+correctness**: an answer that produces the right value but at the wrong cost is the wrong answer.
+Treating "the simulation still produces the right value" as good enough is incompatible with the
+project's reason for existing.
+
+This document fixes the inference path so subsequent features inherit one infrastructure and the
+older hand-coded walkers can be removed.
+
+## Findings that shaped the design
+
+### F1. slang's flow-analysis framework was designed for caller composition
+
+Two public extension points exist on `slang::analysis::AnalysisManager`:
+
+`slang/include/slang/analysis/AnalysisManager.h:100-118`:
+
+```cpp
+void addListener(std::function<void(const AnalyzedProcedure&)> listener);
+```
+
+The procedure listener fires after each procedure-like symbol has been analyzed. It receives the
+finished `AnalyzedProcedure` (which already carries `getSensitivityList()`,
+`getImplicitEventReadSets()`, and `getTimedStatements()`).
+
+`slang/include/slang/analysis/AnalysisManager.h:120-130`:
+
+```cpp
+using CustomDFAProvider = std::function<AnalyzedProcedure(AnalysisContext&,
+                                                          const ast::Symbol&,
+                                                          const AnalyzedProcedure*)>;
+void setCustomDFAProvider(CustomDFAProvider provider);
+```
+
+The custom DFA provider replaces slang's default flow analysis construction. slang calls it for each
+procedure-like symbol with the worker-local `AnalysisContext`, the symbol, and the parent procedure
+(if any). The callback is expected to build and run whatever flow analysis the caller wants, then
+return an `AnalyzedProcedure` instance.
+
+**Consequence:** every piece we need is reachable through public API. The listener handles
+post-analysis result extraction; the provider gives us access to `AnalysisContext` and the
+construction site we need for any secondary analysis that must run in the same context.
+
+### F2. slang treats continuous assignments as procedures for analysis
+
+`slang/include/slang/analysis/AnalyzedProcedure.h:81-82`:
+
+> Note that this can include continuous assignments, which are not technically procedures but are
+> treated as such for analysis purposes.
+
+`slang/source/analysis/AnalyzedProcedure.cpp:295-299` confirms it -- the same `addReads` pipeline
+that builds the sensitivity list for `always_comb` also runs for `ContinuousAssignSymbol`,
+controlled by `AnalysisFlags::ContAssignUsesLSPs`.
+
+`slang/source/analysis/AnalysisScopeVisitor.h:115-122` shows both kinds go through the same listener
+pipeline:
+
+```cpp
+template<typename T>
+    requires(IsAnyOf<T, ProceduralBlockSymbol, ContinuousAssignSymbol>)
+void visit(const T& symbol) {
+    result.procedures.emplace_back(manager.analyzeProcedure(...));
+    // ...
+    for (auto& listener : manager.procListeners)
+        listener(result.procedures.back());
+}
+```
+
+**Consequence:** continuous assignment sensitivity is available through the listener path with no
+extra work beyond recognising the `ContinuousAssignSymbol` symbol kind.
+
+### F3. The abstract flow-analysis pass accepts arbitrary subtree roots
+
+`slang/include/slang/analysis/AbstractFlowAnalysis.h:97-107`:
+
+```cpp
+void run(const Statement& stmt) { state = (DERIVED).topState(); visit(stmt); }
+void run(const Expression& expr) { state = (DERIVED).topState(); visit(expr); }
+```
+
+Both overloads are public and symmetric. The framework will analyze any statement or expression a
+caller hands it -- the symbol-kind switch in `DataFlowAnalysis::run()` is convenience, not a
+restriction.
+
+**Consequence:** any sub-expression read set (a `wait` cond, an assertion clause, a property
+argument) can be analyzed by instantiating a flow-analysis pass and calling `run(expr)` on the
+sub-expression directly. The procedure's overall analysis does not need to track sub-region read
+sets separately -- we re-run the analysis on the sub-tree we care about.
+
+### F4. The default flow-analysis subclass is exported and ready to use
+
+`slang/include/slang/analysis/DataFlowAnalysis.h:675-679`:
+
+```cpp
+class SLANG_EXPORT DefaultDFA : public DataFlowAnalysis<DefaultDFA, DataFlowState> {
+public:
+    DefaultDFA(AnalysisContext& context, const Symbol& symbol, bool reportDiags) :
+        DataFlowAnalysis(context, symbol, reportDiags) {}
+};
+```
+
+`DefaultDFA` is slang's own concrete subclass that inherits the framework unchanged. It is
+`SLANG_EXPORT` -- a public API entry. slang's internal fallback when no custom provider is set is
+itself a `DefaultDFA` instance (`AnalysisManager.cpp:397-403`).
+
+**Consequence:** for our use case ("run full flow analysis on a subtree, no behaviour overrides"),
+no subclass is needed. We instantiate `DefaultDFA` directly. There is no state type to design, no
+hooks to override, no template parameters to choose.
+
+### F5. Must-def precision matters even inside a single Expression subtree
+
+The intuitive split "Statements need DFA, Expressions do not" is wrong. SystemVerilog allows side
+effects inside expressions:
+
+- Embedded assignment expressions: `(tmp = a + b) + tmp`
+- Function calls with `output` / `inout` / `ref` arguments: `f(in, output buf) + buf`
+- Increment / decrement: `++counter + counter`
+- Compound assignment: `(x += y) + x`
+
+In each case, a leaf appears in rvalue position after a definite write to the same symbol. Lvalue
+tracking alone (classifying leaves as read vs write) does not exclude the second-occurrence read;
+only must-def does. A lite walker covers the common case but not these.
+
+For `wait` cond specifically, LRM 11.3.6 forbids assignment operators in timing-control expressions,
+ruling out the first three. Function calls with output arguments remain reachable: a walker that
+does not understand them will over-collect.
+
+**Consequence:** any path that handles read-set inference must come from a data-flow analysis that
+distinguishes lvalue from rvalue position and excludes must-def reads. Hand walkers, no matter how
+careful about leaf enumeration, cannot reach this without re-implementing DFA.
+
+### F6. Local-symbol exclusion alone closes most but not all of the gap
+
+slang's `isLocal` filter (`slang/source/analysis/AnalyzedProcedure.cpp:248-271`) excludes symbols
+declared inside the procedure's scope chain. For `always_comb` bodies this is the dominant source of
+bloat that a hand walker would introduce: procedure-local helpers are common.
+
+The remaining gap -- non-local must-def, where a module-level symbol is written-then-read inside the
+procedure -- only causes spurious wake-ups when the symbol is also driven by another process. In
+well-formed SystemVerilog this is uncommon, because most signals have a single driver.
+
+**Consequence:** a hand walker that adds local-symbol filtering claws back the visible majority of
+slang's precision. However, the project's `perf = correctness` principle makes the residual gap
+unacceptable on principle, even if its quantitative impact is small. Locking in a "good enough"
+walker now forces a second migration later when the residual case starts mattering.
+
+## The decision
+
+All read-set inference is driven by slang's existing flow-analysis framework. We do not write a
+subclass; we do not write a hand walker. We drive two slang surfaces:
+
+1. **`AnalysisManager::setCustomDFAProvider`** is set to a callback that:
+   - Constructs `DefaultDFA(context, symbol, /*reportDiags=*/true)`
+   - Calls `dfa.run()` to do the procedure-level analysis (always_comb / always_latch / `@*` /
+     continuous assignment, depending on the symbol kind)
+   - Iterates `dfa.getTimedStatements()` to find every `WaitStatement`. For each one, constructs a
+     **fresh** `DefaultDFA` and calls `DefaultDFA::AbstractFlowAnalysis::run(wait.cond)` directly.
+     The resulting `getRValues()` is the per-wait sensitivity list.
+   - Records both procedure-level and per-wait results into a project-owned `SensitivityReadStore`
+     under a mutex (the callback may be invoked concurrently from worker threads).
+   - Returns the same `AnalyzedProcedure` slang's default path would have returned, so downstream
+     listeners and consumers see no behavioural difference.
+
+2. **`AnalysisManager::addListener`** is set to a callback that only reads from the already-built
+   `AnalyzedProcedure` -- it harvests `getSensitivityList()` and `getImplicitEventReadSets()` for
+   the procedure-level cases. It does not need `AnalysisContext`, which is why it is split from the
+   provider above. Listener and provider coexist.
+
+Per-wait analysis works precisely because the cond expression is fed to `AbstractFlowAnalysis::run`
+directly. slang's `visitStmt(WaitStatement)` (`AbstractFlowAnalysis.h:603-612`) -- which wraps the
+cond in `enterTimingControlExpr` / `leaveTimingControlExpr` and would suppress rvalue tracking per
+LRM 9.4.2.2 -- never fires, because we bypass that visitor entry point. The cond is analyzed as an
+ordinary expression, and its reads land in `rvalues` like any other expression's reads.
+
+The `SensitivityReadStore` is keyed by slang's two analyzable AST hierarchies:
+`const ast::Statement*` for whole-statement read sets (procedural-block bodies and `@*` regions,
+where slang's listener attaches the read set to a statement) and `const ast::Expression*` for
+sub-expression read sets (the wait cond expression and the continuous assignment's
+`AssignmentExpression`, where we ran or harvested the analysis on an expression subtree). The keying
+split mirrors slang's own AST hierarchy split rather than enumerating specific source-language
+features, so future per-expression analyses (LRM 16 property / assertion expressions, LRM 15.6
+`wait_order` event-list expressions) plug into the existing Expression bucket without API changes.
+Both buckets flow into `TranslateSensitivityReads` on the way to HIR `SensitivityEntry`.
+
+The only project-owned code involved is:
+
+- The two callback lambdas (~30 lines each)
+- A `FlattenReadSet` helper that walks `getRValues()` into `vector<SensitivityRead>` (mirrors
+  `AnalyzedProcedure.cpp:223-227`)
+- The map-shape change and consumer-side lookup migrations
+
+No subclass, no state type, no hook overrides, no use of slang's `detail::` namespace.
+
+## Rejected alternatives
+
+### A. Two paths: slang's listener for symbol-level + hand walker for sub-expression
+
+Use the `addListener` path where it gives us what we need (procedural blocks, `@*` regions,
+continuous assignments), and a hand-coded `ASTVisitor`-derived walker for `wait` cond. Initial
+implementation of both `wait` (in `WaitCondReadCollector`) and continuous assignment (in
+`ContinuousAssignReadCollector` and later `ExpressionReadCollector`) took this shape.
+
+Rejected because the hand-walker side cannot reach slang's precision (F5 says must-def matters even
+inside expressions; F6 says local-symbol filtering does not close the gap). The architectural split
+also has no remaining justification once F1 + F3 + F4 show that slang's framework is already
+composable for the sub-expression case.
+
+### B. Single hand walker for everything
+
+Drop slang entirely and run a hand walker on `always_comb` bodies too. Cheapest path. Rejected
+because losing must-def and local-symbol exclusion on procedural bodies makes the read set
+dramatically wrong on real designs. Project principle: silent over-collection is not acceptable on
+principle, not just when the cost shows up.
+
+### B'. Single hand walker plus local-symbol filter
+
+Add the `isLocal` filter from F6 to a hand walker. Closes most of the gap (estimated 90-95%) for a
+small effort. Rejected because the residual gap (non-local must-def under multi-driver conditions,
+F6) is silently incorrect under the project's principle. Locking in a "good enough" walker now
+creates known-stale interim code that has to be unwound the first time a benchmark exposes the
+residual.
+
+### C. Subclass `DataFlowAnalysis` with custom hooks and state
+
+The first version of this decision (before reading slang's source end-to-end) proposed building a
+project-owned subclass of `DataFlowAnalysis<TDerived, TState>`, designing a custom state type, and
+overriding `enterTimingControlExpr` / `leaveTimingControlExpr` to extract per-wait sub-region read
+sets during the procedure-level analysis.
+
+Rejected as unnecessary. F1 + F3 + F4 show that the same outcome is reachable through slang's public
+API without any of the subclass machinery: `DefaultDFA` is exported,
+`AbstractFlowAnalysis::run(Expression)` accepts arbitrary sub-trees, and `setCustomDFAProvider` is
+the official integration hook. Sub-region reads come from running a second `DefaultDFA` on the
+sub-tree, not from intercepting the procedure-level pass.
+
+This rejection is the load-bearing simplification of this revision of the document. Earlier drafts
+-- and the cuts they would have produced -- assumed work that was never required.
+
+### C'. Vendor a patch to slang adding per-construct sensitivity APIs
+
+File a slang PR adding `getWaitSensitivity(WaitStatement*)` and similar to `AnalyzedProcedure`.
+Deferred -- not categorically rejected. slang's current API is composable enough that a downstream
+consumer (us) can implement the per-wait extraction in a few lines. Upstreaming an "is-per-wait"
+accessor is a reasonable contribution to make later for reusability, but we do not gate on it. If we
+contribute upstream, the project-owned callback shrinks to a few lines of API translation.
+
+## Consequences
+
+### Immediate
+
+- Sensitivity inference lives in `lowering/ast_to_hir/sensitivity.{hpp,cpp}`, alongside the store
+  types and the slang-to-HIR `TranslateSensitivityReads`. The producer is
+  `BuildSensitivityReadStore(compilation)`, which sets a `CustomDFAProvider` (per-wait DFA, store
+  writes) and an `addListener` callback (procedure-level + `@*` region + continuous assignment store
+  writes). The previous single `unordered_map<const Statement*, vector<SensitivityRead>>` becomes a
+  two-keyed `SensitivityReadStore` keyed by `Statement*` (procedure body / `@*` region) and
+  `Expression*` (wait cond / continuous-assignment expression). `compile.cpp` shrinks to
+  orchestration -- it just calls `BuildSensitivityReadStore` and threads the result through
+  `LowerCompilationFacts`.
+- The hand-coded walkers in `include/lyra/lowering/ast_to_hir/sensitivity.hpp` (the
+  `ExpressionReadCollector`) and `src/lyra/lowering/ast_to_hir/statement/lower.cpp` (the
+  `WaitCondReadCollector`) are deleted.
+- Wait-statement and continuous-assignment lowering switch from walker invocation to map lookup,
+  symmetric with how always_comb already looks up by procedure-body statement.
+- Continuous assignment gains correctness it did not have before: function calls with output
+  arguments in the RHS, embedded assignments, and compound expressions are now read-set-correct.
+- Wait cond inherits the same correctness.
+
+### Future features
+
+- `wait_order(...)` (LRM 15.6) reuses the same shape: it is already in
+  `AbstractFlowAnalysis.h:614-619`'s timing-control path, surfaces via `getTimedStatements()`, and
+  feeds the same per-sub-tree DFA pattern.
+- Concurrent assertions and properties (LRM 16) feed into the same framework: slang has
+  `enterAssertionActionBlock` / `leaveAssertionActionBlock` hooks already and the existing flow
+  analysis handles assertion bodies. Per-assertion read-set extraction follows the same per-sub-tree
+  `DefaultDFA::run` pattern.
+- Other compile-time analyses that would otherwise re-walk the AST (unused-write detection,
+  dead-code analysis, lint-style checks) can use the same custom-DFA-provider hook to drive flow
+  analysis once and extract multiple result kinds in a single pass.
+
+### Operational
+
+- Project owns no DFA implementation. Updates to slang's `DataFlowState`, flow-analysis internals,
+  or read-set tracking are transparent. The surface we depend on is `slang::analysis::DefaultDFA`,
+  `slang::analysis::DataFlowState`, `setCustomDFAProvider`, `addListener`, `AnalyzedProcedure`'s
+  public accessors, and `AbstractFlowAnalysis::run` -- all public, all `SLANG_EXPORT`.
+- Listener and provider may be invoked from multiple worker threads
+  (`AnalysisScopeVisitor.h:117-122` runs inside thread-pool worker tasks). The store-write side is
+  protected by a single `std::mutex`. Per-listener cost is dominated by DFA execution; the
+  store-write critical section is trivial, so contention is negligible.
+- Each DFA instance is single-use: the flow-analysis result fields (`rvalues`, `lvalues`,
+  `symbolToSlot`, `timedStatements`, ...) accumulate across `run()` calls and are never cleared by
+  the framework. Per-wait DFAs are freshly constructed inside the provider callback.

--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -146,7 +146,7 @@ Tracked in `processes.md`. Covers procedural blocks (`initial`, `final`, `always
 `always_latch`, `always_ff`), timing controls (`#N`, `@(...)`), assignments (`<=`, `assign`), and
 synchronisation primitives (named events, `wait`, `fork`/`join_*`).
 
-- [ ] processes/continuous_assign -- `processes.md` P7.
+- [x] processes/continuous_assign -- `processes.md` P7.
 - [x] processes/delay -- `processes.md` T1.
 - [ ] processes/edge_trigger_bit_select -- `processes.md` T3 (whole-variable subset, done) and T5
       (selected subset, blocked).

--- a/docs/progress/processes.md
+++ b/docs/progress/processes.md
@@ -19,7 +19,6 @@ order. Items in the [Actionable](#actionable) section can be picked up next; ite
 | Item   | Blocked on                                                                                                            |
 | ------ | --------------------------------------------------------------------------------------------------------------------- |
 | P5, P6 | Bit-select / range-select expressions in MIR (`operators.md` W4 / W5). Edge triggers on selected lvalues need them.   |
-| P7     | `assign` continuous-assignment closures share infrastructure with `always_comb` (P10); start P10 first.               |
 | P8     | `fork` / `join_*`. Needs concurrent-process scheduling primitives; out of scope until single-process work is settled. |
 
 ## Sub-Steps
@@ -44,8 +43,9 @@ order. Items in the [Actionable](#actionable) section can be picked up next; ite
       `always_ff` body of `processes/wait_event`.
 - [x] P10 / P13 -- `always_comb` / `always_latch` (LRM 9.2.2.2.1) and `always @*` / `always @(*)`
       (LRM 9.4.2.2). Slang's `AnalysisManager` produces read sets (per-procedure for always_comb /
-      always_latch, per-region for `@*`), stored in `ImplicitSensitivityReads` keyed by
-      `slang::ast::Statement*`. HIR carries them on `Process::implicit_sensitivity_list` for the
+      always_latch, per-region for `@*`); the lyra pipeline stores them in `SensitivityReadStore`
+      keyed by `slang::ast::Statement*` (see `docs/decisions/read-set-inference.md` for the shared
+      inference architecture). HIR carries them on `Process::implicit_sensitivity_list` for the
       always_comb / always_latch forms and on `ImplicitEventControl::sensitivity_list` for `@*`. HIR
       -> MIR: always_comb / always_latch run `forever { body; SensitivityWaitStmt; }` (body at t=0
       then wait per LRM 9.2.2.2); `@*` expands to `Block { SensitivityWaitStmt; body; }` (wait first
@@ -58,8 +58,15 @@ order. Items in the [Actionable](#actionable) section can be picked up next; ite
       phase; the engine commits all closures in the kCommitNba phase before observing changes.
       Re-entrancy (`SubmitNba` during NBA commit) is rejected. Covers the basic NBA cases used by
       every `always_ff` example.
-- [ ] P7 -- Continuous assignment `assign x = y;`. Module-level construct, not a procedural block;
-      shares the read-set inference path with P10. Closes `processes/continuous_assign`.
+- [x] P7 -- Continuous assignment `assign x = y;` (LRM 10.3). Source-aligned in HIR as a scope-level
+      `ContinuousAssign {lhs, rhs, sensitivity_list}` whose LHS / RHS land in the enclosing
+      structural scope's expr pool alongside parameters and variable initialisers. Read set is
+      precomputed by slang's flow analysis (slang treats continuous assignment as a procedure for
+      analysis purposes, LRM 10.3.2 reads identical to LRM 9.2.2.2.1); the AST -> HIR lowering looks
+      it up keyed by the assignment expression (see `docs/decisions/read-set-inference.md`). HIR ->
+      MIR materialises a `mir::Process { kInitial, forever { lhs = rhs; SensitivityWait(reads); } }`
+      directly. Drive strength (10.3.4) and `assign #N` (10.3.3) are diagnosed; concat LHS rides on
+      the procedural side. Closes `processes/continuous_assign`.
 
 ### Timing controls
 
@@ -93,12 +100,13 @@ order. Items in the [Actionable](#actionable) section can be picked up next; ite
       waiter list. `e.triggered` returns a 1-bit `PackedArray`. `->>` non-blocking trigger,
       `wait_order(...)`, event aliasing / nullness / comparison are out of scope.
 - [x] P11 -- `wait (cond) body` level-sensitive control (LRM 9.4.3). HIR carries
-      `WaitStmt {cond, body, sensitivity_list}`; the sensitivity is collected locally at the
-      `LowerWaitStmt` site by a small ASTVisitor over `cond` (no upstream manager pass, since slang
-      owns no DFA for wait conditions). HIR -> MIR lowers to
-      `Block { While { !cond, SensitivityWait(reads) }; body }` -- the LRM 9.4.3 "skip suspend if
-      cond is already true" semantic falls out of the while-loop shape. `wait fork;` (9.6.1) and
-      `wait_order(...)` (15.6) are out of scope. Closes `processes/wait_event`.
+      `WaitStmt {cond, body, sensitivity_list}`. Sensitivity is precomputed by driving slang's
+      `DefaultDFA` on `cond` as a standalone expression during the AnalysisManager pass (see
+      `docs/decisions/read-set-inference.md`); the AST -> HIR lowering looks it up keyed by the cond
+      expression. HIR -> MIR lowers to `Block { While { !cond, SensitivityWait(reads) }; body }` --
+      the LRM 9.4.3 "skip suspend if cond is already true" semantic falls out of the while-loop
+      shape. `wait fork;` (9.6.1) and `wait_order(...)` (15.6) are out of scope. Closes
+      `processes/wait_event`.
 
 ### Concurrency
 

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -31,6 +31,7 @@ enum class DiagCode : std::uint32_t {
   kUnsupportedTimingControlKind,
   kUnsupportedDelayExpressionForm,
   kUnsupportedEventTriggerForm,
+  kUnsupportedContinuousAssignForm,
 
   kDelayValueOutOfRange,
   kFormatStringTrailingPercent,

--- a/include/lyra/hir/continuous_assign.hpp
+++ b/include/lyra/hir/continuous_assign.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+#include <vector>
+
+#include "lyra/diag/source_span.hpp"
+#include "lyra/hir/expr_id.hpp"
+#include "lyra/hir/lvalue.hpp"
+#include "lyra/hir/stmt.hpp"
+
+namespace lyra::hir {
+
+struct ContinuousAssignId {
+  std::uint32_t value;
+
+  auto operator<=>(const ContinuousAssignId&) const
+      -> std::strong_ordering = default;
+};
+
+// LRM 10.3 `assign lhs = rhs;` -- source-aligned with slang's
+// `ContinuousAssignSymbol` at scope level. The LHS and RHS live in the
+// containing `StructuralScope.exprs` pool (selector ExprIds in `lhs` and the
+// `rhs` ExprId both index into it), matching how every other scope-level
+// expression (parameter values, variable initialisers) is stored. HIR -> MIR
+// translates `lhs` and `rhs` into a synthesised `mir::Process` whose body is
+// `forever { lhs = rhs; SensitivityWaitStmt(sensitivity_list); }`, giving
+// continuous assignment the same runtime mental model as always_comb
+// (LRM 9.2.2.2.1).
+struct ContinuousAssign {
+  diag::SourceSpan span;
+  Lvalue lhs;
+  ExprId rhs;
+  std::vector<SensitivityEntry> sensitivity_list;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "lyra/base/time.hpp"
+#include "lyra/hir/continuous_assign.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/loop_var.hpp"
 #include "lyra/hir/process.hpp"
@@ -73,6 +74,7 @@ struct StructuralScope {
   std::vector<LoopVarDecl> loop_var_decls;
   std::vector<Expr> exprs;
   std::vector<Process> processes;
+  std::vector<ContinuousAssign> continuous_assigns;
   std::vector<Generate> generates;
   std::vector<StructuralSubroutineDecl> structural_subroutines;
   std::vector<TypeAliasDecl> type_aliases;
@@ -90,6 +92,10 @@ struct StructuralScope {
   }
   [[nodiscard]] auto GetProcess(ProcessId id) const -> const Process& {
     return processes.at(id.value);
+  }
+  [[nodiscard]] auto GetContinuousAssign(ContinuousAssignId id) const
+      -> const ContinuousAssign& {
+    return continuous_assigns.at(id.value);
   }
   [[nodiscard]] auto GetGenerate(GenerateId id) const -> const Generate& {
     return generates.at(id.value);

--- a/include/lyra/lowering/ast_to_hir/continuous_assign.hpp
+++ b/include/lyra/lowering/ast_to_hir/continuous_assign.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <slang/ast/symbols/MemberSymbols.h>
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/continuous_assign.hpp"
+#include "lyra/lowering/ast_to_hir/facts.hpp"
+#include "lyra/lowering/ast_to_hir/state.hpp"
+
+namespace lyra::lowering::ast_to_hir {
+
+auto LowerContinuousAssign(
+    const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
+    ScopeStack& stack, const slang::ast::ContinuousAssignSymbol& sym)
+    -> diag::Result<hir::ContinuousAssign>;
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/expression/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/lower.hpp
@@ -19,12 +19,23 @@ auto LowerStructuralExpr(
     ScopeLoweringState& scope_state, const ScopeStack& stack,
     const slang::ast::Expression& expr) -> diag::Result<hir::Expr>;
 
-// Lower a slang assignment LHS into an HIR Lvalue. Process-side only:
-// structural code has no general assignment form. (Generate loop iteration
-// is handled by the loop's next-value semantic, not by an assignment.)
+// Lower a slang assignment LHS into an HIR Lvalue, with selector
+// subexpressions added to the process's expr pool. For the structural
+// counterpart (continuous-assignment LHS, LRM 10.3) see
+// LowerStructuralLvalue below.
 auto LowerProcLvalue(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const slang::ast::Expression& expr) -> diag::Result<hir::Lvalue>;
+
+// Same shape as LowerProcLvalue but for scope-level assignment targets
+// (continuous assignment LHS, LRM 10.3). Selector subexpressions land in the
+// enclosing scope's expr pool. Root is restricted to StructuralVarRef --
+// neither procedural vars nor generate-loop induction vars are visible at
+// scope level.
+auto LowerStructuralLvalue(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ScopeLoweringState& scope_state, const ScopeStack& stack,
     const slang::ast::Expression& expr) -> diag::Result<hir::Lvalue>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/facts.hpp
+++ b/include/lyra/lowering/ast_to_hir/facts.hpp
@@ -4,7 +4,7 @@
 #include <slang/ast/symbols/BlockSymbols.h>
 
 #include "lyra/frontend/slang_source_mapper.hpp"
-#include "lyra/lowering/ast_to_hir/lower.hpp"
+#include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -12,7 +12,7 @@ class UnitLoweringFacts {
  public:
   UnitLoweringFacts(
       const frontend::SlangSourceMapper& source_mapper,
-      const ImplicitSensitivityReads& sensitivity_reads)
+      const SensitivityReadStore& sensitivity_reads)
       : source_mapper_(&source_mapper), sensitivity_reads_(&sensitivity_reads) {
   }
 
@@ -21,14 +21,13 @@ class UnitLoweringFacts {
     return *source_mapper_;
   }
 
-  [[nodiscard]] auto SensitivityReads() const
-      -> const ImplicitSensitivityReads& {
+  [[nodiscard]] auto SensitivityReads() const -> const SensitivityReadStore& {
     return *sensitivity_reads_;
   }
 
  private:
   const frontend::SlangSourceMapper* source_mapper_;
-  const ImplicitSensitivityReads* sensitivity_reads_;
+  const SensitivityReadStore* sensitivity_reads_;
 };
 
 class ScopeLoweringFacts {

--- a/include/lyra/lowering/ast_to_hir/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/lower.hpp
@@ -1,47 +1,20 @@
 #pragma once
 
-#include <cstdint>
-#include <unordered_map>
-#include <utility>
-#include <vector>
-
 #include <slang/ast/Compilation.h>
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/frontend/slang_source_mapper.hpp"
 #include "lyra/hir/module_unit.hpp"
-
-namespace slang::ast {
-class Statement;
-class ValueSymbol;
-}  // namespace slang::ast
+#include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 
 namespace lyra::lowering::ast_to_hir {
-
-// Mirrors slang's ReadRange. Multiple entries for the same symbol with
-// disjoint bit ranges are kept as-is so downstream can preserve precision
-// when the runtime supports bit-level subscription.
-struct SensitivityRead {
-  const slang::ast::ValueSymbol* symbol;
-  std::pair<std::uint64_t, std::uint64_t> bit_range;
-};
-
-// Slang-derived sensitivity precomputed via slang's AnalysisManager, keyed
-// by the slang Statement that LRM associates the list with:
-//   - LRM 9.2.2.2.1 (always_comb / always_latch): key = &proc.getBody().
-//   - LRM 9.4.2.2 (`@*` / `@(*)`): key = the TimedStatement holding `@*`.
-// Forms whose read set we derive ourselves (wait, future wait_order) walk
-// their own expression locally at the lowering site and do not use this
-// map.
-using ImplicitSensitivityReads = std::unordered_map<
-    const slang::ast::Statement*, std::vector<SensitivityRead>>;
 
 class LowerCompilationFacts {
  public:
   LowerCompilationFacts(
       slang::ast::Compilation& compilation,
       const frontend::SlangSourceMapper& source_mapper,
-      const ImplicitSensitivityReads& sensitivity_reads)
+      const SensitivityReadStore& sensitivity_reads)
       : compilation_(&compilation),
         source_mapper_(&source_mapper),
         sensitivity_reads_(&sensitivity_reads) {
@@ -54,15 +27,14 @@ class LowerCompilationFacts {
       -> const frontend::SlangSourceMapper& {
     return *source_mapper_;
   }
-  [[nodiscard]] auto SensitivityReads() const
-      -> const ImplicitSensitivityReads& {
+  [[nodiscard]] auto SensitivityReads() const -> const SensitivityReadStore& {
     return *sensitivity_reads_;
   }
 
  private:
   slang::ast::Compilation* compilation_;
   const frontend::SlangSourceMapper* source_mapper_;
-  const ImplicitSensitivityReads* sensitivity_reads_;
+  const SensitivityReadStore* sensitivity_reads_;
 };
 
 auto LowerCompilation(const LowerCompilationFacts& facts)

--- a/include/lyra/lowering/ast_to_hir/sensitivity.hpp
+++ b/include/lyra/lowering/ast_to_hir/sensitivity.hpp
@@ -1,14 +1,88 @@
 #pragma once
 
+#include <cstdint>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "lyra/hir/stmt.hpp"
-#include "lyra/lowering/ast_to_hir/lower.hpp"
+
+namespace slang::ast {
+class Compilation;
+class Expression;
+class Statement;
+class ValueSymbol;
+}  // namespace slang::ast
 
 namespace lyra::lowering::ast_to_hir {
 
 class ScopeStack;
 class UnitLoweringState;
+
+// Mirrors slang's ReadRange. Multiple entries for the same symbol with
+// disjoint bit ranges are kept as-is so downstream can preserve precision
+// when the runtime supports bit-level subscription.
+struct SensitivityRead {
+  const slang::ast::ValueSymbol* symbol;
+  std::pair<std::uint64_t, std::uint64_t> bit_range;
+};
+
+// Precomputed sensitivity reads, harvested by driving slang's flow analysis
+// from `setCustomDFAProvider` + `addListener`. See
+// `docs/decisions/read-set-inference.md` for the architecture rationale.
+//
+// Two keying dimensions matching slang's two analyzable AST hierarchies:
+//   - `Statement` keys: the whole-statement read set produced by analyzing
+//     a procedure body. always_comb / always_latch (LRM 9.2.2.2.1) and `@*`
+//     regions (LRM 9.4.2.2) live here.
+//   - `Expression` keys: the read set produced by analyzing one expression
+//     subtree. `wait (cond)` (LRM 9.4.3), continuous-assignment
+//     `AssignmentExpression` (LRM 10.3), future `wait_order` event-list
+//     expressions, and future property / assertion expressions live here.
+//
+// The store routes internally via overloaded `Insert` / `Lookup` -- callers
+// pass whatever AST handle they have. The two buckets exist because slang's
+// `Statement` and `Expression` are disjoint hierarchies; a single map key
+// type would require losing type safety.
+class SensitivityReadStore {
+ public:
+  void Insert(
+      const slang::ast::Statement& stmt, std::vector<SensitivityRead> reads) {
+    by_statement_.emplace(&stmt, std::move(reads));
+  }
+  void Insert(
+      const slang::ast::Expression& expr, std::vector<SensitivityRead> reads) {
+    by_expression_.emplace(&expr, std::move(reads));
+  }
+
+  // Lookup returns nullptr if no reads have been recorded for the given key.
+  // Empty result is legal -- the lowering side interprets it as "no
+  // sensitivity", which materialises as a `SensitivityWaitStmt` with an
+  // empty list (i.e. wait forever).
+  [[nodiscard]] auto Lookup(const slang::ast::Statement& stmt) const
+      -> const std::vector<SensitivityRead>* {
+    const auto it = by_statement_.find(&stmt);
+    return it == by_statement_.end() ? nullptr : &it->second;
+  }
+  [[nodiscard]] auto Lookup(const slang::ast::Expression& expr) const
+      -> const std::vector<SensitivityRead>* {
+    const auto it = by_expression_.find(&expr);
+    return it == by_expression_.end() ? nullptr : &it->second;
+  }
+
+ private:
+  std::unordered_map<const slang::ast::Statement*, std::vector<SensitivityRead>>
+      by_statement_;
+  std::unordered_map<
+      const slang::ast::Expression*, std::vector<SensitivityRead>>
+      by_expression_;
+};
+
+// Drives slang's flow analysis over `compilation` and produces the
+// sensitivity store the AST -> HIR lowering will look up against. See
+// `docs/decisions/read-set-inference.md`.
+auto BuildSensitivityReadStore(slang::ast::Compilation& compilation)
+    -> SensitivityReadStore;
 
 // Translates the slang-side read vector (ValueSymbol* + bit_range) into
 // HIR-side identity entries (StructuralVarRef + bit_range), resolving each

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -302,6 +302,14 @@ class ScopeLoweringState {
     return id;
   }
 
+  auto AddContinuousAssign(hir::ContinuousAssign ca)
+      -> hir::ContinuousAssignId {
+    const hir::ContinuousAssignId id{
+        static_cast<std::uint32_t>(scope_->continuous_assigns.size())};
+    scope_->continuous_assigns.push_back(std::move(ca));
+    return id;
+  }
+
   auto AddGenerate(hir::Generate generate) -> hir::GenerateId {
     const hir::GenerateId id{
         static_cast<std::uint32_t>(scope_->generates.size())};

--- a/include/lyra/lowering/hir_to_mir/lower_continuous_assign.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_continuous_assign.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "lyra/base/time.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/continuous_assign.hpp"
+#include "lyra/hir/structural_scope.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/process.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+auto LowerContinuousAssign(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const hir::StructuralScope& scope, const hir::ContinuousAssign& src,
+    TimeResolution time_resolution) -> diag::Result<mir::Process>;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/lower_expr.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_expr.hpp
@@ -39,4 +39,15 @@ auto LowerStructuralExpr(
     const hir::StructuralScope& scope, const hir::Expr& expr)
     -> diag::Result<mir::Expr>;
 
+// Translate a scope-level HIR Lvalue (continuous-assignment LHS, LRM 10.3)
+// into a MIR Lvalue targeted at the given procedural scope. Selector
+// subexpressions are sourced from `scope.exprs` and added to
+// `proc_scope_state.exprs`. The root must be a `StructuralVarRef`.
+auto LowerHirLvalueStructural(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::StructuralScope& scope, const hir::Lvalue& lvalue)
+    -> diag::Result<mir::Lvalue>;
+
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/compiler/compile.cpp
+++ b/src/lyra/compiler/compile.cpp
@@ -2,70 +2,16 @@
 
 #include <format>
 #include <utility>
-#include <vector>
-
-#include <slang/analysis/AnalysisManager.h>
-#include <slang/analysis/AnalyzedProcedure.h>
-#include <slang/ast/Statement.h>
-#include <slang/ast/symbols/BlockSymbols.h>
-#include <slang/ast/symbols/ValueSymbol.h>
 
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/sink.hpp"
 #include "lyra/frontend/load.hpp"
 #include "lyra/lowering/ast_to_hir/lower.hpp"
+#include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 #include "lyra/lowering/hir_to_mir/lower_module_unit.hpp"
 
 namespace lyra::compiler {
-
-namespace {
-
-// Deduplicated `ReadRange`-shaped list from slang's DFA maps 1:1. Disjoint
-// bit ranges for the same symbol are preserved so the runtime can subscribe
-// at bit-range granularity once Observable gains that resolution.
-template <typename SlangReads>
-auto TranslateReads(const SlangReads& reads)
-    -> std::vector<lowering::ast_to_hir::SensitivityRead> {
-  std::vector<lowering::ast_to_hir::SensitivityRead> entries;
-  entries.reserve(reads.size());
-  for (const auto& read : reads) {
-    entries.push_back({.symbol = read.symbol, .bit_range = read.bitRange});
-  }
-  return entries;
-}
-
-// Harvests slang's procedure-level and per-`@*` read sets via the
-// AnalysisManager listener. Other forms (wait, future wait_order, etc.)
-// run their own walkers locally at the lowering site and do not pass
-// through this listener.
-auto ComputeImplicitSensitivityReads(slang::ast::Compilation& compilation)
-    -> lowering::ast_to_hir::ImplicitSensitivityReads {
-  lowering::ast_to_hir::ImplicitSensitivityReads out;
-  slang::analysis::AnalysisManager manager;
-  manager.addListener([&](const slang::analysis::AnalyzedProcedure& ap) {
-    const auto* proc =
-        ap.analyzedSymbol->as_if<slang::ast::ProceduralBlockSymbol>();
-    if (proc == nullptr) return;
-    // LRM 9.2.2.2.1: for always_comb / always_latch the procedure-level
-    // sensitivity attaches to the body statement of the procedure.
-    if (proc->procedureKind == slang::ast::ProceduralBlockKind::AlwaysComb ||
-        proc->procedureKind == slang::ast::ProceduralBlockKind::AlwaysLatch) {
-      const auto& sens = ap.getSensitivityList();
-      if (sens.kind == slang::analysis::SensitivityList::Kind::Implicit) {
-        out.emplace(&proc->getBody(), TranslateReads(sens.reads));
-      }
-    }
-    // LRM 9.4.2.2: each `@*` TimedStatement carries its own sensitivity.
-    for (const auto& region : ap.getImplicitEventReadSets()) {
-      out.emplace(region.statement, TranslateReads(region.reads));
-    }
-  });
-  manager.analyze(compilation);
-  return out;
-}
-
-}  // namespace
 
 auto Compile(
     const frontend::CompilationInput& input, diag::DiagnosticSink& sink,
@@ -90,7 +36,8 @@ auto Compile(
   }
 
   const auto sensitivity_reads =
-      ComputeImplicitSensitivityReads(*result.artifacts.parse->compilation);
+      lowering::ast_to_hir::BuildSensitivityReadStore(
+          *result.artifacts.parse->compilation);
 
   auto hir = lowering::ast_to_hir::LowerCompilation(
       lowering::ast_to_hir::LowerCompilationFacts(

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -132,6 +132,12 @@ constexpr std::array kEntries{
             .kind = DiagKind::kUnsupported,
             .category = UnsupportedCategory::kFeature,
             .name = "unsupported_event_trigger_form"}},
+    std::pair{
+        DiagCode::kUnsupportedContinuousAssignForm,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_continuous_assign_form"}},
 
     std::pair{
         DiagCode::kDelayValueOutOfRange,

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -12,6 +12,7 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/hir/binary_op.hpp"
+#include "lyra/hir/continuous_assign.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/method.hpp"
 #include "lyra/hir/module_unit.hpp"
@@ -818,6 +819,9 @@ class HirDumper {
     for (const auto& p : s.processes) {
       DumpProcess(p);
     }
+    for (const auto& ca : s.continuous_assigns) {
+      DumpContinuousAssign(ca);
+    }
     for (const auto& g : s.generates) {
       DumpGenerate(s, g);
     }
@@ -880,6 +884,27 @@ class HirDumper {
       Dedent();
     }
     DumpStmt(p, p.root_stmt);
+    Dedent();
+  }
+
+  void DumpContinuousAssign(const ContinuousAssign& ca) {
+    Line(
+        std::format(
+            "ContinuousAssign lhs={} rhs=Expr[{}]", FormatLvalue(ca.lhs),
+            ca.rhs.value));
+    Indent();
+    if (!ca.sensitivity_list.empty()) {
+      Line("SensitivityList:");
+      Indent();
+      for (const auto& r : ca.sensitivity_list) {
+        Line(
+            std::format(
+                "StructuralVarRef hops={} var=StructuralVar[{}] bits=[{}:{}]",
+                r.ref.hops.value, r.ref.var.value, r.bit_range.first,
+                r.bit_range.second));
+      }
+      Dedent();
+    }
     Dedent();
   }
 

--- a/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
+++ b/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
@@ -1,0 +1,76 @@
+#include "lyra/lowering/ast_to_hir/continuous_assign.hpp"
+
+#include <expected>
+#include <utility>
+
+#include <slang/ast/Expression.h>
+#include <slang/ast/expressions/AssignmentExpressions.h>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/kind.hpp"
+#include "lyra/lowering/ast_to_hir/expression/lower.hpp"
+#include "lyra/lowering/ast_to_hir/sensitivity.hpp"
+
+namespace lyra::lowering::ast_to_hir {
+
+auto LowerContinuousAssign(
+    const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
+    ScopeStack& stack, const slang::ast::ContinuousAssignSymbol& sym)
+    -> diag::Result<hir::ContinuousAssign> {
+  const auto& mapper = unit_facts.SourceMapper();
+  const auto span = mapper.PointSpanOf(sym.location);
+
+  if (sym.getDelay() != nullptr) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedContinuousAssignForm,
+        "delay on continuous assignment is not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  const auto strength = sym.getDriveStrength();
+  if (strength.first.has_value() || strength.second.has_value()) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedContinuousAssignForm,
+        "drive strength on continuous assignment is not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+
+  const auto& assignment_expr = sym.getAssignment();
+  if (assignment_expr.kind != slang::ast::ExpressionKind::Assignment) {
+    throw InternalError(
+        "LowerContinuousAssign: ContinuousAssignSymbol.getAssignment() did not "
+        "return an AssignmentExpression");
+  }
+  const auto& assign = assignment_expr.as<slang::ast::AssignmentExpression>();
+
+  auto lhs_or = LowerStructuralLvalue(
+      unit_facts, scope_state.UnitState(), scope_state, stack, assign.left());
+  if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+
+  auto rhs_or = LowerStructuralExpr(
+      unit_facts, scope_state.UnitState(), scope_state, stack, assign.right());
+  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+  const hir::ExprId rhs_id = scope_state.AddExpr(*std::move(rhs_or));
+
+  // Sensitivity is precomputed by slang's flow analysis on the assignment
+  // expression during `BuildSensitivityReadStore` (see
+  // `docs/decisions/read-set-inference.md`). Look up keyed by the
+  // AssignmentExpression -- the same Expression-keyed bucket future
+  // per-expression analyses (property / assert / wait_order events) use.
+  std::vector<hir::SensitivityEntry> sensitivity;
+  if (const auto* reads = unit_facts.SensitivityReads().Lookup(assign);
+      reads != nullptr) {
+    sensitivity =
+        TranslateSensitivityReads(*reads, scope_state.UnitState(), stack);
+  }
+
+  return hir::ContinuousAssign{
+      .span = span,
+      .lhs = *std::move(lhs_or),
+      .rhs = rhs_id,
+      .sensitivity_list = std::move(sensitivity),
+  };
+}
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -1225,4 +1225,97 @@ auto LowerProcLvalue(
       primary->data);
 }
 
+auto LowerStructuralLvalue(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ScopeLoweringState& scope_state, const ScopeStack& stack,
+    const slang::ast::Expression& expr) -> diag::Result<hir::Lvalue> {
+  const auto& mapper = unit_facts.SourceMapper();
+  const auto span = mapper.SpanOf(expr.sourceRange);
+  auto unsupported = [&] {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedAssignmentTarget,
+        "assignment target is not supported yet",
+        diag::UnsupportedCategory::kFeature);
+  };
+
+  if (expr.kind == slang::ast::ExpressionKind::ElementSelect) {
+    const auto& sel = expr.as<slang::ast::ElementSelectExpression>();
+    if (!sel.value().type->isIntegral()) {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedAssignmentTarget,
+          "element-select lvalue on non-integral operand is not yet supported",
+          diag::UnsupportedCategory::kFeature);
+    }
+    auto inner = LowerStructuralLvalue(
+        unit_facts, unit_state, scope_state, stack, sel.value());
+    if (!inner) return std::unexpected(std::move(inner.error()));
+    auto idx_or = LowerStructuralExpr(
+        unit_facts, unit_state, scope_state, stack, sel.selector(),
+        std::nullopt);
+    if (!idx_or) return std::unexpected(std::move(idx_or.error()));
+    const hir::ExprId idx_id = scope_state.AddExpr(*std::move(idx_or));
+    inner->selectors.emplace_back(hir::ElementLvalueSelector{.index = idx_id});
+    return std::move(*inner);
+  }
+
+  if (expr.kind == slang::ast::ExpressionKind::RangeSelect) {
+    const auto& sel = expr.as<slang::ast::RangeSelectExpression>();
+    if (!sel.value().type->isIntegral()) {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedAssignmentTarget,
+          "range-select lvalue on non-integral operand is not yet supported",
+          diag::UnsupportedCategory::kFeature);
+    }
+    auto inner = LowerStructuralLvalue(
+        unit_facts, unit_state, scope_state, stack, sel.value());
+    if (!inner) return std::unexpected(std::move(inner.error()));
+    auto left_or = LowerStructuralExpr(
+        unit_facts, unit_state, scope_state, stack, sel.left(), std::nullopt);
+    if (!left_or) return std::unexpected(std::move(left_or.error()));
+    const hir::ExprId left_id = scope_state.AddExpr(*std::move(left_or));
+    auto right_or = LowerStructuralExpr(
+        unit_facts, unit_state, scope_state, stack, sel.right(), std::nullopt);
+    if (!right_or) return std::unexpected(std::move(right_or.error()));
+    const hir::ExprId right_id = scope_state.AddExpr(*std::move(right_or));
+    hir::RangeBounds bounds = [&]() -> hir::RangeBounds {
+      switch (sel.getSelectionKind()) {
+        case slang::ast::RangeSelectionKind::Simple:
+          return hir::RangeConstantBounds{
+              .msb_expr = left_id, .lsb_expr = right_id};
+        case slang::ast::RangeSelectionKind::IndexedUp:
+          return hir::RangeIndexedUpBounds{
+              .base_index = left_id, .width = right_id};
+        case slang::ast::RangeSelectionKind::IndexedDown:
+          return hir::RangeIndexedDownBounds{
+              .base_index = left_id, .width = right_id};
+      }
+      throw InternalError(
+          "LowerStructuralLvalue: unknown slang RangeSelectionKind");
+    }();
+    inner->selectors.emplace_back(
+        hir::RangeLvalueSelector{.bounds = std::move(bounds)});
+    return std::move(*inner);
+  }
+
+  // Leaf: lower as a structural expression and project to the StructuralVarRef
+  // root. Loop-induction vars and (impossible-at-scope-level) procedural vars
+  // are rejected here so the user sees an Unsupported diagnostic instead of
+  // a downstream InternalError.
+  auto leaf = LowerStructuralExpr(
+      unit_facts, unit_state, scope_state, stack, expr, std::nullopt);
+  if (!leaf) return std::unexpected(std::move(leaf.error()));
+  auto* primary = std::get_if<hir::PrimaryExpr>(&leaf->data);
+  if (primary == nullptr) return unsupported();
+  return std::visit(
+      Overloaded{
+          [](const hir::StructuralVarRef& r) -> diag::Result<hir::Lvalue> {
+            return hir::Lvalue{.root = r, .selectors = {}};
+          },
+          [&](const auto&) -> diag::Result<hir::Lvalue> {
+            return unsupported();
+          },
+      },
+      primary->data);
+}
+
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -1300,8 +1300,8 @@ auto LowerStructuralLvalue(
   // root. Loop-induction vars and (impossible-at-scope-level) procedural vars
   // are rejected here so the user sees an Unsupported diagnostic instead of
   // a downstream InternalError.
-  auto leaf = LowerStructuralExpr(
-      unit_facts, unit_state, scope_state, stack, expr);
+  auto leaf =
+      LowerStructuralExpr(unit_facts, unit_state, scope_state, stack, expr);
   if (!leaf) return std::unexpected(std::move(leaf.error()));
   auto* primary = std::get_if<hir::PrimaryExpr>(&leaf->data);
   if (primary == nullptr) return unsupported();

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -1250,8 +1250,7 @@ auto LowerStructuralLvalue(
         unit_facts, unit_state, scope_state, stack, sel.value());
     if (!inner) return std::unexpected(std::move(inner.error()));
     auto idx_or = LowerStructuralExpr(
-        unit_facts, unit_state, scope_state, stack, sel.selector(),
-        std::nullopt);
+        unit_facts, unit_state, scope_state, stack, sel.selector());
     if (!idx_or) return std::unexpected(std::move(idx_or.error()));
     const hir::ExprId idx_id = scope_state.AddExpr(*std::move(idx_or));
     inner->selectors.emplace_back(hir::ElementLvalueSelector{.index = idx_id});
@@ -1270,11 +1269,11 @@ auto LowerStructuralLvalue(
         unit_facts, unit_state, scope_state, stack, sel.value());
     if (!inner) return std::unexpected(std::move(inner.error()));
     auto left_or = LowerStructuralExpr(
-        unit_facts, unit_state, scope_state, stack, sel.left(), std::nullopt);
+        unit_facts, unit_state, scope_state, stack, sel.left());
     if (!left_or) return std::unexpected(std::move(left_or.error()));
     const hir::ExprId left_id = scope_state.AddExpr(*std::move(left_or));
     auto right_or = LowerStructuralExpr(
-        unit_facts, unit_state, scope_state, stack, sel.right(), std::nullopt);
+        unit_facts, unit_state, scope_state, stack, sel.right());
     if (!right_or) return std::unexpected(std::move(right_or.error()));
     const hir::ExprId right_id = scope_state.AddExpr(*std::move(right_or));
     hir::RangeBounds bounds = [&]() -> hir::RangeBounds {
@@ -1302,7 +1301,7 @@ auto LowerStructuralLvalue(
   // are rejected here so the user sees an Unsupported diagnostic instead of
   // a downstream InternalError.
   auto leaf = LowerStructuralExpr(
-      unit_facts, unit_state, scope_state, stack, expr, std::nullopt);
+      unit_facts, unit_state, scope_state, stack, expr);
   if (!leaf) return std::unexpected(std::move(leaf.error()));
   auto* primary = std::get_if<hir::PrimaryExpr>(&leaf->data);
   if (primary == nullptr) return unsupported();

--- a/src/lyra/lowering/ast_to_hir/process.cpp
+++ b/src/lyra/lowering/ast_to_hir/process.cpp
@@ -46,10 +46,9 @@ auto LookupSensitivityEntries(
     const UnitLoweringFacts& unit_facts, const UnitLoweringState& unit_state,
     const ScopeStack& stack, const slang::ast::Statement& key_stmt)
     -> std::vector<hir::SensitivityEntry> {
-  const auto& reads_map = unit_facts.SensitivityReads();
-  const auto it = reads_map.find(&key_stmt);
-  if (it == reads_map.end()) return {};
-  return TranslateSensitivityReads(it->second, unit_state, stack);
+  const auto* reads = unit_facts.SensitivityReads().Lookup(key_stmt);
+  if (reads == nullptr) return {};
+  return TranslateSensitivityReads(*reads, unit_state, stack);
 }
 
 }  // namespace

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -21,6 +21,7 @@
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/type.hpp"
+#include "lyra/lowering/ast_to_hir/continuous_assign.hpp"
 #include "lyra/lowering/ast_to_hir/expression/lower.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/generate.hpp"
@@ -133,6 +134,16 @@ auto LowerProceduralBlockMemberInto(
   return {};
 }
 
+auto LowerContinuousAssignMemberInto(
+    const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
+    ScopeStack& stack, const slang::ast::ContinuousAssignSymbol& sym)
+    -> diag::Result<void> {
+  auto ca = LowerContinuousAssign(unit_facts, scope_state, stack, sym);
+  if (!ca) return std::unexpected(std::move(ca.error()));
+  scope_state.AddContinuousAssign(*std::move(ca));
+  return {};
+}
+
 auto LowerLoopGenerateMemberInto(
     const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
     ScopeStack& stack, const slang::ast::GenerateBlockArraySymbol& array)
@@ -190,6 +201,10 @@ auto LowerScopeMemberInto(
       return LowerProceduralBlockMemberInto(
           unit_facts, scope_state, stack,
           member.as<slang::ast::ProceduralBlockSymbol>());
+    case slang::ast::SymbolKind::ContinuousAssign:
+      return LowerContinuousAssignMemberInto(
+          unit_facts, scope_state, stack,
+          member.as<slang::ast::ContinuousAssignSymbol>());
     case slang::ast::SymbolKind::GenerateBlockArray:
       return LowerLoopGenerateMemberInto(
           unit_facts, scope_state, stack,

--- a/src/lyra/lowering/ast_to_hir/sensitivity.cpp
+++ b/src/lyra/lowering/ast_to_hir/sensitivity.cpp
@@ -1,5 +1,19 @@
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#include <slang/analysis/AbstractFlowAnalysis.h>
+#include <slang/analysis/AnalysisManager.h>
+#include <slang/analysis/AnalyzedProcedure.h>
+#include <slang/analysis/DFAResults.h>
+#include <slang/analysis/DataFlowAnalysis.h>
+#include <slang/ast/Compilation.h>
+#include <slang/ast/Statement.h>
+#include <slang/ast/statements/MiscStatements.h>
+#include <slang/ast/symbols/BlockSymbols.h>
+#include <slang/ast/symbols/MemberSymbols.h>
 #include <slang/ast/symbols/ValueSymbol.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 
@@ -7,6 +21,127 @@
 #include "lyra/lowering/ast_to_hir/state.hpp"
 
 namespace lyra::lowering::ast_to_hir {
+
+namespace {
+
+// Translates slang's `ReadRange`-shaped sensitivity entries (used by
+// `getSensitivityList()` and `getImplicitEventReadSets()`) into lyra's
+// `SensitivityRead` shape. Disjoint bit ranges for the same symbol are kept
+// as-is so downstream can preserve precision when the runtime supports
+// bit-level subscription.
+template <typename SlangReads>
+auto TranslateReadRanges(const SlangReads& reads)
+    -> std::vector<SensitivityRead> {
+  std::vector<SensitivityRead> entries;
+  entries.reserve(reads.size());
+  for (const auto& read : reads) {
+    entries.push_back({.symbol = read.symbol, .bit_range = read.bitRange});
+  }
+  return entries;
+}
+
+// Flattens the post-DFA `ReadSet` (a map from symbol to bit-interval map)
+// into a `SensitivityRead` vector. Mirrors slang's own attribution in
+// AnalyzedProcedure.cpp:223-227.
+auto FlattenReadSet(const slang::analysis::DFAResults::ReadSet& reads)
+    -> std::vector<SensitivityRead> {
+  std::vector<SensitivityRead> entries;
+  for (const auto& [symbol, bitmap] : reads) {
+    for (auto it = bitmap.begin(); it != bitmap.end(); ++it) {
+      entries.push_back({.symbol = symbol, .bit_range = it.bounds()});
+    }
+  }
+  return entries;
+}
+
+}  // namespace
+
+auto BuildSensitivityReadStore(slang::ast::Compilation& compilation)
+    -> SensitivityReadStore {
+  SensitivityReadStore out;
+  std::mutex out_mutex;
+
+  slang::analysis::AnalysisManager manager;
+
+  // Provider runs first per procedure-like symbol. We do not customise the
+  // primary DFA -- we run slang's `DefaultDFA` exactly as the default path
+  // would -- but we use the callback's `AnalysisContext` to drive a fresh
+  // mini-DFA per wait cond. Calling `AbstractFlowAnalysis::run(expression)`
+  // directly bypasses `visitStmt(WaitStatement)`, so the LRM 9.4.2.2 timing-
+  // control suppression hook is not triggered and the cond's reads land in
+  // the mini-DFA's `getRValues()` like an ordinary expression's reads.
+  manager.setCustomDFAProvider(
+      [&](slang::analysis::AnalysisContext& context,
+          const slang::ast::Symbol& symbol,
+          const slang::analysis::AnalyzedProcedure* parent_procedure)
+          -> slang::analysis::AnalyzedProcedure {
+        slang::analysis::DefaultDFA dfa(context, symbol, true);
+        dfa.run();
+
+        if (!dfa.bad) {
+          for (const auto* stmt : dfa.getTimedStatements()) {
+            if (stmt->kind != slang::ast::StatementKind::Wait) continue;
+            const auto& wait_stmt = stmt->as<slang::ast::WaitStatement>();
+
+            // Fresh per-wait DFA: result fields accumulate across run()
+            // calls in slang's framework, so re-using `dfa` would conflate
+            // procedure-wide and per-wait state.
+            slang::analysis::DefaultDFA cond_dfa(context, symbol, false);
+            cond_dfa.slang::analysis::AbstractFlowAnalysis<
+                slang::analysis::DefaultDFA,
+                slang::analysis::DataFlowState>::run(wait_stmt.cond);
+
+            std::scoped_lock lock(out_mutex);
+            out.Insert(wait_stmt.cond, FlattenReadSet(cond_dfa.getRValues()));
+          }
+        }
+
+        if (dfa.bad) {
+          return {symbol, parent_procedure};
+        }
+        return {context, symbol, parent_procedure, dfa};
+      });
+
+  // Listener fires after the AnalyzedProcedure is built. Pure post-analysis
+  // harvest -- no context needed.
+  manager.addListener([&](const slang::analysis::AnalyzedProcedure& ap) {
+    const auto& symbol = *ap.analyzedSymbol;
+
+    if (const auto* proc = symbol.as_if<slang::ast::ProceduralBlockSymbol>()) {
+      // LRM 9.2.2.2.1: always_comb / always_latch sensitivity attaches to
+      // the procedure body statement.
+      if (proc->procedureKind == slang::ast::ProceduralBlockKind::AlwaysComb ||
+          proc->procedureKind == slang::ast::ProceduralBlockKind::AlwaysLatch) {
+        const auto& sens = ap.getSensitivityList();
+        if (sens.kind == slang::analysis::SensitivityList::Kind::Implicit) {
+          std::scoped_lock lock(out_mutex);
+          out.Insert(proc->getBody(), TranslateReadRanges(sens.reads));
+        }
+      }
+      // LRM 9.4.2.2: each `@*` TimedStatement carries its own region read set.
+      for (const auto& region : ap.getImplicitEventReadSets()) {
+        std::scoped_lock lock(out_mutex);
+        out.Insert(*region.statement, TranslateReadRanges(region.reads));
+      }
+    } else if (
+        const auto* ca = symbol.as_if<slang::ast::ContinuousAssignSymbol>()) {
+      // LRM 10.3: continuous assignment sensitivity. slang treats `ca` as a
+      // procedure for analysis purposes and produces an Implicit sensitivity
+      // list under default flags (whole-var reads). We key it by the
+      // assignment expression itself -- nothing in the store API names
+      // continuous assignment specifically; future per-expression analyses
+      // (property / assert / wait_order events) plug into the same bucket.
+      const auto& sens = ap.getSensitivityList();
+      if (sens.kind == slang::analysis::SensitivityList::Kind::Implicit) {
+        std::scoped_lock lock(out_mutex);
+        out.Insert(ca->getAssignment(), TranslateReadRanges(sens.reads));
+      }
+    }
+  });
+
+  manager.analyze(compilation);
+  return out;
+}
 
 auto TranslateSensitivityReads(
     const std::vector<SensitivityRead>& reads,

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -5,7 +5,6 @@
 #include <utility>
 #include <vector>
 
-#include <slang/ast/ASTVisitor.h>
 #include <slang/ast/Expression.h>
 #include <slang/ast/Statement.h>
 #include <slang/ast/Symbol.h>
@@ -13,9 +12,7 @@
 #include <slang/ast/statements/ConditionalStatements.h>
 #include <slang/ast/statements/LoopStatements.h>
 #include <slang/ast/statements/MiscStatements.h>
-#include <slang/ast/symbols/ValueSymbol.h>
 #include <slang/ast/symbols/VariableSymbols.h>
-#include <slang/ast/types/Type.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
@@ -225,11 +222,10 @@ auto LowerTimedStmt(
   // from LowerTimingControl; fill it in here where we still have the
   // parent statement pointer.
   if (auto* ie = std::get_if<hir::ImplicitEventControl>(&*timing)) {
-    const auto& reads_map = unit_facts.SensitivityReads();
-    const auto it = reads_map.find(&ts);
-    if (it != reads_map.end()) {
+    if (const auto* reads = unit_facts.SensitivityReads().Lookup(ts);
+        reads != nullptr) {
       ie->sensitivity_list =
-          TranslateSensitivityReads(it->second, scope_state.UnitState(), stack);
+          TranslateSensitivityReads(*reads, scope_state.UnitState(), stack);
     }
   }
   auto inner_stmt =
@@ -595,40 +591,10 @@ auto LowerEventTriggerStmt(
       .span = span};
 }
 
-// Walks the cond of a `wait (cond)` (LRM 9.4.3), recording every value
-// reference as a read. Slang's `IsSelectExpr` concept closes the set of
-// leaves that produce a read (`NamedValueExpression` /
-// `HierarchicalValueExpression` here; the other three select wrappers
-// recurse via visitDefault to a leaf). Lvalue tracking is unnecessary
-// because LRM 11.3.6 forbids assignment operators inside timing-control
-// expressions, so every value reference in `cond` is a read.
-struct WaitCondReadCollector
-    : slang::ast::ASTVisitor<
-          WaitCondReadCollector, slang::ast::VisitFlags::Expressions> {
-  std::vector<SensitivityRead> out;
-
-  void handle(const slang::ast::NamedValueExpression& e) {
-    Record(e.symbol);
-    visitDefault(e);
-  }
-
-  void handle(const slang::ast::HierarchicalValueExpression& e) {
-    Record(e.symbol);
-    visitDefault(e);
-  }
-
- private:
-  void Record(const slang::ast::ValueSymbol& sym) {
-    const auto width = sym.getType().getSelectableWidth();
-    out.push_back(
-        SensitivityRead{
-            .symbol = &sym, .bit_range = {0, width > 0 ? width - 1 : 0}});
-  }
-};
-
-// LRM 9.4.3 `wait (cond) body`. Sensitivity is derived locally by walking
-// `cond` -- no upstream `AnalysisManager` listener needed, since slang owns
-// no DFA for wait conditions.
+// LRM 9.4.3 `wait (cond) body`. Sensitivity is precomputed by driving slang's
+// flow analysis on `w.cond` via a per-wait `DefaultDFA` run inside
+// `BuildSensitivityReadStore` (see `docs/decisions/read-set-inference.md`).
+// We look up the result here keyed by the cond expression.
 auto LowerWaitStmt(
     const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
     ScopeLoweringState& scope_state, ScopeStack& stack,
@@ -642,10 +608,12 @@ auto LowerWaitStmt(
       LowerStatement(unit_facts, proc_state, scope_state, stack, w.stmt);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_or));
-  WaitCondReadCollector collector;
-  w.cond.visit(collector);
-  auto sensitivity =
-      TranslateSensitivityReads(collector.out, scope_state.UnitState(), stack);
+  std::vector<hir::SensitivityEntry> sensitivity;
+  if (const auto* reads = unit_facts.SensitivityReads().Lookup(w.cond);
+      reads != nullptr) {
+    sensitivity =
+        TranslateSensitivityReads(*reads, scope_state.UnitState(), stack);
+  }
   return hir::Stmt{
       .label = std::nullopt,
       .data =

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -16,6 +16,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/hir_to_mir/case_cascade.hpp"
+#include "lyra/lowering/hir_to_mir/lower_continuous_assign.hpp"
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 #include "lyra/lowering/hir_to_mir/lower_process.hpp"
 #include "lyra/lowering/hir_to_mir/procedural_scope_helpers.hpp"
@@ -539,6 +540,13 @@ auto LowerStructuralScope(
   for (const auto& p : scope.processes) {
     auto proc_or =
         LowerProcess(unit_state, scope_state, p, scope.time_resolution);
+    if (!proc_or) return std::unexpected(std::move(proc_or.error()));
+    scope_state.AddProcess(*std::move(proc_or));
+  }
+
+  for (const auto& ca : scope.continuous_assigns) {
+    auto proc_or = LowerContinuousAssign(
+        unit_state, scope_state, scope, ca, scope.time_resolution);
     if (!proc_or) return std::unexpected(std::move(proc_or.error()));
     scope_state.AddProcess(*std::move(proc_or));
   }

--- a/src/lyra/lowering/hir_to_mir/lower_continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_continuous_assign.cpp
@@ -1,0 +1,82 @@
+#include "lyra/lowering/hir_to_mir/lower_continuous_assign.hpp"
+
+#include <expected>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "lyra/hir/continuous_assign.hpp"
+#include "lyra/hir/structural_scope.hpp"
+#include "lyra/lowering/hir_to_mir/lower_expr.hpp"
+#include "lyra/lowering/hir_to_mir/procedural_scope_helpers.hpp"
+#include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/process.hpp"
+#include "lyra/mir/stmt.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// LRM 10.3.2 (continuous assignment) and LRM 9.2.2.2.1 (always_comb) share a
+// runtime mental model: re-evaluate the assignment whenever any RHS read
+// changes. HIR keeps continuous assignment as a distinct scope-level node so
+// source diagnostics retain provenance; at HIR -> MIR we materialise the
+// runtime shape directly here as `mir::Process { kInitial, forever { lhs =
+// rhs; SensitivityWaitStmt(reads); } }`. The body executes once at t=0 (the
+// natural fall-through of the eternal loop) before the first wait, matching
+// LRM 9.2.2.2's "evaluate at time 0" requirement for inferred sensitivity.
+auto LowerContinuousAssign(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const hir::StructuralScope& scope, const hir::ContinuousAssign& src,
+    TimeResolution time_resolution) -> diag::Result<mir::Process> {
+  ProcessLoweringState proc_state{time_resolution};
+
+  ProceduralScopeLoweringState body_state;
+  {
+    ProceduralDepthGuard guard{proc_state};
+
+    auto rhs_or = LowerStructuralExpr(
+        unit_state, scope_state, body_state, scope, scope.GetExpr(src.rhs));
+    if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+    const mir::TypeId assign_type = (*rhs_or).type;
+    const mir::ExprId rhs_id = body_state.AddExpr(*std::move(rhs_or));
+
+    auto lhs_or = LowerHirLvalueStructural(
+        unit_state, scope_state, body_state, scope, src.lhs);
+    if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+
+    const mir::ExprId assign_id = body_state.AddExpr(
+        mir::Expr{
+            .data =
+                mir::AssignExpr{.target = *std::move(lhs_or), .value = rhs_id},
+            .type = assign_type});
+    body_state.AddRootStmt(body_state.AddStmt(
+        mir::Stmt{
+            .label = std::nullopt,
+            .data = mir::ExprStmt{.expr = assign_id},
+            .child_procedural_scopes = {}}));
+
+    body_state.AddRootStmt(body_state.AddStmt(
+        BuildSensitivityWaitStmt(scope_state, src.sensitivity_list)));
+  }
+
+  ProceduralScopeLoweringState process_state;
+  std::vector<mir::ProceduralScope> child_scopes;
+  const mir::ProceduralScopeId body_scope_id =
+      AddChildProceduralScope(child_scopes, body_state.Finish());
+  process_state.AddRootStmt(process_state.AddStmt(
+      mir::Stmt{
+          .label = std::nullopt,
+          .data =
+              mir::ForStmt{
+                  .init = {},
+                  .condition = std::nullopt,
+                  .step = {},
+                  .scope = body_scope_id},
+          .child_procedural_scopes = std::move(child_scopes)}));
+  return mir::Process{
+      .kind = mir::ProcessKind::kInitial,
+      .root_procedural_scope = process_state.Finish()};
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -297,6 +297,50 @@ auto LowerHirRangeBoundsProc(
       bounds);
 }
 
+auto LowerHirRangeBoundsStructural(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::StructuralScope& scope, const hir::RangeBounds& bounds)
+    -> diag::Result<mir::RangeBounds> {
+  auto lower_one = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
+    auto lowered = LowerStructuralExpr(
+        unit_state, scope_state, proc_scope_state, scope, scope.GetExpr(id));
+    if (!lowered) return std::unexpected(std::move(lowered.error()));
+    return proc_scope_state.AddExpr(*std::move(lowered));
+  };
+  return std::visit(
+      Overloaded{
+          [&](const hir::RangeConstantBounds& b)
+              -> diag::Result<mir::RangeBounds> {
+            auto msb = lower_one(b.msb_expr);
+            if (!msb) return std::unexpected(std::move(msb.error()));
+            auto lsb = lower_one(b.lsb_expr);
+            if (!lsb) return std::unexpected(std::move(lsb.error()));
+            return mir::RangeConstantBounds{.msb_expr = *msb, .lsb_expr = *lsb};
+          },
+          [&](const hir::RangeIndexedUpBounds& b)
+              -> diag::Result<mir::RangeBounds> {
+            auto base = lower_one(b.base_index);
+            if (!base) return std::unexpected(std::move(base.error()));
+            auto width = lower_one(b.width);
+            if (!width) return std::unexpected(std::move(width.error()));
+            return mir::RangeIndexedUpBounds{
+                .base_index = *base, .width = *width};
+          },
+          [&](const hir::RangeIndexedDownBounds& b)
+              -> diag::Result<mir::RangeBounds> {
+            auto base = lower_one(b.base_index);
+            if (!base) return std::unexpected(std::move(base.error()));
+            auto width = lower_one(b.width);
+            if (!width) return std::unexpected(std::move(width.error()));
+            return mir::RangeIndexedDownBounds{
+                .base_index = *base, .width = *width};
+          },
+      },
+      bounds);
+}
+
 auto LowerHirLvalueProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
@@ -1372,6 +1416,53 @@ auto LowerStructuralExpr(
   return LowerExprImpl(
       unit_state, scope_state, nullptr, proc_scope_state, scope, expr,
       LoopVarLoweringMode::kStructuralParam);
+}
+
+auto LowerHirLvalueStructural(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::StructuralScope& scope, const hir::Lvalue& lvalue)
+    -> diag::Result<mir::Lvalue> {
+  const auto* structural_root =
+      std::get_if<hir::StructuralVarRef>(&lvalue.root);
+  if (structural_root == nullptr) {
+    throw InternalError(
+        "LowerHirLvalueStructural: continuous-assign LHS root is not a "
+        "StructuralVarRef; AST -> HIR should have rejected non-structural "
+        "targets");
+  }
+  mir::Lvalue out{
+      .root = scope_state.TranslateStructuralVar(
+          structural_root->hops, structural_root->var),
+      .selectors = {}};
+  out.selectors.reserve(lvalue.selectors.size());
+  for (const auto& sel : lvalue.selectors) {
+    auto lowered_sel = std::visit(
+        Overloaded{
+            [&](const hir::ElementLvalueSelector& s)
+                -> diag::Result<mir::LvalueSelector> {
+              auto idx = LowerStructuralExpr(
+                  unit_state, scope_state, proc_scope_state, scope,
+                  scope.GetExpr(s.index));
+              if (!idx) return std::unexpected(std::move(idx.error()));
+              const mir::ExprId idx_id =
+                  proc_scope_state.AddExpr(*std::move(idx));
+              return mir::ElementLvalueSelector{.index = idx_id};
+            },
+            [&](const hir::RangeLvalueSelector& s)
+                -> diag::Result<mir::LvalueSelector> {
+              auto bounds = LowerHirRangeBoundsStructural(
+                  unit_state, scope_state, proc_scope_state, scope, s.bounds);
+              if (!bounds) return std::unexpected(std::move(bounds.error()));
+              return mir::RangeLvalueSelector{.bounds = *std::move(bounds)};
+            },
+        },
+        sel);
+    if (!lowered_sel) return std::unexpected(std::move(lowered_sel.error()));
+    out.selectors.emplace_back(*std::move(lowered_sel));
+  }
+  return out;
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/tests/cases/cpp/continuous_assign_basic/case.yaml
+++ b/tests/cases/cpp/continuous_assign_basic/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.continuous_assign_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    b: 4

--- a/tests/cases/cpp/continuous_assign_basic/main.sv
+++ b/tests/cases/cpp/continuous_assign_basic/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  int a, b;
+
+  initial a = 3;
+
+  // LRM 10.3.2: `b` is re-evaluated whenever any operand on the RHS
+  // changes; here `b` settles to `a + 1` once `a` is initialised.
+  assign b = a + 1;
+endmodule

--- a/tests/cases/cpp/continuous_assign_chained/case.yaml
+++ b/tests/cases/cpp/continuous_assign_chained/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.continuous_assign_chained
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a: 5
+    b: 5
+    c: 6

--- a/tests/cases/cpp/continuous_assign_chained/main.sv
+++ b/tests/cases/cpp/continuous_assign_chained/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  int a, b, c;
+
+  initial a = 5;
+
+  // Two continuous assignments form a combinational chain: a -> b -> c.
+  // LRM 10.3.2 reads `b` on the RHS of `c`, so updating `a` propagates
+  // through both assigns within the same time step.
+  assign b = a;
+  assign c = b + 1;
+endmodule

--- a/tests/cases/cpp/continuous_assign_constant_rhs/case.yaml
+++ b/tests/cases/cpp/continuous_assign_constant_rhs/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.continuous_assign_constant_rhs
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: 42

--- a/tests/cases/cpp/continuous_assign_constant_rhs/main.sv
+++ b/tests/cases/cpp/continuous_assign_constant_rhs/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  int x;
+
+  // Empty RHS read set: the assignment fires once at t=0 (the always_comb-
+  // style entry evaluation per LRM 9.2.2.2.1) and then suspends forever,
+  // since SensitivityWait on an empty set never wakes up.
+  assign x = 42;
+endmodule

--- a/tests/cases/cpp/continuous_assign_part_select_lhs/case.yaml
+++ b/tests/cases/cpp/continuous_assign_part_select_lhs/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.continuous_assign_part_select_lhs
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: "8'hA5"
+    y: "4'h5"

--- a/tests/cases/cpp/continuous_assign_part_select_lhs/main.sv
+++ b/tests/cases/cpp/continuous_assign_part_select_lhs/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  bit [7:0] x;
+  bit [3:0] y;
+
+  initial begin
+    x = 8'ha0;
+    y = 4'h5;
+  end
+
+  // LRM 10.3 Table 10-1 allows a constant part-select LHS in a continuous
+  // assignment; the low nibble of `x` tracks `y` continuously.
+  assign x[3:0] = y;
+endmodule

--- a/tests/cases/cpp/continuous_assign_ternary/case.yaml
+++ b/tests/cases/cpp/continuous_assign_ternary/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.continuous_assign_ternary
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    y: 7

--- a/tests/cases/cpp/continuous_assign_ternary/main.sv
+++ b/tests/cases/cpp/continuous_assign_ternary/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  bit sel;
+  int a, b, y;
+
+  initial begin
+    sel = 1;
+    a = 7;
+    b = 9;
+  end
+
+  // RHS read set covers all three operands (sel, a, b); change on any of
+  // them re-evaluates the assignment.
+  assign y = sel ? a : b;
+endmodule

--- a/tests/cases/cpp/wait_level_compound_cond/main.sv
+++ b/tests/cases/cpp/wait_level_compound_cond/main.sv
@@ -6,9 +6,8 @@ module Top;
     a = 0;
     b = 0;
     marker = 0;
-    // Compound condition exercises the walker's BinaryExpr recursion: both
-    // `a` and `b` are picked up as reads, so a transition on either kicks
-    // re-evaluation of `a && b`.
+    // Compound `a && b` cond: both operands enter the read set, so a
+    // transition on either kicks re-evaluation.
     wait (a && b) marker = 1;
   end
 


### PR DESCRIPTION
## Summary

Adds SystemVerilog continuous assignment (`assign x = y;`, LRM 10.3) as a scope-level HIR construct and rewrites the read-set inference pipeline so all sensitivity inference -- always_comb / always_latch bodies, `@*` regions, `wait` conds, and continuous assignment expressions -- flows through one infrastructure built on slang's own `DefaultDFA`. The two previous hand-coded `ASTVisitor` walkers (`WaitCondReadCollector`, `ExpressionReadCollector`) are deleted.

## Design

Continuous assignment lands in HIR as `ContinuousAssign {lhs, rhs, sensitivity_list}` at scope level. LHS and RHS live in the enclosing `StructuralScope.exprs` pool alongside parameter values and variable initialisers (`LowerStructuralLvalue` is new on the structural-context lvalue path). HIR -> MIR materialises a `mir::Process { kInitial, forever { lhs = rhs; SensitivityWait(reads); } }` directly, giving continuous assignment the same runtime mental model as always_comb. Delay (`assign #N`, LRM 10.3.3) and drive strength (LRM 10.3.4) are diagnosed; concat LHS rides on the procedural side.

Sensitivity inference now lives in `lowering/ast_to_hir/sensitivity.{hpp,cpp}`. `BuildSensitivityReadStore(compilation)` drives slang's `AnalysisManager` via `setCustomDFAProvider` (for per-wait mini-DFAs on the cond expression -- slang exposes no per-wait API) and `addListener` (for procedure-level and continuous-assignment sensitivity from `getSensitivityList()`). The store has two keying dimensions matching slang's two analyzable AST hierarchies: `Statement*` for whole-statement read sets (procedure body, `@*` region) and `Expression*` for sub-expression read sets (wait cond, continuous-assignment `AssignmentExpression`). Future per-expression analyses (LRM 16 property / assertion expressions, LRM 15.6 `wait_order` event-list expressions) plug into the existing Expression bucket without API changes.

The architectural rationale -- why drive slang's existing framework instead of hand-rolling a walker, why the asymmetric `setCustomDFAProvider` + `addListener` pair, and the four rejected alternatives along the way -- is recorded in `docs/decisions/read-set-inference.md`.

## Testing

Five new `cpp_run` cases under `tests/cases/cpp/continuous_assign_*` cover basic, chained combinational, ternary RHS, constant RHS, and constant part-select LHS. `bazel test //...` passes. The four policy checks (`check_ascii`, `check_architecture`, `check_cpp_style`, `check_exceptions`) and `buildifier -lint=warn` are clean.