### PR TITLE
Add $sformat / $sformatf / $swrite over shared print engine

### DIFF
--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -45,6 +45,14 @@ since the test harness can only probe a variable whose type has an implemented s
       matched outputs). `$sscanf` takes a string or string-literal input; `$fscanf` takes an int FD,
       honours "offending input character is left unread" via the underlying FD's putback buffer, and
       stamps `$ferror` on invalid / closed descriptors.
+- [x] DI9 -- `$sformat` / `$sformatf` / `$swrite` family (LRM 21.3.3). Six subroutines: `$swrite` /
+      `$swriteb` / `$swriteh` / `$swriteo` with auto-format (per-task default radix per LRM
+      21.2.1.1), `$sformat` with explicit literal format, and `$sformatf` returning the formatted
+      string as a function result. Reuses the print engine's literal-format walker and the
+      `value::FormatValue` runtime so the conversion-spec set is identical to `$display` / `$write`
+      (`%d` / `%h` / `%x` / `%b` / `%o` / `%s` / `%c` / `%%` / `%p` / `%0p` / `%f` / `%e` / `%g`
+      plus width / precision / zero-pad / left-align modifiers). No newline appended (LRM 21.3.3 is
+      a string-producer; newline policy belongs to the display / write family).
 
 ## Scan family follow-ups
 
@@ -68,6 +76,20 @@ close as the corresponding behaviour lands.
 - [ ] `$fseek` / `$rewind` cancelling pending `$ungetc` operations (LRM 21.3.5). Independent
       file-positioning gap; not triggered by the scan family but shares the FD surface.
 
+## String-format family follow-ups
+
+Tracks remaining LRM 21.3.3 corners explicitly rejected by `$sformat` / `$sformatf` / `$swrite*`.
+Each item is a user-observable feature gap (lowering-time `diag::Unsupported`) that should close as
+the corresponding behaviour lands.
+
+- [ ] Runtime-evaluated format string for `$sformat` / `$sformatf` (LRM 21.3.3 NOTE: format string
+      may be a non-constant expression). Non-literal format expressions are rejected at lowering; a
+      runtime-side format parser is the prerequisite.
+- [ ] `$sformat` / `$swrite*` output_var of integral or unpacked-array-of-byte type (LRM 21.3.3 +
+      LRM 5.9 assignment rules). Today only string-typed output_var is accepted.
+- [ ] `$sformat` / `$sformatf` format_string of integral or unpacked-array-of-byte type (LRM
+      21.3.3). Shares the runtime-format-parser blocker with the first item.
+
 ## Out of Scope
 
 - Format-string parse diagnostics (trailing `%`, missing specifier, width overflow, unknown
@@ -77,7 +99,5 @@ close as the corresponding behaviour lands.
   strobe's "drain at end of time slot" semantic waits on DI6 (postponed region).
 - Other file read tasks (`$fgetc` / `$ungetc` / `$fgets` / `$fread` / `$fseek` / `$rewind` /
   `$ftell` / `$feof` / `$ferror` / `$fflush`) are implemented per LRM 21.3.4..21.3.8.
-- `$sformat` / `$sformatf` / `$swrite` family (formatting into a string variable). Independent
-  feature.
 - `%u` / `%z` (binary-packed unsigned / signed) and `%v` (strength). Not on the immediate roadmap;
   add entries when concrete consumers appear.

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -79,6 +79,7 @@ class UnitLoweringState {
             .signedness = hir::Signedness::kSigned,
             .dims = {hir::PackedRange{.left = 31, .right = 0}},
             .form = hir::PackedArrayForm::kInt}});
+    string_type_id_ = AddType(hir::TypeData{hir::StringType{}});
   }
 
   // Canonical id for the synthesized `void` type (system-call sinks, lvalue
