### PR TITLE
Add structured and replicated unpacked assignment patterns

### DIFF
--- a/docs/progress/unpacked.md
+++ b/docs/progress/unpacked.md
@@ -13,14 +13,15 @@ Done when:
 
 ## Actionable
 
-U1 and U2 are done; U3..U5 are open. U1 established the IR shape, the literal-init path, and element
-read; U2 added element write across blocking, non-blocking, and compound forms.
+U1..U3 are done; U4..U5 are open. U1 established the IR shape, the literal-init path, and element
+read; U2 added element write across blocking, non-blocking, and compound forms; U3 completed the
+remaining assignment-pattern forms (default fill, index keys, replication, and nested combinations).
 
 | Item | Status                                                       |
 | ---- | ------------------------------------------------------------ |
 | U1   | Done: type infrastructure + literal init + element read      |
 | U2   | Done: element write (blocking, NBA, compound)                |
-| U3   | Open: structured and replicated assignment patterns          |
+| U3   | Done: structured and replicated assignment patterns          |
 | U4   | Open: whole-array assignment, equality, constant-width slice |
 | U5   | Open: OOB read returning element default, base ranges        |
 
@@ -46,9 +47,10 @@ The numeric IDs are stable references and do not imply execution order beyond U1
 
 ### Structured and replicated patterns
 
-- [ ] U3 -- Structured assignment pattern (`'{default: v}`, `'{i: v, j: v}`) and replicated
-      assignment pattern (`'{N{v}}`) per LRM 10.9.2 / 10.9.3. Closes the `unpacked_array_constants`
-      archive cases that depend on `default:` or index labels.
+- [x] U3 -- Structured assignment pattern (`'{default: v}`, `'{i: v, j: v}`, and the mixed form) and
+      replicated assignment pattern (`'{N{v}}`, including multi-item items and arbitrarily nested
+      forms across multi-dimensional targets) per LRM 10.9.1 / 10.9.2. Closes the
+      `unpacked_array_constants` archive cases that depend on `default:` or index labels.
 
 ### Whole-array operations
 

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -1152,6 +1152,37 @@ auto LowerAssignmentPatternFromElementsStructural(
   };
 }
 
