### PR TITLE
Support packed scan source/format with x/z guard

### DIFF
--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -100,9 +100,19 @@ close as the corresponding behaviour lands.
       `SkipSourceWhitespace` and `%s`'s stop condition both consult the source rather than a free
       helper, so NUL acts as a field separator under `$sscanf` only -- `$fscanf` keeps the
       ASCII-only policy.
-- [ ] `$sscanf` "format string or str argument contains x/z bits implies EOF (-1)" (LRM 21.3.4.3
-      sscanf-only). Slang binds str / format expressions to value bytes on this pipeline so the
-      corner cannot be observed in practice yet; revisit once 4-state string surfaces exist.
+- [x] `$sscanf` / `$fscanf` integral str / format and the LRM 21.3.4.3 x/z -> EOF (-1) corner.
+      Packed bit vectors lift to string via a shared `value::String::FromPackedArray` conversion
+      (LRM 5.9 MSB-first byte order), so any integral expression in str or format position now
+      reaches the scanner unchanged. The closure-IIFE body emits an unconditional
+      `if (operand.IsUnknown()) return -1` guard at body entry for source and format; the backend
+      renders the guard as a real `HasUnknown()` query when the operand is a 4-state packed integer
+      and as `Bit(false)` for everything else (string, 2-state packed, byte array), keeping the body
+      shape uniform and dead-code-eliminated where there is no x/z to check. The rule names
+      `$sscanf` literally but the format argument's role is identical under `$fscanf`, so the guard
+      fires on `$fscanf`'s format as well; `$fscanf`'s file descriptor has no string semantics and
+      is exempt. The same conversion path unblocks `$display("%s", x)` on a packed integral operand,
+      which previously built but threw at runtime; x/z bits in that path render as `'\0'` since LRM
+      does not pin `%s` behaviour for 4-state operands.
 - [x] `$fseek` / `$rewind` cancelling pending `$ungetc` operations (LRM 21.3.5). The Lyra-owned
       per-FD putback slot is cleared whenever the file position is repositioned, so any subsequent
       read consults the underlying stream rather than the stale pushback byte.

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -201,6 +201,40 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       case, for instance), or sooner if the loss of the const-on-facts invariant produces a real
       mistake.
 
+- [ ] R10 -- Investigate the lowering layer's organization of fact vs state at the layer level (not
+      just inside `ProcessLoweringState`, which R9 already tracks). The smell surfaced from
+      scan-family work: helpers that compose multi-step MIR construction end up with long parameter
+      lists that thread
+      `(unit_state, structural_scope_state, process_state, procedural_scope_state)` through every
+      call -- typically four references where only one is the operation's real input. The
+      fact-vs-state split is not currently first-class in the layer's organization. Some objects are
+      pure lookup -- HIR-to-MIR var bindings, type tables, builtin type IDs, the static-frame scope;
+      those are facts and want `const` on every signature that uses them. Others accumulate across
+      the lowering -- the procedural scope being built up via add-expr / append-stmt / append-local
+      methods; those are state and are already builder-shaped at the method level, but the surface
+      around them is unstructured (free functions threading the builder plus its facts through every
+      parameter list). Two observations from the scan PR sharpen the question. First: the builder
+      shape is already partially present (`ProceduralScopeLoweringState` exposes `AddExpr` /
+      `AppendStmt` / `AppendIfThen` / `AppendLocal` / `Finish` -- a clean builder API). Second: the
+      awkwardness in helper signatures is not the builder's fault; it is that every helper has to
+      thread the surrounding facts back in separately to do anything builder-shaped on the state. A
+      clearer layer-level organization might separate the two kinds explicitly -- facts handed in by
+      const reference once and read freely, state handed in by mutable reference and operated on
+      through builder methods -- so helpers either operate on a fact (no state argument, no mutation
+      possible) or compose state operations through the builder (fewer threaded-through references).
+      **Target shape unknown.** Possible directions include: a lowering-context struct that splits
+      the fact bundle and the state bundle into two distinct types; encapsulating multi-step body
+      construction into builder methods on a closure-body builder type whose constructor captures
+      the facts once; or some pattern this codebase has not yet adopted. The right shape probably
+      emerges from a second concrete driver, not from an abstract design pass. **Why deferred**:
+      there is no clear target yet, and the current shape, while verbose, is auditable -- every
+      helper signature spells out exactly which facts it reads and which state it mutates, which is
+      the codebase's standing rule. Refactoring without a clear target risks importing a worse
+      pattern. **Trigger**: investigate when (a) a second feature area accumulates a similar
+      verbose-helper smell, or (b) R9 lands and exposes a natural layer-level split that this entry
+      can ride on, or (c) a concrete confusion (someone touches the wrong piece because the facts
+      and state were not clearly separated) makes the cost real.
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/mir/builtin_method.hpp
+++ b/include/lyra/mir/builtin_method.hpp
@@ -63,6 +63,16 @@ enum class ArrayMethodKind : std::uint8_t {
   kXor,
 };
 
