### PR TITLE
Support module instances inside generate blocks

### DIFF
--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -71,13 +71,16 @@ Unlocks the compile-time side of `instantiation/specialization_grouping` and
 
 - [x] B1 -- A module instantiates a child; the constructor builds the child as a distinct object
       owned by the parent in the object tree. Parent and child remain separate units.
-- [ ] B2 -- The same module instantiated several times yields independent objects, each owning its
+- [x] B2 -- The same module instantiated several times yields independent objects, each owning its
       own state.
-- [ ] B3 -- Instantiation nests: a child that itself instantiates a grandchild builds a multi-level
+- [x] B3 -- Instantiation nests: a child that itself instantiates a grandchild builds a multi-level
       object tree.
-- [ ] B4 -- A child's own (non-port) local state and processes run correctly inside its object.
-- [ ] B5 -- Generate (`for` / `if` / `case`) constructs child instances as part of the object tree,
-      including arrays of instances; which children exist is a construction-time decision.
+- [x] B4 -- A child's own (non-port) local state and processes run correctly inside its object.
+- [x] B5 -- Generate (`for` / `if` / `case`) wraps child instances: which generate blocks exist, and
+      how many loop iterations, is a construction-time decision, and each block owns its instances
+      as part of the object tree.
+- [ ] B6 -- An instance array (`Child c[3]()`) is one named member that expands to a vector of
+      independent child objects.
 
 Unlocks `instantiation/multiple_instances`, `instantiation/nested_hierarchy`,
 `instantiation/local_variables`, the runtime side of `instantiation/param_slots`, and

--- a/src/lyra/lowering/ast_to_hir/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/lower.cpp
@@ -1,15 +1,13 @@
 #include "lyra/lowering/ast_to_hir/lower.hpp"
 
-#include <cstddef>
 #include <expected>
 #include <string>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
+#include <slang/ast/ASTVisitor.h>
 #include <slang/ast/Compilation.h>
-#include <slang/ast/Scope.h>
-#include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/CompilationUnitSymbols.h>
 #include <slang/ast/symbols/InstanceSymbols.h>
 
