### PR TITLE
Add unpacked element write across blocking, NBA, and compound

### DIFF
--- a/docs/progress/unpacked.md
+++ b/docs/progress/unpacked.md
@@ -13,13 +13,13 @@ Done when:
 
 ## Actionable
 
-U1 is in flight; U2..U5 are open and ordered. U1 establishes the IR shape and the literal-init path;
-the rest extend on top.
+U1 and U2 are done; U3..U5 are open. U1 established the IR shape, the literal-init path, and element
+read; U2 added element write across blocking, non-blocking, and compound forms.
 
 | Item | Status                                                       |
 | ---- | ------------------------------------------------------------ |
-| U1   | In flight: type infrastructure + literal init + element read |
-| U2   | Open: element write                                          |
+| U1   | Done: type infrastructure + literal init + element read      |
+| U2   | Done: element write (blocking, NBA, compound)                |
 | U3   | Open: structured and replicated assignment patterns          |
 | U4   | Open: whole-array assignment, equality, constant-width slice |
 | U5   | Open: OOB read returning element default, base ranges        |
@@ -30,7 +30,7 @@ The numeric IDs are stable references and do not imply execution order beyond U1
 
 ### Type infrastructure and literal init
 
-- [ ] U1 -- Fixed-size unpacked array declarations of integral element types (LRM 7.4.2), with
+- [x] U1 -- Fixed-size unpacked array declarations of integral element types (LRM 7.4.2), with
       element read on a known-in-bounds index (LRM 7.4.5) and declaration initializer via the simple
       assignment pattern `'{e1, e2, ...}` (LRM 10.9). Multi-dimensional arrays fall out from the
       nested type shape (LRM 7.4.4). Default initialization without an initializer applies the
@@ -39,10 +39,10 @@ The numeric IDs are stable references and do not imply execution order beyond U1
 
 ### Element write
 
-- [ ] U2 -- Procedural element write `arr[i] = v`, including NBA (`arr[i] <= v`) and
-      compound-assignment forms (`arr[i] += v`). The lvalue path mirrors the rvalue element-select
-      from U1 with non-const access. Closes the element-access half of the `unpacked_arrays` archive
-      cases that compute results by populating the array procedurally and reading back.
+- [x] U2 -- Procedural element write `arr[i] = v`, including NBA (`arr[i] <= v`) and
+      compound-assignment forms (`arr[i] += v`, `arr[i] |= v`, etc., per LRM 11.4.1). The lvalue
+      path mirrors the rvalue element-select from U1 with non-const access; NBA wraps the same
+      lvalue inside the standard deferred-assign closure.
 
 ### Structured and replicated patterns
 

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -865,6 +865,29 @@ auto RenderSameShapeLiteral(
       RenderPackedArrayCtorArgs(shape));
 }
 
