### PR TITLE
Add LRM 7.12 array methods on fixed unpacked receivers

### DIFF
--- a/docs/progress/unpacked.md
+++ b/docs/progress/unpacked.md
@@ -14,7 +14,7 @@ Done when:
 ## Actionable
 
 U1..U7 are done. U8 records a cross-cutting observability gap surfaced by the unpacked-vs-packed
-asymmetry; the implementation lives under `refactor.md` R2. U9 records the array-manipulation gap.
+asymmetry; the implementation lives under `refactor.md` R2. U9 (array manipulation) is done.
 
 | Item | Status                                                         |
 | ---- | -------------------------------------------------------------- |
@@ -26,7 +26,7 @@ asymmetry; the implementation lives under `refactor.md` R2. U9 records the array
 | U6   | Done: constant-width slice (read and write)                    |
 | U7   | Done: invalid-index handling and non-canonical declared ranges |
 | U8   | Open: unpacked vars participate in value-change observability  |
-| U9   | Open: array manipulation methods (LRM 7.12)                    |
+| U9   | Done: array manipulation methods (LRM 7.12)                    |
 
 ## Sub-Steps
 
@@ -108,15 +108,15 @@ The numeric IDs are stable references and do not imply execution order beyond U1
 
 ### Array manipulation methods
 
-- [ ] U9 -- Array manipulation methods (LRM 7.12) on fixed-size unpacked arrays: the ordering family
+- [x] U9 -- Array manipulation methods (LRM 7.12) on fixed-size unpacked arrays: the ordering family
       (`reverse`, `sort`, `rsort`), the reduction family (`sum`, `product`, `and`, `or`, `xor`), and
       the locator family (`find` and its variants, `min`, `max`, `unique`, `unique_index`), with the
       optional / mandatory `with` clause per LRM 7.12.1 -- 7.12.3 and the `item.index` iterator (LRM
       7.12.4). LRM 7.12 defines these uniformly for any unpacked array (fixed or dynamically sized)
