### PR TITLE
Move coroutine-return decision from render context onto MIR ReturnStmt

### DIFF
--- a/include/lyra/backend/cpp/render_context.hpp
+++ b/include/lyra/backend/cpp/render_context.hpp
@@ -24,43 +24,24 @@ class RenderContext {
 
   [[nodiscard]] auto WithProceduralScope(
       const mir::ProceduralScope& child) const -> RenderContext {
-    return RenderContext{
-        *unit_,        *scope_,      child, this, structural_parent_,
-        static_frame_, in_coroutine_};
+    return RenderContext{*unit_,       *scope_, child, this, structural_parent_,
+                         static_frame_};
   }
 
   [[nodiscard]] auto WithStructuralScope(
       const mir::StructuralScope& child_scope,
       const mir::ProceduralScope& root_proc_scope) const -> RenderContext {
-    return RenderContext{*unit_, child_scope, root_proc_scope, nullptr, this,
-                         {},     false};
+    return RenderContext{*unit_,  child_scope, root_proc_scope,
+                         nullptr, this,        {}};
   }
 
   // A subroutine body renders its static locals through this per-instance frame
   // member (LRM 13.3.1). Empty when the current callable has no static locals.
   [[nodiscard]] auto WithStaticFrame(std::string_view accessor) const
       -> RenderContext {
-    return RenderContext{*unit_,
-                         *scope_,
-                         *proc_scope_,
-                         procedural_parent_,
-                         structural_parent_,
-                         accessor,
-                         in_coroutine_};
-  }
-
-  // Marks the current body as a coroutine (a process or a task), where `return`
-  // is spelled `co_return`. A function body leaves this false and uses plain
-  // `return`.
-  [[nodiscard]] auto WithCoroutine(bool in_coroutine) const -> RenderContext {
     return RenderContext{
-        *unit_,
-        *scope_,
-        *proc_scope_,
-        procedural_parent_,
-        structural_parent_,
-        static_frame_,
-        in_coroutine};
+        *unit_,  *scope_, *proc_scope_, procedural_parent_, structural_parent_,
+        accessor};
   }
 
   RenderContext(const RenderContext&) = delete;
@@ -111,10 +92,6 @@ class RenderContext {
     return static_frame_;
   }
 
-  [[nodiscard]] auto InCoroutine() const -> bool {
-    return in_coroutine_;
-  }
-
   [[nodiscard]] auto Expr(mir::ExprId id) const -> const mir::Expr& {
     return proc_scope_->GetExpr(id);
   }
@@ -134,15 +111,13 @@ class RenderContext {
       const mir::CompilationUnit& unit, const mir::StructuralScope& scope,
       const mir::ProceduralScope& proc_scope,
       const RenderContext* procedural_parent,
-      const RenderContext* structural_parent, std::string_view static_frame,
-      bool in_coroutine)
+      const RenderContext* structural_parent, std::string_view static_frame)
       : unit_(&unit),
         scope_(&scope),
         proc_scope_(&proc_scope),
         procedural_parent_(procedural_parent),
         structural_parent_(structural_parent),
