### PR TITLE
Add %c format specifier and make print backend type-driven

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -113,7 +113,10 @@ cc_library(
     hdrs = glob(["include/lyra/mir/*.hpp"]),
     includes = ["include"],
     visibility = ["//visibility:public"],
-    deps = [":support"],
+    deps = [
+        ":support",
+        ":value",
+    ],
 )
 
 cc_library(

--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -7,7 +7,10 @@ since the test harness can only probe a variable whose type has an implemented s
 
 ## Sub-Steps
 
-- [ ] DI1 -- `%c` (char): low 7 bits of an integral arg as ASCII.
+- [x] DI1 -- `%c` (char): low byte of an integral argument as ASCII (LRM 21.2.1.1 example). The low
+      byte's X/Z poison collapses to a single character following simulator convention -- any X bit
+      yields `x`, otherwise any Z bit yields `z`. Width / precision modifiers are rejected by the
+      slang frontend, so the lowered form is always a single character.
 - [ ] DI2 -- `%t` (time): formatted against the active timescale. Requires a time variant in the
       runtime value surface and time-unit awareness on the format spec.
 - [x] DI3 -- `%f` / `%e` / `%g` (real). Default precision 6 per LRM Table 21-2. Coverage tracked

--- a/include/lyra/mir/runtime_print.hpp
+++ b/include/lyra/mir/runtime_print.hpp
@@ -9,27 +9,9 @@
 
 #include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/type_id.hpp"
+#include "lyra/value/format.hpp"
 
 namespace lyra::mir {
-
-enum class PrintKind : std::uint8_t {
-  kDisplay,
-  kWrite,
-  kFDisplay,
-  kFWrite,
-};
-
-enum class FormatKind : std::uint8_t {
-  kDecimal,
-  kHex,
-  kBinary,
-  kOctal,
-  kString,
-  kRealDecimal,
-  kRealExponential,
-  kRealGeneral,
-  kAssignmentPattern,
-};
 
 struct FormatModifiers {
   std::int32_t width = -1;
@@ -39,11 +21,11 @@ struct FormatModifiers {
 };
 
 struct FormatSpec {
-  FormatKind kind;
+  value::FormatKind kind;
   FormatModifiers modifiers;
   std::int32_t timeunit_power;
 
-  FormatSpec(FormatKind k, FormatModifiers m, std::int32_t tp = 0)
+  FormatSpec(value::FormatKind k, FormatModifiers m, std::int32_t tp = 0)
       : kind(k), modifiers(m), timeunit_power(tp) {
   }
 };
@@ -65,12 +47,13 @@ struct RuntimePrintValue {
 using RuntimePrintItem = std::variant<RuntimePrintLiteral, RuntimePrintValue>;
 
 struct RuntimePrintCall {
-  PrintKind kind;
+  value::PrintKind kind;
   std::optional<ExprId> descriptor;
   std::vector<RuntimePrintItem> items;
 
   RuntimePrintCall(
-      PrintKind k, std::optional<ExprId> d, std::vector<RuntimePrintItem> i)
+      value::PrintKind k, std::optional<ExprId> d,
+      std::vector<RuntimePrintItem> i)
       : kind(k), descriptor(d), items(std::move(i)) {
   }
 };

--- a/include/lyra/value/format.hpp
+++ b/include/lyra/value/format.hpp
@@ -25,6 +25,7 @@ enum class FormatKind : std::uint8_t {
   kBinary,
   kOctal,
   kString,
+  kChar,
   kRealDecimal,
   kRealExponential,
   kRealGeneral,

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -31,49 +31,51 @@ auto BoolLiteral(bool b) -> std::string_view {
   return b ? "true" : "false";
 }
 
-auto RenderRuntimePrintKind(mir::PrintKind k) -> std::string_view {
+auto RenderPrintKindLiteral(value::PrintKind k) -> std::string_view {
   switch (k) {
-    case mir::PrintKind::kDisplay:
+    case value::PrintKind::kDisplay:
       return "lyra::value::PrintKind::kDisplay";
-    case mir::PrintKind::kWrite:
+    case value::PrintKind::kWrite:
       return "lyra::value::PrintKind::kWrite";
-    case mir::PrintKind::kFDisplay:
+    case value::PrintKind::kFDisplay:
       return "lyra::value::PrintKind::kFDisplay";
-    case mir::PrintKind::kFWrite:
+    case value::PrintKind::kFWrite:
       return "lyra::value::PrintKind::kFWrite";
   }
-  throw InternalError("RenderRuntimePrintKind: unknown PrintKind");
+  throw InternalError("RenderPrintKindLiteral: unknown PrintKind");
 }
 
-auto RenderRuntimeFormatKind(mir::FormatKind k) -> std::string_view {
+auto RenderFormatKindLiteral(value::FormatKind k) -> std::string_view {
   switch (k) {
-    case mir::FormatKind::kDecimal:
+    case value::FormatKind::kDecimal:
       return "lyra::value::FormatKind::kDecimal";
-    case mir::FormatKind::kHex:
+    case value::FormatKind::kHex:
       return "lyra::value::FormatKind::kHex";
-    case mir::FormatKind::kBinary:
+    case value::FormatKind::kBinary:
       return "lyra::value::FormatKind::kBinary";
-    case mir::FormatKind::kOctal:
+    case value::FormatKind::kOctal:
       return "lyra::value::FormatKind::kOctal";
-    case mir::FormatKind::kString:
+    case value::FormatKind::kString:
       return "lyra::value::FormatKind::kString";
-    case mir::FormatKind::kRealDecimal:
+    case value::FormatKind::kChar:
+      return "lyra::value::FormatKind::kChar";
+    case value::FormatKind::kRealDecimal:
       return "lyra::value::FormatKind::kRealDecimal";
-    case mir::FormatKind::kRealExponential:
+    case value::FormatKind::kRealExponential:
       return "lyra::value::FormatKind::kRealExponential";
-    case mir::FormatKind::kRealGeneral:
+    case value::FormatKind::kRealGeneral:
       return "lyra::value::FormatKind::kRealGeneral";
-    case mir::FormatKind::kAssignmentPattern:
+    case value::FormatKind::kAssignmentPattern:
       return "lyra::value::FormatKind::kAssignmentPattern";
   }
-  throw InternalError("RenderRuntimeFormatKind: unknown FormatKind");
+  throw InternalError("RenderFormatKindLiteral: unknown FormatKind");
 }
 
 auto RenderFormatSpecInit(const mir::FormatSpec& spec) -> std::string {
   return std::format(
       "lyra::value::FormatSpec{{.kind = {}, .width = {}, .precision = {}, "
       ".zero_pad = {}, .left_align = {}, .timeunit_power = {}}}",
-      RenderRuntimeFormatKind(spec.kind), spec.modifiers.width,
+      RenderFormatKindLiteral(spec.kind), spec.modifiers.width,
       spec.modifiers.precision, BoolLiteral(spec.modifiers.zero_pad),
       BoolLiteral(spec.modifiers.left_align), spec.timeunit_power);
 }
@@ -83,17 +85,12 @@ auto RenderRuntimeValueViewInit(
     -> diag::Result<std::string> {
   const auto& type = ctx.Unit().GetType(v.type);
 
-  // `%s` operands always reach the runtime as a lyra::value::String --
-  // string-typed variables emit the variable directly, and bit-vector
-  // literals reach mir::StringLiteral which renders as a String{...} ctor.
-  // (Conversion from a bit-vector expression of integral type is gated
-  // behind the bit-vector-to-string conversion path.)
-  if (v.spec.kind == mir::FormatKind::kString) {
-    auto operand_or = RenderExpr(ctx, ctx.Expr(v.value));
-    if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-    return std::format(
-        "lyra::value::RuntimeValueView::String(({}).View())", *operand_or);
-  }
+  // The view init is purely type-driven: a RuntimePrintValue's operand type
+  // determines which RuntimeValueView constructor to call. The format spec
+  // is forwarded unchanged to the runtime, which interprets it within the
+  // operand-type-specific formatter. Any spec/operand mismatch (e.g. `%s`
+  // on a bit vector) must be resolved upstream of the backend -- either at
+  // HIR -> MIR via an explicit ConversionExpr, or rejected as unsupported.
 
   if (type.IsIntegralPacked()) {
     auto operand_or = RenderExpr(ctx, ctx.Expr(v.value));
@@ -159,7 +156,7 @@ auto RenderRuntimePrintCall(
         "file-output runtime print is not yet implemented in cpp emit",
         diag::UnsupportedCategory::kFeature);
   }
-  const std::string_view kind_literal = RenderRuntimePrintKind(call.kind);
+  const std::string_view kind_literal = RenderPrintKindLiteral(call.kind);
 
   // Empty items: pass an explicit empty span. Avoids relying on the
   // `std::array<T, 0>` to `std::span<const T>` conversion path, which is

--- a/src/lyra/lowering/hir_to_mir/lower_deferred_check.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_deferred_check.cpp
@@ -169,7 +169,7 @@ auto BuildDiagnosticThenScope(
         mir::RuntimePrintValue(
             count_read_id, int32_type,
             mir::FormatSpec(
-                mir::FormatKind::kDecimal, mir::FormatModifiers{})));
+                value::FormatKind::kDecimal, mir::FormatModifiers{})));
     items.emplace_back(mir::RuntimePrintLiteral{.text = verdict.suffix_text});
   }
 

--- a/src/lyra/lowering/hir_to_mir/lower_print.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_print.cpp
@@ -21,14 +21,14 @@ namespace lyra::lowering::hir_to_mir {
 
 namespace {
 
-auto ToMirPrintKind(const support::PrintSystemSubroutineInfo& info)
-    -> mir::PrintKind {
+auto ToValuePrintKind(const support::PrintSystemSubroutineInfo& info)
+    -> value::PrintKind {
   if (info.sink_kind == support::PrintSinkKind::kStdout) {
-    return info.append_newline ? mir::PrintKind::kDisplay
-                               : mir::PrintKind::kWrite;
+    return info.append_newline ? value::PrintKind::kDisplay
+                               : value::PrintKind::kWrite;
   }
-  return info.append_newline ? mir::PrintKind::kFDisplay
-                             : mir::PrintKind::kFWrite;
+  return info.append_newline ? value::PrintKind::kFDisplay
+                             : value::PrintKind::kFWrite;
 }
 
 }  // namespace
@@ -58,7 +58,7 @@ auto LowerPrintSystemSubroutineCall(
       .data =
           mir::RuntimeCallExpr{
               .call = mir::RuntimePrintCall(
-                  ToMirPrintKind(print), std::nullopt, std::move(*items_or))},
+                  ToValuePrintKind(print), std::nullopt, std::move(*items_or))},
       .type = unit_state.Builtins().void_type};
 }
 

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -19,8 +19,10 @@
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/runtime_print.hpp"
+#include "lyra/mir/type.hpp"
 #include "lyra/support/format.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -31,35 +33,35 @@ auto SpecCharFor(support::FormatDirectiveKind k) -> std::string_view {
   switch (k) {
     case support::FormatDirectiveKind::kTime:
       return "t";
-    case support::FormatDirectiveKind::kChar:
-      return "c";
     default:
       return "?";
   }
 }
 
-auto ToMirFormatKind(support::FormatDirectiveKind k) -> mir::FormatKind {
+auto ToValueFormatKind(support::FormatDirectiveKind k) -> value::FormatKind {
   switch (k) {
     case support::FormatDirectiveKind::kDecimal:
-      return mir::FormatKind::kDecimal;
+      return value::FormatKind::kDecimal;
     case support::FormatDirectiveKind::kHex:
-      return mir::FormatKind::kHex;
+      return value::FormatKind::kHex;
     case support::FormatDirectiveKind::kBinary:
-      return mir::FormatKind::kBinary;
+      return value::FormatKind::kBinary;
     case support::FormatDirectiveKind::kOctal:
-      return mir::FormatKind::kOctal;
+      return value::FormatKind::kOctal;
     case support::FormatDirectiveKind::kString:
-      return mir::FormatKind::kString;
+      return value::FormatKind::kString;
+    case support::FormatDirectiveKind::kChar:
+      return value::FormatKind::kChar;
     case support::FormatDirectiveKind::kRealDecimal:
-      return mir::FormatKind::kRealDecimal;
+      return value::FormatKind::kRealDecimal;
     case support::FormatDirectiveKind::kRealExponential:
-      return mir::FormatKind::kRealExponential;
+      return value::FormatKind::kRealExponential;
     case support::FormatDirectiveKind::kRealGeneral:
-      return mir::FormatKind::kRealGeneral;
+      return value::FormatKind::kRealGeneral;
     case support::FormatDirectiveKind::kAssignmentPattern:
-      return mir::FormatKind::kAssignmentPattern;
+      return value::FormatKind::kAssignmentPattern;
     default:
-      throw InternalError("ToMirFormatKind: not a value-format kind");
+      throw InternalError("ToValueFormatKind: not a value-format kind");
   }
 }
 
@@ -83,8 +85,28 @@ auto BuildPrintValueItem(
       unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
       hir_proc.exprs.at(hir_arg.value));
   if (!lowered_or) return std::unexpected(std::move(lowered_or.error()));
-  const mir::TypeId type = lowered_or->type;
-  const mir::ExprId value = proc_scope_state.AddExpr(*std::move(lowered_or));
+  mir::Expr lowered = *std::move(lowered_or);
+
+  // %s consumes a runtime String. Slang types SV string literals as packed
+  // bit vectors (LRM 5.9), so a `$display("%s", "hello")` arg arrives here
+  // with a packed-array type. Insert an implicit ConversionExpr targeting
+  // StringType so the backend's RuntimePrintValue rendering stays purely
+  // type-driven. Non-literal integral operands also flow through this same
+  // path -- when slang's bit-vector-to-string conversion lands at the
+  // operand level, this becomes a no-op; until then the conversion is the
+  // single chokepoint that records the semantic.
+  if (spec.kind == value::FormatKind::kString &&
+      unit_state.GetType(lowered.type).Kind() != mir::TypeKind::kString) {
+    const mir::ExprId inner = proc_scope_state.AddExpr(std::move(lowered));
+    lowered = mir::Expr{
+        .data =
+            mir::ConversionExpr{
+                .operand = inner, .kind = mir::ConversionKind::kImplicit},
+        .type = unit_state.Builtins().string};
+  }
+
+  const mir::TypeId type = lowered.type;
+  const mir::ExprId value = proc_scope_state.AddExpr(std::move(lowered));
   return mir::RuntimePrintValue(value, type, std::move(spec));
 }
 
@@ -108,7 +130,6 @@ auto BuildPrintItemFromDirective(
           diag::UnsupportedCategory::kFeature);
 
     case support::FormatDirectiveKind::kTime:
-    case support::FormatDirectiveKind::kChar:
       return diag::Unsupported(
           span, diag::DiagCode::kFormatSpecifierNotImplemented,
           std::format(
@@ -116,6 +137,7 @@ auto BuildPrintItemFromDirective(
               SpecCharFor(directive.kind)),
           diag::UnsupportedCategory::kFeature);
 
+    case support::FormatDirectiveKind::kChar:
     case support::FormatDirectiveKind::kDecimal:
     case support::FormatDirectiveKind::kHex:
     case support::FormatDirectiveKind::kBinary:
@@ -135,7 +157,7 @@ auto BuildPrintItemFromDirective(
           unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
           hir_arg,
           mir::FormatSpec(
-              ToMirFormatKind(directive.kind),
+              ToValueFormatKind(directive.kind),
               ToMirFormatModifiers(directive.modifiers)));
     }
   }
@@ -198,7 +220,7 @@ auto BuildRuntimePrintItemsFromCallArgs(
     auto item_or = BuildPrintValueItem(
         unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
         args[cursor],
-        mir::FormatSpec(mir::FormatKind::kDecimal, mir::FormatModifiers{}));
+        mir::FormatSpec(value::FormatKind::kDecimal, mir::FormatModifiers{}));
     if (!item_or) return std::unexpected(std::move(item_or.error()));
     items.push_back(*std::move(item_or));
     ++cursor;

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -930,7 +930,7 @@ class MirDumper {
     Line(
         std::format(
             "RuntimePrintCall kind={} descriptor={} items={}",
-            FormatMirPrintKind(call.kind),
+            DumpPrintKindLabel(call.kind),
             call.descriptor.has_value()
                 ? std::format("Expr[{}]", call.descriptor->value)
                 : std::string("stdout"),
@@ -979,7 +979,7 @@ class MirDumper {
                       "zero_pad={}, "
                       "left_align={}, timeunit_power={})",
                       i, v.value.value, v.type.value,
-                      FormatMirFormatKind(v.spec.kind), v.spec.modifiers.width,
+                      DumpFormatKindLabel(v.spec.kind), v.spec.modifiers.width,
                       v.spec.modifiers.precision,
                       v.spec.modifiers.zero_pad ? "true" : "false",
                       v.spec.modifiers.left_align ? "true" : "false",
@@ -1008,42 +1008,44 @@ class MirDumper {
     throw InternalError("FormatMirDiagnosticSeverity: unknown severity");
   }
 
-  static auto FormatMirPrintKind(PrintKind k) -> std::string_view {
+  static auto DumpPrintKindLabel(value::PrintKind k) -> std::string_view {
     switch (k) {
-      case PrintKind::kDisplay:
+      case value::PrintKind::kDisplay:
         return "kDisplay";
-      case PrintKind::kWrite:
+      case value::PrintKind::kWrite:
         return "kWrite";
-      case PrintKind::kFDisplay:
+      case value::PrintKind::kFDisplay:
         return "kFDisplay";
-      case PrintKind::kFWrite:
+      case value::PrintKind::kFWrite:
         return "kFWrite";
     }
-    throw InternalError("FormatMirPrintKind: unknown PrintKind");
+    throw InternalError("DumpPrintKindLabel: unknown value::PrintKind");
   }
 
-  static auto FormatMirFormatKind(FormatKind k) -> std::string_view {
+  static auto DumpFormatKindLabel(value::FormatKind k) -> std::string_view {
     switch (k) {
-      case FormatKind::kDecimal:
+      case value::FormatKind::kDecimal:
         return "kDecimal";
-      case FormatKind::kHex:
+      case value::FormatKind::kHex:
         return "kHex";
-      case FormatKind::kBinary:
+      case value::FormatKind::kBinary:
         return "kBinary";
-      case FormatKind::kOctal:
+      case value::FormatKind::kOctal:
         return "kOctal";
-      case FormatKind::kString:
+      case value::FormatKind::kString:
         return "kString";
-      case FormatKind::kRealDecimal:
+      case value::FormatKind::kChar:
+        return "kChar";
+      case value::FormatKind::kRealDecimal:
         return "kRealDecimal";
-      case FormatKind::kRealExponential:
+      case value::FormatKind::kRealExponential:
         return "kRealExponential";
-      case FormatKind::kRealGeneral:
+      case value::FormatKind::kRealGeneral:
         return "kRealGeneral";
-      case FormatKind::kAssignmentPattern:
+      case value::FormatKind::kAssignmentPattern:
         return "kAssignmentPattern";
     }
-    throw InternalError("FormatMirFormatKind: unknown FormatKind");
+    throw InternalError("DumpFormatKindLabel: unknown value::FormatKind");
   }
 
   static auto FormatStringLiteral(std::string_view s) -> std::string {

--- a/src/lyra/value/integral_format.cpp
+++ b/src/lyra/value/integral_format.cpp
@@ -299,6 +299,31 @@ auto FormatDecimalNumeric(const IntegralValueView& v) -> std::string {
   return out;
 }
 
+// LRM 21.2.1.1 example: %c emits the low byte as an ASCII character (e.g.
+// rval=101 -> 'e'). X/Z handling follows the Verilog simulator convention:
+// any X bit in the low byte collapses to "x"; otherwise any Z bit collapses
+// to "z"; otherwise the byte's value is the ASCII code.
+auto FormatCharBody(const IntegralValueView& v) -> std::string {
+  std::uint8_t value_byte = 0;
+  std::uint8_t unknown_byte = 0;
+  const std::uint64_t bits = std::min<std::uint64_t>(8U, v.BitWidth());
+  for (std::uint64_t i = 0; i < bits; ++i) {
+    if (ValueBit(v, i)) {
+      value_byte |= static_cast<std::uint8_t>(1U << i);
+    }
+    if (UnknownBit(v, i)) {
+      unknown_byte |= static_cast<std::uint8_t>(1U << i);
+    }
+  }
+  if (unknown_byte != 0U) {
+    const std::uint8_t x_bits = value_byte & unknown_byte;
+    return x_bits != 0U ? "x" : "z";
+  }
+  std::string out;
+  out.push_back(static_cast<char>(value_byte));
+  return out;
+}
+
 auto FormatDecimalBody(const IntegralValueView& v) -> std::string {
   switch (SummarizeUnknowns(v)) {
     case UnknownSummary::kNone:
@@ -327,6 +352,7 @@ auto AutoWidthFor(FormatKind kind, std::uint64_t bit_width) -> std::int32_t {
       return static_cast<std::int32_t>((bit_width + 2U) / 3U);
     case FormatKind::kDecimal:
     case FormatKind::kString:
+    case FormatKind::kChar:
     case FormatKind::kRealDecimal:
     case FormatKind::kRealExponential:
     case FormatKind::kRealGeneral:
@@ -376,6 +402,9 @@ auto FormatIntegral(const FormatSpec& spec, const IntegralValueView& v)
       break;
     case FormatKind::kOctal:
       body = FormatOctalBody(v);
+      break;
+    case FormatKind::kChar:
+      body = FormatCharBody(v);
       break;
     case FormatKind::kString:
       throw InternalError(

--- a/tests/cases/cpp/display_c_ascii/case.yaml
+++ b/tests/cases/cpp/display_c_ascii/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.display_c_ascii
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      A
+      a
+      0

--- a/tests/cases/cpp/display_c_ascii/main.sv
+++ b/tests/cases/cpp/display_c_ascii/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  logic [7:0] c;
+  initial begin
+    c = 8'h41;
+    $display("%c", c);
+    c = 8'h61;
+    $display("%c", c);
+    c = 8'h30;
+    $display("%c", c);
+  end
+endmodule

--- a/tests/cases/cpp/display_c_low_byte/case.yaml
+++ b/tests/cases/cpp/display_c_low_byte/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.display_c_low_byte
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      rval has e ascii character value

--- a/tests/cases/cpp/display_c_low_byte/main.sv
+++ b/tests/cases/cpp/display_c_low_byte/main.sv
@@ -1,0 +1,9 @@
+// LRM 21.2.1.1 example: %c emits the low byte of an integral argument
+// (the verbatim example uses `logic [31:0]`).
+module Top;
+  logic [31:0] rval;
+  initial begin
+    rval = 101;
+    $display("rval has %c ascii character value", rval);
+  end
+endmodule

--- a/tests/cases/cpp/display_c_partial_x/case.yaml
+++ b/tests/cases/cpp/display_c_partial_x/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.display_c_partial_x
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      x

--- a/tests/cases/cpp/display_c_partial_x/main.sv
+++ b/tests/cases/cpp/display_c_partial_x/main.sv
@@ -1,0 +1,8 @@
+// Partial X collapses to lowercase x for %c (any X bit dominates).
+module Top;
+  logic [7:0] c;
+  initial begin
+    c = 8'b0000_xxxx;
+    $display("%c", c);
+  end
+endmodule

--- a/tests/cases/cpp/display_c_x/case.yaml
+++ b/tests/cases/cpp/display_c_x/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.display_c_x
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      x

--- a/tests/cases/cpp/display_c_x/main.sv
+++ b/tests/cases/cpp/display_c_x/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  logic [7:0] c;
+  initial begin
+    c = 8'bxxxx_xxxx;
+    $display("%c", c);
+  end
+endmodule

--- a/tests/cases/cpp/display_c_z/case.yaml
+++ b/tests/cases/cpp/display_c_z/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.display_c_z
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      z

--- a/tests/cases/cpp/display_c_z/main.sv
+++ b/tests/cases/cpp/display_c_z/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  logic [7:0] c;
+  initial begin
+    c = 8'bzzzz_zzzz;
+    $display("%c", c);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Wires up the `%c` (char) format specifier from parse through MIR through runtime, and removes the last spec-kind smartness from the cpp backend so MIR -> C++ stays a mechanical translation. As a side effect, folds the mirrored `mir::FormatKind` / `mir::PrintKind` enums into the canonical `value::FormatKind` / `value::PrintKind`, so adding a new print kind no longer requires editing three parallel enums.

`%c` follows LRM 21.2.1.1 (the verbatim example, `rval = 101` -> `'e'`): the low byte of the integral operand becomes the ASCII code. X / Z handling matches the existing simulator convention -- any X bit in the low byte collapses to `x`, any Z bit collapses to `z`. Slang's frontend rejects width and precision modifiers on `%c`, so the lowered form is always a single character.

## Design

Three changes ride together because they all live on the same "what does the cpp print backend know" axis. Splitting them would leave the asymmetry in place for one PR cycle.

1. `value::FormatKind::kChar` plus the integral runtime formatter and the parser-to-MIR mapping. Display.md DI1 marks done.

2. Removed the `if (v.spec.kind == kString)` early-exit in `render_print.cpp`. The cpp backend's view-init for a `RuntimePrintValue` is now purely operand-type-driven: IntegralPacked goes to `FromPackedArray`, String goes to `String(op.View())`, real goes to `Real64`, etc. The format spec is forwarded unchanged to the runtime. To keep `$display("%s", "hello")` working under the new contract -- slang types SV string literals as packed bit vectors per LRM 5.9 -- HIR -> MIR's `BuildPrintValueItem` inserts an implicit `mir::ConversionExpr` to `StringType` when the operand of a `%s` is not already a string. The conversion now lives in IR, where it can also be the chokepoint for non-literal integral operands when that conversion lands.

3. Folded the mirrored `mir::FormatKind` and `mir::PrintKind` into the canonical `value::FormatKind` and `value::PrintKind`. The MIR header now includes `lyra/value/format.hpp` and references the value enums directly; `RenderRuntimeFormatKind` / `RenderRuntimePrintKind` become straight `value::*` -> source-name mappers (renamed to `RenderFormatKindLiteral` / `RenderPrintKindLiteral`); the dump helpers (`DumpPrintKindLabel` / `DumpFormatKindLabel`) follow. Adding a new format kind now requires four edits (support enum, support -> value mapping, runtime formatter, consumer arms) instead of six.

A lingering "type lie" remains: `mir::StringLiteral` still carries slang's bit-vector type, but the backend renders it as a `lyra::value::String{...}` value. The new ConversionExpr is the IR-level marker for the conversion that needs to happen; the backend's existing `RenderConversionExpr` string-literal lift fall-through transparently no-ops it for the literal case. Cleaning up the deeper lie (have `mir::StringLiteral` render as a PackedArray, route everything through ConversionExpr) is a larger refactor that touches the runtime and is out of scope here.

## Testing

Five new `cpp_run` cases under `tests/cases/cpp/`:

- `display_c_ascii` -- `'A'`, `'a'`, `'0'`
- `display_c_low_byte` -- the LRM 21.2.1.1 example verbatim (`logic [31:0] rval = 101` -> `'e'`)
- `display_c_x` -- 8-bit all-X -> `x`
- `display_c_z` -- 8-bit all-Z -> `z`
- `display_c_partial_x` -- `8'b0000_xxxx` -> `x` (X bit dominates)

`bazel test //...` passes locally.