### PR TITLE
Add downward cross-unit hierarchical references

### DIFF
--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -88,23 +88,28 @@ Unlocks `instantiation/multiple_instances`, `instantiation/nested_hierarchy`,
 
 ### Stage C -- Non-local access substrate
 
-- [ ] C1 -- Cross-unit references resolve once at construction into a stored direct reference, read
+- [x] C1 -- Cross-unit references resolve once at construction into a stored direct reference, read
       directly thereafter (per `reference_resolution.md`). This is the substrate Stages D and E
-      consume.
-- [ ] C2 -- A process on one instance can observe a member of another instance and re-evaluate when
+      consume. Landed for the downward, single-level form (a direct child's member); the
+      resolve-once slot is the shared path ports will populate. Multi-level navigation and upward
+      resolution feed the same slot in later cuts.
+- [x] C2 -- A process on one instance can observe a member of another instance and re-evaluate when
       that member changes, without the observed instance knowing who watches it (cross-instance
-      sensitivity).
+      sensitivity). The combinational process subscribes through the resolved slot; demonstrated for
+      a downward, single-level reference.
 
 This stage produces no user-visible feature on its own; it is the substrate the next two stages
 consume. Coverage is demonstrated through Stage D and Stage E.
 
 ### Stage D -- Hierarchical references
 
-- [ ] D1 -- A downward reference reads and writes a signal in a child instance.
+- [x] D1 -- A downward reference reads and writes a signal in a child instance.
 - [ ] D2 -- An upward reference reads and writes a signal in an ancestor instance.
 - [ ] D3 -- Multi-level dotted paths resolve through the object tree across more than one level.
 - [ ] D4 -- A combinational process reading a hierarchical reference re-triggers when the referenced
-      signal changes, including paths spanning multiple levels and reads from several instances.
+      signal changes, including paths spanning multiple levels and reads from several instances. The
+      single-level downward case re-triggers today (it rode in with D1); multi-level and
+      multi-instance paths remain.
 - [ ] D5 -- The hierarchical path of an instance (for `%m`, display, and scope queries) derives from
       object-tree ownership.
 

