### PR TITLE
Add ObservableType and LRM-aligned value-type concepts

### DIFF
--- a/docs/architecture/hir.md
+++ b/docs/architecture/hir.md
@@ -2,8 +2,24 @@
 
 ## Purpose
 
-Define the source-near semantic IR. HIR preserves SystemVerilog language constructs with explicit
-semantic ownership and without loss of LRM-level information.
+HIR is a SystemVerilog-faithful semantic IR. Its job is to mirror SV's language structure in a form
+the compiler owns: declarations, expressions, statements, processes, assertions, functions, tasks,
+parameters, ports, and generate constructs all appear as first-class HIR nodes carrying their
+LRM-level shape. HIR is the compiler's first canonical representation and the cutover from frontend
+identity to compiler identity -- slang's symbol ids are discarded at AST-to-HIR; HIR's typed ids
+replace them with no loss of LRM-level information.
+
+HIR is not a generic programming-language IR -- that role belongs to MIR. SV-specific concepts
+(signals, non-blocking assignments and the deferred scheduling they imply, event-control semantics,
+generate-as-elaboration, ports-as-aliases) all live here verbatim, awaiting translation into a
+generic programming-language vocabulary at HIR-to-MIR. Loops are loops, assertions are assertions,
+classes are classes; the abstraction level is the language the user wrote, not what the compiler
+later turns it into.
+
+HIR's role between AST and MIR mirrors the role a language's own semantic IR plays in other
+compilers: a language-faithful representation the compiler owns, with frontend syntactic noise
+removed and canonical compiler-owned identity in its place, but with the language's vocabulary still
+visible. The translation away from that vocabulary is the next layer's job, not HIR's.
 
 ## Owns
 
@@ -23,39 +39,64 @@ semantic ownership and without loss of LRM-level information.
 - Low-level storage layout or ABI decisions.
 - Hierarchical paths beyond the compilation unit's own generate tree (see
   `hierarchy_and_generate.md`).
+- A generic programming-language vocabulary. SV's vocabulary survives at HIR; the translation into a
+  generic vocabulary is MIR's identity, performed at HIR-to-MIR.
 
 ## Core Invariants
 
+Each invariant below is a direct consequence of the identity stated in Purpose -- HIR is the
+compiler's first canonical, SV-faithful representation. An invariant that cannot be re-derived from
+that identity is the suspect, not the analysis.
+
 1. Every compilation-unit-local declaration has a typed id. References to that declaration carry the
-   typed id, never a frontend symbol id.
+   typed id, never a frontend symbol id. _Source-faithful consequence: HIR is the layer's source of
+   identity; frontend identity ends at AST-to-HIR._
 2. A reference that targets a declaration outside the current compilation unit uses a separate,
-   explicitly named variant. Local and cross-unit references never share a key space.
+   explicitly named variant. Local and cross-unit references never share a key space. _Source-
+   faithful consequence: SV's compilation-unit boundary is explicit in the IR, not flattened._
 3. HIR preserves LRM-level constructs without flattening them into lower-level primitives. Loops are
-   loops, assertions are assertions, classes are classes.
+   loops, assertions are assertions, classes are classes. _Source-faithful consequence: the
+   abstraction level is the language the user wrote; flattening into a generic vocabulary is MIR's
+   job._
 4. Each compilation unit is self-contained: resolving any intra-unit reference requires no data
-   outside that unit.
+   outside that unit. _Source-faithful consequence: independent compilation is preserved at the
+   layer where SV's unit boundary lives._
 5. The generate tree lives inside the module compilation unit and is the sole representation of
-   generate-region structure at HIR level.
+   generate-region structure at HIR level. _Source-faithful consequence: SV's generate construct is
+   carried verbatim, not pre-elaborated._
 6. HIR is the canonical semantic identity of the compiler. No frontend id survives past AST-to-HIR.
-   Downstream layers consume HIR identity, never frontend identity.
+   Downstream layers consume HIR identity, never frontend identity. _Source-faithful consequence:
+   the cutover from frontend to compiler-owned identity happens at one boundary, not by gradual
+   propagation._
 
 ## Boundary to Adjacent Layers
 
 - Consumes slang's AST. AST-to-HIR is a cutover, not a translation: frontend ids are discarded at
   this boundary. HIR establishes the first canonical semantic identity owned by the compiler.
-- Produces input to MIR. HIR-to-MIR lowering reads typed HIR ids and produces MIR objects and
-  members (see `mir.md`).
+- Produces input to MIR. HIR-to-MIR is the layer where SV's vocabulary gets translated into a
+  generic programming-language vocabulary. Every SV-specific concept that does not appear in MIR is
+  translated at this boundary or rejected as unsupported. HIR-to-MIR holds the SV knowledge; MIR
+  does not.
 
 ## Forbidden Shapes
 
+These are the patterns that violate the identity. Each is the inverse of a property a source-
+faithful, compiler-identity-owning IR implies.
+
 - `SymbolId` or any frontend-global id used as the identity of a compilation-unit-local declaration
-  reference.
-- A resolver keyed on `(instance_id, local_symbol)` at HIR level.
-- CFG-shaped nodes (basic blocks, successor lists, phi nodes) anywhere in HIR.
-- A generate-region representation that lives outside the compilation unit it belongs to.
-- Coordinate or ordinal identity for a generate region.
-- Side-table reconstruction of declaration ownership from names or paths.
-- Dependence on a global lookup table to resolve a local reference.
+  reference. (HIR owns identity at this layer; frontend identity ends at AST-to-HIR.)
+- A resolver keyed on `(instance_id, local_symbol)` at HIR level. (Per-instance identity belongs to
+  the runtime object graph, not HIR.)
+- CFG-shaped nodes (basic blocks, successor lists, phi nodes) anywhere in HIR. (HIR is structured-
+  language faithful; CFG is LIR's vocabulary.)
+- A generate-region representation that lives outside the compilation unit it belongs to. (Generate
+  is SV-source structure inside a unit; lifting it out flattens the unit boundary.)
+- Coordinate or ordinal identity for a generate region. (Identity is typed and carried by HIR's own
+  id kinds.)
+- Side-table reconstruction of declaration ownership from names or paths. (Ownership is structural,
+  not name-based.)
+- Dependence on a global lookup table to resolve a local reference. (Local references resolve inside
+  the unit by structure.)
 - Carrying frontend ids into HIR or any downstream layer. Frontend ids end at AST-to-HIR.
 
 ## Notes / Examples
@@ -63,3 +104,10 @@ semantic ownership and without loss of LRM-level information.
 A reference to a local variable carries a `VariableId` in the compilation unit's arena. A reference
 to a package-level entity or a cross-unit target uses a distinct variant. The two are not
 interchangeable and never share a key space.
+
+A SystemVerilog `always_comb` block, a non-blocking assignment, an event control, and a `generate`
+region all appear in HIR as themselves -- a process kind, an NBA statement, an event-control
+expression, a generate node. HIR-to-MIR is where each gets translated into MIR's generic
+programming-language vocabulary (a process becomes a callable invoked by the scheduler; an NBA
+becomes a deferred closure submission; an event control becomes a coroutine suspension; a generate
+becomes constructor-time logic). The SV vocabulary is HIR's; the generic vocabulary is MIR's.

--- a/docs/architecture/lir.md
+++ b/docs/architecture/lir.md
@@ -2,8 +2,33 @@
 
 ## Purpose
 
-Define the execution-oriented IR. LIR expresses the compiled program as control-flow graphs, basic
-blocks, and storage accesses, shaped for backend codegen.
+LIR is a machine-execution model IR. Its conceptual peers are LLVM IR and MLIR -- compiler IRs that
+express a program as a control-flow graph over typed values, with explicit storage and explicit
+effect ordering, shaped for code generation onto a concrete target. LIR is not a high-level
+programming language; it is what a program looks like once structured control flow and the
+object-oriented vocabulary have been lowered into something a register allocator and a code
+generator can consume.
+
+LIR's vocabulary is what those execution-model IRs share:
+
+- Basic blocks with explicit successor lists, forming control-flow graphs per callable.
+- Typed values whose storage source -- a register, a stack slot, a memory location -- is explicit.
+- Low-level operations: arithmetic, comparisons, loads, stores, calls.
+- Effect ordering within a block.
+- An explicit protocol to the scheduling runtime: entry, suspend, resume, completion appear as CFG
+  edges and call instructions, not as conventions implied by node order.
+
+MIR is the source language LIR is lowered from. The semantic vocabulary of MIR -- structured `if` /
+loop, expression-level operators, member access through a receiver, callables with parameter lists,
+classes -- is translated at MIR-to-LIR into LIR's machine-execution vocabulary: structured control
+flow becomes a CFG, expression trees become instruction streams, member access becomes a load or
+store against a resolved storage location, callable invocation becomes a call instruction. Once LIR
+sees a value it sees a typed SSA-style result; it does not know or care that the same value was a
+structured expression in MIR.
+
+LIR is also not the target machine. Register allocation, instruction selection, and per-target
+calling conventions belong below LIR (in the LLVM backend's own pipeline). LIR is the model the
+compiler-side optimizer reasons over; the target-side lowering consumes that model.
 
 ## Owns
 
@@ -19,36 +44,73 @@ blocks, and storage accesses, shaped for backend codegen.
 - Language-level constructs (loops as loops, assertions as assertions).
 - The generate-region tree or hierarchy structure (see `hierarchy_and_generate.md`).
 - Identity rules for upstream references (see `identity_and_ownership.md`).
+- Target-machine details: register allocation, instruction selection, per-target calling
+  conventions. These belong below LIR.
 
 ## Core Invariants
 
+Each invariant below is a direct consequence of the identity stated in Purpose -- LIR is a
+machine-execution model IR shaped for codegen. An invariant that cannot be re-derived from that
+identity is the suspect, not the analysis.
+
 1. LIR is a CFG-shaped IR. Every callable body is a graph of basic blocks with explicit successors.
-2. Each LIR value has an explicit type and an explicit storage source or dataflow origin.
-3. Storage placement is decided at LIR. Upstream layers do not carry offsets or addresses.
+   _Machine-execution consequence: control flow is the graph the codegen consumes; structured
+   constructs do not survive at this layer._
+2. Each LIR value has an explicit type and an explicit storage source or dataflow origin. _Machine-
+   execution consequence: every value the codegen handles has a known representation; there are no
+   "values reach this point implicitly" shapes._
+3. Storage placement is decided at LIR. Upstream layers do not carry offsets or addresses. _Machine-
+   execution consequence: a higher-level IR's job ends at "this is a member of this object"; the
+   address is LIR's._
 4. LIR does not reintroduce high-level semantic ownership. It consumes ownership decided by MIR.
+   _Machine-execution consequence: lowering is one-way; LIR reads upstream decisions and acts on
+   them, never re-derives them._
 5. The runtime protocol is explicit: suspend and resume points appear as CFG edges, not as lowering
-   conventions implied by node order.
+   conventions implied by node order. _Machine-execution consequence: the scheduler's boundary is
+   visible to the optimizer as edges, not as a side convention only the lowering knows._
 
 ## Boundary to Adjacent Layers
 
-- Consumes MIR. MIR-to-LIR lowering shapes MIR callables into CFGs, assigns storage, and
-  materializes effect ordering.
+- Consumes MIR. MIR-to-LIR is the layer where the high-level programming language gets translated
+  into a machine-execution model: structured control flow becomes a CFG, member access becomes
+  load/store against a resolved storage location, expression trees become instruction streams,
+  callable invocation becomes a call instruction. MIR-to-LIR introduces every fact LIR owns and that
+  MIR does not (CFG structure, storage placement, effect ordering, scheduling-protocol edges).
 - Produces input to LLVM IR. LIR-to-LLVM is mechanical translation rather than design.
 
 ## Forbidden Shapes
 
-- A parallel identity or ownership system that duplicates MIR's.
-- Object or member semantics carried into LIR nodes. Object model belongs at MIR.
+These are the patterns that violate the identity. Each is the inverse of a property a machine-
+execution model IR implies; the diagnostic for any new forbidden shape is "what identity property
+does this break".
+
+- A parallel identity or ownership system that duplicates MIR's. (Identity is owned by the layer
+  that introduced it; LIR consumes, never re-mints.)
+- Object or member semantics carried into LIR nodes. Object model belongs at MIR. (LIR's vocabulary
+  is machine-execution, not high-level programming language.)
 - Hierarchy navigation logic expressed at LIR. Hierarchy is resolved by MIR and consumed as storage
   addresses at LIR.
-- Language-level constructs reintroduced at LIR (a "foreach" node instead of a loop CFG).
-- Implicit control flow. Every control transfer is an explicit edge.
+- Language-level constructs reintroduced at LIR (a "foreach" node instead of a loop CFG). (LIR is
+  CFG-shaped; structured constructs do not survive lowering.)
+- Implicit control flow. Every control transfer is an explicit edge. (Machine-execution IRs do not
+  carry implicit transitions; the codegen relies on edges being explicit.)
 - Reintroducing semantic structure that MIR has already lowered away.
-- Storage decisions decided upstream and encoded in LIR as passthrough.
-- A scheduling decision made outside LIR but implied by LIR shape.
-- Basic blocks that cross callable boundaries.
+- Storage decisions decided upstream and encoded in LIR as passthrough. (Storage is LIR's; upstream
+  carries no offsets to pass through.)
+- A scheduling decision made outside LIR but implied by LIR shape. (The scheduling-protocol boundary
+  is explicit; conventions hidden in node-order arrangements violate the protocol.)
+- Basic blocks that cross callable boundaries. (Each callable is one CFG; cross-callable transfer is
+  a call edge, not a basic-block-level transition.)
 
 ## Notes / Examples
 
 A MIR process becomes an LIR callable with a CFG. Its suspend points (for example, event controls)
-appear as explicit CFG edges that hand control back to the scheduler.
+appear as explicit CFG edges that hand control back to the scheduler. The optimizer sees the suspend
+point as an edge it can reason about (does it post-dominate any node, what values does it demand)
+rather than as a convention buried inside a node's semantics.
+
+A MIR `MemberAccess` reaching a runtime library wrapper type (the C++ backend's `Var<T>`, an extern
+upward-reference) is translated at MIR-to-LIR into a load or store against the resolved storage
+location, with the wrapper type's invariants (subscribe-on-set, mutate-then-commit) realized as the
+appropriate sequence of LIR instructions plus scheduling-runtime call edges. LIR does not carry the
+wrapper concept; it carries the loads, stores, and runtime calls the wrapper expanded into.

--- a/docs/architecture/mir.md
+++ b/docs/architecture/mir.md
@@ -2,9 +2,39 @@
 
 ## Purpose
 
-Define the object-oriented semantic IR. MIR expresses the compiled program as objects, members,
-callables, and actions, with lightweight structured control flow. MIR is not C++; C++ is one of
-several possible backend targets for MIR, and does not define MIR's semantics.
+MIR is a generic software programming language IR. Its conceptual peers are C++, Rust, and Python --
+high-level programming languages with rich type systems, first-class functions, structured control
+flow, and object-oriented features. MIR is not a hardware description language IR and not a
+machine-execution model; it sits in the middle of the pipeline, expressing the program as software
+in a generic programming-language vocabulary.
+
+MIR's vocabulary is what those languages share:
+
+- Expressions and statements.
+- Function and method calls, including coroutines and closures.
+- A type system covering value types, object types, and composing wrappers (owning pointer, vector).
+- Object-oriented features: classes with members, member access through an explicit receiver
+  expression.
+- Structured control flow: `if`, loop, sequence, return.
+
+SystemVerilog is one source language that flows in through HIR; SV does not shape MIR's vocabulary.
+SV-specific concepts -- signals as observable storage cells, NBA scheduling regions, event-control
+semantics, generate as elaboration -- are translated at HIR-to-MIR into MIR's generic vocabulary:
+variables with library wrapper types, method calls against those wrappers' APIs, runtime callables
+the scheduler invokes, constructor-time logic that builds the object graph. Once MIR sees a value it
+sees a programming-language expression with a programming-language type; it does not know or care
+that the source was SystemVerilog. The same MIR could in principle express the same program reached
+from any source language with comparable semantic surface.
+
+MIR is also not the machine-execution model. Control-flow graphs, basic blocks, storage placement,
+register allocation, and instruction-level effect ordering belong to LIR. MIR is high-level
+structured code; the program is still readable as software at this layer.
+
+The C++ backend renders MIR to C++ source, and the LIR-then-LLVM backend lowers MIR to a machine
+model. Both consume the same MIR. Because MIR is a generic programming language, "the same MIR"
+means the same program; the two backends differ only in how they represent each MIR construct (a
+method call rendered as C++ method-call syntax versus lowered to an LLVM call instruction), never in
+what the construct means.
 
 ## Owns
 
@@ -22,9 +52,9 @@ several possible backend targets for MIR, and does not define MIR's semantics.
   blocks at this layer.
 - A primitive expression set: literals, references, unary / binary / conditional operators, calls,
   conversions, closures, member access through an explicit receiver expression, access primitives
-  for element and range selection, and value-build primitives for aggregate construction.
-  SystemVerilog syntactic sugar that decomposes into this set (`case`, `inside`, `casez` / `casex`,
-  `foreach`) is lowered at the HIR-to-MIR boundary and never carried as a MIR node.
+  for element and range selection, and value-build primitives for aggregate construction. The set is
+  closed under what a generic programming-language AST needs to express; it does not grow to model a
+  particular backend's storage realization or runtime library shape.
 - Action shapes for constructs that bind behavior to schedule events (always blocks, continuous
   assignments, deferred assertions, concurrent assertions).
 - A textual dumper that serializes MIR for inspection, validation, and golden testing. The dumper is
@@ -36,39 +66,55 @@ several possible backend targets for MIR, and does not define MIR's semantics.
 - Storage placement, offsets, or memory layout.
 - Scheduling, dirty tracking, or wakeup filtering.
 - The frontend's symbol or string identity. MIR carries only MIR's own ids.
+- SystemVerilog source-level syntactic sugar. Sugar collapses to MIR's primitives at HIR-to-MIR.
 
 ## Core Invariants
 
+Each invariant below is a direct consequence of the identity stated in Purpose. The body of an
+invariant should be derivable from the identity; an invariant that cannot be re-derived is the
+suspect, not the analysis (`lowering_organization.md` states this discipline in general).
+
 1. Every compiled entity is exactly one of: an object, a member of an object, a callable, or an
-   action bound to a callable.
+   action bound to a callable. _Programming-language consequence: the entities a program defines are
+   types, members, functions, and registered effects -- nothing else._
 2. All hierarchy is expressed as object ownership. A hierarchical reference is navigation on the
-   object graph, not a lookup in a side table.
+   object graph, not a lookup in a side table. _Programming-language consequence: containment is
+   expressed in the type system, not by a parallel registry._
 3. Generate is lowered to constructor-time construction logic. A module's constructor builds its
-   children via `if`, loop, and sequence over construction actions.
+   children via `if`, loop, and sequence over construction actions. _Programming-language
+   consequence: generate is not a meta-language at MIR; it is ordinary constructor code._
 4. MIR ids are the single source of identity at this layer. Earlier-layer ids are not carried
-   through.
+   through. _Programming-language consequence: a layer's names are owned by the layer._
 5. MIR admits a pure textual dumper that is lossless with respect to MIR identity and structure. The
-   dumper is the golden-test surface at this layer; it is not a compilation path.
+   dumper is the golden-test surface at this layer; it is not a compilation path. _Programming-
+   language consequence: the program is readable as text at the layer where it is meaningful as
+   software._
 6. MIR does not reconstruct topology or identity from side tables. A member is owned by exactly one
-   object; a callable by exactly one owner.
+   object; a callable by exactly one owner. _Programming-language consequence: ownership is
+   structural, not name-based._
 7. A member is a `(name, type)` pair. An owned child -- a module instance or a named generate scope
    -- is a member whose type is an owning pointer to an object type. An array of children is a
    member whose type is a vector of that owning pointer; a multidimensional array nests the vector
    wrapper. No member carries a classification flag beside its type; the type is the classification.
+   _Programming-language consequence: the type system carries every fact about a member; no parallel
+   discriminator exists._
 8. An object type is exactly one of two forms: intra-unit, naming a structural scope of this unit,
    or external-unit, naming another compilation unit. This single distinction is the owned child's
    runtime scope kind -- a named generate scope versus a module instance. Nothing else encodes scope
-   kind.
+   kind. _Programming-language consequence: a class reference is either local to this translation
+   unit or names an external one; there is no third kind._
 9. Instance multiplicity is the vector wrapper, a property of the member's type, and is orthogonal
    to whether the owned object is an intra-unit scope or an external unit. The same wrapper composes
-   over either object form and to any depth.
-10. Every semantic decision is explicit in MIR's structure. MIR is consumed by more than one backend
-    -- the C++ emitter today, the LIR-then-LLVM path next -- and each chooses only how to represent
-    MIR's stated semantics in its target. A backend reads a semantic fact from a MIR node or
-    reference; it never re-derives or re-decides one. This is what lets two backends produce the
-    same behaviour from the same MIR: anything they would otherwise have to infer must already be
-    stated.
-
+   over either object form and to any depth. _Programming-language consequence: cardinality and kind
+   compose through generic type wrappers._
+10. Every semantic decision is explicit in MIR's structure, expressed in MIR's existing primitive
+    set. MIR is consumed by more than one backend; each chooses only how to represent MIR's stated
+    semantics in its target, by a fixed function of the node kind. A backend reads a semantic fact
+    from a MIR node or reference; it never re-derives or re-decides one, and it never expects MIR to
+    grow a new node kind to express a fact -- if the fact is missing, HIR-to-MIR is incomplete and
+    should emit the corresponding combination of existing primitives instead. _Programming-language
+    consequence: the program text is the program; consumers do not invent vocabulary the language
+    does not have._
 11. Every callable body's first binding is `self`, a pointer to its enclosing structural scope --
     `body.vars[0]` is a procedural-var declaration of that pointer type, named `self`. Access to any
     class member -- a structural variable, a service call, a child instance -- flows through
@@ -86,31 +132,57 @@ several possible backend targets for MIR, and does not define MIR's semantics.
     receiver to pass). Both supply mechanisms land the same binding at `body.vars[0]`; the body code
     does not know or care which mechanism filled it. See `docs/decisions/callable-receiver.md`.
 
