### PR TITLE
Add packed assignment patterns

### DIFF
--- a/docs/progress/packed.md
+++ b/docs/progress/packed.md
@@ -13,11 +13,7 @@ Done when:
 
 ## Actionable
 
-P5 builds assignment patterns on the field-access machinery P3 / P4 established.
-
-| Item | Status         |
-| ---- | -------------- |
-| P5   | Depends on P3. |
+All sub-steps are complete.
 
 ## Sub-Steps
 
@@ -35,10 +31,15 @@ The numeric IDs are stable references.
       single vector" projection. Tagged packed unions are deferred (need runtime tag-bit logic per
       LRM 11.9).
 
-- [ ] P5 -- Assignment patterns over packed aggregates (LRM 10.9): positional `'{a, b, c}`, default
-      `'{default: v}`, named `'{i: v, j: v}`, and replication `'{N{x}}`. Closes
-      `datatypes/packed/assignment_pattern_fill`, `assignment_pattern_multibit`,
-      `nested_aggregates`, and `operators/replication_patterns`.
+- [x] P5 -- Assignment patterns over packed aggregates (LRM 10.9). Positional `'{a, b, c}`, named /
+      type-key / index-key `'{x: v, default: w}`, `'{default: v}`, and replication `'{N{items}}`
+      over packed structs and packed arrays. The four non-replicated forms collapse into a per-field
+      expression list at the slang binding boundary; replication preserves the LRM shape and unrolls
+      into the same packed concat path used for `{a,b,c}`. The type-prefixed self-determined form
+      `T'{...}` is in. Closes `datatypes/packed/assignment_pattern_fill` and
+      `datatypes/packed/assignment_pattern_multibit`. Unpacked-array targets and LHS destructuring
+      (`'{a,b,c}=B`) are deferred (the unpacked surface lives behind the unpacked-array push; LHS
+      destructuring is a separate ergonomics follow-up).
 
 ## Cross-references
 

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -31,6 +31,7 @@ enum class DiagCode : std::uint32_t {
   kUnsupportedDelayExpressionForm,
   kUnsupportedEventTriggerForm,
   kUnsupportedContinuousAssignForm,
+  kUnsupportedAssignmentPatternKind,
 
   kDelayValueOutOfRange,
   kFormatStringTrailingPercent,

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -115,10 +115,31 @@ struct ReplicationExpr {
   ExprId concat;
 };
 
+// LRM 10.9 assignment pattern (positional / named / type-key / index-key /
+// default forms). Slang has normalised all four forms into a flat per-field
+// expression list in target declaration order (= packed MSB-first), with
+// each item already wrapped in a ConversionExpression to the field's
+// declared type.
+struct AssignmentPatternExpr {
+  std::vector<ExprId> elements;
+};
+
+// LRM 10.9 replicated assignment pattern `'{count{items...}}`. `count` is
+// slang-validated as a constant positive integer. `items` is the per-
+// iteration expression list -- slang stores only one iteration's items with
+// that iteration's per-field casts and requires the target's per-iter type
+// chunks to repeat, so the lowered MIR shape is `Replication(count,
+// Concat(items))`.
+struct AssignmentPatternReplicationExpr {
+  ExprId count;
+  std::vector<ExprId> items;
+};
+
 using ExprData = std::variant<
     PrimaryExpr, UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr, IncDecExpr,
     CallExpr, ConversionExpr, InsideExpr, ElementSelectExpr, RangeSelectExpr,
-    MemberAccessExpr, ConcatExpr, ReplicationExpr>;
+    MemberAccessExpr, ConcatExpr, ReplicationExpr, AssignmentPatternExpr,
+    AssignmentPatternReplicationExpr>;
 
 struct Expr {
   TypeId type;

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -41,12 +41,20 @@ auto RenderField(
   auto type_or = RenderTypeAsCpp(unit, ctor_ctx.StructuralScope(), var.type);
   if (!type_or) return std::unexpected(std::move(type_or.error()));
   const auto& ty = unit.GetType(var.type);
-  const auto storage_type = IsObservableScalarType(ty)
-                                ? "lyra::runtime::Var<" + *type_or + ">"
-                                : *type_or;
+  const auto is_observable = IsObservableScalarType(ty);
+  const auto storage_type =
+      is_observable ? "lyra::runtime::Var<" + *type_or + ">" : *type_or;
   auto args_or = RenderFieldCtorArgs(ctor_ctx, var, ty);
   if (!args_or) return std::unexpected(std::move(args_or.error()));
-  return Indent(indent) + storage_type + " " + var.name + "{" + *args_or +
+  // For `Var<T>` storage with no initializer the args are the inner T's
+  // ctor arguments; wrap in `T{...}` so a braced `std::initializer_list`
+  // argument is bound to `T`'s parameter directly instead of being passed
+  // through `Var`'s perfect-forwarding template (which cannot deduce
+  // `initializer_list` from a brace-enclosed list).
+  const std::string init_body = (is_observable && !var.initializer.has_value())
+                                    ? *type_or + "{" + *args_or + "}"
+                                    : *args_or;
+  return Indent(indent) + storage_type + " " + var.name + "{" + init_body +
          "};\n";
 }
 

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -132,6 +132,12 @@ constexpr std::array kEntries{
             .kind = DiagKind::kUnsupported,
             .category = UnsupportedCategory::kFeature,
             .name = "unsupported_continuous_assign_form"}},
+    std::pair{
+        DiagCode::kUnsupportedAssignmentPatternKind,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kOperation,
+            .name = "unsupported_assignment_pattern_kind"}},
 
     std::pair{
         DiagCode::kDelayValueOutOfRange,

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -746,6 +746,29 @@ class HirDumper {
                   "ReplicationExpr count=Expr[{}] concat=Expr[{}]",
                   r.count.value, r.concat.value);
             },
