### PR TITLE
Add $fstrobe family with postponed-region file-sink semantics

### DIFF
--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -98,12 +98,19 @@ the corresponding behaviour lands.
 
 ## Strobe family follow-ups
 
-Tracks the remaining LRM 21.2.2 file-sink variants now that the stdout-sink half has shipped.
-
-- [ ] `$fstrobe` / `$fstrobeb` / `$fstrobeh` / `$fstrobeo` (LRM 21.2.2, file sink). The
-      `PrintSinkKind::kFile` axis on `PrintSystemSubroutineInfo` and the descriptor / MCD-FD
-      dispatch already exist (DI5); the gap is four descriptor rows plus threading the
-      file-descriptor argument through the strobe closure-submit helper.
+- [x] `$fstrobe` / `$fstrobeb` / `$fstrobeh` / `$fstrobeo` (LRM 21.2.2 + 21.3.2, file sink). Four
+      descriptor rows with `sink_kind = kFile`, `is_strobe = true`, and `min_args = 1` were enough
+      to light up the whole family end-to-end: the HIR -> MIR lowering, the C++ backend, and the
+      runtime were already orthogonal across the `sink_kind` and `is_strobe` axes after DI5 and DI6
+      shipped. First argument is an MCD or FD per LRM 21.3.1; the rest is the print payload at the
+      per-task default radix. Postponed lambdas reference the descriptor through their capture list,
+      so module-scope FDs read NBA-committed values at fire time and procedural- local FDs snapshot
+      at submit time.
+- [ ] LRM 21.3.2 implicit cancel on `$fclose`. "Active `$fmonitor` and/or `$fstrobe` operations on a
+      file descriptor or multichannel descriptor are implicitly cancelled by an `$fclose`
+      operation." Today the postponed lambda fires unconditionally and the underlying `LyraFPrint`
+      hits the closed FD; the cancel path needs an FD/MCD -> pending-callback tracking layer and
+      will likely be tackled together with `$fmonitor`, which shares the cancellation mechanism.
 
 ## Out of Scope
 

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -726,6 +726,62 @@ inline constexpr std::array kSystemSubroutines = {
         .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 0},
         .semantic = TimeSystemSubroutineInfo{.kind = TimeKind::kRealtime},
     },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{47},
+        .name = "$fstrobe",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 1, .max_args = 255},
+        .semantic =
+            PrintSystemSubroutineInfo{
+                .radix = PrintRadix::kDecimal,
+                .append_newline = true,
+                .is_strobe = true,
+                .sink_kind = PrintSinkKind::kFile},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{48},
+        .name = "$fstrobeb",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 1, .max_args = 255},
+        .semantic =
+            PrintSystemSubroutineInfo{
+                .radix = PrintRadix::kBinary,
+                .append_newline = true,
+                .is_strobe = true,
+                .sink_kind = PrintSinkKind::kFile},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{49},
+        .name = "$fstrobeh",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 1, .max_args = 255},
+        .semantic =
+            PrintSystemSubroutineInfo{
+                .radix = PrintRadix::kHex,
+                .append_newline = true,
+                .is_strobe = true,
+                .sink_kind = PrintSinkKind::kFile},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{50},
+        .name = "$fstrobeo",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 1, .max_args = 255},
+        .semantic =
+            PrintSystemSubroutineInfo{
+                .radix = PrintRadix::kOctal,
+                .append_newline = true,
+                .is_strobe = true,
+                .sink_kind = PrintSinkKind::kFile},
+    },
 };
 
 }  // namespace detail

--- a/tests/cases/cpp/fstrobe_after_nba_lrm_21_2_2/case.yaml
+++ b/tests/cases/cpp/fstrobe_after_nba_lrm_21_2_2/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.fstrobe_after_nba_lrm_21_2_2
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  files:
+    out.txt: |
+      fdisplay cnt=0
+      fstrobe  cnt=1

--- a/tests/cases/cpp/fstrobe_after_nba_lrm_21_2_2/main.sv
+++ b/tests/cases/cpp/fstrobe_after_nba_lrm_21_2_2/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  logic clk;
+  int   cnt;
+  int   fd;
+  initial begin
+    fd = $fopen("out.txt", "w");
+    clk = 0;
+    cnt = 0;
+    #1 clk = 1;
+    #1 $fclose(fd);
+  end
+  always @(posedge clk) begin
+    cnt <= cnt + 1;
+    $fdisplay(fd, "fdisplay cnt=%0d", cnt);
+    $fstrobe (fd, "fstrobe  cnt=%0d", cnt);
+  end
+endmodule

--- a/tests/cases/cpp/fstrobe_radix_variants/case.yaml
+++ b/tests/cases/cpp/fstrobe_radix_variants/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.fstrobe_radix_variants
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  files:
+    out.txt: |
+      171
+      10101011
+      ab
+      253

--- a/tests/cases/cpp/fstrobe_radix_variants/main.sv
+++ b/tests/cases/cpp/fstrobe_radix_variants/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  int fd;
+  initial begin
+    fd = $fopen("out.txt", "w");
+    $fstrobe (fd, 8'hAB);
+    $fstrobeb(fd, 8'hAB);
+    $fstrobeh(fd, 8'hAB);
+    $fstrobeo(fd, 8'hAB);
+    #1 $fclose(fd);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds `$fstrobe` / `$fstrobeb` / `$fstrobeh` / `$fstrobeo` (LRM 21.2.2 + 21.3.2). Each call defers to the postponed region and writes through the multichannel descriptor or file descriptor passed as the first argument. The descriptor's bit pattern is interpreted per LRM 21.3.1 (MCD bit 0 = stdout, OR-able fan-out, MSB-set FD).

## Design

The four file-sink variants are added as descriptor rows only. `PrintSystemSubroutineInfo` already carries two orthogonal axes -- `sink_kind` introduced by DI5 and `is_strobe` introduced by DI6 -- so `$fstrobe` falls naturally at the `(kFile, true)` corner. The HIR -> MIR lowering, the C++ backend, and the runtime needed no edits: `lower_print.cpp` already consumes `arguments[0]` as the descriptor when `sink_kind == kFile`, the resulting `RuntimePrintCall` (descriptor included) is wrapped verbatim by `RuntimeSubmitPostponedCall`, and the backend's postponed-region lambda already routes descriptor-bearing prints through `LyraFPrint`. The lambda's `[=, this]` capture handles the FD operand the same way it handles print payload operands: module-scope FDs read through `this->` and see NBA-committed values at fire time, procedural-local FDs snapshot at submit time and survive the originating frame's death.

LRM 21.3.2's "active `$fstrobe` operations on a file descriptor or multichannel descriptor are implicitly cancelled by an `\$fclose` operation" stays out of scope -- no FD/MCD -> pending-callback tracking layer exists today, and `\$fmonitor` is the natural co-implementer. Tracked under `docs/progress/display.md`'s Strobe family follow-ups.

## Testing

`bazel test //... --test_output=errors` -- all three test targets pass. Two new `cpp_run` cases:

- `tests/cases/cpp/fstrobe_after_nba_lrm_21_2_2/` -- canonical LRM 21.2.2 + 21.3.2 reproducer; `\$fdisplay` and `\$fstrobe` on the same posedge produce `fdisplay cnt=0` / `fstrobe  cnt=1` in the output file.
- `tests/cases/cpp/fstrobe_radix_variants/` -- exercises all four descriptor rows through the file sink.