### PR TITLE
Support module instantiation across compilation units

### DIFF
--- a/docs/architecture/compilation_unit_model.md
+++ b/docs/architecture/compilation_unit_model.md
@@ -10,6 +10,8 @@ Define what a compilation unit is, what it owns, and the rules that make it self
 - The enumeration of compilation-unit kinds: module, package, interface.
 - The rule that a compilation unit compiles independently, given only its own contents and declared
   interface.
+- The interface a unit exposes across the compilation boundary: its name and signature (parameters
+  and ports), produced by the unit from its own contents and consumed by other units by name.
 - The shape of instance records: minimal, structural, and free of semantic content that belongs
   inside the unit.
 
@@ -37,6 +39,11 @@ Define what a compilation unit is, what it owns, and the rules that make it self
    full elaboration, but the compiler operates on compilation units and specializations. Instance
    expansion does not drive compilation, and compile-time identity does not depend on instance
    enumeration.
+8. A unit's only cross-boundary surface is its interface: its name and signature (parameters and
+   ports). The unit produces this interface from its own contents. A unit that instantiates or
+   references another depends only on that interface, identified by name, never on the other unit's
+   body or internal ids. Units compile independently and in any order and are combined by matching
+   names; they share no identifier space and exchange no internal state.
 
 ## Boundary to Adjacent Layers
 
@@ -56,6 +63,11 @@ Define what a compilation unit is, what it owns, and the rules that make it self
 - Instance records that carry a copy of the unit's semantic state.
 - Maps keyed by `(instance_id, local_symbol)` used to resolve a reference inside the unit.
 - Implicit cross-unit access that bypasses explicit import or external reference.
+- A design-wide index, ordinal, or numbering that two units both depend on to refer to each other. A
+  cross-unit reference is a name resolved against an interface, never a shared position in a global
+  table.
+- Compiling one unit against another unit's body or internal ids instead of against its interface
+  (name and signature).
 - Treating "the design" as a compilation unit.
 - Treating the frontend as the authority for compilation-unit identity, membership, or boundary. The
   frontend is input; the compiler is authority.

--- a/docs/architecture/hierarchy_and_generate.md
+++ b/docs/architecture/hierarchy_and_generate.md
@@ -61,6 +61,11 @@ shared by all consumers: external references, child routing, and construction.
 - `reference_resolution.md` owns how a reference reaches state across the object tree and when it
   resolves. This doc owns the tree's shape and construction and its faithfulness to the frontend's
   elaboration; that doc relies on this faithfulness to make cross-unit resolution total.
+- A node whose owned child is built from another compilation unit (an instantiation) crosses the
+  unit boundary: the parent references the child's interface by name, never its body or internal
+  ids. An owned child that belongs to the same unit (a named generate scope) is intra-unit and
+  crosses no boundary. `compilation_unit_model.md` owns the interface and the name-based linkage;
+  this doc owns only the resulting ownership edge in the object tree.
 
 ## Forbidden Shapes
 

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -50,7 +50,7 @@ C  Non-local access substrate
 
 ### Stage A -- Specialization as compilation unit
 
-- [ ] A1 -- More than one module definition compiles in a single run; the design is no longer
+- [x] A1 -- More than one module definition compiles in a single run; the design is no longer
       assumed to be a single top module. Each module is its own independently compiled unit. The LRM
       permits multiple top-level blocks (LRM 3.11): every elaborated but uninstantiated module is
       implicitly a top-level block, and all of them sit under one implicit root scope ($root). The
@@ -69,7 +69,7 @@ Unlocks the compile-time side of `instantiation/specialization_grouping` and
 
 ### Stage B -- Object-graph construction (instantiation)
 
-- [ ] B1 -- A module instantiates a child; the constructor builds the child as a distinct object
+- [x] B1 -- A module instantiates a child; the constructor builds the child as a distinct object
       owned by the parent in the object tree. Parent and child remain separate units.
 - [ ] B2 -- The same module instantiated several times yields independent objects, each owning its
       own state.

