### PR TITLE
Read simulation time via $time, $realtime and $stime

### DIFF
--- a/docs/progress/timescale.md
+++ b/docs/progress/timescale.md
@@ -23,6 +23,9 @@ others read from.
   design-global time precision -- the finest precision across the whole design (LRM 3.14.3) -- so a
   design that mixes precisions schedules every delay on one consistent time axis.
 - The `time` and `realtime` data types exist and time literals lower to values.
+- `$time`, `$realtime` and `$stime` read the current simulation time scaled to the calling design
+  element's time unit (LRM 20.3): `$time` rounds to an integer, `$realtime` keeps the fraction, and
+  `$stime` is the low 32 bits.
 
 ## Sub-Steps
 
@@ -36,7 +39,7 @@ others read from.
 
 ### Reading simulation time
 
-- [ ] TS2 -- `$time`, `$realtime`, `$stime` (LRM 20.3): return the current simulation time scaled to
+- [x] TS2 -- `$time`, `$realtime`, `$stime` (LRM 20.3): return the current simulation time scaled to
       the time unit of the calling code's lexical scope -- the design element that contains the
       call, not the activation that runs it. Time unit is a static per-design-element property (LRM
       3.14.2), so a subroutine uses its declaration scope's unit even when enabled across a unit

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -90,6 +90,13 @@ class UnitLoweringState {
             .dims = {hir::PackedRange{.left = 31, .right = 0}},
             .form = hir::PackedArrayForm::kInt}});
     string_type_id_ = AddType(hir::TypeData{hir::StringType{}});
+    time_type_id_ = AddType(
+        hir::TypeData{hir::PackedArrayType{
+            .atom = hir::BitAtom::kLogic,
+            .signedness = hir::Signedness::kUnsigned,
+            .dims = {hir::PackedRange{.left = 63, .right = 0}},
+            .form = hir::PackedArrayForm::kTime}});
+    realtime_type_id_ = AddType(hir::TypeData{hir::RealTimeType{}});
   }
 
   // Canonical id for the synthesized `void` type (system-call sinks, lvalue
