### PR TITLE
Resolve upward hierarchical references by self-climb extern members

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -24,10 +24,12 @@ Read top to bottom on first pass:
 10. `hierarchy_and_generate.md` -- hierarchy and generate ownership
 11. `reference_resolution.md` -- intra-unit vs cross-unit references; compile-time vs
     construction-time resolution
-12. `identity_and_ownership.md` -- identity rules and forbidden shapes
-13. `lowering_boundaries.md` -- what each lowering may and may not do
-14. `incremental_build.md` -- query-based incremental compilation and caching
-15. `testing_strategy.md` -- test categories and structure
+12. `emission_model.md` -- how a backend emits independent per-unit artifacts and realizes
+    cross-unit resolution through the SDK
+13. `identity_and_ownership.md` -- identity rules and forbidden shapes
+14. `lowering_boundaries.md` -- what each lowering may and may not do
+15. `incremental_build.md` -- query-based incremental compilation and caching
+16. `testing_strategy.md` -- test categories and structure
 
 ## Concept Index
 
@@ -43,6 +45,7 @@ If you are looking for a concept, this table points to the canonical doc.
 | Generate as constructor-time logic; object graph shape                    | `hierarchy_and_generate.md` |
 | Instance array as a data type; multiplicity vs generate axes              | `hierarchy_and_generate.md` |
 | Intra-unit vs cross-unit references; compile-time vs construction resolve | `reference_resolution.md`   |
+| Per-unit artifact emission; cross-unit realization via the SDK; no wiring | `emission_model.md`         |
 | Parameter values, specialization keys, per-specialization artifacts       | `specialization_model.md`   |
 | Identity rules; ownership; forbidden identity shapes                      | `identity_and_ownership.md` |
 | Lowering permissions (what each lowering may and may not do)              | `lowering_boundaries.md`    |
@@ -54,6 +57,25 @@ If you are looking for a concept, this table points to the canonical doc.
 | Incremental compilation; query-based caching                              | `incremental_build.md`      |
 | Locating/bundling the C++ runtime; run output contract                    | `runtime_distribution.md`   |
 | Test categories; suite layout; expectation forms                          | `testing_strategy.md`       |
+
+## Required Reading by Decision
+
+Before designing a change, **read `north_star.md` first -- always**. Then read the docs that govern
+the decision's subject, top to bottom, and **check the design against every relevant doc's
+"Forbidden Shapes" before proposing it**. A design that matches a Forbidden Shape is wrong even if
+it compiles and passes tests.
+
+| Decision touches...                                          | Binding docs (read all, top-down)                                                                        |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Cross-unit access / hierarchical refs / ports / connectivity | `north_star`, `compilation_unit_model`, `reference_resolution`, `emission_model`                         |
+| Backend emit / artifact structure / SDK boundary             | `north_star`, `compilation_unit_model`, `reference_resolution`, `emission_model`, `runtime_distribution` |
+| Compilation boundaries / unit dependencies / incrementality  | `north_star`, `compilation_unit_model`, `incremental_build`                                              |
+| Hierarchy / generate / object graph / construction           | `north_star`, `hierarchy_and_generate`, `runtime_model`                                                  |
+| Identity / ownership / id kinds                              | `north_star`, `identity_and_ownership`                                                                   |
+
+The failure mode this guards against: anchoring on current code -- which may be a transitional
+shortcut -- instead of the contract. Current code that contradicts a contract is wrong; read the
+contract, not the code, for design direction.
 
 ## Document Shape
 

--- a/docs/architecture/emission_model.md
+++ b/docs/architecture/emission_model.md
@@ -1,0 +1,125 @@
+# Emission Model
+
+## Purpose
+
+Define how a backend turns per-unit MIR into runnable artifacts while preserving the independent,
+parallel compilation that `north_star.md` requires. This doc owns the **emit-side realization** of
+the compilation-unit boundary and of cross-unit reference resolution: what one unit's emitted
+artifact may depend on, how cross-unit access is expressed without breaking unit independence, and
+what role the runtime SDK plays as the link-time-resolution substrate. It is the missing layer
+between the principle in `reference_resolution.md` (a cross-unit reference resolves at construction,
+not at the referrer's compile time) and the backend code that must obey it.
+
+The C++ backend exists today; an LLVM backend is the eventual target. The rules here are stated for
+any backend. Where the current C++ backend takes a transitional shortcut, that is noted as
+non-conforming code, not as a relaxation of the contract.
+
+## Owns
+
+- The rule that a backend emits one artifact per compilation-unit specialization, and that the
+  program is assembled by linking those artifacts -- never by a single artifact that aggregates many
+  units.
+- The set of inputs one unit's emission may depend on: its own MIR, the interfaces of the units it
+  instantiates, and the runtime SDK.
+- The contract that a cross-unit reference is realized at construction through the SDK / object
+  graph, and that the referrer's emitted artifact never embeds another unit's storage layout and
+  never names a unit it does not instantiate.
+- The role of the runtime SDK as the substrate that stands in for link-time symbol resolution and
+  (under LLVM) intrinsics.
+
+## Does Not Own
+
+- Where the runtime library lives and how a binary locates it (see `runtime_distribution.md`).
+- The compilation-unit boundary itself and what an interface is (see `compilation_unit_model.md`).
+- When and into what a cross-unit reference resolves, semantically (see `reference_resolution.md`);
+  this doc owns only how a backend _realizes_ that resolution.
+- The object-graph shape the resolution navigates (see `hierarchy_and_generate.md`).
+- IR-layer shapes (see `mir.md`, `lir.md`).
+
+## Core Invariants
+
+1. **One artifact per unit specialization; the program is linked, not aggregated.** A backend emits
+   each unit's code as a self-contained artifact. No emitted artifact contains the bodies of more
+   than one unit, and none enumerates "all units." The program is formed by linking the per-unit
+   artifacts. This is what keeps compilation parallel and incremental (`north_star.md` inv 3, 4).
+2. **A unit's emission depends only on itself, the interfaces it instantiates, and the SDK.** The
+   inputs to emitting unit U are: U's own MIR; the interface (name, parameters, ports) of each unit
+   U instantiates; and the runtime SDK. U's artifact never depends on a unit it does not
+   instantiate, and never on another unit's body or internal layout (`compilation_unit_model.md` inv
+   8).
+3. **The runtime SDK is the link-time-resolution substrate.** Cross-unit operations the referrer
+   cannot resolve from its own inputs are expressed as SDK operations. In the C++ backend the SDK is
+   the runtime library; under LLVM its operations become intrinsics the linker resolves. A backend
+   never invents a second cross-unit mechanism outside the SDK.
+4. **A cross-unit reference resolves once into a stored direct reference.** It resolves once -- in
+   the constructor for downward, at Bind for upward -- after which the simulation-time read and
+   change observation read it directly with no per-access lookup (`reference_resolution.md` inv 3,
+   5). How the reference is stored and filled differs by direction.
+5. **Storage and fill by direction:**
+   - **Downward** -- the target lives inside a unit the referrer instantiates, a declared
+     dependency. The referrer holds a slot it fills in its constructor by navigating its owned child
+     to the referenced member. Because the sub-module is a declared dependency, the navigation is
+     bound when the artifacts are linked; the referrer emits the access by name and the link
+     resolves it, carrying no offset.
+   - **Upward** -- the ancestor is one the referrer does **not** instantiate, so it is not a
+     dependency and is unknown to the referrer at compile time. The referrer holds the reference as
+     an ordinary member whose type marks it external; at Bind that member navigates the runtime
+     object graph (the parent chain) to the ancestor named by the reference, matching its instance
+     name or module definition name (LRM 23.8), and obtains the named signal through the SDK. The
+     referrer's artifact carries zero knowledge of the ancestor's unit -- it never names the
+     ancestor type and never includes its artifact, and no cross-unit slot or side table records the
+     upward reference.
+6. **A unit exposes its hierarchically reachable signals through the SDK.** So that an upward
+   referrer (which cannot name the ancestor's type) can obtain a signal from an ancestor found only
+   at runtime, each unit makes its reachable signals available through a uniform SDK surface on the
+   object graph node. The referrer obtains the signal by name once at construction and stores the
+   direct reference; it never embeds the ancestor's layout.
+
+## Boundary to Adjacent Layers
+
+- `compilation_unit_model.md` defines the unit and its interface; this doc defines what a unit's
+  _emitted artifact_ may depend on, which is exactly that interface plus the SDK.
+- `reference_resolution.md` defines that a cross-unit reference resolves once at construction into a
+  stored direct reference; this doc defines how a backend realizes that without breaking unit
+  independence (downward link-binding into a slot vs upward runtime navigation through an extern
+  member).
+- `runtime_distribution.md` owns where the SDK/runtime lives; this doc owns the SDK's role as the
+  resolution substrate.
+- `runtime_model.md` places the fill in the constructor context and the read in the simulation
+  context.
+
+## Forbidden Shapes
+
+- An emitted artifact that contains more than one unit's bodies, or that enumerates all units (a
+  global "wiring" file). This is the canonical violation: it serializes otherwise-independent
+  compilation and reintroduces an undeclared whole-design dependency.
+- A referrer's artifact that names, includes, or casts to the type of a unit it does not instantiate
+  -- in particular, an upward reference naming its ancestor's unit type.
+- Embedding another unit's storage offset in the referrer's own emitted output to resolve a
+  cross-unit reference (as opposed to emitting a by-name access the link resolves).
+- A design-global signal or path table that mirrors the object graph. Cross-unit resolution is local
+  object-graph navigation (an owned child, or the parent chain), resolved once at construction; a
+  per-object by-name signal lookup at construction is local and permitted, a global flat table is
+  not.
+- A per-access cross-unit lookup on the simulation path; the hot path reads the stored reference.
+- A second cross-unit access mechanism that bypasses the SDK and the resolved stored reference.
+
+## Notes / Examples
+
+`always_comb r = c.x;` (downward): `c` is a unit the parent instantiates, so `c`'s interface is a
+declared input to the parent's emission and `x` is bound when the artifacts are linked. The parent
+emits a by-name access; the link resolves it; the parent's own output carries no offset.
+
+`always_comb x = Top.g;` (upward): `Top` is an ancestor the referrer does not instantiate, so the
+referrer knows nothing about `Top` at compile time. It cannot name `Top` or include its artifact.
+The referrer holds the reference as an ordinary member whose type marks it external; at Bind that
+member climbs the parent chain to the ancestor whose instance or module name matches, obtains the
+`g` signal from that node through the SDK, and stores the direct reference. The simulation-time read
+and change observation then read that member directly (`reference_resolution.md` inv 5); no
+cross-unit slot or side table records the reference.
+
+The current C++ backend collapses all units into a single translation unit (one `main.cpp` that
+transitively includes every unit header, with bodies inline). That is a transitional convenience of
+the C++ build step, not a relaxation of invariant 1: any artifact that aggregates multiple units'
+bodies is still wrong and is marked for removal. The per-unit artifact boundary and the resolution
+rules above are the contract the LLVM backend must satisfy and the C++ backend must converge to.

--- a/docs/architecture/emission_model.md
+++ b/docs/architecture/emission_model.md
@@ -65,15 +65,17 @@ non-conforming code, not as a relaxation of the contract.
      dependency and is unknown to the referrer at compile time. The referrer holds the reference as
      an ordinary member whose type marks it external; at Bind that member navigates the runtime
      object graph (the parent chain) to the ancestor named by the reference, matching its instance
