### PR TITLE
Resolve cross-unit references via registered by-name slots

### DIFF
--- a/docs/architecture/compilation_unit_model.md
+++ b/docs/architecture/compilation_unit_model.md
@@ -68,6 +68,11 @@ Define what a compilation unit is, what it owns, and the rules that make it self
   table.
 - Compiling one unit against another unit's body or internal ids instead of against its interface
   (name and signature).
+- A unit that knows or enumerates the units that reference it: a consumer/referrer list, a back-edge
+  from a member to the references that read it, or code that resolves a reference on a referrer's
+  behalf by pushing its own member outward. A unit produces only its own interface from its own
+  contents; who depends on that interface is not part of the unit and is never visible to it.
+  Resolution is always pulled by the referrer, never pushed by the target.
 - Treating "the design" as a compilation unit.
 - Treating the frontend as the authority for compilation-unit identity, membership, or boundary. The
   frontend is input; the compiler is authority.

--- a/docs/architecture/emission_model.md
+++ b/docs/architecture/emission_model.md
@@ -72,10 +72,11 @@ non-conforming code, not as a relaxation of the contract.
      the upward reference.
 6. **A unit exposes its hierarchically reachable signals and owned children through the SDK.** So
    that an upward referrer (which cannot name the ancestor's or an intervening child's type) can
-   reach a signal in an ancestor found only at runtime, each unit makes its reachable signals and
-   its owned children available by name through a uniform SDK surface on the object graph node -- a
-   child step indexes the owner's own storage. The referrer walks that surface once at construction
-   and stores the direct reference; it never embeds another unit's layout.
+   reach a signal in an ancestor found only at runtime, each unit registers its reachable signals
+   and its owned children by name into the object graph node during construction, and the base SDK
+   answers a by-name query from those registrations -- the unit never inspects who asks, and the
+   dispatch is one generic scan, not a per-unit synthesized branch. The referrer walks that surface
+   once at construction and stores the direct reference; it never embeds another unit's layout.
 
 ## Boundary to Adjacent Layers
 

--- a/docs/architecture/reference_resolution.md
+++ b/docs/architecture/reference_resolution.md
@@ -81,6 +81,18 @@ The same resolution serves both accessing the target's value and observing its c
 
 - Compiled body code that bakes in another unit's layout to resolve a cross-unit reference at
   compile time.
+- Resolving a cross-unit reference from the target's side: the referenced unit wiring, pushing, or
+  storing its own member into the units that reference it. A unit compiles against its own interface
+  and cannot know who references it, so it never drives resolution for a consumer and never carries
+  a list of its referrers. Every cross-unit reference -- downward or upward -- is driven by the
+  referrer, which reaches the target by name at construction; the target only answers by-name
+  queries about its own interface.
+- The referrer reaching a cross-unit target by typed member access into the other unit's body
+  (naming the other unit's members, fields, or child types) instead of by name against its
+  interface. Typed access bakes the target unit's layout into the referrer and breaks independent
+  compilation -- this holds even for a downward reference whose referrer instantiated the target,
+  and even when the access is evaluated at construction rather than compile time. The referrer knows
+  the target's name, never its layout.
 - A resolution path for ports that is distinct from the one for hierarchical references. Two
   mechanisms for cross-unit access is the canonical violation.
 - Resolving a cross-unit reference by flattened symbol-name lookup or a design-global path table

--- a/docs/decisions/upward-reference-resolution.md
+++ b/docs/decisions/upward-reference-resolution.md
@@ -116,14 +116,18 @@ The match key is the ancestor's **module definition name**, read from the resolv
 (`path[0].symbol`'s definition name) -- a semantic value, never from source syntax (a wrapped
 sub-expression like `Top.g[3]` may carry no syntax at all). It is class-level: every instance of the
 referring module shares the same module name, so one artifact serves all depths. At runtime the
-climb compares it against each ancestor's instance name (`Scope::Name()`) **or** module definition
-name (`Scope::DefName()`); a module-name reference (`Top.g`) matches the ancestor whose `DefName()`
-is `"Top"`, including the aliased `module Tb; Top dut();` where the instance name is `dut`. The one
-form this does not yet honor is LRM 23.9 instance-name precedence: a reference written as an
-**instance** name (`u_mid.s`) keys on the module name too, so with several instances of that module
-nesting on the chain it can bind the nearer one. That is a known gap (`docs/progress/hierarchy.md`
-D2d) -- the resolved AST gives the ancestor's name and definition name, but not which form the
-source wrote, and recovering that needs the source token the elaborated AST does not retain.
+climb compares it against each ancestor's module definition name (`Scope::DefName()`) alone; a
+module-name reference (`Top.g`) matches the ancestor whose `DefName()` is `"Top"`, including the
+aliased `module Tb; Top dut();` where the instance name is `dut`. The climb deliberately does
+**not** also match an ancestor's instance name (`Scope::Name()`): the key is always a definition
+name, so an instance-name match would only ever fire on a nearer ancestor whose instance name
+happens to equal that definition name (an instance literally named `M` when the target is module
+`M`), binding the wrong object. The one form this does not yet honor is LRM 23.9 instance-name
+precedence: a reference written as an **instance** name (`u_mid.s`) keys on the module name too, so
+with several instances of that module nesting on the chain it can bind the nearer one. That is a
+known gap (`docs/progress/hierarchy.md` D2d) -- the resolved AST gives the ancestor's name and
+definition name, but not which form the source wrote, and recovering that needs the source token the
+elaborated AST does not retain.
 
 Once the ancestor is found, the reference may still descend into the ancestor's subtree before
 reaching the leaf (`Top.sib.y` climbs to `Top`, then steps down into the owned child `sib`). That
@@ -151,10 +155,10 @@ construction. Concretely:
 
 2. **The ancestor (`path[0]`) is matched by its module definition name, and the signal is fetched by
    name.** The key is the resolved ancestor's module name (a semantic value, never from syntax). The
-   climb compares it against each ancestor's `Scope::Name()` or `Scope::DefName()` and stops at the
-   nearest match, then calls `Scope::GetSignal(<signal>)` to obtain the leaf and casts the returned
-   `void*` to the member's own declared cell type. No `dynamic_cast` retry loop, and no cast to the
-   ancestor's type. (Instance-name precedence, LRM 23.9, is a known gap -- see F7.)
+   climb compares it against each ancestor's `Scope::DefName()` and stops at the nearest match, then
+   calls `Scope::GetSignal(<signal>)` to obtain the leaf and casts the returned `void*` to the
+   member's own declared cell type. No `dynamic_cast` retry loop, and no cast to the ancestor's
+   type. (Instance-name precedence, LRM 23.9, is a known gap -- see F7.)
 
 3. **The climb walks only the direct ancestor line.** It never steps into a sibling. A sibling or
    cousin target is the downward tail (`path[1..]`) applied from the ancestor, using the existing
@@ -189,8 +193,8 @@ construction. Concretely:
    };
    ```
 
-   The walk -- climb the parent chain by `Name()`/`DefName()` to the ancestor, step down any tail
-   through `Scope::GetChild`, then `Scope::GetSignal` the leaf -- lives once in the runtime SDK
+   The walk -- climb the parent chain by `DefName()` to the ancestor, step down any tail through
+   `Scope::GetChild`, then `Scope::GetSignal` the leaf -- lives once in the runtime SDK
    (`Scope::ResolveUpwardScope` plus the by-name `GetChild`/`GetSignal` surface), driven by
    `ExternUp<T>::Relocate` at Bind. The referrer carries the reference as an ordinary member whose
    type is `ExternalRef<T>` (the symbol rides on the type); reads, writes, and sensitivity are the
@@ -209,10 +213,10 @@ construction. Concretely:
 - **Multiple depths work with one artifact and no specialization.** The same module climbs to the
   correct ancestor whether the ancestor is one or several levels up; depth is never represented as a
   number anywhere.
-- **The match keys are the runtime instance name and module definition name (`Scope::Name()` /
-  `Scope::DefName()`).** The `ExternalRef` type carries only the match key, the by-name tail down
-  through the ancestor's owned children, and the leaf signal name (the `GetSignal` argument); it
-  carries no ancestor or child type, so the referrer's artifact stays self-contained.
+- **The match key is the ancestor's module definition name (`Scope::DefName()`).** The `ExternalRef`
+  type carries only the match key, the by-name tail down through the ancestor's owned children, and
+  the leaf signal name (the `GetSignal` argument); it carries no ancestor or child type, so the
+  referrer's artifact stays self-contained.
 - **The climb is a construction-time loop, run once per extern member.** It is never on the
   simulation hot path, which reads the stored pointer.
 - **Upward references are not unified with `ref` ports.** A `ref` port is supplied by the parent
@@ -220,7 +224,6 @@ construction. Concretely:
   parent cannot know about it. Both are cross-unit references resolved at construction, but their
   head resolution differs by necessity.
 - **Out of scope, guarded explicitly:** an upward reference written inside a generate block; a
-  `$root`-anchored absolute path; an upward reference through an interface port; an ancestor that is
-  a named generate or procedural block rather than a module instance (such a scope does not yet
-  expose itself as a climb-match target with `GetSignal`); and the corner where a nearer ancestor
-  carries the same instance name as the named one.
+  `$root`-anchored absolute path; an upward reference through an interface port; and an ancestor
+  that is a named generate or procedural block rather than a module instance (such a scope does not
+  yet expose itself as a climb-match target with `GetSignal`).

--- a/docs/decisions/upward-reference-resolution.md
+++ b/docs/decisions/upward-reference-resolution.md
@@ -133,15 +133,15 @@ Once the ancestor is found, the reference may still descend into the ancestor's 
 reaching the leaf (`Top.sib.y` climbs to `Top`, then steps down into the owned child `sib`). That
 tail is by-name too, for the same reason the climb is: the referrer owns neither the ancestor nor
 its children, so it cannot navigate by typed pointer. Each step asks the current scope for an owned
-child through `Scope::GetChild` -- the twin of `GetSignal` for the object tree, which the owner
-answers by indexing its own storage (an array hop is the owner's own `vector` subscript, never a
-re-derived offset). The final leaf is fetched with `Scope::GetSignal("y")`, which the ancestor's own
-emitted code answers by returning a pointer to its own member. The referrer casts the returned
-`void*` to its own `Var<T>` cell type -- a type it already knows from its declaration -- never to
-the ancestor's type. When the leaf sits directly on the ancestor the tail is empty, the zero-case of
-the same walk. The by-name SDK realization (`DefName`, `GetSignal`, `GetChild`, the
-construction-time climb) is owned by `emission_model.md`; this record fixes only the resolution
-strategy, not its emitted shape.
+child through `Scope::GetChild` -- the twin of `GetSignal` for the object tree. The owner does not
+answer with per-unit code: it registered each owned child by name during construction (an array
+element under its per-dimension indices, never a re-derived offset), and the base `Scope` returns
+the match. The final leaf is fetched with `Scope::GetSignal("y")`, answered the same way from the
+ancestor's registered signals. The referrer casts the returned `void*` to its own `Var<T>` cell type
+-- a type it already knows from its declaration -- never to the ancestor's type. When the leaf sits
+directly on the ancestor the tail is empty, the zero-case of the same walk. The by-name SDK
+realization (`DefName`, `GetSignal`, `GetChild`, the construction-time climb) is owned by
+`emission_model.md`; this record fixes only the resolution strategy, not its emitted shape.
 
 ## Decision
 
@@ -180,18 +180,19 @@ construction. Concretely:
      Var<int> g;
      unique_ptr<Sib> sib;
      unique_ptr<Leaf> l;
-     Top(...) { ... }                                   // knows nothing about Leaf's g / s
+     Top(...) {                                         // knows nothing about Leaf's g / s
+       ...
+       RegisterSignal("g", &g);                         // records its own by-name interface
+       RegisterChild("sib", {}, *sib);                  // (an array element: RegisterChild("bank", {i}, *bank[i]))
+     }
      string_view DefName() const override { return "Top"; }
-     void* GetSignal(string_view n) override {          // answers for its own signals
-       if (n == "g") return &g;
-       return nullptr;
-     }
-     Scope* GetChild(ChildRef ref) override {           // answers for its own children
-       if (ref.name == "sib") return sib.get();         // (an array hop: bank.at(ref.indices[0]))
-       return nullptr;
-     }
    };
    ```
+
+   `GetSignal` / `GetChild` are not per-unit overrides: every scope records its own signals and
+   owned children by name into the base `Scope` during construction, and the base answers a by-name
+   query from those registrations -- so a unit never inspects who asks, and the dispatch is one
+   generic scan, not a synthesized per-unit `if`-chain.
 
    The walk -- climb the parent chain by `DefName()` to the ancestor, step down any tail through
    `Scope::GetChild`, then `Scope::GetSignal` the leaf -- lives once in the runtime SDK

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -90,10 +90,10 @@ Unlocks `instantiation/multiple_instances`, `instantiation/nested_hierarchy`,
 
 - [x] C1 -- Cross-unit references resolve once at construction into a stored direct reference, read
       directly thereafter (per `reference_resolution.md`). This is the substrate Stages D and E
-      consume. Landed for downward references at any depth: the slot's recipe is a navigation path
-      from a local child member down to the referenced leaf, materialized once after the subtree is
-      built. The resolve-once slot is the shared path ports will populate; upward resolution feeds
-      the same slot in a later cut.
+      consume. Landed for downward references at any depth: the slot is filled once, after the
+      subtree is built, by navigating from the referrer's own child down to the referenced leaf. The
+      resolve-once slot is the shared path ports will populate; upward resolution feeds the same
+      slot in a later cut.
 - [x] C2 -- A process on one instance can observe a member of another instance and re-evaluate when
       that member changes, without the observed instance knowing who watches it (cross-instance
       sensitivity). The combinational process subscribes through the resolved slot, independent of
@@ -118,8 +118,9 @@ consume. Coverage is demonstrated through Stage D and Stage E.
       `Top.mid.deep.z`, `Top.bank[2].y`): the climb reaches the ancestor, then the reference steps
       down by name into the ancestor's owned children to the leaf, at any depth and through array
       indices. The tail is by-name for the same reason the climb is -- the referrer owns neither the
-      ancestor nor its children -- so each owner answers for its own children, indexing its own
-      storage. A leaf directly on the ancestor is the empty-tail zero-case of the same walk.
+      ancestor nor its children -- so each owner answers for its own children from the names it
+      registered at construction. A leaf directly on the ancestor is the empty-tail zero-case of the
+      same walk.
 - [x] D2b -- An upward reference written inside a generate block (conditional or loop) rather than
       the module body. It resolves the same as one in the module body -- its member rides the
       generate-block scope and climbs that object's own parent chain -- including an upward write,

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -120,7 +120,11 @@ consume. Coverage is demonstrated through Stage D and Stage E.
       indices. The tail is by-name for the same reason the climb is -- the referrer owns neither the
       ancestor nor its children -- so each owner answers for its own children, indexing its own
       storage. A leaf directly on the ancestor is the empty-tail zero-case of the same walk.
-- [ ] D2b -- An upward reference written inside a generate block rather than the module body.
+- [x] D2b -- An upward reference written inside a generate block (conditional or loop) rather than
+      the module body. It resolves the same as one in the module body -- its member rides the
+      generate-block scope and climbs that object's own parent chain -- including an upward write,
+      per-iteration members in a loop block, and several blocks naming the same ancestor signal
+      (each block gets its own resolution within its own scope).
 - [ ] D2c -- An upward reference whose first component is not a module instance: a named generate or
       procedural block, or a `$root`-anchored absolute path.
 - [ ] D2d -- LRM 23.9 instance-name precedence: when the first component is written as an instance