-        static_frame_(static_frame),
-        in_coroutine_(in_coroutine) {
+        static_frame_(static_frame) {
   }
 
   const mir::CompilationUnit* unit_;
@@ -151,7 +126,6 @@ class RenderContext {
   const RenderContext* procedural_parent_;
   const RenderContext* structural_parent_;
   std::string_view static_frame_;
-  bool in_coroutine_ = false;
 };
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/lowering/hir_to_mir/walk_frame.hpp
+++ b/include/lyra/lowering/hir_to_mir/walk_frame.hpp
@@ -83,6 +83,14 @@ struct WalkFrame {
   std::optional<mir::ProceduralVarId> self_binding;
   ProceduralDepth self_decl_depth{};
 
+  // Whether the enclosing callable body suspends -- a process, a task, or a
+  // closure synthesized to run as a separate concurrent process (fork branch).
+  // Set at body entry and inherited unchanged through nested procedural scopes;
+  // a closure entry re-establishes it from the closure's own `is_coroutine`.
+  // The `ReturnStmt` lowering reads this to fill the stmt's
+  // `is_coroutine_return` attribute (a C++ render hint, ignored by LIR / LLVM).
+  bool is_coroutine_body = false;
+
   // How a `LoopVarRef` resolves in `StructuralScopeLowerer::LowerExpr`. Set
   // by the caller before dispatching a constructor expression. The default
   // (`kStructuralParam`) matches the common generate-control / continuous
@@ -142,6 +150,12 @@ struct WalkFrame {
     WalkFrame next = *this;
     next.self_binding = id;
     next.self_decl_depth = decl_depth;
+    return next;
+  }
+
+  [[nodiscard]] auto WithCoroutineBody(bool is_coroutine) const -> WalkFrame {
+    WalkFrame next = *this;
+    next.is_coroutine_body = is_coroutine;
     return next;
   }
 };

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -160,10 +160,13 @@ struct ContinueStmt {};
 
 // LRM 13.4.1 `return [expr];`. `value` carries the returned expression for a
 // value-returning function; it is absent for `return;` and for void functions
-// / tasks. MIR keeps the structured statement; the backend renders it as a
-// C++ `return`.
+// / tasks. The semantic concept is one across all consumers (LRM, LIR, LLVM
+// `ret`); `is_coroutine_return` is a render hint for the C++ backend only,
+// distinguishing `co_return` from plain `return`. HIR-to-MIR sets it from the
+// enclosing callable's `is_coroutine`; LIR / LLVM ignore it.
 struct ReturnStmt {
   std::optional<ExprId> value;
+  bool is_coroutine_return = false;
 };
 
 // One leaf entry of a wait's projection set. Identity-only: which structural

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -114,8 +114,7 @@ auto RenderProcessMethod(
            ? RenderContext::ForRoot(unit, s, process.root_procedural_scope)
            : parent_struct_ctx->WithStructuralScope(
                  s, process.root_procedural_scope))
-          .WithStaticFrame(frame_field)
-          .WithCoroutine(true);
+          .WithStaticFrame(frame_field);
 
   std::string out;
   // LRM 6.21 / 9.3.4 static body locals: one per-instance frame member,
@@ -211,8 +210,7 @@ auto RenderSubroutineMethod(
            ? RenderContext::ForRoot(unit, s, sub.root_procedural_scope)
            : parent_struct_ctx->WithStructuralScope(
                  s, sub.root_procedural_scope))
-          .WithStaticFrame(frame_field)
-          .WithCoroutine(is_task);
+          .WithStaticFrame(frame_field);
 
   std::string out;
   // LRM 13.3.1 static locals: one per-instance frame member, default-evaluated

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1659,13 +1659,8 @@ auto RenderClosureExpr(
     return_clause = " -> " + *ret_ty_or;
   }
 
-  // The closure's coroutine-ness comes from MIR; every closure flowing
-  // through this path (NBA / `$strobe` / `$sscanf` IIFE / with-clause /
-  // deferred check) has `is_coroutine = false`, but the render reads the
-  // flag rather than assuming.
   const RenderContext body_ctx =
-      RenderContext::ForRoot(ctx.Unit(), ctx.StructuralScope(), *closure.body)
-          .WithCoroutine(closure.is_coroutine);
+      RenderContext::ForRoot(ctx.Unit(), ctx.StructuralScope(), *closure.body);
   auto body_or = RenderProceduralScopeStatements(body_ctx, 1);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
 

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -178,12 +178,8 @@ auto RenderForkStmtNode(
       params += *type_or + ref_marker + bind.name;
       args += arg;
     }
-    // The branch closure's coroutine-ness comes from MIR (HIR-to-MIR sets
-    // `is_coroutine = true` on every fork-branch ClosureExpr); the render
-    // does not hardcode the assumption.
     const RenderContext branch_ctx =
-        fork_ctx.WithProceduralScope(*closure->body)
-            .WithCoroutine(closure->is_coroutine);
+        fork_ctx.WithProceduralScope(*closure->body);
     auto body_or = RenderProceduralScopeStatements(branch_ctx, indent + 2);
     if (!body_or) return std::unexpected(std::move(body_or.error()));
     out += Indent(indent + 1) + vec + ".push_back([](" + params +
@@ -479,10 +475,11 @@ auto RenderStmt(
             return Indent(indent) + "continue;\n";
           },
           [&](const mir::ReturnStmt& s) -> diag::Result<std::string> {
-            // A task body is a coroutine, so its early `return` is
-            // `co_return`; a task carries no return value (LRM 13.3). A
-            // function body is a plain method.
-            if (ctx.InCoroutine()) {
+            // The `is_coroutine_return` attribute (set at HIR-to-MIR from the
+            // enclosing callable's coroutine-ness, mir/stmt.hpp) is a C++
+            // render hint -- LIR / LLVM ignore it. A task's `return` is
+            // `co_return` and carries no value (LRM 13.3 / 13.4.1).
+            if (s.is_coroutine_return) {
               return Indent(indent) + "co_return;\n";
             }
             if (!s.value.has_value()) {

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -236,10 +236,12 @@ auto BuildArrayMethodClosure(
           .declaration_procedural_depth = body_depth, .var = item_binding});
 
   CaptureSink sink{body_depth, body_scope, outer_scope};
-  const WalkFrame closure_frame =
-      body_frame.WithClosure(&sink)
-          .WithIndexBinding(index_binding)
-          .WithSelfBinding(self_binding, body_depth);
+  // A with-clause body is a synchronous predicate / projection closure -- it
+  // never suspends; its trailing `return` renders as a plain `return`.
+  const WalkFrame closure_frame = body_frame.WithClosure(&sink)
+                                      .WithIndexBinding(index_binding)
+                                      .WithSelfBinding(self_binding, body_depth)
+                                      .WithCoroutineBody(false);
 
   auto body_expr_or = process.LowerExpr(
       hir_process.exprs.at(with_clause.expr.value), closure_frame);

--- a/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
@@ -232,8 +232,11 @@ auto LowerScanSystemSubroutineCall(
                   .var = *frame.self_binding},
           .type = self_ptr_type});
   CaptureSink sink{body_frame.procedural_depth, body, outer_scope};
-  const WalkFrame closure_frame = body_frame.WithClosure(&sink).WithSelfBinding(
-      self_binding, body_frame.procedural_depth);
+  // The scan IIFE is a synchronous body that returns a count -- no suspends.
+  const WalkFrame closure_frame =
+      body_frame.WithClosure(&sink)
+          .WithSelfBinding(self_binding, body_frame.procedural_depth)
+          .WithCoroutineBody(false);
 
   // Source / format are rvalues inside the body. The leaf lowering routes
   // procedural-var leaves through the sink, producing body-side bindings.

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -188,7 +188,8 @@ auto LowerStraightLineProcess(
   const WalkFrame body_frame =
       frame.WithProceduralScope(&process_scope)
           .WithStaticFrameScope(&process_scope)
-          .WithSelfBinding(self_id, frame.procedural_depth);
+          .WithSelfBinding(self_id, frame.procedural_depth)
+          .WithCoroutineBody(true);
   auto lowered = LowerStraightLineBodyInto(process, body_frame);
   if (!lowered) return std::unexpected(std::move(lowered.error()));
   return mir::Process{
@@ -221,6 +222,7 @@ auto LowerForeverProcess(
         frame.WithStaticFrameScope(&process_scope)
             .WithProceduralScope(&body_scope)
             .WithSelfBinding(self_id, frame.procedural_depth)
+            .WithCoroutineBody(true)
             .Deeper();
     auto lowered = LowerStraightLineBodyInto(process, body_frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
@@ -304,10 +306,14 @@ auto ProcessLowerer::Run(
   const mir::ProceduralVarId self_id = body_scope.AddProceduralVar(
       mir::ProceduralVarDecl{
           .name = "self", .type = module_->Unit().builtins.self_pointer});
+  // A task body suspends on timing controls and renders as a coroutine; a
+  // function body executes synchronously.
+  const bool body_is_coroutine = src.kind == hir::SubroutineKind::kTask;
   const WalkFrame body_frame =
       parent_frame.WithProceduralScope(&body_scope)
           .WithStaticFrameScope(&body_scope)
-          .WithSelfBinding(self_id, parent_frame.procedural_depth);
+          .WithSelfBinding(self_id, parent_frame.procedural_depth)
+          .WithCoroutineBody(body_is_coroutine);
 
   // Formals are procedural vars of the body with no VarDeclStmt: pre-register
   // them in the body scope at depth 0 so the body's references resolve. The
@@ -368,7 +374,10 @@ auto ProcessLowerer::Run(
   if (result_ref.has_value()) {
     const mir::ExprId result_read =
         body_scope.AddExpr(mir::Expr{.data = *result_ref, .type = result_type});
-    body_scope.AppendStmt(mir::ReturnStmt{.value = result_read});
+    body_scope.AppendStmt(
+        mir::ReturnStmt{
+            .value = result_read,
+            .is_coroutine_return = body_frame.is_coroutine_body});
   }
 
   return mir::StructuralSubroutineDecl{

--- a/src/lyra/lowering/hir_to_mir/statement/flow.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/flow.cpp
@@ -98,7 +98,9 @@ auto LowerReturnStmt(
     value = proc_scope.AddExpr(*std::move(value_or));
   }
   return mir::Stmt{
-      .label = std::move(label), .data = mir::ReturnStmt{.value = value}};
+      .label = std::move(label),
+      .data = mir::ReturnStmt{
+          .value = value, .is_coroutine_return = frame.is_coroutine_body}};
 }
 
 auto LowerBreakStmt(std::optional<std::string> label)

--- a/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
@@ -80,11 +80,14 @@ auto LowerForkStmt(
 
     CaptureSink sink{
         fork_frame.procedural_depth.Inner(), branch_scope, fork_scope};
+    // LRM 9.3.2 fork branch: each branch is a concurrent thread that may
+    // suspend on timing controls / event waits inside its body.
     const WalkFrame branch_frame =
         fork_frame.WithClosure(&sink)
             .WithProceduralScope(&branch_scope)
             .WithSelfBinding(
                 branch_self_id, fork_frame.procedural_depth.Inner())
+            .WithCoroutineBody(true)
             .Deeper();
     auto lowered = process.LowerStmt(branch, branch_frame);
     if (!lowered) {

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -1087,11 +1087,13 @@ class MirDumper {
               Line(std::format("Stmt[{}] ContinueStmt", id.value));
             },
             [&](const ReturnStmt& s) {
+              const std::string flavor =
+                  s.is_coroutine_return ? " coroutine" : "";
               if (s.value.has_value()) {
                 Line(
                     std::format(
-                        "Stmt[{}] ReturnStmt value=Expr[{}]", id.value,
-                        s.value->value));
+                        "Stmt[{}] ReturnStmt{} value=Expr[{}]", id.value,
+                        flavor, s.value->value));
                 Indent();
                 Line(
                     std::format(
@@ -1099,7 +1101,7 @@ class MirDumper {
                         FormatExpr(enclosing, *s.value)));
                 Dedent();
               } else {
-                Line(std::format("Stmt[{}] ReturnStmt", id.value));
+                Line(std::format("Stmt[{}] ReturnStmt{}", id.value, flavor));
               }
             },
             [&](const SensitivityWaitStmt& s) {


### PR DESCRIPTION
## Summary

`RenderContext::in_coroutine_` was a render-time decision cache -- the C++ emit was looking around to figure out whether a `ReturnStmt` should render as `return` or `co_return`. This change moves the decision onto MIR: `ReturnStmt` gains a `bool is_coroutine_return` attribute set at HIR-to-MIR from the enclosing callable's coroutine-ness. The C++ render now dispatches purely on the stmt itself, with no context lookup.

## Design

MIR's semantic concept of `return` is one shape (matches LRM 13.4.1, future LIR, and LLVM `ret`). Only C++ has two syntactic forms (`return` / `co_return`). The new attribute is labeled honestly as a C++ render hint -- LIR / LLVM lowerings ignore it; the semantic kind is unchanged.

HIR-to-MIR threads coroutine-ness through `WalkFrame::is_coroutine_body`, set at every body entry (process / task body / fork-branch closure as true; function / sync closure body as false) and inherited unchanged through nested procedural scopes. The `ReturnStmt`-producing sites read the frame and stamp the attribute.

On the render side, `RenderContext` loses `in_coroutine_`, `WithCoroutine`, and `InCoroutine`. Stmt rendering for `ReturnStmt` reads `s.is_coroutine_return` directly -- no walk-state, no context dependency. Other render handlers are unchanged.

Bundled fix: `Queue<T>` gains a defaulted constructor so the post-R19 `Queue<T> q{}` field-declaration form compiles -- same pattern applied to `PackedArray`, `UnpackedArray`, and `DynamicArray` in the previous PR.

## Testing

- [x] `bazel test //... --test_output=errors`
- [x] All format / lint / policy checks (clang-format, prettier, buildifier, architecture / ascii / cpp-style / exceptions)