+            [](const AssignmentPatternExpr& a) -> std::string {
+              std::string elements;
+              for (std::size_t i = 0; i < a.elements.size(); ++i) {
+                if (i != 0) {
+                  elements += ", ";
+                }
+                elements += std::format("Expr[{}]", a.elements[i].value);
+              }
+              return std::format(
+                  "AssignmentPatternExpr elements=[{}]", elements);
+            },
+            [](const AssignmentPatternReplicationExpr& a) -> std::string {
+              std::string items;
+              for (std::size_t i = 0; i < a.items.size(); ++i) {
+                if (i != 0) {
+                  items += ", ";
+                }
+                items += std::format("Expr[{}]", a.items[i].value);
+              }
+              return std::format(
+                  "AssignmentPatternReplicationExpr count=Expr[{}] items=[{}]",
+                  a.count.value, items);
+            },
         },
         e.data);
     return std::format("type=Type[{}] {}", e.type.value, formatted);

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -920,6 +920,77 @@ auto LowerReplicationExprProc(
   };
 }
 
+auto IsAssignmentPatternPackedTarget(const hir::Type& target) -> bool {
+  return target.IsPackedArray() || target.IsPackedStruct() ||
+         target.IsPackedUnion();
+}
+
+auto LowerAssignmentPatternFromElementsProc(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const slang::ast::AssignmentPatternExpressionBase& ap,
+    const slang::ast::Expression& expr, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  if (!IsAssignmentPatternPackedTarget(unit_state.GetType(*type_id))) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedAssignmentPatternKind,
+        "assignment patterns over unpacked aggregates are not yet supported",
+        diag::UnsupportedCategory::kOperation);
+  }
+  std::vector<hir::ExprId> element_ids;
+  element_ids.reserve(ap.elements().size());
+  for (const auto* elem : ap.elements()) {
+    auto lowered =
+        LowerProcExpr(unit_facts, unit_state, proc_state, stack, *elem);
+    if (!lowered) return std::unexpected(std::move(lowered.error()));
+    element_ids.push_back(proc_state.AddExpr(*std::move(lowered)));
+  }
+  return hir::Expr{
+      .type = *type_id,
+      .data = hir::AssignmentPatternExpr{.elements = std::move(element_ids)},
+      .span = span,
+  };
+}
+
+auto LowerReplicatedAssignmentPatternExprProc(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ProcessLoweringState& proc_state, const ScopeStack& stack,
+    const slang::ast::ReplicatedAssignmentPatternExpression& rp,
+    const slang::ast::Expression& expr, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  if (!IsAssignmentPatternPackedTarget(unit_state.GetType(*type_id))) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedAssignmentPatternKind,
+        "assignment patterns over unpacked aggregates are not yet supported",
+        diag::UnsupportedCategory::kOperation);
+  }
+  auto count_or =
+      LowerProcExpr(unit_facts, unit_state, proc_state, stack, rp.count());
+  if (!count_or) return std::unexpected(std::move(count_or.error()));
+  const hir::ExprId count_id = proc_state.AddExpr(*std::move(count_or));
+  std::vector<hir::ExprId> item_ids;
+  item_ids.reserve(rp.elements().size());
+  for (const auto* elem : rp.elements()) {
+    auto lowered =
+        LowerProcExpr(unit_facts, unit_state, proc_state, stack, *elem);
+    if (!lowered) return std::unexpected(std::move(lowered.error()));
+    item_ids.push_back(proc_state.AddExpr(*std::move(lowered)));
+  }
+  return hir::Expr{
+      .type = *type_id,
+      .data =
+          hir::AssignmentPatternReplicationExpr{
+              .count = count_id,
+              .items = std::move(item_ids),
+          },
+      .span = span,
+  };
+}
+
 auto LowerElementSelectExprStructural(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ScopeLoweringState& scope_state, const ScopeStack& stack,
@@ -1059,6 +1130,35 @@ auto LowerConcatExprStructural(
   return hir::Expr{
       .type = *type_id,
       .data = hir::ConcatExpr{.operands = std::move(operand_ids)},
+      .span = span,
+  };
+}
+
+auto LowerAssignmentPatternFromElementsStructural(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ScopeLoweringState& scope_state, const ScopeStack& stack,
+    const slang::ast::AssignmentPatternExpressionBase& ap,
+    const slang::ast::Expression& expr, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  if (!IsAssignmentPatternPackedTarget(unit_state.GetType(*type_id))) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedAssignmentPatternKind,
+        "assignment patterns over unpacked aggregates are not yet supported",
+        diag::UnsupportedCategory::kOperation);
+  }
+  std::vector<hir::ExprId> element_ids;
+  element_ids.reserve(ap.elements().size());
+  for (const auto* elem : ap.elements()) {
+    auto lowered =
+        LowerStructuralExpr(unit_facts, unit_state, scope_state, stack, *elem);
+    if (!lowered) return std::unexpected(std::move(lowered.error()));
+    element_ids.push_back(scope_state.AddExpr(*std::move(lowered)));
+  }
+  return hir::Expr{
+      .type = *type_id,
+      .data = hir::AssignmentPatternExpr{.elements = std::move(element_ids)},
       .span = span,
   };
 }