@@ -146,9 +150,10 @@ consume. Coverage is demonstrated through Stage D and Stage E.
       alternative was instantiated. Landed for a reference whose head reaches the generate from its
       owning scope or from outside: an upward reference whose downward tail enters the generate, and
       a reference from the scope that owns the generate descending into its own block (loop and
-      conditional forms, and regardless of whether the reference precedes the generate in source).
-      Still open: a reference originating inside a generate block that names a signal in an
-      enclosing scope.
+      conditional forms, and regardless of whether the reference precedes the generate in source);
+      and a reference originating inside a generate block (see D2b). Still open: a reference from an
+      enclosing scope descending into a _child instance's_ generate block (e.g. `leaf.g.x` from the
+      parent), which the downward path does not yet navigate by name across the generate boundary.
 
 Unlocks `refs/hierarchical_refs`, `refs/upward_refs`, and `instantiation/hierarchical_sensitivity`.
 

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -143,17 +143,16 @@ consume. Coverage is demonstrated through Stage D and Stage E.
       object-tree ownership.
 - [x] D6 -- A hierarchical path that indexes an instance array (`c[i].x`) resolves to the selected
       element, including multi-dimensional arrays (`c[i][j].x`).
-- [ ] D7 -- A hierarchical reference crosses a generate-block scope boundary. A by-name reference
+- [x] D7 -- A hierarchical reference crosses a generate-block scope boundary. A by-name reference
       reaches a generate block by its LRM name (the source label, or `genblk<n>` when unnamed, LRM
       27.6), indexes a loop-generate block, and continues to a signal or a further child inside it;
       when an if/case construct's alternatives share a name (LRM 27.5) the reference binds whichever
-      alternative was instantiated. Landed for a reference whose head reaches the generate from its
-      owning scope or from outside: an upward reference whose downward tail enters the generate, and
-      a reference from the scope that owns the generate descending into its own block (loop and
-      conditional forms, and regardless of whether the reference precedes the generate in source);
-      and a reference originating inside a generate block (see D2b). Still open: a reference from an
-      enclosing scope descending into a _child instance's_ generate block (e.g. `leaf.g.x` from the
-      parent), which the downward path does not yet navigate by name across the generate boundary.
+      alternative was instantiated. Covered for every head: an upward reference whose downward tail
+      enters the generate; a reference from the scope that owns the generate descending into its own
+      block (and regardless of whether the reference precedes the generate in source); a reference
+      originating inside a generate block (see D2b); and a reference from an enclosing scope into a
+      child instance's generate block (`leaf.g.x`, `leaf.bank[i].y`, and deeper through an instance
+      inside the block).
 
 Unlocks `refs/hierarchical_refs`, `refs/upward_refs`, and `instantiation/hierarchical_sensitivity`.
 

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -108,8 +108,9 @@ consume. Coverage is demonstrated through Stage D and Stage E.
 - [x] D2 -- An upward reference reads and writes a signal directly on the matched ancestor, at any
       depth. The child cannot know its depth when compiled, so it resolves the reference at
       construction inside its own artifact: it climbs its parent chain to the ancestor named by the
