### PR TITLE
Speed up emit-compile pipeline with a precompiled header

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -196,10 +196,12 @@ cc_library(
     name = "driver",
     srcs = [
         "src/lyra/driver/cpp_build.cpp",
+        "src/lyra/driver/pch.cpp",
         "src/lyra/driver/runtime_export.cpp",
     ],
     hdrs = [
         "include/lyra/driver/cpp_build.hpp",
+        "include/lyra/driver/pch.hpp",
         "include/lyra/driver/project_layout.hpp",
         "include/lyra/driver/runtime_export.hpp",
     ],

--- a/docs/architecture/compiler_overview.md
+++ b/docs/architecture/compiler_overview.md
@@ -15,10 +15,12 @@ compile-time and runtime.
 - The contract that separates semantic modeling (HIR, MIR) from execution modeling (LIR, LLVM IR).
 - The contract that separates compile-time artifacts (class-level) from runtime artifacts
   (object-level).
-- The positioning of the C++ backend: a first-class MIR consumer that emits C++ code. Debug
-  inspection of HIR and MIR is separate: dumpers produce textual traversals for reading and golden
-  testing, while `backend::cpp` is the real emitter. Dumpers and backends are both pure over their
-  input IR and must not introduce or reinterpret semantics.
+- The positioning of the C++ backend: a first-class MIR consumer that emits C++ code, serving as
+  both an execution artifact and the human-readable rendering of MIR. The latter is how MIR's
+  semantic correctness is validated by a developer reading from SystemVerilog source through MIR's
+  semantic model. Debug inspection of HIR and MIR is separate: dumpers produce textual traversals
+  for reading and golden testing, while `backend::cpp` is the real emitter. Dumpers and backends are
+  both pure over their input IR and must not introduce or reinterpret semantics.
 
 ## Does Not Own
 
@@ -65,6 +67,10 @@ compile-time and runtime.
   one or more backends".
 - A dumper that diverges semantically from its input IR or introduces meaning not present in the IR.
 - Treating a dumper's text as a backend artifact, or treating a backend's output as a debug view.
+- Trading the C++ backend's emitted readability for its compile time. Emit readability is how MIR's
+  semantic correctness is validated; compile-time wins must come from the runtime library, build
+  infrastructure (precompiled headers, parallel compilation), or backend-internal organization that
+  does not change the emitted form.
 
 ## Notes / Examples
 

--- a/docs/progress/emit-readability.md
+++ b/docs/progress/emit-readability.md
@@ -1,10 +1,21 @@
 # Emitted Code Readability
 
-The emitted C++ exists to compile, but it is also read by hand -- to understand what the compiler
-produced for a given SystemVerilog source and to see where behavior originates. This file tracks the
-gap between "it compiles" and "it reads like code a person would write." The work is done when a
-developer can open an emitted unit and follow it top-down without boilerplate or incidental
-structure getting in the way.
+The emitted C++ exists to compile, but it is also the **human-readable rendering of MIR** -- the way
+a developer validates that MIR's semantic model captures the SystemVerilog source correctly. Until
+LIR and LLVM IR exist, it is the primary surface for that validation alongside the MIR dumper: a
+developer reads the SystemVerilog source, reads the emitted C++, and confirms MIR's semantic model
+produced the expected shape. Compile and run is the machine half of the verification; reading the
+emit is the human half.
+
+This file tracks the gap between "it compiles" and "it reads like code a person would write." The
+work is done when a developer can open an emitted unit and follow it top-down without boilerplate or
+incidental structure getting in the way.
+
+**Compile-time trades.** Emit readability outranks emit compile time. A change that makes the
+emitted form less readable to shave per-case compile time is a wrong trade -- compile-time wins must
+come from the runtime library, build infrastructure (precompiled headers, parallel compilation), or
+backend-internal organization that does not change the emitted form. `compiler_overview.md` carries
+this as a Forbidden Shape.
 
 This is the artifact-legibility companion to `dev-ergonomics.md`: that file owns the run / observe /
 locate-divergence feedback loop; this one owns the readability of what the loop produces.

--- a/include/lyra/driver/cpp_build.hpp
+++ b/include/lyra/driver/cpp_build.hpp
@@ -5,6 +5,7 @@
 
 #include "lyra/backend/cpp/api.hpp"
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/driver/pch.hpp"
 #include "lyra/driver/runtime_export.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 
@@ -22,7 +23,8 @@ auto AssembleProject(
 // Build the assembled project in `dir` by invoking the C++ compiler directly
 // (the same recipe `build.sh` carries). Returns the produced executable's path;
 // a non-zero compiler exit surfaces its stderr as a diagnostic.
-auto BuildProject(const std::filesystem::path& dir)
+auto BuildProject(
+    const std::filesystem::path& dir, const pch::Options& pch_opts)
     -> diag::Result<std::filesystem::path>;
 
 // Emit `units`' sources into `work_dir`, build them in place against `runtime`
@@ -32,6 +34,7 @@ auto BuildProject(const std::filesystem::path& dir)
 auto RunInPlace(
     const RuntimeLocation& runtime, std::span<const mir::CompilationUnit> units,
     std::span<const backend::cpp::TopInstance> tops,
-    const std::filesystem::path& work_dir, bool format) -> diag::Result<int>;
+    const std::filesystem::path& work_dir, bool format,
+    const pch::Options& pch_opts) -> diag::Result<int>;
 
 }  // namespace lyra::driver

--- a/include/lyra/driver/pch.hpp
+++ b/include/lyra/driver/pch.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <optional>
+
+#include "lyra/diag/diagnostic.hpp"
+
+namespace lyra::driver::pch {
+
+// Caller-supplied configuration for precompiled-header cache operations.
+// All fields are explicit; helpers in this namespace do not read environment
+// variables themselves. The translation of CLI flags and environment hints
+// into an Options value lives at the CLI layer, so lower layers see a single
+// source of truth.
+struct Options {
+  // When true, EnsureCached returns nullopt and the caller compiles without
+  // `-include-pch`. Threaded from the `--no-pch` CLI flag (which may itself
+  // be raised by the `LYRA_NO_PCH` environment hint at the CLI boundary).
+  bool disabled = false;
+
+  // Explicit override of where PCH artifacts live. When unset, helpers fall
+  // back to `$XDG_CACHE_HOME/lyra/pch` with `$HOME/.cache/lyra/pch` as the
+  // XDG-spec fallback. Threaded from the `--pch-cache-dir` CLI flag.
+  std::optional<std::filesystem::path> cache_dir_override;
+};
+
+// Return the PCH path to pass via `-include-pch`, building it on demand. The
+// cache filename is fully content-addressed (clang identity + include-root
+// path + every header's content), so a cache hit means content match by
+// construction and no staleness check is needed at lookup time. Returns
+// nullopt when PCH is disabled, the compiler is not clang, or no writable
+// cache directory is available -- the caller then falls back to plain
+// compilation.
+auto EnsureCached(
+    const std::filesystem::path& cxx, const std::filesystem::path& include_root,
+    const Options& opts) -> std::optional<std::filesystem::path>;
+
+// Remove every PCH file in the active cache directory. Returns the number of
+// files actually removed; a failure to resolve the cache directory surfaces
+// as a diagnostic.
+auto Clear(const Options& opts) -> diag::Result<std::size_t>;
+
+}  // namespace lyra::driver::pch

