### PR TITLE
Bring up queue as a basic data type

### DIFF
--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -14,7 +14,6 @@ enum class DiagCode : std::uint32_t {
   kUnsupportedTaggedPackedUnion,
   kUnsupportedFixedSizeUnpackedArrayType,
   kUnsupportedDynamicArrayType,
-  kUnsupportedQueueType,
   kUnsupportedAssociativeArrayType,
   kUnsupportedUnpackedStructType,
   kUnsupportedUnpackedUnionType,

--- a/include/lyra/runtime/prelude.hpp
+++ b/include/lyra/runtime/prelude.hpp
@@ -57,6 +57,7 @@
 #include "lyra/value/packed_convert.hpp"       // IWYU pragma: keep
 #include "lyra/value/packed_reduction.hpp"     // IWYU pragma: keep
 #include "lyra/value/packed_type.hpp"          // IWYU pragma: keep
+#include "lyra/value/queue.hpp"                // IWYU pragma: keep
 #include "lyra/value/string.hpp"               // IWYU pragma: keep
 #include "lyra/value/string_op.hpp"            // IWYU pragma: keep
 #include "lyra/value/unpacked_array.hpp"       // IWYU pragma: keep

--- a/include/lyra/value/format.hpp
+++ b/include/lyra/value/format.hpp
@@ -12,6 +12,8 @@ template <typename T>
 class UnpackedArray;
 template <typename T>
 class DynamicArray;
+template <typename T>
+class Queue;
 
 enum class PrintKind : std::uint8_t {
   kDisplay,
@@ -197,6 +199,11 @@ template <typename T>
 }
 template <typename T>
 [[nodiscard]] auto PrintValue(const DynamicArray<T>& value, FormatSpec spec)
+    -> PrintItem {
+  return PrintValueItem{.spec = spec, .arg = MakeFormatArg(value)};
+}
+template <typename T>
+[[nodiscard]] auto PrintValue(const Queue<T>& value, FormatSpec spec)
     -> PrintItem {
   return PrintValueItem{.spec = spec, .arg = MakeFormatArg(value)};
 }

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <span>
+#include <string>
+#include <utility>
+
+#include "lyra/value/format.hpp"
+
+namespace lyra::value {
+
+// SystemVerilog queue (LRM 7.10): a variable-size ordered collection with
+// efficient insertion and removal at both ends, so the storage is a
+// `std::deque<T>` rather than the `std::vector<T>` the dynamic array uses.
+// Default value is the empty queue (LRM Table 6-7).
+//
+// `oob_slot_` is the LRM 7.4.5 invalid-index shield seed, supplied at
+// construction because `T = PackedArray` carries runtime shape parameters
+// (bit width, signedness, 2/4-state) that cannot be recovered from the C++
+// type alone. See `docs/decisions/runtime-shape-and-default-value.md`. It
+// holds the element's canonical default for construction and the OOB-shield
+// protocol (`ResetToDefault`) shared with the other container wrappers.
+template <typename T>
+class Queue {
+ public:
+  using ElementType = T;
+
+  // Empty queue with the shield slot seeded. Used for declarations like
+  // `int q[$];` where the queue starts empty but the element shape is known
+  // at lowering time.
+  explicit Queue(T oob_slot) : oob_slot_(std::move(oob_slot)) {
+  }
+
+  // LRM 10.9.1 assignment-pattern construction: shield slot seeded, elements
+  // taken from the pattern's list. The list is a span so the emit side hands
+  // in a `std::array<T, N>{...}` literal, mirroring `DynamicArray`.
+  Queue(T oob_slot, std::span<const T> init)
+      : oob_slot_(std::move(oob_slot)), data_(init.begin(), init.end()) {
+  }
+
+  Queue(const Queue&) = default;
+  Queue(Queue&&) noexcept = default;
+  auto operator=(const Queue&) -> Queue& = default;
+  auto operator=(Queue&&) noexcept -> Queue& = default;
+  ~Queue() = default;
+
+  [[nodiscard]] auto Size() const -> std::size_t {
+    return data_.size();
+  }
+
+  [[nodiscard]] auto RawAt(std::size_t i) const -> const T& {
+    return data_[i];
+  }
+
+  [[nodiscard]] auto Clone() const -> Queue {
+    return *this;
+  }
+
+  // LRM Table 6-7: a queue's default is the empty queue. When this container
+  // is itself an OOB shield slot of an outer container, the outer calls this
+  // to restore canonical state before handing out a reference.
+  auto ResetToDefault() -> void {
+    data_.clear();
+  }
+
+ private:
+  mutable T oob_slot_;
+  std::deque<T> data_;
+};
+
+// LRM 21.2.1.6 aggregate format. Mirrors `Formatter<DynamicArray<T>>`: walk
+// the elements, deferring each to its own `Formatter`. Empty queues compose
+// naturally because the loop runs zero times.
+template <typename T>
+struct Formatter<Queue<T>> {
+  static auto Format(const FormatSpec& spec, const Queue<T>& value)
+      -> std::string {
+    std::string out = "'{";
+    for (std::size_t i = 0; i < value.Size(); ++i) {
+      if (i != 0) {
+        out += ", ";
+      }
+      out += lyra::value::Format(spec, MakeFormatArg(value.RawAt(i)));
+    }
+    out += "}";
+    return out;
+  }
+};
+
+}  // namespace lyra::value

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1636,8 +1636,9 @@ auto RenderConcatExpr(
 
 // LRM 10.9.1 array assignment pattern: renders as `std::array<T, N>{e1, ...}`.
 // `expr.type` is the parent container type (`UnpackedArrayType` /
-// `DynamicArrayType`); the element type is read off it and emitted as the
-// `std::array` element parameter. The resulting `std::array<T, N>` implicitly
+// `DynamicArrayType` / `QueueType`); the element type is read off it and
+// emitted as the `std::array` element parameter. The resulting
+// `std::array<T, N>` implicitly
 // converts to the container ctor's `std::span<const T>` parameter, so this
 // rendering is context-independent: the same string is correct standalone
 // and as a `ConstructExpr` argument.
@@ -1650,12 +1651,13 @@ auto RenderArrayLiteralExpr(
         using TyT = std::decay_t<decltype(ty)>;
         if constexpr (
             std::same_as<TyT, mir::UnpackedArrayType> ||
-            std::same_as<TyT, mir::DynamicArrayType>) {
+            std::same_as<TyT, mir::DynamicArrayType> ||
+            std::same_as<TyT, mir::QueueType>) {
           return ty.element_type;
         } else {
           throw InternalError(
-              "RenderArrayLiteralExpr: result type must be UnpackedArrayType "
-              "or DynamicArrayType");
+              "RenderArrayLiteralExpr: result type must be UnpackedArrayType, "
+              "DynamicArrayType, or QueueType");
         }
       },
       container_ty.data);

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -123,7 +123,8 @@ auto RenderPrintValueArg(
       type.Kind() == mir::TypeKind::kShortReal ||
       type.Kind() == mir::TypeKind::kString ||
       type.Kind() == mir::TypeKind::kUnpackedArray ||
-      type.Kind() == mir::TypeKind::kDynamicArray) {
+      type.Kind() == mir::TypeKind::kDynamicArray ||
+      type.Kind() == mir::TypeKind::kQueue) {
     return *operand_or;
   }
   throw InternalError("RenderPrintValueArg: unsupported display operand type");

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -96,6 +96,11 @@ auto RenderTypeAsCpp(
             if (!inner_or) return std::unexpected(std::move(inner_or.error()));
             return "lyra::value::DynamicArray<" + *inner_or + ">";
           },
