### PR TITLE
Add unpacked invalid-index handling and declared-direction slice

### DIFF
--- a/docs/decisions/unpacked-array-representation.md
+++ b/docs/decisions/unpacked-array-representation.md
@@ -129,8 +129,14 @@ Unpacked array support follows these invariants:
    `render(element_type)` + `>`. The wrapper owns a private `std::vector<T>` and exposes a surface
    symmetric with `PackedArray` -- `ElementAt(const PackedArray&)`, `Slice(offset, count)`,
    `operator==` and `CaseEqual` returning a 1-bit `PackedArray` -- so the substrate-asymmetric
-   operations (equality with X / Z propagation, range selectors, future OOB and observability hooks)
-   live behind a single uniform method surface.
+   operations (equality with X / Z propagation, range selectors, observability hooks) live behind a
+   single uniform method surface. LRM 7.4.5 invalid-index handling lives in the wrapper too:
+   non-const `ElementAt` returns an `UnpackedElementRef<T>` proxy that captures the index's
+   validity, and the non-const `Slice` returns an `UnpackedArrayRef<T>` proxy that captures the
+   offset's validity. Reads through the proxies' `Clone()` return Table 7-1 defaults on invalid
+   access; writes through `operator=` and compound ops are silent no-ops. Slice reads on partially-
+   OOB positions handle the in-range and OOB elements per-element rather than at slice granularity,
+   matching `PackedArray::ExtractBits` / `AssignSlice`'s per-bit OOB treatment.
 
 3. **Default initialization emits an `UnpackedArray<T>{e0, e1, ...}` braced-init expression.**
 

--- a/docs/progress/unpacked.md
+++ b/docs/progress/unpacked.md
@@ -13,20 +13,19 @@ Done when:
 
 ## Actionable
 
-U1..U6 are done. U7 covers OOB behaviour plus the direction-mismatched / negative-base range
-follow-up. U8 records a cross-cutting observability gap surfaced by the unpacked-vs-packed
+U1..U7 are done. U8 records a cross-cutting observability gap surfaced by the unpacked-vs-packed
 asymmetry; the implementation lives under `refactor.md` R2.
 
-| Item | Status                                                        |
-| ---- | ------------------------------------------------------------- |
-| U1   | Done: type infrastructure + literal init + element read       |
-| U2   | Done: element write (blocking, NBA, compound)                 |
-| U3   | Done: structured and replicated assignment patterns           |
-| U4   | Done: whole-array assignment (blocking and NBA)               |
-| U5   | Done: array equality, inequality, case-equality               |
-| U6   | Done: constant-width slice (read and write)                   |
-| U7   | Open: OOB element access and ascending / negative-base ranges |
-| U8   | Open: unpacked vars participate in value-change observability |
+| Item | Status                                                         |
+| ---- | -------------------------------------------------------------- |
+| U1   | Done: type infrastructure + literal init + element read        |
+| U2   | Done: element write (blocking, NBA, compound)                  |
+| U3   | Done: structured and replicated assignment patterns            |
+| U4   | Done: whole-array assignment (blocking and NBA)                |
+| U5   | Done: array equality, inequality, case-equality                |
+| U6   | Done: constant-width slice (read and write)                    |
+| U7   | Done: invalid-index handling and non-canonical declared ranges |
+| U8   | Open: unpacked vars participate in value-change observability  |
 
 ## Sub-Steps
 
@@ -83,11 +82,16 @@ The numeric IDs are stable references and do not imply execution order beyond U1
       unpacked array. Slice equality (`A[i +: c] == B[j +: c]`) falls out from U5's recursive
       equality once the rvalue slice produces a wrapper value.
 
-### OOB and ranges
+### Invalid index and non-canonical declared ranges
 