@@ -111,6 +118,19 @@ class UnitLoweringState {
   // 21.3.3) rather than by a slang-derived type.
   [[nodiscard]] auto StringTypeId() const -> hir::TypeId {
     return string_type_id_;
+  }
+
+  // Canonical id for the synthesized 64-bit unsigned `time` (LRM 6.11). Used
+  // by $time, whose return is fixed at `time` by the language (LRM 20.3.1).
+  [[nodiscard]] auto TimeTypeId() const -> hir::TypeId {
+    return time_type_id_;
+  }
+
+  // Canonical id for the synthesized `realtime` (LRM 6.12.1). Used by
+  // $realtime, whose return is fixed at `realtime` by the language (LRM
+  // 20.3.3).
+  [[nodiscard]] auto RealTimeTypeId() const -> hir::TypeId {
+    return realtime_type_id_;
   }
 
   [[nodiscard]] auto HirUnit() const -> const hir::ModuleUnit& {
@@ -294,6 +314,8 @@ class UnitLoweringState {
   hir::TypeId void_type_id_{};
   hir::TypeId int32_type_id_{};
   hir::TypeId string_type_id_{};
+  hir::TypeId time_type_id_{};
+  hir::TypeId realtime_type_id_{};
 };
 
 class ScopeStack {

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -36,6 +36,7 @@ struct BuiltinMirTypes {
   mir::TypeId string;
   mir::TypeId void_type;
   mir::TypeId realtime;
+  mir::TypeId time;
 };
 
 class UnitLoweringState {
@@ -57,7 +58,13 @@ class UnitLoweringState {
                 .form = mir::PackedArrayForm::kExplicit}}),
         .string = AddType(mir::TypeData{mir::StringType{}}),
         .void_type = AddType(mir::TypeData{mir::VoidType{}}),
-        .realtime = AddType(mir::TypeData{mir::RealTimeType{}})};
+        .realtime = AddType(mir::TypeData{mir::RealTimeType{}}),
+        .time = AddType(
+            mir::TypeData{mir::PackedArrayType{
+                .atom = mir::BitAtom::kLogic,
+                .signedness = mir::Signedness::kUnsigned,
+                .dims = {mir::PackedRange{.left = 63, .right = 0}},
+                .form = mir::PackedArrayForm::kTime}})};
   }
 
   [[nodiscard]] auto Unit() const -> const mir::CompilationUnit& {

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -20,6 +20,7 @@
 #include "lyra/mir/runtime_scan.hpp"
 #include "lyra/mir/runtime_sformat.hpp"
 #include "lyra/mir/runtime_submit.hpp"
+#include "lyra/mir/runtime_time.hpp"
 #include "lyra/mir/structural_param.hpp"
 #include "lyra/mir/structural_subroutine_ref.hpp"
 #include "lyra/mir/unary_op.hpp"
@@ -106,7 +107,7 @@ using RuntimeCall = std::variant<
     RuntimeFileUngetcCall, RuntimeFileGetsCall, RuntimeFileReadCall,
     RuntimeFileSeekCall, RuntimeFileRewindCall, RuntimeFileTellCall,
     RuntimeFileEofCall, RuntimeFileErrorCall, RuntimeFileFlushCall,
-    RuntimeScanCall, RuntimeSFormatCall>;
+    RuntimeScanCall, RuntimeSFormatCall, RuntimeTimeCall>;
 
 struct RuntimeCallExpr {
   RuntimeCall call;

--- a/include/lyra/mir/runtime_time.hpp
+++ b/include/lyra/mir/runtime_time.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "lyra/support/system_subroutine.hpp"
+
+namespace lyra::mir {
+
+// LRM 20.3 simulation-time read ($time / $stime / $realtime). The node carries
+// only which function it is; the scaling target (the calling scope's time unit)
+// is read at render time from the enclosing scope's emitted `kTimeUnitPower`
+// constant, and the design-global tick comes from the engine at run time. So a
+// time read inside a subroutine scales by its declaring scope's unit (LRM
+// 3.14.2 / 20.3.1) with nothing threaded onto this node.
+struct RuntimeTimeCall {
+  support::TimeKind kind;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/runtime/sim_time.hpp
+++ b/include/lyra/runtime/sim_time.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <cstdint>
+
+#include "lyra/base/time.hpp"
+#include "lyra/runtime/runtime_services.hpp"
+#include "lyra/value/packed_array.hpp"
+
+namespace lyra::runtime {
+
+// The factor that converts the design-global tick (LRM 3.14.3) to one step of a
+// scope whose time unit is `unit_power`: 10^(unit_power - global_power). The
+// exponent is non-negative because the global precision is the finest in the
+// design, so a scope unit is never finer than the tick. The inverse of
+// `ScaleToGlobalTicks` (which a delay uses to go the other way).
+inline auto TimeUnitDivisor(
+    std::int8_t unit_power, std::int8_t global_power) noexcept -> SimDuration {
+  SimDuration divisor = 1;
+  for (int i = 0; i < unit_power - global_power; ++i) {
+    divisor *= 10;
+  }
+  return divisor;
+}
+
+// $time (LRM 20.3.1): the current time scaled to `unit_power` and rounded to
+// the nearest integer (only the unit conversion rounds; precision does not).
+inline auto SimTimeInUnit(RuntimeServices& services, std::int8_t unit_power)
+    -> value::PackedArray {
+  const SimDuration divisor =
+      TimeUnitDivisor(unit_power, services.GlobalPrecisionPower());
+  const SimTime scaled = (services.Now() + divisor / 2) / divisor;
+  return value::PackedArray::FromInt(
+      static_cast<std::int64_t>(scaled), 64, false, true);
+}
+
+// $stime (LRM 20.3.2): the low 32 bits of the $time value.
+inline auto STimeInUnit(RuntimeServices& services, std::int8_t unit_power)
+    -> value::PackedArray {
+  const SimDuration divisor =
+      TimeUnitDivisor(unit_power, services.GlobalPrecisionPower());
+  const SimTime scaled = (services.Now() + divisor / 2) / divisor;
+  return value::PackedArray::FromInt(
+      static_cast<std::int64_t>(static_cast<std::uint32_t>(scaled)), 32, true,
+      false);
+}
+
+// $realtime (LRM 20.3.3): the current time scaled to `unit_power` as a real,
+// keeping any fractional part.
+inline auto RealTimeInUnit(RuntimeServices& services, std::int8_t unit_power)
+    -> double {
+  const SimDuration divisor =
+      TimeUnitDivisor(unit_power, services.GlobalPrecisionPower());
+  return static_cast<double>(services.Now()) / static_cast<double>(divisor);
+}
+
+}  // namespace lyra::runtime

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -34,6 +34,8 @@ enum class ReturnConvention : std::uint8_t {
   kVoid,
   kInt32,
   kString,
+  kTime64,
+  kRealTime,
 };
 
 struct ArgCountPolicy {
@@ -136,10 +138,25 @@ struct SFormatSystemSubroutineInfo {
   bool has_output_arg;
 };
 
+// LRM 20.3 simulation-time read functions. The kind selects $time (64-bit
+// integer, rounded), $stime (low 32 bits) or $realtime (real, fraction kept);
+// all three scale the current time from the design-global tick to the calling
+// scope's time unit, so they share one runtime scaling core.
+enum class TimeKind : std::uint8_t {
+  kTime,
+  kStime,
+  kRealtime,
+};
+
+struct TimeSystemSubroutineInfo {
+  TimeKind kind;
+};
+
 using SystemSubroutineSemantic = std::variant<
     PrintSystemSubroutineInfo, TerminationSystemSubroutineInfo,
     DiagnosticSystemSubroutineInfo, FileIOSystemSubroutineInfo,
-    ScanSystemSubroutineInfo, SFormatSystemSubroutineInfo>;
+    ScanSystemSubroutineInfo, SFormatSystemSubroutineInfo,
+    TimeSystemSubroutineInfo>;
 
 struct SystemSubroutineDesc {
   SystemSubroutineId id;
@@ -682,6 +699,33 @@ inline constexpr std::array kSystemSubroutines = {
                 .is_strobe = true,
                 .sink_kind = PrintSinkKind::kStdout},
     },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{44},
+        .name = "$time",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kFunction,
+        .result_conv = ReturnConvention::kTime64,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 0},
+        .semantic = TimeSystemSubroutineInfo{.kind = TimeKind::kTime},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{45},
+        .name = "$stime",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kFunction,
+        .result_conv = ReturnConvention::kInt32,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 0},
+        .semantic = TimeSystemSubroutineInfo{.kind = TimeKind::kStime},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{46},
+        .name = "$realtime",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kFunction,
+        .result_conv = ReturnConvention::kRealTime,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 0},
+        .semantic = TimeSystemSubroutineInfo{.kind = TimeKind::kRealtime},
+    },
 };
 
 }  // namespace detail
