### PR TITLE
Add fork-join parallel blocks (FJ1)

### DIFF
--- a/docs/architecture/lowering_boundaries.md
+++ b/docs/architecture/lowering_boundaries.md
@@ -33,6 +33,14 @@ set of allowed transformations.
 6. Lowering does not introduce new semantic identity. The target layer's identity kinds are defined
    by the target layer's contract; a lowering may only use identity kinds that belong to the input
    or output layer.
+7. The pipeline branches at MIR into two backends: the C++ emitter (MIR-to-C++, the path used today)
+   and the LIR-then-LLVM path. A backend emit makes no semantic decisions -- every semantic fact is
+   fixed in MIR -- and chooses only how to represent each MIR node in its target, a representation
+   fixed by the node's kind. The two backends represent the same node differently (a coroutine
+   method versus an LLVM coroutine frame) yet realize the same behaviour, which holds only because
+   neither adds, infers, or re-derives a semantic fact. MIR-to-C++ is not as mechanical as
+   LIR-to-LLVM -- it still chooses C++ forms for higher-level MIR nodes -- but the choice is a fixed
+   function of the node, never a judgement about what the program means.
 
 ## Boundary to Adjacent Layers
 

--- a/docs/architecture/mir.md
+++ b/docs/architecture/mir.md
@@ -60,6 +60,12 @@ several possible backend targets for MIR, and does not define MIR's semantics.
 9. Instance multiplicity is the vector wrapper, a property of the member's type, and is orthogonal
    to whether the owned object is an intra-unit scope or an external unit. The same wrapper composes
    over either object form and to any depth.
+10. Every semantic decision is explicit in MIR's structure. MIR is consumed by more than one backend
+    -- the C++ emitter today, the LIR-then-LLVM path next -- and each chooses only how to represent
+    MIR's stated semantics in its target. A backend reads a semantic fact from a MIR node or
+    reference; it never re-derives or re-decides one. This is what lets two backends produce the
+    same behaviour from the same MIR: anything they would otherwise have to infer must already be
+    stated.
 
 ## Boundary to Adjacent Layers
 
@@ -90,6 +96,19 @@ several possible backend targets for MIR, and does not define MIR's semantics.
   source-level shape (e.g., `Inside(lhs, items)`, `CaseMatch(sel, labels)`). Sugar collapses to
   primitives in MIR; readability of generated backend source is not recovered by reintroducing
   intrinsic-style calls downstream.
+- A backend that recovers a semantic fact MIR does not state by inferring it from a node's body
+  contents or any side signal, instead of reading it from an explicit node or reference. Reading
+  which node consumes a value is reading structure and is allowed; scanning a body to decide what it
+  must be is re-deriving. If two backends could infer a fact differently, it is not yet in MIR and
+  belongs there.
+- A node field that no backend's realization reads, or that restates what the node's structural
+  context -- the nodes it references, or the node that consumes it -- already fixes. A node's fields
+  are the inputs to its fixed per-backend realization: a field a realization can ignore is dead, and
+  a field that duplicates what the surrounding structure already determines is redundant. Both are
+  the same defect from two sides -- the encoded fact is either absent from the structure (and
+  belongs there as structure) or already present (and the field is noise). The falsifiable check on
+  a new field is: does every backend's realization read it, and does it state something the
+  structure does not?
 
 ## Notes / Examples
 
@@ -122,3 +141,17 @@ expression set that decomposes the ternary. Value-build primitives for aggregate
 (concatenation, replication, structured literal, and similar) have no smaller decomposition. Select
 expressions are access primitives. Each of these stays in MIR for the same reason: removing it would
 require expanding into a statement-form rewrite that does not fit the expression context.
+
+A closure is a captured callable value: a capture list plus a procedural-scope body, the one IR
+shape for "a body bound to a snapshot of its environment, run later." A closure is synthesized only
+by HIR-to-MIR lowering; no source construct produces one. Its body reaches enclosing procedural
+state only through the captures, and reaches module-scope storage directly -- the way a lambda
+references globals without capture. The closure node carries nothing about how it executes: like a
+language-level lambda, it has no "suspends" property. Whether a closure runs synchronously or as a
+coroutine follows from its use, which is itself explicit in MIR -- a closure submitted as a deferred
+effect (a non-blocking assignment, a postponed `$strobe`) runs to completion in a later scheduling
+region; a closure referenced by a parallel block (a fork-join branch, LRM 9.3.2) is spawned as a
+concurrent process and therefore a coroutine. The capture model and the body are identical across
+both. A process, a subroutine, and a closure are the three callable forms whose bodies are all the
+same procedural scope; they differ only in how the body binds its environment and in how it is
+invoked.

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -2,11 +2,10 @@
 
 A lyra simulation runs as a set of coroutines coordinated by a stratified event scheduler. Each
 SystemVerilog process -- `initial`, `always*`, `final` -- compiles to a C++ coroutine. The scheduler
-pulls coroutines from time-slot region queues and resumes them; a coroutine runs until it yields
-with a named reason (delay, event wait, `$finish`), and the scheduler parks it on the queue matching
-that reason. Deferred effects (`<=` writes, `$strobe` prints) are not yields: the coroutine
-snapshots its inputs into a closure, hands the closure to the engine, and continues running. The
-engine invokes those closures when their owning region runs.
+pulls coroutines from time-slot region queues and resumes them; a coroutine runs until it suspends,
+and lands on whichever queue its own `await_suspend` chose. Deferred effects (`<=` writes, `$strobe`
+prints) are not yields: the coroutine snapshots its inputs into a closure, hands the closure to the
+engine, and continues running. The engine invokes those closures when their owning region runs.
 
 This doc covers the decisions behind the engine itself: process model, suspension protocol, region
 structure, deferred work, `$finish` semantics, and the MIR boundary. Sensitivity tracking, change
@@ -14,11 +13,10 @@ detection, and edge detection are separate runtime subsystems.
 
 ## Processes and tasks are coroutines
 
-A process body -- and a task body, which may consume time -- compiles into a `Coroutine` whose
-`co_await` expressions hand a `WaitRequest` to the scheduler. The scheduler holds a
-`std::coroutine_handle` and calls `.resume()` to continue the body. Process state -- procedural
-locals, the implicit program counter -- lives in the coroutine frame, which the engine does not
-introspect.
+A process body -- and a task body, which may consume time -- compiles into a `Coroutine`. The
+scheduler holds a `std::coroutine_handle` and calls `.resume()` to continue the body; a `co_await`
+in the body suspends it again. Process state -- procedural locals, the implicit program counter --
+lives in the coroutine frame, which the engine does not introspect.
 
 A task is enabled with `co_await`: enabling a time-consuming task suspends the enabling process
 until the task completes (LRM 13.3). The scheduler resumes the innermost suspended frame, and each
@@ -30,16 +28,31 @@ nontrivial design. Coroutine frames hold only the locals live across suspension 
 state machines are rejected: they would force HIR-to-MIR lowering to thread resumption state through
 every statement that might suspend, defeating the structured form MIR is designed to carry.
 
-## Suspension is a named reason
+## The engine is a mechanism, not a semantics holder
 
-A coroutine surrenders control only by `co_await`-ing an awaitable that sets a `WaitRequest`.
-`WaitRequest` is a closed `std::variant` of the reasons the engine knows how to dispatch:
-`DelayWait`, `EventWait`, `FinishWait`. A new suspension kind is added by extending the variant;
-there is no implicit yield path.
+The engine does three things: it holds queues of runnable coroutine handles, it resumes them, and it
+parks each one on whichever queue the code it just ran asked for. It never inspects what a coroutine
+represents, why it suspended, or what it waits for. A coroutine frame is opaque to it.
 
-The engine sees nothing about a suspended coroutine beyond the reason it yielded with. There is no
-priority field the engine reads, no out-of-band hook for a process to leave notes for the scheduler.
-The reason is the protocol.
+Construct semantics live entirely in awaitables. A `co_await` suspends the coroutine and, in
+`await_suspend`, reaches back through `RuntimeServices` to a small fixed set of construct-neutral
+scheduling verbs: enqueue on the next delta, enqueue on the inactive region, enqueue at a future
+time, request that the simulation stop. The verbs name _when_ a handle becomes runnable again, never
+_why_. Distinct constructs -- a delay, an event wait, a task enable -- bottom out in the same verbs,
+and the engine cannot tell them apart.
+
+This is the division a host event loop draws: the loop runs its queues and knows nothing of the
+timers, I/O, or callbacks that fill them; the meaning lives in the APIs that enqueue, not in the
+loop. The payoff is additivity. A suspending construct is added by writing a new awaitable that
+schedules through the existing verbs; a process-spawning construct may also add one
+construct-neutral verb (adopt a coroutine and schedule it). Either way the engine gains no
+per-construct branch.
+
+**Invariant:** the engine branches only on queue and region, never on the kind of construct a
+coroutine came from. **Forbidden:** a per-construct case inside the engine's resume or dispatch
+path; a priority field or out-of-band note a coroutine leaves for the scheduler to read. When a
+construct seems to require the engine to ask "is this an X?", the neutral verb set is missing a
+primitive -- add the primitive, do not teach the engine the construct.
 
 ## Deferred work is a closure submit, not a suspension
 
@@ -74,9 +87,9 @@ earlier, defeating the intent.
 
 ## `$finish`
 
