### PR TITLE
Capture enclosing variables in fork branches

### DIFF
--- a/docs/progress/fork-join.md
+++ b/docs/progress/fork-join.md
@@ -31,6 +31,27 @@ of the same wait -- resume after zero completions -- `join_any` the one-completi
 the all-completions case; they are one mechanism parameterized by a threshold, not three separate
 constructs.
 
+A branch reads and writes the variables of its enclosing scope. The enclosing scope's lifetime
+encompasses the execution of every process the fork spawns (LRM 6.21), so the storage a branch
+reaches stays alive for as long as that branch runs -- even a detached `join_none` / `join_any`
+branch that textually outlives the fork statement. What a branch may safely reach then follows from
+where that storage lives:
+
+- A variable of an enclosing process (`initial` / `always` / `final`) is reached for shared read and
+  write. The process activation outlives the simulation, so a branch under any join mode shares the
+  one live location, observing the value current when it executes. The LRM 9.3.2 loop example relies
+  on this: a branch reads the enclosing loop variable after the loop has finished and sees its final
+  value.
+- Per-iteration data uses an automatic variable declared in the fork's `block_item_declaration`,
+  initialized on entry to the block before any process is spawned, so each spawned process captures
+  its own copy by value.
+- Referring to a subroutine's by-reference formal argument from a `join_any` / `join_none` branch is
+  illegal unless the formal is declared `ref static` (LRM 9.3.2); the frontend rejects it, so it
+  never reaches lowering.
+- The one case LRM 6.21 mandates that is not yet built: an automatic local of an enclosing task
+  reached by a detached branch. The task activation must outlive the spawned branch -- the runtime
+  guarantees this for process activations but not yet for task activations.
+
 ## Sub-Steps
 
 ### Spawning and the join condition
@@ -40,10 +61,9 @@ constructs.
       (`join_any`), or immediately (`join_none`). The LRM 9.3.2 ordering rule holds -- spawned
       processes do not run until the parent blocks at the join or terminates. Branches carry their
       own delay so the three join modes are observable (the parent resumes after the slowest, the
-      earliest, or not at all). Branches read and write module-scope signals only; a branch that
-      references a procedural variable and a named fork block are rejected with a diagnostic rather
-      than miscompiled. A fork inside a task is supported; a fork inside a function stays rejected
-      (a function cannot suspend). Per-branch local storage and the loop-spawn idiom ride on FJ4.
+      earliest, or not at all). A named fork block is rejected with a diagnostic (FJ5); a fork
+      inside a function stays rejected (a function cannot suspend), while a fork inside a task is
+      supported. How a branch reaches its enclosing scope's variables is FJ4.
 
 ### Timing across branches
 
@@ -62,12 +82,16 @@ constructs.
 
 ### Per-branch storage
 
-- [ ] FJ4 -- Variables declared in the fork block scope are initialized on entry, before any process
-      is spawned (LRM 9.3.2). The loop-spawn idiom -- a fork inside a loop whose branch declares an
-      automatic local capturing the loop variable -- gives each spawned process its own
-      per-iteration copy. In `join_any` / `join_none` blocks it is illegal to refer to a
-      subroutine's formal arguments by reference except in those initializers, unless the formal is
-      declared `ref static` (LRM 9.3.2).
+- [ ] FJ4 -- A fork branch reads and writes the variables of its enclosing process, lifting the FJ1
+      restriction to module-scope signals. The branch shares the one live location under every join
+      mode, observing the value current when it executes (LRM 6.21, 9.3.2). Per-iteration data comes
+      from an automatic variable declared in the fork's `block_item_declaration`, initialized on
+      block entry before any process is spawned -- the loop-spawn idiom captures its own copy by
+      value (LRM 9.3.2). A reference to a subroutine's by-reference formal argument from a
+      `join_any` / `join_none` branch is rejected unless declared `ref static` (LRM 9.3.2), and the
+      frontend already rejects it. Deferred: an automatic local of an enclosing task reached by a
+      detached branch -- LRM 6.21 requires the task activation to outlive the branch, which the
+      runtime does for processes but not yet for task activations.
 
 ### Naming
 

