### PR TITLE
Support constant-width slice on dynamic arrays

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -61,6 +61,10 @@ If you are looking for a concept, this table points to the canonical doc.
 | Locating/bundling the C++ runtime; run output contract                    | `runtime_distribution.md`   |
 | Test categories; suite layout; expectation forms                          | `testing_strategy.md`       |
 
+These docs are the contracts. For the trade-off records behind them -- rejected alternatives and
+load-bearing invariants, grouped by subject -- see the Index in
+[`../decisions/README.md`](../decisions/README.md).
+
 ## Required Reading by Decision
 
 Before designing a change, **read `north_star.md` first -- always**. Then read the docs that govern

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -8,6 +8,60 @@ invariants, or constraints that bind the codebase going forward. Housekeeping no
 archive item is subsumed by an existing surface") do not warrant a decisions entry; record the
 reason inline at the point it matters.
 
+## Index
+
+Grouped by subject so a decision is findable by concept, not only by filename. One line per entry.
+
+### Value types and representation
+
+- [integral-representation](integral-representation.md) -- one fat `PackedArray` carries integral
+  shape (width / signedness / 4-state / dims) as runtime fields, not C++ template parameters.
+- [value-assignment-and-moved-from](value-assignment-and-moved-from.md) -- assignment preserves the
+  destination's declared shape and copies bits in; a moved-from value stays valid for STL
+  relocation.
+- [value-type-concepts](value-type-concepts.md) -- the `lyra::value` operator surface is a lattice
+  of composable C++ concepts, one per LRM operator family.
+- [runtime-shape-and-default-value](runtime-shape-and-default-value.md) -- runtime shape lives on
+  `PackedArray`; collections carry one OOB shield slot that is both the canonical-default source and
+  the out-of-bounds-write discard target.
+
+### Aggregate types and access
+
+- [unpacked-array-representation](unpacked-array-representation.md) -- representation of a
+  fixed-size unpacked array.
+- [slice-value-semantics](slice-value-semantics.md) -- a slice read materializes an owned value; the
+  access model is value, not borrow / view.
+- [queue-operators](queue-operators.md) -- queue access operators (`$`, slice, concatenation,
+  equality, append) lower to built-in method calls; read and write are different methods chosen at
+  lowering.
+- [array-method-dispatch](array-method-dispatch.md) -- how the LRM 7.12 array-manipulation method
+  family dispatches per receiver type.
+- [format-dispatch](format-dispatch.md) -- value formatting dispatches through `Formatter<T>` and
+  `FormatArg`.
+
+### Lowering and IR shape
+
+- [lowering-organization](lowering-organization.md) -- how lowering passes organize their internal
+  objects (facts, registries, builders, walk frame).
+- [foreach-lowering](foreach-lowering.md) -- the lowering shape of `foreach`.
+- [conversion-folding](conversion-folding.md) -- when type conversions are folded.
+- [variable-initialization](variable-initialization.md) -- LRM 10.5 variable initialization as a
+  constructor-scope statement.
+- [variable-lifetime-storage](variable-lifetime-storage.md) -- storage of static-lifetime body
+  locals.
+- [read-set-inference](read-set-inference.md) -- read-set inference via slang flow analysis.
+- [runtime-effects-as-generic-calls](runtime-effects-as-generic-calls.md) -- runtime effects
+  (`$display`, `$finish`, file IO) lower to ordinary `CallExpr` with the engine handle as one
+  argument.
+- [callable-receiver](callable-receiver.md) -- every callable body's first binding is `self`; how it
+  is supplied differs per callable form.
+- [event-control-unification](event-control-unification.md) -- unified treatment of event control.
+
+### References and construction
+
+- [upward-reference-resolution](upward-reference-resolution.md) -- upward hierarchical references
+  resolve by self-climb at construction time.
+
 ## File Naming
 
 `kebab-case.md`. The name describes the decision, not when it was made; the date lives inside the

