### PR TITLE
Backfill integral archive sweep gaps and rewrite progress docs

### DIFF
--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -60,7 +60,8 @@ Granular tracking lives in `integral.md` (integral / packed / wide_integral) and
 - [ ] datatypes/representation
 - [ ] datatypes/string
 - [ ] datatypes/unpacked
-- [ ] datatypes/wide_integral -- `integral.md`.
+- [ ] datatypes/wide_integral -- non-`packed_2d` archive sub-folders covered (`integral.md` J14);
+      `packed_2d` (2D element index / slice) belongs to `datatypes/packed`.
 
 ### directives
 
@@ -114,7 +115,7 @@ Granular tracking lives in `integral.md` (integral / packed / wide_integral) and
 
 ### operators
 
-- [ ] operators/binary -- `integral.md`.
+- [x] operators/binary -- `integral.md`.
 - [ ] operators/binary_string
 - [x] operators/case_equality -- `operators.md`.
 - [ ] operators/comparison_value_temp -- subsumed by the binary-operator coverage in `integral.md`;
@@ -124,8 +125,9 @@ Granular tracking lives in `integral.md` (integral / packed / wide_integral) and
 - [ ] operators/inside -- `operators.md`.
 - [ ] operators/replicate -- `operators.md`.
 - [ ] operators/replication_patterns -- `packed.md`.
-- [ ] operators/shift_overflow -- `integral.md`.
-- [ ] operators/unary -- `integral.md` for the integral surface; `++` / `--` gap in `operators.md`.
+- [x] operators/shift_overflow -- `integral.md`.
+- [ ] operators/unary -- integral surface covered (`integral.md` J14); `++` / `--` archive coverage
+      tracked at `integral.md` J19 (blocked on `operators.md` W12).
 - [ ] operators/value_temp_expansion -- subsumed by the binary-operator coverage in `integral.md`;
       the archived `ValueTemp` IR shape does not exist on the current pipeline.
 - [x] operators/wildcard_equality -- `operators.md`.

--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -1,147 +1,77 @@
 # Control Flow
 
-Tracks procedural control-flow constructs against `backend::cpp`. Covers archive items under
-`archived/tests/sv_features/control_flow/`. Each archive item checkbox in `architecture-reset.md` is
-checked when its `*.yaml` cases reproduce on the current pipeline.
+Tracks procedural control-flow constructs. Covers archive items under
+`archived/tests/sv_features/control_flow/`.
 
 The numeric IDs (C1..C17) are stable references to archive items and do **not** imply execution