@@ -93,6 +94,13 @@ class UnitLoweringState {
   // (`$fopen` per LRM 21.3.1, etc.) rather than by a slang-derived type.
   [[nodiscard]] auto Int32TypeId() const -> hir::TypeId {
     return int32_type_id_;
+  }
+
+  // Canonical id for the synthesized `string` type. Used by system functions
+  // whose return is fixed at `string` by the language (`$sformatf` per LRM
+  // 21.3.3) rather than by a slang-derived type.
+  [[nodiscard]] auto StringTypeId() const -> hir::TypeId {
+    return string_type_id_;
   }
 
   [[nodiscard]] auto HirUnit() const -> const hir::ModuleUnit& {
@@ -203,6 +211,7 @@ class UnitLoweringState {
   std::unordered_map<const slang::ast::Type*, hir::TypeId> type_cache_;
   hir::TypeId void_type_id_{};
   hir::TypeId int32_type_id_{};
+  hir::TypeId string_type_id_{};
 };
 
 class ScopeStack {

--- a/include/lyra/lowering/hir_to_mir/lower_sformat.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_sformat.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_span.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/stmt.hpp"
+#include "lyra/support/system_subroutine.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// LRM 21.3.3 expression-position entry. Only `$sformatf` reaches here
+// legitimately (a function returning a `value::String`); `$sformat` /
+// `$swrite*` are tasks and slang rejects them as expressions, so a call
+// arriving with `info.has_output_arg == true` is an upstream invariant
+// violation and raises `InternalError`.
+auto LowerSFormatSystemSubroutineCall(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
+    const support::SFormatSystemSubroutineInfo& info, diag::SourceSpan span)
+    -> diag::Result<mir::Expr>;
+
+// LRM 21.3.3 statement-position entry. Two shapes:
+//   - `$sformat` / `$swrite*` (has_output_arg == true): build
+//       AssignStmt { lhs = out_var, rhs = LyraSFormat(items) }.
+//   - `$sformatf(...)` as a discard statement (has_output_arg == false):
+//       build ExprStmt { expr = LyraSFormat(items) }.
+// No copy-out wrapper -- the output_var is a single string-typed lvalue
+// fully overwritten by the call result, so the standard AssignStmt
+// covers LRM 13.5 lvalue-binding order naturally.
+auto LowerSFormatSystemSubroutineCallStmt(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::ProceduralBody& hir_proc, const hir::Stmt& stmt,
+    diag::SourceSpan span, const hir::CallExpr& call,
+    const support::SystemSubroutineDesc& desc,
+    const support::SFormatSystemSubroutineInfo& info)
+    -> diag::Result<mir::Stmt>;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/print_items.hpp
+++ b/include/lyra/lowering/hir_to_mir/print_items.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 #include "lyra/diag/diagnostic.hpp"
@@ -14,26 +15,43 @@
 
 namespace lyra::lowering::hir_to_mir {
 
+// Whether the first call argument (at `arg_offset`) is required to be a
+// string literal. `$display` / `$write` / `$fdisplay` / `$fwrite` accept
+// either a literal format string or a value-list with auto-format
+// (kOptional); `$sformat` / `$sformatf` require a literal (kRequired)
+// because the LRM 21.3.3 NOTE that allows a runtime format-string is
+// deferred until a runtime-side format parser lands.
+enum class FormatStringRequirement : std::uint8_t {
+  kOptional,
+  kRequired,
+};
+
 // Maps a system subroutine's bare-argument default radix (LRM 21.2.1.1:
 // `$displayb` -> binary, `$displayh` -> hex, etc.) to the runtime
 // FormatKind that drives single-argument format dispatch.
 auto RadixToFormatKind(support::PrintRadix r) -> value::FormatKind;
 
 // Walks a system-subroutine call's argument list and produces the runtime
-// print-item sequence. If the first argument (after `arg_offset`) is a
-// string literal, it is parsed as a format string and remaining arguments
-// are consumed by its directives; otherwise each remaining argument is
-// rendered with the descriptor's default radix (LRM 21.2.1.1).
-// `arg_offset` is 1 for file-output variants whose first call argument is
-// the MCD/FD descriptor and not part of the format payload; 0 otherwise.
+// print-item sequence. The first argument at `arg_offset` is treated as
+// the format-string slot:
+//   - if it is a `hir::StringLiteral`, it is parsed as a format string
+//     and remaining arguments are consumed by its directives;
+//   - else if `fmt_req == kOptional`, every argument from `arg_offset`
+//     onward is rendered with `default_radix` (LRM 21.2.1.1);
+//   - else (`fmt_req == kRequired`) lowering returns
+//     `diag::Unsupported` -- runtime-evaluated format strings are
+//     deferred and tracked under `docs/progress/display.md`.
+// `arg_offset` is 1 for file-output variants whose first call argument
+// is the MCD/FD descriptor, or for `$sformat` / `$swrite*` whose first
+// argument is the output_var lvalue; 0 otherwise.
 auto BuildRuntimePrintItemsFromCallArgs(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
-    const support::PrintSystemSubroutineInfo& info, std::size_t arg_offset,
-    diag::SourceSpan call_span)
+    support::PrintRadix default_radix, std::size_t arg_offset,
+    FormatStringRequirement fmt_req, diag::SourceSpan call_span)
     -> diag::Result<std::vector<mir::RuntimePrintItem>>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -18,6 +18,7 @@
 #include "lyra/mir/runtime_finish.hpp"
 #include "lyra/mir/runtime_print.hpp"
 #include "lyra/mir/runtime_scan.hpp"
+#include "lyra/mir/runtime_sformat.hpp"
 #include "lyra/mir/runtime_submit.hpp"
 #include "lyra/mir/structural_param.hpp"
 #include "lyra/mir/structural_subroutine_ref.hpp"
@@ -104,7 +105,8 @@ using RuntimeCall = std::variant<
     RuntimeFileCloseCall, RuntimeFileGetcCall, RuntimeFileUngetcCall,
     RuntimeFileGetsCall, RuntimeFileReadCall, RuntimeFileSeekCall,
     RuntimeFileRewindCall, RuntimeFileTellCall, RuntimeFileEofCall,
-    RuntimeFileErrorCall, RuntimeFileFlushCall, RuntimeScanCall>;
+    RuntimeFileErrorCall, RuntimeFileFlushCall, RuntimeScanCall,
+    RuntimeSFormatCall>;
 
 struct RuntimeCallExpr {
   RuntimeCall call;

--- a/include/lyra/mir/runtime_sformat.hpp
+++ b/include/lyra/mir/runtime_sformat.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "lyra/mir/runtime_print.hpp"
+
+namespace lyra::mir {
+
+// LRM 21.3.3 string-format family ($swrite / $sformat / $sformatf). The
+// item sequence is built by the same `BuildRuntimePrintItemsFromCallArgs`
+// walker the print family uses, so the conversion-spec set and the
+// auto-format vs literal-format branching are identical to $display /
+// $write. The backend emits a call to `runtime::LyraSFormat(items)` which
+// returns a `value::String`; the enclosing expression context places the
+// result (assigned to an output_var for $swrite / $sformat, or used
+// directly as an rvalue for $sformatf).
+struct RuntimeSFormatCall {
+  std::vector<RuntimePrintItem> items;
+
+  explicit RuntimeSFormatCall(std::vector<RuntimePrintItem> i)
+      : items(std::move(i)) {
+  }
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/runtime/sformat.hpp
+++ b/include/lyra/runtime/sformat.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <span>
+
+#include "lyra/value/format.hpp"
+#include "lyra/value/string.hpp"
+
+namespace lyra::runtime {
+
+// LRM 21.3.3 string-format family runtime entry. Reuses the same
+// `value::FormatValue` engine as `LyraPrint`, but appends to a local
+// std::string buffer that becomes the returned `value::String` rvalue.
+// No newline is appended -- the formatted text is the entire output.
+[[nodiscard]] auto LyraSFormat(std::span<const value::PrintItem> items)
+    -> value::String;
+
+}  // namespace lyra::runtime

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -33,6 +33,7 @@ enum class SystemSubroutineKind : std::uint8_t {
 enum class ReturnConvention : std::uint8_t {
   kVoid,
   kInt32,
+  kString,
 };
 
 struct ArgCountPolicy {
@@ -122,10 +123,23 @@ struct ScanSystemSubroutineInfo {
   ScanSourceKind source;
 };
 
+// LRM 21.3.3 string-format family. The conversion engine is shared with
+// $display / $write; this descriptor only carries the axes the lowering
+// pass needs to dispatch correctly: the default radix for the auto-format
+// $swrite* variants, whether an explicit format string is expected
+// (false for $swrite*, true for $sformat / $sformatf), and whether the
+// call carries an output-var arg (true for $sformat / $swrite*, false
+// for $sformatf which yields its result as the call's rvalue).
+struct SFormatSystemSubroutineInfo {
+  PrintRadix radix;
+  bool expects_format_string;
+  bool has_output_arg;
+};
+
 using SystemSubroutineSemantic = std::variant<
     PrintSystemSubroutineInfo, TerminationSystemSubroutineInfo,
     DiagnosticSystemSubroutineInfo, FileIOSystemSubroutineInfo,
-    ScanSystemSubroutineInfo>;
+    ScanSystemSubroutineInfo, SFormatSystemSubroutineInfo>;
 
 struct SystemSubroutineDesc {
   SystemSubroutineId id;
@@ -534,6 +548,84 @@ inline constexpr std::array kSystemSubroutines = {
         .arg_policy = ArgCountPolicy{.min_args = 3, .max_args = 255},
         .semantic = ScanSystemSubroutineInfo{.source = ScanSourceKind::kFile},
     },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{34},
+        .name = "$swrite",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 1, .max_args = 255},
+        .semantic =
+            SFormatSystemSubroutineInfo{
+                .radix = PrintRadix::kDecimal,
+                .expects_format_string = false,
+                .has_output_arg = true},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{35},
+        .name = "$swriteb",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 1, .max_args = 255},
+        .semantic =
+            SFormatSystemSubroutineInfo{
+                .radix = PrintRadix::kBinary,
+                .expects_format_string = false,
+                .has_output_arg = true},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{36},
+        .name = "$swriteh",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 1, .max_args = 255},
+        .semantic =
+            SFormatSystemSubroutineInfo{
+                .radix = PrintRadix::kHex,
+                .expects_format_string = false,
+                .has_output_arg = true},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{37},
+        .name = "$swriteo",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 1, .max_args = 255},
+        .semantic =
+            SFormatSystemSubroutineInfo{
+                .radix = PrintRadix::kOctal,
+                .expects_format_string = false,
+                .has_output_arg = true},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{38},
+        .name = "$sformat",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 2, .max_args = 255},
+        .semantic =
+            SFormatSystemSubroutineInfo{
+                .radix = PrintRadix::kDecimal,
+                .expects_format_string = true,
+                .has_output_arg = true},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{39},
+        .name = "$sformatf",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kFunction,
+        .result_conv = ReturnConvention::kString,
+        .arg_policy = ArgCountPolicy{.min_args = 1, .max_args = 255},
+        .semantic =
+            SFormatSystemSubroutineInfo{
+                .radix = PrintRadix::kDecimal,
+                .expects_format_string = true,
+                .has_output_arg = false},
+    },
 };
 
 }  // namespace detail
@@ -576,6 +668,11 @@ inline constexpr std::array kSystemSubroutines = {
 [[nodiscard]] inline auto GetScanInfo(const SystemSubroutineDesc& desc)
     -> const ScanSystemSubroutineInfo* {
   return std::get_if<ScanSystemSubroutineInfo>(&desc.semantic);
+}
+
+[[nodiscard]] inline auto GetSFormatInfo(const SystemSubroutineDesc& desc)
+    -> const SFormatSystemSubroutineInfo* {
+  return std::get_if<SFormatSystemSubroutineInfo>(&desc.semantic);
 }
 
 }  // namespace lyra::support

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -418,6 +418,7 @@ auto RenderScopeHeaderFile(
   out += "#include \"lyra/runtime/runtime_scope_kind.hpp\"\n";
   out += "#include \"lyra/runtime/runtime_services.hpp\"\n";
   out += "#include \"lyra/runtime/scan.hpp\"\n";
+  out += "#include \"lyra/runtime/sformat.hpp\"\n";
   out += "#include \"lyra/runtime/var.hpp\"\n";
   out += "#include \"lyra/value/enum.hpp\"\n";
   out += "#include \"lyra/value/format.hpp\"\n";

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -445,6 +445,33 @@ auto RenderRuntimeCallExpr(
             throw InternalError(
                 "RuntimeScanCall: unknown ScanSourceKind in render");
           },
+          [&](const mir::RuntimeSFormatCall& sf) -> diag::Result<std::string> {
+            if (sf.items.empty()) {
+              return std::string(
+                  "lyra::runtime::LyraSFormat("
+                  "std::span<const lyra::value::PrintItem>{})");
+            }
+            std::vector<std::string> item_pieces;
+            item_pieces.reserve(sf.items.size());
+            for (const mir::RuntimePrintItem& item : sf.items) {
+              auto piece_or = RenderPrintItemInit(ctx, item);
+              if (!piece_or) {
+                return std::unexpected(std::move(piece_or.error()));
+              }
+              item_pieces.push_back(*std::move(piece_or));
+            }
+            std::string body;
+            for (std::size_t k = 0; k < item_pieces.size(); ++k) {
+              if (k != 0) {
+                body += ", ";
+              }
+              body += item_pieces[k];
+            }
+            return std::format(
+                "lyra::runtime::LyraSFormat("
+                "std::array<lyra::value::PrintItem, {}>{{{{{}}}}})",
+                sf.items.size(), body);
+          },
       },
       expr.call);
 }

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -198,6 +198,8 @@ auto MakeReturnConventionType(
       return unit_state.VoidTypeId();
     case support::ReturnConvention::kInt32:
       return unit_state.Int32TypeId();
+    case support::ReturnConvention::kString:
+      return unit_state.StringTypeId();
   }
   throw InternalError("MakeReturnConventionType: unknown ReturnConvention");
 }

