### PR TITLE
Add LRM 7.12 array methods on queue receivers

### DIFF
--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -27,10 +27,11 @@ follow once dynamic array's storage and runtime conventions are settled and prov
 | DA5  | Open: constant-width slice (subject to LRM check).                      |
 | DA6a | Done: method dispatch + no-`with` subset.                               |
 | DA6b | Done: `with` clause + iterator on sort / rsort / reduction methods.     |
-| DA6c | Open: locator family (find\*, min, max, unique\*).                      |
+| DA6c | Done: locator family (find\*, min, max, unique\*).                      |
 | DA7  | Open: invalid-index handling.                                           |
 | Q1   | Done: type, element read/write, native methods, default, case-equality. |
 | Q2   | Done: operator surface (`$`, slice, concat, equality, bound, append).   |
+| Q3   | Done: array-manipulation method family (LRM 7.12).                      |
 | A1   | Done: string / integral index, element read / write, query methods.     |
 | A2   | Done: traversal protocol (`first` / `last` / `next` / `prev`).          |
 | A3   | Done: `foreach` over an associative array (any dimensionality).         |
@@ -98,18 +99,16 @@ The numeric IDs are stable references and do not imply execution order beyond DA
       Slang gates element-type constraints upstream (integral element for reductions, comparable for
       sort).
 
-- [x] DA6b -- `with`-clause variants of the methods that accept one (`sort`, `rsort`, reductions),
-      plus the LRM 7.12.4 `item.index` iterator method. AST -> HIR consumes slang's
-      `IteratorCallInfo` and binds the iterator HIR id; HIR -> MIR synthesises a `mir::ClosureExpr`
-      using main's existing `CaptureSink` (so non-iterator outer reads in the body become
-      by-reference captures automatically) and adds parameter bindings for `item` and `index`. The
-      backend renders the closure as a lambda-with-captures and routes the call to the runtime's
-      `*By` overloads.
+- [x] DA6b -- The `with`-clause variants of the methods that accept one (`sort`, `rsort`, and the
+      reductions), plus the LRM 7.12.4 `item.index` iterator method. The `with` expression is
+      evaluated as a closure over each element and its index; an outer variable read inside the body
+      is captured by reference so the body observes live values, and an omitted `with` clause
+      applies the LRM-default `with (item)`.
 
-- [ ] DA6c -- The locator-family methods that return an index or element queue (`find` family,
-      `min`, `max`, `unique`, `unique_index`). The queue return container now exists (see Queue
-      below). `shuffle()` (needs RNG model) and `map()` (SV2023, needs `with` infra + version gate)
-      are standalone follow-ups after DA6c lands.
+- [x] DA6c -- The locator-family methods that return an index or element queue (`find` family,
+      `min`, `max`, `unique`, `unique_index`), including the optional `with` clause for `min` /
+      `max` / `unique`. `shuffle()` (needs RNG model) and `map()` (SV2023, needs a version gate) are
+      standalone follow-ups.
 
 - [ ] DA7 -- Invalid-index handling. Read on an out-of-range index returns the element type's LRM
       Table 7-1 default; write on an out-of-range index is a silent no-op; X / Z bits in the index
@@ -136,6 +135,16 @@ optional right bound (`q[$:N]`).
       equality operators (`==` / `!=` / `===` / `!==`); bounded-queue discard with a warning (LRM
       7.10.5); and the legal append write `q[$+1] = v` (LRM 7.10.1). One narrow form remains open:
       an unpacked concatenation whose result is a dynamic or fixed array rather than a queue.
+
+- [x] Q3 -- The array-manipulation method family (LRM 7.12) on a queue receiver, available because a
+      queue supports every unpacked-array operation (LRM 7.10.1). The ordering family (`reverse`,
+      `sort`, `rsort`), the reduction family (`sum`, `product`, `and`, `or`, `xor`), and the locator
+      family (`find` and its variants, `min`, `max`, `unique`, `unique_index`), each with the
+      optional / mandatory `with` clause per LRM 7.12.1 -- 7.12.3 and the `item.index` iterator (LRM
+      7.12.4). Locator methods return a queue of elements or of `int` per LRM 7.12.1; reduction
+      result width follows the `with`-expression type. The semantics and the `with`-clause closure
+      are the same as for the dynamic-array receiver; `shuffle` and `map` remain the shared
+      follow-ups noted under DA6c.
 
 ## Associative Array
 

--- a/docs/progress/unpacked.md
+++ b/docs/progress/unpacked.md
@@ -14,7 +14,7 @@ Done when:
 ## Actionable
 
 U1..U7 are done. U8 records a cross-cutting observability gap surfaced by the unpacked-vs-packed
-asymmetry; the implementation lives under `refactor.md` R2.
+asymmetry; the implementation lives under `refactor.md` R2. U9 records the array-manipulation gap.
 
 | Item | Status                                                         |
 | ---- | -------------------------------------------------------------- |
@@ -26,6 +26,7 @@ asymmetry; the implementation lives under `refactor.md` R2.
 | U6   | Done: constant-width slice (read and write)                    |
 | U7   | Done: invalid-index handling and non-canonical declared ranges |
 | U8   | Open: unpacked vars participate in value-change observability  |
+| U9   | Open: array manipulation methods (LRM 7.12)                    |
 
 ## Sub-Steps
 
@@ -105,11 +106,24 @@ The numeric IDs are stable references and do not imply execution order beyond U1
       item exists for visibility from the unpacked workstream. Triggered when a concrete consumer
       needs the capability.
 
+### Array manipulation methods
+
+- [ ] U9 -- Array manipulation methods (LRM 7.12) on fixed-size unpacked arrays: the ordering family
+      (`reverse`, `sort`, `rsort`), the reduction family (`sum`, `product`, `and`, `or`, `xor`), and
+      the locator family (`find` and its variants, `min`, `max`, `unique`, `unique_index`), with the
+      optional / mandatory `with` clause per LRM 7.12.1 -- 7.12.3 and the `item.index` iterator (LRM
+      7.12.4). LRM 7.12 defines these uniformly for any unpacked array (fixed or dynamically sized)
+      except associative; today the family is wired only for dynamic array and queue receivers, so a
+      fixed unpacked receiver (`int arr[5]; arr.sort();`) is not yet accepted. The method semantics
+      and the shared element-walking algorithms already exist; closing this needs the fixed-unpacked
+      receiver routed into the same family plus the thin per-container method surface.
+
 ## Cross-references
 
 - LRM anchors: 7.4.2 (Unpacked arrays), 7.4.4 (Multidimensional arrays), 7.4.5 (Indexing and
-  slicing), 7.4.6 (Operations on arrays), 7.6 (Array assignments), 10.9 (Assignment patterns), Table
-  6-7 (Default initial values), Table 7-1 (Value read from a nonexistent array entry).
+  slicing), 7.4.6 (Operations on arrays), 7.6 (Array assignments), 7.12 (Array manipulation
+  methods), 10.9 (Assignment patterns), Table 6-7 (Default initial values), Table 7-1 (Value read
+  from a nonexistent array entry).
 - Archive items: `datatypes/unpacked/{unpacked_arrays, unpacked_array_constants}`, the unpacked
   subset of `oob_bounds`.
 - Decision: `../decisions/unpacked-array-representation.md`.

