### PR TITLE
Support complex-lvalue scan output args

### DIFF
--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -73,10 +73,14 @@ close as the corresponding behaviour lands.
       arithmetic operand). The scan family is modelled per LRM 21.3.4.3 as a system function whose
       `integer` return is observable in any expression position; writes to output args are runtime
       side effects routed through `Var::Set` for observable structural lvalues.
-- [ ] Complex-lvalue scan output args (bit-select `a[3:0]`, element index `arr[i]`, struct field
-      `s.f`, etc., per LRM 21.3.4.3). Today the lowering restricts output args to bare variable
-      references; the runtime `ScanSlot` ABI binds a whole-variable `Var<T>` / cell reference, not a
-      partial-write target, so complex lvalues need a different slot shape.
+- [x] Complex-lvalue scan output args (bit-select `a[3:0]`, element index `arr[i]`, struct field
+      `s.f`, multi-dim packed element `m[i]`, etc., per LRM 21.3.4.3). The scan call is modelled as
+      a closure invoked immediately (the IIFE pattern): the closure body parses into procedural
+      temps, conditionally writes back to the original output lvalues, and yields the matched count.
+      Lvalue polymorphism is absorbed by the body's writeback assignments through the existing
+      `AssignExpr` path; the runtime sees only plain temp pointers plus per-slot type metadata.
+      Output lvalues that are not reducible to writable expressions (e.g., the result of a
+      non-lvalue function call) remain rejected.
 - [x] Field width (`%5d`) and assignment suppression (`%*d`) for both scan functions (LRM 21.3.4.3
       Table 21-7). The runtime format parser handles the optional `*` and decimal width modifiers;
       suppressed conversions advance the input but do not bump the matched count or consume an

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -170,6 +170,37 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       the duplicated forms; the suspending closure this cut introduces is the first concrete
       cross-form driver, so the unification now has a real motivation rather than being speculative.
 