-order. Most of the remaining open items depend on workstreams outside control-flow (data types,
-operator runtime, string runtime); see the per-item **Depends on** lines and the
-[Actionable](#actionable) summary below for what can actually be picked up next.
+order.
 
 ## Actionable
 
-C9 and C10 (`foreach`) are the only remaining open control-flow items; both wait on
-`datatypes/unpacked`.
+C9 and C10 (`foreach`) are the only remaining open items; both wait on `datatypes/unpacked`.
 
-| Item    | Status                                                                               |
-| ------- | ------------------------------------------------------------------------------------ |
-| C9, C10 | Blocked on `datatypes/unpacked` (procedural unpacked array vars + `arr[i]` element). |
+| Item    | Status                                                                             |
+| ------- | ---------------------------------------------------------------------------------- |
+| C9, C10 | Blocked on `datatypes/unpacked` (procedural unpacked array vars + element access). |
 
 ## Sub-Steps
 
 ### Statements
 
-- [x] C1 -- `if`/`else` (procedural conditional). Reproduces
-      `control_flow/conditional/default.yaml`. Multi-condition lists, patterns, and
-      `unique`/`priority` qualifiers are rejected with `diag::Unsupported`; the qualifier work lives
-      under `unique_priority_if` (see C13).
-- [x] C2 -- `for` (procedural for-loop, no break/continue). Reproduces every
-      `control_flow/for/default.yaml` case except the two `break`-bearing ones (deferred to C7).
-      Includes inline `for (int i = 0; ...)`, external `for (i = 0; ...)`, multi-init / multi-step,
-      countdown, zero-iteration, and `if`-in-body composition.
-- [x] C3 -- `case` (plain, normal condition). HIR keeps a faithful `CaseStmt`; HIR -> MIR always
-      desugars to an if/else-if cascade built from existing primitives (a `BlockStmt` wrapper that
-      snapshots the selector into `_lyra_case_sel` for LRM 12.5 "evaluated once" semantics, then a
-      nested chain of `IfStmt`s whose conditions compare the snapshot against each item's label list
-      joined by `||`). `mir::SwitchStmt` no longer exists -- the cascade form subsumes both
-      literal-label cases and the non-constant/duplicate-label variants tracked under C15.
-      Reproduces the core plain-case subset of `control_flow/case/default.yaml` (basic match,
-      default, multi-label, no-default-no-match, empty body, nested) using integer-literal labels
-      and integer selectors. Enum/string selectors and labels are tracked in C16 and C17.
-- [x] C4 -- `while` (procedural while-loop). Reproduces every `control_flow/while/default.yaml` case
-      that does not depend on `break` (deferred to C7). Includes runtime-condition loops, countdown,
-      `while (0)` zero iterations, two-level nesting, and mixed nesting with `for` in both
-      directions.
-- [x] C5 -- `repeat (N)`. Reproduces every `control_flow/repeat/default.yaml` case that does not
-      depend on `break` (deferred to C7). HIR carries a faithful `RepeatStmt`; HIR -> MIR desugars
-      to a wrapper `BlockStmt` containing a count snapshot (preserves SV's "evaluate count once"
-      semantic for side-effecting count expressions) plus an `mir::ForStmt` over the C2 machinery.
-      Coverage includes literal counts, runtime counts, zero iterations, count-evaluated-once,
-      nesting, single-statement body, and mixed nesting with `if`/`for`/`while`.
-- [x] C6 -- `do_while`. Reproduces every `control_flow/do_while/default.yaml` case that does not
-      depend on `break`/`continue` (deferred to C7). HIR carries a faithful `DoWhileStmt`; MIR
-      mirrors it with the condition stored in the enclosing procedural scope and the body in a child
-      scope (same shape as `WhileStmt`). The C++ backend renders directly to
-      `do { body } while (cond);`. Coverage includes basic loops, `do {...} while (0)` (body still
-      executes once), runtime conditions, nesting, single-statement body, and mixed nesting with
-      `if`/`for`/`while`.
-- [x] C7 -- Loop control: `break`, `continue`. New HIR/MIR statements (no payload) lowered as
-      passthrough to the C++ backend, which renders `break;` and `continue;` directly. C++ scoping
-      already exits only the innermost surrounding loop, which matches SV semantics for every loop
-      shape we model -- including `repeat (N)`, where break/continue land inside the desugared inner
-      `for` (the surrounding count-snapshot block is not a loop). Coverage includes `for_break`,
-      `for_continue`, `for_break_inner_only`, `while_break`, `while_continue`, `do_while_break`,
-      `do_while_continue`, `repeat_break`, `repeat_continue`, and a mixed `break + continue` case.
-      Coroutine interaction (early-exit across `co_await` inside loop bodies) is not exercised
-      because timed bodies in loops are not yet supported; revisit when event-control loops land.
-- [x] C8 -- `forever`. HIR carries a faithful `ForeverStmt` (mirrors the other loop nodes); HIR ->
-      MIR desugars to `mir::ForStmt` with no init, no condition, and no step. The C++ backend
-      renders this as `for (; ; ) { body }`, which loops until `break` or `$finish` exits. Coverage
-      includes `$finish` termination, `break` termination, `continue`, single-statement body (no
-      `begin`/`end`), nested forever with inner `break`, and `if`-guarded forever.
-- [ ] C9 -- `foreach` over fixed unpacked 1D arrays. Desugar in HIR -> MIR to nested `for` over the
-      slang `loopDims`. **Depends on** `datatypes/unpacked`: needs a procedural unpacked-array
-      variable shape and an `arr[i]` element-select expression in both HIR and MIR (neither exists
-      today). Cannot start before that work.
+- [x] C1 -- `if` / `else` (procedural conditional). Multi-condition lists, pattern forms, and
+      `unique` / `priority` qualifiers are rejected as unsupported; the qualifier work is C13.
+- [x] C2 -- `for` (procedural for-loop). Includes inline and external init, multi-init / multi-step,
+      countdown, zero-iteration, and `if`-in-body composition. `break` / `continue` are C7.
+- [x] C3 -- `case` (plain, `==` semantics, LRM 12.5). Reproduces the core archive subset: basic
+      match, default, multi-label, no-default-no-match, empty body, nested. Selector "evaluated
+      once" semantics are preserved through a selector snapshot. Enum / string selectors are tracked
+      as C16 / C17.
+- [x] C4 -- `while`. Includes runtime conditions, countdown, `while (0)` zero iterations, two-level
+      nesting, and mixed nesting with `for`. `break` is C7.
+- [x] C5 -- `repeat (N)` with LRM "evaluate count once" semantics. Includes literal and runtime
+      counts, zero iterations, nesting, single-statement body, and mixed nesting.
+- [x] C6 -- `do_while`. Includes basic loops, `do {...} while (0)` (body still executes once),
+      runtime conditions, nesting, single-statement body, and mixed nesting.
+- [x] C7 -- Loop control: `break`, `continue`. Honours the LRM rule of exiting only the innermost
+      surrounding loop, including the `repeat (N)` case where break / continue land inside the
+      desugared inner loop. Coroutine interaction (early-exit across timing inside loop bodies) is
+      not yet exercised because timed loop bodies are not supported.
+- [x] C8 -- `forever`. Loops until `break` or `$finish` exits. Includes `$finish` termination,
+      `break` termination, `continue`, single-statement body, nested forever with inner `break`, and
+      `if`-guarded forever.
+- [ ] C9 -- `foreach` over fixed unpacked 1D arrays. **Depends on** `datatypes/unpacked` (procedural
+      unpacked array vars + element access).
 - [ ] C10 -- `foreach` multi-dim, skipped dimensions, dynamic-array, queue. **Depends on** C9 plus
       `datatypes/general` (dynamic array, queue) and the `.size()` runtime query.
-- [x] C11 -- `casez` / `casex`. LRM 12.5.1 do-not-care forms; share the plain-case cascade and
-      selector snapshot but swap the per-label compare for a bidirectional wildcard primitive (Z on
-      either operand for casez; Z or X on either operand for casex). Result is deterministic per LRM
-      12.5.1 because every unknown position is masked from comparison; this is distinct from the
-      asymmetric `==?` operator (LRM 11.4.6) which can yield `1'bx`. Coverage: `casez_basic` (RHS
-      `?` wildcards over 2-state selector), `casez_first_match` (LRM 12.5 source-order
-      first-match-wins between an overlapping wildcard label and an exact label), `casez_no_match`
-      (default-taken and no-default no-op), `casez_nested`, `casex_basic` (RHS `x` / `?` wildcards),
-      plus two bidirectional cases (`casez_lhs_z`, `casex_lhs_x`) that pin down the LRM 12.5.1
-      "either operand" contract not exercised by the archive's typical-usage 2-state-selector tests.
-- [x] C12 -- `case (... inside ...)`. Sibling statement family in HIR (distinct from plain case
-      because labels are `range_list` entries -- value or `[lo:hi]` range -- and per-item match uses
-      inside-membership rather than `==`). HIR -> MIR snapshots the selector (LRM 12.5
-      evaluate-once) and builds the per-item inside-membership predicate against the snapshot using
-      the same primitive the `inside` operator uses (asymmetric wildcard equality for value items,
-      `(>= lo) && (<= hi)` for ranges, LRM 11.4.13 OR-reduction across items). The cascade's
-      truthiness test already excludes `1'bx` per LRM 12.5.4 ("match only when inside returns
-      `1'b1`"); no explicit 2-state clamp needed. Coverage: `case_inside_basic`,
-      `case_inside_range`, `case_inside_mixed`, `case_inside_no_match`, and `case_inside_wildcard`
-      (RHS wildcard `4'b00??` against a 4-state logic selector).
-- [x] C13 -- `unique` / `unique0` / `priority` qualifiers on `if` and `case`. HIR carries the
-      qualifier as an optional `UniquePriorityCheck` field on `IfStmt` / `CaseStmt`. HIR -> MIR
-      desugars the site into a `BlockStmt` that snapshots each branch's predicate into a fresh
-      procvar, hands a closure to the Observed region via `RuntimeSubmitObservedCall`, and renders
-      the original cascade as a plain `if`/`else if` chain reading the snapshots. The closure body
-      counts truthy snapshots and emits a warning through the existing `RuntimeDiagnosticCall` /
-      `LyraDiagnostic` path when the qualifier-specific predicate fires (`unique`: count != 1;
-      `unique0`: count > 1; `priority`: count == 0). The runtime drains `Module::observed_pending_`
-      per-object during `Engine::ExecuteObservedRegion`; re-submits at the same site within one time
-      slot collapse via vector-slot replacement, suppressing glitch-driven false positives. Covers
-      archive items `unique_priority_if` and `unique_priority_case`. Source-location propagation
-      still feeds `origin = nullopt`; the warning text reports the violation kind and the matched
-      count but not the file/line of the offending statement -- to be plumbed in a follow-up.
-- [x] C15 -- `case` with labels that are not compile-time constants (`case (sel) some_expr: ...`)
-      and `case` with duplicate labels ("first match wins"). The uniform HIR -> MIR cascade
-      described in C3 handles both: non-constant labels render as runtime `==` comparisons, and
-      duplicate labels honour SV's top-down "first match wins" semantics because the cascade tests
-      items in order. The same cascade also handles a corner where slang's case-context type
-      unification widens the selector from a built-in form to a packed-explicit form; the snapshot
-      peeks through the resulting `ConversionExpr` so the assignment matches the unwrapped source
-      type. Covers archive cases `case_constant_expression`, `case_first_match_wins`. Coverage adds
-      `case_constant_expression`, `case_first_match_wins`, `case_runtime_multi_label`,
-      `case_runtime_no_default`.
-- [x] C16 -- `case` with enum-typed selectors and enum-value labels. The uniform cascade from C3
-      handles this with no new lowering: slang's case-context type unification widens the labels to
-      the enum type, and the cascade's per-label `==` evaluates against the unified enum operands.
-      Coverage: `case_enum_basic` (single / multi-label / default-taken) and `case_enum_no_match`
-      (no default, selector unchanged from initial).
-- [x] C17 -- `case` with string selector / string labels. Same cascade reused: per-label `==` uses
-      the SC1 string equality helper, with the bool result projected back into the cascade's 1-bit
-      truthiness shape. Coverage: `case_string_basic` (single / multi-label / default-taken) and
-      `case_string_no_match`.
+- [x] C11 -- `casez` / `casex` (LRM 12.5.1 do-not-care forms). Bidirectional wildcard compare:
+      `casez` treats Z as don't-care on either operand; `casex` treats Z or X as don't-care on
+      either operand. Result is deterministic, distinct from the asymmetric `==?` operator (LRM
+      11.4.6) which can yield `1'bx`.
+- [x] C12 -- `case (... inside ...)` (LRM 12.5.4). Selector snapshot plus per-item inside-membership
+      with `==?` for value items and `(>= lo) && (<= hi)` for ranges; OR-reduction across items.
+      `1'bx` from inside is correctly excluded from match per LRM 12.5.4 ("match only when inside
+      returns `1'b1`").
+- [x] C13 -- `unique` / `unique0` / `priority` qualifiers on `if` and `case`. Each branch's
+      predicate is snapshotted; the qualifier check runs in the Observed region and emits a runtime
+      warning when violated (`unique`: count != 1; `unique0`: count > 1; `priority`: count == 0).
+      Glitch-driven false positives within one time slot are suppressed. Source-location reporting
+      in the warning text is a follow-up.
+- [x] C15 -- `case` with non-constant labels and with duplicate labels (first-match-wins per LRM
+      12.5). The C3 cascade handles both: non-constant labels render as runtime `==`; duplicate
+      labels honour top-down ordering.
+- [x] C16 -- `case` with enum-typed selectors and enum-value labels (LRM 12.5 with LRM 6.19 type
+      unification).
+- [x] C17 -- `case` with string selector / string labels. Per-label compare uses the SC1 string
+      equality helper from `datatypes.md`.
 
 ### Expressions
 
-- [x] C14 -- Ternary `cond ? a : b`. New `hir::ConditionalExpr` + `mir::ConditionalExpr` carry the
-      three sub-expressions; HIR -> MIR is a straight pass-through (no desugaring); the C++ backend
-      renders as `(cond ? then : else)` on the native (2-state integral) path. Multi-condition
-      (`&&&`) and `matches` pattern forms are rejected with `diag::Unsupported`. 4-state X/Z
-      propagation on the condition follows the broader 4-state work tracked under `operators` (B7 /
-      U4) and is out of scope. Coverage includes basic max-pick, nested chained, ternary embedded in
-      an arithmetic expression, literal-only arms, ternary feeding an `if` condition, and ternary
-      inside a `for`-loop body.
+- [x] C14 -- Ternary `cond ? a : b`. Multi-condition (`&&&`) and `matches` pattern forms are
+      rejected as unsupported. 4-state X/Z propagation on the condition rides on the broader 4-state
+      work in `operators.md`.
 
 ## Out of Scope
 
-- `fork` / `join_any` / `join_none` -- scheduling primitives tracked under `processes`.
-- `wait` / `wait_event` / `@(event)` -- event control, not pure control flow.
+- `fork` / `join_any` / `join_none` -- tracked under `processes.md`.
+- `wait` / `wait_event` / `@(event)` -- event control, tracked under `processes.md`.
 - Assertion control statements (`disable`, `restart`) -- tracked under `assertions`.

--- a/docs/progress/datatypes.md
+++ b/docs/progress/datatypes.md
@@ -6,60 +6,49 @@ file covers every other family: `datatypes/enum`, `datatypes/string`, `datatypes
 `datatypes/general` (dynamic array / queue / associative), `datatypes/real`,
 `datatypes/default_init`, `datatypes/representation`.
 
-Each archive item checkbox in `architecture-reset.md` is checked when its `*.yaml` cases reproduce
-on the current pipeline.
-
 ## Actionable
 
-Real C1 / C2 / C3 / C4 are complete. Structural-var declaration initializers (SV LRM 6.8) are
-complete for the integral, enum, real, shortreal, and realtime families (SI1 below). String SC1
-(declaration with literal initializer plus equality and relational comparison), SC2 (string-mode
-concatenation and replication), and SC3 (built-in methods) are complete. Other unfinished families:
-`datatypes/unpacked`, `datatypes/general`, `datatypes/default_init`, `datatypes/representation`.
+Enum, real, string, and the integral-family declaration initializers are complete. Parameter-driven
+initializers (SI2) and the unpacked / general / default-init / representation families remain.
+
+| Item | Status                                                                          |
+| ---- | ------------------------------------------------------------------------------- |
+| SI2  | Parameter references in declaration initializers (see Structural Initializers). |
+| -    | `datatypes/unpacked`, `datatypes/general`, `datatypes/default_init`,            |
+|      | `datatypes/representation` -- no progress sub-steps opened yet.                 |
 
 ## Enum
 
-Covers archive item `datatypes/enum` (sub-folders `enum`, `enum_implicit_conversion`,
-`enum_methods`). LRM 6.19 semantics: enum types are a labelled subset of an integral base type; enum
--> integral conversion is implicit, integral -> enum requires an explicit cast.
+LRM 6.19: enum types are a labelled subset of an integral base; enum -> integral is implicit,
+integral -> enum requires an explicit cast.
 
-- [x] E1 -- Declarations, member references, comparisons, arithmetic, and conversions. Covers
-      `enum/default.yaml` (basic, sequential, explicit, mixed, comparison, arithmetic, explicit base
-      type, display, range count / bounds / mixed); legal cases in
-      `enum_implicit_conversion/default.yaml`; and the `first` / `last` / `num` / `num_auto_values`
-      cases in `enum_methods/default.yaml`.
-- [x] E2 -- `next` / `prev` methods with optional step argument (LRM 6.19.5.3 / 6.19.5.4). Covers
-      the `enum_next*`, `enum_prev*`, and `enum_next_runtime_step` cases in
-      `enum_methods/default.yaml`. Non-member receivers fall back to a zero default; LRM Table 6-7
-      4-state `'x` behaviour is tracked under `datatypes/default_init`.
-- [x] E3 -- `name()` method (LRM 6.19.5.6); empty string for non-member values. Covers `enum_name`
-      in `enum_methods/default.yaml`.
+- [x] E1 -- Declarations, member references, comparisons, arithmetic, and conversions, including the
+      explicit base type form and the `first` / `last` / `num` / `num_auto_values` methods.
+- [x] E2 -- `next` / `prev` methods with optional step argument (LRM 6.19.5.3 / 6.19.5.4).
+      Non-member receivers fall back to a zero default; LRM Table 6-7 4-state `'x` behaviour is
+      tracked under `datatypes/default_init`.
+- [x] E3 -- `name()` method (LRM 6.19.5.6); empty string for non-member values.
 
 ### Cross-references
 
 - LRM 6.19 (Enumerations), 6.19.3 (conversions), 6.19.5 (methods).
 - Archive items: `datatypes/enum/{enum,enum_implicit_conversion,enum_methods}`.
-- Unblocks: C16 (enum-typed `case` selectors) in `control-flow.md`.
+- Unblocks: `control-flow.md` C16 (enum-typed `case` selectors).
 
 ## Real
 
-Covers archive item `datatypes/real` (sub-folders `real_types`, `shortreal_types`,
-`realtime_types`). Per LRM 6.12, `real` is IEEE 754 double, `shortreal` is IEEE 754 single, and
-`realtime` is synonymous with `real`. LRM 6.12 forbids edge event controls on real variables.
+LRM 6.12: `real` is IEEE 754 double, `shortreal` is IEEE 754 single, `realtime` is synonymous with
+`real`. Edge event controls on real variables are forbidden.
 
 - [x] C1 -- Declarations, blocking assignment, and `$display` formatting (`%f` / `%e` / `%g` with
-      LRM Table 21-2 default precision). Covers the declaration / assignment / display cases across
-      all three archive sub-folders.
+      LRM Table 21-2 default precision 6).
 - [x] C2 -- Operators legal on real per LRM 11.3.1 (arithmetic, relational, equality, logical,
-      conditional), plus `**` via the LRM 11.4.3 result-typing rule, plus shortreal <-> real
-      conversion.
-- [x] C3 -- Cross-family conversions: integral -> real treats `'x` / `'z` bits as 0 per LRM 6.12.1;
-      real -> integral rounds half-away-from-zero per LRM 6.12.1 (not truncate).
-- [x] C4 -- LRM-illegal real forms (LRM 6.12 + 11.3.1 / Table 11-1) -- edge event controls,
-      bit-select / part-select, real-indexed bit-select, modulus, bitwise, reduction, shift,
-      wildcard equality, and case equality on real -- diagnose as `diag::Unsupported` with an LRM
-      citation. The slang frontend filters all but case equality (`===` / `!==`) at AST
-      construction; the case-equality path is guarded by `errors/real_case_equality_unsupported`.
+      conditional), plus `**` via LRM 11.4.3 result-typing, plus shortreal <-> real conversion.
+- [x] C3 -- Cross-family conversions: integral -> real treats `'x` / `'z` as 0 (LRM 6.12.1); real ->
+      integral rounds half-away-from-zero (LRM 6.12.1).
+- [x] C4 -- LRM-illegal real forms (LRM 6.12 + 11.3.1 / Table 11-1) diagnose as `diag::Unsupported`
+      with an LRM citation. Slang's frontend filters all but case equality (`===` / `!==`); the
+      case-equality path is guarded at lowering.
 
 ### Cross-references
 
@@ -69,55 +58,42 @@ Covers archive item `datatypes/real` (sub-folders `real_types`, `shortreal_types
 
 ## Structural Initializers
 
-Covers SV LRM 6.8: a static-lifetime variable declaration may carry an initializer expression
-(`int i = 42;`, `real r = 1.5;`, `logic [7:0] l = 8'hAA;`). The LRM requires the initial-value
-assignment to run before any `initial` / `always` procedure starts, which the emitted code satisfies
-by lowering the initializer onto the C++ field declaration.
+LRM 6.8: a static-lifetime variable declaration may carry an initializer expression (`int i = 42;`,
+`real r = 1.5;`, `logic [7:0] l = 8'hAA;`); the initial-value assignment runs before any `initial` /
+`always` procedure starts.
 
 - [x] SI1 -- Declaration initializers for the integral, enum, real, shortreal, and realtime
-      families. Covers `real_declaration_with_init` (real) plus new cases `int_structural_init`,
-      `bit_structural_init`, `byte_structural_init`, `longint_structural_init`,
-      `logic_structural_init`.
-- [ ] SI2 -- Initializer expressions that read a module parameter (`int i = N * 3;`). Surfaced as
-      `diag::Unsupported` today; the gap is in structural-expression lowering's handling of
-      parameter references, not in the initializer mechanism, but it blocks the natural
-      parameter-driven init pattern. (The string-literal half of this gap was resolved alongside
-      SC1.)
+      families.
+- [ ] SI2 -- Initializer expressions that read a module parameter (`int i = N * 3;`). Diagnosed as
+      unsupported today; the gap is in how parameter references are lowered inside structural
+      expressions, not in the initializer mechanism itself.
 
 ### Cross-references
 
-- LRM 6.8 (Variable declarations -- "Setting the initial value of a static variable... shall occur
-  before any initial or always procedures are started"); Table 6-7 (Default initial values, used
-  when no initializer is present, tracked separately under `datatypes/default_init`).
+- LRM 6.8 (Variable declarations); Table 6-7 (Default initial values, tracked separately under
+  `datatypes/default_init`).
 
 ## String
 
-Covers archive item `datatypes/string` (sub-folder `string_concat`). Per LRM 6.16, `string` is a
-dynamic-length sequence of bytes with `""` as the default (LRM Table 6-7) and the operator set in
-LRM Table 6-9: equality, lexicographic comparison, concatenation, replication, indexing, and a
-dedicated method family. String literals carry a bit-vector type by default; the frontend inserts an
-implicit conversion when a literal participates in an expression that involves a `string`-typed
-operand.
+LRM 6.16: `string` is a dynamic-length sequence of bytes with `""` as the default (Table 6-7) and
+the operator set in Table 6-9: equality, lexicographic comparison, concatenation, replication,
+indexing, and a dedicated method family. String literals carry a bit-vector type by default; the
+frontend inserts an implicit conversion when a literal participates in an expression involving a
+`string`-typed operand.
 
-- [x] SC1 -- Declaration with literal initializer (`string s = "hello";`), assignment from a string
-      literal, equality (`==`, `!=`), and relational comparison (`<`, `<=`, `>`, `>=`) on
-      string-typed operands. Compare semantics match LRM Table 6-9: equality compares contents;
-      relational uses lexicographic ordering. The literal-vs-literal case keeps the integral path
-      per the LRM exception (no change required -- the frontend preserves bit-vector typing for that
-      case).
+- [x] SC1 -- Declaration with literal initializer, assignment from a string literal, equality (`==`,
+      `!=`), and lexicographic relational comparison (`<`, `<=`, `>`, `>=`) on string-typed
+      operands. The literal-vs-literal case keeps the integral path per the LRM exception.
 - [x] SC2 -- Concatenation `{a, b, ...}` and replication `{N{s}}` in string mode (LRM 11.4.12.2):
-      when the result type is `string` the entire expression evaluates to string. Replication
-      accepts a non-constant multiplier (LRM allows this for string mode), and a zero multiplier
-      yields the empty string. The literal-only form (`{"foo", "bar"}` where the frontend keeps the
-      integral result type and inserts an outer string conversion) is gated separately and stays
-      blocked behind `operators/concat` (integral-mode concatenation) plus the bit-vector-to-string
-      conversion path.
+      when the result type is `string` the entire expression evaluates to string. The literal-only
+      form (`{"foo", "bar"}`, integral result type with outer string conversion) stays blocked
+      behind `operators/concat` plus the bit-vector-to-string conversion path.
 - [x] SC3 -- Built-in methods listed in LRM 6.16.1 -- 6.16.15: `.len()`, `.substr(i, j)`,
       `.compare(s)` / `.icompare(s)`, `.toupper()` / `.tolower()`, `.putc(i, c)` / `.getc(i)`, and
       the numeric conversion family (`.atoi()` / `.atohex()` / `.atooct()` / `.atobin()` /
-      `.atoreal()` and the inverse-write `.itoa()` / `.hextoa()` / `.octtoa()` / `.bintoa()` /
-      `.realtoa()`). Out-of-range indices and zero-byte writes follow the LRM no-op rules;
-      `substr(i, j)` returns the empty string for `i<0`, `j<i`, or `j>=len`.
+      `.atoreal()` and `.itoa()` / `.hextoa()` / `.octtoa()` / `.bintoa()` / `.realtoa()`).
+      Out-of-range indices and zero-byte writes follow LRM no-op rules; `substr(i, j)` returns the
+      empty string for `i < 0`, `j < i`, or `j >= len`.
 
 ### Cross-references
 

--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -1,42 +1,28 @@
 # Display
 
-Tracks `$display` / `$write` / `$strobe` format-specifier coverage and file-sink support against the
-runtime print pipeline (`src/lyra/runtime/integral_format.cpp`,
-`src/lyra/lowering/hir_to_mir/lower_print.cpp`). Each item is a single PR-sized step; the file is
-deleted when all sub-steps land.
+Tracks `$display` / `$write` / `$strobe` format-specifier coverage and file-sink support.
 
-The format-specifier sub-steps gate the `expect.variables` shape of the R7 test-framework work
-(`architecture-reset.md`), since the test harness can only probe a variable whose type has an
-implemented specifier.
+The format-specifier sub-steps gate the `expect.variables` shape of `architecture-reset.md` R7,
+since the test harness can only probe a variable whose type has an implemented specifier.
 
 ## Sub-Steps
 
-- [ ] DI1 -- `%c` (char). Decode the low 7 bits of an integral arg as ASCII. `lower_print.cpp`
-      currently returns `kFormatSpecifierNotImplemented` for `kChar`.
-- [ ] DI2 -- `%t` (time). Format a time value against the active timescale. `lower_print.cpp`
-      currently returns `kFormatSpecifierNotImplemented` for `kTime`. Requires a time variant on
-      `RuntimeValueView` and time-unit awareness on the format spec.
-- [x] DI3 -- `%f` / `%e` / `%g` (real). Shipped via real-types C1 in PR #789. `FormatKind` split
-      into `kRealDecimal` / `kRealExponential` / `kRealGeneral`; `RuntimeValueView` gained
-      `Real64ValueView` and `Real32ValueView`; `value::FormatValue` dispatches each kind through
-      `std::format` (`{:.{}f}`, `{:.{}e}`, `{:.{}g}`) with default precision 6 per LRM Table 21-2.
-      Coverage tracked under `datatypes.md` "Real" -> C1.
+- [ ] DI1 -- `%c` (char): low 7 bits of an integral arg as ASCII.
+- [ ] DI2 -- `%t` (time): formatted against the active timescale. Requires a time variant in the
+      runtime value surface and time-unit awareness on the format spec.
+- [x] DI3 -- `%f` / `%e` / `%g` (real). Default precision 6 per LRM Table 21-2. Coverage tracked
+      under `datatypes.md` Real C1.
 - [ ] DI4 -- `%m` (hierarchical name). Requires runtime exposure of the current scope's hierarchical
-      path. `lower_print.cpp` currently returns `kFormatModulePathNotImplemented`. Shares its
-      underlying mechanism with the archive item `hierarchy/refs`, which the `expect.variables`
-      Phase 2 also depends on for hierarchical probe paths.
-- [ ] DI5 -- File sink (`$fdisplay`, `$fwrite`). `lower_print.cpp` currently returns
-      `kFileDisplayNotImplemented` for any non-stdout sink. Requires file-descriptor runtime state
-      (`$fopen` returning an MCD/FD, `$fclose`), per-descriptor output dispatch, and threading the
-      descriptor argument through `RuntimePrintCall`.
-- [ ] DI6 -- `$strobe` postponed-region semantics. `support::SystemSubroutineDesc` already carries
-      `is_strobe`, but `lower_print.cpp` lowers strobe identically to `$display`. Strobe must defer
-      its read-and-print to the postponed region of the same time slot.
+      path; shares its mechanism with archive item `hierarchy/refs`.
+- [ ] DI5 -- File sink (`$fdisplay`, `$fwrite`). Requires file-descriptor runtime state (`$fopen`
+      returning an MCD / FD, `$fclose`) and per-descriptor output dispatch.
+- [ ] DI6 -- `$strobe` postponed-region semantics. Strobe must defer its read-and-print to the
+      postponed region of the same time slot (LRM 21.2).
 
 ## Out of Scope
 
-- Format-string parse diagnostics (`kFormatStringTrailingPercent`, `kFormatStringMissingSpecifier`,
-  `kFormatStringWidthOverflow`, `kFormatStringUnknownSpecifier`) -- already implemented, not gaps.
+- Format-string parse diagnostics (trailing `%`, missing specifier, width overflow, unknown
+  specifier) -- already implemented, not gaps.
 - `$monitor`. Not modelled today; add an entry when a concrete consumer needs it.
-- `%u` / `%z` (binary-packed unsigned/signed) and `%v` (strength). Not on the immediate roadmap; add
-  entries when concrete consumers appear.
+- `%u` / `%z` (binary-packed unsigned / signed) and `%v` (strength). Not on the immediate roadmap;
+  add entries when concrete consumers appear.

--- a/docs/progress/integral.md
+++ b/docs/progress/integral.md
@@ -68,11 +68,16 @@ against `PackedArray`. The dispatch in `RenderExpr*` collapses to a single path.
 - [x] J13 -- Wide (`>64`-bit) coverage on arithmetic, comparison, shift, divmod, and power via
       multi-word algorithms (carry/borrow add/sub, 32x32 schoolbook multiply, top-word-first
       compare, word+bit shift, bit-by-bit long division). 4-state X/Z propagation rides along.
-- [ ] J14 -- Archive sweep: reproduce `operators/binary/default.yaml`, `operators/unary/...`,
-      `operators/shift_overflow/...`, `datatypes/wide_integral/...`, and their `four_state.yaml`
-      companions. **Prerequisite:** `operators.md` W4..W6 (bit-select / range-select / indexed
-      part-select reads); many archive cases select sub-bits of a packed value before applying the
-      operator under test.
+- [x] J14 -- Archive sweep on the integral operator surface: arithmetic, comparison, bitwise, shift,
+      logical, unary (excluding `++` / `--`), reduction, and conversion across `int`, `byte`,
+      `bit [N]`, `logic [N]`, and >64-bit packed values. Includes signed boundary, mixed-width
+      promotion, cross-word bitwise, cross-word reduction, and narrow<->wide zero/sign-extend +
+      truncation. `++` / `--` is split out as J19 because it is read-modify-write rather than a pure
+      operator and depends on the lvalue surface.
+- [ ] J19 -- `++` / `--` archive coverage (`pre_increment`, `post_increment`, `pre_decrement`,
+      `post_decrement`, `nested_increment_decrement` in `operators/unary/two_state.yaml`). **Depends
+      on** `operators.md` W12; the HIR / MIR shape and LRM 11.4.1 (evaluate target once) live there.
+      When W12 lands, the archive cases reproduce.
 
 ### Cut 3 -- Expression dispatch consolidation
 
@@ -105,14 +110,13 @@ wildcard equality (`==?`). Both were plumbed through HIR / MIR but rejected at c
 - LRM anchors: 6.11 (Table 6-8 integer types), 6.11.2 (4-state to 2-state convert), 10.7 (assignment
   extension / truncation), 11.6 (expression bit lengths), 11.7 (signed expressions), 11.8
   (expression evaluation rules, 11.8.4 for x/z handling).
-- Archive items this workstream targets: `operators/binary`, `operators/unary`,
-  `operators/shift_overflow`, `datatypes/integral`, `datatypes/packed`, `datatypes/wide_integral`.
-  Closes when J14 lands. `datatypes/wide_integral/packed_2d` belongs to `datatypes/packed` (2D
-  element index / slice), not this workstream.
+- Archive items this workstream targets: `operators/binary`, `operators/unary` (excluding `++` /
+  `--`, which is J19), `operators/shift_overflow`, `datatypes/integral`, `datatypes/packed`,
+  `datatypes/wide_integral`. Closes when J19 lands. `datatypes/wide_integral/packed_2d` belongs to
+  `datatypes/packed` (2D element index / slice), not this workstream.
 - Slang reference: `slang/ast/types/AllTypes.h:IntegralType`.
 - Legacy archive reference: `archived/include/lyra/common/type.hpp:IntegralInfo`.
 
 ## Remaining operator gap
 
-`++` / `--`: tracked as `operators.md` W12 (new HIR / MIR shape, statement and expression forms, LRM
-evaluate-target-once semantics).
+`++` / `--`: implementation tracked as `operators.md` W12; archive coverage tracked as J19 above.

--- a/docs/progress/integral.md
+++ b/docs/progress/integral.md
@@ -1,122 +1,57 @@
 # Integral Representation
 
-Replace the form-driven, multi-type integral emit in `backend::cpp` with a single
-`lyra::value::PackedArray` class that carries `(bit_width, is_signed, is_four_state)` and owns every
-operator on integral values. Closes the silent-correctness bugs the prior cuts targeted without
-introducing the five-bucket dispatch and view bridges. Background and trade-offs in
-`../decisions/integral-representation.md`.
+Tracks SystemVerilog integral coverage on the current pipeline: `byte`, `shortint`, `int`,
+`longint`, `integer`, `time`, `bit [N:0]`, `logic [N:0]`, `reg [N:0]`, and wide (>64-bit) packed
+variants.
 
-Done when:
+Done when every archive case under `operators/binary`, `operators/unary`,
+`operators/shift_overflow`, `datatypes/integral`, and `datatypes/wide_integral` reproduces.
 
-- Every SystemVerilog integral type (`byte`, `shortint`, `int`, `longint`, `integer`, `time`, any
-  `bit [N:0]`, any `logic [N:0]`, any `reg [N:0]`) emits as `lyra::value::PackedArray` and
-  round-trips through `expect.variables`.
-- `RenderTypeAsCpp`, the single `RenderExpr` path, `RenderRuntimeValueViewInit`, and related helpers
-  no longer dispatch on `PackedArrayForm` or carry separate native / container code paths.
-- The archive item set under `operators/binary`, `operators/unary`, `operators/shift_overflow`,
-  `datatypes/integral`, `datatypes/packed`, `datatypes/wide_integral` reproduces.
+## Actionable
 
-## Defects this workstream closes
+J19 is the only open item; everything else has shipped or is intentionally tracked elsewhere.
 
-- `integer` and `time` silently lose X/Z because their old mapping was a 2-state native int.
-- `byte`, `shortint`, `longint` were unrenderable in `backend::cpp`.
-- `ConversionExpr` is stripped in cpp emit, hiding sign-extend / zero-extend bugs.
-- `bit [N:0]` arithmetic, comparison, and shift are Unsupported because the packed path lacks these
-  op families.
-- Native and packed paths in cpp emit dispatch on `PackedArrayForm` (a syntactic origin marker),
-  creating two parallel op surfaces that must be kept in sync.
+| Item | Status                                                                           |
+| ---- | -------------------------------------------------------------------------------- |
+| J19  | Blocked on `operators.md` W12 (`++` / `--` shape and LRM 11.4.1 eval-once rule). |
 
-## Cuts
+## Sub-Steps
 
-### Cut 1 -- `PackedArray` skeleton + type emit redirect
+The numeric IDs are stable references and do not imply execution order.
 
-Add `lyra::value::PackedArray` with the three-attribute constructor, internal SBO storage, the
-existing copy / set / view-accessor surface (re-exposed for backwards interop with the format
-pipeline), and a thin set of methods needed for declarations and assignments. `RenderTypeAsCpp`
-emits `lyra::value::PackedArray` for every integral type. `RenderRuntimeValueViewInit` builds its
-`RuntimeValueView` from `PackedArray` uniformly. No operator coverage yet; everything else in
-`backend::cpp` continues to compile because variable declarations and `$display` are the only
-consumers that need PackedArray at this point.
-
-- [x] J1 -- Add `lyra::value::PackedArray` class. Storage variant: inline word(s) for
-      `bit_width <= 64`, heap multi-word for `>64`; 4-state carries an unknown plane the same way.
-- [x] J2 -- `RenderTypeAsCpp` returns `lyra::value::PackedArray` for every `PackedArrayType`,
-      regardless of `form`. Catch-all unrenderable type returns `diag::Unsupported`.
-- [x] J3 -- Container init helper retires (only `PackedArray` exists; every integral declares with
-      `{bit_width, is_signed, is_four_state}`).
-- [x] J4 -- `RenderRuntimeValueViewInit` produces its `RuntimeValueView` from `PackedArray`.
-      `NarrowIntegral` / `FromBitView` / `FromLogicView` becomes one path.
-- [x] J5 -- `RenderTypeAsCpp` collapses to a single arm for any `PackedArrayType` regardless of
-      `form`; `tests/cases/cpp/` declaration cases for `byte` / `shortint` / `longint` / `time` /
-      `integer` (with X/Z on the 4-state pair `integer` / `time`).
-
-### Cut 2 -- Operator coverage on `PackedArray`
-
-Add operator overloads / methods so cpp emit can render `BinaryExpr` and `UnaryExpr` directly
-against `PackedArray`. The dispatch in `RenderExpr*` collapses to a single path.
-
-- [x] J6 -- Bitwise (`&`, `|`, `^`, `~^`, `~`) as member operators or method on `PackedArray`.
-- [x] J7 -- Arithmetic (`+`, `-`, `*`, `/`, `%`, `**`) with LRM corner cases (div-by-zero, power
-      semantics).
-- [x] J8 -- Comparison (`==`, `!=`, `<`, `<=`, `>`, `>=`) returning a 1-bit `PackedArray`.
-- [x] J9 -- Shift (`<<`, `>>`, `>>>`) with LRM overflow (`amount >= bit_width` yields 0 /
-      sign-fill).
-- [x] J10 -- Logical (`&&`, `||`, `!`, `->`, `<->`) returning a 1-bit `PackedArray`.
-- [x] J11 -- Reduction (`&a`, `|a`, `^a`, `~&a`, `~|a`, `~^a`) as `PackedArray` methods.
-- [x] J12 -- 4-state X/Z propagation across arithmetic, comparison, shift, power, logical, and unary
-      `-`. Bitwise / reduction already propagate via the view-based truth-table path.
-- [x] J13 -- Wide (`>64`-bit) coverage on arithmetic, comparison, shift, divmod, and power via
-      multi-word algorithms (carry/borrow add/sub, 32x32 schoolbook multiply, top-word-first
-      compare, word+bit shift, bit-by-bit long division). 4-state X/Z propagation rides along.
-- [x] J14 -- Archive sweep on the integral operator surface: arithmetic, comparison, bitwise, shift,
-      logical, unary (excluding `++` / `--`), reduction, and conversion across `int`, `byte`,
-      `bit [N]`, `logic [N]`, and >64-bit packed values. Includes signed boundary, mixed-width
-      promotion, cross-word bitwise, cross-word reduction, and narrow<->wide zero/sign-extend +
-      truncation. `++` / `--` is split out as J19 because it is read-modify-write rather than a pure
-      operator and depends on the lvalue surface.
-- [ ] J19 -- `++` / `--` archive coverage (`pre_increment`, `post_increment`, `pre_decrement`,
-      `post_decrement`, `nested_increment_decrement` in `operators/unary/two_state.yaml`). **Depends
-      on** `operators.md` W12; the HIR / MIR shape and LRM 11.4.1 (evaluate target once) live there.
-      When W12 lands, the archive cases reproduce.
-
-### Cut 3 -- Expression dispatch consolidation
-
-Remove `RenderExprAsNative` / `RenderExprAsPackedTopLevel` split. Single `RenderExpr` path, single
-`ConversionExpr` arm.
-
-- [x] J15 -- One `RenderExpr` path. `IsPackedExplicit`, `NeedsRuntimeContainerInit`, the
-      `MakeBitView` / `BitViewToInt64` bridges (if they exist by then) all retire.
-- [x] J16 -- `ConversionExpr` collapses to "construct a destination `PackedArray` from a source
-      `PackedArray`" -- one case, handled by `PackedArray` itself.
-
-### Cut 4 -- Equality family completion
-
-`==` (logical equality) is 4-state-propagating and returns a `PackedArray` that can be X. LRM gives
-two deterministic-bool equality forms for the cases `==` cannot answer: case equality (`===`) and
-wildcard equality (`==?`). Both were plumbed through HIR / MIR but rejected at cpp emit.
-
-- [x] J17 -- `PackedArray::IsCaseEqual` (LRM 11.4.5 `===`): bit-pattern compare across value and
-      unknown planes, returns deterministic `bool`. Wire `kCaseEquality` and `kCaseInequality` arms
-      in backend. Also consumed by `Var<T>` for event-control change detection (LRM 9.4.2 says
-      `@(x)` fires when the value "is not equal to its previous value" under bit-pattern equality;
-      that is `===` semantics).
-- [x] J18 -- `PackedArray::WildcardEquals` (LRM 11.4.6 `==?` / `!=?`): bit-by-bit compare with the
-      RHS X/Z bits treated as don't-care. Wire `kWildcardEquality` and `kWildcardInequality` arms.
-      Same work item as `operators.md` W2; that file is the canonical home.
+- [x] J1 -- Declarations, assignment, and `$display` round-trip for every integral type, including
+      X/Z preservation on `integer` and `time` (LRM 6.11 Table 6-8).
+- [x] J6 -- Bitwise operators (`&`, `|`, `^`, `~^`, `~`) with 4-state truth tables.
+- [x] J7 -- Arithmetic operators (`+`, `-`, `*`, `/`, `%`, `**`) with LRM 11.4 corner cases
+      (div-by-zero, power semantics).
+- [x] J8 -- Comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`) returning a 1-bit result.
+- [x] J9 -- Shift operators (`<<`, `>>`, `>>>`) with LRM 11.4.10 amount-overflow semantics
+      (`amount >= bit_width` yields 0 or sign-fill).
+- [x] J10 -- Logical operators (`&&`, `||`, `!`, `->`, `<->`).
+- [x] J11 -- Reduction operators (`&`, `|`, `^`, `~&`, `~|`, `~^`).
+- [x] J12 -- 4-state X/Z propagation across every operator family above (LRM 11.8.4 truth tables and
+      X-poisoning rules).
+- [x] J13 -- Wide (>64-bit) coverage on arithmetic, comparison, shift, divmod, and power, with
+      4-state propagation intact across word boundaries.
+- [x] J14 -- Archive sweep on the integral operator surface. Closes the archive contract for
+      everything in scope: signed boundary, mixed-width promotion (LRM 11.6 / 11.7), cross-word
+      bitwise / reduction, and narrow <-> wide zero/sign-extend + truncation. `++` / `--` is split
+      out as J19 because it is read-modify-write rather than a pure operator and rides on the lvalue
+      surface.
+- [x] J17 -- Case equality `===` / `!==` (LRM 11.4.5): bit-pattern compare, deterministic bool; also
+      drives event-control change detection (LRM 9.4.2 "not equal to its previous value").
+- [x] J18 -- Wildcard equality `==?` / `!=?` (LRM 11.4.6): RHS X/Z treated as don't-care. Same work
+      item as `operators.md` W2 (canonical home).
+- [ ] J19 -- `++` / `--` archive coverage (the five increment / decrement cases in
+      `operators/unary/two_state.yaml`). **Depends on** `operators.md` W12.
 
 ## Cross-references
 
-- Decision and findings: `../decisions/integral-representation.md`
 - LRM anchors: 6.11 (Table 6-8 integer types), 6.11.2 (4-state to 2-state convert), 10.7 (assignment
-  extension / truncation), 11.6 (expression bit lengths), 11.7 (signed expressions), 11.8
-  (expression evaluation rules, 11.8.4 for x/z handling).
-- Archive items this workstream targets: `operators/binary`, `operators/unary` (excluding `++` /
-  `--`, which is J19), `operators/shift_overflow`, `datatypes/integral`, `datatypes/packed`,
-  `datatypes/wide_integral`. Closes when J19 lands. `datatypes/wide_integral/packed_2d` belongs to
-  `datatypes/packed` (2D element index / slice), not this workstream.
-- Slang reference: `slang/ast/types/AllTypes.h:IntegralType`.
-- Legacy archive reference: `archived/include/lyra/common/type.hpp:IntegralInfo`.
-
-## Remaining operator gap
-
-`++` / `--`: implementation tracked as `operators.md` W12; archive coverage tracked as J19 above.
+  extension / truncation), 11.4.5 (case equality), 11.4.6 (wildcard equality), 11.4.10 (shift), 11.6
+  (expression bit lengths), 11.7 (signed expressions), 11.8 (expression evaluation rules, 11.8.4 for
+  X/Z handling).
+- Archive items targeted: `operators/binary`, `operators/unary` (excluding `++` / `--`, J19),
+  `operators/shift_overflow`, `datatypes/integral`, `datatypes/wide_integral`. The `packed_2d`
+  sub-folder is part of `datatypes/packed`, not this workstream.
+- Decision and findings: `../decisions/integral-representation.md`.

--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -1,10 +1,8 @@
 # Operators
 
 Tracks the operator surface that does not live in `integral.md`: set membership, wildcard / case
-equality, selectors (bit-select, non-indexed and indexed part-select) on both read and write sides,
-concatenation, replication, compound assignment, and the `++` / `--` family. Each archive item
-checkbox in `architecture-reset.md` is checked when its `*.yaml` cases reproduce on the current
-pipeline.
+equality, selectors (bit-select, part-select, indexed part-select) on both read and write sides,
+concatenation, replication, compound assignment, and the `++` / `--` family.
 
 Done when:
 
@@ -14,365 +12,83 @@ Done when:
 - `datatypes/packed/indexed_part_select` reproduces (the selector surface lives here even though the
   archive groups it under `datatypes/packed`).
 
-The numeric IDs (W1..W12) imply execution order: each later cut assumes the earlier cuts have
-landed. Where a cut is independent the text says so.
+## Actionable
+
+W10 (concat lvalue) and W12 (`++` / `--`) are the only open items.
+
+| Item | Status                                                                                  |
+| ---- | --------------------------------------------------------------------------------------- |
+| W10  | Ready; depends on W6 (shipped). Distributes RHS bits across an ordered sub-lvalue list. |
+| W12  | Read-modify-write on the lvalue surface. LRM 11.4.1 evaluate-target-once applies.       |
 
 ## Sub-Steps
 
+The numeric IDs (W1..W12) imply execution order; where a cut is independent the text says so.
+
 ### Membership and equality
 
-- [x] W1 -- `inside` set-membership. Add `hir::InsideExpr` carrying a left operand and an item list,
-      where each item is either a singular expression or a range `(lo, hi)`. HIR -> MIR desugars to
-      a logical-OR chain of comparisons over the lowered left operand: value items compare with
-      `==`; range items use `(>= lo) && (<= hi)`. MIR gains no new variant, cpp emit gains no new
-      path, and the runtime gains no new helper -- the OR-chain rides on the existing `PackedArray`
-      binary operators. LRM 11.4.13 four-state corner ("no match but some compare X yields `1'bx`")
-      is satisfied automatically because `PackedArray::LogicalOr` already implements the LRM 11.4.7
-      truth table. The left operand is lowered once to a MIR `ExprId` referenced by each comparison;
-      cpp emit re-renders each reference, so plain var-refs read the variable repeatedly
-      (idempotent) while side-effecting left operands would re-evaluate -- the archive test surface
-      uses only var-refs. A procedural-temp snapshot pattern (see C3 case selector) covers the
-      side-effect case if it becomes necessary.
-
-- [x] W2 -- Wildcard equality `==?` / `!=?`. The HIR / MIR `BinaryOp::kWildcardEquality` /
-      `kWildcardInequality` enums and the AST -> HIR -> MIR routing were already in place; this cut
-      adds the runtime helper `PackedArray::WildcardEquals` (asymmetric per LRM 11.4.6: X / Z in the
-      right operand are wildcards, X / Z in the left operand are not, so the result is 1'bx when the
-      left operand carries an X / Z that meets a known right-operand bit and no other bit definitely
-      mismatches). cpp emit lowers `kWildcardEquality` to `WildcardEquals(...)` and
-      `kWildcardInequality` to `WildcardEquals(...).LogicalNot()`. W1's value-item path retrofits
-      from `kEquality` to `kWildcardEquality` so wildcard items in `inside` work. Closes
-      `operators/wildcard_equality/four_state.yaml` and unblocks `control-flow.md` C11.
-
-- [x] W3 -- Case equality `===` / `!==`. `BinaryOp::kCaseEquality` / `kCaseInequality` route through
-      `PackedArray::CaseEqual` (bit-exact 4-state compare, X matches X, Z matches Z, X does not
-      match Z). Closes `operators/case_equality/default.yaml` and `four_state.yaml` including
-      2-state operands, mixed X/Z patterns, and width promotion.
+- [x] W1 -- `inside` set-membership (LRM 11.4.13). Singular and range items; ranges use
+      `(>= lo) && (<= hi)`. The LRM 11.4.13 four-state corner ("no match but some compare yields
+      `1'bx`") is preserved through the existing logical-OR truth table.
+- [x] W2 -- Wildcard equality `==?` / `!=?` (LRM 11.4.6). Asymmetric: X / Z in the right operand are
+      wildcards; X / Z in the left operand are not. Result is `1'bx` when the left operand carries X
+      / Z that meets a known right-operand bit and no other bit definitely mismatches. W1's value
+      items use `==?` so wildcard items in `inside` work.
+- [x] W3 -- Case equality `===` / `!==` (LRM 11.4.5). Bit-exact 4-state compare (X matches X, Z
+      matches Z, X does not match Z); deterministic bool.
 
 ### Selectors
 
-LRM distinguishes two syntactically distinct selector operators with overlapping but **not
-identical** operand domains. HIR and MIR mirror that distinction with **two separate expression
-variants**, not one merged node.
+LRM distinguishes two syntactically distinct selector operators with overlapping but not identical
+operand domains:
 
-**Element-select** `expr[idx]` -- single-bracket index. LRM 7.4.5 names this "element" of the array;
-LRM 11.5.1 specializes it to "bit-select" when the operand is a 1D vector (result is 1 bit).
+- **Element-select** `expr[idx]` (LRM 7.4.5; LRM 11.5.1 names it "bit-select" when the operand is a
+  1D vector).
+- **Range-select** `expr[hi:lo]` / `expr[base +: w]` / `expr[base -: w]` (LRM 7.4.5; LRM 11.5.1
+  names it "part-select" or "indexed part-select" when the operand is a 1D vector).
 
-**Range-select** `expr[hi:lo]` / `expr[base +: w]` / `expr[base -: w]`. LRM 7.4.5 names this "slice"
-of the array; LRM 11.5.1 specializes it to "part-select" when the operand is a 1D vector.
+The two operators differ on operand validity (associative arrays and strings allow element-select
+but not range-select; LRM 7.4.6 and 6.16), so the IR keeps them as separate variants rather than a
+merged node.
 
-LRM operand-domain validity:
-
-| Operand type                            | element-select       | range-select                                   |
-| --------------------------------------- | -------------------- | ---------------------------------------------- |
-| 1D packed integral (vector)             | bit-select (1 bit)   | part-select (multi-bit)                        |
-| multi-dim packed, packed struct / union | element (sub-vector) | slice / part-select                            |
-| unpacked array, dynamic array, queue    | element              | slice                                          |
-| **associative array**                   | element (key-typed)  | **illegal** (LRM 7.4.6)                        |
-| **string**                              | byte (LRM 6.16)      | **illegal** (LRM 6.16 lists only `Str[index]`) |
-| real / shortreal                        | illegal (LRM 6.12)   | illegal (LRM 6.12)                             |
-| scalar `reg` / `logic` / `bit`          | illegal (LRM 11.5.1) | illegal (LRM 11.5.1)                           |
-
-The asymmetry on associative arrays and strings (element-select valid, range-select not) is the
-reason for two IR nodes rather than one merged variant. A single merged node would force every
-visitor that touches selectors to carry a cross-cutting validity check ("this arm is only legal on
-these operand types"). Two nodes keep name and validity domain in lockstep.
-
-HIR shapes:
-
-```
-struct ElementSelectExpr {                       // expr[idx]
-  ExprId base_value;
-  ExprId index;
-};
-
-struct RangeConstantBounds    { ExprId msb_expr;   ExprId lsb_expr; };  // expr[hi:lo]
-struct RangeIndexedUpBounds   { ExprId base_index; ExprId width;    };  // expr[base +: w]
-struct RangeIndexedDownBounds { ExprId base_index; ExprId width;    };  // expr[base -: w]
-using RangeBounds = std::variant<
-    RangeConstantBounds, RangeIndexedUpBounds, RangeIndexedDownBounds>;
-
-struct RangeSelectExpr {
-  ExprId base_value;
-  RangeBounds bounds;
-};
-```
-
-The IR keeps source-form positions verbatim and defers all positional arithmetic to render. No
-constant evaluation or direction normalization happens at lowering -- slang has already validated
-the LRM contract during AST construction (constants are constant, indexed widths are positive,
-simple-form direction matches the operand's declared range; partial-OOB stays in the AST as a
-warning), and the result `Expr.type` carries the slice's width. MIR mirrors HIR 1:1.
-
-The bit width of one element of the operand at any select layer is derived at render time from the
-operand's `PackedArrayType.dims` stack:
-`element_bw = operand.BitWidth() / operand.dims.front().ElementCount()`. For a 1D vector this is 1
-(the LRM 11.5.1 bit-select case); for a multi-dim packed operand it is the inner dimensions' total
-bit width. Render multiplies the source-form index/lsb by this factor to translate from
-element-space to the flat-bit storage offset. The IR does not duplicate this derived value.
-
-Naming:
-
-- `ElementSelectExpr` / `RangeSelectExpr` match slang's `ElementSelectExpression` /
-  `RangeSelectExpression`. LRM 7.4.5 vocabulary aligns with slang on these names. **Not**
-  "BitSelect": whether the result is 1 bit is operand-derived, not an operator property.
-
-#### Write-side `Lvalue` shape
-
-A writable place is a root storage (var ref) plus an ordered chain of selectors that project into
-it. An empty chain is a whole-var write; one or more selectors describe nested partial writes that
-render flattens into a single LRM-bit-level partial assignment.
-
-```
-struct ElementLvalueSelector { ExprId index; };
-struct RangeLvalueSelector   { RangeBounds bounds; };
-using LvalueSelector = std::variant<ElementLvalueSelector, RangeLvalueSelector>;
-
-struct Lvalue {
-  std::variant<StructuralVarRef, ProceduralVarRef /* + LoopVarRef in HIR */> root;
-  std::vector<LvalueSelector> selectors;  // outer-first
-};
-```
-
-The chain shape (vector, not optional) reflects the LRM concept: a selector is a path into the root,
-and the path can have any number of layers. AST -> HIR walks the slang nested AST peeling
-outermost-first to build the chain. Per-layer element bit widths are not stored in the IR; render
-walks the root's `PackedArrayType.dims` stack alongside the chain (each Element selector pops one
-outer dim; each Range selector keeps the inner dims) to compute the factor when it needs one.
-
-#### Runtime `PackedArray` API
-
-`value::PackedArray` carries the source-level dim stack (`dims_`, outer-first) alongside its flat
-bit storage. The dim stack is the API contract; the underlying storage layout (flat bit planes
-today; potentially canonical-byte-aligned, vector-of-elements for huge outer dims, or any other
-shape once optimization work begins) is private. The whole API is element-level -- `ElementAt` and
-`Slice` take positions in the operand's outer-element units, and dispatch on `dims_` internally to
-turn them into bit offsets. Emit never bakes element-width arithmetic into call sites, so future
-storage refactors do not propagate beyond runtime internals. The chain API is uniformly method-style
-(no `operator[]` overload) so every layer of a selector chain reads the same way.
-
-```
-// Low-level bit-level primitives (chain leaves resolve here).
-auto ExtractBits(const PackedArray& lsb_bit, std::uint32_t bit_width) const
-    -> PackedArray;
-auto AssignSlice(const PackedArray& lsb_bit, std::uint32_t bit_width,
-                 const PackedArray& value) -> void;
-
-// Element-level chain entry points. Positions are in outer-element units;
-// the runtime scales by element bit width derived from `dims_`.
-auto ElementAt(const PackedArray& idx) -> PackedArrayRef;        // non-const
-auto ElementAt(const PackedArray& idx) const -> PackedArray;     // const
-auto Slice(const PackedArray& lsb_in_outer_elements,
-           std::uint32_t count_in_outer_elements) -> PackedArrayRef;       // non-const
-auto Slice(const PackedArray& lsb_in_outer_elements,
-           std::uint32_t count_in_outer_elements) const -> PackedArray;    // const
-```
-
-For a 1D operand (`dims_.size() == 1`), one "element" is one bit, so `ElementAt` is the LRM 11.5.1
-bit-select and `Slice` is the LRM 11.5.1 part-select at bit-level. For multi-dim, one "element" is
-the inner subtype, and the runtime multiplies by the element bit width internally.
-
-`PackedArrayRef` is a writable proxy carrying
-`(PackedArray* root, PackedArray bit_offset, uint32_t bit_width, vector<PackedRange> dims)`.
-Explicit `operator PackedArray()` materializes a fresh value via `root.ExtractBits` (callers wrap
-with `PackedArray(ref)` direct-init or rely on overloads taking `PackedArrayRef` directly);
-`operator=(const PackedArray&)` routes through `root.AssignSlice`. The same two chain methods
-compose into another `PackedArrayRef` with the dim stack's outer popped (`ElementAt`) or its outer
-count replaced (`Slice`). `bit_offset` is kept in a canonical 64-bit signed 4-state shape so chained
-`+` / `*` between layers never collide on shape, and X/Z in any layer's index propagates to the
-final write (LRM 11.5.1 "X/Z position is a no-op").
-
-LRM 11.5.1 corner cases (X/Z position no-op, fully-OOB no-op, partial-OOB only in-range bits) live
-inside `AssignSlice` and `ExtractBits`. The proxy chain only accumulates; the final read or write
-call enforces the rules.
-
-#### Observable-target write proxy
-
-`Var<T>` is deliberately a thin storage + subscriber wrapper. It exposes `Get()` for reads and is
-written through:
-
-- `runtime::WriteVar(services, var, value)` -- whole-var commit + change detection + event firing.
-- `var.Mutate(services)` -- partial commit. Returns a `ScopedMutation<T>` RAII handle that snapshots
-  the current value, forwards `ElementAt` / `Slice` to the snapshot so a normal chain composes, and
-  commits the (possibly mutated) snapshot through `WriteVar` in its destructor.
-
-`ScopedMutation<T>` is non-copyable and non-movable: the contract is that the handle lives only
-until the end of the constructing full expression. Returning it by value from `Var<T>::Mutate`
-relies on C++17 mandatory copy elision -- the prvalue is materialized in the caller's storage with
-no copy or move. The destructor runs at the statement's semicolon, after the chain has finished
-mutating the snapshot, and routes the result through `WriteVar` so subscribers fire on change.
-
-The selector chain itself stays on `value::PackedArray` / `PackedArrayRef`. `Var<T>` has no chain
-API of its own; `Mutate` is purely the envelope that turns "mutate a snapshot then commit" into a
-single chain expression. The shape `var.Mutate(svc).ElementAt(...).Slice(...) = rhs` is identical to
-a procedural-local chain except for the `Mutate(svc)` adapter and the implicit commit at the end of
-the statement.
-
-#### Render rules
-
-Render emits a chain of method calls; the runtime composes them. Render never computes element bit
-widths -- the runtime decides via the operand's `dims_`. The chain methods are simply `ElementAt`
-and `Slice`, both taking source-form outer-element positions:
-
-Read (recursive compose -- each layer's render renders its `base_value` and appends its own method
-call):
-
-- `mir::ElementSelectExpr { base, index }` -> `(<base>).ElementAt(<index>)`.
-- `mir::RangeSelectExpr` with `RangeConstantBounds { msb, lsb }` ->
-  `(<base>).Slice(<lsb>, <count>U)` where `count = |msb - lsb| + 1` (slang elaborates msb and lsb to
-  integer literals; render extracts them).
-- `mir::RangeSelectExpr` with `RangeIndexedUpBounds { base_index, width }` ->
-  `(<base>).Slice(<base_index>, <count>U)` where `count` = literal value of `width`.
-- `mir::RangeSelectExpr` with `RangeIndexedDownBounds { base_index, width }` ->
-  `(<base>).Slice((<base_index>) - <count-1 same-shape lit>, <count>U)`.
-
-Write (iterative chain -- walk `lvalue.selectors`, append each layer's method call, end with
-`= rhs`):
-
-- Procedural-local target root: chain mutates the variable in place. Emit shape:
-  `<root>.ElementAt(<idx>).Slice(<lsb>, <count>U) = <rhs>;`.
-- Observable structural-var root: insert `.Mutate(*services_)` after the root so the
-  `ScopedMutation` temporary commits through `WriteVar` at end-of-statement. Emit shape:
-  `<root>.Mutate(*services_).ElementAt(<idx>).Slice(<lsb>, <count>U) = <rhs>;`.
-
-Both branches share `RenderSelectorMethodCall` per layer; the only difference is the single
-`.Mutate(*services_)` adapter inserted between the root and the first selector when the root is
-observable.
-
-#### Variable declaration emit
-
-`PackedArray` exposes two constructors: a 1D shorthand `(bit_width, signed, four_state)` and a
-dim-list `(initializer_list<PackedRange>, signed, four_state)`. Render emits the 1D form for
-single-dim packed types (`bit [N-1:0]`) and the dim-list form for multi-dim packed types
-(`bit [N-1:0][M-1:0]`...) so the runtime instance carries the correct `dims_` stack.
-
-#### LRM 11.5.1 / 7.4.5 corner-case rules (handled inside `PackedArray::ExtractBits` / `AssignSlice`)
-
-Read:
-
-- Any X / Z bit in the runtime `lsb_bit` propagates: result is all-X of `width` bits (4-state) or
-  all-0 (2-state).
-- Fully out-of-range read returns all-X / all-0.
-- Partially out-of-range read returns in-range bits verbatim and X / 0 for the OOB bits.
-
-Write:
-
-- Any X / Z bit in `lsb_bit` makes the entire write a silent no-op (the LRM "no effect on the data
-  stored when written" rule).
-- Fully out-of-range write is a silent no-op.
-- Partially out-of-range write affects only the in-range bits; bits outside the operand's bounds are
-  silently discarded.
-
-Bit-select / part-select of a scalar or real variable is illegal; slang rejects at AST construction,
-so HIR never sees the shape.
-
-#### NBA on selector lvalues
-
-`data[i+:8] <= v` routes through the same closure-based NBA machinery as a whole-var NBA. Each
-`ExprId` reached through the selector chain is handled one of two ways:
-
-- **Integer literals** are cloned verbatim into the closure body's expr store -- no capture entry is
-  created, since the value cannot change between submit and fire.
-- **Non-literal expressions** are captured by value into a fresh procedural var binding via
-  `ByValueCapture`. Each capture gets a distinct name (`_lyra_nba_idx0`, `_lyra_nba_idx1`, ...)
-  drawn from a counter that advances only on non-literal snapshots, so the emitted capture list has
-  no collisions. The capture-name suffix is sequential among non-literal captures but may skip
-  indices implicitly when literals appear between them in the selector chain.
-
-Inside the closure body the chain is rebuilt with body-local refs (`ProceduralVarRef` for captures,
-`IntegerLiteral` clones for literals), so when the NBA region fires it re-evaluates none of the
-original outer-scope expressions -- the snapshotted values at submit time are what get written.
-
-If the NBA target is observable, the body's chain inserts `.Mutate(*services_)` after the root (same
-pattern as the blocking observable selector write) so the NBA-fired write commits through `WriteVar`
-when the `ScopedMutation` temporary tears down at end-of-statement and triggers subscribers. The
-closure stays a single lambda -- there is no nested mutation lambda.
-
-- [x] W4 -- Element-select read `v[idx]`. Wired end-to-end through `hir::ElementSelectExpr` ->
-      `mir::ElementSelectExpr` -> `PackedArray::Slice(<scaled>, ebw)`. Handles 1D bit-select (ebw=1)
-      and multi-dim element-select (ebw=N) uniformly: render derives `ebw` from the operand's
-      `PackedArrayType.dims` stack, so the IR carries no dim-derived duplicate. Chain composition is
-      via nested `Slice` calls on `base_value`. Implements LRM 7.4.5 / 11.5.1 OOB and X / Z
-      propagation rules on the runtime side.
-
-- [x] W5 -- Range-select read covering all three bounds forms: non-indexed constant `v[msb:lsb]`,
-      indexed-up `v[base +: w]`, indexed-down `v[base -: w]`. Wire `mir::RangeSelectExpr` mirroring
-      HIR (three `RangeBounds` variants). HIR -> MIR is a pure structural pass-through. cpp render
-      derives the operand's element bit width from `PackedArrayType.dims`, dispatches on the MIR
-      bounds variant, scales positions, and emits a single `PackedArray::Slice` call. For multi-dim,
-      the scaling translates element-space positions to bit positions; for 1D (`ebw==1`) the scaling
-      is dropped. Runtime reuses `PackedArray::Slice`. Width at render comes from the result type.
-
-- [x] W6 -- Selector lvalue (write side, including NBA + selector). Extended HIR / MIR `Lvalue` to
-      carry a root `*Ref` plus a `vector<LvalueSelector>` chain. Added
-      `PackedArray::AssignSlice(lsb_bit, width, value)` and the `ElementAt` / `Slice` chain entries
-      on `PackedArray` / `PackedArrayRef`. Observable selector writes route through
-      `Var<T>::Mutate(services)` which returns a `ScopedMutation<T>` RAII handle: it snapshots
-      `var.Get()`, forwards chain methods, and commits via `WriteVar` in its destructor (relying on
-      C++17 mandatory copy elision for the prvalue return). NBA on selector lvalues snapshots every
-      non-literal `ExprId` in the chain into the closure body via `ByValueCapture`; integer literals
-      are cloned verbatim. Render walks the chain and emits one method call per layer, with
-      `.Mutate(*services_)` inserted between root and first selector when the root is observable.
-      LRM 11.5.1 write rules (fully-OOB no-op, partial-OOB only in-range bits, X / Z position no-op)
-      live inside `AssignSlice`. Closes `datatypes/packed/indexed_part_select/default.yaml` for the
-      write half.
+- [x] W4 -- Element-select read `v[idx]`. Covers 1D bit-select and multi-dim element-select
+      uniformly. LRM 7.4.5 / 11.5.1 OOB and X / Z propagation rules apply.
+- [x] W5 -- Range-select read covering all three bounds forms: constant `v[msb:lsb]`, indexed-up
+      `v[base +: w]`, indexed-down `v[base -: w]`.
+- [x] W6 -- Selector lvalue (write side, including NBA + selector). LRM 11.5.1 write rules
+      (fully-OOB no-op, partial-OOB only in-range bits, X / Z position no-op) all hold. Closes
+      `datatypes/packed/indexed_part_select` for the write half.
 
 ### Construction
 
-- [x] W8 -- Concatenation read `{a, b, c}`. `hir::ConcatExpr` / `mir::ConcatExpr` route through
-      `PackedArray::Concat`, which packs each operand's bits MSB-first via word-level shift-and-OR
-      (no per-bit loop). Result is unsigned; 4-state iff any operand is 4-state, with both value and
-      unknown planes packed in lockstep. Signed operands contribute raw bits per LRM 11.4.12;
-      unsized literals are rejected at the slang frontend. Closes `operators/concat/default.yaml`
-      including mixed widths, nested concat, signed operands, wide (>64-bit) results, and X/Z
-      propagation.
-
-- [x] W9 -- Replication `{N{x}}`. `hir::ReplicationExpr` / `mir::ReplicationExpr` route through
-      `PackedArray::Replicate`, which does N word-level shift-and-OR copies (O(result_words)). For
-      integral mode the multiplier is a slang-elaborated constant non-negative non-X/Z literal per
-      LRM 11.4.12.1. Zero multipliers produce a `void`-typed operand that the AST -> HIR concat
-      lowering drops, satisfying the LRM rule that zero replication is legal only inside a concat
-      with at least one positive-sized sibling. Closes `operators/replicate/default.yaml` including
-      replication in concat, nested concat, nested replication, signed operands, wide results, and
-      X/Z propagation. String replication remains via `ReplicateString` (#798).
-
-- [ ] W10 -- Concatenation lvalue `{a, b, c} = ...`. Add a `ConcatLvalue` arm to `Lvalue` carrying
-      an ordered list of sub-lvalues. HIR -> MIR snapshots the right-hand side into a `PackedArray`
-      temp and distributes its bits MSB-first into each sub-target via the same selector chain
-      machinery W6 provides.
+- [x] W8 -- Concatenation read `{a, b, c}` (LRM 11.4.12). Result is unsigned; 4-state iff any
+      operand is 4-state. Signed operands contribute raw bits; unsized literals are rejected at the
+      frontend. Includes mixed widths, nested concat, signed operands, wide (>64-bit) results, and X
+      / Z propagation.
+- [x] W9 -- Replication `{N{x}}` (LRM 11.4.12.1). Multiplier is a constant non-negative non-X/Z
+      literal. Zero multipliers are legal only inside a concat with at least one positive-sized
+      sibling; the frontend's `void`-typed operand handling drops them naturally. Includes
+      replication in concat, nested concat, nested replication, signed operands, wide results, and X
+      / Z propagation. String replication lives in `datatypes.md` SC2.
+- [ ] W10 -- Concatenation lvalue `{a, b, c} = rhs`. Snapshots the RHS into a temp and distributes
+      its bits MSB-first into each sub-target via the W6 chain.
 
 ### Assignment families
 
-- [x] W11 -- Compound assignment `+= -= *= /= %= &= |= ^= <<= >>= <<<= >>>=`. Compound stays as
-      compound through HIR and MIR: `AssignExpr` carries an `optional<BinaryOp> compound_op` field
-      that is `nullopt` for a simple `=` and set for `op=`. Slang's expanded
-      `BinaryOp(LValueRef,     user_rhs)` tree is consumed at AST -> HIR -- the helper extracts the
-      user-written rhs from the side that does not wrap `LValueReference`, then re-types it to the
-      lhs type so the runtime stays at one shape (slang's per-operand promotion Conversions become
-      elaboration artifacts that lowering does not reproduce). C++ emit produces `<chain> op= rhs`
-      directly: `PackedArray`, `PackedArrayRef`, and `ScopedMutation<PackedArray>` each overload the
-      arithmetic / bitwise compounds as `operator+=` etc., and the three shifts as `ShiftLeftAssign`
-      / `LogicalShiftRightAssign` / `ArithmeticShiftRightAssign`. The LRM 11.4.1 "evaluate target
-      only once" rule falls out of the C++ standard's eval-once rule on the compound assignment
-      expression; no HIR-level snapshot pass is needed. NBA + compound is rejected at slang parsing
-      (LRM A.6.2); InternalError catches grammar drift. Closes `operators/compound_assignment` for
-      whole-var, selector, and mixed-state target shapes (`x += y`, `x[7:4] |= v`, `x[i +: 4] += k`,
-      `int %= logic[3:0]`).
-
-- [ ] W12 -- `++` / `--` (prefix and postfix). Add `hir::IncrDecrStmt` and `hir::IncrDecrExpr`
-      (separate from `AssignExpr` because the expression form returns the pre- or post-value). Once
-      `++` / `--` are accepted in index positions, the same eval-once rule will need explicit
-      handling at the read-modify-write level; the natural home for that work is LIR's address-once
-      lowering rather than an HIR snapshot pass.
+- [x] W11 -- Compound assignment `+= -= *= /= %= &= |= ^= <<= >>= <<<= >>>=`. LRM 11.4.1 "evaluate
+      target only once" applies; falls out of the C++ eval-once rule on the compound expression.
+      NBA + compound is rejected at slang parsing per LRM A.6.2. Closes
+      `operators/compound_assignment` for whole-var, selector, and mixed-state target shapes.
+- [ ] W12 -- `++` / `--` (prefix and postfix). The expression form returns the pre- or post-value,
+      so it is a distinct shape from `AssignExpr`. Once accepted in index positions, the same LRM
+      11.4.1 evaluate-target-once rule applies at the read-modify-write level.
 
 ## Cross-references
 
-- LRM anchors: 7.4.5 (indexing and slicing of arrays: vocabulary, invalid-index rules), 11.4.5 (case
+- LRM anchors: 7.4.5 (indexing and slicing: vocabulary, invalid-index rules), 11.4.5 (case
   equality), 11.4.6 (wildcard equality), 11.4.10 (shift), 11.4.12 / 11.4.12.1 (concatenation,
   replication), 11.4.13 (set membership), 11.5.1 (bit-select / part-select / indexed part-select on
   packed).
-- `integral.md` J14 archive sweep depends on W4..W6 for any binary / shift-overflow case that
-  selects sub-bits before applying the operator.
-- `control-flow.md` C11 unblocked by W2; C12 unblocked by W1 (basic) and W2 (wildcard items).
-- `packed.md` P3..P5 use W6's selector chain shape and add field / variant selectors on top; multi-
-  dim packed array selectors are handled here, not in `packed.md`.
+- Unblocks: `control-flow.md` C11 (via W2), C12 (via W1 + W2); `integral.md` archive sweep relies on
+  W4..W6 for sub-bit operands; `packed.md` P3..P5 extend the W6 selector chain with field / variant
+  arms.

--- a/docs/progress/packed.md
+++ b/docs/progress/packed.md
@@ -1,12 +1,9 @@
 # Packed Types
 
-Tracks the type-side packed-aggregate surface that is not subsumed by `operators.md`: packed
-structs, packed unions, and assignment patterns over packed types. Multi-dim packed array selectors
-(read and write, including chained selectors on `bit [N-1:0][W-1:0]` and deeper) are covered by
-`operators.md` W4..W6 and their `vector<LvalueSelector>` chain shape; this file picks up where the
-chain machinery leaves off -- field access, union views, and aggregate literal forms. Each archive
-item checkbox in `architecture-reset.md` is checked when its `*.yaml` cases reproduce on the current
-pipeline.
+Tracks the type-side packed-aggregate surface: packed structs, packed unions, and assignment
+patterns over packed types. Multi-dim packed array selectors (read and write) live in `operators.md`
+W4..W6 and reuse the selector chain shape there; this file picks up where the chain machinery leaves
+off -- field access, union views, and aggregate literal forms.
 
 Done when:
 
@@ -14,38 +11,40 @@ Done when:
   `assignment_pattern_multibit`, `nested_aggregates`, and `packed_integral_default` reproduce.
 - `operators/replication_patterns` reproduces (`'{N{x}}` array-literal forms over packed types).
 
-The numeric IDs (P3..P5) are stable references and imply execution order. The earlier P1 / P2
-(multi-dim 2D / 3D selectors) are deleted from this file because they now reproduce through the
-operators.md selector chain.
+## Actionable
+
+P3, P4, P5 are all open and ordered: P3 introduces the field selector and unblocks P4 (union field
+views ride on the same shape); P5 builds assignment patterns on top.
+
+| Item | Status                                                    |
+| ---- | --------------------------------------------------------- |
+| P3   | Ready when `operators.md` W4..W6 are in place (they are). |
+| P4   | Depends on P3.                                            |
+| P5   | Depends on P3.                                            |
 
 ## Sub-Steps
 
-- [ ] P3 -- Packed struct field access. Add a `kField(field_index)` arm to the `LvalueSelector` /
-      `SelectExpr` variants alongside the existing element / range arms. HIR resolves the slang
-      `MemberAccessExpression` to a `(field_index)` payload; MIR carries `(offset, width)` after
-      layout. Reads and writes route through the same chain machinery W4 / W5 / W6 use, with the
-      field arm contributing a constant bit offset and constant width to the accumulator. Closes
-      `datatypes/packed/packed_struct`.
+The numeric IDs are stable references.
 
-- [ ] P4 -- Packed union. All members overlay the same underlying `PackedArray` bits; field access
-      reads / writes the full union width and reinterprets per the accessed member's type. No new
-      storage primitive needed; the type system distinguishes the view. Closes
-      `datatypes/packed/packed_union`.
+- [ ] P3 -- Packed struct field access (LRM 7.2.1). Field selector arm on the selector chain,
+      contributing constant bit offset and constant width. Closes `datatypes/packed/packed_struct`.
 
-- [ ] P5 -- Assignment patterns over packed aggregates. Handles positional `'{a, b, c}`, default
-      `'{default: v}`, named `'{i: v, j: v}`, and replication-pattern `'{N{x}}` literal forms.
-      Lowers to a sequence of selector-targeted writes through the W6 / P3 chain machinery; no new
-      runtime primitive is needed. Closes `datatypes/packed/assignment_pattern_fill`,
-      `assignment_pattern_multibit`, `nested_aggregates`, and `operators/replication_patterns`.
+- [ ] P4 -- Packed union (LRM 7.3.1). All members overlay the same underlying bits; field access
+      reads / writes the full union width and reinterprets per the accessed member's type. The type
+      system distinguishes the view. Closes `datatypes/packed/packed_union`.
+
+- [ ] P5 -- Assignment patterns over packed aggregates (LRM 10.9): positional `'{a, b, c}`, default
+      `'{default: v}`, named `'{i: v, j: v}`, and replication `'{N{x}}`. Lowers to a sequence of
+      selector-targeted writes through the W6 / P3 chain. Closes
+      `datatypes/packed/assignment_pattern_fill`, `assignment_pattern_multibit`,
+      `nested_aggregates`, and `operators/replication_patterns`.
 
 ## Cross-references
 
 - LRM anchors: 7.2 (packed structs and unions), 7.4 (packed and unpacked arrays), 10.9 (assignment
   patterns), 11.5.1 (bit-select / part-select on packed arrays and structs).
-- Prerequisite: `operators.md` W4..W6 must land before P3 (P3 extends the same selector chain shape
-  with a field arm).
+- Prerequisite: `operators.md` W4..W6 (chain shape this file extends).
 - `datatypes/packed/indexed_part_select`, `datatypes/packed/packed_2d`, `packed_3d`,
-  `datatypes/wide_integral/packed_2d`, and `operators/concat`, `operators/replicate`,
-  `operators/compound_assignment` all live in `operators.md`, not here, even though the archive
-  groups some of them under `datatypes/packed`. The split follows the type-vs-operator boundary, not
-  archive directory layout.
+  `datatypes/wide_integral/packed_2d`, and `operators/{concat,replicate,compound_assignment}` are
+  tracked under `operators.md`, not here, even though the archive groups some under
+  `datatypes/packed`. The split follows the type-vs-operator boundary, not archive layout.

--- a/docs/progress/processes.md
+++ b/docs/progress/processes.md
@@ -1,131 +1,91 @@
 # Processes
 
 Tracks SystemVerilog procedural-block constructs and the supporting timing-control machinery. Covers
-archive items under `archived/tests/sv_features/processes/`. Each archive item checkbox in
-`architecture-reset.md` is checked when its `*.yaml` cases reproduce on the current pipeline.
+archive items under `archived/tests/sv_features/processes/`.
 
-The numeric IDs (P1..P11) are stable references to archive items and do **not** imply execution
-order. Items in the [Actionable](#actionable) section can be picked up next; items in
-[Blocked](#blocked) wait on machinery owned by another workstream.
+The numeric IDs (P1..P13, T1..T5) are stable references and do **not** imply execution order.
 
 ## Actionable
 
-| Item | Notes                                                                  |
-| ---- | ---------------------------------------------------------------------- |
-| -    | No procedural-block items left in this workstream's actionable column. |
+No procedural-block items are currently actionable from within this workstream. Open items wait on
+machinery owned by other workstreams; see [Blocked](#blocked).
 
 ## Blocked
 
-| Item   | Blocked on                                                                                                            |
-| ------ | --------------------------------------------------------------------------------------------------------------------- |
-| P5, P6 | Bit-select / range-select expressions in MIR (`operators.md` W4 / W5). Edge triggers on selected lvalues need them.   |
-| P8     | `fork` / `join_*`. Needs concurrent-process scheduling primitives; out of scope until single-process work is settled. |
+| Item | Blocked on                                                                                                       |
+| ---- | ---------------------------------------------------------------------------------------------------------------- |
+| T5   | Bit-select / range-select edge triggers; needs the selector machinery from `operators.md` W4 / W5.               |
+| P8   | `fork` / `join_*`. Needs concurrent-process scheduling primitives; out of scope until single-process is settled. |
+| P12  | Process generate; rides on the existing P1..P11 surface, mostly frontend elaboration.                            |
 
 ## Sub-Steps
 
 ### Procedural blocks
 
-- [x] P1 -- `initial`. `hir::ProcessKind::kInitial` lowers straight-line into a `mir::Process` of
-      kind `kInitial`; runtime registers it in the active queue at time 0. The coroutine completes
-      naturally when the body finishes. Coverage rides on every other test in `tests/cases/cpp/`.
-- [x] P2 -- `final`. `hir::ProcessKind::kFinal` lowers straight-line into a `mir::Process` of kind
-      `kFinal`; runtime drains the finals queue at end of simulation. `$finish` inside a `final`
-      ends simulation immediately (LRM 9.2.3). Time-controlling statements inside `final` are
-      rejected at the runtime boundary because they would suspend a coroutine the engine cannot
-      resume.
-- [x] P3 -- `always` / `always_ff`. HIR keeps the four SV kinds (`kAlways`, `kAlwaysComb`,
-      `kAlwaysLatch`, `kAlwaysFf`). HIR -> MIR wraps the body in
-      `mir::ForStmt(empty, empty, empty,     body)` and emits `ProcessKind::kInitial`. `always_ff`
-      collapses to the same shape as `always` because the LRM 9.2.2.4 restrictions (one event
-      control, no blocking timing) are lint-only and the frontend already enforces them.
-      Pathological zero-delay loops (`always areg     = ~areg;`) are caught by the engine's
-      `kMaxCurrentTimeIterations` settle limit. Covers `processes/initial` (always portion) and the
-      `always_ff` body of `processes/wait_event`.
+- [x] P1 -- `initial` (LRM 9.2.1). Runs once at time 0; finishes when the body completes. Coverage
+      rides on every other test in the corpus.
+- [x] P2 -- `final` (LRM 9.2.3). Drained at end of simulation. `$finish` inside `final` ends
+      simulation immediately. Time-controlling statements inside `final` are rejected at the runtime
+      boundary because they would suspend a coroutine the engine cannot resume.
+- [x] P3 -- `always` / `always_ff` (LRM 9.2.2). `always_ff` collapses to the same shape as `always`
+      because the LRM 9.2.2.4 restrictions are lint-only and the frontend already enforces them.
+      Pathological zero-delay loops are caught by the engine's settle limit.
 - [x] P10 / P13 -- `always_comb` / `always_latch` (LRM 9.2.2.2.1) and `always @*` / `always @(*)`
-      (LRM 9.4.2.2). Slang's `AnalysisManager` produces read sets (per-procedure for always_comb /
-      always_latch, per-region for `@*`); the lyra pipeline stores them in `SensitivityReadStore`
-      keyed by `slang::ast::Statement*` (see `docs/decisions/read-set-inference.md` for the shared
-      inference architecture). HIR carries them on `Process::implicit_sensitivity_list` for the
-      always_comb / always_latch forms and on `ImplicitEventControl::sensitivity_list` for `@*`. HIR
-      -> MIR: always_comb / always_latch run `forever { body; SensitivityWaitStmt; }` (body at t=0
-      then wait per LRM 9.2.2.2); `@*` expands to `Block { SensitivityWaitStmt; body; }` (wait first
-      per LRM 9.4.2.2.2). Reads collapse to whole-variable subscription until the runtime supports
-      bit-level any-change.
+      (LRM 9.4.2.2). Slang's flow analysis produces the implicit read sets; the body runs at t = 0
+      (always_comb / always_latch) or after the first wait (`@*`), then waits on any change to the
+      read set. Reads collapse to whole-variable subscription until the runtime supports bit-level
+      any-change.
 
 ### Procedural assignments
 
-- [x] P4 -- Non-blocking assignment `<=`. Submits a closure to the NBA region during the kActive
-      phase; the engine commits all closures in the kCommitNba phase before observing changes.
-      Re-entrancy (`SubmitNba` during NBA commit) is rejected. Covers the basic NBA cases used by
-      every `always_ff` example.
-- [x] P7 -- Continuous assignment `assign x = y;` (LRM 10.3). Source-aligned in HIR as a scope-level
-      `ContinuousAssign {lhs, rhs, sensitivity_list}` whose LHS / RHS land in the enclosing
-      structural scope's expr pool alongside parameters and variable initialisers. Read set is
-      precomputed by slang's flow analysis (slang treats continuous assignment as a procedure for
-      analysis purposes, LRM 10.3.2 reads identical to LRM 9.2.2.2.1); the AST -> HIR lowering looks
-      it up keyed by the assignment expression (see `docs/decisions/read-set-inference.md`). HIR ->
-      MIR materialises a `mir::Process { kInitial, forever { lhs = rhs; SensitivityWait(reads); } }`
-      directly. Drive strength (10.3.4) and `assign #N` (10.3.3) are diagnosed; concat LHS rides on
-      the procedural side. Closes `processes/continuous_assign`.
+- [x] P4 -- Non-blocking assignment `<=`. Submits a closure to the NBA region during the active
+      phase; the engine commits all closures in the NBA commit phase before observing changes.
+      Re-entrancy during NBA commit is rejected.
+- [x] P7 -- Continuous assignment `assign x = y;` (LRM 10.3). Read set is precomputed by slang's
+      flow analysis (LRM 10.3.2 reads identical to LRM 9.2.2.2.1). Drive strength (LRM 10.3.4) and
+      `assign #N` (LRM 10.3.3) are diagnosed; concat LHS rides on the procedural side.
 
 ### Timing controls
 
-- [x] T1 -- Delay control `#N`. `mir::TimedStmt` with `DelayControl{duration}`; the engine schedules
-      the suspended coroutine onto the delayed queue. Covers `processes/delay`.
-- [x] T2 -- Event control `@(x)` any-change. `mir::EventControl{triggers: [{signal, kAnyChange}]}`.
-      `Var<T>` wrapper compares old vs new values and notifies the engine on any inequality. Covers
-      `processes/event_triggers` (any-change subset).
-- [x] T3 -- Event control edge polarity `@(posedge clk)` / `@(negedge clk)` / `@(edge clk)`.
-      `EventEdge::{kPosedge,     kNegedge, kBothEdges, kAnyChange}` on each trigger;
-      `Observable::TakeMatchingWaiters` filters by edge per LRM Table 9-2. `ClassifyEdge` in
-      `runtime/var.hpp` covers the full 4-state transition table: posedge fires on 0 -> {1, x, z}
-      and {x, z} -> 1; negedge fires on 1 -> {0, x, z} and {x, z} -> 0; x <-> z is `kChangeOnly`.
-      `kBothEdges` (the `edge` keyword) matches either posedge or negedge. Covers
-      `processes/edge_trigger_bit_select` (whole-variable edges) and the edge subset of
-      `processes/event_triggers`.
-- [x] T4 -- Event control event lists `@(posedge clk or negedge rst_n)` / comma form. A single
-      `EventControl` carries multiple `EventTrigger` entries; the runtime races them and re-arms
-      whichever signal won the wake-up. Covers the event-list subset of `processes/event_triggers`.
-- [ ] T5 -- Edge trigger on bit-select / range-select (`@(posedge bus[2])`). Needs `mir::SelectExpr`
-      from `operators.md` W4 / W5. Closes `processes/edge_trigger_bit_select` (selected subset) and
-      `processes/edge_trigger_dynamic`.
+- [x] T1 -- Delay control `#N` (LRM 9.4.1). Engine schedules the suspended coroutine onto the
+      delayed queue.
+- [x] T2 -- Event control `@(x)` any-change. Compares old vs new on each write and notifies on any
+      inequality.
+- [x] T3 -- Event control edge polarity `@(posedge clk)` / `@(negedge clk)` / `@(edge clk)` (LRM
+      Table 9-2). Full 4-state transition table: posedge fires on 0 -> {1, x, z} and {x, z} -> 1;
+      negedge fires on 1 -> {0, x, z} and {x, z} -> 0; x <-> z is a change-only event. `edge`
+      keyword matches either direction.
+- [x] T4 -- Event control event lists `@(posedge clk or negedge rst_n)` and comma form. The runtime
+      races the triggers and re-arms whichever signal won the wake-up.
+- [ ] T5 -- Edge trigger on bit-select / range-select (`@(posedge bus[2])`). **Depends on**
+      `operators.md` W4 / W5.
 
 ### Synchronisation primitives
 
 - [x] P9 -- Named events (LRM 15.5): `event e;` declaration, `-> e;` trigger, `@e;` await,
-      `e.triggered` query. HIR carries `EventTriggerStmt` for `-> e;` and
-      `TimingControl::NamedEventControl` for `@e;`; HIR -> MIR collapses both onto method calls on
-      the `lyra::runtime::NamedEvent` data type, which records `last_triggered_at_` (LRM 15.5.3
-      same-time-step persistence falls out of `last_triggered_at_ == services.Now()`) and wakes its
-      waiter list. `e.triggered` returns a 1-bit `PackedArray`. `->>` non-blocking trigger,
+      `e.triggered` query (LRM 15.5.3 same-time-step persistence). `->>` non-blocking trigger,
       `wait_order(...)`, event aliasing / nullness / comparison are out of scope.
-- [x] P11 -- `wait (cond) body` level-sensitive control (LRM 9.4.3). HIR carries
-      `WaitStmt {cond, body, sensitivity_list}`. Sensitivity is precomputed by driving slang's
-      `DefaultDFA` on `cond` as a standalone expression during the AnalysisManager pass (see
-      `docs/decisions/read-set-inference.md`); the AST -> HIR lowering looks it up keyed by the cond
-      expression. HIR -> MIR lowers to `Block { While { !cond, SensitivityWait(reads) }; body }` --
-      the LRM 9.4.3 "skip suspend if cond is already true" semantic falls out of the while-loop
-      shape. `wait fork;` (9.6.1) and `wait_order(...)` (15.6) are out of scope. Closes
-      `processes/wait_event`.
+- [x] P11 -- `wait (cond) body` level-sensitive control (LRM 9.4.3). Sensitivity is precomputed by
+      slang's flow analysis on `cond` as a standalone expression. The "skip suspend if cond is
+      already true" semantic falls out of the lowering. `wait fork;` (LRM 9.6.1) and
+      `wait_order(...)` (LRM 15.6) are out of scope.
 
 ### Concurrency
 
-- [ ] P8 -- `fork` / `join` / `join_any` / `join_none`. Needs concurrent-process scheduling: spawn
-      child coroutines, parent suspends until the join condition is met. Distinct from every other
-      procedural construct because the body produces multiple parallel threads. Deferred until the
-      single-process surface (P10, P9, P11) is settled.
+- [ ] P8 -- `fork` / `join` / `join_any` / `join_none` (LRM 9.3). Spawns child coroutines; parent
+      suspends until the join condition is met. Distinct from every other procedural construct
+      because the body produces multiple parallel threads. Deferred until the single-process surface
+      is settled.
 
 ### Generate
 
 - [ ] P12 -- Process generate (`generate` / `if generate` / `for generate` containing procedural
-      blocks). Closes `processes/generate`. Largely a frontend elaboration concern; the lowered
-      processes ride on the existing P1..P11 machinery.
+      blocks). Largely a frontend elaboration concern; the lowered processes ride on P1..P11.
 
 ## Out of Scope
 
 - Scheduler-region behaviour (Active / Inactive / NBA / Observed / Reactive / Postponed). Each
-  region's invariants are tracked under `scheduling/*` archive items; the per-region implementation
-  lives in `src/lyra/runtime/engine.cpp` but the cross-region tests have no dedicated progress file
-  yet. Create `scheduling.md` when that workstream becomes actionable.
-- `disable` and `disable fork`. Tracked separately under process control (LRM 9.6).
+  region's invariants are tracked under `scheduling/*` archive items; create `scheduling.md` when
+  that workstream becomes actionable.
+- `disable` and `disable fork` (LRM 9.6). Tracked separately under process control.
 - `expect` statement and `wait_order`. Verification-only constructs.

--- a/tests/cases/cpp/binary_mixed_width_promotion/case.yaml
+++ b/tests/cases/cpp/binary_mixed_width_promotion/case.yaml
@@ -1,0 +1,17 @@
+id: cpp.binary_mixed_width_promotion
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    bit_plus_int: 11
+    int_plus_longint: 1100
+    bit_plus_longint: 1001
+    byte_lt_int: 1
+    byte_gt_int: 0
+    ubyte_lt_int: 0
+    ubyte_gt_int: 1

--- a/tests/cases/cpp/binary_mixed_width_promotion/main.sv
+++ b/tests/cases/cpp/binary_mixed_width_promotion/main.sv
@@ -1,0 +1,40 @@
+module Top;
+  int bit_plus_int;
+  longint int_plus_longint;
+  longint bit_plus_longint;
+  bit byte_lt_int;
+  bit byte_gt_int;
+  bit ubyte_lt_int;
+  bit ubyte_gt_int;
+  initial begin
+    bit a1;
+    int b1;
+    int a2;
+    longint b2;
+    bit a3;
+    longint b3;
+    byte sa;
+    int sb;
+    bit [7:0] ua;
+    int ub;
+
+    a1 = 1; b1 = 10;
+    bit_plus_int = a1 + b1;
+
+    a2 = 100; b2 = 1000;
+    int_plus_longint = a2 + b2;
+
+    a3 = 1; b3 = 1000;
+    bit_plus_longint = a3 + b3;
+
+    sa = -1;
+    sb = 100;
+    byte_lt_int = (sa < sb);
+    byte_gt_int = (sa > sb);
+
+    ua = 8'hFF;
+    ub = 100;
+    ubyte_lt_int = (ua < ub);
+    ubyte_gt_int = (ua > ub);
+  end
+endmodule

--- a/tests/cases/cpp/int_signed_compare_boundary/case.yaml
+++ b/tests/cases/cpp/int_signed_compare_boundary/case.yaml
@@ -1,0 +1,20 @@
+id: cpp.int_signed_compare_boundary
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    hi_lt: 1
+    hi_gt: 0
+    hi_eq: 0
+    neg_lt_zero: 1
+    neg_ge_zero: 0
+    min_lt_zero: 1
+    min_lt_max: 1
+    max_gt_zero: 1
+    allones_eq: 1
+    allones_ne_intmax: 1

--- a/tests/cases/cpp/int_signed_compare_boundary/main.sv
+++ b/tests/cases/cpp/int_signed_compare_boundary/main.sv
@@ -1,0 +1,37 @@
+module Top;
+  bit hi_lt;
+  bit hi_gt;
+  bit hi_eq;
+  bit neg_lt_zero;
+  bit neg_ge_zero;
+  bit min_lt_zero;
+  bit min_lt_max;
+  bit max_gt_zero;
+  bit allones_eq;
+  bit allones_ne_intmax;
+  initial begin
+    int a;
+    int b;
+
+    a = 32'h80000003;
+    b = 32'h00000003;
+    hi_lt = (a < b);
+    hi_gt = (a > b);
+    hi_eq = (a == b);
+
+    a = 32'h80000003;
+    neg_lt_zero = (a < 0);
+    neg_ge_zero = (a >= 0);
+
+    a = 32'h80000000;
+    b = 32'h7FFFFFFF;
+    min_lt_zero = (a < 0);
+    min_lt_max  = (a < b);
+    max_gt_zero = (b > 0);
+
+    a = 32'hFFFFFFFF;
+    b = 32'hFFFFFFFF;
+    allones_eq = (a == b);
+    allones_ne_intmax = (a != 32'h7FFFFFFF);
+  end
+endmodule

--- a/tests/cases/cpp/wide_integral_bitwise/case.yaml
+++ b/tests/cases/cpp/wide_integral_bitwise/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.wide_integral_bitwise
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    and_low: "128'hf"
+    or_low: "128'hff"
+    xor_low: "128'hf0"
+    not_zero: "128'hffffffffffffffffffffffffffffffff"
+    and_cross_word: "128'h0f0f0f0f000000000000000000000000"

--- a/tests/cases/cpp/wide_integral_bitwise/main.sv
+++ b/tests/cases/cpp/wide_integral_bitwise/main.sv
@@ -1,0 +1,30 @@
+module Top;
+  bit [127:0] and_low;
+  bit [127:0] or_low;
+  bit [127:0] xor_low;
+  bit [127:0] not_zero;
+  bit [127:0] and_cross_word;
+  initial begin
+    bit [127:0] a;
+    bit [127:0] b;
+
+    a = 128'd255;
+    b = 128'd15;
+    and_low = a & b;
+
+    a = 128'd240;
+    b = 128'd15;
+    or_low = a | b;
+
+    a = 128'd255;
+    b = 128'd15;
+    xor_low = a ^ b;
+
+    a = 128'd0;
+    not_zero = ~a;
+
+    a = 128'hFFFFFFFF_00000000_00000000_00000000;
+    b = 128'h0F0F0F0F_0F0F0F0F_0F0F0F0F_0F0F0F0F;
+    and_cross_word = a & b;
+  end
+endmodule

--- a/tests/cases/cpp/wide_integral_conversion/case.yaml
+++ b/tests/cases/cpp/wide_integral_conversion/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.wide_integral_conversion
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    wide_zero_ext: "128'h12345678"
+    wide_sign_ext: "128'shffffffffffffffffffffffffffffffff"
+    narrow_trunc: "32'h12345678"
+    narrow_signed: -1
+    longint_to_wide: "128'h123456789abcdef0"
+    longint_roundtrip: "64'h123456789abcdef0"

--- a/tests/cases/cpp/wide_integral_conversion/main.sv
+++ b/tests/cases/cpp/wide_integral_conversion/main.sv
@@ -1,0 +1,31 @@
+module Top;
+  bit [127:0] wide_zero_ext;
+  bit signed [127:0] wide_sign_ext;
+  int narrow_trunc;
+  int narrow_signed;
+  bit [127:0] longint_to_wide;
+  longint longint_roundtrip;
+  initial begin
+    int n_unsigned;
+    int n_signed;
+    bit [127:0] w_unsigned;
+    bit signed [127:0] w_signed;
+    longint l_in;
+
+    n_unsigned = 32'h12345678;
+    wide_zero_ext = n_unsigned;
+
+    n_signed = -1;
+    wide_sign_ext = n_signed;
+
+    w_unsigned = 128'hDEADBEEF_12345678;
+    narrow_trunc = w_unsigned;
+
+    w_signed = -1;
+    narrow_signed = w_signed;
+
+    l_in = 64'h123456789ABCDEF0;
+    longint_to_wide = l_in;
+    longint_roundtrip = longint_to_wide;
+  end
+endmodule

--- a/tests/cases/cpp/wide_integral_reduction/case.yaml
+++ b/tests/cases/cpp/wide_integral_reduction/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.wide_integral_reduction
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    xor_single_bit: 1
+    or_upper_word: 1
+    and_all_ones: 1

--- a/tests/cases/cpp/wide_integral_reduction/main.sv
+++ b/tests/cases/cpp/wide_integral_reduction/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  int xor_single_bit;
+  int or_upper_word;
+  int and_all_ones;
+  initial begin
+    bit [127:0] a;
+
+    a = 128'h1;
+    xor_single_bit = ^a;
+
+    a = 128'd1 << 64;
+    or_upper_word = |a;
+
+    a = ~128'd0;
+    and_all_ones = &a;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Closes the `integral.md` J14 archive sweep on the new architecture by backfilling the gaps existing tests do not cover, then rewrites all `docs/progress/*.md` files to a uniform status-tracking shape that no longer leaks implementation details.

The archive sweep itself adds five test directories. Survey-first pass ruled out cases that already shared a runtime code path with an existing test (signed vs unsigned shift on int, repeated 4-state truth-table cells against a word-parallel op); only the genuinely uncovered cells are added: signed-int comparison at the 32-bit boundary, cross-type binary operand promotion, cross-word bitwise on 128-bit, narrow <-> wide zero/sign-extend, and cross-word reduction. J14 is closed; `++` / `--` archive coverage is carved out as J19 with W12 (`operators.md`) as the dependency.

The progress-doc rewrite cuts roughly 50% of the prose across eight files. Sub-step descriptions used to call out class names, IR enum values, file paths, and runtime algorithm details, so any refactor on the implementation side required a sympathetic edit on the progress side. The rewrite restricts each entry to the user-visible feature, the LRM clause it implements, and any cross-workstream dependency. `operators.md` lost three quarters of its content because an embedded design doc (IR struct definitions, runtime API sketches, render rules, NBA-on-selector closure mechanics) was sitting in a progress file.

Each file now uses the same shape: short scope + done criterion, an Actionable table that distinguishes "ready" from "blocked on X", numbered sub-steps with stable IDs, and a cross-references block.