### PR TITLE
Support instance arrays through the type-driven member model

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -39,13 +39,16 @@ If you are looking for a concept, this table points to the canonical doc.
 | Pipeline (HIR -> MIR -> LIR -> LLVM IR); compile-time vs runtime split    | `compiler_overview.md`      |
 | Compilation unit; class-level artifacts; instance records                 | `compilation_unit_model.md` |
 | Constructor vs simulation execution contexts; structural vs process       | `runtime_model.md`          |
+| Storage and binding vs construction; type-driven member walk              | `runtime_model.md`          |
 | Generate as constructor-time logic; object graph shape                    | `hierarchy_and_generate.md` |
+| Instance array as a data type; multiplicity vs generate axes              | `hierarchy_and_generate.md` |
 | Intra-unit vs cross-unit references; compile-time vs construction resolve | `reference_resolution.md`   |
 | Parameter values, specialization keys, per-specialization artifacts       | `specialization_model.md`   |
 | Identity rules; ownership; forbidden identity shapes                      | `identity_and_ownership.md` |
 | Lowering permissions (what each lowering may and may not do)              | `lowering_boundaries.md`    |
 | HIR shape (statements, expressions, primaries)                            | `hir.md`                    |
 | MIR shape (objects, members, callables, closures)                         | `mir.md`                    |
+| Member and type model; object types; owning pointer; vector wrapper       | `mir.md`                    |
 | LIR shape (CFG, basic blocks, storage)                                    | `lir.md`                    |
 | Stratified scheduler; regions; suspension protocol; NBA / closure submit  | `scheduling.md`             |
 | Incremental compilation; query-based caching                              | `incremental_build.md`      |

--- a/docs/architecture/hierarchy_and_generate.md
+++ b/docs/architecture/hierarchy_and_generate.md
@@ -50,6 +50,11 @@ shared by all consumers: external references, child routing, and construction.
    blocks is an elaboration property, distinct from the set of compiled units (see
    `compilation_unit_model.md`): the two coincide only when nothing is instantiated and must not be
    collapsed into one set.
+9. Instance multiplicity and generate are orthogonal axes. An array of instances (`c[3]`) is a
+   cardinality property of one member's type -- a vector of owned children (see `mir.md`) -- not a
+   generate construct. A generate builds named child scopes as constructor-time logic; an array
+   replicates one child member. Either may appear without the other, and a generate scope may itself
+   contain instance arrays. Neither axis subsumes the other.
 
 ## Boundary to Adjacent Layers
 
@@ -77,6 +82,9 @@ shared by all consumers: external references, child routing, and construction.
 - A child-routing or external-reference path that reconstructs hierarchy from flattened symbol
   names.
 - Per-instance generate trees that duplicate the unit's construction logic.
+- Treating an instance array as a generate construct, or modeling generate replication as an array
+  type. Multiplicity is a property of a member's type; generate is constructor-time scope
+  construction. The two axes must not be conflated or made to subsume each other.
 - Parameter values used as part of compile-time identity. Parameters are constructor inputs that
   steer construction, not identity keys that fork compile-time artifacts.
 

--- a/docs/architecture/mir.md
+++ b/docs/architecture/mir.md
@@ -9,6 +9,11 @@ several possible backend targets for MIR, and does not define MIR's semantics.
 ## Owns
 
 - Objects, members, and member access as first-class entities.
+- A member as a `(name, type)` pair. The type is the sole carrier of the member's storage shape and,
+  for a member that owns a child, of its child-scope kind and cardinality.
+- The type system: value types (integral, real, string, event, ...); object types in two forms -- an
+  intra-unit object (a structural scope of this unit) and an external-unit object (another
+  compilation unit, named); and two composing wrappers, owning pointer and vector.
 - Callables: functions, tasks, constructors, processes, and assertion actions.
 - The identity of each object and member within a compilation unit.
 - Lightweight structured control flow inside a callable body: `if`, loop, and sequence. No basic
@@ -43,6 +48,17 @@ several possible backend targets for MIR, and does not define MIR's semantics.
    dumper is the golden-test surface at this layer; it is not a compilation path.
 6. MIR does not reconstruct topology or identity from side tables. A member is owned by exactly one
    object; a callable by exactly one owner.
+7. A member is a `(name, type)` pair. An owned child -- a module instance or a named generate scope
+   -- is a member whose type is an owning pointer to an object type. An array of children is a
+   member whose type is a vector of that owning pointer; a multidimensional array nests the vector
+   wrapper. No member carries a classification flag beside its type; the type is the classification.
+8. An object type is exactly one of two forms: intra-unit, naming a structural scope of this unit,
+   or external-unit, naming another compilation unit. This single distinction is the owned child's
+   runtime scope kind -- a named generate scope versus a module instance. Nothing else encodes scope
+   kind.
+9. Instance multiplicity is the vector wrapper, a property of the member's type, and is orthogonal
+   to whether the owned object is an intra-unit scope or an external unit. The same wrapper composes
+   over either object form and to any depth.
 
 ## Boundary to Adjacent Layers
 