+// Side-effect-free queries that are defined for every runtime value type
+// (string, packed integral, unpacked array, ...). The receiver's MIR type
+// alone determines the emit shape; lowering passes the operand uniformly.
+// The LRM 21.3.4.3 "unknown bits in $sscanf str / format imply EOF" guard
+// lowers to kIsUnknown; future LRM 20.9 `$isunknown` lowers to the same
+// leaf.
+enum class ValueMethodKind : std::uint8_t {
+  kIsUnknown,
+};
+
 struct EnumMethodInfo {
   TypeId enum_type;
   EnumMethodKind kind;
@@ -80,6 +90,10 @@ struct ArrayMethodInfo {
   ArrayMethodKind kind;
 };
 
+struct ValueMethodInfo {
+  ValueMethodKind kind;
+};
+
 // True for methods whose backend emission must wrap the call site in
 // `co_await`. The runtime returns an awaitable that suspends the calling
 // coroutine and reschedules it through RuntimeServices when the event fires.
@@ -89,7 +103,8 @@ struct ArrayMethodInfo {
 
 struct BuiltinMethodCallee {
   std::variant<
-      EnumMethodInfo, StringMethodInfo, EventMethodInfo, ArrayMethodInfo>
+      EnumMethodInfo, StringMethodInfo, EventMethodInfo, ArrayMethodInfo,
+      ValueMethodInfo>
       method;
 };
 

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -72,6 +72,11 @@ class PackedArray {
   // Default integer shape (32-bit, signed, 4-state) per LRM 6.11 Table 6-8.
   [[nodiscard]] static auto Integer(std::int32_t value) -> PackedArray;
 
+  // 1-bit unsigned 2-state shape, used by the builtin-method renderer to
+  // lift a C++ `bool` result (e.g. `PackedArray::HasUnknown()`) into a
+  // PackedArray of SV `bit` type. Sibling of `Int(int32_t)` / `Byte`.
+  [[nodiscard]] static auto Bit(bool value) -> PackedArray;
+
   // Construct a narrow PackedArray (bit_width <= 64) from an integer value.
   // The `std::int64_t` parameter is the carrier type wide enough to cover
   // every narrow width; the resulting shape is set by `bit_width`, with bits

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -46,6 +46,44 @@ class String {
     return String{std::move(out)};
   }
 
+  // LRM 5.9 / 21.3.4.3: a packed bit vector viewed as a contiguous byte
+  // sequence. The byte at offset 0 of the result is the destination's most
+  // significant byte (matches PackedArray::FromBytes' MSB-first convention).
+  // Bits below the lowest 8-bit boundary are dropped: only bit_width / 8
+  // bytes are produced. Any byte whose 8 source bits contain x or z values
+  // yields '\0' for that byte. $sscanf / $fscanf never observe the x/z
+  // fallback because the closure-IIFE body emits an
+  // `if (operand.HasUnknown()) return -1` guard at body entry before the
+  // conversion runs (LRM 21.3.4.3 unknown-bits-imply-EOF rule); $display
+  // "%s" on an x/z-bearing packed operand sees the fallback (LRM does not
+  // pin %s rendering for 4-state operands).
+  [[nodiscard]] static auto FromPackedArray(const PackedArray& bits) -> String {
+    const std::uint64_t bit_width = bits.BitWidth();
+    const std::uint64_t byte_count = bit_width / 8U;
+    std::string out;
+    out.reserve(static_cast<std::size_t>(byte_count));
+    const auto val_words = bits.ValueWords();
+    const auto unk_words = bits.UnknownWords();
+    for (std::uint64_t byte_i = 0; byte_i < byte_count; ++byte_i) {
+      unsigned char byte = 0;
+      bool any_unknown = false;
+      for (std::uint64_t bit_in_byte = 0; bit_in_byte < 8U; ++bit_in_byte) {
+        const std::uint64_t bit_pos =
+            (bit_width - 1U) - (byte_i * 8U) - bit_in_byte;
+        const auto word_ix = static_cast<std::size_t>(bit_pos / 64U);
+        const auto bit_ix = static_cast<std::size_t>(bit_pos % 64U);
+        if (!unk_words.empty() && ((unk_words[word_ix] >> bit_ix) & 1U) != 0U) {
+          any_unknown = true;
+        }
+        if (((val_words[word_ix] >> bit_ix) & 1U) != 0U) {
+          byte |= static_cast<unsigned char>(1U << (7U - bit_in_byte));
+        }
+      }
+      out.push_back(any_unknown ? '\0' : static_cast<char>(byte));
+    }
+    return String{std::move(out)};
+  }
+
   [[nodiscard]] auto operator==(const String& o) const -> bool {
     return impl_ == o.impl_;
   }

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -717,6 +717,26 @@ auto RenderConversionExpr(
     return std::format(
         "lyra::value::String::FromByteArray({})", *std::move(operand_or));
   }
+  // LRM 5.9 / 21.3.4.3: packed integral source / format lifts to string by
+  // viewing the bit vector as an MSB-first byte sequence. The $sscanf /
+  // $fscanf body emits an unknown-bits guard before this conversion runs,
+  // so x/z is never observed in the scan path; $display "%s" on an x/z-
+  // bearing packed operand sees `'\0'` per the policy documented at the
+  // String::FromPackedArray declaration.
+  //
+  // SV string literals are typed by slang as `bit[N:0]` packed (LRM 5.9)
+  // but the emitter renders them directly as `lyra::value::String{"..."}`,
+  // so the operand at C++ level is already a String when the source is a
+  // StringLiteral node -- the conversion is a slang-typing artifact, not a
+  // real byte-unpacking need. Skip the wrap in that case; the rendered
+  // operand is the lift's result.
+  if (src_ty.IsIntegralPacked() && dst_ty.Kind() == mir::TypeKind::kString) {
+    if (std::holds_alternative<mir::StringLiteral>(src_expr.data)) {
+      return *std::move(operand_or);
+    }
+    return std::format(
+        "lyra::value::String::FromPackedArray({})", *std::move(operand_or));
+  }
   // Identity / no-op rendering: the conversion exists in MIR but the
   // operand's already-rendered C++ matches the destination shape. Covers
   // string -> string identity, and slang's `bit[N-1:0]` string literal ->
@@ -972,6 +992,40 @@ auto RenderArrayMethodCall(
   return raw_call;
 }
 
+// Side-effect-free per-value queries. Dispatch by the receiver's MIR
+// type because the answer is type-static for everything except 4-state
+// integral packed: a string (LRM 6.16) and a byte-element unpacked array
+// have no unknown plane, and a 2-state packed has its unknown plane fixed
+// at zero. Emitting `Bit(false)` for those cases keeps the closure-IIFE
+// body shape uniform (`if (.IsUnknown()) return -1;`) while making the
+// guard a trivial constant the C++ optimizer dead-code-eliminates.
+auto RenderValueMethodCall(
+    const RenderContext& ctx, const mir::CallExpr& call,
+    const mir::ValueMethodInfo& m) -> diag::Result<std::string> {
+  if (call.arguments.empty()) {
+    throw InternalError(
+        "RenderValueMethodCall: value method expects a receiver argument");
+  }
+  const mir::Expr& receiver = ctx.Expr(call.arguments[0]);
+  switch (m.kind) {
+    case mir::ValueMethodKind::kIsUnknown: {
+      const auto& ty = ctx.Unit().GetType(receiver.type);
+      if (ty.IsIntegralPacked() && ty.AsIntegralPacked().IsFourState()) {
+        auto receiver_or = RenderExpr(ctx, receiver);
+        if (!receiver_or) {
+          return std::unexpected(std::move(receiver_or.error()));
+        }
+        // Runtime helper retains its historical `HasUnknown` spelling;
+        // the MIR enum tracks LRM 20.9 `$isunknown` naming.
+        return std::format(
+            "lyra::value::PackedArray::Bit(({}).HasUnknown())", *receiver_or);
+      }
+      return std::string{"lyra::value::PackedArray::Bit(false)"};
+    }
+  }
+  throw InternalError("RenderValueMethodCall: unknown kind");
+}
+
 auto RenderCallExpr(const RenderContext& ctx, const mir::CallExpr& call)
     -> diag::Result<std::string> {
   return std::visit(
@@ -1047,6 +1101,9 @@ auto RenderCallExpr(const RenderContext& ctx, const mir::CallExpr& call)
                     },
                     [&](const mir::ArrayMethodInfo& m) {
                       return RenderArrayMethodCall(ctx, call, m);
+                    },
+                    [&](const mir::ValueMethodInfo& m) {
+                      return RenderValueMethodCall(ctx, call, m);
                     },
                 },
                 b.method);

--- a/src/lyra/lowering/hir_to_mir/lower_scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_scan.cpp
@@ -61,6 +61,64 @@ auto LiftStringSource(
           .type = unit_state.Builtins().string});
 }
 
