### PR TITLE
Generalize foreach to variable-size and jagged arrays

### DIFF
--- a/docs/decisions/foreach-lowering.md
+++ b/docs/decisions/foreach-lowering.md
@@ -1,125 +1,106 @@
 # `foreach` lowering shape
 
-Date: 2026-06-02 Status: accepted
+Date: 2026-06-02 (flat-counter); 2026-06-17 (revised to nested loops + labeled break) Status:
+accepted
 
 ## Context
 
 LRM 12.7.3 defines `foreach` uniformly over "any type of packed or unpacked array" with arbitrary
-dimensionality, optional skipped dims, and optional trailing-dim omission. LRM 12.8 adds two
-semantics that are critical to the lowering choice:
+dimensionality, optional skipped dims, and optional trailing-dim omission. Two LRM 12.8 semantics
+constrain the lowering:
 
-- `continue` jumps to the end of the loop for the **current set of loop variable values**, i.e.
-  advances the iteration to the next combined `(i, j, k, ...)` tuple.
-- `break` jumps out of the **entire foreach**, not just the innermost dimension.
+- `continue` advances the iteration to the next combined `(i, j, k, ...)` tuple.
+- `break` exits the **entire** foreach, not just the innermost dimension.
 
-The pre-reset archived implementation desugared `foreach (arr[i, j])` to N nested for-loops
-(`for (int i = ...) for (int j = ...) BODY`) and let plain SV `break` lower to plain C++ `break`.
-That shape is structurally close to the SV source but is subtly wrong on LRM 12.8: a `break` inside
-the body terminates only the inner `for`, after which the outer `for` continues to its next
-iteration. None of the archived test cases happened to expose the gap, but it is a real LRM
-correctness defect.
+Two further requirements surfaced once variable-size arrays entered scope:
 