@@ -1331,6 +1431,31 @@ auto LowerProcExpr(
           unit_facts, unit_state, proc_state, stack,
           expr.as<slang::ast::ReplicationExpression>(), expr, span);
 
+    case slang::ast::ExpressionKind::SimpleAssignmentPattern: {
+      const auto& sap =
+          expr.as<slang::ast::SimpleAssignmentPatternExpression>();
+      if (sap.isLValue) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedAssignmentPatternKind,
+            "assignment pattern as LHS destructuring is not yet supported",
+            diag::UnsupportedCategory::kOperation);
+      }
+      return LowerAssignmentPatternFromElementsProc(
+          unit_facts, unit_state, proc_state, stack, sap, expr, span);
+    }
+
+    case slang::ast::ExpressionKind::StructuredAssignmentPattern:
+      return LowerAssignmentPatternFromElementsProc(
+          unit_facts, unit_state, proc_state, stack,
+          expr.as<slang::ast::StructuredAssignmentPatternExpression>(), expr,
+          span);
+
+    case slang::ast::ExpressionKind::ReplicatedAssignmentPattern:
+      return LowerReplicatedAssignmentPatternExprProc(
+          unit_facts, unit_state, proc_state, stack,
+          expr.as<slang::ast::ReplicatedAssignmentPatternExpression>(), expr,
+          span);
+
     default:
       return diag::Unsupported(
           span, diag::DiagCode::kUnsupportedExpressionForm,
@@ -1433,6 +1558,25 @@ auto LowerStructuralExpr(
       return LowerConcatExprStructural(
           unit_facts, unit_state, scope_state, stack,
           expr.as<slang::ast::ConcatenationExpression>(), expr, span);
+
+    case slang::ast::ExpressionKind::SimpleAssignmentPattern: {
+      const auto& sap =
+          expr.as<slang::ast::SimpleAssignmentPatternExpression>();
+      if (sap.isLValue) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedAssignmentPatternKind,
+            "assignment pattern as LHS destructuring is not yet supported",
+            diag::UnsupportedCategory::kOperation);
+      }
+      return LowerAssignmentPatternFromElementsStructural(
+          unit_facts, unit_state, scope_state, stack, sap, expr, span);
+    }
+
+    case slang::ast::ExpressionKind::StructuredAssignmentPattern:
+      return LowerAssignmentPatternFromElementsStructural(
+          unit_facts, unit_state, scope_state, stack,
+          expr.as<slang::ast::StructuredAssignmentPatternExpression>(), expr,
+          span);
 
     default:
       return diag::Unsupported(

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -1053,6 +1053,62 @@ auto LowerHirReplicationExprProc(
       .type = result_type};
 }
 
+auto LowerHirAssignmentPatternExprProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process, const hir::AssignmentPatternExpr& a,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  std::vector<mir::ExprId> operand_ids;
+  operand_ids.reserve(a.elements.size());
+  for (const auto& id : a.elements) {
+    auto lowered = LowerExpr(
+        unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+        hir_process.exprs.at(id.value));
+    if (!lowered) return std::unexpected(std::move(lowered.error()));
+    operand_ids.push_back(proc_scope_state.AddExpr(*std::move(lowered)));
+  }
+  return mir::Expr{
+      .data = mir::ConcatExpr{.operands = std::move(operand_ids)},
+      .type = result_type};
+}
+
+auto LowerHirAssignmentPatternReplicationExprProc(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::Process& hir_process,
+    const hir::AssignmentPatternReplicationExpr& a, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
+  std::vector<mir::ExprId> item_ids;
+  item_ids.reserve(a.items.size());
+  for (const auto& id : a.items) {
+    auto lowered = LowerExpr(
+        unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+        hir_process.exprs.at(id.value));
+    if (!lowered) return std::unexpected(std::move(lowered.error()));
+    item_ids.push_back(proc_scope_state.AddExpr(*std::move(lowered)));
+  }
+  const mir::ExprId inner_concat_id = proc_scope_state.AddExpr(
+      mir::Expr{
+          .data = mir::ConcatExpr{.operands = std::move(item_ids)},
+          .type = result_type});
+  auto count_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_process,
+      hir_process.exprs.at(a.count.value));
+  if (!count_or) return std::unexpected(std::move(count_or.error()));
+  const mir::ExprId count_id = proc_scope_state.AddExpr(*std::move(count_or));
+  return mir::Expr{
+      .data =
+          mir::ReplicationExpr{
+              .count = count_id,
+              .concat = inner_concat_id,
+          },
+      .type = result_type};
+}
+
 }  // namespace
 
 auto LowerExpr(
@@ -1133,6 +1189,17 @@ auto LowerExpr(
             return LowerHirReplicationExprProc(
                 unit_state, scope_state, proc_state, proc_scope_state,
                 hir_process, r, result_type);
+          },
+          [&](const hir::AssignmentPatternExpr& a) -> diag::Result<mir::Expr> {
+            return LowerHirAssignmentPatternExprProc(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, a, result_type);
+          },
+          [&](const hir::AssignmentPatternReplicationExpr& a)
+              -> diag::Result<mir::Expr> {
+            return LowerHirAssignmentPatternReplicationExprProc(
+                unit_state, scope_state, proc_state, proc_scope_state,
+                hir_process, a, result_type);
           },
       },
       expr.data);
@@ -1368,6 +1435,28 @@ auto LowerHirConcatExprStructural(
       .type = result_type};
 }
 
