### PR TITLE
Support fork-join per-branch local storage

### DIFF
--- a/docs/progress/fork-join.md
+++ b/docs/progress/fork-join.md
@@ -31,26 +31,26 @@ of the same wait -- resume after zero completions -- `join_any` the one-completi
 the all-completions case; they are one mechanism parameterized by a threshold, not three separate
 constructs.
 
-A branch reads and writes the variables of its enclosing scope. The enclosing scope's lifetime
-encompasses the execution of every process the fork spawns (LRM 6.21), so the storage a branch
-reaches stays alive for as long as that branch runs -- even a detached `join_none` / `join_any`
-branch that textually outlives the fork statement. What a branch may safely reach then follows from
-where that storage lives:
+A branch reads and writes the variables of its enclosing scope. What a branch may reach, and for how
+long, follows from where the storage lives and how long the enclosing activation keeps its locals:
 
-- A variable of an enclosing process (`initial` / `always` / `final`) is reached for shared read and
-  write. The process activation outlives the simulation, so a branch under any join mode shares the
-  one live location, observing the value current when it executes. The LRM 9.3.2 loop example relies
-  on this: a branch reads the enclosing loop variable after the loop has finished and sees its final
-  value.
 - Per-iteration data uses an automatic variable declared in the fork's `block_item_declaration`,
-  initialized on entry to the block before any process is spawned, so each spawned process captures
-  its own copy by value.
+  initialized on entry to the block before any process is spawned. Each spawned process takes its
+  own copy by value, so it is self-contained and stays correct under every join mode -- this is the
+  loop-spawn idiom (LRM 9.3.2). A branch may likewise declare its own locals.
+- A variable of an enclosing process (`initial` / `always` / `final`) is reached by reference for
+  shared read and write while that process is still live -- which holds whenever the parent is
+  blocked at the join, and for a `join_none` / `join_any` branch up until the parent procedure
+  completes. The LRM 9.3.2 loop example reads the enclosing loop variable after the loop finishes
+  and sees its final value.
 - Referring to a subroutine's by-reference formal argument from a `join_any` / `join_none` branch is
   illegal unless the formal is declared `ref static` (LRM 9.3.2); the frontend rejects it, so it
   never reaches lowering.
-- The one case LRM 6.21 mandates that is not yet built: an automatic local of an enclosing task
-  reached by a detached branch. The task activation must outlive the spawned branch -- the runtime
-  guarantees this for process activations but not yet for task activations.
+- Not yet built: a detached `join_none` / `join_any` branch that reads an enclosing variable by
+  reference after the enclosing procedure (process or task) has completed. LRM 6.21 requires the
+  enclosing storage to outlive the branch, but a procedure releases its locals when its body ends;
+  honouring this needs lifetime-extended shared storage for the captured locals, which is not yet in
+  place. The by-value snapshot above sidesteps it, so the loop-spawn idiom is unaffected.
 
 ## Sub-Steps
 
@@ -82,16 +82,17 @@ where that storage lives:
 
 ### Per-branch storage
 
-- [ ] FJ4 -- A fork branch reads and writes the variables of its enclosing process, lifting the FJ1
-      restriction to module-scope signals. The branch shares the one live location under every join
-      mode, observing the value current when it executes (LRM 6.21, 9.3.2). Per-iteration data comes
-      from an automatic variable declared in the fork's `block_item_declaration`, initialized on
-      block entry before any process is spawned -- the loop-spawn idiom captures its own copy by
-      value (LRM 9.3.2). A reference to a subroutine's by-reference formal argument from a
-      `join_any` / `join_none` branch is rejected unless declared `ref static` (LRM 9.3.2), and the
-      frontend already rejects it. Deferred: an automatic local of an enclosing task reached by a
-      detached branch -- LRM 6.21 requires the task activation to outlive the branch, which the
-      runtime does for processes but not yet for task activations.
+- [x] FJ4 -- Per-branch storage. A fork is a procedural scope: a `block_item_declaration` is
+      initialized on entry to the block, before any process spawns, and each branch takes its value
+      as a by-value snapshot, so the loop-spawn idiom gives every spawned process its own
+      per-iteration copy (LRM 9.3.2). A branch may also declare its own locals. A branch reads and
+      writes the variables of its enclosing process by reference while that process is live, lifting
+      the FJ1 restriction to module-scope signals (LRM 6.21). A reference to a subroutine's
+      by-reference formal from a `join_any` / `join_none` branch stays rejected unless declared
+      `ref static` (LRM 9.3.2). Deferred: a detached branch that reads an enclosing variable by
+      reference after the enclosing procedure (process or task) has completed -- the captured local
+      needs lifetime-extended shared storage, which the runtime does not yet provide. The by-value
+      snapshot does not depend on this, so the loop-spawn idiom is complete.
 
 ### Naming
 

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -51,10 +51,14 @@ enum class JoinMode : std::uint8_t {
   kNone,
 };
 