@@ -58,6 +74,11 @@ several possible backend targets for MIR, and does not define MIR's semantics.
 - A secondary hierarchy or identity system that shadows MIR ids (coordinate tuples, ordinals, symbol
   paths used as identity).
 - Global semantic lookup used inside MIR. Relationships live on the owning object.
+- A parallel list, flag, or side field that classifies members -- signal versus owned child,
+  instance versus generate scope, scalar versus array -- outside the type system. The type is the
+  classification, and a consumer reads it from the type.
+- Re-deriving a member's scope kind, cardinality, or storage shape from anything other than its type
+  (its name, a naming convention, an enclosing-construct category, or a separate enum).
 - Side tables that recover topology from keys rather than direct ownership.
 - Deferred or concurrent assertions represented as flags or lowering-pass side effects instead of
   explicit callables.
@@ -75,6 +96,15 @@ Reviewing MIR via the dumper should feel like reading the compiled program's str
 backend emits MIR to C++ source: it is a backend output, not a debug view. The object-oriented
 semantic model maps naturally to C++ surface syntax, but C++ is not MIR's semantics and more than
 one backend may exist.
+
+A module instance, a named generate scope, and an instance array differ only in one member's type:
+`owning-ptr(external-unit object)`, `owning-ptr(intra-unit object)`, and `vector(owning-ptr(...))`
+respectively. A two-dimensional array is `vector(vector(owning-ptr(...)))`. Because the
+classification lives entirely in the type, a consumer that recurses on the type -- a vector layer
+recurses on its element, an owning pointer to an object reaches the object -- handles every
+combination, including arrays of any dimensionality, with no per-form branch. A consumer that
+switches on whether a member "is an instance" or "is a generate scope" or "is an array" is
+reconstructing what the type already states.
 
 The primitive expression set above is shaped by the downstream optimizer. Each backend
 (`backend::cpp` today, the LLVM backend via LIR) consumes MIR as primitives that its optimizer can

--- a/docs/architecture/runtime_model.md
+++ b/docs/architecture/runtime_model.md
@@ -22,6 +22,26 @@ Read every SystemVerilog construct in a module as a piece of a C++ class:
 Generate constructs are constructor code. `initial` and `always*` are runtime methods. They run in
 different contexts and they do different jobs.
 
+## Storage and binding follow the type; construction is the variable part
+
+Reading a module as a class separates two things that are easy to conflate.
+
+A scope's **members** are uniform: each is a name and a type (see `mir.md`). A signal, a child
+instance, an instance array, and a named generate scope are all members; they differ only in their
+type. How a member is stored, and how it is registered into the object graph, follow from that type
+alone. Registering an owned child walks the member's type: a vector layer iterates and indexes by
+position; an owning pointer to an object registers one child scope, whose kind -- module instance
+versus generate scope -- is read off the object type, then recurses into that child. One walk covers
+a scalar instance, an instance array of any dimensionality, and a generate scope, with no per-form
+branch and no separate classification.
+
+**Construction** -- the constructor statements that fill those members -- is the part that
+legitimately varies, because SystemVerilog construction semantics vary. A signal takes its default
+value. A single instance is built once. An instance array is built by replication over its element
+count. A generate-for is a loop driven by a genvar. A generate-if is a branch. These are statements
+in the constructor body, and the variation lives there and only there: it never leaks into how
+members are stored or bound.
+
 ## Constructor runs at t = 0, simulation runs at t >= 0
 
 The constructor allocates per-object state, binds the parameter values it was called with, walks

--- a/docs/glossary/instance-array.md
+++ b/docs/glossary/instance-array.md
@@ -1,0 +1,14 @@
+# Instance Array
+
+**Definition.** One named member whose type is a vector of [owning pointers](owning-pointer.md) to a
+child [object](object-type.md), expanding to a vector of independent child objects; a
+multidimensional array nests the vector wrapper.
+
+**Contrast.** Not a _generate construct_. An instance array is a cardinality property of one
+member's type; a generate builds named child scopes as constructor-time logic. The two are
+orthogonal axes (see `architecture/hierarchy_and_generate.md`): a generate scope may contain
+instance arrays, and an instance array needs no generate. Neither subsumes the other.
+
+**Usage notes.** Multiplicity is the vector wrapper alone, so the same recursion that binds a scalar
+child binds an array of any dimensionality without per-form branching. Construction fills the vector
+by replication over the element count; the child objects are identical except for their connections.