+// LRM 21.3.4.3 valid scan format types: string or integral (lifted via
+// implicit conversion). The byte-array form is source-only per spec.
+auto LiftStringFormat(
+    const UnitLoweringState& unit_state, ProceduralScopeLoweringState& scope,
+    mir::TypeId format_type, mir::ExprId format_id) -> mir::ExprId {
+  const auto& t = unit_state.GetType(format_type);
+  if (t.Kind() == mir::TypeKind::kString) return format_id;
+  if (!t.IsIntegralPacked()) {
+    throw InternalError(
+        "LiftStringFormat: scan format is not string or integral (LRM "
+        "21.3.4.3)");
+  }
+  return scope.AddExpr(
+      mir::Expr{
+          .data =
+              mir::ConversionExpr{
+                  .operand = format_id, .kind = mir::ConversionKind::kImplicit},
+          .type = unit_state.Builtins().string});
+}
+
+// LRM 21.3.4.3: "If the format string or the str argument to $sscanf
+// contains unknown bits (x or z), then the system function shall return
+// EOF (-1)." Emitted unconditionally as a body-entry guard inside the
+// closure-IIFE; whether the operand can actually carry x/z is the
+// backend's render-time concern (the MIR primitive is universal across
+// value types). Placement is BEFORE the PackedArray->String lift, since
+// the lift silently drops x/z.
+//
+// The rule names $sscanf literally, but the str argument's role under
+// $fscanf is a file descriptor (no string semantics), and the format
+// argument's role is identical under both subroutines. The caller picks
+// which arguments receive the guard: $sscanf str, $sscanf format,
+// $fscanf format -- never the $fscanf descriptor.
+auto EmitIsUnknownGuard(
+    const UnitLoweringState& unit_state, ProceduralScopeLoweringState& body,
+    ProcessLoweringState& proc_state, mir::TypeId bit_t, mir::ExprId operand_id)
+    -> void {
+  const mir::ExprId guard_id = body.AddExpr(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee =
+                      mir::BuiltinMethodCallee{
+                          .method =
+                              mir::ValueMethodInfo{
+                                  .kind = mir::ValueMethodKind::kIsUnknown}},
+                  .arguments = {operand_id}},
+          .type = bit_t});
+
+  ProceduralScopeLoweringState then_body;
+  ProceduralDepthGuard then_depth{proc_state};
+  const mir::ExprId minus_one = then_body.AddExpr(
+      unit_state.MakeIntegerLiteralExpr(static_cast<std::int64_t>(-1)));
+  then_body.AppendStmt(mir::ReturnStmt{.value = minus_one});
+
+  body.AppendIfThen(guard_id, then_body.Finish());
+}
+
 // The per-slot type metadata the runtime needs to materialize a fresh
 // value of the output arg's declared shape. Derived from the HIR type
 // alone -- no MIR Expr for the output arg is needed at this point.
