### PR TITLE
Add output and inout subroutine arguments

### DIFF
--- a/docs/progress/functions.md
+++ b/docs/progress/functions.md
@@ -50,9 +50,13 @@ everything and the inline "rides on" notes record the real dependencies.
 
 ### Arguments
 
-- [ ] F4 -- `output` and `inout` arguments (LRM 13.5). `output` copies out at return, `inout` copies
+- [x] F4 -- `output` and `inout` arguments (LRM 13.5). `output` copies out at return, `inout` copies
       in at call and out at return; multiple outputs; mixed directions. Default direction is `input`
-      and subsequent formals inherit the previous direction and data type.
+      and subsequent formals inherit the previous direction and data type. Copy-in-copy-out is
+      observable: a body that also reaches an actual passed as `output` sees the LRM-defined value,
+      and the copy-out goes through the actual's own write path. Supported where the call stands in
+      statement position (a bare call or the whole right side of a blocking assignment); a call with
+      `output` / `inout` actuals nested inside a larger expression is not yet supported.
 - [ ] F6 -- Default argument values (LRM 13.5.3), binding by name (LRM 13.5.4), and the optional
       empty argument list for no-argument / all-defaulted subroutines (LRM 13.5.5). Default
       expressions evaluate in the declaration scope at each defaulting call.

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -32,6 +32,7 @@ enum class DiagCode : std::uint32_t {
   kUnsupportedEventTriggerForm,
   kUnsupportedContinuousAssignForm,
   kUnsupportedAssignmentPatternKind,
+  kUnsupportedSubroutineArgument,
 
   kDelayValueOutOfRange,
   kFormatStringTrailingPercent,

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -161,12 +161,33 @@ struct GenerateBindings {
 class StructuralScopeLoweringState {
  public:
   StructuralScopeLoweringState(
-      const StructuralScopeLoweringState* parent, mir::StructuralScope& scope)
-      : parent_(parent), scope_(&scope) {
+      const StructuralScopeLoweringState* parent, mir::StructuralScope& scope,
+      const hir::StructuralScope& hir_scope)
+      : parent_(parent), scope_(&scope), hir_scope_(&hir_scope) {
   }
 
   [[nodiscard]] auto Parent() const -> const StructuralScopeLoweringState* {
     return parent_;
+  }
+
+  // Resolve a subroutine reference to its HIR declaration by walking `hops`
+  // scopes outward. The HIR declaration is complete before any body is lowered,
+  // so a call can read a peer's formals even when the peer's MIR declaration is
+  // not yet built (forward / mutual reference, LRM 13.7). The desugar reads the
+  // formals' directions and types from here.
+  [[nodiscard]] auto LookupHirSubroutine(
+      hir::StructuralHops hops, hir::StructuralSubroutineId id) const
+      -> const hir::StructuralSubroutineDecl& {
+    if (hops.value == 0) {
+      return hir_scope_->structural_subroutines.at(id.value);
+    }
+    if (parent_ == nullptr) {
+      throw InternalError(
+          "StructuralScopeLoweringState::LookupHirSubroutine: hops walk ran "
+          "past the root scope");
+    }
+    return parent_->LookupHirSubroutine(
+        hir::StructuralHops{.value = hops.value - 1}, id);
   }
 
   [[nodiscard]] auto Scope() const -> const mir::StructuralScope& {
@@ -356,6 +377,7 @@ class StructuralScopeLoweringState {
 
   const StructuralScopeLoweringState* parent_;
   mir::StructuralScope* scope_;
+  const hir::StructuralScope* hir_scope_;
   std::vector<mir::StructuralVarId> structural_var_map_;
   std::vector<std::optional<mir::StructuralParamId>> structural_param_map_;
   std::vector<mir::StructuralSubroutineId> structural_subroutine_map_;
@@ -514,6 +536,34 @@ class ProceduralScopeLoweringState {
 
   void AddRootStmt(mir::StmtId id) {
     scope_.root_stmts.push_back(id);
+  }
+
+  // Append a label-less, scope-less statement to the body in one step: stage
+  // it in the stmts arena and register it as a root statement. Encapsulates the
+  // AddStmt-then-AddRootStmt pairing so a synthesized statement cannot be added
+  // to the arena yet left out of the executed sequence.
+  auto AppendStmt(mir::StmtData data) -> mir::StmtId {
+    const mir::StmtId id = AddStmt(
+        mir::Stmt{
+            .label = std::nullopt,
+            .data = std::move(data),
+            .child_procedural_scopes = {}});
+    AddRootStmt(id);
+    return id;
+  }
+
+  // Declare a body-local variable: register it in the var arena and emit its
+  // declaration statement in the body. The two must co-occur for a genuine
+  // local, so they are exposed as one operation. (A subroutine formal is a
+  // ProceduralVar that is declared in the signature, not the body, and uses
+  // bare AddProceduralVar instead.)
+  auto AppendLocal(mir::ProceduralVarDecl decl, mir::ExprId init)
+      -> mir::ProceduralVarRef {
+    const mir::ProceduralVarId var = AddProceduralVar(std::move(decl));
+    const mir::ProceduralVarRef ref{
+        .hops = mir::ProceduralHops{.value = 0}, .var = var};
+    AppendStmt(mir::ProceduralVarDeclStmt{.target = ref, .init = init});
+    return ref;
   }
 
   auto Finish() -> mir::ProceduralScope {

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -139,16 +139,17 @@ auto RenderSubroutineMethod(
   std::string sig = *result_or + " " + sub.name + "(";
   for (std::size_t i = 0; i < sub.params.size(); ++i) {
     const auto& param = sub.params[i];
-    if (param.direction != mir::ParamDirection::kInput) {
-      return diag::Unsupported(
-          diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-          "only input subroutine arguments are supported in cpp emit",
-          diag::UnsupportedCategory::kFeature);
-    }
     auto type_or = RenderTypeAsCpp(unit, s, param.type);
     if (!type_or) return std::unexpected(std::move(type_or.error()));
     if (i != 0) sig += ", ";
-    sig += *type_or + " " + param.name;
+    // An `input` formal is a by-value copy (LRM 13.5.1); an `output` / `inout`
+    // formal binds to the caller's writeback temp by reference so the body
+    // writes flow back at the copy-out. ref / const ref are rejected upstream.
+    if (param.direction == mir::ParamDirection::kInput) {
+      sig += *type_or + " " + param.name;
+    } else {
+      sig += *type_or + "& " + param.name;
+    }
   }
   sig += ")";
 

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -138,6 +138,12 @@ constexpr std::array kEntries{
             .kind = DiagKind::kUnsupported,
             .category = UnsupportedCategory::kOperation,
             .name = "unsupported_assignment_pattern_kind"}},
+    std::pair{
+        DiagCode::kUnsupportedSubroutineArgument,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_subroutine_argument"}},
 
     std::pair{
         DiagCode::kDelayValueOutOfRange,

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -458,8 +458,20 @@ auto LowerCallExprProc(
   arg_ids.reserve(call.arguments().size());
   std::optional<hir::TypeId> receiver_type;
   for (std::size_t i = 0; i < call.arguments().size(); ++i) {
-    auto arg_or = LowerProcExpr(
-        unit_facts, unit_state, proc_state, stack, *call.arguments()[i]);
+    // LRM 13.5: slang models an `output` / `inout` actual as an
+    // AssignmentExpression whose right side is an EmptyArgument placeholder;
+    // the actual lvalue is the left side. HIR carries just that lvalue -- the
+    // copy-in / copy-out is synthesized at HIR-to-MIR from the formal's
+    // direction.
+    const slang::ast::Expression* arg = call.arguments()[i];
+    if (arg->kind == slang::ast::ExpressionKind::Assignment) {
+      const auto& as = arg->as<slang::ast::AssignmentExpression>();
+      if (as.right().kind == slang::ast::ExpressionKind::EmptyArgument) {
+        arg = &as.left();
+      }
+    }
+    auto arg_or =
+        LowerProcExpr(unit_facts, unit_state, proc_state, stack, *arg);
     if (!arg_or) return std::unexpected(std::move(arg_or.error()));
     if (i == 0) {
       receiver_type = arg_or->type;
@@ -1580,7 +1592,12 @@ auto ValidateAssignableSlangExpr(
     case EK::NamedValue: {
       const auto& nv = expr.as<slang::ast::NamedValueExpression>();
       const auto& sym = nv.symbol;
-      if (sym.kind != slang::ast::SymbolKind::Variable) {
+      // A subroutine formal (LRM 13.5) is a VariableSymbol subclass with its
+      // own SymbolKind; an `output` / `inout` formal is a legal assignment
+      // target inside the body, resolved through the same procedural-var
+      // binding as a body local.
+      if (sym.kind != slang::ast::SymbolKind::Variable &&
+          sym.kind != slang::ast::SymbolKind::FormalArgument) {
         return reject("assignment target must be a variable reference");
       }
       const auto& var = sym.as<slang::ast::VariableSymbol>();

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -503,7 +503,8 @@ auto LowerStructuralScope(
             .name = alias.name,
             .target = unit_state.TranslateType(alias.target)});
   }
-  StructuralScopeLoweringState scope_state(parent_scope_state, mir_scope);
+  StructuralScopeLoweringState scope_state(
+      parent_scope_state, mir_scope, scope);
   const ScopeStackGuard guard(stack, scope);
 
   for (const auto& binding : entry_bindings) {

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -19,6 +19,7 @@
 #include "lyra/hir/integral_constant.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/structural_scope.hpp"
+#include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/unary_op.hpp"
 #include "lyra/hir/value_ref.hpp"
@@ -811,6 +812,22 @@ auto LowerHirCallExprProc(
           },
           [&](const hir::StructuralSubroutineRef& usr)
               -> diag::Result<mir::Expr> {
+            // LRM 13.5: a call with output / inout actuals is desugared to
+            // copy-in-copy-out at statement position (see LowerExprStmt).
+            // Reaching it here means the call is a nested expression operand,
+            // where the copy-out statement has nowhere to be sequenced; that
+            // form is not yet supported.
+            const hir::StructuralSubroutineDecl& decl =
+                scope_state.LookupHirSubroutine(usr.hops, usr.subroutine);
+            for (const auto& param : decl.params) {
+              if (param.direction != hir::ParamDirection::kInput) {
+                return diag::Unsupported(
+                    span, diag::DiagCode::kUnsupportedSubroutineArgument,
+                    "a call with output / inout arguments is only supported "
+                    "in statement position, not as a nested expression",
+                    diag::UnsupportedCategory::kFeature);
+              }
+            }
             std::vector<mir::ExprId> args;
             args.reserve(c.arguments.size());
             for (const auto arg : c.arguments) {

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -2,6 +2,8 @@
 
 #include <expected>
 #include <memory>
+#include <optional>
+#include <string>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -15,6 +17,8 @@
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
+#include "lyra/hir/subroutine.hpp"
+#include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/lowering/hir_to_mir/case_cascade.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/delay_time_resolver.hpp"
@@ -179,22 +183,11 @@ auto LowerDestructuringAssign(
               .left = static_cast<std::int64_t>(total_width) - 1, .right = 0}},
           .form = mir::PackedArrayForm::kExplicit}});
 
-  const mir::ProceduralVarId temp_var = wrapper_state.AddProceduralVar(
-      mir::ProceduralVarDecl{.name = "_lyra_destruct_rhs", .type = temp_type});
   const mir::ExprId temp_default_init =
       SynthesizeDefaultValueExpr(unit_state, wrapper_state, temp_type);
-  const mir::StmtId temp_decl_id = wrapper_state.AddStmt(
-      mir::Stmt{
-          .label = std::nullopt,
-          .data =
-              mir::ProceduralVarDeclStmt{
-                  .target =
-                      mir::ProceduralVarRef{
-                          .hops = mir::ProceduralHops{.value = 0},
-                          .var = temp_var},
-                  .init = temp_default_init},
-          .child_procedural_scopes = {}});
-  wrapper_state.AddRootStmt(temp_decl_id);
+  const mir::ProceduralVarRef snapshot_ref = wrapper_state.AppendLocal(
+      mir::ProceduralVarDecl{.name = "_lyra_destruct_rhs", .type = temp_type},
+      temp_default_init);
 
   // RHS is evaluated once; the snapshot temp is what gets distributed,
   // which is what makes `{a, b} = {b, a}` swap correctly.
@@ -212,22 +205,14 @@ auto LowerDestructuringAssign(
             .type = temp_type});
   }
 
-  const mir::ExprId temp_assign_target = wrapper_state.AddExpr(
-      mir::Expr{
-          .data =
-              mir::ProceduralVarRef{
-                  .hops = mir::ProceduralHops{.value = 0}, .var = temp_var},
-          .type = temp_type});
+  const mir::ExprId temp_assign_target =
+      wrapper_state.AddExpr(mir::Expr{.data = snapshot_ref, .type = temp_type});
   const mir::ExprId temp_assign_id = wrapper_state.AddExpr(
       mir::Expr{
           .data =
               mir::AssignExpr{.target = temp_assign_target, .value = rhs_id},
           .type = temp_type});
-  wrapper_state.AddRootStmt(wrapper_state.AddStmt(
-      mir::Stmt{
-          .label = std::nullopt,
-          .data = mir::ExprStmt{.expr = temp_assign_id},
-          .child_procedural_scopes = {}}));
+  wrapper_state.AppendStmt(mir::ExprStmt{.expr = temp_assign_id});
 
   // MSB-first per LRM 11.4.12: operands[0] occupies the high bits of the
   // snapshot, operands.back() the low bits.
@@ -251,11 +236,7 @@ auto LowerDestructuringAssign(
     const mir::ExprId width_lit = wrapper_state.AddExpr(
         unit_state.MakeInt32LiteralExpr(static_cast<std::int64_t>(w)));
     const mir::ExprId temp_ref = wrapper_state.AddExpr(
-        mir::Expr{
-            .data =
-                mir::ProceduralVarRef{
-                    .hops = mir::ProceduralHops{.value = 0}, .var = temp_var},
-            .type = temp_type});
+        mir::Expr{.data = snapshot_ref, .type = temp_type});
     const mir::TypeId slice_type = unit_state.AddType(
         mir::TypeData{mir::PackedArrayType{
             .atom = any_four_state ? mir::BitAtom::kLogic : mir::BitAtom::kBit,
@@ -302,11 +283,7 @@ auto LowerDestructuringAssign(
                       .call = mir::RuntimeSubmitNbaCall{.closure = closure_id}},
               .type = unit_state.Builtins().void_type});
     }
-    wrapper_state.AddRootStmt(wrapper_state.AddStmt(
-        mir::Stmt{
-            .label = std::nullopt,
-            .data = mir::ExprStmt{.expr = per_part_expr_id},
-            .child_procedural_scopes = {}}));
+    wrapper_state.AppendStmt(mir::ExprStmt{.expr = per_part_expr_id});
   }
 
   std::vector<mir::ProceduralScope> child_scopes;
@@ -316,6 +293,150 @@ auto LowerDestructuringAssign(
   return mir::Stmt{
       .label = stmt.label,
       .data = mir::BlockStmt{.scope = wrapper_scope_id},
+      .child_procedural_scopes = std::move(child_scopes)};
+}
+
+// A user subroutine whose formals include a non-`input` direction needs the
+// call desugared so the writebacks become explicit MIR statements; returns its
+// HIR declaration, or nullptr for a value-only call (system / builtin callee,
+// or an all-`input` user callee).
+auto SubroutineWithWritebacks(
+    const StructuralScopeLoweringState& scope_state, const hir::CallExpr& call)
+    -> const hir::StructuralSubroutineDecl* {
+  const auto* ref = std::get_if<hir::StructuralSubroutineRef>(&call.callee);
+  if (ref == nullptr) {
+    return nullptr;
+  }
+  const hir::StructuralSubroutineDecl& decl =
+      scope_state.LookupHirSubroutine(ref->hops, ref->subroutine);
+  for (const auto& param : decl.params) {
+    if (param.direction != hir::ParamDirection::kInput) {
+      return &decl;
+    }
+  }
+  return nullptr;
+}
+
+// LRM 13.5 output / inout argument passing. A subroutine call whose formals
+// take values out is desugared into a block: a fresh local per writeback
+// formal (default-initialized for `output`, copy-in initialized for `inout`),
+// the call with those locals bound to the formals, then a copy-out assignment
+// of each local back to its actual lvalue. This realizes the copy-in-copy-out
+// semantics -- output values pass at return through the actual's own write
+// path, which is required when the actual is an observable variable -- and
+// isolates the formal from the actual so a body that also reaches the actual
+// directly observes the LRM-defined value.
+//
+// `assign_target` is the lvalue for a `lhs = f(...)` statement, or nullopt for
+// a bare call statement (void function or discarded result).
+auto LowerSubroutineCallWithWritebacks(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
+    const hir::Stmt& stmt, diag::SourceSpan span, const hir::CallExpr& call,
+    const hir::StructuralSubroutineRef& callee_ref,
+    const hir::StructuralSubroutineDecl& decl,
+    std::optional<hir::ExprId> assign_target, mir::TypeId result_type)
+    -> diag::Result<mir::Stmt> {
+  if (call.arguments.size() != decl.params.size()) {
+    throw InternalError(
+        "LowerSubroutineCallWithWritebacks: argument / formal count mismatch");
+  }
+
+  ProceduralScopeLoweringState wrapper;
+  ProceduralDepthGuard depth_guard{proc_state};
+
+  struct Writeback {
+    mir::ExprId actual;
+    mir::ProceduralVarRef temp;
+    mir::TypeId type;
+  };
+  std::vector<mir::ExprId> call_args;
+  call_args.reserve(call.arguments.size());
+  std::vector<Writeback> writebacks;
+
+  for (std::size_t i = 0; i < call.arguments.size(); ++i) {
+    const hir::ParamDirection dir = decl.params[i].direction;
+    const hir::Expr& hir_arg = hir_proc.exprs.at(call.arguments[i].value);
+
+    if (dir == hir::ParamDirection::kInput) {
+      auto arg_or = LowerExpr(
+          unit_state, scope_state, proc_state, wrapper, hir_proc, hir_arg);
+      if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+      call_args.push_back(wrapper.AddExpr(*std::move(arg_or)));
+      continue;
+    }
+    if (dir == hir::ParamDirection::kRef ||
+        dir == hir::ParamDirection::kConstRef) {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedSubroutineArgument,
+          "ref / const ref subroutine arguments are not yet supported",
+          diag::UnsupportedCategory::kFeature);
+    }
+
+    const mir::TypeId formal_type = unit_state.TranslateType(
+        decl.body.GetProceduralVar(decl.params[i].var).type);
+    auto actual_or = LowerExpr(
+        unit_state, scope_state, proc_state, wrapper, hir_proc, hir_arg);
+    if (!actual_or) return std::unexpected(std::move(actual_or.error()));
+    const mir::ExprId actual_id = wrapper.AddExpr(*std::move(actual_or));
+
+    // `output` enters the body default-initialized (LRM 13.3.2); `inout`
+    // enters with the actual's current value copied in.
+    const mir::ExprId init =
+        dir == hir::ParamDirection::kInOut
+            ? actual_id
+            : SynthesizeDefaultValueExpr(unit_state, wrapper, formal_type);
+    const mir::ProceduralVarRef temp = wrapper.AppendLocal(
+        mir::ProceduralVarDecl{
+            .name = "_lyra_arg" + std::to_string(i), .type = formal_type},
+        init);
+    call_args.push_back(
+        wrapper.AddExpr(mir::Expr{.data = temp, .type = formal_type}));
+    writebacks.push_back(
+        {.actual = actual_id, .temp = temp, .type = formal_type});
+  }
+
+  const mir::ExprId call_id = wrapper.AddExpr(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee = scope_state.TranslateStructuralSubroutine(
+                      callee_ref.hops, callee_ref.subroutine),
+                  .arguments = std::move(call_args)},
+          .type = result_type});
+
+  if (assign_target.has_value()) {
+    auto lhs_or = LowerExpr(
+        unit_state, scope_state, proc_state, wrapper, hir_proc,
+        hir_proc.exprs.at(assign_target->value));
+    if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+    const mir::ExprId lhs_id = wrapper.AddExpr(*std::move(lhs_or));
+    const mir::ExprId assign_id = wrapper.AddExpr(
+        mir::Expr{
+            .data = mir::AssignExpr{.target = lhs_id, .value = call_id},
+            .type = result_type});
+    wrapper.AppendStmt(mir::ExprStmt{.expr = assign_id});
+  } else {
+    wrapper.AppendStmt(mir::ExprStmt{.expr = call_id});
+  }
+
+  for (const auto& wb : writebacks) {
+    const mir::ExprId temp_read =
+        wrapper.AddExpr(mir::Expr{.data = wb.temp, .type = wb.type});
+    const mir::ExprId copy_out = wrapper.AddExpr(
+        mir::Expr{
+            .data = mir::AssignExpr{.target = wb.actual, .value = temp_read},
+            .type = wb.type});
+    wrapper.AppendStmt(mir::ExprStmt{.expr = copy_out});
+  }
+
+  std::vector<mir::ProceduralScope> child_scopes;
+  const mir::ProceduralScopeId scope_id =
+      AddChildProceduralScope(child_scopes, wrapper.Finish());
+  return mir::Stmt{
+      .label = stmt.label,
+      .data = mir::BlockStmt{.scope = scope_id},
       .child_procedural_scopes = std::move(child_scopes)};
 }
 
@@ -343,6 +464,34 @@ auto LowerExprStmt(
       return LowerDestructuringAssign(
           unit_state, scope_state, proc_state, hir_proc, stmt, *assign,
           *concat);
+    }
+  }
+
+  // LRM 13.5: a subroutine call with output / inout actuals, in statement
+  // position, desugars to copy-in-copy-out. Two statement shapes carry it:
+  // a bare call (void function / discarded result) and a blocking assignment
+  // whose right side is the call itself (`lhs = f(...)`). A call nested deeper
+  // in an expression is rejected downstream in expression lowering.
+  if (const auto* call = std::get_if<hir::CallExpr>(&inner.data)) {
+    if (const auto* decl = SubroutineWithWritebacks(scope_state, *call)) {
+      return LowerSubroutineCallWithWritebacks(
+          unit_state, scope_state, proc_state, hir_proc, stmt, inner.span,
+          *call, std::get<hir::StructuralSubroutineRef>(call->callee), *decl,
+          std::nullopt, unit_state.TranslateType(inner.type));
+    }
+  }
+  if (const auto* assign = std::get_if<hir::AssignExpr>(&inner.data)) {
+    if (!assign->compound_op.has_value() &&
+        assign->kind == hir::AssignKind::kBlocking) {
+      const hir::Expr& rhs = hir_proc.exprs.at(assign->rhs.value);
+      if (const auto* call = std::get_if<hir::CallExpr>(&rhs.data)) {
+        if (const auto* decl = SubroutineWithWritebacks(scope_state, *call)) {
+          return LowerSubroutineCallWithWritebacks(
+              unit_state, scope_state, proc_state, hir_proc, stmt, rhs.span,
+              *call, std::get<hir::StructuralSubroutineRef>(call->callee),
+              *decl, assign->lhs, unit_state.TranslateType(rhs.type));
+        }
+      }
     }
   }
 

--- a/tests/cases/cpp/function_inout_scalar/case.yaml
+++ b/tests/cases/cpp/function_inout_scalar/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.function_inout_scalar
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: 11

--- a/tests/cases/cpp/function_inout_scalar/main.sv
+++ b/tests/cases/cpp/function_inout_scalar/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  int x;
+
+  function void inc(inout int v);
+    v = v + 1;
+  endfunction
+
+  initial begin
+    x = 10;
+    inc(x);
+  end
+endmodule

--- a/tests/cases/cpp/function_mixed_in_out/case.yaml
+++ b/tests/cases/cpp/function_mixed_in_out/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.function_mixed_in_out
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: 10
+    y: 105

--- a/tests/cases/cpp/function_mixed_in_out/main.sv
+++ b/tests/cases/cpp/function_mixed_in_out/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  int x;
+  int y;
+
+  function void f(input int a, output int b, inout int c);
+    b = a * 2;
+    c = c + a;
+  endfunction
+
+  initial begin
+    x = 0;
+    y = 100;
+    f(5, x, y);
+  end
+endmodule

--- a/tests/cases/cpp/function_output_aliasing/case.yaml
+++ b/tests/cases/cpp/function_output_aliasing/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.function_output_aliasing
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    g: 3

--- a/tests/cases/cpp/function_output_aliasing/main.sv
+++ b/tests/cases/cpp/function_output_aliasing/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  int g;
+
+  function void f(output int b);
+    b = 1;
+    g = 2;
+    b = b + g;
+  endfunction
+
+  initial begin
+    g = 99;
+    f(g);
+  end
+endmodule

--- a/tests/cases/cpp/function_output_four_state/case.yaml
+++ b/tests/cases/cpp/function_output_four_state/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.function_output_four_state
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 0xAA

--- a/tests/cases/cpp/function_output_four_state/main.sv
+++ b/tests/cases/cpp/function_output_four_state/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  logic [7:0] r;
+
+  function void f(output logic [7:0] v);
+    if (v === 8'hxx) v = 8'hAA;
+    else v = 8'h55;
+  endfunction
+
+  initial begin
+    f(r);
+  end
+endmodule

--- a/tests/cases/cpp/function_output_in_assign/case.yaml
+++ b/tests/cases/cpp/function_output_in_assign/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.function_output_in_assign
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r: 3
+    o: 1

--- a/tests/cases/cpp/function_output_in_assign/main.sv
+++ b/tests/cases/cpp/function_output_in_assign/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  int r;
+  int o;
+
+  function int compute(input int a, output int leftover);
+    leftover = a % 3;
+    return a / 3;
+  endfunction
+
+  initial begin
+    r = compute(10, o);
+  end
+endmodule

--- a/tests/cases/cpp/function_output_multi/case.yaml
+++ b/tests/cases/cpp/function_output_multi/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.function_output_multi
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a: 3
+    b: 7

--- a/tests/cases/cpp/function_output_multi/main.sv
+++ b/tests/cases/cpp/function_output_multi/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  int a;
+  int b;
+
+  function void two(output int p, output int q);
+    p = 3;
+    q = 7;
+  endfunction
+
+  initial begin
+    two(a, b);
+  end
+endmodule

--- a/tests/cases/cpp/function_output_scalar/case.yaml
+++ b/tests/cases/cpp/function_output_scalar/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.function_output_scalar
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: 5

--- a/tests/cases/cpp/function_output_scalar/main.sv
+++ b/tests/cases/cpp/function_output_scalar/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  int x;
+
+  function void get_five(output int v);
+    v = 5;
+  endfunction
+
+  initial begin
+    x = 99;
+    get_five(x);
+  end
+endmodule

--- a/tests/cases/errors/call_output_nested_expression/case.yaml
+++ b/tests/cases/errors/call_output_nested_expression/case.yaml
@@ -1,0 +1,16 @@
+id: errors.call_output_nested_expression
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "statement position"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/call_output_nested_expression/main.sv
+++ b/tests/cases/errors/call_output_nested_expression/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  int a;
+  int b;
+
+  function int g(output int o);
+    o = 5;
+    return 3;
+  endfunction
+
+  initial begin
+    a = b + g(b);
+  end
+endmodule


### PR DESCRIPTION
## Summary

This adds `output` and `inout` formal arguments for user-defined subroutines (LRM 13.5), building on the value-returning/`input` support from F1. `output` formals copy out at return and `inout` formals copy in at the call and out at return; multiple outputs, mixed directions, and the nonvoid case (`lhs = f(in, out)`) all work. The default direction is `input` with subsequent formals inheriting the previous direction and data type, which the frontend resolves.

## Design

The copy-in-copy-out is realized as a HIR-to-MIR desugar, keeping MIR a 1-to-1 reflection of the emitted C++ and the backend a dumb printer. A call in statement position whose callee has a non-`input` formal lowers to a block: a fresh local per writeback formal (default-initialized for `output`, copy-in initialized for `inout`), the call with those locals bound to the formals by reference, then a copy-out assignment of each local back to its actual lvalue. The copy-out goes through the actual's own write path, which is why the caller owns it rather than the callee: when the actual is an observable variable the write must trigger its normal scheduling, and only the calling scope can name it. Isolating the formal in a fresh local also gives the LRM-defined value when a body reaches an actual it was also passed as `output`.

The backend renders `output` / `inout` formals as C++ reference parameters and is otherwise unchanged. The desugar reads formal directions and types from the HIR declaration through the scope-lowering state, so a call resolves a peer's formals even across a forward or mutual reference. A call with `output` / `inout` actuals nested inside a larger expression is rejected with a diagnostic; it needs the call hoisted out of the expression, which is deferred. `ref` / `const ref` are likewise rejected for now.

A small builder pair (`AppendStmt`, `AppendLocal`) encapsulates the synthesized-statement boilerplate on the procedural-scope lowering state, and the existing LRM 11.4.12 destructuring desugar is moved onto it.

## Testing

New cpp cases cover scalar `output` and `inout`, multiple outputs, mixed directions, the observable-aliasing case, the nonvoid `lhs = f(in, out)` form, and 4-state `output` default initialization; an error case locks in the nested-expression rejection. `bazel test //...` passes.