### PR TITLE
Keep literal conversions faithful in MIR

### DIFF
--- a/docs/decisions/conversion-folding.md
+++ b/docs/decisions/conversion-folding.md
@@ -1,0 +1,73 @@
+# Conversion folding
+
+Date: 2026-06-19 Status: accepted
+
+## Context
+
+slang inserts an implicit conversion wherever an expression's type differs from its context's type.
+A common case is a 2-state literal feeding a 4-state target -- `logic [7:0] a = 8'd5;` -- where
+slang types `8'd5` as `bit[7:0]` and wraps it in a conversion to `logic[7:0]`. At the value level
+the bits do not change; only the state representation widens (a zero unknown plane is added).
+
+The C++ backend carried a render-time peephole that detected "a `ConversionExpr` whose operand is an
+integer literal and whose destination only restates the same bits (same width, same signedness, no
+X/Z dropped by a 2-state target)" and emitted the literal directly in the destination shape,
+skipping the runtime conversion.
+
+The question raised: should that fold move earlier -- into HIR-to-MIR -- so MIR never carries the
+"redundant-looking" `ConversionExpr` wrapping a literal at all?
+
+## Decision
+
+No. MIR keeps the conversion faithfully: a `ConversionExpr` wrapping a literal stays. Constant
+folding is the downstream optimizer's job, not HIR-to-MIR's. The backend's render-time peephole is
+removed; the conversion render is a pure `(source kind, destination kind)` map that never inspects
+its operand.
+
+The deciding argument is symmetry. A 2-state -> 4-state conversion of a variable and of a constant
+are the same operation:
+
+```
+a = y;       // y : bit[7:0]    -> ConversionExpr(y)
+a = 8'd5;    // 8'd5 : bit[7:0] -> ConversionExpr(8'd5)
+```
+
+Folding only the constant case special-cases the node on whether its operand happens to be a literal
+-- which is an optimizer's concern ("is this expression constant?"), not a structural fact MIR
+should encode. MIR is the program expressed in primitives; `mir.md` states the primitive set is
+shaped by the downstream optimizer, which each backend consumes as primitives "that its optimizer
+can fold, propagate, and pattern-match across." The LLVM backend -- the load-bearing target -- folds
+the constant conversion for free. The C++ backend is a medium for reading MIR and may emit a runtime
+conversion for the constant case; that is acceptable and faithfully mirrors the MIR.
+
+What was genuinely wrong was the peephole itself: a renderer inspecting a node's operand to decide
+the output form is a backend re-deciding a fact (`mir.md` invariant 10) -- an optimization decision
+living in the render layer. Removing it, not relocating it, is the fix.
+
+## Rejected
+
+- **Fold at HIR-to-MIR through a single conversion constructor.** A factory through which every
+  conversion is built, folding the no-op restate of a literal into a re-typed literal so the node
+  never exists. Rejected: it makes MIR do constant folding (the optimizer's job), and it breaks
+  symmetry -- the same conversion gets two MIR shapes depending on whether the operand is a literal.
+  The "redundant node" framing that motivated it was a miscategorization: the node is a faithful
+  primitive the optimizer folds, not a field that restates what the structure already fixes.
+- **Keep the backend peephole.** Leaves a renderer making a fold decision by inspecting operands --
+  an optimization decision in the render layer (against the render-makes-no-decisions direction, and
+  the eventual mechanical-renderer rewrite). The C++ codegen nicety it buys is irrelevant: C++ is a
+  reading medium and the real target folds anyway.
+
+## Consequences
+
+- MIR carries a `ConversionExpr` over any operand, literal or not; the dumper shows the conversion
+  faithfully.
+- The conversion render is a pure `(source kind, destination kind)` map; the C++ output mirrors the
+  MIR (a runtime conversion for the constant case), and the C++ compiler / LLVM fold it downstream.
+- Bit-changing constant conversions (`8'd5` -> `16'd5`) were never folded at MIR and still are not
+  -- the same rule, applied uniformly: MIR faithful, optimizer folds.
+
+## Cross-references
+
+- `architecture/mir.md` invariant 10 (a backend never re-derives a stated fact) and Notes (MIR is
+  primitives shaped for the downstream optimizer to fold).
+- `progress/refactor.md` R7.

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -122,27 +122,20 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       the IR (`mir::CompilationUnit` and the AST -> HIR analogue) -- R6 is the prerequisite cleanup;
       R1 is the architectural promotion.
 
-- [ ] R7 -- Move the literal-fold peephole from the C++ backend into HIR-to-MIR. Today
-      `RenderConversionExpr` in `src/lyra/backend/cpp/render_expr.cpp` carries a
-      `TryFoldLiteralIntegerConversion` helper that detects "MIR `ConversionExpr` wrapping a
-      `mir::IntegerLiteral` whose source and destination shapes are equivalent (same width, same
-      signedness, no X/Z loss)" and renders the literal directly in the destination shape, skipping
-      the runtime `PackedArray::ConvertFrom` call. That fold is a pure semantic decision driven
-      entirely by MIR data, so per `lowering_boundaries.md` Core Invariant 5 ("downstream layers do
-      not re-derive upstream decisions") and `mir.md` Core Invariant 5 ("dumper is the golden-test
-      surface, lossless wrt MIR structure"), it belongs at the HIR -> MIR boundary, not in the
-      backend. Target shape: `LowerHirConversionExprProc` (and its structural twin) recognises a HIR
-      `ConversionExpr` whose operand is a `hir::IntegerLiteral` with a foldable shape pair and emits
-      a `mir::IntegerLiteral` directly in the destination shape -- no `mir::ConversionExpr` node is
-      ever materialised for the no-op case. The backend's render path then becomes pure
-      `(src_kind, dst_kind)` dispatch with no peephole; the MIR dumper shows exactly what the
-      backend will emit (no "node exists but renders to nothing" surprises). **Why deferred**: the
-      current backend-side fold is correct and the scan-family PR that exposed it
-      (`feature/     scan-family-corners`) should not also rewrite the conversion-lowering path --
-      the MIR dump goldens that exercise this fold need separate scrutiny. **Trigger**: standalone
-      -- can be picked up at any time. Highest leverage is just before any other change to
-      `LowerHirConversionExprProc` (or any new constant-folding pass on MIR), because both want a
-      MIR free of redundant `ConversionExpr` nodes.
+- [x] R7 -- The literal conversion keeps its faithful shape in MIR; constant folding is the
+      downstream optimizer's job, not HIR-to-MIR's. A conversion of an integer literal to a
+      same-width / same-signedness destination (e.g. a 2-state literal feeding a 4-state target) is
+      the same operation as the conversion of a non-literal value to that destination, so MIR
+      represents both the same way -- a `mir::ConversionExpr` over the operand -- rather than
+      folding the literal case into a re-typed literal. Folding only the constant case would
+      special-case it on whether the operand happens to be a literal, which is an optimizer's
+      concern, not a MIR structural one; MIR is the program in primitives, and the LLVM backend (the
+      load-bearing target) folds the constant conversion for free. What was wrong was the C++
+      backend's render-time peephole that inspected a conversion's operand to decide whether to fold
+      -- a renderer making a semantic decision; that peephole is removed, and `RenderConversionExpr`
+      is now a pure `(src_kind, dst_kind)` map. The C++ medium may emit a runtime conversion for the
+      constant case, which is acceptable -- it faithfully mirrors the MIR. See
+      `decisions/conversion-folding.md`.
 
 - [ ] R8 -- Unify the callable forms onto one concept. Today a process (`mir::Process`), a
       subroutine (`mir::StructuralSubroutineDecl`), and a closure (`mir::ClosureExpr`) are three

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -625,43 +625,9 @@ auto RenderRealToIntegralConversion(
       RenderPackedArrayCtorArgs(dst_pa));
 }
 
-// Peephole: a same-width / same-signedness integer-literal conversion that
-// only flips the state axis (4-state <-> 2-state, no X/Z loss) folds to the
-// literal in the destination shape -- no runtime ConvertFrom needed. Returns
-// nullopt when the conversion is not eligible; the main dispatch then runs.
-auto TryFoldLiteralIntegerConversion(
-    const RenderContext& ctx, const mir::Expr& expr,
-    const mir::ConversionExpr& cv) -> std::optional<std::string> {
-  const auto& src_expr = ctx.Expr(cv.operand);
-  const auto* lit = std::get_if<mir::IntegerLiteral>(&src_expr.data);
-  if (lit == nullptr) return std::nullopt;
-  const auto& src_ty = ctx.Unit().GetType(src_expr.type);
-  const auto& dst_ty = ctx.Unit().GetType(expr.type);
-  if (!src_ty.IsIntegralPacked() || !dst_ty.IsIntegralPacked() ||
-      src_ty.IsEnum() || dst_ty.IsEnum()) {
-    return std::nullopt;
-  }
-  const auto& src_pa = src_ty.AsIntegralPacked();
-  const auto& dst_pa = dst_ty.AsIntegralPacked();
-  if (src_pa.BitWidth() != dst_pa.BitWidth() ||
-      src_pa.signedness != dst_pa.signedness) {
-    return std::nullopt;
-  }
-  const bool literal_has_xz =
-      !lit->value.state_words.empty() && lit->value.state_words[0] != 0U;
-  const bool dst_two_state = dst_pa.atom == mir::BitAtom::kBit;
-  if (literal_has_xz && dst_two_state) return std::nullopt;
-  return RenderPackedArrayIntegerLiteral(dst_pa, lit->value);
-}
-
 auto RenderConversionExpr(
     const RenderContext& ctx, const mir::Expr& expr,
     const mir::ConversionExpr& cv) -> diag::Result<std::string> {
-  if (auto folded = TryFoldLiteralIntegerConversion(ctx, expr, cv);
-      folded.has_value()) {
-    return *std::move(folded);
-  }
-
   const auto& src_expr = ctx.Expr(cv.operand);
   const auto& src_ty = ctx.Unit().GetType(src_expr.type);
   const auto& dst_ty = ctx.Unit().GetType(expr.type);


### PR DESCRIPTION
## Summary

A conversion of an integer literal to a same-width / same-signedness destination (e.g. a 2-state literal feeding a 4-state target) is the same operation as the conversion of a non-literal value to that destination, so MIR represents both the same way: a `ConversionExpr` over the operand. The C++ backend previously carried a render-time peephole that inspected a conversion's operand and, when it was such a no-op restate of a literal, emitted the literal directly in the destination shape. That is a renderer making an optimization decision by inspecting node contents, which `mir.md` invariant 10 forbids (a backend reads a stated fact, it never re-decides one). This removes the peephole; `RenderConversionExpr` is now a pure `(source kind, destination kind)` map.

Constant folding is the downstream optimizer's job, not HIR-to-MIR's. MIR is the program in primitives, and the LLVM backend (the load-bearing target) folds the constant conversion for free. The C++ backend is a medium for reading MIR and may emit a runtime conversion for the constant case; that is acceptable and faithfully mirrors the MIR. Folding only the constant case at MIR would have special-cased the node on whether its operand happens to be a literal and given the same conversion two MIR shapes, breaking symmetry.

## Design

`docs/decisions/conversion-folding.md` records the decision, the symmetry argument, and the rejected alternative (folding at HIR-to-MIR through a single conversion constructor). `refactor.md` R7 is marked done with this resolution.

## Testing

`bazel test //...` (all four targets, including `cpp_tests`). The constant conversion now renders through the general conversion path instead of the peephole; values are unchanged.