### PR TITLE
Wire self through the MIR-to-cpp render and lower variable init as constructor statement

### DIFF
--- a/docs/architecture/mir.md
+++ b/docs/architecture/mir.md
@@ -14,15 +14,17 @@ several possible backend targets for MIR, and does not define MIR's semantics.
 - The type system: value types (integral, real, string, event, ...); object types in two forms -- an
   intra-unit object (a structural scope of this unit) and an external-unit object (another
   compilation unit, named); and two composing wrappers, owning pointer and vector.
-- Callables: functions, tasks, constructors, processes, and assertion actions.
+- Callables: functions, tasks, constructors, processes, and assertion actions. Every callable's
+  parameter list begins with `self`, a pointer to the enclosing structural scope; the body reaches
+  every value it needs through its parameter list and captures, never through implicit context.
 - The identity of each object and member within a compilation unit.
 - Lightweight structured control flow inside a callable body: `if`, loop, and sequence. No basic
   blocks at this layer.
 - A primitive expression set: literals, references, unary / binary / conditional operators, calls,
-  conversions, closures, access primitives for element and range selection, and value-build
-  primitives for aggregate construction. SystemVerilog syntactic sugar that decomposes into this set
-  (`case`, `inside`, `casez` / `casex`, `foreach`) is lowered at the HIR-to-MIR boundary and never
-  carried as a MIR node.
+  conversions, closures, member access through an explicit receiver expression, access primitives
+  for element and range selection, and value-build primitives for aggregate construction.
+  SystemVerilog syntactic sugar that decomposes into this set (`case`, `inside`, `casez` / `casex`,
+  `foreach`) is lowered at the HIR-to-MIR boundary and never carried as a MIR node.
 - Action shapes for constructs that bind behavior to schedule events (always blocks, continuous
   assignments, deferred assertions, concurrent assertions).
 - A textual dumper that serializes MIR for inspection, validation, and golden testing. The dumper is
@@ -67,6 +69,14 @@ several possible backend targets for MIR, and does not define MIR's semantics.
     same behaviour from the same MIR: anything they would otherwise have to infer must already be
     stated.
 
+11. Every callable body's first parameter is `self`, a pointer to its enclosing structural scope.
+    Access to any class member -- a structural variable, a service call, a child instance -- flows
+    through `MemberAccess` whose receiver expression reaches the scope by traversing from `self`. A
+    callable has no implicit access to its enclosing state; the receiver is on the parameter list,
+    not on the expression. The shape is identical across process, task, function, constructor body,
+    and closure -- a backend reads it once and renders it the same way each time. See
+    `docs/decisions/callable-receiver.md`.
+
 ## Boundary to Adjacent Layers
 
 - Consumes HIR. HIR-to-MIR lowering produces MIR objects and members from HIR declarations and MIR
@@ -109,6 +119,11 @@ several possible backend targets for MIR, and does not define MIR's semantics.
   belongs there as structure) or already present (and the field is noise). The falsifiable check on
   a new field is: does every backend's realization read it, and does it state something the
   structure does not?
+- An expression node whose meaning depends on which callable encloses it. A node that resolves to
+  "the current receiver, whatever that is" carries an implicit context the consumer must walk
+  surroundings to discover. Receiver semantics live on the callable's parameter list as `self`, not
+  on a context-dependent expression node; member access reads the receiver from the containing
+  `MemberAccess`'s receiver field, never from a node that means "look around and figure it out".
 
 ## Notes / Examples
 
@@ -142,16 +157,17 @@ expression set that decomposes the ternary. Value-build primitives for aggregate
 expressions are access primitives. Each of these stays in MIR for the same reason: removing it would
 require expanding into a statement-form rewrite that does not fit the expression context.
 
-A closure is a captured callable value: a capture list plus a procedural-scope body, the one IR
-shape for "a body bound to a snapshot of its environment, run later." A closure is synthesized only
-by HIR-to-MIR lowering; no source construct produces one. Its body reaches enclosing procedural
-state only through the captures, and reaches module-scope storage directly -- the way a lambda
-references globals without capture. The closure node carries nothing about how it executes: like a
+A closure is a captured callable value: a parameter list, a capture list, and a procedural-scope
+body, the one IR shape for "a body bound to a snapshot of its environment, run later." A closure is
+synthesized only by HIR-to-MIR lowering; no source construct produces one. Its body reaches every
+value it needs through its parameter list -- captures for enclosing procedural state, the `self`
+parameter (shared by every callable, invariant 11) for enclosing module-scope storage. Nothing
+reaches the body implicitly. The closure node carries nothing about how it executes: like a
 language-level lambda, it has no "suspends" property. Whether a closure runs synchronously or as a
 coroutine follows from its use, which is itself explicit in MIR -- a closure submitted as a deferred
 effect (a non-blocking assignment, a postponed `$strobe`) runs to completion in a later scheduling
 region; a closure referenced by a parallel block (a fork-join branch, LRM 9.3.2) is spawned as a
 concurrent process and therefore a coroutine. The capture model and the body are identical across
 both. A process, a subroutine, and a closure are the three callable forms whose bodies are all the
-same procedural scope; they differ only in how the body binds its environment and in how it is
-invoked.
+same procedural scope; they differ only in how each is invoked. They share the same shape at the
+parameter list -- `self` first, then any closure captures and parameters or subroutine formals.

--- a/docs/architecture/mir.md
+++ b/docs/architecture/mir.md
@@ -14,9 +14,9 @@ several possible backend targets for MIR, and does not define MIR's semantics.
 - The type system: value types (integral, real, string, event, ...); object types in two forms -- an
   intra-unit object (a structural scope of this unit) and an external-unit object (another
   compilation unit, named); and two composing wrappers, owning pointer and vector.
-- Callables: functions, tasks, constructors, processes, and assertion actions. Every callable's
-  parameter list begins with `self`, a pointer to the enclosing structural scope; the body reaches
-  every value it needs through its parameter list and captures, never through implicit context.
+- Callables: functions, tasks, constructors, processes, and assertion actions. Every callable body's
+  first binding is `self`, a pointer to the enclosing structural scope; the body reaches every value
+  it needs through its parameter list and captures, never through implicit context.
 - The identity of each object and member within a compilation unit.
 - Lightweight structured control flow inside a callable body: `if`, loop, and sequence. No basic
   blocks at this layer.
@@ -69,13 +69,22 @@ several possible backend targets for MIR, and does not define MIR's semantics.
     same behaviour from the same MIR: anything they would otherwise have to infer must already be
     stated.
 
-11. Every callable body's first parameter is `self`, a pointer to its enclosing structural scope.
-    Access to any class member -- a structural variable, a service call, a child instance -- flows
-    through `MemberAccess` whose receiver expression reaches the scope by traversing from `self`. A
-    callable has no implicit access to its enclosing state; the receiver is on the parameter list,
-    not on the expression. The shape is identical across process, task, function, constructor body,
-    and closure -- a backend reads it once and renders it the same way each time. See
-    `docs/decisions/callable-receiver.md`.
+11. Every callable body's first binding is `self`, a pointer to its enclosing structural scope --
+    `body.vars[0]` is a procedural-var declaration of that pointer type, named `self`. Access to any
+    class member -- a structural variable, a service call, a child instance -- flows through
+    `MemberAccess` whose receiver expression reaches the scope by traversing from `self`. A callable
+    has no implicit access to its enclosing state; the receiver is reached through an explicit
+    binding, never through an expression that means "look around and figure it out". The body's view
+    of `self` is uniform across every callable form -- the read site reads `vars[0]` the same way in
+    a process, a task, a function, a constructor body, and a closure.
+
+    Where `self`'s value comes from differs by callable form, following the natural binding shape of
+    each: process, structural subroutine, and constructor bodies receive `self` as their first
+    formal parameter (each caller -- the runtime, a call site, the instance constructor -- supplies
+    it); a closure receives `self` as its first by-value capture (the enclosing scope snapshots its
+    own self at closure construction, because no runtime invoker of the closure value knows which
+    receiver to pass). Both supply mechanisms land the same binding at `body.vars[0]`; the body code
+    does not know or care which mechanism filled it. See `docs/decisions/callable-receiver.md`.
 
 ## Boundary to Adjacent Layers
 
@@ -121,9 +130,9 @@ several possible backend targets for MIR, and does not define MIR's semantics.
   structure does not?
 - An expression node whose meaning depends on which callable encloses it. A node that resolves to
   "the current receiver, whatever that is" carries an implicit context the consumer must walk
-  surroundings to discover. Receiver semantics live on the callable's parameter list as `self`, not
-  on a context-dependent expression node; member access reads the receiver from the containing
-  `MemberAccess`'s receiver field, never from a node that means "look around and figure it out".
+  surroundings to discover. Receiver semantics live on `body.vars[0]` as the `self` binding, reached
+  through `ProceduralVarRef`; member access reads the receiver from the containing `MemberAccess`'s
+  receiver field, never from a node that means "look around and figure it out".
 
 ## Notes / Examples
 
@@ -160,14 +169,17 @@ require expanding into a statement-form rewrite that does not fit the expression
 A closure is a captured callable value: a parameter list, a capture list, and a procedural-scope
 body, the one IR shape for "a body bound to a snapshot of its environment, run later." A closure is
 synthesized only by HIR-to-MIR lowering; no source construct produces one. Its body reaches every
-value it needs through its parameter list -- captures for enclosing procedural state, the `self`
-parameter (shared by every callable, invariant 11) for enclosing module-scope storage. Nothing
-reaches the body implicitly. The closure node carries nothing about how it executes: like a
-language-level lambda, it has no "suspends" property. Whether a closure runs synchronously or as a
-coroutine follows from its use, which is itself explicit in MIR -- a closure submitted as a deferred
-effect (a non-blocking assignment, a postponed `$strobe`) runs to completion in a later scheduling
-region; a closure referenced by a parallel block (a fork-join branch, LRM 9.3.2) is spawned as a
-concurrent process and therefore a coroutine. The capture model and the body are identical across
-both. A process, a subroutine, and a closure are the three callable forms whose bodies are all the
-same procedural scope; they differ only in how each is invoked. They share the same shape at the
-parameter list -- `self` first, then any closure captures and parameters or subroutine formals.
+value it needs through its captures and parameters -- captures snapshot the enclosing scope's values
+at construction (including `self`, captured by value as the first capture; see invariant 11),
+parameters carry per-invocation values. Nothing reaches the body implicitly. The closure node
+carries nothing about how it executes: like a language-level lambda, it has no "suspends" property.
+Whether a closure runs synchronously or as a coroutine follows from its use, which is itself
+explicit in MIR -- a closure submitted as a deferred effect (a non-blocking assignment, a postponed
+`$strobe`) runs to completion in a later scheduling region; a closure referenced by a parallel block
+(a fork-join branch, LRM 9.3.2) is spawned as a concurrent process and therefore a coroutine. The
+capture model and the body are identical across both. Process, structural subroutine, and closure
+are three callable forms whose bodies are all the same procedural scope; they differ in how each is
+invoked and in how `self` is supplied -- a process / subroutine / constructor body receives `self`
+as its first formal parameter at every invocation, a closure captures `self` by value at
+construction. Both supply paths end at the same place: `body.vars[0]` is `self`, read identically by
+every member access in the body.

--- a/docs/decisions/callable-receiver.md
+++ b/docs/decisions/callable-receiver.md
@@ -1,4 +1,4 @@
-# Callable receiver (explicit `self` first parameter)
+# Callable receiver (explicit `self` first binding)
 
 Date: 2026-06-15 Status: accepted
 
@@ -37,23 +37,47 @@ Three forces made the receiver model a real decision:
 
 ## Decision
 
-**Every MIR callable carries a first parameter `self : Pointer<EnclosingScope>`. The parameter is
-added unconditionally -- not derived from whether the body happens to touch class state. The body
-reaches every class member through
-`MemberAccessExpr(receiver = DerefExpr(ProceduralVarRef(self)), var = ...)`.**
+**Every MIR callable body's first binding is `self : Pointer<Self>` -- `body.vars[0]` is a
+procedural-var declaration of that pointer type, named `self`. The binding is added unconditionally,
+not derived from whether the body happens to touch class state. The body reaches every class member
+through `MemberAccessExpr(receiver = DerefExpr(ProceduralVarRef(self)), var = ...)`. The body's read
+of `self` is identical across every callable form -- a backend reads `vars[0]` the same way in a
+process, a subroutine, a constructor body, and a closure.**
+
+Where `self`'s value comes from differs by callable form, following each form's natural binding
+shape:
+
+- **Method-form callables** (process, structural subroutine, constructor body) take `self` as the
+  first formal parameter. Each caller knows its own receiver -- the runtime constructing a process
+  coroutine, a call site invoking a subroutine, the C++ constructor running the init body -- and
+  supplies it at invocation. The body's binding is filled by the call.
+- **Closure** carries `self` as the first by-value capture (`captures[0]` is a `ByValueCapture`
+  whose `value` is the enclosing scope's read of its own `self` and whose `binding` points at the
+  closure body's `vars[0]`). No invoker of a closure value -- the NBA / postponed-`$strobe` /
+  deferred-check region runner, the fork scheduler, the with-clause iterator, an IIFE call site --
+  can be relied on to know which receiver belongs in the body, because a closure value can outlive
+  the enclosing-scope frame that knows. The enclosing scope snapshots its own `self` into the
+  closure at construction; the closure body reads the captured value.
+
+This partition is not a stylistic choice -- it follows from "who knows the receiver?". A method-form
+callable has a caller-who-knows; a closure does not. Forcing both forms onto one supply mechanism
+would either require the closure caller to learn a receiver it cannot know, or require
+`std::bind_front`-style wrapping at every closure submit site that re-encodes the same snapshot
+under a different name. Each form using its natural mechanism yields one C++ idiom per form and zero
+special-case wrapping.
 
 This holds for `mir::Process`, `mir::StructuralSubroutineDecl`, `mir::ClosureExpr`, and the
-constructor-body callable. The shape is uniform; no callable form is special.
+constructor-body callable. The body shape is uniform; the supply mechanism differs.
 
-The C++ backend renders the receiver shape with the most idiomatic C++ form available, but the form
-is fixed by callable kind, not derived from context:
+The C++ backend renders each form in its natural idiom:
 
-- **Closure** -> lambda whose explicit first parameter is `M* self`. Lambda capture clause is `[]`
-  (empty); every value the lambda needs flows through its parameter list, not through implicit
-  capture.
-- **Process / subroutine / constructor-body** -> static method on the enclosing class whose first
-  parameter is `M* self`. The class still owns the storage; method body lives on the class so it can
-  name private members. The body sees `self->X`, never implicit `this`.
+- **Method-form callable** -> static method on the enclosing class whose first formal is `M* self`.
+  The class still owns the storage; the method body lives on the class so it can name private
+  members. The body sees `self->X`, never implicit `this`.
+- **Closure** -> lambda whose capture clause is
+  `[self = <enclosing self expr>, cap1 = ..., &cap2 = ...]`. Every capture is name-explicit; the
+  clause never contains `[this]`, `[=]`, or `[&]`. The body sees `self->X` through the captured
+  binding, never implicit `this`.
 
 The constructor body is the only callable whose corresponding C++ entry cannot be static (the real
 C++ constructor must be an instance constructor for instance creation to work). The constructor body
@@ -81,7 +105,7 @@ The render today carries walker state for the receiver (`ctx.ReceiverObject()`,
 `ctx.MemberPrefix()`, `ctx.DeferredByValueCapture()`) and switches between four C++ mechanisms based
 on which kind of body it has entered. Every future backend faces the same dispatch. Every
 maintenance change risks the four-way switch going out of sync. MIR carrying the receiver as a real
-parameter pushes the answer up to one place that every backend just reads.
+binding pushes the answer up to one place that every backend just reads.
 
 ## Rejected alternatives
 
@@ -106,7 +130,7 @@ parameter pushes the answer up to one place that every backend just reads.
   been the existing shape for fork-branch / NBA / scan closure bodies and is what the current
   `mir::SelfScopeExpr` is. The node's meaning is context-dependent -- it renders to `this` in a
   method body and `self` in a fork-branch body -- which is precisely the walker-state smell. The
-  cleaner replacement is the explicit `self` parameter plus `ProceduralVarRef`.
+  cleaner replacement is the explicit `self` binding plus `ProceduralVarRef`.
 
 - **A struct of free functions, no class membership at all.** Removes C++ implicit `this` entirely
   (process / subroutine bodies become free functions friended into the class). Plausible but breaks
@@ -114,12 +138,31 @@ parameter pushes the answer up to one place that every backend just reads.
   methods through `Scope*` polymorphism. Static methods give the same explicit-receiver shape
   without losing class membership.
 
+- **`self` as a closure parameter, supplied at invocation via `std::bind_front` at every deferred
+  submit site.** The literal "every callable receives self the same way" path: closures get an
+  `M* self` formal, lambda capture is `[]`, deferred submission wraps with
+  `std::bind_front(lambda, this, ...)` to bind the receiver before the runtime invokes the (now
+  zero-arg) callable. Looks uniform on paper but mistakes the question. The closure value's receiver
+  is fixed at the moment the value is built -- the runtime that later invokes it has no other
+  receiver to choose. Calling that fixed value a "parameter supplied at invocation" forces a
+  wrapping layer (`std::bind_front`) at every submit site whose only job is to re-encode
+  "construction-time snapshot" under the name "parameter". Semantically the closure's receiver IS a
+  capture; insisting on the parameter shape is shape-fitting, not modeling, and the wrapping shows
+  up at every deferred site. The chosen shape -- `self` as the closure's first by-value capture --
+  models the actual lifetime: the enclosing scope holds the receiver, the closure snapshots it at
+  construction, and the body reads the snapshot. No `std::bind_front`, no `[this]`, no parameter
+  that never varies.
+
 ## Consequences
 
 - `mir::Process`, `mir::StructuralSubroutineDecl`, `mir::ClosureExpr`, and the constructor body each
-  declare a `self` binding at `body.vars[0]` whose type is the unique-pointer / borrowed- pointer to
-  the enclosing structural scope. The binding's name is `self`; the type makes the pointee
-  unambiguous.
+  declare a `self` binding at `body.vars[0]` whose type is the borrowed-pointer to the enclosing
+  structural scope. The binding's name is `self`; the type makes the pointee unambiguous.
+
+- For method-form callables (process, subroutine, constructor body) the `self` binding is the first
+  formal parameter; the caller supplies it at invocation. For a closure, the `self` binding is the
+  first by-value capture (`captures[0]`); the enclosing scope's read of its own `self` supplies the
+  capture value at construction.
 
 - A new MIR expression `MemberAccessExpr { receiver: ExprId, var: StructuralVarRef-fields }`
   replaces today's implicit-receiver `StructuralVarRef`. The receiver expression is rendered before
@@ -133,15 +176,18 @@ parameter pushes the answer up to one place that every backend just reads.
 
 - C++ emit shape changes: process / subroutine / constructor bodies emit as
   `static auto <name>(M* self, ...) -> ... { ... }`; the C++ constructor delegates the body to a
-  static `init(this)` call. Lambda capture clauses are `[]` -- every captured value flows through
-  the lambda's parameter list. `CreateProcesses()` adapts: where it previously emitted
-  `AddProcess(kind, process_N())` it now emits `AddProcess(kind, process_N(this))`.
+  static `init(this)` call. Closures emit as
+  `[self = <enclosing self expr>, cap1 = ..., &cap2 = ...](closure_params) -> R { ... }` -- every
+  capture is name-explicit; the clause never contains `[this]`, `[=]`, or `[&]`. `CreateProcesses()`
+  adapts: where it previously emitted `AddProcess(kind, process_N())` it now emits
+  `AddProcess(kind, process_N(this))`.
 
-- LIR / LLVM-IR lowering reads the receiver parameter directly off MIR. No backend re-derives
-  receiver semantics.
+- LIR / LLVM-IR lowering reads the `self` binding directly off MIR. No backend re-derives receiver
+  semantics.
 
 - Forbidden Shape: a MIR expression whose meaning depends on which callable encloses it. The
-  receiver is on the callable's parameter list, not on the expression.
+  receiver is reached through `body.vars[0]` as the `self` binding, not through an expression that
+  means "look around and figure it out".
 
 ## Cross-references
 

--- a/docs/decisions/callable-receiver.md
+++ b/docs/decisions/callable-receiver.md
@@ -1,0 +1,149 @@
+# Callable receiver (explicit `self` first parameter)
+
+Date: 2026-06-15 Status: accepted
+
+## Context
+
+Every SV callable (process, task, function, fork-branch closure, NBA / `$strobe` / `$sscanf` /
+with-clause / deferred-check closure, constructor body) reads or writes the enclosing module's state
+-- its signals, its child instances, its services. The body has no way to reach that state without a
+pointer to where it lives; in software-semantic terms it must receive a pointer to the enclosing
+class instance.
+
+C++ provides a convenience for one shape of callable -- an instance method gets a `this` pointer for
+free. The lyra backend leans on this for `mir::Process` / `mir::StructuralSubroutineDecl` bodies
+(emitted as instance methods) and for the constructor body (the C++ constructor itself). For
+closures the convenience does not apply -- a lambda has no `this`, so the backend smuggles the
+receiver in either through `[this]` capture or through an explicit `(M* self, ...)` lambda
+parameter. The choice today is mode-dependent and lives in the render: a fork-branch closure is
+emitted with explicit `M* self`; an NBA / scan / with-clause closure is emitted with `[=, this]`
+capture; `mir::StructuralVarRef` inside any body relies on render-time walker state
+(`RenderContext::ReceiverObject()`) to know whether to spell the receiver `this` or `self`.
+
+Three forces made the receiver model a real decision:
+
+1. **MIR is the golden reference for multiple backends.** A future LIR / LLVM-IR backend will not
+   have a C++ `this` keyword to lean on -- functions there take pointer parameters. If MIR keeps the
+   receiver implicit, every backend re-runs the same "which receiver applies here" analysis, and the
+   analysis is transitive (a helper that uses class state forces every caller to know too).
+2. **Closure body must be self-contained.** A reader of the closure body's MIR cannot today tell
+   whether structural-var access spells `this->X` or `self->X` -- the answer lives in the
+   surrounding callable, propagated as render walker state. That is the "implicit context" smell:
+   the body's meaning depends on where it sits, not on what it says.
+3. **The implicit / explicit split is fragmenting.** The current backend has four mechanisms for
+   receiver access (method `this`, fork-branch `(M* self)` param, NBA `[this]` capture, NBA `[=]`
+   capture) that all answer the same question -- "how does this body reach the class instance". Each
+   new closure family risks adding a fifth.
+
+## Decision
+
+**Every MIR callable carries a first parameter `self : Pointer<EnclosingScope>`. The parameter is
+added unconditionally -- not derived from whether the body happens to touch class state. The body
+reaches every class member through
+`MemberAccessExpr(receiver = DerefExpr(ProceduralVarRef(self)), var = ...)`.**
+
+This holds for `mir::Process`, `mir::StructuralSubroutineDecl`, `mir::ClosureExpr`, and the
+constructor-body callable. The shape is uniform; no callable form is special.
+
+The C++ backend renders the receiver shape with the most idiomatic C++ form available, but the form
+is fixed by callable kind, not derived from context:
+
+- **Closure** -> lambda whose explicit first parameter is `M* self`. Lambda capture clause is `[]`
+  (empty); every value the lambda needs flows through its parameter list, not through implicit
+  capture.
+- **Process / subroutine / constructor-body** -> static method on the enclosing class whose first
+  parameter is `M* self`. The class still owns the storage; method body lives on the class so it can
+  name private members. The body sees `self->X`, never implicit `this`.
+
+The constructor body is the only callable whose corresponding C++ entry cannot be static (the real
+C++ constructor must be an instance constructor for instance creation to work). The constructor body
+lowers to a static `init(M* self)` that the C++ constructor invokes with `init(this)`; the
+constructor itself is the only place where C++'s implicit `this` is used at all, and only as the
+argument to `init`. `CreateProcesses()` (and any other Scope-base virtual override) is C++ plumbing,
+not an SV-derived callable; it remains a virtual instance method, and its body's implicit `this` is
+C++-language-required, not MIR-modeled.
+
+### Why always include `self`, not derive from "body touches class state"
+
+The derivation is transitive: a helper that touches class state forces every caller to take a
+receiver and to forward it. Tracking "this body needs class state" through arbitrary call chains is
+the same kind of cross-cutting analysis that escape-analysis is in higher-level languages --
+expensive, hard to keep correct under refactors, and a constant source of debugging surprise when
+the analysis says one thing and the runtime needs another. Always-include trades 8 bytes of unused
+pointer in the rare case the body genuinely never needs `self` for zero analysis complexity at
+HIR-to-MIR and zero per-backend re-derivation downstream. The C++ build already suppresses
+`-Wunused-parameter`; a future LIR backend can let unused parameters be elided by its own
+constant-propagation pass if the cost ever matters.
+
+### Why MIR explicit, not "let render decide"
+
+The render today carries walker state for the receiver (`ctx.ReceiverObject()`,
+`ctx.MemberPrefix()`, `ctx.DeferredByValueCapture()`) and switches between four C++ mechanisms based
+on which kind of body it has entered. Every future backend faces the same dispatch. Every
+maintenance change risks the four-way switch going out of sync. MIR carrying the receiver as a real
+parameter pushes the answer up to one place that every backend just reads.
+
+## Rejected alternatives
+
+- **Implicit `this` in methods, explicit `self` only in closures.** Matches C++ idioms most closely
+  but leaves the four-mechanism fragmentation in place. A future LIR / LLVM-IR backend would have to
+  re-derive "is this body a method or a closure" to know how to spell receiver access. The asymmetry
+  buys idiomatic C++ at the cost of every other downstream.
+
+- **Conditional `self` (only when the body reads class state).** Requires HIR-to-MIR to compute
+  whether each body transitively touches class state -- a cross-call analysis that becomes wrong the
+  moment a helper is added or removed. Saves a parameter the C++ optimizer would often elide anyway.
+
+- **Body-local `auto self = this;` declaration as the first statement of every method body.** Looks
+  uniform from the body's vantage but adds an emit-side declaration the user did not write. The MIR
+  statement representing it would need a `ThisExpr` / `SelfScopeExpr` node that carries "give me the
+  C++ `this` keyword", and that node is the same implicit-context smell this decision exists to
+  remove (its meaning depends on the surrounding callable kind being "C++ instance method"). It also
+  adds an extra `M*` local at every callable's entry that no optimizer is guaranteed to remove in
+  debug builds.
+
+- **`SelfScopeExpr` / `ThisExpr` as a MIR expression node** carrying "the current receiver". Has
+  been the existing shape for fork-branch / NBA / scan closure bodies and is what the current
+  `mir::SelfScopeExpr` is. The node's meaning is context-dependent -- it renders to `this` in a
+  method body and `self` in a fork-branch body -- which is precisely the walker-state smell. The
+  cleaner replacement is the explicit `self` parameter plus `ProceduralVarRef`.
+
+- **A struct of free functions, no class membership at all.** Removes C++ implicit `this` entirely
+  (process / subroutine bodies become free functions friended into the class). Plausible but breaks
+  the natural C++ class-membership model that scheduler / runtime already use to reach instance
+  methods through `Scope*` polymorphism. Static methods give the same explicit-receiver shape
+  without losing class membership.
+
+## Consequences
+
+- `mir::Process`, `mir::StructuralSubroutineDecl`, `mir::ClosureExpr`, and the constructor body each
+  declare a `self` binding at `body.vars[0]` whose type is the unique-pointer / borrowed- pointer to
+  the enclosing structural scope. The binding's name is `self`; the type makes the pointee
+  unambiguous.
+
+- A new MIR expression `MemberAccessExpr { receiver: ExprId, var: StructuralVarRef-fields }`
+  replaces today's implicit-receiver `StructuralVarRef`. The receiver expression is rendered before
+  the access; the access itself is mechanical (`render(receiver) + "->" + var_name`).
+
+- `mir::SelfScopeExpr` is removed.
+
+- The cpp backend's `RenderContext::ReceiverObject()`, `WithReceiver(...)`, `MemberPrefix()`,
+  `ServicesRef()`, and `DeferredByValueCapture()` are removed. Receiver-related walker state on
+  `RenderContext` is gone.
+
+- C++ emit shape changes: process / subroutine / constructor bodies emit as
+  `static auto <name>(M* self, ...) -> ... { ... }`; the C++ constructor delegates the body to a
+  static `init(this)` call. Lambda capture clauses are `[]` -- every captured value flows through
+  the lambda's parameter list. `CreateProcesses()` adapts: where it previously emitted
+  `AddProcess(kind, process_N())` it now emits `AddProcess(kind, process_N(this))`.
+
+- LIR / LLVM-IR lowering reads the receiver parameter directly off MIR. No backend re-derives
+  receiver semantics.
+
+- Forbidden Shape: a MIR expression whose meaning depends on which callable encloses it. The
+  receiver is on the callable's parameter list, not on the expression.
+
+## Cross-references
+
+- `docs/architecture/mir.md` (callable shape, expression set)
+- `docs/progress/refactor.md` R16

--- a/docs/decisions/variable-initialization.md
+++ b/docs/decisions/variable-initialization.md
@@ -1,0 +1,198 @@
+# Variable initialization (LRM 10.5) as constructor scope statement
+
+Date: 2026-06-16 Status: accepted
+
+## Context
+
+A SystemVerilog variable declaration may carry an initializer at its declaration site:
+
+```sv
+module Top;
+  int a = 1;
+  int b = a + 1;
+endmodule
+```
+
+LRM 10.5 names this construct a _variable declaration assignment_, parenthetically _variable
+initialization_, and defines it as **"a special case of procedural assignment"** that "shall occur
+before any initial or always procedures are started". The semantic content is an assignment whose
+timing is pinned to elaboration.
+
+Before this decision, MIR carried the variable initializer two ways:
+
+1. `mir::StructuralVarDecl.initializer: ExprId` -- the init expression as a field on the declaration
+   itself.
+2. `constructor_scope.root_stmts` -- the constructor-time statement sequence (`RegisterChild`,
+   `RegisterSignal`, `CreateProcesses`, generate construction, ...).
+
+The C++ backend plucked path (1) into an inline class-body NSDMI (`Var<int> a{1};`) and rendered
+path (2) inside a static `init(Self* self)` helper. A `RenderContext::in_class_member_init_` flag
+switched receiver-access rendering between NSDMI position and function-body position, because
+`MemberAccessExpr(self, X)` and `StructuralParamRef(p)` had to spell as the bare field name in NSDMI
+scope but `self->X` in the body.
+
+The two-channel shape forced every backend to read state from two places. It also locked the render
+to a C++-specific syntactic mode dependency that a LIR / LLVM-IR backend would have no analogue for.
+
+## Decision
+
+**MIR has exactly one shape for construction-time work: statements in
+`constructor_scope.root_stmts`. For every value-assignable structural var, HIR-to-MIR inserts an
+`AssignExpr(MemberAccess(self, var), value)` statement at the position the variable is declared in
+source order, before any `RegisterSignal` / `RegisterChild` / `CreateProcesses` for the same scope.
+The value is the user-supplied expression when present, otherwise the LRM Table 6-7 type default;
+the statement shape is uniform either way. The `mir::StructuralVarDecl.initializer` field is
+removed; a structural-var declaration carries name and type only.**
+
+Vars whose type has no value-assignment semantics -- owned children (pointer, vector), object
+companions, upward references (`ExternalRefType`), and named events -- do not receive an init
+statement. Their declaration shape itself fixes the field at construction:
+
+- Pointer / vector / object / external-unit-object fields default to their C++ default (null
+  pointer, empty container).
+- An `ExternalRefType` field is constructed at the declaration site with the symbol payload
+  (ancestor, by-name tail, leaf signal) and relocates at Bind.
+- A `NamedEvent` field is default-constructed; the event identity is fixed for the lifetime of the
+  scope and never reassigned.
+
+### C++ render
+
+A class member is declared with a value-init brace, never an `=`:
+
+```cpp
+lyra::runtime::Var<lyra::value::PackedArray> a{};
+lyra::runtime::Var<lyra::value::PackedArray> b{};
+```
+
+The C++ constructor body is a thin wrapper that delegates to a static helper:
+
+```cpp
+Test(Scope* parent, std::string name, RuntimeServices& services)
+    : Instance(parent, std::move(name), services) {
+  init(this);
+}
+static void init(Test* self) {
+  self->a.Set(self->Services(), PackedArray::Int(1));
+  self->b.Set(self->Services(), self->a.Get() + PackedArray::Int(1));
+  self->RegisterSignal("a", &self->a);
+  self->RegisterSignal("b", &self->b);
+}
+```
+
+Every other MIR callable body (process, subroutine, closure) also renders as a static function whose
+first parameter is `Self* self`; the constructor's delegation to `init(this)` is the one place C++'s
+implicit `this` is mentioned. The body code emits `self->X` mechanically with no context-dependent
+receiver lookup. `RenderContext::in_class_member_init_` and `WithClassMemberInit` are removed in
+this decision.
+
+### Runtime changes that make the shape possible
+
+For an assignment statement in the constructor body to work, the C++ runtime must supply two things
+that were previously deferred:
+
+1. **`Var<T>::Set` needs a valid `RuntimeServices` reference.** Previously `Scope::services_` was
+   null until `Engine::BindDesign` ran, so a constructor-body `Set` threw
+   `Scope::Services: scope not bound`. The constructor now takes `RuntimeServices& services` as a
+   third parameter and wires `services_` at construction. `Scope::Bind` no longer takes a services
+   argument; it only relocates `ExternUp` members, creates processes, and recurses. The generated
+   host `main.cpp` reflects this: `Engine` is constructed first, then each top instance receives
+   `engine.Services()` at construction.
+2. **`Var<T>` must be default-constructible.** A `Var<PackedArray> a{};` value-initializes the inner
+   `T` through `T value_{}`. `PackedArray`, `UnpackedArray<T>`, and `DynamicArray<T>` gain default
+   constructors that produce a 0-bit sentinel ("uninitialized") shape; the first MIR-level
+   `AssignFrom` from a non-zero source shape adopts the source's shape (subsequent writes preserve
+   destination shape per LRM 10.6.1). The `WordCountForBits` / `PackedWords` 0-bit guards are
+   relaxed correspondingly. The default state is unobservable: MIR guarantees an `AssignExpr` runs
+   before any read.
+
+### Why every value var gets an init statement, including the default case
+
+The "user wrote `= value`" and "no user value, take LRM Table 6-7 default" cases differ in MIR by
+exactly one expression node -- the lowered HIR initializer versus the type default literal -- but
+the statement shape is identical. A unified statement list lets a backend treat construction-time
+state as one mechanism: walk the list, render each statement. A backend that peephole-folds "first
+stmt is a literal-Set on a freshly declared var" into NSDMI is free to do so, but the primary
+contract is the statement list.
+
+LLVM-IR makes this contract literal: every var's initial value lowers to a `store` at the start of
+the constructor function, with no NSDMI analogue.
+
+### Why filter non-assignable types out of the init statement
+
+Owned children, upward references, and named events have no value-assignment operation:
+
+- An owned child is constructed by `ConstructExternalUnitStmt` or generate-construction stmts later
+  in `root_stmts`, with its own arguments.
+- An `ExternalRefType` is constructed at the declaration site with symbol arguments that have no
+  value-assignment counterpart.
+- A `NamedEvent` is non-copyable and non-movable by design (LRM 15.5; the runtime takes pointers
+  into the event object); assigning over it would require a copy/move operator the type does not
+  provide.
+
+The HIR-side declaration for these types is the equivalent of "this field exists with its
+construction-time identity"; there is no later "set its value" semantic to encode. Emitting an
+`AssignExpr` for them would either fail to compile (events) or invent a no-op write (containers,
+pointers). The filter is structural: any var whose MIR type is in the set
+`{Pointer, Vector, ExternalRef, Object, ExternalUnitObject, Event}` does not get an init statement.
+
+## Rejected alternatives
+
+- **Keep `StructuralVarDecl.initializer` and continue using inline class-body NSDMI.** Matches C++
+  idiom most closely and is the previous shape. Costs: MIR carries two ways to express the same
+  construction-time work; the `RenderContext::in_class_member_init_` flag switches receiver
+  rendering by syntactic position; every future backend either learns the same dual-mode dispatch or
+  re-lowers `.initializer` into a statement before generating code. The bookkeeping does not pay for
+  itself outside of C++ specifically.
+
+- **Inline the C++ constructor body with a `Self* self = this;` preamble.** Invents a body statement
+  that no MIR node justifies. The render must add content the MIR did not produce, which is
+  precisely the smell the mechanical-translation rule was written to prevent.
+
+- **A `RenderContext` flag that maps `self`-reads to `this` inside the constructor body.** Adds
+  walker state at the moment R18 plans to remove `RenderContext` entirely. Render becomes
+  context-dependent on the very rule the mechanical-translation principle wants pure. Wrong
+  direction.
+
+- **Use C++ member-initializer list
+  (`Top(...) : Instance(...), a(1), b(this->a.Get() + Int(1)) { ... }`).** Native C++ alternative to
+  NSDMI and a closer match to "born with value" timing. Same conceptual position as NSDMI -- a
+  separate syntactic position from the constructor body, with `this` available but `self` not. The
+  render would still need a flag to switch receiver rendering. No advantage.
+
+- **Skip the init statement when there is no user-supplied initializer.** Forces every backend to
+  re-derive the type default at the field declaration position, locking each backend to a per-type
+  default lookup that mirrors `SynthesizeDefaultValueExpr` semantically. The unified always-emit
+  shape lets `SynthesizeDefaultValueExpr` produce the literal once at HIR-to-MIR and every backend
+  reads the same statement.
+
+## Consequences
+
+- `mir::StructuralVarDecl.initializer` is removed; a declaration carries name and type only.
+- HIR-to-MIR's structural scope lowerer appends an `AssignExpr` statement to
+  `constructor_scope.root_stmts` for every value-assignable structural var, using the user-supplied
+  expression or the LRM Table 6-7 default.
+- The C++ backend's `RenderField` emits a pure value-init declaration (`Var<T> name{};` or
+  `T name{};`), with no inline initializer. Upward references retain their symbol-arg construction.
+- `RenderContext::in_class_member_init_`, `WithClassMemberInit`, and the `RenderField`
+  initializer-extraction path are removed.
+- `Scope` takes `RuntimeServices&` at construction; `Scope::Bind()` no longer takes a services
+  argument; the generated host `main.cpp` constructs `Engine` before the top instance and passes
+  `engine.Services()` to the top's constructor.
+- `PackedArray`, `UnpackedArray<T>`, `DynamicArray<T>` gain default constructors;
+  `PackedArray::AssignFrom` adopts the source shape when the destination is the 0-bit sentinel;
+  `WordCountForBits` and `PackedWords::PackedWords` accept 0-bit input.
+- LIR / LLVM-IR lowering reads the construction-time state straight from
+  `constructor_scope.root_stmts`. No backend re-derives type defaults or syntactic position from a
+  side field.
+- Forbidden Shape: two MIR mechanisms for "code that runs at construction time", or a render that
+  adds body statements not present in MIR.
+
+## Cross-references
+
+- LRM 10.5 -- Variable declaration assignment (variable initialization)
+- LRM 6.8 -- Variable declarations
+- LRM 6.21 -- Scope and lifetime
+- LRM 10.6.1 -- Variable declaration assignment shape preservation
+- `docs/architecture/mir.md` -- invariant 11 (`self` binding); Forbidden Shapes
+- `docs/decisions/callable-receiver.md` -- explicit `self` first binding
+- `docs/progress/refactor.md` -- R19

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -326,26 +326,19 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       makes semantic decisions, rendering doesn't. **Trigger**: scheduled after R11, R12, R14, R15,
       R16, R17 all land.
 