--- a/src/lyra/lowering/hir_to_mir/lower_diagnostic.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_diagnostic.cpp
@@ -45,17 +45,11 @@ auto LowerDiagnosticSystemSubroutineCall(
     -> diag::Result<mir::Expr> {
   (void)desc;
   // $info/$warning/$error use display-style format (LRM 20.10) with decimal
-  // as the bare-arg default radix; sink/newline fields are not consulted by
-  // the item builder for diagnostic calls (they drive separate Diagnostic
-  // dispatch downstream).
-  constexpr support::PrintSystemSubroutineInfo kDiagnosticPrintInfo{
-      .radix = support::PrintRadix::kDecimal,
-      .append_newline = true,
-      .is_strobe = false,
-      .sink_kind = support::PrintSinkKind::kStdout};
+  // as the bare-arg default radix; the diagnostic sink runs separately.
   auto items_or = BuildRuntimePrintItemsFromCallArgs(
       unit_state, scope_state, proc_state, proc_scope_state, hir_proc, call,
-      kDiagnosticPrintInfo, 0, span);
+      support::PrintRadix::kDecimal, 0, FormatStringRequirement::kOptional,
+      span);
   if (!items_or) return std::unexpected(std::move(items_or.error()));
 
   return mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/lower_print.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_print.cpp
@@ -58,7 +58,7 @@ auto LowerPrintSystemSubroutineCall(
 
   auto items_or = BuildRuntimePrintItemsFromCallArgs(
       unit_state, scope_state, proc_state, proc_scope_state, hir_proc, call,
-      print, arg_offset, span);
+      print.radix, arg_offset, FormatStringRequirement::kOptional, span);
   if (!items_or) return std::unexpected(std::move(items_or.error()));
 
   return mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/lower_sformat.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_sformat.cpp
@@ -1,0 +1,144 @@
+#include "lyra/lowering/hir_to_mir/lower_sformat.hpp"
+
+#include <cstddef>
+#include <expected>
+#include <format>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/lower_expr.hpp"
+#include "lyra/lowering/hir_to_mir/print_items.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/runtime_sformat.hpp"
+#include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type.hpp"
+#include "lyra/support/system_subroutine.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+namespace {
+
+auto BuildSFormatCallExpr(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
+    const support::SFormatSystemSubroutineInfo& info, std::size_t arg_offset,
+    diag::SourceSpan span) -> diag::Result<mir::Expr> {
+  const FormatStringRequirement fmt_req =
+      info.expects_format_string ? FormatStringRequirement::kRequired
+                                 : FormatStringRequirement::kOptional;
+  auto items_or = BuildRuntimePrintItemsFromCallArgs(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_proc, call,
+      info.radix, arg_offset, fmt_req, span);
+  if (!items_or) return std::unexpected(std::move(items_or.error()));
+
+  return mir::Expr{
+      .data =
+          mir::RuntimeCallExpr{
+              .call = mir::RuntimeSFormatCall(std::move(*items_or))},
+      .type = unit_state.Builtins().string};
+}
+
+auto RejectNonStringOutput(
+    const support::SystemSubroutineDesc& desc, diag::SourceSpan span)
+    -> diag::Result<mir::Stmt> {
+  return diag::Unsupported(
+      span, diag::DiagCode::kUnsupportedSubroutineArgument,
+      std::format(
+          "{} output_var must be string-typed in this build (LRM 21.3.3 "
+          "allows integral and unpacked-byte-array outputs via LRM 5.9 "
+          "assignment rules; deferred)",
+          std::string{desc.name}),
+      diag::UnsupportedCategory::kFeature);
+}
+
+}  // namespace
+
+auto LowerSFormatSystemSubroutineCall(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
+    const support::SFormatSystemSubroutineInfo& info, diag::SourceSpan span)
+    -> diag::Result<mir::Expr> {
+  if (info.has_output_arg) {
+    throw InternalError(
+        "LowerSFormatSystemSubroutineCall: $sformat / $swrite reached "
+        "expression-position lowering; slang's task binding should reject "
+        "them outside statement position");
+  }
+  return BuildSFormatCallExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_proc, call,
+      info, 0, span);
+}
+
+auto LowerSFormatSystemSubroutineCallStmt(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::ProceduralBody& hir_proc, const hir::Stmt& stmt,
+    diag::SourceSpan span, const hir::CallExpr& call,
+    const support::SystemSubroutineDesc& desc,
+    const support::SFormatSystemSubroutineInfo& info)
+    -> diag::Result<mir::Stmt> {
+  if (!info.has_output_arg) {
+    auto call_expr_or = BuildSFormatCallExpr(
+        unit_state, scope_state, proc_state, proc_scope_state, hir_proc, call,
+        info, 0, span);
+    if (!call_expr_or) return std::unexpected(std::move(call_expr_or.error()));
+    const mir::ExprId expr_id =
+        proc_scope_state.AddExpr(*std::move(call_expr_or));
+    return mir::Stmt{
+        .label = stmt.label,
+        .data = mir::ExprStmt{.expr = expr_id},
+        .child_procedural_scopes = {}};
+  }
+
+  if (call.arguments.empty()) {
+    throw InternalError(
+        "LowerSFormatSystemSubroutineCallStmt: $sformat / $swrite requires "
+        "an output_var argument; slang's arg-count check should have "
+        "rejected the call");
+  }
+
+  auto out_or = LowerExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+      hir_proc.exprs.at(call.arguments[0].value));
+  if (!out_or) return std::unexpected(std::move(out_or.error()));
+  const mir::TypeId out_type = out_or->type;
+  if (unit_state.GetType(out_type).Kind() != mir::TypeKind::kString) {
+    return RejectNonStringOutput(desc, span);
+  }
+  const mir::ExprId out_id = proc_scope_state.AddExpr(*std::move(out_or));
+
+  auto call_expr_or = BuildSFormatCallExpr(
+      unit_state, scope_state, proc_state, proc_scope_state, hir_proc, call,
+      info, 1, span);
+  if (!call_expr_or) return std::unexpected(std::move(call_expr_or.error()));
+  const mir::ExprId call_id =
+      proc_scope_state.AddExpr(*std::move(call_expr_or));
+
+  const mir::ExprId assign_id = proc_scope_state.AddExpr(
+      mir::Expr{
+          .data = mir::AssignExpr{.target = out_id, .value = call_id},
+          .type = out_type});
+
+  return mir::Stmt{
+      .label = stmt.label,
+      .data = mir::ExprStmt{.expr = assign_id},
+      .child_procedural_scopes = {}};
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -28,6 +28,7 @@
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 #include "lyra/lowering/hir_to_mir/lower_file_io.hpp"
 #include "lyra/lowering/hir_to_mir/lower_scan.hpp"
