### PR TITLE
Add $strobe family with postponed-region semantics

### DIFF
--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -26,8 +26,14 @@ since the test harness can only probe a variable whose type has an implemented s
       scope. The test framework gained `expect.files` with strict matching (any undeclared file in
       the per-case sandbox fails the case) and per-case sandbox cwd so `$fopen("foo.txt")` writes
       inside the sandbox.
-- [ ] DI6 -- `$strobe` postponed-region semantics. Strobe must defer its read-and-print to the
-      postponed region of the same time slot (LRM 21.2).
+- [x] DI6 -- `$strobe` / `$strobeb` / `$strobeh` / `$strobeo` (LRM 21.2.2). Lowers to the same
+      `RuntimePrintCall` `$display[bho]` produces, wrapped in a postponed-submit MIR node; the C++
+      backend renders the print inside a `services_->SubmitPostponed([=, this]() { ... })` lambda.
+      Lambda init-capture snapshots procedural locals by value (safe even when the issuing
+      `initial` frame has already returned), and module-signal operands resolve through `this->`
+      and are read at fire time -- so they see NBA-committed values, which is the LRM 21.2.2
+      semantic. The postponed queue uses the same swap-and-drain shape NBA uses; re-entrant
+      submission during the drain is rejected.
 - [x] DI7 -- `%p` / `%0p` assignment-pattern format for aggregate types (LRM 21.2.1.6). Scope: fixed
       unpacked array of integral elements. Output is `'{<elem>, <elem>, ...}` with `, ` between
       elements; multi-dimensional arrays nest naturally. Singular integral elements follow the LRM
@@ -90,13 +96,20 @@ the corresponding behaviour lands.
 - [ ] `$sformat` / `$sformatf` format_string of integral or unpacked-array-of-byte type (LRM
       21.3.3). Shares the runtime-format-parser blocker with the first item.
 
+## Strobe family follow-ups
+
+Tracks the remaining LRM 21.2.2 file-sink variants now that the stdout-sink half has shipped.
+
+- [ ] `$fstrobe` / `$fstrobeb` / `$fstrobeh` / `$fstrobeo` (LRM 21.2.2, file sink). The
+      `PrintSinkKind::kFile` axis on `PrintSystemSubroutineInfo` and the descriptor / MCD-FD
+      dispatch already exist (DI5); the gap is four descriptor rows plus threading the
+      file-descriptor argument through the strobe closure-submit helper.
+
 ## Out of Scope
 
 - Format-string parse diagnostics (trailing `%`, missing specifier, width overflow, unknown
   specifier) -- already implemented, not gaps.
 - `$monitor` / `$fmonitor`. Not modelled today; add an entry when a concrete consumer needs it.
