### PR TITLE
Resolve hierarchical references by name across generate blocks

### DIFF
--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -138,9 +138,14 @@ consume. Coverage is demonstrated through Stage D and Stage E.
       object-tree ownership.
 - [x] D6 -- A hierarchical path that indexes an instance array (`c[i].x`) resolves to the selected
       element, including multi-dimensional arrays (`c[i][j].x`).
-- [ ] D7 -- A hierarchical reference crosses a generate-block scope boundary: a path step through a
-      generate block (`g.sig`), or a reference originating inside a generate block that names a
-      signal in an enclosing scope.
+- [ ] D7 -- A hierarchical reference crosses a generate-block scope boundary. A by-name reference
+      reaches a generate block by its LRM name (the source label, or `genblk<n>` when unnamed, LRM
+      27.6), indexes a loop-generate block, and continues to a signal or a further child inside it;
+      when an if/case construct's alternatives share a name (LRM 27.5) the reference binds whichever
+      alternative was instantiated. Landed for the by-name direction -- an upward reference whose
+      downward tail crosses the generate boundary. Still open: a reference from the scope that owns
+      the generate descending into its own generate block, and a reference originating inside a
+      generate block that names a signal in an enclosing scope.
 
 Unlocks `refs/hierarchical_refs`, `refs/upward_refs`, and `instantiation/hierarchical_sensitivity`.
 

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -129,6 +129,9 @@ struct Generate {
 
 struct StructuralScope {
   StructuralScopeId id{};
+  // LRM source name of a generate child (label, or `genblk<n>` when unnamed,
+  // LRM 27.6); empty for other scopes.
+  std::string source_name;
   TimeResolution time_resolution;
   std::vector<StructuralVarDecl> structural_vars;
   std::vector<LoopVarDecl> loop_var_decls;

--- a/include/lyra/mir/structural_var.hpp
+++ b/include/lyra/mir/structural_var.hpp
@@ -21,6 +21,10 @@ struct StructuralVarId {
 // expression at the HIR-to-MIR boundary, so every variable carries one.
 struct StructuralVarDecl {
   std::string name;
+  // By-name lookup key; differs from the unique physical `name` only for a
+  // generate companion, where same-name if/else arms (LRM 27.5) share one key.
+  // Empty when it equals `name`.
+  std::string source_name = {};
   TypeId type;
   ExprId initializer;
 };

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -364,9 +364,13 @@ auto RenderScopeAsClass(
   // name a child's type, so the owner indexes its own storage and answers
   // (emission_model.md). These are exactly the members GetSignal skips.
   {
-    std::string body;
+    // Group owned children by the name a reference uses; same-name if/else arms
+    // (LRM 27.5) share one key, so a conditional arm is guarded and the group
+    // returns whichever was constructed.
+    std::vector<std::pair<std::string, std::string>> groups;
     for (const auto& v : s.structural_vars) {
-      if (!mir::GetOwnedChildLeaf(unit, v.type).has_value()) {
+      const auto leaf = mir::GetOwnedChildLeaf(unit, v.type);
+      if (!leaf.has_value()) {
         continue;
       }
       std::string access = v.name;
@@ -378,9 +382,26 @@ auto RenderScopeAsClass(
         leaf_type = vec->element;
         ++dim;
       }
-      access += ".get()";
-      body += Indent(indent + 2) + "if (ref.name == \"" + v.name +
-              "\") return " + access + ";\n";
+      const bool conditional =
+          leaf->kind == mir::OwnedChildKind::kGenerateScope && dim == 0;
+      const std::string line =
+          conditional ? Indent(indent + 3) + "if (" + v.name + ") return " +
+                            access + ".get();\n"
+                      : Indent(indent + 3) + "return " + access + ".get();\n";
+      const std::string& key = v.source_name.empty() ? v.name : v.source_name;
+      auto it = std::ranges::find(
+          groups, key, &std::pair<std::string, std::string>::first);
+      if (it == groups.end()) {
+        groups.emplace_back(key, line);
+      } else {
+        it->second += line;
+      }
+    }
+    std::string body;
+    for (const auto& [key, lines] : groups) {
+      body += Indent(indent + 2) + "if (ref.name == \"" + key + "\") {\n";
+      body += lines;
+      body += Indent(indent + 2) + "}\n";
     }
     if (!body.empty()) {
       out += "\n";

--- a/src/lyra/lowering/ast_to_hir/generate.cpp
+++ b/src/lyra/lowering/ast_to_hir/generate.cpp
@@ -87,6 +87,7 @@ auto AddChildScope(
     const slang::ast::GenerateBlockSymbol& block)
     -> diag::Result<hir::StructuralScopeId> {
   hir::StructuralScope scope;
+  scope.source_name = std::string{block.name};
   auto r = LowerScopeInto(unit_facts, unit_state, scope, block, stack);
   if (!r) return std::unexpected(std::move(r.error()));
   return AddChildStructuralScope(generate, std::move(scope));
@@ -318,8 +319,10 @@ auto BuildLoopGenerate(
   const hir::ExprId iter_id = parent_state.AddExpr(*std::move(iter_expr));
 
   hir::Generate gen{};
+  hir::StructuralScope loop_scope_seed;
+  loop_scope_seed.source_name = std::string{array.name};
   const hir::StructuralScopeId loop_scope_id =
-      AddChildStructuralScope(gen, hir::StructuralScope{});
+      AddChildStructuralScope(gen, std::move(loop_scope_seed));
 
   if (!array.entries.empty()) {
     const auto& canonical_entry = *array.entries.front();

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -628,6 +628,7 @@ auto InstallGenerateOwnedChildScopes(
       const mir::StructuralVarId var_id = scope_state.AddStructuralVar(
           mir::StructuralVarDecl{
               .name = companion_name,
+              .source_name = spec.scope->source_name,
               .type = var_type,
               .initializer = companion_init});
 

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -619,9 +619,11 @@ class MirDumper {
     Indent();
     for (std::size_t i = 0; i < s.structural_vars.size(); ++i) {
       const auto& v = s.structural_vars[i];
+      const std::string as =
+          v.source_name.empty() ? "" : std::format(" as \"{}\"", v.source_name);
       Line(
           std::format(
-              "[{}] \"{}\" : {} init=Expr[{}]", i, v.name,
+              "[{}] \"{}\"{} : {} init=Expr[{}]", i, v.name, as,
               FormatVarType(v.type), v.initializer.value));
     }
     Dedent();

--- a/tests/cases/cpp/hierarchy_upward_generate_cond/case.yaml
+++ b/tests/cases/cpp/hierarchy_upward_generate_cond/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_upward_generate_cond
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "5 8\n"

--- a/tests/cases/cpp/hierarchy_upward_generate_cond/main.sv
+++ b/tests/cases/cpp/hierarchy_upward_generate_cond/main.sv
@@ -1,0 +1,29 @@
+module Reader;
+  int p, q;
+  always_comb p = Top.bp.v;   // bp resolves to its then arm, bq to its else arm
+  always_comb q = Top.bq.v;
+endmodule
+
+module Top;
+  // Both alternatives of one conditional generate may share a name (LRM 27.5);
+  // a reference binds whichever was instantiated, independent of the condition.
+  generate
+    if (1) begin : bp
+      int v = 5;
+    end
+    else begin : bp
+      int v = 9;
+    end
+    if (0) begin : bq
+      int v = 6;
+    end
+    else begin : bq
+      int v = 8;
+    end
+  endgenerate
+  Reader rd();
+  initial begin
+    #1;
+    $display("%0d %0d", rd.p, rd.q);
+  end
+endmodule

--- a/tests/cases/cpp/hierarchy_upward_through_generate/case.yaml
+++ b/tests/cases/cpp/hierarchy_upward_through_generate/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_upward_through_generate
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "11 207\n"

--- a/tests/cases/cpp/hierarchy_upward_through_generate/main.sv
+++ b/tests/cases/cpp/hierarchy_upward_through_generate/main.sv
@@ -1,0 +1,25 @@
+module Leaf;
+  int x;
+endmodule
+
+module Reader;
+  int a, b;
+  always_comb a = Top.g[1].y;
+  always_comb b = Top.g[2].u.x;
+endmodule
+
+module Top;
+  genvar i;
+  generate
+    for (i = 0; i < 3; i = i + 1) begin : g
+      int y = i * 11;
+      Leaf u();
+      initial u.x = i * 100 + 7;
+    end
+  endgenerate
+  Reader rd();
+  initial begin
+    #1;
+    $display("%0d %0d", rd.a, rd.b);
+  end
+endmodule


### PR DESCRIPTION
## Summary

A hierarchical reference whose path crosses a generate block (`Top.g[1].u.x`, `Top.blk.v`) now resolves by name. The generate block's LRM name -- the source label, or `genblk<n>` when unnamed (LRM 27.6) -- was discarded at the AST-to-HIR boundary and a synthesized member name was fabricated downstream, so a by-name lookup asking for `g` never matched the emitted `gen0_loop_obj`. The reference's tail, the navigation machinery, and the runtime were already in place; the only gap was that the owner answered by-name lookups under its synthesized member name instead of the source name.

This threads the source name through HIR and MIR and keys the owner's by-name child lookup on it. The physical member name stays synthesized so it remains unique, while the source name is a separate lookup key. Same-name `if`/`else` alternatives (LRM 27.5) therefore share one key: the owner groups them and returns whichever alternative was instantiated, with each conditional arm guarded by its own non-null pointer.

This is the by-name direction -- an upward reference whose downward tail crosses the generate boundary. A reference from the scope that owns the generate descending into its own block, and a reference originating inside a generate block, remain open.

## Testing

`bazel test //...` is green. Two cases added: a loop-generate crossing that indexes a block by name and continues into a signal and a further child instance, and a conditional generate where same-name `if`/`else` alternatives bind to the instantiated arm in both directions.