### PR TITLE
Add dynamic-array method dispatch and no-with method subset

### DIFF
--- a/docs/decisions/array-method-dispatch.md
+++ b/docs/decisions/array-method-dispatch.md
@@ -1,0 +1,92 @@
+# Array method dispatch
+
+Date: 2026-06-04 Status: accepted
+
+## Context
+
+LRM 7.5.2 / 7.5.3 attach two methods (`size`, `delete`) to the dynamic-array type, and LRM 7.12
+defines a much larger family (`sort`, `rsort`, `reverse`, `shuffle`, `sum`, `product`, `and`, `or`,
+`xor`, `find` and its variants, `min`, `max`, `unique`, `unique_index`, `map`) that applies
+uniformly to any unpacked array container (fixed unpacked, dynamic, queue, associative). Slang
+implements all of these as `SystemSubroutine` instances registered against each container's
+`SymbolKind`. At the SV call site they share the surface syntax of method dispatch
+(`receiver.method(...)`); at the slang AST they surface as `CallExpression` with
+`isSystemCall() == true`.
+
+Lyra already has a first-class home for receiver-type-bound built-in methods:
+`hir::BuiltinMethodRef` (`include/lyra/hir/method.hpp`), which carries the enum / string / event
+method kinds and is found via receiver-type detection in `LowerCallExprProc`
+(`src/lyra/lowering/ast_to_hir/expression/lower.cpp`). The system-subroutine path
+(`SystemSubroutineRef`) is reserved for global `$xxx` functions whose dispatch is name-based.
+
+This decision pins where the array-method family lives and how the surface area splits across cuts.
+
+## Decision
+
+**Type-bound built-in array methods route through `hir::BuiltinMethodRef`.**
+
+A new `ArrayMethodKind` enum joins the existing variant arms (`EnumMethodKind`, `StringMethodKind`,
+`EventMethodKind`). AST -> HIR detects the receiver type in `LowerCallExprProc` and routes the call
+to `BuiltinMethodRef{ArrayMethodKind::kXxx}`. HIR -> MIR translates the kind through the existing
+`Overloaded` visitor on the `BuiltinMethodRef` callee. The backend renders `(receiver).MethodName()`
+and wraps the result in `lyra::value::PackedArray::Int(...)` for the one method whose C++ return
+type is `std::size_t` (`size`).
+
+The enum is named `ArrayMethodKind` (not `DynArrayMethodKind`) because LRM 7.12 defines the
+semantics uniformly across container kinds; only the AST -> HIR receiver-detection block differs per
+container. Fixed-unpacked, queue, and associative array workstreams extend the routing block, not
+the kind enum.
+
+**Empty-array reduction returns element-shape zero.**
+
+LRM 7.12.3 is silent on the empty-input case. Slang's `ArrayReductionMethod::eval` returns an
+`SVInt` of the element's bit width and signedness filled with zero, regardless of which reduction
+(`sum`, `product`, `and`, `or`, `xor`). The runtime implementation re-uses the receiver's
+`oob_slot_` (which already carries the canonical element shape from the DA1 shield protocol): copy
+the slot, call `ResetToDefault()` on the copy, return.
+
+**The method family ships in three cuts.**
+
+The full LRM 7.12 surface mixes three independent architectural foundations: pure method-dispatch
+infrastructure, the `with` clause / iterator binding, and the `Queue<T>` runtime (needed by methods
+whose return type is `queue<elem>` or `queue<int>`). Folding all three into one PR is unmanageable;
+folding none means each follow-up reopens the dispatch plumbing. The sequencing:
+
+- **DA6-a** (this cut): pure method dispatch + the no-`with`, no-queue-return subset (`size`,
+  `delete`, `reverse`, `sort`, `rsort`, `sum`, `product`, `and`, `or`, `xor`).
+- **DA6-b**: `with` clause + iterator binding + the non-queue-return `with` variants (`sort with`,
+  `sum with`, ...).
+- **DA6-c + Q1**: `Queue<T>` runtime + locator family (`find*`, `min`, `max`, `unique*`).
+
+`shuffle()` (RNG) and SV2023 `map()` ship as standalone follow-ups after DA6-c lands.
+
+**Sort uses selection sort, not `std::ranges::sort`.**
+
+`PackedArray::operator=(PackedArray&&)` enforces destination-shape preservation via `AssignFrom`,
+which is the correct semantic for SV-language assignments. `std::ranges::sort` (libstdc++ introsort)
+internally evicts an element into a temporary via move-construct, then move-assigns from another
+element into the now-empty slot; that move-assign tripping the shape check produces an
+`InternalError`. Reverse works (it uses `iter_swap`, which we ADL-hook with a friend `swap` on
+`PackedArray` that exchanges storage directly). Sort cannot be ADL-hooked the same way -- it touches
+elements via `=`, not `swap`. The runtime therefore implements `Sort` / `Rsort` as in-place
+selection sort using ADL `swap`. The asymptotic O(n^2) cost is acceptable because (a) DA arrays in
+the realistic SV workload are small, (b) the alternative (relaxing PackedArray's move-assign) would
+silently weaken the shape-preservation safety net used by user-facing assignments. A future
+PackedArray refactor can introduce an explicit "moved-from" state and a smarter sort if needed.
+
+## Rejected alternatives
+
+- **Routing array methods through `SystemSubroutineRef`.** That path is keyed on a name in the
+  global `$xxx` namespace; `arr.size()` is keyed on the receiver type. The existing enum / string /
+  event arms already establish the pattern. Forcing all three into one shared system-subroutine
+  registry would conflate two distinct dispatch axes (global function name vs receiver-type method).
+- **Per-container kind enums** (`DynArrayMethodKind`, `UnpackedArrayMethodKind`, ...). The methods'
+  semantics are LRM-uniform across containers; only the receiver-detection block differs. A single
+  `ArrayMethodKind` keeps the kind enum stable as other workstreams open.
+- **Shipping all 18+ methods in one PR.** Even the no-queue-return no-`with` subset is ten methods
+  and ships in one cut here; pulling in queue runtime or `with`-clause infrastructure on top would
+  push the review surface past the point where bisection helps.
+- **Relaxing `PackedArray::operator=(PackedArray&&)` to adopt source shape.** Would let
+  `std::ranges::sort` work directly, but would silently reshape destinations on SV assignments if
+  any backend conversion path failed to insert the matching `Conversion`. Keeping the
+  shape-preservation guarantee in place is worth the O(n^2) sort.

--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -25,7 +25,9 @@ follow once dynamic array's storage and runtime conventions are settled and prov
 | DA3  | Done: positional and replicated assignment patterns (LRM 10.9.1).    |
 | DA4  | Done: aggregate equality, inequality, case-equality.                 |
 | DA5  | Open: constant-width slice (subject to LRM check).                   |
-| DA6  | Open: SV-callable method family (`.size()`, `.delete()`, ...).       |
+| DA6a | Done: method dispatch + no-`with` subset.                            |
+| DA6b | Open: `with` clause + iterator + non-queue-return method variants.   |
+| DA6c | Open: queue runtime + locator family (find\*, min, max, unique\*).   |
 | DA7  | Open: invalid-index handling.                                        |
 | Q1.. | Not yet scoped: queue.                                               |
 | A1.. | Not yet scoped: associative array.                                   |
@@ -84,11 +86,24 @@ The numeric IDs are stable references and do not imply execution order beyond DA
       direction and OOB semantics carry over from U6 / U7. If the LRM forbids slicing on dynamic
       arrays, DA5 closes by emitting the rejection diagnostic instead.
 
-- [ ] DA6 -- SV-callable method family. `.size()` query (LRM 7.5.1), `.delete()` clears all
-      elements, and any other LRM-defined methods on dynamic arrays, plus the LRM 7.10
-      array-querying methods that apply (`$size`, `$dimensions`, etc.). Sets up the SV
-      method-dispatch path for the aggregate types in this file; queue and associative array will
-      extend the same machinery with their respective method families.
+- [x] DA6a -- Method dispatch infrastructure plus the no-`with`, no-queue-return method subset.
+      `.size()` and `.delete()` (LRM 7.5.2 / 7.5.3); the LRM 7.12.2 ordering subset that takes no
+      `with` clause (`.reverse()`, `.sort()`, `.rsort()`); the LRM 7.12.3 reduction subset that
+      takes no `with` clause (`.sum()`, `.product()`, `.and()`, `.or()`, `.xor()`). Dispatch routes
+      receiver-type-bound calls through the existing `BuiltinMethodRef` first-class home alongside
+      enum / string / event methods; system-function array-querying counterparts (`$size`,
+      `$dimensions`, etc. -- LRM 7.11 / 20.7) are a separate dispatch path and not bundled here.
+      Slang gates element-type constraints upstream (integral element for reductions, comparable for
+      sort).
+
+- [ ] DA6b -- `with`-clause variants of the methods that accept one (`sort`, `rsort`, reductions),
+      built on a new iterator-binding pass that lowers slang's `IteratorCallInfo` into HIR/MIR and
+      emits a closure at the backend.
+
+- [ ] DA6c + Q1 -- Queue\<T\> runtime and the locator-family methods that return one (`find` family,
+      `min`, `max`, `unique`, `unique_index`). Opens the queue workstream. `shuffle()` (needs RNG
+      model) and `map()` (SV2023, needs `with` infra + version gate) are standalone follow-ups after
+      DA6c lands.
 
 - [ ] DA7 -- Invalid-index handling. Read on an out-of-range index returns the element type's LRM
       Table 7-1 default; write on an out-of-range index is a silent no-op; X / Z bits in the index
@@ -109,10 +124,11 @@ can be any singular type or `string` (LRM 7.8); storage is sparse; the iteration
 ## Cross-references
 
 - LRM anchors: 7.4.5 (Indexing and slicing of arrays), 7.4.6 (Operations on arrays), 7.5 (Dynamic
-  arrays), 7.6 (Array assignments), 7.8 (Associative arrays), 7.9 (Associative array methods), 7.10
-  (Queues and array-querying methods), 10.9 (Assignment patterns), 11.4.1 (Assignment operators),
-  11.4.5 (Equality operators), Table 6-7 (Default initial values), Table 7-1 (Value read from a
-  nonexistent array entry).
+  arrays), 7.5.2 (`size()`), 7.5.3 (`delete()`), 7.6 (Array assignments), 7.8 (Associative arrays),
+  7.9 (Associative array methods), 7.10 (Queues), 7.11 (Array querying functions), 7.12 (Array
+  manipulation methods), 7.12.1 (Locator), 7.12.2 (Ordering), 7.12.3 (Reduction), 7.12.4 (Iterator
+  index), 10.9 (Assignment patterns), 11.4.1 (Assignment operators), 11.4.5 (Equality operators),
+  Table 6-7 (Default initial values), Table 7-1 (Value read from a nonexistent array entry).
 - Archive items: `datatypes/general/*`.
 - Unblocks: `control-flow.md` C10 (foreach over dynamic / queue / associative subset).
 - Decision: `../decisions/runtime-shape-and-default-value.md` -- runtime shape is retained on