--- a/include/lyra/lowering/hir_to_mir/fork_capture.hpp
+++ b/include/lyra/lowering/hir_to_mir/fork_capture.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/closure.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/procedural_hops.hpp"
+#include "lyra/mir/procedural_var.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// Collects a fork branch's by-reference captures as the branch body is lowered
+// (LRM 6.21: the process activation outlives the branch, so the shared storage
+// stays live). Installed on ProcessLoweringState for the duration of one
+// branch: a body reference that resolves above the branch boundary is captured
+// here and rewritten on the spot to a binding local to the branch, so the
+// closure carries its captures by the time it is built -- never by a post-hoc
+// rewrite. `root` receives the binding vars; `outer` (the fork's enclosing
+// scope) receives the captured lvalues.
+class ForkCaptureSink {
+ public:
+  ForkCaptureSink(
+      std::uint32_t boundary_depth, ProceduralScopeLoweringState& root,
+      ProceduralScopeLoweringState& outer)
+      : boundary_depth_(boundary_depth), root_(&root), outer_(&outer) {
+  }
+
+  [[nodiscard]] auto BoundaryDepth() const -> std::uint32_t {
+    return boundary_depth_;
+  }
+
+  // Captures the enclosing variable `outer_var` (declared `decl_depth` scopes
+  // deep) and returns the body reference -- a binding local to the branch root,
+  // read at `current_depth`.
+  auto Capture(
+      mir::ProceduralVarId outer_var, std::uint32_t decl_depth,
+      mir::TypeId type, std::uint32_t current_depth) -> mir::ProceduralVarRef {
+    mir::ProceduralVarId binding = FindOrCreate(outer_var, decl_depth, type);
+    return mir::ProceduralVarRef{
+        .hops = mir::ProceduralHops{.value = current_depth - boundary_depth_},
+        .var = binding};
+  }
+
+  auto TakeCaptures() -> std::vector<mir::Capture> {
+    return std::move(captures_);
+  }
+
+ private:
+  struct Entry {
+    std::uint32_t decl_depth;
+    mir::ProceduralVarId outer_var;
+    mir::ProceduralVarId binding;
+  };
+
+  auto FindOrCreate(
+      mir::ProceduralVarId outer_var, std::uint32_t decl_depth,
+      mir::TypeId type) -> mir::ProceduralVarId {
+    for (const auto& entry : captured_) {
+      if (entry.decl_depth == decl_depth && entry.outer_var == outer_var) {
+        return entry.binding;
+      }
+    }
+    const mir::ProceduralVarId binding = root_->AddProceduralVar(
+        mir::ProceduralVarDecl{
+            .name = "_lyra_fork_cap_" + std::to_string(captures_.size()),
+            .type = type});
+    const mir::ExprId target = outer_->AddExpr(
+        mir::Expr{
+            .data =
+                mir::ProceduralVarRef{
+                    .hops =
+                        mir::ProceduralHops{
+                            .value = (boundary_depth_ - 1) - decl_depth},
+                    .var = outer_var},
+            .type = type});
+    captures_.emplace_back(
+        mir::ByReferenceCapture{.target = target, .binding = binding});
+    captured_.push_back(
+        Entry{
+            .decl_depth = decl_depth,
+            .outer_var = outer_var,
+            .binding = binding});
+    return binding;
+  }
+
+  std::uint32_t boundary_depth_;
+  ProceduralScopeLoweringState* root_;
+  ProceduralScopeLoweringState* outer_;
+  std::vector<mir::Capture> captures_;
+  std::vector<Entry> captured_;
+};
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -424,6 +424,7 @@ struct ProceduralVarBinding {
 };
 
 class ProceduralScopeLoweringState;
+class ForkCaptureSink;
 
 class ProcessLoweringState {
  public:
@@ -513,11 +514,24 @@ class ProcessLoweringState {
     };
   }
 