+          [&](const mir::QueueType& q) -> diag::Result<std::string> {
+            auto inner_or = RenderTypeAsCpp(unit, owner_scope, q.element_type);
+            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
+            return "lyra::value::Queue<" + *inner_or + ">";
+          },
           [&](const mir::ObjectType& o) -> diag::Result<std::string> {
             return std::string{
                 owner_scope.GetChildStructuralScope(o.target).name};

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -36,12 +36,6 @@ constexpr std::array kEntries{
             .category = UnsupportedCategory::kType,
             .name = "unsupported_dynamic_array_type"}},
     std::pair{
-        DiagCode::kUnsupportedQueueType,
-        DiagCodeInfo{
-            .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kType,
-            .name = "unsupported_queue_type"}},
-    std::pair{
         DiagCode::kUnsupportedAssociativeArrayType,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -1,6 +1,7 @@
 #include "lyra/hir/type.hpp"
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -321,10 +322,21 @@ auto TranslateTypeData(
       }
       return hir::TypeData{hir::DynamicArrayType{.element_type = *elem_id_or}};
     }
-    case slang::ast::SymbolKind::QueueType:
-      return diag::Unsupported(
-          decl_span, diag::DiagCode::kUnsupportedQueueType,
-          "queue types are not supported", diag::UnsupportedCategory::kType);
+    case slang::ast::SymbolKind::QueueType: {
+      const auto& q = canonical.as<slang::ast::QueueType>();
+      auto elem_id_or = module.InternType(q.elementType, decl_span);
+      if (!elem_id_or) {
+        return std::unexpected(std::move(elem_id_or.error()));
+      }
+      // slang encodes the unbounded queue (`[$]`) as maxBound == 0; a bounded
+      // queue (`[$:N]`) carries the bound (LRM 7.10.4).
+      return hir::TypeData{hir::QueueType{
+          .element_type = *elem_id_or,
+          .max_bound = q.maxBound == 0
+                           ? std::nullopt
+                           : std::optional<std::uint64_t>{q.maxBound},
+      }};
+    }
     case slang::ast::SymbolKind::AssociativeArrayType:
       return diag::Unsupported(
           decl_span, diag::DiagCode::kUnsupportedAssociativeArrayType,

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -118,6 +118,17 @@ auto SynthesizeDefaultValueExpr(
                     .data = mir::ConstructExpr{.args = {element_default}},
                     .type = type});
           },
