### PR TITLE
Add dynamic array aggregate equality

### DIFF
--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -23,7 +23,7 @@ follow once dynamic array's storage and runtime conventions are settled and prov
 | DA1  | Done: construction, element read, blocking element write, multi-dim. |
 | DA2  | Done: NBA, compound element write, whole-array assignment.           |
 | DA3  | Done: positional and replicated assignment patterns (LRM 10.9.1).    |
-| DA4  | Open: aggregate equality and inequality.                             |
+| DA4  | Done: aggregate equality, inequality, case-equality.                 |
 | DA5  | Open: constant-width slice (subject to LRM check).                   |
 | DA6  | Open: SV-callable method family (`.size()`, `.delete()`, ...).       |
 | DA7  | Open: invalid-index handling.                                        |
@@ -70,10 +70,13 @@ The numeric IDs are stable references and do not imply execution order beyond DA
       only when the indices cover a dense `0..N-1` set, which adds no expressive power over the
       positional form and is rejected at HIR lowering with a "use positional" diagnostic.
 
-- [ ] DA4 -- Aggregate equality. `A == B`, `A != B`, `A === B`, `A !== B` per LRM 7.4.6 and 11.4.5.
-      Size mismatch yields 0 directly; equal sizes reduce element-by-element comparisons to a 1-bit
-      result. X / Z propagation rules match U5. Multi-dimensional dynamic arrays compose through the
-      recursive element type.
+- [x] DA4 -- Aggregate equality. `A == B`, `A != B`, `A === B`, `A !== B` per LRM 11.2.2 + 11.4.5.
+      LRM 11.2.2 requires equivalent operand type but is silent on runtime size mismatch; the
+      industry-standard reading (Verilator-confirmed) yields 0 on size mismatch and 1 on
+      empty-vs-empty (the identity of the element-wise `&&` reduction). For matched non-empty sizes,
+      `==` / `!=` propagate X / Z through the per-element comparison; `===` / `!==` match X / Z as
+      values and are deterministic. Multi-dimensional and mixed-container nesting (`int [3][]`,
+      `int [][3]`) compose through the recursive element type.
 
 - [ ] DA5 -- Constant-width slice (read and write), subject to LRM confirmation. If the LRM permits
       the `+:` / `-:` indexed-part-select form on `T []`, the in-scope subset mirrors U6:

--- a/include/lyra/value/array_case_equal.hpp
+++ b/include/lyra/value/array_case_equal.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "lyra/value/packed_array.hpp"
+
+namespace lyra::value {
+
+template <typename T>
+class UnpackedArray;
+template <typename T>
+class DynamicArray;
+
+namespace detail {
+
+// LRM 11.4.5 element-level `===` used by both array-container CaseEqual
+// implementations. The PackedArray overload normalises the 0 / 1 result to
+// 4-state when either operand is 4-state so the enclosing `&&` reduction
+// stays in the right state class; the recursive overloads delegate to the
+// container's own CaseEqual.
+inline auto ArrayCaseEqElement(const PackedArray& a, const PackedArray& b)
+    -> PackedArray {
+  auto raw = a.CaseEqual(b);
+  const bool four_state = a.IsFourState() || b.IsFourState();
+  return four_state ? PackedArray::ConvertFrom(raw, 1, false, true) : raw;
+}
+
+template <typename U>
+auto ArrayCaseEqElement(const UnpackedArray<U>& a, const UnpackedArray<U>& b)
+    -> PackedArray {
+  return a.CaseEqual(b);
+}
+
+template <typename U>
+auto ArrayCaseEqElement(const DynamicArray<U>& a, const DynamicArray<U>& b)
+    -> PackedArray {
+  return a.CaseEqual(b);
+}
+
+}  // namespace detail
+}  // namespace lyra::value

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/value/array_case_equal.hpp"
 #include "lyra/value/packed_array.hpp"
 
 namespace lyra::value {
@@ -115,6 +116,44 @@ class DynamicArray {
       return oob_slot_;
     }
     return data_[static_cast<std::size_t>(idx.ToInt64())];
+  }
+
+  // LRM 11.2.2 + 11.4.5 aggregate equality. Runtime size mismatch yields
+  // 0 and matching-size empties yield 1; the LRM is silent on both, this
+  // matches industry convention (Verilator). For matching non-empty sizes,
+  // `==` / `!=` propagate X / Z through the `&&` reduction over element
+  // comparisons; `CaseEqual` matches X / Z as values and is deterministic.
+  [[nodiscard]] auto operator==(const DynamicArray& other) const
+      -> PackedArray {
+    if (data_.size() != other.data_.size()) {
+      return PackedArray::FromInt(0, 1, false, false);
+    }
+    if (data_.empty()) {
+      return PackedArray::FromInt(1, 1, false, false);
+    }
+    PackedArray result = data_[0] == other.data_[0];
+    for (std::size_t i = 1; i < data_.size(); ++i) {
+      result = result && (data_[i] == other.data_[i]);
+    }
+    return result;
+  }
+  [[nodiscard]] auto operator!=(const DynamicArray& other) const
+      -> PackedArray {
+    return !(*this == other);
+  }
+
+  [[nodiscard]] auto CaseEqual(const DynamicArray& other) const -> PackedArray {
+    if (data_.size() != other.data_.size()) {
+      return PackedArray::FromInt(0, 1, false, false);
+    }
+    if (data_.empty()) {
+      return PackedArray::FromInt(1, 1, false, false);
+    }
+    PackedArray result = detail::ArrayCaseEqElement(data_[0], other.data_[0]);
+    for (std::size_t i = 1; i < data_.size(); ++i) {
+      result = result && detail::ArrayCaseEqElement(data_[i], other.data_[i]);
+    }
+    return result;
   }
 
  private:

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "lyra/value/array_case_equal.hpp"
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
 
