### PR TITLE
Lower print-to-sink tasks to generic calls

### DIFF
--- a/docs/decisions/runtime-effects-as-generic-calls.md
+++ b/docs/decisions/runtime-effects-as-generic-calls.md
@@ -68,18 +68,21 @@ the argument vector.
 - One generic `CallExpr` is MIR's only call shape; `RuntimeCallExpr` and the ~22 payload structs
   retire. Runtime free functions (`LyraPrint(RuntimeServices&, ...)`, etc.) stay unchanged.
 - Both backends eat the same generic input; the LLVM optimizer reaches through.
-- **Implementation in progress.** `$finish`, the `$time` / `$stime` / `$realtime` family, and the
-  whole file I/O family (`$fopen` / `$fclose` / `$fgetc` / `$ungetc` / `$fgets` / `$fread` /
-  `$fseek` / `$rewind` / `$ftell` / `$feof` / `$ferror` / `$fflush`) are on this shape: each lowers
-  to a generic `CallExpr` whose first argument is `self.Services()` and renders through one generic
-  system-subroutine path with no injection. A runtime entry that takes a write-through destination
-  (`$fread`, `$fgets`, `$ferror`) receives a copy-out temp as an ordinary argument, so the call
-  carries no live-reference or mutate-routing concept; an effect whose SV form omits optional
-  arguments either materializes the default at lowering or selects a shorter runtime overload, so
-  the argument vector is always complete. The print / scan / `$sformat` / diagnostic / submit
-  effects still use `RuntimeCallExpr` + payload structs and still splice `self->Services()`; that is
-  transitional tech debt to converge to this decision. Flattening `$display` items into value-build
-  expressions is the largest remaining piece.
+- **Implementation in progress.** `$finish`, the `$time` / `$stime` / `$realtime` family, the whole
+  file I/O family (`$fopen` / `$fclose` / `$fgetc` / `$ungetc` / `$fgets` / `$fread` / `$fseek` /
+  `$rewind` / `$ftell` / `$feof` / `$ferror` / `$fflush`), and the print-to-sink family (`$display`
+  / `$write` / `$fdisplay` / `$fwrite`) are on this shape: each lowers to a generic `CallExpr` whose
+  first argument is `self.Services()` and renders through one generic system-subroutine path with no
+  injection. A runtime entry that takes a write-through destination (`$fread`, `$fgets`, `$ferror`)
+  receives a copy-out temp as an ordinary argument, so the call carries no live-reference or
+  mutate-routing concept; an effect whose SV form omits optional arguments either materializes the
+  default at lowering or selects a shorter runtime overload, so the argument vector is always
+  complete. The print family flattens its `$display` items into a constructed `PrintItem` array:
+  each item is a value-build `ConstructExpr` over a runtime-library value type (`PrintItem` /
+  `FormatSpec`), and the print/newline discipline is encoded by the selected runtime entry rather
+  than carried as a `kind` argument. The `$strobe`-family (deferred print), scan, `$sformat`,
+  diagnostic, and NBA / observed submit effects still use `RuntimeCallExpr` + payload structs; that
+  is transitional tech debt to converge to this decision.
 
 ## Cross-references
 

--- a/include/lyra/lowering/hir_to_mir/expression/system/print.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/system/print.hpp
@@ -10,11 +10,15 @@
 
 namespace lyra::lowering::hir_to_mir {
 
-// Lower a print-like system subroutine call (e.g. $display, $write) into a
-// `mir::Expr` carrying a `mir::RuntimeCallExpr`. Returns a user diagnostic for
-// unsupported shapes (file output, %m, malformed format string, etc.).
+// Lower a print-like system subroutine call into a `mir::Expr`. $display /
+// $write / $fdisplay / $fwrite become a generic `CallExpr` whose arguments are
+// the engine handle, an optional descriptor, and a constructed `PrintItem`
+// array; $strobe-family calls defer the same print through a postponed submit.
+// Returns a user diagnostic for unsupported shapes (%m, malformed format
+// string, etc.).
 auto LowerPrintSystemSubroutineCall(
     ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& call,
+    support::SystemSubroutineId id,
     const support::PrintSystemSubroutineInfo& print, diag::SourceSpan span)
     -> diag::Result<mir::Expr>;
 

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -28,6 +28,10 @@ struct BuiltinMirTypes {
   TypeId time;
   TypeId self_pointer;
   TypeId services;
+  TypeId print_item;
+  TypeId print_literal_item;
+  TypeId print_value_item;
+  TypeId format_spec;
 };
 
 struct CompilationUnit {
@@ -70,6 +74,18 @@ struct CompilationUnit {
                     .pointee = AddType(TypeData{SelfType{}}),
                     .ownership = PointerOwnership::kBorrowed}}),
             .services = AddType(TypeData{ServicesType{}}),
