### PR TITLE
Support variable-typed module ports

### DIFF
--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -124,28 +124,34 @@ Unlocks `refs/hierarchical_refs`, `refs/upward_refs`, and `instantiation/hierarc
 
 ### Stage E -- Ports
 
-- [ ] E1 -- Port directions (input / output) and named port connections at the instantiation site.
-- [ ] E2 -- An input port reflects its parent-side source continuously: when the source changes, the
+- [x] E1 -- Port directions (input / output) and named or positional port connections at the
+      instantiation site. Landed for variable-typed ports as the implied continuous assignment
+      between the two objects' own storage (LRM 23.3.3).
+- [x] E2 -- An input port reflects its parent-side source continuously: when the source changes, the
       child sees the new value and its dependent processes re-evaluate.
-- [ ] E3 -- An output port propagates a child write so the parent-side target observes it.
-- [ ] E4 -- Expression-driven and constant-valued port connections.
+- [x] E3 -- An output port propagates a child write so the parent-side target observes it.
+- [x] E4 -- Expression-driven and constant-valued port connections. A constant connection drives the
+      port once at construction and then holds.
 - [ ] E5 -- Single-driver net-typed ports alongside variable-typed ports; both behave as continuous
       assignments between the two objects' own storage.
-- [ ] E6 -- Pass-through ports (a port forwarded into a deeper child while the module keeps its own
-      local state) and sibling-to-sibling connections through a shared parent signal.
+- [x] E6 -- Pass-through ports (a port forwarded into a deeper child while the module keeps its own
+      local state) and sibling-to-sibling connections through a shared parent signal. Landed for
+      variable-typed ports; both endpoints keep their own storage.
+- [ ] E7 -- A `ref` port aliases the connected variable as a hierarchical reference, sharing its
+      storage with no separate continuous assignment (LRM 23.3.3.2).
+- [ ] E8 -- An input port left unconnected takes its declared default value (LRM 23.2.2.4).
+- [ ] E9 -- A port connection on an instance array drives each element.
+- [ ] E10 -- A port connection whose type is non-integral (an unpacked struct or array).
 
 Unlocks the `ports/*` archive group.
 
 ## Open Questions
 
-- Relative order of Stage D and Stage E. Both sit on the Stage C substrate. Hierarchical references
-  exercise the read / write / sensitivity surface most directly and may be the cleaner forcing
-  function for C; ports add connection direction and continuous propagation on top. Ports are more
-  fundamental to real designs. Order to be decided when Stage C lands.
 - How much of the specialization-key classification (which inputs are code-shape-affecting) is
   pinned in A2 versus refined as later stages reveal more code-shape-affecting inputs.
-- Whether positional port connections and connection shorthands (`.*`, `.name` implicit) are in
-  scope for Stage E or deferred.
+- Connection shorthands (`.*`, `.name` implicit) resolve to the same connection set as explicit
+  named connections in the frontend; whether any need distinct handling is open. Positional and
+  explicit named connections are both supported.
 
 ## Out of Scope
 

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -31,6 +31,7 @@ enum class DiagCode : std::uint32_t {
   kUnsupportedDelayExpressionForm,
   kUnsupportedEventTriggerForm,
   kUnsupportedContinuousAssignForm,
+  kUnsupportedPortConnectionForm,
   kUnsupportedAssignmentPatternKind,
   kUnsupportedSubroutineArgument,
 

--- a/include/lyra/lowering/ast_to_hir/expression/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/lower.hpp
@@ -1,12 +1,20 @@
 #pragma once
 
+#include <vector>
+
 #include <slang/ast/Expression.h>
 
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/inside_item.hpp"
+#include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
+
+namespace slang::ast {
+class ValueSymbol;
+}  // namespace slang::ast
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -43,5 +51,17 @@ auto LowerInsideItem(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     ProcessLoweringState& proc_state, const ScopeStack& stack,
     const slang::ast::Expression& item_expr) -> diag::Result<hir::InsideItem>;
+
+// Builds a reference expression to a leaf reached by navigating `path` from a
+// local instance member (the head) down into a child unit. `target` is the
+// leaf value symbol (the cross-unit dedup key); `member` and `home_frame`
+// locate the head. Both a hierarchical reference (`c.x`, `m.l.x`) and a port
+// connection's child-side endpoint resolve through this one path
+// (reference_resolution.md).
+auto MakeCrossUnitMemberRef(
+    UnitLoweringState& unit_state, const slang::ast::ValueSymbol& target,
+    ScopeFrameId home_frame, hir::InstanceMemberId member,
+    std::vector<hir::PathStep> path, hir::TypeId type, diag::SourceSpan span)
+    -> hir::Expr;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/port_connection.hpp
+++ b/include/lyra/lowering/ast_to_hir/port_connection.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/lowering/ast_to_hir/facts.hpp"
+#include "lyra/lowering/ast_to_hir/state.hpp"
+
+namespace slang::ast {
+class Scope;
+}  // namespace slang::ast
+
+namespace lyra::lowering::ast_to_hir {
+
+// Synthesizes the implied continuous assignments for every instance port
+// connection in `slang_scope`. A variable input or output port connection is a
+// continuous assignment between the two objects' own storage, source -> sink by
+// direction (LRM 23.3.3, 23.3.3.2); the child-side endpoint resolves through a
+// cross-unit reference, the same path a hierarchical reference uses
+// (reference_resolution.md). Input writes the child port from the parent-side
+// source; output writes the parent target from the child port. This runs after
+// every variable and instance binding in the scope exists, so a connection
+// resolves regardless of the instantiation-vs-declaration source order. `ref`
+// ports, `inout` / net ports, non-integral ports, unconnected ports, and
+// instance-array port connections are rejected so they never lower into a
+// silently-wrong shape.
+auto LowerScopePortConnectionsInto(
+    const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
+    ScopeStack& stack, const slang::ast::Scope& slang_scope)
+    -> diag::Result<void>;
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -133,6 +133,12 @@ constexpr std::array kEntries{
             .category = UnsupportedCategory::kFeature,
             .name = "unsupported_continuous_assign_form"}},
     std::pair{
+        DiagCode::kUnsupportedPortConnectionForm,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_port_connection_form"}},
+    std::pair{
         DiagCode::kUnsupportedAssignmentPatternKind,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -382,10 +382,9 @@ auto LowerHierarchicalValueProc(
   if (!type_id) return std::unexpected(std::move(type_id.error()));
 
   const auto& var = target.as<slang::ast::VariableSymbol>();
-  const hir::CrossUnitRefId slot = unit_state.MapOrGetCrossUnitRef(
-      var, head_binding->home_frame, head_binding->member_id, std::move(path),
-      *type_id);
-  return MakeRefExpr(hir::CrossUnitVarRef{.id = slot}, *type_id, span);
+  return MakeCrossUnitMemberRef(
+      unit_state, var, head_binding->home_frame, head_binding->member_id,
+      std::move(path), *type_id, span);
 }
 
 auto LowerNamedValueStructural(
@@ -1446,6 +1445,16 @@ auto LowerConditionalExprStructural(
 }
 
 }  // namespace
+
+auto MakeCrossUnitMemberRef(
+    UnitLoweringState& unit_state, const slang::ast::ValueSymbol& target,
+    ScopeFrameId home_frame, hir::InstanceMemberId member,
+    std::vector<hir::PathStep> path, hir::TypeId type, diag::SourceSpan span)
+    -> hir::Expr {
+  const hir::CrossUnitRefId slot = unit_state.MapOrGetCrossUnitRef(
+      target, home_frame, member, std::move(path), type);
+  return MakeRefExpr(hir::CrossUnitVarRef{.id = slot}, type, span);
+}
 
 auto LowerInsideItem(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,

--- a/src/lyra/lowering/ast_to_hir/port_connection.cpp
+++ b/src/lyra/lowering/ast_to_hir/port_connection.cpp
@@ -1,0 +1,179 @@
+#include "lyra/lowering/ast_to_hir/port_connection.hpp"
+
+#include <cstdint>
+#include <expected>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <slang/ast/Expression.h>
+#include <slang/ast/Scope.h>
+#include <slang/ast/SemanticFacts.h>
+#include <slang/ast/expressions/AssignmentExpressions.h>
+#include <slang/ast/symbols/InstanceSymbols.h>
+#include <slang/ast/symbols/PortSymbols.h>
+#include <slang/ast/symbols/ValueSymbol.h>
+#include <slang/ast/types/Type.h>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/kind.hpp"
+#include "lyra/hir/continuous_assign.hpp"
+#include "lyra/hir/structural_scope.hpp"
+#include "lyra/lowering/ast_to_hir/expression/lower.hpp"
+#include "lyra/lowering/ast_to_hir/sensitivity.hpp"
+
+namespace lyra::lowering::ast_to_hir {
+
+namespace {
+
+auto PortConnectionUnsupported(diag::SourceSpan span, std::string message)
+    -> diag::Result<void> {
+  return diag::Unsupported(
+      span, diag::DiagCode::kUnsupportedPortConnectionForm, std::move(message),
+      diag::UnsupportedCategory::kFeature);
+}
+
+// Descends nested array dimensions to the per-element instance.
+auto ArrayElementInstance(const slang::ast::InstanceArraySymbol& array)
+    -> const slang::ast::InstanceSymbol* {
+  if (array.elements.empty()) {
+    return nullptr;
+  }
+  const auto* first = array.elements.front();
+  if (first->kind == slang::ast::SymbolKind::InstanceArray) {
+    return ArrayElementInstance(first->as<slang::ast::InstanceArraySymbol>());
+  }
+  return &first->as<slang::ast::InstanceSymbol>();
+}
+
+auto LowerInstancePortConnectionsInto(
+    const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
+    ScopeStack& stack, const slang::ast::InstanceSymbol& inst)
+    -> diag::Result<void> {
+  auto& unit_state = scope_state.UnitState();
+  const auto span = unit_facts.SourceMapper().PointSpanOf(inst.location);
+
+  // The instance member is bound in the pre-pass; a downward port reach cannot
+  // miss it, so absence is a compiler-bug invariant.
+  const auto binding = unit_state.LookupInstanceMemberBinding(inst);
+  if (!binding.has_value()) {
+    throw InternalError(
+        "LowerInstancePortConnectionsInto: instance member has no binding");
+  }
+
+  for (const auto* conn : inst.getPortConnections()) {
+    const auto& port = conn->port.as<slang::ast::PortSymbol>();
+
+    if (port.direction == slang::ast::ArgumentDirection::Ref) {
+      return PortConnectionUnsupported(
+          span, "ref port connection is not yet supported");
+    }
+    if (port.direction == slang::ast::ArgumentDirection::InOut) {
+      return PortConnectionUnsupported(
+          span, "inout port connection is not yet supported");
+    }
+    if (port.isNetPort()) {
+      return PortConnectionUnsupported(
+          span, "net-typed port connection is not yet supported");
+    }
+    const auto* internal =
+        port.internalSymbol == nullptr
+            ? nullptr
+            : port.internalSymbol->as_if<slang::ast::ValueSymbol>();
+    if (internal == nullptr) {
+      return PortConnectionUnsupported(
+          span,
+          "port not bound to a connectable variable is not yet supported");
+    }
+    const auto& port_type = port.getType();
+    if (!port_type.isIntegral()) {
+      return PortConnectionUnsupported(
+          span, "non-integral port connection is not yet supported");
+    }
+    const auto* expr = conn->getExpression();
+    if (expr == nullptr) {
+      return PortConnectionUnsupported(
+          span, "unconnected port default value is not yet supported");
+    }
+
+    auto type_id = unit_state.GetTypeId(port_type, span);
+    if (!type_id) return std::unexpected(std::move(type_id.error()));
+    hir::Expr child_ref = MakeCrossUnitMemberRef(
+        unit_state, *internal, binding->home_frame, binding->member_id,
+        {hir::MemberHop{std::string{internal->name}}}, *type_id, span);
+
+    if (port.direction == slang::ast::ArgumentDirection::In) {
+      // Input: the parent-side source drives the child port.
+      auto rhs_or = LowerStructuralExpr(
+          unit_facts, unit_state, scope_state, stack, *expr);
+      if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+      const hir::ExprId lhs_id = scope_state.AddExpr(std::move(child_ref));
+      const hir::ExprId rhs_id = scope_state.AddExpr(*std::move(rhs_or));
+      const auto& reads = unit_facts.Sensitivity().AnalyzeReads(*expr, inst);
+      scope_state.AddContinuousAssign(
+          hir::ContinuousAssign{
+              .span = span,
+              .lhs = lhs_id,
+              .rhs = rhs_id,
+              .sensitivity_list =
+                  TranslateSensitivityReads(reads, unit_state, stack)});
+      continue;
+    }
+
+    // Output: slang models the connection as `parent_target = <port>`, with the
+    // port value standing in as an EmptyArgument. The child port drives the
+    // parent target.
+    if (expr->kind != slang::ast::ExpressionKind::Assignment) {
+      throw InternalError(
+          "LowerInstancePortConnectionsInto: output port connection expression "
+          "is "
+          "not an assignment");
+    }
+    const auto& assign = expr->as<slang::ast::AssignmentExpression>();
+    auto lhs_or = LowerStructuralExpr(
+        unit_facts, unit_state, scope_state, stack, assign.left());
+    if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+    const hir::ExprId lhs_id = scope_state.AddExpr(*std::move(lhs_or));
+    const hir::ExprId rhs_id = scope_state.AddExpr(std::move(child_ref));
+    const std::uint64_t width = port_type.getBitWidth();
+    const std::vector<SensitivityRead> reads{
+        SensitivityRead{.symbol = internal, .bit_range = {0, width - 1}}};
+    scope_state.AddContinuousAssign(
+        hir::ContinuousAssign{
+            .span = span,
+            .lhs = lhs_id,
+            .rhs = rhs_id,
+            .sensitivity_list =
+                TranslateSensitivityReads(reads, unit_state, stack)});
+  }
+  return {};
+}
+
+}  // namespace
+
+auto LowerScopePortConnectionsInto(
+    const UnitLoweringFacts& unit_facts, ScopeLoweringState& scope_state,
+    ScopeStack& stack, const slang::ast::Scope& slang_scope)
+    -> diag::Result<void> {
+  for (const auto& member : slang_scope.members()) {
+    if (member.kind == slang::ast::SymbolKind::Instance) {
+      auto r = LowerInstancePortConnectionsInto(
+          unit_facts, scope_state, stack,
+          member.as<slang::ast::InstanceSymbol>());
+      if (!r) return std::unexpected(std::move(r.error()));
+    } else if (member.kind == slang::ast::SymbolKind::InstanceArray) {
+      const auto& array = member.as<slang::ast::InstanceArraySymbol>();
+      const auto* element = ArrayElementInstance(array);
+      if (element != nullptr && !element->getPortConnections().empty()) {
+        return PortConnectionUnsupported(
+            unit_facts.SourceMapper().PointSpanOf(array.location),
+            "instance-array port connection is not yet supported");
+      }
+    }
+  }
+  return {};
+}
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -28,6 +28,7 @@
 #include "lyra/lowering/ast_to_hir/expression/lower.hpp"
 #include "lyra/lowering/ast_to_hir/facts.hpp"
 #include "lyra/lowering/ast_to_hir/generate.hpp"
+#include "lyra/lowering/ast_to_hir/port_connection.hpp"
 #include "lyra/lowering/ast_to_hir/process.hpp"
 #include "lyra/lowering/ast_to_hir/state.hpp"
 #include "lyra/lowering/ast_to_hir/statement/lower.hpp"
@@ -383,6 +384,13 @@ auto LowerScopeMembersInto(
         unit_facts, scope_state, stack, member, slang_scope);
     if (!r) return std::unexpected(std::move(r.error()));
   }
+
+  // A variable port connection is an implied continuous assignment
+  // (LRM 23.3.3), synthesized after every variable and instance binding exists
+  // so its source and child-side endpoint resolve regardless of source order.
+  auto pc = LowerScopePortConnectionsInto(
+      unit_facts, scope_state, stack, slang_scope);
+  if (!pc) return std::unexpected(std::move(pc.error()));
   return {};
 }
 

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -546,7 +546,7 @@ auto LowerHirPrimaryStructural(
           [](const hir::ProceduralVarRef&) -> mir::Expr {
             throw InternalError(
                 "LowerHirPrimaryStructural: HIR ProceduralVarRef does not "
-                "appear in constructor expressions");
+                "appear in structural expressions");
           },
           [&](const hir::LoopVarRef& lv) -> mir::Expr {
             if (loop_var_mode == LoopVarLoweringMode::kProceduralInduction) {
@@ -559,11 +559,14 @@ auto LowerHirPrimaryStructural(
             }
             return LowerStructuralParamRefExpr(scope_state, lv, type);
           },
-          [](const hir::CrossUnitVarRef&) -> mir::Expr {
-            throw InternalError(
-                "LowerHirPrimaryStructural: HIR CrossUnitVarRef does not "
-                "appear "
-                "in constructor expressions");
+          [&](const hir::CrossUnitVarRef& c) -> mir::Expr {
+            // A continuous assignment lowers as a scope-level structural
+            // expression, yet it may read or write a cross-unit member: a
+            // hierarchical reference or a port connection (LRM 10.3, 23.3.3).
+            // The slot resolves once at construction (reference_resolution.md).
+            return mir::Expr{
+                .data = mir::CrossUnitVarRef{.id = {.value = c.id.value}},
+                .type = type};
           },
       },
       p);

--- a/tests/cases/cpp/ports_connections/case.yaml
+++ b/tests/cases/cpp/ports_connections/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.ports_connections
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "42 42 42 100\n"

--- a/tests/cases/cpp/ports_connections/main.sv
+++ b/tests/cases/cpp/ports_connections/main.sv
@@ -1,0 +1,32 @@
+module Src(output int d);
+  initial d = 42;
+endmodule
+
+module Snk(input int d);
+  int cap;
+  always_comb cap = d;
+endmodule
+
+module Inner(input int x);
+  int y;
+  always_comb y = x + 1;
+endmodule
+
+module Outer(input int a);
+  int local_s;
+  Inner inner(.x(a));
+  always_comb local_s = 100;
+endmodule
+
+module Top;
+  int link;
+  Src s(.d(link));
+  Snk k(.d(link));
+  int w;
+  Outer outer(.a(w));
+  initial begin
+    w = 41;
+    #1;
+    $display("%0d %0d %0d %0d", link, k.cap, outer.inner.y, outer.local_s);
+  end
+endmodule

--- a/tests/cases/cpp/ports_input/case.yaml
+++ b/tests/cases/cpp/ports_input/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.ports_input
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "8 3 42\n12 7 42\n"

--- a/tests/cases/cpp/ports_input/main.sv
+++ b/tests/cases/cpp/ports_input/main.sv
@@ -1,0 +1,20 @@
+module Sink(input int a);
+  int y;
+  always_comb y = a;
+endmodule
+
+module Top;
+  int p, q;
+  Sink named(.a(p + q));
+  Sink pos(q);
+  Sink konst(.a(42));
+  initial begin
+    p = 5;
+    q = 3;
+    #1;
+    $display("%0d %0d %0d", named.y, pos.y, konst.y);
+    q = 7;
+    #1;
+    $display("%0d %0d %0d", named.y, pos.y, konst.y);
+  end
+endmodule

--- a/tests/cases/cpp/ports_output/case.yaml
+++ b/tests/cases/cpp/ports_output/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.ports_output
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "6\n2\n"

--- a/tests/cases/cpp/ports_output/main.sv
+++ b/tests/cases/cpp/ports_output/main.sv
@@ -1,0 +1,28 @@
+module Comb(input int a, output int b);
+  always_comb b = a + 1;
+endmodule
+
+module Counter(input bit clk, output int count);
+  always_ff @(posedge clk) count <= count + 1;
+endmodule
+
+module Top;
+  int src, combed;
+  bit clk;
+  int cnt;
+  Comb u(.a(src), .b(combed));
+  Counter ctr(.clk(clk), .count(cnt));
+  initial begin
+    src = 5;
+    clk = 0;
+    #1;
+    $display("%0d", combed);
+    clk = 1;
+    #1;
+    clk = 0;
+    #1;
+    clk = 1;
+    #1;
+    $display("%0d", cnt);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Variable-typed module input and output ports now lower as the implied continuous assignment between the two objects' own storage (LRM 23.3.3): each connection becomes a synthesized continuous assignment in the parent, with the child-side endpoint resolved through the existing cross-unit reference slot. Input writes the child port from the parent-side source; output writes the parent target from the child port. This is the second consumer of the Stage C cross-unit substrate, sharing one resolution path with hierarchical references rather than introducing a parallel mechanism.

## Design

A port connection adds no new IR, backend, or runtime -- the continuous-assignment construct and the depth-1 cross-unit slot both already exist. Synthesis runs after every variable and instance binding in the scope exists, so a connection resolves regardless of instantiation-vs-declaration source order. The work also fixed a latent gap: a continuous assignment lowers as a scope-level structural expression but could not previously carry a cross-unit reference; since assign c.x = y is legal (LRM 10.3), structural lowering now resolves cross-unit refs the same way procedural lowering does. ref ports, inout / net ports, non-integral ports, unconnected default-valued ports, and instance-array port connections are rejected with a diagnostic and tracked as follow-up.

## Testing

Three end-to-end cases grouped by concept: input (named / positional / expression source / constant / multi-instance isolation), output (combinational and sequential), and connection topology (sibling and pass-through).