### PR TITLE
Add tasks without timing controls

### DIFF
--- a/docs/progress/functions.md
+++ b/docs/progress/functions.md
@@ -85,9 +85,11 @@ everything and the inline "rides on" notes record the real dependencies.
 
 ### Tasks
 
-- [ ] T1 -- Tasks without timing controls (LRM 13.3). Enabled as a statement; results returned
-      through `output` / `inout` arguments; `return` exits before `endtask`. Behaves like a void
-      function and rides on F1 and F4.
+- [x] T1 -- Tasks without timing controls (LRM 13.3). Enabled as a statement; results returned
+      through `output` / `inout` arguments; `return` exits before `endtask`; an empty body is a
+      no-op. A task may enable other tasks and functions (LRM 13.2); a function enabling a task is
+      rejected. Behaves like a void function. The static-default lifetime where locals retain values
+      across enables (LRM 13.3.1) is not yet distinguished from automatic and is tracked by F3.
 - [ ] T2 -- Tasks containing time-controlling statements (LRM 13.3). `#`, `@(...)`, and `wait`
       inside a task suspend the calling process and resume it later, so a task enable can span
       multiple time steps. Rides on the timing-control machinery tracked in `processes.md`.

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -119,8 +119,7 @@ auto RenderProcessMethod(
 }
 
 // A value-returning function renders its result type; a void function or task
-// renders C++ `void`. Other formal directions are not in scope for the current
-// subroutine support, so non-input params are rejected here.
+// renders C++ `void`.
 auto RenderSubroutineResultType(
     const mir::CompilationUnit& unit, const mir::StructuralScope& s,
     mir::TypeId result_type) -> diag::Result<std::string> {

--- a/tests/cases/cpp/task_early_return/case.yaml
+++ b/tests/cases/cpp/task_early_return/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.task_early_return
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: 10
+    y: 103

--- a/tests/cases/cpp/task_early_return/main.sv
+++ b/tests/cases/cpp/task_early_return/main.sv
@@ -1,0 +1,19 @@
+module Top;
+  int x;
+  int y;
+
+  task clamp(inout int v);
+    if (v > 10) begin
+      v = 10;
+      return;
+    end
+    v = v + 100;
+  endtask
+
+  initial begin
+    x = 50;
+    clamp(x);
+    y = 3;
+    clamp(y);
+  end
+endmodule

--- a/tests/cases/cpp/task_enables_subroutine/case.yaml
+++ b/tests/cases/cpp/task_enables_subroutine/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.task_enables_subroutine
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 16

--- a/tests/cases/cpp/task_enables_subroutine/main.sv
+++ b/tests/cases/cpp/task_enables_subroutine/main.sv
@@ -1,0 +1,22 @@
+module Top;
+  int result;
+
+  function automatic int doubled(input int n);
+    return n << 1;
+  endfunction
+
+  task add_doubled(input int n, inout int acc);
+    acc = acc + doubled(n);
+  endtask
+
+  task accumulate(output int total);
+    total = 0;
+    add_doubled(3, total);
+    add_doubled(5, total);
+  endtask
+
+  initial begin
+    result = 99;
+    accumulate(result);
+  end
+endmodule

--- a/tests/cases/cpp/task_result_args/case.yaml
+++ b/tests/cases/cpp/task_result_args/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.task_result_args
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: 7
+    y: 9
+    z: 7

--- a/tests/cases/cpp/task_result_args/main.sv
+++ b/tests/cases/cpp/task_result_args/main.sv
@@ -1,0 +1,18 @@
+module Top;
+  int x;
+  int y;
+  int z;
+
+  task my_task(input int a, input int b, inout int c, output int d, output int e);
+    c = a;
+    d = b;
+    e = c;
+  endtask
+
+  initial begin
+    x = 0;
+    y = 0;
+    z = 0;
+    my_task(7, 9, x, y, z);
+  end
+endmodule

--- a/tests/cases/cpp/task_void_enable/case.yaml
+++ b/tests/cases/cpp/task_void_enable/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.task_void_enable
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    counter: 3

--- a/tests/cases/cpp/task_void_enable/main.sv
+++ b/tests/cases/cpp/task_void_enable/main.sv
@@ -1,0 +1,18 @@
+module Top;
+  int counter;
+
+  task noop;
+  endtask
+
+  task tick();
+    counter = counter + 1;
+  endtask
+
+  initial begin
+    counter = 0;
+    noop;
+    tick();
+    tick();
+    tick();
+  end
+endmodule

--- a/tests/cases/errors/function_enables_task/case.yaml
+++ b/tests/cases/errors/function_enables_task/case.yaml
@@ -1,0 +1,16 @@
+id: errors.function_enables_task
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "invoke a task"
+      - "function"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/function_enables_task/main.sv
+++ b/tests/cases/errors/function_enables_task/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  logic [7:0] r;
+
+  task set_one(output logic [7:0] v);
+    v = 8'd1;
+  endtask
+
+  function logic [7:0] bad();
+    logic [7:0] tmp;
+    set_one(tmp);
+    return tmp;
+  endfunction
+
+  initial begin
+    r = bad();
+  end
+endmodule


### PR DESCRIPTION
## Summary

Locks in support for SystemVerilog tasks without timing controls (LRM 13.3). Such a task is semantically a void subroutine: it is enabled as a statement, returns results through `output` / `inout` arguments, exits early on `return`, and may have an empty body. A task may enable other tasks and functions (LRM 13.2), while a function enabling a task is rejected at the frontend. This behavior already flowed through the void-function lowering path once `output` / `inout` argument passing landed, so this change is a focused test corpus that pins the behavior against regression, plus documentation and a stale-comment cleanup.

## Testing

Adds cpp cases covering bare enable and an empty body, output/inout result passing in the LRM 13.3 Example 1 shape, early return versus fall-through, and a task enabling both a task and a function. Adds an error case asserting that a function enabling a task is rejected cleanly. `bazel test //...` passes.