@@ -157,9 +158,9 @@ class UnpackedArray {
 
   [[nodiscard]] auto CaseEqual(const UnpackedArray& other) const
       -> PackedArray {
-    PackedArray result = CaseEqElement(data_[0], other.data_[0]);
+    PackedArray result = detail::ArrayCaseEqElement(data_[0], other.data_[0]);
     for (std::size_t i = 1; i < data_.size(); ++i) {
-      result = result && CaseEqElement(data_[i], other.data_[i]);
+      result = result && detail::ArrayCaseEqElement(data_[i], other.data_[i]);
     }
     return result;
   }
@@ -179,18 +180,6 @@ class UnpackedArray {
     T fresh = oob_slot_;
     fresh.ResetToDefault();
     return fresh;
-  }
-
-  [[nodiscard]] static auto CaseEqElement(
-      const PackedArray& a, const PackedArray& b) -> PackedArray {
-    auto raw = a.CaseEqual(b);
-    const bool four_state = a.IsFourState() || b.IsFourState();
-    return four_state ? PackedArray::ConvertFrom(raw, 1, false, true) : raw;
-  }
-  template <typename U>
-  [[nodiscard]] static auto CaseEqElement(
-      const UnpackedArray<U>& a, const UnpackedArray<U>& b) -> PackedArray {
-    return a.CaseEqual(b);
   }
 
   mutable T oob_slot_;

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -362,11 +362,13 @@ auto RenderBinaryOpReal(
 }
 
 // LRM 11.2.2 + 11.4.5: aggregate equality / inequality / case-equality /
-// case-inequality. `UnpackedArray` overloads `==` / `!=` to return a 1-bit
-// `PackedArray` (X / Z propagating) and exposes `CaseEqual` as a method
-// returning a 1-bit `PackedArray` (0 / 1 only). Relational operators are not
-// defined on aggregate operands.
-auto RenderBinaryOpUnpacked(
+// case-inequality. Both `UnpackedArray` and `DynamicArray` overload `==` /
+// `!=` to return a 1-bit `PackedArray` (X / Z propagating) and expose
+// `CaseEqual` as a method returning a 1-bit `PackedArray` (0 / 1 only). The
+// dynamic-array overloads additionally short-circuit on runtime size
+// mismatch -> 0 (industry convention, LRM 11.2.2 is silent). Relational
+// operators are not defined on aggregate operands.
+auto RenderBinaryOpArray(
     mir::BinaryOp op, const std::string& lhs, const std::string& rhs)
     -> diag::Result<std::string> {
   switch (op) {
@@ -550,9 +552,14 @@ auto RenderBinaryExpr(
     return RenderBinaryOpString(
         b.op, *lhs_or, *rhs_or, ctx.Unit().GetType(expr.type));
   }
-  if (std::holds_alternative<mir::UnpackedArrayType>(lhs_ty.data) &&
-      std::holds_alternative<mir::UnpackedArrayType>(rhs_ty.data)) {
-    return RenderBinaryOpUnpacked(b.op, *lhs_or, *rhs_or);
+  const bool lhs_is_array =
+      std::holds_alternative<mir::UnpackedArrayType>(lhs_ty.data) ||
+      std::holds_alternative<mir::DynamicArrayType>(lhs_ty.data);
+  const bool rhs_is_array =
+      std::holds_alternative<mir::UnpackedArrayType>(rhs_ty.data) ||
+      std::holds_alternative<mir::DynamicArrayType>(rhs_ty.data);
+  if (lhs_is_array && rhs_is_array) {
+    return RenderBinaryOpArray(b.op, *lhs_or, *rhs_or);
   }
   return RenderBinaryOpIntegral(b.op, *lhs_or, *rhs_or);
 }

--- a/tests/cases/cpp/dynamic_array_case_equality/case.yaml
+++ b/tests/cases/cpp/dynamic_array_case_equality/case.yaml
@@ -1,0 +1,25 @@
+id: cpp.dynamic_array_case_equality
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    ce_1d: 1
+    nce_1d: 0
+    ce_size_mismatch: 0
+    nce_size_mismatch: 1
+    ce_diff_val: 0
+    nce_diff_val: 1
+    ce_empty_empty: 1
+    nce_empty_empty: 0
+    ce_empty_nonempty: 0
+    nce_empty_nonempty: 1
+    ce_2d: 1
+    ce_fixed_outer: 1
+    ce_dyn_outer: 1
+    ce_x_match: 1
+    ce_x_mismatch: 0

--- a/tests/cases/cpp/dynamic_array_case_equality/main.sv
+++ b/tests/cases/cpp/dynamic_array_case_equality/main.sv
@@ -1,0 +1,56 @@
+// LRM 11.4.5 case equality on dynamic arrays. `===` / `!==` always yield 0
+// or 1; X and Z are matched as values (not propagated). Size mismatch follows
+// the same convention as `==` (industry: runtime size mismatch yields 0).
+// Multi-dim and mixed-container nesting compose via the recursive element
+// type.
+module Top;
+  int a [] = '{10, 20, 30};
+  int b [] = '{10, 20, 30};
+  int shorter [] = '{10, 20};
+  int diff_val [] = '{10, 20, 99};
+  int empty1 [];
+  int empty2 [];
+
+  int m [][] = '{'{1, 2, 3}, '{4, 5, 6}};
+  int n [][] = '{'{1, 2, 3}, '{4, 5, 6}};
+
+  int fdo_p [2][] = '{'{1, 2}, '{3, 4, 5}};
+  int fdo_q [2][] = '{'{1, 2}, '{3, 4, 5}};
+
+  int dfo_x [][3] = '{'{1, 2, 3}, '{4, 5, 6}};
+  int dfo_y [][3] = '{'{1, 2, 3}, '{4, 5, 6}};
+
+  // 4-state: X matched as value -> 1 when same X positions, 0 when X vs 0.
+  logic [3:0] u_x_a [] = '{4'b1010, 4'b10x0, 4'b1111};
+  logic [3:0] u_x_b [] = '{4'b1010, 4'b10x0, 4'b1111};
+  logic [3:0] u_x_c [] = '{4'b1010, 4'b1010, 4'b1111};
+
+  bit ce_1d, nce_1d;
+  bit ce_size_mismatch, nce_size_mismatch;
+  bit ce_diff_val, nce_diff_val;
+  bit ce_empty_empty, nce_empty_empty;
+  bit ce_empty_nonempty, nce_empty_nonempty;
+  bit ce_2d, ce_fixed_outer, ce_dyn_outer;
+  bit ce_x_match, ce_x_mismatch;
+
+  initial begin
+    ce_1d = (a === b);
+    nce_1d = (a !== b);
+    ce_size_mismatch = (a === shorter);
+    nce_size_mismatch = (a !== shorter);
+    ce_diff_val = (a === diff_val);
+    nce_diff_val = (a !== diff_val);
+
+    ce_empty_empty = (empty1 === empty2);
+    nce_empty_empty = (empty1 !== empty2);
+    ce_empty_nonempty = (empty1 === a);
+    nce_empty_nonempty = (empty1 !== a);
+
+    ce_2d = (m === n);
+    ce_fixed_outer = (fdo_p === fdo_q);
+    ce_dyn_outer = (dfo_x === dfo_y);
+
+    ce_x_match = (u_x_a === u_x_b);
+    ce_x_mismatch = (u_x_a === u_x_c);
+  end
+endmodule

--- a/tests/cases/cpp/dynamic_array_equality/case.yaml
+++ b/tests/cases/cpp/dynamic_array_equality/case.yaml
@@ -1,0 +1,29 @@
+id: cpp.dynamic_array_equality
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    eq_1d: 1
+    ne_1d: 0
+    eq_size_mismatch: 0
+    ne_size_mismatch: 1
+    eq_diff_val: 0
+    ne_diff_val: 1
+    eq_empty_empty: 1
+    ne_empty_empty: 0
+    eq_empty_nonempty: 0
+    ne_empty_nonempty: 1
+    eq_2d: 1
+    eq_2d_row_mismatch: 0
+    eq_2d_outer_mismatch: 0
+    eq_fixed_outer: 1
+    eq_fixed_outer_inner_diff: 0
+    eq_dyn_outer: 1
+    eq_dyn_outer_size_diff: 0
+    eq_with_x: "1'bx"
+    ne_with_x: "1'bx"

--- a/tests/cases/cpp/dynamic_array_equality/main.sv
+++ b/tests/cases/cpp/dynamic_array_equality/main.sv
@@ -1,0 +1,69 @@
+// LRM 11.2.2 + 11.4.5 logical equality on dynamic arrays. Aggregate ==
+// reduces element-wise comparisons through &&; LRM 11.2.2 requires equivalent
+// type but is silent on runtime size mismatch -- industry convention (and
+// Verilator) yields 0 on size mismatch and 1 on empty-vs-empty. X / Z in any
+// element comparison propagates to 1'bx per LRM 11.4.5.
+module Top;
+  int a [] = '{10, 20, 30};
+  int b [] = '{10, 20, 30};
+  int shorter [] = '{10, 20};
+  int diff_val [] = '{10, 20, 99};
+  int empty1 [];
+  int empty2 [];
+
+  // 2D pure dynamic.
+  int m [][] = '{'{1, 2, 3}, '{4, 5, 6}};
+  int n [][] = '{'{1, 2, 3}, '{4, 5, 6}};
+  int row_mismatch [][] = '{'{1, 2, 3}, '{4, 5}};
+  int outer_short [][] = '{'{1, 2, 3}};
+
+  // Mixed: fixed outer, dynamic inner.
+  int fdo_p [2][] = '{'{1, 2}, '{3, 4, 5}};
+  int fdo_q [2][] = '{'{1, 2}, '{3, 4, 5}};
+  int fdo_r [2][] = '{'{1, 2}, '{3, 4}};
+
+  // Mixed: dynamic outer, fixed inner.
+  int dfo_x [][3] = '{'{1, 2, 3}, '{4, 5, 6}};
+  int dfo_y [][3] = '{'{1, 2, 3}, '{4, 5, 6}};
+  int dfo_z [][3] = '{'{1, 2, 3}};
+
+  // 4-state element type for X / Z propagation.
+  logic [3:0] u_with_x [] = '{4'b1010, 4'b10x0, 4'b1111};
+  logic [3:0] u_no_x   [] = '{4'b1010, 4'b1010, 4'b1111};
+
+  bit eq_1d, ne_1d;
+  bit eq_size_mismatch, ne_size_mismatch;
+  bit eq_diff_val, ne_diff_val;
+  bit eq_empty_empty, ne_empty_empty;
+  bit eq_empty_nonempty, ne_empty_nonempty;
+  bit eq_2d, eq_2d_row_mismatch, eq_2d_outer_mismatch;
+  bit eq_fixed_outer, eq_fixed_outer_inner_diff;
+  bit eq_dyn_outer, eq_dyn_outer_size_diff;
+  logic eq_with_x, ne_with_x;
+
+  initial begin
+    eq_1d = (a == b);
+    ne_1d = (a != b);
+    eq_size_mismatch = (a == shorter);
+    ne_size_mismatch = (a != shorter);
+    eq_diff_val = (a == diff_val);
+    ne_diff_val = (a != diff_val);
+
+    eq_empty_empty = (empty1 == empty2);
+    ne_empty_empty = (empty1 != empty2);
+    eq_empty_nonempty = (empty1 == a);
+    ne_empty_nonempty = (empty1 != a);
+
+    eq_2d = (m == n);
+    eq_2d_row_mismatch = (m == row_mismatch);
+    eq_2d_outer_mismatch = (m == outer_short);
+
+    eq_fixed_outer = (fdo_p == fdo_q);
+    eq_fixed_outer_inner_diff = (fdo_p == fdo_r);
+    eq_dyn_outer = (dfo_x == dfo_y);
+    eq_dyn_outer_size_diff = (dfo_x == dfo_z);
+
+    eq_with_x = (u_with_x == u_no_x);
+    ne_with_x = (u_with_x != u_no_x);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements LRM 11.2.2 + 11.4.5 aggregate equality for dynamic arrays: `A == B`, `A != B`, `A === B`, `A !== B`. The frontend / HIR / MIR are already type-agnostic for binary equality, so the work is concentrated in the runtime and a single backend dispatch site. `DynamicArray<T>` gains `operator==` / `operator!=` / `CaseEqual` with a runtime size-mismatch short-circuit (yields 0) and an empty-vs-empty short-circuit (yields 1); for matched non-empty sizes the existing element-wise reduction handles X / Z propagation through `PackedArray::operator==`. Multi-dimensional and mixed-container nesting (`int [3][]`, `int [][3]`) compose through the recursive element type.

