### PR TITLE
Lower $finish to a generic CallExpr

### DIFF
--- a/docs/decisions/runtime-effects-as-generic-calls.md
+++ b/docs/decisions/runtime-effects-as-generic-calls.md
@@ -1,0 +1,87 @@
+# Runtime effects as generic calls
+
+Date: 2026-06-17 Status: accepted (implementation pending)
+
+## Context
+
+Runtime effects -- `$display` / `$write` / `$strobe`, `$finish`, file IO (`$fopen` / `$fread` /
+...), `$fscanf`, `$sformat`, `$time` / `$timeformat`, NBA and postponed submission -- need a MIR
+representation. Today MIR carries them as a dedicated `RuntimeCallExpr` node wrapping one of ~22
+specialized payload structs (`RuntimePrintCall{kind, descriptor, items}`,
+`RuntimeFinishCall{level}`, ...), and the C++ backend injects the engine handle as a spliced
+`self->Services()` string at each call site.
+
+Two problems, both against `mir.md`:
+
+1. **The backend re-decides facts MIR did not state** (`mir.md` invariant 10). It splices
+   `self->Services()` -- a parameter that exists in the runtime SDK signature but nowhere in the MIR
+   call -- and it reads the payload struct's shape to lay out the call. A second backend (LIR ->
+   LLVM) would have to re-derive both. A backend reads a stated fact; it never re-decides one.
+2. **A specialized payload is an opaque call to the LLVM path** (`mir.md` Forbidden Shapes / Notes).
+   `kind` / `items` carried as an ad-hoc struct become, under LLVM, an opaque call through which
+   constant folding, dead-arm elimination, and jump-table synthesis cannot reach.
+
+The tangle this caused (recorded so it is not repeated): trying to "fix" services by giving it a
+special field on the runtime-call node, or a `ServicesType` used specially, or making runtime ops
+methods on `Scope` (a god object), all chase the wrong axis. The axis is: MIR's call must be
+generic.
+
+## Decision
+
+A runtime effect is an ordinary `CallExpr` -- a callee symbol plus a `vector<Expr>` of arguments,
+nothing else. Every operand is a generic expression; MIR does not know the role of any argument.
+
+- The engine handle is just one argument: a `self.Services()` expression (itself a `CallExpr`,
+  result type `ServicesType`). MIR does not know it is "the services parameter". That the runtime
+  free function takes the engine first is the SDK signature's business, not MIR's.
+- `kind` is a literal expression; `descriptor` already is an expression; each print `item` is a
+  value-build expression; `finish` `level` is a literal expression. The per-effect payload structs
+  flatten into the argument list.
+- The backend renders one generic shape: callee name, open paren, each argument rendered as an
+  expression, comma-separated, close paren. No services injection, no payload parsing, no per-effect
+  node. The C++ backend and the LLVM-via-LIR backend consume identical input.
+
+`ServicesType` and the `self.Services()` call are NOT layer violations: a generic value type and a
+generic call, exactly like `PackedArray` and `q.Size()`. The violation was only ever treating
+services _specially_ -- a node field, a special-cased injection -- instead of as a plain element of
+the argument vector.
+
+## Rejected
+
+- **Specialized payload node (`RuntimeCallExpr` + per-effect struct).** The current shape. Opaque to
+  the LLVM optimizer; forces every backend to re-implement payload layout. This is what retires.
+- **Backend injects `self->Services()`.** The backend re-decides a fact (the engine argument) absent
+  from the MIR call; the LLVM backend would then receive a call with one fewer argument than the SDK
+  function takes. Violates `mir.md` invariant 10.
+- **`services` as a special field on the runtime-call node.** Non-generic: it special-cases one
+  argument instead of leaving it a plain element of the argument vector. This was the original layer
+  violation.
+- **Runtime ops as methods on `Scope` (or the engine).** `self->Print(...)`, `self->Finish(...)`.
+  Pushes dozens of effects onto one class (god object) for the cosmetic win of method-call syntax,
+  and binds the runtime SDK to `Scope`. A free function keeps the minimal dependency -- it needs
+  only the engine, not the whole scope. (Calling `LyraPrint(self, ...)` instead of
+  `LyraPrint(services, ...)` is the same idea in disguise: the op stays a free function either way;
+  only the first argument differs, and `self.Services()` as a generic arg is the cleaner pick.)
+
+## Consequences
+
+- One generic `CallExpr` is MIR's only call shape; `RuntimeCallExpr` and the ~22 payload structs
+  retire. Runtime free functions (`LyraPrint(RuntimeServices&, ...)`, etc.) stay unchanged.
+- Both backends eat the same generic input; the LLVM optimizer reaches through.
+- **Implementation in progress.** `$finish` is the first effect on this shape: it lowers to a
+  generic `CallExpr` whose first argument is `self.Services()` and renders through one generic
+  system-subroutine path with no injection. The remaining effects still use `RuntimeCallExpr` +
+  payload structs and still splice `self->Services()`; that is transitional tech debt to converge to
+  this decision. Flattening `$display` items into value-build expressions is the largest piece.
+
+## Cross-references
+
+- `architecture/mir.md` invariant 10 (multi-backend; a backend never re-derives a stated fact) and
+  Forbidden Shapes / Notes (a specialized / opaque payload becomes an opaque call the LLVM optimizer
+  cannot reach).
+- `decisions/format-dispatch.md` (the runtime-side `Formatter<T>` mechanism each flattened print
+  item still uses at execution time).
+- `decisions/callable-receiver.md` (`self` binding; `self.Services()` reaches the engine through
+  it).
+- `progress/refactor.md` R20 (superseded: R20's "runtime call becomes a method call" framing is
+  replaced by this generic-call form).

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -340,22 +340,27 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       their declaration shape itself fixes the field at construction. See
       `docs/decisions/variable-initialization.md`.
 