-      reference (matching an instance or module name, LRM 23.8) and fetches the signal by name,
-      naming no ancestor type (see `docs/decisions/upward-reference-resolution.md`,
+      reference (matching the module name, LRM 23.8; a nearer ancestor whose instance name happens
+      to equal that module name does not shadow the target) and fetches the signal by name, naming
+      no ancestor type (see `docs/decisions/upward-reference-resolution.md`,
       `docs/architecture/emission_model.md`). A reference wrapped in a value-level operation
       (`Top.g[3]`, `Top.g + 1`) works -- the value part is ordinary expression handling. The
       remaining forms below are each rejected with a clean "unsupported" diagnostic, except D2d.

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -201,6 +201,32 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       migration; the backend is `~80%` aligned today but moving the last 20% requires touching every
       renderer in one pass. **Trigger**: scheduled with R9 and R10.
 
+- [ ] R10 -- Model the observable (`Var<T>`) storage as a first-class MIR wrapper type so the cpp
+      backend stops re-deriving "is this observable storage" at render time. Today a signal's MIR
+      type is its value type (`PackedArray`, `string`, ...); whether the field is stored as
+      `lyra::runtime::Var<T>` is a backend predicate (`IsObservableScalarType`) computed at render
+      and consulted at every value access -- the field declaration wraps in `Var<T>`, a read appends
+      `.Get()`, a write routes through `.Set()` / `.Mutate()`, and sensitivity subscribes to the
+      cell. `Var<T>` is a template storage wrapper exactly analogous to the `unique_ptr` / `vector`
+      wrappers MIR already models as `PointerType` / `VectorType`, yet it has no MIR type of its
+      own, so the backend keeps asking the value type "are you observable?" in several places
+      instead of reading a concept off the type. Target shape: a first-class observable wrapper type
+      in MIR (sibling to `PointerType` / `VectorType`); a signal field's type becomes that wrapper,
+      `RenderTypeAsCpp` maps it straight to `Var<T>`, and every value access becomes a mechanical
+      switch on the wrapper variant (a read unwraps to the value type, a write targets the cell)
+      rather than an `IsObservableScalarType` call. The one wrinkle the pointer / vector wrappers do
+      not have is the value/storage duality -- a signal is also read as a value, so the wrapper read
+      must unwrap to `T` -- which the read / write nodes resolve by switching on the wrapper type.
+      The backend then never asks "is this observable" anywhere; the type carries it, and render is
+      a pure structural map. **Why deferred**: orthogonal to the cross-unit hierarchical-reference
+      work in flight; it cross-cuts all signal value access (field declaration, read, write,
+      sensitivity) and is its own focused cut, and the current predicate is behaviorally correct.
+      **Trigger**: standalone -- highest leverage taken together with R2, which reworks the same
+      `IsObservableScalarType` decision from the capability-gating angle (wrap every value type
+      uniformly, push unsupported change-tracking to explicit diagnostics). R10 makes the wrapper a
+      type; R2 makes the wrap uniform and capability-honest -- done together they remove
+      `IsObservableScalarType` entirely and leave the backend a pure renderer.
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/backend/cpp/formatting.hpp
+++ b/include/lyra/backend/cpp/formatting.hpp
@@ -12,14 +12,6 @@ namespace lyra::backend::cpp {
   return result;
 }
 
-// Member name for a cross-unit reference slot: the resolved `Var<T>*` the
-// constructor points at the child's member. The same name backs the slot's
-// declaration, its constructor resolution, and every read / write / subscribe.
-[[nodiscard]] inline auto CrossUnitRefSlotName(std::uint32_t slot)
-    -> std::string {
-  return "xref_" + std::to_string(slot);
-}
-
 // Member name of a static-lifetime body local inside its per-instance
 // `_StaticFrame`. Flattening nested blocks into one frame can repeat an SV name
 // (same identifier in sibling or nested blocks), so the frame-scope var id is

--- a/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
@@ -219,8 +219,9 @@ class ModuleLowerer {
   auto AddType(hir::TypeData data) -> hir::TypeId;
   // Cross-unit ref dedup lookup. Private: TranslateSensitivityReads is the
   // only caller; external code uses MapOrGetCrossUnitRef.
-  [[nodiscard]] auto LookupCrossUnitRef(const slang::ast::ValueSymbol& target)
-      const -> std::optional<hir::CrossUnitRefId>;
+  [[nodiscard]] auto LookupCrossUnitRef(
+      ScopeFrameId frame, const slang::ast::ValueSymbol& target) const
+      -> std::optional<hir::CrossUnitRefId>;
 
   // Facts.
   LoweringFacts facts_;
@@ -236,7 +237,12 @@ class ModuleLowerer {
   SubroutineBindings subroutine_bindings_;
   LoopVarBindings loop_var_bindings_;
   OwnedChildBindings owned_child_bindings_;
-  std::unordered_map<const slang::ast::ValueSymbol*, hir::CrossUnitRefId>
+  // Dedup by (home_frame, target): the slot id is an index within a scope's
+  // own `cross_unit_refs`, so two scopes referencing the same member each need
+  // their own slot.
+  std::map<
+      ScopeFrameId,
+      std::unordered_map<const slang::ast::ValueSymbol*, hir::CrossUnitRefId>>
       cross_unit_ref_dedup_;
   std::map<ScopeFrameId, std::vector<hir::CrossUnitRefDecl>>
       cross_unit_refs_by_frame_;

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -240,13 +240,6 @@ class StructuralScopeLoweringState {
     return scope_->GetStructuralVar(id);
   }
 
-  auto AddCrossUnitRef(mir::CrossUnitRefDecl decl) -> mir::CrossUnitRefId {
-    const mir::CrossUnitRefId id{
-        static_cast<std::uint32_t>(scope_->cross_unit_refs.size())};
-    scope_->cross_unit_refs.push_back(std::move(decl));
-    return id;
-  }
-
   auto AddStructuralParam(mir::StructuralParamDecl param)
       -> mir::StructuralParamId {
     const mir::StructuralParamId id{
@@ -283,9 +276,9 @@ class StructuralScopeLoweringState {
   }
 
   // Records the MIR target each HIR cross-unit ref slot lowers to, in HIR slot
-  // order: an upward ref materializes as a StructuralVarRef to a synthesized
-  // ExternalRef member, a downward ref keeps a CrossUnitVarRef. Reads and
-  // sensitivity resolve a slot through this table.
+  // order: a StructuralVarRef to the slot member -- a synthesized ExternalRef
+  // member for an upward ref, a borrowed-pointer slot for a downward ref. Reads
+  // and sensitivity resolve a slot through this table.
   void AddCrossUnitRefTarget(mir::SensitivityRef target) {
     cross_unit_ref_targets_.push_back(std::move(target));
   }

--- a/include/lyra/lowering/hir_to_mir/state.hpp
+++ b/include/lyra/lowering/hir_to_mir/state.hpp
@@ -235,6 +235,11 @@ class StructuralScopeLoweringState {
     return id;
   }
 
+  [[nodiscard]] auto GetStructuralVar(mir::StructuralVarId id) const
+      -> const mir::StructuralVarDecl& {
+    return scope_->GetStructuralVar(id);
+  }
+
   auto AddCrossUnitRef(mir::CrossUnitRefDecl decl) -> mir::CrossUnitRefId {
     const mir::CrossUnitRefId id{
         static_cast<std::uint32_t>(scope_->cross_unit_refs.size())};

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -102,9 +102,31 @@ struct ClosureRef {
   ExprId closure{};
 };
 
+enum class RuntimeFn : std::uint8_t {
+  kGetChild,
+  kGetSignal,
+  kRegisterSignal,
+};
+
+// Calls a runtime by-name interface method on a scope handle. `fn` selects the
+// method; `name` is the compile-time signal / child name. Argument 0 is the
+// scope handle the method is invoked on:
+//   - `kGetChild`: the remaining arguments are the per-dimension array indices
+//     (none for a scalar), each a runtime expression; renders
+//     `<scope>->GetChild(name, {indices})`.
+//   - `kGetSignal`: renders `<scope>->GetSignal(name)`.
+//   - `kRegisterSignal`: argument 1 is the signal var whose address is
+//     registered under `name`; renders `<scope>->RegisterSignal(name, &<var>)`.
+//     A scope records its own by-name interface during construction with this.
+// The name and indices are never bundled into one struct.
+struct RuntimeNavCallee {
+  RuntimeFn fn;
+  std::string name;
+};
+
 using Callee = std::variant<
     SystemSubroutineCallee, StructuralSubroutineRef, BuiltinMethodCallee,
-    ClosureRef>;
+    ClosureRef, RuntimeNavCallee>;
 
 struct CallExpr {
   Callee callee;
@@ -124,6 +146,18 @@ using RuntimeCall = std::variant<
 struct RuntimeCallExpr {
   RuntimeCall call;
 };
+
+// Dereferences a borrowed pointer to reach the cell it refers to. An
+// lvalue-producing navigation like ElementSelectExpr; `Expr::type` is the
+// pointee value type.
+struct DerefExpr {
+  ExprId pointer;
+};
+
+// The enclosing scope object (`this` in a method body, `self` in a fork-branch
+// closure). The starting handle of an object-tree navigation; `Expr::type` is a
+// borrowed pointer to ScopeType.
+struct SelfScopeExpr {};
 
 struct ElementSelectExpr {
   ExprId base_value;
@@ -181,8 +215,8 @@ struct ConstructExpr {
 
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, StructuralParamRef,
-    StructuralVarRef, ProceduralVarRef, CrossUnitVarRef, UnaryExpr, BinaryExpr,
-    ConditionalExpr, AssignExpr, IncDecExpr, CallExpr, RuntimeCallExpr,
+    StructuralVarRef, ProceduralVarRef, UnaryExpr, BinaryExpr, ConditionalExpr,
+    AssignExpr, IncDecExpr, CallExpr, RuntimeCallExpr, DerefExpr, SelfScopeExpr,
     ConversionExpr, ClosureExpr, ElementSelectExpr, RangeSelectExpr, ConcatExpr,
     ReplicationExpr, ArrayLiteralExpr, ConstructExpr>;
 

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -120,13 +120,6 @@ struct ConstructExternalUnitStmt {
   std::vector<std::uint32_t> dims;
 };
 
-// Fills downward cross-unit slot `slot` once at construction, after the target
-// child exists: the backend stores a direct reference by navigating the recipe
-// in the enclosing scope's `cross_unit_refs` table (reference_resolution.md).
-struct ResolveCrossUnitRefStmt {
-  CrossUnitRefId slot;
-};
-
 struct ForInitDecl {
   ProceduralVarRef induction_var = {};
   ExprId init = {};
@@ -208,9 +201,9 @@ struct SensitivityWaitStmt {
 
 using StmtData = std::variant<
     EmptyStmt, ProceduralVarDeclStmt, ExprStmt, BlockStmt, ForkStmt, IfStmt,
-    ConstructOwnedObjectStmt, ConstructExternalUnitStmt,
-    ResolveCrossUnitRefStmt, ForStmt, DelayStmt, WhileStmt, DoWhileStmt,
-    BreakStmt, ContinueStmt, ReturnStmt, SensitivityWaitStmt>;
+    ConstructOwnedObjectStmt, ConstructExternalUnitStmt, ForStmt, DelayStmt,
+    WhileStmt, DoWhileStmt, BreakStmt, ContinueStmt, ReturnStmt,
+    SensitivityWaitStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/include/lyra/mir/structural_scope.hpp
+++ b/include/lyra/mir/structural_scope.hpp
@@ -10,27 +10,9 @@
 #include "lyra/mir/structural_scope_id.hpp"
 #include "lyra/mir/structural_subroutine.hpp"
 #include "lyra/mir/structural_var.hpp"
-#include "lyra/mir/type.hpp"
 #include "lyra/mir/type_alias.hpp"
-#include "lyra/mir/type_id.hpp"
-#include "lyra/mir/value_ref.hpp"
 
 namespace lyra::mir {
-
-// A downward cross-unit reference resolved once at construction. The navigation
-// is fully by name across the unit boundary (emission_model.md): `steps` are
-// the owned children fetched in order with `GetChild` -- `steps.front()` is the
-// referrer's own owned child (instance, instance-array, or generate scope), and
-// each later step crosses one boundary deeper -- and `signal` is the leaf of
-// `type`, fetched with `GetSignal` from the last step's scope. Mirrors
-// ExternalRefType's `tail` + `signal`; the navigation structure is resolved
-// here so the backend renders each step mechanically with no path
-// interpretation.
-struct CrossUnitRefDecl {
-  std::vector<ChildStep> steps;
-  std::string signal;
-  TypeId type;
-};
 
 struct StructuralScope {
   std::string name;
@@ -40,7 +22,6 @@ struct StructuralScope {
   TimeResolution time_resolution;
   std::vector<StructuralParamDecl> structural_params;
   std::vector<StructuralVarDecl> structural_vars;
-  std::vector<CrossUnitRefDecl> cross_unit_refs;
   ProceduralScope constructor_scope;
   std::vector<Process> processes;
   std::vector<StructuralScope> child_structural_scopes;
@@ -54,10 +35,6 @@ struct StructuralScope {
   [[nodiscard]] auto GetStructuralVar(StructuralVarId id) const
       -> const StructuralVarDecl& {
     return structural_vars.at(id.value);
-  }
-  [[nodiscard]] auto GetCrossUnitRef(CrossUnitRefId id) const
-      -> const CrossUnitRefDecl& {
-    return cross_unit_refs.at(id.value);
   }
   [[nodiscard]] auto GetProcess(ProcessId id) const -> const Process& {
     return processes.at(id.value);

--- a/include/lyra/mir/structural_scope.hpp
+++ b/include/lyra/mir/structural_scope.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <cstdint>
 #include <string>
-#include <variant>
 #include <vector>
 
 #include "lyra/base/time.hpp"
@@ -12,30 +10,25 @@
 #include "lyra/mir/structural_scope_id.hpp"
 #include "lyra/mir/structural_subroutine.hpp"
 #include "lyra/mir/structural_var.hpp"
+#include "lyra/mir/type.hpp"
 #include "lyra/mir/type_alias.hpp"
 #include "lyra/mir/type_id.hpp"
 #include "lyra/mir/value_ref.hpp"
 
 namespace lyra::mir {
 
-// One step of a cross-unit reference's downward navigation past the head: a
-// named member (`->name`) or an instance-array index (`[index]`).
-struct MemberHop {
-  std::string name;
-};
-struct IndexHop {
-  std::uint32_t index;
-};
-using PathStep = std::variant<MemberHop, IndexHop>;
-
-// A downward cross-unit reference resolved once at construction. `instance_var`
-// is the structural var holding the owned child instance (or instance-array) --
-// the head of the downward path; `path` carries the navigation past the head
-// down to the referenced leaf of `type`. Upward references are not cross-unit
-// refs -- they are ExternalRef members (docs/architecture/emission_model.md).
+// A downward cross-unit reference resolved once at construction. The navigation
+// is fully by name across the unit boundary (emission_model.md): `steps` are
+// the owned children fetched in order with `GetChild` -- `steps.front()` is the
+// referrer's own owned child (instance, instance-array, or generate scope), and
+// each later step crosses one boundary deeper -- and `signal` is the leaf of
+// `type`, fetched with `GetSignal` from the last step's scope. Mirrors
+// ExternalRefType's `tail` + `signal`; the navigation structure is resolved
+// here so the backend renders each step mechanically with no path
+// interpretation.
 struct CrossUnitRefDecl {
-  StructuralVarId instance_var;
-  std::vector<PathStep> path;
+  std::vector<ChildStep> steps;
+  std::string signal;
   TypeId type;
 };
 

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -27,6 +27,7 @@ enum class TypeKind {
   kVoid,
   kObject,
   kExternalUnitObject,
+  kScope,
   kPointer,
   kVector,
   kExternalRef,
@@ -137,6 +138,14 @@ struct ExternalUnitObjectType {
   auto operator==(const ExternalUnitObjectType&) const -> bool = default;
 };
 
+// The runtime object-tree base class `lyra::runtime::Scope`, type-erased. A
+// by-name navigation handle (`GetChild` / `ResolveUpward` result) is a
+// `PointerType{ScopeType, kBorrowed}`; the concrete child class is unknown
+// across the unit boundary, so only the runtime base is named.
+struct ScopeType {
+  auto operator==(const ScopeType&) const -> bool = default;
+};
+
 enum class PointerOwnership {
   kUnique,
   kShared,
@@ -161,9 +170,10 @@ struct VectorType {
 
 // One by-name step from a resolved scope into an owned child it answers for:
 // the child member's name plus one index per array dimension (empty for a
-// scalar child). The ancestor indexes its own storage, so a multi-dimensional
-// instance array is just more indices, never a flattened offset. (Distinct from
-// StructuralHops, which is a count of lexical frames climbed, not a path step.)
+// scalar child). The ancestor answers by name from the children it registered,
+// so a multi-dimensional instance array is just more indices, never a flattened
+// offset. (Distinct from StructuralHops, which is a count of lexical frames
+// climbed, not a path step.)
 struct ChildStep {
   std::string name;
   std::vector<std::uint32_t> indices;
@@ -191,7 +201,7 @@ using TypeData = std::variant<
     PackedArrayType, EnumType, UnpackedArrayType, DynamicArrayType, QueueType,
     AssociativeArrayType, StringType, EventType, RealType, ShortRealType,
     RealTimeType, ChandleType, VoidType, ObjectType, ExternalUnitObjectType,
-    PointerType, VectorType, ExternalRefType>;
+    ScopeType, PointerType, VectorType, ExternalRefType>;
 
 struct Type {
   TypeData data;

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -27,7 +27,7 @@ enum class TypeKind {
   kVoid,
   kObject,
   kExternalUnitObject,
-  kOwningPtr,
+  kPointer,
   kVector,
   kExternalRef,
 };
@@ -137,10 +137,20 @@ struct ExternalUnitObjectType {
   auto operator==(const ExternalUnitObjectType&) const -> bool = default;
 };
 
-struct OwningPtrType {
-  TypeId pointee;
+enum class PointerOwnership {
+  kUnique,
+  kShared,
+  kBorrowed,
+};
 
-  auto operator==(const OwningPtrType&) const -> bool = default;
+// One level of indirection, classified by its lifetime axis: `kUnique` and
+// `kShared` own the pointee (`unique_ptr<T>` / `shared_ptr<T>`); `kBorrowed`
+// owns nothing and only refers (`T*`).
+struct PointerType {
+  TypeId pointee;
+  PointerOwnership ownership;
+
+  auto operator==(const PointerType&) const -> bool = default;
 };
 
 struct VectorType {
@@ -181,7 +191,7 @@ using TypeData = std::variant<
     PackedArrayType, EnumType, UnpackedArrayType, DynamicArrayType, QueueType,
     AssociativeArrayType, StringType, EventType, RealType, ShortRealType,
     RealTimeType, ChandleType, VoidType, ObjectType, ExternalUnitObjectType,
-    OwningPtrType, VectorType, ExternalRefType>;
+    PointerType, VectorType, ExternalRefType>;
 
 struct Type {
   TypeData data;
@@ -201,27 +211,16 @@ struct Type {
 
 class CompilationUnit;
 
-[[nodiscard]] auto IsOwningObjectType(const CompilationUnit& unit, TypeId type)
-    -> bool;
-
-[[nodiscard]] auto IsVectorOfOwningObjectType(
-    const CompilationUnit& unit, TypeId type) -> bool;
-
-[[nodiscard]] auto GetOwnedObjectTarget(
-    const CompilationUnit& unit, TypeId type)
-    -> std::optional<StructuralScopeId>;
-
-enum class OwnedChildKind { kModuleInstance, kGenerateScope };
-
-// The classification of an owned-child member, read off the leaf object type
-// after stripping any vector layers: an intra-unit object is a generate scope
-// (with its target scope), an external-unit object is a module instance.
-struct OwnedChildLeaf {
-  OwnedChildKind kind = OwnedChildKind::kModuleInstance;
-  std::optional<StructuralScopeId> intra_target;
+// A child-scope member, classified by the leaf object type after stripping any
+// vector layers: an intra-unit object is a generate scope (carrying its target
+// scope), an external-unit object is a module instance.
+struct GenerateScopeChild {
+  StructuralScopeId target;
 };
+struct ModuleInstanceChild {};
+using ChildScope = std::variant<GenerateScopeChild, ModuleInstanceChild>;
 
-[[nodiscard]] auto GetOwnedChildLeaf(const CompilationUnit& unit, TypeId type)
-    -> std::optional<OwnedChildLeaf>;
+[[nodiscard]] auto GetChildScope(const CompilationUnit& unit, TypeId type)
+    -> std::optional<ChildScope>;
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/value_ref.hpp
+++ b/include/lyra/mir/value_ref.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#include <compare>
-#include <cstdint>
-#include <variant>
-
 #include "lyra/mir/procedural_hops.hpp"
 #include "lyra/mir/procedural_var.hpp"
 #include "lyra/mir/structural_hops.hpp"
@@ -21,22 +17,10 @@ struct ProceduralVarRef {
   ProceduralVarId var{};
 };
 
-struct CrossUnitRefId {
-  std::uint32_t value;
-
-  auto operator<=>(const CrossUnitRefId&) const
-      -> std::strong_ordering = default;
-};
-
-// A reference into a child instance's member, resolved once at construction
-// into a stored direct reference; the navigation recipe lives in the enclosing
-// scope's `cross_unit_refs` table keyed by this id.
-struct CrossUnitVarRef {
-  CrossUnitRefId id;
-};
-
-// A sensitivity leaf observes either a this-unit structural var or a cross-unit
-// member; both resolve to a stored `Observable` the scheduler subscribes to.
-using SensitivityRef = std::variant<StructuralVarRef, CrossUnitVarRef>;
+// A sensitivity leaf observes a structural var that resolves to a stored
+// `Observable` the scheduler subscribes to: a plain signal, an upward
+// ExternalRef member, or a downward borrowed-pointer slot. All three are
+// StructuralVarRefs; the var's type tells the renderer how to reach the cell.
+using SensitivityRef = StructuralVarRef;
 
 }  // namespace lyra::mir

--- a/include/lyra/runtime/extern_up.hpp
+++ b/include/lyra/runtime/extern_up.hpp
@@ -53,8 +53,7 @@ class ExternUp : public ExternBase {
   void Relocate() override {
     Scope* scope = owner_->ResolveUpwardScope(ancestor_);
     for (const ChildStep& hop : tail_) {
-      scope =
-          scope->GetChild(ChildRef{.name = hop.name, .indices = hop.indices});
+      scope = scope->GetChild(hop.name, hop.indices);
     }
     cell_ = static_cast<Var<T>*>(scope->GetSignal(signal_));
   }

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -52,10 +52,10 @@ class Scope {
   [[nodiscard]] auto Name() const -> std::string_view;
 
   // The scope's module definition name. An upward hierarchical reference climbs
-  // the parent chain matching its first name component against each ancestor's
-  // instance name (`Name()`) or module name (this), since the LRM lets the
-  // first component be either (LRM 23.8). The base never matches; a generated
-  // unit class overrides it.
+  // the parent chain matching against this (LRM 23.8): the referrer's emitted
+  // code keys the climb on the target's definition name, so an ancestor matches
+  // by its definition name, never by its instance name. The base never matches;
+  // a generated unit class overrides it.
   [[nodiscard]] virtual auto DefName() const -> std::string_view {
     return {};
   }
@@ -78,11 +78,12 @@ class Scope {
     return nullptr;
   }
 
-  // Climbs the parent chain to the ancestor whose instance name (`Name()`) or
-  // module name (`DefName()`) is `ancestor` (LRM 23.8) and returns it. The
-  // shared start of an upward reference's runtime navigation; from there an
-  // `ExternUp` member walks any by-name tail and fetches the leaf, once at
-  // Bind.
+  // Climbs the parent chain to the nearest ancestor whose module definition
+  // name (`DefName()`) is `ancestor` and returns it (LRM 23.8). `ancestor` is
+  // always a definition name, so the match is on `DefName()` alone; an ancestor
+  // whose instance name merely equals it does not match. The shared start of an
+  // upward reference's runtime navigation; from there an `ExternUp` member
+  // walks any by-name tail and fetches the leaf, once at Bind.
   [[nodiscard]] auto ResolveUpwardScope(std::string_view ancestor) -> Scope*;
 
   // An `ExternUp` member registers itself here from its constructor; Bind

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -19,14 +19,6 @@ namespace lyra::runtime {
 class RuntimeServices;
 class ExternBase;
 
-// Names one owned child to fetch from a scope: the member name plus one index
-// per array dimension (empty for a scalar child). A non-owning view; the caller
-// keeps the backing storage alive.
-struct ChildRef {
-  std::string_view name;
-  std::span<const std::size_t> indices;
-};
-
 // Returned by a scope that declares no timescale of its own (the synthetic
 // `$root`). The engine's design-global precision minimum ignores it, so a
 // purely structural node does not pull the simulation tick finer.
@@ -60,23 +52,26 @@ class Scope {
     return {};
   }
 
-  // Returns the address of a signal this scope owns by that name, or nullptr if
-  // it has none. An upward reference cannot name its ancestor's type, so it
-  // fetches the signal by name and the ancestor's own class answers
-  // (docs/architecture/emission_model.md).
-  // NOLINTNEXTLINE(readability-named-parameter)
-  [[nodiscard]] virtual auto GetSignal(std::string_view) -> void* {
-    return nullptr;
-  }
+  // Records, during construction, the address of a signal this scope owns under
+  // its source name, and the owned child reachable at `name` plus one index per
+  // array dimension (empty for a scalar). A unit answers by-name queries about
+  // its own interface from these registrations; it never inspects who asks
+  // (reference_resolution.md). `name` points at an emitted string literal; the
+  // indices are copied so the entry outlives the constructor's arguments.
+  void RegisterSignal(std::string_view name, void* address);
+  void RegisterChild(
+      std::string_view name, std::span<const std::size_t> indices,
+      Scope& child);
 
-  // Returns the owned child scope named by `ref`, or nullptr if it has none.
-  // The twin of `GetSignal` for the object tree: a by-name reference cannot
-  // name the child's type, so the owner indexes its own storage and answers
-  // (docs/architecture/emission_model.md).
-  // NOLINTNEXTLINE(readability-named-parameter)
-  [[nodiscard]] virtual auto GetChild(ChildRef) -> Scope* {
-    return nullptr;
-  }
+  // Returns the address of the signal registered under `name`, or the owned
+  // child registered at `name` with `indices`; nullptr if none. A cross-unit
+  // referrer reaches a target by name because it knows the target's type but
+  // not its layout; the owner, which knows its layout, answered at construction
+  // by registering the address. Resolution runs once at construction, never on
+  // the simulation path.
+  [[nodiscard]] auto GetSignal(std::string_view name) -> void*;
+  [[nodiscard]] auto GetChild(
+      std::string_view name, std::span<const std::size_t> indices) -> Scope*;
 
   // Climbs the parent chain to the nearest ancestor whose module definition
   // name (`DefName()`) is `ancestor` and returns it (LRM 23.8). `ancestor` is
@@ -135,12 +130,27 @@ class Scope {
   virtual void CreateProcesses() {
   }
 
+  struct SignalEntry {
+    std::string_view name;
+    void* address;
+  };
+  struct ChildEntry {
+    std::string_view name;
+    std::vector<std::size_t> indices;
+    Scope* scope;
+  };
+
   Scope* parent_ = nullptr;
   std::string name_;
   RuntimeServices* services_ = nullptr;
   // Non-owning child links; the typed members on the derived class own the
   // children. This is the object tree's own structure, not a parallel one.
   std::vector<Scope*> children_;
+  // By-name interface this scope answers cross-unit queries from. Filled during
+  // construction; scanned only at construction-time resolution, never on the
+  // simulation path.
+  std::vector<SignalEntry> signals_;
+  std::vector<ChildEntry> child_entries_;
   std::vector<std::unique_ptr<RuntimeProcess>> processes_;
   // Empty std::function == clean slot; no parallel dirty bitmap needed.
   std::vector<std::function<void()>> observed_pending_;

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -34,12 +34,6 @@ auto RenderField(
   const auto& unit = ctor_ctx.Unit();
   auto type_or = RenderTypeAsCpp(unit, ctor_ctx.StructuralScope(), var.type);
   if (!type_or) return std::unexpected(std::move(type_or.error()));
-  // An owned-child member (a unique_ptr, or a vector of them) is filled in the
-  // constructor body; the field itself is just default-constructed storage, so
-  // it needs no initializer.
-  if (mir::GetChildScope(unit, var.type).has_value()) {
-    return Indent(indent) + *type_or + " " + var.name + ";\n";
-  }
   // An upward reference is an ExternUp member constructed with its symbol --
   // the ancestor name, the by-name tail down through its owned children, and
   // the leaf signal. It registers itself and relocates at Bind, so it has no
@@ -355,88 +349,6 @@ auto RenderScopeAsClass(
            s.name + "\"; }\n";
   }
 
-  // Exposes this scope's own signals by name. A descendant's upward reference
-  // cannot name this unit's type, so it fetches the signal by name and this
-  // unit answers (emission_model.md). Owned-child members and ExternUp members
-  // (this unit's own upward references) are not this unit's signals.
-  {
-    std::string body;
-    for (const auto& v : s.structural_vars) {
-      if (mir::GetChildScope(unit, v.type).has_value()) {
-        continue;
-      }
-      if (std::holds_alternative<mir::ExternalRefType>(
-              unit.GetType(v.type).data)) {
-        continue;
-      }
-      body += Indent(indent + 2) + "if (n == \"" + v.name + "\") return &" +
-              v.name + ";\n";
-    }
-    if (!body.empty()) {
-      out += "\n";
-      out += Indent(indent + 1) +
-             "auto GetSignal(std::string_view n) -> void* override {\n";
-      out += body;
-      out += Indent(indent + 2) + "return nullptr;\n";
-      out += Indent(indent + 1) + "}\n";
-    }
-  }
-
-  // Exposes this scope's owned children by name -- the twin of GetSignal for
-  // the object tree. A by-name reference (an upward reference's tail) cannot
-  // name a child's type, so the owner indexes its own storage and answers
-  // (emission_model.md). These are exactly the members GetSignal skips.
-  {
-    // Group owned children by the name a reference uses; same-name if/else arms
-    // (LRM 27.5) share one key, so a conditional arm is guarded and the group
-    // returns whichever was constructed.
-    std::vector<std::pair<std::string, std::string>> groups;
-    for (const auto& v : s.structural_vars) {
-      const auto child = mir::GetChildScope(unit, v.type);
-      if (!child.has_value()) {
-        continue;
-      }
-      std::string access = v.name;
-      mir::TypeId leaf_type = v.type;
-      std::size_t dim = 0;
-      while (const auto* vec =
-                 std::get_if<mir::VectorType>(&unit.GetType(leaf_type).data)) {
-        access += ".at(ref.indices[" + std::to_string(dim) + "])";
-        leaf_type = vec->element;
-        ++dim;
-      }
-      const bool conditional =
-          std::holds_alternative<mir::GenerateScopeChild>(*child) && dim == 0;
-      const std::string line =
-          conditional ? Indent(indent + 3) + "if (" + v.name + ") return " +
-                            access + ".get();\n"
-                      : Indent(indent + 3) + "return " + access + ".get();\n";
-      const std::string& key = v.source_name.empty() ? v.name : v.source_name;
-      auto it = std::ranges::find(
-          groups, key, &std::pair<std::string, std::string>::first);
-      if (it == groups.end()) {
-        groups.emplace_back(key, line);
-      } else {
-        it->second += line;
-      }
-    }
-    std::string body;
-    for (const auto& [key, lines] : groups) {
-      body += Indent(indent + 2) + "if (ref.name == \"" + key + "\") {\n";
-      body += lines;
-      body += Indent(indent + 2) + "}\n";
-    }
-    if (!body.empty()) {
-      out += "\n";
-      out += Indent(indent + 1) +
-             "auto GetChild(lyra::runtime::ChildRef ref) "
-             "-> lyra::runtime::Scope* override {\n";
-      out += body;
-      out += Indent(indent + 2) + "return nullptr;\n";
-      out += Indent(indent + 1) + "}\n";
-    }
-  }
-
   // Members follow the constructor and methods. They are public so cross-unit
   // references can reach them directly (see reference_resolution.md).
   if (!s.structural_params.empty() || !s.structural_vars.empty()) {
@@ -454,21 +366,6 @@ auto RenderScopeAsClass(
     auto field_or = RenderField(this_anchor, v, indent + 1);
     if (!field_or) return std::unexpected(std::move(field_or.error()));
     out += *field_or;
-  }
-
-  // A downward cross-unit reference slot holds the resolved pointer to a
-  // child's member, mirroring its storage: a `Var<T>*` for an observable
-  // scalar, a plain `T*` otherwise. Filled in the constructor.
-  for (std::size_t i = 0; i < s.cross_unit_refs.size(); ++i) {
-    const auto& cu = s.cross_unit_refs[i];
-    auto type_or = RenderTypeAsCpp(unit, s, cu.type);
-    if (!type_or) return std::unexpected(std::move(type_or.error()));
-    const std::string slot_type = IsObservableScalarType(unit.GetType(cu.type))
-                                      ? "lyra::runtime::Var<" + *type_or + ">*"
-                                      : *type_or + "*";
-    out += Indent(indent + 1) + slot_type + " " +
-           CrossUnitRefSlotName(static_cast<std::uint32_t>(i)) +
-           " = nullptr;\n";
   }
 
   if (s.processes.empty() && s.structural_subroutines.empty()) {

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -37,7 +37,7 @@ auto RenderField(
   // An owned-child member (a unique_ptr, or a vector of them) is filled in the
   // constructor body; the field itself is just default-constructed storage, so
   // it needs no initializer.
-  if (mir::GetOwnedChildLeaf(unit, var.type).has_value()) {
+  if (mir::GetChildScope(unit, var.type).has_value()) {
     return Indent(indent) + *type_or + " " + var.name + ";\n";
   }
   // An upward reference is an ExternUp member constructed with its symbol --
@@ -362,7 +362,7 @@ auto RenderScopeAsClass(
   {
     std::string body;
     for (const auto& v : s.structural_vars) {
-      if (mir::GetOwnedChildLeaf(unit, v.type).has_value()) {
+      if (mir::GetChildScope(unit, v.type).has_value()) {
         continue;
       }
       if (std::holds_alternative<mir::ExternalRefType>(
@@ -392,8 +392,8 @@ auto RenderScopeAsClass(
     // returns whichever was constructed.
     std::vector<std::pair<std::string, std::string>> groups;
     for (const auto& v : s.structural_vars) {
-      const auto leaf = mir::GetOwnedChildLeaf(unit, v.type);
-      if (!leaf.has_value()) {
+      const auto child = mir::GetChildScope(unit, v.type);
+      if (!child.has_value()) {
         continue;
       }
       std::string access = v.name;
@@ -406,7 +406,7 @@ auto RenderScopeAsClass(
         ++dim;
       }
       const bool conditional =
-          leaf->kind == mir::OwnedChildKind::kGenerateScope && dim == 0;
+          std::holds_alternative<mir::GenerateScopeChild>(*child) && dim == 0;
       const std::string line =
           conditional ? Indent(indent + 3) + "if (" + v.name + ") return " +
                             access + ".get();\n"

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -252,20 +252,6 @@ auto RenderStructuralVarReadExpr(
   return *name_or;
 }
 
-// Read-side render for a cross-unit reference: the slot is a resolved
-// `Var<T>*`, so the held value is observed via `->Get()` (integral packed) or
-// a dereference (other storage), mirroring the structural-var read split.
-auto RenderCrossUnitVarReadExpr(
-    const RenderContext& ctx, const mir::Expr& expr,
-    const mir::CrossUnitVarRef& m) -> diag::Result<std::string> {
-  const std::string slot =
-      ctx.MemberPrefix() + CrossUnitRefSlotName(m.id.value);
-  if (ctx.Unit().GetType(expr.type).IsIntegralPacked()) {
-    return slot + "->Get()";
-  }
-  return "(*" + slot + ")";
-}
-
 // Builds the C++ literal that materializes a 1-bit PackedArray of the SV-typed
 // shape carried by `result_ty`. Used to wrap the C++ `bool` result of a
 // real-operand relational / equality / logical operator into the 1-bit
@@ -1040,8 +1026,9 @@ auto RenderValueMethodCall(
   throw InternalError("RenderValueMethodCall: unknown kind");
 }
 
-auto RenderCallExpr(const RenderContext& ctx, const mir::CallExpr& call)
-    -> diag::Result<std::string> {
+auto RenderCallExpr(
+    const RenderContext& ctx, const mir::CallExpr& call,
+    mir::TypeId result_type) -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
           [](const mir::SystemSubroutineCallee&) -> diag::Result<std::string> {
@@ -1148,6 +1135,51 @@ auto RenderCallExpr(const RenderContext& ctx, const mir::CallExpr& call)
             }
             return "(" + *closure_or + ")(" + args + ")";
           },
+          [&](const mir::RuntimeNavCallee& nav) -> diag::Result<std::string> {
+            auto base_or = RenderExpr(ctx, ctx.Expr(call.arguments.at(0)));
+            if (!base_or) return std::unexpected(std::move(base_or.error()));
+            switch (nav.fn) {
+              case mir::RuntimeFn::kGetChild: {
+                std::string indices = "{}";
+                if (call.arguments.size() > 1) {
+                  indices = "std::array{";
+                  for (std::size_t i = 1; i < call.arguments.size(); ++i) {
+                    auto idx_or =
+                        RenderExpr(ctx, ctx.Expr(call.arguments.at(i)));
+                    if (!idx_or)
+                      return std::unexpected(std::move(idx_or.error()));
+                    if (i != 1) indices += ", ";
+                    indices +=
+                        "std::size_t((" + *std::move(idx_or) + ").ToInt64())";
+                  }
+                  indices += "}";
+                }
+                return *base_or + "->GetChild(\"" + nav.name + "\", " +
+                       indices + ")";
+              }
+              case mir::RuntimeFn::kGetSignal: {
+                // GetSignal returns an untyped storage pointer; the call's
+                // result type names the cell, so the cast is fixed by that
+                // type.
+                auto cell_or = RenderTypeAsCpp(
+                    ctx.Unit(), ctx.StructuralScope(), result_type);
+                if (!cell_or)
+                  return std::unexpected(std::move(cell_or.error()));
+                return "static_cast<" + *cell_or + ">(" + *base_or +
+                       "->GetSignal(\"" + nav.name + "\"))";
+              }
+              case mir::RuntimeFn::kRegisterSignal: {
+                // Registers the signal's own cell address under its name; the
+                // var argument renders as a bare lvalue so `&` takes the cell.
+                auto var_or = RenderLhsExpr(
+                    ctx, ctx.Expr(call.arguments.at(1)), std::string_view{});
+                if (!var_or) return std::unexpected(std::move(var_or.error()));
+                return *base_or + "->RegisterSignal(\"" + nav.name + "\", &" +
+                       *var_or + ")";
+              }
+            }
+            throw InternalError("RenderCallExpr: unknown RuntimeFn");
+          },
       },
       call.callee);
 }
@@ -1208,11 +1240,6 @@ auto RenderLhsExpr(
             if (!name) return std::unexpected(std::move(name.error()));
             return *name + std::string{mutate_adapter};
           },
-          [&](const mir::CrossUnitVarRef& r) -> diag::Result<std::string> {
-            return "(*" + ctx.MemberPrefix() +
-                   CrossUnitRefSlotName(r.id.value) + ")" +
-                   std::string{mutate_adapter};
-          },
           [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
             return LookupProceduralVarName(ctx, l);
           },
@@ -1232,6 +1259,11 @@ auto RenderLhsExpr(
             auto suffix = RenderRangeSliceSuffix(ctx, s.offset_expr, s.count);
             if (!suffix) return std::unexpected(std::move(suffix.error()));
             return *base + *suffix;
+          },
+          [&](const mir::DerefExpr& d) -> diag::Result<std::string> {
+            auto ptr = RenderExpr(ctx, ctx.Expr(d.pointer));
+            if (!ptr) return std::unexpected(std::move(ptr.error()));
+            return "(*" + *ptr + ")" + std::string{mutate_adapter};
           },
           [&](const auto&) -> diag::Result<std::string> {
             throw InternalError(
@@ -1263,9 +1295,10 @@ auto LhsRootPrimary(const RenderContext& ctx, const mir::Expr& expr)
   }
 }
 
-// Whether the LHS root is an observable scalar -- a structural var or a
-// cross-unit reference slot whose target is an observable scalar type. A write
-// to such a root routes through `Var::Set` / `Var::Mutate` so subscribers fire.
+// Whether the LHS root is an observable scalar -- a structural var, or a
+// dereferenced borrowed-pointer slot whose pointee is an observable scalar
+// type. A write to such a root routes through `Var::Set` / `Var::Mutate` so
+// subscribers fire.
 auto LhsRootIsObservableScalar(const RenderContext& ctx, const mir::Expr& expr)
     -> bool {
   const mir::Expr& root = LhsRootPrimary(ctx, expr);
@@ -1273,16 +1306,15 @@ auto LhsRootIsObservableScalar(const RenderContext& ctx, const mir::Expr& expr)
     return IsObservableScalarType(ctx.Unit().GetType(
         ctx.StructuralScope().GetStructuralVar(sv->var).type));
   }
-  if (const auto* cu = std::get_if<mir::CrossUnitVarRef>(&root.data)) {
-    return IsObservableScalarType(
-        ctx.Unit().GetType(ctx.StructuralScope().GetCrossUnitRef(cu->id).type));
+  if (std::holds_alternative<mir::DerefExpr>(root.data)) {
+    return IsObservableScalarType(ctx.Unit().GetType(root.type));
   }
   return false;
 }
 
 auto IsLhsBarePrimary(const mir::Expr& expr) -> bool {
   return std::holds_alternative<mir::StructuralVarRef>(expr.data) ||
-         std::holds_alternative<mir::CrossUnitVarRef>(expr.data) ||
+         std::holds_alternative<mir::DerefExpr>(expr.data) ||
          std::holds_alternative<mir::ProceduralVarRef>(expr.data);
 }
 
@@ -1648,6 +1680,13 @@ auto RenderArrayLiteralExpr(
 auto RenderConstructExpr(
     const RenderContext& ctx, const mir::Expr& expr,
     const mir::ConstructExpr& c) -> diag::Result<std::string> {
+  // A pointer value-initializes to null; `nullptr` is the valid spelling of
+  // that (the functional-cast form `T*()` is ill-formed for a raw pointer
+  // type).
+  if (c.args.empty() && std::holds_alternative<mir::PointerType>(
+                            ctx.Unit().GetType(expr.type).data)) {
+    return std::string{"nullptr"};
+  }
   auto type_or = RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), expr.type);
   if (!type_or) return std::unexpected(std::move(type_or.error()));
   std::string out = *type_or + "(";
@@ -1704,6 +1743,20 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
   return rendered_or;
 }
 
+// Read-side render of a borrowed-pointer dereference: the cell is reached with
+// `(*ptr)` and observed via `.Get()` for an integral packed pointee, mirroring
+// the structural-var read split.
+auto RenderDerefExpr(
+    const RenderContext& ctx, const mir::Expr& expr, const mir::DerefExpr& d)
+    -> diag::Result<std::string> {
+  auto ptr_or = RenderExpr(ctx, ctx.Expr(d.pointer));
+  if (!ptr_or) return std::unexpected(std::move(ptr_or.error()));
+  if (ctx.Unit().GetType(expr.type).IsIntegralPacked()) {
+    return "(*" + *ptr_or + ").Get()";
+  }
+  return "(*" + *ptr_or + ")";
+}
+
 auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
     -> diag::Result<std::string> {
   return std::visit(
@@ -1729,9 +1782,6 @@ auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
           [&](const mir::StructuralVarRef& m) -> diag::Result<std::string> {
             return RenderStructuralVarReadExpr(ctx, expr, m);
           },
-          [&](const mir::CrossUnitVarRef& m) -> diag::Result<std::string> {
-            return RenderCrossUnitVarReadExpr(ctx, expr, m);
-          },
           [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
             const std::string name = LookupProceduralVarName(ctx, l);
             return IsReferenceProceduralVar(ctx, l) ? name + ".Get()" : name;
@@ -1755,10 +1805,16 @@ auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
             return RenderConversionExpr(ctx, expr, cv);
           },
           [&](const mir::CallExpr& call) -> diag::Result<std::string> {
-            return RenderCallExpr(ctx, call);
+            return RenderCallExpr(ctx, call, expr.type);
           },
           [&](const mir::RuntimeCallExpr& rc) -> diag::Result<std::string> {
             return RenderRuntimeCallExpr(ctx, rc);
+          },
+          [&](const mir::DerefExpr& d) -> diag::Result<std::string> {
+            return RenderDerefExpr(ctx, expr, d);
+          },
+          [&](const mir::SelfScopeExpr&) -> diag::Result<std::string> {
+            return std::string(ctx.ReceiverObject());
           },
           [&](const mir::ClosureExpr& cl) -> diag::Result<std::string> {
             return RenderClosureExpr(ctx, cl);

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -238,11 +238,17 @@ auto RenderConstructOwnedObjectStmt(
         "ConstructOwnedObjectStmt target is not an owned object var");
   }
   const std::string lhs = ctx.MemberPrefix() + var.name;
+  const std::string reg_name =
+      var.source_name.empty() ? var.name : var.source_name;
   if (std::holds_alternative<mir::VectorType>(
           ctx.Unit().GetType(var.type).data)) {
-    return Indent(indent) + lhs + ".push_back(" + make + ");\n";
+    return Indent(indent) + lhs + ".push_back(" + make + ");\n" +
+           Indent(indent) + ctx.MemberPrefix() + "RegisterChild(\"" + reg_name +
+           "\", std::array{" + lhs + ".size() - 1}, *" + lhs + ".back());\n";
   }
-  return Indent(indent) + lhs + " = " + make + ";\n";
+  return Indent(indent) + lhs + " = " + make + ";\n" + Indent(indent) +
+         ctx.MemberPrefix() + "RegisterChild(\"" + reg_name + "\", {}, *" +
+         lhs + ");\n";
 }
 
 // Materializes an external-unit member by recursing on its type, mirroring the
@@ -269,8 +275,20 @@ auto RenderExternalUnitFill(
     out += Indent(indent) + "}\n";
     return out;
   }
-  return Indent(indent) + lvalue + " = std::make_unique<" + unit_name +
-         ">(this, \"" + label + "\");\n";
+  std::string out = Indent(indent) + lvalue + " = std::make_unique<" +
+                    unit_name + ">(this, \"" + label + "\");\n";
+  std::string idx = "{}";
+  if (depth > 0) {
+    idx = "std::array{";
+    for (std::size_t d = 0; d < depth; ++d) {
+      if (d != 0) idx += ", ";
+      idx += "i" + std::to_string(d);
+    }
+    idx += "}";
+  }
+  out += Indent(indent) + ctx.MemberPrefix() + "RegisterChild(\"" + label +
+         "\", " + idx + ", *" + lvalue + ");\n";
+  return out;
 }
 
 auto RenderConstructExternalUnitStmt(
@@ -280,55 +298,6 @@ auto RenderConstructExternalUnitStmt(
   return RenderExternalUnitFill(
       ctx, ctx.MemberPrefix() + var.name, var.type, s.unit_name, var.name,
       s.dims, 0, indent);
-}
-
-// Emits a `ChildRef` literal for a by-name owned-child hop: the LRM name plus,
-// for an indexed loop block or instance array, the per-dimension indices in a
-// temporary `std::array` whose lifetime spans the surrounding navigation call.
-auto RenderChildRefLiteral(
-    const std::string& name, const std::vector<std::uint32_t>& indices)
-    -> std::string {
-  std::string out = "lyra::runtime::ChildRef{.name = \"" + name + "\"";
-  if (!indices.empty()) {
-    out += ", .indices = std::array<std::size_t, " +
-           std::to_string(indices.size()) + ">{";
-    for (std::size_t i = 0; i < indices.size(); ++i) {
-      if (i != 0) out += ", ";
-      out += std::to_string(indices[i]);
-    }
-    out += "}";
-  }
-  out += "}";
-  return out;
-}
-
-// A downward cross-unit reference resolves by name across the unit boundary
-// (emission_model.md). The navigation is already resolved in MIR -- `steps` are
-// the owned children to fetch with `GetChild` in order, `signal` is the leaf to
-// fetch with `GetSignal` -- so this renders each step mechanically and casts to
-// the slot's own cell type (`Var<T>*` for an observable scalar, `T*`
-// otherwise), a representation fixed by the slot's type.
-auto RenderResolveCrossUnitRefStmt(
-    const RenderContext& ctx, const mir::ResolveCrossUnitRefStmt& s,
-    std::size_t indent) -> diag::Result<std::string> {
-  const auto& slot = ctx.StructuralScope().GetCrossUnitRef(s.slot);
-
-  auto elem_or = RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), slot.type);
-  if (!elem_or) return std::unexpected(std::move(elem_or.error()));
-  const std::string cast_type =
-      IsObservableScalarType(ctx.Unit().GetType(slot.type))
-          ? "lyra::runtime::Var<" + *elem_or + ">*"
-          : *elem_or + "*";
-
-  std::string nav = ctx.MemberPrefix();
-  for (const auto& step : slot.steps) {
-    nav += "GetChild(" + RenderChildRefLiteral(step.name, step.indices) + ")->";
-  }
-  nav += "GetSignal(\"" + slot.signal + "\")";
-
-  return Indent(indent) + ctx.MemberPrefix() +
-         CrossUnitRefSlotName(s.slot.value) + " = static_cast<" + cast_type +
-         ">(" + nav + ");\n";
 }
 
 auto RenderForStmtNode(
@@ -404,24 +373,22 @@ auto RenderDoWhileStmtNode(
 auto RenderSensitivityRefPtr(
     const RenderContext& ctx, const mir::SensitivityRef& ref)
     -> diag::Result<std::string> {
-  return std::visit(
-      Overloaded{
-          [&](const mir::StructuralVarRef& r) -> diag::Result<std::string> {
-            auto name = RenderStructuralVarName(ctx, r);
-            if (!name) return std::unexpected(std::move(name.error()));
-            const auto& var =
-                ctx.StructuralScopeAtHops(r.hops).GetStructuralVar(r.var);
-            if (std::holds_alternative<mir::ExternalRefType>(
-                    ctx.Unit().GetType(var.type).data)) {
-              return *name + ".AsObservable()";
-            }
-            return "&" + *name;
-          },
-          [&](const mir::CrossUnitVarRef& r) -> diag::Result<std::string> {
-            return ctx.MemberPrefix() + CrossUnitRefSlotName(r.id.value);
-          },
-      },
-      ref);
+  auto name = RenderStructuralVarName(ctx, ref);
+  if (!name) return std::unexpected(std::move(name.error()));
+  const auto& var =
+      ctx.StructuralScopeAtHops(ref.hops).GetStructuralVar(ref.var);
+  if (std::holds_alternative<mir::ExternalRefType>(
+          ctx.Unit().GetType(var.type).data)) {
+    return *name + ".AsObservable()";
+  }
+  // A borrowed-pointer slot already holds a `Var<T>*` (= Observable*); the
+  // pointer value is the subscription target, no address-of.
+  if (const auto* ptr =
+          std::get_if<mir::PointerType>(&ctx.Unit().GetType(var.type).data);
+      ptr != nullptr && ptr->ownership == mir::PointerOwnership::kBorrowed) {
+    return *name;
+  }
+  return "&" + *name;
 }
 
 auto RenderSensitivityWaitStmt(
@@ -487,10 +454,6 @@ auto RenderStmt(
           [&](const mir::ConstructExternalUnitStmt& s)
               -> diag::Result<std::string> {
             return RenderConstructExternalUnitStmt(ctx, s, indent);
-          },
-          [&](const mir::ResolveCrossUnitRefStmt& s)
-              -> diag::Result<std::string> {
-            return RenderResolveCrossUnitRefStmt(ctx, s, indent);
           },
           [&](const mir::ForStmt& s) -> diag::Result<std::string> {
             return RenderForStmtNode(ctx, stmt, s, indent);

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -280,27 +280,53 @@ auto RenderConstructExternalUnitStmt(
       s.dims, 0, indent);
 }
 
-// Points the downward slot at the leaf member it references, once the subtree
-// exists: the head var and every intervening instance are owning pointers
-// reached with `->`, and an instance-array hop indexes the owning vector with
-// `[i]` (LRM 23.6 resolved at construction, reference_resolution.md).
+// Emits a `ChildRef` literal for a by-name owned-child hop: the LRM name plus,
+// for an indexed loop block or instance array, the per-dimension indices in a
+// temporary `std::array` whose lifetime spans the surrounding navigation call.
+auto RenderChildRefLiteral(
+    const std::string& name, const std::vector<std::uint32_t>& indices)
+    -> std::string {
+  std::string out = "lyra::runtime::ChildRef{.name = \"" + name + "\"";
+  if (!indices.empty()) {
+    out += ", .indices = std::array<std::size_t, " +
+           std::to_string(indices.size()) + ">{";
+    for (std::size_t i = 0; i < indices.size(); ++i) {
+      if (i != 0) out += ", ";
+      out += std::to_string(indices[i]);
+    }
+    out += "}";
+  }
+  out += "}";
+  return out;
+}
+
+// A downward cross-unit reference resolves by name across the unit boundary
+// (emission_model.md). The navigation is already resolved in MIR -- `steps` are
+// the owned children to fetch with `GetChild` in order, `signal` is the leaf to
+// fetch with `GetSignal` -- so this renders each step mechanically and casts to
+// the slot's own cell type (`Var<T>*` for an observable scalar, `T*`
+// otherwise), a representation fixed by the slot's type.
 auto RenderResolveCrossUnitRefStmt(
     const RenderContext& ctx, const mir::ResolveCrossUnitRefStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
   const auto& slot = ctx.StructuralScope().GetCrossUnitRef(s.slot);
-  const auto& inst = ctx.StructuralScope().GetStructuralVar(slot.instance_var);
-  std::string out = Indent(indent) + ctx.MemberPrefix() +
-                    CrossUnitRefSlotName(s.slot.value) + " = &" +
-                    ctx.MemberPrefix() + inst.name;
-  for (const auto& step : slot.path) {
-    if (const auto* member = std::get_if<mir::MemberHop>(&step)) {
-      out += "->" + member->name;
-    } else {
-      out += "[" + std::to_string(std::get<mir::IndexHop>(step).index) + "]";
-    }
+
+  auto elem_or = RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), slot.type);
+  if (!elem_or) return std::unexpected(std::move(elem_or.error()));
+  const std::string cast_type =
+      IsObservableScalarType(ctx.Unit().GetType(slot.type))
+          ? "lyra::runtime::Var<" + *elem_or + ">*"
+          : *elem_or + "*";
+
+  std::string nav = ctx.MemberPrefix();
+  for (const auto& step : slot.steps) {
+    nav += "GetChild(" + RenderChildRefLiteral(step.name, step.indices) + ")->";
   }
-  out += ";\n";
-  return out;
+  nav += "GetSignal(\"" + slot.signal + "\")";
+
+  return Indent(indent) + ctx.MemberPrefix() +
+         CrossUnitRefSlotName(s.slot.value) + " = static_cast<" + cast_type +
+         ">(" + nav + ");\n";
 }
 
 auto RenderForStmtNode(

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -231,16 +231,18 @@ auto RenderConstructOwnedObjectStmt(
   const std::string make = "std::make_unique<" + target_scope.name +
                            ">(this, \"" + target_scope.name + "\"" +
                            trailing_args + ")";
-  if (mir::IsVectorOfOwningObjectType(ctx.Unit(), var.type)) {
-    return Indent(indent) + ctx.MemberPrefix() + var.name + ".push_back(" +
-           make + ");\n";
+  const auto child = mir::GetChildScope(ctx.Unit(), var.type);
+  if (!child.has_value() ||
+      !std::holds_alternative<mir::GenerateScopeChild>(*child)) {
+    throw InternalError(
+        "ConstructOwnedObjectStmt target is not an owned object var");
   }
-  if (mir::IsOwningObjectType(ctx.Unit(), var.type)) {
-    return Indent(indent) + ctx.MemberPrefix() + var.name + " = " + make +
-           ";\n";
+  const std::string lhs = ctx.MemberPrefix() + var.name;
+  if (std::holds_alternative<mir::VectorType>(
+          ctx.Unit().GetType(var.type).data)) {
+    return Indent(indent) + lhs + ".push_back(" + make + ");\n";
   }
-  throw InternalError(
-      "ConstructOwnedObjectStmt target is not an owning object var");
+  return Indent(indent) + lhs + " = " + make + ";\n";
 }
 
 // Materializes an external-unit member by recursing on its type, mirroring the

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -102,10 +102,18 @@ auto RenderTypeAsCpp(
           },
           [](const mir::ExternalUnitObjectType& e)
               -> diag::Result<std::string> { return e.unit_name; },
-          [&](const mir::OwningPtrType& o) -> diag::Result<std::string> {
-            auto inner_or = RenderTypeAsCpp(unit, owner_scope, o.pointee);
+          [&](const mir::PointerType& p) -> diag::Result<std::string> {
+            auto inner_or = RenderTypeAsCpp(unit, owner_scope, p.pointee);
             if (!inner_or) return std::unexpected(std::move(inner_or.error()));
-            return "std::unique_ptr<" + *inner_or + ">";
+            switch (p.ownership) {
+              case mir::PointerOwnership::kUnique:
+                return "std::unique_ptr<" + *inner_or + ">";
+              case mir::PointerOwnership::kShared:
+                return "std::shared_ptr<" + *inner_or + ">";
+              case mir::PointerOwnership::kBorrowed:
+                return *inner_or + "*";
+            }
+            throw InternalError("RenderTypeAsCpp: unknown PointerOwnership");
           },
           [&](const mir::VectorType& v) -> diag::Result<std::string> {
             auto inner_or = RenderTypeAsCpp(unit, owner_scope, v.element);

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -102,6 +102,9 @@ auto RenderTypeAsCpp(
           },
           [](const mir::ExternalUnitObjectType& e)
               -> diag::Result<std::string> { return e.unit_name; },
+          [](const mir::ScopeType&) -> diag::Result<std::string> {
+            return std::string{"lyra::runtime::Scope"};
+          },
           [&](const mir::PointerType& p) -> diag::Result<std::string> {
             auto inner_or = RenderTypeAsCpp(unit, owner_scope, p.pointee);
             if (!inner_or) return std::unexpected(std::move(inner_or.error()));
@@ -110,8 +113,16 @@ auto RenderTypeAsCpp(
                 return "std::unique_ptr<" + *inner_or + ">";
               case mir::PointerOwnership::kShared:
                 return "std::shared_ptr<" + *inner_or + ">";
-              case mir::PointerOwnership::kBorrowed:
-                return *inner_or + "*";
+              case mir::PointerOwnership::kBorrowed: {
+                // A borrowed pointer refers to the pointee's storage cell: a
+                // `Var<T>` for an observable scalar, the bare type otherwise
+                // (e.g. a `Scope`), so the slot mirrors what it points at.
+                const std::string storage =
+                    IsObservableScalarType(unit.GetType(p.pointee))
+                        ? "lyra::runtime::Var<" + *inner_or + ">"
+                        : *inner_or;
+                return storage + "*";
+              }
             }
             throw InternalError("RenderTypeAsCpp: unknown PointerOwnership");
           },

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -271,20 +271,14 @@ auto LowerHierarchicalValueProc(
           "instance is not yet supported",
           diag::UnsupportedCategory::kOperation);
     }
-    // The extern member lives on the owning structural scope and the climb
-    // starts from its object. A reference inside a generate block would need
-    // its member on a nested generate class; restrict to the unit root for now.
-    if (frame.Depth() != 1) {
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedExpressionForm,
-          "upward hierarchical reference inside a generate block is not yet "
-          "supported",
-          diag::UnsupportedCategory::kOperation);
-    }
     // The climb key is the ancestor's module name (LRM 23.8) -- class-level, so
     // one artifact serves every instance regardless of depth. It comes from the
     // resolved ancestor symbol, never from syntax (a wrapped sub-expression
-    // like `Top.g[3]` may carry none).
+    // like `Top.g[3]` may carry none). The extern member is synthesized on the
+    // referrer's own structural scope (`frame.Current()`), whether that is the
+    // unit root or a generate block: its `ExternUp` climbs that object's own
+    // parent chain at Bind, so a reference written inside a generate block
+    // resolves the same way (its member rides the generate-scope class).
     std::string ancestor_name{
         head_sym.as<slang::ast::InstanceSymbol>().getDefinition().name};
     return module.MakeCrossUnitMemberRef(

--- a/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
@@ -194,8 +194,8 @@ auto ModuleLowerer::MapOrGetCrossUnitRef(
     const slang::ast::ValueSymbol& target, ScopeFrameId home_frame,
     hir::CrossUnitRefHead head, std::vector<hir::PathStep> path,
     hir::TypeId type) -> hir::CrossUnitRefId {
-  if (const auto it = cross_unit_ref_dedup_.find(&target);
-      it != cross_unit_ref_dedup_.end()) {
+  auto& frame_dedup = cross_unit_ref_dedup_[home_frame];
+  if (const auto it = frame_dedup.find(&target); it != frame_dedup.end()) {
     return it->second;
   }
   auto& slots = cross_unit_refs_by_frame_[home_frame];
@@ -203,14 +203,19 @@ auto ModuleLowerer::MapOrGetCrossUnitRef(
   slots.push_back(
       hir::CrossUnitRefDecl{
           .head = std::move(head), .path = std::move(path), .type = type});
-  cross_unit_ref_dedup_.emplace(&target, id);
+  frame_dedup.emplace(&target, id);
   return id;
 }
 
-auto ModuleLowerer::LookupCrossUnitRef(const slang::ast::ValueSymbol& target)
-    const -> std::optional<hir::CrossUnitRefId> {
-  const auto it = cross_unit_ref_dedup_.find(&target);
-  if (it == cross_unit_ref_dedup_.end()) {
+auto ModuleLowerer::LookupCrossUnitRef(
+    ScopeFrameId frame, const slang::ast::ValueSymbol& target) const
+    -> std::optional<hir::CrossUnitRefId> {
+  const auto fit = cross_unit_ref_dedup_.find(frame);
+  if (fit == cross_unit_ref_dedup_.end()) {
+    return std::nullopt;
+  }
+  const auto it = fit->second.find(&target);
+  if (it == fit->second.end()) {
     return std::nullopt;
   }
   return it->second;
@@ -261,7 +266,7 @@ auto ModuleLowerer::TranslateSensitivityReads(
     // A read of a cross-unit member resolves to the slot that body lowering
     // created for it; subscribing through the slot is what makes always_comb
     // re-trigger on a child's signal.
-    if (const auto slot = LookupCrossUnitRef(*var)) {
+    if (const auto slot = LookupCrossUnitRef(frame.Current(), *var)) {
       out.push_back(
           hir::SensitivityEntry{
               .ref = hir::CrossUnitVarRef{.id = *slot},

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -132,7 +132,7 @@ auto SynthesizeDefaultValueExpr(
                 mir::Expr{
                     .data = mir::ConstructExpr{.args = {}}, .type = type_id});
           },
-          [&](const mir::OwningPtrType&) -> mir::ExprId {
+          [&](const mir::PointerType&) -> mir::ExprId {
             return scope_state.AddExpr(
                 mir::Expr{
                     .data = mir::ConstructExpr{.args = {}}, .type = type_id});

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -142,36 +142,33 @@ auto EnumerateGenerateChildSpecs(
   return specs;
 }
 
-auto MakeOwnedObjectType(
+auto MakeUniqueObjectPointer(
     UnitLoweringState& unit_state, mir::StructuralScopeId child_id)
     -> mir::TypeId {
   const mir::TypeId object_type =
       unit_state.AddType(mir::ObjectType{.target = child_id});
-  return unit_state.AddType(mir::OwningPtrType{.pointee = object_type});
+  return unit_state.AddType(
+      mir::PointerType{
+          .pointee = object_type, .ownership = mir::PointerOwnership::kUnique});
 }
 
-auto MakeVectorOfOwnedObjectType(
-    UnitLoweringState& unit_state, mir::StructuralScopeId child_id)
-    -> mir::TypeId {
-  const mir::TypeId owned_type = MakeOwnedObjectType(unit_state, child_id);
-  return unit_state.AddType(mir::VectorType{.element = owned_type});
-}
-
-auto MakeExternalUnitOwningType(
+auto MakeUniqueExternalUnitPointer(
     UnitLoweringState& unit_state, std::string unit_name) -> mir::TypeId {
   const mir::TypeId object_type = unit_state.AddType(
       mir::ExternalUnitObjectType{.unit_name = std::move(unit_name)});
-  return unit_state.AddType(mir::OwningPtrType{.pointee = object_type});
+  return unit_state.AddType(
+      mir::PointerType{
+          .pointee = object_type, .ownership = mir::PointerOwnership::kUnique});
 }
 
-// Builds an external-unit member type: an owning pointer to the unit's object,
+// Builds an external-unit member type: a unique pointer to the unit's object,
 // wrapped in one vector layer per array dimension (`num_dims == 0` is a scalar
 // instance). The backend materializes the nested vector by replication.
 auto MakeExternalUnitMemberType(
     UnitLoweringState& unit_state, std::string unit_name, std::size_t num_dims)
     -> mir::TypeId {
   mir::TypeId type =
-      MakeExternalUnitOwningType(unit_state, std::move(unit_name));
+      MakeUniqueExternalUnitPointer(unit_state, std::move(unit_name));
   for (std::size_t i = 0; i < num_dims; ++i) {
     type = unit_state.AddType(mir::VectorType{.element = type});
   }
@@ -357,8 +354,10 @@ void ValidateConstructOwnedObjectStmt(
         "scope");
   }
   const auto& var = owner_scope.GetStructuralVar(stmt.target);
-  const auto target = mir::GetOwnedObjectTarget(unit, var.type);
-  if (!target.has_value() || *target != stmt.scope_id) {
+  const auto child = mir::GetChildScope(unit, var.type);
+  const auto* generate =
+      child ? std::get_if<mir::GenerateScopeChild>(&*child) : nullptr;
+  if (generate == nullptr || generate->target != stmt.scope_id) {
     throw InternalError(
         "ConstructOwnedObjectStmt: target var does not own the requested "
         "scope");
@@ -645,9 +644,10 @@ auto InstallGenerateOwnedChildScopes(
 
       const mir::StructuralScopeId child_id =
           scope_state.AddChildStructuralScope(*std::move(child_r));
-      const mir::TypeId var_type =
-          spec.is_repeated ? MakeVectorOfOwnedObjectType(unit_state, child_id)
-                           : MakeOwnedObjectType(unit_state, child_id);
+      mir::TypeId var_type = MakeUniqueObjectPointer(unit_state, child_id);
+      if (spec.is_repeated) {
+        var_type = unit_state.AddType(mir::VectorType{.element = var_type});
+      }
       const mir::ExprId companion_init =
           SynthesizeDefaultValueExpr(unit_state, ctor_scope_state, var_type);
       const mir::StructuralVarId var_id = scope_state.AddStructuralVar(

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -304,19 +304,34 @@ void InstallCrossUnitRefs(
                      .by_scope_id.at(g.scope.value)
                      .var_id;
     }
-    std::vector<mir::PathStep> path;
-    path.reserve(cu.path.size());
+    // Resolve the by-name navigation here so the backend renders it
+    // mechanically: the owned child is the first GetChild step, each member on
+    // the HIR path opens another step (following array indices attach to it),
+    // and the last name is the GetSignal leaf (emission_model.md).
+    const auto& head = scope_state.GetStructuralVar(head_var);
+    std::vector<mir::ChildStep> steps;
+    steps.push_back(
+        mir::ChildStep{
+            .name = head.source_name.empty() ? head.name : head.source_name,
+            .indices = {}});
     for (const auto& step : cu.path) {
       if (const auto* member = std::get_if<hir::MemberHop>(&step)) {
-        path.emplace_back(mir::MemberHop{member->name});
+        steps.push_back(mir::ChildStep{.name = member->name, .indices = {}});
       } else {
-        path.emplace_back(mir::IndexHop{std::get<hir::IndexHop>(step).index});
+        steps.back().indices.push_back(std::get<hir::IndexHop>(step).index);
       }
     }
+    if (steps.size() < 2) {
+      throw InternalError(
+          "InstallCrossUnitRefs: downward cross-unit reference has no leaf "
+          "signal past its owned child");
+    }
+    std::string signal = std::move(steps.back().name);
+    steps.pop_back();
     const mir::CrossUnitRefId slot = scope_state.AddCrossUnitRef(
         mir::CrossUnitRefDecl{
-            .instance_var = head_var,
-            .path = std::move(path),
+            .steps = std::move(steps),
+            .signal = std::move(signal),
             .type = unit_state.TranslateType(cu.type)});
     const mir::StmtId sid = ctor_scope_state.AddStmt(
         mir::Stmt{

--- a/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_constructor.cpp
@@ -220,14 +220,18 @@ auto InstallInstanceMembers(
 // symbol -- ancestor name, by-name tail through its owned children, and leaf
 // signal -- lives on its type, and the runtime ExternUp member self-relocates
 // at Bind by climbing the parent chain then walking the tail
-// (docs/architecture/emission_model.md). This runs before processes so reads
-// resolve to the member. Every cross-unit ref slot's MIR target is recorded in
-// HIR slot order; a downward slot keeps a CrossUnitVarRef that
-// InstallCrossUnitRefs materializes into the constructor.
-void MaterializeCrossUnitRefTargets(
+// (docs/architecture/emission_model.md). A downward reference gets a borrowed-
+// pointer slot structural var, null until the constructor resolves it. Both
+// run before processes so reads resolve to the slot; both record their MIR read
+// target as a StructuralVarRef to that member, in HIR slot order. The returned
+// vector carries the downward slot var per ref (nullopt for upward), consumed
+// by InstallCrossUnitRefs once the children exist.
+auto MaterializeCrossUnitRefTargets(
     UnitLoweringState& unit_state, StructuralScopeLoweringState& scope_state,
     const hir::StructuralScope& scope,
-    ProceduralScopeLoweringState& ctor_scope_state) {
+    ProceduralScopeLoweringState& ctor_scope_state)
+    -> std::vector<std::optional<mir::StructuralVarId>> {
+  std::vector<std::optional<mir::StructuralVarId>> slot_vars;
   std::uint32_t downward_slot = 0;
   for (const auto& cu : scope.cross_unit_refs) {
     if (const auto* up = std::get_if<hir::UpwardHead>(&cu.head)) {
@@ -270,28 +274,113 @@ void MaterializeCrossUnitRefTargets(
               .initializer = init});
       scope_state.AddCrossUnitRefTarget(
           mir::StructuralVarRef{.hops = {.value = 0}, .var = var});
+      slot_vars.emplace_back(std::nullopt);
     } else {
+      const mir::TypeId leaf = unit_state.TranslateType(cu.type);
+      const mir::TypeId slot_type = unit_state.AddType(
+          mir::PointerType{
+              .pointee = leaf, .ownership = mir::PointerOwnership::kBorrowed});
+      const mir::ExprId init =
+          SynthesizeDefaultValueExpr(unit_state, ctor_scope_state, slot_type);
+      const mir::StructuralVarId slot = scope_state.AddStructuralVar(
+          mir::StructuralVarDecl{
+              .name = "xref" + std::to_string(downward_slot),
+              .type = slot_type,
+              .initializer = init});
       scope_state.AddCrossUnitRefTarget(
-          mir::CrossUnitVarRef{.id = {.value = downward_slot}});
+          mir::StructuralVarRef{.hops = {.value = 0}, .var = slot});
+      slot_vars.emplace_back(slot);
       ++downward_slot;
     }
   }
+  return slot_vars;
 }
 
-// A downward slot resolves in the constructor by navigating an owned child
-// member after the children are built (reference_resolution.md). Upward slots
-// are materialized as ExternalRef members upstream and skipped here.
+// Builds the resolve value for a downward reference: a chain of generic
+// navigation calls from the enclosing scope. The owned-child head and each
+// crossed member open a `GetChild(name, indices)`; the leaf signal is a
+// `GetSignal(name)` whose result type is the slot's borrowed-pointer cell type,
+// so render casts the untyped storage pointer mechanically. Per-dimension array
+// indices are ordinary integer-literal arguments, never bundled with the name.
+auto BuildDownwardNavValue(
+    const UnitLoweringState& unit_state,
+    ProceduralScopeLoweringState& ctor_scope_state,
+    const std::string& head_name, const std::vector<hir::PathStep>& path,
+    mir::TypeId slot_type, mir::TypeId scope_ptr_type) -> mir::ExprId {
+  struct NavHop {
+    std::string name;
+    std::vector<mir::ExprId> indices;
+  };
+  std::vector<NavHop> hops;
+  hops.push_back(NavHop{.name = head_name, .indices = {}});
+  for (const auto& step : path) {
+    if (const auto* member = std::get_if<hir::MemberHop>(&step)) {
+      hops.push_back(NavHop{.name = member->name, .indices = {}});
+    } else {
+      const std::uint32_t index = std::get<hir::IndexHop>(step).index;
+      hops.back().indices.push_back(ctor_scope_state.AddExpr(
+          unit_state.MakeInt32LiteralExpr(static_cast<std::int64_t>(index))));
+    }
+  }
+  if (hops.size() < 2) {
+    throw InternalError(
+        "BuildDownwardNavValue: downward reference has no leaf signal past its "
+        "owned child");
+  }
+
+  mir::ExprId cur = ctor_scope_state.AddExpr(
+      mir::Expr{.data = mir::SelfScopeExpr{}, .type = scope_ptr_type});
+  for (std::size_t i = 0; i + 1 < hops.size(); ++i) {
+    std::vector<mir::ExprId> args;
+    args.push_back(cur);
+    for (const mir::ExprId idx : hops[i].indices) {
+      args.push_back(idx);
+    }
+    cur = ctor_scope_state.AddExpr(
+        mir::Expr{
+            .data =
+                mir::CallExpr{
+                    .callee =
+                        mir::RuntimeNavCallee{
+                            .fn = mir::RuntimeFn::kGetChild,
+                            .name = hops[i].name},
+                    .arguments = std::move(args)},
+            .type = scope_ptr_type});
+  }
+  return ctor_scope_state.AddExpr(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee =
+                      mir::RuntimeNavCallee{
+                          .fn = mir::RuntimeFn::kGetSignal,
+                          .name = hops.back().name},
+                  .arguments = {cur}},
+          .type = slot_type});
+}
+
+// A downward slot resolves in the constructor by navigating from the enclosing
+// scope after the children are built (reference_resolution.md): an ordinary
+// assignment of the navigation value into the borrowed-pointer slot. Upward
+// slots are materialized as ExternalRef members upstream and skipped here.
 void InstallCrossUnitRefs(
     UnitLoweringState& unit_state, StructuralScopeLoweringState& scope_state,
     const hir::StructuralScope& scope,
     const std::vector<mir::StructuralVarId>& instance_member_vars,
     const std::vector<GenerateBindings>& gen_bindings,
+    const std::vector<std::optional<mir::StructuralVarId>>& slot_vars,
     ProceduralScopeLoweringState& ctor_scope_state) {
-  for (const auto& cu : scope.cross_unit_refs) {
+  const mir::TypeId scope_ptr_type = unit_state.AddType(
+      mir::PointerType{
+          .pointee = unit_state.AddType(mir::ScopeType{}),
+          .ownership = mir::PointerOwnership::kBorrowed});
+  for (std::size_t ci = 0; ci < scope.cross_unit_refs.size(); ++ci) {
+    const auto& cu = scope.cross_unit_refs[ci];
     const auto* down = std::get_if<hir::DownwardHead>(&cu.head);
     if (down == nullptr) {
       continue;
     }
+    const mir::StructuralVarId slot = *slot_vars.at(ci);
     mir::StructuralVarId head_var{};
     if (const auto* im = std::get_if<hir::InstanceMemberId>(&down->child)) {
       head_var = instance_member_vars.at(im->value);
@@ -301,39 +390,25 @@ void InstallCrossUnitRefs(
                      .by_scope_id.at(g.scope.value)
                      .var_id;
     }
-    // Resolve the by-name navigation here so the backend renders it
-    // mechanically: the owned child is the first GetChild step, each member on
-    // the HIR path opens another step (following array indices attach to it),
-    // and the last name is the GetSignal leaf (emission_model.md).
     const auto& head = scope_state.GetStructuralVar(head_var);
-    std::vector<mir::ChildStep> steps;
-    steps.push_back(
-        mir::ChildStep{
-            .name = head.source_name.empty() ? head.name : head.source_name,
-            .indices = {}});
-    for (const auto& step : cu.path) {
-      if (const auto* member = std::get_if<hir::MemberHop>(&step)) {
-        steps.push_back(mir::ChildStep{.name = member->name, .indices = {}});
-      } else {
-        steps.back().indices.push_back(std::get<hir::IndexHop>(step).index);
-      }
-    }
-    if (steps.size() < 2) {
-      throw InternalError(
-          "InstallCrossUnitRefs: downward cross-unit reference has no leaf "
-          "signal past its owned child");
-    }
-    std::string signal = std::move(steps.back().name);
-    steps.pop_back();
-    const mir::CrossUnitRefId slot = scope_state.AddCrossUnitRef(
-        mir::CrossUnitRefDecl{
-            .steps = std::move(steps),
-            .signal = std::move(signal),
-            .type = unit_state.TranslateType(cu.type)});
+    const std::string head_name =
+        head.source_name.empty() ? head.name : head.source_name;
+    const mir::TypeId slot_type = scope_state.GetStructuralVar(slot).type;
+    const mir::ExprId nav = BuildDownwardNavValue(
+        unit_state, ctor_scope_state, head_name, cu.path, slot_type,
+        scope_ptr_type);
+    const mir::ExprId target = ctor_scope_state.AddExpr(
+        mir::Expr{
+            .data = mir::StructuralVarRef{.hops = {.value = 0}, .var = slot},
+            .type = slot_type});
+    const mir::ExprId assign = ctor_scope_state.AddExpr(
+        mir::Expr{
+            .data = mir::AssignExpr{.target = target, .value = nav},
+            .type = slot_type});
     const mir::StmtId sid = ctor_scope_state.AddStmt(
         mir::Stmt{
             .label = std::nullopt,
-            .data = mir::ResolveCrossUnitRefStmt{.slot = slot},
+            .data = mir::ExprStmt{.expr = assign},
             .child_procedural_scopes = {}});
     ctor_scope_state.AddRootStmt(sid);
   }
@@ -679,7 +754,6 @@ auto LowerStructuralScope(
       .time_resolution = scope.time_resolution,
       .structural_params = {},
       .structural_vars = {},
-      .cross_unit_refs = {},
       .constructor_scope = {},
       .processes = {},
       .child_structural_scopes = {},
@@ -702,6 +776,11 @@ auto LowerStructuralScope(
   }
 
   ProceduralScopeLoweringState ctor_scope_state;
+  const mir::TypeId scope_ptr_type = unit_state.AddType(
+      mir::PointerType{
+          .pointee = unit_state.AddType(mir::ScopeType{}),
+          .ownership = mir::PointerOwnership::kBorrowed});
+  const mir::TypeId void_type = unit_state.AddType(mir::VoidType{});
   for (std::size_t i = 0; i < scope.structural_vars.size(); ++i) {
     const hir::StructuralVarId hir_id{static_cast<std::uint32_t>(i)};
     const auto& d = scope.structural_vars[i];
@@ -721,12 +800,48 @@ auto LowerStructuralScope(
         mir::StructuralVarDecl{
             .name = d.name, .type = mir_type, .initializer = mir_init});
     scope_state.MapStructuralVar(hir_id, mir_id);
+
+    // A value-typed var is a signal: record its address under its name so a
+    // cross-unit referrer resolves it by name at construction. Owned children
+    // (pointer / vector / object) and resolution slots register differently.
+    const auto& var_data = unit_state.GetType(mir_type).data;
+    const bool is_signal =
+        !std::holds_alternative<mir::PointerType>(var_data) &&
+        !std::holds_alternative<mir::VectorType>(var_data) &&
+        !std::holds_alternative<mir::ExternalRefType>(var_data) &&
+        !std::holds_alternative<mir::ObjectType>(var_data) &&
+        !std::holds_alternative<mir::ExternalUnitObjectType>(var_data);
+    if (is_signal) {
+      const mir::ExprId self = ctor_scope_state.AddExpr(
+          mir::Expr{.data = mir::SelfScopeExpr{}, .type = scope_ptr_type});
+      const mir::ExprId var_ref = ctor_scope_state.AddExpr(
+          mir::Expr{
+              .data =
+                  mir::StructuralVarRef{.hops = {.value = 0}, .var = mir_id},
+              .type = mir_type});
+      const mir::ExprId call = ctor_scope_state.AddExpr(
+          mir::Expr{
+              .data =
+                  mir::CallExpr{
+                      .callee =
+                          mir::RuntimeNavCallee{
+                              .fn = mir::RuntimeFn::kRegisterSignal,
+                              .name = d.name},
+                      .arguments = {self, var_ref}},
+              .type = void_type});
+      const mir::StmtId sid = ctor_scope_state.AddStmt(
+          mir::Stmt{
+              .label = std::nullopt,
+              .data = mir::ExprStmt{.expr = call},
+              .child_procedural_scopes = {}});
+      ctor_scope_state.AddRootStmt(sid);
+    }
   }
 
   // Upward refs become ExternalRef members and every cross-unit slot's MIR
   // target is recorded before any body is lowered, so reads and sensitivity in
   // subroutines and processes resolve each slot.
-  MaterializeCrossUnitRefTargets(
+  const auto cross_unit_slot_vars = MaterializeCrossUnitRefTargets(
       unit_state, scope_state, scope, ctor_scope_state);
 
   // Map every subroutine's identity before lowering any body, so a call in one
@@ -783,7 +898,7 @@ auto LowerStructuralScope(
       InstallInstanceMembers(unit_state, scope_state, scope, ctor_scope_state);
   InstallCrossUnitRefs(
       unit_state, scope_state, scope, instance_member_vars, *bindings_r,
-      ctor_scope_state);
+      cross_unit_slot_vars, ctor_scope_state);
 
   scope_state.SetConstructorScope(ctor_scope_state.Finish());
 

--- a/src/lyra/lowering/hir_to_mir/lower_expr.cpp
+++ b/src/lyra/lowering/hir_to_mir/lower_expr.cpp
@@ -292,17 +292,25 @@ auto LowerProceduralVarRefExpr(
       .data = proc_state.TranslateProceduralVar(l.var), .type = type};
 }
 
-// A cross-unit ref resolves to the MIR target recorded for its slot: an upward
-// ref reads its ExternalRef member through a StructuralVarRef, a downward ref
-// keeps a CrossUnitVarRef. `type` is the referenced leaf type either way.
+// A cross-unit ref reads through the MIR target recorded for its slot, a
+// StructuralVarRef to the slot member. A downward slot is a borrowed pointer,
+// so the read dereferences to the cell; an upward ExternalRef member reads
+// directly. `type` is the referenced leaf type either way.
 auto LowerCrossUnitVarRefExpr(
+    const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
+    ProceduralScopeLoweringState& proc_scope_state,
     const hir::CrossUnitVarRef& c, mir::TypeId type) -> mir::Expr {
-  return std::visit(
-      [&](const auto& ref) -> mir::Expr {
-        return mir::Expr{.data = ref, .type = type};
-      },
-      scope_state.CrossUnitRefTarget(c.id));
+  const mir::StructuralVarRef target = scope_state.CrossUnitRefTarget(c.id);
+  const mir::TypeId var_type = scope_state.GetStructuralVar(target.var).type;
+  const auto* ptr =
+      std::get_if<mir::PointerType>(&unit_state.GetType(var_type).data);
+  if (ptr != nullptr && ptr->ownership == mir::PointerOwnership::kBorrowed) {
+    const mir::ExprId pointer =
+        proc_scope_state.AddExpr(mir::Expr{.data = target, .type = var_type});
+    return mir::Expr{.data = mir::DerefExpr{.pointer = pointer}, .type = type};
+  }
+  return mir::Expr{.data = target, .type = type};
 }
 
 auto LowerLoopVarRefExpr(
@@ -555,8 +563,9 @@ auto LowerHirRealLiteral(const hir::RealLiteral& r, mir::TypeId type)
 auto LowerHirPrimaryProc(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    ProcessLoweringState& proc_state, const hir::Primary& p, mir::TypeId type)
-    -> mir::Expr {
+    ProcessLoweringState& proc_state,
+    ProceduralScopeLoweringState& proc_scope_state, const hir::Primary& p,
+    mir::TypeId type) -> mir::Expr {
   return std::visit(
       Overloaded{
           [&](const hir::IntegerLiteral& i) -> mir::Expr {
@@ -581,7 +590,8 @@ auto LowerHirPrimaryProc(
             return LowerStructuralParamRefExpr(scope_state, lv, type);
           },
           [&](const hir::CrossUnitVarRef& c) -> mir::Expr {
-            return LowerCrossUnitVarRefExpr(scope_state, c, type);
+            return LowerCrossUnitVarRefExpr(
+                unit_state, scope_state, proc_scope_state, c, type);
           },
       },
       p);
@@ -590,7 +600,8 @@ auto LowerHirPrimaryProc(
 auto LowerHirPrimaryStructural(
     const UnitLoweringState& unit_state,
     const StructuralScopeLoweringState& scope_state,
-    const ConstructorLoweringState* ctor_state, const hir::Primary& p,
+    const ConstructorLoweringState* ctor_state,
+    ProceduralScopeLoweringState& proc_scope_state, const hir::Primary& p,
     mir::TypeId type, LoopVarLoweringMode loop_var_mode) -> mir::Expr {
   return std::visit(
       Overloaded{
@@ -629,7 +640,8 @@ auto LowerHirPrimaryStructural(
             // A continuous assignment lowers as a scope-level structural
             // expression, yet it may read or write a cross-unit member: a
             // hierarchical reference or a port connection (LRM 10.3, 23.3.3).
-            return LowerCrossUnitVarRefExpr(scope_state, c, type);
+            return LowerCrossUnitVarRefExpr(
+                unit_state, scope_state, proc_scope_state, c, type);
           },
       },
       p);
@@ -1600,7 +1612,8 @@ auto LowerExpr(
       Overloaded{
           [&](const hir::PrimaryExpr& p) -> diag::Result<mir::Expr> {
             return LowerHirPrimaryProc(
-                unit_state, scope_state, proc_state, p.data, result_type);
+                unit_state, scope_state, proc_state, proc_scope_state, p.data,
+                result_type);
           },
           [&](const hir::UnaryExpr& u) -> diag::Result<mir::Expr> {
             return LowerHirUnaryExprProc(
@@ -2014,8 +2027,8 @@ auto LowerExprImpl(
       Overloaded{
           [&](const hir::PrimaryExpr& p) -> diag::Result<mir::Expr> {
             return LowerHirPrimaryStructural(
-                unit_state, scope_state, ctor_state, p.data, result_type,
-                loop_var_mode);
+                unit_state, scope_state, ctor_state, proc_scope_state, p.data,
+                result_type, loop_var_mode);
           },
           [&](const hir::UnaryExpr& u) -> diag::Result<mir::Expr> {
             return LowerHirUnaryExprStructural(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -649,19 +649,16 @@ class MirDumper {
       Indent();
       for (std::size_t i = 0; i < s.cross_unit_refs.size(); ++i) {
         const auto& cu = s.cross_unit_refs[i];
-        std::string path;
-        for (const auto& step : cu.path) {
-          if (const auto* member = std::get_if<MemberHop>(&step)) {
-            path += "." + member->name;
-          } else {
-            path += std::format("[{}]", std::get<IndexHop>(step).index);
+        std::string nav;
+        for (const auto& step : cu.steps) {
+          nav += step.name;
+          for (const std::uint32_t index : step.indices) {
+            nav += std::format("[{}]", index);
           }
+          nav += ".";
         }
-        const std::string head =
-            std::format("StructuralVar[{}]", cu.instance_var.value);
-        Line(
-            std::format(
-                "[{}] {}{} : {}", i, head, path, FormatVarType(cu.type)));
+        nav += cu.signal;
+        Line(std::format("[{}] {} : {}", i, nav, FormatVarType(cu.type)));
       }
       Dedent();
     }

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -176,6 +176,7 @@ class MirDumper {
               return std::format(
                   "ExternalUnitObject(unit=\"{}\")", e.unit_name);
             },
+            [](const ScopeType&) -> std::string { return "Scope"; },
             [](const PointerType& p) -> std::string {
               switch (p.ownership) {
                 case PointerOwnership::kUnique:
@@ -348,6 +349,11 @@ class MirDumper {
               return std::format(
                   "ClosureRef[closure=Expr[{}]]", cr.closure.value);
             },
+            [](const RuntimeNavCallee& nav) -> std::string {
+              return std::format(
+                  "RuntimeNavCallee[fn={}, name=\"{}\"]",
+                  static_cast<int>(nav.fn), nav.name);
+            },
             [](const BuiltinMethodCallee& b) -> std::string {
               return std::visit(
                   Overloaded{
@@ -484,9 +490,6 @@ class MirDumper {
                   "ProceduralVarRef[hops={}, var={}] \"{}\"", r.hops.value,
                   r.var.value, var.name);
             },
-            [](const CrossUnitVarRef& r) -> std::string {
-              return std::format("CrossUnitVarRef[slot={}]", r.id.value);
-            },
             [](const UnaryExpr& u) -> std::string {
               return std::format(
                   "UnaryExpr op={} operand=Expr[{}]", FormatUnaryOp(u.op),
@@ -541,6 +544,10 @@ class MirDumper {
             },
             [](const RuntimeCallExpr&) -> std::string {
               return "RuntimeCallExpr";
+            },
+            [](const SelfScopeExpr&) -> std::string { return "SelfScopeExpr"; },
+            [](const DerefExpr& d) -> std::string {
+              return std::format("DerefExpr pointer=Expr[{}]", d.pointer.value);
             },
             [](const ConversionExpr& cv) -> std::string {
               return std::format(
@@ -653,25 +660,6 @@ class MirDumper {
               FormatVarType(v.type), v.initializer.value));
     }
     Dedent();
-
-    if (!s.cross_unit_refs.empty()) {
-      Line("CrossUnitRefs:");
-      Indent();
-      for (std::size_t i = 0; i < s.cross_unit_refs.size(); ++i) {
-        const auto& cu = s.cross_unit_refs[i];
-        std::string nav;
-        for (const auto& step : cu.steps) {
-          nav += step.name;
-          for (const std::uint32_t index : step.indices) {
-            nav += std::format("[{}]", index);
-          }
-          nav += ".";
-        }
-        nav += cu.signal;
-        Line(std::format("[{}] {} : {}", i, nav, FormatVarType(cu.type)));
-      }
-      Dedent();
-    }
 
     Line("StructuralSubroutines:");
     Indent();
@@ -1078,12 +1066,6 @@ class MirDumper {
             [&](const ConstructExternalUnitStmt& s) {
               DumpConstructExternalUnitStmt(id, s);
             },
-            [&](const ResolveCrossUnitRefStmt& s) {
-              Line(
-                  std::format(
-                      "Stmt[{}] ResolveCrossUnitRefStmt slot={}", id.value,
-                      s.slot.value));
-            },
             [&](const ForStmt& s) { DumpForStmt(stmt, s, enclosing, id); },
             [&](const DelayStmt& d) {
               Line(
@@ -1120,19 +1102,9 @@ class MirDumper {
               Line(std::format("Stmt[{}] SensitivityWaitStmt", id.value));
               Indent();
               for (const auto& r : s.reads) {
-                const std::string ref_str = std::visit(
-                    Overloaded{
-                        [](const StructuralVarRef& sv) -> std::string {
-                          return std::format(
-                              "StructuralVarRef hops={} var=StructuralVar[{}]",
-                              sv.hops.value, sv.var.value);
-                        },
-                        [](const CrossUnitVarRef& cu) -> std::string {
-                          return std::format(
-                              "CrossUnitVarRef slot={}", cu.id.value);
-                        },
-                    },
-                    r.ref);
+                const std::string ref_str = std::format(
+                    "StructuralVarRef hops={} var=StructuralVar[{}]",
+                    r.ref.hops.value, r.ref.var.value);
                 Line(
                     std::format(
                         "{} bits=[{}:{}] edge={}", ref_str, r.bit_range.first,

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -176,9 +176,19 @@ class MirDumper {
               return std::format(
                   "ExternalUnitObject(unit=\"{}\")", e.unit_name);
             },
-            [](const OwningPtrType& p) -> std::string {
-              return std::format(
-                  "OwningPtr(pointee=Type[{}])", p.pointee.value);
+            [](const PointerType& p) -> std::string {
+              switch (p.ownership) {
+                case PointerOwnership::kUnique:
+                  return std::format(
+                      "Pointer(unique, pointee=Type[{}])", p.pointee.value);
+                case PointerOwnership::kShared:
+                  return std::format(
+                      "Pointer(shared, pointee=Type[{}])", p.pointee.value);
+                case PointerOwnership::kBorrowed:
+                  return std::format(
+                      "Pointer(borrowed, pointee=Type[{}])", p.pointee.value);
+              }
+              throw InternalError("MirDumper: unknown PointerOwnership");
             },
             [](const VectorType& v) -> std::string {
               return std::format("Vector(elem=Type[{}])", v.element.value);

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -9,7 +9,6 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/mir/compilation_unit.hpp"
-#include "lyra/mir/structural_scope_id.hpp"
 
 namespace lyra::mir {
 
@@ -75,7 +74,7 @@ auto Type::Kind() const -> TypeKind {
           [](const ExternalUnitObjectType&) {
             return TypeKind::kExternalUnitObject;
           },
-          [](const OwningPtrType&) { return TypeKind::kOwningPtr; },
+          [](const PointerType&) { return TypeKind::kPointer; },
           [](const VectorType&) { return TypeKind::kVector; },
           [](const ExternalRefType&) { return TypeKind::kExternalRef; },
       },
@@ -123,67 +122,33 @@ auto Type::AsIntegralPacked() const -> const PackedArrayType& {
 
 namespace {
 
-auto AsObjectScope(const CompilationUnit& unit, TypeId type)
-    -> std::optional<StructuralScopeId> {
-  const auto* obj = std::get_if<ObjectType>(&unit.GetType(type).data);
-  if (obj == nullptr) {
+auto AsUniquePointee(const CompilationUnit& unit, TypeId type)
+    -> std::optional<TypeId> {
+  const auto* ptr = std::get_if<PointerType>(&unit.GetType(type).data);
+  if (ptr == nullptr || ptr->ownership != PointerOwnership::kUnique) {
     return std::nullopt;
   }
-  return obj->target;
+  return ptr->pointee;
 }
 
 }  // namespace
 
-auto IsOwningObjectType(const CompilationUnit& unit, TypeId type) -> bool {
-  const auto* owning = std::get_if<OwningPtrType>(&unit.GetType(type).data);
-  if (owning == nullptr) {
-    return false;
+auto GetChildScope(const CompilationUnit& unit, TypeId type)
+    -> std::optional<ChildScope> {
+  TypeId leaf = type;
+  while (const auto* vec = std::get_if<VectorType>(&unit.GetType(leaf).data)) {
+    leaf = vec->element;
   }
-  return AsObjectScope(unit, owning->pointee).has_value();
-}
-
-auto IsVectorOfOwningObjectType(const CompilationUnit& unit, TypeId type)
-    -> bool {
-  const auto* vec = std::get_if<VectorType>(&unit.GetType(type).data);
-  if (vec == nullptr) {
-    return false;
-  }
-  return IsOwningObjectType(unit, vec->element);
-}
-
-auto GetOwnedObjectTarget(const CompilationUnit& unit, TypeId type)
-    -> std::optional<StructuralScopeId> {
-  const auto& data = unit.GetType(type).data;
-  if (const auto* owning = std::get_if<OwningPtrType>(&data)) {
-    return AsObjectScope(unit, owning->pointee);
-  }
-  if (const auto* vec = std::get_if<VectorType>(&data)) {
-    if (const auto* owning =
-            std::get_if<OwningPtrType>(&unit.GetType(vec->element).data)) {
-      return AsObjectScope(unit, owning->pointee);
-    }
-  }
-  return std::nullopt;
-}
-
-auto GetOwnedChildLeaf(const CompilationUnit& unit, TypeId type)
-    -> std::optional<OwnedChildLeaf> {
-  const Type* leaf = &unit.GetType(type);
-  while (const auto* vec = std::get_if<VectorType>(&leaf->data)) {
-    leaf = &unit.GetType(vec->element);
-  }
-  const auto* owning = std::get_if<OwningPtrType>(&leaf->data);
-  if (owning == nullptr) {
+  const auto pointee = AsUniquePointee(unit, leaf);
+  if (!pointee.has_value()) {
     return std::nullopt;
   }
-  const auto& pointee = unit.GetType(owning->pointee).data;
-  if (const auto* obj = std::get_if<ObjectType>(&pointee)) {
-    return OwnedChildLeaf{
-        .kind = OwnedChildKind::kGenerateScope, .intra_target = obj->target};
+  const auto& data = unit.GetType(*pointee).data;
+  if (const auto* obj = std::get_if<ObjectType>(&data)) {
+    return ChildScope{GenerateScopeChild{.target = obj->target}};
   }
-  if (std::holds_alternative<ExternalUnitObjectType>(pointee)) {
-    return OwnedChildLeaf{
-        .kind = OwnedChildKind::kModuleInstance, .intra_target = std::nullopt};
+  if (std::holds_alternative<ExternalUnitObjectType>(data)) {
+    return ChildScope{ModuleInstanceChild{}};
   }
   return std::nullopt;
 }

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -74,6 +74,7 @@ auto Type::Kind() const -> TypeKind {
           [](const ExternalUnitObjectType&) {
             return TypeKind::kExternalUnitObject;
           },
+          [](const ScopeType&) { return TypeKind::kScope; },
           [](const PointerType&) { return TypeKind::kPointer; },
           [](const VectorType&) { return TypeKind::kVector; },
           [](const ExternalRefType&) { return TypeKind::kExternalRef; },

--- a/src/lyra/runtime/scope.cpp
+++ b/src/lyra/runtime/scope.cpp
@@ -1,11 +1,15 @@
 #include "lyra/runtime/scope.hpp"
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/runtime/coroutine.hpp"
@@ -31,6 +35,38 @@ void Scope::ForEachChild(const ChildVisitor& fn) {
   for (Scope* child : children_) {
     fn(*child);
   }
+}
+
+void Scope::RegisterSignal(std::string_view name, void* address) {
+  signals_.push_back(SignalEntry{.name = name, .address = address});
+}
+
+void Scope::RegisterChild(
+    std::string_view name, std::span<const std::size_t> indices, Scope& child) {
+  child_entries_.push_back(
+      ChildEntry{
+          .name = name,
+          .indices = std::vector<std::size_t>(indices.begin(), indices.end()),
+          .scope = &child});
+}
+
+auto Scope::GetSignal(std::string_view name) -> void* {
+  for (const SignalEntry& signal : signals_) {
+    if (signal.name == name) {
+      return signal.address;
+    }
+  }
+  return nullptr;
+}
+
+auto Scope::GetChild(
+    std::string_view name, std::span<const std::size_t> indices) -> Scope* {
+  for (const ChildEntry& child : child_entries_) {
+    if (child.name == name && std::ranges::equal(child.indices, indices)) {
+      return child.scope;
+    }
+  }
+  return nullptr;
 }
 
 auto Scope::Parent() const -> Scope* {

--- a/src/lyra/runtime/scope.cpp
+++ b/src/lyra/runtime/scope.cpp
@@ -58,7 +58,7 @@ void Scope::RegisterExtern(ExternBase* member) {
 
 auto Scope::ResolveUpwardScope(std::string_view ancestor) -> Scope* {
   Scope* s = parent_;
-  while (s != nullptr && s->Name() != ancestor && s->DefName() != ancestor) {
+  while (s != nullptr && s->DefName() != ancestor) {
     s = s->Parent();
   }
   if (s == nullptr) {

--- a/tests/cases/cpp/hierarchy_upward_ref_in_generate/case.yaml
+++ b/tests/cases/cpp/hierarchy_upward_ref_in_generate/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_upward_ref_in_generate
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "gi=42\ngj=42\ngf=42,42\nsig=99\n"

--- a/tests/cases/cpp/hierarchy_upward_ref_in_generate/main.sv
+++ b/tests/cases/cpp/hierarchy_upward_ref_in_generate/main.sv
@@ -1,0 +1,31 @@
+// An upward hierarchical reference written inside a generate block resolves the
+// same as one in the module body: its ExternUp member rides the generate-scope
+// class and climbs that object's own parent chain at Bind (LRM 23.8). Covers a
+// conditional block, a loop block, several blocks referencing the same ancestor
+// signal (each gets its own slot in its own scope), and an upward write.
+module Leaf;
+  if (1) begin : gi
+    initial begin #1; $display("gi=%0d", Top.sig); end
+  end
+  if (1) begin : gj
+    initial begin #2; $display("gj=%0d", Top.sig); end
+  end
+  for (genvar k = 0; k < 2; k = k + 1) begin : gf
+    int x;
+    always_comb x = Top.sig;
+  end
+  initial begin #3; $display("gf=%0d,%0d", gf[0].x, gf[1].x); end
+  if (1) begin : gw
+    initial begin #4; Top.sig = 99; end
+  end
+endmodule
+
+module Top;
+  int sig;
+  Leaf leaf();
+  initial begin
+    sig = 42;
+    #5;
+    $display("sig=%0d", sig);
+  end
+endmodule

--- a/tests/cases/cpp/hierarchy_upward_ref_name_collision/case.yaml
+++ b/tests/cases/cpp/hierarchy_upward_ref_name_collision/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_upward_ref_name_collision
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "100\n"

--- a/tests/cases/cpp/hierarchy_upward_ref_name_collision/main.sv
+++ b/tests/cases/cpp/hierarchy_upward_ref_name_collision/main.sv
@@ -1,0 +1,33 @@
+// An upward reference climbs to the ancestor identified by its module
+// definition name. A nearer ancestor whose *instance* name happens to equal
+// that module name (here a Decoy instance literally named "M") must not shadow
+// the real target: `outer.s` resolves to `outer` (definition M), not to the
+// closer instance called "M". LRM 23.8.
+module Leaf;
+  int x;
+  always_comb x = outer.s;
+endmodule
+
+module Decoy;
+  int s;
+  Leaf leaf();
+endmodule
+
+module Wrap;
+  Decoy M();
+endmodule
+
+module M;
+  int s;
+  Wrap w();
+endmodule
+
+module Top;
+  M outer();
+  initial begin
+    outer.w.M.s = 7;
+    outer.s = 100;
+    #1;
+    $display("%0d", outer.w.M.leaf.x);
+  end
+endmodule

--- a/tests/cases/cpp/hierarchy_xunit_into_generate/case.yaml
+++ b/tests/cases/cpp/hierarchy_xunit_into_generate/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_xunit_into_generate
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "5 7 9\n"

--- a/tests/cases/cpp/hierarchy_xunit_into_generate/main.sv
+++ b/tests/cases/cpp/hierarchy_xunit_into_generate/main.sv
@@ -1,0 +1,23 @@
+// A downward hierarchical reference from an enclosing scope into a child
+// instance's generate block. The reference crosses into the child's unit, so
+// the generate block and its signal are reached by name (LRM 23.6, 27): a
+// conditional block `leaf.g.x` and an indexed loop block `leaf.bank[i].y`.
+module Leaf;
+  if (1) begin : g
+    int x;
+  end
+  for (genvar i = 0; i < 2; i = i + 1) begin : bank
+    int y;
+  end
+endmodule
+
+module Top;
+  Leaf leaf();
+  initial begin
+    leaf.g.x = 5;
+    leaf.bank[0].y = 7;
+    leaf.bank[1].y = 9;
+    #1;
+    $display("%0d %0d %0d", leaf.g.x, leaf.bank[0].y, leaf.bank[1].y);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Every cross-unit hierarchical reference -- downward into a child, upward to a named ancestor, and across generate-block boundaries -- resolves once at construction into a typed borrowed-pointer slot and is read directly thereafter. The owner answers a by-name query (`GetSignal` / `GetChild`) from registrations each scope makes in its own constructor, so the backend renders a mechanical chain of calls instead of synthesizing a per-unit dispatch.

### Resolve upward refs by module definition name only

An upward reference climbs the parent chain matching the ancestor's module definition name (LRM 23.8); a nearer ancestor whose instance name merely equals that module name no longer shadows the target.

### Support upward refs inside generate blocks

An upward reference written inside a generate block synthesizes its extern member on the generate-scope class and climbs that object's own parent chain, so it resolves the same as one in the module body. Cross-unit reference slots dedup per scope frame rather than globally.

### Resolve downward refs into a child's generate block

A downward reference reaches a generate block inside a child instance, indexing loop blocks and continuing to a signal or a further child.

### Model MIR pointers by ownership axis

MIR pointer types carry an ownership axis (unique / shared / borrowed), so a borrowed pointer to a resolved cell is distinct from an owning child pointer.

### Resolve cross-unit refs via slot and registration

A downward reference becomes a borrowed-pointer slot, filled by a by-name navigation and read through a deref. Each scope registers its own signals and children by name during construction, so `GetSignal` / `GetChild` are one generic base-class lookup rather than an emit-synthesized if-chain. Struct fields render uniformly from the MIR initializer.