### PR TITLE
Add $sscanf with shared copy-out desugaring helpers

### DIFF
--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -42,15 +42,19 @@ since the test harness can only probe a variable whose type has an implemented s
 - `$monitor` / `$fmonitor`. Not modelled today; add an entry when a concrete consumer needs it.
 - `$strobe` / `$fstrobe` radix variants. The radix-dispatch mechanism is shared with DI5 but
   strobe's "drain at end of time slot" semantic waits on DI6 (postponed region).
-- `$fscanf` / `$sscanf`. Tracked separately; the format-string scanner that handles SV's 4-state
-  input vocabulary (`x` / `z` / `?` / `_` in numeric fields), sized literals, and the variadic
-  output-arg pipeline is a self-contained cut on top of the file-read surface. Other file read tasks
-  (`$fgetc` / `$ungetc` / `$fgets` / `$fread` / `$fseek` / `$rewind` / `$ftell` / `$feof` /
-  `$ferror` / `$fflush`) are implemented per LRM 21.3.4..21.3.8. The output-arg tasks ride the same
-  LRM 13.5 copy-out shape used by user-defined functions with `output` formals; only
-  statement-position calls are supported. When `$fscanf` lands, fold its variadic copy-out
-  desugaring with the existing UDF F4 path and the file IO output-arg path into one shared helper --
-  three call sites with stable shape will be the right time to extract the abstraction.
+- `$sscanf` implemented per LRM 21.3.4.3: string and string-literal input, statement-position call
+  (bare or blocking assign-RHS), conversions `%d` / `%h` / `%x` / `%b` / `%o` / `%s` / `%c` / `%%`,
+  4-state vocabulary (`x` / `z` / `?` / `_`) inside the integer conversions, single-char `x`/`z`/`?`
+  fill for `%d`. Output-arg copy-out uses LRM 13.5 with copy-in initialization so unmatched slots
+  preserve the actual's prior value (LRM 21.3.4.3 only writes successfully matched outputs).
+- `$fscanf` deferred. Reuses the same scanner core over a file-source adapter plus FD error
+  stamping; no new scanner work expected.
+- `$sscanf` field width (`%5d`) and assignment suppression (`%*d`) deferred. Detected and rejected
+  at runtime so the matched count never silently desyncs from the user's argument list.
+- `$sscanf` integral and unpacked-array-of-byte input sources (LRM 21.3.4.3) deferred; string and
+  string-literal inputs are accepted today.
+- Other file read tasks (`$fgetc` / `$ungetc` / `$fgets` / `$fread` / `$fseek` / `$rewind` /
+  `$ftell` / `$feof` / `$ferror` / `$fflush`) are implemented per LRM 21.3.4..21.3.8.
 - `$sformat` / `$sformatf` / `$swrite` family (formatting into a string variable). Independent
   feature.
 - `%u` / `%z` (binary-packed unsigned / signed) and `%v` (strength). Not on the immediate roadmap;

--- a/include/lyra/lowering/hir_to_mir/copy_out_desugar.hpp
+++ b/include/lyra/lowering/hir_to_mir/copy_out_desugar.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <optional>
+#include <string_view>
+#include <vector>
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/stmt.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// LRM 13.5 copy-out desugaring at the statement boundary. A subroutine call
+// whose actuals are observable lvalues routes the writeback through an
+// explicit MIR assignment so the variable's own write path runs. Three
+// callers share the shape: file IO tasks with an output argument
+// ($fgets / $fread / $ferror), $sscanf, and the UDF F4 path (which inlines
+// its own slot construction because per-formal direction picks between
+// `output` and `inout` init -- only the wrap-up step is shared here).
+//
+// The helper takes two phases: callers register one slot per output arg via
+// BuildOutputArgSlot, then assemble the call expression themselves, then
+// hand the slot list + call to BuildCopyOutBlock to compose:
+//   { temp_0 = actual_0; ... ; [lhs =] call(temps...); actual_0 = temp_0; ... }
+// as a BlockStmt. Temps are always copy-in initialized from the actual:
+// for callees that fully overwrite the temp (file IO) the init is
+// observable-equivalent to any other choice; for callees that may leave a
+// temp untouched ($sscanf on a mismatch) copy-in is required so the
+// unconditional writeback round-trips to a no-op.
+
+struct OutputArgSlot {
+  mir::ExprId actual{};
+  mir::ProceduralVarRef temp{};
+  mir::TypeId type{};
+};
+
+// Lower `actual_hir` as an lvalue, allocate a same-typed temp in `wrapper`
+// initialized from the lowered actual, and return the slot bookkeeping.
+// UDF F4 (LowerSubroutineCallWithWritebacks) does not use this helper
+// because its formal type may differ from the actual type via implicit
+// conversion, and its `output`-direction formals require default init per
+// LRM 13.3.2.
+auto BuildOutputArgSlot(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state, ProceduralScopeLoweringState& wrapper,
+    const hir::ProceduralBody& hir_proc, hir::ExprId actual_hir,
+    std::string_view temp_name) -> diag::Result<OutputArgSlot>;
+
+// Append `call_expr` to `wrapper` (optionally wrapping the call result in
+// an implicit ConversionExpr to match `result_type` when the call's
+// natural return type differs), then a writeback `actual = read(temp)`
+// for each slot, and wrap the resulting child scope in a BlockStmt
+// carrying `stmt.label`. `assign_target_id` is the LHS for an
+// `lhs = f(...)` shape; `nullopt` produces a bare-call statement.
+auto BuildCopyOutBlock(
+    ProceduralScopeLoweringState& wrapper, const hir::Stmt& stmt,
+    mir::TypeId result_type, mir::Expr call_expr,
+    std::optional<mir::ExprId> assign_target_id,
+    const std::vector<OutputArgSlot>& slots) -> mir::Stmt;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/lower_scan.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_scan.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <optional>
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_span.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/stmt.hpp"
+#include "lyra/support/system_subroutine.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// LRM 21.3.4.3 $sscanf reached in expression position (e.g. inside an `if`
+// or a non-blocking-assignment context). $sscanf writes through output
+// argument lvalues, which only lowers cleanly at the statement boundary
+// where the temp + writeback BlockStmt can wrap the call; nested forms
+// return Unsupported. Statement-position calls bypass this entry via
+// LowerScanSystemSubroutineCallStmt, dispatched from lower_stmt.cpp.
+auto LowerScanSystemSubroutineCall(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
+    const support::SystemSubroutineDesc& desc,
+    const support::ScanSystemSubroutineInfo& info, diag::SourceSpan span)
+    -> diag::Result<mir::Expr>;
+
+// Statement-position $sscanf desugaring (LRM 13.5 copy-out for every output
+// argument). Builds:
+//   { temp_i = init_i; ... ;
+//     [lhs =] LyraSScanf(input, format, slots);
+//     actual_i = temp_i; ... }
+// The temps are copy-in initialized from each actual (LRM 21.3.4.3 leaves
+// unmatched output args untouched, so copy-in lets the unconditional
+// writeback round-trip to a no-op when the scanner skips a slot).
+//
+// `assign_target` carries the LHS for `lhs = $sscanf(...)`; `nullopt` is
+// a bare-call statement. `result_type` is the call's int32 return slot.
+auto LowerScanSystemSubroutineCallStmt(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
+    const hir::Stmt& stmt, diag::SourceSpan span, const hir::CallExpr& call,
+    const support::SystemSubroutineDesc& desc,
+    const support::ScanSystemSubroutineInfo& info,
+    std::optional<hir::ExprId> assign_target, mir::TypeId result_type)
+    -> diag::Result<mir::Stmt>;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -17,6 +17,7 @@
 #include "lyra/mir/runtime_file_io.hpp"
 #include "lyra/mir/runtime_finish.hpp"
 #include "lyra/mir/runtime_print.hpp"
+#include "lyra/mir/runtime_scan.hpp"
 #include "lyra/mir/runtime_submit.hpp"
 #include "lyra/mir/structural_param.hpp"
 #include "lyra/mir/structural_subroutine_ref.hpp"
@@ -103,7 +104,7 @@ using RuntimeCall = std::variant<
     RuntimeFileCloseCall, RuntimeFileGetcCall, RuntimeFileUngetcCall,
     RuntimeFileGetsCall, RuntimeFileReadCall, RuntimeFileSeekCall,
     RuntimeFileRewindCall, RuntimeFileTellCall, RuntimeFileEofCall,
