### PR TITLE
Add return-by-name for functions

### DIFF
--- a/docs/progress/functions.md
+++ b/docs/progress/functions.md
@@ -33,7 +33,7 @@ everything and the inline "rides on" notes record the real dependencies.
       `return expr`; nonvoid call as an expression operand and as a nested operand; void call as a
       statement; `void'(f())` to discard a nonvoid result. Sequential body statements, early /
       conditional return, and function-local variable declarations.
-- [ ] F2 -- Return-by-name via the implicit variable that shares the function's name (LRM 13.4.1).
+- [x] F2 -- Return-by-name via the implicit variable that shares the function's name (LRM 13.4.1).
       `return` overrides a prior name-assignment; an empty body returns the implicit variable's
       current value; the implicit variable is default-initialized so a read-before-write sees a
       defined value.

--- a/include/lyra/hir/subroutine.hpp
+++ b/include/lyra/hir/subroutine.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -30,11 +31,17 @@ struct SubroutineParam {
   ParamDirection direction = ParamDirection::kInput;
 };
 
+// LRM 13.4.1 implicit result variable: a non-void function implicitly declares
+// a body-local variable of the return type that the body reads and writes
+// through the function name. `result_var` indexes the body's procedural-var
+// arena for that variable; it is absent for void functions and tasks, which
+// yield no value.
 struct StructuralSubroutineDecl {
   std::string name;
   SubroutineKind kind;
   TypeId result_type;
   std::vector<SubroutineParam> params;
+  std::optional<ProceduralVarId> result_var;
   ProceduralBody body;
 };
 

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -852,6 +852,9 @@ class HirDumper {
               "Param[{}] {} var=ProceduralVar[{}]", i,
               FormatParamDirection(param.direction), param.var.value));
     }
+    if (d.result_var.has_value()) {
+      Line(std::format("Result var=ProceduralVar[{}]", d.result_var->value));
+    }
     DumpProceduralBody(d.body);
     Dedent();
   }

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -154,6 +154,17 @@ auto LowerSubroutineMemberInto(
             .direction = FromSlangArgumentDirection(formal->direction)});
   }
 
+  // LRM 13.4.1: a non-void function implicitly declares a body-local variable
+  // of the return type, named after the function, that the body reads and
+  // writes to produce the return value. slang exposes it as `returnValVar`;
+  // void functions and tasks have none. Bind it after the formals so its
+  // procedural-var id follows them in declaration order.
+  std::optional<hir::ProceduralVarId> result_var;
+  if (sym.returnValVar != nullptr) {
+    result_var =
+        sub_state.AddProceduralVar(*sym.returnValVar, *return_type_id_or);
+  }
+
   auto body_or =
       LowerStatement(unit_facts, sub_state, scope_state, stack, sym.getBody());
   if (!body_or) return std::unexpected(std::move(body_or.error()));
@@ -165,6 +176,7 @@ auto LowerSubroutineMemberInto(
                .kind = FromSlangSubroutineKind(sym.subroutineKind),
                .result_type = *return_type_id_or,
                .params = std::move(params),
+               .result_var = result_var,
                .body = sub_state.FinalizeBody(root)});
   return {};
 }

--- a/src/lyra/lowering/hir_to_mir/lower_process.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_process.cpp
@@ -9,10 +9,12 @@
 #include "lyra/base/time.hpp"
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/lower_stmt.hpp"
 #include "lyra/lowering/hir_to_mir/procedural_scope_helpers.hpp"
 #include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/expr.hpp"
 #include "lyra/mir/process.hpp"
 #include "lyra/mir/stmt.hpp"
 
@@ -164,13 +166,42 @@ auto LowerStructuralSubroutine(
             .direction = LowerParamDirection(param.direction)});
   }
 
+  // LRM 13.4.1 implicit result variable desugar. A non-void function returns
+  // the current value of its implicit same-name variable on fall-through; an
+  // assignment to the function name is just a write to that variable, and an
+  // explicit `return expr` overrides it because it exits before the trailing
+  // read. Materialize the variable as a default-initialized body local (named
+  // distinctly from the C++ method so a self-recursive call still resolves to
+  // the method), then close the body with `return <result>`. void functions
+  // and tasks have no result variable and no trailing return.
+  const mir::TypeId result_type = unit_state.TranslateType(src.result_type);
+  std::optional<mir::ProceduralVarRef> result_ref;
+  if (src.result_var.has_value()) {
+    const mir::ExprId default_init =
+        SynthesizeDefaultValueExpr(unit_state, body_scope_state, result_type);
+    result_ref = body_scope_state.AppendLocal(
+        mir::ProceduralVarDecl{.name = "_lyra_result", .type = result_type},
+        default_init);
+    proc_state.MapProceduralVar(
+        *src.result_var,
+        ProceduralVarBinding{
+            .declaration_procedural_depth = proc_state.CurrentProceduralDepth(),
+            .var = result_ref->var});
+  }
+
   auto lowered = LowerStraightLineBodyInto(
       unit_state, scope_state, src.body, proc_state, body_scope_state);
   if (!lowered) return std::unexpected(std::move(lowered.error()));
 
