### PR TITLE
Add packed union support

### DIFF
--- a/docs/progress/packed.md
+++ b/docs/progress/packed.md
@@ -13,12 +13,10 @@ Done when:
 
 ## Actionable
 
-P4 and P5 are open and ordered: P4 (union field views) rides on the same field-access machinery P3
-introduced; P5 builds assignment patterns on top.
+P5 builds assignment patterns on the field-access machinery P3 / P4 established.
 
 | Item | Status         |
 | ---- | -------------- |
-| P4   | Depends on P3. |
 | P5   | Depends on P3. |
 
 ## Sub-Steps
@@ -31,9 +29,11 @@ The numeric IDs are stable references.
       4-state member conversion (LRM 7.2.1 fourth paragraph) tracks the struct-level atom; per-field
       state-promotion at the boundary is a follow-up.
 
-- [ ] P4 -- Packed union (LRM 7.3.1). All members overlay the same underlying bits; field access
-      reads / writes the full union width and reinterprets per the accessed member's type. The type
-      system distinguishes the view. Closes `datatypes/packed/packed_union`.
+- [x] P4 -- Packed union (LRM 7.3.1). Untagged hard and soft packed unions; members overlay at the
+      LSBs and reads / writes reinterpret per the accessed member's declared type, including signed
+      reinterpretation. Whole-union copy, equality, bit / part selects ride on the "treated as a
+      single vector" projection. Tagged packed unions are deferred (need runtime tag-bit logic per
+      LRM 11.9).
 
 - [ ] P5 -- Assignment patterns over packed aggregates (LRM 10.9): positional `'{a, b, c}`, default
       `'{default: v}`, named `'{i: v, j: v}`, and replication `'{N{x}}`. Closes
@@ -42,8 +42,8 @@ The numeric IDs are stable references.
 
 ## Cross-references
 