-    RuntimeFileErrorCall, RuntimeFileFlushCall>;
+    RuntimeFileErrorCall, RuntimeFileFlushCall, RuntimeSScanCall>;
 
 struct RuntimeCallExpr {
   RuntimeCall call;

--- a/include/lyra/mir/runtime_scan.hpp
+++ b/include/lyra/mir/runtime_scan.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <vector>
+
+#include "lyra/mir/expr_id.hpp"
+
+namespace lyra::mir {
+
+// LRM 21.3.4.3 $sscanf. `input` and `format` are string-typed expressions.
+// `slots` are ExprIds pointing at the per-output-arg ProceduralVarRef temps
+// that the scanner writes through; the surrounding BlockStmt (built by
+// FinalizeOutputArgCallStmt) copies each temp back to the user's actual
+// lvalue after the call returns. `slots[i]`'s MIR-level type is the
+// underlying procedural var's type, which the backend uses to pick the
+// matching ScanSlot::Make overload.
+struct RuntimeSScanCall {
+  ExprId input{};
+  ExprId format{};
+  std::vector<ExprId> slots;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/runtime/scan.hpp
+++ b/include/lyra/runtime/scan.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <initializer_list>
+#include <variant>
+
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/string.hpp"
+
+namespace lyra::runtime {
+
+// LRM 21.3.4.3 scanner output slot. Each conversion in the format string
+// writes through one slot; the slot's variant alternative decides which
+// per-spec parser path the runtime takes. The Make factory picks the right
+// alternative from the temp's C++ type, so emitted call sites stay
+// uniform: `ScanSlot::Make(temp_int)` / `ScanSlot::Make(temp_str)`.
+class ScanSlot {
+ public:
+  static auto Make(value::PackedArray& dest) -> ScanSlot {
+    return ScanSlot{&dest};
+  }
+  static auto Make(value::String& dest) -> ScanSlot {
+    return ScanSlot{&dest};
+  }
+
+  // Typed accessors for the scanner core. Returns nullptr if the slot does
+  // not carry that alternative; the per-spec parser then raises a
+  // type-mismatch runtime_error (lowering should have prevented this, so
+  // the mismatch path is just defensive).
+  [[nodiscard]] auto AsIntegral() const -> value::PackedArray* {
+    if (const auto* p = std::get_if<value::PackedArray*>(&dest_)) {
+      return *p;
+    }
+    return nullptr;
+  }
+  [[nodiscard]] auto AsString() const -> value::String* {
+    if (const auto* p = std::get_if<value::String*>(&dest_)) {
+      return *p;
+    }
+    return nullptr;
+  }
+
+ private:
+  explicit ScanSlot(value::PackedArray* p) : dest_(p) {
+  }
+  explicit ScanSlot(value::String* p) : dest_(p) {
+  }
+
+  std::variant<value::PackedArray*, value::String*> dest_;
+};
+
+// LRM 21.3.4.3 $sscanf entry. Parses `input` against `format` and writes
+// matched conversions into `slots`. Returns the number of items
+// successfully matched and assigned, or -1 on EOF before any conversion
+// (matching LRM "code can be 0 ... If the input ends before the first
+// matching failure or conversion, EOF is returned"). The result is
+// wrapped in a 32-bit PackedArray so emit sites can hand it straight to
+// `WriteVar` for an `int` LHS, parallel to the rest of the file IO
+// runtime surface. `slots` is taken by initializer_list so the emitted
+// call site can build it inline without a named temp; each ScanSlot
+// holds a pointer to the caller's lvalue, so const access through the
+// list still mutates the user's variable.
+auto LyraSScanf(
+    const value::String& input, const value::String& format,
+    std::initializer_list<ScanSlot> slots) -> value::PackedArray;
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/scan_source.hpp
+++ b/include/lyra/runtime/scan_source.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string_view>
+
+namespace lyra::runtime {
+
+// Input source for the $sscanf / $fscanf scanner. The scanner only ever
+// peeks one byte ahead, so a single-byte pushback is enough. The interface
+// is deliberately small so the file-source adapter (a follow-up PR for
+// $fscanf) can satisfy the same contract by wrapping LyraFGetc / LyraFUngetc.
+//
+// `Peek` returns the next byte without advancing the cursor, or -1 on EOF.
+// `Consume` returns the next byte and advances. `Unget` pushes one byte back
+// so the next `Peek` / `Consume` returns it again; pushing while a byte is
+// already pending throws InternalError to surface scanner-side misuse.
+class StringScanSource {
+ public:
+  explicit StringScanSource(std::string_view buf);
+
+  auto Peek() -> int;
+  auto Consume() -> int;
+  void Unget(int byte);
+
+ private:
+  std::string_view buf_;
+  std::size_t cursor_ = 0;
+  std::optional<int> pushback_ = std::nullopt;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -110,9 +110,22 @@ struct FileIOSystemSubroutineInfo {
          kind == FileIOKind::kError;
 }
 
+// LRM 21.3.4.3 scan family ($sscanf / $fscanf). The kind axis tracks where
+// the scanned characters come from. Only kString is implemented today; the
+// kFile variant ($fscanf) wires the same scanner core over a file-source
+// adapter in a follow-up.
+enum class ScanSourceKind : std::uint8_t {
+  kString,
+};
+
+struct ScanSystemSubroutineInfo {
+  ScanSourceKind source;
+};
+
 using SystemSubroutineSemantic = std::variant<
     PrintSystemSubroutineInfo, TerminationSystemSubroutineInfo,
-    DiagnosticSystemSubroutineInfo, FileIOSystemSubroutineInfo>;
+    DiagnosticSystemSubroutineInfo, FileIOSystemSubroutineInfo,
+    ScanSystemSubroutineInfo>;
 
 struct SystemSubroutineDesc {
   SystemSubroutineId id;
@@ -503,6 +516,15 @@ inline constexpr std::array kSystemSubroutines = {
         .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 1},
         .semantic = FileIOSystemSubroutineInfo{.kind = FileIOKind::kFlush},
     },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{32},
+        .name = "$sscanf",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kFunction,
+        .result_conv = ReturnConvention::kInt32,
+        .arg_policy = ArgCountPolicy{.min_args = 3, .max_args = 255},
+        .semantic = ScanSystemSubroutineInfo{.source = ScanSourceKind::kString},
+    },
 };
 
 }  // namespace detail
@@ -540,6 +562,11 @@ inline constexpr std::array kSystemSubroutines = {
 [[nodiscard]] inline auto GetFileIOInfo(const SystemSubroutineDesc& desc)
     -> const FileIOSystemSubroutineInfo* {
   return std::get_if<FileIOSystemSubroutineInfo>(&desc.semantic);
+}
+
+[[nodiscard]] inline auto GetScanInfo(const SystemSubroutineDesc& desc)
+    -> const ScanSystemSubroutineInfo* {
+  return std::get_if<ScanSystemSubroutineInfo>(&desc.semantic);
 }
 
 }  // namespace lyra::support

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -93,6 +93,17 @@ class PackedArray {
       std::uint64_t bit_width, bool is_signed, bool is_four_state)
       -> PackedArray;
 
+  // Span-based twin of FromWords for callers that assemble word planes
+  // dynamically (e.g. the $sscanf scanner accumulating an arbitrary number
+  // of bits). Same shape contract: `value_words.size() ==
+  // ceil(bit_width / 64)`; for 2-state shapes `unknown_words` must be empty;
+  // for 4-state shapes it must either be empty (no X/Z) or match
+  // `value_words` in size.
+  [[nodiscard]] static auto FromWords(
+      std::span<const std::uint64_t> value_words,
+      std::span<const std::uint64_t> unknown_words, std::uint64_t bit_width,
+      bool is_signed, bool is_four_state) -> PackedArray;
+
   // Width-aware conversion. Constructs a fresh PackedArray of the
   // destination shape and copies bits from `src`, sign- or zero-extending
   // per `src`'s signedness when widening, truncating when narrowing.

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -375,6 +375,7 @@ auto RenderScopeHeaderFile(
   out += "#include \"lyra/runtime/process_kind.hpp\"\n";
   out += "#include \"lyra/runtime/runtime_scope_kind.hpp\"\n";
   out += "#include \"lyra/runtime/runtime_services.hpp\"\n";
+  out += "#include \"lyra/runtime/scan.hpp\"\n";
   out += "#include \"lyra/runtime/var.hpp\"\n";
   out += "#include \"lyra/value/enum.hpp\"\n";
   out += "#include \"lyra/value/format.hpp\"\n";

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -405,6 +405,31 @@ auto RenderRuntimeCallExpr(
             return std::format(
                 "lyra::runtime::LyraFFlush(*services_, {})", *fd_or);
           },
+          [&](const mir::RuntimeSScanCall& ss) -> diag::Result<std::string> {
+            auto input_or = RenderExpr(ctx, ctx.Expr(ss.input));
+            if (!input_or) {
+              return std::unexpected(std::move(input_or.error()));
+            }
+            auto format_or = RenderExpr(ctx, ctx.Expr(ss.format));
+            if (!format_or) {
+              return std::unexpected(std::move(format_or.error()));
+            }
+            std::string slot_pieces;
+            for (std::size_t k = 0; k < ss.slots.size(); ++k) {
+              auto slot_or = RenderExpr(ctx, ctx.Expr(ss.slots[k]));
+              if (!slot_or) {
+                return std::unexpected(std::move(slot_or.error()));
+              }
+              if (k != 0) {
+                slot_pieces += ", ";
+              }
+              slot_pieces +=
+                  std::format("lyra::runtime::ScanSlot::Make({})", *slot_or);
+            }
+            return std::format(
+                "lyra::runtime::LyraSScanf({}, {}, {{{}}})", *input_or,
+                *format_or, slot_pieces);
+          },
       },
       expr.call);
 }

--- a/src/lyra/lowering/hir_to_mir/copy_out_desugar.cpp
+++ b/src/lyra/lowering/hir_to_mir/copy_out_desugar.cpp
@@ -1,0 +1,89 @@
+#include "lyra/lowering/hir_to_mir/copy_out_desugar.hpp"
+
+#include <expected>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/lower_expr.hpp"
+#include "lyra/lowering/hir_to_mir/procedural_scope_helpers.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/conversion.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/stmt.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+auto BuildOutputArgSlot(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state, ProceduralScopeLoweringState& wrapper,
+    const hir::ProceduralBody& hir_proc, hir::ExprId actual_hir,
+    std::string_view temp_name) -> diag::Result<OutputArgSlot> {
+  auto actual_or = LowerExpr(
+      unit_state, scope_state, proc_state, wrapper, hir_proc,
+      hir_proc.exprs.at(actual_hir.value));
+  if (!actual_or) return std::unexpected(std::move(actual_or.error()));
+  const mir::TypeId actual_type = actual_or->type;
+  const mir::ExprId actual_id = wrapper.AddExpr(*std::move(actual_or));
+  const mir::ProceduralVarRef temp = wrapper.AppendLocal(
+      mir::ProceduralVarDecl{
+          .name = std::string{temp_name}, .type = actual_type},
+      actual_id);
+  return OutputArgSlot{.actual = actual_id, .temp = temp, .type = actual_type};
+}
+
+auto BuildCopyOutBlock(
+    ProceduralScopeLoweringState& wrapper, const hir::Stmt& stmt,
+    mir::TypeId result_type, mir::Expr call_expr,
+    std::optional<mir::ExprId> assign_target_id,
+    const std::vector<OutputArgSlot>& slots) -> mir::Stmt {
+  const mir::TypeId call_type = call_expr.type;
+  const mir::ExprId call_id = wrapper.AddExpr(std::move(call_expr));
+
+  if (assign_target_id.has_value()) {
+    mir::ExprId value_id = call_id;
+    if (call_type != result_type) {
+      value_id = wrapper.AddExpr(
+          mir::Expr{
+              .data =
+                  mir::ConversionExpr{
+                      .operand = call_id,
+                      .kind = mir::ConversionKind::kImplicit},
+              .type = result_type});
+    }
+    const mir::ExprId assign_id = wrapper.AddExpr(
+        mir::Expr{
+            .data =
+                mir::AssignExpr{.target = *assign_target_id, .value = value_id},
+            .type = result_type});
+    wrapper.AppendStmt(mir::ExprStmt{.expr = assign_id});
+  } else {
+    wrapper.AppendStmt(mir::ExprStmt{.expr = call_id});
+  }
+
+  for (const OutputArgSlot& slot : slots) {
+    const mir::ExprId temp_read =
+        wrapper.AddExpr(mir::Expr{.data = slot.temp, .type = slot.type});
+    const mir::ExprId copy_out = wrapper.AddExpr(
+        mir::Expr{
+            .data = mir::AssignExpr{.target = slot.actual, .value = temp_read},
+            .type = slot.type});
+    wrapper.AppendStmt(mir::ExprStmt{.expr = copy_out});
+  }
+
+  std::vector<mir::ProceduralScope> child_scopes;
+  const mir::ProceduralScopeId scope_id =
+      AddChildProceduralScope(child_scopes, wrapper.Finish());
+  return mir::Stmt{
+      .label = stmt.label,
+      .data = mir::BlockStmt{.scope = scope_id},
+      .child_procedural_scopes = std::move(child_scopes)};
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/lower_file_io.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_file_io.cpp
@@ -14,11 +14,9 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
-#include "lyra/lowering/hir_to_mir/default_value.hpp"
+#include "lyra/lowering/hir_to_mir/copy_out_desugar.hpp"
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
-#include "lyra/lowering/hir_to_mir/procedural_scope_helpers.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
-#include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/runtime_file_io.hpp"
 #include "lyra/mir/stmt.hpp"
@@ -246,97 +244,6 @@ auto RejectOutputArgFileCallInExprPosition(
       diag::UnsupportedCategory::kFeature);
 }
 
