### PR TITLE
Support foreach over associative arrays

### DIFF
--- a/docs/decisions/foreach-lowering.md
+++ b/docs/decisions/foreach-lowering.md
@@ -1,7 +1,7 @@
 # `foreach` lowering shape
 
-Date: 2026-06-02 (flat-counter); 2026-06-17 (revised to nested loops + labeled break) Status:
-accepted
+Date: 2026-06-02 (flat-counter); 2026-06-17 (revised to nested loops + labeled break; extended to
+associative key-walk dimensions) Status: accepted
 
 ## Context
 
@@ -29,12 +29,19 @@ provide natively, and the natural primitive in LLVM IR and WebAssembly.
 **`foreach` lowers to one ordinary nested loop per iterated dimension, and a break that must leave
 the whole foreach is modeled as a labeled break -- the universal multi-level-exit primitive.**
 
-1. **Nested loops, size sampled per level.** The non-skipped dimensions become nested `for` loops in
-   cardinal order (outer to inner). A fixed dimension loops over its declared range and direction. A
-   dynamically sized dimension samples its element count once into a synthetic local on entry to
-   that level -- `a.size()` for the outermost dimension, `a[i].size()` for the next, and so on --
-   then counts `0..count-1`. Because the inner count is read inside the enclosing loop, a jagged
-   array iterates correctly with no special case: the inner bound simply reads the current row.
+1. **Nested loops, one `for` per dimension.** The non-skipped dimensions become nested `for` loops
+   in cardinal order (outer to inner). Each dimension supplies the `for`'s init / condition / step;
+   that is the sole type-dependent step, and the three families all fit the one shape. A fixed
+   dimension loops over its declared range and direction. A dynamically sized dimension samples its
+   element count once into a synthetic local on entry to that level -- `a.size()` for the outermost
+   dimension, `a[i].size()` for the next, and so on -- then counts `0..count-1`. Because the inner
+   count is read inside the enclosing loop, a jagged array iterates correctly with no special case:
+   the inner bound simply reads the current row. An associative dimension walks by key (LRM 7.9.4 --
+   7.9.7) instead of counting an index: the `for`'s counter holds the first / next return, its step
+   advances the key, and its loop variable is the key the body indexes by. `continue` lands on the
+   step, so it advances to the next key (LRM 12.8); an empty array returns 0 from `first`, so the
+   body never runs. Key-walked and index-counted dimensions nest freely in one foreach, since both
+   are just a `for`.
 
 2. **Labeled break.** HIR and MIR carry a `LoopLabelId`: a loop may be a break target, and a `break`
    may name the loop it exits. A `break` whose innermost SystemVerilog loop is the foreach carries
@@ -93,8 +100,9 @@ labeled-break-via-`goto` choice (item 3 above) is the resolution:
 - The labeled break is the only new IR concept, and it is the same primitive every other
   multi-level-exit language and IR uses, so the model transfers directly to a future LLVM backend (a
   branch) rather than baking in a C++-specific trick.
-- Associative-array and string `foreach` remain rejected: they iterate by key (LRM 7.9) and by byte
-  (LRM 6.16), distinct iteration models with their own lowering.
+- Associative-array `foreach` fits the same nested-`for` model with no new construct: its dimension
+  is just a `for` whose pieces are a key walk instead of an index count. String `foreach` remains
+  rejected: it iterates by byte (LRM 6.16), a distinct model with its own lowering.
 
 ## Cross-references
 

--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -32,7 +32,8 @@ follow once dynamic array's storage and runtime conventions are settled and prov
 | Q1.. | Not yet scoped: queue.                                               |
 | A1   | Done: string / integral index, element read / write, query methods.  |
 | A2   | Done: traversal protocol (`first` / `last` / `next` / `prev`).       |
-| A3.. | Open: foreach, literals, whole-array assignment, locators.           |
+| A3   | Done: `foreach` over an associative array (any dimensionality).      |
+| A4.. | Open: literals, whole-array assignment, locators.                    |
 
 ## Dynamic Array
 
@@ -142,10 +143,16 @@ the lookup key and imposes an ordering.
       variable and return -1) is unreachable: the frontend requires the index argument to be
       type-equivalent to the array's index type and rejects a narrower one before lowering.
 