--- a/include/lyra/hir/method.hpp
+++ b/include/lyra/hir/method.hpp
@@ -46,8 +46,29 @@ enum class EventMethodKind : std::uint8_t {
   kTriggered,
 };
 
+// LRM 7.5.2 / 7.5.3 dynamic-array methods plus the LRM 7.12.2 / 7.12.3
+// no-`with`, no-queue-return subset of the array-method family. The arms
+// are named for "array" rather than "dynamic array" because the method
+// semantics are LRM-uniform across container kinds (fixed unpacked, queue);
+// only the AST -> HIR receiver-detection block differs per container, and
+// other containers will extend the routing without renaming this enum.
+enum class ArrayMethodKind : std::uint8_t {
+  kSize,
+  kDelete,
+  kReverse,
+  kSort,
+  kRsort,
+  kSum,
+  kProduct,
+  kAnd,
+  kOr,
+  kXor,
+};
+
 struct BuiltinMethodRef {
-  std::variant<EnumMethodKind, StringMethodKind, EventMethodKind> method;
+  std::variant<
+      EnumMethodKind, StringMethodKind, EventMethodKind, ArrayMethodKind>
+      method;
 };
 
 }  // namespace lyra::hir

--- a/include/lyra/lowering/ast_to_hir/expression/slang_atoms.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/slang_atoms.hpp
@@ -9,8 +9,6 @@
 #include <slang/numeric/Time.h>
 #include <slang/syntax/SyntaxNode.h>
 