-// LRM 9.3.2 parallel block. Each branch is a statement run as its own
+// LRM 9.3.2 parallel block. `locals` are the fork's block_item_declarations
+// (VarDeclStmt) -- initialized at block entry, before any branch spawns, to
+// give each branch a by-value snapshot; they precede the parallel statements in
+// the fork's scope. Each branch in `branches` is a statement run as its own
 // concurrent process; `mode` sets when the parent resumes.
 struct ForkStmt {
   JoinMode mode;
+  std::vector<StmtId> locals;
   std::vector<StmtId> branches;
 };
 

--- a/include/lyra/lowering/hir_to_mir/capture_sink.hpp
+++ b/include/lyra/lowering/hir_to_mir/capture_sink.hpp
@@ -1,105 +1,102 @@
 #pragma once
 
-#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "lyra/lowering/hir_to_mir/procedural_depth.hpp"
 #include "lyra/lowering/hir_to_mir/state.hpp"
-#include "lyra/mir/closure.hpp"
 #include "lyra/mir/expr.hpp"
-#include "lyra/mir/procedural_hops.hpp"
 #include "lyra/mir/procedural_var.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
+// One captured variable, identified while a closure body is lowered. The sink
+// has already allocated `binding` in the body and rewritten the body's
+// references to read it; `source` reaches the captured variable from the
+// enclosing scope and is the same expression whichever way the caller uses it
+// (aliased for a by-reference capture, read for a by-value one). `decl_depth`
+// is the captured variable's declaration depth -- the metadata a caller reads
+// to decide the capture kind. Turning a request into a `mir::Capture` is the
+// caller's job; the sink never decides by value versus by reference.
+struct CaptureRequest {
+  mir::ProceduralVarId var;
+  ProceduralDepth decl_depth;
+  mir::ProceduralVarId binding;
+  mir::ExprId source;
+};
+
 // Identity-only capture collector for a closure body. Installed on
 // ProcessLoweringState for the duration of a single closure construction:
-// during the body's lowering, any procedural-var reference that resolves
-// above the sink's boundary is rerouted here -- a binding in the body
-// scope is allocated (deduplicated by identity) and the reference is
-// rewritten to read that binding. The sink never inspects how the
-// reference is used; closure semantics are the caller's concern.
-//
-// Captures emit as by-reference. Lyra's closure use cases that need this
-// mechanism (sync IIFE for `$sscanf` / `$fscanf`, fork branches per LRM
-// 6.21) are precisely those where the enclosing storage outlives the body,
-// so aliasing is correct for both reads and writes. Capture mechanisms
-// that require a snapshot semantic (the NBA RHS, for instance) belong in
-// a distinct flow that evaluates the value at submission time and stores
-// it independently of any reference to enclosing storage; this sink is
-// not that flow.
+// during the body's lowering, any procedural-var reference that resolves above
+// the sink's boundary is rerouted here -- a binding in the body scope is
+// allocated (deduplicated by identity), the reference is rewritten to read that
+// binding, and a CaptureRequest is recorded. The sink never inspects how the
+// reference is used or which storage the capture should hold; that is the
+// caller's concern. A fork branch snapshots its block_item_declarations by
+// value and aliases enclosing-process variables by reference; the
+// `$sscanf` / `$fscanf` sync IIFE aliases everything by reference -- each reads
+// the requests and assembles its own captures.
 class CaptureSink {
  public:
   CaptureSink(
-      std::uint32_t boundary_depth, ProceduralScopeLoweringState& body,
+      ProceduralDepth boundary_depth, ProceduralScopeLoweringState& body,
       ProceduralScopeLoweringState& outer)
       : boundary_depth_(boundary_depth), body_(&body), outer_(&outer) {
   }
 
-  [[nodiscard]] auto BoundaryDepth() const -> std::uint32_t {
+  [[nodiscard]] auto BoundaryDepth() const -> ProceduralDepth {
     return boundary_depth_;
   }
 
-  // Capture `outer_var` (declared `decl_depth` scopes deep) and return the
-  // body-side reference -- a binding local to the body, read at
-  // `current_depth`.
+  // Capture `var` (declared at `decl_depth`) and return the body-side reference
+  // -- a binding local to the body, read at `current_depth`.
   auto Capture(
-      mir::ProceduralVarId outer_var, std::uint32_t decl_depth,
-      mir::TypeId type, std::uint32_t current_depth) -> mir::ProceduralVarRef {
-    mir::ProceduralVarId binding = FindOrCreate(outer_var, decl_depth, type);
+      mir::ProceduralVarId var, ProceduralDepth decl_depth, mir::TypeId type,
+      ProceduralDepth current_depth) -> mir::ProceduralVarRef {
+    mir::ProceduralVarId binding = FindOrCreate(var, decl_depth, type);
     return mir::ProceduralVarRef{
-        .hops = mir::ProceduralHops{.value = current_depth - boundary_depth_},
-        .var = binding};
+        .hops = current_depth - boundary_depth_, .var = binding};
   }
 
-  auto TakeCaptures() -> std::vector<mir::Capture> {
-    return std::move(captures_);
+  auto TakeRequests() -> std::vector<CaptureRequest> {
+    return std::move(requests_);
   }
 
  private:
-  struct Entry {
-    std::uint32_t decl_depth;
-    mir::ProceduralVarId outer_var;
-    mir::ProceduralVarId binding;
-  };
-
   auto FindOrCreate(
-      mir::ProceduralVarId outer_var, std::uint32_t decl_depth,
-      mir::TypeId type) -> mir::ProceduralVarId {
-    for (const auto& entry : captured_) {
-      if (entry.decl_depth == decl_depth && entry.outer_var == outer_var) {
-        return entry.binding;
+      mir::ProceduralVarId var, ProceduralDepth decl_depth, mir::TypeId type)
+      -> mir::ProceduralVarId {
+    for (const auto& request : requests_) {
+      if (request.decl_depth == decl_depth && request.var == var) {
+        return request.binding;
       }
     }
     const mir::ProceduralVarId binding = body_->AddProceduralVar(
         mir::ProceduralVarDecl{
-            .name = "_lyra_cap_" + std::to_string(captures_.size()),
+            .name = "_lyra_cap_" + std::to_string(requests_.size()),
             .type = type});
-    const mir::ExprId target = outer_->AddExpr(
+    // The source is evaluated one scope outside the body (where the capture is
+    // spawned), so its hops run from there down to the variable.
+    const mir::ExprId source = outer_->AddExpr(
         mir::Expr{
             .data =
                 mir::ProceduralVarRef{
-                    .hops =
-                        mir::ProceduralHops{
-                            .value = (boundary_depth_ - 1) - decl_depth},
-                    .var = outer_var},
+                    .hops = boundary_depth_.Outer() - decl_depth, .var = var},
             .type = type});
-    captures_.emplace_back(
-        mir::ByReferenceCapture{.target = target, .binding = binding});
-    captured_.push_back(
-        Entry{
+    requests_.push_back(
+        CaptureRequest{
+            .var = var,
             .decl_depth = decl_depth,
-            .outer_var = outer_var,
-            .binding = binding});
+            .binding = binding,
+            .source = source});
     return binding;
   }
 
-  std::uint32_t boundary_depth_;
+  ProceduralDepth boundary_depth_;
   ProceduralScopeLoweringState* body_;
   ProceduralScopeLoweringState* outer_;
-  std::vector<mir::Capture> captures_;
-  std::vector<Entry> captured_;
+  std::vector<CaptureRequest> requests_;
 };
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/procedural_depth.hpp
+++ b/include/lyra/lowering/hir_to_mir/procedural_depth.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+#include "lyra/mir/procedural_hops.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// Absolute procedural nesting depth during HIR-to-MIR lowering: 0 at a process
+// or subroutine root, one deeper per nested block. It lives only in the
+// lowering -- MIR references carry the relative ProceduralHops, never an
+// absolute depth. The difference of two depths is exactly that hop count, so
+// subtraction is the one operation that crosses from the lowering's depth into
+// a MIR reference's hops; the strong type makes a depth/hops mix-up not
+// compile.
+struct ProceduralDepth {
+  std::uint32_t value = 0;
+
+  auto operator<=>(const ProceduralDepth&) const
+      -> std::strong_ordering = default;
+
+  // One scope deeper / shallower -- lowering enters and leaves scopes one level
+  // at a time, and a capture's source is evaluated one scope outside the body.
+  [[nodiscard]] auto Inner() const -> ProceduralDepth {
+    return ProceduralDepth{.value = value + 1};
+  }
+  [[nodiscard]] auto Outer() const -> ProceduralDepth {
+    return ProceduralDepth{.value = value - 1};
+  }
+
+  [[nodiscard]] auto operator-(ProceduralDepth rhs) const
+      -> mir::ProceduralHops {
+    return mir::ProceduralHops{.value = value - rhs.value};
+  }
+};
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -15,6 +15,7 @@
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/structural_var.hpp"
 #include "lyra/hir/type.hpp"
+#include "lyra/lowering/hir_to_mir/procedural_depth.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/integral_constant.hpp"
@@ -438,7 +439,7 @@ class StructuralScopeLoweringState {
 };
 
 struct ProceduralVarBinding {
-  std::uint32_t declaration_procedural_depth;
+  ProceduralDepth declaration_procedural_depth;
   mir::ProceduralVarId var;
 };
 
@@ -462,16 +463,16 @@ class ProcessLoweringState {
   }
 
   void EnterProceduralScope() {
-    ++procedural_depth_;
+    procedural_depth_ = procedural_depth_.Inner();
   }
   void LeaveProceduralScope() {
-    if (procedural_depth_ == 0) {
+    if (procedural_depth_ == ProceduralDepth{}) {
       throw InternalError(
           "ProcessLoweringState::LeaveProceduralScope: depth underflow");
     }
-    --procedural_depth_;
+    procedural_depth_ = procedural_depth_.Outer();
   }
-  [[nodiscard]] auto CurrentProceduralDepth() const -> std::uint32_t {
+  [[nodiscard]] auto CurrentProceduralDepth() const -> ProceduralDepth {
     return procedural_depth_;
   }
 
@@ -525,10 +526,7 @@ class ProcessLoweringState {
           "exceeds current depth (forward reference into a child scope)");
     }
     return mir::ProceduralVarRef{
-        .hops =
-            mir::ProceduralHops{
-                .value =
-                    procedural_depth_ - binding.declaration_procedural_depth},
+        .hops = procedural_depth_ - binding.declaration_procedural_depth,
         .var = binding.var,
     };
   }
@@ -547,7 +545,7 @@ class ProcessLoweringState {
 
  private:
   TimeResolution time_resolution_;
-  std::uint32_t procedural_depth_ = 0;
+  ProceduralDepth procedural_depth_;
   std::vector<ProceduralVarBinding> bindings_;
   ProceduralScopeLoweringState* static_frame_scope_ = nullptr;
   CaptureSink* active_capture_sink_ = nullptr;

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -70,14 +70,19 @@ enum class JoinMode : std::uint8_t {
   kNone,
 };
 
-// LRM 9.3.2 parallel block. Each branch is a closure (a captured callable
-// value) in the enclosing scope's expr arena, referenced here by id; the
-// backend spawns each as a concurrent process and the parent waits per `mode`.
-// Being a fork branch is what makes the closure run as a coroutine -- the
-// closure node itself carries no such property. A fork carries no nested scopes
-// of its own.
+// LRM 9.3.2 parallel block. The fork is itself a procedural scope: `scope`
+// (in the owning stmt's child_procedural_scopes) holds the
+// block_item_declaration locals, which are initialized at block entry -- in the
+// parent, before any branch spawns -- giving each spawned branch a by-value
+// snapshot. Each branch is a closure (a captured callable value) in `scope`'s
+// expr arena, referenced here by id; a branch captures a fork-scope local by
+// value (the snapshot) and an enclosing-process variable by reference
+// (LRM 6.21). The backend spawns each branch as a concurrent process and the
+// parent waits per `mode`. Being a fork branch is what makes the closure run as
+// a coroutine -- the closure node itself carries no such property.
 struct ForkStmt {
   JoinMode mode;
+  ProceduralScopeId scope;
   std::vector<ExprId> branches;
 };
 

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -109,25 +109,34 @@ auto RenderForkJoinModeLiteral(mir::JoinMode mode) -> std::string_view {
   return "lyra::runtime::JoinMode::kAll";
 }
 
-// LRM 9.3.2: each branch is an anonymous ClosureExpr spawned as a concurrent
-// coroutine. It renders inline at the fork as a stateless lambda whose
-// parameters are frame-copied -- so the spawned coroutine never dangles the way
-// a captured lambda would. The first parameter is the enclosing scope instance
-// `self`, through which the body reaches module state and Services(); each
-// closure capture adds one more parameter (a `T&` bound to an enclosing
-// variable for a by-reference capture, a `T` for a by-value capture). The fork
-// waits per the join mode.
+// LRM 9.3.2: a fork is a procedural scope, rendered as a block at the fork
+// site. Its block_item_declarations initialize first, in the parent, before any
+// branch spawns -- so a branch's by-value capture of one of them is a snapshot.
+// Each branch is an anonymous ClosureExpr spawned as a concurrent coroutine,
+// rendered inline as a stateless lambda whose parameters are frame-copied -- so
+// the spawned coroutine never dangles the way a captured lambda would. The
+// first parameter is the enclosing scope instance `self`, through which the
+// body reaches module state and Services(); each closure capture adds one more
+// parameter (a `T` snapshot for a by-value capture of a fork-scope local, a
+// `T&` for a by-reference capture of an enclosing variable). The fork waits per
+// the join mode.
 auto RenderForkStmtNode(
-    const RenderContext& ctx, const mir::ForkStmt& s, std::size_t indent)
-    -> diag::Result<std::string> {
+    const RenderContext& ctx, const mir::Stmt& stmt, const mir::ForkStmt& s,
+    std::size_t indent) -> diag::Result<std::string> {
   const std::string vec = ctx.AllocateTemp("fork_branches");
   const std::string& class_name = ctx.StructuralScope().name;
   const std::string receiver_object{ctx.ReceiverObject()};
+  const RenderContext fork_ctx =
+      ctx.WithProceduralScope(stmt.child_procedural_scopes.at(s.scope.value));
   std::string out = Indent(indent) + "{\n";
+  auto locals_or = RenderProceduralScopeStatements(fork_ctx, indent + 1);
+  if (!locals_or) return std::unexpected(std::move(locals_or.error()));
+  out += *locals_or;
   out += Indent(indent + 1) + "std::vector<lyra::runtime::Coroutine> " + vec +
          ";\n";
   for (const auto branch : s.branches) {
-    const auto* closure = std::get_if<mir::ClosureExpr>(&ctx.Expr(branch).data);
+    const auto* closure =
+        std::get_if<mir::ClosureExpr>(&fork_ctx.Expr(branch).data);
     if (closure == nullptr) {
       throw InternalError("RenderForkStmtNode: fork branch is not a closure");
     }
@@ -144,14 +153,14 @@ auto RenderForkStmtNode(
       if (const auto* by_ref = std::get_if<mir::ByReferenceCapture>(&capture)) {
         binding = by_ref->binding;
         ref_marker = "& ";
-        auto target_or = RenderExpr(ctx, ctx.Expr(by_ref->target));
+        auto target_or = RenderExpr(fork_ctx, fork_ctx.Expr(by_ref->target));
         if (!target_or) return std::unexpected(std::move(target_or.error()));
         arg = *std::move(target_or);
       } else {
         const auto& by_value = std::get<mir::ByValueCapture>(capture);
         binding = by_value.binding;
         ref_marker = " ";
-        auto value_or = RenderExpr(ctx, ctx.Expr(by_value.value));
+        auto value_or = RenderExpr(fork_ctx, fork_ctx.Expr(by_value.value));
         if (!value_or) return std::unexpected(std::move(value_or.error()));
         arg = *std::move(value_or);
       }
@@ -162,9 +171,10 @@ auto RenderForkStmtNode(
       params += ", " + *type_or + ref_marker + bind.name;
       args += ", " + arg;
     }
-    const RenderContext branch_ctx = ctx.WithProceduralScope(*closure->body)
-                                         .WithCoroutine(true)
-                                         .WithReceiver("self");
+    const RenderContext branch_ctx =
+        fork_ctx.WithProceduralScope(*closure->body)
+            .WithCoroutine(true)
+            .WithReceiver("self");
     auto body_or = RenderProceduralScopeStatements(branch_ctx, indent + 2);
     if (!body_or) return std::unexpected(std::move(body_or.error()));
     out += Indent(indent + 1) + vec + ".push_back([](" + params +
@@ -437,7 +447,7 @@ auto RenderStmt(
             return RenderBlockStmtNode(ctx, stmt, s, indent);
           },
           [&](const mir::ForkStmt& s) -> diag::Result<std::string> {
-            return RenderForkStmtNode(ctx, s, indent);
+            return RenderForkStmtNode(ctx, stmt, s, indent);
           },
           [&](const mir::IfStmt& s) -> diag::Result<std::string> {
             return RenderIfStmtNode(ctx, stmt, s, indent);

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -1080,9 +1080,12 @@ class HirDumper {
   void DumpForkStmtNode(const ProceduralBody& p, StmtId id, const ForkStmt& f) {
     Line(
         std::format(
-            "Stmt[{}] ForkStmt {} (branches={})", id.value,
-            ForkJoinModeLabel(f.mode), f.branches.size()));
+            "Stmt[{}] ForkStmt {} (locals={}, branches={})", id.value,
+            ForkJoinModeLabel(f.mode), f.locals.size(), f.branches.size()));
     Indent();
+    for (const auto local : f.locals) {
+      DumpStmt(p, local);
+    }
     for (const auto branch : f.branches) {
       DumpStmt(p, branch);
     }

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -302,12 +302,33 @@ auto LowerForkStmt(
       throw InternalError("LowerForkStmt: called on a sequential block");
   }
 
-  std::vector<const slang::ast::Statement*> branch_stmts;
+  std::vector<const slang::ast::Statement*> body_stmts;
   if (block.body.kind == slang::ast::StatementKind::List) {
     const auto& list = block.body.as<slang::ast::StatementList>();
-    branch_stmts.assign(list.list.begin(), list.list.end());
+    body_stmts.assign(list.list.begin(), list.list.end());
   } else {
-    branch_stmts.push_back(&block.body);
+    body_stmts.push_back(&block.body);
+  }
+
+  // LRM 9.3.2: a fork's block_item_declarations are not parallel statements --
+  // they are locals of the fork scope, initialized in the parent at block entry
+  // before any branch spawns. The grammar places them before the statements, so
+  // they form a prefix; each remaining statement is a branch. Locals lower in
+  // the enclosing (parent) context; only the branches enter the fork-branch
+  // scope.
+  std::vector<hir::StmtId> locals;
+  std::vector<const slang::ast::Statement*> branch_stmts;
+  for (const auto* child : body_stmts) {
+    if (child->kind == slang::ast::StatementKind::VariableDeclaration) {
+      auto local_stmt =
+          LowerStatement(unit_facts, proc_state, scope_state, stack, *child);
+      if (!local_stmt) {
+        return std::unexpected(std::move(local_stmt.error()));
+      }
+      locals.push_back(proc_state.AddStmt(*std::move(local_stmt)));
+    } else {
+      branch_stmts.push_back(child);
+    }
   }
 
   std::vector<hir::StmtId> branches;
@@ -326,7 +347,11 @@ auto LowerForkStmt(
 
   return hir::Stmt{
       .label = std::nullopt,
-      .data = hir::ForkStmt{.mode = mode, .branches = std::move(branches)},
+      .data =
+          hir::ForkStmt{
+              .mode = mode,
+              .locals = std::move(locals),
+              .branches = std::move(branches)},
       .span = span};
 }
 

--- a/src/lyra/lowering/hir_to_mir/lower_scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_scan.cpp
@@ -284,8 +284,17 @@ auto LowerScanSystemSubroutineCall(
 
   proc_state.SetCaptureSink(previous_sink);
 
+  // The sync IIFE aliases the caller's storage, which is live throughout the
+  // closure's evaluation -- so every captured identity is a by-reference
+  // capture.
+  std::vector<mir::Capture> captures;
+  for (const CaptureRequest& request : sink.TakeRequests()) {
+    captures.emplace_back(
+        mir::ByReferenceCapture{
+            .target = request.source, .binding = request.binding});
+  }
   mir::ClosureExpr closure;
-  closure.captures = sink.TakeCaptures();
+  closure.captures = std::move(captures);
   closure.body = std::make_unique<mir::ProceduralScope>(body.Finish());
 
   const mir::ExprId closure_id = proc_scope_state.AddExpr(

--- a/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_stmt.cpp
@@ -119,7 +119,8 @@ auto LowerVarDeclStmt(
             .lifetime = mir::VariableLifetime::kStatic});
     proc_state.MapProceduralVar(
         v.var, ProceduralVarBinding{
-                   .declaration_procedural_depth = 0, .var = static_id});
+                   .declaration_procedural_depth = ProceduralDepth{.value = 0},
+                   .var = static_id});
     mir::ExprId static_init{};
     if (v.init.has_value()) {
       auto init_or = LowerExpr(
@@ -639,53 +640,47 @@ auto LowerJoinMode(hir::JoinMode mode) -> mir::JoinMode {
   return mir::JoinMode::kAll;
 }
 
-// True if a fork branch declares a procedural local anywhere in its body. A
-// branch-local initializer that reads an enclosing variable needs a by-value
-// snapshot (the loop-spawn idiom), which is not yet supported; until then a
-// branch that declares a local is rejected rather than risk sharing an
-// enclosing automatic by reference where the LRM wants a per-spawn copy.
-auto ForkBranchDeclaresLocal(const mir::ProceduralScope& scope) -> bool {
-  for (const auto& s : scope.stmts) {
-    if (std::holds_alternative<mir::ProceduralVarDeclStmt>(s.data)) {
-      return true;
-    }
-    for (const auto& child : s.child_procedural_scopes) {
-      if (ForkBranchDeclaresLocal(child)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-// LRM 9.3.2: each parallel statement becomes a concurrent process. Each branch
-// lowers to a closure -- a captured callable value -- composed into the
-// enclosing scope's expr arena, exactly as the NBA deferred-write closure is
-// composed. References to the enclosing process's variables become by-reference
-// captures (LRM 6.21). The ForkStmt then references the branch closures by id;
-// it owns no nested scopes. The closure runs as a coroutine by virtue of being
-// a fork branch (spawned), not by any property of the closure node.
+// LRM 9.3.2: a fork is a procedural scope. Its block_item_declarations lower
+// into that scope and initialize at block entry -- in the parent, before any
+// branch spawns. Each branch lowers to a closure composed into the fork scope's
+// expr arena. The capture sink collects every enclosing reference the body
+// makes as an identity; fork then assigns each capture's kind, which it can
+// because it knows its own declarations sit at the fork-scope depth: a capture
+// of a fork-scope local is a by-value snapshot (each spawned branch carries its
+// own copy -- the loop-spawn idiom), and a capture of an enclosing-process
+// variable is a by-reference alias (LRM 6.21). The ForkStmt holds the fork
+// scope and references the branch closures by id; the closure runs as a
+// coroutine by virtue of being a fork branch (spawned), not by any property of
+// the closure node.
 auto LowerForkStmt(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state,
-    ProceduralScopeLoweringState& proc_scope_state,
-    const hir::ProceduralBody& hir_proc, const hir::Stmt& stmt,
-    const hir::ForkStmt& f) -> diag::Result<mir::Stmt> {
+    ProcessLoweringState& proc_state, const hir::ProceduralBody& hir_proc,
+    const hir::Stmt& stmt, const hir::ForkStmt& f) -> diag::Result<mir::Stmt> {
+  ProceduralDepthGuard fork_depth_guard{proc_state};
+  ProceduralScopeLoweringState fork_scope_state;
+  const ProceduralDepth fork_depth = proc_state.CurrentProceduralDepth();
+
+  for (const hir::StmtId local_hir_id : f.locals) {
+    auto lowered = LowerStmt(
+        unit_state, scope_state, proc_state, fork_scope_state, hir_proc,
+        hir_proc.stmts.at(local_hir_id.value));
+    if (!lowered) {
+      return std::unexpected(std::move(lowered.error()));
+    }
+    fork_scope_state.AddRootStmt(fork_scope_state.AddStmt(*std::move(lowered)));
+  }
+
   std::vector<mir::ExprId> branch_ids;
   branch_ids.reserve(f.branches.size());
   for (const hir::StmtId branch_hir_id : f.branches) {
     const hir::Stmt& branch = hir_proc.stmts.at(branch_hir_id.value);
     ProceduralScopeLoweringState branch_scope_state;
-    ProceduralDepthGuard depth_guard{proc_state};
+    ProceduralDepthGuard branch_depth_guard{proc_state};
 
-    // Collect the branch's captures as its body is lowered: a body reference
-    // resolving above this boundary depth routes through the sink, which
-    // composes the capture and binding on the spot (LRM 6.21). A nested
-    // fork restores the prior sink on exit.
     CaptureSink sink{
         proc_state.CurrentProceduralDepth(), branch_scope_state,
-        proc_scope_state};
+        fork_scope_state};
     CaptureSink* const previous_sink = proc_state.ActiveCaptureSink();
     proc_state.SetCaptureSink(&sink);
     auto lowered = LowerStmt(
@@ -695,33 +690,45 @@ auto LowerForkStmt(
     if (!lowered) {
       return std::unexpected(std::move(lowered.error()));
     }
-    const mir::StmtId branch_stmt_id =
-        branch_scope_state.AddStmt(*std::move(lowered));
-    branch_scope_state.AddRootStmt(branch_stmt_id);
+    branch_scope_state.AddRootStmt(
+        branch_scope_state.AddStmt(*std::move(lowered)));
 
-    mir::ProceduralScope body = branch_scope_state.Finish();
-    if (ForkBranchDeclaresLocal(body)) {
-      return diag::Unsupported(
-          stmt.span, diag::DiagCode::kUnsupportedForkJoinForm,
-          "a fork-join branch that declares a local variable is not yet "
-          "supported",
-          diag::UnsupportedCategory::kFeature);
+    // A capture of a fork-scope local (declared at fork_depth) is a by-value
+    // snapshot; one from further out is a by-reference alias. The source
+    // expression is the same either way; only the capture kind differs.
+    std::vector<mir::Capture> captures;
+    for (const CaptureRequest& request : sink.TakeRequests()) {
+      if (request.decl_depth == fork_depth) {
+        captures.emplace_back(
+            mir::ByValueCapture{
+                .value = request.source, .binding = request.binding});
+      } else {
+        captures.emplace_back(
+            mir::ByReferenceCapture{
+                .target = request.source, .binding = request.binding});
+      }
     }
-
     mir::ClosureExpr closure;
-    closure.captures = sink.TakeCaptures();
-    closure.body = std::make_unique<mir::ProceduralScope>(std::move(body));
-    branch_ids.push_back(proc_scope_state.AddExpr(
+    closure.captures = std::move(captures);
+    closure.body =
+        std::make_unique<mir::ProceduralScope>(branch_scope_state.Finish());
+    branch_ids.push_back(fork_scope_state.AddExpr(
         mir::Expr{
             .data = std::move(closure),
             .type = unit_state.Builtins().void_type}));
   }
+
+  std::vector<mir::ProceduralScope> child_scopes;
+  const mir::ProceduralScopeId scope_id =
+      AddChildProceduralScope(child_scopes, fork_scope_state.Finish());
   return mir::Stmt{
       .label = stmt.label,
       .data =
           mir::ForkStmt{
-              .mode = LowerJoinMode(f.mode), .branches = std::move(branch_ids)},
-      .child_procedural_scopes = {}};
+              .mode = LowerJoinMode(f.mode),
+              .scope = scope_id,
+              .branches = std::move(branch_ids)},
+      .child_procedural_scopes = std::move(child_scopes)};
 }
 
 auto LowerIfStmt(
@@ -1786,8 +1793,7 @@ auto LowerStmt(
           },
           [&](const hir::ForkStmt& f) {
             return LowerForkStmt(
-                unit_state, scope_state, proc_state, proc_scope_state, hir_proc,
-                stmt, f);
+                unit_state, scope_state, proc_state, hir_proc, stmt, f);
           },
           [&](const hir::IfStmt& i) {
             return LowerIfStmt(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -1044,7 +1044,7 @@ class MirDumper {
             },
             [&](const ExprStmt& s) { DumpExprStmt(s, enclosing, id); },
             [&](const BlockStmt& s) { DumpBlockStmt(stmt, s, id); },
-            [&](const ForkStmt& s) { DumpForkStmt(s, id); },
+            [&](const ForkStmt& s) { DumpForkStmt(stmt, s, id); },
             [&](const IfStmt& s) { DumpIfStmt(stmt, s, enclosing, id); },
             [&](const ConstructOwnedObjectStmt& s) {
               DumpConstructOwnedObjectStmt(id, s);
@@ -1436,7 +1436,7 @@ class MirDumper {
     Dedent();
   }
 
-  void DumpForkStmt(const ForkStmt& s, StmtId id) {
+  void DumpForkStmt(const Stmt& parent, const ForkStmt& s, StmtId id) {
     Line(
         std::format(
             "Stmt[{}] ForkStmt {} (branches={})", id.value,
@@ -1445,6 +1445,10 @@ class MirDumper {
     for (const auto branch : s.branches) {
       Line(std::format("branch=Expr[{}]", branch.value));
     }
+    Line(std::format("scope (ProceduralScopeId={}):", s.scope.value));
+    Indent();
+    DumpProceduralScope(parent.child_procedural_scopes.at(s.scope.value));
+    Dedent();
     Dedent();
   }
 

--- a/tests/cases/cpp/fork_block_item_vs_outer/case.yaml
+++ b/tests/cases/cpp/fork_block_item_vs_outer/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.fork_block_item_vs_outer
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      k=1 m=2 x=9

--- a/tests/cases/cpp/fork_block_item_vs_outer/main.sv
+++ b/tests/cases/cpp/fork_block_item_vs_outer/main.sv
@@ -1,0 +1,14 @@
+`timescale 1ns / 1ns
+module Test;
+  initial begin
+    static int x = 1;
+    fork
+      automatic int k = x;
+      begin
+        automatic int m = x + 1;
+        x = 9;
+        $display("k=%0d m=%0d x=%0d", k, m, x);
+      end
+    join
+  end
+endmodule

--- a/tests/cases/cpp/fork_loop_spawn/case.yaml
+++ b/tests/cases/cpp/fork_loop_spawn/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.fork_loop_spawn
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      k=0
+      k=1
+      k=2

--- a/tests/cases/cpp/fork_loop_spawn/main.sv
+++ b/tests/cases/cpp/fork_loop_spawn/main.sv
@@ -1,0 +1,9 @@
+`timescale 1ns / 1ns
+module Test;
+  initial
+    for (int i = 0; i < 3; i++)
+      fork
+        automatic int k = i;
+        #5 $display("k=%0d", k);
+      join_none
+endmodule


### PR DESCRIPTION
## Summary

`fork` now supports per-branch local storage (LRM 9.3.2). A fork is modeled as a procedural scope: its `block_item_declaration`s initialize on block entry, before any branch spawns, and each spawned branch takes them as a by-value snapshot -- so the loop-spawn idiom gives every spawn its own per-iteration copy. A branch may also declare its own locals, and reaches its enclosing process's variables by reference. This lifts the previous restriction that a fork branch could touch only module-scope signals.

## Design

The capture engine (`CaptureSink`) is now identity-only: it collects which enclosing variables a closure body references and rewrites them to body-local bindings, returning a `CaptureRequest` per variable. It never decides by value versus by reference -- that is the caller's policy. A fork snapshots its block-item declarations by value (they sit at the fork-scope depth) and aliases enclosing-process variables by reference; the `$sscanf` / `$fscanf` sync IIFE aliases everything by reference. Procedural depth, previously a raw `uint32_t` while hops were already a strong type, gains a `ProceduralDepth` type whose subtraction yields `ProceduralHops`, so a depth/hops mix-up no longer compiles.

## Testing

Two new `cpp_run` cases (loop-spawn by-value snapshot under `join_none`; fork-scope by-value versus enclosing by-reference with a branch-body local under `join`). Full `bazel test //...` passes.

## Known gap

A detached `join_none` / `join_any` branch that reads an enclosing variable by reference after the enclosing procedure (process or task) has completed is not yet supported -- it needs lifetime-extended shared storage for the captured local. The by-value snapshot path does not depend on this, so the loop-spawn idiom is complete; tracked in `docs/progress/fork-join.md` (FJ4).