### PR TITLE
Add basic user-defined function support

### DIFF
--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -80,13 +80,17 @@ Granular tracking lives in `integral.md` (integral / packed / wide_integral) and
 
 ### functions
 
-- [ ] functions/basic
-- [ ] functions/chandle
-- [ ] functions/container_outparams
-- [ ] functions/container_params
-- [ ] functions/nested_calls
-- [ ] functions/recursion
-- [ ] functions/string_return
+Tracked in `functions.md`, which scopes the full LRM 13 subroutine surface (functions and tasks),
+including features the archive does not exercise. The archive items below remain the high-level
+inventory; each is checked off when `functions.md` reproduces it.
+
+- [ ] functions/basic -- `functions.md` F1, F2, F5.
+- [ ] functions/chandle -- `functions.md` F9.
+- [ ] functions/container_outparams -- `functions.md` F4, F8.
+- [ ] functions/container_params -- `functions.md` F7, F8.
+- [x] functions/nested_calls -- `functions.md` F1.
+- [ ] functions/recursion -- `functions.md` F3.
+- [ ] functions/string_return -- `functions.md` F7.
 
 ### generate
 

--- a/docs/progress/dev-ergonomics.md
+++ b/docs/progress/dev-ergonomics.md
@@ -7,16 +7,11 @@ layer directly.
 
 ## Sub-Steps
 
-- [x] D1 -- A single command that runs a SystemVerilog file end-to-end. Running a source file is now
-      a first-class command that takes the same inputs as the dump and emit commands, builds it, and
-      streams the simulation's output. A sibling command produces a built executable without running
-      it. The backend that performs the build is an implementation detail of these commands.
+- [x] D1 -- Run a SystemVerilog file end-to-end from one command, with a sibling command that builds
+      without running.
 
-- [x] D4 -- A self-contained build for the C++ backend's output. Emitting the C++ now produces a
-      complete project on disk: the translation units, a build recipe, and a bundled copy of the
-      Lyra runtime the emitted code depends on. The directory stands on its own -- one documented
-      command rebuilds it, and it can be handed to another machine of the same platform without a
-      Lyra checkout. Building it and running it are the compile and run commands layered on top.
+- [x] D4 -- Emitting the C++ backend produces a self-contained project that rebuilds and runs on
+      another machine of the same platform without a Lyra checkout.
 
 ## Out of Scope
 