+auto LowerReplicatedAssignmentPatternExprStructural(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    ScopeLoweringState& scope_state, const ScopeStack& stack,
+    const slang::ast::ReplicatedAssignmentPatternExpression& rp,
+    const slang::ast::Expression& expr, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  auto count_or = LowerStructuralExpr(
+      unit_facts, unit_state, scope_state, stack, rp.count());
+  if (!count_or) return std::unexpected(std::move(count_or.error()));
+  const hir::ExprId count_id = scope_state.AddExpr(*std::move(count_or));
+  std::vector<hir::ExprId> item_ids;
+  item_ids.reserve(rp.elements().size());
+  for (const auto* elem : rp.elements()) {
+    auto lowered =
+        LowerStructuralExpr(unit_facts, unit_state, scope_state, stack, *elem);
+    if (!lowered) return std::unexpected(std::move(lowered.error()));
+    item_ids.push_back(scope_state.AddExpr(*std::move(lowered)));
+  }
+  return hir::Expr{
+      .type = *type_id,
+      .data =
+          hir::AssignmentPatternReplicationExpr{
+              .count = count_id,
+              .items = std::move(item_ids),
+          },
+      .span = span,
+  };
+}
+
 auto LowerConversionExprStructural(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ScopeLoweringState& scope_state, const ScopeStack& stack,
@@ -1565,6 +1596,12 @@ auto LowerStructuralExpr(
       return LowerAssignmentPatternFromElementsStructural(
           unit_facts, unit_state, scope_state, stack,
           expr.as<slang::ast::StructuredAssignmentPatternExpression>(), expr,
+          span);
+
+    case slang::ast::ExpressionKind::ReplicatedAssignmentPattern:
+      return LowerReplicatedAssignmentPatternExprStructural(
+          unit_facts, unit_state, scope_state, stack,
+          expr.as<slang::ast::ReplicatedAssignmentPatternExpression>(), expr,
           span);
 
     default:

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -5,6 +5,7 @@
 #include <format>
 #include <memory>
 #include <optional>
+#include <span>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -55,6 +56,39 @@ auto GetAggregateFields(const hir::Type& t)
   }
   throw InternalError(
       "GetAggregateFields: base type is not a packed struct or union");
+}
+
+// LRM 10.9.1: the replication count of an assignment pattern is a constant
+// expression; slang has already evaluated it to an integer literal. The
+// unpacked-target path uses this value to materialize the element list at
+// compile time (no runtime replication primitive exists for unpacked
+// aggregates -- the C++ mental model is a flat `std::vector` initializer).
+auto ExtractHirLiteralUint64(const hir::Expr& expr) -> std::uint64_t {
+  const auto* primary = std::get_if<hir::PrimaryExpr>(&expr.data);
+  if (primary == nullptr) {
+    throw InternalError(
+        "ExtractHirLiteralUint64: expected a primary expression");
+  }
+  const auto* lit = std::get_if<hir::IntegerLiteral>(&primary->data);
+  if (lit == nullptr) {
+    throw InternalError("ExtractHirLiteralUint64: expected an integer literal");
+  }
+  const auto& c = lit->value;
+  if (c.value_words.empty()) return 0;
+  return c.value_words[0];
+}
+
+auto BuildUnpackedReplicationFlatList(
+    std::span<const mir::ExprId> items_ids, std::uint64_t count,
+    mir::TypeId result_type) -> mir::Expr {
+  std::vector<mir::ExprId> flat;
+  flat.reserve(items_ids.size() * count);
+  for (std::uint64_t i = 0; i < count; ++i) {
+    flat.insert(flat.end(), items_ids.begin(), items_ids.end());
+  }
+  return mir::Expr{
+      .data = mir::ArrayLiteralExpr{.elements = std::move(flat)},
+      .type = result_type};
 }
 
 auto LowerBinaryOp(hir::BinaryOp op) -> mir::BinaryOp {
@@ -1152,6 +1186,12 @@ auto LowerHirAssignmentPatternReplicationExprProc(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     item_ids.push_back(proc_scope_state.AddExpr(*std::move(lowered)));
   }
+  if (std::holds_alternative<mir::UnpackedArrayType>(
+          unit_state.GetType(result_type).data)) {
+    const std::uint64_t count =
+        ExtractHirLiteralUint64(hir_process.exprs.at(a.count.value));
+    return BuildUnpackedReplicationFlatList(item_ids, count, result_type);
+  }
   const mir::ExprId inner_concat_id = proc_scope_state.AddExpr(
       mir::Expr{
           .data = mir::ConcatExpr{.operands = std::move(item_ids)},
@@ -1535,6 +1575,47 @@ auto LowerHirAssignmentPatternExprStructural(
       .type = result_type};
 }
 
+auto LowerHirAssignmentPatternReplicationExprStructural(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ConstructorLoweringState* ctor_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::StructuralScope& scope,
+    const hir::AssignmentPatternReplicationExpr& a,
+    LoopVarLoweringMode loop_var_mode, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
+  std::vector<mir::ExprId> item_ids;
+  item_ids.reserve(a.items.size());
+  for (const auto& id : a.items) {
+    auto lowered = LowerExprImpl(
+        unit_state, scope_state, ctor_state, proc_scope_state, scope,
+        scope.GetExpr(id), loop_var_mode);
+    if (!lowered) return std::unexpected(std::move(lowered.error()));
+    item_ids.push_back(proc_scope_state.AddExpr(*std::move(lowered)));
+  }
+  if (std::holds_alternative<mir::UnpackedArrayType>(
+          unit_state.GetType(result_type).data)) {
+    const std::uint64_t count = ExtractHirLiteralUint64(scope.GetExpr(a.count));
+    return BuildUnpackedReplicationFlatList(item_ids, count, result_type);
+  }
+  const mir::ExprId inner_concat_id = proc_scope_state.AddExpr(
+      mir::Expr{
+          .data = mir::ConcatExpr{.operands = std::move(item_ids)},
+          .type = result_type});
+  auto count_or = LowerExprImpl(
+      unit_state, scope_state, ctor_state, proc_scope_state, scope,
+      scope.GetExpr(a.count), loop_var_mode);
+  if (!count_or) return std::unexpected(std::move(count_or.error()));
+  const mir::ExprId count_id = proc_scope_state.AddExpr(*std::move(count_or));
+  return mir::Expr{
+      .data =
+          mir::ReplicationExpr{
+              .count = count_id,
+              .concat = inner_concat_id,
+          },
+      .type = result_type};
+}
+
 auto LowerHirConversionExprStructural(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
@@ -1648,13 +1729,11 @@ auto LowerExprImpl(
                 unit_state, scope_state, ctor_state, proc_scope_state, scope, a,
                 loop_var_mode, result_type);
           },
-          [](const hir::AssignmentPatternReplicationExpr&)
+          [&](const hir::AssignmentPatternReplicationExpr& a)
               -> diag::Result<mir::Expr> {
-            return diag::Unsupported(
-                diag::DiagCode::kUnsupportedStructuralExpressionForm,
-                "replicated assignment patterns in constructor expressions "
-                "are not yet supported",
-                diag::UnsupportedCategory::kFeature);
+            return LowerHirAssignmentPatternReplicationExprStructural(
+                unit_state, scope_state, ctor_state, proc_scope_state, scope, a,
+                loop_var_mode, result_type);
           },
       },
       expr.data);