-- [ ] R20 -- Turn runtime-scope method calls (`Services()`, `RegisterChild(name, indices, child)`,
-      `RegisterSignal(name, var)`, `AddProcess(kind, coroutine)`,
-      `SubmitObserved(site_id,     closure)`, etc.) into MIR-modeled expressions so the cpp render
-      stops hardcoding `"self->Services()"`, `"self->RegisterChild(\"...\", ...)"`,
-      `"std::make_unique<Child>(self,     ...)"` and similar literals in `render_print.cpp` /
-      `render_stmt.cpp`. Today each runtime method has bespoke render code that string-concatenates
-      the receiver name with the method name; every argument is rendered uniformly through
-      `RenderExpr` except the implicit receiver, which is spelled out as a literal. Target shape:
-      each runtime call is a `mir::CallExpr` whose callee is a `RuntimeServicesCallee` (or sibling
-      variants for scope-level methods like RegisterChild) carrying the method identity, and whose
-      `arguments[0]` is the receiver expression (`ProceduralVarRef(self)`). The render becomes one
-      rule for every call shape: "render the callee name, open paren, render each argument as an
-      expression separated by commas, close paren". No render handler knows the literal string
-      `"self"` or the literal `"Services()"` anywhere. **Why deferred**: cross-cuts every
-      runtime-method call site (~30 across `render_print.cpp` / `render_stmt.cpp`) and requires MIR
-      vocabulary additions on the Callee variant. **Trigger**: scheduled in front of R18.
+- [ ] R20 -- **SUPERSEDED by `decisions/runtime-effects-as-generic-calls.md`.** The framing below
+      ("runtime call becomes a method call with a RuntimeServicesCallee / receiver") is replaced by:
+      a runtime effect is a generic `CallExpr` (callee symbol + a `vector<Expr>` of arguments), and
+      services is just one of those arguments -- a plain `self.Services()` expression -- not a
+      receiver and not a special node. Original text retained for history: Turn runtime-scope method
+      calls (`Services()`, `RegisterChild(name, indices, child)`, `RegisterSignal(name, var)`,
+      `AddProcess(kind, coroutine)`, `SubmitObserved(site_id,     closure)`, etc.) into MIR-modeled
+      expressions so the cpp render stops hardcoding `"self->Services()"`,
+      `"self->RegisterChild(\"...\", ...)"`, `"std::make_unique<Child>(self,     ...)"` and similar
+      literals in `render_print.cpp` / `render_stmt.cpp`. Today each runtime method has bespoke
+      render code that string-concatenates the receiver name with the method name; every argument is
+      rendered uniformly through `RenderExpr` except the implicit receiver, which is spelled out as
+      a literal. Target shape: each runtime call is a `mir::CallExpr` whose callee is a
+      `RuntimeServicesCallee` (or sibling variants for scope-level methods like RegisterChild)
+      carrying the method identity, and whose `arguments[0]` is the receiver expression
+      (`ProceduralVarRef(self)`). The render becomes one rule for every call shape: "render the
+      callee name, open paren, render each argument as an expression separated by commas, close
+      paren". No render handler knows the literal string `"self"` or the literal `"Services()"`
+      anywhere. **Why deferred**: cross-cuts every runtime-method call site (~30 across
+      `render_print.cpp` / `render_stmt.cpp`) and requires MIR vocabulary additions on the Callee
+      variant. **Trigger**: scheduled in front of R18.
 
 - [ ] R21 -- Rename `LowerStructuralVarRefExpr` (the central HIR-to-MIR helper) to reflect what it
       actually does post-R16: translate an HIR implicit-receiver structural-var read into a MIR