--- a/docs/decisions/slice-value-semantics.md
+++ b/docs/decisions/slice-value-semantics.md
@@ -1,0 +1,141 @@
+# Slice read materializes a value; the access model is value, not borrow
+
+## Date
+
+2026-06-19
+
+## Status
+
+Accepted
+
+## Context
+
+Aggregate access has two sides. A read produces a value; a write targets a location. For a
+whole-variable access this split is invisible -- `x = arr` reads the value, `arr = y` writes the
+variable. Introducing the slice `arr[base+:w]` (LRM 7.4.5 / 7.4.6) made the split visible: the same
+syntactic construct appears as a read on one side of an assignment and a write on the other, and the
+runtime realizes the two differently -- a read returns an owned value, a write returns a transient
+write-back proxy.
+
+This raised a design question worth recording: now that a slice -- a window into an existing
+aggregate -- exists, should the access model shift to a borrow / view model in the style of Rust,
+where a slice is uniformly a view (`&[T]` / `&mut [T]`) and a read is `view` then `to_owned`, a
+write is `view` then scatter? The decisions that set "read produces a value" predate slices, so they
+were re-evaluated against this rather than treated as settled. The write side (a location, realized
+by reference) was not in dispute; the live question was the read side.
+
+The conclusion below is re-derived from SystemVerilog's semantics and the C++ runtime's reality, not
+from the earlier decisions. It happens to agree with them, but the rationale stands on its own.
+
+## Findings
+
+### F1. A SystemVerilog slice is not a Rust slice
+
+A Rust `&v[1..4]` is a borrow of existing contiguous memory: `view[i]` is `*(ptr + i)`, zero-cost
+and branch-free, and an out-of-range range panics -- the borrow is always in bounds. A SystemVerilog
+slice is the opposite kind of object. LRM 7.4.5 + Table 7-1 define it as a total function of the
+base: an out-of-range position reads the element type's default and an x / z offset makes the whole
+slice default. The slice is therefore a logical window that may include positions with no backing
+storage, whose values are synthesized on read. A partially synthesized window has no pure-pointer
+representation; its natural form is a materialized value -- the synthesized and real elements
+gathered into one result.
+
+### F2. SystemVerilog is a value-semantics language
+
+LRM 7.6 makes array assignment a copy and LRM 7.7 makes a by-value array argument a copy ("a copy of
+the array is passed ... true for all array types"). The source language exposes no user-level
+reference or lifetime concept except the scoped `ref` argument. Owned values are the natural
+lowering of such a language. A borrow / view model serves the ownership-and-borrowing semantics of a
+language that has them; importing it into a value-semantics source language adds a concept the
+language does not use.
+
+### F3. Emitted C++ has no borrow checker
+
+Rust's `&[T]` is safe only because the borrow checker proves the borrow does not outlive its owner.
+The emitted C++ has no such proof. A view over resizable storage that escapes its source dangles,
+and nothing in the emitted code catches it:
+
+```
+auto v = arr.Slice(1, 3);   // a view would hold arr's element-vector pointer
+arr = new[100];             // arr's storage reallocates -> v dangles
+... use v ...               // undefined behavior, uncatchable
+```
+
+The SystemVerilog `x = arr[i+:3]; arr = new[N];` is legal and must be safe. Materializing on read
+makes the dangle impossible -- the reader owns an independent copy. The write proxy avoids the same
+hazard by being move-only and consumed within its statement, never stored. Rust's elegance here is
+the pairing of a zero-cost borrow with a checker that makes it safe; emitted C++ can take the borrow
+but not the checker, which leaves only the hazard.
+
+### F4. The emit is expression-oriented and composes values
+
+A slice read flows into value contexts: an assignment right-hand side, an equality operand, a
+by-value argument, a `foreach`. For a slice expression to be usable wherever an aggregate value is
+expected, its result must be a value or must materialize at the point of use. A lazy view delivers
+none of the saving it promises: it either materializes at each use (no copy avoided, plus an
+implicit conversion), or forces an explicit `to_owned` at every site (which breaks composition and
+pushes a read-vs-write branch back into the backend), or requires every aggregate operator to accept
+a view (a large surface duplicated for a marginal copy saved on a typically small slice).
+
+### F5. Read-as-value with write-as-reference is the value-semantics asymmetry
+
+The asymmetry is not a defect. C++ itself reads `int x = a[i];` as a value and writes `a[i] = x;` as
+a location; the same indexed construct is a value on one side and an lvalue on the other. Rust
+unifies the two with `&` / `&mut` because it is borrow-oriented. A value-semantics language does
+not, and a runtime modeling one should not invent the unification.
+
+## Decision
+
+1. **A slice read is a materialized owned value.** The const slice path returns an owned fixed-size
+   unpacked array; the LRM 7.4.5 / Table 7-1 out-of-range and x / z behavior is computed inside the
+   slice operation, the same way packed bit-extraction lives inside the packed slice. The corner
+   cases live in the runtime operation, never exposed as a view accessor a consumer must interpret.
+
+2. **A slice write is a transient write-back proxy.** The non-const slice path returns a move-only
+   proxy whose assignment scatters the values into the source storage; an out-of-range position is
+   skipped and an x / z offset is a whole no-op. The proxy is consumed within its statement and
+   never stored.
+
+3. **A borrow / view is not the access model and is rejected as the primary form**, for F1 through
+   F5: a SystemVerilog slice is a partially synthesized window, not a memory borrow; the source
+   language is value-semantics; the emitted target has no borrow checker; the expression-oriented
+   emit composes values.
+
+4. **A view may be added later as an opt-in fast path**, never the foundation. If profiling shows a
+   read-only consumer (aggregate equality, a reduction, a `foreach`) paying materialization cost
+   that matters, that consumer may take a view input, the way `std::span` / `std::string_view` layer
+   on `std::vector` / `std::string` without displacing them. The owned value stays the default and
+   the foundation.
+
+## Consequences
+
+- Read-as-value and write-as-reference are uniform across whole-variable access, element access, and
+  slice access; a slice looks like every other aggregate access, not like a borrow.
+- The slice read / write asymmetry is intentional and is documented as such, so it is not mistaken
+  for an inconsistency to be unified away.
+- A future view fast path is additive: it does not require rebuilding the value layer, only adding a
+  view-accepting overload where a measurement justifies one.
+
+## Forbidden shapes
+
+- A slice read realized as a borrow or view that the source language's value semantics would have
+  copied. The read materializes.
+- A slice view that is stored, returned, or otherwise escapes the statement that produced it.
+  Without a borrow checker this is a dangling reference over storage that may reallocate.
+- Lifting the LRM out-of-range / clamp / default-fill semantics out of the runtime slice operation
+  into a view accessor that consumers must re-interpret. The corner cases belong inside the
+  operation.
+- Treating read-as-value / write-as-reference as an inconsistency and unifying it under a borrow
+  model. That asymmetry is the shape of a value-semantics language.
+
+## Cross-references
+
+- LRM 7.4.5 + Table 7-1 (invalid-index read / write), 7.4.6 (operations on arrays), 7.6 (array
+  assignment is a copy), 7.7 (a by-value array argument is a copy).
+- `value-assignment-and-moved-from.md` -- the fat-value, shape-preserving assignment model the
+  materialized read produces into.
+- `runtime-shape-and-default-value.md` -- the element-shape shield slot that sources the synthesized
+  default in an out-of-range slice position.
+- `queue-operators.md` -- the parallel "read and write are different operations, chosen at lowering"
+  result for queue access, reached independently for queues; this decision re-derives the read-side
+  half from language semantics rather than citing it.

--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -24,7 +24,7 @@ follow once dynamic array's storage and runtime conventions are settled and prov
 | DA2  | Done: NBA, compound element write, whole-array assignment.              |
 | DA3  | Done: positional and replicated assignment patterns (LRM 10.9.1).       |
 | DA4  | Done: aggregate equality, inequality, case-equality.                    |
-| DA5  | Open: constant-width slice (subject to LRM check).                      |
+| DA5  | Done: constant-width slice (read and write).                            |
 | DA6a | Done: method dispatch + no-`with` subset.                               |
 | DA6b | Done: `with` clause + iterator on sort / rsort / reduction methods.     |
 | DA6c | Done: locator family (find\*, min, max, unique\*).                      |
@@ -83,11 +83,13 @@ The numeric IDs are stable references and do not imply execution order beyond DA
       values and are deterministic. Multi-dimensional and mixed-container nesting (`int [3][]`,
       `int [][3]`) compose through the recursive element type.
 
-- [ ] DA5 -- Constant-width slice (read and write), subject to LRM confirmation. If the LRM permits
-      the `+:` / `-:` indexed-part-select form on `T []`, the in-scope subset mirrors U6:
-      compile-time width, runtime base, lvalue treated as a single assignment to the slice;
-      direction and OOB semantics carry over from U6 / U7. If the LRM forbids slicing on dynamic
-      arrays, DA5 closes by emitting the rejection diagnostic instead.
+- [x] DA5 -- Constant-width slice (read and write). LRM 7.4.6 permits slicing on any unpacked array
+      except associative, so a dynamic array slices like a fixed unpacked array: the constant width
+      makes the result a fixed-size unpacked array, the position may be runtime, and a slice write
+      (LRM 7.6) is a single assignment to the whole slice. All three bound forms (`a:b`, `+:`, `-:`)
+      and multi-dimensional receivers are covered. Direction and out-of-range / x-z semantics carry
+      over from U6 / U7: an out-of-range position reads the element default and is skipped on write,
+      while an x / z position makes the whole slice default on read and a no-op on write.
 
 - [x] DA6a -- Method dispatch infrastructure plus the no-`with`, no-queue-return method subset.
       `.size()` and `.delete()` (LRM 7.5.2 / 7.5.3); the LRM 7.12.2 ordering subset that takes no

--- a/include/lyra/value/array_manipulation.hpp
+++ b/include/lyra/value/array_manipulation.hpp
@@ -271,4 +271,50 @@ template <typename Seq, typename T, typename F, typename Combine>
   return acc;
 }
 