--- a/docs/glossary/member.md
+++ b/docs/glossary/member.md
@@ -1,0 +1,15 @@
+# Member
+
+**Definition.** A `(name, type)` pair owned by a structural scope; the type is the sole carrier of
+the member's storage shape and, when the member owns a child, of its child-scope kind and
+cardinality.
+
+**Contrast.** Not a _procedural variable_ (local to a process or callable body). Not a _callable_
+(function, task, process, constructor). A signal, a child instance, an instance array, and a named
+generate scope are all members and differ only in their type.
+
+**Usage notes.** Because the type carries the classification, consumers read storage, scope kind,
+and cardinality from the type, never from a parallel flag or naming convention (see
+`architecture/mir.md`). An owned child is a member whose type is an
+[owning pointer](owning-pointer.md) to an [object type](object-type.md); an
+[instance array](instance-array.md) is a member whose type wraps that in a vector.

--- a/docs/glossary/object-type.md
+++ b/docs/glossary/object-type.md
@@ -1,0 +1,15 @@
+# Object Type
+
+**Definition.** A type that denotes an owned child object, in one of two forms: an _intra-unit
+object_, naming a structural scope of this compilation unit (a named generate scope), or an
+_external-unit object_, naming another compilation unit (a module instance).
+
+**Contrast.** Not a _value type_ (integral, real, string, event, ...), which denotes data a process
+reads and writes. Not an [owning pointer](owning-pointer.md) or vector, which are the wrappers that
+compose over an object type to give storage and cardinality.
+
+**Usage notes.** The intra-unit versus external-unit distinction is the owned child's runtime scope
+kind -- generate scope versus module instance -- and is the only thing that encodes scope kind (see
+`architecture/mir.md`). An intra-unit object references a scope of this unit by its local id; an
+external-unit object references another unit by name, and that unit's layout is not visible across
+the boundary (see `architecture/compilation_unit_model.md`).

--- a/docs/glossary/owning-pointer.md
+++ b/docs/glossary/owning-pointer.md
@@ -1,0 +1,13 @@
+# Owning Pointer
+
+**Definition.** A wrapper type expressing that a member owns the heap-allocated object it points to,
+giving the owned child stable identity for the lifetime of the owner.
+
+**Contrast.** Not a value held inline; an owned child object has stable identity and is not stored
+by value (a moved or copied object would break references into it). Not a non-owning reference
+resolved across the object graph (see `architecture/reference_resolution.md`).
+
+**Usage notes.** An owned child member's type is an owning pointer to an
+[object type](object-type.md). A vector of owning pointers gives an
+[instance array](instance-array.md); the wrappers compose to any depth. The owning pointer carries
+ownership only; the scope kind comes from the object type it wraps.

--- a/docs/glossary/structural-scope.md
+++ b/docs/glossary/structural-scope.md
@@ -1,0 +1,15 @@
+# Structural Scope
+
+**Definition.** A scope that owns members and child scopes and whose constructor builds the object
+graph; a compilation unit's body and each named generate scope are structural scopes governed by the
+same member rules.
+
+**Contrast.** Not a _process scope_ (an `initial` / `always*` body, which owns procedural variables
+and assignments and runs in the simulation context). Not the _object graph_ (the runtime tree of
+constructed objects); a structural scope is the compile-time class whose constructor builds part of
+that tree.
+
+**Usage notes.** A module and a generate block are both structural scopes; the declaration rules
+inside them are identical. A structural scope holds [members](member.md), child scopes, parameters,
+processes, and generate constructs, but no procedural variables and no general assignment (see
+`architecture/runtime_model.md`).

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -79,7 +79,7 @@ Unlocks the compile-time side of `instantiation/specialization_grouping` and
 - [x] B5 -- Generate (`for` / `if` / `case`) wraps child instances: which generate blocks exist, and
       how many loop iterations, is a construction-time decision, and each block owns its instances
       as part of the object tree.
-- [ ] B6 -- An instance array (`Child c[3]()`) is one named member that expands to a vector of
+- [x] B6 -- An instance array (`Child c[3]()`) is one named member that expands to a vector of
       independent child objects.
 
 Unlocks `instantiation/multiple_instances`, `instantiation/nested_hierarchy`,

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -48,6 +48,42 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       `wait (s == "x")`, real value-change detection) -- at that moment the `IsObservableScalarType`
       shortcut becomes actively wrong and the layering fix has to happen alongside.
 
