### PR TITLE
Support multi-level and array-indexed hierarchical references

### DIFF
--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -114,8 +114,8 @@ consume. Coverage is demonstrated through Stage D and Stage E.
       remain.
 - [ ] D5 -- The hierarchical path of an instance (for `%m`, display, and scope queries) derives from
       object-tree ownership.
-- [ ] D6 -- A hierarchical path that indexes an instance array (`c[i].x`) resolves to the selected
-      element.
+- [x] D6 -- A hierarchical path that indexes an instance array (`c[i].x`) resolves to the selected
+      element, including multi-dimensional arrays (`c[i][j].x`).
 - [ ] D7 -- A hierarchical reference crosses a generate-block scope boundary: a path step through a
       generate block (`g.sig`), or a reference originating inside a generate block that names a
       signal in an enclosing scope.

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -90,13 +90,14 @@ Unlocks `instantiation/multiple_instances`, `instantiation/nested_hierarchy`,
 
 - [x] C1 -- Cross-unit references resolve once at construction into a stored direct reference, read
       directly thereafter (per `reference_resolution.md`). This is the substrate Stages D and E
-      consume. Landed for the downward, single-level form (a direct child's member); the
-      resolve-once slot is the shared path ports will populate. Multi-level navigation and upward
-      resolution feed the same slot in later cuts.
+      consume. Landed for downward references at any depth: the slot's recipe is a navigation path
+      from a local child member down to the referenced leaf, materialized once after the subtree is
+      built. The resolve-once slot is the shared path ports will populate; upward resolution feeds
+      the same slot in a later cut.
 - [x] C2 -- A process on one instance can observe a member of another instance and re-evaluate when
       that member changes, without the observed instance knowing who watches it (cross-instance
-      sensitivity). The combinational process subscribes through the resolved slot; demonstrated for
-      a downward, single-level reference.
+      sensitivity). The combinational process subscribes through the resolved slot, independent of
+      how deep the slot's path reaches.
 
 This stage produces no user-visible feature on its own; it is the substrate the next two stages
 consume. Coverage is demonstrated through Stage D and Stage E.
@@ -105,13 +106,19 @@ consume. Coverage is demonstrated through Stage D and Stage E.
 
 - [x] D1 -- A downward reference reads and writes a signal in a child instance.
 - [ ] D2 -- An upward reference reads and writes a signal in an ancestor instance.
-- [ ] D3 -- Multi-level dotted paths resolve through the object tree across more than one level.
+- [x] D3 -- Multi-level dotted paths resolve through the object tree across more than one level.
+      Landed for downward paths through scalar instances.
 - [ ] D4 -- A combinational process reading a hierarchical reference re-triggers when the referenced
-      signal changes, including paths spanning multiple levels and reads from several instances. The
-      single-level downward case re-triggers today (it rode in with D1); multi-level and
-      multi-instance paths remain.
+      signal changes, including paths spanning multiple levels and reads from several instances.
+      Downward paths re-trigger today at any depth; reads from several instances within one process
+      remain.
 - [ ] D5 -- The hierarchical path of an instance (for `%m`, display, and scope queries) derives from
       object-tree ownership.
+- [ ] D6 -- A hierarchical path that indexes an instance array (`c[i].x`) resolves to the selected
+      element.
+- [ ] D7 -- A hierarchical reference crosses a generate-block scope boundary: a path step through a
+      generate block (`g.sig`), or a reference originating inside a generate block that names a
+      signal in an enclosing scope.
 
 Unlocks `refs/hierarchical_refs`, `refs/upward_refs`, and `instantiation/hierarchical_sensitivity`.
 
@@ -143,10 +150,12 @@ Unlocks the `ports/*` archive group.
 ## Out of Scope
 
 - Interfaces, modports, and programs as compilation-unit kinds. They are unit kinds in
-  `compilation_unit_model.md` but are a separate workstream from module hierarchy.
+  `compilation_unit_model.md` but are a separate workstream from module hierarchy. A hierarchical
+  reference resolved via an interface port belongs to that workstream.
 - Primitive and gate-level instances (UDPs, built-in gates).
 - Bind directives and configuration (`config` / `bind`).
 - Net resolution and net merging: multi-driver resolved nets and net collapsing across ports. A
   single-driver net port behaves as a continuous assignment and is in scope; multi-driver net
   resolution is a separate design-global concern. `inout` ports are bidirectional net connections in
-  this same deferred net domain.
+  this same deferred net domain. A hierarchical reference whose target is a net-typed (non-variable)
+  signal follows net value support, which is not yet established in any scope.

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -41,17 +41,29 @@ struct InstanceMemberId {
       -> std::strong_ordering = default;
 };
 
