### PR TITLE
Switch array container ctors to span and add dynamic-array patterns

### DIFF
--- a/docs/decisions/unpacked-array-representation.md
+++ b/docs/decisions/unpacked-array-representation.md
@@ -141,38 +141,44 @@ Unpacked array support follows these invariants:
    See `docs/decisions/runtime-shape-and-default-value.md` for the shield contract.
 
 3. **Default initialization emits a `ConstructExpr` whose first positional argument is the
-   canonical-default element and whose remaining elements ride in an `ArrayLiteralExpr` rendered as
-   a brace-init-list.**
+   canonical-default element and whose second is an `ArrayLiteralExpr` rendered as
+   `std::array<T, N>{...}`.**
 
    `default_value.cpp` synthesises an `ArrayLiteralExpr` populated with per-element defaults; the
-   backend wraps it in `ConstructExpr` so the wrapper's
-   `(T canonical_default, std::initializer_list<T>)` constructor receives both the canonical-default
-   seed for `oob_slot_` and the initial elements. For `int arr[3]`:
+   backend wraps it in `ConstructExpr` so the wrapper's `(T canonical_default, std::span<const T>)`
+   constructor receives both the canonical-default seed for `oob_slot_` and the initial elements.
+   The `std::array<T, N>` rvalue produced by the element list implicitly converts to the ctor's
+   `std::span<const T>` parameter. For `int arr[3]`:
 
    ```cpp
    lyra::value::UnpackedArray<lyra::value::PackedArray> arr(
        lyra::value::PackedArray::Int(0),
-       {lyra::value::PackedArray::Int(0),
-        lyra::value::PackedArray::Int(0),
-        lyra::value::PackedArray::Int(0)});
+       std::array<lyra::value::PackedArray, 3>{
+           lyra::value::PackedArray::Int(0),
+           lyra::value::PackedArray::Int(0),
+           lyra::value::PackedArray::Int(0)});
    ```
 
-   Multi-dim composes through the nested element type with the same shape at every layer.
+   Multi-dim composes through the nested element type with the same shape at every layer. The same
+   element-list shape applies to `DynamicArray<T>` -- the only thing that varies is the outer
+   container type.
 
-4. **`'{...}` is a first-class IR expression -- `hir::ArrayLiteral` / `mir::ArrayLiteral`.**
+4. **`'{...}` is a first-class IR expression -- `hir::ArrayLiteral` / `mir::ArrayLiteral` --
+   rendered as `std::array<T, N>{...}`.**
 
    ```text
    hir::ArrayLiteral { elements: vector<ExprId> }
    mir::ArrayLiteral { elements: vector<ExprId> }
    ```
 
-   The expression's resolved type comes through the `Expr`-common `type` field (set by AST -> HIR
-   using slang's resolved type on the pattern). ArrayLiteral joins concat and replication as a
-   value-build primitive at MIR, per `mir.md`. Backend cpp renders to explicit-typed aggregate
-   construction (the wrapper accepts `std::initializer_list<T>`):
+   The expression's resolved type comes through the `Expr`-common `type` field (the container type;
+   the element type is read off it at render time). ArrayLiteral joins concat and replication as a
+   value-build primitive at MIR, per `mir.md`. Backend cpp always renders as
+   `std::array<elem, N>{...}` -- a context-independent rendering whose value implicitly converts to
+   the wrapper ctor's `std::span<const T>` parameter:
 
    ```cpp
-   lyra::value::UnpackedArray<lyra::value::PackedArray>{
+   std::array<lyra::value::PackedArray, 3>{
        lyra::value::PackedArray::Int(10),
        lyra::value::PackedArray::Int(20),
        lyra::value::PackedArray::Int(30)}
@@ -233,3 +239,12 @@ slang's AST already shapes `'{...}` as an Expression (`SimpleAssignmentPatternEx
 Procedural array assignment (`arr = '{1,2,3}`) requires the literal in RHS position; an init-only
 form would force a parallel rewrite when that lands. ConcatExpr and ReplicationExpr are first-class
 expressions despite also being context-typed -- ArrayLiteral is in the same family per `mir.md`.
