### PR TITLE
Add ++ / -- operators (LRM 11.4.2)

### DIFF
--- a/docs/progress/integral.md
+++ b/docs/progress/integral.md
@@ -9,11 +9,7 @@ Done when every archive case under `operators/binary`, `operators/unary`,
 
 ## Actionable
 
-J19 is the only open item; everything else has shipped or is intentionally tracked elsewhere.
-
-| Item | Status                                                                           |
-| ---- | -------------------------------------------------------------------------------- |
-| J19  | Blocked on `operators.md` W12 (`++` / `--` shape and LRM 11.4.1 eval-once rule). |
+All items closed; integral surface complete.
 
 ## Sub-Steps
 
@@ -42,8 +38,8 @@ The numeric IDs are stable references and do not imply execution order.
       drives event-control change detection (LRM 9.4.2 "not equal to its previous value").
 - [x] J18 -- Wildcard equality `==?` / `!=?` (LRM 11.4.6): RHS X/Z treated as don't-care. Same work
       item as `operators.md` W2 (canonical home).
-- [ ] J19 -- `++` / `--` archive coverage (the five increment / decrement cases in
-      `operators/unary/two_state.yaml`). **Depends on** `operators.md` W12.
+- [x] J19 -- `++` / `--` archive coverage (the five increment / decrement cases in
+      `operators/unary/two_state.yaml`). Shipped together with `operators.md` W12.
 
 ## Cross-references
 

--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -14,12 +14,7 @@ Done when:
 
 ## Actionable
 
-W10 (concat lvalue) and W12 (`++` / `--`) are the only open items.
-
-| Item | Status                                                                                  |
-| ---- | --------------------------------------------------------------------------------------- |
-| W10  | Ready; depends on W6 (shipped). Distributes RHS bits across an ordered sub-lvalue list. |
-| W12  | Read-modify-write on the lvalue surface. LRM 11.4.1 evaluate-target-once applies.       |
+All items closed; operator surface in scope is complete.
 
 ## Sub-Steps
 
@@ -74,8 +69,8 @@ merged node.
       evaluated once and bits are distributed MSB-first, so `{a, b} = {b, a}` swaps. Parts may be
       any writable lvalue (including W6 selector chains, e.g. `{a[7:4], b[7:4]} = rhs`). NBA form
       requires every part to be a structural target. Replication operands are rejected per LRM
-      11.4.12.1. LRM 10.9 assignment-pattern LHS and LRM 11.4.14.3 streaming-unpack LHS are
-      separate constructs, both out of scope.
+      11.4.12.1. LRM 10.9 assignment-pattern LHS and LRM 11.4.14.3 streaming-unpack LHS are separate
+      constructs, both out of scope.
 
 ### Assignment families
 
@@ -83,9 +78,11 @@ merged node.
       target only once" applies; falls out of the C++ eval-once rule on the compound expression.
       NBA + compound is rejected at slang parsing per LRM A.6.2. Closes
       `operators/compound_assignment` for whole-var, selector, and mixed-state target shapes.
-- [ ] W12 -- `++` / `--` (prefix and postfix). The expression form returns the pre- or post-value,
-      so it is a distinct shape from `AssignExpr`. Once accepted in index positions, the same LRM
-      11.4.1 evaluate-target-once rule applies at the read-modify-write level.
+- [x] W12 -- `++` / `--` (prefix and postfix, LRM 11.4.2). Behave as blocking assignments; postfix
+      yields the operand's prior value, prefix yields the new value. Integer and real operands;
+      selector chains (`array[i]++`, `++a[15:8]`) and observable structural roots are covered. NBA
+      contexts (`b <= a++`, `var[i++] <= rhs`) evaluate the inc / dec exactly once at submit time.
+      Replication / concatenation operands are rejected as targets per LRM 11.4.12.1.
 
 ## Cross-references
 

--- a/docs/progress/packed.md
+++ b/docs/progress/packed.md
@@ -13,8 +13,8 @@ Done when:
 
 ## Actionable
 