+// One step of a cross-unit reference's downward navigation past the head: a
+// named member (`->name`) or an instance-array index (`[index]`). A dotted path
+// is a sequence of these; `m.l.x` is two member hops, `c[1].x` is an index hop
+// then a member hop.
+struct MemberHop {
+  std::string name;
+};
+struct IndexHop {
+  std::uint32_t index;
+};
+using PathStep = std::variant<MemberHop, IndexHop>;
+
 // A cross-unit reference resolved once at construction (see
-// reference_resolution.md). `instance` names the owned child instance member
-// this unit reaches into -- the head of the downward path. `member_path` is the
-// chain of member names from the head's child down to the referenced leaf,
-// referenced by name across the unit boundary (`c.x` is `{"x"}`; `m.l.x` is
-// `{"l", "x"}`). `type` is the slang-resolved type of the referenced leaf. The
-// slot is read / written / observed through a stored direct reference the
-// constructor materializes by chaining `->` over the path.
+// reference_resolution.md). `instance` names the owned child instance (or
+// instance-array) member this unit reaches into -- the head of the downward
+// path. `path` carries the navigation past the head down to the referenced
+// leaf, referenced by name across the unit boundary. `type` is the
+// slang-resolved type of the referenced leaf. The slot is read / written /
+// observed through a stored direct reference the constructor materializes by
+// chaining the path's hops.
 struct CrossUnitRefDecl {
   InstanceMemberId instance;
-  std::vector<std::string> member_path;
+  std::vector<PathStep> path;
   TypeId type;
 };
 

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -43,13 +43,15 @@ struct InstanceMemberId {
 
 // A cross-unit reference resolved once at construction (see
 // reference_resolution.md). `instance` names the owned child instance member
-// this unit reaches into; `target_member` is the child's interface member name,
-// referenced by name across the unit boundary; `type` is the slang-resolved
-// type of the referenced member. The slot is read / written / observed through
-// a stored direct reference the constructor materializes.
+// this unit reaches into -- the head of the downward path. `member_path` is the
+// chain of member names from the head's child down to the referenced leaf,
+// referenced by name across the unit boundary (`c.x` is `{"x"}`; `m.l.x` is
+// `{"l", "x"}`). `type` is the slang-resolved type of the referenced leaf. The
+// slot is read / written / observed through a stored direct reference the
+// constructor materializes by chaining `->` over the path.
 struct CrossUnitRefDecl {
   InstanceMemberId instance;
-  std::string target_member;
+  std::vector<std::string> member_path;
   TypeId type;
 };
 

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -72,8 +72,8 @@ struct InstanceMemberBinding {
   hir::InstanceMemberId member_id;
 };
 
-using InstanceMemberBindings = std::unordered_map<
-    const slang::ast::InstanceSymbol*, InstanceMemberBinding>;
+using InstanceMemberBindings =
+    std::unordered_map<const slang::ast::Symbol*, InstanceMemberBinding>;
 
 class UnitLoweringState {
  public:
@@ -201,23 +201,22 @@ class UnitLoweringState {
   }
 
   void MapInstanceMemberBinding(
-      const slang::ast::InstanceSymbol& inst, ScopeFrameId home_frame,
+      const slang::ast::Symbol& member, ScopeFrameId home_frame,
       hir::InstanceMemberId member_id) {
     const auto [_, inserted] = instance_member_bindings_.emplace(
-        &inst, InstanceMemberBinding{
-                   .home_frame = home_frame, .member_id = member_id});
+        &member, InstanceMemberBinding{
+                     .home_frame = home_frame, .member_id = member_id});
     if (!inserted) {
       throw InternalError(
-          "UnitLoweringState::MapInstanceMemberBinding: instance symbol "
-          "already "
-          "mapped");
+          "UnitLoweringState::MapInstanceMemberBinding: instance member "
+          "already mapped");
     }
   }
 
   [[nodiscard]] auto LookupInstanceMemberBinding(
-      const slang::ast::InstanceSymbol& inst) const
+      const slang::ast::Symbol& member) const
       -> std::optional<InstanceMemberBinding> {
-    const auto it = instance_member_bindings_.find(&inst);
+    const auto it = instance_member_bindings_.find(&member);
     if (it == instance_member_bindings_.end()) {
       return std::nullopt;
     }
@@ -230,7 +229,7 @@ class UnitLoweringState {
   // HIR scope by TakeCrossUnitRefsForFrame when the scope finishes lowering.
   auto MapOrGetCrossUnitRef(
       const slang::ast::ValueSymbol& target, ScopeFrameId home_frame,
-      hir::InstanceMemberId instance, std::vector<std::string> member_path,
+      hir::InstanceMemberId instance, std::vector<hir::PathStep> path,
       hir::TypeId type) -> hir::CrossUnitRefId {
     if (const auto it = cross_unit_ref_dedup_.find(&target);
         it != cross_unit_ref_dedup_.end()) {
@@ -240,9 +239,7 @@ class UnitLoweringState {
     const hir::CrossUnitRefId id{static_cast<std::uint32_t>(slots.size())};
     slots.push_back(
         hir::CrossUnitRefDecl{
-            .instance = instance,
-            .member_path = std::move(member_path),
-            .type = type});
+            .instance = instance, .path = std::move(path), .type = type});
     cross_unit_ref_dedup_.emplace(&target, id);
     return id;
   }

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -230,7 +230,7 @@ class UnitLoweringState {
   // HIR scope by TakeCrossUnitRefsForFrame when the scope finishes lowering.
   auto MapOrGetCrossUnitRef(
       const slang::ast::ValueSymbol& target, ScopeFrameId home_frame,
-      hir::InstanceMemberId instance, std::string target_member,
+      hir::InstanceMemberId instance, std::vector<std::string> member_path,
       hir::TypeId type) -> hir::CrossUnitRefId {
     if (const auto it = cross_unit_ref_dedup_.find(&target);
         it != cross_unit_ref_dedup_.end()) {
@@ -241,7 +241,7 @@ class UnitLoweringState {
     slots.push_back(
         hir::CrossUnitRefDecl{
             .instance = instance,
-            .target_member = std::move(target_member),
+            .member_path = std::move(member_path),
             .type = type});
     cross_unit_ref_dedup_.emplace(&target, id);
     return id;

--- a/include/lyra/mir/structural_scope.hpp
+++ b/include/lyra/mir/structural_scope.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include "lyra/base/time.hpp"
@@ -16,15 +18,25 @@
 
 namespace lyra::mir {
 
+// One step of a cross-unit reference's downward navigation past the head: a
+// named member (`->name`) or an instance-array index (`[index]`).
+struct MemberHop {
+  std::string name;
+};
+struct IndexHop {
+  std::uint32_t index;
+};
+using PathStep = std::variant<MemberHop, IndexHop>;
+
 // A cross-unit reference resolved once at construction. `instance_var` is the
-// structural var holding the owned child instance -- the head of the downward
-// path; `member_path` is the chain of member names from the head's child down
-// to the referenced leaf (`c.x` is `{"x"}`; `m.l.x` is `{"l", "x"}`); `type` is
-// the referenced leaf's type. The backend stores a direct reference to
-// `instance_var->...->leaf` by chaining `->` over the path.
+// structural var holding the owned child instance (or instance-array) -- the
+// head of the downward path; `path` carries the navigation past the head down
+// to the referenced leaf; `type` is the referenced leaf's type. The backend
+// stores a direct reference to the leaf by chaining the path's hops from
+// `instance_var`.
 struct CrossUnitRefDecl {
   StructuralVarId instance_var;
-  std::vector<std::string> member_path;
+  std::vector<PathStep> path;
   TypeId type;
 };
 

--- a/include/lyra/mir/structural_scope.hpp
+++ b/include/lyra/mir/structural_scope.hpp
@@ -17,12 +17,14 @@
 namespace lyra::mir {
 
 // A cross-unit reference resolved once at construction. `instance_var` is the
-// structural var holding the owned child instance; `target_member` is the
-// child's interface member name; `type` is the referenced member's type. The
-// backend stores a direct reference to `instance_var->target_member`.
+// structural var holding the owned child instance -- the head of the downward
+// path; `member_path` is the chain of member names from the head's child down
+// to the referenced leaf (`c.x` is `{"x"}`; `m.l.x` is `{"l", "x"}`); `type` is
+// the referenced leaf's type. The backend stores a direct reference to
+// `instance_var->...->leaf` by chaining `->` over the path.
 struct CrossUnitRefDecl {
   StructuralVarId instance_var;
-  std::string target_member;
+  std::vector<std::string> member_path;
   TypeId type;
 };
 

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -312,7 +312,7 @@ auto RenderRuntimeCallExpr(
               return std::unexpected(std::move(print_or.error()));
             }
             return std::format(
-                "services_->SubmitPostponed([=, this]() {{ {}; }})", *print_or);
+                "Services().SubmitPostponed([=, this]() {{ {}; }})", *print_or);
           },
           [&](const mir::RuntimeFileOpenCall& fo) -> diag::Result<std::string> {
             auto name_or = RenderExpr(ctx, ctx.Expr(fo.name));

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -184,10 +184,10 @@ auto RenderConstructExternalUnitStmt(
 }
 
 // Points the slot at the leaf member it references, once the subtree exists.
-// The slot is a `Var<T>*`; the head instance var and every intervening instance
-// are owning pointers, so the path is reached by chaining `->` from the head
-// down to the leaf and taking its address (LRM 23.6 resolved at construction,
-// reference_resolution.md).
+// The slot is a `Var<T>*`; the head var and every intervening instance are
+// owning pointers reached with `->`, and an instance-array hop indexes the
+// owning vector with `[i]`. Taking the address yields the resolved reference
+// (LRM 23.6 resolved at construction, reference_resolution.md).
 auto RenderResolveCrossUnitRefStmt(
     const RenderContext& ctx, const mir::ResolveCrossUnitRefStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
@@ -195,8 +195,12 @@ auto RenderResolveCrossUnitRefStmt(
   const auto& inst = ctx.StructuralScope().GetStructuralVar(slot.instance_var);
   std::string out =
       Indent(indent) + CrossUnitRefSlotName(s.slot.value) + " = &" + inst.name;
-  for (const auto& member : slot.member_path) {
-    out += "->" + member;
+  for (const auto& step : slot.path) {
+    if (const auto* member = std::get_if<mir::MemberHop>(&step)) {
+      out += "->" + member->name;
+    } else {
+      out += "[" + std::to_string(std::get<mir::IndexHop>(step).index) + "]";
+    }
   }
   out += ";\n";
   return out;

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -183,17 +183,23 @@ auto RenderConstructExternalUnitStmt(
       ctx, var.name, var.type, s.unit_name, var.name, s.dims, 0, indent);
 }
 
-// Points the slot at the child member it references, once the child exists.
-// The slot is a `Var<T>*`; the child instance var is an owning pointer, so the
-// member is reached with `->` and its address taken (LRM 23.6 resolved at
-// construction, reference_resolution.md).
+// Points the slot at the leaf member it references, once the subtree exists.
+// The slot is a `Var<T>*`; the head instance var and every intervening instance
+// are owning pointers, so the path is reached by chaining `->` from the head
+// down to the leaf and taking its address (LRM 23.6 resolved at construction,
+// reference_resolution.md).
 auto RenderResolveCrossUnitRefStmt(
     const RenderContext& ctx, const mir::ResolveCrossUnitRefStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
   const auto& slot = ctx.StructuralScope().GetCrossUnitRef(s.slot);
   const auto& inst = ctx.StructuralScope().GetStructuralVar(slot.instance_var);
-  return Indent(indent) + CrossUnitRefSlotName(s.slot.value) + " = &" +
-         inst.name + "->" + slot.target_member + ";\n";
+  std::string out =
+      Indent(indent) + CrossUnitRefSlotName(s.slot.value) + " = &" + inst.name;
+  for (const auto& member : slot.member_path) {
+    out += "->" + member;
+  }
+  out += ";\n";
+  return out;
 }
 
 auto RenderForStmtNode(

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -1,5 +1,6 @@
 #include "lyra/lowering/ast_to_hir/expression/lower.hpp"
 
+#include <cstdint>
 #include <expected>
 #include <optional>
 #include <string>
@@ -285,12 +286,12 @@ auto LowerNamedValueProc(
       binding->type, span);
 }
 
-// LRM 23.6 hierarchical reference. Resolves a downward path through scalar
-// instances (`c.x`, `m.l.x`, ...) into a cross-unit reference slot whose recipe
-// is the navigation path from a local child member down to the leaf; the
-// constructor resolution lives downstream (reference_resolution.md). Upward,
-// instance-array-indexed, generate-scope, and interface-port forms are rejected
-// explicitly here so they never lower into a silently-wrong shape.
+// LRM 23.6 hierarchical reference. Resolves a downward path through instances
+// and instance arrays (`c.x`, `m.l.x`, `c[1].x`, ...) into a cross-unit
+// reference slot whose recipe is the navigation path from a local child member
+// down to the leaf; the constructor resolution lives downstream
+// (reference_resolution.md). Upward, generate-scope, and interface-port forms
+// are rejected explicitly here so they never lower into a silently-wrong shape.
 auto LowerHierarchicalValueProc(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     const ScopeStack& stack, const slang::ast::HierarchicalValueExpression& hve)
@@ -321,36 +322,28 @@ auto LowerHierarchicalValueProc(
   }
 
   // ref.path is slang's resolved top-down navigation: path.front() is the head
-  // instance (this unit's local member); the remaining elements name the
-  // members down to the leaf (path.back() is `target`). A non-name selector is
-  // an instance-array index step, not yet supported.
-  for (const auto& step : ref.path) {
-    if (!std::holds_alternative<std::string_view>(step.selector)) {
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedExpressionForm,
-          "instance-array index in hierarchical path is not yet supported",
-          diag::UnsupportedCategory::kOperation);
-    }
-  }
+  // (this unit's local instance or instance-array member); the rest navigate
+  // down to the leaf (path.back() is `target`), each step a named member or an
+  // instance-array index.
   const slang::ast::Symbol& head_sym = *ref.path.front().symbol;
-  if (head_sym.kind != slang::ast::SymbolKind::Instance) {
+  const bool head_is_instance_member =
+      head_sym.kind == slang::ast::SymbolKind::Instance ||
+      head_sym.kind == slang::ast::SymbolKind::InstanceArray;
+  if (!head_is_instance_member) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "hierarchical reference through a generate-block scope is not yet "
         "supported",
         diag::UnsupportedCategory::kOperation);
   }
-  // The head is a scalar instance reached downward from this unit's scope, so
-  // it is a direct instance member, which the pre-pass always binds. A downward
-  // path cannot reach a sibling top-level unit (that routes through $root and
-  // is caught by isUpward above), so a missing binding is a compiler-bug
-  // invariant.
-  const auto head_binding = unit_state.LookupInstanceMemberBinding(
-      head_sym.as<slang::ast::InstanceSymbol>());
+  // An instance / instance-array member reached downward from this unit's scope
+  // is a direct member, which the pre-pass always binds. A downward path cannot
+  // reach a sibling top-level unit (that routes through $root and is caught by
+  // isUpward above), so a missing binding is a compiler-bug invariant.
+  const auto head_binding = unit_state.LookupInstanceMemberBinding(head_sym);
   if (!head_binding.has_value()) {
     throw InternalError(
-        "LowerHierarchicalValueProc: downward head instance has no local "
-        "member binding");
+        "LowerHierarchicalValueProc: downward head member has no binding");
   }
   const auto hops = stack.HopsTo(head_binding->home_frame);
   if (!hops.has_value() || hops->value != 0) {
@@ -361,10 +354,24 @@ auto LowerHierarchicalValueProc(
         diag::UnsupportedCategory::kOperation);
   }
 
-  std::vector<std::string> member_path;
-  member_path.reserve(ref.path.size() - 1);
+  std::vector<hir::PathStep> path;
+  path.reserve(ref.path.size() - 1);
   for (const auto& step : ref.path.subspan(1)) {
-    member_path.emplace_back(std::get<std::string_view>(step.selector));
+    if (std::holds_alternative<std::string_view>(step.selector)) {
+      path.emplace_back(
+          hir::MemberHop{
+              std::string{std::get<std::string_view>(step.selector)}});
+    } else if (std::holds_alternative<std::int32_t>(step.selector)) {
+      path.emplace_back(
+          hir::IndexHop{static_cast<std::uint32_t>(
+              std::get<std::int32_t>(step.selector))});
+    } else {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "instance-array range select in a hierarchical path is not yet "
+          "supported",
+          diag::UnsupportedCategory::kOperation);
+    }
   }
 
   auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, hve);
@@ -372,8 +379,8 @@ auto LowerHierarchicalValueProc(
 
   const auto& var = target.as<slang::ast::VariableSymbol>();
   const hir::CrossUnitRefId slot = unit_state.MapOrGetCrossUnitRef(
-      var, head_binding->home_frame, head_binding->member_id,
-      std::move(member_path), *type_id);
+      var, head_binding->home_frame, head_binding->member_id, std::move(path),
+      *type_id);
   return MakeRefExpr(hir::CrossUnitVarRef{.id = slot}, *type_id, span);
 }
 

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <slang/ast/Expression.h>
@@ -284,12 +285,12 @@ auto LowerNamedValueProc(
       binding->type, span);
 }
 
-// LRM 23.6 hierarchical reference. Resolves the downward, single-level scalar
-// form (`c.x`, `c` a direct child instance of the referring scope) into a
-// cross-unit reference slot; the slot's navigation recipe and the constructor
-// resolution live downstream (reference_resolution.md). Upward, multi-level,
-// instance-array, and interface-port forms are rejected explicitly here so they
-// never lower into a silently-wrong shape.
+// LRM 23.6 hierarchical reference. Resolves a downward path through scalar
+// instances (`c.x`, `m.l.x`, ...) into a cross-unit reference slot whose recipe
+// is the navigation path from a local child member down to the leaf; the
+// constructor resolution lives downstream (reference_resolution.md). Upward,
+// instance-array-indexed, generate-scope, and interface-port forms are rejected
+// explicitly here so they never lower into a silently-wrong shape.
 auto LowerHierarchicalValueProc(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     const ScopeStack& stack, const slang::ast::HierarchicalValueExpression& hve)
@@ -301,13 +302,13 @@ auto LowerHierarchicalValueProc(
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "interface-port hierarchical reference is not yet supported",
-        diag::UnsupportedCategory::kFeature);
+        diag::UnsupportedCategory::kOperation);
   }
   if (ref.isUpward()) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "upward hierarchical reference is not yet supported",