+- [ ] R3 -- Collapse the runtime's dual hierarchy into a single object tree. Today two parallel
+      trees exist: the C++ object-ownership tree (each emitted scope class owns its children by
+      `unique_ptr` and holds their state and process bodies) and a `RuntimeScope` tree the engine
+      builds during `Bind` by mirroring it (name, kind, parent, children, and the process list the
+      scheduler walks). `Bind` is the mirroring step. This is the dual-representation /
+      separate-hierarchy-models shape `hierarchy_and_generate.md` (Core Invariant 4, Forbidden
+      Shapes) forbids: no consumer may own a topology representation parallel to the object tree. It
+      also leaves the emitted scope classes inconsistent -- unit-root classes extend `Module` and
+      each redeclare `services_`, while generate-scope classes are bare -- and leaves the
+      observed-region (combinational settle) machinery on `Module` only, so a process in a nested
+      instance or generate scope cannot drain (combinational logic inside a child instance or
+      generate block is unsupported). Target shape: one tree. A single runtime base -- the hierarchy
+      node, named after the LRM VPI object model (`scope` base, with `instance` and `gen scope`
+      specializations) -- carries name, kind, parent, child links, the process list, and
+      `services_`; every emitted scope class extends it and stays thin (state plus process bodies);
+      the engine walks the real object tree through the base's interface; `RuntimeScope` dissolves
+      into the base. `services_` then lives once, generate-scope classes stop being bare, and the
+      observed-region machinery composes for every scope. **Why deferred**: the instance-array work
+      does not need it, and it is a runtime-wide change touching the scheduling walk, the bind
+      protocol, process ownership, and the emit shape -- too large to fold into a feature PR.
+      **Trigger**: the next cut (agreed); the bind-time mirroring is the smell that forces it.
+
+- [ ] R4 -- Store an instance array as a fixed-size array, not a growable vector with a side dim
+      list. Today `Child c[2][3]` lowers to a nested `VectorType` (`std::vector`) and the
+      per-dimension element counts ride as a separate `dims` list on the construct statement; the
+      backend peels that list into nested container loops at render time. The extent is a
+      compile-time constant, so the storage should be a fixed-size array (`std::array`) carrying its
+      extent on each type layer -- a new array type symmetric with `VectorType`, with the count
+      living in the type (one container layer per dimension) rather than in a side list. Each
+      pre-sized slot is then assigned directly, with no grow step. This is the same
+      size-belongs-in-the-type, one-layer-per-dimension shape the unpacked-array decision fixes; the
+      flat dim list is the rejected form. **Why deferred**: the vector form is behaviorally correct
+      and the instance-array feature ships on it; the array-type refinement is contained but not
+      needed for correctness. **Trigger**: alongside R3's emit rework, or when a second fixed-extent
+      object-collection consumer appears.
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -42,10 +42,13 @@ struct InstanceMemberId {
 
 // `target_unit` is a cross-unit reference -- the name of the instantiated unit,
 // resolved by name at link time, a distinct domain from the unit-local id
-// kinds.
+// kinds. `array_dims` is empty for a scalar instance and holds one element
+// count per dimension, outermost first, for an instance array (`Child c[2][3]`
+// is `{2, 3}`).
 struct InstanceMemberDecl {
   std::string instance_name;
   std::string target_unit;
+  std::vector<std::uint32_t> array_dims;
 };
 
 struct IfGenerate {

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -76,10 +76,13 @@ struct ConstructOwnedObjectStmt {
 
 // The cross-unit twin of ConstructOwnedObjectStmt: it carries no scope_id
 // because the child is a separate compilation unit, not a nested scope of this
-// one.
+// one. `dims` is empty for a scalar instance and holds one element count per
+// array dimension, outermost first; the backend materializes the nested vector
+// by replication over these counts.
 struct ConstructExternalUnitStmt {
   StructuralVarId target;
   std::string unit_name;
+  std::vector<std::uint32_t> dims;
 };
 
 struct ForInitDecl {

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -182,10 +182,17 @@ class CompilationUnit;
     const CompilationUnit& unit, TypeId type)
     -> std::optional<StructuralScopeId>;
 
-[[nodiscard]] auto IsExternalUnitOwningType(
-    const CompilationUnit& unit, TypeId type) -> bool;
+enum class OwnedChildKind { kModuleInstance, kGenerateScope };
 
-[[nodiscard]] auto GetExternalUnitName(const CompilationUnit& unit, TypeId type)
-    -> std::optional<std::string>;
+// The classification of an owned-child member, read off the leaf object type
+// after stripping any vector layers: an intra-unit object is a generate scope
+// (with its target scope), an external-unit object is a module instance.
+struct OwnedChildLeaf {
+  OwnedChildKind kind = OwnedChildKind::kModuleInstance;
+  std::optional<StructuralScopeId> intra_target;
+};
+
+[[nodiscard]] auto GetOwnedChildLeaf(const CompilationUnit& unit, TypeId type)
+    -> std::optional<OwnedChildLeaf>;
 
 }  // namespace lyra::mir

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -213,6 +213,39 @@ auto RenderProcessKindLiteral(mir::ProcessKind kind) -> std::string {
   throw InternalError("RenderProcessKindLiteral: unknown ProcessKind");
 }
 
+// Binds an owned child by recursing on its member type, mirroring the type
+// walk in RenderTypeAsCpp: a vector layer iterates and indexes, an owning
+// pointer to an object registers one child scope and stops. `access` is the
+// C++ lvalue reaching the storage; `name_expr` is the C++ expression that
+// evaluates to the runtime scope-name string. One walk covers a scalar child,
+// an array of any dimensionality, an instance, and a generate scope.
+auto RenderBindChildWalk(
+    const mir::CompilationUnit& unit, const std::string& access,
+    mir::TypeId type, const std::string& name_expr, const std::string& kind,
+    std::size_t depth, std::size_t indent) -> std::string {
+  if (const auto* vec =
+          std::get_if<mir::VectorType>(&unit.GetType(type).data)) {
+    const std::string idx = "idx" + std::to_string(depth);
+    std::string out;
+    out += Indent(indent) + "for (std::size_t " + idx + " = 0; " + idx + " < " +
+           access + ".size(); ++" + idx + ") {\n";
+    out += RenderBindChildWalk(
+        unit, access + "[" + idx + "]", vec->element,
+        name_expr + " + \"[\" + std::to_string(" + idx + ") + \"]\"", kind,
+        depth + 1, indent + 1);
+    out += Indent(indent) + "}\n";
+    return out;
+  }
+  std::string out;
+  out += Indent(indent) + "{\n";
+  out += Indent(indent + 1) + "auto child = ctx.CreateChildScope(\n";
+  out += Indent(indent + 2) + name_expr + ",\n";
+  out += Indent(indent + 2) + kind + ");\n";
+  out += Indent(indent + 1) + access + "->Bind(child);\n";
+  out += Indent(indent) + "}\n";
+  return out;
+}
+
 auto RenderBind(
     const mir::CompilationUnit& unit, const mir::StructuralScope& s,
     std::size_t indent, bool is_top_level) -> std::string {
@@ -226,46 +259,27 @@ auto RenderBind(
     out += Indent(indent + 2) + RenderProcessKindLiteral(p.kind) + ",\n";
     out += Indent(indent + 2) + RenderProcessMethodName(i) + "());\n";
   }
-  // An owned-object var binds its child under this scope. The scope kind is
-  // read off the owning type: an external-unit instance is a module instance;
-  // an intra-unit owned object is a generate scope.
+  // A member that owns a child binds it under this scope. The owned-child
+  // classification -- scope kind and base name -- is read off the leaf object
+  // type; the bind itself recurses on the member type, so cardinality and
+  // dimensionality need no separate handling. Members that own no child (signal
+  // and value members) yield no leaf and are skipped.
   for (const auto& v : s.structural_vars) {
-    if (const auto ext_unit = mir::GetExternalUnitName(unit, v.type);
-        ext_unit.has_value()) {
-      out += Indent(indent + 1) + "if (" + v.name + ") {\n";
-      out += Indent(indent + 2) + "auto child = ctx.CreateChildScope(\n";
-      out += Indent(indent + 3) + "\"" + v.name + "\",\n";
-      out += Indent(indent + 3) +
-             "lyra::runtime::RuntimeScopeKind::kModuleInstance);\n";
-      out += Indent(indent + 2) + v.name + "->Bind(child);\n";
-      out += Indent(indent + 1) + "}\n";
+    const auto leaf = mir::GetOwnedChildLeaf(unit, v.type);
+    if (!leaf.has_value()) {
       continue;
     }
-    const auto target = mir::GetOwnedObjectTarget(unit, v.type);
-    if (!target.has_value()) {
-      continue;
-    }
-    const auto& child_scope = s.GetChildStructuralScope(*target);
-
-    if (mir::IsVectorOfOwningObjectType(unit, v.type)) {
-      out += Indent(indent + 1) + "for (std::size_t idx = 0; idx < " + v.name +
-             ".size(); ++idx) {\n";
-      out += Indent(indent + 2) + "auto child = ctx.CreateChildScope(\n";
-      out += Indent(indent + 3) + "\"" + child_scope.name +
-             "[\" + std::to_string(idx) + \"]\",\n";
-      out += Indent(indent + 3) +
-             "lyra::runtime::RuntimeScopeKind::kGenerateScope);\n";
-      out += Indent(indent + 2) + v.name + "[idx]->Bind(child);\n";
-      out += Indent(indent + 1) + "}\n";
-    } else {
-      out += Indent(indent + 1) + "if (" + v.name + ") {\n";
-      out += Indent(indent + 2) + "auto child = ctx.CreateChildScope(\n";
-      out += Indent(indent + 3) + "\"" + child_scope.name + "\",\n";
-      out += Indent(indent + 3) +
-             "lyra::runtime::RuntimeScopeKind::kGenerateScope);\n";
-      out += Indent(indent + 2) + v.name + "->Bind(child);\n";
-      out += Indent(indent + 1) + "}\n";
-    }
+    const std::string base_name =
+        leaf->intra_target.has_value()
+            ? s.GetChildStructuralScope(*leaf->intra_target).name
+            : v.name;
+    const std::string kind =
+        leaf->kind == mir::OwnedChildKind::kModuleInstance
+            ? "lyra::runtime::RuntimeScopeKind::kModuleInstance"
+            : "lyra::runtime::RuntimeScopeKind::kGenerateScope";
+    out += RenderBindChildWalk(
+        unit, v.name, v.type, "std::string(\"" + base_name + "\")", kind, 0,
+        indent + 1);
   }
   out += Indent(indent) + "}\n";
   return out;

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -146,12 +146,38 @@ auto RenderConstructOwnedObjectStmt(
       "ConstructOwnedObjectStmt target is not an owning object var");
 }
 
+// Materializes an external-unit member by recursing on its type, mirroring the
+// type walk in RenderTypeAsCpp: each vector layer emits a counted loop that
+// grows the vector and recurses into the new element; the owning-pointer leaf
+// assigns a freshly constructed child. `dims` carries one element count per
+// vector layer, so a scalar (no vector layer) renders just the leaf.
+auto RenderExternalUnitFill(
+    const RenderContext& ctx, const std::string& lvalue, mir::TypeId type,
+    const std::string& unit_name, const std::vector<std::uint32_t>& dims,
+    std::size_t depth, std::size_t indent) -> std::string {
+  if (const auto* vec =
+          std::get_if<mir::VectorType>(&ctx.Unit().GetType(type).data)) {
+    const std::string idx = "i" + std::to_string(depth);
+    std::string out;
+    out += Indent(indent) + "for (std::size_t " + idx + " = 0; " + idx + " < " +
+           std::to_string(dims.at(depth)) + "; ++" + idx + ") {\n";
+    out += Indent(indent + 1) + lvalue + ".emplace_back();\n";
+    out += RenderExternalUnitFill(
+        ctx, lvalue + "[" + idx + "]", vec->element, unit_name, dims, depth + 1,
+        indent + 1);
+    out += Indent(indent) + "}\n";
+    return out;
+  }
+  return Indent(indent) + lvalue + " = std::make_unique<" + unit_name +
+         ">();\n";
+}
+
 auto RenderConstructExternalUnitStmt(
     const RenderContext& ctx, const mir::ConstructExternalUnitStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
   const auto& var = ctx.StructuralScope().GetStructuralVar(s.target);
-  return Indent(indent) + var.name + " = std::make_unique<" + s.unit_name +
-         ">();\n";
+  return RenderExternalUnitFill(
+      ctx, var.name, var.type, s.unit_name, s.dims, 0, indent);
 }
 
 auto RenderForStmtNode(

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -835,10 +835,14 @@ class HirDumper {
     }
     for (std::size_t i = 0; i < s.instance_members.size(); ++i) {
       const auto& im = s.instance_members[i];
+      std::string array_suffix;
+      for (const auto dim : im.array_dims) {
+        array_suffix += std::format("[{}]", dim);
+      }
       Line(
           std::format(
-              "InstanceMember[{}] \"{}\" : {}", i, im.instance_name,
-              im.target_unit));
+              "InstanceMember[{}] \"{}\"{} : {}", i, im.instance_name,
+              array_suffix, im.target_unit));
     }
     Dedent();
     scope_stack_.pop_back();

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -251,7 +251,35 @@ auto LowerInstanceMemberInto(
   scope_state.AddInstanceMember(
       hir::InstanceMemberDecl{
           .instance_name = std::string{inst.name},
-          .target_unit = std::string{inst.getDefinition().name}});
+          .target_unit = std::string{inst.getDefinition().name},
+          .array_dims = {}});
+  return {};
+}
+
+auto LowerInstanceArrayMemberInto(
+    ScopeLoweringState& scope_state,
+    const slang::ast::InstanceArraySymbol& array) -> diag::Result<void> {
+  // Each nested InstanceArray level contributes one dimension; the descent
+  // bottoms out at the per-element instance, which names the target unit. A
+  // zero-element level (`Child c[0:-1]`, LRM 23.3.2) has no element to descend
+  // into or to name the unit from and constructs nothing, so it contributes no
+  // member.
+  std::vector<std::uint32_t> dims;
+  const slang::ast::Symbol* level = &array;
+  while (level->kind == slang::ast::SymbolKind::InstanceArray) {
+    const auto& arr = level->as<slang::ast::InstanceArraySymbol>();
+    if (arr.elements.empty()) {
+      return {};
+    }
+    dims.push_back(static_cast<std::uint32_t>(arr.elements.size()));
+    level = arr.elements.front();
+  }
+  const auto& leaf = level->as<slang::ast::InstanceSymbol>();
+  scope_state.AddInstanceMember(
+      hir::InstanceMemberDecl{
+          .instance_name = std::string{array.name},
+          .target_unit = std::string{leaf.getDefinition().name},
+          .array_dims = std::move(dims)});
   return {};
 }
 
