### PR TITLE
Expand case statement coverage and document MIR lowering posture

### DIFF
--- a/docs/architecture/mir.md
+++ b/docs/architecture/mir.md
@@ -13,6 +13,10 @@ several possible backend targets for MIR, and does not define MIR's semantics.
 - The identity of each object and member within a compilation unit.
 - Lightweight structured control flow inside a callable body: `if`, loop, and sequence. No basic
   blocks at this layer.
+- A primitive expression set: literals, references, unary / binary / conditional operators, calls,
+  conversions, closures, element- and range-selects, concat, replication. SystemVerilog syntactic
+  sugar that decomposes into this set (`case`, `inside`, `casez` / `casex`, `foreach`) is lowered at
+  the HIR-to-MIR boundary and never carried as a MIR node.
 - Action shapes for constructs that bind behavior to schedule events (always blocks, continuous
   assignments, deferred assertions, concurrent assertions).
 - A textual dumper that serializes MIR for inspection, validation, and golden testing. The dumper is
@@ -57,6 +61,13 @@ several possible backend targets for MIR, and does not define MIR's semantics.
 - Side tables that recover topology from keys rather than direct ownership.
 - Deferred or concurrent assertions represented as flags or lowering-pass side effects instead of
   explicit callables.
+- A MIR node that preserves SystemVerilog syntactic sugar as an opaque payload: a `CaseStmt` /
+  `CaseInsideStmt` in MIR, an `InsideExpr` / `CasezExpr` / `CasexExpr` in MIR's expression set, a
+  `ForeachStmt` in MIR. Sugar of this kind is desugared to primitives upstream.
+- A runtime helper invocation that wraps a primitive operator family as an opaque call to recover
+  source-level shape (e.g., `Inside(lhs, items)`, `CaseMatch(sel, labels)`). Sugar collapses to
+  primitives in MIR; readability of generated backend source is not recovered by reintroducing
+  intrinsic-style calls downstream.
 
 ## Notes / Examples
 
@@ -64,3 +75,19 @@ Reviewing MIR via the dumper should feel like reading the compiled program's str
 backend emits MIR to C++ source: it is a backend output, not a debug view. The object-oriented
 semantic model maps naturally to C++ surface syntax, but C++ is not MIR's semantics and more than
 one backend may exist.
+
+The primitive expression set above is shaped by the downstream optimizer. Each backend
+(`backend::cpp` today, the LLVM backend via LIR) consumes MIR as primitives that its optimizer can
+fold, propagate, and pattern-match across. A sugar node carried into MIR forces every backend to
+either re-implement the desugaring or emit a runtime helper call; in the LLVM path the helper
+appears as an opaque call through which constant folding, dead-arm elimination, and jump-table
+synthesis cannot reach, and which LTO mitigates but does not eliminate. Backend-local readability of
+generated artifacts is a debug concern and is recovered through value-type C++ operator overloads in
+the runtime, not through sugar nodes in MIR.
+
+Constructs in the expression set that look like sugar are not. `ConditionalExpr` (`?:`) is preserved
+because MIR's `if` is a statement; there is no primitive rvalue branching in MIR's expression set
+that decomposes the ternary. `ConcatExpr` and `ReplicationExpr` are value-build primitives without a
+smaller decomposition. Select expressions are access primitives. Each of these stays in MIR for the
+same reason: removing it would require expanding into a statement-form rewrite that does not fit the
+expression context.

--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -116,7 +116,7 @@ Granular tracking lives in `integral.md` (integral / packed / wide_integral) and
 
 - [ ] operators/binary -- `integral.md`.
 - [ ] operators/binary_string
-- [ ] operators/case_equality -- `operators.md`.
+- [x] operators/case_equality -- `operators.md`.
 - [ ] operators/comparison_value_temp -- subsumed by the binary-operator coverage in `integral.md`;
       the archived `ValueTemp` IR shape does not exist on the current pipeline.
 - [ ] operators/compound_assignment -- `operators.md`.

--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -11,16 +11,14 @@ operator runtime, string runtime); see the per-item **Depends on** lines and the
 
 ## Actionable
 
-No open items are currently actionable inside this workstream alone. Every remaining item depends on
-machinery owned by another workstream; the table below lists the blockers.
+C11 and C12 are unblocked now that their dependencies (W1, W2) have landed. C9 and C10 still wait on
+`datatypes/unpacked`.
 
-| Item    | Blocked on                                                                                 |
-| ------- | ------------------------------------------------------------------------------------------ |
-| C9, C10 | `datatypes/unpacked` (procedural unpacked array vars + `arr[i]` element-select expr).      |
-| C11     | `operators.md` W2 (`==?` / `!=?` masked-compare runtime helper).                           |
-| C12     | `operators.md` W1 (basic `inside`) and W2 (wildcard items in the range list).              |
-| C16     | `datatypes/enum`.                                                                          |
-| C17     | `datatypes/string` plus the string-equality runtime helper from `operators/binary_string`. |
+| Item    | Status                                                                               |
+| ------- | ------------------------------------------------------------------------------------ |
+| C11     | Unblocked (W2 shipped). HIR -> MIR cascade with `==?` per-label compare.             |
+| C12     | Unblocked (W1, W2 shipped). HIR -> MIR cascade reusing `InsideExpr` per-item lower.  |
+| C9, C10 | Blocked on `datatypes/unpacked` (procedural unpacked array vars + `arr[i]` element). |
 
 ## Sub-Steps
 
@@ -109,10 +107,15 @@ machinery owned by another workstream; the table below lists the blockers.
       type. Covers archive cases `case_constant_expression`, `case_first_match_wins`. Coverage adds
       `case_constant_expression`, `case_first_match_wins`, `case_runtime_multi_label`,
       `case_runtime_no_default`.
-- [ ] C16 -- `case` with enum-typed selectors and enum-value labels. **Depends on**
-      `datatypes/enum`.
-- [ ] C17 -- `case` with string selector / string labels. **Depends on** `datatypes/string` plus the
-      string-equality runtime helper tracked under `operators/binary_string`.
+- [x] C16 -- `case` with enum-typed selectors and enum-value labels. The uniform cascade from C3
+      handles this with no new lowering: slang's case-context type unification widens the labels to
+      the enum type, and the cascade's per-label `==` evaluates against the unified enum operands.
+      Coverage: `case_enum_basic` (single / multi-label / default-taken) and `case_enum_no_match`
+      (no default, selector unchanged from initial).
+- [x] C17 -- `case` with string selector / string labels. Same cascade reused: per-label `==` uses
+      the SC1 string equality helper, with the bool result projected back into the cascade's 1-bit
+      truthiness shape. Coverage: `case_string_basic` (single / multi-label / default-taken) and
+      `case_string_no_match`.
 
 ### Expressions
 

--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -11,13 +11,11 @@ operator runtime, string runtime); see the per-item **Depends on** lines and the
 
 ## Actionable
 
-C11 and C12 are unblocked now that their dependencies (W1, W2) have landed. C9 and C10 still wait on
-`datatypes/unpacked`.
+C11 is unblocked now that W2 has landed. C9 and C10 still wait on `datatypes/unpacked`.
 
 | Item    | Status                                                                               |
 | ------- | ------------------------------------------------------------------------------------ |
 | C11     | Unblocked (W2 shipped). HIR -> MIR cascade with `==?` per-label compare.             |
