### PR TITLE
Cancel pending $fstrobe submissions on $fclose

### DIFF
--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -106,11 +106,17 @@ the corresponding behaviour lands.
       per-task default radix. Postponed lambdas reference the descriptor through their capture list,
       so module-scope FDs read NBA-committed values at fire time and procedural- local FDs snapshot
       at submit time.
-- [ ] LRM 21.3.2 implicit cancel on `$fclose`. "Active `$fmonitor` and/or `$fstrobe` operations on a
-      file descriptor or multichannel descriptor are implicitly cancelled by an `$fclose`
-      operation." Today the postponed lambda fires unconditionally and the underlying `LyraFPrint`
-      hits the closed FD; the cancel path needs an FD/MCD -> pending-callback tracking layer and
-      will likely be tackled together with `$fmonitor`, which shares the cancellation mechanism.
+- [x] LRM 21.3.2 implicit cancel on `$fclose`. Cancellation is modelled as a resource event: every
+      FD and every MCD channel owns a cancel signal that `$fclose` fires (and replaces with a fresh
+      one) on every affected channel, so the next `$fopen` reusing the channel starts with a clean
+      signal while any observer captured before the close keeps seeing the original cancelled state
+      -- channel reuse cannot revive a dead submission. The strobe runtime acquires the cancel
+      observer at submit time and short-circuits the wrapped print if any participating channel
+      reports cancelled; an OR-ed MCD resolves as cancelled when any participating channel does,
+      matching the literal LRM wording "operations on a ... multichannel descriptor are implicitly
+      cancelled". Cancel state lives on the channel rather than per submission, so memory stays
+      bounded for free. The same per-channel signal will carry future `$fmonitor` cancellation when
+      that lands.
 
 ## Out of Scope
 

--- a/include/lyra/runtime/file_io.hpp
+++ b/include/lyra/runtime/file_io.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <optional>
 #include <span>
 
@@ -39,6 +40,17 @@ void LyraFPrint(
     RuntimeServices& services, value::PrintKind kind,
     const value::PackedArray& descriptor,
     std::span<const value::PrintItem> items);
+
+// LRM 21.2.2 + 21.3.2 $fstrobe-family runtime entry. Defers `print_action`
+// to the postponed region and wires up LRM 21.3.2 implicit cancel:
+// acquires a ChannelCancellation for `descriptor` at submit time; the
+// wrapped action short-circuits if any participating channel is closed
+// before the postponed region fires. Channel-reuse is safe -- a dead
+// submission's observer keeps seeing the old (permanently stopped) state
+// regardless of what the integer descriptor value later points at.
+void LyraSubmitFStrobe(
+    RuntimeServices& services, const value::PackedArray& descriptor,
+    std::function<void()> print_action);
 
 // LRM 21.3.4.1 $fgetc(fd). Returns the next byte as an int32 PackedArray, or
 // -1 on EOF / error. Errors stamp FileTable's per-fd error slot.

--- a/include/lyra/runtime/file_table.hpp
+++ b/include/lyra/runtime/file_table.hpp
@@ -5,11 +5,31 @@
 #include <fstream>
 #include <memory>
 #include <optional>