+auto LowerHirAssignmentPatternExprStructural(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ConstructorLoweringState* ctor_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::StructuralScope& scope, const hir::AssignmentPatternExpr& a,
+    LoopVarLoweringMode loop_var_mode, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
+  std::vector<mir::ExprId> operand_ids;
+  operand_ids.reserve(a.elements.size());
+  for (const auto& id : a.elements) {
+    auto lowered = LowerExprImpl(
+        unit_state, scope_state, ctor_state, proc_scope_state, scope,
+        scope.GetExpr(id), loop_var_mode);
+    if (!lowered) return std::unexpected(std::move(lowered.error()));
+    operand_ids.push_back(proc_scope_state.AddExpr(*std::move(lowered)));
+  }
+  return mir::Expr{
+      .data = mir::ConcatExpr{.operands = std::move(operand_ids)},
+      .type = result_type};
+}
+
 auto LowerHirConversionExprStructural(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
@@ -1474,6 +1563,19 @@ auto LowerExprImpl(
             return diag::Unsupported(
                 diag::DiagCode::kUnsupportedStructuralExpressionForm,
                 "replication in constructor expressions is not yet supported",
+                diag::UnsupportedCategory::kFeature);
+          },
+          [&](const hir::AssignmentPatternExpr& a) -> diag::Result<mir::Expr> {
+            return LowerHirAssignmentPatternExprStructural(
+                unit_state, scope_state, ctor_state, proc_scope_state, scope, a,
+                loop_var_mode, result_type);
+          },
+          [](const hir::AssignmentPatternReplicationExpr&)
+              -> diag::Result<mir::Expr> {
+            return diag::Unsupported(
+                diag::DiagCode::kUnsupportedStructuralExpressionForm,
+                "replicated assignment patterns in constructor expressions "
+                "are not yet supported",
                 diag::UnsupportedCategory::kFeature);
           },
       },

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -1058,9 +1058,8 @@ auto LowerHirAssignmentPatternExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::ProceduralBody& hir_process,
-    const hir::AssignmentPatternExpr& a, mir::TypeId result_type)
-    -> diag::Result<mir::Expr> {
+    const hir::ProceduralBody& hir_process, const hir::AssignmentPatternExpr& a,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
   std::vector<mir::ExprId> operand_ids;
   operand_ids.reserve(a.elements.size());
   for (const auto& id : a.elements) {

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -1058,8 +1058,9 @@ auto LowerHirAssignmentPatternExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process, const hir::AssignmentPatternExpr& a,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+    const hir::ProceduralBody& hir_process,
+    const hir::AssignmentPatternExpr& a, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
   std::vector<mir::ExprId> operand_ids;
   operand_ids.reserve(a.elements.size());
   for (const auto& id : a.elements) {
@@ -1079,7 +1080,7 @@ auto LowerHirAssignmentPatternReplicationExprProc(
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
-    const hir::Process& hir_process,
+    const hir::ProceduralBody& hir_process,
     const hir::AssignmentPatternReplicationExpr& a, mir::TypeId result_type)
     -> diag::Result<mir::Expr> {
   std::vector<mir::ExprId> item_ids;

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -410,6 +410,14 @@ auto PackedArray::Concat(std::span<const PackedArray* const> operands)
     auto& lv = std::get<LogicValue>(result.storage_);
     dst_unknown = detail::PackedAccess::UnknownWords(lv.View());
   }
+  // `PackedArray` 4-state default is all-X (value=1, unknown=1) so a freshly
+  // constructed result for `any_four_state` has stale 1s in both planes. The
+  // bit-blit loop uses |= and would not clear them, so zero both spans before
+  // depositing operand bits.
+  std::ranges::fill(dst_value, std::uint64_t{0});
+  if (any_four_state) {
+    std::ranges::fill(dst_unknown, std::uint64_t{0});
+  }
   std::uint64_t cursor = 0;
   for (const auto* op : operands | std::views::reverse) {
     BlitBits(dst_value, cursor, op->ValueWords(), op->BitWidth());
@@ -437,6 +445,12 @@ auto PackedArray::Replicate(const PackedArray& operand, std::uint64_t count)
   if (operand.IsFourState()) {
     auto& lv = std::get<LogicValue>(result.storage_);
     dst_unknown = detail::PackedAccess::UnknownWords(lv.View());
+  }
+  // Same stale-X concern as `Concat`: zero both planes before BlitBits ORs in
+  // the operand bits.
+  std::ranges::fill(dst_value, std::uint64_t{0});
+  if (operand.IsFourState()) {
+    std::ranges::fill(dst_unknown, std::uint64_t{0});
   }
   for (std::uint64_t i = 0; i < count; ++i) {
     const std::uint64_t cursor = i * operand.BitWidth();

--- a/tests/cases/cpp/assignment_pattern_default_packed_array_sized/case.yaml
+++ b/tests/cases/cpp/assignment_pattern_default_packed_array_sized/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.assignment_pattern_default_packed_array_sized
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    elem0: 0xaa
+    elem3: 0xaa

--- a/tests/cases/cpp/assignment_pattern_default_packed_array_sized/main.sv
+++ b/tests/cases/cpp/assignment_pattern_default_packed_array_sized/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  logic [3:0][7:0] arr;
+  int elem0;
+  int elem3;
+  initial begin
+    arr = '{default: 8'hAA};
+    elem0 = arr[0];
+    elem3 = arr[3];
+  end
+endmodule

--- a/tests/cases/cpp/assignment_pattern_default_packed_array_unsized/case.yaml
+++ b/tests/cases/cpp/assignment_pattern_default_packed_array_unsized/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.assignment_pattern_default_packed_array_unsized
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a_all: 0x11
+    b_all: 0xff

--- a/tests/cases/cpp/assignment_pattern_default_packed_array_unsized/main.sv
+++ b/tests/cases/cpp/assignment_pattern_default_packed_array_unsized/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  // Distinguishes 'b1 (numeric 1, cast per element) from '1 (unbased one,
+  // fills the element type) -- LRM 10.9 / 5.7.1.
+  logic [1:0][3:0] a;
+  logic [1:0][3:0] b;
+  int a_all;
+  int b_all;
+  initial begin
+    a = '{default: 'b1};   // each 4-bit element = 4'b0001 -> packed 0x11
+    b = '{default: '1};    // each 4-bit element = 4'b1111 -> packed 0xff
+    a_all = a;
+    b_all = b;
+  end
+endmodule

--- a/tests/cases/cpp/assignment_pattern_default_vector_one/case.yaml
+++ b/tests/cases/cpp/assignment_pattern_default_vector_one/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.assignment_pattern_default_vector_one
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    val: 0xf

--- a/tests/cases/cpp/assignment_pattern_default_vector_one/main.sv
+++ b/tests/cases/cpp/assignment_pattern_default_vector_one/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  logic [3:0] x;
+  int val;
+  initial begin
+    x = '{default: '1};
+    val = x;
+  end
+endmodule

--- a/tests/cases/cpp/assignment_pattern_default_vector_zero/case.yaml
+++ b/tests/cases/cpp/assignment_pattern_default_vector_zero/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.assignment_pattern_default_vector_zero
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    val: 0x00

--- a/tests/cases/cpp/assignment_pattern_default_vector_zero/main.sv
+++ b/tests/cases/cpp/assignment_pattern_default_vector_zero/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  logic [7:0] x;
+  int val;
+  initial begin
+    x = '{default: '0};
+    val = x;
+  end
+endmodule

