### PR TITLE
Replace element-ref proxy with shield-slot pattern

### DIFF
--- a/docs/decisions/runtime-shape-and-default-value.md
+++ b/docs/decisions/runtime-shape-and-default-value.md
@@ -1,4 +1,4 @@
-# Packed Array runtime shape and collection default value
+# Packed Array runtime shape and collection OOB shield
 
 Date: 2026-06-03 Status: accepted
 
@@ -18,16 +18,17 @@ element of a given array shares the same shape. The collection sees friction:
   LRM 7.4.5 default value.
 - The C++ type `DynamicArray<PackedArray>` cannot express the SystemVerilog "all elements share one
   shape" invariant.
-- Earlier iterations of the runtime papered this over with a `MakeDefaultLike(data_.front())` oracle
-  that consults an existing element for shape -- correct only when the container is non-empty, and
-  only by convention rather than enforcement.
+- LRM 7.4.5 requires both OOB read (returns LRM Table 7-1 default) and OOB write (silent no-op) to
+  behave correctly; neither has a natural home on `PackedArray` itself.
 
-Two questions surface:
+Three questions surface:
 
 1. Is the runtime-shape representation still the right choice, or should shape be lifted to the C++
    type level?
 2. If runtime-shape stays, how should a container synthesize a shape-correct default value without
    depending on an existing instance?
+3. How should the LRM 7.4.5 OOB write-is-no-op semantic be expressed -- on the container, on the
+   element value, or at the codegen boundary?
 
 ## Decision
 
@@ -39,23 +40,38 @@ Two questions surface:
    operator-overload growth infeasible at scale. Runtime-shape is the correct engineering trade-off
    given this cardinality property.
 
-2. **Every container wrapper carries an explicit `default_value_` field of type `T`.** For wrappers
-   whose element type `T` requires runtime construction parameters (`PackedArray`, packed struct,
-   packed union, multi-dim packed), the wrapper stores one `T` instance as a `default_value_`
-   member. The member is set at construction and persists for the wrapper's lifetime. OOB reads,
-   resize-fill operations, and empty- container synthesis all consult `default_value_`. This
-   restores the shape information that the C++ template-parameter boundary discards.
+2. **Every container wrapper carries one `oob_slot_` field of type `T`, declared `mutable`.** The
+   slot is seeded to the canonical default at construction (so initial OOB reads return the LRM
+   Table 7-1 default) and doubles as the discard target for OOB writes (so the proxy / forwarding
+   layer the wrapper would otherwise need vanishes). The wrapper restores the slot to canonical
+   state via `T::ResetToDefault` on every OOB access before handing out a reference, so any write
+   accumulated in the slot is erased before the next access observes it. Single field, single
+   responsibility: "the LRM 7.4.5 shield for this container."
 
-3. **Container construction API aligns with `std::vector(n, value)`.** The default value is a
+3. **Every value type that can be an element provides `ResetToDefault()`.** `PackedArray` in-place
+   zero-fills (2-state) or X-fills (4-state) the data bits while preserving shape; `DynamicArray<T>`
+   clears `data_`; `UnpackedArray<T>` recurses into each element. The recursive case for fixed-size
+   unpacked is O(N) and is the LRM-mandated cost of "Array, all of whose elements have the value
+   specified ... for that array's element type" -- there is no way to express that default cheaper
+   than initializing N elements.
+
+4. **`ElementAt` returns `T&` directly; element-level proxy classes are absent.** Compound semantics
+   (`+=`, `&=`, the shift-assign family, the increment / decrement pair) live on `PackedArray` where
+   they belong; the container layer never reimplements them. OOB read is a reference to the shield
+   slot in canonical state, OOB write mutates the shield slot which is then reset on the next
+   access. The non-const overload returns `T&` for the write path; the const overload returns
+   `const T&` and is permitted by the `mutable` qualifier on `oob_slot_`.
+
+5. **Container construction API aligns with `std::vector(n, value)`.** The canonical default is a
    required constructor argument, not optional. Wrappers offer a one-argument form for the
-   declare-empty case (`Wrapper(default_value)`), a two-argument form for sized construction
-   (`Wrapper(n, default_value)`), and additional forms as element semantics require. The `value`
-   parameter is stored as `default_value_` rather than consumed during the fill, so the same value
-   is available for later resize and OOB paths.
+   declare-empty case (`Wrapper(canonical_default)`), a two-argument form for sized construction
+   (`Wrapper(n, canonical_default)`), and additional forms as element semantics require. The
+   parameter is stored as `oob_slot_` rather than consumed during the fill, so the same value is
+   available for later resize and OOB paths.
 
-4. **The default value flows from MIR lowering.** `SynthesizeDefaultValueExpr` (HIR-to-MIR) already
-   produces shape-correct default expressions from MIR type information. The emit chain becomes: MIR
-   type -> default-value expression -> wrapper-constructor argument -> stored `default_value_`
+6. **The canonical default flows from MIR lowering.** `SynthesizeDefaultValueExpr` (HIR-to-MIR)
+   already produces shape-correct default expressions from MIR type information. The emit chain is:
+   MIR type -> default-value expression -> wrapper-constructor argument -> stored `oob_slot_`
    member. The shape information that is "lost" at the C++ template-parameter level is restored via
    this explicit channel; no separate channel is introduced.
 
@@ -64,6 +80,16 @@ _Rejected alternatives:_
 - **Template `PackedArray` on shape.** Distinct C++ types per shape, distinct operator template
   instantiations per cross-shape pair. Cardinality grows with design complexity; not viable for
   compile time, binary size, or operator-overload growth.
+
+- **Per-container element-ref proxy (`UnpackedElementRef<T>`, `DynamicElementRef<T>`) with `valid_`
+  flag and forwarded compound operators.** Mixes layer responsibilities -- the container's OOB
+  concern leaks into a per-T forwarder set that duplicates `PackedArray`'s compound operators on
+  every container type and grows by ~11 method definitions per new container. Replaced by direct
+  `T&` return + shield slot.
+
+- **Two separate fields: `default_value_` (immutable canonical) plus `scratch_` (mutable write
+  target).** Twice the per-wrapper memory cost for no observable behavior difference -- the
+  canonical can be recovered from the shield via `ResetToDefault` whenever needed.
 
 - **Store a callable (`std::function<T()>` or lambda) instead of a `T` instance.** Type-erasure
   overhead, no shape introspection from the stored callable, idiomatic mismatch with the
@@ -76,28 +102,43 @@ _Rejected alternatives:_
   instances would lose self-description; every operation handling an individual element would
   require shape passed in alongside the value.
 
+- **Emit-side validity gate (`if (in_bounds(idx)) arr.RawAt(idx) op= rhs;` instead of returning
+  `T&`).** Pushes LRM 7.4.5 semantics into every codegen site, complicates NBA capture (validity has
+  to be re-derived at fire time), and explodes for multi-dim chains. The shield slot keeps codegen
+  uniform across in-bounds and OOB.
+
 - **Throw on empty-container OOB read.** Violates LRM 7.4.5, which mandates the element type's Table
   7-1 default.
 
 ## Consequences
 