-`$finish` yields a `FinishWait`. When the scheduler dispatches it, it sets a `finished_` flag and
-the time-slot loop exits without running further regions in the in-progress slot. Pending NBA writes
-for that slot do not commit; queued active processes do not resume.
+`$finish` reaches the engine's stop verb, which sets a `finished_` flag; the time-slot loop then
+exits without running further regions in the in-progress slot. Pending NBA writes for that slot do
+not commit; queued active processes do not resume.
 
 Registered `final` actions then run in registration order. A `$finish` raised from inside a `final`
 aborts the remaining finals. This three-cornered behavior (active shutdown, NBA discard, final

--- a/docs/progress/fork-join.md
+++ b/docs/progress/fork-join.md
@@ -35,12 +35,15 @@ constructs.
 
 ### Spawning and the join condition
 
-- [ ] FJ1 -- A fork spawns each parallel statement as its own concurrent process, and the join
+- [x] FJ1 -- A fork spawns each parallel statement as its own concurrent process, and the join
       keyword sets when the forking process resumes: after all of them (`join`), after the first
       (`join_any`), or immediately (`join_none`). The LRM 9.3.2 ordering rule holds -- spawned
-      processes do not run until the parent blocks at the join or terminates. Minimal end-to-end
-      shape: single-statement branches with no internal timing, where each join mode is observable
-      through the order in which the parent and the branches write shared state.
+      processes do not run until the parent blocks at the join or terminates. Branches carry their
+      own delay so the three join modes are observable (the parent resumes after the slowest, the
+      earliest, or not at all). Branches read and write module-scope signals only; a branch that
+      references a procedural variable and a named fork block are rejected with a diagnostic rather
+      than miscompiled. A fork inside a task is supported; a fork inside a function stays rejected
+      (a function cannot suspend). Per-branch local storage and the loop-spawn idiom ride on FJ4.
 
 ### Timing across branches
 
@@ -79,24 +82,21 @@ constructs.
 - [ ] FJ7 -- `disable fork` terminates all descendant processes of the calling process, including
       descendants of subprocesses that have already terminated (LRM 9.6.3).
 
-## Blocked
+### Fork inside a function
 
-- The runtime side of FJ1 -- a running process bringing new processes into being mid-simulation, and
-  the ownership and scheduling of those children -- rides on the single object-tree refactor
-  (`refactor.md` R3). Today processes are born only at construction and the scheduler walks a
-  topology tree mirrored at bind time; fork needs processes created during simulation that attach to
-  the live hierarchy. Designing the spawn / ownership substrate against the current dual-tree shape
-  would be invalidated when R3 collapses it, so the runtime design waits on R3. The suspending-
-  coroutine and join-barrier machinery this builds on is settled (`functions.md` T2). The LRM
-  semantics above, the join threshold model, and the fork statement's IR representation are
-  independent of R3.
+- [ ] FJ8 -- `fork ... join_none` inside a function (LRM 13.4.4). A function is not a coroutine and
+      cannot suspend, so it cannot await a join; only `join_none` is legal there, and it must spawn
+      its branches without suspending. FJ1 rejects every fork inside a function. (`join` /
+      `join_any` inside a function stays a compile error -- see Rejected at the frontend. A fork
+      inside a task is supported by FJ1.)
 
 ## Rejected at the frontend
 
 - A `return` statement inside a fork-join block is a compile error: the branch lives in a separate
   process (LRM 9.3.2).
-- A function body may contain only `fork ... join_none`, never `join` or `join_any`, because a
-  function cannot suspend (LRM 13.4). See `functions.md`.
+- Inside a function, `fork ... join` and `fork ... join_any` are a compile error: a function cannot
+  suspend (LRM 13.4). Only `join_none` is legal there, and enabling it is tracked by FJ8. See
+  `functions.md`.
 
 ## Out of Scope
 

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -144,6 +144,32 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       `LowerHirConversionExprProc` (or any new constant-folding pass on MIR), because both want a
       MIR free of redundant `ConversionExpr` nodes.
 
+- [ ] R8 -- Unify the callable forms onto one concept. Today a process (`mir::Process`), a
+      subroutine (`mir::StructuralSubroutineDecl`), and a closure (`mir::ClosureExpr`) are three
+      separate types whose bodies are all the same `ProceduralScope`; the code already notes the
+      duplication ("a subroutine is a callable peer of a process"). Each hardcodes a fixed point in
+      three orthogonal axes: how the body binds outer state (the enclosing object only / named
+      parameters / captured values), whether the body suspends (coroutine vs plain), and whether it
+      is an anonymous value or a named declaration. The combinations in use today are partial --
+      process is (object-only, suspends, value-spawned-at-startup), function is (params, no-suspend,
+      named, returns), task is (params, suspends, named), closure is (captures, no-suspend,
+      anonymous value). A fork-join branch is the missing fourth-axis combination -- an anonymous
+      value, with captured state, that suspends -- which no form provides. This cut fills it the
+      minimal way, by completing `ClosureExpr` with a suspend axis (so a closure value may be
+      suspending or not), which unifies the NBA / `$strobe` closure and the fork branch under one
+      type but leaves the three-way duplication between process, subroutine, and closure standing.
+      Target shape: a single callable concept carrying a `ProceduralScope` body, a list of bound
+      inputs that unifies parameters and captures behind one binding-mode axis, a suspend flag, and
+      an optional result type; the five forms become instances differing only in their axis values
+      and in how the referencing site invokes them (spawn at startup, call, submit, spawn
+      concurrently). **Why deferred**: this rebases the whole process / subroutine / closure
+      machinery across lowering, MIR, the dumper, and the backend; the fork cut needs only the
+      suspend axis on `ClosureExpr` and reaches it without touching processes or subroutines, so
+      folding the full merge into a feature cut is scope explosion. **Trigger**: when a further
+      feature needs yet another axis combination, or when a change has to be made three times across
+      the duplicated forms; the suspending closure this cut introduces is the first concrete
+      cross-form driver, so the unification now has a real motivation rather than being speculative.
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/backend/cpp/render_context.hpp
+++ b/include/lyra/backend/cpp/render_context.hpp
@@ -27,9 +27,15 @@ class RenderContext {
 
   [[nodiscard]] auto WithProceduralScope(
       const mir::ProceduralScope& child) const -> RenderContext {
-    return RenderContext{
-        *unit_,        *scope_,       child,        this, structural_parent_,
-        temp_counter_, static_frame_, in_coroutine_};
+    return RenderContext{*unit_,
+                         *scope_,
+                         child,
+                         this,
+                         structural_parent_,
+                         temp_counter_,
+                         static_frame_,
+                         in_coroutine_,
+                         receiver_};
   }
 
   [[nodiscard]] auto WithStructuralScope(
@@ -37,7 +43,7 @@ class RenderContext {
       const mir::ProceduralScope& root_proc_scope) const -> RenderContext {
     return RenderContext{*unit_,  child_scope, root_proc_scope,
                          nullptr, this,        temp_counter_,
-                         {},      false};
+                         {},      false,       "this"};
   }
 
   // A subroutine body renders its static locals through this per-instance frame
@@ -51,7 +57,8 @@ class RenderContext {
                          structural_parent_,
                          temp_counter_,
                          accessor,
-                         in_coroutine_};
+                         in_coroutine_,
+                         receiver_};
   }
 
   // Marks the current body as a coroutine (a process or a task), where `return`
@@ -66,7 +73,27 @@ class RenderContext {
         structural_parent_,
         temp_counter_,
         static_frame_,
-        in_coroutine};
+        in_coroutine,
+        receiver_};
+  }
+
+  // Names the object the body reaches module state and Services() through. A
+  // method body leaves this "this" and emits implicit-`this` access; a fork
+  // branch (LRM 9.3.2) renders as an inline coroutine closure with no implicit
+  // `this`, so its body names the frame-copied receiver parameter `self`
+  // explicitly.
+  [[nodiscard]] auto WithReceiver(std::string_view object) const
+      -> RenderContext {
+    return RenderContext{
+        *unit_,
+        *scope_,
+        *proc_scope_,
+        procedural_parent_,
+        structural_parent_,
+        temp_counter_,
+        static_frame_,
+        in_coroutine_,
+        object};
   }
 
   RenderContext(const RenderContext&) = delete;
@@ -130,6 +157,35 @@ class RenderContext {
     return std::format("{}_{}", prefix, (*temp_counter_)++);
   }
 
+  // The object the current body reaches the enclosing scope instance through:
+  // `this` in a method body, `self` in a fork-branch closure body. Named where
+  // the object itself is spelled -- a spawned inner closure is invoked with it
+  // and captures it, so a nested fork passes `self` on down.
+  [[nodiscard]] auto ReceiverObject() const -> std::string_view {
+    return receiver_;
+  }
+
+  // The prefix every scope-member access carries. Always explicit -- `this->`
+  // in a method body, `self->` in a fork-branch closure body -- so a process
+  // body and a branch body render identically up to the receiver name.
+  [[nodiscard]] auto MemberPrefix() const -> std::string {
+    return std::string(receiver_) + "->";
+  }
+
+  // The C++ expression naming the RuntimeServices the body submits effects
+  // through (`this->Services()` / `self->Services()`).
+  [[nodiscard]] auto ServicesRef() const -> std::string {
+    return MemberPrefix() + "Services()";
+  }
+
+  // The capture clause of a `[=]`-default deferred lambda (NBA / `$strobe`)
+  // that also grabs the receiver. A `self` pointer is a local captured by the
+  // bare `[=]`; the `this` keyword must be named explicitly because C++20
+  // deprecates `[=]` capture of `this`.
+  [[nodiscard]] auto DeferredByValueCapture() const -> std::string_view {
+    return receiver_ == "this" ? "[=, this]" : "[=]";
+  }
+
  private:
   RenderContext(
       const mir::CompilationUnit& unit, const mir::StructuralScope& scope,
@@ -147,7 +203,8 @@ class RenderContext {
       const mir::ProceduralScope& proc_scope,
       const RenderContext* procedural_parent,
       const RenderContext* structural_parent, std::size_t* temp_counter,
-      std::string_view static_frame, bool in_coroutine)
+      std::string_view static_frame, bool in_coroutine,
+      std::string_view receiver)
       : unit_(&unit),
         scope_(&scope),
         proc_scope_(&proc_scope),
