### PR TITLE
Return SV value types from runtime method signatures

### DIFF
--- a/docs/decisions/array-method-dispatch.md
+++ b/docs/decisions/array-method-dispatch.md
@@ -29,8 +29,9 @@ A new `ArrayMethodKind` enum joins the existing variant arms (`EnumMethodKind`, 
 `EventMethodKind`). AST -> HIR detects the receiver type in `LowerCallExprProc` and routes the call
 to `BuiltinMethodRef{ArrayMethodKind::kXxx}`. HIR -> MIR translates the kind through the existing
 `Overloaded` visitor on the `BuiltinMethodRef` callee. The backend renders `(receiver).MethodName()`
-and wraps the result in `lyra::value::PackedArray::Int(...)` for the one method whose C++ return
-type is `std::size_t` (`size`).
+through the one generic method-call rule, doing no representation work: an SV-facing query yields
+the SV value type directly from the runtime method's signature (`size` returns the SV `int` shape; a
+separate `RawSize` serves internal native-count callers).
 
 The enum is named `ArrayMethodKind` (not `DynArrayMethodKind`) because LRM 7.12 defines the
 semantics uniformly across container kinds; only the AST -> HIR receiver-detection block differs per

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -448,29 +448,26 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
 
 - [ ] R25 -- Collapse the per-data-type builtin-method render handlers onto the single generic
       `(receiver).name(args)` rule (R20's rule, now also carrying user-subroutine calls and the
-      event family). Each remaining per-type handler (string, queue, array, associative, enum,
-      value) still bakes in coercions the render rule should not know: (1) **Return-type coercion**
-      -- a method returning a native C++ type (container `size()` -> `size_t`, `getc` -> byte,
-      `atoi` family -> integer, `$isunknown` -> bit, enum `num` -> int) is wrapped to an SV value at
-      the call site. This should be an explicit MIR conversion node on the call result so the
-      backend stops fabricating the wrap. **Open design question (settle before coding)**: is a
-      `size_t`-to-SV-int wrap an SV-level `ConversionExpr`, or a representation bridge that belongs
-      to the runtime method's return type? The two give very different MIR -- cross-check
-      `decisions/` (integral-representation) before touching code. (2) **Argument coercion** --
-      string integral args (`SV int` -> `static_cast<int32>(ToInt64())`) and the enum next/prev step
-      are wrapped at the call site; same treatment as (1), a MIR conversion on the argument. (3)
-      **Non-member shapes** -- three families do not fit `(receiver).name(args)` at all and need
-      their own decision: enum static methods (`Class::first()`, no receiver), associative traversal
-      (`AssocFirst(services, recv, Ref<K>(idx))`, a free runtime call -- note its `self->Services()`
-      is still spliced, the one remaining services fabrication), and value `$isunknown`
-      (type-static, no call in the all-2-state case). Decide whether each stays a distinct handler
-      or is remodeled. Once (1)-(3) are resolved, the member-shaped families reduce to one handler
-      whose only per-kind input is the `kind -> member name` table. **Why deferred**: (1)/(2) are a
-      value-model decision (where representation wraps live), not a mechanical refactor.
-      **Trigger**: continuation of `decisions/runtime-effects-as-generic-calls.md`. Landed so far on
-      this thread -- user calls carry `self` as `arguments[0]`, and event trigger / triggered carry
-      the engine handle as a real argument; both now render through the generic rule with no
-      fabricated argument.
+      event family). **Value-model decision settled** (it was the blocker): an SV-facing runtime
+      method's return and parameter types _are_ the SV value types; the representation bridge lives
+      inside the method body, compiled once, an internal detail of the value layer. It is neither a
+      MIR `ConversionExpr` (the call's SV type does not change, so there is nothing to convert) nor
+      an emit-side wrap (forbidden by `decisions/integral-representation.md`: no native-scalar
+      bridges in emit). This follows from `mir.md` invariant 10 -- the backend reads the call's
+      stated result type and emits it, never re-deciding a representation. Internal native-count
+      callers use a separate `Raw*` accessor. **Landed on this thread**: the integral-query surface
+      (container `size`, associative `num` / `size` / `exists`, string `len` / `getc` / `compare` /
+      `atoi` family, enum `num`) and the integral-argument surface (string index / byte args, enum
+      next / prev step) now return / take SV value types directly; the member-shaped families
+      (string, array, queue, associative non-traversal, enum instance) render through one generic
+      handler whose only per-kind inputs are the member name and a mutates flag; all
+      `PackedArray::Int(...)` result wraps and `static_cast<...>(ToInt64())` argument casts are gone
+      from emit; user calls carry `self` and event trigger / triggered carry the engine handle as
+      real arguments. **Remaining**: three families do not fit `(receiver).name(args)` and still
+      need their own decision -- enum static methods (`Class::first()`, no receiver), associative
+      traversal (a free runtime call still splicing the engine handle, the one remaining services
+      fabrication), and value `$isunknown` (type-static, no call in the all-2-state case).
+      **Trigger**: continuation of `decisions/runtime-effects-as-generic-calls.md`.
 
 ## Out of Scope
 

--- a/include/lyra/value/associative_array.hpp
+++ b/include/lyra/value/associative_array.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <concepts>
-#include <cstddef>
-#include <functional>
 #include <iterator>
 #include <map>
 #include <optional>
@@ -86,18 +84,18 @@ class AssociativeArray {
   auto operator=(AssociativeArray&&) noexcept -> AssociativeArray& = default;
   ~AssociativeArray() = default;
 
-  // LRM 7.9.1: num() and size() both return the number of entries.
-  [[nodiscard]] auto Size() const -> std::size_t {
-    return data_.size();
+  // LRM 7.9.1: num() and size() both return the entry count as an SV int.
+  [[nodiscard]] auto Size() const -> PackedArray {
+    return PackedArray::Int(static_cast<std::int32_t>(data_.size()));
   }
 
-  // LRM 7.9.3: an element exists at this key. An invalid integral key never
+  // LRM 7.9.3: exists() yields an SV int 1 / 0. An invalid integral key never
   // matches an entry, so it reports absent.
-  [[nodiscard]] auto Exists(const K& key) const -> bool {
+  [[nodiscard]] auto Exists(const K& key) const -> PackedArray {
     if (IsInvalidKey(key)) {
-      return false;
+      return PackedArray::Int(0);
     }
-    return data_.contains(key);
+    return PackedArray::Int(data_.contains(key) ? 1 : 0);
   }
 
   // LRM 7.9.2: delete a single entry (no warning if absent) or, via the

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -127,7 +127,12 @@ class DynamicArray {
     swap(a.data_, b.data_);
   }
 
-  [[nodiscard]] auto Size() const -> std::size_t {
+  // LRM 7.5.1: size() yields an SV int.
+  [[nodiscard]] auto Size() const -> PackedArray {
+    return PackedArray::Int(static_cast<std::int32_t>(RawSize()));
+  }
+
+  [[nodiscard]] auto RawSize() const -> std::size_t {
     return data_.size();
   }
 
@@ -534,7 +539,7 @@ struct Formatter<DynamicArray<T>> {
   static auto Format(const FormatSpec& spec, const DynamicArray<T>& value)
       -> std::string {
     std::string out = "'{";
-    for (std::size_t i = 0; i < value.Size(); ++i) {
+    for (std::size_t i = 0; i < value.RawSize(); ++i) {
       if (i != 0) {
         out += ", ";
       }

--- a/include/lyra/value/enum.hpp
+++ b/include/lyra/value/enum.hpp
@@ -56,12 +56,15 @@ class Enum : public PackedArray {
     return {};
   }
 
-  [[nodiscard]] auto Next(unsigned step = 1) const -> Derived {
-    return StepBy(static_cast<std::int64_t>(step));
+  // LRM 6.19.5.3 / 6.19.5.4: the step is an SV int (default 1).
+  [[nodiscard]] auto Next(const PackedArray& step = PackedArray::Int(1)) const
+      -> Derived {
+    return StepBy(step.ToInt64());
   }
 
-  [[nodiscard]] auto Prev(unsigned step = 1) const -> Derived {
-    return StepBy(-static_cast<std::int64_t>(step));
+  [[nodiscard]] auto Prev(const PackedArray& step = PackedArray::Int(1)) const
+      -> Derived {
+    return StepBy(-step.ToInt64());
   }
 
   static auto First() -> Derived {
@@ -73,8 +76,10 @@ class Enum : public PackedArray {
     return Derived{MakeFromInt64(Derived::kMembers[kLastIdx].value)};
   }
 
-  static constexpr auto Num() -> std::int32_t {
-    return static_cast<std::int32_t>(std::size(Derived::kMembers));
+  // LRM 6.19.5.1: num() yields an SV int.
+  [[nodiscard]] static auto Num() -> PackedArray {
+    return PackedArray::Int(
+        static_cast<std::int32_t>(std::size(Derived::kMembers)));
   }
 
  private:

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -114,7 +114,12 @@ class Queue {
   }
   ~Queue() = default;
 
-  [[nodiscard]] auto Size() const -> std::size_t {
+  // LRM 7.10.2.1: size() yields an SV int.
+  [[nodiscard]] auto Size() const -> PackedArray {
+    return PackedArray::Int(static_cast<std::int32_t>(RawSize()));
+  }
+
+  [[nodiscard]] auto RawSize() const -> std::size_t {
     return data_.size();
   }
 
@@ -388,7 +393,7 @@ struct Formatter<Queue<T>> {
   static auto Format(const FormatSpec& spec, const Queue<T>& value)
       -> std::string {
     std::string out = "'{";
-    for (std::size_t i = 0; i < value.Size(); ++i) {
+    for (std::size_t i = 0; i < value.RawSize(); ++i) {
       if (i != 0) {
         out += ", ";
       }

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -37,8 +37,8 @@ class String {
   [[nodiscard]] static auto FromByteArray(
       const UnpackedArray<PackedArray>& bytes) -> String {
     std::string out;
-    out.reserve(bytes.Size());
-    for (std::size_t i = 0; i < bytes.Size(); ++i) {
+    out.reserve(bytes.RawSize());
+    for (std::size_t i = 0; i < bytes.RawSize(); ++i) {
       const auto byte =
           static_cast<unsigned char>(bytes.RawAt(i).ToInt64() & 0xFF);
       out.push_back(static_cast<char>(byte));
@@ -126,22 +126,28 @@ class String {
     return String{impl_ + o.impl_};
   }
 
-  // LRM 6.16.1
-  [[nodiscard]] auto Len() const -> std::int32_t {
-    return static_cast<std::int32_t>(impl_.size());
+  // LRM 6.16.1: len() yields an SV int.
+  [[nodiscard]] auto Len() const -> PackedArray {
+    return PackedArray::Int(static_cast<std::int32_t>(impl_.size()));
   }
 
   // LRM 6.16.2. Out-of-range index or zero byte -- no change.
-  void Putc(std::int32_t i, std::int8_t c) {
+  void Putc(const PackedArray& i_arg, const PackedArray& c_arg) {
+    const auto c = static_cast<std::int8_t>(c_arg.ToInt64());
     if (c == 0) return;
+    const auto i = i_arg.ToInt64();
     if (i < 0 || static_cast<std::size_t>(i) >= impl_.size()) return;
     impl_[static_cast<std::size_t>(i)] = static_cast<char>(c);
   }
 
-  // LRM 6.16.3. Out-of-range index returns 0.
-  [[nodiscard]] auto Getc(std::int32_t i) const -> std::int8_t {
-    if (i < 0 || static_cast<std::size_t>(i) >= impl_.size()) return 0;
-    return static_cast<std::int8_t>(impl_[static_cast<std::size_t>(i)]);
+  // LRM 6.16.3: getc() yields an SV byte. Out-of-range index returns 0.
+  [[nodiscard]] auto Getc(const PackedArray& i_arg) const -> PackedArray {
+    const auto i = i_arg.ToInt64();
+    if (i < 0 || static_cast<std::size_t>(i) >= impl_.size()) {
+      return PackedArray::Byte(0);
+    }
+    return PackedArray::Byte(
+        static_cast<std::int8_t>(impl_[static_cast<std::size_t>(i)]));
   }
 
   // LRM 6.16.4. Receiver unchanged.
@@ -162,47 +168,51 @@ class String {
     return String{std::move(out)};
   }
 
-  // LRM 6.16.6. ANSI C strcmp semantics: negative / zero / positive.
-  [[nodiscard]] auto Compare(const String& s) const -> std::int32_t {
+  // LRM 6.16.6: compare() yields an SV int. ANSI C strcmp semantics:
+  // negative / zero / positive.
+  [[nodiscard]] auto Compare(const String& s) const -> PackedArray {
     const int r = impl_.compare(s.impl_);
-    if (r < 0) return -1;
-    if (r > 0) return 1;
-    return 0;
+    if (r < 0) return PackedArray::Int(-1);
+    if (r > 0) return PackedArray::Int(1);
+    return PackedArray::Int(0);
   }
 
-  // LRM 6.16.7. Case-insensitive strcmp.
-  [[nodiscard]] auto Icompare(const String& s) const -> std::int32_t {
+  // LRM 6.16.7: icompare() yields an SV int. Case-insensitive strcmp.
+  [[nodiscard]] auto Icompare(const String& s) const -> PackedArray {
     const std::size_t n = std::min(impl_.size(), s.impl_.size());
     for (std::size_t k = 0; k < n; ++k) {
       const int a = std::tolower(static_cast<unsigned char>(impl_[k]));
       const int b = std::tolower(static_cast<unsigned char>(s.impl_[k]));
-      if (a != b) return (a < b) ? -1 : 1;
+      if (a != b) return PackedArray::Int((a < b) ? -1 : 1);
     }
-    if (impl_.size() == s.impl_.size()) return 0;
-    return (impl_.size() < s.impl_.size()) ? -1 : 1;
+    if (impl_.size() == s.impl_.size()) return PackedArray::Int(0);
+    return PackedArray::Int((impl_.size() < s.impl_.size()) ? -1 : 1);
   }
 
   // LRM 6.16.8. i..j inclusive. Returns "" if i<0, j<i, or j>=len.
-  [[nodiscard]] auto Substr(std::int32_t i, std::int32_t j) const -> String {
+  [[nodiscard]] auto Substr(
+      const PackedArray& i_arg, const PackedArray& j_arg) const -> String {
+    const auto i = static_cast<std::int32_t>(i_arg.ToInt64());
+    const auto j = static_cast<std::int32_t>(j_arg.ToInt64());
     const auto n = static_cast<std::int32_t>(impl_.size());
     if (i < 0 || j < i || j >= n) return String{};
     return String{impl_.substr(
         static_cast<std::size_t>(i), static_cast<std::size_t>(j - i + 1))};
   }
 
-  // LRM 6.16.9. Parse leading optional sign and digits (with `_` skipped).
-  // Returns 0 if no digits were consumed.
-  [[nodiscard]] auto Atoi() const -> std::int32_t {
-    return ParseInt(10);
+  // LRM 6.16.9: the ato* family yields an SV integer (4-state). Parse leading
+  // optional sign and digits (with `_` skipped); 0 if no digits were consumed.
+  [[nodiscard]] auto Atoi() const -> PackedArray {
+    return PackedArray::Integer(ParseInt(10));
   }
-  [[nodiscard]] auto Atohex() const -> std::int32_t {
-    return ParseInt(16);
+  [[nodiscard]] auto Atohex() const -> PackedArray {
+    return PackedArray::Integer(ParseInt(16));
   }
-  [[nodiscard]] auto Atooct() const -> std::int32_t {
-    return ParseInt(8);
+  [[nodiscard]] auto Atooct() const -> PackedArray {
+    return PackedArray::Integer(ParseInt(8));
   }
-  [[nodiscard]] auto Atobin() const -> std::int32_t {
-    return ParseInt(2);
+  [[nodiscard]] auto Atobin() const -> PackedArray {
+    return PackedArray::Integer(ParseInt(2));
   }
 
   // LRM 6.16.10. Parse leading real-number syntax; 0.0 if none.
@@ -218,10 +228,10 @@ class String {
   // representation of the argument in the corresponding base / format.
   // Out-of-line so std::format does not leak into every translation unit
   // that includes this header.
-  void Itoa(std::int32_t i);
-  void Hextoa(std::int32_t i);
-  void Octtoa(std::int32_t i);
-  void Bintoa(std::int32_t i);
+  void Itoa(const PackedArray& i);
+  void Hextoa(const PackedArray& i);
+  void Octtoa(const PackedArray& i);
+  void Bintoa(const PackedArray& i);
   void Realtoa(double r);
 
   [[nodiscard]] auto View() const -> std::string_view {

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -67,12 +67,18 @@ class UnpackedArray {
   auto operator=(UnpackedArray&&) noexcept -> UnpackedArray& = default;
   ~UnpackedArray() = default;
 
-  [[nodiscard]] auto Size() const -> std::size_t {
+  // LRM 7.4.2: size() yields an SV int.
+  [[nodiscard]] auto Size() const -> PackedArray {
+    return PackedArray::Int(static_cast<std::int32_t>(RawSize()));
+  }
+
+  [[nodiscard]] auto RawSize() const -> std::size_t {
     return data_.size();
   }
 
-  // Flat-storage element read. `i` is in [0, Size()); no SV-index translation,
-  // no invalid-index handling. Sole consumer is the aggregate-format path
+  // Flat-storage element read. `i` is in [0, RawSize()); no SV-index
+  // translation, no invalid-index handling. Sole consumer is the
+  // aggregate-format path
   // (`Formatter<UnpackedArray<T>>::Format`), which traverses storage to defer
   // each element to its own `Formatter` specialization. SV-semantics access
   // goes through `ElementAt(PackedArray)`.
@@ -283,7 +289,7 @@ struct Formatter<UnpackedArray<T>> {
   static auto Format(const FormatSpec& spec, const UnpackedArray<T>& value)
       -> std::string {
     std::string out = "'{";
-    for (std::size_t i = 0; i < value.Size(); ++i) {
+    for (std::size_t i = 0; i < value.RawSize(); ++i) {
       if (i != 0) {
         out += ", ";
       }

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -838,57 +838,29 @@ auto EventMethodMemberName(mir::EventMethodKind k) -> std::string_view {
   throw InternalError("EventMethodMemberName: unknown kind");
 }
 
-// LRM 6.19.5: first/last/num are static on the enum class; name/next/prev
-// dispatch on the receiver. num returns std::int32_t and wraps into the SV
-// `int` shape via PackedArray::Int.
+auto RenderMethodCall(
+    const RenderContext& ctx, const mir::CallExpr& call,
+    std::string_view member_name, bool mutates) -> diag::Result<std::string>;
+
+// LRM 6.19.5: first / last / num are static on the enum class (no receiver);
+// next / prev dispatch on the receiver and render through the generic method
+// call. num() yields the SV `int` shape from the runtime, so no wrap here; the
+// optional next / prev step is a plain SV argument the runtime takes by value.
 auto RenderEnumMethodCall(
     const RenderContext& ctx, const mir::CallExpr& call,
     const mir::EnumMethodInfo& m) -> diag::Result<std::string> {
   const auto member = EnumMethodMemberName(m.kind);
-  const auto class_name =
-      RenderEnumClassName(ctx.StructuralScope(), m.enum_type);
   const bool is_static = m.kind == mir::EnumMethodKind::kFirst ||
                          m.kind == mir::EnumMethodKind::kLast ||
                          m.kind == mir::EnumMethodKind::kNum;
-  const bool takes_step = m.kind == mir::EnumMethodKind::kNext ||
-                          m.kind == mir::EnumMethodKind::kPrev;
-  std::string raw_call;
   if (is_static) {
-    raw_call = std::format("{}::{}()", class_name, member);
-  } else {
-    if (call.arguments.empty()) {
-      throw InternalError(
-          "RenderEnumMethodCall: instance method expects a receiver "
-          "argument");
-    }
-    auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
-    if (!receiver_or) {
-      return std::unexpected(std::move(receiver_or.error()));
-    }
-    // next / prev have an optional step. Omitted at the SV call site ->
-    // omit at the C++ call site too; the Enum<Derived> method's default
-    // argument supplies 1.
-    std::string step_arg;
-    if (takes_step && call.arguments.size() >= 2) {
-      auto step_or = RenderExpr(ctx, ctx.Expr(call.arguments[1]));
-      if (!step_or) {
-        return std::unexpected(std::move(step_or.error()));
-      }
-      step_arg = std::format("static_cast<unsigned>(({}).ToInt64())", *step_or);
-    }
-    raw_call = std::format("({}).{}({})", *receiver_or, member, step_arg);
+    return std::format(
+        "{}::{}()", RenderEnumClassName(ctx.StructuralScope(), m.enum_type),
+        member);
   }
-  if (m.kind == mir::EnumMethodKind::kNum) {
-    return std::format("lyra::value::PackedArray::Int({})", raw_call);
-  }
-  return raw_call;
+  return RenderMethodCall(ctx, call, member, false);
 }
 
-// LRM 6.16: dispatch on the receiver (arguments[0]); subsequent SV args are
-// the method parameters. Integral-typed args (SV int / integer / byte) live
-// in a PackedArray at the call site and project to std::int32_t / std::int64_t
-// via ToInt64. Integral return values are wrapped back into the appropriate
-// PackedArray shape.
 // LRM 6.16: `Putc` and the integer-to-string family (`Itoa`, `Hextoa`,
 // `Octtoa`, `Bintoa`, `Realtoa`) mutate the receiver string in place.
 auto StringMethodMutatesReceiver(mir::StringMethodKind k) -> bool {
@@ -931,74 +903,24 @@ auto RenderMethodReceiver(
   return MethodReceiverText{.text = std::move(*receiver_or), .sep = "."};
 }
 
-auto RenderStringMethodCall(
-    const RenderContext& ctx, const mir::CallExpr& call,
-    const mir::StringMethodInfo& m) -> diag::Result<std::string> {
-  if (call.arguments.empty()) {
-    throw InternalError(
-        "RenderStringMethodCall: instance method expects a receiver "
-        "argument");
-  }
-  auto recv_or = RenderMethodReceiver(
-      ctx, ctx.Expr(call.arguments[0]), StringMethodMutatesReceiver(m.kind));
-  if (!recv_or) return std::unexpected(std::move(recv_or.error()));
-  const std::string& receiver_text = recv_or->text;
-  std::string args_text;
-  for (std::size_t i = 1; i < call.arguments.size(); ++i) {
-    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
-    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
-    const auto& arg_ty = ctx.Unit().GetType(ctx.Expr(call.arguments[i]).type);
-    std::string rendered = arg_ty.IsIntegralPacked()
-                               ? std::format(
-                                     "static_cast<std::int32_t>("
-                                     "({}).ToInt64())",
-                                     *arg_or)
-                               : std::move(*arg_or);
-    if (i > 1) args_text += ", ";
-    args_text += rendered;
-  }
-  const std::string raw_call = std::format(
-      "({}){}{}({})", receiver_text, recv_or->sep,
-      StringMethodMemberName(m.kind), args_text);
-  switch (m.kind) {
-    case mir::StringMethodKind::kLen:
-    case mir::StringMethodKind::kCompare:
-    case mir::StringMethodKind::kIcompare:
-      // Returns SV int (32-bit signed 2-state).
-      return std::format("lyra::value::PackedArray::Int({})", raw_call);
-    case mir::StringMethodKind::kGetc:
-      // Returns SV byte (8-bit signed 2-state).
-      return std::format("lyra::value::PackedArray::Byte({})", raw_call);
-    case mir::StringMethodKind::kAtoi:
-    case mir::StringMethodKind::kAtohex:
-    case mir::StringMethodKind::kAtooct:
-    case mir::StringMethodKind::kAtobin:
-      // Returns SV integer (32-bit signed 4-state).
-      return std::format("lyra::value::PackedArray::Integer({})", raw_call);
-    // Atoreal returns C++ double, matching SV real.
-    // Toupper / Tolower / Substr return lyra::value::String.
-    // Putc / Itoa / Hextoa / Octtoa / Bintoa / Realtoa are void.
-    default:
-      return raw_call;
-  }
-}
-
 // A method call renders generically as `(receiver).name(args)`: the receiver is
 // arguments[0]; every following argument renders uniformly. Nothing here is
 // method-family specific -- the only per-call input beyond the operands is the
-// member name, which the caller derives from the callee kind. Any engine handle
-// a method needs is one of the arguments, supplied by lowering.
+// member name and whether the call mutates its receiver. Any engine handle a
+// method needs, and any representation shaping of arguments or result, lives in
+// the runtime method's signature; the backend reads the call and emits it.
+// When `mutates` is set and the receiver is an observable cell, the receiver
+// routes through `Var<T>::Mutate(svc)` so the destructor commits once.
 auto RenderMethodCall(
     const RenderContext& ctx, const mir::CallExpr& call,
-    std::string_view member_name) -> diag::Result<std::string> {
+    std::string_view member_name, bool mutates) -> diag::Result<std::string> {
   if (call.arguments.empty()) {
     throw InternalError(
         "RenderMethodCall: a method call expects a receiver argument");
   }
-  auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
-  if (!receiver_or) {
-    return std::unexpected(std::move(receiver_or.error()));
-  }
+  auto recv_or =
+      RenderMethodReceiver(ctx, ctx.Expr(call.arguments[0]), mutates);
+  if (!recv_or) return std::unexpected(std::move(recv_or.error()));
   std::string args;
   for (std::size_t i = 1; i < call.arguments.size(); ++i) {
     auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
@@ -1006,47 +928,16 @@ auto RenderMethodCall(
     if (i != 1) args += ", ";
     args += *std::move(arg_or);
   }
-  return std::format("({}).{}({})", *receiver_or, member_name, args);
+  return std::format(
+      "({}){}{}({})", recv_or->text, recv_or->sep, member_name, args);
 }
 
-// LRM 7.5.2 / 7.5.3 / 7.12.2 / 7.12.3: dispatch on the receiver
-// (arguments[0]); none of the no-`with` methods in this PR take additional
-// arguments. `Size()` returns std::size_t and gets wrapped in
-// `PackedArray::Int` to land in SV `int` shape (mirrors EnumMethod::kNum).
-// All other methods either return void (in-place mutators) or already return
-// the receiver's element type (reductions); no wrap.
 // LRM 7.5.3 / 7.12.1: array methods that mutate the receiver in place. The
 // rest of the family is read-only (queries, reductions, locators).
 auto ArrayMethodMutatesReceiver(mir::ArrayMethodKind k) -> bool {
   return k == mir::ArrayMethodKind::kDelete ||
          k == mir::ArrayMethodKind::kReverse ||
          k == mir::ArrayMethodKind::kSort || k == mir::ArrayMethodKind::kRsort;
-}
-
-auto RenderArrayMethodCall(
-    const RenderContext& ctx, const mir::CallExpr& call,
-    const mir::ArrayMethodInfo& m) -> diag::Result<std::string> {
-  if (call.arguments.empty()) {
-    throw InternalError(
-        "RenderArrayMethodCall: array method expects a receiver argument");
-  }
-  auto recv_or = RenderMethodReceiver(
-      ctx, ctx.Expr(call.arguments[0]), ArrayMethodMutatesReceiver(m.kind));
-  if (!recv_or) return std::unexpected(std::move(recv_or.error()));
-  std::string args_text;
-  for (std::size_t i = 1; i < call.arguments.size(); ++i) {
-    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
-    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
-    if (i > 1) args_text += ", ";
-    args_text += *arg_or;
-  }
-  const std::string raw_call = std::format(
-      "({}){}{}({})", recv_or->text, recv_or->sep,
-      ArrayMethodMemberName(m.kind), args_text);
-  if (m.kind == mir::ArrayMethodKind::kSize) {
-    return std::format("lyra::value::PackedArray::Int({})", raw_call);
-  }
-  return raw_call;
 }
 
 auto QueueMethodMemberName(mir::QueueMethodKind k) -> std::string_view {
@@ -1094,41 +985,6 @@ auto QueueMethodMutatesReceiver(mir::QueueMethodKind k) -> bool {
       return true;
   }
   throw InternalError("QueueMethodMutatesReceiver: unknown kind");
-}
-
-// LRM 7.10.2 queue-native methods. The receiver is arguments[0] and any SV
-// method parameters follow as real C++ arguments, so the overload set on
-// `Queue<T>` resolves arity (`Delete()` vs `Delete(index)`) directly.
-auto RenderQueueMethodCall(
-    const RenderContext& ctx, const mir::CallExpr& call,
-    const mir::QueueMethodInfo& m) -> diag::Result<std::string> {
-  if (call.arguments.empty()) {
-    throw InternalError(
-        "RenderQueueMethodCall: queue method expects a receiver argument");
-  }
-  auto recv_or = RenderMethodReceiver(
-      ctx, ctx.Expr(call.arguments[0]), QueueMethodMutatesReceiver(m.kind));
-  if (!recv_or) return std::unexpected(std::move(recv_or.error()));
-  std::string args;
-  for (std::size_t i = 1; i < call.arguments.size(); ++i) {
-    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
-    if (!arg_or) {
-      return std::unexpected(std::move(arg_or.error()));
-    }
-    if (i != 1) {
-      args += ", ";
-    }
-    args += *arg_or;
-  }
-  const std::string member_call = std::format(
-      "({}){}{}({})", recv_or->text, recv_or->sep,
-      QueueMethodMemberName(m.kind), args);
-  // LRM 7.10.2.1: size() returns an int; wrap the C++ std::size_t in the
-  // runtime integral so it composes with the rest of the value model.
-  if (m.kind == mir::QueueMethodKind::kSize) {
-    return std::format("lyra::value::PackedArray::Int({})", member_call);
-  }
-  return member_call;
 }
 
 auto AssociativeMethodMemberName(mir::AssociativeMethodKind k)
@@ -1214,11 +1070,6 @@ auto RenderAssociativeTraversalCall(
 auto RenderAssociativeMethodCall(
     const RenderContext& ctx, const mir::CallExpr& call,
     const mir::AssociativeMethodInfo& m) -> diag::Result<std::string> {
-  if (call.arguments.empty()) {
-    throw InternalError(
-        "RenderAssociativeMethodCall: associative method expects a receiver "
-        "argument");
-  }
   if (auto traversal = AssociativeTraversalFunctionName(m.kind)) {
     return RenderAssociativeTraversalCall(ctx, call, *traversal);
   }
@@ -1226,29 +1077,8 @@ auto RenderAssociativeMethodCall(
   // read-only queries (traversal methods are routed above through a runtime
   // shim).
   const bool mutates = m.kind == mir::AssociativeMethodKind::kDelete;
-  auto recv_or =
-      RenderMethodReceiver(ctx, ctx.Expr(call.arguments[0]), mutates);
-  if (!recv_or) return std::unexpected(std::move(recv_or.error()));
-  std::string args;
-  for (std::size_t i = 1; i < call.arguments.size(); ++i) {
-    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
-    if (!arg_or) {
-      return std::unexpected(std::move(arg_or.error()));
-    }
-    if (i != 1) {
-      args += ", ";
-    }
-    args += *arg_or;
-  }
-  const std::string member_call = std::format(
-      "({}){}{}({})", recv_or->text, recv_or->sep,
-      AssociativeMethodMemberName(m.kind), args);
-  // LRM 7.9.1 / 7.9.3: num / size / exists yield an int; wrap the C++
-  // std::size_t / bool in the runtime integral. delete returns void.
-  if (m.kind != mir::AssociativeMethodKind::kDelete) {
-    return std::format("lyra::value::PackedArray::Int({})", member_call);
-  }
-  return member_call;
+  return RenderMethodCall(
+      ctx, call, AssociativeMethodMemberName(m.kind), mutates);
 }
 
 // Side-effect-free per-value queries. Dispatch by the receiver's MIR
@@ -1450,17 +1280,23 @@ auto RenderCallExpr(
                       return RenderEnumMethodCall(ctx, call, m);
                     },
                     [&](const mir::StringMethodInfo& m) {
-                      return RenderStringMethodCall(ctx, call, m);
+                      return RenderMethodCall(
+                          ctx, call, StringMethodMemberName(m.kind),
+                          StringMethodMutatesReceiver(m.kind));
                     },
                     [&](const mir::EventMethodInfo& m) {
                       return RenderMethodCall(
-                          ctx, call, EventMethodMemberName(m.kind));
+                          ctx, call, EventMethodMemberName(m.kind), false);
                     },
                     [&](const mir::ArrayMethodInfo& m) {
-                      return RenderArrayMethodCall(ctx, call, m);
+                      return RenderMethodCall(
+                          ctx, call, ArrayMethodMemberName(m.kind),
+                          ArrayMethodMutatesReceiver(m.kind));
                     },
                     [&](const mir::QueueMethodInfo& m) {
-                      return RenderQueueMethodCall(ctx, call, m);
+                      return RenderMethodCall(
+                          ctx, call, QueueMethodMemberName(m.kind),
+                          QueueMethodMutatesReceiver(m.kind));
                     },
                     [&](const mir::AssociativeMethodInfo& m) {
                       return RenderAssociativeMethodCall(ctx, call, m);

--- a/src/lyra/runtime/file_io.cpp
+++ b/src/lyra/runtime/file_io.cpp
@@ -308,7 +308,7 @@ auto LyraFRead(
     Stamp(services, fd, EBADF, "$fread: file not open for reading");
     return MakeInt(0);
   }
-  if (dest.Size() == 0U) return MakeInt(0);
+  if (dest.RawSize() == 0U) return MakeInt(0);
 
   const bool ascending = declared_left <= declared_right;
   const auto lowest_sv = std::min(declared_left, declared_right);

--- a/src/lyra/value/string.cpp
+++ b/src/lyra/value/string.cpp
@@ -5,20 +5,20 @@
 
 namespace lyra::value {
 
-void String::Itoa(std::int32_t i) {
-  impl_ = std::format("{}", i);
+void String::Itoa(const PackedArray& i) {
+  impl_ = std::format("{}", static_cast<std::int32_t>(i.ToInt64()));
 }
 
-void String::Hextoa(std::int32_t i) {
-  impl_ = std::format("{:x}", static_cast<std::uint32_t>(i));
+void String::Hextoa(const PackedArray& i) {
+  impl_ = std::format("{:x}", static_cast<std::uint32_t>(i.ToInt64()));
 }
 
-void String::Octtoa(std::int32_t i) {
-  impl_ = std::format("{:o}", static_cast<std::uint32_t>(i));
+void String::Octtoa(const PackedArray& i) {
+  impl_ = std::format("{:o}", static_cast<std::uint32_t>(i.ToInt64()));
 }
 
-void String::Bintoa(std::int32_t i) {
-  impl_ = std::format("{:b}", static_cast<std::uint32_t>(i));
+void String::Bintoa(const PackedArray& i) {
+  impl_ = std::format("{:b}", static_cast<std::uint32_t>(i.ToInt64()));
 }
 
 void String::Realtoa(double r) {


### PR DESCRIPTION
## Summary

An SV-facing runtime method's return and parameter types are now the SV value types themselves, not native C++ scalars. The integral query surface (container `size`, associative `num` / `size` / `exists`, string `len` / `getc` / `compare` / `icompare` / `atoi` family, enum `num`) returns `PackedArray`, and the integral argument surface (string index / byte args, enum `next` / `prev` step) takes `PackedArray`. The C++ backend stops fabricating the representation: every `PackedArray::Int(...)` result wrap and `static_cast<...>(ToInt64())` argument cast is gone from emit, and the string / array / queue / associative (non-traversal) / enum-instance method handlers collapse onto one generic `(receiver).name(args)` renderer whose only per-kind inputs are the member name and a mutates flag.

## Design

This follows from `mir.md` invariant 10 and `decisions/integral-representation.md`: the backend reads a call's stated result type and emits it, never re-deciding a representation, and emit carries no native-scalar bridges. The representation conversion lives inside the runtime method body, compiled once, an internal detail of the value layer. It is neither a MIR `ConversionExpr` (the call's SV type does not change, so there is nothing to convert) nor an emit-side wrap. Internal native-count callers (the aggregate formatters, `$fread`) use a separate `RawSize` accessor, mirroring the existing `RawAt`.

## Testing

`bazel test //...` -- full suite green, including the end-to-end `cpp_tests` that compile and run the emitted C++ for the queue / array / string / enum / associative method families. The change is behavior-preserving.