+
+**Element list as `std::initializer_list<T>` with a backend special-case that strips the type prefix
+when the literal appears inside a `ConstructExpr` argument slot.** Rejected. The backend rendering
+becomes context-dependent (the same MIR primitive renders differently as a standalone expression vs
+as a `ConstructExpr` argument), which couples `RenderArrayLiteralExpr` and `RenderConstructExpr`.
+`std::span<const T>` with `std::array<T, N>{...}` at the call site keeps rendering uniform:
+`ArrayLiteralExpr` always emits `std::array<T, N>{...}`, `std::array` implicitly converts to
+`std::span<const T>`, and no parent-context inspection is needed. The cost is a slightly longer emit
+string, which has no readability cost for emitted code.

--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -22,7 +22,7 @@ follow once dynamic array's storage and runtime conventions are settled and prov
 | ---- | -------------------------------------------------------------------- |
 | DA1  | Done: construction, element read, blocking element write, multi-dim. |
 | DA2  | Done: NBA, compound element write, whole-array assignment.           |
-| DA3  | Open: literal init and assignment patterns.                          |
+| DA3  | Done: positional and replicated assignment patterns (LRM 10.9.1).    |
 | DA4  | Open: aggregate equality and inequality.                             |
 | DA5  | Open: constant-width slice (subject to LRM check).                   |
 | DA6  | Open: SV-callable method family (`.size()`, `.delete()`, ...).       |
@@ -60,11 +60,15 @@ The numeric IDs are stable references and do not imply execution order beyond DA
       10.4.2 -- the NBA LHS rules forbid bit/element selects on dynamically sized targets, so the
       construct is rejected upstream by slang and produces no Lyra-side path.
 
-- [ ] DA3 -- Literal init and assignment patterns (LRM 10.9). Declaration initializer
+- [x] DA3 -- Literal init and assignment patterns (LRM 10.9.1). Declaration initializer
       `int arr [] = '{e1, e2, ...}` where the pattern determines array size, procedural assignment
       `arr = '{...}` which resizes the destination, and the replicated form `'{N{v}}` with a