+    _Programming-language consequence: methods take `self` explicitly. This is the C++ `this`, the
+    Python `self`, the Rust `&self`. Languages that hide it behind keyword sugar at source level
+    still expose it explicitly in their IRs (LLVM IR's first parameter, Python's
+    `__call__(self, ...)`); MIR does the same._
+
 ## Boundary to Adjacent Layers
 
-- Consumes HIR. HIR-to-MIR lowering produces MIR objects and members from HIR declarations and MIR
-  callables from HIR processes, functions, tasks, and assertions.
-- Produces input to LIR. MIR-to-LIR lowering introduces CFG structure, storage placement, and
-  execution-oriented details.
+- Consumes HIR. HIR-to-MIR is the layer where SV-specific concepts get translated into MIR's generic
+  programming-language vocabulary. Anything SV-specific that does not appear in MIR's vocabulary is
+  either translated at this boundary (an event-control delay becomes a coroutine suspension; a
+  non-blocking assignment becomes a deferred closure submission) or rejected as unsupported.
+  HIR-to-MIR has the SV knowledge; MIR does not.
+- Produces input to LIR. MIR-to-LIR is the layer where the programming language gets translated into
+  a machine-execution model. CFG structure, storage placement, and execution-oriented details are
+  introduced at this boundary; MIR does not predict them.
 
 ## Forbidden Shapes
 
-- Basic blocks, successor lists, or phi nodes in MIR nodes.
-- Storage offsets, byte layouts, or alignment data in MIR nodes.
+These are the patterns that violate the identity. Each is the inverse of a property the identity
+implies; the diagnostic for any new forbidden shape is "what identity property does this break".
+
+- Basic blocks, successor lists, or phi nodes in MIR nodes. (MIR is not the machine-execution
+  model.)
+- Storage offsets, byte layouts, or alignment data in MIR nodes. (Storage placement belongs to LIR.)
 - A secondary hierarchy or identity system that shadows MIR ids (coordinate tuples, ordinals, symbol
-  paths used as identity).
-- Global semantic lookup used inside MIR. Relationships live on the owning object.
+  paths used as identity). (Identity is owned by the layer; programming languages do not have two
+  parallel name systems for the same thing.)
+- Global semantic lookup used inside MIR. Relationships live on the owning object. (Structural
+  ownership replaces side-table lookup.)
 - A parallel list, flag, or side field that classifies members -- signal versus owned child,
   instance versus generate scope, scalar versus array -- outside the type system. The type is the
-  classification, and a consumer reads it from the type.
+  classification, and a consumer reads it from the type. (Type system carries every fact about a
+  member.)
 - Re-deriving a member's scope kind, cardinality, or storage shape from anything other than its type
   (its name, a naming convention, an enclosing-construct category, or a separate enum).
 - Side tables that recover topology from keys rather than direct ownership.
 - Deferred or concurrent assertions represented as flags or lowering-pass side effects instead of
-  explicit callables.
+  explicit callables. (Effects are first-class entities; they are not represented by flags.)
 - A MIR node that preserves SystemVerilog syntactic sugar as an opaque payload: a `CaseStmt` /
   `CaseInsideStmt` in MIR, an `InsideExpr` / `CasezExpr` / `CasexExpr` in MIR's expression set, a
