### PR TITLE
Drop dead is_coroutine field from ClosureExpr

### DIFF
--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -239,24 +239,15 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       kind touches three files (subsystem header, subsystem implementation, dispatcher switch) and
       leaves the pass-class header untouched.
 
-- [x] R14 -- Move the "is this callable a coroutine" decision off `RenderContext` and onto MIR.
-      Today the cpp backend reads `RenderContext::InCoroutine()` -- a walk-state flag installed via
-      `WithCoroutine(...)` at every callable-body entry -- to decide whether a `mir::ReturnStmt`
-      lowers to `return` or `co_return`. The distinction is not semantic at the MIR or LIR level:
-      `return` and `co_return` describe the same operation (exit the callable); "how" depends purely
-      on whether the surrounding callable is a coroutine. That fact is already captured by every
-      callable MIR node except `mir::ClosureExpr` (Process is implicit; `StructuralSubroutineDecl`'s
-      `kind` distinguishes task / function; constructor body is implicit). `ClosureExpr` is the gap:
-      the same node is constructed for fork-branch closures (concurrent coroutines that may suspend)
-      and for NBA / `$strobe` / `$sscanf` IIFE / with-clause iterator / deferred-check closures
-      (synchronous lambdas), with no field to say which. Target shape: `mir::ClosureExpr` gains an
-      `is_coroutine` flag set at HIR-to-MIR construction; the cpp backend reads it directly at every
-      closure entry instead of inheriting a walk-state assumption.
-      `RenderContext::WithCoroutine(...)` / `InCoroutine()` remain (the bool still propagates across
-      nested if / loop / block scopes within a body) but the install path is MIR-sourced -- the
-      render no longer "decides" coroutine-ness, it only reads. The eventual removal of the
-      propagation flag from `RenderContext` ships in R18, when the whole walk frame is dissolved.
-      **Trigger**: scheduled in front of R18 (the render-layer rewrite).
+- [x] R14 -- The `return` / `co_return` choice is carried by MIR, not re-decided in the backend.
+      `return` and `co_return` describe the same operation (exit the callable); whether a given
+      `mir::ReturnStmt` renders as one or the other depends only on whether its enclosing callable
+      is a coroutine. `mir::ReturnStmt` carries that as `is_coroutine_return`, set at HIR-to-MIR
+      from the enclosing callable body's coroutine kind; the cpp backend reads it at each return
+      rather than inheriting a render-time walk-state flag. A closure needs no coroutine field of
+      its own -- whether a closure body suspends follows from how the closure is used (a fork-branch
+      reference spawns it as a coroutine; a deferred submit runs it synchronously), which is itself
+      explicit in MIR per `architecture/mir.md`.
 
 - [x] R15 -- Give `mir::Process` a `name` field, so the C++ method name, static-frame struct name,
       static-frame field name, and any future LLVM-IR function symbol all flow from a single

--- a/include/lyra/mir/closure.hpp
+++ b/include/lyra/mir/closure.hpp
@@ -64,14 +64,6 @@ struct Parameter {
 //      carrying the result expression. An empty-`params` closure is invoked
 //      once (fork branch / deferred IIFE) and renders as a captures-as-args
 //      IIFE.
-//   5. `is_coroutine` declares whether the body may suspend (LRM 9.4 timing
-//      controls / event waits) -- equivalent to asking "is the body lowered
-//      as a C++20 coroutine vs a plain lambda". A fork branch (LRM 9.3.2)
-//      spawns its body as a concurrent coroutine; all other closure shapes
-//      (NBA submit / `$strobe` / `$sscanf` IIFE / with-clause iterator /
-//      deferred check) run their body synchronously without suspending.
-//      HIR-to-MIR encodes the value at construction; the backend renders
-//      the body purely by reading it -- no surrounding context lookup.
 //
 // StructuralVarRef inside body may carry hops that reach module-scope storage
 // directly, the same way C++ lambdas may reference globals without capture.
@@ -79,7 +71,6 @@ struct ClosureExpr {
   std::vector<Capture> captures;
   std::vector<Parameter> params;
   std::unique_ptr<ProceduralScope> body;
-  bool is_coroutine = false;
 
   ClosureExpr();
   ~ClosureExpr();

--- a/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
@@ -109,9 +109,6 @@ auto LowerForkStmt(
     closure.captures = std::move(captures);
     closure.body =
         std::make_unique<mir::ProceduralScope>(std::move(branch_scope));
-    // LRM 9.3.2 fork branch: each branch is a concurrent thread that may
-    // suspend on timing controls / event waits inside its body.
-    closure.is_coroutine = true;
     branch_ids.push_back(fork_scope.AddExpr(
         mir::Expr{
             .data = std::move(closure),

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -574,9 +574,8 @@ class MirDumper {
             },
             [](const ClosureExpr& cl) -> std::string {
               return std::format(
-                  "ClosureExpr captures={} params={} is_coroutine={}",
-                  cl.captures.size(), cl.params.size(),
-                  cl.is_coroutine ? "true" : "false");
+                  "ClosureExpr captures={} params={}", cl.captures.size(),
+                  cl.params.size());
             },
             [](const ElementSelectExpr& sel) -> std::string {
               return std::format(


### PR DESCRIPTION
## Summary

`mir::ClosureExpr` carried a `bool is_coroutine` flag, but no codegen path ever read it -- the only consumer was the MIR dumper. The C++ backend decides coroutine-ness structurally instead (a fork-branch render emits a coroutine; `RenderClosureExpr` emits a plain lambda), and the `return` / `co_return` choice already flows through `mir::ReturnStmt::is_coroutine_return`. The field was a redundant restatement of a fact that is fixed by how a closure is used.

This matches the `architecture/mir.md` contract, which states a closure carries no property describing how it executes: whether its body runs synchronously or as a coroutine follows from its use (a fork-branch reference spawns it as a concurrent process; a deferred submit runs it to completion in a later region), and that use is itself explicit in MIR. The removed field contradicted that contract.

The change removes the field, its single lowering writer in the fork-join lowering, and the dumper output, and rewrites `refactor.md` R14 so it reflects the actual mechanism (`ReturnStmt::is_coroutine_return`) rather than the never-realized `ClosureExpr` flag. No MIR dump golden captured the field, so there is no behavioral change.