+#include "lyra/lowering/hir_to_mir/lower_sformat.hpp"
 #include "lyra/lowering/hir_to_mir/procedural_scope_helpers.hpp"
 #include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
@@ -505,6 +506,11 @@ auto LowerExprStmt(
             unit_state, scope_state, proc_state, hir_proc, stmt, inner.span,
             *call, desc, *scan_info, std::nullopt,
             unit_state.TranslateType(inner.type));
+      }
+      if (const auto* sformat_info = support::GetSFormatInfo(desc)) {
+        return LowerSFormatSystemSubroutineCallStmt(
+            unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+            stmt, inner.span, *call, desc, *sformat_info);
       }
     }
   }

--- a/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
@@ -12,6 +12,7 @@
 #include "lyra/lowering/hir_to_mir/lower_finish.hpp"
 #include "lyra/lowering/hir_to_mir/lower_print.hpp"
 #include "lyra/lowering/hir_to_mir/lower_scan.hpp"
+#include "lyra/lowering/hir_to_mir/lower_sformat.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/support/system_subroutine.hpp"
@@ -57,6 +58,12 @@ auto LowerSystemSubroutineCall(
             return LowerScanSystemSubroutineCall(
                 unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
                 call, desc, scan, span);
+          },
+          [&](const support::SFormatSystemSubroutineInfo& sformat)
+              -> diag::Result<mir::Expr> {
+            return LowerSFormatSystemSubroutineCall(
+                unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+                call, sformat, span);
           },
       },
       desc.semantic);

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -203,32 +203,47 @@ auto BuildRuntimePrintItemsFromCallArgs(
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
-    const support::PrintSystemSubroutineInfo& info, std::size_t arg_offset,
-    diag::SourceSpan call_span)
+    support::PrintRadix default_radix, std::size_t arg_offset,
+    FormatStringRequirement fmt_req, diag::SourceSpan call_span)
     -> diag::Result<std::vector<mir::RuntimePrintItem>> {
   std::vector<mir::RuntimePrintItem> items;
   const auto& args = call.arguments;
   std::size_t cursor = arg_offset;
 
+  std::optional<LiteralFormatStringRef> literal;
   if (cursor < args.size()) {
-    if (auto literal = TryGetHirStringLiteral(hir_proc, args[cursor])) {
-      auto parsed_or =
-          support::ParseLiteralFormatString(literal->text, literal->span);
-      if (!parsed_or) return std::unexpected(std::move(parsed_or.error()));
-      ++cursor;
-      auto value_index = cursor;
-      for (const auto& directive : *parsed_or) {
-        auto item_or = BuildPrintItemFromDirective(
-            unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
-            directive, args, value_index, literal->span);
-        if (!item_or) return std::unexpected(std::move(item_or.error()));
-        items.push_back(std::move(*item_or));
-      }
-      cursor = value_index;
+    literal = TryGetHirStringLiteral(hir_proc, args[cursor]);
+  }
+  if (!literal.has_value() && fmt_req == FormatStringRequirement::kRequired) {
+    // LRM 21.3.3 NOTE permits non-literal format strings; this build defers
+    // them. Tracked under docs/progress/display.md "String-format family
+    // follow-ups".
+    const diag::SourceSpan span =
+        cursor < args.size() ? hir_proc.exprs.at(args[cursor].value).span
+                             : call_span;
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedSubroutineArgument,
+        "format string must be a string literal in this build (LRM 21.3.3 "
+        "runtime-evaluated format strings deferred)",
+        diag::UnsupportedCategory::kFeature);
+  }
+  if (literal.has_value()) {
+    auto parsed_or =
+        support::ParseLiteralFormatString(literal->text, literal->span);
+    if (!parsed_or) return std::unexpected(std::move(parsed_or.error()));
+    ++cursor;
+    auto value_index = cursor;
+    for (const auto& directive : *parsed_or) {
+      auto item_or = BuildPrintItemFromDirective(
+          unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+          directive, args, value_index, literal->span);
+      if (!item_or) return std::unexpected(std::move(item_or.error()));
+      items.push_back(std::move(*item_or));
     }
+    cursor = value_index;
   }
 
-  const value::FormatKind default_kind = RadixToFormatKind(info.radix);
+  const value::FormatKind default_kind = RadixToFormatKind(default_radix);
   while (cursor < args.size()) {
     if (!items.empty()) {
       items.emplace_back(mir::RuntimePrintLiteral{.text = " "});

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -825,6 +825,11 @@ class MirDumper {
                             kind_text, ss.source.value, ss.format.value,
                             slot_list));
                   },
+                  [&](const RuntimeSFormatCall& sf) {
+                    Line(
+                        std::format(
+                            "RuntimeSFormatCall items={}", sf.items.size()));
+                  },
               },
               rc->call);
           Dedent();