--- a/include/lyra/driver/project_layout.hpp
+++ b/include/lyra/driver/project_layout.hpp
@@ -10,6 +10,8 @@ namespace lyra::driver {
 inline constexpr std::string_view kRuntimeIncludeDir = "runtime/include";
 inline constexpr std::string_view kRuntimeLibDir = "runtime/lib";
 inline constexpr std::string_view kRuntimeLibFile = "libcpp_runtime.a";
+inline constexpr std::string_view kRuntimeCacheDir = "runtime/cache";
+inline constexpr std::string_view kPreludeHeader = "lyra/runtime/prelude.hpp";
 inline constexpr std::string_view kMainSource = "main.cpp";
 inline constexpr std::string_view kProgramName = "program";
 inline constexpr std::string_view kCxxStandardFlag = "-std=c++23";

--- a/include/lyra/runtime/prelude.hpp
+++ b/include/lyra/runtime/prelude.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+// Umbrella header that an emitted project's precompiled header pre-parses.
+// Forms the superset of standard-library and Lyra headers any emitted
+// `main.cpp` or scope header could pull in. Listing a header here that the
+// emit does not use is harmless (its parse cost is paid once when building
+// the PCH and never again); missing one means the emit pays the parse cost
+// at compile time and loses no correctness. Keep the list a superset rather
+// than a tight union so additions in the backend require no synchronized
+// edit here. Per-line `IWYU pragma: keep` marks the file's intent so
+// include-cleaner tools do not flag the umbrella as having unused includes.
+
+#include <array>       // IWYU pragma: keep
+#include <cmath>       // IWYU pragma: keep
+#include <cstdint>     // IWYU pragma: keep
+#include <functional>  // IWYU pragma: keep
+#include <memory>      // IWYU pragma: keep
+#include <span>        // IWYU pragma: keep
+#include <stdexcept>   // IWYU pragma: keep
+#include <string>      // IWYU pragma: keep
+#include <vector>      // IWYU pragma: keep
+
+#include "lyra/runtime/coroutine.hpp"          // IWYU pragma: keep
+#include "lyra/runtime/delay.hpp"              // IWYU pragma: keep
+#include "lyra/runtime/diagnostic.hpp"         // IWYU pragma: keep
+#include "lyra/runtime/engine.hpp"             // IWYU pragma: keep
+#include "lyra/runtime/event.hpp"              // IWYU pragma: keep
+#include "lyra/runtime/extern_up.hpp"          // IWYU pragma: keep
+#include "lyra/runtime/file_io.hpp"            // IWYU pragma: keep
+#include "lyra/runtime/file_table.hpp"         // IWYU pragma: keep
+#include "lyra/runtime/finish.hpp"             // IWYU pragma: keep
+#include "lyra/runtime/fork.hpp"               // IWYU pragma: keep
+#include "lyra/runtime/io.hpp"                 // IWYU pragma: keep
+#include "lyra/runtime/named_event.hpp"        // IWYU pragma: keep
+#include "lyra/runtime/process_kind.hpp"       // IWYU pragma: keep
+#include "lyra/runtime/runtime_process.hpp"    // IWYU pragma: keep
+#include "lyra/runtime/runtime_services.hpp"   // IWYU pragma: keep
+#include "lyra/runtime/runtime_traversal.hpp"  // IWYU pragma: keep
+#include "lyra/runtime/scan.hpp"               // IWYU pragma: keep
+#include "lyra/runtime/scan_source.hpp"        // IWYU pragma: keep
+#include "lyra/runtime/scope.hpp"              // IWYU pragma: keep
+#include "lyra/runtime/sformat.hpp"            // IWYU pragma: keep
+#include "lyra/runtime/sim_time.hpp"           // IWYU pragma: keep
+#include "lyra/runtime/simulation_entry.hpp"   // IWYU pragma: keep
+#include "lyra/runtime/stream_dispatcher.hpp"  // IWYU pragma: keep
+#include "lyra/runtime/timescale.hpp"          // IWYU pragma: keep
+#include "lyra/runtime/trigger.hpp"            // IWYU pragma: keep
+#include "lyra/runtime/var.hpp"                // IWYU pragma: keep
+#include "lyra/value/array_case_equal.hpp"     // IWYU pragma: keep
+#include "lyra/value/dynamic_array.hpp"        // IWYU pragma: keep
+#include "lyra/value/enum.hpp"                 // IWYU pragma: keep
+#include "lyra/value/format.hpp"               // IWYU pragma: keep
+#include "lyra/value/integral_format.hpp"      // IWYU pragma: keep
+#include "lyra/value/packed.hpp"               // IWYU pragma: keep
+#include "lyra/value/packed_array.hpp"         // IWYU pragma: keep
+#include "lyra/value/packed_bitwise.hpp"       // IWYU pragma: keep
+#include "lyra/value/packed_convert.hpp"       // IWYU pragma: keep
+#include "lyra/value/packed_reduction.hpp"     // IWYU pragma: keep
+#include "lyra/value/packed_type.hpp"          // IWYU pragma: keep
+#include "lyra/value/string.hpp"               // IWYU pragma: keep
+#include "lyra/value/string_op.hpp"            // IWYU pragma: keep
+#include "lyra/value/unpacked_array.hpp"       // IWYU pragma: keep

--- a/include/lyra/runtime/simulation_entry.hpp
+++ b/include/lyra/runtime/simulation_entry.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace lyra::runtime {
+
+class Engine;
+
+// Boundary between a host program and the simulation Engine. Drives a
+// bound Engine to completion and converts any escaping C++ exception
+// (an InternalError, std::bad_alloc, or other std::exception) into
+// EXIT_FAILURE. Never throws.
+//
+// Engine::Run is the scheduler proper -- its body describes the LRM
+// region order and may throw on invariant violation or allocation
+// failure. This function is the host-process boundary that catches
+// such exceptions and maps them to an exit code. Emitted main.cpp
+// calls this rather than Engine::Run directly; any other host program
+// that embeds the runtime should do the same.
+auto RunSimulation(Engine& engine) -> int;
+
+}  // namespace lyra::runtime

--- a/include/lyra/value/packed_internal.hpp
+++ b/include/lyra/value/packed_internal.hpp
@@ -1,12 +1,9 @@
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
-#include <format>
 #include <span>
 #include <string_view>
 
-#include "lyra/base/internal_error.hpp"
 #include "lyra/value/packed.hpp"
 
 namespace lyra::value::detail {
@@ -49,43 +46,20 @@ struct PackedAccess {
   }
 };
 
-inline auto RequireSameWidth(
-    std::string_view where, std::uint64_t a, std::uint64_t b) -> void {
-  if (a != b) {
-    throw InternalError(
-        std::format("{}: width mismatch ({} vs {})", where, a, b));
-  }
-}
+// Out-of-line so std::format does not leak into every translation unit
+// that includes this header.
+auto RequireSameWidth(std::string_view where, std::uint64_t a, std::uint64_t b)
+    -> void;
 
-inline auto RequireSameWidth(
+auto RequireSameWidth(
     std::string_view where, std::uint64_t a, std::uint64_t b, std::uint64_t c)
-    -> void {
-  if (a != b || a != c) {
-    throw InternalError(
-        std::format("{}: width mismatch ({} vs {} vs {})", where, a, b, c));
-  }
-}
+    -> void;
 
-inline auto RequireAligned(std::string_view where, std::uint64_t bit_offset)
-    -> void {
-  if (bit_offset != 0U) {
-    throw InternalError(
-        std::format(
-            "{}: requires bit_offset == 0 (got {})", where, bit_offset));
-  }
-}
+auto RequireAligned(std::string_view where, std::uint64_t bit_offset) -> void;
 
-inline auto RequireWordCount(
+auto RequireWordCount(
     std::string_view where, std::span<const std::uint64_t> words,
-    std::uint64_t bit_width) -> void {
-  const std::size_t expected = WordCountForBits(bit_width);
-  if (words.size() != expected) {
-    throw InternalError(
-        std::format(
-            "{}: word count mismatch ({} vs expected {})", where, words.size(),
-            expected));
-  }
-}
+    std::uint64_t bit_width) -> void;
 
 inline auto RequireWordCount(
     std::string_view where, std::span<std::uint64_t> words,

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -4,7 +4,6 @@
 #include <cctype>
 #include <cstdint>
 #include <cstdlib>
-#include <format>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -197,21 +196,13 @@ class String {
 
   // LRM 6.16.11 through 6.16.15. Each replaces receiver with the ASCII
   // representation of the argument in the corresponding base / format.
-  void Itoa(std::int32_t i) {
-    impl_ = std::format("{}", i);
-  }
-  void Hextoa(std::int32_t i) {
-    impl_ = std::format("{:x}", static_cast<std::uint32_t>(i));
-  }
-  void Octtoa(std::int32_t i) {
-    impl_ = std::format("{:o}", static_cast<std::uint32_t>(i));
-  }
-  void Bintoa(std::int32_t i) {
-    impl_ = std::format("{:b}", static_cast<std::uint32_t>(i));
-  }
-  void Realtoa(double r) {
-    impl_ = std::format("{}", r);
-  }
+  // Out-of-line so std::format does not leak into every translation unit
+  // that includes this header.
+  void Itoa(std::int32_t i);
+  void Hextoa(std::int32_t i);
+  void Octtoa(std::int32_t i);
+  void Bintoa(std::int32_t i);
+  void Realtoa(double r);
 
   [[nodiscard]] auto View() const -> std::string_view {
     return impl_;

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -615,11 +615,10 @@ auto RenderScopeHeaderFile(
 
 auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
   std::string out;
-  out += "#include <exception>\n";
-  out += "#include <iostream>\n";
   out += "#include <vector>\n";
   out += "\n";
   out += "#include \"lyra/runtime/engine.hpp\"\n";
+  out += "#include \"lyra/runtime/simulation_entry.hpp\"\n";
   for (const auto& top : tops) {
     out += "#include \"" + top.unit->structural_scope.name + ".hpp\"\n";
   }
@@ -636,12 +635,7 @@ auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
   }
   out += "  };\n";
   out += "  engine.BindDesign(tops);\n";
-  out += "  try {\n";
-  out += "    return engine.Run();\n";
-  out += "  } catch (const std::exception& e) {\n";
-  out += "    std::cerr << e.what() << \"\\n\";\n";
-  out += "    return 1;\n";
-  out += "  }\n";
+  out += "  return lyra::runtime::RunSimulation(engine);\n";
   out += "}\n";
   return out;
 }

--- a/src/lyra/driver/cli.cpp
+++ b/src/lyra/driver/cli.cpp
@@ -23,6 +23,7 @@
 #include "lyra/diag/sink.hpp"
 #include "lyra/diag/source_manager.hpp"
 #include "lyra/driver/cpp_build.hpp"
+#include "lyra/driver/pch.hpp"
 #include "lyra/driver/runtime_export.hpp"
 #include "lyra/frontend/load.hpp"
 #include "lyra/hir/dump.hpp"
@@ -31,7 +32,14 @@
 
 namespace {
 
-enum class CommandKind { kDumpHir, kDumpMir, kEmitCpp, kCompile, kRun };
+enum class CommandKind {
+  kDumpHir,
+  kDumpMir,
+  kEmitCpp,
+  kCompile,
+  kRun,
+  kCacheClear,
+};
 
 struct ParsedArgs {
   CommandKind cmd = CommandKind::kEmitCpp;
@@ -39,6 +47,8 @@ struct ParsedArgs {
   bool no_color = false;
   bool force_color = false;
   bool format = false;
+  bool no_pch = false;
+  std::string pch_cache_dir;
   lyra::frontend::CompilationInput input;
   std::string out_dir;
 };
@@ -123,19 +133,43 @@ auto ParseArgs(int argc, char** argv)
       .default_value(std::string{});
   emit_cmd.add_subparser(emit_cpp_cmd);
 
+  // The C++ compile path (used by `compile` and `run`) caches a precompiled
+  // header keyed on the runtime tree contents. `--no-pch` short-circuits the
+  // cache (equivalent to setting `LYRA_NO_PCH=1` in the environment), and
+  // `--pch-cache-dir` overrides where the cache lives (used by the test
+  // framework to land cache files inside its per-shard scratch dir).
+  const auto add_pch_flags = [](argparse::ArgumentParser& p) {
+    p.add_argument("--no-pch")
+        .help("disable the precompiled-header cache for this invocation")
+        .default_value(false)
+        .implicit_value(true);
+    p.add_argument("--pch-cache-dir")
+        .help("override the PCH cache directory")
+        .default_value(std::string{});
+  };
+
   argparse::ArgumentParser compile_cmd("compile");
   AddCompilationFlags(compile_cmd);
+  add_pch_flags(compile_cmd);
   compile_cmd.add_argument("-o", "--out-dir")
       .help("write the self-contained project and built program here")
       .default_value(std::string{});
 
   argparse::ArgumentParser run_cmd("run");
   AddCompilationFlags(run_cmd);
+  add_pch_flags(run_cmd);
+
+  argparse::ArgumentParser cache_cmd("cache");
+  argparse::ArgumentParser cache_clear_cmd("clear");
+  cache_clear_cmd.add_description(
+      "remove the active precompiled-header cache directory's contents");
+  cache_cmd.add_subparser(cache_clear_cmd);
 
   program.add_subparser(dump_cmd);
   program.add_subparser(emit_cmd);
   program.add_subparser(compile_cmd);
   program.add_subparser(run_cmd);
+  program.add_subparser(cache_cmd);
 
   try {
     program.parse_args(argc, argv);
@@ -174,6 +208,8 @@ auto ParseArgs(int argc, char** argv)
   } else if (program.is_subcommand_used("compile")) {
     out.cmd = CommandKind::kCompile;
     BindCompilationFlags(compile_cmd, out);
+    out.no_pch = compile_cmd.get<bool>("--no-pch");
+    out.pch_cache_dir = compile_cmd.get<std::string>("--pch-cache-dir");
     out.out_dir = compile_cmd.get<std::string>("--out-dir");
     if (out.out_dir.empty()) {
       return std::unexpected(
@@ -183,6 +219,15 @@ auto ParseArgs(int argc, char** argv)
   } else if (program.is_subcommand_used("run")) {
     out.cmd = CommandKind::kRun;
     BindCompilationFlags(run_cmd, out);
+    out.no_pch = run_cmd.get<bool>("--no-pch");
+    out.pch_cache_dir = run_cmd.get<std::string>("--pch-cache-dir");
+  } else if (program.is_subcommand_used("cache")) {
+    if (cache_cmd.is_subcommand_used("clear")) {
+      out.cmd = CommandKind::kCacheClear;
+    } else {
+      return std::unexpected(
+          std::format("cache requires 'clear'\n{}", cache_cmd.help().str()));
+    }
   } else {
     return std::unexpected(program.help().str());
   }
@@ -227,6 +272,38 @@ auto main(int argc, char** argv) -> int {
       return 1;
     }
     auto& args = *parsed;
+
+    // PCH options condensed into a single explicit value passed down to the
+    // build helpers. The `--no-pch` flag is authoritative; the `LYRA_NO_PCH`
+    // environment hint is honored at this boundary only and disappears from
+    // every lower layer.
+    const auto pch_opts = [&] {
+      lyra::driver::pch::Options o;
+      o.disabled = args.no_pch;
+      if (const char* v = std::getenv("LYRA_NO_PCH");
+          v != nullptr && *v != '\0' && std::string_view(v) != "0") {
+        o.disabled = true;
+      }
+      if (!args.pch_cache_dir.empty()) {
+        o.cache_dir_override = std::filesystem::path(args.pch_cache_dir);
+      }
+      return o;
+    }();
+
+    // `cache clear` does not consult a project, take input files, or invoke
+    // the compiler pipeline. Dispatch it before the compilation-input checks
+    // below so it works whether or not a project is configured.
+    if (args.cmd == CommandKind::kCacheClear) {
+      auto cleared_or = lyra::driver::pch::Clear(pch_opts);
+      if (!cleared_or) {
+        report(std::move(cleared_or.error()));
+        return 1;
+      }
+      fmt::print(
+          "cleared {} precompiled-header file{}\n", *cleared_or,
+          *cleared_or == 1 ? "" : "s");
+      return 0;
+    }
 
     if (!args.no_project) {
       report(
@@ -346,7 +423,7 @@ auto main(int argc, char** argv) -> int {
           report(std::move(assembled.error()), mgr);
           return 1;
         }
-        auto built = lyra::driver::BuildProject(dir);
+        auto built = lyra::driver::BuildProject(dir, pch_opts);
         if (!built) {
           report(std::move(built.error()), mgr);
           return 1;
@@ -370,7 +447,7 @@ auto main(int argc, char** argv) -> int {
         const auto& units = *result.artifacts.mir_units;
         const auto tops = build_tops(units, result.artifacts.top_unit_names);
         auto exit_code = lyra::driver::RunInPlace(
-            *runtime, units, tops, *tmp_or, args.format);
+            *runtime, units, tops, *tmp_or, args.format, pch_opts);
         if (!exit_code) {
           report(std::move(exit_code.error()), mgr);
           return 1;
@@ -378,6 +455,7 @@ auto main(int argc, char** argv) -> int {
         return *exit_code;
       }
       case CommandKind::kDumpHir:
+      case CommandKind::kCacheClear:
         break;
     }
     return 0;

--- a/src/lyra/driver/cpp_build.cpp
+++ b/src/lyra/driver/cpp_build.cpp
@@ -1,5 +1,8 @@
 #include "lyra/driver/cpp_build.hpp"
 
+#include <array>
+#include <cstddef>
+#include <filesystem>
 #include <format>
 #include <fstream>
 #include <span>
@@ -11,6 +14,7 @@
 
 #include "lyra/backend/cpp/api.hpp"
 #include "lyra/diag/diag_code.hpp"
+#include "lyra/driver/pch.hpp"
 #include "lyra/driver/project_layout.hpp"
 #include "lyra/driver/runtime_export.hpp"
 #include "lyra/support/subprocess.hpp"
@@ -42,15 +46,94 @@ auto WriteFile(const std::filesystem::path& path, std::string_view content)
   return {};
 }
 
+// Replace every `@KEY@` occurrence in `tpl` with its mapped substitution.
+// Tokens left unbound are passed through unchanged (build.sh shell syntax
+// uses `${VAR}` and `$VAR`, never the `@...@` form, so unbound tokens here
+// are author bugs rather than legal shell). Kept inline because the script
+// is the only caller; promoting to a public utility waits for a second use.
+auto SubstituteTokens(
+    std::string_view tpl,
+    std::span<const std::pair<std::string_view, std::string_view>> bindings)
+    -> std::string {
+  std::string out;
+  out.reserve(tpl.size());
+  std::size_t i = 0;
+  while (i < tpl.size()) {
+    if (tpl[i] != '@') {
+      out.push_back(tpl[i]);
+      ++i;
+      continue;
+    }
+    const auto end = tpl.find('@', i + 1);
+    if (end == std::string_view::npos) {
+      out.append(tpl.substr(i));
+      break;
+    }
+    const auto key = tpl.substr(i, end - i + 1);  // includes both '@'s
+    bool replaced = false;
+    for (const auto& [k, v] : bindings) {
+      if (key == k) {
+        out.append(v);
+        replaced = true;
+        break;
+      }
+    }
+    if (!replaced) out.append(key);
+    i = end + 1;
+  }
+  return out;
+}
+
+// build.sh as a raw-string template. `@TOKEN@` placeholders bind to the
+// `project_layout` constants below. Shell `${VAR}` and `$VAR` pass through
+// unchanged. The PCH section gates on three runtime checks: `$CXX` looking
+// like clang (gcc's PCH dialect does not match these flags), `LYRA_NO_PCH`
+// being unset, and `sha1sum` being available (used to fingerprint the
+// header tree so a header edit produces a different cache file rather
+// than reusing a PCH built against stale-on-disk content). Any failing
+// check falls back to plain compilation; correctness is unaffected.
+constexpr std::string_view kBuildScriptTemplate = R"sh(#!/bin/sh
+# Build this self-contained Lyra C++ project. Override the compiler with $CXX.
+# A precompiled header is built on first run and reused on subsequent rebuilds
+# to amortize parsing of the runtime headers (clang only).
+# Disable with LYRA_NO_PCH=1.
+set -e
+CXX="${CXX:-clang++}"
+USE_PCH=0
+if [ -z "$LYRA_NO_PCH" ] || [ "$LYRA_NO_PCH" = "0" ]; then
+  case "$CXX" in
+    *clang*)
+      if command -v sha1sum >/dev/null 2>&1; then USE_PCH=1; fi
+      ;;
+  esac
+fi
+PCH_FLAG=""
+if [ "$USE_PCH" = "1" ]; then
+  PRELUDE="@INCLUDE@/@PRELUDE@"
+  FP=$(find @INCLUDE@ -name '*.hpp' -print0 | sort -z | xargs -0 sha1sum | sha1sum | cut -c1-16)
+  PCH="@CACHE@/prelude-${FP}.pch"
+  if [ ! -f "$PCH" ]; then
+    mkdir -p "$(dirname "$PCH")"
+    "$CXX" @STD@ -I @INCLUDE@ -xc++-header "$PRELUDE" -o "$PCH"
+  fi
+  PCH_FLAG="-include-pch $PCH"
+fi
+"$CXX" @STD@ -I @INCLUDE@ $PCH_FLAG @MAIN@ @LIBDIR@/@LIB@ -o @PROG@
+)sh";
+
 auto RenderBuildScript() -> std::string {
-  return std::format(
-      "#!/bin/sh\n"
-      "# Build this self-contained Lyra C++ project. Override the compiler "
-      "with $CXX.\n"
-      "set -e\n"
-      "\"${{CXX:-clang++}}\" {} -I {} {} {}/{} -o {}\n",
-      kCxxStandardFlag, kRuntimeIncludeDir, kMainSource, kRuntimeLibDir,
-      kRuntimeLibFile, kProgramName);
+  const std::array<std::pair<std::string_view, std::string_view>, 8> bindings =
+      {{
+          {"@INCLUDE@", kRuntimeIncludeDir},
+          {"@PRELUDE@", kPreludeHeader},
+          {"@CACHE@", kRuntimeCacheDir},
+          {"@STD@", kCxxStandardFlag},
+          {"@MAIN@", kMainSource},
+          {"@LIBDIR@", kRuntimeLibDir},
+          {"@LIB@", kRuntimeLibFile},
+          {"@PROG@", kProgramName},
+      }};
+  return SubstituteTokens(kBuildScriptTemplate, bindings);
 }
 
 // Best-effort: reformat the emitted C++ files in place with clang-format if it
@@ -92,19 +175,22 @@ auto EmitAndWriteSources(
 auto CompileProgram(
     const std::filesystem::path& main_cpp,
     const std::filesystem::path& include_root, const std::filesystem::path& lib,
-    const std::filesystem::path& program) -> diag::Result<void> {
+    const std::filesystem::path& program, const pch::Options& pch_opts)
+    -> diag::Result<void> {
   auto cxx_or = support::ResolveCxxCompiler();
   if (!cxx_or) {
     return IoError(std::move(cxx_or.error()));
   }
-  const std::vector<std::string> args = {
-      std::string(kCxxStandardFlag),
-      "-I",
-      include_root.string(),
-      main_cpp.string(),
-      lib.string(),
-      "-o",
-      program.string()};
+  std::vector<std::string> args = {
+      std::string(kCxxStandardFlag), "-I", include_root.string()};
+  if (auto cached = pch::EnsureCached(*cxx_or, include_root, pch_opts)) {
+    args.emplace_back("-include-pch");
+    args.push_back(cached->string());
+  }
+  args.push_back(main_cpp.string());
+  args.push_back(lib.string());
+  args.emplace_back("-o");
+  args.push_back(program.string());
   auto result_or = support::RunProcessCaptured(*cxx_or, args);
   if (!result_or) {
     return IoError(std::move(result_or.error()));
@@ -152,12 +238,13 @@ auto AssembleProject(
   return {};
 }
 
-auto BuildProject(const std::filesystem::path& dir)
+auto BuildProject(
+    const std::filesystem::path& dir, const pch::Options& pch_opts)
     -> diag::Result<std::filesystem::path> {
   const auto program = dir / kProgramName;
   if (auto r = CompileProgram(
           dir / kMainSource, dir / kRuntimeIncludeDir,
-          dir / kRuntimeLibDir / kRuntimeLibFile, program);
+          dir / kRuntimeLibDir / kRuntimeLibFile, program, pch_opts);
       !r) {
     return std::unexpected(std::move(r.error()));
   }
@@ -167,13 +254,15 @@ auto BuildProject(const std::filesystem::path& dir)
 auto RunInPlace(
     const RuntimeLocation& runtime, std::span<const mir::CompilationUnit> units,
     std::span<const backend::cpp::TopInstance> tops,
-    const std::filesystem::path& work_dir, bool format) -> diag::Result<int> {
+    const std::filesystem::path& work_dir, bool format,
+    const pch::Options& pch_opts) -> diag::Result<int> {
   if (auto r = EmitAndWriteSources(units, tops, work_dir, format); !r) {
     return std::unexpected(std::move(r.error()));
   }
   const auto program = work_dir / kProgramName;
   if (auto r = CompileProgram(
-          work_dir / kMainSource, runtime.include_root, runtime.lib, program);
+          work_dir / kMainSource, runtime.include_root, runtime.lib, program,
+          pch_opts);
       !r) {
     return std::unexpected(std::move(r.error()));
   }

--- a/src/lyra/driver/pch.cpp
+++ b/src/lyra/driver/pch.cpp
@@ -1,0 +1,259 @@
+#include "lyra/driver/pch.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <expected>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <functional>
+#include <iterator>
+#include <random>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/driver/project_layout.hpp"
+#include "lyra/support/subprocess.hpp"
+
+namespace lyra::driver::pch {
+
+namespace {
+
+auto IoError(std::string message) {
+  return diag::HostError(diag::DiagCode::kHostIoError, std::move(message));
+}
+
+// True when the resolved compiler is clang-based. PCH file format and the
+// `-include-pch` driver flag are clang-specific; gcc uses `.gch` placed next
+// to the header. Sniff by basename rather than running `--version` to keep
+// the check cheap. Misclassification only degrades to a non-PCH compile, so
+// correctness is unaffected.
+auto IsClangCompiler(const std::filesystem::path& cxx) -> bool {
+  return cxx.filename().string().find("clang") != std::string::npos;
+}
+
+// Read the file at `path` into `out`, appended. Bulk seek + read is much
+// faster than the `istreambuf_iterator` idiom on inputs of any meaningful
+// size. Silently no-ops on open/read failure -- the caller treats partial
+// content as a fingerprint divergence, which is the correct outcome anyway.
+auto AppendFileContent(const std::filesystem::path& path, std::string& out)
+    -> void {
+  std::ifstream f(path, std::ios::binary | std::ios::ate);
+  if (!f) return;
+  const auto size = static_cast<std::streamsize>(f.tellg());
+  if (size <= 0) return;
+  const auto offset = out.size();
+  out.resize(offset + static_cast<std::size_t>(size));
+  f.seekg(0);
+  f.read(std::next(out.data(), static_cast<std::ptrdiff_t>(offset)), size);
+}
+
+// Resolve the cache directory. Order: caller-supplied override first, then
+// the XDG-spec defaults. The CLI layer is responsible for surfacing any
+// environment hints (e.g. `LYRA_NO_PCH`) into the Options value; this helper
+// limits its env reads to `XDG_CACHE_HOME` and `HOME`, both of which are
+// XDG-standard rather than Lyra-specific.
+auto ResolveCacheDir(const Options& opts)
+    -> std::expected<std::filesystem::path, std::string> {
+  std::vector<std::filesystem::path> candidates;
+  if (opts.cache_dir_override) {
+    candidates.push_back(*opts.cache_dir_override);
+  } else {
+    const auto from_env =
+        [](const char* var) -> std::optional<std::filesystem::path> {
+      const char* v = std::getenv(var);
+      if (v == nullptr || *v == '\0') return std::nullopt;
+      return std::filesystem::path(v);
+    };
+    if (auto p = from_env("XDG_CACHE_HOME")) {
+      candidates.push_back(*p / "lyra/pch");
+    }
+    if (auto p = from_env("HOME")) {
+      candidates.push_back(*p / ".cache/lyra/pch");
+    }
+  }
+
+  for (const auto& dir : candidates) {
+    std::error_code ec;
+    std::filesystem::create_directories(dir, ec);
+    if (!ec) return dir;
+  }
+  return std::unexpected("no writable PCH cache directory found");
+}
+
+// Identity of the compiler binary, condensed into a 64-bit hash. The
+// realpath catches `$CXX` pointing at a different installation; the mtime
+// catches an in-place upgrade of the same binary. Together they ensure two
+// clang versions never share a PCH file (the PCH binary format is
+// clang-version-sensitive).
+auto HashCxxIdentity(const std::filesystem::path& cxx) -> std::uint64_t {
+  std::error_code ec;
+  const auto canonical = std::filesystem::canonical(cxx, ec);
+  std::string key = ec ? cxx.string() : canonical.string();
+  std::error_code mtime_ec;
+  const auto mtime = std::filesystem::last_write_time(canonical, mtime_ec);
+  if (!mtime_ec) {
+    const auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                           mtime.time_since_epoch())
+                           .count();
+    key.push_back('\0');
+    key += std::format("{}", nanos);
+  }
+  return std::hash<std::string>{}(key);
+}
+
+// Canonical path of the include root, hashed. Distinguishes cache entries
+// when two runtime installations exist side by side; PCH files store
+// absolute paths to their inputs and cannot be shared across trees.
+auto HashIncludeRootPath(const std::filesystem::path& include_root)
+    -> std::uint64_t {
+  std::error_code ec;
+  const auto canonical = std::filesystem::canonical(include_root, ec);
+  const std::string key = ec ? include_root.string() : canonical.string();
+  return std::hash<std::string>{}(key);
+}
+
+// Content fingerprint of every `.hpp` under `include_root`. Concatenates each
+// file's relative path and full byte content into one buffer (NUL-separated
+// to keep boundaries unambiguous) and hashes the buffer with std::hash. Any
+// edit, addition, or removal under `include_root` perturbs the buffer and
+// therefore the hash, driving the cache filename to a new value.
+auto HeaderTreeFingerprint(const std::filesystem::path& include_root)
+    -> std::uint64_t {
+  std::vector<std::filesystem::path> paths;
+  std::error_code ec;
+  for (const auto& e : std::filesystem::recursive_directory_iterator(
+           include_root,
+           std::filesystem::directory_options::follow_directory_symlink, ec)) {
+    if (e.is_regular_file() && e.path().extension() == ".hpp") {
+      paths.push_back(e.path());
+    }
+  }
+  std::ranges::sort(paths);
+
+  std::string buf;
+  for (const auto& p : paths) {
+    buf += p.lexically_relative(include_root).generic_string();
+    buf.push_back('\0');
+    AppendFileContent(p, buf);
+    buf.push_back('\0');
+  }
+  return std::hash<std::string>{}(buf);
+}
+
+// Cache filename derived from cxx identity + include-root path + tree
+// content. The triple provides three independent invalidation axes: upgrading
+// the compiler, swapping runtime installations, or editing any header. Two
+// cache entries with the same name are byte-equivalent by construction.
+auto CacheFilename(
+    const std::filesystem::path& cxx, const std::filesystem::path& include_root)
+    -> std::string {
+  return std::format(
+      "prelude-{:016x}-{:016x}-{:016x}.pch", HashCxxIdentity(cxx),
+      HashIncludeRootPath(include_root), HeaderTreeFingerprint(include_root));
+}
+
+// 64 bits of entropy for a tmp filename suffix. Two random_device draws are
+// concatenated because the underlying RNG only guarantees 32 bits per call.
+auto RandomTmpSuffix() -> std::string {
+  std::random_device rd;
+  const auto hi = static_cast<std::uint64_t>(rd());
+  const auto lo = static_cast<std::uint64_t>(rd());
+  return std::format("{:08x}{:08x}", hi, lo);
+}
+
+// Build the PCH at a per-call tmp path, then rename atomically. Concurrent
+// shards racing on the same final cache file are harmless: the rename is
+// last-writer-wins on a fully-formed PCH; tmp paths are unique per call so
+// writers do not corrupt each other.
+//
+// Validation strategy: clang stores each input header's mtime in the PCH and
+// validates them on load by default, so a system-stdlib or libc upgrade
+// surfaces as a loud load-time error rather than a stale PCH. We rely on
+// that default for files outside `include_root`; everything inside
+// `include_root` is captured proactively by the cache filename's content
+// fingerprint, so the two layers together produce a coherent cache.
+auto BuildAt(
+    const std::filesystem::path& cxx, const std::filesystem::path& include_root,
+    const std::filesystem::path& pch_path) -> diag::Result<void> {
+  const auto prelude = include_root / kPreludeHeader;
+  const auto tmp = pch_path.parent_path() /
+                   std::format(".prelude.pch.tmp.{}", RandomTmpSuffix());
+  const std::vector<std::string> args = {
+      std::string(kCxxStandardFlag),
+      "-I",
+      include_root.string(),
+      "-xc++-header",
+      prelude.string(),
+      "-o",
+      tmp.string()};
+  auto result_or = support::RunProcessCaptured(cxx, args);
+  if (!result_or) {
+    return IoError(std::move(result_or.error()));
+  }
+  if (result_or->exit_code != 0) {
+    return diag::HostError(
+        diag::DiagCode::kHostBuildFailed,
+        std::format(
+            "PCH build exited with {}:\n{}", result_or->exit_code,
+            result_or->stderr_text));
+  }
+  std::error_code ec;
+  std::filesystem::rename(tmp, pch_path, ec);
+  if (ec) {
+    std::filesystem::remove(tmp, ec);
+    return IoError(
+        std::format(
+            "failed to install PCH at '{}': {}", pch_path.string(),
+            ec.message()));
+  }
+  return {};
+}
+
+}  // namespace
+
+auto EnsureCached(
+    const std::filesystem::path& cxx, const std::filesystem::path& include_root,
+    const Options& opts) -> std::optional<std::filesystem::path> {
+  if (opts.disabled) return std::nullopt;
+  if (!IsClangCompiler(cxx)) return std::nullopt;
+
+  auto cache_or = ResolveCacheDir(opts);
+  if (!cache_or) return std::nullopt;
+  const auto pch_path = *cache_or / CacheFilename(cxx, include_root);
+
+  std::error_code ec;
+  if (std::filesystem::exists(pch_path, ec) && !ec) {
+    return pch_path;
+  }
+  if (auto r = BuildAt(cxx, include_root, pch_path); !r) {
+    return std::nullopt;
+  }
+  return pch_path;
+}
+
+auto Clear(const Options& opts) -> diag::Result<std::size_t> {
+  auto dir_or = ResolveCacheDir(opts);
+  if (!dir_or) {
+    return IoError(std::move(dir_or.error()));
+  }
+  std::size_t removed = 0;
+  std::error_code ec;
+  for (const auto& e : std::filesystem::directory_iterator(*dir_or, ec)) {
+    if (!e.is_regular_file()) continue;
+    if (!e.path().filename().string().starts_with("prelude-")) continue;
+    std::error_code remove_ec;
+    if (std::filesystem::remove(e.path(), remove_ec)) {
+      ++removed;
+    }
+  }
+  return removed;
+}
+
+}  // namespace lyra::driver::pch

--- a/src/lyra/runtime/simulation_entry.cpp
+++ b/src/lyra/runtime/simulation_entry.cpp
@@ -1,0 +1,28 @@
+#include "lyra/runtime/simulation_entry.hpp"
+
+#include <cstdlib>
+#include <exception>
+#include <new>
+#include <print>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/runtime/engine.hpp"
+
+namespace lyra::runtime {
+
+auto RunSimulation(Engine& engine) -> int {
+  try {
+    return engine.Run();
+  } catch (const InternalError& e) {
+    std::print(stderr, "{}\n", e.what());
+    return EXIT_FAILURE;
+  } catch (const std::bad_alloc&) {
+    std::print(stderr, "out of memory\n");
+    return EXIT_FAILURE;
+  } catch (const std::exception& e) {
+    std::print(stderr, "unexpected error: {}\n", e.what());
+    return EXIT_FAILURE;
+  }
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/runtime/simulation_entry.cpp
+++ b/src/lyra/runtime/simulation_entry.cpp
@@ -2,8 +2,8 @@
 
 #include <cstdlib>
 #include <exception>
+#include <iostream>
 #include <new>
-#include <print>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/runtime/engine.hpp"
@@ -14,13 +14,13 @@ auto RunSimulation(Engine& engine) -> int {
   try {
     return engine.Run();
   } catch (const InternalError& e) {
-    std::print(stderr, "{}\n", e.what());
+    std::cerr << e.what() << "\n";
     return EXIT_FAILURE;
   } catch (const std::bad_alloc&) {
-    std::print(stderr, "out of memory\n");
+    std::cerr << "out of memory\n";
     return EXIT_FAILURE;
   } catch (const std::exception& e) {
-    std::print(stderr, "unexpected error: {}\n", e.what());
+    std::cerr << "unexpected error: " << e.what() << "\n";
     return EXIT_FAILURE;
   }
 }

--- a/src/lyra/value/packed_internal.cpp
+++ b/src/lyra/value/packed_internal.cpp
@@ -1,0 +1,51 @@
+#include "lyra/value/packed_internal.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <span>
+#include <string_view>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/value/packed.hpp"
+
+namespace lyra::value::detail {
+
+auto RequireSameWidth(std::string_view where, std::uint64_t a, std::uint64_t b)
+    -> void {
+  if (a != b) {
+    throw InternalError(
+        std::format("{}: width mismatch ({} vs {})", where, a, b));
+  }
+}
+
+auto RequireSameWidth(
+    std::string_view where, std::uint64_t a, std::uint64_t b, std::uint64_t c)
+    -> void {
+  if (a != b || a != c) {
+    throw InternalError(
+        std::format("{}: width mismatch ({} vs {} vs {})", where, a, b, c));
+  }
+}
+
+auto RequireAligned(std::string_view where, std::uint64_t bit_offset) -> void {
+  if (bit_offset != 0U) {
+    throw InternalError(
+        std::format(
+            "{}: requires bit_offset == 0 (got {})", where, bit_offset));
+  }
+}
+
+auto RequireWordCount(
+    std::string_view where, std::span<const std::uint64_t> words,
+    std::uint64_t bit_width) -> void {
+  const std::size_t expected = WordCountForBits(bit_width);
+  if (words.size() != expected) {
+    throw InternalError(
+        std::format(
+            "{}: word count mismatch ({} vs expected {})", where, words.size(),
+            expected));
+  }
+}
+
+}  // namespace lyra::value::detail

--- a/src/lyra/value/string.cpp
+++ b/src/lyra/value/string.cpp
@@ -1,0 +1,28 @@
+#include "lyra/value/string.hpp"
+
+#include <cstdint>
+#include <format>
+
+namespace lyra::value {
+
+void String::Itoa(std::int32_t i) {
+  impl_ = std::format("{}", i);
+}
+
+void String::Hextoa(std::int32_t i) {
+  impl_ = std::format("{:x}", static_cast<std::uint32_t>(i));
+}
+
+void String::Octtoa(std::int32_t i) {
+  impl_ = std::format("{:o}", static_cast<std::uint32_t>(i));
+}
+
+void String::Bintoa(std::int32_t i) {
+  impl_ = std::format("{:b}", static_cast<std::uint32_t>(i));
+}
+
+void String::Realtoa(double r) {
+  impl_ = std::format("{}", r);
+}
+
+}  // namespace lyra::value

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -39,6 +39,23 @@ cc_test(
 )
 
 cc_test(
+    name = "pch_audit_test",
+    srcs = ["pch_audit_test.cpp"],
+    data = ["//:lyra"],
+    # Spawns the host C++ compiler with `-H` to enumerate every header opened
+    # while building the prelude PCH. Filtered out of CI's `Test` job for the
+    # same reason as run_tests/cpp_tests; run locally as needed.
+    tags = ["requires-host-cxx"],
+    deps = [
+        "//:driver",
+        "//:support",
+        "@bazel_tools//tools/cpp/runfiles",
+        "@fmt",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "cpp_tests",
     srcs = ["cpp_test.cpp"],
     data = [

--- a/tests/framework/runner.cpp
+++ b/tests/framework/runner.cpp
@@ -471,6 +471,16 @@ auto RunCppCase(const std::filesystem::path& lyra_exe, const TestCase& c)
   std::vector<std::string>& argv = result.argv;
   argv.emplace_back("run");
   argv.emplace_back("--no-project");
+  // Land the precompiled-header cache inside bazel's per-shard scratch dir
+  // so PCH files share across the shard's many cases without leaking into
+  // the user's home cache or contending across parallel shards. The CLI
+  // layer reads this argument explicitly; the lyra binary has no implicit
+  // TEST_TMPDIR handling of its own.
+  if (const char* tmp = std::getenv("TEST_TMPDIR");
+      tmp != nullptr && *tmp != '\0') {
+    argv.emplace_back("--pch-cache-dir");
+    argv.push_back(std::string(tmp) + "/lyra-pch");
+  }
   if (c.input.top.has_value()) {
     argv.emplace_back("--top");
     argv.push_back(*c.input.top);

--- a/tests/pch_audit_test.cpp
+++ b/tests/pch_audit_test.cpp
@@ -1,0 +1,144 @@
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <filesystem>
+#include <format>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fmt/core.h>
+
+#include "lyra/driver/runtime_export.hpp"
+#include "lyra/support/subprocess.hpp"
+#include "tools/cpp/runfiles/runfiles.h"
+
+namespace {
+
+using bazel::tools::cpp::runfiles::Runfiles;
+
+// `clang -H` writes one stderr line per header it opened. Each line starts
+// with one or more `.` characters denoting include depth, then a space, then
+// the absolute path. Non-trace lines (e.g. warnings, "Multiple include
+// guards may be useful for ..." footer) lack the leading dot or have no
+// path after the prefix, and are skipped.
+auto ParseHeaderTrace(std::string_view stderr_text)
+    -> std::vector<std::filesystem::path> {
+  std::vector<std::filesystem::path> out;
+  std::size_t start = 0;
+  while (start < stderr_text.size()) {
+    const auto end = stderr_text.find('\n', start);
+    const auto line = stderr_text.substr(
+        start, end == std::string_view::npos ? end : end - start);
+    start = end == std::string_view::npos ? stderr_text.size() : end + 1;
+    if (line.empty() || line.front() != '.') continue;
+    const auto dot_end = line.find_first_not_of('.');
+    if (dot_end == std::string_view::npos) continue;
+    if (line[dot_end] != ' ') continue;
+    const auto path_begin = line.find_first_not_of(' ', dot_end);
+    if (path_begin == std::string_view::npos) continue;
+    out.emplace_back(std::string{line.substr(path_begin)});
+  }
+  return out;
+}
+
+// A path is "fingerprint-covered" if it lives under `include_root`. The
+// HeaderTreeFingerprint walks `include_root` recursively, so any content
+// change to a covered header drives a different cache filename. Compare
+// both the raw runfiles-relative form and the symlink-resolved form so the
+// check is robust against either side dereferencing first.
+auto IsFingerprintCovered(
+    const std::filesystem::path& p, const std::filesystem::path& include_root)
+    -> bool {
+  const auto starts_under = [](const std::filesystem::path& candidate,
+                               const std::filesystem::path& root) {
+    const auto rel = candidate.lexically_relative(root);
+    if (rel.empty()) return false;
+    return rel.begin() != rel.end() && rel.begin()->string() != "..";
+  };
+  if (starts_under(p, include_root)) return true;
+  std::error_code ec;
+  const auto canonical_h = std::filesystem::weakly_canonical(p, ec);
+  const auto canonical_root =
+      std::filesystem::weakly_canonical(include_root, ec);
+  return starts_under(canonical_h, canonical_root);
+}
+
+// A path is "system-covered" if it lives in a well-known system include
+// path. clang stores each input header's mtime in the PCH and re-validates
+// them on load by default, so a system-stdlib or libc upgrade that bumps
+// header mtimes surfaces as a loud load-time error rather than a silent
+// stale PCH; this is the safety net for inputs the fingerprint cannot see.
+auto IsSystemPath(const std::filesystem::path& p) -> bool {
+  static const std::array<std::string_view, 6> kRoots = {
+      "/usr/include",   "/usr/lib", "/usr/local/include",
+      "/usr/local/lib", "/opt",     "/Library"};
+  const auto s = p.string();
+  return std::ranges::any_of(
+      kRoots, [&](std::string_view r) { return s.starts_with(r); });
+}
+
+}  // namespace
+
+// Audits the prelude header tree: each input clang opens while building the
+// PCH must fall into one of two coverage categories. If a new include slips
+// in from a third-party root, CI flags it here rather than letting it become
+// a silent staleness hole.
+TEST(PchCoverage, EveryInputIsCovered) {
+  std::string err;
+  std::unique_ptr<Runfiles> runfiles{Runfiles::CreateForTest(&err)};
+  ASSERT_TRUE(runfiles) << err;
+
+  const std::filesystem::path lyra_exe = runfiles->Rlocation("_main/lyra");
+  ASSERT_FALSE(lyra_exe.empty());
+
+  auto loc_or = lyra::driver::ResolveRuntimeLocation(lyra_exe.string());
+  ASSERT_TRUE(loc_or) << loc_or.error();
+
+  auto cxx_or = lyra::support::ResolveCxxCompiler();
+  ASSERT_TRUE(cxx_or) << cxx_or.error();
+  if (cxx_or->filename().string().find("clang") == std::string::npos) {
+    GTEST_SKIP() << "audit requires clang-based $CXX (resolved: "
+                 << cxx_or->string() << ")";
+  }
+
+  const auto prelude = loc_or->include_root / "lyra/runtime/prelude.hpp";
+  const std::vector<std::string> args = {
+      "-std=c++23",   "-H",
+      "-I",           loc_or->include_root.string(),
+      "-xc++-header", prelude.string(),
+      "-o",           "/dev/null"};
+
+  auto result_or = lyra::support::RunProcessCaptured(*cxx_or, args);
+  ASSERT_TRUE(result_or) << result_or.error();
+  ASSERT_EQ(result_or->exit_code, 0) << "PCH-trace build failed:\n"
+                                     << result_or->stderr_text;
+
+  const auto headers = ParseHeaderTrace(result_or->stderr_text);
+  ASSERT_FALSE(headers.empty())
+      << "clang -H produced no header trace; parsing logic is likely stale";
+
+  std::vector<std::filesystem::path> uncovered;
+  for (const auto& h : headers) {
+    if (IsFingerprintCovered(h, loc_or->include_root)) continue;
+    if (IsSystemPath(h)) continue;
+    uncovered.push_back(h);
+  }
+
+  if (uncovered.empty()) return;
+
+  std::string msg = std::format(
+      "PCH opened {} header(s) that are neither under include_root "
+      "({}) nor in a recognized system path:\n",
+      uncovered.size(), loc_or->include_root.string());
+  for (const auto& u : uncovered) {
+    msg += std::format("  {}\n", u.string());
+  }
+  msg +=
+      "Either relocate them under include_root (so the content "
+      "fingerprint covers them) or extend tests/pch_audit_test.cpp's "
+      "IsSystemPath to recognize their root.";
+  FAIL() << msg;
+}


### PR DESCRIPTION
## Summary

Cache the runtime-header parse that every emitted main.cpp pays at C++ compile time by routing compilation through a precompiled header. The PCH cache filename is content-addressed (clang identity + include-root path + every header's content), so any compiler upgrade, runtime swap, or header edit produces a different filename and the cache stays coherent without trusting mtimes for its core invalidation. A bazel-side audit test proves every input clang opens while building the PCH is either covered by that fingerprint (lyra-owned headers) or by clang's default load-time mtime check (system headers), so coverage drift surfaces as a CI failure rather than a silent staleness hole. The first commit lightens the include surface and isolates a runtime-side simulation entry point so the emitted main.cpp stops pulling `<iostream>` / `<exception>` through every translation unit.

## Design

`pch::Options` is the single explicit value driving cache behavior. `--no-pch` and `--pch-cache-dir` are CLI-level flags; the `LYRA_NO_PCH` environment hint is read once at the CLI boundary and folded into `Options.disabled` there. Lower layers (`CompileProgram`, `BuildProject`, `RunInPlace`, `pch::EnsureCached`, `pch::Clear`) take `Options` by const reference and never touch the environment. The lyra test framework hands `--pch-cache-dir $TEST_TMPDIR/lyra-pch` to every spawned `lyra run`, so PCH artifacts share across a shard's many cases without leaking into the user's home cache or contending across parallel shards. `lyra cache clear` removes every cache entry in the resolved directory; the emitted `build.sh` carries an equivalent shell-side PCH block that honors the same `LYRA_NO_PCH` hint and falls back to plain compilation if `$CXX` is not clang or `sha1sum` is unavailable.

## Testing

`bazel test //...` (16-way sharded). cpp_tests went from ~272s wall clock without PCH to ~124s with PCH and the content fingerprint active; the new `//tests:pch_audit_test` verifies every header the prelude pulls in is either inside the include root (fingerprint-covered) or under a recognized system path (clang-mtime-covered).