+  // The capture sink active while a fork branch body is lowered, or null. A
+  // branch-body reference resolving above the branch boundary routes through it
+  // so the closure's by-reference captures are composed as the body is built
+  // (LRM 6.21). Fork lowering installs it; the const expr lowering only reads
+  // it.
+  void SetForkCaptureSink(ForkCaptureSink* sink) {
+    fork_capture_sink_ = sink;
+  }
+  [[nodiscard]] auto ActiveForkCaptureSink() const -> ForkCaptureSink* {
+    return fork_capture_sink_;
+  }
+
  private:
   TimeResolution time_resolution_;
   std::uint32_t procedural_depth_ = 0;
   std::vector<ProceduralVarBinding> bindings_;
   ProceduralScopeLoweringState* static_frame_scope_ = nullptr;
+  ForkCaptureSink* fork_capture_sink_ = nullptr;
   std::vector<mir::StaticLocal> static_locals_;
 };
 

--- a/include/lyra/mir/closure.hpp
+++ b/include/lyra/mir/closure.hpp
@@ -16,7 +16,17 @@ struct ByValueCapture {
   ProceduralVarId binding{};
 };
 
-using Capture = std::variant<ByValueCapture>;
+// A by-reference capture binds the body's `binding` var to an enclosing-scope
+// lvalue (`target`). The spawned body reaches it through a frame-copied
+// reference parameter; the enclosing storage outlives the body (LRM 6.21), so
+// reads and writes share the one live location. Used by fork branches that
+// touch their enclosing process's variables.
+struct ByReferenceCapture {
+  ExprId target{};
+  ProceduralVarId binding{};
+};
+
+using Capture = std::variant<ByValueCapture, ByReferenceCapture>;
 
 // A callable value with captured state and a procedural body.
 //
@@ -27,7 +37,8 @@ using Capture = std::variant<ByValueCapture>;
 // Invariants enforced by lowering (violations are compiler-bug class):
 //   1. Each capture's binding is a ProceduralVarId valid in body.vars and is
 //      unique across the capture list.
-//   2. Bindings are read-only inside body.
+//   2. A ByValueCapture binding is read-only inside body. A ByReferenceCapture
+//      binding may be read and written -- it aliases the enclosing storage.
 //   3. ProceduralVarRef inside body uses hops bounded by body's own scope
 //      nesting and does not escape into the enclosing process scope. Outer
 //      procedural state reaches body only through captures.

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1406,6 +1406,11 @@ auto RenderClosureExpr(
                 return std::unexpected(std::move(value_or.error()));
               }
               return bind_name + " = " + *value_or;
+            },
+            [&](const mir::ByReferenceCapture&) -> diag::Result<std::string> {
+              throw InternalError(
+                  "RenderClosureExpr: by-reference capture appears only in a "
+                  "fork branch, which renders through RenderForkStmtNode");
             }},
         closure.captures[i]);
     if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -110,11 +110,13 @@ auto RenderForkJoinModeLiteral(mir::JoinMode mode) -> std::string_view {
 }
 
 // LRM 9.3.2: each branch is an anonymous ClosureExpr spawned as a concurrent