--- a/src/lyra/runtime/sformat.cpp
+++ b/src/lyra/runtime/sformat.cpp
@@ -1,0 +1,32 @@
+#include "lyra/runtime/sformat.hpp"
+
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+
+#include "lyra/base/overloaded.hpp"
+#include "lyra/value/format.hpp"
+#include "lyra/value/string.hpp"
+
+namespace lyra::runtime {
+
+auto LyraSFormat(std::span<const value::PrintItem> items) -> value::String {
+  std::string buf;
+  for (const value::PrintItem& item : items) {
+    std::visit(
+        Overloaded{
+            [&](const value::PrintLiteralItem& lit) {
+              buf.append(std::string_view{lit.data, lit.size});
+            },
+            [&](const value::PrintValueItem& v) {
+              buf.append(value::FormatValue(v.spec, v.value));
+            },
+        },
+        item);
+  }
+  return value::String(std::move(buf));
+}
+
+}  // namespace lyra::runtime

--- a/tests/cases/cpp/sformat_basics/case.yaml
+++ b/tests/cases/cpp/sformat_basics/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.sformat_basics
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    out_specs: "d=42 h=dead o=377 b=1011"
+    out_strings: "hi=world lit=literal"
+    out_width: "[    7]"
+    out_lalign: "[hi   ]"
+    out_zpad: "[0007]"