@@ -290,6 +318,9 @@ auto LowerScopeMemberInto(
     case slang::ast::SymbolKind::Instance:
       return LowerInstanceMemberInto(
           scope_state, member.as<slang::ast::InstanceSymbol>());
+    case slang::ast::SymbolKind::InstanceArray:
+      return LowerInstanceArrayMemberInto(
+          scope_state, member.as<slang::ast::InstanceArraySymbol>());
     default:
       return {};
   }

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -164,6 +164,20 @@ auto MakeExternalUnitOwningType(
   return unit_state.AddType(mir::OwningPtrType{.pointee = object_type});
 }
 
+// Builds an external-unit member type: an owning pointer to the unit's object,
+// wrapped in one vector layer per array dimension (`num_dims == 0` is a scalar
+// instance). The backend materializes the nested vector by replication.
+auto MakeExternalUnitMemberType(
+    UnitLoweringState& unit_state, std::string unit_name, std::size_t num_dims)
+    -> mir::TypeId {
+  mir::TypeId type =
+      MakeExternalUnitOwningType(unit_state, std::move(unit_name));
+  for (std::size_t i = 0; i < num_dims; ++i) {
+    type = unit_state.AddType(mir::VectorType{.element = type});
+  }
+  return type;
+}
+
 void InstallInstanceMembers(
     UnitLoweringState& unit_state, StructuralScopeLoweringState& scope_state,
     const hir::StructuralScope& scope,
@@ -176,19 +190,22 @@ void InstallInstanceMembers(
             "declaration in the enclosing scope");
       }
     }