-// coroutine. It renders inline at the fork as a stateless lambda taking the
-// enclosing scope instance as a by-value `self` parameter -- a parameter is
-// frame-copied, so the spawned coroutine never outlives a captured receiver the
-// way a `[this]` capture would -- through which its body reaches module state
-// and Services(). The fork waits per the join mode.
+// coroutine. It renders inline at the fork as a stateless lambda whose
+// parameters are frame-copied -- so the spawned coroutine never dangles the way
+// a captured lambda would. The first parameter is the enclosing scope instance
+// `self`, through which the body reaches module state and Services(); each
+// closure capture adds one more parameter (a `T&` bound to an enclosing
+// variable for a by-reference capture, a `T` for a by-value capture). The fork
+// waits per the join mode.
 auto RenderForkStmtNode(
     const RenderContext& ctx, const mir::ForkStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
@@ -133,16 +135,43 @@ auto RenderForkStmtNode(
       throw InternalError(
           "RenderForkStmtNode: fork branch closure has no body");
     }
+    std::string params = class_name + "* self";
+    std::string args{receiver_object};
+    for (const auto& capture : closure->captures) {
+      mir::ProceduralVarId binding{};
+      std::string ref_marker;
+      std::string arg;
+      if (const auto* by_ref = std::get_if<mir::ByReferenceCapture>(&capture)) {
+        binding = by_ref->binding;
+        ref_marker = "& ";
+        auto target_or = RenderExpr(ctx, ctx.Expr(by_ref->target));
+        if (!target_or) return std::unexpected(std::move(target_or.error()));
+        arg = *std::move(target_or);
+      } else {
+        const auto& by_value = std::get<mir::ByValueCapture>(capture);
+        binding = by_value.binding;
+        ref_marker = " ";
+        auto value_or = RenderExpr(ctx, ctx.Expr(by_value.value));
+        if (!value_or) return std::unexpected(std::move(value_or.error()));
+        arg = *std::move(value_or);
+      }
+      const auto& bind = closure->body->vars.at(binding.value);
+      auto type_or =
+          RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), bind.type);
+      if (!type_or) return std::unexpected(std::move(type_or.error()));
+      params += ", " + *type_or + ref_marker + bind.name;
+      args += ", " + arg;
+    }
     const RenderContext branch_ctx = ctx.WithProceduralScope(*closure->body)
                                          .WithCoroutine(true)
                                          .WithReceiver("self");
     auto body_or = RenderProceduralScopeStatements(branch_ctx, indent + 2);
     if (!body_or) return std::unexpected(std::move(body_or.error()));
-    out += Indent(indent + 1) + vec + ".push_back([](" + class_name +
-           "* self) -> lyra::runtime::Coroutine {\n";
+    out += Indent(indent + 1) + vec + ".push_back([](" + params +
+           ") -> lyra::runtime::Coroutine {\n";
     out += *body_or;
     out += Indent(indent + 2) + "co_return;\n";