+// LRM 7.4.5 contiguous-range gather. The slice is `count` elements starting at
+// `offset`; an out-of-range position yields `canonical` and an x / z offset
+// (an invalid position) makes the whole result canonical. The flat vector is
+// wrapped by the caller as a fixed-size unpacked array.
+template <typename T>
+[[nodiscard]] auto ArraySliceGather(
+    const std::vector<T>& data, const T& canonical, const PackedArray& offset,
+    std::uint32_t count) -> std::vector<T> {
+  std::vector<T> result;
+  if (offset.HasUnknown()) {
+    result.assign(count, canonical);
+    return result;
+  }
+  result.reserve(count);
+  const auto base = offset.ToInt64();
+  const auto size = static_cast<std::int64_t>(data.size());
+  for (std::uint32_t i = 0; i < count; ++i) {
+    const auto pos = base + static_cast<std::int64_t>(i);
+    const bool in_bounds = pos >= 0 && pos < size;
+    result.push_back(
+        in_bounds ? data[static_cast<std::size_t>(pos)] : canonical);
+  }
+  return result;
+}
+
+// LRM 7.6 + 7.4.5 whole-slice scatter. Each of the `count` values lands at
+// `offset + i`; an out-of-range position is skipped and an x / z offset
+// performs no operation, matching the invalid-index write contract.
+template <typename T>
+auto ArraySliceScatter(
+    std::vector<T>& data, const PackedArray& offset, std::uint32_t count,
+    const std::vector<T>& values) -> void {
+  if (offset.HasUnknown()) {
+    return;
+  }
+  const auto base = offset.ToInt64();
+  const auto size = static_cast<std::int64_t>(data.size());
+  for (std::uint32_t i = 0; i < count; ++i) {
+    const auto pos = base + static_cast<std::int64_t>(i);
+    if (pos < 0 || pos >= size) {
+      continue;
+    }
+    data[static_cast<std::size_t>(pos)] = values[i];
+  }
+}
+
 }  // namespace lyra::value::detail

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -15,6 +15,7 @@
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/queue.hpp"
+#include "lyra/value/unpacked_array.hpp"
 #include "lyra/value/value_concept.hpp"
 
 namespace lyra::value {
@@ -149,6 +150,24 @@ class DynamicArray {
       return oob_slot_;
     }
     return data_[static_cast<std::size_t>(idx.ToInt64())];
+  }
+
+  // LRM 7.4.5 / 7.4.6 contiguous-range selector. A dynamic array slices like
+  // any unpacked array; the constant width makes the result a fixed-size
+  // unpacked array. The const overload materializes a fresh sub-array
+  // (partial-OOB positions and an x / z offset yield the canonical default);
+  // the non-const overload returns the shared write-back proxy with the same
+  // invalid-index policy on `operator=`.
+  [[nodiscard]] auto Slice(const PackedArray& offset, std::uint32_t count) const
+      -> UnpackedArray<T> {
+    const T canonical = MakeCanonicalElement();
+    return UnpackedArray<T>(
+        canonical, detail::ArraySliceGather(data_, canonical, offset, count));
+  }
+
+  [[nodiscard]] auto Slice(const PackedArray& offset, std::uint32_t count)
+      -> ArraySliceRef<T> {
+    return ArraySliceRef<T>{data_, MakeCanonicalElement(), offset, count};
   }
 
   // LRM 11.2.2 + 11.4.5 aggregate equality. Runtime size mismatch yields