-- [ ] R19 -- Move structural-var initializers from inline C++ class-member-init to constructor body
-      statements. Today a structural var's `.initializer` ExprId is rendered as an inline
-      `Var<T> y{<init>};` at the C++ class body; the initializer expression lives in
-      `constructor_scope` but the render emits it at class-body scope where neither `this` nor
-      `self` is available. R16 worked around this by adding an `in_class_member_init_` flag to
-      `RenderContext` so `MemberAccessExpr` and `StructuralParamRef` render bare field names instead
-      of the body-context `self->name`. That flag is exactly the kind of render-time walker state
-      R18 wants gone. Target shape: HIR-to-MIR appends an `AssignExpr` statement to the constructor
-      scope for each structural var with an initializer (matching how a body local with init is
-      lowered); the cpp emit declares the class member with no inline initializer and the ctor body
-      runs the assignment in init-list order. The `in_class_member_init_` flag and the inline-init
-      handling in `RenderField` both disappear. As a follow-on, the `init(M* self)` static helper
-      the C++ ctor currently delegates to can collapse back into the ctor body proper -- a single
-      `Top* self = this;` preamble at the top of the ctor body gives every callable form the same
-      "body opens by binding self" shape (process / subroutine become instance methods with the same
-      preamble; the `static` keyword disappears from method-form callables, which were only static
-      so `self` could be an explicit formal). **Why deferred**: orthogonal to landing R16; requires
-      touching HIR-to-MIR's constructor-scope wiring and the emit shape for class members.
-      **Trigger**: scheduled in front of R18, to ensure the render layer has no class-scope vs
-      body-scope flag left when R18 collapses the render walk.
+- [x] R19 -- LRM 10.5 variable initialization lowers to an `AssignExpr` statement at the top of
+      `constructor_scope.root_stmts`, with the value being the user-supplied expression when present
+      or the LRM Table 6-7 type default. `mir::StructuralVarDecl.initializer` is removed; MIR has
+      exactly one mechanism for construction-time work (the statement list). `RenderField` emits a
+      pure value-init declaration (`Var<T> name{};` or `T name{};`) with no inline initializer;
+      `RenderContext::in_class_member_init_` and `WithClassMemberInit` are removed. The C++ runtime
+      takes `RuntimeServices&` at `Scope` construction (Bind no longer wires services), and
+      `PackedArray` / `UnpackedArray<T>` / `DynamicArray<T>` gain default constructors with a 0-bit
+      sentinel shape that the first `AssignFrom` adopts -- so a constructor-body `Set` works without
+      the deferred-bind dance. Vars whose MIR type is non-assignable (pointer / vector / object /
+      external-unit-object / external-ref / event) are filtered out of the init-statement path --
+      their declaration shape itself fixes the field at construction. See
+      `docs/decisions/variable-initialization.md`.
 
 - [ ] R20 -- Turn runtime-scope method calls (`Services()`, `RegisterChild(name, indices, child)`,
       `RegisterSignal(name, var)`, `AddProcess(kind, coroutine)`,

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -265,13 +265,15 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       propagation flag from `RenderContext` ships in R18, when the whole walk frame is dissolved.
       **Trigger**: scheduled in front of R18 (the render-layer rewrite).
 
-- [ ] R15 -- Lift the static-frame field path into `mir::ProceduralVarRef`. Today a procedural-var
-      ref with `lifetime == kStatic` renders as `<receiver>-><frame_field>.<member>` where the frame
-      field name (`process_N__static`, `subroutine_name__static`) is constructed at render time from
-      "which callable body I am rendering". HIR-to-MIR knows which callable owns the static; encode
-      the field path directly on the static-bearing ref kind, so the render is a mechanical
-      structural map with no "which callable am I in" question. The `StaticFrame()` accessor on
-      `RenderContext` (and its `WithStaticFrame(...)` install path) disappear in lockstep.
+- [ ] R15 -- Give `mir::Process` a `name` field, so the C++ method name, static-frame struct name,
+      static-frame field name, and any future LLVM-IR function symbol all flow from a single
+      MIR-level identifier instead of each backend re-deriving "process_N" from a position-in-scope
+      iteration index. `mir::StructuralSubroutineDecl::name` already plays this role for
+      subroutines; processes are anonymous in SV (LRM 9.2) so HIR-to-MIR synthesises a positional
+      identifier (`"process_0"` etc.) and threads it into the lowering so the returned `Process` is
+      constant -- no post-hoc mutation. The `WithStaticFrame(...)` install in the cpp backend now
+      reads `process.name + "__static"` rather than computing from an iteration index; the
+      walker-state propagation of the frame field name continues until R18 dissolves the walk frame.
       **Trigger**: scheduled in front of R18.
 
 - [ ] R16 -- Model the fork-branch receiver as an explicit closure capture, so a structural-var

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -276,22 +276,26 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       walker-state propagation of the frame field name continues until R18 dissolves the walk frame.
       **Trigger**: scheduled in front of R18.
 
-- [ ] R16 -- Give every MIR callable an explicit `self` first parameter (a pointer to its enclosing
-      structural scope) and route every class-member access through a new
-      `mir::MemberAccessExpr { receiver, var }`. Today four distinct receiver mechanisms coexist --
-      method `this` (process / subroutine / constructor bodies), fork-branch `(M* self)` parameter,
-      NBA / `$strobe` / scan closures' `[this]` or `[=, this]` capture, and
+- [ ] R16 -- Give every MIR callable body an explicit `self` first binding -- `body.vars[0]` is a
+      procedural-var of borrowed-pointer-to-enclosing-scope type, named `self`. Route every
+      class-member access through a new `mir::MemberAccessExpr { receiver, var }` whose receiver
+      reaches `self` via `DerefExpr(ProceduralVarRef(self))`. Today four distinct receiver
+      mechanisms coexist -- method `this` (process / subroutine / constructor bodies), fork-branch
+      `(M* self)` parameter, NBA / `$strobe` / scan closures' `[this]` or `[=, this]` capture, and
       `mir::StructuralVarRef`'s implicit-receiver render -- and the cpp backend dispatches between
       them through `RenderContext` walker state (`ReceiverObject()` / `WithReceiver(...)` /
       `DeferredByValueCapture()` / `MemberPrefix()`). The same dispatch would have to be re-derived
-      by every future backend (LIR / LLVM-IR). Target shape: `self` lives on the callable's
-      parameter list, the body reaches every class member through `MemberAccessExpr` whose receiver
-      is some expression reaching from `self`, and `mir::SelfScopeExpr` is removed (its job was to
-      denote "the current receiver, whatever that is" -- precisely the implicit-context shape this
-      refactor eliminates). C++ emit becomes uniform: closure bodies emit as
-      `[](M* self, ...) -> ... { ... }(self, ...)` with an empty `[]` capture clause; process /
-      subroutine / constructor bodies emit as `static auto <name>(M* self, ...) -> ... { ... }` with
-      the constructor delegating its body to a `init(this)` call from the real C++ constructor;
+      by every future backend (LIR / LLVM-IR). Target shape: `body.vars[0]` is uniformly `self`
+      across every callable form, but how it is supplied follows each form's natural binding
+      mechanism -- a process / subroutine / constructor body receives `self` as its first formal
+      parameter (the caller supplies), while a closure carries `self` as its first by-value capture
+      (the enclosing scope snapshots its own self at construction). `mir::SelfScopeExpr` is removed
+      (its job was to denote "the current receiver, whatever that is" -- precisely the
+      implicit-context shape this refactor eliminates). C++ emit per form: process / subroutine /
+      constructor bodies as `static auto <name>(M* self, ...) -> ... { ... }`, with the C++
+      constructor delegating its body to a `static init(this)` call; closures as
+      `[self = <enclosing self>, cap1 = ..., &cap2 = ...](closure_params) -> R { ... }` -- every
+      capture is name-explicit, the clause never contains `[this]`, `[=]`, or `[&]`.
       `CreateProcesses()` remains a virtual instance method (C++ requires it) and emits
       `AddProcess(kind, process_N(this))`. The receiver-related `RenderContext` machinery disappears
       in lockstep. See `docs/decisions/callable-receiver.md`. **Trigger**: scheduled in front of

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -276,15 +276,25 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       walker-state propagation of the frame field name continues until R18 dissolves the walk frame.
       **Trigger**: scheduled in front of R18.
 
-- [ ] R16 -- Model the fork-branch receiver as an explicit closure capture, so a structural-var
-      access inside a fork-branch body routes through a MIR-modeled receiver binding instead of
-      through render-time knowledge that "I am inside a fork branch, emit `self->` instead of
-      `this->`". Today `mir::StructuralVarRef` carries no receiver hint; the render decides based on
-      whether the enclosing scope is a fork-branch closure body. With explicit capture, the closure
-      binding list grows a receiver entry, and the closure body's structural-var access reads as
-      "(captured-receiver).<member>", rendered identically wherever it appears. The
-      `ReceiverObject()` / `DeferredByValueCapture()` accessors on `RenderContext` (and the
-      `WithReceiver(...)` install path) disappear in lockstep. **Trigger**: scheduled in front of
+- [ ] R16 -- Give every MIR callable an explicit `self` first parameter (a pointer to its enclosing
+      structural scope) and route every class-member access through a new
+      `mir::MemberAccessExpr { receiver, var }`. Today four distinct receiver mechanisms coexist --
+      method `this` (process / subroutine / constructor bodies), fork-branch `(M* self)` parameter,
+      NBA / `$strobe` / scan closures' `[this]` or `[=, this]` capture, and
+      `mir::StructuralVarRef`'s implicit-receiver render -- and the cpp backend dispatches between
+      them through `RenderContext` walker state (`ReceiverObject()` / `WithReceiver(...)` /
+      `DeferredByValueCapture()` / `MemberPrefix()`). The same dispatch would have to be re-derived
+      by every future backend (LIR / LLVM-IR). Target shape: `self` lives on the callable's
+      parameter list, the body reaches every class member through `MemberAccessExpr` whose receiver
+      is some expression reaching from `self`, and `mir::SelfScopeExpr` is removed (its job was to
+      denote "the current receiver, whatever that is" -- precisely the implicit-context shape this
+      refactor eliminates). C++ emit becomes uniform: closure bodies emit as
+      `[](M* self, ...) -> ... { ... }(self, ...)` with an empty `[]` capture clause; process /
+      subroutine / constructor bodies emit as `static auto <name>(M* self, ...) -> ... { ... }` with
+      the constructor delegating its body to a `init(this)` call from the real C++ constructor;
+      `CreateProcesses()` remains a virtual instance method (C++ requires it) and emits
+      `AddProcess(kind, process_N(this))`. The receiver-related `RenderContext` machinery disappears
+      in lockstep. See `docs/decisions/callable-receiver.md`. **Trigger**: scheduled in front of
       R18.
 
 - [ ] R17 -- Make the ref-vs-value distinction explicit in MIR for selector expressions. Today

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -246,16 +246,24 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       kind touches three files (subsystem header, subsystem implementation, dispatcher switch) and
       leaves the pass-class header untouched.
 
-- [ ] R14 -- Split `mir::ReturnStmt` into a plain-`return` form and a coroutine-`co_return` form, so
-      the render-time decision of which C++ keyword to emit disappears. Today both MIR `ReturnStmt`s
-      look identical; the cpp backend walks up the `RenderContext` to see whether the surrounding
-      callable is a coroutine (process body, task body, fork-branch closure body) versus a plain
-      function (function body, constructor body, NBA closure body). HIR-to-MIR already knows which
-      kind it is lowering into -- bake the decision into the MIR node. The `InCoroutine()` predicate
-      on `RenderContext` (and its `WithCoroutine(...)` install path) disappear in lockstep. **Why
-      deferred**: each render-time decision the MIR currently leaves implicit is one slice of the
-      render-layer wedge that culminates in R18. R14 is the smallest first slice. **Trigger**:
-      scheduled in front of R18 (the render-layer rewrite).
+- [ ] R14 -- Move the "is this callable a coroutine" decision off `RenderContext` and onto MIR.
+      Today the cpp backend reads `RenderContext::InCoroutine()` -- a walk-state flag installed via
+      `WithCoroutine(...)` at every callable-body entry -- to decide whether a `mir::ReturnStmt`
+      lowers to `return` or `co_return`. The distinction is not semantic at the MIR or LIR level:
+      `return` and `co_return` describe the same operation (exit the callable); "how" depends purely
+      on whether the surrounding callable is a coroutine. That fact is already captured by every
+      callable MIR node except `mir::ClosureExpr` (Process is implicit; `StructuralSubroutineDecl`'s
+      `kind` distinguishes task / function; constructor body is implicit). `ClosureExpr` is the gap:
+      the same node is constructed for fork-branch closures (concurrent coroutines that may suspend)
+      and for NBA / `$strobe` / `$sscanf` IIFE / with-clause iterator / deferred-check closures
+      (synchronous lambdas), with no field to say which. Target shape: `mir::ClosureExpr` gains an
+      `is_coroutine` flag set at HIR-to-MIR construction; the cpp backend reads it directly at every
+      closure entry instead of inheriting a walk-state assumption.
+      `RenderContext::WithCoroutine(...)` / `InCoroutine()` remain (the bool still propagates across
+      nested if / loop / block scopes within a body) but the install path is MIR-sourced -- the
+      render no longer "decides" coroutine-ness, it only reads. The eventual removal of the
+      propagation flag from `RenderContext` ships in R18, when the whole walk frame is dissolved.
+      **Trigger**: scheduled in front of R18 (the render-layer rewrite).
 
 - [ ] R15 -- Lift the static-frame field path into `mir::ProceduralVarRef`. Today a procedural-var
       ref with `lifetime == kStatic` renders as `<receiver>-><frame_field>.<member>` where the frame

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -192,16 +192,21 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       `scope_state` -> `scope`, `proc_state` -> `process`, `proc_scope_state` -> `proc_scope`,
       etc.). The per-LRM-family subsystem split ships as its own focused cut; see R13.
 
