### PR TITLE
Unify event control with SensitivityWaitStmt pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ scratch/
 
 # Node.js (Prettier tooling). package-lock.json is committed for reproducibility.
 node_modules/
+
+# Claude Code runtime artifacts
+.claude/scheduled_tasks.lock

--- a/docs/decisions/event-control-unification.md
+++ b/docs/decisions/event-control-unification.md
@@ -1,0 +1,143 @@
+# Event Control Unification
+
+## Date
+
+2026-05-31
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+SystemVerilog has four constructs whose runtime behaviour is "subscribe to a value-change leaf set,
+suspend, wake when a relevant leaf changes":
+
+- `always_comb` / `always_latch` body (LRM 9.2.2.2.1)
+- `always @* body` (LRM 9.4.2.2)
+- `wait (cond) body` (LRM 9.4.3)
+- `@(expr) body`, including event-list forms `@(expr_1 or expr_2)` (LRM 9.4.2)
+
+Before this cut, the first three shared the `SensitivityWaitStmt` machinery introduced for the
+continuous-assignment unification (see [read-set-inference.md](read-set-inference.md)). `@(...)` had
+a parallel `EventControl` chain whose `EventTrigger.signal` was a single expression and whose
+runtime subscription was always at whole-variable granularity. The moment a selector or compound
+expression appeared inside `@(...)`, the chain rejected the form with
+`kUnsupportedEventTriggerForm`.
+
+The parallel chain was not a small wart. It blocked:
+
+- LRM 9.4.2 "edge event shall be detected only on the LSB of the expression" -- the runtime had no
+  per-leaf bit position to monitor, so even simple `@(posedge bus[3])` could not be implemented.
+- LRM 9.4.2 "no change in the result of the expression shall not be detected as an event" -- with
+  whole-variable subscription, a write to any bit of the variable woke every subscriber, including
+  ones whose projection had not changed. Performance regressed and behavioural correctness for
+  compound forms was unreachable.
+- Reuse of the slang DFA already feeding the other three constructs. The DFA produces a
+  `(symbol, bit_range)` leaf set for any expression; `@(...)` ignored that work and looked at the
+  source-form structurally instead.
+
+The right shape was to collapse the `@(...)` chain into the `SensitivityWaitStmt` shape, route the
+DFA at the event expression, and propagate edge polarity per leaf so the runtime can filter.
+
+## Decision
+
+Every value-change suspension in the simulator goes through one MIR construct,
+`mir::SensitivityWaitStmt`, whose `reads` carries per-leaf
+`(StructuralVarRef, bit_range, edge_kind)` records. `mir::EventControl` and `mir::EventTrigger` are
+deleted.
+
+Delay is a separate, parallel construct: `mir::DelayStmt { duration }` lowers from
+`hir::DelayControl` in `LowerTimedStmt`, wrapped in a `BlockStmt` together with the controlled body.
+`mir::TimingControl`, `mir::DelayControl`, and `mir::TimedStmt` are deleted -- they were
+syntax-grouped artifacts that combined two execution families (clock-anchored delay; data-anchored
+value-change) under one variant. MIR is execution-modelling, so the three wait families live at the
+same level as disjoint statements:
+
+| Family                | MIR construct                   | Engine subsystem         |
+| --------------------- | ------------------------------- | ------------------------ |
+| Time-anchored         | `DelayStmt { duration }`        | `Engine::ScheduleAtTime` |
+| Value-change anchored | `SensitivityWaitStmt { reads }` | `Observable::Subscribe`  |
+| Sync-primitive        | `ExprStmt { event.Await() }`    | `NamedEvent` waiter list |
+
+HIR keeps `hir::TimingControl` as a sum type because HIR is source-faithful and LRM 9.4 groups them
+syntactically.
+
+The shape is:
+
+```text
+leaves = list of (var, bit_range, edge_kind)
+  -- bit_range follows slang's `(lo, hi)` inclusive convention in the var's flat-storage space
+  -- edge_kind takes the SV edge identifier on the event expression for single-leaf forms;
+     defaults to kAnyChange for implicit sensitivity (always_comb / @* / wait / continuous-assign)
+subscribe(every leaf)
+suspend
+```
+
+The runtime extends `Trigger`, `Observable::Waiter`, and the `Observable::Subscribe` API to carry
+`(lsb_bit_offset, bit_width, edge)` per waiter. `WriteVar` on `Var<PackedArray>` snapshots
+`var.Get()` before the assignment, then invokes a per-leaf classifier that compares
+`old.ExtractBits(lsb, width)` against `new.ExtractBits(lsb, width)` for any-change waiters and
+`ClassifyEdge(old.GetBit(lsb), new.GetBit(lsb))` for edge waiters. The classifier is type-erased via
+`std::function`; the `Observable` itself stays value-type agnostic.
+
+At AST -> HIR, `LowerSignalEventTrigger`:
+
+1. Looks up the leaf set in `SensitivityReadStore` keyed by the event expression
+   (`SignalEventControl::expr`). The store builder runs a fresh `DefaultDFA` per event expression
+   from inside `setCustomDFAProvider`, mirroring the pattern already used for `wait` conds.
+2. Attaches the SV edge identifier to each leaf. For the single-leaf case (DFA returned exactly one
+   `(symbol, bit_range)` pair), the leaf's bit range is collapsed to `(lo, lo)` so the runtime
+   monitors only the LSB of the expression per LRM 9.4.2.
+3. Multi-leaf expressions (concatenation, arithmetic, dynamic index, cross-variable) are rejected
+   with `kUnsupportedEventTriggerForm` and a "compound event expressions ... are not yet supported"
+   message. The deferred implementation is a snapshot + re-eval loop at HIR -> MIR around a
+   `SensitivityWaitStmt` whose leaves carry `kAnyChange`. Both halves -- the wrapper and a runtime
+   `MatchesEdgeTransition` helper -- are intentionally left to a follow-up so this PR ships a
+   bounded slice.
+
+`mir::SensitivityRead.bit_range` retains slang's `(lo, hi)` convention end-to-end. Emit converts to
+the runtime's `(lsb, width)` shape at the call site (`width = hi - lo + 1`).
+
+## Consequences
+
+Closed under this PR:
+
+- Every existing `event_*`, `always_comb_*`, `wait_*`, `named_event_*` test continues to pass; the
+  named-event path is orthogonal to the unification.
+- New tests cover constant bit-select, range-select, indexed part-select (`+:` / `-:`), edge keyword
+  combinations, event-list with mixed bit-select members, and `LRM 9.4.2` "no false wake" anchors.
+
+Out of scope but unblocked by this design:
+
+- Compound event expressions: the snapshot + re-eval wrapper is the natural next step. The HIR
+  carries `EventTrigger.sensitivity_list` for every event expression, so the wrapper just needs to
+  iterate triggers, materialise per-trigger snapshot vars, and call the deferred edge helper.
+- Ascending / negative base packed ranges, multi-dim packed events, struct / unpacked event
+  triggers. Each is bounded by a separate workstream (PackedArray direction handling, multi-dim
+  initializer emit, type infrastructure).
+
+## Alternatives considered
+
+**Keep `EventControl` and add per-leaf metadata in parallel.** Rejected: the parallel chain
+duplicates the wait-suspension semantics already lived through `SensitivityWaitStmt` plus the slang
+DFA. Two shapes for one runtime behaviour is exactly the kind of seam we keep paying down.
+
+**Move LRM 9.4.2 LSB-reduce to runtime.** Rejected: the LRM rule is "edge events detect only the LSB
+of the expression". For a single-leaf event whose expression is `bus[hi:lo]` the LSB is statically
+the leaf's `lo`. Computing that at codegen time produces a runtime subscription with `width = 1`,
+which is both correct and cheap. Pushing it to runtime would require the runtime to know the
+expression's LSB semantics, which is a frontend concern.
+
+**Always emit a snapshot + re-eval loop even for simple single-leaf forms.** Rejected: per-leaf
+runtime filtering already produces LRM-correct wake decisions when the expression is a single leaf
+(its projection covers the full result). The snapshot loop is overhead in that case; the wrapper is
+only necessary when leaf changes don't entail an expression-level change. The HIR side does the
+classification cheaply by looking at `sensitivity_list.size()`.
+
+**Keep `mir::TimingControl` as a single-arm variant of `DelayControl`.** Rejected: a variant with
+one arm carries no polymorphism, only the historical shape of an abstraction that no longer applies.
+The LRM groups `#N`, `@(...)`, and `wait` syntactically because they share the
+procedural-timing-control grammar position; the engine treats them as three disjoint subsystems
+(time queue vs Observable subscription vs NamedEvent waiter list). MIR is execution-modelling, so it
+follows the execution split, not the syntactic one.

--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -150,9 +150,12 @@ synchronisation primitives (named events, `wait`, `fork`/`join_*`).
 
 - [x] processes/continuous_assign -- `processes.md` P7.
 - [x] processes/delay -- `processes.md` T1.
-- [ ] processes/edge_trigger_bit_select -- `processes.md` T3 (whole-variable subset, done) and T5
-      (selected subset, blocked).
-- [ ] processes/edge_trigger_dynamic -- `processes.md` T5.
+- [ ] processes/edge_trigger_bit_select -- `processes.md` T2..T5 cover constant bit-select /
+      range-select / indexed part-select on packed 1D types and event lists thereof. Multi-dim
+      packed, ascending / negative-base ranges, struct fields and unpacked elements are blocked on
+      separate workstreams (see `processes.md` Blocked).
+- [ ] processes/edge_trigger_dynamic -- blocked on compound-event snapshot + re-eval (see
+      `processes.md` Blocked).
 - [x] processes/event_triggers -- `processes.md` T2, T3, T4 cover the event-control surface;
       remaining named-event trigger lives in P9.
 - [x] processes/final_block -- `processes.md` P2.

--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -74,8 +74,8 @@ merged node.
       evaluated once and bits are distributed MSB-first, so `{a, b} = {b, a}` swaps. Parts may be
       any writable lvalue (including W6 selector chains, e.g. `{a[7:4], b[7:4]} = rhs`). NBA form
       requires every part to be a structural target. Replication operands are rejected per LRM
-      11.4.12.1. LRM 10.9 assignment-pattern LHS and LRM 11.4.14.3 streaming-unpack LHS are
-      separate constructs, both out of scope.
+      11.4.12.1. LRM 10.9 assignment-pattern LHS and LRM 11.4.14.3 streaming-unpack LHS are separate
+      constructs, both out of scope.
 
 ### Assignment families
 

--- a/docs/progress/packed.md
+++ b/docs/progress/packed.md
@@ -13,8 +13,8 @@ Done when:
 
 ## Actionable
 
-P3, P4, P5 are all open and ordered: P3 introduces packed-struct field access and unblocks P4
-(union field views ride on the same machinery); P5 builds assignment patterns on top.
+P3, P4, P5 are all open and ordered: P3 introduces packed-struct field access and unblocks P4 (union
+field views ride on the same machinery); P5 builds assignment patterns on top.
 
 | Item | Status                                                    |
 | ---- | --------------------------------------------------------- |