--- a/include/lyra/lowering/hir_to_mir/expression/system/control.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/system/control.hpp
@@ -6,18 +6,20 @@
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
-// Lower a termination system subroutine call ($finish) into a `mir::Expr`
-// carrying a `mir::RuntimeCallExpr` with a `RuntimeFinishCall` payload.
-// Resolves the optional level argument from the call's literal integer arg
+// Lower a termination system subroutine call ($finish) into a generic
+// `mir::CallExpr`: the engine handle (`self.Services()`) followed by the level
+// argument. Resolves the optional level from the call's literal integer arg
 // (falling back to the descriptor's default_level when omitted). Returns a
 // user diagnostic if the level arg is non-literal or out of range.
 auto LowerFinishSystemSubroutineCall(
-    const ProcessLowerer& process, const hir::CallExpr& call,
+    const ProcessLowerer& process, const WalkFrame& frame,
+    const hir::CallExpr& call, support::SystemSubroutineId id,
     std::string_view name, const support::TerminationSystemSubroutineInfo& info,
     diag::SourceSpan span) -> diag::Result<mir::Expr>;
 

--- a/include/lyra/mir/builtin_method.hpp
+++ b/include/lyra/mir/builtin_method.hpp
@@ -114,6 +114,14 @@ enum class IteratorMethodKind : std::uint8_t {
   kIndex,
 };
 
