### PR TITLE
Support dynamic-array methods with `with` clause

### DIFF
--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -26,7 +26,7 @@ follow once dynamic array's storage and runtime conventions are settled and prov
 | DA4  | Done: aggregate equality, inequality, case-equality.                 |
 | DA5  | Open: constant-width slice (subject to LRM check).                   |
 | DA6a | Done: method dispatch + no-`with` subset.                            |
-| DA6b | Open: `with` clause + iterator + non-queue-return method variants.   |
+| DA6b | Done: `with` clause + iterator on sort / rsort / reduction methods.  |
 | DA6c | Open: queue runtime + locator family (find\*, min, max, unique\*).   |
 | DA7  | Open: invalid-index handling.                                        |
 | Q1.. | Not yet scoped: queue.                                               |
@@ -96,9 +96,13 @@ The numeric IDs are stable references and do not imply execution order beyond DA
       Slang gates element-type constraints upstream (integral element for reductions, comparable for
       sort).
 
-- [ ] DA6b -- `with`-clause variants of the methods that accept one (`sort`, `rsort`, reductions),
-      built on a new iterator-binding pass that lowers slang's `IteratorCallInfo` into HIR/MIR and
-      emits a closure at the backend.
+- [x] DA6b -- `with`-clause variants of the methods that accept one (`sort`, `rsort`, reductions),
+      plus the LRM 7.12.4 `item.index` iterator method. AST -> HIR consumes slang's
+      `IteratorCallInfo` and binds the iterator HIR id; HIR -> MIR synthesises a `mir::ClosureExpr`
+      using main's existing `CaptureSink` (so non-iterator outer reads in the body become
+      by-reference captures automatically) and adds parameter bindings for `item` and `index`. The
+      backend renders the closure as a lambda-with-captures and routes the call to the runtime's
+      `*By` overloads.
 
 - [ ] DA6c + Q1 -- Queue\<T\> runtime and the locator-family methods that return one (`find` family,
       `min`, `max`, `unique`, `unique_index`). Opens the queue workstream. `shuffle()` (needs RNG

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -76,6 +76,20 @@ struct IncDecExpr {
   ExprId target;
 };
 
+// LRM 7.12 array-method `with` clause. Present only on array-method calls
+// (sort, rsort, sum, product, and, or, xor) that take a `with`. `iterator`
+// is a procedural-var entry on the enclosing process body; references to it
+// inside `expr` resolve through the normal `LookupProceduralVar` path.
+// HIR -> MIR pre-allocates a body procedural var for the iterator at
+// closure-construction time and remaps this id to that body var, so the
+// closure's `LowerExpr` walk sees the iterator as a body-local. Captures
+// are discovered automatically by the `CaptureSink` installed around that
+// walk -- they are not pre-listed here.
+struct WithClause {
+  ProceduralVarId iterator;
+  ExprId expr;
+};
+
 // LRM 21.3.4.4 form 2d (`$fread(mem, fd, , count)`) and any future
 // system-call positional-elision case lands here as `std::nullopt` at the
 // elided slot; user calls and most system calls leave every entry filled.
@@ -84,6 +98,7 @@ struct IncDecExpr {
 struct CallExpr {
   SubroutineRef callee;
   std::vector<std::optional<ExprId>> arguments;
+  std::optional<WithClause> with_clause = std::nullopt;
 };
 
 struct InsideExpr {

--- a/include/lyra/hir/method.hpp
+++ b/include/lyra/hir/method.hpp
@@ -65,9 +65,16 @@ enum class ArrayMethodKind : std::uint8_t {
   kXor,
 };
 
+// LRM 7.12.4 iterator intrinsic methods (only `index` is in scope today;
+// extends naturally if SV adds more iterator methods).
+enum class IteratorMethodKind : std::uint8_t {
+  kIndex,
+};
+
 struct BuiltinMethodRef {
   std::variant<
-      EnumMethodKind, StringMethodKind, EventMethodKind, ArrayMethodKind>
+      EnumMethodKind, StringMethodKind, EventMethodKind, ArrayMethodKind,
+      IteratorMethodKind>
       method;
 };
 

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -543,12 +543,26 @@ class ProcessLoweringState {
     return active_capture_sink_;
   }
 
+  // LRM 7.12.4 with-clause body: the `index` parameter binding live during
+  // closure construction. `LowerHirCallExprProc` reads this when the body
+  // dispatches an `IteratorMethodKind::kIndex` call so the call resolves to
+  // the closure's `index` parameter slot. Outside a with-clause body this is
+  // `nullopt`; reaching the kIndex arm without a value is a lowering bug.
+  void SetActiveIndexBinding(std::optional<mir::ProceduralVarId> binding) {
+    active_index_binding_ = binding;
+  }
+  [[nodiscard]] auto ActiveIndexBinding() const
+      -> std::optional<mir::ProceduralVarId> {
+    return active_index_binding_;
+  }
+
  private:
   TimeResolution time_resolution_;
   ProceduralDepth procedural_depth_;
   std::vector<ProceduralVarBinding> bindings_;
   ProceduralScopeLoweringState* static_frame_scope_ = nullptr;
   CaptureSink* active_capture_sink_ = nullptr;
+  std::optional<mir::ProceduralVarId> active_index_binding_;
   std::vector<mir::StaticLocal> static_locals_;
 };
 

--- a/include/lyra/mir/builtin_method.hpp
+++ b/include/lyra/mir/builtin_method.hpp
@@ -73,6 +73,11 @@ enum class ValueMethodKind : std::uint8_t {
   kIsUnknown,
 };
 
+// LRM 7.12.4 iterator intrinsic methods (only `index` is in scope today).
+enum class IteratorMethodKind : std::uint8_t {
+  kIndex,
+};
+
 struct EnumMethodInfo {
   TypeId enum_type;
   EnumMethodKind kind;
@@ -94,6 +99,10 @@ struct ValueMethodInfo {
   ValueMethodKind kind;
 };
 
+struct IteratorMethodInfo {
+  IteratorMethodKind kind;
+};
+
 // True for methods whose backend emission must wrap the call site in
 // `co_await`. The runtime returns an awaitable that suspends the calling
 // coroutine and reschedules it through RuntimeServices when the event fires.
@@ -104,7 +113,7 @@ struct ValueMethodInfo {
 struct BuiltinMethodCallee {
   std::variant<
       EnumMethodInfo, StringMethodInfo, EventMethodInfo, ArrayMethodInfo,
-      ValueMethodInfo>
+      ValueMethodInfo, IteratorMethodInfo>
       method;
 };
 

--- a/include/lyra/mir/closure.hpp
+++ b/include/lyra/mir/closure.hpp
@@ -29,25 +29,47 @@ struct ByReferenceCapture {
 
 using Capture = std::variant<ByValueCapture, ByReferenceCapture>;
 
-// A callable value with captured state and a procedural body.
+// A per-invocation closure parameter (LRM 7.12.4 with-clause `item` /
+// `index`). `binding` is a procedural-var slot in the closure body that
+// holds the per-call argument value; body reads go through
+// `ProceduralVarRef{binding}` -- the same mechanism captures use. The
+// difference between a `Capture` and a `Parameter` is when the binding is
+// filled: captures snapshot once at closure creation, parameters receive a
+// new value on each invocation.
+struct Parameter {
+  ProceduralVarId binding{};
+};
+
+// A callable value with captured state, per-invocation parameters, and a
+// procedural body.
 //
 // Closures are synthesized exclusively by HIR-to-MIR lowering. No SystemVerilog
-// source construct produces one directly; both the capture list and the body
-// statements are compiler-generated.
+// source construct produces one directly; the capture list, parameter list,
+// and body statements are all compiler-generated.
 //
 // Invariants enforced by lowering (violations are compiler-bug class):
-//   1. Each capture's binding is a ProceduralVarId valid in body.vars and is
-//      unique across the capture list.
+//   1. Each capture's binding and each parameter's binding is a
+//      ProceduralVarId valid in body.vars and is unique across the union of
+//      the two lists.
 //   2. A ByValueCapture binding is read-only inside body. A ByReferenceCapture
 //      binding may be read and written -- it aliases the enclosing storage.
+//      A parameter binding is read-only inside body; the value is supplied
+//      by the caller per invocation.
 //   3. ProceduralVarRef inside body uses hops bounded by body's own scope
 //      nesting and does not escape into the enclosing process scope. Outer
 //      procedural state reaches body only through captures.
+//   4. A closure with non-empty `params` is invoked many times (each call
+//      supplies new parameter values) and renders as a lambda whose `(...)`
+//      clause lists the parameters and whose body ends with a `ReturnStmt`
+//      carrying the result expression. An empty-`params` closure is invoked
+//      once (fork branch / deferred IIFE) and renders as a captures-as-args
+//      IIFE.
 //
 // StructuralVarRef inside body may carry hops that reach module-scope storage
 // directly, the same way C++ lambdas may reference globals without capture.
 struct ClosureExpr {
   std::vector<Capture> captures;
+  std::vector<Parameter> params;
   std::unique_ptr<ProceduralScope> body;
 
   ClosureExpr();

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -230,6 +230,54 @@ class DynamicArray {
     return Fold([](const T& a, const T& b) { return a ^ b; });
   }
 
+  // LRM 7.12.2 / 7.12.3 `with`-clause variants. The closure receives each
+  // element and its index per call and returns a key (for ordering) or a
+  // summand (for reduction). The closure's result type is the inferred
+  // template parameter R; for reductions R must be element-shape (slang
+  // accepts width-widening with-expressions, which the closure body
+  // synthesizes via ConversionExpr at HIR -> MIR). PackedArray is used as
+  // the index type so the user-facing `item.index` reads as a regular
+  // integral value in SV semantics; the closure body converts to
+  // std::size_t at compare sites if needed.
+  template <typename F>
+  auto SortBy(F&& key) -> void {
+    SelectionSortByKey(std::forward<F>(key), std::less<>{});
+  }
+  template <typename F>
+  auto RsortBy(F&& key) -> void {
+    SelectionSortByKey(std::forward<F>(key), std::greater<>{});
+  }
+  template <typename F>
+  [[nodiscard]] auto SumBy(F&& key) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    return FoldBy(
+        std::forward<F>(key), [](auto& acc, auto& v) { acc = acc + v; });
+  }
+  template <typename F>
+  [[nodiscard]] auto ProductBy(F&& key) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    return FoldBy(
+        std::forward<F>(key), [](auto& acc, auto& v) { acc = acc * v; });
+  }
+  template <typename F>
+  [[nodiscard]] auto AndBy(F&& key) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    return FoldBy(
+        std::forward<F>(key), [](auto& acc, auto& v) { acc = acc & v; });
+  }
+  template <typename F>
+  [[nodiscard]] auto OrBy(F&& key) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    return FoldBy(
+        std::forward<F>(key), [](auto& acc, auto& v) { acc = acc | v; });
+  }
+  template <typename F>
+  [[nodiscard]] auto XorBy(F&& key) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    return FoldBy(
+        std::forward<F>(key), [](auto& acc, auto& v) { acc = acc ^ v; });
+  }
+
  private:
   template <typename Compare>
   auto SelectionSortBy(Compare cmp) -> void {
@@ -247,6 +295,34 @@ class DynamicArray {
     }
   }
 
+  // The keyed sort path is `selection sort over (key, index)`: a per-element
+  // key is materialized once via the closure (passing both the element and
+  // the per-element index), then the elements move in sync with the keys.
+  // Selection sort is used for the same shape-preservation reason as the
+  // unkeyed path; the small keys vector is the price.
+  template <typename F, typename Compare>
+  auto SelectionSortByKey(F key, Compare cmp) -> void {
+    using KeyT = std::invoke_result_t<F&, const T&, const PackedArray&>;
+    std::vector<KeyT> keys;
+    keys.reserve(data_.size());
+    for (std::size_t i = 0; i < data_.size(); ++i) {
+      keys.push_back(key(data_[i], PackedArray::Int(static_cast<int>(i))));
+    }
+    using std::swap;
+    for (std::size_t i = 0; i + 1 < data_.size(); ++i) {
+      std::size_t pick = i;
+      for (std::size_t j = i + 1; j < data_.size(); ++j) {
+        if (static_cast<bool>(cmp(keys[j], keys[pick]))) {
+          pick = j;
+        }
+      }
+      if (pick != i) {
+        swap(keys[i], keys[pick]);
+        swap(data_[i], data_[pick]);
+      }
+    }
+  }
+
   template <typename F>
   [[nodiscard]] auto Fold(F op) const -> T {
     if (data_.empty()) {
@@ -259,6 +335,27 @@ class DynamicArray {
       result = op(result, data_[i]);
     }
     return result;
+  }
+
+  // The empty-array case mirrors `Fold`: synthesize an element-shape zero
+  // via the OOB shield slot and feed it through the closure once so the
+  // result carries whatever shape the closure produces, then zero it out.
+  template <typename F, typename Combine>
+  [[nodiscard]] auto FoldBy(F key, Combine combine) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    if (data_.empty()) {
+      T zero = oob_slot_;
+      zero.ResetToDefault();
+      auto acc = key(zero, PackedArray::Int(0));
+      acc.ResetToDefault();
+      return acc;
+    }
+    auto acc = key(data_[0], PackedArray::Int(0));
+    for (std::size_t i = 1; i < data_.size(); ++i) {
+      auto v = key(data_[i], PackedArray::Int(static_cast<int>(i)));
+      combine(acc, v);
+    }
+    return acc;
   }
 
   [[nodiscard]] auto IsInvalidIndex(const PackedArray& idx) const -> bool {

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -984,6 +984,19 @@ auto RenderArrayMethodCall(
   if (!receiver_or) {
     return std::unexpected(std::move(receiver_or.error()));
   }
+  // LRM 7.12.2 / 7.12.3 with-clause: HIR -> MIR appends the closure as the
+  // second positional argument. The runtime exposes a parallel `*By`
+  // overload that takes the closure; both members share the no-with
+  // base name in `ArrayMethodMemberName`.
+  if (call.arguments.size() == 2) {
+    auto closure_or = RenderExpr(ctx, ctx.Expr(call.arguments[1]));
+    if (!closure_or) {
+      return std::unexpected(std::move(closure_or.error()));
+    }
+    return std::format(
+        "({}).{}By({})", *receiver_or, ArrayMethodMemberName(m.kind),
+        *closure_or);
+  }
   const std::string raw_call =
       std::format("({}).{}()", *receiver_or, ArrayMethodMemberName(m.kind));
   if (m.kind == mir::ArrayMethodKind::kSize) {
@@ -1104,6 +1117,18 @@ auto RenderCallExpr(const RenderContext& ctx, const mir::CallExpr& call)
                     },
                     [&](const mir::ValueMethodInfo& m) {
                       return RenderValueMethodCall(ctx, call, m);
+                    },
+                    [](const mir::IteratorMethodInfo&)
+                        -> diag::Result<std::string> {
+                      // LRM 7.12.4 `item.index` is resolved at HIR -> MIR to
+                      // a `ProceduralVarRef` on the closure's `index`
+                      // parameter binding; reaching the backend means
+                      // closure synthesis failed to rewrite it.
+                      throw InternalError(
+                          "RenderCallExpr: IteratorMethodInfo reached the "
+                          "backend (LRM 7.12.4 -- HIR -> MIR should have "
+                          "rewritten `item.index` to a ProceduralVarRef on "
+                          "the closure parameter binding)");
                     },
                 },
                 b.method);
@@ -1494,13 +1519,56 @@ auto RenderClosureExpr(
     captures_text += *rendered_or;
   }
 
+  // LRM 7.12.4 with-clause closures (or any closure built with a non-empty
+  // `params` list) render as a value-returning lambda whose parameter
+  // clause names the bindings in declaration order and whose body ends with
+  // `return <value>;` (lowered from a tail `ReturnStmt`). Closures with no
+  // `params` (fork branches, NBA submit) keep the existing `()` form.
+  std::string params_text;
+  for (std::size_t i = 0; i < closure.params.size(); ++i) {
+    const auto& bind = closure.body->vars.at(closure.params[i].binding.value);
+    auto type_or =
+        RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), bind.type);
+    if (!type_or) return std::unexpected(std::move(type_or.error()));
+    if (i != 0) params_text += ", ";
+    params_text += "const " + *type_or + "& " + bind.name;
+  }
+
+  // Derive the lambda return type from the tail `ReturnStmt`'s value
+  // expression -- closures synthesized for LRM 7.12.2 / 7.12.3 always end
+  // there. An empty-params closure (fork branch / NBA submit) carries no
+  // return value; leave the lambda return type unspecified so C++ deduces
+  // `void`.
+  std::string return_clause;
+  if (!closure.params.empty()) {
+    const auto& root_stmts = closure.body->root_stmts;
+    if (root_stmts.empty()) {
+      throw InternalError(
+          "RenderClosureExpr: with-clause closure body has no root "
+          "statements (expected a tail ReturnStmt)");
+    }
+    const auto& tail = closure.body->stmts.at(root_stmts.back().value);
+    const auto* ret = std::get_if<mir::ReturnStmt>(&tail.data);
+    if (ret == nullptr || !ret->value.has_value()) {
+      throw InternalError(
+          "RenderClosureExpr: with-clause closure body does not end with a "
+          "value-returning `ReturnStmt`");
+    }
+    const auto& ret_expr = closure.body->GetExpr(*ret->value);
+    auto ret_ty_or =
+        RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), ret_expr.type);
+    if (!ret_ty_or) return std::unexpected(std::move(ret_ty_or.error()));
+    return_clause = " -> " + *ret_ty_or;
+  }
+
   const RenderContext body_ctx =
       RenderContext::ForRoot(ctx.Unit(), ctx.StructuralScope(), *closure.body)
           .WithReceiver(ctx.ReceiverObject());
   auto body_or = RenderProceduralScopeStatements(body_ctx, 1);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
 
