### PR TITLE
Add foreach over fixed packed and unpacked arrays

### DIFF
--- a/docs/decisions/foreach-lowering.md
+++ b/docs/decisions/foreach-lowering.md
@@ -1,0 +1,125 @@
+# `foreach` lowering shape
+
+Date: 2026-06-02 Status: accepted
+
+## Context
+
+LRM 12.7.3 defines `foreach` uniformly over "any type of packed or unpacked array" with arbitrary
+dimensionality, optional skipped dims, and optional trailing-dim omission. LRM 12.8 adds two
+semantics that are critical to the lowering choice:
+
+- `continue` jumps to the end of the loop for the **current set of loop variable values**, i.e.
+  advances the iteration to the next combined `(i, j, k, ...)` tuple.
+- `break` jumps out of the **entire foreach**, not just the innermost dimension.
+
+The pre-reset archived implementation desugared `foreach (arr[i, j])` to N nested for-loops
+(`for (int i = ...) for (int j = ...) BODY`) and let plain SV `break` lower to plain C++ `break`.
+That shape is structurally close to the SV source but is subtly wrong on LRM 12.8: a `break` inside
+the body terminates only the inner `for`, after which the outer `for` continues to its next
+iteration. None of the archived test cases happened to expose the gap, but it is a real LRM
+correctness defect.
+
+This is also a forcing function on a broader design choice: how do we express "non-local exit out of
+N enclosing scopes" in the emitted C++? C++ has no first-class labeled break (the construct in Java
+/ Rust / Kotlin and the natural primitive in LLVM IR / WebAssembly).
+
+## Decision
+
+1. **Every `foreach` lowers to a single flattened `hir::ForStmt`.** The iteration space is the
+   Cartesian product of the non-skipped dimensions. A synthetic procedural variable
+   `__lyra_foreach_n` is declared in the loop's `ForInitDecl` and counts from `0` to `total - 1`,
+   where `total` is the product of the non-skipped dim counts. The loop body begins by computing
+   each loop variable's per-iteration value by decomposing the counter, then continues with the
+   lowered user body. There is exactly one for-loop level in the lowered HIR regardless of
+   dimensionality.
+
+2. **Per-dim decompose formula.** Each non-skipped loop variable is computed as
+
+   ```
+   var = base + sign * ((__n / inner_product) % count)
+   ```
+
+   where `inner_product` is the product of all non-skipped dim counts to its right (1 for the
+   innermost), `count = abs(range.right - range.left) + 1`, and `(base, sign) = (range.left, +1)`
+   for an ascending range, `(range.left, -1)` for a descending range. Slang's `LoopDim` order is
+   already outer->inner per LRM cardinality, so no reordering is needed.
+
+3. **Plain SV `break` / `continue` / `return` lower to plain HIR `BreakStmt` / `ContinueStmt` /
+   `ReturnStmt`, with no foreach-aware rewriting.** Because the lowered HIR has exactly one
+   for-loop, plain `break` exits the entire foreach (matching LRM 12.8), plain `continue` advances
+   `__n` to the next tuple (matching LRM 12.8 "current set of loop variable values"), and `return`
+   exits the enclosing subroutine without any wrapper interception. This is the design's payoff: no
+   special primitive, no flag, no rewrite, no lint exception.
+
+_Rejected alternatives:_
+
+- **Nested for-loops + plain `break`** (archived shape): LRM-incorrect for break -- terminates only
+  the innermost dim.
+
+- **Nested for-loops + flag-based break propagation**: each outer loop tail checks a synthetic
+  `__break` flag and re-breaks if set; the body's `break` becomes `__break = 1; break;`. Correct but
+  adds N+1 places per dim that must stay coherent across edits, and pays a per-iteration branch cost
+  at every level. Mechanism does not collapse with dim count.
+
+- **Nested for-loops + `goto label;` after the outermost closing brace**: matches structure 1:1 and
+  is the natural emit for "break to labeled block" in C++. Rejected because a single `goto`
+  exception in emitted code undermines a clean project-wide rule against `goto` and invites future
+  misuse (anywhere else where someone wants a "controlled" jump). The cost of the rule violation
+  outweighs the structural fidelity gain.
+
+- **Nested for-loops wrapped in an IIFE; SV `break` -> C++ `return`**: cleanly handles `break` by
+  returning from the lambda, but corrupts SV `return` from inside the foreach body -- the C++
+  `return` exits the lambda, not the enclosing SV function. Modeling the difference would require
+  separating "break-style return" from "function-style return" at every emit site, defeating the
+  simplicity.
+
+- **`std::views::cartesian_product` (C++23 ranges)**: conceptually correct -- analogous to Python's
+  `itertools.product`. Rejected because `cartesian_product` is a libc++ 19+ (Sept 2024) / libstdc++
+  13+ stdlib feature; requiring it pushes the toolchain floor for the emitted C++ beyond what the
+  project will commit to (see `docs/progress/refactor.md` R5 for the toolchain-baseline workstream).
+  The same _semantic_ -- flattening the product space -- is captured by the manual flat-index
+  decompose without any stdlib dependency.
+
+## Consequences
+
+- The lowering is **uniform across dimensionality**. 1D / 2D / N-D / mixed packed-unpacked /
+  ascending / descending / skipped-dim cases share one code path. The dispatch over packed vs
+  unpacked element access happens entirely in the body's existing `ElementSelectExpr` lowering,
+  which the foreach itself never touches.
+
+- Per-iteration cost is **N-1 divisions and N modulos on `__n`** for an N-dim foreach. All divisors
+  are compile-time constants for fixed-bound arrays (always the case in C9's scope), so modern C++
+  compilers fold them to multiply-by-magic-number sequences (~2-3 instructions per dim). The emitted
+  C++ for-loop has no flag overhead and no lambda boundary, so the only excess vs nested for-loops
+  is the index arithmetic. `foreach` is not a typical simulator hot path.
+
+- Skipped dimensions (`arr[i, , k]`) and trailing-dim omission (`int arr[2][3]; foreach (arr[i])`)
+  fall out of the same model: skipped dims contribute neither a loop variable nor a factor to the
+  product, and the body simply never references them. No special-case code paths required.
+
+- The lowering reaches the body via the usual recursive `LowerStatement`, so `break` inside a `for`
+  / `while` / `do-while` nested in the foreach body still targets the nested loop (standard C
+  nesting). The "exit the entire foreach" semantic is structural -- there is only one for-loop --
+  not contextual.
+
+- Dynamic-array / queue / associative-array element types are rejected with
+  `kUnsupportedStatementForm` until `datatypes/general` brings procedural support for those types.
+  When that lands, the same flat-index model extends naturally: the iteration count becomes a
+  runtime query (`arr.size()`) instead of a compile-time literal, and the decompose formula stays
+  identical.
+
+- The slang `IteratorSymbol` for a foreach loop variable derives from `VariableSymbol` but carries
+  its own `SymbolKind::Iterator`. The AST -> HIR name resolution at
+  `src/lyra/lowering/ast_to_hir/expression/lower.cpp` was extended to accept `Iterator` alongside
+  `Variable` and `FormalArgument`; all three route through
+  `ProcessLoweringState::LookupProceduralVar`.
+
+## Cross-references
+
+- LRM 12.7.3 (foreach syntax, dim cardinality, implicit begin-end, read-only loop vars).
+- LRM 12.8 (break exits whole foreach; continue advances current loop var values).
+- Conceptual analogue: Python `itertools.product`, C++23 `std::views::cartesian_product`,
+  WebAssembly `br N`, LLVM IR labeled blocks. None used directly; all express the same
+  flatten-the-product-space idea.
+- `docs/progress/refactor.md` R5 -- emit-CPP smoke suite and toolchain baseline (the reason
+  `cartesian_product` was rejected).

--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -8,11 +8,13 @@ order.
 
 ## Actionable
 
-C9 and C10 (`foreach`) are the only remaining open items; both wait on `datatypes/unpacked`.
+C9 is done. C10's skipped-dimension and trailing-dim subset rides on C9 because the lowering shape
+is uniform across dim counts; the dynamic-array, queue, and associative-array subset stays open and
+remains blocked on `datatypes/general`.
 
-| Item    | Status                                                                             |
-| ------- | ---------------------------------------------------------------------------------- |
-| C9, C10 | Blocked on `datatypes/unpacked` (procedural unpacked array vars + element access). |
+| Item | Status                                                              |
+| ---- | ------------------------------------------------------------------- |
+| C10  | Blocked on `datatypes/general` (dynamic array, queue, associative). |
 
 ## Sub-Steps
 
@@ -39,10 +41,17 @@ C9 and C10 (`foreach`) are the only remaining open items; both wait on `datatype
 - [x] C8 -- `forever`. Loops until `break` or `$finish` exits. Includes `$finish` termination,
       `break` termination, `continue`, single-statement body, nested forever with inner `break`, and
       `if`-guarded forever.
-- [ ] C9 -- `foreach` over fixed unpacked 1D arrays. **Depends on** `datatypes/unpacked` (procedural
-      unpacked array vars + element access).
-- [ ] C10 -- `foreach` multi-dim, skipped dimensions, dynamic-array, queue. **Depends on** C9 plus
-      `datatypes/general` (dynamic array, queue) and the `.size()` runtime query.
+- [x] C9 -- `foreach` over fixed packed and unpacked arrays of any dimensionality. Single lowering
+      handles 1D, 2D, N-D, mixed packed/unpacked nests, ascending and descending ranges, non-zero
+      and negative bases. The lowered HIR is a single flattened `ForStmt` whose body computes per-
+      iteration loop-variable values from a synthetic flat counter, so plain SV `break` / `continue`
+      / `return` map 1:1 to LRM 12.8 semantics without any rewrite. See
+      `../decisions/foreach-lowering.md`.
+- [ ] C10 -- `foreach` skipped dimensions, dynamic-array, queue. Skipped dims and trailing dim
+      omission (`int arr[2][3]; foreach (arr[i])`) ship with C9 because they fall out of the same
+      uniform lowering. Dynamic-array, queue, and associative-array foreach are rejected with
+      `kUnsupportedStatementForm` until `datatypes/general` brings procedural support for those
+      types and the `.size()` runtime query.
 - [x] C11 -- `casez` / `casex` (LRM 12.5.1 do-not-care forms). Bidirectional wildcard compare:
       `casez` treats Z as don't-care on either operand; `casex` treats Z or X as don't-care on
       either operand. Result is deterministic, distinct from the asymmetric `==?` operator (LRM

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -84,6 +84,53 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       needed for correctness. **Trigger**: alongside R3's emit rework, or when a second fixed-extent
       object-collection consumer appears.
 
+- [ ] R5 -- Resurrect a smoke-suite tier so the emit-cpp path gets CI gating. Today
+      `tests/suites.yaml` carries only the monolithic `architecture_reset` suite, and the
+      `cpp_tests` target is tagged `requires-host-cxx` while CI's `Test` job filters that tag out --
+      so every PR merges without any automated check that the emitted C++ still compiles and runs. A
+      toolchain-compat regression (runtime header or emitted code reaching for a stdlib feature
+      absent from the floor toolchain), or an emit-vs-runtime ABI break, is only caught when a
+      contributor runs `cpp_tests` locally. Target shape: a `cpp_run_smoke` suite defined in
+      `tests/suites.yaml`, populated by `cpp_run_smoke`-tagged cases -- one representative per
+      distinct emit codegen family (integral / unpacked array / process / `$display` / loop / etc.),
+      5-10 cases total, target wall-clock under 30 seconds. A dedicated CI lane runs that suite via
+      the existing `cpp_tests` target with whatever toolchain `ubuntu-latest` ships -- no explicit
+      LLVM install. The lane is the anchor for a (yet-to-be-written)
+      `docs/decisions/emit-cpp-baseline.md` that pins the supported toolchain floor. The shape
+      mirrors the pre-reset `aot_smoke` suite (see `archived/tests/suites.yaml`); the only
+      adaptation is regex-on-path becoming tag-on-case, since cpp is currently the only backend and
+      tags travel with cases more naturally than external catalogs do. **Why deferred**: this is its
+      own focused PR (decision doc + suite entry + tag application + CI lane); folding it into a
+      feature PR makes both diffs noisy. Full `cpp_tests` in CI remains separately gated on the LLVM
+      JIT backend replacing per-case clang invocations (expected 5-10x faster), at which point a
+      sibling `jit_smoke` / `jit_full` pair can be added on the same pattern. **Trigger**:
+      standalone -- can be picked up at any time. The longer it waits, the larger the window for an
+      unspotted toolchain-compat regression to land in emit or runtime headers.
+
+- [ ] R6 -- Consolidate the "synthesize an expression of canonical type X" helpers that lowerings
+      reach for whenever they need a temporary, sentinel, or computed bound. The HIR -> MIR side
+      already exposes `UnitLoweringState::MakeInt32LiteralExpr(int64)` and has ~8 consumers across
+      `lower_expr.cpp`, `lower_stmt.cpp`, and `lower_deferred_check.cpp`. The AST -> HIR side has no
+      equivalent public helper: `expression/lower.cpp` carries an anonymous-namespace
+      `MakeIntegerLiteralExpr` that takes a slang `IntegerLiteral&` (no raw-int64 entry point) and
+      an anonymous `MakeRefExpr` for procedural / structural / loop var refs. New consumers that
+      can't see those private helpers (most recently `statement/foreach.cpp`) reroll their own
+      copies inline -- `MakeInt32Constant` + `MakeInt32LiteralExpr` + `MakeProcVarRefExpr` are all
+      sitting in foreach's anonymous namespace today, and similar copies will accumulate at every
+      future desugar site that needs a synthetic counter, sentinel, or width-constant. Target shape:
+      a small set of public helpers on each layer's `UnitLoweringState` mirroring the MIR-side
+      `MakeInt32LiteralExpr` -- minimally a raw-int64 int32 literal expr builder, a bool literal
+      expr builder, and ref-expr builders for the three var families -- with the `IntegralConstant`
+      construction (the masked-word layout) factored into a single function rather than copy-pasted
+      at every site. **Why deferred**: foreach's local helpers are correct, scoped to one TU, and
+      shipping them inline kept the immediate PR focused. The duplication only becomes painful when
+      the next consumer arrives. **Trigger**: when a second AST -> HIR lowering needs a raw-int64
+      int32 literal expr (or a synthetic ProceduralVarRef expr), at which point the per-consumer
+      copy is the smell that forces extraction. Related to R1, which is the further move of
+      promoting the canonical `Builtins` table and these helpers from the lowering-state scope to
+      the IR (`mir::CompilationUnit` and the AST -> HIR analogue) -- R6 is the prerequisite cleanup;
+      R1 is the architectural promotion.
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -434,6 +434,23 @@ class ProcessLoweringState {
     return id;
   }
 
+  // Procedural variable with no slang symbol behind it. Name resolution
+  // keys on slang symbol pointers, so a synthetic var cannot shadow a user
+  // identifier; the `__lyra_` prefix is convention so the var is visually
+  // distinct in dumps and emit. Lifetime is automatic because no SV
+  // declaration governs it.
+  auto AddSyntheticProceduralVar(std::string_view name, hir::TypeId type)
+      -> hir::ProceduralVarId {
+    const hir::ProceduralVarId id{
+        static_cast<std::uint32_t>(body_.procedural_vars.size())};
+    body_.procedural_vars.push_back(
+        hir::ProceduralVarDecl{
+            .name = std::string{name},
+            .type = type,
+            .lifetime = hir::VariableLifetime::kAutomatic});
+    return id;
+  }
+
   [[nodiscard]] auto LookupProceduralVar(const slang::ast::VariableSymbol& var)
       const -> std::optional<hir::ProceduralVarId> {
     const auto it = procedural_var_bindings_.find(&var);

--- a/include/lyra/lowering/ast_to_hir/statement/foreach.hpp
+++ b/include/lyra/lowering/ast_to_hir/statement/foreach.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <slang/ast/statements/LoopStatements.h>
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_span.hpp"
+#include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/ast_to_hir/facts.hpp"
+#include "lyra/lowering/ast_to_hir/state.hpp"
+
+namespace lyra::lowering::ast_to_hir {
+
+// Flattens the Cartesian product of the non-skipped dims into a single
+// `hir::ForStmt` driven by a synthetic counter. The flat shape is what makes
+// plain `BreakStmt` / `ContinueStmt` / `ReturnStmt` in the body satisfy
+// LRM 12.8 directly -- see `docs/decisions/foreach-lowering.md`.
+auto LowerForeachLoopStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, ScopeStack& stack,
+    const slang::ast::ForeachLoopStatement& fs, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt>;
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -247,11 +247,12 @@ auto LowerNamedValueProc(
         sym.as<slang::ast::ParameterSymbol>(), *type_id, span);
   }
 
-  // A subroutine formal (LRM 13.5) is a VariableSymbol subclass with its own
-  // SymbolKind; it resolves through the same procedural-var binding as a body
-  // local.
+  // Subroutine formals (LRM 13.5) and foreach iterators (LRM 12.7.3) are
+  // VariableSymbol subclasses and route through the same procedural-var
+  // binding as ordinary body locals.
   if (sym.kind != slang::ast::SymbolKind::Variable &&
-      sym.kind != slang::ast::SymbolKind::FormalArgument) {
+      sym.kind != slang::ast::SymbolKind::FormalArgument &&
+      sym.kind != slang::ast::SymbolKind::Iterator) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedNonVariableNamedReference,
         "reference to non-variable declaration is not supported",

--- a/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
@@ -1,0 +1,309 @@
+#include "lyra/lowering/ast_to_hir/statement/foreach.hpp"
+
+#include <cstdint>
+#include <expected>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <slang/ast/Expression.h>
+#include <slang/ast/Statement.h>
+#include <slang/ast/symbols/VariableSymbols.h>
+#include <slang/ast/types/AllTypes.h>
+#include <slang/ast/types/Type.h>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/kind.hpp"
+#include "lyra/hir/binary_op.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/integral_constant.hpp"
+#include "lyra/hir/primary.hpp"
+#include "lyra/hir/stmt.hpp"
+#include "lyra/hir/value_ref.hpp"
+#include "lyra/lowering/ast_to_hir/expression/lower.hpp"
+#include "lyra/lowering/ast_to_hir/statement/lower.hpp"
+
+namespace lyra::lowering::ast_to_hir {
+
+namespace {
+
+constexpr std::string_view kFlatCounterName = "__lyra_foreach_n";
+
+auto MakeInt32Constant(std::int64_t value) -> hir::IntegralConstant {
+  return hir::IntegralConstant{
+      .value_words = {static_cast<std::uint64_t>(value) & 0xFFFFFFFFULL},
+      .state_words = {},
+      .width = 32,
+      .signedness = hir::Signedness::kSigned,
+      .state_kind = hir::IntegralStateKind::kTwoState,
+  };
+}
+
+auto MakeInt32LiteralExpr(
+    std::int64_t value, hir::TypeId int32_type, diag::SourceSpan span)
+    -> hir::Expr {
+  return hir::Expr{
+      .type = int32_type,
+      .data =
+          hir::PrimaryExpr{
+              .data =
+                  hir::IntegerLiteral{
+                      .value = MakeInt32Constant(value),
+                      .base = hir::IntegerLiteralBase::kDecimal,
+                      .declared_unsized = false,
+                  }},
+      .span = span,
+  };
+}
+
+auto MakeProcVarRefExpr(
+    hir::ProceduralVarId var, hir::TypeId type, diag::SourceSpan span)
+    -> hir::Expr {
+  return hir::Expr{
+      .type = type,
+      .data = hir::PrimaryExpr{.data = hir::ProceduralVarRef{.var = var}},
+      .span = span,
+  };
+}
+
+// Ordered outer-to-inner per LRM 12.7.3 cardinality. `inner_product` is the
+// product of `count` for every later (more-inner) entry; the innermost has
+// inner_product = 1.
+struct DimMeta {
+  const slang::ast::IteratorSymbol* loop_var;
+  std::int64_t lo;
+  std::int64_t count;
+  std::int64_t inner_product;
+  bool ascending;
+};
+
+// lo +/- ((counter / inner_product) % count)
+auto BuildDecomposeExpr(
+    ProcessLoweringState& proc_state, hir::TypeId int32_type,
+    diag::SourceSpan span, hir::ProceduralVarId counter_var, const DimMeta& dim)
+    -> hir::ExprId {
+  const auto counter_ref_id =
+      proc_state.AddExpr(MakeProcVarRefExpr(counter_var, int32_type, span));
+
+  hir::ExprId divided_id = counter_ref_id;
+  if (dim.inner_product != 1) {
+    const auto inner_id = proc_state.AddExpr(
+        MakeInt32LiteralExpr(dim.inner_product, int32_type, span));
+    divided_id = proc_state.AddExpr(
+        hir::Expr{
+            .type = int32_type,
+            .data =
+                hir::BinaryExpr{
+                    .op = hir::BinaryOp::kDiv,
+                    .lhs = counter_ref_id,
+                    .rhs = inner_id},
+            .span = span});
+  }
+
+  const auto count_id =
+      proc_state.AddExpr(MakeInt32LiteralExpr(dim.count, int32_type, span));
+  const auto offset_id = proc_state.AddExpr(
+      hir::Expr{
+          .type = int32_type,
+          .data =
+              hir::BinaryExpr{
+                  .op = hir::BinaryOp::kMod,
+                  .lhs = divided_id,
+                  .rhs = count_id},
+          .span = span});
+
+  const auto lo_id =
+      proc_state.AddExpr(MakeInt32LiteralExpr(dim.lo, int32_type, span));
+  return proc_state.AddExpr(
+      hir::Expr{
+          .type = int32_type,
+          .data =
+              hir::BinaryExpr{
+                  .op =
+                      dim.ascending ? hir::BinaryOp::kAdd : hir::BinaryOp::kSub,
+                  .lhs = lo_id,
+                  .rhs = offset_id},
+          .span = span});
+}
+
+auto RejectUnsupportedArrayType(
+    const slang::ast::Type& canonical, diag::SourceSpan span)
+    -> diag::Result<void> {
+  using slang::ast::SymbolKind;
+  switch (canonical.kind) {
+    case SymbolKind::DynamicArrayType:
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedStatementForm,
+          "foreach over dynamic array is not yet supported",
+          diag::UnsupportedCategory::kFeature);
+    case SymbolKind::QueueType:
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedStatementForm,
+          "foreach over queue is not yet supported",
+          diag::UnsupportedCategory::kFeature);
+    case SymbolKind::AssociativeArrayType:
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedStatementForm,
+          "foreach over associative array is not yet supported",
+          diag::UnsupportedCategory::kFeature);
+    case SymbolKind::StringType:
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedStatementForm,
+          "foreach over string is not yet supported",
+          diag::UnsupportedCategory::kFeature);
+    default:
+      return {};
+  }
+}
+
+}  // namespace
+
+auto LowerForeachLoopStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, ScopeStack& stack,
+    const slang::ast::ForeachLoopStatement& fs, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  const auto& canonical = fs.arrayRef.type->getCanonicalType();
+  if (auto check = RejectUnsupportedArrayType(canonical, span); !check) {
+    return std::unexpected(std::move(check.error()));
+  }
+
+  const hir::TypeId int32_type = scope_state.UnitState().Int32TypeId();
+
+  std::vector<DimMeta> dims;
+  dims.reserve(fs.loopDims.size());
+  for (const auto& dim : fs.loopDims) {
+    if (dim.loopVar == nullptr) {
+      continue;
+    }
+    if (!dim.range.has_value()) {
+      throw InternalError(
+          "LowerForeachLoopStmt: non-skipped dim has no constant range; the "
+          "type-level rejection above should have caught dynamic / queue / "
+          "associative element types");
+    }
+    const auto& range = *dim.range;
+    const bool ascending = range.left <= range.right;
+    const std::int64_t count = ascending ? (range.right - range.left + 1)
+                                         : (range.left - range.right + 1);
+    dims.push_back(
+        DimMeta{
+            .loop_var = dim.loopVar,
+            .lo = range.left,
+            .count = count,
+            .inner_product = 1,
+            .ascending = ascending});
+  }
+
+  // All-dims-skipped: arrayRef still needs evaluation for side effects, body
+  // runs once.
+  if (dims.empty()) {
+    auto array_or = LowerProcExpr(
+        unit_facts, scope_state.UnitState(), proc_state, stack, fs.arrayRef);
+    if (!array_or) return std::unexpected(std::move(array_or.error()));
+    const auto array_eval_id = proc_state.AddExpr(*std::move(array_or));
+    const auto array_eval_stmt = proc_state.AddStmt(
+        hir::Stmt{
+            .label = std::nullopt,
+            .data = hir::ExprStmt{.expr = array_eval_id},
+            .span = span});
+    auto body_or =
+        LowerStatement(unit_facts, proc_state, scope_state, stack, fs.body);
+    if (!body_or) return std::unexpected(std::move(body_or.error()));
+    const auto body_stmt_id = proc_state.AddStmt(*std::move(body_or));
+    return hir::Stmt{
+        .label = std::nullopt,
+        .data = hir::BlockStmt{.statements = {array_eval_stmt, body_stmt_id}},
+        .span = span};
+  }
+
+  std::int64_t inner = 1;
+  for (auto it = dims.rbegin(); it != dims.rend(); ++it) {
+    it->inner_product = inner;
+    inner *= it->count;
+  }
+  const std::int64_t total = inner;
+
+  // HIR -> MIR maps procedural vars in HIR-id order driven by VarDecl
+  // encounter order. The counter's ForInitDecl is the first VarDecl in the
+  // lowered body, so the counter must claim the lowest id; loop variables
+  // follow in the same outer-to-inner order their VarDeclStmts appear in.
+  const hir::ProceduralVarId counter_var =
+      proc_state.AddSyntheticProceduralVar(kFlatCounterName, int32_type);
+  for (const auto& dim : dims) {
+    proc_state.AddProceduralVar(*dim.loop_var, int32_type);
+  }
+
+  const auto zero_id =
+      proc_state.AddExpr(MakeInt32LiteralExpr(0, int32_type, span));
+  std::vector<hir::ForInit> init;
+  init.emplace_back(hir::ForInitDecl{.var = counter_var, .init = zero_id});
+
+  const auto cond_counter_ref_id =
+      proc_state.AddExpr(MakeProcVarRefExpr(counter_var, int32_type, span));
+  const auto total_id =
+      proc_state.AddExpr(MakeInt32LiteralExpr(total, int32_type, span));
+  const auto cond_id = proc_state.AddExpr(
+      hir::Expr{
+          .type = int32_type,
+          .data =
+              hir::BinaryExpr{
+                  .op = hir::BinaryOp::kLessThan,
+                  .lhs = cond_counter_ref_id,
+                  .rhs = total_id},
+          .span = span});
+
+  const auto step_counter_ref_id =
+      proc_state.AddExpr(MakeProcVarRefExpr(counter_var, int32_type, span));
+  const auto step_id = proc_state.AddExpr(
+      hir::Expr{
+          .type = int32_type,
+          .data =
+              hir::IncDecExpr{
+                  .op = hir::IncDecOp::kPreInc, .target = step_counter_ref_id},
+          .span = span});
+
+  std::vector<hir::StmtId> inner_stmts;
+  inner_stmts.reserve(dims.size() + 1);
+  for (const auto& dim : dims) {
+    const auto local_id = *proc_state.LookupProceduralVar(*dim.loop_var);
+    const auto init_expr_id =
+        BuildDecomposeExpr(proc_state, int32_type, span, counter_var, dim);
+    inner_stmts.push_back(proc_state.AddStmt(
+        hir::Stmt{
+            .label = std::nullopt,
+            .data = hir::VarDeclStmt{.var = local_id, .init = init_expr_id},
+            .span = span}));
+  }
+  auto body_or =
+      LowerStatement(unit_facts, proc_state, scope_state, stack, fs.body);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+  inner_stmts.push_back(proc_state.AddStmt(*std::move(body_or)));
+
+  const auto inner_block_id = proc_state.AddStmt(
+      hir::Stmt{
+          .label = std::nullopt,
+          .data = hir::BlockStmt{.statements = std::move(inner_stmts)},
+          .span = span});
+
+  const auto for_stmt_id = proc_state.AddStmt(
+      hir::Stmt{
+          .label = std::nullopt,
+          .data =
+              hir::ForStmt{
+                  .init = std::move(init),
+                  .condition = cond_id,
+                  .step = {step_id},
+                  .body = inner_block_id},
+          .span = span});
+
+  // LRM 12.7.3 implicit begin-end around the foreach.
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data = hir::BlockStmt{.statements = {for_stmt_id}},
+      .span = span};
+}
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -24,6 +24,7 @@
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
+#include "lyra/lowering/ast_to_hir/statement/foreach.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -772,6 +773,11 @@ auto LowerStatement(
       return LowerForeverLoopStmt(
           unit_facts, proc_state, scope_state, stack,
           stmt.as<slang::ast::ForeverLoopStatement>(), span);
+
+    case slang::ast::StatementKind::ForeachLoop:
+      return LowerForeachLoopStmt(
+          unit_facts, proc_state, scope_state, stack,
+          stmt.as<slang::ast::ForeachLoopStatement>(), span);
 
     case slang::ast::StatementKind::Break:
       return LowerBreakStmt(span);

--- a/tests/cases/cpp/foreach_1d/case.yaml
+++ b/tests/cases/cpp/foreach_1d/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.foreach_1d
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sum_all: 15
+    sum_break: 6
+    last_break: 2
+    sum_continue: 12

--- a/tests/cases/cpp/foreach_1d/main.sv
+++ b/tests/cases/cpp/foreach_1d/main.sv
@@ -1,0 +1,26 @@
+module Top;
+  int arr [5] = '{1, 2, 3, 4, 5};
+  int sum_all;
+  int sum_break;
+  int sum_continue;
+  int last_break;
+
+  initial begin
+    sum_all = 0;
+    sum_break = 0;
+    sum_continue = 0;
+    last_break = -1;
+    foreach (arr[i]) begin
+      sum_all = sum_all + arr[i];
+    end
+    foreach (arr[i]) begin
+      if (arr[i] >= 4) break;
+      sum_break = sum_break + arr[i];
+      last_break = i;
+    end
+    foreach (arr[i]) begin
+      if (arr[i] == 3) continue;
+      sum_continue = sum_continue + arr[i];
+    end
+  end
+endmodule

--- a/tests/cases/cpp/foreach_1d_descending_packed/case.yaml
+++ b/tests/cases/cpp/foreach_1d_descending_packed/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.foreach_1d_descending_packed
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    first_idx: 3
+    last_idx: 0
+    sum_idx: 6
+    set_count: 2

--- a/tests/cases/cpp/foreach_1d_descending_packed/main.sv
+++ b/tests/cases/cpp/foreach_1d_descending_packed/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  bit [3:0] data = 4'b1010;
+  int first_idx;
+  int last_idx;
+  int sum_idx;
+  int set_count;
+
+  initial begin
+    first_idx = -1;
+    last_idx = -1;
+    sum_idx = 0;
+    set_count = 0;
+    foreach (data[i]) begin
+      if (first_idx == -1) first_idx = i;
+      last_idx = i;
+      sum_idx = sum_idx + i;
+      if (data[i]) set_count = set_count + 1;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/foreach_1d_negative_base/case.yaml
+++ b/tests/cases/cpp/foreach_1d_negative_base/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.foreach_1d_negative_base
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    first_idx: -2
+    last_idx: 1
+    sum_idx: -2
+    sum_val: 100

--- a/tests/cases/cpp/foreach_1d_negative_base/main.sv
+++ b/tests/cases/cpp/foreach_1d_negative_base/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  int arr [-2:1] = '{10, 20, 30, 40};
+  int sum_idx;
+  int sum_val;
+  int first_idx;
+  int last_idx;
+
+  initial begin
+    sum_idx = 0;
+    sum_val = 0;
+    first_idx = 99;
+    last_idx = 99;
+    foreach (arr[i]) begin
+      if (first_idx == 99) first_idx = i;
+      last_idx = i;
+      sum_idx = sum_idx + i;
+      sum_val = sum_val + arr[i];
+    end
+  end
+endmodule

--- a/tests/cases/cpp/foreach_2d_break_exits_all/case.yaml
+++ b/tests/cases/cpp/foreach_2d_break_exits_all/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.foreach_2d_break_exits_all
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sum: 10
+    last_i: 0
+    last_j: 0

--- a/tests/cases/cpp/foreach_2d_break_exits_all/main.sv
+++ b/tests/cases/cpp/foreach_2d_break_exits_all/main.sv
@@ -1,0 +1,22 @@
+module Top;
+  int arr [2][3] = '{'{10, 20, 30}, '{40, 50, 60}};
+  int sum;
+  int last_i;
+  int last_j;
+
+  initial begin
+    sum = 0;
+    last_i = -1;
+    last_j = -1;
+    // LRM 12.8: break exits the ENTIRE foreach, not just the innermost dim.
+    // Iteration order: (0,0)=10 (sum=10), (0,1)=20 -> break immediately.
+    // If break only exited the inner loop, iteration would continue at (1,0),
+    // sum would reach 160, last_i/last_j would advance to (1,2).
+    foreach (arr[i, j]) begin
+      if (arr[i][j] == 20) break;
+      sum = sum + arr[i][j];
+      last_i = i;
+      last_j = j;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/foreach_2d_iteration_order/case.yaml
+++ b/tests/cases/cpp/foreach_2d_iteration_order/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.foreach_2d_iteration_order
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    first_i: 0
+    first_j: 0
+    last_i: 1
+    last_j: 2
+    order: 102101112

--- a/tests/cases/cpp/foreach_2d_iteration_order/main.sv
+++ b/tests/cases/cpp/foreach_2d_iteration_order/main.sv
@@ -1,0 +1,25 @@
+module Top;
+  int arr [2][3];
+  int order;
+  int first_i, first_j;
+  int last_i, last_j;
+
+  initial begin
+    order = 0;
+    first_i = -1;
+    first_j = -1;
+    last_i = -1;
+    last_j = -1;
+    foreach (arr[i, j]) begin
+      if (first_i == -1) begin
+        first_i = i;
+        first_j = j;
+      end
+      last_i = i;
+      last_j = j;
+      // Build sequence number: at each iteration multiply by 100, then add i*10+j.
+      // Order over (i,j): (0,0)(0,1)(0,2)(1,0)(1,1)(1,2)
+      order = order * 100 + i * 10 + j;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/foreach_2d_mixed_directions/case.yaml
+++ b/tests/cases/cpp/foreach_2d_mixed_directions/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.foreach_2d_mixed_directions
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    first_i: 0
+    first_j: 5
+    last_i: 2
+    last_j: 3

--- a/tests/cases/cpp/foreach_2d_mixed_directions/main.sv
+++ b/tests/cases/cpp/foreach_2d_mixed_directions/main.sv
@@ -1,0 +1,22 @@
+module Top;
+  int arr [0:2][5:3];
+  int first_i, first_j;
+  int last_i, last_j;
+
+  initial begin
+    first_i = -1;
+    first_j = -1;
+    last_i = -1;
+    last_j = -1;
+    // Outer ascending [0:2], inner descending [5:3]. First iteration is
+    // (i=0, j=5), last iteration is (i=2, j=3).
+    foreach (arr[i, j]) begin
+      if (first_i == -1) begin
+        first_i = i;
+        first_j = j;
+      end
+      last_i = i;
+      last_j = j;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/foreach_2d_packed_inner/case.yaml
+++ b/tests/cases/cpp/foreach_2d_packed_inner/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.foreach_2d_packed_inner
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    count: 24
+    first_i: 0
+    first_j: 7
+    last_i: 2
+    last_j: 0

--- a/tests/cases/cpp/foreach_2d_packed_inner/main.sv
+++ b/tests/cases/cpp/foreach_2d_packed_inner/main.sv
@@ -1,0 +1,25 @@
+module Top;
+  // Outer: fixed unpacked of size 3. Inner: packed bit-vector [7:0] (descending).
+  bit [7:0] arr [3];
+  int count;
+  int first_i, first_j;
+  int last_i, last_j;
+
+  initial begin
+    count = 0;
+    first_i = -1;
+    first_j = -1;
+    last_i = -1;
+    last_j = -1;
+    // Total = 3 * 8 = 24 iterations. j iterates 7 -> 0 (descending packed).
+    foreach (arr[i, j]) begin
+      if (first_i == -1) begin
+        first_i = i;
+        first_j = j;
+      end
+      last_i = i;
+      last_j = j;
+      count = count + 1;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/foreach_3d/case.yaml
+++ b/tests/cases/cpp/foreach_3d/case.yaml
@@ -1,0 +1,17 @@
+id: cpp.foreach_3d
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    count: 24
+    first_i: 0
+    first_j: 0
+    first_k: 0
+    last_i: 1
+    last_j: 2
+    last_k: 3

--- a/tests/cases/cpp/foreach_3d/main.sv
+++ b/tests/cases/cpp/foreach_3d/main.sv
@@ -1,0 +1,27 @@
+module Top;
+  int arr [2][3][4];
+  int count;
+  int first_i, first_j, first_k;
+  int last_i, last_j, last_k;
+
+  initial begin
+    count = 0;
+    first_i = -1;
+    first_j = -1;
+    first_k = -1;
+    last_i = -1;
+    last_j = -1;
+    last_k = -1;
+    foreach (arr[i, j, k]) begin
+      if (first_i == -1) begin
+        first_i = i;
+        first_j = j;
+        first_k = k;
+      end
+      last_i = i;
+      last_j = j;
+      last_k = k;
+      count = count + 1;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/foreach_3d_skip_middle/case.yaml
+++ b/tests/cases/cpp/foreach_3d_skip_middle/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.foreach_3d_skip_middle
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    count: 8
+    first_i: 0
+    first_k: 0
+    last_i: 1
+    last_k: 3

--- a/tests/cases/cpp/foreach_3d_skip_middle/main.sv
+++ b/tests/cases/cpp/foreach_3d_skip_middle/main.sv
@@ -1,0 +1,24 @@
+module Top;
+  int arr [2][3][4];
+  int count;
+  int first_i, first_k;
+  int last_i, last_k;
+
+  initial begin
+    count = 0;
+    first_i = -1;
+    first_k = -1;
+    last_i = -1;
+    last_k = -1;
+    // Skip the middle dimension: iterate only outer (2) x inner (4) = 8 times.
+    foreach (arr[i, , k]) begin
+      if (first_i == -1) begin
+        first_i = i;
+        first_k = k;
+      end
+      last_i = i;
+      last_k = k;
+      count = count + 1;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/foreach_3d_skip_trailing/case.yaml
+++ b/tests/cases/cpp/foreach_3d_skip_trailing/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.foreach_3d_skip_trailing
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    count: 2
+    sum_i: 1
+    first_i: 0
+    last_i: 1

--- a/tests/cases/cpp/foreach_3d_skip_trailing/main.sv
+++ b/tests/cases/cpp/foreach_3d_skip_trailing/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  int arr [2][3][4];
+  int count;
+  int sum_i;
+  int first_i, last_i;
+
+  initial begin
+    count = 0;
+    sum_i = 0;
+    first_i = -1;
+    last_i = -1;
+    // Only iterate the outermost dimension: 2 iterations.
+    foreach (arr[i]) begin
+      if (first_i == -1) first_i = i;
+      last_i = i;
+      sum_i = sum_i + i;
+      count = count + 1;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/foreach_break_inside_outer_loop/case.yaml
+++ b/tests/cases/cpp/foreach_break_inside_outer_loop/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.foreach_break_inside_outer_loop
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    outer_iters: 3
+    total_sum: 30

--- a/tests/cases/cpp/foreach_break_inside_outer_loop/main.sv
+++ b/tests/cases/cpp/foreach_break_inside_outer_loop/main.sv
@@ -1,0 +1,19 @@
+module Top;
+  int arr [3] = '{10, 20, 30};
+  int outer_iters;
+  int total_sum;
+
+  initial begin
+    outer_iters = 0;
+    total_sum = 0;
+    // foreach is nested inside a while. break in foreach exits only the
+    // foreach -- the while continues to its next iteration.
+    while (outer_iters < 3) begin
+      foreach (arr[i]) begin
+        if (arr[i] == 20) break;
+        total_sum = total_sum + arr[i];
+      end
+      outer_iters = outer_iters + 1;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/foreach_return_exits_function/case.yaml
+++ b/tests/cases/cpp/foreach_return_exits_function/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.foreach_return_exits_function
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    result: 3
+    trailing_marker: 0

--- a/tests/cases/cpp/foreach_return_exits_function/main.sv
+++ b/tests/cases/cpp/foreach_return_exits_function/main.sv
@@ -1,0 +1,21 @@
+module Top;
+  int arr [4] = '{1, 2, 3, 4};
+  int result;
+  int trailing_marker;
+
+  function int find_first_ge (int threshold);
+    foreach (arr[i]) begin
+      if (arr[i] >= threshold) return arr[i];
+    end
+    return -1;
+  endfunction
+
+  initial begin
+    trailing_marker = 0;
+    // First match for >= 3 is arr[2] = 3. return inside foreach must exit the
+    // enclosing function, not just the foreach. trailing_marker stays 0 only
+    // because no fall-through happened; with an IIFE-style wrapper, return
+    // would have exited the lambda and trailing_marker would have flipped.
+    result = find_first_ge(3);
+  end
+endmodule

--- a/tests/cases/errors/foreach_string_rejected/case.yaml
+++ b/tests/cases/errors/foreach_string_rejected/case.yaml
@@ -1,0 +1,16 @@
+id: errors.foreach_string_rejected
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "main.sv:"
+      - "foreach over string is not yet supported"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/foreach_string_rejected/main.sv
+++ b/tests/cases/errors/foreach_string_rejected/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  string s = "hello";
+  initial begin
+    foreach (s[i]) begin
+      s[i] = "x";
+    end
+  end
+endmodule


### PR DESCRIPTION
## Summary

Restores `foreach` over fixed packed and unpacked arrays (C9) with a lowering shape that is uniform across dimensionality. The lowered HIR is a single flattened `ForStmt` whose body computes per-iteration loop-variable values from a synthetic flat counter; this is what makes plain SV `break` / `continue` / `return` map to LRM 12.8 semantics directly, with no goto, no flag, no IIFE wrapper, and no rewrite.

Coverage: 1D / 2D / N-D, ascending and descending ranges, non-zero and negative bases, mixed packed/unpacked nests, skipped dimensions (`arr[i, , k]`), trailing-dim omission (`int arr[2][3]; foreach (arr[i])`), and the interactions with outer SV loops and enclosing functions. Dynamic-array, queue, associative-array, and string element types are rejected with `kUnsupportedStatementForm` until `datatypes/general` lands.

## Design

`docs/decisions/foreach-lowering.md` records the flat-index decompose decision and the explicitly-rejected alternatives (nested for + plain break, nested for + flag, nested for + goto, IIFE + return, `std::views::cartesian_product`). The archived nested-for shape was subtly wrong on LRM 12.8 -- the `foreach_2d_break_exits_all` test is the correctness anchor: with the design choice in this PR it observes `sum=10, last_i=0, last_j=0`; the archived shape would have produced `sum=160, last_i=1, last_j=2`.

Two ancillary changes ride this PR:

- `ProcessLoweringState::AddSyntheticProceduralVar(name, type)` overload for compiler-generated temps with no slang symbol behind them (the flat counter is the first consumer).
- `SymbolKind::Iterator` joins `Variable` and `FormalArgument` in the AST -> HIR name-resolution accept-list so loop variables resolve through the existing procedural-var binding.

Two follow-up items got recorded against this work:

- `docs/progress/refactor.md` R5 -- emit-cpp smoke suite and CI lane, anchoring an emit toolchain baseline. Discovered while ruling out `cartesian_product`.
- `docs/progress/refactor.md` R6 -- consolidate the synthetic-int32-literal helpers that foreach reinvented locally. R6 is the prerequisite cleanup for R1's broader Builtins promotion.

## Testing

13 new test cases under `tests/cases/cpp/foreach_*` and `tests/cases/errors/foreach_*`, covering the matrix above. `bazel test //...` passes locally.