-      except associative; today the family is wired only for dynamic array and queue receivers, so a
-      fixed unpacked receiver (`int arr[5]; arr.sort();`) is not yet accepted. The method semantics
-      and the shared element-walking algorithms already exist; closing this needs the fixed-unpacked
-      receiver routed into the same family plus the thin per-container method surface.
+      except associative, so the semantics and the `with`-clause closure match the dynamic-array and
+      queue receivers exactly; ordering mutates in place at the array's fixed size, and the locator
+      family returns a queue. `shuffle` (needs RNG) and `map` (SV2023) remain the shared follow-ups
+      noted under the aggregate workstream.
 
 ## Cross-references
 

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -475,7 +475,7 @@ auto AppendConcatPart(Queue<T>& out, const ConcatElemArg<T>& part) -> void {
 }
 template <typename T, typename C>
 auto AppendConcatPart(Queue<T>& out, const ConcatSpreadArg<C>& part) -> void {
-  for (std::size_t i = 0; i < part.array->Size(); ++i) {
+  for (std::size_t i = 0; i < part.array->RawSize(); ++i) {
     out.PushBack(part.array->RawAt(i));
   }
 }

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -2,14 +2,18 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <span>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "lyra/value/array_case_equal.hpp"
+#include "lyra/value/array_manipulation.hpp"
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
+#include "lyra/value/queue.hpp"
 #include "lyra/value/value_concept.hpp"
 
 namespace lyra::value {
@@ -194,6 +198,116 @@ class UnpackedArray {
       }
     }
     return true;
+  }
+
+  // LRM 7.12 ordering and reduction, each a thin wrapper over the shared
+  // `detail::Array*` algorithms. HIR-to-MIR always supplies the closure (the
+  // `with`-clause body or the LRM-default identity), so the runtime exposes
+  // only the closure-taking form; `reverse` takes none -- its `with` clause is
+  // a compiler error filtered upstream by slang. Ordering mutates in place at
+  // constant size (a fixed array never grows or shrinks). The closure receives
+  // each element and its index and returns a key (ordering) or a summand
+  // (reduction); the reduction result type follows the closure's return type,
+  // so a width-widening `with`-expression widens the result.
+  auto Reverse() -> void {
+    detail::ArrayReverse(data_);
+  }
+  template <typename F>
+  auto Sort(F&& key) -> void {
+    detail::ArraySortByKey(data_, std::forward<F>(key), std::less<>{});
+  }
+  template <typename F>
+  auto Rsort(F&& key) -> void {
+    detail::ArraySortByKey(data_, std::forward<F>(key), std::greater<>{});
+  }
+  template <typename F>
+  [[nodiscard]] auto Sum(F&& key) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    return detail::ArrayFold(
+        data_, oob_slot_, std::forward<F>(key),
+        [](auto& acc, auto& v) { acc = acc + v; });
+  }
+  template <typename F>
+  [[nodiscard]] auto Product(F&& key) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    return detail::ArrayFold(
+        data_, oob_slot_, std::forward<F>(key),
+        [](auto& acc, auto& v) { acc = acc * v; });
+  }
+  template <typename F>
+  [[nodiscard]] auto And(F&& key) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    return detail::ArrayFold(
+        data_, oob_slot_, std::forward<F>(key),
+        [](auto& acc, auto& v) { acc = acc & v; });
+  }
+  template <typename F>
+  [[nodiscard]] auto Or(F&& key) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    return detail::ArrayFold(
+        data_, oob_slot_, std::forward<F>(key),
+        [](auto& acc, auto& v) { acc = acc | v; });
+  }
+  template <typename F>
+  [[nodiscard]] auto Xor(F&& key) const
+      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+    return detail::ArrayFold(
+        data_, oob_slot_, std::forward<F>(key),
+        [](auto& acc, auto& v) { acc = acc ^ v; });
+  }
+
+  // LRM 7.12.1 locator methods, thin wrappers over the shared `detail::Array*`
+  // algorithms. The value locators (`find`, `find_first`, `find_last`, `min`,
+  // `max`, `unique`) return a queue of elements carrying this array's element
+  // shape via `oob_slot_`; the index locators return a queue of `int` whose
+  // shield is a plain zero. No match yields an empty queue. The `with` clause
+  // is mandatory for the find family (a Boolean predicate) and optional for
+  // `min` / `max` / `unique` (a comparison key, defaulting to the element).
+  template <typename F>
+  [[nodiscard]] auto Find(F pred) const -> Queue<T> {
+    return Queue<T>(oob_slot_, detail::ArrayFind(data_, std::move(pred)));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindIndex(F pred) const -> Queue<PackedArray> {
+    return {
+        PackedArray::Int(0), detail::ArrayFindIndex(data_, std::move(pred))};
+  }
+  template <typename F>
+  [[nodiscard]] auto FindFirst(F pred) const -> Queue<T> {
+    return Queue<T>(oob_slot_, detail::ArrayFindFirst(data_, std::move(pred)));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindFirstIndex(F pred) const -> Queue<PackedArray> {
+    return {
+        PackedArray::Int(0),
+        detail::ArrayFindFirstIndex(data_, std::move(pred))};
+  }
+  template <typename F>
+  [[nodiscard]] auto FindLast(F pred) const -> Queue<T> {
+    return Queue<T>(oob_slot_, detail::ArrayFindLast(data_, std::move(pred)));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindLastIndex(F pred) const -> Queue<PackedArray> {
+    return {
+        PackedArray::Int(0),
+        detail::ArrayFindLastIndex(data_, std::move(pred))};
+  }
+  template <typename F>
+  [[nodiscard]] auto Min(F&& key) const -> Queue<T> {
+    return Queue<T>(oob_slot_, detail::ArrayMin(data_, std::forward<F>(key)));
+  }
+  template <typename F>
+  [[nodiscard]] auto Max(F&& key) const -> Queue<T> {
+    return Queue<T>(oob_slot_, detail::ArrayMax(data_, std::forward<F>(key)));
+  }
+  template <typename F>
+  [[nodiscard]] auto Unique(F key) const -> Queue<T> {
+    return Queue<T>(oob_slot_, detail::ArrayUnique(data_, std::move(key)));
+  }
+  template <typename F>
+  [[nodiscard]] auto UniqueIndex(F key) const -> Queue<PackedArray> {
+    return {
+        PackedArray::Int(0), detail::ArrayUniqueIndex(data_, std::move(key))};
   }
 
  private:

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -185,14 +185,19 @@ auto LowerCallExprProc(
       }
     }
 
-    // LRM 7.12 array-manipulation family. LRM 7.10.1 makes it available on a
-    // queue (which supports the same operations as an unpacked array) as well
-    // as a dynamic array, whose LRM 7.5.2 / 7.5.3 `size` / `delete` share the
-    // same family enum. The no-`with` form takes only the receiver; the `with`
-    // form (LRM 7.12.4) binds an iterator and a body expression carried as the
-    // optional `WithClause`, which HIR -> MIR turns into a closure argument.
+    // LRM 7.12 array-manipulation family, defined for any unpacked array: a
+    // fixed-size unpacked array (LRM 7.12.1 / 7.12.2 operate on "any unpacked
+    // array"), a dynamic array, and a queue (LRM 7.10.1 gives it the same
+    // operations as an unpacked array). For dynamic array and queue the LRM
+    // 7.5.2 / 7.5.3 / 7.10.2 `size` / `delete` are resolved earlier as native
+    // methods; slang rejects them on a fixed array. The no-`with` form takes
+    // only the receiver; the `with` form (LRM 7.12.4) binds an iterator and a
+    // body expression carried as the optional `WithClause`, which HIR -> MIR
+    // turns into a closure argument.
     if (receiver_type.has_value() &&
-        (std::holds_alternative<hir::DynamicArrayType>(
+        (std::holds_alternative<hir::UnpackedArrayType>(
+             module.Unit().GetType(*receiver_type).data) ||
+         std::holds_alternative<hir::DynamicArrayType>(
              module.Unit().GetType(*receiver_type).data) ||
          std::holds_alternative<hir::QueueType>(
              module.Unit().GetType(*receiver_type).data))) {

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -259,6 +259,9 @@ auto LowerUserCallee(
 // as `element_type`.
 auto ArrayMethodReceiverElementType(const hir::Type& ty)
     -> std::optional<hir::TypeId> {
+  if (const auto* ua = std::get_if<hir::UnpackedArrayType>(&ty.data)) {
+    return ua->element_type;
+  }
   if (const auto* da = std::get_if<hir::DynamicArrayType>(&ty.data)) {
     return da->element_type;
   }

--- a/tests/cases/cpp/unpacked_method_locator/case.yaml
+++ b/tests/cases/cpp/unpacked_method_locator/case.yaml
@@ -1,0 +1,21 @@
+id: cpp.unpacked_method_locator
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a_find: [5, 8, 8]
+    a_find_idx: [0, 2, 5]
+    a_first: [5]
+    a_first_idx: [0]
+    a_last: [8]
+    a_last_idx: [5]
+    a_nomatch: []
+    a_min: [1]
+    a_max: [8]
+    a_unique: [5, 3, 8, 1]
+    a_unique_idx: [0, 1, 2, 4]

--- a/tests/cases/cpp/unpacked_method_locator/main.sv
+++ b/tests/cases/cpp/unpacked_method_locator/main.sv
@@ -1,0 +1,35 @@
+module Top;
+  // LRM 7.12.1 locator methods on a fixed-size unpacked array receiver. Value
+  // locators return a queue of the element type; index locators return a queue
+  // of int. The find family takes a mandatory Boolean `with`; min / max /
+  // unique take none.
+  int a [6] = '{5, 3, 8, 3, 1, 8};
+
+  int a_find [$];
+  int a_find_idx [$];
+  int a_first [$];
+  int a_first_idx [$];
+  int a_last [$];
+  int a_last_idx [$];
+  int a_nomatch [$];
+
+  int a_min [$];
+  int a_max [$];
+  int a_unique [$];
+  int a_unique_idx [$];
+
+  initial begin
+    a_find       = a.find             with (item > 3);
+    a_find_idx   = a.find_index       with (item > 3);
+    a_first      = a.find_first       with (item > 3);
+    a_first_idx  = a.find_first_index with (item > 3);
+    a_last       = a.find_last        with (item > 3);
+    a_last_idx   = a.find_last_index  with (item > 3);
+    a_nomatch    = a.find             with (item > 100);
+
+    a_min        = a.min;
+    a_max        = a.max;
+    a_unique     = a.unique;
+    a_unique_idx = a.unique_index;
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_method_order/case.yaml
+++ b/tests/cases/cpp/unpacked_method_order/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.unpacked_method_order
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a_sort: [-5, -1, 2, 3]
+    a_rsort: [3, 2, -1, -5]
+    a_rev: [3, 2, 1]
+    a_key: [3, 2, -1, -5]

--- a/tests/cases/cpp/unpacked_method_order/main.sv
+++ b/tests/cases/cpp/unpacked_method_order/main.sv
@@ -1,0 +1,18 @@
+module Top;
+  // LRM 7.12.2 ordering methods on a fixed-size unpacked array receiver. The
+  // array is an observable structural variable, so an in-place reorder routes
+  // through the mutate receiver path; asserting the final contents proves the
+  // write persisted. A fixed array is never empty, so size is preserved.
+  int a_sort [4] = '{3, -1, 2, -5};
+  int a_rsort [4] = '{3, -1, 2, -5};
+  int a_rev [3] = '{1, 2, 3};
+  int a_key [4] = '{3, -1, 2, -5};
+
+  initial begin
+    a_sort.sort();
+    a_rsort.rsort();
+    a_rev.reverse();
+    // `with` key = 10 - item sorts ascending by key, i.e. descending by item.
+    a_key.sort with (10 - item);
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_method_reduction/case.yaml
+++ b/tests/cases/cpp/unpacked_method_reduction/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.unpacked_method_reduction
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s: 10
+    p: 24
+    x: 4
+    sw: 10
+    idx_sum: 13

--- a/tests/cases/cpp/unpacked_method_reduction/main.sv
+++ b/tests/cases/cpp/unpacked_method_reduction/main.sv
@@ -1,0 +1,22 @@
+module Top;
+  // LRM 7.12.3 reduction methods on a fixed-size unpacked array receiver.
+  // `byte` elements make the width-cast case meaningful: by default the result
+  // is element-shaped, and a `with (int'(item))` clause widens it to 32 bits
+  // (LRM 7.12.3).
+  byte ab [4] = '{1, 2, 3, 4};
+  int s;
+  int p;
+  int x;
+  int sw;
+  int idx_sum;
+  int asrc [4] = '{4, 1, 3, 2};
+
+  initial begin
+    s = ab.sum;
+    p = ab.product;
+    x = ab.xor;
+    sw = ab.sum with (int'(item));
+    // LRM 7.12.4 `item.index`: 4*0 + 1*1 + 3*2 + 2*3 = 13.
+    idx_sum = asrc.sum with (item * item.index);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Fixed-size unpacked array receivers now support the full LRM 7.12 array-manipulation method family: the ordering methods (`reverse`, `sort`, `rsort`), the reduction methods (`sum`, `product`, `and`, `or`, `xor`), and the locator methods (the `find` family, `min`, `max`, `unique`, `unique_index`), each with the optional / mandatory `with` clause per LRM 7.12.1 -- 7.12.3 and the `item.index` iterator (LRM 7.12.4). LRM 7.12.1 / 7.12.2 define these for any unpacked array (fixed or dynamically sized) except associative; previously the family was wired only for dynamic-array and queue receivers, so `int a[5]; a.sort();` was not accepted.

## Design

The LRM 7.12 algorithms already live in a shared `detail::` layer that reads its receiver only through `data[i]` and `data.size()`, so the fixed unpacked array exposes the LRM-named methods as the same thin wrappers the dynamic array and queue use, owning the value/index result shaping (a result queue of elements vs of `int`). Ordering mutates in place at the array's fixed size, and the locator family returns a queue, so the container header now depends on the queue header exactly as the dynamic-array header already does. On the lowering side the array-method routing accepts a fixed-unpacked receiver in addition to dynamic array and queue, and the with-clause closure synthesis learns the fixed-unpacked element type; the queue-native `size` / `delete` never collide because slang rejects them on a fixed array. The backend is unchanged because the call render is already container-agnostic.

Adding the queue dependency to the unpacked-array header surfaced a latent fragility in the queue concatenation helper, which bounded a `size_t` loop with `Size()` (an SV `int` value) rather than `RawSize()`; it had compiled only through an implicit conversion sensitive to instantiation order. The loop now bounds against `RawSize()`, matching the element access on the next line and every other size loop in the value headers.

## Testing

New end-to-end cases cover ordering (including `sort with` and an observable module-level array that exercises the mutate-receiver path), reduction (including the width-cast `with` form and `item.index`), and the full locator family. The complete `bazel test //...` suite passes, including the existing queue concatenation case that runs through the corrected loop bound.