@@ -155,7 +212,8 @@ class RenderContext {
         structural_parent_(structural_parent),
         temp_counter_(temp_counter),
         static_frame_(static_frame),
-        in_coroutine_(in_coroutine) {
+        in_coroutine_(in_coroutine),
+        receiver_(receiver) {
   }
 
   const mir::CompilationUnit* unit_;
@@ -166,6 +224,7 @@ class RenderContext {
   std::size_t* temp_counter_;
   std::string_view static_frame_;
   bool in_coroutine_ = false;
+  std::string_view receiver_ = "this";
   mutable std::size_t owned_temp_counter_ = 0;
 };
 

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -34,6 +34,7 @@ enum class DiagCode : std::uint32_t {
   kUnsupportedPortConnectionForm,
   kUnsupportedAssignmentPatternKind,
   kUnsupportedSubroutineArgument,
+  kUnsupportedForkJoinForm,
 
   kDelayValueOutOfRange,
   kFormatStringTrailingPercent,

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -43,6 +43,21 @@ struct BlockStmt {
   std::vector<StmtId> statements;
 };
 
+// LRM 9.3.2 Table 9-1: which join keyword controls when the forking process
+// resumes.
+enum class JoinMode : std::uint8_t {
+  kAll,
+  kAny,
+  kNone,
+};
+
+// LRM 9.3.2 parallel block. Each branch is a statement run as its own
+// concurrent process; `mode` sets when the parent resumes.
+struct ForkStmt {
+  JoinMode mode;
+  std::vector<StmtId> branches;
+};
+
 enum class UniquePriorityCheck : std::uint8_t {
   kUnique,
   kUnique0,
@@ -228,7 +243,7 @@ struct WaitStmt {
 };
 
 using StmtData = std::variant<
-    EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, IfStmt, CaseStmt,
+    EmptyStmt, VarDeclStmt, ExprStmt, BlockStmt, ForkStmt, IfStmt, CaseStmt,
     CaseInsideStmt, ForStmt, WhileStmt, RepeatStmt, DoWhileStmt, ForeverStmt,
     BreakStmt, ContinueStmt, ReturnStmt, TimedStmt, EventTriggerStmt, WaitStmt>;
 

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -580,11 +580,27 @@ class ProcessLoweringState {
     return std::move(body_);
   }
 
+  // FJ1 lowers each fork-join branch as a separate process whose body may touch
+  // only structural (module-scope) state. While a branch is being lowered this
+  // depth is nonzero, and a reference to a procedural variable is rejected --
+  // per-branch local storage and capture of the parent's locals ride on a later
+  // cut. A counter (not a flag) so a nested fork stays rejected correctly.
+  void EnterForkBranch() {
+    ++fork_branch_depth_;
+  }
+  void ExitForkBranch() {
+    --fork_branch_depth_;
+  }
+  [[nodiscard]] auto InForkBranch() const -> bool {
+    return fork_branch_depth_ > 0;
+  }
+
  private:
   hir::ProceduralBody body_;
   std::unordered_map<const slang::ast::VariableSymbol*, hir::ProceduralVarId>
       procedural_var_bindings_;
   const slang::ast::Symbol* containing_symbol_;
+  int fork_branch_depth_ = 0;
 };
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/mir/builtin_method.hpp
+++ b/include/lyra/mir/builtin_method.hpp
@@ -81,8 +81,8 @@ struct ArrayMethodInfo {
 };
 
 // True for methods whose backend emission must wrap the call site in
-// `co_await`. The runtime returns an awaitable that submits the appropriate
-// WaitRequest via the coroutine's promise.
+// `co_await`. The runtime returns an awaitable that suspends the calling
+// coroutine and reschedules it through RuntimeServices when the event fires.
 [[nodiscard]] inline auto IsSuspending(const EventMethodInfo& info) -> bool {
   return info.kind == EventMethodKind::kAwait;
 }

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -62,6 +62,25 @@ struct BlockStmt {
   ProceduralScopeId scope;
 };
 
+// LRM 9.3.2 Table 9-1: when the forking process resumes relative to its
+// branches.
+enum class JoinMode : std::uint8_t {
+  kAll,
+  kAny,
+  kNone,
+};
+
+// LRM 9.3.2 parallel block. Each branch is a closure (a captured callable
+// value) in the enclosing scope's expr arena, referenced here by id; the
+// backend spawns each as a concurrent process and the parent waits per `mode`.
+// Being a fork branch is what makes the closure run as a coroutine -- the
+// closure node itself carries no such property. A fork carries no nested scopes
+// of its own.
+struct ForkStmt {
+  JoinMode mode;
+  std::vector<ExprId> branches;
+};
+
 struct IfStmt {
   ExprId condition;
   ProceduralScopeId then_scope;
@@ -173,7 +192,7 @@ struct SensitivityWaitStmt {
 };
 
 using StmtData = std::variant<
-    EmptyStmt, ProceduralVarDeclStmt, ExprStmt, BlockStmt, IfStmt,
+    EmptyStmt, ProceduralVarDeclStmt, ExprStmt, BlockStmt, ForkStmt, IfStmt,
     ConstructOwnedObjectStmt, ConstructExternalUnitStmt,
     ResolveCrossUnitRefStmt, ForStmt, DelayStmt, WhileStmt, DoWhileStmt,
     BreakStmt, ContinueStmt, ReturnStmt, SensitivityWaitStmt>;

--- a/include/lyra/runtime/coroutine.hpp
+++ b/include/lyra/runtime/coroutine.hpp
@@ -2,6 +2,7 @@
 
 #include <coroutine>
 #include <exception>
+#include <functional>
 #include <utility>
 #include <vector>
 
@@ -41,6 +42,11 @@ class Coroutine {
     // (`@(a or b)`); when one fires the engine sweeps the rest to drop the
     // stale subscriptions. Per-wait state, so it lives on the frame.
     std::vector<Observable*> pending_value_change_subscriptions;
+    // Run when this frame completes, before transferring to any continuation. A
+    // spawned fork branch sets this to report completion to its join group; the
+    // callback owns whatever state it needs (a shared_ptr keeping that group
+    // alive), so the coroutine machinery never names the construct.
+    std::function<void()> on_complete;
 
     auto get_return_object() -> Coroutine {
       return Coroutine{
@@ -60,6 +66,9 @@ class Coroutine {
       static auto await_suspend(
           std::coroutine_handle<promise_type> handle) noexcept
           -> std::coroutine_handle<> {
+        if (auto& on_complete = handle.promise().on_complete) {
+          on_complete();
+        }
         std::coroutine_handle<promise_type> cont =
             handle.promise().continuation;
         if (cont) {

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -15,6 +15,7 @@
 #include "lyra/runtime/coroutine.hpp"
 #include "lyra/runtime/diagnostic.hpp"
 #include "lyra/runtime/file_table.hpp"
+#include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_services.hpp"
 #include "lyra/runtime/scope.hpp"
 #include "lyra/runtime/stream_dispatcher.hpp"
@@ -95,10 +96,14 @@ class Engine {
   // ScheduleAtTime      -- enqueue at a future SimTime (used by `#N`).
   // RequestFinish       -- tear down the simulation (used by `$finish`).
   // Now                 -- query current simulation time.
+  // Spawn               -- adopt a coroutine created mid-simulation as a
+  //                        runnable process and schedule it (used by fork-join
+  //                        branches); construct-neutral by design.
   void ScheduleNextDelta(CoroutineHandle handle);
   void ScheduleInactive(CoroutineHandle handle);
   void ScheduleAtTime(SimTime when, CoroutineHandle handle);
   void RequestFinish(int level);
+  void Spawn(Coroutine coroutine);
   [[nodiscard]] auto Now() const -> SimTime {
     return now_;
   }
@@ -180,6 +185,10 @@ class Engine {
   FileTable files_;
   RuntimeServices services_{stream_, diagnostic_, files_, *this};
   std::unique_ptr<Scope> root_;
+  // Processes created during simulation (fork-join branches), owned for their
+  // dynamic lifetime. Each is dropped in RunProcess when it completes; static
+  // processes live on their scope instead.
+  std::vector<std::unique_ptr<RuntimeProcess>> spawned_;
   SchedulerQueues queues_;
   SimTime now_ = 0;
   std::int8_t global_precision_power_ = kDefaultTimePrecisionPower;

--- a/include/lyra/runtime/fork.hpp
+++ b/include/lyra/runtime/fork.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "lyra/runtime/coroutine.hpp"
+#include "lyra/runtime/runtime_services.hpp"
+
+namespace lyra::runtime {
+
+// LRM 9.3.2 Table 9-1: which join keyword controls when the forking (parent)
+// process resumes.
+enum class JoinMode : std::uint8_t {
+  kAll,   // resume after all branches finish (`join`)
+  kAny,   // resume after the first branch finishes (`join_any`)
+  kNone,  // resume immediately, branches run concurrently (`join_none`)
+};
+
+// Shared join state for one fork. Each spawned branch (through its promise's
+// completion callback) and the parent's JoinAwaitable hold a shared_ptr to it,
+// so it frees itself once the last branch frame and the awaitable are gone.
+// Branch completion is reported here, never to the engine: the engine only ever
+// sees another coroutine to schedule.
+class ForkGroup {
+ public:
+  ForkGroup(RuntimeServices& services, std::size_t branch_count, JoinMode mode)
+      : services_(&services),
+        completions_needed_(NeededFor(branch_count, mode)) {
+  }
+
+  // join / join_any park the parent; join_none needs zero completions and so
+  // never parks.
+  [[nodiscard]] auto NeedsPark() const -> bool {
+    return completions_needed_ > 0;
+  }
+
+  void ParkParent(CoroutineHandle parent) {
+    parent_ = parent;
+    parent_parked_ = true;
+  }
+
+  // Called from a branch's completion. Decrements the outstanding count and
+  // wakes the parent once the threshold is reached.
+  void OnBranchDone() {
+    if (completions_needed_ > 0) {
+      completions_needed_ -= 1;
+    }
+    if (parent_parked_ && completions_needed_ == 0) {
+      parent_parked_ = false;
+      services_->ScheduleNextDelta(parent_);
+    }
+  }
+
+ private:
+  static auto NeededFor(std::size_t branch_count, JoinMode mode)
+      -> std::int64_t {
+    switch (mode) {
+      case JoinMode::kAll:
+        return static_cast<std::int64_t>(branch_count);
+      case JoinMode::kAny:
+        return branch_count == 0 ? 0 : 1;
+      case JoinMode::kNone:
+        return 0;
+    }
+    return 0;
+  }
+
+  RuntimeServices* services_;
+  std::int64_t completions_needed_;
+  CoroutineHandle parent_{};
+  bool parent_parked_ = false;
+};
+
+// What the parent `co_await`s after the branches are spawned. join_none reports
+// ready and runs straight through; the others park the parent on the group.
+class JoinAwaitable {
+ public:
+  explicit JoinAwaitable(std::shared_ptr<ForkGroup> group)
+      : group_(std::move(group)) {
+  }
+
+  [[nodiscard]] auto await_ready() const noexcept -> bool {
+    return !group_->NeedsPark();
+  }
+
+  void await_suspend(CoroutineHandle parent) noexcept {
+    group_->ParkParent(parent);
+  }
+
+  void await_resume() const noexcept {
+  }
+
+ private:
+  std::shared_ptr<ForkGroup> group_;
+};
+
+// Spawns each branch as its own process and returns the parent's join wait.
+// LRM 9.3.2: branches do not run until the parent blocks at the join (or, for
+// join_none, continues past it) -- that ordering falls out of the engine's
+// snapshot-drain, since a branch enqueued while the parent runs is reached only
+// on the next drain pass, after the parent has parked or moved on.
+inline auto Fork(
+    RuntimeServices& services, std::vector<Coroutine> branches, JoinMode mode)
+    -> JoinAwaitable {
+  auto group = std::make_shared<ForkGroup>(services, branches.size(), mode);
+  for (auto& branch : branches) {
+    CoroutineHandle handle = branch.Handle();
+    handle.promise().on_complete = [group] { group->OnBranchDone(); };
+    services.Spawn(std::move(branch));
+  }
+  return JoinAwaitable{group};
+}
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/process_kind.hpp
+++ b/include/lyra/runtime/process_kind.hpp
@@ -5,6 +5,9 @@ namespace lyra::runtime {
 enum class ProcessKind {
   kInitial,
   kFinal,
+  // A process brought into being during simulation (a fork-join branch), owned
+  // by the engine's dynamic pool rather than registered at startup.
+  kSpawned,
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_services.hpp
+++ b/include/lyra/runtime/runtime_services.hpp
@@ -81,6 +81,7 @@ class RuntimeServices {
   void ScheduleInactive(CoroutineHandle handle);
   void ScheduleAtTime(SimTime when, CoroutineHandle handle);
   void RequestFinish(int level);
+  void Spawn(Coroutine coroutine);
   [[nodiscard]] auto Now() const -> SimTime;
 
   // The design-global time precision (LRM 3.14.3) the delay awaitable scales a

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -400,6 +400,7 @@ auto RenderScopeHeaderFile(
   out += "#include \"lyra/runtime/delay.hpp\"\n";
   out += "#include \"lyra/runtime/file_io.hpp\"\n";
   out += "#include \"lyra/runtime/finish.hpp\"\n";
+  out += "#include \"lyra/runtime/fork.hpp\"\n";
   out += "#include \"lyra/runtime/io.hpp\"\n";
   out += "#include \"lyra/runtime/named_event.hpp\"\n";
   out += "#include \"lyra/runtime/process_kind.hpp\"\n";

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -205,7 +205,8 @@ auto LookupProceduralVarName(
     const RenderContext& ctx, const mir::ProceduralVarRef& ref) -> std::string {
   const auto& var = ctx.ProceduralScopeAtHops(ref.hops).vars.at(ref.var.value);
   if (var.lifetime == mir::VariableLifetime::kStatic) {
-    return std::format("{}.{}", ctx.StaticFrame(), var.name);
+    return std::format(
+        "{}{}.{}", ctx.MemberPrefix(), ctx.StaticFrame(), var.name);
   }
   return var.name;
 }
@@ -231,7 +232,8 @@ auto RenderStructuralVarName(
         "emit",
         diag::UnsupportedCategory::kFeature);
   }
-  return ctx.StructuralScope().GetStructuralVar(ref.var).name;
+  return ctx.MemberPrefix() +
+         ctx.StructuralScope().GetStructuralVar(ref.var).name;
 }
 
 namespace {
@@ -259,7 +261,8 @@ auto RenderStructuralVarReadExpr(
 auto RenderCrossUnitVarReadExpr(
     const RenderContext& ctx, const mir::Expr& expr,
     const mir::CrossUnitVarRef& m) -> diag::Result<std::string> {
-  const std::string slot = CrossUnitRefSlotName(m.id.value);
+  const std::string slot =
+      ctx.MemberPrefix() + CrossUnitRefSlotName(m.id.value);
   if (ctx.Unit().GetType(expr.type).IsIntegralPacked()) {
     return slot + "->Get()";
   }
@@ -940,8 +943,8 @@ auto RenderEventMethodCall(
   }
   const std::string args = (m.kind == mir::EventMethodKind::kTrigger ||
                             m.kind == mir::EventMethodKind::kTriggered)
-                               ? "Services()"
-                               : "";
+                               ? ctx.ServicesRef()
+                               : std::string{};
   const std::string raw_call = std::format(
       "({}).{}({})", *receiver_or, EventMethodMemberName(m.kind), args);
   if (mir::IsSuspending(m)) return "co_await " + raw_call;
@@ -1024,7 +1027,8 @@ auto RenderCallExpr(const RenderContext& ctx, const mir::CallExpr& call)
               if (i != 0) args += ", ";
               args += rendered;
             }
-            std::string call = std::format("{}({})", decl.name, args);
+            std::string call =
+                std::format("{}{}({})", ctx.MemberPrefix(), decl.name, args);
             // A task is a coroutine enabled with `co_await`; the only legal
             // callers are process / task bodies, which are themselves
             // coroutines (LRM 13.4 b forbids a function enabling a task).
@@ -1110,7 +1114,8 @@ auto RenderLhsExpr(
             return *name + std::string{mutate_adapter};
           },
           [&](const mir::CrossUnitVarRef& r) -> diag::Result<std::string> {
-            return "(*" + CrossUnitRefSlotName(r.id.value) + ")" +
+            return "(*" + ctx.MemberPrefix() +
+                   CrossUnitRefSlotName(r.id.value) + ")" +
                    std::string{mutate_adapter};
           },
           [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
@@ -1256,8 +1261,8 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
           "not yet implemented in cpp emit",
           diag::UnsupportedCategory::kFeature);
     }
-    return LookupProceduralVarName(ctx, *ref_root) + ".Set(Services(), " +
-           *value_or + ")";
+    return LookupProceduralVarName(ctx, *ref_root) + ".Set(" +
+           ctx.ServicesRef() + ", " + *value_or + ")";
   }
 
   const bool observable = LhsRootIsObservableScalar(ctx, lhs_expr);
@@ -1274,11 +1279,12 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
       // Procedural-local compounds operate on the underlying PackedArray
       // directly via its own `op=` overloads.
       const std::string chain =
-          observable ? *root_or + ".Mutate(Services())" : *root_or;
+          observable ? *root_or + ".Mutate(" + ctx.ServicesRef() + ")"
+                     : *root_or;
       return "(" + RenderCompoundAssign(*a.compound_op, chain, *value_or) + ")";
     }
     if (observable) {
-      return *root_or + ".Set(Services(), " + *value_or + ")";
+      return *root_or + ".Set(" + ctx.ServicesRef() + ", " + *value_or + ")";
     }
     return "(" + *root_or + " = " + *value_or + ")";
   }
@@ -1295,8 +1301,8 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
   // methods as on PackedArray; when the full expression ends, the handle's
   // destructor commits the snapshot through `Var::Set` so subscribers fire.
   // Same shape inside or outside an NBA closure body -- no nested lambda.
-  const std::string_view mutate_adapter =
-      observable ? std::string_view{".Mutate(Services())"} : std::string_view{};
+  const std::string mutate_adapter =
+      observable ? ".Mutate(" + ctx.ServicesRef() + ")" : std::string{};
   auto chain_or = RenderLhsExpr(ctx, lhs_expr, mutate_adapter);
   if (!chain_or) return std::unexpected(std::move(chain_or.error()));
   if (a.compound_op.has_value()) {
@@ -1322,11 +1328,11 @@ auto RenderIncDecExpr(const RenderContext& ctx, const mir::IncDecExpr& inc)
   if (IsLhsBarePrimary(target_expr)) {
     auto root_or = RenderLhsExpr(ctx, target_expr, std::string_view{});
     if (!root_or) return std::unexpected(std::move(root_or.error()));
-    lhs = observable ? *root_or + ".Mutate(Services())" : *root_or;
+    lhs =
+        observable ? *root_or + ".Mutate(" + ctx.ServicesRef() + ")" : *root_or;
   } else {
-    const std::string_view mutate_adapter =
-        observable ? std::string_view{".Mutate(Services())"}
-                   : std::string_view{};
+    const std::string mutate_adapter =
+        observable ? ".Mutate(" + ctx.ServicesRef() + ")" : std::string{};
     auto chain_or = RenderLhsExpr(ctx, target_expr, mutate_adapter);
     if (!chain_or) return std::unexpected(std::move(chain_or.error()));
     lhs = *std::move(chain_or);
@@ -1381,11 +1387,13 @@ auto RenderClosureExpr(
     throw InternalError("RenderClosureExpr: closure has no body");
   }
 
-  // Always capture `this` so the closure body can reach scope members (the
-  // Scope base's Services() accessor and SubmitObserved interface, plus the
-  // emitted class's structural vars). The explicit by-value captures from the
+  // Capture the receiver by value so the deferred body can reach scope members
+  // (the Scope base's Services() accessor and SubmitObserved interface, plus
+  // the emitted class's structural vars) when it later runs: `this` in a method
+  // body, or the branch's `self` pointer when the closure is nested in a
+  // fork-branch closure (LRM 9.3.2). The explicit by-value captures from the
   // MIR list go after.
-  std::string captures_text = "this";
+  std::string captures_text{ctx.ReceiverObject()};
   for (std::size_t i = 0; i < closure.captures.size(); ++i) {
     captures_text += ", ";
     auto rendered_or = std::visit(
@@ -1405,7 +1413,8 @@ auto RenderClosureExpr(
   }
 
   const RenderContext body_ctx =
-      RenderContext::ForRoot(ctx.Unit(), ctx.StructuralScope(), *closure.body);
+      RenderContext::ForRoot(ctx.Unit(), ctx.StructuralScope(), *closure.body)
+          .WithReceiver(ctx.ReceiverObject());
   auto body_or = RenderProceduralScopeStatements(body_ctx, 1);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
 

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -176,8 +176,8 @@ auto RenderRuntimePrintCall(
   // legal but a fragile spelling to depend on.
   if (call.items.empty()) {
     return std::format(
-        "{}(Services(), {}, {}std::span<const lyra::value::PrintItem>{{}})",
-        call_target, kind_literal, descriptor_arg);
+        "{}({}, {}, {}std::span<const lyra::value::PrintItem>{{}})",
+        call_target, ctx.ServicesRef(), kind_literal, descriptor_arg);
   }
 
   // The PrintItem array is built inline via `std::array<PrintItem, N>{...}`;
@@ -193,8 +193,8 @@ auto RenderRuntimePrintCall(
   }
 
   std::string out = std::format(
-      "{}(Services(), {}, {}std::array<lyra::value::PrintItem, {}>{{",
-      call_target, kind_literal, descriptor_arg, call.items.size());
+      "{}({}, {}, {}std::array<lyra::value::PrintItem, {}>{{", call_target,
+      ctx.ServicesRef(), kind_literal, descriptor_arg, call.items.size());
   for (std::size_t i = 0; i < item_inits.size(); ++i) {
     if (i != 0) {
       out += ", ";
@@ -205,10 +205,11 @@ auto RenderRuntimePrintCall(
   return out;
 }
 
-auto RenderRuntimeFinishCall(const mir::RuntimeFinishCall& call)
+auto RenderRuntimeFinishCall(
+    const RenderContext& ctx, const mir::RuntimeFinishCall& call)
     -> std::string {
   return std::format(
-      "co_await lyra::runtime::Finish(Services(), {})", call.level);
+      "co_await lyra::runtime::Finish({}, {})", ctx.ServicesRef(), call.level);
 }
 
 auto RenderRuntimeDiagnosticSeverity(mir::DiagnosticSeverity s)
@@ -244,9 +245,9 @@ auto RenderRuntimeDiagnosticCall(
 
   if (call.items.empty()) {
     return std::format(
-        "lyra::runtime::LyraDiagnostic(Services(), {}, {}, "
+        "lyra::runtime::LyraDiagnostic({}, {}, {}, "
         "std::span<const lyra::value::PrintItem>{{}})",
-        sev_literal, origin_init);
+        ctx.ServicesRef(), sev_literal, origin_init);
   }
 
   std::vector<std::string> item_inits;
@@ -258,9 +259,9 @@ auto RenderRuntimeDiagnosticCall(
   }
 
   std::string out = std::format(
-      "lyra::runtime::LyraDiagnostic(Services(), {}, {}, "
+      "lyra::runtime::LyraDiagnostic({}, {}, {}, "
       "std::array<lyra::value::PrintItem, {}>{{",
-      sev_literal, origin_init, call.items.size());
+      ctx.ServicesRef(), sev_literal, origin_init, call.items.size());
   for (std::size_t i = 0; i < item_inits.size(); ++i) {
     if (i != 0) {
       out += ", ";
@@ -286,7 +287,7 @@ auto RenderRuntimeCallExpr(
             return RenderRuntimeDiagnosticCall(ctx, dc);
           },
           [&](const mir::RuntimeFinishCall& fc) -> diag::Result<std::string> {
-            return RenderRuntimeFinishCall(fc);
+            return RenderRuntimeFinishCall(ctx, fc);
           },
           [&](const mir::RuntimeSubmitObservedCall& sc)
               -> diag::Result<std::string> {
@@ -295,7 +296,8 @@ auto RenderRuntimeCallExpr(
               return std::unexpected(std::move(closure_or.error()));
             }
             return std::format(
-                "this->SubmitObserved({}, {})", sc.site_id.value, *closure_or);
+                "{}SubmitObserved({}, {})", ctx.MemberPrefix(),
+                sc.site_id.value, *closure_or);
           },
           [&](const mir::RuntimeSubmitNbaCall& nc)
               -> diag::Result<std::string> {
@@ -303,35 +305,38 @@ auto RenderRuntimeCallExpr(
             if (!closure_or) {
               return std::unexpected(std::move(closure_or.error()));
             }
-            return std::format("Services().SubmitNba({})", *closure_or);
+            return std::format(
+                "{}.SubmitNba({})", ctx.ServicesRef(), *closure_or);
           },
           [&](const mir::RuntimeSubmitPostponedCall& pc)
               -> diag::Result<std::string> {
             // LRM 21.2.2: defer the print to the postponed region via the
             // matching $strobe-family runtime entry. The lambda captures
-            // procedural locals by value ([=, this]) -- NBAs do not touch
-            // them and the snapshot is frame-death-safe for `initial`
-            // bodies; structural signals resolve through `this->` at fire
-            // time and so see NBA-committed values. LRM 21.3.2 cancellation
-            // on $fclose is the file-sink entry's responsibility.
+            // procedural locals and the receiver by value -- NBAs do not touch
+            // the locals and the snapshot is frame-death-safe for `initial`
+            // bodies; structural signals resolve through the receiver at fire
+            // time and so see NBA-committed values. A method body captures
+            // `this` explicitly (`[=]`-capture of `this` is deprecated); a
+            // fork-branch body's `self` pointer is captured by the bare `[=]`.
+            // LRM 21.3.2 cancellation on $fclose is the file-sink entry's
+            // responsibility.
+            const std::string_view capture = ctx.DeferredByValueCapture();
             auto print_or = RenderRuntimePrintCall(ctx, pc.print);
             if (!print_or) {
               return std::unexpected(std::move(print_or.error()));
             }
             if (!pc.print.descriptor.has_value()) {
               return std::format(
-                  "lyra::runtime::LyraSubmitStrobe(Services(), "
-                  "[=, this]() {{ {}; }})",
-                  *print_or);
+                  "lyra::runtime::LyraSubmitStrobe({}, {}() {{ {}; }})",
+                  ctx.ServicesRef(), capture, *print_or);
             }
             auto desc_or = RenderExpr(ctx, ctx.Expr(*pc.print.descriptor));
             if (!desc_or) {
               return std::unexpected(std::move(desc_or.error()));
             }
             return std::format(
-                "lyra::runtime::LyraSubmitFStrobe(Services(), {}, "
-                "[=, this]() {{ {}; }})",
-                *desc_or, *print_or);
+                "lyra::runtime::LyraSubmitFStrobe({}, {}, {}() {{ {}; }})",
+                ctx.ServicesRef(), *desc_or, capture, *print_or);
           },
           [&](const mir::RuntimeFileOpenCall& fo) -> diag::Result<std::string> {
             auto name_or = RenderExpr(ctx, ctx.Expr(fo.name));
@@ -340,25 +345,26 @@ auto RenderRuntimeCallExpr(
               auto mode_or = RenderExpr(ctx, ctx.Expr(*fo.mode));
               if (!mode_or) return std::unexpected(std::move(mode_or.error()));
               return std::format(
-                  "lyra::runtime::LyraFOpen(Services(), {}, {})", *name_or,
-                  *mode_or);
+                  "lyra::runtime::LyraFOpen({}, {}, {})", ctx.ServicesRef(),
+                  *name_or, *mode_or);
             }
             return std::format(
-                "lyra::runtime::LyraFOpen(Services(), {}, std::nullopt)",
-                *name_or);
+                "lyra::runtime::LyraFOpen({}, {}, std::nullopt)",
+                ctx.ServicesRef(), *name_or);
           },
           [&](const mir::RuntimeFileCloseCall& fc)
               -> diag::Result<std::string> {
             auto desc_or = RenderExpr(ctx, ctx.Expr(fc.descriptor));
             if (!desc_or) return std::unexpected(std::move(desc_or.error()));
             return std::format(
-                "lyra::runtime::LyraFClose(Services(), {})", *desc_or);
+                "lyra::runtime::LyraFClose({}, {})", ctx.ServicesRef(),
+                *desc_or);
           },
           [&](const mir::RuntimeFileGetcCall& fg) -> diag::Result<std::string> {
             auto fd_or = RenderExpr(ctx, ctx.Expr(fg.fd));
             if (!fd_or) return std::unexpected(std::move(fd_or.error()));
             return std::format(
-                "lyra::runtime::LyraFGetc(Services(), {})", *fd_or);
+                "lyra::runtime::LyraFGetc({}, {})", ctx.ServicesRef(), *fd_or);
           },
           [&](const mir::RuntimeFileUngetcCall& fu)
               -> diag::Result<std::string> {
@@ -367,8 +373,8 @@ auto RenderRuntimeCallExpr(
             auto fd_or = RenderExpr(ctx, ctx.Expr(fu.fd));
             if (!fd_or) return std::unexpected(std::move(fd_or.error()));
             return std::format(
-                "lyra::runtime::LyraFUngetc(Services(), {}, {})", *c_or,
-                *fd_or);
+                "lyra::runtime::LyraFUngetc({}, {}, {})", ctx.ServicesRef(),
+                *c_or, *fd_or);
           },
           [&](const mir::RuntimeFileGetsCall& fg) -> diag::Result<std::string> {
             // str_dest is a procedural-local temp introduced by the
@@ -379,8 +385,8 @@ auto RenderRuntimeCallExpr(
             auto fd_or = RenderExpr(ctx, ctx.Expr(fg.fd));
             if (!fd_or) return std::unexpected(std::move(fd_or.error()));
             return std::format(
-                "lyra::runtime::LyraFGets(Services(), {}, {})", *dest_or,
-                *fd_or);
+                "lyra::runtime::LyraFGets({}, {}, {})", ctx.ServicesRef(),
+                *dest_or, *fd_or);
           },
           [&](const mir::RuntimeFileReadCall& fr) -> diag::Result<std::string> {
             auto fd_or = RenderExpr(ctx, ctx.Expr(fr.fd));
@@ -394,8 +400,8 @@ auto RenderRuntimeCallExpr(
                         return std::unexpected(std::move(dest_or.error()));
                       }
                       return std::format(
-                          "lyra::runtime::LyraFRead(Services(), {}, {})",
-                          *dest_or, *fd_or);
+                          "lyra::runtime::LyraFRead({}, {}, {})",
+                          ctx.ServicesRef(), *dest_or, *fd_or);
                     },
                     [&](const mir::RuntimeFileReadCall::UnpackedTarget& ut)
                         -> diag::Result<std::string> {
@@ -427,10 +433,10 @@ auto RenderRuntimeCallExpr(
                         return std::unexpected(std::move(count_or.error()));
                       }
                       return std::format(
-                          "lyra::runtime::LyraFRead(Services(), {}, {}, "
+                          "lyra::runtime::LyraFRead({}, {}, {}, "
                           "{}, {}, {}LL, {}LL)",
-                          *dest_or, *fd_or, *start_or, *count_or,
-                          ut.declared_left, ut.declared_right);
+                          ctx.ServicesRef(), *dest_or, *fd_or, *start_or,
+                          *count_or, ut.declared_left, ut.declared_right);
                     },
                 },
                 fr.target);
@@ -443,27 +449,28 @@ auto RenderRuntimeCallExpr(
             auto op_or = RenderExpr(ctx, ctx.Expr(fs.operation));
             if (!op_or) return std::unexpected(std::move(op_or.error()));
             return std::format(
-                "lyra::runtime::LyraFSeek(Services(), {}, {}, {})", *fd_or,
-                *off_or, *op_or);
+                "lyra::runtime::LyraFSeek({}, {}, {}, {})", ctx.ServicesRef(),
+                *fd_or, *off_or, *op_or);
           },
           [&](const mir::RuntimeFileRewindCall& fr)
               -> diag::Result<std::string> {
             auto fd_or = RenderExpr(ctx, ctx.Expr(fr.fd));
             if (!fd_or) return std::unexpected(std::move(fd_or.error()));
             return std::format(
-                "lyra::runtime::LyraFRewind(Services(), {})", *fd_or);
+                "lyra::runtime::LyraFRewind({}, {})", ctx.ServicesRef(),
+                *fd_or);
           },
           [&](const mir::RuntimeFileTellCall& ft) -> diag::Result<std::string> {
             auto fd_or = RenderExpr(ctx, ctx.Expr(ft.fd));
             if (!fd_or) return std::unexpected(std::move(fd_or.error()));
             return std::format(
-                "lyra::runtime::LyraFTell(Services(), {})", *fd_or);
+                "lyra::runtime::LyraFTell({}, {})", ctx.ServicesRef(), *fd_or);
           },
           [&](const mir::RuntimeFileEofCall& fe) -> diag::Result<std::string> {
             auto fd_or = RenderExpr(ctx, ctx.Expr(fe.fd));
             if (!fd_or) return std::unexpected(std::move(fd_or.error()));
             return std::format(
-                "lyra::runtime::LyraFEof(Services(), {})", *fd_or);
+                "lyra::runtime::LyraFEof({}, {})", ctx.ServicesRef(), *fd_or);
           },
           [&](const mir::RuntimeFileErrorCall& fe)
               -> diag::Result<std::string> {
@@ -472,19 +479,20 @@ auto RenderRuntimeCallExpr(
             auto dest_or = RenderExpr(ctx, ctx.Expr(fe.str_dest));
             if (!dest_or) return std::unexpected(std::move(dest_or.error()));
             return std::format(
-                "lyra::runtime::LyraFError(Services(), {}, {})", *fd_or,
-                *dest_or);
+                "lyra::runtime::LyraFError({}, {}, {})", ctx.ServicesRef(),
+                *fd_or, *dest_or);
           },
           [&](const mir::RuntimeFileFlushCall& ff)
               -> diag::Result<std::string> {
             if (!ff.descriptor.has_value()) {
-              return std::string(
-                  "lyra::runtime::LyraFFlush(Services(), std::nullopt)");
+              return std::format(
+                  "lyra::runtime::LyraFFlush({}, std::nullopt)",
+                  ctx.ServicesRef());
             }
             auto fd_or = RenderExpr(ctx, ctx.Expr(*ff.descriptor));
             if (!fd_or) return std::unexpected(std::move(fd_or.error()));
             return std::format(
-                "lyra::runtime::LyraFFlush(Services(), {})", *fd_or);
+                "lyra::runtime::LyraFFlush({}, {})", ctx.ServicesRef(), *fd_or);
           },
           [&](const mir::RuntimeScanCall& ss) -> diag::Result<std::string> {
             auto source_or = RenderExpr(ctx, ctx.Expr(ss.source));
@@ -514,17 +522,18 @@ auto RenderRuntimeCallExpr(
                     *format_or, slot_pieces);
               case support::ScanSourceKind::kFile:
                 return std::format(
-                    "lyra::runtime::LyraFScanf(Services(), {}, {}, {{{}}})",
-                    *source_or, *format_or, slot_pieces);
+                    "lyra::runtime::LyraFScanf({}, {}, {}, {{{}}})",
+                    ctx.ServicesRef(), *source_or, *format_or, slot_pieces);
             }
             throw InternalError(
                 "RuntimeScanCall: unknown ScanSourceKind in render");
           },
           [&](const mir::RuntimeSFormatCall& sf) -> diag::Result<std::string> {
             if (sf.items.empty()) {
-              return std::string(
-                  "lyra::runtime::LyraSFormat(Services(), "
-                  "std::span<const lyra::value::PrintItem>{})");
+              return std::format(
+                  "lyra::runtime::LyraSFormat({}, "
+                  "std::span<const lyra::value::PrintItem>{{}})",
+                  ctx.ServicesRef());
             }
             std::vector<std::string> item_pieces;
             item_pieces.reserve(sf.items.size());
@@ -543,9 +552,9 @@ auto RenderRuntimeCallExpr(
               body += item_pieces[k];
             }
             return std::format(
-                "lyra::runtime::LyraSFormat(Services(), "
+                "lyra::runtime::LyraSFormat({}, "
                 "std::array<lyra::value::PrintItem, {}>{{{{{}}}}})",
-                sf.items.size(), body);
+                ctx.ServicesRef(), sf.items.size(), body);
           },
           [&](const mir::RuntimeTimeCall& tc) -> diag::Result<std::string> {
             // The scaling target is the enclosing scope's time unit, read
@@ -555,23 +564,24 @@ auto RenderRuntimeCallExpr(
             // engine's design-global tick.
             switch (tc.kind) {
               case support::TimeKind::kTime:
-                return std::string(
-                    "lyra::runtime::SimTimeInUnit(Services(), "
-                    "kTimeUnitPower)");
+                return std::format(
+                    "lyra::runtime::SimTimeInUnit({}, kTimeUnitPower)",
+                    ctx.ServicesRef());
               case support::TimeKind::kStime:
-                return std::string(
-                    "lyra::runtime::STimeInUnit(Services(), kTimeUnitPower)");
+                return std::format(
+                    "lyra::runtime::STimeInUnit({}, kTimeUnitPower)",
+                    ctx.ServicesRef());
               case support::TimeKind::kRealtime:
-                return std::string(
-                    "lyra::runtime::RealTimeInUnit(Services(), "
-                    "kTimeUnitPower)");
+                return std::format(
+                    "lyra::runtime::RealTimeInUnit({}, kTimeUnitPower)",
+                    ctx.ServicesRef());
             }
             throw InternalError("RenderRuntimeCallExpr: unknown TimeKind");
           },
           [&](const mir::RuntimeSetTimeFormatCall& tf)
               -> diag::Result<std::string> {
             if (!tf.args.has_value()) {
-              return std::string("Services().ResetTimeFormat()");
+              return ctx.ServicesRef() + ".ResetTimeFormat()";
             }
             auto units = RenderExpr(ctx, ctx.Expr(tf.args->units));
             if (!units) return std::unexpected(std::move(units.error()));
@@ -584,17 +594,17 @@ auto RenderRuntimeCallExpr(
             auto width = RenderExpr(ctx, ctx.Expr(tf.args->min_width));
             if (!width) return std::unexpected(std::move(width.error()));
             return std::format(
-                "Services().SetTimeFormat({}, {}, {}, {})", *units, *precision,
-                *suffix, *width);
+                "{}.SetTimeFormat({}, {}, {}, {})", ctx.ServicesRef(), *units,
+                *precision, *suffix, *width);
           },
           [&](const mir::RuntimePrintTimescaleCall& pt)
               -> diag::Result<std::string> {
             // Unit and precision come from the enclosing scope class constants
             // (LRM 20.4.2, current-scope form); the name is baked at lowering.
             return std::format(
-                "lyra::runtime::LyraPrintTimescale(Services(), {}, "
+                "lyra::runtime::LyraPrintTimescale({}, {}, "
                 "kTimeUnitPower, kTimePrecisionPower)",
-                RenderCStringLiteral(pt.scope_name));
+                ctx.ServicesRef(), RenderCStringLiteral(pt.scope_name));
           },
       },
       expr.call);

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -5,6 +5,7 @@
 #include <string_view>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "lyra/backend/cpp/formatting.hpp"
 #include "lyra/backend/cpp/render_context.hpp"
