### PR TITLE
Add reference-resolution contract and multi-module hierarchy plan

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -22,32 +22,35 @@ Read top to bottom on first pass:
 8. `lir.md` -- execution-oriented IR (CFG, basic blocks, storage)
 9. `scheduling.md` -- stratified event scheduler, regions, suspension protocol
 10. `hierarchy_and_generate.md` -- hierarchy and generate ownership
-11. `identity_and_ownership.md` -- identity rules and forbidden shapes
-12. `lowering_boundaries.md` -- what each lowering may and may not do
-13. `incremental_build.md` -- query-based incremental compilation and caching
-14. `testing_strategy.md` -- test categories and structure
+11. `reference_resolution.md` -- intra-unit vs cross-unit references; compile-time vs
+    construction-time resolution
+12. `identity_and_ownership.md` -- identity rules and forbidden shapes
+13. `lowering_boundaries.md` -- what each lowering may and may not do
+14. `incremental_build.md` -- query-based incremental compilation and caching
+15. `testing_strategy.md` -- test categories and structure
 
 ## Concept Index
 
 If you are looking for a concept, this table points to the canonical doc.
 
-| Concept                                                                  | Canonical doc               |
-| ------------------------------------------------------------------------ | --------------------------- |
-| Primary optimization target; non-negotiable design constraints           | `north_star.md`             |
-| Pipeline (HIR -> MIR -> LIR -> LLVM IR); compile-time vs runtime split   | `compiler_overview.md`      |
-| Compilation unit; class-level artifacts; instance records                | `compilation_unit_model.md` |
-| Constructor vs simulation execution contexts; structural vs process      | `runtime_model.md`          |
-| Generate as constructor-time logic; object graph shape                   | `hierarchy_and_generate.md` |
-| Parameter values, specialization keys, per-specialization artifacts      | `specialization_model.md`   |
-| Identity rules; ownership; forbidden identity shapes                     | `identity_and_ownership.md` |
-| Lowering permissions (what each lowering may and may not do)             | `lowering_boundaries.md`    |
-| HIR shape (statements, expressions, primaries)                           | `hir.md`                    |
-| MIR shape (objects, members, callables, closures)                        | `mir.md`                    |
-| LIR shape (CFG, basic blocks, storage)                                   | `lir.md`                    |
-| Stratified scheduler; regions; suspension protocol; NBA / closure submit | `scheduling.md`             |
-| Incremental compilation; query-based caching                             | `incremental_build.md`      |
-| Locating/bundling the C++ runtime; run output contract                   | `runtime_distribution.md`   |
-| Test categories; suite layout; expectation forms                         | `testing_strategy.md`       |
+| Concept                                                                   | Canonical doc               |
+| ------------------------------------------------------------------------- | --------------------------- |
+| Primary optimization target; non-negotiable design constraints            | `north_star.md`             |
+| Pipeline (HIR -> MIR -> LIR -> LLVM IR); compile-time vs runtime split    | `compiler_overview.md`      |
+| Compilation unit; class-level artifacts; instance records                 | `compilation_unit_model.md` |
+| Constructor vs simulation execution contexts; structural vs process       | `runtime_model.md`          |
+| Generate as constructor-time logic; object graph shape                    | `hierarchy_and_generate.md` |
+| Intra-unit vs cross-unit references; compile-time vs construction resolve | `reference_resolution.md`   |
+| Parameter values, specialization keys, per-specialization artifacts       | `specialization_model.md`   |
+| Identity rules; ownership; forbidden identity shapes                      | `identity_and_ownership.md` |
+| Lowering permissions (what each lowering may and may not do)              | `lowering_boundaries.md`    |
+| HIR shape (statements, expressions, primaries)                            | `hir.md`                    |
+| MIR shape (objects, members, callables, closures)                         | `mir.md`                    |
+| LIR shape (CFG, basic blocks, storage)                                    | `lir.md`                    |
+| Stratified scheduler; regions; suspension protocol; NBA / closure submit  | `scheduling.md`             |
+| Incremental compilation; query-based caching                              | `incremental_build.md`      |
+| Locating/bundling the C++ runtime; run output contract                    | `runtime_distribution.md`   |
+| Test categories; suite layout; expectation forms                          | `testing_strategy.md`       |
 
 ## Document Shape
 

--- a/docs/architecture/compilation_unit_model.md
+++ b/docs/architecture/compilation_unit_model.md
@@ -44,6 +44,8 @@ Define what a compilation unit is, what it owns, and the rules that make it self
   elaboration hints; it does not define what a compilation unit is or which compilation units exist.
 - The runtime constructor consumes compile-time artifacts and per-instance records to build the
   object graph.