--- a/tests/cases/cpp/assignment_pattern_named_struct/case.yaml
+++ b/tests/cases/cpp/assignment_pattern_named_struct/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.assignment_pattern_named_struct
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    fx: 0x3
+    fy: 0xc

--- a/tests/cases/cpp/assignment_pattern_named_struct/main.sv
+++ b/tests/cases/cpp/assignment_pattern_named_struct/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  typedef struct packed {
+    logic [3:0] x;
+    logic [3:0] y;
+  } pair_t;
+  pair_t s;
+  int fx;
+  int fy;
+  initial begin
+    s = '{x: 4'h3, y: 4'hC};
+    fx = s.x;
+    fy = s.y;
+  end
+endmodule

--- a/tests/cases/cpp/assignment_pattern_named_with_default/case.yaml
+++ b/tests/cases/cpp/assignment_pattern_named_with_default/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.assignment_pattern_named_with_default
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    fx: 0x1
+    fy: 0x0
+    fz: 0x0

--- a/tests/cases/cpp/assignment_pattern_named_with_default/main.sv
+++ b/tests/cases/cpp/assignment_pattern_named_with_default/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  typedef struct packed {
+    logic [3:0] x;
+    logic [3:0] y;
+    logic [3:0] z;
+  } trio_t;
+  trio_t s;
+  int fx;
+  int fy;
+  int fz;
+  initial begin
+    s = '{x: 4'h1, default: 4'h0};
+    fx = s.x;
+    fy = s.y;
+    fz = s.z;
+  end
+endmodule

