### PR TITLE
Add %t time formatting, $timeformat and $printtimescale

### DIFF
--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -11,8 +11,9 @@ since the test harness can only probe a variable whose type has an implemented s
       byte's X/Z poison collapses to a single character following simulator convention -- any X bit
       yields `x`, otherwise any Z bit yields `z`. Width / precision modifiers are rejected by the
       slang frontend, so the lowered form is always a single character.
-- [ ] DI2 -- `%t` (time): formatted against the active timescale. Tracked in `timescale.md` TS3; it
-      rides on the design-global precision and scope-unit scaling that workstream establishes.
+- [x] DI2 -- `%t` (time): formatted against the active timescale. Implemented under `timescale.md`
+      TS3 -- the display unit, precision, suffix and field width come from `$timeformat` (LRM
+      20.4.3), applied design-wide.
 - [x] DI3 -- `%f` / `%e` / `%g` (real). Default precision 6 per LRM Table 21-2. Coverage tracked
       under `datatypes.md` Real C1.
 - [ ] DI4 -- `%m` (hierarchical name). Requires runtime exposure of the current scope's hierarchical

--- a/docs/progress/processes.md
+++ b/docs/progress/processes.md
@@ -3,7 +3,7 @@
 Tracks SystemVerilog procedural-block constructs and the supporting timing-control machinery. Covers
 archive items under `archived/tests/sv_features/processes/`.
 
-The numeric IDs (P1..P13, T1..T5) are stable references and do **not** imply execution order.
+The numeric IDs (P1..P14, T1..T5) are stable references and do **not** imply execution order.
 
 ## Actionable
 
@@ -28,6 +28,10 @@ machinery owned by other workstreams; see [Blocked](#blocked).
 - [x] P2 -- `final` (LRM 9.2.3). Drained at end of simulation. `$finish` inside `final` ends
       simulation immediately. Time-controlling statements inside `final` are rejected at the runtime
       boundary because they would suspend a coroutine the engine cannot resume.
+- [ ] P14 -- `$finish` / `$stop` verbosity level (LRM 20.2). The level argument (0 / 1 / 2) is
+      parsed and validated at lowering, but the engine terminates regardless of its value; the
+      level-gated end-of-simulation reporting (nothing / time / time plus statistics) is not
+      implemented.
 - [x] P3 -- `always` / `always_ff` (LRM 9.2.2). `always_ff` collapses to the same shape as `always`
       because the LRM 9.2.2.4 restrictions are lint-only and the frontend already enforces them.
       Pathological zero-delay loops are caught by the engine's settle limit.

--- a/docs/progress/timescale.md
+++ b/docs/progress/timescale.md
@@ -26,6 +26,10 @@ others read from.
 - `$time`, `$realtime` and `$stime` read the current simulation time scaled to the calling design
   element's time unit (LRM 20.3): `$time` rounds to an integer, `$realtime` keeps the fraction, and
   `$stime` is the low 32 bits.
+- `%t` formats a time value against the design-wide `$timeformat` display unit, precision, suffix
+  and field width (LRM 21.2.1.3 / 20.4.3), and `$printtimescale` reports a scope's unit and
+  precision (LRM 20.4.2). The display unit is applied design-wide, so `%t` reports on one uniform
+  scale across scopes, distinct from the per-scope unit scaling of `$time`.
 
 ## Sub-Steps
 
@@ -49,12 +53,14 @@ others read from.
 
 ### Formatting simulation time
 
-- [ ] TS3 -- `%t` time format (LRM 21.2), `$timeformat` (LRM 20.4.3) and `$printtimescale` (LRM
+- [x] TS3 -- `%t` time format (LRM 21.2), `$timeformat` (LRM 20.4.3) and `$printtimescale` (LRM
       20.4.2): `%t` formats a time value against the `$timeformat` settings -- a display unit,
       fractional-digit count, suffix, and minimum field width, defaulting to the smallest precision
       across all timescale directives. The display unit is `$timeformat`'s, applied design-wide, not
       the calling scope's unit, so it is uniform across the design (distinct from TS2's per-scope
-      scaling). Closes `display.md` DI2. Rides on TS1.
+      scaling). Closes `display.md` DI2. Rides on TS1. `$printtimescale` covers the no-argument
+      (current scope) form; the `$unit` / `$root` / hierarchical-name argument forms ride on the
+      cross-scope name resolution tracked under `display.md` DI4.
 
 ## Design direction
 

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -42,7 +42,6 @@ enum class DiagCode : std::uint32_t {
   kFormatStringUnknownSpecifier,
   kDisplayMissingArg,
   kFormatModulePathNotImplemented,
-  kFormatSpecifierNotImplemented,
   kSystemSubroutineExecutionNotImplemented,
 
   kCppEmitExpressionFormNotImplemented,

--- a/include/lyra/lowering/hir_to_mir/lower_diagnostic.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_diagnostic.hpp
@@ -20,7 +20,6 @@ auto LowerDiagnosticSystemSubroutineCall(
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
-    const support::SystemSubroutineDesc& desc,
     const support::DiagnosticSystemSubroutineInfo& info, diag::SourceSpan span)
     -> diag::Result<mir::Expr>;
 

--- a/include/lyra/lowering/hir_to_mir/lower_file_io.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_file_io.hpp
@@ -42,8 +42,7 @@ auto LowerFileIOSystemSubroutineCallStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
     ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
-    const hir::Stmt& stmt, diag::SourceSpan span, const hir::CallExpr& call,
-    const support::SystemSubroutineDesc& desc,
+    const hir::Stmt& stmt, const hir::CallExpr& call,
     const support::FileIOSystemSubroutineInfo& info,
     std::optional<hir::ExprId> assign_target, mir::TypeId result_type)
     -> diag::Result<mir::Stmt>;

--- a/include/lyra/lowering/hir_to_mir/lower_print.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_print.hpp
@@ -19,7 +19,6 @@ auto LowerPrintSystemSubroutineCall(
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
-    const support::SystemSubroutineDesc& desc,
     const support::PrintSystemSubroutineInfo& print, diag::SourceSpan span)
     -> diag::Result<mir::Expr>;
 