-    const mir::TypeId var_type =
-        MakeExternalUnitOwningType(unit_state, im.target_unit);
+    const mir::TypeId var_type = MakeExternalUnitMemberType(
+        unit_state, im.target_unit, im.array_dims.size());
     const mir::ExprId init =
         SynthesizeDefaultValueExpr(unit_state, ctor_scope_state, var_type);
     const mir::StructuralVarId var_id = scope_state.AddStructuralVar(
         mir::StructuralVarDecl{
             .name = im.instance_name, .type = var_type, .initializer = init});
+
     const mir::StmtId sid = ctor_scope_state.AddStmt(
         mir::Stmt{
             .label = std::nullopt,
             .data =
                 mir::ConstructExternalUnitStmt{
-                    .target = var_id, .unit_name = im.target_unit},
+                    .target = var_id,
+                    .unit_name = im.target_unit,
+                    .dims = im.array_dims},
             .child_procedural_scopes = {}});
     ctor_scope_state.AddRootStmt(sid);
   }

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -868,11 +868,15 @@ class MirDumper {
 
   void DumpConstructExternalUnitStmt(
       StmtId id, const ConstructExternalUnitStmt& s) {
+    std::string dims;
+    for (const auto dim : s.dims) {
+      dims += std::format("[{}]", dim);
+    }
     Line(
         std::format(
             "Stmt[{}] ConstructExternalUnitStmt target=StructuralVar[{}] "
-            "unit=\"{}\"",
-            id.value, s.target.value, s.unit_name));
+            "unit=\"{}\"{}",
+            id.value, s.target.value, s.unit_name, dims));
   }
 
   void DumpStmt(const ProceduralScope& enclosing, StmtId id) {

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -165,23 +165,26 @@ auto GetOwnedObjectTarget(const CompilationUnit& unit, TypeId type)
   return std::nullopt;
 }
 