-- [ ] R11 -- MIR-to-C++ backend migration to the class-based organization defined in
-      `docs/architecture/lowering_organization.md`. Replaces `RenderContext` plus the `With*()`
-      copy-on-descend convention with per-task-instance classes (`CppProcessRenderer` and analogues
-      at scope and unit levels) whose walker methods take `(node, WalkFrame)`. The
-      `mutable owned_temp_counter_` escape hatch becomes a class-owned registry; the ambient
-      `indent` parameter (currently threaded through every `Render*` signature) moves into
-      `WalkFrame`. All `~51` free `Render*` functions across `render_expr.cpp` and `render_stmt.cpp`
-      become class methods in one cut; no transitional shape coexists. **Why deferred**: large-scope
-      migration; the backend is `~80%` aligned today but moving the last 20% requires touching every
-      renderer in one pass. **Trigger**: scheduled with R10.
+- [ ] R11 -- Remove the `mutable owned_temp_counter_` escape hatch on `RenderContext`. Today the C++
+      backend's temp-name counter is a `mutable` field reached through a pointer from every
+      `With*()` descendant; the escape hatch exists because every `Render*` helper takes the context
+      by `const&`, but the counter genuinely mutates. Target shape: pull the counter out of
+      `RenderContext` entirely. Each callable-body render entry (`RenderProcessMethod`,
+      `RenderSubroutineMethod`, `RenderConstructor`) declares a local
+      `std::size_t temp_counter = 0;` and threads `std::size_t& temp_counter` down the
+      statement-handler chain. `RenderClosureExpr` opens its own fresh counter for the closure body.
+      The `mutable` keyword disappears from the backend; const-correctness on `RenderContext`
+      matches reality (it carries facts and walk position, both immutable per descent). **Why this
+      minimal scope**: the rest of the lowering-organization contract (class-based pass shape with
+      `WalkFrame`) does not transfer cleanly to the render layer -- rendering is mechanical
+      translation, not semantic lowering, so the per-task state model is fundamentally different
+      (see R18). The mutable escape hatch is the one shape that is unambiguously wrong from any
+      vantage. **Trigger**: standalone -- can be picked up at any time.
 
 - [ ] R12 -- Model the observable (`Var<T>`) storage as a first-class MIR wrapper type so the cpp
       backend stops re-deriving "is this observable storage" at render time. Today a signal's MIR
@@ -240,6 +245,62 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       Subsystem files include only the pass-class headers and their own family header, so adding a
       kind touches three files (subsystem header, subsystem implementation, dispatcher switch) and
       leaves the pass-class header untouched.
+
+- [ ] R14 -- Split `mir::ReturnStmt` into a plain-`return` form and a coroutine-`co_return` form, so
+      the render-time decision of which C++ keyword to emit disappears. Today both MIR `ReturnStmt`s
+      look identical; the cpp backend walks up the `RenderContext` to see whether the surrounding
+      callable is a coroutine (process body, task body, fork-branch closure body) versus a plain
+      function (function body, constructor body, NBA closure body). HIR-to-MIR already knows which
+      kind it is lowering into -- bake the decision into the MIR node. The `InCoroutine()` predicate
+      on `RenderContext` (and its `WithCoroutine(...)` install path) disappear in lockstep. **Why
+      deferred**: each render-time decision the MIR currently leaves implicit is one slice of the
+      render-layer wedge that culminates in R18. R14 is the smallest first slice. **Trigger**:
+      scheduled in front of R18 (the render-layer rewrite).
+
+- [ ] R15 -- Lift the static-frame field path into `mir::ProceduralVarRef`. Today a procedural-var
+      ref with `lifetime == kStatic` renders as `<receiver>-><frame_field>.<member>` where the frame
+      field name (`process_N__static`, `subroutine_name__static`) is constructed at render time from
+      "which callable body I am rendering". HIR-to-MIR knows which callable owns the static; encode
+      the field path directly on the static-bearing ref kind, so the render is a mechanical
+      structural map with no "which callable am I in" question. The `StaticFrame()` accessor on
+      `RenderContext` (and its `WithStaticFrame(...)` install path) disappear in lockstep.
+      **Trigger**: scheduled in front of R18.
+
+- [ ] R16 -- Model the fork-branch receiver as an explicit closure capture, so a structural-var
+      access inside a fork-branch body routes through a MIR-modeled receiver binding instead of
+      through render-time knowledge that "I am inside a fork branch, emit `self->` instead of
+      `this->`". Today `mir::StructuralVarRef` carries no receiver hint; the render decides based on
+      whether the enclosing scope is a fork-branch closure body. With explicit capture, the closure
+      binding list grows a receiver entry, and the closure body's structural-var access reads as
+      "(captured-receiver).<member>", rendered identically wherever it appears. The
+      `ReceiverObject()` / `DeferredByValueCapture()` accessors on `RenderContext` (and the
+      `WithReceiver(...)` install path) disappear in lockstep. **Trigger**: scheduled in front of
+      R18.
+
+- [ ] R17 -- Make the ref-vs-value distinction explicit in MIR for selector expressions. Today
+      `mir::ElementSelectExpr` and `mir::RangeSelectExpr` render to runtime `PackedArrayRef` view
+      values; the public `RenderExpr` wraps the rendered string in `.Clone()` when the expression
+      yields a ref so consumers see an owning value. The wrap decision lives in the render
+      (`ProducesPackedArrayRef`). Either lift ref-producing expressions into an explicit MIR shape
+      (e.g. an explicit `CloneExpr` inserted by HIR-to-MIR at the value-context boundary, or a
+      separate ref-vs-value type-level distinction), so the render is a mechanical one-form-per-
+      node mapping with no post-process wrap. **Trigger**: design decision pending -- the exact
+      shape (explicit `CloneExpr` versus type-level ref/value split) is to be discussed before this
+      entry is sharpened.
+
+- [ ] R18 -- Rewrite the MIR-to-C++ backend to free functions per node kind, with no
+      `RenderContext`, no class hierarchy, and no `WalkFrame`. Once R11 has removed the mutable
+      escape hatch, and R14 + R15 + R16 + R17 + R12 have closed every render-time decision that
+      currently lives on the context, the render layer's per-task state collapses to a
+      procedural-scope chain (for hops resolution within one callable body) and a temp counter --
+      both local to one callable body, both plain locals in the callable's render function. Each
+      callable kind (process, task, function, constructor, fork-branch, deferred closure) becomes
+      one render function; per-node-kind handlers are free functions taking only what they read. The
+      result is the mechanical-translation shape rendering should always have had;
+      `lowering_organization.md` invariant 9 (which today claims lowering and rendering share the
+      same pattern) is updated in this cut to reflect that the patterns are distinct -- lowering
+      makes semantic decisions, rendering doesn't. **Trigger**: scheduled after R11, R12, R14, R15,
+      R16, R17 all land.
 
 ## Out of Scope
 

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -192,7 +192,7 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       `scope_state` -> `scope`, `proc_state` -> `process`, `proc_scope_state` -> `proc_scope`,
       etc.). The per-LRM-family subsystem split ships as its own focused cut; see R13.
 
-- [ ] R11 -- Remove the `mutable owned_temp_counter_` escape hatch on `RenderContext`. Today the C++
+- [x] R11 -- Remove the `mutable owned_temp_counter_` escape hatch on `RenderContext`. Today the C++
       backend's temp-name counter is a `mutable` field reached through a pointer from every
       `With*()` descendant; the escape hatch exists because every `Render*` helper takes the context
       by `const&`, but the counter genuinely mutates. Target shape: pull the counter out of
@@ -246,7 +246,7 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       kind touches three files (subsystem header, subsystem implementation, dispatcher switch) and
       leaves the pass-class header untouched.
 
-- [ ] R14 -- Move the "is this callable a coroutine" decision off `RenderContext` and onto MIR.
+- [x] R14 -- Move the "is this callable a coroutine" decision off `RenderContext` and onto MIR.
       Today the cpp backend reads `RenderContext::InCoroutine()` -- a walk-state flag installed via
       `WithCoroutine(...)` at every callable-body entry -- to decide whether a `mir::ReturnStmt`
       lowers to `return` or `co_return`. The distinction is not semantic at the MIR or LIR level:
@@ -265,7 +265,7 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       propagation flag from `RenderContext` ships in R18, when the whole walk frame is dissolved.
       **Trigger**: scheduled in front of R18 (the render-layer rewrite).
 
-- [ ] R15 -- Give `mir::Process` a `name` field, so the C++ method name, static-frame struct name,
+- [x] R15 -- Give `mir::Process` a `name` field, so the C++ method name, static-frame struct name,
       static-frame field name, and any future LLVM-IR function symbol all flow from a single
       MIR-level identifier instead of each backend re-deriving "process_N" from a position-in-scope
       iteration index. `mir::StructuralSubroutineDecl::name` already plays this role for
@@ -276,7 +276,7 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       walker-state propagation of the frame field name continues until R18 dissolves the walk frame.
       **Trigger**: scheduled in front of R18.
 
-- [ ] R16 -- Give every MIR callable body an explicit `self` first binding -- `body.vars[0]` is a
+- [x] R16 -- Give every MIR callable body an explicit `self` first binding -- `body.vars[0]` is a
       procedural-var of borrowed-pointer-to-enclosing-scope type, named `self`. Route every
       class-member access through a new `mir::MemberAccessExpr { receiver, var }` whose receiver
       reaches `self` via `DerefExpr(ProceduralVarRef(self))`. Today four distinct receiver
@@ -325,6 +325,66 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       same pattern) is updated in this cut to reflect that the patterns are distinct -- lowering
       makes semantic decisions, rendering doesn't. **Trigger**: scheduled after R11, R12, R14, R15,
       R16, R17 all land.
+
+- [ ] R19 -- Move structural-var initializers from inline C++ class-member-init to constructor body
+      statements. Today a structural var's `.initializer` ExprId is rendered as an inline
+      `Var<T> y{<init>};` at the C++ class body; the initializer expression lives in
+      `constructor_scope` but the render emits it at class-body scope where neither `this` nor
+      `self` is available. R16 worked around this by adding an `in_class_member_init_` flag to
+      `RenderContext` so `MemberAccessExpr` and `StructuralParamRef` render bare field names instead
+      of the body-context `self->name`. That flag is exactly the kind of render-time walker state
+      R18 wants gone. Target shape: HIR-to-MIR appends an `AssignExpr` statement to the constructor
+      scope for each structural var with an initializer (matching how a body local with init is
+      lowered); the cpp emit declares the class member with no inline initializer and the ctor body
+      runs the assignment in init-list order. The `in_class_member_init_` flag and the inline-init
+      handling in `RenderField` both disappear. As a follow-on, the `init(M* self)` static helper
+      the C++ ctor currently delegates to can collapse back into the ctor body proper -- a single
+      `Top* self = this;` preamble at the top of the ctor body gives every callable form the same
+      "body opens by binding self" shape (process / subroutine become instance methods with the same
+      preamble; the `static` keyword disappears from method-form callables, which were only static
+      so `self` could be an explicit formal). **Why deferred**: orthogonal to landing R16; requires
+      touching HIR-to-MIR's constructor-scope wiring and the emit shape for class members.
+      **Trigger**: scheduled in front of R18, to ensure the render layer has no class-scope vs
+      body-scope flag left when R18 collapses the render walk.
+
+- [ ] R20 -- Turn runtime-scope method calls (`Services()`, `RegisterChild(name, indices, child)`,
+      `RegisterSignal(name, var)`, `AddProcess(kind, coroutine)`,
+      `SubmitObserved(site_id,     closure)`, etc.) into MIR-modeled expressions so the cpp render
+      stops hardcoding `"self->Services()"`, `"self->RegisterChild(\"...\", ...)"`,
+      `"std::make_unique<Child>(self,     ...)"` and similar literals in `render_print.cpp` /
+      `render_stmt.cpp`. Today each runtime method has bespoke render code that string-concatenates
+      the receiver name with the method name; every argument is rendered uniformly through
+      `RenderExpr` except the implicit receiver, which is spelled out as a literal. Target shape:
+      each runtime call is a `mir::CallExpr` whose callee is a `RuntimeServicesCallee` (or sibling
+      variants for scope-level methods like RegisterChild) carrying the method identity, and whose
+      `arguments[0]` is the receiver expression (`ProceduralVarRef(self)`). The render becomes one
+      rule for every call shape: "render the callee name, open paren, render each argument as an
+      expression separated by commas, close paren". No render handler knows the literal string
+      `"self"` or the literal `"Services()"` anywhere. **Why deferred**: cross-cuts every
+      runtime-method call site (~30 across `render_print.cpp` / `render_stmt.cpp`) and requires MIR
+      vocabulary additions on the Callee variant. **Trigger**: scheduled in front of R18.
+
+- [ ] R21 -- Rename `LowerStructuralVarRefExpr` (the central HIR-to-MIR helper) to reflect what it
+      actually does post-R16: translate an HIR implicit-receiver structural-var read into a MIR
+      `MemberAccessExpr` whose receiver reaches `self`. The current name still refers to
+      `mir::StructuralVarRef` even though that node is no longer a top-level `ExprData` arm. As a
+      follow-on, consider whether HIR should also retire its own `hir::StructuralVarRef` primary in
+      favour of a unified `hir::MemberAccessExpr` -- SV's `x` (implicit-receiver) and `obj.x`
+      (explicit-receiver) are the same operation at the IR level, and a unified shape would push the
+      implicit-vs-explicit distinction back to the slang front-end. **Trigger**: standalone -- the
+      rename is mechanical; the HIR unification is a separate design discussion.
+
+- [ ] R22 -- Reconsider the procedural-vs-structural variable naming and structure now that
+      "structural variable" no longer appears as an `ExprData` arm. With class-member access
+      generalised to `MemberAccessExpr(receiver, member)`, "structural var" is just "a member of the
+      class" -- a fully general concept -- while "procedural var" is the body-local concept. The two
+      were named as a symmetric pair when both were specialised expression forms; now the structural
+      side has been abstracted into general member access, the asymmetry is awkward. Open questions:
+      does `mir::StructuralVarDecl` need a different name (e.g. `ClassMemberDecl`)? Do shared
+      structures that paralleled the two (e.g. `*VarRef`, `Lookup*Var`) still need to be parallel,
+      or did some of them only exist to mirror an axis that no longer divides? **Trigger**: design
+      discussion -- requires walking the structural / procedural axis across MIR vocabulary, dumper,
+      lowering helpers, and backend, deciding what stays paired and what merges.
 
 ## Out of Scope
 

--- a/include/lyra/backend/cpp/render_context.hpp
+++ b/include/lyra/backend/cpp/render_context.hpp
@@ -25,36 +25,28 @@ class RenderContext {
   [[nodiscard]] auto WithProceduralScope(
       const mir::ProceduralScope& child) const -> RenderContext {
     return RenderContext{
-        *unit_,
-        *scope_,
-        child,
-        this,
-        structural_parent_,
-        static_frame_,
-        in_coroutine_,
-        in_class_member_init_};
+        *unit_,        *scope_,      child, this, structural_parent_,
+        static_frame_, in_coroutine_};
   }
 
   [[nodiscard]] auto WithStructuralScope(
       const mir::StructuralScope& child_scope,
       const mir::ProceduralScope& root_proc_scope) const -> RenderContext {
-    return RenderContext{*unit_, child_scope, root_proc_scope, nullptr,
-                         this,   {},          false,           false};
+    return RenderContext{*unit_, child_scope, root_proc_scope, nullptr, this,
+                         {},     false};
   }
 
   // A subroutine body renders its static locals through this per-instance frame
   // member (LRM 13.3.1). Empty when the current callable has no static locals.
   [[nodiscard]] auto WithStaticFrame(std::string_view accessor) const
       -> RenderContext {
-    return RenderContext{
-        *unit_,
-        *scope_,
-        *proc_scope_,
-        procedural_parent_,
-        structural_parent_,
-        accessor,
-        in_coroutine_,
-        in_class_member_init_};
+    return RenderContext{*unit_,
+                         *scope_,
+                         *proc_scope_,
+                         procedural_parent_,
+                         structural_parent_,
+                         accessor,
+                         in_coroutine_};
   }
 
   // Marks the current body as a coroutine (a process or a task), where `return`
@@ -68,24 +60,7 @@ class RenderContext {
         procedural_parent_,
         structural_parent_,
         static_frame_,
-        in_coroutine,
-        in_class_member_init_};
-  }
-
-  // A class-member initializer is rendered without `self`: there is no instance
-  // in scope at C++ class body init time, so structural-param / structural-var
-  // accesses spell the field name directly. Method bodies leave this false and
-  // qualify accesses with `self->`.
-  [[nodiscard]] auto WithClassMemberInit() const -> RenderContext {
-    return RenderContext{
-        *unit_,
-        *scope_,
-        *proc_scope_,
-        procedural_parent_,
-        structural_parent_,
-        static_frame_,
-        in_coroutine_,
-        true};
+        in_coroutine};
   }
 
   RenderContext(const RenderContext&) = delete;
@@ -144,10 +119,6 @@ class RenderContext {
     return proc_scope_->GetExpr(id);
   }
 
-  [[nodiscard]] auto InClassMemberInit() const -> bool {
-    return in_class_member_init_;
-  }
-
  private:
   RenderContext(
       const mir::CompilationUnit& unit, const mir::StructuralScope& scope,
@@ -164,15 +135,14 @@ class RenderContext {
       const mir::ProceduralScope& proc_scope,
       const RenderContext* procedural_parent,
       const RenderContext* structural_parent, std::string_view static_frame,
-      bool in_coroutine, bool in_class_member_init)
+      bool in_coroutine)
       : unit_(&unit),
         scope_(&scope),
         proc_scope_(&proc_scope),
         procedural_parent_(procedural_parent),
         structural_parent_(structural_parent),
         static_frame_(static_frame),
-        in_coroutine_(in_coroutine),
-        in_class_member_init_(in_class_member_init) {
+        in_coroutine_(in_coroutine) {
   }
 
   const mir::CompilationUnit* unit_;
@@ -182,7 +152,6 @@ class RenderContext {
   const RenderContext* structural_parent_;
   std::string_view static_frame_;
   bool in_coroutine_ = false;
-  bool in_class_member_init_ = false;
 };
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/backend/cpp/render_context.hpp
+++ b/include/lyra/backend/cpp/render_context.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <string>
 #include <string_view>
 
 #include "lyra/base/internal_error.hpp"
@@ -26,29 +25,36 @@ class RenderContext {
   [[nodiscard]] auto WithProceduralScope(
       const mir::ProceduralScope& child) const -> RenderContext {
     return RenderContext{
-        *unit_,        *scope_,       child,    this, structural_parent_,
-        static_frame_, in_coroutine_, receiver_};
+        *unit_,
+        *scope_,
+        child,
+        this,
+        structural_parent_,
+        static_frame_,
+        in_coroutine_,
+        in_class_member_init_};
   }
 
   [[nodiscard]] auto WithStructuralScope(
       const mir::StructuralScope& child_scope,
       const mir::ProceduralScope& root_proc_scope) const -> RenderContext {
     return RenderContext{*unit_, child_scope, root_proc_scope, nullptr,
-                         this,   {},          false,           "this"};
+                         this,   {},          false,           false};
   }
 
   // A subroutine body renders its static locals through this per-instance frame
   // member (LRM 13.3.1). Empty when the current callable has no static locals.
   [[nodiscard]] auto WithStaticFrame(std::string_view accessor) const
       -> RenderContext {
-    return RenderContext{*unit_,
-                         *scope_,
-                         *proc_scope_,
-                         procedural_parent_,
-                         structural_parent_,
-                         accessor,
-                         in_coroutine_,
-                         receiver_};
+    return RenderContext{
+        *unit_,
+        *scope_,
+        *proc_scope_,
+        procedural_parent_,
+        structural_parent_,
+        accessor,
+        in_coroutine_,
+        in_class_member_init_};
   }
 
   // Marks the current body as a coroutine (a process or a task), where `return`
@@ -63,16 +69,14 @@ class RenderContext {
         structural_parent_,
         static_frame_,
         in_coroutine,
-        receiver_};
+        in_class_member_init_};
   }
 