-    out += Indent(indent + 1) + "}(" + receiver_object + "));\n";
+    out += Indent(indent + 1) + "}(" + args + "));\n";
   }
   out += Indent(indent + 1) + "co_await lyra::runtime::Fork(" +
          ctx.ServicesRef() + ", std::move(" + vec + "), " +

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -274,11 +274,17 @@ auto LowerNamedValueProc(
   const auto& var = sym.as<slang::ast::VariableSymbol>();
 
   if (auto local = proc_state.LookupProceduralVar(var)) {
-    if (proc_state.InForkBranch()) {
+    // A branch reaches its enclosing process's variables through a by-reference
+    // capture computed at HIR-to-MIR: the process activation outlives the
+    // spawned branch (LRM 6.21), so the shared storage stays live. A fork
+    // inside a task is deferred -- the task activation does not yet outlive its
+    // spawned branches.
+    if (proc_state.InForkBranch() && proc_state.ContainingSymbol().kind ==
+                                         slang::ast::SymbolKind::Subroutine) {
       return diag::Unsupported(
           span, diag::DiagCode::kUnsupportedForkJoinForm,
-          "a fork-join branch referencing a procedural variable is not yet "
-          "supported; branches may touch only module-scope signals",
+          "a fork-join branch inside a task referencing a procedural variable "
+          "is not yet supported",
           diag::UnsupportedCategory::kFeature);
     }
     const hir::TypeId type_id = proc_state.GetProceduralVarType(*local);

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -25,6 +25,7 @@
 #include "lyra/hir/unary_op.hpp"
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
+#include "lyra/lowering/hir_to_mir/fork_capture.hpp"
 #include "lyra/lowering/hir_to_mir/inside_predicate.hpp"
 #include "lyra/lowering/hir_to_mir/lower_system_subroutine.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
@@ -274,6 +275,19 @@ auto LowerStructuralVarRefExpr(
 auto LowerProceduralVarRefExpr(
     const ProcessLoweringState& proc_state, const hir::ProceduralVarRef& l,
     mir::TypeId type) -> mir::Expr {
+  // Inside a fork branch body, a reference that resolves to an enclosing scope
+  // (declared above the branch boundary) is captured by reference as the body
+  // is lowered (LRM 6.21), so it reads the binding rather than reaching out.
+  if (auto* sink = proc_state.ActiveForkCaptureSink()) {
+    const auto& binding = proc_state.LookupProceduralVar(l.var);
+    if (binding.declaration_procedural_depth < sink->BoundaryDepth()) {
+      return mir::Expr{
+          .data = sink->Capture(
+              binding.var, binding.declaration_procedural_depth, type,
+              proc_state.CurrentProceduralDepth()),
+          .type = type};
+    }
+  }
   return mir::Expr{
       .data = proc_state.TranslateProceduralVar(l.var), .type = type};
 }

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -23,6 +23,7 @@
 #include "lyra/lowering/hir_to_mir/copy_out_desugar.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/delay_time_resolver.hpp"
+#include "lyra/lowering/hir_to_mir/fork_capture.hpp"
 #include "lyra/lowering/hir_to_mir/inside_predicate.hpp"
 #include "lyra/lowering/hir_to_mir/lower_deferred_check.hpp"
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
@@ -638,13 +639,32 @@ auto LowerJoinMode(hir::JoinMode mode) -> mir::JoinMode {
   return mir::JoinMode::kAll;
 }
 
+// True if a fork branch declares a procedural local anywhere in its body. A
+// branch-local initializer that reads an enclosing variable needs a by-value
+// snapshot (the loop-spawn idiom), which is not yet supported; until then a
+// branch that declares a local is rejected rather than risk sharing an
+// enclosing automatic by reference where the LRM wants a per-spawn copy.
+auto ForkBranchDeclaresLocal(const mir::ProceduralScope& scope) -> bool {
+  for (const auto& s : scope.stmts) {
+    if (std::holds_alternative<mir::ProceduralVarDeclStmt>(s.data)) {
+      return true;
+    }
+    for (const auto& child : s.child_procedural_scopes) {
+      if (ForkBranchDeclaresLocal(child)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 // LRM 9.3.2: each parallel statement becomes a concurrent process. Each branch
-// lowers to a closure -- a captured callable value with (for FJ1) an empty
-// capture list -- composed into the enclosing scope's expr arena, exactly as
-// the NBA deferred-write closure is composed. The ForkStmt then references the
-// branch closures by id; it owns no nested scopes. The closure runs as a
-// coroutine by virtue of being a fork branch (spawned), not by any property of
-// the closure node.
+// lowers to a closure -- a captured callable value -- composed into the
+// enclosing scope's expr arena, exactly as the NBA deferred-write closure is
+// composed. References to the enclosing process's variables become by-reference
+// captures (LRM 6.21). The ForkStmt then references the branch closures by id;
+// it owns no nested scopes. The closure runs as a coroutine by virtue of being
+// a fork branch (spawned), not by any property of the closure node.
 auto LowerForkStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
@@ -658,9 +678,20 @@ auto LowerForkStmt(
     const hir::Stmt& branch = hir_proc.stmts.at(branch_hir_id.value);
     ProceduralScopeLoweringState branch_scope_state;
     ProceduralDepthGuard depth_guard{proc_state};
+
+    // Collect the branch's by-reference captures as its body is lowered: a body
+    // reference resolving above this boundary depth routes through the sink,
+    // which composes the capture and binding on the spot (LRM 6.21). A nested
+    // fork restores the prior sink on exit.
+    ForkCaptureSink sink{
+        proc_state.CurrentProceduralDepth(), branch_scope_state,
+        proc_scope_state};
+    ForkCaptureSink* const previous_sink = proc_state.ActiveForkCaptureSink();
+    proc_state.SetForkCaptureSink(&sink);
     auto lowered = LowerStmt(
         unit_state, scope_state, proc_state, branch_scope_state, hir_proc,
         branch);
+    proc_state.SetForkCaptureSink(previous_sink);
     if (!lowered) {
       return std::unexpected(std::move(lowered.error()));
     }
@@ -668,9 +699,18 @@ auto LowerForkStmt(
         branch_scope_state.AddStmt(*std::move(lowered));
     branch_scope_state.AddRootStmt(branch_stmt_id);
 
+    mir::ProceduralScope body = branch_scope_state.Finish();
+    if (ForkBranchDeclaresLocal(body)) {
+      return diag::Unsupported(
+          stmt.span, diag::DiagCode::kUnsupportedForkJoinForm,
+          "a fork-join branch that declares a local variable is not yet "
+          "supported",
+          diag::UnsupportedCategory::kFeature);
+    }
+
     mir::ClosureExpr closure;
-    closure.body =
-        std::make_unique<mir::ProceduralScope>(branch_scope_state.Finish());
+    closure.captures = sink.TakeCaptures();
+    closure.body = std::make_unique<mir::ProceduralScope>(std::move(body));
     branch_ids.push_back(proc_scope_state.AddExpr(
         mir::Expr{
             .data = std::move(closure),

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -1170,6 +1170,19 @@ class MirDumper {
                       FormatExpr(enclosing, bv.value)));
               Dedent();
             },
+            [&](const ByReferenceCapture& br) {
+              Line(
+                  std::format(
+                      "[{}] ByReferenceCapture target=Expr[{}] binding="
+                      "ProceduralVarId{{{}}}",
+                      index, br.target.value, br.binding.value));
+              Indent();
+              Line(
+                  std::format(
+                      "Expr[{}] {}", br.target.value,
+                      FormatExpr(enclosing, br.target)));
+              Dedent();
+            },
         },
         capture);
   }

--- a/tests/cases/cpp/fork_branch_outer_static/case.yaml
+++ b/tests/cases/cpp/fork_branch_outer_static/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.fork_branch_outer_static
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      [10] read x=5
+      [20] after join x=7

--- a/tests/cases/cpp/fork_branch_outer_static/main.sv
+++ b/tests/cases/cpp/fork_branch_outer_static/main.sv
@@ -1,0 +1,11 @@
+`timescale 1ns / 1ns
+module Test;
+  initial begin
+    static int x = 5;
+    fork
+      #10 $display("[%0d] read x=%0d", $time, x);
+      #20 x = 7;
+    join
+    $display("[%0d] after join x=%0d", $time, x);
+  end
+endmodule

--- a/tests/cases/errors/fork_branch_procedural_local/case.yaml
+++ b/tests/cases/errors/fork_branch_procedural_local/case.yaml
@@ -11,6 +11,6 @@ expect:
   stderr:
     contains:
       - "unsupported:"
-      - "fork-join branch referencing a procedural variable"
+      - "fork-join branch inside a task referencing a procedural variable"
     not_contains:
       - "internal error"

--- a/tests/cases/errors/fork_branch_procedural_local/main.sv
+++ b/tests/cases/errors/fork_branch_procedural_local/main.sv
@@ -1,9 +1,11 @@
 `timescale 1ns / 1ns
 module Test;
-  initial begin
-    int x = 5;
+  task automatic run_branches();
+    automatic int x = 5;
     fork
       #10 $display("%0d", x);
     join
-  end
+  endtask
+
+  initial run_branches();
 endmodule


### PR DESCRIPTION
## Summary

A fork branch can now read and write the variables of its enclosing process, not just module-scope signals. Each branch is a spawned coroutine that reaches an enclosing variable through a frame-copied by-reference parameter; the process activation outlives the simulation (LRM 6.21), so the shared storage stays live under every join mode and the branch observes the value current when it executes.

## Design

The captures are collected as the branch body is lowered, through a `ForkCaptureSink` the fork lowering installs on the process state: a reference resolving above the branch boundary is captured on the spot (binding created in the branch, captured lvalue recorded in the enclosing scope) and rewritten to read that binding. So the closure carries its captures the moment it is built, never by a post-hoc rewrite. The expression lowering stays `const` on the process state; only the external sink mutates. A new `ByReferenceCapture` MIR kind sits beside the existing by-value capture and renders as a `T&` coroutine parameter.

## Deferred

A fork inside a task touching a task-local stays rejected (LRM 6.21 requires the task activation to outlive the branch, which the runtime does for processes but not yet for tasks), and a branch that declares a local (the loop-spawn by-value snapshot) is rejected -- both with explicit diagnostics rather than miscompiled.

## Testing

A `cpp_run` case where one branch reads and another writes the enclosing variable and the parent observes the write after join; the existing rejection case repointed to the still-deferred fork-in-task form.