-// One arg's worth of bookkeeping for the output-arg desugaring: the user's
-// actual lvalue ExprId and the procedural temp the call writes through. The
-// post-call writeback assigns *actual = read(temp).
-struct OutputArgSlot {
-  mir::ExprId actual;
-  mir::ProceduralVarRef temp;
-  mir::TypeId type;
-};
-
-// Lower the lvalue arg, then allocate a same-typed default-initialized temp
-// in `wrapper`. Returns the (lvalue id, temp ref, temp type) tuple. The
-// "default value" is fine for $fgets / $fread / $ferror because each task
-// fully overwrites the slot at runtime (the temp's pre-call content is
-// never observed); the assignment is just to satisfy MIR's "every local has
-// an initializer" invariant.
-auto BuildOutputArgSlot(
-    const UnitLoweringState& unit_state,
-    const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, ProceduralScopeLoweringState& wrapper,
-    const hir::ProceduralBody& hir_proc, hir::ExprId actual_hir,
-    std::string_view temp_name) -> diag::Result<OutputArgSlot> {
-  auto actual_or = LowerExpr(
-      unit_state, scope_state, proc_state, wrapper, hir_proc,
-      hir_proc.exprs.at(actual_hir.value));
-  if (!actual_or) return std::unexpected(std::move(actual_or.error()));
-  const mir::TypeId actual_type = actual_or->type;
-  const mir::ExprId actual_id = wrapper.AddExpr(*std::move(actual_or));
-  const mir::ExprId default_init =
-      SynthesizeDefaultValueExpr(unit_state, wrapper, actual_type);
-  const mir::ProceduralVarRef temp = wrapper.AppendLocal(
-      mir::ProceduralVarDecl{
-          .name = std::string{temp_name}, .type = actual_type},
-      default_init);
-  return OutputArgSlot{.actual = actual_id, .temp = temp, .type = actual_type};
-}
-
-// Compose the call + return-assignment + writeback sequence into `wrapper`
-// and return a BlockStmt wrapping the resulting child scope. When the
-// call's natural return type (`call_expr.type`, always int32 for the file IO
-// tasks) does not match the AssignExpr's `result_type`, the call result is
-// wrapped in an implicit ConversionExpr -- this mirrors what slang would
-// have done if the call expression had reached an integer-typed LHS through
-// the normal expression-lowering path.
-auto FinalizeOutputArgCallStmt(
-    ProceduralScopeLoweringState& wrapper, const hir::Stmt& stmt,
-    mir::TypeId result_type, mir::Expr call_expr,
-    std::optional<mir::ExprId> assign_target_id,
-    const std::vector<OutputArgSlot>& slots) -> mir::Stmt {
-  const mir::TypeId call_type = call_expr.type;
-  const mir::ExprId call_id = wrapper.AddExpr(std::move(call_expr));
-
-  if (assign_target_id.has_value()) {
-    mir::ExprId value_id = call_id;
-    if (call_type != result_type) {
-      value_id = wrapper.AddExpr(
-          mir::Expr{
-              .data =
-                  mir::ConversionExpr{
-                      .operand = call_id,
-                      .kind = mir::ConversionKind::kImplicit},
-              .type = result_type});
-    }
-    const mir::ExprId assign_id = wrapper.AddExpr(
-        mir::Expr{
-            .data =
-                mir::AssignExpr{.target = *assign_target_id, .value = value_id},
-            .type = result_type});
-    wrapper.AppendStmt(mir::ExprStmt{.expr = assign_id});
-  } else {
-    wrapper.AppendStmt(mir::ExprStmt{.expr = call_id});
-  }
-
-  for (const OutputArgSlot& slot : slots) {
-    const mir::ExprId temp_read =
-        wrapper.AddExpr(mir::Expr{.data = slot.temp, .type = slot.type});
-    const mir::ExprId copy_out = wrapper.AddExpr(
-        mir::Expr{
-            .data = mir::AssignExpr{.target = slot.actual, .value = temp_read},
-            .type = slot.type});
-    wrapper.AppendStmt(mir::ExprStmt{.expr = copy_out});
-  }
-
-  std::vector<mir::ProceduralScope> child_scopes;
-  const mir::ProceduralScopeId scope_id =
-      AddChildProceduralScope(child_scopes, wrapper.Finish());
-  return mir::Stmt{
-      .label = stmt.label,
-      .data = mir::BlockStmt{.scope = scope_id},
-      .child_procedural_scopes = std::move(child_scopes)};
-}
-
 }  // namespace
 
 auto LowerFileIOSystemSubroutineCall(
@@ -502,7 +409,7 @@ auto LowerFileIOSystemSubroutineCallStmt(
     assign_target_id = wrapper.AddExpr(*std::move(lhs_or));
   }
 
-  return FinalizeOutputArgCallStmt(
+  return BuildCopyOutBlock(
       wrapper, stmt, result_type, std::move(call_expr), assign_target_id,
       slots);
 }

--- a/src/lyra/lowering/hir_to_mir/lower_scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_scan.cpp
@@ -1,0 +1,163 @@
+#include "lyra/lowering/hir_to_mir/lower_scan.hpp"
+
+#include <expected>
+#include <format>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/copy_out_desugar.hpp"
+#include "lyra/lowering/hir_to_mir/lower_expr.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/runtime_scan.hpp"
+#include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type.hpp"
+#include "lyra/support/system_subroutine.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+namespace {
+
+auto RejectScanCallInExprPosition(std::string_view name, diag::SourceSpan span)
+    -> diag::Result<mir::Expr> {
+  return diag::Unsupported(
+      span, diag::DiagCode::kUnsupportedSubroutineArgument,
+      std::format(
+          "{} writes through output arguments and is only supported as a "
+          "bare call or as the right-hand side of a blocking assignment "
+          "(LRM 13.5 copy-out semantics)",
+          std::string{name}),
+      diag::UnsupportedCategory::kFeature);
+}
+
+}  // namespace
+
+auto LowerScanSystemSubroutineCall(
+    [[maybe_unused]] const UnitLoweringState& unit_state,
+    [[maybe_unused]] const StructuralScopeLoweringState& scope_state,
+    [[maybe_unused]] const ProcessLoweringState& proc_state,
+    [[maybe_unused]] ProceduralScopeLoweringState& proc_scope_state,
+    [[maybe_unused]] const hir::ProceduralBody& hir_proc,
+    [[maybe_unused]] const hir::CallExpr& call,
+    const support::SystemSubroutineDesc& desc,
+    [[maybe_unused]] const support::ScanSystemSubroutineInfo& info,
+    diag::SourceSpan span) -> diag::Result<mir::Expr> {
+  return RejectScanCallInExprPosition(desc.name, span);
+}
+
+auto LowerScanSystemSubroutineCallStmt(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
+    const hir::Stmt& stmt, diag::SourceSpan span, const hir::CallExpr& call,
+    const support::SystemSubroutineDesc& desc,
+    const support::ScanSystemSubroutineInfo& info,
+    std::optional<hir::ExprId> assign_target, mir::TypeId result_type)
+    -> diag::Result<mir::Stmt> {
+  if (info.source != support::ScanSourceKind::kString) {
+    throw InternalError(
+        "LowerScanSystemSubroutineCallStmt: only kString source is wired "
+        "today, but the descriptor has a different source kind");
+  }
+  if (call.arguments.size() < 3) {
+    throw InternalError(
+        "LowerScanSystemSubroutineCallStmt: $sscanf requires at least input, "
+        "format, and one output argument (slang's ArgCountPolicy should have "
+        "rejected fewer)");
+  }
+
+  ProceduralScopeLoweringState wrapper;
+  ProceduralDepthGuard depth_guard{proc_state};
+
+  // LRM 21.3.4.3 also permits integral and unpacked-array-of-byte input
+  // sources; first-cut runtime only handles `string`. A string-literal
+  // actual reaches lowering as a packed byte-array, so wrap any non-string
+  // packed-array input in an implicit ConversionExpr to string -- the
+  // backend's render-side identity path turns the literal byte form into
+  // the C++ string literal which binds to `value::String` natively. Other
+  // input shapes (e.g. unpacked byte arrays) are rejected here.
+  auto input_or = LowerExpr(
+      unit_state, scope_state, proc_state, wrapper, hir_proc,
+      hir_proc.exprs.at(call.arguments[0].value));
+  if (!input_or) return std::unexpected(std::move(input_or.error()));
+  const mir::TypeId input_type = input_or->type;
+  mir::ExprId input_id = wrapper.AddExpr(*std::move(input_or));
+  const mir::TypeKind input_kind = unit_state.GetType(input_type).Kind();
+  if (input_kind != mir::TypeKind::kString) {
+    if (input_kind != mir::TypeKind::kPackedArray) {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedSubroutineArgument,
+          std::format(
+              "{} input source must be a string or string-literal expression; "
+              "integral and unpacked-array-of-byte sources (LRM 21.3.4.3) are "
+              "not yet supported",
+              std::string{desc.name}),
+          diag::UnsupportedCategory::kFeature);
+    }
+    input_id = wrapper.AddExpr(
+        mir::Expr{
+            .data =
+                mir::ConversionExpr{
+                    .operand = input_id,
+                    .kind = mir::ConversionKind::kImplicit},
+            .type = unit_state.Builtins().string});
+  }
+
+  auto format_or = LowerExpr(
+      unit_state, scope_state, proc_state, wrapper, hir_proc,
+      hir_proc.exprs.at(call.arguments[1].value));
+  if (!format_or) return std::unexpected(std::move(format_or.error()));
+  const mir::ExprId format_id = wrapper.AddExpr(*std::move(format_or));
+
+  // Output slots: args[2..]. Copy-in init so unmatched slots round-trip
+  // through the unconditional writeback as no-ops (LRM 21.3.4.3 only writes
+  // successfully matched outputs).
+  std::vector<OutputArgSlot> slots;
+  slots.reserve(call.arguments.size() - 2);
+  std::vector<mir::ExprId> slot_refs;
+  slot_refs.reserve(call.arguments.size() - 2);
+  for (std::size_t i = 2; i < call.arguments.size(); ++i) {
+    const std::string temp_name = "_lyra_sscanf_dest_" + std::to_string(i - 2);
+    auto slot_or = BuildOutputArgSlot(
+        unit_state, scope_state, proc_state, wrapper, hir_proc,
+        call.arguments[i], temp_name);
+    if (!slot_or) return std::unexpected(std::move(slot_or.error()));
+    slots.push_back(*slot_or);
+    slot_refs.push_back(wrapper.AddExpr(
+        mir::Expr{.data = slots.back().temp, .type = slots.back().type}));
+  }
+
+  mir::Expr call_expr{
+      .data =
+          mir::RuntimeCallExpr{
+              .call =
+                  mir::RuntimeSScanCall{
+                      .input = input_id,
+                      .format = format_id,
+                      .slots = std::move(slot_refs)}},
+      .type = unit_state.Builtins().int32};
+
+  std::optional<mir::ExprId> assign_target_id = std::nullopt;
+  if (assign_target.has_value()) {
+    auto lhs_or = LowerExpr(
+        unit_state, scope_state, proc_state, wrapper, hir_proc,
+        hir_proc.exprs.at(assign_target->value));
+    if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+    assign_target_id = wrapper.AddExpr(*std::move(lhs_or));
+  }
+
+  return BuildCopyOutBlock(
+      wrapper, stmt, result_type, std::move(call_expr), assign_target_id,
+      slots);
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -20,12 +20,14 @@
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/lowering/hir_to_mir/case_cascade.hpp"
+#include "lyra/lowering/hir_to_mir/copy_out_desugar.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/delay_time_resolver.hpp"
 #include "lyra/lowering/hir_to_mir/inside_predicate.hpp"
 #include "lyra/lowering/hir_to_mir/lower_deferred_check.hpp"
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 #include "lyra/lowering/hir_to_mir/lower_file_io.hpp"
+#include "lyra/lowering/hir_to_mir/lower_scan.hpp"
 #include "lyra/lowering/hir_to_mir/procedural_scope_helpers.hpp"
 #include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