-- [ ] A3 -- `foreach` over an associative array (`control-flow.md` C10); associative-array literals
-      with an optional default (LRM 7.9.11) and whole-array associative assignment (LRM 7.9.9); the
-      wildcard `[*]`, class, and other user-defined index families (LRM 7.8.1 / 7.8.3 / 7.8.5); and
-      the locator-family methods that return an index queue of the key type (LRM 7.12.1).
+- [x] A3 -- `foreach` over an associative array (`control-flow.md` C10), iterating the entries in
+      LRM 7.8 index order (lexicographic for string keys, signed numeric for integral). The
+      dimension walks by key via the traversal protocol rather than counting an index, and an
+      associative dimension nests freely with index-counted dimensions in one foreach (associative
+      of associative, associative of fixed, and the reverse).
+
+- [ ] A4 -- Associative-array literals with an optional default (LRM 7.9.11) and whole-array
+      associative assignment (LRM 7.9.9); the wildcard `[*]`, class, and other user-defined index
+      families (LRM 7.8.1 / 7.8.3 / 7.8.5); and the locator-family methods that return an index
+      queue of the key type (LRM 7.12.1).
 
 ## Cross-references
 

--- a/docs/progress/control-flow.md
+++ b/docs/progress/control-flow.md
@@ -8,13 +8,13 @@ order.
 
 ## Actionable
 
-C9 and C10 are done for packed, unpacked, dynamic-array, and queue arrays of any dimensionality,
-including jagged dynamic-of-dynamic nests. The associative-array case stays open (it iterates by
-key, a distinct model).
+C9 and C10 are done for packed, unpacked, dynamic-array, queue, and associative arrays of any
+dimensionality, including jagged dynamic-of-dynamic nests and mixed key-walked / index-counted
+nests. Only `foreach` over a string (by byte, LRM 6.16) stays open.
 
-| Item | Status                                                                     |
-| ---- | -------------------------------------------------------------------------- |
-| C10  | Done: dynamic array / queue, any dimensionality incl. jagged. Open: assoc. |
+| Item | Status                                                                      |
+| ---- | --------------------------------------------------------------------------- |
+| C10  | Done: dynamic array / queue / associative, any dimensionality incl. jagged. |
 
 ## Sub-Steps
 
@@ -54,8 +54,11 @@ key, a distinct model).
       (LRM 12.7.3), so a jagged dynamic-of-dynamic array (`int a[][]`, inner length per row)
       iterates correctly. A `break` that must leave the whole foreach (LRM 12.8) is modeled as a
       labeled break and rendered as a `goto` past the outermost loop. `foreach` over an associative