-- `$strobe` / `$fstrobe` radix variants. The radix-dispatch mechanism is shared with DI5 but
-  strobe's "drain at end of time slot" semantic waits on DI6 (postponed region).
 - Other file read tasks (`$fgetc` / `$ungetc` / `$fgets` / `$fread` / `$fseek` / `$rewind` /
   `$ftell` / `$feof` / `$ferror` / `$fflush`) are implemented per LRM 21.3.4..21.3.8.
 - `%u` / `%z` (binary-packed unsigned / signed) and `%v` (strength). Not on the immediate roadmap;

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -101,12 +101,12 @@ struct CallExpr {
 
 using RuntimeCall = std::variant<
     RuntimePrintCall, RuntimeDiagnosticCall, RuntimeFinishCall,
-    RuntimeSubmitObservedCall, RuntimeSubmitNbaCall, RuntimeFileOpenCall,
-    RuntimeFileCloseCall, RuntimeFileGetcCall, RuntimeFileUngetcCall,
-    RuntimeFileGetsCall, RuntimeFileReadCall, RuntimeFileSeekCall,
-    RuntimeFileRewindCall, RuntimeFileTellCall, RuntimeFileEofCall,
-    RuntimeFileErrorCall, RuntimeFileFlushCall, RuntimeScanCall,
-    RuntimeSFormatCall>;
+    RuntimeSubmitObservedCall, RuntimeSubmitNbaCall, RuntimeSubmitPostponedCall,
+    RuntimeFileOpenCall, RuntimeFileCloseCall, RuntimeFileGetcCall,
+    RuntimeFileUngetcCall, RuntimeFileGetsCall, RuntimeFileReadCall,
+    RuntimeFileSeekCall, RuntimeFileRewindCall, RuntimeFileTellCall,
+    RuntimeFileEofCall, RuntimeFileErrorCall, RuntimeFileFlushCall,
+    RuntimeScanCall, RuntimeSFormatCall>;
 
 struct RuntimeCallExpr {
   RuntimeCall call;

--- a/include/lyra/mir/runtime_submit.hpp
+++ b/include/lyra/mir/runtime_submit.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include "lyra/mir/expr_id.hpp"
+#include "lyra/mir/runtime_print.hpp"
 
 namespace lyra::mir {
 
@@ -26,6 +27,17 @@ struct RuntimeSubmitObservedCall {
 // in the slot's NBA region in enqueue order (LRM 4.4.2).
 struct RuntimeSubmitNbaCall {
   ExprId closure;
+};
+
+// LRM 21.2.2 `$strobe` payload. Holds the same `RuntimePrintCall` shape
+// `$display` produces -- items reference the enclosing scope's ExprIds
+// directly, so the LRM 21.2.2 "evaluate at end-of-slot" semantic falls
+// out of where the print is rendered (inside the postponed lambda).
+// Procedural-local references inside the items are by-value snapshotted
+// at the C++ codegen boundary via the lambda's init-capture list; module
+// signals are reached through `this` and read at fire time.
+struct RuntimeSubmitPostponedCall {
+  RuntimePrintCall print;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -73,6 +73,7 @@ class Engine {
   }
 
   void SubmitNba(std::function<void()> closure);
+  void SubmitPostponed(std::function<void()> closure);
 
   void TriggerValueChange(
       Observable& observable, const EdgeClassifier& classify);
@@ -103,14 +104,12 @@ class Engine {
   }
 
  private:
-  struct PostponedWorkItem {};
-
   struct SchedulerQueues {
     std::deque<CoroutineHandle> active;
     std::deque<CoroutineHandle> inactive;
     std::vector<CoroutineHandle> next_delta;
     std::vector<std::function<void()>> nba;
-    std::vector<PostponedWorkItem> postponed;
+    std::vector<std::function<void()>> postponed;
     std::map<SimTime, std::vector<CoroutineHandle>> delayed;
     std::vector<CoroutineHandle> finals;
   };

--- a/include/lyra/runtime/runtime_services.hpp
+++ b/include/lyra/runtime/runtime_services.hpp
@@ -48,6 +48,7 @@ class RuntimeServices {
   }
 
   void SubmitNba(std::function<void()> closure);
+  void SubmitPostponed(std::function<void()> closure);
 
   void TriggerValueChange(
       Observable& observable, const EdgeClassifier& classify);

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -626,6 +626,62 @@ inline constexpr std::array kSystemSubroutines = {
                 .expects_format_string = true,
                 .has_output_arg = false},
     },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{40},
+        .name = "$strobe",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 255},
+        .semantic =
+            PrintSystemSubroutineInfo{
+                .radix = PrintRadix::kDecimal,
+                .append_newline = true,
+                .is_strobe = true,
+                .sink_kind = PrintSinkKind::kStdout},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{41},
+        .name = "$strobeb",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 255},
+        .semantic =
+            PrintSystemSubroutineInfo{
+                .radix = PrintRadix::kBinary,
+                .append_newline = true,
+                .is_strobe = true,
+                .sink_kind = PrintSinkKind::kStdout},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{42},
+        .name = "$strobeh",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 255},
+        .semantic =
+            PrintSystemSubroutineInfo{
+                .radix = PrintRadix::kHex,
+                .append_newline = true,
+                .is_strobe = true,
+                .sink_kind = PrintSinkKind::kStdout},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{43},
+        .name = "$strobeo",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 255},
+        .semantic =
+            PrintSystemSubroutineInfo{
+                .radix = PrintRadix::kOctal,
+                .append_newline = true,
+                .is_strobe = true,
+                .sink_kind = PrintSinkKind::kStdout},
+    },
 };
 
 }  // namespace detail

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -299,6 +299,21 @@ auto RenderRuntimeCallExpr(
             }
             return std::format("Services().SubmitNba({})", *closure_or);
           },