-        diag::UnsupportedCategory::kFeature);
+        diag::UnsupportedCategory::kOperation);
   }
 
   const auto& target = hve.symbol;
@@ -316,43 +317,54 @@ auto LowerHierarchicalValueProc(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "cross-unit reference to a non-variable declaration is not yet "
         "supported",
-        diag::UnsupportedCategory::kFeature);
+        diag::UnsupportedCategory::kOperation);
   }
 
-  // Single-level downward: the referenced member must be a direct member of a
-  // child instance body. A deeper target (`c.gen.x`) sits in a nested scope and
-  // is a multi-level reference, which is not yet supported.
-  const slang::ast::Scope* parent = target.getParentScope();
-  if (parent == nullptr ||
-      parent->asSymbol().kind != slang::ast::SymbolKind::InstanceBody) {
-    return diag::Unsupported(
-        span, diag::DiagCode::kUnsupportedExpressionForm,
-        "multi-level hierarchical reference is not yet supported",
-        diag::UnsupportedCategory::kFeature);
+  // ref.path is slang's resolved top-down navigation: path.front() is the head
+  // instance (this unit's local member); the remaining elements name the
+  // members down to the leaf (path.back() is `target`). A non-name selector is
+  // an instance-array index step, not yet supported.
+  for (const auto& step : ref.path) {
+    if (!std::holds_alternative<std::string_view>(step.selector)) {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "instance-array index in hierarchical path is not yet supported",
+          diag::UnsupportedCategory::kOperation);
+    }
   }