+- [ ] R9 -- Split `ProcessLoweringState` along the fact-vs-traversal-state line so const-correctness
+      can be restored to expression lowering. Today the class mixes two categorically different
+      kinds of information. The first kind is "facts about this process" -- HIR-to-MIR var bindings,
+      the static-frame scope, the time resolution, the accumulated static-locals list. Facts are
+      filled at statement-declaration lowering and are read-only from that point on; expressions
+      never legitimately change them. The second kind is "where is the lowering pass currently
+      standing" -- the procedural depth counter, the active capture sink for closure-body lowering.
+      That is traversal state: it is pushed on entry into a nested scope and popped on exit, and
+      stays balanced across any one full lowering. Because both kinds shared one class, the
+      `const ProcessLoweringState&` qualifier on expression-lowering signatures was honest for facts
+      and accidentally worked for traversal state only because ordinary expressions do not open
+      scopes. The qualifier broke the moment an expression-form construct that creates a procedural
+      scope appeared (the `$sscanf` / `$fscanf` closure-IIFE), forcing a binary choice between
+      smuggling the mutation through `mutable` back doors and dropping the qualifier from the entire
+      expression lowering layer. We chose the latter as the temporary shape, which means "expression
+      lowering does not change process facts" is now a docstring convention rather than a
+      signature-level invariant. Target shape: separate the two kinds. Facts live on an immutable
+      object handed in by reference -- it is the process's identity, set once by upstream lowering
+      and read by everyone below. Traversal state lives on a separate, explicitly mutable object
+      pushed/popped via RAII guards; closure-body construction installs its capture sink there. The
+      LowerExpr signature then carries the right qualifier on each: const on facts, mutable on
+      state. The invariant "expression lowering does not change process facts" is restored at the
+      signature level, and the existing mutation pattern for traversal state stops needing to argue
+      with `const`. **Why deferred**: the fact-vs-state split rebases every `Lower*` function
+      signature across the lowering layer and every site that constructs or extends the lowering
+      objects; folding it into the scan-family PR doubled the diff without architectural gain on
+      that PR's terms. **Trigger**: when a second expression-form construct that opens a procedural
+      scope appears (any future closure-IIFE expression -- the user-function-call-with-output-args
+      case, for instance), or sooner if the loss of the const-on-facts invariant produces a real
+      mistake.
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/lowering/hir_to_mir/capture_sink.hpp
+++ b/include/lyra/lowering/hir_to_mir/capture_sink.hpp
@@ -13,29 +13,37 @@
 
 namespace lyra::lowering::hir_to_mir {
 
-// Collects a fork branch's by-reference captures as the branch body is lowered
-// (LRM 6.21: the process activation outlives the branch, so the shared storage
-// stays live). Installed on ProcessLoweringState for the duration of one
-// branch: a body reference that resolves above the branch boundary is captured
-// here and rewritten on the spot to a binding local to the branch, so the
-// closure carries its captures by the time it is built -- never by a post-hoc
-// rewrite. `root` receives the binding vars; `outer` (the fork's enclosing
-// scope) receives the captured lvalues.
-class ForkCaptureSink {
+// Identity-only capture collector for a closure body. Installed on
+// ProcessLoweringState for the duration of a single closure construction:
+// during the body's lowering, any procedural-var reference that resolves
+// above the sink's boundary is rerouted here -- a binding in the body
+// scope is allocated (deduplicated by identity) and the reference is
+// rewritten to read that binding. The sink never inspects how the
+// reference is used; closure semantics are the caller's concern.
+//
+// Captures emit as by-reference. Lyra's closure use cases that need this
+// mechanism (sync IIFE for `$sscanf` / `$fscanf`, fork branches per LRM
+// 6.21) are precisely those where the enclosing storage outlives the body,
+// so aliasing is correct for both reads and writes. Capture mechanisms
+// that require a snapshot semantic (the NBA RHS, for instance) belong in
+// a distinct flow that evaluates the value at submission time and stores
+// it independently of any reference to enclosing storage; this sink is
+// not that flow.
+class CaptureSink {
  public:
-  ForkCaptureSink(
-      std::uint32_t boundary_depth, ProceduralScopeLoweringState& root,
+  CaptureSink(
+      std::uint32_t boundary_depth, ProceduralScopeLoweringState& body,
       ProceduralScopeLoweringState& outer)
-      : boundary_depth_(boundary_depth), root_(&root), outer_(&outer) {
+      : boundary_depth_(boundary_depth), body_(&body), outer_(&outer) {
   }
 
   [[nodiscard]] auto BoundaryDepth() const -> std::uint32_t {
     return boundary_depth_;
   }
 
-  // Captures the enclosing variable `outer_var` (declared `decl_depth` scopes
-  // deep) and returns the body reference -- a binding local to the branch root,
-  // read at `current_depth`.
+  // Capture `outer_var` (declared `decl_depth` scopes deep) and return the
+  // body-side reference -- a binding local to the body, read at
+  // `current_depth`.
   auto Capture(
       mir::ProceduralVarId outer_var, std::uint32_t decl_depth,
       mir::TypeId type, std::uint32_t current_depth) -> mir::ProceduralVarRef {
@@ -64,9 +72,9 @@ class ForkCaptureSink {
         return entry.binding;
       }
     }
-    const mir::ProceduralVarId binding = root_->AddProceduralVar(
+    const mir::ProceduralVarId binding = body_->AddProceduralVar(
         mir::ProceduralVarDecl{
-            .name = "_lyra_fork_cap_" + std::to_string(captures_.size()),
+            .name = "_lyra_cap_" + std::to_string(captures_.size()),
             .type = type});
     const mir::ExprId target = outer_->AddExpr(
         mir::Expr{
@@ -88,7 +96,7 @@ class ForkCaptureSink {
   }
 
   std::uint32_t boundary_depth_;
-  ProceduralScopeLoweringState* root_;
+  ProceduralScopeLoweringState* body_;
   ProceduralScopeLoweringState* outer_;
   std::vector<mir::Capture> captures_;
   std::vector<Entry> captured_;

--- a/include/lyra/lowering/hir_to_mir/inside_predicate.hpp
+++ b/include/lyra/lowering/hir_to_mir/inside_predicate.hpp
@@ -17,7 +17,7 @@ namespace lyra::lowering::hir_to_mir {
 auto BuildHirInsideItemPredicate(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, mir::ExprId lhs_id,
     const hir::InsideItem& item, mir::TypeId result_type)

--- a/include/lyra/lowering/hir_to_mir/lower_diagnostic.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_diagnostic.hpp
@@ -17,7 +17,7 @@ namespace lyra::lowering::hir_to_mir {
 auto LowerDiagnosticSystemSubroutineCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const support::DiagnosticSystemSubroutineInfo& info, diag::SourceSpan span)

--- a/include/lyra/lowering/hir_to_mir/lower_expr.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_expr.hpp
@@ -9,10 +9,16 @@
 
 namespace lyra::lowering::hir_to_mir {
 
+// `proc_state` is taken by mutable reference: most expression lowering is
+// pure-functional with respect to it, but a system-subroutine expression
+// that models a closure-IIFE (e.g. `$sscanf`) constructs a new procedural
+// scope on the way through, which pushes a depth frame and installs a
+// capture sink. The non-const signature carries that possibility honestly
+// instead of routing the mutation through `mutable` back doors.
 auto LowerExpr(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::Expr& expr)
     -> diag::Result<mir::Expr>;

--- a/include/lyra/lowering/hir_to_mir/lower_file_io.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_file_io.hpp
@@ -24,7 +24,7 @@ namespace lyra::lowering::hir_to_mir {
 auto LowerFileIOSystemSubroutineCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const support::SystemSubroutineDesc& desc,

--- a/include/lyra/lowering/hir_to_mir/lower_print.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_print.hpp
@@ -16,7 +16,7 @@ namespace lyra::lowering::hir_to_mir {
 auto LowerPrintSystemSubroutineCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const support::PrintSystemSubroutineInfo& print, diag::SourceSpan span)

--- a/include/lyra/lowering/hir_to_mir/lower_scan.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_scan.hpp
@@ -10,13 +10,20 @@
 
 namespace lyra::lowering::hir_to_mir {
 
-// LRM 21.3.4.3 `$sscanf` / `$fscanf`. Position-independent: the matched
-// count returns through the call's MIR Expr value and writes to output
-// args happen as runtime side effects (see `runtime::ScanSlot`).
+// LRM 21.3.4.3 `$sscanf` / `$fscanf`. The call is modelled as a closure
+// invoked immediately (the IIFE pattern). The closure's body parses into
+// procedural-local temps, conditionally writes back to the original output
+// lvalues, and yields the matched-conversion count. The body's writeback
+// assignments use the existing `AssignExpr` path -- lvalue polymorphism
+// stays at the backend; the runtime sees plain temp pointers plus
+// per-slot type metadata. `proc_state` is taken by mutable reference
+// because the body construction pushes a procedural depth frame and
+// installs a capture sink, both of which mutate state during the
+// closure's body lowering.
 auto LowerScanSystemSubroutineCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const support::ScanSystemSubroutineInfo& info, diag::SourceSpan span)

--- a/include/lyra/lowering/hir_to_mir/lower_sformat.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_sformat.hpp
@@ -20,7 +20,7 @@ namespace lyra::lowering::hir_to_mir {
 auto LowerSFormatSystemSubroutineCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const support::SFormatSystemSubroutineInfo& info, diag::SourceSpan span)

--- a/include/lyra/lowering/hir_to_mir/lower_system_subroutine.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_system_subroutine.hpp
@@ -17,7 +17,7 @@ namespace lyra::lowering::hir_to_mir {
 auto LowerSystemSubroutineCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const hir::SystemSubroutineRef& ref, diag::SourceSpan span)

--- a/include/lyra/lowering/hir_to_mir/lower_timescale.hpp
+++ b/include/lyra/lowering/hir_to_mir/lower_timescale.hpp
@@ -16,7 +16,7 @@ namespace lyra::lowering::hir_to_mir {
 auto LowerTimeFormatSystemSubroutineCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     diag::SourceSpan span) -> diag::Result<mir::Expr>;

--- a/include/lyra/lowering/hir_to_mir/print_items.hpp
+++ b/include/lyra/lowering/hir_to_mir/print_items.hpp
@@ -47,7 +47,7 @@ auto RadixToFormatKind(support::PrintRadix r) -> value::FormatKind;
 auto BuildRuntimePrintItemsFromCallArgs(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     support::PrintRadix default_radix, std::size_t arg_offset,

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -139,6 +139,25 @@ class UnitLoweringState {
         .type = builtins_.int32};
   }
 
+  // 4-state signed 32-bit literal, typed `integer` (LRM 6.11.1). Used by
+  // sites that need to compare against the matched-count return of
+  // `$sscanf` / `$fscanf` -- those return `integer`, so the operand on
+  // the other side of the comparison must match state-kind.
+  [[nodiscard]] auto MakeIntegerLiteralExpr(std::int64_t value) const
+      -> mir::Expr {
+    return mir::Expr{
+        .data =
+            mir::IntegerLiteral{
+                .value =
+                    mir::IntegralConstant{
+                        .value_words = {static_cast<std::uint64_t>(value)},
+                        .state_words = {},
+                        .width = 32,
+                        .signedness = mir::Signedness::kSigned,
+                        .state_kind = mir::IntegralStateKind::kFourState}},
+        .type = builtins_.integer};
+  }
+
   // Allocates a fresh class-local DeferredCheckSiteId from the underlying
   // CompilationUnit's counter. The method is const because UnitLoweringState's
   // observable lowering state (type map, builtins) is unaffected; the counter
@@ -424,7 +443,7 @@ struct ProceduralVarBinding {
 };
 
 class ProceduralScopeLoweringState;
-class ForkCaptureSink;
+class CaptureSink;
 
 class ProcessLoweringState {
  public:
@@ -514,16 +533,16 @@ class ProcessLoweringState {
     };
   }
 
-  // The capture sink active while a fork branch body is lowered, or null. A
-  // branch-body reference resolving above the branch boundary routes through it
-  // so the closure's by-reference captures are composed as the body is built
-  // (LRM 6.21). Fork lowering installs it; the const expr lowering only reads
-  // it.
-  void SetForkCaptureSink(ForkCaptureSink* sink) {
-    fork_capture_sink_ = sink;
+  // The capture sink active while a closure body is lowered, or null. A
+  // body reference whose declaration sits above the sink's boundary routes
+  // through it so the closure's captures are composed as the body is
+  // built. Install at closure-body construction; the leaf lowering only
+  // reads it.
+  void SetCaptureSink(CaptureSink* sink) {
+    active_capture_sink_ = sink;
   }
-  [[nodiscard]] auto ActiveForkCaptureSink() const -> ForkCaptureSink* {
-    return fork_capture_sink_;
+  [[nodiscard]] auto ActiveCaptureSink() const -> CaptureSink* {
+    return active_capture_sink_;
   }
 
  private:
@@ -531,7 +550,7 @@ class ProcessLoweringState {
   std::uint32_t procedural_depth_ = 0;
   std::vector<ProceduralVarBinding> bindings_;
   ProceduralScopeLoweringState* static_frame_scope_ = nullptr;
-  ForkCaptureSink* fork_capture_sink_ = nullptr;
+  CaptureSink* active_capture_sink_ = nullptr;
   std::vector<mir::StaticLocal> static_locals_;
 };
 
@@ -644,6 +663,29 @@ class ProceduralScopeLoweringState {
         .hops = mir::ProceduralHops{.value = 0}, .var = var};
     AppendStmt(mir::ProceduralVarDeclStmt{.target = ref, .init = init});
     return ref;
+  }
+
+  // Append an `if (cond) <then_body>` statement, consuming `then_body` as
+  // the IfStmt's nested then-scope. Encapsulates the AddChildProceduralScope
+  // + AddStmt + AddRootStmt sequence so callers do not have to manage the
+  // child_procedural_scopes vector by hand.
+  auto AppendIfThen(mir::ExprId cond, mir::ProceduralScope then_body)
+      -> mir::StmtId {
+    std::vector<mir::ProceduralScope> child_scopes;
+    const mir::ProceduralScopeId then_scope_id{
+        static_cast<std::uint32_t>(child_scopes.size())};
+    child_scopes.push_back(std::move(then_body));
+    const mir::StmtId id = AddStmt(
+        mir::Stmt{
+            .label = std::nullopt,
+            .data =
+                mir::IfStmt{
+                    .condition = cond,
+                    .then_scope = then_scope_id,
+                    .else_scope = std::nullopt},
+            .child_procedural_scopes = std::move(child_scopes)});
+    AddRootStmt(id);
+    return id;
   }
 
   auto Finish() -> mir::ProceduralScope {

--- a/include/lyra/mir/closure.hpp
+++ b/include/lyra/mir/closure.hpp
@@ -20,7 +20,8 @@ struct ByValueCapture {
 // lvalue (`target`). The spawned body reaches it through a frame-copied
 // reference parameter; the enclosing storage outlives the body (LRM 6.21), so
 // reads and writes share the one live location. Used by fork branches that
-// touch their enclosing process's variables.
+// touch their enclosing process's variables and by synchronous IIFEs (e.g.
+// `$sscanf` / `$fscanf`) whose body writes back to its output args.
 struct ByReferenceCapture {
   ExprId target{};
   ProceduralVarId binding{};

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -93,8 +93,18 @@ struct SystemSubroutineCallee {
   support::SystemSubroutineId id;
 };
 
+// Calls a closure stored as an expression in the same procedural scope.
+// The backend renders the call as `(closure_lambda)(args)` -- the standard
+// IIFE shape when invoked synchronously. Used for SV expression-position
+// constructs whose evaluation has side effects (e.g., `$sscanf` writing
+// through its output args while yielding the matched count).
+struct ClosureRef {
+  ExprId closure{};
+};
+
 using Callee = std::variant<
-    SystemSubroutineCallee, StructuralSubroutineRef, BuiltinMethodCallee>;
+    SystemSubroutineCallee, StructuralSubroutineRef, BuiltinMethodCallee,
+    ClosureRef>;
 
 struct CallExpr {
   Callee callee;

--- a/include/lyra/mir/runtime_scan.hpp
+++ b/include/lyra/mir/runtime_scan.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+#include <variant>
 #include <vector>
 
 #include "lyra/mir/expr_id.hpp"
@@ -7,20 +9,32 @@
 
 namespace lyra::mir {
 
-// LRM 21.3.4.3 $sscanf / $fscanf. `source_kind` selects the runtime entry
-// and constrains `source`'s MIR type:
-//   kString -> `source` is string-typed
-//   kFile   -> `source` is int-typed (FD per LRM 21.3.1)
-// `format` is always string-typed. Each slot is a bare lvalue (Structural
-// or Procedural var ref) bound by `ScanSlot::Make` at the backend; the
-// runtime writes through it directly (observable for structural vars via
-// `Var::Set`). Each slot's MIR-level type drives the backend's overload
-// selection.
+// LRM 21.3.4.3 `$sscanf` / `$fscanf`. The runtime call is positioned
+// inside a closure body synthesized by the lowering; each slot's `temp`
+// references a procedural-local sink in that body. Lvalue semantics
+// (observable structural vars, partial selectors, etc.) belong to the
+// closure body's conditional writeback assignments, NOT to this call --
+// the runtime sees only plain temp pointers plus per-slot type metadata
+// and the matched-conversion count.
+
+struct IntegralScanSlot {
+  ExprId temp{};  // ProceduralVarRef to a PackedArray temp
+  std::uint32_t bit_width{};
+  bool is_signed{};
+  bool is_four_state{};
+};
+
+struct StringScanSlot {
+  ExprId temp{};  // ProceduralVarRef to a String temp
+};
+
+using ScanSlotDesc = std::variant<IntegralScanSlot, StringScanSlot>;
+
 struct RuntimeScanCall {
   support::ScanSourceKind source_kind{};
   ExprId source{};
   ExprId format{};
-  std::vector<ExprId> slots;
+  std::vector<ScanSlotDesc> slots;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/runtime/scan.hpp
+++ b/include/lyra/runtime/scan.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <cstdint>
 #include <initializer_list>
 #include <variant>
 
-#include "lyra/runtime/var.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/string.hpp"
 
@@ -11,67 +11,37 @@ namespace lyra::runtime {
 
 class RuntimeServices;
 
-// LRM 21.3.4.3 scanner output slot. Integral lvalues ride `Ref<PackedArray>`
-// so structural vars route writes through `Var::Set` (firing the LRM 4.3
-// update event) while procedural locals fall through to direct assignment.
-// String vars are not observable on this pipeline today, so the string
-// alternative is a raw pointer with no services threading.
-class ScanSlot {
- public:
-  static auto Make(Var<value::PackedArray>& dest) -> ScanSlot {
-    return ScanSlot{Ref<value::PackedArray>{dest}};
-  }
-  static auto Make(value::PackedArray& dest) -> ScanSlot {
-    return ScanSlot{Ref<value::PackedArray>{dest}};
-  }
-  static auto Make(value::String& dest) -> ScanSlot {
-    return ScanSlot{&dest};
-  }
-
-  [[nodiscard]] auto IsIntegral() const -> bool {
-    return std::holds_alternative<Ref<value::PackedArray>>(dest_);
-  }
-  [[nodiscard]] auto IsString() const -> bool {
-    return std::holds_alternative<value::String*>(dest_);
-  }
-
-  // Per-spec parsers snapshot the current value to read width / sign /
-  // 4-state metadata, mutate locally, then commit through `SetIntegral`.
-  [[nodiscard]] auto GetIntegral() const -> value::PackedArray {
-    return std::get<Ref<value::PackedArray>>(dest_).Get();
-  }
-
-  void SetIntegral(
-      RuntimeServices& services, const value::PackedArray& new_val) const {
-    std::get<Ref<value::PackedArray>>(dest_).Set(services, new_val);
-  }
-  void SetString(const value::String& new_val) const {
-    *std::get<value::String*>(dest_) = new_val;
-  }
-
- private:
-  explicit ScanSlot(Ref<value::PackedArray> r) : dest_(r) {
-  }
-  explicit ScanSlot(value::String* p) : dest_(p) {
-  }
-
-  std::variant<Ref<value::PackedArray>, value::String*> dest_;
+// LRM 21.3.4.3 per-slot write target. The runtime parses one value of the
+// caller-declared shape and writes it through `dest`; lvalue semantics
+// (observable Var<T>, partial selectors, etc.) live entirely at the
+// callsite -- the runtime only sees a plain pointer.
+struct IntegralScanTarget {
+  value::PackedArray* dest;
+  std::uint32_t bit_width;
+  bool is_signed;
+  bool is_four_state;
 };
 
-// LRM 21.3.4.3 $sscanf. Returns matched-conversion count, or -1 on EOF
-// before any conversion.
-auto LyraSScanf(
-    RuntimeServices& services, const value::String& input,
-    const value::String& format, std::initializer_list<ScanSlot> slots)
-    -> value::PackedArray;
+struct StringScanTarget {
+  value::String* dest;
+};
 
-// LRM 21.3.4.3 $fscanf. Resolves `fd` via `RuntimeServices::Files()`,
+using ScanTarget = std::variant<IntegralScanTarget, StringScanTarget>;
+
+// LRM 21.3.4.3 `$sscanf`. Returns matched-conversion count, or -1 on EOF
+// before any conversion. String scanning is self-contained -- no engine
+// services are needed.
+auto LyraSScanf(
+    const value::String& input, const value::String& format,
+    std::initializer_list<ScanTarget> targets) -> value::PackedArray;
+
+// LRM 21.3.4.3 `$fscanf`. Resolves `fd` via `RuntimeServices::Files()`,
 // parks the offending-character pushback in the slot's putback so the
 // next read on the same FD sees it. Invalid / closed / MCD descriptors
 // stamp `EBADF` on `$ferror` and return -1.
 auto LyraFScanf(
     RuntimeServices& services, const value::PackedArray& fd,
-    const value::String& format, std::initializer_list<ScanSlot> slots)
+    const value::String& format, std::initializer_list<ScanTarget> targets)
     -> value::PackedArray;
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -202,7 +202,7 @@ class Ref {
     return *plain_;
   }
 
-  void Set(RuntimeServices& services, const T& new_val) const {
+  void Set(RuntimeServices& services, const T& new_val) {
     if (signal_ != nullptr) {
       signal_->Set(services, new_val);
     } else {

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1051,6 +1051,20 @@ auto RenderCallExpr(const RenderContext& ctx, const mir::CallExpr& call)
                 },
                 b.method);
           },
+          [&](const mir::ClosureRef& cr) -> diag::Result<std::string> {
+            auto closure_or = RenderExpr(ctx, ctx.Expr(cr.closure));
+            if (!closure_or) {
+              return std::unexpected(std::move(closure_or.error()));
+            }
+            std::string args;
+            for (std::size_t i = 0; i < call.arguments.size(); ++i) {
+              auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+              if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+              if (i != 0) args += ", ";
+              args += *std::move(arg_or);
+            }
+            return "(" + *closure_or + ")(" + args + ")";
+          },
       },
       call.callee);
 }
@@ -1407,10 +1421,16 @@ auto RenderClosureExpr(
               }
               return bind_name + " = " + *value_or;
             },
-            [&](const mir::ByReferenceCapture&) -> diag::Result<std::string> {
-              throw InternalError(
-                  "RenderClosureExpr: by-reference capture appears only in a "
-                  "fork branch, which renders through RenderForkStmtNode");
+            [&](const mir::ByReferenceCapture& br)
+                -> diag::Result<std::string> {
+              const std::string& bind_name =
+                  closure.body->vars.at(br.binding.value).name;
+              auto lvalue_or =
+                  RenderLhsExpr(ctx, ctx.Expr(br.target), std::string_view{});
+              if (!lvalue_or) {
+                return std::unexpected(std::move(lvalue_or.error()));
+              }
+              return "&" + bind_name + " = " + *lvalue_or;
             }},
         closure.captures[i]);
     if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -503,26 +503,54 @@ auto RenderRuntimeCallExpr(
             if (!format_or) {
               return std::unexpected(std::move(format_or.error()));
             }
-            // Slots render as bare lvalues so `ScanSlot::Make` binds a
-            // `Var<>` / cell reference for observable writes.
+            // Slots render as ScanTarget variant literals. Each carries a
+            // pointer to a procedural-local temp in the surrounding closure
+            // body plus the per-slot type metadata the parser needs to
+            // materialize a fresh value of the lvalue's shape.
             std::string slot_pieces;
             for (std::size_t k = 0; k < ss.slots.size(); ++k) {
-              auto slot_or =
-                  RenderLhsExpr(ctx, ctx.Expr(ss.slots[k]), std::string_view{});
-              if (!slot_or) {
-                return std::unexpected(std::move(slot_or.error()));
+              auto piece_or = std::visit(
+                  Overloaded{
+                      [&](const mir::IntegralScanSlot& s)
+                          -> diag::Result<std::string> {
+                        auto temp_or = RenderLhsExpr(
+                            ctx, ctx.Expr(s.temp), std::string_view{});
+                        if (!temp_or) {
+                          return std::unexpected(std::move(temp_or.error()));
+                        }
+                        return std::format(
+                            "lyra::runtime::IntegralScanTarget{{.dest = &{}, "
+                            ".bit_width = {}U, .is_signed = {}, "
+                            ".is_four_state = {}}}",
+                            *temp_or, s.bit_width,
+                            s.is_signed ? "true" : "false",
+                            s.is_four_state ? "true" : "false");
+                      },
+                      [&](const mir::StringScanSlot& s)
+                          -> diag::Result<std::string> {
+                        auto temp_or = RenderLhsExpr(
+                            ctx, ctx.Expr(s.temp), std::string_view{});
+                        if (!temp_or) {
+                          return std::unexpected(std::move(temp_or.error()));
+                        }
+                        return std::format(
+                            "lyra::runtime::StringScanTarget{{.dest = &{}}}",
+                            *temp_or);
+                      }},
+                  ss.slots[k]);
+              if (!piece_or) {
+                return std::unexpected(std::move(piece_or.error()));
               }
               if (k != 0) {
                 slot_pieces += ", ";
               }
-              slot_pieces +=
-                  std::format("lyra::runtime::ScanSlot::Make({})", *slot_or);
+              slot_pieces += *piece_or;
             }
             switch (ss.source_kind) {
               case support::ScanSourceKind::kString:
                 return std::format(
-                    "lyra::runtime::LyraSScanf(Services(), {}, {}, {{{}}})",
-                    *source_or, *format_or, slot_pieces);
+                    "lyra::runtime::LyraSScanf({}, {}, {{{}}})", *source_or,
+                    *format_or, slot_pieces);
               case support::ScanSourceKind::kFile:
                 return std::format(
                     "lyra::runtime::LyraFScanf({}, {}, {}, {{{}}})",

--- a/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
+++ b/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
@@ -15,7 +15,7 @@ namespace lyra::lowering::hir_to_mir {
 auto BuildHirInsideItemPredicate(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, mir::ExprId lhs_id,
     const hir::InsideItem& item, mir::TypeId result_type)

--- a/src/lyra/lowering/hir_to_mir/lower_diagnostic.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_diagnostic.cpp
@@ -37,7 +37,7 @@ auto ToMirDiagnosticSeverity(support::DiagnosticSeverityKind k)
 auto LowerDiagnosticSystemSubroutineCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const support::DiagnosticSystemSubroutineInfo& info, diag::SourceSpan span)

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -24,8 +24,8 @@
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/unary_op.hpp"
 #include "lyra/hir/value_ref.hpp"
+#include "lyra/lowering/hir_to_mir/capture_sink.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
-#include "lyra/lowering/hir_to_mir/fork_capture.hpp"
 #include "lyra/lowering/hir_to_mir/inside_predicate.hpp"
 #include "lyra/lowering/hir_to_mir/lower_system_subroutine.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
@@ -273,12 +273,12 @@ auto LowerStructuralVarRefExpr(
 }
 
 auto LowerProceduralVarRefExpr(
-    const ProcessLoweringState& proc_state, const hir::ProceduralVarRef& l,
+    ProcessLoweringState& proc_state, const hir::ProceduralVarRef& l,
     mir::TypeId type) -> mir::Expr {
-  // Inside a fork branch body, a reference that resolves to an enclosing scope
-  // (declared above the branch boundary) is captured by reference as the body
-  // is lowered (LRM 6.21), so it reads the binding rather than reaching out.
-  if (auto* sink = proc_state.ActiveForkCaptureSink()) {
+  // Inside a closure body that installed a capture sink, a reference
+  // resolving above the sink's boundary is captured (by identity) and
+  // rewritten to read the body-side binding the sink composes.
+  if (auto* sink = proc_state.ActiveCaptureSink()) {
     const auto& binding = proc_state.LookupProceduralVar(l.var);
     if (binding.declaration_procedural_depth < sink->BoundaryDepth()) {
       return mir::Expr{
@@ -545,8 +545,8 @@ auto LowerHirRealLiteral(const hir::RealLiteral& r, mir::TypeId type)
 auto LowerHirPrimaryProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state, const hir::Primary& p,
-    mir::TypeId type) -> mir::Expr {
+    ProcessLoweringState& proc_state, const hir::Primary& p, mir::TypeId type)
+    -> mir::Expr {
   return std::visit(
       Overloaded{
           [&](const hir::IntegerLiteral& i) -> mir::Expr {
@@ -759,7 +759,7 @@ auto IsExprRootedAtStructuralVar(
 auto LowerHirUnaryExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::UnaryExpr& u,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
@@ -779,7 +779,7 @@ auto LowerHirUnaryExprProc(
 auto LowerHirBinaryExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::BinaryExpr& b,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
@@ -803,7 +803,7 @@ auto LowerHirBinaryExprProc(
 auto LowerHirConditionalExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::ConditionalExpr& c,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
@@ -834,7 +834,7 @@ auto LowerHirConditionalExprProc(
 auto LowerHirAssignExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::AssignExpr& a,
     diag::SourceSpan span, mir::TypeId result_type) -> diag::Result<mir::Expr> {
@@ -888,7 +888,7 @@ auto LowerHirAssignExprProc(
 auto LowerHirIncDecExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::IncDecExpr& inc,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
@@ -905,7 +905,7 @@ auto LowerHirIncDecExprProc(
 auto LowerHirConversionExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::ConversionExpr& cv,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
@@ -927,7 +927,7 @@ auto LowerHirConversionExprProc(
 auto LowerHirCallExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::CallExpr& c,
     diag::SourceSpan span, mir::TypeId result_type) -> diag::Result<mir::Expr> {
@@ -1047,7 +1047,7 @@ auto LowerHirCallExprProc(
 auto LowerHirInsideExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::InsideExpr& in,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
@@ -1181,7 +1181,7 @@ auto UnfoldHirRangeBoundsForUnpacked(
 auto LowerHirElementSelectExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::ElementSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
@@ -1218,7 +1218,7 @@ auto LowerHirElementSelectExprProc(
 auto LowerHirRangeSelectExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::RangeSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
@@ -1268,7 +1268,7 @@ auto LowerHirRangeSelectExprProc(
 auto LowerHirMemberAccessExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::MemberAccessExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
@@ -1301,7 +1301,7 @@ auto LowerHirMemberAccessExprProc(
 auto LowerHirConcatExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::ConcatExpr& c,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
@@ -1322,7 +1322,7 @@ auto LowerHirConcatExprProc(
 auto LowerHirReplicationExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::ReplicationExpr& r,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
@@ -1349,7 +1349,7 @@ auto LowerHirReplicationExprProc(
 auto LowerHirAssignmentPatternExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::AssignmentPatternExpr& a,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
@@ -1374,7 +1374,7 @@ auto LowerHirAssignmentPatternExprProc(
 auto LowerHirAssignmentPatternReplicationExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process,
     const hir::AssignmentPatternReplicationExpr& a, mir::TypeId result_type)
@@ -1421,7 +1421,7 @@ auto LowerHirAssignmentPatternReplicationExprProc(
 auto LowerHirDynamicArrayNewExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::DynamicArrayNewExpr& n,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
@@ -1460,7 +1460,7 @@ auto LowerHirDynamicArrayNewExprProc(
 auto LowerExpr(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_process, const hir::Expr& expr)
     -> diag::Result<mir::Expr> {

--- a/src/lyra/lowering/hir_to_mir/lower_file_io.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_file_io.cpp
@@ -29,7 +29,7 @@ namespace {
 auto LowerFileOpenCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call)
     -> diag::Result<mir::Expr> {
@@ -59,7 +59,7 @@ auto LowerFileOpenCall(
 auto LowerFileCloseCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call)
     -> diag::Result<mir::Expr> {
@@ -80,7 +80,7 @@ auto LowerFileCloseCall(
 auto LowerFileGetcCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call)
     -> diag::Result<mir::Expr> {
@@ -98,7 +98,7 @@ auto LowerFileGetcCall(
 auto LowerFileUngetcCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call)
     -> diag::Result<mir::Expr> {
@@ -122,7 +122,7 @@ auto LowerFileUngetcCall(
 auto LowerFileSeekCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call)
     -> diag::Result<mir::Expr> {
@@ -153,7 +153,7 @@ auto LowerFileSeekCall(
 auto LowerFileRewindCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call)
     -> diag::Result<mir::Expr> {
@@ -171,7 +171,7 @@ auto LowerFileRewindCall(
 auto LowerFileTellCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call)
     -> diag::Result<mir::Expr> {
@@ -189,7 +189,7 @@ auto LowerFileTellCall(
 auto LowerFileEofCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call)
     -> diag::Result<mir::Expr> {
@@ -207,7 +207,7 @@ auto LowerFileEofCall(
 auto LowerFileFlushCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call)
     -> diag::Result<mir::Expr> {
@@ -249,7 +249,7 @@ auto RejectOutputArgFileCallInExprPosition(
 auto LowerFileIOSystemSubroutineCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const support::SystemSubroutineDesc& desc,

--- a/src/lyra/lowering/hir_to_mir/lower_print.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_print.cpp
@@ -36,7 +36,7 @@ auto ToValuePrintKind(const support::PrintSystemSubroutineInfo& info)
 auto LowerPrintSystemSubroutineCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const support::PrintSystemSubroutineInfo& print, diag::SourceSpan span)

--- a/src/lyra/lowering/hir_to_mir/lower_scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_scan.cpp
@@ -1,10 +1,10 @@
 #include "lyra/lowering/hir_to_mir/lower_scan.hpp"
 
+#include <cstdint>
 #include <expected>
-#include <format>
+#include <memory>
 #include <string>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
@@ -12,10 +12,15 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_body.hpp"
+#include "lyra/lowering/hir_to_mir/capture_sink.hpp"
+#include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
+#include "lyra/mir/binary_op.hpp"
+#include "lyra/mir/closure.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/runtime_scan.hpp"
+#include "lyra/mir/stmt.hpp"
 #include "lyra/mir/type.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
@@ -23,16 +28,13 @@ namespace lyra::lowering::hir_to_mir {
 
 namespace {
 
-// LRM 21.3.4.3: $sscanf accepts string, integral, or unpacked-array-of-byte
-// sources. The runtime entry takes `value::String`, so the non-string
-// shapes wrap in an implicit `ConversionExpr` and the backend picks the
-// matching constructor (string literal unwrap or `String::FromByteArray`).
-// Any source type outside the three permitted shapes is an upstream
-// invariant violation -- slang's type-check rejects it before HIR.
+// LRM 21.3.4.3 valid `$sscanf` source types: string, integral (lifted via
+// implicit conversion), or unpacked-array-of-byte (lifted via implicit
+// conversion). Any other shape is an upstream-validation invariant
+// violation -- slang's type-check rejects it before HIR.
 auto LiftStringSource(
-    const UnitLoweringState& unit_state,
-    ProceduralScopeLoweringState& proc_scope_state, mir::TypeId source_type,
-    mir::ExprId source_id) -> mir::ExprId {
+    const UnitLoweringState& unit_state, ProceduralScopeLoweringState& scope,
+    mir::TypeId source_type, mir::ExprId source_id) -> mir::ExprId {
   const mir::TypeKind kind = unit_state.GetType(source_type).Kind();
   if (kind == mir::TypeKind::kString) return source_id;
 
@@ -43,17 +45,15 @@ auto LiftStringSource(
     if (!elem.IsIntegralPacked() || elem.AsIntegralPacked().BitWidth() != 8U) {
       throw InternalError(
           "LiftStringSource: $sscanf unpacked-array source must have an "
-          "8-bit integral element (LRM 21.3.4.3); slang's type-check should "
-          "have rejected other shapes");
+          "8-bit integral element (LRM 21.3.4.3)");
     }
   } else if (kind != mir::TypeKind::kPackedArray) {
     throw InternalError(
         "LiftStringSource: $sscanf source is not string, integral, or "
-        "unpacked array of byte (LRM 21.3.4.3); slang's type-check should "
-        "have rejected upstream");
+        "unpacked array of byte (LRM 21.3.4.3)");
   }
 
-  return proc_scope_state.AddExpr(
+  return scope.AddExpr(
       mir::Expr{
           .data =
               mir::ConversionExpr{
@@ -61,18 +61,71 @@ auto LiftStringSource(
           .type = unit_state.Builtins().string});
 }
 
+// The per-slot type metadata the runtime needs to materialize a fresh
+// value of the output arg's declared shape. Derived from the HIR type
+// alone -- no MIR Expr for the output arg is needed at this point.
+struct SlotMeta {
+  mir::TypeId mir_type;
+  bool is_string;
+  std::uint32_t bit_width;
+  bool is_signed;
+  bool is_four_state;
+};
+
+auto ComputeSlotMeta(
+    const UnitLoweringState& unit_state, mir::TypeId mir_type,
+    support::ScanSourceKind source_kind, diag::SourceSpan span)
+    -> diag::Result<SlotMeta> {
+  SlotMeta meta{
+      .mir_type = mir_type,
+      .is_string = false,
+      .bit_width = 0,
+      .is_signed = false,
+      .is_four_state = false};
+  const auto& target = unit_state.GetType(mir_type);
+  if (target.Kind() == mir::TypeKind::kString) {
+    meta.is_string = true;
+    return meta;
+  }
+  if (target.IsIntegralPacked()) {
+    const auto& pa = target.AsIntegralPacked();
+    meta.bit_width = static_cast<std::uint32_t>(pa.BitWidth());
+    meta.is_signed = pa.signedness == mir::Signedness::kSigned;
+    meta.is_four_state = pa.IsFourState();
+    return meta;
+  }
+  return diag::Unsupported(
+      span, diag::DiagCode::kUnsupportedSubroutineArgument,
+      std::format(
+          "{} output argument must be an integral or string lvalue "
+          "(LRM 21.3.4.3)",
+          source_kind == support::ScanSourceKind::kFile ? "$fscanf"
+                                                        : "$sscanf"),
+      diag::UnsupportedCategory::kFeature);
+}
+
+// `body.AddExpr(ProceduralVarRef{hops, var}, type)` shorthand.
+auto AppendVarRef(
+    ProceduralScopeLoweringState& scope, mir::ProceduralVarId var,
+    std::uint32_t hops, mir::TypeId type) -> mir::ExprId {
+  return scope.AddExpr(
+      mir::Expr{
+          .data =
+              mir::ProceduralVarRef{
+                  .hops = mir::ProceduralHops{.value = hops}, .var = var},
+          .type = type});
+}
+
 }  // namespace
 
 auto LowerScanSystemSubroutineCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const support::ScanSystemSubroutineInfo& info, diag::SourceSpan span)
     -> diag::Result<mir::Expr> {
-  // LRM 21.3.4.3 grammar requires source + format + at least one output,
-  // none elidable; slang's ArgCountPolicy enforces this upstream.
   if (call.arguments.size() < 3) {
     throw InternalError(
         "LowerScanSystemSubroutineCall: fewer than 3 arguments reached "
@@ -83,72 +136,167 @@ auto LowerScanSystemSubroutineCall(
         "LowerScanSystemSubroutineCall: source / format arg elided");
   }
 
-  auto source_or = LowerExpr(
-      unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
-      hir_proc.exprs.at(call.arguments[0]->value));
-  if (!source_or) return std::unexpected(std::move(source_or.error()));
-  const mir::TypeId source_type = source_or->type;
-  mir::ExprId source_id = proc_scope_state.AddExpr(*std::move(source_or));
-  switch (info.source) {
-    case support::ScanSourceKind::kString:
-      source_id = LiftStringSource(
-          unit_state, proc_scope_state, source_type, source_id);
-      break;
-    case support::ScanSourceKind::kFile:
-      // LRM 21.3.1 binds fd to integer; slang's type-check rejects
-      // non-integral arguments before HIR.
-      if (unit_state.GetType(source_type).Kind() !=
-          mir::TypeKind::kPackedArray) {
-        throw InternalError(
-            "LowerScanSystemSubroutineCall: $fscanf fd is not packed-integer");
-      }
-      break;
-  }
-
-  auto format_or = LowerExpr(
-      unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
-      hir_proc.exprs.at(call.arguments[1]->value));
-  if (!format_or) return std::unexpected(std::move(format_or.error()));
-  const mir::ExprId format_id = proc_scope_state.AddExpr(*std::move(format_or));
-
-  // Output slots are restricted to bare var refs; the runtime ABI
-  // (`ScanSlot::Make`) binds a whole-variable `Var<T>` / cell reference,
-  // not a partial-write target.
-  std::vector<mir::ExprId> slot_refs;
-  slot_refs.reserve(call.arguments.size() - 2);
+  // Compute slot metadata from HIR type alone -- output args are not
+  // lowered until their conditional commit point inside the closure body.
+  std::vector<SlotMeta> metas;
+  metas.reserve(call.arguments.size() - 2);
   for (std::size_t i = 2; i < call.arguments.size(); ++i) {
     if (!call.arguments[i].has_value()) {
       throw InternalError("LowerScanSystemSubroutineCall: output arg elided");
     }
-    auto actual_or = LowerExpr(
-        unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
-        hir_proc.exprs.at(call.arguments[i]->value));
-    if (!actual_or) return std::unexpected(std::move(actual_or.error()));
-    if (!std::holds_alternative<mir::StructuralVarRef>(actual_or->data) &&
-        !std::holds_alternative<mir::ProceduralVarRef>(actual_or->data)) {
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedSubroutineArgument,
-          std::format(
-              "{} output argument must be a bare variable reference; "
-              "bit-selects, element indices, and struct fields are not yet "
-              "supported (LRM 21.3.4.3)",
-              info.source == support::ScanSourceKind::kFile ? "$fscanf"
-                                                            : "$sscanf"),
-          diag::UnsupportedCategory::kFeature);
-    }
-    slot_refs.push_back(proc_scope_state.AddExpr(*std::move(actual_or)));
+    const auto& hir_arg = hir_proc.exprs.at(call.arguments[i]->value);
+    const mir::TypeId mir_type = unit_state.TranslateType(hir_arg.type);
+    auto meta_or = ComputeSlotMeta(unit_state, mir_type, info.source, span);
+    if (!meta_or) return std::unexpected(std::move(meta_or.error()));
+    metas.push_back(*std::move(meta_or));
   }
+
+  const mir::TypeId integer_t = unit_state.Builtins().integer;
+  const mir::TypeId bit_t = unit_state.Builtins().bit1;
+
+  // Build the closure body. Entering the procedural-depth guard before
+  // installing the capture sink is what makes the sink's boundary depth
+  // reflect the body's own depth; any leaf reference resolving above it
+  // is captured by reference (sync IIFE -- aliasing is correct for both
+  // reads and writes because the caller's storage is live throughout the
+  // closure's evaluation).
+  ProceduralScopeLoweringState body;
+  ProceduralDepthGuard depth_guard{proc_state};
+  CaptureSink sink{proc_state.CurrentProceduralDepth(), body, proc_scope_state};
+  CaptureSink* const previous_sink = proc_state.ActiveCaptureSink();
+  proc_state.SetCaptureSink(&sink);
+
+  // Source / format are rvalues inside the body. The leaf lowering routes
+  // procedural-var leaves through the sink, producing body-side bindings.
+  auto source_or = LowerExpr(
+      unit_state, scope_state, proc_state, body, hir_proc,
+      hir_proc.exprs.at(call.arguments[0]->value));
+  if (!source_or) return std::unexpected(std::move(source_or.error()));
+  const mir::TypeId source_type = source_or->type;
+  mir::ExprId source_id = body.AddExpr(*std::move(source_or));
+  if (info.source == support::ScanSourceKind::kString) {
+    source_id = LiftStringSource(unit_state, body, source_type, source_id);
+  } else if (
+      unit_state.GetType(source_type).Kind() != mir::TypeKind::kPackedArray) {
+    throw InternalError(
+        "LowerScanSystemSubroutineCall: $fscanf fd is not packed-integer");
+  }
+
+  auto format_or = LowerExpr(
+      unit_state, scope_state, proc_state, body, hir_proc,
+      hir_proc.exprs.at(call.arguments[1]->value));
+  if (!format_or) return std::unexpected(std::move(format_or.error()));
+  const mir::ExprId format_id = body.AddExpr(*std::move(format_or));
+
+  // Allocate body-side temps for each slot. The parse call writes them;
+  // the conditional commit later reads them back into the original
+  // lvalue. Default-init is a syntactic requirement for procedural locals;
+  // the value is never observed because parse runs before commit.
+  std::vector<mir::ProceduralVarId> temp_ids;
+  temp_ids.reserve(metas.size());
+  for (std::size_t k = 0; k < metas.size(); ++k) {
+    const mir::ExprId init_id =
+        SynthesizeDefaultValueExpr(unit_state, body, metas[k].mir_type);
+    const mir::ProceduralVarRef temp_ref = body.AppendLocal(
+        mir::ProceduralVarDecl{
+            .name = std::format("_lyra_scan_temp_{}", k),
+            .type = metas[k].mir_type},
+        init_id);
+    temp_ids.push_back(temp_ref.var);
+  }
+
+  // RuntimeScanCall: each slot points at its body-local temp through a
+  // ProceduralVarRef, carrying the parser's per-slot metadata.
+  std::vector<mir::ScanSlotDesc> mir_slots;
+  mir_slots.reserve(metas.size());
+  for (std::size_t k = 0; k < metas.size(); ++k) {
+    const mir::ExprId temp_ref_id =
+        AppendVarRef(body, temp_ids[k], 0, metas[k].mir_type);
+    if (metas[k].is_string) {
+      mir_slots.emplace_back(mir::StringScanSlot{.temp = temp_ref_id});
+    } else {
+      mir_slots.emplace_back(
+          mir::IntegralScanSlot{
+              .temp = temp_ref_id,
+              .bit_width = metas[k].bit_width,
+              .is_signed = metas[k].is_signed,
+              .is_four_state = metas[k].is_four_state});
+    }
+  }
+
+  const mir::ExprId parse_call_id = body.AddExpr(
+      mir::Expr{
+          .data =
+              mir::RuntimeCallExpr{
+                  .call =
+                      mir::RuntimeScanCall{
+                          .source_kind = info.source,
+                          .source = source_id,
+                          .format = format_id,
+                          .slots = std::move(mir_slots)}},
+          .type = integer_t});
+
+  const mir::ProceduralVarRef count_ref = body.AppendLocal(
+      mir::ProceduralVarDecl{.name = "_lyra_scan_count", .type = integer_t},
+      parse_call_id);
+
+  // Conditional commits: for each output arg k, lower the lvalue HIR
+  // freshly inside the then-scope. The leaf lowering path routes any
+  // procedural-var leaf above the sink's boundary through the sink, which
+  // installs a by-reference binding in the closure body so writes to the
+  // rebased lvalue propagate to the caller's storage.
+  for (std::size_t k = 0; k < metas.size(); ++k) {
+    const mir::ExprId count_read_id =
+        body.AddExpr(mir::Expr{.data = count_ref, .type = integer_t});
+    const mir::ExprId k_lit_id = body.AddExpr(
+        unit_state.MakeIntegerLiteralExpr(static_cast<std::int64_t>(k + 1)));
+    const mir::ExprId cond_id = body.AddExpr(
+        mir::Expr{
+            .data =
+                mir::BinaryExpr{
+                    .op = mir::BinaryOp::kGreaterEqual,
+                    .lhs = count_read_id,
+                    .rhs = k_lit_id},
+            .type = bit_t});
+
+    ProceduralScopeLoweringState then_body;
+    ProceduralDepthGuard then_depth{proc_state};
+    auto lvalue_or = LowerExpr(
+        unit_state, scope_state, proc_state, then_body, hir_proc,
+        hir_proc.exprs.at(call.arguments[k + 2]->value));
+    if (!lvalue_or) return std::unexpected(std::move(lvalue_or.error()));
+    const mir::ExprId lvalue_id = then_body.AddExpr(*std::move(lvalue_or));
+    const mir::ExprId temp_read_id =
+        AppendVarRef(then_body, temp_ids[k], 1, metas[k].mir_type);
+    const mir::ExprId assign_id = then_body.AddExpr(
+        mir::Expr{
+            .data = mir::AssignExpr{.target = lvalue_id, .value = temp_read_id},
+            .type = metas[k].mir_type});
+    then_body.AppendStmt(mir::ExprStmt{.expr = assign_id});
+
+    body.AppendIfThen(cond_id, then_body.Finish());
+  }
+
+  // return count_local -- the closure's yield value.
+  const mir::ExprId return_value_id =
+      body.AddExpr(mir::Expr{.data = count_ref, .type = integer_t});
+  body.AppendStmt(mir::ReturnStmt{.value = return_value_id});
+
+  proc_state.SetCaptureSink(previous_sink);
+
+  mir::ClosureExpr closure;
+  closure.captures = sink.TakeCaptures();
+  closure.body = std::make_unique<mir::ProceduralScope>(body.Finish());
+
+  const mir::ExprId closure_id = proc_scope_state.AddExpr(
+      mir::Expr{.data = std::move(closure), .type = integer_t});
 
   return mir::Expr{
       .data =
-          mir::RuntimeCallExpr{
-              .call =
-                  mir::RuntimeScanCall{
-                      .source_kind = info.source,
-                      .source = source_id,
-                      .format = format_id,
-                      .slots = std::move(slot_refs)}},
-      .type = unit_state.Builtins().integer};
+          mir::CallExpr{
+              .callee = mir::ClosureRef{.closure = closure_id},
+              .arguments = {}},
+      .type = integer_t};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/lower_sformat.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_sformat.cpp
@@ -29,7 +29,7 @@ namespace {
 auto BuildSFormatCallExpr(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const support::SFormatSystemSubroutineInfo& info, std::size_t arg_offset,
@@ -67,7 +67,7 @@ auto RejectNonStringOutput(
 auto LowerSFormatSystemSubroutineCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const support::SFormatSystemSubroutineInfo& info, diag::SourceSpan span)

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -19,11 +19,11 @@
 #include "lyra/hir/stmt.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
+#include "lyra/lowering/hir_to_mir/capture_sink.hpp"
 #include "lyra/lowering/hir_to_mir/case_cascade.hpp"
 #include "lyra/lowering/hir_to_mir/copy_out_desugar.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/delay_time_resolver.hpp"
-#include "lyra/lowering/hir_to_mir/fork_capture.hpp"
 #include "lyra/lowering/hir_to_mir/inside_predicate.hpp"
 #include "lyra/lowering/hir_to_mir/lower_deferred_check.hpp"
 #include "lyra/lowering/hir_to_mir/lower_expr.hpp"
@@ -82,7 +82,7 @@ auto ResolveDelayDuration(
 }
 
 auto ResolveDelayTicks(
-    const ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
     const hir::DelayControl& d) -> diag::Result<SimDuration> {
   const DelayTimeResolver resolver{proc_state.Resolution()};
   return ResolveDelayDuration(resolver, hir_proc.exprs.at(d.duration.value));
@@ -679,19 +679,19 @@ auto LowerForkStmt(
     ProceduralScopeLoweringState branch_scope_state;
     ProceduralDepthGuard depth_guard{proc_state};
 
-    // Collect the branch's by-reference captures as its body is lowered: a body
-    // reference resolving above this boundary depth routes through the sink,
-    // which composes the capture and binding on the spot (LRM 6.21). A nested
+    // Collect the branch's captures as its body is lowered: a body reference
+    // resolving above this boundary depth routes through the sink, which
+    // composes the capture and binding on the spot (LRM 6.21). A nested
     // fork restores the prior sink on exit.
-    ForkCaptureSink sink{
+    CaptureSink sink{
         proc_state.CurrentProceduralDepth(), branch_scope_state,
         proc_scope_state};
-    ForkCaptureSink* const previous_sink = proc_state.ActiveForkCaptureSink();
-    proc_state.SetForkCaptureSink(&sink);
+    CaptureSink* const previous_sink = proc_state.ActiveCaptureSink();
+    proc_state.SetCaptureSink(&sink);
     auto lowered = LowerStmt(
         unit_state, scope_state, proc_state, branch_scope_state, hir_proc,
         branch);
-    proc_state.SetForkCaptureSink(previous_sink);
+    proc_state.SetCaptureSink(previous_sink);
     if (!lowered) {
       return std::unexpected(std::move(lowered.error()));
     }
@@ -1414,7 +1414,7 @@ auto LowerContinueStmt(const hir::Stmt& stmt) -> diag::Result<mir::Stmt> {
 auto LowerEventTriggerStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::Stmt& stmt,
     const hir::EventTriggerStmt& et) -> diag::Result<mir::Stmt> {

--- a/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_system_subroutine.cpp
@@ -23,7 +23,7 @@ namespace lyra::lowering::hir_to_mir {
 auto LowerSystemSubroutineCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     const hir::SystemSubroutineRef& ref, diag::SourceSpan span)

--- a/src/lyra/lowering/hir_to_mir/lower_timescale.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_timescale.cpp
@@ -22,7 +22,7 @@ namespace lyra::lowering::hir_to_mir {
 auto LowerTimeFormatSystemSubroutineCall(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     diag::SourceSpan span) -> diag::Result<mir::Expr> {

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -69,7 +69,7 @@ auto ToMirFormatModifiers(const support::FormatDirectiveModifiers& m)
 auto BuildPrintValueItem(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, hir::ExprId hir_arg,
     mir::FormatSpec spec) -> diag::Result<mir::RuntimePrintItem> {
@@ -105,7 +105,7 @@ auto BuildPrintValueItem(
 auto BuildPrintItemFromDirective(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc,
     const support::ParsedFormatDirective& directive,
@@ -185,7 +185,7 @@ auto RadixToFormatKind(support::PrintRadix r) -> value::FormatKind {
 auto BuildRuntimePrintItemsFromCallArgs(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ProcessLoweringState& proc_state,
+    ProcessLoweringState& proc_state,
     ProceduralScopeLoweringState& proc_scope_state,
     const hir::ProceduralBody& hir_proc, const hir::CallExpr& call,
     support::PrintRadix default_radix, std::size_t arg_offset,

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -334,6 +334,10 @@ class MirDumper {
                   "StructuralSubroutineRef[hops={}, subroutine={}] \"{}\"",
                   r.hops.value, r.subroutine.value, target.name);
             },
+            [](const ClosureRef& cr) -> std::string {
+              return std::format(
+                  "ClosureRef[closure=Expr[{}]]", cr.closure.value);
+            },
             [](const BuiltinMethodCallee& b) -> std::string {
               return std::visit(
                   Overloaded{
@@ -895,7 +899,21 @@ class MirDumper {
                       if (k != 0) {
                         slot_list += ", ";
                       }
-                      slot_list += std::format("Expr[{}]", ss.slots[k].value);
+                      slot_list += std::visit(
+                          Overloaded{
+                              [](const IntegralScanSlot& s) -> std::string {
+                                return std::format(
+                                    "Integral{{temp=Expr[{}], width={}, "
+                                    "signed={}, four_state={}}}",
+                                    s.temp.value, s.bit_width,
+                                    s.is_signed ? "true" : "false",
+                                    s.is_four_state ? "true" : "false");
+                              },
+                              [](const StringScanSlot& s) -> std::string {
+                                return std::format(
+                                    "String{{temp=Expr[{}]}}", s.temp.value);
+                              }},
+                          ss.slots[k]);
                     }
                     const std::string_view kind_text =
                         ss.source_kind == support::ScanSourceKind::kString

--- a/src/lyra/runtime/scan.cpp
+++ b/src/lyra/runtime/scan.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
@@ -69,15 +70,12 @@ void SkipSourceWhitespace(ScanSource& src) {
   }
 }
 
-// Write `bits` (MSB-first, i.e. bits[0] is the leftmost scanned digit /
-// bit) into `dest`. If `bits.size() < dest.BitWidth()`, MSBs of dest fill
-// with zero. If `bits.size() > dest.BitWidth()`, the high (leading) bits
-// are dropped -- only the trailing dest_width bits land. For a 2-state
-// dest, X/Z scanned bits collapse to 0 per the LRM 4-state -> 2-state
-// convention.
-void AssignBitsMsbFirst(
-    value::PackedArray& dest, std::span<const ScannedBit> bits) {
-  const std::uint64_t width = dest.BitWidth();
+// Build a PackedArray of the target shape from MSB-first scanned bits.
+// `bits.size() < width` zero-fills the MSBs; `bits.size() > width` drops
+// the high bits. For a 2-state target, X/Z scanned bits collapse to 0.
+auto MakePackedFromBits(
+    std::span<const ScannedBit> bits, std::uint32_t width, bool is_signed,
+    bool is_four_state) -> value::PackedArray {
   const auto word_count = static_cast<std::size_t>((width + 63U) / 64U);
   std::vector<std::uint64_t> val_words(word_count, 0U);
   std::vector<std::uint64_t> unk_words(word_count, 0U);
@@ -97,95 +95,93 @@ void AssignBitsMsbFirst(
     }
   }
 
-  const bool four_state = dest.IsFourState();
-  if (!four_state) {
+  if (!is_four_state) {
     for (std::size_t w = 0; w < word_count; ++w) {
       val_words[w] &= ~unk_words[w];
     }
-    dest = value::PackedArray::FromWords(
+    return value::PackedArray::FromWords(
         std::span<const std::uint64_t>{val_words},
-        std::span<const std::uint64_t>{}, width, dest.IsSigned(), false);
-    return;
+        std::span<const std::uint64_t>{}, width, is_signed, false);
   }
-  dest = value::PackedArray::FromWords(
+  return value::PackedArray::FromWords(
       std::span<const std::uint64_t>{val_words},
-      std::span<const std::uint64_t>{unk_words}, width, dest.IsSigned(), true);
+      std::span<const std::uint64_t>{unk_words}, width, is_signed, true);
 }
 
-void FillAllX(value::PackedArray& dest) {
-  const std::uint64_t width = dest.BitWidth();
-  const bool four_state = dest.IsFourState();
-  if (!four_state) {
-    dest = value::PackedArray::FromInt(0, width, dest.IsSigned(), false);
-    return;
+auto MakePackedAllX(std::uint32_t width, bool is_signed, bool is_four_state)
+    -> value::PackedArray {
+  if (!is_four_state) {
+    return value::PackedArray::FromInt(0, width, is_signed, false);
   }
   const auto word_count = static_cast<std::size_t>((width + 63U) / 64U);
   std::vector<std::uint64_t> val_words(word_count, ~std::uint64_t{0});
   std::vector<std::uint64_t> unk_words(word_count, ~std::uint64_t{0});
-  dest = value::PackedArray::FromWords(
+  return value::PackedArray::FromWords(
       std::span<const std::uint64_t>{val_words},
-      std::span<const std::uint64_t>{unk_words}, width, dest.IsSigned(), true);
+      std::span<const std::uint64_t>{unk_words}, width, is_signed, true);
 }
 
-void FillAllZ(value::PackedArray& dest) {
-  const std::uint64_t width = dest.BitWidth();
-  const bool four_state = dest.IsFourState();
-  if (!four_state) {
-    dest = value::PackedArray::FromInt(0, width, dest.IsSigned(), false);
-    return;
+auto MakePackedAllZ(std::uint32_t width, bool is_signed, bool is_four_state)
+    -> value::PackedArray {
+  if (!is_four_state) {
+    return value::PackedArray::FromInt(0, width, is_signed, false);
   }
   const auto word_count = static_cast<std::size_t>((width + 63U) / 64U);
   std::vector<std::uint64_t> val_words(word_count, 0U);
   std::vector<std::uint64_t> unk_words(word_count, ~std::uint64_t{0});
-  dest = value::PackedArray::FromWords(
+  return value::PackedArray::FromWords(
       std::span<const std::uint64_t>{val_words},
-      std::span<const std::uint64_t>{unk_words}, width, dest.IsSigned(), true);
+      std::span<const std::uint64_t>{unk_words}, width, is_signed, true);
 }
 
-void AssignFromI64(value::PackedArray& dest, std::int64_t value) {
-  dest = value::PackedArray::FromInt(
-      value, dest.BitWidth(), dest.IsSigned(), dest.IsFourState());
+auto MakePackedFromI64(
+    std::int64_t value, std::uint32_t width, bool is_signed, bool is_four_state)
+    -> value::PackedArray {
+  return value::PackedArray::FromInt(value, width, is_signed, is_four_state);
 }
 
-void RequireIntegralSlot(const ScanSlot& slot, std::string_view spec) {
-  if (!slot.IsIntegral()) {
+[[nodiscard]] auto RequireIntegralTarget(
+    const ScanTarget& target, std::string_view spec)
+    -> const IntegralScanTarget& {
+  const auto* t = std::get_if<IntegralScanTarget>(&target);
+  if (t == nullptr) {
     throw InternalError(
         std::format(
             "$sscanf/$fscanf: format spec '%{}' expects an integral output "
             "argument, but the corresponding actual is not integral",
             spec));
   }
+  return *t;
 }
 
-void RequireStringSlot(const ScanSlot& slot, std::string_view spec) {
-  if (!slot.IsString()) {
+[[nodiscard]] auto RequireStringTarget(
+    const ScanTarget& target, std::string_view spec)
+    -> const StringScanTarget& {
+  const auto* t = std::get_if<StringScanTarget>(&target);
+  if (t == nullptr) {
     throw InternalError(
         std::format(
             "$sscanf/$fscanf: format spec '%{}' expects a string output "
             "argument, but the corresponding actual is not a string",
             spec));
   }
+  return *t;
 }
 
 // Per-spec parser convention: each returns `nullopt` on LRM-defined input
-// failure; the dispatcher commits the result into the slot (or discards
-// it under `%*spec` assignment suppression).
+// failure. The dispatcher builds the final value from the parsed result
+// plus the target's type metadata.
 
-// ScanDecimal result. Mutually exclusive forms per LRM 21.3.4.3 `%d`:
-// either an integer value, or one of the single-char fills (x / X
-// collapse to kFillX; z / Z / ? collapse to kFillZ).
 struct DecimalResult {
   enum class Form : std::uint8_t { kInt, kFillX, kFillZ };
   Form form;
-  std::int64_t int_value = 0;  // valid only when form == kInt
+  std::int64_t int_value = 0;
 };
 
 // LRM 21.3.4.3 Table 21-7 `%d`. Either a sign-prefixed decimal digit run
 // (with `_` separators) or a single x/X/z/Z/? that fills the entire dest.
-// Mixed (`12x`) stops at the first non-digit -- the `x` is not consumed
-// here, so a following `%h` could still match it. `max_width == 0` means
-// no limit; non-zero caps the digit / `_` chars consumed (C-scanf
-// convention: the sign does not count toward the width).
+// `max_width == 0` means no limit; non-zero caps the digit / `_` chars
+// consumed (C-scanf convention: the sign does not count toward the width).
 [[nodiscard]] auto ScanDecimal(ScanSource& src, std::size_t max_width)
     -> std::optional<DecimalResult> {
   SkipSourceWhitespace(src);
@@ -239,10 +235,6 @@ struct DecimalResult {
 }
 
 // LRM 21.3.4.3 Table 21-7 `%h` / `%x`. Each character -> one 4-bit nibble.
-// Hex digits 0..9 a..f A..F land as (val=digit, unk=0); xX as
-// (val=1111, unk=1111); zZ? as (val=0000, unk=1111); `_` is a separator.
-// `max_width` caps total chars consumed (digits + `_`); zero means
-// unlimited.
 [[nodiscard]] auto ScanHex(ScanSource& src, std::size_t max_width)
     -> std::optional<std::vector<ScannedBit>> {
   SkipSourceWhitespace(src);
@@ -288,9 +280,7 @@ struct DecimalResult {
   return bits;
 }
 
-// LRM 21.3.4.3 Table 21-7 `%o`. 3 bits per octal digit; xX -> (111,111),
-// zZ? -> (000,111); `_` is a separator. `max_width` caps total chars
-// consumed.
+// LRM 21.3.4.3 Table 21-7 `%o`. 3 bits per octal digit.
 [[nodiscard]] auto ScanOctal(ScanSource& src, std::size_t max_width)
     -> std::optional<std::vector<ScannedBit>> {
   SkipSourceWhitespace(src);
@@ -336,9 +326,7 @@ struct DecimalResult {
   return bits;
 }
 
-// LRM 21.3.4.3 Table 21-7 `%b`. Per-character to one bit: 0/1 -> (val,0),
-// xX -> (1,1), zZ? -> (0,1), `_` separator. `max_width` caps total chars
-// consumed.
+// LRM 21.3.4.3 Table 21-7 `%b`. Per-character to one bit.
 [[nodiscard]] auto ScanBinary(ScanSource& src, std::size_t max_width)
     -> std::optional<std::vector<ScannedBit>> {
   SkipSourceWhitespace(src);
@@ -378,7 +366,7 @@ struct DecimalResult {
 }
 
 // Standard scanf `%s`: skip leading whitespace, then read non-whitespace
-// chars until whitespace or EOF. `max_width` caps total chars consumed.
+// chars until whitespace or EOF.
 [[nodiscard]] auto ScanString(ScanSource& src, std::size_t max_width)
     -> std::optional<std::string> {
   SkipSourceWhitespace(src);
@@ -414,46 +402,46 @@ struct DecimalResult {
   return static_cast<unsigned char>(ch & 0xFF);
 }
 
-// Commit helpers: snapshot the slot's current value, apply the parsed
-// result, then write back through `SetIntegral` so observability fires.
-void CommitDecimal(
-    const ScanSlot& slot, RuntimeServices& services,
-    const DecimalResult& result) {
-  value::PackedArray dest = slot.GetIntegral();
-  switch (result.form) {
+// Build helpers: from parsed value + target metadata to a final
+// PackedArray of the target's declared shape.
+
+auto BuildIntegralFromDecimal(
+    const DecimalResult& parsed, const IntegralScanTarget& target)
+    -> value::PackedArray {
+  switch (parsed.form) {
     case DecimalResult::Form::kInt:
-      AssignFromI64(dest, result.int_value);
-      break;
+      return MakePackedFromI64(
+          parsed.int_value, target.bit_width, target.is_signed,
+          target.is_four_state);
     case DecimalResult::Form::kFillX:
-      FillAllX(dest);
-      break;
+      return MakePackedAllX(
+          target.bit_width, target.is_signed, target.is_four_state);
     case DecimalResult::Form::kFillZ:
-      FillAllZ(dest);
-      break;
+      return MakePackedAllZ(
+          target.bit_width, target.is_signed, target.is_four_state);
   }
-  slot.SetIntegral(services, dest);
+  throw InternalError("BuildIntegralFromDecimal: unreachable form");
 }
 
-void CommitBits(
-    const ScanSlot& slot, RuntimeServices& services,
-    std::span<const ScannedBit> bits) {
-  value::PackedArray dest = slot.GetIntegral();
-  AssignBitsMsbFirst(dest, bits);
-  slot.SetIntegral(services, dest);
+auto BuildIntegralFromBits(
+    std::span<const ScannedBit> bits, const IntegralScanTarget& target)
+    -> value::PackedArray {
+  return MakePackedFromBits(
+      bits, target.bit_width, target.is_signed, target.is_four_state);
 }
 
-void CommitChar(
-    const ScanSlot& slot, RuntimeServices& services, unsigned char ch) {
-  value::PackedArray dest = slot.GetIntegral();
-  AssignFromI64(dest, static_cast<std::int64_t>(ch));
-  slot.SetIntegral(services, dest);
+auto BuildIntegralFromChar(unsigned char ch, const IntegralScanTarget& target)
+    -> value::PackedArray {
+  return MakePackedFromI64(
+      static_cast<std::int64_t>(ch), target.bit_width, target.is_signed,
+      target.is_four_state);
 }
 
 [[nodiscard]] auto ScanFromSource(
-    RuntimeServices& services, ScanSource& src, std::string_view fmt,
-    std::span<const ScanSlot> slots) -> std::int32_t {
+    ScanSource& src, std::string_view fmt, std::span<const ScanTarget> targets)
+    -> std::int32_t {
   std::int32_t items = 0;
-  std::size_t slot_ix = 0;
+  std::size_t target_ix = 0;
   bool first_conversion = true;
   std::size_t fmt_ix = 0;
 
@@ -461,8 +449,6 @@ void CommitChar(
     const char fc = fmt[fmt_ix];
 
     if (IsAsciiWhitespace(static_cast<unsigned char>(fc))) {
-      // Any whitespace in the format matches zero-or-more whitespace in
-      // the input.
       SkipSourceWhitespace(src);
       ++fmt_ix;
       continue;
@@ -516,8 +502,6 @@ void CommitChar(
     const char spec = fmt[fmt_ix];
     ++fmt_ix;
 
-    // `%%` literal -- LRM treats it as a non-conversion directive; modifiers
-    // do not apply.
     if (spec == '%') {
       if (suppress || max_width != 0) {
         throw InternalError(
@@ -535,24 +519,20 @@ void CommitChar(
       continue;
     }
 
-    if (!suppress && slot_ix >= slots.size()) {
+    if (!suppress && target_ix >= targets.size()) {
       throw InternalError(
           "$sscanf/$fscanf: format string has more (non-suppressed) "
           "conversion specifiers than output arguments");
     }
 
-    // Two-phase per spec: (1) parse the input -- pure, mode-independent;
-    // (2) commit the result into the slot if the conversion is not
-    // suppressed. Suppress lives in this dispatcher; parsers are
-    // suppression-agnostic.
     bool ok = false;
     switch (spec) {
       case 'd': {
         if (auto parsed = ScanDecimal(src, max_width); parsed.has_value()) {
           ok = true;
           if (!suppress) {
-            RequireIntegralSlot(slots[slot_ix], "d");
-            CommitDecimal(slots[slot_ix], services, *parsed);
+            const auto& t = RequireIntegralTarget(targets[target_ix], "d");
+            *t.dest = BuildIntegralFromDecimal(*parsed, t);
           }
         }
         break;
@@ -562,8 +542,9 @@ void CommitChar(
         if (auto parsed = ScanHex(src, max_width); parsed.has_value()) {
           ok = true;
           if (!suppress) {
-            RequireIntegralSlot(slots[slot_ix], spec == 'x' ? "x" : "h");
-            CommitBits(slots[slot_ix], services, *parsed);
+            const auto& t = RequireIntegralTarget(
+                targets[target_ix], spec == 'x' ? "x" : "h");
+            *t.dest = BuildIntegralFromBits(*parsed, t);
           }
         }
         break;
@@ -572,8 +553,8 @@ void CommitChar(
         if (auto parsed = ScanBinary(src, max_width); parsed.has_value()) {
           ok = true;
           if (!suppress) {
-            RequireIntegralSlot(slots[slot_ix], "b");
-            CommitBits(slots[slot_ix], services, *parsed);
+            const auto& t = RequireIntegralTarget(targets[target_ix], "b");
+            *t.dest = BuildIntegralFromBits(*parsed, t);
           }
         }
         break;
@@ -582,8 +563,8 @@ void CommitChar(
         if (auto parsed = ScanOctal(src, max_width); parsed.has_value()) {
           ok = true;
           if (!suppress) {
-            RequireIntegralSlot(slots[slot_ix], "o");
-            CommitBits(slots[slot_ix], services, *parsed);
+            const auto& t = RequireIntegralTarget(targets[target_ix], "o");
+            *t.dest = BuildIntegralFromBits(*parsed, t);
           }
         }
         break;
@@ -592,8 +573,8 @@ void CommitChar(
         if (auto parsed = ScanString(src, max_width); parsed.has_value()) {
           ok = true;
           if (!suppress) {
-            RequireStringSlot(slots[slot_ix], "s");
-            slots[slot_ix].SetString(value::String(std::move(*parsed)));
+            const auto& t = RequireStringTarget(targets[target_ix], "s");
+            *t.dest = value::String(std::move(*parsed));
           }
         }
         break;
@@ -602,8 +583,8 @@ void CommitChar(
         if (auto parsed = ScanChar(src, max_width); parsed.has_value()) {
           ok = true;
           if (!suppress) {
-            RequireIntegralSlot(slots[slot_ix], "c");
-            CommitChar(slots[slot_ix], services, *parsed);
+            const auto& t = RequireIntegralTarget(targets[target_ix], "c");
+            *t.dest = BuildIntegralFromChar(*parsed, t);
           }
         }
         break;
@@ -616,21 +597,15 @@ void CommitChar(
     }
 
     if (!ok) {
-      // Mismatch / EOF mid-conversion. The LRM distinguishes "EOF before
-      // any conversion" (-1) from "match failure after some" (return the
-      // count so far).
       if (first_conversion && src.Peek() == -1) {
         return -1;
       }
       return items;
     }
     first_conversion = false;
-    // LRM "success of suppressed assignments is not directly determinable":
-    // suppressed conversions advance the input but do not bump items or
-    // consume an output slot.
     if (!suppress) {
       ++items;
-      ++slot_ix;
+      ++target_ix;
     }
   }
   return items;
@@ -639,28 +614,22 @@ void CommitChar(
 }  // namespace
 
 auto LyraSScanf(
-    RuntimeServices& services, const value::String& input,
-    const value::String& format, std::initializer_list<ScanSlot> slots)
-    -> value::PackedArray {
+    const value::String& input, const value::String& format,
+    std::initializer_list<ScanTarget> targets) -> value::PackedArray {
   StringScanSource src(input.View());
   const std::int32_t items = ScanFromSource(
-      services, src, format.View(),
-      std::span<const ScanSlot>{slots.begin(), slots.size()});
+      src, format.View(),
+      std::span<const ScanTarget>{targets.begin(), targets.size()});
   return value::PackedArray::Integer(items);
 }
 
 auto LyraFScanf(
     RuntimeServices& services, const value::PackedArray& fd_pa,
-    const value::String& format, std::initializer_list<ScanSlot> slots)
+    const value::String& format, std::initializer_list<ScanTarget> targets)
     -> value::PackedArray {
   const auto fd = static_cast<std::int32_t>(fd_pa.ToInt64());
   auto* slot = services.Files().ResolveSlot(fd);
   if (slot == nullptr) {
-    // MCD descriptors, closed FDs, and unmapped FDs all land here. LRM
-    // 21.3.4.3 specifies EOF (-1) when the input ends before the first
-    // matching failure or conversion; we treat "no readable stream" as
-    // that condition and additionally stamp $ferror so an SV caller
-    // querying it sees EBADF.
     services.Files().SetError(
         fd, EBADF, "$fscanf: not an open file descriptor");
     return value::PackedArray::Integer(-1);
@@ -671,8 +640,8 @@ auto LyraFScanf(
   }
   FileScanSource src(*slot);
   const std::int32_t items = ScanFromSource(
-      services, src, format.View(),
-      std::span<const ScanSlot>{slots.begin(), slots.size()});
+      src, format.View(),
+      std::span<const ScanTarget>{targets.begin(), targets.size()});
   src.FlushPushback();
   return value::PackedArray::Integer(items);
 }

--- a/tests/cases/cpp/sscanf_complex_lvalues/case.yaml
+++ b/tests/cases/cpp/sscanf_complex_lvalues/case.yaml
@@ -1,0 +1,20 @@
+id: cpp.sscanf_complex_lvalues
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    count_unp: 2
+    count_dyn: 2
+    count_slice: 1
+    count_field: 2
+    unp_if: 5
+    count_tern: 1
+    dyn_tern: 7
+    unp: [10, 20, 5]
+    dyn: [7, 40]
+    v: 0xab

--- a/tests/cases/cpp/sscanf_complex_lvalues/main.sv
+++ b/tests/cases/cpp/sscanf_complex_lvalues/main.sv
@@ -1,0 +1,35 @@
+module Top;
+  // LRM 21.3.4.3: scan output args may be any writable lvalue. Today the
+  // lowering restricts them to bare variable references; this case proves
+  // bit-slice, packed struct field, unpacked element, and dynamic element
+  // all work as output args.
+
+  int unp[3];
+  int dyn[];
+  bit [15:0] v;
+  struct packed {
+    int a;
+    int b;
+  } s;
+
+  int count_unp, count_dyn, count_slice, count_field;
+  int unp_if;
+  int count_tern, dyn_tern;
+
+  initial begin
+    dyn = new[2];
+
+    // Statement position: complex lvalues.
+    count_unp = $sscanf("10 20", "%d %d", unp[0], unp[1]);
+    count_dyn = $sscanf("30 40", "%d %d", dyn[0], dyn[1]);
+    count_slice = $sscanf("ab", "%h", v[7:0]);
+    count_field = $sscanf("99 77", "%d %d", s.a, s.b);
+
+    // Expression position: if-condition with complex lvalue output.
+    if ($sscanf("5", "%d", unp[2])) unp_if = unp[2];
+
+    // Ternary: only the taken arm's scan runs (C++ ternary is short-circuit).
+    count_tern = (unp_if == 5) ? $sscanf("7", "%d", dyn[0]) : 0;
+    dyn_tern = dyn[0];
+  end
+endmodule


### PR DESCRIPTION
## Summary

Closes the LRM 21.3.4.3 gap where `$sscanf` / `$fscanf` output args were restricted to bare variable references; bit-selects (`a[3:0]`), element indices (`arr[i]`), packed struct fields (`s.f`), and multi-dim packed elements now work.

The scan call is modelled as a closure invoked immediately (the IIFE pattern): the closure body parses into procedural-local temps, conditionally writes back to the original output lvalues, and yields the matched-conversion count. Lvalue polymorphism is absorbed by the body's writeback assignments through the existing `AssignExpr` path; the runtime sees only plain temp pointers plus per-slot type metadata.

The fork branch's by-reference capture mechanism is renamed from `ForkCaptureSink` to a generic identity-only `CaptureSink` and reused by scan. The leaf lowering routes any procedural-var reference resolving above the sink's boundary through the sink, which composes the closure's captures as the body is built. Aliasing is correct for both reads and writes because the caller's storage is live throughout the closure's evaluation (sync IIFE) or outlives the body (fork, LRM 6.21).

The runtime scan ABI is rewritten to lvalue-agnostic pointer-to-temps with per-slot type metadata; the old `ScanSlot` variant binding `Var<T>` / cell references is dropped.

## Design

`LowerExpr` now takes `ProcessLoweringState&` by mutable reference instead of by const reference. The class mixes process facts (HIR-to-MIR bindings, static frame, time resolution) with traversal state (current depth, active capture sink); the const fig leaf was honest for facts but accidentally worked for traversal state only because ordinary expressions do not open scopes. The closure-IIFE pattern breaks that, and the temporary fix is the non-const signature -- documented under refactor R9, which is the proper split.

## Testing

Added `tests/cases/cpp/sscanf_complex_lvalues` covering unpacked element, dynamic element, packed bit-slice, packed struct field, if-condition position, ternary, and arithmetic operand. Full `bazel test //...` passes.