### PR TITLE
Resolve time precision to a design-global minimum

### DIFF
--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -11,8 +11,8 @@ since the test harness can only probe a variable whose type has an implemented s
       byte's X/Z poison collapses to a single character following simulator convention -- any X bit
       yields `x`, otherwise any Z bit yields `z`. Width / precision modifiers are rejected by the
       slang frontend, so the lowered form is always a single character.
-- [ ] DI2 -- `%t` (time): formatted against the active timescale. Requires a time variant in the
-      runtime value surface and time-unit awareness on the format spec.
+- [ ] DI2 -- `%t` (time): formatted against the active timescale. Tracked in `timescale.md` TS3; it
+      rides on the design-global precision and scope-unit scaling that workstream establishes.
 - [x] DI3 -- `%f` / `%e` / `%g` (real). Default precision 6 per LRM Table 21-2. Coverage tracked
       under `datatypes.md` Real C1.
 - [ ] DI4 -- `%m` (hierarchical name). Requires runtime exposure of the current scope's hierarchical

--- a/docs/progress/fork-join.md
+++ b/docs/progress/fork-join.md
@@ -1,0 +1,119 @@
+# Fork-join parallel blocks
+
+Tracks the `fork` ... `join` / `join_any` / `join_none` parallel-block construct (LRM 9.3.2) and the
+process-control statements that act on the threads it spawns (LRM 9.6). A parallel block turns each
+of its parallel statements into a concurrently scheduled process; the join keyword decides when the
+forking (parent) process resumes. This is the first construct in the corpus where one process
+dynamically creates more processes, so it rides directly on the suspending-coroutine machinery
+established for time-consuming tasks (`functions.md` T2) and the timing controls owned by
+`processes.md`.
+
+Done when the LRM 9.3.2 parallel block reproduces: all three join modes, timing inside branches,
+nested and sequential-block composition, per-branch local storage and the loop-spawn idiom, named
+fork blocks, and the `wait fork` / `disable fork` controls over the spawned threads. The concurrency
+is logical, not physical: spawned processes are interleaved on the one shared time axis by the same
+single scheduler that already runs `initial` / `always` processes.
+
+The `FJ*` IDs are stable references and do not impose a total order, but FJ1 is the foundation every
+other item builds on.
+
+## Background semantics
+
+The three control options (LRM Table 9-1) differ only in when the parent resumes:
+
+- `join` -- parent blocks until **all** spawned processes terminate.
+- `join_any` -- parent blocks until **any one** spawned process terminates.
+- `join_none` -- parent **continues immediately**, concurrently with the spawned processes.
+
+One ordering rule governs all three (LRM 9.3.2): processes spawned by a fork do not start executing
+until the parent process blocks (at the join) or terminates. `join_none` is the zero-threshold case
+of the same wait -- resume after zero completions -- `join_any` the one-completion case, and `join`
+the all-completions case; they are one mechanism parameterized by a threshold, not three separate
+constructs.
+
+## Sub-Steps
+
+### Spawning and the join condition
+
+- [ ] FJ1 -- A fork spawns each parallel statement as its own concurrent process, and the join
+      keyword sets when the forking process resumes: after all of them (`join`), after the first
+      (`join_any`), or immediately (`join_none`). The LRM 9.3.2 ordering rule holds -- spawned
+      processes do not run until the parent blocks at the join or terminates. Minimal end-to-end
+      shape: single-statement branches with no internal timing, where each join mode is observable
+      through the order in which the parent and the branches write shared state.
+
+### Timing across branches
+
+- [ ] FJ2 -- A delay, event control, or `wait` inside a forked branch suspends that branch
+      independently while its siblings proceed; the join condition observes each branch's actual
+      completion time, so `join` resumes the parent only after the slowest branch elapses and
+      `join_any` after the earliest. Rides on the timing-control machinery (`processes.md` T1,
+      T2..T5, P11) and the suspending-task work (`functions.md` T2).
+
+### Composition
+
+- [ ] FJ3 -- Branches compose: a branch may be a begin-end sequential block (one process running
+      several statements in order), and a fork may nest inside another fork's branch, building a
+      tree of concurrent processes. A whole fork wrapped in a begin-end block is a single sequential
+      process (LRM 9.3.2).
+
+### Per-branch storage
+
+- [ ] FJ4 -- Variables declared in the fork block scope are initialized on entry, before any process
+      is spawned (LRM 9.3.2). The loop-spawn idiom -- a fork inside a loop whose branch declares an
+      automatic local capturing the loop variable -- gives each spawned process its own
+      per-iteration copy. In `join_any` / `join_none` blocks it is illegal to refer to a
+      subroutine's formal arguments by reference except in those initializers, unless the formal is
+      declared `ref static` (LRM 9.3.2).
+
+### Naming
+
+- [ ] FJ5 -- A fork block may be named (`fork : name ... join : name`) or labelled, creating a
+      hierarchy scope (LRM 9.3.4, 9.3.5). This is the handle that process-control statements and
+      hierarchical references address.
+
+### Process control over spawned threads
+
+- [ ] FJ6 -- `wait fork` blocks the current process until all of its immediate child processes (not
+      their descendants) have terminated (LRM 9.6.1).
+- [ ] FJ7 -- `disable fork` terminates all descendant processes of the calling process, including
+      descendants of subprocesses that have already terminated (LRM 9.6.3).
+
+## Blocked
+
+- The runtime side of FJ1 -- a running process bringing new processes into being mid-simulation, and
+  the ownership and scheduling of those children -- rides on the single object-tree refactor
+  (`refactor.md` R3). Today processes are born only at construction and the scheduler walks a
+  topology tree mirrored at bind time; fork needs processes created during simulation that attach to
+  the live hierarchy. Designing the spawn / ownership substrate against the current dual-tree shape
+  would be invalidated when R3 collapses it, so the runtime design waits on R3. The suspending-
+  coroutine and join-barrier machinery this builds on is settled (`functions.md` T2). The LRM
+  semantics above, the join threshold model, and the fork statement's IR representation are
+  independent of R3.
+
+## Rejected at the frontend
+
+- A `return` statement inside a fork-join block is a compile error: the branch lives in a separate
+  process (LRM 9.3.2).
+- A function body may contain only `fork ... join_none`, never `join` or `join_any`, because a
+  function cannot suspend (LRM 13.4). See `functions.md`.
+
+## Out of Scope
+
+- `disable` of a named block or task (LRM 9.6.2) as a general control-flow construct. It interacts
+  with fork (disabling a named fork block) but is a broader process-control feature, tracked
+  separately.
+- `wait_order` (LRM 15.6).
+- `std::process` and dynamic process handles (LRM 9.7): process introspection and `status` / `kill`
+  / `await` / `suspend` / `resume` on a process object.
+
+## Cross-references
+
+- LRM anchors: 9.3.2 (parallel blocks, Table 9-1 join control, ordering rule), 9.3.3 (start / finish
+  times), 9.3.4 (block names), 9.3.5 (statement labels), 9.5 (process execution threads), 9.6.1
+  (`wait fork`), 9.6.3 (`disable fork`); 13.4 (`fork ... join_none` inside functions).
+- Rides on: `functions.md` T2 (suspending-coroutine machinery), `processes.md` timing controls (T1,
+  T2..T5, P11).
+- Archive: the archived corpus has no dedicated fork-join feature tests and no fork-join
+  implementation; `fork ... join_any` appears only as scaffolding inside one edge-trigger test.
+  Nothing to port.