+          // LRM Table 6-7: a queue's default is the empty queue. Same emit
+          // chain as the dynamic array -- the element default seeds the
+          // wrapper's shield slot while storage starts empty.
+          [&](const mir::QueueType& q) -> mir::ExprId {
+            const mir::ExprId element_default =
+                SynthesizeDefaultValueExpr(module, frame, q.element_type);
+            return scope.AddExpr(
+                mir::Expr{
+                    .data = mir::ConstructExpr{.args = {element_default}},
+                    .type = type});
+          },
           // Types whose runtime default is the C++ language-level default
           // (named-event handle, child module instance, `unique_ptr<Child>`,
           // `vector<Child>`). The constructor scope is the real populator
@@ -163,12 +174,13 @@ auto BuildArrayConstructExpr(
         using TyT = std::decay_t<decltype(t)>;
         if constexpr (
             std::same_as<TyT, mir::UnpackedArrayType> ||
-            std::same_as<TyT, mir::DynamicArrayType>) {
+            std::same_as<TyT, mir::DynamicArrayType> ||
+            std::same_as<TyT, mir::QueueType>) {
           return t.element_type;
         } else {
           throw InternalError(
-              "BuildArrayConstructExpr: type is not UnpackedArrayType or "
-              "DynamicArrayType");
+              "BuildArrayConstructExpr: type is not UnpackedArrayType, "
+              "DynamicArrayType, or QueueType");
         }
       },
       ty.data);

--- a/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
@@ -57,7 +57,8 @@ auto BuildArrayReplicationFlatList(
 
 auto IsArrayContainerType(const mir::Type& ty) -> bool {
   return std::holds_alternative<mir::UnpackedArrayType>(ty.data) ||
-         std::holds_alternative<mir::DynamicArrayType>(ty.data);
+         std::holds_alternative<mir::DynamicArrayType>(ty.data) ||
+         std::holds_alternative<mir::QueueType>(ty.data);
 }
 
 }  // namespace
