### PR TITLE
Add lyra run and compile commands

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -189,14 +189,40 @@ cc_library(
     ],
 )
 
-cc_binary(
-    name = "lyra",
-    srcs = ["src/lyra/driver/cli.cpp"],
+cc_library(
+    name = "driver",
+    srcs = [
+        "src/lyra/driver/cpp_build.cpp",
+        "src/lyra/driver/runtime_export.cpp",
+    ],
+    hdrs = [
+        "include/lyra/driver/cpp_build.hpp",
+        "include/lyra/driver/project_layout.hpp",
+        "include/lyra/driver/runtime_export.hpp",
+    ],
+    includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
         ":backend_cpp",
+        ":diag",
+        ":mir",
+        ":support",
+        "@bazel_tools//tools/cpp/runfiles",
+    ],
+)
+
+cc_binary(
+    name = "lyra",
+    srcs = ["src/lyra/driver/cli.cpp"],
+    data = [
+        ":cpp_runtime",
+        ":runtime_headers",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
         ":compiler",
         ":diag",
+        ":driver",
         ":frontend",
         ":hir",
         ":mir",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,11 @@ buildifier -r .
 ## Lyra CLI
 
 ```bash
-lyra dump hir [files...]         # Dump HIR (looks up lyra.toml by default)
-lyra dump mir [files...]         # Dump MIR
-lyra emit cpp [files...]         # Emit C++ source linked against the runtime
+lyra dump hir [files...]              # Dump HIR (looks up lyra.toml by default)
+lyra dump mir [files...]              # Dump MIR
+lyra emit cpp -o <dir> [files...]     # Write a self-contained C++ project (sources + build.sh + runtime)
+lyra compile -o <dir> [files...]      # Emit that project and build it -> <dir>/program
+lyra run [files...]                   # Emit, build, and execute, streaming the simulation output
 ```
 
 Common flags (apply to all subcommands):
@@ -40,7 +42,7 @@ Common flags (apply to all subcommands):
 -D NAME[=VALUE]                  # Preprocessor macro
 -G NAME=VALUE                    # Override a module parameter
 --single-unit                    # Compile all files as one compilation unit
--o <dir>                         # (emit cpp only) C++ output directory
+-o <dir>                         # Output directory (required for emit cpp and compile)
 ```
 
 ## SystemVerilog Version
@@ -77,7 +79,8 @@ bazel test //... --test_output=errors    # Same target set CI runs
 ## Benchmarks
 
 The benchmark runner under `tools/bench/` and the corresponding CI jobs depend on the `lyra run`
-subcommand and the runtime static library, neither of which is part of the current build.
+subcommand and the runtime static library. Both now exist, but the runner has not been re-validated
+against them.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -21,15 +21,18 @@ prioritizing fast iteration (compile + run + debug) over peak simulation speed.
 bazel build //:lyra
 
 # Dump HIR or MIR for a source file
-./bazel-bin/lyra dump hir path/to/file.sv
-./bazel-bin/lyra dump mir path/to/file.sv
+./bazel-bin/lyra dump hir --no-project --top Top path/to/file.sv
+./bazel-bin/lyra dump mir --no-project --top Top path/to/file.sv
 
-# Emit C++ from a project (looks up lyra.toml in the current directory)
-cd examples/hello
-../../bazel-bin/lyra emit cpp
+# Run a source file end to end (builds and executes, streaming output)
+./bazel-bin/lyra run --no-project --top Top path/to/file.sv
+
+# Or write a self-contained C++ project, optionally building it
+./bazel-bin/lyra emit cpp --no-project --top Top -o out path/to/file.sv
+./bazel-bin/lyra compile --no-project --top Top -o out path/to/file.sv
 ```
 
-The CLI exposes `dump {hir,mir}` and `emit cpp`.
+The CLI exposes `dump {hir,mir}`, `emit cpp`, `compile`, and `run`.
 
 ## Tests
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -46,6 +46,7 @@ If you are looking for a concept, this table points to the canonical doc.
 | LIR shape (CFG, basic blocks, storage)                                   | `lir.md`                    |
 | Stratified scheduler; regions; suspension protocol; NBA / closure submit | `scheduling.md`             |
 | Incremental compilation; query-based caching                             | `incremental_build.md`      |
+| Locating/bundling the C++ runtime; run output contract                   | `runtime_distribution.md`   |
 | Test categories; suite layout; expectation forms                         | `testing_strategy.md`       |
 
 ## Document Shape

--- a/docs/architecture/runtime_distribution.md
+++ b/docs/architecture/runtime_distribution.md
@@ -1,0 +1,52 @@
+# Runtime Distribution
+
+The C++ backend emits a program that links the **Lyra C++ runtime**: a standard-library-only static
+library and its headers. The emitted code depends on nothing else from the Lyra toolchain -- no
+third-party libraries. The runtime is, in effect, a small library that ships with the compiler and
+that emitted programs link against.
+
+## Two consumers of the runtime
+
+- **Bundled (portable artifact).** `emit cpp` and `compile` copy the runtime -- headers and static
+  library -- into the output directory alongside the generated sources and a build recipe. The
+  directory is then self-contained: it builds on another machine of the same platform with no Lyra
+  toolchain present.
+- **In place (ephemeral).** `run` builds the generated sources directly against the runtime where it
+  already lives and executes the result. It copies nothing.
+
+Both reduce to one question: _where does the Lyra runtime live for this binary?_
+
+## Locating the runtime
+
+There is a single answer point: a resolver that, given the running binary's own path, returns the
+runtime's include root and static library. Every consumer depends on the resolved location, never on
+how it was found. The resolution strategy is therefore free to change without touching the emit,
+compile, or run paths.
+
+Resolution strategies:
+
+- **Runfiles (current).** When `lyra` is built and run by Bazel -- the development binary and the
+  test suite -- the runtime is staged in the binary's runfiles tree and resolved from there.
+- **Install-relative (release; not yet built).** A released `lyra` is a plain binary with no
+  runfiles. It locates its runtime relative to its own executable path -- the convention clang, gcc,
+  and rustc use for their resource and sysroot directories. A distribution ships the binary
+  alongside its runtime, and the binary finds it from `argv0` / the executable path. This strategy
+  drops into the same resolver; the emit, compile, and run paths are unaffected.
+
+Until the install-relative strategy exists, `run`, `emit cpp`, and `compile` work only where
+runfiles are present (the Bazel build tree and the tests). This is a property of how `lyra` locates
+_its own_ runtime, not of the emitted output: an emitted project, once produced, carries its own
+runtime copy and build recipe and is independent of how `lyra` itself was distributed.
+
+## Command output contract
+
+`run` executes the simulation; its stdout and stderr are the simulation's own. Compile-phase
+diagnostics do not bleed into them -- warnings are not shown during `run` (use `dump`, `emit cpp`,
+or `compile` to see them), and compile errors are reported and abort before any simulation begins.
+This keeps `run` faithfully pipeable and testable as "the simulation's output".
+
+## Out of scope (for now)
+
+- The install layout and packaging of a `lyra` distribution: where the runtime sits relative to the
+  installed binary and how the two are packaged together. The resolver above is the single seam
+  where that work lands.

--- a/docs/progress/dev-ergonomics.md
+++ b/docs/progress/dev-ergonomics.md
@@ -7,16 +7,16 @@ layer directly.
 
 ## Sub-Steps
 
-- [ ] D1 -- A single command that runs a SystemVerilog file end-to-end. Today the CLI can dump the
-      intermediate forms and emit the C++ backend's output, but no command takes a source file all
-      the way to an executed simulation, so developers fall back on the test harness. Execution
-      should be a first-class command accepting the same inputs as the dump and emit commands.
+- [x] D1 -- A single command that runs a SystemVerilog file end-to-end. Running a source file is now
+      a first-class command that takes the same inputs as the dump and emit commands, builds it, and
+      streams the simulation's output. A sibling command produces a built executable without running
+      it. The backend that performs the build is an implementation detail of these commands.
 
-- [ ] D4 -- A self-contained build for the C++ backend's output. The emitted C++ depends only on the
-      C++ standard library and the Lyra runtime, so a standalone build needs no third-party include
-      paths. What remains is that the backend emits no build recipe, so a developer still assembles
-      the compile and link by hand. The backend should emit the build alongside the C++ so one
-      documented command produces a runnable binary and the output is portable on its own.
+- [x] D4 -- A self-contained build for the C++ backend's output. Emitting the C++ now produces a
+      complete project on disk: the translation units, a build recipe, and a bundled copy of the
+      Lyra runtime the emitted code depends on. The directory stands on its own -- one documented
+      command rebuilds it, and it can be handed to another machine of the same platform without a
+      Lyra checkout. Building it and running it are the compile and run commands layered on top.
 
 ## Out of Scope
 

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -49,6 +49,7 @@ enum class DiagCode : std::uint32_t {
   kHostProjectModeUnimplemented,
   kHostNoInputFiles,
   kHostIoError,
+  kHostBuildFailed,
   kHostExpectedSingleTopModule,
 
   kWarningPedantic,

--- a/include/lyra/driver/cpp_build.hpp
+++ b/include/lyra/driver/cpp_build.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <filesystem>
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/driver/runtime_export.hpp"
+#include "lyra/mir/compilation_unit.hpp"
+
+namespace lyra::driver {
+
+// Assemble a self-contained C++ project for `unit` into `dir`: the generated
+// translation units, a `build.sh` recipe, and a bundled copy of `runtime`. The
+// directory then builds with no external include or link paths.
+auto AssembleProject(
+    const RuntimeLocation& runtime, const mir::CompilationUnit& unit,
+    const std::filesystem::path& dir) -> diag::Result<void>;
+
+// Build the assembled project in `dir` by invoking the C++ compiler directly
+// (the same recipe `build.sh` carries). Returns the produced executable's path;
+// a non-zero compiler exit surfaces its stderr as a diagnostic.
+auto BuildProject(const std::filesystem::path& dir)
+    -> diag::Result<std::filesystem::path>;
+
+// Emit `unit`'s sources into `work_dir`, build them in place against `runtime`
+// (no bundled copy), execute the result streaming its stdout/stderr, and return
+// its exit code. This is the ephemeral path behind `run`: it never materializes
+// a portable project.
+auto RunInPlace(
+    const RuntimeLocation& runtime, const mir::CompilationUnit& unit,
+    const std::filesystem::path& work_dir) -> diag::Result<int>;
+
+}  // namespace lyra::driver

--- a/include/lyra/driver/project_layout.hpp
+++ b/include/lyra/driver/project_layout.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string_view>
+
+namespace lyra::driver {
+
+// Relative layout and build recipe of a self-contained emitted C++ project.
+// Shared by the `build.sh` the project ships and the in-process build that
+// `compile`/`run` drive, so the two never drift.
+inline constexpr std::string_view kRuntimeIncludeDir = "runtime/include";
+inline constexpr std::string_view kRuntimeLibDir = "runtime/lib";
+inline constexpr std::string_view kRuntimeLibFile = "libcpp_runtime.a";
+inline constexpr std::string_view kMainSource = "main.cpp";
+inline constexpr std::string_view kProgramName = "program";
+inline constexpr std::string_view kCxxStandardFlag = "-std=c++23";
+
+}  // namespace lyra::driver

--- a/include/lyra/driver/runtime_export.hpp
+++ b/include/lyra/driver/runtime_export.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+namespace lyra::driver {
+
+// The Lyra C++ runtime as it sits on disk for the running binary.
+struct RuntimeLocation {
+  // Directory to pass to the compiler's `-I`; contains the `lyra/` header tree.
+  std::filesystem::path include_root;
+  // The runtime static library to link.
+  std::filesystem::path lib;
+};
+
+// Locate the Lyra C++ runtime for the binary at `binary_path`. Resolution is a
+// single seam (see docs/architecture/runtime_distribution.md): today it reads
+// the binary's Bazel runfiles tree; a released binary will resolve relative to
+// its own install location. Callers depend only on the returned paths.
+auto ResolveRuntimeLocation(std::string_view binary_path)
+    -> std::expected<RuntimeLocation, std::string>;
+
+// Copy the located runtime (header closure plus the static library) into
+// `dest_dir`, matching the relative layout the emitted build recipe references,
+// so an emitted project builds with no external include or link paths.
+auto ExportRuntimeTree(
+    const RuntimeLocation& runtime, const std::filesystem::path& dest_dir)
+    -> std::expected<void, std::string>;
+
+}  // namespace lyra::driver

--- a/include/lyra/support/subprocess.hpp
+++ b/include/lyra/support/subprocess.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <span>
+#include <string>
+#include <string_view>
+
+namespace lyra::support {
+
+struct ProcessResult {
+  int exit_code = 0;
+  std::string stdout_text;
+  std::string stderr_text;
+};
+
+// Resolve an executable `name` to an absolute path. An absolute or
+// parent-qualified name is checked directly; a bare name is searched on PATH.
+auto FindOnPath(std::string_view name)
+    -> std::expected<std::filesystem::path, std::string>;
+
+// Resolve the C++ compiler to use for building emitted artifacts: `$CXX` when
+// set, otherwise the first of clang++, g++, c++ found on PATH. The emitted code
+// uses only standard C++23 features, so any of these compiles it.
+auto ResolveCxxCompiler() -> std::expected<std::filesystem::path, std::string>;
+
+// Run `exe args...` capturing stdout and stderr. A non-zero exit code is a
+// successful result (reported via ProcessResult::exit_code); an error is
+// returned only when the process cannot be spawned or reaped.
+auto RunProcessCaptured(
+    const std::filesystem::path& exe, std::span<const std::string> args)
+    -> std::expected<ProcessResult, std::string>;
+
+// Run `exe args...` inheriting this process's stdout and stderr, so the child's
+// output streams straight to the terminal. Returns the child's exit code.
+auto RunProcessStreaming(
+    const std::filesystem::path& exe, std::span<const std::string> args)
+    -> std::expected<int, std::string>;
+
+// Create a unique temporary directory and return its absolute path.
+auto MakeTempDir() -> std::expected<std::filesystem::path, std::string>;
+
+}  // namespace lyra::support

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -225,6 +225,12 @@ constexpr std::array kEntries{
             .category = std::nullopt,
             .name = "host_io_error"}},
     std::pair{
+        DiagCode::kHostBuildFailed,
+        DiagCodeInfo{
+            .kind = DiagKind::kHostError,
+            .category = std::nullopt,
+            .name = "host_build_failed"}},
+    std::pair{
         DiagCode::kHostExpectedSingleTopModule,
         DiagCodeInfo{
             .kind = DiagKind::kHostError,

--- a/src/lyra/driver/cli.cpp
+++ b/src/lyra/driver/cli.cpp
@@ -4,17 +4,15 @@
 #include <expected>
 #include <filesystem>
 #include <format>
-#include <fstream>
+#include <optional>
+#include <span>
 #include <string>
-#include <system_error>
 #include <unistd.h>
 #include <utility>
 #include <vector>
 
 #include <fmt/core.h>
 
-#include "lyra/backend/cpp/api.hpp"
-#include "lyra/backend/cpp/artifact.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/compiler/compile.hpp"
 #include "lyra/diag/diag_code.hpp"
@@ -22,14 +20,16 @@
 #include "lyra/diag/render.hpp"
 #include "lyra/diag/sink.hpp"
 #include "lyra/diag/source_manager.hpp"
+#include "lyra/driver/cpp_build.hpp"
+#include "lyra/driver/runtime_export.hpp"
 #include "lyra/frontend/load.hpp"
 #include "lyra/hir/dump.hpp"
 #include "lyra/mir/dump.hpp"
-#include "lyra/mir/structural_scope.hpp"
+#include "lyra/support/subprocess.hpp"
 
 namespace {
 
-enum class CommandKind { kDumpHir, kDumpMir, kEmitCpp };
+enum class CommandKind { kDumpHir, kDumpMir, kEmitCpp, kCompile, kRun };
 
 struct ParsedArgs {
   CommandKind cmd = CommandKind::kEmitCpp;
@@ -37,7 +37,7 @@ struct ParsedArgs {
   bool no_color = false;
   bool force_color = false;
   lyra::frontend::CompilationInput input;
-  std::string emit_out_dir;
+  std::string out_dir;
 };
 
 void AddCompilationFlags(argparse::ArgumentParser& cmd) {
@@ -111,12 +111,23 @@ auto ParseArgs(int argc, char** argv)
   argparse::ArgumentParser emit_cpp_cmd("cpp");
   AddCompilationFlags(emit_cpp_cmd);
   emit_cpp_cmd.add_argument("-o", "--out-dir")
-      .help("write C++ artifacts to this directory")
+      .help("write the self-contained C++ project to this directory")
       .default_value(std::string{});
   emit_cmd.add_subparser(emit_cpp_cmd);
 
+  argparse::ArgumentParser compile_cmd("compile");
+  AddCompilationFlags(compile_cmd);
+  compile_cmd.add_argument("-o", "--out-dir")
+      .help("write the self-contained project and built program here")
+      .default_value(std::string{});
+
+  argparse::ArgumentParser run_cmd("run");
+  AddCompilationFlags(run_cmd);
+
   program.add_subparser(dump_cmd);
   program.add_subparser(emit_cmd);
+  program.add_subparser(compile_cmd);
+  program.add_subparser(run_cmd);
 
   try {
     program.parse_args(argc, argv);
@@ -142,11 +153,28 @@ auto ParseArgs(int argc, char** argv)
     if (emit_cmd.is_subcommand_used("cpp")) {
       out.cmd = CommandKind::kEmitCpp;
       BindCompilationFlags(emit_cpp_cmd, out);
-      out.emit_out_dir = emit_cpp_cmd.get<std::string>("--out-dir");
+      out.out_dir = emit_cpp_cmd.get<std::string>("--out-dir");
+      if (out.out_dir.empty()) {
+        return std::unexpected(
+            std::format(
+                "emit cpp requires --out-dir\n{}", emit_cpp_cmd.help().str()));
+      }
     } else {
       return std::unexpected(
           std::format("emit requires 'cpp'\n{}", emit_cmd.help().str()));
     }
+  } else if (program.is_subcommand_used("compile")) {
+    out.cmd = CommandKind::kCompile;
+    BindCompilationFlags(compile_cmd, out);
+    out.out_dir = compile_cmd.get<std::string>("--out-dir");
+    if (out.out_dir.empty()) {
+      return std::unexpected(
+          std::format(
+              "compile requires --out-dir\n{}", compile_cmd.help().str()));
+    }
+  } else if (program.is_subcommand_used("run")) {
+    out.cmd = CommandKind::kRun;
+    BindCompilationFlags(run_cmd, out);
   } else {
     return std::unexpected(program.help().str());
   }
@@ -167,6 +195,9 @@ auto ResolveColorPreference(bool no_color_flag, bool force_color_flag) -> bool {
 
 auto main(int argc, char** argv) -> int {
   try {
+    const std::span<char* const> raw_args(argv, static_cast<std::size_t>(argc));
+    const std::string program_path =
+        raw_args.empty() ? std::string{} : std::string(raw_args.front());
     auto parsed = ParseArgs(argc, argv);
     const bool use_color =
         parsed.has_value()
@@ -210,7 +241,13 @@ auto main(int argc, char** argv) -> int {
                                 : lyra::compiler::StopAfter::kMir;
     auto result = lyra::compiler::Compile(args.input, sink, stop_after);
 
-    if (result.artifacts.parse) {
+    // `run` executes the simulation; its stdout/stderr are the simulation's
+    // own, so compile-phase warnings must not bleed into them. Surface slang
+    // diagnostics for run only when they carry errors (which abort below);
+    // other commands always show them. Use `compile`/`dump` to see warnings.
+    const bool suppress_compile_warnings =
+        args.cmd == CommandKind::kRun && result.slang_ok && !sink.HasErrors();
+    if (result.artifacts.parse && !suppress_compile_warnings) {
       std::string slang_text;
       lyra::frontend::RenderSlangDiagnostics(
           *result.artifacts.parse, use_color, slang_text);
@@ -236,70 +273,81 @@ auto main(int argc, char** argv) -> int {
       return 0;
     }
 
+    const lyra::diag::SourceManager* mgr =
+        result.artifacts.parse ? &result.artifacts.parse->diag_sources
+                               : nullptr;
+
+    auto resolve_runtime =
+        [&]() -> std::optional<lyra::driver::RuntimeLocation> {
+      auto loc_or = lyra::driver::ResolveRuntimeLocation(program_path);
+      if (!loc_or) {
+        report(
+            lyra::diag::Diagnostic::HostError(
+                lyra::diag::DiagCode::kHostIoError, std::move(loc_or.error())));
+        return std::nullopt;
+      }
+      return *loc_or;
+    };
+
     switch (args.cmd) {
       case CommandKind::kDumpMir:
         fmt::print("{}", lyra::mir::DumpMir(*result.artifacts.mir_unit));
         return 0;
       case CommandKind::kEmitCpp: {
-        const auto& root = result.artifacts.mir_unit->structural_scope;
-        if (root.name != args.input.top) {
-          throw lyra::InternalError(
-              std::format(
-                  "emit cpp: top scope '{}' does not match compilation unit "
-                  "root '{}'",
-                  args.input.top, root.name));
-        }
-        auto set_or = lyra::backend::cpp::EmitCpp(*result.artifacts.mir_unit);
-        if (!set_or) {
-          const lyra::diag::SourceManager* mgr =
-              result.artifacts.parse ? &result.artifacts.parse->diag_sources
-                                     : nullptr;
-          report(std::move(set_or.error()), mgr);
+        auto runtime = resolve_runtime();
+        if (!runtime) {
           return 1;
         }
-        const auto& set = *set_or;
-        if (args.emit_out_dir.empty()) {
-          for (const auto& file : set.files) {
-            fmt::print("=== {} ===\n{}", file.relpath, file.content);
-            if (!file.content.empty() && file.content.back() != '\n') {
-              fmt::print("\n");
-            }
-          }
-        } else {
-          std::error_code ec;
-          std::filesystem::create_directories(args.emit_out_dir, ec);
-          if (ec) {
-            throw lyra::InternalError(
-                std::format(
-                    "emit cpp: failed to create out-dir '{}': {}",
-                    args.emit_out_dir, ec.message()));
-          }
-          for (const auto& file : set.files) {
-            const auto path =
-                std::filesystem::path(args.emit_out_dir) / file.relpath;
-            std::filesystem::create_directories(path.parent_path(), ec);
-            if (ec) {
-              throw lyra::InternalError(
-                  std::format(
-                      "emit cpp: failed to create '{}': {}",
-                      path.parent_path().string(), ec.message()));
-            }
-            std::ofstream out_stream(path);
-            if (!out_stream) {
-              throw lyra::InternalError(
-                  std::format(
-                      "emit cpp: failed to open '{}' for write",
-                      path.string()));
-            }
-            out_stream << file.content;
-            out_stream.flush();
-            if (!out_stream) {
-              throw lyra::InternalError(
-                  std::format("emit cpp: failed to write '{}'", path.string()));
-            }
-          }
+        const std::filesystem::path dir = args.out_dir;
+        auto assembled = lyra::driver::AssembleProject(
+            *runtime, *result.artifacts.mir_unit, dir);
+        if (!assembled) {
+          report(std::move(assembled.error()), mgr);
+          return 1;
         }
+        fmt::print("emitted: {}\n", dir.string());
         return 0;
+      }
+      case CommandKind::kCompile: {
+        auto runtime = resolve_runtime();
+        if (!runtime) {
+          return 1;
+        }
+        const std::filesystem::path dir = args.out_dir;
+        auto assembled = lyra::driver::AssembleProject(
+            *runtime, *result.artifacts.mir_unit, dir);
+        if (!assembled) {
+          report(std::move(assembled.error()), mgr);
+          return 1;
+        }
+        auto built = lyra::driver::BuildProject(dir);
+        if (!built) {
+          report(std::move(built.error()), mgr);
+          return 1;
+        }
+        fmt::print("compiled: {}\n", built->string());
+        return 0;
+      }
+      case CommandKind::kRun: {
+        auto runtime = resolve_runtime();
+        if (!runtime) {
+          return 1;
+        }
+        auto tmp_or = lyra::support::MakeTempDir();
+        if (!tmp_or) {
+          report(
+              lyra::diag::Diagnostic::HostError(
+                  lyra::diag::DiagCode::kHostIoError,
+                  std::move(tmp_or.error())));
+          return 1;
+        }
+        auto exit_code = lyra::driver::RunInPlace(
+            *runtime, *result.artifacts.mir_unit, *tmp_or);
+        if (!exit_code) {
+          report(std::move(exit_code.error()), mgr);
+          return 1;
+        }
+        return *exit_code;
       }
       case CommandKind::kDumpHir:
         break;

--- a/src/lyra/driver/cpp_build.cpp
+++ b/src/lyra/driver/cpp_build.cpp
@@ -1,0 +1,163 @@
+#include "lyra/driver/cpp_build.hpp"
+
+#include <format>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "lyra/backend/cpp/api.hpp"
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/driver/project_layout.hpp"
+#include "lyra/driver/runtime_export.hpp"
+#include "lyra/support/subprocess.hpp"
+
+namespace lyra::driver {
+
+namespace {
+
+auto IoError(std::string message) {
+  return diag::HostError(diag::DiagCode::kHostIoError, std::move(message));
+}
+
+auto WriteFile(const std::filesystem::path& path, std::string_view content)
+    -> diag::Result<void> {
+  std::error_code ec;
+  std::filesystem::create_directories(path.parent_path(), ec);
+  if (ec) {
+    return IoError(
+        std::format(
+            "failed to create '{}': {}", path.parent_path().string(),
+            ec.message()));
+  }
+  std::ofstream out(path, std::ios::binary);
+  out << content;
+  out.flush();
+  if (!out) {
+    return IoError(std::format("failed to write '{}'", path.string()));
+  }
+  return {};
+}
+
+auto RenderBuildScript() -> std::string {
+  return std::format(
+      "#!/bin/sh\n"
+      "# Build this self-contained Lyra C++ project. Override the compiler "
+      "with $CXX.\n"
+      "set -e\n"
+      "\"${{CXX:-clang++}}\" {} -I {} {} {}/{} -o {}\n",
+      kCxxStandardFlag, kRuntimeIncludeDir, kMainSource, kRuntimeLibDir,
+      kRuntimeLibFile, kProgramName);
+}
+
+auto EmitAndWriteSources(
+    const mir::CompilationUnit& unit, const std::filesystem::path& dir)
+    -> diag::Result<void> {
+  auto set_or = backend::cpp::EmitCpp(unit);
+  if (!set_or) {
+    return std::unexpected(std::move(set_or.error()));
+  }
+  for (const auto& file : set_or->files) {
+    if (auto r = WriteFile(dir / file.relpath, file.content); !r) {
+      return r;
+    }
+  }
+  return {};
+}
+
+auto CompileProgram(
+    const std::filesystem::path& main_cpp,
+    const std::filesystem::path& include_root, const std::filesystem::path& lib,
+    const std::filesystem::path& program) -> diag::Result<void> {
+  auto cxx_or = support::ResolveCxxCompiler();
+  if (!cxx_or) {
+    return IoError(std::move(cxx_or.error()));
+  }
+  const std::vector<std::string> args = {
+      std::string(kCxxStandardFlag),
+      "-I",
+      include_root.string(),
+      main_cpp.string(),
+      lib.string(),
+      "-o",
+      program.string()};
+  auto result_or = support::RunProcessCaptured(*cxx_or, args);
+  if (!result_or) {
+    return IoError(std::move(result_or.error()));
+  }
+  if (result_or->exit_code != 0) {
+    return diag::HostError(
+        diag::DiagCode::kHostBuildFailed,
+        std::format(
+            "C++ compiler exited with {}:\n{}", result_or->exit_code,
+            result_or->stderr_text));
+  }
+  return {};
+}
+
+}  // namespace
+
+auto AssembleProject(
+    const RuntimeLocation& runtime, const mir::CompilationUnit& unit,
+    const std::filesystem::path& dir) -> diag::Result<void> {
+  if (auto r = EmitAndWriteSources(unit, dir); !r) {
+    return r;
+  }
+
+  const auto script_path = dir / "build.sh";
+  if (auto r = WriteFile(script_path, RenderBuildScript()); !r) {
+    return r;
+  }
+  std::error_code ec;
+  std::filesystem::permissions(
+      script_path,
+      std::filesystem::perms::owner_exec | std::filesystem::perms::group_exec |
+          std::filesystem::perms::others_exec,
+      std::filesystem::perm_options::add, ec);
+  if (ec) {
+    return IoError(
+        std::format(
+            "failed to mark '{}' executable: {}", script_path.string(),
+            ec.message()));
+  }
+
+  if (auto exported = ExportRuntimeTree(runtime, dir); !exported) {
+    return IoError(std::move(exported.error()));
+  }
+  return {};
+}
+
+auto BuildProject(const std::filesystem::path& dir)
+    -> diag::Result<std::filesystem::path> {
+  const auto program = dir / kProgramName;
+  if (auto r = CompileProgram(
+          dir / kMainSource, dir / kRuntimeIncludeDir,
+          dir / kRuntimeLibDir / kRuntimeLibFile, program);
+      !r) {
+    return std::unexpected(std::move(r.error()));
+  }
+  return program;
+}
+
+auto RunInPlace(
+    const RuntimeLocation& runtime, const mir::CompilationUnit& unit,
+    const std::filesystem::path& work_dir) -> diag::Result<int> {
+  if (auto r = EmitAndWriteSources(unit, work_dir); !r) {
+    return std::unexpected(std::move(r.error()));
+  }
+  const auto program = work_dir / kProgramName;
+  if (auto r = CompileProgram(
+          work_dir / kMainSource, runtime.include_root, runtime.lib, program);
+      !r) {
+    return std::unexpected(std::move(r.error()));
+  }
+  auto exit_or = support::RunProcessStreaming(program, {});
+  if (!exit_or) {
+    return IoError(std::move(exit_or.error()));
+  }
+  return *exit_or;
+}
+
+}  // namespace lyra::driver

--- a/src/lyra/driver/runtime_export.cpp
+++ b/src/lyra/driver/runtime_export.cpp
@@ -1,0 +1,140 @@
+#include "lyra/driver/runtime_export.hpp"
+
+#include <expected>
+#include <filesystem>
+#include <format>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include "lyra/driver/project_layout.hpp"
+#include "tools/cpp/runfiles/runfiles.h"
+
+namespace lyra::driver {
+
+namespace {
+
+using bazel::tools::cpp::runfiles::Runfiles;
+
+// Copy one file, overwriting, and ensure the result is owner-writable. The
+// runtime sources come from the build cache read-only; without this a re-emit
+// into the same directory cannot overwrite the previous copy.
+auto CopyFileOverwrite(
+    const std::filesystem::path& from, const std::filesystem::path& to)
+    -> std::expected<void, std::string> {
+  std::error_code ec;
+  std::filesystem::copy_file(
+      from, to, std::filesystem::copy_options::overwrite_existing, ec);
+  if (ec) {
+    return std::unexpected(
+        std::format(
+            "failed to copy '{}' to '{}': {}", from.string(), to.string(),
+            ec.message()));
+  }
+  std::filesystem::permissions(
+      to, std::filesystem::perms::owner_write,
+      std::filesystem::perm_options::add, ec);
+  if (ec) {
+    return std::unexpected(
+        std::format(
+            "failed to set permissions on '{}': {}", to.string(),
+            ec.message()));
+  }
+  return {};
+}
+
+// Copy a directory tree, dereferencing symlinks into real files. Runfiles
+// stages headers as symlinks into the build cache; copying them verbatim would
+// leave the exported tree pointing back at the cache instead of standing alone.
+auto CopyTree(
+    const std::filesystem::path& from, const std::filesystem::path& to)
+    -> std::expected<void, std::string> {
+  std::error_code ec;
+  for (const auto& entry : std::filesystem::recursive_directory_iterator(
+           from, std::filesystem::directory_options::follow_directory_symlink,
+           ec)) {
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    // Lexical relative only: runfiles entries are symlinks into the build
+    // cache, and a filesystem-resolving `relative` would canonicalize them
+    // back to their source locations and escape the destination tree.
+    const auto rel = entry.path().lexically_relative(from);
+    const auto dest = to / rel;
+    std::filesystem::create_directories(dest.parent_path(), ec);
+    if (ec) {
+      return std::unexpected(
+          std::format(
+              "failed to create '{}': {}", dest.parent_path().string(),
+              ec.message()));
+    }
+    if (auto r = CopyFileOverwrite(entry.path(), dest); !r) {
+      return r;
+    }
+  }
+  if (ec) {
+    return std::unexpected(
+        std::format("failed to walk '{}': {}", from.string(), ec.message()));
+  }
+  return {};
+}
+
+}  // namespace
+
+auto ResolveRuntimeLocation(std::string_view binary_path)
+    -> std::expected<RuntimeLocation, std::string> {
+  std::string rf_error;
+  std::unique_ptr<Runfiles> runfiles{
+      Runfiles::Create(std::string(binary_path), &rf_error)};
+  if (!runfiles) {
+    return std::unexpected(
+        std::format("cannot access the Lyra runtime: {}", rf_error));
+  }
+  // The header closure is staged under `include/lyra/`; resolve one known
+  // header and walk up to the `include` root the emitted code includes from.
+  const std::filesystem::path engine_hpp =
+      runfiles->Rlocation("_main/include/lyra/runtime/engine.hpp");
+  if (engine_hpp.empty() || !std::filesystem::exists(engine_hpp)) {
+    return std::unexpected("cannot locate the Lyra runtime headers");
+  }
+  const std::filesystem::path lib =
+      runfiles->Rlocation("_main/libcpp_runtime.a");
+  if (lib.empty() || !std::filesystem::exists(lib)) {
+    return std::unexpected("cannot locate the Lyra runtime library");
+  }
+  return RuntimeLocation{
+      .include_root = engine_hpp.parent_path().parent_path().parent_path(),
+      .lib = lib};
+}
+
+auto ExportRuntimeTree(
+    const RuntimeLocation& runtime, const std::filesystem::path& dest_dir)
+    -> std::expected<void, std::string> {
+  const auto lyra_include_root = runtime.include_root / "lyra";
+
+  const auto include_dest = dest_dir / kRuntimeIncludeDir / "lyra";
+  const auto lib_dest_dir = dest_dir / kRuntimeLibDir;
+
+  std::error_code ec;
+  std::filesystem::create_directories(include_dest.parent_path(), ec);
+  if (ec) {
+    return std::unexpected(
+        std::format(
+            "failed to create '{}': {}", include_dest.parent_path().string(),
+            ec.message()));
+  }
+  std::filesystem::create_directories(lib_dest_dir, ec);
+  if (ec) {
+    return std::unexpected(
+        std::format(
+            "failed to create '{}': {}", lib_dest_dir.string(), ec.message()));
+  }
+
+  if (auto r = CopyTree(lyra_include_root, include_dest); !r) {
+    return r;
+  }
+  return CopyFileOverwrite(runtime.lib, lib_dest_dir / kRuntimeLibFile);
+}
+
+}  // namespace lyra::driver

--- a/src/lyra/support/subprocess.cpp
+++ b/src/lyra/support/subprocess.cpp
@@ -1,0 +1,225 @@
+#include "lyra/support/subprocess.hpp"
+
+#include <array>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <expected>
+#include <filesystem>
+#include <format>
+#include <poll.h>
+#include <span>
+#include <spawn.h>
+#include <string>
+#include <string_view>
+#include <sys/wait.h>
+#include <system_error>
+#include <unistd.h>
+#include <vector>
+
+namespace lyra::support {
+
+namespace {
+
+auto IsExecutableFile(const std::filesystem::path& path) -> bool {
+  std::error_code ec;
+  if (!std::filesystem::is_regular_file(path, ec) || ec) {
+    return false;
+  }
+  return access(path.c_str(), X_OK) == 0;
+}
+
+auto BuildArgv(const std::string& exe, std::span<const std::string> args)
+    -> std::vector<std::string> {
+  std::vector<std::string> argv;
+  argv.reserve(args.size() + 1);
+  argv.push_back(exe);
+  argv.insert(argv.end(), args.begin(), args.end());
+  return argv;
+}
+
+auto ToCharPointers(std::vector<std::string>& argv) -> std::vector<char*> {
+  std::vector<char*> ptrs;
+  ptrs.reserve(argv.size() + 1);
+  for (auto& arg : argv) {
+    ptrs.push_back(arg.data());
+  }
+  ptrs.push_back(nullptr);
+  return ptrs;
+}
+
+}  // namespace
+
+auto FindOnPath(std::string_view name)
+    -> std::expected<std::filesystem::path, std::string> {
+  const std::filesystem::path candidate(name);
+  if (candidate.is_absolute() || candidate.has_parent_path()) {
+    auto absolute = std::filesystem::absolute(candidate);
+    if (IsExecutableFile(absolute)) {
+      return absolute;
+    }
+    return std::unexpected(
+        std::format("'{}' is not an executable file", absolute.string()));
+  }
+  const char* path_env = std::getenv("PATH");
+  if (path_env == nullptr) {
+    return std::unexpected("PATH is unset");
+  }
+  std::string_view path(path_env);
+  while (!path.empty()) {
+    const auto sep = path.find(':');
+    const auto entry = path.substr(0, sep);
+    if (!entry.empty()) {
+      auto full = std::filesystem::path(entry) / candidate;
+      if (IsExecutableFile(full)) {
+        return full;
+      }
+    }
+    if (sep == std::string_view::npos) {
+      break;
+    }
+    path.remove_prefix(sep + 1);
+  }
+  return std::unexpected(
+      std::format("'{}' not found on PATH", candidate.string()));
+}
+
+auto ResolveCxxCompiler() -> std::expected<std::filesystem::path, std::string> {
+  const char* env = std::getenv("CXX");
+  if (env != nullptr) {
+    const std::string_view sv(env);
+    if (!sv.empty()) {
+      return FindOnPath(sv);
+    }
+  }
+  for (const std::string_view candidate : {"clang++", "g++", "c++"}) {
+    auto found = FindOnPath(candidate);
+    if (found) {
+      return *found;
+    }
+  }
+  return std::unexpected(
+      "no C++ compiler found on PATH (tried clang++, g++, c++; set $CXX to "
+      "override)");
+}
+
+auto RunProcessCaptured(
+    const std::filesystem::path& exe, std::span<const std::string> args)
+    -> std::expected<ProcessResult, std::string> {
+  std::array<int, 2> out_pipe{};
+  std::array<int, 2> err_pipe{};
+  if (pipe(out_pipe.data()) != 0 || pipe(err_pipe.data()) != 0) {
+    return std::unexpected(
+        std::format("failed to create pipe: {}", std::strerror(errno)));
+  }
+
+  posix_spawn_file_actions_t actions{};
+  posix_spawn_file_actions_init(&actions);
+  posix_spawn_file_actions_adddup2(&actions, out_pipe[1], STDOUT_FILENO);
+  posix_spawn_file_actions_adddup2(&actions, err_pipe[1], STDERR_FILENO);
+  posix_spawn_file_actions_addclose(&actions, out_pipe[0]);
+  posix_spawn_file_actions_addclose(&actions, out_pipe[1]);
+  posix_spawn_file_actions_addclose(&actions, err_pipe[0]);
+  posix_spawn_file_actions_addclose(&actions, err_pipe[1]);
+
+  std::string exe_str = exe.string();
+  auto argv = BuildArgv(exe_str, args);
+  auto argv_ptrs = ToCharPointers(argv);
+
+  pid_t pid = 0;
+  const int spawn_result = posix_spawn(
+      &pid, exe_str.c_str(), &actions, nullptr, argv_ptrs.data(), environ);
+  posix_spawn_file_actions_destroy(&actions);
+  close(out_pipe[1]);
+  close(err_pipe[1]);
+
+  if (spawn_result != 0) {
+    close(out_pipe[0]);
+    close(err_pipe[0]);
+    return std::unexpected(
+        std::format(
+            "failed to spawn '{}': {}", exe_str, std::strerror(spawn_result)));
+  }
+
+  ProcessResult result;
+  std::array<struct pollfd, 2> fds{};
+  fds[0] = {.fd = out_pipe[0], .events = POLLIN, .revents = 0};
+  fds[1] = {.fd = err_pipe[0], .events = POLLIN, .revents = 0};
+  const int out_fd = out_pipe[0];
+  int open_fds = 2;
+  std::array<char, 4096> buffer{};
+
+  while (open_fds > 0) {
+    const int ready = poll(fds.data(), fds.size(), -1);
+    if (ready < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      break;
+    }
+    for (auto& fd : fds) {
+      if (fd.fd >= 0 && (fd.revents & (POLLIN | POLLHUP)) != 0) {
+        const ssize_t n = read(fd.fd, buffer.data(), buffer.size());
+        if (n > 0) {
+          auto& target =
+              (fd.fd == out_fd) ? result.stdout_text : result.stderr_text;
+          target.append(buffer.data(), static_cast<std::size_t>(n));
+        } else {
+          close(fd.fd);
+          fd.fd = -1;
+          --open_fds;
+        }
+      }
+    }
+  }
+
+  int status = 0;
+  while (waitpid(pid, &status, 0) < 0) {
+    if (errno != EINTR) {
+      return std::unexpected(
+          std::format("waitpid failed: {}", std::strerror(errno)));
+    }
+  }
+  result.exit_code =
+      WIFEXITED(status) ? WEXITSTATUS(status) : 128 + WTERMSIG(status);
+  return result;
+}
+
+auto RunProcessStreaming(
+    const std::filesystem::path& exe, std::span<const std::string> args)
+    -> std::expected<int, std::string> {
+  std::string exe_str = exe.string();
+  auto argv = BuildArgv(exe_str, args);
+  auto argv_ptrs = ToCharPointers(argv);
+
+  pid_t pid = 0;
+  const int spawn_result = posix_spawn(
+      &pid, exe_str.c_str(), nullptr, nullptr, argv_ptrs.data(), environ);
+  if (spawn_result != 0) {
+    return std::unexpected(
+        std::format(
+            "failed to spawn '{}': {}", exe_str, std::strerror(spawn_result)));
+  }
+
+  int status = 0;
+  while (waitpid(pid, &status, 0) < 0) {
+    if (errno != EINTR) {
+      return std::unexpected(
+          std::format("waitpid failed: {}", std::strerror(errno)));
+    }
+  }
+  return WIFEXITED(status) ? WEXITSTATUS(status) : 128 + WTERMSIG(status);
+}
+
+auto MakeTempDir() -> std::expected<std::filesystem::path, std::string> {
+  const auto base = std::filesystem::temp_directory_path() / "lyra-XXXXXX";
+  std::string templ = base.string();
+  if (mkdtemp(templ.data()) == nullptr) {
+    return std::unexpected(
+        std::format(
+            "mkdtemp('{}') failed: {}", base.string(), std::strerror(errno)));
+  }
+  return std::filesystem::path(templ);
+}
+
+}  // namespace lyra::support

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -23,13 +23,27 @@ cc_test(
 )
 
 cc_test(
+    name = "run_tests",
+    srcs = ["run_test.cpp"],
+    data = ["//:lyra"],
+    # `compile`/`run` drive the host C++ compiler, so this is excluded from CI's
+    # `Test` job (which filters out `requires-host-cxx`). Run locally with
+    # `bazel test //tests:run_tests`.
+    tags = ["requires-host-cxx"],
+    deps = [
+        ":framework",
+        "//:support",
+        "@bazel_tools//tools/cpp/runfiles",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "cpp_tests",
     srcs = ["cpp_test.cpp"],
     data = [
         "suites.yaml",
-        "//:cpp_runtime",
         "//:lyra",
-        "//:runtime_headers",
     ] + glob(
         [
             "cases/**/*.yaml",
@@ -38,7 +52,7 @@ cc_test(
         allow_empty = True,
     ),
     shard_count = 16,
-    # cpp-backend cases compile emitted artifacts with the host C++ compiler.
+    # cpp-backend cases run `lyra run`, which builds with the host C++ compiler.
     # CI's `Test` job passes `--test_tag_filters=-requires-host-cxx` so this
     # target is excluded; run locally with `bazel test //tests:cpp_tests`.
     tags = ["requires-host-cxx"],

--- a/tests/cpp_test.cpp
+++ b/tests/cpp_test.cpp
@@ -25,7 +25,6 @@ struct CppEnv {
   std::filesystem::path lyra_exe;
   std::filesystem::path cases_root;
   std::filesystem::path suites_yaml;
-  lyra::test::CppRunPaths cpp_paths;
 };
 
 auto ResolveEnv(Runfiles& rf) -> CppEnv {
@@ -33,14 +32,6 @@ auto ResolveEnv(Runfiles& rf) -> CppEnv {
   env.lyra_exe = rf.Rlocation("_main/lyra");
   env.cases_root = rf.Rlocation("_main/tests/cases");
   env.suites_yaml = rf.Rlocation("_main/tests/suites.yaml");
-
-  const std::filesystem::path engine_hpp =
-      rf.Rlocation("_main/include/lyra/runtime/engine.hpp");
-  env.cpp_paths.include_root =
-      engine_hpp.parent_path().parent_path().parent_path();
-
-  env.cpp_paths.cpp_runtime = rf.Rlocation("_main/libcpp_runtime.a");
-
   return env;
 }
 
@@ -51,7 +42,7 @@ class CppTest : public testing::Test {
 
  protected:
   void TestBody() override {
-    auto result = RunCase(env_->lyra_exe, *case_, env_->cpp_paths);
+    auto result = RunCase(env_->lyra_exe, *case_);
     if (result.mismatch) {
       ADD_FAILURE() << *result.mismatch;
     }

--- a/tests/framework/build.cpp
+++ b/tests/framework/build.cpp
@@ -1,88 +1,14 @@
 #include "build.hpp"
 
 #include <cerrno>
-#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <expected>
 #include <filesystem>
 #include <format>
 #include <string>
-#include <string_view>
-#include <unistd.h>
-#include <vector>
-
-#include "process.hpp"
 
 namespace lyra::test {
-
-namespace {
-
-auto IsExecutableFile(const std::filesystem::path& path) -> bool {
-  std::error_code ec;
-  if (!std::filesystem::is_regular_file(path, ec) || ec) {
-    return false;
-  }
-  return access(path.c_str(), X_OK) == 0;
-}
-
-auto FindOnPath(std::string_view name)
-    -> std::expected<std::filesystem::path, std::string> {
-  const std::filesystem::path candidate(name);
-  if (candidate.is_absolute() || candidate.has_parent_path()) {
-    auto absolute = std::filesystem::absolute(candidate);
-    if (IsExecutableFile(absolute)) {
-      return absolute;
-    }
-    return std::unexpected(
-        std::format("'{}' is not an executable file", absolute.string()));
-  }
-  const char* path_env = std::getenv("PATH");
-  if (path_env == nullptr) {
-    return std::unexpected("PATH is unset");
-  }
-  std::string_view path(path_env);
-  while (!path.empty()) {
-    const auto sep = path.find(':');
-    const auto entry = path.substr(0, sep);
-    if (!entry.empty()) {
-      auto full = std::filesystem::path(entry) / candidate;
-      if (IsExecutableFile(full)) {
-        return full;
-      }
-    }
-    if (sep == std::string_view::npos) {
-      break;
-    }
-    path.remove_prefix(sep + 1);
-  }
-  return std::unexpected(
-      std::format("'{}' not found on PATH", candidate.string()));
-}
-
-auto ResolveCxxCompiler() -> std::expected<std::filesystem::path, std::string> {
-  const char* env = std::getenv("CXX");
-  if (env != nullptr) {
-    const std::string_view sv(env);
-    if (!sv.empty()) {
-      return FindOnPath(sv);
-    }
-  }
-  // Fall back through the common C++ compiler names. CI runners may have
-  // either clang++ or g++ in PATH depending on the image; both compile the
-  // emitted C++ since it uses only standard C++23 features.
-  for (const std::string_view candidate : {"clang++", "g++", "c++"}) {
-    auto found = FindOnPath(candidate);
-    if (found) {
-      return *found;
-    }
-  }
-  return std::unexpected(
-      "no C++ compiler found on PATH (tried clang++, g++, c++; set $CXX to "
-      "override)");
-}
-
-}  // namespace
 
 auto MakeTempCaseDir() -> std::expected<std::filesystem::path, std::string> {
   const auto base = std::filesystem::temp_directory_path() / "lyra-XXXXXX";
@@ -93,73 +19,6 @@ auto MakeTempCaseDir() -> std::expected<std::filesystem::path, std::string> {
             "mkdtemp('{}') failed: {}", base.string(), std::strerror(errno)));
   }
   return std::filesystem::path(templ);
-}
-
-auto BuildAndRunEmittedArtifacts(
-    const std::filesystem::path& work_dir,
-    const std::filesystem::path& include_root,
-    const std::filesystem::path& cpp_runtime) -> BuildAndRunOutcome {
-  BuildAndRunOutcome outcome;
-
-  auto cxx_or = ResolveCxxCompiler();
-  if (!cxx_or) {
-    outcome.error =
-        std::format("compiler resolution failed: {}", cxx_or.error());
-    return outcome;
-  }
-  const auto& cxx = *cxx_or;
-
-  if (!std::filesystem::exists(cpp_runtime)) {
-    outcome.error = std::format(
-        "missing prebuilt C++ runtime at '{}'", cpp_runtime.string());
-    return outcome;
-  }
-
-  const auto main_cpp = work_dir / "main.cpp";
-  const auto program = work_dir / "program";
-
-  if (!std::filesystem::exists(main_cpp)) {
-    outcome.error =
-        std::format("missing emitted main.cpp at '{}'", main_cpp.string());
-    return outcome;
-  }
-
-  // The C++ runtime must follow main.cpp on the link line so the linker
-  // resolves main.cpp's references against runtime members.
-  std::vector<std::string> compile_args = {
-      "-std=c++23",
-      "-O0",
-      "-I",
-      include_root.string(),
-  };
-  compile_args.push_back(main_cpp.string());
-  compile_args.push_back(cpp_runtime.string());
-  compile_args.emplace_back("-o");
-  compile_args.push_back(program.string());
-
-  auto compile = RunChildProcess(cxx, compile_args, std::chrono::seconds{60});
-  if (compile.termination != TerminationKind::kExitedNormally) {
-    outcome.error = std::format(
-        "compile failed (termination={}, exit={}):\nstdout:\n{}\nstderr:\n{}",
-        static_cast<int>(compile.termination), compile.exit_code,
-        compile.stdout_text, compile.stderr_text);
-    return outcome;
-  }
-
-  auto run = RunChildProcess(program, {}, std::chrono::seconds{30});
-  if (run.termination != TerminationKind::kExitedNormally &&
-      run.termination != TerminationKind::kExitedNonZero) {
-    outcome.error = std::format(
-        "program did not exit normally (termination={}, signal={}):\n"
-        "stdout:\n{}\nstderr:\n{}",
-        static_cast<int>(run.termination), run.signal_number, run.stdout_text,
-        run.stderr_text);
-    return outcome;
-  }
-  outcome.exit_code = run.exit_code;
-  outcome.stdout_text = std::move(run.stdout_text);
-  outcome.stderr_text = std::move(run.stderr_text);
-  return outcome;
 }
 
 }  // namespace lyra::test

--- a/tests/framework/build.hpp
+++ b/tests/framework/build.hpp
@@ -2,7 +2,6 @@
 
 #include <expected>
 #include <filesystem>
-#include <optional>
 #include <string>
 
 namespace lyra::test {
@@ -10,25 +9,5 @@ namespace lyra::test {
 // Create a unique temp directory using mkdtemp. Returns the absolute path on
 // success, or an error description on failure. Never throws.
 auto MakeTempCaseDir() -> std::expected<std::filesystem::path, std::string>;
-
-struct BuildAndRunOutcome {
-  // Plumbing failure (compile failed, spawn failed, timed out, etc.). When
-  // set, the numeric fields below are unspecified.
-  std::optional<std::string> error;
-  int exit_code = 0;
-  std::string stdout_text;
-  std::string stderr_text;
-};
-
-// Compile <work_dir>/main.cpp against the prebuilt C++ runtime `cpp_runtime`,
-// with includes rooted at `include_root`, producing <work_dir>/program. Then
-// run the program.
-//
-// Uses RunChildProcess for both compile and run -- no new process helper.
-// Returns errors via BuildAndRunOutcome::error; never throws.
-auto BuildAndRunEmittedArtifacts(
-    const std::filesystem::path& work_dir,
-    const std::filesystem::path& include_root,
-    const std::filesystem::path& cpp_runtime) -> BuildAndRunOutcome;
 
 }  // namespace lyra::test

--- a/tests/framework/runner.cpp
+++ b/tests/framework/runner.cpp
@@ -351,25 +351,23 @@ auto WriteStringToFile(const std::filesystem::path& p, std::string_view content)
   return std::nullopt;
 }
 
-auto RunCppCase(
-    const std::filesystem::path& lyra_exe, const TestCase& c,
-    const CppRunPaths& cpp_paths) -> RunResult {
+auto RunCppCase(const std::filesystem::path& lyra_exe, const TestCase& c)
+    -> RunResult {
   RunResult result;
-  auto work_or = MakeTempCaseDir();
-  if (!work_or) {
-    result.mismatch = "MakeTempCaseDir failed: " + work_or.error();
-    return result;
-  }
-  const auto& work = *work_or;
   const std::string top = c.input.top.value_or("Top");
 
   // When `expect.variables` is set, rewrite the source to append a synthetic
   // `final` block that prints sentinel-bracketed marker lines. The rewritten
-  // source goes into the same temp work dir under the original basename, and
-  // becomes the new input to `lyra emit cpp`.
+  // source goes into a temp dir under the original basename and becomes the
+  // input to `lyra run`.
   std::vector<std::filesystem::path> resolved_input_files;
   resolved_input_files.reserve(c.input.files.size());
   if (!c.expect.variables.empty()) {
+    auto work_or = MakeTempCaseDir();
+    if (!work_or) {
+      result.mismatch = "MakeTempCaseDir failed: " + work_or.error();
+      return result;
+    }
     const auto src_path = c.case_dir / c.input.files[0];
     auto source_or = ReadFileToString(src_path);
     if (!source_or) {
@@ -388,7 +386,7 @@ auto RunCppCase(
           "expect.variables source rewrite: " + rewritten_or.error();
       return result;
     }
-    const auto rewritten_path = work / src_path.filename();
+    const auto rewritten_path = *work_or / src_path.filename();
     if (auto err = WriteStringToFile(rewritten_path, *rewritten_or)) {
       result.mismatch = *err;
       return result;
@@ -401,36 +399,21 @@ auto RunCppCase(
   }
 
   std::vector<std::string>& argv = result.argv;
-  argv.emplace_back("emit");
-  argv.emplace_back("cpp");
+  argv.emplace_back("run");
   argv.emplace_back("--no-project");
   argv.emplace_back("--top");
   argv.push_back(top);
-  argv.emplace_back("--out-dir");
-  argv.push_back(work.string());
   for (const auto& f : resolved_input_files) {
     argv.push_back(f.string());
   }
 
-  auto emit = RunChildProcess(lyra_exe, argv, std::chrono::seconds{30});
-  if (emit.termination != TerminationKind::kExitedNormally) {
-    result.proc = emit;
+  result.proc = RunChildProcess(lyra_exe, argv, std::chrono::seconds{60});
+  if (result.proc.termination != TerminationKind::kExitedNormally &&
+      result.proc.termination != TerminationKind::kExitedNonZero) {
     result.mismatch =
-        FormatCaseFailure(c.id, argv, emit) + "\nlyra emit cpp failed";
+        FormatCaseFailure(c.id, argv, result.proc) + "\nlyra run failed";
     return result;
   }
-
-  auto outcome = BuildAndRunEmittedArtifacts(
-      work, cpp_paths.include_root, cpp_paths.cpp_runtime);
-  if (outcome.error.has_value()) {
-    result.mismatch = "build+run failed: " + *outcome.error;
-    return result;
-  }
-
-  result.proc.exit_code = outcome.exit_code;
-  result.proc.stdout_text = std::move(outcome.stdout_text);
-  result.proc.stderr_text = std::move(outcome.stderr_text);
-  result.proc.termination = TerminationKind::kExitedNormally;
 
   auto record = [&](std::string header, std::string body) {
     std::string prefix =
@@ -512,11 +495,10 @@ auto IsCppRunCase(const TestCase& c) -> bool {
 
 }  // namespace
 
-auto RunCase(
-    const std::filesystem::path& lyra_exe, const TestCase& c,
-    const CppRunPaths& cpp_paths) -> RunResult {
+auto RunCase(const std::filesystem::path& lyra_exe, const TestCase& c)
+    -> RunResult {
   if (IsCppRunCase(c)) {
-    return RunCppCase(lyra_exe, c, cpp_paths);
+    return RunCppCase(lyra_exe, c);
   }
 
   RunResult result;
@@ -535,6 +517,23 @@ auto RunCase(
   for (const auto& a : c.input.extra_args) {
     argv.push_back(a);
   }
+
+  // `emit cpp` writes a self-contained project and requires an output
+  // directory; supply a throwaway one so error cases reach the diagnostic
+  // they probe. Cases that fail earlier in the pipeline never write to it.
+  const bool is_emit_cpp = c.input.command.size() == 2 &&
+                           c.input.command[0] == "emit" &&
+                           c.input.command[1] == "cpp";
+  if (is_emit_cpp) {
+    auto work_or = MakeTempCaseDir();
+    if (!work_or) {
+      result.mismatch = "MakeTempCaseDir failed: " + work_or.error();
+      return result;
+    }
+    argv.emplace_back("-o");
+    argv.push_back(work_or->string());
+  }
+
   for (const auto& f : c.input.files) {
     argv.push_back((c.case_dir / f).string());
   }

--- a/tests/framework/runner.hpp
+++ b/tests/framework/runner.hpp
@@ -55,13 +55,6 @@ struct RunResult {
   std::optional<std::string> mismatch;
 };
 
-// Paths needed to build and run an emitted C++ artifact. Used by the
-// `[run, cpp]` command path in RunCase.
-struct CppRunPaths {
-  std::filesystem::path include_root;
-  std::filesystem::path cpp_runtime;
-};
-
 auto LoadCases(const std::filesystem::path& cases_root)
     -> std::vector<TestCase>;
 
@@ -71,9 +64,8 @@ auto LoadSuite(const std::filesystem::path& suites_yaml, std::string_view name)
 auto FilterCases(const std::vector<TestCase>& cases, const Suite& suite)
     -> std::vector<TestCase>;
 
-auto RunCase(
-    const std::filesystem::path& lyra_exe, const TestCase& c,
-    const CppRunPaths& cpp_paths) -> RunResult;
+auto RunCase(const std::filesystem::path& lyra_exe, const TestCase& c)
+    -> RunResult;
 
 auto FormatCaseFailure(
     std::string_view case_id, std::span<const std::string> argv,

--- a/tests/run_test.cpp
+++ b/tests/run_test.cpp
@@ -1,0 +1,123 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "lyra/support/subprocess.hpp"
+#include "tests/framework/build.hpp"
+#include "tests/framework/process.hpp"
+#include "tools/cpp/runfiles/runfiles.h"
+
+namespace {
+
+using bazel::tools::cpp::runfiles::Runfiles;
+using lyra::test::MakeTempCaseDir;
+using lyra::test::RunChildProcess;
+using lyra::test::TerminationKind;
+using namespace std::chrono_literals;
+
+auto ResolveLyra() -> std::filesystem::path {
+  std::string err;
+  std::unique_ptr<Runfiles> runfiles{Runfiles::CreateForTest(&err)};
+  EXPECT_TRUE(runfiles) << err;
+  return runfiles ? std::filesystem::path(runfiles->Rlocation("_main/lyra"))
+                  : std::filesystem::path{};
+}
+
+auto WriteTrivialSource(const std::filesystem::path& path) -> void {
+  std::ofstream out(path);
+  out << "module Test;\n"
+      << "  initial $display(\"ran %0d\", 6 * 7);\n"
+      << "endmodule\n";
+}
+
+TEST(LyraRun, ExecutesSourceEndToEnd) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteTrivialSource(src);
+
+  const std::vector<std::string> args = {
+      "run", "--no-project", "--top", "Test", src.string()};
+  const auto run = RunChildProcess(lyra, args, 120s);
+  ASSERT_EQ(run.termination, TerminationKind::kExitedNormally)
+      << run.stdout_text << run.stderr_text;
+  EXPECT_EQ(run.exit_code, 0) << run.stderr_text;
+  EXPECT_NE(run.stdout_text.find("ran 42"), std::string::npos)
+      << "stdout: " << run.stdout_text;
+}
+
+TEST(LyraCompile, ProducesPortableBuildableProject) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteTrivialSource(src);
+  const auto out_dir = *tmp_or / "out";
+
+  const std::vector<std::string> args = {
+      "compile", "--no-project",   "--top",     "Test",
+      "-o",      out_dir.string(), src.string()};
+  const auto compile = RunChildProcess(lyra, args, 120s);
+  ASSERT_EQ(compile.termination, TerminationKind::kExitedNormally)
+      << compile.stdout_text << compile.stderr_text;
+  ASSERT_EQ(compile.exit_code, 0) << compile.stderr_text;
+
+  const auto program = out_dir / "program";
+  ASSERT_TRUE(std::filesystem::exists(program)) << program.string();
+  ASSERT_TRUE(std::filesystem::exists(out_dir / "build.sh"));
+
+  // The directory must rebuild standalone, with no Lyra checkout: drop the
+  // built program and rebuild via the shipped build.sh from within the dir.
+  std::filesystem::remove(program);
+  auto sh_or = lyra::support::FindOnPath("sh");
+  ASSERT_TRUE(sh_or.has_value()) << sh_or.error();
+  const std::vector<std::string> rebuild = {
+      "-c", "cd '" + out_dir.string() + "' && sh build.sh"};
+  const auto built = RunChildProcess(*sh_or, rebuild, 120s);
+  ASSERT_EQ(built.termination, TerminationKind::kExitedNormally)
+      << built.stdout_text << built.stderr_text;
+  ASSERT_EQ(built.exit_code, 0) << built.stderr_text;
+  ASSERT_TRUE(std::filesystem::exists(program)) << program.string();
+
+  const auto run = RunChildProcess(program, {}, 30s);
+  EXPECT_EQ(run.exit_code, 0) << run.stderr_text;
+  EXPECT_NE(run.stdout_text.find("ran 42"), std::string::npos)
+      << "stdout: " << run.stdout_text;
+}
+
+TEST(LyraEmit, ReEmitIntoSameDirectorySucceeds) {
+  const auto lyra = ResolveLyra();
+  ASSERT_TRUE(std::filesystem::exists(lyra)) << lyra.string();
+
+  auto tmp_or = MakeTempCaseDir();
+  ASSERT_TRUE(tmp_or.has_value()) << tmp_or.error();
+  const auto src = *tmp_or / "test.sv";
+  WriteTrivialSource(src);
+  const auto out_dir = *tmp_or / "out";
+
+  const std::vector<std::string> args = {
+      "emit", "cpp", "--no-project",   "--top",
+      "Test", "-o",  out_dir.string(), src.string()};
+  // The bundled runtime is copied from a read-only source; emitting twice into
+  // the same directory must still succeed (the copy is made writable).
+  for (int i = 0; i < 2; ++i) {
+    const auto emit = RunChildProcess(lyra, args, 60s);
+    ASSERT_EQ(emit.termination, TerminationKind::kExitedNormally)
+        << "iteration " << i << ": " << emit.stderr_text;
+    ASSERT_EQ(emit.exit_code, 0)
+        << "iteration " << i << ": " << emit.stderr_text;
+  }
+  EXPECT_TRUE(
+      std::filesystem::exists(out_dir / "runtime/lib/libcpp_runtime.a"));
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

Adds `lyra run` and `lyra compile` as first-class commands and turns `emit cpp -o` into a self-contained C++ project. `emit cpp -o <dir>` now writes the generated translation units, a `build.sh` recipe, and a bundled copy of the std-only Lyra runtime, so the directory builds on another machine of the same platform with no Lyra toolchain present. `compile -o <dir>` assembles that project and builds it to `<dir>/program`; `run` builds the sources in place against the runtime where it already lives and executes the result, streaming the simulation's output.

## Design

Every consumer of the runtime asks one question -- where does the Lyra runtime live -- answered by a single resolver keyed on the running binary's own path. Today it reads the Bazel runfiles tree; a released binary will resolve install-relative (the clang/gcc/rustc convention) through the same seam, with no change to the emit, compile, or run paths. The contract is documented in `docs/architecture/runtime_distribution.md`. `run` executes the simulation and its stdout/stderr are the simulation's own: compile-phase warnings are not interleaved (use `dump`, `emit cpp`, or `compile` to see them), and compile errors abort before any simulation begins.

## Testing

`bazel test //...` green, including a new end-to-end test that runs a source file, builds a standalone project via the shipped `build.sh`, and re-emits into an existing directory. The cpp suite now drives `lyra run` directly, removing a duplicate in-harness build recipe; per-case cost is the host C++ compile, which `hyperfine` confirms dominates while Lyra's own pipeline is milliseconds.