### PR TITLE
Add $fscanf over shared scanner core

### DIFF
--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -37,6 +37,36 @@ since the test harness can only probe a variable whose type has an implemented s
       workstreams. Drives the test framework's whole-array `expect.variables` assertion path:
       sequence-valued YAML entries (`a: [10, 20, 30]`) lower to a recursive `UnpackedArrayValueView`
       and round-trip through the same `FormatValue` the runtime uses.
+- [x] DI8 -- `$sscanf` and `$fscanf` over a shared scanner core (LRM 21.3.4.3). Statement-position
+      call (bare or blocking assign-RHS); conversions `%d` / `%h` / `%x` / `%b` / `%o` / `%s` / `%c`
+      / `%%`; 4-state vocabulary (`x` / `z` / `?` / `_`) inside the integer conversions; single-char
+      `x`/`z`/`?` fill for `%d`. Output-arg copy-out uses LRM 13.5 with copy-in initialization so
+      unmatched slots preserve the actual's prior value (LRM 21.3.4.3 only writes successfully
+      matched outputs). `$sscanf` takes a string or string-literal input; `$fscanf` takes an int FD,
+      honours "offending input character is left unread" via the underlying FD's putback buffer, and
+      stamps `$ferror` on invalid / closed descriptors.
+
+## Scan family follow-ups
+
+Tracks remaining LRM 21.3.4.3 corners explicitly rejected by the scan family. Each item is a
+user-observable feature gap (lowering-time `diag::Unsupported` or runtime rejection) that should
+close as the corresponding behaviour lands.
+
+- [ ] Expression-position `$sscanf` / `$fscanf` (e.g. `if ($sscanf(...))`). Rejected at lowering;
+      only statement position (bare call or blocking assign-RHS) supports the LRM 13.5 copy-out
+      desugaring today.
+- [ ] Field width (`%5d`) and assignment suppression (`%*d`) for both scan functions (LRM 21.3.4.3
+      Table 21-7). Rejected at runtime so the matched count never silently desyncs from the user's
+      argument list.
+- [ ] `$sscanf` input source of unpacked-array-of-byte type (LRM 21.3.4.3). String and integral
+      inputs work; the unpacked aggregate variant is rejected at lowering.
+- [ ] `$sscanf` NUL-as-whitespace (LRM 21.3.4.3 sscanf-only). NUL is currently treated as a literal
+      byte rather than a separator.
+- [ ] `$sscanf` "format string or str argument contains x/z bits implies EOF (-1)" (LRM 21.3.4.3
+      sscanf-only). Slang binds str / format expressions to value bytes on this pipeline so the
+      corner cannot be observed in practice yet; revisit once 4-state string surfaces exist.
+- [ ] `$fseek` / `$rewind` cancelling pending `$ungetc` operations (LRM 21.3.5). Independent
+      file-positioning gap; not triggered by the scan family but shares the FD surface.
 
 ## Out of Scope
 
@@ -45,17 +75,6 @@ since the test harness can only probe a variable whose type has an implemented s
 - `$monitor` / `$fmonitor`. Not modelled today; add an entry when a concrete consumer needs it.
 - `$strobe` / `$fstrobe` radix variants. The radix-dispatch mechanism is shared with DI5 but
   strobe's "drain at end of time slot" semantic waits on DI6 (postponed region).
-- `$sscanf` implemented per LRM 21.3.4.3: string and string-literal input, statement-position call
-  (bare or blocking assign-RHS), conversions `%d` / `%h` / `%x` / `%b` / `%o` / `%s` / `%c` / `%%`,
-  4-state vocabulary (`x` / `z` / `?` / `_`) inside the integer conversions, single-char `x`/`z`/`?`
-  fill for `%d`. Output-arg copy-out uses LRM 13.5 with copy-in initialization so unmatched slots
-  preserve the actual's prior value (LRM 21.3.4.3 only writes successfully matched outputs).
-- `$fscanf` deferred. Reuses the same scanner core over a file-source adapter plus FD error
-  stamping; no new scanner work expected.
-- `$sscanf` field width (`%5d`) and assignment suppression (`%*d`) deferred. Detected and rejected
-  at runtime so the matched count never silently desyncs from the user's argument list.
-- `$sscanf` integral and unpacked-array-of-byte input sources (LRM 21.3.4.3) deferred; string and
-  string-literal inputs are accepted today.
 - Other file read tasks (`$fgetc` / `$ungetc` / `$fgets` / `$fread` / `$fseek` / `$rewind` /
   `$ftell` / `$feof` / `$ferror` / `$fflush`) are implemented per LRM 21.3.4..21.3.8.
 - `$sformat` / `$sformatf` / `$swrite` family (formatting into a string variable). Independent

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -104,7 +104,7 @@ using RuntimeCall = std::variant<
     RuntimeFileCloseCall, RuntimeFileGetcCall, RuntimeFileUngetcCall,
     RuntimeFileGetsCall, RuntimeFileReadCall, RuntimeFileSeekCall,
     RuntimeFileRewindCall, RuntimeFileTellCall, RuntimeFileEofCall,
