### PR TITLE
Add queue operator surface via built-in methods

### DIFF
--- a/docs/decisions/queue-operators.md
+++ b/docs/decisions/queue-operators.md
@@ -1,0 +1,94 @@
+# Queue operator lowering
+
+## Date
+
+2026-06-18
+
+## Status
+
+Accepted
+
+## Context
+
+A queue (LRM 7.10) is a variable-size unpacked array, so beyond its native methods it also supports
+the unpacked-array operator surface: indexing with `$`, the slice `q[a:b]`, unpacked array
+concatenation `{...}` (LRM 10.10), aggregate equality, the `q[$+1]` append, and the bounded form
+`q[$:N]` (LRM 7.10.5). The question this records is how those operators are represented in MIR. MIR
+is a small primitive expression set shaped by the downstream optimizer, not a place to add a node
+per SystemVerilog construct; a queue's bounds are runtime values and its element storage is an
+unpacked container, so the operators cannot reuse the packed-array operator lowering verbatim.
+
+## Decisions
+
+1. **A queue access operator is a built-in method call, not a select node.** `q[i]` and `q[a:b]`
+   have no native C++ expression -- each realizes as `receiver.Method(args)` on the runtime
+   `Queue<T>` (`ElementAt`, `WriteRef`, `Slice`). So they lower to the existing call primitive: a
+   `CallExpr` whose callee is a `QueueMethodKind` (the same first-class home as `size` /
+   `push_back`), with the receiver as `arguments[0]` and the index or bounds as the remaining
+   arguments. The element-access methods carry no SystemVerilog syntax -- they are compiler-internal
+   -- but they sit at the same level as the SV-callable queue methods because both are function
+   calls. The backend render is the one generic built-in-method-call render
+   (`(arg0).Name(arg1, ...)`); no queue-specific access node or render path exists. A dedicated MIR
+   node was rejected: it would duplicate an existing primitive (a select, or a call) and freeze one
+   receiver type's argument shape -- packed part-select's `(offset, compile-time width)` -- into the
+   IR, which is exactly what does not fit a queue's runtime `(lo, hi)` bounds. The LRM 7.10.1
+   clamping and the append-vs-discard rules live in the runtime method, the same way packed
+   bit-extraction lives in `PackedArray::Slice`; each backend realizes the method per receiver type.
+
+2. **Read and write are different methods, chosen at lowering.** A read takes the default-on-miss
+   `ElementAt`; a write (and the `q[$+1]` append) takes the append-aware `WriteRef`. The distinction
+   is resolved where it is known -- the assignment lowering marks its left-hand side as a write
+   target, and the queue element-select lowers to `WriteRef` under that flag and `ElementAt`
+   otherwise. Keeping the choice at lowering leaves the backend render purely mechanical: it emits
+   the method the node names and never re-decides read versus write.
+
+3. **Unpacked concatenation reuses the concatenation value-build primitive.** Packed, string, and
+   queue `{...}` are the same `ConcatExpr` primitive, realized per result type -- a bit join, a
+   string join, or the runtime queue builder. The backend derives element-vs-spread from each
+   operand's type (an unpacked-container operand is spliced, anything else is one element), so the
+   node needs no per-operand tag. A second concatenation node was rejected for the same reason as a
+   dedicated access node: concatenation is one primitive, and the result type already states which
+   realization applies.
+
+4. **A queue's element shape and bound are declared-type properties, preserved across assignment.**
+   `value-assignment-and-moved-from.md` established that a shape-bearing value keeps the
+   destination's declared type across assignment and copies only the value in. A queue's element
+   shape (its out-of-bounds shield slot, see `runtime-shape-and-default-value.md`) and its LRM
+   7.10.5 bound are that kind of property: `q = rhs` keeps `q`'s shape and bound and copies the
+   elements, rather than adopting the source's. Because a declared queue is default-constructed and
+   then initialized by assignment, the value type adopts the source's shape (and bound) on that
+   first store and preserves thereafter -- so assigning the empty `{}` or an unbounded concatenation
+   result keeps the variable's shape, and the concatenation value therefore carries no element
+   default. This is what removed an earlier element-default field that had been compensating for an
+   assignment that wrongly adopted the source's shape.
+
+5. **`$` resolves to `size - 1` at the indexing site.** Slang models `$` as an unbounded literal
+   with no value of its own; it means "the last index" of the queue being indexed. The AST-to-HIR
+   walk threads that queue base through the walk frame, and `$` lowers to `size(base) - 1` against
+   it -- so `$`, `$-1`, and the `q[1:$]` / `q[0:$-1]` pop idioms (LRM 7.10.4) all become ordinary
+   index or bound arguments to the access method calls above.
+
+## Consequences
+
+- Queue access operators are built-in method calls today; the packed part-select, packed struct
+  field access, unpacked slice, and fixed/dynamic element access still use the dedicated select
+  nodes. This cut is the role model for migrating those to the same call form when that work is
+  taken up; until then the two forms coexist deliberately.
+- All three queue slice forms (`q[a:b]`, `q[base+:w]`, `q[base-:w]`) are supported: they reduce to a
+  low / high pair fed to the same `Slice` method call, so the indexed forms cost no extra machinery.
+- An unpacked concatenation whose result is a dynamic or fixed array rather than a queue is rejected
+  with a diagnostic; it extends the same `ConcatExpr` mechanism when a consumer needs it.
+- `$` is supported in procedural contexts, where every documented queue idiom lives. A `$` in a
+  structural context (a continuous assignment) surfaces as unsupported rather than silently
+  mis-lowering.
+
+## Cross-references
+
+- LRM 7.10 (queues), 7.10.1 (operators / invalid index / `q[$+1]`), 7.10.4 (push / pop / insert via
+  assignment and concatenation), 7.10.5 (bounded queues), 10.10 (unpacked array concatenation),
+  11.2.2 / 11.4.5 (aggregate equality).
+- `value-assignment-and-moved-from.md` -- the type-vs-value distinction the queue's shape and bound
+  follow.
+- `runtime-shape-and-default-value.md` -- the element-shape shield slot a queue carries.
+- `array-method-dispatch.md` -- the built-in method-call mechanism these operators reuse rather than
+  adding select nodes beside.

--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -18,22 +18,23 @@ element-access shape is closest to fixed unpacked (already complete in U1..U7), 
 natural reuse for procedural read / write and aggregate operations. Queue and associative array
 follow once dynamic array's storage and runtime conventions are settled and proven against tests.
 
-| Item | Status                                                               |
-| ---- | -------------------------------------------------------------------- |
-| DA1  | Done: construction, element read, blocking element write, multi-dim. |
-| DA2  | Done: NBA, compound element write, whole-array assignment.           |
-| DA3  | Done: positional and replicated assignment patterns (LRM 10.9.1).    |
-| DA4  | Done: aggregate equality, inequality, case-equality.                 |
-| DA5  | Open: constant-width slice (subject to LRM check).                   |
-| DA6a | Done: method dispatch + no-`with` subset.                            |
-| DA6b | Done: `with` clause + iterator on sort / rsort / reduction methods.  |
-| DA6c | Open: queue runtime + locator family (find\*, min, max, unique\*).   |
-| DA7  | Open: invalid-index handling.                                        |
-| Q1.. | Not yet scoped: queue.                                               |
-| A1   | Done: string / integral index, element read / write, query methods.  |
-| A2   | Done: traversal protocol (`first` / `last` / `next` / `prev`).       |
-| A3   | Done: `foreach` over an associative array (any dimensionality).      |
-| A4.. | Open: literals, whole-array assignment, locators.                    |
+| Item | Status                                                                  |
+| ---- | ----------------------------------------------------------------------- |
+| DA1  | Done: construction, element read, blocking element write, multi-dim.    |
+| DA2  | Done: NBA, compound element write, whole-array assignment.              |
+| DA3  | Done: positional and replicated assignment patterns (LRM 10.9.1).       |
+| DA4  | Done: aggregate equality, inequality, case-equality.                    |
+| DA5  | Open: constant-width slice (subject to LRM check).                      |
+| DA6a | Done: method dispatch + no-`with` subset.                               |
+| DA6b | Done: `with` clause + iterator on sort / rsort / reduction methods.     |
+| DA6c | Open: locator family (find\*, min, max, unique\*).                      |
+| DA7  | Open: invalid-index handling.                                           |
+| Q1   | Done: type, element read/write, native methods, default, case-equality. |
+| Q2   | Done: operator surface (`$`, slice, concat, equality, bound, append).   |
+| A1   | Done: string / integral index, element read / write, query methods.     |
+| A2   | Done: traversal protocol (`first` / `last` / `next` / `prev`).          |
+| A3   | Done: `foreach` over an associative array (any dimensionality).         |
+| A4.. | Open: literals, whole-array assignment, locators.                       |
 
 ## Dynamic Array
 