--- a/tests/cases/cpp/sformat_basics/main.sv
+++ b/tests/cases/cpp/sformat_basics/main.sv
@@ -1,0 +1,38 @@
+module Top;
+  // LRM 21.3.3: $sformat writes its formatted output to the first argument
+  // (a string-typed lvalue per Cut 1 scope). Format conversions reuse the
+  // same engine as $display, so this case only proves end-to-end wiring
+  // across a representative spec set plus the width / precision / pad /
+  // align modifiers rather than re-testing every spec semantics.
+  int          a;
+  logic [15:0] b;
+  logic [7:0]  c;
+  logic [3:0]  d;
+  int          n;
+  string       greeting;
+  string       label;
+  string       out_specs;
+  string       out_strings;
+  string       out_width;
+  string       out_lalign;
+  string       out_zpad;
+  initial begin
+    a = 42;
+    b = 16'hDEAD;
+    c = 8'o377;
+    d = 4'b1011;
+    n = 7;
+    greeting = "world";
+    label = "hi";
+    $sformat(out_specs, "d=%0d h=%0h o=%0o b=%0b", a, b, c, d);
+    // %s consumes both a `string` arg and a packed-string-literal arg --
+    // proves the implicit ConversionExpr path the print engine inserts
+    // for non-string %s operands also fires through the sformat lowering.
+    $sformat(out_strings, "hi=%s lit=%s", greeting, "literal");
+    // Format-modifier wiring: width / left-align / zero-pad all feed the
+    // same FormatModifiers struct the print engine uses.
+    $sformat(out_width, "[%5d]", n);
+    $sformat(out_lalign, "[%-5s]", label);
+    $sformat(out_zpad, "[%04h]", n);
+  end
+endmodule