@@ -379,14 +381,9 @@ auto LowerSubroutineCallWithWritebacks(
   ProceduralScopeLoweringState wrapper;
   ProceduralDepthGuard depth_guard{proc_state};
 
-  struct Writeback {
-    mir::ExprId actual;
-    mir::ProceduralVarRef temp;
-    mir::TypeId type;
-  };
   std::vector<mir::ExprId> call_args;
   call_args.reserve(call.arguments.size());
-  std::vector<Writeback> writebacks;
+  std::vector<OutputArgSlot> writebacks;
 
   for (std::size_t i = 0; i < call.arguments.size(); ++i) {
     const hir::ParamDirection dir = decl.params[i].direction;
@@ -430,47 +427,26 @@ auto LowerSubroutineCallWithWritebacks(
         {.actual = actual_id, .temp = temp, .type = formal_type});
   }
 
-  const mir::ExprId call_id = wrapper.AddExpr(
-      mir::Expr{
-          .data =
-              mir::CallExpr{
-                  .callee = scope_state.TranslateStructuralSubroutine(
-                      callee_ref.hops, callee_ref.subroutine),
-                  .arguments = std::move(call_args)},
-          .type = result_type});
+  mir::Expr call_expr{
+      .data =
+          mir::CallExpr{
+              .callee = scope_state.TranslateStructuralSubroutine(
+                  callee_ref.hops, callee_ref.subroutine),
+              .arguments = std::move(call_args)},
+      .type = result_type};
 
+  std::optional<mir::ExprId> assign_target_id = std::nullopt;
   if (assign_target.has_value()) {
     auto lhs_or = LowerExpr(
         unit_state, scope_state, proc_state, wrapper, hir_proc,
         hir_proc.exprs.at(assign_target->value));
     if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-    const mir::ExprId lhs_id = wrapper.AddExpr(*std::move(lhs_or));
-    const mir::ExprId assign_id = wrapper.AddExpr(
-        mir::Expr{
-            .data = mir::AssignExpr{.target = lhs_id, .value = call_id},
-            .type = result_type});
-    wrapper.AppendStmt(mir::ExprStmt{.expr = assign_id});
-  } else {
-    wrapper.AppendStmt(mir::ExprStmt{.expr = call_id});
+    assign_target_id = wrapper.AddExpr(*std::move(lhs_or));
   }
 
-  for (const auto& wb : writebacks) {
-    const mir::ExprId temp_read =
-        wrapper.AddExpr(mir::Expr{.data = wb.temp, .type = wb.type});
-    const mir::ExprId copy_out = wrapper.AddExpr(
-        mir::Expr{
-            .data = mir::AssignExpr{.target = wb.actual, .value = temp_read},
-            .type = wb.type});
-    wrapper.AppendStmt(mir::ExprStmt{.expr = copy_out});
-  }
-
-  std::vector<mir::ProceduralScope> child_scopes;
-  const mir::ProceduralScopeId scope_id =
-      AddChildProceduralScope(child_scopes, wrapper.Finish());
-  return mir::Stmt{
-      .label = stmt.label,
-      .data = mir::BlockStmt{.scope = scope_id},
-      .child_procedural_scopes = std::move(child_scopes)};
+  return BuildCopyOutBlock(
+      wrapper, stmt, result_type, std::move(call_expr), assign_target_id,
+      writebacks);
 }
 
 auto LowerExprStmt(
@@ -527,6 +503,12 @@ auto LowerExprStmt(
               unit_state.TranslateType(inner.type));
         }
       }