@@ -729,6 +773,11 @@ inline constexpr std::array kSystemSubroutines = {
 [[nodiscard]] inline auto GetSFormatInfo(const SystemSubroutineDesc& desc)
     -> const SFormatSystemSubroutineInfo* {
   return std::get_if<SFormatSystemSubroutineInfo>(&desc.semantic);
+}
+
+[[nodiscard]] inline auto GetTimeInfo(const SystemSubroutineDesc& desc)
+    -> const TimeSystemSubroutineInfo* {
+  return std::get_if<TimeSystemSubroutineInfo>(&desc.semantic);
 }
 
 }  // namespace lyra::support

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -276,6 +276,14 @@ auto RenderScopeAsClass(
   out += Indent(indent + 2) + "return kTimePrecisionPower;\n";
   out += Indent(indent + 1) + "}\n\n";
 
+  // The scope's own time unit (LRM 3.14.2). $time / $realtime read here to
+  // scale the design-global tick back to this design element's unit (LRM
+  // 20.3); an unqualified reference in a process or subroutine body resolves
+  // to the lexically enclosing scope's value.
+  out += Indent(indent + 1) + "static constexpr std::int8_t kTimeUnitPower = " +
+         std::to_string(static_cast<int>(s.time_resolution.unit_power)) +
+         ";\n\n";
+
   for (const auto& child : s.child_structural_scopes) {
     auto child_or =
         RenderScopeAsClass(unit, child, indent + 1, false, &this_anchor);
@@ -399,6 +407,7 @@ auto RenderScopeHeaderFile(
   out += "#include \"lyra/runtime/scope.hpp\"\n";
   out += "#include \"lyra/runtime/scan.hpp\"\n";
   out += "#include \"lyra/runtime/sformat.hpp\"\n";
+  out += "#include \"lyra/runtime/sim_time.hpp\"\n";
   out += "#include \"lyra/runtime/var.hpp\"\n";
   out += "#include \"lyra/value/enum.hpp\"\n";
   out += "#include \"lyra/value/format.hpp\"\n";

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -484,6 +484,27 @@ auto RenderRuntimeCallExpr(
                 "std::array<lyra::value::PrintItem, {}>{{{{{}}}}})",
                 sf.items.size(), body);
           },
+          [&](const mir::RuntimeTimeCall& tc) -> diag::Result<std::string> {
+            // The scaling target is the enclosing scope's time unit, read
+            // from its emitted `kTimeUnitPower` constant; unqualified lookup
+            // resolves it to the design element that lexically contains the
+            // call (LRM 20.3.1 / 3.14.2). The runtime scales against the
+            // engine's design-global tick.
+            switch (tc.kind) {
+              case support::TimeKind::kTime:
+                return std::string(
+                    "lyra::runtime::SimTimeInUnit(Services(), "
+                    "kTimeUnitPower)");
+              case support::TimeKind::kStime:
+                return std::string(
+                    "lyra::runtime::STimeInUnit(Services(), kTimeUnitPower)");
+              case support::TimeKind::kRealtime:
+                return std::string(
+                    "lyra::runtime::RealTimeInUnit(Services(), "
+                    "kTimeUnitPower)");
+            }
+            throw InternalError("RenderRuntimeCallExpr: unknown TimeKind");
+          },
       },
       expr.call);
 }

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -202,6 +202,10 @@ auto MakeReturnConventionType(
       return unit_state.Int32TypeId();
     case support::ReturnConvention::kString:
       return unit_state.StringTypeId();
+    case support::ReturnConvention::kTime64:
+      return unit_state.TimeTypeId();
+    case support::ReturnConvention::kRealTime:
+      return unit_state.RealTimeTypeId();
   }
   throw InternalError("MakeReturnConventionType: unknown ReturnConvention");
 }