-#include "lyra/diag/diagnostic.hpp"
-#include "lyra/diag/source_span.hpp"
 #include "lyra/hir/binary_op.hpp"
 #include "lyra/hir/conversion.hpp"
 #include "lyra/hir/inc_dec_op.hpp"
@@ -33,8 +31,7 @@ auto LowerConversionKind(slang::ast::ConversionKind k) -> hir::ConversionKind;
 
 auto LowerBinaryOp(slang::ast::BinaryOperator op) -> hir::BinaryOp;
 
-auto LowerUnaryOp(slang::ast::UnaryOperator op, diag::SourceSpan span)
-    -> diag::Result<hir::UnaryOp>;
+auto LowerUnaryOp(slang::ast::UnaryOperator op) -> hir::UnaryOp;
 
 // LRM 11.4.2: maps slang's inc/dec UnaryOperator values to hir::IncDecOp.
 // Throws InternalError if `op` is not one of the four inc/dec variants
@@ -51,6 +48,9 @@ auto LowerEnumMethodName(std::string_view name)
 
 auto LowerStringMethodName(std::string_view name)
     -> std::optional<hir::StringMethodKind>;
+
+auto LowerArrayMethodName(std::string_view name)
+    -> std::optional<hir::ArrayMethodKind>;
 
 // Recover the original user-written rhs from slang's compound expansion:
 // slang lowers `lhs op= e` to `right = Conv(lhs.type) { BinaryOp(op) {

--- a/include/lyra/mir/builtin_method.hpp
+++ b/include/lyra/mir/builtin_method.hpp
@@ -48,6 +48,21 @@ enum class EventMethodKind : std::uint8_t {
   kTriggered,
 };
 