+  if (result_ref.has_value()) {
+    const mir::ExprId result_read = body_scope_state.AddExpr(
+        mir::Expr{.data = *result_ref, .type = result_type});
+    body_scope_state.AppendStmt(mir::ReturnStmt{.value = result_read});
+  }
+
   return mir::StructuralSubroutineDecl{
       .name = src.name,
-      .result_type = unit_state.TranslateType(src.result_type),
+      .result_type = result_type,
       .params = std::move(params),
       .root_procedural_scope = body_scope_state.Finish()};
 }

--- a/tests/cases/cpp/function_return_by_name/case.yaml
+++ b/tests/cases/cpp/function_return_by_name/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.function_return_by_name
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 36

--- a/tests/cases/cpp/function_return_by_name/main.sv
+++ b/tests/cases/cpp/function_return_by_name/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  int result;
+
+  function int square(input int n);
+    square = n * n;
+  endfunction
+
+  initial begin
+    result = square(6);
+  end
+endmodule

--- a/tests/cases/cpp/function_return_default_four_state/case.yaml
+++ b/tests/cases/cpp/function_return_default_four_state/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.function_return_default_four_state
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: "8'hxx"

--- a/tests/cases/cpp/function_return_default_four_state/main.sv
+++ b/tests/cases/cpp/function_return_default_four_state/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  logic [7:0] result;
+
+  function logic [7:0] unwritten(input logic [7:0] n);
+  endfunction
+
+  initial begin
+    result = unwritten(8'hAA);
+  end
+endmodule

--- a/tests/cases/cpp/function_return_empty_body/case.yaml
+++ b/tests/cases/cpp/function_return_empty_body/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.function_return_empty_body
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 0

--- a/tests/cases/cpp/function_return_empty_body/main.sv
+++ b/tests/cases/cpp/function_return_empty_body/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  int result;
+
+  function int nothing(input int n);
+  endfunction
+
+  initial begin
+    result = nothing(7);
+  end
+endmodule

--- a/tests/cases/cpp/function_return_name_override/case.yaml
+++ b/tests/cases/cpp/function_return_name_override/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.function_return_name_override
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x: 10
+    y: 103

--- a/tests/cases/cpp/function_return_name_override/main.sv
+++ b/tests/cases/cpp/function_return_name_override/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  int x;
+  int y;
+
+  function int clamp(input int v);
+    clamp = v;
+    if (v > 10) return 10;
+    clamp = clamp + 100;
+  endfunction
+
+  initial begin
+    x = clamp(50);
+    y = clamp(3);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements F2 from the subroutine roadmap: returning a function value by assigning to the implicit variable that shares the function's name (LRM 13.4.1). A non-void function now reads and writes that implicit variable through its own name; the value it holds when control reaches `endfunction` is returned. An explicit `return expr` still works and overrides any prior name-assignment, an empty body returns the implicit variable's current value, and the variable is default-initialized so a read-before-write sees a defined value (0 for 2-state, X for 4-state).

## Design

The implicit variable is modeled as a syntax sugar that desugars at the HIR-to-MIR boundary. The frontend binds slang's `returnValVar` as a body-local procedural variable so name-assignments and reads resolve like any other variable. The lowering then materializes that variable as a default-initialized local and closes the body with a trailing `return <result>`. An explicit `return expr` lowers unchanged and exits before the trailing read, so it naturally overrides the name-assignment per the LRM. The result local is named distinctly from the emitted method so a self-recursive call still resolves to the function rather than shadowing it. MIR and the C++ backend are unchanged: after the desugar a non-void function is just an ordinary body that ends in a return, so the backend stays a plain printer.

## Testing

New cpp run cases cover assign-to-name, an explicit return overriding a prior name-assignment combined with read-back of the implicit variable and fall-through, an empty body returning the 2-state default, and an unwritten 4-state implicit variable returning X.

🤖 Generated with [Claude Code](https://claude.com/claude-code)