### PR TITLE
Add dynamic-array locator methods returning queues

### DIFF
--- a/include/lyra/hir/method.hpp
+++ b/include/lyra/hir/method.hpp
@@ -46,12 +46,17 @@ enum class EventMethodKind : std::uint8_t {
   kTriggered,
 };
 
-// LRM 7.5.2 / 7.5.3 dynamic-array methods plus the LRM 7.12.2 / 7.12.3
-// no-`with`, no-queue-return subset of the array-method family. The arms
+// LRM 7.5.2 / 7.5.3 dynamic-array methods plus the LRM 7.12 array-method
+// family (ordering, reduction, and the 7.12.1 locator methods). The arms
 // are named for "array" rather than "dynamic array" because the method
 // semantics are LRM-uniform across container kinds (fixed unpacked, queue);
 // only the AST -> HIR receiver-detection block differs per container, and
 // other containers will extend the routing without renaming this enum.
+//
+// The 7.12.1 locator arms (`kFind` onward) return a queue: an element queue
+// for the value locators (`find`, `find_first`, `find_last`, `min`, `max`,
+// `unique`) and an `int` queue for the index locators (`find_index`,
+// `find_first_index`, `find_last_index`, `unique_index`).
 enum class ArrayMethodKind : std::uint8_t {
   kSize,
   kDelete,
@@ -63,6 +68,16 @@ enum class ArrayMethodKind : std::uint8_t {
   kAnd,
   kOr,
   kXor,
+  kFind,
+  kFindIndex,
+  kFindFirst,
+  kFindFirstIndex,
+  kFindLast,
+  kFindLastIndex,
+  kMin,
+  kMax,
+  kUnique,
+  kUniqueIndex,
 };
 
 // LRM 7.12.4 iterator intrinsic methods (only `index` is in scope today;

--- a/include/lyra/mir/builtin_method.hpp
+++ b/include/lyra/mir/builtin_method.hpp
@@ -48,8 +48,10 @@ enum class EventMethodKind : std::uint8_t {
   kTriggered,
 };
 
-// LRM 7.5.2 / 7.5.3 dynamic-array methods plus the LRM 7.12.2 / 7.12.3
-// no-`with`, no-queue-return subset of the array-method family.
+// LRM 7.5.2 / 7.5.3 dynamic-array methods plus the LRM 7.12 array-method
+// family (ordering, reduction, and the 7.12.1 locator methods). The locator
+// arms (`kFind` onward) return a queue -- an element queue for the value
+// locators and an `int` queue for the index locators.
 enum class ArrayMethodKind : std::uint8_t {
   kSize,
   kDelete,
@@ -61,6 +63,16 @@ enum class ArrayMethodKind : std::uint8_t {
   kAnd,
   kOr,
   kXor,
+  kFind,
+  kFindIndex,
+  kFindFirst,
+  kFindFirstIndex,
+  kFindLast,
+  kFindLastIndex,
+  kMin,
+  kMax,
+  kUnique,
+  kUniqueIndex,
 };
 
 // Side-effect-free queries that are defined for every runtime value type

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <span>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -13,8 +14,34 @@
 #include "lyra/value/array_case_equal.hpp"
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
+#include "lyra/value/queue.hpp"
 
 namespace lyra::value {
+
+namespace detail {
+
+// LRM 7.12.1 locator comparisons over a key type (the element itself for the
+// no-`with` form, or the `with`-expression result otherwise). `PackedArray`
+// returns a 1-bit truth value whose X/Z collapses to false in a boolean
+// context; `String` / `double` return a plain `bool`.
+template <typename K>
+[[nodiscard]] auto LocatorKeyLess(const K& a, const K& b) -> bool {
+  return static_cast<bool>(a < b);
+}
+
+// Uniqueness equality. 4-state integral keys compare bit-exact (LRM 11.4.5
+// `===`), so two X-valued keys are the same value while X never equals a
+// known bit; non-integral keys have no unknown plane and use value equality.
+template <typename K>
+[[nodiscard]] auto LocatorKeySame(const K& a, const K& b) -> bool {
+  if constexpr (std::is_same_v<K, PackedArray>) {
+    return static_cast<bool>(a.CaseEqual(b));
+  } else {
+    return a == b;
+  }
+}
+
+}  // namespace detail
 
 // SystemVerilog dynamic array (LRM 7.5). Size set at run time via `new[N]` /
 // `new[N](other)` constructors; default is the empty array (LRM Table 6-7).
@@ -278,7 +305,217 @@ class DynamicArray {
         std::forward<F>(key), [](auto& acc, auto& v) { acc = acc ^ v; });
   }
 
+  // LRM 7.12.1 locator methods. Each returns a queue: the value locators
+  // (`find`, `find_first`, `find_last`, `min`, `max`, `unique`) return a
+  // queue of elements; the index locators (`find_index`, ...) return a queue
+  // of `int`. No match or an empty receiver yields an empty queue. The `with`
+  // clause is mandatory for the find family (a Boolean predicate) and
+  // optional for `min` / `max` / `unique` (a comparison key; omitted means the
+  // element itself). The closure receives each element and its index, matching
+  // the ordering / reduction `*By` convention above.
+
+  template <typename F>
+  [[nodiscard]] auto FindBy(F pred) const -> Queue<T> {
+    std::vector<T> out;
+    for (std::size_t i = 0; i < data_.size(); ++i) {
+      if (static_cast<bool>(
+              pred(data_[i], PackedArray::Int(static_cast<int>(i))))) {
+        out.push_back(data_[i]);
+      }
+    }
+    return Queue<T>(oob_slot_, out);
+  }
+
+  template <typename F>
+  [[nodiscard]] auto FindIndexBy(F pred) const -> Queue<PackedArray> {
+    std::vector<PackedArray> out;
+    for (std::size_t i = 0; i < data_.size(); ++i) {
+      if (static_cast<bool>(
+              pred(data_[i], PackedArray::Int(static_cast<int>(i))))) {
+        out.push_back(PackedArray::Int(static_cast<int>(i)));
+      }
+    }
+    return {PackedArray::Int(0), out};
+  }
+
+  template <typename F>
+  [[nodiscard]] auto FindFirstBy(F pred) const -> Queue<T> {
+    std::vector<T> out;
+    for (std::size_t i = 0; i < data_.size(); ++i) {
+      if (static_cast<bool>(
+              pred(data_[i], PackedArray::Int(static_cast<int>(i))))) {
+        out.push_back(data_[i]);
+        break;
+      }
+    }
+    return Queue<T>(oob_slot_, out);
+  }
+
+  template <typename F>
+  [[nodiscard]] auto FindFirstIndexBy(F pred) const -> Queue<PackedArray> {
+    std::vector<PackedArray> out;
+    for (std::size_t i = 0; i < data_.size(); ++i) {
+      if (static_cast<bool>(
+              pred(data_[i], PackedArray::Int(static_cast<int>(i))))) {
+        out.push_back(PackedArray::Int(static_cast<int>(i)));
+        break;
+      }
+    }
+    return {PackedArray::Int(0), out};
+  }
+
+  template <typename F>
+  [[nodiscard]] auto FindLastBy(F pred) const -> Queue<T> {
+    std::vector<T> out;
+    for (std::size_t i = data_.size(); i-- > 0;) {
+      if (static_cast<bool>(
+              pred(data_[i], PackedArray::Int(static_cast<int>(i))))) {
+        out.push_back(data_[i]);
+        break;
+      }
+    }
+    return Queue<T>(oob_slot_, out);
+  }
+
+  template <typename F>
+  [[nodiscard]] auto FindLastIndexBy(F pred) const -> Queue<PackedArray> {
+    std::vector<PackedArray> out;
+    for (std::size_t i = data_.size(); i-- > 0;) {
+      if (static_cast<bool>(
+              pred(data_[i], PackedArray::Int(static_cast<int>(i))))) {
+        out.push_back(PackedArray::Int(static_cast<int>(i)));
+        break;
+      }
+    }
+    return {PackedArray::Int(0), out};
+  }
+
+  [[nodiscard]] auto Min() const -> Queue<T> {
+    return ExtremumElement(
+        [](const T& a, const T& b) { return detail::LocatorKeyLess(a, b); });
+  }
+  [[nodiscard]] auto Max() const -> Queue<T> {
+    return ExtremumElement(
+        [](const T& a, const T& b) { return detail::LocatorKeyLess(b, a); });
+  }
+  template <typename F>
+  [[nodiscard]] auto MinBy(F&& key) const -> Queue<T> {
+    return ExtremumByKey(
+        std::forward<F>(key), [](const auto& a, const auto& b) {
+          return detail::LocatorKeyLess(a, b);
+        });
+  }
+  template <typename F>
+  [[nodiscard]] auto MaxBy(F&& key) const -> Queue<T> {
+    return ExtremumByKey(
+        std::forward<F>(key), [](const auto& a, const auto& b) {
+          return detail::LocatorKeyLess(b, a);
+        });
+  }
+
+  [[nodiscard]] auto Unique() const -> Queue<T> {
+    std::vector<T> out;
+    std::vector<T> seen;
+    for (const auto& elem : data_) {
+      if (!SeenContains(seen, elem)) {
+        seen.push_back(elem);
+        out.push_back(elem);
+      }
+    }
+    return Queue<T>(oob_slot_, out);
+  }
+  template <typename F>
+  [[nodiscard]] auto UniqueBy(F key) const -> Queue<T> {
+    using KeyT = std::invoke_result_t<F&, const T&, const PackedArray&>;
+    std::vector<T> out;
+    std::vector<KeyT> seen;
+    for (std::size_t i = 0; i < data_.size(); ++i) {
+      auto k = key(data_[i], PackedArray::Int(static_cast<int>(i)));
+      if (!SeenContains(seen, k)) {
+        seen.push_back(k);
+        out.push_back(data_[i]);
+      }
+    }
+    return Queue<T>(oob_slot_, out);
+  }
+
+  [[nodiscard]] auto UniqueIndex() const -> Queue<PackedArray> {
+    std::vector<PackedArray> out;
+    std::vector<T> seen;
+    for (std::size_t i = 0; i < data_.size(); ++i) {
+      if (!SeenContains(seen, data_[i])) {
+        seen.push_back(data_[i]);
+        out.push_back(PackedArray::Int(static_cast<int>(i)));
+      }
+    }
+    return {PackedArray::Int(0), out};
+  }
+  template <typename F>
+  [[nodiscard]] auto UniqueIndexBy(F key) const -> Queue<PackedArray> {
+    using KeyT = std::invoke_result_t<F&, const T&, const PackedArray&>;
+    std::vector<PackedArray> out;
+    std::vector<KeyT> seen;
+    for (std::size_t i = 0; i < data_.size(); ++i) {
+      auto k = key(data_[i], PackedArray::Int(static_cast<int>(i)));
+      if (!SeenContains(seen, k)) {
+        seen.push_back(k);
+        out.push_back(PackedArray::Int(static_cast<int>(i)));
+      }
+    }
+    return {PackedArray::Int(0), out};
+  }
+
  private:
+  // Returns a one-element queue holding the element ranked first by `prefer`
+  // (`prefer(candidate, current)` true means the candidate replaces the
+  // current pick), or an empty queue when the receiver is empty. Min and Max
+  // differ only in the direction of `prefer`.
+  template <typename Prefer>
+  [[nodiscard]] auto ExtremumElement(Prefer prefer) const -> Queue<T> {
+    std::vector<T> out;
+    if (!data_.empty()) {
+      std::size_t pick = 0;
+      for (std::size_t i = 1; i < data_.size(); ++i) {
+        if (prefer(data_[i], data_[pick])) {
+          pick = i;
+        }
+      }
+      out.push_back(data_[pick]);
+    }
+    return Queue<T>(oob_slot_, out);
+  }
+
+  // Keyed sibling of ExtremumElement: ranks by the closure's key but returns
+  // the element itself (LRM 7.12.1 `min` / `max with`).
+  template <typename F, typename Prefer>
+  [[nodiscard]] auto ExtremumByKey(F key, Prefer prefer) const -> Queue<T> {
+    std::vector<T> out;
+    if (!data_.empty()) {
+      std::size_t pick = 0;
+      auto best_key = key(data_[0], PackedArray::Int(0));
+      for (std::size_t i = 1; i < data_.size(); ++i) {
+        auto k = key(data_[i], PackedArray::Int(static_cast<int>(i)));
+        if (prefer(k, best_key)) {
+          best_key = k;
+          pick = i;
+        }
+      }
+      out.push_back(data_[pick]);
+    }
+    return Queue<T>(oob_slot_, out);
+  }
+
+  template <typename K>
+  [[nodiscard]] static auto SeenContains(const std::vector<K>& seen, const K& k)
+      -> bool {
+    for (const auto& s : seen) {
+      if (detail::LocatorKeySame(k, s)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   template <typename Compare>
   auto SelectionSortBy(Compare cmp) -> void {
     using std::swap;

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -813,6 +813,26 @@ auto ArrayMethodMemberName(mir::ArrayMethodKind k) -> std::string_view {
       return "Or";
     case mir::ArrayMethodKind::kXor:
       return "Xor";
+    case mir::ArrayMethodKind::kFind:
+      return "Find";
+    case mir::ArrayMethodKind::kFindIndex:
+      return "FindIndex";
+    case mir::ArrayMethodKind::kFindFirst:
+      return "FindFirst";
+    case mir::ArrayMethodKind::kFindFirstIndex:
+      return "FindFirstIndex";
+    case mir::ArrayMethodKind::kFindLast:
+      return "FindLast";
+    case mir::ArrayMethodKind::kFindLastIndex:
+      return "FindLastIndex";
+    case mir::ArrayMethodKind::kMin:
+      return "Min";
+    case mir::ArrayMethodKind::kMax:
+      return "Max";
+    case mir::ArrayMethodKind::kUnique:
+      return "Unique";
+    case mir::ArrayMethodKind::kUniqueIndex:
+      return "UniqueIndex";
   }
   throw InternalError("ArrayMethodMemberName: unknown kind");
 }

--- a/src/lyra/lowering/ast_to_hir/expression/slang_atoms.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/slang_atoms.cpp
@@ -231,6 +231,16 @@ auto LowerArrayMethodName(std::string_view name)
   if (name == "and") return hir::ArrayMethodKind::kAnd;
   if (name == "or") return hir::ArrayMethodKind::kOr;
   if (name == "xor") return hir::ArrayMethodKind::kXor;
+  if (name == "find") return hir::ArrayMethodKind::kFind;
+  if (name == "find_index") return hir::ArrayMethodKind::kFindIndex;
+  if (name == "find_first") return hir::ArrayMethodKind::kFindFirst;
+  if (name == "find_first_index") return hir::ArrayMethodKind::kFindFirstIndex;
+  if (name == "find_last") return hir::ArrayMethodKind::kFindLast;
+  if (name == "find_last_index") return hir::ArrayMethodKind::kFindLastIndex;
+  if (name == "min") return hir::ArrayMethodKind::kMin;
+  if (name == "max") return hir::ArrayMethodKind::kMax;
+  if (name == "unique") return hir::ArrayMethodKind::kUnique;
+  if (name == "unique_index") return hir::ArrayMethodKind::kUniqueIndex;
   return std::nullopt;
 }
 

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -12,10 +12,8 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_body.hpp"
-#include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
-#include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/hir_to_mir/capture_sink.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/control.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/diagnostic.hpp"
@@ -32,7 +30,6 @@
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/procedural_hops.hpp"
-#include "lyra/mir/runtime_timescale.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -133,6 +130,26 @@ auto LowerArrayMethodKind(hir::ArrayMethodKind k) -> mir::ArrayMethodKind {
       return mir::ArrayMethodKind::kOr;
     case hir::ArrayMethodKind::kXor:
       return mir::ArrayMethodKind::kXor;
+    case hir::ArrayMethodKind::kFind:
+      return mir::ArrayMethodKind::kFind;
+    case hir::ArrayMethodKind::kFindIndex:
+      return mir::ArrayMethodKind::kFindIndex;
+    case hir::ArrayMethodKind::kFindFirst:
+      return mir::ArrayMethodKind::kFindFirst;
+    case hir::ArrayMethodKind::kFindFirstIndex:
+      return mir::ArrayMethodKind::kFindFirstIndex;
+    case hir::ArrayMethodKind::kFindLast:
+      return mir::ArrayMethodKind::kFindLast;
+    case hir::ArrayMethodKind::kFindLastIndex:
+      return mir::ArrayMethodKind::kFindLastIndex;
+    case hir::ArrayMethodKind::kMin:
+      return mir::ArrayMethodKind::kMin;
+    case hir::ArrayMethodKind::kMax:
+      return mir::ArrayMethodKind::kMax;
+    case hir::ArrayMethodKind::kUnique:
+      return mir::ArrayMethodKind::kUnique;
+    case hir::ArrayMethodKind::kUniqueIndex:
+      return mir::ArrayMethodKind::kUniqueIndex;
   }
   throw InternalError("LowerArrayMethodKind: unknown hir::ArrayMethodKind");
 }

--- a/tests/cases/cpp/queue_locator_methods/case.yaml
+++ b/tests/cases/cpp/queue_locator_methods/case.yaml
@@ -1,0 +1,23 @@
+id: cpp.queue_locator_methods
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q_find: [5, 8, 8]
+    q_find_idx: [0, 2, 5]
+    q_first: [5]
+    q_first_idx: [0]
+    q_last: [8]
+    q_last_idx: [5]
+    q_nomatch: []
+    q_min: [1]
+    q_max: [8]
+    q_unique: [5, 3, 8, 1]
+    q_unique_idx: [0, 1, 2, 4]
+    q_min_empty: []
+    q_minby: [8]

--- a/tests/cases/cpp/queue_locator_methods/main.sv
+++ b/tests/cases/cpp/queue_locator_methods/main.sv
@@ -1,0 +1,38 @@
+module Top;
+  int ia [] = '{5, 3, 8, 3, 1, 8};
+  int empty_arr [];
+
+  // find family (with clause mandatory, Boolean predicate).
+  int q_find [$];
+  int q_find_idx [$];
+  int q_first [$];
+  int q_first_idx [$];
+  int q_last [$];
+  int q_last_idx [$];
+  int q_nomatch [$];
+
+  // min / max / unique (with clause optional); index variants return queue<int>.
+  int q_min [$];
+  int q_max [$];
+  int q_unique [$];
+  int q_unique_idx [$];
+  int q_min_empty [$];
+  int q_minby [$];
+
+  initial begin
+    q_find          = ia.find             with (item > 3);
+    q_find_idx      = ia.find_index       with (item > 3);
+    q_first         = ia.find_first       with (item > 3);
+    q_first_idx     = ia.find_first_index with (item > 3);
+    q_last          = ia.find_last        with (item > 3);
+    q_last_idx      = ia.find_last_index  with (item > 3);
+    q_nomatch       = ia.find             with (item > 100);
+
+    q_min           = ia.min;
+    q_max           = ia.max;
+    q_unique        = ia.unique;
+    q_unique_idx    = ia.unique_index;
+    q_min_empty     = empty_arr.min;
+    q_minby         = ia.min with (10 - item);
+  end
+endmodule

--- a/tests/cases/cpp/queue_locator_string/case.yaml
+++ b/tests/cases/cpp/queue_locator_string/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.queue_locator_string
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      '{"apple"}
+      '{"banana", "apple", "cherry"}
+      '{"cherry"}

--- a/tests/cases/cpp/queue_locator_string/main.sv
+++ b/tests/cases/cpp/queue_locator_string/main.sv
@@ -1,0 +1,10 @@
+module Top;
+  string sa [] = '{"banana", "apple", "cherry", "apple"};
+  initial begin
+    // No-with min uses String operator<; unique dedups by String value.
+    $display("%p", sa.min);
+    $display("%p", sa.unique);
+    // with-key max compares by the closure key (still String here).
+    $display("%p", sa.max with (item));
+  end
+endmodule


### PR DESCRIPTION
## Summary

Implements the full LRM 7.12.1 array locator family on the dynamic array, now that queues exist as a return type. This adds `find`, `find_index`, `find_first`, `find_first_index`, `find_last`, `find_last_index`, `min`, `max`, `unique`, and `unique_index` -- the ten methods previously blocked because each returns a queue (an element queue for the value locators, an `int` queue for the index locators). The dispatch plumbing reuses the existing array-method routing: the AST-to-HIR receiver detection already binds the `with` clause and its iterator generically, the closure synthesis and capture machinery already exist, and the backend already dispatches on argument count between the no-`with` and `with` forms. The change is therefore additive -- new method kinds across HIR and MIR, their name and member-name mappings, and the runtime methods on the dynamic array that build and return the result queues.

## Design

The find family takes a mandatory Boolean predicate; a result whose unknown bits make the comparison X is treated as not matching, since X is not truthy. The `min`, `max`, and `unique` methods take an optional `with` key and otherwise compare the elements themselves, so each has a no-key and a keyed runtime variant. `min` and `max` return the element ranked first by the key, not the key value, and collapse duplicate extrema to one. Uniqueness dedups by case-equality for integral keys so two X-valued keys count as the same value while X never equals a known bit; non-integral keys use plain value equality. An empty receiver or no match yields an empty queue throughout. Index locators build a queue of 32-bit `int` regardless of the element type.

## Testing

One case asserts all ten methods on an integer array through `expect.variables`, covering the no-match, empty-receiver, keyed-`min`, and dedup cases. A second case exercises the string-element path (`min`, `unique`, and a keyed `max`) through `$display %p` to confirm the runtime templates hold for a non-integral element type. Full `bazel test //...` passes.