+#include <stop_token>
 #include <string>
 #include <string_view>
 #include <vector>
 
 namespace lyra::runtime {
+
+// LRM 21.3.2 cancellation observable. One or more output channels' joint
+// cancel state; `IsCancelled()` returns true once any participating channel
+// has been closed since this view was acquired. Captured by value into a
+// postponed closure so the closure short-circuits when the descriptor it
+// targets is invalidated mid-slot.
+//
+// "Whole-operation cancellation" -- any participating channel closing kills
+// the entire submit, matching the literal LRM wording "operations on a ...
+// multichannel descriptor are implicitly cancelled".
+class ChannelCancellation {
+ public:
+  [[nodiscard]] auto IsCancelled() const noexcept -> bool;
+
+ private:
+  friend class FileTable;
+  explicit ChannelCancellation(std::vector<std::stop_token> tokens);
+  std::vector<std::stop_token> tokens_;
+};
 
 // Owns file handles opened by `$fopen` (LRM 21.3.1). Two descriptor shapes
 // share the same int32 namespace:
@@ -30,6 +50,12 @@ namespace lyra::runtime {
 // Owned slots hold `std::unique_ptr<std::fstream>`; fstream's destructor
 // flushes and closes when the slot is reset, so no raw fopen / fclose
 // machinery lives at this layer.
+//
+// Each slot also owns a `std::stop_source` -- the LRM 21.3.2 cancel signal
+// for postponed operations tied to the channel ($fstrobe, and any future
+// $fmonitor). Close() request_stops the slot's source and replaces it with
+// a fresh one, so channel-reuse after close starts with a clean signal
+// while observers of the old source see a permanent stop.
 class FileTable {
  public:
   FileTable() = default;
@@ -51,7 +77,9 @@ class FileTable {
   // Closes the file(s) addressed by `descriptor`. For an MCD, iterates set
   // bits in 1..30 and closes each. For an FD, closes that single owned
   // slot. Bit 0 (stdout) and the pre-bound STDIN / STDOUT / STDERR FDs are
-  // never closed.
+  // never closed. Also fires the cancel signal on every affected slot
+  // (LRM 21.3.2) and replaces each slot's stop_source so the next open on
+  // a reused slot starts with a fresh signal.
   void Close(std::int32_t descriptor);
 
   // Returns the owned `std::fstream*` for `descriptor`, or nullptr if the
@@ -74,6 +102,18 @@ class FileTable {
       -> std::string_view;
   void ClearError(std::int32_t fd);
 
+  // Returns a `ChannelCancellation` covering every owned channel
+  // `descriptor` names (LRM 21.3.2). For an FD the view holds one token
+  // from the FD slot's source; for an MCD the view holds a token per set
+  // bit (1..30), with bit 0 / stdio sentinels / 0 silently skipped because
+  // they cannot be closed. Held-by-value by the consumer; once a slot's
+  // source is request_stopped, the consumer's stop_tokens see the stop
+  // even if the slot is later reused (the new open installs a fresh
+  // source -- the old token still observes the old, permanently-stopped
+  // state through its own refcount).
+  [[nodiscard]] auto CancellationFor(std::int32_t descriptor)
+      -> ChannelCancellation;
+
   // FD encoding constants exposed for dispatch-site value comparisons.
   static constexpr std::int32_t kFdHighBit =
       static_cast<std::int32_t>(static_cast<std::uint32_t>(1) << 31U);
@@ -93,9 +133,19 @@ class FileTable {
     std::string message;
   };
 
-  std::array<std::unique_ptr<std::fstream>, kMcdSlotCount> mcd_slots_{};
-  std::vector<std::unique_ptr<std::fstream>> fd_pool_{kFdReservedSlots};
-  std::vector<ErrorRecord> fd_errors_{kFdReservedSlots};
+  struct FdSlot {
+    std::unique_ptr<std::fstream> file;
+    ErrorRecord error;
+    std::stop_source cancel_source;
+  };
+
+  struct McdSlot {
+    std::unique_ptr<std::fstream> file;
+    std::stop_source cancel_source;
+  };
+
+  std::array<McdSlot, kMcdSlotCount> mcd_slots_{};
+  std::vector<FdSlot> fd_pool_{kFdReservedSlots};
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/io.hpp
+++ b/include/lyra/runtime/io.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <span>
 
 #include "lyra/value/format.hpp"
@@ -14,5 +15,13 @@ class RuntimeServices;
 void LyraPrint(
     RuntimeServices& services, value::PrintKind kind,
     std::span<const value::PrintItem> items);
+
+// LRM 21.2.2 $strobe-family runtime entry. Defers `print_action` to the
+// postponed region of the current time slot so the print observes
+// NBA-committed values. stdout-sink variants ($strobe[bho]) -- nothing to
+// cancel (stdout has no $fclose), so this is a thin SubmitPostponed
+// wrapper; the entry exists for symmetry with LyraSubmitFStrobe.
+void LyraSubmitStrobe(
+    RuntimeServices& services, std::function<void()> print_action);
 
 }  // namespace lyra::runtime

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -301,18 +301,31 @@ auto RenderRuntimeCallExpr(
           },
           [&](const mir::RuntimeSubmitPostponedCall& pc)
               -> diag::Result<std::string> {
-            // LRM 21.2.2: wrap the print in a lambda that fires from the
-            // postponed region. `[=, this]` snapshots procedural locals
-            // by value (NBAs do not touch them, so a snapshot is also
-            // semantically correct -- and frame-death-safe for `initial`
-            // bodies) and resolves module signals through `this`, so
-            // they read NBA-committed values at fire time.
+            // LRM 21.2.2: defer the print to the postponed region via the
+            // matching $strobe-family runtime entry. The lambda captures
+            // procedural locals by value ([=, this]) -- NBAs do not touch
+            // them and the snapshot is frame-death-safe for `initial`
+            // bodies; structural signals resolve through `this->` at fire
+            // time and so see NBA-committed values. LRM 21.3.2 cancellation
+            // on $fclose is the file-sink entry's responsibility.
             auto print_or = RenderRuntimePrintCall(ctx, pc.print);
             if (!print_or) {
               return std::unexpected(std::move(print_or.error()));
             }
+            if (!pc.print.descriptor.has_value()) {
+              return std::format(
+                  "lyra::runtime::LyraSubmitStrobe(Services(), "
+                  "[=, this]() {{ {}; }})",
+                  *print_or);
+            }
+            auto desc_or = RenderExpr(ctx, ctx.Expr(*pc.print.descriptor));
+            if (!desc_or) {
+              return std::unexpected(std::move(desc_or.error()));
+            }
             return std::format(
-                "Services().SubmitPostponed([=, this]() {{ {}; }})", *print_or);
+                "lyra::runtime::LyraSubmitFStrobe(Services(), {}, "
+                "[=, this]() {{ {}; }})",
+                *desc_or, *print_or);
           },
           [&](const mir::RuntimeFileOpenCall& fo) -> diag::Result<std::string> {
             auto name_or = RenderExpr(ctx, ctx.Expr(fo.name));

--- a/src/lyra/runtime/file_io.cpp
+++ b/src/lyra/runtime/file_io.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstring>
 #include <fstream>
+#include <functional>
 #include <ios>
 #include <iostream>
 #include <optional>
@@ -70,6 +71,18 @@ auto LyraFOpen(
 void LyraFClose(
     RuntimeServices& services, const value::PackedArray& descriptor) {
   services.Files().Close(static_cast<std::int32_t>(descriptor.ToInt64()));
+}
+
+void LyraSubmitFStrobe(
+    RuntimeServices& services, const value::PackedArray& descriptor,
+    std::function<void()> print_action) {
+  auto cancel = services.Files().CancellationFor(
+      static_cast<std::int32_t>(descriptor.ToInt64()));
+  services.SubmitPostponed(
+      [cancel = std::move(cancel), action = std::move(print_action)]() mutable {
+        if (cancel.IsCancelled()) return;
+        action();
+      });
 }
 
 void LyraFPrint(

--- a/src/lyra/runtime/file_table.cpp
+++ b/src/lyra/runtime/file_table.cpp
@@ -1,14 +1,17 @@
 #include "lyra/runtime/file_table.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <fstream>
 #include <ios>
 #include <memory>
 #include <optional>
+#include <stop_token>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 namespace lyra::runtime {
 
@@ -46,6 +49,15 @@ auto ParseMode(std::string_view mode)
 
 }  // namespace
 
+ChannelCancellation::ChannelCancellation(std::vector<std::stop_token> tokens)
+    : tokens_(std::move(tokens)) {
+}
+
+auto ChannelCancellation::IsCancelled() const noexcept -> bool {
+  return std::ranges::any_of(
+      tokens_, [](const std::stop_token& t) { return t.stop_requested(); });
+}
+
 auto FileTable::Open(
     std::string_view name, std::optional<std::string_view> mode)
     -> std::int32_t {
@@ -58,14 +70,14 @@ auto FileTable::Open(
     // Reuse the first free slot above the reserved stdio indexes; grow on
     // demand. fstream destructor closes/flushes on slot reset.
     for (std::size_t i = kFdReservedSlots; i < fd_pool_.size(); ++i) {
-      if (fd_pool_.at(i) == nullptr) {
-        fd_pool_.at(i) = std::move(stream);
-        fd_errors_.at(i) = ErrorRecord{};
+      if (fd_pool_.at(i).file == nullptr) {
+        fd_pool_.at(i).file = std::move(stream);
+        fd_pool_.at(i).error = ErrorRecord{};
         return kFdHighBit | static_cast<std::int32_t>(i);
       }
     }
-    fd_pool_.push_back(std::move(stream));
-    fd_errors_.emplace_back();
+    fd_pool_.emplace_back(
+        FdSlot{.file = std::move(stream), .error = {}, .cancel_source = {}});
     return kFdHighBit | static_cast<std::int32_t>(fd_pool_.size() - 1);
   }
   // MCD path: open write-truncate (LRM 21.3.1 omits the type for MCD form).
@@ -73,8 +85,8 @@ auto FileTable::Open(
       name_z, std::ios_base::out | std::ios_base::trunc);
   if (!stream->is_open()) return 0;
   for (std::size_t slot = 1; slot < kMcdSlotCount; ++slot) {
-    if (mcd_slots_.at(slot) == nullptr) {
-      mcd_slots_.at(slot) = std::move(stream);
+    if (mcd_slots_.at(slot).file == nullptr) {
+      mcd_slots_.at(slot).file = std::move(stream);
       return static_cast<std::int32_t>(1U << slot);
     }
   }
@@ -89,15 +101,23 @@ void FileTable::Close(std::int32_t descriptor) {
   if ((raw & (1U << 31U)) != 0U) {
     const std::size_t idx = raw & 0x7FFF'FFFFU;
     if (idx < kFdReservedSlots || idx >= fd_pool_.size()) return;
-    fd_pool_.at(idx).reset();
-    fd_errors_.at(idx) = ErrorRecord{};
+    auto& slot = fd_pool_.at(idx);
+    slot.file.reset();
+    slot.error = ErrorRecord{};
+    // LRM 21.3.2: fire cancel on any pending observers; replace the source
+    // so the next $fopen on this slot starts with a fresh signal.
+    slot.cancel_source.request_stop();
+    slot.cancel_source = std::stop_source{};
     return;
   }
   // MCD: iterate each set bit in 1..30 and close that slot. Bit 0 is the
   // stdout sentinel and is never closed.
-  for (std::size_t slot = 1; slot < kMcdSlotCount; ++slot) {
-    if ((raw & (1U << slot)) == 0U) continue;
-    mcd_slots_.at(slot).reset();
+  for (std::size_t slot_idx = 1; slot_idx < kMcdSlotCount; ++slot_idx) {
+    if ((raw & (1U << slot_idx)) == 0U) continue;
+    auto& slot = mcd_slots_.at(slot_idx);
+    slot.file.reset();
+    slot.cancel_source.request_stop();
+    slot.cancel_source = std::stop_source{};
   }
 }
 
@@ -108,11 +128,11 @@ auto FileTable::Resolve(std::int32_t descriptor) -> std::fstream* {
     const std::size_t idx = raw & 0x7FFF'FFFFU;
     // Stdio sentinels (0/1/2) and out-of-range indexes are not owned here.
     if (idx < kFdReservedSlots || idx >= fd_pool_.size()) return nullptr;
-    return fd_pool_.at(idx).get();
+    return fd_pool_.at(idx).file.get();
   }
   // MCD single bit. Bit 0 alone is the stdout sentinel -- not owned here.
   for (std::size_t slot = 1; slot < kMcdSlotCount; ++slot) {
-    if (raw == (1U << slot)) return mcd_slots_.at(slot).get();
+    if (raw == (1U << slot)) return mcd_slots_.at(slot).file.get();
   }
   return nullptr;
 }
@@ -137,26 +157,49 @@ void FileTable::SetError(
     std::int32_t fd, int errno_value, std::string message) {
   const auto idx = FdPoolIndex(fd, fd_pool_.size());
   if (!idx.has_value()) return;
-  fd_errors_.at(*idx) =
+  fd_pool_.at(*idx).error =
       ErrorRecord{.errno_value = errno_value, .message = std::move(message)};
 }
 
 auto FileTable::LastError(std::int32_t fd) const -> int {
   const auto idx = FdPoolIndex(fd, fd_pool_.size());
   if (!idx.has_value()) return 0;
-  return fd_errors_.at(*idx).errno_value;
+  return fd_pool_.at(*idx).error.errno_value;
 }
 
 auto FileTable::LastErrorMessage(std::int32_t fd) const -> std::string_view {
   const auto idx = FdPoolIndex(fd, fd_pool_.size());
   if (!idx.has_value()) return {};
-  return fd_errors_.at(*idx).message;
+  return fd_pool_.at(*idx).error.message;
 }
 
 void FileTable::ClearError(std::int32_t fd) {
   const auto idx = FdPoolIndex(fd, fd_pool_.size());
   if (!idx.has_value()) return;
-  fd_errors_.at(*idx) = ErrorRecord{};
+  fd_pool_.at(*idx).error = ErrorRecord{};
+}
+
+auto FileTable::CancellationFor(std::int32_t descriptor)
+    -> ChannelCancellation {
+  std::vector<std::stop_token> tokens;
+  if (descriptor == 0) return ChannelCancellation{std::move(tokens)};
+  const auto raw = static_cast<std::uint32_t>(descriptor);
+  if ((raw & (1U << 31U)) != 0U) {
+    const std::size_t idx = raw & 0x7FFF'FFFFU;
+    // Stdio sentinels (0/1/2) and out-of-range indexes have no observable
+    // close event -- contribute no token.
+    if (idx >= kFdReservedSlots && idx < fd_pool_.size()) {
+      tokens.push_back(fd_pool_.at(idx).cancel_source.get_token());
+    }
+    return ChannelCancellation{std::move(tokens)};
+  }
+  // MCD: collect one token per set bit in 1..30. Bit 0 is stdout sentinel
+  // (cannot be closed) so it contributes nothing.
+  for (std::size_t slot = 1; slot < kMcdSlotCount; ++slot) {
+    if ((raw & (1U << slot)) == 0U) continue;
+    tokens.push_back(mcd_slots_.at(slot).cancel_source.get_token());
+  }
+  return ChannelCancellation{std::move(tokens)};
 }
 
 }  // namespace lyra::runtime

--- a/src/lyra/runtime/io.cpp
+++ b/src/lyra/runtime/io.cpp
@@ -1,7 +1,9 @@
 #include "lyra/runtime/io.hpp"
 
+#include <functional>
 #include <span>
 #include <string_view>
+#include <utility>
 #include <variant>
 
 #include "lyra/base/overloaded.hpp"
@@ -31,6 +33,11 @@ void LyraPrint(
   const bool append_newline =
       kind == value::PrintKind::kDisplay || kind == value::PrintKind::kFDisplay;
   stream.FinishRecord(append_newline);
+}
+
+void LyraSubmitStrobe(
+    RuntimeServices& services, std::function<void()> print_action) {
+  services.SubmitPostponed(std::move(print_action));
 }
 
 }  // namespace lyra::runtime

--- a/tests/cases/cpp/fstrobe_cancel_basic/case.yaml
+++ b/tests/cases/cpp/fstrobe_cancel_basic/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.fstrobe_cancel_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  files:
+    out.txt: ""

--- a/tests/cases/cpp/fstrobe_cancel_basic/main.sv
+++ b/tests/cases/cpp/fstrobe_cancel_basic/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  int fd;
+  initial begin
+    fd = $fopen("out.txt", "w");
+    $fstrobe(fd, "should not appear");
+    $fclose(fd);
+  end
+endmodule

--- a/tests/cases/cpp/fstrobe_cancel_channel_reuse/case.yaml
+++ b/tests/cases/cpp/fstrobe_cancel_channel_reuse/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.fstrobe_cancel_channel_reuse
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  files:
+    a.txt: ""
+    b.txt: |
+      from second open

--- a/tests/cases/cpp/fstrobe_cancel_channel_reuse/main.sv
+++ b/tests/cases/cpp/fstrobe_cancel_channel_reuse/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  int fd1, fd2;
+  initial begin
+    fd1 = $fopen("a.txt", "w");
+    $fstrobe(fd1, "from first open");
+    $fclose(fd1);
+    // LRM 21.3.1: $fopen reuses closed channels; fd2 will equal fd1 numerically.
+    fd2 = $fopen("b.txt", "w");
+    $fstrobe(fd2, "from second open");
+    #1 $fclose(fd2);
+  end
+endmodule

--- a/tests/cases/cpp/fstrobe_cancel_independent_fds/case.yaml
+++ b/tests/cases/cpp/fstrobe_cancel_independent_fds/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.fstrobe_cancel_independent_fds
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  files:
+    a.txt: ""
+    b.txt: |
+      from fd2

--- a/tests/cases/cpp/fstrobe_cancel_independent_fds/main.sv
+++ b/tests/cases/cpp/fstrobe_cancel_independent_fds/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  int fd1, fd2;
+  initial begin
+    fd1 = $fopen("a.txt", "w");
+    fd2 = $fopen("b.txt", "w");
+    $fstrobe(fd1, "from fd1");
+    $fstrobe(fd2, "from fd2");
+    $fclose(fd1);
+    #1 $fclose(fd2);
+  end
+endmodule

--- a/tests/cases/cpp/fstrobe_cancel_mcd_partial/case.yaml
+++ b/tests/cases/cpp/fstrobe_cancel_mcd_partial/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.fstrobe_cancel_mcd_partial
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  files:
+    a.txt: ""
+    b.txt: ""

--- a/tests/cases/cpp/fstrobe_cancel_mcd_partial/main.sv
+++ b/tests/cases/cpp/fstrobe_cancel_mcd_partial/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  int mcd_a, mcd_b;
+  initial begin
+    mcd_a = $fopen("a.txt");
+    mcd_b = $fopen("b.txt");
+    $fstrobe(mcd_a | mcd_b, "fans out");
+    // LRM 21.3.2: closing any participating channel cancels the whole
+    // postponed operation; mcd_b is still open at fire time but b.txt
+    // is still empty.
+    $fclose(mcd_a);
+    #1 $fclose(mcd_b);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements LRM 21.3.2 implicit cancellation: a pending `$fstrobe` submission whose target channel is closed by `$fclose` before the postponed region fires is dropped silently rather than writing to a closed (or, worse, channel-reused) descriptor. Without this, the channel-reuse path -- `$fopen` returning the same numeric descriptor after a close -- causes a stale strobe to leak into the freshly opened file.

## Design

Cancellation is modelled as a resource event: every FD pool slot and every MCD slot owns a `std::stop_source`. `$fclose` request_stops the slot's source and replaces it with a fresh one, so the next open on a reused slot starts clean while observers captured before the close keep seeing the original, permanently-stopped state through the source's refcounted shared state. The strobe runtime entry `LyraSubmitFStrobe` acquires a `ChannelCancellation` view at submit time and short-circuits the wrapped print if any participating channel reports cancelled; the stdout counterpart `LyraSubmitStrobe` is a thin SubmitPostponed wrapper for symmetry (stdout has no `$fclose`). Whole-operation cancellation for OR-ed MCDs matches the literal LRM wording "operations on a ... multichannel descriptor are implicitly cancelled".

The slot refactor (collapsing parallel `fd_pool_` / `fd_errors_` vectors into `vector<FdSlot>`, and `mcd_slots_` into `array<McdSlot, N>`) absorbs the new cancel field cleanly and removes a pre-existing parallel-arrays smell.

## Testing

Four `cpp_run` cases:
- `fstrobe_cancel_basic` -- minimal submit-then-close reproducer
- `fstrobe_cancel_independent_fds` -- closing one FD does not cancel another's strobe
- `fstrobe_cancel_channel_reuse` -- the load-bearing case (LRM 21.3.1 reuse without cancellation = corruption)
- `fstrobe_cancel_mcd_partial` -- documents whole-operation cancellation when one of an OR-ed MCD's channels closes