-P3, P4, P5 are all open and ordered: P3 introduces packed-struct field access and unblocks P4
-(union field views ride on the same machinery); P5 builds assignment patterns on top.
+P3, P4, P5 are all open and ordered: P3 introduces packed-struct field access and unblocks P4 (union
+field views ride on the same machinery); P5 builds assignment patterns on top.
 
 | Item | Status                                                    |
 | ---- | --------------------------------------------------------- |

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -9,6 +9,7 @@
 #include "lyra/hir/binary_op.hpp"
 #include "lyra/hir/conversion.hpp"
 #include "lyra/hir/expr_id.hpp"
+#include "lyra/hir/inc_dec_op.hpp"
 #include "lyra/hir/inside_item.hpp"
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/range_bounds.hpp"
@@ -64,6 +65,17 @@ struct AssignExpr {
   ExprId rhs;
 };
 
+// LRM 11.4.2: `++a`, `a++`, `--a`, `a--`. Behave as blocking assignments;
+// postfix yields the operand's prior value, prefix yields the new value. The
+// `target` is an ExprId whose form must be addressable -- the same allowed
+// forms as `AssignExpr.lhs` minus `ConcatExpr` (slang rejects `++{a,b}` at
+// AST construction). Lvalue-ness is positional, validated by
+// `ValidateAssignableSlangExpr` at AST -> HIR time.
+struct IncDecExpr {
+  IncDecOp op;
+  ExprId target;
+};
+
 struct CallExpr {
   SubroutineRef callee;
   std::vector<ExprId> arguments;
@@ -96,9 +108,9 @@ struct ReplicationExpr {
 };
 
 using ExprData = std::variant<
-    PrimaryExpr, UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr, CallExpr,
-    ConversionExpr, InsideExpr, ElementSelectExpr, RangeSelectExpr, ConcatExpr,
-    ReplicationExpr>;
+    PrimaryExpr, UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr, IncDecExpr,
+    CallExpr, ConversionExpr, InsideExpr, ElementSelectExpr, RangeSelectExpr,
+    ConcatExpr, ReplicationExpr>;
 
 struct Expr {
   TypeId type;

--- a/include/lyra/hir/inc_dec_op.hpp
+++ b/include/lyra/hir/inc_dec_op.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+
+namespace lyra::hir {
+
+// LRM 11.4.2: `++a`, `a++`, `--a`, `a--`. The four forms differ on which
+// side of the operand the operator sits (pre / post -- affects the yielded
+// value) and on the direction of the side effect (inc / dec).
+enum class IncDecOp : std::uint8_t {
+  kPreInc,
+  kPostInc,
+  kPreDec,
+  kPostDec,
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/lowering/ast_to_hir/expression/slang_atoms.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/slang_atoms.hpp
@@ -13,6 +13,7 @@
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/binary_op.hpp"
 #include "lyra/hir/conversion.hpp"
+#include "lyra/hir/inc_dec_op.hpp"
 #include "lyra/hir/method.hpp"
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/unary_op.hpp"
@@ -34,6 +35,11 @@ auto LowerBinaryOp(slang::ast::BinaryOperator op) -> hir::BinaryOp;
 
 auto LowerUnaryOp(slang::ast::UnaryOperator op, diag::SourceSpan span)
     -> diag::Result<hir::UnaryOp>;
+
+// LRM 11.4.2: maps slang's inc/dec UnaryOperator values to hir::IncDecOp.
+// Throws InternalError if `op` is not one of the four inc/dec variants
+// (callers must dispatch on `slang::ast::OpInfo::isLValue(op)` first).
+auto LowerSlangIncDecOp(slang::ast::UnaryOperator op) -> hir::IncDecOp;
 
 auto LowerTimeUnit(slang::TimeUnit u) -> hir::TimeScale;
 

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -11,6 +11,7 @@
 #include "lyra/mir/closure.hpp"
 #include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr_id.hpp"
+#include "lyra/mir/inc_dec_op.hpp"
 #include "lyra/mir/integral_constant.hpp"
 #include "lyra/mir/range_bounds.hpp"
 #include "lyra/mir/runtime_diagnostic.hpp"
@@ -75,6 +76,15 @@ struct AssignExpr {
   ExprId value;
 };
 
+// LRM 11.4.2: `++a`, `a++`, `--a`, `a--`. Mirrors hir::IncDecExpr. The
+// `target` ExprId points at an addressable expression (PrimaryExpr var ref,
+// ElementSelectExpr, or RangeSelectExpr); ConcatExpr-as-target is illegal
+// per slang.
+struct IncDecExpr {
+  IncDecOp op;
+  ExprId target;
+};
+
 struct SystemSubroutineCallee {
   support::SystemSubroutineId id;
 };
@@ -119,8 +129,9 @@ struct ReplicationExpr {
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, StructuralParamRef,
     StructuralVarRef, ProceduralVarRef, UnaryExpr, BinaryExpr, ConditionalExpr,
-    AssignExpr, CallExpr, RuntimeCallExpr, ConversionExpr, ClosureExpr,
-    ElementSelectExpr, RangeSelectExpr, ConcatExpr, ReplicationExpr>;
+    AssignExpr, IncDecExpr, CallExpr, RuntimeCallExpr, ConversionExpr,
+    ClosureExpr, ElementSelectExpr, RangeSelectExpr, ConcatExpr,
+    ReplicationExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/mir/inc_dec_op.hpp
+++ b/include/lyra/mir/inc_dec_op.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+
+namespace lyra::mir {
+
+// LRM 11.4.2 mirror of hir::IncDecOp.
+enum class IncDecOp : std::uint8_t {
+  kPreInc,
+  kPostInc,
+  kPreDec,
+  kPostDec,
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -334,6 +334,31 @@ class ScopedMutation {
     return *this;
   }
 
+  // LRM 11.4.2 inc/dec on an observable whole-var. The snapshot is mutated
+  // in place; the destructor commits via WriteVar so subscribers fire exactly
+  // once. Prefix returns the new value; postfix returns the old. Both return
+  // by value (not `ScopedMutation&`) so outer rvalue use such as
+  // `b = ++observable_var` routes a materialized PackedArray through the
+  // outer WriteVar instead of a transient proxy.
+  auto operator++() -> value::PackedArray {
+    ++snapshot_;
+    return snapshot_;
+  }
+  auto operator++(int) -> value::PackedArray {
+    value::PackedArray prior = snapshot_;
+    ++snapshot_;
+    return prior;
+  }
+  auto operator--() -> value::PackedArray {
+    --snapshot_;
+    return snapshot_;
+  }
+  auto operator--(int) -> value::PackedArray {
+    value::PackedArray prior = snapshot_;
+    --snapshot_;
+    return prior;
+  }
+
  private:
   RuntimeServices* services_;
   Var<T>* var_;

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -261,6 +261,26 @@ class PackedArray {
     return *this = ArithmeticShiftRight(rhs);
   }
 
+  // LRM 11.4.2 inc/dec on a 1D integer value: prefix mutates in place and
+  // returns the new value (standard C++ idiom); postfix snapshots the old
+  // value, mutates, returns the snapshot.
+  auto operator++() -> PackedArray& {
+    return *this = *this + FromInt(1, bit_width_, is_signed_, is_four_state_);
+  }
+  auto operator++(int) -> PackedArray {
+    PackedArray prior = *this;
+    ++*this;
+    return prior;
+  }
+  auto operator--() -> PackedArray& {
+    return *this = *this - FromInt(1, bit_width_, is_signed_, is_four_state_);
+  }
+  auto operator--(int) -> PackedArray {
+    PackedArray prior = *this;
+    --*this;
+    return prior;
+  }
+
   [[nodiscard]] auto operator==(const PackedArray& other) const -> PackedArray;
   [[nodiscard]] auto operator!=(const PackedArray& other) const -> PackedArray;
   // LRM 11.4.6: X/Z in `other` are wildcards; X/Z in `*this` are not.
@@ -451,6 +471,39 @@ class PackedArrayRef {
   }
   auto ArithmeticShiftRightAssign(const PackedArray& rhs) -> PackedArrayRef& {
     return *this = PackedArray(*this).ArithmeticShiftRight(rhs);
+  }
+
+  // LRM 11.4.2 inc/dec on a partial-write proxy. Both forms return PackedArray
+  // by value -- prefix returns the new sub-slice, postfix returns the old --
+  // so an outer rvalue use (`b = ++var[3:0]`) consumes a materialized value
+  // instead of holding a transient proxy past the end of the full expression.
+  auto operator++() -> PackedArray {
+    PackedArray current(*this);
+    auto updated =
+        current + PackedArray::FromInt(
+                      1, bit_width_, current.IsSigned(), current.IsFourState());
+    *this = updated;
+    return updated;
+  }
+  auto operator++(int) -> PackedArray {
+    PackedArray prior(*this);
+    *this = prior + PackedArray::FromInt(
+                        1, bit_width_, prior.IsSigned(), prior.IsFourState());
+    return prior;
+  }
+  auto operator--() -> PackedArray {
+    PackedArray current(*this);
+    auto updated =
+        current - PackedArray::FromInt(
+                      1, bit_width_, current.IsSigned(), current.IsFourState());
+    *this = updated;
+    return updated;
+  }
+  auto operator--(int) -> PackedArray {
+    PackedArray prior(*this);
+    *this = prior - PackedArray::FromInt(
+                        1, bit_width_, prior.IsSigned(), prior.IsFourState());
+    return prior;
   }
 
   // Chain composition. Positions are in the current sub-view's outer-element

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1063,6 +1063,44 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
   return *chain_or + " = " + *value_or;
 }
 
+auto RenderIncDecExpr(const RenderContext& ctx, const mir::IncDecExpr& inc)
+    -> diag::Result<std::string> {
+  const mir::Expr& target_expr = ctx.Expr(inc.target);
+  const mir::StructuralVarRef* observable_root =
+      LhsRootStructuralVarForObservable(ctx, target_expr);
+  const bool observable = observable_root != nullptr && [&] {
+    const auto& var_decl =
+        ctx.StructuralScope().GetStructuralVar(observable_root->var);
+    return IsObservableScalarType(ctx.Unit().GetType(var_decl.type));
+  }();
+
+  std::string lhs;
+  if (IsLhsBarePrimary(target_expr)) {
+    auto root_or = RenderLhsExpr(ctx, target_expr, std::string_view{});
+    if (!root_or) return std::unexpected(std::move(root_or.error()));
+    lhs = observable ? *root_or + ".Mutate(*services_)" : *root_or;
+  } else {
+    const std::string_view mutate_adapter =
+        observable ? std::string_view{".Mutate(*services_)"}
+                   : std::string_view{};
+    auto chain_or = RenderLhsExpr(ctx, target_expr, mutate_adapter);
+    if (!chain_or) return std::unexpected(std::move(chain_or.error()));
+    lhs = *std::move(chain_or);
+  }
+
+  switch (inc.op) {
+    case mir::IncDecOp::kPreInc:
+      return "(++" + lhs + ")";
+    case mir::IncDecOp::kPostInc:
+      return "(" + lhs + "++)";
+    case mir::IncDecOp::kPreDec:
+      return "(--" + lhs + ")";
+    case mir::IncDecOp::kPostDec:
+      return "(" + lhs + "--)";
+  }
+  throw InternalError("RenderIncDecExpr: unknown IncDecOp");
+}
+
 auto RenderRangeSelectExpr(
     const RenderContext& ctx, const mir::Expr& expr,
     const mir::RangeSelectExpr& sel) -> diag::Result<std::string> {
@@ -1248,6 +1286,9 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
           },
           [&](const mir::AssignExpr& a) -> diag::Result<std::string> {
             return RenderAssignExpr(ctx, a);
+          },
+          [&](const mir::IncDecExpr& inc) -> diag::Result<std::string> {
+            return RenderIncDecExpr(ctx, inc);
           },
           [&](const mir::ConversionExpr& cv) -> diag::Result<std::string> {
             return RenderConversionExpr(ctx, expr, cv);

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -617,6 +617,23 @@ class HirDumper {
                   "AssignExpr kind={}{} lhs=Expr[{}] rhs=Expr[{}]", kind_str,
                   op_str, a.lhs.value, a.rhs.value);
             },
+            [](const IncDecExpr& inc) -> std::string {
+              const auto* op_str = [&] {
+                switch (inc.op) {
+                  case IncDecOp::kPreInc:
+                    return "PreInc";
+                  case IncDecOp::kPostInc:
+                    return "PostInc";
+                  case IncDecOp::kPreDec:
+                    return "PreDec";
+                  case IncDecOp::kPostDec:
+                    return "PostDec";
+                }
+                return "?";
+              }();
+              return std::format(
+                  "IncDecExpr op={} target=Expr[{}]", op_str, inc.target.value);
+            },
             [this](const CallExpr& c) -> std::string {
               std::string args;
               for (std::size_t i = 0; i < c.arguments.size(); ++i) {

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -607,6 +607,31 @@ auto LowerAssignmentExprProc(
   };
 }
 
+auto LowerIncDecExprProc(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const slang::ast::UnaryExpression& un, const slang::ast::Expression& expr,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  auto validate = ValidateAssignableSlangExpr(
+      unit_facts, unit_state, &proc_state, un.operand());
+  if (!validate) return std::unexpected(std::move(validate.error()));
+
+  auto target_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, un.operand());
+  if (!target_or) return std::unexpected(std::move(target_or.error()));
+  const hir::ExprId target_id = proc_state.AddExpr(*std::move(target_or));
+
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+
+  return hir::Expr{
+      .type = *type_id,
+      .data =
+          hir::IncDecExpr{.op = LowerSlangIncDecOp(un.op), .target = target_id},
+      .span = span,
+  };
+}
+
 auto LowerInsideExprProc(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ProcessLoweringState& proc_state, const ScopeStack& stack,
@@ -1119,10 +1144,15 @@ auto LowerProcExpr(
           unit_facts, unit_state, proc_state, stack,
           expr.as<slang::ast::ConversionExpression>(), expr, span);
 
-    case slang::ast::ExpressionKind::UnaryOp:
+    case slang::ast::ExpressionKind::UnaryOp: {
+      const auto& un = expr.as<slang::ast::UnaryExpression>();
+      if (slang::ast::OpInfo::isLValue(un.op)) {
+        return LowerIncDecExprProc(
+            unit_facts, unit_state, proc_state, stack, un, expr, span);
+      }
       return LowerUnaryExprProc(
-          unit_facts, unit_state, proc_state, stack,
-          expr.as<slang::ast::UnaryExpression>(), expr, span);
+          unit_facts, unit_state, proc_state, stack, un, expr, span);
+    }
 
     case slang::ast::ExpressionKind::BinaryOp:
       return LowerBinaryExprProc(
@@ -1229,10 +1259,18 @@ auto LowerStructuralExpr(
           unit_facts, unit_state, scope_state, stack,
           expr.as<slang::ast::ConversionExpression>(), expr, span);
 
-    case slang::ast::ExpressionKind::UnaryOp:
+    case slang::ast::ExpressionKind::UnaryOp: {
+      const auto& un = expr.as<slang::ast::UnaryExpression>();
+      if (slang::ast::OpInfo::isLValue(un.op)) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
+            "increment / decrement is not legal outside procedural code "
+            "(LRM 11.3.6, 11.4.2)",
+            diag::UnsupportedCategory::kOperation);
+      }
       return LowerUnaryExprStructural(
-          unit_facts, unit_state, scope_state, stack,
-          expr.as<slang::ast::UnaryExpression>(), expr, span);
+          unit_facts, unit_state, scope_state, stack, un, expr, span);
+    }
 
     case slang::ast::ExpressionKind::BinaryOp:
       return LowerBinaryExprStructural(

--- a/src/lyra/lowering/ast_to_hir/expression/slang_atoms.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/slang_atoms.cpp
@@ -134,12 +134,27 @@ auto LowerUnaryOp(slang::ast::UnaryOperator op, diag::SourceSpan span)
     case slang::ast::UnaryOperator::Predecrement:
     case slang::ast::UnaryOperator::Postincrement:
     case slang::ast::UnaryOperator::Postdecrement:
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedExpressionForm,
-          "increment and decrement expressions are not supported yet",
-          diag::UnsupportedCategory::kOperation);
+      throw InternalError(
+          "LowerUnaryOp: increment / decrement is handled via "
+          "LowerSlangIncDecOp into hir::IncDecExpr, not hir::UnaryExpr");
   }
   throw InternalError("LowerUnaryOp: unknown slang UnaryOperator");
+}
+
+auto LowerSlangIncDecOp(slang::ast::UnaryOperator op) -> hir::IncDecOp {
+  switch (op) {
+    case slang::ast::UnaryOperator::Preincrement:
+      return hir::IncDecOp::kPreInc;
+    case slang::ast::UnaryOperator::Postincrement:
+      return hir::IncDecOp::kPostInc;
+    case slang::ast::UnaryOperator::Predecrement:
+      return hir::IncDecOp::kPreDec;
+    case slang::ast::UnaryOperator::Postdecrement:
+      return hir::IncDecOp::kPostDec;
+    default:
+      throw InternalError(
+          "LowerSlangIncDecOp: not an increment / decrement operator");
+  }
 }
 
 auto LowerTimeUnit(slang::TimeUnit u) -> hir::TimeScale {

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -131,6 +131,20 @@ auto LowerUnaryOp(hir::UnaryOp op) -> mir::UnaryOp {
   throw InternalError("LowerUnaryOp: unknown HIR UnaryOp");
 }
 
+auto LowerIncDecOp(hir::IncDecOp op) -> mir::IncDecOp {
+  switch (op) {
+    case hir::IncDecOp::kPreInc:
+      return mir::IncDecOp::kPreInc;
+    case hir::IncDecOp::kPostInc:
+      return mir::IncDecOp::kPostInc;
+    case hir::IncDecOp::kPreDec:
+      return mir::IncDecOp::kPreDec;
+    case hir::IncDecOp::kPostDec:
+      return mir::IncDecOp::kPostDec;
+  }
+  throw InternalError("LowerIncDecOp: unknown HIR IncDecOp");
+}
+
 auto LowerTimeScale(hir::TimeScale s) -> mir::TimeScale {
   switch (s) {
     case hir::TimeScale::kFs:
@@ -730,6 +744,23 @@ auto LowerHirAssignExprProc(
       .type = unit_state.Builtins().void_type};
 }
 
+auto LowerHirIncDecExprProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, const hir::IncDecExpr& inc,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  auto target_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(inc.target.value));
+  if (!target_or) return std::unexpected(std::move(target_or.error()));
+  const mir::ExprId target_id = proc_scope_state.AddExpr(*std::move(target_or));
+  return mir::Expr{
+      .data = mir::IncDecExpr{.op = LowerIncDecOp(inc.op), .target = target_id},
+      .type = result_type};
+}
+
 auto LowerHirConversionExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
@@ -1006,6 +1037,11 @@ auto LowerExpr(
             return LowerHirAssignExprProc(
                 unit_state, scope_state, proc_state, proc_scope_state,
                 hir_process, a, expr.span, result_type);
+          },
+          [&](const hir::IncDecExpr& inc) -> diag::Result<mir::Expr> {
+            return LowerHirIncDecExprProc(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, inc, result_type);
           },
           [&](const hir::ConversionExpr& cv) -> diag::Result<mir::Expr> {
             return LowerHirConversionExprProc(
@@ -1298,6 +1334,12 @@ auto LowerExprImpl(
                 "LowerExprImpl (structural): HIR AssignExpr does not appear "
                 "in constructor-side expressions; structural code has no "
                 "general assignment");
+          },
+          [](const hir::IncDecExpr&) -> diag::Result<mir::Expr> {
+            throw InternalError(
+                "LowerExprImpl (structural): HIR IncDecExpr does not appear "
+                "in constructor-side expressions; structural code has no "
+                "increment / decrement");
           },
           [&](const hir::ConversionExpr& cv) -> diag::Result<mir::Expr> {
             return LowerHirConversionExprStructural(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -497,6 +497,23 @@ class MirDumper {
                   "AssignExpr target=Expr[{}]{} value=Expr[{}]", a.target.value,
                   op_str, a.value.value);
             },
+            [](const IncDecExpr& inc) -> std::string {
+              const auto* op_str = [&] {
+                switch (inc.op) {
+                  case IncDecOp::kPreInc:
+                    return "PreInc";
+                  case IncDecOp::kPostInc:
+                    return "PostInc";
+                  case IncDecOp::kPreDec:
+                    return "PreDec";
+                  case IncDecOp::kPostDec:
+                    return "PostDec";
+                }
+                return "?";
+              }();
+              return std::format(
+                  "IncDecExpr op={} target=Expr[{}]", op_str, inc.target.value);
+            },
             [this](const CallExpr& c) -> std::string {
               std::string args;
               for (std::size_t i = 0; i < c.arguments.size(); ++i) {

--- a/tests/cases/cpp/inc_dec_in_arithmetic/case.yaml
+++ b/tests/cases/cpp/inc_dec_in_arithmetic/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.inc_dec_in_arithmetic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a: 5
+    b: 10
+    c: 16
+    d: 15

--- a/tests/cases/cpp/inc_dec_in_arithmetic/main.sv
+++ b/tests/cases/cpp/inc_dec_in_arithmetic/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  int a, b, c, d;
+  initial begin
+    a = 5;
+    b = 10;
+    c = ++a + b--;
+    d = --a + ++b;
+  end
+endmodule

--- a/tests/cases/cpp/inc_dec_nba_rhs/case.yaml
+++ b/tests/cases/cpp/inc_dec_nba_rhs/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.inc_dec_nba_rhs
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a: 6
+    b: 5

--- a/tests/cases/cpp/inc_dec_nba_rhs/main.sv
+++ b/tests/cases/cpp/inc_dec_nba_rhs/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  int a;
+  int b;
+  initial begin
+    a = 5;
+    b <= a++;
+    #1;
+  end
+endmodule

--- a/tests/cases/cpp/inc_dec_nba_selector_index/case.yaml
+++ b/tests/cases/cpp/inc_dec_nba_selector_index/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.inc_dec_nba_selector_index
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    arr: "8'b00001000"
+    i: 4

--- a/tests/cases/cpp/inc_dec_nba_selector_index/main.sv
+++ b/tests/cases/cpp/inc_dec_nba_selector_index/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  bit [7:0] arr;
+  int i;
+  initial begin
+    arr = 8'b0000_0000;
+    i = 3;
+    arr[i++] <= 1'b1;
+    #1;
+  end
+endmodule

--- a/tests/cases/cpp/inc_dec_observable_var/case.yaml
+++ b/tests/cases/cpp/inc_dec_observable_var/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.inc_dec_observable_var
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a: 1
+    observed: 1

--- a/tests/cases/cpp/inc_dec_observable_var/main.sv
+++ b/tests/cases/cpp/inc_dec_observable_var/main.sv
@@ -1,0 +1,19 @@
+module Top;
+  int a;
+  int observed;
+  initial begin
+    a = 0;
+    observed = 0;
+  end
+  always @(a) begin
+    observed = a;
+  end
+  initial begin
+    #1;
+    a++;
+    #1;
+    ++a;
+    #1;
+    a--;
+  end
+endmodule

--- a/tests/cases/cpp/inc_dec_on_element_select/case.yaml
+++ b/tests/cases/cpp/inc_dec_on_element_select/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.inc_dec_on_element_select
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    e1: "8'h21"
+    e2: "8'h34"

--- a/tests/cases/cpp/inc_dec_on_element_select/main.sv
+++ b/tests/cases/cpp/inc_dec_on_element_select/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  byte e1, e2;
+  initial begin
+    bit [3:0][7:0] arr;
+    arr = 32'h11_22_33_44;
+    arr[2]--;
+    ++arr[1];
+    e1 = arr[2];
+    e2 = arr[1];
+  end
+endmodule

--- a/tests/cases/cpp/inc_dec_on_range_select/case.yaml
+++ b/tests/cases/cpp/inc_dec_on_range_select/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.inc_dec_on_range_select
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a: "16'h1335"

--- a/tests/cases/cpp/inc_dec_on_range_select/main.sv
+++ b/tests/cases/cpp/inc_dec_on_range_select/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  bit [15:0] a;
+  initial begin
+    a = 16'h1234;
+    a[7:0]++;
+    ++a[15:8];
+  end
+endmodule

--- a/tests/cases/cpp/inc_dec_postfix_int/case.yaml
+++ b/tests/cases/cpp/inc_dec_postfix_int/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.inc_dec_postfix_int
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a: 6
+    b: 5
+    c: 4
+    d: 5

--- a/tests/cases/cpp/inc_dec_postfix_int/main.sv
+++ b/tests/cases/cpp/inc_dec_postfix_int/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int a, b;
+  int c, d;
+  initial begin
+    a = 5;
+    b = a++;
+    c = 5;
+    d = c--;
+  end
+endmodule

--- a/tests/cases/cpp/inc_dec_prefix_int/case.yaml
+++ b/tests/cases/cpp/inc_dec_prefix_int/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.inc_dec_prefix_int
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a: 6
+    b: 6
+    c: 4
+    d: 4

--- a/tests/cases/cpp/inc_dec_prefix_int/main.sv
+++ b/tests/cases/cpp/inc_dec_prefix_int/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int a, b;
+  int c, d;
+  initial begin
+    a = 5;
+    b = ++a;
+    c = 5;
+    d = --c;
+  end
+endmodule

--- a/tests/cases/cpp/inc_dec_real/case.yaml
+++ b/tests/cases/cpp/inc_dec_real/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.inc_dec_real
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      2.500000
+      3.500000
+      3.500000

--- a/tests/cases/cpp/inc_dec_real/main.sv
+++ b/tests/cases/cpp/inc_dec_real/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  real r;
+  real prefix_new;
+  real postfix_old;
+  initial begin
+    r = 2.5;
+    prefix_new = ++r;
+    postfix_old = r--;
+    $display("%f", r);
+    $display("%f", prefix_new);
+    $display("%f", postfix_old);
+  end
+endmodule

--- a/tests/cases/cpp/inc_dec_statement_form/case.yaml
+++ b/tests/cases/cpp/inc_dec_statement_form/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.inc_dec_statement_form
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a: 11
+    b: 11
+    c: 9
+    d: 9

--- a/tests/cases/cpp/inc_dec_statement_form/main.sv
+++ b/tests/cases/cpp/inc_dec_statement_form/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  int a;
+  int b;
+  int c;
+  int d;
+  initial begin
+    a = 10;
+    b = 10;
+    c = 10;
+    d = 10;
+    a++;
+    ++b;
+    c--;
+    --d;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements the four `++` / `--` forms (LRM 11.4.2): prefix and postfix on inc and dec. Closes `operators.md` W12 and `integral.md` J19. Behaviour matches the LRM blocking-assignment semantic -- postfix yields the operand's prior value, prefix yields the new -- and covers integer and real operands, selector chains (`array[i]++`, `++a[15:8]`), observable structural roots, and NBA contexts (`b <= a++`, `var[i++] <= rhs`).

## Design

The W10 cut established that addressable-ness is a positional property of an expression (which field carries an `ExprId`), not a type tag. W12 extends that rule: ++ / -- introduces a single new IR node `IncDecExpr { IncDecOp op; ExprId target; }` in HIR and MIR, whose `target` is a positional-lvalue site validated by the same `ValidateAssignableSlangExpr` used for `AssignExpr.lhs`. A four-valued enum (`kPreInc`, `kPostInc`, `kPreDec`, `kPostDec`) avoids splitting the LRM's single operator family across two IR shapes.

Alternatives considered and rejected: (a) extending `UnaryOp` with four new values -- re-introduces the W10 anti-pattern by making the operand position addressable iff the tag matches; (b) desugaring prefix to `AssignExpr(compound=+)` at AST -> HIR with only postfix getting a node -- asymmetric and loses the source-level identity for both dumps and errors; (c) folding into `AssignExpr` with a `yield_old` flag -- over-generalises to a non-existent SV construct.

NBA interaction needs no new machinery. `BuildNbaSubmitClosureExpr` already captures the RHS by value at submit time, so `b <= a++` evaluates `a++` once during submit (writing `a`, yielding the old value) and the captured value flows to the closure body. The same applies to inc / dec inside selector indices on the NBA LHS via `CloneLhsExprForNbaBody`'s existing non-literal snapshot policy.

Render emits native C++ `++` / `--` against the existing LHS-render path -- same observable-root detection, same `.Mutate(*services_)` adapter for observable structural targets, same selector-chain composition. Runtime grows symmetric `operator++` / `operator--` (prefix + postfix) on `PackedArray`, `PackedArrayRef`, and `ScopedMutation`. The two proxy types return `PackedArray` by value (not the proxy by reference) so observable rvalue use such as `b = ++observable_var` routes a materialised value through the outer `WriteVar` rather than holding a transient proxy past the end of the full expression. Real operands ride on C++'s built-in `++` / `--` on `double`.

## Testing

Ten new end-to-end YAML cases under `tests/cases/cpp/inc_dec_*` covering prefix, postfix, statement form, mixed-expression (archive's `nested_increment_decrement`), range-select, element-select, observable structural, NBA on RHS, NBA on selector index, and real. The five archive cases in `operators/unary/two_state.yaml` reproduce via these tests.

`bazel test //... --test_output=errors` passes; `clang-format`, `buildifier`, `prettier`, and the four `tools/policy/check_*.py` are clean.