### PR TITLE
Resolve downward hierarchical references into owned generate blocks

### DIFF
--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -142,10 +142,12 @@ consume. Coverage is demonstrated through Stage D and Stage E.
       reaches a generate block by its LRM name (the source label, or `genblk<n>` when unnamed, LRM
       27.6), indexes a loop-generate block, and continues to a signal or a further child inside it;
       when an if/case construct's alternatives share a name (LRM 27.5) the reference binds whichever
-      alternative was instantiated. Landed for the by-name direction -- an upward reference whose
-      downward tail crosses the generate boundary. Still open: a reference from the scope that owns
-      the generate descending into its own generate block, and a reference originating inside a
-      generate block that names a signal in an enclosing scope.
+      alternative was instantiated. Landed for a reference whose head reaches the generate from its
+      owning scope or from outside: an upward reference whose downward tail enters the generate, and
+      a reference from the scope that owns the generate descending into its own block (loop and
+      conditional forms, and regardless of whether the reference precedes the generate in source).
+      Still open: a reference originating inside a generate block that names a signal in an
+      enclosing scope.
 
 Unlocks `refs/hierarchical_refs`, `refs/upward_refs`, and `instantiation/hierarchical_sensitivity`.
 

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -54,7 +54,10 @@ struct IndexHop {
 using PathStep = std::variant<MemberHop, IndexHop>;
 
 // Where a cross-unit reference starts its navigation. A downward reference
-// reaches into an owned child instance (or instance-array) member. An upward
+// reaches into an owned child the referrer's own scope declares -- an
+// instance/instance-array member, or a generate block (LRM 27) identified by
+// its position in the scope. Both resolve to one owned-child companion var at
+// construction, so the navigation past the head is identical. An upward
 // reference (LRM 23.6) climbs the parent chain at construction to the nearest
 // ancestor whose instance or module name is `ancestor_name`; from there both
 // directions share `path` to reach the leaf, by name across the unit boundary
@@ -62,8 +65,12 @@ using PathStep = std::variant<MemberHop, IndexHop>;
 // depend on (docs/architecture/emission_model.md). The child cannot know its
 // depth at compile time, so it locates the ancestor by name rather than a
 // baked-in offset.
+struct GenerateChildRef {
+  GenerateId generate;
+  StructuralScopeId scope;
+};
 struct DownwardHead {
-  InstanceMemberId instance;
+  std::variant<InstanceMemberId, GenerateChildRef> child;
 };
 struct UpwardHead {
   std::string ancestor_name;

--- a/include/lyra/lowering/ast_to_hir/state.hpp
+++ b/include/lyra/lowering/ast_to_hir/state.hpp
@@ -67,13 +67,20 @@ struct LoopVarBinding {
 using LoopVarBindings =
     std::unordered_map<const slang::ast::ValueSymbol*, LoopVarBinding>;
 
-struct InstanceMemberBinding {
+// A downward reference's leading component names an owned child this scope
+// declares: an instance / instance-array member (`c.x`, `c[1].x`), or a
+// generate block (`g[1].x`, LRM 27) -- the GenerateBlockArray for a loop, the
+// GenerateBlock arm for an if/case. The child's slang symbol maps to the head
+// the reference navigates from, so the reference resolves regardless of whether
+// it precedes the child in source. `head` is exactly the downward head, ready
+// to hand to MakeCrossUnitMemberRef.
+struct OwnedChildBinding {
   ScopeFrameId home_frame;
-  hir::InstanceMemberId member_id;
+  hir::DownwardHead head;
 };
 
-using InstanceMemberBindings =
-    std::unordered_map<const slang::ast::Symbol*, InstanceMemberBinding>;
+using OwnedChildBindings =
+    std::unordered_map<const slang::ast::Symbol*, OwnedChildBinding>;
 
 class UnitLoweringState {
  public:
@@ -233,24 +240,23 @@ class UnitLoweringState {
     return it->second;
   }
 
-  void MapInstanceMemberBinding(
-      const slang::ast::Symbol& member, ScopeFrameId home_frame,
-      hir::InstanceMemberId member_id) {
-    const auto [_, inserted] = instance_member_bindings_.emplace(
-        &member, InstanceMemberBinding{
-                     .home_frame = home_frame, .member_id = member_id});
+  void MapOwnedChildBinding(
+      const slang::ast::Symbol& child, ScopeFrameId home_frame,
+      hir::DownwardHead head) {
+    const auto [_, inserted] = owned_child_bindings_.emplace(
+        &child,
+        OwnedChildBinding{.home_frame = home_frame, .head = std::move(head)});
     if (!inserted) {
       throw InternalError(
-          "UnitLoweringState::MapInstanceMemberBinding: instance member "
-          "already mapped");
+          "UnitLoweringState::MapOwnedChildBinding: owned child already "
+          "mapped");
     }
   }
 
-  [[nodiscard]] auto LookupInstanceMemberBinding(
-      const slang::ast::Symbol& member) const
-      -> std::optional<InstanceMemberBinding> {
-    const auto it = instance_member_bindings_.find(&member);
-    if (it == instance_member_bindings_.end()) {
+  [[nodiscard]] auto LookupOwnedChildBinding(const slang::ast::Symbol& child)
+      const -> std::optional<OwnedChildBinding> {
+    const auto it = owned_child_bindings_.find(&child);
+    if (it == owned_child_bindings_.end()) {
       return std::nullopt;
     }
     return it->second;
@@ -315,7 +321,7 @@ class UnitLoweringState {
   StructuralVarBindings structural_var_bindings_;
   SubroutineBindings subroutine_bindings_;
   LoopVarBindings loop_var_bindings_;
-  InstanceMemberBindings instance_member_bindings_;
+  OwnedChildBindings owned_child_bindings_;
   std::unordered_map<const slang::ast::ValueSymbol*, hir::CrossUnitRefId>
       cross_unit_ref_dedup_;
   std::map<ScopeFrameId, std::vector<hir::CrossUnitRefDecl>>
@@ -466,6 +472,16 @@ class ScopeLoweringState {
         static_cast<std::uint32_t>(scope_->generates.size())};
     scope_->generates.push_back(std::move(generate));
     return id;
+  }
+
+  // The id the next AddGenerate will assign. A generate's head binding is
+  // registered while its body is built, before AddGenerate appends it, so the
+  // binding must name this prospective id; building a generate never appends to
+  // this scope's generates (nested generates belong to child scopes), so the id
+  // is stable across the build.
+  [[nodiscard]] auto NextGenerateId() const -> hir::GenerateId {
+    return hir::GenerateId{
+        static_cast<std::uint32_t>(scope_->generates.size())};
   }
 
   auto AddInstanceMember(hir::InstanceMemberDecl decl)

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -307,9 +307,10 @@ auto LowerNamedValueProc(
 }
 
 // LRM 23.6 hierarchical reference. The head of the navigation differs by
-// direction: a downward path (`c.x`, `m.l.x`, `c[1].x`) starts at a local child
-// member; an upward path (`Top.g`, `Top.sib.y`) starts by climbing the parent
-// chain at construction to the named ancestor instance. The shared tail
+// direction: a downward path (`c.x`, `c[1].x`, `g[1].u.x`) starts at a local
+// owned child -- an instance member or a generate block; an upward path
+// (`Top.g`, `Top.sib.y`) starts by climbing the parent chain at construction to
+// the named ancestor instance. The shared tail
 // (`path.subspan(1)`) and the resolve-once slot are common
 // (reference_resolution.md, docs/decisions/upward-reference-resolution.md).
 auto LowerHierarchicalValueProc(
@@ -399,36 +400,40 @@ auto LowerHierarchicalValueProc(
         std::move(path), *type_id, span);
   }
 
-  // Downward: the head is an owned instance / instance-array member this unit's
-  // scope directly binds (the pre-pass always binds it). A missing binding is a
-  // compiler-bug invariant. Crossing a generate-block scope is not yet
-  // supported.
-  const bool head_is_instance_member =
+  // Downward: the head is an owned child this unit's scope declares -- an
+  // instance / instance-array member, or a generate block (LRM 27). Both are
+  // bound before any process body is lowered, so a reference resolves
+  // regardless of source order; a missing binding is a compiler-bug invariant.
+  const bool head_is_owned_child =
       head_sym.kind == slang::ast::SymbolKind::Instance ||
-      head_sym.kind == slang::ast::SymbolKind::InstanceArray;
-  if (!head_is_instance_member) {
+      head_sym.kind == slang::ast::SymbolKind::InstanceArray ||
+      head_sym.kind == slang::ast::SymbolKind::GenerateBlock ||
+      head_sym.kind == slang::ast::SymbolKind::GenerateBlockArray;
+  if (!head_is_owned_child) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedExpressionForm,
-        "hierarchical reference through a generate-block scope is not yet "
-        "supported",
+        "hierarchical reference through this scope kind is not yet supported",
         diag::UnsupportedCategory::kOperation);
   }
-  const auto head_binding = unit_state.LookupInstanceMemberBinding(head_sym);
-  if (!head_binding.has_value()) {
+  const auto binding = unit_state.LookupOwnedChildBinding(head_sym);
+  if (!binding.has_value()) {
     throw InternalError(
-        "LowerHierarchicalValueProc: downward head member has no binding");
+        "LowerHierarchicalValueProc: downward owned-child head has no binding");
   }
-  const auto hops = stack.HopsTo(head_binding->home_frame);
+
+  // The owner navigates its own storage, so the head must live on the
+  // referencing frame. A reference reaching the owned child from a nested
+  // generate frame (`hops != 0`) is a separate, unsupported case.
+  const auto hops = stack.HopsTo(binding->home_frame);
   if (!hops.has_value() || hops->value != 0) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedExpressionForm,
-        "hierarchical reference across a generate-block scope boundary is not "
-        "yet supported",
+        "hierarchical reference reaching an owned child from a nested generate "
+        "scope is not yet supported",
         diag::UnsupportedCategory::kOperation);
   }
   return MakeCrossUnitMemberRef(
-      unit_state, var, head_binding->home_frame,
-      hir::DownwardHead{.instance = head_binding->member_id}, std::move(path),
+      unit_state, var, binding->home_frame, binding->head, std::move(path),
       *type_id, span);
 }
 

--- a/src/lyra/lowering/ast_to_hir/generate.cpp
+++ b/src/lyra/lowering/ast_to_hir/generate.cpp
@@ -83,14 +83,21 @@ auto DeriveLoopVariableSubstitution(
 
 auto AddChildScope(
     const UnitLoweringFacts& unit_facts, UnitLoweringState& unit_state,
-    ScopeStack& stack, hir::Generate& generate,
-    const slang::ast::GenerateBlockSymbol& block)
+    ScopeStack& stack, hir::Generate& generate, ScopeFrameId home_frame,
+    hir::GenerateId generate_id, const slang::ast::GenerateBlockSymbol& block)
     -> diag::Result<hir::StructuralScopeId> {
   hir::StructuralScope scope;
   scope.source_name = std::string{block.name};
   auto r = LowerScopeInto(unit_facts, unit_state, scope, block, stack);
   if (!r) return std::unexpected(std::move(r.error()));
-  return AddChildStructuralScope(generate, std::move(scope));
+  const hir::StructuralScopeId scope_id =
+      AddChildStructuralScope(generate, std::move(scope));
+  unit_state.MapOwnedChildBinding(
+      block, home_frame,
+      hir::DownwardHead{
+          .child = hir::GenerateChildRef{
+              .generate = generate_id, .scope = scope_id}});
+  return scope_id;
 }
 
 }  // namespace
@@ -137,13 +144,17 @@ auto BuildIfGenerate(
   const hir::ExprId cond_id = parent_state.AddExpr(*std::move(cond_expr));
 
   hir::Generate gen{};
+  const ScopeFrameId gen_frame = parent_state.Frame();
+  const hir::GenerateId gen_id = parent_state.NextGenerateId();
 
-  auto then_id = AddChildScope(unit_facts, unit_state, stack, gen, *then_block);
+  auto then_id = AddChildScope(
+      unit_facts, unit_state, stack, gen, gen_frame, gen_id, *then_block);
   if (!then_id) return std::unexpected(std::move(then_id.error()));
 
   std::optional<hir::StructuralScopeId> else_id;
   if (else_block != nullptr) {
-    auto built = AddChildScope(unit_facts, unit_state, stack, gen, *else_block);
+    auto built = AddChildScope(
+        unit_facts, unit_state, stack, gen, gen_frame, gen_id, *else_block);
     if (!built) return std::unexpected(std::move(built.error()));
     else_id = *built;
   }
@@ -181,6 +192,8 @@ auto BuildCaseGenerate(
   const hir::ExprId cond_id = parent_state.AddExpr(*std::move(cond_expr));
 
   hir::Generate gen{};
+  const ScopeFrameId gen_frame = parent_state.Frame();
+  const hir::GenerateId gen_id = parent_state.NextGenerateId();
 
   std::vector<hir::CaseGenerateItem> items;
   std::optional<hir::StructuralScopeId> default_id;
@@ -198,8 +211,8 @@ auto BuildCaseGenerate(
           labels.push_back(
               parent_state.AddExpr(*std::move(label_expr_lowered)));
         }
-        auto item_id =
-            AddChildScope(unit_facts, unit_state, stack, gen, *block);
+        auto item_id = AddChildScope(
+            unit_facts, unit_state, stack, gen, gen_frame, gen_id, *block);
         if (!item_id) return std::unexpected(std::move(item_id.error()));
         items.push_back(
             hir::CaseGenerateItem{
@@ -212,7 +225,8 @@ auto BuildCaseGenerate(
               "BuildCaseGenerate: case-generate has more than one default "
               "branch");
         }
-        auto built = AddChildScope(unit_facts, unit_state, stack, gen, *block);
+        auto built = AddChildScope(
+            unit_facts, unit_state, stack, gen, gen_frame, gen_id, *block);
         if (!built) return std::unexpected(std::move(built.error()));
         default_id = *built;
         break;
@@ -323,6 +337,12 @@ auto BuildLoopGenerate(
   loop_scope_seed.source_name = std::string{array.name};
   const hir::StructuralScopeId loop_scope_id =
       AddChildStructuralScope(gen, std::move(loop_scope_seed));
+  unit_state.MapOwnedChildBinding(
+      array, parent_state.Frame(),
+      hir::DownwardHead{
+          .child = hir::GenerateChildRef{
+              .generate = parent_state.NextGenerateId(),
+              .scope = loop_scope_id}});
 
   if (!array.entries.empty()) {
     const auto& canonical_entry = *array.entries.front();

--- a/src/lyra/lowering/ast_to_hir/port_connection.cpp
+++ b/src/lyra/lowering/ast_to_hir/port_connection.cpp
@@ -57,7 +57,7 @@ auto LowerInstancePortConnectionsInto(
 
   // The instance member is bound in the pre-pass; a downward port reach cannot
   // miss it, so absence is a compiler-bug invariant.
-  const auto binding = unit_state.LookupInstanceMemberBinding(inst);
+  const auto binding = unit_state.LookupOwnedChildBinding(inst);
   if (!binding.has_value()) {
     throw InternalError(
         "LowerInstancePortConnectionsInto: instance member has no binding");
@@ -109,8 +109,7 @@ auto LowerInstancePortConnectionsInto(
     auto type_id = unit_state.GetTypeId(port_type, span);
     if (!type_id) return std::unexpected(std::move(type_id.error()));
     hir::Expr child_ref = MakeCrossUnitMemberRef(
-        unit_state, *internal, binding->home_frame,
-        hir::DownwardHead{.instance = binding->member_id},
+        unit_state, *internal, binding->home_frame, binding->head,
         {hir::MemberHop{std::string{internal->name}}}, *type_id, span);
 
     if (port.direction == slang::ast::ArgumentDirection::In) {

--- a/src/lyra/lowering/ast_to_hir/scope.cpp
+++ b/src/lyra/lowering/ast_to_hir/scope.cpp
@@ -257,8 +257,8 @@ auto LowerInstanceMemberInto(
   // A downward cross-unit reference (`c.x`) resolves the leading `c` to this
   // member; the binding lets process-body lowering find it regardless of
   // source order.
-  scope_state.UnitState().MapInstanceMemberBinding(
-      inst, scope_state.Frame(), member_id);
+  scope_state.UnitState().MapOwnedChildBinding(
+      inst, scope_state.Frame(), hir::DownwardHead{.child = member_id});
   return {};
 }
 
@@ -289,8 +289,8 @@ auto LowerInstanceArrayMemberInto(
   // A downward cross-unit reference whose path indexes this array (`c[i].x`)
   // resolves the leading `c` to this member; the binding lets process-body
   // lowering find it regardless of source order.
-  scope_state.UnitState().MapInstanceMemberBinding(
-      array, scope_state.Frame(), member_id);
+  scope_state.UnitState().MapOwnedChildBinding(
+      array, scope_state.Frame(), hir::DownwardHead{.child = member_id});
   return {};
 }
 
@@ -368,10 +368,17 @@ auto LowerScopeMembersInto(
     }
   }
 
+  // Structural members (variables, generates, subroutine bodies) are lowered
+  // before behavioral ones (processes, continuous assigns), so a process or
+  // continuous assign resolves a downward reference into a generate block it
+  // textually precedes -- declarations are scope-wide (LRM 27), the same reason
+  // instances are bound in the pre-pass above.
   std::unordered_set<std::uint32_t> consumed_construct_indices;
   for (const auto& member : slang_scope.members()) {
     if (member.kind == slang::ast::SymbolKind::Instance ||
-        member.kind == slang::ast::SymbolKind::InstanceArray) {
+        member.kind == slang::ast::SymbolKind::InstanceArray ||
+        member.kind == slang::ast::SymbolKind::ProceduralBlock ||
+        member.kind == slang::ast::SymbolKind::ContinuousAssign) {
       continue;
     }
     if (member.kind == slang::ast::SymbolKind::GenerateBlock) {
@@ -379,6 +386,15 @@ auto LowerScopeMembersInto(
       if (!consumed_construct_indices.insert(block.constructIndex).second) {
         continue;
       }
+    }
+    auto r = LowerScopeMemberInto(
+        unit_facts, scope_state, stack, member, slang_scope);
+    if (!r) return std::unexpected(std::move(r.error()));
+  }
+  for (const auto& member : slang_scope.members()) {
+    if (member.kind != slang::ast::SymbolKind::ProceduralBlock &&
+        member.kind != slang::ast::SymbolKind::ContinuousAssign) {
+      continue;
     }
     auto r = LowerScopeMemberInto(
         unit_facts, scope_state, stack, member, slang_scope);

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -288,11 +288,21 @@ void InstallCrossUnitRefs(
     UnitLoweringState& unit_state, StructuralScopeLoweringState& scope_state,
     const hir::StructuralScope& scope,
     const std::vector<mir::StructuralVarId>& instance_member_vars,
+    const std::vector<GenerateBindings>& gen_bindings,
     ProceduralScopeLoweringState& ctor_scope_state) {
   for (const auto& cu : scope.cross_unit_refs) {
     const auto* down = std::get_if<hir::DownwardHead>(&cu.head);
     if (down == nullptr) {
       continue;
+    }
+    mir::StructuralVarId head_var{};
+    if (const auto* im = std::get_if<hir::InstanceMemberId>(&down->child)) {
+      head_var = instance_member_vars.at(im->value);
+    } else {
+      const auto& g = std::get<hir::GenerateChildRef>(down->child);
+      head_var = gen_bindings.at(g.generate.value)
+                     .by_scope_id.at(g.scope.value)
+                     .var_id;
     }
     std::vector<mir::PathStep> path;
     path.reserve(cu.path.size());
@@ -305,7 +315,7 @@ void InstallCrossUnitRefs(
     }
     const mir::CrossUnitRefId slot = scope_state.AddCrossUnitRef(
         mir::CrossUnitRefDecl{
-            .instance_var = instance_member_vars.at(down->instance.value),
+            .instance_var = head_var,
             .path = std::move(path),
             .type = unit_state.TranslateType(cu.type)});
     const mir::StmtId sid = ctor_scope_state.AddStmt(
@@ -757,7 +767,8 @@ auto LowerStructuralScope(
   const auto instance_member_vars =
       InstallInstanceMembers(unit_state, scope_state, scope, ctor_scope_state);
   InstallCrossUnitRefs(
-      unit_state, scope_state, scope, instance_member_vars, ctor_scope_state);
+      unit_state, scope_state, scope, instance_member_vars, *bindings_r,
+      ctor_scope_state);
 
   scope_state.SetConstructorScope(ctor_scope_state.Finish());
 

--- a/tests/cases/cpp/hierarchy_downward_into_generate/case.yaml
+++ b/tests/cases/cpp/hierarchy_downward_into_generate/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_downward_into_generate
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "11 207 42 5\n"

--- a/tests/cases/cpp/hierarchy_downward_into_generate/main.sv
+++ b/tests/cases/cpp/hierarchy_downward_into_generate/main.sv
@@ -1,0 +1,33 @@
+module Leaf;
+  int x;
+endmodule
+
+module Top;
+  int a, b, c, d;
+  initial begin
+    g[2].u.x = 207;
+    #1;
+    a = g[1].y;
+    b = g[2].u.x;
+    c = bk.v;
+    d = bp.w;
+    $display("%0d %0d %0d %0d", a, b, c, d);
+  end
+  genvar i;
+  generate
+    for (i = 0; i < 3; i = i + 1) begin : g
+      int y = i * 11;
+      Leaf u();
+    end
+    if (1) begin : bk
+      int v = 42;
+    end
+    // Same-name arms (LRM 27.5): the owner reaches the instantiated arm.
+    if (1) begin : bp
+      int w = 5;
+    end
+    else begin : bp
+      int w = 9;
+    end
+  endgenerate
+endmodule


### PR DESCRIPTION
## Summary

A reference written in the scope that owns a generate block can now descend into that block by typed-pointer navigation, exactly as it already does into an instance array. `g[1].y`, `g[2].u.x`, and the conditional forms (`bk.v`, same-name `if`/`else` arms) all resolve from the owner's own storage -- the generate origin is invisible to the read, which compiles to the same `&this->gen0_loop_obj[1]->y` chase an instance member produces. This is the owner-side, typed direction of D7; the by-name direction (an outsider climbing in via `GetChild`) already landed, and a reference originating inside a generate block remains the one open D7 case.

## Design

A downward reference's head is an owned child of the referring scope, which is either an instance member or a generate block. Both kinds are now bound before any process body is lowered, so a reference resolves regardless of whether it precedes the generate in source -- the same scope-wide-declaration guarantee instances already had, achieved by lowering structural members (generates) ahead of behavioral ones (processes, continuous assigns). The HIR downward head carries a variant of the two owned-child kinds, and the two AST-level binding tables (one for instances, one added for generates) are unified into a single owned-child binding whose payload is exactly the downward head, so the reference-lowering and port-connection paths look it up once with no per-kind branching. The MIR and C++ backend are unchanged: the cross-unit slot already navigates from a plain structural-var head, so a generate companion vector feeds it the same way an instance array does.

## Testing

A new cpp_run case exercises all three shapes -- a loop-generate vector read and write, an if-generate single block, and same-name `if`/`else` arm selection -- with the reference deliberately written before the generate to cover the source-order independence.