@@ -105,10 +106,10 @@ The numeric IDs are stable references and do not imply execution order beyond DA
       backend renders the closure as a lambda-with-captures and routes the call to the runtime's
       `*By` overloads.
 
-- [ ] DA6c + Q1 -- Queue\<T\> runtime and the locator-family methods that return one (`find` family,
-      `min`, `max`, `unique`, `unique_index`). Opens the queue workstream. `shuffle()` (needs RNG
-      model) and `map()` (SV2023, needs `with` infra + version gate) are standalone follow-ups after
-      DA6c lands.
+- [ ] DA6c -- The locator-family methods that return an index or element queue (`find` family,
+      `min`, `max`, `unique`, `unique_index`). The queue return container now exists (see Queue
+      below). `shuffle()` (needs RNG model) and `map()` (SV2023, needs `with` infra + version gate)
+      are standalone follow-ups after DA6c lands.
 
 - [ ] DA7 -- Invalid-index handling. Read on an out-of-range index returns the element type's LRM
       Table 7-1 default; write on an out-of-range index is a silent no-op; X / Z bits in the index
@@ -116,9 +117,25 @@ The numeric IDs are stable references and do not imply execution order beyond DA
 
 ## Queue
 
-Not yet scoped. Sub-steps Q1.. open when dynamic array's runtime conventions are settled and the
-queue-specific method family (LRM 7.10: `push_back`, `push_front`, `pop_back`, `pop_front`,
-`insert`, `delete(i)`) is ready to be sequenced.
+LRM 7.10: a queue is a variable-size, ordered unpacked array with constant-time access and growth at
+both ends. The index `0` is the first element and `$` the last; a queue may be bounded by an
+optional right bound (`q[$:N]`).
+
+- [x] Q1 -- Type infrastructure plus the element and native-method surface. Declaration `int q[$]`
+      with the empty queue as default (LRM Table 6-7), element read and blocking element write on an
+      ordinal index, the native methods of LRM 7.10.2 (`size`, `insert`, `delete` with and without
+      an index, `pop_front`, `pop_back`, `push_front`, `push_back`), assignment-pattern
+      initialization, whole-queue assignment, `%p` formatting (LRM 21.2.1.6), and the case-equality
+      predicate used when a queue is an observable signal.
+
+- [x] Q2 -- The operator surface that treats a queue as an unpacked array (LRM 7.10.1 / 10.10). `$`
+      as the last-element index and as a slice bound (including `$-1` and friends); the slice in all
+      three forms `q[a:b]` / `q[base+:w]` / `q[base-:w]` with the LRM 7.10.1 clamping and
+      empty-result rules; unpacked array concatenation `{...}` including the empty queue `{}` (LRM
+      10.10), which also expresses the push / pop / insert idioms of LRM 7.10.4; the aggregate
+      equality operators (`==` / `!=` / `===` / `!==`); bounded-queue discard with a warning (LRM
+      7.10.5); and the legal append write `q[$+1] = v` (LRM 7.10.1). One narrow form remains open:
+      an unpacked concatenation whose result is a dynamic or fixed array rather than a queue.
 
 ## Associative Array
 

--- a/include/lyra/hir/method.hpp
+++ b/include/lyra/hir/method.hpp
@@ -80,11 +80,14 @@ enum class ArrayMethodKind : std::uint8_t {
   kUniqueIndex,
 };
 