-  const slang::ast::InstanceSymbol* inst =
-      parent->asSymbol().as<slang::ast::InstanceBodySymbol>().parentInstance;
-  if (inst == nullptr) {
+  const slang::ast::Symbol& head_sym = *ref.path.front().symbol;
+  if (head_sym.kind != slang::ast::SymbolKind::Instance) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedExpressionForm,
-        "hierarchical reference target has no instance parent",
-        diag::UnsupportedCategory::kFeature);
-  }
-
-  const auto inst_binding = unit_state.LookupInstanceMemberBinding(*inst);
-  if (!inst_binding.has_value()) {
-    return diag::Unsupported(
-        span, diag::DiagCode::kUnsupportedExpressionForm,
-        "hierarchical reference through this instance form is not yet "
+        "hierarchical reference through a generate-block scope is not yet "
         "supported",
-        diag::UnsupportedCategory::kFeature);
+        diag::UnsupportedCategory::kOperation);
   }
-  const auto hops = stack.HopsTo(inst_binding->home_frame);
+  // The head is a scalar instance reached downward from this unit's scope, so
+  // it is a direct instance member, which the pre-pass always binds. A downward
+  // path cannot reach a sibling top-level unit (that routes through $root and
+  // is caught by isUpward above), so a missing binding is a compiler-bug
+  // invariant.
+  const auto head_binding = unit_state.LookupInstanceMemberBinding(
+      head_sym.as<slang::ast::InstanceSymbol>());
+  if (!head_binding.has_value()) {
+    throw InternalError(
+        "LowerHierarchicalValueProc: downward head instance has no local "
+        "member binding");
+  }
+  const auto hops = stack.HopsTo(head_binding->home_frame);
   if (!hops.has_value() || hops->value != 0) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedExpressionForm,