-      compile-time count. Any LRM-defined structured shapes on dynamic arrays (for example
-      `'{default: v}` once a base size exists) land here too.
+      compile-time count. Multi-dimensional forms fall out from the recursive element-type
+      representation; jagged sizing per row is the natural consequence of each inner pattern
+      determining its row's size. Structured forms with `default:` keys are rejected by slang for
+      dynamic-array targets (LRM forbids `default` here); index-keyed forms are accepted by slang
+      only when the indices cover a dense `0..N-1` set, which adds no expressive power over the
+      positional form and is rejected at HIR lowering with a "use positional" diagnostic.
 
 - [ ] DA4 -- Aggregate equality. `A == B`, `A != B`, `A === B`, `A !== B` per LRM 7.4.6 and 11.4.5.
       Size mismatch yields 0 directly; equal sizes reduce element-by-element comparisons to a 1-bit

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -119,9 +119,9 @@ struct ReplicationExpr {
 // default forms). Slang has normalised all four forms into a flat per-element
 // expression list in target declaration order (= packed MSB-first), with each
 // item already wrapped in a ConversionExpression to the field / element's
-// declared type. The shape covers both packed targets (struct / union /
-// packed array) and unpacked fixed-size arrays; HIR-to-MIR dispatches to the
-// right primitive based on the resolved target type.
+// declared type. The shape covers packed targets (struct / union / packed
+// array), fixed-size unpacked arrays, and dynamic arrays; HIR-to-MIR
+// dispatches to the right primitive based on the resolved target type.
 struct AssignmentPatternExpr {
   std::vector<ExprId> elements;
 };
@@ -130,8 +130,9 @@ struct AssignmentPatternExpr {
 // slang-validated as a constant positive integer. `items` is the per-
 // iteration expression list -- slang stores only one iteration's items with
 // that iteration's per-field casts and requires the target's per-iter type
-// chunks to repeat, so the lowered MIR shape is `Replication(count,
-// Concat(items))`.
+// chunks to repeat. The lowered MIR shape is `Replication(count,
+// Concat(items))` for packed targets and a `Construct(canonical_default,
+// ArrayLiteral{items repeated count times})` for unpacked / dynamic targets.
 struct AssignmentPatternReplicationExpr {
   ExprId count;
   std::vector<ExprId> items;

--- a/include/lyra/lowering/hir_to_mir/default_value.hpp
+++ b/include/lyra/lowering/hir_to_mir/default_value.hpp
@@ -21,18 +21,18 @@ namespace lyra::lowering::hir_to_mir {
     ProceduralScopeLoweringState& scope_state, mir::TypeId type_id)
     -> mir::ExprId;
 
-// Wraps a list of element ExprIds destined for an `UnpackedArrayType`
-// constructor in `ConstructExpr{[element_default,
-// ArrayLiteralExpr{elements}]}`. This is the construction shape every site that
-// produces an unpacked-array value must use: the canonical-default element
-// required by `UnpackedArray<T>`'s runtime ctor (to seed `oob_slot_`) is
-// supplied here via `SynthesizeDefaultValueExpr` on the element type, and the
-// elements ride in an `ArrayLiteralExpr` that the `ConstructExpr` renderer
-// emits as a brace-init-list. See
+// Wraps a list of element ExprIds destined for an array container constructor
+// (`UnpackedArrayType` or `DynamicArrayType`) in
+// `ConstructExpr{[element_default, ArrayLiteralExpr{elements}]}`. This is the
+// construction shape every site that produces an array-container value must
+// use: the canonical-default element required by the wrapper's runtime ctor
+// (to seed `oob_slot_`) is supplied here via `SynthesizeDefaultValueExpr` on
+// the element type, and the elements ride in an `ArrayLiteralExpr` that the
+// renderer emits as `std::array<T, N>{...}`. See
 // `docs/decisions/runtime-shape-and-default-value.md`.
-[[nodiscard]] auto BuildUnpackedArrayConstructExpr(
+[[nodiscard]] auto BuildArrayConstructExpr(
     const UnitLoweringState& unit_state,
-    ProceduralScopeLoweringState& scope_state, mir::TypeId unpacked_type_id,
+    ProceduralScopeLoweringState& scope_state, mir::TypeId array_type_id,
     std::vector<mir::ExprId> elements) -> mir::Expr;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -148,8 +148,12 @@ struct ReplicationExpr {
   ExprId concat;
 };
 
-// LRM 10.9.1: simple assignment pattern `'{e1, e2, ...}`. The aggregate type
-// lives on Expr::type.
+// LRM 10.9.1 array assignment pattern `'{e1, e2, ...}` element list. Always
+// appears as an argument of a `ConstructExpr` whose result is an array
+// container; renders as `std::array<T, N>{e1, ...}` so the surrounding ctor
+// resolves uniformly against a `std::span<const T>` parameter. `Expr::type`
+// is the parent container type (`UnpackedArrayType` / `DynamicArrayType`);
+// the element type is read off it at render time.
 struct ArrayLiteralExpr {
   std::vector<ExprId> elements;
 };

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <span>
 #include <utility>
 #include <vector>
 
@@ -56,6 +57,14 @@ class DynamicArray {
           "DynamicArray::new[N](src): size operand is negative (LRM 7.5.1)");
     }
     data_.resize(static_cast<std::size_t>(n_val), oob_slot_);
+  }
+
+  // LRM 10.9.1 assignment-pattern construction: shield slot seeded, size
+  // taken from the pattern's element list. Mirrors `UnpackedArray`'s span
+  // ctor so a single emit path produces `std::array<T, N>{...}` as the
+  // second argument for either container.
+  DynamicArray(T oob_slot, std::span<const T> init)
+      : oob_slot_(std::move(oob_slot)), data_(init.begin(), init.end()) {
   }
 
   DynamicArray(const DynamicArray&) = default;

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -2,7 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <initializer_list>
+#include <span>
 #include <utility>
 #include <vector>
 
@@ -44,9 +44,12 @@ class UnpackedArray {
   }
 
   // Element-list construction: shield slot seeded, plus the explicit
-  // initial elements (LRM 10.9 assignment pattern lowering).
-  UnpackedArray(T oob_slot, std::initializer_list<T> init)
-      : oob_slot_(std::move(oob_slot)), data_(init) {
+  // initial elements (LRM 10.9 assignment pattern lowering). The element
+  // list is taken as a span so the emit side can hand in a `std::array<T,
+  // N>{...}` literal whose self-determined type is unambiguous, rather
+  // than relying on context-dependent braced-init binding.
+  UnpackedArray(T oob_slot, std::span<const T> init)
+      : oob_slot_(std::move(oob_slot)), data_(init.begin(), init.end()) {
   }
 
   UnpackedArray(const UnpackedArray&) = default;

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1357,13 +1357,36 @@ auto RenderConcatExpr(
       "RenderConcatExpr: result type must be PackedArrayType or string");
 }
 
+// LRM 10.9.1 array assignment pattern: renders as `std::array<T, N>{e1, ...}`.
+// `expr.type` is the parent container type (`UnpackedArrayType` /
+// `DynamicArrayType`); the element type is read off it and emitted as the
+// `std::array` element parameter. The resulting `std::array<T, N>` implicitly
+// converts to the container ctor's `std::span<const T>` parameter, so this
+// rendering is context-independent: the same string is correct standalone
+// and as a `ConstructExpr` argument.
 auto RenderArrayLiteralExpr(
     const RenderContext& ctx, const mir::Expr& expr,
     const mir::ArrayLiteralExpr& a) -> diag::Result<std::string> {
-  auto vec_type_or =
-      RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), expr.type);
-  if (!vec_type_or) return std::unexpected(std::move(vec_type_or.error()));
-  std::string out = *vec_type_or + "{";
+  const auto& container_ty = ctx.Unit().GetType(expr.type);
+  const mir::TypeId elem_type_id = std::visit(
+      [](const auto& ty) -> mir::TypeId {
+        using TyT = std::decay_t<decltype(ty)>;
+        if constexpr (
+            std::same_as<TyT, mir::UnpackedArrayType> ||
+            std::same_as<TyT, mir::DynamicArrayType>) {
+          return ty.element_type;
+        } else {
+          throw InternalError(
+              "RenderArrayLiteralExpr: result type must be UnpackedArrayType "
+              "or DynamicArrayType");
+        }
+      },
+      container_ty.data);
+  auto elem_type_or =
+      RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), elem_type_id);
+  if (!elem_type_or) return std::unexpected(std::move(elem_type_or.error()));
+  std::string out =
+      std::format("std::array<{}, {}>{{", *elem_type_or, a.elements.size());
   for (std::size_t i = 0; i < a.elements.size(); ++i) {
     auto rendered = RenderExpr(ctx, ctx.Expr(a.elements[i]));
     if (!rendered) return std::unexpected(std::move(rendered.error()));
@@ -1377,11 +1400,6 @@ auto RenderArrayLiteralExpr(
 // LRM 7.5.1 / 7.6: constructor invocation. Emits `RenderType(type)(args...)`
 // -- parenthesised so brace-vs-paren overload resolution is unambiguous and
 // the runtime ctor is selected by arg-list shape.
-//
-// An `ArrayLiteralExpr` argument is rendered as `{e1, e2, ...}` without the
-// type prefix so it decays to `std::initializer_list<T>` for the parameter
-// slot. This is what allows `UnpackedArray<T>(default_value, {e1, e2, ...})`
-// to compile against the wrapper's `(T, std::initializer_list<T>)` ctor.
 auto RenderConstructExpr(
     const RenderContext& ctx, const mir::Expr& expr,
     const mir::ConstructExpr& c) -> diag::Result<std::string> {
@@ -1389,25 +1407,10 @@ auto RenderConstructExpr(
   if (!type_or) return std::unexpected(std::move(type_or.error()));
   std::string out = *type_or + "(";
   for (std::size_t i = 0; i < c.args.size(); ++i) {
-    const auto& arg_expr = ctx.Expr(c.args[i]);
-    std::string rendered;
-    if (const auto* al = std::get_if<mir::ArrayLiteralExpr>(&arg_expr.data)) {
-      std::string list = "{";
-      for (std::size_t j = 0; j < al->elements.size(); ++j) {
-        auto element = RenderExpr(ctx, ctx.Expr(al->elements[j]));
-        if (!element) return std::unexpected(std::move(element.error()));
-        if (j != 0) list += ", ";
-        list += *element;
-      }
-      list += "}";
-      rendered = std::move(list);
-    } else {
-      auto r = RenderExpr(ctx, arg_expr);
-      if (!r) return std::unexpected(std::move(r.error()));
-      rendered = *std::move(r);
-    }
+    auto r = RenderExpr(ctx, ctx.Expr(c.args[i]));
+    if (!r) return std::unexpected(std::move(r.error()));
     if (i != 0) out += ", ";
-    out += rendered;
+    out += *r;
   }
   out += ")";
   return out;

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -1625,11 +1625,24 @@ auto LowerProcExpr(
           unit_facts, unit_state, proc_state, stack, sap, expr, span);
     }
 
-    case slang::ast::ExpressionKind::StructuredAssignmentPattern:
+    case slang::ast::ExpressionKind::StructuredAssignmentPattern: {
+      // Slang accepts `'{idx:val, ...}` for a dynamic-array target as long
+      // as indices cover a dense `0..N-1`. The legal subset is equivalent to
+      // positional and adds no expressive power; rejecting it here keeps the
+      // dispatch narrow until a consumer needs the structured form.
+      if (expr.type->getCanonicalType().kind ==
+          slang::ast::SymbolKind::DynamicArrayType) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedAssignmentPatternKind,
+            "index-keyed assignment pattern on a dynamic array is not yet "
+            "supported; use positional form",
+            diag::UnsupportedCategory::kOperation);
+      }
       return LowerAssignmentPatternFromElementsProc(
           unit_facts, unit_state, proc_state, stack,
           expr.as<slang::ast::StructuredAssignmentPatternExpression>(), expr,
           span);
+    }
 
     case slang::ast::ExpressionKind::ReplicatedAssignmentPattern:
       return LowerReplicatedAssignmentPatternExprProc(
@@ -1758,11 +1771,20 @@ auto LowerStructuralExpr(
           unit_facts, unit_state, scope_state, stack, sap, expr, span);
     }
 
-    case slang::ast::ExpressionKind::StructuredAssignmentPattern:
+    case slang::ast::ExpressionKind::StructuredAssignmentPattern: {
+      if (expr.type->getCanonicalType().kind ==
+          slang::ast::SymbolKind::DynamicArrayType) {
+        return diag::Unsupported(
+            span, diag::DiagCode::kUnsupportedAssignmentPatternKind,
+            "index-keyed assignment pattern on a dynamic array is not yet "
+            "supported; use positional form",
+            diag::UnsupportedCategory::kOperation);
+      }
       return LowerAssignmentPatternFromElementsStructural(
           unit_facts, unit_state, scope_state, stack,
           expr.as<slang::ast::StructuredAssignmentPatternExpression>(), expr,
           span);
+    }
 
     case slang::ast::ExpressionKind::ReplicatedAssignmentPattern:
       return LowerReplicatedAssignmentPatternExprStructural(

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -99,7 +99,7 @@ auto SynthesizeDefaultValueExpr(
               elements.push_back(SynthesizeDefaultValueExpr(
                   unit_state, scope_state, ua.element_type));
             }
-            return scope_state.AddExpr(BuildUnpackedArrayConstructExpr(
+            return scope_state.AddExpr(BuildArrayConstructExpr(
                 unit_state, scope_state, type_id, std::move(elements)));
           },
           // LRM Table 6-7: a dynamic array's default is the empty array.
@@ -118,34 +118,29 @@ auto SynthesizeDefaultValueExpr(
           },
           // Types whose runtime default is the C++ language-level default
           // (named-event handle, child module instance, `unique_ptr<Child>`,
-          // `vector<Child>`). The constructor scope is the real populator for
-          // the object family; named-events have no SV initializer expression
-          // grammar at all. Both paths share the same shape: an empty
-          // ArrayLiteralExpr renders as `T{}`, hitting each type's default
-          // ctor.
+          // `vector<Child>`). The constructor scope is the real populator
+          // for the object family; named-events have no SV initializer
+          // grammar at all. Empty `ConstructExpr` renders as `T()` and
+          // invokes the type's default ctor.
           [&](const mir::EventType&) -> mir::ExprId {
             return scope_state.AddExpr(
                 mir::Expr{
-                    .data = mir::ArrayLiteralExpr{.elements = {}},
-                    .type = type_id});
+                    .data = mir::ConstructExpr{.args = {}}, .type = type_id});
           },
           [&](const mir::ObjectType&) -> mir::ExprId {
             return scope_state.AddExpr(
                 mir::Expr{
-                    .data = mir::ArrayLiteralExpr{.elements = {}},
-                    .type = type_id});
+                    .data = mir::ConstructExpr{.args = {}}, .type = type_id});
           },
           [&](const mir::OwningPtrType&) -> mir::ExprId {
             return scope_state.AddExpr(
                 mir::Expr{
-                    .data = mir::ArrayLiteralExpr{.elements = {}},
-                    .type = type_id});
+                    .data = mir::ConstructExpr{.args = {}}, .type = type_id});
           },
           [&](const mir::VectorType&) -> mir::ExprId {
             return scope_state.AddExpr(
                 mir::Expr{
-                    .data = mir::ArrayLiteralExpr{.elements = {}},
-                    .type = type_id});
+                    .data = mir::ConstructExpr{.args = {}}, .type = type_id});
           },
           [&](const auto&) -> mir::ExprId {
             throw InternalError(
@@ -156,25 +151,34 @@ auto SynthesizeDefaultValueExpr(
       ty.data);
 }
 
-auto BuildUnpackedArrayConstructExpr(
+auto BuildArrayConstructExpr(
     const UnitLoweringState& unit_state,
-    ProceduralScopeLoweringState& scope_state, mir::TypeId unpacked_type_id,
+    ProceduralScopeLoweringState& scope_state, mir::TypeId array_type_id,
     std::vector<mir::ExprId> elements) -> mir::Expr {
-  const auto& ty = unit_state.GetType(unpacked_type_id);
-  const auto* ua = std::get_if<mir::UnpackedArrayType>(&ty.data);
-  if (ua == nullptr) {
-    throw InternalError(
-        "BuildUnpackedArrayConstructExpr: type_id is not UnpackedArrayType");
-  }
+  const auto& ty = unit_state.GetType(array_type_id);
+  const mir::TypeId element_type_id = std::visit(
+      [](const auto& t) -> mir::TypeId {
+        using TyT = std::decay_t<decltype(t)>;
+        if constexpr (
+            std::same_as<TyT, mir::UnpackedArrayType> ||
+            std::same_as<TyT, mir::DynamicArrayType>) {
+          return t.element_type;
+        } else {
+          throw InternalError(
+              "BuildArrayConstructExpr: type_id is not UnpackedArrayType or "
+              "DynamicArrayType");
+        }
+      },
+      ty.data);
   const mir::ExprId element_default =
-      SynthesizeDefaultValueExpr(unit_state, scope_state, ua->element_type);
+      SynthesizeDefaultValueExpr(unit_state, scope_state, element_type_id);
   const mir::ExprId list_id = scope_state.AddExpr(
       mir::Expr{
           .data = mir::ArrayLiteralExpr{.elements = std::move(elements)},
-          .type = unpacked_type_id});
+          .type = array_type_id});
   return mir::Expr{
       .data = mir::ConstructExpr{.args = {element_default, list_id}},
-      .type = unpacked_type_id};
+      .type = array_type_id};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -79,7 +79,7 @@ auto ExtractHirLiteralUint64(const hir::Expr& expr) -> std::uint64_t {
   return c.value_words[0];
 }
 