@@ -168,6 +226,10 @@ auto LowerScanSystemSubroutineCall(
 
   // Source / format are rvalues inside the body. The leaf lowering routes
   // procedural-var leaves through the sink, producing body-side bindings.
+  // For each operand the order is: raw-lower -> x/z guard (if 4-state
+  // integral) -> conversion lift to string. The guard reads the raw
+  // PackedArray; the lift is post-guard because conversion to string
+  // silently drops x/z bits and would defeat the LRM 21.3.4.3 EOF rule.
   auto source_or = LowerExpr(
       unit_state, scope_state, proc_state, body, hir_proc,
       hir_proc.exprs.at(call.arguments[0]->value));
@@ -175,6 +237,7 @@ auto LowerScanSystemSubroutineCall(
   const mir::TypeId source_type = source_or->type;
   mir::ExprId source_id = body.AddExpr(*std::move(source_or));
   if (info.source == support::ScanSourceKind::kString) {
+    EmitIsUnknownGuard(unit_state, body, proc_state, bit_t, source_id);
     source_id = LiftStringSource(unit_state, body, source_type, source_id);
   } else if (
       unit_state.GetType(source_type).Kind() != mir::TypeKind::kPackedArray) {
@@ -186,7 +249,10 @@ auto LowerScanSystemSubroutineCall(
       unit_state, scope_state, proc_state, body, hir_proc,
       hir_proc.exprs.at(call.arguments[1]->value));
   if (!format_or) return std::unexpected(std::move(format_or.error()));
-  const mir::ExprId format_id = body.AddExpr(*std::move(format_or));
+  const mir::TypeId format_type = format_or->type;
+  mir::ExprId format_id = body.AddExpr(*std::move(format_or));
+  EmitIsUnknownGuard(unit_state, body, proc_state, bit_t, format_id);
+  format_id = LiftStringFormat(unit_state, body, format_type, format_id);
 
   // Allocate body-side temps for each slot. The parse call writes them;
   // the conditional commit later reads them back into the original

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -361,6 +361,11 @@ class MirDumper {
                             "ArrayMethodInfo[kind={}]",
                             static_cast<int>(m.kind));
                       },
+                      [](const ValueMethodInfo& m) -> std::string {
+                        return std::format(
+                            "ValueMethodInfo[kind={}]",
+                            static_cast<int>(m.kind));
+                      },
                   },
                   b.method);
             },

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -105,6 +105,10 @@ auto PackedArray::Integer(std::int32_t value) -> PackedArray {
   return FromInt(value, 32U, true, true);
 }
 
