### PR TITLE
Add subroutine static/automatic lifetime and recursion

### DIFF
--- a/docs/progress/functions.md
+++ b/docs/progress/functions.md
@@ -43,10 +43,16 @@ everything and the inline "rides on" notes record the real dependencies.
 
 ### Lifetime and recursion
 
-- [ ] F3 -- `automatic` lifetime and recursion (LRM 13.3.1, 13.3.2, 13.4.2). Automatic subroutines
-      are reentrant with per-call storage; static (the module / package default) shares one copy
-      across concurrent activations and retains values between calls. Recursion requires automatic
-      storage. Rides on F1.
+- [x] F3 -- `automatic` lifetime and recursion (LRM 13.3.1, 13.3.2, 13.4.2). A subroutine local
+      follows its resolved lifetime: an automatic local is reinitialized on entry and lives only for
+      the activation, while a static local (the module / package default) has one per-instance copy
+      that retains its value between calls and is default-initialized once. Per-variable `automatic`
+      / `static` overrides are honored, so both lifetimes coexist in one body. Calls resolve
+      regardless of source order, so direct recursion, mutual recursion, and forward references to a
+      later-defined subroutine all work for automatic-lifetime subroutines. Not yet: separate static
+      storage across multiple instances of a module (rides on module hierarchy); static-lifetime
+      formal arguments and the implicit result variable, which still behave as automatic; and two
+      static locals sharing a name in sibling blocks of one subroutine.
 
 ### Arguments
 
@@ -90,8 +96,8 @@ everything and the inline "rides on" notes record the real dependencies.
 - [x] T1 -- Tasks without timing controls (LRM 13.3). Enabled as a statement; results returned
       through `output` / `inout` arguments; `return` exits before `endtask`; an empty body is a
       no-op. A task may enable other tasks and functions (LRM 13.2); a function enabling a task is
-      rejected. Behaves like a void function. The static-default lifetime where locals retain values
-      across enables (LRM 13.3.1) is not yet distinguished from automatic and is tracked by F3.
+      rejected. Behaves like a void function. Task locals follow the static / automatic lifetime
+      distinction established by F3.
 - [ ] T2 -- Tasks containing time-controlling statements (LRM 13.3). `#`, `@(...)`, and `wait`
       inside a task suspend the calling process and resume it later, so a task enable can span
       multiple time steps. Rides on the timing-control machinery tracked in `processes.md`.

--- a/include/lyra/backend/cpp/render_context.hpp
+++ b/include/lyra/backend/cpp/render_context.hpp
@@ -27,15 +27,29 @@ class RenderContext {
 
   [[nodiscard]] auto WithProceduralScope(
       const mir::ProceduralScope& child) const -> RenderContext {
-    return RenderContext{*unit_,       *scope_, child, this, structural_parent_,
-                         temp_counter_};
+    return RenderContext{
+        *unit_,        *scope_,      child, this, structural_parent_,
+        temp_counter_, static_frame_};
   }
 
   [[nodiscard]] auto WithStructuralScope(
       const mir::StructuralScope& child_scope,
       const mir::ProceduralScope& root_proc_scope) const -> RenderContext {
-    return RenderContext{*unit_,  child_scope, root_proc_scope,
-                         nullptr, this,        temp_counter_};
+    return RenderContext{
+        *unit_, child_scope, root_proc_scope, nullptr, this, temp_counter_, {}};
+  }
+
+  // A subroutine body renders its static locals through this per-instance frame
+  // member (LRM 13.3.1). Empty when the current callable has no static locals.
+  [[nodiscard]] auto WithStaticFrame(std::string_view accessor) const
+      -> RenderContext {
+    return RenderContext{*unit_,
+                         *scope_,
+                         *proc_scope_,
+                         procedural_parent_,
+                         structural_parent_,
+                         temp_counter_,
+                         accessor};
   }
 
   RenderContext(const RenderContext&) = delete;
@@ -82,6 +96,10 @@ class RenderContext {
         mir::StructuralHops{.value = hops.value - 1});
   }
 
+  [[nodiscard]] auto StaticFrame() const -> std::string_view {
+    return static_frame_;
+  }
+
   [[nodiscard]] auto Expr(mir::ExprId id) const -> const mir::Expr& {
     return proc_scope_->GetExpr(id);
   }
