### PR TITLE
Lower parameter references and reconcile progress inventory

### DIFF
--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -54,11 +54,11 @@ Granular tracking lives in `integral.md` (integral / packed / wide_integral) and
 - [ ] datatypes/default_init
 - [x] datatypes/enum
 - [ ] datatypes/general
-- [ ] datatypes/integral -- `integral.md`.
+- [x] datatypes/integral -- `integral.md`.
 - [ ] datatypes/packed -- `packed.md`.
 - [x] datatypes/real
 - [ ] datatypes/representation
-- [ ] datatypes/string
+- [x] datatypes/string -- `datatypes.md` (string family SC1..SC3).
 - [ ] datatypes/unpacked
 - [ ] datatypes/wide_integral -- non-`packed_2d` archive sub-folders covered (`integral.md` J14);
       `packed_2d` (2D element index / slice) belongs to `datatypes/packed`.
@@ -116,18 +116,18 @@ Granular tracking lives in `integral.md` (integral / packed / wide_integral) and
 ### operators
 
 - [x] operators/binary -- `integral.md`.
-- [ ] operators/binary_string
+- [x] operators/binary_string -- `datatypes.md` SC1 (string equality and lexicographic comparison).
 - [x] operators/case_equality -- `operators.md`.
 - [ ] operators/comparison_value_temp -- subsumed by the binary-operator coverage in `integral.md`;
       the archived `ValueTemp` IR shape does not exist on the current pipeline.
-- [ ] operators/compound_assignment -- `operators.md`.
-- [ ] operators/concat -- `operators.md`.
-- [ ] operators/inside -- `operators.md`.
-- [ ] operators/replicate -- `operators.md`.
+- [x] operators/compound_assignment -- `operators.md`.
+- [x] operators/concat -- `operators.md`.
+- [x] operators/inside -- `operators.md`.
+- [x] operators/replicate -- `operators.md`.
 - [ ] operators/replication_patterns -- `packed.md`.
 - [x] operators/shift_overflow -- `integral.md`.
-- [ ] operators/unary -- integral surface covered (`integral.md` J14); `++` / `--` archive coverage
-      tracked at `integral.md` J19 (blocked on `operators.md` W12).
+- [x] operators/unary -- integral surface covered (`integral.md` J14); `++` / `--` archive coverage
+      via `operators.md` W12 and `integral.md` J19.
 - [ ] operators/value_temp_expansion -- subsumed by the binary-operator coverage in `integral.md`;
       the archived `ValueTemp` IR shape does not exist on the current pipeline.
 - [x] operators/wildcard_equality -- `operators.md`.