@@ -98,8 +99,8 @@ auto LowerHirReplicationExprProc(
 
 // Lowers an HIR AssignmentPatternExpr by dispatching on the destination
 // type's runtime shape: packed targets fold into MIR `ConcatExpr` (bit
-// concatenation matches the packed bit plane), array containers (unpacked
-// and dynamic) land as `ArrayLiteralExpr` over distinct `std::vector` slots
+// concatenation matches the packed bit plane), array containers (unpacked,
+// dynamic, queue) land as `ArrayLiteralExpr` over distinct element slots
 // wrapped by a `ConstructExpr` against the container ctor.
 auto LowerHirAssignmentPatternExprProc(
     ProcessLowerer& process, WalkFrame frame,

--- a/tests/cases/cpp/queue_basic_type/case.yaml
+++ b/tests/cases/cpp/queue_basic_type/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.queue_basic_type
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q: [1, 2, 3]
+    r: [7, 7, 7, 7]
+    e: []

--- a/tests/cases/cpp/queue_basic_type/main.sv
+++ b/tests/cases/cpp/queue_basic_type/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  // Positional assignment-pattern declaration initializer (LRM 7.10 / 10.9.1).
+  int q [$] = '{1, 2, 3};
+  // Replicated assignment-pattern declaration initializer.
+  int r [$] = '{4{7}};
+  // No initializer: LRM Table 6-7 default is the empty queue.
+  int e [$];
+endmodule

--- a/tests/cases/errors/unsupported_type/case.yaml
+++ b/tests/cases/errors/unsupported_type/case.yaml
@@ -12,8 +12,8 @@ expect:
     contains:
       - "main.sv:2:"
       - "unsupported:"
-      - "queue types are not supported"
-      - "logic q [$];"
+      - "associative array types are not supported"
+      - "int m [string];"
     not_contains:
       - "internal error"
       - "\x1b["

--- a/tests/cases/errors/unsupported_type/main.sv
+++ b/tests/cases/errors/unsupported_type/main.sv
@@ -1,3 +1,3 @@
 module Top;
-  logic q [$];
+  int m [string];
 endmodule


### PR DESCRIPTION
## Summary

Brings the SystemVerilog queue (`int q [$]`, LRM 7.10) up as a basic data type, end to end. The type-system plumbing for queues already existed in HIR and MIR (the `QueueType` struct, the `kQueue` kind, the HIR-to-MIR translation, and both dumpers); what was missing was the AST-to-HIR lowering, a runtime value type, and the backend rendering. The AST-to-HIR boundary now builds a `hir::QueueType` from slang's queue (carrying the bounded-queue limit) instead of rejecting it as unsupported. A new runtime `Queue<T>` is backed by `std::deque` so the eventual double-ended method family lands on O(1) front operations, and it carries the LRM 7.4.5 invalid-index shield seed and a `%p` aggregate formatter mirroring the dynamic array. The empty-queue default (LRM Table 6-7) and the assignment-pattern initializer (positional and replicated) reuse the array-container construction path the dynamic array already uses, and the print and assignment-pattern paths are widened to admit queues.

Scope is intentionally the basic type only. Element indexing, the method family (push, pop, size, insert, delete), aggregate equality, and bounded-queue enforcement are out of scope and follow in a later cut. The now-dead `kUnsupportedQueueType` diagnostic is removed.

## Testing

A new `queue_basic_type` case asserts the empty default, a positional initializer, and a replicated initializer through `expect.variables`, which round-trips each queue through the same `%p` aggregate-render path the runtime uses. The test framework needed no change: its aggregate probe is type-agnostic and works for queues once the print path accepts them and the formatter exists. The `unsupported_type` error case is repointed at an associative array, which remains unsupported. Full `bazel test //...` passes.