-auto BuildUnpackedReplicationFlatList(
+auto BuildArrayReplicationFlatList(
     const UnitLoweringState& unit_state,
     ProceduralScopeLoweringState& proc_scope_state,
     std::span<const mir::ExprId> items_ids, std::uint64_t count,
@@ -89,8 +89,13 @@ auto BuildUnpackedReplicationFlatList(
   for (std::uint64_t i = 0; i < count; ++i) {
     flat.insert(flat.end(), items_ids.begin(), items_ids.end());
   }
-  return BuildUnpackedArrayConstructExpr(
+  return BuildArrayConstructExpr(
       unit_state, proc_scope_state, result_type, std::move(flat));
+}
+
+auto IsArrayContainerType(const mir::Type& ty) -> bool {
+  return std::holds_alternative<mir::UnpackedArrayType>(ty.data) ||
+         std::holds_alternative<mir::DynamicArrayType>(ty.data);
 }
 
 auto LowerBinaryOp(hir::BinaryOp op) -> mir::BinaryOp {
@@ -1270,8 +1275,9 @@ auto LowerHirReplicationExprProc(
 
 // Lowers an HIR AssignmentPatternExpr by dispatching on the destination
 // type's runtime shape: packed targets fold into MIR `ConcatExpr` (bit
-// concatenation matches the packed bit plane), unpacked arrays land as
-// `ArrayLiteralExpr` over distinct std::vector slots.
+// concatenation matches the packed bit plane), array containers (unpacked
+// and dynamic) land as `ArrayLiteralExpr` over distinct `std::vector` slots
+// wrapped by a `ConstructExpr` against the container ctor.
 auto LowerHirAssignmentPatternExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
@@ -1288,9 +1294,8 @@ auto LowerHirAssignmentPatternExprProc(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     element_ids.push_back(proc_scope_state.AddExpr(*std::move(lowered)));
   }
-  if (std::holds_alternative<mir::UnpackedArrayType>(
-          unit_state.GetType(result_type).data)) {
-    return BuildUnpackedArrayConstructExpr(
+  if (IsArrayContainerType(unit_state.GetType(result_type))) {
+    return BuildArrayConstructExpr(
         unit_state, proc_scope_state, result_type, std::move(element_ids));
   }
   return mir::Expr{
@@ -1315,11 +1320,10 @@ auto LowerHirAssignmentPatternReplicationExprProc(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     item_ids.push_back(proc_scope_state.AddExpr(*std::move(lowered)));
   }
-  if (std::holds_alternative<mir::UnpackedArrayType>(
-          unit_state.GetType(result_type).data)) {
+  if (IsArrayContainerType(unit_state.GetType(result_type))) {
     const std::uint64_t count =
         ExtractHirLiteralUint64(hir_process.exprs.at(a.count.value));
-    return BuildUnpackedReplicationFlatList(
+    return BuildArrayReplicationFlatList(
         unit_state, proc_scope_state, item_ids, count, result_type);
   }
   const mir::ExprId inner_concat_id = proc_scope_state.AddExpr(
@@ -1726,9 +1730,8 @@ auto LowerHirAssignmentPatternExprStructural(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     element_ids.push_back(proc_scope_state.AddExpr(*std::move(lowered)));
   }
-  if (std::holds_alternative<mir::UnpackedArrayType>(
-          unit_state.GetType(result_type).data)) {
-    return BuildUnpackedArrayConstructExpr(
+  if (IsArrayContainerType(unit_state.GetType(result_type))) {
+    return BuildArrayConstructExpr(
         unit_state, proc_scope_state, result_type, std::move(element_ids));
   }
   return mir::Expr{
@@ -1754,10 +1757,9 @@ auto LowerHirAssignmentPatternReplicationExprStructural(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     item_ids.push_back(proc_scope_state.AddExpr(*std::move(lowered)));
   }
-  if (std::holds_alternative<mir::UnpackedArrayType>(
-          unit_state.GetType(result_type).data)) {
+  if (IsArrayContainerType(unit_state.GetType(result_type))) {
     const std::uint64_t count = ExtractHirLiteralUint64(scope.GetExpr(a.count));
-    return BuildUnpackedReplicationFlatList(
+    return BuildArrayReplicationFlatList(
         unit_state, proc_scope_state, item_ids, count, result_type);
   }
   const mir::ExprId inner_concat_id = proc_scope_state.AddExpr(

--- a/tests/cases/cpp/dynamic_array_assignment_pattern/case.yaml
+++ b/tests/cases/cpp/dynamic_array_assignment_pattern/case.yaml
@@ -1,0 +1,30 @@
+id: cpp.dynamic_array_assignment_pattern
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a0: 10
+    a1: 20
+    a2: 30
+    r0: 7
+    r3: 7
+    j00: 1
+    j01: 2
+    j10: 3
+    j11: 4
+    j12: 5
+    m00: 8
+    m01: 9
+    m10: 8
+    m11: 9
+    m20: 8
+    m21: 9
+    p0: 1
+    p1: 2
+    p2: 3
+    p3: 4

--- a/tests/cases/cpp/dynamic_array_assignment_pattern/main.sv
+++ b/tests/cases/cpp/dynamic_array_assignment_pattern/main.sv
@@ -1,0 +1,35 @@
+module Top;
+  // 1D positional declaration initializer.
+  int a [] = '{10, 20, 30};
+  // 1D replicated declaration initializer.
+  int r [] = '{4{7}};
+  // 2D jagged: each inner pattern sets its row's runtime size.
+  int j [][] = '{'{1, 2}, '{3, 4, 5}};
+  // 2D replicated nested inside the outer replication.
+  int m [][] = '{3{'{8, 9}}};
+
+  // Procedural assignment with resize: pre-sized destination is resized to the
+  // pattern's element count, overwriting the prior contents (LRM 7.6).
+  int p [];
+  int a0, a1, a2;
+  int r0, r3;
+  int j00, j01, j10, j11, j12;
+  int m00, m01, m10, m11, m20, m21;
+  int p0, p1, p2, p3;
+
+  initial begin
+    p = new[2];
+    p[0] = 99;
+    p[1] = 99;
+    p = '{1, 2, 3, 4};
+
+    a0 = a[0]; a1 = a[1]; a2 = a[2];
+    r0 = r[0]; r3 = r[3];
+    j00 = j[0][0]; j01 = j[0][1];
+    j10 = j[1][0]; j11 = j[1][1]; j12 = j[1][2];
+    m00 = m[0][0]; m01 = m[0][1];
+    m10 = m[1][0]; m11 = m[1][1];
+    m20 = m[2][0]; m21 = m[2][1];
+    p0 = p[0]; p1 = p[1]; p2 = p[2]; p3 = p[3];
+  end
+endmodule

--- a/tests/cases/errors/dynamic_array_pattern_index_keyed_rejected/case.yaml
+++ b/tests/cases/errors/dynamic_array_pattern_index_keyed_rejected/case.yaml
@@ -1,0 +1,16 @@
+id: errors.dynamic_array_pattern_index_keyed_rejected
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "main.sv:"
+      - "index-keyed assignment pattern on a dynamic array is not yet supported"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/dynamic_array_pattern_index_keyed_rejected/main.sv
+++ b/tests/cases/errors/dynamic_array_pattern_index_keyed_rejected/main.sv
@@ -1,0 +1,6 @@
+module Top;
+  int arr [];
+  initial begin
+    arr = '{0: 10, 1: 20};
+  end
+endmodule


### PR DESCRIPTION
## Summary

Removes the context-dependent rendering tax `ArrayLiteralExpr` was paying in the C++ backend. `UnpackedArray<T>` and `DynamicArray<T>` now take an element list as `std::span<const T>`; the MIR-level array literal renders uniformly as `std::array<T, N>{...}`, which implicitly converts to that span parameter. The backend special-case in `RenderConstructExpr` that stripped the type prefix from a child `ArrayLiteralExpr` is gone, and the misc default-init types (named event, child module instance, owning pointer, child vector) that were piggybacking on `ArrayLiteralExpr{}` now route through `ConstructExpr{}` so they emit `T()` and stop borrowing the array-literal primitive.

Dynamic-array assignment patterns (LRM 10.9.1) ride the same lowering: `int arr[] = '{e1, e2, ...}`, procedural `arr = '{...}` with resize, `'{N{v}}` replicated, and multi-dim including jagged inner sizes. Index-keyed structured patterns on dynamic-array targets are rejected at HIR lowering with a "use positional" diagnostic since slang only accepts the dense 0..N-1 subset, which adds no expressive power. The HIR-to-MIR helper `BuildUnpackedArrayConstructExpr` is renamed to `BuildArrayConstructExpr` and accepts both `UnpackedArrayType` and `DynamicArrayType`.

## Testing

`bazel test //...` passes. New coverage is one consolidated `dynamic_array_assignment_pattern` case (positional + replicated, 1D + 2D jagged + 2D replicated, declaration init + procedural assign with resize) plus a diagnostic test for the rejected index-keyed form. Refactor regression coverage rides the existing unpacked literal-init / pattern tests.