@@ -107,13 +125,15 @@ class RenderContext {
       const mir::CompilationUnit& unit, const mir::StructuralScope& scope,
       const mir::ProceduralScope& proc_scope,
       const RenderContext* procedural_parent,
-      const RenderContext* structural_parent, std::size_t* temp_counter)
+      const RenderContext* structural_parent, std::size_t* temp_counter,
+      std::string_view static_frame)
       : unit_(&unit),
         scope_(&scope),
         proc_scope_(&proc_scope),
         procedural_parent_(procedural_parent),
         structural_parent_(structural_parent),
-        temp_counter_(temp_counter) {
+        temp_counter_(temp_counter),
+        static_frame_(static_frame) {
   }
 
   const mir::CompilationUnit* unit_;
@@ -122,6 +142,7 @@ class RenderContext {
   const RenderContext* procedural_parent_;
   const RenderContext* structural_parent_;
   std::size_t* temp_counter_;
+  std::string_view static_frame_;
   mutable std::size_t owned_temp_counter_ = 0;
 };
 

--- a/include/lyra/hir/procedural_var.hpp
+++ b/include/lyra/hir/procedural_var.hpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <string>
 
-#include "lyra/hir/type.hpp"
+#include "lyra/hir/type_id.hpp"
 
 namespace lyra::hir {
 
@@ -15,9 +15,20 @@ struct ProceduralVarId {
       -> std::strong_ordering = default;
 };
 
+// LRM 13.3.1 / 13.4.2 variable lifetime. A static-lifetime variable has one
+// storage location per module instance that retains its value between calls;
+// an automatic-lifetime variable is allocated fresh for each activation. slang
+// resolves the source keyword and the enclosing module / subroutine default
+// into a per-variable choice, which HIR records verbatim.
+enum class VariableLifetime : std::uint8_t {
+  kStatic,
+  kAutomatic,
+};
+
 struct ProceduralVarDecl {
   std::string name;
   TypeId type;
+  VariableLifetime lifetime = VariableLifetime::kAutomatic;
 };
 
 }  // namespace lyra::hir

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -339,14 +339,30 @@ class ScopeLoweringState {
     return id;
   }
 
-  auto AddStructuralSubroutine(
-      const slang::ast::SubroutineSymbol& sym,
-      hir::StructuralSubroutineDecl decl) -> hir::StructuralSubroutineId {
-    const hir::StructuralSubroutineId local{
-        static_cast<std::uint32_t>(scope_->structural_subroutines.size())};
-    scope_->structural_subroutines.push_back(std::move(decl));
+  // Forward-declares a subroutine: registers its binding to a stable
+  // source-order id before any body is lowered, so a call resolves regardless
+  // of source order -- direct and mutual recursion and forward references (LRM
+  // 13.4.2). Bodies are added afterwards in the same order by
+  // AddStructuralSubroutine.
+  void ReserveSubroutineBinding(const slang::ast::SubroutineSymbol& sym) {
+    const hir::StructuralSubroutineId local{reserved_subroutine_count_++};
     unit_state_->MapSubroutineBinding(sym, frame_, local);
-    return local;
+  }
+
+  void AddStructuralSubroutine(
+      const slang::ast::SubroutineSymbol& sym,
+      hir::StructuralSubroutineDecl decl) {
+    const auto binding = unit_state_->LookupSubroutineBinding(sym);
+    if (!binding.has_value() ||
+        binding->subroutine_id.value !=
+            static_cast<std::uint32_t>(scope_->structural_subroutines.size())) {
+      throw InternalError(
+          "ScopeLoweringState::AddStructuralSubroutine: subroutine added out "
+          "of "
+          "reserved order; ReserveSubroutineBinding must run first in the same "
+          "order");
+    }
+    scope_->structural_subroutines.push_back(std::move(decl));
   }
 
   [[nodiscard]] auto UnitState() -> UnitLoweringState& {
@@ -369,6 +385,7 @@ class ScopeLoweringState {
   UnitLoweringState* unit_state_;
   hir::StructuralScope* scope_;
   ScopeFrameId frame_;
+  std::uint32_t reserved_subroutine_count_ = 0;
 };
 
 class ProcessLoweringState {
@@ -402,7 +419,12 @@ class ProcessLoweringState {
     const hir::ProceduralVarId id{
         static_cast<std::uint32_t>(body_.procedural_vars.size())};
     body_.procedural_vars.push_back(
-        hir::ProceduralVarDecl{.name = std::string{var.name}, .type = type});
+        hir::ProceduralVarDecl{
+            .name = std::string{var.name},
+            .type = type,
+            .lifetime = var.lifetime == slang::ast::VariableLifetime::Automatic
+                            ? hir::VariableLifetime::kAutomatic
+                            : hir::VariableLifetime::kStatic});
     const auto [_, inserted] = procedural_var_bindings_.emplace(&var, id);
     if (!inserted) {
       throw InternalError(

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -388,10 +388,18 @@ struct ProceduralVarBinding {
   mir::ProceduralVarId var;
 };
 
+class ProceduralScopeLoweringState;
+
 class ProcessLoweringState {
  public:
-  explicit ProcessLoweringState(TimeResolution time_resolution)
-      : time_resolution_(time_resolution) {
+  // A subroutine passes its root procedural scope as the static-frame scope so
+  // static-lifetime locals are collected there (LRM 13.3.1); a process / a
+  // continuous assign leaves it null and keeps every local in the activation.
+  explicit ProcessLoweringState(
+      TimeResolution time_resolution,
+      ProceduralScopeLoweringState* static_frame_scope = nullptr)
+      : time_resolution_(time_resolution),
+        static_frame_scope_(static_frame_scope) {
   }
 
   [[nodiscard]] auto Resolution() const -> TimeResolution {
@@ -410,6 +418,27 @@ class ProcessLoweringState {
   }
   [[nodiscard]] auto CurrentProceduralDepth() const -> std::uint32_t {
     return procedural_depth_;
+  }
+
+  // Static-lifetime locals land in the frame scope (the subroutine's root
+  // procedural scope) regardless of the block they are declared in, so a body
+  // reference reaches the storage by hops (LRM 13.3.1). Null for processes,
+  // where every local stays in the activation.
+  [[nodiscard]] auto CollectsStaticLocals() const -> bool {
+    return static_frame_scope_ != nullptr;
+  }
+  [[nodiscard]] auto StaticFrameScope() const -> ProceduralScopeLoweringState& {
+    if (static_frame_scope_ == nullptr) {
+      throw InternalError(
+          "ProcessLoweringState::StaticFrameScope: no frame scope set");
+    }
+    return *static_frame_scope_;
+  }
+  void AddStaticLocal(mir::StaticLocal local) {
+    static_locals_.push_back(local);
+  }
+  auto TakeStaticLocals() -> std::vector<mir::StaticLocal> {
+    return std::move(static_locals_);
   }
 
   void MapProceduralVar(
@@ -453,6 +482,8 @@ class ProcessLoweringState {
   TimeResolution time_resolution_;
   std::uint32_t procedural_depth_ = 0;
   std::vector<ProceduralVarBinding> bindings_;
+  ProceduralScopeLoweringState* static_frame_scope_ = nullptr;
+  std::vector<mir::StaticLocal> static_locals_;
 };
 
 class ProceduralDepthGuard {

--- a/include/lyra/mir/procedural_var.hpp
+++ b/include/lyra/mir/procedural_var.hpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <string>
 
-#include "lyra/mir/type.hpp"
+#include "lyra/mir/type_id.hpp"
 
 namespace lyra::mir {
 
@@ -15,9 +15,19 @@ struct ProceduralVarId {
       -> std::strong_ordering = default;
 };
 
+// LRM 13.3.1 / 13.4.2 variable lifetime. A kStatic var has one storage slot
+// per module instance that the body shares across activations; a kAutomatic var
+// lives in the activation (a C++ stack local). The lifetime is a semantic
+// property; the backend chooses the placement it implies.
+enum class VariableLifetime : std::uint8_t {
+  kStatic,
+  kAutomatic,
+};
+
 struct ProceduralVarDecl {
   std::string name;
   TypeId type;
+  VariableLifetime lifetime = VariableLifetime::kAutomatic;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/structural_subroutine.hpp
+++ b/include/lyra/mir/structural_subroutine.hpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+#include "lyra/mir/expr_id.hpp"
+#include "lyra/mir/procedural_var.hpp"
 #include "lyra/mir/stmt.hpp"
 #include "lyra/mir/type_id.hpp"
 
@@ -27,14 +29,27 @@ struct SubroutineParam {
   ParamDirection direction = ParamDirection::kInput;
 };
 
+// A static-lifetime body local (LRM 13.3.1). It does not live in the
+// activation; the backend gives it one storage slot per module instance. `var`
+// indexes `root_procedural_scope.vars` (body references reach it through that
+// id); `init` indexes `root_procedural_scope.exprs` and is evaluated once when
+// the instance is built, not on each call.
+struct StaticLocal {
+  ProceduralVarId var;
+  ExprId init;
+};
+
 // A subroutine is a callable peer of a process: its body is a ProceduralScope,
 // the same shape a process body uses. `params` names which of the scope's vars
-// are formals (the rest are body locals).
+// are formals (the rest are body locals). `static_locals` lists the body locals
+// whose lifetime is static; the backend stores them per instance instead of in
+// the activation.
 struct StructuralSubroutineDecl {
   std::string name;
   TypeId result_type;
   std::vector<SubroutineParam> params;
   ProceduralScope root_procedural_scope;
+  std::vector<StaticLocal> static_locals;
 };
 
 }  // namespace lyra::mir

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -155,13 +155,33 @@ auto RenderSubroutineMethod(
   }
   sig += ")";
 
+  const std::string frame_field =
+      sub.static_locals.empty() ? std::string{} : sub.name + "__static";
   const RenderContext sub_ctx =
-      (parent_struct_ctx == nullptr)
-          ? RenderContext::ForRoot(unit, s, sub.root_procedural_scope)
-          : parent_struct_ctx->WithStructuralScope(
-                s, sub.root_procedural_scope);
+      (parent_struct_ctx == nullptr
+           ? RenderContext::ForRoot(unit, s, sub.root_procedural_scope)
+           : parent_struct_ctx->WithStructuralScope(
+                 s, sub.root_procedural_scope))
+          .WithStaticFrame(frame_field);
 
   std::string out;
+  // LRM 13.3.1 static locals: one per-instance frame member, default-evaluated
+  // once at construction; the body reads and writes it across activations.
+  if (!sub.static_locals.empty()) {
+    out += Indent(indent) + "struct " + sub.name + "_StaticFrame {\n";
+    for (const auto& sl : sub.static_locals) {
+      const auto& var = sub.root_procedural_scope.vars.at(sl.var.value);
+      auto type_or = RenderTypeAsCpp(unit, s, var.type);
+      if (!type_or) return std::unexpected(std::move(type_or.error()));
+      auto init_or =
+          RenderExpr(sub_ctx, sub.root_procedural_scope.GetExpr(sl.init));
+      if (!init_or) return std::unexpected(std::move(init_or.error()));
+      out += Indent(indent + 1) + *type_or + " " + var.name + " = " + *init_or +
+             ";\n";
+    }
+    out += Indent(indent) + "} " + frame_field + "{};\n";
+  }
+
   out += Indent(indent) + sig + " {\n";
   auto rendered_or = RenderProceduralScopeStatements(sub_ctx, indent + 1);
   if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -192,9 +192,12 @@ auto RenderStructuralParamExpr(
 }
 
 auto LookupProceduralVarName(
-    const RenderContext& ctx, const mir::ProceduralVarRef& ref)
-    -> const std::string& {
-  return ctx.ProceduralScopeAtHops(ref.hops).vars.at(ref.var.value).name;
+    const RenderContext& ctx, const mir::ProceduralVarRef& ref) -> std::string {
+  const auto& var = ctx.ProceduralScopeAtHops(ref.hops).vars.at(ref.var.value);
+  if (var.lifetime == mir::VariableLifetime::kStatic) {
+    return std::format("{}.{}", ctx.StaticFrame(), var.name);
+  }
+  return var.name;
 }
 
 }  // namespace

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -929,8 +929,9 @@ class HirDumper {
         const auto& lv = body.procedural_vars[i];
         Line(
             std::format(
-                "ProceduralVar[{}] \"{}\" : Type[{}]", i, lv.name,
-                lv.type.value));
+                "ProceduralVar[{}] \"{}\" : Type[{}]{}", i, lv.name,
+                lv.type.value,
+                lv.lifetime == VariableLifetime::kStatic ? " static" : ""));
       }
       Dedent();
     }

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -299,6 +299,17 @@ auto LowerScopeMembersInto(
   // (slang Scope.cpp:927-1033); we hand the dispatcher only the first sibling
   // and skip the rest, so the per-construct sibling-collect loop inside
   // LowerIfOrCaseGenerateMemberInto runs exactly once per construct.
+  // Forward-declare every subroutine's binding before lowering any body so a
+  // call resolves regardless of source order: direct self-recursion, mutual
+  // recursion, and forward references to a later-defined subroutine (LRM
+  // 13.4.2). Bodies are added in the same order by the main pass below.
+  for (const auto& member : slang_scope.members()) {
+    if (member.kind == slang::ast::SymbolKind::Subroutine) {
+      scope_state.ReserveSubroutineBinding(
+          member.as<slang::ast::SubroutineSymbol>());
+    }
+  }
+
   std::unordered_set<std::uint32_t> consumed_construct_indices;
   for (const auto& member : slang_scope.members()) {
     if (member.kind == slang::ast::SymbolKind::GenerateBlock) {

--- a/src/lyra/lowering/hir_to_mir/lower_process.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_process.cpp
@@ -141,8 +141,8 @@ auto LowerStructuralSubroutine(
     const StructuralScopeLoweringState& scope_state,
     const hir::StructuralSubroutineDecl& src, TimeResolution time_resolution)
     -> diag::Result<mir::StructuralSubroutineDecl> {
-  ProcessLoweringState proc_state{time_resolution};
   ProceduralScopeLoweringState body_scope_state;
+  ProcessLoweringState proc_state{time_resolution, &body_scope_state};
 
   // Formals are procedural vars of the body with no VarDeclStmt: pre-register
   // them in the body scope at depth 0 so the body's references resolve. The
@@ -199,11 +199,13 @@ auto LowerStructuralSubroutine(
     body_scope_state.AppendStmt(mir::ReturnStmt{.value = result_read});
   }
 
+  std::vector<mir::StaticLocal> static_locals = proc_state.TakeStaticLocals();
   return mir::StructuralSubroutineDecl{
       .name = src.name,
       .result_type = result_type,
       .params = std::move(params),
-      .root_procedural_scope = body_scope_state.Finish()};
+      .root_procedural_scope = body_scope_state.Finish(),
+      .static_locals = std::move(static_locals)};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -99,6 +99,40 @@ auto LowerVarDeclStmt(
     const hir::VarDeclStmt& v) -> diag::Result<mir::Stmt> {
   const auto& hir_local = hir_proc.procedural_vars.at(v.var.value);
   const mir::TypeId type = unit_state.TranslateType(hir_local.type);
+
+  // LRM 13.3.1: a static body local does not live in the activation. Its
+  // storage and init go into the subroutine's frame scope (the root procedural
+  // scope), so a body reference reaches it by hops and the init is evaluated
+  // once when the instance is built. The body declaration itself emits nothing.
+  const bool is_static = hir_local.lifetime == hir::VariableLifetime::kStatic;
+  if (is_static && proc_state.CollectsStaticLocals()) {
+    auto& frame_scope = proc_state.StaticFrameScope();
+    const mir::ProceduralVarId static_id = frame_scope.AddProceduralVar(
+        mir::ProceduralVarDecl{
+            .name = hir_local.name,
+            .type = type,
+            .lifetime = mir::VariableLifetime::kStatic});
+    proc_state.MapProceduralVar(
+        v.var, ProceduralVarBinding{
+                   .declaration_procedural_depth = 0, .var = static_id});
+    mir::ExprId static_init{};
+    if (v.init.has_value()) {
+      auto init_or = LowerExpr(
+          unit_state, scope_state, proc_state, frame_scope, hir_proc,
+          hir_proc.exprs.at(v.init->value));
+      if (!init_or) return std::unexpected(std::move(init_or.error()));
+      static_init = frame_scope.AddExpr(*std::move(init_or));
+    } else {
+      static_init = SynthesizeDefaultValueExpr(unit_state, frame_scope, type);
+    }
+    proc_state.AddStaticLocal(
+        mir::StaticLocal{.var = static_id, .init = static_init});
+    return mir::Stmt{
+        .label = stmt.label,
+        .data = mir::EmptyStmt{},
+        .child_procedural_scopes = {}};
+  }
+
   const mir::ProceduralVarId local_id = proc_scope_state.AddProceduralVar(
       mir::ProceduralVarDecl{.name = hir_local.name, .type = type});
   proc_state.MapProceduralVar(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -657,6 +657,13 @@ class MirDumper {
               FormatParamDirection(param.direction), param.name,
               param.type.value));
     }
+    for (std::size_t i = 0; i < d.static_locals.size(); ++i) {
+      const auto& sl = d.static_locals[i];
+      Line(
+          std::format(
+              "StaticLocal[{}] var=ProceduralVar[{}] init=Expr[{}]", i,
+              sl.var.value, sl.init.value));
+    }
     DumpProceduralScope(d.root_procedural_scope);
     Dedent();
   }
@@ -670,8 +677,9 @@ class MirDumper {
         const auto& v = scope.vars[i];
         Line(
             std::format(
-                "ProceduralVar[{}] \"{}\" : Type[{}]", i, v.name,
-                v.type.value));
+                "ProceduralVar[{}] \"{}\" : Type[{}]{}", i, v.name,
+                v.type.value,
+                v.lifetime == VariableLifetime::kStatic ? " static" : ""));
       }
       Dedent();
     }

--- a/tests/cases/cpp/function_automatic_recursion/case.yaml
+++ b/tests/cases/cpp/function_automatic_recursion/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.function_automatic_recursion
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r_fact: 120
+    r_reinit1: 5
+    r_reinit2: 5
+    r_forward: 21
+    r_even: 1
+    r_odd: 0

--- a/tests/cases/cpp/function_automatic_recursion/main.sv
+++ b/tests/cases/cpp/function_automatic_recursion/main.sv
@@ -1,0 +1,46 @@
+module Top;
+  int r_fact;
+  int r_reinit1;
+  int r_reinit2;
+  int r_forward;
+  int r_even;
+  int r_odd;
+
+  function automatic int fact(int n);
+    if (n <= 1) return 1;
+    return n * fact(n - 1);
+  endfunction
+
+  function automatic int g();
+    int x;
+    x = x + 5;
+    return x;
+  endfunction
+
+  function automatic int caller(int n);
+    return callee(n) + 1;
+  endfunction
+
+  function automatic int callee(int n);
+    return n * 2;
+  endfunction
+
+  function automatic int is_even(int n);
+    if (n == 0) return 1;
+    return is_odd(n - 1);
+  endfunction
+
+  function automatic int is_odd(int n);
+    if (n == 0) return 0;
+    return is_even(n - 1);
+  endfunction
+
+  initial begin
+    r_fact = fact(5);
+    r_reinit1 = g();
+    r_reinit2 = g();
+    r_forward = caller(10);
+    r_even = is_even(8);
+    r_odd = is_odd(8);
+  end
+endmodule

--- a/tests/cases/cpp/function_static_local/case.yaml
+++ b/tests/cases/cpp/function_static_local/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.function_static_local
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r_id1: 1
+    r_id2: 2
+    r_id3: 3
+    r_mix1: 2
+    r_mix2: 4

--- a/tests/cases/cpp/function_static_local/main.sv
+++ b/tests/cases/cpp/function_static_local/main.sv
@@ -1,0 +1,29 @@
+module Top;
+  int r_id1;
+  int r_id2;
+  int r_id3;
+  int r_mix1;
+  int r_mix2;
+
+  function int next_id();
+    int counter;
+    counter = counter + 1;
+    return counter;
+  endfunction
+
+  function automatic int mix();
+    int a;
+    static int hits;
+    hits = hits + 1;
+    a = hits * 2;
+    return a;
+  endfunction
+
+  initial begin
+    r_id1 = next_id();
+    r_id2 = next_id();
+    r_id3 = next_id();
+    r_mix1 = mix();
+    r_mix2 = mix();
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements F3 of the subroutine roadmap: a subroutine local now follows its resolved variable lifetime. A static-lifetime local (the module/package default) gets one per-instance storage slot that retains its value between calls and is default-initialized once; an automatic-lifetime local lives in the activation and is reinitialized on entry. Per-variable `automatic`/`static` overrides are honored, so both lifetimes coexist in one body. Before this change every subroutine local was emitted as a stack local, so static locals silently failed to retain across calls.

Recursion also works now, and it was genuinely broken before: a self-call threw an internal error because the subroutine's binding was registered only after its body was lowered. Subroutine bindings are now forward-declared for the whole scope before any body is lowered, so calls resolve regardless of source order -- direct recursion, mutual recursion, and forward references to a later-defined subroutine.

## Design

Lifetime is a semantic tag carried through HIR and MIR (read verbatim from slang's resolved per-variable lifetime); the C++ backend chooses the placement it implies. A static local's storage and one-time init live in the subroutine's root procedural scope, so a body reference reaches it by hops at any block-nesting depth; the backend emits those as a per-instance frame struct member and renders references through it, while automatic locals stay stack-resident. The forward-declaration is a declare-then-define split: a scope pre-pass reserves each subroutine's binding id, and bodies are added afterwards in the same order.

## Testing

New cpp run-tests cover static retention across calls, mixed lifetimes in one body, factorial recursion, automatic re-initialization, mutual recursion, and forward references. Full suite green.

Not yet (noted in `docs/progress/functions.md`): separate static storage across multiple instances of a module (rides on module hierarchy); static-lifetime formal arguments and the implicit result variable, which still behave as automatic; and two static locals sharing a name in sibling blocks of one subroutine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)