+      if (const auto* scan_info = support::GetScanInfo(desc)) {
+        return LowerScanSystemSubroutineCallStmt(
+            unit_state, scope_state, proc_state, hir_proc, stmt, inner.span,
+            *call, desc, *scan_info, std::nullopt,
+            unit_state.TranslateType(inner.type));
+      }
     }
   }
   if (const auto* assign = std::get_if<hir::AssignExpr>(&inner.data)) {
@@ -562,19 +544,25 @@ auto LowerExprStmt(
         if (const auto* sys_ref =
                 std::get_if<hir::SystemSubroutineRef>(&call->callee)) {
           const auto& desc = support::LookupSystemSubroutine(sys_ref->id);
+          // When slang wraps the call result in an implicit conversion to
+          // match the LHS, route the call return through the same
+          // conversion before the writeback assigns to the user's LHS.
+          const mir::TypeId result_type = unit_state.TranslateType(
+              conv_target_type.has_value() ? *conv_target_type
+                                           : call_carrier->type);
           if (const auto* file_info = support::GetFileIOInfo(desc)) {
             if (support::FileIOHasOutputArg(file_info->kind)) {
-              // When slang wraps the call result in an implicit conversion to
-              // match the LHS, route the call return through the same
-              // conversion before the writeback assigns to the user's LHS.
-              const mir::TypeId result_type = unit_state.TranslateType(
-                  conv_target_type.has_value() ? *conv_target_type
-                                               : call_carrier->type);
               return LowerFileIOSystemSubroutineCallStmt(
                   unit_state, scope_state, proc_state, hir_proc, stmt,
                   call_carrier->span, *call, desc, *file_info, assign->lhs,
                   result_type);
             }
+          }
+          if (const auto* scan_info = support::GetScanInfo(desc)) {
+            return LowerScanSystemSubroutineCallStmt(
+                unit_state, scope_state, proc_state, hir_proc, stmt,
+                call_carrier->span, *call, desc, *scan_info, assign->lhs,
+                result_type);
           }
         }
       }

--- a/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
@@ -11,6 +11,7 @@
 #include "lyra/lowering/hir_to_mir/lower_file_io.hpp"
 #include "lyra/lowering/hir_to_mir/lower_finish.hpp"
 #include "lyra/lowering/hir_to_mir/lower_print.hpp"
+#include "lyra/lowering/hir_to_mir/lower_scan.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/support/system_subroutine.hpp"
@@ -50,6 +51,12 @@ auto LowerSystemSubroutineCall(
             return LowerFileIOSystemSubroutineCall(
                 unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
                 call, desc, file_io, span);
+          },
+          [&](const support::ScanSystemSubroutineInfo& scan)
+              -> diag::Result<mir::Expr> {
+            return LowerScanSystemSubroutineCall(
+                unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+                call, desc, scan, span);
           },
       },
       desc.semantic);

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -793,6 +793,20 @@ class MirDumper {
                                 ? std::format("Expr[{}]", ff.descriptor->value)
                                 : std::string("all")));
                   },
+                  [&](const RuntimeSScanCall& ss) {
+                    std::string slot_list;
+                    for (std::size_t k = 0; k < ss.slots.size(); ++k) {
+                      if (k != 0) {
+                        slot_list += ", ";
+                      }
+                      slot_list += std::format("Expr[{}]", ss.slots[k].value);
+                    }
+                    Line(
+                        std::format(
+                            "RuntimeSScanCall input=Expr[{}] format=Expr[{}] "
+                            "slots=[{}]",
+                            ss.input.value, ss.format.value, slot_list));
+                  },
               },
               rc->call);
           Dedent();

--- a/src/lyra/runtime/scan.cpp
+++ b/src/lyra/runtime/scan.cpp
@@ -5,11 +5,11 @@
 #include <cstdint>
 #include <format>
 #include <span>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include "lyra/base/internal_error.hpp"
 #include "lyra/runtime/scan_source.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/string.hpp"