--- a/tests/cases/cpp/assignment_pattern_nested_default/case.yaml
+++ b/tests/cases/cpp/assignment_pattern_nested_default/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.assignment_pattern_nested_default
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a_x: 0x5
+    a_y: 0x5
+    b: 0x5

--- a/tests/cases/cpp/assignment_pattern_nested_default/main.sv
+++ b/tests/cases/cpp/assignment_pattern_nested_default/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  typedef struct packed {
+    logic [3:0] x;
+    logic [3:0] y;
+  } pair_t;
+  typedef struct packed {
+    pair_t a;
+    logic [3:0] b;
+  } outer_t;
+  outer_t s;
+  int a_x;
+  int a_y;
+  int b;
+  initial begin
+    s = '{default: 4'h5};
+    a_x = s.a.x;
+    a_y = s.a.y;
+    b = s.b;
+  end
+endmodule

--- a/tests/cases/cpp/assignment_pattern_positional_struct/case.yaml
+++ b/tests/cases/cpp/assignment_pattern_positional_struct/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.assignment_pattern_positional_struct
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    f0: 0xa
+    f1: 0x5
+    f2: 0x3

--- a/tests/cases/cpp/assignment_pattern_positional_struct/main.sv
+++ b/tests/cases/cpp/assignment_pattern_positional_struct/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  typedef struct packed {
+    logic [3:0] a;
+    logic [3:0] b;
+    logic [3:0] c;
+  } trio_t;
+  trio_t s;
+  int f0;
+  int f1;
+  int f2;
+  initial begin
+    s = '{4'hA, 4'h5, 4'h3};
+    f0 = s.a;
+    f1 = s.b;
+    f2 = s.c;
+  end
+endmodule

--- a/tests/cases/cpp/assignment_pattern_replication_multi_item/case.yaml
+++ b/tests/cases/cpp/assignment_pattern_replication_multi_item/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.assignment_pattern_replication_multi_item
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    field0: 0x1
+    field1: 0x2
+    field2: 0x1
+    field3: 0x2

--- a/tests/cases/cpp/assignment_pattern_replication_multi_item/main.sv
+++ b/tests/cases/cpp/assignment_pattern_replication_multi_item/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  typedef struct packed {
+    logic [3:0] a;
+    logic [3:0] b;
+    logic [3:0] c;
+    logic [3:0] d;
+  } nibbles_t;
+  nibbles_t s;
+  int field0;
+  int field1;
+  int field2;
+  int field3;
+  initial begin
+    s = '{2{4'h1, 4'h2}};
+    field0 = s.a;
+    field1 = s.b;
+    field2 = s.c;
+    field3 = s.d;
+  end
+endmodule

--- a/tests/cases/cpp/assignment_pattern_replication_single_item/case.yaml
+++ b/tests/cases/cpp/assignment_pattern_replication_single_item/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.assignment_pattern_replication_single_item
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    elem0: 0xab
+    elem3: 0xab

--- a/tests/cases/cpp/assignment_pattern_replication_single_item/main.sv
+++ b/tests/cases/cpp/assignment_pattern_replication_single_item/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  logic [3:0][7:0] arr;
+  int elem0;
+  int elem3;
+  initial begin
+    arr = '{4{8'hAB}};
+    elem0 = arr[0];
+    elem3 = arr[3];
+  end
+endmodule

--- a/tests/cases/cpp/assignment_pattern_signed_field/case.yaml
+++ b/tests/cases/cpp/assignment_pattern_signed_field/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.assignment_pattern_signed_field
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    raw_us: 0xff
+    via_signed: -1