@@ -20,41 +18,47 @@
 
 namespace lyra::lowering::ast_to_hir {
 
+namespace {
+
+// Collects the distinct unit bodies reachable from the tops. slang owns the
+// structural descent: visiting an instance recurses into its body, and every
+// container (generate blocks, instance arrays) is a Scope the visitor walks
+// through, so an instance nested in a generate block is reached without this
+// code knowing the container taxonomy. The canonical body keys the dedup so a
+// module instantiated many times is lowered once.
+struct UnitCollector
+    : slang::ast::ASTVisitor<UnitCollector, slang::ast::VisitFlags::Canonical> {
+  std::unordered_set<const slang::ast::InstanceBodySymbol*> seen;
+  std::vector<const slang::ast::InstanceBodySymbol*> order;
+
+  void handle(const slang::ast::InstanceSymbol& inst) {
+    const auto* canonical = inst.getCanonicalBody();
+    const auto& body = canonical != nullptr ? *canonical : inst.body;
+    if (seen.insert(&body).second) {
+      order.push_back(&body);
+      visitDefault(inst);
+    }
+  }
+};
+
+}  // namespace
+
 auto LowerCompilation(const LowerCompilationFacts& facts)
     -> diag::Result<std::vector<hir::ModuleUnit>> {
   const UnitLoweringFacts unit_facts(facts.SourceMapper(), facts.Sensitivity());
   const auto& root = facts.Compilation().getRoot();
 
-  // Worklist of unit bodies, seeded with the top-level blocks and grown by
-  // walking each lowered body's child instances, deduped so each definition is
-  // lowered once. A child is reached only through its instance's definition
-  // name (its header); the parent never reads the child's body.
-  std::vector<const slang::ast::InstanceBodySymbol*> worklist;
-  std::unordered_set<const slang::ast::DefinitionSymbol*> seen_defs;
-  std::vector<hir::ModuleUnit> units;
-
-  for (const auto* inst : root.topInstances) {
-    const auto* body = &inst->body;
-    if (seen_defs.insert(&body->getDefinition()).second) {
-      worklist.push_back(body);
-    }
+  UnitCollector collector;
+  for (const auto* top : root.topInstances) {
+    top->visit(collector);
   }
 
-  for (std::size_t i = 0; i < worklist.size(); ++i) {
-    const auto* body = worklist[i];
+  std::vector<hir::ModuleUnit> units;
+  units.reserve(collector.order.size());
+  for (const auto* body : collector.order) {
     auto u = LowerModule(unit_facts, *body);
     if (!u) return std::unexpected(std::move(u.error()));
     units.push_back(*std::move(u));
-
-    for (const auto& member : body->members()) {
-      if (member.kind != slang::ast::SymbolKind::Instance) {
-        continue;
-      }
-      const auto* child_body = &member.as<slang::ast::InstanceSymbol>().body;
-      if (seen_defs.insert(&child_body->getDefinition()).second) {
-        worklist.push_back(child_body);
-      }
-    }
   }
 
   return units;

--- a/tests/cases/cpp/hierarchy_generate_instance/case.yaml
+++ b/tests/cases/cpp/hierarchy_generate_instance/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.hierarchy_generate_instance
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      child
+      child
+      child

--- a/tests/cases/cpp/hierarchy_generate_instance/main.sv
+++ b/tests/cases/cpp/hierarchy_generate_instance/main.sv
@@ -1,0 +1,12 @@
+module Child;
+  initial $display("child");
+endmodule
+
+module Top;
+  for (genvar i = 0; i < 2; i = i + 1) begin : row
+    Child c();
+  end
+  if (1) begin : g
+    Child d();
+  end
+endmodule

--- a/tests/cases/cpp/hierarchy_multiple_instances/case.yaml
+++ b/tests/cases/cpp/hierarchy_multiple_instances/case.yaml
@@ -1,0 +1,10 @@
+id: cpp.hierarchy_multiple_instances
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "x=2\nx=2\n"

--- a/tests/cases/cpp/hierarchy_multiple_instances/main.sv
+++ b/tests/cases/cpp/hierarchy_multiple_instances/main.sv
@@ -1,0 +1,14 @@
+module Child;
+  int x;
+  initial begin
+    x = 0;
+    #1 x = x + 1;
+    #1 x = x + 1;
+    $display("x=%0d", x);
+  end
+endmodule
+
+module Top;
+  Child c1();
+  Child c2();
+endmodule

--- a/tests/cases/cpp/hierarchy_nested_instance/case.yaml
+++ b/tests/cases/cpp/hierarchy_nested_instance/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.hierarchy_nested_instance
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    contains:
+      - "top"
+      - "mid m=9"
+      - "leaf v=5 dbl=10"

--- a/tests/cases/cpp/hierarchy_nested_instance/main.sv
+++ b/tests/cases/cpp/hierarchy_nested_instance/main.sv
@@ -1,0 +1,23 @@
+module Leaf;
+  int v;
+  int dbl;
+  always_comb dbl = v * 2;
+  initial begin
+    v = 5;
+    #1 $display("leaf v=%0d dbl=%0d", v, dbl);
+  end
+endmodule
+
+module Mid;
+  Leaf lf();
+  int m;
+  initial begin
+    m = 9;
+    $display("mid m=%0d", m);
+  end
+endmodule
+
+module Top;
+  Mid md();
+  initial $display("top");
+endmodule


### PR DESCRIPTION
## Summary

Stage B1 added the instantiation edge; this lands the rest of Stage B's object-graph construction. Module instances written inside `generate for` / `if` / `case` blocks now compile and run. Unit discovery previously walked only a module's top-level instances, so a child instantiated inside a generate block was never compiled into its own unit and its header was never emitted (`Child.hpp` not found). Discovery now walks the full elaborated instance tree, driven by slang's AST visitor, which descends through every container scope so a nested instance is reached without this code re-deriving the container taxonomy. Construction, binding, and header inclusion already composed through the existing nested-scope machinery, so this discovery gap was the one missing piece.

The same change keys unit deduplication on the canonical instance body rather than the definition, which is the correct axis once code-shape parameters arrive in Stage A2.

This PR also adds regression coverage for the multiplicity, nesting, and child-local-state behaviors that B1's machinery already supported but were untested, and splits the progress tracker's combined generate/array item into two: generate-wrapped instances (done) and instance arrays (deferred to a later cut).

## Testing

`bazel test //...` passes. New end-to-end cases cover instances in `for` and `if` generate blocks, several independent instances of one module with provably independent state, three-level nested instantiation carrying local state at each level, and a child combinational process recomputing on its own storage.