-- LRM anchors: 7.2 (packed structs and unions), 7.4 (packed and unpacked arrays), 10.9 (assignment
-  patterns), 11.5.1 (bit-select / part-select on packed arrays and structs).
+- LRM anchors: 7.2 (packed structs), 7.3 (packed unions), 7.4 (packed and unpacked arrays), 10.9
+  (assignment patterns), 11.5.1 (bit-select / part-select on packed arrays, structs, and unions).
 - Prerequisite: `operators.md` W4..W6 (P3 adds packed-struct field access as a new addressable
   expression form on top of the existing selectors).
 - `datatypes/packed/indexed_part_select`, `datatypes/packed/packed_2d`, `packed_3d`,

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -11,7 +11,7 @@ namespace lyra::diag {
 // Stable identity for primary diagnostics. Notes have no code.
 enum class DiagCode : std::uint32_t {
   kUnsupportedPackedArrayElementType,
-  kUnsupportedPackedUnionType,
+  kUnsupportedTaggedPackedUnion,
   kUnsupportedFixedSizeUnpackedArrayType,
   kUnsupportedDynamicArrayType,
   kUnsupportedQueueType,

--- a/include/lyra/hir/type.hpp
+++ b/include/lyra/hir/type.hpp
@@ -14,6 +14,7 @@ namespace lyra::hir {
 enum class TypeKind {
   kPackedArray,
   kPackedStruct,
+  kPackedUnion,
   kEnum,
   kUnpackedArray,
   kDynamicArray,
@@ -75,10 +76,12 @@ struct EnumType {
   std::vector<EnumMember> members;
 };
 
-// LRM 7.2.1: each field occupies a contiguous bit range within the struct's
-// packed bit space. `bit_offset` is the LSB position of the field (slang's
-// FieldSymbol::bitOffset); the first-declared field has the highest offset.
-struct PackedStructField {
+// A named bit-range member of a packed aggregate (struct or union). For a
+// packed struct each field has its own contiguous slot computed by slang
+// (`FieldSymbol::bitOffset`); for an untagged packed union every field has
+// `bit_offset = 0` and `bit_width = member's own width` (LRM 7.3.1: members
+// are right-justified to the LSBs).
+struct PackedAggregateField {
   std::string name;
   TypeId type;
   std::uint64_t bit_offset;
@@ -92,7 +95,18 @@ struct PackedStructField {
 // member-access expressions consult.
 struct PackedStructType {
   PackedArrayType base;
-  std::vector<PackedStructField> fields;
+  std::vector<PackedAggregateField> fields;
+};
+
+// LRM 7.3.1 untagged packed union. `base` is the "single vector" projection
+// (width = max member width; 4-state iff any member is 4-state). Members
+// overlap at the LSBs; for hard packed unions every member equals the union
+// width, for soft packed unions a narrower member's bits sit at the LSBs and
+// MSBs beyond the member are preserved across writes. Tagged unions are a
+// separate future feature (require runtime tag-bit logic, LRM 11.9).
+struct PackedUnionType {
+  PackedArrayType base;
+  std::vector<PackedAggregateField> fields;
 };
 
 struct UnpackedRange {
@@ -128,9 +142,10 @@ struct ChandleType {};
 struct VoidType {};
 
 using TypeData = std::variant<
-    PackedArrayType, PackedStructType, EnumType, UnpackedArrayType,
-    DynamicArrayType, QueueType, AssociativeArrayType, StringType, EventType,
-    RealType, ShortRealType, RealTimeType, ChandleType, VoidType>;
+    PackedArrayType, PackedStructType, PackedUnionType, EnumType,
+    UnpackedArrayType, DynamicArrayType, QueueType, AssociativeArrayType,
+    StringType, EventType, RealType, ShortRealType, RealTimeType, ChandleType,
+    VoidType>;
 
 struct Type {
   TypeData data;
@@ -140,6 +155,8 @@ struct Type {
   [[nodiscard]] auto AsPackedArray() const -> const PackedArrayType&;
   [[nodiscard]] auto IsPackedStruct() const -> bool;
   [[nodiscard]] auto AsPackedStruct() const -> const PackedStructType&;
+  [[nodiscard]] auto IsPackedUnion() const -> bool;
+  [[nodiscard]] auto AsPackedUnion() const -> const PackedUnionType&;
   [[nodiscard]] auto IsEnum() const -> bool;
   [[nodiscard]] auto AsEnum() const -> const EnumType&;
 };

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -81,11 +81,12 @@ struct EnumType {
   std::vector<EnumMember> members;
 };
 
-// LRM 7.2.1 packed struct has no MIR-level distinct shape: HIR -> MIR
-// translates a `hir::PackedStructType` to its "single vector" projection
+// LRM 7.2.1 / 7.3.1 packed struct and packed union have no MIR-level
+// distinct shape: HIR -> MIR translates `hir::PackedStructType` and
+// `hir::PackedUnionType` to their "single vector" projection
 // (`PackedArrayType`). Field accesses lower to constant-bounds RangeSelect
-// against that vector. A future MIR node for *unpacked* struct is a
-// genuinely different shape and will get its own variant when that work
+// against that vector. A future MIR node for *unpacked* struct / union is
+// a genuinely different shape and will get its own variant when that work
 // lands.
 
 struct UnpackedRange {

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1126,20 +1126,37 @@ auto RenderRangeSelectExpr(
     throw InternalError(
         "RenderRangeSelectExpr: result PackedArrayType has no dims");
   }
-  const auto count = static_cast<std::uint32_t>(
-      result_ty.AsPackedArray().dims.front().ElementCount());
+  const auto& result_pa = result_ty.AsPackedArray();
+  const auto count =
+      static_cast<std::uint32_t>(result_pa.dims.front().ElementCount());
+
+  // PackedArray::Slice() always produces an unsigned result (LRM 7.4.1
+  // part-select default). When the MIR result type carries signed semantics
+  // -- e.g. member access of a `logic signed` packed-struct/union field --
+  // re-tag the slice via ConvertFrom so a downstream sign-extending
+  // conversion sees the correct source signedness.
+  const auto wrap_for_sign = [&](std::string slice_expr) -> std::string {
+    if (result_pa.signedness == mir::Signedness::kSigned) {
+      return std::format(
+          "lyra::value::PackedArray::ConvertFrom({}, {})", slice_expr,
+          RenderPackedArrayCtorArgs(result_pa));
+    }
+    return slice_expr;
+  };
 
   return std::visit(
       Overloaded{
           [&](const mir::RangeConstantBounds& b) -> diag::Result<std::string> {
             auto lsb_or = RenderExpr(ctx, ctx.Expr(b.lsb_expr));
             if (!lsb_or) return std::unexpected(std::move(lsb_or.error()));
-            return std::format("({}).Slice({}, {}U)", *base_or, *lsb_or, count);
+            return wrap_for_sign(
+                std::format("({}).Slice({}, {}U)", *base_or, *lsb_or, count));
           },
           [&](const mir::RangeIndexedUpBounds& b) -> diag::Result<std::string> {
             auto base = RenderExpr(ctx, ctx.Expr(b.base_index));
             if (!base) return std::unexpected(std::move(base.error()));
-            return std::format("({}).Slice({}, {}U)", *base_or, *base, count);
+            return wrap_for_sign(
+                std::format("({}).Slice({}, {}U)", *base_or, *base, count));
           },
           [&](const mir::RangeIndexedDownBounds& b)
               -> diag::Result<std::string> {
@@ -1155,7 +1172,8 @@ auto RenderRangeSelectExpr(
             const auto sub_lit = RenderSameShapeLiteral(
                 base_ty.AsPackedArray(), static_cast<std::int64_t>(count) - 1);
             const auto lsb = std::format("(({}) - {})", *base, sub_lit);
-            return std::format("({}).Slice({}, {}U)", *base_or, lsb, count);
+            return wrap_for_sign(
+                std::format("({}).Slice({}, {}U)", *base_or, lsb, count));
           },
       },
       sel.bounds);

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -18,11 +18,11 @@ constexpr std::array kEntries{
             .category = UnsupportedCategory::kType,
             .name = "unsupported_packed_array_element_type"}},
     std::pair{
-        DiagCode::kUnsupportedPackedUnionType,
+        DiagCode::kUnsupportedTaggedPackedUnion,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
             .category = UnsupportedCategory::kType,
-            .name = "unsupported_packed_union_type"}},
+            .name = "unsupported_tagged_packed_union"}},
     std::pair{
         DiagCode::kUnsupportedFixedSizeUnpackedArrayType,
         DiagCodeInfo{

--- a/src/lyra/frontend/load.cpp
+++ b/src/lyra/frontend/load.cpp
@@ -7,6 +7,7 @@
 #include <slang/ast/Compilation.h>
 #include <slang/diagnostics/DiagnosticEngine.h>
 #include <slang/diagnostics/TextDiagnosticClient.h>
+#include <slang/parsing/Parser.h>
 #include <slang/text/SourceManager.h>
 #include <slang/util/Bag.h>
 
@@ -26,6 +27,9 @@ auto LoadFiles(const CompilationInput& input, diag::DiagnosticSink& sink)
 
   slang::Bag options;
   options.set(BuildLyraPreprocessorOptions(input.defines));
+  slang::parsing::ParserOptions parser_options;
+  parser_options.languageVersion = slang::LanguageVersion::v1800_2023;
+  options.set(parser_options);
 
   slang::ast::CompilationOptions comp_options;
   comp_options.languageVersion = slang::LanguageVersion::v1800_2023;

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -232,6 +232,21 @@ class HirDumper {
                   FormatSignedness(s.base.signedness), s.base.BitWidth(),
                   fields);
             },
+            [](const PackedUnionType& u) -> std::string {
+              std::string fields;
+              for (std::size_t i = 0; i < u.fields.size(); ++i) {
+                if (i > 0) fields += ", ";
+                fields += std::format(
+                    "{}@bit{}+{}:Type[{}]", u.fields[i].name,
+                    u.fields[i].bit_offset, u.fields[i].bit_width,
+                    u.fields[i].type.value);
+              }
+              return std::format(
+                  "PackedUnion(atom={}, signed={}, width={}, fields=[{}])",
+                  FormatBitAtom(u.base.atom),
+                  FormatSignedness(u.base.signedness), u.base.BitWidth(),
+                  fields);
+            },
             [](const EnumType& e) -> std::string {
               std::string members;
               for (std::size_t i = 0; i < e.members.size(); ++i) {

--- a/src/lyra/hir/type.cpp
+++ b/src/lyra/hir/type.cpp
@@ -84,6 +84,7 @@ auto Type::Kind() const -> TypeKind {
       Overloaded{
           [](const PackedArrayType&) { return TypeKind::kPackedArray; },
           [](const PackedStructType&) { return TypeKind::kPackedStruct; },
+          [](const PackedUnionType&) { return TypeKind::kPackedUnion; },
           [](const EnumType&) { return TypeKind::kEnum; },
           [](const UnpackedArrayType&) { return TypeKind::kUnpackedArray; },
           [](const DynamicArrayType&) { return TypeKind::kDynamicArray; },
@@ -122,6 +123,17 @@ auto Type::AsPackedStruct() const -> const PackedStructType& {
     return *s;
   }
   throw InternalError("Type::AsPackedStruct called on non-packed-struct type");
+}
+
+auto Type::IsPackedUnion() const -> bool {
+  return std::holds_alternative<PackedUnionType>(data);
+}
+
+auto Type::AsPackedUnion() const -> const PackedUnionType& {
+  if (const auto* u = std::get_if<PackedUnionType>(&data)) {
+    return *u;
+  }
+  throw InternalError("Type::AsPackedUnion called on non-packed-union type");
 }
 
 auto Type::IsEnum() const -> bool {

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -137,7 +137,7 @@ auto LowerPackedStruct(
       .dims = {hir::PackedRange{.left = width - 1, .right = 0}},
       .form = hir::PackedArrayForm::kExplicit,
   };
-  std::vector<hir::PackedStructField> fields;
+  std::vector<hir::PackedAggregateField> fields;
   for (const auto& field :
        struct_type.membersOfType<slang::ast::FieldSymbol>()) {
     auto field_type_or = state.GetTypeId(field.getType(), decl_span);
@@ -147,7 +147,7 @@ auto LowerPackedStruct(
     const auto field_width =
         static_cast<std::uint64_t>(field.getType().getBitWidth());
     fields.push_back(
-        hir::PackedStructField{
+        hir::PackedAggregateField{
             .name = std::string(field.name),
             .type = *field_type_or,
             .bit_offset = field.bitOffset,
@@ -155,6 +155,52 @@ auto LowerPackedStruct(
         });
   }
   return hir::PackedStructType{
+      .base = std::move(base),
+      .fields = std::move(fields),
+  };
+}
+
+auto LowerPackedUnion(
+    const slang::ast::PackedUnionType& union_type, diag::SourceSpan decl_span,
+    UnitLoweringState& state) -> diag::Result<hir::PackedUnionType> {
+  if (union_type.isTagged) {
+    return diag::Unsupported(
+        decl_span, diag::DiagCode::kUnsupportedTaggedPackedUnion,
+        "tagged packed unions are not yet supported",
+        diag::UnsupportedCategory::kType);
+  }
+  const auto width = static_cast<std::int64_t>(union_type.bitWidth);
+  if (width <= 0) {
+    throw InternalError("LowerPackedUnion: zero-width packed union");
+  }
+  const auto atom =
+      union_type.isFourState ? hir::BitAtom::kLogic : hir::BitAtom::kBit;
+  const auto signedness = union_type.isSigned ? hir::Signedness::kSigned
+                                              : hir::Signedness::kUnsigned;
+  hir::PackedArrayType base{
+      .atom = atom,
+      .signedness = signedness,
+      .dims = {hir::PackedRange{.left = width - 1, .right = 0}},
+      .form = hir::PackedArrayForm::kExplicit,
+  };
+  std::vector<hir::PackedAggregateField> fields;
+  for (const auto& field :
+       union_type.membersOfType<slang::ast::FieldSymbol>()) {
+    auto field_type_or = state.GetTypeId(field.getType(), decl_span);
+    if (!field_type_or) {
+      return std::unexpected(std::move(field_type_or.error()));
+    }
+    const auto field_width =
+        static_cast<std::uint64_t>(field.getType().getBitWidth());
+    fields.push_back(
+        hir::PackedAggregateField{
+            .name = std::string(field.name),
+            .type = *field_type_or,
+            .bit_offset = 0U,
+            .bit_width = field_width,
+        });
+  }
+  return hir::PackedUnionType{
       .base = std::move(base),
       .fields = std::move(fields),
   };
@@ -249,11 +295,14 @@ auto LowerType(
       }
       return hir::TypeData{*std::move(s)};
     }
-    case slang::ast::SymbolKind::PackedUnionType:
-      return diag::Unsupported(
-          decl_span, diag::DiagCode::kUnsupportedPackedUnionType,
-          "packed union types are not supported",
-          diag::UnsupportedCategory::kType);
+    case slang::ast::SymbolKind::PackedUnionType: {
+      auto u = LowerPackedUnion(
+          canonical.as<slang::ast::PackedUnionType>(), decl_span, state);
+      if (!u.has_value()) {
+        return std::unexpected(std::move(u.error()));
+      }
+      return hir::TypeData{*std::move(u)};
+    }
     case slang::ast::SymbolKind::FixedSizeUnpackedArrayType:
       return diag::Unsupported(
           decl_span, diag::DiagCode::kUnsupportedFixedSizeUnpackedArrayType,

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -44,6 +44,18 @@ enum class LoopVarLoweringMode : std::uint8_t {
   kStructuralParam,
 };
 
+auto GetAggregateFields(const hir::Type& t)
+    -> const std::vector<hir::PackedAggregateField>& {
+  if (t.IsPackedStruct()) {
+    return t.AsPackedStruct().fields;
+  }
+  if (t.IsPackedUnion()) {
+    return t.AsPackedUnion().fields;
+  }
+  throw InternalError(
+      "GetAggregateFields: base type is not a packed struct or union");
+}
+
 auto LowerBinaryOp(hir::BinaryOp op) -> mir::BinaryOp {
   switch (op) {
     case hir::BinaryOp::kAdd:
@@ -972,11 +984,7 @@ auto LowerHirMemberAccessExprProc(
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& base_hir_expr = hir_process.exprs.at(sel.base_value.value);
   const auto& base_hir_type = unit_state.GetHirType(base_hir_expr.type);
-  if (!base_hir_type.IsPackedStruct()) {
-    throw InternalError(
-        "LowerHirMemberAccessExprProc: base type is not a PackedStructType");
-  }
-  const auto& fields = base_hir_type.AsPackedStruct().fields;
+  const auto& fields = GetAggregateFields(base_hir_type);
   if (sel.field_index >= fields.size()) {
     throw InternalError(
         "LowerHirMemberAccessExprProc: field_index out of range");
@@ -1312,12 +1320,7 @@ auto LowerHirMemberAccessExprStructural(
     -> diag::Result<mir::Expr> {
   const auto& base_hir_expr = scope.GetExpr(sel.base_value);
   const auto& base_hir_type = unit_state.GetHirType(base_hir_expr.type);
-  if (!base_hir_type.IsPackedStruct()) {
-    throw InternalError(
-        "LowerHirMemberAccessExprStructural: base type is not a "
-        "PackedStructType");
-  }
-  const auto& fields = base_hir_type.AsPackedStruct().fields;
+  const auto& fields = GetAggregateFields(base_hir_type);
   if (sel.field_index >= fields.size()) {
     throw InternalError(
         "LowerHirMemberAccessExprStructural: field_index out of range");

--- a/src/lyra/lowering/hir_to_mir/lower_type.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_type.cpp
@@ -97,6 +97,18 @@ auto TranslateTypeData(
                 .form = TranslatePackedArrayForm(src.base.form),
             };
           },
+          [&](const hir::PackedUnionType& src) -> mir::TypeData {
+            // LRM 7.3.1: untagged packed union "appears as a primary" is
+            // "treated as a single vector". Same MIR shape as packed
+            // struct -- the per-member (offset=0, width) table flows
+            // through to RangeSelect at expression lowering.
+            return mir::PackedArrayType{
+                .atom = TranslateBitAtom(src.base.atom),
+                .signedness = TranslateSignedness(src.base.signedness),
+                .dims = TranslatePackedRanges(src.base.dims),
+                .form = TranslatePackedArrayForm(src.base.form),
+            };
+          },
           [&](const hir::EnumType& src) -> mir::TypeData {
             // Enum is kept as a distinct mir::EnumType wrapping its base
             // PackedArray plus the member table. Value-level operations

--- a/tests/cases/cpp/packed_union_bit_select/case.yaml
+++ b/tests/cases/cpp/packed_union_bit_select/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.packed_union_bit_select
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    bit_lsb: 1
+    bit_4: 0
+    bit_8: 1
+    bit_msb: 1

--- a/tests/cases/cpp/packed_union_bit_select/main.sv
+++ b/tests/cases/cpp/packed_union_bit_select/main.sv
@@ -1,0 +1,18 @@
+module Top;
+  typedef union packed {
+    logic [15:0] word;
+    logic [15:0] bits;
+  } my_union_t;
+  my_union_t u;
+  int bit_lsb;
+  int bit_4;
+  int bit_8;
+  int bit_msb;
+  initial begin
+    u = 16'hABCD;
+    bit_lsb = u[0];
+    bit_4 = u[4];
+    bit_8 = u[8];
+    bit_msb = u[15];
+  end
+endmodule

--- a/tests/cases/cpp/packed_union_hard_basic/case.yaml
+++ b/tests/cases/cpp/packed_union_hard_basic/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.packed_union_hard_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result_word: 0xaabb
+    result_bits: 0xaabb

--- a/tests/cases/cpp/packed_union_hard_basic/main.sv
+++ b/tests/cases/cpp/packed_union_hard_basic/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  typedef union packed {
+    logic [15:0] word;
+    logic [15:0] bits;
+  } my_union_t;
+  my_union_t u;
+  int result_word;
+  int result_bits;
+  initial begin
+    u = 16'hAABB;
+    result_word = u.word;
+    result_bits = u.bits;
+  end
+endmodule

--- a/tests/cases/cpp/packed_union_hard_field_write/case.yaml
+++ b/tests/cases/cpp/packed_union_hard_field_write/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.packed_union_hard_field_write
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 0x5678

--- a/tests/cases/cpp/packed_union_hard_field_write/main.sv
+++ b/tests/cases/cpp/packed_union_hard_field_write/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  typedef union packed {
+    logic [15:0] view1;
+    logic [15:0] view2;
+  } my_union_t;
+  my_union_t u;
+  int result;
+  initial begin
+    u.view1 = 16'h1234;
+    u.view2 = 16'h5678;
+    result = u.view1;
+  end
+endmodule

--- a/tests/cases/cpp/packed_union_hard_signed_unsigned/case.yaml
+++ b/tests/cases/cpp/packed_union_hard_signed_unsigned/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.packed_union_hard_signed_unsigned
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result_u: 255
+    result_s: -1

--- a/tests/cases/cpp/packed_union_hard_signed_unsigned/main.sv
+++ b/tests/cases/cpp/packed_union_hard_signed_unsigned/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  typedef union packed {
+    logic        [7:0] as_unsigned;
+    logic signed [7:0] as_signed;
+  } byte_view_t;
+  byte_view_t u;
+  int result_u;
+  int result_s;
+  initial begin
+    u.as_unsigned = 8'hFF;
+    result_u = u.as_unsigned;
+    result_s = u.as_signed;
+  end
+endmodule

--- a/tests/cases/cpp/packed_union_hard_struct_member/case.yaml
+++ b/tests/cases/cpp/packed_union_hard_struct_member/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.packed_union_hard_struct_member
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result_word: 0xabcd
+    result_high: 0xab
+    result_low: 0xcd

--- a/tests/cases/cpp/packed_union_hard_struct_member/main.sv
+++ b/tests/cases/cpp/packed_union_hard_struct_member/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  typedef struct packed {
+    logic [7:0] high;
+    logic [7:0] low;
+  } pair_t;
+  typedef union packed {
+    pair_t       pair;
+    logic [15:0] word;
+  } combo_t;
+  combo_t u;
+  int result_word;
+  int result_high;
+  int result_low;
+  initial begin
+    u.word = 16'hABCD;
+    result_word = u.word;
+    result_high = u.pair.high;
+    result_low = u.pair.low;
+  end
+endmodule

--- a/tests/cases/cpp/packed_union_hard_type_punning/case.yaml
+++ b/tests/cases/cpp/packed_union_hard_type_punning/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.packed_union_hard_type_punning
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 0xdead

--- a/tests/cases/cpp/packed_union_hard_type_punning/main.sv
+++ b/tests/cases/cpp/packed_union_hard_type_punning/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  typedef union packed {
+    logic [15:0] as_logic;
+    bit [15:0]   as_bit;
+  } pun_t;
+  pun_t u;
+  int result;
+  initial begin
+    u.as_logic = 16'hDEAD;
+    result = u.as_bit;
+  end
+endmodule

--- a/tests/cases/cpp/packed_union_part_select/case.yaml
+++ b/tests/cases/cpp/packed_union_part_select/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.packed_union_part_select
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    low_nibble: 0xd
+    mid_byte: 0xbc
+    high_nibble: 0xa

--- a/tests/cases/cpp/packed_union_part_select/main.sv
+++ b/tests/cases/cpp/packed_union_part_select/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  typedef union packed {
+    logic [15:0] word;
+    logic [15:0] bits;
+  } my_union_t;
+  my_union_t u;
+  int low_nibble;
+  int mid_byte;
+  int high_nibble;
+  initial begin
+    u = 16'hABCD;
+    low_nibble = u[3:0];
+    mid_byte = u[11:4];
+    high_nibble = u[15:12];
+  end
+endmodule

--- a/tests/cases/cpp/packed_union_soft_different_sizes/case.yaml
+++ b/tests/cases/cpp/packed_union_soft_different_sizes/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.packed_union_soft_different_sizes
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result_word: 0xaabb
+    result_byte: 0xbb

--- a/tests/cases/cpp/packed_union_soft_different_sizes/main.sv
+++ b/tests/cases/cpp/packed_union_soft_different_sizes/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  typedef union soft packed {
+    logic [15:0] word;
+    logic [7:0]  byte_val;
+  } my_union_t;
+  my_union_t u;
+  int result_word;
+  int result_byte;
+  initial begin
+    u.word = 16'hAABB;
+    result_word = u.word;
+    result_byte = u.byte_val;
+  end
+endmodule

--- a/tests/cases/cpp/packed_union_soft_write_narrow_preserves_msb/case.yaml
+++ b/tests/cases/cpp/packed_union_soft_write_narrow_preserves_msb/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.packed_union_soft_write_narrow_preserves_msb
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 0xffab

--- a/tests/cases/cpp/packed_union_soft_write_narrow_preserves_msb/main.sv
+++ b/tests/cases/cpp/packed_union_soft_write_narrow_preserves_msb/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  typedef union soft packed {
+    logic [15:0] wide;
+    logic [7:0]  narrow;
+  } u_t;
+  u_t u;
+  int result;
+  initial begin
+    u.wide = 16'hFF00;
+    u.narrow = 8'hAB;
+    result = u.wide;
+  end
+endmodule

--- a/tests/cases/cpp/packed_union_whole_copy/case.yaml
+++ b/tests/cases/cpp/packed_union_whole_copy/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.packed_union_whole_copy
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 0xbeef

--- a/tests/cases/cpp/packed_union_whole_copy/main.sv
+++ b/tests/cases/cpp/packed_union_whole_copy/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  typedef union packed {
+    logic [15:0] a;
+    logic [15:0] b;
+  } my_union_t;
+  my_union_t u1;
+  my_union_t u2;
+  int result;
+  initial begin
+    u1.a = 16'hBEEF;
+    u2 = u1;
+    result = u2.b;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds LRM 7.3.1 untagged packed union support (hard and soft packed). Members overlay at the LSBs and member access reinterprets per the accessed member's declared type, including signed reinterpretation. Whole-union copy, equality, bit and part selects all ride on the "treated as a single vector" projection. Tagged packed unions remain deferred -- they need runtime tag-bit logic per LRM 11.9 and are now gated by their own diag code.

## Design

HIR gets a new `PackedUnionType` sibling to `PackedStructType`, sharing a renamed `PackedAggregateField` record. HIR -> MIR translates both struct and union to a single `mir::PackedArrayType` projection -- field access lowers to constant-bounds RangeSelect against that vector. The MemberAccess consumers in `lower_expr.cpp` now use a small `GetAggregateFields()` helper that handles either kind. Slang's `PackedUnionType` already exposes members via `membersOfType<FieldSymbol>()`, so the AST -> HIR lowering is a straight parallel of `LowerPackedStruct` with `bit_offset = 0` on every field.

Two non-union fixes ride along because the union tests surfaced them. First, the slang parser was defaulting to v1800-2017 while Compilation was already set to v1800-2023, which blocked `union soft packed` parsing; ParserOptions is now wired through the options bag at the same version. Second, `PackedArray::Slice()` always produces an unsigned result (which matches LRM 7.4.1 for part-select, but loses signedness when the MIR result type is a signed packed-struct/union field); `RenderRangeSelectExpr` now wraps the slice in a re-tagging `ConvertFrom` when the result type carries `kSigned`, so downstream sign-extending conversions see the correct source signedness.

## Testing

Ten new `cpp_run` cases under `tests/cases/cpp/packed_union_*/`: hard_basic, hard_type_punning, hard_signed_unsigned, hard_field_write, hard_struct_member, soft_different_sizes, soft_write_narrow_preserves_msb, bit_select, part_select, whole_copy. Full `bazel test //...` green.