-- Every container wrapper carries one extra `T` member. The size cost is one element-sized object
-  per wrapper, independent of element count.
+- Every container wrapper carries one extra `T` member (`oob_slot_`). The size cost is one
+  element-sized object per wrapper, independent of element count.
 
-- All container construction sites -- emit-generated and direct C++ -- must provide `default_value`
-  explicitly. Container wrappers no longer expose a zero-argument default constructor when `T` has
-  runtime construction parameters.
+- Every value type usable as a container element implements `ResetToDefault()`. The contract is
+  in-place restoration to the LRM Table 6-7 / Table 7-1 canonical default while preserving any shape
+  information embedded in the value (bit width / signedness / state kind for `PackedArray`).
 
-- The `MakeDefaultLike` overload set and the `data_.front()` oracle pattern are removed. Wrappers do
-  not consult element storage to recover shape.
+- `UnpackedArray<T>::ResetToDefault` is O(N) where N is the array's fixed size; this cost is paid
+  only on OOB access to the outer container and is the LRM-mandated cost of materializing "all
+  elements at default." In-bounds access pays no shield cost.
+
+- All container construction sites -- emit-generated and direct C++ -- must provide
+  `canonical_default` explicitly. Container wrappers no longer expose a zero-argument default
+  constructor when `T` has runtime construction parameters.
+
+- The `MakeDefaultLike` overload set, the `data_.front()` oracle pattern, and the
+  `UnpackedElementRef` / `DynamicElementRef` proxy classes are removed.
 
 - The pattern extends naturally to queue, associative array, packed-struct collection,
   unpacked-struct collection, and any future wrapper whose element type requires runtime
-  construction parameters. Each new wrapper introduces a `default_value_` member following the same
-  shape.
+  construction parameters. Each new wrapper introduces an `oob_slot_` member following the same
+  shape and implements its own `ResetToDefault`. Associative array's "auto-allocate on write" rule
+  (LRM 7.8.7) is a different ElementAt contract and requires its own design when that workstream
+  opens.
 
 - Shape uniformity within a collection is enforced by convention -- lowering supplies the same
-  `default_value` for all writes and never mixes shapes in one container -- not by the C++ type
+  canonical default for all writes and never mixes shapes in one container -- not by the C++ type
   system. This is an accepted limitation of the runtime-shape choice.
 
 ## Cross-references
@@ -105,7 +146,8 @@ _Rejected alternatives:_
 - LRM 7.4.5 (Indexing and slicing of arrays), 7.4.6 (Operations on arrays), Table 6-7 (Default
   initial values), Table 7-1 (Value read from a nonexistent array entry).
 - `src/lyra/lowering/hir_to_mir/default_value.cpp` -- `SynthesizeDefaultValueExpr`.
-- `include/lyra/value/packed_array.hpp` -- runtime-shape `PackedArray` definition.
+- `include/lyra/value/packed_array.hpp` -- runtime-shape `PackedArray` definition and
+  `ResetToDefault`.
 - `include/lyra/value/dynamic_array.hpp`, `include/lyra/value/unpacked_array.hpp` -- first wrappers
-  to adopt the `default_value_` pattern.
+  to adopt the shield pattern.
 - `docs/progress/aggregate.md` -- variable-size aggregate workstream.

--- a/docs/decisions/unpacked-array-representation.md
+++ b/docs/decisions/unpacked-array-representation.md
@@ -131,23 +131,30 @@ Unpacked array support follows these invariants:
    `operator==` and `CaseEqual` returning a 1-bit `PackedArray` -- so the substrate-asymmetric
    operations (equality with X / Z propagation, range selectors, observability hooks) live behind a
    single uniform method surface. LRM 7.4.5 invalid-index handling lives in the wrapper too:
-   non-const `ElementAt` returns an `UnpackedElementRef<T>` proxy that captures the index's
-   validity, and the non-const `Slice` returns an `UnpackedArrayRef<T>` proxy that captures the
-   offset's validity. Reads through the proxies' `Clone()` return Table 7-1 defaults on invalid
-   access; writes through `operator=` and compound ops are silent no-ops. Slice reads on partially-
-   OOB positions handle the in-range and OOB elements per-element rather than at slice granularity,
-   matching `PackedArray::ExtractBits` / `AssignSlice`'s per-bit OOB treatment.
+   `ElementAt` returns `T&` (or `const T&` from the const overload); on an invalid index the
+   returned reference is to the wrapper's `oob_slot_` shield, restored to canonical state via
+   `T::ResetToDefault` immediately before being handed out so any prior OOB write is erased.
+   Element-level compound semantics live on `PackedArray` directly -- the wrapper carries no per-T
+   forwarder. `Slice` (non-const) returns an `UnpackedArrayRef<T>` proxy for slice writeback; slice
+   reads on partially-OOB positions handle the in-range and OOB elements per-element rather than at
+   slice granularity, matching `PackedArray::ExtractBits` / `AssignSlice`'s per-bit OOB treatment.
+   See `docs/decisions/runtime-shape-and-default-value.md` for the shield contract.
 
-3. **Default initialization emits an `UnpackedArray<T>{e0, e1, ...}` braced-init expression.**
+3. **Default initialization emits a `ConstructExpr` whose first positional argument is the
+   canonical-default element and whose remaining elements ride in an `ArrayLiteralExpr` rendered as
+   a brace-init-list.**
 
    `default_value.cpp` synthesises an `ArrayLiteralExpr` populated with per-element defaults; the
-   backend renders the result through the literal-init path. For `int arr[3]`:
+   backend wraps it in `ConstructExpr` so the wrapper's
+   `(T canonical_default, std::initializer_list<T>)` constructor receives both the canonical-default
+   seed for `oob_slot_` and the initial elements. For `int arr[3]`:
 
    ```cpp
-   lyra::value::UnpackedArray<lyra::value::PackedArray> arr{
+   lyra::value::UnpackedArray<lyra::value::PackedArray> arr(
        lyra::value::PackedArray::Int(0),
-       lyra::value::PackedArray::Int(0),
-       lyra::value::PackedArray::Int(0)};
+       {lyra::value::PackedArray::Int(0),
+        lyra::value::PackedArray::Int(0),
+        lyra::value::PackedArray::Int(0)});
    ```
 
    Multi-dim composes through the nested element type with the same shape at every layer.

--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -20,8 +20,8 @@ follow once dynamic array's storage and runtime conventions are settled and prov
 
 | Item | Status                                                               |
 | ---- | -------------------------------------------------------------------- |
-| DA1  | Open: construction, element read, blocking element write, multi-dim. |
-| DA2  | Open: NBA, compound element write, whole-array assignment.           |
+| DA1  | Done: construction, element read, blocking element write, multi-dim. |
+| DA2  | Done: NBA, compound element write, whole-array assignment.           |
 | DA3  | Open: literal init and assignment patterns.                          |
 | DA4  | Open: aggregate equality and inequality.                             |
 | DA5  | Open: constant-width slice (subject to LRM check).                   |