--- a/docs/progress/datatypes.md
+++ b/docs/progress/datatypes.md
@@ -8,14 +8,13 @@ file covers every other family: `datatypes/enum`, `datatypes/string`, `datatypes
 
 ## Actionable
 
-Enum, real, string, and the integral-family declaration initializers are complete. Parameter-driven
-initializers (SI2) and the unpacked / general / default-init / representation families remain.
+Enum, real, string, the integral-family declaration initializers, and parameter references in
+expressions are complete. The unpacked / general / default-init / representation families remain.
 
-| Item | Status                                                                          |
-| ---- | ------------------------------------------------------------------------------- |
-| SI2  | Parameter references in declaration initializers (see Structural Initializers). |
-| -    | `datatypes/unpacked`, `datatypes/general`, `datatypes/default_init`,            |
-|      | `datatypes/representation` -- no progress sub-steps opened yet.                 |
+| Item | Status                                                               |
+| ---- | -------------------------------------------------------------------- |
+| -    | `datatypes/unpacked`, `datatypes/general`, `datatypes/default_init`, |
+|      | `datatypes/representation` -- no progress sub-steps opened yet.      |
 
 ## Enum
 
@@ -64,9 +63,12 @@ LRM 6.8: a static-lifetime variable declaration may carry an initializer express
 
 - [x] SI1 -- Declaration initializers for the integral, enum, real, shortreal, and realtime
       families.
-- [ ] SI2 -- Initializer expressions that read a module parameter (`int i = N * 3;`). Diagnosed as
-      unsupported today; the gap is in how parameter references are lowered inside structural
-      expressions, not in the initializer mechanism itself.
+- [x] SI2 -- Parameter references in any expression context (LRM 6.20). A `NamedValueExpression`
+      whose symbol is a `parameter` / `localparam` lowers to the parameter's resolved value as a
+      literal, matching how enum-member references are handled. Covers integer, packed, real,
+      shortreal, and string parameter values; aggregate parameter types (unpacked array, queue,
+      packed struct) are blocked behind their respective type workstreams. Type parameters
+      (`parameter type T = int;`) ride on the type lowering path, not the expression path.
 
 ### Cross-references
 

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -485,7 +485,7 @@ class PackedArrayRef {
   // so an outer rvalue use (`b = ++var[3:0]`) consumes a materialized value
   // instead of holding a transient proxy past the end of the full expression.
   auto operator++() -> PackedArray {
-    PackedArray current(*this);
+    PackedArray current = Clone();
     auto updated =
         current + PackedArray::FromInt(
                       1, bit_width_, current.IsSigned(), current.IsFourState());
@@ -493,13 +493,13 @@ class PackedArrayRef {
     return updated;
   }
   auto operator++(int) -> PackedArray {
-    PackedArray prior(*this);
+    PackedArray prior = Clone();
     *this = prior + PackedArray::FromInt(
                         1, bit_width_, prior.IsSigned(), prior.IsFourState());
     return prior;
   }
   auto operator--() -> PackedArray {
-    PackedArray current(*this);
+    PackedArray current = Clone();
     auto updated =
         current - PackedArray::FromInt(
                       1, bit_width_, current.IsSigned(), current.IsFourState());
@@ -507,7 +507,7 @@ class PackedArrayRef {
     return updated;
   }
   auto operator--(int) -> PackedArray {
-    PackedArray prior(*this);
+    PackedArray prior = Clone();
     *this = prior - PackedArray::FromInt(
                         1, bit_width_, prior.IsSigned(), prior.IsFourState());
     return prior;

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -18,6 +18,7 @@
 #include <slang/ast/expressions/MiscExpressions.h>
 #include <slang/ast/expressions/OperatorExpressions.h>
 #include <slang/ast/expressions/SelectExpressions.h>
+#include <slang/ast/symbols/ParameterSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/AllTypes.h>
@@ -97,6 +98,55 @@ auto MakeEnumValueExpr(
                   }},
       .span = span,
   };
+}
+
+auto MakeParameterValueExpr(
+    const slang::ast::ParameterSymbol& sym, hir::TypeId type,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  const auto& cv = sym.getValue();
+  if (cv.isInteger()) {
+    return hir::Expr{
+        .type = type,
+        .data =
+            hir::PrimaryExpr{
+                .data =
+                    hir::IntegerLiteral{
+                        .value = LowerSVIntToIntegralConstant(cv.integer()),
+                        .base = hir::IntegerLiteralBase::kDecimal,
+                        .declared_unsized = false,
+                    }},
+        .span = span,
+    };
+  }
+  if (cv.isReal()) {
+    return hir::Expr{
+        .type = type,
+        .data = hir::PrimaryExpr{.data = hir::RealLiteral{.value = cv.real()}},
+        .span = span,
+    };
+  }
+  if (cv.isShortReal()) {
+    return hir::Expr{
+        .type = type,
+        .data =
+            hir::PrimaryExpr{
+                .data =
+                    hir::RealLiteral{
+                        .value = static_cast<double>(cv.shortReal())}},
+        .span = span,
+    };
+  }
+  if (cv.isString()) {
+    return hir::Expr{
+        .type = type,
+        .data = hir::PrimaryExpr{.data = hir::StringLiteral{.value = cv.str()}},
+        .span = span,
+    };
+  }
+  return diag::Unsupported(
+      span, diag::DiagCode::kUnsupportedExpressionForm,
+      "parameter of aggregate type is not yet supported",
+      diag::UnsupportedCategory::kFeature);
 }
 
 auto MakeStringLiteralExpr(
@@ -188,6 +238,13 @@ auto LowerNamedValueProc(
     }
   }
 
+  if (sym.kind == slang::ast::SymbolKind::Parameter) {
+    auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, named);
+    if (!type_id) return std::unexpected(std::move(type_id.error()));
+    return MakeParameterValueExpr(
+        sym.as<slang::ast::ParameterSymbol>(), *type_id, span);
+  }
+
   if (sym.kind != slang::ast::SymbolKind::Variable) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedNonVariableNamedReference,
@@ -243,6 +300,12 @@ auto LowerNamedValueStructural(
           hir::LoopVarRef{.hops = *hops, .loop_var = loop_binding->loop_var_id},
           loop_binding->type, span);
     }
+  }
+  if (sym.kind == slang::ast::SymbolKind::Parameter) {
+    auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, named);
+    if (!type_id) return std::unexpected(std::move(type_id.error()));
+    return MakeParameterValueExpr(
+        sym.as<slang::ast::ParameterSymbol>(), *type_id, span);
   }
   if (sym.kind != slang::ast::SymbolKind::Variable) {
     return diag::Unsupported(

--- a/tests/cases/cpp/localparam_in_initializer/case.yaml
+++ b/tests/cases/cpp/localparam_in_initializer/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.localparam_in_initializer
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    i: 8

--- a/tests/cases/cpp/localparam_in_initializer/main.sv
+++ b/tests/cases/cpp/localparam_in_initializer/main.sv
@@ -1,0 +1,4 @@
+module Top;
+  localparam int N = 7;
+  int i = N + 1;
+endmodule

--- a/tests/cases/cpp/parameter_in_for_loop_bound/case.yaml
+++ b/tests/cases/cpp/parameter_in_for_loop_bound/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.parameter_in_for_loop_bound
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    total: 6

--- a/tests/cases/cpp/parameter_in_for_loop_bound/main.sv
+++ b/tests/cases/cpp/parameter_in_for_loop_bound/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  parameter int LIMIT = 4;
+  int total = 0;
+  initial begin
+    for (int i = 0; i < LIMIT; i = i + 1) begin
+      total = total + i;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/parameter_in_initializer_int/case.yaml
+++ b/tests/cases/cpp/parameter_in_initializer_int/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.parameter_in_initializer_int
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    i: 15
+    j: 5

--- a/tests/cases/cpp/parameter_in_initializer_int/main.sv
+++ b/tests/cases/cpp/parameter_in_initializer_int/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  parameter int N = 5;
+  int i = N * 3;
+  int j = N;
+endmodule

--- a/tests/cases/cpp/parameter_in_initializer_packed/case.yaml
+++ b/tests/cases/cpp/parameter_in_initializer_packed/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.parameter_in_initializer_packed
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q: 0xAA
+    r: 0x0A

--- a/tests/cases/cpp/parameter_in_initializer_packed/main.sv
+++ b/tests/cases/cpp/parameter_in_initializer_packed/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  parameter logic [7:0] P = 8'hAA;
+  logic [7:0] q = P;
+  logic [7:0] r = P & 8'h0F;
+endmodule

--- a/tests/cases/cpp/parameter_in_initializer_real/case.yaml
+++ b/tests/cases/cpp/parameter_in_initializer_real/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.parameter_in_initializer_real
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      2.000000

--- a/tests/cases/cpp/parameter_in_initializer_real/main.sv
+++ b/tests/cases/cpp/parameter_in_initializer_real/main.sv
@@ -1,0 +1,5 @@
+module Top;
+  parameter real R = 1.5;
+  real r = R + 0.5;
+  initial $display("%f", r);
+endmodule

--- a/tests/cases/cpp/parameter_in_procedural/case.yaml
+++ b/tests/cases/cpp/parameter_in_procedural/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.parameter_in_procedural
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: 6
+    y: 10

--- a/tests/cases/cpp/parameter_in_procedural/main.sv
+++ b/tests/cases/cpp/parameter_in_procedural/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  parameter int N = 5;
+  int x;
+  int y;
+  initial begin
+    x = N + 1;
+    if (N > 0) y = N * 2;
+    else y = -1;
+  end
+endmodule

--- a/tests/cases/cpp/parameter_string_initializer/case.yaml
+++ b/tests/cases/cpp/parameter_string_initializer/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.parameter_string_initializer
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s: "hello"

--- a/tests/cases/cpp/parameter_string_initializer/main.sv
+++ b/tests/cases/cpp/parameter_string_initializer/main.sv
@@ -1,0 +1,4 @@
+module Top;
+  parameter string S = "hello";
+  string s = S;
+endmodule


### PR DESCRIPTION
## Summary

Closes `datatypes.md` SI2 by lowering parameter references the same way enum-value references already work: when a `NamedValueExpression` resolves to a `ParameterSymbol`, the lowering reads the parameter's compile-time `ConstantValue` and emits a HIR literal. Covers `int` / packed / `real` / `shortreal` / `string` parameter values; aggregate parameter types (unpacked array, queue, packed struct) are still rejected until their respective type workstreams open.

The change unblocks parameters everywhere — declaration initializers (`int i = N * 3;`), procedural code (`if (N > 0)`), and for-loop bounds (`for (int i = 0; i < LIMIT; i++)`). `localparam` rides on the same `SymbolKind::Parameter` path.

## Inventory reconciliation

While auditing whether SI2 closure should also flip the corresponding `architecture-reset.md` checkbox, found eight items in the inventory that had drifted out of sync with their working docs. All eight are now ticked: `operators/binary_string`, `operators/compound_assignment`, `operators/concat`, `operators/inside`, `operators/replicate`, `operators/unary`, `datatypes/string`, and `datatypes/integral`. The `operators/unary` note also no longer references the (now-resolved) `W12` block.

## Drive-by fix

`PackedArrayRef::operator++` / `operator--` (added in #809) used `PackedArray current(*this)`, but `PackedArrayRef` has no implicit conversion to `PackedArray`. The four methods now materialize via `Clone()` to match the compound-assignment shape on the same class.

## Testing

Seven new YAML cases under `tests/cases/cpp/` exercise parameter refs in initializers (int, packed, real, string), procedural code, for-loop bounds, and `localparam`. All pass alongside the full existing suite.