--- a/tests/cases/cpp/assignment_pattern_signed_field/main.sv
+++ b/tests/cases/cpp/assignment_pattern_signed_field/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  typedef struct packed {
+    logic signed [7:0] s_field;
+  } wrapper_t;
+  wrapper_t w;
+  int raw_us;
+  int via_signed;
+  initial begin
+    // Pattern element is bound under the field's signed context; the
+    // emitted concat must preserve signedness on the field read so the
+    // sign-extending int conversion sees -1, not 0xFF.
+    w = '{s_field: 8'hFF};
+    raw_us = w;
+    via_signed = w.s_field;
+  end
+endmodule

--- a/tests/cases/cpp/assignment_pattern_type_prefix_rhs/case.yaml
+++ b/tests/cases/cpp/assignment_pattern_type_prefix_rhs/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.assignment_pattern_type_prefix_rhs
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    fx: 0x7
+    fy: 0xe

--- a/tests/cases/cpp/assignment_pattern_type_prefix_rhs/main.sv
+++ b/tests/cases/cpp/assignment_pattern_type_prefix_rhs/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  typedef struct packed {
+    logic [3:0] x;
+    logic [3:0] y;
+  } pair_t;
+  pair_t s;
+  int fx;
+  int fy;
+  initial begin
+    // LRM 10.9: type-prefixed assignment pattern is self-determined,
+    // usable as a general RHS expression.
+    s = pair_t'{4'h7, 4'hE};
+    fx = s.x;
+    fy = s.y;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements LRM 10.9 assignment patterns over packed structs, packed unions, and packed arrays as the final item in `docs/progress/packed.md` (P5). Positional `'{a, b, c}`, named / type-key / index-key `'{x: v, default: w}`, default `'{default: v}`, and replicated `'{N{items}}` forms now lower; the type-prefixed self-determined form `T'{...}` rides along. Unpacked-array targets and LHS destructuring (`'{a,b,c}=B`) are gated behind a new `kUnsupportedAssignmentPatternKind` diagnostic and deferred.

## Design

HIR carries two new variants. `AssignmentPatternExpr` is a flat per-field expression list — slang has already normalised the four non-replicated forms into `elements()` in target declaration order with per-field `ConversionExpression` wrappers, so positional / named / type-key / index-key / default all collapse onto the same node. `AssignmentPatternReplicationExpr` keeps the LRM `'{N{items}}` shape (count + per-iter items) since slang only stores one iteration's items and the consumer is responsible for replicating; this preserves the SV-level concept without bloating HIR with N copies of the expression.

HIR -> MIR lowers `AssignmentPatternExpr` to `mir::ConcatExpr` and lowers `AssignmentPatternReplicationExpr` to `mir::ReplicationExpr` wrapping an inner `ConcatExpr` over the items. Slang's binding contract for struct replication requires the per-iter type chunks to repeat exactly, so the N copies are bit-identical and the existing `PackedArray::Replicate` runtime path drives codegen unchanged. MIR gains no new nodes; the cpp backend's `RenderConcatExpr` / `RenderReplicationExpr` already produce `PackedArray::Concat(...)` / `PackedArray::Replicate(...)` calls.

## Runtime fix

Surfaced a latent bug in `PackedArray::Concat` / `Replicate`: a freshly constructed 4-state result is all-X (value plane = 1, unknown plane = 1) and the bit-blit loop uses `|=`, so the stale 1-bits in the unknown plane were never cleared. Existing tests didn't hit it because no prior path produced 4-state concat operands. Fixed by zeroing both planes before the blit loop in both functions.

## Backend fix

Multi-dim `Var<PackedArray>` field initialization emitted `Var<PackedArray> arr{{{3,0},{7,0}}, false, true}`, which fails to compile: `Var`'s perfect-forwarding template constructor cannot deduce a braced list as `std::initializer_list<PackedRange>`. Fixed by wrapping default-ctor args in `T{...}` so the brace-init binds directly to the inner type's parameter. No existing test hit this either because no test used a multi-dim packed-array module-scope variable.

## Testing

12 new `cpp_run` cases under `tests/cases/cpp/assignment_pattern_*` cover all forms: positional struct, named struct, named+default, default-vector (`'0` / `'1`), default-packed-array (sized / unsized literal distinction), replication (single-item / multi-item), nested-default recursion, type-prefix RHS, and signed-field sign extension. `bazel test //... --test_output=errors` is green.