--- a/docs/progress/processes.md
+++ b/docs/progress/processes.md
@@ -12,11 +12,13 @@ machinery owned by other workstreams; see [Blocked](#blocked).
 
 ## Blocked
 
-| Item | Blocked on                                                                                                       |
-| ---- | ---------------------------------------------------------------------------------------------------------------- |
-| T5   | Bit-select / range-select edge triggers; needs the selector machinery from `operators.md` W4 / W5.               |
-| P8   | `fork` / `join_*`. Needs concurrent-process scheduling primitives; out of scope until single-process is settled. |
-| P12  | Process generate; rides on the existing P1..P11 surface, mostly frontend elaboration.                            |
+| Item   | Blocked on                                                                                                                                                            |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P8     | `fork` / `join_*`. Needs concurrent-process scheduling primitives; out of scope until single-process work is settled.                                                 |
+| P12    | Process generate; rides on the existing P1..P11 surface, mostly frontend elaboration.                                                                                 |
+| T2..T5 | Compound event expressions (concatenation, arithmetic, dynamic index): needs the snapshot + re-eval wrapper at HIR -> MIR plus a runtime edge-classifier helper.      |
+| T2..T5 | Ascending / negative-base packed ranges (`logic [0:7]`, `logic [-1:6]`): runtime `PackedArray::ElementAt` does not yet honor LRM direction translation on write side. |
+| T2..T5 | Multi-dim packed events (`logic [1:0][7:0] bus; @(bus[1])`): emit of the dim-stack initializer for multi-dim packed variables is broken.                              |
 
 ## Sub-Steps
 
@@ -49,16 +51,20 @@ machinery owned by other workstreams; see [Blocked](#blocked).
 
 - [x] T1 -- Delay control `#N` (LRM 9.4.1). Engine schedules the suspended coroutine onto the
       delayed queue.
-- [x] T2 -- Event control `@(x)` any-change. Compares old vs new on each write and notifies on any
-      inequality.
-- [x] T3 -- Event control edge polarity `@(posedge clk)` / `@(negedge clk)` / `@(edge clk)` (LRM
-      Table 9-2). Full 4-state transition table: posedge fires on 0 -> {1, x, z} and {x, z} -> 1;
-      negedge fires on 1 -> {0, x, z} and {x, z} -> 0; x <-> z is a change-only event. `edge`
-      keyword matches either direction.
-- [x] T4 -- Event control event lists `@(posedge clk or negedge rst_n)` and comma form. The runtime
-      races the triggers and re-arms whichever signal won the wake-up.
-- [ ] T5 -- Edge trigger on bit-select / range-select (`@(posedge bus[2])`). **Depends on**
-      `operators.md` W4 / W5.
+- [x] T2..T5 -- Event control `@(...)` across all `expression`, `posedge`, `negedge`, `edge` forms,
+      including bit-select (`bus[N]`), range-select (`bus[hi:lo]`), and indexed part-select
+      (`bus[base +: w]` / `bus[base -: w]`) on packed types, plus event-list (`or` / `,`) of any of
+      the above. The pipeline routes every value-change wait (always_comb body, `@*`, `wait (cond)`,
+      `@(...)`) through `mir::SensitivityWaitStmt` carrying per-leaf `(var, bit_range, edge_kind)`
+      records; slang's flow analysis computes the leaves and the AST -> HIR lowering attaches the SV
+      edge identifier (with LRM 9.4.2 LSB-reduce for edge-qualified single-leaf expressions).
+      Runtime per-leaf classification samples each waiter's projection on every `WriteVar`, so
+      changes outside the projection do not cause spurious wakes (LRM 9.4.2 "no change in result"
+      rule). `ClassifyEdge` covers the LRM Table 9-2 4-state transition matrix; `kBothEdges` matches
+      either posedge or negedge. Covers `processes/event_triggers` and
+      `processes/edge_trigger_bit_select` for the packed-vector, constant-selector, single-leaf
+      subset. Compound expressions (concatenation, arithmetic, dynamic index) and base ranges with
+      ascending or negative bounds remain rejected -- see Blocked.
 
 ### Synchronisation primitives
 

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -150,24 +150,33 @@ enum class EventEdge : std::uint8_t {
   kBothEdges,
 };
 
+// One leaf entry of a wait's projection set. Identity-only: which structural
+// variable, which flat bit range of its packed encoding, and what edge
+// polarity the leaf was subscribed under. Implicit sensitivity sources
+// (always_comb / always_latch / `@*` / wait cond / continuous assignment)
+// supply leaves with `edge_kind == kAnyChange`. Explicit event control
+// `@(posedge ...)` / `@(negedge ...)` / `@(edge ...)` set the per-leaf edge.
+struct SensitivityEntry {
+  StructuralVarRef ref;
+  std::pair<std::uint64_t, std::uint64_t> bit_range;
+  EventEdge edge_kind = EventEdge::kAnyChange;
+};
+
+// One entry of an explicit `@(...)` event control. `signal` is the SV
+// expression being monitored; `edge` is the optional edge identifier; the
+// per-leaf `sensitivity_list` is the read set of `signal` (slang DFA) used
+// for subscription. For a compound expression (concat / arithmetic / dynamic
+// index) the leaves are over-broad relative to "fire only when the result
+// changes" -- HIR -> MIR builds a snapshot + re-eval loop around the leaf
+// wait that enforces LRM 9.4.2 correctness.
 struct EventTrigger {
   ExprId signal;
   EventEdge edge;
+  std::vector<SensitivityEntry> sensitivity_list;
 };
 
 struct EventControl {
   std::vector<EventTrigger> triggers;
-};
-
-// One entry of an implicit sensitivity list (LRM 9.2.2.2.1 for always_comb /
-// always_latch; 9.4.2.2 for `@*`; 9.4.3 for `wait (expr)`). Identity-only:
-// which structural variable, which flat bit range of its packed encoding.
-// The current runtime collapses to whole-variable subscription at HIR ->
-// MIR; bit_range is preserved here so the collapse can be lifted once the
-// runtime gains bit-level Observable.
-struct SensitivityEntry {
-  StructuralVarRef ref;
-  std::pair<std::uint64_t, std::uint64_t> bit_range;
 };
 
 // LRM 9.4.2.2 `@*` / `@(*)`. Sensitivity for the controlled body is

--- a/include/lyra/lowering/ast_to_hir/facts.hpp
+++ b/include/lyra/lowering/ast_to_hir/facts.hpp
@@ -12,8 +12,9 @@ class UnitLoweringFacts {
  public:
   UnitLoweringFacts(
       const frontend::SlangSourceMapper& source_mapper,
-      const SensitivityReadStore& sensitivity_reads)
-      : source_mapper_(&source_mapper), sensitivity_reads_(&sensitivity_reads) {
+      SensitivityAnalyzer& sensitivity_analyzer)
+      : source_mapper_(&source_mapper),
+        sensitivity_analyzer_(&sensitivity_analyzer) {
   }
 
   [[nodiscard]] auto SourceMapper() const
@@ -21,13 +22,13 @@ class UnitLoweringFacts {
     return *source_mapper_;
   }
 
-  [[nodiscard]] auto SensitivityReads() const -> const SensitivityReadStore& {
-    return *sensitivity_reads_;
+  [[nodiscard]] auto Sensitivity() const -> SensitivityAnalyzer& {
+    return *sensitivity_analyzer_;
   }
 
  private:
   const frontend::SlangSourceMapper* source_mapper_;
-  const SensitivityReadStore* sensitivity_reads_;
+  SensitivityAnalyzer* sensitivity_analyzer_;
 };
 
 class ScopeLoweringFacts {

--- a/include/lyra/lowering/ast_to_hir/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/lower.hpp
@@ -14,10 +14,10 @@ class LowerCompilationFacts {
   LowerCompilationFacts(
       slang::ast::Compilation& compilation,
       const frontend::SlangSourceMapper& source_mapper,
-      const SensitivityReadStore& sensitivity_reads)
+      SensitivityAnalyzer& sensitivity_analyzer)
       : compilation_(&compilation),
         source_mapper_(&source_mapper),
-        sensitivity_reads_(&sensitivity_reads) {
+        sensitivity_analyzer_(&sensitivity_analyzer) {
   }
 
   [[nodiscard]] auto Compilation() const -> slang::ast::Compilation& {
@@ -27,14 +27,14 @@ class LowerCompilationFacts {
       -> const frontend::SlangSourceMapper& {
     return *source_mapper_;
   }
-  [[nodiscard]] auto SensitivityReads() const -> const SensitivityReadStore& {
-    return *sensitivity_reads_;
+  [[nodiscard]] auto Sensitivity() const -> SensitivityAnalyzer& {
+    return *sensitivity_analyzer_;
   }
 
  private:
   slang::ast::Compilation* compilation_;
   const frontend::SlangSourceMapper* source_mapper_;
-  const SensitivityReadStore* sensitivity_reads_;
+  SensitivityAnalyzer* sensitivity_analyzer_;
 };
 
 auto LowerCompilation(const LowerCompilationFacts& facts)

--- a/include/lyra/lowering/ast_to_hir/sensitivity.hpp
+++ b/include/lyra/lowering/ast_to_hir/sensitivity.hpp
@@ -1,16 +1,22 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "lyra/hir/stmt.hpp"
 
+namespace slang::analysis {
+class AnalysisContext;
+class AnalysisManager;
+}  // namespace slang::analysis
+
 namespace slang::ast {
-class Compilation;
 class Expression;
 class Statement;
+class Symbol;
 class ValueSymbol;
 }  // namespace slang::ast
 
@@ -19,77 +25,61 @@ namespace lyra::lowering::ast_to_hir {
 class ScopeStack;
 class UnitLoweringState;
 
-// Mirrors slang's ReadRange. Multiple entries for the same symbol with
-// disjoint bit ranges are kept as-is so downstream can preserve precision
-// when the runtime supports bit-level subscription.
+// One leaf read produced by `SensitivityAnalyzer`.
 struct SensitivityRead {
   const slang::ast::ValueSymbol* symbol;
   std::pair<std::uint64_t, std::uint64_t> bit_range;
 };
 
-// Precomputed sensitivity reads, harvested by driving slang's flow analysis
-// from `setCustomDFAProvider` + `addListener`. See
-// `docs/decisions/read-set-inference.md` for the architecture rationale.
+// Reports every value read inside an arbitrary `slang::ast::Expression` or
+// `slang::ast::Statement`. The analyzer is intentionally generic -- it does
+// not know what feature is asking, and it does not filter out reads of
+// locally-declared symbols. LRM-specific transformations on top of the raw
+// read set (e.g. LRM 9.2.2.2.1 procedure-body sensitivity, which excludes
+// locals) live at the layer that knows about the construct, not here.
 //
-// Two keying dimensions matching slang's two analyzable AST hierarchies:
-//   - `Statement` keys: the whole-statement read set produced by analyzing
-//     a procedure body. always_comb / always_latch (LRM 9.2.2.2.1) and `@*`
-//     regions (LRM 9.4.2.2) live here.
-//   - `Expression` keys: the read set produced by analyzing one expression
-//     subtree. `wait (cond)` (LRM 9.4.3), continuous-assignment
-//     `AssignmentExpression` (LRM 10.3), future `wait_order` event-list
-//     expressions, and future property / assertion expressions live here.
+// `containing_symbol` is a slang plumbing requirement: slang's flow analysis
+// builds a name-lookup `EvalContext` from `symbol.getParentScope()`, so the
+// analyzer needs any symbol whose parent scope covers the analyzed node.
+// The choice of symbol does not change the returned read set; pass whatever
+// symbol the caller already has on hand to wrap the node (a `ProceduralBlock`
+// for waits inside a procedure, a `ContinuousAssignSymbol` for an `assign`
+// rhs, and so on).
 //
-// The store routes internally via overloaded `Insert` / `Lookup` -- callers
-// pass whatever AST handle they have. The two buckets exist because slang's
-// `Statement` and `Expression` are disjoint hierarchies; a single map key
-// type would require losing type safety.
-class SensitivityReadStore {
+// Results are cached, so repeated queries on the same AST pointer are free.
+class SensitivityAnalyzer {
  public:
-  void Insert(
-      const slang::ast::Statement& stmt, std::vector<SensitivityRead> reads) {
-    by_statement_.emplace(&stmt, std::move(reads));
-  }
-  void Insert(
-      const slang::ast::Expression& expr, std::vector<SensitivityRead> reads) {
-    by_expression_.emplace(&expr, std::move(reads));
-  }
+  SensitivityAnalyzer();
+  ~SensitivityAnalyzer();
 
-  // Lookup returns nullptr if no reads have been recorded for the given key.
-  // Empty result is legal -- the lowering side interprets it as "no
-  // sensitivity", which materialises as a `SensitivityWaitStmt` with an
-  // empty list (i.e. wait forever).
-  [[nodiscard]] auto Lookup(const slang::ast::Statement& stmt) const
-      -> const std::vector<SensitivityRead>* {
-    const auto it = by_statement_.find(&stmt);
-    return it == by_statement_.end() ? nullptr : &it->second;
-  }
-  [[nodiscard]] auto Lookup(const slang::ast::Expression& expr) const
-      -> const std::vector<SensitivityRead>* {
-    const auto it = by_expression_.find(&expr);
-    return it == by_expression_.end() ? nullptr : &it->second;
-  }
+  SensitivityAnalyzer(const SensitivityAnalyzer&) = delete;
+  auto operator=(const SensitivityAnalyzer&) -> SensitivityAnalyzer& = delete;
+  SensitivityAnalyzer(SensitivityAnalyzer&&) noexcept;
+  auto operator=(SensitivityAnalyzer&&) noexcept -> SensitivityAnalyzer&;
+
+  [[nodiscard]] auto AnalyzeReads(
+      const slang::ast::Expression& expr,
+      const slang::ast::Symbol& containing_symbol)
+      -> const std::vector<SensitivityRead>&;
+
+  [[nodiscard]] auto AnalyzeReads(
+      const slang::ast::Statement& stmt,
+      const slang::ast::Symbol& containing_symbol)
+      -> const std::vector<SensitivityRead>&;
 
  private:
-  std::unordered_map<const slang::ast::Statement*, std::vector<SensitivityRead>>
-      by_statement_;
+  std::unique_ptr<slang::analysis::AnalysisManager> manager_;
+  std::unique_ptr<slang::analysis::AnalysisContext> context_;
   std::unordered_map<
       const slang::ast::Expression*, std::vector<SensitivityRead>>
-      by_expression_;
+      expression_cache_;
+  std::unordered_map<const slang::ast::Statement*, std::vector<SensitivityRead>>
+      statement_cache_;
 };
 
-// Drives slang's flow analysis over `compilation` and produces the
-// sensitivity store the AST -> HIR lowering will look up against. See
-// `docs/decisions/read-set-inference.md`.
-auto BuildSensitivityReadStore(slang::ast::Compilation& compilation)
-    -> SensitivityReadStore;
-
-// Translates the slang-side read vector (ValueSymbol* + bit_range) into
-// HIR-side identity entries (StructuralVarRef + bit_range), resolving each
-// symbol through the unit's structural binding table and the active scope
-// stack. Reads that don't resolve to a visible structural variable are
-// silently skipped -- slang may surface reads whose home scope was not
-// elaborated into HIR (e.g. ports of an instance the caller is not in).
+// Translates slang-side reads to HIR `SensitivityEntry`s. Reads whose symbol
+// has no visible structural binding (e.g. ports of an instance the caller is
+// not in) are silently skipped.
 auto TranslateSensitivityReads(
     const std::vector<SensitivityRead>& reads,
     const UnitLoweringState& unit_state, const ScopeStack& stack)

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -351,6 +351,18 @@ class ScopeLoweringState {
 
 class ProcessLoweringState {
  public:
+  // `containing_symbol` is the slang symbol whose AST subtree this process
+  // belongs to (a `ProceduralBlockSymbol` for `initial` / `always*`, the
+  // `ContinuousAssignSymbol` when reused for continuous-assignment lowering,
+  // etc.). Threaded into `SensitivityAnalyzer` as its name-lookup anchor.
+  explicit ProcessLoweringState(const slang::ast::Symbol& containing_symbol)
+      : containing_symbol_(&containing_symbol) {
+  }
+
+  [[nodiscard]] auto ContainingSymbol() const -> const slang::ast::Symbol& {
+    return *containing_symbol_;
+  }
+
   auto AddExpr(hir::Expr expr) -> hir::ExprId {
     const hir::ExprId id{static_cast<std::uint32_t>(hir_process_.exprs.size())};
     hir_process_.exprs.push_back(std::move(expr));
@@ -405,6 +417,7 @@ class ProcessLoweringState {
   hir::Process hir_process_;
   std::unordered_map<const slang::ast::VariableSymbol*, hir::ProceduralVarId>
       procedural_var_bindings_;
+  const slang::ast::Symbol* containing_symbol_;
 };
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -92,10 +92,6 @@ struct ForStmt {
   ProceduralScopeId scope;
 };
 
-struct DelayControl {
-  SimDuration duration;
-};
-
 enum class EventEdge : std::uint8_t {
   kAnyChange,
   kPosedge,
@@ -103,20 +99,14 @@ enum class EventEdge : std::uint8_t {
   kBothEdges,
 };
 
-struct EventTrigger {
-  ExprId signal;
-  EventEdge edge;
-};
-
-struct EventControl {
-  std::vector<EventTrigger> triggers;
-};
-
-using TimingControl = std::variant<DelayControl, EventControl>;
-
-struct TimedStmt {
-  TimingControl timing;
-  StmtId stmt;
+// LRM 9.4.1 `#N`. A time-anchored suspension: the engine schedules the next
+// resume at `now + duration`. Standalone -- the controlled body (if any) is
+// a separate statement in the enclosing block. Disjoint from the value-change
+// suspension family (`SensitivityWaitStmt`) and the named-event method-call
+// family: those are data-dependency anchored, this one is clock anchored.
+// See `docs/decisions/event-control-unification.md` for the rationale.
+struct DelayStmt {
+  SimDuration duration;
 };
 
 struct WhileStmt {
@@ -133,14 +123,15 @@ struct BreakStmt {};
 
 struct ContinueStmt {};
 
-// One entry of the LRM 9.2.2.2.1 implicit sensitivity list. Identity-only:
-// which structural variable, which flat bit range of its packed encoding.
-// Distinct from EventTrigger by design -- EventTrigger carries an expression
-// (explicit `@(...)`); SensitivityRead carries identity (slang DFA result,
-// never reassembled into an expression).
+// One leaf entry of a wait's projection set. Identity-only: which structural
+// variable, which flat bit range of its packed encoding, and what edge
+// polarity the leaf was subscribed under (LRM 9.4.2 / 9.4.2.2 / 9.4.3). slang
+// DFA produces the (var, bit_range) pairs; the SV edge identifier (or
+// `kAnyChange` for implicit sensitivity) attaches per leaf at AST lowering.
 struct SensitivityRead {
   StructuralVarRef ref;
   std::pair<std::uint64_t, std::uint64_t> bit_range;
+  EventEdge edge_kind = EventEdge::kAnyChange;
 };
 
 // Suspends the enclosing process until any signal in `reads` changes. Lowered
@@ -153,7 +144,7 @@ struct SensitivityWaitStmt {
 
 using StmtData = std::variant<
     EmptyStmt, ProceduralVarDeclStmt, ExprStmt, BlockStmt, IfStmt,
-    ConstructOwnedObjectStmt, ForStmt, TimedStmt, WhileStmt, DoWhileStmt,
+    ConstructOwnedObjectStmt, ForStmt, DelayStmt, WhileStmt, DoWhileStmt,
     BreakStmt, ContinueStmt, SensitivityWaitStmt>;
 
 struct Stmt {

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -14,13 +14,13 @@
 #include "lyra/runtime/runtime_scope.hpp"
 #include "lyra/runtime/runtime_services.hpp"
 #include "lyra/runtime/stream_dispatcher.hpp"
+#include "lyra/runtime/trigger.hpp"
 
 namespace lyra::runtime {
 
 class Module;
 class Observable;
 class RuntimeProcess;
-enum class EdgeTransition : std::uint8_t;
 
 enum class SchedulerPhase : std::uint8_t {
   kIdle,
@@ -67,7 +67,8 @@ class Engine {
 
   void SubmitNba(std::function<void()> closure);
 
-  void TriggerValueChange(Observable& observable, EdgeTransition transition);
+  void TriggerValueChange(
+      Observable& observable, const EdgeClassifier& classify);
 
   // Generic primitives exposed to runtime data types and awaitables so they
   // can manage their own producer/consumer wiring without the engine needing

--- a/include/lyra/runtime/runtime_services.hpp
+++ b/include/lyra/runtime/runtime_services.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <cstdint>
 #include <functional>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/time.hpp"
+#include "lyra/runtime/trigger.hpp"
 
 namespace lyra::runtime {
 
@@ -13,7 +13,6 @@ class DiagnosticDispatcher;
 class Engine;
 class Observable;
 class RuntimeProcess;
-enum class EdgeTransition : std::uint8_t;
 
 class RuntimeServices {
  public:
@@ -39,7 +38,8 @@ class RuntimeServices {
 
   void SubmitNba(std::function<void()> closure);
 
-  void TriggerValueChange(Observable& observable, EdgeTransition transition);
+  void TriggerValueChange(
+      Observable& observable, const EdgeClassifier& classify);
 
   // Generic forwarders to Engine primitives used by runtime data types
   // (NamedEvent, etc.) and by every awaitable's `await_suspend` so they

--- a/include/lyra/runtime/trigger.hpp
+++ b/include/lyra/runtime/trigger.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 
 namespace lyra::runtime {
 
@@ -15,12 +16,28 @@ enum class Edge : std::uint8_t {
   kBothEdges,
 };
 
-// One observable + the edge polarity the waiter cares about. Multiple
-// Triggers in a single `EventControlAwaitable` model an event list
-// `@(a or posedge b)`; the process resumes when any matches.
+// One leaf subscription on a single `Observable`. The projection is described
+// by `(lsb_bit_offset, bit_width)` in the observable's flat-bit address space.
+// `bit_width == 0` is a "whole var" sentinel: any-change subscriptions fire on
+// any write, and edge subscriptions sample bit 0 (LRM 9.4.2 LSB rule on a
+// whole-var expression). For explicit projections (bit-select, range-select,
+// LRM 9.4.2 LSB-reduced edge), `bit_width` is the projection's actual width.
+//
+// Multiple Triggers in a single `EventControlAwaitable` model an event-list
+// `@(a or posedge b[3])` or a multi-leaf expression `@({clk_a, clk_b})`; the
+// process resumes when any leaf passes its per-leaf classifier.
 struct Trigger {
   Observable* observable = nullptr;
   Edge edge = Edge::kAnyChange;
+  std::uint64_t lsb_bit_offset = 0;
+  std::uint64_t bit_width = 0;
 };
+
+// Per-leaf fire decision: receives a waiter's `(lsb_bit_offset, bit_width,
+// edge)` and returns whether to wake it. The caller (the producer of the
+// value change -- typically `WriteVar` on `Var<PackedArray>`) captures the
+// value context (old/new) so the `Observable` stays value-type agnostic.
+using EdgeClassifier =
+    std::function<bool(std::uint64_t lsb, std::uint64_t width, Edge edge)>;
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -80,8 +80,15 @@ class Observable {
   auto operator=(Observable&&) -> Observable& = delete;
   ~Observable() = default;
 
-  void Subscribe(RuntimeProcess& p, Edge edge) {
-    waiters_.push_back(Waiter{.process = &p, .edge = edge});
+  void Subscribe(
+      RuntimeProcess& p, Edge edge, std::uint64_t lsb_bit_offset,
+      std::uint64_t bit_width) {
+    waiters_.push_back(
+        Waiter{
+            .process = &p,
+            .edge = edge,
+            .lsb_bit_offset = lsb_bit_offset,
+            .bit_width = bit_width});
   }
 
   // Idempotent: a no-op if `p` is not currently subscribed. Used to clean up
@@ -90,13 +97,15 @@ class Observable {
     std::erase_if(waiters_, [&](const Waiter& w) { return w.process == &p; });
   }
 
-  // Removes and returns the processes whose subscribed Edge matches the
-  // transition that just occurred. Non-matching waiters stay subscribed.
-  [[nodiscard]] auto TakeMatchingWaiters(EdgeTransition transition)
+  // Removes and returns the processes whose per-waiter classifier returns
+  // true. Non-matching waiters stay subscribed. The classifier receives each
+  // waiter's projection and edge and decides based on context the caller
+  // (WriteVar) captured (old/new value).
+  [[nodiscard]] auto TakeMatchingWaiters(const EdgeClassifier& classify)
       -> std::vector<RuntimeProcess*> {
     std::vector<RuntimeProcess*> out;
     auto keep_begin = std::ranges::partition(waiters_, [&](const Waiter& w) {
-                        return !EdgeMatches(w.edge, transition);
+                        return !classify(w.lsb_bit_offset, w.bit_width, w.edge);
                       }).begin();
     out.reserve(static_cast<std::size_t>(waiters_.end() - keep_begin));
     for (auto it = keep_begin; it != waiters_.end(); ++it) {
@@ -110,6 +119,8 @@ class Observable {
   struct Waiter {
     RuntimeProcess* process;
     Edge edge;
+    std::uint64_t lsb_bit_offset;
+    std::uint64_t bit_width;
   };
   std::vector<Waiter> waiters_;
 };
@@ -198,7 +209,8 @@ class EventControlAwaitable {
             "EventControlAwaitable::await_suspend: observable pointer is "
             "null");
       }
-      trigger.observable->Subscribe(process, trigger.edge);
+      trigger.observable->Subscribe(
+          process, trigger.edge, trigger.lsb_bit_offset, trigger.bit_width);
       subs.push_back(trigger.observable);
     }
     process.SetPendingValueChangeSubscriptions(std::move(subs));
@@ -216,35 +228,58 @@ inline auto WaitAny(std::initializer_list<Trigger> triggers)
   return EventControlAwaitable{std::vector<Trigger>(triggers)};
 }
 
+// Builds the per-leaf classifier that the Observable invokes per waiter.
+// For any-change waiters: compares the projected slice in `old` and `new` (or
+// fires unconditionally when the waiter is whole-var, `bit_width == 0`).
+// For edge waiters: classifies the transition at `lsb_bit_offset` (LRM Table
+// 9-2 via `ClassifyEdge`), then matches against the subscribed edge.
+inline auto MakePackedArrayEdgeClassifier(
+    const value::PackedArray& old_val, const value::PackedArray& new_val)
+    -> EdgeClassifier {
+  return [&old_val, &new_val](
+             std::uint64_t lsb, std::uint64_t width, Edge edge) -> bool {
+    if (edge == Edge::kAnyChange) {
+      if (width == 0U) {
+        return true;
+      }
+      const auto lsb_arg = value::PackedArray::FromInt(
+          static_cast<std::int64_t>(lsb), 64U, false, false);
+      const auto old_slice =
+          old_val.ExtractBits(lsb_arg, static_cast<std::uint32_t>(width));
+      const auto new_slice =
+          new_val.ExtractBits(lsb_arg, static_cast<std::uint32_t>(width));
+      return !old_slice.IsCaseEqual(new_slice);
+    }
+    const value::FourStateBit old_bit =
+        (width == 0U) ? old_val.Lsb() : old_val.GetBit(lsb);
+    const value::FourStateBit new_bit =
+        (width == 0U) ? new_val.Lsb() : new_val.GetBit(lsb);
+    return EdgeMatches(edge, ClassifyEdge(old_bit, new_bit));
+  };
+}
+
 template <CaseEqualComparable T>
 inline void WriteVar(RuntimeServices& services, Var<T>& var, const T& new_val) {
-  const value::FourStateBit old_lsb = var.Get().Lsb();
-  const value::FourStateBit new_lsb = new_val.Lsb();
   if (var.AssignIfChanged(new_val)) {
-    services.TriggerValueChange(var, ClassifyEdge(old_lsb, new_lsb));
+    services.TriggerValueChange(
+        var, [](std::uint64_t, std::uint64_t, Edge edge) -> bool {
+          return edge == Edge::kAnyChange;
+        });
   }
 }
 
-// Non-template overload for the common Var<PackedArray> case. Template
-// deduction would otherwise miss `PackedArrayRef` arguments (the explicit
-// conversion does not participate in implicit conversion sequences).
+// Non-template overload for the common Var<PackedArray> case. Required
+// because template deduction would otherwise fail when emit passes a freshly
+// cloned `PackedArray` rvalue (the template `T` cannot be deduced from
+// `Var<T>` and `PackedArray` together).
 inline void WriteVar(
     RuntimeServices& services, Var<value::PackedArray>& var,
     const value::PackedArray& new_val) {
-  const value::FourStateBit old_lsb = var.Get().Lsb();
-  const value::FourStateBit new_lsb = new_val.Lsb();
+  const value::PackedArray old_val = var.Get();
   if (var.AssignIfChanged(new_val)) {
-    services.TriggerValueChange(var, ClassifyEdge(old_lsb, new_lsb));
+    services.TriggerValueChange(
+        var, MakePackedArrayEdgeClassifier(old_val, new_val));
   }
-}
-
-// Emit may produce a `PackedArrayRef` rvalue when the source expression is a
-// chain over a mutable PackedArray. Materialize via the explicit conversion
-// (direct-init) before forwarding to the value overload.
-inline void WriteVar(
-    RuntimeServices& services, Var<value::PackedArray>& var,
-    const value::PackedArrayRef& new_val) {
-  WriteVar(services, var, value::PackedArray(new_val));
 }
 
 // RAII handle that owns a snapshot of `var.Get()` for the lifetime of one

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -151,9 +151,21 @@ class PackedArray {
   // posedge, 1/x/z to 0 negedge).
   [[nodiscard]] auto Lsb() const -> FourStateBit;
 
+  // Returns one bit at the flat-storage offset, encoded as a 4-state code.
+  // Used by the runtime's per-leaf edge classifier to sample the bit a waiter
+  // projected onto. LRM 11.5.1 OOB rule applies: a position outside `[0,
+  // BitWidth())` reads as X for 4-state and 0 for 2-state.
+  [[nodiscard]] auto GetBit(std::uint64_t flat_offset) const -> FourStateBit;
+
   // LRM 11.4.5 `===` operator form (1-bit PackedArray); `==` returns 4-state
   // and propagates X, this returns deterministic 0 or 1.
   [[nodiscard]] auto CaseEqual(const PackedArray& other) const -> PackedArray;
+
+  // Mirror of `PackedArrayRef::Clone`. A chain that ends on a const path
+  // (e.g. `var.Get().Slice(...)`) materializes to `PackedArray` directly, so
+  // the emit-side `.Clone()` wrap needs to compile on both sides; here it is
+  // just an explicit copy.
+  [[nodiscard]] auto Clone() const -> PackedArray { return *this; }
 
   // Word-level access for `RuntimeValueView` construction and intra-runtime
   // interop. The spans alias the PackedArray's storage and stay valid for
@@ -388,30 +400,23 @@ class PackedArrayRef {
       PackedArray& root, const PackedArray& bit_offset, std::uint32_t bit_width,
       std::vector<PackedRange> dims);
 
-  PackedArrayRef(const PackedArrayRef&) = default;
-  PackedArrayRef(PackedArrayRef&&) = default;
+  // Move-only: a ref aliases its root by raw pointer, so duplicating the
+  // handle and outliving the source would dangle. Moves are fine because the
+  // descriptor is just relocated. Chain composition relies on RVO / move.
+  PackedArrayRef(const PackedArrayRef&) = delete;
+  auto operator=(const PackedArrayRef&) -> PackedArrayRef& = delete;
+  PackedArrayRef(PackedArrayRef&&) noexcept = default;
+  auto operator=(PackedArrayRef&&) noexcept -> PackedArrayRef& = default;
   ~PackedArrayRef() = default;
 
-  // Read-side: materialize the sub-slice. Explicit so a chain expression
-  // does not silently decay to a PackedArray value in unrelated contexts;
-  // callers wrap with `PackedArray(ref)` (direct-init) when they need a
-  // materialized value.
-  [[nodiscard]] explicit operator PackedArray() const;
+  // Allocate an independent `PackedArray` holding the bits this view
+  // currently projects. There is no implicit conversion from ref to value;
+  // every materialization is spelled `.Clone()` so the allocation cost is
+  // visible at the call site.
+  [[nodiscard]] auto Clone() const -> PackedArray;
 
   // Write-side: route through AssignSlice on root.
   auto operator=(const PackedArray& value) -> PackedArrayRef&;
-
-  // Without these, `lhs_ref = rhs_ref` would resolve to the implicitly
-  // generated copy / move assignment, which rebinds the lhs's bookkeeping
-  // pointers instead of writing through the proxy -- silently wrong. Both
-  // forms materialize the rhs and forward to the value-taking overload so
-  // the chain writes through `AssignSlice` as intended.
-  auto operator=(const PackedArrayRef& value) -> PackedArrayRef& {
-    return *this = PackedArray(value);
-  }
-  auto operator=(PackedArrayRef&& value) noexcept -> PackedArrayRef& {
-    return *this = PackedArray(value);
-  }
 
   // LRM 11.4 compound assignments. Read the current sub-slice once, combine
   // with `rhs` (frontend converts rhs to lhs.type), write back through
@@ -420,37 +425,37 @@ class PackedArrayRef {
   // caller, the proxy captures the position, and both the read and write
   // here use that same position with no re-evaluation of indices.
   auto operator+=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = PackedArray(*this) + rhs;
+    return *this = Clone() + rhs;
   }
   auto operator-=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = PackedArray(*this) - rhs;
+    return *this = Clone() - rhs;
   }
   auto operator*=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = PackedArray(*this) * rhs;
+    return *this = Clone() * rhs;
   }
   auto operator/=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = PackedArray(*this) / rhs;
+    return *this = Clone() / rhs;
   }
   auto operator%=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = PackedArray(*this) % rhs;
+    return *this = Clone() % rhs;
   }
   auto operator&=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = PackedArray(*this) & rhs;
+    return *this = Clone() & rhs;
   }
   auto operator|=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = PackedArray(*this) | rhs;
+    return *this = Clone() | rhs;
   }
   auto operator^=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = PackedArray(*this) ^ rhs;
+    return *this = Clone() ^ rhs;
   }
   auto ShiftLeftAssign(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = PackedArray(*this).ShiftLeft(rhs);
+    return *this = Clone().ShiftLeft(rhs);
   }
   auto LogicalShiftRightAssign(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = PackedArray(*this).LogicalShiftRight(rhs);
+    return *this = Clone().LogicalShiftRight(rhs);
   }
   auto ArithmeticShiftRightAssign(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = PackedArray(*this).ArithmeticShiftRight(rhs);
+    return *this = Clone().ArithmeticShiftRight(rhs);
   }
 
   // Chain composition. Positions are in the current sub-view's outer-element

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -165,7 +165,9 @@ class PackedArray {
   // (e.g. `var.Get().Slice(...)`) materializes to `PackedArray` directly, so
   // the emit-side `.Clone()` wrap needs to compile on both sides; here it is
   // just an explicit copy.
-  [[nodiscard]] auto Clone() const -> PackedArray { return *this; }
+  [[nodiscard]] auto Clone() const -> PackedArray {
+    return *this;
+  }
 
   // Word-level access for `RuntimeValueView` construction and intra-runtime
   // interop. The spans alias the PackedArray's storage and stay valid for

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -29,6 +29,12 @@
 
 namespace lyra::backend::cpp {
 
+// Renders `expr` without forcing a `PackedArrayRef` chain to materialize.
+// Public `RenderExpr` wraps any leftover ref in `.Clone()` so consumers see
+// an owning value.
+auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
+    -> diag::Result<std::string>;
+
 namespace {
 
 // Type-kind predicate. `real`, `shortreal`, and `realtime` (LRM 6.12)
@@ -823,7 +829,7 @@ auto RenderSameShapeLiteral(
 auto RenderElementSelectExpr(
     const RenderContext& ctx, const mir::ElementSelectExpr& sel)
     -> diag::Result<std::string> {
-  auto base_or = RenderExpr(ctx, ctx.Expr(sel.base_value));
+  auto base_or = RenderExprNatural(ctx, ctx.Expr(sel.base_value));
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   auto idx_or = RenderExpr(ctx, ctx.Expr(sel.index));
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
@@ -1067,7 +1073,7 @@ auto RenderRangeSelectExpr(
     const RenderContext& ctx, const mir::Expr& expr,
     const mir::RangeSelectExpr& sel) -> diag::Result<std::string> {
   const auto& operand_expr = ctx.Expr(sel.base_value);
-  auto base_or = RenderExpr(ctx, operand_expr);
+  auto base_or = RenderExprNatural(ctx, operand_expr);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
 
   const auto& result_ty = ctx.Unit().GetType(expr.type);
@@ -1207,9 +1213,24 @@ auto RenderReplicationExpr(
       "lyra::value::ReplicateString({}, {})", *concat, count_text);
 }
 
+auto ProducesPackedArrayRef(const mir::Expr& expr) -> bool {
+  return std::holds_alternative<mir::ElementSelectExpr>(expr.data) ||
+         std::holds_alternative<mir::RangeSelectExpr>(expr.data);
+}
+
 }  // namespace
 
 auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
+    -> diag::Result<std::string> {
+  auto rendered_or = RenderExprNatural(ctx, expr);
+  if (!rendered_or) return rendered_or;
+  if (ProducesPackedArrayRef(expr)) {
+    return "(" + *std::move(rendered_or) + ").Clone()";
+  }
+  return rendered_or;
+}
+
+auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
     -> diag::Result<std::string> {
   return std::visit(
       Overloaded{

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -67,49 +67,6 @@ auto RenderEventEdgeAsRuntime(mir::EventEdge edge) -> std::string_view {
   throw InternalError("RenderEventEdgeAsRuntime: unknown EventEdge value");
 }
 
-auto RenderTimedStmt(
-    const RenderContext& ctx, const mir::TimedStmt& s, std::size_t indent)
-    -> diag::Result<std::string> {
-  auto timing_or = std::visit(
-      Overloaded{
-          [&](const mir::DelayControl& d) -> diag::Result<std::string> {
-            return Indent(indent) +
-                   "co_await lyra::runtime::Delay(*services_, " +
-                   std::to_string(d.duration) + ");\n";
-          },
-          [&](const mir::EventControl& e) -> diag::Result<std::string> {
-            std::string out =
-                Indent(indent) + "co_await lyra::runtime::WaitAny({";
-            for (std::size_t i = 0; i < e.triggers.size(); ++i) {
-              const auto& sig_expr = ctx.Expr(e.triggers[i].signal);
-              const auto* svr =
-                  std::get_if<mir::StructuralVarRef>(&sig_expr.data);
-              if (svr == nullptr) {
-                throw InternalError(
-                    "RenderTimedStmt: event-control trigger is not a "
-                    "StructuralVarRef (should be rejected at HIR lowering)");
-              }
-              auto name_or = RenderStructuralVarName(ctx, *svr);
-              if (!name_or) return std::unexpected(std::move(name_or.error()));
-              if (i != 0) out += ", ";
-              out += "{&" + *name_or + ", " +
-                     std::string{RenderEventEdgeAsRuntime(e.triggers[i].edge)} +
-                     "}";
-            }
-            out += "});\n";
-            return out;
-          },
-      },
-      s.timing);
-  if (!timing_or) return std::unexpected(std::move(timing_or.error()));
-  std::string out = *std::move(timing_or);
-  auto inner_or =
-      RenderStmt(ctx, ctx.ProceduralScope().stmts.at(s.stmt.value), indent);
-  if (!inner_or) return std::unexpected(std::move(inner_or.error()));
-  out += *inner_or;
-  return out;
-}
-
 auto RenderProceduralVarDeclStmt(
     const RenderContext& ctx, const mir::ProceduralVarDeclStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
@@ -266,6 +223,27 @@ auto RenderDoWhileStmtNode(
   return result;
 }
 
+auto RenderSensitivityWaitStmt(
+    const RenderContext& ctx, const mir::SensitivityWaitStmt& s,
+    std::size_t indent) -> diag::Result<std::string> {
+  std::string result = Indent(indent) + "co_await lyra::runtime::WaitAny({";
+  for (std::size_t i = 0; i < s.reads.size(); ++i) {
+    const auto& read = s.reads[i];
+    auto name_or = RenderStructuralVarName(ctx, read.ref);
+    if (!name_or) return std::unexpected(std::move(name_or.error()));
+    if (i != 0) result += ", ";
+    // bit_range follows slang's `(lo_bit, hi_bit)` inclusive convention; the
+    // runtime Trigger takes `(lsb_offset, width)`.
+    const auto lsb = read.bit_range.first;
+    const auto width = read.bit_range.second - read.bit_range.first + 1;
+    result += "{&" + *name_or + ", " +
+              std::string{RenderEventEdgeAsRuntime(read.edge_kind)} + ", " +
+              std::to_string(lsb) + "ULL, " + std::to_string(width) + "ULL}";
+  }
+  result += "});\n";
+  return result;
+}
+
 }  // namespace
 
 auto RenderStmt(
@@ -280,8 +258,10 @@ auto RenderStmt(
           [&](const mir::EmptyStmt&) -> diag::Result<std::string> {
             return Indent(indent) + ";\n";
           },
-          [&](const mir::TimedStmt& s) -> diag::Result<std::string> {
-            return RenderTimedStmt(ctx, s, indent);
+          [&](const mir::DelayStmt& s) -> diag::Result<std::string> {
+            return Indent(indent) +
+                   "co_await lyra::runtime::Delay(*services_, " +
+                   std::to_string(s.duration) + ");\n";
           },
           [&](const mir::ProceduralVarDeclStmt& s)
               -> diag::Result<std::string> {
@@ -316,18 +296,7 @@ auto RenderStmt(
             return Indent(indent) + "continue;\n";
           },
           [&](const mir::SensitivityWaitStmt& s) -> diag::Result<std::string> {
-            std::string out =
-                Indent(indent) + "co_await lyra::runtime::WaitAny({";
-            for (std::size_t i = 0; i < s.reads.size(); ++i) {
-              auto name_or = RenderStructuralVarName(ctx, s.reads[i].ref);
-              if (!name_or) {
-                return std::unexpected(std::move(name_or.error()));
-              }
-              if (i != 0) out += ", ";
-              out += "{&" + *name_or + ", lyra::runtime::Edge::kAnyChange}";
-            }
-            out += "});\n";
-            return out;
+            return RenderSensitivityWaitStmt(ctx, s, indent);
           },
       },
       stmt.data);

--- a/src/lyra/compiler/compile.cpp
+++ b/src/lyra/compiler/compile.cpp
@@ -35,14 +35,11 @@ auto Compile(
     return result;
   }
 
-  const auto sensitivity_reads =
-      lowering::ast_to_hir::BuildSensitivityReadStore(
-          *result.artifacts.parse->compilation);
-
+  lowering::ast_to_hir::SensitivityAnalyzer sensitivity_analyzer;
   auto hir = lowering::ast_to_hir::LowerCompilation(
       lowering::ast_to_hir::LowerCompilationFacts(
           *result.artifacts.parse->compilation,
-          result.artifacts.parse->source_mapper, sensitivity_reads));
+          result.artifacts.parse->source_mapper, sensitivity_analyzer));
   if (!hir) {
     sink.Report(std::move(hir.error()));
     return result;

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -446,6 +446,20 @@ class HirDumper {
         p);
   }
 
+  static auto FormatEventEdge(EventEdge edge) -> std::string_view {
+    switch (edge) {
+      case EventEdge::kAnyChange:
+        return "any";
+      case EventEdge::kPosedge:
+        return "posedge";
+      case EventEdge::kNegedge:
+        return "negedge";
+      case EventEdge::kBothEdges:
+        return "edge";
+    }
+    throw InternalError("HirDumper::FormatEventEdge: unknown EventEdge");
+  }
+
   static auto FormatTimingControlHeader(const TimingControl& tc)
       -> std::string {
     return std::visit(
@@ -458,24 +472,20 @@ class HirDumper {
               std::string out = "EventControl triggers=[";
               for (std::size_t i = 0; i < e.triggers.size(); ++i) {
                 if (i != 0) out += ", ";
-                const char* edge = "any";
-                switch (e.triggers[i].edge) {
-                  case EventEdge::kAnyChange:
-                    edge = "any";
-                    break;
-                  case EventEdge::kPosedge:
-                    edge = "posedge";
-                    break;
-                  case EventEdge::kNegedge:
-                    edge = "negedge";
-                    break;
-                  case EventEdge::kBothEdges:
-                    edge = "edge";
-                    break;
-                }
                 out += std::format(
-                    "{{signal=Expr[{}] edge={}}}", e.triggers[i].signal.value,
-                    edge);
+                    "{{signal=Expr[{}] edge={} sensitivity=[",
+                    e.triggers[i].signal.value,
+                    FormatEventEdge(e.triggers[i].edge));
+                for (std::size_t j = 0;
+                     j < e.triggers[i].sensitivity_list.size(); ++j) {
+                  if (j != 0) out += ", ";
+                  const auto& r = e.triggers[i].sensitivity_list[j];
+                  out += std::format(
+                      "{{hops={} var=StructuralVar[{}] bits=[{}:{}] edge={}}}",
+                      r.ref.hops.value, r.ref.var.value, r.bit_range.first,
+                      r.bit_range.second, FormatEventEdge(r.edge_kind));
+                }
+                out += "]}";
               }
               out += "]";
               return out;
@@ -486,9 +496,9 @@ class HirDumper {
                 if (i != 0) out += ", ";
                 const auto& r = ie.sensitivity_list[i];
                 out += std::format(
-                    "{{hops={} var=StructuralVar[{}] bits=[{}:{}]}}",
+                    "{{hops={} var=StructuralVar[{}] bits=[{}:{}] edge={}}}",
                     r.ref.hops.value, r.ref.var.value, r.bit_range.first,
-                    r.bit_range.second);
+                    r.bit_range.second, FormatEventEdge(r.edge_kind));
               }
               out += "]";
               return out;

--- a/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
+++ b/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
@@ -61,17 +61,13 @@ auto LowerContinuousAssign(
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const hir::ExprId rhs_id = scope_state.AddExpr(*std::move(rhs_or));
 
-  // Sensitivity is precomputed by slang's flow analysis on the assignment
-  // expression during `BuildSensitivityReadStore` (see
-  // `docs/decisions/read-set-inference.md`). Look up keyed by the
-  // AssignmentExpression -- the same Expression-keyed bucket future
-  // per-expression analyses (property / assert / wait_order events) use.
-  std::vector<hir::SensitivityEntry> sensitivity;
-  if (const auto* reads = unit_facts.SensitivityReads().Lookup(assign);
-      reads != nullptr) {
-    sensitivity =
-        TranslateSensitivityReads(*reads, scope_state.UnitState(), stack);
-  }
+  // LRM 10.3.2: continuous assignment sensitivity is the read set of the
+  // RHS expression. slang treats the `ContinuousAssignSymbol` as the
+  // procedural scope for analysis purposes.
+  const auto& reads =
+      unit_facts.Sensitivity().AnalyzeReads(assignment_expr, sym);
+  auto sensitivity =
+      TranslateSensitivityReads(reads, scope_state.UnitState(), stack);
 
   return hir::ContinuousAssign{
       .span = span,

--- a/src/lyra/lowering/ast_to_hir/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/lower.cpp
@@ -36,8 +36,7 @@ auto CollectTopBodies(slang::ast::Compilation& compilation)
 
 auto LowerCompilation(const LowerCompilationFacts& facts)
     -> diag::Result<std::vector<hir::ModuleUnit>> {
-  const UnitLoweringFacts unit_facts(
-      facts.SourceMapper(), facts.SensitivityReads());
+  const UnitLoweringFacts unit_facts(facts.SourceMapper(), facts.Sensitivity());
   std::vector<hir::ModuleUnit> units;
   for (const auto* body : CollectTopBodies(facts.Compilation())) {
     auto u = LowerModule(unit_facts, *body);

--- a/src/lyra/lowering/ast_to_hir/process.cpp
+++ b/src/lyra/lowering/ast_to_hir/process.cpp
@@ -1,10 +1,15 @@
 #include "lyra/lowering/ast_to_hir/process.hpp"
 
+#include <algorithm>
 #include <expected>
 #include <utility>
 #include <vector>
 
+#include <slang/ast/Scope.h>
+#include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/BlockSymbols.h>
+#include <slang/ast/symbols/ValueSymbol.h>
+#include <slang/ast/symbols/VariableSymbols.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
@@ -38,17 +43,50 @@ auto FromSlangProceduralBlockKind(slang::ast::ProceduralBlockKind kind)
       "ast_to_hir::FromSlangProceduralBlockKind: unknown ProceduralBlockKind");
 }
 
-// Slang's procedure-body sensitivity for always_comb / always_latch
-// (LRM 9.2.2.2.1). Empty result is legal -- a SensitivityWaitStmt with an
-// empty list means "wait forever", which is the correct degenerate
-// behaviour for a procedure body with no external reads.
-auto LookupSensitivityEntries(
-    const UnitLoweringFacts& unit_facts, const UnitLoweringState& unit_state,
-    const ScopeStack& stack, const slang::ast::Statement& key_stmt)
+// LRM 9.2.2.2.1: a symbol is local to `proc` if it is an automatic-lifetime
+// variable, or if it is declared inside one of `proc`'s statement blocks.
+// `ProceduralBlockSymbol` itself is not a `Scope`, so its statement blocks
+// hang off the surrounding scope -- we walk the symbol's parent-scope chain
+// up to the outermost `StatementBlockSymbol` and check whether that block is
+// one of `proc.getBlocks()`.
+auto IsLocalTo(
+    const slang::ast::ValueSymbol& sym,
+    const slang::ast::ProceduralBlockSymbol& proc) -> bool {
+  if (const auto* var = sym.as_if<slang::ast::VariableSymbol>();
+      var != nullptr &&
+      var->lifetime == slang::ast::VariableLifetime::Automatic) {
+    return true;
+  }
+  const slang::ast::Scope* scope = sym.getParentScope();
+  const slang::ast::StatementBlockSymbol* root_block = nullptr;
+  while (scope != nullptr &&
+         scope->asSymbol().kind == slang::ast::SymbolKind::StatementBlock) {
+    root_block = &scope->asSymbol().as<slang::ast::StatementBlockSymbol>();
+    scope = root_block->getParentScope();
+  }
+  if (root_block == nullptr) return false;
+  const auto blocks = proc.getBlocks();
+  return std::ranges::any_of(
+      blocks, [&](const auto* block) { return block == root_block; });
+}
+
+// LRM 9.2.2.2.1 procedure-body sensitivity list: the reads of `body`,
+// excluding any symbol declared inside `proc`. Empty result is legal -- a
+// SensitivityWaitStmt with an empty reads list means "wait forever", the
+// correct degenerate behaviour for a body with no external reads.
+auto ProcedureBodySensitivity(
+    SensitivityAnalyzer& analyzer, const UnitLoweringState& unit_state,
+    const ScopeStack& stack, const slang::ast::ProceduralBlockSymbol& proc)
     -> std::vector<hir::SensitivityEntry> {
-  const auto* reads = unit_facts.SensitivityReads().Lookup(key_stmt);
-  if (reads == nullptr) return {};
-  return TranslateSensitivityReads(*reads, unit_state, stack);
+  const auto& raw = analyzer.AnalyzeReads(proc.getBody(), proc);
+  std::vector<SensitivityRead> filtered;
+  filtered.reserve(raw.size());
+  for (const auto& read : raw) {
+    if (!IsLocalTo(*read.symbol, proc)) {
+      filtered.push_back(read);
+    }
+  }
+  return TranslateSensitivityReads(filtered, unit_state, stack);
 }
 
 }  // namespace
@@ -57,7 +95,7 @@ auto LowerProcess(
     const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
     ScopeStack& stack, const slang::ast::ProceduralBlockSymbol& proc)
     -> diag::Result<hir::Process> {
-  ProcessLoweringState proc_state;
+  ProcessLoweringState proc_state(proc);
 
   auto root_stmt = LowerStatement(
       unit_facts, proc_state, scope_state, stack, proc.getBody());
@@ -74,8 +112,8 @@ auto LowerProcess(
     // LRM 9.2.2.2.1: implicit sensitivity is a property of the always_comb /
     // always_latch procedure itself (no `@*` token in source). Attach it to
     // the Process; HIR -> MIR materialises the trailing wait stmt.
-    out.implicit_sensitivity_list = LookupSensitivityEntries(
-        unit_facts, scope_state.UnitState(), stack, proc.getBody());
+    out.implicit_sensitivity_list = ProcedureBodySensitivity(
+        unit_facts.Sensitivity(), scope_state.UnitState(), stack, proc);
   }
   return out;
 }

--- a/src/lyra/lowering/ast_to_hir/sensitivity.cpp
+++ b/src/lyra/lowering/ast_to_hir/sensitivity.cpp
@@ -1,20 +1,15 @@
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 
-#include <mutex>
 #include <utility>
 #include <vector>
 
 #include <slang/analysis/AbstractFlowAnalysis.h>
 #include <slang/analysis/AnalysisManager.h>
-#include <slang/analysis/AnalyzedProcedure.h>
 #include <slang/analysis/DFAResults.h>
 #include <slang/analysis/DataFlowAnalysis.h>
-#include <slang/ast/Compilation.h>
+#include <slang/ast/Expression.h>
 #include <slang/ast/Statement.h>
-#include <slang/ast/statements/MiscStatements.h>
-#include <slang/ast/symbols/BlockSymbols.h>
-#include <slang/ast/symbols/MemberSymbols.h>
-#include <slang/ast/symbols/ValueSymbol.h>
+#include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 
 #include "lyra/hir/value_ref.hpp"
@@ -24,123 +19,69 @@ namespace lyra::lowering::ast_to_hir {
 
 namespace {
 
-// Translates slang's `ReadRange`-shaped sensitivity entries (used by
-// `getSensitivityList()` and `getImplicitEventReadSets()`) into lyra's
-// `SensitivityRead` shape. Disjoint bit ranges for the same symbol are kept
-// as-is so downstream can preserve precision when the runtime supports
-// bit-level subscription.
-template <typename SlangReads>
-auto TranslateReadRanges(const SlangReads& reads)
-    -> std::vector<SensitivityRead> {
-  std::vector<SensitivityRead> entries;
-  entries.reserve(reads.size());
-  for (const auto& read : reads) {
-    entries.push_back({.symbol = read.symbol, .bit_range = read.bitRange});
-  }
-  return entries;
-}
-
-// Flattens the post-DFA `ReadSet` (a map from symbol to bit-interval map)
-// into a `SensitivityRead` vector. Mirrors slang's own attribution in
-// AnalyzedProcedure.cpp:223-227.
+// Flattens slang's `(symbol, bitMap)` `ReadSet` into a vector of
+// `(symbol, [lo, hi])` entries. Disjoint ranges for the same symbol stay
+// disjoint so downstream can preserve precision.
 auto FlattenReadSet(const slang::analysis::DFAResults::ReadSet& reads)
     -> std::vector<SensitivityRead> {
-  std::vector<SensitivityRead> entries;
+  std::vector<SensitivityRead> out;
   for (const auto& [symbol, bitmap] : reads) {
     for (auto it = bitmap.begin(); it != bitmap.end(); ++it) {
-      entries.push_back({.symbol = symbol, .bit_range = it.bounds()});
+      out.push_back({.symbol = symbol, .bit_range = it.bounds()});
     }
   }
-  return entries;
+  return out;
+}
+
+// Runs slang's `DefaultDFA` on a single AST node and harvests its read set.
+template <typename Node>
+auto RunDfa(
+    slang::analysis::AnalysisContext& context,
+    const slang::ast::Symbol& containing_symbol, const Node& node)
+    -> std::vector<SensitivityRead> {
+  slang::analysis::DefaultDFA dfa(context, containing_symbol, false);
+  dfa.slang::analysis::AbstractFlowAnalysis<
+      slang::analysis::DefaultDFA, slang::analysis::DataFlowState>::run(node);
+  return FlattenReadSet(dfa.getRValues());
 }
 
 }  // namespace
 
-auto BuildSensitivityReadStore(slang::ast::Compilation& compilation)
-    -> SensitivityReadStore {
-  SensitivityReadStore out;
-  std::mutex out_mutex;
+SensitivityAnalyzer::SensitivityAnalyzer()
+    : manager_(std::make_unique<slang::analysis::AnalysisManager>()),
+      context_(std::make_unique<slang::analysis::AnalysisContext>(*manager_)) {
+}
 
-  slang::analysis::AnalysisManager manager;
+SensitivityAnalyzer::~SensitivityAnalyzer() = default;
+SensitivityAnalyzer::SensitivityAnalyzer(SensitivityAnalyzer&&) noexcept =
+    default;
+auto SensitivityAnalyzer::operator=(SensitivityAnalyzer&&) noexcept
+    -> SensitivityAnalyzer& = default;
 
-  // Provider runs first per procedure-like symbol. We do not customise the
-  // primary DFA -- we run slang's `DefaultDFA` exactly as the default path
-  // would -- but we use the callback's `AnalysisContext` to drive a fresh
-  // mini-DFA per wait cond. Calling `AbstractFlowAnalysis::run(expression)`
-  // directly bypasses `visitStmt(WaitStatement)`, so the LRM 9.4.2.2 timing-
-  // control suppression hook is not triggered and the cond's reads land in
-  // the mini-DFA's `getRValues()` like an ordinary expression's reads.
-  manager.setCustomDFAProvider(
-      [&](slang::analysis::AnalysisContext& context,
-          const slang::ast::Symbol& symbol,
-          const slang::analysis::AnalyzedProcedure* parent_procedure)
-          -> slang::analysis::AnalyzedProcedure {
-        slang::analysis::DefaultDFA dfa(context, symbol, true);
-        dfa.run();
+auto SensitivityAnalyzer::AnalyzeReads(
+    const slang::ast::Expression& expr,
+    const slang::ast::Symbol& containing_symbol)
+    -> const std::vector<SensitivityRead>& {
+  if (const auto it = expression_cache_.find(&expr);
+      it != expression_cache_.end()) {
+    return it->second;
+  }
+  auto [inserted_it, _] = expression_cache_.emplace(
+      &expr, RunDfa(*context_, containing_symbol, expr));
+  return inserted_it->second;
+}
 
-        if (!dfa.bad) {
-          for (const auto* stmt : dfa.getTimedStatements()) {
-            if (stmt->kind != slang::ast::StatementKind::Wait) continue;
-            const auto& wait_stmt = stmt->as<slang::ast::WaitStatement>();
-
-            // Fresh per-wait DFA: result fields accumulate across run()
-            // calls in slang's framework, so re-using `dfa` would conflate
-            // procedure-wide and per-wait state.
-            slang::analysis::DefaultDFA cond_dfa(context, symbol, false);
-            cond_dfa.slang::analysis::AbstractFlowAnalysis<
-                slang::analysis::DefaultDFA,
-                slang::analysis::DataFlowState>::run(wait_stmt.cond);
-
-            std::scoped_lock lock(out_mutex);
-            out.Insert(wait_stmt.cond, FlattenReadSet(cond_dfa.getRValues()));
-          }
-        }
-
-        if (dfa.bad) {
-          return {symbol, parent_procedure};
-        }
-        return {context, symbol, parent_procedure, dfa};
-      });
-
-  // Listener fires after the AnalyzedProcedure is built. Pure post-analysis
-  // harvest -- no context needed.
-  manager.addListener([&](const slang::analysis::AnalyzedProcedure& ap) {
-    const auto& symbol = *ap.analyzedSymbol;
-
-    if (const auto* proc = symbol.as_if<slang::ast::ProceduralBlockSymbol>()) {
-      // LRM 9.2.2.2.1: always_comb / always_latch sensitivity attaches to
-      // the procedure body statement.
-      if (proc->procedureKind == slang::ast::ProceduralBlockKind::AlwaysComb ||
-          proc->procedureKind == slang::ast::ProceduralBlockKind::AlwaysLatch) {
-        const auto& sens = ap.getSensitivityList();
-        if (sens.kind == slang::analysis::SensitivityList::Kind::Implicit) {
-          std::scoped_lock lock(out_mutex);
-          out.Insert(proc->getBody(), TranslateReadRanges(sens.reads));
-        }
-      }
-      // LRM 9.4.2.2: each `@*` TimedStatement carries its own region read set.
-      for (const auto& region : ap.getImplicitEventReadSets()) {
-        std::scoped_lock lock(out_mutex);
-        out.Insert(*region.statement, TranslateReadRanges(region.reads));
-      }
-    } else if (
-        const auto* ca = symbol.as_if<slang::ast::ContinuousAssignSymbol>()) {
-      // LRM 10.3: continuous assignment sensitivity. slang treats `ca` as a
-      // procedure for analysis purposes and produces an Implicit sensitivity
-      // list under default flags (whole-var reads). We key it by the
-      // assignment expression itself -- nothing in the store API names
-      // continuous assignment specifically; future per-expression analyses
-      // (property / assert / wait_order events) plug into the same bucket.
-      const auto& sens = ap.getSensitivityList();
-      if (sens.kind == slang::analysis::SensitivityList::Kind::Implicit) {
-        std::scoped_lock lock(out_mutex);
-        out.Insert(ca->getAssignment(), TranslateReadRanges(sens.reads));
-      }
-    }
-  });
-
-  manager.analyze(compilation);
-  return out;
+auto SensitivityAnalyzer::AnalyzeReads(
+    const slang::ast::Statement& stmt,
+    const slang::ast::Symbol& containing_symbol)
+    -> const std::vector<SensitivityRead>& {
+  if (const auto it = statement_cache_.find(&stmt);
+      it != statement_cache_.end()) {
+    return it->second;
+  }
+  auto [inserted_it, _] = statement_cache_.emplace(
+      &stmt, RunDfa(*context_, containing_symbol, stmt));
+  return inserted_it->second;
 }
 
 auto TranslateSensitivityReads(

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -75,27 +75,30 @@ auto LowerSignalEventTrigger(
       LowerProcExpr(unit_facts, unit_state, proc_state, stack, sig.expr);
   if (!expr_or) return std::unexpected(std::move(expr_or.error()));
 
-  const auto* primary = std::get_if<hir::PrimaryExpr>(&expr_or->data);
-  if (primary == nullptr ||
-      !std::holds_alternative<hir::StructuralVarRef>(primary->data)) {
-    return diag::Unsupported(
-        span, diag::DiagCode::kUnsupportedEventTriggerForm,
-        "event trigger must be a plain structural variable reference; "
-        "bit-selects, member access, and hierarchical refs are "
-        "not yet supported",
-        diag::UnsupportedCategory::kFeature);
-  }
   if (!unit_state.GetType(expr_or->type).IsPackedArray()) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedEventTriggerForm,
-        "event trigger must reference an integral signal; non-integral "
+        "event trigger expression must have an integral type; non-integral "
         "trigger types are not yet supported",
         diag::UnsupportedCategory::kFeature);
   }
 
+  const auto edge_kind = LowerEventEdge(sig.edge);
+
+  const auto& reads = unit_facts.Sensitivity().AnalyzeReads(
+      sig.expr, proc_state.ContainingSymbol());
+  auto sensitivity_list = TranslateSensitivityReads(reads, unit_state, stack);
+  // Faithful record of SV: every leaf carries the trigger's edge identifier.
+  // Whether the runtime can act on it directly (single leaf, LSB-reduce) or
+  // needs a snapshot + re-eval wrapper (compound) is a HIR -> MIR decision.
+  for (auto& leaf : sensitivity_list) {
+    leaf.edge_kind = edge_kind;
+  }
+
   return hir::EventTrigger{
       .signal = proc_state.AddExpr(*std::move(expr_or)),
-      .edge = LowerEventEdge(sig.edge),
+      .edge = edge_kind,
+      .sensitivity_list = std::move(sensitivity_list),
   };
 }
 
@@ -217,16 +220,14 @@ auto LowerTimedStmt(
   auto timing = LowerTimingControl(
       unit_facts, scope_state.UnitState(), proc_state, stack, ts.timing, span);
   if (!timing) return std::unexpected(std::move(timing.error()));
-  // LRM 9.4.2.2: `@*` carries its sensitivity from a slang side-channel
-  // keyed by this TimedStatement. The TimingControl shell came back empty
-  // from LowerTimingControl; fill it in here where we still have the
-  // parent statement pointer.
+  // LRM 9.4.2.2: `@*` watches every read in the controlled body. Analyze
+  // the body statement directly; the TimingControl shell came back empty
+  // from LowerTimingControl.
   if (auto* ie = std::get_if<hir::ImplicitEventControl>(&*timing)) {
-    if (const auto* reads = unit_facts.SensitivityReads().Lookup(ts);
-        reads != nullptr) {
-      ie->sensitivity_list =
-          TranslateSensitivityReads(*reads, scope_state.UnitState(), stack);
-    }
+    const auto& reads = unit_facts.Sensitivity().AnalyzeReads(
+        ts.stmt, proc_state.ContainingSymbol());
+    ie->sensitivity_list =
+        TranslateSensitivityReads(reads, scope_state.UnitState(), stack);
   }
   auto inner_stmt =
       LowerStatement(unit_facts, proc_state, scope_state, stack, ts.stmt);
@@ -667,12 +668,10 @@ auto LowerWaitStmt(
       LowerStatement(unit_facts, proc_state, scope_state, stack, w.stmt);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   const hir::StmtId body_id = proc_state.AddStmt(*std::move(body_or));
-  std::vector<hir::SensitivityEntry> sensitivity;
-  if (const auto* reads = unit_facts.SensitivityReads().Lookup(w.cond);
-      reads != nullptr) {
-    sensitivity =
-        TranslateSensitivityReads(*reads, scope_state.UnitState(), stack);
-  }
+  const auto& reads = unit_facts.Sensitivity().AnalyzeReads(
+      w.cond, proc_state.ContainingSymbol());
+  auto sensitivity =
+      TranslateSensitivityReads(reads, scope_state.UnitState(), stack);
   return hir::Stmt{
       .label = std::nullopt,
       .data =

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -71,78 +71,11 @@ auto ResolveDelayDuration(
       diag::UnsupportedCategory::kFeature);
 }
 
-auto LowerTimingControl(
-    const UnitLoweringState& unit_state,
-    const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
-    ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::TimingControl& tc)
-    -> diag::Result<mir::TimingControl> {
-  return std::visit(
-      Overloaded{
-          [&](const hir::DelayControl& d) -> diag::Result<mir::TimingControl> {
-            const DelayTimeResolver resolver{proc_state.Resolution()};
-            auto ticks_or = ResolveDelayDuration(
-                resolver, hir_proc.exprs.at(d.duration.value));
-            if (!ticks_or) {
-              return std::unexpected(std::move(ticks_or.error()));
-            }
-            return mir::TimingControl{mir::DelayControl{.duration = *ticks_or}};
-          },
-          [&](const hir::EventControl& e) -> diag::Result<mir::TimingControl> {
-            std::vector<mir::EventTrigger> triggers;
-            triggers.reserve(e.triggers.size());
-            for (const auto& t : e.triggers) {
-              auto signal_or = LowerExpr(
-                  unit_state, scope_state, proc_state, proc_scope_state,
-                  hir_proc, hir_proc.exprs.at(t.signal.value));
-              if (!signal_or) {
-                return std::unexpected(std::move(signal_or.error()));
-              }
-              const mir::ExprId signal_id =
-                  proc_scope_state.AddExpr(*std::move(signal_or));
-              mir::EventEdge edge = mir::EventEdge::kAnyChange;
-              switch (t.edge) {
-                case hir::EventEdge::kAnyChange:
-                  edge = mir::EventEdge::kAnyChange;
-                  break;
-                case hir::EventEdge::kPosedge:
-                  edge = mir::EventEdge::kPosedge;
-                  break;
-                case hir::EventEdge::kNegedge:
-                  edge = mir::EventEdge::kNegedge;
-                  break;
-                case hir::EventEdge::kBothEdges:
-                  edge = mir::EventEdge::kBothEdges;
-                  break;
-              }
-              triggers.push_back(
-                  mir::EventTrigger{.signal = signal_id, .edge = edge});
-            }
-            return mir::TimingControl{
-                mir::EventControl{.triggers = std::move(triggers)}};
-          },
-          [](const hir::ImplicitEventControl&)
-              -> diag::Result<mir::TimingControl> {
-            // ImplicitEventControl never reaches the MIR TimingControl level:
-            // LowerTimedStmt intercepts it and expands the TimedStmt into a
-            // mir::Block { SensitivityWaitStmt; body; }.
-            throw InternalError(
-                "LowerTimingControl: ImplicitEventControl must be expanded by "
-                "LowerTimedStmt, not lowered as a MIR timing control");
-          },
-          [](const hir::NamedEventControl&)
-              -> diag::Result<mir::TimingControl> {
-            // NamedEventControl never reaches the MIR TimingControl level:
-            // LowerTimedStmt intercepts it and expands the TimedStmt into a
-            // mir::ExprStmt(method_call(event, Await)).
-            throw InternalError(
-                "LowerTimingControl: NamedEventControl must be expanded by "
-                "LowerTimedStmt into a method call, not lowered as a MIR "
-                "timing control");
-          },
-      },
-      tc);
+auto ResolveDelayTicks(
+    const ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    const hir::DelayControl& d) -> diag::Result<SimDuration> {
+  const DelayTimeResolver resolver{proc_state.Resolution()};
+  return ResolveDelayDuration(resolver, hir_proc.exprs.at(d.duration.value));
 }
 
 auto LowerEmptyStmt(const hir::Stmt& stmt) -> diag::Result<mir::Stmt> {
@@ -1246,6 +1179,75 @@ auto LowerNamedEventTimedStmt(
       .child_procedural_scopes = std::move(child_scopes)};
 }
 
+// LRM 9.4.2 `@(...) body` (explicit event control). Each `hir::EventTrigger`
+// carries its event_expression and the DFA-computed leaf set. For the
+// single-leaf case ("the expression is a simple selector chain on a packed
+// var"), the leaf already carries the right edge polarity (or LSB-reduced
+// for edge-qualified) and we lower directly to:
+//
+//   child_scope {
+//     SensitivityWaitStmt(union of all triggers' single leaves)
+//     body
+//   }
+//
+// Multi-leaf event expressions (concatenation, arithmetic, cross-var, dynamic
+// index) require a snapshot + re-eval wrapper to enforce LRM 9.4.2 "fire only
+// when the expression's result changes" -- not yet implemented; reject with
+// diagnostic.
+auto LowerEventTimedStmt(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    const hir::Stmt& stmt, const hir::TimedStmt& t, const hir::EventControl& ec)
+    -> diag::Result<mir::Stmt> {
+  std::vector<hir::SensitivityEntry> union_reads;
+  union_reads.reserve(ec.triggers.size());
+  for (const auto& trigger : ec.triggers) {
+    // Compound (multi-leaf) requires a snapshot + re-eval wrapper to enforce
+    // LRM 9.4.2 "fire only when the expression's result changes" -- not yet
+    // implemented; reject. An empty leaf set falls through harmlessly (loop
+    // iterates zero times, mirroring SensitivityWaitStmt's "no reads = wait
+    // forever" convention).
+    if (trigger.sensitivity_list.size() > 1) {
+      return diag::Unsupported(
+          stmt.span, diag::DiagCode::kUnsupportedEventTriggerForm,
+          "compound event expressions (concatenation, arithmetic, dynamic "
+          "index) are not yet supported",
+          diag::UnsupportedCategory::kFeature);
+    }
+    for (auto leaf : trigger.sensitivity_list) {
+      // LRM 9.4.2 LSB-reduce: an edge event monitors only the LSB of the
+      // expression. The leaf's `bit_range` follows slang's `(lo, hi)`;
+      // collapsing to `(lo, lo)` keeps the LSB only.
+      if (leaf.edge_kind != hir::EventEdge::kAnyChange) {
+        leaf.bit_range = {leaf.bit_range.first, leaf.bit_range.first};
+      }
+      union_reads.push_back(leaf);
+    }
+  }
+
+  ProceduralScopeLoweringState child_proc_scope_state;
+  ProceduralDepthGuard depth_guard{proc_state};
+  child_proc_scope_state.AddRootStmt(child_proc_scope_state.AddStmt(
+      BuildSensitivityWaitStmt(scope_state, union_reads)));
+  const hir::Stmt& inner_hir = hir_proc.stmts.at(t.stmt.value);
+  auto inner_or = LowerStmt(
+      unit_state, scope_state, proc_state, child_proc_scope_state, hir_proc,
+      inner_hir);
+  if (!inner_or) {
+    return std::unexpected(std::move(inner_or.error()));
+  }
+  child_proc_scope_state.AddRootStmt(
+      child_proc_scope_state.AddStmt(*std::move(inner_or)));
+  std::vector<mir::ProceduralScope> child_scopes;
+  const mir::ProceduralScopeId scope_id =
+      AddChildProceduralScope(child_scopes, child_proc_scope_state.Finish());
+  return mir::Stmt{
+      .label = stmt.label,
+      .data = mir::BlockStmt{.scope = scope_id},
+      .child_procedural_scopes = std::move(child_scopes)};
+}
+
 // LRM 9.4.2.2 `@* body` expands to:
 //
 //   child_scope {
@@ -1351,13 +1353,56 @@ auto LowerWaitStmt(
       .child_procedural_scopes = std::move(outer_child_scopes)};
 }
 
+// LRM 9.4.1 `#N body` expands to:
+//
+//   child_scope {
+//     DelayStmt(ticks)
+//     body
+//   }
+//
+// Parallel to the SensitivityWaitStmt / NamedEvent expansions, except the
+// suspension is anchored to simulation time rather than a value-change or
+// named-event subscription.
+auto LowerDelayTimedStmt(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    const hir::Stmt& stmt, const hir::TimedStmt& t, const hir::DelayControl& d)
+    -> diag::Result<mir::Stmt> {
+  auto ticks_or = ResolveDelayTicks(proc_state, hir_proc, d);
+  if (!ticks_or) {
+    return std::unexpected(std::move(ticks_or.error()));
+  }
+  ProceduralScopeLoweringState child_proc_scope_state;
+  ProceduralDepthGuard depth_guard{proc_state};
+  child_proc_scope_state.AddRootStmt(child_proc_scope_state.AddStmt(
+      mir::Stmt{
+          .label = std::nullopt,
+          .data = mir::DelayStmt{.duration = *ticks_or},
+          .child_procedural_scopes = {}}));
+  const hir::Stmt& inner_hir = hir_proc.stmts.at(t.stmt.value);
+  auto inner_or = LowerStmt(
+      unit_state, scope_state, proc_state, child_proc_scope_state, hir_proc,
+      inner_hir);
+  if (!inner_or) {
+    return std::unexpected(std::move(inner_or.error()));
+  }
+  child_proc_scope_state.AddRootStmt(
+      child_proc_scope_state.AddStmt(*std::move(inner_or)));
+  std::vector<mir::ProceduralScope> child_scopes;
+  const mir::ProceduralScopeId scope_id =
+      AddChildProceduralScope(child_scopes, child_proc_scope_state.Finish());
+  return mir::Stmt{
+      .label = stmt.label,
+      .data = mir::BlockStmt{.scope = scope_id},
+      .child_procedural_scopes = std::move(child_scopes)};
+}
+
 auto LowerTimedStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state,
-    ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::Stmt& stmt,
-    const hir::TimedStmt& t) -> diag::Result<mir::Stmt> {
+    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    const hir::Stmt& stmt, const hir::TimedStmt& t) -> diag::Result<mir::Stmt> {
   if (const auto* ie = std::get_if<hir::ImplicitEventControl>(&t.timing)) {
     return LowerImplicitEventTimedStmt(
         unit_state, scope_state, proc_state, hir_proc, stmt, t, *ie);
@@ -1366,24 +1411,16 @@ auto LowerTimedStmt(
     return LowerNamedEventTimedStmt(
         unit_state, scope_state, proc_state, hir_proc, stmt, t, *nec);
   }
-  auto timing_or = LowerTimingControl(
-      unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
-      t.timing);
-  if (!timing_or) {
-    return std::unexpected(std::move(timing_or.error()));
+  if (const auto* ec = std::get_if<hir::EventControl>(&t.timing)) {
+    return LowerEventTimedStmt(
+        unit_state, scope_state, proc_state, hir_proc, stmt, t, *ec);
   }
-  const hir::Stmt& inner_hir = hir_proc.stmts.at(t.stmt.value);
-  auto inner_or = LowerStmt(
-      unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
-      inner_hir);
-  if (!inner_or) {
-    return std::unexpected(std::move(inner_or.error()));
+  const auto* d = std::get_if<hir::DelayControl>(&t.timing);
+  if (d == nullptr) {
+    throw InternalError("LowerTimedStmt: unknown hir::TimingControl variant");
   }
-  const mir::StmtId inner_id = proc_scope_state.AddStmt(*std::move(inner_or));
-  return mir::Stmt{
-      .label = stmt.label,
-      .data = mir::TimedStmt{.timing = *std::move(timing_or), .stmt = inner_id},
-      .child_procedural_scopes = {}};
+  return LowerDelayTimedStmt(
+      unit_state, scope_state, proc_state, hir_proc, stmt, t, *d);
 }
 
 }  // namespace
@@ -1470,8 +1507,7 @@ auto LowerStmt(
           [&](const hir::ContinueStmt&) { return LowerContinueStmt(stmt); },
           [&](const hir::TimedStmt& t) {
             return LowerTimedStmt(
-                unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
-                stmt, t);
+                unit_state, scope_state, proc_state, hir_proc, stmt, t);
           },
           [&](const hir::EventTriggerStmt& et) {
             return LowerEventTriggerStmt(

--- a/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
+++ b/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
@@ -3,11 +3,30 @@
 #include <utility>
 #include <vector>
 
+#include "lyra/base/internal_error.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/stmt.hpp"
 
 namespace lyra::lowering::hir_to_mir {
+
+namespace {
+
+auto LowerEventEdge(hir::EventEdge edge) -> mir::EventEdge {
+  switch (edge) {
+    case hir::EventEdge::kAnyChange:
+      return mir::EventEdge::kAnyChange;
+    case hir::EventEdge::kPosedge:
+      return mir::EventEdge::kPosedge;
+    case hir::EventEdge::kNegedge:
+      return mir::EventEdge::kNegedge;
+    case hir::EventEdge::kBothEdges:
+      return mir::EventEdge::kBothEdges;
+  }
+  throw InternalError("LowerEventEdge: unknown hir::EventEdge value");
+}
+
+}  // namespace
 
 auto BuildSensitivityWaitStmt(
     const StructuralScopeLoweringState& scope_state,
@@ -19,7 +38,8 @@ auto BuildSensitivityWaitStmt(
         mir::SensitivityRead{
             .ref = scope_state.TranslateStructuralVar(
                 entry.ref.hops, entry.ref.var),
-            .bit_range = entry.bit_range});
+            .bit_range = entry.bit_range,
+            .edge_kind = LowerEventEdge(entry.edge_kind)});
   }
   return mir::Stmt{
       .label = std::nullopt,

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -213,40 +213,18 @@ class MirDumper {
     throw InternalError("MirDumper::FormatTimeScale: unknown TimeScale");
   }
 
-  static auto FormatTimingControl(const TimingControl& tc) -> std::string {
-    return std::visit(
-        Overloaded{
-            [](const DelayControl& d) -> std::string {
-              return std::format("DelayControl ticks={}", d.duration);
-            },
-            [](const EventControl& e) -> std::string {
-              std::string out = "EventControl triggers=[";
-              for (std::size_t i = 0; i < e.triggers.size(); ++i) {
-                if (i != 0) out += ", ";
-                const char* edge = "any";
-                switch (e.triggers[i].edge) {
-                  case EventEdge::kAnyChange:
-                    edge = "any";
-                    break;
-                  case EventEdge::kPosedge:
-                    edge = "posedge";
-                    break;
-                  case EventEdge::kNegedge:
-                    edge = "negedge";
-                    break;
-                  case EventEdge::kBothEdges:
-                    edge = "edge";
-                    break;
-                }
-                out += std::format(
-                    "{{signal=Expr[{}] edge={}}}", e.triggers[i].signal.value,
-                    edge);
-              }
-              out += "]";
-              return out;
-            },
-        },
-        tc);
+  static auto FormatEventEdge(EventEdge edge) -> std::string_view {
+    switch (edge) {
+      case EventEdge::kAnyChange:
+        return "any";
+      case EventEdge::kPosedge:
+        return "posedge";
+      case EventEdge::kNegedge:
+        return "negedge";
+      case EventEdge::kBothEdges:
+        return "edge";
+    }
+    throw InternalError("MirDumper::FormatEventEdge: unknown EventEdge");
   }
 
   static auto FormatUnaryOp(UnaryOp op) -> std::string {
@@ -781,7 +759,11 @@ class MirDumper {
               DumpConstructOwnedObjectStmt(id, s);
             },
             [&](const ForStmt& s) { DumpForStmt(stmt, s, enclosing, id); },
-            [&](const TimedStmt& t) { DumpTimedStmt(t, enclosing, id); },
+            [&](const DelayStmt& d) {
+              Line(
+                  std::format(
+                      "Stmt[{}] DelayStmt ticks={}", id.value, d.duration));
+            },
             [&](const WhileStmt& s) { DumpWhileStmt(stmt, s, enclosing, id); },
             [&](const DoWhileStmt& s) {
               DumpDoWhileStmt(stmt, s, enclosing, id);
@@ -799,9 +781,9 @@ class MirDumper {
                 Line(
                     std::format(
                         "StructuralVarRef hops={} var=StructuralVar[{}] "
-                        "bits=[{}:{}]",
+                        "bits=[{}:{}] edge={}",
                         r.ref.hops.value, r.ref.var.value, r.bit_range.first,
-                        r.bit_range.second));
+                        r.bit_range.second, FormatEventEdge(r.edge_kind)));
               }
               Dedent();
             },
@@ -837,18 +819,6 @@ class MirDumper {
     Line(std::format("scope (ProceduralScopeId={}):", s.scope.value));
     Indent();
     DumpProceduralScope(parent.child_procedural_scopes.at(s.scope.value));
-    Dedent();
-    Dedent();
-  }
-
-  void DumpTimedStmt(
-      const TimedStmt& t, const ProceduralScope& enclosing, StmtId id) {
-    Line(std::format("Stmt[{}] TimedStmt", id.value));
-    Indent();
-    Line(std::format("timing: {}", FormatTimingControl(t.timing)));
-    Line("stmt:");
-    Indent();
-    DumpStmt(enclosing, t.stmt);
     Dedent();
     Dedent();
   }

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -286,8 +286,8 @@ void Engine::RequestFinish(int level) {
 }
 
 void Engine::TriggerValueChange(
-    Observable& observable, EdgeTransition transition) {
-  for (RuntimeProcess* p : observable.TakeMatchingWaiters(transition)) {
+    Observable& observable, const EdgeClassifier& classify) {
+  for (RuntimeProcess* p : observable.TakeMatchingWaiters(classify)) {
     // Clean up sibling subscriptions so they don't leak across waits when this
     // process re-enters the runnable queue.
     for (Observable* other : p->TakePendingValueChangeSubscriptions()) {

--- a/src/lyra/runtime/runtime_services.cpp
+++ b/src/lyra/runtime/runtime_services.cpp
@@ -16,11 +16,11 @@ void RuntimeServices::SubmitNba(std::function<void()> closure) {
 }
 
 void RuntimeServices::TriggerValueChange(
-    Observable& observable, EdgeTransition transition) {
+    Observable& observable, const EdgeClassifier& classify) {
   if (engine_ == nullptr) {
     throw InternalError("RuntimeServices::TriggerValueChange: no Engine bound");
   }
-  engine_->TriggerValueChange(observable, transition);
+  engine_->TriggerValueChange(observable, classify);
 }
 
 void RuntimeServices::ScheduleProcess(RuntimeProcess& process) {

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -237,6 +237,26 @@ auto PackedArray::Lsb() const -> FourStateBit {
   return value_bit ? FourStateBit::kOne : FourStateBit::kZero;
 }
 
+auto PackedArray::GetBit(std::uint64_t flat_offset) const -> FourStateBit {
+  if (flat_offset >= bit_width_) {
+    return is_four_state_ ? FourStateBit::kUnknown : FourStateBit::kZero;
+  }
+  const auto w_idx = static_cast<std::size_t>(flat_offset / 64U);
+  const auto b_idx = static_cast<std::uint64_t>(flat_offset % 64U);
+  const auto vw = ValueWords();
+  const bool value_bit = ((vw[w_idx] >> b_idx) & std::uint64_t{1}) != 0U;
+  if (!is_four_state_) {
+    return value_bit ? FourStateBit::kOne : FourStateBit::kZero;
+  }
+  const auto uw = UnknownWords();
+  const bool unknown_bit =
+      w_idx < uw.size() && ((uw[w_idx] >> b_idx) & std::uint64_t{1}) != 0U;
+  if (unknown_bit) {
+    return value_bit ? FourStateBit::kUnknown : FourStateBit::kHighImpedance;
+  }
+  return value_bit ? FourStateBit::kOne : FourStateBit::kZero;
+}
+
 auto PackedArray::AsBitView() -> BitView {
   auto* bv = std::get_if<BitValue>(&storage_);
   if (bv == nullptr) {
@@ -432,7 +452,7 @@ auto PackedArray::ConvertFrom(
     const PackedArrayRef& src, std::uint64_t dst_bit_width, bool dst_is_signed,
     bool dst_is_four_state) -> PackedArray {
   return ConvertFrom(
-      PackedArray(src), dst_bit_width, dst_is_signed, dst_is_four_state);
+      src.Clone(), dst_bit_width, dst_is_signed, dst_is_four_state);
 }
 
 auto PackedArray::ConvertFrom(
@@ -1298,7 +1318,7 @@ PackedArrayRef::PackedArrayRef(
       dims_(std::move(dims)) {
 }
 
-PackedArrayRef::operator PackedArray() const {
+auto PackedArrayRef::Clone() const -> PackedArray {
   return std::as_const(*root_).ExtractBits(bit_offset_, bit_width_);
 }
 

--- a/tests/cases/cpp/edge_trigger_anychange_bit_select/case.yaml
+++ b/tests/cases/cpp/edge_trigger_anychange_bit_select/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.edge_trigger_anychange_bit_select
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    count: 2
+    snapshot_at_5: 0

--- a/tests/cases/cpp/edge_trigger_anychange_bit_select/main.sv
+++ b/tests/cases/cpp/edge_trigger_anychange_bit_select/main.sv
@@ -1,0 +1,19 @@
+// No edge keyword: @(bus[3]) wakes on any change to bit 3 -- regardless of
+// direction. Changing bit 5 (different projection) must NOT wake.
+module Top;
+  logic [7:0] bus = 8'b0000_1000;
+  int count = 0;
+  int snapshot_at_5 = 99;
+  initial begin
+    @(bus[3]);
+    count = count + 1;
+    @(bus[3]);
+    count = count + 1;
+  end
+  initial begin
+    #5 bus = 8'b0010_1000;
+    snapshot_at_5 = count;
+    #5 bus[3] = 0;
+    #5 bus[3] = 1;
+  end
+endmodule

--- a/tests/cases/cpp/edge_trigger_bit_select_negedge/case.yaml
+++ b/tests/cases/cpp/edge_trigger_bit_select_negedge/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.edge_trigger_bit_select_negedge
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 1

--- a/tests/cases/cpp/edge_trigger_bit_select_negedge/main.sv
+++ b/tests/cases/cpp/edge_trigger_bit_select_negedge/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  logic [7:0] bus = 8'b0000_1000;
+  int result = 0;
+  initial begin
+    @(negedge bus[3]);
+    result = 1;
+  end
+  initial #5 bus = 8'h00;
+endmodule

--- a/tests/cases/cpp/edge_trigger_bit_select_no_false_trigger/case.yaml
+++ b/tests/cases/cpp/edge_trigger_bit_select_no_false_trigger/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.edge_trigger_bit_select_no_false_trigger
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 1
+    snapshot_at_5: 0

--- a/tests/cases/cpp/edge_trigger_bit_select_no_false_trigger/main.sv
+++ b/tests/cases/cpp/edge_trigger_bit_select_no_false_trigger/main.sv
@@ -1,0 +1,18 @@
+// LRM 9.4.2 correctness anchor: @(posedge bus[3]) must NOT wake on bit 5
+// changes -- bit 3 alone is the projection. The first write only flips bit 5,
+// so result should stay 0 at t=5; the second write at t=10 flips bit 3 and
+// fires the wake.
+module Top;
+  logic [7:0] bus = 8'h00;
+  int result = 0;
+  int snapshot_at_5 = 99;
+  initial begin
+    @(posedge bus[3]);
+    result = 1;
+  end
+  initial begin
+    #5 bus = 8'b0010_0000;
+    snapshot_at_5 = result;
+    #5 bus = 8'b0010_1000;
+  end
+endmodule

--- a/tests/cases/cpp/edge_trigger_bit_select_posedge/case.yaml
+++ b/tests/cases/cpp/edge_trigger_bit_select_posedge/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.edge_trigger_bit_select_posedge
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 1

--- a/tests/cases/cpp/edge_trigger_bit_select_posedge/main.sv
+++ b/tests/cases/cpp/edge_trigger_bit_select_posedge/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  logic [7:0] bus = 8'h00;
+  int result = 0;
+  initial begin
+    @(posedge bus[3]);
+    result = 1;
+  end
+  initial #5 bus = 8'b0000_1000;
+endmodule

--- a/tests/cases/cpp/edge_trigger_both_edges_bit/case.yaml
+++ b/tests/cases/cpp/edge_trigger_both_edges_bit/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.edge_trigger_both_edges_bit
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    count: 2

--- a/tests/cases/cpp/edge_trigger_both_edges_bit/main.sv
+++ b/tests/cases/cpp/edge_trigger_both_edges_bit/main.sv
@@ -1,0 +1,15 @@
+// `edge` keyword fires on both posedge and negedge.
+module Top;
+  logic [7:0] bus = 8'h00;
+  int count = 0;
+  initial begin
+    @(edge bus[3]);
+    count = count + 1;
+    @(edge bus[3]);
+    count = count + 1;
+  end
+  initial begin
+    #5 bus = 8'b0000_1000;
+    #5 bus = 8'h00;
+  end
+endmodule

--- a/tests/cases/cpp/edge_trigger_event_list_mixed/case.yaml
+++ b/tests/cases/cpp/edge_trigger_event_list_mixed/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.edge_trigger_event_list_mixed
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    count: 2

--- a/tests/cases/cpp/edge_trigger_event_list_mixed/main.sv
+++ b/tests/cases/cpp/edge_trigger_event_list_mixed/main.sv
@@ -1,0 +1,17 @@
+// Event list with one whole-var trigger and one bit-select trigger.
+// Two `@()` waits demonstrate each member can fire independently.
+module Top;
+  bit clk = 0;
+  logic [7:0] bus = 8'b0000_1000;
+  int count = 0;
+  initial begin
+    @(posedge clk or negedge bus[3]);
+    count = count + 1;
+    @(posedge clk or negedge bus[3]);
+    count = count + 1;
+  end
+  initial begin
+    #5 clk = 1;
+    #5 bus[3] = 0;
+  end
+endmodule

--- a/tests/cases/cpp/edge_trigger_indexed_part_select_down/case.yaml
+++ b/tests/cases/cpp/edge_trigger_indexed_part_select_down/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.edge_trigger_indexed_part_select_down
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 1

--- a/tests/cases/cpp/edge_trigger_indexed_part_select_down/main.sv
+++ b/tests/cases/cpp/edge_trigger_indexed_part_select_down/main.sv
@@ -1,0 +1,11 @@
+// Indexed part-select `bus[6 -: 4]` is bus[6:3], so LSB is bus[3].
+// @(posedge ...) fires when bit 3 transitions.
+module Top;
+  logic [7:0] bus = 8'h00;
+  int result = 0;
+  initial begin
+    @(posedge bus[6 -: 4]);
+    result = 1;
+  end
+  initial #5 bus = 8'b0000_1000;
+endmodule

--- a/tests/cases/cpp/edge_trigger_indexed_part_select_up/case.yaml
+++ b/tests/cases/cpp/edge_trigger_indexed_part_select_up/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.edge_trigger_indexed_part_select_up
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 1

--- a/tests/cases/cpp/edge_trigger_indexed_part_select_up/main.sv
+++ b/tests/cases/cpp/edge_trigger_indexed_part_select_up/main.sv
@@ -1,0 +1,11 @@
+// Indexed part-select `bus[3 +: 4]` is bus[6:3], so LSB is bus[3].
+// @(posedge ...) fires when bit 3 transitions.
+module Top;
+  logic [7:0] bus = 8'h00;
+  int result = 0;
+  initial begin
+    @(posedge bus[3 +: 4]);
+    result = 1;
+  end
+  initial #5 bus = 8'b0000_1000;
+endmodule

--- a/tests/cases/cpp/edge_trigger_range_select_multibit_lsb/case.yaml
+++ b/tests/cases/cpp/edge_trigger_range_select_multibit_lsb/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.edge_trigger_range_select_multibit_lsb
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 1
+    snapshot_at_5: 0

--- a/tests/cases/cpp/edge_trigger_range_select_multibit_lsb/main.sv
+++ b/tests/cases/cpp/edge_trigger_range_select_multibit_lsb/main.sv
@@ -1,0 +1,17 @@
+// LRM 9.4.2: "edge event shall be detected only on the LSB of the expression".
+// `@(posedge bus[7:4])` watches the LSB of bus[7:4], i.e. bus[4]. Flipping
+// bit 7 alone must NOT wake; flipping bit 4 fires the edge.
+module Top;
+  logic [7:0] bus = 8'h00;
+  int result = 0;
+  int snapshot_at_5 = 99;
+  initial begin
+    @(posedge bus[7:4]);
+    result = 1;
+  end
+  initial begin
+    #5 bus = 8'b1000_0000;
+    snapshot_at_5 = result;
+    #5 bus = 8'b1001_0000;
+  end
+endmodule

--- a/tests/cases/errors/event_bit_select_unsupported/main.sv
+++ b/tests/cases/errors/event_bit_select_unsupported/main.sv
@@ -1,6 +1,0 @@
-module Top;
-  logic [7:0] data;
-  initial begin
-    @(data[3]);
-  end
-endmodule

--- a/tests/cases/errors/event_compound_trigger_unsupported/case.yaml
+++ b/tests/cases/errors/event_compound_trigger_unsupported/case.yaml
@@ -1,0 +1,16 @@
+id: errors.event_compound_trigger_unsupported
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "compound event expressions"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/event_compound_trigger_unsupported/main.sv
+++ b/tests/cases/errors/event_compound_trigger_unsupported/main.sv
@@ -1,0 +1,6 @@
+module Top;
+  logic [7:0] bus = 0;
+  initial begin
+    @(bus[3] | bus[5]);
+  end
+endmodule

--- a/tests/cases/errors/event_dynamic_index_unsupported/case.yaml
+++ b/tests/cases/errors/event_dynamic_index_unsupported/case.yaml
@@ -1,7 +1,7 @@
-id: errors.event_bit_select_unsupported
+id: errors.event_dynamic_index_unsupported
 tags: [errors, diag]
 input:
-  command: [dump, hir]
+  command: [emit, cpp]
   project: false
   top: Top
   files: [main.sv]
@@ -10,7 +10,7 @@ expect:
   exit: 1
   stderr:
     contains:
-      - "main.sv:4:"
       - "unsupported:"
+      - "compound event expressions"
     not_contains:
       - "internal error"

--- a/tests/cases/errors/event_dynamic_index_unsupported/main.sv
+++ b/tests/cases/errors/event_dynamic_index_unsupported/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  logic [7:0] bus = 0;
+  int i = 3;
+  initial begin
+    @(posedge bus[i]);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Closes processes.md T2..T5. Routes `@(...)` through slang's flow analysis on the same `SensitivityReadStore`-equivalent path already used by `always_comb`, `@*`, `wait`, and continuous assignment, lifting the previous whole-variable subscription to per-leaf `(var, bit_range, edge_kind)` records. The runtime gains a per-waiter classifier so projection compares stay precise; the LRM 9.4.2 LSB-reduce on edge-qualified single-leaf expressions is applied at AST -> HIR. Compound expressions (concatenation, arithmetic, dynamic index), ascending / negative-base packed ranges, and multi-dim packed events remain rejected with explicit diagnostics; details are recorded under `processes.md` Blocked.

## Design

`mir::EventControl` and `mir::EventTrigger` are deleted. Delay separates into a standalone `mir::DelayStmt` so the time-anchored and value-change-anchored wait families live as disjoint MIR constructs rather than under a one-arm `TimingControl` variant. The sensitivity analyzer is refactored to be construct-agnostic: it exposes a single overloaded `AnalyzeReads(node, containing_symbol)` that drives `slang::DefaultDFA` against a standalone `AnalysisContext`, and the LRM 9.2.2.2.1 locally-declared-symbol exclusion moves to `process.cpp` where it semantically belongs. `PackedArrayRef` drops the implicit conversion operator in favour of an explicit `.Clone()` and becomes move-only; the emit visitor wraps any leftover proxy in `.Clone()` at the value-consumer boundary. Full rationale in `docs/decisions/event-control-unification.md`.

## Testing

- `bazel test //...` passes; new `edge_trigger_*` cases cover constant bit-select, range-select, indexed part-select (`+:` / `-:`), edge keyword combinations, event lists, and the LRM 9.4.2 "no false wake" anchor.
- Two rejection tests pin the compound and dynamic-index diagnostics.
- Every existing `event_*`, `always_comb_*`, `wait_level_*`, `named_event_*` test continues to pass with no modification.