--- a/tests/cases/cpp/sformatf_basics/case.yaml
+++ b/tests/cases/cpp/sformatf_basics/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.sformatf_basics
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s_assign: "x=42"
+    branch_taken: 1
+    s_passed: "[2a]"

--- a/tests/cases/cpp/sformatf_basics/main.sv
+++ b/tests/cases/cpp/sformatf_basics/main.sv
@@ -1,0 +1,29 @@
+module Top;
+  // LRM 21.3.3: $sformatf is the rvalue variant -- the formatted string is
+  // the call's return value. This case proves the call composes across
+  // expression positions (assign-RHS, function-call argument, condition
+  // boolean) and tolerates the function-as-statement discard form.
+  int    x;
+  string s_assign;
+  string s_passed;
+  int    branch_taken;
+  initial begin
+    x = 42;
+    // Assign-RHS form.
+    s_assign = $sformatf("x=%0d", x);
+
+    // String-comparison-as-condition: proves $sformatf's result behaves
+    // like any other string-typed rvalue (no special-casing).
+    if ($sformatf("%0d", x) == "42") begin
+      branch_taken = 1;
+    end else begin
+      branch_taken = 0;
+    end
+
+    // Bare-call discard form: legal per SV (function-as-statement). The
+    // assignment to `s_passed` afterwards proves the discard does not
+    // disturb subsequent state.
+    $sformatf("ignored=%0d", x);
+    s_passed = $sformatf("[%0h]", x);
+  end
+endmodule