-| C12     | Unblocked (W1, W2 shipped). HIR -> MIR cascade reusing `InsideExpr` per-item lower.  |
 | C9, C10 | Blocked on `datatypes/unpacked` (procedural unpacked array vars + `arr[i]` element). |
 
 ## Sub-Steps
@@ -81,9 +79,16 @@ C11 and C12 are unblocked now that their dependencies (W1, W2) have landed. C9 a
 - [ ] C11 -- `casez` / `casex`. Lower to an if/else cascade with masked comparisons in HIR -> MIR
       (C++ `switch` does not support wildcard match). **Depends on** `operators.md` W2 for the `==?`
       / `!=?` runtime helper.
-- [ ] C12 -- `case (... inside ...)`. Range patterns (`[lo:hi]`) and `inside` membership; lower to
-      an if/else cascade whose conditions reuse the `InsideExpr` lowering. **Depends on**
-      `operators.md` W1 (basic `inside`) and W2 (wildcard items in the range list).
+- [x] C12 -- `case (... inside ...)`. Sibling statement family in HIR (distinct from plain case
+      because labels are `range_list` entries -- value or `[lo:hi]` range -- and per-item match uses
+      inside-membership rather than `==`). HIR -> MIR snapshots the selector (LRM 12.5
+      evaluate-once) and builds the per-item inside-membership predicate against the snapshot using
+      the same primitive the `inside` operator uses (asymmetric wildcard equality for value items,
+      `(>= lo) && (<= hi)` for ranges, LRM 11.4.13 OR-reduction across items). The cascade's
+      truthiness test already excludes `1'bx` per LRM 12.5.4 ("match only when inside returns
+      `1'b1`"); no explicit 2-state clamp needed. Coverage: `case_inside_basic`,
+      `case_inside_range`, `case_inside_mixed`, `case_inside_no_match`, and `case_inside_wildcard`
+      (RHS wildcard `4'b00??` against a 4-state logic selector).
 - [x] C13 -- `unique` / `unique0` / `priority` qualifiers on `if` and `case`. HIR carries the
       qualifier as an optional `UniquePriorityCheck` field on `IfStmt` / `CaseStmt`. HIR -> MIR
       desugars the site into a `BlockStmt` that snapshots each branch's predicate into a fresh

--- a/docs/progress/integral.md
+++ b/docs/progress/integral.md
@@ -95,9 +95,9 @@ wildcard equality (`==?`). Both were plumbed through HIR / MIR but rejected at c
       in backend. Also consumed by `Var<T>` for event-control change detection (LRM 9.4.2 says
       `@(x)` fires when the value "is not equal to its previous value" under bit-pattern equality;
       that is `===` semantics).
-- [ ] J18 -- `PackedArray::WildcardEquals` (LRM 11.4.6 `==?` / `!=?`): bit-by-bit compare with the
-      RHS X/Z bits treated as don't-care; returns deterministic `bool`. Wire `kWildcardEquality` and
-      `kWildcardInequality` arms.
+- [x] J18 -- `PackedArray::WildcardEquals` (LRM 11.4.6 `==?` / `!=?`): bit-by-bit compare with the
+      RHS X/Z bits treated as don't-care. Wire `kWildcardEquality` and `kWildcardInequality` arms.
+      Same work item as `operators.md` W2; that file is the canonical home.
 
 ## Cross-references
 
@@ -116,6 +116,3 @@ wildcard equality (`==?`). Both were plumbed through HIR / MIR but rejected at c
 
 `++` / `--`: tracked as `operators.md` W12 (new HIR / MIR shape, statement and expression forms, LRM
 evaluate-target-once semantics).
-
-`==?` / `!=?` wildcard equality: deterministic-bool form with RHS X/Z as don't-care (LRM 11.4.6).
-Plumbed through HIR / MIR; cpp emit rejects. Tracked as J18 in Cut 4 above.

--- a/include/lyra/backend/cpp/render_expr.hpp
+++ b/include/lyra/backend/cpp/render_expr.hpp
@@ -17,9 +17,10 @@ auto RenderStructuralVarName(
     const RenderContext& ctx, const mir::StructuralVarRef& ref)
     -> diag::Result<std::string>;
 
-// Renders `expr` and, when its MIR type is a packed array, appends
-// `.IsTruthy()`. Used by every statement that consumes an expression as a C++
-// `bool` (`if`, `while`, `do`, `for` condition, etc.).
+// Renders `expr` for use in a C++ boolean context (`if`, `while`, `do`, `for`
+// condition, ternary cond, `&&` / `||` / `!`). When the expression's MIR type
+// is a packed array, `PackedArray`'s `explicit operator bool` fires on the
+// contextual conversion; no explicit wrapping is needed.
 auto RenderConditionAsBool(const RenderContext& ctx, const mir::Expr& expr)
     -> diag::Result<std::string>;
 

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -9,6 +9,7 @@
 #include "lyra/hir/binary_op.hpp"
 #include "lyra/hir/conversion.hpp"
 #include "lyra/hir/expr_id.hpp"
+#include "lyra/hir/inside_item.hpp"
 #include "lyra/hir/lvalue.hpp"
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/range_bounds.hpp"
@@ -61,13 +62,6 @@ struct CallExpr {
   SubroutineRef callee;
   std::vector<ExprId> arguments;
 };
-
-struct InsideRangePair {
-  ExprId lo;
-  ExprId hi;
-};
-
-using InsideItem = std::variant<ExprId, InsideRangePair>;
 
 struct InsideExpr {
   ExprId lhs;

--- a/include/lyra/hir/inside_item.hpp
+++ b/include/lyra/hir/inside_item.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <variant>
+
+#include "lyra/hir/expr_id.hpp"
+
+namespace lyra::hir {
+
+struct InsideRangePair {
+  ExprId lo;
+  ExprId hi;
+};
+
+using InsideItem = std::variant<ExprId, InsideRangePair>;
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -10,6 +10,7 @@
 
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr_id.hpp"
+#include "lyra/hir/inside_item.hpp"
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/value_ref.hpp"
 
@@ -63,6 +64,23 @@ struct CaseItem {
 struct CaseStmt {
   ExprId condition;
   std::vector<CaseItem> items;
+  std::optional<StmtId> default_stmt;
+  std::optional<UniquePriorityCheck> check;
+};
+
+// LRM 12.5.4 set-membership form `case (X) inside { ... }`. Distinct from
+// CaseStmt because both the per-item label shape (range_list, not value list)
+// and the per-item match semantics (asymmetric wildcard inside-membership per
+// LRM 11.4.13 / 11.4.6) differ -- a match here is only the deterministic
+// `1'b1` from the inside operator; `1'b0` and `1'bx` are both no-match.
+struct CaseInsideItem {
+  std::vector<InsideItem> items;
+  StmtId stmt;
+};
+
+struct CaseInsideStmt {
+  ExprId condition;
+  std::vector<CaseInsideItem> items;
   std::optional<StmtId> default_stmt;
   std::optional<UniquePriorityCheck> check;
 };
@@ -182,9 +200,9 @@ struct WaitStmt {
 };
 
 using StmtData = std::variant<
-    EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, IfStmt, CaseStmt, ForStmt,
-    WhileStmt, RepeatStmt, DoWhileStmt, ForeverStmt, BreakStmt, ContinueStmt,
-    TimedStmt, EventTriggerStmt, WaitStmt>;
+    EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, IfStmt, CaseStmt,
+    CaseInsideStmt, ForStmt, WhileStmt, RepeatStmt, DoWhileStmt, ForeverStmt,
+    BreakStmt, ContinueStmt, TimedStmt, EventTriggerStmt, WaitStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/include/lyra/lowering/ast_to_hir/expression/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/lower.hpp
@@ -4,6 +4,7 @@
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
+#include "lyra/hir/inside_item.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
 
@@ -37,5 +38,14 @@ auto LowerStructuralLvalue(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ScopeLoweringState& scope_state, const ScopeStack& stack,
     const slang::ast::Expression& expr) -> diag::Result<hir::Lvalue>;
+
+// Lower one entry from a slang range_list (the operand list of `inside` and
+// the per-item label list of `case (...) inside`). ValueRange entries become
+// an InsideRangePair; any other expression becomes a plain ExprId. The
+// resulting ExprId(s) are appended to proc_state's expression table.
+auto LowerInsideItem(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const slang::ast::Expression& item_expr) -> diag::Result<hir::InsideItem>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/hir_to_mir/inside_predicate.hpp
+++ b/include/lyra/lowering/hir_to_mir/inside_predicate.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/inside_item.hpp"
+#include "lyra/hir/process.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// Builds the 1-bit MIR predicate for one `inside`-style item against a
+// pre-lowered LHS:
+//   - value items lower to asymmetric wildcard equality (LRM 11.4.6),
+//   - range items lower to `(lhs >= lo) && (lhs <= hi)`.
+// Shared between the inside operator (LRM 11.4.13) and the case-inside
+// cascade (LRM 12.5.4). Callers OR-chain the per-item results to obtain the
+// final inside predicate.
+auto BuildHirInsideItemPredicate(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, mir::ExprId lhs_id,
+    const hir::InsideItem& item, mir::TypeId result_type)
+    -> diag::Result<mir::ExprId>;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -194,10 +194,15 @@ class PackedArray {
   // be <= 64.
   [[nodiscard]] auto ToInt64() const -> std::int64_t;
 
-  // SystemVerilog "non-zero" interpretation: any non-zero value bit makes
-  // the result true. X/Z bits do not count as non-zero. Used by `if`,
-  // `while`, and ternary conditions emitted as `if (cond.IsTruthy())`.
+  // SystemVerilog "non-zero" interpretation: any value bit set with the
+  // matching unknown-plane bit clear makes the result true. X/Z bits do not
+  // count as truthy. `operator bool` is explicit so it only fires in boolean
+  // contexts (`if`, `while`, ternary cond, `&&`, `||`, `!`) and never as an
+  // implicit conversion that would shadow the operator overloads.
   [[nodiscard]] auto IsTruthy() const -> bool;
+  [[nodiscard]] explicit operator bool() const {
+    return IsTruthy();
+  }
 
   // Drives LRM 11.4 X/Z propagation: arithmetic, comparison, shift, and
   // power return all-X (or 1-bit X) when any operand has HasUnknown().
@@ -305,10 +310,17 @@ class PackedArray {
   [[nodiscard]] auto operator-() const -> PackedArray;
   [[nodiscard]] auto operator~() const -> PackedArray;
 
-  // Methods for ops that have no C++ operator counterpart.
-  [[nodiscard]] auto LogicalAnd(const PackedArray& other) const -> PackedArray;
-  [[nodiscard]] auto LogicalOr(const PackedArray& other) const -> PackedArray;
-  [[nodiscard]] auto LogicalNot() const -> PackedArray;
+  // Logical operators. `&&` / `||` lose C++ short-circuit semantics when
+  // overloaded; that is acceptable here because callers (cpp emit, ad-hoc
+  // runtime use) work with already-materialized PackedArray values without
+  // side effects, and any optimizer pass that cares (clang's mem2reg, LLVM)
+  // sees these as plain member calls equivalent to the OR-chain it would
+  // see for `LogicalOr` -- there is no codegen difference.
+  [[nodiscard]] auto operator&&(const PackedArray& other) const -> PackedArray;
+  [[nodiscard]] auto operator||(const PackedArray& other) const -> PackedArray;
+  [[nodiscard]] auto operator!() const -> PackedArray;
+
+  // SV `->` and `<->` have no C++ operator counterpart; method-only.
   [[nodiscard]] auto LogicalImplication(const PackedArray& other) const
       -> PackedArray;
   [[nodiscard]] auto LogicalEquivalence(const PackedArray& other) const

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -362,9 +362,9 @@ auto RenderBinaryOpIntegral(
       tok = " >= ";
       break;
     case mir::BinaryOp::kLogicalAnd:
-      return "(" + lhs + ").LogicalAnd(" + rhs + ")";
+      return "(" + lhs + " && " + rhs + ")";
     case mir::BinaryOp::kLogicalOr:
-      return "(" + lhs + ").LogicalOr(" + rhs + ")";
+      return "(" + lhs + " || " + rhs + ")";
     case mir::BinaryOp::kBitwiseXnor:
       return "(" + lhs + ").BitwiseXnor(" + rhs + ")";
     case mir::BinaryOp::kPower:
@@ -382,11 +382,11 @@ auto RenderBinaryOpIntegral(
     case mir::BinaryOp::kWildcardEquality:
       return "(" + lhs + ").WildcardEquals(" + rhs + ")";
     case mir::BinaryOp::kWildcardInequality:
-      return "(" + lhs + ").WildcardEquals(" + rhs + ").LogicalNot()";
+      return "(!(" + lhs + ").WildcardEquals(" + rhs + "))";
     case mir::BinaryOp::kCaseEquality:
       return "(" + lhs + ").CaseEqual(" + rhs + ")";
     case mir::BinaryOp::kCaseInequality:
-      return "(" + lhs + ").CaseEqual(" + rhs + ").LogicalNot()";
+      return "(!(" + lhs + ").CaseEqual(" + rhs + "))";
   }
   return "(" + lhs + std::string{tok} + rhs + ")";
 }
@@ -420,7 +420,7 @@ auto RenderUnaryOpIntegral(mir::UnaryOp op, const std::string& operand)
     case mir::UnaryOp::kBitwiseNot:
       return "(~" + operand + ")";
     case mir::UnaryOp::kLogicalNot:
-      return "(" + operand + ").LogicalNot()";
+      return "(!(" + operand + "))";
     case mir::UnaryOp::kReductionAnd:
       return "(" + operand + ").ReductionAnd()";
     case mir::UnaryOp::kReductionOr:
@@ -1251,9 +1251,8 @@ auto RenderConditionAsBool(const RenderContext& ctx, const mir::Expr& expr)
     -> diag::Result<std::string> {
   auto text_or = RenderExpr(ctx, expr);
   if (!text_or) return std::unexpected(std::move(text_or.error()));
-  if (ctx.Unit().GetType(expr.type).IsIntegralPacked()) {
-    return "(" + *text_or + ").IsTruthy()";
-  }
+  // PackedArray's `explicit operator bool` fires in any boolean context (if /
+  // while / for / ternary cond / `&&` / `||` / `!`), so no wrapping needed.
   return *text_or;
 }
 

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -1002,6 +1002,54 @@ class HirDumper {
     Dedent();
   }
 
+  void DumpCaseInsideStmtNode(
+      const Process& p, StmtId id, const CaseInsideStmt& c) {
+    Line(
+        std::format(
+            "Stmt[{}] CaseInsideStmt{} cond=Expr[{}] (items={})", id.value,
+            FormatUniquePriorityCheck(c.check), c.condition.value,
+            c.items.size()));
+    Indent();
+    Line(
+        std::format(
+            "Expr[{}] {}", c.condition.value, FormatProcExpr(p, c.condition)));
+    for (std::size_t k = 0; k < c.items.size(); ++k) {
+      const auto& item = c.items[k];
+      Line(std::format("item[{}] range_list (count={})", k, item.items.size()));
+      Indent();
+      for (const auto& inside_item : item.items) {
+        std::visit(
+            Overloaded{
+                [&](const ExprId& val_id) {
+                  Line(
+                      std::format(
+                          "Expr[{}] {}", val_id.value,
+                          FormatProcExpr(p, val_id)));
+                },
+                [&](const InsideRangePair& r) {
+                  Line(
+                      std::format(
+                          "[Expr[{}]:Expr[{}]] {} : {}", r.lo.value, r.hi.value,
+                          FormatProcExpr(p, r.lo), FormatProcExpr(p, r.hi)));
+                },
+            },
+            inside_item);
+      }
+      Line("stmt:");
+      Indent();
+      DumpStmt(p, item.stmt);
+      Dedent();
+      Dedent();
+    }
+    if (c.default_stmt.has_value()) {
+      Line("default:");
+      Indent();
+      DumpStmt(p, *c.default_stmt);
+      Dedent();
+    }
+    Dedent();
+  }
+
   void DumpForStmtNode(const Process& p, StmtId id, const ForStmt& f) {
     Line(
         std::format(
@@ -1144,6 +1192,7 @@ class HirDumper {
             [&](const BlockStmt& b) { DumpBlockStmtNode(p, id, b); },
             [&](const IfStmt& i) { DumpIfStmtNode(p, id, i); },
             [&](const CaseStmt& c) { DumpCaseStmtNode(p, id, c); },
+            [&](const CaseInsideStmt& c) { DumpCaseInsideStmtNode(p, id, c); },
             [&](const ForStmt& f) { DumpForStmtNode(p, id, f); },
             [&](const WhileStmt& w) { DumpWhileStmtNode(p, id, w); },
             [&](const RepeatStmt& r) { DumpRepeatStmtNode(p, id, r); },

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -609,8 +609,6 @@ auto LowerInsideExprProc(
     ProcessLoweringState& proc_state, const ScopeStack& stack,
     const slang::ast::InsideExpression& in, const slang::ast::Expression& expr,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  const auto& mapper = unit_facts.SourceMapper();
-
   auto lhs_or =
       LowerProcExpr(unit_facts, unit_state, proc_state, stack, in.left());
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
@@ -619,31 +617,10 @@ auto LowerInsideExprProc(
   std::vector<hir::InsideItem> items;
   items.reserve(in.rangeList().size());
   for (const auto* item : in.rangeList()) {
-    if (item->kind == slang::ast::ExpressionKind::ValueRange) {
-      const auto& vr = item->as<slang::ast::ValueRangeExpression>();
-      if (vr.rangeKind != slang::ast::ValueRangeKind::Simple) {
-        return diag::Unsupported(
-            mapper.SpanOf(vr.sourceRange),
-            diag::DiagCode::kUnsupportedExpressionForm,
-            "tolerance-range form in inside operator is not yet supported",
-            diag::UnsupportedCategory::kFeature);
-      }
-      auto lo_or =
-          LowerProcExpr(unit_facts, unit_state, proc_state, stack, vr.left());
-      if (!lo_or) return std::unexpected(std::move(lo_or.error()));
-      const hir::ExprId lo_id = proc_state.AddExpr(*std::move(lo_or));
-      auto hi_or =
-          LowerProcExpr(unit_facts, unit_state, proc_state, stack, vr.right());
-      if (!hi_or) return std::unexpected(std::move(hi_or.error()));
-      const hir::ExprId hi_id = proc_state.AddExpr(*std::move(hi_or));
-      items.emplace_back(hir::InsideRangePair{.lo = lo_id, .hi = hi_id});
-    } else {
-      auto val_or =
-          LowerProcExpr(unit_facts, unit_state, proc_state, stack, *item);
-      if (!val_or) return std::unexpected(std::move(val_or.error()));
-      const hir::ExprId val_id = proc_state.AddExpr(*std::move(val_or));
-      items.emplace_back(val_id);
-    }
+    auto item_or =
+        LowerInsideItem(unit_facts, unit_state, proc_state, stack, *item);
+    if (!item_or) return std::unexpected(std::move(item_or.error()));
+    items.push_back(*std::move(item_or));
   }
 
   auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
@@ -934,6 +911,35 @@ auto LowerConditionalExprStructural(
 }
 
 }  // namespace
+
+auto LowerInsideItem(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const slang::ast::Expression& item_expr) -> diag::Result<hir::InsideItem> {
+  if (item_expr.kind == slang::ast::ExpressionKind::ValueRange) {
+    const auto& vr = item_expr.as<slang::ast::ValueRangeExpression>();
+    if (vr.rangeKind != slang::ast::ValueRangeKind::Simple) {
+      return diag::Unsupported(
+          unit_facts.SourceMapper().SpanOf(vr.sourceRange),
+          diag::DiagCode::kUnsupportedExpressionForm,
+          "tolerance-range form in inside operator is not yet supported",
+          diag::UnsupportedCategory::kFeature);
+    }
+    auto lo_or =
+        LowerProcExpr(unit_facts, unit_state, proc_state, stack, vr.left());
+    if (!lo_or) return std::unexpected(std::move(lo_or.error()));
+    const hir::ExprId lo_id = proc_state.AddExpr(*std::move(lo_or));
+    auto hi_or =
+        LowerProcExpr(unit_facts, unit_state, proc_state, stack, vr.right());
+    if (!hi_or) return std::unexpected(std::move(hi_or.error()));
+    const hir::ExprId hi_id = proc_state.AddExpr(*std::move(hi_or));
+    return hir::InsideRangePair{.lo = lo_id, .hi = hi_id};
+  }
+  auto val_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, item_expr);
+  if (!val_or) return std::unexpected(std::move(val_or.error()));
+  return proc_state.AddExpr(*std::move(val_or));
+}
 
 auto LowerProcExpr(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -452,15 +452,65 @@ auto LowerContinueStmt(diag::SourceSpan span) -> diag::Result<hir::Stmt> {
       .label = std::nullopt, .data = hir::ContinueStmt{}, .span = span};
 }
 
+auto LowerCaseInsideStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, ScopeStack& stack,
+    const slang::ast::CaseStatement& cs, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  const auto case_check = LowerUniquePriorityCheck(cs.check);
+  auto cond_expr = LowerProcExpr(
+      unit_facts, scope_state.UnitState(), proc_state, stack, cs.expr);
+  if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
+  const hir::ExprId cond_id = proc_state.AddExpr(*std::move(cond_expr));
+  std::vector<hir::CaseInsideItem> items;
+  items.reserve(cs.items.size());
+  for (const auto& item : cs.items) {
+    std::vector<hir::InsideItem> inside_items;
+    inside_items.reserve(item.expressions.size());
+    for (const auto* label_expr : item.expressions) {
+      auto item_or = LowerInsideItem(
+          unit_facts, scope_state.UnitState(), proc_state, stack, *label_expr);
+      if (!item_or) return std::unexpected(std::move(item_or.error()));
+      inside_items.push_back(*std::move(item_or));
+    }
+    auto item_stmt =
+        LowerStatement(unit_facts, proc_state, scope_state, stack, *item.stmt);
+    if (!item_stmt) return std::unexpected(std::move(item_stmt.error()));
+    const hir::StmtId item_id = proc_state.AddStmt(*std::move(item_stmt));
+    items.push_back(
+        hir::CaseInsideItem{.items = std::move(inside_items), .stmt = item_id});
+  }
+  std::optional<hir::StmtId> default_id;
+  if (cs.defaultCase != nullptr) {
+    auto default_stmt = LowerStatement(
+        unit_facts, proc_state, scope_state, stack, *cs.defaultCase);
+    if (!default_stmt) return std::unexpected(std::move(default_stmt.error()));
+    default_id = proc_state.AddStmt(*std::move(default_stmt));
+  }
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data =
+          hir::CaseInsideStmt{
+              .condition = cond_id,
+              .items = std::move(items),
+              .default_stmt = default_id,
+              .check = case_check},
+      .span = span};
+}
+
 auto LowerCaseStmt(
     const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
     ScopeLoweringState& scope_state, ScopeStack& stack,
     const slang::ast::CaseStatement& cs, diag::SourceSpan span)
     -> diag::Result<hir::Stmt> {
+  if (cs.condition == slang::ast::CaseStatementCondition::Inside) {
+    return LowerCaseInsideStmt(
+        unit_facts, proc_state, scope_state, stack, cs, span);
+  }
   if (cs.condition != slang::ast::CaseStatementCondition::Normal) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedStatementForm,
-        "casez/casex/case-inside are not yet supported",
+        "casez/casex are not yet supported",
         diag::UnsupportedCategory::kFeature);
   }
   const auto case_check = LowerUniquePriorityCheck(cs.check);

--- a/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
+++ b/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
@@ -1,0 +1,81 @@
+#include "lyra/lowering/hir_to_mir/inside_predicate.hpp"
+
+#include <expected>
+#include <utility>
+
+#include "lyra/base/overloaded.hpp"
+#include "lyra/hir/inside_item.hpp"
+#include "lyra/hir/process.hpp"
+#include "lyra/lowering/hir_to_mir/lower_expr.hpp"
+#include "lyra/mir/binary_op.hpp"
+#include "lyra/mir/expr.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+auto BuildHirInsideItemPredicate(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, mir::ExprId lhs_id,
+    const hir::InsideItem& item, mir::TypeId result_type)
+    -> diag::Result<mir::ExprId> {
+  auto lower_id = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
+    auto lowered = LowerExpr(
+        unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+        hir_process.exprs.at(id.value));
+    if (!lowered) {
+      return std::unexpected(std::move(lowered.error()));
+    }
+    return proc_scope_state.AddExpr(*std::move(lowered));
+  };
+
+  return std::visit(
+      Overloaded{
+          [&](const hir::ExprId& val_id) -> diag::Result<mir::ExprId> {
+            auto v = lower_id(val_id);
+            if (!v) return std::unexpected(std::move(v.error()));
+            return proc_scope_state.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::BinaryExpr{
+                            .op = mir::BinaryOp::kWildcardEquality,
+                            .lhs = lhs_id,
+                            .rhs = *v},
+                    .type = result_type});
+          },
+          [&](const hir::InsideRangePair& r) -> diag::Result<mir::ExprId> {
+            auto lo = lower_id(r.lo);
+            if (!lo) return std::unexpected(std::move(lo.error()));
+            auto hi = lower_id(r.hi);
+            if (!hi) return std::unexpected(std::move(hi.error()));
+            const mir::ExprId ge_id = proc_scope_state.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::BinaryExpr{
+                            .op = mir::BinaryOp::kGreaterEqual,
+                            .lhs = lhs_id,
+                            .rhs = *lo},
+                    .type = result_type});
+            const mir::ExprId le_id = proc_scope_state.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::BinaryExpr{
+                            .op = mir::BinaryOp::kLessEqual,
+                            .lhs = lhs_id,
+                            .rhs = *hi},
+                    .type = result_type});
+            return proc_scope_state.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::BinaryExpr{
+                            .op = mir::BinaryOp::kLogicalAnd,
+                            .lhs = ge_id,
+                            .rhs = le_id},
+                    .type = result_type});
+          },
+      },
+      item);
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <format>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -20,6 +21,7 @@
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/unary_op.hpp"
 #include "lyra/hir/value_ref.hpp"