The per-element `CaseEqElement` helper used by `UnpackedArray::CaseEqual` is extracted to a shared `lyra::value::detail::ArrayCaseEqElement` so both containers (and their cross-container nesting overloads) call a single source of truth. The backend dispatch site that previously routed to `RenderBinaryOpUnpacked` is widened to fire on either `UnpackedArrayType` or `DynamicArrayType` and the helper is renamed to `RenderBinaryOpArray`; slang rejects mixed-container equality at binding, so the dispatch never sees an `UnpackedArray vs DynamicArray` pair.

## Design

LRM 11.2.2 requires aggregate equality operands to be of equivalent type but is silent on runtime size mismatch and empty-vs-empty results for dynamic arrays; 11.4.5's "bit for bit" wording is integral-focused and does not address aggregates. The implementation adopts the industry reading (confirmed against Verilator): size mismatch yields 0 directly, both-empty yields 1 (the conjunction-reduction identity), matched non-empty sizes reduce element-wise. This is documented at the call sites and in `docs/progress/aggregate.md`.

## Testing

Two consolidated test cases cover the full grid in one compile each: `dynamic_array_equality` for `==` / `!=` (1D same-size, size mismatch, empty, 2D, fixed-outer / dynamic-inner mixed nesting, dynamic-outer / fixed-inner mixed nesting, X / Z propagation with 4-state elements) and `dynamic_array_case_equality` for `===` / `!==` (same grid plus X-as-value matching). Full `bazel test //...` passes.