-  // Names the object the body reaches module state and Services() through. A
-  // method body leaves this "this" and emits implicit-`this` access; a fork
-  // branch (LRM 9.3.2) renders as an inline coroutine closure with no implicit
-  // `this`, so its body names the frame-copied receiver parameter `self`
-  // explicitly.
-  [[nodiscard]] auto WithReceiver(std::string_view object) const
-      -> RenderContext {
+  // A class-member initializer is rendered without `self`: there is no instance
+  // in scope at C++ class body init time, so structural-param / structural-var
+  // accesses spell the field name directly. Method bodies leave this false and
+  // qualify accesses with `self->`.
+  [[nodiscard]] auto WithClassMemberInit() const -> RenderContext {
     return RenderContext{
         *unit_,
         *scope_,
@@ -81,7 +85,7 @@ class RenderContext {
         structural_parent_,
         static_frame_,
         in_coroutine_,
-        object};
+        true};
   }
 
   RenderContext(const RenderContext&) = delete;
@@ -140,33 +144,8 @@ class RenderContext {
     return proc_scope_->GetExpr(id);
   }
 
-  // The object the current body reaches the enclosing scope instance through:
-  // `this` in a method body, `self` in a fork-branch closure body. Named where
-  // the object itself is spelled -- a spawned inner closure is invoked with it
-  // and captures it, so a nested fork passes `self` on down.
-  [[nodiscard]] auto ReceiverObject() const -> std::string_view {
-    return receiver_;
-  }
-
-  // The prefix every scope-member access carries. Always explicit -- `this->`
-  // in a method body, `self->` in a fork-branch closure body -- so a process
-  // body and a branch body render identically up to the receiver name.
-  [[nodiscard]] auto MemberPrefix() const -> std::string {
-    return std::string(receiver_) + "->";
-  }
-
-  // The C++ expression naming the RuntimeServices the body submits effects
-  // through (`this->Services()` / `self->Services()`).
-  [[nodiscard]] auto ServicesRef() const -> std::string {
-    return MemberPrefix() + "Services()";
-  }
-
-  // The capture clause of a `[=]`-default deferred lambda (NBA / `$strobe`)
-  // that also grabs the receiver. A `self` pointer is a local captured by the
-  // bare `[=]`; the `this` keyword must be named explicitly because C++20
-  // deprecates `[=]` capture of `this`.
-  [[nodiscard]] auto DeferredByValueCapture() const -> std::string_view {
-    return receiver_ == "this" ? "[=, this]" : "[=]";
+  [[nodiscard]] auto InClassMemberInit() const -> bool {
+    return in_class_member_init_;
   }
 
  private:
@@ -185,7 +164,7 @@ class RenderContext {
       const mir::ProceduralScope& proc_scope,
       const RenderContext* procedural_parent,
       const RenderContext* structural_parent, std::string_view static_frame,
-      bool in_coroutine, std::string_view receiver)
+      bool in_coroutine, bool in_class_member_init)
       : unit_(&unit),
         scope_(&scope),
         proc_scope_(&proc_scope),
@@ -193,7 +172,7 @@ class RenderContext {
         structural_parent_(structural_parent),
         static_frame_(static_frame),
         in_coroutine_(in_coroutine),
-        receiver_(receiver) {
+        in_class_member_init_(in_class_member_init) {
   }
 
   const mir::CompilationUnit* unit_;
@@ -203,7 +182,7 @@ class RenderContext {
   const RenderContext* structural_parent_;
   std::string_view static_frame_;
   bool in_coroutine_ = false;
-  std::string_view receiver_ = "this";
+  bool in_class_member_init_ = false;
 };
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/backend/cpp/render_context.hpp
+++ b/include/lyra/backend/cpp/render_context.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <cstddef>
-#include <format>
 #include <string>
 #include <string_view>
 
@@ -27,23 +25,16 @@ class RenderContext {
 
   [[nodiscard]] auto WithProceduralScope(
       const mir::ProceduralScope& child) const -> RenderContext {
-    return RenderContext{*unit_,
-                         *scope_,
-                         child,
-                         this,
-                         structural_parent_,
-                         temp_counter_,
-                         static_frame_,
-                         in_coroutine_,
-                         receiver_};
+    return RenderContext{
+        *unit_,        *scope_,       child,    this, structural_parent_,
+        static_frame_, in_coroutine_, receiver_};
   }
 
   [[nodiscard]] auto WithStructuralScope(
       const mir::StructuralScope& child_scope,
       const mir::ProceduralScope& root_proc_scope) const -> RenderContext {
-    return RenderContext{*unit_,  child_scope, root_proc_scope,
-                         nullptr, this,        temp_counter_,
-                         {},      false,       "this"};
+    return RenderContext{*unit_, child_scope, root_proc_scope, nullptr,
+                         this,   {},          false,           "this"};
   }
 
   // A subroutine body renders its static locals through this per-instance frame
@@ -55,7 +46,6 @@ class RenderContext {
                          *proc_scope_,
                          procedural_parent_,
                          structural_parent_,
-                         temp_counter_,
                          accessor,
                          in_coroutine_,
                          receiver_};
@@ -71,7 +61,6 @@ class RenderContext {
         *proc_scope_,
         procedural_parent_,
         structural_parent_,
-        temp_counter_,
         static_frame_,
         in_coroutine,
         receiver_};
@@ -90,7 +79,6 @@ class RenderContext {
         *proc_scope_,
         procedural_parent_,
         structural_parent_,
-        temp_counter_,
         static_frame_,
         in_coroutine_,
         object};
@@ -152,11 +140,6 @@ class RenderContext {
     return proc_scope_->GetExpr(id);
   }
 
-  [[nodiscard]] auto AllocateTemp(std::string_view prefix) const
-      -> std::string {
-    return std::format("{}_{}", prefix, (*temp_counter_)++);
-  }
-
   // The object the current body reaches the enclosing scope instance through:
   // `this` in a method body, `self` in a fork-branch closure body. Named where
   // the object itself is spelled -- a spawned inner closure is invoked with it
@@ -194,23 +177,20 @@ class RenderContext {
         scope_(&scope),
         proc_scope_(&proc_scope),
         procedural_parent_(nullptr),
-        structural_parent_(nullptr),
-        temp_counter_(&owned_temp_counter_) {
+        structural_parent_(nullptr) {
   }
 
   RenderContext(
       const mir::CompilationUnit& unit, const mir::StructuralScope& scope,
       const mir::ProceduralScope& proc_scope,
       const RenderContext* procedural_parent,
-      const RenderContext* structural_parent, std::size_t* temp_counter,
-      std::string_view static_frame, bool in_coroutine,
-      std::string_view receiver)
+      const RenderContext* structural_parent, std::string_view static_frame,
+      bool in_coroutine, std::string_view receiver)
       : unit_(&unit),
         scope_(&scope),
         proc_scope_(&proc_scope),
         procedural_parent_(procedural_parent),
         structural_parent_(structural_parent),
-        temp_counter_(temp_counter),
         static_frame_(static_frame),
         in_coroutine_(in_coroutine),
         receiver_(receiver) {
@@ -221,11 +201,9 @@ class RenderContext {
   const mir::ProceduralScope* proc_scope_;
   const RenderContext* procedural_parent_;
   const RenderContext* structural_parent_;
-  std::size_t* temp_counter_;
   std::string_view static_frame_;
   bool in_coroutine_ = false;
   std::string_view receiver_ = "this";
-  mutable std::size_t owned_temp_counter_ = 0;
 };
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/lowering/hir_to_mir/case_cascade.hpp
+++ b/include/lyra/lowering/hir_to_mir/case_cascade.hpp
@@ -111,7 +111,8 @@ auto BuildCaseCascade(
 
   for (std::size_t i = item_count; i-- > 1;) {
     mir::ProceduralScope level_scope;
-    const WalkFrame level_frame = frame.WithProceduralScope(&level_scope);
+    const WalkFrame level_frame =
+        frame.WithProceduralScope(&level_scope).Deeper();
     auto pred_or = std::forward<PredicateBuilder>(build_predicate)(
         level_frame, i, static_cast<std::uint32_t>(i));
     if (!pred_or) {
@@ -137,7 +138,8 @@ auto BuildCaseCascade(
   }
 
   if (item_count > 0) {
-    const WalkFrame wrapper_frame = frame.WithProceduralScope(&wrapper_scope);
+    const WalkFrame wrapper_frame =
+        frame.WithProceduralScope(&wrapper_scope).Deeper();
     auto pred0_or =
         std::forward<PredicateBuilder>(build_predicate)(wrapper_frame, 0, 0);
     if (!pred0_or) {

--- a/include/lyra/lowering/hir_to_mir/continuous_assign.hpp
+++ b/include/lyra/lowering/hir_to_mir/continuous_assign.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/continuous_assign.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
@@ -9,7 +11,7 @@
 namespace lyra::lowering::hir_to_mir {
 
 auto LowerContinuousAssign(
-    const StructuralScopeLowerer& scope, WalkFrame frame,
+    const StructuralScopeLowerer& scope, WalkFrame frame, std::string name,
     const hir::ContinuousAssign& src) -> diag::Result<mir::Process>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
@@ -48,8 +48,10 @@ class ProcessLowerer {
 
   // Lowers an entire HIR process (initial / final / always / always_ff /
   // always_comb / always_latch) into a `mir::Process`. Constructs the process
-  // root scope on the stack and walks `src`'s body into it.
-  auto Run(WalkFrame parent_frame, const hir::Process& src)
+  // root scope on the stack and walks `src`'s body into it. `name` is the
+  // identifier the enclosing scope chose for this process (LRM processes are
+  // anonymous, so the caller synthesises a positional identifier).
+  auto Run(WalkFrame parent_frame, std::string name, const hir::Process& src)
       -> diag::Result<mir::Process>;
 
   // Lowers a HIR subroutine declaration into a `mir::StructuralSubroutineDecl`.

--- a/include/lyra/lowering/hir_to_mir/walk_frame.hpp
+++ b/include/lyra/lowering/hir_to_mir/walk_frame.hpp
@@ -74,6 +74,12 @@ struct WalkFrame {
   // lowering. Empty outside a with-clause body.
   std::optional<mir::ProceduralVarId> active_index_binding;
 
+  // The `self` binding (mir.md invariant 11) at the root of the current body.
+  // Set at body entry (process / subroutine / constructor / closure) and
+  // unchanged through the body walk; updated on entry into a fresh body to
+  // that body's own self id. Empty before any body has been entered.
+  std::optional<mir::ProceduralVarId> self_binding;
+
   // How a `LoopVarRef` resolves in `StructuralScopeLowerer::LowerExpr`. Set
   // by the caller before dispatching a constructor expression. The default
   // (`kStructuralParam`) matches the common generate-control / continuous
@@ -125,6 +131,13 @@ struct WalkFrame {
       -> WalkFrame {
     WalkFrame next = *this;
     next.loop_var_mode = mode;
+    return next;
+  }
+
+  [[nodiscard]] auto WithSelfBinding(mir::ProceduralVarId id) const
+      -> WalkFrame {
+    WalkFrame next = *this;
+    next.self_binding = id;
     return next;
   }
 };

--- a/include/lyra/lowering/hir_to_mir/walk_frame.hpp
+++ b/include/lyra/lowering/hir_to_mir/walk_frame.hpp
@@ -77,8 +77,11 @@ struct WalkFrame {
   // The `self` binding (mir.md invariant 11) at the root of the current body.
   // Set at body entry (process / subroutine / constructor / closure) and
   // unchanged through the body walk; updated on entry into a fresh body to
-  // that body's own self id. Empty before any body has been entered.
+  // that body's own self id. Empty before any body has been entered. The
+  // declaration depth records where the binding was declared so a deeper
+  // reader can compute hops as `current_depth - self_decl_depth`.
   std::optional<mir::ProceduralVarId> self_binding;
+  ProceduralDepth self_decl_depth{};
 
   // How a `LoopVarRef` resolves in `StructuralScopeLowerer::LowerExpr`. Set
   // by the caller before dispatching a constructor expression. The default
@@ -134,10 +137,11 @@ struct WalkFrame {
     return next;
   }
 
-  [[nodiscard]] auto WithSelfBinding(mir::ProceduralVarId id) const
-      -> WalkFrame {
+  [[nodiscard]] auto WithSelfBinding(
+      mir::ProceduralVarId id, ProceduralDepth decl_depth) const -> WalkFrame {
     WalkFrame next = *this;
     next.self_binding = id;
+    next.self_decl_depth = decl_depth;
     return next;
   }
 };

--- a/include/lyra/mir/closure.hpp
+++ b/include/lyra/mir/closure.hpp
@@ -64,6 +64,14 @@ struct Parameter {
 //      carrying the result expression. An empty-`params` closure is invoked
 //      once (fork branch / deferred IIFE) and renders as a captures-as-args
 //      IIFE.
+//   5. `is_coroutine` declares whether the body may suspend (LRM 9.4 timing
+//      controls / event waits) -- equivalent to asking "is the body lowered
+//      as a C++20 coroutine vs a plain lambda". A fork branch (LRM 9.3.2)
+//      spawns its body as a concurrent coroutine; all other closure shapes
+//      (NBA submit / `$strobe` / `$sscanf` IIFE / with-clause iterator /
+//      deferred check) run their body synchronously without suspending.
+//      HIR-to-MIR encodes the value at construction; the backend renders
+//      the body purely by reading it -- no surrounding context lookup.
 //
 // StructuralVarRef inside body may carry hops that reach module-scope storage
 // directly, the same way C++ lambdas may reference globals without capture.
@@ -71,6 +79,7 @@ struct ClosureExpr {
   std::vector<Capture> captures;
   std::vector<Parameter> params;
   std::unique_ptr<ProceduralScope> body;
+  bool is_coroutine = false;
 
   ClosureExpr();
   ~ClosureExpr();

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -26,6 +26,7 @@ struct BuiltinMirTypes {
   TypeId void_type;
   TypeId realtime;
   TypeId time;
+  TypeId self_pointer;
 };
 
 struct CompilationUnit {
@@ -63,6 +64,10 @@ struct CompilationUnit {
                     .signedness = Signedness::kUnsigned,
                     .dims = {PackedRange{.left = 63, .right = 0}},
                     .form = PackedArrayForm::kTime}}),
+            .self_pointer = AddType(
+                TypeData{PointerType{
+                    .pointee = AddType(TypeData{SelfType{}}),
+                    .ownership = PointerOwnership::kBorrowed}}),
         } {
   }
 

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -154,17 +154,11 @@ struct DerefExpr {
   ExprId pointer;
 };
 
-// The enclosing scope object (`this` in a method body, `self` in a fork-branch
-// closure). The starting handle of an object-tree navigation; `Expr::type` is a
-// borrowed pointer to ScopeType. Will be removed once every site that produces
-// it migrates to the explicit-receiver shape (mir.md invariant 11).
-struct SelfScopeExpr {};
-
 // Class-member access through an explicit receiver expression. `receiver`
-// evaluates to a class-instance value (typically
-// `DerefExpr(ProceduralVarRef(self))`); `member` names which structural var of
-// the receiver's class to reach. The receiver is explicit -- a backend never
-// asks "what is the current receiver?" (mir.md invariant 11).
+// evaluates to a class-instance value (typically `ProceduralVarRef(self)`);
+// `member` names which structural var of the receiver's class to reach. The
+// receiver is explicit -- a backend never asks "what is the current receiver?"
+// (mir.md invariant 11).
 struct MemberAccessExpr {
   ExprId receiver;
   StructuralVarRef member;
@@ -226,11 +220,10 @@ struct ConstructExpr {
 
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, StructuralParamRef,
-    StructuralVarRef, ProceduralVarRef, UnaryExpr, BinaryExpr, ConditionalExpr,
-    AssignExpr, IncDecExpr, CallExpr, RuntimeCallExpr, DerefExpr, SelfScopeExpr,
-    MemberAccessExpr, ConversionExpr, ClosureExpr, ElementSelectExpr,
-    RangeSelectExpr, ConcatExpr, ReplicationExpr, ArrayLiteralExpr,
-    ConstructExpr>;
+    ProceduralVarRef, UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr,
+    IncDecExpr, CallExpr, RuntimeCallExpr, DerefExpr, MemberAccessExpr,
+    ConversionExpr, ClosureExpr, ElementSelectExpr, RangeSelectExpr, ConcatExpr,
+    ReplicationExpr, ArrayLiteralExpr, ConstructExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -156,8 +156,19 @@ struct DerefExpr {
 
 // The enclosing scope object (`this` in a method body, `self` in a fork-branch
 // closure). The starting handle of an object-tree navigation; `Expr::type` is a
-// borrowed pointer to ScopeType.
+// borrowed pointer to ScopeType. Will be removed once every site that produces
+// it migrates to the explicit-receiver shape (mir.md invariant 11).
 struct SelfScopeExpr {};
+
+// Class-member access through an explicit receiver expression. `receiver`
+// evaluates to a class-instance value (typically
+// `DerefExpr(ProceduralVarRef(self))`); `member` names which structural var of
+// the receiver's class to reach. The receiver is explicit -- a backend never
+// asks "what is the current receiver?" (mir.md invariant 11).
+struct MemberAccessExpr {
+  ExprId receiver;
+  StructuralVarRef member;
+};
 
 struct ElementSelectExpr {
   ExprId base_value;
@@ -217,8 +228,9 @@ using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, StructuralParamRef,
     StructuralVarRef, ProceduralVarRef, UnaryExpr, BinaryExpr, ConditionalExpr,
     AssignExpr, IncDecExpr, CallExpr, RuntimeCallExpr, DerefExpr, SelfScopeExpr,
-    ConversionExpr, ClosureExpr, ElementSelectExpr, RangeSelectExpr, ConcatExpr,
-    ReplicationExpr, ArrayLiteralExpr, ConstructExpr>;
+    MemberAccessExpr, ConversionExpr, ClosureExpr, ElementSelectExpr,
+    RangeSelectExpr, ConcatExpr, ReplicationExpr, ArrayLiteralExpr,
+    ConstructExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/mir/process.hpp
+++ b/include/lyra/mir/process.hpp
@@ -21,6 +21,7 @@ enum class ProcessKind : std::uint8_t {
 
 struct Process {
   ProcessKind kind = ProcessKind::kInitial;
+  std::string name;
   ProceduralScope root_procedural_scope;
   std::vector<StaticLocal> static_locals;
 };

--- a/include/lyra/mir/structural_var.hpp
+++ b/include/lyra/mir/structural_var.hpp
@@ -4,7 +4,6 @@
 #include <cstdint>
 #include <string>
 
-#include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/type_id.hpp"
 
 namespace lyra::mir {
@@ -16,9 +15,11 @@ struct StructuralVarId {
       -> std::strong_ordering = default;
 };
 
-// HIR distinguishes "no user initializer" from "explicit zero initializer";
-// MIR does not -- the LRM Table 6-7 default is materialised as a primitive
-// expression at the HIR-to-MIR boundary, so every variable carries one.
+// A declaration carries name and type only. LRM 10.5 variable initialization
+// (the user-supplied `= value` or the LRM Table 6-7 type default) lowers to
+// an `AssignExpr` statement at the top of the enclosing scope's
+// `constructor_scope.root_stmts`; every backend renders construction-time
+// state from that single statement list.
 struct StructuralVarDecl {
   std::string name;
   // By-name lookup key; differs from the unique physical `name` only for a
@@ -26,7 +27,6 @@ struct StructuralVarDecl {
   // Empty when it equals `name`.
   std::string source_name = {};
   TypeId type;
-  ExprId initializer;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -28,6 +28,7 @@ enum class TypeKind {
   kObject,
   kExternalUnitObject,
   kScope,
+  kSelf,
   kPointer,
   kVector,
   kExternalRef,
@@ -146,6 +147,13 @@ struct ScopeType {
   auto operator==(const ScopeType&) const -> bool = default;
 };
 
+// Pointee of `self` (mir.md invariant 11). Distinct from `ScopeType` (the
+// type-erased runtime base) and `ObjectType` (a child of the owner): names
+// the concrete scope this declaration sits in, resolved lexically.
+struct SelfType {
+  auto operator==(const SelfType&) const -> bool = default;
+};
+
 enum class PointerOwnership {
   kUnique,
   kShared,
@@ -201,7 +209,7 @@ using TypeData = std::variant<
     PackedArrayType, EnumType, UnpackedArrayType, DynamicArrayType, QueueType,
     AssociativeArrayType, StringType, EventType, RealType, ShortRealType,
     RealTimeType, ChandleType, VoidType, ObjectType, ExternalUnitObjectType,
-    ScopeType, PointerType, VectorType, ExternalRefType>;
+    ScopeType, SelfType, PointerType, VectorType, ExternalRefType>;
 
 struct Type {
   TypeData data;

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -33,7 +33,7 @@ class Scope {
  public:
   using ChildVisitor = std::function<void(Scope&)>;
 
-  Scope(Scope* parent, std::string name);
+  Scope(Scope* parent, std::string name, RuntimeServices& services);
   virtual ~Scope() = default;
   Scope(const Scope&) = delete;
   auto operator=(const Scope&) -> Scope& = delete;
@@ -93,10 +93,11 @@ class Scope {
     return kUnspecifiedTimePrecisionPower;
   }
 
-  // Wires the services handle, creates this scope's processes, then recurses
-  // into the children. Identity (name, parent, kind-as-type) is already fixed
-  // at construction; bind only installs runtime behavior.
-  void Bind(RuntimeServices& services);
+  // Relocates any registered `ExternUp` members, creates this scope's
+  // processes, then recurses into the children. Services are already wired in
+  // the constructor; Bind only installs runtime behavior that requires the
+  // whole tree to exist.
+  void Bind();
 
   // Last-write-wins per site within a time slot: re-submit at the same site
   // overwrites the prior closure, which suppresses settle-time glitches.
@@ -142,7 +143,7 @@ class Scope {
 
   Scope* parent_ = nullptr;
   std::string name_;
-  RuntimeServices* services_ = nullptr;
+  RuntimeServices* services_ = nullptr;  // borrowed; set in ctor.
   // Non-owning child links; the typed members on the derived class own the
   // children. This is the object tree's own structure, not a parallel one.
   std::vector<Scope*> children_;

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -31,6 +31,12 @@ class DynamicArray {
  public:
   using ElementType = T;
 
+  // Sentinel "uninitialized" form -- empty container with default-constructed
+  // OOB slot. Used as the declared default state of a `Var<DynamicArray<T>>`
+  // field; the first MIR-level assignment overwrites the whole array (LRM
+  // 10.5 variable initialization).
+  DynamicArray() = default;
+
   // Empty container with the shield slot seeded. Used for declarations like
   // `int arr[];` where the array starts empty but the element shape is
   // known at lowering time.

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -51,6 +51,13 @@ struct PackedRange {
 // the API contract.
 class PackedArray {
  public:
+  // Default constructor: 0-bit unsigned 2-state. A 0-bit PackedArray is not a
+  // valid SV value -- it serves as the "uninitialized" sentinel state that lets
+  // `Var<PackedArray>` be declared without an inline initializer; the first
+  // assignment into a 0-bit destination adopts the source's shape (see
+  // `AssignFrom`).
+  PackedArray();
+
   // Primary constructor: declared dim stack + sign + 4-state. Total bit
   // width is the product of dim sizes (cached internally as `bit_width_`).
   PackedArray(

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -39,6 +39,12 @@ class UnpackedArray {
  public:
   using ElementType = T;
 
+  // Sentinel "uninitialized" form -- empty container with default-constructed
+  // OOB slot. Used as the declared default state of a `Var<UnpackedArray<T>>`
+  // field; the first MIR-level assignment overwrites the whole array (LRM
+  // 10.5 variable initialization).
+  UnpackedArray() = default;
+
   // Empty container with the shield slot seeded. Internal use only -- SV
   // fixed-size arrays are always non-empty; this form serves `Slice` and
   // similar paths that build a fresh `UnpackedArray` element-by-element.

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -110,15 +110,11 @@ auto RenderConstructor(
   return out;
 }
 
-auto RenderProcessMethodName(std::size_t index) -> std::string {
-  return "process_" + std::to_string(index);
-}
-
 auto RenderProcessMethod(
     const RenderContext* parent_struct_ctx, const mir::CompilationUnit& unit,
     const mir::StructuralScope& s, const mir::Process& process,
-    std::size_t index, std::size_t indent) -> diag::Result<std::string> {
-  const std::string frame_field = RenderProcessMethodName(index) + "__static";
+    std::size_t indent) -> diag::Result<std::string> {
+  const std::string frame_field = process.name + "__static";
   const RenderContext proc_ctx =
       ((parent_struct_ctx == nullptr)
            ? RenderContext::ForRoot(unit, s, process.root_procedural_scope)
@@ -133,8 +129,7 @@ auto RenderProcessMethod(
   // it, and a detached fork branch reaches it by reference past the activation.
   // A process with no static locals yields a fieldless frame -- harmless, and
   // it keeps the emit a uniform walk with no presence decision.
-  out += Indent(indent) + "struct " + RenderProcessMethodName(index) +
-         "_StaticFrame {\n";
+  out += Indent(indent) + "struct " + process.name + "_StaticFrame {\n";
   for (const auto& sl : process.static_locals) {
     const auto& var = process.root_procedural_scope.vars.at(sl.var.value);
     auto type_or = RenderTypeAsCpp(unit, s, var.type);
@@ -148,7 +143,7 @@ auto RenderProcessMethod(
   }
   out += Indent(indent) + "} " + frame_field + "{};\n";
 
-  out += Indent(indent) + "auto " + RenderProcessMethodName(index) +
+  out += Indent(indent) + "auto " + process.name +
          "() -> lyra::runtime::Coroutine {\n";
   auto rendered_or = RenderProceduralScopeStatements(proc_ctx, indent + 1);
   if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
@@ -269,11 +264,9 @@ auto RenderCreateProcesses(const mir::StructuralScope& s, std::size_t indent)
     -> std::string {
   std::string out;
   out += Indent(indent) + "void CreateProcesses() override {\n";
-  for (std::size_t i = 0; i < s.processes.size(); ++i) {
-    const auto& p = s.processes[i];
+  for (const auto& p : s.processes) {
     out += Indent(indent + 1) + "AddProcess(" +
-           RenderProcessKindLiteral(p.kind) + ", " +
-           RenderProcessMethodName(i) + "());\n";
+           RenderProcessKindLiteral(p.kind) + ", " + p.name + "());\n";
   }
   out += Indent(indent) + "}\n";
   return out;
@@ -376,10 +369,10 @@ auto RenderScopeAsClass(
   out += "\n";
   out += Indent(indent) + " private:\n";
 
-  for (std::size_t i = 0; i < s.processes.size(); ++i) {
+  for (const auto& p : s.processes) {
     out += "\n";
-    auto method_or = RenderProcessMethod(
-        parent_struct_ctx, unit, s, s.processes[i], i, indent + 1);
+    auto method_or =
+        RenderProcessMethod(parent_struct_ctx, unit, s, p, indent + 1);
     if (!method_or) return std::unexpected(std::move(method_or.error()));
     out += *method_or;
   }

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -34,10 +34,9 @@ auto RenderField(
   const auto& unit = ctor_ctx.Unit();
   auto type_or = RenderTypeAsCpp(unit, ctor_ctx.StructuralScope(), var.type);
   if (!type_or) return std::unexpected(std::move(type_or.error()));
-  // An upward reference is an ExternUp member constructed with its symbol --
-  // the ancestor name, the by-name tail down through its owned children, and
-  // the leaf signal. It registers itself and relocates at Bind, so it has no
-  // value initializer.
+  // An upward reference is an ExternUp member: its constructor takes the
+  // symbol payload (ancestor, by-name tail, leaf signal) rather than a value
+  // initializer; it registers itself and relocates at Bind.
   if (const auto* er =
           std::get_if<mir::ExternalRefType>(&unit.GetType(var.type).data)) {
     std::string tail = "{";
@@ -54,21 +53,11 @@ auto RenderField(
     return Indent(indent) + *type_or + " " + var.name + "{this, \"" +
            er->ancestor + "\", " + tail + ", \"" + er->signal + "\"};\n";
   }
-  const RenderContext field_init_ctx = ctor_ctx.WithClassMemberInit();
-  auto value_expr_or =
-      RenderExpr(field_init_ctx, field_init_ctx.Expr(var.initializer));
-  if (!value_expr_or) {
-    return std::unexpected(std::move(value_expr_or.error()));
-  }
-  // Var<T> forwards its single payload through a variadic-of-1 ctor to T's
-  // copy ctor. Plain T uses copy-init because `T n(args);` at class scope
-  // would parse as a member-function declaration.
   if (IsObservableScalarType(unit.GetType(var.type))) {
     return Indent(indent) + "lyra::runtime::Var<" + *type_or + "> " + var.name +
-           "{" + *value_expr_or + "};\n";
+           "{};\n";
   }
-  return Indent(indent) + *type_or + " " + var.name + " = " + *value_expr_or +
-         ";\n";
+  return Indent(indent) + *type_or + " " + var.name + "{};\n";
 }
 
 auto RenderParamField(
@@ -88,8 +77,10 @@ auto RenderConstructor(
     const RenderContext& scope_ctx, const mir::StructuralScope& s,
     const std::string& base_class, std::size_t indent)
     -> diag::Result<std::string> {
-  std::string sig = s.name + "(lyra::runtime::Scope* parent, std::string name";
-  std::string init_list = base_class + "(parent, std::move(name))";
+  std::string sig = s.name +
+                    "(lyra::runtime::Scope* parent, std::string name, "
+                    "lyra::runtime::RuntimeServices& services";
+  std::string init_list = base_class + "(parent, std::move(name), services)";
   for (std::size_t i = 0; i < s.structural_params.size(); ++i) {
     const auto& p = s.structural_params[i];
     const auto param_name = CtorParamName(i);
@@ -517,11 +508,12 @@ auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
   }
   out += "\n";
   out += "auto main() -> int {\n";
+  out += "  lyra::runtime::Engine engine;\n";
   for (std::size_t i = 0; i < tops.size(); ++i) {
     out += "  " + tops[i].unit->structural_scope.name + " top" +
-           std::to_string(i) + "{nullptr, \"" + tops[i].name + "\"};\n";
+           std::to_string(i) + "{nullptr, \"" + tops[i].name +
+           "\", engine.Services()};\n";
   }
-  out += "  lyra::runtime::Engine engine;\n";
   out += "  std::vector<lyra::runtime::TopBinding> tops = {\n";
   for (std::size_t i = 0; i < tops.size(); ++i) {
     out += "      {&top" + std::to_string(i) + "},\n";

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -54,7 +54,9 @@ auto RenderField(
     return Indent(indent) + *type_or + " " + var.name + "{this, \"" +
            er->ancestor + "\", " + tail + ", \"" + er->signal + "\"};\n";
   }
-  auto value_expr_or = RenderExpr(ctor_ctx, ctor_ctx.Expr(var.initializer));
+  const RenderContext field_init_ctx = ctor_ctx.WithClassMemberInit();
+  auto value_expr_or =
+      RenderExpr(field_init_ctx, field_init_ctx.Expr(var.initializer));
   if (!value_expr_or) {
     return std::unexpected(std::move(value_expr_or.error()));
   }
@@ -102,7 +104,8 @@ auto RenderConstructor(
     return Indent(indent) + sig + " {}\n";
   }
   std::string out;
-  out += Indent(indent) + sig + " {\n";
+  out += Indent(indent) + sig + " { init(this); }\n";
+  out += Indent(indent) + "static void init(" + s.name + "* self) {\n";
   auto rendered_or = RenderProceduralScopeStatements(scope_ctx, indent + 1);
   if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
   out += *rendered_or;
@@ -143,8 +146,8 @@ auto RenderProcessMethod(
   }
   out += Indent(indent) + "} " + frame_field + "{};\n";
 
-  out += Indent(indent) + "auto " + process.name +
-         "() -> lyra::runtime::Coroutine {\n";
+  out += Indent(indent) + "static auto " + process.name + "(" + s.name +
+         "* self) -> lyra::runtime::Coroutine {\n";
   auto rendered_or = RenderProceduralScopeStatements(proc_ctx, indent + 1);
   if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
   out += *rendered_or;
@@ -181,12 +184,12 @@ auto RenderSubroutineMethod(
     return_type = *std::move(result_or);
   }
 
-  std::string sig = return_type + " " + sub.name + "(";
-  for (std::size_t i = 0; i < sub.params.size(); ++i) {
-    const auto& param = sub.params[i];
+  std::string sig =
+      "static " + return_type + " " + sub.name + "(" + s.name + "* self";
+  for (const auto& param : sub.params) {
     auto type_or = RenderTypeAsCpp(unit, s, param.type);
     if (!type_or) return std::unexpected(std::move(type_or.error()));
-    if (i != 0) sig += ", ";
+    sig += ", ";
     // An `input` formal is a by-value copy (LRM 13.5.1). An `output` / `inout`
     // formal binds to the caller's writeback temp by reference (`T&`) so body
     // writes flow back at the copy-out. A `ref` / `const ref` formal aliases
@@ -266,7 +269,7 @@ auto RenderCreateProcesses(const mir::StructuralScope& s, std::size_t indent)
   out += Indent(indent) + "void CreateProcesses() override {\n";
   for (const auto& p : s.processes) {
     out += Indent(indent + 1) + "AddProcess(" +
-           RenderProcessKindLiteral(p.kind) + ", " + p.name + "());\n";
+           RenderProcessKindLiteral(p.kind) + ", " + p.name + "(this));\n";
   }
   out += Indent(indent) + "}\n";
   return out;

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1821,6 +1821,11 @@ auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
           [&](const mir::SelfScopeExpr&) -> diag::Result<std::string> {
             return std::string(ctx.ReceiverObject());
           },
+          [&](const mir::MemberAccessExpr&) -> diag::Result<std::string> {
+            throw InternalError(
+                "MemberAccessExpr rendering not implemented yet -- HIR-to-MIR "
+                "has not migrated to producing it");
+          },
           [&](const mir::ClosureExpr& cl) -> diag::Result<std::string> {
             return RenderClosureExpr(ctx, cl);
           },

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1594,9 +1594,14 @@ auto RenderClosureExpr(
     return_clause = " -> " + *ret_ty_or;
   }
 
+  // The closure's coroutine-ness comes from MIR; every closure flowing
+  // through this path (NBA / `$strobe` / `$sscanf` IIFE / with-clause /
+  // deferred check) has `is_coroutine = false`, but the render reads the
+  // flag rather than assuming.
   const RenderContext body_ctx =
       RenderContext::ForRoot(ctx.Unit(), ctx.StructuralScope(), *closure.body)
-          .WithReceiver(ctx.ReceiverObject());
+          .WithReceiver(ctx.ReceiverObject())
+          .WithCoroutine(closure.is_coroutine);
   auto body_or = RenderProceduralScopeStatements(body_ctx, 1);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
 

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -196,7 +196,7 @@ auto RenderStructuralParamExpr(
   }
   const std::string& name =
       ctx.StructuralScope().GetStructuralParam(r.param).name;
-  return ctx.InClassMemberInit() ? name : "self->" + name;
+  return "self->" + name;
 }
 
 auto LookupProceduralVarName(
@@ -1803,16 +1803,11 @@ auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
           [&](const mir::MemberAccessExpr& m) -> diag::Result<std::string> {
             const auto& scope = ctx.StructuralScopeAtHops(m.member.hops);
             const auto& var = scope.GetStructuralVar(m.member.var);
-            std::string base;
-            if (ctx.InClassMemberInit()) {
-              base = var.name;
-            } else {
-              auto receiver_or = RenderExpr(ctx, ctx.Expr(m.receiver));
-              if (!receiver_or) {
-                return std::unexpected(std::move(receiver_or.error()));
-              }
-              base = *receiver_or + "->" + var.name;
+            auto receiver_or = RenderExpr(ctx, ctx.Expr(m.receiver));
+            if (!receiver_or) {
+              return std::unexpected(std::move(receiver_or.error()));
             }
+            std::string base = *receiver_or + "->" + var.name;
             if (ctx.Unit().GetType(expr.type).IsIntegralPacked()) {
               base += ".Get()";
             }

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -194,7 +194,9 @@ auto RenderStructuralParamExpr(
         "cpp emit",
         diag::UnsupportedCategory::kFeature);
   }
-  return ctx.StructuralScope().GetStructuralParam(r.param).name;
+  const std::string& name =
+      ctx.StructuralScope().GetStructuralParam(r.param).name;
+  return ctx.InClassMemberInit() ? name : "self->" + name;
 }
 
 auto LookupProceduralVarName(
@@ -202,7 +204,7 @@ auto LookupProceduralVarName(
   const auto& var = ctx.ProceduralScopeAtHops(ref.hops).vars.at(ref.var.value);
   if (var.lifetime == mir::VariableLifetime::kStatic) {
     return std::format(
-        "{}{}.{}", ctx.MemberPrefix(), ctx.StaticFrame(),
+        "{}{}.{}", "self->", ctx.StaticFrame(),
         StaticFrameMemberName(var.name, ref.var.value));
   }
   return var.name;
@@ -229,28 +231,10 @@ auto RenderStructuralVarName(
         "emit",
         diag::UnsupportedCategory::kFeature);
   }
-  return ctx.MemberPrefix() +
-         ctx.StructuralScope().GetStructuralVar(ref.var).name;
+  return "self->" + ctx.StructuralScope().GetStructuralVar(ref.var).name;
 }
 
 namespace {
-
-// Read-side render for a structural var ref. Integral packed vars wrap in
-// `Var<PackedArray>` whose held value is observed via `.Get()`; all other
-// storage types (real-family, string, ObjectType) expose the value directly,
-// so the bare field name is the C++ read expression. Writes use
-// `RenderStructuralVarName` directly (no `.Get()`); the read/write split is
-// intentional and lives at this boundary.
-auto RenderStructuralVarReadExpr(
-    const RenderContext& ctx, const mir::Expr& expr,
-    const mir::StructuralVarRef& m) -> diag::Result<std::string> {
-  auto name_or = RenderStructuralVarName(ctx, m);
-  if (!name_or) return std::unexpected(std::move(name_or.error()));
-  if (ctx.Unit().GetType(expr.type).IsIntegralPacked()) {
-    return *name_or + ".Get()";
-  }
-  return *name_or;
-}
 
 // Builds the C++ literal that materializes a 1-bit PackedArray of the SV-typed
 // shape carried by `result_ty`. Used to wrap the C++ `bool` result of a
@@ -946,7 +930,7 @@ auto RenderEventMethodCall(
   }
   const std::string args = (m.kind == mir::EventMethodKind::kTrigger ||
                             m.kind == mir::EventMethodKind::kTriggered)
-                               ? ctx.ServicesRef()
+                               ? "self->Services()"
                                : std::string{};
   const std::string raw_call = std::format(
       "({}).{}({})", *receiver_or, EventMethodMemberName(m.kind), args);
@@ -1078,8 +1062,9 @@ auto RenderCallExpr(
               if (i != 0) args += ", ";
               args += rendered;
             }
-            std::string call =
-                std::format("{}{}({})", ctx.MemberPrefix(), decl.name, args);
+            std::string call_args{std::string_view{"self"}};
+            if (!args.empty()) call_args += ", " + args;
+            std::string call = std::format("{}({})", decl.name, call_args);
             // A task is a coroutine enabled with `co_await`; the only legal
             // callers are process / task bodies, which are themselves
             // coroutines (LRM 13.4 b forbids a function enabling a task).
@@ -1235,10 +1220,14 @@ auto RenderLhsExpr(
     std::string_view mutate_adapter) -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
-          [&](const mir::StructuralVarRef& r) -> diag::Result<std::string> {
-            auto name = RenderStructuralVarName(ctx, r);
-            if (!name) return std::unexpected(std::move(name.error()));
-            return *name + std::string{mutate_adapter};
+          [&](const mir::MemberAccessExpr& m) -> diag::Result<std::string> {
+            auto receiver_or = RenderExpr(ctx, ctx.Expr(m.receiver));
+            if (!receiver_or) {
+              return std::unexpected(std::move(receiver_or.error()));
+            }
+            const auto& scope = ctx.StructuralScopeAtHops(m.member.hops);
+            const auto& var = scope.GetStructuralVar(m.member.var);
+            return *receiver_or + "->" + var.name + std::string{mutate_adapter};
           },
           [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
             return LookupProceduralVarName(ctx, l);
@@ -1302,9 +1291,10 @@ auto LhsRootPrimary(const RenderContext& ctx, const mir::Expr& expr)
 auto LhsRootIsObservableScalar(const RenderContext& ctx, const mir::Expr& expr)
     -> bool {
   const mir::Expr& root = LhsRootPrimary(ctx, expr);
-  if (const auto* sv = std::get_if<mir::StructuralVarRef>(&root.data)) {
-    return IsObservableScalarType(ctx.Unit().GetType(
-        ctx.StructuralScope().GetStructuralVar(sv->var).type));
+  if (const auto* m = std::get_if<mir::MemberAccessExpr>(&root.data)) {
+    const auto& scope = ctx.StructuralScopeAtHops(m->member.hops);
+    return IsObservableScalarType(
+        ctx.Unit().GetType(scope.GetStructuralVar(m->member.var).type));
   }
   if (std::holds_alternative<mir::DerefExpr>(root.data)) {
     return IsObservableScalarType(ctx.Unit().GetType(root.type));
@@ -1313,7 +1303,7 @@ auto LhsRootIsObservableScalar(const RenderContext& ctx, const mir::Expr& expr)
 }
 
 auto IsLhsBarePrimary(const mir::Expr& expr) -> bool {
-  return std::holds_alternative<mir::StructuralVarRef>(expr.data) ||
+  return std::holds_alternative<mir::MemberAccessExpr>(expr.data) ||
          std::holds_alternative<mir::DerefExpr>(expr.data) ||
          std::holds_alternative<mir::ProceduralVarRef>(expr.data);
 }
@@ -1391,7 +1381,7 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
           diag::UnsupportedCategory::kFeature);
     }
     return LookupProceduralVarName(ctx, *ref_root) + ".Set(" +
-           ctx.ServicesRef() + ", " + *value_or + ")";
+           "self->Services()" + ", " + *value_or + ")";
   }
 
   const bool observable = LhsRootIsObservableScalar(ctx, lhs_expr);
@@ -1408,12 +1398,12 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
       // Procedural-local compounds operate on the underlying PackedArray
       // directly via its own `op=` overloads.
       const std::string chain =
-          observable ? *root_or + ".Mutate(" + ctx.ServicesRef() + ")"
+          observable ? *root_or + ".Mutate(" + "self->Services()" + ")"
                      : *root_or;
       return "(" + RenderCompoundAssign(*a.compound_op, chain, *value_or) + ")";
     }
     if (observable) {
-      return *root_or + ".Set(" + ctx.ServicesRef() + ", " + *value_or + ")";
+      return *root_or + ".Set(" + "self->Services()" + ", " + *value_or + ")";
     }
     return "(" + *root_or + " = " + *value_or + ")";
   }
@@ -1431,7 +1421,7 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
   // destructor commits the snapshot through `Var::Set` so subscribers fire.
   // Same shape inside or outside an NBA closure body -- no nested lambda.
   const std::string mutate_adapter =
-      observable ? ".Mutate(" + ctx.ServicesRef() + ")" : std::string{};
+      observable ? std::string{".Mutate(self->Services())"} : std::string{};
   auto chain_or = RenderLhsExpr(ctx, lhs_expr, mutate_adapter);
   if (!chain_or) return std::unexpected(std::move(chain_or.error()));
   if (a.compound_op.has_value()) {
@@ -1457,11 +1447,10 @@ auto RenderIncDecExpr(const RenderContext& ctx, const mir::IncDecExpr& inc)
   if (IsLhsBarePrimary(target_expr)) {
     auto root_or = RenderLhsExpr(ctx, target_expr, std::string_view{});
     if (!root_or) return std::unexpected(std::move(root_or.error()));
-    lhs =
-        observable ? *root_or + ".Mutate(" + ctx.ServicesRef() + ")" : *root_or;
+    lhs = observable ? *root_or + ".Mutate(self->Services())" : *root_or;
   } else {
     const std::string mutate_adapter =
-        observable ? ".Mutate(" + ctx.ServicesRef() + ")" : std::string{};
+        observable ? std::string{".Mutate(self->Services())"} : std::string{};
     auto chain_or = RenderLhsExpr(ctx, target_expr, mutate_adapter);
     if (!chain_or) return std::unexpected(std::move(chain_or.error()));
     lhs = *std::move(chain_or);
@@ -1516,15 +1505,12 @@ auto RenderClosureExpr(
     throw InternalError("RenderClosureExpr: closure has no body");
   }
 
-  // Capture the receiver by value so the deferred body can reach scope members
-  // (the Scope base's Services() accessor and SubmitObserved interface, plus
-  // the emitted class's structural vars) when it later runs: `this` in a method
-  // body, or the branch's `self` pointer when the closure is nested in a
-  // fork-branch closure (LRM 9.3.2). The explicit by-value captures from the
-  // MIR list go after.
-  std::string captures_text{ctx.ReceiverObject()};
+  // Every captured value flows through `closure.captures` as a named
+  // by-value or by-reference entry; the receiver `self` is captures[0] (mir.md
+  // invariant 11). The clause never contains `[this]`, `[=]`, or `[&]`.
+  std::string captures_text;
   for (std::size_t i = 0; i < closure.captures.size(); ++i) {
-    captures_text += ", ";
+    if (i != 0) captures_text += ", ";
     auto rendered_or = std::visit(
         Overloaded{
             [&](const mir::ByValueCapture& bv) -> diag::Result<std::string> {
@@ -1600,7 +1586,6 @@ auto RenderClosureExpr(
   // flag rather than assuming.
   const RenderContext body_ctx =
       RenderContext::ForRoot(ctx.Unit(), ctx.StructuralScope(), *closure.body)
-          .WithReceiver(ctx.ReceiverObject())
           .WithCoroutine(closure.is_coroutine);
   auto body_or = RenderProceduralScopeStatements(body_ctx, 1);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
@@ -1784,9 +1769,6 @@ auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
           [&](const mir::StructuralParamRef& r) -> diag::Result<std::string> {
             return RenderStructuralParamExpr(ctx, r);
           },
-          [&](const mir::StructuralVarRef& m) -> diag::Result<std::string> {
-            return RenderStructuralVarReadExpr(ctx, expr, m);
-          },
           [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
             const std::string name = LookupProceduralVarName(ctx, l);
             return IsReferenceProceduralVar(ctx, l) ? name + ".Get()" : name;
@@ -1818,13 +1800,23 @@ auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
           [&](const mir::DerefExpr& d) -> diag::Result<std::string> {
             return RenderDerefExpr(ctx, expr, d);
           },
-          [&](const mir::SelfScopeExpr&) -> diag::Result<std::string> {
-            return std::string(ctx.ReceiverObject());
-          },
-          [&](const mir::MemberAccessExpr&) -> diag::Result<std::string> {
-            throw InternalError(
-                "MemberAccessExpr rendering not implemented yet -- HIR-to-MIR "
-                "has not migrated to producing it");
+          [&](const mir::MemberAccessExpr& m) -> diag::Result<std::string> {
+            const auto& scope = ctx.StructuralScopeAtHops(m.member.hops);
+            const auto& var = scope.GetStructuralVar(m.member.var);
+            std::string base;
+            if (ctx.InClassMemberInit()) {
+              base = var.name;
+            } else {
+              auto receiver_or = RenderExpr(ctx, ctx.Expr(m.receiver));
+              if (!receiver_or) {
+                return std::unexpected(std::move(receiver_or.error()));
+              }
+              base = *receiver_or + "->" + var.name;
+            }
+            if (ctx.Unit().GetType(expr.type).IsIntegralPacked()) {
+              base += ".Get()";
+            }
+            return base;
           },
           [&](const mir::ClosureExpr& cl) -> diag::Result<std::string> {
             return RenderClosureExpr(ctx, cl);

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -177,7 +177,7 @@ auto RenderRuntimePrintCall(
   if (call.items.empty()) {
     return std::format(
         "{}({}, {}, {}std::span<const lyra::value::PrintItem>{{}})",
-        call_target, ctx.ServicesRef(), kind_literal, descriptor_arg);
+        call_target, "self->Services()", kind_literal, descriptor_arg);
   }
 
   // The PrintItem array is built inline via `std::array<PrintItem, N>{...}`;
@@ -194,7 +194,7 @@ auto RenderRuntimePrintCall(
 
   std::string out = std::format(
       "{}({}, {}, {}std::array<lyra::value::PrintItem, {}>{{", call_target,
-      ctx.ServicesRef(), kind_literal, descriptor_arg, call.items.size());
+      "self->Services()", kind_literal, descriptor_arg, call.items.size());
   for (std::size_t i = 0; i < item_inits.size(); ++i) {
     if (i != 0) {
       out += ", ";
@@ -205,11 +205,10 @@ auto RenderRuntimePrintCall(
   return out;
 }
 
-auto RenderRuntimeFinishCall(
-    const RenderContext& ctx, const mir::RuntimeFinishCall& call)
+auto RenderRuntimeFinishCall(const mir::RuntimeFinishCall& call)
     -> std::string {
   return std::format(
-      "co_await lyra::runtime::Finish({}, {})", ctx.ServicesRef(), call.level);
+      "co_await lyra::runtime::Finish(self->Services(), {})", call.level);
 }
 
 auto RenderRuntimeDiagnosticSeverity(mir::DiagnosticSeverity s)
@@ -247,7 +246,7 @@ auto RenderRuntimeDiagnosticCall(
     return std::format(
         "lyra::runtime::LyraDiagnostic({}, {}, {}, "
         "std::span<const lyra::value::PrintItem>{{}})",
-        ctx.ServicesRef(), sev_literal, origin_init);
+        "self->Services()", sev_literal, origin_init);
   }
 
   std::vector<std::string> item_inits;
@@ -261,7 +260,7 @@ auto RenderRuntimeDiagnosticCall(
   std::string out = std::format(
       "lyra::runtime::LyraDiagnostic({}, {}, {}, "
       "std::array<lyra::value::PrintItem, {}>{{",
-      ctx.ServicesRef(), sev_literal, origin_init, call.items.size());
+      "self->Services()", sev_literal, origin_init, call.items.size());
   for (std::size_t i = 0; i < item_inits.size(); ++i) {
     if (i != 0) {
       out += ", ";
@@ -287,7 +286,7 @@ auto RenderRuntimeCallExpr(
             return RenderRuntimeDiagnosticCall(ctx, dc);
           },
           [&](const mir::RuntimeFinishCall& fc) -> diag::Result<std::string> {
-            return RenderRuntimeFinishCall(ctx, fc);
+            return RenderRuntimeFinishCall(fc);
           },
           [&](const mir::RuntimeSubmitObservedCall& sc)
               -> diag::Result<std::string> {
@@ -296,8 +295,8 @@ auto RenderRuntimeCallExpr(
               return std::unexpected(std::move(closure_or.error()));
             }
             return std::format(
-                "{}SubmitObserved({}, {})", ctx.MemberPrefix(),
-                sc.site_id.value, *closure_or);
+                "{}SubmitObserved({}, {})", "self->", sc.site_id.value,
+                *closure_or);
           },
           [&](const mir::RuntimeSubmitNbaCall& nc)
               -> diag::Result<std::string> {
@@ -306,7 +305,7 @@ auto RenderRuntimeCallExpr(
               return std::unexpected(std::move(closure_or.error()));
             }
             return std::format(
-                "{}.SubmitNba({})", ctx.ServicesRef(), *closure_or);
+                "{}.SubmitNba({})", "self->Services()", *closure_or);
           },
           [&](const mir::RuntimeSubmitPostponedCall& pc)
               -> diag::Result<std::string> {
@@ -314,13 +313,11 @@ auto RenderRuntimeCallExpr(
             // matching $strobe-family runtime entry. The lambda captures
             // procedural locals and the receiver by value -- NBAs do not touch
             // the locals and the snapshot is frame-death-safe for `initial`
-            // bodies; structural signals resolve through the receiver at fire
-            // time and so see NBA-committed values. A method body captures
-            // `this` explicitly (`[=]`-capture of `this` is deprecated); a
-            // fork-branch body's `self` pointer is captured by the bare `[=]`.
-            // LRM 21.3.2 cancellation on $fclose is the file-sink entry's
-            // responsibility.
-            const std::string_view capture = ctx.DeferredByValueCapture();
+            // The closure captures every referenced local by value (`[=]`)
+            // including `self`, so it can reach scope members and Services()
+            // at fire time. LRM 21.3.2 cancellation on $fclose is the
+            // file-sink entry's responsibility.
+            const std::string_view capture{"[=]"};
             auto print_or = RenderRuntimePrintCall(ctx, pc.print);
             if (!print_or) {
               return std::unexpected(std::move(print_or.error()));
@@ -328,7 +325,7 @@ auto RenderRuntimeCallExpr(
             if (!pc.print.descriptor.has_value()) {
               return std::format(
                   "lyra::runtime::LyraSubmitStrobe({}, {}() {{ {}; }})",
-                  ctx.ServicesRef(), capture, *print_or);
+                  "self->Services()", capture, *print_or);
             }
             auto desc_or = RenderExpr(ctx, ctx.Expr(*pc.print.descriptor));
             if (!desc_or) {
@@ -336,7 +333,7 @@ auto RenderRuntimeCallExpr(
             }
             return std::format(
                 "lyra::runtime::LyraSubmitFStrobe({}, {}, {}() {{ {}; }})",
-                ctx.ServicesRef(), *desc_or, capture, *print_or);
+                "self->Services()", *desc_or, capture, *print_or);
           },
           [&](const mir::RuntimeFileOpenCall& fo) -> diag::Result<std::string> {
             auto name_or = RenderExpr(ctx, ctx.Expr(fo.name));
@@ -345,26 +342,26 @@ auto RenderRuntimeCallExpr(
               auto mode_or = RenderExpr(ctx, ctx.Expr(*fo.mode));
               if (!mode_or) return std::unexpected(std::move(mode_or.error()));
               return std::format(
-                  "lyra::runtime::LyraFOpen({}, {}, {})", ctx.ServicesRef(),
+                  "lyra::runtime::LyraFOpen({}, {}, {})", "self->Services()",
                   *name_or, *mode_or);
             }
             return std::format(
                 "lyra::runtime::LyraFOpen({}, {}, std::nullopt)",
-                ctx.ServicesRef(), *name_or);
+                "self->Services()", *name_or);
           },
           [&](const mir::RuntimeFileCloseCall& fc)
               -> diag::Result<std::string> {
             auto desc_or = RenderExpr(ctx, ctx.Expr(fc.descriptor));
             if (!desc_or) return std::unexpected(std::move(desc_or.error()));
             return std::format(
-                "lyra::runtime::LyraFClose({}, {})", ctx.ServicesRef(),
+                "lyra::runtime::LyraFClose({}, {})", "self->Services()",
                 *desc_or);
           },
           [&](const mir::RuntimeFileGetcCall& fg) -> diag::Result<std::string> {
             auto fd_or = RenderExpr(ctx, ctx.Expr(fg.fd));
             if (!fd_or) return std::unexpected(std::move(fd_or.error()));
             return std::format(
-                "lyra::runtime::LyraFGetc({}, {})", ctx.ServicesRef(), *fd_or);
+                "lyra::runtime::LyraFGetc({}, {})", "self->Services()", *fd_or);
           },
           [&](const mir::RuntimeFileUngetcCall& fu)
               -> diag::Result<std::string> {
@@ -373,7 +370,7 @@ auto RenderRuntimeCallExpr(
             auto fd_or = RenderExpr(ctx, ctx.Expr(fu.fd));
             if (!fd_or) return std::unexpected(std::move(fd_or.error()));
             return std::format(
-                "lyra::runtime::LyraFUngetc({}, {}, {})", ctx.ServicesRef(),
+                "lyra::runtime::LyraFUngetc({}, {}, {})", "self->Services()",
                 *c_or, *fd_or);
           },
           [&](const mir::RuntimeFileGetsCall& fg) -> diag::Result<std::string> {
@@ -385,7 +382,7 @@ auto RenderRuntimeCallExpr(
             auto fd_or = RenderExpr(ctx, ctx.Expr(fg.fd));
             if (!fd_or) return std::unexpected(std::move(fd_or.error()));
             return std::format(
-                "lyra::runtime::LyraFGets({}, {}, {})", ctx.ServicesRef(),
+                "lyra::runtime::LyraFGets({}, {}, {})", "self->Services()",
                 *dest_or, *fd_or);
           },
           [&](const mir::RuntimeFileReadCall& fr) -> diag::Result<std::string> {
@@ -401,7 +398,7 @@ auto RenderRuntimeCallExpr(
                       }
                       return std::format(
                           "lyra::runtime::LyraFRead({}, {}, {})",
-                          ctx.ServicesRef(), *dest_or, *fd_or);
+                          "self->Services()", *dest_or, *fd_or);
                     },
                     [&](const mir::RuntimeFileReadCall::UnpackedTarget& ut)
                         -> diag::Result<std::string> {
@@ -435,7 +432,7 @@ auto RenderRuntimeCallExpr(
                       return std::format(
                           "lyra::runtime::LyraFRead({}, {}, {}, "
                           "{}, {}, {}LL, {}LL)",
-                          ctx.ServicesRef(), *dest_or, *fd_or, *start_or,
+                          "self->Services()", *dest_or, *fd_or, *start_or,
                           *count_or, ut.declared_left, ut.declared_right);
                     },
                 },
@@ -449,7 +446,7 @@ auto RenderRuntimeCallExpr(
             auto op_or = RenderExpr(ctx, ctx.Expr(fs.operation));
             if (!op_or) return std::unexpected(std::move(op_or.error()));
             return std::format(
-                "lyra::runtime::LyraFSeek({}, {}, {}, {})", ctx.ServicesRef(),
+                "lyra::runtime::LyraFSeek({}, {}, {}, {})", "self->Services()",
                 *fd_or, *off_or, *op_or);
           },
           [&](const mir::RuntimeFileRewindCall& fr)
@@ -457,20 +454,20 @@ auto RenderRuntimeCallExpr(
             auto fd_or = RenderExpr(ctx, ctx.Expr(fr.fd));
             if (!fd_or) return std::unexpected(std::move(fd_or.error()));
             return std::format(
-                "lyra::runtime::LyraFRewind({}, {})", ctx.ServicesRef(),
+                "lyra::runtime::LyraFRewind({}, {})", "self->Services()",
                 *fd_or);
           },
           [&](const mir::RuntimeFileTellCall& ft) -> diag::Result<std::string> {
             auto fd_or = RenderExpr(ctx, ctx.Expr(ft.fd));
             if (!fd_or) return std::unexpected(std::move(fd_or.error()));
             return std::format(
-                "lyra::runtime::LyraFTell({}, {})", ctx.ServicesRef(), *fd_or);
+                "lyra::runtime::LyraFTell({}, {})", "self->Services()", *fd_or);
           },
           [&](const mir::RuntimeFileEofCall& fe) -> diag::Result<std::string> {
             auto fd_or = RenderExpr(ctx, ctx.Expr(fe.fd));
             if (!fd_or) return std::unexpected(std::move(fd_or.error()));
             return std::format(
-                "lyra::runtime::LyraFEof({}, {})", ctx.ServicesRef(), *fd_or);
+                "lyra::runtime::LyraFEof({}, {})", "self->Services()", *fd_or);
           },
           [&](const mir::RuntimeFileErrorCall& fe)
               -> diag::Result<std::string> {
@@ -479,7 +476,7 @@ auto RenderRuntimeCallExpr(
             auto dest_or = RenderExpr(ctx, ctx.Expr(fe.str_dest));
             if (!dest_or) return std::unexpected(std::move(dest_or.error()));
             return std::format(
-                "lyra::runtime::LyraFError({}, {}, {})", ctx.ServicesRef(),
+                "lyra::runtime::LyraFError({}, {}, {})", "self->Services()",
                 *fd_or, *dest_or);
           },
           [&](const mir::RuntimeFileFlushCall& ff)
@@ -487,12 +484,13 @@ auto RenderRuntimeCallExpr(
             if (!ff.descriptor.has_value()) {
               return std::format(
                   "lyra::runtime::LyraFFlush({}, std::nullopt)",
-                  ctx.ServicesRef());
+                  "self->Services()");
             }
             auto fd_or = RenderExpr(ctx, ctx.Expr(*ff.descriptor));
             if (!fd_or) return std::unexpected(std::move(fd_or.error()));
             return std::format(
-                "lyra::runtime::LyraFFlush({}, {})", ctx.ServicesRef(), *fd_or);
+                "lyra::runtime::LyraFFlush({}, {})", "self->Services()",
+                *fd_or);
           },
           [&](const mir::RuntimeScanCall& ss) -> diag::Result<std::string> {
             auto source_or = RenderExpr(ctx, ctx.Expr(ss.source));
@@ -554,7 +552,7 @@ auto RenderRuntimeCallExpr(
               case support::ScanSourceKind::kFile:
                 return std::format(
                     "lyra::runtime::LyraFScanf({}, {}, {}, {{{}}})",
-                    ctx.ServicesRef(), *source_or, *format_or, slot_pieces);
+                    "self->Services()", *source_or, *format_or, slot_pieces);
             }
             throw InternalError(
                 "RuntimeScanCall: unknown ScanSourceKind in render");
@@ -564,7 +562,7 @@ auto RenderRuntimeCallExpr(
               return std::format(
                   "lyra::runtime::LyraSFormat({}, "
                   "std::span<const lyra::value::PrintItem>{{}})",
-                  ctx.ServicesRef());
+                  "self->Services()");
             }
             std::vector<std::string> item_pieces;
             item_pieces.reserve(sf.items.size());
@@ -585,7 +583,7 @@ auto RenderRuntimeCallExpr(
             return std::format(
                 "lyra::runtime::LyraSFormat({}, "
                 "std::array<lyra::value::PrintItem, {}>{{{{{}}}}})",
-                ctx.ServicesRef(), sf.items.size(), body);
+                "self->Services()", sf.items.size(), body);
           },
           [&](const mir::RuntimeTimeCall& tc) -> diag::Result<std::string> {
             // The scaling target is the enclosing scope's time unit, read
@@ -597,22 +595,22 @@ auto RenderRuntimeCallExpr(
               case support::TimeKind::kTime:
                 return std::format(
                     "lyra::runtime::SimTimeInUnit({}, kTimeUnitPower)",
-                    ctx.ServicesRef());
+                    "self->Services()");
               case support::TimeKind::kStime:
                 return std::format(
                     "lyra::runtime::STimeInUnit({}, kTimeUnitPower)",
-                    ctx.ServicesRef());
+                    "self->Services()");
               case support::TimeKind::kRealtime:
                 return std::format(
                     "lyra::runtime::RealTimeInUnit({}, kTimeUnitPower)",
-                    ctx.ServicesRef());
+                    "self->Services()");
             }
             throw InternalError("RenderRuntimeCallExpr: unknown TimeKind");
           },
           [&](const mir::RuntimeSetTimeFormatCall& tf)
               -> diag::Result<std::string> {
             if (!tf.args.has_value()) {
-              return ctx.ServicesRef() + ".ResetTimeFormat()";
+              return std::string{"self->Services().ResetTimeFormat()"};
             }
             auto units = RenderExpr(ctx, ctx.Expr(tf.args->units));
             if (!units) return std::unexpected(std::move(units.error()));
@@ -625,7 +623,7 @@ auto RenderRuntimeCallExpr(
             auto width = RenderExpr(ctx, ctx.Expr(tf.args->min_width));
             if (!width) return std::unexpected(std::move(width.error()));
             return std::format(
-                "{}.SetTimeFormat({}, {}, {}, {})", ctx.ServicesRef(), *units,
+                "{}.SetTimeFormat({}, {}, {}, {})", "self->Services()", *units,
                 *precision, *suffix, *width);
           },
           [&](const mir::RuntimePrintTimescaleCall& pt)
@@ -635,7 +633,7 @@ auto RenderRuntimeCallExpr(
             return std::format(
                 "lyra::runtime::LyraPrintTimescale({}, {}, "
                 "kTimeUnitPower, kTimePrecisionPower)",
-                ctx.ServicesRef(), RenderCStringLiteral(pt.scope_name));
+                "self->Services()", RenderCStringLiteral(pt.scope_name));
           },
       },
       expr.call);

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -128,8 +128,6 @@ auto RenderForkStmtNode(
   // surrounding scope, or a nested fork in a branch lambda body, each has
   // its own `fork_branches` in its own C++ scope.
   const std::string vec = "fork_branches";
-  const std::string& class_name = ctx.StructuralScope().name;
-  const std::string receiver_object{ctx.ReceiverObject()};
   const RenderContext fork_ctx =
       ctx.WithProceduralScope(ctx.ProceduralScope().GetChildScope(s.scope));
   std::string out = Indent(indent) + "{\n";
@@ -148,9 +146,10 @@ auto RenderForkStmtNode(
       throw InternalError(
           "RenderForkStmtNode: fork branch closure has no body");
     }
-    std::string params = class_name + "* self";
-    std::string args{receiver_object};
-    for (const auto& capture : closure->captures) {
+    std::string params;
+    std::string args;
+    for (std::size_t ci = 0; ci < closure->captures.size(); ++ci) {
+      const auto& capture = closure->captures[ci];
       mir::ProceduralVarId binding{};
       std::string ref_marker;
       std::string arg;
@@ -172,16 +171,19 @@ auto RenderForkStmtNode(
       auto type_or =
           RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), bind.type);
       if (!type_or) return std::unexpected(std::move(type_or.error()));
-      params += ", " + *type_or + ref_marker + bind.name;
-      args += ", " + arg;
+      if (ci != 0) {
+        params += ", ";
+        args += ", ";
+      }
+      params += *type_or + ref_marker + bind.name;
+      args += arg;
     }
     // The branch closure's coroutine-ness comes from MIR (HIR-to-MIR sets
     // `is_coroutine = true` on every fork-branch ClosureExpr); the render
     // does not hardcode the assumption.
     const RenderContext branch_ctx =
         fork_ctx.WithProceduralScope(*closure->body)
-            .WithCoroutine(closure->is_coroutine)
-            .WithReceiver("self");
+            .WithCoroutine(closure->is_coroutine);
     auto body_or = RenderProceduralScopeStatements(branch_ctx, indent + 2);
     if (!body_or) return std::unexpected(std::move(body_or.error()));
     out += Indent(indent + 1) + vec + ".push_back([](" + params +
@@ -191,7 +193,7 @@ auto RenderForkStmtNode(
     out += Indent(indent + 1) + "}(" + args + "));\n";
   }
   out += Indent(indent + 1) + "co_await lyra::runtime::Fork(" +
-         ctx.ServicesRef() + ", std::move(" + vec + "), " +
+         "self->Services()" + ", std::move(" + vec + "), " +
          std::string(RenderForkJoinModeLiteral(s.mode)) + ");\n";
   out += Indent(indent) + "}\n";
   return out;
@@ -235,7 +237,7 @@ auto RenderConstructOwnedObjectStmt(
     trailing_args += ", " + *arg_or;
   }
   const std::string make = "std::make_unique<" + target_scope.name +
-                           ">(this, \"" + target_scope.name + "\"" +
+                           ">(self, \"" + target_scope.name + "\"" +
                            trailing_args + ")";
   const auto child = mir::GetChildScope(ctx.Unit(), var.type);
   if (!child.has_value() ||
@@ -243,18 +245,17 @@ auto RenderConstructOwnedObjectStmt(
     throw InternalError(
         "ConstructOwnedObjectStmt target is not an owned object var");
   }
-  const std::string lhs = ctx.MemberPrefix() + var.name;
+  const std::string lhs = "self->" + var.name;
   const std::string reg_name =
       var.source_name.empty() ? var.name : var.source_name;
   if (std::holds_alternative<mir::VectorType>(
           ctx.Unit().GetType(var.type).data)) {
     return Indent(indent) + lhs + ".push_back(" + make + ");\n" +
-           Indent(indent) + ctx.MemberPrefix() + "RegisterChild(\"" + reg_name +
+           Indent(indent) + "self->RegisterChild(\"" + reg_name +
            "\", std::array{" + lhs + ".size() - 1}, *" + lhs + ".back());\n";
   }
   return Indent(indent) + lhs + " = " + make + ";\n" + Indent(indent) +
-         ctx.MemberPrefix() + "RegisterChild(\"" + reg_name + "\", {}, *" +
-         lhs + ");\n";
+         "self->RegisterChild(\"" + reg_name + "\", {}, *" + lhs + ");\n";
 }
 
 // Materializes an external-unit member by recursing on its type, mirroring the
@@ -282,7 +283,7 @@ auto RenderExternalUnitFill(
     return out;
   }
   std::string out = Indent(indent) + lvalue + " = std::make_unique<" +
-                    unit_name + ">(this, \"" + label + "\");\n";
+                    unit_name + ">(self, \"" + label + "\");\n";
   std::string idx = "{}";
   if (depth > 0) {
     idx = "std::array{";
@@ -292,8 +293,8 @@ auto RenderExternalUnitFill(
     }
     idx += "}";
   }
-  out += Indent(indent) + ctx.MemberPrefix() + "RegisterChild(\"" + label +
-         "\", " + idx + ", *" + lvalue + ");\n";
+  out += Indent(indent) + "self->RegisterChild(\"" + label + "\", " + idx +
+         ", *" + lvalue + ");\n";
   return out;
 }
 
@@ -302,8 +303,8 @@ auto RenderConstructExternalUnitStmt(
     std::size_t indent) -> diag::Result<std::string> {
   const auto& var = ctx.StructuralScope().GetStructuralVar(s.target);
   return RenderExternalUnitFill(
-      ctx, ctx.MemberPrefix() + var.name, var.type, s.unit_name, var.name,
-      s.dims, 0, indent);
+      ctx, "self->" + var.name, var.type, s.unit_name, var.name, s.dims, 0,
+      indent);
 }
 
 auto RenderForStmtNode(
@@ -434,7 +435,7 @@ auto RenderStmt(
           },
           [&](const mir::DelayStmt& s) -> diag::Result<std::string> {
             return Indent(indent) + "co_await lyra::runtime::Delay(" +
-                   ctx.ServicesRef() + ", " + std::to_string(s.duration) +
+                   "self->Services()" + ", " + std::to_string(s.duration) +
                    ", kTimePrecisionPower);\n";
           },
           [&](const mir::ProceduralVarDeclStmt& s)

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -123,7 +123,11 @@ auto RenderForkJoinModeLiteral(mir::JoinMode mode) -> std::string_view {
 auto RenderForkStmtNode(
     const RenderContext& ctx, const mir::ForkStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
-  const std::string vec = ctx.AllocateTemp("fork_branches");
+  // The fork-branches vector lives in this fork's own `{...}` block scope
+  // (opened just below), so a fixed name suffices -- a sibling fork in the
+  // surrounding scope, or a nested fork in a branch lambda body, each has
+  // its own `fork_branches` in its own C++ scope.
+  const std::string vec = "fork_branches";
   const std::string& class_name = ctx.StructuralScope().name;
   const std::string receiver_object{ctx.ReceiverObject()};
   const RenderContext fork_ctx =

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -175,9 +175,12 @@ auto RenderForkStmtNode(
       params += ", " + *type_or + ref_marker + bind.name;
       args += ", " + arg;
     }
+    // The branch closure's coroutine-ness comes from MIR (HIR-to-MIR sets
+    // `is_coroutine = true` on every fork-branch ClosureExpr); the render
+    // does not hardcode the assumption.
     const RenderContext branch_ctx =
         fork_ctx.WithProceduralScope(*closure->body)
-            .WithCoroutine(true)
+            .WithCoroutine(closure->is_coroutine)
             .WithReceiver("self");
     auto body_or = RenderProceduralScopeStatements(branch_ctx, indent + 2);
     if (!body_or) return std::unexpected(std::move(body_or.error()));

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -237,8 +237,8 @@ auto RenderConstructOwnedObjectStmt(
     trailing_args += ", " + *arg_or;
   }
   const std::string make = "std::make_unique<" + target_scope.name +
-                           ">(self, \"" + target_scope.name + "\"" +
-                           trailing_args + ")";
+                           ">(self, \"" + target_scope.name +
+                           "\", self->Services()" + trailing_args + ")";
   const auto child = mir::GetChildScope(ctx.Unit(), var.type);
   if (!child.has_value() ||
       !std::holds_alternative<mir::GenerateScopeChild>(*child)) {
@@ -283,7 +283,8 @@ auto RenderExternalUnitFill(
     return out;
   }
   std::string out = Indent(indent) + lvalue + " = std::make_unique<" +
-                    unit_name + ">(self, \"" + label + "\");\n";
+                    unit_name + ">(self, \"" + label +
+                    "\", self->Services());\n";
   std::string idx = "{}";
   if (depth > 0) {
     idx = "std::array{";

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -105,6 +105,9 @@ auto RenderTypeAsCpp(
           [](const mir::ScopeType&) -> diag::Result<std::string> {
             return std::string{"lyra::runtime::Scope"};
           },
+          [&](const mir::SelfType&) -> diag::Result<std::string> {
+            return std::string{owner_scope.name};
+          },
           [&](const mir::PointerType& p) -> diag::Result<std::string> {
             auto inner_or = RenderTypeAsCpp(unit, owner_scope, p.pointee);
             if (!inner_or) return std::unexpected(std::move(inner_or.error()));

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -31,7 +31,9 @@ auto LowerContinuousAssign(
           .name = "self", .type = scope.Module().Unit().builtins.self_pointer});
   mir::ProceduralScope body_scope;
   const WalkFrame body_frame =
-      frame.WithProceduralScope(&body_scope).WithSelfBinding(self_id).Deeper();
+      frame.WithProceduralScope(&body_scope)
+          .WithSelfBinding(self_id, frame.procedural_depth)
+          .Deeper();
 
   const hir::StructuralScope& hir_scope = scope.HirScope();
 

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -5,7 +5,6 @@
 #include <utility>
 
 #include "lyra/hir/continuous_assign.hpp"
-#include "lyra/hir/expr.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
@@ -27,8 +26,12 @@ auto LowerContinuousAssign(
     const StructuralScopeLowerer& scope, WalkFrame frame, std::string name,
     const hir::ContinuousAssign& src) -> diag::Result<mir::Process> {
   mir::ProceduralScope process_scope;
+  const mir::ProceduralVarId self_id = process_scope.AddProceduralVar(
+      mir::ProceduralVarDecl{
+          .name = "self", .type = scope.Module().Unit().builtins.self_pointer});
   mir::ProceduralScope body_scope;
-  const WalkFrame body_frame = frame.WithProceduralScope(&body_scope).Deeper();
+  const WalkFrame body_frame =
+      frame.WithProceduralScope(&body_scope).WithSelfBinding(self_id).Deeper();
 
   const hir::StructuralScope& hir_scope = scope.HirScope();
 

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -24,7 +24,7 @@ namespace lyra::lowering::hir_to_mir {
 // natural fall-through of the eternal loop) before the first wait, matching
 // LRM 9.2.2.2's "evaluate at time 0" requirement for inferred sensitivity.
 auto LowerContinuousAssign(
-    const StructuralScopeLowerer& scope, WalkFrame frame,
+    const StructuralScopeLowerer& scope, WalkFrame frame, std::string name,
     const hir::ContinuousAssign& src) -> diag::Result<mir::Process> {
   mir::ProceduralScope process_scope;
   mir::ProceduralScope body_scope;
@@ -63,6 +63,7 @@ auto LowerContinuousAssign(
               .scope = body_scope_id}});
   return mir::Process{
       .kind = mir::ProcessKind::kInitial,
+      .name = std::move(name),
       .root_procedural_scope = std::move(process_scope),
       .static_locals = {}};
 }

--- a/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
@@ -182,7 +182,8 @@ auto BuildUniqueCheckClosure(
       mir::Expr{
           .data =
               mir::ProceduralVarRef{
-                  .hops = wrapper_frame.procedural_depth - ProceduralDepth{},
+                  .hops = wrapper_frame.procedural_depth -
+                          wrapper_frame.self_decl_depth,
                   .var = *wrapper_frame.self_binding},
           .type = self_ptr_type});
   closure.captures.emplace_back(
@@ -316,8 +317,10 @@ auto BuildDeferredCheckCascade(
 
   // SnapshotPredicate / SynthesizeDefaultValueExpr append to wrapper, so
   // route through a wrapper-local frame; the cascade levels each derive their
-  // own local frames below.
-  const WalkFrame wrapper_frame = frame.WithProceduralScope(&wrapper);
+  // own local frames below. The wrapper itself sits one procedural scope
+  // deeper than the caller, so any read of an enclosing binding (e.g. the
+  // process body's `self`) climbs through that extra level.
+  const WalkFrame wrapper_frame = frame.WithProceduralScope(&wrapper).Deeper();
 
   std::vector<mir::ProceduralVarId> snapshot_vars;
   snapshot_vars.reserve(branches.size());
@@ -455,11 +458,17 @@ auto LowerUniqueIfStmt(
             .predicate = predicates[i], .body = std::move(*body_or)});
   }
 
+  // The trailing else sits at the same MIR depth as the last branch body
+  // (their if-then-else share an enclosing level scope), so the lowering
+  // walks one fewer level than `bodies.size()` extras.
   std::optional<mir::ProceduralScope> tail_scope;
   if (cascade.tail_else.has_value()) {
-    auto tail_or = LowerStmtIntoChildScope(
-        process, deeper_by(wrapper_frame, cascade.bodies.size()),
-        *cascade.tail_else);
+    const WalkFrame tail_enter_frame =
+        cascade.bodies.empty()
+            ? wrapper_frame
+            : deeper_by(wrapper_frame, cascade.bodies.size() - 1);
+    auto tail_or =
+        LowerStmtIntoChildScope(process, tail_enter_frame, *cascade.tail_else);
     if (!tail_or) return std::unexpected(std::move(tail_or.error()));
     tail_scope = std::move(*tail_or);
   }

--- a/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
-#include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
@@ -167,6 +166,7 @@ auto BuildDiagnosticThenScope(
 }
 
 auto BuildUniqueCheckClosure(
+    const ModuleLowerer& module, const WalkFrame& wrapper_frame,
     mir::ProceduralScope& wrapper, mir::TypeId int32_type,
     mir::TypeId void_type, hir::UniquePriorityCheck check,
     const std::vector<mir::ProceduralVarId>& snapshot_vars)
@@ -174,6 +174,19 @@ auto BuildUniqueCheckClosure(
   mir::ClosureExpr closure;
   closure.body = std::make_unique<mir::ProceduralScope>();
   auto& body = *closure.body;
+
+  const mir::TypeId self_ptr_type = module.Unit().builtins.self_pointer;
+  const mir::ProceduralVarId self_binding = body.AddProceduralVar(
+      mir::ProceduralVarDecl{.name = "self", .type = self_ptr_type});
+  const mir::ExprId outer_self_read = wrapper.AddExpr(
+      mir::Expr{
+          .data =
+              mir::ProceduralVarRef{
+                  .hops = wrapper_frame.procedural_depth - ProceduralDepth{},
+                  .var = *wrapper_frame.self_binding},
+          .type = self_ptr_type});
+  closure.captures.emplace_back(
+      mir::ByValueCapture{.value = outer_self_read, .binding = self_binding});
 
   std::vector<mir::ExprId> inner_reads;
   inner_reads.reserve(snapshot_vars.size());
@@ -317,7 +330,8 @@ auto BuildDeferredCheckCascade(
   }
 
   mir::ClosureExpr closure = BuildUniqueCheckClosure(
-      wrapper, int32_type, void_type, check, snapshot_vars);
+      module, wrapper_frame, wrapper, int32_type, void_type, check,
+      snapshot_vars);
   const mir::ExprId closure_expr_id =
       wrapper.AddExpr(mir::Expr{.data = std::move(closure), .type = void_type});
 

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -41,6 +41,7 @@ auto IsExprRootedAtStructuralVar(
   return std::visit(
       Overloaded{
           [](const mir::StructuralVarRef&) { return true; },
+          [](const mir::MemberAccessExpr&) { return true; },
           [](const mir::ProceduralVarRef&) { return false; },
           [&](const mir::ElementSelectExpr& s) {
             return IsExprRootedAtStructuralVar(proc_scope, s.base_value);
@@ -95,6 +96,7 @@ auto SnapshotNonLhsSubexpr(
 // the closure body sees the values that were live at submit time.
 auto CloneLhsExprForNbaBody(
     const mir::ProceduralScope& outer_scope, mir::ProceduralScope& body,
+    mir::TypeId self_ptr_type, mir::ProceduralVarId body_self_id,
     std::vector<mir::Capture>& captures, std::uint32_t& snapshot_counter,
     mir::ExprId outer_id) -> mir::ExprId {
   const auto& outer_expr = outer_scope.GetExpr(outer_id);
@@ -102,7 +104,8 @@ auto CloneLhsExprForNbaBody(
       Overloaded{
           [&](const mir::ElementSelectExpr& s) -> mir::ExprId {
             const mir::ExprId base = CloneLhsExprForNbaBody(
-                outer_scope, body, captures, snapshot_counter, s.base_value);
+                outer_scope, body, self_ptr_type, body_self_id, captures,
+                snapshot_counter, s.base_value);
             const mir::ExprId index = SnapshotNonLhsSubexpr(
                 outer_scope, body, captures, snapshot_counter, s.index, "nba");
             return body.AddExpr(
@@ -114,7 +117,8 @@ auto CloneLhsExprForNbaBody(
           },
           [&](const mir::RangeSelectExpr& s) -> mir::ExprId {
             const mir::ExprId base = CloneLhsExprForNbaBody(
-                outer_scope, body, captures, snapshot_counter, s.base_value);
+                outer_scope, body, self_ptr_type, body_self_id, captures,
+                snapshot_counter, s.base_value);
             const mir::ExprId offset = SnapshotNonLhsSubexpr(
                 outer_scope, body, captures, snapshot_counter, s.offset_expr,
                 "nba");
@@ -132,7 +136,8 @@ auto CloneLhsExprForNbaBody(
             body_operands.reserve(c.operands.size());
             for (const mir::ExprId op_id : c.operands) {
               body_operands.push_back(CloneLhsExprForNbaBody(
-                  outer_scope, body, captures, snapshot_counter, op_id));
+                  outer_scope, body, self_ptr_type, body_self_id, captures,
+                  snapshot_counter, op_id));
             }
             return body.AddExpr(
                 mir::Expr{
@@ -142,6 +147,21 @@ auto CloneLhsExprForNbaBody(
           },
           [&](const mir::StructuralVarRef&) -> mir::ExprId {
             return body.AddExpr(outer_expr);
+          },
+          [&](const mir::MemberAccessExpr& m) -> mir::ExprId {
+            const mir::ExprId body_receiver = body.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::ProceduralVarRef{
+                            .hops = mir::ProceduralHops{.value = 0},
+                            .var = body_self_id},
+                    .type = self_ptr_type});
+            return body.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::MemberAccessExpr{
+                            .receiver = body_receiver, .member = m.member},
+                    .type = outer_expr.type});
           },
           [&](const mir::ProceduralVarRef&) -> mir::ExprId {
             return body.AddExpr(outer_expr);
@@ -223,7 +243,7 @@ auto BuildNbaSubmitClosureExpr(
       mir::Expr{
           .data =
               mir::ProceduralVarRef{
-                  .hops = frame.procedural_depth - ProceduralDepth{},
+                  .hops = frame.procedural_depth - frame.self_decl_depth,
                   .var = *frame.self_binding},
           .type = self_ptr_type});
   captures.emplace_back(
@@ -242,7 +262,8 @@ auto BuildNbaSubmitClosureExpr(
 
   std::uint32_t snapshot_counter = 0;
   const mir::ExprId body_lhs_id = CloneLhsExprForNbaBody(
-      outer_scope, body, captures, snapshot_counter, lhs_in_outer);
+      outer_scope, body, self_ptr_type, self_id, captures, snapshot_counter,
+      lhs_in_outer);
 
   const mir::ExprId assign_id = body.AddExpr(
       mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -212,9 +212,22 @@ auto LowerHirAssignExprProc(
 auto BuildNbaSubmitClosureExpr(
     const ModuleLowerer& module, WalkFrame frame, mir::ExprId lhs_in_outer,
     mir::ExprId rhs_id_in_outer, mir::TypeId rhs_type) -> mir::Expr {
-  const auto& outer_scope = *frame.current_procedural_scope;
+  auto& outer_scope = *frame.current_procedural_scope;
   mir::ProceduralScope body;
   std::vector<mir::Capture> captures;
+
+  const mir::TypeId self_ptr_type = module.Unit().builtins.self_pointer;
+  const mir::ProceduralVarId self_id = body.AddProceduralVar(
+      mir::ProceduralVarDecl{.name = "self", .type = self_ptr_type});
+  const mir::ExprId outer_self_read = outer_scope.AddExpr(
+      mir::Expr{
+          .data =
+              mir::ProceduralVarRef{
+                  .hops = frame.procedural_depth - ProceduralDepth{},
+                  .var = *frame.self_binding},
+          .type = self_ptr_type});
+  captures.emplace_back(
+      mir::ByValueCapture{.value = outer_self_read, .binding = self_id});
 
   const mir::ProceduralVarId rhs_binding = body.AddProceduralVar(
       mir::ProceduralVarDecl{.name = "_lyra_nba_rhs", .type = rhs_type});

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -12,10 +12,8 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_body.hpp"
-#include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
-#include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/hir_to_mir/capture_sink.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/control.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/diagnostic.hpp"
@@ -32,7 +30,6 @@
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/procedural_hops.hpp"
-#include "lyra/mir/runtime_timescale.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -175,10 +172,20 @@ auto BuildArrayMethodClosure(
   const auto& iterator_decl =
       hir_process.procedural_vars.at(with_clause.iterator.value);
 
+  const mir::TypeId self_ptr_type = module.Unit().builtins.self_pointer;
   mir::ProceduralScope body_scope;
   const WalkFrame body_frame = frame.WithProceduralScope(&body_scope).Deeper();
   const ProceduralDepth body_depth = body_frame.procedural_depth;
 
+  const mir::ProceduralVarId self_binding = body_scope.AddProceduralVar(
+      mir::ProceduralVarDecl{.name = "self", .type = self_ptr_type});
+  const mir::ExprId outer_self_read = outer_scope.AddExpr(
+      mir::Expr{
+          .data =
+              mir::ProceduralVarRef{
+                  .hops = frame.procedural_depth - ProceduralDepth{},
+                  .var = *frame.self_binding},
+          .type = self_ptr_type});
   const mir::ProceduralVarId item_binding = body_scope.AddProceduralVar(
       mir::ProceduralVarDecl{.name = iterator_decl.name, .type = item_type});
   const mir::ProceduralVarId index_binding = body_scope.AddProceduralVar(
@@ -189,8 +196,9 @@ auto BuildArrayMethodClosure(
           .declaration_procedural_depth = body_depth, .var = item_binding});
 
   CaptureSink sink{body_depth, body_scope, outer_scope};
-  const WalkFrame closure_frame =
-      body_frame.WithClosure(&sink).WithIndexBinding(index_binding);
+  const WalkFrame closure_frame = body_frame.WithClosure(&sink)
+                                      .WithIndexBinding(index_binding)
+                                      .WithSelfBinding(self_binding);
 
   auto body_expr_or = process.LowerExpr(
       hir_process.exprs.at(with_clause.expr.value), closure_frame);
@@ -205,6 +213,8 @@ auto BuildArrayMethodClosure(
           .data = mir::ReturnStmt{.value = body_return_value}});
 
   std::vector<mir::Capture> captures;
+  captures.emplace_back(
+      mir::ByValueCapture{.value = outer_self_read, .binding = self_binding});
   for (const CaptureRequest& request : sink.TakeRequests()) {
     captures.emplace_back(
         mir::ByReferenceCapture{

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -183,7 +183,7 @@ auto BuildArrayMethodClosure(
       mir::Expr{
           .data =
               mir::ProceduralVarRef{
-                  .hops = frame.procedural_depth - ProceduralDepth{},
+                  .hops = frame.procedural_depth - frame.self_decl_depth,
                   .var = *frame.self_binding},
           .type = self_ptr_type});
   const mir::ProceduralVarId item_binding = body_scope.AddProceduralVar(
@@ -196,9 +196,10 @@ auto BuildArrayMethodClosure(
           .declaration_procedural_depth = body_depth, .var = item_binding});
 
   CaptureSink sink{body_depth, body_scope, outer_scope};
-  const WalkFrame closure_frame = body_frame.WithClosure(&sink)
-                                      .WithIndexBinding(index_binding)
-                                      .WithSelfBinding(self_binding);
+  const WalkFrame closure_frame =
+      body_frame.WithClosure(&sink)
+          .WithIndexBinding(index_binding)
+          .WithSelfBinding(self_binding, body_depth);
 
   auto body_expr_or = process.LowerExpr(
       hir_process.exprs.at(with_clause.expr.value), closure_frame);

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -2,7 +2,6 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
-#include "lyra/hir/expr.hpp"
 #include "lyra/hir/integral_constant.hpp"
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/value_ref.hpp"
@@ -95,10 +94,21 @@ auto LowerHirRealLiteral(const hir::RealLiteral& r, mir::TypeId type)
 }
 
 auto LowerStructuralVarRefExpr(
-    const StructuralScopeLowerer& scope, const hir::StructuralVarRef& m,
-    mir::TypeId type) -> mir::Expr {
+    const StructuralScopeLowerer& scope, const WalkFrame& frame,
+    const hir::StructuralVarRef& m, mir::TypeId type) -> mir::Expr {
+  const mir::StructuralVarRef member =
+      scope.TranslateStructuralVar(m.hops, m.var);
+  const mir::TypeId self_ptr_type = scope.Module().Unit().builtins.self_pointer;
+  const mir::ExprId receiver = frame.current_procedural_scope->AddExpr(
+      mir::Expr{
+          .data =
+              mir::ProceduralVarRef{
+                  .hops = frame.procedural_depth - frame.self_decl_depth,
+                  .var = *frame.self_binding},
+          .type = self_ptr_type});
   return mir::Expr{
-      .data = scope.TranslateStructuralVar(m.hops, m.var), .type = type};
+      .data = mir::MemberAccessExpr{.receiver = receiver, .member = member},
+      .type = type};
 }
 
 auto LowerProceduralVarRefExpr(
@@ -123,14 +133,27 @@ auto LowerCrossUnitVarRefExpr(
     const hir::CrossUnitVarRef& c, mir::TypeId type) -> mir::Expr {
   const auto& meta = scope.CrossUnitRefTarget(c.id);
   const mir::StructuralVarRef target = meta.target;
+  const mir::TypeId self_ptr_type = scope.Module().Unit().builtins.self_pointer;
+  const mir::ExprId self_ref = frame.current_procedural_scope->AddExpr(
+      mir::Expr{
+          .data =
+              mir::ProceduralVarRef{
+                  .hops = frame.procedural_depth - frame.self_decl_depth,
+                  .var = *frame.self_binding},
+          .type = self_ptr_type});
   const auto* ptr = std::get_if<mir::PointerType>(
       &scope.Module().Unit().GetType(meta.slot_type).data);
   if (ptr != nullptr && ptr->ownership == mir::PointerOwnership::kBorrowed) {
     const mir::ExprId pointer = frame.current_procedural_scope->AddExpr(
-        mir::Expr{.data = target, .type = meta.slot_type});
+        mir::Expr{
+            .data =
+                mir::MemberAccessExpr{.receiver = self_ref, .member = target},
+            .type = meta.slot_type});
     return mir::Expr{.data = mir::DerefExpr{.pointer = pointer}, .type = type};
   }
-  return mir::Expr{.data = target, .type = type};
+  return mir::Expr{
+      .data = mir::MemberAccessExpr{.receiver = self_ref, .member = target},
+      .type = type};
 }
 
 auto LowerLoopVarRefExprAsProcedural(
@@ -169,7 +192,7 @@ auto LowerHirPrimaryExprProc(
             return LowerHirRealLiteral(r, result_type);
           },
           [&](const hir::StructuralVarRef& m) -> mir::Expr {
-            return LowerStructuralVarRefExpr(scope, m, result_type);
+            return LowerStructuralVarRefExpr(scope, frame, m, result_type);
           },
           [&](const hir::ProceduralVarRef& l) -> mir::Expr {
             return LowerProceduralVarRefExpr(process, frame, l, result_type);
@@ -202,7 +225,7 @@ auto LowerHirPrimaryExprStructural(
             return LowerHirRealLiteral(r, result_type);
           },
           [&](const hir::StructuralVarRef& m) -> mir::Expr {
-            return LowerStructuralVarRefExpr(scope, m, result_type);
+            return LowerStructuralVarRefExpr(scope, frame, m, result_type);
           },
           [](const hir::ProceduralVarRef&) -> mir::Expr {
             throw InternalError(

--- a/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
@@ -228,12 +228,12 @@ auto LowerScanSystemSubroutineCall(
       mir::Expr{
           .data =
               mir::ProceduralVarRef{
-                  .hops = frame.procedural_depth - ProceduralDepth{},
+                  .hops = frame.procedural_depth - frame.self_decl_depth,
                   .var = *frame.self_binding},
           .type = self_ptr_type});
   CaptureSink sink{body_frame.procedural_depth, body, outer_scope};
-  const WalkFrame closure_frame =
-      body_frame.WithClosure(&sink).WithSelfBinding(self_binding);
+  const WalkFrame closure_frame = body_frame.WithClosure(&sink).WithSelfBinding(
+      self_binding, body_frame.procedural_depth);
 
   // Source / format are rvalues inside the body. The leaf lowering routes
   // procedural-var leaves through the sink, producing body-side bindings.

--- a/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
@@ -219,10 +219,21 @@ auto LowerScanSystemSubroutineCall(
   // it is captured by reference (sync IIFE -- aliasing is correct for both
   // reads and writes because the caller's storage is live throughout the
   // closure's evaluation).
+  const mir::TypeId self_ptr_type = module.Unit().builtins.self_pointer;
   mir::ProceduralScope body;
   const WalkFrame body_frame = frame.WithProceduralScope(&body).Deeper();
+  const mir::ProceduralVarId self_binding = body.AddProceduralVar(
+      mir::ProceduralVarDecl{.name = "self", .type = self_ptr_type});
+  const mir::ExprId outer_self_read = outer_scope.AddExpr(
+      mir::Expr{
+          .data =
+              mir::ProceduralVarRef{
+                  .hops = frame.procedural_depth - ProceduralDepth{},
+                  .var = *frame.self_binding},
+          .type = self_ptr_type});
   CaptureSink sink{body_frame.procedural_depth, body, outer_scope};
-  const WalkFrame closure_frame = body_frame.WithClosure(&sink);
+  const WalkFrame closure_frame =
+      body_frame.WithClosure(&sink).WithSelfBinding(self_binding);
 
   // Source / format are rvalues inside the body. The leaf lowering routes
   // procedural-var leaves through the sink, producing body-side bindings.
@@ -352,6 +363,8 @@ auto LowerScanSystemSubroutineCall(
   // closure's evaluation -- so every captured identity is a by-reference
   // capture.
   std::vector<mir::Capture> captures;
+  captures.emplace_back(
+      mir::ByValueCapture{.value = outer_self_read, .binding = self_binding});
   for (const CaptureRequest& request : sink.TakeRequests()) {
     captures.emplace_back(
         mir::ByReferenceCapture{

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -181,8 +181,13 @@ auto LowerStraightLineProcess(
   // local lands here (instance-owned, LRM 6.21 / 9.3.4) instead of in the
   // coroutine activation, the same shape a subroutine uses.
   mir::ProceduralScope process_scope;
+  const mir::ProceduralVarId self_id = process_scope.AddProceduralVar(
+      mir::ProceduralVarDecl{
+          .name = "self",
+          .type = process.Module().Unit().builtins.self_pointer});
   const WalkFrame body_frame = frame.WithProceduralScope(&process_scope)
-                                   .WithStaticFrameScope(&process_scope);
+                                   .WithStaticFrameScope(&process_scope)
+                                   .WithSelfBinding(self_id);
   auto lowered = LowerStraightLineBodyInto(process, body_frame);
   if (!lowered) return std::unexpected(std::move(lowered.error()));
   return mir::Process{
@@ -205,10 +210,15 @@ auto LowerForeverProcess(
   // that model successive activations (LRM 6.21). The loop body lowers one
   // depth in, so a body reference reaches the frame by one hop.
   mir::ProceduralScope process_scope;
+  const mir::ProceduralVarId self_id = process_scope.AddProceduralVar(
+      mir::ProceduralVarDecl{
+          .name = "self",
+          .type = process.Module().Unit().builtins.self_pointer});
   mir::ProceduralScope body_scope;
   {
     const WalkFrame body_frame = frame.WithStaticFrameScope(&process_scope)
                                      .WithProceduralScope(&body_scope)
+                                     .WithSelfBinding(self_id)
                                      .Deeper();
     auto lowered = LowerStraightLineBodyInto(process, body_frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
@@ -289,8 +299,12 @@ auto ProcessLowerer::Run(
     WalkFrame parent_frame, const hir::StructuralSubroutineDecl& src)
     -> diag::Result<mir::StructuralSubroutineDecl> {
   mir::ProceduralScope body_scope;
+  const mir::ProceduralVarId self_id = body_scope.AddProceduralVar(
+      mir::ProceduralVarDecl{
+          .name = "self", .type = module_->Unit().builtins.self_pointer});
   const WalkFrame body_frame = parent_frame.WithProceduralScope(&body_scope)
-                                   .WithStaticFrameScope(&body_scope);
+                                   .WithStaticFrameScope(&body_scope)
+                                   .WithSelfBinding(self_id);
 
   // Formals are procedural vars of the body with no VarDeclStmt: pre-register
   // them in the body scope at depth 0 so the body's references resolve. The

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -185,9 +185,10 @@ auto LowerStraightLineProcess(
       mir::ProceduralVarDecl{
           .name = "self",
           .type = process.Module().Unit().builtins.self_pointer});
-  const WalkFrame body_frame = frame.WithProceduralScope(&process_scope)
-                                   .WithStaticFrameScope(&process_scope)
-                                   .WithSelfBinding(self_id);
+  const WalkFrame body_frame =
+      frame.WithProceduralScope(&process_scope)
+          .WithStaticFrameScope(&process_scope)
+          .WithSelfBinding(self_id, frame.procedural_depth);
   auto lowered = LowerStraightLineBodyInto(process, body_frame);
   if (!lowered) return std::unexpected(std::move(lowered.error()));
   return mir::Process{
@@ -216,10 +217,11 @@ auto LowerForeverProcess(
           .type = process.Module().Unit().builtins.self_pointer});
   mir::ProceduralScope body_scope;
   {
-    const WalkFrame body_frame = frame.WithStaticFrameScope(&process_scope)
-                                     .WithProceduralScope(&body_scope)
-                                     .WithSelfBinding(self_id)
-                                     .Deeper();
+    const WalkFrame body_frame =
+        frame.WithStaticFrameScope(&process_scope)
+            .WithProceduralScope(&body_scope)
+            .WithSelfBinding(self_id, frame.procedural_depth)
+            .Deeper();
     auto lowered = LowerStraightLineBodyInto(process, body_frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     if (tail_stmt.has_value()) {
@@ -302,9 +304,10 @@ auto ProcessLowerer::Run(
   const mir::ProceduralVarId self_id = body_scope.AddProceduralVar(
       mir::ProceduralVarDecl{
           .name = "self", .type = module_->Unit().builtins.self_pointer});
-  const WalkFrame body_frame = parent_frame.WithProceduralScope(&body_scope)
-                                   .WithStaticFrameScope(&body_scope)
-                                   .WithSelfBinding(self_id);
+  const WalkFrame body_frame =
+      parent_frame.WithProceduralScope(&body_scope)
+          .WithStaticFrameScope(&body_scope)
+          .WithSelfBinding(self_id, parent_frame.procedural_depth);
 
   // Formals are procedural vars of the body with no VarDeclStmt: pre-register
   // them in the body scope at depth 0 so the body's references resolve. The

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -175,8 +175,8 @@ auto LowerStraightLineBodyInto(ProcessLowerer& process, WalkFrame frame)
 }
 
 auto LowerStraightLineProcess(
-    ProcessLowerer& process, WalkFrame frame, mir::ProcessKind kind)
-    -> diag::Result<mir::Process> {
+    ProcessLowerer& process, WalkFrame frame, std::string name,
+    mir::ProcessKind kind) -> diag::Result<mir::Process> {
   // The process root scope is also its static frame: a static-lifetime body
   // local lands here (instance-owned, LRM 6.21 / 9.3.4) instead of in the
   // coroutine activation, the same shape a subroutine uses.
@@ -187,6 +187,7 @@ auto LowerStraightLineProcess(
   if (!lowered) return std::unexpected(std::move(lowered.error()));
   return mir::Process{
       .kind = kind,
+      .name = std::move(name),
       .root_procedural_scope = std::move(process_scope),
       .static_locals = process.TakeStaticLocals()};
 }
@@ -197,7 +198,7 @@ auto LowerStraightLineProcess(
 // nullopt for `always` / `always_ff` where the body itself carries any
 // timing.
 auto LowerForeverProcess(
-    ProcessLowerer& process, WalkFrame frame,
+    ProcessLowerer& process, WalkFrame frame, std::string name,
     std::optional<mir::Stmt> tail_stmt) -> diag::Result<mir::Process> {
   // The static frame is the process root scope, which sits outside the
   // forever loop, so a static body local persists across the loop iterations
@@ -228,6 +229,7 @@ auto LowerForeverProcess(
               .scope = body_scope_id}});
   return mir::Process{
       .kind = mir::ProcessKind::kInitial,
+      .name = std::move(name),
       .root_procedural_scope = std::move(process_scope),
       .static_locals = process.TakeStaticLocals()};
 }
@@ -260,22 +262,24 @@ auto LowerParamDirection(hir::ParamDirection dir) -> mir::ParamDirection {
 
 }  // namespace
 
-auto ProcessLowerer::Run(WalkFrame parent_frame, const hir::Process& src)
+auto ProcessLowerer::Run(
+    WalkFrame parent_frame, std::string name, const hir::Process& src)
     -> diag::Result<mir::Process> {
   switch (src.kind) {
     case hir::ProcessKind::kInitial:
       return LowerStraightLineProcess(
-          *this, parent_frame, mir::ProcessKind::kInitial);
+          *this, parent_frame, std::move(name), mir::ProcessKind::kInitial);
     case hir::ProcessKind::kFinal:
       return LowerStraightLineProcess(
-          *this, parent_frame, mir::ProcessKind::kFinal);
+          *this, parent_frame, std::move(name), mir::ProcessKind::kFinal);
     case hir::ProcessKind::kAlways:
     case hir::ProcessKind::kAlwaysFf:
-      return LowerForeverProcess(*this, parent_frame, std::nullopt);
+      return LowerForeverProcess(
+          *this, parent_frame, std::move(name), std::nullopt);
     case hir::ProcessKind::kAlwaysComb:
     case hir::ProcessKind::kAlwaysLatch:
       return LowerForeverProcess(
-          *this, parent_frame,
+          *this, parent_frame, std::move(name),
           BuildSensitivityWaitStmt(*scope_, src.implicit_sensitivity_list));
   }
   throw InternalError("ProcessLowerer::Run: unknown HIR ProcessKind");

--- a/src/lyra/lowering/hir_to_mir/statement/branches.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/branches.cpp
@@ -11,7 +11,6 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
-#include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/case_cascade.hpp"
@@ -25,7 +24,6 @@
 #include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/procedural_hops.hpp"
-#include "lyra/mir/procedural_var.hpp"
 #include "lyra/mir/stmt.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -140,10 +138,17 @@ auto LowerCaseStmt(
     body_scopes.push_back(std::move(*body_or));
   }
 
+  // The cascade places the default at the same depth as the last item's body
+  // (their if-then-else share an enclosing level scope), so the default
+  // lowers at `items.size() - 1` extras; an empty item list is the cascade's
+  // degenerate `if (true) default` form at the wrapper depth.
+  const WalkFrame default_enter_frame =
+      c.items.empty() ? wrapper_frame
+                      : deeper_by(wrapper_frame, c.items.size() - 1);
   std::optional<mir::ProceduralScope> default_scope;
   if (c.default_stmt.has_value()) {
-    auto def_or = LowerStmtIntoChildScope(
-        process, deeper_by(wrapper_frame, c.items.size()), *c.default_stmt);
+    auto def_or =
+        LowerStmtIntoChildScope(process, default_enter_frame, *c.default_stmt);
     if (!def_or) {
       return std::unexpected(std::move(def_or.error()));
     }
@@ -246,10 +251,13 @@ auto LowerCaseInsideStmt(
     body_scopes.push_back(std::move(*body_or));
   }
 
+  const WalkFrame default_enter_frame =
+      c.items.empty() ? wrapper_frame
+                      : deeper_by(wrapper_frame, c.items.size() - 1);
   std::optional<mir::ProceduralScope> default_scope;
   if (c.default_stmt.has_value()) {
-    auto def_or = LowerStmtIntoChildScope(
-        process, deeper_by(wrapper_frame, c.items.size()), *c.default_stmt);
+    auto def_or =
+        LowerStmtIntoChildScope(process, default_enter_frame, *c.default_stmt);
     if (!def_or) {
       return std::unexpected(std::move(def_or.error()));
     }

--- a/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
@@ -61,14 +61,27 @@ auto LowerForkStmt(
 
   std::vector<mir::ExprId> branch_ids;
   branch_ids.reserve(f.branches.size());
+  const mir::TypeId self_ptr_type =
+      process.Module().Unit().builtins.self_pointer;
   for (const hir::StmtId branch_hir_id : f.branches) {
     const hir::Stmt& branch = hir_proc.stmts.at(branch_hir_id.value);
     mir::ProceduralScope branch_scope;
+
+    const mir::ProceduralVarId branch_self_id = branch_scope.AddProceduralVar(
+        mir::ProceduralVarDecl{.name = "self", .type = self_ptr_type});
+    const mir::ExprId outer_self_read = fork_scope.AddExpr(
+        mir::Expr{
+            .data =
+                mir::ProceduralVarRef{
+                    .hops = fork_frame.procedural_depth - ProceduralDepth{},
+                    .var = *fork_frame.self_binding},
+            .type = self_ptr_type});
 
     CaptureSink sink{
         fork_frame.procedural_depth.Inner(), branch_scope, fork_scope};
     const WalkFrame branch_frame = fork_frame.WithClosure(&sink)
                                        .WithProceduralScope(&branch_scope)
+                                       .WithSelfBinding(branch_self_id)
                                        .Deeper();
     auto lowered = process.LowerStmt(branch, branch_frame);
     if (!lowered) {
@@ -77,6 +90,9 @@ auto LowerForkStmt(
     branch_scope.AppendStmt(*std::move(lowered));
 
     std::vector<mir::Capture> captures;
+    captures.emplace_back(
+        mir::ByValueCapture{
+            .value = outer_self_read, .binding = branch_self_id});
     for (const CaptureRequest& request : sink.TakeRequests()) {
       if (request.decl_depth == fork_depth) {
         captures.emplace_back(

--- a/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
@@ -73,16 +73,19 @@ auto LowerForkStmt(
         mir::Expr{
             .data =
                 mir::ProceduralVarRef{
-                    .hops = fork_frame.procedural_depth - ProceduralDepth{},
+                    .hops = fork_frame.procedural_depth -
+                            fork_frame.self_decl_depth,
                     .var = *fork_frame.self_binding},
             .type = self_ptr_type});
 
     CaptureSink sink{
         fork_frame.procedural_depth.Inner(), branch_scope, fork_scope};
-    const WalkFrame branch_frame = fork_frame.WithClosure(&sink)
-                                       .WithProceduralScope(&branch_scope)
-                                       .WithSelfBinding(branch_self_id)
-                                       .Deeper();
+    const WalkFrame branch_frame =
+        fork_frame.WithClosure(&sink)
+            .WithProceduralScope(&branch_scope)
+            .WithSelfBinding(
+                branch_self_id, fork_frame.procedural_depth.Inner())
+            .Deeper();
     auto lowered = process.LowerStmt(branch, branch_frame);
     if (!lowered) {
       return std::unexpected(std::move(lowered.error()));

--- a/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
@@ -92,6 +92,9 @@ auto LowerForkStmt(
     closure.captures = std::move(captures);
     closure.body =
         std::make_unique<mir::ProceduralScope>(std::move(branch_scope));
+    // LRM 9.3.2 fork branch: each branch is a concurrent thread that may
+    // suspend on timing controls / event waits inside its body.
+    closure.is_coroutine = true;
     branch_ids.push_back(fork_scope.AddExpr(
         mir::Expr{
             .data = std::move(closure),

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -741,8 +741,12 @@ auto StructuralScopeLowerer::Run(
   }
 
   mir::ProceduralScope ctor_scope;
-  const WalkFrame scope_frame =
-      frame.WithStructuralScope(&mir_scope).WithProceduralScope(&ctor_scope);
+  const mir::ProceduralVarId self_id = ctor_scope.AddProceduralVar(
+      mir::ProceduralVarDecl{
+          .name = "self", .type = module.Unit().builtins.self_pointer});
+  const WalkFrame scope_frame = frame.WithStructuralScope(&mir_scope)
+                                    .WithProceduralScope(&ctor_scope)
+                                    .WithSelfBinding(self_id);
   const mir::TypeId scope_ptr_type = module.Unit().AddType(
       mir::PointerType{
           .pointee = module.Unit().AddType(mir::ScopeType{}),

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -308,6 +308,7 @@ auto BuildDownwardNavValue(
     const std::vector<hir::PathStep>& path, mir::TypeId slot_type,
     mir::TypeId scope_ptr_type) -> mir::ExprId {
   mir::ProceduralScope& ctor_scope = *frame.current_procedural_scope;
+  const mir::TypeId self_ptr_type = module.Unit().builtins.self_pointer;
   struct NavHop {
     std::string name;
     std::vector<mir::ExprId> indices;
@@ -331,7 +332,12 @@ auto BuildDownwardNavValue(
   }
 
   mir::ExprId cur = ctor_scope.AddExpr(
-      mir::Expr{.data = mir::SelfScopeExpr{}, .type = scope_ptr_type});
+      mir::Expr{
+          .data =
+              mir::ProceduralVarRef{
+                  .hops = frame.procedural_depth - frame.self_decl_depth,
+                  .var = *frame.self_binding},
+          .type = self_ptr_type});
   for (std::size_t i = 0; i + 1 < hops.size(); ++i) {
     std::vector<mir::ExprId> args;
     args.push_back(cur);
@@ -400,9 +406,21 @@ void InstallCrossUnitRefs(
     const mir::TypeId slot_type = mir_scope.GetStructuralVar(slot).type;
     const mir::ExprId nav = BuildDownwardNavValue(
         module, frame, head_name, cu.path, slot_type, scope_ptr_type);
+    const mir::ExprId self_for_target = ctor_scope.AddExpr(
+        mir::Expr{
+            .data =
+                mir::ProceduralVarRef{
+                    .hops = frame.procedural_depth - frame.self_decl_depth,
+                    .var = *frame.self_binding},
+            .type = module.Unit().builtins.self_pointer});
     const mir::ExprId target = ctor_scope.AddExpr(
         mir::Expr{
-            .data = mir::StructuralVarRef{.hops = {.value = 0}, .var = slot},
+            .data =
+                mir::MemberAccessExpr{
+                    .receiver = self_for_target,
+                    .member =
+                        mir::StructuralVarRef{
+                            .hops = {.value = 0}, .var = slot}},
             .type = slot_type});
     const mir::ExprId assign = ctor_scope.AddExpr(
         mir::Expr{
@@ -744,13 +762,10 @@ auto StructuralScopeLowerer::Run(
   const mir::ProceduralVarId self_id = ctor_scope.AddProceduralVar(
       mir::ProceduralVarDecl{
           .name = "self", .type = module.Unit().builtins.self_pointer});
-  const WalkFrame scope_frame = frame.WithStructuralScope(&mir_scope)
-                                    .WithProceduralScope(&ctor_scope)
-                                    .WithSelfBinding(self_id);
-  const mir::TypeId scope_ptr_type = module.Unit().AddType(
-      mir::PointerType{
-          .pointee = module.Unit().AddType(mir::ScopeType{}),
-          .ownership = mir::PointerOwnership::kBorrowed});
+  const WalkFrame scope_frame =
+      frame.WithStructuralScope(&mir_scope)
+          .WithProceduralScope(&ctor_scope)
+          .WithSelfBinding(self_id, frame.procedural_depth);
   const mir::TypeId void_type = module.Unit().AddType(mir::VoidType{});
   for (std::size_t i = 0; i < hir_scope.structural_vars.size(); ++i) {
     const hir::StructuralVarId hir_id{static_cast<std::uint32_t>(i)};
@@ -781,12 +796,31 @@ auto StructuralScopeLowerer::Run(
         !std::holds_alternative<mir::ObjectType>(var_data) &&
         !std::holds_alternative<mir::ExternalUnitObjectType>(var_data);
     if (is_signal) {
+      const mir::TypeId self_ptr_type = module.Unit().builtins.self_pointer;
       const mir::ExprId self = ctor_scope.AddExpr(
-          mir::Expr{.data = mir::SelfScopeExpr{}, .type = scope_ptr_type});
+          mir::Expr{
+              .data =
+                  mir::ProceduralVarRef{
+                      .hops = scope_frame.procedural_depth -
+                              scope_frame.self_decl_depth,
+                      .var = *scope_frame.self_binding},
+              .type = self_ptr_type});
+      const mir::ExprId self_for_member = ctor_scope.AddExpr(
+          mir::Expr{
+              .data =
+                  mir::ProceduralVarRef{
+                      .hops = scope_frame.procedural_depth -
+                              scope_frame.self_decl_depth,
+                      .var = *scope_frame.self_binding},
+              .type = self_ptr_type});
       const mir::ExprId var_ref = ctor_scope.AddExpr(
           mir::Expr{
               .data =
-                  mir::StructuralVarRef{.hops = {.value = 0}, .var = mir_id},
+                  mir::MemberAccessExpr{
+                      .receiver = self_for_member,
+                      .member =
+                          mir::StructuralVarRef{
+                              .hops = {.value = 0}, .var = mir_id}},
               .type = mir_type});
       const mir::ExprId call = ctor_scope.AddExpr(
           mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -834,13 +834,16 @@ auto StructuralScopeLowerer::Run(
   for (const auto& p : hir_scope.processes) {
     ProcessLowerer process_lowerer(
         module, scope, hir_scope.time_resolution, p.body);
-    auto proc_or = process_lowerer.Run(scope_frame, p);
+    std::string name = std::format("process_{}", mir_scope.processes.size());
+    auto proc_or = process_lowerer.Run(scope_frame, std::move(name), p);
     if (!proc_or) return std::unexpected(std::move(proc_or.error()));
     mir_scope.AddProcess(*std::move(proc_or));
   }
 
   for (const auto& ca : hir_scope.continuous_assigns) {
-    auto proc_or = LowerContinuousAssign(scope, scope_frame, ca);
+    std::string name = std::format("process_{}", mir_scope.processes.size());
+    auto proc_or =
+        LowerContinuousAssign(scope, scope_frame, std::move(name), ca);
     if (!proc_or) return std::unexpected(std::move(proc_or.error()));
     mir_scope.AddProcess(*std::move(proc_or));
   }

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -199,11 +199,8 @@ auto InstallInstanceMembers(StructuralScopeLowerer& scope, WalkFrame frame)
     }
     const mir::TypeId var_type = MakeExternalUnitMemberType(
         scope.Module(), im.target_unit, im.array_dims.size());
-    const mir::ExprId init =
-        SynthesizeDefaultValueExpr(scope.Module(), frame, var_type);
     const mir::StructuralVarId var_id = mir_scope.AddStructuralVar(
-        mir::StructuralVarDecl{
-            .name = im.instance_name, .type = var_type, .initializer = init});
+        mir::StructuralVarDecl{.name = im.instance_name, .type = var_type});
     instance_member_vars.push_back(var_id);
 
     ctor_scope.AppendStmt(
@@ -267,12 +264,9 @@ auto MaterializeCrossUnitRefTargets(
               .ancestor = up->ancestor_name,
               .tail = std::move(tail),
               .signal = std::move(signal)});
-      const mir::ExprId init = SynthesizeDefaultValueExpr(module, frame, leaf);
       const mir::StructuralVarId var = mir_scope.AddStructuralVar(
           mir::StructuralVarDecl{
-              .name = std::move(member_name),
-              .type = ext_type,
-              .initializer = init});
+              .name = std::move(member_name), .type = ext_type});
       scope.AddCrossUnitRefTarget(
           mir::StructuralVarRef{.hops = {.value = 0}, .var = var}, ext_type);
       slot_vars.emplace_back(std::nullopt);
@@ -281,13 +275,10 @@ auto MaterializeCrossUnitRefTargets(
       const mir::TypeId slot_type = module.Unit().AddType(
           mir::PointerType{
               .pointee = leaf, .ownership = mir::PointerOwnership::kBorrowed});
-      const mir::ExprId init =
-          SynthesizeDefaultValueExpr(module, frame, slot_type);
       const mir::StructuralVarId slot = mir_scope.AddStructuralVar(
           mir::StructuralVarDecl{
               .name = "xref" + std::to_string(downward_slot),
-              .type = slot_type,
-              .initializer = init});
+              .type = slot_type});
       scope.AddCrossUnitRefTarget(
           mir::StructuralVarRef{.hops = {.value = 0}, .var = slot}, slot_type);
       slot_vars.emplace_back(slot);
@@ -708,14 +699,11 @@ auto InstallGenerateOwnedChildScopes(
       if (spec.is_repeated) {
         var_type = module.Unit().AddType(mir::VectorType{.element = var_type});
       }
-      const mir::ExprId companion_init =
-          SynthesizeDefaultValueExpr(module, frame, var_type);
       const mir::StructuralVarId var_id = mir_scope.AddStructuralVar(
           mir::StructuralVarDecl{
               .name = companion_name,
               .source_name = spec.scope->source_name,
-              .type = var_type,
-              .initializer = companion_init});
+              .type = var_type});
 
       gen_bindings.by_scope_id.at(spec.scope_id.value) =
           ChildStructuralScopeBinding{.scope_id = child_id, .var_id = var_id};
@@ -767,28 +755,69 @@ auto StructuralScopeLowerer::Run(
           .WithProceduralScope(&ctor_scope)
           .WithSelfBinding(self_id, frame.procedural_depth);
   const mir::TypeId void_type = module.Unit().AddType(mir::VoidType{});
+  const mir::TypeId self_ptr_type = module.Unit().builtins.self_pointer;
+  const auto self_read = [&]() -> mir::ExprId {
+    return ctor_scope.AddExpr(
+        mir::Expr{
+            .data =
+                mir::ProceduralVarRef{
+                    .hops = scope_frame.procedural_depth -
+                            scope_frame.self_decl_depth,
+                    .var = *scope_frame.self_binding},
+            .type = self_ptr_type});
+  };
   for (std::size_t i = 0; i < hir_scope.structural_vars.size(); ++i) {
     const hir::StructuralVarId hir_id{static_cast<std::uint32_t>(i)};
     const auto& d = hir_scope.structural_vars[i];
     const mir::TypeId mir_type = module.TranslateType(d.type);
-    mir::ExprId mir_init{};
-    if (d.initializer.has_value()) {
-      auto init_or =
-          scope.LowerExpr(hir_scope.GetExpr(*d.initializer), scope_frame);
-      if (!init_or) return std::unexpected(std::move(init_or.error()));
-      mir_init = ctor_scope.AddExpr(*std::move(init_or));
-    } else {
-      mir_init = SynthesizeDefaultValueExpr(module, scope_frame, mir_type);
-    }
     const mir::StructuralVarId mir_id = mir_scope.AddStructuralVar(
-        mir::StructuralVarDecl{
-            .name = d.name, .type = mir_type, .initializer = mir_init});
+        mir::StructuralVarDecl{.name = d.name, .type = mir_type});
     scope.MapStructuralVar(hir_id, mir_id);
+
+    const auto& var_data = module.Unit().GetType(mir_type).data;
+    // Owned children (pointer / vector / object), resolution slots, upward
+    // refs, and named events have no "value assignment" -- their declaration
+    // shape itself fixes the field at construction. Value-typed signals
+    // (integral, string, real, unpacked / dynamic array) receive an LRM 10.5
+    // initialization statement before any RegisterSignal / CreateProcesses.
+    const bool is_assignable_value =
+        !std::holds_alternative<mir::PointerType>(var_data) &&
+        !std::holds_alternative<mir::VectorType>(var_data) &&
+        !std::holds_alternative<mir::ExternalRefType>(var_data) &&
+        !std::holds_alternative<mir::ObjectType>(var_data) &&
+        !std::holds_alternative<mir::ExternalUnitObjectType>(var_data) &&
+        !std::holds_alternative<mir::EventType>(var_data);
+    if (is_assignable_value) {
+      mir::ExprId value_id{};
+      if (d.initializer.has_value()) {
+        auto value_or =
+            scope.LowerExpr(hir_scope.GetExpr(*d.initializer), scope_frame);
+        if (!value_or) return std::unexpected(std::move(value_or.error()));
+        value_id = ctor_scope.AddExpr(*std::move(value_or));
+      } else {
+        value_id = SynthesizeDefaultValueExpr(module, scope_frame, mir_type);
+      }
+      const mir::ExprId init_target = ctor_scope.AddExpr(
+          mir::Expr{
+              .data =
+                  mir::MemberAccessExpr{
+                      .receiver = self_read(),
+                      .member =
+                          mir::StructuralVarRef{
+                              .hops = {.value = 0}, .var = mir_id}},
+              .type = mir_type});
+      const mir::ExprId assign_id = ctor_scope.AddExpr(
+          mir::Expr{
+              .data = mir::AssignExpr{.target = init_target, .value = value_id},
+              .type = mir_type});
+      ctor_scope.AppendStmt(
+          mir::Stmt{
+              .label = std::nullopt, .data = mir::ExprStmt{.expr = assign_id}});
+    }
 
     // A value-typed var is a signal: record its address under its name so a
     // cross-unit referrer resolves it by name at construction. Owned children
     // (pointer / vector / object) and resolution slots register differently.
-    const auto& var_data = module.Unit().GetType(mir_type).data;
     const bool is_signal =
         !std::holds_alternative<mir::PointerType>(var_data) &&
         !std::holds_alternative<mir::VectorType>(var_data) &&
@@ -796,28 +825,11 @@ auto StructuralScopeLowerer::Run(
         !std::holds_alternative<mir::ObjectType>(var_data) &&
         !std::holds_alternative<mir::ExternalUnitObjectType>(var_data);
     if (is_signal) {
-      const mir::TypeId self_ptr_type = module.Unit().builtins.self_pointer;
-      const mir::ExprId self = ctor_scope.AddExpr(
-          mir::Expr{
-              .data =
-                  mir::ProceduralVarRef{
-                      .hops = scope_frame.procedural_depth -
-                              scope_frame.self_decl_depth,
-                      .var = *scope_frame.self_binding},
-              .type = self_ptr_type});
-      const mir::ExprId self_for_member = ctor_scope.AddExpr(
-          mir::Expr{
-              .data =
-                  mir::ProceduralVarRef{
-                      .hops = scope_frame.procedural_depth -
-                              scope_frame.self_decl_depth,
-                      .var = *scope_frame.self_binding},
-              .type = self_ptr_type});
       const mir::ExprId var_ref = ctor_scope.AddExpr(
           mir::Expr{
               .data =
                   mir::MemberAccessExpr{
-                      .receiver = self_for_member,
+                      .receiver = self_read(),
                       .member =
                           mir::StructuralVarRef{
                               .hops = {.value = 0}, .var = mir_id}},
@@ -830,7 +842,7 @@ auto StructuralScopeLowerer::Run(
                           mir::RuntimeNavCallee{
                               .fn = mir::RuntimeFn::kRegisterSignal,
                               .name = d.name},
-                      .arguments = {self, var_ref}},
+                      .arguments = {self_read(), var_ref}},
               .type = void_type});
       ctor_scope.AppendStmt(
           mir::Stmt{

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -177,6 +177,7 @@ class MirDumper {
                   "ExternalUnitObject(unit=\"{}\")", e.unit_name);
             },
             [](const ScopeType&) -> std::string { return "Scope"; },
+            [](const SelfType&) -> std::string { return "Self"; },
             [](const PointerType& p) -> std::string {
               switch (p.ownership) {
                 case PointerOwnership::kUnique:

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -556,8 +556,9 @@ class MirDumper {
             },
             [](const ClosureExpr& cl) -> std::string {
               return std::format(
-                  "ClosureExpr captures={} params={}", cl.captures.size(),
-                  cl.params.size());
+                  "ClosureExpr captures={} params={} is_coroutine={}",
+                  cl.captures.size(), cl.params.size(),
+                  cl.is_coroutine ? "true" : "false");
             },
             [](const ElementSelectExpr& sel) -> std::string {
               return std::format(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -686,7 +686,9 @@ class MirDumper {
   }
 
   void DumpProcess(const Process& p, std::size_t index) {
-    Line(std::format("Process[{}] {}", index, FormatProcessKind(p)));
+    Line(
+        std::format(
+            "Process[{}] {} name={}", index, FormatProcessKind(p), p.name));
     Indent();
     for (std::size_t i = 0; i < p.static_locals.size(); ++i) {
       const auto& sl = p.static_locals[i];

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -477,13 +477,6 @@ class MirDumper {
                   "StructuralParamRef[hops={}, param={}] \"{}\"", r.hops.value,
                   r.param.value, param.name);
             },
-            [this](const StructuralVarRef& r) -> std::string {
-              const auto& owner = ResolveScopeAtHops(r.hops.value);
-              const auto& var = owner.GetStructuralVar(r.var);
-              return std::format(
-                  "StructuralVarRef[hops={}, var={}] \"{}\"", r.hops.value,
-                  r.var.value, var.name);
-            },
             [this](const ProceduralVarRef& r) -> std::string {
               const auto& owner = ResolveProceduralScopeAtHops(r.hops.value);
               const auto& var = owner.vars.at(r.var.value);
@@ -546,7 +539,6 @@ class MirDumper {
             [](const RuntimeCallExpr&) -> std::string {
               return "RuntimeCallExpr";
             },
-            [](const SelfScopeExpr&) -> std::string { return "SelfScopeExpr"; },
             [](const MemberAccessExpr& m) -> std::string {
               return std::format(
                   "MemberAccessExpr receiver=Expr[{}] hops={} "

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -656,8 +656,7 @@ class MirDumper {
           v.source_name.empty() ? "" : std::format(" as \"{}\"", v.source_name);
       Line(
           std::format(
-              "[{}] \"{}\"{} : {} init=Expr[{}]", i, v.name, as,
-              FormatVarType(v.type), v.initializer.value));
+              "[{}] \"{}\"{} : {}", i, v.name, as, FormatVarType(v.type)));
     }
     Dedent();
 

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -546,6 +546,12 @@ class MirDumper {
               return "RuntimeCallExpr";
             },
             [](const SelfScopeExpr&) -> std::string { return "SelfScopeExpr"; },
+            [](const MemberAccessExpr& m) -> std::string {
+              return std::format(
+                  "MemberAccessExpr receiver=Expr[{}] hops={} "
+                  "var=StructuralVar[{}]",
+                  m.receiver.value, m.member.hops.value, m.member.var.value);
+            },
             [](const DerefExpr& d) -> std::string {
               return std::format("DerefExpr pointer=Expr[{}]", d.pointer.value);
             },

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -75,6 +75,7 @@ auto Type::Kind() const -> TypeKind {
             return TypeKind::kExternalUnitObject;
           },
           [](const ScopeType&) { return TypeKind::kScope; },
+          [](const SelfType&) { return TypeKind::kSelf; },
           [](const PointerType&) { return TypeKind::kPointer; },
           [](const VectorType&) { return TypeKind::kVector; },
           [](const ExternalRefType&) { return TypeKind::kExternalRef; },

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -42,10 +42,10 @@ void Engine::BindDesign(std::span<const TopBinding> tops) {
     throw InternalError("Engine::BindDesign called more than once");
   }
   bound_ = true;
-  root_ = std::make_unique<Scope>(nullptr, "$root");
+  root_ = std::make_unique<Scope>(nullptr, "$root", services_);
   for (const auto& top : tops) {
     root_->AddChild(*top.scope);
-    top.scope->Bind(services_);
+    top.scope->Bind();
   }
 }
 

--- a/src/lyra/runtime/scope.cpp
+++ b/src/lyra/runtime/scope.cpp
@@ -20,8 +20,8 @@
 
 namespace lyra::runtime {
 
-Scope::Scope(Scope* parent, std::string name)
-    : parent_(parent), name_(std::move(name)) {
+Scope::Scope(Scope* parent, std::string name, RuntimeServices& services)
+    : parent_(parent), name_(std::move(name)), services_(&services) {
   if (parent_ != nullptr) {
     parent_->AddChild(*this);
   }
@@ -77,15 +77,14 @@ auto Scope::Name() const -> std::string_view {
   return name_;
 }
 
-void Scope::Bind(RuntimeServices& services) {
-  services_ = &services;
+void Scope::Bind() {
   // The whole tree is constructed before Bind runs, so every ancestor and the
   // full parent chain exist when an ExternUp member relocates by climbing.
   for (ExternBase* member : externs_) {
     member->Relocate();
   }
   CreateProcesses();
-  ForEachChild([&services](Scope& child) { child.Bind(services); });
+  ForEachChild([](Scope& child) { child.Bind(); });
 }
 
 void Scope::RegisterExtern(ExternBase* member) {
@@ -106,9 +105,6 @@ auto Scope::ResolveUpwardScope(std::string_view ancestor) -> Scope* {
 }
 
 auto Scope::Services() -> RuntimeServices& {
-  if (services_ == nullptr) {
-    throw InternalError("Scope::Services: scope not bound");
-  }
   return *services_;
 }
 

--- a/src/lyra/value/packed.cpp
+++ b/src/lyra/value/packed.cpp
@@ -11,9 +11,8 @@
 namespace lyra::value {
 
 auto WordCountForBits(std::uint64_t bit_width) -> std::size_t {
-  if (bit_width == 0U) {
-    throw InternalError("WordCountForBits: zero bit_width");
-  }
+  // 0 bits is the `PackedArray()` sentinel "uninitialized" shape; an empty
+  // storage vector matches it. Non-zero widths round up to whole words.
   // Overflow-safe form: never compute `bit_width + 63`.
   const std::uint64_t whole = bit_width / 64U;
   const std::uint64_t remainder = bit_width % 64U;
@@ -54,9 +53,6 @@ auto ValidateViewRange(
 PackedWords::PackedWords(std::uint64_t bit_width)
     : bit_width_(bit_width),
       words_(WordCountForBits(bit_width), std::uint64_t{0}) {
-  if (bit_width == 0U) {
-    throw InternalError("PackedWords: zero bit_width");
-  }
 }
 
 auto PackedWords::BitWidth() const -> std::uint64_t {

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -73,6 +73,14 @@ auto TotalBitWidthOf(std::span<const PackedRange> dims) -> std::uint64_t {
 
 }  // namespace
 
+PackedArray::PackedArray()
+    : bit_width_(0),
+      is_signed_(false),
+      is_four_state_(false),
+      storage_(BitValue{0}),
+      dims_() {
+}
+
 PackedArray::PackedArray(
     std::initializer_list<PackedRange> dims, bool is_signed, bool is_four_state)
     : bit_width_(TotalBitWidthOf(
@@ -359,6 +367,18 @@ auto PackedArray::operator=(PackedArray&& other) noexcept(false)
 }
 
 auto PackedArray::AssignFrom(const PackedArray& other) -> void {
+  // A 0-bit destination is the default-constructed "uninitialized" sentinel
+  // state (e.g., an `Var<PackedArray>` field that has not yet received its
+  // first MIR-level assignment). Adopt the source's shape entirely so the
+  // first store into a freshly declared variable succeeds; subsequent stores
+  // run through the normal LRM 10.6.1 shape-preserving path.
+  if (bit_width_ == 0) {
+    bit_width_ = other.bit_width_;
+    is_signed_ = other.is_signed_;
+    is_four_state_ = other.is_four_state_;
+    storage_ = MakeStorage(bit_width_, is_four_state_);
+    dims_ = other.dims_;
+  }
   ExpectSameShape(*this, other, "PackedArray::AssignFrom");
   auto dst = std::visit(
       [](auto& v) { return detail::PackedAccess::ValueWords(v.View()); },


### PR DESCRIPTION
## Summary

This branch closes R11, R14, R15, R16, and R19 in `docs/progress/refactor.md`: explicit `self` first binding on every MIR callable body, paired with LRM 10.5 variable initialization lowered as a constructor-scope statement.

## What changed

### R11, R14, R15, R16 — explicit `self` first binding

Every MIR callable body (process, structural subroutine, constructor body, closure) now declares `self` as `body.vars[0]`, a procedural-var of borrowed-pointer-to-enclosing-scope type. Class-member access flows through a new `mir::MemberAccessExpr { receiver, var }` whose receiver reads `self` via `ProceduralVarRef`. `mir::SelfScopeExpr` is removed. C++ emits each form in its natural idiom: method-form callables as `static fn(Self* self, ...)`, closures with `[self = ...]` capture; the previously fragmented receiver mechanisms (`this` / fork-branch `(M* self)` / NBA `[this]` / NBA `[=, this]`) collapse to one. The cpp backend's receiver-related `RenderContext` walker state (`ReceiverObject` / `WithReceiver` / `MemberPrefix` / `DeferredByValueCapture`) is removed. `mir::Process` gains a `name` field; `mir::ClosureExpr` gains an `is_coroutine` flag. The mutable temp-counter escape hatch on `RenderContext` is gone. See `docs/decisions/callable-receiver.md`.

### R19 — LRM 10.5 variable init as constructor scope statement

`mir::StructuralVarDecl.initializer` is removed; a declaration carries name and type only. HIR-to-MIR appends an `AssignExpr(MemberAccess(self, var), value)` statement to `constructor_scope.root_stmts` for every value-assignable structural var, using the user-supplied expression when present or the LRM Table 6-7 type default. `RenderField` becomes a pure value-init declaration (`Var<T> name{};` or `T name{};`) with no inline initializer; `RenderContext::in_class_member_init_` and `WithClassMemberInit` are removed. To make a constructor-body `Set` work, `Scope` now takes `RuntimeServices&` at construction (Bind no longer wires services), and `PackedArray` / `UnpackedArray<T>` / `DynamicArray<T>` gain default constructors with a 0-bit sentinel shape that the first `AssignFrom` adopts. The generated host `main.cpp` flips to `Engine engine; Test top0{nullptr, "Test", engine.Services()};` order. Non-assignable vars (pointer / vector / object / external-ref / event) are filtered out of the init-statement path. See `docs/decisions/variable-initialization.md`.

## Test plan

- [x] `bazel test //... --test_output=errors`
- [x] `clang-format`, `prettier`, `buildifier`
- [x] `tools/policy/check_architecture.py`, `check_ascii.py`, `check_cpp_style.py`, `check_exceptions.py`