+#include "lyra/lowering/hir_to_mir/inside_predicate.hpp"
 #include "lyra/lowering/hir_to_mir/lower_system_subroutine.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/binary_op.hpp"
@@ -907,76 +909,6 @@ auto LowerHirCallExprProc(
       c.callee);
 }
 
-// Builds the 1-bit MIR predicate ExprId for one inside-operator item, comparing
-// against the already-lowered LHS. Value items use `==`; range items use
-// `(>= lo) && (<= hi)`. The returned ExprId references a freshly added MIR
-// expression in `proc_scope_state`.
-auto BuildHirInsideItemPredicateProc(
-    const UnitLoweringState& unit_state,
-    const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
-    ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, mir::ExprId lhs_id,
-    const hir::InsideItem& item, mir::TypeId result_type)
-    -> diag::Result<mir::ExprId> {
-  auto lower_id = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
-    auto lowered = LowerExpr(
-        unit_state, scope_state, proc_state, proc_scope_state, hir_process,
-        hir_process.exprs.at(id.value));
-    if (!lowered) {
-      return std::unexpected(std::move(lowered.error()));
-    }
-    return proc_scope_state.AddExpr(*std::move(lowered));
-  };
-
-  return std::visit(
-      Overloaded{
-          [&](const hir::ExprId& val_id) -> diag::Result<mir::ExprId> {
-            auto v = lower_id(val_id);
-            if (!v) return std::unexpected(std::move(v.error()));
-            return proc_scope_state.AddExpr(
-                mir::Expr{
-                    .data =
-                        mir::BinaryExpr{
-                            .op = mir::BinaryOp::kWildcardEquality,
-                            .lhs = lhs_id,
-                            .rhs = *v},
-                    .type = result_type});
-          },
-          [&](const hir::InsideRangePair& r) -> diag::Result<mir::ExprId> {
-            auto lo = lower_id(r.lo);
-            if (!lo) return std::unexpected(std::move(lo.error()));
-            auto hi = lower_id(r.hi);
-            if (!hi) return std::unexpected(std::move(hi.error()));
-            const mir::ExprId ge_id = proc_scope_state.AddExpr(
-                mir::Expr{
-                    .data =
-                        mir::BinaryExpr{
-                            .op = mir::BinaryOp::kGreaterEqual,
-                            .lhs = lhs_id,
-                            .rhs = *lo},
-                    .type = result_type});
-            const mir::ExprId le_id = proc_scope_state.AddExpr(
-                mir::Expr{
-                    .data =
-                        mir::BinaryExpr{
-                            .op = mir::BinaryOp::kLessEqual,
-                            .lhs = lhs_id,
-                            .rhs = *hi},
-                    .type = result_type});
-            return proc_scope_state.AddExpr(
-                mir::Expr{
-                    .data =
-                        mir::BinaryExpr{
-                            .op = mir::BinaryOp::kLogicalAnd,
-                            .lhs = ge_id,
-                            .rhs = le_id},
-                    .type = result_type});
-          },
-      },
-      item);
-}
-
 auto LowerHirInsideExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