--- a/include/lyra/compiler/compile.hpp
+++ b/include/lyra/compiler/compile.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "lyra/diag/sink.hpp"
@@ -22,6 +23,9 @@ struct CompileArtifacts {
   std::optional<frontend::ParseResult> parse;
   std::optional<std::vector<hir::ModuleUnit>> hir_units;
   std::optional<std::vector<mir::CompilationUnit>> mir_units;
+  // A subset of the compiled units: a unit reached only through instantiation
+  // is compiled but is not a top.
+  std::vector<std::string> top_unit_names;
 
   CompileArtifacts() = default;
   CompileArtifacts(const CompileArtifacts&) = delete;

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -3,6 +3,7 @@
 #include <compare>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <variant>
 #include <vector>
 
@@ -30,6 +31,21 @@ struct StructuralScopeId {
 
   auto operator<=>(const StructuralScopeId&) const
       -> std::strong_ordering = default;
+};
+
+struct InstanceMemberId {
+  std::uint32_t value;
+
+  auto operator<=>(const InstanceMemberId&) const
+      -> std::strong_ordering = default;
+};
+
+// `target_unit` is a cross-unit reference -- the name of the instantiated unit,
+// resolved by name at link time, a distinct domain from the unit-local id
+// kinds.
+struct InstanceMemberDecl {
+  std::string instance_name;
+  std::string target_unit;
 };
 
 struct IfGenerate {
@@ -76,6 +92,7 @@ struct StructuralScope {
   std::vector<Process> processes;
   std::vector<ContinuousAssign> continuous_assigns;
   std::vector<Generate> generates;
+  std::vector<InstanceMemberDecl> instance_members;
   std::vector<StructuralSubroutineDecl> structural_subroutines;
   std::vector<TypeAliasDecl> type_aliases;
 
@@ -99,6 +116,10 @@ struct StructuralScope {
   }
   [[nodiscard]] auto GetGenerate(GenerateId id) const -> const Generate& {
     return generates.at(id.value);
+  }
+  [[nodiscard]] auto GetInstanceMember(InstanceMemberId id) const
+      -> const InstanceMemberDecl& {
+    return instance_members.at(id.value);
   }
   [[nodiscard]] auto GetStructuralSubroutine(StructuralSubroutineId id) const
       -> const StructuralSubroutineDecl& {

--- a/include/lyra/lowering/ast_to_hir/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/lower.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include <slang/ast/Compilation.h>
 
 #include "lyra/diag/diagnostic.hpp"
@@ -37,7 +40,16 @@ class LowerCompilationFacts {
   SensitivityAnalyzer* sensitivity_analyzer_;
 };
 
+// Lowers the top-level blocks and, transitively, every unit they instantiate.
+// The result is a superset of the tops: a unit reached only through
+// instantiation is compiled but is not itself a top.
 auto LowerCompilation(const LowerCompilationFacts& facts)
     -> diag::Result<std::vector<hir::ModuleUnit>>;
+
+// A top-level block is an auto-promoted, uninstantiated module. These names are
+// a subset of the compiled units: a unit reached only through instantiation is
+// compiled but is not a top.
+auto TopLevelUnitNames(slang::ast::Compilation& compilation)
+    -> std::vector<std::string>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -317,6 +317,14 @@ class ScopeLoweringState {
     return id;
   }
 
+  auto AddInstanceMember(hir::InstanceMemberDecl decl)
+      -> hir::InstanceMemberId {
+    const hir::InstanceMemberId id{
+        static_cast<std::uint32_t>(scope_->instance_members.size())};
+    scope_->instance_members.push_back(std::move(decl));
+    return id;
+  }
+
   auto AddStructuralSubroutine(
       const slang::ast::SubroutineSymbol& sym,
       hir::StructuralSubroutineDecl decl) -> hir::StructuralSubroutineId {

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -74,9 +74,17 @@ struct ConstructOwnedObjectStmt {
   std::vector<ExprId> args;
 };
 
+// The cross-unit twin of ConstructOwnedObjectStmt: it carries no scope_id
+// because the child is a separate compilation unit, not a nested scope of this
+// one.
+struct ConstructExternalUnitStmt {
+  StructuralVarId target;
+  std::string unit_name;
+};
+
 struct ForInitDecl {
   ProceduralVarRef induction_var = {};
-  ExprId init;
+  ExprId init = {};
 };
 
 struct ForInitExpr {
@@ -152,8 +160,9 @@ struct SensitivityWaitStmt {
 
 using StmtData = std::variant<
     EmptyStmt, ProceduralVarDeclStmt, ExprStmt, BlockStmt, IfStmt,
-    ConstructOwnedObjectStmt, ForStmt, DelayStmt, WhileStmt, DoWhileStmt,
-    BreakStmt, ContinueStmt, ReturnStmt, SensitivityWaitStmt>;
+    ConstructOwnedObjectStmt, ConstructExternalUnitStmt, ForStmt, DelayStmt,
+    WhileStmt, DoWhileStmt, BreakStmt, ContinueStmt, ReturnStmt,
+    SensitivityWaitStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -26,6 +26,7 @@ enum class TypeKind {
   kChandle,
   kVoid,
   kObject,
+  kExternalUnitObject,
   kOwningPtr,
   kVector,
 };
@@ -126,6 +127,15 @@ struct ObjectType {
   auto operator==(const ObjectType&) const -> bool = default;
 };
 
+// The cross-unit twin of ObjectType: the target is another unit's name,
+// resolved by name at link time, not a scope of this unit -- so its layout is
+// not visible here.
+struct ExternalUnitObjectType {
+  std::string unit_name;
+
+  auto operator==(const ExternalUnitObjectType&) const -> bool = default;
+};
+
 struct OwningPtrType {
   TypeId pointee;
 
@@ -141,7 +151,8 @@ struct VectorType {
 using TypeData = std::variant<
     PackedArrayType, EnumType, UnpackedArrayType, DynamicArrayType, QueueType,
     AssociativeArrayType, StringType, EventType, RealType, ShortRealType,
-    RealTimeType, ChandleType, VoidType, ObjectType, OwningPtrType, VectorType>;
+    RealTimeType, ChandleType, VoidType, ObjectType, ExternalUnitObjectType,
+    OwningPtrType, VectorType>;
 
 struct Type {
   TypeData data;
@@ -170,5 +181,11 @@ class CompilationUnit;
 [[nodiscard]] auto GetOwnedObjectTarget(
     const CompilationUnit& unit, TypeId type)
     -> std::optional<StructuralScopeId>;
+
+[[nodiscard]] auto IsExternalUnitOwningType(
+    const CompilationUnit& unit, TypeId type) -> bool;
+
+[[nodiscard]] auto GetExternalUnitName(const CompilationUnit& unit, TypeId type)
+    -> std::optional<std::string>;
 
 }  // namespace lyra::mir

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -1,9 +1,11 @@
+#include <algorithm>
 #include <cstddef>
 #include <format>
 #include <span>
 #include <string>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "lyra/backend/cpp/api.hpp"
 #include "lyra/backend/cpp/artifact.hpp"
@@ -191,10 +193,21 @@ auto RenderBind(
     out += Indent(indent + 2) + RenderProcessKindLiteral(p.kind) + ",\n";
     out += Indent(indent + 2) + RenderProcessMethodName(i) + "());\n";
   }
-  // Bind eligibility is inferred from storage type structure today; when
-  // non-generate producers of `ObjectType` appear, switch to explicit scope
-  // metadata.
+  // An owned-object var binds its child under this scope. The scope kind is
+  // read off the owning type: an external-unit instance is a module instance;
+  // an intra-unit owned object is a generate scope.
   for (const auto& v : s.structural_vars) {
+    if (const auto ext_unit = mir::GetExternalUnitName(unit, v.type);
+        ext_unit.has_value()) {
+      out += Indent(indent + 1) + "if (" + v.name + ") {\n";
+      out += Indent(indent + 2) + "auto child = ctx.CreateChildScope(\n";
+      out += Indent(indent + 3) + "\"" + v.name + "\",\n";
+      out += Indent(indent + 3) +
+             "lyra::runtime::RuntimeScopeKind::kModuleInstance);\n";
+      out += Indent(indent + 2) + v.name + "->Bind(child);\n";
+      out += Indent(indent + 1) + "}\n";
+      continue;
+    }
     const auto target = mir::GetOwnedObjectTarget(unit, v.type);
     if (!target.has_value()) {
       continue;
@@ -304,6 +317,21 @@ auto RenderScopeAsClass(
   return out;
 }
 
+auto CollectExternalUnitNames(const mir::CompilationUnit& unit)
+    -> std::vector<std::string> {
+  std::vector<std::string> names;
+  for (const auto& t : unit.types) {
+    const auto* ext = std::get_if<mir::ExternalUnitObjectType>(&t.data);
+    if (ext == nullptr) {
+      continue;
+    }
+    if (std::ranges::find(names, ext->unit_name) == names.end()) {
+      names.push_back(ext->unit_name);
+    }
+  }
+  return names;
+}
+
 auto RenderScopeHeaderFile(
     const mir::CompilationUnit& unit, const mir::StructuralScope& s)
     -> diag::Result<std::string> {
@@ -338,6 +366,9 @@ auto RenderScopeHeaderFile(
   out += "#include \"lyra/value/packed_reduction.hpp\"\n";
   out += "#include \"lyra/value/string.hpp\"\n";
   out += "#include \"lyra/value/string_op.hpp\"\n";
+  for (const auto& name : CollectExternalUnitNames(unit)) {
+    out += "#include \"" + name + ".hpp\"\n";
+  }
   out += "\n";
   bool any_enum = false;
   for (std::size_t i = 0; i < unit.types.size(); ++i) {

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -146,6 +146,14 @@ auto RenderConstructOwnedObjectStmt(
       "ConstructOwnedObjectStmt target is not an owning object var");
 }
 
+auto RenderConstructExternalUnitStmt(
+    const RenderContext& ctx, const mir::ConstructExternalUnitStmt& s,
+    std::size_t indent) -> diag::Result<std::string> {
+  const auto& var = ctx.StructuralScope().GetStructuralVar(s.target);
+  return Indent(indent) + var.name + " = std::make_unique<" + s.unit_name +
+         ">();\n";
+}
+
 auto RenderForStmtNode(
     const RenderContext& ctx, const mir::Stmt& stmt, const mir::ForStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
@@ -268,6 +276,10 @@ auto RenderStmt(
           [&](const mir::ConstructOwnedObjectStmt& s)
               -> diag::Result<std::string> {
             return RenderConstructOwnedObjectStmt(ctx, s, indent);
+          },
+          [&](const mir::ConstructExternalUnitStmt& s)
+              -> diag::Result<std::string> {
+            return RenderConstructExternalUnitStmt(ctx, s, indent);
           },
           [&](const mir::ForStmt& s) -> diag::Result<std::string> {
             return RenderForStmtNode(ctx, stmt, s, indent);

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -92,6 +92,8 @@ auto RenderTypeAsCpp(
             return std::string{
                 owner_scope.GetChildStructuralScope(o.target).name};
           },
+          [](const mir::ExternalUnitObjectType& e)
+              -> diag::Result<std::string> { return e.unit_name; },
           [&](const mir::OwningPtrType& o) -> diag::Result<std::string> {
             auto inner_or = RenderTypeAsCpp(unit, owner_scope, o.pointee);
             if (!inner_or) return std::unexpected(std::move(inner_or.error()));

--- a/src/lyra/compiler/compile.cpp
+++ b/src/lyra/compiler/compile.cpp
@@ -43,6 +43,8 @@ auto Compile(
     return result;
   }
   result.artifacts.hir_units = std::move(*hir);
+  result.artifacts.top_unit_names = lowering::ast_to_hir::TopLevelUnitNames(
+      *result.artifacts.parse->compilation);
 
   if (stop_after == StopAfter::kHir) {
     return result;

--- a/src/lyra/driver/cli.cpp
+++ b/src/lyra/driver/cli.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <argparse/argparse.hpp>
 #include <cstdio>
 #include <exception>
@@ -290,11 +291,14 @@ auto main(int argc, char** argv) -> int {
       return *loc_or;
     };
 
-    auto build_tops = [](const std::vector<lyra::mir::CompilationUnit>& units) {
+    auto build_tops = [](const std::vector<lyra::mir::CompilationUnit>& units,
+                         const std::vector<std::string>& top_names) {
       std::vector<lyra::backend::cpp::TopInstance> tops;
-      tops.reserve(units.size());
       for (const auto& unit : units) {
-        tops.push_back({.name = unit.structural_scope.name, .unit = &unit});
+        if (std::ranges::find(top_names, unit.structural_scope.name) !=
+            top_names.end()) {
+          tops.push_back({.name = unit.structural_scope.name, .unit = &unit});
+        }
       }
       return tops;
     };
@@ -312,7 +316,7 @@ auto main(int argc, char** argv) -> int {
         }
         const std::filesystem::path dir = args.out_dir;
         const auto& units = *result.artifacts.mir_units;
-        const auto tops = build_tops(units);
+        const auto tops = build_tops(units, result.artifacts.top_unit_names);
         auto assembled =
             lyra::driver::AssembleProject(*runtime, units, tops, dir);
         if (!assembled) {
@@ -329,7 +333,7 @@ auto main(int argc, char** argv) -> int {
         }
         const std::filesystem::path dir = args.out_dir;
         const auto& units = *result.artifacts.mir_units;
-        const auto tops = build_tops(units);
+        const auto tops = build_tops(units, result.artifacts.top_unit_names);
         auto assembled =
             lyra::driver::AssembleProject(*runtime, units, tops, dir);
         if (!assembled) {
@@ -358,7 +362,7 @@ auto main(int argc, char** argv) -> int {
           return 1;
         }
         const auto& units = *result.artifacts.mir_units;
-        const auto tops = build_tops(units);
+        const auto tops = build_tops(units, result.artifacts.top_unit_names);
         auto exit_code =
             lyra::driver::RunInPlace(*runtime, units, tops, *tmp_or);
         if (!exit_code) {

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -833,6 +833,13 @@ class HirDumper {
     for (const auto& g : s.generates) {
       DumpGenerate(s, g);
     }
+    for (std::size_t i = 0; i < s.instance_members.size(); ++i) {
+      const auto& im = s.instance_members[i];
+      Line(
+          std::format(
+              "InstanceMember[{}] \"{}\" : {}", i, im.instance_name,
+              im.target_unit));
+    }
     Dedent();
     scope_stack_.pop_back();
   }

--- a/src/lyra/lowering/ast_to_hir/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/lower.cpp
@@ -1,11 +1,15 @@
 #include "lyra/lowering/ast_to_hir/lower.hpp"
 
+#include <cstddef>
 #include <expected>
+#include <string>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include <slang/ast/Compilation.h>
+#include <slang/ast/Scope.h>
+#include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/CompilationUnitSymbols.h>
 #include <slang/ast/symbols/InstanceSymbols.h>
 
@@ -16,34 +20,55 @@
 
 namespace lyra::lowering::ast_to_hir {
 
-namespace {
-
-auto CollectTopBodies(slang::ast::Compilation& compilation)
-    -> std::vector<const slang::ast::InstanceBodySymbol*> {
-  const auto& root = compilation.getRoot();
-  std::vector<const slang::ast::InstanceBodySymbol*> bodies;
-  std::unordered_set<const slang::ast::InstanceBodySymbol*> seen;
-  for (const auto* inst : root.topInstances) {
-    const auto* body = &inst->body;
-    if (seen.insert(body).second) {
-      bodies.push_back(body);
-    }
-  }
-  return bodies;
-}
-
-}  // namespace
-
 auto LowerCompilation(const LowerCompilationFacts& facts)
     -> diag::Result<std::vector<hir::ModuleUnit>> {
   const UnitLoweringFacts unit_facts(facts.SourceMapper(), facts.Sensitivity());
+  const auto& root = facts.Compilation().getRoot();
+
+  // Worklist of unit bodies, seeded with the top-level blocks and grown by
+  // walking each lowered body's child instances, deduped so each definition is
+  // lowered once. A child is reached only through its instance's definition
+  // name (its header); the parent never reads the child's body.
+  std::vector<const slang::ast::InstanceBodySymbol*> worklist;
+  std::unordered_set<const slang::ast::DefinitionSymbol*> seen_defs;
   std::vector<hir::ModuleUnit> units;
-  for (const auto* body : CollectTopBodies(facts.Compilation())) {
+
+  for (const auto* inst : root.topInstances) {
+    const auto* body = &inst->body;
+    if (seen_defs.insert(&body->getDefinition()).second) {
+      worklist.push_back(body);
+    }
+  }
+
+  for (std::size_t i = 0; i < worklist.size(); ++i) {
+    const auto* body = worklist[i];
     auto u = LowerModule(unit_facts, *body);
     if (!u) return std::unexpected(std::move(u.error()));
     units.push_back(*std::move(u));
+
+    for (const auto& member : body->members()) {
+      if (member.kind != slang::ast::SymbolKind::Instance) {
+        continue;
+      }
+      const auto* child_body = &member.as<slang::ast::InstanceSymbol>().body;
+      if (seen_defs.insert(&child_body->getDefinition()).second) {
+        worklist.push_back(child_body);
+      }
+    }
   }
+
   return units;
+}
+
+auto TopLevelUnitNames(slang::ast::Compilation& compilation)
+    -> std::vector<std::string> {
+  const auto& root = compilation.getRoot();
+  std::vector<std::string> names;
+  names.reserve(root.topInstances.size());
+  for (const auto* inst : root.topInstances) {
+    names.emplace_back(inst->body.name);
+  }
+  return names;
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -11,6 +11,8 @@
 #include <slang/ast/Statement.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/BlockSymbols.h>
+#include <slang/ast/symbols/CompilationUnitSymbols.h>
+#include <slang/ast/symbols/InstanceSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/ValueSymbol.h>
 #include <slang/ast/symbols/VariableSymbols.h>
@@ -239,6 +241,16 @@ auto LowerIfOrCaseGenerateMemberInto(
   return {};
 }
 
+auto LowerInstanceMemberInto(
+    ScopeLoweringState& scope_state, const slang::ast::InstanceSymbol& inst)
+    -> diag::Result<void> {
+  scope_state.AddInstanceMember(
+      hir::InstanceMemberDecl{
+          .instance_name = std::string{inst.name},
+          .target_unit = std::string{inst.getDefinition().name}});
+  return {};
+}
+
 auto LowerScopeMemberInto(
     const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
     ScopeStack& stack, const slang::ast::Symbol& member,
@@ -271,6 +283,9 @@ auto LowerScopeMemberInto(
       return LowerIfOrCaseGenerateMemberInto(
           unit_facts, scope_state, stack,
           member.as<slang::ast::GenerateBlockSymbol>(), slang_scope);
+    case slang::ast::SymbolKind::Instance:
+      return LowerInstanceMemberInto(
+          scope_state, member.as<slang::ast::InstanceSymbol>());
     default:
       return {};
   }

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -157,6 +157,43 @@ auto MakeVectorOfOwnedObjectType(
   return unit_state.AddType(mir::VectorType{.element = owned_type});
 }
 
+auto MakeExternalUnitOwningType(
+    UnitLoweringState& unit_state, std::string unit_name) -> mir::TypeId {
+  const mir::TypeId object_type = unit_state.AddType(
+      mir::ExternalUnitObjectType{.unit_name = std::move(unit_name)});
+  return unit_state.AddType(mir::OwningPtrType{.pointee = object_type});
+}
+
+void InstallInstanceMembers(
+    UnitLoweringState& unit_state, StructuralScopeLoweringState& scope_state,
+    const hir::StructuralScope& scope,
+    ProceduralScopeLoweringState& ctor_scope_state) {
+  for (const auto& im : scope.instance_members) {
+    for (const auto& v : scope_state.Scope().structural_vars) {
+      if (v.name == im.instance_name) {
+        throw InternalError(
+            "instance member name collides with an existing structural var "
+            "declaration in the enclosing scope");
+      }
+    }
+    const mir::TypeId var_type =
+        MakeExternalUnitOwningType(unit_state, im.target_unit);
+    const mir::ExprId init =
+        SynthesizeDefaultValueExpr(unit_state, ctor_scope_state, var_type);
+    const mir::StructuralVarId var_id = scope_state.AddStructuralVar(
+        mir::StructuralVarDecl{
+            .name = im.instance_name, .type = var_type, .initializer = init});
+    const mir::StmtId sid = ctor_scope_state.AddStmt(
+        mir::Stmt{
+            .label = std::nullopt,
+            .data =
+                mir::ConstructExternalUnitStmt{
+                    .target = var_id, .unit_name = im.target_unit},
+            .child_procedural_scopes = {}});
+    ctor_scope_state.AddRootStmt(sid);
+  }
+}
+
 void ValidateConstructOwnedObjectStmt(
     const mir::CompilationUnit& unit, const mir::StructuralScope& owner_scope,
     const ProceduralScopeLoweringState& proc_scope_state,
@@ -584,6 +621,9 @@ auto LowerStructuralScope(
     const mir::StmtId sid = ctor_scope_state.AddStmt(*std::move(stmt));
     ctor_scope_state.AddRootStmt(sid);
   }
+
+  InstallInstanceMembers(unit_state, scope_state, scope, ctor_scope_state);
+
   scope_state.SetConstructorScope(ctor_scope_state.Finish());
 
   return mir_scope;

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -172,6 +172,10 @@ class MirDumper {
               return std::format(
                   "Object(scope=ChildStructuralScope[{}])", o.target.value);
             },
+            [](const ExternalUnitObjectType& e) -> std::string {
+              return std::format(
+                  "ExternalUnitObject(unit=\"{}\")", e.unit_name);
+            },
             [](const OwningPtrType& p) -> std::string {
               return std::format(
                   "OwningPtr(pointee=Type[{}])", p.pointee.value);
@@ -781,6 +785,15 @@ class MirDumper {
             id.value, s.target.value, s.scope_id.value, args_str));
   }
 
+  void DumpConstructExternalUnitStmt(
+      StmtId id, const ConstructExternalUnitStmt& s) {
+    Line(
+        std::format(
+            "Stmt[{}] ConstructExternalUnitStmt target=StructuralVar[{}] "
+            "unit=\"{}\"",
+            id.value, s.target.value, s.unit_name));
+  }
+
   void DumpStmt(const ProceduralScope& enclosing, StmtId id) {
     const auto& stmt = enclosing.stmts.at(id.value);
     if (stmt.label.has_value()) {
@@ -799,6 +812,9 @@ class MirDumper {
             [&](const IfStmt& s) { DumpIfStmt(stmt, s, enclosing, id); },
             [&](const ConstructOwnedObjectStmt& s) {
               DumpConstructOwnedObjectStmt(id, s);
+            },
+            [&](const ConstructExternalUnitStmt& s) {
+              DumpConstructExternalUnitStmt(id, s);
             },
             [&](const ForStmt& s) { DumpForStmt(stmt, s, enclosing, id); },
             [&](const DelayStmt& d) {

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <variant>
 
 #include "lyra/base/internal_error.hpp"
@@ -71,6 +72,9 @@ auto Type::Kind() const -> TypeKind {
           [](const ChandleType&) { return TypeKind::kChandle; },
           [](const VoidType&) { return TypeKind::kVoid; },
           [](const ObjectType&) { return TypeKind::kObject; },
+          [](const ExternalUnitObjectType&) {
+            return TypeKind::kExternalUnitObject;
+          },
           [](const OwningPtrType&) { return TypeKind::kOwningPtr; },
           [](const VectorType&) { return TypeKind::kVector; },
       },
@@ -159,6 +163,25 @@ auto GetOwnedObjectTarget(const CompilationUnit& unit, TypeId type)
     }
   }
   return std::nullopt;
+}
+
+auto IsExternalUnitOwningType(const CompilationUnit& unit, TypeId type)
+    -> bool {
+  return GetExternalUnitName(unit, type).has_value();
+}
+
+auto GetExternalUnitName(const CompilationUnit& unit, TypeId type)
+    -> std::optional<std::string> {
+  const auto* owning = std::get_if<OwningPtrType>(&unit.GetType(type).data);
+  if (owning == nullptr) {
+    return std::nullopt;
+  }
+  const auto* ext =
+      std::get_if<ExternalUnitObjectType>(&unit.GetType(owning->pointee).data);
+  if (ext == nullptr) {
+    return std::nullopt;
+  }
+  return ext->unit_name;
 }
 
 }  // namespace lyra::mir

--- a/tests/cases/cpp/hierarchy_parent_child_instance/case.yaml
+++ b/tests/cases/cpp/hierarchy_parent_child_instance/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.hierarchy_parent_child_instance
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "parent"
+      - "child"

--- a/tests/cases/cpp/hierarchy_parent_child_instance/main.sv
+++ b/tests/cases/cpp/hierarchy_parent_child_instance/main.sv
@@ -1,0 +1,8 @@
+module Child;
+  initial $display("child");
+endmodule
+
+module Test;
+  Child c();
+  initial $display("parent");
+endmodule


### PR DESCRIPTION
## Summary

A module can now instantiate another module, and the parent's constructor builds that child as a distinct object it owns in the object tree. Parent and child stay separate compilation units: the only thing that crosses the boundary is the child's interface (its name), resolved by name at emit time as an `#include`, exactly like a C++ header. Until now a child instance in a module body was silently dropped and the instantiated module was never compiled at all.

## Design

The generate-child machinery already builds owned child objects, but intra-unit: an owning pointer to a nested scope of the same unit. This adds the cross-unit twin. HIR gains an instance-member declaration that names the target unit by string; MIR gains an `ExternalUnitObjectType` (an owning pointer whose target is another unit's name) and a `ConstructExternalUnitStmt`, kept deliberately separate from the intra-unit object type and construct statement so the two never share a target kind. The AST-to-HIR seam, the last point holding the whole design in view, now enumerates every compiled unit (the tops plus everything reached transitively through instantiation, deduped per definition) while keeping the set of top-level blocks distinct from the set of compiled units. The backend emits the child's header include, an owning-pointer member constructed in the parent's constructor, and a module-instance child scope in `Bind`; the driver constructs only the tops in `main`, so an instantiated-only child is compiled but not a top.

## Testing

New end-to-end case `hierarchy_parent_child_instance`: a parent instantiates a child, both run an `initial`, and both lines appear in the output. Full `bazel test //...` passes.