+// Indexed element access shared by rvalue `RenderElementSelectExpr` and the
+// lvalue `RenderLhsExpr` ElementSelect arm. Packed and unpacked bases land on
+// different C++ access shapes:
+//   - Packed -> `lyra::value::PackedArray::ElementAt(idx)`, range-aware
+//     translation lives inside the runtime type.
+//   - Unpacked -> `std::vector::operator[]` with a zero-based size_t index;
+//     the HIR-to-MIR pass already rewrote any declared-range origin into a
+//     zero-based offset on `sel.index`.
+auto RenderIndexedElementAccess(
+    const mir::Type& base_ty, std::string_view base, std::string_view idx)
+    -> std::string {
+  if (std::holds_alternative<mir::UnpackedArrayType>(base_ty.data)) {
+    return std::format(
+        "({})[static_cast<std::size_t>(({}).ToInt64())]", base, idx);
+  }
+  if (std::holds_alternative<mir::PackedArrayType>(base_ty.data)) {
+    return std::format("({}).ElementAt({})", base, idx);
+  }
+  throw InternalError(
+      "RenderIndexedElementAccess: base type must be PackedArrayType or "
+      "UnpackedArrayType");
+}
+
 auto RenderElementSelectExpr(
     const RenderContext& ctx, const mir::ElementSelectExpr& sel)
     -> diag::Result<std::string> {
@@ -874,14 +897,7 @@ auto RenderElementSelectExpr(
   auto idx_or = RenderExpr(ctx, ctx.Expr(sel.index));
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const auto& base_ty = ctx.Unit().GetType(base_expr.type);
-  // Unpacked vectors are zero-based; the SV declared-range translation
-  // already lives in `sel.index` (HIR-to-MIR rewrites it). Packed arrays
-  // keep their range-aware ElementAt path inside PackedArray.
-  if (std::holds_alternative<mir::UnpackedArrayType>(base_ty.data)) {
-    return std::format(
-        "({})[static_cast<std::size_t>(({}).ToInt64())]", *base_or, *idx_or);
-  }
-  return std::format("({}).ElementAt({})", *base_or, *idx_or);
+  return RenderIndexedElementAccess(base_ty, *base_or, *idx_or);
 }
 
 // Constant integer extracted from a MIR expression. Caller is responsible for
@@ -963,12 +979,13 @@ auto RenderLhsExpr(
             return LookupProceduralVarName(ctx, l);
           },
           [&](const mir::ElementSelectExpr& s) -> diag::Result<std::string> {
-            auto base =
-                RenderLhsExpr(ctx, ctx.Expr(s.base_value), mutate_adapter);
+            const mir::Expr& base_expr = ctx.Expr(s.base_value);
+            auto base = RenderLhsExpr(ctx, base_expr, mutate_adapter);
             if (!base) return std::unexpected(std::move(base.error()));
             auto idx = RenderExpr(ctx, ctx.Expr(s.index));
             if (!idx) return std::unexpected(std::move(idx.error()));
-            return std::format("{}.ElementAt({})", *base, *idx);
+            const auto& base_ty = ctx.Unit().GetType(base_expr.type);
+            return RenderIndexedElementAccess(base_ty, *base, *idx);
           },
           [&](const mir::RangeSelectExpr& s) -> diag::Result<std::string> {
             auto base =
@@ -1272,27 +1289,27 @@ auto RenderConcatExpr(
     throw InternalError("RenderConcatExpr: hir lowering produced empty concat");
   }
   const auto& result_ty = ctx.Unit().GetType(expr.type);
-  if (result_ty.IsIntegralPacked()) {
-    std::string out = "lyra::value::PackedArray::Concat(";
+  const auto join = [&](std::string_view open, std::string_view sep,
+                        std::string_view close) -> diag::Result<std::string> {
+    std::string out{open};
     for (std::size_t i = 0; i < c.operands.size(); ++i) {
       auto rendered = RenderExpr(ctx, ctx.Expr(c.operands[i]));
       if (!rendered) return std::unexpected(std::move(rendered.error()));
-      if (i != 0) out += ", ";
+      if (i != 0) out += sep;
       out += *rendered;
     }
-    out += ")";
+    out += close;
     return out;
+  };
+  if (result_ty.IsIntegralPacked()) {
+    return join("lyra::value::PackedArray::Concat(", ", ", ")");
   }
-  // String mode (LRM 6.16): operator+ on std::string joins contents.
-  std::string out = "(";
-  for (std::size_t i = 0; i < c.operands.size(); ++i) {
-    auto rendered = RenderExpr(ctx, ctx.Expr(c.operands[i]));
-    if (!rendered) return std::unexpected(std::move(rendered.error()));
-    if (i != 0) out += " + ";
-    out += *rendered;
+  if (result_ty.Kind() == mir::TypeKind::kString) {
+    // LRM 6.16: string concat joins contents via std::string `operator+`.
+    return join("(", " + ", ")");
   }
-  out += ")";
-  return out;
+  throw InternalError(
+      "RenderConcatExpr: result type must be PackedArrayType or string");
 }
 
 auto RenderArrayLiteralExpr(
@@ -1330,8 +1347,12 @@ auto RenderReplicationExpr(
         "static_cast<std::uint64_t>({}))",
         *concat, count_text);
   }
-  return std::format(
-      "lyra::value::ReplicateString({}, {})", *concat, count_text);
+  if (result_ty.Kind() == mir::TypeKind::kString) {
+    return std::format(
+        "lyra::value::ReplicateString({}, {})", *concat, count_text);
+  }
+  throw InternalError(
+      "RenderReplicationExpr: result type must be PackedArrayType or string");
 }
 
 auto ProducesPackedArrayRef(const mir::Expr& expr) -> bool {

--- a/tests/cases/cpp/unpacked_element_write_2d/case.yaml
+++ b/tests/cases/cpp/unpacked_element_write_2d/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.unpacked_element_write_2d
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    p00: 10
+    p01: 11
+    p02: 12
+    p10: 20
+    p11: 21
+    p12: 22

--- a/tests/cases/cpp/unpacked_element_write_2d/main.sv
+++ b/tests/cases/cpp/unpacked_element_write_2d/main.sv
@@ -1,0 +1,18 @@
+module Top;
+  int a [2][3];
+  int p00, p01, p02, p10, p11, p12;
+  initial begin
+    int i, j;
+    for (i = 0; i < 2; i = i + 1) begin
+      for (j = 0; j < 3; j = j + 1) begin
+        a[i][j] = (i + 1) * 10 + j;
+      end
+    end
+    p00 = a[0][0];
+    p01 = a[0][1];
+    p02 = a[0][2];
+    p10 = a[1][0];
+    p11 = a[1][1];
+    p12 = a[1][2];
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_element_write_compound_arith/case.yaml
+++ b/tests/cases/cpp/unpacked_element_write_compound_arith/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.unpacked_element_write_compound_arith
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    p0: 15
+    p1: 15
+    p2: 60

--- a/tests/cases/cpp/unpacked_element_write_compound_arith/main.sv
+++ b/tests/cases/cpp/unpacked_element_write_compound_arith/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  int a [3] = '{10, 20, 30};
+  int p0, p1, p2;
+  initial begin
+    a[0] += 5;
+    a[1] -= 5;
+    a[2] *= 2;
+    p0 = a[0];
+    p1 = a[1];
+    p2 = a[2];
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_element_write_compound_bitwise/case.yaml
+++ b/tests/cases/cpp/unpacked_element_write_compound_bitwise/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.unpacked_element_write_compound_bitwise
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    p0: "8'h0F"
+    p1: "8'hF0"
+    p2: "8'hFF"

--- a/tests/cases/cpp/unpacked_element_write_compound_bitwise/main.sv
+++ b/tests/cases/cpp/unpacked_element_write_compound_bitwise/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  bit [7:0] a [3] = '{8'h00, 8'hFF, 8'hAA};
+  bit [7:0] p0, p1, p2;
+  initial begin
+    a[0] |= 8'h0F;
+    a[1] &= 8'hF0;
+    a[2] ^= 8'h55;
+    p0 = a[0];
+    p1 = a[1];
+    p2 = a[2];
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_element_write_const_index/case.yaml
+++ b/tests/cases/cpp/unpacked_element_write_const_index/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.unpacked_element_write_const_index
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    p0: 10
+    p1: 20
+    p2: 30

--- a/tests/cases/cpp/unpacked_element_write_const_index/main.sv
+++ b/tests/cases/cpp/unpacked_element_write_const_index/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  int a [3];
+  int p0, p1, p2;
+  initial begin
+    a[0] = 10;
+    a[1] = 20;
+    a[2] = 30;
+    p0 = a[0];
+    p1 = a[1];
+    p2 = a[2];
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_element_write_nba/case.yaml
+++ b/tests/cases/cpp/unpacked_element_write_nba/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.unpacked_element_write_nba
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    p0: 100
+    p1: 200
+    p2: 300

--- a/tests/cases/cpp/unpacked_element_write_nba/main.sv
+++ b/tests/cases/cpp/unpacked_element_write_nba/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  int a [3] = '{1, 2, 3};
+  int p0, p1, p2;
+  initial begin
+    a[0] <= 100;
+    a[1] <= 200;
+    a[2] <= 300;
+    #1;
+    p0 = a[0];
+    p1 = a[1];
+    p2 = a[2];
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_element_write_var_index/case.yaml
+++ b/tests/cases/cpp/unpacked_element_write_var_index/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.unpacked_element_write_var_index
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    p0: 0
+    p1: 100
+    p2: 200
+    p3: 300

--- a/tests/cases/cpp/unpacked_element_write_var_index/main.sv
+++ b/tests/cases/cpp/unpacked_element_write_var_index/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  int a [4];
+  int p0, p1, p2, p3;
+  initial begin
+    int i;
+    for (i = 0; i < 4; i = i + 1) begin
+      a[i] = i * 100;
+    end
+    p0 = a[0];
+    p1 = a[1];
+    p2 = a[2];
+    p3 = a[3];
+  end
+endmodule


### PR DESCRIPTION
## Summary

Closes `unpacked.md` U2. Procedural element write `arr[i] = v` now works on fixed-size unpacked arrays of integral elements, including non-blocking (`arr[i] <= v`) and the LRM 11.4.1 compound forms (`+=`, `-=`, `*=`, `|=`, `&=`, `^=`, etc.). Multi-dimensional writes (`arr[i][j] = v`) fall out from the same recursive lvalue path.

## Design

The trace through the stack found that AST -> HIR, HIR -> MIR, the NBA closure rewrite, and the compound-assign rewrite all already routed unpacked-base lvalue `ElementSelectExpr` correctly. The only broken layer was the C++ emit: lvalue `RenderLhsExpr` unconditionally emitted `.ElementAt(idx)`, which is a `PackedArray` method, so unpacked bases (`std::vector<PackedArray>`) failed at C++ compile time.

The fix introduces `RenderIndexedElementAccess`, used by both the rvalue `RenderElementSelectExpr` and the lvalue `RenderLhsExpr` ElementSelect arm. Packed and unpacked are now two parallel arms with an explicit `InternalError` on any other base type, instead of "packed default + unpacked exception". `RenderConcatExpr` and `RenderReplicationExpr` were carrying the same anti-pattern between packed and string arms; they got the same symmetrization.

## Testing

Six new `tests/cases/cpp/unpacked_element_write_*` cases cover const-index, variable-index, 2D, NBA (with `#1` settle), arithmetic compound, and bitwise compound forms. Each case verifies the post-write state via scalar probes against `expect.variables`. All cases failed on the same `no member named 'ElementAt'` error before the fix; all pass after. Full `bazel test //...` stays green.