### PR TITLE
Support multiple top-level modules

### DIFF
--- a/docs/architecture/compilation_unit_model.md
+++ b/docs/architecture/compilation_unit_model.md
@@ -69,3 +69,8 @@ Define what a compilation unit is, what it owns, and the rules that make it self
 If resolving a name inside a compilation unit requires information not reachable from the unit
 itself, the compilation-unit boundary has been violated. The fix is to move ownership inward, not to
 add another lookup path outward.
+
+The term "compilation unit" here is the compiler's own: a module, package, or interface. It is not
+the LRM's "compilation unit" (LRM 3.12.1), which names the `$unit` file-set scope that holds
+declarations lying outside any design element. The two concepts are unrelated; do not conflate them
+when packages or `$unit`-scope declarations enter scope.

--- a/docs/architecture/hierarchy_and_generate.md
+++ b/docs/architecture/hierarchy_and_generate.md
@@ -8,6 +8,8 @@ shared by all consumers: external references, child routing, and construction.
 ## Owns
 
 - The rule that the canonical hierarchy is an object tree, built at construction time.
+- The rule that the object tree is single-rooted at the implicit `$root` scope, which owns every
+  top-level block as a child.
 - The rule that generate constructs are constructor-time mechanisms that build the object tree.
   Generate is not a separate identity or topology system.
 - The rule that a semantically visible generate scope (named, navigable) is represented as a
@@ -40,6 +42,14 @@ shared by all consumers: external references, child routing, and construction.
    and named scope has a corresponding constructed object, and generate-produced objects preserve
    the elaborated index and identity. Reference resolution relies on this faithfulness (see
    `reference_resolution.md`).
+8. The object tree has a single implicit root scope, `$root`, that owns every top-level block as a
+   child. A design with multiple top-level modules (LRM 3.11) is still one tree rooted at `$root`;
+   each elaborated, uninstantiated module is a child of `$root`, not a separate disconnected root.
+   Path identity for a top-level block derives from this ownership, the same as for any other node.
+   One top is the N = 1 case of the same model, not a special case. Which modules are top-level
+   blocks is an elaboration property, distinct from the set of compiled units (see
+   `compilation_unit_model.md`): the two coincide only when nothing is instantiated and must not be
+   collapsed into one set.
 
 ## Boundary to Adjacent Layers
 

--- a/docs/architecture/runtime_model.md
+++ b/docs/architecture/runtime_model.md
@@ -33,6 +33,10 @@ The simulation runs after the constructor returns. Processes get pulled off sche
 resumed. They read and write per-object state. They do not create or destroy objects. The graph
 shape does not change once the simulation starts.
 
+At program entry the runtime constructs every top-level block under the implicit root scope `$root`
+(see `hierarchy_and_generate.md`). A single scheduler then drives the processes of all of them on
+one time axis; multiple top-level modules are one simulation, not several.
+
 ## Generate is not compile-time expansion
 
 A generate-for with 1024 iterations does not produce 1024 things at compile time. Compile-time

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -41,7 +41,8 @@ C  Non-local access substrate
 
 - A gates everything: until more than one module can be compiled as its own unit, there is no second
   object to instantiate, connect, or reference.
-- B gates C: a handle can only be bound once the target instance exists in the object tree.
+- B gates C: a cross-unit reference can only be bound once the target instance exists in the object
+  tree.
 - C gates D and E: both are cross-unit references resolved over the same construction-time path.
 - D and E are independent of each other; their relative order is an open question (see below).
 
@@ -50,7 +51,13 @@ C  Non-local access substrate
 ### Stage A -- Specialization as compilation unit
 
 - [ ] A1 -- More than one module definition compiles in a single run; the design is no longer
-      assumed to be a single top module. Each module is its own independently compiled unit.
+      assumed to be a single top module. Each module is its own independently compiled unit. The LRM
+      permits multiple top-level blocks (LRM 3.11): every elaborated but uninstantiated module is
+      implicitly a top-level block, and all of them sit under one implicit root scope ($root). The
+      program constructs every top-level block as a child of $root and runs them all under a single
+      scheduler on one shared time axis -- there is no single "main" block. This is end-to-end
+      testable with no instantiation edge: two independent top modules each run their own processes
+      under the shared schedule.
 - [ ] A2 -- Inputs are classified into code-shape-affecting (enter the specialization key) versus
       constructor/config inputs (flow in at construction). One compiled artifact exists per distinct
       code shape, not per instance.