--- a/docs/progress/processes.md
+++ b/docs/progress/processes.md
@@ -14,7 +14,6 @@ machinery owned by other workstreams; see [Blocked](#blocked).
 
 | Item   | Blocked on                                                                                                                                                            |
 | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| P8     | `fork` / `join_*`. Needs concurrent-process scheduling primitives; out of scope until single-process work is settled.                                                 |
 | P12    | Process generate; rides on the existing P1..P11 surface, mostly frontend elaboration.                                                                                 |
 | T2..T5 | Compound event expressions (concatenation, arithmetic, dynamic index): needs the snapshot + re-eval wrapper at HIR -> MIR plus a runtime edge-classifier helper.      |
 | T2..T5 | Ascending / negative-base packed ranges (`logic [0:7]`, `logic [-1:6]`): runtime `PackedArray::ElementAt` does not yet honor LRM direction translation on write side. |
@@ -78,10 +77,9 @@ machinery owned by other workstreams; see [Blocked](#blocked).
 
 ### Concurrency
 
-- [ ] P8 -- `fork` / `join` / `join_any` / `join_none` (LRM 9.3). Spawns child coroutines; parent
-      suspends until the join condition is met. Distinct from every other procedural construct
-      because the body produces multiple parallel threads. Deferred until the single-process surface
-      is settled.
+- [ ] P8 -- `fork` / `join` / `join_any` / `join_none` (LRM 9.3). Spawns concurrent processes; the
+      parent resumes per the join condition. Now tracked in its own workstream (`fork-join.md`),
+      unblocked: the single-process timing surface (T1, T2..T5, P9, P11) is settled.
 
 ### Generate
 

--- a/docs/progress/timescale.md
+++ b/docs/progress/timescale.md
@@ -1,0 +1,99 @@
+# Timescale and simulation time
+
+Tracks the timescale surface: time-unit / time-precision resolution, delay scaling, the
+design-global time precision, and the system functions that read and print simulation time (`$time`,
+`$realtime`, `$stime`, `%t`, `$timeformat`, `$printtimescale`).
+
+Time already advances correctly for designs that use a single time precision. This workstream closes
+the two remaining gaps: the design-global precision unification that makes mixed-precision designs
+correct (LRM 3.14.3), and the observation surface that lets a design read and format the current
+simulation time. Done when a mixed-precision design schedules delays on one consistent time axis,
+the query functions report time in the calling scope's unit, and `%t` formats time against the
+`$timeformat` display unit.
+
+The `TS*` IDs are stable references and do not impose a total order, but TS1 is the keystone the
+others read from.
+
+## Already in place
+
+- Time unit and precision are resolved per design element from `` `timescale `` / `timeunit` /
+  `timeprecision` (LRM 3.14.2, precedence per 3.14.2.3) and carried through lowering, one resolved
+  unit and precision per scope.
+- `#N` delays and time literals (`#5ns`) scale to integer simulation ticks. The tick is the
+  design-global time precision -- the finest precision across the whole design (LRM 3.14.3) -- so a
+  design that mixes precisions schedules every delay on one consistent time axis.
+- The `time` and `realtime` data types exist and time literals lower to values.
+
+## Sub-Steps
+
+### Global precision
+
+- [x] TS1 -- Unify on a single design-global time precision: the minimum precision across the whole
+      design (LRM 3.14.3). It is the engine's tick, the denominator every delay scales against
+      (numerator stays the delay's own scope unit), and the basis the query / format functions scale
+      back from. Mixed-precision designs schedule on one consistent time axis; single-precision
+      designs (scaling factor one) are unchanged.
+
+### Reading simulation time
+
+- [ ] TS2 -- `$time`, `$realtime`, `$stime` (LRM 20.3): return the current simulation time scaled to
+      the time unit of the calling code's lexical scope -- the design element that contains the
+      call, not the activation that runs it. Time unit is a static per-design-element property (LRM
+      3.14.2), so a subroutine uses its declaration scope's unit even when enabled across a unit
+      boundary (LRM 20.3.1). `$time` rounds to an integer in scope units, `$realtime` keeps the
+      fractional part, `$stime` is the 32-bit truncation. Rides on TS1 for the global-precision
+      basis to scale from.
+
+### Formatting simulation time
+
+- [ ] TS3 -- `%t` time format (LRM 21.2), `$timeformat` (LRM 20.4.3) and `$printtimescale` (LRM
+      20.4.2): `%t` formats a time value against the `$timeformat` settings -- a display unit,
+      fractional-digit count, suffix, and minimum field width, defaulting to the smallest precision
+      across all timescale directives. The display unit is `$timeformat`'s, applied design-wide, not
+      the calling scope's unit, so it is uniform across the design (distinct from TS2's per-scope
+      scaling). Closes `display.md` DI2. Rides on TS1.
+
+## Design direction
+
+- The global time precision is a design-global value, in the same category as net resolution -- a
+  design-global concern that sits outside the per-unit compilation model (`reference_resolution.md`
+  carves out that category explicitly). It is not part of any unit's class-level artifact: baking it
+  in would make a unit's compiled form depend on the design it happens to sit in, which
+  `compilation_unit_model.md` forbids (compile-time artifacts are class-level and
+  instance-independent) and which would fork the artifact per design.
+- Each scope owns its own time unit and precision as class-level constants. The engine resolves the
+  design-global precision at construction (time zero) as the minimum precision across the built
+  scope tree -- the same construction-time resolution the architecture uses for cross-unit
+  references (`reference_resolution.md`), and the runtime owns the single time axis
+  (`runtime_model.md`). No precision value is threaded through the compile or emit pipeline; each
+  scope reports its own and the engine takes the minimum.
+- The runtime performs the two scalings from those constants and the resolved global precision: a
+  delay scales from its scope's precision to the global tick, and the current time scales back from
+  the global tick to a scope's unit for the query and format functions. With a single design-wide
+  precision the scaling factor is one, so single-precision designs are unchanged. A synthetic node
+  with no declared timescale (the implicit `$root`) does not contribute to the minimum.
+- Known limitation: a `package` or compilation-unit-scope timeprecision (LRM 3.14.3) is not folded
+  into the minimum, because those scopes are not instantiated into the object tree. The pre-reset
+  tree had the same gap; revisit if a design relies on a package-driven precision.
+
+## Open questions
+
+- The exact rounding rule for a fractional delay (`#1.5`) under a coarse scope precision: round to
+  the scope precision first, then scale to the global tick. Integer delays are unaffected, so TS1
+  ships without it; pin the LRM rounding wording when fractional delays under a coarse precision are
+  exercised.
+
+## Out of Scope
+
+- `step` as a time unit (LRM 3.14.3): defined as equal to the global precision but not usable to set
+  or modify a unit or precision.
+- SDF annotation and `$timeskew`-style back-annotation of delays.
+
+## Cross-references
+
+- LRM anchors: 3.14.2 (`timeunit` / `timeprecision`, precedence), 3.14.3 (global time precision),
+  20.3 (simulation-time functions), 20.4 (timescale tasks), 21.2 (`%t` in the display family).
+- Closes: `display.md` DI2 (`%t`).
+- Archive: the pre-reset tree implemented the whole surface -- a design-global minimum-precision
+  pass, the time query functions, `%t`, `$timeformat`, and `$printtimescale` -- and is a usable
+  reference for all three items.

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -125,6 +125,9 @@ enum class EventEdge : std::uint8_t {
 // family: those are data-dependency anchored, this one is clock anchored.
 // See `docs/decisions/event-control-unification.md` for the rationale.
 struct DelayStmt {
+  // `duration` is in the declaring scope's time-precision steps. The scope owns
+  // its precision (emitted as a class constant); the runtime scales from there
+  // to the design-global tick (LRM 3.14.3).
   SimDuration duration;
 };
 

--- a/include/lyra/mir/structural_scope.hpp
+++ b/include/lyra/mir/structural_scope.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include "lyra/base/time.hpp"
 #include "lyra/mir/process.hpp"
 #include "lyra/mir/stmt.hpp"
 #include "lyra/mir/structural_param.hpp"
@@ -27,6 +28,10 @@ struct CrossUnitRefDecl {
 
 struct StructuralScope {
   std::string name;
+  // The scope's resolved time unit and precision (LRM 3.14.2). The emitted
+  // class exposes the precision so the engine can take the design-global
+  // minimum (LRM 3.14.3) and so delays scale to it.
+  TimeResolution time_resolution;
   std::vector<StructuralParamDecl> structural_params;
   std::vector<StructuralVarDecl> structural_vars;
   std::vector<CrossUnitRefDecl> cross_unit_refs;

--- a/include/lyra/runtime/delay.hpp
+++ b/include/lyra/runtime/delay.hpp
@@ -6,14 +6,34 @@
 
 namespace lyra::runtime {
 
-// Suspends the calling process for `duration` simulation-time units.
-// `#0` enqueues on the inactive region of the current slot; `#N>0` enqueues
-// at SimTime `now + N`. The engine does not know about delays as a category
-// -- it only sees a process arriving in a queue at the right time.
+// Scales `ticks`, expressed in `from_power` precision steps, up to the engine's
+// `global_power` tick (LRM 3.14.3). `from_power >= global_power` because the
+// global precision is the finest in the design, so the factor is a non-negative
+// power of ten. A single-precision design has `from_power == global_power` and
+// the factor is one.
+inline auto ScaleToGlobalTicks(
+    SimDuration ticks, std::int8_t from_power,
+    std::int8_t global_power) noexcept -> SimDuration {
+  SimDuration result = ticks;
+  for (int i = 0; i < from_power - global_power; ++i) {
+    result *= 10;
+  }
+  return result;
+}
+
+// Suspends the calling process for `duration` time steps of its scope's
+// precision (`precision_power`). `#0` enqueues on the inactive region of the
+// current slot; `#N>0` scales to the engine's global tick and enqueues at that
+// future SimTime. The engine does not know about delays as a category -- it
+// only sees a process arriving in a queue at the right time.
 class DelayAwaitable {
  public:
-  DelayAwaitable(RuntimeServices& services, SimDuration duration)
-      : services_(&services), duration_(duration) {
+  DelayAwaitable(
+      RuntimeServices& services, SimDuration duration,
+      std::int8_t precision_power)
+      : services_(&services),
+        duration_(duration),
+        precision_power_(precision_power) {
   }
 
   [[nodiscard]] static auto await_ready() noexcept -> bool {
@@ -24,7 +44,9 @@ class DelayAwaitable {
     if (duration_ == 0) {
       services_->ScheduleInactive(handle);
     } else {
-      services_->ScheduleAtTime(services_->Now() + duration_, handle);
+      const SimDuration global_ticks = ScaleToGlobalTicks(
+          duration_, precision_power_, services_->GlobalPrecisionPower());
+      services_->ScheduleAtTime(services_->Now() + global_ticks, handle);
     }
   }
 
@@ -34,11 +56,13 @@ class DelayAwaitable {
  private:
   RuntimeServices* services_;
   SimDuration duration_;
+  std::int8_t precision_power_;
 };
 
-inline auto Delay(RuntimeServices& services, SimDuration duration)
-    -> DelayAwaitable {
-  return DelayAwaitable{services, duration};
+inline auto Delay(
+    RuntimeServices& services, SimDuration duration,
+    std::int8_t precision_power) -> DelayAwaitable {
+  return DelayAwaitable{services, duration, precision_power};
 }
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -98,6 +98,9 @@ class Engine {
   [[nodiscard]] auto Now() const -> SimTime {
     return now_;
   }
+  [[nodiscard]] auto GlobalPrecisionPower() const -> std::int8_t {
+    return global_precision_power_;
+  }
 
  private:
   struct PostponedWorkItem {};
@@ -116,6 +119,10 @@ class Engine {
   static constexpr std::size_t kMaxDeltaCyclesPerTimeSlot = 10000;
 
   void EnsureReadyToRun();
+  // Fixes the design-global time precision (LRM 3.14.3) as the minimum declared
+  // precision across the bound scope tree. The simulation tick; delays scale to
+  // it.
+  void ResolveGlobalTimePrecision();
   void RegisterProcesses();
   void RunProcess(CoroutineHandle handle);
   void DrainRunnableQueue(std::deque<CoroutineHandle>& queue);
@@ -152,6 +159,7 @@ class Engine {
   std::unique_ptr<Scope> root_;
   SchedulerQueues queues_;
   SimTime now_ = 0;
+  std::int8_t global_precision_power_ = kDefaultTimePrecisionPower;
   SchedulerPhase phase_ = SchedulerPhase::kIdle;
   std::size_t current_delta_ = 0;
   bool bound_ = false;

--- a/include/lyra/runtime/runtime_services.hpp
+++ b/include/lyra/runtime/runtime_services.hpp
@@ -75,6 +75,10 @@ class RuntimeServices {
   void RequestFinish(int level);
   [[nodiscard]] auto Now() const -> SimTime;
 
+  // The design-global time precision (LRM 3.14.3) the delay awaitable scales a
+  // scope-precision delay against to reach the engine's tick.
+  [[nodiscard]] auto GlobalPrecisionPower() const -> std::int8_t;
+
  private:
   StreamDispatcher* stream_ = nullptr;
   DiagnosticDispatcher* diagnostic_ = nullptr;

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -16,6 +16,11 @@ namespace lyra::runtime {
 
 class RuntimeServices;
 
+// Returned by a scope that declares no timescale of its own (the synthetic
+// `$root`). The engine's design-global precision minimum ignores it, so a
+// purely structural node does not pull the simulation tick finer.
+inline constexpr std::int8_t kUnspecifiedTimePrecisionPower = 127;
+
 // A node in the one canonical object tree. Every constructed SystemVerilog
 // scope -- a module instance, a generate block, the implicit `$root` -- is a
 // Scope. It carries the scope's identity (name, parent), the services handle
@@ -34,6 +39,14 @@ class Scope {
 
   [[nodiscard]] auto Parent() const -> Scope*;
   [[nodiscard]] auto Name() const -> std::string_view;
+
+  // The scope's declared time precision as a power of ten (LRM Table 20-2).
+  // A scope that declares a timescale overrides this; the base returns the
+  // unspecified sentinel. The engine takes the minimum across the tree to fix
+  // the design-global precision (LRM 3.14.3).
+  [[nodiscard]] virtual auto TimePrecisionPower() const -> std::int8_t {
+    return kUnspecifiedTimePrecisionPower;
+  }
 
   // Wires the services handle, creates this scope's processes, then recurses
   // into the children. Identity (name, parent, kind-as-type) is already fixed

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -264,6 +264,18 @@ auto RenderScopeAsClass(
          " {\n";
   out += Indent(indent) + " public:\n";
 
+  // The scope's own time precision (LRM 3.14.2). The engine takes the minimum
+  // across the tree as the design-global tick (LRM 3.14.3); a delay in this
+  // scope scales from this precision to that tick.
+  out += Indent(indent + 1) +
+         "static constexpr std::int8_t kTimePrecisionPower = " +
+         std::to_string(static_cast<int>(s.time_resolution.precision_power)) +
+         ";\n";
+  out += Indent(indent + 1) +
+         "auto TimePrecisionPower() const -> std::int8_t override {\n";
+  out += Indent(indent + 2) + "return kTimePrecisionPower;\n";
+  out += Indent(indent + 1) + "}\n\n";
+
   for (const auto& child : s.child_structural_scopes) {
     auto child_or =
         RenderScopeAsClass(unit, child, indent + 1, false, &this_anchor);

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -320,7 +320,7 @@ auto RenderStmt(
           [&](const mir::DelayStmt& s) -> diag::Result<std::string> {
             return Indent(indent) +
                    "co_await lyra::runtime::Delay(Services(), " +
-                   std::to_string(s.duration) + ");\n";
+                   std::to_string(s.duration) + ", kTimePrecisionPower);\n";
           },
           [&](const mir::ProceduralVarDeclStmt& s)
               -> diag::Result<std::string> {

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -577,6 +577,7 @@ auto LowerStructuralScope(
     -> diag::Result<mir::StructuralScope> {
   mir::StructuralScope mir_scope{
       .name = std::move(name),
+      .time_resolution = scope.time_resolution,
       .structural_params = {},
       .structural_vars = {},
       .cross_unit_refs = {},

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -1,6 +1,8 @@
 #include "lyra/runtime/engine.hpp"
 
+#include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <limits>
 #include <memory>
@@ -49,6 +51,7 @@ void Engine::BindDesign(std::span<const TopBinding> tops) {
 
 auto Engine::Run() -> int {
   EnsureReadyToRun();
+  ResolveGlobalTimePrecision();
   RegisterProcesses();
 
   while (HasScheduledWork() && !finished_) {
@@ -77,6 +80,20 @@ void Engine::EnsureReadyToRun() {
     throw InternalError("Engine::Run called more than once");
   }
   ran_ = true;
+}
+
+void Engine::ResolveGlobalTimePrecision() {
+  bool found = false;
+  std::int8_t min_power = kDefaultTimePrecisionPower;
+  WalkScopePreOrder(*root_, [&](Scope& scope) {
+    const std::int8_t power = scope.TimePrecisionPower();
+    if (power == kUnspecifiedTimePrecisionPower) {
+      return;
+    }
+    min_power = found ? std::min(min_power, power) : power;
+    found = true;
+  });
+  global_precision_power_ = found ? min_power : kDefaultTimePrecisionPower;
 }
 
 void Engine::RegisterProcesses() {

--- a/src/lyra/runtime/runtime_services.cpp
+++ b/src/lyra/runtime/runtime_services.cpp
@@ -58,4 +58,12 @@ auto RuntimeServices::Now() const -> SimTime {
   return engine_->Now();
 }
 
+auto RuntimeServices::GlobalPrecisionPower() const -> std::int8_t {
+  if (engine_ == nullptr) {
+    throw InternalError(
+        "RuntimeServices::GlobalPrecisionPower: no Engine bound");
+  }
+  return engine_->GlobalPrecisionPower();
+}
+
 }  // namespace lyra::runtime

--- a/tests/cases/cpp/timescale_mixed_precision/case.yaml
+++ b/tests/cases/cpp/timescale_mixed_precision/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.timescale_mixed_precision
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      a
+      b

--- a/tests/cases/cpp/timescale_mixed_precision/main.sv
+++ b/tests/cases/cpp/timescale_mixed_precision/main.sv
@@ -1,0 +1,17 @@
+// A design mixing time precisions shares one time axis whose tick is the
+// global (finest) precision (LRM 3.14.3). Top is 1ns/1ps; the child Coarse is
+// 1ns/1ns. The global precision is 1ps, so Top's `#1` lands at 1000 ticks (1 ns)
+// and Coarse's `#5` at 5000 ticks (5 ns): "a" prints before "b".
+//
+// If Coarse's delay were scaled to its own 1ns precision instead of the global
+// 1ps tick, Coarse's `#5` would land at tick 5 and print "b" first.
+`timescale 1ns / 1ps
+module Top;
+  Coarse c ();
+  initial #1 $display("a");
+endmodule
+
+`timescale 1ns / 1ns
+module Coarse;
+  initial #5 $display("b");
+endmodule


### PR DESCRIPTION
## Summary

The simulation tick must be the design-global time precision -- the finest precision declared anywhere in the design (LRM 3.14.3). Previously each scope scaled its delays to its own precision and the engine treated those ticks as if they shared one axis, so a design mixing precisions (a `1ns/1ns` scope alongside a `1ns/1ps` one) scheduled equal physical delays at unequal times. This was a latent defect, unobserved only because every test used a single precision.

This lands the keystone (timescale TS1). Each scope owns its time precision as a class-level constant; the engine resolves the design-global precision at construction (time zero) as the minimum across the built scope tree -- the same construction-time resolution the architecture already uses for cross-unit references, and the runtime owns the single time axis. No precision value is threaded through the compile or emit pipeline: each scope reports its own and the engine takes the minimum. A delay then scales from its scope's precision to that global tick at runtime; with a single design-wide precision the factor is one, so single-precision designs are unchanged.

## Design

The global precision is a design-global concern that sits outside the per-unit compilation model -- baking it into a unit's class-level artifact would make the compiled form depend on the surrounding design, which the compilation-unit model forbids. So MIR scopes carry their resolved `TimeResolution`, the emitted scope class exposes the precision and a `TimePrecisionPower()` override, and the engine mins over the tree (the synthetic `$root` reports an unspecified sentinel and is ignored). A `package` or compilation-unit-scope precision is not folded in yet, since those scopes are not instantiated into the object tree; this matches the pre-reset behavior and is noted in `docs/progress/timescale.md`.

Also fixes a latent emit bug surfaced by the full cpp suite: `$fscanf` rendered `*services_` (a now-private base member) instead of the `Services()` accessor; the cpp suite is tag-excluded from CI, so it had not been caught.

The fork-join workstream progress doc rides along (authored while scoping that work); no fork-join code is included.

## Testing

`bazel test //...` green, including a new `timescale_mixed_precision` case: a `1ns/1ps` top instantiating a `1ns/1ns` child, where the global tick is `1ps` and the coarse child's `#5` must scale to land after the fine top's `#1`. Single-precision timing/delay/finish/event cases are unchanged.