+            .print_item = AddType(
+                TypeData{RuntimeLibraryType{
+                    .kind = RuntimeLibraryKind::kPrintItem}}),
+            .print_literal_item = AddType(
+                TypeData{RuntimeLibraryType{
+                    .kind = RuntimeLibraryKind::kPrintLiteralItem}}),
+            .print_value_item = AddType(
+                TypeData{RuntimeLibraryType{
+                    .kind = RuntimeLibraryKind::kPrintValueItem}}),
+            .format_spec = AddType(
+                TypeData{RuntimeLibraryType{
+                    .kind = RuntimeLibraryKind::kFormatSpec}}),
         } {
   }
 

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -30,6 +30,7 @@ enum class TypeKind {
   kScope,
   kSelf,
   kServices,
+  kRuntimeLibrary,
   kPointer,
   kVector,
   kExternalRef,
@@ -164,6 +165,26 @@ struct ServicesType {
   auto operator==(const ServicesType&) const -> bool = default;
 };
 
+// A pass-through value type from the runtime library that MIR never inspects:
+// it is constructed (via ConstructExpr) and forwarded to a runtime-effect call,
+// and MIR makes no decision on its contents. The branch selects which library
+// type, and the backend maps the branch to the concrete library name. Distinct
+// from ServicesType / ScopeType, which are runtime object-model handles the
+// receiver semantics reason about; these are inert payloads
+// (docs/decisions/runtime-effects-as-generic-calls.md).
+enum class RuntimeLibraryKind : std::uint8_t {
+  kPrintItem,
+  kPrintLiteralItem,
+  kPrintValueItem,
+  kFormatSpec,
+};
+
+struct RuntimeLibraryType {
+  RuntimeLibraryKind kind;
+
+  auto operator==(const RuntimeLibraryType&) const -> bool = default;
+};
+
 enum class PointerOwnership {
   kUnique,
   kShared,
@@ -235,8 +256,8 @@ using TypeData = std::variant<
     PackedArrayType, EnumType, UnpackedArrayType, DynamicArrayType, QueueType,
     AssociativeArrayType, StringType, EventType, RealType, ShortRealType,
     RealTimeType, ChandleType, VoidType, ObjectType, ExternalUnitObjectType,
-    ScopeType, SelfType, ServicesType, PointerType, VectorType, ExternalRefType,
-    ObservableType>;
+    ScopeType, SelfType, ServicesType, RuntimeLibraryType, PointerType,
+    VectorType, ExternalRefType, ObservableType>;
 
 struct Type {
   TypeData data;

--- a/include/lyra/runtime/file_io.hpp
+++ b/include/lyra/runtime/file_io.hpp
@@ -37,11 +37,12 @@ auto LyraFOpen(
 void LyraFClose(
     RuntimeServices& services, const value::PackedArray& descriptor);
 
-// $fdisplay / $fwrite with descriptor. Iterates set bits per LRM 21.3.1.
-// Bit 0 of an MCD (or the pre-bound STDOUT FD 32'h8000_0001) routes through
-// RuntimeServices::Stream() so test-harness stdout matching stays
+// Writes the formatted record to a descriptor's sink, iterating set bits per
+// LRM 21.3.1. Bit 0 of an MCD (or the pre-bound STDOUT FD 32'h8000_0001) routes
+// through RuntimeServices::Stream() so test-harness stdout matching stays
 // consistent with $display output ordering; other bits go directly to
-// FileTable's owned FILE* handles. Invalid bits silently no-op.
+// FileTable's owned FILE* handles. Invalid bits silently no-op. A trailing
+// newline is appended for the newline kind (kFDisplay, LRM 21.2.1.1).
 void LyraFPrint(
     RuntimeServices& services, value::PrintKind kind,
     const value::PackedArray& descriptor,

--- a/include/lyra/runtime/io.hpp
+++ b/include/lyra/runtime/io.hpp
@@ -9,11 +9,27 @@ namespace lyra::runtime {
 
 class RuntimeServices;
 
-// Single high-level runtime print API. The compiler emits one call per
-// $display/$write/...; the runtime walks the items, formats values via
-// value::Format, and finalizes the record (newline for kDisplay/kFDisplay).
+// Walks the item sequence, formats each value via value::Format, and writes the
+// record to stdout, appending a trailing newline for the newline kind
+// (kDisplay, LRM 21.2.1.1).
 void LyraPrint(
     RuntimeServices& services, value::PrintKind kind,
+    std::span<const value::PrintItem> items);
+
+// The print-to-sink entries for $display / $write / $fdisplay / $fwrite. The
+// Display / FDisplay pair append a trailing newline (LRM 21.2.1.1); Write /
+// FWrite do not. The F-prefixed pair writes to the descriptor's sink (LRM
+// 21.3.2); the others write to stdout. Each formats the item sequence and
+// emits it.
+void LyraDisplay(
+    RuntimeServices& services, std::span<const value::PrintItem> items);
+void LyraWrite(
+    RuntimeServices& services, std::span<const value::PrintItem> items);
+void LyraFDisplay(
+    RuntimeServices& services, const value::PackedArray& descriptor,
+    std::span<const value::PrintItem> items);
+void LyraFWrite(
+    RuntimeServices& services, const value::PackedArray& descriptor,
     std::span<const value::PrintItem> items);
 
 // LRM 21.2.2 $strobe-family runtime entry. Defers `print_action` to the

--- a/include/lyra/value/format.hpp
+++ b/include/lyra/value/format.hpp
@@ -53,6 +53,17 @@ struct FormatSpec {
   bool zero_pad = false;
   bool left_align = false;
   std::int32_t timeunit_power = 0;
+
+  FormatSpec() = default;
+
+  // Each field arrives as a PackedArray literal -- the value model routes
+  // compile-time scalars as SV values, the same way the file-IO runtime entries
+  // take their int args -- and converts to its native field type here.
+  explicit FormatSpec(const PackedArray& kind);
+  FormatSpec(
+      const PackedArray& kind, const PackedArray& width,
+      const PackedArray& precision, const PackedArray& zero_pad,
+      const PackedArray& left_align, const PackedArray& timeunit_power);
 };
 
 // LRM 20.4.3 / Table 20-3: the design-wide settings that drive every `%t`. The
@@ -162,57 +173,63 @@ struct Formatter<float> {
 };
 
 struct PrintLiteralItem {
-  const char* data;
-  std::uint32_t size;
+  const char* data = nullptr;
+  std::uint32_t size = 0;
+
+  PrintLiteralItem() = default;
+  PrintLiteralItem(const char* data, std::uint32_t size)
+      : data(data), size(size) {
+  }
+
+  // Borrows the text bytes of `text`. The caller materializes `text` as a
+  // temporary in the same full-expression as the runtime print call, so the
+  // borrowed bytes outlive the walk (the same lifetime contract FormatArg
+  // relies on; see docs/decisions/format-dispatch.md).
+  explicit PrintLiteralItem(const String& text);
 };
 
 struct PrintValueItem {
   FormatSpec spec;
   FormatArg arg;
+
+  // The emit side constructs this directly (`PrintValueItem(x, spec)`). The
+  // overload set is closed on the leaf formattable types rather than a single
+  // greedy template so an operand that is not itself formattable but converts
+  // to one -- an `Enum<T>` decaying to `PackedArray` -- selects the converted
+  // overload instead of instantiating an undefined `Formatter`. `const T&` so
+  // a caller-side temporary (an arithmetic rvalue) binds via lifetime
+  // extension through the full expression that contains the runtime print
+  // call.
+  PrintValueItem(const PackedArray& value, FormatSpec spec)
+      : spec(spec), arg(MakeFormatArg(value)) {
+  }
+  PrintValueItem(const String& value, FormatSpec spec)
+      : spec(spec), arg(MakeFormatArg(value)) {
+  }
+  PrintValueItem(const double& value, FormatSpec spec)
+      : spec(spec), arg(MakeFormatArg(value)) {
+  }
+  PrintValueItem(const float& value, FormatSpec spec)
+      : spec(spec), arg(MakeFormatArg(value)) {
+  }
+  template <typename T>
+  PrintValueItem(const UnpackedArray<T>& value, FormatSpec spec)
+      : spec(spec), arg(MakeFormatArg(value)) {
+  }
+  template <typename T>
+  PrintValueItem(const DynamicArray<T>& value, FormatSpec spec)
+      : spec(spec), arg(MakeFormatArg(value)) {
+  }
+  template <typename T>
+  PrintValueItem(const Queue<T>& value, FormatSpec spec)
+      : spec(spec), arg(MakeFormatArg(value)) {
+  }
+  template <typename K, typename V>
+  PrintValueItem(const AssociativeArray<K, V>& value, FormatSpec spec)
+      : spec(spec), arg(MakeFormatArg(value)) {
+  }
 };
 
 using PrintItem = std::variant<PrintLiteralItem, PrintValueItem>;
-
-// Convenience constructors -- the emit side reads as
-// `PrintValue(x, spec)` and the overload set selects the right `Formatter`
-// from the operand's type. `const T&` everywhere so a caller-side temporary
-// (e.g. an arithmetic rvalue) binds via lifetime extension through the full
-// expression that contains the runtime print call.
-[[nodiscard]] inline auto PrintValue(const PackedArray& value, FormatSpec spec)
-    -> PrintItem {
-  return PrintValueItem{.spec = spec, .arg = MakeFormatArg(value)};
-}
-[[nodiscard]] inline auto PrintValue(const String& value, FormatSpec spec)
-    -> PrintItem {
-  return PrintValueItem{.spec = spec, .arg = MakeFormatArg(value)};
-}
-[[nodiscard]] inline auto PrintValue(const double& value, FormatSpec spec)
-    -> PrintItem {
-  return PrintValueItem{.spec = spec, .arg = MakeFormatArg(value)};
-}
-[[nodiscard]] inline auto PrintValue(const float& value, FormatSpec spec)
-    -> PrintItem {
-  return PrintValueItem{.spec = spec, .arg = MakeFormatArg(value)};
-}
-template <typename T>
-[[nodiscard]] auto PrintValue(const UnpackedArray<T>& value, FormatSpec spec)
-    -> PrintItem {
-  return PrintValueItem{.spec = spec, .arg = MakeFormatArg(value)};
-}
-template <typename T>
-[[nodiscard]] auto PrintValue(const DynamicArray<T>& value, FormatSpec spec)
-    -> PrintItem {
-  return PrintValueItem{.spec = spec, .arg = MakeFormatArg(value)};
-}
-template <typename T>
-[[nodiscard]] auto PrintValue(const Queue<T>& value, FormatSpec spec)
-    -> PrintItem {
-  return PrintValueItem{.spec = spec, .arg = MakeFormatArg(value)};
-}
-template <typename K, typename V>
-[[nodiscard]] auto PrintValue(
-    const AssociativeArray<K, V>& value, FormatSpec spec) -> PrintItem {
-  return PrintValueItem{.spec = spec, .arg = MakeFormatArg(value)};
-}
 
 }  // namespace lyra::value

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1114,6 +1114,17 @@ auto RenderSystemSubroutineEntryName(const support::SystemSubroutineDesc& desc)
               -> diag::Result<std::string_view> {
             return std::string_view{"lyra::runtime::Finish"};
           },
+          [](const support::PrintSystemSubroutineInfo& print)
+              -> diag::Result<std::string_view> {
+            if (print.sink_kind == support::PrintSinkKind::kStdout) {
+              return print.append_newline
+                         ? std::string_view{"lyra::runtime::LyraDisplay"}
+                         : std::string_view{"lyra::runtime::LyraWrite"};
+            }
+            return print.append_newline
+                       ? std::string_view{"lyra::runtime::LyraFDisplay"}
+                       : std::string_view{"lyra::runtime::LyraFWrite"};
+          },
           [](const support::TimeSystemSubroutineInfo& time)
               -> diag::Result<std::string_view> {
             switch (time.kind) {

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -39,68 +39,34 @@ auto RenderPrintKindLiteral(value::PrintKind k) -> std::string_view {
   throw InternalError("RenderPrintKindLiteral: unknown PrintKind");
 }
 
-auto RenderFormatKindLiteral(value::FormatKind k) -> std::string_view {
-  switch (k) {
-    case value::FormatKind::kDecimal:
-      return "lyra::value::FormatKind::kDecimal";
-    case value::FormatKind::kHex:
-      return "lyra::value::FormatKind::kHex";
-    case value::FormatKind::kBinary:
-      return "lyra::value::FormatKind::kBinary";
-    case value::FormatKind::kOctal:
-      return "lyra::value::FormatKind::kOctal";
-    case value::FormatKind::kString:
-      return "lyra::value::FormatKind::kString";
-    case value::FormatKind::kChar:
-      return "lyra::value::FormatKind::kChar";
-    case value::FormatKind::kRealDecimal:
-      return "lyra::value::FormatKind::kRealDecimal";
-    case value::FormatKind::kRealExponential:
-      return "lyra::value::FormatKind::kRealExponential";
-    case value::FormatKind::kRealGeneral:
-      return "lyra::value::FormatKind::kRealGeneral";
-    case value::FormatKind::kAssignmentPattern:
-      return "lyra::value::FormatKind::kAssignmentPattern";
-    case value::FormatKind::kTime:
-      return "lyra::value::FormatKind::kTime";
-  }
-  throw InternalError("RenderFormatKindLiteral: unknown FormatKind");
-}
-
+// Each FormatSpec field travels to the runtime as a PackedArray, the value
+// model the runtime constructor converts internally. The kind-only overload
+// covers the common all-default spec; the full overload spells out all six.
+// LRM 21.2.1.3 / 3.14.2: `%t` scales from the enclosing scope's time unit, the
+// scope class constant `kTimeUnitPower`, resolved by unqualified C++ name
+// lookup -- mirrors how $time reads it, so a `%t` inside a subroutine uses its
+// declaration scope's unit.
 auto RenderFormatSpecInit(const mir::FormatSpec& spec) -> std::string {
-  // Emit only the fields that differ from value::FormatSpec's in-class
-  // defaults; an omitted field designated-initializes to that same default, so
-  // the spec is identical but far terser than spelling out all six.
-  std::vector<std::string> fields;
-  if (spec.kind != value::FormatKind::kDecimal) {
-    fields.push_back(
-        std::format(".kind = {}", RenderFormatKindLiteral(spec.kind)));
+  const auto from_int = [](std::string_view e) {
+    return std::format(
+        "lyra::value::PackedArray::FromInt({}, 32, true, false)", e);
+  };
+  const std::string kind_arg =
+      from_int(std::format("{}LL", static_cast<std::int64_t>(spec.kind)));
+  const bool is_time = spec.kind == value::FormatKind::kTime;
+  const bool all_default =
+      spec.modifiers.width == -1 && spec.modifiers.precision == -1 &&
+      !spec.modifiers.zero_pad && !spec.modifiers.left_align && !is_time;
+  if (all_default) {
+    return std::format("lyra::value::FormatSpec({})", kind_arg);
   }
-  if (spec.modifiers.width != -1) {
-    fields.push_back(std::format(".width = {}", spec.modifiers.width));
-  }
-  if (spec.modifiers.precision != -1) {
-    fields.push_back(std::format(".precision = {}", spec.modifiers.precision));
-  }
-  if (spec.modifiers.zero_pad) {
-    fields.emplace_back(".zero_pad = true");
-  }
-  if (spec.modifiers.left_align) {
-    fields.emplace_back(".left_align = true");
-  }
-  // LRM 21.2.1.3 / 3.14.2: `%t` scales from the enclosing scope's time unit.
-  // The unit is the scope class constant, resolved by unqualified C++ name
-  // lookup to the lexically enclosing design element -- mirrors how $time
-  // reads it, so a `%t` inside a subroutine uses its declaration scope's unit.
-  if (spec.kind == value::FormatKind::kTime) {
-    fields.emplace_back(".timeunit_power = kTimeUnitPower");
-  }
-  std::string joined;
-  for (const auto& field : fields) {
-    if (!joined.empty()) joined += ", ";
-    joined += field;
-  }
-  return std::format("lyra::value::FormatSpec{{{}}}", joined);
+  return std::format(
+      "lyra::value::FormatSpec({}, {}, {}, {}, {}, {})", kind_arg,
+      from_int(std::format("{}LL", spec.modifiers.width)),
+      from_int(std::format("{}LL", spec.modifiers.precision)),
+      from_int(spec.modifiers.zero_pad ? "1LL" : "0LL"),
+      from_int(spec.modifiers.left_align ? "1LL" : "0LL"),
+      from_int(is_time ? "kTimeUnitPower" : "0LL"));
 }
 
 auto RenderPrintValueArg(
@@ -144,7 +110,7 @@ auto RenderPrintItemInit(
             auto arg_or = RenderPrintValueArg(ctx, v);
             if (!arg_or) return std::unexpected(std::move(arg_or.error()));
             return std::format(
-                "lyra::value::PrintValue({}, {})", *arg_or,
+                "lyra::value::PrintValueItem({}, {})", *arg_or,
                 RenderFormatSpecInit(v.spec));
           },
       },

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -122,6 +122,19 @@ auto RenderTypeAsCpp(
           [](const mir::ServicesType&) -> diag::Result<std::string> {
             return std::string{"lyra::runtime::RuntimeServices&"};
           },
+          [](const mir::RuntimeLibraryType& r) -> diag::Result<std::string> {
+            switch (r.kind) {
+              case mir::RuntimeLibraryKind::kPrintItem:
+                return std::string{"lyra::value::PrintItem"};
+              case mir::RuntimeLibraryKind::kPrintLiteralItem:
+                return std::string{"lyra::value::PrintLiteralItem"};
+              case mir::RuntimeLibraryKind::kPrintValueItem:
+                return std::string{"lyra::value::PrintValueItem"};
+              case mir::RuntimeLibraryKind::kFormatSpec:
+                return std::string{"lyra::value::FormatSpec"};
+            }
+            throw InternalError("RenderTypeAsCpp: unknown RuntimeLibraryKind");
+          },
           [&](const mir::PointerType& p) -> diag::Result<std::string> {
             auto inner_or = RenderTypeAsCpp(unit, owner_scope, p.pointee);
             if (!inner_or) return std::unexpected(std::move(inner_or.error()));

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -378,7 +378,7 @@ auto LowerSystemSubroutineCall(
           [&](const support::PrintSystemSubroutineInfo& print)
               -> diag::Result<mir::Expr> {
             return LowerPrintSystemSubroutineCall(
-                process, frame, call, print, span);
+                process, frame, call, desc.id, print, span);
           },
           [&](const support::TerminationSystemSubroutineInfo& term)
               -> diag::Result<mir::Expr> {

--- a/src/lyra/lowering/hir_to_mir/expression/system/print.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/print.cpp
@@ -1,20 +1,27 @@
 #include "lyra/lowering/hir_to_mir/expression/system/print.hpp"
 
 #include <cstddef>
+#include <cstdint>
 #include <expected>
 #include <optional>
 #include <utility>
+#include <variant>
+#include <vector>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/base/overloaded.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/print_items.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/services_call.hpp"
+#include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/runtime_print.hpp"
 #include "lyra/mir/runtime_submit.hpp"
+#include "lyra/mir/type.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -31,14 +38,93 @@ auto ToValuePrintKind(const support::PrintSystemSubroutineInfo& info)
                              : value::PrintKind::kFWrite;
 }
 
+// LRM 21.2.1.3: a %t directive scales by the enclosing scope's time unit, which
+// is known only at lowering -- so its power is materialized here as the spec's
+// sixth field rather than read from the directive like the others. Fields pass
+// as `int` literals the runtime FormatSpec constructor converts; the modifier
+// fields are omitted when none differs from its default.
+auto BuildFormatSpecExpr(
+    mir::CompilationUnit& unit, mir::ProceduralScope& scope,
+    const mir::FormatSpec& spec, std::int64_t time_unit_power) -> mir::ExprId {
+  const auto int_lit = [&](std::int64_t v) {
+    return scope.AddExpr(mir::MakeInt32Literal(unit.builtins.int32, v));
+  };
+  std::vector<mir::ExprId> args;
+  args.push_back(int_lit(static_cast<std::int64_t>(spec.kind)));
+  const bool is_time = spec.kind == value::FormatKind::kTime;
+  const bool all_default =
+      spec.modifiers.width == -1 && spec.modifiers.precision == -1 &&
+      !spec.modifiers.zero_pad && !spec.modifiers.left_align && !is_time;
+  if (!all_default) {
+    args.push_back(int_lit(spec.modifiers.width));
+    args.push_back(int_lit(spec.modifiers.precision));
+    args.push_back(int_lit(spec.modifiers.zero_pad ? 1 : 0));
+    args.push_back(int_lit(spec.modifiers.left_align ? 1 : 0));
+    args.push_back(int_lit(is_time ? time_unit_power : 0));
+  }
+  return scope.AddExpr(
+      mir::Expr{
+          .data = mir::ConstructExpr{.args = std::move(args)},
+          .type = unit.builtins.format_spec});
+}
+
+auto BuildPrintItemExpr(
+    mir::CompilationUnit& unit, mir::ProceduralScope& scope,
+    const mir::RuntimePrintItem& item, std::int64_t time_unit_power)
+    -> mir::ExprId {
+  return std::visit(
+      Overloaded{
+          [&](const mir::RuntimePrintLiteral& lit) -> mir::ExprId {
+            const mir::ExprId text = scope.AddExpr(
+                mir::Expr{
+                    .data = mir::StringLiteral{.value = lit.text},
+                    .type = unit.builtins.string});
+            return scope.AddExpr(
+                mir::Expr{
+                    .data = mir::ConstructExpr{.args = {text}},
+                    .type = unit.builtins.print_literal_item});
+          },
+          [&](const mir::RuntimePrintValue& v) -> mir::ExprId {
+            const mir::ExprId spec =
+                BuildFormatSpecExpr(unit, scope, v.spec, time_unit_power);
+            return scope.AddExpr(
+                mir::Expr{
+                    .data = mir::ConstructExpr{.args = {v.value, spec}},
+                    .type = unit.builtins.print_value_item});
+          }},
+      item);
+}
+
+// The array's MIR type supplies only the element type to the renderer; its
+// declared size is not read there, so it merely mirrors the element count.
+auto BuildPrintItemsArray(
+    mir::CompilationUnit& unit, mir::ProceduralScope& scope,
+    const std::vector<mir::RuntimePrintItem>& items,
+    std::int64_t time_unit_power) -> mir::ExprId {
+  std::vector<mir::ExprId> elements;
+  elements.reserve(items.size());
+  for (const mir::RuntimePrintItem& item : items) {
+    elements.push_back(BuildPrintItemExpr(unit, scope, item, time_unit_power));
+  }
+  const mir::TypeId array_type = unit.AddType(
+      mir::TypeData{mir::UnpackedArrayType{
+          .element_type = unit.builtins.print_item, .size = items.size()}});
+  return scope.AddExpr(
+      mir::Expr{
+          .data = mir::ArrayLiteralExpr{.elements = std::move(elements)},
+          .type = array_type});
+}
+
 }  // namespace
 
 auto LowerPrintSystemSubroutineCall(
     ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& call,
+    support::SystemSubroutineId id,
     const support::PrintSystemSubroutineInfo& print, diag::SourceSpan span)
     -> diag::Result<mir::Expr> {
   const auto& hir_proc = process.HirBody();
   auto& proc_scope = *frame.current_procedural_scope;
+  const mir::TypeId void_type = process.Module().Unit().builtins.void_type;
 
   std::optional<mir::ExprId> descriptor = std::nullopt;
   std::size_t arg_offset = 0;
@@ -61,28 +147,41 @@ auto LowerPrintSystemSubroutineCall(
       FormatStringRequirement::kOptional, span);
   if (!items_or) return std::unexpected(std::move(items_or.error()));
 
-  mir::RuntimePrintCall print_call(
-      ToValuePrintKind(print), descriptor, std::move(*items_or));
-
-  if (!print.is_strobe) {
+  // LRM 21.2.2: $strobe defers the same print to the postponed region. The
+  // items keep their outer-scope ExprIds; the backend wraps the rendered print
+  // in a postponed-region lambda whose init-capture list snapshots any
+  // procedural-local operands.
+  if (print.is_strobe) {
+    mir::RuntimePrintCall print_call(
+        ToValuePrintKind(print), descriptor, std::move(*items_or));
     return mir::Expr{
-        .data = mir::RuntimeCallExpr{.call = std::move(print_call)},
-        .type = process.Module().Unit().builtins.void_type};
+        .data =
+            mir::RuntimeCallExpr{
+                .call =
+                    mir::RuntimeSubmitPostponedCall{
+                        .print = std::move(print_call)}},
+        .type = void_type};
   }
 
-  // LRM 21.2.2: $strobe defers the same print to the postponed region. The
-  // items keep their outer-scope ExprIds; the backend wraps the rendered
-  // print in a postponed-region lambda whose init-capture list snapshots
-  // any procedural-local operands. StructuralVarRef operands resolve
-  // through `this->`, so the lambda body reads them at fire time and sees
-  // the NBA-committed values.
+  auto& unit = process.Module().Unit();
+  const auto time_unit_power =
+      static_cast<std::int64_t>(process.Resolution().unit_power);
+  const mir::ExprId items_array =
+      BuildPrintItemsArray(unit, proc_scope, *items_or, time_unit_power);
+
+  std::vector<mir::ExprId> args;
+  args.push_back(proc_scope.AddExpr(BuildServicesCallExpr(process, frame)));
+  if (descriptor.has_value()) {
+    args.push_back(*descriptor);
+  }
+  args.push_back(items_array);
+
   return mir::Expr{
       .data =
-          mir::RuntimeCallExpr{
-              .call =
-                  mir::RuntimeSubmitPostponedCall{
-                      .print = std::move(print_call)}},
-      .type = process.Module().Unit().builtins.void_type};
+          mir::CallExpr{
+              .callee = mir::SystemSubroutineCallee{.id = id},
+              .arguments = std::move(args)},
+      .type = void_type};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -179,6 +179,19 @@ class MirDumper {
             [](const ScopeType&) -> std::string { return "Scope"; },
             [](const SelfType&) -> std::string { return "Self"; },
             [](const ServicesType&) -> std::string { return "Services"; },
+            [](const RuntimeLibraryType& r) -> std::string {
+              switch (r.kind) {
+                case RuntimeLibraryKind::kPrintItem:
+                  return "RuntimeLibrary(PrintItem)";
+                case RuntimeLibraryKind::kPrintLiteralItem:
+                  return "RuntimeLibrary(PrintLiteralItem)";
+                case RuntimeLibraryKind::kPrintValueItem:
+                  return "RuntimeLibrary(PrintValueItem)";
+                case RuntimeLibraryKind::kFormatSpec:
+                  return "RuntimeLibrary(FormatSpec)";
+              }
+              throw InternalError("dump: unknown RuntimeLibraryKind");
+            },
             [](const PointerType& p) -> std::string {
               switch (p.ownership) {
                 case PointerOwnership::kUnique:

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -77,6 +77,7 @@ auto Type::Kind() const -> TypeKind {
           [](const ScopeType&) { return TypeKind::kScope; },
           [](const SelfType&) { return TypeKind::kSelf; },
           [](const ServicesType&) { return TypeKind::kServices; },
+          [](const RuntimeLibraryType&) { return TypeKind::kRuntimeLibrary; },
           [](const PointerType&) { return TypeKind::kPointer; },
           [](const VectorType&) { return TypeKind::kVector; },
           [](const ExternalRefType&) { return TypeKind::kExternalRef; },

--- a/src/lyra/runtime/io.cpp
+++ b/src/lyra/runtime/io.cpp
@@ -7,9 +7,11 @@
 #include <variant>
 
 #include "lyra/base/overloaded.hpp"
+#include "lyra/runtime/file_io.hpp"
 #include "lyra/runtime/runtime_services.hpp"
 #include "lyra/runtime/stream_dispatcher.hpp"
 #include "lyra/value/format.hpp"
+#include "lyra/value/packed_array.hpp"
 
 namespace lyra::runtime {
 
@@ -37,6 +39,28 @@ void LyraPrint(
   const bool append_newline =
       kind == value::PrintKind::kDisplay || kind == value::PrintKind::kFDisplay;
   stream.FinishRecord(append_newline);
+}
+
+void LyraDisplay(
+    RuntimeServices& services, std::span<const value::PrintItem> items) {
+  LyraPrint(services, value::PrintKind::kDisplay, items);
+}
+
+void LyraWrite(
+    RuntimeServices& services, std::span<const value::PrintItem> items) {
+  LyraPrint(services, value::PrintKind::kWrite, items);
+}
+
+void LyraFDisplay(
+    RuntimeServices& services, const value::PackedArray& descriptor,
+    std::span<const value::PrintItem> items) {
+  LyraFPrint(services, value::PrintKind::kFDisplay, descriptor, items);
+}
+
+void LyraFWrite(
+    RuntimeServices& services, const value::PackedArray& descriptor,
+    std::span<const value::PrintItem> items) {
+  LyraFPrint(services, value::PrintKind::kFWrite, descriptor, items);
 }
 
 void LyraSubmitStrobe(

--- a/src/lyra/value/format.cpp
+++ b/src/lyra/value/format.cpp
@@ -123,4 +123,25 @@ auto Formatter<float>::Format(
       FormatRealBody(spec, static_cast<double>(value)), spec);
 }
 
+FormatSpec::FormatSpec(const PackedArray& kind)
+    : kind(static_cast<FormatKind>(kind.ToInt64())) {
+}
+
+FormatSpec::FormatSpec(
+    const PackedArray& kind, const PackedArray& width,
+    const PackedArray& precision, const PackedArray& zero_pad,
+    const PackedArray& left_align, const PackedArray& timeunit_power)
+    : kind(static_cast<FormatKind>(kind.ToInt64())),
+      width(static_cast<std::int32_t>(width.ToInt64())),
+      precision(static_cast<std::int32_t>(precision.ToInt64())),
+      zero_pad(zero_pad.ToInt64() != 0),
+      left_align(left_align.ToInt64() != 0),
+      timeunit_power(static_cast<std::int32_t>(timeunit_power.ToInt64())) {
+}
+
+PrintLiteralItem::PrintLiteralItem(const String& text)
+    : data(text.View().data()),
+      size(static_cast<std::uint32_t>(text.View().size())) {
+}
+
 }  // namespace lyra::value


### PR DESCRIPTION
## Summary

This migrates the print-to-sink family (`$display` / `$write` / `$fdisplay` / `$fwrite`) off the dedicated `RuntimePrintCall` payload node and onto MIR's single generic `CallExpr` shape, per `decisions/runtime-effects-as-generic-calls.md`. Each task lowers to a call whose first argument is a plain `self.Services()` expression, whose optional descriptor follows for the file variants, and whose final argument is a constructed `PrintItem` array. Both backends consume identical input and neither re-derives the engine handle or parses a payload struct.

## Design

The flattening of `$display` items into value-build expressions was the decision's largest remaining piece, and it is what this cut delivers. Each print item is an ordinary `ConstructExpr` over a runtime-library value type: a literal chunk constructs a `PrintLiteralItem` from a string, and a formatted operand constructs a `PrintValueItem` from the operand plus a `FormatSpec` that is itself a `ConstructExpr` of `int` literals. These runtime-library types are named in MIR through one opaque `RuntimeLibraryType` (a pass-through value type MIR never inspects, distinct from the object-model handles `ServicesType` / `ScopeType`), mirroring how `Var<T>` is a library type whose operations appear as ordinary calls. A `%t` directive's time-unit power is the one field not read from the directive itself; it is resolved from the enclosing scope at lowering, exactly as `$time` already does. The print/newline discipline is encoded by selecting the runtime entry (`LyraDisplay` / `LyraWrite` / `LyraFDisplay` / `LyraFWrite`) rather than carried as a `kind` argument, so no `PrintKind` literal is needed.

The runtime print value types gain constructors that take their fields as SV values and convert internally, the same value model the file-IO entries use. The `$strobe`-family, scan, `$sformat`, diagnostic, and submit effects still use `RuntimeCallExpr`; that remains transitional tech debt tracked in the decision doc.

## Testing

`bazel test //...` -- existing `$display` / `$write` / `$fdisplay` / `$fwrite` behavioral cases (including enum, aggregate `%p`, `%t`, and file-descriptor forms) cover the migrated path.