--- a/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
@@ -65,6 +65,30 @@ auto LowerSystemSubroutineCall(
                 unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
                 call, sformat, span);
           },
+          [&](const support::TimeSystemSubroutineInfo& time_info)
+              -> diag::Result<mir::Expr> {
+            // No arguments to lower (LRM 20.3 takes none); the scope-unit
+            // scaling happens at render time against the emitted
+            // `kTimeUnitPower`, so the node carries only the kind. The result
+            // type is fixed by the function (LRM 20.3.1/.2/.3).
+            mir::TypeId result_type = unit_state.Builtins().time;
+            switch (time_info.kind) {
+              case support::TimeKind::kTime:
+                result_type = unit_state.Builtins().time;
+                break;
+              case support::TimeKind::kStime:
+                result_type = unit_state.Builtins().int32;
+                break;
+              case support::TimeKind::kRealtime:
+                result_type = unit_state.Builtins().realtime;
+                break;
+            }
+            return mir::Expr{
+                .data =
+                    mir::RuntimeCallExpr{
+                        .call = mir::RuntimeTimeCall{.kind = time_info.kind}},
+                .type = result_type};
+          },
       },
       desc.semantic);
 }

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -862,6 +862,21 @@ class MirDumper {
                         std::format(
                             "RuntimeSFormatCall items={}", sf.items.size()));
                   },
+                  [&](const RuntimeTimeCall& tc) {
+                    std::string_view kind_text = "time";
+                    switch (tc.kind) {
+                      case support::TimeKind::kTime:
+                        kind_text = "time";
+                        break;
+                      case support::TimeKind::kStime:
+                        kind_text = "stime";
+                        break;
+                      case support::TimeKind::kRealtime:
+                        kind_text = "realtime";
+                        break;
+                    }
+                    Line(std::format("RuntimeTimeCall kind={}", kind_text));
+                  },
               },
               rc->call);
           Dedent();

--- a/tests/cases/cpp/timescale_realtime/case.yaml
+++ b/tests/cases/cpp/timescale_realtime/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.timescale_realtime
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      5

