### PR TITLE
Support default values for unconnected input ports

### DIFF
--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -174,7 +174,14 @@ Unlocks `refs/hierarchical_refs`, `refs/upward_refs`, and `instantiation/hierarc
       variable-typed ports; both endpoints keep their own storage.
 - [ ] E7 -- A `ref` port aliases the connected variable as a hierarchical reference, sharing its
       storage with no separate continuous assignment (LRM 23.3.3.2).
-- [ ] E8 -- An input port left unconnected takes its declared default value (LRM 23.2.2.4).
+- [x] E8 -- An input port left unconnected takes its declared default value (LRM 23.2.2.4). A
+      declared default is a constant expression whose names resolve in the module that declares the
+      port, not the instantiating scope; like a default argument at a call site, its value is
+      materialized into the connection wherever the port is omitted. Omitting a port inserts its
+      default; an explicit empty connection (`.port()`) suppresses the default and leaves the port
+      at the data type's default initial value (LRM 23.3.2.2 / 23.3.3.2), as does an unconnected
+      port with no default; an explicit expression overrides. Defaults are permitted only on input
+      ports (LRM 23.2.2.4), which the frontend enforces.
 - [ ] E9 -- A port connection on an instance array drives each element.
 - [ ] E10 -- A port connection whose type is non-integral (an unpacked struct or array).
 

--- a/include/lyra/lowering/ast_to_hir/constant_value.hpp
+++ b/include/lyra/lowering/ast_to_hir/constant_value.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <slang/numeric/ConstantValue.h>
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_span.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/type_id.hpp"
+
+namespace lyra::lowering::ast_to_hir {
+
+// Materialize an already-evaluated slang ConstantValue as an HIR literal
+// expression of `type`: integral, real, shortreal, or string. Used wherever a
+// slang-folded constant is spliced into the HIR -- parameter and enum-value
+// references, and defaulted port connections. Aggregate constants are not yet
+// supported.
+auto MakeConstantValueExpr(
+    const slang::ConstantValue& cv, hir::TypeId type, diag::SourceSpan span)
+    -> diag::Result<hir::Expr>;
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/integral_constant.hpp
+++ b/include/lyra/lowering/ast_to_hir/integral_constant.hpp
@@ -2,7 +2,10 @@
 
 #include <slang/numeric/SVInt.h>
 
+#include "lyra/diag/source_span.hpp"
+#include "lyra/hir/expr.hpp"
 #include "lyra/hir/integral_constant.hpp"
+#include "lyra/hir/type_id.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -12,5 +15,13 @@ namespace lyra::lowering::ast_to_hir {
 // X=(value=1,state=1).
 auto LowerSVIntToIntegralConstant(const slang::SVInt& sv)
     -> hir::IntegralConstant;
+
+// Materialize an already-evaluated slang integral constant as an HIR
+// integer-literal expression of `type`. Shared by every site that splices a
+// constant slang has folded into the HIR: parameter and enum-value references,
+// and defaulted port connections.
+auto MakeIntegralLiteralExpr(
+    const slang::SVInt& sv, hir::TypeId type, diag::SourceSpan span)
+    -> hir::Expr;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/constant_value.cpp
+++ b/src/lyra/lowering/ast_to_hir/constant_value.cpp
@@ -1,0 +1,47 @@
+#include "lyra/lowering/ast_to_hir/constant_value.hpp"
+
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/kind.hpp"
+#include "lyra/hir/primary.hpp"
+#include "lyra/lowering/ast_to_hir/integral_constant.hpp"
+
+namespace lyra::lowering::ast_to_hir {
+
+auto MakeConstantValueExpr(
+    const slang::ConstantValue& cv, hir::TypeId type, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  if (cv.isInteger()) {
+    return MakeIntegralLiteralExpr(cv.integer(), type, span);
+  }
+  if (cv.isReal()) {
+    return hir::Expr{
+        .type = type,
+        .data = hir::PrimaryExpr{.data = hir::RealLiteral{.value = cv.real()}},
+        .span = span,
+    };
+  }
+  if (cv.isShortReal()) {
+    return hir::Expr{
+        .type = type,
+        .data =
+            hir::PrimaryExpr{
+                .data =
+                    hir::RealLiteral{
+                        .value = static_cast<double>(cv.shortReal())}},
+        .span = span,
+    };
+  }
+  if (cv.isString()) {
+    return hir::Expr{
+        .type = type,
+        .data = hir::PrimaryExpr{.data = hir::StringLiteral{.value = cv.str()}},
+        .span = span,
+    };
+  }
+  return diag::Unsupported(
+      span, diag::DiagCode::kUnsupportedExpressionForm,
+      "constant of aggregate type is not yet supported",
+      diag::UnsupportedCategory::kFeature);
+}
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -25,6 +25,7 @@
 #include "lyra/diag/kind.hpp"
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/value_ref.hpp"
+#include "lyra/lowering/ast_to_hir/constant_value.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
 
 namespace lyra::lowering::ast_to_hir {
@@ -49,67 +50,7 @@ auto MakeEnumValueExpr(
   if (!cv.isInteger()) {
     throw InternalError("MakeEnumValueExpr: enum value is not integral");
   }
-  return hir::Expr{
-      .type = type,
-      .data =
-          hir::PrimaryExpr{
-              .data =
-                  hir::IntegerLiteral{
-                      .value = LowerSVIntToIntegralConstant(cv.integer()),
-                      .base = hir::IntegerLiteralBase::kDecimal,
-                      .declared_unsized = false,
-                  }},
-      .span = span,
-  };
-}
-
-auto MakeParameterValueExpr(
-    const slang::ast::ParameterSymbol& sym, hir::TypeId type,
-    diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  const auto& cv = sym.getValue();
-  if (cv.isInteger()) {
-    return hir::Expr{
-        .type = type,
-        .data =
-            hir::PrimaryExpr{
-                .data =
-                    hir::IntegerLiteral{
-                        .value = LowerSVIntToIntegralConstant(cv.integer()),
-                        .base = hir::IntegerLiteralBase::kDecimal,
-                        .declared_unsized = false,
-                    }},
-        .span = span,
-    };
-  }
-  if (cv.isReal()) {
-    return hir::Expr{
-        .type = type,
-        .data = hir::PrimaryExpr{.data = hir::RealLiteral{.value = cv.real()}},
-        .span = span,
-    };
-  }
-  if (cv.isShortReal()) {
-    return hir::Expr{
-        .type = type,
-        .data =
-            hir::PrimaryExpr{
-                .data =
-                    hir::RealLiteral{
-                        .value = static_cast<double>(cv.shortReal())}},
-        .span = span,
-    };
-  }
-  if (cv.isString()) {
-    return hir::Expr{
-        .type = type,
-        .data = hir::PrimaryExpr{.data = hir::StringLiteral{.value = cv.str()}},
-        .span = span,
-    };
-  }
-  return diag::Unsupported(
-      span, diag::DiagCode::kUnsupportedExpressionForm,
-      "parameter of aggregate type is not yet supported",
-      diag::UnsupportedCategory::kFeature);
+  return MakeIntegralLiteralExpr(cv.integer(), type, span);
 }
 
 }  // namespace
@@ -148,8 +89,8 @@ auto LowerNamedValueProc(
   if (sym.kind == slang::ast::SymbolKind::Parameter) {
     auto type_id = module.InternType(*named.type, span);
     if (!type_id) return std::unexpected(std::move(type_id.error()));
-    return MakeParameterValueExpr(
-        sym.as<slang::ast::ParameterSymbol>(), *type_id, span);
+    return MakeConstantValueExpr(
+        sym.as<slang::ast::ParameterSymbol>().getValue(), *type_id, span);
   }
 
   // Subroutine formals (LRM 13.5) and foreach iterators (LRM 12.7.3) are
@@ -354,8 +295,8 @@ auto LowerNamedValueStructural(
   if (sym.kind == slang::ast::SymbolKind::Parameter) {
     auto type_id = module.InternType(*named.type, span);
     if (!type_id) return std::unexpected(std::move(type_id.error()));
-    return MakeParameterValueExpr(
-        sym.as<slang::ast::ParameterSymbol>(), *type_id, span);
+    return MakeConstantValueExpr(
+        sym.as<slang::ast::ParameterSymbol>().getValue(), *type_id, span);
   }
   if (sym.kind != slang::ast::SymbolKind::Variable) {
     return diag::Unsupported(

--- a/src/lyra/lowering/ast_to_hir/integral_constant.cpp
+++ b/src/lyra/lowering/ast_to_hir/integral_constant.cpp
@@ -72,4 +72,21 @@ auto LowerSVIntToIntegralConstant(const slang::SVInt& sv)
   return out;
 }
 
+auto MakeIntegralLiteralExpr(
+    const slang::SVInt& sv, hir::TypeId type, diag::SourceSpan span)
+    -> hir::Expr {
+  return hir::Expr{
+      .type = type,
+      .data =
+          hir::PrimaryExpr{
+              .data =
+                  hir::IntegerLiteral{
+                      .value = LowerSVIntToIntegralConstant(sv),
+                      .base = hir::IntegerLiteralBase::kDecimal,
+                      .declared_unsized = false,
+                  }},
+      .span = span,
+  };
+}
+
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/port_connection.cpp
+++ b/src/lyra/lowering/ast_to_hir/port_connection.cpp
@@ -12,6 +12,7 @@
 #include <slang/ast/symbols/PortSymbols.h>
 #include <slang/ast/symbols/ValueSymbol.h>
 #include <slang/ast/types/Type.h>
+#include <slang/numeric/ConstantValue.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
@@ -19,6 +20,7 @@
 #include "lyra/diag/kind.hpp"
 #include "lyra/hir/continuous_assign.hpp"
 #include "lyra/hir/structural_scope.hpp"
+#include "lyra/lowering/ast_to_hir/constant_value.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
@@ -97,8 +99,10 @@ auto PopulateInstancePortConnections(
     }
     const auto* expr = conn->getExpression();
     if (expr == nullptr) {
-      return PortConnectionUnsupported(
-          span, "unconnected port default value is not yet supported");
+      // Unconnected: an explicit empty connection (`.port()`) or a port omitted
+      // with no default. The child's storage holds the data type's default
+      // initial value (LRM 23.3.3.2); no parent driver is installed.
+      continue;
     }
 
     auto type_id = module.InternType(port_type, span);
@@ -108,14 +112,35 @@ auto PopulateInstancePortConnections(
         {hir::MemberHop{std::string{internal->name}}}, *type_id, span);
 
     if (port.direction == slang::ast::ArgumentDirection::In) {
-      // Input: the parent-side source drives the child port.
-      auto rhs_or = scope.LowerExpr(*expr, frame);
-      if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+      // The child port is driven by the connection's value: the parent-side
+      // expression, or -- when the port was omitted -- the declared default
+      // (LRM 23.2.2.4), which slang surfaces through getExpression() as the
+      // port's own getInitializer() pointer. The default's names resolve in the
+      // child, so it cannot be lowered in the parent frame; like a C++ default
+      // argument, its already-evaluated constant is spliced in here and driven
+      // once with no sensitivity.
+      hir::Expr rhs;
+      std::vector<SensitivityRead> reads;
+      if (expr == port.getInitializer()) {
+        const auto* constant = expr->getConstant();
+        if (constant == nullptr) {
+          throw InternalError(
+              "PopulateInstancePortConnections: port default did not fold to a "
+              "constant");
+        }
+        auto rhs_or = MakeConstantValueExpr(*constant, *type_id, span);
+        if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+        rhs = *std::move(rhs_or);
+      } else {
+        auto rhs_or = scope.LowerExpr(*expr, frame);
+        if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+        rhs = *std::move(rhs_or);
+        reads = module.Sensitivity().AnalyzeReads(*expr, inst);
+      }
       const hir::ExprId lhs_id =
           frame.current_structural_scope->AddExpr(std::move(child_ref));
       const hir::ExprId rhs_id =
-          frame.current_structural_scope->AddExpr(*std::move(rhs_or));
-      const auto& reads = module.Sensitivity().AnalyzeReads(*expr, inst);
+          frame.current_structural_scope->AddExpr(std::move(rhs));
       frame.current_structural_scope->AddContinuousAssign(
           hir::ContinuousAssign{
               .span = span,

--- a/tests/cases/cpp/ports_default_value/case.yaml
+++ b/tests/cases/cpp/ports_default_value/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.ports_default_value
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "176 113 5\n"

--- a/tests/cases/cpp/ports_default_value/main.sv
+++ b/tests/cases/cpp/ports_default_value/main.sv
@@ -1,0 +1,22 @@
+// Input-port connection value resolution. Omitting a port inserts its declared
+// default (LRM 23.2.2.4); an explicit empty connection `.din()` suppresses the
+// default and leaves the port at its type default (LRM 23.3.2.2 / 23.3.3.2); an
+// explicit expression overrides. (Some simulators reuse the default for `.din()`
+// too; that is non-conformant, so this diverges from them by design.)
+module Child (input int din = 171, input int ein, input int cin, output int dout);
+  assign dout = din + ein + cin;
+endmodule
+
+module Top;
+  int c;
+  int q_def;
+  int q_conn;
+  int q_empty;
+  Child u_def (.cin(c), .dout(q_def));
+  Child u_conn (.din(8), .ein(100), .cin(c), .dout(q_conn));
+  Child u_empty (.din(), .cin(c), .dout(q_empty));
+  initial begin
+    c = 5;
+    #1 $display("%0d %0d %0d", q_def, q_conn, q_empty);
+  end
+endmodule


### PR DESCRIPTION
## Summary

An input port left unconnected at an instantiation now takes its declared default value (LRM 23.2.2.4). The model mirrors a C++ default argument: the default's names resolve in the module that declares the port, but its already-evaluated constant value is materialized into the connection at the instantiation site. The child module is uniform and never participates in default resolution, so this keeps each module an independently compiled unit.

The three connection shapes all fall out of one rule. Omitting a port inserts its default; an explicit empty connection `.port()` suppresses the default and leaves the port at the data type's default initial value (LRM 23.3.2.2 / 23.3.3.2), as does an unconnected port with no default; an explicit expression drives normally and overrides any default. Resolution is type-agnostic: the default's constant is materialized through the same path parameter values use.

## Design

The parent distinguishes the inserted default (slang surfaces it through `getExpression()` as the port's own `getInitializer()` pointer) from a real connection. A real connection lowers in the parent frame; the default cannot, since its names resolve in the child, so its constant is spliced in directly and driven once with no sensitivity. This adds a shared `MakeConstantValueExpr` (integral, real, shortreal, string) and routes parameter and enum-value references through it, removing duplicated constant-materialization logic.

## Testing

`cpp.ports_default_value` asserts all four behaviors end to end (omitted default, no-default type default, explicit override, explicit-empty suppression). Note: some simulators reuse the default for `.port()`, which is non-conformant with LRM 23.3.2.2; this implementation follows the LRM and the test documents the divergence.