@@ -40,7 +40,7 @@ array (Table 6-7).
 
 The numeric IDs are stable references and do not imply execution order beyond DA1 -> DA2.
 
-- [ ] DA1 -- Type infrastructure, construction, element read, and blocking element write, including
+- [x] DA1 -- Type infrastructure, construction, element read, and blocking element write, including
       multi-dimensional dynamic arrays. Covers declaration `int arr []` and `int matrix [][]` with
       empty default (LRM Table 6-7), `new[N]` construction with a runtime size expression,
       `new[N](other)` copy construction from another dynamic array of the same element type (LRM
@@ -53,10 +53,12 @@ The numeric IDs are stable references and do not imply execution order beyond DA
       C10 dynamic-array subset). SV-callable methods, including `.size()`, are not part of DA1 and
       ship with the method family in DA6.
 
-- [ ] DA2 -- Aggregate write paths. NBA element write `arr[i] <= v`, compound element write per LRM
-      11.4.1, whole-array assignment `A = B` which grows A to B's size per LRM 7.6, and the NBA form
-      of whole-array assignment. Element-level paths follow the lvalue surface from U2; whole-array
-      paths follow U4 with size-takeover on the destination.
+- [x] DA2 -- Aggregate write paths. Compound element write per LRM 11.4.1, whole-array assignment
+      `A = B` which grows A to B's size per LRM 7.6, and the NBA form of whole-array assignment.
+      Element-level paths follow the lvalue surface from U2; whole-array paths follow U4 with
+      size-takeover on the destination. NBA on a single element (`arr[i] <= v`) is excluded by LRM
+      10.4.2 -- the NBA LHS rules forbid bit/element selects on dynamically sized targets, so the
+      construct is rejected upstream by slang and produces no Lyra-side path.
 
 - [ ] DA3 -- Literal init and assignment patterns (LRM 10.9). Declaration initializer
       `int arr [] = '{e1, e2, ...}` where the pattern determines array size, procedural assignment
@@ -107,8 +109,8 @@ can be any singular type or `string` (LRM 7.8); storage is sparse; the iteration
 - Archive items: `datatypes/general/*`.
 - Unblocks: `control-flow.md` C10 (foreach over dynamic / queue / associative subset).
 - Decision: `../decisions/runtime-shape-and-default-value.md` -- runtime shape is retained on
-  `PackedArray`; collection wrappers carry an explicit `default_value_` member for OOB synthesis and
-  resize-fill.
+  `PackedArray`; collection wrappers carry one `oob_slot_` member that doubles as canonical-default
+  source and OOB-write discard target, reset via `T::ResetToDefault` on every OOB access.
 - Cross-cutting: `refactor.md` R2 -- value-typed structural fields uniformly wrapped for
   observability (the U8 analogue for these container types once they participate in event control,
   level-sensitive `wait`, `always_comb`, or continuous assignment).