-      array stays rejected with `kUnsupportedStatementForm` (it iterates by key, a distinct model).
-      See `../decisions/foreach-lowering.md`.
+      array iterates its entries in index order (LRM 7.8: lexicographic for string keys, signed
+      numeric for integral): the dimension walks by key via the traversal protocol rather than
+      counting an index, and key-walked and index-counted dimensions nest freely in one foreach.
+      `foreach` over a string (by byte) stays rejected with `kUnsupportedStatementForm`. See
+      `../decisions/foreach-lowering.md`.
 - [x] C11 -- `casez` / `casex` (LRM 12.5.1 do-not-care forms). Bidirectional wildcard compare:
       `casez` treats Z as don't-care on either operand; `casex` treats Z or X as don't-care on
       either operand. Result is deterministic, distinct from the asymmetric `==?` operator (LRM

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -405,12 +405,19 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       decision returns to the semantic layer that owns it, and "two different MIR -> two different
       emit" holds. **Why surfaced**: pre-existing, not caused by the foreach work; foreach's
       synthetic `.size()` on a jagged dynamic-of-dynamic array made it visible
-      (`jag[i].Clone().Size()` copies a whole row just to read its size). **Why deferred**: a
-      cross-cutting change to the backend value model -- MIR vocabulary, the HIR -> MIR
-      value-vs-reference context decision, the dumper, and the backend -- far larger than, and
-      orthogonal to, any feature that surfaces it. **Trigger**: the LIR / LLVM backend work (when
-      cross-backend divergence becomes real), or any change to the backend's clone / reference
-      rendering.
+      (`jag[i].Clone().Size()` copies a whole row just to read its size). The associative-array work
+      surfaced it more sharply: a builtin-method **receiver** rendered through the value path
+      clones, and a nested associative receiver (`mm[i].exists(j)`, `mm[i].delete(j)`, or the
+      traversal `mm[i].first(k)`) has element type `AssociativeArray`, which has no `Clone()` -- so
+      the split is a hard compile error there, and for `delete` it would also be a silent
+      correctness bug (mutating a throwaway copy). Interim: associative method receivers render
+      through the reference path, which is the value model R23 will generalize, so this is
+      alignment, not a new band-aid; the remaining R23 scope is value-position reads that genuinely
+      escape. **Why deferred**: a cross-cutting change to the backend value model -- MIR vocabulary,
+      the HIR -> MIR value-vs-reference context decision, the dumper, and the backend -- far larger
+      than, and orthogonal to, any feature that surfaces it. **Trigger**: the LIR / LLVM backend
+      work (when cross-backend divergence becomes real), or any change to the backend's clone /
+      reference rendering.
 
 - [ ] R24 -- Dispatch the "sized collection" concept (`.size()` / `.num()`) through one resolver
       instead of branching on the concrete container at each call site. Today the element-count

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1090,7 +1090,9 @@ auto AssociativeTraversalFunctionName(mir::AssociativeMethodKind k)
 // `ref` that the method writes the visited key into and whose observable
 // update event must fire (LRM 4.3), so it lowers to a runtime call carrying
 // the index lvalue as a `Ref<K>` -- the same by-reference shape a user `ref`
-// argument uses -- and `Services()` as the leading argument.
+// argument uses -- and `Services()` as the leading argument. The receiver is
+// rendered as an lvalue so the call reads the array in place: a nested receiver
+// such as `mm[i]` must reach the stored sub-map, not a detached clone.
 auto RenderAssociativeTraversalCall(
     const RenderContext& ctx, const mir::CallExpr& call,
     std::string_view function_name) -> diag::Result<std::string> {
@@ -1099,7 +1101,8 @@ auto RenderAssociativeTraversalCall(
         "RenderAssociativeTraversalCall: traversal method expects a receiver "
         "and an index argument");
   }
-  auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
+  auto receiver_or =
+      RenderLhsExpr(ctx, ctx.Expr(call.arguments[0]), std::string_view{});
   if (!receiver_or) {
     return std::unexpected(std::move(receiver_or.error()));
   }
@@ -1132,7 +1135,11 @@ auto RenderAssociativeMethodCall(
   if (auto traversal = AssociativeTraversalFunctionName(m.kind)) {
     return RenderAssociativeTraversalCall(ctx, call, *traversal);
   }
-  auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
+  // The receiver is rendered as an lvalue: every method reads (and `delete`
+  // mutates) the array in place, so a nested receiver such as `mm[i]` must
+  // reach the stored sub-map, not a detached clone.
+  auto receiver_or =
+      RenderLhsExpr(ctx, ctx.Expr(call.arguments[0]), std::string_view{});
   if (!receiver_or) {
     return std::unexpected(std::move(receiver_or.error()));
   }

--- a/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
@@ -29,98 +29,206 @@ namespace lyra::lowering::ast_to_hir {
 namespace {
 
 constexpr std::string_view kLastIndexName = "__lyra_foreach_last";
+constexpr std::string_view kMoreFlagName = "__lyra_foreach_more";
 
-// slang already describes each `foreach` dimension: a fixed dimension carries a
-// constant `range` (its declared bounds and direction); a dynamically sized one
-// (queue / dynamic array) has no `range` and takes its bounds from `.size()` at
-// run time. `DescribeRange` turns either form into a uniform
-// `(first, last, direction)`.
 using LoopDim = slang::ast::ForeachLoopStatement::LoopDim;
 
-// A dimension's iteration range: iterate the loop variable from `first` to
-// `last` inclusive, ascending or descending. `first` and `last` are HIR
-// expressions, so a fixed dimension and a dynamically sized one (whose `last`
-// is `size - 1`) are described the same way and iterated by the same loop.
-struct DimensionRange {
-  hir::ExprId first;
-  hir::ExprId last;
-  bool ascending;
+// The pieces that drive one iterated dimension's `for` loop, plus the loop
+// variable the body indexes by. Every dimension -- fixed, dynamically sized, or
+// associative -- iterates through this one shape; only how the pieces are built
+// differs, and that is the sole type-dependent step. A dimension's per-loop
+// preamble (a dynamically sized dimension samples its count once, an
+// associative dimension declares its key) is appended to a separate `setup`
+// stream the caller emits before the `for`.
+struct LevelLoop {
+  hir::ProceduralVarId loop_var;
+  hir::TypeId loop_var_type;
+  std::vector<hir::ForInit> init;
+  hir::ExprId condition;
+  std::vector<hir::ExprId> step;
 };
 
-// Describes one iterated dimension's index range. The only place a dimension's
-// type is consulted: a fixed dimension yields its declared range and direction;
-// a dynamically sized one yields 0..size-1 ascending, with the count sampled
-// once on entry (LRM 12.7.3) into a local that `setup` declares. `array` is the
-// receiver whose `.size()` bounds a dynamic dimension (queue and dynamic array
-// both expose it; the type only names the builtin-method kind).
-auto DescribeRange(
-    hir::ProceduralBody& body, const LoopDim& dim,
+// Build the loop for one index-counted dimension. A fixed dimension iterates
+// its declared range and direction; a dynamically sized one (queue / dynamic
+// array) counts 0..size-1 ascending, sampling the count once on entry
+// (LRM 12.7.3) into a `setup` local that the condition then reads. The loop
+// variable is the counter, declared in the `for`. `array` is the receiver whose
+// `.size()` bounds a dynamic dimension (queue and dynamic array both expose it;
+// the type only names the builtin-method kind).
+auto BuildIntegerLevel(
+    ProcessLowerer& proc, hir::ProceduralBody& body, const LoopDim& dim,
     std::optional<hir::ExprId> array, const slang::ast::Type* array_type,
     hir::TypeId int32_type, diag::SourceSpan span,
-    std::vector<hir::StmtId>& setup) -> DimensionRange {
+    std::vector<hir::StmtId>& setup) -> LevelLoop {
+  hir::ExprId first_id{};
+  hir::ExprId last_id{};
+  bool ascending = true;
   if (dim.range.has_value()) {
     const auto& declared = *dim.range;
-    return DimensionRange{
-        .first = body.AddExpr(
-            hir::MakeInt32Literal(declared.left, int32_type, span)),
-        .last = body.AddExpr(
-            hir::MakeInt32Literal(declared.right, int32_type, span)),
-        .ascending = declared.left <= declared.right};
+    first_id =
+        body.AddExpr(hir::MakeInt32Literal(declared.left, int32_type, span));
+    last_id =
+        body.AddExpr(hir::MakeInt32Literal(declared.right, int32_type, span));
+    ascending = declared.left <= declared.right;
+  } else {
+    hir::SubroutineRef size_callee =
+        array_type->isQueue() ? hir::SubroutineRef{hir::BuiltinMethodRef{
+                                    .method = hir::QueueMethodKind::kSize}}
+                              : hir::SubroutineRef{hir::BuiltinMethodRef{
+                                    .method = hir::ArrayMethodKind::kSize}};
+    const hir::ExprId size_id = body.AddExpr(
+        hir::Expr{
+            .type = int32_type,
+            .data =
+                hir::CallExpr{
+                    .callee = std::move(size_callee), .arguments = {*array}},
+            .span = span});
+    const hir::ExprId one_id =
+        body.AddExpr(hir::MakeInt32Literal(1, int32_type, span));
+    const hir::ExprId last_value_id = body.AddExpr(
+        hir::Expr{
+            .type = int32_type,
+            .data =
+                hir::BinaryExpr{
+                    .op = hir::BinaryOp::kSub, .lhs = size_id, .rhs = one_id},
+            .span = span});
+    const hir::ProceduralVarId last_var = body.AddProceduralVar(
+        hir::ProceduralVarDecl{
+            .name = std::string{kLastIndexName},
+            .type = int32_type,
+            .lifetime = hir::VariableLifetime::kAutomatic});
+    setup.push_back(body.AddStmt(
+        hir::Stmt{
+            .label = std::nullopt,
+            .data = hir::VarDeclStmt{.var = last_var, .init = last_value_id},
+            .span = span}));
+    first_id = body.AddExpr(hir::MakeInt32Literal(0, int32_type, span));
+    last_id = body.AddExpr(hir::MakeProcVarRefExpr(last_var, int32_type, span));
   }
 
-  hir::SubroutineRef size_callee =
-      array_type->isQueue() ? hir::SubroutineRef{hir::BuiltinMethodRef{
-                                  .method = hir::QueueMethodKind::kSize}}
-                            : hir::SubroutineRef{hir::BuiltinMethodRef{
-                                  .method = hir::ArrayMethodKind::kSize}};
-  const hir::ExprId size_id = body.AddExpr(
-      hir::Expr{
-          .type = int32_type,
-          .data =
-              hir::CallExpr{
-                  .callee = std::move(size_callee), .arguments = {*array}},
-          .span = span});
-  const hir::ExprId one_id =
-      body.AddExpr(hir::MakeInt32Literal(1, int32_type, span));
-  const hir::ExprId last_value_id = body.AddExpr(
+  const hir::ProceduralVarId loop_var =
+      proc.AddProceduralVar(body, *dim.loopVar, int32_type);
+  std::vector<hir::ForInit> init;
+  init.emplace_back(hir::ForInitDecl{.var = loop_var, .init = first_id});
+  const hir::ExprId cond_ref =
+      body.AddExpr(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
+  const hir::ExprId cond_id = body.AddExpr(
       hir::Expr{
           .type = int32_type,
           .data =
               hir::BinaryExpr{
-                  .op = hir::BinaryOp::kSub, .lhs = size_id, .rhs = one_id},
+                  .op = ascending ? hir::BinaryOp::kLessEqual
+                                  : hir::BinaryOp::kGreaterEqual,
+                  .lhs = cond_ref,
+                  .rhs = last_id},
           .span = span});
-  const hir::ProceduralVarId last_var = body.AddProceduralVar(
-      hir::ProceduralVarDecl{
-          .name = std::string{kLastIndexName},
+  const hir::ExprId step_ref =
+      body.AddExpr(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
+  const hir::ExprId step_id = body.AddExpr(
+      hir::Expr{
           .type = int32_type,
-          .lifetime = hir::VariableLifetime::kAutomatic});
+          .data =
+              hir::IncDecExpr{
+                  .op = ascending ? hir::IncDecOp::kPreInc
+                                  : hir::IncDecOp::kPreDec,
+                  .target = step_ref},
+          .span = span});
+  return LevelLoop{
+      .loop_var = loop_var,
+      .loop_var_type = int32_type,
+      .init = std::move(init),
+      .condition = cond_id,
+      .step = {step_id}};
+}
+
+// Build the loop for one associative dimension (LRM 7.9.4 -- 7.9.7). The array
+// iterates by key: a `for` whose counter holds first / next's 0/1 return and
+// whose step advances the key through the method's `ref` index argument.
+// `continue` lands on the step, so it advances the key (LRM 12.8); an empty
+// array makes `first` return 0, so the body never runs. The loop variable is
+// the key (the body indexes the array by it); the counter is a synthetic flag.
+// The key is declared in `setup` rather than the `for` init because its type
+// differs from the counter and cannot share one C++ init declaration.
+auto BuildAssociativeLevel(
+    ProcessLowerer& proc, hir::ProceduralBody& body, const LoopDim& dim,
+    hir::ExprId array, hir::TypeId int32_type, diag::SourceSpan span,
+    std::vector<hir::StmtId>& setup) -> diag::Result<LevelLoop> {
+  auto key_type_or = proc.Module().InternType(dim.loopVar->getType(), span);
+  if (!key_type_or) return std::unexpected(std::move(key_type_or.error()));
+  const hir::TypeId key_type = *key_type_or;
+
+  const hir::ProceduralVarId key_var =
+      proc.AddProceduralVar(body, *dim.loopVar, key_type);
   setup.push_back(body.AddStmt(
       hir::Stmt{
           .label = std::nullopt,
-          .data = hir::VarDeclStmt{.var = last_var, .init = last_value_id},
+          .data = hir::VarDeclStmt{.var = key_var, .init = std::nullopt},
           .span = span}));
-  return DimensionRange{
-      .first = body.AddExpr(hir::MakeInt32Literal(0, int32_type, span)),
-      .last = body.AddExpr(hir::MakeProcVarRefExpr(last_var, int32_type, span)),
-      .ascending = true};
+  const hir::ProceduralVarId more_var = body.AddProceduralVar(
+      hir::ProceduralVarDecl{
+          .name = std::string{kMoreFlagName},
+          .type = int32_type,
+          .lifetime = hir::VariableLifetime::kAutomatic});
+
+  auto walk_call = [&](hir::AssociativeMethodKind method) -> hir::ExprId {
+    const hir::ExprId key_ref =
+        body.AddExpr(hir::MakeProcVarRefExpr(key_var, key_type, span));
+    return body.AddExpr(
+        hir::Expr{
+            .type = int32_type,
+            .data =
+                hir::CallExpr{
+                    .callee = hir::SubroutineRef{hir::BuiltinMethodRef{
+                        .method = method}},
+                    .arguments = {array, key_ref}},
+            .span = span});
+  };
+
+  std::vector<hir::ForInit> init;
+  init.emplace_back(
+      hir::ForInitDecl{
+          .var = more_var,
+          .init = walk_call(hir::AssociativeMethodKind::kFirst)});
+  const hir::ExprId cond_id =
+      body.AddExpr(hir::MakeProcVarRefExpr(more_var, int32_type, span));
+  const hir::ExprId more_lhs =
+      body.AddExpr(hir::MakeProcVarRefExpr(more_var, int32_type, span));
+  const hir::ExprId step_id = body.AddExpr(
+      hir::Expr{
+          .type = int32_type,
+          .data =
+              hir::AssignExpr{
+                  .kind = hir::AssignKind::kBlocking,
+                  .lhs = more_lhs,
+                  .compound_op = std::nullopt,
+                  .rhs = walk_call(hir::AssociativeMethodKind::kNext)},
+          .span = span});
+  return LevelLoop{
+      .loop_var = key_var,
+      .loop_var_type = key_type,
+      .init = std::move(init),
+      .condition = cond_id,
+      .step = {step_id}};
 }
 
 // Recursively wraps the loop body in one nested loop per remaining dimension.
 //
 // `array` is `arrayRef` indexed by the enclosing loop variables -- the receiver
-// whose `.size()` bounds a dynamic dimension -- with `array_type` its slang
-// type; both are absent when no dimension at or below is dynamically sized (a
-// purely fixed nest never touches the array). Descending one level indexes
-// `array` by this level's loop variable and peels `array_type` once, so the
-// type flows down naturally rather than being recomputed from the root.
+// a dynamic dimension reads for its `.size()` and an associative dimension for
+// its keys -- with `array_type` its slang type; both are absent when no
+// dimension at or below reads the array at run time (a purely fixed nest never
+// touches it). Descending one level indexes `array` by this level's loop
+// variable and peels `array_type` once, so the type flows down naturally rather
+// than being recomputed from the root.
 //
-// Procedural-var ids are minted top to bottom (each level's `last` local before
-// its loop variable, then the body's own locals), matching the order HIR-to-MIR
-// encounters the declarations. The outermost loop (level 0) is the break
-// landing target, marked only when a break in the body actually used the label.
+// Procedural-var ids are minted top to bottom in statement order (a level's
+// pre-loop locals before its `for`-init locals, then the body's own locals),
+// matching the order HIR-to-MIR encounters the declarations. The outermost loop
+// (level 0) is the break landing target, marked only when a break in the body
+// actually used the label.
 //
-// Returns the statements realizing this level: a lone `for`, or a dynamic
-// dimension's sampled-`last` declaration followed by its `for`.
+// Returns the statements realizing this level: the `for`, preceded by any
+// pre-loop setup the level needs (a sampled `last`, an associative key).
 auto BuildForeachNest(
     ProcessLowerer& proc, const slang::ast::ForeachLoopStatement& fs,
     WalkFrame frame, const std::vector<const LoopDim*>& levels,
@@ -141,19 +249,29 @@ auto BuildForeachNest(
 
   const LoopDim& dim = *levels[level];
 
-  // Describe this dimension's range -- the one type-dependent step. Any setup
-  // (a dynamic dimension samples its `last` once into a local) lands in `stmts`
-  // before the loop.
+  // The one type-dependent step: build this level's `for` loop. A declared
+  // range is fixed; an absent range is runtime-sized, and among those an
+  // associative array walks by key while a queue / dynamic array counts by
+  // index. Any setup (a sampled `last`, an associative key declaration) lands
+  // in `stmts` before the loop.
   std::vector<hir::StmtId> stmts;
-  const DimensionRange range =
-      DescribeRange(body, dim, array, array_type, int32_type, span, stmts);
-
-  const hir::ProceduralVarId loop_var =
-      proc.AddProceduralVar(body, *dim.loopVar, int32_type);
+  const bool is_associative =
+      !dim.range.has_value() && array_type != nullptr &&
+      array_type->getCanonicalType().isAssociativeArray();
+  LevelLoop loop{};
+  if (is_associative) {
+    auto loop_or =
+        BuildAssociativeLevel(proc, body, dim, *array, int32_type, span, stmts);
+    if (!loop_or) return std::unexpected(std::move(loop_or.error()));
+    loop = std::move(*loop_or);
+  } else {
+    loop = BuildIntegerLevel(
+        proc, body, dim, array, array_type, int32_type, span, stmts);
+  }
 
   // Descend: the inner levels iterate `array[loop_var]`, one type peel deeper.
-  // Only built while the array is being threaded (some inner level is dynamic);
-  // a deeper fixed-only tail leaves it absent.
+  // Only built while the array is being threaded (some inner level is runtime
+  // sized); a deeper fixed-only tail leaves it absent.
   std::optional<hir::ExprId> inner_array;
   const slang::ast::Type* inner_array_type = nullptr;
   if (array.has_value()) {
@@ -162,8 +280,8 @@ auto BuildForeachNest(
     if (!inner_hir_type) {
       return std::unexpected(std::move(inner_hir_type.error()));
     }
-    const hir::ExprId index_id =
-        body.AddExpr(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
+    const hir::ExprId index_id = body.AddExpr(
+        hir::MakeProcVarRefExpr(loop.loop_var, loop.loop_var_type, span));
     inner_array = body.AddExpr(
         hir::Expr{
             .type = *inner_hir_type,
@@ -185,42 +303,14 @@ auto BuildForeachNest(
                     .data = hir::BlockStmt{.statements = std::move(*inner_or)},
                     .span = span});
 
-  // Iterate the range: one loop shape for every dimension, driven only by
-  // (first, last, direction) -- no dynamic-vs-fixed branch here.
-  const hir::ExprId cond_ref =
-      body.AddExpr(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
-  const hir::ExprId cond_id = body.AddExpr(
-      hir::Expr{
-          .type = int32_type,
-          .data =
-              hir::BinaryExpr{
-                  .op = range.ascending ? hir::BinaryOp::kLessEqual
-                                        : hir::BinaryOp::kGreaterEqual,
-                  .lhs = cond_ref,
-                  .rhs = range.last},
-          .span = span});
-  const hir::ExprId step_ref =
-      body.AddExpr(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
-  const hir::ExprId step_id = body.AddExpr(
-      hir::Expr{
-          .type = int32_type,
-          .data =
-              hir::IncDecExpr{
-                  .op = range.ascending ? hir::IncDecOp::kPreInc
-                                        : hir::IncDecOp::kPreDec,
-                  .target = step_ref},
-          .span = span});
-
-  std::vector<hir::ForInit> init;
-  init.emplace_back(hir::ForInitDecl{.var = loop_var, .init = range.first});
   stmts.push_back(body.AddStmt(
       hir::Stmt{
           .label = std::nullopt,
           .data =
               hir::ForStmt{
-                  .init = std::move(init),
-                  .condition = cond_id,
-                  .step = {step_id},
+                  .init = std::move(loop.init),
+                  .condition = loop.condition,
+                  .step = std::move(loop.step),
                   .body = inner_body,
                   .break_label = (level == 0 && *label_used)
                                      ? std::optional{foreach_label}
@@ -229,19 +319,14 @@ auto BuildForeachNest(
   return stmts;
 }
 
-// The associative array iterates by key and the string by byte (LRM 7.9 /
-// 6.16), distinct iteration models from the index-counted dynamic array and
-// queue handled here. Both stay rejected until their own lowering lands.
+// Iterating a string itself walks by byte (LRM 6.16), a distinct model from the
+// index-counted and key-walked array families handled here; it stays rejected
+// until its own lowering lands.
 auto RejectUnsupportedArrayType(
     const slang::ast::Type& canonical, diag::SourceSpan span)
     -> diag::Result<void> {
   using slang::ast::SymbolKind;
   switch (canonical.kind) {
-    case SymbolKind::AssociativeArrayType:
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedStatementForm,
-          "foreach over associative array is not yet supported",
-          diag::UnsupportedCategory::kFeature);
     case SymbolKind::StringType:
       return diag::Unsupported(
           span, diag::DiagCode::kUnsupportedStatementForm,
@@ -269,15 +354,17 @@ auto ProcessLowerer::LowerForeachStmt(
   const hir::TypeId int32_type = module.Unit().builtins.int32;
 
   // Collect the iterated (non-skipped) dimensions in cardinal order. A
-  // dimension with no constant range is dynamically sized (LRM 7.5 / 7.10).
+  // dimension with no constant range reads the array value at run time -- a
+  // dynamic array / queue for its size (LRM 7.5 / 7.10), an associative array
+  // for its keys (LRM 7.9) -- so the array must be threaded into the nest.
   std::vector<const LoopDim*> levels;
   levels.reserve(fs.loopDims.size());
-  bool any_dynamic = false;
+  bool needs_array = false;
   for (const auto& dim : fs.loopDims) {
     if (dim.loopVar == nullptr) {
       continue;
     }
-    any_dynamic = any_dynamic || !dim.range.has_value();
+    needs_array = needs_array || !dim.range.has_value();
     levels.push_back(&dim);
   }
 
@@ -301,12 +388,12 @@ auto ProcessLowerer::LowerForeachStmt(
         .span = span};
   }
 
-  // Thread `arrayRef` into the nest only when some dimension needs a runtime
-  // size; a purely fixed foreach lowers to plain range loops that never read
+  // Thread `arrayRef` into the nest only when some dimension reads it at run
+  // time; a purely fixed foreach lowers to plain range loops that never touch
   // the array.
   std::optional<hir::ExprId> array;
   const slang::ast::Type* array_type = nullptr;
-  if (any_dynamic) {
+  if (needs_array) {
     auto array_or = proc.LowerExpr(fs.arrayRef, frame);
     if (!array_or) return std::unexpected(std::move(array_or.error()));
     array = body.AddExpr(*std::move(array_or));

--- a/tests/cases/cpp/assoc_basic/case.yaml
+++ b/tests/cases/cpp/assoc_basic/case.yaml
@@ -24,3 +24,5 @@ expect:
     nsz: 2
     nmiss: 0
     nsz2: 2
+    nest_ex: 1
+    nest_after_delete: 1

--- a/tests/cases/cpp/assoc_basic/main.sv
+++ b/tests/cases/cpp/assoc_basic/main.sv
@@ -20,6 +20,12 @@ module Top;
   int nmiss;
   int nsz2;
 
+  // A method on a nested receiver (`mm[i]`) must reach the stored sub-map: a
+  // const query reads it and `delete` mutates it in place.
+  int mm [string][int];
+  int nest_ex;
+  int nest_after_delete;
+
   initial begin
     m["a"] = 1;
     m["b"] = 2;
@@ -51,5 +57,11 @@ module Top;
     nsz = n.num();
     nmiss = n[7];
     nsz2 = n.num();
+
+    mm["x"][1] = 10;
+    mm["x"][2] = 20;
+    nest_ex = mm["x"].exists(2);
+    mm["x"].delete(1);
+    nest_after_delete = mm["x"].num();
   end
 endmodule

--- a/tests/cases/cpp/foreach_assoc/case.yaml
+++ b/tests/cases/cpp/foreach_assoc/case.yaml
@@ -1,0 +1,18 @@
+id: cpp.foreach_assoc
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    order_str: 123
+    order_int: 213
+    empty_iters: 0
+    sum_2d: 60
+    sum_mixed: 7
+    break_count: 1
+    cont_sum: 4
+    sum_fixed_assoc: 7

--- a/tests/cases/cpp/foreach_assoc/main.sv
+++ b/tests/cases/cpp/foreach_assoc/main.sv
@@ -1,0 +1,85 @@
+module Top;
+  // LRM 7.9 / 12.7.3: foreach over an associative array walks the entries in
+  // index order (LRM 7.8: lexicographic for string, signed numeric for
+  // integral). Each case inserts out of order and decodes the visit order into
+  // a decimal number to prove the order, mirroring the traversal-method tests.
+
+  int sm [string];
+  int order_str;
+
+  int im [int];
+  int order_int;
+
+  int em [string];
+  int empty_iters;
+
+  int mm [string][int];
+  int sum_2d;
+
+  int af [string][0:1];
+  int sum_mixed;
+
+  int bm [string][int];
+  int break_count;
+
+  int cm [int];
+  int cont_sum;
+
+  int fa [2][string];
+  int sum_fixed_assoc;
+
+  initial begin
+    sm["banana"] = 2;
+    sm["apple"] = 1;
+    sm["cherry"] = 3;
+    order_str = 0;
+    foreach (sm[k]) order_str = order_str * 10 + sm[k];
+
+    im[10] = 3;
+    im[-5] = 2;
+    im[5] = 1;
+    order_int = 0;
+    foreach (im[k]) order_int = order_int * 10 + im[k];
+
+    empty_iters = 0;
+    foreach (em[k]) empty_iters = empty_iters + 1;
+
+    mm["x"][2] = 20;
+    mm["x"][1] = 10;
+    mm["y"][1] = 30;
+    sum_2d = 0;
+    foreach (mm[i, j]) sum_2d = sum_2d + mm[i][j];
+
+    af["p"][0] = 1;
+    af["p"][1] = 2;
+    af["q"][0] = 4;
+    sum_mixed = 0;
+    foreach (af[i, j]) sum_mixed = sum_mixed + af[i][j];
+
+    bm["a"][1] = 5;
+    bm["a"][2] = 7;
+    bm["b"][1] = 9;
+    break_count = 0;
+    foreach (bm[i, j]) begin
+      if (bm[i][j] == 7) break;
+      break_count = break_count + 1;
+    end
+
+    cm[1] = 1;
+    cm[2] = 2;
+    cm[3] = 3;
+    cont_sum = 0;
+    foreach (cm[k]) begin
+      if (cm[k] == 2) continue;
+      cont_sum = cont_sum + cm[k];
+    end
+
+    // A fixed outer dimension enclosing an associative inner one: the index walk
+    // and the key walk nest in the same foreach.
+    fa[0]["a"] = 1;
+    fa[1]["a"] = 4;
+    fa[1]["b"] = 2;
+    sum_fixed_assoc = 0;
+    foreach (fa[i, k]) sum_fixed_assoc = sum_fixed_assoc + fa[i][k];
+  end
+endmodule


### PR DESCRIPTION
## Summary

`foreach` over an associative array now iterates its entries in index order (LRM 7.8: lexicographic for string keys, signed numeric for integral keys), closing the last open piece of `control-flow.md` C10.

## Design

Each `foreach` dimension now supplies its own for-loop init / condition / step, which widened the per-dimension descriptor from an integer range (`first`, `last`, direction) to the for-loop pieces themselves. The integer range was a lossy intermediate that the nest builder had to re-expand into a loop with a hardcoded integer-counting rule; describing the for-loop directly removes that buried assumption, so the builder carries no per-family branch. An associative dimension is just a `for` whose counter holds the first / next return value and whose step advances the key through the traversal protocol's `ref` index, so `continue` advances to the next key and an empty array runs the body zero times. Key-walked and index-counted dimensions nest freely in one foreach (associative of associative, associative of fixed, fixed of associative).

Associative method receivers now render as in-place lvalues. A receiver rendered through the value path clones, and a nested associative receiver (`mm[i].first(k)`, `mm[i].exists(j)`, `mm[i].delete(j)`) has element type `AssociativeArray`, which has no `Clone()` -- a hard compile error there, and for `delete` a silent correctness bug (mutating a throwaway copy). Rendering the receiver as a reference is the value model R23 will generalize, so this is alignment rather than a new band-aid; the surfacing is recorded under R23.

## Testing

New `foreach_assoc` case covers single string / integral keys (signed order, negative keys), empty array, all nesting permutations, `break` leaving the whole nest, and `continue` advancing the key. `assoc_basic` gains a nested-receiver method-call assertion. Full `bazel test //...` passes.