-  return "[" + captures_text + "]() {\n" + *body_or + "}";
+  return "[" + captures_text + "](" + params_text + ")" + return_clause +
+         " {\n" + *body_or + "}";
 }
 
 auto RenderConcatExpr(

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -636,6 +636,12 @@ class HirDumper {
                         return std::format(
                             "ArrayMethod \"{}\"", FormatArrayMethodKind(k));
                       },
+                      [](IteratorMethodKind k) -> std::string {
+                        return std::format(
+                            "IteratorMethod \"{}\"",
+                            k == IteratorMethodKind::kIndex ? "index"
+                                                            : "unknown");
+                      },
                   },
                   b.method);
             },
@@ -734,9 +740,15 @@ class HirDumper {
                   args += "<elided>";
                 }
               }
+              std::string with_text;
+              if (c.with_clause.has_value()) {
+                with_text = std::format(
+                    " with={{iterator=ProceduralVarId[{}], expr=Expr[{}]}}",
+                    c.with_clause->iterator.value, c.with_clause->expr.value);
+              }
               return std::format(
-                  "CallExpr callee={} args=[{}]", FormatSubroutineRef(c.callee),
-                  args);
+                  "CallExpr callee={} args=[{}]{}",
+                  FormatSubroutineRef(c.callee), args, with_text);
             },
             [](const ConversionExpr& cv) -> std::string {
               return std::format(

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -722,22 +722,67 @@ auto LowerCallExprProc(
             unit_state.GetType(*receiver_type).data)) {
       if (auto kind = LowerArrayMethodName(name); kind.has_value()) {
         // LRM 7.5.2 / 7.5.3 dynamic-array methods plus LRM 7.12.2 / 7.12.3
-        // no-`with` subset. Receiver is arguments[0]; this PR's surface
-        // takes no further arguments. Slang upstream gates element-type
-        // constraints (integral for reductions, comparable for sort), so
-        // any call landing here is well-typed.
+        // family. The no-`with` form takes only the receiver. The `with`
+        // form (LRM 7.12.4) binds an iterator and a body expression which
+        // HIR carries as the optional `WithClause` -- HIR -> MIR turns it
+        // into a closure argument.
         auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
         if (!type_id) return std::unexpected(std::move(type_id.error()));
+        std::optional<hir::WithClause> with_clause;
+        if (std::holds_alternative<
+                slang::ast::CallExpression::IteratorCallInfo>(info.extraInfo)) {
+          const auto& iter_info =
+              std::get<slang::ast::CallExpression::IteratorCallInfo>(
+                  info.extraInfo);
+          const auto& iter_var =
+              iter_info.iterVar->as<slang::ast::VariableSymbol>();
+          auto iter_type = unit_state.GetTypeId(iter_var.getType(), span);
+          if (!iter_type) {
+            return std::unexpected(std::move(iter_type.error()));
+          }
+          const hir::ProceduralVarId iterator_id =
+              proc_state.AddProceduralVar(iter_var, *iter_type);
+          auto body_or = LowerProcExpr(
+              unit_facts, unit_state, proc_state, stack, *iter_info.iterExpr);
+          if (!body_or) return std::unexpected(std::move(body_or.error()));
+          const auto body_expr_id = proc_state.AddExpr(*std::move(body_or));
+          with_clause =
+              hir::WithClause{.iterator = iterator_id, .expr = body_expr_id};
+        }
         return hir::Expr{
             .type = *type_id,
             .data =
                 hir::CallExpr{
                     .callee = hir::BuiltinMethodRef{.method = *kind},
                     .arguments = std::move(arg_ids),
+                    .with_clause = std::move(with_clause),
                 },
             .span = span,
         };
       }
+    }
+
+    // LRM 7.12.4 `item.index`: slang resolves to a SystemSubroutine with
+    // `KnownSystemName::Index`. Only legal inside an array-method `with`
+    // body; the call lowers to a `BuiltinMethodRef{IteratorMethodKind::
+    // kIndex}` and HIR -> MIR rewrites it to a `ProceduralVarRef` on the
+    // closure's `index` parameter binding.
+    if (info.subroutine != nullptr &&
+        info.subroutine->knownNameId ==
+            slang::parsing::KnownSystemName::Index) {
+      auto type_id = TypeIdOfSlangExpr(unit_facts, unit_state, expr);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return hir::Expr{
+          .type = *type_id,
+          .data =
+              hir::CallExpr{
+                  .callee =
+                      hir::BuiltinMethodRef{
+                          .method = hir::IteratorMethodKind::kIndex},
+                  .arguments = std::move(arg_ids),
+              },
+          .span = span,
+      };
     }
 
     const auto* desc = support::FindSystemSubroutine(name);

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -523,6 +523,16 @@ auto LowerArrayMethodKind(hir::ArrayMethodKind k) -> mir::ArrayMethodKind {
   throw InternalError("LowerArrayMethodKind: unknown hir::ArrayMethodKind");
 }
 
+auto LowerIteratorMethodKind(hir::IteratorMethodKind k)
+    -> mir::IteratorMethodKind {
+  switch (k) {
+    case hir::IteratorMethodKind::kIndex:
+      return mir::IteratorMethodKind::kIndex;
+  }
+  throw InternalError(
+      "LowerIteratorMethodKind: unknown hir::IteratorMethodKind");
+}
+
 auto LowerHirStringLiteral(const hir::StringLiteral& s, mir::TypeId type)
     -> mir::Expr {
   return mir::Expr{.data = mir::StringLiteral{.value = s.value}, .type = type};
@@ -924,6 +934,92 @@ auto LowerHirConversionExprProc(
       .type = result_type};
 }
 
+// LRM 7.12.2 / 7.12.3 with-clause closure synthesis. The body is a normal
+// expression lowered through `LowerExpr`; only the closure-specific leaf
+// behaviour lives elsewhere -- captures via `CaptureSink`, iterator and
+// index resolution via pre-allocated body procedural-var bindings remapped
+// for the iterator HIR id and tracked on `proc_state` for the kIndex call.
+//
+// Returns a `mir::ClosureExpr` packaged as a `mir::Expr` of void type;
+// caller adds it to the appropriate scope and uses the resulting ExprId as
+// the second argument of the array-method call.
+auto BuildArrayMethodClosure(
+    const UnitLoweringState& unit_state,
+    const StructuralScopeLoweringState& scope_state,
+    ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& outer_scope_state,
+    const hir::ProceduralBody& hir_process, hir::TypeId hir_receiver_type,
+    const hir::WithClause& with_clause) -> diag::Result<mir::Expr> {
+  const auto& hir_recv_ty = unit_state.GetHirType(hir_receiver_type);
+  const auto* hir_da = std::get_if<hir::DynamicArrayType>(&hir_recv_ty.data);
+  if (hir_da == nullptr) {
+    throw InternalError(
+        "BuildArrayMethodClosure: receiver is not a dynamic-array type");
+  }
+  const mir::TypeId item_type = unit_state.TranslateType(hir_da->element_type);
+  const mir::TypeId index_type = unit_state.Builtins().int32;
+  const auto& iterator_decl =
+      hir_process.procedural_vars.at(with_clause.iterator.value);
+
+  ProceduralScopeLoweringState body_scope_state;
+  ProceduralDepthGuard depth_guard{proc_state};
+  const ProceduralDepth body_depth = proc_state.CurrentProceduralDepth();
+
+  // Pre-allocate the body procedural vars that hold the per-invocation
+  // arguments. The iterator HIR id is then remapped to the item binding so
+  // the body lowering sees the iterator as body-local (CaptureSink leaves
+  // body-local refs alone).
+  const mir::ProceduralVarId item_binding = body_scope_state.AddProceduralVar(
+      mir::ProceduralVarDecl{.name = iterator_decl.name, .type = item_type});
+  const mir::ProceduralVarId index_binding = body_scope_state.AddProceduralVar(
+      mir::ProceduralVarDecl{.name = "index", .type = index_type});
+  proc_state.MapProceduralVar(
+      with_clause.iterator,
+      ProceduralVarBinding{
+          .declaration_procedural_depth = body_depth, .var = item_binding});
+
+  CaptureSink sink{body_depth, body_scope_state, outer_scope_state};
+  CaptureSink* const previous_sink = proc_state.ActiveCaptureSink();
+  const auto previous_index_binding = proc_state.ActiveIndexBinding();
+  proc_state.SetCaptureSink(&sink);
+  proc_state.SetActiveIndexBinding(index_binding);
+
+  auto body_expr_or = LowerExpr(
+      unit_state, scope_state, proc_state, body_scope_state, hir_process,
+      hir_process.exprs.at(with_clause.expr.value));
+
+  proc_state.SetActiveIndexBinding(previous_index_binding);
+  proc_state.SetCaptureSink(previous_sink);
+
+  if (!body_expr_or) return std::unexpected(std::move(body_expr_or.error()));
+
+  const mir::ExprId body_return_value =
+      body_scope_state.AddExpr(*std::move(body_expr_or));
+  const mir::StmtId return_id = body_scope_state.AddStmt(
+      mir::Stmt{
+          .label = std::nullopt,
+          .data = mir::ReturnStmt{.value = body_return_value},
+          .child_procedural_scopes = {}});
+  body_scope_state.AddRootStmt(return_id);
+
+  // LRM 7.12: the with-expression is re-evaluated per element; any reference
+  // to an enclosing local aliases that storage rather than snapshotting it.
+  std::vector<mir::Capture> captures;
+  for (const CaptureRequest& request : sink.TakeRequests()) {
+    captures.emplace_back(
+        mir::ByReferenceCapture{
+            .target = request.source, .binding = request.binding});
+  }
+  mir::ClosureExpr closure;
+  closure.captures = std::move(captures);
+  closure.params.push_back(mir::Parameter{.binding = item_binding});
+  closure.params.push_back(mir::Parameter{.binding = index_binding});
+  closure.body =
+      std::make_unique<mir::ProceduralScope>(body_scope_state.Finish());
+  return mir::Expr{
+      .data = std::move(closure), .type = unit_state.Builtins().void_type};
+}
+
 auto LowerHirCallExprProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
@@ -982,6 +1078,24 @@ auto LowerHirCallExprProc(
                 .type = result_type};
           },
           [&](const hir::BuiltinMethodRef& b) -> diag::Result<mir::Expr> {
+            // LRM 7.12.4 `item.index` -> the closure's `index` parameter
+            // binding. Reaches here from a with-clause body and the binding
+            // was installed by `BuildArrayMethodClosure`; reaching here
+            // without one is a lowering bug.
+            if (std::holds_alternative<hir::IteratorMethodKind>(b.method)) {
+              const auto index_binding = proc_state.ActiveIndexBinding();
+              if (!index_binding.has_value()) {
+                throw InternalError(
+                    "LowerHirCallExprProc: IteratorMethodKind outside an "
+                    "array-method `with` body (LRM 7.12.4)");
+              }
+              return mir::Expr{
+                  .data =
+                      mir::ProceduralVarRef{
+                          .hops = mir::ProceduralHops{.value = 0},
+                          .var = *index_binding},
+                  .type = result_type};
+            }
             if (c.arguments.empty()) {
               throw InternalError(
                   "BuiltinMethodRef call has no receiver argument");
@@ -993,7 +1107,7 @@ auto LowerHirCallExprProc(
             const hir::TypeId hir_receiver_type =
                 hir_process.exprs.at(c.arguments.front()->value).type;
             std::vector<mir::ExprId> args;
-            args.reserve(c.arguments.size());
+            args.reserve(c.arguments.size() + 1);
             for (const auto& arg : c.arguments) {
               if (!arg.has_value()) {
                 throw InternalError(
@@ -1006,6 +1120,18 @@ auto LowerHirCallExprProc(
                 return std::unexpected(std::move(arg_or.error()));
               }
               args.push_back(proc_scope_state.AddExpr(*std::move(arg_or)));
+            }
+            // LRM 7.12.2 / 7.12.3 with-clause: synthesize the closure and
+            // append it as the second positional argument so the backend
+            // can route to the `*By` runtime method mechanically.
+            if (c.with_clause.has_value()) {
+              auto closure_or = BuildArrayMethodClosure(
+                  unit_state, scope_state, proc_state, proc_scope_state,
+                  hir_process, hir_receiver_type, *c.with_clause);
+              if (!closure_or) {
+                return std::unexpected(std::move(closure_or.error()));
+              }
+              args.push_back(proc_scope_state.AddExpr(*std::move(closure_or)));
             }
             auto callee = std::visit(
                 Overloaded{
@@ -1030,6 +1156,11 @@ auto LowerHirCallExprProc(
                       return {
                           .method = mir::ArrayMethodInfo{
                               .kind = LowerArrayMethodKind(k)}};
+                    },
+                    [&](hir::IteratorMethodKind k) -> mir::BuiltinMethodCallee {
+                      return {
+                          .method = mir::IteratorMethodInfo{
+                              .kind = LowerIteratorMethodKind(k)}};
                     },
                 },
                 b.method);

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -366,6 +366,11 @@ class MirDumper {
                             "ValueMethodInfo[kind={}]",
                             static_cast<int>(m.kind));
                       },
+                      [](const IteratorMethodInfo& m) -> std::string {
+                        return std::format(
+                            "IteratorMethodInfo[kind={}]",
+                            static_cast<int>(m.kind));
+                      },
                   },
                   b.method);
             },
@@ -533,7 +538,9 @@ class MirDumper {
                   FormatConversionKind(cv.kind), cv.operand.value);
             },
             [](const ClosureExpr& cl) -> std::string {
-              return std::format("ClosureExpr captures={}", cl.captures.size());
+              return std::format(
+                  "ClosureExpr captures={} params={}", cl.captures.size(),
+                  cl.params.size());
             },
             [](const ElementSelectExpr& sel) -> std::string {
               return std::format(
@@ -1164,6 +1171,19 @@ class MirDumper {
       Indent();
       for (std::size_t i = 0; i < closure.captures.size(); ++i) {
         DumpCapture(i, closure.captures[i], enclosing);
+      }
+      Dedent();
+    }
+    if (closure.params.empty()) {
+      Line("params: (none)");
+    } else {
+      Line("params:");
+      Indent();
+      for (std::size_t i = 0; i < closure.params.size(); ++i) {
+        Line(
+            std::format(
+                "[{}] Parameter binding=ProceduralVarId{{{}}}", i,
+                closure.params[i].binding.value));
       }
       Dedent();
     }

--- a/tests/cases/cpp/dynamic_array_method_with_index/case.yaml
+++ b/tests/cases/cpp/dynamic_array_method_with_index/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.dynamic_array_method_with_index
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    weighted_sum: 80
+    first_two_sum: 30

--- a/tests/cases/cpp/dynamic_array_method_with_index/main.sv
+++ b/tests/cases/cpp/dynamic_array_method_with_index/main.sv
@@ -1,0 +1,18 @@
+module Top;
+  int arr [];
+  int weighted_sum;
+  int first_two_sum;
+
+  initial begin
+    arr = new[4];
+    arr[0] = 10;
+    arr[1] = 20;
+    arr[2] = 30;
+    arr[3] = 0;
+    // LRM 7.12.4 `item.index`: 0*10 + 1*20 + 2*30 + 3*0 = 80.
+    weighted_sum = arr.sum with (item * item.index);
+    // LRM 7.12.4 `item.index`: only the first two elements (index < 2)
+    // contribute: 10 + 20 = 30.
+    first_two_sum = arr.sum with (item.index < 2 ? item : 0);
+  end
+endmodule

--- a/tests/cases/cpp/dynamic_array_method_with_order/case.yaml
+++ b/tests/cases/cpp/dynamic_array_method_with_order/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.dynamic_array_method_with_order
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sorted_payload_0: 1
+    sorted_payload_1: 2
+    sorted_payload_2: 3
+    rsorted_payload_0: 30
+    rsorted_payload_1: 20
+    rsorted_payload_2: 10

--- a/tests/cases/cpp/dynamic_array_method_with_order/main.sv
+++ b/tests/cases/cpp/dynamic_array_method_with_order/main.sv
@@ -1,0 +1,28 @@
+module Top;
+  int arr [];
+  int rs [];
+  int sorted_payload_0, sorted_payload_1, sorted_payload_2;
+  int rsorted_payload_0, rsorted_payload_1, rsorted_payload_2;
+
+  initial begin
+    arr = new[3];
+    arr[0] = 3;
+    arr[1] = 1;
+    arr[2] = 2;
+    // LRM 7.12.2: sort with key = item; result ascending.
+    arr.sort with (item);
+    sorted_payload_0 = arr[0];
+    sorted_payload_1 = arr[1];
+    sorted_payload_2 = arr[2];
+
+    rs = new[3];
+    rs[0] = 10;
+    rs[1] = 30;
+    rs[2] = 20;
+    // LRM 7.12.2: rsort with key = item; result descending.
+    rs.rsort with (item);
+    rsorted_payload_0 = rs[0];
+    rsorted_payload_1 = rs[1];
+    rsorted_payload_2 = rs[2];
+  end
+endmodule

--- a/tests/cases/cpp/dynamic_array_method_with_reduction/case.yaml
+++ b/tests/cases/cpp/dynamic_array_method_with_reduction/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.dynamic_array_method_with_reduction
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sum_doubled: 60
+    sum_with_threshold: 40
+    product_plus_one: 24

--- a/tests/cases/cpp/dynamic_array_method_with_reduction/main.sv
+++ b/tests/cases/cpp/dynamic_array_method_with_reduction/main.sv
@@ -1,0 +1,28 @@
+module Top;
+  int arr [];
+  int sum_doubled;
+  int sum_with_threshold;
+  int product_plus_one;
+  int threshold;
+
+  initial begin
+    arr = new[3];
+    arr[0] = 10;
+    arr[1] = 20;
+    arr[2] = 0;
+    // LRM 7.12.3: sum with key = 2 * item; 2*10 + 2*20 + 2*0 = 60.
+    sum_doubled = arr.sum with (item * 2);
+
+    threshold = 5;
+    // LRM 7.12.3: sum with conditional reads captured `threshold` via
+    // ByReferenceCapture; both elements >= threshold contribute.
+    sum_with_threshold = arr.sum with (item >= threshold ? item + threshold : 0);
+
+    arr = new[3];
+    arr[0] = 1;
+    arr[1] = 2;
+    arr[2] = 3;
+    // LRM 7.12.3: product with key = item + 1; 2 * 3 * 4 = 24.
+    product_plus_one = arr.product with (item + 1);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Add LRM 7.12.2 / 7.12.3 `with`-clause support for the dynamic-array methods that accept one (`sort`, `rsort`, `sum`, `product`, `and`, `or`, `xor`), plus the LRM 7.12.4 `item.index` iterator method inside those expressions.

## Design

AST -> HIR consumes slang's `IteratorCallInfo` and binds the iterator HIR id; HIR -> MIR synthesises a `mir::ClosureExpr` using the existing `CaptureSink` -- non-iterator outer reads become by-reference captures automatically -- and adds parameter bindings for `item` and `index`. The backend renders the closure as a lambda-with-captures and routes the call to the runtime's `*By` overloads on `DynamicArray`.

## Testing

- `tests/cases/cpp/dynamic_array_method_with_order` -- sort / rsort under closure keys.
- `tests/cases/cpp/dynamic_array_method_with_reduction` -- sum / product with simple keys, conditional bodies, and by-reference captures of enclosing locals.
- `tests/cases/cpp/dynamic_array_method_with_index` -- `item.index` inside reduction closures.