-     name or module definition name (LRM 23.8), and obtains the named signal through the SDK. The
-     referrer's artifact carries zero knowledge of the ancestor's unit -- it never names the
-     ancestor type and never includes its artifact, and no cross-unit slot or side table records the
-     upward reference.
-6. **A unit exposes its hierarchically reachable signals through the SDK.** So that an upward
-   referrer (which cannot name the ancestor's type) can obtain a signal from an ancestor found only
-   at runtime, each unit makes its reachable signals available through a uniform SDK surface on the
-   object graph node. The referrer obtains the signal by name once at construction and stores the
-   direct reference; it never embeds the ancestor's layout.
+     name or module definition name (LRM 23.8), then steps down any remaining path through the
+     ancestor's owned children by name, and obtains the leaf signal through the SDK. The referrer's
+     artifact carries zero knowledge of the ancestor's or those children's units -- it never names
+     their types and never includes their artifacts, and no cross-unit slot or side table records
+     the upward reference.
+6. **A unit exposes its hierarchically reachable signals and owned children through the SDK.** So
+   that an upward referrer (which cannot name the ancestor's or an intervening child's type) can
+   reach a signal in an ancestor found only at runtime, each unit makes its reachable signals and
+   its owned children available by name through a uniform SDK surface on the object graph node -- a
+   child step indexes the owner's own storage. The referrer walks that surface once at construction
+   and stores the direct reference; it never embeds another unit's layout.
 
 ## Boundary to Adjacent Layers
 

--- a/docs/decisions/upward-reference-resolution.md
+++ b/docs/decisions/upward-reference-resolution.md
@@ -125,10 +125,17 @@ nesting on the chain it can bind the nearer one. That is a known gap (`docs/prog
 D2d) -- the resolved AST gives the ancestor's name and definition name, but not which form the
 source wrote, and recovering that needs the source token the elaborated AST does not retain.
 
-Once the ancestor is found, the leaf signal is obtained through `Scope::GetSignal("g")`, which the
-ancestor's own emitted code answers by returning a pointer to its own member. The referrer casts the
-returned `void*` to its own `Var<T>` cell type -- a type it already knows from its declaration --
-never to the ancestor's type. The by-name SDK realization (`DefName`, `GetSignal`, the
+Once the ancestor is found, the reference may still descend into the ancestor's subtree before
+reaching the leaf (`Top.sib.y` climbs to `Top`, then steps down into the owned child `sib`). That
+tail is by-name too, for the same reason the climb is: the referrer owns neither the ancestor nor
+its children, so it cannot navigate by typed pointer. Each step asks the current scope for an owned
+child through `Scope::GetChild` -- the twin of `GetSignal` for the object tree, which the owner
+answers by indexing its own storage (an array hop is the owner's own `vector` subscript, never a
+re-derived offset). The final leaf is fetched with `Scope::GetSignal("y")`, which the ancestor's own
+emitted code answers by returning a pointer to its own member. The referrer casts the returned
+`void*` to its own `Var<T>` cell type -- a type it already knows from its declaration -- never to
+the ancestor's type. When the leaf sits directly on the ancestor the tail is empty, the zero-case of
+the same walk. The by-name SDK realization (`DefName`, `GetSignal`, `GetChild`, the
 construction-time climb) is owned by `emission_model.md`; this record fixes only the resolution
 strategy, not its emitted shape.
 
@@ -158,32 +165,38 @@ construction. Concretely:
    naming a signal the referrer does not own:
 
    ```cpp
-   struct Leaf {                                  // module Leaf; always_comb x = Top.g;
-     Var<int> x;
-     ExternUp<int> g{this, "Top", "g"};           // extern member: symbol on the type;
-                                                  // self-registers, relocates at Bind
+   struct Leaf {                                  // always_comb x = Top.g;  y = Top.sib.s;
+     Var<int> x, y;
+     ExternUp<int> g{this, "Top", {}, "g"};           // empty tail: leaf on the ancestor
+     ExternUp<int> s{this, "Top", {{"sib", {}}}, "s"};// tail steps down into owned child `sib`
      // always_comb:  x = g.Get();   sensitivity subscribes to g.AsObservable()
    };
 
    struct Top {
      Var<int> g;
+     unique_ptr<Sib> sib;
      unique_ptr<Leaf> l;
-     Top(...) { l = make_unique<Leaf>(this, "l"); }     // knows nothing about Leaf's g
+     Top(...) { ... }                                   // knows nothing about Leaf's g / s
      string_view DefName() const override { return "Top"; }
-     void* GetSignal(string_view n) override {          // answers for its own members
+     void* GetSignal(string_view n) override {          // answers for its own signals
        if (n == "g") return &g;
+       return nullptr;
+     }
+     Scope* GetChild(ChildRef ref) override {           // answers for its own children
+       if (ref.name == "sib") return sib.get();         // (an array hop: bank.at(ref.indices[0]))
        return nullptr;
      }
    };
    ```
 
-   The climb -- match the parent chain by `Name()`/`DefName()`, then `GetSignal` -- lives once in
-   the runtime SDK as `Scope::ResolveUpward`, called by `ExternUp<T>::Relocate` at Bind. The
-   referrer carries the reference as an ordinary member whose type is `ExternalRef<T>` (the symbol
-   rides on the type); reads, writes, and sensitivity are the normal structural-var paths,
-   dispatched by that type. MIR keeps no cross-unit slot or resolve statement for an upward
-   reference -- the typed member is the whole story, which is why `type is the classification` holds
-   here (see `docs/architecture/mir.md` and `emission_model.md`).
+   The walk -- climb the parent chain by `Name()`/`DefName()` to the ancestor, step down any tail
+   through `Scope::GetChild`, then `Scope::GetSignal` the leaf -- lives once in the runtime SDK
+   (`Scope::ResolveUpwardScope` plus the by-name `GetChild`/`GetSignal` surface), driven by
+   `ExternUp<T>::Relocate` at Bind. The referrer carries the reference as an ordinary member whose
+   type is `ExternalRef<T>` (the symbol rides on the type); reads, writes, and sensitivity are the
+   normal structural-var paths, dispatched by that type. MIR keeps no cross-unit slot or resolve
+   statement for an upward reference -- the typed member is the whole story, which is why
+   `type is the classification` holds here (see `docs/architecture/mir.md` and `emission_model.md`).
 
 5. **No compile-time depth, no global tree walk, no interface threading, no RTTI retry.** The climb
    is the construction-time resolution that `reference_resolution.md` prescribes (resolve once into
@@ -197,17 +210,16 @@ construction. Concretely:
   correct ancestor whether the ancestor is one or several levels up; depth is never represented as a
   number anywhere.
 - **The match keys are the runtime instance name and module definition name (`Scope::Name()` /
-  `Scope::DefName()`).** The `ExternalRef` type carries only the reference's source-level identifier
-  (the match key) and the leaf signal name (the `GetSignal` argument); it carries no ancestor type,
-  so the referrer's artifact stays self-contained.
+  `Scope::DefName()`).** The `ExternalRef` type carries only the match key, the by-name tail down
+  through the ancestor's owned children, and the leaf signal name (the `GetSignal` argument); it
+  carries no ancestor or child type, so the referrer's artifact stays self-contained.
 - **The climb is a construction-time loop, run once per extern member.** It is never on the
   simulation hot path, which reads the stored pointer.
 - **Upward references are not unified with `ref` ports.** A `ref` port is supplied by the parent
   because the connection is explicit there; an upward reference is resolved by the child because the
   parent cannot know about it. Both are cross-unit references resolved at construction, but their
   head resolution differs by necessity.
-- **Out of scope, guarded explicitly:** a down-tail through a child after the climb (`Top.other.y`,
-  needs a by-name child-navigation surface); an upward reference written inside a generate block; a
+- **Out of scope, guarded explicitly:** an upward reference written inside a generate block; a
   `$root`-anchored absolute path; an upward reference through an interface port; an ancestor that is
   a named generate or procedural block rather than a module instance (such a scope does not yet
   expose itself as a climb-match target with `GetSignal`); and the corner where a nearer ancestor

--- a/docs/decisions/upward-reference-resolution.md
+++ b/docs/decisions/upward-reference-resolution.md
@@ -1,0 +1,214 @@
+# Upward Hierarchical Reference Resolution by Self-Climb at Construction
+
+## Date
+
+2026-06-03
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+An upward hierarchical reference is a child naming a signal in one of its ancestors
+(`always_comb x = Top.g;` inside a module instantiated under `Top`). Unlike a downward reference --
+where the referrer owns the child it navigates -- the referrer does not own, instantiate, or even
+know the type of the ancestor it must reach. What had to be settled is how the referrer, alone,
+locates the ancestor object at run time and binds a direct reference to the signal, without ever
+naming the ancestor's unit.
+
+Several plausible mechanisms were considered and rejected for concrete architectural reasons before
+the design converged. This record captures those reasons so the convergence is not relitigated, and
+because the rejected paths each look reasonable until a specific invariant rules them out.
+
+## Findings that shaped the design
+
+### F1. The referrer must resolve and store the reference alone
+
+A cross-unit reference is a stored direct pointer, resolved once and read on the hot path with no
+per-access lookup. A downward reference reaches its target by navigating from an owned child member
+(`&c->x`); the child is a declared dependency, so the referrer has somewhere to start. An upward
+reference has no owned member to start from -- the ancestor is not a dependency -- so the open
+question is how the referrer, alone, locates the ancestor at run time and binds the pointer.
+
+### F2. slang gives the ancestor as `path[0]`, and `upwardCount` is anchored at the lexical scope
+
+For an upward reference, slang's `HierarchicalReference` carries `path[0]` = the ancestor (the
+ancestor found by upward name search) and `path[1..]` = a downward navigation from that ancestor.
+`upwardCount` is the number of scopes climbed during the _lexical_ name lookup. Measured directly (a
+standalone slang probe), `upwardCount` counts scopes that have no runtime object:
+
+- A reference inside an `always_comb begin ... end` with a local declaration reports `upwardCount`
+  one higher than the runtime parent hop count, because the statement block is a lexical scope with
+  no runtime object.
+- A reference inside a `generate for` reports `upwardCount` one higher again, because slang models
+  the loop as a `GenerateBlockArray` container scope plus per-iteration `GenerateBlock` scopes,
+  while the runtime materializes only the per-iteration block (the array is a vector member, not a
+  scope -- `hierarchy_and_generate.md` invariant 9).
+
+**Consequence:** `upwardCount` cannot be used as a runtime hop count. Matching it by materializing
+the `GenerateBlockArray` as a runtime scope is rejected: it would contradict the array-as-vector-
+member model, which is correct.
+
+### F3. The depth is not computable at the child's compile time
+
+A compilation unit compiles knowing only its own contents plus the _interfaces_ (name and signature:
+ports and parameters) of the units it directly references by name; it never sees another unit's body
+(`compilation_unit_model.md` invariants 3 and 8). A query depends only on its declared inputs, with
+no global identity coupling (`incremental_build.md` invariants 1 and 6). Walking the fully
+elaborated instance tree to count hops at compile time is a design-level lookup that these
+invariants forbid.
+
+The child therefore cannot see its parent at compile time, so the climb depth is unknowable when the
+child is compiled.
+
+**Consequence:** computing a constant climb count `K` at the child's compile time is rejected,
+whether by counting materialized scopes or by reading `upwardCount`. Resolution must be deferred to
+construction, the first phase at which the ancestor chain exists.
+
+### F4. The same artifact can sit at different depths
+
+One compiled artifact is instantiated many times (`hierarchy_and_generate.md` invariant 5). The same
+module can be instantiated directly under `Top` (depth 1) and again under an intermediate module
+(depth 2), both naming `Top.g`. No single constant baked into the artifact is correct for both
+sites.
+
+**Consequence:** making the climb depth a specialization key (one artifact per depth) is rejected.
+It couples the feature to specialization that does not exist yet, and F3 already rules out computing
+the depth at compile time regardless.
+
+### F5. The reference cannot be threaded down from the ancestor
+
+A tempting alternative is to resolve from the ancestor: have `Top` hand a pointer to `g` down
+through the hierarchy (an implicit port or constructor argument forwarded at each level). This is
+rejected because it requires `Top` to know that a descendant needs `g`. A parent sees only its
+child's _signature_ (ports and parameters), never its body, and an upward reference lives in the
+child's body, not its declared interface. Threading would force a unit's interface to grow with its
+descendants' internal references, which violates the rule that a unit depends only on the interfaces
+it references by name.
+
+This is the precise difference between an upward reference and an explicit `ref` port. A `ref` port
+connection is written at the parent (`.p(sig)`), so the parent knows the target and can supply it;
+an upward reference is implicit in the child, so the parent cannot. They are both cross-unit
+references, but they are not the same mechanism.
+
+### F6. The ancestor is always on the direct ancestor line; siblings are reached downward
+
+Measured directly: `Top.other.y` from a child of `Top` reports `path = [Top, other, y]` with
+`upwardCount = 1`. `path[0]` (the ancestor) is the common ancestor, always on the referrer's direct
+`parent` chain; `path[1..]` (`other`, `y`) is a downward navigation from the ancestor into a sibling
+subtree.
+
+**Consequence:** the climb only ever walks up the direct ancestor line to find the ancestor. It
+never steps sideways into a sibling. A sibling or cousin target is reached by the existing downward
+tail navigation, applied from the ancestor.
+
+### F7. The ancestor is matched by name and the signal is fetched by name -- the referrer never names the ancestor's type
+
+A climb that tries `dynamic_cast<Top*>` at each step and advances on failure is trial-and-error and
+pulls in RTTI. Worse, any cast to the ancestor's type makes the referrer depend on a unit it does
+not instantiate: an ancestor is not a declared dependency, so the referrer cannot name its class
+without baking in another unit's layout, which `emission_model.md` forbids (invariants 2 and 5). The
+conformant form matches the ancestor by name and then asks the ancestor for the signal by name,
+through the generic `Scope` SDK -- no ancestor type appears in the referrer at all.
+
+The match key is the ancestor's **module definition name**, read from the resolved ancestor symbol
+(`path[0].symbol`'s definition name) -- a semantic value, never from source syntax (a wrapped
+sub-expression like `Top.g[3]` may carry no syntax at all). It is class-level: every instance of the
+referring module shares the same module name, so one artifact serves all depths. At runtime the
+climb compares it against each ancestor's instance name (`Scope::Name()`) **or** module definition
+name (`Scope::DefName()`); a module-name reference (`Top.g`) matches the ancestor whose `DefName()`
+is `"Top"`, including the aliased `module Tb; Top dut();` where the instance name is `dut`. The one
+form this does not yet honor is LRM 23.9 instance-name precedence: a reference written as an
+**instance** name (`u_mid.s`) keys on the module name too, so with several instances of that module
+nesting on the chain it can bind the nearer one. That is a known gap (`docs/progress/hierarchy.md`
+D2d) -- the resolved AST gives the ancestor's name and definition name, but not which form the
+source wrote, and recovering that needs the source token the elaborated AST does not retain.
+
+Once the ancestor is found, the leaf signal is obtained through `Scope::GetSignal("g")`, which the
+ancestor's own emitted code answers by returning a pointer to its own member. The referrer casts the
+returned `void*` to its own `Var<T>` cell type -- a type it already knows from its declaration --
+never to the ancestor's type. The by-name SDK realization (`DefName`, `GetSignal`, the
+construction-time climb) is owned by `emission_model.md`; this record fixes only the resolution
+strategy, not its emitted shape.
+
+## Decision
+
+An upward hierarchical reference resolves by the referrer climbing its own ancestor chain at
+construction. Concretely:
+
+1. **Resolution is at construction, by the referrer, not the ancestor.** The child walks up its own
+   `parent` chain to the ancestor, binds a direct pointer inside its own extern member, and reads
+   through that member on the hot path. The ancestor is never involved; its construction of the
+   child is unchanged and knows nothing about the child's upward references.
+
+2. **The ancestor (`path[0]`) is matched by its module definition name, and the signal is fetched by
+   name.** The key is the resolved ancestor's module name (a semantic value, never from syntax). The
+   climb compares it against each ancestor's `Scope::Name()` or `Scope::DefName()` and stops at the
+   nearest match, then calls `Scope::GetSignal(<signal>)` to obtain the leaf and casts the returned
+   `void*` to the member's own declared cell type. No `dynamic_cast` retry loop, and no cast to the
+   ancestor's type. (Instance-name precedence, LRM 23.9, is a known gap -- see F7.)
+
+3. **The climb walks only the direct ancestor line.** It never steps into a sibling. A sibling or
+   cousin target is the downward tail (`path[1..]`) applied from the ancestor, using the existing
+   downward navigation.
+
+4. **Upward is an extern member; downward is owned navigation.** They are not the same shape -- a
+   downward reference navigates a child the referrer owns, an upward reference is an extern member
+   naming a signal the referrer does not own:
+
+   ```cpp
+   struct Leaf {                                  // module Leaf; always_comb x = Top.g;
+     Var<int> x;
+     ExternUp<int> g{this, "Top", "g"};           // extern member: symbol on the type;
+                                                  // self-registers, relocates at Bind
+     // always_comb:  x = g.Get();   sensitivity subscribes to g.AsObservable()
+   };
+
+   struct Top {
+     Var<int> g;
+     unique_ptr<Leaf> l;
+     Top(...) { l = make_unique<Leaf>(this, "l"); }     // knows nothing about Leaf's g
+     string_view DefName() const override { return "Top"; }
+     void* GetSignal(string_view n) override {          // answers for its own members
+       if (n == "g") return &g;
+       return nullptr;
+     }
+   };
+   ```
+
+   The climb -- match the parent chain by `Name()`/`DefName()`, then `GetSignal` -- lives once in
+   the runtime SDK as `Scope::ResolveUpward`, called by `ExternUp<T>::Relocate` at Bind. The
+   referrer carries the reference as an ordinary member whose type is `ExternalRef<T>` (the symbol
+   rides on the type); reads, writes, and sensitivity are the normal structural-var paths,
+   dispatched by that type. MIR keeps no cross-unit slot or resolve statement for an upward
+   reference -- the typed member is the whole story, which is why `type is the classification` holds
+   here (see `docs/architecture/mir.md` and `emission_model.md`).
+
+5. **No compile-time depth, no global tree walk, no interface threading, no RTTI retry.** The climb
+   is the construction-time resolution that `reference_resolution.md` prescribes (resolve once into
+   a stored direct reference). It is a local navigation of the object tree, which the
+   forbidden-shape list permits; the list forbids flattened symbol-name lookup and design-global
+   path tables, neither of which a parent-chain walk is.
+
+## Consequences
+
+- **Multiple depths work with one artifact and no specialization.** The same module climbs to the
+  correct ancestor whether the ancestor is one or several levels up; depth is never represented as a
+  number anywhere.
+- **The match keys are the runtime instance name and module definition name (`Scope::Name()` /
+  `Scope::DefName()`).** The `ExternalRef` type carries only the reference's source-level identifier
+  (the match key) and the leaf signal name (the `GetSignal` argument); it carries no ancestor type,
+  so the referrer's artifact stays self-contained.
+- **The climb is a construction-time loop, run once per extern member.** It is never on the
+  simulation hot path, which reads the stored pointer.
+- **Upward references are not unified with `ref` ports.** A `ref` port is supplied by the parent
+  because the connection is explicit there; an upward reference is resolved by the child because the
+  parent cannot know about it. Both are cross-unit references resolved at construction, but their
+  head resolution differs by necessity.
+- **Out of scope, guarded explicitly:** a down-tail through a child after the climb (`Top.other.y`,
+  needs a by-name child-navigation surface); an upward reference written inside a generate block; a
+  `$root`-anchored absolute path; an upward reference through an interface port; an ancestor that is
+  a named generate or procedural block rather than a module instance (such a scope does not yet
+  expose itself as a climb-match target with `GetSignal`); and the corner where a nearer ancestor
+  carries the same instance name as the named one.

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -105,7 +105,25 @@ consume. Coverage is demonstrated through Stage D and Stage E.
 ### Stage D -- Hierarchical references
 
 - [x] D1 -- A downward reference reads and writes a signal in a child instance.
-- [ ] D2 -- An upward reference reads and writes a signal in an ancestor instance.
+- [x] D2 -- An upward reference reads and writes a signal directly on the matched ancestor, at any
+      depth. The child cannot know its depth when compiled, so it resolves the reference at
+      construction inside its own artifact: it climbs its parent chain to the ancestor named by the
+      reference (matching an instance or module name, LRM 23.8) and fetches the signal by name,
+      naming no ancestor type (see `docs/decisions/upward-reference-resolution.md`,
+      `docs/architecture/emission_model.md`). A reference wrapped in a value-level operation
+      (`Top.g[3]`, `Top.g + 1`) works -- the value part is ordinary expression handling. The
+      remaining forms below are each rejected with a clean "unsupported" diagnostic, except D2d.
+- [ ] D2a -- An upward reference that descends through a child after the climb (`Top.sib.y`): reach
+      the ancestor, then navigate back down by name into a sibling subtree.
+- [ ] D2b -- An upward reference written inside a generate block rather than the module body.
+- [ ] D2c -- An upward reference whose first component is not a module instance: a named generate or
+      procedural block, or a `$root`-anchored absolute path.
+- [ ] D2d -- LRM 23.9 instance-name precedence: when the first component is written as an instance
+      name and several instances of the same module nest on the chain, the reference must bind the
+      named instance. Today the climb keys on the module name, so it can silently bind the nearer
+      same-module ancestor instead -- the one form that resolves wrong without an error. The common
+      module-name form is correct at any depth; this gap needs the source-written first identifier,
+      which the elaborated AST does not retain.
 - [x] D3 -- Multi-level dotted paths resolve through the object tree across more than one level.
       Landed for downward paths through scalar instances.
 - [ ] D4 -- A combinational process reading a hierarchical reference re-triggers when the referenced

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -113,8 +113,12 @@ consume. Coverage is demonstrated through Stage D and Stage E.
       `docs/architecture/emission_model.md`). A reference wrapped in a value-level operation
       (`Top.g[3]`, `Top.g + 1`) works -- the value part is ordinary expression handling. The
       remaining forms below are each rejected with a clean "unsupported" diagnostic, except D2d.
-- [ ] D2a -- An upward reference that descends through a child after the climb (`Top.sib.y`): reach
-      the ancestor, then navigate back down by name into a sibling subtree.
+- [x] D2a -- An upward reference that descends through a child after the climb (`Top.sib.y`,
+      `Top.mid.deep.z`, `Top.bank[2].y`): the climb reaches the ancestor, then the reference steps
+      down by name into the ancestor's owned children to the leaf, at any depth and through array
+      indices. The tail is by-name for the same reason the climb is -- the referrer owns neither the
+      ancestor nor its children -- so each owner answers for its own children, indexing its own
+      storage. A leaf directly on the ancestor is the empty-tail zero-case of the same walk.
 - [ ] D2b -- An upward reference written inside a generate block rather than the module body.
 - [ ] D2c -- An upward reference whose first component is not a module instance: a named generate or
       procedural block, or a `$root`-anchored absolute path.

--- a/include/lyra/backend/cpp/render_stmt.hpp
+++ b/include/lyra/backend/cpp/render_stmt.hpp
@@ -6,6 +6,7 @@
 #include "lyra/backend/cpp/render_context.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/stmt.hpp"
+#include "lyra/mir/structural_scope.hpp"
 
 namespace lyra::backend::cpp {
 

--- a/include/lyra/backend/cpp/render_stmt.hpp
+++ b/include/lyra/backend/cpp/render_stmt.hpp
@@ -6,7 +6,6 @@
 #include "lyra/backend/cpp/render_context.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/stmt.hpp"
-#include "lyra/mir/structural_scope.hpp"
 
 namespace lyra::backend::cpp {
 

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -53,16 +53,31 @@ struct IndexHop {
 };
 using PathStep = std::variant<MemberHop, IndexHop>;
 
-// A cross-unit reference resolved once at construction (see
-// reference_resolution.md). `instance` names the owned child instance (or
-// instance-array) member this unit reaches into -- the head of the downward
-// path. `path` carries the navigation past the head down to the referenced
-// leaf, referenced by name across the unit boundary. `type` is the
-// slang-resolved type of the referenced leaf. The slot is read / written /
-// observed through a stored direct reference the constructor materializes by
-// chaining the path's hops.
-struct CrossUnitRefDecl {
+// Where a cross-unit reference starts its navigation. A downward reference
+// reaches into an owned child instance (or instance-array) member. An upward
+// reference (LRM 23.6) climbs the parent chain at construction to the nearest
+// ancestor whose instance name or module name is `ancestor_name` (the
+// reference's source-level first component), then fetches `signal_name` from
+// that ancestor by name through the SDK -- it never names the ancestor's unit
+// type, which it does not depend on (docs/architecture/emission_model.md). The
+// child cannot know its depth at compile time, so it locates the ancestor by
+// name rather than a baked-in offset.
+struct DownwardHead {
   InstanceMemberId instance;
+};
+struct UpwardHead {
+  std::string ancestor_name;
+  std::string signal_name;
+};
+using CrossUnitRefHead = std::variant<DownwardHead, UpwardHead>;
+
+// A cross-unit reference resolved once at construction (see
+// reference_resolution.md). `head` is where navigation starts; `path` carries
+// the shared navigation from the head down to the referenced leaf, by name
+// across the unit boundary; `type` is the slang-resolved leaf type. The slot is
+// read / written / observed through one stored direct reference.
+struct CrossUnitRefDecl {
+  CrossUnitRefHead head;
   std::vector<PathStep> path;
   TypeId type;
 };

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -56,18 +56,17 @@ using PathStep = std::variant<MemberHop, IndexHop>;
 // Where a cross-unit reference starts its navigation. A downward reference
 // reaches into an owned child instance (or instance-array) member. An upward
 // reference (LRM 23.6) climbs the parent chain at construction to the nearest
-// ancestor whose instance name or module name is `ancestor_name` (the
-// reference's source-level first component), then fetches `signal_name` from
-// that ancestor by name through the SDK -- it never names the ancestor's unit
-// type, which it does not depend on (docs/architecture/emission_model.md). The
-// child cannot know its depth at compile time, so it locates the ancestor by
-// name rather than a baked-in offset.
+// ancestor whose instance or module name is `ancestor_name`; from there both
+// directions share `path` to reach the leaf, by name across the unit boundary
+// -- the referrer never names the ancestor's unit type, which it does not
+// depend on (docs/architecture/emission_model.md). The child cannot know its
+// depth at compile time, so it locates the ancestor by name rather than a
+// baked-in offset.
 struct DownwardHead {
   InstanceMemberId instance;
 };
 struct UpwardHead {
   std::string ancestor_name;
-  std::string signal_name;
 };
 using CrossUnitRefHead = std::variant<DownwardHead, UpwardHead>;
 

--- a/include/lyra/lowering/ast_to_hir/expression/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/lower.hpp
@@ -52,15 +52,16 @@ auto LowerInsideItem(
     ProcessLoweringState& proc_state, const ScopeStack& stack,
     const slang::ast::Expression& item_expr) -> diag::Result<hir::InsideItem>;
 
-// Builds a reference expression to a leaf reached by navigating `path` from a
-// local instance member (the head) down into a child unit. `target` is the
-// leaf value symbol (the cross-unit dedup key); `member` and `home_frame`
-// locate the head. Both a hierarchical reference (`c.x`, `m.l.x`) and a port
-// connection's child-side endpoint resolve through this one path
+// Builds a reference expression to a leaf reached by navigating `path` down
+// from `head`. `target` is the leaf value symbol (the cross-unit dedup key);
+// `home_frame` is the owning structural scope's frame. A downward head reaches
+// into an owned child member; an upward head climbs to an ancestor at
+// construction. Hierarchical references (`c.x`, `Top.g`) and a port
+// connection's child-side endpoint all resolve through this one path
 // (reference_resolution.md).
 auto MakeCrossUnitMemberRef(
     UnitLoweringState& unit_state, const slang::ast::ValueSymbol& target,
-    ScopeFrameId home_frame, hir::InstanceMemberId member,
+    ScopeFrameId home_frame, hir::CrossUnitRefHead head,
     std::vector<hir::PathStep> path, hir::TypeId type, diag::SourceSpan span)
     -> hir::Expr;
 

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -262,7 +262,7 @@ class UnitLoweringState {
   // HIR scope by TakeCrossUnitRefsForFrame when the scope finishes lowering.
   auto MapOrGetCrossUnitRef(
       const slang::ast::ValueSymbol& target, ScopeFrameId home_frame,
-      hir::InstanceMemberId instance, std::vector<hir::PathStep> path,
+      hir::CrossUnitRefHead head, std::vector<hir::PathStep> path,
       hir::TypeId type) -> hir::CrossUnitRefId {
     if (const auto it = cross_unit_ref_dedup_.find(&target);
         it != cross_unit_ref_dedup_.end()) {
@@ -272,7 +272,7 @@ class UnitLoweringState {
     const hir::CrossUnitRefId id{static_cast<std::uint32_t>(slots.size())};
     slots.push_back(
         hir::CrossUnitRefDecl{
-            .instance = instance, .path = std::move(path), .type = type});
+            .head = std::move(head), .path = std::move(path), .type = type});
     cross_unit_ref_dedup_.emplace(&target, id);
     return id;
   }
@@ -342,6 +342,19 @@ class ScopeStack {
       throw InternalError("ScopeStack::Pop: unbalanced pop");
     }
     frames_.pop_back();
+  }
+
+  // The frame of the scope currently being lowered. An upward cross-unit
+  // reference stores its slot here (its owning structural scope), since it has
+  // no owned-member head to locate it by.
+  [[nodiscard]] auto Current() const -> ScopeFrameId {
+    return frames_.back();
+  }
+
+  // Structural nesting depth; 1 is the unit root, more means inside a generate
+  // scope.
+  [[nodiscard]] auto Depth() const -> std::size_t {
+    return frames_.size();
   }
 
   [[nodiscard]] auto HopsTo(ScopeFrameId target) const

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -257,6 +257,19 @@ class StructuralScopeLoweringState {
     scope_->constructor_scope = std::move(ctor);
   }
 
+  // Records the MIR target each HIR cross-unit ref slot lowers to, in HIR slot
+  // order: an upward ref materializes as a StructuralVarRef to a synthesized
+  // ExternalRef member, a downward ref keeps a CrossUnitVarRef. Reads and
+  // sensitivity resolve a slot through this table.
+  void AddCrossUnitRefTarget(mir::SensitivityRef target) {
+    cross_unit_ref_targets_.push_back(std::move(target));
+  }
+
+  [[nodiscard]] auto CrossUnitRefTarget(hir::CrossUnitRefId hir_id) const
+      -> const mir::SensitivityRef& {
+    return cross_unit_ref_targets_.at(hir_id.value);
+  }
+
   void MapStructuralVar(
       hir::StructuralVarId hir_id, mir::StructuralVarId mir_id) {
     if (hir_id.value != structural_var_map_.size()) {
@@ -402,6 +415,7 @@ class StructuralScopeLoweringState {
   std::vector<mir::StructuralVarId> structural_var_map_;
   std::vector<std::optional<mir::StructuralParamId>> structural_param_map_;
   std::vector<mir::StructuralSubroutineId> structural_subroutine_map_;
+  std::vector<mir::SensitivityRef> cross_unit_ref_targets_;
 };
 
 struct ProceduralVarBinding {

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -104,10 +104,9 @@ struct ConstructExternalUnitStmt {
   std::vector<std::uint32_t> dims;
 };
 
-// Resolves a cross-unit reference slot once at construction, after the target
-// child is built (reference_resolution.md): the backend materializes a stored
-// direct reference to the child's member. The navigation recipe lives in the
-// enclosing scope's `cross_unit_refs` table, keyed by `slot`.
+// Fills downward cross-unit slot `slot` once at construction, after the target
+// child exists: the backend stores a direct reference by navigating the recipe
+// in the enclosing scope's `cross_unit_refs` table (reference_resolution.md).
 struct ResolveCrossUnitRefStmt {
   CrossUnitRefId slot;
 };

--- a/include/lyra/mir/structural_scope.hpp
+++ b/include/lyra/mir/structural_scope.hpp
@@ -28,12 +28,11 @@ struct IndexHop {
 };
 using PathStep = std::variant<MemberHop, IndexHop>;
 
-// A cross-unit reference resolved once at construction. `instance_var` is the
-// structural var holding the owned child instance (or instance-array) -- the
-// head of the downward path; `path` carries the navigation past the head down
-// to the referenced leaf; `type` is the referenced leaf's type. The backend
-// stores a direct reference to the leaf by chaining the path's hops from
-// `instance_var`.
+// A downward cross-unit reference resolved once at construction. `instance_var`
+// is the structural var holding the owned child instance (or instance-array) --
+// the head of the downward path; `path` carries the navigation past the head
+// down to the referenced leaf of `type`. Upward references are not cross-unit
+// refs -- they are ExternalRef members (docs/architecture/emission_model.md).
 struct CrossUnitRefDecl {
   StructuralVarId instance_var;
   std::vector<PathStep> path;

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -29,6 +29,7 @@ enum class TypeKind {
   kExternalUnitObject,
   kOwningPtr,
   kVector,
+  kExternalRef,
 };
 
 enum class BitAtom {
@@ -148,11 +149,24 @@ struct VectorType {
   auto operator==(const VectorType&) const -> bool = default;
 };
 
+// An upward hierarchical reference's storage: a resolved pointer to a leaf of
+// `element` living in the ancestor named `ancestor` under signal `signal` (LRM
+// 23.8). Like ExternalUnitObjectType it carries the cross-unit symbol on the
+// type; the address binds at construction, never the layout. Emitted as the
+// runtime `ExternUp<element>` member.
+struct ExternalRefType {
+  TypeId element;
+  std::string ancestor;
+  std::string signal;
+
+  auto operator==(const ExternalRefType&) const -> bool = default;
+};
+
 using TypeData = std::variant<
     PackedArrayType, EnumType, UnpackedArrayType, DynamicArrayType, QueueType,
     AssociativeArrayType, StringType, EventType, RealType, ShortRealType,
     RealTimeType, ChandleType, VoidType, ObjectType, ExternalUnitObjectType,
-    OwningPtrType, VectorType>;
+    OwningPtrType, VectorType, ExternalRefType>;
 
 struct Type {
   TypeData data;

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -149,14 +149,29 @@ struct VectorType {
   auto operator==(const VectorType&) const -> bool = default;
 };
 
+// One by-name step from a resolved scope into an owned child it answers for:
+// the child member's name plus one index per array dimension (empty for a
+// scalar child). The ancestor indexes its own storage, so a multi-dimensional
+// instance array is just more indices, never a flattened offset. (Distinct from
+// StructuralHops, which is a count of lexical frames climbed, not a path step.)
+struct ChildStep {
+  std::string name;
+  std::vector<std::uint32_t> indices;
+
+  auto operator==(const ChildStep&) const -> bool = default;
+};
+
 // An upward hierarchical reference's storage: a resolved pointer to a leaf of
-// `element` living in the ancestor named `ancestor` under signal `signal` (LRM
-// 23.8). Like ExternalUnitObjectType it carries the cross-unit symbol on the
-// type; the address binds at construction, never the layout. Emitted as the
-// runtime `ExternUp<element>` member.
+// `element`, reached by climbing to the ancestor named `ancestor`, walking
+// `tail` down through its owned children by name, then fetching `signal` (LRM
+// 23.8). `tail` is empty when the leaf sits directly on the ancestor. Like
+// ExternalUnitObjectType it carries the cross-unit symbol on the type; the
+// address binds at construction, never the layout. Emitted as the runtime
+// `ExternUp<element>` member.
 struct ExternalRefType {
   TypeId element;
   std::string ancestor;
+  std::vector<ChildStep> tail;
   std::string signal;
 
   auto operator==(const ExternalRefType&) const -> bool = default;

--- a/include/lyra/runtime/extern_up.hpp
+++ b/include/lyra/runtime/extern_up.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <string_view>
+
+#include "lyra/runtime/scope.hpp"
+#include "lyra/runtime/var.hpp"
+
+namespace lyra::runtime {
+
+// A registered upward-reference member. Scope::Bind walks every ExternUp on a
+// scope and relocates it once the whole object tree exists.
+struct ExternBase {
+  ExternBase() = default;
+  ExternBase(const ExternBase&) = delete;
+  auto operator=(const ExternBase&) -> ExternBase& = delete;
+  ExternBase(ExternBase&&) = delete;
+  auto operator=(ExternBase&&) -> ExternBase& = delete;
+  virtual ~ExternBase() = default;
+
+  virtual void Relocate() = 0;
+};
+
+// An upward hierarchical reference modeled as an extern member: it holds the
+// symbol -- the ancestor's instance or module name and the signal name -- and
+// at Bind climbs the parent chain to bind a direct pointer to the ancestor's
+// signal. Reads, writes, and sensitivity forward to that resolved cell, so the
+// member behaves like the referenced `Var<T>` while naming no ancestor type
+// (docs/architecture/emission_model.md). Non-movable: it registers `this`, and
+// is owned by the stable scope node that declares it.
+template <CaseEqualComparable T>
+class ExternUp : public ExternBase {
+ public:
+  ExternUp(Scope* owner, std::string_view ancestor, std::string_view signal)
+      : owner_(owner), ancestor_(ancestor), signal_(signal) {
+    owner_->RegisterExtern(this);
+  }
+
+  void Relocate() override {
+    cell_ = static_cast<Var<T>*>(owner_->ResolveUpward(ancestor_, signal_));
+  }
+
+  [[nodiscard]] auto Get() const -> const T& {
+    return cell_->Get();
+  }
+
+  void Set(RuntimeServices& services, const T& value) {
+    cell_->Set(services, value);
+  }
+
+  auto Mutate(RuntimeServices& services) -> ScopedMutation<T> {
+    return cell_->Mutate(services);
+  }
+
+  [[nodiscard]] auto AsObservable() -> Observable* {
+    return cell_;
+  }
+
+ private:
+  Scope* owner_;
+  std::string_view ancestor_;
+  std::string_view signal_;
+  Var<T>* cell_ = nullptr;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/extern_up.hpp
+++ b/include/lyra/runtime/extern_up.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <cstddef>
+#include <initializer_list>
 #include <string_view>
+#include <vector>
 
 #include "lyra/runtime/scope.hpp"
 #include "lyra/runtime/var.hpp"
@@ -20,23 +23,40 @@ struct ExternBase {
   virtual void Relocate() = 0;
 };
 
+// One by-name step of an extern reference's tail: an owned child of the
+// resolved ancestor, named and indexed once per array dimension. Names point at
+// emitted string literals; the indices it owns so the ExternUp outlives its
+// constructor arguments.
+struct ChildStep {
+  std::string_view name;
+  std::vector<std::size_t> indices;
+};
+
 // An upward hierarchical reference modeled as an extern member: it holds the
-// symbol -- the ancestor's instance or module name and the signal name -- and
-// at Bind climbs the parent chain to bind a direct pointer to the ancestor's
-// signal. Reads, writes, and sensitivity forward to that resolved cell, so the
-// member behaves like the referenced `Var<T>` while naming no ancestor type
-// (docs/architecture/emission_model.md). Non-movable: it registers `this`, and
-// is owned by the stable scope node that declares it.
+// symbol -- the ancestor's instance or module name, the by-name tail down
+// through the ancestor's owned children, and the leaf signal name -- and at
+// Bind climbs to the ancestor, walks the tail, and binds a direct pointer to
+// the leaf. Reads, writes, and sensitivity forward to that resolved cell, so
+// the member behaves like the referenced `Var<T>` while naming no ancestor
+// type (docs/architecture/emission_model.md). Non-movable: it registers `this`,
+// and is owned by the stable scope node that declares it.
 template <CaseEqualComparable T>
 class ExternUp : public ExternBase {
  public:
-  ExternUp(Scope* owner, std::string_view ancestor, std::string_view signal)
-      : owner_(owner), ancestor_(ancestor), signal_(signal) {
+  ExternUp(
+      Scope* owner, std::string_view ancestor,
+      std::initializer_list<ChildStep> tail, std::string_view signal)
+      : owner_(owner), ancestor_(ancestor), tail_(tail), signal_(signal) {
     owner_->RegisterExtern(this);
   }
 
   void Relocate() override {
-    cell_ = static_cast<Var<T>*>(owner_->ResolveUpward(ancestor_, signal_));
+    Scope* scope = owner_->ResolveUpwardScope(ancestor_);
+    for (const ChildStep& hop : tail_) {
+      scope =
+          scope->GetChild(ChildRef{.name = hop.name, .indices = hop.indices});
+    }
+    cell_ = static_cast<Var<T>*>(scope->GetSignal(signal_));
   }
 
   [[nodiscard]] auto Get() const -> const T& {
@@ -58,6 +78,7 @@ class ExternUp : public ExternBase {
  private:
   Scope* owner_;
   std::string_view ancestor_;
+  std::vector<ChildStep> tail_;
   std::string_view signal_;
   Var<T>* cell_ = nullptr;
 };

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -15,6 +15,7 @@
 namespace lyra::runtime {
 
 class RuntimeServices;
+class ExternBase;
 
 // Returned by a scope that declares no timescale of its own (the synthetic
 // `$root`). The engine's design-global precision minimum ignores it, so a
@@ -39,6 +40,35 @@ class Scope {
 
   [[nodiscard]] auto Parent() const -> Scope*;
   [[nodiscard]] auto Name() const -> std::string_view;
+
+  // The scope's module definition name. An upward hierarchical reference climbs
+  // the parent chain matching its first name component against each ancestor's
+  // instance name (`Name()`) or module name (this), since the LRM lets the
+  // first component be either (LRM 23.8). The base never matches; a generated
+  // unit class overrides it.
+  [[nodiscard]] virtual auto DefName() const -> std::string_view {
+    return {};
+  }
+
+  // Returns the address of a signal this scope owns by that name, or nullptr if
+  // it has none. An upward reference cannot name its ancestor's type, so it
+  // fetches the signal by name and the ancestor's own class answers
+  // (docs/architecture/emission_model.md).
+  // NOLINTNEXTLINE(readability-named-parameter)
+  [[nodiscard]] virtual auto GetSignal(std::string_view) -> void* {
+    return nullptr;
+  }
+
+  // Climbs the parent chain to the ancestor whose instance name (`Name()`) or
+  // module name (`DefName()`) is `ancestor` and returns its signal named
+  // `signal` (LRM 23.8). The single shared implementation of an upward
+  // reference's runtime navigation; an `ExternUp` member calls it once at Bind.
+  [[nodiscard]] auto ResolveUpward(
+      std::string_view ancestor, std::string_view signal) -> void*;
+
+  // An `ExternUp` member registers itself here from its constructor; Bind
+  // relocates all registered members once the whole tree exists.
+  void RegisterExtern(ExternBase* member);
 
   // The scope's declared time precision as a power of ten (LRM Table 20-2).
   // A scope that declares a timescale overrides this; the base returns the
@@ -94,6 +124,9 @@ class Scope {
   std::vector<std::unique_ptr<RuntimeProcess>> processes_;
   // Empty std::function == clean slot; no parallel dirty bitmap needed.
   std::vector<std::function<void()>> observed_pending_;
+  // Non-owning links to this scope's ExternUp members; relocated at Bind once
+  // the whole tree exists. The members are owned by the derived class.
+  std::vector<ExternBase*> externs_;
 };
 
 // A module / interface / program instance: an owned child built from another

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -16,6 +18,14 @@ namespace lyra::runtime {
 
 class RuntimeServices;
 class ExternBase;
+
+// Names one owned child to fetch from a scope: the member name plus one index
+// per array dimension (empty for a scalar child). A non-owning view; the caller
+// keeps the backing storage alive.
+struct ChildRef {
+  std::string_view name;
+  std::span<const std::size_t> indices;
+};
 
 // Returned by a scope that declares no timescale of its own (the synthetic
 // `$root`). The engine's design-global precision minimum ignores it, so a
@@ -59,12 +69,21 @@ class Scope {
     return nullptr;
   }
 
+  // Returns the owned child scope named by `ref`, or nullptr if it has none.
+  // The twin of `GetSignal` for the object tree: a by-name reference cannot
+  // name the child's type, so the owner indexes its own storage and answers
+  // (docs/architecture/emission_model.md).
+  // NOLINTNEXTLINE(readability-named-parameter)
+  [[nodiscard]] virtual auto GetChild(ChildRef) -> Scope* {
+    return nullptr;
+  }
+
   // Climbs the parent chain to the ancestor whose instance name (`Name()`) or
-  // module name (`DefName()`) is `ancestor` and returns its signal named
-  // `signal` (LRM 23.8). The single shared implementation of an upward
-  // reference's runtime navigation; an `ExternUp` member calls it once at Bind.
-  [[nodiscard]] auto ResolveUpward(
-      std::string_view ancestor, std::string_view signal) -> void*;
+  // module name (`DefName()`) is `ancestor` (LRM 23.8) and returns it. The
+  // shared start of an upward reference's runtime navigation; from there an
+  // `ExternUp` member walks any by-name tail and fetches the leaf, once at
+  // Bind.
+  [[nodiscard]] auto ResolveUpwardScope(std::string_view ancestor) -> Scope*;
 
   // An `ExternUp` member registers itself here from its constructor; Bind
   // relocates all registered members once the whole tree exists.

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -40,6 +40,13 @@ auto RenderField(
   if (mir::GetOwnedChildLeaf(unit, var.type).has_value()) {
     return Indent(indent) + *type_or + " " + var.name + ";\n";
   }
+  // An upward reference is an ExternUp member constructed with its symbol; it
+  // registers itself and relocates at Bind, so it has no value initializer.
+  if (const auto* er =
+          std::get_if<mir::ExternalRefType>(&unit.GetType(var.type).data)) {
+    return Indent(indent) + *type_or + " " + var.name + "{this, \"" +
+           er->ancestor + "\", \"" + er->signal + "\"};\n";
+  }
   auto value_expr_or = RenderExpr(ctor_ctx, ctor_ctx.Expr(var.initializer));
   if (!value_expr_or) {
     return std::unexpected(std::move(value_expr_or.error()));
@@ -304,6 +311,41 @@ auto RenderScopeAsClass(
     out += RenderCreateProcesses(s, indent + 1);
   }
 
+  // A unit-root scope is a module; its name is the def-name an upward reference
+  // matches when climbing the parent chain (LRM 23.8).
+  if (is_top_level) {
+    out += Indent(indent + 1) +
+           "auto DefName() const -> std::string_view override { return \"" +
+           s.name + "\"; }\n";
+  }
+
+  // Exposes this scope's own signals by name. A descendant's upward reference
+  // cannot name this unit's type, so it fetches the signal by name and this
+  // unit answers (emission_model.md). Owned-child members and ExternUp members
+  // (this unit's own upward references) are not this unit's signals.
+  {
+    std::string body;
+    for (const auto& v : s.structural_vars) {
+      if (mir::GetOwnedChildLeaf(unit, v.type).has_value()) {
+        continue;
+      }
+      if (std::holds_alternative<mir::ExternalRefType>(
+              unit.GetType(v.type).data)) {
+        continue;
+      }
+      body += Indent(indent + 2) + "if (n == \"" + v.name + "\") return &" +
+              v.name + ";\n";
+    }
+    if (!body.empty()) {
+      out += "\n";
+      out += Indent(indent + 1) +
+             "auto GetSignal(std::string_view n) -> void* override {\n";
+      out += body;
+      out += Indent(indent + 2) + "return nullptr;\n";
+      out += Indent(indent + 1) + "}\n";
+    }
+  }
+
   // Members follow the constructor and methods. They are public so cross-unit
   // references can reach them directly (see reference_resolution.md).
   if (!s.structural_params.empty() || !s.structural_vars.empty()) {
@@ -323,21 +365,19 @@ auto RenderScopeAsClass(
     out += *field_or;
   }
 
-  // A cross-unit reference slot holds a resolved pointer into a child's member;
-  // the constructor points it at `&child->member`. It mirrors that member's
-  // storage: a `Var<T>*` for an observable scalar, a plain `T*` otherwise.
+  // A downward cross-unit reference slot holds the resolved pointer to a
+  // child's member, mirroring its storage: a `Var<T>*` for an observable
+  // scalar, a plain `T*` otherwise. Filled in the constructor.
   for (std::size_t i = 0; i < s.cross_unit_refs.size(); ++i) {
     const auto& cu = s.cross_unit_refs[i];
     auto type_or = RenderTypeAsCpp(unit, s, cu.type);
     if (!type_or) return std::unexpected(std::move(type_or.error()));
-    const std::string slot =
-        CrossUnitRefSlotName(static_cast<std::uint32_t>(i));
-    if (IsObservableScalarType(unit.GetType(cu.type))) {
-      out += Indent(indent + 1) + "lyra::runtime::Var<" + *type_or + ">* " +
-             slot + " = nullptr;\n";
-    } else {
-      out += Indent(indent + 1) + *type_or + "* " + slot + " = nullptr;\n";
-    }
+    const std::string slot_type = IsObservableScalarType(unit.GetType(cu.type))
+                                      ? "lyra::runtime::Var<" + *type_or + ">*"
+                                      : *type_or + "*";
+    out += Indent(indent + 1) + slot_type + " " +
+           CrossUnitRefSlotName(static_cast<std::uint32_t>(i)) +
+           " = nullptr;\n";
   }
 
   if (s.processes.empty() && s.structural_subroutines.empty()) {
@@ -394,10 +434,12 @@ auto RenderScopeHeaderFile(
   out += "#include <functional>\n";
   out += "#include <memory>\n";
   out += "#include <span>\n";
+  out += "#include <stdexcept>\n";
   out += "#include <string>\n";
   out += "#include <vector>\n";
   out += "#include \"lyra/runtime/coroutine.hpp\"\n";
   out += "#include \"lyra/runtime/delay.hpp\"\n";
+  out += "#include \"lyra/runtime/extern_up.hpp\"\n";
   out += "#include \"lyra/runtime/file_io.hpp\"\n";
   out += "#include \"lyra/runtime/finish.hpp\"\n";
   out += "#include \"lyra/runtime/fork.hpp\"\n";

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -40,12 +40,25 @@ auto RenderField(
   if (mir::GetOwnedChildLeaf(unit, var.type).has_value()) {
     return Indent(indent) + *type_or + " " + var.name + ";\n";
   }
-  // An upward reference is an ExternUp member constructed with its symbol; it
-  // registers itself and relocates at Bind, so it has no value initializer.
+  // An upward reference is an ExternUp member constructed with its symbol --
+  // the ancestor name, the by-name tail down through its owned children, and
+  // the leaf signal. It registers itself and relocates at Bind, so it has no
+  // value initializer.
   if (const auto* er =
           std::get_if<mir::ExternalRefType>(&unit.GetType(var.type).data)) {
+    std::string tail = "{";
+    for (std::size_t i = 0; i < er->tail.size(); ++i) {
+      if (i != 0) tail += ", ";
+      tail += "{\"" + er->tail[i].name + "\", {";
+      for (std::size_t j = 0; j < er->tail[i].indices.size(); ++j) {
+        if (j != 0) tail += ", ";
+        tail += std::to_string(er->tail[i].indices[j]);
+      }
+      tail += "}}";
+    }
+    tail += "}";
     return Indent(indent) + *type_or + " " + var.name + "{this, \"" +
-           er->ancestor + "\", \"" + er->signal + "\"};\n";
+           er->ancestor + "\", " + tail + ", \"" + er->signal + "\"};\n";
   }
   auto value_expr_or = RenderExpr(ctor_ctx, ctor_ctx.Expr(var.initializer));
   if (!value_expr_or) {
@@ -340,6 +353,40 @@ auto RenderScopeAsClass(
       out += "\n";
       out += Indent(indent + 1) +
              "auto GetSignal(std::string_view n) -> void* override {\n";
+      out += body;
+      out += Indent(indent + 2) + "return nullptr;\n";
+      out += Indent(indent + 1) + "}\n";
+    }
+  }
+
+  // Exposes this scope's owned children by name -- the twin of GetSignal for
+  // the object tree. A by-name reference (an upward reference's tail) cannot
+  // name a child's type, so the owner indexes its own storage and answers
+  // (emission_model.md). These are exactly the members GetSignal skips.
+  {
+    std::string body;
+    for (const auto& v : s.structural_vars) {
+      if (!mir::GetOwnedChildLeaf(unit, v.type).has_value()) {
+        continue;
+      }
+      std::string access = v.name;
+      mir::TypeId leaf_type = v.type;
+      std::size_t dim = 0;
+      while (const auto* vec =
+                 std::get_if<mir::VectorType>(&unit.GetType(leaf_type).data)) {
+        access += ".at(ref.indices[" + std::to_string(dim) + "])";
+        leaf_type = vec->element;
+        ++dim;
+      }
+      access += ".get()";
+      body += Indent(indent + 2) + "if (ref.name == \"" + v.name +
+              "\") return " + access + ";\n";
+    }
+    if (!body.empty()) {
+      out += "\n";
+      out += Indent(indent + 1) +
+             "auto GetChild(lyra::runtime::ChildRef ref) "
+             "-> lyra::runtime::Scope* override {\n";
       out += body;
       out += Indent(indent + 2) + "return nullptr;\n";
       out += Indent(indent + 1) + "}\n";

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -241,11 +241,10 @@ auto RenderConstructExternalUnitStmt(
       s.dims, 0, indent);
 }
 
-// Points the slot at the leaf member it references, once the subtree exists.
-// The slot is a `Var<T>*`; the head var and every intervening instance are
-// owning pointers reached with `->`, and an instance-array hop indexes the
-// owning vector with `[i]`. Taking the address yields the resolved reference
-// (LRM 23.6 resolved at construction, reference_resolution.md).
+// Points the downward slot at the leaf member it references, once the subtree
+// exists: the head var and every intervening instance are owning pointers
+// reached with `->`, and an instance-array hop indexes the owning vector with
+// `[i]` (LRM 23.6 resolved at construction, reference_resolution.md).
 auto RenderResolveCrossUnitRefStmt(
     const RenderContext& ctx, const mir::ResolveCrossUnitRefStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
@@ -331,9 +330,10 @@ auto RenderDoWhileStmtNode(
   return result;
 }
 
-// The Observable pointer a sensitivity leaf subscribes to: a structural var
-// yields the address of its own field; a cross-unit slot is already a resolved
-// `Var<T>*`, so the slot name is the pointer.
+// The Observable pointer a sensitivity leaf subscribes to: a plain structural
+// var yields the address of its own field; an ExternalRef member subscribes
+// through its resolved cell (AsObservable); a downward slot is already a
+// resolved `Var<T>*`, so the slot name is the pointer.
 auto RenderSensitivityRefPtr(
     const RenderContext& ctx, const mir::SensitivityRef& ref)
     -> diag::Result<std::string> {
@@ -342,6 +342,12 @@ auto RenderSensitivityRefPtr(
           [&](const mir::StructuralVarRef& r) -> diag::Result<std::string> {
             auto name = RenderStructuralVarName(ctx, r);
             if (!name) return std::unexpected(std::move(name.error()));
+            const auto& var =
+                ctx.StructuralScopeAtHops(r.hops).GetStructuralVar(r.var);
+            if (std::holds_alternative<mir::ExternalRefType>(
+                    ctx.Unit().GetType(var.type).data)) {
+              return *name + ".AsObservable()";
+            }
             return "&" + *name;
           },
           [&](const mir::CrossUnitVarRef& r) -> diag::Result<std::string> {

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -42,7 +42,10 @@ auto RenderPackedArrayCtorArgs(const mir::PackedArrayType& pa) -> std::string {
 }
 
 auto IsObservableScalarType(const mir::Type& ty) -> bool {
-  return ty.IsIntegralPacked();
+  // An ExternalRef member is a Var-like observable: it forwards reads, writes,
+  // and subscription to its resolved cell, so a write routes through Set.
+  return ty.IsIntegralPacked() ||
+         std::holds_alternative<mir::ExternalRefType>(ty.data);
 }
 
 auto RenderEnumClassName(
@@ -108,6 +111,11 @@ auto RenderTypeAsCpp(
             auto inner_or = RenderTypeAsCpp(unit, owner_scope, v.element);
             if (!inner_or) return std::unexpected(std::move(inner_or.error()));
             return "std::vector<" + *inner_or + ">";
+          },
+          [&](const mir::ExternalRefType& e) -> diag::Result<std::string> {
+            auto inner_or = RenderTypeAsCpp(unit, owner_scope, e.element);
+            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
+            return "lyra::runtime::ExternUp<" + *inner_or + ">";
           },
           [](const auto&) -> diag::Result<std::string> {
             throw InternalError(

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -21,6 +21,7 @@
 #include <slang/ast/expressions/MiscExpressions.h>
 #include <slang/ast/expressions/OperatorExpressions.h>
 #include <slang/ast/expressions/SelectExpressions.h>
+#include <slang/ast/symbols/CompilationUnitSymbols.h>
 #include <slang/ast/symbols/InstanceSymbols.h>
 #include <slang/ast/symbols/ParameterSymbols.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
@@ -299,12 +300,12 @@ auto LowerNamedValueProc(
       binding->type, span);
 }
 
-// LRM 23.6 hierarchical reference. Resolves a downward path through instances
-// and instance arrays (`c.x`, `m.l.x`, `c[1].x`, ...) into a cross-unit
-// reference slot whose recipe is the navigation path from a local child member
-// down to the leaf; the constructor resolution lives downstream
-// (reference_resolution.md). Upward, generate-scope, and interface-port forms
-// are rejected explicitly here so they never lower into a silently-wrong shape.
+// LRM 23.6 hierarchical reference. The head of the navigation differs by
+// direction: a downward path (`c.x`, `m.l.x`, `c[1].x`) starts at a local child
+// member; an upward path (`Top.g`, `Top.sib.y`) starts by climbing the parent
+// chain at construction to the named ancestor instance. The shared tail
+// (`path.subspan(1)`) and the resolve-once slot are common
+// (reference_resolution.md, docs/decisions/upward-reference-resolution.md).
 auto LowerHierarchicalValueProc(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
     const ScopeStack& stack, const slang::ast::HierarchicalValueExpression& hve)
@@ -318,12 +319,6 @@ auto LowerHierarchicalValueProc(
         "interface-port hierarchical reference is not yet supported",
         diag::UnsupportedCategory::kOperation);
   }
-  if (ref.isUpward()) {
-    return diag::Unsupported(
-        span, diag::DiagCode::kUnsupportedExpressionForm,
-        "upward hierarchical reference is not yet supported",
-        diag::UnsupportedCategory::kOperation);
-  }
 
   const auto& target = hve.symbol;
   if (target.kind != slang::ast::SymbolKind::Variable) {
@@ -334,39 +329,13 @@ auto LowerHierarchicalValueProc(
         diag::UnsupportedCategory::kOperation);
   }
 
-  // ref.path is slang's resolved top-down navigation: path.front() is the head
-  // (this unit's local instance or instance-array member); the rest navigate
-  // down to the leaf (path.back() is `target`), each step a named member or an
-  // instance-array index.
-  const slang::ast::Symbol& head_sym = *ref.path.front().symbol;
-  const bool head_is_instance_member =
-      head_sym.kind == slang::ast::SymbolKind::Instance ||
-      head_sym.kind == slang::ast::SymbolKind::InstanceArray;
-  if (!head_is_instance_member) {
-    return diag::Unsupported(
-        span, diag::DiagCode::kUnsupportedExpressionForm,
-        "hierarchical reference through a generate-block scope is not yet "
-        "supported",
-        diag::UnsupportedCategory::kOperation);
-  }
-  // An instance / instance-array member reached downward from this unit's scope
-  // is a direct member, which the pre-pass always binds. A downward path cannot
-  // reach a sibling top-level unit (that routes through $root and is caught by
-  // isUpward above), so a missing binding is a compiler-bug invariant.
-  const auto head_binding = unit_state.LookupInstanceMemberBinding(head_sym);
-  if (!head_binding.has_value()) {
-    throw InternalError(
-        "LowerHierarchicalValueProc: downward head member has no binding");
-  }
-  const auto hops = stack.HopsTo(head_binding->home_frame);
-  if (!hops.has_value() || hops->value != 0) {
-    return diag::Unsupported(
-        span, diag::DiagCode::kUnsupportedExpressionForm,
-        "hierarchical reference across a generate-block scope boundary is not "
-        "yet supported",
-        diag::UnsupportedCategory::kOperation);
-  }
+  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, hve);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
 
+  // ref.path is slang's resolved top-down navigation: path.front() is the head
+  // (a local member downward, the named ancestor upward); the rest navigate
+  // down to the leaf (path.back() is `target`), each step a named member or an
+  // instance-array index. The tail is shared by both directions.
   std::vector<hir::PathStep> path;
   path.reserve(ref.path.size() - 1);
   for (const auto& step : ref.path.subspan(1)) {
@@ -387,13 +356,88 @@ auto LowerHierarchicalValueProc(
     }
   }
 
-  auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, hve);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-
   const auto& var = target.as<slang::ast::VariableSymbol>();
+  const slang::ast::Symbol& head_sym = *ref.path.front().symbol;
+
+  if (ref.isUpward()) {
+    // An upward reference (LRM 23.8) climbs the parent chain to the ancestor
+    // named by the reference's first source component, then fetches the leaf
+    // signal from it by name. A named generate / procedural block ancestor or a
+    // `$root`-anchored path (neither a module instance) is not yet supported.
+    if (head_sym.kind != slang::ast::SymbolKind::Instance) {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "upward hierarchical reference whose target ancestor is not a module "
+          "instance is not yet supported",
+          diag::UnsupportedCategory::kOperation);
+    }
+    // First cut: the leaf sits directly on the matched ancestor (path is
+    // ancestor + leaf). Descending through a child instance after the climb
+    // needs a separate by-name child-navigation surface.
+    if (ref.path.size() != 2) {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "upward hierarchical reference that descends through a child "
+          "instance "
+          "is not yet supported",
+          diag::UnsupportedCategory::kOperation);
+    }
+    // The slot lives in the owning structural scope and the climb starts from
+    // its object. A reference inside a generate block would need its slot on a
+    // nested generate class; restrict to the unit root for now.
+    if (stack.Depth() != 1) {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "upward hierarchical reference inside a generate block is not yet "
+          "supported",
+          diag::UnsupportedCategory::kOperation);
+    }
+    // The climb key is the ancestor's module name (LRM 23.8) -- class-level, so
+    // one artifact serves every instance regardless of depth. It comes from the
+    // resolved ancestor symbol, never from syntax (a wrapped sub-expression
+    // like `Top.g[3]` may carry none).
+    std::string ancestor_name{
+        head_sym.as<slang::ast::InstanceSymbol>().getDefinition().name};
+    std::string signal_name{ref.path.back().symbol->name};
+    return MakeCrossUnitMemberRef(
+        unit_state, var, stack.Current(),
+        hir::UpwardHead{
+            .ancestor_name = std::move(ancestor_name),
+            .signal_name = std::move(signal_name)},
+        {}, *type_id, span);
+  }
+
+  // Downward: the head is an owned instance / instance-array member this unit's
+  // scope directly binds (the pre-pass always binds it). A missing binding is a
+  // compiler-bug invariant. Crossing a generate-block scope is not yet
+  // supported.
+  const bool head_is_instance_member =
+      head_sym.kind == slang::ast::SymbolKind::Instance ||
+      head_sym.kind == slang::ast::SymbolKind::InstanceArray;
+  if (!head_is_instance_member) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "hierarchical reference through a generate-block scope is not yet "
+        "supported",
+        diag::UnsupportedCategory::kOperation);
+  }
+  const auto head_binding = unit_state.LookupInstanceMemberBinding(head_sym);
+  if (!head_binding.has_value()) {
+    throw InternalError(
+        "LowerHierarchicalValueProc: downward head member has no binding");
+  }
+  const auto hops = stack.HopsTo(head_binding->home_frame);
+  if (!hops.has_value() || hops->value != 0) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "hierarchical reference across a generate-block scope boundary is not "
+        "yet supported",
+        diag::UnsupportedCategory::kOperation);
+  }
   return MakeCrossUnitMemberRef(
-      unit_state, var, head_binding->home_frame, head_binding->member_id,
-      std::move(path), *type_id, span);
+      unit_state, var, head_binding->home_frame,
+      hir::DownwardHead{.instance = head_binding->member_id}, std::move(path),
+      *type_id, span);
 }
 
 auto LowerNamedValueStructural(
@@ -1486,11 +1530,11 @@ auto LowerConditionalExprStructural(
 
 auto MakeCrossUnitMemberRef(
     UnitLoweringState& unit_state, const slang::ast::ValueSymbol& target,
-    ScopeFrameId home_frame, hir::InstanceMemberId member,
+    ScopeFrameId home_frame, hir::CrossUnitRefHead head,
     std::vector<hir::PathStep> path, hir::TypeId type, diag::SourceSpan span)
     -> hir::Expr {
   const hir::CrossUnitRefId slot = unit_state.MapOrGetCrossUnitRef(
-      target, home_frame, member, std::move(path), type);
+      target, home_frame, std::move(head), std::move(path), type);
   return MakeRefExpr(hir::CrossUnitVarRef{.id = slot}, type, span);
 }
 

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -360,10 +360,10 @@ auto LowerHierarchicalValueProc(
   const slang::ast::Symbol& head_sym = *ref.path.front().symbol;
 
   if (ref.isUpward()) {
-    // An upward reference (LRM 23.8) climbs the parent chain to the ancestor
-    // named by the reference's first source component, then fetches the leaf
-    // signal from it by name. A named generate / procedural block ancestor or a
-    // `$root`-anchored path (neither a module instance) is not yet supported.
+    // An upward reference (LRM 23.8) climbs the parent chain to the named
+    // ancestor, then shares `path` with the downward direction to reach the
+    // leaf. A named generate / procedural block ancestor or a `$root`-anchored
+    // path (neither a module instance) is not yet supported.
     if (head_sym.kind != slang::ast::SymbolKind::Instance) {
       return diag::Unsupported(
           span, diag::DiagCode::kUnsupportedExpressionForm,
@@ -371,20 +371,9 @@ auto LowerHierarchicalValueProc(
           "instance is not yet supported",
           diag::UnsupportedCategory::kOperation);
     }
-    // First cut: the leaf sits directly on the matched ancestor (path is
-    // ancestor + leaf). Descending through a child instance after the climb
-    // needs a separate by-name child-navigation surface.
-    if (ref.path.size() != 2) {
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedExpressionForm,
-          "upward hierarchical reference that descends through a child "
-          "instance "
-          "is not yet supported",
-          diag::UnsupportedCategory::kOperation);
-    }
-    // The slot lives in the owning structural scope and the climb starts from
-    // its object. A reference inside a generate block would need its slot on a
-    // nested generate class; restrict to the unit root for now.
+    // The extern member lives on the owning structural scope and the climb
+    // starts from its object. A reference inside a generate block would need
+    // its member on a nested generate class; restrict to the unit root for now.
     if (stack.Depth() != 1) {
       return diag::Unsupported(
           span, diag::DiagCode::kUnsupportedExpressionForm,
@@ -398,13 +387,10 @@ auto LowerHierarchicalValueProc(
     // like `Top.g[3]` may carry none).
     std::string ancestor_name{
         head_sym.as<slang::ast::InstanceSymbol>().getDefinition().name};
-    std::string signal_name{ref.path.back().symbol->name};
     return MakeCrossUnitMemberRef(
         unit_state, var, stack.Current(),
-        hir::UpwardHead{
-            .ancestor_name = std::move(ancestor_name),
-            .signal_name = std::move(signal_name)},
-        {}, *type_id, span);
+        hir::UpwardHead{.ancestor_name = std::move(ancestor_name)},
+        std::move(path), *type_id, span);
   }
 
   // Downward: the head is an owned instance / instance-array member this unit's

--- a/src/lyra/lowering/ast_to_hir/port_connection.cpp
+++ b/src/lyra/lowering/ast_to_hir/port_connection.cpp
@@ -64,6 +64,14 @@ auto LowerInstancePortConnectionsInto(
   }
 
   for (const auto* conn : inst.getPortConnections()) {
+    // An interface port's connection symbol is an InterfacePortSymbol, not a
+    // PortSymbol; casting it as one is undefined. Interface ports are a
+    // separate workstream (compilation_unit_model.md).
+    if (conn->port.kind != slang::ast::SymbolKind::Port) {
+      return PortConnectionUnsupported(
+          span,
+          "interface or non-variable port connection is not yet supported");
+    }
     const auto& port = conn->port.as<slang::ast::PortSymbol>();
 
     if (port.direction == slang::ast::ArgumentDirection::Ref) {
@@ -101,7 +109,8 @@ auto LowerInstancePortConnectionsInto(
     auto type_id = unit_state.GetTypeId(port_type, span);
     if (!type_id) return std::unexpected(std::move(type_id.error()));
     hir::Expr child_ref = MakeCrossUnitMemberRef(
-        unit_state, *internal, binding->home_frame, binding->member_id,
+        unit_state, *internal, binding->home_frame,
+        hir::DownwardHead{.instance = binding->member_id},
         {hir::MemberHop{std::string{internal->name}}}, *type_id, span);
 
     if (port.direction == slang::ast::ArgumentDirection::In) {

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -220,8 +220,9 @@ auto InstallInstanceMembers(
 }
 
 // An upward cross-unit reference materializes as an ExternalRef member: the
-// (ancestor, signal) symbol lives on its type, and the runtime ExternUp member
-// self-relocates at Bind by climbing the parent chain
+// symbol -- ancestor name, by-name tail through its owned children, and leaf
+// signal -- lives on its type, and the runtime ExternUp member self-relocates
+// at Bind by climbing the parent chain then walking the tail
 // (docs/architecture/emission_model.md). This runs before processes so reads
 // resolve to the member. Every cross-unit ref slot's MIR target is recorded in
 // HIR slot order; a downward slot keeps a CrossUnitVarRef that
@@ -233,17 +234,41 @@ void MaterializeCrossUnitRefTargets(
   std::uint32_t downward_slot = 0;
   for (const auto& cu : scope.cross_unit_refs) {
     if (const auto* up = std::get_if<hir::UpwardHead>(&cu.head)) {
+      // `cu.path` runs from the ancestor down to the leaf, shared with the
+      // downward direction. Fold it into by-name child hops (each member opens
+      // a hop, following array indices attach to it) and the final leaf signal.
+      std::vector<mir::ChildStep> tail;
+      for (const auto& step : cu.path) {
+        if (const auto* member = std::get_if<hir::MemberHop>(&step)) {
+          tail.push_back(mir::ChildStep{.name = member->name, .indices = {}});
+        } else {
+          tail.back().indices.push_back(std::get<hir::IndexHop>(step).index);
+        }
+      }
+      std::string signal = std::move(tail.back().name);
+      tail.pop_back();
+
+      std::string member_name = "up_" + up->ancestor_name;
+      for (const auto& hop : tail) {
+        member_name += "_" + hop.name;
+        for (const std::uint32_t index : hop.indices) {
+          member_name += std::to_string(index);
+        }
+      }
+      member_name += "_" + signal;
+
       const mir::TypeId leaf = unit_state.TranslateType(cu.type);
       const mir::TypeId ext_type = unit_state.AddType(
           mir::ExternalRefType{
               .element = leaf,
               .ancestor = up->ancestor_name,
-              .signal = up->signal_name});
+              .tail = std::move(tail),
+              .signal = std::move(signal)});
       const mir::ExprId init =
           SynthesizeDefaultValueExpr(unit_state, ctor_scope_state, leaf);
       const mir::StructuralVarId var = scope_state.AddStructuralVar(
           mir::StructuralVarDecl{
-              .name = "up_" + up->ancestor_name + "_" + up->signal_name,
+              .name = std::move(member_name),
               .type = ext_type,
               .initializer = init});
       scope_state.AddCrossUnitRefTarget(

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -219,17 +219,56 @@ auto InstallInstanceMembers(
   return instance_member_vars;
 }
 
-// Cross-unit references resolve once at construction, after the child
-// instances are built (reference_resolution.md). Each slot's resolution
-// statement runs at the tail of the constructor body.
+// An upward cross-unit reference materializes as an ExternalRef member: the
+// (ancestor, signal) symbol lives on its type, and the runtime ExternUp member
+// self-relocates at Bind by climbing the parent chain
+// (docs/architecture/emission_model.md). This runs before processes so reads
+// resolve to the member. Every cross-unit ref slot's MIR target is recorded in
+// HIR slot order; a downward slot keeps a CrossUnitVarRef that
+// InstallCrossUnitRefs materializes into the constructor.
+void MaterializeCrossUnitRefTargets(
+    UnitLoweringState& unit_state, StructuralScopeLoweringState& scope_state,
+    const hir::StructuralScope& scope,
+    ProceduralScopeLoweringState& ctor_scope_state) {
+  std::uint32_t downward_slot = 0;
+  for (const auto& cu : scope.cross_unit_refs) {
+    if (const auto* up = std::get_if<hir::UpwardHead>(&cu.head)) {
+      const mir::TypeId leaf = unit_state.TranslateType(cu.type);
+      const mir::TypeId ext_type = unit_state.AddType(
+          mir::ExternalRefType{
+              .element = leaf,
+              .ancestor = up->ancestor_name,
+              .signal = up->signal_name});
+      const mir::ExprId init =
+          SynthesizeDefaultValueExpr(unit_state, ctor_scope_state, leaf);
+      const mir::StructuralVarId var = scope_state.AddStructuralVar(
+          mir::StructuralVarDecl{
+              .name = "up_" + up->ancestor_name + "_" + up->signal_name,
+              .type = ext_type,
+              .initializer = init});
+      scope_state.AddCrossUnitRefTarget(
+          mir::StructuralVarRef{.hops = {.value = 0}, .var = var});
+    } else {
+      scope_state.AddCrossUnitRefTarget(
+          mir::CrossUnitVarRef{.id = {.value = downward_slot}});
+      ++downward_slot;
+    }
+  }
+}
+
+// A downward slot resolves in the constructor by navigating an owned child
+// member after the children are built (reference_resolution.md). Upward slots
+// are materialized as ExternalRef members upstream and skipped here.
 void InstallCrossUnitRefs(
     UnitLoweringState& unit_state, StructuralScopeLoweringState& scope_state,
     const hir::StructuralScope& scope,
     const std::vector<mir::StructuralVarId>& instance_member_vars,
     ProceduralScopeLoweringState& ctor_scope_state) {
   for (const auto& cu : scope.cross_unit_refs) {
-    const mir::StructuralVarId instance_var =
-        instance_member_vars.at(cu.instance.value);
+    const auto* down = std::get_if<hir::DownwardHead>(&cu.head);
+    if (down == nullptr) {
+      continue;
+    }
     std::vector<mir::PathStep> path;
     path.reserve(cu.path.size());
     for (const auto& step : cu.path) {
@@ -241,7 +280,7 @@ void InstallCrossUnitRefs(
     }
     const mir::CrossUnitRefId slot = scope_state.AddCrossUnitRef(
         mir::CrossUnitRefDecl{
-            .instance_var = instance_var,
+            .instance_var = instance_member_vars.at(down->instance.value),
             .path = std::move(path),
             .type = unit_state.TranslateType(cu.type)});
     const mir::StmtId sid = ctor_scope_state.AddStmt(
@@ -632,6 +671,12 @@ auto LowerStructuralScope(
             .name = d.name, .type = mir_type, .initializer = mir_init});
     scope_state.MapStructuralVar(hir_id, mir_id);
   }
+
+  // Upward refs become ExternalRef members and every cross-unit slot's MIR
+  // target is recorded before any body is lowered, so reads and sensitivity in
+  // subroutines and processes resolve each slot.
+  MaterializeCrossUnitRefTargets(
+      unit_state, scope_state, scope, ctor_scope_state);
 
   // Map every subroutine's identity before lowering any body, so a call in one
   // body resolves a forward or mutual reference to a peer (LRM 13.7). Only the

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -278,6 +278,19 @@ auto LowerProceduralVarRefExpr(
       .data = proc_state.TranslateProceduralVar(l.var), .type = type};
 }
 
+// A cross-unit ref resolves to the MIR target recorded for its slot: an upward
+// ref reads its ExternalRef member through a StructuralVarRef, a downward ref
+// keeps a CrossUnitVarRef. `type` is the referenced leaf type either way.
+auto LowerCrossUnitVarRefExpr(
+    const StructuralScopeLoweringState& scope_state,
+    const hir::CrossUnitVarRef& c, mir::TypeId type) -> mir::Expr {
+  return std::visit(
+      [&](const auto& ref) -> mir::Expr {
+        return mir::Expr{.data = ref, .type = type};
+      },
+      scope_state.CrossUnitRefTarget(c.id));
+}
+
 auto LowerLoopVarRefExpr(
     const ConstructorLoweringState& ctor_state, const hir::LoopVarRef& lv,
     mir::TypeId type) -> mir::Expr {
@@ -544,9 +557,7 @@ auto LowerHirPrimaryProc(
             return LowerStructuralParamRefExpr(scope_state, lv, type);
           },
           [&](const hir::CrossUnitVarRef& c) -> mir::Expr {
-            return mir::Expr{
-                .data = mir::CrossUnitVarRef{.id = {.value = c.id.value}},
-                .type = type};
+            return LowerCrossUnitVarRefExpr(scope_state, c, type);
           },
       },
       p);
@@ -594,10 +605,7 @@ auto LowerHirPrimaryStructural(
             // A continuous assignment lowers as a scope-level structural
             // expression, yet it may read or write a cross-unit member: a
             // hierarchical reference or a port connection (LRM 10.3, 23.3.3).
-            // The slot resolves once at construction (reference_resolution.md).
-            return mir::Expr{
-                .data = mir::CrossUnitVarRef{.id = {.value = c.id.value}},
-                .type = type};
+            return LowerCrossUnitVarRefExpr(scope_state, c, type);
           },
       },
       p);

--- a/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
+++ b/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
@@ -42,8 +42,8 @@ auto BuildSensitivityWaitStmt(
             [&](const hir::StructuralVarRef& r) -> mir::SensitivityRef {
               return scope_state.TranslateStructuralVar(r.hops, r.var);
             },
-            [](const hir::CrossUnitVarRef& r) -> mir::SensitivityRef {
-              return mir::CrossUnitVarRef{.id = {.value = r.id.value}};
+            [&](const hir::CrossUnitVarRef& r) -> mir::SensitivityRef {
+              return scope_state.CrossUnitRefTarget(r.id);
             },
         },
         entry.ref);

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -183,6 +183,11 @@ class MirDumper {
             [](const VectorType& v) -> std::string {
               return std::format("Vector(elem=Type[{}])", v.element.value);
             },
+            [](const ExternalRefType& e) -> std::string {
+              return std::format(
+                  "ExternalRef(elem=Type[{}], ancestor={}, signal={})",
+                  e.element.value, e.ancestor, e.signal);
+            },
         },
         t.data);
   }
@@ -627,10 +632,11 @@ class MirDumper {
             path += std::format("[{}]", std::get<IndexHop>(step).index);
           }
         }
+        const std::string head =
+            std::format("StructuralVar[{}]", cu.instance_var.value);
         Line(
             std::format(
-                "[{}] StructuralVar[{}]{} : {}", i, cu.instance_var.value, path,
-                FormatVarType(cu.type)));
+                "[{}] {}{} : {}", i, head, path, FormatVarType(cu.type)));
       }
       Dedent();
     }

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -184,9 +184,16 @@ class MirDumper {
               return std::format("Vector(elem=Type[{}])", v.element.value);
             },
             [](const ExternalRefType& e) -> std::string {
+              std::string tail;
+              for (const auto& hop : e.tail) {
+                tail += "." + hop.name;
+                for (const std::uint32_t index : hop.indices) {
+                  tail += std::format("[{}]", index);
+                }
+              }
               return std::format(
-                  "ExternalRef(elem=Type[{}], ancestor={}, signal={})",
-                  e.element.value, e.ancestor, e.signal);
+                  "ExternalRef(elem=Type[{}], ancestor={}, tail={}, signal={})",
+                  e.element.value, e.ancestor, tail, e.signal);
             },
         },
         t.data);

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -77,6 +77,7 @@ auto Type::Kind() const -> TypeKind {
           },
           [](const OwningPtrType&) { return TypeKind::kOwningPtr; },
           [](const VectorType&) { return TypeKind::kVector; },
+          [](const ExternalRefType&) { return TypeKind::kExternalRef; },
       },
       data);
 }

--- a/src/lyra/runtime/scope.cpp
+++ b/src/lyra/runtime/scope.cpp
@@ -56,18 +56,17 @@ void Scope::RegisterExtern(ExternBase* member) {
   externs_.push_back(member);
 }
 
-auto Scope::ResolveUpward(std::string_view ancestor, std::string_view signal)
-    -> void* {
+auto Scope::ResolveUpwardScope(std::string_view ancestor) -> Scope* {
   Scope* s = parent_;
   while (s != nullptr && s->Name() != ancestor && s->DefName() != ancestor) {
     s = s->Parent();
   }
   if (s == nullptr) {
     throw InternalError(
-        "Scope::ResolveUpward: no ancestor named " + std::string(ancestor) +
-        " on the parent chain");
+        "Scope::ResolveUpwardScope: no ancestor named " +
+        std::string(ancestor) + " on the parent chain");
   }
-  return s->GetSignal(signal);
+  return s;
 }
 
 auto Scope::Services() -> RuntimeServices& {

--- a/src/lyra/runtime/scope.cpp
+++ b/src/lyra/runtime/scope.cpp
@@ -9,6 +9,7 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/runtime/coroutine.hpp"
+#include "lyra/runtime/extern_up.hpp"
 #include "lyra/runtime/process_kind.hpp"
 #include "lyra/runtime/runtime_process.hpp"
 #include "lyra/runtime/runtime_services.hpp"
@@ -42,8 +43,31 @@ auto Scope::Name() const -> std::string_view {
 
 void Scope::Bind(RuntimeServices& services) {
   services_ = &services;
+  // The whole tree is constructed before Bind runs, so every ancestor and the
+  // full parent chain exist when an ExternUp member relocates by climbing.
+  for (ExternBase* member : externs_) {
+    member->Relocate();
+  }
   CreateProcesses();
   ForEachChild([&services](Scope& child) { child.Bind(services); });
+}
+
+void Scope::RegisterExtern(ExternBase* member) {
+  externs_.push_back(member);
+}
+
+auto Scope::ResolveUpward(std::string_view ancestor, std::string_view signal)
+    -> void* {
+  Scope* s = parent_;
+  while (s != nullptr && s->Name() != ancestor && s->DefName() != ancestor) {
+    s = s->Parent();
+  }
+  if (s == nullptr) {
+    throw InternalError(
+        "Scope::ResolveUpward: no ancestor named " + std::string(ancestor) +
+        " on the parent chain");
+  }
+  return s->GetSignal(signal);
 }
 
 auto Scope::Services() -> RuntimeServices& {

--- a/tests/cases/cpp/hierarchy_upward_down_tail/case.yaml
+++ b/tests/cases/cpp/hierarchy_upward_down_tail/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_upward_down_tail
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "11 22 33\n44 22 55\n"

--- a/tests/cases/cpp/hierarchy_upward_down_tail/main.sv
+++ b/tests/cases/cpp/hierarchy_upward_down_tail/main.sv
@@ -1,0 +1,40 @@
+module Sib;
+  int y;
+endmodule
+
+module Deep;
+  int z;
+endmodule
+
+module MidH;
+  Deep deep();
+endmodule
+
+module Bank;
+  int y;
+endmodule
+
+module Reader;
+  int a, b, c;
+  always_comb a = Top.sib.y;        // climb to Top, down into scalar child `sib`
+  always_comb b = Top.mid.deep.z;   // climb to Top, two scalar hops down
+  always_comb c = Top.bank[2].y;    // climb to Top, array-index hop down
+endmodule
+
+module Top;
+  Sib sib();
+  MidH mid();
+  Bank bank[3]();
+  Reader rd();
+  initial begin
+    sib.y = 11;
+    mid.deep.z = 22;
+    bank[2].y = 33;
+    #1;
+    $display("%0d %0d %0d", rd.a, rd.b, rd.c);
+    sib.y = 44;
+    bank[2].y = 55;
+    #1;
+    $display("%0d %0d %0d", rd.a, rd.b, rd.c);
+  end
+endmodule

--- a/tests/cases/cpp/hierarchy_upward_ref/case.yaml
+++ b/tests/cases/cpp/hierarchy_upward_ref/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_upward_ref
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "5 5 99 5\n8 8 8\n"

--- a/tests/cases/cpp/hierarchy_upward_ref/main.sv
+++ b/tests/cases/cpp/hierarchy_upward_ref/main.sv
@@ -1,0 +1,33 @@
+module Leaf;
+  int x;
+  always_comb x = Top.g;
+endmodule
+
+module Mid;
+  Leaf l();
+endmodule
+
+module Writer;
+  initial Top.g2 = 99;
+endmodule
+
+module Sel;
+  int s;
+  always_comb s = Top.g[3:0];   // upward reference wrapped in a value-level select
+endmodule
+
+module Top;
+  int g, g2;
+  Leaf a();
+  Mid m();
+  Writer wr();
+  Sel sel();
+  initial begin
+    g = 5;
+    #1;
+    $display("%0d %0d %0d %0d", a.x, m.l.x, g2, sel.s);
+    g = 8;
+    #1;
+    $display("%0d %0d %0d", a.x, m.l.x, sel.s);
+  end
+endmodule

--- a/tests/cases/cpp/hierarchy_upward_ref_aliased/case.yaml
+++ b/tests/cases/cpp/hierarchy_upward_ref_aliased/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_upward_ref_aliased
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Tb
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "42\n"

--- a/tests/cases/cpp/hierarchy_upward_ref_aliased/main.sv
+++ b/tests/cases/cpp/hierarchy_upward_ref_aliased/main.sv
@@ -1,0 +1,18 @@
+module Leaf;
+  int x;
+  always_comb x = Top.g;
+endmodule
+
+module Top;
+  int g;
+  Leaf l();
+endmodule
+
+module Tb;
+  Top dut();
+  initial begin
+    dut.g = 42;
+    #1;
+    $display("%0d", dut.l.x);
+  end
+endmodule


### PR DESCRIPTION
## Summary

An upward hierarchical reference is a descendant naming a signal in one of its ancestors (`always_comb x = Top.g;` inside a module instantiated under `Top`). Unlike a downward reference, the referrer does not own, instantiate, or even know the type of the ancestor. This resolves such a reference by the referrer climbing its own parent chain at construction to the named ancestor and binding a direct pointer through a generic extern member, naming no ancestor type and embedding no ancestor layout. The match key is the ancestor's semantic module definition name, never source syntax, so a value-wrapped reference like `Top.g[3]` resolves the same way and one artifact serves the referrer at any depth.

The reference is modeled as an ordinary structural-var member whose type is a new `ExternalRef` wrapper, backed by a runtime `ExternUp<T>` that self-registers and relocates once the object tree exists. Reads, writes, and sensitivity flow through the normal structural-var paths dispatched by that type, so MIR keeps no cross-unit slot or resolve statement for an upward reference -- the typed member is the whole story.

Building on that, an upward reference may descend through the ancestor's subtree after the climb (`Top.sib.y`, `Top.mid.deep.z`, `Top.bank[2].y`). That tail is by-name for the same reason the climb is: the referrer owns neither the ancestor nor its children. Each owner answers a `GetChild` query by indexing its own typed storage -- the twin of `GetSignal` for the object tree -- so a multi-dimensional instance array is just more indices, and the leaf-on-ancestor case is the empty-tail zero-case of one uniform walk.

## Testing

`bazel test //...` passes. New end-to-end cases cover the leaf-on-ancestor form, the aliased `module Tb; Top dut();` form resolved by definition name, value-wrapped upward reads, and the scalar / multi-level / array-indexed down-tails.