--- a/docs/progress/functions.md
+++ b/docs/progress/functions.md
@@ -1,0 +1,120 @@
+# Subroutines (tasks and functions)
+
+Tracks user-defined `function` and `task` declarations and the calls that invoke them (LRM 13).
+Functions and tasks are the same construct -- a _subroutine_ -- differing only in whether the body
+may suspend and whether it yields a value, so they are tracked together.
+
+The semantic surface that scopes this workstream is LRM 13, not any single reference corpus. The
+archived `functions/*` cases are drawn on for inspiration where they fit, but coverage is judged
+against the LRM concept space below and the tests authored alongside each cut.
+
+Done when the LRM 13 subroutine surface reproduces: value-returning and void functions, tasks
+(including suspending tasks), all five argument directions, by-value and by-reference passing,
+default and named arguments, return-by-name, automatic lifetime / recursion, local default
+initialization, and subroutine boundaries for every data-type family Lyra otherwise supports
+(integral, packed, string, container, chandle, struct / union). Multi-instance and the
+elaboration-time / foreign / class-method surfaces are out of scope here; see [Blocked](#blocked)
+and [Out of Scope](#out-of-scope).
+
+## Actionable
+
+F1 is the entry point: the value-returning function call and return path. Most other items build on
+it -- the dependencies are stated inline. Tasks that suspend (T2) wait on the timing machinery owned
+by `processes.md`.
+
+## Sub-Steps
+
+The `F*` / `T*` IDs are stable references. They do **not** impose a total order, but F1 precedes
+everything and the inline "rides on" notes record the real dependencies.
+
+### Functions: call and return
+
+- [x] F1 -- Value-returning and void functions with `input` by-value arguments (LRM 13.4, 13.5.1).
+      `return expr`; nonvoid call as an expression operand and as a nested operand; void call as a
+      statement; `void'(f())` to discard a nonvoid result. Sequential body statements, early /
+      conditional return, and function-local variable declarations.
+- [ ] F2 -- Return-by-name via the implicit variable that shares the function's name (LRM 13.4.1).
+      `return` overrides a prior name-assignment; an empty body returns the implicit variable's
+      current value; the implicit variable is default-initialized so a read-before-write sees a
+      defined value.
+- [ ] F11 -- Struct / union return values (LRM 13.4.1). A hierarchical name beginning with the
+      function name denotes a member of the return value inside the body; member access on the
+      returned aggregate at the call site.
+
+### Lifetime and recursion
+
+- [ ] F3 -- `automatic` lifetime and recursion (LRM 13.3.1, 13.3.2, 13.4.2). Automatic subroutines
+      are reentrant with per-call storage; static (the module / package default) shares one copy
+      across concurrent activations and retains values between calls. Recursion requires automatic
+      storage. Rides on F1.
+
+### Arguments
+
+- [ ] F4 -- `output` and `inout` arguments (LRM 13.5). `output` copies out at return, `inout` copies
+      in at call and out at return; multiple outputs; mixed directions. Default direction is `input`
+      and subsequent formals inherit the previous direction and data type.
+- [ ] F6 -- Default argument values (LRM 13.5.3), binding by name (LRM 13.5.4), and the optional
+      empty argument list for no-argument / all-defaulted subroutines (LRM 13.5.5). Default
+      expressions evaluate in the declaration scope at each defaulting call.
+- [ ] F10 -- `ref` and `const ref` arguments (LRM 13.5.2). A reference shares the caller's storage;
+      changes are visible immediately. `const ref` is read-only. Legal only for automatic-lifetime
+      subroutines and only for a variable, class property, unpacked-struct member, or unpacked-array
+      element. Outdated-reference rules for resized / deleted container elements.
+
+### Local storage
+
+- [ ] F5 -- Function-local default initialization (LRM 13.3.2 default-init, 6.8). 2-state locals
+      default to 0, 4-state locals to X (four-state suite), unpacked arrays element-wise, managed
+      string / container locals to empty, unpacked unions to zero-fill.
+
+### Data types across the boundary
+
+- [ ] F7 -- `string` arguments and return values. Managed lifecycle across the call boundary;
+      concatenated and computed string returns.
+- [ ] F8 -- Container arguments and return values: dynamic array, queue, associative array. Managed
+      ownership and lifecycle across the boundary, including `output` / `inout` containers and the
+      outdated-reference rules of LRM 13.5.2. Blocked: these container types do not yet exist as
+      runtime values; the boundary work waits on the container datatype workstream, not on the
+      subroutine ABI. See [Blocked](#blocked).
+- [ ] F9 -- `chandle` arguments and return values (LRM 6.14). Identity round-trip and `null`
+      handling through the subroutine boundary.
+
+### Tasks
+
+- [ ] T1 -- Tasks without timing controls (LRM 13.3). Enabled as a statement; results returned
+      through `output` / `inout` arguments; `return` exits before `endtask`. Behaves like a void
+      function and rides on F1 and F4.
+- [ ] T2 -- Tasks containing time-controlling statements (LRM 13.3). `#`, `@(...)`, and `wait`
+      inside a task suspend the calling process and resume it later, so a task enable can span
+      multiple time steps. Rides on the timing-control machinery tracked in `processes.md`.
+
+## Blocked
+
+| Item                                                    | Blocked on                                                                                                                                                                                                                                                                                            |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Module-scoped subroutine accessing per-instance storage | Module hierarchy. A subroutine declared in a module reads and writes the storage of the specific instance that called it; correct per-instance addressing needs the instantiation / object-tree model that does not yet exist. Tracked under `architecture-reset.md` hierarchy.                       |
+| F8 -- container arguments and returns                   | Dynamic array, queue, and associative array do not yet exist as runtime value types. The cross-boundary lifecycle rides on those types' own copy / move / destroy semantics, so F8 waits on the container datatype workstream. F7 (string) is unblocked because the string value type already exists. |
+
+## Out of Scope
+
+- DPI import / export subroutines (LRM 13.6). Foreign-language boundary; a separate workstream.
+- Class methods (LRM 8.6). Always automatic; ride on the class workstream, not this one.
+- Parameterized tasks and functions (LRM 13.8), which the LRM realizes through static methods of
+  parameterized classes. Needs classes.
+- Constant functions (LRM 13.4.3). Evaluated at elaboration time inside constant expressions, a
+  distinct evaluation context from the runtime call path tracked here.
+- `fork`-`join_none` spawned inside a function (LRM 13.4.4). Concurrency; rides on `fork` / `join`
+  (`processes.md` P8).
+
+## Cross-references
+
+- LRM anchors: 13.2 (overview), 13.3 (tasks), 13.3.1 / 13.3.2 (static vs automatic, concurrent
+  activation), 13.4 (functions), 13.4.1 (return values and void functions), 13.4.2 (static vs
+  automatic functions), 13.4.4 (background processes), 13.5 (calls and argument passing), 13.5.1
+  (pass by value), 13.5.2 (pass by reference), 13.5.3 (default argument values), 13.5.4 (binding by
+  name), 13.5.5 (optional argument list); 6.8 (default initialization), 6.14 (chandle).
+- Rides on: `control-flow.md` (return / conditional / loop within bodies), `processes.md` timing
+  controls (T2), `datatypes.md` (string, container, chandle boundary types), `packed.md` and
+  `integral.md` (packed / integral boundary types).
+- Blocks / unblocks: module hierarchy (`architecture-reset.md`) unblocks the per-instance subroutine
+  case.

--- a/include/lyra/hir/procedural_body.hpp
+++ b/include/lyra/hir/procedural_body.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <vector>
+
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/procedural_var.hpp"
+#include "lyra/hir/stmt.hpp"
+
+namespace lyra::hir {
+
+// The statement tree of a process or subroutine together with the arenas its
+// statements, expressions, and local variables index into. Processes and
+// subroutines are both procedural bodies; they differ only in what wraps the
+// body (a process kind and sensitivity, or a subroutine signature).
+struct ProceduralBody {
+  StmtId root_stmt{};
+  std::vector<Expr> exprs;
+  std::vector<Stmt> stmts;
+  std::vector<ProceduralVarDecl> procedural_vars;
+
+  [[nodiscard]] auto GetExpr(ExprId id) const -> const Expr& {
+    return exprs.at(id.value);
+  }
+  [[nodiscard]] auto GetStmt(StmtId id) const -> const Stmt& {
+    return stmts.at(id.value);
+  }
+  [[nodiscard]] auto GetProceduralVar(ProceduralVarId id) const
+      -> const ProceduralVarDecl& {
+    return procedural_vars.at(id.value);
+  }
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/process.hpp
+++ b/include/lyra/hir/process.hpp
@@ -5,8 +5,7 @@
 #include <vector>
 
 #include "lyra/diag/source_span.hpp"
-#include "lyra/hir/expr.hpp"
-#include "lyra/hir/procedural_var.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
 
 namespace lyra::hir {
@@ -29,10 +28,7 @@ enum class ProcessKind : std::uint8_t {
 struct Process {
   ProcessKind kind = ProcessKind::kInitial;
   diag::SourceSpan span;
-  StmtId root_stmt{};
-  std::vector<Expr> exprs;
-  std::vector<Stmt> stmts;
-  std::vector<ProceduralVarDecl> procedural_vars;
+  ProceduralBody body;
   // LRM 9.2.2.2.1 implicit sensitivity for always_comb / always_latch
   // (procedure-level; the body is a plain statement). Empty for every other
   // process kind -- `always @*` carries its sensitivity inside

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -139,6 +139,12 @@ struct BreakStmt {};
 
 struct ContinueStmt {};
 
+// LRM 13.4.1 `return [expr];`. `value` carries the returned expression for a
+// non-void function; it is absent for `return;` and for void functions / tasks.
+struct ReturnStmt {
+  std::optional<ExprId> value;
+};
+
 struct DelayControl {
   ExprId duration;
 };
@@ -224,7 +230,7 @@ struct WaitStmt {
 using StmtData = std::variant<
     EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, IfStmt, CaseStmt,
     CaseInsideStmt, ForStmt, WhileStmt, RepeatStmt, DoWhileStmt, ForeverStmt,
-    BreakStmt, ContinueStmt, TimedStmt, EventTriggerStmt, WaitStmt>;
+    BreakStmt, ContinueStmt, ReturnStmt, TimedStmt, EventTriggerStmt, WaitStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/include/lyra/hir/subroutine.hpp
+++ b/include/lyra/hir/subroutine.hpp
@@ -2,8 +2,10 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
-#include "lyra/hir/subroutine_id.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/type_id.hpp"
 
 namespace lyra::hir {
@@ -13,10 +15,27 @@ enum class SubroutineKind : std::uint8_t {
   kFunction,
 };
 
+// LRM 13.5 argument directions. A formal is also a local variable of the
+// subroutine body; `var` indexes the body's procedural-var arena.
+enum class ParamDirection : std::uint8_t {
+  kInput,
+  kOutput,
+  kInOut,
+  kRef,
+  kConstRef,
+};
+
+struct SubroutineParam {
+  ProceduralVarId var = {};
+  ParamDirection direction = ParamDirection::kInput;
+};
+
 struct StructuralSubroutineDecl {
   std::string name;
   SubroutineKind kind;
   TypeId result_type;
+  std::vector<SubroutineParam> params;
+  ProceduralBody body;
 };
 
 }  // namespace lyra::hir

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -364,22 +364,22 @@ class ProcessLoweringState {
   }
 
   auto AddExpr(hir::Expr expr) -> hir::ExprId {
-    const hir::ExprId id{static_cast<std::uint32_t>(hir_process_.exprs.size())};
-    hir_process_.exprs.push_back(std::move(expr));
+    const hir::ExprId id{static_cast<std::uint32_t>(body_.exprs.size())};
+    body_.exprs.push_back(std::move(expr));
     return id;
   }
 
   auto AddStmt(hir::Stmt stmt) -> hir::StmtId {
-    const hir::StmtId id{static_cast<std::uint32_t>(hir_process_.stmts.size())};
-    hir_process_.stmts.push_back(std::move(stmt));
+    const hir::StmtId id{static_cast<std::uint32_t>(body_.stmts.size())};
+    body_.stmts.push_back(std::move(stmt));
     return id;
   }
 
   auto AddProceduralVar(const slang::ast::VariableSymbol& var, hir::TypeId type)
       -> hir::ProceduralVarId {
     const hir::ProceduralVarId id{
-        static_cast<std::uint32_t>(hir_process_.procedural_vars.size())};
-    hir_process_.procedural_vars.push_back(
+        static_cast<std::uint32_t>(body_.procedural_vars.size())};
+    body_.procedural_vars.push_back(
         hir::ProceduralVarDecl{.name = std::string{var.name}, .type = type});
     const auto [_, inserted] = procedural_var_bindings_.emplace(&var, id);
     if (!inserted) {
@@ -401,20 +401,16 @@ class ProcessLoweringState {
 
   [[nodiscard]] auto GetProceduralVarType(hir::ProceduralVarId id) const
       -> hir::TypeId {
-    return hir_process_.procedural_vars.at(id.value).type;
+    return body_.procedural_vars.at(id.value).type;
   }
 
-  auto Finalize(
-      hir::ProcessKind kind, diag::SourceSpan span, hir::StmtId root_stmt)
-      -> hir::Process {
-    hir_process_.kind = kind;
-    hir_process_.span = span;
-    hir_process_.root_stmt = root_stmt;
-    return std::move(hir_process_);
+  auto FinalizeBody(hir::StmtId root_stmt) -> hir::ProceduralBody {
+    body_.root_stmt = root_stmt;
+    return std::move(body_);
   }
 
  private:
-  hir::Process hir_process_;
+  hir::ProceduralBody body_;
   std::unordered_map<const slang::ast::VariableSymbol*, hir::ProceduralVarId>
       procedural_var_bindings_;
   const slang::ast::Symbol* containing_symbol_;

--- a/include/lyra/lowering/hir_to_mir/inside_predicate.hpp
+++ b/include/lyra/lowering/hir_to_mir/inside_predicate.hpp
@@ -2,7 +2,7 @@
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/inside_item.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -19,7 +19,7 @@ auto BuildHirInsideItemPredicate(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, mir::ExprId lhs_id,
+    const hir::ProceduralBody& hir_process, mir::ExprId lhs_id,
     const hir::InsideItem& item, mir::TypeId result_type)
     -> diag::Result<mir::ExprId>;
 

--- a/include/lyra/lowering/hir_to_mir/lower_deferred_check.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_deferred_check.hpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include "lyra/diag/diagnostic.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/expr.hpp"
@@ -34,7 +34,7 @@ auto BuildDeferredCheckCascade(
 auto LowerUniqueIfStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::Stmt& stmt, const hir::IfStmt& root) -> diag::Result<mir::Stmt>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/lower_diagnostic.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_diagnostic.hpp
@@ -3,7 +3,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/support/system_subroutine.hpp"
@@ -19,7 +19,7 @@ auto LowerDiagnosticSystemSubroutineCall(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::CallExpr& call,
+    const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const support::SystemSubroutineDesc& desc,
     const support::DiagnosticSystemSubroutineInfo& info, diag::SourceSpan span)
     -> diag::Result<mir::Expr>;

--- a/include/lyra/lowering/hir_to_mir/lower_expr.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_expr.hpp
@@ -2,7 +2,7 @@
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/expr.hpp"
@@ -14,7 +14,7 @@ auto LowerExpr(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::Expr& expr)
+    const hir::ProceduralBody& hir_process, const hir::Expr& expr)
     -> diag::Result<mir::Expr>;
 
 // Procedural expression lowering for the constructor's for-stmt header

--- a/include/lyra/lowering/hir_to_mir/lower_finish.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_finish.hpp
@@ -3,7 +3,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/support/system_subroutine.hpp"
@@ -16,7 +16,7 @@ namespace lyra::lowering::hir_to_mir {
 // (falling back to the descriptor's default_level when omitted). Returns a
 // user diagnostic if the level arg is non-literal or out of range.
 auto LowerFinishSystemSubroutineCall(
-    const UnitLoweringState& unit_state, const hir::Process& hir_proc,
+    const UnitLoweringState& unit_state, const hir::ProceduralBody& hir_proc,
     const hir::CallExpr& call, const support::SystemSubroutineDesc& desc,
     const support::TerminationSystemSubroutineInfo& info, diag::SourceSpan span)
     -> diag::Result<mir::Expr>;

--- a/include/lyra/lowering/hir_to_mir/lower_print.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_print.hpp
@@ -3,7 +3,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/support/system_subroutine.hpp"
@@ -18,7 +18,7 @@ auto LowerPrintSystemSubroutineCall(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::CallExpr& call,
+    const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const support::SystemSubroutineDesc& desc,
     const support::PrintSystemSubroutineInfo& print, diag::SourceSpan span)
     -> diag::Result<mir::Expr>;

--- a/include/lyra/lowering/hir_to_mir/lower_process.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_process.hpp
@@ -3,8 +3,10 @@
 #include "lyra/base/time.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/process.hpp"
+#include "lyra/hir/subroutine.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/process.hpp"
+#include "lyra/mir/structural_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -12,5 +14,11 @@ auto LowerProcess(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state, const hir::Process& src,
     TimeResolution time_resolution) -> diag::Result<mir::Process>;
+
+auto LowerStructuralSubroutine(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const hir::StructuralSubroutineDecl& src, TimeResolution time_resolution)
+    -> diag::Result<mir::StructuralSubroutineDecl>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/lower_stmt.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_stmt.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "lyra/diag/diagnostic.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/stmt.hpp"
@@ -13,7 +13,7 @@ auto LowerStmt(
     const StructuralScopeLoweringState& scope_state,
     ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::Stmt& stmt)
+    const hir::ProceduralBody& hir_proc, const hir::Stmt& stmt)
     -> diag::Result<mir::Stmt>;
 
 // Lowers a single HIR stmt into its own fresh ProceduralScope: pushes a
@@ -24,7 +24,7 @@ auto LowerStmt(
 auto LowerStmtIntoChildScope(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     hir::StmtId hir_stmt_id) -> diag::Result<mir::ProceduralScope>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/lower_system_subroutine.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_system_subroutine.hpp
@@ -3,7 +3,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/expr.hpp"
@@ -19,7 +19,7 @@ auto LowerSystemSubroutineCall(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::CallExpr& call,
+    const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const hir::SystemSubroutineRef& ref, diag::SourceSpan span)
     -> diag::Result<mir::Expr>;
 

--- a/include/lyra/lowering/hir_to_mir/print_items.hpp
+++ b/include/lyra/lowering/hir_to_mir/print_items.hpp
@@ -5,7 +5,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/runtime_print.hpp"
 
@@ -22,7 +22,7 @@ auto BuildRuntimePrintItemsFromCallArgs(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::CallExpr& call,
+    const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     diag::SourceSpan call_span)
     -> diag::Result<std::vector<mir::RuntimePrintItem>>;
 

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -19,7 +19,7 @@
 #include "lyra/mir/runtime_print.hpp"
 #include "lyra/mir/runtime_submit.hpp"
 #include "lyra/mir/structural_param.hpp"
-#include "lyra/mir/structural_subroutine.hpp"
+#include "lyra/mir/structural_subroutine_ref.hpp"
 #include "lyra/mir/unary_op.hpp"
 #include "lyra/mir/value_ref.hpp"
 #include "lyra/support/system_subroutine.hpp"

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -123,6 +123,14 @@ struct BreakStmt {};
 
 struct ContinueStmt {};
 
+// LRM 13.4.1 `return [expr];`. `value` carries the returned expression for a
+// value-returning function; it is absent for `return;` and for void functions
+// / tasks. MIR keeps the structured statement; the backend renders it as a
+// C++ `return`.
+struct ReturnStmt {
+  std::optional<ExprId> value;
+};
+
 // One leaf entry of a wait's projection set. Identity-only: which structural
 // variable, which flat bit range of its packed encoding, and what edge
 // polarity the leaf was subscribed under (LRM 9.4.2 / 9.4.2.2 / 9.4.3). slang
@@ -145,7 +153,7 @@ struct SensitivityWaitStmt {
 using StmtData = std::variant<
     EmptyStmt, ProceduralVarDeclStmt, ExprStmt, BlockStmt, IfStmt,
     ConstructOwnedObjectStmt, ForStmt, DelayStmt, WhileStmt, DoWhileStmt,
-    BreakStmt, ContinueStmt, SensitivityWaitStmt>;
+    BreakStmt, ContinueStmt, ReturnStmt, SensitivityWaitStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/include/lyra/mir/structural_subroutine.hpp
+++ b/include/lyra/mir/structural_subroutine.hpp
@@ -1,27 +1,40 @@
 #pragma once
 
-#include <compare>
 #include <cstdint>
 #include <string>
+#include <vector>
 
-#include "lyra/mir/structural_hops.hpp"
+#include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type_id.hpp"
 
 namespace lyra::mir {
 
-struct StructuralSubroutineId {
-  std::uint32_t value;
-
-  auto operator<=>(const StructuralSubroutineId&) const
-      -> std::strong_ordering = default;
+// LRM 13.5 argument direction. MIR carries the semantic direction only; the
+// C++ argument-passing mode is the backend's decision.
+enum class ParamDirection : std::uint8_t {
+  kInput,
+  kOutput,
+  kInOut,
+  kRef,
+  kConstRef,
 };
 
+// A formal argument of a subroutine. `name` is the procedural var the body
+// reads through; the backend renders it as the C++ parameter of that name.
+struct SubroutineParam {
+  std::string name;
+  TypeId type;
+  ParamDirection direction = ParamDirection::kInput;
+};
+
+// A subroutine is a callable peer of a process: its body is a ProceduralScope,
+// the same shape a process body uses. `params` names which of the scope's vars
+// are formals (the rest are body locals).
 struct StructuralSubroutineDecl {
   std::string name;
-};
-
-struct StructuralSubroutineRef {
-  StructuralHops hops = {};
-  StructuralSubroutineId subroutine = {};
+  TypeId result_type;
+  std::vector<SubroutineParam> params;
+  ProceduralScope root_procedural_scope;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/structural_subroutine_ref.hpp
+++ b/include/lyra/mir/structural_subroutine_ref.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+#include "lyra/mir/structural_hops.hpp"
+
+namespace lyra::mir {
+
+struct StructuralSubroutineId {
+  std::uint32_t value;
+
+  auto operator<=>(const StructuralSubroutineId&) const
+      -> std::strong_ordering = default;
+};
+
+struct StructuralSubroutineRef {
+  StructuralHops hops = {};
+  StructuralSubroutineId subroutine = {};
+};
+
+}  // namespace lyra::mir

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -121,6 +121,56 @@ auto RenderProcessMethod(
   return out;
 }
 
+// A value-returning function renders its result type; a void function or task
+// renders C++ `void`. Other formal directions are not in scope for the current
+// subroutine support, so non-input params are rejected here.
+auto RenderSubroutineResultType(
+    const mir::CompilationUnit& unit, const mir::StructuralScope& s,
+    mir::TypeId result_type) -> diag::Result<std::string> {
+  if (std::holds_alternative<mir::VoidType>(unit.GetType(result_type).data)) {
+    return std::string{"void"};
+  }
+  return RenderTypeAsCpp(unit, s, result_type);
+}
+
+auto RenderSubroutineMethod(
+    const RenderContext* parent_struct_ctx, const mir::CompilationUnit& unit,
+    const mir::StructuralScope& s, const mir::StructuralSubroutineDecl& sub,
+    std::size_t indent) -> diag::Result<std::string> {
+  auto result_or = RenderSubroutineResultType(unit, s, sub.result_type);
+  if (!result_or) return std::unexpected(std::move(result_or.error()));
+
+  std::string sig = *result_or + " " + sub.name + "(";
+  for (std::size_t i = 0; i < sub.params.size(); ++i) {
+    const auto& param = sub.params[i];
+    if (param.direction != mir::ParamDirection::kInput) {
+      return diag::Unsupported(
+          diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+          "only input subroutine arguments are supported in cpp emit",
+          diag::UnsupportedCategory::kFeature);
+    }
+    auto type_or = RenderTypeAsCpp(unit, s, param.type);
+    if (!type_or) return std::unexpected(std::move(type_or.error()));
+    if (i != 0) sig += ", ";
+    sig += *type_or + " " + param.name;
+  }
+  sig += ")";
+
+  const RenderContext sub_ctx =
+      (parent_struct_ctx == nullptr)
+          ? RenderContext::ForRoot(unit, s, sub.root_procedural_scope)
+          : parent_struct_ctx->WithStructuralScope(
+                s, sub.root_procedural_scope);
+
+  std::string out;
+  out += Indent(indent) + sig + " {\n";
+  auto rendered_or = RenderProceduralScopeStatements(sub_ctx, indent + 1);
+  if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
+  out += *rendered_or;
+  out += Indent(indent) + "}\n";
+  return out;
+}
+
 auto RenderProcessKindLiteral(mir::ProcessKind kind) -> std::string {
   switch (kind) {
     case mir::ProcessKind::kInitial:
@@ -241,6 +291,14 @@ auto RenderScopeAsClass(
     out += "\n";
     auto method_or = RenderProcessMethod(
         parent_struct_ctx, unit, s, s.processes[i], i, indent + 1);
+    if (!method_or) return std::unexpected(std::move(method_or.error()));
+    out += *method_or;
+  }
+
+  for (const auto& sub : s.structural_subroutines) {
+    out += "\n";
+    auto method_or =
+        RenderSubroutineMethod(parent_struct_ctx, unit, s, sub, indent + 1);
     if (!method_or) return std::unexpected(std::move(method_or.error()));
     out += *method_or;
   }

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -794,11 +794,27 @@ auto RenderCallExpr(const RenderContext& ctx, const mir::CallExpr& call)
                 "in cpp emit",
                 diag::UnsupportedCategory::kFeature);
           },
-          [](const mir::StructuralSubroutineRef&) -> diag::Result<std::string> {
-            return diag::Unsupported(
-                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-                "user subroutine call is not yet implemented in cpp emit",
-                diag::UnsupportedCategory::kFeature);
+          [&](const mir::StructuralSubroutineRef& ref)
+              -> diag::Result<std::string> {
+            if (ref.hops.value != 0) {
+              return diag::Unsupported(
+                  diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+                  "subroutine call across structural scopes is not yet "
+                  "implemented in cpp emit",
+                  diag::UnsupportedCategory::kFeature);
+            }
+            const auto& scope = ctx.StructuralScopeAtHops(
+                mir::StructuralHops{.value = ref.hops.value});
+            const std::string& name =
+                scope.GetStructuralSubroutine(ref.subroutine).name;
+            std::string args;
+            for (std::size_t i = 0; i < call.arguments.size(); ++i) {
+              auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+              if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+              if (i != 0) args += ", ";
+              args += *arg_or;
+            }
+            return std::format("{}({})", name, args);
           },
           [&](const mir::BuiltinMethodCallee& b) -> diag::Result<std::string> {
             return std::visit(

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -295,6 +295,14 @@ auto RenderStmt(
           [&](const mir::ContinueStmt&) -> diag::Result<std::string> {
             return Indent(indent) + "continue;\n";
           },
+          [&](const mir::ReturnStmt& s) -> diag::Result<std::string> {
+            if (!s.value.has_value()) {
+              return Indent(indent) + "return;\n";
+            }
+            auto value_or = RenderExpr(ctx, ctx.Expr(*s.value));
+            if (!value_or) return std::unexpected(std::move(value_or.error()));
+            return Indent(indent) + "return " + *value_or + ";\n";
+          },
           [&](const mir::SensitivityWaitStmt& s) -> diag::Result<std::string> {
             return RenderSensitivityWaitStmt(ctx, s, indent);
           },

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -751,7 +751,7 @@ class HirDumper {
     return std::format("type=Type[{}] {}", e.type.value, formatted);
   }
 
-  [[nodiscard]] auto FormatProcExpr(const Process& p, ExprId id) const
+  [[nodiscard]] auto FormatProcExpr(const ProceduralBody& p, ExprId id) const
       -> std::string {
     return FormatExpr(p.exprs.at(id.value));
   }
@@ -803,12 +803,7 @@ class HirDumper {
               "LoopVarDecl[{}] \"{}\" : Type[{}]", i, lv.name, lv.type.value));
     }
     for (std::size_t i = 0; i < s.structural_subroutines.size(); ++i) {
-      const auto& d = s.structural_subroutines[i];
-      Line(
-          std::format(
-              "StructuralSubroutine[{}] {} \"{}\" : Type[{}]", i,
-              d.kind == SubroutineKind::kTask ? "task" : "function", d.name,
-              d.result_type.value));
+      DumpStructuralSubroutine(i, s.structural_subroutines[i]);
     }
     if (!s.exprs.empty()) {
       Line("Exprs:");
@@ -829,6 +824,42 @@ class HirDumper {
     }
     Dedent();
     scope_stack_.pop_back();
+  }
+
+  void DumpStructuralSubroutine(
+      std::size_t index, const StructuralSubroutineDecl& d) {
+    Line(
+        std::format(
+            "StructuralSubroutine[{}] {} \"{}\" : Type[{}]", index,
+            d.kind == SubroutineKind::kTask ? "task" : "function", d.name,
+            d.result_type.value));
+    Indent();
+    for (std::size_t i = 0; i < d.params.size(); ++i) {
+      const auto& param = d.params[i];
+      Line(
+          std::format(
+              "Param[{}] {} var=ProceduralVar[{}]", i,
+              FormatParamDirection(param.direction), param.var.value));
+    }
+    DumpProceduralBody(d.body);
+    Dedent();
+  }
+
+  [[nodiscard]] static auto FormatParamDirection(ParamDirection dir)
+      -> std::string_view {
+    switch (dir) {
+      case ParamDirection::kInput:
+        return "input";
+      case ParamDirection::kOutput:
+        return "output";
+      case ParamDirection::kInOut:
+        return "inout";
+      case ParamDirection::kRef:
+        return "ref";
+      case ParamDirection::kConstRef:
+        return "const ref";
+    }
+    throw InternalError("FormatParamDirection: unknown hir::ParamDirection");
   }
 
   void DumpProcess(const Process& p) {
@@ -853,18 +884,6 @@ class HirDumper {
         break;
     }
     Indent();
-    if (!p.procedural_vars.empty()) {
-      Line("ProceduralVars:");
-      Indent();
-      for (std::size_t i = 0; i < p.procedural_vars.size(); ++i) {
-        const auto& lv = p.procedural_vars[i];
-        Line(
-            std::format(
-                "ProceduralVar[{}] \"{}\" : Type[{}]", i, lv.name,
-                lv.type.value));
-      }
-      Dedent();
-    }
     if (!p.implicit_sensitivity_list.empty()) {
       Line("ImplicitSensitivityList:");
       Indent();
@@ -877,16 +896,32 @@ class HirDumper {
       }
       Dedent();
     }
-    if (!p.exprs.empty()) {
-      Line("Exprs:");
+    DumpProceduralBody(p.body);
+    Dedent();
+  }
+
+  void DumpProceduralBody(const ProceduralBody& body) {
+    if (!body.procedural_vars.empty()) {
+      Line("ProceduralVars:");
       Indent();
-      for (std::size_t i = 0; i < p.exprs.size(); ++i) {
-        Line(std::format("Expr[{}] {}", i, FormatExpr(p.exprs[i])));
+      for (std::size_t i = 0; i < body.procedural_vars.size(); ++i) {
+        const auto& lv = body.procedural_vars[i];
+        Line(
+            std::format(
+                "ProceduralVar[{}] \"{}\" : Type[{}]", i, lv.name,
+                lv.type.value));
       }
       Dedent();
     }
-    DumpStmt(p, p.root_stmt);
-    Dedent();
+    if (!body.exprs.empty()) {
+      Line("Exprs:");
+      Indent();
+      for (std::size_t i = 0; i < body.exprs.size(); ++i) {
+        Line(std::format("Expr[{}] {}", i, FormatExpr(body.exprs[i])));
+      }
+      Dedent();
+    }
+    DumpStmt(body, body.root_stmt);
   }
 
   void DumpContinuousAssign(const ContinuousAssign& ca) {
@@ -910,7 +945,8 @@ class HirDumper {
     Dedent();
   }
 
-  void DumpVarDeclStmtNode(const Process& p, StmtId id, const VarDeclStmt& v) {
+  void DumpVarDeclStmtNode(
+      const ProceduralBody& p, StmtId id, const VarDeclStmt& v) {
     Line(
         std::format(
             "Stmt[{}] VarDeclStmt var=ProceduralVar[{}]", id.value,
@@ -924,7 +960,7 @@ class HirDumper {
     }
   }
 
-  void DumpExprStmtNode(const Process& p, StmtId id, const ExprStmt& e) {
+  void DumpExprStmtNode(const ProceduralBody& p, StmtId id, const ExprStmt& e) {
     Line(
         std::format("Stmt[{}] ExprStmt expr=Expr[{}]", id.value, e.expr.value));
     Indent();
@@ -932,7 +968,8 @@ class HirDumper {
     Dedent();
   }
 
-  void DumpBlockStmtNode(const Process& p, StmtId id, const BlockStmt& b) {
+  void DumpBlockStmtNode(
+      const ProceduralBody& p, StmtId id, const BlockStmt& b) {
     Line(
         std::format(
             "Stmt[{}] BlockStmt (count={})", id.value, b.statements.size()));
@@ -943,7 +980,7 @@ class HirDumper {
     Dedent();
   }
 
-  void DumpIfStmtNode(const Process& p, StmtId id, const IfStmt& i) {
+  void DumpIfStmtNode(const ProceduralBody& p, StmtId id, const IfStmt& i) {
     Line(
         std::format(
             "Stmt[{}] IfStmt{} cond=Expr[{}]", id.value,
@@ -965,7 +1002,7 @@ class HirDumper {
     Dedent();
   }
 
-  void DumpCaseStmtNode(const Process& p, StmtId id, const CaseStmt& c) {
+  void DumpCaseStmtNode(const ProceduralBody& p, StmtId id, const CaseStmt& c) {
     std::string_view kind_tag;
     switch (c.condition_kind) {
       case CaseCondition::kNormal:
@@ -1017,7 +1054,7 @@ class HirDumper {
   }
 
   void DumpCaseInsideStmtNode(
-      const Process& p, StmtId id, const CaseInsideStmt& c) {
+      const ProceduralBody& p, StmtId id, const CaseInsideStmt& c) {
     Line(
         std::format(
             "Stmt[{}] CaseInsideStmt{} cond=Expr[{}] (items={})", id.value,
@@ -1064,7 +1101,7 @@ class HirDumper {
     Dedent();
   }
 
-  void DumpForStmtNode(const Process& p, StmtId id, const ForStmt& f) {
+  void DumpForStmtNode(const ProceduralBody& p, StmtId id, const ForStmt& f) {
     Line(
         std::format(
             "Stmt[{}] ForStmt (init={}, step={})", id.value, f.init.size(),
@@ -1115,7 +1152,8 @@ class HirDumper {
     Dedent();
   }
 
-  void DumpWhileStmtNode(const Process& p, StmtId id, const WhileStmt& w) {
+  void DumpWhileStmtNode(
+      const ProceduralBody& p, StmtId id, const WhileStmt& w) {
     Line(
         std::format(
             "Stmt[{}] WhileStmt cond=Expr[{}]", id.value, w.condition.value));
@@ -1130,7 +1168,8 @@ class HirDumper {
     Dedent();
   }
 
-  void DumpRepeatStmtNode(const Process& p, StmtId id, const RepeatStmt& r) {
+  void DumpRepeatStmtNode(
+      const ProceduralBody& p, StmtId id, const RepeatStmt& r) {
     Line(
         std::format(
             "Stmt[{}] RepeatStmt count=Expr[{}]", id.value, r.count.value));
@@ -1143,7 +1182,8 @@ class HirDumper {
     Dedent();
   }
 
-  void DumpDoWhileStmtNode(const Process& p, StmtId id, const DoWhileStmt& d) {
+  void DumpDoWhileStmtNode(
+      const ProceduralBody& p, StmtId id, const DoWhileStmt& d) {
     Line(
         std::format(
             "Stmt[{}] DoWhileStmt cond=Expr[{}]", id.value, d.condition.value));
@@ -1158,7 +1198,8 @@ class HirDumper {
     Dedent();
   }
 
-  void DumpForeverStmtNode(const Process& p, StmtId id, const ForeverStmt& f) {
+  void DumpForeverStmtNode(
+      const ProceduralBody& p, StmtId id, const ForeverStmt& f) {
     Line(std::format("Stmt[{}] ForeverStmt", id.value));
     Indent();
     Line("body:");
@@ -1168,7 +1209,8 @@ class HirDumper {
     Dedent();
   }
 
-  void DumpTimedStmtNode(const Process& p, StmtId id, const TimedStmt& t) {
+  void DumpTimedStmtNode(
+      const ProceduralBody& p, StmtId id, const TimedStmt& t) {
     Line(std::format("Stmt[{}] TimedStmt", id.value));
     Indent();
     Line(std::format("timing: {}", FormatTimingControlHeader(t.timing)));
@@ -1194,7 +1236,7 @@ class HirDumper {
     Dedent();
   }
 
-  void DumpStmt(const Process& p, StmtId id) {
+  void DumpStmt(const ProceduralBody& p, StmtId id) {
     const auto& s = p.stmts.at(id.value);
     std::visit(
         Overloaded{
@@ -1217,6 +1259,22 @@ class HirDumper {
             },
             [&](const ContinueStmt&) {
               Line(std::format("Stmt[{}] ContinueStmt", id.value));
+            },
+            [&](const ReturnStmt& r) {
+              if (r.value.has_value()) {
+                Line(
+                    std::format(
+                        "Stmt[{}] ReturnStmt value=Expr[{}]", id.value,
+                        r.value->value));
+                Indent();
+                Line(
+                    std::format(
+                        "Expr[{}] {}", r.value->value,
+                        FormatProcExpr(p, *r.value)));
+                Dedent();
+              } else {
+                Line(std::format("Stmt[{}] ReturnStmt", id.value));
+              }
             },
             [&](const TimedStmt& t) { DumpTimedStmtNode(p, id, t); },
             [&](const EventTriggerStmt& et) {

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -245,7 +245,11 @@ auto LowerNamedValueProc(
         sym.as<slang::ast::ParameterSymbol>(), *type_id, span);
   }
 
-  if (sym.kind != slang::ast::SymbolKind::Variable) {
+  // A subroutine formal (LRM 13.5) is a VariableSymbol subclass with its own
+  // SymbolKind; it resolves through the same procedural-var binding as a body
+  // local.
+  if (sym.kind != slang::ast::SymbolKind::Variable &&
+      sym.kind != slang::ast::SymbolKind::FormalArgument) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedNonVariableNamedReference,
         "reference to non-variable declaration is not supported",

--- a/src/lyra/lowering/ast_to_hir/process.cpp
+++ b/src/lyra/lowering/ast_to_hir/process.cpp
@@ -106,7 +106,11 @@ auto LowerProcess(
   const auto span = mapper.PointSpanOf(proc.location);
   const auto kind = FromSlangProceduralBlockKind(proc.procedureKind);
 
-  auto out = proc_state.Finalize(kind, span, root_stmt_id);
+  hir::Process out{
+      .kind = kind,
+      .span = span,
+      .body = proc_state.FinalizeBody(root_stmt_id),
+      .implicit_sensitivity_list = {}};
   if (kind == hir::ProcessKind::kAlwaysComb ||
       kind == hir::ProcessKind::kAlwaysLatch) {
     // LRM 9.2.2.2.1: implicit sensitivity is a property of the always_comb /

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -8,6 +8,7 @@
 
 #include <slang/ast/Scope.h>
 #include <slang/ast/SemanticFacts.h>
+#include <slang/ast/Statement.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/BlockSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
@@ -27,6 +28,7 @@
 #include "lyra/lowering/ast_to_hir/generate.hpp"
 #include "lyra/lowering/ast_to_hir/process.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
+#include "lyra/lowering/ast_to_hir/statement/lower.hpp"
 #include "lyra/lowering/ast_to_hir/time_resolution.hpp"
 
 namespace lyra::lowering::ast_to_hir {
@@ -107,20 +109,63 @@ auto LowerVariableMemberInto(
   return {};
 }
 
+auto FromSlangArgumentDirection(slang::ast::ArgumentDirection dir)
+    -> hir::ParamDirection {
+  switch (dir) {
+    case slang::ast::ArgumentDirection::In:
+      return hir::ParamDirection::kInput;
+    case slang::ast::ArgumentDirection::Out:
+      return hir::ParamDirection::kOutput;
+    case slang::ast::ArgumentDirection::InOut:
+      return hir::ParamDirection::kInOut;
+    case slang::ast::ArgumentDirection::Ref:
+      return hir::ParamDirection::kRef;
+  }
+  throw InternalError("FromSlangArgumentDirection: unknown ArgumentDirection");
+}
+
 auto LowerSubroutineMemberInto(
     const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
-    const slang::ast::SubroutineSymbol& sym) -> diag::Result<void> {
+    ScopeStack& stack, const slang::ast::SubroutineSymbol& sym)
+    -> diag::Result<void> {
   const auto& mapper = unit_facts.SourceMapper();
-  auto return_type_id_or = scope_state.UnitState().GetTypeId(
+  auto& unit_state = scope_state.UnitState();
+  auto return_type_id_or = unit_state.GetTypeId(
       sym.getReturnType(), mapper.PointSpanOf(sym.location));
   if (!return_type_id_or) {
     return std::unexpected(std::move(return_type_id_or.error()));
   }
+
+  ProcessLoweringState sub_state(sym);
+
+  std::vector<hir::SubroutineParam> params;
+  params.reserve(sym.getArguments().size());
+  for (const auto* formal : sym.getArguments()) {
+    auto formal_type_or = unit_state.GetTypeId(
+        formal->getType(), mapper.PointSpanOf(formal->location));
+    if (!formal_type_or) {
+      return std::unexpected(std::move(formal_type_or.error()));
+    }
+    const hir::ProceduralVarId var =
+        sub_state.AddProceduralVar(*formal, *formal_type_or);
+    params.push_back(
+        hir::SubroutineParam{
+            .var = var,
+            .direction = FromSlangArgumentDirection(formal->direction)});
+  }
+
+  auto body_or =
+      LowerStatement(unit_facts, sub_state, scope_state, stack, sym.getBody());
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+  const hir::StmtId root = sub_state.AddStmt(*std::move(body_or));
+
   scope_state.AddStructuralSubroutine(
       sym, hir::StructuralSubroutineDecl{
                .name = std::string{sym.name},
                .kind = FromSlangSubroutineKind(sym.subroutineKind),
-               .result_type = *return_type_id_or});
+               .result_type = *return_type_id_or,
+               .params = std::move(params),
+               .body = sub_state.FinalizeBody(root)});
   return {};
 }
 
@@ -196,7 +241,8 @@ auto LowerScopeMemberInto(
           member.as<slang::ast::VariableSymbol>());
     case slang::ast::SymbolKind::Subroutine:
       return LowerSubroutineMemberInto(
-          unit_facts, scope_state, member.as<slang::ast::SubroutineSymbol>());
+          unit_facts, scope_state, stack,
+          member.as<slang::ast::SubroutineSymbol>());
     case slang::ast::SymbolKind::ProceduralBlock:
       return LowerProceduralBlockMemberInto(
           unit_facts, scope_state, stack,

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -609,6 +609,27 @@ auto LowerConditionalStmt(
       .span = span};
 }
 
+// LRM 13.4.1 `return [expr];`. A non-void function carries the returned
+// expression; void functions and tasks use the bare form, leaving `value`
+// absent.
+auto LowerReturnStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, const ScopeStack& stack,
+    const slang::ast::ReturnStatement& rs, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  std::optional<hir::ExprId> value;
+  if (rs.expr != nullptr) {
+    auto expr_or = LowerProcExpr(
+        unit_facts, scope_state.UnitState(), proc_state, stack, *rs.expr);
+    if (!expr_or) return std::unexpected(std::move(expr_or.error()));
+    value = proc_state.AddExpr(*std::move(expr_or));
+  }
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data = hir::ReturnStmt{.value = value},
+      .span = span};
+}
+
 }  // namespace
 
 // LRM 15.5.1 `-> e;`. Source-aligned with slang's EventTriggerStatement. The
@@ -767,6 +788,11 @@ auto LowerStatement(
       return LowerConditionalStmt(
           unit_facts, proc_state, scope_state, stack,
           stmt.as<slang::ast::ConditionalStatement>(), span);
+
+    case slang::ast::StatementKind::Return:
+      return LowerReturnStmt(
+          unit_facts, proc_state, scope_state, stack,
+          stmt.as<slang::ast::ReturnStatement>(), span);
 
     default:
       return diag::Unsupported(

--- a/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
+++ b/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
@@ -5,7 +5,7 @@
 
 #include "lyra/base/overloaded.hpp"
 #include "lyra/hir/inside_item.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/expr.hpp"
@@ -17,7 +17,7 @@ auto BuildHirInsideItemPredicate(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, mir::ExprId lhs_id,
+    const hir::ProceduralBody& hir_process, mir::ExprId lhs_id,
     const hir::InsideItem& item, mir::TypeId result_type)
     -> diag::Result<mir::ExprId> {
   auto lower_id = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -528,13 +528,27 @@ auto LowerStructuralScope(
     scope_state.MapStructuralVar(hir_id, mir_id);
   }
 
+  // Map every subroutine's identity before lowering any body, so a call in one
+  // body resolves a forward or mutual reference to a peer (LRM 13.7). Only the
+  // HIR -> MIR id mapping has to precede the bodies; the MIR id is the index
+  // each decl will occupy, and the loop below adds the lowered decls in that
+  // same order.
   for (std::size_t i = 0; i < scope.structural_subroutines.size(); ++i) {
-    const hir::StructuralSubroutineId hir_id{static_cast<std::uint32_t>(i)};
-    const auto& decl = scope.structural_subroutines[i];
-    const mir::StructuralSubroutineId mir_id =
-        scope_state.AddStructuralSubroutine(
-            mir::StructuralSubroutineDecl{.name = decl.name});
-    scope_state.MapStructuralSubroutine(hir_id, mir_id);
+    scope_state.MapStructuralSubroutine(
+        hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)},
+        mir::StructuralSubroutineId{static_cast<std::uint32_t>(i)});
+  }
+  for (std::size_t i = 0; i < scope.structural_subroutines.size(); ++i) {
+    auto decl_or = LowerStructuralSubroutine(
+        unit_state, scope_state, scope.structural_subroutines[i],
+        scope.time_resolution);
+    if (!decl_or) return std::unexpected(std::move(decl_or.error()));
+    const mir::StructuralSubroutineId added =
+        scope_state.AddStructuralSubroutine(*std::move(decl_or));
+    if (added.value != i) {
+      throw InternalError(
+          "LowerStructuralScope: subroutine added out of mapped id order");
+    }
   }
 
   for (const auto& p : scope.processes) {

--- a/src/lyra/lowering/hir_to_mir/lower_deferred_check.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_deferred_check.cpp
@@ -34,7 +34,8 @@ struct UniqueIfCascade {
   std::optional<hir::StmtId> tail_else;
 };
 
-auto FlattenUniqueCascade(const hir::Process& proc, const hir::IfStmt& root)
+auto FlattenUniqueCascade(
+    const hir::ProceduralBody& proc, const hir::IfStmt& root)
     -> UniqueIfCascade {
   UniqueIfCascade out;
   out.conditions.push_back(root.condition);
@@ -458,7 +459,7 @@ auto BuildDeferredCheckCascade(
 auto LowerUniqueIfStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::Stmt& stmt, const hir::IfStmt& root) -> diag::Result<mir::Stmt> {
   const auto cascade = FlattenUniqueCascade(hir_proc, root);
 

--- a/src/lyra/lowering/hir_to_mir/lower_diagnostic.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_diagnostic.cpp
@@ -8,7 +8,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/print_items.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/expr.hpp"
@@ -39,7 +39,7 @@ auto LowerDiagnosticSystemSubroutineCall(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::CallExpr& call,
+    const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const support::SystemSubroutineDesc& desc,
     const support::DiagnosticSystemSubroutineInfo& info, diag::SourceSpan span)
     -> diag::Result<mir::Expr> {

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -17,7 +17,7 @@
 #include "lyra/hir/conversion.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/integral_constant.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/unary_op.hpp"
@@ -257,7 +257,7 @@ auto LowerHirRangeBoundsProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::RangeBounds& bounds)
+    const hir::ProceduralBody& hir_process, const hir::RangeBounds& bounds)
     -> diag::Result<mir::RangeBounds> {
   auto lower_one = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
     auto lowered = LowerExpr(
@@ -632,7 +632,7 @@ auto LowerHirUnaryExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::UnaryExpr& u,
+    const hir::ProceduralBody& hir_process, const hir::UnaryExpr& u,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto operand_or = LowerExpr(
       unit_state, scope_state, proc_state, proc_scope_state, hir_process,
@@ -652,7 +652,7 @@ auto LowerHirBinaryExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::BinaryExpr& b,
+    const hir::ProceduralBody& hir_process, const hir::BinaryExpr& b,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto lhs_or = LowerExpr(
       unit_state, scope_state, proc_state, proc_scope_state, hir_process,
@@ -676,7 +676,7 @@ auto LowerHirConditionalExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::ConditionalExpr& c,
+    const hir::ProceduralBody& hir_process, const hir::ConditionalExpr& c,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto cond_or = LowerExpr(
       unit_state, scope_state, proc_state, proc_scope_state, hir_process,
@@ -707,7 +707,7 @@ auto LowerHirAssignExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::AssignExpr& a,
+    const hir::ProceduralBody& hir_process, const hir::AssignExpr& a,
     diag::SourceSpan span, mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto rhs_or = LowerExpr(
       unit_state, scope_state, proc_state, proc_scope_state, hir_process,
@@ -761,7 +761,7 @@ auto LowerHirIncDecExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::IncDecExpr& inc,
+    const hir::ProceduralBody& hir_process, const hir::IncDecExpr& inc,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto target_or = LowerExpr(
       unit_state, scope_state, proc_state, proc_scope_state, hir_process,
@@ -778,7 +778,7 @@ auto LowerHirConversionExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::ConversionExpr& cv,
+    const hir::ProceduralBody& hir_process, const hir::ConversionExpr& cv,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto operand_or = LowerExpr(
       unit_state, scope_state, proc_state, proc_scope_state, hir_process,
@@ -800,7 +800,7 @@ auto LowerHirCallExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::CallExpr& c,
+    const hir::ProceduralBody& hir_process, const hir::CallExpr& c,
     diag::SourceSpan span, mir::TypeId result_type) -> diag::Result<mir::Expr> {
   return std::visit(
       Overloaded{
@@ -882,7 +882,7 @@ auto LowerHirInsideExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::InsideExpr& in,
+    const hir::ProceduralBody& hir_process, const hir::InsideExpr& in,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto lhs_or = LowerExpr(
       unit_state, scope_state, proc_state, proc_scope_state, hir_process,
@@ -921,7 +921,7 @@ auto LowerHirElementSelectExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::ElementSelectExpr& sel,
+    const hir::ProceduralBody& hir_process, const hir::ElementSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto base_or = LowerExpr(
       unit_state, scope_state, proc_state, proc_scope_state, hir_process,
@@ -949,7 +949,7 @@ auto LowerHirRangeSelectExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::RangeSelectExpr& sel,
+    const hir::ProceduralBody& hir_process, const hir::RangeSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto base_or = LowerExpr(
       unit_state, scope_state, proc_state, proc_scope_state, hir_process,
@@ -980,7 +980,7 @@ auto LowerHirMemberAccessExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::MemberAccessExpr& sel,
+    const hir::ProceduralBody& hir_process, const hir::MemberAccessExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& base_hir_expr = hir_process.exprs.at(sel.base_value.value);
   const auto& base_hir_type = unit_state.GetHirType(base_hir_expr.type);
@@ -1015,7 +1015,7 @@ auto LowerHirConcatExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::ConcatExpr& c,
+    const hir::ProceduralBody& hir_process, const hir::ConcatExpr& c,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   std::vector<mir::ExprId> operand_ids;
   operand_ids.reserve(c.operands.size());
@@ -1036,7 +1036,7 @@ auto LowerHirReplicationExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::ReplicationExpr& r,
+    const hir::ProceduralBody& hir_process, const hir::ReplicationExpr& r,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto count_or = LowerExpr(
       unit_state, scope_state, proc_state, proc_scope_state, hir_process,
@@ -1060,7 +1060,7 @@ auto LowerExpr(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::Expr& expr)
+    const hir::ProceduralBody& hir_process, const hir::Expr& expr)
     -> diag::Result<mir::Expr> {
   const mir::TypeId result_type = unit_state.TranslateType(expr.type);
   return std::visit(

--- a/src/lyra/lowering/hir_to_mir/lower_finish.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_finish.cpp
@@ -11,7 +11,7 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/integral_constant.hpp"
 #include "lyra/hir/primary.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/runtime_finish.hpp"
 #include "lyra/support/system_subroutine.hpp"
@@ -35,7 +35,7 @@ auto TryExtractLiteralInt(const hir::Expr& expr)
 }  // namespace
 
 auto LowerFinishSystemSubroutineCall(
-    const UnitLoweringState& unit_state, const hir::Process& hir_proc,
+    const UnitLoweringState& unit_state, const hir::ProceduralBody& hir_proc,
     const hir::CallExpr& call, const support::SystemSubroutineDesc& desc,
     const support::TerminationSystemSubroutineInfo& info, diag::SourceSpan span)
     -> diag::Result<mir::Expr> {

--- a/src/lyra/lowering/hir_to_mir/lower_print.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_print.cpp
@@ -10,7 +10,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/print_items.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/expr.hpp"
@@ -38,7 +38,7 @@ auto LowerPrintSystemSubroutineCall(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::CallExpr& call,
+    const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const support::SystemSubroutineDesc& desc,
     const support::PrintSystemSubroutineInfo& print, diag::SourceSpan span)
     -> diag::Result<mir::Expr> {

--- a/src/lyra/lowering/hir_to_mir/lower_process.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_process.cpp
@@ -20,18 +20,28 @@ namespace lyra::lowering::hir_to_mir {
 
 namespace {
 
+auto LowerStraightLineBodyInto(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const hir::ProceduralBody& body, ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& body_scope_state) -> diag::Result<void> {
+  auto lowered = LowerStmt(
+      unit_state, scope_state, proc_state, body_scope_state, body,
+      body.stmts.at(body.root_stmt.value));
+  if (!lowered) return std::unexpected(std::move(lowered.error()));
+  body_scope_state.AddRootStmt(body_scope_state.AddStmt(*std::move(lowered)));
+  return {};
+}
+
 auto LowerStraightLineProcess(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state, const hir::Process& src,
     ProcessLoweringState& proc_state, mir::ProcessKind kind)
     -> diag::Result<mir::Process> {
   ProceduralScopeLoweringState process_scope_state;
-  auto lowered = LowerStmt(
-      unit_state, scope_state, proc_state, process_scope_state, src,
-      src.stmts.at(src.root_stmt.value));
+  auto lowered = LowerStraightLineBodyInto(
+      unit_state, scope_state, src.body, proc_state, process_scope_state);
   if (!lowered) return std::unexpected(std::move(lowered.error()));
-  process_scope_state.AddRootStmt(
-      process_scope_state.AddStmt(*std::move(lowered)));
   return mir::Process{
       .kind = kind, .root_procedural_scope = process_scope_state.Finish()};
 }
@@ -49,11 +59,9 @@ auto LowerForeverProcess(
   ProceduralScopeLoweringState body_scope_state;
   {
     ProceduralDepthGuard guard{proc_state};
-    auto lowered = LowerStmt(
-        unit_state, scope_state, proc_state, body_scope_state, src,
-        src.stmts.at(src.root_stmt.value));
+    auto lowered = LowerStraightLineBodyInto(
+        unit_state, scope_state, src.body, proc_state, body_scope_state);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    body_scope_state.AddRootStmt(body_scope_state.AddStmt(*std::move(lowered)));
     if (tail_stmt.has_value()) {
       body_scope_state.AddRootStmt(
           body_scope_state.AddStmt(*std::move(tail_stmt)));
@@ -104,6 +112,67 @@ auto LowerProcess(
           BuildSensitivityWaitStmt(scope_state, src.implicit_sensitivity_list));
   }
   throw InternalError("LowerProcess: unknown HIR ProcessKind");
+}
+
+namespace {
+
+auto LowerParamDirection(hir::ParamDirection dir) -> mir::ParamDirection {
+  switch (dir) {
+    case hir::ParamDirection::kInput:
+      return mir::ParamDirection::kInput;
+    case hir::ParamDirection::kOutput:
+      return mir::ParamDirection::kOutput;
+    case hir::ParamDirection::kInOut:
+      return mir::ParamDirection::kInOut;
+    case hir::ParamDirection::kRef:
+      return mir::ParamDirection::kRef;
+    case hir::ParamDirection::kConstRef:
+      return mir::ParamDirection::kConstRef;
+  }
+  throw InternalError("LowerParamDirection: unknown hir::ParamDirection");
+}
+
+}  // namespace
+
+auto LowerStructuralSubroutine(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const hir::StructuralSubroutineDecl& src, TimeResolution time_resolution)
+    -> diag::Result<mir::StructuralSubroutineDecl> {
+  ProcessLoweringState proc_state{time_resolution};
+  ProceduralScopeLoweringState body_scope_state;
+
+  // Formals are procedural vars of the body with no VarDeclStmt: pre-register
+  // them in the body scope at depth 0 so the body's references resolve. The
+  // backend renders these as C++ parameters rather than in-body declarations.
+  std::vector<mir::SubroutineParam> params;
+  params.reserve(src.params.size());
+  for (const auto& param : src.params) {
+    const auto& hir_var = src.body.procedural_vars.at(param.var.value);
+    const mir::TypeId type = unit_state.TranslateType(hir_var.type);
+    const mir::ProceduralVarId mir_var = body_scope_state.AddProceduralVar(
+        mir::ProceduralVarDecl{.name = hir_var.name, .type = type});
+    proc_state.MapProceduralVar(
+        param.var,
+        ProceduralVarBinding{
+            .declaration_procedural_depth = proc_state.CurrentProceduralDepth(),
+            .var = mir_var});
+    params.push_back(
+        mir::SubroutineParam{
+            .name = hir_var.name,
+            .type = type,
+            .direction = LowerParamDirection(param.direction)});
+  }
+
+  auto lowered = LowerStraightLineBodyInto(
+      unit_state, scope_state, src.body, proc_state, body_scope_state);
+  if (!lowered) return std::unexpected(std::move(lowered.error()));
+
+  return mir::StructuralSubroutineDecl{
+      .name = src.name,
+      .result_type = unit_state.TranslateType(src.result_type),
+      .params = std::move(params),
+      .root_procedural_scope = body_scope_state.Finish()};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -13,7 +13,7 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/integral_constant.hpp"
 #include "lyra/hir/primary.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/case_cascade.hpp"
 #include "lyra/lowering/hir_to_mir/delay_time_resolver.hpp"
@@ -72,7 +72,7 @@ auto ResolveDelayDuration(
 }
 
 auto ResolveDelayTicks(
-    const ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    const ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::DelayControl& d) -> diag::Result<SimDuration> {
   const DelayTimeResolver resolver{proc_state.Resolution()};
   return ResolveDelayDuration(resolver, hir_proc.exprs.at(d.duration.value));
@@ -90,7 +90,7 @@ auto LowerVarDeclStmt(
     const StructuralScopeLoweringState& scope_state,
     ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::Stmt& stmt,
+    const hir::ProceduralBody& hir_proc, const hir::Stmt& stmt,
     const hir::VarDeclStmt& v) -> diag::Result<mir::Stmt> {
   const auto& hir_local = hir_proc.procedural_vars.at(v.var.value);
   const mir::TypeId type = unit_state.TranslateType(hir_local.type);
@@ -139,7 +139,7 @@ auto LowerVarDeclStmt(
 auto LowerDestructuringAssign(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::Stmt& stmt, const hir::AssignExpr& assign,
     const hir::ConcatExpr& lhs_concat) -> diag::Result<mir::Stmt> {
   ProceduralScopeLoweringState wrapper_state;
@@ -320,8 +320,8 @@ auto LowerExprStmt(
     const StructuralScopeLoweringState& scope_state,
     ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::Stmt& stmt, const hir::ExprStmt& e)
-    -> diag::Result<mir::Stmt> {
+    const hir::ProceduralBody& hir_proc, const hir::Stmt& stmt,
+    const hir::ExprStmt& e) -> diag::Result<mir::Stmt> {
   // LRM 11.4.12 LHS destructuring: detect AssignExpr-with-ConcatExpr-LHS
   // and dispatch to the snapshot+distribute desugar. Destructuring is
   // grammatically statement-only (LRM A.6.2), so this is the only context
@@ -355,10 +355,31 @@ auto LowerExprStmt(
       .child_procedural_scopes = {}};
 }
 
+auto LowerReturnStmt(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::ProceduralBody& hir_proc, const hir::Stmt& stmt,
+    const hir::ReturnStmt& r) -> diag::Result<mir::Stmt> {
+  std::optional<mir::ExprId> value;
+  if (r.value.has_value()) {
+    auto value_or = LowerExpr(
+        unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+        hir_proc.exprs.at(r.value->value));
+    if (!value_or) return std::unexpected(std::move(value_or.error()));
+    value = proc_scope_state.AddExpr(*std::move(value_or));
+  }
+  return mir::Stmt{
+      .label = stmt.label,
+      .data = mir::ReturnStmt{.value = value},
+      .child_procedural_scopes = {}};
+}
+
 auto LowerBlockStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::Stmt& stmt, const hir::BlockStmt& b) -> diag::Result<mir::Stmt> {
   ProceduralScopeLoweringState child_proc_scope_state;
   ProceduralDepthGuard depth_guard{proc_state};
@@ -388,8 +409,8 @@ auto LowerIfStmt(
     const StructuralScopeLoweringState& scope_state,
     ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::Stmt& stmt, const hir::IfStmt& i)
-    -> diag::Result<mir::Stmt> {
+    const hir::ProceduralBody& hir_proc, const hir::Stmt& stmt,
+    const hir::IfStmt& i) -> diag::Result<mir::Stmt> {
   if (i.check.has_value()) {
     return LowerUniqueIfStmt(
         unit_state, scope_state, proc_state, hir_proc, stmt, i);
@@ -431,7 +452,7 @@ auto LowerIfStmt(
 auto LowerCaseStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::Stmt& stmt, const hir::CaseStmt& c) -> diag::Result<mir::Stmt> {
   const mir::TypeId bit_type = unit_state.Builtins().bit1;
   const mir::BinaryOp compare_op = [&] {
@@ -590,7 +611,7 @@ auto LowerCaseStmt(
 auto LowerCaseInsideStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::Stmt& stmt, const hir::CaseInsideStmt& c)
     -> diag::Result<mir::Stmt> {
   const mir::TypeId bit_type = unit_state.Builtins().bit1;
@@ -725,8 +746,8 @@ auto LowerForStmt(
     const StructuralScopeLoweringState& scope_state,
     ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::Stmt& stmt, const hir::ForStmt& f)
-    -> diag::Result<mir::Stmt> {
+    const hir::ProceduralBody& hir_proc, const hir::Stmt& stmt,
+    const hir::ForStmt& f) -> diag::Result<mir::Stmt> {
   std::vector<mir::ForInit> mir_init;
   mir_init.reserve(f.init.size());
   for (const auto& hinit : f.init) {
@@ -826,7 +847,7 @@ auto LowerWhileStmt(
     const StructuralScopeLoweringState& scope_state,
     ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::Stmt& stmt,
+    const hir::ProceduralBody& hir_proc, const hir::Stmt& stmt,
     const hir::WhileStmt& w) -> diag::Result<mir::Stmt> {
   auto cond_or = LowerExpr(
       unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
@@ -855,7 +876,7 @@ auto LowerWhileStmt(
 auto LowerRepeatStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::Stmt& stmt, const hir::RepeatStmt& r)
     -> diag::Result<mir::Stmt> {
   const mir::TypeId int_type = unit_state.Builtins().int32;
@@ -996,7 +1017,7 @@ auto LowerDoWhileStmt(
     const StructuralScopeLoweringState& scope_state,
     ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::Stmt& stmt,
+    const hir::ProceduralBody& hir_proc, const hir::Stmt& stmt,
     const hir::DoWhileStmt& d) -> diag::Result<mir::Stmt> {
   auto body_or = LowerStmtIntoChildScope(
       unit_state, scope_state, proc_state, hir_proc, d.body);
@@ -1025,7 +1046,7 @@ auto LowerDoWhileStmt(
 auto LowerForeverStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::Stmt& stmt, const hir::ForeverStmt& f)
     -> diag::Result<mir::Stmt> {
   auto body_or = LowerStmtIntoChildScope(
@@ -1072,7 +1093,7 @@ auto LowerEventTriggerStmt(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::Stmt& stmt,
+    const hir::ProceduralBody& hir_proc, const hir::Stmt& stmt,
     const hir::EventTriggerStmt& et) -> diag::Result<mir::Stmt> {
   auto receiver_or = LowerExpr(
       unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
@@ -1105,7 +1126,7 @@ auto LowerEventTriggerStmt(
 auto LowerNamedEventTimedStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::Stmt& stmt, const hir::TimedStmt& t,
     const hir::NamedEventControl& nec) -> diag::Result<mir::Stmt> {
   ProceduralScopeLoweringState child_proc_scope_state;
@@ -1170,7 +1191,7 @@ auto LowerNamedEventTimedStmt(
 auto LowerEventTimedStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::Stmt& stmt, const hir::TimedStmt& t, const hir::EventControl& ec)
     -> diag::Result<mir::Stmt> {
   std::vector<hir::SensitivityEntry> union_reads;
@@ -1230,7 +1251,7 @@ auto LowerEventTimedStmt(
 auto LowerImplicitEventTimedStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::Stmt& stmt, const hir::TimedStmt& t,
     const hir::ImplicitEventControl& ie) -> diag::Result<mir::Stmt> {
   ProceduralScopeLoweringState child_proc_scope_state;
@@ -1269,7 +1290,7 @@ auto LowerImplicitEventTimedStmt(
 auto LowerWaitStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::Stmt& stmt, const hir::WaitStmt& w) -> diag::Result<mir::Stmt> {
   ProceduralScopeLoweringState wrapper_state;
   ProceduralDepthGuard wrapper_depth_guard{proc_state};
@@ -1339,7 +1360,7 @@ auto LowerWaitStmt(
 auto LowerDelayTimedStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::Stmt& stmt, const hir::TimedStmt& t, const hir::DelayControl& d)
     -> diag::Result<mir::Stmt> {
   auto ticks_or = ResolveDelayTicks(proc_state, hir_proc, d);
@@ -1374,7 +1395,7 @@ auto LowerDelayTimedStmt(
 auto LowerTimedStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::Stmt& stmt, const hir::TimedStmt& t) -> diag::Result<mir::Stmt> {
   if (const auto* ie = std::get_if<hir::ImplicitEventControl>(&t.timing)) {
     return LowerImplicitEventTimedStmt(
@@ -1401,7 +1422,7 @@ auto LowerTimedStmt(
 auto LowerStmtIntoChildScope(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Process& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     hir::StmtId hir_stmt_id) -> diag::Result<mir::ProceduralScope> {
   ProceduralScopeLoweringState child_state;
   ProceduralDepthGuard depth_guard{proc_state};
@@ -1421,7 +1442,7 @@ auto LowerStmt(
     const StructuralScopeLoweringState& scope_state,
     ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::Stmt& stmt)
+    const hir::ProceduralBody& hir_proc, const hir::Stmt& stmt)
     -> diag::Result<mir::Stmt> {
   return std::visit(
       Overloaded{
@@ -1478,6 +1499,11 @@ auto LowerStmt(
           },
           [&](const hir::BreakStmt&) { return LowerBreakStmt(stmt); },
           [&](const hir::ContinueStmt&) { return LowerContinueStmt(stmt); },
+          [&](const hir::ReturnStmt& r) {
+            return LowerReturnStmt(
+                unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+                stmt, r);
+          },
           [&](const hir::TimedStmt& t) {
             return LowerTimedStmt(
                 unit_state, scope_state, proc_state, hir_proc, stmt, t);

--- a/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
@@ -5,7 +5,7 @@
 #include "lyra/base/overloaded.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/lowering/hir_to_mir/lower_diagnostic.hpp"
 #include "lyra/lowering/hir_to_mir/lower_finish.hpp"
@@ -21,7 +21,7 @@ auto LowerSystemSubroutineCall(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::CallExpr& call,
+    const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const hir::SystemSubroutineRef& ref, diag::SourceSpan span)
     -> diag::Result<mir::Expr> {
   const auto& desc = support::LookupSystemSubroutine(ref.id);

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -16,7 +16,7 @@
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/primary.hpp"
-#include "lyra/hir/process.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/expr.hpp"
@@ -75,8 +75,8 @@ auto BuildPrintValueItem(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, hir::ExprId hir_arg, mir::FormatSpec spec)
-    -> diag::Result<mir::RuntimePrintItem> {
+    const hir::ProceduralBody& hir_proc, hir::ExprId hir_arg,
+    mir::FormatSpec spec) -> diag::Result<mir::RuntimePrintItem> {
   auto lowered_or = LowerExpr(
       unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
       hir_proc.exprs.at(hir_arg.value));
@@ -91,7 +91,7 @@ auto BuildPrintItemFromDirective(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc,
+    const hir::ProceduralBody& hir_proc,
     const support::ParsedFormatDirective& directive,
     std::span<const hir::ExprId> args, std::size_t& value_index,
     diag::SourceSpan span) -> diag::Result<mir::RuntimePrintItem> {
@@ -145,7 +145,8 @@ struct LiteralFormatStringRef {
   diag::SourceSpan span;
 };
 
-auto TryGetHirStringLiteral(const hir::Process& proc, hir::ExprId expr_id)
+auto TryGetHirStringLiteral(
+    const hir::ProceduralBody& proc, hir::ExprId expr_id)
     -> std::optional<LiteralFormatStringRef> {
   const auto& expr = proc.exprs.at(expr_id.value);
   const auto* primary = std::get_if<hir::PrimaryExpr>(&expr.data);
@@ -162,7 +163,7 @@ auto BuildRuntimePrintItemsFromCallArgs(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_proc, const hir::CallExpr& call,
+    const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     diag::SourceSpan call_span)
     -> diag::Result<std::vector<mir::RuntimePrintItem>> {
   std::vector<mir::RuntimePrintItem> items;

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -620,8 +620,7 @@ class MirDumper {
     Line("StructuralSubroutines:");
     Indent();
     for (std::size_t i = 0; i < s.structural_subroutines.size(); ++i) {
-      const auto& d = s.structural_subroutines[i];
-      Line(std::format("[{}] \"{}\"", i, d.name));
+      DumpStructuralSubroutine(s.structural_subroutines[i], i);
     }
     Dedent();
 
@@ -645,6 +644,41 @@ class MirDumper {
     Line(std::format("Process[{}] {}", index, FormatProcessKind(p)));
     Indent();
     DumpProceduralScope(p.root_procedural_scope);
+    Dedent();
+  }
+
+  [[nodiscard]] static auto FormatParamDirection(ParamDirection dir)
+      -> std::string_view {
+    switch (dir) {
+      case ParamDirection::kInput:
+        return "input";
+      case ParamDirection::kOutput:
+        return "output";
+      case ParamDirection::kInOut:
+        return "inout";
+      case ParamDirection::kRef:
+        return "ref";
+      case ParamDirection::kConstRef:
+        return "const ref";
+    }
+    throw InternalError("FormatParamDirection: unknown mir::ParamDirection");
+  }
+
+  void DumpStructuralSubroutine(
+      const StructuralSubroutineDecl& d, std::size_t index) {
+    Line(
+        std::format(
+            "[{}] \"{}\" : Type[{}]", index, d.name, d.result_type.value));
+    Indent();
+    for (std::size_t i = 0; i < d.params.size(); ++i) {
+      const auto& param = d.params[i];
+      Line(
+          std::format(
+              "Param[{}] {} \"{}\" : Type[{}]", i,
+              FormatParamDirection(param.direction), param.name,
+              param.type.value));
+    }
+    DumpProceduralScope(d.root_procedural_scope);
     Dedent();
   }
 
@@ -790,6 +824,22 @@ class MirDumper {
             },
             [&](const ContinueStmt&) {
               Line(std::format("Stmt[{}] ContinueStmt", id.value));
+            },
+            [&](const ReturnStmt& s) {
+              if (s.value.has_value()) {
+                Line(
+                    std::format(
+                        "Stmt[{}] ReturnStmt value=Expr[{}]", id.value,
+                        s.value->value));
+                Indent();
+                Line(
+                    std::format(
+                        "Expr[{}] {}", s.value->value,
+                        FormatExpr(enclosing, *s.value)));
+                Dedent();
+              } else {
+                Line(std::format("Stmt[{}] ReturnStmt", id.value));
+              }
             },
             [&](const SensitivityWaitStmt& s) {
               Line(std::format("Stmt[{}] SensitivityWaitStmt", id.value));

--- a/tests/cases/cpp/function_call_in_expression/case.yaml
+++ b/tests/cases/cpp/function_call_in_expression/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.function_call_in_expression
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 25

--- a/tests/cases/cpp/function_call_in_expression/main.sv
+++ b/tests/cases/cpp/function_call_in_expression/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  int result;
+
+  function int square(int x);
+    return x * x;
+  endfunction
+
+  initial begin
+    result = square(3) + square(4);
+  end
+endmodule

--- a/tests/cases/cpp/function_early_return/case.yaml
+++ b/tests/cases/cpp/function_early_return/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.function_early_return
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: -99

--- a/tests/cases/cpp/function_early_return/main.sv
+++ b/tests/cases/cpp/function_early_return/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  int result;
+
+  function int check(int x);
+    if (x < 0)
+      return -1;
+    if (x == 0)
+      return 0;
+    return 1;
+  endfunction
+
+  initial begin
+    result = check(5) + check(0) * 10 + check(-3) * 100;
+  end
+endmodule

--- a/tests/cases/cpp/function_local_var/case.yaml
+++ b/tests/cases/cpp/function_local_var/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.function_local_var
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 42

--- a/tests/cases/cpp/function_local_var/main.sv
+++ b/tests/cases/cpp/function_local_var/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  int result;
+
+  function int compute(int x);
+    int temp;
+    temp = x + 10;
+    return temp * 2;
+  endfunction
+
+  initial begin
+    result = compute(11);
+  end
+endmodule

--- a/tests/cases/cpp/function_multi_param/case.yaml
+++ b/tests/cases/cpp/function_multi_param/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.function_multi_param
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 42

--- a/tests/cases/cpp/function_multi_param/main.sv
+++ b/tests/cases/cpp/function_multi_param/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  int result;
+
+  function int add(int a, int b);
+    return a + b;
+  endfunction
+
+  initial begin
+    result = add(17, 25);
+  end
+endmodule

--- a/tests/cases/cpp/function_nested_call/case.yaml
+++ b/tests/cases/cpp/function_nested_call/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.function_nested_call
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 20

--- a/tests/cases/cpp/function_nested_call/main.sv
+++ b/tests/cases/cpp/function_nested_call/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  int result;
+
+  function int inner(int x);
+    return x * 2;
+  endfunction
+
+  function int outer(int x);
+    return inner(x) + 10;
+  endfunction
+
+  initial begin
+    result = outer(5);
+  end
+endmodule

--- a/tests/cases/cpp/function_param/case.yaml
+++ b/tests/cases/cpp/function_param/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.function_param
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 42

--- a/tests/cases/cpp/function_param/main.sv
+++ b/tests/cases/cpp/function_param/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  int result;
+
+  function int double_it(int x);
+    return x * 2;
+  endfunction
+
+  initial begin
+    result = double_it(21);
+  end
+endmodule

--- a/tests/cases/cpp/function_simple_return/case.yaml
+++ b/tests/cases/cpp/function_simple_return/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.function_simple_return
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 42

--- a/tests/cases/cpp/function_simple_return/main.sv
+++ b/tests/cases/cpp/function_simple_return/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  int result;
+
+  function int get_value();
+    return 42;
+  endfunction
+
+  initial begin
+    result = get_value();
+  end
+endmodule

--- a/tests/cases/cpp/function_void/case.yaml
+++ b/tests/cases/cpp/function_void/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.function_void
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    counter: 3

--- a/tests/cases/cpp/function_void/main.sv
+++ b/tests/cases/cpp/function_void/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  int counter;
+
+  function void increment();
+    counter = counter + 1;
+  endfunction
+
+  initial begin
+    counter = 0;
+    increment();
+    increment();
+    increment();
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds the first cut of user-defined SystemVerilog functions (tracked as F1 in `docs/progress/functions.md`): value-returning and void functions with `input` by-value arguments, a `return` statement, function-local variables, and calls used both as expression operands and as statements. The work spans every layer from AST lowering to C++ emission and lands single-instance, scalar (integral / packed) functions end to end; output / inout / ref arguments, return-by-name, recursion, managed-type boundaries, and cross-instance access remain tracked as later items.

## Design

A subroutine body is the same shape as a process body, so the two now share a single HIR `ProceduralBody` (statement tree plus its expr / stmt / local arenas). In MIR a subroutine is a callable peer of a process whose body is a `ProceduralScope`; MIR carries only the semantic argument direction and leaves the C++ passing mode to the backend. The cpp backend emits each function as a by-value member function with a native `return`, so C++ value semantics and return-by-value cover argument copy-in and result conveyance with no return-slot or hand-rolled lifecycle. Peer and mutual references resolve by mapping every subroutine's identity before any body is lowered, then composing each lowered decl and adding it once.

## Testing

`bazel test //...` passes, including eight new `function_*` cases covering simple return, parameters, locals, void calls, nested calls, calls in expressions, and early return.