--- a/tests/cases/cpp/unpacked_pattern_default_fill/case.yaml
+++ b/tests/cases/cpp/unpacked_pattern_default_fill/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.unpacked_pattern_default_fill
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    p0: 99
+    p1: 99
+    p2: 99
+    p3: 99

--- a/tests/cases/cpp/unpacked_pattern_default_fill/main.sv
+++ b/tests/cases/cpp/unpacked_pattern_default_fill/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int a [4] = '{default: 99};
+  int p0, p1, p2, p3;
+  initial begin
+    p0 = a[0];
+    p1 = a[1];
+    p2 = a[2];
+    p3 = a[3];
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_pattern_index_keys/case.yaml
+++ b/tests/cases/cpp/unpacked_pattern_index_keys/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.unpacked_pattern_index_keys
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    p0: 100
+    p1: 200
+    p2: 300

--- a/tests/cases/cpp/unpacked_pattern_index_keys/main.sv
+++ b/tests/cases/cpp/unpacked_pattern_index_keys/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  int a [3] = '{0: 100, 1: 200, 2: 300};
+  int p0, p1, p2;
+  initial begin
+    p0 = a[0];
+    p1 = a[1];
+    p2 = a[2];
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_pattern_index_with_default/case.yaml
+++ b/tests/cases/cpp/unpacked_pattern_index_with_default/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.unpacked_pattern_index_with_default
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    p0: 1
+    p1: 0
+    p2: 2
+    p3: 0
+    p4: 0

--- a/tests/cases/cpp/unpacked_pattern_index_with_default/main.sv
+++ b/tests/cases/cpp/unpacked_pattern_index_with_default/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  int a [5] = '{0: 1, 2: 2, default: 0};
+  int p0, p1, p2, p3, p4;
+  initial begin
+    p0 = a[0];
+    p1 = a[1];
+    p2 = a[2];
+    p3 = a[3];
+    p4 = a[4];
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_pattern_mixed_nested_2d/case.yaml
+++ b/tests/cases/cpp/unpacked_pattern_mixed_nested_2d/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.unpacked_pattern_mixed_nested_2d
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    p00: 1
+    p01: 2
+    p02: 3
+    p10: 0
+    p11: 0
+    p12: 0