+          [&](const mir::RuntimeSubmitPostponedCall& pc)
+              -> diag::Result<std::string> {
+            // LRM 21.2.2: wrap the print in a lambda that fires from the
+            // postponed region. `[=, this]` snapshots procedural locals
+            // by value (NBAs do not touch them, so a snapshot is also
+            // semantically correct -- and frame-death-safe for `initial`
+            // bodies) and resolves module signals through `this`, so
+            // they read NBA-committed values at fire time.
+            auto print_or = RenderRuntimePrintCall(ctx, pc.print);
+            if (!print_or) {
+              return std::unexpected(std::move(print_or.error()));
+            }
+            return std::format(
+                "services_->SubmitPostponed([=, this]() {{ {}; }})", *print_or);
+          },
           [&](const mir::RuntimeFileOpenCall& fo) -> diag::Result<std::string> {
             auto name_or = RenderExpr(ctx, ctx.Expr(fo.name));
             if (!name_or) return std::unexpected(std::move(name_or.error()));

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -571,18 +571,22 @@ auto LowerHirPrimaryStructural(
 // values clone verbatim so the body still sees an IntegerLiteral (some
 // downstream code paths extract constants from literal-shape exprs). Other
 // expressions are captured by value into a fresh procedural var so the body
-// reads the value as it stood at submit time.
+// reads the value as it stood at submit time. `name_prefix` distinguishes the
+// caller (`"nba"`, `"strobe"`, ...) so the synthesized binding names stay
+// readable when MIR dumps are inspected.
 auto SnapshotNonLhsSubexpr(
     const ProceduralScopeLoweringState& outer_scope_state,
     ProceduralScopeLoweringState& body, std::vector<mir::Capture>& captures,
-    std::uint32_t& snapshot_counter, mir::ExprId outer_id) -> mir::ExprId {
+    std::uint32_t& snapshot_counter, mir::ExprId outer_id,
+    std::string_view name_prefix) -> mir::ExprId {
   const auto& outer_expr = outer_scope_state.GetExpr(outer_id);
   if (std::holds_alternative<mir::IntegerLiteral>(outer_expr.data)) {
     return body.AddExpr(outer_expr);
   }
   const auto binding = body.AddProceduralVar(
       mir::ProceduralVarDecl{
-          .name = std::format("_lyra_nba_idx{}", snapshot_counter++),
+          .name =
+              std::format("_lyra_{}_arg{}", name_prefix, snapshot_counter++),
           .type = outer_expr.type});
   captures.emplace_back(
       mir::ByValueCapture{.value = outer_id, .binding = binding});
@@ -611,7 +615,8 @@ auto CloneLhsExprForNbaBody(
                 outer_scope_state, body, captures, snapshot_counter,
                 s.base_value);
             const mir::ExprId index = SnapshotNonLhsSubexpr(
-                outer_scope_state, body, captures, snapshot_counter, s.index);
+                outer_scope_state, body, captures, snapshot_counter, s.index,
+                "nba");
             return body.AddExpr(
                 mir::Expr{
                     .data =
@@ -625,7 +630,7 @@ auto CloneLhsExprForNbaBody(
                 s.base_value);
             const mir::ExprId offset = SnapshotNonLhsSubexpr(
                 outer_scope_state, body, captures, snapshot_counter,
-                s.offset_expr);
+                s.offset_expr, "nba");
             return body.AddExpr(
                 mir::Expr{
                     .data =

--- a/src/lyra/lowering/hir_to_mir/lower_print.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_print.cpp
@@ -14,6 +14,7 @@
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/runtime_print.hpp"
+#include "lyra/mir/runtime_submit.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -61,11 +62,27 @@ auto LowerPrintSystemSubroutineCall(
       print.radix, arg_offset, FormatStringRequirement::kOptional, span);
   if (!items_or) return std::unexpected(std::move(items_or.error()));
 
+  mir::RuntimePrintCall print_call(
+      ToValuePrintKind(print), descriptor, std::move(*items_or));
+
+  if (!print.is_strobe) {
+    return mir::Expr{
+        .data = mir::RuntimeCallExpr{.call = std::move(print_call)},
+        .type = unit_state.Builtins().void_type};
+  }
+
+  // LRM 21.2.2: $strobe defers the same print to the postponed region. The
+  // items keep their outer-scope ExprIds; the backend wraps the rendered
+  // print in a postponed-region lambda whose init-capture list snapshots
+  // any procedural-local operands. StructuralVarRef operands resolve
+  // through `this->`, so the lambda body reads them at fire time and sees
+  // the NBA-committed values.
   return mir::Expr{
       .data =
           mir::RuntimeCallExpr{
-              .call = mir::RuntimePrintCall(
-                  ToValuePrintKind(print), descriptor, std::move(*items_or))},
+              .call =
+                  mir::RuntimeSubmitPostponedCall{
+                      .print = std::move(print_call)}},
       .type = unit_state.Builtins().void_type};
 }
 

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -745,6 +745,12 @@ class MirDumper {
                             "RuntimeSubmitNbaCall closure=Expr[{}]",
                             nc.closure.value));
                   },
