### PR TITLE
Fix queue field default-construction regression

### DIFF
--- a/docs/progress/dev-ergonomics.md
+++ b/docs/progress/dev-ergonomics.md
@@ -13,6 +13,11 @@ layer directly.
 - [x] D4 -- Emitting the C++ backend produces a self-contained project that rebuilds and runs on
       another machine of the same platform without a Lyra checkout.
 
+- [ ] D5 -- A failing end-to-end case surfaces its underlying cause -- the emitted-C++ compile error
+      or the runtime message -- directly from the test command. Today that detail is truncated in
+      the test summary and the full text lives only in per-shard log files outside the readable
+      path, so finding why a case failed takes several manual reruns of the same suite.
+
 ## Out of Scope
 
 - New SystemVerilog feature coverage. This file tracks the developer feedback loop, not language

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -26,6 +26,12 @@ class Queue {
  public:
   using ElementType = T;
 
+  // Sentinel "uninitialized" form -- empty queue with a default-constructed
+  // OOB slot. Used as the declared default state of a queue field; the first
+  // MIR-level assignment overwrites the whole queue (LRM 10.5 variable
+  // initialization).
+  Queue() = default;
+
   // Empty queue with the shield slot seeded. Used for declarations like
   // `int q[$];` where the queue starts empty but the element shape is known
   // at lowering time.


### PR DESCRIPTION
## Summary

Queue-typed fields fail to compile on the current main. The variable-initialization change in #878 renders every field as a value-initialized member (`Type x{}`) and moves the real initializer into a constructor statement, which requires every field type to be default-constructible. `Queue` was introduced in #876 without a default constructor -- `oob_slot` must be supplied at construction because the element shape is not recoverable from the C++ type alone -- so `Queue<PackedArray> q{}` has no matching constructor and the emitted C++ does not build. The two regressions intersected only after both merged, so neither PR's CI observed it.

The fix adds the sentinel default constructor `Queue() = default;`, exactly mirroring `DynamicArray`, which already carries one for the same role: an empty container with a default-constructed OOB slot that serves as the declared default state of a field until the first MIR-level assignment overwrites it (LRM 10.5).

## Testing

`cpp.queue_basic_type` and `cpp.queue_locator_methods` already exercise queue field declarations and were the failing cases; both pass with the fix. Full `bazel test //...` is green.