### PR TITLE
Add IsCaseEqual to value container types

### DIFF
--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -208,6 +208,22 @@ class DynamicArray {
     return result;
   }
 
+  // LRM 11.4.5 `===` predicate form (host bool): the Var change-detection
+  // counterpart of `CaseEqual`. A size mismatch is a change; matching empties
+  // are equal; otherwise recurse into each element's own predicate (LRM 9.4.2
+  // update event).
+  [[nodiscard]] auto IsCaseEqual(const DynamicArray& other) const -> bool {
+    if (data_.size() != other.data_.size()) {
+      return false;
+    }
+    for (std::size_t i = 0; i < data_.size(); ++i) {
+      if (!data_[i].IsCaseEqual(other.data_[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   // LRM 7.5.3: empties the array, resulting in a zero-sized array. Body is
   // identical to ResetToDefault (LRM Table 6-7 default for dynamic array is
   // the empty array), but the two surface names track distinct contracts:

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -63,6 +63,22 @@ class Queue {
     return *this;
   }
 
+  // LRM 11.4.5 `===` predicate form (host bool): the Var change-detection
+  // counterpart used when a queue is an observable signal. A size mismatch is
+  // a change; otherwise recurse into each element's own predicate (LRM 9.4.2
+  // update event).
+  [[nodiscard]] auto IsCaseEqual(const Queue& other) const -> bool {
+    if (data_.size() != other.data_.size()) {
+      return false;
+    }
+    for (std::size_t i = 0; i < data_.size(); ++i) {
+      if (!data_[i].IsCaseEqual(other.data_[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   // LRM Table 6-7: a queue's default is the empty queue. When this container
   // is itself an OOB shield slot of an outer container, the outer calls this
   // to restore canonical state before handing out a reference.

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -89,6 +89,13 @@ class String {
   [[nodiscard]] auto operator!=(const String& o) const -> bool {
     return impl_ != o.impl_;
   }
+
+  // LRM 11.4.5 `===` predicate form (host bool): a string has no unknown
+  // plane, so case equality is exact content equality. The Var change-detection
+  // counterpart for an observable string signal (LRM 9.4.2 update event).
+  [[nodiscard]] auto IsCaseEqual(const String& o) const -> bool {
+    return impl_ == o.impl_;
+  }
   [[nodiscard]] auto operator<(const String& o) const -> bool {
     return impl_ < o.impl_;
   }

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -172,6 +172,23 @@ class UnpackedArray {
     return result;
   }
 
+  // LRM 11.4.5 `===` predicate form (host bool): the Var change-detection
+  // counterpart of `CaseEqual`, recursing into each element's own predicate
+  // (LRM 9.4.2 update event). A size mismatch is a change -- this is how the
+  // empty default of a fresh `Var<UnpackedArray>` is detected as different from
+  // the first sized write, so the declared-shape initializer commits.
+  [[nodiscard]] auto IsCaseEqual(const UnpackedArray& other) const -> bool {
+    if (data_.size() != other.data_.size()) {
+      return false;
+    }
+    for (std::size_t i = 0; i < data_.size(); ++i) {
+      if (!data_[i].IsCaseEqual(other.data_[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
  private:
   [[nodiscard]] auto IsInvalidIndex(const PackedArray& idx) const -> bool {
     if (idx.HasUnknown()) return true;


### PR DESCRIPTION
## Summary

Adds the host-bool `IsCaseEqual` predicate to `UnpackedArray`, `DynamicArray`, `Queue`, and `String`. This is the LRM 11.4.5 `===` predicate form (returning a host `bool`), which is the change-detection counterpart a `Var<T>` uses to decide whether an assignment is an update event (LRM 9.4.2). Each container recurses element-wise into the element's own predicate; for the aggregates a size mismatch counts as a change, and `String` compares content directly since it has no unknown plane.

These methods let the value container types satisfy `Var<T>`'s `CaseEqualComparable` requirement, which is groundwork for treating them as observable signals.