--- a/include/lyra/backend/cpp/formatting.hpp
+++ b/include/lyra/backend/cpp/formatting.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 
 namespace lyra::backend::cpp {
@@ -8,6 +9,14 @@ namespace lyra::backend::cpp {
 [[nodiscard]] inline auto Indent(std::size_t level) -> std::string {
   std::string result(level * 2, ' ');
   return result;
+}
+
+// Member name for a cross-unit reference slot: the resolved `Var<T>*` the
+// constructor points at the child's member. The same name backs the slot's
+// declaration, its constructor resolution, and every read / write / subscribe.
+[[nodiscard]] inline auto CrossUnitRefSlotName(std::uint32_t slot)
+    -> std::string {
+  return "xref_" + std::to_string(slot);
 }
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/hir/primary.hpp
+++ b/include/lyra/hir/primary.hpp
@@ -40,6 +40,6 @@ struct RealLiteral {
 // tag.
 using Primary = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, StructuralVarRef,
-    ProceduralVarRef, LoopVarRef>;
+    ProceduralVarRef, LoopVarRef, CrossUnitVarRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -163,7 +163,7 @@ enum class EventEdge : std::uint8_t {
 // supply leaves with `edge_kind == kAnyChange`. Explicit event control
 // `@(posedge ...)` / `@(negedge ...)` / `@(edge ...)` set the per-leaf edge.
 struct SensitivityEntry {
-  StructuralVarRef ref;
+  SensitivityRef ref;
   std::pair<std::uint64_t, std::uint64_t> bit_range;
   EventEdge edge_kind = EventEdge::kAnyChange;
 };

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -15,6 +15,7 @@
 #include "lyra/hir/structural_var.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/type_alias.hpp"
+#include "lyra/hir/value_ref.hpp"
 
 namespace lyra::hir {
 
@@ -38,6 +39,18 @@ struct InstanceMemberId {
 
   auto operator<=>(const InstanceMemberId&) const
       -> std::strong_ordering = default;
+};
+
+// A cross-unit reference resolved once at construction (see
+// reference_resolution.md). `instance` names the owned child instance member
+// this unit reaches into; `target_member` is the child's interface member name,
+// referenced by name across the unit boundary; `type` is the slang-resolved
+// type of the referenced member. The slot is read / written / observed through
+// a stored direct reference the constructor materializes.
+struct CrossUnitRefDecl {
+  InstanceMemberId instance;
+  std::string target_member;
+  TypeId type;
 };
 
 // `target_unit` is a cross-unit reference -- the name of the instantiated unit,
@@ -96,6 +109,7 @@ struct StructuralScope {
   std::vector<ContinuousAssign> continuous_assigns;
   std::vector<Generate> generates;
   std::vector<InstanceMemberDecl> instance_members;
+  std::vector<CrossUnitRefDecl> cross_unit_refs;
   std::vector<StructuralSubroutineDecl> structural_subroutines;
   std::vector<TypeAliasDecl> type_aliases;
 
@@ -123,6 +137,10 @@ struct StructuralScope {
   [[nodiscard]] auto GetInstanceMember(InstanceMemberId id) const
       -> const InstanceMemberDecl& {
     return instance_members.at(id.value);
+  }
+  [[nodiscard]] auto GetCrossUnitRef(CrossUnitRefId id) const
+      -> const CrossUnitRefDecl& {
+    return cross_unit_refs.at(id.value);
   }
   [[nodiscard]] auto GetStructuralSubroutine(StructuralSubroutineId id) const
       -> const StructuralSubroutineDecl& {

--- a/include/lyra/hir/value_ref.hpp
+++ b/include/lyra/hir/value_ref.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <compare>
+#include <cstdint>
+#include <variant>
+
 #include "lyra/hir/loop_var.hpp"
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/structural_hops.hpp"
@@ -14,6 +18,23 @@ struct StructuralVarRef {
   auto operator==(const StructuralVarRef&) const -> bool = default;
 };
 
+struct CrossUnitRefId {
+  std::uint32_t value;
+
+  auto operator<=>(const CrossUnitRefId&) const
+      -> std::strong_ordering = default;
+};
+
+// A reference whose target lives in another compilation unit (a child
+// instance's member). Resolved once at construction into a stored direct
+// reference; the navigation recipe lives in the enclosing scope's
+// `cross_unit_refs` table keyed by this id (see reference_resolution.md).
+struct CrossUnitVarRef {
+  CrossUnitRefId id;
+
+  auto operator==(const CrossUnitVarRef&) const -> bool = default;
+};
+
 struct ProceduralVarRef {
   ProceduralVarId var;
 
@@ -26,5 +47,9 @@ struct LoopVarRef {
 
   auto operator==(const LoopVarRef&) const -> bool = default;
 };
+
+// A sensitivity leaf observes either a this-unit structural var or a cross-unit
+// member; both resolve to a stored `Observable` the scheduler subscribes to.
+using SensitivityRef = std::variant<StructuralVarRef, CrossUnitVarRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -2,6 +2,7 @@
 
 #include <compare>
 #include <cstdint>
+#include <map>
 #include <optional>
 #include <ranges>
 #include <string>
@@ -9,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include <slang/ast/symbols/InstanceSymbols.h>
 #include <slang/ast/symbols/ParameterSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/ValueSymbol.h>
@@ -64,6 +66,14 @@ struct LoopVarBinding {
 
 using LoopVarBindings =
     std::unordered_map<const slang::ast::ValueSymbol*, LoopVarBinding>;
+
+struct InstanceMemberBinding {
+  ScopeFrameId home_frame;
+  hir::InstanceMemberId member_id;
+};
+
+using InstanceMemberBindings = std::unordered_map<
+    const slang::ast::InstanceSymbol*, InstanceMemberBinding>;
 
 class UnitLoweringState {
  public:
@@ -190,6 +200,73 @@ class UnitLoweringState {
     return it->second;
   }
 
+  void MapInstanceMemberBinding(
+      const slang::ast::InstanceSymbol& inst, ScopeFrameId home_frame,
+      hir::InstanceMemberId member_id) {
+    const auto [_, inserted] = instance_member_bindings_.emplace(
+        &inst, InstanceMemberBinding{
+                   .home_frame = home_frame, .member_id = member_id});
+    if (!inserted) {
+      throw InternalError(
+          "UnitLoweringState::MapInstanceMemberBinding: instance symbol "
+          "already "
+          "mapped");
+    }
+  }
+
+  [[nodiscard]] auto LookupInstanceMemberBinding(
+      const slang::ast::InstanceSymbol& inst) const
+      -> std::optional<InstanceMemberBinding> {
+    const auto it = instance_member_bindings_.find(&inst);
+    if (it == instance_member_bindings_.end()) {
+      return std::nullopt;
+    }
+    return it->second;
+  }
+
+  // Dedups by target symbol (one slot per referenced cross-unit member) and
+  // accumulates the slot decl under its owning scope's frame. The returned id
+  // is the slot's index within that scope's `cross_unit_refs`, flushed onto the
+  // HIR scope by TakeCrossUnitRefsForFrame when the scope finishes lowering.
+  auto MapOrGetCrossUnitRef(
+      const slang::ast::ValueSymbol& target, ScopeFrameId home_frame,
+      hir::InstanceMemberId instance, std::string target_member,
+      hir::TypeId type) -> hir::CrossUnitRefId {
+    if (const auto it = cross_unit_ref_dedup_.find(&target);
+        it != cross_unit_ref_dedup_.end()) {
+      return it->second;
+    }
+    auto& slots = cross_unit_refs_by_frame_[home_frame];
+    const hir::CrossUnitRefId id{static_cast<std::uint32_t>(slots.size())};
+    slots.push_back(
+        hir::CrossUnitRefDecl{
+            .instance = instance,
+            .target_member = std::move(target_member),
+            .type = type});
+    cross_unit_ref_dedup_.emplace(&target, id);
+    return id;
+  }
+
+  [[nodiscard]] auto LookupCrossUnitRef(const slang::ast::ValueSymbol& target)
+      const -> std::optional<hir::CrossUnitRefId> {
+    const auto it = cross_unit_ref_dedup_.find(&target);
+    if (it == cross_unit_ref_dedup_.end()) {
+      return std::nullopt;
+    }
+    return it->second;
+  }
+
+  auto TakeCrossUnitRefsForFrame(ScopeFrameId frame)
+      -> std::vector<hir::CrossUnitRefDecl> {
+    const auto it = cross_unit_refs_by_frame_.find(frame);
+    if (it == cross_unit_refs_by_frame_.end()) {
+      return {};
+    }
+    auto out = std::move(it->second);
+    cross_unit_refs_by_frame_.erase(it);
+    return out;
+  }
+
   auto MoveHirUnit() -> hir::ModuleUnit {
     return std::move(hir_unit_);
   }
@@ -208,6 +285,11 @@ class UnitLoweringState {
   StructuralVarBindings structural_var_bindings_;
   SubroutineBindings subroutine_bindings_;
   LoopVarBindings loop_var_bindings_;
+  InstanceMemberBindings instance_member_bindings_;
+  std::unordered_map<const slang::ast::ValueSymbol*, hir::CrossUnitRefId>
+      cross_unit_ref_dedup_;
+  std::map<ScopeFrameId, std::vector<hir::CrossUnitRefDecl>>
+      cross_unit_refs_by_frame_;
   std::unordered_map<const slang::ast::Type*, hir::TypeId> type_cache_;
   hir::TypeId void_type_id_{};
   hir::TypeId int32_type_id_{};

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -201,6 +201,13 @@ class StructuralScopeLoweringState {
     return id;
   }
 
+  auto AddCrossUnitRef(mir::CrossUnitRefDecl decl) -> mir::CrossUnitRefId {
+    const mir::CrossUnitRefId id{
+        static_cast<std::uint32_t>(scope_->cross_unit_refs.size())};
+    scope_->cross_unit_refs.push_back(std::move(decl));
+    return id;
+  }
+
   auto AddStructuralParam(mir::StructuralParamDecl param)
       -> mir::StructuralParamId {
     const mir::StructuralParamId id{

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -153,9 +153,9 @@ struct ArrayLiteralExpr {
 
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, StructuralParamRef,
-    StructuralVarRef, ProceduralVarRef, UnaryExpr, BinaryExpr, ConditionalExpr,
-    AssignExpr, IncDecExpr, CallExpr, RuntimeCallExpr, ConversionExpr,
-    ClosureExpr, ElementSelectExpr, RangeSelectExpr, ConcatExpr,
+    StructuralVarRef, ProceduralVarRef, CrossUnitVarRef, UnaryExpr, BinaryExpr,
+    ConditionalExpr, AssignExpr, IncDecExpr, CallExpr, RuntimeCallExpr,
+    ConversionExpr, ClosureExpr, ElementSelectExpr, RangeSelectExpr, ConcatExpr,
     ReplicationExpr, ArrayLiteralExpr>;
 
 struct Expr {

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -85,6 +85,14 @@ struct ConstructExternalUnitStmt {
   std::vector<std::uint32_t> dims;
 };
 
+// Resolves a cross-unit reference slot once at construction, after the target
+// child is built (reference_resolution.md): the backend materializes a stored
+// direct reference to the child's member. The navigation recipe lives in the
+// enclosing scope's `cross_unit_refs` table, keyed by `slot`.
+struct ResolveCrossUnitRefStmt {
+  CrossUnitRefId slot;
+};
+
 struct ForInitDecl {
   ProceduralVarRef induction_var = {};
   ExprId init = {};
@@ -148,7 +156,7 @@ struct ReturnStmt {
 // DFA produces the (var, bit_range) pairs; the SV edge identifier (or
 // `kAnyChange` for implicit sensitivity) attaches per leaf at AST lowering.
 struct SensitivityRead {
-  StructuralVarRef ref;
+  SensitivityRef ref;
   std::pair<std::uint64_t, std::uint64_t> bit_range;
   EventEdge edge_kind = EventEdge::kAnyChange;
 };
@@ -163,9 +171,9 @@ struct SensitivityWaitStmt {
 
 using StmtData = std::variant<
     EmptyStmt, ProceduralVarDeclStmt, ExprStmt, BlockStmt, IfStmt,
-    ConstructOwnedObjectStmt, ConstructExternalUnitStmt, ForStmt, DelayStmt,
-    WhileStmt, DoWhileStmt, BreakStmt, ContinueStmt, ReturnStmt,
-    SensitivityWaitStmt>;
+    ConstructOwnedObjectStmt, ConstructExternalUnitStmt,
+    ResolveCrossUnitRefStmt, ForStmt, DelayStmt, WhileStmt, DoWhileStmt,
+    BreakStmt, ContinueStmt, ReturnStmt, SensitivityWaitStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/include/lyra/mir/structural_scope.hpp
+++ b/include/lyra/mir/structural_scope.hpp
@@ -10,13 +10,26 @@
 #include "lyra/mir/structural_subroutine.hpp"
 #include "lyra/mir/structural_var.hpp"
 #include "lyra/mir/type_alias.hpp"
+#include "lyra/mir/type_id.hpp"
+#include "lyra/mir/value_ref.hpp"
 
 namespace lyra::mir {
+
+// A cross-unit reference resolved once at construction. `instance_var` is the
+// structural var holding the owned child instance; `target_member` is the
+// child's interface member name; `type` is the referenced member's type. The
+// backend stores a direct reference to `instance_var->target_member`.
+struct CrossUnitRefDecl {
+  StructuralVarId instance_var;
+  std::string target_member;
+  TypeId type;
+};
 
 struct StructuralScope {
   std::string name;
   std::vector<StructuralParamDecl> structural_params;
   std::vector<StructuralVarDecl> structural_vars;
+  std::vector<CrossUnitRefDecl> cross_unit_refs;
   ProceduralScope constructor_scope;
   std::vector<Process> processes;
   std::vector<StructuralScope> child_structural_scopes;
@@ -30,6 +43,10 @@ struct StructuralScope {
   [[nodiscard]] auto GetStructuralVar(StructuralVarId id) const
       -> const StructuralVarDecl& {
     return structural_vars.at(id.value);
+  }
+  [[nodiscard]] auto GetCrossUnitRef(CrossUnitRefId id) const
+      -> const CrossUnitRefDecl& {
+    return cross_unit_refs.at(id.value);
   }
   [[nodiscard]] auto GetProcess(ProcessId id) const -> const Process& {
     return processes.at(id.value);

--- a/include/lyra/mir/value_ref.hpp
+++ b/include/lyra/mir/value_ref.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <compare>
+#include <cstdint>
+#include <variant>
+
 #include "lyra/mir/procedural_hops.hpp"
 #include "lyra/mir/procedural_var.hpp"
 #include "lyra/mir/structural_hops.hpp"
@@ -16,5 +20,23 @@ struct ProceduralVarRef {
   ProceduralHops hops;
   ProceduralVarId var{};
 };
+
+struct CrossUnitRefId {
+  std::uint32_t value;
+
+  auto operator<=>(const CrossUnitRefId&) const
+      -> std::strong_ordering = default;
+};
+
+// A reference into a child instance's member, resolved once at construction
+// into a stored direct reference; the navigation recipe lives in the enclosing
+// scope's `cross_unit_refs` table keyed by this id.
+struct CrossUnitVarRef {
+  CrossUnitRefId id;
+};
+
+// A sensitivity leaf observes either a this-unit structural var or a cross-unit
+// member; both resolve to a stored `Observable` the scheduler subscribes to.
+using SensitivityRef = std::variant<StructuralVarRef, CrossUnitVarRef>;
 
 }  // namespace lyra::mir

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -303,6 +303,23 @@ auto RenderScopeAsClass(
     out += *field_or;
   }
 
+  // A cross-unit reference slot holds a resolved pointer into a child's member;
+  // the constructor points it at `&child->member`. It mirrors that member's
+  // storage: a `Var<T>*` for an observable scalar, a plain `T*` otherwise.
+  for (std::size_t i = 0; i < s.cross_unit_refs.size(); ++i) {
+    const auto& cu = s.cross_unit_refs[i];
+    auto type_or = RenderTypeAsCpp(unit, s, cu.type);
+    if (!type_or) return std::unexpected(std::move(type_or.error()));
+    const std::string slot =
+        CrossUnitRefSlotName(static_cast<std::uint32_t>(i));
+    if (IsObservableScalarType(unit.GetType(cu.type))) {
+      out += Indent(indent + 1) + "lyra::runtime::Var<" + *type_or + ">* " +
+             slot + " = nullptr;\n";
+    } else {
+      out += Indent(indent + 1) + *type_or + "* " + slot + " = nullptr;\n";
+    }
+  }
+
   if (s.processes.empty() && s.structural_subroutines.empty()) {
     out += Indent(indent) + "};\n";
     return out;

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <variant>
 
+#include "lyra/backend/cpp/formatting.hpp"
 #include "lyra/backend/cpp/render_context.hpp"
 #include "lyra/backend/cpp/render_print.hpp"
 #include "lyra/backend/cpp/render_stmt.hpp"
@@ -249,6 +250,19 @@ auto RenderStructuralVarReadExpr(
     return *name_or + ".Get()";
   }
   return *name_or;
+}
+
+// Read-side render for a cross-unit reference: the slot is a resolved
+// `Var<T>*`, so the held value is observed via `->Get()` (integral packed) or
+// a dereference (other storage), mirroring the structural-var read split.
+auto RenderCrossUnitVarReadExpr(
+    const RenderContext& ctx, const mir::Expr& expr,
+    const mir::CrossUnitVarRef& m) -> diag::Result<std::string> {
+  const std::string slot = CrossUnitRefSlotName(m.id.value);
+  if (ctx.Unit().GetType(expr.type).IsIntegralPacked()) {
+    return slot + "->Get()";
+  }
+  return "(*" + slot + ")";
 }
 
 // Builds the C++ literal that materializes a 1-bit PackedArray of the SV-typed
@@ -1009,6 +1023,10 @@ auto RenderLhsExpr(
             if (!name) return std::unexpected(std::move(name.error()));
             return *name + std::string{mutate_adapter};
           },
+          [&](const mir::CrossUnitVarRef& r) -> diag::Result<std::string> {
+            return "(*" + CrossUnitRefSlotName(r.id.value) + ")" +
+                   std::string{mutate_adapter};
+          },
           [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
             return LookupProceduralVarName(ctx, l);
           },
@@ -1057,16 +1075,26 @@ auto LhsRootPrimary(const RenderContext& ctx, const mir::Expr& expr)
   }
 }
 
-// The root structural var iff the LHS root is one, else nullptr -- used to
-// detect whether the assignment touches an observable scalar.
-auto LhsRootStructuralVarForObservable(
-    const RenderContext& ctx, const mir::Expr& expr)
-    -> const mir::StructuralVarRef* {
-  return std::get_if<mir::StructuralVarRef>(&LhsRootPrimary(ctx, expr).data);
+// Whether the LHS root is an observable scalar -- a structural var or a
+// cross-unit reference slot whose target is an observable scalar type. A write
+// to such a root routes through `Var::Set` / `Var::Mutate` so subscribers fire.
+auto LhsRootIsObservableScalar(const RenderContext& ctx, const mir::Expr& expr)
+    -> bool {
+  const mir::Expr& root = LhsRootPrimary(ctx, expr);
+  if (const auto* sv = std::get_if<mir::StructuralVarRef>(&root.data)) {
+    return IsObservableScalarType(ctx.Unit().GetType(
+        ctx.StructuralScope().GetStructuralVar(sv->var).type));
+  }
+  if (const auto* cu = std::get_if<mir::CrossUnitVarRef>(&root.data)) {
+    return IsObservableScalarType(
+        ctx.Unit().GetType(ctx.StructuralScope().GetCrossUnitRef(cu->id).type));
+  }
+  return false;
 }
 
 auto IsLhsBarePrimary(const mir::Expr& expr) -> bool {
   return std::holds_alternative<mir::StructuralVarRef>(expr.data) ||
+         std::holds_alternative<mir::CrossUnitVarRef>(expr.data) ||
          std::holds_alternative<mir::ProceduralVarRef>(expr.data);
 }
 
@@ -1146,13 +1174,7 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
            *value_or + ")";
   }
 
-  const mir::StructuralVarRef* observable_root =
-      LhsRootStructuralVarForObservable(ctx, lhs_expr);
-  const bool observable = observable_root != nullptr && [&] {
-    const auto& var_decl =
-        ctx.StructuralScope().GetStructuralVar(observable_root->var);
-    return IsObservableScalarType(ctx.Unit().GetType(var_decl.type));
-  }();
+  const bool observable = LhsRootIsObservableScalar(ctx, lhs_expr);
 
   // Whole-var write: route observable structural targets through Var::Set
   // (which fires subscribers), procedural locals get a direct C++ assignment.
@@ -1208,13 +1230,7 @@ auto RenderIncDecExpr(const RenderContext& ctx, const mir::IncDecExpr& inc)
         "implemented in cpp emit",
         diag::UnsupportedCategory::kFeature);
   }
-  const mir::StructuralVarRef* observable_root =
-      LhsRootStructuralVarForObservable(ctx, target_expr);
-  const bool observable = observable_root != nullptr && [&] {
-    const auto& var_decl =
-        ctx.StructuralScope().GetStructuralVar(observable_root->var);
-    return IsObservableScalarType(ctx.Unit().GetType(var_decl.type));
-  }();
+  const bool observable = LhsRootIsObservableScalar(ctx, target_expr);
 
   std::string lhs;
   if (IsLhsBarePrimary(target_expr)) {
@@ -1424,6 +1440,9 @@ auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
           },
           [&](const mir::StructuralVarRef& m) -> diag::Result<std::string> {
             return RenderStructuralVarReadExpr(ctx, expr, m);
+          },
+          [&](const mir::CrossUnitVarRef& m) -> diag::Result<std::string> {
+            return RenderCrossUnitVarReadExpr(ctx, expr, m);
           },
           [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
             const std::string name = LookupProceduralVarName(ctx, l);

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -436,7 +436,7 @@ auto RenderRuntimeCallExpr(
                     *format_or, slot_pieces);
               case support::ScanSourceKind::kFile:
                 return std::format(
-                    "lyra::runtime::LyraFScanf(*services_, {}, {}, {{{}}})",
+                    "lyra::runtime::LyraFScanf(Services(), {}, {}, {{{}}})",
                     *source_or, *format_or, slot_pieces);
             }
             throw InternalError(

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -183,6 +183,19 @@ auto RenderConstructExternalUnitStmt(
       ctx, var.name, var.type, s.unit_name, var.name, s.dims, 0, indent);
 }
 
+// Points the slot at the child member it references, once the child exists.
+// The slot is a `Var<T>*`; the child instance var is an owning pointer, so the
+// member is reached with `->` and its address taken (LRM 23.6 resolved at
+// construction, reference_resolution.md).
+auto RenderResolveCrossUnitRefStmt(
+    const RenderContext& ctx, const mir::ResolveCrossUnitRefStmt& s,
+    std::size_t indent) -> diag::Result<std::string> {
+  const auto& slot = ctx.StructuralScope().GetCrossUnitRef(s.slot);
+  const auto& inst = ctx.StructuralScope().GetStructuralVar(slot.instance_var);
+  return Indent(indent) + CrossUnitRefSlotName(s.slot.value) + " = &" +
+         inst.name + "->" + slot.target_member + ";\n";
+}
+
 auto RenderForStmtNode(
     const RenderContext& ctx, const mir::Stmt& stmt, const mir::ForStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
@@ -249,20 +262,40 @@ auto RenderDoWhileStmtNode(
   return result;
 }
 
+// The Observable pointer a sensitivity leaf subscribes to: a structural var
+// yields the address of its own field; a cross-unit slot is already a resolved
+// `Var<T>*`, so the slot name is the pointer.
+auto RenderSensitivityRefPtr(
+    const RenderContext& ctx, const mir::SensitivityRef& ref)
+    -> diag::Result<std::string> {
+  return std::visit(
+      Overloaded{
+          [&](const mir::StructuralVarRef& r) -> diag::Result<std::string> {
+            auto name = RenderStructuralVarName(ctx, r);
+            if (!name) return std::unexpected(std::move(name.error()));
+            return "&" + *name;
+          },
+          [&](const mir::CrossUnitVarRef& r) -> diag::Result<std::string> {
+            return CrossUnitRefSlotName(r.id.value);
+          },
+      },
+      ref);
+}
+
 auto RenderSensitivityWaitStmt(
     const RenderContext& ctx, const mir::SensitivityWaitStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
   std::string result = Indent(indent) + "co_await lyra::runtime::WaitAny({";
   for (std::size_t i = 0; i < s.reads.size(); ++i) {
     const auto& read = s.reads[i];
-    auto name_or = RenderStructuralVarName(ctx, read.ref);
-    if (!name_or) return std::unexpected(std::move(name_or.error()));
+    auto ptr_or = RenderSensitivityRefPtr(ctx, read.ref);
+    if (!ptr_or) return std::unexpected(std::move(ptr_or.error()));
     if (i != 0) result += ", ";
     // bit_range follows slang's `(lo_bit, hi_bit)` inclusive convention; the
     // runtime Trigger takes `(lsb_offset, width)`.
     const auto lsb = read.bit_range.first;
     const auto width = read.bit_range.second - read.bit_range.first + 1;
-    result += "{&" + *name_or + ", " +
+    result += "{" + *ptr_or + ", " +
               std::string{RenderEventEdgeAsRuntime(read.edge_kind)} + ", " +
               std::to_string(lsb) + "ULL, " + std::to_string(width) + "ULL}";
   }
@@ -309,6 +342,10 @@ auto RenderStmt(
           [&](const mir::ConstructExternalUnitStmt& s)
               -> diag::Result<std::string> {
             return RenderConstructExternalUnitStmt(ctx, s, indent);
+          },
+          [&](const mir::ResolveCrossUnitRefStmt& s)
+              -> diag::Result<std::string> {
+            return RenderResolveCrossUnitRefStmt(ctx, s, indent);
           },
           [&](const mir::ForStmt& s) -> diag::Result<std::string> {
             return RenderForStmtNode(ctx, stmt, s, indent);

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -460,8 +460,25 @@ class HirDumper {
               return std::format(
                   "LoopVar[{}](hops={})", r.loop_var.value, r.hops.value);
             },
+            [](const CrossUnitVarRef& r) -> std::string {
+              return std::format("CrossUnitRef[{}]", r.id.value);
+            },
         },
         p);
+  }
+
+  static auto FormatSensitivityRef(const SensitivityRef& ref) -> std::string {
+    return std::visit(
+        Overloaded{
+            [](const StructuralVarRef& r) -> std::string {
+              return std::format(
+                  "hops={} var=StructuralVar[{}]", r.hops.value, r.var.value);
+            },
+            [](const CrossUnitVarRef& r) -> std::string {
+              return std::format("cross_unit_ref={}", r.id.value);
+            },
+        },
+        ref);
   }
 
   static auto FormatEventEdge(EventEdge edge) -> std::string_view {
@@ -499,8 +516,8 @@ class HirDumper {
                   if (j != 0) out += ", ";
                   const auto& r = e.triggers[i].sensitivity_list[j];
                   out += std::format(
-                      "{{hops={} var=StructuralVar[{}] bits=[{}:{}] edge={}}}",
-                      r.ref.hops.value, r.ref.var.value, r.bit_range.first,
+                      "{{{} bits=[{}:{}] edge={}}}",
+                      FormatSensitivityRef(r.ref), r.bit_range.first,
                       r.bit_range.second, FormatEventEdge(r.edge_kind));
                 }
                 out += "]}";
@@ -514,9 +531,9 @@ class HirDumper {
                 if (i != 0) out += ", ";
                 const auto& r = ie.sensitivity_list[i];
                 out += std::format(
-                    "{{hops={} var=StructuralVar[{}] bits=[{}:{}] edge={}}}",
-                    r.ref.hops.value, r.ref.var.value, r.bit_range.first,
-                    r.bit_range.second, FormatEventEdge(r.edge_kind));
+                    "{{{} bits=[{}:{}] edge={}}}", FormatSensitivityRef(r.ref),
+                    r.bit_range.first, r.bit_range.second,
+                    FormatEventEdge(r.edge_kind));
               }
               out += "]";
               return out;
@@ -915,9 +932,8 @@ class HirDumper {
       for (const auto& r : p.implicit_sensitivity_list) {
         Line(
             std::format(
-                "StructuralVarRef hops={} var=StructuralVar[{}] bits=[{}:{}]",
-                r.ref.hops.value, r.ref.var.value, r.bit_range.first,
-                r.bit_range.second));
+                "{} bits=[{}:{}]", FormatSensitivityRef(r.ref),
+                r.bit_range.first, r.bit_range.second));
       }
       Dedent();
     }
@@ -962,9 +978,8 @@ class HirDumper {
       for (const auto& r : ca.sensitivity_list) {
         Line(
             std::format(
-                "StructuralVarRef hops={} var=StructuralVar[{}] bits=[{}:{}]",
-                r.ref.hops.value, r.ref.var.value, r.bit_range.first,
-                r.bit_range.second));
+                "{} bits=[{}:{}]", FormatSensitivityRef(r.ref),
+                r.bit_range.first, r.bit_range.second));
       }
       Dedent();
     }
@@ -1315,9 +1330,8 @@ class HirDumper {
                 if (i != 0) sens += ", ";
                 const auto& r = w.sensitivity_list[i];
                 sens += std::format(
-                    "{{hops={} var=StructuralVar[{}] bits=[{}:{}]}}",
-                    r.ref.hops.value, r.ref.var.value, r.bit_range.first,
-                    r.bit_range.second);
+                    "{{{} bits=[{}:{}]}}", FormatSensitivityRef(r.ref),
+                    r.bit_range.first, r.bit_range.second);
               }
               sens += "]";
               Line(

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include <slang/ast/Expression.h>
+#include <slang/ast/HierarchicalReference.h>
 #include <slang/ast/SemanticFacts.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/SystemSubroutine.h>
@@ -18,6 +19,7 @@
 #include <slang/ast/expressions/MiscExpressions.h>
 #include <slang/ast/expressions/OperatorExpressions.h>
 #include <slang/ast/expressions/SelectExpressions.h>
+#include <slang/ast/symbols/InstanceSymbols.h>
 #include <slang/ast/symbols/ParameterSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
@@ -280,6 +282,87 @@ auto LowerNamedValueProc(
   return MakeRefExpr(
       hir::StructuralVarRef{.hops = *hops, .var = binding->var_id},
       binding->type, span);
+}
+
+// LRM 23.6 hierarchical reference. Resolves the downward, single-level scalar
+// form (`c.x`, `c` a direct child instance of the referring scope) into a
+// cross-unit reference slot; the slot's navigation recipe and the constructor
+// resolution live downstream (reference_resolution.md). Upward, multi-level,
+// instance-array, and interface-port forms are rejected explicitly here so they
+// never lower into a silently-wrong shape.
+auto LowerHierarchicalValueProc(
+    const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
+    const ScopeStack& stack, const slang::ast::HierarchicalValueExpression& hve)
+    -> diag::Result<hir::Expr> {
+  const auto span = unit_facts.SourceMapper().SpanOf(hve.sourceRange);
+  const auto& ref = hve.ref;
+
+  if (ref.isViaIfacePort()) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "interface-port hierarchical reference is not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  if (ref.isUpward()) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "upward hierarchical reference is not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+
+  const auto& target = hve.symbol;
+  if (target.kind != slang::ast::SymbolKind::Variable) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "cross-unit reference to a non-variable declaration is not yet "
+        "supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+
+  // Single-level downward: the referenced member must be a direct member of a
+  // child instance body. A deeper target (`c.gen.x`) sits in a nested scope and
+  // is a multi-level reference, which is not yet supported.
+  const slang::ast::Scope* parent = target.getParentScope();
+  if (parent == nullptr ||
+      parent->asSymbol().kind != slang::ast::SymbolKind::InstanceBody) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "multi-level hierarchical reference is not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  const slang::ast::InstanceSymbol* inst =
+      parent->asSymbol().as<slang::ast::InstanceBodySymbol>().parentInstance;
+  if (inst == nullptr) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "hierarchical reference target has no instance parent",
+        diag::UnsupportedCategory::kFeature);
+  }
+
+  const auto inst_binding = unit_state.LookupInstanceMemberBinding(*inst);
+  if (!inst_binding.has_value()) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "hierarchical reference through this instance form is not yet "
+        "supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  const auto hops = stack.HopsTo(inst_binding->home_frame);
+  if (!hops.has_value() || hops->value != 0) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "multi-level hierarchical reference is not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, hve);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+
+  const auto& var = target.as<slang::ast::VariableSymbol>();
+  const hir::CrossUnitRefId slot = unit_state.MapOrGetCrossUnitRef(
+      var, inst_binding->home_frame, inst_binding->member_id,
+      std::string{var.name}, *type_id);
+  return MakeRefExpr(hir::CrossUnitVarRef{.id = slot}, *type_id, span);
 }
 
 auto LowerNamedValueStructural(
@@ -1386,6 +1469,11 @@ auto LowerProcExpr(
           unit_facts, unit_state, proc_state, stack,
           expr.as<slang::ast::NamedValueExpression>());
 
+    case slang::ast::ExpressionKind::HierarchicalValue:
+      return LowerHierarchicalValueProc(
+          unit_facts, unit_state, stack,
+          expr.as<slang::ast::HierarchicalValueExpression>());
+
     case slang::ast::ExpressionKind::LValueReference:
       throw InternalError(
           "LowerProcExpr: slang LValueReference must not reach HIR; "
@@ -1675,6 +1763,22 @@ auto ValidateAssignableSlangExpr(
       }
       return ValidateAssignableSlangExpr(
           unit_facts, unit_state, proc_state, ma.value());
+    }
+    case EK::HierarchicalValue: {
+      // A downward cross-unit write (`c.x = ...`). The downward / single-level
+      // / scalar guard and the slot creation run during lowering
+      // (LowerHierarchicalValueProc on the assignment target); validation only
+      // confirms the target is a variable. A continuous-assignment context has
+      // no process, and cross-unit continuous-assign targets are deferred.
+      const auto& hv = expr.as<slang::ast::HierarchicalValueExpression>();
+      if (hv.symbol.kind != slang::ast::SymbolKind::Variable) {
+        return reject("assignment target must be a variable reference");
+      }
+      if (proc_state == nullptr) {
+        return reject(
+            "continuous-assignment target must be a structural variable");
+      }
+      return {};
     }
     case EK::Concatenation: {
       const auto& cc = expr.as<slang::ast::ConcatenationExpression>();

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -248,11 +248,16 @@ auto LowerIfOrCaseGenerateMemberInto(
 auto LowerInstanceMemberInto(
     ScopeLoweringState& scope_state, const slang::ast::InstanceSymbol& inst)
     -> diag::Result<void> {
-  scope_state.AddInstanceMember(
+  const hir::InstanceMemberId member_id = scope_state.AddInstanceMember(
       hir::InstanceMemberDecl{
           .instance_name = std::string{inst.name},
           .target_unit = std::string{inst.getDefinition().name},
           .array_dims = {}});
+  // A downward cross-unit reference (`c.x`) resolves the leading `c` to this
+  // member; the binding lets process-body lowering find it regardless of
+  // source order.
+  scope_state.UnitState().MapInstanceMemberBinding(
+      inst, scope_state.Frame(), member_id);
   return {};
 }
 
@@ -315,13 +320,9 @@ auto LowerScopeMemberInto(
       return LowerIfOrCaseGenerateMemberInto(
           unit_facts, scope_state, stack,
           member.as<slang::ast::GenerateBlockSymbol>(), slang_scope);
-    case slang::ast::SymbolKind::Instance:
-      return LowerInstanceMemberInto(
-          scope_state, member.as<slang::ast::InstanceSymbol>());
-    case slang::ast::SymbolKind::InstanceArray:
-      return LowerInstanceArrayMemberInto(
-          scope_state, member.as<slang::ast::InstanceArraySymbol>());
     default:
+      // Instance / InstanceArray members are lowered in a pre-pass (see
+      // LowerScopeMembersInto); every other member kind is not modeled.
       return {};
   }
 }
@@ -345,8 +346,28 @@ auto LowerScopeMembersInto(
     }
   }
 
+  // Instance members are lowered ahead of process bodies so a downward
+  // cross-unit reference (`c.x`) resolves its leading `c` even when the
+  // referencing process precedes the instance in source order (declarations
+  // are scope-wide). The main pass below skips them.
+  for (const auto& member : slang_scope.members()) {
+    if (member.kind == slang::ast::SymbolKind::Instance) {
+      auto r = LowerInstanceMemberInto(
+          scope_state, member.as<slang::ast::InstanceSymbol>());
+      if (!r) return std::unexpected(std::move(r.error()));
+    } else if (member.kind == slang::ast::SymbolKind::InstanceArray) {
+      auto r = LowerInstanceArrayMemberInto(
+          scope_state, member.as<slang::ast::InstanceArraySymbol>());
+      if (!r) return std::unexpected(std::move(r.error()));
+    }
+  }
+
   std::unordered_set<std::uint32_t> consumed_construct_indices;
   for (const auto& member : slang_scope.members()) {
+    if (member.kind == slang::ast::SymbolKind::Instance ||
+        member.kind == slang::ast::SymbolKind::InstanceArray) {
+      continue;
+    }
     if (member.kind == slang::ast::SymbolKind::GenerateBlock) {
       const auto& block = member.as<slang::ast::GenerateBlockSymbol>();
       if (!consumed_construct_indices.insert(block.constructIndex).second) {
@@ -379,7 +400,10 @@ auto LowerScopeInto(
     unit_state.MapLoopVarBinding(
         *binding.symbol, binding.home_frame, binding.loop_var, binding.type);
   }
-  return LowerScopeMembersInto(unit_facts, scope_state, stack, slang_scope);
+  auto r = LowerScopeMembersInto(unit_facts, scope_state, stack, slang_scope);
+  if (!r) return std::unexpected(std::move(r.error()));
+  scope.cross_unit_refs = unit_state.TakeCrossUnitRefsForFrame(guard.Frame());
+  return {};
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/sensitivity.cpp
+++ b/src/lyra/lowering/ast_to_hir/sensitivity.cpp
@@ -93,14 +93,27 @@ auto TranslateSensitivityReads(
   for (const auto& read : reads) {
     const auto* var = read.symbol->as_if<slang::ast::VariableSymbol>();
     if (var == nullptr) continue;
-    const auto binding = unit_state.LookupStructuralVarBinding(*var);
-    if (!binding.has_value()) continue;
-    const auto hops = stack.HopsTo(binding->home_frame);
-    if (!hops.has_value()) continue;
-    out.push_back(
-        hir::SensitivityEntry{
-            .ref = hir::StructuralVarRef{.hops = *hops, .var = binding->var_id},
-            .bit_range = read.bit_range});
+    if (const auto binding = unit_state.LookupStructuralVarBinding(*var)) {
+      const auto hops = stack.HopsTo(binding->home_frame);
+      if (!hops.has_value()) continue;
+      out.push_back(
+          hir::SensitivityEntry{
+              .ref =
+                  hir::StructuralVarRef{.hops = *hops, .var = binding->var_id},
+              .bit_range = read.bit_range});
+      continue;
+    }
+    // A read of a cross-unit member resolves to the slot that body lowering
+    // created for it; subscribing through the slot is what makes always_comb
+    // re-trigger on a child's signal. Any symbol that is neither a structural
+    // var nor a cross-unit slot is not an observable this unit drives, so it is
+    // not a sensitivity source.
+    if (const auto slot = unit_state.LookupCrossUnitRef(*var)) {
+      out.push_back(
+          hir::SensitivityEntry{
+              .ref = hir::CrossUnitVarRef{.id = *slot},
+              .bit_range = read.bit_range});
+    }
   }
   return out;
 }

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -178,10 +178,16 @@ auto MakeExternalUnitMemberType(
   return type;
 }
 
-void InstallInstanceMembers(
+// Returns the StructuralVarId of each instance member, indexed by
+// InstanceMemberId, so cross-unit reference resolution can reach the child
+// instance var by the same id the HIR recipe carries.
+auto InstallInstanceMembers(
     UnitLoweringState& unit_state, StructuralScopeLoweringState& scope_state,
     const hir::StructuralScope& scope,
-    ProceduralScopeLoweringState& ctor_scope_state) {
+    ProceduralScopeLoweringState& ctor_scope_state)
+    -> std::vector<mir::StructuralVarId> {
+  std::vector<mir::StructuralVarId> instance_member_vars;
+  instance_member_vars.reserve(scope.instance_members.size());
   for (const auto& im : scope.instance_members) {
     for (const auto& v : scope_state.Scope().structural_vars) {
       if (v.name == im.instance_name) {
@@ -197,6 +203,7 @@ void InstallInstanceMembers(
     const mir::StructuralVarId var_id = scope_state.AddStructuralVar(
         mir::StructuralVarDecl{
             .name = im.instance_name, .type = var_type, .initializer = init});
+    instance_member_vars.push_back(var_id);
 
     const mir::StmtId sid = ctor_scope_state.AddStmt(
         mir::Stmt{
@@ -206,6 +213,32 @@ void InstallInstanceMembers(
                     .target = var_id,
                     .unit_name = im.target_unit,
                     .dims = im.array_dims},
+            .child_procedural_scopes = {}});
+    ctor_scope_state.AddRootStmt(sid);
+  }
+  return instance_member_vars;
+}
+
+// Cross-unit references resolve once at construction, after the child
+// instances are built (reference_resolution.md). Each slot's resolution
+// statement runs at the tail of the constructor body.
+void InstallCrossUnitRefs(
+    UnitLoweringState& unit_state, StructuralScopeLoweringState& scope_state,
+    const hir::StructuralScope& scope,
+    const std::vector<mir::StructuralVarId>& instance_member_vars,
+    ProceduralScopeLoweringState& ctor_scope_state) {
+  for (const auto& cu : scope.cross_unit_refs) {
+    const mir::StructuralVarId instance_var =
+        instance_member_vars.at(cu.instance.value);
+    const mir::CrossUnitRefId slot = scope_state.AddCrossUnitRef(
+        mir::CrossUnitRefDecl{
+            .instance_var = instance_var,
+            .target_member = cu.target_member,
+            .type = unit_state.TranslateType(cu.type)});
+    const mir::StmtId sid = ctor_scope_state.AddStmt(
+        mir::Stmt{
+            .label = std::nullopt,
+            .data = mir::ResolveCrossUnitRefStmt{.slot = slot},
             .child_procedural_scopes = {}});
     ctor_scope_state.AddRootStmt(sid);
   }
@@ -546,6 +579,7 @@ auto LowerStructuralScope(
       .name = std::move(name),
       .structural_params = {},
       .structural_vars = {},
+      .cross_unit_refs = {},
       .constructor_scope = {},
       .processes = {},
       .child_structural_scopes = {},
@@ -639,7 +673,10 @@ auto LowerStructuralScope(
     ctor_scope_state.AddRootStmt(sid);
   }
 
-  InstallInstanceMembers(unit_state, scope_state, scope, ctor_scope_state);
+  const auto instance_member_vars =
+      InstallInstanceMembers(unit_state, scope_state, scope, ctor_scope_state);
+  InstallCrossUnitRefs(
+      unit_state, scope_state, scope, instance_member_vars, ctor_scope_state);
 
   scope_state.SetConstructorScope(ctor_scope_state.Finish());
 

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -510,6 +510,11 @@ auto LowerHirPrimaryProc(
           [&](const hir::LoopVarRef& lv) -> mir::Expr {
             return LowerStructuralParamRefExpr(scope_state, lv, type);
           },
+          [&](const hir::CrossUnitVarRef& c) -> mir::Expr {
+            return mir::Expr{
+                .data = mir::CrossUnitVarRef{.id = {.value = c.id.value}},
+                .type = type};
+          },
       },
       p);
 }
@@ -551,6 +556,12 @@ auto LowerHirPrimaryStructural(
               return LowerLoopVarRefExpr(*ctor_state, lv, type);
             }
             return LowerStructuralParamRefExpr(scope_state, lv, type);
+          },
+          [](const hir::CrossUnitVarRef&) -> mir::Expr {
+            throw InternalError(
+                "LowerHirPrimaryStructural: HIR CrossUnitVarRef does not "
+                "appear "
+                "in constructor expressions");
           },
       },
       p);

--- a/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
+++ b/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
@@ -1,12 +1,15 @@
 #include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
 
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/base/overloaded.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/stmt.hpp"
+#include "lyra/mir/value_ref.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -34,10 +37,19 @@ auto BuildSensitivityWaitStmt(
   std::vector<mir::SensitivityRead> reads;
   reads.reserve(sensitivity_list.size());
   for (const auto& entry : sensitivity_list) {
+    mir::SensitivityRef ref = std::visit(
+        Overloaded{
+            [&](const hir::StructuralVarRef& r) -> mir::SensitivityRef {
+              return scope_state.TranslateStructuralVar(r.hops, r.var);
+            },
+            [](const hir::CrossUnitVarRef& r) -> mir::SensitivityRef {
+              return mir::CrossUnitVarRef{.id = {.value = r.id.value}};
+            },
+        },
+        entry.ref);
     reads.push_back(
         mir::SensitivityRead{
-            .ref = scope_state.TranslateStructuralVar(
-                entry.ref.hops, entry.ref.var),
+            .ref = std::move(ref),
             .bit_range = entry.bit_range,
             .edge_kind = LowerEventEdge(entry.edge_kind)});
   }

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -443,6 +443,9 @@ class MirDumper {
                   "ProceduralVarRef[hops={}, var={}] \"{}\"", r.hops.value,
                   r.var.value, var.name);
             },
+            [](const CrossUnitVarRef& r) -> std::string {
+              return std::format("CrossUnitVarRef[slot={}]", r.id.value);
+            },
             [](const UnaryExpr& u) -> std::string {
               return std::format(
                   "UnaryExpr op={} operand=Expr[{}]", FormatUnaryOp(u.op),
@@ -595,6 +598,19 @@ class MirDumper {
               FormatVarType(v.type), v.initializer.value));
     }
     Dedent();
+
+    if (!s.cross_unit_refs.empty()) {
+      Line("CrossUnitRefs:");
+      Indent();
+      for (std::size_t i = 0; i < s.cross_unit_refs.size(); ++i) {
+        const auto& cu = s.cross_unit_refs[i];
+        Line(
+            std::format(
+                "[{}] StructuralVar[{}].\"{}\" : {}", i, cu.instance_var.value,
+                cu.target_member, FormatVarType(cu.type)));
+      }
+      Dedent();
+    }
 
     Line("StructuralSubroutines:");
     Indent();
@@ -923,6 +939,12 @@ class MirDumper {
             [&](const ConstructExternalUnitStmt& s) {
               DumpConstructExternalUnitStmt(id, s);
             },
+            [&](const ResolveCrossUnitRefStmt& s) {
+              Line(
+                  std::format(
+                      "Stmt[{}] ResolveCrossUnitRefStmt slot={}", id.value,
+                      s.slot.value));
+            },
             [&](const ForStmt& s) { DumpForStmt(stmt, s, enclosing, id); },
             [&](const DelayStmt& d) {
               Line(
@@ -959,11 +981,22 @@ class MirDumper {
               Line(std::format("Stmt[{}] SensitivityWaitStmt", id.value));
               Indent();
               for (const auto& r : s.reads) {
+                const std::string ref_str = std::visit(
+                    Overloaded{
+                        [](const StructuralVarRef& sv) -> std::string {
+                          return std::format(
+                              "StructuralVarRef hops={} var=StructuralVar[{}]",
+                              sv.hops.value, sv.var.value);
+                        },
+                        [](const CrossUnitVarRef& cu) -> std::string {
+                          return std::format(
+                              "CrossUnitVarRef slot={}", cu.id.value);
+                        },
+                    },
+                    r.ref);
                 Line(
                     std::format(
-                        "StructuralVarRef hops={} var=StructuralVar[{}] "
-                        "bits=[{}:{}] edge={}",
-                        r.ref.hops.value, r.ref.var.value, r.bit_range.first,
+                        "{} bits=[{}:{}] edge={}", ref_str, r.bit_range.first,
                         r.bit_range.second, FormatEventEdge(r.edge_kind)));
               }
               Dedent();

--- a/tests/cases/cpp/hierarchy_xunit_comb/case.yaml
+++ b/tests/cases/cpp/hierarchy_xunit_comb/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_xunit_comb
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "r=7\n"

--- a/tests/cases/cpp/hierarchy_xunit_comb/main.sv
+++ b/tests/cases/cpp/hierarchy_xunit_comb/main.sv
@@ -1,0 +1,17 @@
+module Child;
+  int x;
+  initial begin
+    x = 1;
+    #1 x = 7;
+  end
+endmodule
+
+module Top;
+  Child c();
+  int r;
+  always_comb r = c.x;
+  initial begin
+    #2;
+    $display("r=%0d", r);
+  end
+endmodule

--- a/tests/cases/cpp/hierarchy_xunit_read/case.yaml
+++ b/tests/cases/cpp/hierarchy_xunit_read/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_xunit_read
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "r=42\n"

--- a/tests/cases/cpp/hierarchy_xunit_read/main.sv
+++ b/tests/cases/cpp/hierarchy_xunit_read/main.sv
@@ -1,0 +1,14 @@
+module Child;
+  int x;
+  initial x = 42;
+endmodule
+
+module Top;
+  Child c();
+  int r;
+  initial begin
+    #1;
+    r = c.x;
+    $display("r=%0d", r);
+  end
+endmodule

--- a/tests/cases/cpp/hierarchy_xunit_write/case.yaml
+++ b/tests/cases/cpp/hierarchy_xunit_write/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_xunit_write
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "r=99\n"

--- a/tests/cases/cpp/hierarchy_xunit_write/main.sv
+++ b/tests/cases/cpp/hierarchy_xunit_write/main.sv
@@ -1,0 +1,14 @@
+module Child;
+  int x;
+endmodule
+
+module Top;
+  Child c();
+  int r;
+  initial begin
+    c.x = 99;
+    #1;
+    r = c.x;
+    $display("r=%0d", r);
+  end
+endmodule


### PR DESCRIPTION
## Summary

This lands the non-local access substrate (Stage C) and the downward, single-level slice of hierarchical references (Stage D1) from the multi-module hierarchy workstream. A reference like `always_comb r = c.x;` where `c` is a child instance now reads, writes, and re-triggers correctly. Its target lives in another compilation unit whose layout is not visible while this unit compiles, so the reference cannot be resolved at compile time; instead it resolves once at construction into a stored direct reference and is read directly thereafter, exactly as `reference_resolution.md` requires.

## Design

A cross-unit reference becomes a per-scope slot. During AST-to-HIR each `c.x` registers a slot recording which owned child instance to reach into and the child's interface member name, and the expression becomes a `CrossUnitVarRef`. HIR-to-MIR translates the slot's child to the structural var that holds the constructed instance and appends a resolution statement to the tail of the constructor, after the child is built. The backend emits the slot as a resolved pointer member, points it at `&child->member` in the constructor, and renders every read, write, and sensitivity subscription through it. Because the pointed-at member is both the value store and its own change source, reading and observing share the one reference, so cross-instance sensitivity needs no new runtime mechanism. This resolve-once slot is the single path that ports (Stage E) will populate, so hierarchical references and ports never grow two parallel resolution mechanisms.

Upward references, multi-level dotted paths, instance-array indices in the path, interface-port references, and cross-unit references in a constructor context are each rejected with an explicit diagnostic rather than lowering into a silently-wrong shape. Instance members are registered in a pre-pass so a process that references an instance declared later in source still resolves.

This also fixes the emitted `$fscanf` call to reach runtime services through `Services()` rather than the now-private `services_` member.

## Testing

`bazel test //...` is green. New cases cover the downward read, the write round-trip, and an `always_comb` that re-triggers when the child signal changes.