-// LRM 7.10.2 queue-native methods. These are exclusive to the queue container
-// (no dynamic-array / fixed-unpacked analogue): they mutate the receiver in
-// place, and `pop_front` / `pop_back` also return the removed element. The
-// LRM 7.12 ordering / reduction / locator family that queues share with the
-// other unpacked arrays stays in `ArrayMethodKind`.
+// LRM 7.10.2 queue-native methods plus the compiler-internal access methods a
+// queue's operators lower to. The named methods (`size` .. `push_back`) are the
+// SV-callable family; `kElementAt` / `kWriteRef` / `kSlice` carry no SV syntax
+// but realize `q[i]` (read), `q[i] = v` (write / `q[$+1]` append), and `q[a:b]`
+// as ordinary built-in method calls -- the operators have no native C++
+// expression, so they are function calls like `size` (LRM 7.10.1). The LRM 7.12
+// ordering / reduction / locator family shared with other unpacked arrays stays
+// in `ArrayMethodKind`.
 enum class QueueMethodKind : std::uint8_t {
   kSize,
   kInsert,
@@ -93,6 +96,9 @@ enum class QueueMethodKind : std::uint8_t {
   kPopBack,
   kPushFront,
   kPushBack,
+  kElementAt,
+  kWriteRef,
+  kSlice,
 };
 
 // LRM 7.9 associative-array methods. Exclusive to the associative container:

--- a/include/lyra/lowering/ast_to_hir/expression/selects.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/selects.hpp
@@ -20,6 +20,12 @@ class RangeSelectExpression;
 
 namespace lyra::lowering::ast_to_hir {
 
+// LRM 7.10 `$` (UnboundedLiteral) in a queue index / slice bound. Resolves to
+// the queue's last index via the base bound on the walk frame.
+auto LowerUnboundedLiteralProc(
+    ProcessLowerer& proc, WalkFrame frame, diag::SourceSpan span)
+    -> diag::Result<hir::Expr>;
+
 // Procedural-context handlers.
 auto LowerElementSelectExprProc(
     ProcessLowerer& proc, WalkFrame frame,

--- a/include/lyra/lowering/ast_to_hir/walk_frame.hpp
+++ b/include/lyra/lowering/ast_to_hir/walk_frame.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/loop_label_id.hpp"
 #include "lyra/hir/structural_hops.hpp"
 
@@ -75,6 +76,12 @@ struct WalkFrame {
   std::optional<hir::LoopLabelId> innermost_break_label = std::nullopt;
   bool* innermost_break_used = nullptr;
 
+  // The queue base whose `$` (LRM 7.10 last index) is resolved while lowering
+  // an element-select index or slice bound: `$` lowers to `size(base) - 1`.
+  // Null outside a queue index / bound expression. Re-set per select, so each
+  // `$` in a nested `q[r[$]]` binds to the array its own select indexes.
+  std::optional<hir::ExprId> dollar_base = std::nullopt;
+
   [[nodiscard]] auto Current() const -> ScopeFrameId {
     if (structural_chain.empty()) {
       throw InternalError("WalkFrame::Current: empty structural chain");
@@ -126,6 +133,14 @@ struct WalkFrame {
   [[nodiscard]] auto WithForkBranch() const -> WalkFrame {
     WalkFrame next = *this;
     ++next.fork_branch_depth;
+    return next;
+  }
+
+  // Binds `base` as the queue whose `$` resolves to its last index while the
+  // index / slice-bound subtree is lowered (LRM 7.10).
+  [[nodiscard]] auto WithDollarBase(hir::ExprId base) const -> WalkFrame {
+    WalkFrame next = *this;
+    next.dollar_base = base;
     return next;
   }
 

--- a/include/lyra/lowering/hir_to_mir/walk_frame.hpp
+++ b/include/lyra/lowering/hir_to_mir/walk_frame.hpp
@@ -90,6 +90,13 @@ struct WalkFrame {
   // `kProceduralInduction`. Ignored by `ProcessLowerer::LowerExpr`.
   LoopVarLoweringMode loop_var_mode = LoopVarLoweringMode::kStructuralParam;
 
+  // True while lowering an assignment's left-hand side. A queue element-select
+  // resolves to its write access method (`WriteRef`, append-aware) under this
+  // flag and to its read access method (`ElementAt`) otherwise; the index and
+  // other rvalue subexpressions clear it. Read only by the queue element-select
+  // lowering; no other access form distinguishes read from write at this layer.
+  bool is_lvalue_target = false;
+
   [[nodiscard]] auto WithStructuralScope(mir::StructuralScope* scope) const
       -> WalkFrame {
     WalkFrame next = *this;
@@ -141,6 +148,12 @@ struct WalkFrame {
   [[nodiscard]] auto WithCoroutineBody(bool is_coroutine) const -> WalkFrame {
     WalkFrame next = *this;
     next.is_coroutine_body = is_coroutine;
+    return next;
+  }
+
+  [[nodiscard]] auto WithLvalueTarget(bool is_target) const -> WalkFrame {
+    WalkFrame next = *this;
+    next.is_lvalue_target = is_target;
     return next;
   }
 };

--- a/include/lyra/mir/builtin_method.hpp
+++ b/include/lyra/mir/builtin_method.hpp
@@ -83,9 +83,11 @@ enum class ArrayMethodKind : std::uint8_t {
   kUniqueIndex,
 };
 
-// LRM 7.10.2 queue-native methods. Exclusive to the queue container: they
-// mutate the receiver, and `pop_front` / `pop_back` also return the removed
-// element. The shared LRM 7.12 family stays in `ArrayMethodKind`.
+// LRM 7.10.2 queue-native methods plus the compiler-internal access methods the
+// queue operators lower to. `size` .. `push_back` are SV-callable; `kElementAt`
+// / `kWriteRef` / `kSlice` realize `q[i]` read, `q[i] = v` write (and `q[$+1]`
+// append), and `q[a:b]` as built-in method calls (LRM 7.10.1). The shared LRM
+// 7.12 family stays in `ArrayMethodKind`.
 enum class QueueMethodKind : std::uint8_t {
   kSize,
   kInsert,
@@ -94,6 +96,9 @@ enum class QueueMethodKind : std::uint8_t {
   kPopBack,
   kPushFront,
   kPushBack,
+  kElementAt,
+  kWriteRef,
+  kSlice,
 };
 
 // LRM 7.9 associative-array methods. Exclusive to the associative container:

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -68,7 +68,8 @@ struct ConditionalExpr {
 // `nullopt` is a simple write. `value` is already typed to match `target`.
 //
 // `target` is an ExprId pointing at one of: a PrimaryExpr var reference,
-// ElementSelectExpr / RangeSelectExpr on an addressable base. The
+// ElementSelectExpr / RangeSelectExpr on an addressable base, or a queue
+// access method call (`WriteRef`) that returns the element reference. The
 // ConcatExpr-as-target form (LRM 11.4.12 destructuring LHS) is desugared
 // upstream into a snapshot + per-part assignment sequence, so render does
 // not encounter it.
@@ -80,8 +81,8 @@ struct AssignExpr {
 
 // LRM 11.4.2: `++a`, `a++`, `--a`, `a--`. Mirrors hir::IncDecExpr. The
 // `target` ExprId points at an addressable expression (PrimaryExpr var ref,
-// ElementSelectExpr, or RangeSelectExpr); ConcatExpr-as-target is illegal
-// per slang.
+// ElementSelectExpr, RangeSelectExpr, or a queue access method call returning
+// an element reference); ConcatExpr-as-target is illegal per slang.
 struct IncDecExpr {
   IncDecOp op;
   ExprId target;

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <deque>
+#include <iostream>
+#include <optional>
 #include <span>
 #include <string>
 #include <utility>
@@ -39,20 +42,76 @@ class Queue {
   // Empty queue with the shield slot seeded. Used for declarations like
   // `int q[$];` where the queue starts empty but the element shape is known
   // at lowering time.
-  explicit Queue(T oob_slot) : oob_slot_(std::move(oob_slot)) {
+  explicit Queue(T oob_slot)
+      : oob_slot_(std::move(oob_slot)), oob_seeded_(true) {
   }
 
   // LRM 10.9.1 assignment-pattern construction: shield slot seeded, elements
   // taken from the pattern's list. The list is a span so the emit side hands
   // in a `std::array<T, N>{...}` literal, mirroring `DynamicArray`.
   Queue(T oob_slot, std::span<const T> init)
-      : oob_slot_(std::move(oob_slot)), data_(init.begin(), init.end()) {
+      : oob_slot_(std::move(oob_slot)),
+        data_(init.begin(), init.end()),
+        oob_seeded_(true) {
+  }
+
+  // LRM 7.10.5 bounded queue `int q[$:N]`: the empty start is unchanged, but
+  // the maximum index N is recorded so growth past N+1 elements is discarded
+  // with a warning. The bound arrives as a PackedArray construction argument.
+  Queue(T oob_slot, const PackedArray& max_bound)
+      : oob_slot_(std::move(oob_slot)),
+        max_bound_(static_cast<std::uint64_t>(max_bound.ToInt64())),
+        oob_seeded_(true) {
+  }
+
+  // LRM 7.10.5 bounded queue initialized by an assignment pattern: take the
+  // pattern's elements, record the bound, and trim any overflow on entry.
+  Queue(T oob_slot, std::span<const T> init, const PackedArray& max_bound)
+      : oob_slot_(std::move(oob_slot)),
+        data_(init.begin(), init.end()),
+        max_bound_(static_cast<std::uint64_t>(max_bound.ToInt64())),
+        oob_seeded_(true) {
+    EnforceBound();
   }
 
   Queue(const Queue&) = default;
   Queue(Queue&&) noexcept = default;
-  auto operator=(const Queue&) -> Queue& = default;
-  auto operator=(Queue&&) noexcept -> Queue& = default;
+  // LRM 10.6.1 / `value-assignment-and-moved-from.md`: the element shape and
+  // the LRM 7.10.5 bound are declared-type properties of the variable, not
+  // value content. A declared queue is default-constructed and then initialized
+  // by assignment, so an as-yet-unseeded target adopts the source's element
+  // shape (and an unbounded target the source's bound) on that first store;
+  // once seeded it keeps its own shape and bound on every later assignment and
+  // copies only the elements in -- so assigning the empty `{}` or an unbounded
+  // concat result preserves the variable's shape rather than overwriting it.
+  auto operator=(const Queue& other) -> Queue& {
+    if (this != &other) {
+      if (!oob_seeded_ && other.oob_seeded_) {
+        oob_slot_ = other.oob_slot_;
+        oob_seeded_ = true;
+      }
+      data_ = other.data_;
+      if (!max_bound_.has_value()) {
+        max_bound_ = other.max_bound_;
+      }
+      EnforceBound();
+    }
+    return *this;
+  }
+  auto operator=(Queue&& other) noexcept -> Queue& {
+    if (this != &other) {
+      if (!oob_seeded_ && other.oob_seeded_) {
+        oob_slot_ = std::move(other.oob_slot_);
+        oob_seeded_ = true;
+      }
+      data_ = std::move(other.data_);
+      if (!max_bound_.has_value()) {
+        max_bound_ = other.max_bound_;
+      }
+      EnforceBound();
+    }
+    return *this;
+  }
   ~Queue() = default;
 
   [[nodiscard]] auto Size() const -> std::size_t {
@@ -123,12 +182,9 @@ class Queue {
     data_.clear();
   }
 
-  // LRM 7.10.1 / 7.4.5: an index outside 0..size-1 (or carrying x/z) routes
-  // the access through `oob_slot_`, restored to its canonical default first so
-  // an OOB write lands on the shield and is erased on the next access.
-  // TODO(hankhsu): LRM 7.10.1 makes a write to Q[$+1] a legal append; the
-  // shared read/write `ElementAt` cannot distinguish it from an invalid write,
-  // so that one append corner is deferred (push_back covers the same need).
+  // LRM 7.10.1 / 7.4.5 read: an index outside 0..size-1 (or carrying x/z)
+  // returns the element default via `oob_slot_`, restored to canonical state
+  // first. Reads never grow the queue; the backend routes writes to `WriteRef`.
   [[nodiscard]] auto ElementAt(const PackedArray& idx) -> T& {
     if (IsInvalidIndex(idx)) {
       oob_slot_.ResetToDefault();
@@ -145,12 +201,59 @@ class Queue {
     return data_[static_cast<std::size_t>(idx.ToInt64())];
   }
 
+  // LRM 7.10.1 write: `q[$+1] = v` (index == size) appends a default-shaped
+  // slot and returns it. An x/z, negative, or beyond-`$+1` index lands on the
+  // discarded shield so the write is ignored. The backend takes this path only
+  // for an element-write lvalue, so a read of index == size still returns the
+  // default rather than growing the queue.
+  [[nodiscard]] auto WriteRef(const PackedArray& idx) -> T& {
+    if (!idx.HasUnknown()) {
+      const auto v = idx.ToInt64();
+      if (v >= 0 && static_cast<std::uint64_t>(v) < data_.size()) {
+        return data_[static_cast<std::size_t>(v)];
+      }
+      if (v >= 0 && static_cast<std::uint64_t>(v) == data_.size()) {
+        oob_slot_.ResetToDefault();
+        data_.push_back(oob_slot_);
+        EnforceBound();
+        if (static_cast<std::uint64_t>(v) < data_.size()) {
+          return data_[static_cast<std::size_t>(v)];
+        }
+        oob_slot_.ResetToDefault();
+        return oob_slot_;
+      }
+    }
+    oob_slot_.ResetToDefault();
+    return oob_slot_;
+  }
+
+  // LRM 7.10.1 queue slice `q[lo:hi]`. An x/z bound, or `lo > hi` after
+  // clamping, yields the empty queue. `lo` clamps up to 0 and `hi` clamps down
+  // to the last index (`q[a:b]` with `a < 0` is `q[0:b]`, with `b > $` is
+  // `q[a:$]`). The result carries this queue's element shape via `oob_slot_`.
+  [[nodiscard]] auto Slice(const PackedArray& lo, const PackedArray& hi) const
+      -> Queue {
+    Queue out(oob_slot_);
+    if (lo.HasUnknown() || hi.HasUnknown() || data_.empty()) {
+      return out;
+    }
+    const std::int64_t a = std::max<std::int64_t>(lo.ToInt64(), 0);
+    const auto last = static_cast<std::int64_t>(data_.size()) - 1;
+    const std::int64_t b = std::min<std::int64_t>(hi.ToInt64(), last);
+    for (std::int64_t i = a; i <= b; ++i) {
+      out.data_.push_back(data_[static_cast<std::size_t>(i)]);
+    }
+    return out;
+  }
+
   // LRM 7.10.2.7 / 7.10.2.6: append / prepend a single element.
   auto PushBack(const T& item) -> void {
     data_.push_back(item);
+    EnforceBound();
   }
   auto PushFront(const T& item) -> void {
     data_.push_front(item);
+    EnforceBound();
   }
 
   // LRM 7.10.2.4 / 7.10.2.5: remove and return the first / last element. On an
@@ -187,6 +290,7 @@ class Queue {
       return;
     }
     data_.insert(data_.begin() + static_cast<std::ptrdiff_t>(v), item);
+    EnforceBound();
   }
 
   // LRM 7.10.2.3: with no index, clear the queue; with an index, remove that
@@ -211,9 +315,70 @@ class Queue {
                         static_cast<std::uint64_t>(data_.size());
   }
 
+  // LRM 7.10.5: a bounded queue holds no element whose index exceeds the bound,
+  // so once a write grows it past `max_bound_ + 1` elements the overflow is
+  // discarded and a warning is issued. A no-op for an unbounded queue.
+  auto EnforceBound() -> void {
+    if (!max_bound_.has_value()) {
+      return;
+    }
+    const std::size_t cap = static_cast<std::size_t>(*max_bound_) + 1;
+    if (data_.size() > cap) {
+      data_.resize(cap);
+      std::cerr << "warning: bounded queue exceeded its declared bound; "
+                   "elements beyond the bound were discarded (LRM 7.10.5)\n";
+    }
+  }
+
   mutable T oob_slot_;
   std::deque<T> data_;
+  std::optional<std::uint64_t> max_bound_ = std::nullopt;
+  bool oob_seeded_ = false;
 };
+
+// LRM 10.10 unpacked array concatenation builder. The backend wraps each part
+// as a single element (`QElem`) or an array to splice in element order
+// (`QSpread`); `MakeQueueConcat` folds the parts onto a queue seeded with the
+// element default, so even the empty `{}` carries the element shape.
+template <typename T>
+struct ConcatElemArg {
+  T value;
+};
+template <typename C>
+struct ConcatSpreadArg {
+  const C* array;
+};
+
+template <typename T>
+auto QElem(const T& value) -> ConcatElemArg<T> {
+  return ConcatElemArg<T>{value};
+}
+template <typename C>
+auto QSpread(const C& array) -> ConcatSpreadArg<C> {
+  return ConcatSpreadArg<C>{&array};
+}
+
+template <typename T>
+auto AppendConcatPart(Queue<T>& out, const ConcatElemArg<T>& part) -> void {
+  out.PushBack(part.value);
+}
+template <typename T, typename C>
+auto AppendConcatPart(Queue<T>& out, const ConcatSpreadArg<C>& part) -> void {
+  for (std::size_t i = 0; i < part.array->Size(); ++i) {
+    out.PushBack(part.array->RawAt(i));
+  }
+}
+
+// The result is default-constructed (unseeded): the destination of the
+// enclosing assignment keeps its own element shape (LRM 10.6.1), so the concat
+// value need not carry one. The element type is supplied explicitly because it
+// cannot be deduced from an empty `{}` part list.
+template <typename T, typename... Parts>
+auto MakeQueueConcat(const Parts&... parts) -> Queue<T> {
+  Queue<T> out;
+  (AppendConcatPart(out, parts), ...);
+  return out;
+}
 
 // LRM 21.2.1.6 aggregate format. Mirrors `Formatter<DynamicArray<T>>`: walk
 // the elements, deferring each to its own `Formatter`. Empty queues compose

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1065,13 +1065,35 @@ auto QueueMethodMemberName(mir::QueueMethodKind k) -> std::string_view {
       return "PushFront";
     case mir::QueueMethodKind::kPushBack:
       return "PushBack";
+    case mir::QueueMethodKind::kElementAt:
+      return "ElementAt";
+    case mir::QueueMethodKind::kWriteRef:
+      return "WriteRef";
+    case mir::QueueMethodKind::kSlice:
+      return "Slice";
   }
   throw InternalError("QueueMethodMemberName: unknown kind");
 }
 
-// LRM 7.10.2: every queue method except `Size` mutates the receiver.
+// The queue methods that write the receiver (LRM 7.10.2 insert / delete / pop /
+// push, and the LRM 7.10.1 element-write `WriteRef`) take the mutating receiver
+// path; the read accessors (`Size`, `ElementAt`, `Slice`) do not.
 auto QueueMethodMutatesReceiver(mir::QueueMethodKind k) -> bool {
-  return k != mir::QueueMethodKind::kSize;
+  switch (k) {
+    case mir::QueueMethodKind::kSize:
+    case mir::QueueMethodKind::kElementAt:
+    case mir::QueueMethodKind::kSlice:
+      return false;
+    case mir::QueueMethodKind::kInsert:
+    case mir::QueueMethodKind::kDelete:
+    case mir::QueueMethodKind::kPopFront:
+    case mir::QueueMethodKind::kPopBack:
+    case mir::QueueMethodKind::kPushFront:
+    case mir::QueueMethodKind::kPushBack:
+    case mir::QueueMethodKind::kWriteRef:
+      return true;
+  }
+  throw InternalError("QueueMethodMutatesReceiver: unknown kind");
 }
 
 // LRM 7.10.2 queue-native methods. The receiver is arguments[0] and any SV
@@ -1548,12 +1570,10 @@ auto RenderIndexedElementAccess(
   }
   if (!std::holds_alternative<mir::PackedArrayType>(base_ty.data) &&
       !std::holds_alternative<mir::UnpackedArrayType>(base_ty.data) &&
-      !std::holds_alternative<mir::DynamicArrayType>(base_ty.data) &&
-      !std::holds_alternative<mir::QueueType>(base_ty.data)) {
+      !std::holds_alternative<mir::DynamicArrayType>(base_ty.data)) {
     throw InternalError(
         "RenderIndexedElementAccess: base type must be PackedArrayType, "
-        "UnpackedArrayType, DynamicArrayType, QueueType, or "
-        "AssociativeArrayType");
+        "UnpackedArrayType, DynamicArrayType, or AssociativeArrayType");
   }
   return std::format("({}).ElementAt({})", base, idx);
 }
@@ -1627,10 +1647,17 @@ auto RenderLhsExpr(
             if (!ptr) return std::unexpected(std::move(ptr.error()));
             return "(*" + *ptr + ")" + std::string{mutate_adapter};
           },
+          [&](const mir::CallExpr& call) -> diag::Result<std::string> {
+            // LRM 7.10.1: a queue element write lowers to a `WriteRef` built-in
+            // method call that returns the element reference, so the call site
+            // is itself the assignable lvalue.
+            return RenderCallExpr(ctx, call, expr.type);
+          },
           [&](const auto&) -> diag::Result<std::string> {
             throw InternalError(
-                "RenderLhsExpr: expression form is not addressable; "
-                "ValidateAssignableProcExpr should have rejected it");
+                "RenderLhsExpr: expression form is not addressable; the "
+                "assignment target lowering should have produced an "
+                "addressable form");
           },
       },
       expr.data);
@@ -1944,13 +1971,48 @@ auto RenderClosureExpr(
          " {\n" + *body_or + "}";
 }
 
+// LRM 10.10 unpacked array concatenation into a queue. Each operand is spliced
+// (an unpacked container of the element type) or appended as a single element
+// (anything else); the empty `{}` is the empty queue. The result is unseeded --
+// the assignment destination keeps its own element shape (LRM 10.6.1) -- so no
+// element default is threaded.
+auto RenderQueueConcat(
+    const RenderContext& ctx, const mir::Type& result_ty,
+    const mir::ConcatExpr& c) -> diag::Result<std::string> {
+  const mir::TypeId elem_type_id =
+      std::get<mir::QueueType>(result_ty.data).element_type;
+  auto elem_cpp =
+      RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), elem_type_id);
+  if (!elem_cpp) return std::unexpected(std::move(elem_cpp.error()));
+  std::string out = "lyra::value::MakeQueueConcat<" + *elem_cpp + ">(";
+  for (std::size_t i = 0; i < c.operands.size(); ++i) {
+    const auto& op_expr = ctx.Expr(c.operands[i]);
+    const auto& op_ty = ctx.Unit().GetType(op_expr.type);
+    const bool spread =
+        std::holds_alternative<mir::QueueType>(op_ty.data) ||
+        std::holds_alternative<mir::DynamicArrayType>(op_ty.data) ||
+        std::holds_alternative<mir::UnpackedArrayType>(op_ty.data);
+    auto rendered =
+        spread ? RenderExprNatural(ctx, op_expr) : RenderExpr(ctx, op_expr);
+    if (!rendered) return std::unexpected(std::move(rendered.error()));
+    if (i != 0) out += ", ";
+    out += spread ? "lyra::value::QSpread(" + *rendered + ")"
+                  : "lyra::value::QElem(" + *rendered + ")";
+  }
+  out += ")";
+  return out;
+}
+
 auto RenderConcatExpr(
     const RenderContext& ctx, const mir::Expr& expr, const mir::ConcatExpr& c)
     -> diag::Result<std::string> {
+  const auto& result_ty = ctx.Unit().GetType(expr.type);
+  if (std::holds_alternative<mir::QueueType>(result_ty.data)) {
+    return RenderQueueConcat(ctx, result_ty, c);
+  }
   if (c.operands.empty()) {
     throw InternalError("RenderConcatExpr: hir lowering produced empty concat");
   }
-  const auto& result_ty = ctx.Unit().GetType(expr.type);
   const auto join = [&](std::string_view open, std::string_view sep,
                         std::string_view close) -> diag::Result<std::string> {
     std::string out{open};

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -239,6 +239,12 @@ class HirDumper {
         return "push_front";
       case QueueMethodKind::kPushBack:
         return "push_back";
+      case QueueMethodKind::kElementAt:
+        return "element_at";
+      case QueueMethodKind::kWriteRef:
+        return "write_ref";
+      case QueueMethodKind::kSlice:
+        return "slice";
     }
     throw InternalError(
         "HirDumper::FormatQueueMethodKind: unknown QueueMethodKind");

--- a/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
@@ -27,10 +27,12 @@ auto LowerConcatExprProc(
   auto type_id = module.InternType(*cc.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   const auto kind = module.Unit().GetType(*type_id).Kind();
-  if (kind != hir::TypeKind::kString && kind != hir::TypeKind::kPackedArray) {
+  if (kind != hir::TypeKind::kString && kind != hir::TypeKind::kPackedArray &&
+      kind != hir::TypeKind::kQueue) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedExpressionForm,
-        "concatenation result type is neither string nor packed (LRM 11.4.12)",
+        "concatenation result type is not string, packed, or a queue (LRM "
+        "11.4.12 / 10.10)",
         diag::UnsupportedCategory::kOperation);
   }
   std::vector<hir::ExprId> operand_ids;

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -208,6 +208,9 @@ auto LowerProcExpr(
       return LowerMemberAccessExprProc(
           proc, frame, expr.as<slang::ast::MemberAccessExpression>(), span);
 
+    case slang::ast::ExpressionKind::UnboundedLiteral:
+      return LowerUnboundedLiteralProc(proc, frame, span);
+
     case slang::ast::ExpressionKind::Concatenation:
       return LowerConcatExprProc(
           proc, frame, expr.as<slang::ast::ConcatenationExpression>(), span);

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -11,11 +11,49 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/kind.hpp"
+#include "lyra/hir/binary_op.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/expr_builders.hpp"
+#include "lyra/hir/method.hpp"
+#include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
+
+// LRM 7.10: `$` in a queue index or slice bound denotes the last element, i.e.
+// `size(base) - 1`. The base whose `$` this resolves is threaded on the walk
+// frame by the enclosing queue select; outside that context `$` has no value.
+auto LowerUnboundedLiteralProc(
+    ProcessLowerer& proc, WalkFrame frame, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  if (!frame.dollar_base.has_value()) {
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "`$` is only supported as a queue index or slice bound (LRM 7.10)",
+        diag::UnsupportedCategory::kOperation);
+  }
+  auto& body = *frame.current_procedural_body;
+  const hir::TypeId int32_type = proc.Module().Unit().builtins.int32;
+  const hir::ExprId size_id = body.AddExpr(
+      hir::Expr{
+          .type = int32_type,
+          .data =
+              hir::CallExpr{
+                  .callee = hir::SubroutineRef{hir::BuiltinMethodRef{
+                      .method = hir::QueueMethodKind::kSize}},
+                  .arguments = {*frame.dollar_base}},
+          .span = span});
+  const hir::ExprId one_id =
+      body.AddExpr(hir::MakeInt32Literal(1, int32_type, span));
+  return hir::Expr{
+      .type = int32_type,
+      .data =
+          hir::BinaryExpr{
+              .op = hir::BinaryOp::kSub, .lhs = size_id, .rhs = one_id},
+      .span = span};
+}
 
 auto LowerElementSelectExprProc(
     ProcessLowerer& proc, WalkFrame frame,
@@ -32,7 +70,9 @@ auto LowerElementSelectExprProc(
   const hir::ExprId base_id =
       frame.current_procedural_body->AddExpr(*std::move(base_or));
 
-  auto idx_or = proc.LowerExpr(sel.selector(), frame);
+  const WalkFrame idx_frame =
+      sel.value().type->isQueue() ? frame.WithDollarBase(base_id) : frame;
+  auto idx_or = proc.LowerExpr(sel.selector(), idx_frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const hir::ExprId idx_id =
       frame.current_procedural_body->AddExpr(*std::move(idx_or));
@@ -67,12 +107,14 @@ auto LowerRangeSelectExprProc(
   const hir::ExprId base_id =
       frame.current_procedural_body->AddExpr(*std::move(base_or));
 
-  auto left_or = proc.LowerExpr(sel.left(), frame);
+  const WalkFrame bound_frame =
+      sel.value().type->isQueue() ? frame.WithDollarBase(base_id) : frame;
+  auto left_or = proc.LowerExpr(sel.left(), bound_frame);
   if (!left_or) return std::unexpected(std::move(left_or.error()));
   const hir::ExprId left_id =
       frame.current_procedural_body->AddExpr(*std::move(left_or));
 
-  auto right_or = proc.LowerExpr(sel.right(), frame);
+  auto right_or = proc.LowerExpr(sel.right(), bound_frame);
   if (!right_or) return std::unexpected(std::move(right_or.error()));
   const hir::ExprId right_id =
       frame.current_procedural_body->AddExpr(*std::move(right_or));

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -116,8 +116,17 @@ auto BuildDefaultValueExpr(
           [&](const mir::QueueType& q) -> mir::Expr {
             const mir::ExprId element_default = scope.AddExpr(
                 BuildDefaultValueExpr(module, frame, q.element_type));
+            std::vector<mir::ExprId> args = {element_default};
+            // LRM 7.10.5: a bounded queue `int q[$:N]` carries its max index N
+            // as a second construction argument so the runtime can enforce it.
+            if (q.max_bound.has_value()) {
+              args.push_back(scope.AddExpr(
+                  mir::MakeInt32Literal(
+                      module.Unit().builtins.int32,
+                      static_cast<std::int64_t>(*q.max_bound))));
+            }
             return mir::Expr{
-                .data = mir::ConstructExpr{.args = {element_default}},
+                .data = mir::ConstructExpr{.args = std::move(args)},
                 .type = type};
           },
           // LRM Table 6-7: an associative array's default is empty. The element
@@ -187,9 +196,19 @@ auto BuildArrayConstructExpr(
       mir::Expr{
           .data = mir::ArrayLiteralExpr{.elements = std::move(elements)},
           .type = array_type});
+  std::vector<mir::ExprId> args = {element_default, list_id};
+  // LRM 7.10.5: a bounded queue initialized by an assignment pattern still
+  // carries its max index, so the bound rides as a third construction argument
+  // and the runtime trims an over-long initializer.
+  if (const auto* q = std::get_if<mir::QueueType>(&ty.data);
+      q != nullptr && q->max_bound.has_value()) {
+    args.push_back(scope.AddExpr(
+        mir::MakeInt32Literal(
+            module.Unit().builtins.int32,
+            static_cast<std::int64_t>(*q->max_bound))));
+  }
   return mir::Expr{
-      .data = mir::ConstructExpr{.args = {element_default, list_id}},
-      .type = array_type};
+      .data = mir::ConstructExpr{.args = std::move(args)}, .type = array_type};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -187,7 +187,8 @@ auto LowerHirAssignExprProc(
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const mir::TypeId rhs_type = (*rhs_or).type;
   const mir::ExprId rhs_id = proc_scope.AddExpr(*std::move(rhs_or));
-  auto lhs_or = process.LowerExpr(hir_process.exprs.at(a.lhs.value), frame);
+  auto lhs_or = process.LowerExpr(
+      hir_process.exprs.at(a.lhs.value), frame.WithLvalueTarget(true));
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const mir::ExprId lhs_id = proc_scope.AddExpr(*std::move(lhs_or));
 

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -204,6 +204,12 @@ auto LowerQueueMethodKind(hir::QueueMethodKind k) -> mir::QueueMethodKind {
       return mir::QueueMethodKind::kPushFront;
     case hir::QueueMethodKind::kPushBack:
       return mir::QueueMethodKind::kPushBack;
+    case hir::QueueMethodKind::kElementAt:
+      return mir::QueueMethodKind::kElementAt;
+    case hir::QueueMethodKind::kWriteRef:
+      return mir::QueueMethodKind::kWriteRef;
+    case hir::QueueMethodKind::kSlice:
+      return mir::QueueMethodKind::kSlice;
   }
   throw InternalError("LowerQueueMethodKind: unknown hir::QueueMethodKind");
 }

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -210,8 +210,10 @@ auto LowerHirIncDecExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::IncDecExpr& inc,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& hir_process = process.HirBody();
-  auto target_or =
-      process.LowerExpr(hir_process.exprs.at(inc.target.value), frame);
+  // The target is written in place, so a queue element resolves to its write
+  // access method (`WriteRef`) just as an assignment target does.
+  auto target_or = process.LowerExpr(
+      hir_process.exprs.at(inc.target.value), frame.WithLvalueTarget(true));
   if (!target_or) return std::unexpected(std::move(target_or.error()));
   const mir::ExprId target_id =
       frame.current_procedural_scope->AddExpr(*std::move(target_or));

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -213,6 +213,83 @@ auto UnfoldHirRangeBoundsForUnpacked(
       bounds);
 }
 
+struct QueueSliceBounds {
+  mir::ExprId lo;
+  mir::ExprId hi;
+};
+
+// LRM 7.10.1 queue slice low / high indices. The three source bound forms
+// differ only in how they derive them: `q[a:b]` is `(a, b)`, `q[base+:w]` is
+// `(base, base+w-1)`, and `q[base-:w]` is `(base-w+1, base)`. The width is a
+// constant but is left as an expression -- the runtime `Slice` clamps either
+// bound, so no folding is required here.
+template <typename LowerOne>
+auto QueueSliceLoHi(
+    const ModuleLowerer& module, mir::ProceduralScope& proc_scope,
+    const hir::RangeBounds& bounds, LowerOne lower_one)
+    -> diag::Result<QueueSliceBounds> {
+  const mir::TypeId int32_type = module.Unit().builtins.int32;
+  auto binop = [&](mir::ExprId lhs, mir::ExprId rhs,
+                   mir::BinaryOp op) -> mir::ExprId {
+    const auto type = proc_scope.GetExpr(lhs).type;
+    return proc_scope.AddExpr(
+        mir::Expr{
+            .data = mir::BinaryExpr{.op = op, .lhs = lhs, .rhs = rhs},
+            .type = type});
+  };
+  auto width_minus_one = [&](mir::ExprId width) -> mir::ExprId {
+    const auto one = proc_scope.AddExpr(mir::MakeInt32Literal(int32_type, 1));
+    return binop(width, one, mir::BinaryOp::kSub);
+  };
+  return std::visit(
+      Overloaded{
+          [&](const hir::RangeConstantBounds& b)
+              -> diag::Result<QueueSliceBounds> {
+            auto lo = lower_one(b.msb_expr);
+            if (!lo) return std::unexpected(std::move(lo.error()));
+            auto hi = lower_one(b.lsb_expr);
+            if (!hi) return std::unexpected(std::move(hi.error()));
+            return QueueSliceBounds{.lo = *lo, .hi = *hi};
+          },
+          [&](const hir::RangeIndexedUpBounds& b)
+              -> diag::Result<QueueSliceBounds> {
+            auto base = lower_one(b.base_index);
+            if (!base) return std::unexpected(std::move(base.error()));
+            auto width = lower_one(b.width);
+            if (!width) return std::unexpected(std::move(width.error()));
+            const auto hi =
+                binop(*base, width_minus_one(*width), mir::BinaryOp::kAdd);
+            return QueueSliceBounds{.lo = *base, .hi = hi};
+          },
+          [&](const hir::RangeIndexedDownBounds& b)
+              -> diag::Result<QueueSliceBounds> {
+            auto base = lower_one(b.base_index);
+            if (!base) return std::unexpected(std::move(base.error()));
+            auto width = lower_one(b.width);
+            if (!width) return std::unexpected(std::move(width.error()));
+            const auto lo =
+                binop(*base, width_minus_one(*width), mir::BinaryOp::kSub);
+            return QueueSliceBounds{.lo = lo, .hi = *base};
+          },
+      },
+      bounds);
+}
+
+auto BuildQueueSliceCall(
+    mir::ExprId base, const QueueSliceBounds& bounds, mir::TypeId result_type)
+    -> mir::Expr {
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinMethodCallee{
+                      .method =
+                          mir::QueueMethodInfo{
+                              .kind = mir::QueueMethodKind::kSlice}},
+              .arguments = {base, bounds.lo, bounds.hi}},
+      .type = result_type};
+}
+
 }  // namespace
 
 auto LowerHirElementSelectExprProc(
@@ -221,17 +298,34 @@ auto LowerHirElementSelectExprProc(
   const auto& module = process.Module();
   const auto& hir_process = process.HirBody();
   auto& proc_scope = *frame.current_procedural_scope;
+  const bool is_write = frame.is_lvalue_target;
+  const WalkFrame sub_frame = frame.WithLvalueTarget(false);
   const auto& hir_base = hir_process.exprs.at(sel.base_value.value);
-  auto base_or = process.LowerExpr(hir_base, frame);
+  auto base_or = process.LowerExpr(hir_base, sub_frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = proc_scope.AddExpr(*std::move(base_or));
 
   const auto& hir_idx = hir_process.exprs.at(sel.index.value);
-  auto idx_or = process.LowerExpr(hir_idx, frame);
+  auto idx_or = process.LowerExpr(hir_idx, sub_frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   mir::ExprId idx_id = proc_scope.AddExpr(*std::move(idx_or));
 
   const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
+  // LRM 7.10.1: a queue has no native indexing expression -- `q[i]` realizes as
+  // a built-in method call. A write target takes the append-aware `WriteRef`, a
+  // read the default-on-miss `ElementAt` (the index stays a plain argument).
+  if (std::holds_alternative<hir::QueueType>(hir_base_ty.data)) {
+    const auto kind = is_write ? mir::QueueMethodKind::kWriteRef
+                               : mir::QueueMethodKind::kElementAt;
+    return mir::Expr{
+        .data =
+            mir::CallExpr{
+                .callee =
+                    mir::BuiltinMethodCallee{
+                        .method = mir::QueueMethodInfo{.kind = kind}},
+                .arguments = {base_id, idx_id}},
+        .type = result_type};
+  }
   if (const auto* ua = std::get_if<hir::UnpackedArrayType>(&hir_base_ty.data)) {
     idx_id = WrapUnpackedIndex(
         module, proc_scope, ua->dim, idx_id,
@@ -264,6 +358,13 @@ auto LowerHirRangeSelectExprProc(
     return proc_scope.AddExpr(*std::move(lowered));
   };
   const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
+  // LRM 7.10.1: a queue slice is a built-in method call; all three bound forms
+  // (`a:b`, `base+:w`, `base-:w`) reduce to a low / high pair fed to `Slice`.
+  if (std::holds_alternative<hir::QueueType>(hir_base_ty.data)) {
+    auto bounds_or = QueueSliceLoHi(module, proc_scope, sel.bounds, lower_one);
+    if (!bounds_or) return std::unexpected(std::move(bounds_or.error()));
+    return BuildQueueSliceCall(base_id, *bounds_or, result_type);
+  }
   auto unfolded = [&]() {
     if (const auto* ua =
             std::get_if<hir::UnpackedArrayType>(&hir_base_ty.data)) {
@@ -340,6 +441,9 @@ auto LowerHirElementSelectExprStructural(
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   mir::ExprId idx_id = proc_scope.AddExpr(*std::move(idx_or));
 
+  // A queue element select cannot reach the structural path: slang forbids
+  // referencing an element of a dynamic-typed variable outside a procedural
+  // context, so no queue method-call lowering is needed here.
   const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
   if (const auto* ua = std::get_if<hir::UnpackedArrayType>(&hir_base_ty.data)) {
     idx_id = WrapUnpackedIndex(
@@ -369,6 +473,9 @@ auto LowerHirRangeSelectExprStructural(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     return proc_scope.AddExpr(*std::move(lowered));
   };
+  // A queue slice cannot reach the structural path: slang forbids referencing
+  // an element of a dynamic-typed variable outside a procedural context, so a
+  // queue base never appears here. Only packed and fixed-unpacked slices do.
   const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
   auto unfolded = [&]() {
     if (const auto* ua =

--- a/tests/cases/cpp/queue_append/case.yaml
+++ b/tests/cases/cpp/queue_append/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.queue_append
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q: [2, 20, 8, 4, 5]
+    last: 5
+    oob_read: 0
+    size_after: 5

--- a/tests/cases/cpp/queue_append/main.sv
+++ b/tests/cases/cpp/queue_append/main.sv
@@ -1,0 +1,24 @@
+// LRM 7.10.1 queue element-write rules. A write to `q[$+1]` (index == size) is
+// a legal append; an index that is x/z, negative, or beyond `$+1` is ignored.
+// A read of an invalid index returns the element default and never grows the
+// queue, so the read/write split matters: `q[100]` read stays a no-op. The
+// read-modify-write forms `q[i]++` and `q[i] += v` also take the write path so
+// the update reaches the observable queue.
+module Top;
+  int q [$] = '{1, 2, 3};
+  int last;
+  int oob_read;
+  int size_after;
+
+  initial begin
+    q[$+1] = 4;
+    q[$+1] = 5;
+    q[10] = 99;
+    q[1] = 20;
+    q[0]++;
+    q[2] += 5;
+    last = q[$];
+    oob_read = q[100];
+    size_after = q.size();
+  end
+endmodule

--- a/tests/cases/cpp/queue_bounded/case.yaml
+++ b/tests/cases/cpp/queue_bounded/case.yaml
@@ -1,0 +1,18 @@
+id: cpp.queue_bounded
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    grow: [10, 20, 30, 40]
+    s_grow: 4
+    init_big: [1, 2, 3]
+    s_init: 3
+    assigned: [1, 2, 3]
+    s_assigned: 3
+    retained: [1, 2, 3, 4]
+    s_retained: 4

--- a/tests/cases/cpp/queue_bounded/main.sv
+++ b/tests/cases/cpp/queue_bounded/main.sv
@@ -1,0 +1,35 @@
+// LRM 7.10.5 bounded queue `int q[$:N]`: the queue never holds an element whose
+// index exceeds N, so any write growing it past N+1 elements discards the
+// overflow (a warning is also issued). The bound reaches the variable however
+// it is first built -- empty declaration, assignment-pattern initializer, or a
+// later whole-queue assignment -- and is retained across later assignments.
+module Top;
+  bit [7:0] grow [$:3];
+  bit [7:0] init_big [$:2] = '{1, 2, 3, 4, 5};
+  bit [7:0] assigned [$:2];
+  bit [7:0] retained [$:3] = '{1, 2};
+
+  int s_grow;
+  int s_init;
+  int s_assigned;
+  int s_retained;
+
+  initial begin
+    grow.push_back(8'd10);
+    grow.push_back(8'd20);
+    grow.push_back(8'd30);
+    grow.push_back(8'd40);
+    grow.push_back(8'd50);
+    s_grow = grow.size();
+
+    s_init = init_big.size();
+
+    assigned = {8'd1, 8'd2, 8'd3, 8'd4};
+    s_assigned = assigned.size();
+
+    retained.push_back(8'd3);
+    retained.push_back(8'd4);
+    retained.push_back(8'd5);
+    s_retained = retained.size();
+  end
+endmodule

--- a/tests/cases/cpp/queue_concat/case.yaml
+++ b/tests/cases/cpp/queue_concat/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.queue_concat
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    pb: [1, 2, 3, 4]
+    pf: [0, 1, 2, 3]
+    ins: [1, 2, 99, 3, 4]
+    cat: [10, 20, 30, 40]
+    emptied: []
+    reseed: [5]

--- a/tests/cases/cpp/queue_concat/main.sv
+++ b/tests/cases/cpp/queue_concat/main.sv
@@ -1,0 +1,25 @@
+// LRM 10.10 unpacked array concatenation into a queue, including the push /
+// pop / insert idioms of LRM 7.10.4. An operand that is a queue is spliced in
+// element order; any other operand is a single element. The empty `{}` is the
+// empty queue, and a concat reseeds the element default so a later append still
+// carries the element shape.
+module Top;
+  int pb [$] = '{1, 2, 3};
+  int pf [$] = '{1, 2, 3};
+  int ins [$] = '{1, 2, 3, 4};
+  int a [$] = '{10, 20};
+  int b [$] = '{30, 40};
+  int cat [$];
+  int emptied [$] = '{7, 8};
+  int reseed [$] = '{7, 8};
+
+  initial begin
+    pb = {pb, 4};
+    pf = {0, pf};
+    ins = {ins[0:1], 99, ins[2:$]};
+    cat = {a, b};
+    emptied = {};
+    reseed = {};
+    reseed = {reseed, 5};
+  end
+endmodule

--- a/tests/cases/cpp/queue_equality/case.yaml
+++ b/tests/cases/cpp/queue_equality/case.yaml
@@ -1,0 +1,26 @@
+id: cpp.queue_equality
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    eq_1d: 1
+    ne_1d: 0
+    eq_size_mismatch: 0
+    ne_size_mismatch: 1
+    eq_diff_val: 0
+    ne_diff_val: 1
+    eq_empty_empty: 1
+    ne_empty_empty: 0
+    eq_empty_nonempty: 0
+    eq_with_x: "1'bx"
+    ne_with_x: "1'bx"
+    ce_1d: 1
+    nce_1d: 0
+    ce_size_mismatch: 0
+    ce_x_match: 1
+    ce_x_mismatch: 0

--- a/tests/cases/cpp/queue_equality/main.sv
+++ b/tests/cases/cpp/queue_equality/main.sv
@@ -1,0 +1,45 @@
+// LRM 11.2.2 + 11.4.5 logical and case equality on queues. Aggregate == reduces
+// element-wise comparisons through &&; runtime size mismatch yields 0 and
+// empty-vs-empty yields 1 (industry convention, LRM 11.2.2 silent). == / !=
+// propagate X / Z (LRM 11.4.5); === / !== match X / Z as values.
+module Top;
+  int a [$] = '{10, 20, 30};
+  int b [$] = '{10, 20, 30};
+  int shorter [$] = '{10, 20};
+  int diff_val [$] = '{10, 20, 99};
+  int empty1 [$];
+  int empty2 [$];
+
+  logic [3:0] u_with_x [$] = '{4'b1010, 4'b10x0, 4'b1111};
+  logic [3:0] u_no_x   [$] = '{4'b1010, 4'b1010, 4'b1111};
+  logic [3:0] u_x_same [$] = '{4'b1010, 4'b10x0, 4'b1111};
+
+  bit eq_1d, ne_1d;
+  bit eq_size_mismatch, ne_size_mismatch;
+  bit eq_diff_val, ne_diff_val;
+  bit eq_empty_empty, ne_empty_empty;
+  bit eq_empty_nonempty;
+  logic eq_with_x, ne_with_x;
+  bit ce_1d, nce_1d;
+  bit ce_size_mismatch;
+  bit ce_x_match, ce_x_mismatch;
+
+  initial begin
+    eq_1d = (a == b);
+    ne_1d = (a != b);
+    eq_size_mismatch = (a == shorter);
+    ne_size_mismatch = (a != shorter);
+    eq_diff_val = (a == diff_val);
+    ne_diff_val = (a != diff_val);
+    eq_empty_empty = (empty1 == empty2);
+    ne_empty_empty = (empty1 != empty2);
+    eq_empty_nonempty = (empty1 == a);
+    eq_with_x = (u_with_x == u_no_x);
+    ne_with_x = (u_with_x != u_no_x);
+    ce_1d = (a === b);
+    nce_1d = (a !== b);
+    ce_size_mismatch = (a === shorter);
+    ce_x_match = (u_with_x === u_x_same);
+    ce_x_mismatch = (u_with_x === u_no_x);
+  end
+endmodule

--- a/tests/cases/cpp/queue_slice/case.yaml
+++ b/tests/cases/cpp/queue_slice/case.yaml
@@ -1,0 +1,24 @@
+id: cpp.queue_slice
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    last: 50
+    second_last: 40
+    s_const: [20, 30, 40]
+    s_to_end: [20, 30, 40, 50]
+    s_drop_last: [10, 20, 30, 40]
+    s_empty_rev: []
+    s_clamp_lo: [10, 20]
+    s_clamp_hi: [40, 50]
+    xz: []
+    up: [20, 30, 40]
+    down: [30, 40]
+    up_clamp: [40, 50]
+    down_clamp: [10, 20]
+    pf: [3, 4]

--- a/tests/cases/cpp/queue_slice/main.sv
+++ b/tests/cases/cpp/queue_slice/main.sv
@@ -1,0 +1,44 @@
+// LRM 7.10 `$` last index and LRM 7.10.1 queue slice. `$` denotes the last
+// index (and `$-1` the one before). The slice `q[a:b]` clamps `a` up to 0 and
+// `b` down to the last index, yields the empty queue when `a > b` or a bound is
+// x/z, and `q = q[1:$]` is the pop-front idiom of LRM 7.10.4. The indexed forms
+// `q[base+:w]` and `q[base-:w]` reduce to the same low / high pair and clamp the
+// same way.
+module Top;
+  int q [$] = '{10, 20, 30, 40, 50};
+  logic [31:0] bad;
+
+  int last;
+  int second_last;
+  int s_const [$];
+  int s_to_end [$];
+  int s_drop_last [$];
+  int s_empty_rev [$];
+  int s_clamp_lo [$];
+  int s_clamp_hi [$];
+  int xz [$];
+  int up [$];
+  int down [$];
+  int up_clamp [$];
+  int down_clamp [$];
+  int pf [$] = '{1, 2, 3, 4};
+
+  initial begin
+    last = q[$];
+    second_last = q[$-1];
+    s_const = q[1:3];
+    s_to_end = q[1:$];
+    s_drop_last = q[0:$-1];
+    s_empty_rev = q[3:1];
+    s_clamp_lo = q[-2:1];
+    s_clamp_hi = q[3:99];
+    bad = 32'hx;
+    xz = q[0:bad];
+    up = q[1 +: 3];
+    down = q[3 -: 2];
+    up_clamp = q[3 +: 5];
+    down_clamp = q[1 -: 4];
+    pf = pf[1:$];
+    pf = pf[1:$];
+  end
+endmodule


### PR DESCRIPTION
## Summary

Queues now support the full unpacked-array operator surface beyond their native methods: indexing with `$`, the slice `q[a:b]` / `q[base+:w]` / `q[base-:w]`, unpacked array concatenation `{...}` including the push / pop / insert idioms of LRM 7.10.4, aggregate equality, the `q[$+1]` append, and the bounded form `q[$:N]` with discard-and-warn.

## Design

The access operators lower to built-in method calls rather than new MIR nodes. A queue index, slice, or element write has no native C++ expression -- it realizes as `receiver.Method(args)` on the runtime `Queue<T>` -- so it lowers to the existing call primitive with a `QueueMethodKind` callee (`ElementAt`, `WriteRef`, `Slice`) beside the SV-callable queue methods, and the backend render stays one generic method-call path. Read versus write is decided at lowering: an assignment or increment target takes the append-aware `WriteRef`, a read the default-on-miss `ElementAt`. Unpacked concatenation reuses the existing `ConcatExpr` value-build primitive dispatched on result type. A queue's element shape and bound are declared-type properties, so assignment preserves the destination's and copies only the elements in, per `value-assignment-and-moved-from.md`. See `docs/decisions/queue-operators.md`.

## Testing

`bazel test //...` is green. New cases cover equality, `$` and all three slice forms with clamping corners, concatenation and the empty queue, the `q[$+1]` append plus the `q[i]++` / `q[i] += v` read-modify-write forms, and bounded-queue discard.