-- [ ] U7 -- OOB read returns the element type's LRM Table 6-7 default; OOB write is a no-op (LRM
-      Table 7-1, LRM 7.4.5). Ascending range bounds (`int a [0:N]`) and negative-base bounds
-      (`int a [-1:6]`) translate through the index-to-offset path correctly.
+- [x] U7 -- LRM 7.4.5 invalid-index handling: a read with an out-of-bounds position or any X / Z bit
+      in the index returns the element type's LRM Table 7-1 default; a write under the same
+      condition is a silent no-op. Slice reads against a partially-OOB position yield in-range
+      elements normally and defaults for the OOB portion; slice writes drop the OOB portion. Slice
+      offset translation honours every declared range form -- ascending-from-zero, ascending with a
+      non-zero base, descending, and negative-base -- so the in-memory offset of a slice's first
+      element matches the slice's syntactic-leftmost SV position. Direction-mismatched constant
+      ranges and entirely-OOB constant ranges remain frontend-rejected by slang's binding.
 
 ### Observability
 

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
@@ -10,7 +11,25 @@
 namespace lyra::value {
 
 template <typename T>
+class UnpackedArray;
+template <typename T>
 class UnpackedArrayRef;
+template <typename T>
+class UnpackedElementRef;
+
+// LRM Table 7-1 default for a value of the same shape as `oracle`. The shape
+// oracle is needed because the type alone (`PackedArray`, `UnpackedArray<U>`)
+// does not determine the value's runtime parameters (bit width, signedness,
+// state-kind, nested size).
+inline auto MakeDefaultLike(const PackedArray& oracle) -> PackedArray {
+  return PackedArray{
+      oracle.BitWidth(), oracle.IsSigned(), oracle.IsFourState()};
+}
+
+template <typename U>
+auto MakeDefaultLike(const UnpackedArray<U>& oracle) -> UnpackedArray<U> {
+  return oracle.DefaultLike();
+}
 
 // SystemVerilog fixed-size unpacked array (LRM 7.4.2). One C++ container layer
 // per declared unpacked dimension; multi-dim composes as
@@ -20,9 +39,18 @@ class UnpackedArrayRef;
 // 7.4.5 contiguous-range selector, and `operator==` / `CaseEqual` returning a
 // 1-bit `PackedArray` so equality on aggregates propagates through the same
 // value-type the integral surface uses.
+//
+// LRM 7.4.5 invalid-index handling lives in this class and its non-const
+// chain proxies (`UnpackedElementRef`, `UnpackedArrayRef`): any X / Z bit in
+// the index, or any out-of-bounds position, makes the index invalid -- read
+// returns the Table 7-1 default for the requested type, write is a silent
+// no-op. Partial-OOB slices behave per-element: in-range elements participate
+// normally, OOB elements use the default on read / are dropped on write.
 template <typename T>
 class UnpackedArray {
  public:
+  using ElementType = T;
+
   UnpackedArray() = default;
   UnpackedArray(std::initializer_list<T> init) : data_(init) {
   }
@@ -32,26 +60,65 @@ class UnpackedArray {
   auto operator=(UnpackedArray&&) noexcept -> UnpackedArray& = default;
   ~UnpackedArray() = default;
 
-  // LRM 7.4.5 indexed access. The index arrives as a `PackedArray` carrying
-  // the SV-side value; the wrapper canonicalizes to a flat-vector offset so
-  // emitted call sites stay `(base).ElementAt(idx)` regardless of substrate.
-  [[nodiscard]] auto ElementAt(const PackedArray& idx) const -> const T& {
-    return data_[static_cast<std::size_t>(idx.ToInt64())];
-  }
-  [[nodiscard]] auto ElementAt(const PackedArray& idx) -> T& {
-    return data_[static_cast<std::size_t>(idx.ToInt64())];
-  }
-
   [[nodiscard]] auto Size() const -> std::size_t {
     return data_.size();
   }
 
-  // LRM 11.2.2 + 11.4.5: aggregate equality folds element comparisons with
-  // logical AND so X / Z in any element propagates to the 1-bit result. The
-  // terminal element comparison routes through the element type's own
-  // `operator==` (PackedArray for the integral leaf; UnpackedArray recursively
-  // for nested aggregates). `operator!=` is the bitwise negation of the
-  // equality result -- it stays a 1-bit PackedArray, not a host `bool`.
+  // LRM 7.4.5: read returns Table 7-1 default on invalid index. Returns a
+  // fresh value rather than a reference so the OOB case can synthesize a
+  // default without aliasing storage. Symmetric with
+  // `PackedArray::ElementAt(...) const -> PackedArray`.
+  [[nodiscard]] auto ElementAt(const PackedArray& idx) const -> T {
+    if (IsInvalidIndex(idx)) {
+      return MakeDefaultLike(data_.front());
+    }
+    return data_[static_cast<std::size_t>(idx.ToInt64())];
+  }
+
+  // Non-const overload yields a write-back proxy. The proxy captures the
+  // index's validity at construction; subsequent `operator=` / compound ops
+  // / chain calls observe that captured validity. Symmetric with
+  // `PackedArray::ElementAt(...) -> PackedArrayRef`.
+  [[nodiscard]] auto ElementAt(const PackedArray& idx)
+      -> UnpackedElementRef<T> {
+    return MakeElementRef(*this, idx);
+  }
+
+  // LRM 7.4.5 contiguous-range selector. The const overload materializes a
+  // fresh sub-array; partial-OOB positions yield Table 7-1 defaults at the
+  // element type, X / Z offset yields a wholly-default sub-array. The
+  // non-const overload returns a write-back proxy with the same invalid-index
+  // policy on `operator=`.
+  [[nodiscard]] auto Slice(
+      const PackedArray& offset_in_outer_elements,
+      std::uint32_t count_in_outer_elements) const -> UnpackedArray {
+    UnpackedArray result;
+    result.data_.reserve(count_in_outer_elements);
+    const bool offset_unknown = offset_in_outer_elements.HasUnknown();
+    const std::int64_t base =
+        offset_unknown ? 0 : offset_in_outer_elements.ToInt64();
+    const auto size = static_cast<std::int64_t>(data_.size());
+    for (std::uint32_t i = 0; i < count_in_outer_elements; ++i) {
+      const std::int64_t pos = base + static_cast<std::int64_t>(i);
+      if (offset_unknown || pos < 0 || pos >= size) {
+        result.data_.push_back(MakeDefaultLike(data_.front()));
+      } else {
+        result.data_.push_back(data_[static_cast<std::size_t>(pos)]);
+      }
+    }
+    return result;
+  }
+
+  [[nodiscard]] auto Slice(
+      const PackedArray& offset_in_outer_elements,
+      std::uint32_t count_in_outer_elements) -> UnpackedArrayRef<T> {
+    return UnpackedArrayRef<T>{
+        *this, offset_in_outer_elements, count_in_outer_elements};
+  }
+
+  // LRM 11.2.2 + 11.4.5 aggregate equality / case-equality. Slang's binding
+  // enforces equivalent operand size, so the loops over `data_` are matched.
+  // `==` / `!=` propagate X / Z; `CaseEqual` returns a deterministic 0/1.
   [[nodiscard]] auto operator==(const UnpackedArray& other) const
       -> PackedArray {
     PackedArray result = data_[0] == other.data_[0];
@@ -65,11 +132,6 @@ class UnpackedArray {
     return !(*this == other);
   }
 
-  // LRM 11.4.5 `===`: X / Z match as values, result is always 0 or 1 (no
-  // propagation). The fold mirrors `operator==`; the per-element terminal is
-  // `CaseEqElement` so a 4-state PackedArray operand re-tags its 2-state raw
-  // result to 4-state, keeping the aggregate state-kind consistent with the
-  // operands' element type.
   [[nodiscard]] auto CaseEqual(const UnpackedArray& other) const
       -> PackedArray {
     PackedArray result = CaseEqElement(data_[0], other.data_[0]);
@@ -79,36 +141,35 @@ class UnpackedArray {
     return result;
   }
 
-  // LRM 7.4.5 / 7.4.6 contiguous-range selector. Const overload materializes
-  // a fresh `UnpackedArray` (rvalue slice); the non-const overload returns an
-  // `UnpackedArrayRef` proxy so `arr.Slice(i, c) = b` routes element copies
-  // back to the base. Positions are outer-element offsets (a `PackedArray`
-  // carrying the SV-side index value); count is the LRM-guaranteed
-  // compile-time constant width.
-  [[nodiscard]] auto Slice(
-      const PackedArray& offset_in_outer_elements,
-      std::uint32_t count_in_outer_elements) const -> UnpackedArray {
-    const auto off =
-        static_cast<std::size_t>(offset_in_outer_elements.ToInt64());
+  // Build a fresh array of the same size with each element defaulted from
+  // this array's element 0. Used by `MakeDefaultLike` for the nested case
+  // and by `Slice` for OOB element synthesis on the const path.
+  [[nodiscard]] auto DefaultLike() const -> UnpackedArray {
     UnpackedArray result;
-    result.data_.assign(
-        data_.begin() + off, data_.begin() + off + count_in_outer_elements);
+    if (data_.empty()) {
+      return result;
+    }
+    result.data_.assign(data_.size(), MakeDefaultLike(data_.front()));
     return result;
-  }
-  [[nodiscard]] auto Slice(
-      const PackedArray& offset_in_outer_elements,
-      std::uint32_t count_in_outer_elements) -> UnpackedArrayRef<T> {
-    return UnpackedArrayRef<T>{
-        *this, static_cast<std::size_t>(offset_in_outer_elements.ToInt64()),
-        count_in_outer_elements};
   }
 
  private:
-  // Per-element CaseEqual. Terminal case (integral leaf) re-tags to 4-state
-  // when either operand is 4-state, because PackedArray::CaseEqual returns
-  // 2-state by LRM 11.4.5 but the aggregate state-kind follows the operand
-  // element type. Nested case (UnpackedArray<U>) delegates to the recursive
-  // CaseEqual -- it already produces the right state.
+  [[nodiscard]] auto IsInvalidIndex(const PackedArray& idx) const -> bool {
+    if (idx.HasUnknown()) return true;
+    const auto v = idx.ToInt64();
+    return v < 0 || static_cast<std::uint64_t>(v) >=
+                        static_cast<std::uint64_t>(data_.size());
+  }
+
+  static auto MakeElementRef(UnpackedArray& self, const PackedArray& idx)
+      -> UnpackedElementRef<T> {
+    if (self.IsInvalidIndex(idx)) {
+      return UnpackedElementRef<T>{self, std::size_t{0}, false};
+    }
+    return UnpackedElementRef<T>{
+        self, static_cast<std::size_t>(idx.ToInt64()), true};
+  }
+
   [[nodiscard]] static auto CaseEqElement(
       const PackedArray& a, const PackedArray& b) -> PackedArray {
     auto raw = a.CaseEqual(b);
@@ -124,19 +185,165 @@ class UnpackedArray {
   std::vector<T> data_;
 
   friend class UnpackedArrayRef<T>;
+  friend class UnpackedElementRef<T>;
+};
+
+// Write-back proxy for `UnpackedArray::ElementAt` non-const. Captures index
+// validity at construction; subsequent reads through `Clone()` and writes
+// through `operator=` (or compound ops, when T is `PackedArray`) honor that
+// validity per LRM 7.4.5. Chain methods (`ElementAt`, `Slice`) on a proxy
+// over a nested-aggregate element propagate the validity flag so an invalid
+// outer index makes the entire chain a no-op write / Table 7-1 default read.
+template <typename T>
+class UnpackedElementRef {
+ public:
+  UnpackedElementRef(UnpackedArray<T>& base, std::size_t offset, bool valid)
+      : base_(&base), offset_(offset), valid_(valid) {
+  }
+  UnpackedElementRef(const UnpackedElementRef&) = delete;
+  auto operator=(const UnpackedElementRef&) -> UnpackedElementRef& = delete;
+  UnpackedElementRef(UnpackedElementRef&&) noexcept = default;
+  auto operator=(UnpackedElementRef&&) noexcept
+      -> UnpackedElementRef& = default;
+  ~UnpackedElementRef() = default;
+
+  [[nodiscard]] auto Clone() const -> T {
+    if (valid_) {
+      return base_->data_[offset_];
+    }
+    return MakeDefaultLike(base_->data_.front());
+  }
+
+  auto operator=(const T& value) -> UnpackedElementRef& {
+    if (valid_) {
+      base_->data_[offset_] = value;
+    }
+    return *this;
+  }
+
+  // Compound assignment for PackedArray-element arrays. The load-modify-store
+  // pattern is gated by `valid_` so an invalid index is a silent no-op end to
+  // end, including the read that would otherwise observe garbage memory.
+  auto operator+=(const PackedArray& rhs) -> UnpackedElementRef&
+    requires std::same_as<T, PackedArray>
+  {
+    if (valid_) base_->data_[offset_] += rhs;
+    return *this;
+  }
+  auto operator-=(const PackedArray& rhs) -> UnpackedElementRef&
+    requires std::same_as<T, PackedArray>
+  {
+    if (valid_) base_->data_[offset_] -= rhs;
+    return *this;
+  }
+  auto operator*=(const PackedArray& rhs) -> UnpackedElementRef&
+    requires std::same_as<T, PackedArray>
+  {
+    if (valid_) base_->data_[offset_] *= rhs;
+    return *this;
+  }
+  auto operator/=(const PackedArray& rhs) -> UnpackedElementRef&
+    requires std::same_as<T, PackedArray>
+  {
+    if (valid_) base_->data_[offset_] /= rhs;
+    return *this;
+  }
+  auto operator%=(const PackedArray& rhs) -> UnpackedElementRef&
+    requires std::same_as<T, PackedArray>
+  {
+    if (valid_) base_->data_[offset_] %= rhs;
+    return *this;
+  }
+  auto operator&=(const PackedArray& rhs) -> UnpackedElementRef&
+    requires std::same_as<T, PackedArray>
+  {
+    if (valid_) base_->data_[offset_] &= rhs;
+    return *this;
+  }
+  auto operator|=(const PackedArray& rhs) -> UnpackedElementRef&
+    requires std::same_as<T, PackedArray>
+  {
+    if (valid_) base_->data_[offset_] |= rhs;
+    return *this;
+  }
+  auto operator^=(const PackedArray& rhs) -> UnpackedElementRef&
+    requires std::same_as<T, PackedArray>
+  {
+    if (valid_) base_->data_[offset_] ^= rhs;
+    return *this;
+  }
+  auto ShiftLeftAssign(const PackedArray& rhs) -> UnpackedElementRef&
+    requires std::same_as<T, PackedArray>
+  {
+    if (valid_) base_->data_[offset_].ShiftLeftAssign(rhs);
+    return *this;
+  }
+  auto LogicalShiftRightAssign(const PackedArray& rhs) -> UnpackedElementRef&
+    requires std::same_as<T, PackedArray>
+  {
+    if (valid_) base_->data_[offset_].LogicalShiftRightAssign(rhs);
+    return *this;
+  }
+  auto ArithmeticShiftRightAssign(const PackedArray& rhs) -> UnpackedElementRef&
+    requires std::same_as<T, PackedArray>
+  {
+    if (valid_) base_->data_[offset_].ArithmeticShiftRightAssign(rhs);
+    return *this;
+  }
+
+  // Chain composition for nested aggregates. The validity flag propagates: an
+  // invalid outer index makes the inner proxy invalid too, regardless of the
+  // inner index's value. The inner proxy still needs a real `UnpackedArray<U>`
+  // to bind to for shape oracle; we use `data_[0]` (always present in
+  // fixed-size unpacked arrays per LRM 7.4.2) when the outer is invalid.
+  // Chain composition for nested aggregates. Returned type is deduced so
+  // `typename T::ElementType` only fires at call-site instantiation; for a
+  // leaf-element proxy (T = PackedArray) the method is declared but never
+  // called from emit, so the dependent-name lookup never resolves.
+  [[nodiscard]] auto ElementAt(const PackedArray& idx) {
+    auto& inner = valid_ ? base_->data_[offset_] : base_->data_.front();
+    auto proxy = inner.ElementAt(idx);
+    if (!valid_) proxy.MarkInvalid();
+    return proxy;
+  }
+
+  [[nodiscard]] auto Slice(
+      const PackedArray& offset_in_outer_elements,
+      std::uint32_t count_in_outer_elements) {
+    auto& inner = valid_ ? base_->data_[offset_] : base_->data_.front();
+    auto proxy = inner.Slice(offset_in_outer_elements, count_in_outer_elements);
+    if (!valid_) proxy.MarkInvalid();
+    return proxy;
+  }
+
+  // Drop validity after construction. Used by chain composition when the
+  // outer proxy is invalid -- the inner proxy is constructed normally then
+  // demoted so any subsequent write is dropped.
+  auto MarkInvalid() -> void {
+    valid_ = false;
+  }
+
+ private:
+  UnpackedArray<T>* base_;
+  std::size_t offset_;
+  bool valid_;
 };
 
 // LRM 7.6: an assignment to an unpacked slice is a single assignment to the
 // entire slice. The proxy holds a non-owning pointer back to the source array
-// plus the (offset, count) window; `operator=` writes `count` elements at
-// `offset` from the right-hand-side value. Move-only so the proxy cannot
-// outlive the source it aliases.
+// plus the (offset, count) window. Invalid offset (X / Z, fully OOB) makes
+// `Clone()` return a wholly-default sub-array and `operator=` a no-op;
+// partial-OOB behaves per-element. Move-only so the proxy cannot outlive the
+// source it aliases.
 template <typename T>
 class UnpackedArrayRef {
  public:
   UnpackedArrayRef(
-      UnpackedArray<T>& base, std::size_t offset, std::size_t count)
-      : base_(&base), offset_(offset), count_(count) {
+      UnpackedArray<T>& base, const PackedArray& offset, std::uint32_t count)
+      : base_(&base),
+        offset_unknown_(offset.HasUnknown()),
+        offset_(offset.HasUnknown() ? 0 : offset.ToInt64()),
+        count_(count) {
   }
   UnpackedArrayRef(const UnpackedArrayRef&) = delete;
   auto operator=(const UnpackedArrayRef&) -> UnpackedArrayRef& = delete;
@@ -146,23 +353,40 @@ class UnpackedArrayRef {
 
   [[nodiscard]] auto Clone() const -> UnpackedArray<T> {
     UnpackedArray<T> result;
-    result.data_.assign(
-        base_->data_.begin() + offset_,
-        base_->data_.begin() + offset_ + count_);
+    result.data_.reserve(count_);
+    const auto size = static_cast<std::int64_t>(base_->data_.size());
+    for (std::uint32_t i = 0; i < count_; ++i) {
+      const std::int64_t pos = offset_ + static_cast<std::int64_t>(i);
+      if (!valid_ || offset_unknown_ || pos < 0 || pos >= size) {
+        result.data_.push_back(MakeDefaultLike(base_->data_.front()));
+      } else {
+        result.data_.push_back(base_->data_[static_cast<std::size_t>(pos)]);
+      }
+    }
     return result;
   }
 
   auto operator=(const UnpackedArray<T>& value) -> UnpackedArrayRef& {
-    for (std::size_t i = 0; i < count_; ++i) {
-      base_->data_[offset_ + i] = value.data_[i];
+    if (!valid_ || offset_unknown_) return *this;
+    const auto size = static_cast<std::int64_t>(base_->data_.size());
+    for (std::uint32_t i = 0; i < count_; ++i) {
+      const std::int64_t pos = offset_ + static_cast<std::int64_t>(i);
+      if (pos < 0 || pos >= size) continue;
+      base_->data_[static_cast<std::size_t>(pos)] = value.data_[i];
     }
     return *this;
   }
 
+  auto MarkInvalid() -> void {
+    valid_ = false;
+  }
+
  private:
   UnpackedArray<T>* base_;
-  std::size_t offset_;
-  std::size_t count_;
+  bool offset_unknown_;
+  std::int64_t offset_;
+  std::uint32_t count_;
+  bool valid_ = true;
 };
 
 }  // namespace lyra::value

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -1012,6 +1012,76 @@ auto WrapUnpackedIndex(
           .type = idx_type});
 }
 
+// LRM 7.4.5: an unpacked-array slice's first in-memory element is the
+// syntactic-leftmost SV position of the slice (slang enforces direction
+// match), translated through the declared range to a zero-based vector
+// offset. This is asymmetric to packed slice's `lowest LSB-bit` convention
+// because packed addresses are flat-bit and unpacked stores elements in
+// declared source order. The slice's element count comes from the result
+// type rather than the bounds expressions, so the helper does not need to
+// fold either bound to a literal -- negative-base sources can therefore
+// survive (slang exposes `-1` as a UnaryOp around an IntegerLiteral and
+// preserves it through binding).
+template <typename LowerOne>
+auto UnfoldHirRangeBoundsForUnpacked(
+    const UnitLoweringState& unit_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::RangeBounds& bounds, const hir::UnpackedRange& declared,
+    std::uint32_t count, LowerOne lower_one) -> diag::Result<RangeOffsetCount> {
+  const bool descending = declared.left >= declared.right;
+  auto with_delta = [&](mir::ExprId base, std::int64_t delta,
+                        mir::BinaryOp op) -> mir::ExprId {
+    const auto base_type = proc_scope_state.GetExpr(base).type;
+    const auto delta_lit =
+        proc_scope_state.AddExpr(unit_state.MakeInt32LiteralExpr(delta));
+    return proc_scope_state.AddExpr(
+        mir::Expr{
+            .data = mir::BinaryExpr{.op = op, .lhs = base, .rhs = delta_lit},
+            .type = base_type});
+  };
+  return std::visit(
+      Overloaded{
+          [&](const hir::RangeConstantBounds& b)
+              -> diag::Result<RangeOffsetCount> {
+            auto msb = lower_one(b.msb_expr);
+            if (!msb) return std::unexpected(std::move(msb.error()));
+            const auto msb_type = proc_scope_state.GetExpr(*msb).type;
+            const auto vec_offset = WrapUnpackedIndex(
+                unit_state, proc_scope_state, declared, *msb, msb_type);
+            return RangeOffsetCount{.offset_expr = vec_offset, .count = count};
+          },
+          [&](const hir::RangeIndexedUpBounds& b)
+              -> diag::Result<RangeOffsetCount> {
+            auto base = lower_one(b.base_index);
+            if (!base) return std::unexpected(std::move(base.error()));
+            const auto base_type = proc_scope_state.GetExpr(*base).type;
+            const auto leftmost_sv =
+                descending ? with_delta(
+                                 *base, static_cast<std::int64_t>(count) - 1,
+                                 mir::BinaryOp::kAdd)
+                           : *base;
+            const auto vec_offset = WrapUnpackedIndex(
+                unit_state, proc_scope_state, declared, leftmost_sv, base_type);
+            return RangeOffsetCount{.offset_expr = vec_offset, .count = count};
+          },
+          [&](const hir::RangeIndexedDownBounds& b)
+              -> diag::Result<RangeOffsetCount> {
+            auto base = lower_one(b.base_index);
+            if (!base) return std::unexpected(std::move(base.error()));
+            const auto base_type = proc_scope_state.GetExpr(*base).type;
+            const auto leftmost_sv =
+                descending ? *base
+                           : with_delta(
+                                 *base, static_cast<std::int64_t>(count) - 1,
+                                 mir::BinaryOp::kSub);
+            const auto vec_offset = WrapUnpackedIndex(
+                unit_state, proc_scope_state, declared, leftmost_sv, base_type);
+            return RangeOffsetCount{.offset_expr = vec_offset, .count = count};
+          },
+      },
+      bounds);
+}
+
 auto LowerHirElementSelectExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
@@ -1056,9 +1126,10 @@ auto LowerHirRangeSelectExprProc(
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::RangeSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  const auto& hir_base = hir_process.exprs.at(sel.base_value.value);
   auto base_or = LowerExpr(
       unit_state, scope_state, proc_state, proc_scope_state, hir_process,
-      hir_process.exprs.at(sel.base_value.value));
+      hir_base);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = proc_scope_state.AddExpr(*std::move(base_or));
 
@@ -1069,8 +1140,19 @@ auto LowerHirRangeSelectExprProc(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     return proc_scope_state.AddExpr(*std::move(lowered));
   };
-  auto unfolded = UnfoldHirRangeBoundsToOffsetCount(
-      unit_state, proc_scope_state, sel.bounds, lower_one);
+  const auto& hir_base_ty = unit_state.GetHirType(hir_base.type);
+  auto unfolded = [&]() {
+    if (const auto* ua =
+            std::get_if<hir::UnpackedArrayType>(&hir_base_ty.data)) {
+      const auto& result_ty = unit_state.GetType(result_type);
+      const auto count = static_cast<std::uint32_t>(
+          std::get<mir::UnpackedArrayType>(result_ty.data).size);
+      return UnfoldHirRangeBoundsForUnpacked(
+          unit_state, proc_scope_state, sel.bounds, ua->dim, count, lower_one);
+    }
+    return UnfoldHirRangeBoundsToOffsetCount(
+        unit_state, proc_scope_state, sel.bounds, lower_one);
+  }();
   if (!unfolded) return std::unexpected(std::move(unfolded.error()));
 
   return mir::Expr{
@@ -1461,9 +1543,10 @@ auto LowerHirRangeSelectExprStructural(
     const hir::StructuralScope& scope, const hir::RangeSelectExpr& sel,
     LoopVarLoweringMode loop_var_mode, mir::TypeId result_type)
     -> diag::Result<mir::Expr> {
+  const auto& hir_base = scope.GetExpr(sel.base_value);
   auto base_or = LowerExprImpl(
-      unit_state, scope_state, ctor_state, proc_scope_state, scope,
-      scope.GetExpr(sel.base_value), loop_var_mode);
+      unit_state, scope_state, ctor_state, proc_scope_state, scope, hir_base,
+      loop_var_mode);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = proc_scope_state.AddExpr(*std::move(base_or));
 
@@ -1474,8 +1557,19 @@ auto LowerHirRangeSelectExprStructural(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     return proc_scope_state.AddExpr(*std::move(lowered));
   };
-  auto unfolded = UnfoldHirRangeBoundsToOffsetCount(
-      unit_state, proc_scope_state, sel.bounds, lower_one);
+  const auto& hir_base_ty = unit_state.GetHirType(hir_base.type);
+  auto unfolded = [&]() {
+    if (const auto* ua =
+            std::get_if<hir::UnpackedArrayType>(&hir_base_ty.data)) {
+      const auto& result_ty = unit_state.GetType(result_type);
+      const auto count = static_cast<std::uint32_t>(
+          std::get<mir::UnpackedArrayType>(result_ty.data).size);
+      return UnfoldHirRangeBoundsForUnpacked(
+          unit_state, proc_scope_state, sel.bounds, ua->dim, count, lower_one);
+    }
+    return UnfoldHirRangeBoundsToOffsetCount(
+        unit_state, proc_scope_state, sel.bounds, lower_one);
+  }();
   if (!unfolded) return std::unexpected(std::move(unfolded.error()));
 
   return mir::Expr{

--- a/tests/cases/cpp/unpacked_elem_invalid_index/case.yaml
+++ b/tests/cases/cpp/unpacked_elem_invalid_index/case.yaml
@@ -1,0 +1,23 @@
+id: cpp.unpacked_elem_invalid_index
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    oob_2s_pos: 0
+    oob_2s_neg: 0
+    in_range_2s: 20
+    oob_4s_pos: "8'bxxxxxxxx"
+    x_idx_4s: "8'bxxxxxxxx"
+    z_idx_4s: "8'bxxxxxxxx"
+    in_range_4s: "8'h22"
+    int_e0: 10
+    int_e1: 20
+    int_e2: 30
+    logic_e0: "8'h11"
+    logic_e1: "8'h22"
+    logic_e2: "8'h33"

--- a/tests/cases/cpp/unpacked_elem_invalid_index/main.sv
+++ b/tests/cases/cpp/unpacked_elem_invalid_index/main.sv
@@ -1,0 +1,32 @@
+module Top;
+  int int_arr [3] = '{10, 20, 30};
+  logic [7:0] logic_arr [3] = '{8'h11, 8'h22, 8'h33};
+  integer idx;
+
+  int oob_2s_pos, oob_2s_neg, in_range_2s;
+  logic [7:0] oob_4s_pos, x_idx_4s, z_idx_4s, in_range_4s;
+
+  int int_e0, int_e1, int_e2;
+  logic [7:0] logic_e0, logic_e1, logic_e2;
+
+  initial begin
+    // Reads: 2-state OOB -> 0, 4-state OOB -> 'x, X / Z index -> 'x.
+    idx = 100; oob_2s_pos  = int_arr[idx];
+    idx = -5;  oob_2s_neg  = int_arr[idx];
+    idx = 1;   in_range_2s = int_arr[idx];
+    idx = 100; oob_4s_pos  = logic_arr[idx];
+    idx = 'x;  x_idx_4s    = logic_arr[idx];
+    idx = 'z;  z_idx_4s    = logic_arr[idx];
+    idx = 1;   in_range_4s = logic_arr[idx];
+
+    // Writes under the same invalid-index conditions are no-ops; the
+    // originals are unchanged.
+    idx = 100; int_arr[idx]   = 999;
+    idx = -5;  int_arr[idx]   = 888;
+    idx = 'x;  logic_arr[idx] = 8'hAA;
+    idx = 'z;  logic_arr[idx] = 8'hBB;
+
+    int_e0   = int_arr[0];   int_e1   = int_arr[1];   int_e2   = int_arr[2];
+    logic_e0 = logic_arr[0]; logic_e1 = logic_arr[1]; logic_e2 = logic_arr[2];
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_slice_decl_directions/case.yaml
+++ b/tests/cases/cpp/unpacked_slice_decl_directions/case.yaml
@@ -1,0 +1,19 @@
+id: cpp.unpacked_slice_decl_directions
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    anz_e0: 30
+    anz_e1: 40
+    anz_e2: 50
+    desc_e0: 50
+    desc_e1: 40
+    desc_e2: 30
+    neg_e0: 11
+    neg_e1: 22
+    neg_e2: 33

--- a/tests/cases/cpp/unpacked_slice_decl_directions/main.sv
+++ b/tests/cases/cpp/unpacked_slice_decl_directions/main.sv
@@ -1,0 +1,24 @@
+module Top;
+  // Three non-canonical declared ranges. Each const slice exercises a
+  // distinct branch of the unpacked declared-range translation:
+  // ascending non-zero base, descending, and negative base.
+  int asc_nz   [3:5]  = '{30, 40, 50};
+  int desc     [5:3]  = '{50, 40, 30};
+  int neg_base [-1:1] = '{11, 22, 33};
+
+  int sl_anz [3], sl_desc [3], sl_neg [3];
+  int anz_e0, anz_e1, anz_e2;
+  int desc_e0, desc_e1, desc_e2;
+  int neg_e0, neg_e1, neg_e2;
+
+  initial begin
+    sl_anz = asc_nz[3:5];
+    anz_e0 = sl_anz[0]; anz_e1 = sl_anz[1]; anz_e2 = sl_anz[2];
+
+    sl_desc = desc[5:3];
+    desc_e0 = sl_desc[0]; desc_e1 = sl_desc[1]; desc_e2 = sl_desc[2];
+
+    sl_neg = neg_base[-1:1];
+    neg_e0 = sl_neg[0]; neg_e1 = sl_neg[1]; neg_e2 = sl_neg[2];
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_slice_invalid_offset/case.yaml
+++ b/tests/cases/cpp/unpacked_slice_invalid_offset/case.yaml
@@ -1,0 +1,31 @@
+id: cpp.unpacked_slice_invalid_offset
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r2s_e0: 50
+    r2s_e1: 60
+    r2s_e2: 0
+    r4s_e0: "8'h50"
+    r4s_e1: "8'h60"
+    r4s_e2: "8'bxxxxxxxx"
+    xr_e0: "8'bxxxxxxxx"
+    xr_e1: "8'bxxxxxxxx"
+    xr_e2: "8'bxxxxxxxx"
+    w2s_e0: 10
+    w2s_e1: 20
+    w2s_e2: 30
+    w2s_e3: 40
+    w2s_e4: 77
+    w2s_e5: 88
+    xw_e0: "8'h10"
+    xw_e1: "8'h20"
+    xw_e2: "8'h30"
+    xw_e3: "8'h40"
+    xw_e4: "8'h50"
+    xw_e5: "8'h60"

--- a/tests/cases/cpp/unpacked_slice_invalid_offset/main.sv
+++ b/tests/cases/cpp/unpacked_slice_invalid_offset/main.sv
@@ -1,0 +1,45 @@
+module Top;
+  int int_arr   [6] = '{10, 20, 30, 40, 50, 60};
+  int int_src   [3] = '{77, 88, 99};
+  logic [7:0] logic_arr [6] = '{8'h10, 8'h20, 8'h30, 8'h40, 8'h50, 8'h60};
+  logic [7:0] logic_src [3] = '{8'hAA, 8'hBB, 8'hCC};
+
+  integer idx;
+  integer x_idx;
+
+  int int_dst [3];
+  logic [7:0] logic_dst [3];
+  logic [7:0] x_dst [3];
+
+  int r2s_e0, r2s_e1, r2s_e2;
+  logic [7:0] r4s_e0, r4s_e1, r4s_e2;
+  logic [7:0] xr_e0, xr_e1, xr_e2;
+  int w2s_e0, w2s_e1, w2s_e2, w2s_e3, w2s_e4, w2s_e5;
+  logic [7:0] xw_e0, xw_e1, xw_e2, xw_e3, xw_e4, xw_e5;
+
+  initial begin
+    // Partial-OOB read: positions [4, 5, 6] on a size-6 source; pos 6 OOB.
+    // 2-state element default -> 0; 4-state element default -> 'x.
+    idx = 4;
+    int_dst = int_arr[idx +: 3];
+    r2s_e0 = int_dst[0]; r2s_e1 = int_dst[1]; r2s_e2 = int_dst[2];
+    logic_dst = logic_arr[idx +: 3];
+    r4s_e0 = logic_dst[0]; r4s_e1 = logic_dst[1]; r4s_e2 = logic_dst[2];
+
+    // X-bit offset on read -> whole slice defaults to Table 7-1.
+    x_idx = 'x;
+    x_dst = logic_arr[x_idx +: 3];
+    xr_e0 = x_dst[0]; xr_e1 = x_dst[1]; xr_e2 = x_dst[2];
+
+    // Partial-OOB write: in-range portion writes, OOB portion drops.
+    idx = 4;
+    int_arr[idx +: 3] = int_src;
+    w2s_e0 = int_arr[0]; w2s_e1 = int_arr[1]; w2s_e2 = int_arr[2];
+    w2s_e3 = int_arr[3]; w2s_e4 = int_arr[4]; w2s_e5 = int_arr[5];
+
+    // X-bit offset on write -> no-op; original array unchanged.
+    logic_arr[x_idx +: 3] = logic_src;
+    xw_e0 = logic_arr[0]; xw_e1 = logic_arr[1]; xw_e2 = logic_arr[2];
+    xw_e3 = logic_arr[3]; xw_e4 = logic_arr[4]; xw_e5 = logic_arr[5];
+  end
+endmodule


### PR DESCRIPTION
## Summary

Closes U7 of the unpacked-array workstream. LRM 7.4.5 mandates that any out-of-bounds position or X / Z bit in an array index makes the index invalid: reads return the element type's LRM Table 7-1 default, writes are silent no-ops. Packed (LRM 11.5.1) already implements this inside `PackedArray::ExtractBits` / `AssignSlice`; the unpacked wrapper had naked `vector::operator[]` accesses that would silently corrupt memory or crash on every variant. Slice lowering also assumed packed's "lowest LSB-bit" convention, so any unpacked source declared with a non-`[0:N]` range (ascending non-zero base, descending, negative base) silently mis-indexed.

## Design

Invalid-index handling now lives in two write-back proxies symmetric with `PackedArrayRef`: `UnpackedElementRef<T>` for `ElementAt` non-const and the existing `UnpackedArrayRef<T>` for `Slice` non-const, both extended with a captured validity flag. `Clone()` returns Table 7-1 defaults on invalid access via a `MakeDefaultLike(oracle)` helper that uses element 0 as a shape oracle for the per-type default ctor; `operator=` and the `PackedArray`-element compound ops are silent no-ops. Const `ElementAt` returns by value with the same default fallback; const `Slice` handles partial-OOB per-element rather than at slice granularity. Chain methods on the proxy propagate the validity flag through nested aggregates so an invalid outer index makes the entire chain a no-op write / default read.

For the slice declared-direction gap, HIR -> MIR now dispatches on the base's HIR type. Unpacked sources route through a new `UnfoldHirRangeBoundsForUnpacked` helper that takes the slice's element count from the result type (so negative-base sources, which slang exposes as `UnaryOp(Minus, IntegerLiteral)` rather than a folded literal, survive without const-folding) and emits a `WrapUnpackedIndex` translation of the slice's syntactic-leftmost SV position. Direction-mismatched constant slices and entirely-OOB constant slices remain frontend-rejected by slang's binding, so neither needs runtime handling.

## Testing

Three new YAML cases under `tests/cases/cpp/`: `unpacked_elem_invalid_index` (element OOB + X / Z index read and write across 2-state and 4-state), `unpacked_slice_invalid_offset` (partial-OOB and X-offset slice read and write across both state-kinds), and `unpacked_slice_decl_directions` (const slice over each non-canonical declared-range form). One file per distinct code path; the `expect.variables` block covers the 2-state / 4-state / pos / neg / read / write grid so the bazel suite stays tight.