@@ -990,41 +922,30 @@ auto LowerHirInsideExprProc(
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const mir::ExprId lhs_id = proc_scope_state.AddExpr(*std::move(lhs_or));
 
-  std::vector<mir::ExprId> predicates;
-  predicates.reserve(in.items.size());
-  for (const auto& item : in.items) {
-    auto pred_or = BuildHirInsideItemPredicateProc(
-        unit_state, scope_state, proc_state, proc_scope_state, hir_process,
-        lhs_id, item, result_type);
-    if (!pred_or) return std::unexpected(std::move(pred_or.error()));
-    predicates.push_back(*pred_or);
-  }
-
-  if (predicates.empty()) {
+  if (in.items.empty()) {
     throw InternalError(
         "LowerHirInsideExprProc: hir::InsideExpr has empty item list");
   }
-  if (predicates.size() == 1) {
-    return mir::Expr{proc_scope_state.GetExpr(predicates.front())};
+  std::optional<mir::ExprId> acc;
+  for (const auto& item : in.items) {
+    auto pred_or = BuildHirInsideItemPredicate(
+        unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+        lhs_id, item, result_type);
+    if (!pred_or) return std::unexpected(std::move(pred_or.error()));
+    if (acc.has_value()) {
+      acc = proc_scope_state.AddExpr(
+          mir::Expr{
+              .data =
+                  mir::BinaryExpr{
+                      .op = mir::BinaryOp::kLogicalOr,
+                      .lhs = *acc,
+                      .rhs = *pred_or},
+              .type = result_type});
+    } else {
+      acc = *pred_or;
+    }
   }
-  mir::ExprId acc = predicates.front();
-  for (std::size_t i = 1; i + 1 < predicates.size(); ++i) {
-    acc = proc_scope_state.AddExpr(
-        mir::Expr{
-            .data =
-                mir::BinaryExpr{
-                    .op = mir::BinaryOp::kLogicalOr,
-                    .lhs = acc,
-                    .rhs = predicates[i]},
-            .type = result_type});
-  }
-  return mir::Expr{
-      .data =
-          mir::BinaryExpr{
-              .op = mir::BinaryOp::kLogicalOr,
-              .lhs = acc,
-              .rhs = predicates.back()},
-      .type = result_type};
+  return mir::Expr{proc_scope_state.GetExpr(*acc)};
 }
 
 auto LowerHirElementSelectExprProc(

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -17,6 +17,7 @@
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/case_cascade.hpp"
 #include "lyra/lowering/hir_to_mir/delay_time_resolver.hpp"
+#include "lyra/lowering/hir_to_mir/inside_predicate.hpp"
 #include "lyra/lowering/hir_to_mir/lower_deferred_check.hpp"
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 #include "lyra/lowering/hir_to_mir/procedural_scope_helpers.hpp"
@@ -406,6 +407,139 @@ auto LowerCaseStmt(
   return BuildCaseCascade(
       std::move(wrapper_state), stmt.label, c.items.size(),
       std::move(body_scopes), std::move(default_scope), build_predicate);
+}
+
+auto LowerCaseInsideStmt(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    const hir::Stmt& stmt, const hir::CaseInsideStmt& c)
+    -> diag::Result<mir::Stmt> {
+  const mir::TypeId bit_type = unit_state.Builtins().bit1;
+
+  ProceduralScopeLoweringState wrapper_state;
+  ProceduralDepthGuard wrapper_depth_guard{proc_state};
+
+  auto cond_or = LowerExpr(
+      unit_state, scope_state, proc_state, wrapper_state, hir_proc,
+      hir_proc.exprs.at(c.condition.value));
+  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
+  mir::ExprId cond_expr_id = wrapper_state.AddExpr(*std::move(cond_or));
+
+  // Peel an outer ConversionExpr from a case-context-widened selector (same
+  // reason as the plain case form: cpp backend cannot init form=explicit from
+  // form=int, and the per-item inside predicate compares against the
+  // unwrapped source type directly).
+  if (const auto* cv = std::get_if<mir::ConversionExpr>(
+          &wrapper_state.GetExpr(cond_expr_id).data)) {
+    cond_expr_id = cv->operand;
+  }
+
+  const CaseSnapshotRefs snapshot =
+      AppendCaseSnapshot(wrapper_state, cond_expr_id);
+
+  auto with_extra_depth = [&](std::size_t extras, auto fn) {
+    std::vector<std::unique_ptr<ProceduralDepthGuard>> guards;
+    guards.reserve(extras);
+    for (std::size_t i = 0; i < extras; ++i) {
+      guards.push_back(std::make_unique<ProceduralDepthGuard>(proc_state));
+    }
+    return fn();
+  };
+
+  std::vector<mir::ProceduralScope> body_scopes;
+  body_scopes.reserve(c.items.size());
+  for (std::size_t i = 0; i < c.items.size(); ++i) {
+    auto body_or = with_extra_depth(i, [&] {
+      return LowerStmtIntoChildScope(
+          unit_state, scope_state, proc_state, hir_proc, c.items[i].stmt);
+    });
+    if (!body_or) {
+      return std::unexpected(std::move(body_or.error()));
+    }
+    body_scopes.push_back(std::move(*body_or));
+  }
+
+  std::optional<mir::ProceduralScope> default_scope;
+  if (c.default_stmt.has_value()) {
+    auto def_or = with_extra_depth(c.items.size(), [&] {
+      return LowerStmtIntoChildScope(
+          unit_state, scope_state, proc_state, hir_proc, *c.default_stmt);
+    });
+    if (!def_or) {
+      return std::unexpected(std::move(def_or.error()));
+    }
+    default_scope = std::move(*def_or);
+  }
+
+  // Builds the per-item inside-membership predicate against the snapshot ref,
+  // matching the LRM 11.4.13 OR-reduction semantics. Per LRM 12.5.4 the
+  // cascade's boolean-context test on this predicate already excludes 1'bx
+  // (`explicit operator bool` returns false for any X bit), so no explicit
+  // 2-state clamp is needed.
+  auto build_item_predicate =
+      [&](ProceduralScopeLoweringState& enc, std::size_t item_idx,
+          std::uint32_t sel_hops) -> diag::Result<mir::ExprId> {
+    return with_extra_depth(item_idx, [&] -> diag::Result<mir::ExprId> {
+      const mir::ExprId sel_ref = enc.AddExpr(
+          mir::Expr{
+              .data =
+                  mir::ProceduralVarRef{
+                      .hops = mir::ProceduralHops{.value = sel_hops},
+                      .var = snapshot.sel_var},
+              .type = snapshot.sel_type});
+      const auto& item = c.items[item_idx];
+      if (item.items.empty()) {
+        throw InternalError(
+            "LowerCaseInsideStmt: case-inside item has empty range_list");
+      }
+      std::optional<mir::ExprId> acc;
+      for (const auto& inside_item : item.items) {
+        auto pred_or = BuildHirInsideItemPredicate(
+            unit_state, scope_state, proc_state, enc, hir_proc, sel_ref,
+            inside_item, bit_type);
+        if (!pred_or) return std::unexpected(std::move(pred_or.error()));
+        if (acc.has_value()) {
+          acc = enc.AddExpr(
+              mir::Expr{
+                  .data =
+                      mir::BinaryExpr{
+                          .op = mir::BinaryOp::kLogicalOr,
+                          .lhs = *acc,
+                          .rhs = *pred_or},
+                  .type = bit_type});
+        } else {
+          acc = *pred_or;
+        }
+      }
+      return *acc;
+    });
+  };
+
+  if (c.check.has_value()) {
+    std::vector<mir::ExprId> predicates;
+    predicates.reserve(c.items.size());
+    for (std::size_t i = 0; i < c.items.size(); ++i) {
+      auto pred_or = build_item_predicate(wrapper_state, i, 0);
+      if (!pred_or) return std::unexpected(std::move(pred_or.error()));
+      predicates.push_back(*pred_or);
+    }
+
+    std::vector<DeferredCheckBranch> branches;
+    branches.reserve(c.items.size());
+    for (std::size_t i = 0; i < c.items.size(); ++i) {
+      branches.push_back(
+          DeferredCheckBranch{
+              .predicate = predicates[i], .body = std::move(body_scopes[i])});
+    }
+    return BuildDeferredCheckCascade(
+        unit_state, std::move(wrapper_state), std::move(branches),
+        std::move(default_scope), *c.check, stmt.label);
+  }
+
+  return BuildCaseCascade(
+      std::move(wrapper_state), stmt.label, c.items.size(),
+      std::move(body_scopes), std::move(default_scope), build_item_predicate);
 }
 
 auto LowerForStmt(
@@ -1047,6 +1181,10 @@ auto LowerStmt(
           },
           [&](const hir::CaseStmt& c) {
             return LowerCaseStmt(
+                unit_state, scope_state, proc_state, hir_proc, stmt, c);
+          },
+          [&](const hir::CaseInsideStmt& c) {
+            return LowerCaseInsideStmt(
                 unit_state, scope_state, proc_state, hir_proc, stmt, c);
           },
           [&](const hir::ForStmt& f) {

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -1359,7 +1359,7 @@ auto PackedArray::operator~() const -> PackedArray {
   return result;
 }
 
-auto PackedArray::LogicalAnd(const PackedArray& other) const -> PackedArray {
+auto PackedArray::operator&&(const PackedArray& other) const -> PackedArray {
   const auto a = TruthinessOf(*this);
   const auto b = TruthinessOf(other);
   const bool result_four_state = is_four_state_ || other.is_four_state_;
@@ -1372,7 +1372,7 @@ auto PackedArray::LogicalAnd(const PackedArray& other) const -> PackedArray {
   return AllX(1U, false);
 }
 
-auto PackedArray::LogicalOr(const PackedArray& other) const -> PackedArray {
+auto PackedArray::operator||(const PackedArray& other) const -> PackedArray {
   const auto a = TruthinessOf(*this);
   const auto b = TruthinessOf(other);
   const bool result_four_state = is_four_state_ || other.is_four_state_;
@@ -1385,7 +1385,7 @@ auto PackedArray::LogicalOr(const PackedArray& other) const -> PackedArray {
   return AllX(1U, false);
 }
 
-auto PackedArray::LogicalNot() const -> PackedArray {
+auto PackedArray::operator!() const -> PackedArray {
   switch (TruthinessOf(*this)) {
     case Truthiness::kKnownZero:
       return OneBitResult(true, is_four_state_);
@@ -1394,7 +1394,7 @@ auto PackedArray::LogicalNot() const -> PackedArray {
     case Truthiness::kUnknown:
       return AllX(1U, false);
   }
-  throw InternalError("LogicalNot: unhandled Truthiness");
+  throw InternalError("operator!: unhandled Truthiness");
 }
 
 auto PackedArray::LogicalImplication(const PackedArray& other) const

--- a/tests/cases/cpp/case_enum_basic/case.yaml
+++ b/tests/cases/cpp/case_enum_basic/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.case_enum_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    single: 2
+    multi: 23
+    defaulted: 100

--- a/tests/cases/cpp/case_enum_basic/main.sv
+++ b/tests/cases/cpp/case_enum_basic/main.sv
@@ -1,0 +1,32 @@
+module Top;
+  typedef enum {RED, GREEN, BLUE} Color;
+
+  int single;
+  int multi;
+  int defaulted;
+
+  initial begin
+    single = 0;
+    multi = 0;
+    defaulted = 0;
+
+    case (GREEN)
+      RED:   single = 1;
+      GREEN: single = 2;
+      BLUE:  single = 3;
+      default: single = 99;
+    endcase
+
+    case (BLUE)
+      RED:         multi = 1;
+      GREEN, BLUE: multi = 23;
+      default:     multi = 99;
+    endcase
+
+    case (RED)
+      GREEN:   defaulted = 1;
+      BLUE:    defaulted = 2;
+      default: defaulted = 100;
+    endcase
+  end
+endmodule

--- a/tests/cases/cpp/case_enum_no_match/case.yaml
+++ b/tests/cases/cpp/case_enum_no_match/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.case_enum_no_match
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 7

--- a/tests/cases/cpp/case_enum_no_match/main.sv
+++ b/tests/cases/cpp/case_enum_no_match/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  typedef enum {ALPHA, BETA, GAMMA} Tag;
+
+  Tag t;
+  int r;
+
+  initial begin
+    r = 7;
+    t = GAMMA;
+    case (t)
+      ALPHA: r = 1;
+      BETA:  r = 2;
+    endcase
+  end
+endmodule

--- a/tests/cases/cpp/case_inside_basic/case.yaml
+++ b/tests/cases/cpp/case_inside_basic/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.case_inside_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    matched: 2
+    multi: 23

--- a/tests/cases/cpp/case_inside_basic/main.sv
+++ b/tests/cases/cpp/case_inside_basic/main.sv
@@ -1,0 +1,22 @@
+module Top;
+  int val;
+  int matched;
+  int multi;
+
+  initial begin
+    val = 2;
+    matched = 0;
+    case (val) inside
+      1: matched = 1;
+      2: matched = 2;
+      3: matched = 3;
+    endcase
+
+    multi = 0;
+    val = 3;
+    case (val) inside
+      1, 2, 3: multi = 23;
+      4, 5:    multi = 45;
+    endcase
+  end
+endmodule

--- a/tests/cases/cpp/case_inside_mixed/case.yaml
+++ b/tests/cases/cpp/case_inside_mixed/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.case_inside_mixed
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 30

--- a/tests/cases/cpp/case_inside_mixed/main.sv
+++ b/tests/cases/cpp/case_inside_mixed/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  int val;
+  int r;
+
+  initial begin
+    val = 7;
+    r = 0;
+    case (val) inside
+      1, 2, 3:  r = 10;
+      [4:6]:    r = 20;
+      7:        r = 30;
+      [10:20]:  r = 40;
+      default:  r = 99;
+    endcase
+  end
+endmodule

--- a/tests/cases/cpp/case_inside_no_match/case.yaml
+++ b/tests/cases/cpp/case_inside_no_match/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.case_inside_no_match
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 7

--- a/tests/cases/cpp/case_inside_no_match/main.sv
+++ b/tests/cases/cpp/case_inside_no_match/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  int val;
+  int r;
+
+  initial begin
+    val = 100;
+    r = 7;
+    case (val) inside
+      [1:3]:  r = 1;
+      [4:6]:  r = 2;
+    endcase
+  end
+endmodule

--- a/tests/cases/cpp/case_inside_range/case.yaml
+++ b/tests/cases/cpp/case_inside_range/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.case_inside_range
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    low: 1
+    mid: 2
+    high: 3
+    oor: 1

--- a/tests/cases/cpp/case_inside_range/main.sv
+++ b/tests/cases/cpp/case_inside_range/main.sv
@@ -1,0 +1,40 @@
+module Top;
+  int val;
+  int low;
+  int mid;
+  int high;
+  int oor;
+
+  initial begin
+    low = 0; mid = 0; high = 0; oor = 0;
+
+    val = 2;
+    case (val) inside
+      [1:3]: low = 1;
+      [4:6]: mid = 1;
+      [7:9]: high = 1;
+    endcase
+
+    val = 5;
+    case (val) inside
+      [1:3]: low = 2;
+      [4:6]: mid = 2;
+      [7:9]: high = 2;
+    endcase
+
+    val = 8;
+    case (val) inside
+      [1:3]: low = 3;
+      [4:6]: mid = 3;
+      [7:9]: high = 3;
+    endcase
+
+    val = 100;
+    case (val) inside
+      [1:3]: low = 9;
+      [4:6]: mid = 9;
+      [7:9]: high = 9;
+      default: oor = 1;
+    endcase
+  end
+endmodule

--- a/tests/cases/cpp/case_inside_wildcard/case.yaml
+++ b/tests/cases/cpp/case_inside_wildcard/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.case_inside_wildcard
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 2

--- a/tests/cases/cpp/case_inside_wildcard/main.sv
+++ b/tests/cases/cpp/case_inside_wildcard/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  logic [3:0] val;
+  int r;
+
+  initial begin
+    val = 4'b1010;
+    r = 0;
+    case (val) inside
+      4'b00??: r = 1;
+      4'b10??: r = 2;
+      4'b11??: r = 3;
+      default: r = 99;
+    endcase
+  end
+endmodule

--- a/tests/cases/cpp/case_string_basic/case.yaml
+++ b/tests/cases/cpp/case_string_basic/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.case_string_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    single: 2
+    multi: 23
+    defaulted: 100

--- a/tests/cases/cpp/case_string_basic/main.sv
+++ b/tests/cases/cpp/case_string_basic/main.sv
@@ -1,0 +1,34 @@
+module Top;
+  string s;
+  int single;
+  int multi;
+  int defaulted;
+
+  initial begin
+    single = 0;
+    multi = 0;
+    defaulted = 0;
+
+    s = "hello";
+    case (s)
+      "hi":    single = 1;
+      "hello": single = 2;
+      "bye":   single = 3;
+      default: single = 99;
+    endcase
+
+    s = "world";
+    case (s)
+      "hi":             multi = 1;
+      "hello", "world": multi = 23;
+      default:          multi = 99;
+    endcase
+
+    s = "unknown";
+    case (s)
+      "alpha":  defaulted = 1;
+      "beta":   defaulted = 2;
+      default:  defaulted = 100;
+    endcase
+  end
+endmodule

--- a/tests/cases/cpp/case_string_no_match/case.yaml
+++ b/tests/cases/cpp/case_string_no_match/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.case_string_no_match
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 7

--- a/tests/cases/cpp/case_string_no_match/main.sv
+++ b/tests/cases/cpp/case_string_no_match/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  string s;
+  int r;
+
+  initial begin
+    r = 7;
+    s = "nope";
+    case (s)
+      "a": r = 1;
+      "b": r = 2;
+    endcase
+  end
+endmodule


### PR DESCRIPTION
## Summary

Extends `case` statement support to cover enum-typed selectors, string-typed selectors, and the `case (X) inside { ... }` form (LRM 12.5.4). The two existing case statements in HIR (plain `case` and the new `case ... inside`) are sibling top-level statement alternatives because their per-item label shapes and per-item match semantics differ. The inside cascade reuses the existing selector-snapshot machinery from the plain-case cascade so LRM 12.5 "selector evaluated exactly once" applies uniformly, and per-item predicates are built from the same inside-item primitive the standalone `inside` operator uses (asymmetric wildcard equality per LRM 11.4.6 for value items, `(>= lo) && (<= hi)` for ranges, OR-reduction across the item list per LRM 11.4.13).

## Design

The MIR contract is clarified in `docs/architecture/mir.md`. MIR's expression set is a fixed primitive set; SystemVerilog syntactic sugar that decomposes into those primitives (`case`, `inside`, `casez` / `casex`, `foreach`) is desugared at the HIR-to-MIR boundary and never carried as a MIR node. Wrapping sugar as a runtime helper call would be opaque to the LLVM backend's optimizer (no constant folding, no dead-arm elimination, limited LTO leverage), and the cost is paid by the production backend rather than the debug-time backend (`backend::cpp`). Backend-local readability is recovered through value-type C++ operator overloads in the runtime instead.

Following that, `PackedArray` gains `operator&&`, `operator||`, `operator!`, and `explicit operator bool`; `LogicalAnd` / `LogicalOr` / `LogicalNot` are removed. The cpp emit now renders logical ops as native C++ operators and drops the `IsTruthy()` wrapper on `if` / `while` / `for` / ternary conditions (the explicit bool conversion fires automatically). The generated cpp for `a inside {1, 2, [4:6], 9}` collapses from a five-level nested `.LogicalOr(...)` chain to a flat `... || ... || (... && ...) || ...` expression.

## Testing

Nine new `cpp_run` cases: four covering enum / string selectors (`case_enum_basic`, `case_enum_no_match`, `case_string_basic`, `case_string_no_match`) and five covering case-inside (`case_inside_basic`, `case_inside_range`, `case_inside_mixed`, `case_inside_no_match`, `case_inside_wildcard`). The wildcard case exercises the asymmetric `==?` semantics with `4'b00??` patterns against a 4-state logic selector. Full `bazel test //...` passes.