### PR TITLE
Add ref and const ref subroutine arguments

### DIFF
--- a/docs/decisions/event-control-unification.md
+++ b/docs/decisions/event-control-unification.md
@@ -75,9 +75,9 @@ suspend
 ```
 
 The runtime extends `Trigger`, `Observable::Waiter`, and the `Observable::Subscribe` API to carry
-`(lsb_bit_offset, bit_width, edge)` per waiter. `WriteVar` on `Var<PackedArray>` snapshots
-`var.Get()` before the assignment, then invokes a per-leaf classifier that compares
-`old.ExtractBits(lsb, width)` against `new.ExtractBits(lsb, width)` for any-change waiters and
+`(lsb_bit_offset, bit_width, edge)` per waiter. `Var<PackedArray>::Set` snapshots `var.Get()` before
+the assignment, then invokes a per-leaf classifier that compares `old.ExtractBits(lsb, width)`
+against `new.ExtractBits(lsb, width)` for any-change waiters and
 `ClassifyEdge(old.GetBit(lsb), new.GetBit(lsb))` for edge waiters. The classifier is type-erased via
 `std::function`; the `Observable` itself stays value-type agnostic.
 

--- a/docs/progress/functions.md
+++ b/docs/progress/functions.md
@@ -66,10 +66,15 @@ everything and the inline "rides on" notes record the real dependencies.
 - [x] F6 -- Default argument values (LRM 13.5.3), binding by name (LRM 13.5.4), and the optional
       empty argument list for no-argument / all-defaulted subroutines (LRM 13.5.5). Default
       expressions evaluate in the declaration scope at each defaulting call.
-- [ ] F10 -- `ref` and `const ref` arguments (LRM 13.5.2). A reference shares the caller's storage;
-      changes are visible immediately. `const ref` is read-only. Legal only for automatic-lifetime
-      subroutines and only for a variable, class property, unpacked-struct member, or unpacked-array
-      element. Outdated-reference rules for resized / deleted container elements.
+- [x] F10 -- `ref` and `const ref` arguments (LRM 13.5.2). A reference aliases the caller's
+      variable; reads and writes go through that variable's own access path, so a write is visible
+      immediately and, when the variable is observable, wakes its event subscribers (LRM 4.3 update
+      event). `const ref` is read-only. Legal only for automatic-lifetime subroutines and for a
+      variable or unpacked-array element; mixes with `output` / `inout` in one call. Not yet:
+      compound, partial, or increment / decrement writes through a reference formal (whole-variable
+      reads and writes are supported); class properties and unpacked-struct members (those data
+      types); and the outdated-reference rules for resized / deleted container elements, which ride
+      on F8.
 
 ### Local storage
 

--- a/docs/progress/processes.md
+++ b/docs/progress/processes.md
@@ -58,7 +58,7 @@ machinery owned by other workstreams; see [Blocked](#blocked).
       `@(...)`) through `mir::SensitivityWaitStmt` carrying per-leaf `(var, bit_range, edge_kind)`
       records; slang's flow analysis computes the leaves and the AST -> HIR lowering attaches the SV
       edge identifier (with LRM 9.4.2 LSB-reduce for edge-qualified single-leaf expressions).
-      Runtime per-leaf classification samples each waiter's projection on every `WriteVar`, so
+      Runtime per-leaf classification samples each waiter's projection on every variable write, so
       changes outside the projection do not cause spurious wakes (LRM 9.4.2 "no change in result"
       rule). `ClassifyEdge` covers the LRM Table 9-2 4-state transition matrix; `kBothEdges` matches
       either posedge or negedge. Covers `processes/event_triggers` and

--- a/include/lyra/backend/cpp/render_type.hpp
+++ b/include/lyra/backend/cpp/render_type.hpp
@@ -35,8 +35,8 @@ namespace lyra::backend::cpp {
     const mir::StructuralScope& owner_scope, mir::TypeId id) -> std::string;
 
 // True iff a structural field of this type is emitted as `Var<T>` (and writes
-// go through `lyra::runtime::WriteVar`). Today: only integral types via
-// `PackedArray`. The set grows as more SV value types gain `IsCaseEqual`.
+// go through `Var<T>::Set`). Today: only integral types via `PackedArray`. The
+// set grows as more SV value types gain `IsCaseEqual`.
 [[nodiscard]] auto IsObservableScalarType(const mir::Type& ty) -> bool;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/hir/subroutine.hpp
+++ b/include/lyra/hir/subroutine.hpp
@@ -31,6 +31,18 @@ struct SubroutineParam {
   ParamDirection direction = ParamDirection::kInput;
 };
 
+// LRM 13.5 data flow at the call boundary. `output` and `inout` carry a value
+// back to the actual at return, so a call desugars them into a temp with a
+// copy-out assignment after the call (`inout` also copies in before). `input`
+// passes a value and `ref` / `const ref` alias the actual directly, so neither
+// writes back. Only the writeback directions force the call into statement
+// position, where the copy-out can be sequenced.
+[[nodiscard]] constexpr auto RequiresWriteback(ParamDirection direction)
+    -> bool {
+  return direction == ParamDirection::kOutput ||
+         direction == ParamDirection::kInOut;
+}
+
 // LRM 13.4.1 implicit result variable: a non-void function implicitly declares
 // a body-local variable of the return type that the body reads and writes
 // through the function name. `result_var` indexes the body's procedural-var

--- a/include/lyra/mir/procedural_var.hpp
+++ b/include/lyra/mir/procedural_var.hpp
@@ -24,10 +24,21 @@ enum class VariableLifetime : std::uint8_t {
   kAutomatic,
 };
 
+// LRM 13.5.2 pass-by-reference. A kValue var owns its storage; a kReference var
+// (a `ref` / `const ref` formal) is an alias to the actual's cell, so the
+// backend renders it as a `Ref<T>` and reads / writes route through the
+// actual's own access path. The backend distinguishes the two read / write
+// renderings on this axis.
+enum class VariableBinding : std::uint8_t {
+  kValue,
+  kReference,
+};
+
 struct ProceduralVarDecl {
   std::string name;
   TypeId type;
   VariableLifetime lifetime = VariableLifetime::kAutomatic;
+  VariableBinding binding = VariableBinding::kValue;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/runtime/trigger.hpp
+++ b/include/lyra/runtime/trigger.hpp
@@ -35,7 +35,7 @@ struct Trigger {
 
 // Per-leaf fire decision: receives a waiter's `(lsb_bit_offset, bit_width,
 // edge)` and returns whether to wake it. The caller (the producer of the
-// value change -- typically `WriteVar` on `Var<PackedArray>`) captures the
+// value change -- typically `Var<PackedArray>::Set`) captures the
 // value context (old/new) so the `Observable` stays value-type agnostic.
 using EdgeClassifier =
     std::function<bool(std::uint64_t lsb, std::uint64_t width, Edge edge)>;

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -100,7 +100,7 @@ class Observable {
   // Removes and returns the processes whose per-waiter classifier returns
   // true. Non-matching waiters stay subscribed. The classifier receives each
   // waiter's projection and edge and decides based on context the caller
-  // (WriteVar) captured (old/new value).
+  // (Var::Set) captured (old/new value).
   [[nodiscard]] auto TakeMatchingWaiters(const EdgeClassifier& classify)
       -> std::vector<RuntimeProcess*> {
     std::vector<RuntimeProcess*> out;
@@ -166,10 +166,15 @@ class Var : public Observable {
     return value_;
   }
 
+  // Commits a whole-variable write and, on a real change (LRM 4.3 update
+  // event), wakes subscribers through the engine. Defined out of line below so
+  // it can reach the PackedArray edge classifier.
+  void Set(RuntimeServices& services, const T& new_val);
+
   // RAII entry to partial-write context. Construct via `var.Mutate(services)`
   // at the start of a chain; the returned handle snapshots the current value,
   // forwards chain methods so `var.Mutate(svc)[idx].Slice(...) = v` works as a
-  // single expression, and commits the mutated snapshot through `WriteVar` in
+  // single expression, and commits the mutated snapshot through `Var::Set` in
   // its destructor (fires subscribers on change). Lifetime is C++ standard
   // full-expression temporary lifetime -- the handle is non-copyable and
   // non-movable, so storing it past the statement is rejected at compile time.
@@ -177,6 +182,37 @@ class Var : public Observable {
 
  private:
   T value_{};
+};
+
+// A reference to a variable cell (LRM 13.5.2 pass-by-reference). Transparently
+// views either an observable `Var<T>` (writes route through `Var::Set` so the
+// update event fires and subscribers wake) or a plain `T` cell (raw read /
+// write, no observers). It shares `Var`'s `Get` / `Set` surface, so a ref
+// formal renders identically to a var. Copyable, so a ref formal can be
+// forwarded as a ref argument to a nested call.
+template <CaseEqualComparable T>
+class Ref {
+ public:
+  explicit Ref(Var<T>& cell) : signal_(&cell) {
+  }
+  explicit Ref(T& cell) : plain_(&cell) {
+  }
+
+  [[nodiscard]] auto Get() const -> const T& {
+    return signal_ != nullptr ? signal_->Get() : *plain_;
+  }
+
+  void Set(RuntimeServices& services, const T& new_val) {
+    if (signal_ != nullptr) {
+      signal_->Set(services, new_val);
+    } else {
+      *plain_ = new_val;
+    }
+  }
+
+ private:
+  Var<T>* signal_ = nullptr;
+  T* plain_ = nullptr;
 };
 
 // Suspends the calling process until one of the supplied Triggers fires
@@ -259,33 +295,29 @@ inline auto MakePackedArrayEdgeClassifier(
 }
 
 template <CaseEqualComparable T>
-inline void WriteVar(RuntimeServices& services, Var<T>& var, const T& new_val) {
-  if (var.AssignIfChanged(new_val)) {
-    services.TriggerValueChange(
-        var, [](std::uint64_t, std::uint64_t, Edge edge) -> bool {
-          return edge == Edge::kAnyChange;
-        });
-  }
-}
-
-// Non-template overload for the common Var<PackedArray> case. Required
-// because template deduction would otherwise fail when emit passes a freshly
-// cloned `PackedArray` rvalue (the template `T` cannot be deduced from
-// `Var<T>` and `PackedArray` together).
-inline void WriteVar(
-    RuntimeServices& services, Var<value::PackedArray>& var,
-    const value::PackedArray& new_val) {
-  const value::PackedArray old_val = var.Get();
-  if (var.AssignIfChanged(new_val)) {
-    services.TriggerValueChange(
-        var, MakePackedArrayEdgeClassifier(old_val, new_val));
+void Var<T>::Set(RuntimeServices& services, const T& new_val) {
+  // A PackedArray write classifies the LSB transition per waiter (LRM 9.4.2
+  // Table 9-2); every other cell type only has any-change waiters.
+  if constexpr (std::same_as<T, value::PackedArray>) {
+    const value::PackedArray old_val = Get();
+    if (AssignIfChanged(new_val)) {
+      services.TriggerValueChange(
+          *this, MakePackedArrayEdgeClassifier(old_val, new_val));
+    }
+  } else {
+    if (AssignIfChanged(new_val)) {
+      services.TriggerValueChange(
+          *this, [](std::uint64_t, std::uint64_t, Edge edge) -> bool {
+            return edge == Edge::kAnyChange;
+          });
+    }
   }
 }
 
 // RAII handle that owns a snapshot of `var.Get()` for the lifetime of one
 // partial-write expression. Forwards chain methods to the snapshot so emitted
 // code reads like a normal `PackedArrayRef` chain. The destructor calls
-// `WriteVar` with the (possibly mutated) snapshot -- subscribers fire on
+// `Var::Set` with the (possibly mutated) snapshot -- subscribers fire on
 // change. Non-copyable and non-movable: the contract is that it lives only
 // until the end of the constructing full expression. Returning it by value
 // from `Var<T>::Mutate` relies on C++17 mandatory copy elision (prvalues are
@@ -303,7 +335,7 @@ class ScopedMutation {
   auto operator=(ScopedMutation&&) -> ScopedMutation& = delete;
 
   ~ScopedMutation() {
-    WriteVar(*services_, *var_, std::move(snapshot_));
+    var_->Set(*services_, std::move(snapshot_));
   }
 
   // Chain forwards. The returned `PackedArrayRef` holds a pointer into this
@@ -318,8 +350,8 @@ class ScopedMutation {
 
   // LRM 11.4 whole-var compound. Mirrors `x op= rhs` directly: snapshot is
   // mutated through the underlying type's own `op=`, and the destructor
-  // commits via WriteVar. Keeping the emit shape `x.Mutate(svc) op= rhs`
-  // (instead of expanding to `WriteVar(svc, x, x.Get() op rhs)`) preserves
+  // commits via Var::Set. Keeping the emit shape `x.Mutate(svc) op= rhs`
+  // (instead of expanding to `x.Set(svc, x.Get() op rhs)`) preserves
   // the compound intent end-to-end and mirrors the selector form
   // `x.Mutate(svc).Chain(...) op= rhs`.
   auto operator+=(const value::PackedArray& rhs) -> ScopedMutation& {
@@ -370,11 +402,11 @@ class ScopedMutation {
   }
 
   // LRM 11.4.2 inc/dec on an observable whole-var. The snapshot is mutated
-  // in place; the destructor commits via WriteVar so subscribers fire exactly
+  // in place; the destructor commits via Var::Set so subscribers fire exactly
   // once. Prefix returns the new value; postfix returns the old. Both return
   // by value (not `ScopedMutation&`) so outer rvalue use such as
   // `b = ++observable_var` routes a materialized PackedArray through the
-  // outer WriteVar instead of a transient proxy.
+  // outer Var::Set instead of a transient proxy.
   auto operator++() -> value::PackedArray {
     ++snapshot_;
     return snapshot_;

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -144,13 +144,26 @@ auto RenderSubroutineMethod(
     auto type_or = RenderTypeAsCpp(unit, s, param.type);
     if (!type_or) return std::unexpected(std::move(type_or.error()));
     if (i != 0) sig += ", ";
-    // An `input` formal is a by-value copy (LRM 13.5.1); an `output` / `inout`
-    // formal binds to the caller's writeback temp by reference so the body
-    // writes flow back at the copy-out. ref / const ref are rejected upstream.
-    if (param.direction == mir::ParamDirection::kInput) {
-      sig += *type_or + " " + param.name;
-    } else {
-      sig += *type_or + "& " + param.name;
+    // An `input` formal is a by-value copy (LRM 13.5.1). An `output` / `inout`
+    // formal binds to the caller's writeback temp by reference (`T&`) so body
+    // writes flow back at the copy-out. A `ref` / `const ref` formal aliases
+    // the actual's cell through a `Ref<T>` so writes route through that cell's
+    // update-event path (LRM 13.5.2); `const ref` is `const Ref<T>`, which
+    // makes `Set` ill-formed and enforces the read-only promise.
+    switch (param.direction) {
+      case mir::ParamDirection::kInput:
+        sig += *type_or + " " + param.name;
+        break;
+      case mir::ParamDirection::kOutput:
+      case mir::ParamDirection::kInOut:
+        sig += *type_or + "& " + param.name;
+        break;
+      case mir::ParamDirection::kRef:
+        sig += "lyra::runtime::Ref<" + *type_or + "> " + param.name;
+        break;
+      case mir::ParamDirection::kConstRef:
+        sig += "const lyra::runtime::Ref<" + *type_or + "> " + param.name;
+        break;
     }
   }
   sig += ")";

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -37,6 +37,10 @@ auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
 
 namespace {
 
+auto RenderLhsExpr(
+    const RenderContext& ctx, const mir::Expr& expr,
+    std::string_view mutate_adapter) -> diag::Result<std::string>;
+
 // Type-kind predicate. `real`, `shortreal`, and `realtime` (LRM 6.12)
 // collectively form the "real family"; arithmetic / relational / logical
 // operator dispatch all branch on this. Taking the full `mir::Type` instead
@@ -198,6 +202,15 @@ auto LookupProceduralVarName(
     return std::format("{}.{}", ctx.StaticFrame(), var.name);
   }
   return var.name;
+}
+
+// True iff the procedural var is a `ref` / `const ref` formal, rendered as a
+// `Ref<T>` whose read is `.Get()` and whose write is `.Set(*services_, ...)`
+// (LRM 13.5.2), the same surface as a structural Var.
+auto IsReferenceProceduralVar(
+    const RenderContext& ctx, const mir::ProceduralVarRef& ref) -> bool {
+  return ctx.ProceduralScopeAtHops(ref.hops).vars.at(ref.var.value).binding ==
+         mir::VariableBinding::kReference;
 }
 
 }  // namespace
@@ -861,16 +874,35 @@ auto RenderCallExpr(const RenderContext& ctx, const mir::CallExpr& call)
             }
             const auto& scope = ctx.StructuralScopeAtHops(
                 mir::StructuralHops{.value = ref.hops.value});
-            const std::string& name =
-                scope.GetStructuralSubroutine(ref.subroutine).name;
+            const auto& decl = scope.GetStructuralSubroutine(ref.subroutine);
             std::string args;
             for (std::size_t i = 0; i < call.arguments.size(); ++i) {
-              auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
-              if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+              const mir::Expr& actual = ctx.Expr(call.arguments[i]);
+              const mir::ParamDirection dir = decl.params[i].direction;
+              std::string rendered;
+              if (dir == mir::ParamDirection::kRef ||
+                  dir == mir::ParamDirection::kConstRef) {
+                // A ref / const ref actual binds the variable's cell: render
+                // its lvalue and wrap it in a `Ref<T>`. Constructor overload
+                // picks the observable (`Var<T>`) or plain (`T`) backing; a ref
+                // formal passed on forwards via the copy ctor (LRM 13.5.2).
+                auto lhs_or = RenderLhsExpr(ctx, actual, std::string_view{});
+                if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+                auto type_or = RenderTypeAsCpp(
+                    ctx.Unit(), ctx.StructuralScope(), decl.params[i].type);
+                if (!type_or)
+                  return std::unexpected(std::move(type_or.error()));
+                rendered =
+                    "lyra::runtime::Ref<" + *type_or + ">(" + *lhs_or + ")";
+              } else {
+                auto arg_or = RenderExpr(ctx, actual);
+                if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+                rendered = *std::move(arg_or);
+              }
               if (i != 0) args += ", ";
-              args += *arg_or;
+              args += rendered;
             }
-            return std::format("{}({})", name, args);
+            return std::format("{}({})", decl.name, args);
           },
           [&](const mir::BuiltinMethodCallee& b) -> diag::Result<std::string> {
             return std::visit(
@@ -924,12 +956,6 @@ auto RenderElementSelectExpr(
 // `mutate_adapter` string (typically `.Mutate(*services_)` or empty) is
 // inserted immediately after the structural-var root so an observable
 // partial write enters a ScopedMutation before the selector chain begins.
-// Output shape:
-//   <root>{<mutate_adapter>}{.ElementAt(idx) | .Slice(offset, count)}*
-auto RenderLhsExpr(
-    const RenderContext& ctx, const mir::Expr& expr,
-    std::string_view mutate_adapter) -> diag::Result<std::string>;
-
 auto RenderRangeSliceSuffix(
     const RenderContext& ctx, mir::ExprId offset_expr, std::uint32_t count)
     -> diag::Result<std::string> {
@@ -938,6 +964,8 @@ auto RenderRangeSliceSuffix(
   return std::format(".Slice({}, {}U)", *offset, count);
 }
 
+// Output shape:
+//   <root>{<mutate_adapter>}{.ElementAt(idx) | .Slice(offset, count)}*
 auto RenderLhsExpr(
     const RenderContext& ctx, const mir::Expr& expr,
     std::string_view mutate_adapter) -> diag::Result<std::string> {
@@ -977,33 +1005,47 @@ auto RenderLhsExpr(
       expr.data);
 }
 
-// Walks an LHS expression to its root PrimaryExpr and returns the
-// StructuralVarRef there iff that's what the root is, else nullptr. Used
-// to detect whether the assignment touches an observable scalar.
+// Walks an LHS expression through element / range selects to its root primary.
+// Whether a write touches an observable cell or a reference formal is decided
+// by what that root is.
+auto LhsRootPrimary(const RenderContext& ctx, const mir::Expr& expr)
+    -> const mir::Expr& {
+  const mir::Expr* current = &expr;
+  while (true) {
+    if (const auto* sel = std::get_if<mir::ElementSelectExpr>(&current->data)) {
+      current = &ctx.Expr(sel->base_value);
+      continue;
+    }
+    if (const auto* sel = std::get_if<mir::RangeSelectExpr>(&current->data)) {
+      current = &ctx.Expr(sel->base_value);
+      continue;
+    }
+    return *current;
+  }
+}
+
+// The root structural var iff the LHS root is one, else nullptr -- used to
+// detect whether the assignment touches an observable scalar.
 auto LhsRootStructuralVarForObservable(
     const RenderContext& ctx, const mir::Expr& expr)
     -> const mir::StructuralVarRef* {
-  const mir::Expr* current = &expr;
-  while (true) {
-    const mir::Expr& e = *current;
-    if (const auto* svr = std::get_if<mir::StructuralVarRef>(&e.data)) {
-      return svr;
-    }
-    if (const auto* sel = std::get_if<mir::ElementSelectExpr>(&e.data)) {
-      current = &ctx.Expr(sel->base_value);
-      continue;
-    }
-    if (const auto* sel = std::get_if<mir::RangeSelectExpr>(&e.data)) {
-      current = &ctx.Expr(sel->base_value);
-      continue;
-    }
-    return nullptr;
-  }
+  return std::get_if<mir::StructuralVarRef>(&LhsRootPrimary(ctx, expr).data);
 }
 
 auto IsLhsBarePrimary(const mir::Expr& expr) -> bool {
   return std::holds_alternative<mir::StructuralVarRef>(expr.data) ||
          std::holds_alternative<mir::ProceduralVarRef>(expr.data);
+}
+
+// The root procedural var iff the LHS root is a `ref` / `const ref` formal,
+// else nullptr. A write whose root is a reference formal must route through
+// `Ref::Set` (LRM 13.5.2).
+auto LhsRootReferenceProceduralVar(
+    const RenderContext& ctx, const mir::Expr& expr)
+    -> const mir::ProceduralVarRef* {
+  const auto* pvr =
+      std::get_if<mir::ProceduralVarRef>(&LhsRootPrimary(ctx, expr).data);
+  return pvr != nullptr && IsReferenceProceduralVar(ctx, *pvr) ? pvr : nullptr;
 }
 
 // Render a compound op suffix for the SV `op=` family. Arithmetic /
@@ -1054,6 +1096,23 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
   if (!value_or) return std::unexpected(std::move(value_or.error()));
 
   const mir::Expr& lhs_expr = ctx.Expr(a.target);
+
+  // A `ref` / `const ref` formal aliases the actual's cell; a whole write
+  // routes through `Ref::Set` so the actual's update-event path fires (LRM
+  // 13.5.2). Compound and partial writes through a ref formal are not yet
+  // supported.
+  if (const auto* ref_root = LhsRootReferenceProceduralVar(ctx, lhs_expr)) {
+    if (!IsLhsBarePrimary(lhs_expr) || a.compound_op.has_value()) {
+      return diag::Unsupported(
+          diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+          "compound or partial assignment through a ref / const ref formal is "
+          "not yet implemented in cpp emit",
+          diag::UnsupportedCategory::kFeature);
+    }
+    return LookupProceduralVarName(ctx, *ref_root) + ".Set(*services_, " +
+           *value_or + ")";
+  }
+
   const mir::StructuralVarRef* observable_root =
       LhsRootStructuralVarForObservable(ctx, lhs_expr);
   const bool observable = observable_root != nullptr && [&] {
@@ -1062,7 +1121,7 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
     return IsObservableScalarType(ctx.Unit().GetType(var_decl.type));
   }();
 
-  // Whole-var write: route observable structural targets through WriteVar
+  // Whole-var write: route observable structural targets through Var::Set
   // (which fires subscribers), procedural locals get a direct C++ assignment.
   if (IsLhsBarePrimary(lhs_expr)) {
     auto root_or = RenderLhsExpr(ctx, lhs_expr, std::string_view{});
@@ -1078,8 +1137,7 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
       return "(" + RenderCompoundAssign(*a.compound_op, chain, *value_or) + ")";
     }
     if (observable) {
-      return "lyra::runtime::WriteVar(*services_, " + *root_or + ", " +
-             *value_or + ")";
+      return *root_or + ".Set(*services_, " + *value_or + ")";
     }
     return "(" + *root_or + " = " + *value_or + ")";
   }
@@ -1094,7 +1152,7 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
   // which returns a `ScopedMutation` RAII handle that snapshots the current
   // value. The chain runs against the snapshot via the same forwarding
   // methods as on PackedArray; when the full expression ends, the handle's
-  // destructor commits the snapshot through `WriteVar` so subscribers fire.
+  // destructor commits the snapshot through `Var::Set` so subscribers fire.
   // Same shape inside or outside an NBA closure body -- no nested lambda.
   const std::string_view mutate_adapter =
       observable ? std::string_view{".Mutate(*services_)"} : std::string_view{};
@@ -1110,6 +1168,13 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
 auto RenderIncDecExpr(const RenderContext& ctx, const mir::IncDecExpr& inc)
     -> diag::Result<std::string> {
   const mir::Expr& target_expr = ctx.Expr(inc.target);
+  if (LhsRootReferenceProceduralVar(ctx, target_expr) != nullptr) {
+    return diag::Unsupported(
+        diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+        "increment / decrement of a ref / const ref formal is not yet "
+        "implemented in cpp emit",
+        diag::UnsupportedCategory::kFeature);
+  }
   const mir::StructuralVarRef* observable_root =
       LhsRootStructuralVarForObservable(ctx, target_expr);
   const bool observable = observable_root != nullptr && [&] {
@@ -1328,7 +1393,8 @@ auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
             return RenderStructuralVarReadExpr(ctx, expr, m);
           },
           [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
-            return LookupProceduralVarName(ctx, l);
+            const std::string name = LookupProceduralVarName(ctx, l);
+            return IsReferenceProceduralVar(ctx, l) ? name + ".Get()" : name;
           },
           [&](const mir::UnaryExpr& u) -> diag::Result<std::string> {
             return RenderUnaryExpr(ctx, expr, u);

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -111,9 +111,12 @@ auto LowerVariableMemberInto(
   return {};
 }
 
-auto FromSlangArgumentDirection(slang::ast::ArgumentDirection dir)
+// slang has no ConstRef direction (LRM 13.5.2): a `const ref` formal carries
+// direction Ref with the Const variable flag, so the const-ness must be read
+// off the formal rather than the direction enum alone.
+auto ParamDirectionOf(const slang::ast::FormalArgumentSymbol& formal)
     -> hir::ParamDirection {
-  switch (dir) {
+  switch (formal.direction) {
     case slang::ast::ArgumentDirection::In:
       return hir::ParamDirection::kInput;
     case slang::ast::ArgumentDirection::Out:
@@ -121,9 +124,11 @@ auto FromSlangArgumentDirection(slang::ast::ArgumentDirection dir)
     case slang::ast::ArgumentDirection::InOut:
       return hir::ParamDirection::kInOut;
     case slang::ast::ArgumentDirection::Ref:
-      return hir::ParamDirection::kRef;
+      return formal.flags.has(slang::ast::VariableFlags::Const)
+                 ? hir::ParamDirection::kConstRef
+                 : hir::ParamDirection::kRef;
   }
-  throw InternalError("FromSlangArgumentDirection: unknown ArgumentDirection");
+  throw InternalError("ParamDirectionOf: unknown ArgumentDirection");
 }
 
 auto LowerSubroutineMemberInto(
@@ -152,8 +157,7 @@ auto LowerSubroutineMemberInto(
         sub_state.AddProceduralVar(*formal, *formal_type_or);
     params.push_back(
         hir::SubroutineParam{
-            .var = var,
-            .direction = FromSlangArgumentDirection(formal->direction)});
+            .var = var, .direction = ParamDirectionOf(*formal)});
   }
 
   // LRM 13.4.1: a non-void function implicitly declares a body-local variable

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -870,11 +870,13 @@ auto LowerHirCallExprProc(
             // copy-in-copy-out at statement position (see LowerExprStmt).
             // Reaching it here means the call is a nested expression operand,
             // where the copy-out statement has nowhere to be sequenced; that
-            // form is not yet supported.
+            // form is not yet supported. ref / const ref alias the actual and
+            // copy nothing back (LRM 13.5.2), so they are fine as operands and
+            // fall through to the value-only argument lowering below.
             const hir::StructuralSubroutineDecl& decl =
                 scope_state.LookupHirSubroutine(usr.hops, usr.subroutine);
             for (const auto& param : decl.params) {
-              if (param.direction != hir::ParamDirection::kInput) {
+              if (hir::RequiresWriteback(param.direction)) {
                 return diag::Unsupported(
                     span, diag::DiagCode::kUnsupportedSubroutineArgument,
                     "a call with output / inout arguments is only supported "

--- a/src/lyra/lowering/hir_to_mir/lower_process.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_process.cpp
@@ -152,8 +152,16 @@ auto LowerStructuralSubroutine(
   for (const auto& param : src.params) {
     const auto& hir_var = src.body.procedural_vars.at(param.var.value);
     const mir::TypeId type = unit_state.TranslateType(hir_var.type);
+    // A ref / const ref formal aliases the actual's cell, so its body var is a
+    // reference binding the backend renders as `Ref<T>` (LRM 13.5.2).
+    const mir::VariableBinding binding =
+        (param.direction == hir::ParamDirection::kRef ||
+         param.direction == hir::ParamDirection::kConstRef)
+            ? mir::VariableBinding::kReference
+            : mir::VariableBinding::kValue;
     const mir::ProceduralVarId mir_var = body_scope_state.AddProceduralVar(
-        mir::ProceduralVarDecl{.name = hir_var.name, .type = type});
+        mir::ProceduralVarDecl{
+            .name = hir_var.name, .type = type, .binding = binding});
     proc_state.MapProceduralVar(
         param.var,
         ProceduralVarBinding{

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -343,7 +343,7 @@ auto SubroutineWithWritebacks(
   const hir::StructuralSubroutineDecl& decl =
       scope_state.LookupHirSubroutine(ref->hops, ref->subroutine);
   for (const auto& param : decl.params) {
-    if (param.direction != hir::ParamDirection::kInput) {
+    if (hir::RequiresWriteback(param.direction)) {
       return &decl;
     }
   }
@@ -366,7 +366,7 @@ auto LowerSubroutineCallWithWritebacks(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
     ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
-    const hir::Stmt& stmt, diag::SourceSpan span, const hir::CallExpr& call,
+    const hir::Stmt& stmt, const hir::CallExpr& call,
     const hir::StructuralSubroutineRef& callee_ref,
     const hir::StructuralSubroutineDecl& decl,
     std::optional<hir::ExprId> assign_target, mir::TypeId result_type)
@@ -392,19 +392,16 @@ auto LowerSubroutineCallWithWritebacks(
     const hir::ParamDirection dir = decl.params[i].direction;
     const hir::Expr& hir_arg = hir_proc.exprs.at(call.arguments[i].value);
 
-    if (dir == hir::ParamDirection::kInput) {
+    // input passes a value; ref / const ref alias the actual lvalue. Neither
+    // copies back, so both pass the lowered actual directly with no temp
+    // (LRM 13.5.1, 13.5.2). Only output / inout fall through to the writeback
+    // temp below.
+    if (!hir::RequiresWriteback(dir)) {
       auto arg_or = LowerExpr(
           unit_state, scope_state, proc_state, wrapper, hir_proc, hir_arg);
       if (!arg_or) return std::unexpected(std::move(arg_or.error()));
       call_args.push_back(wrapper.AddExpr(*std::move(arg_or)));
       continue;
-    }
-    if (dir == hir::ParamDirection::kRef ||
-        dir == hir::ParamDirection::kConstRef) {
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedSubroutineArgument,
-          "ref / const ref subroutine arguments are not yet supported",
-          diag::UnsupportedCategory::kFeature);
     }
 
     const mir::TypeId formal_type = unit_state.TranslateType(
@@ -508,8 +505,8 @@ auto LowerExprStmt(
   if (const auto* call = std::get_if<hir::CallExpr>(&inner.data)) {
     if (const auto* decl = SubroutineWithWritebacks(scope_state, *call)) {
       return LowerSubroutineCallWithWritebacks(
-          unit_state, scope_state, proc_state, hir_proc, stmt, inner.span,
-          *call, std::get<hir::StructuralSubroutineRef>(call->callee), *decl,
+          unit_state, scope_state, proc_state, hir_proc, stmt, *call,
+          std::get<hir::StructuralSubroutineRef>(call->callee), *decl,
           std::nullopt, unit_state.TranslateType(inner.type));
     }
     // System-subroutine tasks with an output arg ($fgets / $fread / $ferror)
@@ -553,8 +550,7 @@ auto LowerExprStmt(
           // firing when the call sits directly under the AssignExpr.
           if (!conv_target_type.has_value()) {
             return LowerSubroutineCallWithWritebacks(
-                unit_state, scope_state, proc_state, hir_proc, stmt,
-                call_carrier->span, *call,
+                unit_state, scope_state, proc_state, hir_proc, stmt, *call,
                 std::get<hir::StructuralSubroutineRef>(call->callee), *decl,
                 assign->lhs, unit_state.TranslateType(call_carrier->type));
           }

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -677,9 +677,10 @@ class MirDumper {
         const auto& v = scope.vars[i];
         Line(
             std::format(
-                "ProceduralVar[{}] \"{}\" : Type[{}]{}", i, v.name,
+                "ProceduralVar[{}] \"{}\" : Type[{}]{}{}", i, v.name,
                 v.type.value,
-                v.lifetime == VariableLifetime::kStatic ? " static" : ""));
+                v.lifetime == VariableLifetime::kStatic ? " static" : "",
+                v.binding == VariableBinding::kReference ? " ref" : ""));
       }
       Dedent();
     }

--- a/tests/cases/cpp/function_ref/case.yaml
+++ b/tests/cases/cpp/function_ref/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.function_ref
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a: 7
+    b: 3
+    src: 21
+    ro: 42
+    e: 6
+    e_ret: 106

--- a/tests/cases/cpp/function_ref/main.sv
+++ b/tests/cases/cpp/function_ref/main.sv
@@ -1,0 +1,40 @@
+module Top;
+  int a;
+  int b;
+  int src;
+  int ro;
+  int e;
+  int e_ret;
+
+  // Two refs aliasing distinct cells, mutated through a void function.
+  function automatic void swap(ref int x, ref int y);
+    int t;
+    t = x;
+    x = y;
+    y = t;
+  endfunction
+
+  // const ref: a read-only alias; the actual is not modified.
+  function automatic int doubled(const ref int d);
+    return d * 2;
+  endfunction
+
+  // A ref formal written then read; the call below uses it as a nested operand,
+  // exercising a ref call in expression position (not statement position).
+  function automatic int bump_get(ref int x);
+    x = x + 1;
+    return x;
+  endfunction
+
+  initial begin
+    a = 3;
+    b = 7;
+    swap(a, b);
+
+    src = 21;
+    ro = doubled(src);
+
+    e = 5;
+    e_ret = bump_get(e) + 100;
+  end
+endmodule

--- a/tests/cases/cpp/function_ref_lvalue_targets/case.yaml
+++ b/tests/cases/cpp/function_ref_lvalue_targets/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.function_ref_lvalue_targets
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r1: 102
+    r2: 112

--- a/tests/cases/cpp/function_ref_lvalue_targets/main.sv
+++ b/tests/cases/cpp/function_ref_lvalue_targets/main.sv
@@ -1,0 +1,24 @@
+module Top;
+  int arr [3];
+  int grid [2][2];
+  int r1;
+  int r2;
+
+  function automatic void bump(ref int x);
+    x = x + 100;
+  endfunction
+
+  initial begin
+    arr[0] = 1;
+    arr[1] = 2;
+    arr[2] = 3;
+    grid[0][0] = 10;
+    grid[0][1] = 11;
+    grid[1][0] = 12;
+    grid[1][1] = 13;
+    bump(arr[1]);
+    bump(grid[1][0]);
+    r1 = arr[1];
+    r2 = grid[1][0];
+  end
+endmodule

--- a/tests/cases/cpp/function_ref_mixed_directions/case.yaml
+++ b/tests/cases/cpp/function_ref_mixed_directions/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.function_ref_mixed_directions
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    o: 10
+    r: 105

--- a/tests/cases/cpp/function_ref_mixed_directions/main.sv
+++ b/tests/cases/cpp/function_ref_mixed_directions/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  int o;
+  int r;
+
+  function automatic void compute(output int o_arg, ref int r_arg, input int v);
+    o_arg = v * 2;
+    r_arg = r_arg + v;
+  endfunction
+
+  initial begin
+    r = 100;
+    compute(o, r, 5);
+  end
+endmodule

--- a/tests/cases/cpp/function_ref_wakeup/case.yaml
+++ b/tests/cases/cpp/function_ref_wakeup/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.function_ref_wakeup
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    g: 1
+    woke: 1

--- a/tests/cases/cpp/function_ref_wakeup/main.sv
+++ b/tests/cases/cpp/function_ref_wakeup/main.sv
@@ -1,0 +1,22 @@
+module Top;
+  int g;
+  int woke;
+
+  function automatic void poke(ref int x);
+    x = x + 1;
+  endfunction
+
+  // Waits for any change to the observable variable g. This only fires if the
+  // ref write inside poke routes through g's update-event path (LRM 4.3).
+  initial begin
+    @(g);
+    woke = 1;
+  end
+
+  // The #1 lets the waiter above subscribe before g changes, so the wake is
+  // deterministic rather than racing the subscription.
+  initial begin
+    #1;
+    poke(g);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements F10 of the subroutine workstream: `ref` and `const ref` arguments (LRM 13.5.2), the last unfinished argument-passing mode. A reference aliases the caller's variable rather than copying it, so writes are visible immediately and, when the variable is observable, wake its event subscribers.

## Design

The runtime models a reference as a `Ref<T>` cell view that shares `Var<T>`'s read/write surface (`Get` / `Set`). It transparently backs either an observable `Var<T>` (writes route through `Var::Set` so the update event fires, LRM 4.3) or a plain `T` cell (raw write, no observers). A ref formal therefore renders identically to a variable in the emitted body (`x.Get()` / `x.Set(*services_, v)`), and the call site wraps the actual as `Ref<T>(<lvalue>)`, letting C++ overload resolution pick the observable or plain backing. `const ref` is `const Ref<T>`, which makes `Set` ill-formed and enforces the read-only promise on top of the frontend check.

As part of this, the free function `WriteVar` becomes the method `Var<T>::Set`, so `Var` and `Ref` expose one symmetric cell-accessor surface. Whole-variable reads and writes through a ref formal are supported, including mixing with `output` / `inout` in one call; compound, partial, and increment / decrement writes through a reference formal are deferred.

## Testing

`function_ref` (two-ref swap, const ref read-only, ref call in expression position), `function_ref_wakeup` (a ref write to an observable variable wakes a process waiting on `@(g)`), `function_ref_lvalue_targets` (ref to unpacked-array elements, the plain-cell backing), and `function_ref_mixed_directions` (output copy-out and a direct ref in one call). Full `bazel test //...` passes.