### PR TITLE
Add associative arrays with string and integral keys

### DIFF
--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -30,7 +30,8 @@ follow once dynamic array's storage and runtime conventions are settled and prov
 | DA6c | Open: queue runtime + locator family (find\*, min, max, unique\*).   |
 | DA7  | Open: invalid-index handling.                                        |
 | Q1.. | Not yet scoped: queue.                                               |
-| A1.. | Not yet scoped: associative array.                                   |
+| A1   | Done: string / integral index, element read / write, query methods.  |
+| A2.. | Open: iteration protocol, literals, whole-array assignment.          |
 
 ## Dynamic Array
 
@@ -121,9 +122,24 @@ queue-specific method family (LRM 7.10: `push_back`, `push_front`, `pop_back`, `
 
 ## Associative Array
 
-Not yet scoped. Sub-steps A1.. open when dynamic array's runtime conventions are settled. Key type
-can be any singular type or `string` (LRM 7.8); storage is sparse; the iteration protocol
-(`.first()`, `.next()`, `.exists()` -- LRM 7.9) has no analogue in the other two families.
+LRM 7.8: a sparse lookup table whose entries are allocated on first write. The index data type is
+the lookup key and imposes an ordering.
+
+- [x] A1 -- Type infrastructure plus the core element and query surface for string-indexed (LRM
+      7.8.2, lexicographical order) and integral-indexed (LRM 7.8.4, signed/unsigned numerical
+      order) arrays. Element read returns the element default for a nonexistent or invalid index
+      without allocating (LRM 7.8.6); element write, including the read-modify-write compound form,
+      allocates the entry with the element default first (LRM 7.8.7); an integral index carrying x/z
+      is invalid, so a read returns the default and a write is ignored (LRM 7.8.6). Query methods
+      `num` / `size` / `exists` / `delete` (LRM 7.9.1 -- 7.9.3), with the no-argument `delete`
+      clearing the array. `%p` formatting prints entries in key order (LRM 21.2.1.6).
+
+- [ ] A2 -- The iteration protocol `first` / `last` / `next` / `prev` (LRM 7.9.4 -- 7.9.8), which
+      assigns through a `ref` index out-parameter and has no analogue in the other two families;
+      `foreach` over an associative array (`control-flow.md` C10); associative-array literals with
+      an optional default (LRM 7.9.11) and whole-array associative assignment (LRM 7.9.9); the
+      wildcard `[*]`, class, and other user-defined index families (LRM 7.8.1 / 7.8.3 / 7.8.5); and
+      the locator-family methods that return an index queue of the key type (LRM 7.12.1).
 
 ## Cross-references
 

--- a/include/lyra/hir/method.hpp
+++ b/include/lyra/hir/method.hpp
@@ -95,6 +95,19 @@ enum class QueueMethodKind : std::uint8_t {
   kPushBack,
 };
 
+// LRM 7.9 associative-array methods. Exclusive to the associative container:
+// `num` / `size` query the entry count, `exists` tests a key, and `delete`
+// removes one entry (with index) or clears the array (without). Like the
+// queue-native family they mutate or query the receiver and have no analogue
+// in the other containers; the shared LRM 7.12 family stays in
+// `ArrayMethodKind`.
+enum class AssociativeMethodKind : std::uint8_t {
+  kNum,
+  kSize,
+  kExists,
+  kDelete,
+};
+
 // LRM 7.12.4 iterator intrinsic methods (only `index` is in scope today;
 // extends naturally if SV adds more iterator methods).
 enum class IteratorMethodKind : std::uint8_t {
@@ -104,7 +117,7 @@ enum class IteratorMethodKind : std::uint8_t {
 struct BuiltinMethodRef {
   std::variant<
       EnumMethodKind, StringMethodKind, EventMethodKind, ArrayMethodKind,
-      QueueMethodKind, IteratorMethodKind>
+      QueueMethodKind, AssociativeMethodKind, IteratorMethodKind>
       method;
 };
 

--- a/include/lyra/lowering/ast_to_hir/expression/slang_atoms.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/slang_atoms.hpp
@@ -55,6 +55,9 @@ auto LowerArrayMethodName(std::string_view name)
 auto LowerQueueMethodName(std::string_view name)
     -> std::optional<hir::QueueMethodKind>;
 
+auto LowerAssociativeMethodName(std::string_view name)
+    -> std::optional<hir::AssociativeMethodKind>;
+
 // Recover the original user-written rhs from slang's compound expansion:
 // slang lowers `lhs op= e` to `right = Conv(lhs.type) { BinaryOp(op) {
 // Conv(common, LValueRef), Conv(common, e) } }`. This helper peels the

--- a/include/lyra/mir/builtin_method.hpp
+++ b/include/lyra/mir/builtin_method.hpp
@@ -88,6 +88,17 @@ enum class QueueMethodKind : std::uint8_t {
   kPushBack,
 };
 
+// LRM 7.9 associative-array methods. Exclusive to the associative container:
+// `num` / `size` query the entry count, `exists` tests a key, `delete` removes
+// one entry or clears the array. The shared LRM 7.12 family stays in
+// `ArrayMethodKind`.
+enum class AssociativeMethodKind : std::uint8_t {
+  kNum,
+  kSize,
+  kExists,
+  kDelete,
+};
+
 // Side-effect-free queries that are defined for every runtime value type
 // (string, packed integral, unpacked array, ...). The receiver's MIR type
 // alone determines the emit shape; lowering passes the operand uniformly.
@@ -124,6 +135,10 @@ struct QueueMethodInfo {
   QueueMethodKind kind;
 };
 
+struct AssociativeMethodInfo {
+  AssociativeMethodKind kind;
+};
+
 struct ValueMethodInfo {
   ValueMethodKind kind;
 };
@@ -142,7 +157,8 @@ struct IteratorMethodInfo {
 struct BuiltinMethodCallee {
   std::variant<
       EnumMethodInfo, StringMethodInfo, EventMethodInfo, ArrayMethodInfo,
-      QueueMethodInfo, ValueMethodInfo, IteratorMethodInfo>
+      QueueMethodInfo, AssociativeMethodInfo, ValueMethodInfo,
+      IteratorMethodInfo>
       method;
 };
 

--- a/include/lyra/runtime/prelude.hpp
+++ b/include/lyra/runtime/prelude.hpp
@@ -47,6 +47,7 @@
 #include "lyra/runtime/trigger.hpp"            // IWYU pragma: keep
 #include "lyra/runtime/var.hpp"                // IWYU pragma: keep
 #include "lyra/value/array_case_equal.hpp"     // IWYU pragma: keep
+#include "lyra/value/associative_array.hpp"    // IWYU pragma: keep
 #include "lyra/value/dynamic_array.hpp"        // IWYU pragma: keep
 #include "lyra/value/enum.hpp"                 // IWYU pragma: keep
 #include "lyra/value/format.hpp"               // IWYU pragma: keep

--- a/include/lyra/value/associative_array.hpp
+++ b/include/lyra/value/associative_array.hpp
@@ -1,0 +1,187 @@
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <string>
+#include <utility>
+
+#include "lyra/value/format.hpp"
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/string.hpp"
+#include "lyra/value/value_concept.hpp"
+
+namespace lyra::value {
+
+// Numerical key ordering for integral-indexed associative arrays (LRM 7.8.4):
+// the SystemVerilog `<` operator respects the shared signedness of the index
+// type, so a 1-bit result of 1 means strictly-less. Every key carries the same
+// declared index shape (slang casts each index expression to the index type),
+// so the comparison is total over the keys actually stored.
+struct PackedArrayKeyLess {
+  [[nodiscard]] auto operator()(
+      const PackedArray& a, const PackedArray& b) const -> bool {
+    return static_cast<bool>(a < b);
+  }
+};
+
+template <typename K>
+struct AssocKeyTraits;
+
+// LRM 7.8.2: string keys order lexicographically.
+template <>
+struct AssocKeyTraits<String> {
+  using Less = std::less<String>;
+};
+
+// LRM 7.8.4: integral keys order by signed/unsigned numerical value.
+template <>
+struct AssocKeyTraits<PackedArray> {
+  using Less = PackedArrayKeyLess;
+};
+
+// SystemVerilog associative array (LRM 7.8): a sparse lookup table allocated
+// entry-by-entry. `K` is the index type (`String` for string-indexed arrays,
+// `PackedArray` for integral-indexed arrays) and `V` the element type. Storage
+// is an ordered `std::map` so iteration and `%p` formatting follow the LRM 7.8
+// key ordering and stay deterministic.
+//
+// `oob_slot_` seeds the element default (supplied at construction because
+// `V = PackedArray` carries runtime shape the C++ type cannot recover; see
+// `docs/decisions/runtime-shape-and-default-value.md`). It doubles as the
+// LRM 7.8.6 shield: a read of a nonexistent or invalid index returns it, and a
+// write through an invalid index lands on it and is discarded.
+template <typename K, typename V>
+class AssociativeArray {
+ public:
+  using KeyType = K;
+  using ElementType = V;
+
+  // Sentinel "uninitialized" form -- empty map with a default-constructed OOB
+  // slot, used as the declared default state of an associative field before
+  // the constructor scope seeds the element shape.
+  AssociativeArray() = default;
+
+  // Empty map with the shield slot seeded, used for declarations like
+  // `int m[string];` where the element shape is known at lowering time.
+  explicit AssociativeArray(V oob_slot) : oob_slot_(std::move(oob_slot)) {
+  }
+
+  AssociativeArray(const AssociativeArray&) = default;
+  AssociativeArray(AssociativeArray&&) noexcept = default;
+  auto operator=(const AssociativeArray&) -> AssociativeArray& = default;
+  auto operator=(AssociativeArray&&) noexcept -> AssociativeArray& = default;
+  ~AssociativeArray() = default;
+
+  // LRM 7.9.1: num() and size() both return the number of entries.
+  [[nodiscard]] auto Size() const -> std::size_t {
+    return data_.size();
+  }
+
+  // LRM 7.9.3: an element exists at this key. An invalid integral key never
+  // matches an entry, so it reports absent.
+  [[nodiscard]] auto Exists(const K& key) const -> bool {
+    if (IsInvalidKey(key)) {
+      return false;
+    }
+    return data_.contains(key);
+  }
+
+  // LRM 7.9.2: delete a single entry (no warning if absent) or, via the
+  // no-argument overload, clear the whole array. An invalid key is a no-op.
+  auto Delete(const K& key) -> void {
+    if (IsInvalidKey(key)) {
+      return;
+    }
+    data_.erase(key);
+  }
+  auto Delete() -> void {
+    data_.clear();
+  }
+
+  // LRM Table 6-7: an associative array's default is empty. When this container
+  // is itself the OOB shield slot of an outer container, the outer restores it
+  // to canonical state before handing out a reference.
+  auto ResetToDefault() -> void {
+    data_.clear();
+  }
+
+  // LRM 7.8.6: a read of a nonexistent or invalid index returns the element
+  // default without allocating. The shield slot is restored first so a prior
+  // discarded write does not leak into the result.
+  [[nodiscard]] auto Read(const K& key) const -> const V& {
+    if (IsInvalidKey(key)) {
+      oob_slot_.ResetToDefault();
+      return oob_slot_;
+    }
+    auto it = data_.find(key);
+    if (it == data_.end()) {
+      oob_slot_.ResetToDefault();
+      return oob_slot_;
+    }
+    return it->second;
+  }
+
+  // LRM 7.8.7: a write target allocates the entry with the element default if
+  // absent, then yields a reference the caller stores into. An invalid index
+  // (LRM 7.8.6) yields the shield slot instead, so the write is discarded.
+  [[nodiscard]] auto ElementRef(const K& key) -> V& {
+    if (IsInvalidKey(key)) {
+      oob_slot_.ResetToDefault();
+      return oob_slot_;
+    }
+    auto it = data_.find(key);
+    if (it == data_.end()) {
+      it = data_.emplace(key, oob_slot_).first;
+    }
+    return it->second;
+  }
+
+  template <typename Fn>
+  auto ForEachEntry(const Fn& fn) const -> void {
+    for (const auto& [key, value] : data_) {
+      fn(key, value);
+    }
+  }
+
+ private:
+  [[nodiscard]] auto IsInvalidKey(const K& key) const -> bool {
+    if constexpr (std::same_as<K, PackedArray>) {
+      return key.HasUnknown();
+    } else {
+      return false;
+    }
+  }
+
+  mutable V oob_slot_;
+  std::map<K, V, typename AssocKeyTraits<K>::Less> data_;
+};
+
+// LRM 21.2.1.6 aggregate format: `'{key:value, ...}` in key order. Each key and
+// value defers to its own `Formatter`, so string keys print quoted and integral
+// keys / values print in the element format.
+template <typename K, typename V>
+struct Formatter<AssociativeArray<K, V>> {
+  static auto Format(
+      const FormatSpec& spec, const AssociativeArray<K, V>& value)
+      -> std::string {
+    std::string out = "'{";
+    bool first = true;
+    value.ForEachEntry([&](const K& key, const V& elem) {
+      if (!first) {
+        out += ", ";
+      }
+      first = false;
+      out += lyra::value::Format(spec, MakeFormatArg(key));
+      out += ":";
+      out += lyra::value::Format(spec, MakeFormatArg(elem));
+    });
+    out += "}";
+    return out;
+  }
+};
+
+static_assert(LyraValue<AssociativeArray<String, PackedArray>>);
+static_assert(LyraValue<AssociativeArray<PackedArray, PackedArray>>);
+
+}  // namespace lyra::value

--- a/include/lyra/value/format.hpp
+++ b/include/lyra/value/format.hpp
@@ -14,6 +14,8 @@ template <typename T>
 class DynamicArray;
 template <typename T>
 class Queue;
+template <typename K, typename V>
+class AssociativeArray;
 
 enum class PrintKind : std::uint8_t {
   kDisplay,
@@ -205,6 +207,11 @@ template <typename T>
 template <typename T>
 [[nodiscard]] auto PrintValue(const Queue<T>& value, FormatSpec spec)
     -> PrintItem {
+  return PrintValueItem{.spec = spec, .arg = MakeFormatArg(value)};
+}
+template <typename K, typename V>
+[[nodiscard]] auto PrintValue(
+    const AssociativeArray<K, V>& value, FormatSpec spec) -> PrintItem {
   return PrintValueItem{.spec = spec, .arg = MakeFormatArg(value)};
 }
 

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1051,6 +1051,56 @@ auto RenderQueueMethodCall(
   return member_call;
 }
 
+auto AssociativeMethodMemberName(mir::AssociativeMethodKind k)
+    -> std::string_view {
+  switch (k) {
+    case mir::AssociativeMethodKind::kNum:
+    case mir::AssociativeMethodKind::kSize:
+      return "Size";
+    case mir::AssociativeMethodKind::kExists:
+      return "Exists";
+    case mir::AssociativeMethodKind::kDelete:
+      return "Delete";
+  }
+  throw InternalError("AssociativeMethodMemberName: unknown kind");
+}
+
+// LRM 7.9 associative-array methods. The receiver is arguments[0] and the key
+// (exists / delete-by-index) follows as a real C++ argument, so the overload
+// set on `AssociativeArray<K, V>` resolves arity (`Delete()` vs `Delete(key)`).
+auto RenderAssociativeMethodCall(
+    const RenderContext& ctx, const mir::CallExpr& call,
+    const mir::AssociativeMethodInfo& m) -> diag::Result<std::string> {
+  if (call.arguments.empty()) {
+    throw InternalError(
+        "RenderAssociativeMethodCall: associative method expects a receiver "
+        "argument");
+  }
+  auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
+  if (!receiver_or) {
+    return std::unexpected(std::move(receiver_or.error()));
+  }
+  std::string args;
+  for (std::size_t i = 1; i < call.arguments.size(); ++i) {
+    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+    if (!arg_or) {
+      return std::unexpected(std::move(arg_or.error()));
+    }
+    if (i != 1) {
+      args += ", ";
+    }
+    args += *arg_or;
+  }
+  const std::string member_call = std::format(
+      "({}).{}({})", *receiver_or, AssociativeMethodMemberName(m.kind), args);
+  // LRM 7.9.1 / 7.9.3: num / size / exists yield an int; wrap the C++
+  // std::size_t / bool in the runtime integral. delete returns void.
+  if (m.kind != mir::AssociativeMethodKind::kDelete) {
+    return std::format("lyra::value::PackedArray::Int({})", member_call);
+  }
+  return member_call;
+}
+
 // Side-effect-free per-value queries. Dispatch by the receiver's MIR
 // type because the answer is type-static for everything except 4-state
 // integral packed: a string (LRM 6.16) and a byte-element unpacked array
@@ -1166,6 +1216,9 @@ auto RenderCallExpr(
                     [&](const mir::QueueMethodInfo& m) {
                       return RenderQueueMethodCall(ctx, call, m);
                     },
+                    [&](const mir::AssociativeMethodInfo& m) {
+                      return RenderAssociativeMethodCall(ctx, call, m);
+                    },
                     [&](const mir::ValueMethodInfo& m) {
                       return RenderValueMethodCall(ctx, call, m);
                     },
@@ -1247,21 +1300,33 @@ auto RenderCallExpr(
       call.callee);
 }
 
+enum class ElementAccessMode : std::uint8_t { kRead, kWrite };
+
 // Indexed element access shared by rvalue `RenderElementSelectExpr` and the
 // lvalue `RenderLhsExpr` ElementSelect arm. `PackedArray`, `UnpackedArray`,
 // `DynamicArray`, and `Queue` expose a symmetric `ElementAt(const
 // PackedArray&)` so the emit string is substrate-agnostic; declared-range
 // translation and `ToInt64` canonicalize inside the runtime type.
+//
+// The associative array splits read from write (LRM 7.8.6 / 7.8.7): a read
+// never allocates and returns the element default for a missing key, while a
+// write allocates the entry. The access mode selects `Read` vs `ElementRef`.
 auto RenderIndexedElementAccess(
-    const mir::Type& base_ty, std::string_view base, std::string_view idx)
-    -> std::string {
+    const mir::Type& base_ty, std::string_view base, std::string_view idx,
+    ElementAccessMode mode) -> std::string {
+  if (std::holds_alternative<mir::AssociativeArrayType>(base_ty.data)) {
+    const std::string_view member =
+        mode == ElementAccessMode::kWrite ? "ElementRef" : "Read";
+    return std::format("({}).{}({})", base, member, idx);
+  }
   if (!std::holds_alternative<mir::PackedArrayType>(base_ty.data) &&
       !std::holds_alternative<mir::UnpackedArrayType>(base_ty.data) &&
       !std::holds_alternative<mir::DynamicArrayType>(base_ty.data) &&
       !std::holds_alternative<mir::QueueType>(base_ty.data)) {
     throw InternalError(
         "RenderIndexedElementAccess: base type must be PackedArrayType, "
-        "UnpackedArrayType, DynamicArrayType, or QueueType");
+        "UnpackedArrayType, DynamicArrayType, QueueType, or "
+        "AssociativeArrayType");
   }
   return std::format("({}).ElementAt({})", base, idx);
 }
@@ -1275,7 +1340,8 @@ auto RenderElementSelectExpr(
   auto idx_or = RenderExpr(ctx, ctx.Expr(sel.index));
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const auto& base_ty = ctx.Unit().GetType(base_expr.type);
-  return RenderIndexedElementAccess(base_ty, *base_or, *idx_or);
+  return RenderIndexedElementAccess(
+      base_ty, *base_or, *idx_or, ElementAccessMode::kRead);
 }
 
 // Renders an LHS-shaped expression for use as an assignment target. The
@@ -1318,7 +1384,8 @@ auto RenderLhsExpr(
             auto idx = RenderExpr(ctx, ctx.Expr(s.index));
             if (!idx) return std::unexpected(std::move(idx.error()));
             const auto& base_ty = ctx.Unit().GetType(base_expr.type);
-            return RenderIndexedElementAccess(base_ty, *base, *idx);
+            return RenderIndexedElementAccess(
+                base_ty, *base, *idx, ElementAccessMode::kWrite);
           },
           [&](const mir::RangeSelectExpr& s) -> diag::Result<std::string> {
             auto base =

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -124,7 +124,8 @@ auto RenderPrintValueArg(
       type.Kind() == mir::TypeKind::kString ||
       type.Kind() == mir::TypeKind::kUnpackedArray ||
       type.Kind() == mir::TypeKind::kDynamicArray ||
-      type.Kind() == mir::TypeKind::kQueue) {
+      type.Kind() == mir::TypeKind::kQueue ||
+      type.Kind() == mir::TypeKind::kAssociativeArray) {
     return *operand_or;
   }
   throw InternalError("RenderPrintValueArg: unsupported display operand type");

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -101,6 +101,19 @@ auto RenderTypeAsCpp(
             if (!inner_or) return std::unexpected(std::move(inner_or.error()));
             return "lyra::value::Queue<" + *inner_or + ">";
           },
+          [&](const mir::AssociativeArrayType& a) -> diag::Result<std::string> {
+            if (!a.key_type.has_value()) {
+              throw InternalError(
+                  "RenderTypeAsCpp: associative array with a wildcard index "
+                  "type reached the backend; AST -> HIR rejects it");
+            }
+            auto key_or = RenderTypeAsCpp(unit, owner_scope, *a.key_type);
+            if (!key_or) return std::unexpected(std::move(key_or.error()));
+            auto elem_or = RenderTypeAsCpp(unit, owner_scope, a.element_type);
+            if (!elem_or) return std::unexpected(std::move(elem_or.error()));
+            return "lyra::value::AssociativeArray<" + *key_or + ", " +
+                   *elem_or + ">";
+          },
           [&](const mir::ObjectType& o) -> diag::Result<std::string> {
             return std::string{
                 owner_scope.GetChildStructuralScope(o.target).name};

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -244,6 +244,23 @@ class HirDumper {
         "HirDumper::FormatQueueMethodKind: unknown QueueMethodKind");
   }
 
+  static auto FormatAssociativeMethodKind(AssociativeMethodKind k)
+      -> std::string_view {
+    switch (k) {
+      case AssociativeMethodKind::kNum:
+        return "num";
+      case AssociativeMethodKind::kSize:
+        return "size";
+      case AssociativeMethodKind::kExists:
+        return "exists";
+      case AssociativeMethodKind::kDelete:
+        return "delete";
+    }
+    throw InternalError(
+        "HirDumper::FormatAssociativeMethodKind: unknown "
+        "AssociativeMethodKind");
+  }
+
   static auto FormatPackedForm(PackedArrayForm f) -> std::string_view {
     switch (f) {
       case PackedArrayForm::kExplicit:
@@ -680,6 +697,11 @@ class HirDumper {
                       [](QueueMethodKind k) -> std::string {
                         return std::format(
                             "QueueMethod \"{}\"", FormatQueueMethodKind(k));
+                      },
+                      [](AssociativeMethodKind k) -> std::string {
+                        return std::format(
+                            "AssociativeMethod \"{}\"",
+                            FormatAssociativeMethodKind(k));
                       },
                       [](IteratorMethodKind k) -> std::string {
                         return std::format(

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -228,6 +228,27 @@ auto LowerCallExprProc(
       }
     }
 
+    if (receiver_type.has_value() &&
+        std::holds_alternative<hir::AssociativeArrayType>(
+            module.Unit().GetType(*receiver_type).data)) {
+      if (auto kind = LowerAssociativeMethodName(name); kind.has_value()) {
+        // LRM 7.9 associative-array methods. The receiver is arguments[0]; the
+        // key (exists / delete-by-index) follows as the next argument. The
+        // no-argument `delete` clears the array.
+        auto type_id = module.InternType(*call.type, span);
+        if (!type_id) return std::unexpected(std::move(type_id.error()));
+        return hir::Expr{
+            .type = *type_id,
+            .data =
+                hir::CallExpr{
+                    .callee = hir::BuiltinMethodRef{.method = *kind},
+                    .arguments = std::move(arg_ids),
+                },
+            .span = span,
+        };
+      }
+    }
+
     // LRM 7.12.4 `item.index`: slang resolves to a SystemSubroutine with
     // `KnownSystemName::Index`. Only legal inside an array-method `with`
     // body; the call lowers to a `BuiltinMethodRef{IteratorMethodKind::

--- a/src/lyra/lowering/ast_to_hir/expression/slang_atoms.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/slang_atoms.cpp
@@ -256,6 +256,15 @@ auto LowerQueueMethodName(std::string_view name)
   return std::nullopt;
 }
 
+auto LowerAssociativeMethodName(std::string_view name)
+    -> std::optional<hir::AssociativeMethodKind> {
+  if (name == "num") return hir::AssociativeMethodKind::kNum;
+  if (name == "size") return hir::AssociativeMethodKind::kSize;
+  if (name == "exists") return hir::AssociativeMethodKind::kExists;
+  if (name == "delete") return hir::AssociativeMethodKind::kDelete;
+  return std::nullopt;
+}
+
 auto BareCompoundUserRhs(const slang::ast::Expression& slang_expanded_rhs)
     -> const slang::ast::Expression& {
   // Slang's `convertAssignment` adds at most one outer Conversion when the

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -337,11 +337,33 @@ auto TranslateTypeData(
                            : std::optional<std::uint64_t>{q.maxBound},
       }};
     }
-    case slang::ast::SymbolKind::AssociativeArrayType:
-      return diag::Unsupported(
-          decl_span, diag::DiagCode::kUnsupportedAssociativeArrayType,
-          "associative array types are not supported",
-          diag::UnsupportedCategory::kType);
+    case slang::ast::SymbolKind::AssociativeArrayType: {
+      const auto& aa = canonical.as<slang::ast::AssociativeArrayType>();
+      // LRM 7.8.1 wildcard index (`[*]`) carries no index type and has its own
+      // minimal-length normalization rules; LRM 7.8.3 / 7.8.5 class and other
+      // user-defined indices have their own ordering contracts. Only the string
+      // (LRM 7.8.2) and integral (LRM 7.8.4) index families are in scope.
+      if (aa.indexType == nullptr ||
+          !(aa.indexType->isIntegral() || aa.indexType->isString())) {
+        return diag::Unsupported(
+            decl_span, diag::DiagCode::kUnsupportedAssociativeArrayType,
+            "associative arrays are only supported with a string or integral "
+            "index type",
+            diag::UnsupportedCategory::kType);
+      }
+      auto elem_id_or = module.InternType(aa.elementType, decl_span);
+      if (!elem_id_or) {
+        return std::unexpected(std::move(elem_id_or.error()));
+      }
+      auto key_id_or = module.InternType(*aa.indexType, decl_span);
+      if (!key_id_or) {
+        return std::unexpected(std::move(key_id_or.error()));
+      }
+      return hir::TypeData{hir::AssociativeArrayType{
+          .element_type = *elem_id_or,
+          .key_type = *key_id_or,
+      }};
+    }
     case slang::ast::SymbolKind::UnpackedStructType:
       return diag::Unsupported(
           decl_span, diag::DiagCode::kUnsupportedUnpackedStructType,

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -129,6 +129,17 @@ auto SynthesizeDefaultValueExpr(
                     .data = mir::ConstructExpr{.args = {element_default}},
                     .type = type});
           },
+          // LRM Table 6-7: an associative array's default is empty. The element
+          // default seeds the wrapper's shield slot (the source of nonexistent-
+          // entry reads, LRM 7.8.6) while storage starts empty.
+          [&](const mir::AssociativeArrayType& a) -> mir::ExprId {
+            const mir::ExprId element_default =
+                SynthesizeDefaultValueExpr(module, frame, a.element_type);
+            return scope.AddExpr(
+                mir::Expr{
+                    .data = mir::ConstructExpr{.args = {element_default}},
+                    .type = type});
+          },
           // Types whose runtime default is the C++ language-level default
           // (named-event handle, child module instance, `unique_ptr<Child>`,
           // `vector<Child>`). The constructor scope is the real populator

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -174,6 +174,22 @@ auto LowerQueueMethodKind(hir::QueueMethodKind k) -> mir::QueueMethodKind {
   throw InternalError("LowerQueueMethodKind: unknown hir::QueueMethodKind");
 }
 
+auto LowerAssociativeMethodKind(hir::AssociativeMethodKind k)
+    -> mir::AssociativeMethodKind {
+  switch (k) {
+    case hir::AssociativeMethodKind::kNum:
+      return mir::AssociativeMethodKind::kNum;
+    case hir::AssociativeMethodKind::kSize:
+      return mir::AssociativeMethodKind::kSize;
+    case hir::AssociativeMethodKind::kExists:
+      return mir::AssociativeMethodKind::kExists;
+    case hir::AssociativeMethodKind::kDelete:
+      return mir::AssociativeMethodKind::kDelete;
+  }
+  throw InternalError(
+      "LowerAssociativeMethodKind: unknown hir::AssociativeMethodKind");
+}
+
 auto LowerIteratorMethodKind(hir::IteratorMethodKind k)
     -> mir::IteratorMethodKind {
   switch (k) {
@@ -476,6 +492,12 @@ auto LowerHirCallExprProc(
                       return {
                           .method = mir::QueueMethodInfo{
                               .kind = LowerQueueMethodKind(k)}};
+                    },
+                    [&](hir::AssociativeMethodKind k)
+                        -> mir::BuiltinMethodCallee {
+                      return {
+                          .method = mir::AssociativeMethodInfo{
+                              .kind = LowerAssociativeMethodKind(k)}};
                     },
                     [&](hir::IteratorMethodKind k) -> mir::BuiltinMethodCallee {
                       return {

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -383,6 +383,11 @@ class MirDumper {
                             "QueueMethodInfo[kind={}]",
                             static_cast<int>(m.kind));
                       },
+                      [](const AssociativeMethodInfo& m) -> std::string {
+                        return std::format(
+                            "AssociativeMethodInfo[kind={}]",
+                            static_cast<int>(m.kind));
+                      },
                       [](const ValueMethodInfo& m) -> std::string {
                         return std::format(
                             "ValueMethodInfo[kind={}]",

--- a/tests/cases/cpp/assoc_basic/case.yaml
+++ b/tests/cases/cpp/assoc_basic/case.yaml
@@ -1,0 +1,26 @@
+id: cpp.assoc_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    va: 1
+    vb: 2
+    ex_a: 1
+    ex_z: 0
+    sz1: 2
+    vmiss: 0
+    sz2: 2
+    vc: 5
+    sz3: 3
+    sz4: 2
+    ex_b: 0
+    nv10: 100
+    nv3: 30
+    nsz: 2
+    nmiss: 0
+    nsz2: 2

--- a/tests/cases/cpp/assoc_basic/main.sv
+++ b/tests/cases/cpp/assoc_basic/main.sv
@@ -1,0 +1,55 @@
+module Top;
+  int m [string];
+  int n [int];
+
+  int va;
+  int vb;
+  int ex_a;
+  int ex_z;
+  int sz1;
+  int vmiss;
+  int sz2;
+  int vc;
+  int sz3;
+  int sz4;
+  int ex_b;
+
+  int nv10;
+  int nv3;
+  int nsz;
+  int nmiss;
+  int nsz2;
+
+  initial begin
+    m["a"] = 1;
+    m["b"] = 2;
+    va = m["a"];
+    vb = m["b"];
+    ex_a = m.exists("a");
+    ex_z = m.exists("z");
+    sz1 = m.num();
+
+    // LRM 7.8.6: reading a nonexistent entry returns the element default and
+    // does not allocate; sz2 proves num() is unchanged by the read.
+    vmiss = m["z"];
+    sz2 = m.num();
+
+    // LRM 7.8.7: a compound write to a nonexistent entry allocates the element
+    // default (0) first, then applies the operation.
+    m["c"] += 5;
+    vc = m["c"];
+    sz3 = m.num();
+
+    m.delete("b");
+    sz4 = m.num();
+    ex_b = m.exists("b");
+
+    n[10] = 100;
+    n[3] = 30;
+    nv10 = n[10];
+    nv3 = n[3];
+    nsz = n.num();
+    nmiss = n[7];
+    nsz2 = n.num();
+  end
+endmodule

--- a/tests/cases/cpp/assoc_display/case.yaml
+++ b/tests/cases/cpp/assoc_display/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.assoc_display
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "m='{\"a\":1, \"b\":2}\nn='{3:30, 10:100}\n"

--- a/tests/cases/cpp/assoc_display/main.sv
+++ b/tests/cases/cpp/assoc_display/main.sv
@@ -1,0 +1,15 @@
+module Top;
+  int m [string];
+  int n [int];
+
+  initial begin
+    // Insertion order differs from key order to show that %p prints in the
+    // LRM 7.8 key ordering (string lexicographical, integral numerical).
+    m["b"] = 2;
+    m["a"] = 1;
+    n[10] = 100;
+    n[3] = 30;
+    $display("m=%p", m);
+    $display("n=%p", n);
+  end
+endmodule

--- a/tests/cases/cpp/assoc_invalid_index/case.yaml
+++ b/tests/cases/cpp/assoc_invalid_index/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.assoc_invalid_index
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sz: 1
+    rd: "32'hxxxxxxxx"

--- a/tests/cases/cpp/assoc_invalid_index/main.sv
+++ b/tests/cases/cpp/assoc_invalid_index/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  // A 4-state index type can carry x/z, which LRM 7.8.6 declares an invalid
+  // index: a read returns the element default and a write is ignored.
+  integer n [integer];
+  integer xi;
+
+  integer rd;
+  int sz;
+
+  initial begin
+    n[5] = 50;
+    xi = 'x;
+    n[xi] = 99;
+    sz = n.num();
+    rd = n[xi];
+  end
+endmodule

--- a/tests/cases/errors/unsupported_type/case.yaml
+++ b/tests/cases/errors/unsupported_type/case.yaml
@@ -12,8 +12,8 @@ expect:
     contains:
       - "main.sv:2:"
       - "unsupported:"
-      - "associative array types are not supported"
-      - "int m [string];"
+      - "unpacked struct types are not supported"
+      - "struct { int a; int b; } s;"
     not_contains:
       - "internal error"
       - "\x1b["

--- a/tests/cases/errors/unsupported_type/main.sv
+++ b/tests/cases/errors/unsupported_type/main.sv
@@ -1,3 +1,3 @@
 module Top;
-  int m [string];
+  struct { int a; int b; } s;
 endmodule


### PR DESCRIPTION
## Summary

Brings up the SystemVerilog associative array (`int m [string]`, `int n [int]`), the last of the three variable-size aggregate containers. The string-indexed (LRM 7.8.2) and integral-indexed (LRM 7.8.4) families are in scope: declaration with the empty default (LRM Table 6-7), element read and write, the read-modify-write compound form, invalid-index handling, the LRM 7.9.1 -- 7.9.3 query methods (`num` / `size` / `exists` / `delete`), and `%p` formatting. The wildcard `[*]`, class, and other user-defined index families, the iteration protocol (`first` / `next` / ...), associative literals, whole-array assignment, and the locator methods are deferred to follow-ups.

## Design

Associative element access splits read from write, which is the one place the container diverges from queue. A read returns the element default for a nonexistent or invalid index without allocating (LRM 7.8.6), while a write allocates the entry with the element default first (LRM 7.8.7); the backend already renders rvalue and lvalue element-selects through separate paths, so the rvalue path emits a non-allocating `Read` and the lvalue path an allocating `ElementRef`, and the compound form composes for free. The runtime container is an ordered `std::map` so iteration and `%p` follow the LRM 7.8 key ordering and stay deterministic; the key comparator reuses the language operators (string lexicographical via `String::operator<`, integral signed/unsigned numerical via `PackedArray::operator<`), and an integral key carrying x/z is invalid (LRM 7.8.6). Method dispatch mirrors the queue-native family through a new `AssociativeMethodKind` arm on `BuiltinMethodRef`.

## Testing

`bazel test //...` is green. New end-to-end cases cover the string and integral core semantics (read / write / compound RMW with allocate-on-write, nonexistent-read default proven non-allocating via `num`, `exists`, `delete`), the 4-state invalid-index path (read returns the default, write is ignored), and `%p` formatting in key order. The pre-existing unsupported-type diagnostic case moved off `int m [string]` (now supported) onto an unpacked struct.