--- a/tests/cases/cpp/timescale_realtime/main.sv
+++ b/tests/cases/cpp/timescale_realtime/main.sv
@@ -1,0 +1,11 @@
+// $realtime (LRM 20.3.3) scales the current time to the calling scope's unit
+// like $time but returns a real, preserving any fractional part. Top is
+// 1ns/1ps, so `#5` lands at 5000 global ticks and $realtime reads
+// 5000 / 1000.0 = 5.0, printed as "5" by %g.
+`timescale 1ns / 1ps
+module Top;
+  initial begin
+    #5;
+    $display("%g", $realtime);
+  end
+endmodule

--- a/tests/cases/cpp/timescale_time_read/case.yaml
+++ b/tests/cases/cpp/timescale_time_read/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.timescale_time_read
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    t: 5
+    st: 5

--- a/tests/cases/cpp/timescale_time_read/main.sv
+++ b/tests/cases/cpp/timescale_time_read/main.sv
@@ -1,0 +1,15 @@
+// $time / $stime (LRM 20.3) return the current simulation time scaled to the
+// calling scope's time unit. Top is 1ns/1ps, so the design-global tick is 1ps
+// and `#5` lands at 5000 ticks; $time scales that back to the 1ns unit
+// (5000 / 10^(unit(-9) - global(-12)) = 5000 / 1000 = 5). $stime is the 32-bit
+// twin of the same value.
+`timescale 1ns / 1ps
+module Top;
+  time t;
+  int st;
+  initial begin
+    #5;
+    t = $time;
+    st = $stime;
+  end
+endmodule

--- a/tests/cases/cpp/timescale_time_unit_scaling/case.yaml
+++ b/tests/cases/cpp/timescale_time_unit_scaling/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.timescale_time_unit_scaling
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      Top=2500
+      Slow=3

--- a/tests/cases/cpp/timescale_time_unit_scaling/main.sv
+++ b/tests/cases/cpp/timescale_time_unit_scaling/main.sv
@@ -1,0 +1,16 @@
+// $time reports time in the calling scope's own unit (LRM 20.3), while every
+// scope shares one design-global tick (LRM 3.14.3). The global precision here
+// is 1ps. Top (unit 1ps) wakes at 2500 ticks and reads 2500; the child Slow
+// (unit 1ns) wakes at #3 = 3 ns = 3000 ticks and reads 3. Top's read prints
+// first because 2500 ticks precedes 3000 ticks on the shared axis, proving both
+// the shared time axis and the per-scope unit scaling.
+`timescale 1ps / 1ps
+module Top;
+  Slow s ();
+  initial #2500 $display("Top=%0d", $time);
+endmodule
+
+`timescale 1ns / 1ps
+module Slow;
+  initial #3 $display("Slow=%0d", $time);
+endmodule


### PR DESCRIPTION
## Summary

Adds the LRM 20.3 simulation-time read functions `$time`, `$realtime` and `$stime`. Each returns the current simulation time scaled to the time unit of the design element that lexically contains the call: `$time` rounds to the nearest integer, `$realtime` returns a real keeping the fractional part, and `$stime` is the low 32 bits. This is the read half of the timescale workstream (TS2), building on the design-global precision the engine resolves at construction (TS1).

## Design

The pre-reset tree baked the scaling divisor as a compile-time constant because it computed the design-global precision at the frontend. Under the engine-derives model the global precision is a runtime value (`RuntimeServices::GlobalPrecisionPower()`), so the divisor's denominator is unknown at lowering. Scaling therefore runs at the call site as the exact inverse of TS1's delay scaling: a delay multiplies scope-precision steps up to the global tick, a time read divides the global tick down to the scope unit.

The scope unit is not threaded onto the IR node. Each scope emits its `kTimeUnitPower` as a class constant alongside the TS1 `kTimePrecisionPower`, and the rendered call references it unqualified. Because processes and subroutines are emitted as methods on the scope class, C++ name lookup resolves `kTimeUnitPower` to the enclosing design element -- which is the LRM-correct lexical scope for a time read inside a subroutine (time unit is a static per-design-element property, LRM 3.14.2). The MIR node carries only which of the three functions it is. This mirrors how TS1's `DelayStmt` carries no precision and reads `kTimePrecisionPower` from the scope.

The three functions reach the existing value-returning system-function path (`$fopen` / `$sformatf`): a new `TimeSystemSubroutineInfo` semantic, a `RuntimeTimeCall` MIR node, and three small runtime helpers sharing one scaling core. `ReturnConvention` gains a 64-bit `time` and a `realtime` entry; `$stime` reuses the existing 32-bit convention.

## Testing

Three `cpp_run` cases: `$time` / `$stime` read under a non-trivial divisor asserted via `expect.variables`; a mixed-precision design (two scopes, different units, one shared tick) whose print order and per-scope readings prove both the shared axis and the unit scaling; and `$realtime` returning a real. Full `bazel test //...` is green.