+- `reference_resolution.md` defines how the cross-unit access named here is resolved: at
+  construction, once, into a stored direct reference.
 
 ## Forbidden Shapes
 

--- a/docs/architecture/hierarchy_and_generate.md
+++ b/docs/architecture/hierarchy_and_generate.md
@@ -36,6 +36,10 @@ shared by all consumers: external references, child routing, and construction.
 6. Parameters affect constructor-time construction, not compile-time identity. A parameter value
    changes which children are constructed, how many, and with which sub-parameter bindings, but it
    does not fork the unit's compile-time artifacts or its identity.
+7. The constructed object tree is faithful to the frontend's elaboration. Every elaborated instance
+   and named scope has a corresponding constructed object, and generate-produced objects preserve
+   the elaborated index and identity. Reference resolution relies on this faithfulness (see
+   `reference_resolution.md`).
 
 ## Boundary to Adjacent Layers
 
@@ -44,6 +48,9 @@ shared by all consumers: external references, child routing, and construction.
 - The runtime constructor executes this logic to produce the live object graph.
 - `runtime_model.md` defines the constructor / simulation execution-context split that this doc
   builds on. Generate logic is constructor-context; processes are simulation-context.
+- `reference_resolution.md` owns how a reference reaches state across the object tree and when it
+  resolves. This doc owns the tree's shape and construction and its faithfulness to the frontend's
+  elaboration; that doc relies on this faithfulness to make cross-unit resolution total.
 
 ## Forbidden Shapes
 

--- a/docs/architecture/identity_and_ownership.md
+++ b/docs/architecture/identity_and_ownership.md
@@ -17,6 +17,7 @@ references another; ownership is which entity holds a given piece of state.
 
 - The specific id kinds per IR layer (see `hir.md`, `mir.md`).
 - The hierarchy and generate ownership model (see `hierarchy_and_generate.md`).
+- How a cross-unit reference is resolved to a concrete target (see `reference_resolution.md`).
 
 ## Core Invariants
 