--- a/tests/cases/cpp/swrite_auto_format/case.yaml
+++ b/tests/cases/cpp/swrite_auto_format/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.swrite_auto_format
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    # Same value 8'h2A formatted via each $swrite* default radix; widths
+    # follow the $display family defaults (LRM 21.2.1.1).
+    s_dec: "42"
+    s_bin: "00101010"
+    s_hex: "2a"
+    s_oct: "052"

--- a/tests/cases/cpp/swrite_auto_format/main.sv
+++ b/tests/cases/cpp/swrite_auto_format/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  // LRM 21.3.3: $swrite / $swriteb / $swriteh / $swriteo pick the same
+  // default radix as their $write / $writeb / $writeh / $writeo
+  // counterparts and emit the formatted text to the first arg (no format
+  // string, no newline). All four invariants are proven by writing the
+  // same value `x` and reading the resulting strings back.
+  logic [7:0] x;
+  string s_dec, s_bin, s_hex, s_oct;
+  initial begin
+    x = 8'h2A;          // 42 dec, 0010_1010 bin, 2a hex, 52 oct
+    $swrite(s_dec, x);
+    $swriteb(s_bin, x);
+    $swriteh(s_hex, x);
+    $swriteo(s_oct, x);
+  end
+endmodule

--- a/tests/cases/errors/sformat_non_literal_format/case.yaml
+++ b/tests/cases/errors/sformat_non_literal_format/case.yaml
@@ -1,0 +1,16 @@
+id: errors.sformat_non_literal_format
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "format string must be a string literal"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/sformat_non_literal_format/main.sv
+++ b/tests/cases/errors/sformat_non_literal_format/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  // LRM 21.3.3 NOTE: $sformat / $sformatf accept a non-literal format
+  // expression (string variable, integral, unpacked array of byte). This
+  // build defers all three to a follow-up runtime format parser; each is
+  // rejected at lowering with the same diagnostic shape.
+  string  fmt_var;
+  int     a;
+  string  s;
+  initial begin
+    fmt_var = "%d";
+    $sformat(s, fmt_var, a);
+  end
+endmodule

--- a/tests/cases/errors/sformat_non_string_output/case.yaml
+++ b/tests/cases/errors/sformat_non_string_output/case.yaml
@@ -1,0 +1,16 @@
+id: errors.sformat_non_string_output
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "output_var must be string-typed"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/sformat_non_string_output/main.sv
+++ b/tests/cases/errors/sformat_non_string_output/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  // LRM 21.3.3 allows integral and unpacked-array-of-byte outputs via
+  // LRM 5.9 string-literal-assignment rules; Cut 1 defers those and only
+  // accepts a string-typed output_var.
+  int    out_int;
+  int    a;
+  initial begin
+    a = 7;
+    $sformat(out_int, "%d", a);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements the LRM 21.3.3 string-format family ($swrite / $swriteb / $swriteh / $swriteo / $sformat / $sformatf) on top of the existing print engine. All six subroutines lower to a new `mir::RuntimeSFormatCall` node that the backend renders as a `runtime::LyraSFormat` call returning a `value::String`. $sformatf surfaces the result as the call's rvalue (any expression position); $sformat and $swrite* assign-to-output-var via a standard `AssignStmt` (no copy-out wrapper needed because the output is a single string-typed lvalue fully overwritten by the call). The runtime entry reuses `value::FormatValue` unchanged -- one format engine, no parallel implementation.

## Design

The literal-vs-runtime format-string distinction is encoded as a new `FormatStringRequirement` enum threaded through `BuildRuntimePrintItemsFromCallArgs`. $display / $write / $fdisplay / $fwrite pass `kOptional` (literal parses, otherwise auto-format fallback); $sformat / $sformatf pass `kRequired` (literal parses, otherwise the engine returns `diag::Unsupported`). This consolidates the literal-check in one place rather than duplicating it at every caller. While there, the function's `info` parameter narrowed from the full `PrintSystemSubroutineInfo` to just `support::PrintRadix` -- the only field it ever read.

## Testing

5 new test directories under `tests/cases/`: three `cpp_run` cases covering spec set + auto-format radix variants + expression-position composition, plus two `errors` cases covering the deferred runtime-format-string and non-string output_var gates. Playground smoke test verified end-to-end emit + build + run output matches.

Deferred (tracked as new "String-format family follow-ups" checkboxes in `docs/progress/display.md`): runtime-evaluated format strings, integral / unpacked-byte-array output_var, integral / unpacked-byte-array format_string.