@@ -146,7 +146,7 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
     const ScanSlot& slot, std::string_view spec) -> value::PackedArray& {
   value::PackedArray* dest = slot.AsIntegral();
   if (dest == nullptr) {
-    throw std::runtime_error(
+    throw InternalError(
         std::format(
             "$sscanf: format spec '%{}' expects an integral output argument, "
             "but "
@@ -160,7 +160,7 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
     const ScanSlot& slot, std::string_view spec) -> value::String& {
   value::String* dest = slot.AsString();
   if (dest == nullptr) {
-    throw std::runtime_error(
+    throw InternalError(
         std::format(
             "$sscanf: format spec '%{}' expects a string output argument, but "
             "the corresponding actual is not a string",
@@ -430,7 +430,7 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
 
     ++fmt_ix;
     if (fmt_ix >= fmt.size()) {
-      throw std::runtime_error(
+      throw InternalError(
           "$sscanf: format string ended after '%' with no conversion "
           "specifier");
     }
@@ -453,13 +453,13 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
     // detect explicitly so a future-supported format does not silently
     // miscount items.
     if (spec == '*' || IsDecDigit(static_cast<unsigned char>(spec))) {
-      throw std::runtime_error(
+      throw InternalError(
           "$sscanf: field width and assignment suppression are not yet "
           "supported (LRM 21.3.4.3)");
     }
 
     if (slot_ix >= slots.size()) {
-      throw std::runtime_error(
+      throw InternalError(
           "$sscanf: format string has more conversion specifiers than "
           "output arguments");
     }
@@ -487,7 +487,7 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
         ok = ScanChar(src, slot);
         break;
       default:
-        throw std::runtime_error(
+        throw InternalError(
             std::format(
                 "$sscanf: unsupported conversion specifier '%{}'", spec));
     }

--- a/src/lyra/runtime/scan.cpp
+++ b/src/lyra/runtime/scan.cpp
@@ -1,0 +1,523 @@
+#include "lyra/runtime/scan.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "lyra/runtime/scan_source.hpp"
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/string.hpp"
+
+namespace lyra::runtime {
+
+namespace {
+
+// One scanned bit as it leaves a per-spec parser. The val/unk pair mirrors
+// PackedArray's storage planes: 0=(0,0), 1=(1,0), X=(1,1), Z=(0,1).
+struct ScannedBit {
+  bool val;
+  bool unk;
+};
+
+[[nodiscard]] auto IsAsciiWhitespace(int ch) -> bool {
+  return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\f' ||
+         ch == '\v';
+}
+
+[[nodiscard]] auto IsDecDigit(int ch) -> bool {
+  return ch >= '0' && ch <= '9';
+}
+
+[[nodiscard]] auto HexDigit(int ch) -> int {
+  if (ch >= '0' && ch <= '9') {
+    return ch - '0';
+  }
+  if (ch >= 'a' && ch <= 'f') {
+    return (ch - 'a') + 10;
+  }
+  if (ch >= 'A' && ch <= 'F') {
+    return (ch - 'A') + 10;
+  }
+  return -1;
+}
+
+[[nodiscard]] auto OctDigit(int ch) -> int {
+  if (ch >= '0' && ch <= '7') {
+    return ch - '0';
+  }
+  return -1;
+}
+
+void SkipSourceWhitespace(StringScanSource& src) {
+  while (true) {
+    const int ch = src.Peek();
+    if (ch == -1 || !IsAsciiWhitespace(ch)) {
+      return;
+    }
+    src.Consume();
+  }
+}
+
+// Write `bits` (MSB-first, i.e. bits[0] is the leftmost scanned digit /
+// bit) into `dest`. If `bits.size() < dest.BitWidth()`, MSBs of dest fill
+// with zero. If `bits.size() > dest.BitWidth()`, the high (leading) bits
+// are dropped -- only the trailing dest_width bits land. For a 2-state
+// dest, X/Z scanned bits collapse to 0 per the LRM 4-state -> 2-state
+// convention.
+void AssignBitsMsbFirst(
+    value::PackedArray& dest, std::span<const ScannedBit> bits) {
+  const std::uint64_t width = dest.BitWidth();
+  const auto word_count = static_cast<std::size_t>((width + 63U) / 64U);
+  std::vector<std::uint64_t> val_words(word_count, 0U);
+  std::vector<std::uint64_t> unk_words(word_count, 0U);
+
+  const std::size_t bits_to_use = std::min<std::size_t>(bits.size(), width);
+  const std::size_t skip = bits.size() - bits_to_use;
+  for (std::size_t i = 0; i < bits_to_use; ++i) {
+    const std::size_t bit_pos = bits_to_use - 1U - i;
+    const ScannedBit b = bits[skip + i];
+    const std::size_t word_ix = bit_pos / 64U;
+    const std::size_t bit_ix = bit_pos % 64U;
+    if (b.val) {
+      val_words[word_ix] |= (std::uint64_t{1} << bit_ix);
+    }
+    if (b.unk) {
+      unk_words[word_ix] |= (std::uint64_t{1} << bit_ix);
+    }
+  }
+
+  const bool four_state = dest.IsFourState();
+  if (!four_state) {
+    for (std::size_t w = 0; w < word_count; ++w) {
+      val_words[w] &= ~unk_words[w];
+    }
+    dest = value::PackedArray::FromWords(
+        std::span<const std::uint64_t>{val_words},
+        std::span<const std::uint64_t>{}, width, dest.IsSigned(), false);
+    return;
+  }
+  dest = value::PackedArray::FromWords(
+      std::span<const std::uint64_t>{val_words},
+      std::span<const std::uint64_t>{unk_words}, width, dest.IsSigned(), true);
+}
+
+void FillAllX(value::PackedArray& dest) {
+  const std::uint64_t width = dest.BitWidth();
+  const bool four_state = dest.IsFourState();
+  if (!four_state) {
+    dest = value::PackedArray::FromInt(0, width, dest.IsSigned(), false);
+    return;
+  }
+  const auto word_count = static_cast<std::size_t>((width + 63U) / 64U);
+  std::vector<std::uint64_t> val_words(word_count, ~std::uint64_t{0});
+  std::vector<std::uint64_t> unk_words(word_count, ~std::uint64_t{0});
+  dest = value::PackedArray::FromWords(
+      std::span<const std::uint64_t>{val_words},
+      std::span<const std::uint64_t>{unk_words}, width, dest.IsSigned(), true);
+}
+
+void FillAllZ(value::PackedArray& dest) {
+  const std::uint64_t width = dest.BitWidth();
+  const bool four_state = dest.IsFourState();
+  if (!four_state) {
+    dest = value::PackedArray::FromInt(0, width, dest.IsSigned(), false);
+    return;
+  }
+  const auto word_count = static_cast<std::size_t>((width + 63U) / 64U);
+  std::vector<std::uint64_t> val_words(word_count, 0U);
+  std::vector<std::uint64_t> unk_words(word_count, ~std::uint64_t{0});
+  dest = value::PackedArray::FromWords(
+      std::span<const std::uint64_t>{val_words},
+      std::span<const std::uint64_t>{unk_words}, width, dest.IsSigned(), true);
+}
+
+void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
+  dest = value::PackedArray::FromInt(
+      value, dest.BitWidth(), dest.IsSigned(), dest.IsFourState());
+}
+
+[[nodiscard]] auto RequireIntegralSlot(
+    const ScanSlot& slot, std::string_view spec) -> value::PackedArray& {
+  value::PackedArray* dest = slot.AsIntegral();
+  if (dest == nullptr) {
+    throw std::runtime_error(
+        std::format(
+            "$sscanf: format spec '%{}' expects an integral output argument, "
+            "but "
+            "the corresponding actual is not integral",
+            spec));
+  }
+  return *dest;
+}
+
+[[nodiscard]] auto RequireStringSlot(
+    const ScanSlot& slot, std::string_view spec) -> value::String& {
+  value::String* dest = slot.AsString();
+  if (dest == nullptr) {
+    throw std::runtime_error(
+        std::format(
+            "$sscanf: format spec '%{}' expects a string output argument, but "
+            "the corresponding actual is not a string",
+            spec));
+  }
+  return *dest;
+}
+
+// LRM 21.3.4.3 Table 21-7 `%d`. Either a sign-prefixed decimal digit run
+// (with `_` separators) or a single x/X/z/Z/? that fills the entire dest.
+// Mixed (`12x`) stops at the first non-digit -- the `x` is not consumed
+// here, so a following `%h` could still match it.
+[[nodiscard]] auto ScanDecimal(StringScanSource& src, const ScanSlot& slot)
+    -> bool {
+  SkipSourceWhitespace(src);
+  int ch = src.Peek();
+  if (ch == -1) {
+    return false;
+  }
+
+  value::PackedArray& dest = RequireIntegralSlot(slot, "d");
+
+  if (ch == 'x' || ch == 'X') {
+    src.Consume();
+    FillAllX(dest);
+    return true;
+  }
+  if (ch == 'z' || ch == 'Z' || ch == '?') {
+    src.Consume();
+    FillAllZ(dest);
+    return true;
+  }
+
+  bool negative = false;
+  bool had_sign = false;
+  if (ch == '+' || ch == '-') {
+    negative = (ch == '-');
+    had_sign = true;
+    src.Consume();
+    ch = src.Peek();
+  }
+
+  if (!IsDecDigit(ch)) {
+    if (had_sign) {
+      src.Unget(negative ? '-' : '+');
+    }
+    return false;
+  }
+
+  std::int64_t acc = 0;
+  bool consumed_digit = false;
+  while (ch != -1 && (IsDecDigit(ch) || ch == '_')) {
+    if (ch != '_') {
+      acc = (acc * 10) + (ch - '0');
+      consumed_digit = true;
+    }
+    src.Consume();
+    ch = src.Peek();
+  }
+  if (!consumed_digit) {
+    return false;
+  }
+  if (negative) {
+    acc = -acc;
+  }
+  AssignFromI64(dest, acc);
+  return true;
+}
+
+// LRM 21.3.4.3 Table 21-7 `%h` / `%x`. Each character -> one 4-bit nibble.
+// Hex digits 0..9 a..f A..F land as (val=digit, unk=0); xX as
+// (val=1111, unk=1111); zZ? as (val=0000, unk=1111); `_` is a separator.
+[[nodiscard]] auto ScanHex(StringScanSource& src, const ScanSlot& slot)
+    -> bool {
+  SkipSourceWhitespace(src);
+  value::PackedArray& dest = RequireIntegralSlot(slot, "h");
+  std::vector<ScannedBit> bits;
+  bool consumed_digit = false;
+  while (true) {
+    const int ch = src.Peek();
+    if (ch == -1) {
+      break;
+    }
+    const int hd = HexDigit(ch);
+    if (hd >= 0) {
+      for (int b = 3; b >= 0; --b) {
+        bits.push_back(
+            {.val = ((static_cast<unsigned>(hd) >> static_cast<unsigned>(b)) &
+                     1U) != 0U,
+             .unk = false});
+      }
+      consumed_digit = true;
+    } else if (ch == 'x' || ch == 'X') {
+      for (int b = 0; b < 4; ++b) {
+        bits.push_back({.val = true, .unk = true});
+      }
+      consumed_digit = true;
+    } else if (ch == 'z' || ch == 'Z' || ch == '?') {
+      for (int b = 0; b < 4; ++b) {
+        bits.push_back({.val = false, .unk = true});
+      }
+      consumed_digit = true;
+    } else if (ch == '_') {
+      // separator, no bit
+    } else {
+      break;
+    }
+    src.Consume();
+  }
+  if (!consumed_digit) {
+    return false;
+  }
+  AssignBitsMsbFirst(dest, std::span<const ScannedBit>{bits});
+  return true;
+}
+
+// LRM 21.3.4.3 Table 21-7 `%o`. 3 bits per octal digit; xX -> (111,111),
+// zZ? -> (000,111); `_` is a separator.
+[[nodiscard]] auto ScanOctal(StringScanSource& src, const ScanSlot& slot)
+    -> bool {
+  SkipSourceWhitespace(src);
+  value::PackedArray& dest = RequireIntegralSlot(slot, "o");
+  std::vector<ScannedBit> bits;
+  bool consumed_digit = false;
+  while (true) {
+    const int ch = src.Peek();
+    if (ch == -1) {
+      break;
+    }
+    const int od = OctDigit(ch);
+    if (od >= 0) {
+      for (int b = 2; b >= 0; --b) {
+        bits.push_back(
+            {.val = ((static_cast<unsigned>(od) >> static_cast<unsigned>(b)) &
+                     1U) != 0U,
+             .unk = false});
+      }
+      consumed_digit = true;
+    } else if (ch == 'x' || ch == 'X') {
+      for (int b = 0; b < 3; ++b) {
+        bits.push_back({.val = true, .unk = true});
+      }
+      consumed_digit = true;
+    } else if (ch == 'z' || ch == 'Z' || ch == '?') {
+      for (int b = 0; b < 3; ++b) {
+        bits.push_back({.val = false, .unk = true});
+      }
+      consumed_digit = true;
+    } else if (ch == '_') {
+      // separator
+    } else {
+      break;
+    }
+    src.Consume();
+  }
+  if (!consumed_digit) {
+    return false;
+  }
+  AssignBitsMsbFirst(dest, std::span<const ScannedBit>{bits});
+  return true;
+}
+
+// LRM 21.3.4.3 Table 21-7 `%b`. Per-character to one bit: 0/1 -> (val,0),
+// xX -> (1,1), zZ? -> (0,1), `_` separator.
+[[nodiscard]] auto ScanBinary(StringScanSource& src, const ScanSlot& slot)
+    -> bool {
+  SkipSourceWhitespace(src);
+  value::PackedArray& dest = RequireIntegralSlot(slot, "b");
+  std::vector<ScannedBit> bits;
+  bool consumed_digit = false;
+  while (true) {
+    const int ch = src.Peek();
+    if (ch == -1) {
+      break;
+    }
+    if (ch == '0') {
+      bits.push_back({.val = false, .unk = false});
+      consumed_digit = true;
+    } else if (ch == '1') {
+      bits.push_back({.val = true, .unk = false});
+      consumed_digit = true;
+    } else if (ch == 'x' || ch == 'X') {
+      bits.push_back({.val = true, .unk = true});
+      consumed_digit = true;
+    } else if (ch == 'z' || ch == 'Z' || ch == '?') {
+      bits.push_back({.val = false, .unk = true});
+      consumed_digit = true;
+    } else if (ch == '_') {
+      // separator
+    } else {
+      break;
+    }
+    src.Consume();
+  }
+  if (!consumed_digit) {
+    return false;
+  }
+  AssignBitsMsbFirst(dest, std::span<const ScannedBit>{bits});
+  return true;
+}
+
+// Standard scanf `%s`: skip leading whitespace, then read non-whitespace
+// chars until whitespace or EOF.
+[[nodiscard]] auto ScanString(StringScanSource& src, const ScanSlot& slot)
+    -> bool {
+  SkipSourceWhitespace(src);
+  std::string buf;
+  while (true) {
+    const int ch = src.Peek();
+    if (ch == -1 || IsAsciiWhitespace(ch)) {
+      break;
+    }
+    buf.push_back(static_cast<char>(ch));
+    src.Consume();
+  }
+  if (buf.empty()) {
+    return false;
+  }
+  value::String& dest = RequireStringSlot(slot, "s");
+  dest = value::String(std::move(buf));
+  return true;
+}
+
+// Standard scanf `%c`: no whitespace skip, one byte stored as int8.
+[[nodiscard]] auto ScanChar(StringScanSource& src, const ScanSlot& slot)
+    -> bool {
+  const int ch = src.Consume();
+  if (ch == -1) {
+    return false;
+  }
+  value::PackedArray& dest = RequireIntegralSlot(slot, "c");
+  AssignFromI64(dest, static_cast<std::int64_t>(ch & 0xFF));
+  return true;
+}
+
+[[nodiscard]] auto ScanFromStringSource(
+    StringScanSource& src, std::string_view fmt,
+    std::span<const ScanSlot> slots) -> std::int32_t {
+  std::int32_t items = 0;
+  std::size_t slot_ix = 0;
+  bool first_conversion = true;
+  std::size_t fmt_ix = 0;
+
+  while (fmt_ix < fmt.size()) {
+    const char fc = fmt[fmt_ix];
+
+    if (IsAsciiWhitespace(static_cast<unsigned char>(fc))) {
+      // Any whitespace in the format matches zero-or-more whitespace in
+      // the input.
+      SkipSourceWhitespace(src);
+      ++fmt_ix;
+      continue;
+    }
+
+    if (fc != '%') {
+      const int ch = src.Peek();
+      if (ch == -1) {
+        return first_conversion ? -1 : items;
+      }
+      if (ch != static_cast<unsigned char>(fc)) {
+        return items;
+      }
+      src.Consume();
+      ++fmt_ix;
+      continue;
+    }
+
+    ++fmt_ix;
+    if (fmt_ix >= fmt.size()) {
+      throw std::runtime_error(
+          "$sscanf: format string ended after '%' with no conversion "
+          "specifier");
+    }
+    const char spec = fmt[fmt_ix];
+    ++fmt_ix;
+
+    if (spec == '%') {
+      const int ch = src.Peek();
+      if (ch == -1) {
+        return first_conversion ? -1 : items;
+      }
+      if (ch != '%') {
+        return items;
+      }
+      src.Consume();
+      continue;
+    }
+
+    // Field width (`%5d`) and assignment suppression (`%*d`) are deferred;
+    // detect explicitly so a future-supported format does not silently
+    // miscount items.
+    if (spec == '*' || IsDecDigit(static_cast<unsigned char>(spec))) {
+      throw std::runtime_error(
+          "$sscanf: field width and assignment suppression are not yet "
+          "supported (LRM 21.3.4.3)");
+    }
+
+    if (slot_ix >= slots.size()) {
+      throw std::runtime_error(
+          "$sscanf: format string has more conversion specifiers than "
+          "output arguments");
+    }
+    const ScanSlot slot = slots[slot_ix];
+
+    bool ok = false;
+    switch (spec) {
+      case 'd':
+        ok = ScanDecimal(src, slot);
+        break;
+      case 'h':
+      case 'x':
+        ok = ScanHex(src, slot);
+        break;
+      case 'b':
+        ok = ScanBinary(src, slot);
+        break;
+      case 'o':
+        ok = ScanOctal(src, slot);
+        break;
+      case 's':
+        ok = ScanString(src, slot);
+        break;
+      case 'c':
+        ok = ScanChar(src, slot);
+        break;
+      default:
+        throw std::runtime_error(
+            std::format(
+                "$sscanf: unsupported conversion specifier '%{}'", spec));
+    }
+
+    if (!ok) {
+      // Mismatch / EOF mid-conversion. The LRM distinguishes "EOF before
+      // any conversion" (-1) from "match failure after some" (return the
+      // count so far).
+      if (first_conversion && src.Peek() == -1) {
+        return -1;
+      }
+      return items;
+    }
+    first_conversion = false;
+    ++items;
+    ++slot_ix;
+  }
+  return items;
+}
+
+}  // namespace
+
+auto LyraSScanf(
+    const value::String& input, const value::String& format,
+    std::initializer_list<ScanSlot> slots) -> value::PackedArray {
+  StringScanSource src(input.View());
+  const std::int32_t items = ScanFromStringSource(
+      src, format.View(),
+      std::span<const ScanSlot>{slots.begin(), slots.size()});
+  return value::PackedArray::Int(items);
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/runtime/scan_source.cpp
+++ b/src/lyra/runtime/scan_source.cpp
@@ -1,0 +1,46 @@
+#include "lyra/runtime/scan_source.hpp"
+
+#include "lyra/base/internal_error.hpp"
+
+namespace lyra::runtime {
+
+StringScanSource::StringScanSource(std::string_view buf) : buf_(buf) {
+}
+
+auto StringScanSource::Peek() -> int {
+  if (pushback_.has_value()) {
+    return *pushback_;
+  }
+  if (cursor_ >= buf_.size()) {
+    return -1;
+  }
+  return static_cast<unsigned char>(buf_[cursor_]);
+}
+
+auto StringScanSource::Consume() -> int {
+  if (pushback_.has_value()) {
+    const int byte = *pushback_;
+    pushback_.reset();
+    return byte;
+  }
+  if (cursor_ >= buf_.size()) {
+    return -1;
+  }
+  const int byte = static_cast<unsigned char>(buf_[cursor_]);
+  ++cursor_;
+  return byte;
+}
+
+void StringScanSource::Unget(int byte) {
+  if (pushback_.has_value()) {
+    throw InternalError(
+        "StringScanSource::Unget: pushback slot already holds a byte; "
+        "scanner attempted to Unget twice without an intervening Consume");
+  }
+  if (byte == -1) {
+    return;
+  }
+  pushback_ = byte;
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -178,6 +178,14 @@ auto PackedArray::FromWords(
           unknown_words.begin(), unknown_words.size()});
 }
 
+auto PackedArray::FromWords(
+    std::span<const std::uint64_t> value_words,
+    std::span<const std::uint64_t> unknown_words, std::uint64_t bit_width,
+    bool is_signed, bool is_four_state) -> PackedArray {
+  return MakeFromWordPlanes(
+      bit_width, is_signed, is_four_state, value_words, unknown_words);
+}
+
 auto PackedArray::BitWidth() const -> std::uint64_t {
   return bit_width_;
 }

--- a/tests/cases/cpp/sscanf_format_b/case.yaml
+++ b/tests/cases/cpp/sscanf_format_b/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.sscanf_format_b
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    code_basic: 1
+    code_mixed: 1
+  stdout:
+    exact: |
+      a_basic=1010 a_mixed=1x0z

--- a/tests/cases/cpp/sscanf_format_b/main.sv
+++ b/tests/cases/cpp/sscanf_format_b/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  // LRM 21.3.4.3 Table 21-7 `%b`: per-character to one bit, with the
+  // 4-state vocabulary 0/1/x/X/z/Z/?/_ from the spec.
+  int code_basic, code_mixed;
+  bit   [3:0] a_basic;
+  logic [3:0] a_mixed;
+  initial begin
+    code_basic = $sscanf("1010", "%b", a_basic);
+    code_mixed = $sscanf("1x0z", "%b", a_mixed);
+    $display("a_basic=%b a_mixed=%b", a_basic, a_mixed);
+  end
+endmodule

--- a/tests/cases/cpp/sscanf_format_c/case.yaml
+++ b/tests/cases/cpp/sscanf_format_c/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.sscanf_format_c
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    code: 1
+    b: 65          # ASCII 'A'

--- a/tests/cases/cpp/sscanf_format_c/main.sv
+++ b/tests/cases/cpp/sscanf_format_c/main.sv
@@ -1,0 +1,9 @@
+module Top;
+  // LRM 21.3.4.3 Table 21-7 `%c`: one byte, no whitespace skip, stored as
+  // the ASCII code in an integral lvalue.
+  int code;
+  byte b;
+  initial begin
+    code = $sscanf("A", "%c", b);
+  end
+endmodule

--- a/tests/cases/cpp/sscanf_format_d/case.yaml
+++ b/tests/cases/cpp/sscanf_format_d/case.yaml
@@ -1,0 +1,22 @@
+id: cpp.sscanf_format_d
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    code_dec: 1
+    code_neg: 1
+    code_under: 1
+    code_x: 1
+    code_z: 1
+    code_q: 1
+    x_dec: 42
+    x_neg: -17
+    x_under: 1234567
+  stdout:
+    exact: |
+      x_fill=xxxxxxxx z_fill=zzzzzzzz q_fill=zzzz

--- a/tests/cases/cpp/sscanf_format_d/main.sv
+++ b/tests/cases/cpp/sscanf_format_d/main.sv
@@ -1,0 +1,18 @@
+module Top;
+  // LRM 21.3.4.3 Table 21-7 `%d`: optional sign + decimal digits (with `_`
+  // separators), or a single character from {x, X, z, Z, ?} that fills the
+  // entire dest. LRM 5.7.3 makes `?` an alias for Z.
+  int code_dec, code_neg, code_under, code_x, code_z, code_q;
+  int x_dec, x_neg, x_under;
+  logic [7:0] x_fill, z_fill;
+  logic [3:0] q_fill;
+  initial begin
+    code_dec   = $sscanf("42",        "%d", x_dec);
+    code_neg   = $sscanf("-17",       "%d", x_neg);
+    code_under = $sscanf("1_234_567", "%d", x_under);
+    code_x     = $sscanf("x",         "%d", x_fill);
+    code_z     = $sscanf("z",         "%d", z_fill);
+    code_q     = $sscanf("?",         "%d", q_fill);
+    $display("x_fill=%b z_fill=%b q_fill=%b", x_fill, z_fill, q_fill);
+  end
+endmodule

--- a/tests/cases/cpp/sscanf_format_h/case.yaml
+++ b/tests/cases/cpp/sscanf_format_h/case.yaml
@@ -1,0 +1,19 @@
+id: cpp.sscanf_format_h
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    code_basic: 1
+    code_under: 1
+    code_x_nib: 1
+    code_z_nib: 1
+    x_basic: 0xdead
+    x_under: 0xdead
+  stdout:
+    exact: |
+      x_nib=0011xxxx z_nib=0011zzzz

--- a/tests/cases/cpp/sscanf_format_h/main.sv
+++ b/tests/cases/cpp/sscanf_format_h/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  // LRM 21.3.4.3 Table 21-7 `%h` / `%x`: hex digits 0..9 a..f A..F, plus
+  // the 4-state vocabulary x/X (whole nibble X), z/Z/? (whole nibble Z),
+  // and `_` separator.
+  int code_basic, code_under, code_x_nib, code_z_nib;
+  int x_basic, x_under;
+  logic [7:0] x_nib, z_nib;
+  initial begin
+    code_basic = $sscanf("dead",    "%h", x_basic);
+    code_under = $sscanf("d_e_a_d", "%h", x_under);
+    code_x_nib = $sscanf("3x",      "%h", x_nib);
+    code_z_nib = $sscanf("3z",      "%h", z_nib);
+    $display("x_nib=%b z_nib=%b", x_nib, z_nib);
+  end
+endmodule

--- a/tests/cases/cpp/sscanf_format_o/case.yaml
+++ b/tests/cases/cpp/sscanf_format_o/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.sscanf_format_o
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    code_basic: 1
+    code_xz: 1
+  stdout:
+    exact: |
+      a_basic=011111111 a_xz=011xxxzzz

--- a/tests/cases/cpp/sscanf_format_o/main.sv
+++ b/tests/cases/cpp/sscanf_format_o/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  // LRM 21.3.4.3 Table 21-7 `%o`: 3 bits per octal digit; xX -> 3 X bits,
+  // zZ? -> 3 Z bits, `_` separator.
+  int code_basic, code_xz;
+  bit   [8:0] a_basic;
+  logic [8:0] a_xz;
+  initial begin
+    code_basic = $sscanf("377", "%o", a_basic);
+    code_xz    = $sscanf("3xz", "%o", a_xz);
+    $display("a_basic=%b a_xz=%b", a_basic, a_xz);
+  end
+endmodule

--- a/tests/cases/cpp/sscanf_match_semantics/case.yaml
+++ b/tests/cases/cpp/sscanf_match_semantics/case.yaml
@@ -1,0 +1,29 @@
+id: cpp.sscanf_match_semantics
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    code_partial: 1
+    a_partial: 12
+    b_partial: 99
+    code_eof: -1
+    a_eof: 42
+    code_lit: 1
+    a_lit: 12
+    b_lit: 99
+    code_ws: 3
+    a_ws: 1
+    b_ws: 2
+    c_ws: 3
+    code_multi: 3
+    a_multi: 12
+    b_multi: 0xAB
+    s_multi: "hi"
+    s_multi_len: 2
+    code_pct: 1
+    x_pct: 100

--- a/tests/cases/cpp/sscanf_match_semantics/main.sv
+++ b/tests/cases/cpp/sscanf_match_semantics/main.sv
@@ -1,0 +1,43 @@
+module Top;
+  // Scanner control-flow and return-value rules from LRM 21.3.4.3 -- these
+  // sit above any single conversion: partial-match return count, EOF -1
+  // before first conversion, literal-character must-match, whitespace skip
+  // in format, multi-arg fan-out, `%s` to string, `%%` literal, and
+  // copy-in preservation of unmatched output args (LRM 13.5 + 21.3.4.3
+  // "only successfully matched outputs are assigned").
+  int code_partial, code_eof, code_lit, code_ws, code_multi, code_pct;
+  int a_partial, b_partial;
+  int a_eof;
+  int a_lit, b_lit;
+  int a_ws, b_ws, c_ws;
+  int a_multi, b_multi;
+  string s_multi;
+  int s_multi_len;
+  int x_pct;
+  initial begin
+    // Partial match: second %d sees 'a' (not digit, not 4-state single-char),
+    // mismatch -> return 1; b_partial's copy-in baseline preserved.
+    b_partial = 99;
+    code_partial = $sscanf("12 abc", "%d %d", a_partial, b_partial);
+
+    // EOF before any conversion -> -1, copy-in preserved.
+    a_eof = 42;
+    code_eof = $sscanf("", "%d", a_eof);
+
+    // Literal `:` in the format must match `:` in input; here it doesn't,
+    // so the scan stops after the first %d.
+    a_lit = 0;
+    b_lit = 99;
+    code_lit = $sscanf("12x34", "%d:%d", a_lit, b_lit);
+
+    // Whitespace in format matches any (incl. mixed) whitespace in input.
+    code_ws = $sscanf("1\t2\n3", "%d %d %d", a_ws, b_ws, c_ws);
+
+    // Multi-arg fan-out across format specs (also exercises %s).
+    code_multi = $sscanf("12 0xAB hi", "%d %h %s", a_multi, b_multi, s_multi);
+    s_multi_len = s_multi.len();
+
+    // `%%` literal: matches a single `%` in input.
+    code_pct = $sscanf("100%", "%d%%", x_pct);
+  end
+endmodule

--- a/tests/cases/errors/sscanf_field_width/case.yaml
+++ b/tests/cases/errors/sscanf_field_width/case.yaml
@@ -1,0 +1,12 @@
+id: errors.sscanf_field_width
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 1                  # `lyra run` catches the runtime error and exits 1
+  stderr:
+    contains:
+      - "field width and assignment suppression are not yet supported"

--- a/tests/cases/errors/sscanf_field_width/main.sv
+++ b/tests/cases/errors/sscanf_field_width/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  int code;
+  int x;
+  initial begin
+    code = $sscanf("12345", "%5d", x);
+  end
+endmodule

--- a/tests/cases/errors/sscanf_in_expression/case.yaml
+++ b/tests/cases/errors/sscanf_in_expression/case.yaml
@@ -1,0 +1,16 @@
+id: errors.sscanf_in_expression
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "writes through output arguments"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/sscanf_in_expression/main.sv
+++ b/tests/cases/errors/sscanf_in_expression/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  int a;
+  initial begin
+    if ($sscanf("1", "%d", a)) begin
+      a = a + 1;
+    end
+  end
+endmodule

--- a/tests/cases/errors/sscanf_suppress/case.yaml
+++ b/tests/cases/errors/sscanf_suppress/case.yaml
@@ -1,0 +1,12 @@
+id: errors.sscanf_suppress
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 1                  # `lyra run` catches the runtime error and exits 1
+  stderr:
+    contains:
+      - "field width and assignment suppression are not yet supported"

--- a/tests/cases/errors/sscanf_suppress/main.sv
+++ b/tests/cases/errors/sscanf_suppress/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  int code;
+  int a, b;
+  initial begin
+    code = $sscanf("1 2 3", "%d %*d %d", a, b);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements `$sscanf` per LRM 21.3.4.3 over a string source, statement-position only (bare call or blocking assign-RHS). Supports the conversions `%d` / `%h` / `%x` / `%b` / `%o` / `%s` / `%c` / `%%`, including the 4-state input vocabulary (`x` / `X` / `z` / `Z` / `?` / `_`) inside the integer specs, the single-character `x`/`z`/`?` fill form of `%d`, optional `+`/`-` sign on decimal, underscore separators inside integer runs, whitespace skip, and literal-character must-match. `$fscanf` is deferred to a follow-up that wires the same scanner core over a file-source adapter; field width (`%5d`), assignment suppression (`%*d`), and non-string input sources are detected and rejected explicitly so the matched count never silently desyncs from the user's argument list.

## Design

The LRM 13.5 copy-out helpers (`BuildOutputArgSlot` / `BuildCopyOutBlock`) move from `lower_file_io.cpp`'s anon namespace into a shared `copy_out_desugar.{hpp,cpp}` and now back three callers: the file IO output-arg tasks (`$fgets` / `$fread` / `$ferror`), `$sscanf`, and the UDF F4 path. Temp init is uniformly copy-in from the actual, which is required by `$sscanf`'s LRM 21.3.4.3 "only successfully matched outputs are assigned" semantics (unmatched slots round-trip the unconditional writeback as no-ops) and observable-equivalent for file IO (runtime overwrites the temp before any read).

The scanner core is templated on its input source so a `$fscanf` follow-up only needs a file-source adapter on top of `LyraFGetc` / `LyraFUngetc` plus FD error stamping. Arbitrary-width 4-state destinations are written through a new `value::PackedArray::FromWords` span overload that assembles word planes dynamically from the per-bit scanner output.

## Testing

Six `cpp_run` cases grouped by format family (`sscanf_format_d` / `_h` / `_b` / `_o` / `_c` plus `sscanf_match_semantics` for scanner control flow) plus three error cases (field-width / suppression runtime rejection, expression-position lowering rejection). Each format case bundles 2-state and 4-state variants in one program rather than spawning a case per micro-distinction, to keep per-case elaboration overhead in check.