--- a/include/lyra/lowering/hir_to_mir/lower_scan.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_scan.hpp
@@ -14,20 +14,14 @@
 
 namespace lyra::lowering::hir_to_mir {
 
-// LRM 21.3.4.3 $sscanf reached in expression position (e.g. inside an `if`
-// or a non-blocking-assignment context). $sscanf writes through output
-// argument lvalues, which only lowers cleanly at the statement boundary
-// where the temp + writeback BlockStmt can wrap the call; nested forms
-// return Unsupported. Statement-position calls bypass this entry via
-// LowerScanSystemSubroutineCallStmt, dispatched from lower_stmt.cpp.
-auto LowerScanSystemSubroutineCall(
-    const UnitLoweringState& unit_state,
-    const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
-    ProceduralScopeLoweringState& proc_scope_state,
-    const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
-    const support::SystemSubroutineDesc& desc,
-    const support::ScanSystemSubroutineInfo& info, diag::SourceSpan span)
+// Reject a $sscanf / $fscanf reached in expression position (e.g. inside an
+// `if` or a non-blocking-assignment context). The scan family writes through
+// output argument lvalues, which only lowers cleanly at the statement boundary
+// where the temp + writeback BlockStmt can wrap the call (see
+// LowerScanSystemSubroutineCallStmt, dispatched from lower_stmt.cpp); every
+// other position is unsupported.
+auto RejectScanCallInExprPosition(
+    const support::SystemSubroutineDesc& desc, diag::SourceSpan span)
     -> diag::Result<mir::Expr>;
 
 // Statement-position $sscanf desugaring (LRM 13.5 copy-out for every output

--- a/include/lyra/lowering/hir_to_mir/lower_timescale.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_timescale.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_span.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/expr.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// Lower `$timeformat` (LRM 20.4.3) into a void `mir::RuntimeCallExpr` carrying
+// a `RuntimeSetTimeFormatCall`. The four-argument form lowers its arguments as
+// expressions (the runtime narrows them); the no-argument form restores the
+// defaults.
+auto LowerTimeFormatSystemSubroutineCall(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
+    diag::SourceSpan span) -> diag::Result<mir::Expr>;
+
+// Lower `$printtimescale` (LRM 20.4.2, no-argument form) into a void
+// `mir::RuntimeCallExpr` carrying a `RuntimePrintTimescaleCall` with the
+// enclosing scope's name.
+auto LowerPrintTimescaleSystemSubroutineCall(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state) -> diag::Result<mir::Expr>;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -21,6 +21,7 @@
 #include "lyra/mir/runtime_sformat.hpp"
 #include "lyra/mir/runtime_submit.hpp"
 #include "lyra/mir/runtime_time.hpp"
+#include "lyra/mir/runtime_timescale.hpp"
 #include "lyra/mir/structural_param.hpp"
 #include "lyra/mir/structural_subroutine_ref.hpp"
 #include "lyra/mir/unary_op.hpp"
@@ -107,7 +108,8 @@ using RuntimeCall = std::variant<
     RuntimeFileUngetcCall, RuntimeFileGetsCall, RuntimeFileReadCall,
     RuntimeFileSeekCall, RuntimeFileRewindCall, RuntimeFileTellCall,
     RuntimeFileEofCall, RuntimeFileErrorCall, RuntimeFileFlushCall,
-    RuntimeScanCall, RuntimeSFormatCall, RuntimeTimeCall>;
+    RuntimeScanCall, RuntimeSFormatCall, RuntimeTimeCall,
+    RuntimeSetTimeFormatCall, RuntimePrintTimescaleCall>;
 
 struct RuntimeCallExpr {
   RuntimeCall call;

--- a/include/lyra/mir/runtime_print.hpp
+++ b/include/lyra/mir/runtime_print.hpp
@@ -23,10 +23,8 @@ struct FormatModifiers {
 struct FormatSpec {
   value::FormatKind kind;
   FormatModifiers modifiers;
-  std::int32_t timeunit_power;
 
-  FormatSpec(value::FormatKind k, FormatModifiers m, std::int32_t tp = 0)
-      : kind(k), modifiers(m), timeunit_power(tp) {
+  FormatSpec(value::FormatKind k, FormatModifiers m) : kind(k), modifiers(m) {
   }
 };
 

--- a/include/lyra/mir/runtime_timescale.hpp
+++ b/include/lyra/mir/runtime_timescale.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "lyra/mir/expr_id.hpp"
+
+namespace lyra::mir {
+
+// The four `$timeformat` argument expressions (LRM 20.4.3): display unit power,
+// fractional-digit count, suffix string, and minimum field width.
+struct TimeFormatArgExprs {
+  ExprId units;
+  ExprId precision;
+  ExprId suffix;
+  ExprId min_width;
+};
+
+// LRM 20.4.3: `$timeformat`. The four-argument form carries the argument
+// expressions; the no-argument form is `nullopt` and restores the defaults
+// (LRM Table 20-3). Arguments may be non-constant, so they stay as expressions
+// and the runtime narrows them, matching how file descriptors flow.
+struct RuntimeSetTimeFormatCall {
+  std::optional<TimeFormatArgExprs> args;
+};
+
+// LRM 20.4.2: `$printtimescale` (no-argument form). The scope name is the
+// lexically enclosing design element, resolved at lowering; the unit and
+// precision come from the scope class constants at render time.
+struct RuntimePrintTimescaleCall {
+  std::string scope_name;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -7,6 +7,8 @@
 #include <map>
 #include <memory>
 #include <span>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "lyra/base/time.hpp"
@@ -17,6 +19,7 @@
 #include "lyra/runtime/scope.hpp"
 #include "lyra/runtime/stream_dispatcher.hpp"
 #include "lyra/runtime/trigger.hpp"
+#include "lyra/value/format.hpp"
 
 namespace lyra::runtime {
 
@@ -103,6 +106,27 @@ class Engine {
     return global_precision_power_;
   }
 
+  // LRM 20.4.3: the design-wide `$timeformat` settings that drive every `%t`.
+  [[nodiscard]] auto TimeFormat() const -> const value::TimeFormat& {
+    return time_format_;
+  }
+  void SetTimeFormat(
+      std::int8_t units_power, std::int32_t precision, std::string suffix,
+      std::int32_t min_width) {
+    time_format_ = value::TimeFormat{
+        .units_power = units_power,
+        .precision = precision,
+        .suffix = std::move(suffix),
+        .min_width = min_width};
+  }
+  // LRM Table 20-3: the no-argument `$timeformat` form restores the defaults --
+  // display unit is the design-global precision, precision 0, no suffix, field
+  // width 20.
+  void ResetTimeFormat() {
+    time_format_ = value::TimeFormat{};
+    time_format_.units_power = global_precision_power_;
+  }
+
  private:
   struct SchedulerQueues {
     std::deque<CoroutineHandle> active;
@@ -159,6 +183,7 @@ class Engine {
   SchedulerQueues queues_;
   SimTime now_ = 0;
   std::int8_t global_precision_power_ = kDefaultTimePrecisionPower;
+  value::TimeFormat time_format_;
   SchedulerPhase phase_ = SchedulerPhase::kIdle;
   std::size_t current_delta_ = 0;
   bool bound_ = false;

--- a/include/lyra/runtime/finish.hpp
+++ b/include/lyra/runtime/finish.hpp
@@ -19,8 +19,10 @@ class FinishAwaitable {
     return false;
   }
 
-  void await_suspend(CoroutineHandle handle) noexcept {
-    (void)handle;
+  // The coroutine protocol passes the awaiting handle, but `$finish` suspends
+  // forever (the engine drops the frame), so the handle is unused.
+  // NOLINTNEXTLINE(readability-named-parameter)
+  void await_suspend(CoroutineHandle) noexcept {
     services_->RequestFinish(level_);
   }
 

--- a/include/lyra/runtime/runtime_services.hpp
+++ b/include/lyra/runtime/runtime_services.hpp
@@ -1,11 +1,18 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/time.hpp"
 #include "lyra/runtime/coroutine.hpp"
 #include "lyra/runtime/trigger.hpp"
+#include "lyra/value/format.hpp"
+
+namespace lyra::value {
+class PackedArray;
+class String;
+}  // namespace lyra::value
 
 namespace lyra::runtime {
 
@@ -79,6 +86,15 @@ class RuntimeServices {
   // The design-global time precision (LRM 3.14.3) the delay awaitable scales a
   // scope-precision delay against to reach the engine's tick.
   [[nodiscard]] auto GlobalPrecisionPower() const -> std::int8_t;
+
+  // The design-wide `$timeformat` state (LRM 20.4.3) read by `%t`, and the
+  // setter / reset that `$timeformat` invokes.
+  [[nodiscard]] auto TimeFormat() const -> const value::TimeFormat&;
+  void SetTimeFormat(
+      const value::PackedArray& units_power,
+      const value::PackedArray& precision, const value::String& suffix,
+      const value::PackedArray& min_width);
+  void ResetTimeFormat();
 
  private:
   StreamDispatcher* stream_ = nullptr;

--- a/include/lyra/runtime/sformat.hpp
+++ b/include/lyra/runtime/sformat.hpp
@@ -7,11 +7,15 @@
 
 namespace lyra::runtime {
 
+class RuntimeServices;
+
 // LRM 21.3.3 string-format family runtime entry. Reuses the same
 // `value::FormatValue` engine as `LyraPrint`, but appends to a local
 // std::string buffer that becomes the returned `value::String` rvalue.
-// No newline is appended -- the formatted text is the entire output.
-[[nodiscard]] auto LyraSFormat(std::span<const value::PrintItem> items)
+// No newline is appended -- the formatted text is the entire output. Takes
+// `services` so `%t` can read the design-wide `$timeformat` state.
+[[nodiscard]] auto LyraSFormat(
+    RuntimeServices& services, std::span<const value::PrintItem> items)
     -> value::String;
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/timescale.hpp
+++ b/include/lyra/runtime/timescale.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace lyra::runtime {
+
+class RuntimeServices;
+
+// LRM 20.4.2: `$printtimescale`. Prints
+// `Time scale of (<scope_name>) is <unit> / <precision>` using the LRM Table
+// 20-2 unit spelling, terminated by a newline.
+void LyraPrintTimescale(
+    RuntimeServices& services, std::string_view scope_name,
+    std::int8_t unit_power, std::int8_t precision_power);
+
+}  // namespace lyra::runtime

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -152,11 +152,21 @@ struct TimeSystemSubroutineInfo {
   TimeKind kind;
 };
 
+// LRM 20.4.3: `$timeformat` sets the design-wide `%t` display unit, precision,
+// suffix, and minimum field width (or restores the defaults when called with no
+// arguments).
+struct TimeFormatSystemSubroutineInfo {};
+
+// LRM 20.4.2: `$printtimescale` prints a design element's time unit and
+// precision. Only the no-argument (current scope) form is modeled.
+struct PrintTimescaleSystemSubroutineInfo {};
+
 using SystemSubroutineSemantic = std::variant<
     PrintSystemSubroutineInfo, TerminationSystemSubroutineInfo,
     DiagnosticSystemSubroutineInfo, FileIOSystemSubroutineInfo,
     ScanSystemSubroutineInfo, SFormatSystemSubroutineInfo,
-    TimeSystemSubroutineInfo>;
+    TimeSystemSubroutineInfo, TimeFormatSystemSubroutineInfo,
+    PrintTimescaleSystemSubroutineInfo>;
 
 struct SystemSubroutineDesc {
   SystemSubroutineId id;
@@ -781,6 +791,24 @@ inline constexpr std::array kSystemSubroutines = {
                 .append_newline = true,
                 .is_strobe = true,
                 .sink_kind = PrintSinkKind::kFile},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{51},
+        .name = "$timeformat",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 4},
+        .semantic = TimeFormatSystemSubroutineInfo{},
+    },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{52},
+        .name = "$printtimescale",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kTask,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 0},
+        .semantic = PrintTimescaleSystemSubroutineInfo{},
     },
 };
 

--- a/include/lyra/value/format.hpp
+++ b/include/lyra/value/format.hpp
@@ -33,6 +33,7 @@ enum class FormatKind : std::uint8_t {
   kRealExponential,
   kRealGeneral,
   kAssignmentPattern,
+  kTime,
 };
 
 // Two-state vs four-state lives on the integral axis, not as a top-level
@@ -50,6 +51,16 @@ struct FormatSpec {
   bool zero_pad = false;
   bool left_align = false;
   std::int32_t timeunit_power = 0;
+};
+
+// LRM 20.4.3 / Table 20-3: the design-wide settings that drive every `%t`. The
+// runtime owns one mutable instance (on the Engine); `$timeformat` writes it.
+// `units_power` is the display unit as an LRM Table 20-2 power value.
+struct TimeFormat {
+  std::int8_t units_power = 0;
+  std::int32_t precision = 0;
+  std::string suffix;
+  std::int32_t min_width = 20;
 };
 
 struct NarrowIntegralView {
@@ -159,6 +170,13 @@ struct RuntimeValueView {
 
 [[nodiscard]] auto FormatValue(
     const FormatSpec& spec, const RuntimeValueView& value) -> std::string;
+
+// LRM 21.2.1.3: `%t`. Rescales the operand from the calling scope's time unit
+// (`spec.timeunit_power`) to the design-wide display unit (`tf.units_power`),
+// then formats with the `$timeformat` precision / suffix / min field width.
+[[nodiscard]] auto FormatTime(
+    const FormatSpec& spec, const RuntimeValueView& value, const TimeFormat& tf)
+    -> std::string;
 
 struct PrintLiteralItem {
   const char* data;

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -408,6 +408,7 @@ auto RenderScopeHeaderFile(
   out += "#include \"lyra/runtime/scan.hpp\"\n";
   out += "#include \"lyra/runtime/sformat.hpp\"\n";
   out += "#include \"lyra/runtime/sim_time.hpp\"\n";
+  out += "#include \"lyra/runtime/timescale.hpp\"\n";
   out += "#include \"lyra/runtime/var.hpp\"\n";
   out += "#include \"lyra/value/enum.hpp\"\n";
   out += "#include \"lyra/value/format.hpp\"\n";

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -20,6 +20,7 @@
 #include "lyra/mir/runtime_finish.hpp"
 #include "lyra/mir/runtime_print.hpp"
 #include "lyra/mir/runtime_submit.hpp"
+#include "lyra/mir/runtime_timescale.hpp"
 #include "lyra/mir/type.hpp"
 
 namespace lyra::backend::cpp {
@@ -62,6 +63,8 @@ auto RenderFormatKindLiteral(value::FormatKind k) -> std::string_view {
       return "lyra::value::FormatKind::kRealGeneral";
     case value::FormatKind::kAssignmentPattern:
       return "lyra::value::FormatKind::kAssignmentPattern";
+    case value::FormatKind::kTime:
+      return "lyra::value::FormatKind::kTime";
   }
   throw InternalError("RenderFormatKindLiteral: unknown FormatKind");
 }
@@ -87,8 +90,12 @@ auto RenderFormatSpecInit(const mir::FormatSpec& spec) -> std::string {
   if (spec.modifiers.left_align) {
     fields.emplace_back(".left_align = true");
   }
-  if (spec.timeunit_power != 0) {
-    fields.push_back(std::format(".timeunit_power = {}", spec.timeunit_power));
+  // LRM 21.2.1.3 / 3.14.2: `%t` scales from the enclosing scope's time unit.
+  // The unit is the scope class constant, resolved by unqualified C++ name
+  // lookup to the lexically enclosing design element -- mirrors how $time
+  // reads it, so a `%t` inside a subroutine uses its declaration scope's unit.
+  if (spec.kind == value::FormatKind::kTime) {
+    fields.emplace_back(".timeunit_power = kTimeUnitPower");
   }
   std::string joined;
   for (const auto& field : fields) {
@@ -473,7 +480,7 @@ auto RenderRuntimeCallExpr(
           [&](const mir::RuntimeSFormatCall& sf) -> diag::Result<std::string> {
             if (sf.items.empty()) {
               return std::string(
-                  "lyra::runtime::LyraSFormat("
+                  "lyra::runtime::LyraSFormat(Services(), "
                   "std::span<const lyra::value::PrintItem>{})");
             }
             std::vector<std::string> item_pieces;
@@ -493,7 +500,7 @@ auto RenderRuntimeCallExpr(
               body += item_pieces[k];
             }
             return std::format(
-                "lyra::runtime::LyraSFormat("
+                "lyra::runtime::LyraSFormat(Services(), "
                 "std::array<lyra::value::PrintItem, {}>{{{{{}}}}})",
                 sf.items.size(), body);
           },
@@ -517,6 +524,34 @@ auto RenderRuntimeCallExpr(
                     "kTimeUnitPower)");
             }
             throw InternalError("RenderRuntimeCallExpr: unknown TimeKind");
+          },
+          [&](const mir::RuntimeSetTimeFormatCall& tf)
+              -> diag::Result<std::string> {
+            if (!tf.args.has_value()) {
+              return std::string("Services().ResetTimeFormat()");
+            }
+            auto units = RenderExpr(ctx, ctx.Expr(tf.args->units));
+            if (!units) return std::unexpected(std::move(units.error()));
+            auto precision = RenderExpr(ctx, ctx.Expr(tf.args->precision));
+            if (!precision) {
+              return std::unexpected(std::move(precision.error()));
+            }
+            auto suffix = RenderExpr(ctx, ctx.Expr(tf.args->suffix));
+            if (!suffix) return std::unexpected(std::move(suffix.error()));
+            auto width = RenderExpr(ctx, ctx.Expr(tf.args->min_width));
+            if (!width) return std::unexpected(std::move(width.error()));
+            return std::format(
+                "Services().SetTimeFormat({}, {}, {}, {})", *units, *precision,
+                *suffix, *width);
+          },
+          [&](const mir::RuntimePrintTimescaleCall& pt)
+              -> diag::Result<std::string> {
+            // Unit and precision come from the enclosing scope class constants
+            // (LRM 20.4.2, current-scope form); the name is baked at lowering.
+            return std::format(
+                "lyra::runtime::LyraPrintTimescale(Services(), {}, "
+                "kTimeUnitPower, kTimePrecisionPower)",
+                RenderCStringLiteral(pt.scope_name));
           },
       },
       expr.call);

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -194,12 +194,6 @@ constexpr std::array kEntries{
             .category = UnsupportedCategory::kFeature,
             .name = "format_module_path_not_implemented"}},
     std::pair{
-        DiagCode::kFormatSpecifierNotImplemented,
-        DiagCodeInfo{
-            .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
-            .name = "format_specifier_not_implemented"}},
-    std::pair{
         DiagCode::kSystemSubroutineExecutionNotImplemented,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,

--- a/src/lyra/lowering/hir_to_mir/lower_diagnostic.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_diagnostic.cpp
@@ -40,10 +40,8 @@ auto LowerDiagnosticSystemSubroutineCall(
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
-    const support::SystemSubroutineDesc& desc,
     const support::DiagnosticSystemSubroutineInfo& info, diag::SourceSpan span)
     -> diag::Result<mir::Expr> {
-  (void)desc;
   // $info/$warning/$error use display-style format (LRM 20.10) with decimal
   // as the bare-arg default radix; the diagnostic sink runs separately.
   auto items_or = BuildRuntimePrintItemsFromCallArgs(

--- a/src/lyra/lowering/hir_to_mir/lower_file_io.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_file_io.cpp
@@ -308,9 +308,7 @@ auto LowerFileIOSystemSubroutineCallStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
     ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
-    const hir::Stmt& stmt, [[maybe_unused]] diag::SourceSpan span,
-    const hir::CallExpr& call,
-    [[maybe_unused]] const support::SystemSubroutineDesc& desc,
+    const hir::Stmt& stmt, const hir::CallExpr& call,
     const support::FileIOSystemSubroutineInfo& info,
     std::optional<hir::ExprId> assign_target, mir::TypeId result_type)
     -> diag::Result<mir::Stmt> {

--- a/src/lyra/lowering/hir_to_mir/lower_print.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_print.cpp
@@ -39,10 +39,8 @@ auto LowerPrintSystemSubroutineCall(
     const ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
-    const support::SystemSubroutineDesc& desc,
     const support::PrintSystemSubroutineInfo& print, diag::SourceSpan span)
     -> diag::Result<mir::Expr> {
-  (void)desc;
   std::optional<mir::ExprId> descriptor = std::nullopt;
   std::size_t arg_offset = 0;
   if (print.sink_kind == support::PrintSinkKind::kFile) {

--- a/src/lyra/lowering/hir_to_mir/lower_scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_scan.cpp
@@ -4,7 +4,6 @@
 #include <format>
 #include <optional>
 #include <string>
-#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -25,9 +24,8 @@
 
 namespace lyra::lowering::hir_to_mir {
 
-namespace {
-
-auto RejectScanCallInExprPosition(std::string_view name, diag::SourceSpan span)
+auto RejectScanCallInExprPosition(
+    const support::SystemSubroutineDesc& desc, diag::SourceSpan span)
     -> diag::Result<mir::Expr> {
   return diag::Unsupported(
       span, diag::DiagCode::kUnsupportedSubroutineArgument,
@@ -35,23 +33,8 @@ auto RejectScanCallInExprPosition(std::string_view name, diag::SourceSpan span)
           "{} writes through output arguments and is only supported as a "
           "bare call or as the right-hand side of a blocking assignment "
           "(LRM 13.5 copy-out semantics)",
-          std::string{name}),
+          std::string{desc.name}),
       diag::UnsupportedCategory::kFeature);
-}
-
-}  // namespace
-
-auto LowerScanSystemSubroutineCall(
-    [[maybe_unused]] const UnitLoweringState& unit_state,
-    [[maybe_unused]] const StructuralScopeLoweringState& scope_state,
-    [[maybe_unused]] const ProcessLoweringState& proc_state,
-    [[maybe_unused]] ProceduralScopeLoweringState& proc_scope_state,
-    [[maybe_unused]] const hir::ProceduralBody& hir_proc,
-    [[maybe_unused]] const hir::CallExpr& call,
-    const support::SystemSubroutineDesc& desc,
-    [[maybe_unused]] const support::ScanSystemSubroutineInfo& info,
-    diag::SourceSpan span) -> diag::Result<mir::Expr> {
-  return RejectScanCallInExprPosition(desc.name, span);
 }
 
 auto LowerScanSystemSubroutineCallStmt(

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -496,9 +496,8 @@ auto LowerExprStmt(
       if (const auto* file_info = support::GetFileIOInfo(desc)) {
         if (support::FileIOHasOutputArg(file_info->kind)) {
           return LowerFileIOSystemSubroutineCallStmt(
-              unit_state, scope_state, proc_state, hir_proc, stmt, inner.span,
-              *call, desc, *file_info, std::nullopt,
-              unit_state.TranslateType(inner.type));
+              unit_state, scope_state, proc_state, hir_proc, stmt, *call,
+              *file_info, std::nullopt, unit_state.TranslateType(inner.type));
         }
       }
       if (const auto* scan_info = support::GetScanInfo(desc)) {
@@ -555,9 +554,8 @@ auto LowerExprStmt(
           if (const auto* file_info = support::GetFileIOInfo(desc)) {
             if (support::FileIOHasOutputArg(file_info->kind)) {
               return LowerFileIOSystemSubroutineCallStmt(
-                  unit_state, scope_state, proc_state, hir_proc, stmt,
-                  call_carrier->span, *call, desc, *file_info, assign->lhs,
-                  result_type);
+                  unit_state, scope_state, proc_state, hir_proc, stmt, *call,
+                  *file_info, assign->lhs, result_type);
             }
           }
           if (const auto* scan_info = support::GetScanInfo(desc)) {

--- a/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
@@ -13,6 +13,7 @@
 #include "lyra/lowering/hir_to_mir/lower_print.hpp"
 #include "lyra/lowering/hir_to_mir/lower_scan.hpp"
 #include "lyra/lowering/hir_to_mir/lower_sformat.hpp"
+#include "lyra/lowering/hir_to_mir/lower_timescale.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/support/system_subroutine.hpp"
@@ -34,7 +35,7 @@ auto LowerSystemSubroutineCall(
               -> diag::Result<mir::Expr> {
             return LowerPrintSystemSubroutineCall(
                 unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
-                call, desc, print, span);
+                call, print, span);
           },
           [&](const support::TerminationSystemSubroutineInfo& term)
               -> diag::Result<mir::Expr> {
@@ -45,7 +46,7 @@ auto LowerSystemSubroutineCall(
               -> diag::Result<mir::Expr> {
             return LowerDiagnosticSystemSubroutineCall(
                 unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
-                call, desc, diag_info, span);
+                call, diag_info, span);
           },
           [&](const support::FileIOSystemSubroutineInfo& file_io)
               -> diag::Result<mir::Expr> {
@@ -53,11 +54,12 @@ auto LowerSystemSubroutineCall(
                 unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
                 call, desc, file_io, span);
           },
-          [&](const support::ScanSystemSubroutineInfo& scan)
+          // Expression-position $sscanf only rejects; it needs no scan-info
+          // payload, so the visitor alternative is unnamed.
+          // NOLINTNEXTLINE(readability-named-parameter)
+          [&](const support::ScanSystemSubroutineInfo&)
               -> diag::Result<mir::Expr> {
-            return LowerScanSystemSubroutineCall(
-                unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
-                call, desc, scan, span);
+            return RejectScanCallInExprPosition(desc, span);
           },
           [&](const support::SFormatSystemSubroutineInfo& sformat)
               -> diag::Result<mir::Expr> {
@@ -88,6 +90,17 @@ auto LowerSystemSubroutineCall(
                     mir::RuntimeCallExpr{
                         .call = mir::RuntimeTimeCall{.kind = time_info.kind}},
                 .type = result_type};
+          },
+          [&](const support::TimeFormatSystemSubroutineInfo&)
+              -> diag::Result<mir::Expr> {
+            return LowerTimeFormatSystemSubroutineCall(
+                unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+                call, span);
+          },
+          [&](const support::PrintTimescaleSystemSubroutineInfo&)
+              -> diag::Result<mir::Expr> {
+            return LowerPrintTimescaleSystemSubroutineCall(
+                unit_state, scope_state);
           },
       },
       desc.semantic);

--- a/src/lyra/lowering/hir_to_mir/lower_timescale.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_timescale.cpp
@@ -1,0 +1,72 @@
+#include "lyra/lowering/hir_to_mir/lower_timescale.hpp"
+
+#include <array>
+#include <cstddef>
+#include <expected>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/procedural_body.hpp"
+#include "lyra/lowering/hir_to_mir/lower_expr.hpp"
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/runtime_timescale.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+auto LowerTimeFormatSystemSubroutineCall(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    const ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
+    diag::SourceSpan span) -> diag::Result<mir::Expr> {
+  const auto& args = call.arguments;
+  std::optional<mir::TimeFormatArgExprs> arg_exprs;
+  if (!args.empty()) {
+    if (args.size() != 4) {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedSubroutineArgument,
+          "$timeformat takes either no arguments or exactly four (LRM 20.4.3)",
+          diag::UnsupportedCategory::kFeature);
+    }
+    std::array<mir::ExprId, 4> ids{};
+    for (std::size_t i = 0; i < args.size(); ++i) {
+      auto lowered = LowerExpr(
+          unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+          hir_proc.exprs.at(args[i].value));
+      if (!lowered) return std::unexpected(std::move(lowered.error()));
+      ids.at(i) = proc_scope_state.AddExpr(*std::move(lowered));
+    }
+    arg_exprs = mir::TimeFormatArgExprs{
+        .units = ids[0],
+        .precision = ids[1],
+        .suffix = ids[2],
+        .min_width = ids[3]};
+  }
+  return mir::Expr{
+      .data =
+          mir::RuntimeCallExpr{
+              .call =
+                  mir::RuntimeSetTimeFormatCall{.args = std::move(arg_exprs)}},
+      .type = unit_state.Builtins().void_type};
+}
+
+auto LowerPrintTimescaleSystemSubroutineCall(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state)
+    -> diag::Result<mir::Expr> {
+  return mir::Expr{
+      .data =
+          mir::RuntimeCallExpr{
+              .call =
+                  mir::RuntimePrintTimescaleCall{
+                      .scope_name = std::string(scope_state.Scope().name)}},
+      .type = unit_state.Builtins().void_type};
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -2,7 +2,6 @@
 
 #include <cstddef>
 #include <expected>
-#include <format>
 #include <optional>
 #include <span>
 #include <string_view>
@@ -29,15 +28,6 @@ namespace lyra::lowering::hir_to_mir {
 
 namespace {
 
-auto SpecCharFor(support::FormatDirectiveKind k) -> std::string_view {
-  switch (k) {
-    case support::FormatDirectiveKind::kTime:
-      return "t";
-    default:
-      return "?";
-  }
-}
-
 auto ToValueFormatKind(support::FormatDirectiveKind k) -> value::FormatKind {
   switch (k) {
     case support::FormatDirectiveKind::kDecimal:
@@ -60,6 +50,8 @@ auto ToValueFormatKind(support::FormatDirectiveKind k) -> value::FormatKind {
       return value::FormatKind::kRealGeneral;
     case support::FormatDirectiveKind::kAssignmentPattern:
       return value::FormatKind::kAssignmentPattern;
+    case support::FormatDirectiveKind::kTime:
+      return value::FormatKind::kTime;
     default:
       throw InternalError("ToValueFormatKind: not a value-format kind");
   }
@@ -130,13 +122,6 @@ auto BuildPrintItemFromDirective(
           diag::UnsupportedCategory::kFeature);
 
     case support::FormatDirectiveKind::kTime:
-      return diag::Unsupported(
-          span, diag::DiagCode::kFormatSpecifierNotImplemented,
-          std::format(
-              "format specifier %{} is not implemented in this build",
-              SpecCharFor(directive.kind)),
-          diag::UnsupportedCategory::kFeature);
-
     case support::FormatDirectiveKind::kChar:
     case support::FormatDirectiveKind::kDecimal:
     case support::FormatDirectiveKind::kHex:
@@ -255,7 +240,6 @@ auto BuildRuntimePrintItemsFromCallArgs(
     items.push_back(*std::move(item_or));
     ++cursor;
   }
-  (void)call_span;
   return items;
 }
 

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -885,6 +885,18 @@ class MirDumper {
                     }
                     Line(std::format("RuntimeTimeCall kind={}", kind_text));
                   },
+                  [&](const RuntimeSetTimeFormatCall& tf) {
+                    Line(
+                        std::format(
+                            "RuntimeSetTimeFormatCall args={}",
+                            tf.args.has_value() ? "4" : "default"));
+                  },
+                  [&](const RuntimePrintTimescaleCall& pt) {
+                    Line(
+                        std::format(
+                            "RuntimePrintTimescaleCall scope={}",
+                            pt.scope_name));
+                  },
               },
               rc->call);
           Dedent();
@@ -1172,13 +1184,12 @@ class MirDumper {
                       "Item[{}] Value value=Expr[{}] type=Type[{}] "
                       "spec=Format(kind={}, width={}, precision={}, "
                       "zero_pad={}, "
-                      "left_align={}, timeunit_power={})",
+                      "left_align={})",
                       i, v.value.value, v.type.value,
                       DumpFormatKindLabel(v.spec.kind), v.spec.modifiers.width,
                       v.spec.modifiers.precision,
                       v.spec.modifiers.zero_pad ? "true" : "false",
-                      v.spec.modifiers.left_align ? "true" : "false",
-                      v.spec.timeunit_power));
+                      v.spec.modifiers.left_align ? "true" : "false"));
               Indent();
               Line(
                   std::format(
@@ -1239,6 +1250,8 @@ class MirDumper {
         return "kRealGeneral";
       case value::FormatKind::kAssignmentPattern:
         return "kAssignmentPattern";
+      case value::FormatKind::kTime:
+        return "kTime";
     }
     throw InternalError("DumpFormatKindLabel: unknown value::FormatKind");
   }

--- a/src/lyra/runtime/diagnostic.cpp
+++ b/src/lyra/runtime/diagnostic.cpp
@@ -96,6 +96,11 @@ void LyraDiagnostic(
               body.append(std::string_view{lit.data, lit.size});
             },
             [&](const value::PrintValueItem& v) {
+              if (v.spec.kind == value::FormatKind::kTime) {
+                body.append(
+                    value::FormatTime(v.spec, v.value, services.TimeFormat()));
+                return;
+              }
               body.append(value::FormatValue(v.spec, v.value));
             },
         },

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -94,6 +94,9 @@ void Engine::ResolveGlobalTimePrecision() {
     found = true;
   });
   global_precision_power_ = found ? min_power : kDefaultTimePrecisionPower;
+  // LRM Table 20-3: the default `%t` display unit is the design-global
+  // precision (the smallest across all timescale directives).
+  time_format_.units_power = global_precision_power_;
 }
 
 void Engine::RegisterProcesses() {
@@ -293,11 +296,10 @@ void Engine::RunProcess(CoroutineHandle handle) {
   handle.promise().Process().ResumeWith(handle);
 }
 
-void Engine::RequestFinish(int level) {
-  // `level` is the LRM 20.2 verbosity argument to `$finish`. Lyra's engine
-  // currently terminates regardless of level; the parameter is accepted to
-  // preserve the call shape for future verbosity-aware reporting.
-  (void)level;
+void Engine::RequestFinish(int) {  // NOLINT(readability-named-parameter)
+  // The LRM 20.2 `$finish` verbosity argument is validated at lowering and
+  // threaded here for interface completeness, but the engine terminates
+  // regardless of its value; acting on it is a known gap.
   finished_ = true;
 }
 

--- a/src/lyra/runtime/io.cpp
+++ b/src/lyra/runtime/io.cpp
@@ -24,6 +24,11 @@ void LyraPrint(
               stream.Append(std::string_view{lit.data, lit.size});
             },
             [&](const value::PrintValueItem& v) {
+              if (v.spec.kind == value::FormatKind::kTime) {
+                stream.Append(
+                    value::FormatTime(v.spec, v.value, services.TimeFormat()));
+                return;
+              }
               stream.Append(value::FormatValue(v.spec, v.value));
             },
         },

--- a/src/lyra/runtime/runtime_services.cpp
+++ b/src/lyra/runtime/runtime_services.cpp
@@ -1,10 +1,14 @@
 #include "lyra/runtime/runtime_services.hpp"
 
+#include <cstdint>
 #include <functional>
+#include <string>
 #include <utility>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/runtime/engine.hpp"
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/string.hpp"
 
 namespace lyra::runtime {
 
@@ -71,6 +75,33 @@ auto RuntimeServices::GlobalPrecisionPower() const -> std::int8_t {
         "RuntimeServices::GlobalPrecisionPower: no Engine bound");
   }
   return engine_->GlobalPrecisionPower();
+}
+
+auto RuntimeServices::TimeFormat() const -> const value::TimeFormat& {
+  if (engine_ == nullptr) {
+    throw InternalError("RuntimeServices::TimeFormat: no Engine bound");
+  }
+  return engine_->TimeFormat();
+}
+
+void RuntimeServices::SetTimeFormat(
+    const value::PackedArray& units_power, const value::PackedArray& precision,
+    const value::String& suffix, const value::PackedArray& min_width) {
+  if (engine_ == nullptr) {
+    throw InternalError("RuntimeServices::SetTimeFormat: no Engine bound");
+  }
+  engine_->SetTimeFormat(
+      static_cast<std::int8_t>(units_power.ToInt64()),
+      static_cast<std::int32_t>(precision.ToInt64()),
+      std::string(suffix.View()),
+      static_cast<std::int32_t>(min_width.ToInt64()));
+}
+
+void RuntimeServices::ResetTimeFormat() {
+  if (engine_ == nullptr) {
+    throw InternalError("RuntimeServices::ResetTimeFormat: no Engine bound");
+  }
+  engine_->ResetTimeFormat();
 }
 
 }  // namespace lyra::runtime

--- a/src/lyra/runtime/sformat.cpp
+++ b/src/lyra/runtime/sformat.cpp
@@ -7,12 +7,15 @@
 #include <variant>
 
 #include "lyra/base/overloaded.hpp"
+#include "lyra/runtime/runtime_services.hpp"
 #include "lyra/value/format.hpp"
 #include "lyra/value/string.hpp"
 
 namespace lyra::runtime {
 
-auto LyraSFormat(std::span<const value::PrintItem> items) -> value::String {
+auto LyraSFormat(
+    RuntimeServices& services, std::span<const value::PrintItem> items)
+    -> value::String {
   std::string buf;
   for (const value::PrintItem& item : items) {
     std::visit(
@@ -21,6 +24,11 @@ auto LyraSFormat(std::span<const value::PrintItem> items) -> value::String {
               buf.append(std::string_view{lit.data, lit.size});
             },
             [&](const value::PrintValueItem& v) {
+              if (v.spec.kind == value::FormatKind::kTime) {
+                buf.append(
+                    value::FormatTime(v.spec, v.value, services.TimeFormat()));
+                return;
+              }
               buf.append(value::FormatValue(v.spec, v.value));
             },
         },

--- a/src/lyra/runtime/timescale.cpp
+++ b/src/lyra/runtime/timescale.cpp
@@ -1,0 +1,46 @@
+#include "lyra/runtime/timescale.hpp"
+
+#include <array>
+#include <format>
+#include <string>
+
+#include "lyra/runtime/runtime_services.hpp"
+#include "lyra/runtime/stream_dispatcher.hpp"
+
+namespace lyra::runtime {
+
+namespace {
+
+// LRM Table 20-2: a power value maps to one of {1, 10, 100} times a unit that
+// cycles s / ms / us / ns / ps / fs every three decades below 1 s.
+auto TimeUnitText(std::int8_t power) -> std::string {
+  constexpr std::array<std::string_view, 6> kUnits = {"s",  "ms", "us",
+                                                      "ns", "ps", "fs"};
+  constexpr std::array<std::string_view, 3> kMantissa = {"1", "10", "100"};
+  const int p = static_cast<int>(power);
+  const int index = (-p + 2) / 3;
+  const int mantissa_exp = p + (3 * index);
+  const std::string_view unit = (index >= 0 && index < 6)
+                                    ? kUnits.at(static_cast<std::size_t>(index))
+                                    : "?";
+  const std::string_view mantissa =
+      (mantissa_exp >= 0 && mantissa_exp < 3)
+          ? kMantissa.at(static_cast<std::size_t>(mantissa_exp))
+          : "?";
+  return std::string(mantissa) + std::string(unit);
+}
+
+}  // namespace
+
+void LyraPrintTimescale(
+    RuntimeServices& services, std::string_view scope_name,
+    std::int8_t unit_power, std::int8_t precision_power) {
+  auto& stream = services.Stream();
+  stream.Append(
+      std::format(
+          "Time scale of ({}) is {} / {}", scope_name, TimeUnitText(unit_power),
+          TimeUnitText(precision_power)));
+  stream.FinishRecord(true);
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/value/format.cpp
+++ b/src/lyra/value/format.cpp
@@ -196,7 +196,56 @@ auto FormatRealBody(const FormatSpec& spec, double v) -> std::string {
   }
 }
 
+auto Pow10Double(int exp) -> double {
+  double result = 1.0;
+  for (int i = 0; i < exp; ++i) {
+    result *= 10.0;
+  }
+  for (int i = 0; i < -exp; ++i) {
+    result /= 10.0;
+  }
+  return result;
+}
+
+auto TimeOperandMagnitude(const RuntimeValueView& value) -> double {
+  if (const auto* integral = std::get_if<IntegralValueView>(&value.data)) {
+    return std::visit(
+        Overloaded{
+            [](const NarrowIntegralView& n) {
+              return static_cast<double>(n.value_word);
+            },
+            [](const WideIntegralView& w) {
+              return w.value_words.empty()
+                         ? 0.0
+                         : static_cast<double>(w.value_words[0]);
+            }},
+        integral->data);
+  }
+  if (const auto* real64 = std::get_if<Real64ValueView>(&value.data)) {
+    return real64->value;
+  }
+  if (const auto* real32 = std::get_if<Real32ValueView>(&value.data)) {
+    return static_cast<double>(real32->value);
+  }
+  throw InternalError("FormatTime: %t operand is not numeric");
+}
+
 }  // namespace
+
+auto FormatTime(
+    const FormatSpec& spec, const RuntimeValueView& value, const TimeFormat& tf)
+    -> std::string {
+  const double scaled = TimeOperandMagnitude(value) *
+                        Pow10Double(spec.timeunit_power - tf.units_power);
+  const int precision = tf.precision >= 0 ? tf.precision : 0;
+  std::string body = std::format("{:.{}f}", scaled, precision);
+  body += tf.suffix;
+  if (tf.min_width > 0 &&
+      body.size() < static_cast<std::size_t>(tf.min_width)) {
+    body.insert(0, static_cast<std::size_t>(tf.min_width) - body.size(), ' ');
+  }
+  return body;
+}
 
 auto FormatValue(const FormatSpec& spec, const RuntimeValueView& value)
     -> std::string {

--- a/src/lyra/value/integral_format.cpp
+++ b/src/lyra/value/integral_format.cpp
@@ -392,6 +392,7 @@ auto AutoWidthFor(FormatKind kind, std::uint64_t bit_width) -> std::int32_t {
     case FormatKind::kRealExponential:
     case FormatKind::kRealGeneral:
     case FormatKind::kAssignmentPattern:
+    case FormatKind::kTime:
       return -1;
   }
   return -1;
@@ -453,6 +454,9 @@ auto FormatIntegral(const FormatSpec& spec, const IntegralValueView& v)
       throw InternalError(
           "FormatIntegral: kAssignmentPattern must be rewritten to kDecimal "
           "by the caller before reaching FormatIntegral");
+    case FormatKind::kTime:
+      throw InternalError(
+          "FormatIntegral: kTime must route through FormatTime");
   }
 
   if (spec.kind == FormatKind::kHex || spec.kind == FormatKind::kBinary ||

--- a/tests/cases/cpp/timescale_printtimescale/case.yaml
+++ b/tests/cases/cpp/timescale_printtimescale/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.timescale_printtimescale
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      Time scale of (Top) is 1ns / 1ps

--- a/tests/cases/cpp/timescale_printtimescale/main.sv
+++ b/tests/cases/cpp/timescale_printtimescale/main.sv
@@ -1,0 +1,6 @@
+// $printtimescale prints the time unit and precision of the current scope (LRM
+// 20.4.2) in the Table 20-2 spelling.
+`timescale 1ns / 1ps
+module Top;
+  initial $printtimescale;
+endmodule

--- a/tests/cases/cpp/timescale_time_format/case.yaml
+++ b/tests/cases/cpp/timescale_time_format/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.timescale_time_format
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      [                5000]
+      5.00 ns
+      s=5.00 ns

--- a/tests/cases/cpp/timescale_time_format/main.sv
+++ b/tests/cases/cpp/timescale_time_format/main.sv
@@ -1,0 +1,20 @@
+// %t formats a time value against the design-wide $timeformat settings (LRM
+// 21.2.1.3 / 20.4.3), in $display and $sformatf alike (LRM 21.3.3). Before any
+// $timeformat call the display unit defaults to the design-global precision
+// (LRM Table 20-3): here 1ps, so $time (read in the 1ns scope unit, = 5) scales
+// up by 10^3 to 5000 and pads to the default field width of 20. After
+// $timeformat(-9, 2, " ns", 0) the display unit is ns, so the same time prints
+// "5.00 ns" -- and $sformatf produces the identical text, proving the
+// string-format path reads the same design-wide state.
+`timescale 1ns / 1ps
+module Top;
+  string s;
+  initial begin
+    #5;
+    $display("[%t]", $time);
+    $timeformat(-9, 2, " ns", 0);
+    $display("%t", $time);
+    s = $sformatf("%t", $time);
+    $display("s=%s", s);
+  end
+endmodule

--- a/tests/cases/cpp/timescale_time_format_mixed/case.yaml
+++ b/tests/cases/cpp/timescale_time_format_mixed/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.timescale_time_format_mixed
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      Top=2.50ns
+      Slow=3.00ns

--- a/tests/cases/cpp/timescale_time_format_mixed/main.sv
+++ b/tests/cases/cpp/timescale_time_format_mixed/main.sv
@@ -1,0 +1,19 @@
+// %t uses the $timeformat display unit applied design-wide (LRM 20.4.3), not the
+// calling scope's own unit -- so a single $timeformat makes every scope report
+// on one uniform scale, unlike $time (TS2), which scales to each scope's own
+// unit. Top (1ps) sets the display unit to ns once; both scopes then print %t on
+// the ns scale despite holding different time units. Top wakes at 2500 ticks
+// (2500 ps = 2.5 ns); Slow wakes at #3 = 3 ns = 3000 ticks, so Top prints first.
+`timescale 1ps / 1ps
+module Top;
+  Slow s ();
+  initial begin
+    $timeformat(-9, 2, "ns", 0);
+    #2500 $display("Top=%t", $time);
+  end
+endmodule
+
+`timescale 1ns / 1ps
+module Slow;
+  initial #3 $display("Slow=%t", $time);
+endmodule

--- a/tests/framework/sv_injection.cpp
+++ b/tests/framework/sv_injection.cpp
@@ -41,7 +41,6 @@ auto FindModuleDeclarations(std::string_view source) -> std::vector<ModuleHit> {
   std::size_t i = 0;
   const std::size_t n = source.size();
   while (i < n) {
-    std::size_t line_start = i;
     i = SkipWhitespace(source, i);
     if (i + 6 <= n && source.substr(i, 6) == "module") {
       const std::size_t after = i + 6;
@@ -65,7 +64,6 @@ auto FindModuleDeclarations(std::string_view source) -> std::vector<ModuleHit> {
     if (i < n) {
       ++i;
     }
-    (void)line_start;
   }
   return hits;
 }

--- a/tools/policy/check_cpp_style.py
+++ b/tools/policy/check_cpp_style.py
@@ -32,6 +32,25 @@ Rules:
         policed by this rule.
         Scope: every .cpp/.hpp under src/, include/, tests/.
 
+  S005  No cast-to-void of a bare name as a statement -- `(void)x;` or
+        `static_cast<void>(x);` where `x` is a plain identifier. This is the
+        unused-parameter / unused-variable suppression hack. The correct fix
+        is to drop the parameter, leave it unnamed (when an interface mandates
+        its presence), or remove the dead variable -- never silence the
+        warning. Intentional discard of a call's return value (`(void)f();`)
+        is spared: the identifier char class stops at `(`, so anything with a
+        call does not match.
+        Scope: every .cpp/.hpp under src/, include/, tests/.
+
+  S006  No `[[maybe_unused]]` on a parameter or variable. Like `(void)x;`, it
+        keeps something unused and silences the warning instead of fixing the
+        cause. Remove the parameter (narrow the signature so the caller passes
+        only what is used), or for a parameter an external interface mandates
+        but the body cannot use, leave it unnamed (with a single-line
+        `// NOLINT(readability-named-parameter)` only if that check then
+        objects).
+        Scope: every .cpp/.hpp under src/, include/, tests/.
+
 Usage:
   python3 tools/policy/check_cpp_style.py
 """
@@ -90,6 +109,19 @@ STDLIB_HEADERS = frozenset({
 
 INCLUDE_QUOTE_PATTERN = re.compile(r'^\s*#\s*include\s*"([^"]+)"')
 INCLUDE_ANGLE_PATTERN = re.compile(r'^\s*#\s*include\s*<([^>]+)>')
+
+# S005: cast-to-void of a bare name as a statement. A member/scope chain
+# (`a.b`, `a->b`, `ns::x`) is still a bare name; a call (`f(...)`) is not,
+# because the identifier char class never crosses a `(`.
+_VOID_NAME = r"[A-Za-z_]\w*(?:\s*(?:\.|->|::)\s*[A-Za-z_]\w*)*"
+VOID_DISCARD_PATTERNS = [
+    re.compile(r"\(\s*void\s*\)\s*" + _VOID_NAME + r"\s*;"),
+    re.compile(r"static_cast\s*<\s*void\s*>\s*\(\s*" + _VOID_NAME + r"\s*\)\s*;"),
+]
+
+# S006: the `[[maybe_unused]]` attribute. Same smell as S005 -- it keeps an
+# unused parameter/variable and silences the warning instead of removing it.
+MAYBE_UNUSED_PATTERN = re.compile(r"\[\[\s*maybe_unused\s*\]\]")
 
 
 def iter_cpp_files(repo_root: Path, roots=("src", "include", "tests")):
@@ -181,6 +213,34 @@ def check_s004(repo_root: Path) -> list[str]:
     return errors
 
 
+def check_s005(repo_root: Path) -> list[str]:
+    errors = []
+    for path, rel in iter_cpp_files(repo_root):
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            for pattern in VOID_DISCARD_PATTERNS:
+                if (m := pattern.search(line)):
+                    errors.append(
+                        f"  {rel}:{lineno}: S005 cast-to-void '{m.group(0)}' "
+                        f"suppresses an unused-parameter/variable warning; "
+                        f"drop or unname the parameter instead"
+                    )
+                    break
+    return errors
+
+
+def check_s006(repo_root: Path) -> list[str]:
+    errors = []
+    for path, rel in iter_cpp_files(repo_root):
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            if MAYBE_UNUSED_PATTERN.search(line):
+                errors.append(
+                    f"  {rel}:{lineno}: S006 [[maybe_unused]] keeps an unused "
+                    f"parameter/variable; remove it or leave the parameter "
+                    f"unnamed instead"
+                )
+    return errors
+
+
 def run_self_tests() -> bool:
     def expect(cond, msg):
         if not cond:
@@ -228,6 +288,25 @@ def run_self_tests() -> bool:
     ok &= expect(angle_inc("#include <vector>") == "vector", "S004 angle")
     ok &= expect("vector" in STDLIB_HEADERS, "S004 vector is stdlib")
     ok &= expect("fmt/core.h" not in STDLIB_HEADERS, "S004 fmt not stdlib")
+
+    def void_hit(text):
+        return any(p.search(text) for p in VOID_DISCARD_PATTERNS)
+
+    ok &= expect(void_hit("(void)handle;"), "S005 (void)name")
+    ok &= expect(void_hit("    (void)call_span;"), "S005 indented")
+    ok &= expect(void_hit("(void)foo.bar;"), "S005 member chain")
+    ok &= expect(void_hit("(void)ns::x;"), "S005 scope chain")
+    ok &= expect(void_hit("static_cast<void>(x);"), "S005 static_cast name")
+    ok &= expect(not void_hit("(void)RunProcess(args);"), "S005 spares call")
+    ok &= expect(not void_hit("(void)node.as<std::int64_t>();"),
+                 "S005 spares templated call")
+    ok &= expect(not void_hit("static_cast<void>(f());"),
+                 "S005 spares static_cast call")
+
+    ok &= expect(MAYBE_UNUSED_PATTERN.search("[[maybe_unused]] int x"),
+                 "S006 attribute")
+    ok &= expect(not MAYBE_UNUSED_PATTERN.search("int x = 0;"),
+                 "S006 unrelated")
     return ok
 
 
@@ -237,6 +316,8 @@ CHECKS = [
     ("S002 header files under src/", check_s002),
     ("S003 migration-progress / development-stage language", check_s003),
     ("S004 include style (stdlib <>, lyra \"\")", check_s004),
+    ("S005 cast-to-void unused-parameter/variable suppression", check_s005),
+    ("S006 [[maybe_unused]] suppression", check_s006),
 ]
 
 


### PR DESCRIPTION
## Summary

Implements the timescale observation surface TS3: the `%t` format specifier (LRM 21.2.1.3), the `$timeformat` system task (LRM 20.4.3), and the no-argument form of `$printtimescale` (LRM 20.4.2). `%t` rescales its operand from the calling scope's time unit to the design-wide `$timeformat` display unit, then formats it with the configured precision, suffix, and minimum field width; before any `$timeformat` call the display unit defaults to the design-global precision. `$timeformat` state lives on the engine as mutable design-wide state, the same category as the global precision but writable. This closes `display.md` DI2 and completes the timescale workstream.

## Design

The scope time unit reaches `%t` the same way `$time` reads it (TS2): the backend emits the scope class constant `kTimeUnitPower` into the format spec, so unqualified C++ name lookup resolves it to the lexically enclosing design element. `FormatValue` stays pure; `%t` formats through a new `FormatTime` routed in the three print-family runtime entries, which required giving `LyraSFormat` a `RuntimeServices&` so `$sformatf("%t", ...)` can read the same state.

The change also lands a small policy pass: new style checks S005 (no `(void)x;`) and S006 (no `[[maybe_unused]]`), both forms of keeping an unused parameter and silencing the warning. Existing offenders were fixed by narrowing signatures to what each function uses; the few genuinely interface-mandated unused parameters (a coroutine `await_suspend` handle, a `std::visit` alternative that only rejects) are left unnamed. The `$finish` verbosity level is one such case and its unimplemented behavior is recorded as a new checkbox in `processes.md`.

## Testing

`bazel test //...` passes (all three test targets green). New `cpp_run` cases cover `%t` default and explicit `$timeformat`, `$sformatf` with `%t`, the design-wide uniform display unit across mixed-precision scopes, and `$printtimescale`.