-    RuntimeFileErrorCall, RuntimeFileFlushCall, RuntimeSScanCall>;
+    RuntimeFileErrorCall, RuntimeFileFlushCall, RuntimeScanCall>;
 
 struct RuntimeCallExpr {
   RuntimeCall call;

--- a/include/lyra/mir/runtime_scan.hpp
+++ b/include/lyra/mir/runtime_scan.hpp
@@ -3,18 +3,22 @@
 #include <vector>
 
 #include "lyra/mir/expr_id.hpp"
+#include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::mir {
 
-// LRM 21.3.4.3 $sscanf. `input` and `format` are string-typed expressions.
-// `slots` are ExprIds pointing at the per-output-arg ProceduralVarRef temps
-// that the scanner writes through; the surrounding BlockStmt (built by
-// FinalizeOutputArgCallStmt) copies each temp back to the user's actual
-// lvalue after the call returns. `slots[i]`'s MIR-level type is the
-// underlying procedural var's type, which the backend uses to pick the
-// matching ScanSlot::Make overload.
-struct RuntimeSScanCall {
-  ExprId input{};
+// LRM 21.3.4.3 $sscanf / $fscanf. `source_kind` selects the runtime entry
+// and constrains `source`'s MIR type:
+//   kString -> `source` is string-typed
+//   kFile   -> `source` is int-typed (FD per LRM 21.3.1)
+// `format` is always string-typed. `slots` reference the per-output-arg
+// procedural temps the scanner writes through; the LRM 13.5 copy-out
+// desugaring at the statement boundary copies each temp back to the
+// user's actual lvalue after the call returns. Each slot's MIR-level
+// type drives the backend's ScanSlot::Make overload selection.
+struct RuntimeScanCall {
+  support::ScanSourceKind source_kind{};
+  ExprId source{};
   ExprId format{};
   std::vector<ExprId> slots;
 };

--- a/include/lyra/runtime/scan.hpp
+++ b/include/lyra/runtime/scan.hpp
@@ -8,6 +8,8 @@
 
 namespace lyra::runtime {
 
+class RuntimeServices;
+
 // LRM 21.3.4.3 scanner output slot. Each conversion in the format string
 // writes through one slot; the slot's variant alternative decides which
 // per-spec parser path the runtime takes. The Make factory picks the right
@@ -62,5 +64,18 @@ class ScanSlot {
 auto LyraSScanf(
     const value::String& input, const value::String& format,
     std::initializer_list<ScanSlot> slots) -> value::PackedArray;
+
+// LRM 21.3.4.3 $fscanf entry. Resolves `fd` to the underlying fstream via
+// RuntimeServices::Files(), runs the same scanner core as LyraSScanf over
+// a FileScanSource, and pushes the offending-character pushback back into
+// the fstream's putback buffer before returning so the next $fgetc sees
+// it. Invalid / closed / MCD descriptors stamp EBADF on the FD's $ferror
+// slot and return -1 (LRM "If the input ends before the first matching
+// failure or conversion, EOF (-1) is returned"). The result is wrapped in
+// a 32-bit PackedArray to parallel LyraSScanf.
+auto LyraFScanf(
+    RuntimeServices& services, const value::PackedArray& fd,
+    const value::String& format, std::initializer_list<ScanSlot> slots)
+    -> value::PackedArray;
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/scan_source.hpp
+++ b/include/lyra/runtime/scan_source.hpp
@@ -1,32 +1,72 @@
 #pragma once
 
 #include <cstddef>
+#include <fstream>
 #include <optional>
 #include <string_view>
 
 namespace lyra::runtime {
 
-// Input source for the $sscanf / $fscanf scanner. The scanner only ever
-// peeks one byte ahead, so a single-byte pushback is enough. The interface
-// is deliberately small so the file-source adapter (a follow-up PR for
-// $fscanf) can satisfy the same contract by wrapping LyraFGetc / LyraFUngetc.
+// Abstract byte-source for the $sscanf / $fscanf scanner. The scanner only
+// ever looks one byte ahead, so a single-byte pushback is enough; each
+// concrete source manages its own pushback internally.
 //
 // `Peek` returns the next byte without advancing the cursor, or -1 on EOF.
 // `Consume` returns the next byte and advances. `Unget` pushes one byte back
 // so the next `Peek` / `Consume` returns it again; pushing while a byte is
 // already pending throws InternalError to surface scanner-side misuse.
-class StringScanSource {
+class ScanSource {
+ public:
+  ScanSource() = default;
+  virtual ~ScanSource() = default;
+  ScanSource(const ScanSource&) = delete;
+  auto operator=(const ScanSource&) -> ScanSource& = delete;
+  ScanSource(ScanSource&&) = delete;
+  auto operator=(ScanSource&&) -> ScanSource& = delete;
+
+  virtual auto Peek() -> int = 0;
+  virtual auto Consume() -> int = 0;
+  virtual void Unget(int byte) = 0;
+};
+
+// The pushback slot holds a byte the scanner Peek'd but decided not to
+// Consume (e.g. a literal-mismatch byte per LRM 21.3.4.3 "the offending
+// input character is left unread in the input stream"); the cursor itself
+// never moves past such a byte.
+class StringScanSource : public ScanSource {
  public:
   explicit StringScanSource(std::string_view buf);
 
-  auto Peek() -> int;
-  auto Consume() -> int;
-  void Unget(int byte);
+  auto Peek() -> int override;
+  auto Consume() -> int override;
+  void Unget(int byte) override;
 
  private:
   std::string_view buf_;
   std::size_t cursor_ = 0;
   std::optional<int> pushback_ = std::nullopt;
+};
+
+// The scanner-local pushback (`peeked_`) holds a byte that has been read
+// from the underlying fstream into the scanner but not yet logically
+// consumed. `FlushPushback` must be called when the scanner finishes with
+// the source so any unconsumed byte (typically the "offending character"
+// per LRM 21.3.4.3 "the offending input character is left unread in the
+// input stream") is pushed back into the fstream's putback buffer and
+// becomes observable to the next read on the same FD.
+class FileScanSource : public ScanSource {
+ public:
+  explicit FileScanSource(std::fstream& stream);
+
+  auto Peek() -> int override;
+  auto Consume() -> int override;
+  void Unget(int byte) override;
+
+  void FlushPushback();
+
+ private:
+  std::fstream* stream_;
+  std::optional<int> peeked_ = std::nullopt;
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -111,11 +111,11 @@ struct FileIOSystemSubroutineInfo {
 }
 
 // LRM 21.3.4.3 scan family ($sscanf / $fscanf). The kind axis tracks where
-// the scanned characters come from. Only kString is implemented today; the
-// kFile variant ($fscanf) wires the same scanner core over a file-source
-// adapter in a follow-up.
+// the scanned characters come from; the scanner core is shared and only
+// the source-adapter and runtime entry differ.
 enum class ScanSourceKind : std::uint8_t {
   kString,
+  kFile,
 };
 
 struct ScanSystemSubroutineInfo {
@@ -524,6 +524,15 @@ inline constexpr std::array kSystemSubroutines = {
         .result_conv = ReturnConvention::kInt32,
         .arg_policy = ArgCountPolicy{.min_args = 3, .max_args = 255},
         .semantic = ScanSystemSubroutineInfo{.source = ScanSourceKind::kString},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{33},
+        .name = "$fscanf",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kFunction,
+        .result_conv = ReturnConvention::kInt32,
+        .arg_policy = ArgCountPolicy{.min_args = 3, .max_args = 255},
+        .semantic = ScanSystemSubroutineInfo{.source = ScanSourceKind::kFile},
     },
 };
 

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -411,10 +411,10 @@ auto RenderRuntimeCallExpr(
             return std::format(
                 "lyra::runtime::LyraFFlush(*services_, {})", *fd_or);
           },
-          [&](const mir::RuntimeSScanCall& ss) -> diag::Result<std::string> {
-            auto input_or = RenderExpr(ctx, ctx.Expr(ss.input));
-            if (!input_or) {
-              return std::unexpected(std::move(input_or.error()));
+          [&](const mir::RuntimeScanCall& ss) -> diag::Result<std::string> {
+            auto source_or = RenderExpr(ctx, ctx.Expr(ss.source));
+            if (!source_or) {
+              return std::unexpected(std::move(source_or.error()));
             }
             auto format_or = RenderExpr(ctx, ctx.Expr(ss.format));
             if (!format_or) {
@@ -432,9 +432,18 @@ auto RenderRuntimeCallExpr(
               slot_pieces +=
                   std::format("lyra::runtime::ScanSlot::Make({})", *slot_or);
             }
-            return std::format(
-                "lyra::runtime::LyraSScanf({}, {}, {{{}}})", *input_or,
-                *format_or, slot_pieces);
+            switch (ss.source_kind) {
+              case support::ScanSourceKind::kString:
+                return std::format(
+                    "lyra::runtime::LyraSScanf({}, {}, {{{}}})", *source_or,
+                    *format_or, slot_pieces);
+              case support::ScanSourceKind::kFile:
+                return std::format(
+                    "lyra::runtime::LyraFScanf(*services_, {}, {}, {{{}}})",
+                    *source_or, *format_or, slot_pieces);
+            }
+            throw InternalError(
+                "RuntimeScanCall: unknown ScanSourceKind in render");
           },
       },
       expr.call);

--- a/src/lyra/lowering/hir_to_mir/lower_scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_scan.cpp
@@ -63,53 +63,60 @@ auto LowerScanSystemSubroutineCallStmt(
     const support::ScanSystemSubroutineInfo& info,
     std::optional<hir::ExprId> assign_target, mir::TypeId result_type)
     -> diag::Result<mir::Stmt> {
-  if (info.source != support::ScanSourceKind::kString) {
-    throw InternalError(
-        "LowerScanSystemSubroutineCallStmt: only kString source is wired "
-        "today, but the descriptor has a different source kind");
-  }
   if (call.arguments.size() < 3) {
     throw InternalError(
-        "LowerScanSystemSubroutineCallStmt: $sscanf requires at least input, "
-        "format, and one output argument (slang's ArgCountPolicy should have "
-        "rejected fewer)");
+        "LowerScanSystemSubroutineCallStmt: scan family requires at least "
+        "source, format, and one output argument (slang's ArgCountPolicy "
+        "should have rejected fewer)");
   }
 
   ProceduralScopeLoweringState wrapper;
   ProceduralDepthGuard depth_guard{proc_state};
 
-  // LRM 21.3.4.3 also permits integral and unpacked-array-of-byte input
-  // sources; first-cut runtime only handles `string`. A string-literal
-  // actual reaches lowering as a packed byte-array, so wrap any non-string
-  // packed-array input in an implicit ConversionExpr to string -- the
-  // backend's render-side identity path turns the literal byte form into
-  // the C++ string literal which binds to `value::String` natively. Other
-  // input shapes (e.g. unpacked byte arrays) are rejected here.
-  auto input_or = LowerExpr(
+  auto source_or = LowerExpr(
       unit_state, scope_state, proc_state, wrapper, hir_proc,
       hir_proc.exprs.at(call.arguments[0].value));
-  if (!input_or) return std::unexpected(std::move(input_or.error()));
-  const mir::TypeId input_type = input_or->type;
-  mir::ExprId input_id = wrapper.AddExpr(*std::move(input_or));
-  const mir::TypeKind input_kind = unit_state.GetType(input_type).Kind();
-  if (input_kind != mir::TypeKind::kString) {
-    if (input_kind != mir::TypeKind::kPackedArray) {
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedSubroutineArgument,
-          std::format(
-              "{} input source must be a string or string-literal expression; "
-              "integral and unpacked-array-of-byte sources (LRM 21.3.4.3) are "
-              "not yet supported",
-              std::string{desc.name}),
-          diag::UnsupportedCategory::kFeature);
-    }
-    input_id = wrapper.AddExpr(
-        mir::Expr{
-            .data =
-                mir::ConversionExpr{
-                    .operand = input_id,
-                    .kind = mir::ConversionKind::kImplicit},
-            .type = unit_state.Builtins().string});
+  if (!source_or) return std::unexpected(std::move(source_or.error()));
+  const mir::TypeId source_type = source_or->type;
+  mir::ExprId source_id = wrapper.AddExpr(*std::move(source_or));
+  const mir::TypeKind source_kind = unit_state.GetType(source_type).Kind();
+  switch (info.source) {
+    case support::ScanSourceKind::kString:
+      if (source_kind != mir::TypeKind::kString) {
+        if (source_kind != mir::TypeKind::kPackedArray) {
+          return diag::Unsupported(
+              span, diag::DiagCode::kUnsupportedSubroutineArgument,
+              std::format(
+                  "{} input source of unpacked-array-of-byte type "
+                  "(LRM 21.3.4.3) is not yet supported",
+                  std::string{desc.name}),
+              diag::UnsupportedCategory::kFeature);
+        }
+        // LRM 5.9 + 6.16: string literals and integral expressions both
+        // reach lowering as packed bit-vectors whose bytes are the input
+        // characters; the implicit conversion reinterprets those bits as
+        // a string view.
+        source_id = wrapper.AddExpr(
+            mir::Expr{
+                .data =
+                    mir::ConversionExpr{
+                        .operand = source_id,
+                        .kind = mir::ConversionKind::kImplicit},
+                .type = unit_state.Builtins().string});
+      }
+      break;
+    case support::ScanSourceKind::kFile:
+      if (source_kind != mir::TypeKind::kPackedArray) {
+        // LRM 21.3.1 binds fd as a 32-bit int; slang's type-check on the
+        // $fscanf signature rejects non-integral arguments before HIR.
+        // Any other MIR type reaching here is an invariant violation
+        // upstream, not a missing feature.
+        throw InternalError(
+            "LowerScanSystemSubroutineCallStmt: $fscanf fd must be a "
+            "packed-integer-typed expression (LRM 21.3.1); slang's "
+            "type-check should have rejected non-integral arguments");
+      }
+      break;
   }
 
   auto format_or = LowerExpr(
@@ -126,7 +133,7 @@ auto LowerScanSystemSubroutineCallStmt(
   std::vector<mir::ExprId> slot_refs;
   slot_refs.reserve(call.arguments.size() - 2);
   for (std::size_t i = 2; i < call.arguments.size(); ++i) {
-    const std::string temp_name = "_lyra_sscanf_dest_" + std::to_string(i - 2);
+    const std::string temp_name = "_lyra_scan_dest_" + std::to_string(i - 2);
     auto slot_or = BuildOutputArgSlot(
         unit_state, scope_state, proc_state, wrapper, hir_proc,
         call.arguments[i], temp_name);
@@ -140,8 +147,9 @@ auto LowerScanSystemSubroutineCallStmt(
       .data =
           mir::RuntimeCallExpr{
               .call =
-                  mir::RuntimeSScanCall{
-                      .input = input_id,
+                  mir::RuntimeScanCall{
+                      .source_kind = info.source,
+                      .source = source_id,
                       .format = format_id,
                       .slots = std::move(slot_refs)}},
       .type = unit_state.Builtins().int32};

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -794,7 +794,7 @@ class MirDumper {
                                 ? std::format("Expr[{}]", ff.descriptor->value)
                                 : std::string("all")));
                   },
-                  [&](const RuntimeSScanCall& ss) {
+                  [&](const RuntimeScanCall& ss) {
                     std::string slot_list;
                     for (std::size_t k = 0; k < ss.slots.size(); ++k) {
                       if (k != 0) {
@@ -802,11 +802,16 @@ class MirDumper {
                       }
                       slot_list += std::format("Expr[{}]", ss.slots[k].value);
                     }
+                    const std::string_view kind_text =
+                        ss.source_kind == support::ScanSourceKind::kString
+                            ? "string"
+                            : "file";
                     Line(
                         std::format(
-                            "RuntimeSScanCall input=Expr[{}] format=Expr[{}] "
-                            "slots=[{}]",
-                            ss.input.value, ss.format.value, slot_list));
+                            "RuntimeScanCall source_kind={} source=Expr[{}] "
+                            "format=Expr[{}] slots=[{}]",
+                            kind_text, ss.source.value, ss.format.value,
+                            slot_list));
                   },
               },
               rc->call);

--- a/src/lyra/runtime/scan.cpp
+++ b/src/lyra/runtime/scan.cpp
@@ -1,15 +1,19 @@
 #include "lyra/runtime/scan.hpp"
 
 #include <algorithm>
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <format>
+#include <fstream>
 #include <span>
 #include <string>
 #include <string_view>
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/runtime/file_table.hpp"
+#include "lyra/runtime/runtime_services.hpp"
 #include "lyra/runtime/scan_source.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/string.hpp"
@@ -54,7 +58,7 @@ struct ScannedBit {
   return -1;
 }
 
-void SkipSourceWhitespace(StringScanSource& src) {
+void SkipSourceWhitespace(ScanSource& src) {
   while (true) {
     const int ch = src.Peek();
     if (ch == -1 || !IsAsciiWhitespace(ch)) {
@@ -148,9 +152,8 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
   if (dest == nullptr) {
     throw InternalError(
         std::format(
-            "$sscanf: format spec '%{}' expects an integral output argument, "
-            "but "
-            "the corresponding actual is not integral",
+            "$sscanf/$fscanf: format spec '%{}' expects an integral output "
+            "argument, but the corresponding actual is not integral",
             spec));
   }
   return *dest;
@@ -162,8 +165,8 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
   if (dest == nullptr) {
     throw InternalError(
         std::format(
-            "$sscanf: format spec '%{}' expects a string output argument, but "
-            "the corresponding actual is not a string",
+            "$sscanf/$fscanf: format spec '%{}' expects a string output "
+            "argument, but the corresponding actual is not a string",
             spec));
   }
   return *dest;
@@ -173,8 +176,7 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
 // (with `_` separators) or a single x/X/z/Z/? that fills the entire dest.
 // Mixed (`12x`) stops at the first non-digit -- the `x` is not consumed
 // here, so a following `%h` could still match it.
-[[nodiscard]] auto ScanDecimal(StringScanSource& src, const ScanSlot& slot)
-    -> bool {
+[[nodiscard]] auto ScanDecimal(ScanSource& src, const ScanSlot& slot) -> bool {
   SkipSourceWhitespace(src);
   int ch = src.Peek();
   if (ch == -1) {
@@ -233,8 +235,7 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
 // LRM 21.3.4.3 Table 21-7 `%h` / `%x`. Each character -> one 4-bit nibble.
 // Hex digits 0..9 a..f A..F land as (val=digit, unk=0); xX as
 // (val=1111, unk=1111); zZ? as (val=0000, unk=1111); `_` is a separator.
-[[nodiscard]] auto ScanHex(StringScanSource& src, const ScanSlot& slot)
-    -> bool {
+[[nodiscard]] auto ScanHex(ScanSource& src, const ScanSlot& slot) -> bool {
   SkipSourceWhitespace(src);
   value::PackedArray& dest = RequireIntegralSlot(slot, "h");
   std::vector<ScannedBit> bits;
@@ -279,8 +280,7 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
 
 // LRM 21.3.4.3 Table 21-7 `%o`. 3 bits per octal digit; xX -> (111,111),
 // zZ? -> (000,111); `_` is a separator.
-[[nodiscard]] auto ScanOctal(StringScanSource& src, const ScanSlot& slot)
-    -> bool {
+[[nodiscard]] auto ScanOctal(ScanSource& src, const ScanSlot& slot) -> bool {
   SkipSourceWhitespace(src);
   value::PackedArray& dest = RequireIntegralSlot(slot, "o");
   std::vector<ScannedBit> bits;
@@ -325,8 +325,7 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
 
 // LRM 21.3.4.3 Table 21-7 `%b`. Per-character to one bit: 0/1 -> (val,0),
 // xX -> (1,1), zZ? -> (0,1), `_` separator.
-[[nodiscard]] auto ScanBinary(StringScanSource& src, const ScanSlot& slot)
-    -> bool {
+[[nodiscard]] auto ScanBinary(ScanSource& src, const ScanSlot& slot) -> bool {
   SkipSourceWhitespace(src);
   value::PackedArray& dest = RequireIntegralSlot(slot, "b");
   std::vector<ScannedBit> bits;
@@ -364,8 +363,7 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
 
 // Standard scanf `%s`: skip leading whitespace, then read non-whitespace
 // chars until whitespace or EOF.
-[[nodiscard]] auto ScanString(StringScanSource& src, const ScanSlot& slot)
-    -> bool {
+[[nodiscard]] auto ScanString(ScanSource& src, const ScanSlot& slot) -> bool {
   SkipSourceWhitespace(src);
   std::string buf;
   while (true) {
@@ -385,8 +383,7 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
 }
 
 // Standard scanf `%c`: no whitespace skip, one byte stored as int8.
-[[nodiscard]] auto ScanChar(StringScanSource& src, const ScanSlot& slot)
-    -> bool {
+[[nodiscard]] auto ScanChar(ScanSource& src, const ScanSlot& slot) -> bool {
   const int ch = src.Consume();
   if (ch == -1) {
     return false;
@@ -396,9 +393,9 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
   return true;
 }
 
-[[nodiscard]] auto ScanFromStringSource(
-    StringScanSource& src, std::string_view fmt,
-    std::span<const ScanSlot> slots) -> std::int32_t {
+[[nodiscard]] auto ScanFromSource(
+    ScanSource& src, std::string_view fmt, std::span<const ScanSlot> slots)
+    -> std::int32_t {
   std::int32_t items = 0;
   std::size_t slot_ix = 0;
   bool first_conversion = true;
@@ -431,7 +428,7 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
     ++fmt_ix;
     if (fmt_ix >= fmt.size()) {
       throw InternalError(
-          "$sscanf: format string ended after '%' with no conversion "
+          "$sscanf/$fscanf: format string ended after '%' with no conversion "
           "specifier");
     }
     const char spec = fmt[fmt_ix];
@@ -454,14 +451,14 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
     // miscount items.
     if (spec == '*' || IsDecDigit(static_cast<unsigned char>(spec))) {
       throw InternalError(
-          "$sscanf: field width and assignment suppression are not yet "
-          "supported (LRM 21.3.4.3)");
+          "$sscanf/$fscanf: field width and assignment suppression are not "
+          "yet supported (LRM 21.3.4.3)");
     }
 
     if (slot_ix >= slots.size()) {
       throw InternalError(
-          "$sscanf: format string has more conversion specifiers than "
-          "output arguments");
+          "$sscanf/$fscanf: format string has more conversion specifiers "
+          "than output arguments");
     }
     const ScanSlot slot = slots[slot_ix];
 
@@ -489,7 +486,8 @@ void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
       default:
         throw InternalError(
             std::format(
-                "$sscanf: unsupported conversion specifier '%{}'", spec));
+                "$sscanf/$fscanf: unsupported conversion specifier '%{}'",
+                spec));
     }
 
     if (!ok) {
@@ -514,9 +512,33 @@ auto LyraSScanf(
     const value::String& input, const value::String& format,
     std::initializer_list<ScanSlot> slots) -> value::PackedArray {
   StringScanSource src(input.View());
-  const std::int32_t items = ScanFromStringSource(
+  const std::int32_t items = ScanFromSource(
       src, format.View(),
       std::span<const ScanSlot>{slots.begin(), slots.size()});
+  return value::PackedArray::Int(items);
+}
+
+auto LyraFScanf(
+    RuntimeServices& services, const value::PackedArray& fd_pa,
+    const value::String& format, std::initializer_list<ScanSlot> slots)
+    -> value::PackedArray {
+  const auto fd = static_cast<std::int32_t>(fd_pa.ToInt64());
+  std::fstream* stream = services.Files().Resolve(fd);
+  if (stream == nullptr) {
+    // MCD descriptors, closed FDs, and unmapped FDs all land here. LRM
+    // 21.3.4.3 specifies EOF (-1) when the input ends before the first
+    // matching failure or conversion; we treat "no readable stream" as
+    // that condition and additionally stamp $ferror so an SV caller
+    // querying it sees EBADF.
+    services.Files().SetError(
+        fd, EBADF, "$fscanf: not an open file descriptor");
+    return value::PackedArray::Int(-1);
+  }
+  FileScanSource src(*stream);
+  const std::int32_t items = ScanFromSource(
+      src, format.View(),
+      std::span<const ScanSlot>{slots.begin(), slots.size()});
+  src.FlushPushback();
   return value::PackedArray::Int(items);
 }
 

--- a/src/lyra/runtime/scan_source.cpp
+++ b/src/lyra/runtime/scan_source.cpp
@@ -43,4 +43,54 @@ void StringScanSource::Unget(int byte) {
   pushback_ = byte;
 }
 
+FileScanSource::FileScanSource(std::fstream& stream) : stream_(&stream) {
+}
+
+auto FileScanSource::Peek() -> int {
+  if (peeked_.has_value()) {
+    return *peeked_;
+  }
+  const int byte = stream_->get();
+  if (byte == std::char_traits<char>::eof()) {
+    return -1;
+  }
+  peeked_ = byte;
+  return byte;
+}
+
+auto FileScanSource::Consume() -> int {
+  if (peeked_.has_value()) {
+    const int byte = *peeked_;
+    peeked_.reset();
+    return byte;
+  }
+  const int byte = stream_->get();
+  return byte == std::char_traits<char>::eof() ? -1 : byte;
+}
+
+void FileScanSource::Unget(int byte) {
+  if (byte == -1) {
+    return;
+  }
+  if (peeked_.has_value()) {
+    throw InternalError(
+        "FileScanSource::Unget: pushback slot already holds a byte; "
+        "scanner attempted to Unget twice without an intervening Consume");
+  }
+  peeked_ = byte;
+}
+
+void FileScanSource::FlushPushback() {
+  if (!peeked_.has_value()) {
+    return;
+  }
+  // Clear eofbit / failbit so putback succeeds even when Peek hit EOF
+  // earlier in the scan. LRM 21.3.4.3 "the offending input character is
+  // left unread in the input stream" -- pushing back here makes the
+  // unconsumed peeked byte visible to the next $fgetc on this FD.
+  stream_->clear();
+  stream_->putback(static_cast<char>(*peeked_));
+  peeked_.reset();
+}
+
 }  // namespace lyra::runtime

--- a/tests/cases/cpp/fscanf_basics/case.yaml
+++ b/tests/cases/cpp/fscanf_basics/case.yaml
@@ -1,0 +1,17 @@
+id: cpp.fscanf_basics
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    code: 3
+    a: 42
+    b: 0xdead
+    s: "hello"
+  files:
+    scan_input.txt: |
+      42 dead hello

--- a/tests/cases/cpp/fscanf_basics/main.sv
+++ b/tests/cases/cpp/fscanf_basics/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  // LRM 21.3.4.3: $fscanf shares Table 21-7 with $sscanf. This case proves
+  // the file source actually works end-to-end across the conversion-spec
+  // set; the scanner core itself is already exercised by sscanf cases.
+  // The test is self-contained: write input via $fopen("w")+$fwrite, then
+  // read it back via $fopen("r")+$fscanf (same pattern as fread_int).
+  int    fd, code;
+  int    a;
+  logic [15:0] b;
+  string s;
+  initial begin
+    fd = $fopen("scan_input.txt", "w");
+    $fdisplay(fd, "42 dead hello");
+    $fclose(fd);
+
+    fd = $fopen("scan_input.txt", "r");
+    code = $fscanf(fd, "%d %h %s", a, b, s);
+    $fclose(fd);
+  end
+endmodule

--- a/tests/cases/cpp/fscanf_invalid_fd/case.yaml
+++ b/tests/cases/cpp/fscanf_invalid_fd/case.yaml
@@ -1,0 +1,17 @@
+id: cpp.fscanf_invalid_fd
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    code: -1
+    a: 99
+    errno_val: 9                                # EBADF on Linux (LRM 21.3.7)
+    err_msg: "$fscanf: not an open file descriptor"
+    err_msg_len: 36
+  files:
+    dummy.txt: ""

--- a/tests/cases/cpp/fscanf_invalid_fd/main.sv
+++ b/tests/cases/cpp/fscanf_invalid_fd/main.sv
@@ -1,0 +1,25 @@
+module Top;
+  // LRM 21.3.4.3 + 21.3.7: $fscanf on a closed FD returns -1 (no input
+  // available) and stamps $ferror with EBADF + a message naming "$fscanf",
+  // so a follow-up call surfaces the error condition.
+  int    fd;
+  int    code;
+  int    a;
+  int    errno_val;
+  string err_msg;
+  int    err_msg_len;
+  initial begin
+    // Open then close so the FD's pool slot exists (the SetError surface
+    // only stamps for allocated FD-pool indexes; a never-opened FD has
+    // no slot to stamp into and silently no-ops).
+    fd = $fopen("dummy.txt", "w");
+    $fclose(fd);
+
+    // Now use the same FD: Resolve returns nullptr (slot is empty after
+    // close) so $fscanf hits the invalid-FD short-circuit.
+    a = 99;                            // copy-in preserves this on -1 return
+    code = $fscanf(fd, "%d", a);
+    errno_val = $ferror(fd, err_msg);
+    err_msg_len = err_msg.len();
+  end
+endmodule

--- a/tests/cases/cpp/fscanf_stream_semantics/case.yaml
+++ b/tests/cases/cpp/fscanf_stream_semantics/case.yaml
@@ -1,0 +1,43 @@
+id: cpp.fscanf_stream_semantics
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    # Empty file: EOF before any conversion.
+    code_empty: -1
+    a_empty: 99
+    # Partial match: 12 matches, abc fails second %d.
+    code_partial: 1
+    a_partial: 12
+    b_partial: 99
+    # Literal mismatch: only first %d matches; 'x' must be readable after.
+    code_lit: 1
+    a_lit: 12
+    b_lit: 99
+    leftover_byte: 120  # 'x' = 0x78 = 120 in $feof+$fgetc check below
+    # Drain: code matched, then we peek past last digit so $feof is true.
+    code_drain: 1
+    a_drain: 777
+    peek_past_eof: -1
+    eof_after_drain: 1
+    # Read 'A', ungetc it, scan %c -- should re-read 'A' (0x41 = 65).
+    first_byte: 65
+    ret_ungetc: 0
+    code_ungetc: 1
+    c_ungetc: 65
+    # Assign-RHS: matched count, both vars assigned.
+    code_rhs: 2
+    a_rhs: 5
+    b_rhs: 9
+  files:
+    empty.txt: ""
+    partial.txt: "12 abc"
+    lit.txt: "12x34"
+    drain.txt: "777"
+    ung.txt: "AB"
+    rhs.txt: "5 9"

--- a/tests/cases/cpp/fscanf_stream_semantics/main.sv
+++ b/tests/cases/cpp/fscanf_stream_semantics/main.sv
@@ -1,0 +1,97 @@
+module Top;
+  // LRM 21.3.4.3 source-driven semantics for $fscanf. The format/conversion
+  // semantics themselves are covered by the sscanf tests; this case targets
+  // the file-source-specific surface:
+  //   - EOF before any conversion -> -1
+  //   - partial match returns the matched count
+  //   - literal mismatch: scan stops, offending byte is left unread
+  //     (verified by a subsequent $fgetc returning that exact byte)
+  //   - $feof reflects EOF after a scan that drained the file
+  //   - $ungetc'd byte is visible to $fscanf (proves scanner uses the
+  //     underlying stream rather than bypassing the FD's putback buffer)
+  //   - assign-RHS form
+  int fd;
+
+  int code_empty, a_empty;
+
+  int code_partial, a_partial, b_partial;
+
+  int code_lit, a_lit, b_lit;
+  int leftover_byte;
+
+  int code_drain;
+  int a_drain;
+  int eof_after_drain;
+  int peek_past_eof;
+
+  int code_ungetc, ret_ungetc;
+  int first_byte, c_ungetc;
+
+  int code_rhs, a_rhs, b_rhs;
+
+  initial begin
+    // Empty file: EOF before any conversion -> -1.
+    fd = $fopen("empty.txt", "w");
+    $fclose(fd);
+    a_empty = 99;
+    fd = $fopen("empty.txt", "r");
+    code_empty = $fscanf(fd, "%d", a_empty);
+    $fclose(fd);
+
+    // Partial match: second %d sees 'a' (not digit), mismatch -> return 1.
+    b_partial = 99;
+    fd = $fopen("partial.txt", "w");
+    $fwrite(fd, "12 abc");
+    $fclose(fd);
+    fd = $fopen("partial.txt", "r");
+    code_partial = $fscanf(fd, "%d %d", a_partial, b_partial);
+    $fclose(fd);
+
+    // Literal mismatch: ':' in format does not match 'x' in input. After
+    // the scan stops, the next $fgetc must observe 'x' (LRM 21.3.4.3
+    // "the offending input character is left unread in the input stream").
+    b_lit = 99;
+    fd = $fopen("lit.txt", "w");
+    $fwrite(fd, "12x34");
+    $fclose(fd);
+    fd = $fopen("lit.txt", "r");
+    code_lit = $fscanf(fd, "%d:%d", a_lit, b_lit);
+    leftover_byte = $fgetc(fd);
+    $fclose(fd);
+
+    // Drain to EOF: after scanning everything, $feof returns nonzero.
+    fd = $fopen("drain.txt", "w");
+    $fwrite(fd, "777");
+    $fclose(fd);
+    fd = $fopen("drain.txt", "r");
+    code_drain = $fscanf(fd, "%d", a_drain);
+    // One extra peek to actually push the stream past the last byte; $fscanf
+    // by itself stops at the (logical) end without setting fstream's eof
+    // bit unless the scanner needed to look past the final digit.
+    peek_past_eof = $fgetc(fd);
+    eof_after_drain = $feof(fd);
+    $fclose(fd);
+
+    // Read one byte, $ungetc it, then $fscanf %c. The scanner must observe
+    // the putback'd byte rather than skip past it -- proves $fscanf goes
+    // through the underlying FD's input stream (including its putback
+    // buffer) rather than bypassing $ungetc state. Putback of the
+    // most-recently-read byte is the portable form per std::istream.
+    fd = $fopen("ung.txt", "w");
+    $fwrite(fd, "AB");
+    $fclose(fd);
+    fd = $fopen("ung.txt", "r");
+    first_byte = $fgetc(fd);                       // 'A' = 0x41 = 65
+    ret_ungetc = $ungetc(first_byte, fd);          // push 'A' back
+    code_ungetc = $fscanf(fd, "%c", c_ungetc);     // expect c == 'A'
+    $fclose(fd);
+
+    // Assign-RHS form: code = $fscanf(...).
+    fd = $fopen("rhs.txt", "w");
+    $fwrite(fd, "5 9");
+    $fclose(fd);
+    fd = $fopen("rhs.txt", "r");
+    code_rhs = $fscanf(fd, "%d %d", a_rhs, b_rhs);
+    $fclose(fd);
+  end
+endmodule

--- a/tests/cases/errors/fscanf_field_width/case.yaml
+++ b/tests/cases/errors/fscanf_field_width/case.yaml
@@ -1,0 +1,12 @@
+id: errors.fscanf_field_width
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 1                  # `lyra run` catches the runtime error and exits 1
+  stderr:
+    contains:
+      - "field width and assignment suppression are not yet supported"

--- a/tests/cases/errors/fscanf_field_width/main.sv
+++ b/tests/cases/errors/fscanf_field_width/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  int fd;
+  int code;
+  int x;
+  initial begin
+    fd = $fopen("input.txt", "w");
+    $fwrite(fd, "12345");
+    $fclose(fd);
+    fd = $fopen("input.txt", "r");
+    code = $fscanf(fd, "%5d", x);
+    $fclose(fd);
+  end
+endmodule

--- a/tests/cases/errors/fscanf_in_expression/case.yaml
+++ b/tests/cases/errors/fscanf_in_expression/case.yaml
@@ -1,0 +1,16 @@
+id: errors.fscanf_in_expression
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "writes through output arguments"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/fscanf_in_expression/main.sv
+++ b/tests/cases/errors/fscanf_in_expression/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  int fd;
+  int a;
+  initial begin
+    fd = $fopen("input.txt", "r");
+    if ($fscanf(fd, "%d", a)) begin
+      a = a + 1;
+    end
+    $fclose(fd);
+  end
+endmodule

--- a/tests/cases/errors/fscanf_suppress/case.yaml
+++ b/tests/cases/errors/fscanf_suppress/case.yaml
@@ -1,0 +1,12 @@
+id: errors.fscanf_suppress
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "field width and assignment suppression are not yet supported"

--- a/tests/cases/errors/fscanf_suppress/main.sv
+++ b/tests/cases/errors/fscanf_suppress/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  int fd;
+  int code;
+  int a, b;
+  initial begin
+    fd = $fopen("input.txt", "w");
+    $fwrite(fd, "1 2 3");
+    $fclose(fd);
+    fd = $fopen("input.txt", "r");
+    code = $fscanf(fd, "%d %*d %d", a, b);
+    $fclose(fd);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements `$fscanf` (LRM 21.3.4.3) by extending the `$sscanf` scanner over a file-source adapter. The scanner core is shared: `ScanSource` is promoted to an abstract base with `StringScanSource` and a new `FileScanSource` over `std::fstream`; the MIR `RuntimeSScanCall` becomes a unified `RuntimeScanCall` with a `source_kind` axis so the backend picks `LyraSScanf` or `LyraFScanf` from one visitor arm. Output-arg copy-out keeps using the LRM 13.5 helpers built for `$sscanf`.

## Design

`FileScanSource` keeps a scanner-local 1-byte pushback (`peeked_`) for the `Peek`/`Consume`/`Unget` contract and exposes `FlushPushback` so `LyraFScanf` can putback any unconsumed byte before returning - this is what makes LRM 21.3.4.3 "the offending input character is left unread" observable to a subsequent `$fgetc` on the same FD. Invalid / closed / MCD descriptors short-circuit to `-1` with an EBADF stamp on the FD's `$ferror` slot. The `kFile` lowering branch is `InternalError` rather than `diag::Unsupported` because slang's `$fscanf` signature already rejects non-int `fd` arguments at frontend - any non-PackedArray reaching lowering would be an upstream invariant violation, not a missing feature.

`docs/progress/display.md` gains a new "Scan family follow-ups" subsection that promotes every remaining LRM 21.3.4.3 corner into a tracking checkbox: expression-position scan, field width / suppress, `$sscanf` unpacked-byte-array input, `$sscanf` NUL-as-whitespace, `$sscanf` x/z-in-format, and the cross-cutting `$fseek` / `$rewind` cancel-`$ungetc` gap.

## Testing

Three new `cpp_run` cases cover the file-source surface: `fscanf_basics` (end-to-end `%d %h %s` round-trip), `fscanf_stream_semantics` (EOF -> -1, partial match, literal mismatch + offending-char-left-unread, `$feof` reflection, `$ungetc` round-trip, assign-RHS), and `fscanf_invalid_fd` (closed FD -> EBADF via `$ferror`). Three negative cases mirror the sscanf rejections (`field_width`, `suppress`, `in_expression`).