+auto PackedArray::Bit(bool value) -> PackedArray {
+  return FromInt(value ? 1 : 0, 1U, false, false);
+}
+
 auto PackedArray::MakeFromWordPlanes(
     std::uint64_t bit_width, bool is_signed, bool is_four_state,
     std::span<const std::uint64_t> value_words,

--- a/tests/cases/cpp/display_string_integral/case.yaml
+++ b/tests/cases/cpp/display_string_integral/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.display_string_integral
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      got: ABC end
+      [TEST]

--- a/tests/cases/cpp/display_string_integral/main.sv
+++ b/tests/cases/cpp/display_string_integral/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  // LRM 5.9: SV string literals are packed bit vectors. LRM 21.2.1.1 %s
+  // renders the operand as a string. When the operand is a packed integral
+  // variable, the runtime needs the same PackedArray->String conversion the
+  // $sscanf integral source path uses. This case proves it works end-to-end.
+  logic [23:0] greeting = 24'h41_42_43;   // "ABC"
+  bit   [31:0] tag      = 32'h54_45_53_54; // "TEST"
+
+  initial begin
+    $display("got: %s end", greeting);
+    $display("[%s]", tag);
+  end
+endmodule

--- a/tests/cases/cpp/fscanf_integral_format/case.yaml
+++ b/tests/cases/cpp/fscanf_integral_format/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.fscanf_integral_format
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    code: 2
+    a: 99
+    b: 0xcafe
+  files:
+    fscanf_fmt.txt: |
+      99 cafe

--- a/tests/cases/cpp/fscanf_integral_format/main.sv
+++ b/tests/cases/cpp/fscanf_integral_format/main.sv
@@ -1,0 +1,20 @@
+module Top;
+  // LRM 21.3.4.3: $fscanf format may be an expression of integral type or
+  // string. This case exercises the format-side conversion lift for the
+  // file scan path, matching what sscanf_integral_format covers for the
+  // string scan path. Format bytes spell "%d %h" (5 bytes -> 40 bits).
+  int fd, code;
+  logic [39:0] fmt = 40'h25_64_20_25_68;     // "%d %h"
+  int a;
+  logic [15:0] b;
+
+  initial begin
+    fd = $fopen("fscanf_fmt.txt", "w");
+    $fdisplay(fd, "99 cafe");
+    $fclose(fd);
+
+    fd = $fopen("fscanf_fmt.txt", "r");
+    code = $fscanf(fd, fmt, a, b);
+    $fclose(fd);
+  end
+endmodule

--- a/tests/cases/cpp/sscanf_integral_format/case.yaml
+++ b/tests/cases/cpp/sscanf_integral_format/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.sscanf_integral_format
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    count2: 2
+    count4: 2
+    a2: 10
+    b2: 20
+    a4: 30
+    b4: 40

--- a/tests/cases/cpp/sscanf_integral_format/main.sv
+++ b/tests/cases/cpp/sscanf_integral_format/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  // LRM 21.3.4.3: $sscanf format may be an expression of integral type or
+  // a string. This case covers a 2-state packed format (`bit`) and a
+  // 4-state packed format (`logic`) without x/z bits. Format bytes spell
+  // "%d %d" -- 5 bytes -> 40-bit packed value.
+  bit   [39:0] fmt2 = 40'h25_64_20_25_64;     // "%d %d"
+  logic [39:0] fmt4 = 40'h25_64_20_25_64;     // same, 4-state typed
+
+  int a2, b2, a4, b4;
+  int count2, count4;
+
+  initial begin
+    count2 = $sscanf("10 20", fmt2, a2, b2);
+    count4 = $sscanf("30 40", fmt4, a4, b4);
+  end
+endmodule

--- a/tests/cases/cpp/sscanf_integral_source/case.yaml
+++ b/tests/cases/cpp/sscanf_integral_source/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.sscanf_integral_source
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    count2: 1
+    count4: 2
+    v_two_state: 1234
+    v_four_state: 56
+    v_after: 78

--- a/tests/cases/cpp/sscanf_integral_source/main.sv
+++ b/tests/cases/cpp/sscanf_integral_source/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  // LRM 21.3.4.3: $sscanf str may be an expression of integral type. The
+  // packed bit vector is viewed as a contiguous byte sequence per LRM 5.9
+  // (high byte first). This case covers both 2-state (`bit [N:0]`) and
+  // 4-state (`logic [N:0]`) integral sources without x/z bits.
+  bit   [31:0] src2 = 32'h31_32_33_34;        // "1234" as 2-state
+  logic [39:0] src4 = 40'h35_36_20_37_38;     // "56 78" as 4-state, no x/z
+
+  int v_two_state, v_four_state, v_after;
+  int count2, count4;
+
+  initial begin
+    count2 = $sscanf(src2, "%d", v_two_state);
+    count4 = $sscanf(src4, "%d %d", v_four_state, v_after);
+  end
+endmodule

--- a/tests/cases/cpp/sscanf_xz_eof/case.yaml
+++ b/tests/cases/cpp/sscanf_xz_eof/case.yaml
@@ -1,0 +1,18 @@
+id: cpp.sscanf_xz_eof
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    count_xs: -1
+    count_zs: -1
+    count_xf: -1
+    v_xs: 999
+    v_zs: 999
+    v_xf: 999
+    count_clean: 1
+    v_clean: 50

--- a/tests/cases/cpp/sscanf_xz_eof/main.sv
+++ b/tests/cases/cpp/sscanf_xz_eof/main.sv
@@ -1,0 +1,27 @@
+module Top;
+  // LRM 21.3.4.3: "If the format string or the str argument to $sscanf
+  // contains unknown bits (x or z), then the system function shall return
+  // EOF (-1)." This case exercises three sub-cases:
+  //   1. source carrying x bits  -> count_xs == -1
+  //   2. source carrying z bits  -> count_zs == -1
+  //   3. format carrying x bits  -> count_xf == -1
+  // and confirms that the output args remain at their pre-scan sentinel
+  // (untouched), proving the early-return path actually skips parsing.
+  logic [15:0] src_x = 16'b00110001_xxxx0010;   // "1" then x's
+  logic [15:0] src_z = 16'b00110010_zzzz0011;   // "2" then z's
+  logic [39:0] fmt_x = 40'h25_64_20_xx_64;     // "%d " then x in spec
+
+  int v_xs = 999, v_zs = 999, v_xf = 999;
+  int count_xs, count_zs, count_xf;
+  int count_clean;
+  int v_clean = 999;
+
+  initial begin
+    count_xs = $sscanf(src_x, "%d", v_xs);
+    count_zs = $sscanf(src_z, "%d", v_zs);
+    count_xf = $sscanf("42 99", fmt_x, v_xf, v_clean);
+    // Control: a clean 4-state source / format combination must still
+    // parse successfully, so the guard does not over-fire.
+    count_clean = $sscanf(16'h35_30, "%d", v_clean);  // "50"
+  end
+endmodule


### PR DESCRIPTION
## Summary

LRM 21.3.4.3 permits `$sscanf` / `$fscanf` `str` and `format` arguments to be packed integral expressions, but the lowering wrapped only the source in a ConversionExpr to string, the backend had no IntegralPacked->String branch, and the format argument was never lifted at all -- emitted code passed `PackedArray` where `value::String` was expected and failed to compile. The same broken conversion path silently broke `$display("%s", x)` on a packed integral operand (the runtime threw at format dispatch). This PR adds `String::FromPackedArray` (LRM 5.9 MSB-first byte order), wires the conversion branch in `RenderConversionExpr`, lifts the scan format symmetrically with the source, and emits the LRM 21.3.4.3 "unknown bits in str / format imply EOF (-1)" guard at the closure-IIFE body entry.

## Design

`IsUnknown` lands as a new `ValueMethodInfo` leaf in `BuiltinMethodCallee` -- type-agnostic at the MIR level. Lowering emits the guard unconditionally; backend dispatches on receiver MIR type so non-4-state packed receivers (string, 2-state packed, byte arrays) emit a trivial `Bit(false)`, letting the C++ optimizer dead-code-eliminate the dead branch. `$fscanf`'s file descriptor has no string semantics and is exempt from the guard; the format guard fires on both `$sscanf` and `$fscanf` because the format argument's role is identical. Future LRM 20.9 `$isunknown` lowers to the same leaf.

The fact-vs-state line in the lowering layer surfaced during this PR via verbose helper signatures and is recorded as `docs/progress/refactor.md` R10 for later investigation.

## Testing

Five new `cpp_run` cases: `sscanf_integral_source` (2-state and 4-state without x/z), `sscanf_integral_format`, `fscanf_integral_format`, `sscanf_xz_eof` (source x, source z, format x, plus a clean control proving the guard does not over-fire), and `display_string_integral`. Full `bazel test //...` green.