--- a/include/lyra/backend/cpp/api.hpp
+++ b/include/lyra/backend/cpp/api.hpp
@@ -1,19 +1,29 @@
 #pragma once
 
+#include <span>
+#include <string>
 #include <vector>
 
 #include "lyra/backend/cpp/artifact.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/compilation_unit.hpp"
-#include "lyra/mir/structural_scope.hpp"
 
 namespace lyra::backend::cpp {
+
+// A top-level block the emitted program constructs under $root: its instance
+// name and the compiled unit whose class is instantiated for it.
+struct TopInstance {
+  std::string name;
+  const mir::CompilationUnit* unit;
+};
 
 auto EmitCppDeclarations(const mir::CompilationUnit& unit)
     -> diag::Result<std::vector<CppArtifact>>;
 
-auto EmitCppHostMain(const mir::StructuralScope& entry_scope) -> CppArtifact;
+auto EmitCppHostMain(std::span<const TopInstance> tops) -> CppArtifact;
 
-auto EmitCpp(const mir::CompilationUnit& unit) -> diag::Result<CppArtifactSet>;
+auto EmitCpp(
+    std::span<const mir::CompilationUnit> units,
+    std::span<const TopInstance> tops) -> diag::Result<CppArtifactSet>;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/compiler/compile.hpp
+++ b/include/lyra/compiler/compile.hpp
@@ -21,7 +21,7 @@ enum class StopAfter : std::uint8_t { kParse, kHir, kMir };
 struct CompileArtifacts {
   std::optional<frontend::ParseResult> parse;
   std::optional<std::vector<hir::ModuleUnit>> hir_units;
-  std::optional<mir::CompilationUnit> mir_unit;
+  std::optional<std::vector<mir::CompilationUnit>> mir_units;
 
   CompileArtifacts() = default;
   CompileArtifacts(const CompileArtifacts&) = delete;

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -52,7 +52,6 @@ enum class DiagCode : std::uint32_t {
   kHostNoInputFiles,
   kHostIoError,
   kHostBuildFailed,
-  kHostExpectedSingleTopModule,
 
   kWarningPedantic,
 };

--- a/include/lyra/driver/cpp_build.hpp
+++ b/include/lyra/driver/cpp_build.hpp
@@ -1,18 +1,22 @@
 #pragma once
 
 #include <filesystem>
+#include <span>
 
+#include "lyra/backend/cpp/api.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/driver/runtime_export.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 
 namespace lyra::driver {
 
-// Assemble a self-contained C++ project for `unit` into `dir`: the generated
-// translation units, a `build.sh` recipe, and a bundled copy of `runtime`. The
-// directory then builds with no external include or link paths.
+// Assemble a self-contained C++ project into `dir`: one translation unit per
+// compiled unit, a program `main` constructing each top in `tops`, a `build.sh`
+// recipe, and a bundled copy of `runtime`. The directory then builds with no
+// external include or link paths.
 auto AssembleProject(
-    const RuntimeLocation& runtime, const mir::CompilationUnit& unit,
+    const RuntimeLocation& runtime, std::span<const mir::CompilationUnit> units,
+    std::span<const backend::cpp::TopInstance> tops,
     const std::filesystem::path& dir) -> diag::Result<void>;
 
 // Build the assembled project in `dir` by invoking the C++ compiler directly
@@ -21,12 +25,13 @@ auto AssembleProject(
 auto BuildProject(const std::filesystem::path& dir)
     -> diag::Result<std::filesystem::path>;
 
-// Emit `unit`'s sources into `work_dir`, build them in place against `runtime`
+// Emit `units`' sources into `work_dir`, build them in place against `runtime`
 // (no bundled copy), execute the result streaming its stdout/stderr, and return
-// its exit code. This is the ephemeral path behind `run`: it never materializes
-// a portable project.
+// its exit code. `tops` are the top-level blocks the program constructs. This
+// is the ephemeral path behind `run`: it never materializes a portable project.
 auto RunInPlace(
-    const RuntimeLocation& runtime, const mir::CompilationUnit& unit,
+    const RuntimeLocation& runtime, std::span<const mir::CompilationUnit> units,
+    std::span<const backend::cpp::TopInstance> tops,
     const std::filesystem::path& work_dir) -> diag::Result<int>;
 
 }  // namespace lyra::driver

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -41,6 +42,13 @@ struct EngineOptions {
 
 [[nodiscard]] auto DefaultEngineOptions() -> EngineOptions;
 
+// One top-level block to install under $root: its instance name and the module
+// object the emitted program constructs for it.
+struct TopBinding {
+  std::string name;
+  Module* module;
+};
+
 class Engine {
  public:
   Engine();
@@ -54,7 +62,7 @@ class Engine {
   auto operator=(Engine&&) -> Engine& = delete;
   ~Engine() = default;
 
-  void BindRoot(std::string root_name, Module& top);
+  void BindDesign(std::span<const TopBinding> tops);
   auto Run() -> int;
 
   auto Stream() -> StreamDispatcher& {

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -1,5 +1,6 @@
 #include <cstddef>
 #include <format>
+#include <span>
 #include <string>
 #include <utility>
 #include <variant>
@@ -391,18 +392,29 @@ auto RenderScopeHeaderFile(
   return out;
 }
 
-auto RenderHostMain(const mir::StructuralScope& entry) -> std::string {
+auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
   std::string out;
   out += "#include <exception>\n";
   out += "#include <iostream>\n";
+  out += "#include <vector>\n";
   out += "\n";
   out += "#include \"lyra/runtime/engine.hpp\"\n";
-  out += "#include \"" + entry.name + ".hpp\"\n";
+  for (const auto& top : tops) {
+    out += "#include \"" + top.unit->structural_scope.name + ".hpp\"\n";
+  }
   out += "\n";
   out += "auto main() -> int {\n";
-  out += "  " + entry.name + " top;\n";
+  for (std::size_t i = 0; i < tops.size(); ++i) {
+    out += "  " + tops[i].unit->structural_scope.name + " top" +
+           std::to_string(i) + ";\n";
+  }
   out += "  lyra::runtime::Engine engine;\n";
-  out += "  engine.BindRoot(\"top\", top);\n";
+  out += "  std::vector<lyra::runtime::TopBinding> tops = {\n";
+  for (std::size_t i = 0; i < tops.size(); ++i) {
+    out += "      {\"" + tops[i].name + "\", &top" + std::to_string(i) + "},\n";
+  }
+  out += "  };\n";
+  out += "  engine.BindDesign(tops);\n";
   out += "  try {\n";
   out += "    return engine.Run();\n";
   out += "  } catch (const std::exception& e) {\n";
@@ -426,18 +438,22 @@ auto EmitCppDeclarations(const mir::CompilationUnit& unit)
   return headers;
 }
 
-auto EmitCppHostMain(const mir::StructuralScope& entry_scope) -> CppArtifact {
-  return {.relpath = "main.cpp", .content = RenderHostMain(entry_scope)};
+auto EmitCppHostMain(std::span<const TopInstance> tops) -> CppArtifact {
+  return {.relpath = "main.cpp", .content = RenderHostMain(tops)};
 }
 
-auto EmitCpp(const mir::CompilationUnit& unit) -> diag::Result<CppArtifactSet> {
+auto EmitCpp(
+    std::span<const mir::CompilationUnit> units,
+    std::span<const TopInstance> tops) -> diag::Result<CppArtifactSet> {
   CppArtifactSet set;
-  auto headers_or = EmitCppDeclarations(unit);
-  if (!headers_or) return std::unexpected(std::move(headers_or.error()));
-  for (auto& h : *headers_or) {
-    set.files.push_back(std::move(h));
+  for (const auto& unit : units) {
+    auto headers_or = EmitCppDeclarations(unit);
+    if (!headers_or) return std::unexpected(std::move(headers_or.error()));
+    for (auto& h : *headers_or) {
+      set.files.push_back(std::move(h));
+    }
   }
-  set.files.push_back(EmitCppHostMain(unit.structural_scope));
+  set.files.push_back(EmitCppHostMain(tops));
   return set;
 }
 

--- a/src/lyra/compiler/compile.cpp
+++ b/src/lyra/compiler/compile.cpp
@@ -1,10 +1,8 @@
 #include "lyra/compiler/compile.hpp"
 
-#include <format>
 #include <utility>
+#include <vector>
 
-#include "lyra/diag/diag_code.hpp"
-#include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/sink.hpp"
 #include "lyra/frontend/load.hpp"
 #include "lyra/lowering/ast_to_hir/lower.hpp"
@@ -50,23 +48,17 @@ auto Compile(
     return result;
   }
 
-  if (result.artifacts.hir_units->size() != 1) {
-    sink.Report(
-        diag::Diagnostic::HostError(
-            diag::DiagCode::kHostExpectedSingleTopModule,
-            std::format(
-                "expected exactly one top module, got {}",
-                result.artifacts.hir_units->size())));
-    return result;
+  std::vector<mir::CompilationUnit> units;
+  units.reserve(result.artifacts.hir_units->size());
+  for (const auto& hir_unit : *result.artifacts.hir_units) {
+    auto mir = lowering::hir_to_mir::LowerModuleUnit(hir_unit);
+    if (!mir) {
+      sink.Report(std::move(mir.error()));
+      return result;
+    }
+    units.push_back(std::move(*mir));
   }
-
-  auto mir = lowering::hir_to_mir::LowerModuleUnit(
-      result.artifacts.hir_units->front());
-  if (!mir) {
-    sink.Report(std::move(mir.error()));
-    return result;
-  }
-  result.artifacts.mir_unit = std::move(*mir);
+  result.artifacts.mir_units = std::move(units);
 
   return result;
 }

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -242,12 +242,6 @@ constexpr std::array kEntries{
             .kind = DiagKind::kHostError,
             .category = std::nullopt,
             .name = "host_build_failed"}},
-    std::pair{
-        DiagCode::kHostExpectedSingleTopModule,
-        DiagCodeInfo{
-            .kind = DiagKind::kHostError,
-            .category = std::nullopt,
-            .name = "host_expected_single_top_module"}},
 
     std::pair{
         DiagCode::kWarningPedantic,

--- a/src/lyra/driver/cli.cpp
+++ b/src/lyra/driver/cli.cpp
@@ -13,6 +13,7 @@
 
 #include <fmt/core.h>
 
+#include "lyra/backend/cpp/api.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/compiler/compile.hpp"
 #include "lyra/diag/diag_code.hpp"
@@ -289,9 +290,20 @@ auto main(int argc, char** argv) -> int {
       return *loc_or;
     };
 
+    auto build_tops = [](const std::vector<lyra::mir::CompilationUnit>& units) {
+      std::vector<lyra::backend::cpp::TopInstance> tops;
+      tops.reserve(units.size());
+      for (const auto& unit : units) {
+        tops.push_back({.name = unit.structural_scope.name, .unit = &unit});
+      }
+      return tops;
+    };
+
     switch (args.cmd) {
       case CommandKind::kDumpMir:
-        fmt::print("{}", lyra::mir::DumpMir(*result.artifacts.mir_unit));
+        for (const auto& unit : *result.artifacts.mir_units) {
+          fmt::print("{}", lyra::mir::DumpMir(unit));
+        }
         return 0;
       case CommandKind::kEmitCpp: {
         auto runtime = resolve_runtime();
@@ -299,8 +311,10 @@ auto main(int argc, char** argv) -> int {
           return 1;
         }
         const std::filesystem::path dir = args.out_dir;
-        auto assembled = lyra::driver::AssembleProject(
-            *runtime, *result.artifacts.mir_unit, dir);
+        const auto& units = *result.artifacts.mir_units;
+        const auto tops = build_tops(units);
+        auto assembled =
+            lyra::driver::AssembleProject(*runtime, units, tops, dir);
         if (!assembled) {
           report(std::move(assembled.error()), mgr);
           return 1;
@@ -314,8 +328,10 @@ auto main(int argc, char** argv) -> int {
           return 1;
         }
         const std::filesystem::path dir = args.out_dir;
-        auto assembled = lyra::driver::AssembleProject(
-            *runtime, *result.artifacts.mir_unit, dir);
+        const auto& units = *result.artifacts.mir_units;
+        const auto tops = build_tops(units);
+        auto assembled =
+            lyra::driver::AssembleProject(*runtime, units, tops, dir);
         if (!assembled) {
           report(std::move(assembled.error()), mgr);
           return 1;
@@ -341,8 +357,10 @@ auto main(int argc, char** argv) -> int {
                   std::move(tmp_or.error())));
           return 1;
         }
-        auto exit_code = lyra::driver::RunInPlace(
-            *runtime, *result.artifacts.mir_unit, *tmp_or);
+        const auto& units = *result.artifacts.mir_units;
+        const auto tops = build_tops(units);
+        auto exit_code =
+            lyra::driver::RunInPlace(*runtime, units, tops, *tmp_or);
         if (!exit_code) {
           report(std::move(exit_code.error()), mgr);
           return 1;

--- a/src/lyra/driver/cpp_build.cpp
+++ b/src/lyra/driver/cpp_build.cpp
@@ -2,6 +2,7 @@
 
 #include <format>
 #include <fstream>
+#include <span>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -53,9 +54,10 @@ auto RenderBuildScript() -> std::string {
 }
 
 auto EmitAndWriteSources(
-    const mir::CompilationUnit& unit, const std::filesystem::path& dir)
-    -> diag::Result<void> {
-  auto set_or = backend::cpp::EmitCpp(unit);
+    std::span<const mir::CompilationUnit> units,
+    std::span<const backend::cpp::TopInstance> tops,
+    const std::filesystem::path& dir) -> diag::Result<void> {
+  auto set_or = backend::cpp::EmitCpp(units, tops);
   if (!set_or) {
     return std::unexpected(std::move(set_or.error()));
   }
@@ -100,9 +102,10 @@ auto CompileProgram(
 }  // namespace
 
 auto AssembleProject(
-    const RuntimeLocation& runtime, const mir::CompilationUnit& unit,
+    const RuntimeLocation& runtime, std::span<const mir::CompilationUnit> units,
+    std::span<const backend::cpp::TopInstance> tops,
     const std::filesystem::path& dir) -> diag::Result<void> {
-  if (auto r = EmitAndWriteSources(unit, dir); !r) {
+  if (auto r = EmitAndWriteSources(units, tops, dir); !r) {
     return r;
   }
 
@@ -142,9 +145,10 @@ auto BuildProject(const std::filesystem::path& dir)
 }
 
 auto RunInPlace(
-    const RuntimeLocation& runtime, const mir::CompilationUnit& unit,
+    const RuntimeLocation& runtime, std::span<const mir::CompilationUnit> units,
+    std::span<const backend::cpp::TopInstance> tops,
     const std::filesystem::path& work_dir) -> diag::Result<int> {
-  if (auto r = EmitAndWriteSources(unit, work_dir); !r) {
+  if (auto r = EmitAndWriteSources(units, tops, work_dir); !r) {
     return std::unexpected(std::move(r.error()));
   }
   const auto program = work_dir / kProgramName;

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -38,16 +39,20 @@ Engine::Engine(EngineOptions options)
       diagnostic_(std::move(options.diagnostic_sink)) {
 }
 
-void Engine::BindRoot(std::string root_name, Module& top) {
+void Engine::BindDesign(std::span<const TopBinding> tops) {
   if (bound_) {
-    throw InternalError("Engine::BindRoot called more than once");
+    throw InternalError("Engine::BindDesign called more than once");
   }
   bound_ = true;
   root_ = std::make_unique<RuntimeScope>(
-      nullptr, std::move(root_name), RuntimeScopeKind::kModuleInstance);
-  registered_modules_.push_back(&top);
-  RuntimeBindContext ctx(*root_, services_);
-  top.Bind(ctx);
+      nullptr, "$root", RuntimeScopeKind::kModuleInstance);
+  RuntimeBindContext root_ctx(*root_, services_);
+  for (const auto& top : tops) {
+    RuntimeBindContext child_ctx =
+        root_ctx.CreateChildScope(top.name, RuntimeScopeKind::kModuleInstance);
+    registered_modules_.push_back(top.module);
+    top.module->Bind(child_ctx);
+  }
 }
 
 auto Engine::Run() -> int {
@@ -74,7 +79,7 @@ auto Engine::Run() -> int {
 
 void Engine::EnsureReadyToRun() {
   if (!bound_) {
-    throw InternalError("Engine::Run called before BindRoot");
+    throw InternalError("Engine::Run called before BindDesign");
   }
   if (ran_) {
     throw InternalError("Engine::Run called more than once");

--- a/tests/cases/cpp/hierarchy_two_top_modules/case.yaml
+++ b/tests/cases/cpp/hierarchy_two_top_modules/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.hierarchy_two_top_modules
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "top a"
+      - "top b"

--- a/tests/cases/cpp/hierarchy_two_top_modules/main.sv
+++ b/tests/cases/cpp/hierarchy_two_top_modules/main.sv
@@ -1,0 +1,7 @@
+module TopA;
+  initial $display("top a");
+endmodule
+
+module TopB;
+  initial $display("top b");
+endmodule

--- a/tests/framework/runner.cpp
+++ b/tests/framework/runner.cpp
@@ -354,7 +354,6 @@ auto WriteStringToFile(const std::filesystem::path& p, std::string_view content)
 auto RunCppCase(const std::filesystem::path& lyra_exe, const TestCase& c)
     -> RunResult {
   RunResult result;
-  const std::string top = c.input.top.value_or("Top");
 
   // When `expect.variables` is set, rewrite the source to append a synthetic
   // `final` block that prints sentinel-bracketed marker lines. The rewritten
@@ -380,6 +379,7 @@ auto RunCppCase(const std::filesystem::path& lyra_exe, const TestCase& c)
       entries.push_back(
           {.name = v.name, .sv_format_specifier = v.value.sv_format_specifier});
     }
+    const std::string top = c.input.top.value_or("Top");
     auto rewritten_or = RewriteSourceWithProbes(*source_or, top, entries);
     if (!rewritten_or) {
       result.mismatch =
@@ -401,8 +401,10 @@ auto RunCppCase(const std::filesystem::path& lyra_exe, const TestCase& c)
   std::vector<std::string>& argv = result.argv;
   argv.emplace_back("run");
   argv.emplace_back("--no-project");
-  argv.emplace_back("--top");
-  argv.push_back(top);
+  if (c.input.top.has_value()) {
+    argv.emplace_back("--top");
+    argv.push_back(*c.input.top);
+  }
   for (const auto& f : resolved_input_files) {
     argv.push_back(f.string());
   }


### PR DESCRIPTION
## Summary

SystemVerilog permits multiple top-level blocks (LRM 3.11): every elaborated, uninstantiated module is implicitly a top-level block. This lifts the long-standing single-top assumption so more than one module compiles in a single run. Each module is lowered to its own compilation unit, and the emitted program constructs every top under one implicit root scope ($root) driven by a single scheduler on one shared time axis. This is Stage A1 of the multi-module hierarchy workstream and gates the later instantiation, ports, and hierarchical-reference stages.

## Design

The runtime models $root explicitly as the single root scope that owns each top-level block as a child, rather than carrying a vector of disconnected roots; binding reuses the existing child-scope machinery and the single-rooted process walk is unchanged. The compiled-unit set and the top-level-root set are kept as distinct inputs to the backend even though they coincide here (nothing is instantiated yet), so the upcoming instantiation stage needs no unwinding. CLI input is unchanged: --top stays a single optional designation, and multiple tops arrive through the existing auto-promotion path when no top is named.

## Testing

A new end-to-end case compiles two independent top modules and asserts both run their own initial blocks. The cpp-run test harness now passes --top only when a case names one, mirroring the dump/emit path; every existing single-module case is unaffected. Full suite green.