-auto IsExternalUnitOwningType(const CompilationUnit& unit, TypeId type)
-    -> bool {
-  return GetExternalUnitName(unit, type).has_value();
-}
-
-auto GetExternalUnitName(const CompilationUnit& unit, TypeId type)
-    -> std::optional<std::string> {
-  const auto* owning = std::get_if<OwningPtrType>(&unit.GetType(type).data);
+auto GetOwnedChildLeaf(const CompilationUnit& unit, TypeId type)
+    -> std::optional<OwnedChildLeaf> {
+  const Type* leaf = &unit.GetType(type);
+  while (const auto* vec = std::get_if<VectorType>(&leaf->data)) {
+    leaf = &unit.GetType(vec->element);
+  }
+  const auto* owning = std::get_if<OwningPtrType>(&leaf->data);
   if (owning == nullptr) {
     return std::nullopt;
   }
-  const auto* ext =
-      std::get_if<ExternalUnitObjectType>(&unit.GetType(owning->pointee).data);
-  if (ext == nullptr) {
-    return std::nullopt;
+  const auto& pointee = unit.GetType(owning->pointee).data;
+  if (const auto* obj = std::get_if<ObjectType>(&pointee)) {
+    return OwnedChildLeaf{
+        .kind = OwnedChildKind::kGenerateScope, .intra_target = obj->target};
   }
-  return ext->unit_name;
+  if (std::holds_alternative<ExternalUnitObjectType>(pointee)) {
+    return OwnedChildLeaf{
+        .kind = OwnedChildKind::kModuleInstance, .intra_target = std::nullopt};
+  }
+  return std::nullopt;
 }
 
 }  // namespace lyra::mir

--- a/tests/cases/cpp/hierarchy_instance_array/case.yaml
+++ b/tests/cases/cpp/hierarchy_instance_array/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.hierarchy_instance_array
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      x=2
+      x=2
+      x=2

--- a/tests/cases/cpp/hierarchy_instance_array/main.sv
+++ b/tests/cases/cpp/hierarchy_instance_array/main.sv
@@ -1,0 +1,13 @@
+module Child;
+  int x;
+  initial begin
+    x = 0;
+    #1 x = x + 1;
+    #1 x = x + 1;
+    $display("x=%0d", x);
+  end
+endmodule
+
+module Top;
+  Child c[3]();
+endmodule

--- a/tests/cases/cpp/hierarchy_instance_array_2d/case.yaml
+++ b/tests/cases/cpp/hierarchy_instance_array_2d/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.hierarchy_instance_array_2d
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      x=2
+      x=2
+      x=2
+      x=2
+      x=2
+      x=2

--- a/tests/cases/cpp/hierarchy_instance_array_2d/main.sv
+++ b/tests/cases/cpp/hierarchy_instance_array_2d/main.sv
@@ -1,0 +1,13 @@
+module Child;
+  int x;
+  initial begin
+    x = 0;
+    #1 x = x + 1;
+    #1 x = x + 1;
+    $display("x=%0d", x);
+  end
+endmodule
+
+module Top;
+  Child c[2][3]();
+endmodule


### PR DESCRIPTION
## Summary

This lands instance arrays (`Child c[3]`, including multidimensional `Child c[2][3]`) on the multi-module hierarchy. The work reframes how owned children are emitted: a scope member is a `(name, type)` pair, and the member's type alone carries its storage shape, runtime scope kind, and cardinality. An instance is an owning pointer to an external-unit object; an array is that wrapped in a vector; a generate scope is an owning pointer to an intra-unit object. Construction and binding became a single recursive walk over the member type, mirroring the existing type-to-C++ walk, so a scalar instance, an array of any dimensionality, and a generate scope all flow through one path with no per-form branching. The earlier per-form `if`/`else` in bind and the one-dimensional construction loop are gone, and the multidimensional case is supported rather than diagnosed.

A dead null guard around each child's bind was removed so the emitted C++ reads cleanly against the source: nothing in the source produces a conditional there, and every constructed child is always present.

This PR also writes down the model it relies on. `mir.md` gains the member/type contract (object types in their intra-unit and external-unit forms, the owning-pointer and vector wrappers, and the rule that the type is the classification); `runtime_model.md` gains the split between uniform type-driven storage/binding and the construction statements that legitimately vary; `hierarchy_and_generate.md` records that instance multiplicity and generate are orthogonal axes. The previously empty glossary gets its first entries for these terms, and the Concept Index points at them.

## Deferred

Two architectural follow-ups are recorded in `docs/progress/refactor.md` rather than done here. R3 collapses the runtime's dual hierarchy -- the engine builds a `RuntimeScope` tree that mirrors the C++ object tree during bind, which the architecture contract forbids -- into a single object tree with one base class hiding the scheduling and hierarchy machinery; that change subsumes deduplicating the per-class service handle, giving generate-scope classes a shared base, and making the observed-region machinery compose for nested scopes. R4 switches instance-array storage from a growable vector with a side dimension list to a fixed-size array that carries its extent in the type.

## Testing

`bazel test //...` passes. New end-to-end cases cover a one-dimensional instance array with provably independent per-element state and a two-dimensional array; the existing generate cases exercise the unified bind walk on the intra-unit side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)