@@ -330,6 +349,14 @@ class DynamicArray {
     const auto v = idx.ToInt64();
     return v < 0 || static_cast<std::uint64_t>(v) >=
                         static_cast<std::uint64_t>(data_.size());
+  }
+
+  // Returns a fresh `T` at this container's element shape in LRM Table 7-1
+  // canonical state, disconnected from the OOB shield identity (slice fill).
+  [[nodiscard]] auto MakeCanonicalElement() const -> T {
+    T fresh = oob_slot_;
+    fresh.ResetToDefault();
+    return fresh;
   }
 
   mutable T oob_slot_;

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -21,7 +21,7 @@ namespace lyra::value {
 template <typename T>
 class UnpackedArray;
 template <typename T>
-class UnpackedArrayRef;
+class ArraySliceRef;
 
 // SystemVerilog fixed-size unpacked array (LRM 7.4.2). One C++ container layer
 // per declared unpacked dimension; multi-dim composes as
@@ -136,26 +136,13 @@ class UnpackedArray {
   [[nodiscard]] auto Slice(const PackedArray& offset, std::uint32_t count) const
       -> UnpackedArray {
     const T canonical = MakeCanonicalElement();
-    UnpackedArray result(canonical);
-    if (offset.HasUnknown()) {
-      result.data_.assign(count, canonical);
-      return result;
-    }
-    result.data_.reserve(count);
-    const auto base = offset.ToInt64();
-    const auto size = static_cast<std::int64_t>(data_.size());
-    for (std::uint32_t i = 0; i < count; ++i) {
-      const auto pos = base + static_cast<std::int64_t>(i);
-      const bool in_bounds = pos >= 0 && pos < size;
-      result.data_.push_back(
-          in_bounds ? data_[static_cast<std::size_t>(pos)] : canonical);
-    }
-    return result;
+    return UnpackedArray(
+        canonical, detail::ArraySliceGather(data_, canonical, offset, count));
   }
 
   [[nodiscard]] auto Slice(const PackedArray& offset, std::uint32_t count)
-      -> UnpackedArrayRef<T> {
-    return UnpackedArrayRef<T>{*this, offset, count};
+      -> ArraySliceRef<T> {
+    return ArraySliceRef<T>{data_, MakeCanonicalElement(), offset, count};
   }
 
   // LRM 11.2.2 + 11.4.5 aggregate equality / case-equality. Slang's binding
@@ -330,63 +317,47 @@ class UnpackedArray {
   mutable T oob_slot_;
   std::vector<T> data_;
 
-  friend class UnpackedArrayRef<T>;
+  friend class ArraySliceRef<T>;
 };
 
 // LRM 7.6: an assignment to an unpacked slice is a single assignment to the
-// entire slice. The proxy holds a non-owning pointer back to the source array
-// plus the (offset, count) window. X / Z offset makes `Clone()` return a
-// wholly-default sub-array and `operator=` a no-op; partial-OOB behaves
-// per-element. Move-only so the proxy cannot outlive the source it aliases.
+// entire slice. The proxy aliases the source storage (a non-owning pointer to
+// its element vector) plus the (offset, count) window, so a fixed-size unpacked
+// array and a dynamic array share one slice-write surface. X / Z offset makes
+// `Clone()` a wholly-default sub-array and `operator=` a no-op; partial-OOB
+// behaves per-element. Move-only so the proxy cannot outlive what it aliases.
 template <typename T>
-class UnpackedArrayRef {
+class ArraySliceRef {
  public:
-  UnpackedArrayRef(
-      UnpackedArray<T>& base, const PackedArray& offset, std::uint32_t count)
-      : base_(&base),
-        offset_unknown_(offset.HasUnknown()),
-        offset_(offset_unknown_ ? 0 : offset.ToInt64()),
+  ArraySliceRef(
+      std::vector<T>& data, T canonical, PackedArray offset,
+      std::uint32_t count)
+      : data_(&data),
+        canonical_(std::move(canonical)),
+        offset_(std::move(offset)),
         count_(count) {
   }
-  UnpackedArrayRef(const UnpackedArrayRef&) = delete;
-  auto operator=(const UnpackedArrayRef&) -> UnpackedArrayRef& = delete;
-  UnpackedArrayRef(UnpackedArrayRef&&) noexcept = default;
-  auto operator=(UnpackedArrayRef&&) noexcept -> UnpackedArrayRef& = default;
-  ~UnpackedArrayRef() = default;
+  ArraySliceRef(const ArraySliceRef&) = delete;
+  auto operator=(const ArraySliceRef&) -> ArraySliceRef& = delete;
+  ArraySliceRef(ArraySliceRef&&) noexcept = default;
+  auto operator=(ArraySliceRef&&) noexcept -> ArraySliceRef& = default;
+  ~ArraySliceRef() = default;
 
   [[nodiscard]] auto Clone() const -> UnpackedArray<T> {
-    const T canonical = base_->MakeCanonicalElement();
-    UnpackedArray<T> result(canonical);
-    if (offset_unknown_) {
-      result.data_.assign(count_, canonical);
-      return result;
-    }
-    result.data_.reserve(count_);
-    const auto size = static_cast<std::int64_t>(base_->data_.size());
-    for (std::uint32_t i = 0; i < count_; ++i) {
-      const auto pos = offset_ + static_cast<std::int64_t>(i);
-      const bool in_bounds = pos >= 0 && pos < size;
-      result.data_.push_back(
-          in_bounds ? base_->data_[static_cast<std::size_t>(pos)] : canonical);
-    }
-    return result;
+    return UnpackedArray<T>(
+        canonical_,
+        detail::ArraySliceGather(*data_, canonical_, offset_, count_));
   }
 
-  auto operator=(const UnpackedArray<T>& value) -> UnpackedArrayRef& {
-    if (offset_unknown_) return *this;
-    const auto size = static_cast<std::int64_t>(base_->data_.size());
-    for (std::uint32_t i = 0; i < count_; ++i) {
-      const auto pos = offset_ + static_cast<std::int64_t>(i);
-      if (pos < 0 || pos >= size) continue;
-      base_->data_[static_cast<std::size_t>(pos)] = value.data_[i];
-    }
+  auto operator=(const UnpackedArray<T>& value) -> ArraySliceRef& {
+    detail::ArraySliceScatter(*data_, offset_, count_, value.data_);
     return *this;
   }
 
  private:
-  UnpackedArray<T>* base_;
-  bool offset_unknown_;
-  std::int64_t offset_;
+  std::vector<T>* data_;
+  T canonical_;
+  PackedArray offset_;
   std::uint32_t count_;
 };
 

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -58,6 +58,27 @@ auto IntConstFromMirExpr(const mir::Expr& expr) -> std::int64_t {
       "IntConstFromMirExpr: expression is not an IntegerLiteral");
 }
 
+// Builds the `base <op> value` expression for a slice-bound offset. The delta
+// literal matches `base`'s state-kind so the runtime arithmetic never mixes a
+// 2-state literal with a 4-state index; an x / z index then propagates into the
+// offset and invalidates the whole slice (LRM 7.4.5). The caller adds the
+// returned expression to its scope.
+auto BuildOffsetDelta(
+    const ModuleLowerer& module, mir::ProceduralScope& proc_scope,
+    mir::ExprId base, std::int64_t value, mir::BinaryOp op) -> mir::Expr {
+  const auto base_type = proc_scope.GetExpr(base).type;
+  const auto& base_ty = module.Unit().GetType(base_type);
+  const bool four_state =
+      base_ty.IsIntegralPacked() && base_ty.AsIntegralPacked().IsFourState();
+  const auto delta_lit = proc_scope.AddExpr(
+      four_state
+          ? mir::MakeIntegerLiteral(module.Unit().builtins.integer, value)
+          : mir::MakeInt32Literal(module.Unit().builtins.int32, value));
+  return mir::Expr{
+      .data = mir::BinaryExpr{.op = op, .lhs = base, .rhs = delta_lit},
+      .type = base_type};
+}
+
 // LRM 7.4.5 + 11.5.1: the three source-faithful bound forms collapse to a
 // single (offset, count) shape at HIR -> MIR. ConstantBounds reduce by
 // reading both folded literals; IndexedUp uses base/width directly;
@@ -105,18 +126,9 @@ auto UnfoldHirRangeBoundsToOffsetCount(
             if (!width) return std::unexpected(std::move(width.error()));
             const auto count = static_cast<std::uint32_t>(
                 IntConstFromMirExpr(proc_scope.GetExpr(*width)));
-            const auto base_type = proc_scope.GetExpr(*base).type;
-            const auto sub_lit = proc_scope.AddExpr(
-                mir::MakeInt32Literal(
-                    int32_type, static_cast<std::int64_t>(count) - 1));
-            const auto offset = proc_scope.AddExpr(
-                mir::Expr{
-                    .data =
-                        mir::BinaryExpr{
-                            .op = mir::BinaryOp::kSub,
-                            .lhs = *base,
-                            .rhs = sub_lit},
-                    .type = base_type});
+            const auto offset = proc_scope.AddExpr(BuildOffsetDelta(
+                module, proc_scope, *base, static_cast<std::int64_t>(count) - 1,
+                mir::BinaryOp::kSub));
             return RangeOffsetCount{.offset_expr = offset, .count = count};
           },
       },
@@ -158,17 +170,11 @@ auto UnfoldHirRangeBoundsForUnpacked(
     const ModuleLowerer& module, mir::ProceduralScope& proc_scope,
     const hir::RangeBounds& bounds, const hir::UnpackedRange& declared,
     std::uint32_t count, LowerOne lower_one) -> diag::Result<RangeOffsetCount> {
-  const mir::TypeId int32_type = module.Unit().builtins.int32;
   const bool descending = declared.left >= declared.right;
   auto with_delta = [&](mir::ExprId base, std::int64_t delta,
                         mir::BinaryOp op) -> mir::ExprId {
-    const auto base_type = proc_scope.GetExpr(base).type;
-    const auto delta_lit =
-        proc_scope.AddExpr(mir::MakeInt32Literal(int32_type, delta));
     return proc_scope.AddExpr(
-        mir::Expr{
-            .data = mir::BinaryExpr{.op = op, .lhs = base, .rhs = delta_lit},
-            .type = base_type});
+        BuildOffsetDelta(module, proc_scope, base, delta, op));
   };
   return std::visit(
       Overloaded{

--- a/tests/cases/cpp/dynamic_array_slice/case.yaml
+++ b/tests/cases/cpp/dynamic_array_slice/case.yaml
@@ -1,0 +1,20 @@
+id: cpp.dynamic_array_slice
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    up: [20, 30, 40]
+    down: [20, 30, 40]
+    cst: [30, 40]
+    oob: [40, 50, 0]
+    oob4: ["8'h33", "8'bxxxxxxxx", "8'bxxxxxxxx"]
+    xoff: [0, 0]
+    sub: [[1, 2], [3, 4]]
+    warr: [10, 100, 200, 300, 50]
+    woob: [10, 20, 30, 100, 200]
+    wx: [10, 20, 30, 40, 50]

--- a/tests/cases/cpp/dynamic_array_slice/main.sv
+++ b/tests/cases/cpp/dynamic_array_slice/main.sv
@@ -1,0 +1,46 @@
+module Top;
+  // LRM 7.4.6: a constant-width slice is a valid operation on a dynamic array
+  // (only associative arrays cannot be sliced). LRM 7.4.5: the width is
+  // constant and the position may be runtime; an out-of-range position fills
+  // with the element type's Table 7-1 default and an x / z position makes the
+  // whole slice default. A slice write (LRM 7.6) is a single assignment to the
+  // whole slice: out-of-range positions are skipped and an x / z position
+  // performs no operation. The result of slicing a dynamic array is a
+  // fixed-size unpacked array of the constant width.
+  int arr [] = '{10, 20, 30, 40, 50};
+  logic [7:0] larr [] = '{8'h11, 8'h22, 8'h33};
+  int m [][] = '{'{1, 2}, '{3, 4}, '{5, 6}};
+  integer base;
+
+  int up [3];
+  int down [3];
+  int cst [2];
+  int oob [3];
+  logic [7:0] oob4 [3];
+  int xoff [2];
+  int sub [2][];
+
+  int warr [] = '{10, 20, 30, 40, 50};
+  int woob [] = '{10, 20, 30, 40, 50};
+  int wx [] = '{10, 20, 30, 40, 50};
+
+  initial begin
+    base = 1;
+    up = arr[base +: 3];
+    base = 3;
+    down = arr[base -: 3];
+    cst = arr[2:3];
+    oob = arr[3 +: 3];
+    oob4 = larr[2 +: 3];
+    base = 'x;
+    xoff = arr[base +: 2];
+    base = 0;
+    sub = m[base +: 2];
+
+    base = 1;
+    warr[base +: 3] = '{100, 200, 300};
+    woob[3 +: 3] = '{100, 200, 300};
+    base = 'x;
+    wx[base +: 2] = '{100, 200};
+  end
+endmodule


### PR DESCRIPTION
## Summary

Dynamic-array element access now supports the LRM 7.4.6 constant-width slice for both read and write, closing DA5. A dynamic array slices like a fixed unpacked array: the constant width makes the result a fixed-size unpacked array, the base position may be a runtime value, and an out-of-range position or an x / z offset follows the LRM 7.4.5 invalid-index contract (element default on read, no operation on write). All three bound forms (`a:b`, `+:`, `-:`) and multi-dimensional receivers are covered.

## Design

The HIR-to-MIR lowering and the backend render already produced the slice node and emitted a uniform `.Slice(offset, count)` call; the only missing piece was the runtime method. `DynamicArray::Slice` is added as a const read returning an owned fixed-size unpacked array and a non-const write returning a transient write-back proxy. The gather and scatter algorithms and the write proxy are factored into shared helpers so a fixed unpacked array and a dynamic array drive one implementation -- the previous `UnpackedArrayRef` is generalized into the substrate-agnostic `ArraySliceRef`. A latent bug surfaced by a 4-state index is fixed in the same change: the synthesized `-:` offset literal now matches the index's state-kind, so the runtime arithmetic never mixes a 2-state literal with a 4-state operand.

The read-by-value / write-by-reference choice was re-derived from SystemVerilog's value semantics and the C++ runtime's reality and recorded as a decision (`slice-value-semantics.md`); a borrow / view model is rejected as the primary form and reserved as a future opt-in fast path. The decisions directory also gains a grouped index, linked from the architecture concept index, so a decision is findable by concept rather than only by filename.

## Testing

A new end-to-end case exercises all three bound forms, partial out-of-bounds and x / z offsets on read across 2-state and 4-state element defaults, the write no-op on an out-of-range or x / z offset, and a multi-dimensional slice. The full `bazel test //...` suite passes.
