### PR TITLE
Add queue indexing and native methods

### DIFF
--- a/docs/decisions/value-assignment-and-moved-from.md
+++ b/docs/decisions/value-assignment-and-moved-from.md
@@ -1,0 +1,99 @@
+# Assignment and Moved-From Contract for Shape-Bearing Value Types
+
+## Date
+
+2026-06-17
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+`integral-representation.md` decided that an integral's shape -- `bit_width`, `signedness`,
+4-state-ness, and packed `dims` -- lives as runtime fields on one `lyra::value::PackedArray` rather
+than in C++ template parameters (a real design had ~10k integral variations, so templating
+explodes). That makes `PackedArray` a "fat" value: it carries its own type description. A fat value
+plays two roles at once -- a SystemVerilog value with SV assignment semantics, and an ordinary C++
+object that STL containers (`queue` over `std::deque`, dynamic array over `std::vector`) relocate
+with move / copy / assignment. Those two roles pull in opposite directions on `operator=`, and
+leaving the conflict unstated produced two concrete bugs: a crash when inserting into a queue, and
+silent corruption of `logic [3:0][7:0] arr = '{4{8'hAB}}` where `arr[0]` read `1` instead of `0xAB`.
+This record fixes what assignment means and what a moved-from object is.
+
+## Findings that shaped the design
+
+### F1. Shape is type information, not value content
+
+Of everything a `PackedArray` carries, only the value bit-plane (and, for 4-state, the X/Z plane) is
+the _value_. `bit_width`, `signedness`, 4-state-ness, and `dims` are the _declared type_, fixed when
+the variable is constructed. A SystemVerilog variable keeps its declared type across assignment
+(LRM: the right-hand side is coerced to the left-hand variable's type), so assignment must
+**preserve the destination's shape and copy only the bits in**. This is the explicit, dims-inclusive
+form of `integral-representation.md`'s consequence that "the destination's
+`(bit_width, is_signed, is_four_state)` drives" a conversion.
+
+### F2. A vector's size is value; a packed array's width is type
+
+The instructive contrast is `std::vector`: its size is genuine value state, so `v1 = v2` adopts
+`v2`'s size, and pure C++ value semantics are correct. A `PackedArray`'s width / dims are _not_
+value state -- they are the variable's fixed type -- so assignment must preserve them, not adopt the
+source's. This one difference is the whole reason `operator=` cannot be a plain value adopt.
+
+### F3. STL relocation requires a valid moved-from object
+
+`std::deque::insert` / `std::vector::insert` / `erase` relocate elements by move-constructing one
+slot and then move-assigning into the vacated slot. The move-assignment reads and writes the
+destination's storage. So a moved-from `PackedArray` must remain a fully formed value -- valid
+storage of its width, and its `dims` intact -- not an empty husk. A defaulted move that keeps
+`bit_width_` but steals the storage and dims leaves an object that crashes the next assignment into
+it (`BitView` over zero words) and, if it survives, indexes at the wrong granularity.
+
+### F4. Rejected: make `operator=` a pure C++ value adopt
+
+The tempting "clean" move is to default `operator=` to adopt the source entirely, so `PackedArray`
+becomes trivially STL-safe. Rejected: adopt copies the source's `dims`, destroying the destination
+variable's declared structure. `logic [3:0][7:0] arr = '{4{8'hAB}}` assigns a flat 32-bit value
+whose dims are `[32]`; adopt replaces `arr`'s `[4][8]` dims with `[32]`, so `arr[0]` extracts a
+single bit. Pure value-adopt fights the fat-value model and is wrong for SV variable assignment. (A
+"thin value" model -- bits only, shape as compile-time type, backend emits per-type indexing --
+would make adopt correct, but that is the LLVM lowering's representation, not the C++ backend's; see
+`integral-representation.md` F6. It is explicitly out of scope here.)
+
+## Decision
+
+`lyra::value` shape-bearing value types (`PackedArray` first; the same contract governs any future
+value type whose shape is declared rather than value-derived) follow these invariants:
+
+1. **Assignment preserves the destination's shape.** `operator=` (copy and move) routes through
+   `AssignFrom`, which keeps this object's `bit_width` / `signedness` / 4-state / `dims` and copies
+   the source's bit-planes in. It is deliberately NOT a pure C++ value adopt.
+2. **Construction adopts the source's shape.** Copy / move constructors take the source's shape,
+   because a freshly constructed object has no declared shape to preserve.
+3. **A moved-from object is a valid value of the same shape**, never an empty husk: the move
+   constructor keeps the source's `dims` and rebuilds its storage to the canonical zero of its
+   width. This is the property that makes the type safe inside STL containers; it is the
+   C++-mechanics half of the `LyraValue` concept (`std::copyable`) asserted on every value type. The
+   concept is a relocation-safety guarantee, not a claim that assignment is value-adopt.
+4. **Cross-shape coercion is an explicit `ConvertFrom`, not assignment.** When a value must change
+   width / state to reach the destination's shape, the lowering emits `PackedArray::ConvertFrom`
+   ahead of the store; `AssignFrom` then runs same-shape and asserts (`ExpectSameShape`) that the
+   conversion was in fact emitted. A shape mismatch reaching `AssignFrom` is a compiler bug, not a
+   user error.
+5. **In-container reordering uses `swap`, not assignment.** `sort` / `rsort` / `reverse` move
+   elements structurally, which adopts shape and is correct; the ADL `swap` friend is that
+   primitive, kept distinct from the shape-preserving `operator=`.
+
+## Consequences
+
+- Queue and dynamic-array `insert` / `erase` / `push` / `pop` use plain STL container operations; no
+  per-container element-shuffling workaround is needed for move safety. The fix lives once, in the
+  value type's move constructor.
+- `operator=` is intentionally not pure C++ value semantics. This is documented on the type so STL
+  code and readers are not surprised that assignment throws on a shape mismatch and ignores the
+  source's declared shape.
+- The shape-mismatch assertion in `AssignFrom` is the safety net for a lowering that forgets a
+  `ConvertFrom`; it is intentionally kept even though correct lowering never triggers it.
+- A future LLVM backend renders the same MIR assignment as an explicit convert followed by a store;
+  the C++ backend's `ConvertFrom` + same-shape `AssignFrom` split is that backend's lowering of the
+  identical semantics, consistent with `integral-representation.md` F6.

--- a/include/lyra/hir/method.hpp
+++ b/include/lyra/hir/method.hpp
@@ -80,6 +80,21 @@ enum class ArrayMethodKind : std::uint8_t {
   kUniqueIndex,
 };
 
+// LRM 7.10.2 queue-native methods. These are exclusive to the queue container
+// (no dynamic-array / fixed-unpacked analogue): they mutate the receiver in
+// place, and `pop_front` / `pop_back` also return the removed element. The
+// LRM 7.12 ordering / reduction / locator family that queues share with the
+// other unpacked arrays stays in `ArrayMethodKind`.
+enum class QueueMethodKind : std::uint8_t {
+  kSize,
+  kInsert,
+  kDelete,
+  kPopFront,
+  kPopBack,
+  kPushFront,
+  kPushBack,
+};
+
 // LRM 7.12.4 iterator intrinsic methods (only `index` is in scope today;
 // extends naturally if SV adds more iterator methods).
 enum class IteratorMethodKind : std::uint8_t {
@@ -89,7 +104,7 @@ enum class IteratorMethodKind : std::uint8_t {
 struct BuiltinMethodRef {
   std::variant<
       EnumMethodKind, StringMethodKind, EventMethodKind, ArrayMethodKind,
-      IteratorMethodKind>
+      QueueMethodKind, IteratorMethodKind>
       method;
 };
 

--- a/include/lyra/lowering/ast_to_hir/expression/slang_atoms.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/slang_atoms.hpp
@@ -52,6 +52,9 @@ auto LowerStringMethodName(std::string_view name)
 auto LowerArrayMethodName(std::string_view name)
     -> std::optional<hir::ArrayMethodKind>;
 
+auto LowerQueueMethodName(std::string_view name)
+    -> std::optional<hir::QueueMethodKind>;
+
 // Recover the original user-written rhs from slang's compound expansion:
 // slang lowers `lhs op= e` to `right = Conv(lhs.type) { BinaryOp(op) {
 // Conv(common, LValueRef), Conv(common, e) } }`. This helper peels the

--- a/include/lyra/mir/builtin_method.hpp
+++ b/include/lyra/mir/builtin_method.hpp
@@ -75,6 +75,19 @@ enum class ArrayMethodKind : std::uint8_t {
   kUniqueIndex,
 };
 
+// LRM 7.10.2 queue-native methods. Exclusive to the queue container: they
+// mutate the receiver, and `pop_front` / `pop_back` also return the removed
+// element. The shared LRM 7.12 family stays in `ArrayMethodKind`.
+enum class QueueMethodKind : std::uint8_t {
+  kSize,
+  kInsert,
+  kDelete,
+  kPopFront,
+  kPopBack,
+  kPushFront,
+  kPushBack,
+};
+
 // Side-effect-free queries that are defined for every runtime value type
 // (string, packed integral, unpacked array, ...). The receiver's MIR type
 // alone determines the emit shape; lowering passes the operand uniformly.
@@ -107,6 +120,10 @@ struct ArrayMethodInfo {
   ArrayMethodKind kind;
 };
 
+struct QueueMethodInfo {
+  QueueMethodKind kind;
+};
+
 struct ValueMethodInfo {
   ValueMethodKind kind;
 };
@@ -125,7 +142,7 @@ struct IteratorMethodInfo {
 struct BuiltinMethodCallee {
   std::variant<
       EnumMethodInfo, StringMethodInfo, EventMethodInfo, ArrayMethodInfo,
-      ValueMethodInfo, IteratorMethodInfo>
+      QueueMethodInfo, ValueMethodInfo, IteratorMethodInfo>
       method;
 };
 

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -15,6 +15,7 @@
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/queue.hpp"
+#include "lyra/value/value_concept.hpp"
 
 namespace lyra::value {
 
@@ -630,5 +631,7 @@ struct Formatter<DynamicArray<T>> {
     return out;
   }
 };
+
+static_assert(LyraValue<DynamicArray<PackedArray>>);
 
 }  // namespace lyra::value

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "lyra/value/packed.hpp"
+#include "lyra/value/value_concept.hpp"
 
 namespace lyra::value {
 
@@ -225,25 +226,24 @@ class PackedArray {
   [[nodiscard]] auto AsLogicView() -> LogicView;
   [[nodiscard]] auto AsLogicView() const -> ConstLogicView;
 
-  // Width-aware copy. The destination's attributes drive sign-extension,
-  // zero-extension, or truncation as appropriate.
-  auto AssignFrom(const PackedArray& other) -> void;
-
-  // Variable assignment in SystemVerilog preserves the destination's declared
-  // shape; the producer is expected to insert any width/state conversion (the
-  // cpp backend lowers slang's ConversionExpr into PackedArray::ConvertFrom).
-  // Both copy- and move-assignment route through AssignFrom, which throws
-  // InternalError on shape mismatch. This makes "(target = value)" the single
-  // emit shape for variable assignment and surfaces any missing conversion as
-  // a backend bug rather than silently relayout-ing the destination.
-  // Construction (copy/move ctor) does the opposite: a freshly-constructed
-  // PackedArray adopts the source's shape, since there is no declared shape
-  // to preserve.
+  // Construction adopts the source's shape (a fresh object has no declared
+  // shape to preserve). Assignment is the opposite -- it preserves this
+  // variable's declared shape via AssignFrom, because a SystemVerilog variable
+  // keeps its type across assignment. The move constructor leaves the source a
+  // valid zero-of-the-same-shape (not an empty husk), so PackedArray relocates
+  // correctly inside STL containers (queue / vector / deque insert and erase).
   PackedArray(const PackedArray&) = default;
-  PackedArray(PackedArray&&) noexcept = default;
+  PackedArray(PackedArray&& other) noexcept;
   auto operator=(const PackedArray& other) -> PackedArray&;
   auto operator=(PackedArray&& other) noexcept(false) -> PackedArray&;
   ~PackedArray() = default;
+
+  // Width-aware copy preserving THIS object's shape. The shape
+  // (bit_width / signedness / 4-state / dims) is declared type information
+  // fixed at construction; assignment keeps it and copies the source's bits
+  // in (docs/decisions/integral-representation.md). ExpectSameShape guards a
+  // missing upstream ConvertFrom.
+  auto AssignFrom(const PackedArray& other) -> void;
 
   // Storage-level swap, bypassing AssignFrom's shape-preservation rule.
   // Found by ADL so STL element-relocation primitives (`std::ranges::sort`,
@@ -586,5 +586,7 @@ class PackedArrayRef {
   std::uint32_t bit_width_;
   std::vector<PackedRange> dims_;
 };
+
+static_assert(LyraValue<PackedArray>);
 
 }  // namespace lyra::value

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -1,12 +1,15 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <deque>
 #include <span>
 #include <string>
 #include <utility>
 
 #include "lyra/value/format.hpp"
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/value_concept.hpp"
 
 namespace lyra::value {
 
@@ -70,7 +73,94 @@ class Queue {
     data_.clear();
   }
 
+  // LRM 7.10.1 / 7.4.5: an index outside 0..size-1 (or carrying x/z) routes
+  // the access through `oob_slot_`, restored to its canonical default first so
+  // an OOB write lands on the shield and is erased on the next access.
+  // TODO(hankhsu): LRM 7.10.1 makes a write to Q[$+1] a legal append; the
+  // shared read/write `ElementAt` cannot distinguish it from an invalid write,
+  // so that one append corner is deferred (push_back covers the same need).
+  [[nodiscard]] auto ElementAt(const PackedArray& idx) -> T& {
+    if (IsInvalidIndex(idx)) {
+      oob_slot_.ResetToDefault();
+      return oob_slot_;
+    }
+    return data_[static_cast<std::size_t>(idx.ToInt64())];
+  }
+
+  [[nodiscard]] auto ElementAt(const PackedArray& idx) const -> const T& {
+    if (IsInvalidIndex(idx)) {
+      oob_slot_.ResetToDefault();
+      return oob_slot_;
+    }
+    return data_[static_cast<std::size_t>(idx.ToInt64())];
+  }
+
+  // LRM 7.10.2.7 / 7.10.2.6: append / prepend a single element.
+  auto PushBack(const T& item) -> void {
+    data_.push_back(item);
+  }
+  auto PushFront(const T& item) -> void {
+    data_.push_front(item);
+  }
+
+  // LRM 7.10.2.4 / 7.10.2.5: remove and return the first / last element. On an
+  // empty queue the result is the element type's LRM Table 7-1 default (the
+  // canonical seed held by `oob_slot_`) and the queue is left unchanged.
+  auto PopFront() -> T {
+    if (data_.empty()) {
+      oob_slot_.ResetToDefault();
+      return oob_slot_;
+    }
+    T front = std::move(data_.front());
+    data_.pop_front();
+    return front;
+  }
+  auto PopBack() -> T {
+    if (data_.empty()) {
+      oob_slot_.ResetToDefault();
+      return oob_slot_;
+    }
+    T back = std::move(data_.back());
+    data_.pop_back();
+    return back;
+  }
+
+  // LRM 7.10.2.2: insert before `index`. The index is `integer` (4-state) so
+  // x/z, negative, or `> size` is detectable and makes the call a no-op;
+  // `index == size` is a valid append.
+  auto Insert(const PackedArray& index, const T& item) -> void {
+    if (index.HasUnknown()) {
+      return;
+    }
+    const auto v = index.ToInt64();
+    if (v < 0 || static_cast<std::uint64_t>(v) > data_.size()) {
+      return;
+    }
+    data_.insert(data_.begin() + static_cast<std::ptrdiff_t>(v), item);
+  }
+
+  // LRM 7.10.2.3: with no index, clear the queue; with an index, remove that
+  // element. An x/z, negative, or `>= size` index is a no-op.
+  auto Delete() -> void {
+    data_.clear();
+  }
+  auto Delete(const PackedArray& index) -> void {
+    if (IsInvalidIndex(index)) {
+      return;
+    }
+    data_.erase(data_.begin() + static_cast<std::ptrdiff_t>(index.ToInt64()));
+  }
+
  private:
+  [[nodiscard]] auto IsInvalidIndex(const PackedArray& idx) const -> bool {
+    if (idx.HasUnknown()) {
+      return true;
+    }
+    const auto v = idx.ToInt64();
+    return v < 0 || static_cast<std::uint64_t>(v) >=
+                        static_cast<std::uint64_t>(data_.size());
+  }
+
   mutable T oob_slot_;
   std::deque<T> data_;
 };
@@ -93,5 +183,7 @@ struct Formatter<Queue<T>> {
     return out;
   }
 };
+
+static_assert(LyraValue<Queue<PackedArray>>);
 
 }  // namespace lyra::value

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -10,6 +10,7 @@
 
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/unpacked_array.hpp"
+#include "lyra/value/value_concept.hpp"
 
 namespace lyra::value {
 
@@ -247,5 +248,7 @@ class String {
 
   std::string impl_;
 };
+
+static_assert(LyraValue<String>);
 
 }  // namespace lyra::value

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -10,6 +10,7 @@
 #include "lyra/value/array_case_equal.hpp"
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
+#include "lyra/value/value_concept.hpp"
 
 namespace lyra::value {
 
@@ -275,5 +276,7 @@ struct Formatter<UnpackedArray<T>> {
     return out;
   }
 };
+
+static_assert(LyraValue<UnpackedArray<PackedArray>>);
 
 }  // namespace lyra::value

--- a/include/lyra/value/value_concept.hpp
+++ b/include/lyra/value/value_concept.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <concepts>
+
+namespace lyra::value {
+
+// The contract every Lyra runtime value type satisfies so it can live in the
+// STL containers the runtime stores it in (`std::vector` / `std::deque` /
+// `std::map`) and survive their relocation (insert / erase / grow). `std::
+// copyable` requires move- and copy-construction, move- and copy-assignment,
+// and swappability -- and, per the standard library contract it builds on, a
+// moved-from object that remains valid for assignment and destruction. That
+// moved-from validity is the property that actually bites: a value type whose
+// move leaves an unusable husk crashes inside container relocation.
+//
+// This is a C++-mechanics contract, NOT a statement about assignment meaning.
+// For shape-bearing types like `PackedArray`, assignment preserves the
+// destination's declared shape and copies the source's bits in (it is not a
+// pure value adopt); see docs/decisions/integral-representation.md. The
+// concept only guarantees the operations exist and relocation is safe.
+template <typename T>
+concept LyraValue = std::copyable<T>;
+
+}  // namespace lyra::value

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -996,6 +996,61 @@ auto RenderArrayMethodCall(
   return raw_call;
 }
 
+auto QueueMethodMemberName(mir::QueueMethodKind k) -> std::string_view {
+  switch (k) {
+    case mir::QueueMethodKind::kSize:
+      return "Size";
+    case mir::QueueMethodKind::kInsert:
+      return "Insert";
+    case mir::QueueMethodKind::kDelete:
+      return "Delete";
+    case mir::QueueMethodKind::kPopFront:
+      return "PopFront";
+    case mir::QueueMethodKind::kPopBack:
+      return "PopBack";
+    case mir::QueueMethodKind::kPushFront:
+      return "PushFront";
+    case mir::QueueMethodKind::kPushBack:
+      return "PushBack";
+  }
+  throw InternalError("QueueMethodMemberName: unknown kind");
+}
+
+// LRM 7.10.2 queue-native methods. The receiver is arguments[0] and any SV
+// method parameters follow as real C++ arguments, so the overload set on
+// `Queue<T>` resolves arity (`Delete()` vs `Delete(index)`) directly.
+auto RenderQueueMethodCall(
+    const RenderContext& ctx, const mir::CallExpr& call,
+    const mir::QueueMethodInfo& m) -> diag::Result<std::string> {
+  if (call.arguments.empty()) {
+    throw InternalError(
+        "RenderQueueMethodCall: queue method expects a receiver argument");
+  }
+  auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
+  if (!receiver_or) {
+    return std::unexpected(std::move(receiver_or.error()));
+  }
+  std::string args;
+  for (std::size_t i = 1; i < call.arguments.size(); ++i) {
+    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+    if (!arg_or) {
+      return std::unexpected(std::move(arg_or.error()));
+    }
+    if (i != 1) {
+      args += ", ";
+    }
+    args += *arg_or;
+  }
+  const std::string member_call = std::format(
+      "({}).{}({})", *receiver_or, QueueMethodMemberName(m.kind), args);
+  // LRM 7.10.2.1: size() returns an int; wrap the C++ std::size_t in the
+  // runtime integral so it composes with the rest of the value model.
+  if (m.kind == mir::QueueMethodKind::kSize) {
+    return std::format("lyra::value::PackedArray::Int({})", member_call);
+  }
+  return member_call;
+}
+
 // Side-effect-free per-value queries. Dispatch by the receiver's MIR
 // type because the answer is type-static for everything except 4-state
 // integral packed: a string (LRM 6.16) and a byte-element unpacked array
@@ -1108,6 +1163,9 @@ auto RenderCallExpr(
                     [&](const mir::ArrayMethodInfo& m) {
                       return RenderArrayMethodCall(ctx, call, m);
                     },
+                    [&](const mir::QueueMethodInfo& m) {
+                      return RenderQueueMethodCall(ctx, call, m);
+                    },
                     [&](const mir::ValueMethodInfo& m) {
                       return RenderValueMethodCall(ctx, call, m);
                     },
@@ -1191,18 +1249,19 @@ auto RenderCallExpr(
 
 // Indexed element access shared by rvalue `RenderElementSelectExpr` and the
 // lvalue `RenderLhsExpr` ElementSelect arm. `PackedArray`, `UnpackedArray`,
-// and `DynamicArray` expose a symmetric `ElementAt(const PackedArray&)` so
-// the emit string is substrate-agnostic; declared-range translation and
-// `ToInt64` canonicalize inside the runtime type.
+// `DynamicArray`, and `Queue` expose a symmetric `ElementAt(const
+// PackedArray&)` so the emit string is substrate-agnostic; declared-range
+// translation and `ToInt64` canonicalize inside the runtime type.
 auto RenderIndexedElementAccess(
     const mir::Type& base_ty, std::string_view base, std::string_view idx)
     -> std::string {
   if (!std::holds_alternative<mir::PackedArrayType>(base_ty.data) &&
       !std::holds_alternative<mir::UnpackedArrayType>(base_ty.data) &&
-      !std::holds_alternative<mir::DynamicArrayType>(base_ty.data)) {
+      !std::holds_alternative<mir::DynamicArrayType>(base_ty.data) &&
+      !std::holds_alternative<mir::QueueType>(base_ty.data)) {
     throw InternalError(
         "RenderIndexedElementAccess: base type must be PackedArrayType, "
-        "UnpackedArrayType, or DynamicArrayType");
+        "UnpackedArrayType, DynamicArrayType, or QueueType");
   }
   return std::format("({}).ElementAt({})", base, idx);
 }

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -198,9 +198,50 @@ class HirDumper {
         return "or";
       case ArrayMethodKind::kXor:
         return "xor";
+      case ArrayMethodKind::kFind:
+        return "find";
+      case ArrayMethodKind::kFindIndex:
+        return "find_index";
+      case ArrayMethodKind::kFindFirst:
+        return "find_first";
+      case ArrayMethodKind::kFindFirstIndex:
+        return "find_first_index";
+      case ArrayMethodKind::kFindLast:
+        return "find_last";
+      case ArrayMethodKind::kFindLastIndex:
+        return "find_last_index";
+      case ArrayMethodKind::kMin:
+        return "min";
+      case ArrayMethodKind::kMax:
+        return "max";
+      case ArrayMethodKind::kUnique:
+        return "unique";
+      case ArrayMethodKind::kUniqueIndex:
+        return "unique_index";
     }
     throw InternalError(
         "HirDumper::FormatArrayMethodKind: unknown ArrayMethodKind");
+  }
+
+  static auto FormatQueueMethodKind(QueueMethodKind k) -> std::string_view {
+    switch (k) {
+      case QueueMethodKind::kSize:
+        return "size";
+      case QueueMethodKind::kInsert:
+        return "insert";
+      case QueueMethodKind::kDelete:
+        return "delete";
+      case QueueMethodKind::kPopFront:
+        return "pop_front";
+      case QueueMethodKind::kPopBack:
+        return "pop_back";
+      case QueueMethodKind::kPushFront:
+        return "push_front";
+      case QueueMethodKind::kPushBack:
+        return "push_back";
+    }
+    throw InternalError(
+        "HirDumper::FormatQueueMethodKind: unknown QueueMethodKind");
   }
 
   static auto FormatPackedForm(PackedArrayForm f) -> std::string_view {
@@ -635,6 +676,10 @@ class HirDumper {
                       [](ArrayMethodKind k) -> std::string {
                         return std::format(
                             "ArrayMethod \"{}\"", FormatArrayMethodKind(k));
+                      },
+                      [](QueueMethodKind k) -> std::string {
+                        return std::format(
+                            "QueueMethod \"{}\"", FormatQueueMethodKind(k));
                       },
                       [](IteratorMethodKind k) -> std::string {
                         return std::format(

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -207,6 +207,27 @@ auto LowerCallExprProc(
       }
     }
 
+    if (receiver_type.has_value() &&
+        std::holds_alternative<hir::QueueType>(
+            module.Unit().GetType(*receiver_type).data)) {
+      if (auto kind = LowerQueueMethodName(name); kind.has_value()) {
+        // LRM 7.10.2 queue-native methods. The receiver is arguments[0]; any
+        // method parameters (insert's index and item, push's item) follow as
+        // the remaining arguments. These methods take no `with` clause.
+        auto type_id = module.InternType(*call.type, span);
+        if (!type_id) return std::unexpected(std::move(type_id.error()));
+        return hir::Expr{
+            .type = *type_id,
+            .data =
+                hir::CallExpr{
+                    .callee = hir::BuiltinMethodRef{.method = *kind},
+                    .arguments = std::move(arg_ids),
+                },
+            .span = span,
+        };
+      }
+    }
+
     // LRM 7.12.4 `item.index`: slang resolves to a SystemSubroutine with
     // `KnownSystemName::Index`. Only legal inside an array-method `with`
     // body; the call lowers to a `BuiltinMethodRef{IteratorMethodKind::

--- a/src/lyra/lowering/ast_to_hir/expression/slang_atoms.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/slang_atoms.cpp
@@ -244,6 +244,18 @@ auto LowerArrayMethodName(std::string_view name)
   return std::nullopt;
 }
 
+auto LowerQueueMethodName(std::string_view name)
+    -> std::optional<hir::QueueMethodKind> {
+  if (name == "size") return hir::QueueMethodKind::kSize;
+  if (name == "insert") return hir::QueueMethodKind::kInsert;
+  if (name == "delete") return hir::QueueMethodKind::kDelete;
+  if (name == "pop_front") return hir::QueueMethodKind::kPopFront;
+  if (name == "pop_back") return hir::QueueMethodKind::kPopBack;
+  if (name == "push_front") return hir::QueueMethodKind::kPushFront;
+  if (name == "push_back") return hir::QueueMethodKind::kPushBack;
+  return std::nullopt;
+}
+
 auto BareCompoundUserRhs(const slang::ast::Expression& slang_expanded_rhs)
     -> const slang::ast::Expression& {
   // Slang's `convertAssignment` adds at most one outer Conversion when the

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -154,6 +154,26 @@ auto LowerArrayMethodKind(hir::ArrayMethodKind k) -> mir::ArrayMethodKind {
   throw InternalError("LowerArrayMethodKind: unknown hir::ArrayMethodKind");
 }
 
+auto LowerQueueMethodKind(hir::QueueMethodKind k) -> mir::QueueMethodKind {
+  switch (k) {
+    case hir::QueueMethodKind::kSize:
+      return mir::QueueMethodKind::kSize;
+    case hir::QueueMethodKind::kInsert:
+      return mir::QueueMethodKind::kInsert;
+    case hir::QueueMethodKind::kDelete:
+      return mir::QueueMethodKind::kDelete;
+    case hir::QueueMethodKind::kPopFront:
+      return mir::QueueMethodKind::kPopFront;
+    case hir::QueueMethodKind::kPopBack:
+      return mir::QueueMethodKind::kPopBack;
+    case hir::QueueMethodKind::kPushFront:
+      return mir::QueueMethodKind::kPushFront;
+    case hir::QueueMethodKind::kPushBack:
+      return mir::QueueMethodKind::kPushBack;
+  }
+  throw InternalError("LowerQueueMethodKind: unknown hir::QueueMethodKind");
+}
+
 auto LowerIteratorMethodKind(hir::IteratorMethodKind k)
     -> mir::IteratorMethodKind {
   switch (k) {
@@ -449,6 +469,11 @@ auto LowerHirCallExprProc(
                       return {
                           .method = mir::ArrayMethodInfo{
                               .kind = LowerArrayMethodKind(k)}};
+                    },
+                    [&](hir::QueueMethodKind k) -> mir::BuiltinMethodCallee {
+                      return {
+                          .method = mir::QueueMethodInfo{
+                              .kind = LowerQueueMethodKind(k)}};
                     },
                     [&](hir::IteratorMethodKind k) -> mir::BuiltinMethodCallee {
                       return {

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -378,6 +378,11 @@ class MirDumper {
                             "ArrayMethodInfo[kind={}]",
                             static_cast<int>(m.kind));
                       },
+                      [](const QueueMethodInfo& m) -> std::string {
+                        return std::format(
+                            "QueueMethodInfo[kind={}]",
+                            static_cast<int>(m.kind));
+                      },
                       [](const ValueMethodInfo& m) -> std::string {
                         return std::format(
                             "ValueMethodInfo[kind={}]",

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -351,6 +351,23 @@ auto PackedArray::AsLogicView() const -> ConstLogicView {
   return lv->View();
 }
 
+// A moved-from PackedArray must stay a fully formed value of the same shape,
+// not an empty husk: STL relocation (deque / vector insert / erase)
+// move-constructs an element and then assigns into the vacated slot, and
+// AssignFrom requires valid storage and dims on its destination. So the source
+// keeps its dims (copied, not moved) and its storage is rebuilt to the
+// canonical zero of its width. ResetToDefault can allocate for wide values; on
+// allocation failure the noexcept move terminates, which is the codebase's
+// treatment of OOM anyway.
+PackedArray::PackedArray(PackedArray&& other) noexcept
+    : bit_width_(other.bit_width_),
+      is_signed_(other.is_signed_),
+      is_four_state_(other.is_four_state_),
+      storage_(std::move(other.storage_)),
+      dims_(other.dims_) {
+  other.ResetToDefault();
+}
+
 auto PackedArray::operator=(const PackedArray& other) -> PackedArray& {
   if (this != &other) {
     AssignFrom(other);

--- a/tests/cases/cpp/queue_indexing/case.yaml
+++ b/tests/cases/cpp/queue_indexing/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.queue_indexing
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q: [10, 99, 30]
+    a: 10
+    b: 99
+    oob: 0

--- a/tests/cases/cpp/queue_indexing/main.sv
+++ b/tests/cases/cpp/queue_indexing/main.sv
@@ -1,0 +1,13 @@
+module Top;
+  int q [$] = '{10, 20, 30};
+  int a;
+  int b;
+  int oob;
+
+  initial begin
+    a = q[0];
+    q[1] = 99;
+    b = q[1];
+    oob = q[5];
+  end
+endmodule

--- a/tests/cases/cpp/queue_methods/case.yaml
+++ b/tests/cases/cpp/queue_methods/case.yaml
@@ -1,0 +1,18 @@
+id: cpp.queue_methods
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q: [1, 9, 3]
+    sz: 5
+    pf: 0
+    pb: 4
+    pe: 0
+    eq: []
+    cq: []
+    badq: [1, 2]

--- a/tests/cases/cpp/queue_methods/main.sv
+++ b/tests/cases/cpp/queue_methods/main.sv
@@ -1,0 +1,32 @@
+module Top;
+  int q [$] = '{1, 2, 3};
+  int sz;
+  int pf;
+  int pb;
+
+  // pop on an empty queue returns the element default (LRM 7.10.2.4 / 7.10.2.5).
+  int eq [$];
+  int pe;
+
+  // delete() with no index clears the queue (LRM 7.10.2.3).
+  int cq [$] = '{7, 8};
+
+  // An invalid insert index is a no-op (LRM 7.10.2.2).
+  int badq [$] = '{1, 2};
+
+  initial begin
+    q.push_back(4);
+    q.push_front(0);
+    sz = q.size();
+    pf = q.pop_front();
+    pb = q.pop_back();
+    q.insert(1, 9);
+    q.delete(2);
+
+    pe = eq.pop_front();
+
+    cq.delete();
+
+    badq.insert(99, 5);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Brings the SystemVerilog queue (`int q[$]`) up to a usable container: element indexing `q[i]` for read and write with the LRM 7.10.1 / 7.4.5 out-of-range shield, plus the LRM 7.10.2 native methods `size`, `insert`, `delete`, `pop_front`, `pop_back`, `push_front`, and `push_back`. The queue-native methods get their own `QueueMethodKind` dispatch family alongside the existing builtin-method families because they mutate the receiver and have no dynamic-array analogue; the shared LRM 7.12 ordering / reduction / locator family stays in `ArrayMethodKind`.

## Design

Implementing queue insert / erase surfaced a latent defect in `PackedArray`: its move constructor left a moved-from object that was invalid for assignment (width retained, storage stolen), so relocation inside `std::deque` / `std::vector` crashed. The fix keeps the deliberate "fat value" design (one `PackedArray` carrying its shape at runtime, per `integral-representation.md`) and pins down the assignment contract: assignment preserves the destination's declared shape and copies the source's bits in via `AssignFrom`, construction adopts the source's shape, and a moved-from object stays a valid zero of the same shape so it relocates safely. A new `LyraValue` concept (`std::copyable`) is asserted on every runtime value type to enforce relocation-safety going forward. The full reasoning, the rejected pure-adopt alternative (which corrupts packed `dims` and broke `logic [3:0][7:0] arr = '{4{8'hAB}}`), and the relationship to a future LLVM backend are recorded in `docs/decisions/value-assignment-and-moved-from.md`.

## Testing

`bazel test //...` is green. New end-to-end cases cover queue indexing (in-bounds read / write plus an out-of-range read returning the element default) and the full native-method family, including empty-queue pop returning the default, a no-op invalid insert, and `delete()` clearing the queue.