--- a/docs/architecture/reference_resolution.md
+++ b/docs/architecture/reference_resolution.md
@@ -1,0 +1,124 @@
+# Reference Resolution
+
+## Purpose
+
+Define how a reference reaches its target, and when. Every reference resolves to a concrete target;
+the compilation-unit boundary decides the timing. A reference whose target is in the same unit
+resolves at compile time. A reference whose target is in another unit resolves once at construction.
+The same resolution serves both accessing the target's value and observing its changes.
+
+## Owns
+
+- The classification of a reference as intra-unit or cross-unit by where its target lives relative
+  to the referrer's compilation unit.
+- The rule that an intra-unit reference resolves at compile time and a cross-unit reference resolves
+  once at construction into a stored direct reference.
+- The contract that cross-unit resolution is total: a resolution that fails is a compiler-invariant
+  violation, not a user error.
+- The contract that port connections, hierarchical references, and cross-instance triggers all reach
+  across the unit boundary through a cross-unit reference on one shared resolution path.
+- The contract that a cross-unit reference's resolution serves both accessing the target and
+  observing its changes, through one resolved reference.
+- The rule that connectivity is linkage between objects and never alters what an object owns.
+
+## Does Not Own
+
+- The shape of the object graph, the construction order, and the graph's faithfulness to the
+  frontend's elaboration (see `hierarchy_and_generate.md`). This doc relies on that faithfulness but
+  does not establish it.
+- The compilation-unit boundary that defines what counts as intra-unit (see
+  `compilation_unit_model.md`).
+- The compile-time id kinds for intra-unit versus cross-unit references (see
+  `identity_and_ownership.md`, `hir.md`, `mir.md`).
+- How an observed cross-unit change wakes a dependent process (see `scheduling.md`).
+- Storage placement and offsets of members (see `lir.md`).
+- Net resolution and net merging across ports (a single simulated net shared by both sides). That is
+  a design-global net-resolution concern, separate from per-object reference resolution.
+
+## Core Invariants
+
+1. Every reference resolves to a concrete target and is classified as intra-unit or cross-unit by
+   where that target lives relative to the referrer's compilation unit.
+2. An intra-unit reference resolves at compile time. The unit knows the layout of every object it
+   constructs, so the target is a constructed-object reference the unit owns plus a compile-time
+   offset. A reference into a generate scope is intra-unit even though the scope is a distinct
+   runtime object: the generate scope belongs to the same unit, so its layout is known at compile
+   time.
+3. A cross-unit reference cannot be resolved at compile time, because the target lives inside
+   another independently compiled unit whose layout is not visible during this unit's compilation.
+   It is resolved once, at construction, when the program is linked and the target unit's layout is
+   available, and stored as a direct reference to the target object's member. Simulation-time access
+   reads the stored reference directly, with no per-access lookup. The same stored reference serves
+   both value access and change observation; sensitivity to a cross-unit member rides this
+   reference, not a separate path.
+4. Cross-unit resolution is total. Every cross-unit reference is resolvable, because the frontend
+   fully elaborated and validated it before lowering and the constructed object graph is faithful to
+   that elaboration (see `hierarchy_and_generate.md`). A resolution that fails at construction is an
+   `InternalError`, never a user diagnostic and never a runtime fallback.
+5. Port connections, downward and upward hierarchical references, and cross-instance trigger
+   subscriptions all reach across the unit boundary through a cross-unit reference and share the
+   single resolution path. No form has its own parallel resolution.
+6. Connectivity is linkage between objects. For a variable member it never removes the object's
+   storage, never changes the object's layout, and never makes an intra-unit member's addressing
+   depend on what it is wired to. (Merging nets into a single shared net is a design-global
+   net-resolution concern, outside this contract.)
+
+## Boundary to Adjacent Layers
+
+- `compilation_unit_model.md` owns the unit boundary. Intra-unit is "inside this unit"; cross-unit
+  is "across that boundary".
+- `hierarchy_and_generate.md` owns the object graph that a cross-unit reference resolves into, and
+  the faithfulness of that graph to the frontend's elaboration that makes cross-unit resolution
+  total.
+- `runtime_model.md` places resolution of cross-unit references in the constructor context and the
+  access in the simulation context. A cross-unit reference resolves at t = 0 and is read or written
+  at t >= 0.
+- `identity_and_ownership.md` requires a cross-unit reference to be a distinct id kind from an
+  intra-unit id.
+- `scheduling.md` owns the wakeup that fires when a resolved cross-unit member changes.
+
+## Forbidden Shapes
+
+- Compiled body code that bakes in another unit's layout to resolve a cross-unit reference at
+  compile time.
+- A resolution path for ports that is distinct from the one for hierarchical references. Two
+  mechanisms for cross-unit access is the canonical violation.
+- Resolving a cross-unit reference by flattened symbol-name lookup or a design-global path table
+  that mirrors the object graph.
+- A per-access runtime lookup on the simulation path. Cross-unit references resolve once at
+  construction; the hot path reads a stored direct reference.
+- A cross-unit reference keyed or resolved by a design-global coordinate, ordinal, or instance id.
+- A user-facing diagnostic or a runtime fallback for a cross-unit reference that fails to resolve.
+  Such a failure is a compiler-invariant violation and raises `InternalError`.
+- Connectivity that eliminates an object's local storage for a member, or that changes the object's
+  layout based on what the member is wired to.
+- Intra-unit member addressing that differs between a wired and an unwired member.
+
+## Notes / Examples
+
+`always_comb r = c.x;` inside a parent module, where `c` is a child module instance: the target `x`
+lives inside `c`'s unit, so this is a cross-unit reference. The parent's compiled body does not know
+`x`'s offset. At construction, once `c` is built, the reference resolves to `c`'s storage for `x`
+and is stored; the process then reads it directly. Because the body reads `c.x`, the process is also
+sensitive to it: the re-evaluation when `c.x` changes rides the same resolved reference, not a
+separate sensitivity path. An input port `.x(src)` and an upward reference `Parent.v` are also
+cross-unit references and resolve through the same path; they are not separate features.
+
+A multi-segment path mixes both kinds. In `top.gen.child.x`, navigating `top.gen` is intra-unit (the
+generate scope belongs to `top`'s unit), reaching `gen.child` is an intra-unit reference to a child
+object the unit owns, and `child.x` crosses into `child`'s unit. The reference's classification
+follows its final target: `x` is cross-unit. Construction performs the full navigation once and
+stores the direct reference to `x`.
+
+A module port connection reaches across the unit boundary through a cross-unit reference, resolved
+at construction like any other. The connection's form follows the port: an input or output port is a
+continuous assignment between the two objects' own storage (LRM 23.3.3, 23.3.3.2), with the
+cross-unit side resolved as a reference; a `ref` port is itself a hierarchical reference to the
+connected variable, with no separate storage (LRM 23.3.3.2); an `inout` port is a bidirectional net
+connection and belongs to the deferred net-resolution domain (LRM 23.3.3.2). For input, output, and
+`ref` ports the cross-unit reach uses the one resolution path.
+
+Resolution is deferred, not dynamic. The deferral to construction is a compilation-architecture
+choice that keeps each unit independently and incrementally compilable; it carries no semantic
+uncertainty. The frontend has already proven every cross-unit reference has a determinate target, so
+construction always succeeds.

--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -98,6 +98,9 @@ inventory; each is checked off when `functions.md` reproduces it.
 
 ### hierarchy
 
+Tracked in `hierarchy.md`. Covers `hierarchy/instantiation`, `hierarchy/ports`, and
+`hierarchy/refs`, plus the instantiation side of `generate`.
+
 - [ ] hierarchy/instantiation
 - [ ] hierarchy/ports
 - [ ] hierarchy/refs

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -1,0 +1,137 @@
+# Multi-Module Hierarchy
+
+Tracks multi-level module structure and hierarchical paths: a module instantiating other modules,
+the per-instance object tree this builds, the connections across that tree (ports), and references
+that name signals in another instance (hierarchical references). Covers the archive items under
+`archived/tests/sv_features/hierarchy/` (`instantiation`, `ports`, `refs`) and the instantiation
+side of `archived/tests/sv_features/generate/`. When the last item lands, this file is deleted.
+
+The stage IDs (A1, B1, ...) are stable references. Stage letters **do** imply dependency order: a
+later stage may not begin until the stages it depends on are settled. Within a stage the items are
+not ordered.
+
+## Contracts
+
+This workstream reasons from these architecture docs; it does not restate them:
+
+- `reference_resolution.md` -- intra-unit references resolve at compile time; cross-unit references
+  (ports, hierarchical references, cross-instance triggers) resolve once at construction into a
+  stored direct reference. This is why Stages D and E are two surfaces on one resolution path (Stage
+  C), not separate features.
+- `specialization_model.md` -- one compiled artifact per distinct code shape; value-only parameters
+  flow in at construction.
+- `compilation_unit_model.md` -- each module is an independently compiled unit.
+- `hierarchy_and_generate.md` -- the object tree is built at construction; path identity derives
+  from ownership on it.
+- `runtime_model.md` -- constructor context builds the tree; simulation context runs processes.
+
+## Dependency Order
+
+```
+A  Specialization as compilation unit
+   |
+B  Object-graph construction (instantiation)
+   |
+C  Non-local access substrate
+   |
+   +---- D  Hierarchical references
+   |
+   +---- E  Ports
+```
+
+- A gates everything: until more than one module can be compiled as its own unit, there is no second
+  object to instantiate, connect, or reference.
+- B gates C: a handle can only be bound once the target instance exists in the object tree.
+- C gates D and E: both are cross-unit references resolved over the same construction-time path.
+- D and E are independent of each other; their relative order is an open question (see below).
+
+## Sub-Steps
+
+### Stage A -- Specialization as compilation unit
+
+- [ ] A1 -- More than one module definition compiles in a single run; the design is no longer
+      assumed to be a single top module. Each module is its own independently compiled unit.
+- [ ] A2 -- Inputs are classified into code-shape-affecting (enter the specialization key) versus
+      constructor/config inputs (flow in at construction). One compiled artifact exists per distinct
+      code shape, not per instance.
+- [ ] A3 -- Two instances whose code-shape inputs match share one compiled artifact; value-only
+      parameters differ per instance without forking the artifact.
+
+Unlocks the compile-time side of `instantiation/specialization_grouping` and
+`instantiation/param_slots`.
+
+### Stage B -- Object-graph construction (instantiation)
+
+- [ ] B1 -- A module instantiates a child; the constructor builds the child as a distinct object
+      owned by the parent in the object tree. Parent and child remain separate units.
+- [ ] B2 -- The same module instantiated several times yields independent objects, each owning its
+      own state.
+- [ ] B3 -- Instantiation nests: a child that itself instantiates a grandchild builds a multi-level
+      object tree.
+- [ ] B4 -- A child's own (non-port) local state and processes run correctly inside its object.
+- [ ] B5 -- Generate (`for` / `if` / `case`) constructs child instances as part of the object tree,
+      including arrays of instances; which children exist is a construction-time decision.
+
+Unlocks `instantiation/multiple_instances`, `instantiation/nested_hierarchy`,
+`instantiation/local_variables`, the runtime side of `instantiation/param_slots`, and
+`instantiation/generate_repertoire`.
+
+### Stage C -- Non-local access substrate
+
+- [ ] C1 -- Cross-unit references resolve once at construction into a stored direct reference, read
+      directly thereafter (per `reference_resolution.md`). This is the substrate Stages D and E
+      consume.
+- [ ] C2 -- A process on one instance can observe a member of another instance and re-evaluate when
+      that member changes, without the observed instance knowing who watches it (cross-instance
+      sensitivity).
+
+This stage produces no user-visible feature on its own; it is the substrate the next two stages
+consume. Coverage is demonstrated through Stage D and Stage E.
+
+### Stage D -- Hierarchical references
+
+- [ ] D1 -- A downward reference reads and writes a signal in a child instance.
+- [ ] D2 -- An upward reference reads and writes a signal in an ancestor instance.
+- [ ] D3 -- Multi-level dotted paths resolve through the object tree across more than one level.
+- [ ] D4 -- A combinational process reading a hierarchical reference re-triggers when the referenced
+      signal changes, including paths spanning multiple levels and reads from several instances.
+- [ ] D5 -- The hierarchical path of an instance (for `%m`, display, and scope queries) derives from
+      object-tree ownership.
+
+Unlocks `refs/hierarchical_refs`, `refs/upward_refs`, and `instantiation/hierarchical_sensitivity`.
+
+### Stage E -- Ports
+
+- [ ] E1 -- Port directions (input / output) and named port connections at the instantiation site.
+- [ ] E2 -- An input port reflects its parent-side source continuously: when the source changes, the
+      child sees the new value and its dependent processes re-evaluate.
+- [ ] E3 -- An output port propagates a child write so the parent-side target observes it.
+- [ ] E4 -- Expression-driven and constant-valued port connections.
+- [ ] E5 -- Single-driver net-typed ports alongside variable-typed ports; both behave as continuous
+      assignments between the two objects' own storage.
+- [ ] E6 -- Pass-through ports (a port forwarded into a deeper child while the module keeps its own
+      local state) and sibling-to-sibling connections through a shared parent signal.
+
+Unlocks the `ports/*` archive group.
+
+## Open Questions
+
+- Relative order of Stage D and Stage E. Both sit on the Stage C substrate. Hierarchical references
+  exercise the read / write / sensitivity surface most directly and may be the cleaner forcing
+  function for C; ports add connection direction and continuous propagation on top. Ports are more
+  fundamental to real designs. Order to be decided when Stage C lands.
+- How much of the specialization-key classification (which inputs are code-shape-affecting) is
+  pinned in A2 versus refined as later stages reveal more code-shape-affecting inputs.
+- Whether positional port connections and connection shorthands (`.*`, `.name` implicit) are in
+  scope for Stage E or deferred.
+
+## Out of Scope
+
+- Interfaces, modports, and programs as compilation-unit kinds. They are unit kinds in
+  `compilation_unit_model.md` but are a separate workstream from module hierarchy.
+- Primitive and gate-level instances (UDPs, built-in gates).
+- Bind directives and configuration (`config` / `bind`).
+- Net resolution and net merging: multi-driver resolved nets and net collapsing across ports. A
+  single-driver net port behaves as a continuous assignment and is in scope; multi-driver net
+  resolution is a separate design-global concern. `inout` ports are bidirectional net connections in
+  this same deferred net domain.


### PR DESCRIPTION
## Summary

This change captures the architecture model for multi-module hierarchy and hierarchical paths that we worked through, entirely at the documentation level. The load-bearing piece is a new `reference_resolution.md` contract: every reference resolves to a concrete target, and the compilation-unit boundary decides when. An intra-unit reference (including into a generate scope) resolves at compile time; a cross-unit reference resolves once at construction into a stored direct reference and is read directly thereafter. Cross-unit resolution is total because the frontend has already elaborated and validated every such reference, so a failure at construction is a compiler-invariant violation rather than a user error. The same resolution serves both value access and change observation, so ports, hierarchical references, and cross-instance triggers all reach across the boundary on one path rather than as separate features.

The doc also pins the port model against the LRM: an input or output port is an implied continuous assignment between the two objects' own storage (LRM 23.3.3, 23.3.3.2), a `ref` port is itself a hierarchical reference, and `inout` together with net merging are bidirectional net-resolution concerns deferred to the design-global layer.

## Design

`hierarchy_and_generate.md` gains an invariant that the constructed object tree is faithful to the frontend's elaboration, which is what makes cross-unit resolution total. The new contract is wired into the architecture index and cross-referenced from `compilation_unit_model.md` and `identity_and_ownership.md`, which previously alluded to cross-unit access without a canonical home. A new `hierarchy.md` progress plan lays out the workstream as dependency-ordered stages (specialization, object-graph construction, the shared cross-unit substrate, then hierarchical references and ports) with the net-resolution surface marked out of scope.