@@ -96,6 +97,60 @@ auto RenderBlockStmtNode(
   return result;
 }
 
+auto RenderForkJoinModeLiteral(mir::JoinMode mode) -> std::string_view {
+  switch (mode) {
+    case mir::JoinMode::kAll:
+      return "lyra::runtime::JoinMode::kAll";
+    case mir::JoinMode::kAny:
+      return "lyra::runtime::JoinMode::kAny";
+    case mir::JoinMode::kNone:
+      return "lyra::runtime::JoinMode::kNone";
+  }
+  return "lyra::runtime::JoinMode::kAll";
+}
+
+// LRM 9.3.2: each branch is an anonymous ClosureExpr spawned as a concurrent
+// coroutine. It renders inline at the fork as a stateless lambda taking the
+// enclosing scope instance as a by-value `self` parameter -- a parameter is
+// frame-copied, so the spawned coroutine never outlives a captured receiver the
+// way a `[this]` capture would -- through which its body reaches module state
+// and Services(). The fork waits per the join mode.
+auto RenderForkStmtNode(
+    const RenderContext& ctx, const mir::ForkStmt& s, std::size_t indent)
+    -> diag::Result<std::string> {
+  const std::string vec = ctx.AllocateTemp("fork_branches");
+  const std::string& class_name = ctx.StructuralScope().name;
+  const std::string receiver_object{ctx.ReceiverObject()};
+  std::string out = Indent(indent) + "{\n";
+  out += Indent(indent + 1) + "std::vector<lyra::runtime::Coroutine> " + vec +
+         ";\n";
+  for (const auto branch : s.branches) {
+    const auto* closure = std::get_if<mir::ClosureExpr>(&ctx.Expr(branch).data);
+    if (closure == nullptr) {
+      throw InternalError("RenderForkStmtNode: fork branch is not a closure");
+    }
+    if (closure->body == nullptr) {
+      throw InternalError(
+          "RenderForkStmtNode: fork branch closure has no body");
+    }
+    const RenderContext branch_ctx = ctx.WithProceduralScope(*closure->body)
+                                         .WithCoroutine(true)
+                                         .WithReceiver("self");
+    auto body_or = RenderProceduralScopeStatements(branch_ctx, indent + 2);
+    if (!body_or) return std::unexpected(std::move(body_or.error()));
+    out += Indent(indent + 1) + vec + ".push_back([](" + class_name +
+           "* self) -> lyra::runtime::Coroutine {\n";
+    out += *body_or;
+    out += Indent(indent + 2) + "co_return;\n";
+    out += Indent(indent + 1) + "}(" + receiver_object + "));\n";
+  }
+  out += Indent(indent + 1) + "co_await lyra::runtime::Fork(" +
+         ctx.ServicesRef() + ", std::move(" + vec + "), " +
+         std::string(RenderForkJoinModeLiteral(s.mode)) + ");\n";
+  out += Indent(indent) + "}\n";
+  return out;
+}
+
 auto RenderIfStmtNode(
     const RenderContext& ctx, const mir::Stmt& stmt, const mir::IfStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
@@ -138,10 +193,12 @@ auto RenderConstructOwnedObjectStmt(
                            ">(this, \"" + target_scope.name + "\"" +
                            trailing_args + ")";
   if (mir::IsVectorOfOwningObjectType(ctx.Unit(), var.type)) {
-    return Indent(indent) + var.name + ".push_back(" + make + ");\n";
+    return Indent(indent) + ctx.MemberPrefix() + var.name + ".push_back(" +
+           make + ");\n";
   }
   if (mir::IsOwningObjectType(ctx.Unit(), var.type)) {
-    return Indent(indent) + var.name + " = " + make + ";\n";
+    return Indent(indent) + ctx.MemberPrefix() + var.name + " = " + make +
+           ";\n";
   }
   throw InternalError(
       "ConstructOwnedObjectStmt target is not an owning object var");
@@ -180,7 +237,8 @@ auto RenderConstructExternalUnitStmt(
     std::size_t indent) -> diag::Result<std::string> {
   const auto& var = ctx.StructuralScope().GetStructuralVar(s.target);
   return RenderExternalUnitFill(
-      ctx, var.name, var.type, s.unit_name, var.name, s.dims, 0, indent);
+      ctx, ctx.MemberPrefix() + var.name, var.type, s.unit_name, var.name,
+      s.dims, 0, indent);
 }
 
 // Points the slot at the leaf member it references, once the subtree exists.
@@ -193,8 +251,9 @@ auto RenderResolveCrossUnitRefStmt(
     std::size_t indent) -> diag::Result<std::string> {
   const auto& slot = ctx.StructuralScope().GetCrossUnitRef(s.slot);
   const auto& inst = ctx.StructuralScope().GetStructuralVar(slot.instance_var);
-  std::string out =
-      Indent(indent) + CrossUnitRefSlotName(s.slot.value) + " = &" + inst.name;
+  std::string out = Indent(indent) + ctx.MemberPrefix() +
+                    CrossUnitRefSlotName(s.slot.value) + " = &" +
+                    ctx.MemberPrefix() + inst.name;
   for (const auto& step : slot.path) {
     if (const auto* member = std::get_if<mir::MemberHop>(&step)) {
       out += "->" + member->name;
@@ -286,7 +345,7 @@ auto RenderSensitivityRefPtr(
             return "&" + *name;
           },
           [&](const mir::CrossUnitVarRef& r) -> diag::Result<std::string> {
-            return CrossUnitRefSlotName(r.id.value);
+            return ctx.MemberPrefix() + CrossUnitRefSlotName(r.id.value);
           },
       },
       ref);
@@ -328,9 +387,9 @@ auto RenderStmt(
             return Indent(indent) + ";\n";
           },
           [&](const mir::DelayStmt& s) -> diag::Result<std::string> {
-            return Indent(indent) +
-                   "co_await lyra::runtime::Delay(Services(), " +
-                   std::to_string(s.duration) + ", kTimePrecisionPower);\n";
+            return Indent(indent) + "co_await lyra::runtime::Delay(" +
+                   ctx.ServicesRef() + ", " + std::to_string(s.duration) +
+                   ", kTimePrecisionPower);\n";
           },
           [&](const mir::ProceduralVarDeclStmt& s)
               -> diag::Result<std::string> {
@@ -341,6 +400,9 @@ auto RenderStmt(
           },
           [&](const mir::BlockStmt& s) -> diag::Result<std::string> {
             return RenderBlockStmtNode(ctx, stmt, s, indent);
+          },
+          [&](const mir::ForkStmt& s) -> diag::Result<std::string> {
+            return RenderForkStmtNode(ctx, s, indent);
           },
           [&](const mir::IfStmt& s) -> diag::Result<std::string> {
             return RenderIfStmtNode(ctx, stmt, s, indent);

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -150,6 +150,12 @@ constexpr std::array kEntries{
             .kind = DiagKind::kUnsupported,
             .category = UnsupportedCategory::kFeature,
             .name = "unsupported_subroutine_argument"}},
+    std::pair{
+        DiagCode::kUnsupportedForkJoinForm,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .category = UnsupportedCategory::kFeature,
+            .name = "unsupported_fork_join_form"}},
 
     std::pair{
         DiagCode::kDelayValueOutOfRange,

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -34,6 +34,18 @@ namespace lyra::hir {
 
 namespace {
 
+auto ForkJoinModeLabel(JoinMode mode) -> std::string_view {
+  switch (mode) {
+    case JoinMode::kAll:
+      return "join";
+    case JoinMode::kAny:
+      return "join_any";
+    case JoinMode::kNone:
+      return "join_none";
+  }
+  return "join";
+}
+
 class HirDumper {
  public:
   auto Dump(const std::vector<ModuleUnit>& units) -> std::string {
@@ -1065,6 +1077,18 @@ class HirDumper {
     Dedent();
   }
 
+  void DumpForkStmtNode(const ProceduralBody& p, StmtId id, const ForkStmt& f) {
+    Line(
+        std::format(
+            "Stmt[{}] ForkStmt {} (branches={})", id.value,
+            ForkJoinModeLabel(f.mode), f.branches.size()));
+    Indent();
+    for (const auto branch : f.branches) {
+      DumpStmt(p, branch);
+    }
+    Dedent();
+  }
+
   void DumpIfStmtNode(const ProceduralBody& p, StmtId id, const IfStmt& i) {
     Line(
         std::format(
@@ -1331,6 +1355,7 @@ class HirDumper {
             [&](const VarDeclStmt& v) { DumpVarDeclStmtNode(p, id, v); },
             [&](const ExprStmt& e) { DumpExprStmtNode(p, id, e); },
             [&](const BlockStmt& b) { DumpBlockStmtNode(p, id, b); },
+            [&](const ForkStmt& f) { DumpForkStmtNode(p, id, f); },
             [&](const IfStmt& i) { DumpIfStmtNode(p, id, i); },
             [&](const CaseStmt& c) { DumpCaseStmtNode(p, id, c); },
             [&](const CaseInsideStmt& c) { DumpCaseInsideStmtNode(p, id, c); },

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -271,6 +271,13 @@ auto LowerNamedValueProc(
   const auto& var = sym.as<slang::ast::VariableSymbol>();
 
   if (auto local = proc_state.LookupProceduralVar(var)) {
+    if (proc_state.InForkBranch()) {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedForkJoinForm,
+          "a fork-join branch referencing a procedural variable is not yet "
+          "supported; branches may touch only module-scope signals",
+          diag::UnsupportedCategory::kFeature);
+    }
     const hir::TypeId type_id = proc_state.GetProceduralVarType(*local);
     return MakeRefExpr(hir::ProceduralVarRef{.var = *local}, type_id, span);
   }

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -259,11 +259,86 @@ auto LowerStatementListStmt(
       .span = span};
 }
 
+// LRM 9.3.2 parallel block. Each parallel statement becomes one branch. FJ1
+// covers branches that touch only module-scope state; forms that need
+// procedural state or a hierarchy name, and forks inside a function, are
+// rejected here rather than miscompiled.
+auto LowerForkStmt(
+    const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
+    ScopeLoweringState& scope_state, ScopeStack& stack,
+    const slang::ast::BlockStatement& block, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  // A function body is not a coroutine and cannot suspend, so it cannot spawn a
+  // branch (LRM 13.4). A task body is a coroutine and is supported.
+  if (proc_state.ContainingSymbol().kind ==
+          slang::ast::SymbolKind::Subroutine &&
+      proc_state.ContainingSymbol()
+              .as<slang::ast::SubroutineSymbol>()
+              .subroutineKind == slang::ast::SubroutineKind::Function) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedForkJoinForm,
+        "a fork-join block inside a function is not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  if (block.blockSymbol != nullptr && !block.blockSymbol->name.empty()) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedForkJoinForm,
+        "a named fork-join block is not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+
+  hir::JoinMode mode = hir::JoinMode::kAll;
+  switch (block.blockKind) {
+    case slang::ast::StatementBlockKind::JoinAll:
+      mode = hir::JoinMode::kAll;
+      break;
+    case slang::ast::StatementBlockKind::JoinAny:
+      mode = hir::JoinMode::kAny;
+      break;
+    case slang::ast::StatementBlockKind::JoinNone:
+      mode = hir::JoinMode::kNone;
+      break;
+    case slang::ast::StatementBlockKind::Sequential:
+      throw InternalError("LowerForkStmt: called on a sequential block");
+  }
+
+  std::vector<const slang::ast::Statement*> branch_stmts;
+  if (block.body.kind == slang::ast::StatementKind::List) {
+    const auto& list = block.body.as<slang::ast::StatementList>();
+    branch_stmts.assign(list.list.begin(), list.list.end());
+  } else {
+    branch_stmts.push_back(&block.body);
+  }
+
+  std::vector<hir::StmtId> branches;
+  branches.reserve(branch_stmts.size());
+  proc_state.EnterForkBranch();
+  for (const auto* child : branch_stmts) {
+    auto child_stmt =
+        LowerStatement(unit_facts, proc_state, scope_state, stack, *child);
+    if (!child_stmt) {
+      proc_state.ExitForkBranch();
+      return std::unexpected(std::move(child_stmt.error()));
+    }
+    branches.push_back(proc_state.AddStmt(*std::move(child_stmt)));
+  }
+  proc_state.ExitForkBranch();
+
+  return hir::Stmt{
+      .label = std::nullopt,
+      .data = hir::ForkStmt{.mode = mode, .branches = std::move(branches)},
+      .span = span};
+}
+
 auto LowerBlockStmt(
     const UnitLoweringFacts& unit_facts, ProcessLoweringState& proc_state,
     ScopeLoweringState& scope_state, ScopeStack& stack,
     const slang::ast::BlockStatement& block, diag::SourceSpan span)
     -> diag::Result<hir::Stmt> {
+  if (block.blockKind != slang::ast::StatementBlockKind::Sequential) {
+    return LowerForkStmt(
+        unit_facts, proc_state, scope_state, stack, block, span);
+  }
   std::vector<hir::StmtId> kids;
   if (block.body.kind == slang::ast::StatementKind::List) {
     const auto& list = block.body.as<slang::ast::StatementList>();

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -637,6 +637,64 @@ auto LowerBlockStmt(
       .child_procedural_scopes = std::move(child_scopes)};
 }
 
+auto LowerJoinMode(hir::JoinMode mode) -> mir::JoinMode {
+  switch (mode) {
+    case hir::JoinMode::kAll:
+      return mir::JoinMode::kAll;
+    case hir::JoinMode::kAny:
+      return mir::JoinMode::kAny;
+    case hir::JoinMode::kNone:
+      return mir::JoinMode::kNone;
+  }
+  return mir::JoinMode::kAll;
+}
+
+// LRM 9.3.2: each parallel statement becomes a concurrent process. Each branch
+// lowers to a closure -- a captured callable value with (for FJ1) an empty
+// capture list -- composed into the enclosing scope's expr arena, exactly as
+// the NBA deferred-write closure is composed. The ForkStmt then references the
+// branch closures by id; it owns no nested scopes. The closure runs as a
+// coroutine by virtue of being a fork branch (spawned), not by any property of
+// the closure node.
+auto LowerForkStmt(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state,
+    const hir::ProceduralBody& hir_proc, const hir::Stmt& stmt,
+    const hir::ForkStmt& f) -> diag::Result<mir::Stmt> {
+  std::vector<mir::ExprId> branch_ids;
+  branch_ids.reserve(f.branches.size());
+  for (const hir::StmtId branch_hir_id : f.branches) {
+    const hir::Stmt& branch = hir_proc.stmts.at(branch_hir_id.value);
+    ProceduralScopeLoweringState branch_scope_state;
+    ProceduralDepthGuard depth_guard{proc_state};
+    auto lowered = LowerStmt(
+        unit_state, scope_state, proc_state, branch_scope_state, hir_proc,
+        branch);
+    if (!lowered) {
+      return std::unexpected(std::move(lowered.error()));
+    }
+    const mir::StmtId branch_stmt_id =
+        branch_scope_state.AddStmt(*std::move(lowered));
+    branch_scope_state.AddRootStmt(branch_stmt_id);
+
+    mir::ClosureExpr closure;
+    closure.body =
+        std::make_unique<mir::ProceduralScope>(branch_scope_state.Finish());
+    branch_ids.push_back(proc_scope_state.AddExpr(
+        mir::Expr{
+            .data = std::move(closure),
+            .type = unit_state.Builtins().void_type}));
+  }
+  return mir::Stmt{
+      .label = stmt.label,
+      .data =
+          mir::ForkStmt{
+              .mode = LowerJoinMode(f.mode), .branches = std::move(branch_ids)},
+      .child_procedural_scopes = {}};
+}
+
 auto LowerIfStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
@@ -1696,6 +1754,11 @@ auto LowerStmt(
           [&](const hir::BlockStmt& b) {
             return LowerBlockStmt(
                 unit_state, scope_state, proc_state, hir_proc, stmt, b);
+          },
+          [&](const hir::ForkStmt& f) {
+            return LowerForkStmt(
+                unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
+                stmt, f);
           },
           [&](const hir::IfStmt& i) {
             return LowerIfStmt(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -1011,6 +1011,7 @@ class MirDumper {
             },
             [&](const ExprStmt& s) { DumpExprStmt(s, enclosing, id); },
             [&](const BlockStmt& s) { DumpBlockStmt(stmt, s, id); },
+            [&](const ForkStmt& s) { DumpForkStmt(s, id); },
             [&](const IfStmt& s) { DumpIfStmt(stmt, s, enclosing, id); },
             [&](const ConstructOwnedObjectStmt& s) {
               DumpConstructOwnedObjectStmt(id, s);
@@ -1242,6 +1243,18 @@ class MirDumper {
     throw InternalError("FormatMirDiagnosticSeverity: unknown severity");
   }
 
+  static auto ForkJoinModeLabel(JoinMode mode) -> std::string_view {
+    switch (mode) {
+      case JoinMode::kAll:
+        return "join";
+      case JoinMode::kAny:
+        return "join_any";
+      case JoinMode::kNone:
+        return "join_none";
+    }
+    throw InternalError("ForkJoinModeLabel: unknown JoinMode");
+  }
+
   static auto DumpPrintKindLabel(value::PrintKind k) -> std::string_view {
     switch (k) {
       case value::PrintKind::kDisplay:
@@ -1374,6 +1387,18 @@ class MirDumper {
             s.scope.value));
     Indent();
     DumpProceduralScope(parent.child_procedural_scopes.at(s.scope.value));
+    Dedent();
+  }
+
+  void DumpForkStmt(const ForkStmt& s, StmtId id) {
+    Line(
+        std::format(
+            "Stmt[{}] ForkStmt {} (branches={})", id.value,
+            ForkJoinModeLabel(s.mode), s.branches.size()));
+    Indent();
+    for (const auto branch : s.branches) {
+      Line(std::format("branch=Expr[{}]", branch.value));
+    }
     Dedent();
   }
 

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -109,6 +109,10 @@ void Engine::RegisterProcesses() {
         case ProcessKind::kFinal:
           queues_.finals.push_back(process.TopHandle());
           break;
+        case ProcessKind::kSpawned:
+          throw InternalError(
+              "Engine::RegisterProcesses: a spawned process must not appear in "
+              "static scope registration");
       }
     });
   });
@@ -289,11 +293,20 @@ void Engine::RunProcess(CoroutineHandle handle) {
         "Engine::RunProcess: process resumed outside runnable phase");
   }
   // No wait dispatch: each awaitable has already arranged its own wakeup path
-  // during await_suspend. The engine only observes "process completed or still
-  // suspended" and acts accordingly. Capture the owning process before
-  // resuming, since `handle` may be an enabled task's frame that is destroyed
-  // as control returns up the enable chain.
-  handle.promise().Process().ResumeWith(handle);
+  // during await_suspend. Capture the owning process before resuming, since
+  // `handle` may be an enabled task's frame that is destroyed as control
+  // returns up the enable chain.
+  RuntimeProcess& process = handle.promise().Process();
+  const bool completed = process.ResumeWith(handle);
+  // A spawned process (a fork-join branch) is owned by the engine for its
+  // dynamic lifetime; drop it the moment it finishes -- executor-standard
+  // drop-on-completion, co-located with the resume that completed it. Static
+  // processes are owned by their scope and outlive the simulation.
+  if (completed && process.Kind() == ProcessKind::kSpawned) {
+    std::erase_if(spawned_, [&](const std::unique_ptr<RuntimeProcess>& p) {
+      return p.get() == &process;
+    });
+  }
 }
 
 void Engine::RequestFinish(int) {  // NOLINT(readability-named-parameter)
@@ -332,6 +345,14 @@ void Engine::ScheduleNextDelta(CoroutineHandle handle) {
 
 void Engine::ScheduleAtTime(SimTime when, CoroutineHandle handle) {
   queues_.delayed[when].push_back(handle);
+}
+
+void Engine::Spawn(Coroutine coroutine) {
+  auto process = std::make_unique<RuntimeProcess>(
+      ProcessKind::kSpawned, std::move(coroutine));
+  const CoroutineHandle handle = process->TopHandle();
+  spawned_.push_back(std::move(process));
+  ScheduleActive(handle);
 }
 
 auto Engine::CheckedAdd(SimTime base, SimDuration delta) -> SimTime {

--- a/src/lyra/runtime/runtime_services.cpp
+++ b/src/lyra/runtime/runtime_services.cpp
@@ -62,6 +62,13 @@ void RuntimeServices::RequestFinish(int level) {
   engine_->RequestFinish(level);
 }
 
+void RuntimeServices::Spawn(Coroutine coroutine) {
+  if (engine_ == nullptr) {
+    throw InternalError("RuntimeServices::Spawn: no Engine bound");
+  }
+  engine_->Spawn(std::move(coroutine));
+}
+
 auto RuntimeServices::Now() const -> SimTime {
   if (engine_ == nullptr) {
     throw InternalError("RuntimeServices::Now: no Engine bound");

--- a/tests/cases/cpp/fork_branch_deferred_effects/case.yaml
+++ b/tests/cases/cpp/fork_branch_deferred_effects/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.fork_branch_deferred_effects
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      [0] strobe a=5
+      [10] after join a=9

--- a/tests/cases/cpp/fork_branch_deferred_effects/main.sv
+++ b/tests/cases/cpp/fork_branch_deferred_effects/main.sv
@@ -1,0 +1,14 @@
+`timescale 1ns / 1ns
+module Test;
+  int a;
+  initial begin
+    fork
+      begin
+        a <= 5;
+        $strobe("[%0d] strobe a=%0d", $time, a);
+      end
+      #10 a = 9;
+    join
+    $display("[%0d] after join a=%0d", $time, a);
+  end
+endmodule

--- a/tests/cases/cpp/fork_join/case.yaml
+++ b/tests/cases/cpp/fork_join/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.fork_join
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      [10] branch A
+      [20] branch B
+      [20] after join

--- a/tests/cases/cpp/fork_join/main.sv
+++ b/tests/cases/cpp/fork_join/main.sv
@@ -1,0 +1,10 @@
+`timescale 1ns / 1ns
+module Test;
+  initial begin
+    fork
+      #10 $display("[%0d] branch A", $time);
+      #20 $display("[%0d] branch B", $time);
+    join
+    $display("[%0d] after join", $time);
+  end
+endmodule

--- a/tests/cases/cpp/fork_join_any/case.yaml
+++ b/tests/cases/cpp/fork_join_any/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.fork_join_any
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      [10] branch A
+      [10] after join_any
+      [20] branch B

--- a/tests/cases/cpp/fork_join_any/main.sv
+++ b/tests/cases/cpp/fork_join_any/main.sv
@@ -1,0 +1,10 @@
+`timescale 1ns / 1ns
+module Test;
+  initial begin
+    fork
+      #10 $display("[%0d] branch A", $time);
+      #20 $display("[%0d] branch B", $time);
+    join_any
+    $display("[%0d] after join_any", $time);
+  end
+endmodule

--- a/tests/cases/cpp/fork_join_in_task/case.yaml
+++ b/tests/cases/cpp/fork_join_in_task/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.fork_join_in_task
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      [10] branch A
+      [20] branch B
+      [20] after task

--- a/tests/cases/cpp/fork_join_in_task/main.sv
+++ b/tests/cases/cpp/fork_join_in_task/main.sv
@@ -1,0 +1,14 @@
+`timescale 1ns / 1ns
+module Test;
+  task run_branches();
+    fork
+      #10 $display("[%0d] branch A", $time);
+      #20 $display("[%0d] branch B", $time);
+    join
+  endtask
+
+  initial begin
+    run_branches();
+    $display("[%0d] after task", $time);
+  end
+endmodule

--- a/tests/cases/cpp/fork_join_none/case.yaml
+++ b/tests/cases/cpp/fork_join_none/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.fork_join_none
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      [0] after join_none
+      [10] branch A

--- a/tests/cases/cpp/fork_join_none/main.sv
+++ b/tests/cases/cpp/fork_join_none/main.sv
@@ -1,0 +1,9 @@
+`timescale 1ns / 1ns
+module Test;
+  initial begin
+    fork
+      #10 $display("[%0d] branch A", $time);
+    join_none
+    $display("[%0d] after join_none", $time);
+  end
+endmodule

--- a/tests/cases/errors/fork_branch_procedural_local/case.yaml
+++ b/tests/cases/errors/fork_branch_procedural_local/case.yaml
@@ -1,0 +1,16 @@
+id: errors.fork_branch_procedural_local
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "fork-join branch referencing a procedural variable"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/fork_branch_procedural_local/main.sv
+++ b/tests/cases/errors/fork_branch_procedural_local/main.sv
@@ -1,0 +1,9 @@
+`timescale 1ns / 1ns
+module Test;
+  initial begin
+    int x = 5;
+    fork
+      #10 $display("%0d", x);
+    join
+  end
+endmodule

--- a/tests/cases/errors/fork_in_function/case.yaml
+++ b/tests/cases/errors/fork_in_function/case.yaml
@@ -1,0 +1,16 @@
+id: errors.fork_in_function
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "fork-join block inside a function"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/fork_in_function/main.sv
+++ b/tests/cases/errors/fork_in_function/main.sv
@@ -1,0 +1,9 @@
+module Test;
+  int x;
+  function void f();
+    fork
+      x = 1;
+    join_none
+  endfunction
+  initial f();
+endmodule


### PR DESCRIPTION
## Summary

Implements `fork ... join` / `join_any` / `join_none` (LRM 9.3.2, FJ1): a fork spawns each parallel statement as its own concurrent coroutine and the join keyword sets when the forking process resumes -- after all branches (`join`), after the first (`join_any`), or immediately (`join_none`). Spawned processes do not run until the parent blocks at the join or terminates, per the LRM 9.3.2 ordering rule. Branches read and write module-scope signals (including non-blocking assignments and `$strobe`); referencing a procedural variable, and a named fork block, are rejected with a diagnostic. A fork inside a task is supported; a fork inside a function stays rejected because a function cannot suspend.

## Design

A fork branch is modelled as an anonymous `mir::ClosureExpr` referenced by `mir::ForkStmt`. The C++ backend realizes each branch inline at the fork site as a stateless coroutine lambda that takes the enclosing scope instance as a by-value `self` parameter -- a parameter is frame-copied into the coroutine frame, so the spawned coroutine never outlives a captured receiver the way a `[this]` capture would. This keeps the emitted code structurally one-to-one with the source: an anonymous in-place branch maps to an anonymous in-place closure, with no hoisting to a named method.

Because a branch body has no implicit `this`, the backend now names its scope receiver explicitly everywhere. Every scope-member access (signals, `Services()`, member subroutine calls, deferred-effect closures, static-frame locals, cross-unit references, and constructor construct-statements) routes through a single receiver prefix on the render context -- `this->` in a method body, `self->` in a branch closure. A process body and a branch body therefore render identically up to the receiver name. Behaviour is unchanged (`this->x` is `x`); the join count latch and the engine's spawned-process pool back the runtime semantics.

## Testing

`fork_join`, `fork_join_any`, `fork_join_none`, `fork_join_in_task`, and `fork_branch_deferred_effects` (NBA + `$strobe` inside a branch) run end-to-end; `fork_in_function` and `fork_branch_procedural_local` cover the rejections. Full `bazel test //...` is green.