-        "multi-level hierarchical reference is not yet supported",
-        diag::UnsupportedCategory::kFeature);
+        "hierarchical reference across a generate-block scope boundary is not "
+        "yet supported",
+        diag::UnsupportedCategory::kOperation);
+  }
+
+  std::vector<std::string> member_path;
+  member_path.reserve(ref.path.size() - 1);
+  for (const auto& step : ref.path.subspan(1)) {
+    member_path.emplace_back(std::get<std::string_view>(step.selector));
   }
 
   auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, hve);
@@ -360,8 +372,8 @@ auto LowerHierarchicalValueProc(
 
   const auto& var = target.as<slang::ast::VariableSymbol>();
   const hir::CrossUnitRefId slot = unit_state.MapOrGetCrossUnitRef(
-      var, inst_binding->home_frame, inst_binding->member_id,
-      std::string{var.name}, *type_id);
+      var, head_binding->home_frame, head_binding->member_id,
+      std::move(member_path), *type_id);
   return MakeRefExpr(hir::CrossUnitVarRef{.id = slot}, *type_id, span);
 }
 
@@ -1804,8 +1816,8 @@ auto ValidateAssignableSlangExpr(
           unit_facts, unit_state, proc_state, ma.value());
     }
     case EK::HierarchicalValue: {
-      // A downward cross-unit write (`c.x = ...`). The downward / single-level
-      // / scalar guard and the slot creation run during lowering
+      // A downward cross-unit write (`c.x = ...`, `m.l.x = ...`). The path
+      // guards and the slot creation run during lowering
       // (LowerHierarchicalValueProc on the assignment target); validation only
       // confirms the target is a variable. A continuous-assignment context has
       // no process, and cross-unit continuous-assign targets are deferred.

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -280,11 +280,16 @@ auto LowerInstanceArrayMemberInto(
     level = arr.elements.front();
   }
   const auto& leaf = level->as<slang::ast::InstanceSymbol>();
-  scope_state.AddInstanceMember(
+  const hir::InstanceMemberId member_id = scope_state.AddInstanceMember(
       hir::InstanceMemberDecl{
           .instance_name = std::string{array.name},
           .target_unit = std::string{leaf.getDefinition().name},
           .array_dims = std::move(dims)});
+  // A downward cross-unit reference whose path indexes this array (`c[i].x`)
+  // resolves the leading `c` to this member; the binding lets process-body
+  // lowering find it regardless of source order.
+  scope_state.UnitState().MapInstanceMemberBinding(
+      array, scope_state.Frame(), member_id);
   return {};
 }
 

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -230,10 +230,19 @@ void InstallCrossUnitRefs(
   for (const auto& cu : scope.cross_unit_refs) {
     const mir::StructuralVarId instance_var =
         instance_member_vars.at(cu.instance.value);
+    std::vector<mir::PathStep> path;
+    path.reserve(cu.path.size());
+    for (const auto& step : cu.path) {
+      if (const auto* member = std::get_if<hir::MemberHop>(&step)) {
+        path.emplace_back(mir::MemberHop{member->name});
+      } else {
+        path.emplace_back(mir::IndexHop{std::get<hir::IndexHop>(step).index});
+      }
+    }
     const mir::CrossUnitRefId slot = scope_state.AddCrossUnitRef(
         mir::CrossUnitRefDecl{
             .instance_var = instance_var,
-            .member_path = cu.member_path,
+            .path = std::move(path),
             .type = unit_state.TranslateType(cu.type)});
     const mir::StmtId sid = ctor_scope_state.AddStmt(
         mir::Stmt{

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -233,7 +233,7 @@ void InstallCrossUnitRefs(
     const mir::CrossUnitRefId slot = scope_state.AddCrossUnitRef(
         mir::CrossUnitRefDecl{
             .instance_var = instance_var,
-            .target_member = cu.target_member,
+            .member_path = cu.member_path,
             .type = unit_state.TranslateType(cu.type)});
     const mir::StmtId sid = ctor_scope_state.AddStmt(
         mir::Stmt{

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -614,10 +614,15 @@ class MirDumper {
       Indent();
       for (std::size_t i = 0; i < s.cross_unit_refs.size(); ++i) {
         const auto& cu = s.cross_unit_refs[i];
+        std::string path;
+        for (const auto& member : cu.member_path) {
+          if (!path.empty()) path += ".";
+          path += member;
+        }
         Line(
             std::format(
-                "[{}] StructuralVar[{}].\"{}\" : {}", i, cu.instance_var.value,
-                cu.target_member, FormatVarType(cu.type)));
+                "[{}] StructuralVar[{}].{} : {}", i, cu.instance_var.value,
+                path, FormatVarType(cu.type)));
       }
       Dedent();
     }

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -615,14 +615,17 @@ class MirDumper {
       for (std::size_t i = 0; i < s.cross_unit_refs.size(); ++i) {
         const auto& cu = s.cross_unit_refs[i];
         std::string path;
-        for (const auto& member : cu.member_path) {
-          if (!path.empty()) path += ".";
-          path += member;
+        for (const auto& step : cu.path) {
+          if (const auto* member = std::get_if<MemberHop>(&step)) {
+            path += "." + member->name;
+          } else {
+            path += std::format("[{}]", std::get<IndexHop>(step).index);
+          }
         }
         Line(
             std::format(
-                "[{}] StructuralVar[{}].{} : {}", i, cu.instance_var.value,
-                path, FormatVarType(cu.type)));
+                "[{}] StructuralVar[{}]{} : {}", i, cu.instance_var.value, path,
+                FormatVarType(cu.type)));
       }
       Dedent();
     }

--- a/tests/cases/cpp/hierarchy_xunit_array_index/case.yaml
+++ b/tests/cases/cpp/hierarchy_xunit_array_index/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_xunit_array_index
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "r=42\n"

--- a/tests/cases/cpp/hierarchy_xunit_array_index/main.sv
+++ b/tests/cases/cpp/hierarchy_xunit_array_index/main.sv
@@ -1,0 +1,14 @@
+module Leaf;
+  int x;
+endmodule
+
+module Top;
+  Leaf c[2][3] ();
+  int r;
+  initial begin
+    c[1][2].x = 42;
+    #1;
+    r = c[1][2].x;
+    $display("r=%0d", r);
+  end
+endmodule

--- a/tests/cases/cpp/hierarchy_xunit_multilevel/case.yaml
+++ b/tests/cases/cpp/hierarchy_xunit_multilevel/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_xunit_multilevel
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "r=42\n"

--- a/tests/cases/cpp/hierarchy_xunit_multilevel/main.sv
+++ b/tests/cases/cpp/hierarchy_xunit_multilevel/main.sv
@@ -1,0 +1,18 @@
+module Leaf;
+  int x;
+endmodule
+
+module Mid;
+  Leaf l();
+endmodule
+
+module Top;
+  Mid m();
+  int r;
+  initial begin
+    m.l.x = 42;
+    #1;
+    r = m.l.x;
+    $display("r=%0d", r);
+  end
+endmodule

--- a/tests/cases/cpp/hierarchy_xunit_multilevel_comb/case.yaml
+++ b/tests/cases/cpp/hierarchy_xunit_multilevel_comb/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_xunit_multilevel_comb
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "r=9\n"

--- a/tests/cases/cpp/hierarchy_xunit_multilevel_comb/main.sv
+++ b/tests/cases/cpp/hierarchy_xunit_multilevel_comb/main.sv
@@ -1,0 +1,25 @@
+module Leaf;
+  int x;
+  initial begin
+    x = 1;
+    #1 x = 9;
+  end
+endmodule
+
+module Mid;
+  Leaf l();
+endmodule
+
+module Outer;
+  Mid m();
+endmodule
+
+module Top;
+  Outer o();
+  int r;
+  always_comb r = o.m.l.x;
+  initial begin
+    #2;
+    $display("r=%0d", r);
+  end
+endmodule


### PR DESCRIPTION
## Summary

This extends downward cross-unit hierarchical references from the single-level scalar form to arbitrary downward paths. The cross-unit reference recipe is now an N-hop navigation path rather than a single child member, so a slot resolves once at construction into `&head->...->leaf` no matter how deep the path runs. Each hop is either a named member (`->name`) or an instance-array index (`[i]`), so `c.x`, `m.l.x`, `c[1].x`, and `c[1][2].x` all lower through one uniform mechanism; the slot stays a single observable pointer, so reads, writes, and combinational re-triggering ride the existing substrate at any depth.

The lowering consumes slang's already-resolved `ref.path` directly instead of reconstructing the path by walking parent instances, which removes a special-cased single-hop reconstruction and lets the multi-level and array cases fall out of the same loop. Instance arrays are now bound as referenceable members so an array head resolves, and the array index slang hands us in the path selector is rendered straight through.

Every remaining rejection in this path is now traceable: upward references and the generate-block-scope cases map to tracked roadmap items, a downward head that fails to bind is a compiler-bug invariant rather than a user-facing error, and references to net-typed signals or via interface ports belong to other workstreams noted in the progress doc.

## Other changes

While running the cpp suite against the rebased base, the emitted `$strobe` postponed-region print was reaching the runtime through the private `services_` member instead of the `Services()` accessor, so the generated code failed to compile. That codegen is corrected here. The fault was invisible to CI because the cpp end-to-end suite requires a host C++ compiler and is excluded from the standard test job.

## Deferred

Hierarchical references that cross a generate-block scope boundary (D7) are left as a follow-up: the generate companion object is given a synthetic positional name at HIR to MIR, so resolving such a hop is a structural change rather than a one-line addition, and is best designed on its own.