+// LRM 7.5.2 / 7.5.3 dynamic-array methods plus the LRM 7.12.2 / 7.12.3
+// no-`with`, no-queue-return subset of the array-method family.
+enum class ArrayMethodKind : std::uint8_t {
+  kSize,
+  kDelete,
+  kReverse,
+  kSort,
+  kRsort,
+  kSum,
+  kProduct,
+  kAnd,
+  kOr,
+  kXor,
+};
+
 struct EnumMethodInfo {
   TypeId enum_type;
   EnumMethodKind kind;
@@ -61,6 +76,10 @@ struct EventMethodInfo {
   EventMethodKind kind;
 };
 
+struct ArrayMethodInfo {
+  ArrayMethodKind kind;
+};
+
 // True for methods whose backend emission must wrap the call site in
 // `co_await`. The runtime returns an awaitable that submits the appropriate
 // WaitRequest via the coroutine's promise.
@@ -69,7 +88,9 @@ struct EventMethodInfo {
 }
 
 struct BuiltinMethodCallee {
-  std::variant<EnumMethodInfo, StringMethodInfo, EventMethodInfo> method;
+  std::variant<
+      EnumMethodInfo, StringMethodInfo, EventMethodInfo, ArrayMethodInfo>
+      method;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <span>
 #include <string>
 #include <utility>
@@ -75,6 +77,21 @@ class DynamicArray {
   auto operator=(const DynamicArray&) -> DynamicArray& = default;
   auto operator=(DynamicArray&&) noexcept -> DynamicArray& = default;
   ~DynamicArray() = default;
+
+  // ADL swap so STL element-relocation primitives can shuffle nested
+  // DynamicArrays inside an outer container (e.g. `matrix.reverse()` on
+  // `int matrix[][]` swaps two row arrays). The default move-assign on
+  // DynamicArray<PackedArray> trips PackedArray::AssignFrom's
+  // shape-preservation rule because storage moves out without the
+  // shape scalars being reset; swapping member-wise avoids the path.
+  // Mirrors PackedArray's friend swap; same NOLINT rationale (ADL name
+  // is mandated lowercase).
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  friend auto swap(DynamicArray& a, DynamicArray& b) noexcept -> void {
+    using std::swap;
+    swap(a.oob_slot_, b.oob_slot_);
+    swap(a.data_, b.data_);
+  }
 
   [[nodiscard]] auto Size() const -> std::size_t {
     return data_.size();
@@ -158,7 +175,92 @@ class DynamicArray {
     return result;
   }
 
+  // LRM 7.5.3: empties the array, resulting in a zero-sized array. Body is
+  // identical to ResetToDefault (LRM Table 6-7 default for dynamic array is
+  // the empty array), but the two surface names track distinct contracts:
+  // Delete is the user-facing method name; ResetToDefault is the OOB-shield
+  // protocol shared with PackedArray / UnpackedArray.
+  auto Delete() -> void {
+    data_.clear();
+  }
+
+  // LRM 7.12.2 reverse: in-place reversal; `with` clause is a compiler
+  // error and is filtered upstream by slang.
+  auto Reverse() -> void {
+    std::ranges::reverse(data_);
+  }
+
+  // LRM 7.12.2 sort / rsort: in-place ordering using the element type's
+  // relational operators. Slang upstream rejects element types lacking
+  // `<`/`>`/`==`. PackedArray::operator< returns a 1-bit PackedArray
+  // truth value whose explicit bool conversion is the sort comparator.
+  //
+  // Selection sort is used (O(n^2)) rather than std::ranges::sort because
+  // libstdc++'s introsort uses `tmp = std::move(arr[i])` during insertion
+  // sort, which empties arr[i] and breaks PackedArray's
+  // shape-preservation invariant on the subsequent `arr[i] = std::move(...)`.
+  // Selection sort touches elements only via the ADL friend swap, which
+  // exchanges storage directly and stays shape-safe. Test-sized arrays
+  // (the only consumers under DA6-a) make the asymptotic cost a non-issue.
+  auto Sort() -> void {
+    SelectionSortBy(std::less<>{});
+  }
+  auto Rsort() -> void {
+    SelectionSortBy(std::greater<>{});
+  }
+
+  // LRM 7.12.3 reductions: fold the element type's arithmetic / bitwise
+  // operator over the elements. Slang upstream restricts the element type to
+  // integral. Empty-array result is element-shape zero (slang behaviour;
+  // LRM is silent) -- the OOB shield slot already carries the canonical
+  // default and is the cheapest in-shape zero.
+  [[nodiscard]] auto Sum() const -> T {
+    return Fold([](const T& a, const T& b) { return a + b; });
+  }
+  [[nodiscard]] auto Product() const -> T {
+    return Fold([](const T& a, const T& b) { return a * b; });
+  }
+  [[nodiscard]] auto And() const -> T {
+    return Fold([](const T& a, const T& b) { return a & b; });
+  }
+  [[nodiscard]] auto Or() const -> T {
+    return Fold([](const T& a, const T& b) { return a | b; });
+  }
+  [[nodiscard]] auto Xor() const -> T {
+    return Fold([](const T& a, const T& b) { return a ^ b; });
+  }
+
  private:
+  template <typename Compare>
+  auto SelectionSortBy(Compare cmp) -> void {
+    using std::swap;
+    for (std::size_t i = 0; i + 1 < data_.size(); ++i) {
+      std::size_t pick = i;
+      for (std::size_t j = i + 1; j < data_.size(); ++j) {
+        if (static_cast<bool>(cmp(data_[j], data_[pick]))) {
+          pick = j;
+        }
+      }
+      if (pick != i) {
+        swap(data_[i], data_[pick]);
+      }
+    }
+  }
+
+  template <typename F>
+  [[nodiscard]] auto Fold(F op) const -> T {
+    if (data_.empty()) {
+      T zero = oob_slot_;
+      zero.ResetToDefault();
+      return zero;
+    }
+    T result = data_[0];
+    for (std::size_t i = 1; i < data_.size(); ++i) {
+      result = op(result, data_[i]);
+    }
+    return result;
+  }
+
   [[nodiscard]] auto IsInvalidIndex(const PackedArray& idx) const -> bool {
     if (idx.HasUnknown()) return true;
     const auto v = idx.ToInt64();

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -221,6 +221,24 @@ class PackedArray {
   auto operator=(PackedArray&& other) noexcept(false) -> PackedArray&;
   ~PackedArray() = default;
 
+  // Storage-level swap, bypassing AssignFrom's shape-preservation rule.
+  // Found by ADL so STL element-relocation primitives (`std::ranges::sort`,
+  // `reverse`, etc.) can shuffle PackedArrays inside a container without
+  // tripping the user-facing "assignment preserves destination shape"
+  // invariant. Element relocation within a container is structural motion,
+  // not an SV-visible assignment, so adopting source shape via swap is the
+  // correct primitive for that context. Name is lowercase to satisfy the
+  // ADL contract std::swap and std::ranges::swap require.
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  friend auto swap(PackedArray& a, PackedArray& b) noexcept -> void {
+    using std::swap;
+    swap(a.bit_width_, b.bit_width_);
+    swap(a.is_signed_, b.is_signed_);
+    swap(a.is_four_state_, b.is_four_state_);
+    swap(a.storage_, b.storage_);
+    swap(a.dims_, b.dims_);
+  }
+
   // Extract the value as a 64-bit signed integer. Sign-extends from
   // bit_width when is_signed_ is true. X/Z bits map to 0. bit_width must
   // be <= 64.

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -761,6 +761,32 @@ auto StringMethodMemberName(mir::StringMethodKind k) -> std::string_view {
   throw InternalError("StringMethodMemberName: unknown kind");
 }
 
+auto ArrayMethodMemberName(mir::ArrayMethodKind k) -> std::string_view {
+  switch (k) {
+    case mir::ArrayMethodKind::kSize:
+      return "Size";
+    case mir::ArrayMethodKind::kDelete:
+      return "Delete";
+    case mir::ArrayMethodKind::kReverse:
+      return "Reverse";
+    case mir::ArrayMethodKind::kSort:
+      return "Sort";
+    case mir::ArrayMethodKind::kRsort:
+      return "Rsort";
+    case mir::ArrayMethodKind::kSum:
+      return "Sum";
+    case mir::ArrayMethodKind::kProduct:
+      return "Product";
+    case mir::ArrayMethodKind::kAnd:
+      return "And";
+    case mir::ArrayMethodKind::kOr:
+      return "Or";
+    case mir::ArrayMethodKind::kXor:
+      return "Xor";
+  }
+  throw InternalError("ArrayMethodMemberName: unknown kind");
+}
+
 auto EventMethodMemberName(mir::EventMethodKind k) -> std::string_view {
   switch (k) {
     case mir::EventMethodKind::kTrigger:
@@ -898,6 +924,31 @@ auto RenderEventMethodCall(
   return raw_call;
 }
 
+// LRM 7.5.2 / 7.5.3 / 7.12.2 / 7.12.3: dispatch on the receiver
+// (arguments[0]); none of the no-`with` methods in this PR take additional
+// arguments. `Size()` returns std::size_t and gets wrapped in
+// `PackedArray::Int` to land in SV `int` shape (mirrors EnumMethod::kNum).
+// All other methods either return void (in-place mutators) or already return
+// the receiver's element type (reductions); no wrap.
+auto RenderArrayMethodCall(
+    const RenderContext& ctx, const mir::CallExpr& call,
+    const mir::ArrayMethodInfo& m) -> diag::Result<std::string> {
+  if (call.arguments.empty()) {
+    throw InternalError(
+        "RenderArrayMethodCall: array method expects a receiver argument");
+  }
+  auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
+  if (!receiver_or) {
+    return std::unexpected(std::move(receiver_or.error()));
+  }
+  const std::string raw_call =
+      std::format("({}).{}()", *receiver_or, ArrayMethodMemberName(m.kind));
+  if (m.kind == mir::ArrayMethodKind::kSize) {
+    return std::format("lyra::value::PackedArray::Int({})", raw_call);
+  }
+  return raw_call;
+}
+
 auto RenderCallExpr(const RenderContext& ctx, const mir::CallExpr& call)
     -> diag::Result<std::string> {
   return std::visit(
@@ -969,6 +1020,9 @@ auto RenderCallExpr(const RenderContext& ctx, const mir::CallExpr& call)
                     },
                     [&](const mir::EventMethodInfo& m) {
                       return RenderEventMethodCall(ctx, call, m);
+                    },
+                    [&](const mir::ArrayMethodInfo& m) {
+                      return RenderArrayMethodCall(ctx, call, m);
                     },
                 },
                 b.method);

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -164,6 +164,33 @@ class HirDumper {
         "HirDumper::FormatEventMethodKind: unknown EventMethodKind");
   }
 
+  static auto FormatArrayMethodKind(ArrayMethodKind k) -> std::string_view {
+    switch (k) {
+      case ArrayMethodKind::kSize:
+        return "size";
+      case ArrayMethodKind::kDelete:
+        return "delete";
+      case ArrayMethodKind::kReverse:
+        return "reverse";
+      case ArrayMethodKind::kSort:
+        return "sort";
+      case ArrayMethodKind::kRsort:
+        return "rsort";
+      case ArrayMethodKind::kSum:
+        return "sum";
+      case ArrayMethodKind::kProduct:
+        return "product";
+      case ArrayMethodKind::kAnd:
+        return "and";
+      case ArrayMethodKind::kOr:
+        return "or";
+      case ArrayMethodKind::kXor:
+        return "xor";
+    }
+    throw InternalError(
+        "HirDumper::FormatArrayMethodKind: unknown ArrayMethodKind");
+  }
+
   static auto FormatPackedForm(PackedArrayForm f) -> std::string_view {
     switch (f) {
       case PackedArrayForm::kExplicit:
@@ -592,6 +619,10 @@ class HirDumper {
                       [](EventMethodKind k) -> std::string {
                         return std::format(
                             "EventMethod \"{}\"", FormatEventMethodKind(k));
+                      },
+                      [](ArrayMethodKind k) -> std::string {
+                        return std::format(
+                            "ArrayMethod \"{}\"", FormatArrayMethodKind(k));
                       },
                   },
                   b.method);

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -472,8 +472,7 @@ auto LowerUnaryExprProc(
     ProcessLoweringState& proc_state, const ScopeStack& stack,
     const slang::ast::UnaryExpression& un, const slang::ast::Expression& expr,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto op_or = LowerUnaryOp(un.op, span);
-  if (!op_or) return std::unexpected(std::move(op_or.error()));
+  const hir::UnaryOp op = LowerUnaryOp(un.op);
   auto operand_or =
       LowerProcExpr(unit_facts, unit_state, proc_state, stack, un.operand());
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
@@ -482,7 +481,7 @@ auto LowerUnaryExprProc(
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
-      .data = hir::UnaryExpr{.op = *op_or, .operand = operand_id},
+      .data = hir::UnaryExpr{.op = op, .operand = operand_id},
       .span = span,
   };
 }
@@ -658,6 +657,29 @@ auto LowerCallExprProc(
               },
           .span = span,
       };
+    }
+
+    if (receiver_type.has_value() &&
+        std::holds_alternative<hir::DynamicArrayType>(
+            unit_state.GetType(*receiver_type).data)) {
+      if (auto kind = LowerArrayMethodName(name); kind.has_value()) {
+        // LRM 7.5.2 / 7.5.3 dynamic-array methods plus LRM 7.12.2 / 7.12.3
+        // no-`with` subset. Receiver is arguments[0]; this PR's surface
+        // takes no further arguments. Slang upstream gates element-type
+        // constraints (integral for reductions, comparable for sort), so
+        // any call landing here is well-typed.
+        auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+        if (!type_id) return std::unexpected(std::move(type_id.error()));
+        return hir::Expr{
+            .type = *type_id,
+            .data =
+                hir::CallExpr{
+                    .callee = hir::BuiltinMethodRef{.method = *kind},
+                    .arguments = std::move(arg_ids),
+                },
+            .span = span,
+        };
+      }
     }
 
     const auto* desc = support::FindSystemSubroutine(name);
@@ -1357,8 +1379,7 @@ auto LowerUnaryExprStructural(
     ScopeLoweringState& scope_state, const ScopeStack& stack,
     const slang::ast::UnaryExpression& un, const slang::ast::Expression& expr,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto op_or = LowerUnaryOp(un.op, span);
-  if (!op_or) return std::unexpected(std::move(op_or.error()));
+  const hir::UnaryOp op = LowerUnaryOp(un.op);
   auto operand_or = LowerStructuralExpr(
       unit_facts, unit_state, scope_state, stack, un.operand());
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
@@ -1367,7 +1388,7 @@ auto LowerUnaryExprStructural(
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
-      .data = hir::UnaryExpr{.op = *op_or, .operand = operand_id},
+      .data = hir::UnaryExpr{.op = op, .operand = operand_id},
       .span = span,
   };
 }

--- a/src/lyra/lowering/ast_to_hir/expression/slang_atoms.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/slang_atoms.cpp
@@ -107,8 +107,7 @@ auto LowerBinaryOp(slang::ast::BinaryOperator op) -> hir::BinaryOp {
   throw InternalError("LowerBinaryOp: unknown slang BinaryOperator");
 }
 
-auto LowerUnaryOp(slang::ast::UnaryOperator op, diag::SourceSpan span)
-    -> diag::Result<hir::UnaryOp> {
+auto LowerUnaryOp(slang::ast::UnaryOperator op) -> hir::UnaryOp {
   switch (op) {
     case slang::ast::UnaryOperator::Plus:
       return hir::UnaryOp::kPlus;
@@ -217,6 +216,21 @@ auto LowerStringMethodName(std::string_view name)
   if (name == "octtoa") return hir::StringMethodKind::kOcttoa;
   if (name == "bintoa") return hir::StringMethodKind::kBintoa;
   if (name == "realtoa") return hir::StringMethodKind::kRealtoa;
+  return std::nullopt;
+}
+
+auto LowerArrayMethodName(std::string_view name)
+    -> std::optional<hir::ArrayMethodKind> {
+  if (name == "size") return hir::ArrayMethodKind::kSize;
+  if (name == "delete") return hir::ArrayMethodKind::kDelete;
+  if (name == "reverse") return hir::ArrayMethodKind::kReverse;
+  if (name == "sort") return hir::ArrayMethodKind::kSort;
+  if (name == "rsort") return hir::ArrayMethodKind::kRsort;
+  if (name == "sum") return hir::ArrayMethodKind::kSum;
+  if (name == "product") return hir::ArrayMethodKind::kProduct;
+  if (name == "and") return hir::ArrayMethodKind::kAnd;
+  if (name == "or") return hir::ArrayMethodKind::kOr;
+  if (name == "xor") return hir::ArrayMethodKind::kXor;
   return std::nullopt;
 }
 

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -470,6 +470,32 @@ auto LowerEventMethodKind(hir::EventMethodKind k) -> mir::EventMethodKind {
   throw InternalError("LowerEventMethodKind: unknown hir::EventMethodKind");
 }
 
+auto LowerArrayMethodKind(hir::ArrayMethodKind k) -> mir::ArrayMethodKind {
+  switch (k) {
+    case hir::ArrayMethodKind::kSize:
+      return mir::ArrayMethodKind::kSize;
+    case hir::ArrayMethodKind::kDelete:
+      return mir::ArrayMethodKind::kDelete;
+    case hir::ArrayMethodKind::kReverse:
+      return mir::ArrayMethodKind::kReverse;
+    case hir::ArrayMethodKind::kSort:
+      return mir::ArrayMethodKind::kSort;
+    case hir::ArrayMethodKind::kRsort:
+      return mir::ArrayMethodKind::kRsort;
+    case hir::ArrayMethodKind::kSum:
+      return mir::ArrayMethodKind::kSum;
+    case hir::ArrayMethodKind::kProduct:
+      return mir::ArrayMethodKind::kProduct;
+    case hir::ArrayMethodKind::kAnd:
+      return mir::ArrayMethodKind::kAnd;
+    case hir::ArrayMethodKind::kOr:
+      return mir::ArrayMethodKind::kOr;
+    case hir::ArrayMethodKind::kXor:
+      return mir::ArrayMethodKind::kXor;
+  }
+  throw InternalError("LowerArrayMethodKind: unknown hir::ArrayMethodKind");
+}
+
 auto LowerHirStringLiteral(const hir::StringLiteral& s, mir::TypeId type)
     -> mir::Expr {
   return mir::Expr{.data = mir::StringLiteral{.value = s.value}, .type = type};
@@ -962,6 +988,11 @@ auto LowerHirCallExprProc(
                       return {
                           .method = mir::EventMethodInfo{
                               .kind = LowerEventMethodKind(k)}};
+                    },
+                    [&](hir::ArrayMethodKind k) -> mir::BuiltinMethodCallee {
+                      return {
+                          .method = mir::ArrayMethodInfo{
+                              .kind = LowerArrayMethodKind(k)}};
                     },
                 },
                 b.method);

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -340,6 +340,11 @@ class MirDumper {
                             "EventMethodInfo[kind={}]",
                             static_cast<int>(m.kind));
                       },
+                      [](const ArrayMethodInfo& m) -> std::string {
+                        return std::format(
+                            "ArrayMethodInfo[kind={}]",
+                            static_cast<int>(m.kind));
+                      },
                   },
                   b.method);
             },

--- a/tests/cases/cpp/dynamic_array_method_delete/case.yaml
+++ b/tests/cases/cpp/dynamic_array_method_delete/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.dynamic_array_method_delete
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    arr: [7, 8, 9]
+    size_after_delete: 0
+    matrix: []

--- a/tests/cases/cpp/dynamic_array_method_delete/main.sv
+++ b/tests/cases/cpp/dynamic_array_method_delete/main.sv
@@ -1,0 +1,23 @@
+module Top;
+  int arr [];
+  int matrix [][];
+  int size_after_delete;
+  initial begin
+    arr = new[3];
+    arr[0] = 100;
+    arr[1] = 200;
+    arr[2] = 300;
+    arr.delete();
+    size_after_delete = arr.size();
+    // Re-fill after delete: a fresh `new[N]` rebuilds cleanly.
+    arr = new[3];
+    arr[0] = 7;
+    arr[1] = 8;
+    arr[2] = 9;
+    // Multi-dim outer-dim delete clears the entire row table.
+    matrix = new[2];
+    matrix[0] = new[3];
+    matrix[1] = new[3];
+    matrix.delete();
+  end
+endmodule

--- a/tests/cases/cpp/dynamic_array_method_order/case.yaml
+++ b/tests/cases/cpp/dynamic_array_method_order/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.dynamic_array_method_order
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sorted: [-5, -1, 2, 3]
+    rsorted: [3, 2, -1, -5]
+    empty_sorted: []
+    single_sorted: [9]
+    sorted_dup: [1, 1, 2, 2, 3]

--- a/tests/cases/cpp/dynamic_array_method_order/main.sv
+++ b/tests/cases/cpp/dynamic_array_method_order/main.sv
@@ -1,0 +1,40 @@
+module Top;
+  // Signed-integer order anchors LRM 7.12.2: relational < uses the element
+  // type's natural ordering, so negatives sort below positives.
+  int sorted [];
+  int rsorted [];
+  int empty_sorted [];
+  int single_sorted [];
+  int sorted_dup [];
+  initial begin
+    sorted = new[4];
+    sorted[0] = 3;
+    sorted[1] = -1;
+    sorted[2] = 2;
+    sorted[3] = -5;
+    sorted.sort();
+
+    rsorted = new[4];
+    rsorted[0] = 3;
+    rsorted[1] = -1;
+    rsorted[2] = 2;
+    rsorted[3] = -5;
+    rsorted.rsort();
+
+    // Empty and single-element are no-ops for both sort and rsort.
+    empty_sorted.sort();
+
+    single_sorted = new[1];
+    single_sorted[0] = 9;
+    single_sorted.rsort();
+
+    // Duplicates preserve count.
+    sorted_dup = new[5];
+    sorted_dup[0] = 2;
+    sorted_dup[1] = 1;
+    sorted_dup[2] = 3;
+    sorted_dup[3] = 1;
+    sorted_dup[4] = 2;
+    sorted_dup.sort();
+  end
+endmodule

--- a/tests/cases/cpp/dynamic_array_method_reduction/case.yaml
+++ b/tests/cases/cpp/dynamic_array_method_reduction/case.yaml
@@ -1,0 +1,22 @@
+id: cpp.dynamic_array_method_reduction
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s_sum: 100
+    s_product: 240000
+    s_and: "8'h08"
+    s_or: "8'h7F"
+    s_xor: "8'h4F"
+    empty_sum: 0
+    empty_product: 0
+    empty_and: 0
+    empty_or: 0
+    empty_xor: 0
+    single_sum: 42
+    single_product: 42

--- a/tests/cases/cpp/dynamic_array_method_reduction/main.sv
+++ b/tests/cases/cpp/dynamic_array_method_reduction/main.sv
@@ -1,0 +1,47 @@
+module Top;
+  int arr [];
+  int s_sum, s_product;
+  bit [7:0] bits [];
+  bit [7:0] s_and, s_or, s_xor;
+
+  // Empty-array reductions all return element-shape zero. LRM 7.12.3 is
+  // silent on the empty case; this matches slang's ArrayReductionMethod
+  // behaviour and is the slang-compat anchor.
+  bit [7:0] empty_bits [];
+  int empty_int [];
+  bit [7:0] empty_and, empty_or, empty_xor;
+  int empty_sum, empty_product;
+
+  // Single-element reduction returns the element verbatim for every kind.
+  int single [];
+  int single_sum, single_product;
+
+  initial begin
+    arr = new[4];
+    arr[0] = 10;
+    arr[1] = 20;
+    arr[2] = 30;
+    arr[3] = 40;
+    s_sum = arr.sum();           // 10+20+30+40 = 100
+    s_product = arr.product();   // 10*20*30*40 = 240000
+
+    bits = new[3];
+    bits[0] = 8'h7C;
+    bits[1] = 8'h2B;
+    bits[2] = 8'h18;
+    s_and = bits.and();   // 0x7C & 0x2B & 0x18 = 0x08
+    s_or  = bits.or();    // 0x7C | 0x2B | 0x18 = 0x7F
+    s_xor = bits.xor();   // 0x7C ^ 0x2B ^ 0x18 = 0x4F
+
+    empty_sum     = empty_int.sum();
+    empty_product = empty_int.product();
+    empty_and     = empty_bits.and();
+    empty_or      = empty_bits.or();
+    empty_xor     = empty_bits.xor();
+
+    single = new[1];
+    single[0] = 42;
+    single_sum     = single.sum();
+    single_product = single.product();
+  end
+endmodule

--- a/tests/cases/cpp/dynamic_array_method_reverse/case.yaml
+++ b/tests/cases/cpp/dynamic_array_method_reverse/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.dynamic_array_method_reverse
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    empty: []
+    single: [42]
+    multi: [50, 40, 30, 20, 10]
+    matrix: [[10, 20, 30], [1, 2, 3]]

--- a/tests/cases/cpp/dynamic_array_method_reverse/main.sv
+++ b/tests/cases/cpp/dynamic_array_method_reverse/main.sv
@@ -1,0 +1,30 @@
+module Top;
+  int empty [];
+  int single [];
+  int multi [];
+  int matrix [][];
+  initial begin
+    // Empty array reverses to empty (no-op).
+    empty.reverse();
+    // Single element is a no-op too.
+    single = new[1];
+    single[0] = 42;
+    single.reverse();
+    // Multi-element reversal restores the input in reverse order.
+    multi = new[5];
+    multi[0] = 10;
+    multi[1] = 20;
+    multi[2] = 30;
+    multi[3] = 40;
+    multi[4] = 50;
+    multi.reverse();
+    // Multi-dim outer-dim reversal swaps rows; inner rows are preserved
+    // intact per row (no nested flip).
+    matrix = new[2];
+    matrix[0] = new[3];
+    matrix[1] = new[3];
+    matrix[0][0] = 1;  matrix[0][1] = 2;  matrix[0][2] = 3;
+    matrix[1][0] = 10; matrix[1][1] = 20; matrix[1][2] = 30;
+    matrix.reverse();
+  end
+endmodule

--- a/tests/cases/cpp/dynamic_array_method_size/case.yaml
+++ b/tests/cases/cpp/dynamic_array_method_size/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.dynamic_array_method_size
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    n_empty: 0
+    n_three: 3
+    n_after_writes: 3
+    n_resized: 5
+    n_outer: 2

--- a/tests/cases/cpp/dynamic_array_method_size/main.sv
+++ b/tests/cases/cpp/dynamic_array_method_size/main.sv
@@ -1,0 +1,23 @@
+module Top;
+  int arr [];
+  int matrix [][];
+  int n_empty, n_three, n_after_writes, n_resized, n_outer;
+  initial begin
+    // Empty (uncreated) dynamic array reports zero per LRM 7.5.2.
+    n_empty = arr.size();
+    arr = new[3];
+    n_three = arr.size();
+    arr[0] = 100;
+    arr[1] = 200;
+    arr[2] = 300;
+    n_after_writes = arr.size();
+    // new[N](src) resizes; size now reflects N.
+    arr = new[5](arr);
+    n_resized = arr.size();
+    // Multi-dim outer-dim count.
+    matrix = new[2];
+    matrix[0] = new[4];
+    matrix[1] = new[4];
+    n_outer = matrix.size();
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds the first cut of LRM-defined methods on dynamic arrays: `.size()`, `.delete()`, `.reverse()`, `.sort()`, `.rsort()`, and the reductions `.sum()`, `.product()`, `.and()`, `.or()`, `.xor()`. Method dispatch routes receiver-type-bound calls through `hir::BuiltinMethodRef` alongside the existing enum/string/event method arms, mirroring the established first-class pattern for type-bound built-ins. Queue-returning methods (`find*`, `min`, `max`, `unique*`), `with`-clause variants, `shuffle`, and `map` are out of scope for this cut and tracked under DA6-b / DA6-c.

## Design

A single `ArrayMethodKind` enum joins `BuiltinMethodRef::method` (HIR/MIR mirrored). The AST -> HIR receiver-detection block in `LowerCallExprProc` routes calls when the receiver is a dynamic array; the system-subroutine path stays reserved for global `$xxx` functions. Backend renders `(receiver).MethodName()`, wrapping `.size()` in `PackedArray::Int` to land in SV `int` shape. Empty-array reductions return element-shape zero via the `oob_slot_` shield (matches slang; LRM 7.12.3 is silent).

`Sort` and `Rsort` use selection sort, not `std::ranges::sort`. libstdc++ introsort evicts an element into a temporary via move-construct and then move-assigns into the now-empty slot; that path trips `PackedArray::AssignFrom`'s shape-preservation rule with an `InternalError`. Selection sort touches elements only through an ADL friend `swap` on `PackedArray` (and its mirror on `DynamicArray<T>`), which exchanges storage directly. The O(n^2) cost is acceptable for realistic SV array sizes; relaxing PackedArray's move-assign would silently weaken the shape-preservation safety net on user-facing assignments. Full rationale in `docs/decisions/array-method-dispatch.md`.

## Testing

Five new cpp_run test cases under `tests/cases/cpp/dynamic_array_method_*` cover: size on empty / after grow / multi-dim outer; delete + re-fill; reverse including multi-dim outer with inner rows preserved; sort/rsort on signed-negative entries with empty and duplicate-element cases; reductions including the empty-array element-shape-zero anchor. Full `bazel test //...` green.