+// Methods on the runtime scope handle (the `self` receiver). `kServices`
+// reaches the engine facade `RuntimeServices` -- the engine handle every
+// runtime-effect call threads as a plain argument
+// (docs/decisions/runtime-effects-as-generic-calls.md).
+enum class ScopeMethodKind : std::uint8_t {
+  kServices,
+};
+
 struct EnumMethodInfo {
   TypeId enum_type;
   EnumMethodKind kind;
@@ -147,6 +155,10 @@ struct IteratorMethodInfo {
   IteratorMethodKind kind;
 };
 
+struct ScopeMethodInfo {
+  ScopeMethodKind kind;
+};
+
 // True for methods whose backend emission must wrap the call site in
 // `co_await`. The runtime returns an awaitable that suspends the calling
 // coroutine and reschedules it through RuntimeServices when the event fires.
@@ -158,7 +170,7 @@ struct BuiltinMethodCallee {
   std::variant<
       EnumMethodInfo, StringMethodInfo, EventMethodInfo, ArrayMethodInfo,
       QueueMethodInfo, AssociativeMethodInfo, ValueMethodInfo,
-      IteratorMethodInfo>
+      IteratorMethodInfo, ScopeMethodInfo>
       method;
 };
 

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -27,6 +27,7 @@ struct BuiltinMirTypes {
   TypeId realtime;
   TypeId time;
   TypeId self_pointer;
+  TypeId services;
 };
 
 struct CompilationUnit {
@@ -68,6 +69,7 @@ struct CompilationUnit {
                 TypeData{PointerType{
                     .pointee = AddType(TypeData{SelfType{}}),
                     .ownership = PointerOwnership::kBorrowed}}),
+            .services = AddType(TypeData{ServicesType{}}),
         } {
   }
 

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -15,7 +15,6 @@
 #include "lyra/mir/integral_constant.hpp"
 #include "lyra/mir/runtime_diagnostic.hpp"
 #include "lyra/mir/runtime_file_io.hpp"
-#include "lyra/mir/runtime_finish.hpp"
 #include "lyra/mir/runtime_print.hpp"
 #include "lyra/mir/runtime_scan.hpp"
 #include "lyra/mir/runtime_sformat.hpp"
@@ -134,14 +133,14 @@ struct CallExpr {
 };
 
 using RuntimeCall = std::variant<
-    RuntimePrintCall, RuntimeDiagnosticCall, RuntimeFinishCall,
-    RuntimeSubmitObservedCall, RuntimeSubmitNbaCall, RuntimeSubmitPostponedCall,
-    RuntimeFileOpenCall, RuntimeFileCloseCall, RuntimeFileGetcCall,
-    RuntimeFileUngetcCall, RuntimeFileGetsCall, RuntimeFileReadCall,
-    RuntimeFileSeekCall, RuntimeFileRewindCall, RuntimeFileTellCall,
-    RuntimeFileEofCall, RuntimeFileErrorCall, RuntimeFileFlushCall,
-    RuntimeScanCall, RuntimeSFormatCall, RuntimeTimeCall,
-    RuntimeSetTimeFormatCall, RuntimePrintTimescaleCall>;
+    RuntimePrintCall, RuntimeDiagnosticCall, RuntimeSubmitObservedCall,
+    RuntimeSubmitNbaCall, RuntimeSubmitPostponedCall, RuntimeFileOpenCall,
+    RuntimeFileCloseCall, RuntimeFileGetcCall, RuntimeFileUngetcCall,
+    RuntimeFileGetsCall, RuntimeFileReadCall, RuntimeFileSeekCall,
+    RuntimeFileRewindCall, RuntimeFileTellCall, RuntimeFileEofCall,
+    RuntimeFileErrorCall, RuntimeFileFlushCall, RuntimeScanCall,
+    RuntimeSFormatCall, RuntimeTimeCall, RuntimeSetTimeFormatCall,
+    RuntimePrintTimescaleCall>;
 
 struct RuntimeCallExpr {
   RuntimeCall call;
@@ -246,6 +245,23 @@ struct Expr {
     ExprId target, ExprId value, TypeId type) -> Expr {
   return Expr{
       .data = AssignExpr{.target = target, .value = value}, .type = type};
+}
+
+// `self.Services()` -- reaches the engine facade from the scope handle.
+// `self` is the receiver ExprId; `services` is ServicesType. The caller does
+// the AddExpr. Every runtime-effect call threads the result as its engine
+// handle (docs/decisions/runtime-effects-as-generic-calls.md).
+[[nodiscard]] inline auto MakeServicesCallExpr(ExprId self, TypeId services)
+    -> Expr {
+  return Expr{
+      .data =
+          CallExpr{
+              .callee =
+                  BuiltinMethodCallee{
+                      .method =
+                          ScopeMethodInfo{.kind = ScopeMethodKind::kServices}},
+              .arguments = {self}},
+      .type = services};
 }
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/runtime_finish.hpp
+++ b/include/lyra/mir/runtime_finish.hpp
@@ -1,9 +1,0 @@
-#pragma once
-
-namespace lyra::mir {
-
-struct RuntimeFinishCall {
-  int level;
-};
-
-}  // namespace lyra::mir

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -29,6 +29,7 @@ enum class TypeKind {
   kExternalUnitObject,
   kScope,
   kSelf,
+  kServices,
   kPointer,
   kVector,
   kExternalRef,
@@ -154,6 +155,14 @@ struct SelfType {
   auto operator==(const SelfType&) const -> bool = default;
 };
 
+// The engine facade `lyra::runtime::RuntimeServices`. A callable body reaches
+// it from `self` through the `Services` scope method; it is the engine handle
+// every runtime-effect call threads as a plain argument
+// (docs/decisions/runtime-effects-as-generic-calls.md).
+struct ServicesType {
+  auto operator==(const ServicesType&) const -> bool = default;
+};
+
 enum class PointerOwnership {
   kUnique,
   kShared,
@@ -209,7 +218,8 @@ using TypeData = std::variant<
     PackedArrayType, EnumType, UnpackedArrayType, DynamicArrayType, QueueType,
     AssociativeArrayType, StringType, EventType, RealType, ShortRealType,
     RealTimeType, ChandleType, VoidType, ObjectType, ExternalUnitObjectType,
-    ScopeType, SelfType, PointerType, VectorType, ExternalRefType>;
+    ScopeType, SelfType, ServicesType, PointerType, VectorType,
+    ExternalRefType>;
 
 struct Type {
   TypeData data;

--- a/include/lyra/runtime/finish.hpp
+++ b/include/lyra/runtime/finish.hpp
@@ -2,17 +2,20 @@
 
 #include "lyra/runtime/coroutine.hpp"
 #include "lyra/runtime/runtime_services.hpp"
+#include "lyra/value/packed_array.hpp"
 
 namespace lyra::runtime {
 
 // `$finish(level)` -- requests the engine to tear down the simulation after
 // the current slot completes. The awaitable also suspends the calling
 // process; since `finished_` is set before await_suspend returns, the
-// engine drops it on the next dispatch.
+// engine drops it on the next dispatch. `level` arrives as a Lyra value, the
+// same as any other call argument (LRM 20.2).
 class FinishAwaitable {
  public:
-  FinishAwaitable(RuntimeServices& services, int level)
-      : services_(&services), level_(level) {
+  FinishAwaitable(
+      RuntimeServices& services, const lyra::value::PackedArray& level)
+      : services_(&services), level_(static_cast<int>(level.ToInt64())) {
   }
 
   [[nodiscard]] static auto await_ready() noexcept -> bool {
@@ -34,7 +37,9 @@ class FinishAwaitable {
   int level_;
 };
 
-inline auto Finish(RuntimeServices& services, int level) -> FinishAwaitable {
+inline auto Finish(
+    RuntimeServices& services, const lyra::value::PackedArray& level)
+    -> FinishAwaitable {
   return FinishAwaitable{services, level};
 }
 

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -27,6 +27,7 @@
 #include "lyra/mir/integral_constant.hpp"
 #include "lyra/mir/type.hpp"
 #include "lyra/mir/unary_op.hpp"
+#include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::backend::cpp {
 
@@ -1128,17 +1129,75 @@ auto RenderValueMethodCall(
   throw InternalError("RenderValueMethodCall: unknown kind");
 }
 
+// `self.Services()` -- reaches the engine facade from the scope handle. The
+// receiver (arguments[0]) is the `self` pointer, so the call is `->`. This is
+// the engine handle every runtime-effect call threads as a plain argument.
+auto RenderScopeMethodCall(
+    const RenderContext& ctx, const mir::CallExpr& call,
+    const mir::ScopeMethodInfo& m) -> diag::Result<std::string> {
+  if (call.arguments.empty()) {
+    throw InternalError(
+        "RenderScopeMethodCall: scope method expects a receiver argument");
+  }
+  auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
+  if (!receiver_or) {
+    return std::unexpected(std::move(receiver_or.error()));
+  }
+  switch (m.kind) {
+    case mir::ScopeMethodKind::kServices:
+      return std::format("({})->Services()", *receiver_or);
+  }
+  throw InternalError("RenderScopeMethodCall: unknown ScopeMethodKind");
+}
+
+// A system subroutine renders as one generic call: the runtime entry name
+// followed by every argument rendered uniformly. The engine handle is not
+// injected here -- it is `arguments[0]` (a `self.Services()` expression) and
+// renders like any other argument. Which runtime entry an id maps to, and
+// whether the call suspends the caller (a suspending effect must be co_awaited
+// at the site, since a plain function cannot suspend its calling coroutine),
+// are the backend's fixed realization of the stated id.
+auto RenderSystemSubroutineCall(
+    const RenderContext& ctx, const mir::CallExpr& call,
+    const mir::SystemSubroutineCallee& callee) -> diag::Result<std::string> {
+  const support::SystemSubroutineDesc& desc =
+      support::LookupSystemSubroutine(callee.id);
+  std::string name;
+  bool suspends = false;
+  if (std::holds_alternative<support::TerminationSystemSubroutineInfo>(
+          desc.semantic)) {
+    name = "lyra::runtime::Finish";
+    suspends = true;
+  } else {
+    return diag::Unsupported(
+        diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+        std::format(
+            "system subroutine '{}' is not yet lowered to a generic call",
+            desc.name),
+        diag::UnsupportedCategory::kFeature);
+  }
+
+  std::string out = suspends ? "co_await " : "";
+  out += name;
+  out += "(";
+  for (std::size_t i = 0; i < call.arguments.size(); ++i) {
+    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+    if (i != 0) out += ", ";
+    out += *std::move(arg_or);
+  }
+  out += ")";
+  return out;
+}
+
 auto RenderCallExpr(
     const RenderContext& ctx, const mir::CallExpr& call,
     mir::TypeId result_type) -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
-          [](const mir::SystemSubroutineCallee&) -> diag::Result<std::string> {
-            return diag::Unsupported(
-                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-                "system subroutine call as expression is not yet implemented "
-                "in cpp emit",
-                diag::UnsupportedCategory::kFeature);
+          [&](const mir::SystemSubroutineCallee& s)
+              -> diag::Result<std::string> {
+            return RenderSystemSubroutineCall(ctx, call, s);
           },
           [&](const mir::StructuralSubroutineRef& ref)
               -> diag::Result<std::string> {
@@ -1226,6 +1285,9 @@ auto RenderCallExpr(
                           "backend (LRM 7.12.4 -- HIR -> MIR should have "
                           "rewritten `item.index` to a ProceduralVarRef on "
                           "the closure parameter binding)");
+                    },
+                    [&](const mir::ScopeMethodInfo& m) {
+                      return RenderScopeMethodCall(ctx, call, m);
                     },
                 },
                 b.method);

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -17,7 +17,6 @@
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/runtime_diagnostic.hpp"
 #include "lyra/mir/runtime_file_io.hpp"
-#include "lyra/mir/runtime_finish.hpp"
 #include "lyra/mir/runtime_print.hpp"
 #include "lyra/mir/runtime_submit.hpp"
 #include "lyra/mir/runtime_timescale.hpp"
@@ -207,12 +206,6 @@ auto RenderRuntimePrintCall(
   return out;
 }
 
-auto RenderRuntimeFinishCall(const mir::RuntimeFinishCall& call)
-    -> std::string {
-  return std::format(
-      "co_await lyra::runtime::Finish(self->Services(), {})", call.level);
-}
-
 auto RenderRuntimeDiagnosticSeverity(mir::DiagnosticSeverity s)
     -> std::string_view {
   switch (s) {
@@ -286,9 +279,6 @@ auto RenderRuntimeCallExpr(
           [&](const mir::RuntimeDiagnosticCall& dc)
               -> diag::Result<std::string> {
             return RenderRuntimeDiagnosticCall(ctx, dc);
-          },
-          [&](const mir::RuntimeFinishCall& fc) -> diag::Result<std::string> {
-            return RenderRuntimeFinishCall(fc);
           },
           [&](const mir::RuntimeSubmitObservedCall& sc)
               -> diag::Result<std::string> {

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -126,6 +126,9 @@ auto RenderTypeAsCpp(
           [&](const mir::SelfType&) -> diag::Result<std::string> {
             return std::string{owner_scope.name};
           },
+          [](const mir::ServicesType&) -> diag::Result<std::string> {
+            return std::string{"lyra::runtime::RuntimeServices&"};
+          },
           [&](const mir::PointerType& p) -> diag::Result<std::string> {
             auto inner_or = RenderTypeAsCpp(unit, owner_scope, p.pointee);
             if (!inner_or) return std::unexpected(std::move(inner_or.error()));

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -307,7 +307,7 @@ auto LowerSystemSubroutineCall(
           [&](const support::TerminationSystemSubroutineInfo& term)
               -> diag::Result<mir::Expr> {
             return LowerFinishSystemSubroutineCall(
-                process, call, desc.name, term, span);
+                process, frame, call, desc.id, desc.name, term, span);
           },
           [&](const support::DiagnosticSystemSubroutineInfo& diag_info)
               -> diag::Result<mir::Expr> {

--- a/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
@@ -14,8 +14,9 @@
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/walk_frame.hpp"
+#include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
-#include "lyra/mir/runtime_finish.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -34,10 +35,25 @@ auto TryExtractLiteralInt(const hir::Expr& expr)
   return static_cast<std::int64_t>(c.value_words[0]);
 }
 
+// Builds the `self.Services()` argument: a `ProceduralVarRef` to `self`
+// (mir.md invariant 11) wrapped in the `Services` scope-method call. Every
+// runtime-effect call threads its result as the engine handle.
+auto BuildServicesArg(const ProcessLowerer& process, const WalkFrame& frame)
+    -> mir::ExprId {
+  auto& body = *frame.current_procedural_scope;
+  const auto& builtins = process.Module().Unit().builtins;
+  const mir::ExprId self_id = body.AddExpr(
+      mir::MakeProceduralVarRefExpr(
+          frame.procedural_depth - frame.self_decl_depth, *frame.self_binding,
+          builtins.self_pointer));
+  return body.AddExpr(mir::MakeServicesCallExpr(self_id, builtins.services));
+}
+
 }  // namespace
 
 auto LowerFinishSystemSubroutineCall(
-    const ProcessLowerer& process, const hir::CallExpr& call,
+    const ProcessLowerer& process, const WalkFrame& frame,
+    const hir::CallExpr& call, support::SystemSubroutineId id,
     std::string_view name, const support::TerminationSystemSubroutineInfo& info,
     diag::SourceSpan span) -> diag::Result<mir::Expr> {
   const auto& hir_proc = process.HirBody();
@@ -65,10 +81,16 @@ auto LowerFinishSystemSubroutineCall(
     }
     level = static_cast<int>(*literal);
   }
+  const auto& builtins = process.Module().Unit().builtins;
+  const mir::ExprId services_id = BuildServicesArg(process, frame);
+  const mir::ExprId level_id = frame.current_procedural_scope->AddExpr(
+      mir::MakeInt32Literal(builtins.int32, static_cast<std::int64_t>(level)));
   return mir::Expr{
       .data =
-          mir::RuntimeCallExpr{.call = mir::RuntimeFinishCall{.level = level}},
-      .type = process.Module().Unit().builtins.void_type};
+          mir::CallExpr{
+              .callee = mir::SystemSubroutineCallee{.id = id},
+              .arguments = {services_id, level_id}},
+      .type = builtins.void_type};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -178,6 +178,7 @@ class MirDumper {
             },
             [](const ScopeType&) -> std::string { return "Scope"; },
             [](const SelfType&) -> std::string { return "Self"; },
+            [](const ServicesType&) -> std::string { return "Services"; },
             [](const PointerType& p) -> std::string {
               switch (p.ownership) {
                 case PointerOwnership::kUnique:
@@ -396,6 +397,11 @@ class MirDumper {
                       [](const IteratorMethodInfo& m) -> std::string {
                         return std::format(
                             "IteratorMethodInfo[kind={}]",
+                            static_cast<int>(m.kind));
+                      },
+                      [](const ScopeMethodInfo& m) -> std::string {
+                        return std::format(
+                            "ScopeMethodInfo[kind={}]",
                             static_cast<int>(m.kind));
                       },
                   },
@@ -780,9 +786,6 @@ class MirDumper {
                   },
                   [&](const RuntimeDiagnosticCall& dc) {
                     DumpRuntimeDiagnosticCallItems(dc, scope);
-                  },
-                  [&](const RuntimeFinishCall& fc) {
-                    Line(std::format("RuntimeFinishCall level={}", fc.level));
                   },
                   [&](const RuntimeSubmitObservedCall& sc) {
                     Line(

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -76,6 +76,7 @@ auto Type::Kind() const -> TypeKind {
           },
           [](const ScopeType&) { return TypeKind::kScope; },
           [](const SelfType&) { return TypeKind::kSelf; },
+          [](const ServicesType&) { return TypeKind::kServices; },
           [](const PointerType&) { return TypeKind::kPointer; },
           [](const VectorType&) { return TypeKind::kVector; },
           [](const ExternalRefType&) { return TypeKind::kExternalRef; },


### PR DESCRIPTION
## Summary

Migrates `$finish` off the dedicated `RuntimeCallExpr` + `RuntimeFinishCall` payload onto the generic `CallExpr` shape, the first step of `docs/decisions/runtime-effects-as-generic-calls.md`. A runtime effect is now an ordinary call: a callee symbol plus a `vector<Expr>` of arguments, with the engine handle threaded as a plain `self.Services()` argument rather than injected by the backend. MIR knows no argument's role, so the C++ backend and the future LIR-to-LLVM backend consume identical input.

## Design

`$finish(level)` lowers to `CallExpr(SystemSubroutineCallee{id}, [self.Services(), level])`. `self.Services()` is itself a generic call -- a `BuiltinMethodCallee` with a new `ScopeMethod(kServices)` arm on the scope receiver -- with result type `ServicesType` (reintroduced as a MIR type rendering to `RuntimeServices&`). The backend renders any system-subroutine call as one uniform shape: an optional `co_await` prefix for suspending effects, the runtime entry name, then every argument rendered through the same `RenderExpr` path. No services injection, no payload parsing. `RuntimeFinishCall` and its render/dump arms are deleted; the runtime `Finish` now accepts the level as a Lyra value (`PackedArray`), matching the generic argument it receives.

A shared MIR factory `MakeServicesCallExpr` sits beside `MakeInt32Literal` / `MakeMemberAccessExpr`; the lowering glue that reaches `self` from the walk frame stays on the lowering side.

## Testing

`bazel test //...` green. `$finish` behaviour is unchanged (the existing `finish_*` cpp_run cases cover level 0/1/2, loops, final blocks, sibling termination); verified end-to-end that the emitted call is `co_await lyra::runtime::Finish((self)->Services(), lyra::value::PackedArray::Int(2))`.