--- a/include/lyra/lowering/hir_to_mir/default_value.hpp
+++ b/include/lyra/lowering/hir_to_mir/default_value.hpp
@@ -24,11 +24,12 @@ namespace lyra::lowering::hir_to_mir {
 // Wraps a list of element ExprIds destined for an `UnpackedArrayType`
 // constructor in `ConstructExpr{[element_default,
 // ArrayLiteralExpr{elements}]}`. This is the construction shape every site that
-// produces an unpacked-array value must use: the `default_value_` member
-// required by `UnpackedArray<T>`'s runtime ctor is supplied here via
-// `SynthesizeDefaultValueExpr` on the element type, and the elements ride in an
-// `ArrayLiteralExpr` that the `ConstructExpr` renderer emits as a
-// brace-init-list. See `docs/decisions/runtime-shape-and-default-value.md`.
+// produces an unpacked-array value must use: the canonical-default element
+// required by `UnpackedArray<T>`'s runtime ctor (to seed `oob_slot_`) is
+// supplied here via `SynthesizeDefaultValueExpr` on the element type, and the
+// elements ride in an `ArrayLiteralExpr` that the `ConstructExpr` renderer
+// emits as a brace-init-list. See
+// `docs/decisions/runtime-shape-and-default-value.md`.
 [[nodiscard]] auto BuildUnpackedArrayConstructExpr(
     const UnitLoweringState& unit_state,
     ProceduralScopeLoweringState& scope_state, mir::TypeId unpacked_type_id,

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -4,7 +4,6 @@
 #include <concepts>
 #include <cstdint>
 #include <initializer_list>
-#include <optional>
 #include <utility>
 #include <vector>
 
@@ -14,7 +13,6 @@
 #include "lyra/runtime/trigger.hpp"
 #include "lyra/value/packed.hpp"
 #include "lyra/value/packed_array.hpp"
-#include "lyra/value/unpacked_array.hpp"
 
 namespace lyra::runtime {
 
@@ -184,14 +182,11 @@ class Var : public Observable {
   T value_{};
 };
 
-// A reference to a variable cell (LRM 13.5.2 pass-by-reference). Transparently
-// views one of three backings: an observable `Var<T>` (writes route through
-// `Var::Set` so the update event fires and subscribers wake), a plain `T` cell
-// (raw read / write, no observers), or an unpacked-array element through its
-// write-back proxy (so an invalid / out-of-range index reads a default and
-// drops the write per LRM 7.4.5). `Get` returns by value because the proxy
-// backing has no storage to reference for an invalid index. Copyable, so a ref
-// formal can be forwarded as a ref argument to a nested call.
+// A reference to a variable cell. Transparently views one of two backings:
+// an observable `Var<T>` (writes route through `Var::Set` so the update
+// event fires and subscribers wake), or a plain `T` cell (raw read / write,
+// no observers). Copyable, so a ref formal can be forwarded as a ref
+// argument to a nested call.
 template <CaseEqualComparable T>
 class Ref {
  public:
@@ -199,33 +194,25 @@ class Ref {
   }
   explicit Ref(T& cell) : plain_(&cell) {
   }
-  explicit Ref(value::UnpackedElementRef<T> elem) : elem_(std::move(elem)) {
-  }
 
   [[nodiscard]] auto Get() const -> T {
     if (signal_ != nullptr) {
       return signal_->Get();
     }
-    if (plain_ != nullptr) {
-      return *plain_;
-    }
-    return elem_->Clone();
+    return *plain_;
   }
 
   void Set(RuntimeServices& services, const T& new_val) {
     if (signal_ != nullptr) {
       signal_->Set(services, new_val);
-    } else if (plain_ != nullptr) {
-      *plain_ = new_val;
     } else {
-      *elem_ = new_val;
+      *plain_ = new_val;
     }
   }
 
  private:
   Var<T>* signal_ = nullptr;
   T* plain_ = nullptr;
-  std::optional<value::UnpackedElementRef<T>> elem_;
 };
 
 // Suspends the calling frame until one of the supplied Triggers fires

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <utility>
@@ -11,63 +10,52 @@
 
 namespace lyra::value {
 
-template <typename T>
-class DynamicArray;
-template <typename T>
-class DynamicElementRef;
-
 // SystemVerilog dynamic array (LRM 7.5). Size set at run time via `new[N]` /
 // `new[N](other)` constructors; default is the empty array (LRM Table 6-7).
 //
-// `default_value_` carries the element type's LRM Table 6-7 default and is
-// the single source for OOB synthesis (LRM 7.4.5) and resize-fill. It is
-// supplied at construction -- there is no zero-argument constructor, because
-// `T = PackedArray` requires runtime shape parameters that cannot be
-// recovered from the C++ type alone. See `docs/decisions/runtime-shape-and-
-// default-value.md`.
+// `oob_slot_` is the LRM 7.4.5 invalid-index shield. Its state is restored
+// to the canonical default on every OOB access via `T::ResetToDefault`, so
+// reads after an OOB write observe the LRM Table 7-1 default rather than
+// whatever the prior write left in the slot. It is supplied at construction
+// because `T = PackedArray` requires runtime shape parameters (bit width,
+// signedness, 2/4-state) that cannot be recovered from the C++ type alone.
+// See `docs/decisions/runtime-shape-and-default-value.md`.
 template <typename T>
 class DynamicArray {
  public:
   using ElementType = T;
 
-  // Empty container with default_value populated. Used for declarations like
-  // `int arr[];` where the array starts empty but the element shape is known
-  // at lowering time.
-  explicit DynamicArray(T default_value)
-      : default_value_(std::move(default_value)) {
+  // Empty container with the shield slot seeded. Used for declarations like
+  // `int arr[];` where the array starts empty but the element shape is
+  // known at lowering time.
+  explicit DynamicArray(T oob_slot) : oob_slot_(std::move(oob_slot)) {
   }
 
-  // LRM 7.5.1 `new[N]`: build `n` elements, each a copy of `default_value`.
-  // `n` is a longint per LRM 7.5.1; the negative-N case throws at
-  // construction.
-  DynamicArray(const PackedArray& n, T default_value)
-      : default_value_(std::move(default_value)) {
+  // LRM 7.5.1 `new[N]`: build `n` elements, each a copy of the shield-slot
+  // seed (which is also the canonical default). `n` is a longint per LRM
+  // 7.5.1; the negative-N case throws at construction.
+  DynamicArray(const PackedArray& n, T oob_slot)
+      : oob_slot_(std::move(oob_slot)) {
     const std::int64_t n_val = n.ToInt64();
     if (n_val < 0) {
       throw InternalError(
           "DynamicArray::new[N]: size operand is negative (LRM 7.5.1)");
     }
-    data_.assign(static_cast<std::size_t>(n_val), default_value_);
+    data_.assign(static_cast<std::size_t>(n_val), oob_slot_);
   }
 
-  // LRM 7.5.1 `new[N](other)`: build `n` elements; copy the first
-  // min(n, other.Size()) from `other`, pad the rest with `default_value`.
-  DynamicArray(const PackedArray& n, T default_value, const DynamicArray& src)
-      : default_value_(std::move(default_value)) {
+  // LRM 7.5.1 `new[N](other)`: copy `other` then `resize(N, oob_slot_)` --
+  // `std::vector::resize` truncates when target is smaller and pads with
+  // the fill value when target is larger, covering both halves of LRM
+  // 7.5.1 in one call.
+  DynamicArray(const PackedArray& n, T oob_slot, const DynamicArray& src)
+      : oob_slot_(std::move(oob_slot)), data_(src.data_) {
     const std::int64_t n_val = n.ToInt64();
     if (n_val < 0) {
       throw InternalError(
           "DynamicArray::new[N](src): size operand is negative (LRM 7.5.1)");
     }
-    const auto target = static_cast<std::size_t>(n_val);
-    data_.reserve(target);
-    const auto copy_count = std::min(target, src.data_.size());
-    for (std::size_t i = 0; i < copy_count; ++i) {
-      data_.push_back(src.data_[i]);
-    }
-    for (std::size_t i = copy_count; i < target; ++i) {
-      data_.push_back(default_value_);
-    }
+    data_.resize(static_cast<std::size_t>(n_val), oob_slot_);
   }
 
   DynamicArray(const DynamicArray&) = default;
@@ -84,18 +72,40 @@ class DynamicArray {
     return data_[i];
   }
 
-  // LRM 7.4.5: invalid index returns the element type's Table 7-1 default.
-  // `default_value_` was supplied at construction and remains valid for the
-  // wrapper's lifetime, so the empty-storage case is handled uniformly.
-  [[nodiscard]] auto ElementAt(const PackedArray& idx) const -> T {
+  [[nodiscard]] auto Clone() const -> DynamicArray {
+    return *this;
+  }
+
+  // LRM Table 6-7: dynamic array default is the empty array. When this
+  // container is itself an OOB shield slot of an outer container, the outer
+  // calls this method to restore canonical state before handing out a
+  // reference; any subsequent inner access then re-OOBs naturally (data_ is
+  // empty), so chained access through the shield never observes a stale
+  // write.
+  auto ResetToDefault() -> void {
+    data_.clear();
+  }
+
+  // LRM 7.4.5: an invalid index makes the access route through `oob_slot_`.
+  // The slot is restored to canonical state before the reference is handed
+  // out, so OOB writes that mutate it are invisible to any subsequent
+  // access. The non-const overload returns a writable reference; writes
+  // through it land on the shield rather than on real storage and are
+  // erased on the next OOB access.
+  [[nodiscard]] auto ElementAt(const PackedArray& idx) -> T& {
     if (IsInvalidIndex(idx)) {
-      return default_value_;
+      oob_slot_.ResetToDefault();
+      return oob_slot_;
     }
     return data_[static_cast<std::size_t>(idx.ToInt64())];
   }
 
-  [[nodiscard]] auto ElementAt(const PackedArray& idx) -> DynamicElementRef<T> {
-    return MakeElementRef(*this, idx);
+  [[nodiscard]] auto ElementAt(const PackedArray& idx) const -> const T& {
+    if (IsInvalidIndex(idx)) {
+      oob_slot_.ResetToDefault();
+      return oob_slot_;
+    }
+    return data_[static_cast<std::size_t>(idx.ToInt64())];
   }
 
  private:
@@ -106,66 +116,8 @@ class DynamicArray {
                         static_cast<std::uint64_t>(data_.size());
   }
 
-  static auto MakeElementRef(DynamicArray& self, const PackedArray& idx)
-      -> DynamicElementRef<T> {
-    if (self.IsInvalidIndex(idx)) {
-      return DynamicElementRef<T>{self, std::size_t{0}, false};
-    }
-    return DynamicElementRef<T>{
-        self, static_cast<std::size_t>(idx.ToInt64()), true};
-  }
-
-  T default_value_;
+  mutable T oob_slot_;
   std::vector<T> data_;
-
-  friend class DynamicElementRef<T>;
-};
-
-// Write-back proxy for `DynamicArray::ElementAt` non-const. Captures index
-// validity at construction; subsequent reads through `Clone()` and writes
-// through `operator=` honour that validity per LRM 7.4.5 (invalid write is
-// a silent no-op, invalid read returns the element default).
-template <typename T>
-class DynamicElementRef {
- public:
-  DynamicElementRef(DynamicArray<T>& base, std::size_t offset, bool valid)
-      : base_(&base), offset_(offset), valid_(valid) {
-  }
-  DynamicElementRef(const DynamicElementRef&) = delete;
-  auto operator=(const DynamicElementRef&) -> DynamicElementRef& = delete;
-  DynamicElementRef(DynamicElementRef&&) noexcept = default;
-  auto operator=(DynamicElementRef&&) noexcept -> DynamicElementRef& = default;
-  ~DynamicElementRef() = default;
-
-  [[nodiscard]] auto Clone() const -> T {
-    if (valid_) return base_->data_[offset_];
-    return base_->default_value_;
-  }
-
-  auto operator=(const T& value) -> DynamicElementRef& {
-    if (valid_) base_->data_[offset_] = value;
-    return *this;
-  }
-
-  // Chain composition for multi-dim access. An invalid outer has no inner
-  // element to bind to; LRM 7.5.1 multi-dim initialization order makes this
-  // a user-side ordering bug rather than a supported path.
-  [[nodiscard]] auto ElementAt(const PackedArray& idx) {
-    if (!valid_) {
-      throw InternalError(
-          "DynamicArray::ElementAt: chain access through an invalid proxy");
-    }
-    return base_->data_[offset_].ElementAt(idx);
-  }
-
-  auto MarkInvalid() -> void {
-    valid_ = false;
-  }
-
- private:
-  DynamicArray<T>* base_;
-  std::size_t offset_;
-  bool valid_;
 };
 
 }  // namespace lyra::value

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -154,6 +154,13 @@ class PackedArray {
   [[nodiscard]] auto Dims() const -> std::span<const PackedRange>;
   [[nodiscard]] auto IsFourState() const -> bool;
 
+  // Restore the value to this shape's canonical default in place: all-zero
+  // for 2-state, all-X for 4-state (LRM Table 6-7 / Table 7-1). Shape fields
+  // (`bit_width_`, `is_signed_`, `is_four_state_`, `dims_`) are preserved.
+  // Container shield slots call this on OOB access so the slot mirrors what
+  // a freshly-defaulted element would read as.
+  auto ResetToDefault() -> void;
+
   // LRM 11.4.5 `===` predicate form (host bool). Operator form: `CaseEqual`.
   [[nodiscard]] auto IsCaseEqual(const PackedArray& other) const -> bool;
 

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
@@ -16,8 +15,6 @@ template <typename T>
 class UnpackedArray;
 template <typename T>
 class UnpackedArrayRef;
-template <typename T>
-class UnpackedElementRef;
 
 // SystemVerilog fixed-size unpacked array (LRM 7.4.2). One C++ container layer
 // per declared unpacked dimension; multi-dim composes as
@@ -28,28 +25,28 @@ class UnpackedElementRef;
 // 1-bit `PackedArray` so equality on aggregates propagates through the same
 // value-type the integral surface uses.
 //
-// `default_value_` carries the element type's LRM Table 6-7 default and is
-// the single source for OOB synthesis (LRM 7.4.5) on every access path. It
-// is supplied at construction -- there is no zero-argument constructor,
-// because `T = PackedArray` requires runtime shape parameters that cannot
-// be recovered from the C++ type alone. See `docs/decisions/runtime-shape-
-// and-default-value.md`.
+// `oob_slot_` is the LRM 7.4.5 invalid-index shield. Its state is restored
+// to the canonical default on every OOB access via `T::ResetToDefault`, so
+// reads after an OOB write observe the LRM Table 7-1 default rather than
+// whatever the prior write left in the slot. It is supplied at construction
+// because `T = PackedArray` requires runtime shape parameters (bit width,
+// signedness, 2/4-state) that cannot be recovered from the C++ type alone.
+// See `docs/decisions/runtime-shape-and-default-value.md`.
 template <typename T>
 class UnpackedArray {
  public:
   using ElementType = T;
 
-  // Empty container with `default_value_` populated. Internal use only --
-  // SV fixed-size arrays are always non-empty; this form serves `Slice` and
+  // Empty container with the shield slot seeded. Internal use only -- SV
+  // fixed-size arrays are always non-empty; this form serves `Slice` and
   // similar paths that build a fresh `UnpackedArray` element-by-element.
-  explicit UnpackedArray(T default_value)
-      : default_value_(std::move(default_value)) {
+  explicit UnpackedArray(T oob_slot) : oob_slot_(std::move(oob_slot)) {
   }
 
-  // Element-list construction: `default_value_` for OOB synthesis, plus the
-  // explicit initial elements (LRM 10.9 assignment pattern lowering).
-  UnpackedArray(T default_value, std::initializer_list<T> init)
-      : default_value_(std::move(default_value)), data_(init) {
+  // Element-list construction: shield slot seeded, plus the explicit
+  // initial elements (LRM 10.9 assignment pattern lowering).
+  UnpackedArray(T oob_slot, std::initializer_list<T> init)
+      : oob_slot_(std::move(oob_slot)), data_(init) {
   }
 
   UnpackedArray(const UnpackedArray&) = default;
@@ -71,54 +68,72 @@ class UnpackedArray {
     return data_[i];
   }
 
-  // LRM 7.4.5: read returns Table 7-1 default on invalid index. The stored
-  // `default_value_` is the source of truth for the default; no oracle from
-  // existing storage is needed.
-  [[nodiscard]] auto ElementAt(const PackedArray& idx) const -> T {
+  [[nodiscard]] auto Clone() const -> UnpackedArray {
+    return *this;
+  }
+
+  // LRM Table 7-1 default for a fixed-size unpacked array is "Array, all of
+  // whose elements have the value specified in this table for that array's
+  // element type." When this container is itself the OOB shield slot of an
+  // outer container, the outer calls this method to restore the canonical
+  // all-defaults state before handing out a reference. This is O(N) in the
+  // unpacked dim and is the LRM-mandated cost of "all elements at default."
+  auto ResetToDefault() -> void {
+    for (auto& elem : data_) {
+      elem.ResetToDefault();
+    }
+  }
+
+  // LRM 7.4.5: an invalid index makes the access route through `oob_slot_`.
+  // The slot is restored to canonical state before the reference is handed
+  // out, so OOB writes that mutate it are invisible to any subsequent
+  // access. The non-const overload returns a writable reference; writes
+  // through it land on the shield rather than on real storage and are
+  // erased on the next OOB access.
+  [[nodiscard]] auto ElementAt(const PackedArray& idx) -> T& {
     if (IsInvalidIndex(idx)) {
-      return default_value_;
+      oob_slot_.ResetToDefault();
+      return oob_slot_;
     }
     return data_[static_cast<std::size_t>(idx.ToInt64())];
   }
 
-  // Non-const overload yields a write-back proxy. The proxy captures the
-  // index's validity at construction; subsequent `operator=` / compound ops
-  // / chain calls observe that captured validity. Symmetric with
-  // `PackedArray::ElementAt(...) -> PackedArrayRef`.
-  [[nodiscard]] auto ElementAt(const PackedArray& idx)
-      -> UnpackedElementRef<T> {
-    return MakeElementRef(*this, idx);
+  [[nodiscard]] auto ElementAt(const PackedArray& idx) const -> const T& {
+    if (IsInvalidIndex(idx)) {
+      oob_slot_.ResetToDefault();
+      return oob_slot_;
+    }
+    return data_[static_cast<std::size_t>(idx.ToInt64())];
   }
 
   // LRM 7.4.5 contiguous-range selector. The const overload materializes a
-  // fresh sub-array; partial-OOB positions yield `default_value_`, X / Z
-  // offset yields a wholly-default sub-array. The non-const overload returns
-  // a write-back proxy with the same invalid-index policy on `operator=`.
-  [[nodiscard]] auto Slice(
-      const PackedArray& offset_in_outer_elements,
-      std::uint32_t count_in_outer_elements) const -> UnpackedArray {
-    UnpackedArray result(default_value_);
-    result.data_.reserve(count_in_outer_elements);
-    const bool offset_unknown = offset_in_outer_elements.HasUnknown();
-    const std::int64_t base =
-        offset_unknown ? 0 : offset_in_outer_elements.ToInt64();
+  // fresh sub-array; partial-OOB positions yield the canonical default,
+  // X / Z offset yields a wholly-default sub-array. The non-const overload
+  // returns a write-back proxy with the same invalid-index policy on
+  // `operator=`.
+  [[nodiscard]] auto Slice(const PackedArray& offset, std::uint32_t count) const
+      -> UnpackedArray {
+    const T canonical = MakeCanonicalElement();
+    UnpackedArray result(canonical);
+    if (offset.HasUnknown()) {
+      result.data_.assign(count, canonical);
+      return result;
+    }
+    result.data_.reserve(count);
+    const auto base = offset.ToInt64();
     const auto size = static_cast<std::int64_t>(data_.size());
-    for (std::uint32_t i = 0; i < count_in_outer_elements; ++i) {
-      const std::int64_t pos = base + static_cast<std::int64_t>(i);
-      if (offset_unknown || pos < 0 || pos >= size) {
-        result.data_.push_back(default_value_);
-      } else {
-        result.data_.push_back(data_[static_cast<std::size_t>(pos)]);
-      }
+    for (std::uint32_t i = 0; i < count; ++i) {
+      const auto pos = base + static_cast<std::int64_t>(i);
+      const bool in_bounds = pos >= 0 && pos < size;
+      result.data_.push_back(
+          in_bounds ? data_[static_cast<std::size_t>(pos)] : canonical);
     }
     return result;
   }
 
-  [[nodiscard]] auto Slice(
-      const PackedArray& offset_in_outer_elements,
-      std::uint32_t count_in_outer_elements) -> UnpackedArrayRef<T> {
-    return UnpackedArrayRef<T>{
-        *this, offset_in_outer_elements, count_in_outer_elements};
+  [[nodiscard]] auto Slice(const PackedArray& offset, std::uint32_t count)
+      -> UnpackedArrayRef<T> {
+    return UnpackedArrayRef<T>{*this, offset, count};
   }
 
   // LRM 11.2.2 + 11.4.5 aggregate equality / case-equality. Slang's binding
@@ -154,13 +169,13 @@ class UnpackedArray {
                         static_cast<std::uint64_t>(data_.size());
   }
 
-  static auto MakeElementRef(UnpackedArray& self, const PackedArray& idx)
-      -> UnpackedElementRef<T> {
-    if (self.IsInvalidIndex(idx)) {
-      return UnpackedElementRef<T>{self, std::size_t{0}, false};
-    }
-    return UnpackedElementRef<T>{
-        self, static_cast<std::size_t>(idx.ToInt64()), true};
+  // Returns a fresh `T` at this container's element shape in LRM Table 7-1
+  // canonical state. Used by paths that need a default element disconnected
+  // from the OOB shield identity (Slice fill, Slice-ref Clone).
+  [[nodiscard]] auto MakeCanonicalElement() const -> T {
+    T fresh = oob_slot_;
+    fresh.ResetToDefault();
+    return fresh;
   }
 
   [[nodiscard]] static auto CaseEqElement(
@@ -175,159 +190,17 @@ class UnpackedArray {
     return a.CaseEqual(b);
   }
 
-  T default_value_;
+  mutable T oob_slot_;
   std::vector<T> data_;
 
   friend class UnpackedArrayRef<T>;
-  friend class UnpackedElementRef<T>;
-};
-
-// Write-back proxy for `UnpackedArray::ElementAt` non-const. Captures index
-// validity at construction; subsequent reads through `Clone()` and writes
-// through `operator=` (or compound ops, when T is `PackedArray`) honor that
-// validity per LRM 7.4.5. Chain methods (`ElementAt`, `Slice`) on a proxy
-// over a nested-aggregate element propagate the validity flag so an invalid
-// outer index makes the entire chain a no-op write / Table 7-1 default read.
-template <typename T>
-class UnpackedElementRef {
- public:
-  UnpackedElementRef(UnpackedArray<T>& base, std::size_t offset, bool valid)
-      : base_(&base), offset_(offset), valid_(valid) {
-  }
-  // Copyable: the proxy is a thin (array, offset, validity) view, so a copy is
-  // another view of the same element. A `Ref` binding a ref formal to an
-  // unpacked element (LRM 13.5.2) holds the proxy and is itself copyable to
-  // forward to nested calls.
-  UnpackedElementRef(const UnpackedElementRef&) = default;
-  auto operator=(const UnpackedElementRef&) -> UnpackedElementRef& = default;
-  UnpackedElementRef(UnpackedElementRef&&) noexcept = default;
-  auto operator=(UnpackedElementRef&&) noexcept
-      -> UnpackedElementRef& = default;
-  ~UnpackedElementRef() = default;
-
-  [[nodiscard]] auto Clone() const -> T {
-    if (valid_) {
-      return base_->data_[offset_];
-    }
-    return base_->default_value_;
-  }
-
-  auto operator=(const T& value) -> UnpackedElementRef& {
-    if (valid_) {
-      base_->data_[offset_] = value;
-    }
-    return *this;
-  }
-
-  // Compound assignment for PackedArray-element arrays. The load-modify-store
-  // pattern is gated by `valid_` so an invalid index is a silent no-op end to
-  // end, including the read that would otherwise observe garbage memory.
-  auto operator+=(const PackedArray& rhs) -> UnpackedElementRef&
-    requires std::same_as<T, PackedArray>
-  {
-    if (valid_) base_->data_[offset_] += rhs;
-    return *this;
-  }
-  auto operator-=(const PackedArray& rhs) -> UnpackedElementRef&
-    requires std::same_as<T, PackedArray>
-  {
-    if (valid_) base_->data_[offset_] -= rhs;
-    return *this;
-  }
-  auto operator*=(const PackedArray& rhs) -> UnpackedElementRef&
-    requires std::same_as<T, PackedArray>
-  {
-    if (valid_) base_->data_[offset_] *= rhs;
-    return *this;
-  }
-  auto operator/=(const PackedArray& rhs) -> UnpackedElementRef&
-    requires std::same_as<T, PackedArray>
-  {
-    if (valid_) base_->data_[offset_] /= rhs;
-    return *this;
-  }
-  auto operator%=(const PackedArray& rhs) -> UnpackedElementRef&
-    requires std::same_as<T, PackedArray>
-  {
-    if (valid_) base_->data_[offset_] %= rhs;
-    return *this;
-  }
-  auto operator&=(const PackedArray& rhs) -> UnpackedElementRef&
-    requires std::same_as<T, PackedArray>
-  {
-    if (valid_) base_->data_[offset_] &= rhs;
-    return *this;
-  }
-  auto operator|=(const PackedArray& rhs) -> UnpackedElementRef&
-    requires std::same_as<T, PackedArray>
-  {
-    if (valid_) base_->data_[offset_] |= rhs;
-    return *this;
-  }
-  auto operator^=(const PackedArray& rhs) -> UnpackedElementRef&
-    requires std::same_as<T, PackedArray>
-  {
-    if (valid_) base_->data_[offset_] ^= rhs;
-    return *this;
-  }
-  auto ShiftLeftAssign(const PackedArray& rhs) -> UnpackedElementRef&
-    requires std::same_as<T, PackedArray>
-  {
-    if (valid_) base_->data_[offset_].ShiftLeftAssign(rhs);
-    return *this;
-  }
-  auto LogicalShiftRightAssign(const PackedArray& rhs) -> UnpackedElementRef&
-    requires std::same_as<T, PackedArray>
-  {
-    if (valid_) base_->data_[offset_].LogicalShiftRightAssign(rhs);
-    return *this;
-  }
-  auto ArithmeticShiftRightAssign(const PackedArray& rhs) -> UnpackedElementRef&
-    requires std::same_as<T, PackedArray>
-  {
-    if (valid_) base_->data_[offset_].ArithmeticShiftRightAssign(rhs);
-    return *this;
-  }
-
-  // Chain composition for nested aggregates. An invalid outer makes the chain
-  // bind to the outer's `default_value_` (always present, properly
-  // constructed for the inner type) and propagates invalidity onto the
-  // returned inner proxy.
-  [[nodiscard]] auto ElementAt(const PackedArray& idx) {
-    auto& inner = valid_ ? base_->data_[offset_] : base_->default_value_;
-    auto proxy = inner.ElementAt(idx);
-    if (!valid_) proxy.MarkInvalid();
-    return proxy;
-  }
-
-  [[nodiscard]] auto Slice(
-      const PackedArray& offset_in_outer_elements,
-      std::uint32_t count_in_outer_elements) {
-    auto& inner = valid_ ? base_->data_[offset_] : base_->default_value_;
-    auto proxy = inner.Slice(offset_in_outer_elements, count_in_outer_elements);
-    if (!valid_) proxy.MarkInvalid();
-    return proxy;
-  }
-
-  // Drop validity after construction. Used by chain composition when the
-  // outer proxy is invalid -- the inner proxy is constructed normally then
-  // demoted so any subsequent write is dropped.
-  auto MarkInvalid() -> void {
-    valid_ = false;
-  }
-
- private:
-  UnpackedArray<T>* base_;
-  std::size_t offset_;
-  bool valid_;
 };
 
 // LRM 7.6: an assignment to an unpacked slice is a single assignment to the
 // entire slice. The proxy holds a non-owning pointer back to the source array
-// plus the (offset, count) window. Invalid offset (X / Z, fully OOB) makes
-// `Clone()` return a wholly-default sub-array and `operator=` a no-op;
-// partial-OOB behaves per-element. Move-only so the proxy cannot outlive the
-// source it aliases.
+// plus the (offset, count) window. X / Z offset makes `Clone()` return a
+// wholly-default sub-array and `operator=` a no-op; partial-OOB behaves
+// per-element. Move-only so the proxy cannot outlive the source it aliases.
 template <typename T>
 class UnpackedArrayRef {
  public:
@@ -335,7 +208,7 @@ class UnpackedArrayRef {
       UnpackedArray<T>& base, const PackedArray& offset, std::uint32_t count)
       : base_(&base),
         offset_unknown_(offset.HasUnknown()),
-        offset_(offset.HasUnknown() ? 0 : offset.ToInt64()),
+        offset_(offset_unknown_ ? 0 : offset.ToInt64()),
         count_(count) {
   }
   UnpackedArrayRef(const UnpackedArrayRef&) = delete;
@@ -345,33 +218,32 @@ class UnpackedArrayRef {
   ~UnpackedArrayRef() = default;
 
   [[nodiscard]] auto Clone() const -> UnpackedArray<T> {
-    UnpackedArray<T> result(base_->default_value_);
+    const T canonical = base_->MakeCanonicalElement();
+    UnpackedArray<T> result(canonical);
+    if (offset_unknown_) {
+      result.data_.assign(count_, canonical);
+      return result;
+    }
     result.data_.reserve(count_);
     const auto size = static_cast<std::int64_t>(base_->data_.size());
     for (std::uint32_t i = 0; i < count_; ++i) {
-      const std::int64_t pos = offset_ + static_cast<std::int64_t>(i);
-      if (!valid_ || offset_unknown_ || pos < 0 || pos >= size) {
-        result.data_.push_back(base_->default_value_);
-      } else {
-        result.data_.push_back(base_->data_[static_cast<std::size_t>(pos)]);
-      }
+      const auto pos = offset_ + static_cast<std::int64_t>(i);
+      const bool in_bounds = pos >= 0 && pos < size;
+      result.data_.push_back(
+          in_bounds ? base_->data_[static_cast<std::size_t>(pos)] : canonical);
     }
     return result;
   }
 
   auto operator=(const UnpackedArray<T>& value) -> UnpackedArrayRef& {
-    if (!valid_ || offset_unknown_) return *this;
+    if (offset_unknown_) return *this;
     const auto size = static_cast<std::int64_t>(base_->data_.size());
     for (std::uint32_t i = 0; i < count_; ++i) {
-      const std::int64_t pos = offset_ + static_cast<std::int64_t>(i);
+      const auto pos = offset_ + static_cast<std::int64_t>(i);
       if (pos < 0 || pos >= size) continue;
       base_->data_[static_cast<std::size_t>(pos)] = value.data_[i];
     }
     return *this;
-  }
-
-  auto MarkInvalid() -> void {
-    valid_ = false;
   }
 
  private:
@@ -379,7 +251,6 @@ class UnpackedArrayRef {
   bool offset_unknown_;
   std::int64_t offset_;
   std::uint32_t count_;
-  bool valid_ = true;
 };
 
 // LRM 21.2.1.6 aggregate-view construction. Element views borrow into `arr`'s

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -198,6 +198,20 @@ auto PackedArray::IsFourState() const -> bool {
   return is_four_state_;
 }
 
+auto PackedArray::ResetToDefault() -> void {
+  // Re-construct the storage in place. `BitValue(W)`'s default state is
+  // all-zero and `LogicValue(W)`'s is all-X, which match the LRM Table 6-7
+  // canonical defaults for 2-state and 4-state respectively. Routing through
+  // the value-type ctors keeps the LRM rule encoded in exactly one place
+  // (the ctors themselves). `bit_width_`, `is_signed_`, `is_four_state_`,
+  // and `dims_` are preserved.
+  if (is_four_state_) {
+    storage_.emplace<LogicValue>(bit_width_);
+  } else {
+    storage_.emplace<BitValue>(bit_width_);
+  }
+}
+
 auto PackedArray::Dims() const -> std::span<const PackedRange> {
   return std::span<const PackedRange>{dims_.data(), dims_.size()};
 }

--- a/tests/cases/cpp/dynamic_array_element_write_compound_arith/case.yaml
+++ b/tests/cases/cpp/dynamic_array_element_write_compound_arith/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.dynamic_array_element_write_compound_arith
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a0: 15
+    a1: 15
+    a2: 60

--- a/tests/cases/cpp/dynamic_array_element_write_compound_arith/main.sv
+++ b/tests/cases/cpp/dynamic_array_element_write_compound_arith/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  int arr [];
+  int a0, a1, a2;
+  initial begin
+    arr = new[3];
+    arr[0] = 10;
+    arr[1] = 20;
+    arr[2] = 30;
+    arr[0] += 5;
+    arr[1] -= 5;
+    arr[2] *= 2;
+    a0 = arr[0];
+    a1 = arr[1];
+    a2 = arr[2];
+  end
+endmodule

--- a/tests/cases/cpp/dynamic_array_element_write_compound_bitwise/case.yaml
+++ b/tests/cases/cpp/dynamic_array_element_write_compound_bitwise/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.dynamic_array_element_write_compound_bitwise
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a0: "8'h0F"
+    a1: "8'hF0"
+    a2: "8'hFF"

--- a/tests/cases/cpp/dynamic_array_element_write_compound_bitwise/main.sv
+++ b/tests/cases/cpp/dynamic_array_element_write_compound_bitwise/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  bit [7:0] arr [];
+  bit [7:0] a0, a1, a2;
+  initial begin
+    arr = new[3];
+    arr[0] = 8'h00;
+    arr[1] = 8'hFF;
+    arr[2] = 8'hAA;
+    arr[0] |= 8'h0F;
+    arr[1] &= 8'hF0;
+    arr[2] ^= 8'h55;
+    a0 = arr[0];
+    a1 = arr[1];
+    a2 = arr[2];
+  end
+endmodule

--- a/tests/cases/cpp/dynamic_array_whole_assign_blocking/case.yaml
+++ b/tests/cases/cpp/dynamic_array_whole_assign_blocking/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.dynamic_array_whole_assign_blocking
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    c0: 100
+    c1: 200
+    c2: 300
+    c3: 400

--- a/tests/cases/cpp/dynamic_array_whole_assign_blocking/main.sv
+++ b/tests/cases/cpp/dynamic_array_whole_assign_blocking/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  int a [];
+  int b [];
+  int c0, c1, c2, c3;
+  initial begin
+    a = new[2];
+    a[0] = 1;
+    a[1] = 2;
+    b = new[4];
+    b[0] = 100;
+    b[1] = 200;
+    b[2] = 300;
+    b[3] = 400;
+    a = b;
+    c0 = a[0];
+    c1 = a[1];
+    c2 = a[2];
+    c3 = a[3];
+  end
+endmodule

--- a/tests/cases/cpp/dynamic_array_whole_assign_nba/case.yaml
+++ b/tests/cases/cpp/dynamic_array_whole_assign_nba/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.dynamic_array_whole_assign_nba
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    c0: 70
+    c1: 80
+    c2: 90

--- a/tests/cases/cpp/dynamic_array_whole_assign_nba/main.sv
+++ b/tests/cases/cpp/dynamic_array_whole_assign_nba/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  int a [];
+  int b [];
+  int c0, c1, c2;
+  initial begin
+    a = new[3];
+    a[0] = 1;
+    a[1] = 2;
+    a[2] = 3;
+    b = new[3];
+    b[0] = 70;
+    b[1] = 80;
+    b[2] = 90;
+    a <= b;
+    #1;
+    c0 = a[0];
+    c1 = a[1];
+    c2 = a[2];
+  end
+endmodule


### PR DESCRIPTION
## Summary

Containers no longer carry per-element proxy classes (`UnpackedElementRef<T>` / `DynamicElementRef<T>`) for LRM 7.4.5 invalid-index handling. Instead, each container holds one mutable `oob_slot_` of type `T` and `ElementAt` returns `T&` directly. On OOB access the slot is restored to canonical state via `T::ResetToDefault` before the reference is handed out, so any write that landed in the slot is erased before the next access observes it. Element-level compound operators (`+=`, `&=`, the shift-assign family, etc.) now live entirely on `PackedArray`; the container layer never reimplements them.

## Design

The previous proxy pattern duplicated 11 forwarder methods on every container that wraps a packed element, and the duplication grew per future container type. The shield-slot pattern moves the LRM 7.4.5 silent-no-op write semantic into the container's `ElementAt` itself: in-bounds returns `&data_[i]`, OOB returns `&oob_slot_` after `ResetToDefault`. The reset cost is O(1) on `DynamicArray` (`data_.clear()`), O(W/64) on `PackedArray` (re-emplace `BitValue` / `LogicValue`), and O(N) on fixed-size `UnpackedArray` (recurse). The O(N) on unpacked is the LRM-mandated cost of "Array, all of whose elements have the value specified... for the element type" -- no implementation can express that default cheaper.

`PackedArray::ResetToDefault` re-emplaces the storage variant via the value-type ctors, which centralises the LRM Table 6-7 / Table 7-1 canonical-default rule in exactly one place (the `BitValue` / `LogicValue` default ctors). OOB reset trades a `vector<uint64_t>` allocation for that centralisation; OOB is not on the hot path.

`Slice` and `UnpackedArrayRef::Clone` share a `MakeCanonicalElement()` helper instead of inlining `T canonical = oob_slot_; canonical.ResetToDefault();`. The `offset.HasUnknown()` branch is hoisted out of the per-position loops -- a wholly-OOB slice becomes one `data_.assign(count, canonical)` call.

`Ref<T>` collapses to two backings (`Var<T>*` observable, `T*` plain); the third backing (`UnpackedElementRef<T>`) is gone because element refs are now plain `T&`. Decision doc and unpacked-array representation doc are synced to the new shape. Strobe codegen typo (`services_->` direct private-member access) bundled in.

## Testing

`bazel test //...` green. Added cpp_run cases for dynamic array compound element writes (arith / bitwise) and whole-array assignment (blocking / NBA) -- the latter exercises LRM 7.6 destination-takes-source-size resize on `DynamicArray::operator=`.