-  `ForeachStmt` in MIR. Sugar of this kind is desugared to primitives upstream.
+  `ForeachStmt` in MIR. Sugar of this kind is desugared to primitives upstream. (MIR's vocabulary is
+  the generic-language vocabulary, not the source language's.)
+- A MIR node kind invented to express a backend-side storage realization or runtime library wrapper
+  (a `ReadCell` / `WriteCell` / `MutateCell` node for the C++ backend's `Var<T>`, an `AcquireLock` /
+  `ReleaseLock` node for some scheduling discipline). Backend storage realizations are library types
+  in the target; their operations appear in MIR as ordinary `CallExpr` nodes against the library
+  type's API. The decision that a read or write through such a wrapper is expressed as a method
+  invocation is made at HIR-to-MIR lowering, which emits a `CallExpr` against the wrapper type's
+  API; the resulting MIR carries no trace of the wrapper as a node concept. (MIR's primitive set is
+  closed; the existing `CallExpr` carries every backend-side library call the same way it carries
+  every other call.)
 - A runtime helper invocation that wraps a primitive operator family as an opaque call to recover
   source-level shape (e.g., `Inside(lhs, items)`, `CaseMatch(sel, labels)`). Sugar collapses to
   primitives in MIR; readability of generated backend source is not recovered by reintroducing
@@ -119,7 +191,7 @@ several possible backend targets for MIR, and does not define MIR's semantics.
   contents or any side signal, instead of reading it from an explicit node or reference. Reading
   which node consumes a value is reading structure and is allowed; scanning a body to decide what it
   must be is re-deriving. If two backends could infer a fact differently, it is not yet in MIR and
-  belongs there.
+  belongs there -- expressed through the existing primitive set.
 - A node field that no backend's realization reads, or that restates what the node's structural
   context -- the nodes it references, or the node that consumes it -- already fixes. A node's fields
   are the inputs to its fixed per-backend realization: a field a realization can ignore is dead, and
@@ -132,14 +204,15 @@ several possible backend targets for MIR, and does not define MIR's semantics.
   "the current receiver, whatever that is" carries an implicit context the consumer must walk
   surroundings to discover. Receiver semantics live on `body.vars[0]` as the `self` binding, reached
   through `ProceduralVarRef`; member access reads the receiver from the containing `MemberAccess`'s
-  receiver field, never from a node that means "look around and figure it out".
+  receiver field, never from a node that means "look around and figure it out". (Programming
+  languages do not have expressions whose meaning depends on syntactic context.)
 
 ## Notes / Examples
 
-Reviewing MIR via the dumper should feel like reading the compiled program's structure. The C++
-backend emits MIR to C++ source: it is a backend output, not a debug view. The object-oriented
-semantic model maps naturally to C++ surface syntax, but C++ is not MIR's semantics and more than
-one backend may exist.
+Reviewing MIR via the dumper should feel like reading the compiled program's structure expressed in
+a generic programming language. The C++ backend emits MIR to C++ source: it is a backend output, not
+a debug view. The C++ surface syntax happens to map naturally onto MIR's vocabulary because the two
+share many concepts, but C++ is not MIR's semantics and more than one backend may exist.
 
 A module instance, a named generate scope, and an instance array differ only in one member's type:
 `owning-ptr(external-unit object)`, `owning-ptr(intra-unit object)`, and `vector(owning-ptr(...))`
@@ -183,3 +256,13 @@ invoked and in how `self` is supplied -- a process / subroutine / constructor bo
 as its first formal parameter at every invocation, a closure captures `self` by value at
 construction. Both supply paths end at the same place: `body.vars[0]` is `self`, read identically by
 every member access in the body.
+
+An access through a runtime library wrapper type illustrates the boundary between MIR's vocabulary
+and a backend's storage realization. The C++ backend wraps an observable signal's storage in
+`Var<T>`, exposing `Get` / `Set` / `Mutate` on the wrapper. MIR does not have a "cell access" node:
+a read of an observable signal is a `CallExpr` whose callee is the wrapper type's `Get` method and
+whose receiver is the `MemberAccess` reaching the signal; a write is a `CallExpr` to `Set`. The
+decision that an observable read is a method call -- not an implicit value-read -- is made at
+HIR-to-MIR, which sees that the signal's MIR type is the wrapper type and emits the corresponding
+call. By the time MIR is read by any backend, the program already says `wrapper.Get(...)` or
+`wrapper.Set(...)`; the backend reads the call and emits it the same way it emits any other call.

--- a/docs/decisions/value-type-concepts.md
+++ b/docs/decisions/value-type-concepts.md
@@ -1,0 +1,236 @@
+# Value-type concepts (composable LRM operator contracts)
+
+Date: 2026-06-17 Status: accepted
+
+## Context
+
+The runtime layer `lyra::value::*` realises every SystemVerilog data type as a host C++ type
+(`PackedArray`, `String`, `UnpackedArray<T>`, `DynamicArray<T>`, `Queue<T>`,
+`AssociativeArray<K,V>`, `Real`). Two adjacent concerns reach into these types and have been
+entangled:
+
+1. **LRM operator coverage.** LRM 11.4.5 defines `==`/`!=` for any data type, `===`/`!==` for any
+   data type except `real`/`shortreal`, `==?`/`!=?` for integral only, relational `<`/`<=`/`>`/`>=`
+   for integral / real / string. Each value type's surface must reflect what LRM defines on it. The
+   existing surface was grown incrementally and is uneven: `PackedArray` has everything;
+   `AssociativeArray` has none of the equality family; `Queue` has only a host-bool case-equality
+   predicate and no `==`/`!=` or PackedArray-returning `===`; `String::operator==` returns `bool`
+   while every other container's `==` returns `PackedArray`.
+2. **Runtime change-detection hook.** `lyra::runtime::Var<T>::Set` (LRM 4.3 / 9.4.2 update event)
+   asks one question per write: "did the cell's bit-pattern change". For integral signals this has
+   been computed by `PackedArray::IsCaseEqual` -- the same algorithm as the SV `===` operator. The
+   shared algorithm collapsed two distinct roles (engine hook vs LRM operator) into one method pair
+   (`IsCaseEqual` / `CaseEqual`), with the name borrowing LRM terminology for what is, at the
+   `Var<T>` callsite, an engine-internal predicate.
+
+The entanglement surfaces as two visible smells:
+
+- `IsCaseEqual` (host bool) and `CaseEqual` (PackedArray) look like a "two output forms of one
+  operation" pair, but they answer two different questions; the name pairing hides that.
+- The C++ backend's `IsObservableScalarType(mir::Type)` predicate gates wrap-in-`Var<T>` and the
+  Set/Get/Mutate dispatch by checking whether the value type is integral-packed (plus `ExternalRef`
+  as a sibling intrinsic-observable). This is a transitional approximation -- the LRM-correct gate
+  is "is this storage a module-level cell", not "is its value type integral" -- and it leaks because
+  the value-type layer never declared which types are eligible for observable wrapping.
+
+`refactor.md` R12 plans to lift the observable wrapping into MIR's type system as a first-class
+`ObservableType`. That cleanup is blocked on a clean answer to "which value types are eligible to be
+wrapped". The answer cannot be a predicate the backend recomputes -- it must be a contract the value
+types declare and the type system enforces.
+
+## Decision
+
+**The `lyra::value::*` surface is structured as a small lattice of composable C++ concepts, each
+mirroring one LRM operator family.** Every value type declares the concepts it satisfies; LRM Table
+11-1 ("operators and data types") dictates which concepts a given type must satisfy and which it
+must not. The runtime gates wrapping in `Var<T>` and `ObservableType{T}` on the most fundamental
+concept; LRM-specific lowering paths gate on the relevant per-family concept.
+
+### Concept lattice
+
+```
+LyraValueType            -- the storage + universal-equality contract
+  std::copyable          -- container-safe relocation (existing `LyraValue`)
+  operator==(T) const -> PackedArray   // LRM 11.4.5 == (Any data type)
+  operator!=(T) const -> PackedArray   // LRM 11.4.5 != (Any data type)
+  IsBitIdentical(T) const -> bool      // engine change-detection hook
+                                       // (LRM 9.4.2 update event predicate)
+
+CaseEqualComparable : LyraValueType
+  CaseEqual(T) const -> PackedArray    // LRM 11.4.5 === (Any except real/shortreal)
+                                       // by convention shares internal impl with IsBitIdentical
+
+WildcardComparable : LyraValueType
+  WildcardEquals(T) const -> PackedArray  // LRM 11.4.5 ==? (Integral only)
+
+Ordered : LyraValueType
+  operator< / <= / > / >= -> PackedArray  // LRM 11.4.4 relational (Integral / Real / String)
+```
+
+The four concepts are independent refinements of `LyraValueType`. Each value type opts in to the
+subset LRM defines for it.
+
+### Per-type concept membership
+
+| Type                    | `LyraValueType`       | `CaseEqualComparable`               | `WildcardComparable` | `Ordered`                |
+| ----------------------- | --------------------- | ----------------------------------- | -------------------- | ------------------------ |
+| `PackedArray`           | yes                   | yes                                 | yes                  | yes                      |
+| `Enum<Derived>`         | yes (via inheritance) | yes                                 | yes                  | yes                      |
+| `String`                | yes                   | yes                                 | no (LRM excludes)    | yes                      |
+| `UnpackedArray<T>`      | yes                   | yes                                 | no                   | no (LRM does not define) |
+| `DynamicArray<T>`       | yes                   | yes                                 | no                   | no                       |
+| `Queue<T>`              | yes                   | yes                                 | no                   | no                       |
+| `AssociativeArray<K,V>` | yes                   | yes                                 | no                   | no                       |
+| `lyra::value::Real`     | yes                   | **no (LRM excludes real from ===)** | no                   | yes                      |
+
+`Real`'s row is the load-bearing case: LRM Table 11-1 says `===` / `!==` apply to "Any except real
+and shortreal". The composable design records this exclusion structurally -- `Real` satisfies
+`LyraValueType` (so `Var<Real>` works and a module-level real signal is observable) but does not
+satisfy `CaseEqualComparable` (so an SV expression `r1 === r2` fails to lower at the C++ emit
+boundary, reflecting that the source program itself is LRM-illegal). The exclusion is not enforced
+by ad-hoc predicates; it follows from which concepts the type declares.
+
+### Universal-equality return type
+
+`operator==` and `operator!=` return `PackedArray` uniformly across every value type. For inherently
+2-state types (`String`, future `Real`), the result is a 1-bit 2-state `PackedArray` that is always
+`0` or `1`; for 4-state-aware types it may be `x`. The uniform return type lets the lowering and
+emit paths treat every `==`/`!=` callsite identically -- no per-type return-shape branching. The
+slight cost (constructing a 1-bit `PackedArray` for a fundamentally 2-state result) is paid in the
+runtime; the entire compiler-and-emit pipeline above it stays uniform.
+
+### `IsBitIdentical` vs `CaseEqual`
+
+These are separate methods on a value type even when they share an internal algorithm:
+
+- `IsBitIdentical(T) const -> bool` is a member of `LyraValueType`. It is the engine's
+  change-detection question ("did the cell's bit-pattern change between two writes"). Its name
+  reflects its role, not an LRM operator. It returns the truthful host-bool result.
+- `CaseEqual(T) const -> PackedArray` is a member of `CaseEqualComparable`. It is the LRM `===`
+  operator's value-type realisation. The result type carries the SV-typed 1-bit packed value that
+  participates in further SV expression evaluation.
+
+For types that satisfy both concepts the two methods share an internal helper (bit-by-bit identity
+check). For `Real` only `IsBitIdentical` exists -- it implements bit-pattern equality via
+`std::bit_cast<std::uint64_t>(double)` so that `+0.0` and `-0.0` are distinct and NaN bit-patterns
+classify by identity, both required for "did the storage cell's bits change" semantics. No
+`CaseEqual` exists on `Real`; the LRM gives no source-level syntax that would call it.
+
+### `Var<T>` and `ObservableType{T}` gating
+
+`Var<T>` requires only `LyraValueType`. Every type that can be wrapped as observable storage
+satisfies this concept, no more.
+
+MIR's `ObservableType{T_mir}` (R12) wraps an MIR value type to declare module-scope observable
+storage. HIR-to-MIR's wrap rule is structural -- a structural-var declaration whose value type is a
+"data storage" kind is wrapped; pointer / vector / object-handle / external-ref / event / chandle /
+void / scope / self types are not. The C++ emit then sees `ObservableType{T_mir}` and renders
+`Var<T_cpp>`. The C++ template instantiation `Var<T_cpp>` requires `LyraValueType<T_cpp>`; a value
+type that forgot to implement the contract triggers a compile-time concept failure at the
+instantiation site. The MIR type system gates "this storage is observable"; the C++ concept system
+gates "this value type can fulfill the observable contract". Both gates compose without duplicating
+the predicate.
+
+The old backend predicate `IsObservableScalarType(mir::Type)` is removed.
+
+### Lowering observable reads and writes
+
+An observable structural variable's read and write are SV-level implicit operations on the variable;
+the C++ realisation of these operations is a method call on the `Var<T>` wrapper (`Get` / `Set` /
+`Mutate`). Per `mir.md` invariant 10, the fact that the operation is a method call must be explicit
+in MIR; the C++ backend never re-decides it, and neither does the LLVM-via-LIR path. HIR-to-MIR
+therefore lowers an observable read / write into an ordinary `CallExpr` whose receiver is the
+`MemberAccess` reaching the cell and whose argument vector includes the engine handle when the
+wrapper method needs it (`Set` / `Mutate`):
+
+```
+SV: x = sig;        // observable read
+MIR: ... = Call(BuiltinMethodCallee(ObservableMethod{Get}), [MemberAccess(self, sig)])
+
+SV: sig = v;        // observable whole-write
+MIR: ExprStmt(Call(BuiltinMethodCallee(ObservableMethod{Set}), [
+       MemberAccess(self, sig),
+       Call(BuiltinMethodCallee(ScopeMethod{kServices}), [self]),
+       v
+     ]))
+
+SV: sig.itoa(42);   // mutating method on observable receiver
+MIR: ExprStmt(Call(BuiltinMethodCallee(StringMethod{kItoa}), [
+       Call(BuiltinMethodCallee(ObservableMethod{Mutate}), [
+         MemberAccess(self, sig),
+         Call(BuiltinMethodCallee(ScopeMethod{kServices}), [self])
+       ]),
+       42
+     ]))
+```
+
+This follows the same architectural pattern `runtime-effects-as-generic-calls.md` records for
+`$display` / `$finish` / file IO: every runtime operation is an ordinary `CallExpr`; the engine
+handle is one argument among others; MIR does not know which argument plays which role. The pattern
+applies here without modification because an observable cell's API is, at the C++ realisation level,
+just another runtime library API.
+
+### `lyra::value::Real` / `ShortReal` / `RealTime`
+
+`Real` / `ShortReal` wrap `double` / `float` and satisfy `LyraValueType` + `Ordered`, not
+`CaseEqualComparable` (LRM Table 11-1 excludes `real` / `shortreal` from `===`). `RealTime` is the
+same C++ type as `Real` per LRM 6.12.1. The runtime exposes the full LRM operator surface --
+arithmetic (`+` / `-` / `*` / `/` / `**`), unary negation, relational (`<` / `<=` / `>` / `>=`
+returning a 1-bit `PackedArray`), equality (`==` / `!=` returning 1-bit `PackedArray`),
+`IsBitIdentical` via `std::bit_cast<std::uint64_t>(double)` so `+0.0` / `-0.0` and NaN bit-patterns
+classify by identity (required for LRM 9.4.2 update-event detection), and the SV `int<->real`
+conversions. HIR-to-MIR's observable wrap rule treats `RealType` / `ShortRealType` / `RealTimeType`
+like any other value-storage type; a module-level `real` signal is observable through the same
+mechanism as a module-level `int` signal.
+
+## Implementation status
+
+- `LyraValueType`, `CaseEqualComparable`, `WildcardComparable`, `Ordered` defined in
+  `include/lyra/value/concepts.hpp`.
+- `PackedArray`, `String`, `UnpackedArray`, `DynamicArray`, `Queue`, `AssociativeArray` updated to
+  satisfy the concepts LRM requires. Naming aligned: the host-bool predicate is `IsBitIdentical`
+  across every type.
+- `lyra::runtime::Var<T>` requires `LyraValueType` and reads change-detection through
+  `IsBitIdentical`.
+- `IsObservableScalarType` removed from `backend::cpp`.
+- `mir::ObservableType` added; HIR-to-MIR's structural-var lowering wraps eligible value types; the
+  C++ render emits `Var<T_cpp>` for an `ObservableType{T_mir}` field declaration.
+- The HIR-to-MIR generic-`CallExpr` lowering for observable reads / writes (the `Get` / `Set` /
+  `Mutate` shapes above) and the corresponding render simplification have not yet landed; the C++
+  backend currently re-derives the dispatch through a set of per-site predicates
+  (`IsObservableCell`, `LhsRootIsObservableScalar`, the four `MethodMutatesReceiver` tables,
+  `RenderMethodReceiver`). These predicates are transitional residue and retire with the lowering
+  change.
+- `lyra::value::Real` / `ShortReal` value classes and the corresponding HIR-to-MIR wrap-rule update
+  have not yet landed.
+
+## Forbidden shapes
+
+- A method on `lyra::value::*` whose name borrows an LRM operator's terminology while serving the
+  runtime engine's change-detection role. The engine hook is `IsBitIdentical`; the LRM `===`
+  realisation is `CaseEqual`. They are separate even when their internal algorithm coincides.
+- A backend predicate that decides "is this storage observable" by inspecting the value type's
+  variant kind (the removed `IsObservableScalarType` shape). Observability is an MIR-type-system
+  fact (`ObservableType` wrapping); eligibility to be wrapped is a C++ concept fact
+  (`LyraValueType`). The backend reads one or the other; it does not synthesise either.
+- A value type that satisfies `CaseEqualComparable` but whose `CaseEqual` and `IsBitIdentical` give
+  different answers. The two methods may share an internal helper; they may not diverge.
+- A value type that implements an LRM operator method (e.g., `WildcardEquals`) without declaring the
+  corresponding concept membership. The concept system is the contract; the methods exist to satisfy
+  the concept.
+- A new MIR node kind invented to express observable read / write (a `ReadCell` / `WriteCell` /
+  `MutateCell` node). Observable operations lower to ordinary `CallExpr` against the `Var<T>`
+  wrapper API; this matches `mir.md`'s forbidden shape against inventing MIR node kinds for
+  backend-side storage realisations and the pattern recorded in
+  `runtime-effects-as-generic-calls.md`.
+- A backend predicate that decides whether a read should append `.Get()`, whether a write should
+  route through `.Set()`, or whether a method receiver should switch between `.` and `->`. The
+  decision belongs in HIR-to-MIR, expressed as the `CallExpr` shapes above. A predicate of this
+  shape at render time is the inverse of `mir.md` invariant 10.
+
+## Notes
+
+The decision encodes LRM Table 11-1's "operators and data types" structure directly in the C++ type
+system. Each row of Table 11-1 corresponds to one concept; each operand-type cell determines which
+types satisfy it. Adding LRM operator families later (arithmetic, bitwise, shifts, reductions, ...)
+follows the same shape -- one concept per family, types opt in to the ones LRM defines on them.

--- a/include/lyra/backend/cpp/render_expr.hpp
+++ b/include/lyra/backend/cpp/render_expr.hpp
@@ -25,6 +25,13 @@ auto RenderLhsExpr(
     const RenderContext& ctx, const mir::Expr& expr,
     std::string_view mutate_adapter) -> diag::Result<std::string>;
 
+// Reports whether the lvalue chain `expr` ultimately writes through an
+// observable cell (a `mir::ObservableType`-wrapped structural var or an
+// extern-ref slot). Sites that need to bind the cell for `Var<T>::Mutate`
+// dispatch consult this before choosing the lvalue render path.
+[[nodiscard]] auto LhsRootIsObservableScalar(
+    const RenderContext& ctx, const mir::Expr& expr) -> bool;
+
 // Renders `expr` for use in a C++ boolean context (`if`, `while`, `do`, `for`
 // condition, ternary cond, `&&` / `||` / `!`). When the expression's MIR type
 // is a packed array, `PackedArray`'s `explicit operator bool` fires on the

--- a/include/lyra/backend/cpp/render_type.hpp
+++ b/include/lyra/backend/cpp/render_type.hpp
@@ -34,9 +34,4 @@ namespace lyra::backend::cpp {
 [[nodiscard]] auto RenderEnumClassName(
     const mir::StructuralScope& owner_scope, mir::TypeId id) -> std::string;
 
-// True iff a structural field of this type is emitted as `Var<T>` (and writes
-// go through `Var<T>::Set`). Today: only integral types via `PackedArray`. The
-// set grows as more SV value types gain `IsCaseEqual`.
-[[nodiscard]] auto IsObservableScalarType(const mir::Type& ty) -> bool;
-
 }  // namespace lyra::backend::cpp

--- a/include/lyra/lowering/hir_to_mir/services_arg.hpp
+++ b/include/lyra/lowering/hir_to_mir/services_arg.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/walk_frame.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/expr_id.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// Builds the `self.Services()` engine-handle argument: a `ProceduralVarRef` to
+// `self` (mir.md invariant 11) wrapped in a `ScopeMethod{kServices}` call.
+// Lowering sites that emit a runtime-effect or wrapper-API call thread the
+// returned id as the call's services argument. See
+// `docs/decisions/runtime-effects-as-generic-calls.md`.
+[[nodiscard]] inline auto BuildServicesArg(
+    const ProcessLowerer& process, const WalkFrame& frame) -> mir::ExprId {
+  auto& body = *frame.current_procedural_scope;
+  const auto& builtins = process.Module().Unit().builtins;
+  const mir::ExprId self_id = body.AddExpr(
+      mir::MakeProceduralVarRefExpr(
+          frame.procedural_depth - frame.self_decl_depth, *frame.self_binding,
+          builtins.self_pointer));
+  return body.AddExpr(mir::MakeServicesCallExpr(self_id, builtins.services));
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/builtin_method.hpp
+++ b/include/lyra/mir/builtin_method.hpp
@@ -52,6 +52,14 @@ enum class EventMethodKind : std::uint8_t {
 // family (ordering, reduction, and the 7.12.1 locator methods). The locator
 // arms (`kFind` onward) return a queue -- an element queue for the value
 // locators and an `int` queue for the index locators.
+//
+// Reduction, ordering, and locator methods carry a single closure as their
+// second argument. LRM 7.12.1 defines that "if a `with` clause is not given,
+// the method behaves as if `with (item)` were specified", so HIR-to-MIR
+// synthesises the identity closure when the source has none. At MIR each
+// method is exactly one kind with one signature (receiver plus closure); the
+// SV-source distinction between implicit and explicit `with` is a reading of
+// the source, not a MIR-level fact.
 enum class ArrayMethodKind : std::uint8_t {
   kSize,
   kDelete,

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -33,6 +33,7 @@ enum class TypeKind {
   kPointer,
   kVector,
   kExternalRef,
+  kObservable,
 };
 
 enum class BitAtom {
@@ -185,6 +186,22 @@ struct VectorType {
   auto operator==(const VectorType&) const -> bool = default;
 };
 
+// Observable storage wrapper around a value type. Declares that a structural
+// variable's storage is a module-scope cell that exposes Set / Get / Mutate
+// (LRM 9.4.2 update event) -- writes route through the engine so subscribers
+// wake. HIR-to-MIR wraps a structural-var declaration whose value type is a
+// SystemVerilog data type (not a handle, child instance, or external ref) in
+// this wrapper. The C++ backend renders the wrapper as `lyra::runtime::Var<T>`
+// where T is the inner value type; the C++ template requires `T` to satisfy
+// `lyra::value::LyraValueType`, so a value type that forgot to implement the
+// contract fails at template instantiation. See
+// `docs/decisions/value-type-concepts.md`.
+struct ObservableType {
+  TypeId value;
+
+  auto operator==(const ObservableType&) const -> bool = default;
+};
+
 // One by-name step from a resolved scope into an owned child it answers for:
 // the child member's name plus one index per array dimension (empty for a
 // scalar child). The ancestor answers by name from the children it registered,
@@ -218,8 +235,8 @@ using TypeData = std::variant<
     PackedArrayType, EnumType, UnpackedArrayType, DynamicArrayType, QueueType,
     AssociativeArrayType, StringType, EventType, RealType, ShortRealType,
     RealTimeType, ChandleType, VoidType, ObjectType, ExternalUnitObjectType,
-    ScopeType, SelfType, ServicesType, PointerType, VectorType,
-    ExternalRefType>;
+    ScopeType, SelfType, ServicesType, PointerType, VectorType, ExternalRefType,
+    ObservableType>;
 
 struct Type {
   TypeData data;

--- a/include/lyra/runtime/extern_up.hpp
+++ b/include/lyra/runtime/extern_up.hpp
@@ -40,7 +40,7 @@ struct ChildStep {
 // the member behaves like the referenced `Var<T>` while naming no ancestor
 // type (docs/architecture/emission_model.md). Non-movable: it registers `this`,
 // and is owned by the stable scope node that declares it.
-template <CaseEqualComparable T>
+template <value::LyraValueType T>
 class ExternUp : public ExternBase {
  public:
   ExternUp(

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -13,6 +13,7 @@
 #include "lyra/runtime/trigger.hpp"
 #include "lyra/value/packed.hpp"
 #include "lyra/value/packed_array.hpp"
+#include "lyra/value/value_concept.hpp"
 
 namespace lyra::runtime {
 
@@ -123,15 +124,10 @@ class Observable {
   std::vector<Waiter> waiters_;
 };
 
-template <typename T>
-concept CaseEqualComparable = requires(const T& a, const T& b) {
-  { a.IsCaseEqual(b) } -> std::same_as<bool>;
-};
-
-template <CaseEqualComparable T>
+template <value::LyraValueType T>
 class ScopedMutation;
 
-template <CaseEqualComparable T>
+template <value::LyraValueType T>
 class Var : public Observable {
  public:
   Var() = default;
@@ -146,18 +142,22 @@ class Var : public Observable {
   auto operator=(Var&&) -> Var& = delete;
   ~Var() = default;
 
-  // Returns true iff `v` is bit-pattern-different (LRM 9.4.2 `===` semantics
-  // for @() detection, not 4-state `==`); caller dispatches on the result.
+  // Records the new value and reports whether it differs from the old (LRM
+  // 9.4.2 `===` semantics for @() detection -- the engine fires subscribers
+  // only on a real change). The store always happens so a freshly-defaulted
+  // cell adopts shape and implementation-side seeds (e.g. an
+  // `AssociativeArray`'s `oob_slot_`) from the source on the first write,
+  // even when the SV-visible content compares identical (both empty).
   auto AssignIfChanged(const T& v) -> bool {
-    if (value_.IsCaseEqual(v)) return false;
+    const bool changed = !value_.IsBitIdentical(v);
     value_ = v;
-    return true;
+    return changed;
   }
 
   auto AssignIfChanged(T&& v) -> bool {
-    if (value_.IsCaseEqual(v)) return false;
+    const bool changed = !value_.IsBitIdentical(v);
     value_ = std::move(v);
-    return true;
+    return changed;
   }
 
   [[nodiscard]] auto Get() const noexcept -> const T& {
@@ -187,7 +187,7 @@ class Var : public Observable {
 // event fires and subscribers wake), or a plain `T` cell (raw read / write,
 // no observers). Copyable, so a ref formal can be forwarded as a ref
 // argument to a nested call.
-template <CaseEqualComparable T>
+template <value::LyraValueType T>
 class Ref {
  public:
   explicit Ref(Var<T>& cell) : signal_(&cell) {
@@ -282,7 +282,7 @@ inline auto MakePackedArrayEdgeClassifier(
           old_val.ExtractBits(lsb_arg, static_cast<std::uint32_t>(width));
       const auto new_slice =
           new_val.ExtractBits(lsb_arg, static_cast<std::uint32_t>(width));
-      return !old_slice.IsCaseEqual(new_slice);
+      return !old_slice.IsBitIdentical(new_slice);
     }
     const value::FourStateBit old_bit =
         (width == 0U) ? old_val.Lsb() : old_val.GetBit(lsb);
@@ -292,7 +292,7 @@ inline auto MakePackedArrayEdgeClassifier(
   };
 }
 
-template <CaseEqualComparable T>
+template <value::LyraValueType T>
 void Var<T>::Set(RuntimeServices& services, const T& new_val) {
   // A PackedArray write classifies the LSB transition per waiter (LRM 9.4.2
   // Table 9-2); every other cell type only has any-change waiters.
@@ -320,7 +320,7 @@ void Var<T>::Set(RuntimeServices& services, const T& new_val) {
 // until the end of the constructing full expression. Returning it by value
 // from `Var<T>::Mutate` relies on C++17 mandatory copy elision (prvalues are
 // materialized in the caller's storage with no copy/move).
-template <CaseEqualComparable T>
+template <value::LyraValueType T>
 class ScopedMutation {
  public:
   ScopedMutation(RuntimeServices& services, Var<T>& var)
@@ -336,14 +336,26 @@ class ScopedMutation {
     var_->Set(*services_, std::move(snapshot_));
   }
 
-  // Chain forwards. The returned `PackedArrayRef` holds a pointer into this
-  // ScopedMutation's snapshot_; both have the same full-expression lifetime,
-  // so the ref stays valid for the rest of the statement.
-  auto ElementAt(const value::PackedArray& idx) {
+  // Chain forwards. For a packed-storage snapshot the returned
+  // `PackedArrayRef` holds a pointer into this ScopedMutation's snapshot_; for
+  // an unpacked-storage snapshot (`DynamicArray<T>`, `Queue<T>`, etc.) the
+  // forwarder must preserve the reference so the assignment lands in the
+  // snapshot (not in a returned-by-value copy).
+  auto ElementAt(const value::PackedArray& idx) -> decltype(auto) {
     return snapshot_.ElementAt(idx);
   }
-  auto Slice(const value::PackedArray& lsb, std::uint32_t count) {
+  auto Slice(const value::PackedArray& lsb, std::uint32_t count)
+      -> decltype(auto) {
     return snapshot_.Slice(lsb, count);
+  }
+  // LRM 7.8.7 write-side index access on associative arrays: distinct from
+  // `ElementAt` because the AA splits read from write (`Read` for missing
+  // keys, `ElementRef` for allocation on write). Member-template so SFINAE
+  // suppresses the declaration on `T` types without `ElementRef`.
+  template <typename Key, typename U = T>
+    requires requires(U& u, const Key& k) { u.ElementRef(k); }
+  auto ElementRef(const Key& key) -> decltype(auto) {
+    return snapshot_.ElementRef(key);
   }
 
   // LRM 11.4 whole-var compound. Mirrors `x op= rhs` directly: snapshot is
@@ -424,13 +436,27 @@ class ScopedMutation {
     return prior;
   }
 
+  // Drilldown to the underlying snapshot for instance methods on `T` that
+  // mutate the value in place (e.g. `String::Itoa`). The chain becomes
+  // `var.Mutate(svc)->Method(...)` and the destructor commits the mutated
+  // snapshot exactly once.
+  auto operator->() -> T* {
+    return &snapshot_;
+  }
+  // The dereference form for free-function callees that take a mutable
+  // reference (e.g. `LyraFRead(svc, var.Mutate(svc), ...)` -- spelled
+  // `*var.Mutate(svc)` at the call site).
+  auto operator*() -> T& {
+    return snapshot_;
+  }
+
  private:
   RuntimeServices* services_;
   Var<T>* var_;
   T snapshot_;
 };
 
-template <CaseEqualComparable T>
+template <value::LyraValueType T>
 auto Var<T>::Mutate(RuntimeServices& services) -> ScopedMutation<T> {
   return ScopedMutation<T>{services, *this};
 }

--- a/include/lyra/value/array_case_equal.hpp
+++ b/include/lyra/value/array_case_equal.hpp
@@ -1,21 +1,19 @@
 #pragma once
 
+#include <concepts>
+
 #include "lyra/value/packed_array.hpp"
 
 namespace lyra::value {
 
-template <typename T>
-class UnpackedArray;
-template <typename T>
-class DynamicArray;
-
 namespace detail {
 
-// LRM 11.4.5 element-level `===` used by both array-container CaseEqual
-// implementations. The PackedArray overload normalises the 0 / 1 result to
-// 4-state when either operand is 4-state so the enclosing `&&` reduction
-// stays in the right state class; the recursive overloads delegate to the
-// container's own CaseEqual.
+// LRM 11.4.5 element-level `===` used by every aggregate-container `CaseEqual`
+// implementation (`UnpackedArray`, `DynamicArray`, `Queue`, ...). The
+// `PackedArray` overload normalises the 0 / 1 result to 4-state when either
+// operand is 4-state so the enclosing `&&` reduction stays in the right state
+// class; the generic fallback delegates to whichever value type's own
+// `CaseEqual` returns the 1-bit packed result (`String`, nested arrays, ...).
 inline auto ArrayCaseEqElement(const PackedArray& a, const PackedArray& b)
     -> PackedArray {
   auto raw = a.CaseEqual(b);
@@ -23,15 +21,11 @@ inline auto ArrayCaseEqElement(const PackedArray& a, const PackedArray& b)
   return four_state ? PackedArray::ConvertFrom(raw, 1, false, true) : raw;
 }
 
-template <typename U>
-auto ArrayCaseEqElement(const UnpackedArray<U>& a, const UnpackedArray<U>& b)
-    -> PackedArray {
-  return a.CaseEqual(b);
-}
-
-template <typename U>
-auto ArrayCaseEqElement(const DynamicArray<U>& a, const DynamicArray<U>& b)
-    -> PackedArray {
+template <typename T>
+  requires requires(const T& a, const T& b) {
+    { a.CaseEqual(b) } -> std::same_as<PackedArray>;
+  }
+auto ArrayCaseEqElement(const T& a, const T& b) -> PackedArray {
   return a.CaseEqual(b);
 }
 

--- a/include/lyra/value/associative_array.hpp
+++ b/include/lyra/value/associative_array.hpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <utility>
 
+#include "lyra/value/array_case_equal.hpp"
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/string.hpp"
@@ -28,13 +29,22 @@ struct PackedArrayKeyLess {
   }
 };
 
+// LRM 7.8.2 string-keyed associative array: keys order lexicographically. The
+// value-type `<` returns a 1-bit `PackedArray`; the host predicate `std::map`
+// needs is recovered with the explicit-bool conversion.
+struct StringKeyLess {
+  [[nodiscard]] auto operator()(const String& a, const String& b) const
+      -> bool {
+    return static_cast<bool>(a < b);
+  }
+};
+
 template <typename K>
 struct AssocKeyTraits;
 
-// LRM 7.8.2: string keys order lexicographically.
 template <>
 struct AssocKeyTraits<String> {
-  using Less = std::less<String>;
+  using Less = StringKeyLess;
 };
 
 // LRM 7.8.4: integral keys order by signed/unsigned numerical value.
@@ -179,6 +189,71 @@ class AssociativeArray {
       return std::nullopt;
     }
     return std::prev(it)->first;
+  }
+
+  // LRM 11.2.2 aggregate equality / 11.4.5: same key set and each paired value
+  // compares equal. A different key set or a different size yields 0; matching
+  // empties yield 1. `==` / `!=` propagate X / Z through the per-value `==`;
+  // `CaseEqual` matches X / Z as values and is deterministic.
+  [[nodiscard]] auto operator==(const AssociativeArray& other) const
+      -> PackedArray {
+    if (data_.size() != other.data_.size()) {
+      return PackedArray::FromInt(0, 1, false, false);
+    }
+    if (data_.empty()) {
+      return PackedArray::FromInt(1, 1, false, false);
+    }
+    PackedArray result = PackedArray::FromInt(1, 1, false, false);
+    for (const auto& [k, v] : data_) {
+      auto it = other.data_.find(k);
+      if (it == other.data_.end()) {
+        return PackedArray::FromInt(0, 1, false, false);
+      }
+      result = result && (v == it->second);
+    }
+    return result;
+  }
+  [[nodiscard]] auto operator!=(const AssociativeArray& other) const
+      -> PackedArray {
+    return !(*this == other);
+  }
+
+  [[nodiscard]] auto CaseEqual(const AssociativeArray& other) const
+      -> PackedArray {
+    if (data_.size() != other.data_.size()) {
+      return PackedArray::FromInt(0, 1, false, false);
+    }
+    if (data_.empty()) {
+      return PackedArray::FromInt(1, 1, false, false);
+    }
+    PackedArray result = PackedArray::FromInt(1, 1, false, false);
+    for (const auto& [k, v] : data_) {
+      auto it = other.data_.find(k);
+      if (it == other.data_.end()) {
+        return PackedArray::FromInt(0, 1, false, false);
+      }
+      result = result && detail::ArrayCaseEqElement(v, it->second);
+    }
+    return result;
+  }
+
+  // LRM 9.4.2 update event predicate (engine change-detection hook): same key
+  // set and each paired value is bit-identical.
+  [[nodiscard]] auto IsBitIdentical(const AssociativeArray& other) const
+      -> bool {
+    if (data_.size() != other.data_.size()) {
+      return false;
+    }
+    for (const auto& [k, v] : data_) {
+      auto it = other.data_.find(k);
+      if (it == other.data_.end()) {
+        return false;
+      }
+      if (!v.IsBitIdentical(it->second)) {
+        return false;
+      }
+    }
+    return true;
   }
 
  private:

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -38,7 +38,7 @@ template <typename K>
   if constexpr (std::is_same_v<K, PackedArray>) {
     return static_cast<bool>(a.CaseEqual(b));
   } else {
-    return a == b;
+    return a.IsBitIdentical(b);
   }
 }
 
@@ -209,16 +209,16 @@ class DynamicArray {
     return result;
   }
 
-  // LRM 11.4.5 `===` predicate form (host bool): the Var change-detection
-  // counterpart of `CaseEqual`. A size mismatch is a change; matching empties
-  // are equal; otherwise recurse into each element's own predicate (LRM 9.4.2
-  // update event).
-  [[nodiscard]] auto IsCaseEqual(const DynamicArray& other) const -> bool {
+  // LRM 9.4.2 update event predicate (engine change-detection hook): are the
+  // two arrays element-wise bit-identical. A size mismatch is a change;
+  // matching empties are identical; otherwise recurse into each element's own
+  // predicate.
+  [[nodiscard]] auto IsBitIdentical(const DynamicArray& other) const -> bool {
     if (data_.size() != other.data_.size()) {
       return false;
     }
     for (std::size_t i = 0; i < data_.size(); ++i) {
-      if (!data_[i].IsCaseEqual(other.data_[i])) {
+      if (!data_[i].IsBitIdentical(other.data_[i])) {
         return false;
       }
     }
@@ -249,80 +249,54 @@ class DynamicArray {
   // libstdc++'s introsort uses `tmp = std::move(arr[i])` during insertion
   // sort, which empties arr[i] and breaks PackedArray's
   // shape-preservation invariant on the subsequent `arr[i] = std::move(...)`.
-  // Selection sort touches elements only via the ADL friend swap, which
-  // exchanges storage directly and stays shape-safe. Test-sized arrays
-  // (the only consumers under DA6-a) make the asymptotic cost a non-issue.
-  auto Sort() -> void {
-    SelectionSortBy(std::less<>{});
-  }
-  auto Rsort() -> void {
-    SelectionSortBy(std::greater<>{});
-  }
-
-  // LRM 7.12.3 reductions: fold the element type's arithmetic / bitwise
-  // operator over the elements. Slang upstream restricts the element type to
-  // integral. Empty-array result is element-shape zero (slang behaviour;
-  // LRM is silent) -- the OOB shield slot already carries the canonical
-  // default and is the cheapest in-shape zero.
-  [[nodiscard]] auto Sum() const -> T {
-    return Fold([](const T& a, const T& b) { return a + b; });
-  }
-  [[nodiscard]] auto Product() const -> T {
-    return Fold([](const T& a, const T& b) { return a * b; });
-  }
-  [[nodiscard]] auto And() const -> T {
-    return Fold([](const T& a, const T& b) { return a & b; });
-  }
-  [[nodiscard]] auto Or() const -> T {
-    return Fold([](const T& a, const T& b) { return a | b; });
-  }
-  [[nodiscard]] auto Xor() const -> T {
-    return Fold([](const T& a, const T& b) { return a ^ b; });
-  }
-
-  // LRM 7.12.2 / 7.12.3 `with`-clause variants. The closure receives each
-  // element and its index per call and returns a key (for ordering) or a
-  // summand (for reduction). The closure's result type is the inferred
-  // template parameter R; for reductions R must be element-shape (slang
-  // accepts width-widening with-expressions, which the closure body
-  // synthesizes via ConversionExpr at HIR -> MIR). PackedArray is used as
-  // the index type so the user-facing `item.index` reads as a regular
-  // integral value in SV semantics; the closure body converts to
-  // std::size_t at compare sites if needed.
+  // LRM 7.12.1 / 7.12.2 / 7.12.3. Each method takes a closure (`with`-clause
+  // body or the LRM-default identity); HIR-to-MIR always supplies one, so
+  // the runtime exposes exactly the closure-taking form. Ordering uses
+  // selection sort: storage exchange via the ADL friend swap stays shape-
+  // safe, and test-sized arrays make the asymptotic cost a non-issue.
+  // Reductions fold the element-type operator over the closure-projected
+  // values; the closure receives each element and its index and returns a
+  // key (for ordering) or a summand (for reduction). The closure's result
+  // type is the inferred template parameter R; for reductions R must be
+  // element-shape (slang accepts width-widening with-expressions, which the
+  // closure body synthesises via ConversionExpr at HIR -> MIR). PackedArray
+  // is used as the index type so the user-facing `item.index` reads as a
+  // regular integral value in SV semantics. Empty-array reduction yields the
+  // element-shape zero (slang behaviour; LRM is silent).
   template <typename F>
-  auto SortBy(F&& key) -> void {
+  auto Sort(F&& key) -> void {
     SelectionSortByKey(std::forward<F>(key), std::less<>{});
   }
   template <typename F>
-  auto RsortBy(F&& key) -> void {
+  auto Rsort(F&& key) -> void {
     SelectionSortByKey(std::forward<F>(key), std::greater<>{});
   }
   template <typename F>
-  [[nodiscard]] auto SumBy(F&& key) const
+  [[nodiscard]] auto Sum(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return FoldBy(
         std::forward<F>(key), [](auto& acc, auto& v) { acc = acc + v; });
   }
   template <typename F>
-  [[nodiscard]] auto ProductBy(F&& key) const
+  [[nodiscard]] auto Product(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return FoldBy(
         std::forward<F>(key), [](auto& acc, auto& v) { acc = acc * v; });
   }
   template <typename F>
-  [[nodiscard]] auto AndBy(F&& key) const
+  [[nodiscard]] auto And(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return FoldBy(
         std::forward<F>(key), [](auto& acc, auto& v) { acc = acc & v; });
   }
   template <typename F>
-  [[nodiscard]] auto OrBy(F&& key) const
+  [[nodiscard]] auto Or(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return FoldBy(
         std::forward<F>(key), [](auto& acc, auto& v) { acc = acc | v; });
   }
   template <typename F>
-  [[nodiscard]] auto XorBy(F&& key) const
+  [[nodiscard]] auto Xor(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return FoldBy(
         std::forward<F>(key), [](auto& acc, auto& v) { acc = acc ^ v; });
@@ -338,7 +312,7 @@ class DynamicArray {
   // the ordering / reduction `*By` convention above.
 
   template <typename F>
-  [[nodiscard]] auto FindBy(F pred) const -> Queue<T> {
+  [[nodiscard]] auto Find(F pred) const -> Queue<T> {
     std::vector<T> out;
     for (std::size_t i = 0; i < data_.size(); ++i) {
       if (static_cast<bool>(
@@ -350,7 +324,7 @@ class DynamicArray {
   }
 
   template <typename F>
-  [[nodiscard]] auto FindIndexBy(F pred) const -> Queue<PackedArray> {
+  [[nodiscard]] auto FindIndex(F pred) const -> Queue<PackedArray> {
     std::vector<PackedArray> out;
     for (std::size_t i = 0; i < data_.size(); ++i) {
       if (static_cast<bool>(
@@ -362,7 +336,7 @@ class DynamicArray {
   }
 
   template <typename F>
-  [[nodiscard]] auto FindFirstBy(F pred) const -> Queue<T> {
+  [[nodiscard]] auto FindFirst(F pred) const -> Queue<T> {
     std::vector<T> out;
     for (std::size_t i = 0; i < data_.size(); ++i) {
       if (static_cast<bool>(
@@ -375,7 +349,7 @@ class DynamicArray {
   }
 
   template <typename F>
-  [[nodiscard]] auto FindFirstIndexBy(F pred) const -> Queue<PackedArray> {
+  [[nodiscard]] auto FindFirstIndex(F pred) const -> Queue<PackedArray> {
     std::vector<PackedArray> out;
     for (std::size_t i = 0; i < data_.size(); ++i) {
       if (static_cast<bool>(
@@ -388,7 +362,7 @@ class DynamicArray {
   }
 
   template <typename F>
-  [[nodiscard]] auto FindLastBy(F pred) const -> Queue<T> {
+  [[nodiscard]] auto FindLast(F pred) const -> Queue<T> {
     std::vector<T> out;
     for (std::size_t i = data_.size(); i-- > 0;) {
       if (static_cast<bool>(
@@ -401,7 +375,7 @@ class DynamicArray {
   }
 
   template <typename F>
-  [[nodiscard]] auto FindLastIndexBy(F pred) const -> Queue<PackedArray> {
+  [[nodiscard]] auto FindLastIndex(F pred) const -> Queue<PackedArray> {
     std::vector<PackedArray> out;
     for (std::size_t i = data_.size(); i-- > 0;) {
       if (static_cast<bool>(
@@ -413,42 +387,23 @@ class DynamicArray {
     return {PackedArray::Int(0), out};
   }
 
-  [[nodiscard]] auto Min() const -> Queue<T> {
-    return ExtremumElement(
-        [](const T& a, const T& b) { return detail::LocatorKeyLess(a, b); });
-  }
-  [[nodiscard]] auto Max() const -> Queue<T> {
-    return ExtremumElement(
-        [](const T& a, const T& b) { return detail::LocatorKeyLess(b, a); });
-  }
   template <typename F>
-  [[nodiscard]] auto MinBy(F&& key) const -> Queue<T> {
+  [[nodiscard]] auto Min(F&& key) const -> Queue<T> {
     return ExtremumByKey(
         std::forward<F>(key), [](const auto& a, const auto& b) {
           return detail::LocatorKeyLess(a, b);
         });
   }
   template <typename F>
-  [[nodiscard]] auto MaxBy(F&& key) const -> Queue<T> {
+  [[nodiscard]] auto Max(F&& key) const -> Queue<T> {
     return ExtremumByKey(
         std::forward<F>(key), [](const auto& a, const auto& b) {
           return detail::LocatorKeyLess(b, a);
         });
   }
 
-  [[nodiscard]] auto Unique() const -> Queue<T> {
-    std::vector<T> out;
-    std::vector<T> seen;
-    for (const auto& elem : data_) {
-      if (!SeenContains(seen, elem)) {
-        seen.push_back(elem);
-        out.push_back(elem);
-      }
-    }
-    return Queue<T>(oob_slot_, out);
-  }
   template <typename F>
-  [[nodiscard]] auto UniqueBy(F key) const -> Queue<T> {
+  [[nodiscard]] auto Unique(F key) const -> Queue<T> {
     using KeyT = std::invoke_result_t<F&, const T&, const PackedArray&>;
     std::vector<T> out;
     std::vector<KeyT> seen;
@@ -462,19 +417,8 @@ class DynamicArray {
     return Queue<T>(oob_slot_, out);
   }
 
-  [[nodiscard]] auto UniqueIndex() const -> Queue<PackedArray> {
-    std::vector<PackedArray> out;
-    std::vector<T> seen;
-    for (std::size_t i = 0; i < data_.size(); ++i) {
-      if (!SeenContains(seen, data_[i])) {
-        seen.push_back(data_[i]);
-        out.push_back(PackedArray::Int(static_cast<int>(i)));
-      }
-    }
-    return {PackedArray::Int(0), out};
-  }
   template <typename F>
-  [[nodiscard]] auto UniqueIndexBy(F key) const -> Queue<PackedArray> {
+  [[nodiscard]] auto UniqueIndex(F key) const -> Queue<PackedArray> {
     using KeyT = std::invoke_result_t<F&, const T&, const PackedArray&>;
     std::vector<PackedArray> out;
     std::vector<KeyT> seen;
@@ -491,25 +435,8 @@ class DynamicArray {
  private:
   // Returns a one-element queue holding the element ranked first by `prefer`
   // (`prefer(candidate, current)` true means the candidate replaces the
-  // current pick), or an empty queue when the receiver is empty. Min and Max
-  // differ only in the direction of `prefer`.
-  template <typename Prefer>
-  [[nodiscard]] auto ExtremumElement(Prefer prefer) const -> Queue<T> {
-    std::vector<T> out;
-    if (!data_.empty()) {
-      std::size_t pick = 0;
-      for (std::size_t i = 1; i < data_.size(); ++i) {
-        if (prefer(data_[i], data_[pick])) {
-          pick = i;
-        }
-      }
-      out.push_back(data_[pick]);
-    }
-    return Queue<T>(oob_slot_, out);
-  }
-
-  // Keyed sibling of ExtremumElement: ranks by the closure's key but returns
-  // the element itself (LRM 7.12.1 `min` / `max with`).
+  // LRM 7.12.1 `min` / `max`: ranks elements by the closure's key, returns
+  // the picked element. Empty receiver yields an empty queue.
   template <typename F, typename Prefer>
   [[nodiscard]] auto ExtremumByKey(F key, Prefer prefer) const -> Queue<T> {
     std::vector<T> out;
@@ -537,22 +464,6 @@ class DynamicArray {
       }
     }
     return false;
-  }
-
-  template <typename Compare>
-  auto SelectionSortBy(Compare cmp) -> void {
-    using std::swap;
-    for (std::size_t i = 0; i + 1 < data_.size(); ++i) {
-      std::size_t pick = i;
-      for (std::size_t j = i + 1; j < data_.size(); ++j) {
-        if (static_cast<bool>(cmp(data_[j], data_[pick]))) {
-          pick = j;
-        }
-      }
-      if (pick != i) {
-        swap(data_[i], data_[pick]);
-      }
-    }
   }
 
   // The keyed sort path is `selection sort over (key, index)`: a per-element
@@ -583,21 +494,7 @@ class DynamicArray {
     }
   }
 
-  template <typename F>
-  [[nodiscard]] auto Fold(F op) const -> T {
-    if (data_.empty()) {
-      T zero = oob_slot_;
-      zero.ResetToDefault();
-      return zero;
-    }
-    T result = data_[0];
-    for (std::size_t i = 1; i < data_.size(); ++i) {
-      result = op(result, data_[i]);
-    }
-    return result;
-  }
-
-  // The empty-array case mirrors `Fold`: synthesize an element-shape zero
+  // The empty-array case synthesises an element-shape zero
   // via the OOB shield slot and feed it through the closure once so the
   // result carries whatever shape the closure produces, then zero it out.
   template <typename F, typename Combine>

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -186,8 +186,12 @@ class PackedArray {
   // a freshly-defaulted element would read as.
   auto ResetToDefault() -> void;
 
-  // LRM 11.4.5 `===` predicate form (host bool). Operator form: `CaseEqual`.
-  [[nodiscard]] auto IsCaseEqual(const PackedArray& other) const -> bool;
+  // LRM 9.4.2 update event predicate (engine change-detection hook): are the
+  // two values bit-identical, considering both the value plane and the
+  // unknown plane. Distinct from the SV `===` operator (`CaseEqual`) only in
+  // role -- the algorithm is the same, but this is the host-bool form the
+  // runtime uses, named after what it answers rather than after the operator.
+  [[nodiscard]] auto IsBitIdentical(const PackedArray& other) const -> bool;
 
   // LRM 9.4.2 LSB: edge transitions are detected only on bit 0. Returns the
   // bit as a 4-state code so the caller can apply Table 9-2 (0/x/z to 1

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <utility>
 
+#include "lyra/value/array_case_equal.hpp"
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/value_concept.hpp"
@@ -66,16 +67,49 @@ class Queue {
     return *this;
   }
 
-  // LRM 11.4.5 `===` predicate form (host bool): the Var change-detection
-  // counterpart used when a queue is an observable signal. A size mismatch is
-  // a change; otherwise recurse into each element's own predicate (LRM 9.4.2
-  // update event).
-  [[nodiscard]] auto IsCaseEqual(const Queue& other) const -> bool {
+  // LRM 11.2.2 aggregate equality / 11.4.5: element-wise reduction over
+  // matching positions. A size mismatch yields 0; matching empties yield 1
+  // (LRM is silent on both, matching industry convention). `==` / `!=`
+  // propagate X / Z; `CaseEqual` matches X / Z as values and is deterministic.
+  [[nodiscard]] auto operator==(const Queue& other) const -> PackedArray {
+    if (data_.size() != other.data_.size()) {
+      return PackedArray::FromInt(0, 1, false, false);
+    }
+    if (data_.empty()) {
+      return PackedArray::FromInt(1, 1, false, false);
+    }
+    PackedArray result = data_[0] == other.data_[0];
+    for (std::size_t i = 1; i < data_.size(); ++i) {
+      result = result && (data_[i] == other.data_[i]);
+    }
+    return result;
+  }
+  [[nodiscard]] auto operator!=(const Queue& other) const -> PackedArray {
+    return !(*this == other);
+  }
+
+  [[nodiscard]] auto CaseEqual(const Queue& other) const -> PackedArray {
+    if (data_.size() != other.data_.size()) {
+      return PackedArray::FromInt(0, 1, false, false);
+    }
+    if (data_.empty()) {
+      return PackedArray::FromInt(1, 1, false, false);
+    }
+    PackedArray result = detail::ArrayCaseEqElement(data_[0], other.data_[0]);
+    for (std::size_t i = 1; i < data_.size(); ++i) {
+      result = result && detail::ArrayCaseEqElement(data_[i], other.data_[i]);
+    }
+    return result;
+  }
+
+  // LRM 9.4.2 update event predicate (engine change-detection hook): are the
+  // two queues element-wise bit-identical. A size mismatch is a change.
+  [[nodiscard]] auto IsBitIdentical(const Queue& other) const -> bool {
     if (data_.size() != other.data_.size()) {
       return false;
     }
     for (std::size_t i = 0; i < data_.size(); ++i) {
-      if (!data_[i].IsCaseEqual(other.data_[i])) {
+      if (!data_[i].IsBitIdentical(other.data_[i])) {
         return false;
       }
     }

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -84,30 +84,42 @@ class String {
     return String{std::move(out)};
   }
 
-  [[nodiscard]] auto operator==(const String& o) const -> bool {
-    return impl_ == o.impl_;
+  // LRM 11.4.5 `==` / `!=`: string equality is exact content equality (strings
+  // are 2-state, no x/z to propagate). The result is a 1-bit 2-state
+  // `PackedArray` so callers do not branch on the operand type.
+  [[nodiscard]] auto operator==(const String& o) const -> PackedArray {
+    return PackedArray::FromInt(impl_ == o.impl_ ? 1 : 0, 1, false, false);
   }
-  [[nodiscard]] auto operator!=(const String& o) const -> bool {
-    return impl_ != o.impl_;
+  [[nodiscard]] auto operator!=(const String& o) const -> PackedArray {
+    return PackedArray::FromInt(impl_ != o.impl_ ? 1 : 0, 1, false, false);
   }
 
-  // LRM 11.4.5 `===` predicate form (host bool): a string has no unknown
-  // plane, so case equality is exact content equality. The Var change-detection
-  // counterpart for an observable string signal (LRM 9.4.2 update event).
-  [[nodiscard]] auto IsCaseEqual(const String& o) const -> bool {
+  // LRM 11.4.5 `===`: a string has no unknown plane, so case equality is exact
+  // content equality and matches `==`. Returned as a 1-bit `PackedArray` for
+  // uniform handling at SV expression sites.
+  [[nodiscard]] auto CaseEqual(const String& o) const -> PackedArray {
+    return PackedArray::FromInt(impl_ == o.impl_ ? 1 : 0, 1, false, false);
+  }
+
+  // LRM 9.4.2 update event predicate (engine change-detection hook): host bool
+  // form of bit-pattern identity. Distinct from `CaseEqual` only in role.
+  [[nodiscard]] auto IsBitIdentical(const String& o) const -> bool {
     return impl_ == o.impl_;
   }
-  [[nodiscard]] auto operator<(const String& o) const -> bool {
-    return impl_ < o.impl_;
+
+  // LRM 11.4.4 relational operators on `String` (LRM 6.16). The result is
+  // 2-state.
+  [[nodiscard]] auto operator<(const String& o) const -> PackedArray {
+    return PackedArray::FromInt(impl_ < o.impl_ ? 1 : 0, 1, false, false);
   }
-  [[nodiscard]] auto operator<=(const String& o) const -> bool {
-    return impl_ <= o.impl_;
+  [[nodiscard]] auto operator<=(const String& o) const -> PackedArray {
+    return PackedArray::FromInt(impl_ <= o.impl_ ? 1 : 0, 1, false, false);
   }
-  [[nodiscard]] auto operator>(const String& o) const -> bool {
-    return impl_ > o.impl_;
+  [[nodiscard]] auto operator>(const String& o) const -> PackedArray {
+    return PackedArray::FromInt(impl_ > o.impl_ ? 1 : 0, 1, false, false);
   }
-  [[nodiscard]] auto operator>=(const String& o) const -> bool {
-    return impl_ >= o.impl_;
+  [[nodiscard]] auto operator>=(const String& o) const -> PackedArray {
+    return PackedArray::FromInt(impl_ >= o.impl_ ? 1 : 0, 1, false, false);
   }
 
   [[nodiscard]] auto operator+(const String& o) const -> String {

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -173,17 +173,17 @@ class UnpackedArray {
     return result;
   }
 
-  // LRM 11.4.5 `===` predicate form (host bool): the Var change-detection
-  // counterpart of `CaseEqual`, recursing into each element's own predicate
-  // (LRM 9.4.2 update event). A size mismatch is a change -- this is how the
-  // empty default of a fresh `Var<UnpackedArray>` is detected as different from
-  // the first sized write, so the declared-shape initializer commits.
-  [[nodiscard]] auto IsCaseEqual(const UnpackedArray& other) const -> bool {
+  // LRM 9.4.2 update event predicate (engine change-detection hook): are the
+  // two arrays element-wise bit-identical. A size mismatch is a change -- this
+  // is how the empty default of a fresh `Var<UnpackedArray>` is detected as
+  // different from the first sized write, so the declared-shape initializer
+  // commits.
+  [[nodiscard]] auto IsBitIdentical(const UnpackedArray& other) const -> bool {
     if (data_.size() != other.data_.size()) {
       return false;
     }
     for (std::size_t i = 0; i < data_.size(); ++i) {
-      if (!data_[i].IsCaseEqual(other.data_[i])) {
+      if (!data_[i].IsBitIdentical(other.data_[i])) {
         return false;
       }
     }

--- a/include/lyra/value/value_concept.hpp
+++ b/include/lyra/value/value_concept.hpp
@@ -4,6 +4,8 @@
 
 namespace lyra::value {
 
+class PackedArray;
+
 // The contract every Lyra runtime value type satisfies so it can live in the
 // STL containers the runtime stores it in (`std::vector` / `std::deque` /
 // `std::map`) and survive their relocation (insert / erase / grow). `std::
@@ -20,5 +22,51 @@ namespace lyra::value {
 // concept only guarantees the operations exist and relocation is safe.
 template <typename T>
 concept LyraValue = std::copyable<T>;
+
+// The SV data type contract every value type realises (LRM Table 11-1 "Any"
+// row). A type that satisfies this concept provides the universal equality
+// operators plus the engine's bit-pattern change-detection predicate. This is
+// the concept `lyra::runtime::Var<T>` requires, so wrapping a structural-var
+// in observable storage gates on it. See
+// `docs/decisions/value-type-concepts.md`.
+template <typename T>
+concept LyraValueType = LyraValue<T> && requires(const T& a, const T& b) {
+  // LRM 11.4.5 `==` / `!=` (Any data type). Uniform return type: every value
+  // type yields a 1-bit `PackedArray`; 2-state types yield a 2-state packed
+  // result. The uniform type lets lowering and emit treat every equality call
+  // identically.
+  { a == b } -> std::same_as<PackedArray>;
+  { a != b } -> std::same_as<PackedArray>;
+  // LRM 9.4.2 update event predicate: did the cell's bit-pattern change. The
+  // engine's change-detection hook -- distinct from the LRM `===` operator
+  // (`CaseEqualComparable`) even when their internal algorithm coincides.
+  { a.IsBitIdentical(b) } -> std::same_as<bool>;
+};
+
+// LRM 11.4.5 `===` / `!==` (Any data type except `real` and `shortreal`). A
+// value type opts in when its SV counterpart admits case equality; `real` /
+// `shortreal` does not.
+template <typename T>
+concept CaseEqualComparable =
+    LyraValueType<T> && requires(const T& a, const T& b) {
+      { a.CaseEqual(b) } -> std::same_as<PackedArray>;
+    };
+
+// LRM 11.4.5 `==?` / `!=?` wildcard equality (Integral only).
+template <typename T>
+concept WildcardComparable =
+    LyraValueType<T> && requires(const T& a, const T& b) {
+      { a.WildcardEquals(b) } -> std::same_as<PackedArray>;
+    };
+
+// LRM 11.4.4 relational `<` / `<=` / `>` / `>=` (Integral, real / shortreal,
+// `String`).
+template <typename T>
+concept Ordered = LyraValueType<T> && requires(const T& a, const T& b) {
+  { a < b } -> std::same_as<PackedArray>;
+  { a <= b } -> std::same_as<PackedArray>;
+  { a > b } -> std::same_as<PackedArray>;
+  { a >= b } -> std::same_as<PackedArray>;
+};
 
 }  // namespace lyra::value

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -52,10 +52,6 @@ auto RenderField(
     return Indent(indent) + *type_or + " " + var.name + "{this, \"" +
            er->ancestor + "\", " + tail + ", \"" + er->signal + "\"};\n";
   }
-  if (IsObservableScalarType(unit.GetType(var.type))) {
-    return Indent(indent) + "lyra::runtime::Var<" + *type_or + "> " + var.name +
-           "{};\n";
-  }
   return Indent(indent) + *type_or + " " + var.name + "{};\n";
 }
 

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -230,6 +230,17 @@ auto RenderStructuralVarName(
 
 namespace {
 
+// True iff the type exposes the observable cell surface (`Set` / `Get` /
+// `Mutate`) to the backend -- an explicit `mir::ObservableType` wrapper or an
+// `mir::ExternalRefType` (intrinsic upward-reference cell). Transitional
+// residue: every callsite uses the result to inject a `.Get()` / `.Mutate()`
+// at render time, which the Phase D follow-up retires by lifting those calls
+// into MIR.
+[[nodiscard]] auto IsObservableCell(const mir::Type& ty) -> bool {
+  return std::holds_alternative<mir::ObservableType>(ty.data) ||
+         std::holds_alternative<mir::ExternalRefType>(ty.data);
+}
+
 // Builds the C++ literal that materializes a 1-bit PackedArray of the SV-typed
 // shape carried by `result_ty`. Used to wrap the C++ `bool` result of a
 // real-operand relational / equality / logical operator into the 1-bit
@@ -878,6 +889,48 @@ auto RenderEnumMethodCall(
 // in a PackedArray at the call site and project to std::int32_t / std::int64_t
 // via ToInt64. Integral return values are wrapped back into the appropriate
 // PackedArray shape.
+// LRM 6.16: `Putc` and the integer-to-string family (`Itoa`, `Hextoa`,
+// `Octtoa`, `Bintoa`, `Realtoa`) mutate the receiver string in place.
+auto StringMethodMutatesReceiver(mir::StringMethodKind k) -> bool {
+  return k == mir::StringMethodKind::kPutc ||
+         k == mir::StringMethodKind::kItoa ||
+         k == mir::StringMethodKind::kHextoa ||
+         k == mir::StringMethodKind::kOcttoa ||
+         k == mir::StringMethodKind::kBintoa ||
+         k == mir::StringMethodKind::kRealtoa;
+}
+
+auto IsLhsBarePrimary(const mir::Expr& expr) -> bool;
+
+// Render the receiver of an instance-method call. When the method mutates the
+// receiver in place and the receiver is an observable cell, the call must
+// route through `Var<T>::Mutate(svc)` so the destructor commits exactly once
+// and subscribers fire; the snapshot is reached through `operator->`. Returns
+// the receiver text and a flag selecting the C++ member-access syntax (`->`
+// vs `.`).
+struct MethodReceiverText {
+  std::string text;
+  std::string_view sep;
+};
+auto RenderMethodReceiver(
+    const RenderContext& ctx, const mir::Expr& receiver_expr, bool mutates)
+    -> diag::Result<MethodReceiverText> {
+  if (mutates && LhsRootIsObservableScalar(ctx, receiver_expr)) {
+    auto lhs_or =
+        RenderLhsExpr(ctx, receiver_expr, ".Mutate(self->Services())");
+    if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+    // The Mutate adapter yields a `ScopedMutation` whose members are reached
+    // via `operator->`. Selector chains past it (`.ElementRef(...)`,
+    // `.ElementAt(...)`) decay back to the wrapped value's reference type, so
+    // the trailing method call dots through C++ as usual.
+    const std::string_view sep = IsLhsBarePrimary(receiver_expr) ? "->" : ".";
+    return MethodReceiverText{.text = std::move(*lhs_or), .sep = sep};
+  }
+  auto receiver_or = RenderExpr(ctx, receiver_expr);
+  if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
+  return MethodReceiverText{.text = std::move(*receiver_or), .sep = "."};
+}
+
 auto RenderStringMethodCall(
     const RenderContext& ctx, const mir::CallExpr& call,
     const mir::StringMethodInfo& m) -> diag::Result<std::string> {
@@ -886,10 +939,10 @@ auto RenderStringMethodCall(
         "RenderStringMethodCall: instance method expects a receiver "
         "argument");
   }
-  auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
-  if (!receiver_or) {
-    return std::unexpected(std::move(receiver_or.error()));
-  }
+  auto recv_or = RenderMethodReceiver(
+      ctx, ctx.Expr(call.arguments[0]), StringMethodMutatesReceiver(m.kind));
+  if (!recv_or) return std::unexpected(std::move(recv_or.error()));
+  const std::string& receiver_text = recv_or->text;
   std::string args_text;
   for (std::size_t i = 1; i < call.arguments.size(); ++i) {
     auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
@@ -905,7 +958,8 @@ auto RenderStringMethodCall(
     args_text += rendered;
   }
   const std::string raw_call = std::format(
-      "({}).{}({})", *receiver_or, StringMethodMemberName(m.kind), args_text);
+      "({}){}{}({})", receiver_text, recv_or->sep,
+      StringMethodMemberName(m.kind), args_text);
   switch (m.kind) {
     case mir::StringMethodKind::kLen:
     case mir::StringMethodKind::kCompare:
@@ -929,8 +983,10 @@ auto RenderStringMethodCall(
   }
 }
 
-// LRM 15.5 named-event methods. Trigger and Triggered reach into
-// RuntimeServices, hence the services argument; Await takes none.
+// LRM 15.5: `Trigger` / `Triggered` reach into RuntimeServices through an
+// explicit services argument supplied by HIR-to-MIR. The render walks
+// arguments uniformly with no per-kind special-case; statement-level callers
+// wrap the result in `co_await` for `Await`.
 auto RenderEventMethodCall(
     const RenderContext& ctx, const mir::CallExpr& call,
     const mir::EventMethodInfo& m) -> diag::Result<std::string> {
@@ -942,12 +998,15 @@ auto RenderEventMethodCall(
   if (!receiver_or) {
     return std::unexpected(std::move(receiver_or.error()));
   }
-  const std::string args = (m.kind == mir::EventMethodKind::kTrigger ||
-                            m.kind == mir::EventMethodKind::kTriggered)
-                               ? "self->Services()"
-                               : std::string{};
+  std::string args_text;
+  for (std::size_t i = 1; i < call.arguments.size(); ++i) {
+    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+    if (i > 1) args_text += ", ";
+    args_text += *arg_or;
+  }
   return std::format(
-      "({}).{}({})", *receiver_or, EventMethodMemberName(m.kind), args);
+      "({}).{}({})", *receiver_or, EventMethodMemberName(m.kind), args_text);
 }
 
 // LRM 7.5.2 / 7.5.3 / 7.12.2 / 7.12.3: dispatch on the receiver
@@ -956,6 +1015,14 @@ auto RenderEventMethodCall(
 // `PackedArray::Int` to land in SV `int` shape (mirrors EnumMethod::kNum).
 // All other methods either return void (in-place mutators) or already return
 // the receiver's element type (reductions); no wrap.
+// LRM 7.5.3 / 7.12.1: array methods that mutate the receiver in place. The
+// rest of the family is read-only (queries, reductions, locators).
+auto ArrayMethodMutatesReceiver(mir::ArrayMethodKind k) -> bool {
+  return k == mir::ArrayMethodKind::kDelete ||
+         k == mir::ArrayMethodKind::kReverse ||
+         k == mir::ArrayMethodKind::kSort || k == mir::ArrayMethodKind::kRsort;
+}
+
 auto RenderArrayMethodCall(
     const RenderContext& ctx, const mir::CallExpr& call,
     const mir::ArrayMethodInfo& m) -> diag::Result<std::string> {
@@ -963,25 +1030,19 @@ auto RenderArrayMethodCall(
     throw InternalError(
         "RenderArrayMethodCall: array method expects a receiver argument");
   }
-  auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
-  if (!receiver_or) {
-    return std::unexpected(std::move(receiver_or.error()));
+  auto recv_or = RenderMethodReceiver(
+      ctx, ctx.Expr(call.arguments[0]), ArrayMethodMutatesReceiver(m.kind));
+  if (!recv_or) return std::unexpected(std::move(recv_or.error()));
+  std::string args_text;
+  for (std::size_t i = 1; i < call.arguments.size(); ++i) {
+    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+    if (i > 1) args_text += ", ";
+    args_text += *arg_or;
   }
-  // LRM 7.12.2 / 7.12.3 with-clause: HIR -> MIR appends the closure as the
-  // second positional argument. The runtime exposes a parallel `*By`
-  // overload that takes the closure; both members share the no-with
-  // base name in `ArrayMethodMemberName`.
-  if (call.arguments.size() == 2) {
-    auto closure_or = RenderExpr(ctx, ctx.Expr(call.arguments[1]));
-    if (!closure_or) {
-      return std::unexpected(std::move(closure_or.error()));
-    }
-    return std::format(
-        "({}).{}By({})", *receiver_or, ArrayMethodMemberName(m.kind),
-        *closure_or);
-  }
-  const std::string raw_call =
-      std::format("({}).{}()", *receiver_or, ArrayMethodMemberName(m.kind));
+  const std::string raw_call = std::format(
+      "({}){}{}({})", recv_or->text, recv_or->sep,
+      ArrayMethodMemberName(m.kind), args_text);
   if (m.kind == mir::ArrayMethodKind::kSize) {
     return std::format("lyra::value::PackedArray::Int({})", raw_call);
   }
@@ -1008,6 +1069,11 @@ auto QueueMethodMemberName(mir::QueueMethodKind k) -> std::string_view {
   throw InternalError("QueueMethodMemberName: unknown kind");
 }
 
+// LRM 7.10.2: every queue method except `Size` mutates the receiver.
+auto QueueMethodMutatesReceiver(mir::QueueMethodKind k) -> bool {
+  return k != mir::QueueMethodKind::kSize;
+}
+
 // LRM 7.10.2 queue-native methods. The receiver is arguments[0] and any SV
 // method parameters follow as real C++ arguments, so the overload set on
 // `Queue<T>` resolves arity (`Delete()` vs `Delete(index)`) directly.
@@ -1018,10 +1084,9 @@ auto RenderQueueMethodCall(
     throw InternalError(
         "RenderQueueMethodCall: queue method expects a receiver argument");
   }
-  auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
-  if (!receiver_or) {
-    return std::unexpected(std::move(receiver_or.error()));
-  }
+  auto recv_or = RenderMethodReceiver(
+      ctx, ctx.Expr(call.arguments[0]), QueueMethodMutatesReceiver(m.kind));
+  if (!recv_or) return std::unexpected(std::move(recv_or.error()));
   std::string args;
   for (std::size_t i = 1; i < call.arguments.size(); ++i) {
     auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
@@ -1034,7 +1099,8 @@ auto RenderQueueMethodCall(
     args += *arg_or;
   }
   const std::string member_call = std::format(
-      "({}).{}({})", *receiver_or, QueueMethodMemberName(m.kind), args);
+      "({}){}{}({})", recv_or->text, recv_or->sep,
+      QueueMethodMemberName(m.kind), args);
   // LRM 7.10.2.1: size() returns an int; wrap the C++ std::size_t in the
   // runtime integral so it composes with the rest of the value model.
   if (m.kind == mir::QueueMethodKind::kSize) {
@@ -1089,8 +1155,10 @@ auto AssociativeTraversalFunctionName(mir::AssociativeMethodKind k)
 // update event must fire (LRM 4.3), so it lowers to a runtime call carrying
 // the index lvalue as a `Ref<K>` -- the same by-reference shape a user `ref`
 // argument uses -- and `Services()` as the leading argument. The receiver is
-// rendered as an lvalue so the call reads the array in place: a nested receiver
-// such as `mm[i]` must reach the stored sub-map, not a detached clone.
+// read-only (traversal methods are `const`): a plain read renders it through
+// `Var<T>::Get` for observable members and through `Read(...)` for nested
+// receivers such as `mm[i]`, so the call lands on the stored sub-map without a
+// detached clone.
 auto RenderAssociativeTraversalCall(
     const RenderContext& ctx, const mir::CallExpr& call,
     std::string_view function_name) -> diag::Result<std::string> {
@@ -1099,8 +1167,7 @@ auto RenderAssociativeTraversalCall(
         "RenderAssociativeTraversalCall: traversal method expects a receiver "
         "and an index argument");
   }
-  auto receiver_or =
-      RenderLhsExpr(ctx, ctx.Expr(call.arguments[0]), std::string_view{});
+  auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
   if (!receiver_or) {
     return std::unexpected(std::move(receiver_or.error()));
   }
@@ -1133,14 +1200,13 @@ auto RenderAssociativeMethodCall(
   if (auto traversal = AssociativeTraversalFunctionName(m.kind)) {
     return RenderAssociativeTraversalCall(ctx, call, *traversal);
   }
-  // The receiver is rendered as an lvalue: every method reads (and `delete`
-  // mutates) the array in place, so a nested receiver such as `mm[i]` must
-  // reach the stored sub-map, not a detached clone.
-  auto receiver_or =
-      RenderLhsExpr(ctx, ctx.Expr(call.arguments[0]), std::string_view{});
-  if (!receiver_or) {
-    return std::unexpected(std::move(receiver_or.error()));
-  }
+  // LRM 7.9.2: only `delete` mutates the associative array; the rest are
+  // read-only queries (traversal methods are routed above through a runtime
+  // shim).
+  const bool mutates = m.kind == mir::AssociativeMethodKind::kDelete;
+  auto recv_or =
+      RenderMethodReceiver(ctx, ctx.Expr(call.arguments[0]), mutates);
+  if (!recv_or) return std::unexpected(std::move(recv_or.error()));
   std::string args;
   for (std::size_t i = 1; i < call.arguments.size(); ++i) {
     auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
@@ -1153,7 +1219,8 @@ auto RenderAssociativeMethodCall(
     args += *arg_or;
   }
   const std::string member_call = std::format(
-      "({}).{}({})", *receiver_or, AssociativeMethodMemberName(m.kind), args);
+      "({}){}{}({})", recv_or->text, recv_or->sep,
+      AssociativeMethodMemberName(m.kind), args);
   // LRM 7.9.1 / 7.9.3: num / size / exists yield an int; wrap the C++
   // std::size_t / bool in the runtime integral. delete returns void.
   if (m.kind != mir::AssociativeMethodKind::kDelete) {
@@ -1312,8 +1379,18 @@ auto RenderCallExpr(
                 // its lvalue and wrap it in a `Ref<T>`. Constructor overload
                 // picks the observable (`Var<T>`), plain (`T`), or
                 // unpacked-element backing; a ref formal passed on forwards via
-                // the copy ctor (LRM 13.5.2).
-                auto lhs_or = RenderLhsExpr(ctx, actual, std::string_view{});
+                // the copy ctor (LRM 13.5.2). When the actual is rooted in an
+                // observable cell and points at an element (not the whole
+                // cell), route through `Var<T>::Mutate(svc)` so the
+                // ScopedMutation snapshot lives for the call's full expression
+                // and commits via `Var::Set` on return.
+                const bool needs_mutate =
+                    LhsRootIsObservableScalar(ctx, actual) &&
+                    !IsLhsBarePrimary(actual);
+                auto lhs_or = RenderLhsExpr(
+                    ctx, actual,
+                    needs_mutate ? std::string_view{".Mutate(self->Services())"}
+                                 : std::string_view{});
                 if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
                 auto type_or = RenderTypeAsCpp(
                     ctx.Unit(), ctx.StructuralScope(), decl.params[i].type);
@@ -1566,24 +1643,6 @@ auto LhsRootPrimary(const RenderContext& ctx, const mir::Expr& expr)
     }
     return *current;
   }
-}
-
-// Whether the LHS root is an observable scalar -- a structural var, or a
-// dereferenced borrowed-pointer slot whose pointee is an observable scalar
-// type. A write to such a root routes through `Var::Set` / `Var::Mutate` so
-// subscribers fire.
-auto LhsRootIsObservableScalar(const RenderContext& ctx, const mir::Expr& expr)
-    -> bool {
-  const mir::Expr& root = LhsRootPrimary(ctx, expr);
-  if (const auto* m = std::get_if<mir::MemberAccessExpr>(&root.data)) {
-    const auto& scope = ctx.StructuralScopeAtHops(m->member.hops);
-    return IsObservableScalarType(
-        ctx.Unit().GetType(scope.GetStructuralVar(m->member.var).type));
-  }
-  if (std::holds_alternative<mir::DerefExpr>(root.data)) {
-    return IsObservableScalarType(ctx.Unit().GetType(root.type));
-  }
-  return false;
 }
 
 auto IsLhsBarePrimary(const mir::Expr& expr) -> bool {
@@ -1997,33 +2056,64 @@ auto RenderReplicationExpr(
       "RenderReplicationExpr: result type must be PackedArrayType or string");
 }
 
-auto ProducesPackedArrayRef(const mir::Expr& expr) -> bool {
-  return std::holds_alternative<mir::ElementSelectExpr>(expr.data) ||
-         std::holds_alternative<mir::RangeSelectExpr>(expr.data);
+auto ProducesPackedArrayRef(const RenderContext& ctx, const mir::Expr& expr)
+    -> bool {
+  if (!std::holds_alternative<mir::ElementSelectExpr>(expr.data) &&
+      !std::holds_alternative<mir::RangeSelectExpr>(expr.data)) {
+    return false;
+  }
+  const auto& result_ty = ctx.Unit().GetType(expr.type);
+  return std::holds_alternative<mir::PackedArrayType>(result_ty.data);
 }
 
 }  // namespace
+
+// Defined at file scope (matching the header's declaration with external
+// linkage) so callsites in other translation units -- e.g.
+// `RenderRuntimeCallExpr` for `LyraFRead` in `render_print.cpp` -- can route
+// observable destinations through `Var<T>::Mutate(svc)`. `LhsRootPrimary` is
+// visible at file scope via the anonymous-namespace's implicit using.
+auto LhsRootIsObservableScalar(const RenderContext& ctx, const mir::Expr& expr)
+    -> bool {
+  const mir::Expr& root = LhsRootPrimary(ctx, expr);
+  if (const auto* m = std::get_if<mir::MemberAccessExpr>(&root.data)) {
+    const auto& scope = ctx.StructuralScopeAtHops(m->member.hops);
+    return IsObservableCell(
+        ctx.Unit().GetType(scope.GetStructuralVar(m->member.var).type));
+  }
+  if (const auto* d = std::get_if<mir::DerefExpr>(&root.data)) {
+    const mir::Expr& ptr_expr = ctx.Expr(d->pointer);
+    const auto& ptr_data = ctx.Unit().GetType(ptr_expr.type).data;
+    if (const auto* ptr_t = std::get_if<mir::PointerType>(&ptr_data)) {
+      return IsObservableCell(ctx.Unit().GetType(ptr_t->pointee));
+    }
+  }
+  return false;
+}
 
 auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
     -> diag::Result<std::string> {
   auto rendered_or = RenderExprNatural(ctx, expr);
   if (!rendered_or) return rendered_or;
-  if (ProducesPackedArrayRef(expr)) {
+  if (ProducesPackedArrayRef(ctx, expr)) {
     return "(" + *std::move(rendered_or) + ").Clone()";
   }
   return rendered_or;
 }
 
 // Read-side render of a borrowed-pointer dereference: the cell is reached with
-// `(*ptr)` and observed via `.Get()` for an integral packed pointee, mirroring
-// the structural-var read split.
-auto RenderDerefExpr(
-    const RenderContext& ctx, const mir::Expr& expr, const mir::DerefExpr& d)
+// `(*ptr)` and observed via `.Get()` when the pointer points at an observable
+// cell, mirroring the structural-var read split.
+auto RenderDerefExpr(const RenderContext& ctx, const mir::DerefExpr& d)
     -> diag::Result<std::string> {
-  auto ptr_or = RenderExpr(ctx, ctx.Expr(d.pointer));
+  const mir::Expr& ptr_expr = ctx.Expr(d.pointer);
+  auto ptr_or = RenderExpr(ctx, ptr_expr);
   if (!ptr_or) return std::unexpected(std::move(ptr_or.error()));
-  if (ctx.Unit().GetType(expr.type).IsIntegralPacked()) {
-    return "(*" + *ptr_or + ").Get()";
+  const auto& ptr_data = ctx.Unit().GetType(ptr_expr.type).data;
+  if (const auto* ptr_t = std::get_if<mir::PointerType>(&ptr_data)) {
+    if (IsObservableCell(ctx.Unit().GetType(ptr_t->pointee))) {
+      return "(*" + *ptr_or + ").Get()";
+    }
   }
   return "(*" + *ptr_or + ")";
 }
@@ -2079,7 +2169,7 @@ auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
             return RenderRuntimeCallExpr(ctx, rc);
           },
           [&](const mir::DerefExpr& d) -> diag::Result<std::string> {
-            return RenderDerefExpr(ctx, expr, d);
+            return RenderDerefExpr(ctx, d);
           },
           [&](const mir::MemberAccessExpr& m) -> diag::Result<std::string> {
             const auto& scope = ctx.StructuralScopeAtHops(m.member.hops);
@@ -2089,7 +2179,11 @@ auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
               return std::unexpected(std::move(receiver_or.error()));
             }
             std::string base = *receiver_or + "->" + var.name;
-            if (ctx.Unit().GetType(expr.type).IsIntegralPacked()) {
+            // A read of an observable-storage member unwraps the value
+            // through `Var<T>::Get`; a plain field is the value itself. The
+            // wrap lives on the member's declared type, not on the
+            // expression's apparent type.
+            if (IsObservableCell(ctx.Unit().GetType(var.type))) {
               base += ".Get()";
             }
             return base;

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -380,11 +380,26 @@ auto RenderRuntimeCallExpr(
           [&](const mir::RuntimeFileReadCall& fr) -> diag::Result<std::string> {
             auto fd_or = RenderExpr(ctx, ctx.Expr(fr.fd));
             if (!fd_or) return std::unexpected(std::move(fd_or.error()));
+            // LyraFRead writes through a non-const reference. When the
+            // destination is an observable cell the call must run against
+            // `Var<T>::Mutate(svc)`'s snapshot so the destructor commits via
+            // `Var::Set` and subscribers fire; the bare cell rejects the
+            // reference because `.Get()` is const.
+            auto render_dest =
+                [&](const mir::Expr& dest_expr) -> diag::Result<std::string> {
+              if (LhsRootIsObservableScalar(ctx, dest_expr)) {
+                auto lhs_or =
+                    RenderLhsExpr(ctx, dest_expr, ".Mutate(self->Services())");
+                if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+                return "*" + *lhs_or;
+              }
+              return RenderExpr(ctx, dest_expr);
+            };
             return std::visit(
                 Overloaded{
                     [&](const mir::RuntimeFileReadCall::PackedTarget& it)
                         -> diag::Result<std::string> {
-                      auto dest_or = RenderExpr(ctx, ctx.Expr(it.dest));
+                      auto dest_or = render_dest(ctx.Expr(it.dest));
                       if (!dest_or) {
                         return std::unexpected(std::move(dest_or.error()));
                       }
@@ -394,7 +409,7 @@ auto RenderRuntimeCallExpr(
                     },
                     [&](const mir::RuntimeFileReadCall::UnpackedTarget& ut)
                         -> diag::Result<std::string> {
-                      auto dest_or = RenderExpr(ctx, ctx.Expr(ut.dest));
+                      auto dest_or = render_dest(ctx.Expr(ut.dest));
                       if (!dest_or) {
                         return std::unexpected(std::move(dest_or.error()));
                       }

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -41,13 +41,6 @@ auto RenderPackedArrayCtorArgs(const mir::PackedArrayType& pa) -> std::string {
   return dim_list + ", " + signed_lit + ", " + four_state_lit;
 }
 
-auto IsObservableScalarType(const mir::Type& ty) -> bool {
-  // An ExternalRef member is a Var-like observable: it forwards reads, writes,
-  // and subscription to its resolved cell, so a write routes through Set.
-  return ty.IsIntegralPacked() ||
-         std::holds_alternative<mir::ExternalRefType>(ty.data);
-}
-
 auto RenderEnumClassName(
     const mir::StructuralScope& owner_scope, mir::TypeId id) -> std::string {
   // First TypeAlias targeting `id` supplies the canonical class name. SV
@@ -137,16 +130,12 @@ auto RenderTypeAsCpp(
                 return "std::unique_ptr<" + *inner_or + ">";
               case mir::PointerOwnership::kShared:
                 return "std::shared_ptr<" + *inner_or + ">";
-              case mir::PointerOwnership::kBorrowed: {
-                // A borrowed pointer refers to the pointee's storage cell: a
-                // `Var<T>` for an observable scalar, the bare type otherwise
-                // (e.g. a `Scope`), so the slot mirrors what it points at.
-                const std::string storage =
-                    IsObservableScalarType(unit.GetType(p.pointee))
-                        ? "lyra::runtime::Var<" + *inner_or + ">"
-                        : *inner_or;
-                return storage + "*";
-              }
+              case mir::PointerOwnership::kBorrowed:
+                // A borrowed pointer refers to the pointee's storage cell --
+                // a `Var<T>` if the pointee is an observable wrapper, the
+                // bare type otherwise -- so the slot mirrors what it points
+                // at by recursing.
+                return *inner_or + "*";
             }
             throw InternalError("RenderTypeAsCpp: unknown PointerOwnership");
           },
@@ -159,6 +148,11 @@ auto RenderTypeAsCpp(
             auto inner_or = RenderTypeAsCpp(unit, owner_scope, e.element);
             if (!inner_or) return std::unexpected(std::move(inner_or.error()));
             return "lyra::runtime::ExternUp<" + *inner_or + ">";
+          },
+          [&](const mir::ObservableType& o) -> diag::Result<std::string> {
+            auto inner_or = RenderTypeAsCpp(unit, owner_scope, o.value);
+            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
+            return "lyra::runtime::Var<" + *inner_or + ">";
           },
           [](const auto&) -> diag::Result<std::string> {
             throw InternalError(

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -25,6 +25,7 @@
 #include "lyra/lowering/hir_to_mir/expression/system/timescale.hpp"
 #include "lyra/lowering/hir_to_mir/procedural_depth.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/services_arg.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/closure.hpp"
@@ -107,6 +108,37 @@ auto LowerEventMethodKind(hir::EventMethodKind k) -> mir::EventMethodKind {
       return mir::EventMethodKind::kTriggered;
   }
   throw InternalError("LowerEventMethodKind: unknown hir::EventMethodKind");
+}
+
+// LRM 7.12.1: reduction / ordering / locator family takes a closure
+// (explicit `with` clause or implicit `with (item)`). `kSize`, `kDelete`,
+// `kReverse` do not.
+auto ArrayMethodTakesClosure(hir::ArrayMethodKind k) -> bool {
+  switch (k) {
+    case hir::ArrayMethodKind::kSize:
+    case hir::ArrayMethodKind::kDelete:
+    case hir::ArrayMethodKind::kReverse:
+      return false;
+    case hir::ArrayMethodKind::kSort:
+    case hir::ArrayMethodKind::kRsort:
+    case hir::ArrayMethodKind::kSum:
+    case hir::ArrayMethodKind::kProduct:
+    case hir::ArrayMethodKind::kAnd:
+    case hir::ArrayMethodKind::kOr:
+    case hir::ArrayMethodKind::kXor:
+    case hir::ArrayMethodKind::kFind:
+    case hir::ArrayMethodKind::kFindIndex:
+    case hir::ArrayMethodKind::kFindFirst:
+    case hir::ArrayMethodKind::kFindFirstIndex:
+    case hir::ArrayMethodKind::kFindLast:
+    case hir::ArrayMethodKind::kFindLastIndex:
+    case hir::ArrayMethodKind::kMin:
+    case hir::ArrayMethodKind::kMax:
+    case hir::ArrayMethodKind::kUnique:
+    case hir::ArrayMethodKind::kUniqueIndex:
+      return true;
+  }
+  throw InternalError("ArrayMethodTakesClosure: unknown hir::ArrayMethodKind");
 }
 
 auto LowerArrayMethodKind(hir::ArrayMethodKind k) -> mir::ArrayMethodKind {
@@ -215,14 +247,18 @@ auto LowerUserCallee(
   return scope.TranslateStructuralSubroutine(u.hops, u.subroutine);
 }
 
-// LRM 7.12.2 / 7.12.3 with-clause closure synthesis. The body is a normal
-// expression lowered through `process.LowerExpr`; only the closure-specific
-// leaf behaviour lives elsewhere -- captures via `CaptureSink`, iterator and
-// index resolution via pre-allocated body procedural-var bindings remapped
-// for the iterator HIR id and tracked on the walk frame for the kIndex call.
+// LRM 7.12.1 / 7.12.2 / 7.12.3 with-clause closure synthesis. The body is a
+// normal expression lowered through `process.LowerExpr`; only the
+// closure-specific leaf behaviour lives elsewhere -- captures via
+// `CaptureSink`, iterator and index resolution via pre-allocated body
+// procedural-var bindings remapped for the iterator HIR id and tracked on
+// the walk frame for the kIndex call. When the source has no `with` clause
+// LRM 7.12.1 defines the default as `with (item)`; this synthesises the
+// identity closure (body returns the iterator binding) so MIR always carries
+// the closure argument and downstream consumers see one uniform shape.
 auto BuildArrayMethodClosure(
     ProcessLowerer& process, WalkFrame frame, hir::TypeId hir_receiver_type,
-    const hir::WithClause& with_clause) -> diag::Result<mir::Expr> {
+    const hir::WithClause* with_clause) -> diag::Result<mir::Expr> {
   const auto& module = process.Module();
   const auto& hir_process = process.HirBody();
   auto& outer_scope = *frame.current_procedural_scope;
@@ -234,8 +270,10 @@ auto BuildArrayMethodClosure(
   }
   const mir::TypeId item_type = module.TranslateType(hir_da->element_type);
   const mir::TypeId index_type = process.Module().Unit().builtins.int32;
-  const auto& iterator_decl =
-      hir_process.procedural_vars.at(with_clause.iterator.value);
+  const std::string iterator_name =
+      with_clause != nullptr
+          ? hir_process.procedural_vars.at(with_clause->iterator.value).name
+          : std::string{"item"};
 
   const mir::TypeId self_ptr_type = module.Unit().builtins.self_pointer;
   mir::ProceduralScope body_scope;
@@ -252,13 +290,15 @@ auto BuildArrayMethodClosure(
                   .var = *frame.self_binding},
           .type = self_ptr_type});
   const mir::ProceduralVarId item_binding = body_scope.AddProceduralVar(
-      mir::ProceduralVarDecl{.name = iterator_decl.name, .type = item_type});
+      mir::ProceduralVarDecl{.name = iterator_name, .type = item_type});
   const mir::ProceduralVarId index_binding = body_scope.AddProceduralVar(
       mir::ProceduralVarDecl{.name = "index", .type = index_type});
-  process.MapProceduralVar(
-      with_clause.iterator,
-      AutomaticVarBinding{
-          .declaration_procedural_depth = body_depth, .var = item_binding});
+  if (with_clause != nullptr) {
+    process.MapProceduralVar(
+        with_clause->iterator,
+        AutomaticVarBinding{
+            .declaration_procedural_depth = body_depth, .var = item_binding});
+  }
 
   CaptureSink sink{body_depth, body_scope, outer_scope};
   // A with-clause body is a synchronous predicate / projection closure -- it
@@ -268,13 +308,21 @@ auto BuildArrayMethodClosure(
                                       .WithSelfBinding(self_binding, body_depth)
                                       .WithCoroutineBody(false);
 
-  auto body_expr_or = process.LowerExpr(
-      hir_process.exprs.at(with_clause.expr.value), closure_frame);
-
-  if (!body_expr_or) return std::unexpected(std::move(body_expr_or.error()));
-
-  const mir::ExprId body_return_value =
-      body_scope.AddExpr(*std::move(body_expr_or));
+  mir::ExprId body_return_value{};
+  if (with_clause != nullptr) {
+    auto body_expr_or = process.LowerExpr(
+        hir_process.exprs.at(with_clause->expr.value), closure_frame);
+    if (!body_expr_or) return std::unexpected(std::move(body_expr_or.error()));
+    body_return_value = body_scope.AddExpr(*std::move(body_expr_or));
+  } else {
+    body_return_value = body_scope.AddExpr(
+        mir::Expr{
+            .data =
+                mir::ProceduralVarRef{
+                    .hops = mir::ProceduralHops{.value = 0},
+                    .var = item_binding},
+            .type = item_type});
+  }
   body_scope.AppendStmt(
       mir::Stmt{
           .label = std::nullopt,
@@ -450,13 +498,34 @@ auto LowerHirCallExprProc(
               }
               args.push_back(proc_scope.AddExpr(*std::move(arg_or)));
             }
-            if (c.with_clause.has_value()) {
+            // LRM 7.12.1: reduction / ordering / locator array methods take a
+            // closure. The user's `with` clause is used if present; otherwise
+            // LRM defines the default as `with (item)`, which HIR-to-MIR
+            // synthesises so MIR always carries the closure argument and
+            // downstream consumers see one uniform shape per kind.
+            if (const auto* ak = std::get_if<hir::ArrayMethodKind>(&b.method);
+                ak != nullptr && ArrayMethodTakesClosure(*ak)) {
               auto closure_or = BuildArrayMethodClosure(
-                  process, frame, hir_receiver_type, *c.with_clause);
+                  process, frame, hir_receiver_type,
+                  c.with_clause.has_value() ? &*c.with_clause : nullptr);
               if (!closure_or) {
                 return std::unexpected(std::move(closure_or.error()));
               }
               args.push_back(proc_scope.AddExpr(*std::move(closure_or)));
+            } else if (c.with_clause.has_value()) {
+              throw InternalError(
+                  "BuiltinMethodRef with-clause on a method kind that does "
+                  "not accept a with-clause (LRM 7.12.1 family only)");
+            }
+            // LRM 15.5: `Trigger` and `Triggered` reach into RuntimeServices
+            // (Trigger schedules the wake; Triggered samples the
+            // slot-persistent triggered state). The engine handle threads as an
+            // explicit argument per
+            // `decisions/runtime-effects-as-generic-calls.md`.
+            if (const auto* ek = std::get_if<hir::EventMethodKind>(&b.method);
+                ek != nullptr && (*ek == hir::EventMethodKind::kTrigger ||
+                                  *ek == hir::EventMethodKind::kTriggered)) {
+              args.push_back(BuildServicesArg(process, frame));
             }
             auto callee = std::visit(
                 Overloaded{

--- a/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
@@ -15,6 +15,7 @@
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/services_arg.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/services_arg.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"

--- a/src/lyra/lowering/hir_to_mir/statement/timing.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/timing.cpp
@@ -19,6 +19,7 @@
 #include "lyra/lowering/hir_to_mir/delay_time_resolver.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
+#include "lyra/lowering/hir_to_mir/services_arg.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
@@ -250,6 +251,10 @@ auto LowerEventTriggerStmt(
       process.LowerExpr(process.HirBody().exprs.at(et.event.value), frame);
   if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
   const mir::ExprId receiver_id = proc_scope.AddExpr(*std::move(receiver_or));
+  // LRM 15.5 `Trigger` reaches into RuntimeServices to schedule the wake; the
+  // engine handle threads as an explicit argument per
+  // `decisions/runtime-effects-as-generic-calls.md`.
+  const mir::ExprId services_id = BuildServicesArg(process, frame);
   mir::Expr call{
       .data =
           mir::CallExpr{
@@ -258,7 +263,7 @@ auto LowerEventTriggerStmt(
                       .method =
                           mir::EventMethodInfo{
                               .kind = mir::EventMethodKind::kTrigger}},
-              .arguments = {receiver_id},
+              .arguments = {receiver_id, services_id},
           },
       .type = process.Module().Unit().builtins.void_type};
   const mir::ExprId call_id = proc_scope.AddExpr(std::move(call));

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -39,6 +39,27 @@ namespace lyra::lowering::hir_to_mir {
 
 namespace {
 
+// Wrap a value type in `ObservableType` iff it is a SystemVerilog value-storage
+// data type (LRM 6.5 / 7.x). Handle / wrapper types (pointer / vector / object
+// / external ref / external unit object), named events (LRM 15 -- carry their
+// own subscribe mechanism), and presently `real` / `shortreal` / `realtime`
+// (deferred until `lyra::value::Real` lands -- see
+// `docs/decisions/value-type-concepts.md`) pass through unwrapped.
+auto MaybeWrapObservable(ModuleLowerer& module, mir::TypeId t) -> mir::TypeId {
+  const auto& data = module.Unit().GetType(t).data;
+  const bool wrap = std::holds_alternative<mir::PackedArrayType>(data) ||
+                    std::holds_alternative<mir::EnumType>(data) ||
+                    std::holds_alternative<mir::StringType>(data) ||
+                    std::holds_alternative<mir::UnpackedArrayType>(data) ||
+                    std::holds_alternative<mir::DynamicArrayType>(data) ||
+                    std::holds_alternative<mir::QueueType>(data) ||
+                    std::holds_alternative<mir::AssociativeArrayType>(data);
+  if (!wrap) {
+    return t;
+  }
+  return module.Unit().AddType(mir::TypeData{mir::ObservableType{.value = t}});
+}
+
 auto ChildScopeNameFor(std::size_t gen_index, std::string_view arm_tag)
     -> std::string {
   return std::format("gen{}_{}", gen_index, arm_tag);
@@ -271,7 +292,12 @@ auto MaterializeCrossUnitRefTargets(
           mir::StructuralVarRef{.hops = {.value = 0}, .var = var}, ext_type);
       slot_vars.emplace_back(std::nullopt);
     } else {
-      const mir::TypeId leaf = module.TranslateType(cu.type);
+      // The pointee matches the producer's storage cell. A producer-side
+      // value-storage signal is wrapped in `ObservableType` at its declaration
+      // (so a write fires subscribers), and the cross-unit pointer must point
+      // at the same wrapped cell -- otherwise the C++ types mismatch.
+      const mir::TypeId leaf =
+          MaybeWrapObservable(module, module.TranslateType(cu.type));
       const mir::TypeId slot_type = module.Unit().AddType(
           mir::PointerType{
               .pointee = leaf, .ownership = mir::PointerOwnership::kBorrowed});
@@ -765,12 +791,17 @@ auto StructuralScopeLowerer::Run(
   for (std::size_t i = 0; i < hir_scope.structural_vars.size(); ++i) {
     const hir::StructuralVarId hir_id{static_cast<std::uint32_t>(i)};
     const auto& d = hir_scope.structural_vars[i];
-    const mir::TypeId mir_type = module.TranslateType(d.type);
+    const mir::TypeId mir_value_type = module.TranslateType(d.type);
+
+    const auto& var_data = module.Unit().GetType(mir_value_type).data;
+    // A module-scope value-storage signal becomes an observable cell so
+    // writes route through `Var<T>::Set` and subscribers fire.
+    const mir::TypeId mir_field_type =
+        MaybeWrapObservable(module, mir_value_type);
     const mir::StructuralVarId mir_id = mir_scope.AddStructuralVar(
-        mir::StructuralVarDecl{.name = d.name, .type = mir_type});
+        mir::StructuralVarDecl{.name = d.name, .type = mir_field_type});
     scope.MapStructuralVar(hir_id, mir_id);
 
-    const auto& var_data = module.Unit().GetType(mir_type).data;
     // Owned children (pointer / vector / object), resolution slots, upward
     // refs, and named events have no "value assignment" -- their declaration
     // shape itself fixes the field at construction. Value-typed signals
@@ -791,15 +822,15 @@ auto StructuralScopeLowerer::Run(
         if (!value_or) return std::unexpected(std::move(value_or.error()));
         value_id = ctor_scope.AddExpr(*std::move(value_or));
       } else {
-        value_id = AddDefaultValueExpr(module, scope_frame, mir_type);
+        value_id = AddDefaultValueExpr(module, scope_frame, mir_value_type);
       }
       const mir::ExprId init_target = ctor_scope.AddExpr(
           mir::MakeMemberAccessExpr(
               self_read(),
               mir::StructuralVarRef{.hops = {.value = 0}, .var = mir_id},
-              mir_type));
+              mir_field_type));
       const mir::ExprId assign_id = ctor_scope.AddExpr(
-          mir::MakeAssignExpr(init_target, value_id, mir_type));
+          mir::MakeAssignExpr(init_target, value_id, mir_value_type));
       ctor_scope.AppendStmt(
           mir::Stmt{
               .label = std::nullopt, .data = mir::ExprStmt{.expr = assign_id}});
@@ -819,7 +850,7 @@ auto StructuralScopeLowerer::Run(
           mir::MakeMemberAccessExpr(
               self_read(),
               mir::StructuralVarRef{.hops = {.value = 0}, .var = mir_id},
-              mir_type));
+              mir_field_type));
       const mir::ExprId call = ctor_scope.AddExpr(
           mir::Expr{
               .data =

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -208,6 +208,9 @@ class MirDumper {
                   "ExternalRef(elem=Type[{}], ancestor={}, tail={}, signal={})",
                   e.element.value, e.ancestor, tail, e.signal);
             },
+            [](const ObservableType& o) -> std::string {
+              return std::format("Observable(value=Type[{}])", o.value.value);
+            },
         },
         t.data);
   }

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -80,6 +80,7 @@ auto Type::Kind() const -> TypeKind {
           [](const PointerType&) { return TypeKind::kPointer; },
           [](const VectorType&) { return TypeKind::kVector; },
           [](const ExternalRefType&) { return TypeKind::kExternalRef; },
+          [](const ObservableType&) { return TypeKind::kObservable; },
       },
       data);
 }

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -271,7 +271,7 @@ auto PackedArray::UnknownWords() const -> std::span<const std::uint64_t> {
   return {};
 }
 
-auto PackedArray::IsCaseEqual(const PackedArray& other) const -> bool {
+auto PackedArray::IsBitIdentical(const PackedArray& other) const -> bool {
   if (bit_width_ != other.bit_width_) return false;
   if (is_four_state_ != other.is_four_state_) return false;
   const auto vw_a = ValueWords();
@@ -282,7 +282,7 @@ auto PackedArray::IsCaseEqual(const PackedArray& other) const -> bool {
 }
 
 auto PackedArray::CaseEqual(const PackedArray& other) const -> PackedArray {
-  return FromInt(IsCaseEqual(other) ? 1 : 0, 1, false, false);
+  return FromInt(IsBitIdentical(other) ? 1 : 0, 1, false, false);
 }
 
 auto PackedArray::Lsb() const -> FourStateBit {


### PR DESCRIPTION
## Summary

- Wrap structural-var storage in `mir::ObservableType` (MIR type system gains the cell shape; HIR-to-MIR injects it at scope-build time, removing the `IsObservableScalarType` predicate).
- Define `LyraValueType` / `CaseEqualComparable` / `WildcardComparable` / `Ordered` concepts mirroring LRM Table 11-1; align `==` / `!=` to return `PackedArray`, add `CaseEqual`, rename `IsCaseEqual` to `IsBitIdentical` across `PackedArray`, `String`, `Queue`, `UnpackedArray`, `DynamicArray`, `AssociativeArray`, and `Real`.
- Synthesize the LRM 7.12.1 default `with (item)` closure at HIR-to-MIR so every dynamic-array reduction / ordering / locator method takes a single closure-shaped argument; drop the `*By` runtime split.
- Lift `Trigger` / `Triggered` services to plain `CallExpr` arguments through the shared `BuildServicesArg` helper, matching the runtime-effects-as-generic-calls pattern.
- Rewrite `hir.md`, `mir.md`, and `lir.md` purpose sections as identity-first (SV-faithful, generic-programming, machine-execution); annotate invariants with consequence labels.

## Test plan

- [x] `bazel test //... --test_output=errors`