--- a/include/lyra/value/array_manipulation.hpp
+++ b/include/lyra/value/array_manipulation.hpp
@@ -1,0 +1,274 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "lyra/value/packed_array.hpp"
+
+// LRM 7.12 array manipulation algorithms, shared by every indexable sequence
+// container (dynamic array, queue, and -- when wired -- fixed unpacked array).
+// The algorithms read the receiver only through `data[i]` and `data.size()`, so
+// one template body serves `std::vector` and `std::deque` element storage
+// alike. Each container exposes the LRM-named methods as thin wrappers over
+// these; the value/index shaping (a result queue of elements vs of `int`) is
+// the container's concern, so the algorithms return a plain `std::vector` or a
+// scalar and never name a container type.
+namespace lyra::value::detail {
+
+// LRM 7.12.1 locator comparison over a key type (the element itself for the
+// no-`with` form, or the `with`-expression result otherwise). `PackedArray`
+// returns a 1-bit truth value whose X/Z collapses to false in a boolean
+// context; `String` / `double` return a plain `bool`.
+template <typename K>
+[[nodiscard]] auto LocatorKeyLess(const K& a, const K& b) -> bool {
+  return static_cast<bool>(a < b);
+}
+
+// Uniqueness equality. 4-state integral keys compare bit-exact (LRM 11.4.5
+// `===`), so two X-valued keys are the same value while X never equals a known
+// bit; non-integral keys have no unknown plane and use value equality.
+template <typename K>
+[[nodiscard]] auto LocatorKeySame(const K& a, const K& b) -> bool {
+  if constexpr (std::is_same_v<K, PackedArray>) {
+    return static_cast<bool>(a.CaseEqual(b));
+  } else {
+    return a.IsBitIdentical(b);
+  }
+}
+
+// The per-element index handed to every `with`-clause closure. A `PackedArray`
+// so `item.index` reads as a regular integral value in SV semantics (LRM
+// 7.12.4).
+[[nodiscard]] inline auto LocatorIndex(std::size_t i) -> PackedArray {
+  return PackedArray::Int(static_cast<int>(i));
+}
+
+template <typename Seq>
+[[nodiscard]] auto ElementsAtIndices(
+    const Seq& data, const std::vector<std::size_t>& indices)
+    -> std::vector<typename Seq::value_type> {
+  std::vector<typename Seq::value_type> out;
+  out.reserve(indices.size());
+  for (std::size_t i : indices) {
+    out.push_back(data[i]);
+  }
+  return out;
+}
+
+[[nodiscard]] inline auto IndicesAsPacked(
+    const std::vector<std::size_t>& indices) -> std::vector<PackedArray> {
+  std::vector<PackedArray> out;
+  out.reserve(indices.size());
+  for (std::size_t i : indices) {
+    out.push_back(LocatorIndex(i));
+  }
+  return out;
+}
+
+enum class LocatorScan : std::uint8_t { kAll, kFirst, kLast };
+
+// LRM 7.12.1 find family core: positions satisfying `pred`, collecting every
+// match (`kAll`), the leftmost (`kFirst`), or the rightmost (`kLast`).
+template <typename Seq, typename F>
+[[nodiscard]] auto MatchingIndices(const Seq& data, F& pred, LocatorScan scan)
+    -> std::vector<std::size_t> {
+  std::vector<std::size_t> out;
+  if (scan == LocatorScan::kLast) {
+    for (std::size_t i = data.size(); i-- > 0;) {
+      if (static_cast<bool>(pred(data[i], LocatorIndex(i)))) {
+        out.push_back(i);
+        break;
+      }
+    }
+    return out;
+  }
+  for (std::size_t i = 0; i < data.size(); ++i) {
+    if (static_cast<bool>(pred(data[i], LocatorIndex(i)))) {
+      out.push_back(i);
+      if (scan == LocatorScan::kFirst) {
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+// LRM 7.12.1 min / max core: the single position whose key the `prefer`
+// comparator ranks first. Empty receiver yields no position.
+template <typename Seq, typename F, typename Prefer>
+[[nodiscard]] auto ExtremumIndex(const Seq& data, F& key, Prefer prefer)
+    -> std::vector<std::size_t> {
+  std::vector<std::size_t> out;
+  if (!data.empty()) {
+    std::size_t pick = 0;
+    auto best = key(data[0], LocatorIndex(0));
+    for (std::size_t i = 1; i < data.size(); ++i) {
+      auto k = key(data[i], LocatorIndex(i));
+      if (prefer(k, best)) {
+        best = k;
+        pick = i;
+      }
+    }
+    out.push_back(pick);
+  }
+  return out;
+}
+
+template <typename K>
+[[nodiscard]] auto SeenContains(const std::vector<K>& seen, const K& k)
+    -> bool {
+  for (const auto& s : seen) {
+    if (LocatorKeySame(k, s)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// LRM 7.12.1 unique / unique_index core: the position of the first occurrence
+// of each distinct key value, in first-seen order.
+template <typename Seq, typename F>
+[[nodiscard]] auto UniqueRepresentativeIndices(const Seq& data, F& key)
+    -> std::vector<std::size_t> {
+  using KeyT = std::invoke_result_t<
+      F&, const typename Seq::value_type&, const PackedArray&>;
+  std::vector<std::size_t> out;
+  std::vector<KeyT> seen;
+  for (std::size_t i = 0; i < data.size(); ++i) {
+    auto k = key(data[i], LocatorIndex(i));
+    if (!SeenContains(seen, k)) {
+      seen.push_back(k);
+      out.push_back(i);
+    }
+  }
+  return out;
+}
+
+template <typename Seq, typename F>
+[[nodiscard]] auto ArrayFind(const Seq& data, F pred)
+    -> std::vector<typename Seq::value_type> {
+  return ElementsAtIndices(
+      data, MatchingIndices(data, pred, LocatorScan::kAll));
+}
+template <typename Seq, typename F>
+[[nodiscard]] auto ArrayFindIndex(const Seq& data, F pred)
+    -> std::vector<PackedArray> {
+  return IndicesAsPacked(MatchingIndices(data, pred, LocatorScan::kAll));
+}
+template <typename Seq, typename F>
+[[nodiscard]] auto ArrayFindFirst(const Seq& data, F pred)
+    -> std::vector<typename Seq::value_type> {
+  return ElementsAtIndices(
+      data, MatchingIndices(data, pred, LocatorScan::kFirst));
+}
+template <typename Seq, typename F>
+[[nodiscard]] auto ArrayFindFirstIndex(const Seq& data, F pred)
+    -> std::vector<PackedArray> {
+  return IndicesAsPacked(MatchingIndices(data, pred, LocatorScan::kFirst));
+}
+template <typename Seq, typename F>
+[[nodiscard]] auto ArrayFindLast(const Seq& data, F pred)
+    -> std::vector<typename Seq::value_type> {
+  return ElementsAtIndices(
+      data, MatchingIndices(data, pred, LocatorScan::kLast));
+}
+template <typename Seq, typename F>
+[[nodiscard]] auto ArrayFindLastIndex(const Seq& data, F pred)
+    -> std::vector<PackedArray> {
+  return IndicesAsPacked(MatchingIndices(data, pred, LocatorScan::kLast));
+}
+
+template <typename Seq, typename F>
+[[nodiscard]] auto ArrayMin(const Seq& data, F key)
+    -> std::vector<typename Seq::value_type> {
+  return ElementsAtIndices(
+      data, ExtremumIndex(data, key, [](const auto& a, const auto& b) {
+        return LocatorKeyLess(a, b);
+      }));
+}
+template <typename Seq, typename F>
+[[nodiscard]] auto ArrayMax(const Seq& data, F key)
+    -> std::vector<typename Seq::value_type> {
+  return ElementsAtIndices(
+      data, ExtremumIndex(data, key, [](const auto& a, const auto& b) {
+        return LocatorKeyLess(b, a);
+      }));
+}
+template <typename Seq, typename F>
+[[nodiscard]] auto ArrayUnique(const Seq& data, F key)
+    -> std::vector<typename Seq::value_type> {
+  return ElementsAtIndices(data, UniqueRepresentativeIndices(data, key));
+}
+template <typename Seq, typename F>
+[[nodiscard]] auto ArrayUniqueIndex(const Seq& data, F key)
+    -> std::vector<PackedArray> {
+  return IndicesAsPacked(UniqueRepresentativeIndices(data, key));
+}
+
+// LRM 7.12.2 reverse: in-place reversal. `iter_swap` exchanges element storage
+// through the element type's ADL `swap`, which stays shape-safe for
+// `PackedArray`.
+template <typename Seq>
+auto ArrayReverse(Seq& data) -> void {
+  std::ranges::reverse(data);
+}
+
+// LRM 7.12.2 sort / rsort: in-place ordering by the closure-projected key.
+// Selection sort (O(n^2)) rather than `std::ranges::sort` because libstdc++'s
+// introsort move-assigns elements, which trips `PackedArray`'s
+// shape-preservation invariant; exchanging storage via the ADL `swap` stays
+// shape-safe, and test-sized arrays make the asymptotic cost a non-issue. The
+// per-element key is materialised once, then the elements move in sync.
+template <typename Seq, typename F, typename Compare>
+auto ArraySortByKey(Seq& data, F key, Compare cmp) -> void {
+  using KeyT = std::invoke_result_t<
+      F&, const typename Seq::value_type&, const PackedArray&>;
+  std::vector<KeyT> keys;
+  keys.reserve(data.size());
+  for (std::size_t i = 0; i < data.size(); ++i) {
+    keys.push_back(key(data[i], LocatorIndex(i)));
+  }
+  using std::swap;
+  for (std::size_t i = 0; i + 1 < data.size(); ++i) {
+    std::size_t pick = i;
+    for (std::size_t j = i + 1; j < data.size(); ++j) {
+      if (static_cast<bool>(cmp(keys[j], keys[pick]))) {
+        pick = j;
+      }
+    }
+    if (pick != i) {
+      swap(keys[i], keys[pick]);
+      swap(data[i], data[pick]);
+    }
+  }
+}
+
+// LRM 7.12.3 reduction: fold the closure-projected values with `combine`. The
+// result type follows the closure's return type, so a width-widening
+// `with`-expression (`sum with (int'(item))`) widens the result (LRM 7.12.3).
+// An empty receiver yields the closure-shaped zero (slang behaviour; LRM is
+// silent), synthesised from the element shield slot.
+template <typename Seq, typename T, typename F, typename Combine>
+[[nodiscard]] auto ArrayFold(
+    const Seq& data, const T& oob_slot, F key, Combine combine)
+    -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+  if (data.empty()) {
+    T zero = oob_slot;
+    zero.ResetToDefault();
+    auto acc = key(zero, LocatorIndex(0));
+    acc.ResetToDefault();
+    return acc;
+  }
+  auto acc = key(data[0], LocatorIndex(0));
+  for (std::size_t i = 1; i < data.size(); ++i) {
+    auto v = key(data[i], LocatorIndex(i));
+    combine(acc, v);
+  }
+  return acc;
+}
+
+}  // namespace lyra::value::detail

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -12,37 +11,13 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/value/array_case_equal.hpp"
+#include "lyra/value/array_manipulation.hpp"
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/queue.hpp"
 #include "lyra/value/value_concept.hpp"
 
 namespace lyra::value {
-
-namespace detail {
-
-// LRM 7.12.1 locator comparisons over a key type (the element itself for the
-// no-`with` form, or the `with`-expression result otherwise). `PackedArray`
-// returns a 1-bit truth value whose X/Z collapses to false in a boolean
-// context; `String` / `double` return a plain `bool`.
-template <typename K>
-[[nodiscard]] auto LocatorKeyLess(const K& a, const K& b) -> bool {
-  return static_cast<bool>(a < b);
-}
-
-// Uniqueness equality. 4-state integral keys compare bit-exact (LRM 11.4.5
-// `===`), so two X-valued keys are the same value while X never equals a
-// known bit; non-integral keys have no unknown plane and use value equality.
-template <typename K>
-[[nodiscard]] auto LocatorKeySame(const K& a, const K& b) -> bool {
-  if constexpr (std::is_same_v<K, PackedArray>) {
-    return static_cast<bool>(a.CaseEqual(b));
-  } else {
-    return a.IsBitIdentical(b);
-  }
-}
-
-}  // namespace detail
 
 // SystemVerilog dynamic array (LRM 7.5). Size set at run time via `new[N]` /
 // `new[N](other)` constructors; default is the empty array (LRM Table 6-7).
@@ -239,287 +214,117 @@ class DynamicArray {
     data_.clear();
   }
 
-  // LRM 7.12.2 reverse: in-place reversal; `with` clause is a compiler
-  // error and is filtered upstream by slang.
+  // LRM 7.12 ordering and reduction, each a thin wrapper over the shared
+  // `detail::Array*` algorithms. HIR-to-MIR always supplies the closure (the
+  // `with`-clause body or the LRM-default identity), so the runtime exposes
+  // only the closure-taking form; `reverse` takes none -- its `with` clause is
+  // a compiler error filtered upstream by slang. The closure receives each
+  // element and its index and returns a key (ordering) or a summand
+  // (reduction); the reduction result type follows the closure's return type,
+  // so a width-widening `with`-expression widens the result.
   auto Reverse() -> void {
-    std::ranges::reverse(data_);
+    detail::ArrayReverse(data_);
   }
-
-  // LRM 7.12.2 sort / rsort: in-place ordering using the element type's
-  // relational operators. Slang upstream rejects element types lacking
-  // `<`/`>`/`==`. PackedArray::operator< returns a 1-bit PackedArray
-  // truth value whose explicit bool conversion is the sort comparator.
-  //
-  // Selection sort is used (O(n^2)) rather than std::ranges::sort because
-  // libstdc++'s introsort uses `tmp = std::move(arr[i])` during insertion
-  // sort, which empties arr[i] and breaks PackedArray's
-  // shape-preservation invariant on the subsequent `arr[i] = std::move(...)`.
-  // LRM 7.12.1 / 7.12.2 / 7.12.3. Each method takes a closure (`with`-clause
-  // body or the LRM-default identity); HIR-to-MIR always supplies one, so
-  // the runtime exposes exactly the closure-taking form. Ordering uses
-  // selection sort: storage exchange via the ADL friend swap stays shape-
-  // safe, and test-sized arrays make the asymptotic cost a non-issue.
-  // Reductions fold the element-type operator over the closure-projected
-  // values; the closure receives each element and its index and returns a
-  // key (for ordering) or a summand (for reduction). The closure's result
-  // type is the inferred template parameter R; for reductions R must be
-  // element-shape (slang accepts width-widening with-expressions, which the
-  // closure body synthesises via ConversionExpr at HIR -> MIR). PackedArray
-  // is used as the index type so the user-facing `item.index` reads as a
-  // regular integral value in SV semantics. Empty-array reduction yields the
-  // element-shape zero (slang behaviour; LRM is silent).
   template <typename F>
   auto Sort(F&& key) -> void {
-    SelectionSortByKey(std::forward<F>(key), std::less<>{});
+    detail::ArraySortByKey(data_, std::forward<F>(key), std::less<>{});
   }
   template <typename F>
   auto Rsort(F&& key) -> void {
-    SelectionSortByKey(std::forward<F>(key), std::greater<>{});
+    detail::ArraySortByKey(data_, std::forward<F>(key), std::greater<>{});
   }
   template <typename F>
   [[nodiscard]] auto Sum(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
-    return FoldBy(
-        std::forward<F>(key), [](auto& acc, auto& v) { acc = acc + v; });
+    return detail::ArrayFold(
+        data_, oob_slot_, std::forward<F>(key),
+        [](auto& acc, auto& v) { acc = acc + v; });
   }
   template <typename F>
   [[nodiscard]] auto Product(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
-    return FoldBy(
-        std::forward<F>(key), [](auto& acc, auto& v) { acc = acc * v; });
+    return detail::ArrayFold(
+        data_, oob_slot_, std::forward<F>(key),
+        [](auto& acc, auto& v) { acc = acc * v; });
   }
   template <typename F>
   [[nodiscard]] auto And(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
-    return FoldBy(
-        std::forward<F>(key), [](auto& acc, auto& v) { acc = acc & v; });
+    return detail::ArrayFold(
+        data_, oob_slot_, std::forward<F>(key),
+        [](auto& acc, auto& v) { acc = acc & v; });
   }
   template <typename F>
   [[nodiscard]] auto Or(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
-    return FoldBy(
-        std::forward<F>(key), [](auto& acc, auto& v) { acc = acc | v; });
+    return detail::ArrayFold(
+        data_, oob_slot_, std::forward<F>(key),
+        [](auto& acc, auto& v) { acc = acc | v; });
   }
   template <typename F>
   [[nodiscard]] auto Xor(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
-    return FoldBy(
-        std::forward<F>(key), [](auto& acc, auto& v) { acc = acc ^ v; });
+    return detail::ArrayFold(
+        data_, oob_slot_, std::forward<F>(key),
+        [](auto& acc, auto& v) { acc = acc ^ v; });
   }
 
-  // LRM 7.12.1 locator methods. Each returns a queue: the value locators
-  // (`find`, `find_first`, `find_last`, `min`, `max`, `unique`) return a
-  // queue of elements; the index locators (`find_index`, ...) return a queue
-  // of `int`. No match or an empty receiver yields an empty queue. The `with`
-  // clause is mandatory for the find family (a Boolean predicate) and
-  // optional for `min` / `max` / `unique` (a comparison key; omitted means the
-  // element itself). The closure receives each element and its index, matching
-  // the ordering / reduction `*By` convention above.
-
+  // LRM 7.12.1 locator methods, thin wrappers over the shared `detail::Array*`
+  // algorithms. The value locators (`find`, `find_first`, `find_last`, `min`,
+  // `max`, `unique`) return a queue of elements carrying this array's element
+  // shape via `oob_slot_`; the index locators return a queue of `int` whose
+  // shield is a plain zero. No match or an empty receiver yields an empty
+  // queue. The `with` clause is mandatory for the find family (a Boolean
+  // predicate) and optional for `min` / `max` / `unique` (a comparison key,
+  // defaulting to the element).
   template <typename F>
   [[nodiscard]] auto Find(F pred) const -> Queue<T> {
-    std::vector<T> out;
-    for (std::size_t i = 0; i < data_.size(); ++i) {
-      if (static_cast<bool>(
-              pred(data_[i], PackedArray::Int(static_cast<int>(i))))) {
-        out.push_back(data_[i]);
-      }
-    }
-    return Queue<T>(oob_slot_, out);
+    return Queue<T>(oob_slot_, detail::ArrayFind(data_, std::move(pred)));
   }
-
   template <typename F>
   [[nodiscard]] auto FindIndex(F pred) const -> Queue<PackedArray> {
-    std::vector<PackedArray> out;
-    for (std::size_t i = 0; i < data_.size(); ++i) {
-      if (static_cast<bool>(
-              pred(data_[i], PackedArray::Int(static_cast<int>(i))))) {
-        out.push_back(PackedArray::Int(static_cast<int>(i)));
-      }
-    }
-    return {PackedArray::Int(0), out};
+    return {
+        PackedArray::Int(0), detail::ArrayFindIndex(data_, std::move(pred))};
   }
-
   template <typename F>
   [[nodiscard]] auto FindFirst(F pred) const -> Queue<T> {
-    std::vector<T> out;
-    for (std::size_t i = 0; i < data_.size(); ++i) {
-      if (static_cast<bool>(
-              pred(data_[i], PackedArray::Int(static_cast<int>(i))))) {
-        out.push_back(data_[i]);
-        break;
-      }
-    }
-    return Queue<T>(oob_slot_, out);
+    return Queue<T>(oob_slot_, detail::ArrayFindFirst(data_, std::move(pred)));
   }
-
   template <typename F>
   [[nodiscard]] auto FindFirstIndex(F pred) const -> Queue<PackedArray> {
-    std::vector<PackedArray> out;
-    for (std::size_t i = 0; i < data_.size(); ++i) {
-      if (static_cast<bool>(
-              pred(data_[i], PackedArray::Int(static_cast<int>(i))))) {
-        out.push_back(PackedArray::Int(static_cast<int>(i)));
-        break;
-      }
-    }
-    return {PackedArray::Int(0), out};
+    return {
+        PackedArray::Int(0),
+        detail::ArrayFindFirstIndex(data_, std::move(pred))};
   }
-
   template <typename F>
   [[nodiscard]] auto FindLast(F pred) const -> Queue<T> {
-    std::vector<T> out;
-    for (std::size_t i = data_.size(); i-- > 0;) {
-      if (static_cast<bool>(
-              pred(data_[i], PackedArray::Int(static_cast<int>(i))))) {
-        out.push_back(data_[i]);
-        break;
-      }
-    }
-    return Queue<T>(oob_slot_, out);
+    return Queue<T>(oob_slot_, detail::ArrayFindLast(data_, std::move(pred)));
   }
-
   template <typename F>
   [[nodiscard]] auto FindLastIndex(F pred) const -> Queue<PackedArray> {
-    std::vector<PackedArray> out;
-    for (std::size_t i = data_.size(); i-- > 0;) {
-      if (static_cast<bool>(
-              pred(data_[i], PackedArray::Int(static_cast<int>(i))))) {
-        out.push_back(PackedArray::Int(static_cast<int>(i)));
-        break;
-      }
-    }
-    return {PackedArray::Int(0), out};
+    return {
+        PackedArray::Int(0),
+        detail::ArrayFindLastIndex(data_, std::move(pred))};
   }
-
   template <typename F>
   [[nodiscard]] auto Min(F&& key) const -> Queue<T> {
-    return ExtremumByKey(
-        std::forward<F>(key), [](const auto& a, const auto& b) {
-          return detail::LocatorKeyLess(a, b);
-        });
+    return Queue<T>(oob_slot_, detail::ArrayMin(data_, std::forward<F>(key)));
   }
   template <typename F>
   [[nodiscard]] auto Max(F&& key) const -> Queue<T> {
-    return ExtremumByKey(
-        std::forward<F>(key), [](const auto& a, const auto& b) {
-          return detail::LocatorKeyLess(b, a);
-        });
+    return Queue<T>(oob_slot_, detail::ArrayMax(data_, std::forward<F>(key)));
   }
-
   template <typename F>
   [[nodiscard]] auto Unique(F key) const -> Queue<T> {
-    using KeyT = std::invoke_result_t<F&, const T&, const PackedArray&>;
-    std::vector<T> out;
-    std::vector<KeyT> seen;
-    for (std::size_t i = 0; i < data_.size(); ++i) {
-      auto k = key(data_[i], PackedArray::Int(static_cast<int>(i)));
-      if (!SeenContains(seen, k)) {
-        seen.push_back(k);
-        out.push_back(data_[i]);
-      }
-    }
-    return Queue<T>(oob_slot_, out);
+    return Queue<T>(oob_slot_, detail::ArrayUnique(data_, std::move(key)));
   }
-
   template <typename F>
   [[nodiscard]] auto UniqueIndex(F key) const -> Queue<PackedArray> {
-    using KeyT = std::invoke_result_t<F&, const T&, const PackedArray&>;
-    std::vector<PackedArray> out;
-    std::vector<KeyT> seen;
-    for (std::size_t i = 0; i < data_.size(); ++i) {
-      auto k = key(data_[i], PackedArray::Int(static_cast<int>(i)));
-      if (!SeenContains(seen, k)) {
-        seen.push_back(k);
-        out.push_back(PackedArray::Int(static_cast<int>(i)));
-      }
-    }
-    return {PackedArray::Int(0), out};
+    return {
+        PackedArray::Int(0), detail::ArrayUniqueIndex(data_, std::move(key))};
   }
 
  private:
-  // Returns a one-element queue holding the element ranked first by `prefer`
-  // (`prefer(candidate, current)` true means the candidate replaces the
-  // LRM 7.12.1 `min` / `max`: ranks elements by the closure's key, returns
-  // the picked element. Empty receiver yields an empty queue.
-  template <typename F, typename Prefer>
-  [[nodiscard]] auto ExtremumByKey(F key, Prefer prefer) const -> Queue<T> {
-    std::vector<T> out;
-    if (!data_.empty()) {
-      std::size_t pick = 0;
-      auto best_key = key(data_[0], PackedArray::Int(0));
-      for (std::size_t i = 1; i < data_.size(); ++i) {
-        auto k = key(data_[i], PackedArray::Int(static_cast<int>(i)));
-        if (prefer(k, best_key)) {
-          best_key = k;
-          pick = i;
-        }
-      }
-      out.push_back(data_[pick]);
-    }
-    return Queue<T>(oob_slot_, out);
-  }
-
-  template <typename K>
-  [[nodiscard]] static auto SeenContains(const std::vector<K>& seen, const K& k)
-      -> bool {
-    for (const auto& s : seen) {
-      if (detail::LocatorKeySame(k, s)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  // The keyed sort path is `selection sort over (key, index)`: a per-element
-  // key is materialized once via the closure (passing both the element and
-  // the per-element index), then the elements move in sync with the keys.
-  // Selection sort is used for the same shape-preservation reason as the
-  // unkeyed path; the small keys vector is the price.
-  template <typename F, typename Compare>
-  auto SelectionSortByKey(F key, Compare cmp) -> void {
-    using KeyT = std::invoke_result_t<F&, const T&, const PackedArray&>;
-    std::vector<KeyT> keys;
-    keys.reserve(data_.size());
-    for (std::size_t i = 0; i < data_.size(); ++i) {
-      keys.push_back(key(data_[i], PackedArray::Int(static_cast<int>(i))));
-    }
-    using std::swap;
-    for (std::size_t i = 0; i + 1 < data_.size(); ++i) {
-      std::size_t pick = i;
-      for (std::size_t j = i + 1; j < data_.size(); ++j) {
-        if (static_cast<bool>(cmp(keys[j], keys[pick]))) {
-          pick = j;
-        }
-      }
-      if (pick != i) {
-        swap(keys[i], keys[pick]);
-        swap(data_[i], data_[pick]);
-      }
-    }
-  }
-
-  // The empty-array case synthesises an element-shape zero
-  // via the OOB shield slot and feed it through the closure once so the
-  // result carries whatever shape the closure produces, then zero it out.
-  template <typename F, typename Combine>
-  [[nodiscard]] auto FoldBy(F key, Combine combine) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
-    if (data_.empty()) {
-      T zero = oob_slot_;
-      zero.ResetToDefault();
-      auto acc = key(zero, PackedArray::Int(0));
-      acc.ResetToDefault();
-      return acc;
-    }
-    auto acc = key(data_[0], PackedArray::Int(0));
-    for (std::size_t i = 1; i < data_.size(); ++i) {
-      auto v = key(data_[i], PackedArray::Int(static_cast<int>(i)));
-      combine(acc, v);
-    }
-    return acc;
-  }
-
   [[nodiscard]] auto IsInvalidIndex(const PackedArray& idx) const -> bool {
     if (idx.HasUnknown()) return true;
     const auto v = idx.ToInt64();

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -4,13 +4,16 @@
 #include <cstddef>
 #include <cstdint>
 #include <deque>
+#include <functional>
 #include <iostream>
 #include <optional>
 #include <span>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #include "lyra/value/array_case_equal.hpp"
+#include "lyra/value/array_manipulation.hpp"
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/value_concept.hpp"
@@ -308,6 +311,109 @@ class Queue {
       return;
     }
     data_.erase(data_.begin() + static_cast<std::ptrdiff_t>(index.ToInt64()));
+  }
+
+  // LRM 7.12 ordering and reduction (queues are unpacked arrays, LRM 7.10.1),
+  // each a thin wrapper over the shared `detail::Array*` algorithms. HIR-to-MIR
+  // always supplies the closure (the `with`-clause body or the LRM-default
+  // identity); `reverse` takes none -- its `with` clause is a compiler error
+  // filtered upstream by slang. The reduction result type follows the closure's
+  // return type, so a width-widening `with`-expression widens the result.
+  auto Reverse() -> void {
+    detail::ArrayReverse(data_);
+  }
+  template <typename F>
+  auto Sort(F&& key) -> void {
+    detail::ArraySortByKey(data_, std::forward<F>(key), std::less<>{});
+  }
+  template <typename F>
+  auto Rsort(F&& key) -> void {
+    detail::ArraySortByKey(data_, std::forward<F>(key), std::greater<>{});
+  }
+  template <typename F>
+  [[nodiscard]] auto Sum(F&& key) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    return detail::ArrayFold(
+        data_, oob_slot_, std::forward<F>(key),
+        [](auto& acc, auto& v) { acc = acc + v; });
+  }
+  template <typename F>
+  [[nodiscard]] auto Product(F&& key) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    return detail::ArrayFold(
+        data_, oob_slot_, std::forward<F>(key),
+        [](auto& acc, auto& v) { acc = acc * v; });
+  }
+  template <typename F>
+  [[nodiscard]] auto And(F&& key) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    return detail::ArrayFold(
+        data_, oob_slot_, std::forward<F>(key),
+        [](auto& acc, auto& v) { acc = acc & v; });
+  }
+  template <typename F>
+  [[nodiscard]] auto Or(F&& key) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    return detail::ArrayFold(
+        data_, oob_slot_, std::forward<F>(key),
+        [](auto& acc, auto& v) { acc = acc | v; });
+  }
+  template <typename F>
+  [[nodiscard]] auto Xor(F&& key) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    return detail::ArrayFold(
+        data_, oob_slot_, std::forward<F>(key),
+        [](auto& acc, auto& v) { acc = acc ^ v; });
+  }
+
+  // LRM 7.12.1 locator methods. Value locators return a queue of elements
+  // carrying this queue's element shape via `oob_slot_`; index locators return
+  // a queue of `int`. No match or an empty receiver yields an empty queue.
+  template <typename F>
+  [[nodiscard]] auto Find(F pred) const -> Queue<T> {
+    return Queue<T>(oob_slot_, detail::ArrayFind(data_, std::move(pred)));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindIndex(F pred) const -> Queue<PackedArray> {
+    return {
+        PackedArray::Int(0), detail::ArrayFindIndex(data_, std::move(pred))};
+  }
+  template <typename F>
+  [[nodiscard]] auto FindFirst(F pred) const -> Queue<T> {
+    return Queue<T>(oob_slot_, detail::ArrayFindFirst(data_, std::move(pred)));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindFirstIndex(F pred) const -> Queue<PackedArray> {
+    return {
+        PackedArray::Int(0),
+        detail::ArrayFindFirstIndex(data_, std::move(pred))};
+  }
+  template <typename F>
+  [[nodiscard]] auto FindLast(F pred) const -> Queue<T> {
+    return Queue<T>(oob_slot_, detail::ArrayFindLast(data_, std::move(pred)));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindLastIndex(F pred) const -> Queue<PackedArray> {
+    return {
+        PackedArray::Int(0),
+        detail::ArrayFindLastIndex(data_, std::move(pred))};
+  }
+  template <typename F>
+  [[nodiscard]] auto Min(F&& key) const -> Queue<T> {
+    return Queue<T>(oob_slot_, detail::ArrayMin(data_, std::forward<F>(key)));
+  }
+  template <typename F>
+  [[nodiscard]] auto Max(F&& key) const -> Queue<T> {
+    return Queue<T>(oob_slot_, detail::ArrayMax(data_, std::forward<F>(key)));
+  }
+  template <typename F>
+  [[nodiscard]] auto Unique(F key) const -> Queue<T> {
+    return Queue<T>(oob_slot_, detail::ArrayUnique(data_, std::move(key)));
+  }
+  template <typename F>
+  [[nodiscard]] auto UniqueIndex(F key) const -> Queue<PackedArray> {
+    return {
+        PackedArray::Int(0), detail::ArrayUniqueIndex(data_, std::move(key))};
   }
 
  private:

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -163,14 +163,40 @@ auto LowerCallExprProc(
     }
 
     if (receiver_type.has_value() &&
-        std::holds_alternative<hir::DynamicArrayType>(
+        std::holds_alternative<hir::QueueType>(
             module.Unit().GetType(*receiver_type).data)) {
+      // LRM 7.10.2 queue-native methods. The receiver is arguments[0]; any
+      // method parameters (insert's index and item, push's item) follow as the
+      // remaining arguments. These methods take no `with` clause and are tried
+      // before the array-manipulation family so `size` / `delete` resolve to
+      // the queue-native form rather than the LRM 7.12 one.
+      if (auto kind = LowerQueueMethodName(name); kind.has_value()) {
+        auto type_id = module.InternType(*call.type, span);
+        if (!type_id) return std::unexpected(std::move(type_id.error()));
+        return hir::Expr{
+            .type = *type_id,
+            .data =
+                hir::CallExpr{
+                    .callee = hir::BuiltinMethodRef{.method = *kind},
+                    .arguments = std::move(arg_ids),
+                },
+            .span = span,
+        };
+      }
+    }
+
+    // LRM 7.12 array-manipulation family. LRM 7.10.1 makes it available on a
+    // queue (which supports the same operations as an unpacked array) as well
+    // as a dynamic array, whose LRM 7.5.2 / 7.5.3 `size` / `delete` share the
+    // same family enum. The no-`with` form takes only the receiver; the `with`
+    // form (LRM 7.12.4) binds an iterator and a body expression carried as the
+    // optional `WithClause`, which HIR -> MIR turns into a closure argument.
+    if (receiver_type.has_value() &&
+        (std::holds_alternative<hir::DynamicArrayType>(
+             module.Unit().GetType(*receiver_type).data) ||
+         std::holds_alternative<hir::QueueType>(
+             module.Unit().GetType(*receiver_type).data))) {
       if (auto kind = LowerArrayMethodName(name); kind.has_value()) {
-        // LRM 7.5.2 / 7.5.3 dynamic-array methods plus LRM 7.12.2 / 7.12.3
-        // family. The no-`with` form takes only the receiver. The `with`
-        // form (LRM 7.12.4) binds an iterator and a body expression which
-        // HIR carries as the optional `WithClause` -- HIR -> MIR turns it
-        // into a closure argument.
         auto type_id = module.InternType(*call.type, span);
         if (!type_id) return std::unexpected(std::move(type_id.error()));
         std::optional<hir::WithClause> with_clause;
@@ -201,27 +227,6 @@ auto LowerCallExprProc(
                     .callee = hir::BuiltinMethodRef{.method = *kind},
                     .arguments = std::move(arg_ids),
                     .with_clause = std::move(with_clause),
-                },
-            .span = span,
-        };
-      }
-    }
-
-    if (receiver_type.has_value() &&
-        std::holds_alternative<hir::QueueType>(
-            module.Unit().GetType(*receiver_type).data)) {
-      if (auto kind = LowerQueueMethodName(name); kind.has_value()) {
-        // LRM 7.10.2 queue-native methods. The receiver is arguments[0]; any
-        // method parameters (insert's index and item, push's item) follow as
-        // the remaining arguments. These methods take no `with` clause.
-        auto type_id = module.InternType(*call.type, span);
-        if (!type_id) return std::unexpected(std::move(type_id.error()));
-        return hir::Expr{
-            .type = *type_id,
-            .data =
-                hir::CallExpr{
-                    .callee = hir::BuiltinMethodRef{.method = *kind},
-                    .arguments = std::move(arg_ids),
                 },
             .span = span,
         };

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -254,6 +254,20 @@ auto LowerUserCallee(
   return scope.TranslateStructuralSubroutine(u.hops, u.subroutine);
 }
 
+// The LRM 7.12 family shares one closure shape across every unpacked-array
+// receiver; only the element type differs, and each such HIR type exposes it
+// as `element_type`.
+auto ArrayMethodReceiverElementType(const hir::Type& ty)
+    -> std::optional<hir::TypeId> {
+  if (const auto* da = std::get_if<hir::DynamicArrayType>(&ty.data)) {
+    return da->element_type;
+  }
+  if (const auto* q = std::get_if<hir::QueueType>(&ty.data)) {
+    return q->element_type;
+  }
+  return std::nullopt;
+}
+
 // LRM 7.12.1 / 7.12.2 / 7.12.3 with-clause closure synthesis. The body is a
 // normal expression lowered through `process.LowerExpr`; only the
 // closure-specific leaf behaviour lives elsewhere -- captures via
@@ -270,13 +284,13 @@ auto BuildArrayMethodClosure(
   const auto& hir_process = process.HirBody();
   auto& outer_scope = *frame.current_procedural_scope;
   const auto& hir_recv_ty = module.Hir().GetType(hir_receiver_type);
-  const auto* hir_da = std::get_if<hir::DynamicArrayType>(&hir_recv_ty.data);
-  if (hir_da == nullptr) {
+  const auto element_type = ArrayMethodReceiverElementType(hir_recv_ty);
+  if (!element_type.has_value()) {
     throw InternalError(
-        "BuildArrayMethodClosure: receiver is not a dynamic-array type");
+        "BuildArrayMethodClosure: receiver is not an unpacked-array type");
   }
-  const mir::TypeId item_type = module.TranslateType(hir_da->element_type);
-  const mir::TypeId index_type = process.Module().Unit().builtins.int32;
+  const mir::TypeId item_type = module.TranslateType(*element_type);
+  const mir::TypeId index_type = module.Unit().builtins.int32;
   const std::string iterator_name =
       with_clause != nullptr
           ? hir_process.procedural_vars.at(with_clause->iterator.value).name

--- a/tests/cases/cpp/queue_method_locator/case.yaml
+++ b/tests/cases/cpp/queue_method_locator/case.yaml
@@ -1,0 +1,21 @@
+id: cpp.queue_method_locator
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    q_find: [5, 8, 8]
+    q_find_idx: [0, 2, 5]
+    q_first: [5]
+    q_first_idx: [0]
+    q_last: [8]
+    q_last_idx: [5]
+    q_nomatch: []
+    q_min: [1]
+    q_max: [8]
+    q_unique: [5, 3, 8, 1]
+    q_unique_idx: [0, 1, 2, 4]

--- a/tests/cases/cpp/queue_method_locator/main.sv
+++ b/tests/cases/cpp/queue_method_locator/main.sv
@@ -1,0 +1,34 @@
+module Top;
+  // LRM 7.12.1 locator methods on a queue receiver. Value locators return a
+  // queue of the element type; index locators return a queue of int. The find
+  // family takes a mandatory Boolean `with`; min / max / unique take none.
+  int q [$] = '{5, 3, 8, 3, 1, 8};
+
+  int q_find [$];
+  int q_find_idx [$];
+  int q_first [$];
+  int q_first_idx [$];
+  int q_last [$];
+  int q_last_idx [$];
+  int q_nomatch [$];
+
+  int q_min [$];
+  int q_max [$];
+  int q_unique [$];
+  int q_unique_idx [$];
+
+  initial begin
+    q_find       = q.find             with (item > 3);
+    q_find_idx   = q.find_index       with (item > 3);
+    q_first      = q.find_first       with (item > 3);
+    q_first_idx  = q.find_first_index with (item > 3);
+    q_last       = q.find_last        with (item > 3);
+    q_last_idx   = q.find_last_index  with (item > 3);
+    q_nomatch    = q.find             with (item > 100);
+
+    q_min        = q.min;
+    q_max        = q.max;
+    q_unique     = q.unique;
+    q_unique_idx = q.unique_index;
+  end
+endmodule

--- a/tests/cases/cpp/queue_method_order/case.yaml
+++ b/tests/cases/cpp/queue_method_order/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.queue_method_order
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    qs: [-5, -1, 2, 3]
+    qr: [3, 2, -1, -5]
+    qrev: [3, 2, 1]
+    qkey: [3, 2, -1, -5]
+    qempty: []

--- a/tests/cases/cpp/queue_method_order/main.sv
+++ b/tests/cases/cpp/queue_method_order/main.sv
@@ -1,0 +1,19 @@
+module Top;
+  // LRM 7.12.2 ordering methods on a queue receiver. The queue is an observable
+  // structural variable, so an in-place reorder routes through the mutate
+  // receiver path; asserting the final contents proves the write persisted.
+  int qs [$] = '{3, -1, 2, -5};
+  int qr [$] = '{3, -1, 2, -5};
+  int qrev [$] = '{1, 2, 3};
+  int qkey [$] = '{3, -1, 2, -5};
+  int qempty [$];
+
+  initial begin
+    qs.sort();
+    qr.rsort();
+    qrev.reverse();
+    // `with` key = 10 - item sorts ascending by key, i.e. descending by item.
+    qkey.sort with (10 - item);
+    qempty.sort();
+  end
+endmodule

--- a/tests/cases/cpp/queue_method_reduction/case.yaml
+++ b/tests/cases/cpp/queue_method_reduction/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.queue_method_reduction
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s: 10
+    p: 24
+    x: 4
+    sw: 10
+    qidx_sum: 13

--- a/tests/cases/cpp/queue_method_reduction/main.sv
+++ b/tests/cases/cpp/queue_method_reduction/main.sv
@@ -1,0 +1,21 @@
+module Top;
+  // LRM 7.12.3 reduction methods on a queue receiver. `byte` elements make the
+  // width-cast case meaningful: by default the result is element-shaped, and a
+  // `with (int'(item))` clause widens it to 32 bits (LRM 7.12.3).
+  byte qb [$] = '{1, 2, 3, 4};
+  int s;
+  int p;
+  int x;
+  int sw;
+  int qidx_sum;
+  int qsrc [$] = '{4, 1, 3, 2};
+
+  initial begin
+    s = qb.sum;
+    p = qb.product;
+    x = qb.xor;
+    sw = qb.sum with (int'(item));
+    // LRM 7.12.4 `item.index`: 4*0 + 1*1 + 3*2 + 2*3 = 13.
+    qidx_sum = qsrc.sum with (item * item.index);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Queue receivers now support the full LRM 7.12 array-manipulation method family: the ordering methods (`reverse`, `sort`, `rsort`), the reduction methods (`sum`, `product`, `and`, `or`, `xor`), and the locator methods (the `find` family, `min`, `max`, `unique`, `unique_index`), each with the optional / mandatory `with` clause per LRM 7.12.1 -- 7.12.3 and the `item.index` iterator (LRM 7.12.4). LRM 7.10.1 makes these available on a queue because a queue supports every unpacked-array operation; previously the family was wired only for dynamic-array receivers.

## Design

The LRM 7.12 algorithms are factored into a shared `detail::` layer (the new `array_manipulation.hpp`) that reads the receiver only through `data[i]` and `data.size()`, so one template body serves both the dynamic array's `std::vector` storage and the queue's `std::deque` storage. Each container exposes the LRM-named methods as thin wrappers and owns the value/index result shaping (a result queue of elements vs of `int`), matching the existing per-container shape of the equality and access methods. The dynamic array is migrated onto this shared layer in the same change rather than leaving its algorithms duplicated. On the lowering side a queue receiver routes into the existing `ArrayMethodKind` family -- the queue-native `size` / `delete` still resolve first -- and the with-clause closure synthesis is generalized to any unpacked-array element type. The backend is unchanged because the call render is already container-agnostic, so runtime overload resolution selects the queue or dynamic-array method.

## Testing

New end-to-end queue cases cover ordering (including `sort with` and an observable queue that exercises the mutate-receiver path), reduction (including the width-cast `with` form and `item.index`), and the full locator family. The complete `bazel test //...` suite passes, including the existing dynamic-array method cases that now run through the shared layer.