--- a/tests/cases/cpp/unpacked_pattern_mixed_nested_2d/main.sv
+++ b/tests/cases/cpp/unpacked_pattern_mixed_nested_2d/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  int a [2][3] = '{'{1, 2, 3}, '{default: 0}};
+  int p00, p01, p02, p10, p11, p12;
+  initial begin
+    p00 = a[0][0];
+    p01 = a[0][1];
+    p02 = a[0][2];
+    p10 = a[1][0];
+    p11 = a[1][1];
+    p12 = a[1][2];
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_pattern_replicated_multi_item/case.yaml
+++ b/tests/cases/cpp/unpacked_pattern_replicated_multi_item/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.unpacked_pattern_replicated_multi_item
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    p0: 1
+    p1: 2
+    p2: 3
+    p3: 1
+    p4: 2
+    p5: 3

--- a/tests/cases/cpp/unpacked_pattern_replicated_multi_item/main.sv
+++ b/tests/cases/cpp/unpacked_pattern_replicated_multi_item/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  int a [6] = '{2{1, 2, 3}};
+  int p0, p1, p2, p3, p4, p5;
+  initial begin
+    p0 = a[0];
+    p1 = a[1];
+    p2 = a[2];
+    p3 = a[3];
+    p4 = a[4];
+    p5 = a[5];
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_pattern_replicated_nested_2d/case.yaml
+++ b/tests/cases/cpp/unpacked_pattern_replicated_nested_2d/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.unpacked_pattern_replicated_nested_2d
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    p00: 42
+    p01: 42
+    p02: 42
+    p10: 42
+    p11: 42
+    p12: 42

--- a/tests/cases/cpp/unpacked_pattern_replicated_nested_2d/main.sv
+++ b/tests/cases/cpp/unpacked_pattern_replicated_nested_2d/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  int a [2][3] = '{2{'{3{42}}}};
+  int p00, p01, p02, p10, p11, p12;
+  initial begin
+    p00 = a[0][0];
+    p01 = a[0][1];
+    p02 = a[0][2];
+    p10 = a[1][0];
+    p11 = a[1][1];
+    p12 = a[1][2];
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_pattern_replicated_single/case.yaml
+++ b/tests/cases/cpp/unpacked_pattern_replicated_single/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.unpacked_pattern_replicated_single
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    p0: 7
+    p1: 7
+    p2: 7
+    p3: 7

--- a/tests/cases/cpp/unpacked_pattern_replicated_single/main.sv
+++ b/tests/cases/cpp/unpacked_pattern_replicated_single/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int a [4] = '{4{7}};
+  int p0, p1, p2, p3;
+  initial begin
+    p0 = a[0];
+    p1 = a[1];
+    p2 = a[2];
+    p3 = a[3];
+  end
+endmodule


### PR DESCRIPTION
## Summary

Closes U3 of the unpacked workstream. Brings the remaining LRM 10.9 / 10.9.1 / 10.9.2 assignment-pattern forms to fixed-size unpacked arrays: the structured forms `'{default: v}` / `'{i: v}` / mixed index-with-default, and the replicated form `'{N{items}}` including multi-item bodies and arbitrarily nested forms across multi-dimensional targets. Module-scope initializers and procedural assignments share the same path.

## Design

The C++ mental model for an unpacked array literal is a flat `std::vector<T>{...}` initializer. C++ has no `replicate(N, tuple)` operator on sequences, so unpacked replication is purely a SystemVerilog / HIR notation that the HIR-to-MIR boundary flattens; replication is never carried as a runtime concept on the unpacked side. Packed arrays keep `ReplicationExpr` at MIR for `PackedArray::Replicate(...)` since C++ has no bit-level repeat either. This places the asymmetry in the right layer.

Concretely: HIR preserves slang's `count + items` shape; HIR-to-MIR dispatches on the target type and emits an `ArrayLiteralExpr` whose elements are `count` references to the same item ExprIds (no deep-copy, side effects re-evaluate at each position as LRM allows). Structured-pattern forms (`default:`, `i:`, mixed) ride for free because slang's `forFixedArray` already pre-expands them to a flat element list at AST construction time.

## Testing

Seven new YAML cases under `tests/cases/cpp/unpacked_pattern_*` cover default fill, plain index keys, index+default mix, single-value replication, multi-item replication, nested replicated 2D, and mixed structured+positional 2D. Verified by `bazel test //...`.