-This is also a forcing function on a broader design choice: how do we express "non-local exit out of
-N enclosing scopes" in the emitted C++? C++ has no first-class labeled break (the construct in Java
-/ Rust / Kotlin and the natural primitive in LLVM IR / WebAssembly).
+- A dynamically sized dimension's element count is known only at run time (LRM 7.5 / 7.10). For a
+  **jagged** array (`int a[][]`) an inner dimension's length depends on the enclosing index --
+  `a[i].size()` differs per `i` -- so the iteration space is not a rectangle.
+- LRM 12.7.3 samples each bound once on entry to its dimension (the construct "is similar to a
+  repeat-loop", and a repeat-loop evaluates its count once).
+
+The hard design question is how to express "exit out of N enclosing loops" in the emitted C++. C++
+has no labeled break -- the construct Java, JavaScript, Go, Rust, Kotlin, Swift, and Perl all
+provide natively, and the natural primitive in LLVM IR and WebAssembly.
 
 ## Decision
 
-1. **Every `foreach` lowers to a single flattened `hir::ForStmt`.** The iteration space is the
-   Cartesian product of the non-skipped dimensions. A synthetic procedural variable
-   `__lyra_foreach_n` is declared in the loop's `ForInitDecl` and counts from `0` to `total - 1`,
-   where `total` is the product of the non-skipped dim counts. The loop body begins by computing
-   each loop variable's per-iteration value by decomposing the counter, then continues with the
-   lowered user body. There is exactly one for-loop level in the lowered HIR regardless of
-   dimensionality.
+**`foreach` lowers to one ordinary nested loop per iterated dimension, and a break that must leave
+the whole foreach is modeled as a labeled break -- the universal multi-level-exit primitive.**
 
-2. **Per-dim decompose formula.** Each non-skipped loop variable is computed as
+1. **Nested loops, size sampled per level.** The non-skipped dimensions become nested `for` loops in
+   cardinal order (outer to inner). A fixed dimension loops over its declared range and direction. A
+   dynamically sized dimension samples its element count once into a synthetic local on entry to
+   that level -- `a.size()` for the outermost dimension, `a[i].size()` for the next, and so on --
+   then counts `0..count-1`. Because the inner count is read inside the enclosing loop, a jagged
+   array iterates correctly with no special case: the inner bound simply reads the current row.
 
-   ```
-   var = base + sign * ((__n / inner_product) % count)
-   ```
+2. **Labeled break.** HIR and MIR carry a `LoopLabelId`: a loop may be a break target, and a `break`
+   may name the loop it exits. A `break` whose innermost SystemVerilog loop is the foreach carries
+   the outermost loop's label; an ordinary innermost break carries none. The AST-to-HIR walk threads
+   the current foreach label through the body and clears it on entering any nested loop, so a break
+   binds to the nearest enclosing loop exactly as SystemVerilog requires. `continue` and `return`
+   stay plain: a plain innermost `continue` already advances to the next tuple, and a plain `return`
+   already exits the enclosing subroutine.
 
-   where `inner_product` is the product of all non-skipped dim counts to its right (1 for the
-   innermost), `count = abs(range.right - range.left) + 1`, and `(base, sign) = (range.left, +1)`
-   for an ascending range, `(range.left, -1)` for a descending range. Slang's `LoopDim` order is
-   already outer->inner per LRM cardinality, so no reordering is needed.
+3. **Each backend renders the primitive its own way.** The C++ backend, lacking labeled break, emits
+   a `goto` to a label placed after the outermost loop -- the canonical C idiom for leaving a loop
+   nest. An LLVM backend would emit a branch to the loop's merge block directly. The labeled break
+   lives in the semantic layers (HIR/MIR); the exit mechanism is a backend concern.
 
-3. **Plain SV `break` / `continue` / `return` lower to plain HIR `BreakStmt` / `ContinueStmt` /
-   `ReturnStmt`, with no foreach-aware rewriting.** Because the lowered HIR has exactly one
-   for-loop, plain `break` exits the entire foreach (matching LRM 12.8), plain `continue` advances
-   `__n` to the next tuple (matching LRM 12.8 "current set of loop variable values"), and `return`
-   exits the enclosing subroutine without any wrapper interception. This is the design's payoff: no
-   special primitive, no flag, no rewrite, no lint exception.
+## History: why not a flat counter
 
-_Rejected alternatives:_
+The first implementation (2026-06-02) desugared every `foreach` to a **single** flattened loop: a
+synthetic counter ran `0..total-1` over the Cartesian product of the dimension counts, and each loop
+variable was recovered by decomposing the counter
+(`var = base + sign * ((n / inner_product) % count)`). Its appeal was that a single loop makes
+`break` / `continue` / `return` map one-to-one to the plain C++ statements with no labeled-exit
+mechanism at all.
 
-- **Nested for-loops + plain `break`** (archived shape): LRM-incorrect for break -- terminates only
-  the innermost dim.
+That shape has a fatal limitation: the flat counter assumes a **rectangular** iteration space (a
+single `total` and per-dimension `inner_product`). It cannot represent a jagged array, where an
+inner count depends on the outer index. The flat counter was, in effect, a workaround that avoided
+modeling multi-level break by collapsing the nest -- and the collapse is only possible when every
+dimension's bound is independent of the others. Once jagged dynamic arrays were in scope, the
+workaround could not generalize, so the nested-loop model with an explicit labeled break replaced
+it.
 
-- **Nested for-loops + flag-based break propagation**: each outer loop tail checks a synthetic
-  `__break` flag and re-breaks if set; the body's `break` becomes `__break = 1; break;`. Correct but
-  adds N+1 places per dim that must stay coherent across edits, and pays a per-iteration branch cost
-  at every level. Mechanism does not collapse with dim count.
+The earlier rejected alternatives to plain nested loops were re-examined and the
+labeled-break-via-`goto` choice (item 3 above) is the resolution:
 
-- **Nested for-loops + `goto label;` after the outermost closing brace**: matches structure 1:1 and
-  is the natural emit for "break to labeled block" in C++. Rejected because a single `goto`
-  exception in emitted code undermines a clean project-wide rule against `goto` and invites future
-  misuse (anywhere else where someone wants a "controlled" jump). The cost of the rule violation
-  outweighs the structural fidelity gain.
-
-- **Nested for-loops wrapped in an IIFE; SV `break` -> C++ `return`**: cleanly handles `break` by
-  returning from the lambda, but corrupts SV `return` from inside the foreach body -- the C++
-  `return` exits the lambda, not the enclosing SV function. Modeling the difference would require
-  separating "break-style return" from "function-style return" at every emit site, defeating the
-  simplicity.
-
-- **`std::views::cartesian_product` (C++23 ranges)**: conceptually correct -- analogous to Python's
-  `itertools.product`. Rejected because `cartesian_product` is a libc++ 19+ (Sept 2024) / libstdc++
-  13+ stdlib feature; requiring it pushes the toolchain floor for the emitted C++ beyond what the
-  project will commit to (see `docs/progress/refactor.md` R5 for the toolchain-baseline workstream).
-  The same _semantic_ -- flattening the product space -- is captured by the manual flat-index
-  decompose without any stdlib dependency.
+- **Nested loops + a `__break` flag** ANDed into every loop condition: correct but pays a
+  per-iteration branch at every level and spreads the break logic across N+1 sites that must stay
+  coherent. The single `goto` is simpler and costs nothing per iteration.
+- **`goto` after the nest** was originally rejected purely on a project-wide "no goto" preference.
+  With jagged support now required, that preference is the thing in tension, and a _generated_,
+  localized `goto` -- the faithful rendering of a labeled break that no hand-written code ever sees
+  -- is the right trade. The MIR models the labeled break; only the C++ backend spells it `goto`.
+- **IIFE / lambda with `return` for break** corrupts SystemVerilog `return` from inside the body,
+  which must exit the enclosing function, not the lambda.
+- **`std::views::cartesian_product`** only models rectangular spaces and pushes the emitted-code
+  toolchain floor higher; rejected for the same jagged limitation as the flat counter plus a
+  dependency cost.
 
 ## Consequences
 
-- The lowering is **uniform across dimensionality**. 1D / 2D / N-D / mixed packed-unpacked /
-  ascending / descending / skipped-dim cases share one code path. The dispatch over packed vs
-  unpacked element access happens entirely in the body's existing `ElementSelectExpr` lowering,
-  which the foreach itself never touches.
-
-- Per-iteration cost is **N-1 divisions and N modulos on `__n`** for an N-dim foreach. All divisors
-  are compile-time constants for fixed-bound arrays (always the case in C9's scope), so modern C++
-  compilers fold them to multiply-by-magic-number sequences (~2-3 instructions per dim). The emitted
-  C++ for-loop has no flag overhead and no lambda boundary, so the only excess vs nested for-loops
-  is the index arithmetic. `foreach` is not a typical simulator hot path.
-
-- Skipped dimensions (`arr[i, , k]`) and trailing-dim omission (`int arr[2][3]; foreach (arr[i])`)
-  fall out of the same model: skipped dims contribute neither a loop variable nor a factor to the
-  product, and the body simply never references them. No special-case code paths required.
-
-- The lowering reaches the body via the usual recursive `LowerStatement`, so `break` inside a `for`
-  / `while` / `do-while` nested in the foreach body still targets the nested loop (standard C
-  nesting). The "exit the entire foreach" semantic is structural -- there is only one for-loop --
-  not contextual.
-
-- Dynamic-array / queue / associative-array element types are rejected with
-  `kUnsupportedStatementForm` until `datatypes/general` brings procedural support for those types.
-  When that lands, the same flat-index model extends naturally: the iteration count becomes a
-  runtime query (`arr.size()`) instead of a compile-time literal, and the decompose formula stays
-  identical.
-
-- The slang `IteratorSymbol` for a foreach loop variable derives from `VariableSymbol` but carries
-  its own `SymbolKind::Iterator`. The AST -> HIR name resolution at
-  `src/lyra/lowering/ast_to_hir/expression/lower.cpp` was extended to accept `Iterator` alongside
-  `Variable` and `FormalArgument`; all three route through
-  `ProcessLoweringState::LookupProceduralVar`.
+- The lowering is uniform across dimensionality, direction, skipped and trailing-omitted dims, and
+  across fixed, dynamic, queue, and jagged element containers. Each dimension is an ordinary `for`;
+  nothing about the foreach touches element access, which the body's existing index lowering
+  handles.
+- Per-iteration cost is a plain nested loop. A dynamic level pays one `.size()` read on entry
+  (sampled into a local, not re-queried each iteration).
+- The labeled break is the only new IR concept, and it is the same primitive every other
+  multi-level-exit language and IR uses, so the model transfers directly to a future LLVM backend (a
+  branch) rather than baking in a C++-specific trick.
+- Associative-array and string `foreach` remain rejected: they iterate by key (LRM 7.9) and by byte
+  (LRM 6.16), distinct iteration models with their own lowering.
 
 ## Cross-references
 
-- LRM 12.7.3 (foreach syntax, dim cardinality, implicit begin-end, read-only loop vars).
-- LRM 12.8 (break exits whole foreach; continue advances current loop var values).
-- Conceptual analogue: Python `itertools.product`, C++23 `std::views::cartesian_product`,
-  WebAssembly `br N`, LLVM IR labeled blocks. None used directly; all express the same
-  flatten-the-product-space idea.
-- `docs/progress/refactor.md` R5 -- emit-CPP smoke suite and toolchain baseline (the reason
-  `cartesian_product` was rejected).
+- LRM 12.7.3 (foreach syntax, dim cardinality, bound sampled once, read-only loop vars), 12.8 (break
+  exits whole foreach; continue advances loop vars), 7.5 / 7.10 (dynamic array / queue runtime
+  size).
+- Multi-level-exit primitives surveyed: Java / JavaScript / Go / Rust / Kotlin / Swift labeled
+  break, Perl `last LABEL`, LLVM IR branch to merge block, WebAssembly `br N`. C is the outlier with
+  no labeled break; its idiom is the `goto` the C++ backend emits.

--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -51,10 +51,8 @@ The numeric IDs are stable references and do not imply execution order beyond DA
       Newly constructed slots default to the element type's LRM Table 6-7 value (recursively, so
       nested dynamic arrays default to empty). Multi-dimensional forms fall out from the recursive
       element-type representation; no dim-count-specific scope is needed. `foreach` over a dynamic
-      array stays rejected because the existing `foreach` flat-index lowering is keyed on
-      compile-time per-dim counts; the runtime-count adaptation is its own step (`control-flow.md`
-      C10 dynamic-array subset). SV-callable methods, including `.size()`, are not part of DA1 and
-      ship with the method family in DA6.
+      array (including jagged nests) is handled by `control-flow.md` C10. SV-callable methods,
+      including `.size()`, are not part of DA1 and ship with the method family in DA6.
 
 - [x] DA2 -- Aggregate write paths. Compound element write per LRM 11.4.1, whole-array assignment
       `A = B` which grows A to B's size per LRM 7.6, and the NBA form of whole-array assignment.

--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -8,13 +8,13 @@ order.
 
 ## Actionable
 
-C9 is done. C10's skipped-dimension and trailing-dim subset rides on C9 because the lowering shape
-is uniform across dim counts; the dynamic-array, queue, and associative-array subset stays open and
-remains blocked on `datatypes/general`.
+C9 and C10 are done for packed, unpacked, dynamic-array, and queue arrays of any dimensionality,
+including jagged dynamic-of-dynamic nests. The associative-array case stays open (it iterates by
+key, a distinct model).
 
-| Item | Status                                                              |
-| ---- | ------------------------------------------------------------------- |
-| C10  | Blocked on `datatypes/general` (dynamic array, queue, associative). |
+| Item | Status                                                                     |
+| ---- | -------------------------------------------------------------------------- |
+| C10  | Done: dynamic array / queue, any dimensionality incl. jagged. Open: assoc. |
 
 ## Sub-Steps
 
@@ -41,17 +41,21 @@ remains blocked on `datatypes/general`.
 - [x] C8 -- `forever`. Loops until `break` or `$finish` exits. Includes `$finish` termination,
       `break` termination, `continue`, single-statement body, nested forever with inner `break`, and
       `if`-guarded forever.
-- [x] C9 -- `foreach` over fixed packed and unpacked arrays of any dimensionality. Single lowering
+- [x] C9 -- `foreach` over fixed packed and unpacked arrays of any dimensionality. One lowering
       handles 1D, 2D, N-D, mixed packed/unpacked nests, ascending and descending ranges, non-zero
-      and negative bases. The lowered HIR is a single flattened `ForStmt` whose body computes per-
-      iteration loop-variable values from a synthetic flat counter, so plain SV `break` / `continue`
-      / `return` map 1:1 to LRM 12.8 semantics without any rewrite. See
-      `../decisions/foreach-lowering.md`.
-- [ ] C10 -- `foreach` skipped dimensions, dynamic-array, queue. Skipped dims and trailing dim
-      omission (`int arr[2][3]; foreach (arr[i])`) ship with C9 because they fall out of the same
-      uniform lowering. Dynamic-array, queue, and associative-array foreach are rejected with
-      `kUnsupportedStatementForm` until `datatypes/general` brings procedural support for those
-      types and the `.size()` runtime query.
+      and negative bases: each iterated dimension becomes a nested `for` over its range and
+      direction. Plain SV `continue` / `return` map 1:1 to LRM 12.8 (a plain innermost `continue`
+      advances to the next tuple; `return` exits the subroutine); a `break` that must leave the
+      whole foreach is a labeled break (shared with C10). See `../decisions/foreach-lowering.md`.
+- [x] C10 -- `foreach` skipped dimensions plus dynamic-array and queue iteration of any
+      dimensionality. Skipped dims and trailing-dim omission (`int arr[2][3]; foreach (arr[i])`)
+      fall out of the same lowering. Every iterated dimension becomes a nested loop in cardinal
+      order; a dynamically sized dimension samples its element count once on entry to that level
+      (LRM 12.7.3), so a jagged dynamic-of-dynamic array (`int a[][]`, inner length per row)
+      iterates correctly. A `break` that must leave the whole foreach (LRM 12.8) is modeled as a
+      labeled break and rendered as a `goto` past the outermost loop. `foreach` over an associative
+      array stays rejected with `kUnsupportedStatementForm` (it iterates by key, a distinct model).
+      See `../decisions/foreach-lowering.md`.
 - [x] C11 -- `casez` / `casex` (LRM 12.5.1 do-not-care forms). Bidirectional wildcard compare:
       `casez` treats Z as don't-care on either operand; `casex` treats Z or X as don't-care on
       either operand. Result is deterministic, distinct from the asymmetric `==?` operator (LRM

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -379,6 +379,61 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       discussion -- requires walking the structural / procedural axis across MIR vocabulary, dumper,
       lowering helpers, and backend, deciding what stays paired and what merges.
 
+- [ ] R23 -- Make the "materialize a reference into an owning value" (`.Clone()`) a node in MIR
+      instead of a render-time decision. Today a reference-producing read -- an element / range /
+      field select that yields a `PackedArrayRef` view into packed bit storage, or a container `T&`
+      for an unpacked / dynamic / queue element -- is materialized by the C++ backend: `RenderExpr`
+      wraps the result in `.Clone()` when `ProducesPackedArrayRef(expr)` holds, while
+      `RenderExprNatural` leaves the bare reference for lvalue / write contexts. So the same MIR
+      node (e.g. `ElementSelectExpr`) emits two different C++ strings (`x` vs `(x).Clone()`)
+      depending on which render entry point reaches it -- a semantic decision made in the backend.
+      `.Clone()` is a real operation (a method call that copies a borrowed reference / view into an
+      independent owning value); it must be represented in MIR so that every backend renders it. A
+      future LIR / LLVM backend that mechanically lowers MIR would not know to clone -- the decision
+      lives only in the C++ renderer -- so the two backends would diverge on value / aliasing
+      semantics (the LIR path would alias storage that the C++ path snapshots). Target shape: an
+      explicit MIR materialize node inserted at the HIR -> MIR boundary wherever a
+      reference-producing read is used in a value position (a read that escapes, is stored, or could
+      alias a subsequent mutation); the backend then renders mechanically -- a select renders to its
+      reference form, the materialize node renders to `.Clone()` -- with the `RenderExpr` /
+      `RenderExprNatural` split and the `ProducesPackedArrayRef` predicate both deleted. The
+      decision returns to the semantic layer that owns it, and "two different MIR -> two different
+      emit" holds. **Why surfaced**: pre-existing, not caused by the foreach work; foreach's
+      synthetic `.size()` on a jagged dynamic-of-dynamic array made it visible
+      (`jag[i].Clone().Size()` copies a whole row just to read its size). **Why deferred**: a
+      cross-cutting change to the backend value model -- MIR vocabulary, the HIR -> MIR
+      value-vs-reference context decision, the dumper, and the backend -- far larger than, and
+      orthogonal to, any feature that surfaces it. **Trigger**: the LIR / LLVM backend work (when
+      cross-backend divergence becomes real), or any change to the backend's clone / reference
+      rendering.
+
+- [ ] R24 -- Dispatch the "sized collection" concept (`.size()` / `.num()`) through one resolver
+      instead of branching on the concrete container at each call site. Today the element-count
+      query is a separate enum value on every container's method family (`ArrayMethodKind::kSize`,
+      `QueueMethodKind::kSize`, `AssociativeMethodKind::kSize` / `kNum`), and a caller that wants a
+      count branches on the receiver type to pick the right one -- the `foreach` synthetic bound
+      does exactly this (`isQueue() ? QueueMethodKind::kSize : ArrayMethodKind::kSize`). The concept
+      is "any collection with an element count exposes `size()`", and the key modeling point (from
+      how Rust generics, C++ templates + concepts, TypeScript interfaces, and Python protocols are
+      implemented) is that under **static dispatch** -- which is our regime, the receiver's concrete
+      type is always known at lowering -- the concept is a **compile-time resolver that is erased in
+      the backend IR**, not a persistent IR node. So the per-container method enums stay (they are
+      the concrete implementations, like Rust `impl` blocks / C++ members), and MIR keeps carrying
+      the concrete per-type method; the concept lives only as a single lowering-time
+      `ResolveSized(type) -> that type's size method` table -- the one place the type-to-method
+      branch lives. The earlier mistake to avoid: extracting `size` into a flat
+      `CollectionMethodKind` that removed it from each container's method set (that loses dimension
+      one -- an array genuinely has a `size` method -- and persists a concept node in MIR, which the
+      static-dispatch model says should be erased). **Why deferred**: only one consumer (`foreach`)
+      today, so the resolver is a one-caller function -- the interface payoff is multiple generic
+      callers sharing the table, which do not exist yet. **Trigger**: a second generic consumer of
+      collection-size dispatch (a locator / reduction lowering, an array-querying system function,
+      or a generic-algorithm pass). A separate, structural sub-question rides along: whether fixed
+      unpacked and packed arrays should also be "sized collections" with a runtime `.size()` (a
+      type-model decision, distinct from how `foreach` iterates them -- `foreach` over a fixed array
+      uses its declared range and direction, not a count, so that split is a real semantic
+      difference, not the same redundancy).
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/hir/expr_builders.hpp
+++ b/include/lyra/hir/expr_builders.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <cstdint>
+
+#include "lyra/diag/source_span.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/integral_constant.hpp"
+#include "lyra/hir/primary.hpp"
+#include "lyra/hir/procedural_var.hpp"
+#include "lyra/hir/type_id.hpp"
+#include "lyra/hir/value_ref.hpp"
+
+// Pure builders for the synthetic HIR expressions a lowering reaches for
+// whenever it needs a counter, bound, or sentinel -- each a function of its
+// inputs plus a type and span, with no lowering state. The caller owns the
+// `AddExpr` into its body. The AST-to-HIR counterpart of
+// `mir::MakeInt32Literal`.
+namespace lyra::hir {
+
+// A 32-bit signed two-state `int`-typed integer literal for a raw value.
+[[nodiscard]] inline auto MakeInt32Literal(
+    std::int64_t value, TypeId int32_type, diag::SourceSpan span) -> Expr {
+  return Expr{
+      .type = int32_type,
+      .data =
+          PrimaryExpr{
+              .data =
+                  IntegerLiteral{
+                      .value =
+                          IntegralConstant{
+                              .value_words =
+                                  {static_cast<std::uint64_t>(value) &
+                                   0xFFFFFFFFULL},
+                              .state_words = {},
+                              .width = 32,
+                              .signedness = Signedness::kSigned,
+                              .state_kind = IntegralStateKind::kTwoState},
+                      .base = IntegerLiteralBase::kDecimal,
+                      .declared_unsized = false}},
+      .span = span};
+}
+
+// A reference to a procedural variable.
+[[nodiscard]] inline auto MakeProcVarRefExpr(
+    ProceduralVarId var, TypeId type, diag::SourceSpan span) -> Expr {
+  return Expr{
+      .type = type,
+      .data = PrimaryExpr{.data = ProceduralVarRef{.var = var}},
+      .span = span};
+}
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/loop_label_id.hpp
+++ b/include/lyra/hir/loop_label_id.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace lyra::hir {
+
+// Identifies a loop as a non-local break target. A `foreach` lowers to nested
+// loops, so a `break` that exits the whole foreach must name the outermost
+// loop -- the universal labeled-break primitive (Java/Go/Rust loop labels,
+// LLVM/Wasm branch targets). Minted per procedural body via AddLoopLabel.
+struct LoopLabelId {
+  std::uint32_t value;
+
+  auto operator<=>(const LoopLabelId&) const -> std::strong_ordering = default;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/procedural_body.hpp
+++ b/include/lyra/hir/procedural_body.hpp
@@ -17,6 +17,7 @@ struct ProceduralBody {
   std::vector<Expr> exprs;
   std::vector<Stmt> stmts;
   std::vector<ProceduralVarDecl> procedural_vars;
+  std::uint32_t loop_label_count = 0;
 
   [[nodiscard]] auto GetExpr(ExprId id) const -> const Expr& {
     return exprs.at(id.value);
@@ -44,6 +45,9 @@ struct ProceduralBody {
         static_cast<std::uint32_t>(procedural_vars.size())};
     procedural_vars.push_back(std::move(decl));
     return id;
+  }
+  auto AddLoopLabel() -> LoopLabelId {
+    return LoopLabelId{loop_label_count++};
   }
 };
 

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -11,6 +11,7 @@
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/inside_item.hpp"
+#include "lyra/hir/loop_label_id.hpp"
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/value_ref.hpp"
 
@@ -133,6 +134,7 @@ struct ForStmt {
   std::optional<ExprId> condition;
   std::vector<ExprId> step;
   StmtId body;
+  std::optional<LoopLabelId> break_label = std::nullopt;
 };
 
 struct WhileStmt {
@@ -154,7 +156,9 @@ struct ForeverStmt {
   StmtId body;
 };
 
-struct BreakStmt {};
+struct BreakStmt {
+  std::optional<LoopLabelId> target = std::nullopt;
+};
 
 struct ContinueStmt {};
 

--- a/include/lyra/lowering/ast_to_hir/walk_frame.hpp
+++ b/include/lyra/lowering/ast_to_hir/walk_frame.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/hir/loop_label_id.hpp"
 #include "lyra/hir/structural_hops.hpp"
 
 namespace lyra::hir {
@@ -64,6 +65,16 @@ struct WalkFrame {
   // outside a process body.
   std::uint32_t fork_branch_depth = 0;
 
+  // Non-local break target for the innermost enclosing loop. A `foreach`
+  // lowers to nested loops, so a `break` whose innermost SystemVerilog loop is
+  // that foreach must leave the whole nest -- it carries the outermost loop's
+  // label. Set while lowering a foreach body; reset to nullopt while lowering
+  // an ordinary loop body (whose break is a plain innermost exit). When a break
+  // consumes the label, `innermost_break_used` is flipped so the foreach knows
+  // to mark the outer loop as a landing target.
+  std::optional<hir::LoopLabelId> innermost_break_label = std::nullopt;
+  bool* innermost_break_used = nullptr;
+
   [[nodiscard]] auto Current() const -> ScopeFrameId {
     if (structural_chain.empty()) {
       throw InternalError("WalkFrame::Current: empty structural chain");
@@ -115,6 +126,27 @@ struct WalkFrame {
   [[nodiscard]] auto WithForkBranch() const -> WalkFrame {
     WalkFrame next = *this;
     ++next.fork_branch_depth;
+    return next;
+  }
+
+  // Establishes `label` as the break target for the body being lowered. `used`
+  // points at a flag the foreach owns; a break that consumes the label flips
+  // it. Used by the foreach lowering for its nested loop body.
+  [[nodiscard]] auto WithBreakLabel(hir::LoopLabelId label, bool* used) const
+      -> WalkFrame {
+    WalkFrame next = *this;
+    next.innermost_break_label = label;
+    next.innermost_break_used = used;
+    return next;
+  }
+
+  // Clears the foreach break target. An ordinary loop body uses this so a break
+  // inside it is the plain innermost exit, not an escape to an enclosing
+  // foreach.
+  [[nodiscard]] auto WithoutBreakLabel() const -> WalkFrame {
+    WalkFrame next = *this;
+    next.innermost_break_label = std::nullopt;
+    next.innermost_break_used = nullptr;
     return next;
   }
 

--- a/include/lyra/lowering/hir_to_mir/statement/flow.hpp
+++ b/include/lyra/lowering/hir_to_mir/statement/flow.hpp
@@ -23,7 +23,8 @@ auto LowerReturnStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::ReturnStmt& r) -> diag::Result<mir::Stmt>;
 
-auto LowerBreakStmt(std::optional<std::string> label)
+auto LowerBreakStmt(
+    std::optional<std::string> label, std::optional<hir::LoopLabelId> target)
     -> diag::Result<mir::Stmt>;
 
 auto LowerContinueStmt(std::optional<std::string> label)

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -26,6 +26,16 @@ struct StmtId {
   auto operator<=>(const StmtId&) const -> std::strong_ordering = default;
 };
 
+// Identifies a loop as a non-local break target (the outermost loop of a
+// multi-dimensional `foreach`). The universal labeled-break primitive; the C++
+// backend renders it as a `goto` to a label after the loop, an LLVM backend as
+// a branch. See `docs/decisions/foreach-lowering.md`.
+struct LoopLabelId {
+  std::uint32_t value;
+
+  auto operator<=>(const LoopLabelId&) const -> std::strong_ordering = default;
+};
+
 struct ProceduralScopeId {
   std::uint32_t value;
 
@@ -111,6 +121,7 @@ struct ForStmt {
   std::optional<ExprId> condition;
   std::vector<ExprId> step;
   ProceduralScopeId scope;
+  std::optional<LoopLabelId> break_label = std::nullopt;
 };
 
 enum class EventEdge : std::uint8_t {
@@ -143,7 +154,9 @@ struct DoWhileStmt {
   ProceduralScopeId scope;
 };
 
-struct BreakStmt {};
+struct BreakStmt {
+  std::optional<LoopLabelId> target = std::nullopt;
+};
 
 struct ContinueStmt {};
 

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -304,6 +304,13 @@ auto RenderConstructExternalUnitStmt(
       indent);
 }
 
+// C++ has no labeled break, so a `foreach` break that must leave every nested
+// dimension lowers to a `goto` aimed at a label after the outermost loop. Both
+// the landing label and the jump derive their name from the loop's LoopLabelId.
+auto BreakLandingLabel(mir::LoopLabelId label) -> std::string {
+  return "__lyra_break_" + std::to_string(label.value);
+}
+
 auto RenderForStmtNode(
     const RenderContext& ctx, const mir::ForStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
@@ -336,6 +343,9 @@ auto RenderForStmtNode(
       Indent(indent) + "for (" + init + "; " + cond + "; " + step + ") {\n";
   result += *body_or;
   result += Indent(indent) + "}\n";
+  if (s.break_label.has_value()) {
+    result += Indent(indent) + BreakLandingLabel(*s.break_label) + ":;\n";
+  }
   return result;
 }
 
@@ -468,7 +478,11 @@ auto RenderStmt(
           [&](const mir::DoWhileStmt& s) -> diag::Result<std::string> {
             return RenderDoWhileStmtNode(ctx, s, indent);
           },
-          [&](const mir::BreakStmt&) -> diag::Result<std::string> {
+          [&](const mir::BreakStmt& s) -> diag::Result<std::string> {
+            if (s.target.has_value()) {
+              return Indent(indent) + "goto " + BreakLandingLabel(*s.target) +
+                     ";\n";
+            }
             return Indent(indent) + "break;\n";
           },
           [&](const mir::ContinueStmt&) -> diag::Result<std::string> {

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -1295,8 +1295,11 @@ class HirDumper {
   void DumpForStmtNode(const ProceduralBody& p, StmtId id, const ForStmt& f) {
     Line(
         std::format(
-            "Stmt[{}] ForStmt (init={}, step={})", id.value, f.init.size(),
-            f.step.size()));
+            "Stmt[{}] ForStmt (init={}, step={}{})", id.value, f.init.size(),
+            f.step.size(),
+            f.break_label.has_value()
+                ? std::format(", break_label={}", f.break_label->value)
+                : ""));
     Indent();
     for (std::size_t k = 0; k < f.init.size(); ++k) {
       std::visit(
@@ -1446,8 +1449,13 @@ class HirDumper {
             [&](const RepeatStmt& r) { DumpRepeatStmtNode(p, id, r); },
             [&](const DoWhileStmt& d) { DumpDoWhileStmtNode(p, id, d); },
             [&](const ForeverStmt& f) { DumpForeverStmtNode(p, id, f); },
-            [&](const BreakStmt&) {
-              Line(std::format("Stmt[{}] BreakStmt", id.value));
+            [&](const BreakStmt& b) {
+              Line(
+                  std::format(
+                      "Stmt[{}] BreakStmt{}", id.value,
+                      b.target.has_value()
+                          ? std::format(" -> label {}", b.target->value)
+                          : ""));
             },
             [&](const ContinueStmt&) {
               Line(std::format("Stmt[{}] ContinueStmt", id.value));

--- a/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
@@ -1,6 +1,6 @@
-#include <cstdint>
 #include <expected>
-#include <ranges>
+#include <optional>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -11,16 +11,16 @@
 #include <slang/ast/types/AllTypes.h>
 #include <slang/ast/types/Type.h>
 
-#include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/kind.hpp"
 #include "lyra/hir/binary_op.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/integral_constant.hpp"
-#include "lyra/hir/primary.hpp"
+#include "lyra/hir/expr_builders.hpp"
+#include "lyra/hir/inc_dec_op.hpp"
+#include "lyra/hir/method.hpp"
 #include "lyra/hir/stmt.hpp"
-#include "lyra/hir/value_ref.hpp"
+#include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 
@@ -28,119 +28,215 @@ namespace lyra::lowering::ast_to_hir {
 
 namespace {
 
-constexpr std::string_view kFlatCounterName = "__lyra_foreach_n";
+constexpr std::string_view kLastIndexName = "__lyra_foreach_last";
 
-auto MakeInt32Constant(std::int64_t value) -> hir::IntegralConstant {
-  return hir::IntegralConstant{
-      .value_words = {static_cast<std::uint64_t>(value) & 0xFFFFFFFFULL},
-      .state_words = {},
-      .width = 32,
-      .signedness = hir::Signedness::kSigned,
-      .state_kind = hir::IntegralStateKind::kTwoState,
-  };
-}
+// slang already describes each `foreach` dimension: a fixed dimension carries a
+// constant `range` (its declared bounds and direction); a dynamically sized one
+// (queue / dynamic array) has no `range` and takes its bounds from `.size()` at
+// run time. `DescribeRange` turns either form into a uniform
+// `(first, last, direction)`.
+using LoopDim = slang::ast::ForeachLoopStatement::LoopDim;
 
-auto MakeInt32LiteralExpr(
-    std::int64_t value, hir::TypeId int32_type, diag::SourceSpan span)
-    -> hir::Expr {
-  return hir::Expr{
-      .type = int32_type,
-      .data =
-          hir::PrimaryExpr{
-              .data =
-                  hir::IntegerLiteral{
-                      .value = MakeInt32Constant(value),
-                      .base = hir::IntegerLiteralBase::kDecimal,
-                      .declared_unsized = false,
-                  }},
-      .span = span,
-  };
-}
-
-auto MakeProcVarRefExpr(
-    hir::ProceduralVarId var, hir::TypeId type, diag::SourceSpan span)
-    -> hir::Expr {
-  return hir::Expr{
-      .type = type,
-      .data = hir::PrimaryExpr{.data = hir::ProceduralVarRef{.var = var}},
-      .span = span,
-  };
-}
-
-// Ordered outer-to-inner per LRM 12.7.3 cardinality. `inner_product` is the
-// product of `count` for every later (more-inner) entry; the innermost has
-// inner_product = 1.
-struct DimMeta {
-  const slang::ast::IteratorSymbol* loop_var;
-  std::int64_t lo;
-  std::int64_t count;
-  std::int64_t inner_product;
+// A dimension's iteration range: iterate the loop variable from `first` to
+// `last` inclusive, ascending or descending. `first` and `last` are HIR
+// expressions, so a fixed dimension and a dynamically sized one (whose `last`
+// is `size - 1`) are described the same way and iterated by the same loop.
+struct DimensionRange {
+  hir::ExprId first;
+  hir::ExprId last;
   bool ascending;
 };
 
-// lo +/- ((counter / inner_product) % count)
-auto BuildDecomposeExpr(
-    WalkFrame frame, hir::TypeId int32_type, diag::SourceSpan span,
-    hir::ProceduralVarId counter_var, const DimMeta& dim) -> hir::ExprId {
-  const auto counter_ref_id = frame.current_procedural_body->AddExpr(
-      MakeProcVarRefExpr(counter_var, int32_type, span));
+// Describes one iterated dimension's index range. The only place a dimension's
+// type is consulted: a fixed dimension yields its declared range and direction;
+// a dynamically sized one yields 0..size-1 ascending, with the count sampled
+// once on entry (LRM 12.7.3) into a local that `setup` declares. `array` is the
+// receiver whose `.size()` bounds a dynamic dimension (queue and dynamic array
+// both expose it; the type only names the builtin-method kind).
+auto DescribeRange(
+    hir::ProceduralBody& body, const LoopDim& dim,
+    std::optional<hir::ExprId> array, const slang::ast::Type* array_type,
+    hir::TypeId int32_type, diag::SourceSpan span,
+    std::vector<hir::StmtId>& setup) -> DimensionRange {
+  if (dim.range.has_value()) {
+    const auto& declared = *dim.range;
+    return DimensionRange{
+        .first = body.AddExpr(
+            hir::MakeInt32Literal(declared.left, int32_type, span)),
+        .last = body.AddExpr(
+            hir::MakeInt32Literal(declared.right, int32_type, span)),
+        .ascending = declared.left <= declared.right};
+  }
 
-  hir::ExprId divided_id = counter_ref_id;
-  if (dim.inner_product != 1) {
-    const auto inner_id = frame.current_procedural_body->AddExpr(
-        MakeInt32LiteralExpr(dim.inner_product, int32_type, span));
-    divided_id = frame.current_procedural_body->AddExpr(
+  hir::SubroutineRef size_callee =
+      array_type->isQueue() ? hir::SubroutineRef{hir::BuiltinMethodRef{
+                                  .method = hir::QueueMethodKind::kSize}}
+                            : hir::SubroutineRef{hir::BuiltinMethodRef{
+                                  .method = hir::ArrayMethodKind::kSize}};
+  const hir::ExprId size_id = body.AddExpr(
+      hir::Expr{
+          .type = int32_type,
+          .data =
+              hir::CallExpr{
+                  .callee = std::move(size_callee), .arguments = {*array}},
+          .span = span});
+  const hir::ExprId one_id =
+      body.AddExpr(hir::MakeInt32Literal(1, int32_type, span));
+  const hir::ExprId last_value_id = body.AddExpr(
+      hir::Expr{
+          .type = int32_type,
+          .data =
+              hir::BinaryExpr{
+                  .op = hir::BinaryOp::kSub, .lhs = size_id, .rhs = one_id},
+          .span = span});
+  const hir::ProceduralVarId last_var = body.AddProceduralVar(
+      hir::ProceduralVarDecl{
+          .name = std::string{kLastIndexName},
+          .type = int32_type,
+          .lifetime = hir::VariableLifetime::kAutomatic});
+  setup.push_back(body.AddStmt(
+      hir::Stmt{
+          .label = std::nullopt,
+          .data = hir::VarDeclStmt{.var = last_var, .init = last_value_id},
+          .span = span}));
+  return DimensionRange{
+      .first = body.AddExpr(hir::MakeInt32Literal(0, int32_type, span)),
+      .last = body.AddExpr(hir::MakeProcVarRefExpr(last_var, int32_type, span)),
+      .ascending = true};
+}
+
+// Recursively wraps the loop body in one nested loop per remaining dimension.
+//
+// `array` is `arrayRef` indexed by the enclosing loop variables -- the receiver
+// whose `.size()` bounds a dynamic dimension -- with `array_type` its slang
+// type; both are absent when no dimension at or below is dynamically sized (a
+// purely fixed nest never touches the array). Descending one level indexes
+// `array` by this level's loop variable and peels `array_type` once, so the
+// type flows down naturally rather than being recomputed from the root.
+//
+// Procedural-var ids are minted top to bottom (each level's `last` local before
+// its loop variable, then the body's own locals), matching the order HIR-to-MIR
+// encounters the declarations. The outermost loop (level 0) is the break
+// landing target, marked only when a break in the body actually used the label.
+//
+// Returns the statements realizing this level: a lone `for`, or a dynamic
+// dimension's sampled-`last` declaration followed by its `for`.
+auto BuildForeachNest(
+    ProcessLowerer& proc, const slang::ast::ForeachLoopStatement& fs,
+    WalkFrame frame, const std::vector<const LoopDim*>& levels,
+    std::size_t level, std::optional<hir::ExprId> array,
+    const slang::ast::Type* array_type, hir::TypeId int32_type,
+    diag::SourceSpan span, hir::LoopLabelId foreach_label, bool* label_used)
+    -> diag::Result<std::vector<hir::StmtId>> {
+  auto& body = *frame.current_procedural_body;
+
+  if (level == levels.size()) {
+    // Innermost: the user body, lowered with the foreach label in scope so a
+    // `break` that exits the whole nest (LRM 12.8) targets the outermost loop.
+    auto body_or = proc.LowerStmt(
+        fs.body, frame.WithBreakLabel(foreach_label, label_used));
+    if (!body_or) return std::unexpected(std::move(body_or.error()));
+    return std::vector<hir::StmtId>{body.AddStmt(*std::move(body_or))};
+  }
+
+  const LoopDim& dim = *levels[level];
+
+  // Describe this dimension's range -- the one type-dependent step. Any setup
+  // (a dynamic dimension samples its `last` once into a local) lands in `stmts`
+  // before the loop.
+  std::vector<hir::StmtId> stmts;
+  const DimensionRange range =
+      DescribeRange(body, dim, array, array_type, int32_type, span, stmts);
+
+  const hir::ProceduralVarId loop_var =
+      proc.AddProceduralVar(body, *dim.loopVar, int32_type);
+
+  // Descend: the inner levels iterate `array[loop_var]`, one type peel deeper.
+  // Only built while the array is being threaded (some inner level is dynamic);
+  // a deeper fixed-only tail leaves it absent.
+  std::optional<hir::ExprId> inner_array;
+  const slang::ast::Type* inner_array_type = nullptr;
+  if (array.has_value()) {
+    inner_array_type = array_type->getCanonicalType().getArrayElementType();
+    auto inner_hir_type = proc.Module().InternType(*inner_array_type, span);
+    if (!inner_hir_type) {
+      return std::unexpected(std::move(inner_hir_type.error()));
+    }
+    const hir::ExprId index_id =
+        body.AddExpr(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
+    inner_array = body.AddExpr(
         hir::Expr{
-            .type = int32_type,
+            .type = *inner_hir_type,
             .data =
-                hir::BinaryExpr{
-                    .op = hir::BinaryOp::kDiv,
-                    .lhs = counter_ref_id,
-                    .rhs = inner_id},
+                hir::ElementSelectExpr{.base_value = *array, .index = index_id},
             .span = span});
   }
 
-  const auto count_id = frame.current_procedural_body->AddExpr(
-      MakeInt32LiteralExpr(dim.count, int32_type, span));
-  const auto offset_id = frame.current_procedural_body->AddExpr(
+  auto inner_or = BuildForeachNest(
+      proc, fs, frame, levels, level + 1, inner_array, inner_array_type,
+      int32_type, span, foreach_label, label_used);
+  if (!inner_or) return std::unexpected(std::move(inner_or.error()));
+  const hir::StmtId inner_body =
+      inner_or->size() == 1
+          ? inner_or->front()
+          : body.AddStmt(
+                hir::Stmt{
+                    .label = std::nullopt,
+                    .data = hir::BlockStmt{.statements = std::move(*inner_or)},
+                    .span = span});
+
+  // Iterate the range: one loop shape for every dimension, driven only by
+  // (first, last, direction) -- no dynamic-vs-fixed branch here.
+  const hir::ExprId cond_ref =
+      body.AddExpr(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
+  const hir::ExprId cond_id = body.AddExpr(
       hir::Expr{
           .type = int32_type,
           .data =
               hir::BinaryExpr{
-                  .op = hir::BinaryOp::kMod,
-                  .lhs = divided_id,
-                  .rhs = count_id},
+                  .op = range.ascending ? hir::BinaryOp::kLessEqual
+                                        : hir::BinaryOp::kGreaterEqual,
+                  .lhs = cond_ref,
+                  .rhs = range.last},
+          .span = span});
+  const hir::ExprId step_ref =
+      body.AddExpr(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
+  const hir::ExprId step_id = body.AddExpr(
+      hir::Expr{
+          .type = int32_type,
+          .data =
+              hir::IncDecExpr{
+                  .op = range.ascending ? hir::IncDecOp::kPreInc
+                                        : hir::IncDecOp::kPreDec,
+                  .target = step_ref},
           .span = span});
 
-  const auto lo_id = frame.current_procedural_body->AddExpr(
-      MakeInt32LiteralExpr(dim.lo, int32_type, span));
-  return frame.current_procedural_body->AddExpr(
-      hir::Expr{
-          .type = int32_type,
+  std::vector<hir::ForInit> init;
+  init.emplace_back(hir::ForInitDecl{.var = loop_var, .init = range.first});
+  stmts.push_back(body.AddStmt(
+      hir::Stmt{
+          .label = std::nullopt,
           .data =
-              hir::BinaryExpr{
-                  .op =
-                      dim.ascending ? hir::BinaryOp::kAdd : hir::BinaryOp::kSub,
-                  .lhs = lo_id,
-                  .rhs = offset_id},
-          .span = span});
+              hir::ForStmt{
+                  .init = std::move(init),
+                  .condition = cond_id,
+                  .step = {step_id},
+                  .body = inner_body,
+                  .break_label = (level == 0 && *label_used)
+                                     ? std::optional{foreach_label}
+                                     : std::nullopt},
+          .span = span}));
+  return stmts;
 }
 
+// The associative array iterates by key and the string by byte (LRM 7.9 /
+// 6.16), distinct iteration models from the index-counted dynamic array and
+// queue handled here. Both stay rejected until their own lowering lands.
 auto RejectUnsupportedArrayType(
     const slang::ast::Type& canonical, diag::SourceSpan span)
     -> diag::Result<void> {
   using slang::ast::SymbolKind;
   switch (canonical.kind) {
-    case SymbolKind::DynamicArrayType:
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedStatementForm,
-          "foreach over dynamic array is not yet supported",
-          diag::UnsupportedCategory::kFeature);
-    case SymbolKind::QueueType:
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedStatementForm,
-          "foreach over queue is not yet supported",
-          diag::UnsupportedCategory::kFeature);
     case SymbolKind::AssociativeArrayType:
       return diag::Unsupported(
           span, diag::DiagCode::kUnsupportedStatementForm,
@@ -163,6 +259,7 @@ auto ProcessLowerer::LowerForeachStmt(
     -> diag::Result<hir::Stmt> {
   auto& proc = *this;
   auto& module = proc.Module();
+  auto& body = *frame.current_procedural_body;
   const auto span = module.SourceMapper().SpanOf(fs.sourceRange);
   const auto& canonical = fs.arrayRef.type->getCanonicalType();
   if (auto check = RejectUnsupportedArrayType(canonical, span); !check) {
@@ -171,142 +268,62 @@ auto ProcessLowerer::LowerForeachStmt(
 
   const hir::TypeId int32_type = module.Unit().builtins.int32;
 
-  std::vector<DimMeta> dims;
-  dims.reserve(fs.loopDims.size());
+  // Collect the iterated (non-skipped) dimensions in cardinal order. A
+  // dimension with no constant range is dynamically sized (LRM 7.5 / 7.10).
+  std::vector<const LoopDim*> levels;
+  levels.reserve(fs.loopDims.size());
+  bool any_dynamic = false;
   for (const auto& dim : fs.loopDims) {
     if (dim.loopVar == nullptr) {
       continue;
     }
-    if (!dim.range.has_value()) {
-      throw InternalError(
-          "ProcessLowerer::LowerForeachStmt: non-skipped dim has no constant "
-          "range; the type-level rejection above should have caught dynamic / "
-          "queue / associative element types");
-    }
-    const auto& range = *dim.range;
-    const bool ascending = range.left <= range.right;
-    const std::int64_t count = ascending ? (range.right - range.left + 1)
-                                         : (range.left - range.right + 1);
-    dims.push_back(
-        DimMeta{
-            .loop_var = dim.loopVar,
-            .lo = range.left,
-            .count = count,
-            .inner_product = 1,
-            .ascending = ascending});
+    any_dynamic = any_dynamic || !dim.range.has_value();
+    levels.push_back(&dim);
   }
 
-  // All-dims-skipped: arrayRef still needs evaluation for side effects, body
-  // runs once.
-  if (dims.empty()) {
+  // All dimensions skipped (`foreach (a[])`): the array reference is still
+  // evaluated for side effects and the body runs once. No loop, so a break in
+  // the body is a plain innermost exit.
+  if (levels.empty()) {
     auto array_or = proc.LowerExpr(fs.arrayRef, frame);
     if (!array_or) return std::unexpected(std::move(array_or.error()));
-    const auto array_eval_id =
-        frame.current_procedural_body->AddExpr(*std::move(array_or));
-    const auto array_eval_stmt = frame.current_procedural_body->AddStmt(
+    const auto array_eval_stmt = body.AddStmt(
         hir::Stmt{
             .label = std::nullopt,
-            .data = hir::ExprStmt{.expr = array_eval_id},
+            .data = hir::ExprStmt{.expr = body.AddExpr(*std::move(array_or))},
             .span = span});
-    auto body_or = proc.LowerStmt(fs.body, frame);
+    auto body_or = proc.LowerStmt(fs.body, frame.WithoutBreakLabel());
     if (!body_or) return std::unexpected(std::move(body_or.error()));
-    const auto body_stmt_id =
-        frame.current_procedural_body->AddStmt(*std::move(body_or));
+    const auto body_stmt_id = body.AddStmt(*std::move(body_or));
     return hir::Stmt{
         .label = std::nullopt,
         .data = hir::BlockStmt{.statements = {array_eval_stmt, body_stmt_id}},
         .span = span};
   }
 
-  std::int64_t inner = 1;
-  for (auto& dim : dims | std::views::reverse) {
-    dim.inner_product = inner;
-    inner *= dim.count;
-  }
-  const std::int64_t total = inner;
-
-  // HIR -> MIR maps procedural vars in HIR-id order driven by VarDecl
-  // encounter order. The counter's ForInitDecl is the first VarDecl in the
-  // lowered body, so the counter must claim the lowest id; loop variables
-  // follow in the same outer-to-inner order their VarDeclStmts appear in.
-  const hir::ProceduralVarId counter_var =
-      frame.current_procedural_body->AddProceduralVar(
-          hir::ProceduralVarDecl{
-              .name = std::string{kFlatCounterName},
-              .type = int32_type,
-              .lifetime = hir::VariableLifetime::kAutomatic});
-  for (const auto& dim : dims) {
-    proc.AddProceduralVar(
-        *frame.current_procedural_body, *dim.loop_var, int32_type);
+  // Thread `arrayRef` into the nest only when some dimension needs a runtime
+  // size; a purely fixed foreach lowers to plain range loops that never read
+  // the array.
+  std::optional<hir::ExprId> array;
+  const slang::ast::Type* array_type = nullptr;
+  if (any_dynamic) {
+    auto array_or = proc.LowerExpr(fs.arrayRef, frame);
+    if (!array_or) return std::unexpected(std::move(array_or.error()));
+    array = body.AddExpr(*std::move(array_or));
+    array_type = fs.arrayRef.type;
   }
 
-  const auto zero_id = frame.current_procedural_body->AddExpr(
-      MakeInt32LiteralExpr(0, int32_type, span));
-  std::vector<hir::ForInit> init;
-  init.emplace_back(hir::ForInitDecl{.var = counter_var, .init = zero_id});
-
-  const auto cond_counter_ref_id = frame.current_procedural_body->AddExpr(
-      MakeProcVarRefExpr(counter_var, int32_type, span));
-  const auto total_id = frame.current_procedural_body->AddExpr(
-      MakeInt32LiteralExpr(total, int32_type, span));
-  const auto cond_id = frame.current_procedural_body->AddExpr(
-      hir::Expr{
-          .type = int32_type,
-          .data =
-              hir::BinaryExpr{
-                  .op = hir::BinaryOp::kLessThan,
-                  .lhs = cond_counter_ref_id,
-                  .rhs = total_id},
-          .span = span});
-
-  const auto step_counter_ref_id = frame.current_procedural_body->AddExpr(
-      MakeProcVarRefExpr(counter_var, int32_type, span));
-  const auto step_id = frame.current_procedural_body->AddExpr(
-      hir::Expr{
-          .type = int32_type,
-          .data =
-              hir::IncDecExpr{
-                  .op = hir::IncDecOp::kPreInc, .target = step_counter_ref_id},
-          .span = span});
-
-  std::vector<hir::StmtId> inner_stmts;
-  inner_stmts.reserve(dims.size() + 1);
-  for (const auto& dim : dims) {
-    const auto local_id = *proc.LookupProceduralVar(*dim.loop_var);
-    const auto init_expr_id =
-        BuildDecomposeExpr(frame, int32_type, span, counter_var, dim);
-    inner_stmts.push_back(frame.current_procedural_body->AddStmt(
-        hir::Stmt{
-            .label = std::nullopt,
-            .data = hir::VarDeclStmt{.var = local_id, .init = init_expr_id},
-            .span = span}));
-  }
-  auto body_or = proc.LowerStmt(fs.body, frame);
-  if (!body_or) return std::unexpected(std::move(body_or.error()));
-  inner_stmts.push_back(
-      frame.current_procedural_body->AddStmt(*std::move(body_or)));
-
-  const auto inner_block_id = frame.current_procedural_body->AddStmt(
-      hir::Stmt{
-          .label = std::nullopt,
-          .data = hir::BlockStmt{.statements = std::move(inner_stmts)},
-          .span = span});
-
-  const auto for_stmt_id = frame.current_procedural_body->AddStmt(
-      hir::Stmt{
-          .label = std::nullopt,
-          .data =
-              hir::ForStmt{
-                  .init = std::move(init),
-                  .condition = cond_id,
-                  .step = {step_id},
-                  .body = inner_block_id},
-          .span = span});
+  const hir::LoopLabelId foreach_label = body.AddLoopLabel();
+  bool label_used = false;
+  auto top = BuildForeachNest(
+      proc, fs, frame, levels, 0, array, array_type, int32_type, span,
+      foreach_label, &label_used);
+  if (!top) return std::unexpected(std::move(top.error()));
 
   // LRM 12.7.3 implicit begin-end around the foreach.
   return hir::Stmt{
       .label = std::nullopt,
-      .data = hir::BlockStmt{.statements = {for_stmt_id}},
+      .data = hir::BlockStmt{.statements = std::move(*top)},
       .span = span};
 }
 

--- a/src/lyra/lowering/ast_to_hir/statement/loops.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/loops.cpp
@@ -43,7 +43,7 @@ auto LowerForLoopStmt(
     step_ids.push_back(
         frame.current_procedural_body->AddExpr(*std::move(step_or)));
   }
-  auto body_stmt = proc.LowerStmt(fs.body, frame);
+  auto body_stmt = proc.LowerStmt(fs.body, frame.WithoutBreakLabel());
   if (!body_stmt) return std::unexpected(std::move(body_stmt.error()));
   const hir::StmtId body_id =
       frame.current_procedural_body->AddStmt(*std::move(body_stmt));
@@ -66,7 +66,7 @@ auto LowerWhileLoopStmt(
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
   const hir::ExprId cond_id =
       frame.current_procedural_body->AddExpr(*std::move(cond_or));
-  auto body_or = proc.LowerStmt(ws.body, frame);
+  auto body_or = proc.LowerStmt(ws.body, frame.WithoutBreakLabel());
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   const hir::StmtId body_id =
       frame.current_procedural_body->AddStmt(*std::move(body_or));
@@ -84,7 +84,7 @@ auto LowerRepeatLoopStmt(
   if (!count_or) return std::unexpected(std::move(count_or.error()));
   const hir::ExprId count_id =
       frame.current_procedural_body->AddExpr(*std::move(count_or));
-  auto body_or = proc.LowerStmt(rs.body, frame);
+  auto body_or = proc.LowerStmt(rs.body, frame.WithoutBreakLabel());
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   const hir::StmtId body_id =
       frame.current_procedural_body->AddStmt(*std::move(body_or));
@@ -98,7 +98,7 @@ auto LowerDoWhileLoopStmt(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::DoWhileLoopStatement& ds, diag::SourceSpan span)
     -> diag::Result<hir::Stmt> {
-  auto body_or = proc.LowerStmt(ds.body, frame);
+  auto body_or = proc.LowerStmt(ds.body, frame.WithoutBreakLabel());
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   const hir::StmtId body_id =
       frame.current_procedural_body->AddStmt(*std::move(body_or));
@@ -116,7 +116,7 @@ auto LowerForeverLoopStmt(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::ForeverLoopStatement& fs, diag::SourceSpan span)
     -> diag::Result<hir::Stmt> {
-  auto body_or = proc.LowerStmt(fs.body, frame);
+  auto body_or = proc.LowerStmt(fs.body, frame.WithoutBreakLabel());
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   const hir::StmtId body_id =
       frame.current_procedural_body->AddStmt(*std::move(body_or));

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -30,9 +30,20 @@ auto LowerEmptyStmt(diag::SourceSpan span) -> diag::Result<hir::Stmt> {
       .label = std::nullopt, .data = hir::EmptyStmt{}, .span = span};
 }
 
-auto LowerBreakStmt(diag::SourceSpan span) -> diag::Result<hir::Stmt> {
+auto LowerBreakStmt(const WalkFrame& frame, diag::SourceSpan span)
+    -> diag::Result<hir::Stmt> {
+  // A break whose innermost SystemVerilog loop is a `foreach` must leave every
+  // nested dimension, so it carries that foreach's loop label; consuming the
+  // label marks the outer loop a landing target. An ordinary innermost break
+  // (no foreach label in scope) stays plain.
+  std::optional<hir::LoopLabelId> target = frame.innermost_break_label;
+  if (target.has_value() && frame.innermost_break_used != nullptr) {
+    *frame.innermost_break_used = true;
+  }
   return hir::Stmt{
-      .label = std::nullopt, .data = hir::BreakStmt{}, .span = span};
+      .label = std::nullopt,
+      .data = hir::BreakStmt{.target = target},
+      .span = span};
 }
 
 auto LowerContinueStmt(diag::SourceSpan span) -> diag::Result<hir::Stmt> {
@@ -158,7 +169,7 @@ auto LowerStatement(
           stmt.as<slang::ast::ForeachLoopStatement>(), frame);
 
     case slang::ast::StatementKind::Break:
-      return LowerBreakStmt(span);
+      return LowerBreakStmt(frame, span);
 
     case slang::ast::StatementKind::Continue:
       return LowerContinueStmt(span);

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -142,7 +142,9 @@ auto ProcessLowerer::LowerStmt(const hir::Stmt& stmt, WalkFrame frame)
           [&](const hir::ForeverStmt& f) {
             return LowerForeverStmt(*this, frame, stmt.label, f);
           },
-          [&](const hir::BreakStmt&) { return LowerBreakStmt(stmt.label); },
+          [&](const hir::BreakStmt& b) {
+            return LowerBreakStmt(stmt.label, b.target);
+          },
           [&](const hir::ContinueStmt&) {
             return LowerContinueStmt(stmt.label);
           },

--- a/src/lyra/lowering/hir_to_mir/statement/flow.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/flow.cpp
@@ -141,9 +141,15 @@ auto LowerReturnStmt(
           .value = value, .is_coroutine_return = frame.is_coroutine_body}};
 }
 
-auto LowerBreakStmt(std::optional<std::string> label)
+auto LowerBreakStmt(
+    std::optional<std::string> label, std::optional<hir::LoopLabelId> target)
     -> diag::Result<mir::Stmt> {
-  return mir::Stmt{.label = std::move(label), .data = mir::BreakStmt{}};
+  return mir::Stmt{
+      .label = std::move(label),
+      .data = mir::BreakStmt{
+          .target = target.has_value()
+                        ? std::optional{mir::LoopLabelId{target->value}}
+                        : std::nullopt}};
 }
 
 auto LowerContinueStmt(std::optional<std::string> label)

--- a/src/lyra/lowering/hir_to_mir/statement/loops.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/loops.cpp
@@ -113,7 +113,11 @@ auto LowerForStmt(
           .init = std::move(mir_init),
           .condition = cond_id,
           .step = std::move(step_ids),
-          .scope = body_scope_id}};
+          .scope = body_scope_id,
+          .break_label =
+              f.break_label.has_value()
+                  ? std::optional{mir::LoopLabelId{f.break_label->value}}
+                  : std::nullopt}};
 }
 
 auto LowerWhileStmt(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -1070,8 +1070,13 @@ class MirDumper {
             },
             [&](const WhileStmt& s) { DumpWhileStmt(enclosing, s, id); },
             [&](const DoWhileStmt& s) { DumpDoWhileStmt(enclosing, s, id); },
-            [&](const BreakStmt&) {
-              Line(std::format("Stmt[{}] BreakStmt", id.value));
+            [&](const BreakStmt& s) {
+              Line(
+                  std::format(
+                      "Stmt[{}] BreakStmt{}", id.value,
+                      s.target.has_value()
+                          ? std::format(" -> label {}", s.target->value)
+                          : ""));
             },
             [&](const ContinueStmt&) {
               Line(std::format("Stmt[{}] ContinueStmt", id.value));
@@ -1376,7 +1381,12 @@ class MirDumper {
 
   void DumpForStmt(
       const ProceduralScope& enclosing, const ForStmt& s, StmtId id) {
-    Line(std::format("Stmt[{}] ForStmt", id.value));
+    Line(
+        std::format(
+            "Stmt[{}] ForStmt{}", id.value,
+            s.break_label.has_value()
+                ? std::format(" break_label={}", s.break_label->value)
+                : ""));
     Indent();
     Line("init:");
     Indent();

--- a/tests/cases/cpp/foreach_dynamic_array/case.yaml
+++ b/tests/cases/cpp/foreach_dynamic_array/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.foreach_dynamic_array
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sum_read: 60
+    sum_after_write: 6
+    empty_iters: 0

--- a/tests/cases/cpp/foreach_dynamic_array/main.sv
+++ b/tests/cases/cpp/foreach_dynamic_array/main.sv
@@ -1,0 +1,23 @@
+module Top;
+  int a [];
+  int e [];
+  int sum_read;
+  int sum_after_write;
+  int empty_iters;
+
+  initial begin
+    a = '{10, 20, 30};
+
+    sum_read = 0;
+    foreach (a[i]) sum_read = sum_read + a[i];
+
+    foreach (a[i]) a[i] = i * 2;
+    sum_after_write = 0;
+    foreach (a[i]) sum_after_write = sum_after_write + a[i];
+
+    // A default-constructed dynamic array is empty (LRM Table 6-7), so the
+    // foreach body never runs: the runtime size bound is just zero.
+    empty_iters = 0;
+    foreach (e[i]) empty_iters = empty_iters + 1;
+  end
+endmodule

--- a/tests/cases/cpp/foreach_dynamic_multidim/case.yaml
+++ b/tests/cases/cpp/foreach_dynamic_multidim/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.foreach_dynamic_multidim
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sum_jag: 28
+    sum_rect: 100
+    sum_fixouter: 163
+    sum_break: 6

--- a/tests/cases/cpp/foreach_dynamic_multidim/main.sv
+++ b/tests/cases/cpp/foreach_dynamic_multidim/main.sv
@@ -1,0 +1,48 @@
+module Top;
+  // Jagged dynamic-of-dynamic: each row has its own length, so the inner bound
+  // is sampled per outer iteration. A single flat counter cannot iterate this;
+  // the nested-loop lowering (LRM 12.7.3) takes each dimension's size at its
+  // own level.
+  int jag [][];
+  int sum_jag;
+
+  // A dynamic outer dimension with a fixed inner dimension.
+  int rect [][2];
+  int sum_rect;
+
+  // A fixed outer dimension with a dynamic inner dimension: the inner bound is
+  // `fixouter[i].size()`, still sampled per outer iteration.
+  int fixouter [3][];
+  int sum_fixouter;
+
+  // break must leave every nested dimension (LRM 12.8), even when the bounds
+  // are runtime.
+  int sum_break;
+
+  initial begin
+    jag = new[3];
+    jag[0] = '{1, 2};
+    jag[1] = '{3, 4, 5, 6};
+    jag[2] = '{7};
+    sum_jag = 0;
+    foreach (jag[i, j]) sum_jag = sum_jag + jag[i][j];
+
+    rect = new[2];
+    rect[0] = '{10, 20};
+    rect[1] = '{30, 40};
+    sum_rect = 0;
+    foreach (rect[i, j]) sum_rect = sum_rect + rect[i][j];
+
+    fixouter[0] = '{1, 2};
+    fixouter[1] = '{10, 20, 30};
+    fixouter[2] = '{100};
+    sum_fixouter = 0;
+    foreach (fixouter[i, j]) sum_fixouter = sum_fixouter + fixouter[i][j];
+
+    sum_break = 0;
+    foreach (jag[i, j]) begin
+      if (jag[i][j] == 4) break;
+      sum_break = sum_break + jag[i][j];
+    end
+  end
+endmodule

--- a/tests/cases/cpp/foreach_queue/case.yaml
+++ b/tests/cases/cpp/foreach_queue/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.foreach_queue
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sum_read: 18
+    sum_after_write: 21

--- a/tests/cases/cpp/foreach_queue/main.sv
+++ b/tests/cases/cpp/foreach_queue/main.sv
@@ -1,0 +1,14 @@
+module Top;
+  int q [$] = '{5, 6, 7};
+  int sum_read;
+  int sum_after_write;
+
+  initial begin
+    sum_read = 0;
+    foreach (q[i]) sum_read = sum_read + q[i];
+
+    foreach (q[i]) q[i] = q[i] + 1;
+    sum_after_write = 0;
+    foreach (q[i]) sum_after_write = sum_after_write + q[i];
+  end
+endmodule


### PR DESCRIPTION
## Summary

`foreach` now lowers over dynamic arrays, queues, and jagged dynamic-of-dynamic nests of any dimensionality, alongside the existing fixed packed and unpacked arrays. Each iterated dimension becomes one nested loop driven by a uniform `(first, last, direction)`; the only type-dependent step computes that range -- a fixed dimension from its declared range, a dynamically sized one from `0 .. size-1` with the count sampled once on entry. A `break` that must leave the whole foreach (LRM 12.8) is modeled as a labeled break in HIR/MIR and rendered by the C++ backend as a `goto` past the outermost loop, so multi-level exit is correct and the primitive transfers directly to a future LLVM backend.

## Design

The lowering separates describing the index space (the one type-dependent step, producing a `(first, last, direction)` per dimension) from iterating it (a uniform recursive nest, one loop shape for every dimension). Jagged inner bounds fall out for free because a dimension's `last` is an expression that may reference enclosing loop variables, evaluated on entry to its level. The labeled break replaces the earlier flat-counter trick, which could not represent jagged spaces; see `docs/decisions/foreach-lowering.md`. Two follow-ups are recorded in `docs/progress/refactor.md`: R23 (move the `.Clone()` materialize decision from the renderer into MIR) and R24 (collapse per-container `size` dispatch behind a compile-time resolver).

## Testing

`bazel test //...` passes. New cases cover 1-D dynamic array and queue, jagged and rectangular multi-dimensional dynamic nests, and break-exits-all over runtime bounds; the existing fixed-array foreach suite (multi-dim, skipped dims, directions, negative bases, break/continue/return) continues to pass on the new nested lowering.