+                  [&](const RuntimeSubmitPostponedCall& pc) {
+                    Line("RuntimeSubmitPostponedCall");
+                    Indent();
+                    DumpRuntimePrintCallItems(pc.print, scope);
+                    Dedent();
+                  },
                   [&](const RuntimeFileOpenCall& fo) {
                     Line(
                         std::format(

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -180,6 +180,15 @@ void Engine::SubmitNba(std::function<void()> closure) {
   queues_.nba.push_back(std::move(closure));
 }
 
+void Engine::SubmitPostponed(std::function<void()> closure) {
+  if (phase_ == SchedulerPhase::kPostponed) {
+    throw InternalError(
+        "Engine::SubmitPostponed: re-entrant postponed submission during "
+        "postponed region is not supported");
+  }
+  queues_.postponed.push_back(std::move(closure));
+}
+
 void Engine::ExecuteObservedRegion() {
   phase_ = SchedulerPhase::kObserved;
   WalkScopePreOrder(*root_, [](Scope& scope) { scope.DrainObserved(); });
@@ -191,6 +200,11 @@ void Engine::ExecuteReactiveRegion() {
 
 void Engine::ExecutePostponedRegion() {
   phase_ = SchedulerPhase::kPostponed;
+  auto pending = std::move(queues_.postponed);
+  queues_.postponed.clear();
+  for (auto& closure : pending) {
+    closure();
+  }
 }
 
 void Engine::ExecuteFinalProcesses() {

--- a/src/lyra/runtime/runtime_services.cpp
+++ b/src/lyra/runtime/runtime_services.cpp
@@ -15,6 +15,13 @@ void RuntimeServices::SubmitNba(std::function<void()> closure) {
   engine_->SubmitNba(std::move(closure));
 }
 
+void RuntimeServices::SubmitPostponed(std::function<void()> closure) {
+  if (engine_ == nullptr) {
+    throw InternalError("RuntimeServices::SubmitPostponed: no Engine bound");
+  }
+  engine_->SubmitPostponed(std::move(closure));
+}
+
 void RuntimeServices::TriggerValueChange(
     Observable& observable, const EdgeClassifier& classify) {
   if (engine_ == nullptr) {

--- a/tests/cases/cpp/strobe_after_nba_lrm_21_2_2/case.yaml
+++ b/tests/cases/cpp/strobe_after_nba_lrm_21_2_2/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.strobe_after_nba_lrm_21_2_2
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      display cnt=0
+      strobe  cnt=1

--- a/tests/cases/cpp/strobe_after_nba_lrm_21_2_2/main.sv
+++ b/tests/cases/cpp/strobe_after_nba_lrm_21_2_2/main.sv
@@ -1,0 +1,18 @@
+module Top;
+  // LRM 21.2.2 canonical reproducer: at the same posedge, $display sees the
+  // pre-NBA value and $strobe sees the post-NBA value, proving that
+  // $strobe's argument list is re-evaluated in the postponed region after
+  // NBAs commit.
+  logic clk;
+  int   cnt;
+  initial begin
+    clk = 0;
+    cnt = 0;
+    #1 clk = 1;
+  end
+  always @(posedge clk) begin
+    cnt <= cnt + 1;
+    $display("display cnt=%0d", cnt);
+    $strobe ("strobe  cnt=%0d", cnt);
+  end
+endmodule

--- a/tests/cases/cpp/strobe_procedural_local_snapshot/case.yaml
+++ b/tests/cases/cpp/strobe_procedural_local_snapshot/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.strobe_procedural_local_snapshot
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      5

--- a/tests/cases/cpp/strobe_procedural_local_snapshot/main.sv
+++ b/tests/cases/cpp/strobe_procedural_local_snapshot/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  // Procedural locals are ByValueCapture'd at submit time, not re-read at
+  // postponed-fire time. Without the snapshot the closure body would either
+  // observe the post-mutation value (99) or dangle into a destroyed initial
+  // frame; with the snapshot it prints the value as of the $strobe call (5).
+  initial begin
+    int x;
+    x = 5;
+    $strobe("%0d", x);
+    x = 99;
+  end
+endmodule

--- a/tests/cases/cpp/strobe_radix_variants/case.yaml
+++ b/tests/cases/cpp/strobe_radix_variants/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.strobe_radix_variants
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      171
+      10101011
+      ab
+      253

--- a/tests/cases/cpp/strobe_radix_variants/main.sv
+++ b/tests/cases/cpp/strobe_radix_variants/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  // LRM 21.2.2 + LRM 21.2.1.1: $strobe / $strobeb / $strobeh / $strobeo pick
+  // the same default radix as their $display / $displayb / $displayh /
+  // $displayo counterparts. All four submits land in the postponed queue and
+  // drain in append order.
+  initial begin
+    $strobe (8'hAB);
+    $strobeb(8'hAB);
+    $strobeh(8'hAB);
+    $strobeo(8'hAB);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds `$strobe` / `$strobeb` / `$strobeh` / `$strobeo` (LRM 21.2.2) over the existing print engine, closing the DI6 entry in `docs/progress/display.md`. The print arguments are evaluated in the postponed region of the same time slot, so structural signals observe their NBA-committed values; this is the only behavioural difference from `$display[bho]`.

## Design

A new `RuntimeSubmitPostponedCall` MIR node carries a `RuntimePrintCall` directly -- the same print shape `$display` produces, with items referencing the enclosing scope's ExprIds. The C++ backend renders the print inside a `services_->SubmitPostponed([=, this]() { ... })` lambda; C++ lambda capture rules then do the work: procedural locals are by-value snapshotted (frame-death-safe for `initial` blocks), and module signals resolve through `this->` and are read at fire time. No closure body scope, no expression cloning, no leaf scanner.

`Engine::SubmitPostponed` mirrors the existing NBA queue: append at submit time, swap-and-drain in `ExecutePostponedRegion`, reject re-entrant submission during the drain.

## Testing

Three new `cpp_run` cases:

- `strobe_after_nba_lrm_21_2_2` -- the LRM 21.2.2 canonical reproducer: at the same posedge, `$display` prints the pre-NBA `cnt`, `$strobe` prints the post-NBA `cnt`.
- `strobe_radix_variants` -- exercises all four descriptors (`$strobe` / `$strobeb` / `$strobeh` / `$strobeo`) so the radix dispatch is verified end to end.
- `strobe_procedural_local_snapshot` -- proves the `[=, this]` by-value capture survives an `initial` body that mutates the local after the strobe call and then returns.

`bazel test //...` passes.