### PR TITLE
Lift selector and observable dispatch into explicit MIR calls

### DIFF
--- a/docs/progress/datatypes.md
+++ b/docs/progress/datatypes.md
@@ -52,6 +52,11 @@ LRM 6.12: `real` is IEEE 754 double, `shortreal` is IEEE 754 single, `realtime` 
 - [x] C4 -- LRM-illegal real forms (LRM 6.12 + 11.3.1 / Table 11-1) diagnose as `diag::Unsupported`
       with an LRM citation. Slang's frontend filters all but case equality (`===` / `!==`); the
       case-equality path is guarded at lowering.
+- [ ] C5 -- Observable storage for module-scope `real` / `shortreal` / `realtime` signals. Today a
+      module-scope floating-point variable lowers to plain value storage rather than an observable
+      cell, so `@(sig)`, `wait (sig == ...)`, and non-blocking writes do not propagate change events
+      for it. Blocked on first-class runtime support for the floating-point value family; once that
+      lands the observable-storage gate extends uniformly with no further special-casing.
 
 ### Cross-references
 

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -285,16 +285,47 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       in lockstep. See `docs/decisions/callable-receiver.md`. **Trigger**: scheduled in front of
       R18.
 
-- [ ] R17 -- Make the ref-vs-value distinction explicit in MIR for selector expressions. Today
-      `mir::ElementSelectExpr` and `mir::RangeSelectExpr` render to runtime `PackedArrayRef` view
-      values; the public `RenderExpr` wraps the rendered string in `.Clone()` when the expression
-      yields a ref so consumers see an owning value. The wrap decision lives in the render
-      (`ProducesPackedArrayRef`). Either lift ref-producing expressions into an explicit MIR shape
-      (e.g. an explicit `CloneExpr` inserted by HIR-to-MIR at the value-context boundary, or a
-      separate ref-vs-value type-level distinction), so the render is a mechanical one-form-per-
-      node mapping with no post-process wrap. **Trigger**: design decision pending -- the exact
-      shape (explicit `CloneExpr` versus type-level ref/value split) is to be discussed before this
-      entry is sharpened.
+- [x] R17 -- Selector and packed-struct field access lower to explicit
+      `Call(ArrayMethod{kElementAt|kSlice})` / `Call(AssociativeMethod{kRead|kElementRef})`, and
+      HIR-to-MIR materialises a borrowed `PackedArrayRef` chain with an explicit
+      `Call(ArrayMethod{kToOwned})` wrap. `mir::ElementSelectExpr` and `mir::RangeSelectExpr` are
+      retired; the render decides the emit shape from the callee alone. The runtime mirrors Rust's
+      `ToOwned` trait -- ref types expose `ToOwned()` for materialisation, owning types expose the
+      same name as an explicit copy.
+
+- [x] R17a -- Signed-slice re-interpretation is explicit in MIR. HIR-to-MIR types a packed struct /
+      union field slice with the runtime-honest unsigned signedness and wraps signed-field accesses
+      with an explicit `ConversionExpr` re-tag to the declared field type. Render is a pure
+      mechanical translation of `Call(kSlice)` / `Call(kToOwned)` / `ConversionExpr` independently.
+
+- [ ] R17b -- Stop window-projecting the `kSlice` `count` argument from an `IntegerLiteral` in the
+      C++ backend. Today `RenderArrayMethodCall` peeks at the third argument of a
+      `Call(ArrayMethod{kSlice})` and -- only when that argument is a literal -- emits a raw `N U`
+      integer, because the runtime `Slice` signature takes `std::uint32_t`. The peek is a backend
+      re-derivation that no other backend will replicate uniformly, violating `mir.md` Core
+      Invariant 10. Target shape: the runtime `Slice` accepts a `PackedArray` for `count` and
+      projects to `std::uint32_t` internally (matching how the `offset` argument already flows);
+      render renders the `Call` mechanically with no peek. **Trigger**: standalone, batches with
+      R17a as one render-cleanup cut.
+
+- [x] R17c -- Render-side method-receiver dispatch is gone. `RenderMethodReceiver` retired and every
+      method-call render path (`String` / `Array` / `Queue` / `Associative` / `Observable`) renders
+      its receiver through plain `RenderExpr`. The read-vs-write decision lives entirely on the MIR
+      receiver chain (LHS-side callees, `Deref(Mutate)` wraps) produced by HIR-to-MIR.
+
+- [ ] R17d -- Lift the remaining backend-side post-process wraps in the method-call render paths
+      into explicit MIR. Today `RenderArrayMethodCall` / `RenderQueueMethodCall` /
+      `RenderAssociativeMethodCall` synthesise `lyra::value::PackedArray::Int(...)` around the
+      result of size-style methods (`kSize` on Array / Queue; `kNum` / `kSize` / `kExists` on
+      Associative) because the runtime returns `std::size_t` / `bool`, and `RenderStringMethodCall`
+      projects integral string-method arguments through `static_cast<std::int32_t>((...).ToInt64())`
+      because the runtime method takes `std::int32_t`. Both are backend re-derivations of facts MIR
+      did not state, violating `mir.md` Core Invariant 10. Target shape: either the runtime APIs
+      change to take and return `PackedArray` uniformly (the cleanest bridge), or HIR-to-MIR wraps
+      the corresponding `Call(...)` with an explicit `ConversionExpr` so render is purely
+      mechanical. After this, the five method-call render paths share an identical 5-step shape
+      (receiver / `.` / name+`(` / args / `)`) and can collapse into one shared helper parameterised
+      by the per-family member-name table. **Trigger**: batches with R17b as one render-cleanup cut.
 
 - [ ] R18 -- Rewrite the MIR-to-C++ backend to free functions per node kind, with no
       `RenderContext`, no class hierarchy, and no `WalkFrame`. Once R11 has removed the mutable
@@ -368,40 +399,10 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       discussion -- requires walking the structural / procedural axis across MIR vocabulary, dumper,
       lowering helpers, and backend, deciding what stays paired and what merges.
 
-- [ ] R23 -- Make the "materialize a reference into an owning value" (`.Clone()`) a node in MIR
-      instead of a render-time decision. Today a reference-producing read -- an element / range /
-      field select that yields a `PackedArrayRef` view into packed bit storage, or a container `T&`
-      for an unpacked / dynamic / queue element -- is materialized by the C++ backend: `RenderExpr`
-      wraps the result in `.Clone()` when `ProducesPackedArrayRef(expr)` holds, while
-      `RenderExprNatural` leaves the bare reference for lvalue / write contexts. So the same MIR
-      node (e.g. `ElementSelectExpr`) emits two different C++ strings (`x` vs `(x).Clone()`)
-      depending on which render entry point reaches it -- a semantic decision made in the backend.
-      `.Clone()` is a real operation (a method call that copies a borrowed reference / view into an
-      independent owning value); it must be represented in MIR so that every backend renders it. A
-      future LIR / LLVM backend that mechanically lowers MIR would not know to clone -- the decision
-      lives only in the C++ renderer -- so the two backends would diverge on value / aliasing
-      semantics (the LIR path would alias storage that the C++ path snapshots). Target shape: an
-      explicit MIR materialize node inserted at the HIR -> MIR boundary wherever a
-      reference-producing read is used in a value position (a read that escapes, is stored, or could
-      alias a subsequent mutation); the backend then renders mechanically -- a select renders to its
-      reference form, the materialize node renders to `.Clone()` -- with the `RenderExpr` /
-      `RenderExprNatural` split and the `ProducesPackedArrayRef` predicate both deleted. The
-      decision returns to the semantic layer that owns it, and "two different MIR -> two different
-      emit" holds. **Why surfaced**: pre-existing, not caused by the foreach work; foreach's
-      synthetic `.size()` on a jagged dynamic-of-dynamic array made it visible
-      (`jag[i].Clone().Size()` copies a whole row just to read its size). The associative-array work
-      surfaced it more sharply: a builtin-method **receiver** rendered through the value path
-      clones, and a nested associative receiver (`mm[i].exists(j)`, `mm[i].delete(j)`, or the
-      traversal `mm[i].first(k)`) has element type `AssociativeArray`, which has no `Clone()` -- so
-      the split is a hard compile error there, and for `delete` it would also be a silent
-      correctness bug (mutating a throwaway copy). Interim: associative method receivers render
-      through the reference path, which is the value model R23 will generalize, so this is
-      alignment, not a new band-aid; the remaining R23 scope is value-position reads that genuinely
-      escape. **Why deferred**: a cross-cutting change to the backend value model -- MIR vocabulary,
-      the HIR -> MIR value-vs-reference context decision, the dumper, and the backend -- far larger
-      than, and orthogonal to, any feature that surfaces it. **Trigger**: the LIR / LLVM backend
-      work (when cross-backend divergence becomes real), or any change to the backend's clone /
-      reference rendering.
+- [x] R23 -- "Materialise a reference into an owning value" is an explicit
+      `Call(ArrayMethod{kToOwned})` node in MIR (Rust's `ToOwned` trait). HIR-to-MIR inserts the
+      wrap at the read boundary; render is a mechanical translation. The `RenderExpr` /
+      `RenderExprNatural` split and `ProducesPackedArrayRef` predicate are gone.
 
 - [ ] R24 -- Dispatch the "sized collection" concept (`.size()` / `.num()`) through one resolver
       instead of branching on the concrete container at each call site. Today the element-count

--- a/include/lyra/backend/cpp/render_expr.hpp
+++ b/include/lyra/backend/cpp/render_expr.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <string_view>
 
 #include "lyra/backend/cpp/render_context.hpp"
 #include "lyra/diag/diagnostic.hpp"
@@ -18,19 +17,13 @@ auto RenderStructuralVarName(
     const RenderContext& ctx, const mir::StructuralVarRef& ref)
     -> diag::Result<std::string>;
 
-// Renders `expr` as an lvalue: bare root + optional `mutate_adapter`
-// (e.g. `.Mutate(svc)` for partial-write chains) + element / range select
-// suffixes. Throws InternalError on non-addressable forms.
-auto RenderLhsExpr(
-    const RenderContext& ctx, const mir::Expr& expr,
-    std::string_view mutate_adapter) -> diag::Result<std::string>;
-
-// Reports whether the lvalue chain `expr` ultimately writes through an
-// observable cell (a `mir::ObservableType`-wrapped structural var or an
-// extern-ref slot). Sites that need to bind the cell for `Var<T>::Mutate`
-// dispatch consult this before choosing the lvalue render path.
-[[nodiscard]] auto LhsRootIsObservableScalar(
-    const RenderContext& ctx, const mir::Expr& expr) -> bool;
+// Renders `expr` as an lvalue: bare root + element / range select suffixes.
+// Throws InternalError on non-addressable forms. The cell's `Mutate(svc)`
+// adapter (if any) is encoded explicitly in MIR as a
+// `DerefExpr(CallExpr(ObservableMethod{kMutate}, ...))` node by HIR-to-MIR,
+// so this render is purely structural -- it does not inject any wrapper.
+auto RenderLhsExpr(const RenderContext& ctx, const mir::Expr& expr)
+    -> diag::Result<std::string>;
 
 // Renders `expr` for use in a C++ boolean context (`if`, `while`, `do`, `for`
 // condition, ternary cond, `&&` / `||` / `!`). When the expression's MIR type

--- a/include/lyra/lowering/hir_to_mir/copy_out_desugar.hpp
+++ b/include/lyra/lowering/hir_to_mir/copy_out_desugar.hpp
@@ -8,7 +8,9 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
+#include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/stmt.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -56,6 +58,7 @@ auto BuildOutputArgSlot(
 // call statement is emitted as a suspension (`AwaitStmt`); an `lhs = f(...)`
 // shape is a function and never suspends.
 auto BuildCopyOutBlock(
+    const mir::CompilationUnit& unit, mir::ExprId services_id,
     WalkFrame parent_frame, mir::ProceduralScope wrapper,
     std::optional<std::string> label, mir::TypeId result_type,
     mir::Expr call_expr, bool call_suspends,

--- a/include/lyra/lowering/hir_to_mir/expression/selects.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/selects.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-// Lowering of access primitives (LRM 11.5 select expressions): element-,
-// range-, and member-select. Member-access on a packed struct / union
-// resolves to a `RangeSelectExpr` over the aggregate's bit plane (LRM
-// 7.2.1) -- MIR carries no struct-specific node.
+// LRM 11.5 select expressions: element-, range-, and member-select.
+// LRM 7.2.1: a packed struct / union field access lowers as a slice over
+// the aggregate's bit plane -- MIR carries no struct-specific node.
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
@@ -25,6 +24,19 @@ auto LowerHirMemberAccessExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::MemberAccessExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
 
+// LHS-context selector lowerings: like the read-context handlers but the
+// base lowers through `LowerLhsExpr`, leaving the chain cell-rooted with no
+// `ObservableMethod{kGet}` wrap.
+auto LowerHirElementSelectExprProcLhs(
+    ProcessLowerer& process, WalkFrame frame, const hir::ElementSelectExpr& sel,
+    mir::TypeId result_type) -> diag::Result<mir::Expr>;
+auto LowerHirRangeSelectExprProcLhs(
+    ProcessLowerer& process, WalkFrame frame, const hir::RangeSelectExpr& sel,
+    mir::TypeId result_type) -> diag::Result<mir::Expr>;
+auto LowerHirMemberAccessExprProcLhs(
+    ProcessLowerer& process, WalkFrame frame, const hir::MemberAccessExpr& sel,
+    mir::TypeId result_type) -> diag::Result<mir::Expr>;
+
 auto LowerHirElementSelectExprStructural(
     const StructuralScopeLowerer& scope, WalkFrame frame,
     const hir::ElementSelectExpr& sel, mir::TypeId result_type)
@@ -34,6 +46,19 @@ auto LowerHirRangeSelectExprStructural(
     const hir::RangeSelectExpr& sel, mir::TypeId result_type)
     -> diag::Result<mir::Expr>;
 auto LowerHirMemberAccessExprStructural(
+    const StructuralScopeLowerer& scope, WalkFrame frame,
+    const hir::MemberAccessExpr& sel, mir::TypeId result_type)
+    -> diag::Result<mir::Expr>;
+
+auto LowerHirElementSelectExprStructuralLhs(
+    const StructuralScopeLowerer& scope, WalkFrame frame,
+    const hir::ElementSelectExpr& sel, mir::TypeId result_type)
+    -> diag::Result<mir::Expr>;
+auto LowerHirRangeSelectExprStructuralLhs(
+    const StructuralScopeLowerer& scope, WalkFrame frame,
+    const hir::RangeSelectExpr& sel, mir::TypeId result_type)
+    -> diag::Result<mir::Expr>;
+auto LowerHirMemberAccessExprStructuralLhs(
     const StructuralScopeLowerer& scope, WalkFrame frame,
     const hir::MemberAccessExpr& sel, mir::TypeId result_type)
     -> diag::Result<mir::Expr>;

--- a/include/lyra/lowering/hir_to_mir/lhs_observable.hpp
+++ b/include/lyra/lowering/hir_to_mir/lhs_observable.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <optional>
+
+#include "lyra/mir/binary_op.hpp"
+#include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/expr_id.hpp"
+#include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type_id.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// Walks through container-access CallExprs to the LHS chain's root primary.
+[[nodiscard]] auto FindLhsRootId(
+    const mir::ProceduralScope& scope, mir::ExprId lhs_id) -> mir::ExprId;
+
+// Rebuilds the LHS chain with its root replaced by
+// `DerefExpr(CallExpr(ObservableMethod{kMutate}, [cell, services]))`. The
+// returned chain is value-typed; the `ScopedMutation` destructor commits via
+// `Var::Set` at full-expression end. Precondition: the LHS root MIR type
+// satisfies `IsObservableCellType`.
+[[nodiscard]] auto RewriteLhsRootWithMutate(
+    const mir::CompilationUnit& unit, mir::ProceduralScope& scope,
+    mir::ExprId lhs_id, mir::ExprId services_id) -> mir::ExprId;
+
+// Builds an `lhs op= rhs` (or simple `lhs = rhs`) expression, routing
+// through the observable wrapper API when the LHS root is an observable
+// cell. Result shape:
+//   non-observable                    -> `AssignExpr{lhs, rhs, op?}`
+//   observable bare cell, simple `=`  -> `Call(ObservableMethod{kSet}, ...)`
+//   observable, anything else         -> `AssignExpr{rewritten_lhs, rhs, op?}`
+//                                        with the root wrapped in
+//                                        `Deref(Call(kMutate))`.
+// `services_id` is consumed only on the observable paths.
+[[nodiscard]] auto BuildObservableAssignExpr(
+    const mir::CompilationUnit& unit, mir::ProceduralScope& scope,
+    mir::ExprId services_id, mir::ExprId lhs_id, mir::ExprId rhs_id,
+    std::optional<mir::BinaryOp> compound_op, mir::TypeId result_type,
+    mir::TypeId void_type) -> mir::Expr;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
@@ -85,7 +85,15 @@ class ProcessLowerer {
   // each kind to the per-family handler in `expression/{operators, calls,
   // references, selects, aggregates, assignment, inside}.cpp`. Handlers
   // recurse through this method; sub-expressions reach `frame` through it.
+  // An observable-cell leaf is auto-wrapped in an `ObservableMethod{kGet}`
+  // call so the result is a value-typed expression.
   auto LowerExpr(const hir::Expr& expr, WalkFrame frame)
+      -> diag::Result<mir::Expr>;
+
+  // LHS-context expression dispatcher: same dispatch as `LowerExpr` but
+  // without the `ObservableMethod{kGet}` auto-wrap, so an observable-cell
+  // leaf flows out as the bare cell expression.
+  auto LowerLhsExpr(const hir::Expr& expr, WalkFrame frame)
       -> diag::Result<mir::Expr>;
 
   // Central statement dispatcher. One switch over `hir::Stmt::data` routing

--- a/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
@@ -80,10 +80,12 @@ class StructuralScopeLowerer {
   [[nodiscard]] auto LowerExpr(const hir::Expr& expr, WalkFrame frame) const
       -> diag::Result<mir::Expr>;
 
-  [[nodiscard]] auto Module() -> ModuleLowerer& {
-    return *module_;
-  }
-  [[nodiscard]] auto Module() const -> const ModuleLowerer& {
+  // LHS-context expression dispatcher: addressable kinds only, no auto-Get
+  // wrap. Mirrors `ProcessLowerer::LowerLhsExpr`.
+  [[nodiscard]] auto LowerLhsExpr(const hir::Expr& expr, WalkFrame frame) const
+      -> diag::Result<mir::Expr>;
+
+  [[nodiscard]] auto Module() const -> ModuleLowerer& {
     return *module_;
   }
 

--- a/include/lyra/lowering/hir_to_mir/walk_frame.hpp
+++ b/include/lyra/lowering/hir_to_mir/walk_frame.hpp
@@ -3,8 +3,10 @@
 #include <cstdint>
 #include <optional>
 
+#include "lyra/base/internal_error.hpp"
 #include "lyra/lowering/hir_to_mir/procedural_depth.hpp"
 #include "lyra/mir/procedural_var.hpp"
+#include "lyra/mir/structural_hops.hpp"
 
 namespace lyra::mir {
 struct StructuralScope;
@@ -14,6 +16,17 @@ struct ProceduralScope;
 namespace lyra::lowering::hir_to_mir {
 
 class CaptureSink;
+
+// Singly-linked node carrying a structural scope's parent chain so a leaf
+// reference can read the declared type of a `StructuralVar` at `hops > 0`.
+// Each node lives on the stack of the `StructuralScopeLowerer::Run` that
+// pushed it; the chain extends one node per scope opened during traversal.
+// Mirrors `RenderContext`'s `structural_parent_` link so lowering and render
+// reach the same `mir::StructuralVarDecl` for any (hops, var) reference.
+struct ScopeChainNode {
+  const mir::StructuralScope* scope;
+  const ScopeChainNode* parent;
+};
 
 // How a HIR `LoopVarRef` resolves at the structural-scope dispatcher. The two
 // values correspond to the two structural contexts a constructor expression
@@ -42,6 +55,13 @@ struct WalkFrame {
   // task constructs its scope and entered via `WithStructuralScope`. Null
   // outside structural-scope handlers.
   mir::StructuralScope* current_structural_scope = nullptr;
+
+  // Outer structural scopes reached by climbing `parent` links, in the same
+  // order as the lowerer `parent_` chain. Populated by `WithStructuralScope`
+  // when a `StructuralScopeLowerer::Run` opens a new scope. Read via
+  // `StructuralScopeAtHops` to resolve a `StructuralVar` reference at
+  // `hops > 0`.
+  const ScopeChainNode* outer_structural_scopes = nullptr;
 
   // The current procedural-scope write target. Set when a walker opens a new
   // procedural scope (process body, nested block body, fork branch body,
@@ -97,11 +117,42 @@ struct WalkFrame {
   // lowering; no other access form distinguishes read from write at this layer.
   bool is_lvalue_target = false;
 
-  [[nodiscard]] auto WithStructuralScope(mir::StructuralScope* scope) const
+  // Pushes `scope` as the current structural scope and links the previous
+  // `current_structural_scope` into the outer chain through `chain_node`,
+  // which the caller stack-allocates so its lifetime spans the descent.
+  [[nodiscard]] auto WithStructuralScope(
+      mir::StructuralScope* scope, ScopeChainNode& chain_node) const
       -> WalkFrame {
+    chain_node.scope = current_structural_scope;
+    chain_node.parent = outer_structural_scopes;
     WalkFrame next = *this;
     next.current_structural_scope = scope;
+    next.outer_structural_scopes = current_structural_scope != nullptr
+                                       ? &chain_node
+                                       : outer_structural_scopes;
     return next;
+  }
+
+  // Resolves the structural scope at `hops`: 0 yields the current one, N
+  // walks N steps through `outer_structural_scopes`.
+  [[nodiscard]] auto StructuralScopeAtHops(mir::StructuralHops hops) const
+      -> const mir::StructuralScope& {
+    if (hops.value == 0) {
+      if (current_structural_scope == nullptr) {
+        throw InternalError(
+            "WalkFrame::StructuralScopeAtHops: no current structural scope");
+      }
+      return *current_structural_scope;
+    }
+    const ScopeChainNode* node = outer_structural_scopes;
+    for (std::uint32_t step = 1; step < hops.value && node != nullptr; ++step) {
+      node = node->parent;
+    }
+    if (node == nullptr || node->scope == nullptr) {
+      throw InternalError(
+          "WalkFrame::StructuralScopeAtHops: hops exceed chain depth");
+    }
+    return *node->scope;
   }
 
   [[nodiscard]] auto WithProceduralScope(mir::ProceduralScope* scope) const

--- a/include/lyra/mir/builtin_method.hpp
+++ b/include/lyra/mir/builtin_method.hpp
@@ -48,19 +48,24 @@ enum class EventMethodKind : std::uint8_t {
   kTriggered,
 };
 
-// LRM 7.5.2 / 7.5.3 dynamic-array methods plus the LRM 7.12 array-method
-// family (ordering, reduction, and the 7.12.1 locator methods). The locator
-// arms (`kFind` onward) return a queue -- an element queue for the value
-// locators and an `int` queue for the index locators.
+// Methods on the array-shaped containers (`PackedArray`, `UnpackedArray<T>`,
+// `DynamicArray<T>`, `Queue<T>`).
 //
-// Reduction, ordering, and locator methods carry a single closure as their
-// second argument. LRM 7.12.1 defines that "if a `with` clause is not given,
-// the method behaves as if `with (item)` were specified", so HIR-to-MIR
-// synthesises the identity closure when the source has none. At MIR each
-// method is exactly one kind with one signature (receiver plus closure); the
-// SV-source distinction between implicit and explicit `with` is a reading of
-// the source, not a MIR-level fact.
+// LRM 11.5 container access: `kElementAt` is `arr[i]` and `kSlice` is
+// `arr[hi:lo]` (LRM 7.4.5 / 11.5.1); both yield a borrowed view.
+// `kToOwned` materialises that view into an owning value (Rust's `ToOwned`
+// trait: `&str::to_owned() -> String`); needed only when the storage uses a
+// distinct ref type (PackedArrayRef), since other containers' `T&` is
+// implicitly materialised by the C++ copy constructor.
+//
+// `kSize` is the LRM 7.9.1 element count. The shared LRM 7.12 family
+// (ordering, reduction, locator) carries one closure as the second argument
+// -- the source `with` clause or the LRM 7.12.1 default `with (item)`. The
+// locator arms (`kFind` onward) return a queue.
 enum class ArrayMethodKind : std::uint8_t {
+  kElementAt,
+  kSlice,
+  kToOwned,
   kSize,
   kDelete,
   kReverse,
@@ -101,13 +106,15 @@ enum class QueueMethodKind : std::uint8_t {
   kSlice,
 };
 
-// LRM 7.9 associative-array methods. Exclusive to the associative container:
-// `num` / `size` query the entry count, `exists` tests a key, `delete` removes
-// one entry or clears the array. The traversal family (`first` / `last` /
-// `next` / `prev`, LRM 7.9.4 -- 7.9.7) assigns the visited key through a `ref`
-// index argument and returns 0 / 1 / -1. The shared LRM 7.12 family stays in
-// `ArrayMethodKind`.
+// LRM 7.9 associative-array methods. LRM 7.8.6 / 7.8.7: container access
+// splits read from write because the AA allocates on the write-side path --
+// `kRead` returns the element default when the key is absent; `kElementRef`
+// allocates the key with the element default before yielding a write target.
+// The traversal family (LRM 7.9.4 -- 7.9.7) assigns the visited key through
+// a `ref` index argument and returns 0 / 1 / -1.
 enum class AssociativeMethodKind : std::uint8_t {
+  kRead,
+  kElementRef,
   kNum,
   kSize,
   kExists,
@@ -139,6 +146,16 @@ enum class IteratorMethodKind : std::uint8_t {
 // (docs/decisions/runtime-effects-as-generic-calls.md).
 enum class ScopeMethodKind : std::uint8_t {
   kServices,
+};
+
+// Operations on an observable storage cell (`ObservableType` /
+// `ExternalRefType`). The cell is the first argument; `kSet` / `kMutate`
+// thread the engine handle as the second. See
+// docs/decisions/value-type-concepts.md.
+enum class ObservableMethodKind : std::uint8_t {
+  kGet,
+  kSet,
+  kMutate,
 };
 
 struct EnumMethodInfo {
@@ -178,12 +195,26 @@ struct ScopeMethodInfo {
   ScopeMethodKind kind;
 };
 
+struct ObservableMethodInfo {
+  ObservableMethodKind kind;
+};
+
 struct BuiltinMethodCallee {
   std::variant<
       EnumMethodInfo, StringMethodInfo, EventMethodInfo, ArrayMethodInfo,
       QueueMethodInfo, AssociativeMethodInfo, ValueMethodInfo,
-      IteratorMethodInfo, ScopeMethodInfo>
+      IteratorMethodInfo, ScopeMethodInfo, ObservableMethodInfo>
       method;
 };
+
+// Whether the method mutates its receiver in place.
+[[nodiscard]] auto IsMutatingBuiltinMethod(const BuiltinMethodCallee& callee)
+    -> bool;
+
+// Whether `callee` is a container-access method (`kElementAt`, `kSlice`,
+// `kRead`, `kElementRef`) whose first argument is the container being
+// accessed.
+[[nodiscard]] auto IsContainerAccessCall(const BuiltinMethodCallee& callee)
+    -> bool;
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -156,28 +156,6 @@ struct MemberAccessExpr {
   StructuralVarRef member;
 };
 
-struct ElementSelectExpr {
-  ExprId base_value;
-  ExprId index;
-};
-
-// Contiguous slice of `count` outer elements starting at `offset_expr`.
-// HIR's three source-faithful forms (`m:n`, `i +: w`, `i -: w`) collapse to
-// this single shape at HIR -> MIR; `count` is the LRM 7.4.5 compile-time
-// constant width, `offset_expr` is the lsb in outer-element units.
-//
-// LRM 7.2.1 packed struct field access has no MIR-level distinct shape: it
-// lowers at HIR -> MIR into this same slice form (since "a packed structure
-// can be selected as if it were a packed array", LRM 7.2.1). A future MIR
-// node for *unpacked* struct named access is a genuinely different shape (it
-// maps to C++ `s.member`, not bit math) and will get its own variant when
-// that work lands.
-struct RangeSelectExpr {
-  ExprId base_value;
-  ExprId offset_expr;
-  std::uint32_t count;
-};
-
 struct ConcatExpr {
   std::vector<ExprId> operands;
 };
@@ -214,8 +192,8 @@ using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, StructuralParamRef,
     ProceduralVarRef, UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr,
     IncDecExpr, CallExpr, RuntimeCallExpr, DerefExpr, MemberAccessExpr,
-    ConversionExpr, ClosureExpr, ElementSelectExpr, RangeSelectExpr, ConcatExpr,
-    ReplicationExpr, ArrayLiteralExpr, ConstructExpr>;
+    ConversionExpr, ClosureExpr, ConcatExpr, ReplicationExpr, ArrayLiteralExpr,
+    ConstructExpr>;
 
 struct Expr {
   ExprData data;
@@ -255,6 +233,54 @@ struct Expr {
                           ScopeMethodInfo{.kind = ScopeMethodKind::kServices}},
               .arguments = {self}},
       .type = services};
+}
+
+// `cell.Get()` -- unwraps an observable cell to its inner value.
+[[nodiscard]] inline auto MakeObservableGetCallExpr(
+    ExprId cell, TypeId value_type) -> Expr {
+  return Expr{
+      .data =
+          CallExpr{
+              .callee =
+                  BuiltinMethodCallee{
+                      .method =
+                          ObservableMethodInfo{
+                              .kind = ObservableMethodKind::kGet}},
+              .arguments = {cell}},
+      .type = value_type};
+}
+
+// `cell.Set(services, value)` -- whole-cell write that fires subscribers
+// on change.
+[[nodiscard]] inline auto MakeObservableSetCallExpr(
+    ExprId cell, ExprId services, ExprId value, TypeId void_type) -> Expr {
+  return Expr{
+      .data =
+          CallExpr{
+              .callee =
+                  BuiltinMethodCallee{
+                      .method =
+                          ObservableMethodInfo{
+                              .kind = ObservableMethodKind::kSet}},
+              .arguments = {cell, services, value}},
+      .type = void_type};
+}
+
+// `cell.Mutate(services)` -- opens a partial-write proxy. The MIR result
+// type is the inner value T; consumers wrap the call in a `DerefExpr` so
+// downstream selectors / operators run on T directly.
+[[nodiscard]] inline auto MakeObservableMutateCallExpr(
+    ExprId cell, ExprId services, TypeId value_type) -> Expr {
+  return Expr{
+      .data =
+          CallExpr{
+              .callee =
+                  BuiltinMethodCallee{
+                      .method =
+                          ObservableMethodInfo{
+                              .kind = ObservableMethodKind::kMutate}},
+              .arguments = {cell, services}},
+      .type = value_type};
 }
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -289,4 +289,13 @@ using ChildScope = std::variant<GenerateScopeChild, ModuleInstanceChild>;
 [[nodiscard]] auto GetChildScope(const CompilationUnit& unit, TypeId type)
     -> std::optional<ChildScope>;
 
+// True for storage forms that expose the observable-cell surface
+// (`Get` / `Set` / `Mutate`): the explicit `ObservableType` wrapper and the
+// intrinsic `ExternalRefType` (upward hierarchical reference).
+[[nodiscard]] auto IsObservableCellType(const Type& ty) -> bool;
+
+// The inner value type of an observable storage wrapper -- the `value` of
+// an `ObservableType`, the `element` of an `ExternalRefType`.
+[[nodiscard]] auto ObservableInnerValueType(const Type& ty) -> TypeId;
+
 }  // namespace lyra::mir

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -313,13 +313,15 @@ void Var<T>::Set(RuntimeServices& services, const T& new_val) {
 }
 
 // RAII handle that owns a snapshot of `var.Get()` for the lifetime of one
-// partial-write expression. Forwards chain methods to the snapshot so emitted
-// code reads like a normal `PackedArrayRef` chain. The destructor calls
-// `Var::Set` with the (possibly mutated) snapshot -- subscribers fire on
-// change. Non-copyable and non-movable: the contract is that it lives only
-// until the end of the constructing full expression. Returning it by value
-// from `Var<T>::Mutate` relies on C++17 mandatory copy elision (prvalues are
-// materialized in the caller's storage with no copy/move).
+// partial-write expression. The destructor calls `Var::Set` with the
+// (possibly mutated) snapshot -- subscribers fire on change. Non-copyable
+// and non-movable: the contract is that it lives only until the end of the
+// constructing full expression. Returning it by value from `Var<T>::Mutate`
+// relies on C++17 mandatory copy elision (prvalues are materialized in the
+// caller's storage with no copy/move).
+//
+// `operator*` is the single access point -- all chain methods, operators,
+// and selectors are reached through the deref'd T directly.
 template <value::LyraValueType T>
 class ScopedMutation {
  public:
@@ -336,116 +338,6 @@ class ScopedMutation {
     var_->Set(*services_, std::move(snapshot_));
   }
 
-  // Chain forwards. For a packed-storage snapshot the returned
-  // `PackedArrayRef` holds a pointer into this ScopedMutation's snapshot_; for
-  // an unpacked-storage snapshot (`DynamicArray<T>`, `Queue<T>`, etc.) the
-  // forwarder must preserve the reference so the assignment lands in the
-  // snapshot (not in a returned-by-value copy).
-  auto ElementAt(const value::PackedArray& idx) -> decltype(auto) {
-    return snapshot_.ElementAt(idx);
-  }
-  auto Slice(const value::PackedArray& lsb, std::uint32_t count)
-      -> decltype(auto) {
-    return snapshot_.Slice(lsb, count);
-  }
-  // LRM 7.8.7 write-side index access on associative arrays: distinct from
-  // `ElementAt` because the AA splits read from write (`Read` for missing
-  // keys, `ElementRef` for allocation on write). Member-template so SFINAE
-  // suppresses the declaration on `T` types without `ElementRef`.
-  template <typename Key, typename U = T>
-    requires requires(U& u, const Key& k) { u.ElementRef(k); }
-  auto ElementRef(const Key& key) -> decltype(auto) {
-    return snapshot_.ElementRef(key);
-  }
-
-  // LRM 11.4 whole-var compound. Mirrors `x op= rhs` directly: snapshot is
-  // mutated through the underlying type's own `op=`, and the destructor
-  // commits via Var::Set. Keeping the emit shape `x.Mutate(svc) op= rhs`
-  // (instead of expanding to `x.Set(svc, x.Get() op rhs)`) preserves
-  // the compound intent end-to-end and mirrors the selector form
-  // `x.Mutate(svc).Chain(...) op= rhs`.
-  auto operator+=(const value::PackedArray& rhs) -> ScopedMutation& {
-    snapshot_ += rhs;
-    return *this;
-  }
-  auto operator-=(const value::PackedArray& rhs) -> ScopedMutation& {
-    snapshot_ -= rhs;
-    return *this;
-  }
-  auto operator*=(const value::PackedArray& rhs) -> ScopedMutation& {
-    snapshot_ *= rhs;
-    return *this;
-  }
-  auto operator/=(const value::PackedArray& rhs) -> ScopedMutation& {
-    snapshot_ /= rhs;
-    return *this;
-  }
-  auto operator%=(const value::PackedArray& rhs) -> ScopedMutation& {
-    snapshot_ %= rhs;
-    return *this;
-  }
-  auto operator&=(const value::PackedArray& rhs) -> ScopedMutation& {
-    snapshot_ &= rhs;
-    return *this;
-  }
-  auto operator|=(const value::PackedArray& rhs) -> ScopedMutation& {
-    snapshot_ |= rhs;
-    return *this;
-  }
-  auto operator^=(const value::PackedArray& rhs) -> ScopedMutation& {
-    snapshot_ ^= rhs;
-    return *this;
-  }
-  auto ShiftLeftAssign(const value::PackedArray& rhs) -> ScopedMutation& {
-    snapshot_.ShiftLeftAssign(rhs);
-    return *this;
-  }
-  auto LogicalShiftRightAssign(const value::PackedArray& rhs)
-      -> ScopedMutation& {
-    snapshot_.LogicalShiftRightAssign(rhs);
-    return *this;
-  }
-  auto ArithmeticShiftRightAssign(const value::PackedArray& rhs)
-      -> ScopedMutation& {
-    snapshot_.ArithmeticShiftRightAssign(rhs);
-    return *this;
-  }
-
-  // LRM 11.4.2 inc/dec on an observable whole-var. The snapshot is mutated
-  // in place; the destructor commits via Var::Set so subscribers fire exactly
-  // once. Prefix returns the new value; postfix returns the old. Both return
-  // by value (not `ScopedMutation&`) so outer rvalue use such as
-  // `b = ++observable_var` routes a materialized PackedArray through the
-  // outer Var::Set instead of a transient proxy.
-  auto operator++() -> value::PackedArray {
-    ++snapshot_;
-    return snapshot_;
-  }
-  auto operator++(int) -> value::PackedArray {
-    value::PackedArray prior = snapshot_;
-    ++snapshot_;
-    return prior;
-  }
-  auto operator--() -> value::PackedArray {
-    --snapshot_;
-    return snapshot_;
-  }
-  auto operator--(int) -> value::PackedArray {
-    value::PackedArray prior = snapshot_;
-    --snapshot_;
-    return prior;
-  }
-
-  // Drilldown to the underlying snapshot for instance methods on `T` that
-  // mutate the value in place (e.g. `String::Itoa`). The chain becomes
-  // `var.Mutate(svc)->Method(...)` and the destructor commits the mutated
-  // snapshot exactly once.
-  auto operator->() -> T* {
-    return &snapshot_;
-  }
-  // The dereference form for free-function callees that take a mutable
-  // reference (e.g. `LyraFRead(svc, var.Mutate(svc), ...)` -- spelled
-  // `*var.Mutate(svc)` at the call site).
   auto operator*() -> T& {
     return snapshot_;
   }

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -116,7 +116,7 @@ class DynamicArray {
     return data_[i];
   }
 
-  [[nodiscard]] auto Clone() const -> DynamicArray {
+  [[nodiscard]] auto ToOwned() const -> DynamicArray {
     return *this;
   }
 

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -208,11 +208,12 @@ class PackedArray {
   // and propagates X, this returns deterministic 0 or 1.
   [[nodiscard]] auto CaseEqual(const PackedArray& other) const -> PackedArray;
 
-  // Mirror of `PackedArrayRef::Clone`. A chain that ends on a const path
-  // (e.g. `var.Get().Slice(...)`) materializes to `PackedArray` directly, so
-  // the emit-side `.Clone()` wrap needs to compile on both sides; here it is
-  // just an explicit copy.
-  [[nodiscard]] auto Clone() const -> PackedArray {
+  // Mirror of `PackedArrayRef::ToOwned`. A chain that ends on a const path
+  // (e.g. `var.Get().Slice(...)`) materialises to `PackedArray` directly, so
+  // the emit-side `.ToOwned()` wrap needs to compile on both sides; here it
+  // is just an explicit copy. Mirrors Rust's `<T as ToOwned>::to_owned()`
+  // for `T = PackedArray`, where `&T -> T` is a copy.
+  [[nodiscard]] auto ToOwned() const -> PackedArray {
     return *this;
   }
 
@@ -497,9 +498,10 @@ class PackedArrayRef {
 
   // Allocate an independent `PackedArray` holding the bits this view
   // currently projects. There is no implicit conversion from ref to value;
-  // every materialization is spelled `.Clone()` so the allocation cost is
+  // every materialisation is spelled `.ToOwned()` (Rust's `ToOwned` trait
+  // semantics: borrowed view -> owning value) so the allocation cost is
   // visible at the call site.
-  [[nodiscard]] auto Clone() const -> PackedArray;
+  [[nodiscard]] auto ToOwned() const -> PackedArray;
 
   // Write-side: route through AssignSlice on root.
   auto operator=(const PackedArray& value) -> PackedArrayRef&;
@@ -511,37 +513,37 @@ class PackedArrayRef {
   // caller, the proxy captures the position, and both the read and write
   // here use that same position with no re-evaluation of indices.
   auto operator+=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = Clone() + rhs;
+    return *this = ToOwned() + rhs;
   }
   auto operator-=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = Clone() - rhs;
+    return *this = ToOwned() - rhs;
   }
   auto operator*=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = Clone() * rhs;
+    return *this = ToOwned() * rhs;
   }
   auto operator/=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = Clone() / rhs;
+    return *this = ToOwned() / rhs;
   }
   auto operator%=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = Clone() % rhs;
+    return *this = ToOwned() % rhs;
   }
   auto operator&=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = Clone() & rhs;
+    return *this = ToOwned() & rhs;
   }
   auto operator|=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = Clone() | rhs;
+    return *this = ToOwned() | rhs;
   }
   auto operator^=(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = Clone() ^ rhs;
+    return *this = ToOwned() ^ rhs;
   }
   auto ShiftLeftAssign(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = Clone().ShiftLeft(rhs);
+    return *this = ToOwned().ShiftLeft(rhs);
   }
   auto LogicalShiftRightAssign(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = Clone().LogicalShiftRight(rhs);
+    return *this = ToOwned().LogicalShiftRight(rhs);
   }
   auto ArithmeticShiftRightAssign(const PackedArray& rhs) -> PackedArrayRef& {
-    return *this = Clone().ArithmeticShiftRight(rhs);
+    return *this = ToOwned().ArithmeticShiftRight(rhs);
   }
 
   // LRM 11.4.2 inc/dec on a partial-write proxy. Both forms return PackedArray
@@ -549,7 +551,7 @@ class PackedArrayRef {
   // so an outer rvalue use (`b = ++var[3:0]`) consumes a materialized value
   // instead of holding a transient proxy past the end of the full expression.
   auto operator++() -> PackedArray {
-    PackedArray current = Clone();
+    PackedArray current = ToOwned();
     auto updated =
         current + PackedArray::FromInt(
                       1, bit_width_, current.IsSigned(), current.IsFourState());
@@ -557,13 +559,13 @@ class PackedArrayRef {
     return updated;
   }
   auto operator++(int) -> PackedArray {
-    PackedArray prior = Clone();
+    PackedArray prior = ToOwned();
     *this = prior + PackedArray::FromInt(
                         1, bit_width_, prior.IsSigned(), prior.IsFourState());
     return prior;
   }
   auto operator--() -> PackedArray {
-    PackedArray current = Clone();
+    PackedArray current = ToOwned();
     auto updated =
         current - PackedArray::FromInt(
                       1, bit_width_, current.IsSigned(), current.IsFourState());
@@ -571,7 +573,7 @@ class PackedArrayRef {
     return updated;
   }
   auto operator--(int) -> PackedArray {
-    PackedArray prior = Clone();
+    PackedArray prior = ToOwned();
     *this = prior - PackedArray::FromInt(
                         1, bit_width_, prior.IsSigned(), prior.IsFourState());
     return prior;

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -130,7 +130,7 @@ class Queue {
     return data_[i];
   }
 
-  [[nodiscard]] auto Clone() const -> Queue {
+  [[nodiscard]] auto ToOwned() const -> Queue {
     return *this;
   }
 

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -90,7 +90,7 @@ class UnpackedArray {
     return data_[i];
   }
 
-  [[nodiscard]] auto Clone() const -> UnpackedArray {
+  [[nodiscard]] auto ToOwned() const -> UnpackedArray {
     return *this;
   }
 
@@ -324,7 +324,7 @@ class UnpackedArray {
 // entire slice. The proxy aliases the source storage (a non-owning pointer to
 // its element vector) plus the (offset, count) window, so a fixed-size unpacked
 // array and a dynamic array share one slice-write surface. X / Z offset makes
-// `Clone()` a wholly-default sub-array and `operator=` a no-op; partial-OOB
+// `ToOwned()` a wholly-default sub-array and `operator=` a no-op; partial-OOB
 // behaves per-element. Move-only so the proxy cannot outlive what it aliases.
 template <typename T>
 class ArraySliceRef {
@@ -343,7 +343,7 @@ class ArraySliceRef {
   auto operator=(ArraySliceRef&&) noexcept -> ArraySliceRef& = default;
   ~ArraySliceRef() = default;
 
-  [[nodiscard]] auto Clone() const -> UnpackedArray<T> {
+  [[nodiscard]] auto ToOwned() const -> UnpackedArray<T> {
     return UnpackedArray<T>(
         canonical_,
         detail::ArraySliceGather(*data_, canonical_, offset_, count_));

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -31,12 +31,6 @@
 
 namespace lyra::backend::cpp {
 
-// Renders `expr` without forcing a `PackedArrayRef` chain to materialize.
-// Public `RenderExpr` wraps any leftover ref in `.Clone()` so consumers see
-// an owning value.
-auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
-    -> diag::Result<std::string>;
-
 namespace {
 
 // Type-kind predicate. `real`, `shortreal`, and `realtime` (LRM 6.12)
@@ -229,17 +223,6 @@ auto RenderStructuralVarName(
 }
 
 namespace {
-
-// True iff the type exposes the observable cell surface (`Set` / `Get` /
-// `Mutate`) to the backend -- an explicit `mir::ObservableType` wrapper or an
-// `mir::ExternalRefType` (intrinsic upward-reference cell). Transitional
-// residue: every callsite uses the result to inject a `.Get()` / `.Mutate()`
-// at render time, which the Phase D follow-up retires by lifting those calls
-// into MIR.
-[[nodiscard]] auto IsObservableCell(const mir::Type& ty) -> bool {
-  return std::holds_alternative<mir::ObservableType>(ty.data) ||
-         std::holds_alternative<mir::ExternalRefType>(ty.data);
-}
 
 // Builds the C++ literal that materializes a 1-bit PackedArray of the SV-typed
 // shape carried by `result_ty`. Used to wrap the C++ `bool` result of a
@@ -748,6 +731,12 @@ auto StringMethodMemberName(mir::StringMethodKind k) -> std::string_view {
 
 auto ArrayMethodMemberName(mir::ArrayMethodKind k) -> std::string_view {
   switch (k) {
+    case mir::ArrayMethodKind::kElementAt:
+      return "ElementAt";
+    case mir::ArrayMethodKind::kSlice:
+      return "Slice";
+    case mir::ArrayMethodKind::kToOwned:
+      return "ToOwned";
     case mir::ArrayMethodKind::kSize:
       return "Size";
     case mir::ArrayMethodKind::kDelete:
@@ -806,7 +795,7 @@ auto EventMethodMemberName(mir::EventMethodKind k) -> std::string_view {
 
 auto RenderMethodCall(
     const RenderContext& ctx, const mir::CallExpr& call,
-    std::string_view member_name, bool mutates) -> diag::Result<std::string>;
+    std::string_view member_name) -> diag::Result<std::string>;
 
 // LRM 6.19.5: first / last / num are static on the enum class (no receiver);
 // next / prev dispatch on the receiver and render through the generic method
@@ -824,68 +813,25 @@ auto RenderEnumMethodCall(
         "{}::{}()", RenderEnumClassName(ctx.StructuralScope(), m.enum_type),
         member);
   }
-  return RenderMethodCall(ctx, call, member, false);
-}
-
-// LRM 6.16: `Putc` and the integer-to-string family (`Itoa`, `Hextoa`,
-// `Octtoa`, `Bintoa`, `Realtoa`) mutate the receiver string in place.
-auto StringMethodMutatesReceiver(mir::StringMethodKind k) -> bool {
-  return k == mir::StringMethodKind::kPutc ||
-         k == mir::StringMethodKind::kItoa ||
-         k == mir::StringMethodKind::kHextoa ||
-         k == mir::StringMethodKind::kOcttoa ||
-         k == mir::StringMethodKind::kBintoa ||
-         k == mir::StringMethodKind::kRealtoa;
+  return RenderMethodCall(ctx, call, member);
 }
 
 auto IsLhsBarePrimary(const mir::Expr& expr) -> bool;
 
-// Render the receiver of an instance-method call. When the method mutates the
-// receiver in place and the receiver is an observable cell, the call must
-// route through `Var<T>::Mutate(svc)` so the destructor commits exactly once
-// and subscribers fire; the snapshot is reached through `operator->`. Returns
-// the receiver text and a flag selecting the C++ member-access syntax (`->`
-// vs `.`).
-struct MethodReceiverText {
-  std::string text;
-  std::string_view sep;
-};
-auto RenderMethodReceiver(
-    const RenderContext& ctx, const mir::Expr& receiver_expr, bool mutates)
-    -> diag::Result<MethodReceiverText> {
-  if (mutates && LhsRootIsObservableScalar(ctx, receiver_expr)) {
-    auto lhs_or =
-        RenderLhsExpr(ctx, receiver_expr, ".Mutate(self->Services())");
-    if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-    // The Mutate adapter yields a `ScopedMutation` whose members are reached
-    // via `operator->`. Selector chains past it (`.ElementRef(...)`,
-    // `.ElementAt(...)`) decay back to the wrapped value's reference type, so
-    // the trailing method call dots through C++ as usual.
-    const std::string_view sep = IsLhsBarePrimary(receiver_expr) ? "->" : ".";
-    return MethodReceiverText{.text = std::move(*lhs_or), .sep = sep};
-  }
-  auto receiver_or = RenderExpr(ctx, receiver_expr);
-  if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
-  return MethodReceiverText{.text = std::move(*receiver_or), .sep = "."};
-}
-
-// A method call renders generically as `(receiver).name(args)`: the receiver is
-// arguments[0]; every following argument renders uniformly. Nothing here is
-// method-family specific -- the only per-call input beyond the operands is the
-// member name and whether the call mutates its receiver. Any engine handle a
-// method needs, and any representation shaping of arguments or result, lives in
-// the runtime method's signature; the backend reads the call and emits it.
-// When `mutates` is set and the receiver is an observable cell, the receiver
-// routes through `Var<T>::Mutate(svc)` so the destructor commits once.
+// A method call renders generically as `(receiver).name(args)`: the receiver
+// is arguments[0]; every following argument renders uniformly. The decision
+// of whether the receiver is a write target or a value receiver is encoded
+// upstream in the MIR receiver chain by HIR-to-MIR (LHS-side callees,
+// `Deref(Mutate)` wraps for observable cells); the backend reads the chain
+// and emits it.
 auto RenderMethodCall(
     const RenderContext& ctx, const mir::CallExpr& call,
-    std::string_view member_name, bool mutates) -> diag::Result<std::string> {
+    std::string_view member_name) -> diag::Result<std::string> {
   if (call.arguments.empty()) {
     throw InternalError(
         "RenderMethodCall: a method call expects a receiver argument");
   }
-  auto recv_or =
-      RenderMethodReceiver(ctx, ctx.Expr(call.arguments[0]), mutates);
+  auto recv_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
   if (!recv_or) return std::unexpected(std::move(recv_or.error()));
   std::string args;
   for (std::size_t i = 1; i < call.arguments.size(); ++i) {
@@ -894,16 +840,56 @@ auto RenderMethodCall(
     if (i != 1) args += ", ";
     args += *std::move(arg_or);
   }
-  return std::format(
-      "({}){}{}({})", recv_or->text, recv_or->sep, member_name, args);
+  return std::format("({}).{}({})", *recv_or, member_name, args);
 }
 
-// LRM 7.5.3 / 7.12.1: array methods that mutate the receiver in place. The
-// rest of the family is read-only (queries, reductions, locators).
-auto ArrayMethodMutatesReceiver(mir::ArrayMethodKind k) -> bool {
-  return k == mir::ArrayMethodKind::kDelete ||
-         k == mir::ArrayMethodKind::kReverse ||
-         k == mir::ArrayMethodKind::kSort || k == mir::ArrayMethodKind::kRsort;
+auto RenderStringMethodCall(
+    const RenderContext& ctx, const mir::CallExpr& call,
+    const mir::StringMethodInfo& m) -> diag::Result<std::string> {
+  return RenderMethodCall(ctx, call, StringMethodMemberName(m.kind));
+}
+
+// LRM 7.5.2 / 7.5.3 / 7.12.2 / 7.12.3: dispatch on the receiver
+// (arguments[0]); none of the no-`with` methods in this PR take additional
+// arguments. `Size()` returns std::size_t and gets wrapped in
+// `PackedArray::Int` to land in SV `int` shape (mirrors EnumMethod::kNum).
+// All other methods either return void (in-place mutators) or already return
+// the receiver's element type (reductions); no wrap.
+auto RenderArrayMethodCall(
+    const RenderContext& ctx, const mir::CallExpr& call,
+    const mir::ArrayMethodInfo& m) -> diag::Result<std::string> {
+  if (call.arguments.empty()) {
+    throw InternalError(
+        "RenderArrayMethodCall: array method expects a receiver argument");
+  }
+  auto recv_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
+  if (!recv_or) return std::unexpected(std::move(recv_or.error()));
+  std::string args_text;
+  for (std::size_t i = 1; i < call.arguments.size(); ++i) {
+    // LRM 7.4.5 + 11.5.1: Slice's `count` argument is a compile-time outer-
+    // element count -- HIR-to-MIR lowers it as an `IntegerLiteral` and the
+    // runtime API takes `std::uint32_t`. Render the literal as a raw integer
+    // so the C++ overload resolves without a `.ToInt64()` projection at the
+    // call site.
+    if (m.kind == mir::ArrayMethodKind::kSlice && i == 2) {
+      const auto& count_expr = ctx.Expr(call.arguments[i]);
+      const auto* lit = std::get_if<mir::IntegerLiteral>(&count_expr.data);
+      if (lit == nullptr) {
+        throw InternalError(
+            "RenderArrayMethodCall: Slice count must be an IntegerLiteral");
+      }
+      if (i > 1) args_text += ", ";
+      args_text += std::format(
+          "{}U", static_cast<std::uint32_t>(lit->value.value_words.front()));
+      continue;
+    }
+    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+    if (i > 1) args_text += ", ";
+    args_text += *arg_or;
+  }
+  return std::format(
+      "({}).{}({})", *recv_or, ArrayMethodMemberName(m.kind), args_text);
 }
 
 auto QueueMethodMemberName(mir::QueueMethodKind k) -> std::string_view {
@@ -932,30 +918,40 @@ auto QueueMethodMemberName(mir::QueueMethodKind k) -> std::string_view {
   throw InternalError("QueueMethodMemberName: unknown kind");
 }
 
-// The queue methods that write the receiver (LRM 7.10.2 insert / delete / pop /
-// push, and the LRM 7.10.1 element-write `WriteRef`) take the mutating receiver
-// path; the read accessors (`Size`, `ElementAt`, `Slice`) do not.
-auto QueueMethodMutatesReceiver(mir::QueueMethodKind k) -> bool {
-  switch (k) {
-    case mir::QueueMethodKind::kSize:
-    case mir::QueueMethodKind::kElementAt:
-    case mir::QueueMethodKind::kSlice:
-      return false;
-    case mir::QueueMethodKind::kInsert:
-    case mir::QueueMethodKind::kDelete:
-    case mir::QueueMethodKind::kPopFront:
-    case mir::QueueMethodKind::kPopBack:
-    case mir::QueueMethodKind::kPushFront:
-    case mir::QueueMethodKind::kPushBack:
-    case mir::QueueMethodKind::kWriteRef:
-      return true;
+// LRM 7.10.2 queue-native methods. The receiver is arguments[0] and any SV
+// method parameters follow as real C++ arguments, so the overload set on
+// `Queue<T>` resolves arity (`Delete()` vs `Delete(index)`) directly.
+auto RenderQueueMethodCall(
+    const RenderContext& ctx, const mir::CallExpr& call,
+    const mir::QueueMethodInfo& m) -> diag::Result<std::string> {
+  if (call.arguments.empty()) {
+    throw InternalError(
+        "RenderQueueMethodCall: queue method expects a receiver argument");
   }
-  throw InternalError("QueueMethodMutatesReceiver: unknown kind");
+  auto recv_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
+  if (!recv_or) return std::unexpected(std::move(recv_or.error()));
+  std::string args;
+  for (std::size_t i = 1; i < call.arguments.size(); ++i) {
+    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+    if (!arg_or) {
+      return std::unexpected(std::move(arg_or.error()));
+    }
+    if (i != 1) {
+      args += ", ";
+    }
+    args += *arg_or;
+  }
+  return std::format(
+      "({}).{}({})", *recv_or, QueueMethodMemberName(m.kind), args);
 }
 
 auto AssociativeMethodMemberName(mir::AssociativeMethodKind k)
     -> std::string_view {
   switch (k) {
+    case mir::AssociativeMethodKind::kRead:
+      return "Read";
+    case mir::AssociativeMethodKind::kElementRef:
+      return "ElementRef";
     case mir::AssociativeMethodKind::kNum:
     case mir::AssociativeMethodKind::kSize:
       return "Size";
@@ -985,6 +981,8 @@ auto AssociativeTraversalFunctionName(mir::AssociativeMethodKind k)
       return "AssocNext";
     case mir::AssociativeMethodKind::kPrev:
       return "AssocPrev";
+    case mir::AssociativeMethodKind::kRead:
+    case mir::AssociativeMethodKind::kElementRef:
     case mir::AssociativeMethodKind::kNum:
     case mir::AssociativeMethodKind::kSize:
     case mir::AssociativeMethodKind::kExists:
@@ -1016,12 +1014,19 @@ auto RenderAssociativeTraversalCall(
     return std::unexpected(std::move(receiver_or.error()));
   }
   const mir::Expr& index = ctx.Expr(call.arguments[1]);
-  auto index_or = RenderLhsExpr(ctx, index, std::string_view{});
+  auto index_or = RenderLhsExpr(ctx, index);
   if (!index_or) {
     return std::unexpected(std::move(index_or.error()));
   }
+  // `Ref<T>` is templated on the inner value type, not the observable wrapper.
+  // The index's MIR type carries the wrapper for an observable cell -- unwrap
+  // it before rendering the C++ type so `Ref<T>(Var<T>&)` resolves correctly.
+  const mir::Type& index_ty = ctx.Unit().GetType(index.type);
+  const mir::TypeId key_type_id = mir::IsObservableCellType(index_ty)
+                                      ? mir::ObservableInnerValueType(index_ty)
+                                      : index.type;
   auto key_type_or =
-      RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), index.type);
+      RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), key_type_id);
   if (!key_type_or) {
     return std::unexpected(std::move(key_type_or.error()));
   }
@@ -1039,12 +1044,21 @@ auto RenderAssociativeMethodCall(
   if (auto traversal = AssociativeTraversalFunctionName(m.kind)) {
     return RenderAssociativeTraversalCall(ctx, call, *traversal);
   }
-  // LRM 7.9.2: only `delete` mutates the associative array; the rest are
-  // read-only queries (traversal methods are routed above through a runtime
-  // shim).
-  const bool mutates = m.kind == mir::AssociativeMethodKind::kDelete;
-  return RenderMethodCall(
-      ctx, call, AssociativeMethodMemberName(m.kind), mutates);
+  auto recv_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
+  if (!recv_or) return std::unexpected(std::move(recv_or.error()));
+  std::string args;
+  for (std::size_t i = 1; i < call.arguments.size(); ++i) {
+    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+    if (!arg_or) {
+      return std::unexpected(std::move(arg_or.error()));
+    }
+    if (i != 1) {
+      args += ", ";
+    }
+    args += *arg_or;
+  }
+  return std::format(
+      "({}).{}({})", *recv_or, AssociativeMethodMemberName(m.kind), args);
 }
 
 // Side-effect-free per-value queries. Dispatch by the receiver's MIR
@@ -1100,6 +1114,35 @@ auto RenderScopeMethodCall(
       return std::format("({})->Services()", *receiver_or);
   }
   throw InternalError("RenderScopeMethodCall: unknown ScopeMethodKind");
+}
+
+auto ObservableMethodMemberName(mir::ObservableMethodKind k)
+    -> std::string_view {
+  switch (k) {
+    case mir::ObservableMethodKind::kGet:
+      return "Get";
+    case mir::ObservableMethodKind::kSet:
+      return "Set";
+    case mir::ObservableMethodKind::kMutate:
+      return "Mutate";
+  }
+  throw InternalError("ObservableMethodMemberName: unknown kind");
+}
+
+auto RenderObservableMethodCall(
+    const RenderContext& ctx, const mir::CallExpr& call,
+    const mir::ObservableMethodInfo& m) -> diag::Result<std::string> {
+  auto recv_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
+  if (!recv_or) return std::unexpected(std::move(recv_or.error()));
+  std::string args_text;
+  for (std::size_t i = 1; i < call.arguments.size(); ++i) {
+    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+    if (i > 1) args_text += ", ";
+    args_text += *arg_or;
+  }
+  return std::format(
+      "({}).{}({})", *recv_or, ObservableMethodMemberName(m.kind), args_text);
 }
 
 // The C++ runtime entry this backend realizes a system subroutine with. Pure
@@ -1256,23 +1299,11 @@ auto RenderCallExpr(
                 const mir::ParamDirection dir = decl.params[i - 1].direction;
                 if (dir == mir::ParamDirection::kRef ||
                     dir == mir::ParamDirection::kConstRef) {
-                  // A ref / const ref actual binds the variable's cell: render
-                  // its lvalue and wrap it in a `Ref<T>`. Constructor overload
-                  // picks the observable (`Var<T>`), plain (`T`), or
-                  // unpacked-element backing; a ref formal passed on forwards
-                  // via the copy ctor (LRM 13.5.2). When the actual is rooted
-                  // in an observable cell and points at an element (not the
-                  // whole cell), route through `Var<T>::Mutate(svc)` so the
-                  // ScopedMutation snapshot lives for the call's full
-                  // expression and commits via `Var::Set` on return.
-                  const bool needs_mutate =
-                      LhsRootIsObservableScalar(ctx, actual) &&
-                      !IsLhsBarePrimary(actual);
-                  auto lhs_or = RenderLhsExpr(
-                      ctx, actual,
-                      needs_mutate
-                          ? std::string_view{".Mutate(self->Services())"}
-                          : std::string_view{});
+                  // A ref / const-ref actual binds the variable's cell.
+                  // HIR-to-MIR wraps observable selector-chain actuals with
+                  // `DerefExpr(CallExpr(kMutate, ...))`, so render is
+                  // mechanical.
+                  auto lhs_or = RenderLhsExpr(ctx, actual);
                   if (!lhs_or)
                     return std::unexpected(std::move(lhs_or.error()));
                   auto type_or = RenderTypeAsCpp(
@@ -1301,23 +1332,17 @@ auto RenderCallExpr(
                       return RenderEnumMethodCall(ctx, call, m);
                     },
                     [&](const mir::StringMethodInfo& m) {
-                      return RenderMethodCall(
-                          ctx, call, StringMethodMemberName(m.kind),
-                          StringMethodMutatesReceiver(m.kind));
+                      return RenderStringMethodCall(ctx, call, m);
                     },
                     [&](const mir::EventMethodInfo& m) {
                       return RenderMethodCall(
-                          ctx, call, EventMethodMemberName(m.kind), false);
+                          ctx, call, EventMethodMemberName(m.kind));
                     },
                     [&](const mir::ArrayMethodInfo& m) {
-                      return RenderMethodCall(
-                          ctx, call, ArrayMethodMemberName(m.kind),
-                          ArrayMethodMutatesReceiver(m.kind));
+                      return RenderArrayMethodCall(ctx, call, m);
                     },
                     [&](const mir::QueueMethodInfo& m) {
-                      return RenderMethodCall(
-                          ctx, call, QueueMethodMemberName(m.kind),
-                          QueueMethodMutatesReceiver(m.kind));
+                      return RenderQueueMethodCall(ctx, call, m);
                     },
                     [&](const mir::AssociativeMethodInfo& m) {
                       return RenderAssociativeMethodCall(ctx, call, m);
@@ -1339,6 +1364,9 @@ auto RenderCallExpr(
                     },
                     [&](const mir::ScopeMethodInfo& m) {
                       return RenderScopeMethodCall(ctx, call, m);
+                    },
+                    [&](const mir::ObservableMethodInfo& m) {
+                      return RenderObservableMethodCall(ctx, call, m);
                     },
                 },
                 b.method);
@@ -1393,8 +1421,8 @@ auto RenderCallExpr(
               case mir::RuntimeFn::kRegisterSignal: {
                 // Registers the signal's own cell address under its name; the
                 // var argument renders as a bare lvalue so `&` takes the cell.
-                auto var_or = RenderLhsExpr(
-                    ctx, ctx.Expr(call.arguments.at(1)), std::string_view{});
+                auto var_or =
+                    RenderLhsExpr(ctx, ctx.Expr(call.arguments.at(1)));
                 if (!var_or) return std::unexpected(std::move(var_or.error()));
                 return *base_or + "->RegisterSignal(\"" + nav.name + "\", &" +
                        *var_or + ")";
@@ -1406,67 +1434,14 @@ auto RenderCallExpr(
       call.callee);
 }
 
-enum class ElementAccessMode : std::uint8_t { kRead, kWrite };
-
-// Indexed element access shared by rvalue `RenderElementSelectExpr` and the
-// lvalue `RenderLhsExpr` ElementSelect arm. `PackedArray`, `UnpackedArray`,
-// `DynamicArray`, and `Queue` expose a symmetric `ElementAt(const
-// PackedArray&)` so the emit string is substrate-agnostic; declared-range
-// translation and `ToInt64` canonicalize inside the runtime type.
-//
-// The associative array splits read from write (LRM 7.8.6 / 7.8.7): a read
-// never allocates and returns the element default for a missing key, while a
-// write allocates the entry. The access mode selects `Read` vs `ElementRef`.
-auto RenderIndexedElementAccess(
-    const mir::Type& base_ty, std::string_view base, std::string_view idx,
-    ElementAccessMode mode) -> std::string {
-  if (std::holds_alternative<mir::AssociativeArrayType>(base_ty.data)) {
-    const std::string_view member =
-        mode == ElementAccessMode::kWrite ? "ElementRef" : "Read";
-    return std::format("({}).{}({})", base, member, idx);
-  }
-  if (!std::holds_alternative<mir::PackedArrayType>(base_ty.data) &&
-      !std::holds_alternative<mir::UnpackedArrayType>(base_ty.data) &&
-      !std::holds_alternative<mir::DynamicArrayType>(base_ty.data)) {
-    throw InternalError(
-        "RenderIndexedElementAccess: base type must be PackedArrayType, "
-        "UnpackedArrayType, DynamicArrayType, or AssociativeArrayType");
-  }
-  return std::format("({}).ElementAt({})", base, idx);
-}
-
-auto RenderElementSelectExpr(
-    const RenderContext& ctx, const mir::ElementSelectExpr& sel)
-    -> diag::Result<std::string> {
-  const auto& base_expr = ctx.Expr(sel.base_value);
-  auto base_or = RenderExprNatural(ctx, base_expr);
-  if (!base_or) return std::unexpected(std::move(base_or.error()));
-  auto idx_or = RenderExpr(ctx, ctx.Expr(sel.index));
-  if (!idx_or) return std::unexpected(std::move(idx_or.error()));
-  const auto& base_ty = ctx.Unit().GetType(base_expr.type);
-  return RenderIndexedElementAccess(
-      base_ty, *base_or, *idx_or, ElementAccessMode::kRead);
-}
-
-// Renders an LHS-shaped expression for use as an assignment target. The
-// `mutate_adapter` string (typically `.Mutate(Services())` or empty) is
-// inserted immediately after the structural-var root so an observable
-// partial write enters a ScopedMutation before the selector chain begins.
-auto RenderRangeSliceSuffix(
-    const RenderContext& ctx, mir::ExprId offset_expr, std::uint32_t count)
-    -> diag::Result<std::string> {
-  auto offset = RenderExpr(ctx, ctx.Expr(offset_expr));
-  if (!offset) return std::unexpected(std::move(offset.error()));
-  return std::format(".Slice({}, {}U)", *offset, count);
-}
-
 }  // namespace
 
-// Output shape:
-//   <root>{<mutate_adapter>}{.ElementAt(idx) | .Slice(offset, count)}*
-auto RenderLhsExpr(
-    const RenderContext& ctx, const mir::Expr& expr,
-    std::string_view mutate_adapter) -> diag::Result<std::string> {
+// Output shape: <root>{ .ElementAt(idx) | .ElementRef(idx) | .Slice(offset,
+// count) }* The observable-cell `Mutate(svc)` adapter, if needed, is already in
+// MIR as `DerefExpr(CallExpr(ObservableMethod{kMutate}, ...))` -- this render
+// emits nothing implicit on top of the explicit MIR shape.
+auto RenderLhsExpr(const RenderContext& ctx, const mir::Expr& expr)
+    -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
           [&](const mir::MemberAccessExpr& m) -> diag::Result<std::string> {
@@ -1476,39 +1451,23 @@ auto RenderLhsExpr(
             }
             const auto& scope = ctx.StructuralScopeAtHops(m.member.hops);
             const auto& var = scope.GetStructuralVar(m.member.var);
-            return *receiver_or + "->" + var.name + std::string{mutate_adapter};
+            return *receiver_or + "->" + var.name;
           },
           [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
             return LookupProceduralVarName(ctx, l);
           },
-          [&](const mir::ElementSelectExpr& s) -> diag::Result<std::string> {
-            const mir::Expr& base_expr = ctx.Expr(s.base_value);
-            auto base = RenderLhsExpr(ctx, base_expr, mutate_adapter);
-            if (!base) return std::unexpected(std::move(base.error()));
-            auto idx = RenderExpr(ctx, ctx.Expr(s.index));
-            if (!idx) return std::unexpected(std::move(idx.error()));
-            const auto& base_ty = ctx.Unit().GetType(base_expr.type);
-            return RenderIndexedElementAccess(
-                base_ty, *base, *idx, ElementAccessMode::kWrite);
-          },
-          [&](const mir::RangeSelectExpr& s) -> diag::Result<std::string> {
-            auto base =
-                RenderLhsExpr(ctx, ctx.Expr(s.base_value), mutate_adapter);
-            if (!base) return std::unexpected(std::move(base.error()));
-            auto suffix = RenderRangeSliceSuffix(ctx, s.offset_expr, s.count);
-            if (!suffix) return std::unexpected(std::move(suffix.error()));
-            return *base + *suffix;
+          // HIR-to-MIR lowers an LHS selector chain (AA's `kElementRef`,
+          // others' `kElementAt` / `kSlice`, queue's `kWriteRef`) to a
+          // `CallExpr`. The C++ surface returns a write-through reference,
+          // so the natural value-side rendering is itself the assignment
+          // target; LHS context needs no extra fix-up.
+          [&](const mir::CallExpr&) -> diag::Result<std::string> {
+            return RenderExpr(ctx, expr);
           },
           [&](const mir::DerefExpr& d) -> diag::Result<std::string> {
             auto ptr = RenderExpr(ctx, ctx.Expr(d.pointer));
             if (!ptr) return std::unexpected(std::move(ptr.error()));
-            return "(*" + *ptr + ")" + std::string{mutate_adapter};
-          },
-          [&](const mir::CallExpr& call) -> diag::Result<std::string> {
-            // LRM 7.10.1: a queue element write lowers to a `WriteRef` built-in
-            // method call that returns the element reference, so the call site
-            // is itself the assignable lvalue.
-            return RenderCallExpr(ctx, call, expr.type);
+            return "(*" + *ptr + ")";
           },
           [&](const auto&) -> diag::Result<std::string> {
             throw InternalError(
@@ -1522,22 +1481,21 @@ auto RenderLhsExpr(
 
 namespace {
 
-// Walks an LHS expression through element / range selects to its root primary.
-// Whether a write touches an observable cell or a reference formal is decided
-// by what that root is.
+// Walks an LHS expression through container-access calls
+// (`kElementAt` / `kSlice` / `kRead` / `kElementRef`) to its root primary.
+// Whether a write touches a reference formal is decided by what that root is.
 auto LhsRootPrimary(const RenderContext& ctx, const mir::Expr& expr)
     -> const mir::Expr& {
   const mir::Expr* current = &expr;
   while (true) {
-    if (const auto* sel = std::get_if<mir::ElementSelectExpr>(&current->data)) {
-      current = &ctx.Expr(sel->base_value);
-      continue;
+    const auto* call = std::get_if<mir::CallExpr>(&current->data);
+    if (call == nullptr) return *current;
+    const auto* callee = std::get_if<mir::BuiltinMethodCallee>(&call->callee);
+    if (callee == nullptr || !mir::IsContainerAccessCall(*callee) ||
+        call->arguments.empty()) {
+      return *current;
     }
-    if (const auto* sel = std::get_if<mir::RangeSelectExpr>(&current->data)) {
-      current = &ctx.Expr(sel->base_value);
-      continue;
-    }
-    return *current;
+    current = &ctx.Expr(call->arguments.front());
   }
 }
 
@@ -1623,45 +1581,22 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
            "self->Services()" + ", " + *value_or + ")";
   }
 
-  const bool observable = LhsRootIsObservableScalar(ctx, lhs_expr);
-
-  // Whole-var write: route observable structural targets through Var::Set
-  // (which fires subscribers), procedural locals get a direct C++ assignment.
+  // Mechanical render: the observable cell's `Set` is now an explicit
+  // `CallExpr(ObservableMethod{kSet}, ...)` and `Mutate` shows up as a
+  // `DerefExpr(CallExpr(ObservableMethod{kMutate}, ...))` at the chain root
+  // -- both injected at HIR-to-MIR
+  // (`docs/decisions/value-type-concepts.md`). This render emits a plain
+  // C++ assignment over whatever `RenderLhsExpr` produces.
   if (IsLhsBarePrimary(lhs_expr)) {
-    auto root_or = RenderLhsExpr(ctx, lhs_expr, std::string_view{});
+    auto root_or = RenderLhsExpr(ctx, lhs_expr);
     if (!root_or) return std::unexpected(std::move(root_or.error()));
     if (a.compound_op.has_value()) {
-      // For observable whole-var compound we still route through Mutate so
-      // the destructor commit fires subscribers exactly once -- the
-      // ScopedMutation overloads `op=` to mutate the snapshot in place.
-      // Procedural-local compounds operate on the underlying PackedArray
-      // directly via its own `op=` overloads.
-      const std::string chain =
-          observable ? *root_or + ".Mutate(" + "self->Services()" + ")"
-                     : *root_or;
-      return "(" + RenderCompoundAssign(*a.compound_op, chain, *value_or) + ")";
-    }
-    if (observable) {
-      return *root_or + ".Set(" + "self->Services()" + ", " + *value_or + ")";
+      return "(" + RenderCompoundAssign(*a.compound_op, *root_or, *value_or) +
+             ")";
     }
     return "(" + *root_or + " = " + *value_or + ")";
   }
-
-  // Selector chain: compose PackedArrayRef method calls. Per-layer element
-  // bit widths are derived by the runtime PackedArray / PackedArrayRef from
-  // their own dim stack; render emits source-form positions only.
-  //
-  // Procedural-local target: chain mutates the variable in place. Chain base
-  // is the variable name itself.
-  // Observable target: enter a partial-write scope via `Var<T>::Mutate(svc)`,
-  // which returns a `ScopedMutation` RAII handle that snapshots the current
-  // value. The chain runs against the snapshot via the same forwarding
-  // methods as on PackedArray; when the full expression ends, the handle's
-  // destructor commits the snapshot through `Var::Set` so subscribers fire.
-  // Same shape inside or outside an NBA closure body -- no nested lambda.
-  const std::string mutate_adapter =
-      observable ? std::string{".Mutate(self->Services())"} : std::string{};
-  auto chain_or = RenderLhsExpr(ctx, lhs_expr, mutate_adapter);
+  auto chain_or = RenderLhsExpr(ctx, lhs_expr);
   if (!chain_or) return std::unexpected(std::move(chain_or.error()));
   if (a.compound_op.has_value()) {
     return "(" + RenderCompoundAssign(*a.compound_op, *chain_or, *value_or) +
@@ -1680,20 +1615,9 @@ auto RenderIncDecExpr(const RenderContext& ctx, const mir::IncDecExpr& inc)
         "implemented in cpp emit",
         diag::UnsupportedCategory::kFeature);
   }
-  const bool observable = LhsRootIsObservableScalar(ctx, target_expr);
-
-  std::string lhs;
-  if (IsLhsBarePrimary(target_expr)) {
-    auto root_or = RenderLhsExpr(ctx, target_expr, std::string_view{});
-    if (!root_or) return std::unexpected(std::move(root_or.error()));
-    lhs = observable ? *root_or + ".Mutate(self->Services())" : *root_or;
-  } else {
-    const std::string mutate_adapter =
-        observable ? std::string{".Mutate(self->Services())"} : std::string{};
-    auto chain_or = RenderLhsExpr(ctx, target_expr, mutate_adapter);
-    if (!chain_or) return std::unexpected(std::move(chain_or.error()));
-    lhs = *std::move(chain_or);
-  }
+  auto lhs_or = RenderLhsExpr(ctx, target_expr);
+  if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+  std::string lhs = *std::move(lhs_or);
 
   switch (inc.op) {
     case mir::IncDecOp::kPreInc:
@@ -1706,35 +1630,6 @@ auto RenderIncDecExpr(const RenderContext& ctx, const mir::IncDecExpr& inc)
       return "(" + lhs + "--)";
   }
   throw InternalError("RenderIncDecExpr: unknown IncDecOp");
-}
-
-auto RenderRangeSelectExpr(
-    const RenderContext& ctx, const mir::Expr& expr,
-    const mir::RangeSelectExpr& sel) -> diag::Result<std::string> {
-  const auto& operand_expr = ctx.Expr(sel.base_value);
-  auto base_or = RenderExprNatural(ctx, operand_expr);
-  if (!base_or) return std::unexpected(std::move(base_or.error()));
-
-  auto offset_or = RenderExpr(ctx, ctx.Expr(sel.offset_expr));
-  if (!offset_or) return std::unexpected(std::move(offset_or.error()));
-  auto slice_expr =
-      std::format("({}).Slice({}, {}U)", *base_or, *offset_or, sel.count);
-
-  // PackedArray::Slice() always produces an unsigned result (LRM 7.4.1
-  // part-select default). When the MIR result type carries signed semantics
-  // -- e.g. member access of a `logic signed` packed-struct/union field --
-  // re-tag the slice via ConvertFrom so a downstream sign-extending
-  // conversion sees the correct source signedness. Unpacked slice produces
-  // an UnpackedArray<T> with no top-level signedness attribute, so the
-  // wrap is packed-only.
-  const auto& result_ty = ctx.Unit().GetType(expr.type);
-  if (result_ty.IsPackedArray() &&
-      result_ty.AsPackedArray().signedness == mir::Signedness::kSigned) {
-    return std::format(
-        "lyra::value::PackedArray::ConvertFrom({}, {})", slice_expr,
-        RenderPackedArrayCtorArgs(result_ty.AsPackedArray()));
-  }
-  return slice_expr;
 }
 
 auto RenderClosureExpr(
@@ -1765,8 +1660,7 @@ auto RenderClosureExpr(
                 -> diag::Result<std::string> {
               const std::string& bind_name =
                   closure.body->vars.at(br.binding.value).name;
-              auto lvalue_or =
-                  RenderLhsExpr(ctx, ctx.Expr(br.target), std::string_view{});
+              auto lvalue_or = RenderLhsExpr(ctx, ctx.Expr(br.target));
               if (!lvalue_or) {
                 return std::unexpected(std::move(lvalue_or.error()));
               }
@@ -1849,8 +1743,7 @@ auto RenderQueueConcat(
         std::holds_alternative<mir::QueueType>(op_ty.data) ||
         std::holds_alternative<mir::DynamicArrayType>(op_ty.data) ||
         std::holds_alternative<mir::UnpackedArrayType>(op_ty.data);
-    auto rendered =
-        spread ? RenderExprNatural(ctx, op_expr) : RenderExpr(ctx, op_expr);
+    auto rendered = RenderExpr(ctx, op_expr);
     if (!rendered) return std::unexpected(std::move(rendered.error()));
     if (i != 0) out += ", ";
     out += spread ? "lyra::value::QSpread(" + *rendered + ")"
@@ -1987,69 +1880,21 @@ auto RenderReplicationExpr(
       "RenderReplicationExpr: result type must be PackedArrayType or string");
 }
 
-auto ProducesPackedArrayRef(const RenderContext& ctx, const mir::Expr& expr)
-    -> bool {
-  if (!std::holds_alternative<mir::ElementSelectExpr>(expr.data) &&
-      !std::holds_alternative<mir::RangeSelectExpr>(expr.data)) {
-    return false;
-  }
-  const auto& result_ty = ctx.Unit().GetType(expr.type);
-  return std::holds_alternative<mir::PackedArrayType>(result_ty.data);
-}
-
-}  // namespace
-
-// Defined at file scope (matching the header's declaration with external
-// linkage) so callsites in other translation units -- e.g.
-// `RenderRuntimeCallExpr` for `LyraFRead` in `render_print.cpp` -- can route
-// observable destinations through `Var<T>::Mutate(svc)`. `LhsRootPrimary` is
-// visible at file scope via the anonymous-namespace's implicit using.
-auto LhsRootIsObservableScalar(const RenderContext& ctx, const mir::Expr& expr)
-    -> bool {
-  const mir::Expr& root = LhsRootPrimary(ctx, expr);
-  if (const auto* m = std::get_if<mir::MemberAccessExpr>(&root.data)) {
-    const auto& scope = ctx.StructuralScopeAtHops(m->member.hops);
-    return IsObservableCell(
-        ctx.Unit().GetType(scope.GetStructuralVar(m->member.var).type));
-  }
-  if (const auto* d = std::get_if<mir::DerefExpr>(&root.data)) {
-    const mir::Expr& ptr_expr = ctx.Expr(d->pointer);
-    const auto& ptr_data = ctx.Unit().GetType(ptr_expr.type).data;
-    if (const auto* ptr_t = std::get_if<mir::PointerType>(&ptr_data)) {
-      return IsObservableCell(ctx.Unit().GetType(ptr_t->pointee));
-    }
-  }
-  return false;
-}
-
-auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
-    -> diag::Result<std::string> {
-  auto rendered_or = RenderExprNatural(ctx, expr);
-  if (!rendered_or) return rendered_or;
-  if (ProducesPackedArrayRef(ctx, expr)) {
-    return "(" + *std::move(rendered_or) + ").Clone()";
-  }
-  return rendered_or;
-}
-
-// Read-side render of a borrowed-pointer dereference: the cell is reached with
-// `(*ptr)` and observed via `.Get()` when the pointer points at an observable
-// cell, mirroring the structural-var read split.
+// Read-side render of a borrowed-pointer dereference: the cell is reached
+// with `(*ptr)`. The `.Get()` unwrap, if applicable, is emitted by the
+// explicit `ObservableMethod{kGet}` call that HIR-to-MIR wraps around an
+// observable read (`docs/decisions/value-type-concepts.md`).
 auto RenderDerefExpr(const RenderContext& ctx, const mir::DerefExpr& d)
     -> diag::Result<std::string> {
   const mir::Expr& ptr_expr = ctx.Expr(d.pointer);
   auto ptr_or = RenderExpr(ctx, ptr_expr);
   if (!ptr_or) return std::unexpected(std::move(ptr_or.error()));
-  const auto& ptr_data = ctx.Unit().GetType(ptr_expr.type).data;
-  if (const auto* ptr_t = std::get_if<mir::PointerType>(&ptr_data)) {
-    if (IsObservableCell(ctx.Unit().GetType(ptr_t->pointee))) {
-      return "(*" + *ptr_or + ").Get()";
-    }
-  }
   return "(*" + *ptr_or + ")";
 }
 
-auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
+}  // namespace
+
+auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
     -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
@@ -2109,24 +1954,10 @@ auto RenderExprNatural(const RenderContext& ctx, const mir::Expr& expr)
             if (!receiver_or) {
               return std::unexpected(std::move(receiver_or.error()));
             }
-            std::string base = *receiver_or + "->" + var.name;
-            // A read of an observable-storage member unwraps the value
-            // through `Var<T>::Get`; a plain field is the value itself. The
-            // wrap lives on the member's declared type, not on the
-            // expression's apparent type.
-            if (IsObservableCell(ctx.Unit().GetType(var.type))) {
-              base += ".Get()";
-            }
-            return base;
+            return *receiver_or + "->" + var.name;
           },
           [&](const mir::ClosureExpr& cl) -> diag::Result<std::string> {
             return RenderClosureExpr(ctx, cl);
-          },
-          [&](const mir::ElementSelectExpr& sel) -> diag::Result<std::string> {
-            return RenderElementSelectExpr(ctx, sel);
-          },
-          [&](const mir::RangeSelectExpr& sel) -> diag::Result<std::string> {
-            return RenderRangeSelectExpr(ctx, expr, sel);
           },
           [&](const mir::ConcatExpr& c) -> diag::Result<std::string> {
             return RenderConcatExpr(ctx, expr, c);

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -246,8 +246,7 @@ auto RenderRuntimeCallExpr(
                   Overloaded{
                       [&](const mir::IntegralScanSlot& s)
                           -> diag::Result<std::string> {
-                        auto temp_or = RenderLhsExpr(
-                            ctx, ctx.Expr(s.temp), std::string_view{});
+                        auto temp_or = RenderLhsExpr(ctx, ctx.Expr(s.temp));
                         if (!temp_or) {
                           return std::unexpected(std::move(temp_or.error()));
                         }
@@ -261,8 +260,7 @@ auto RenderRuntimeCallExpr(
                       },
                       [&](const mir::StringScanSlot& s)
                           -> diag::Result<std::string> {
-                        auto temp_or = RenderLhsExpr(
-                            ctx, ctx.Expr(s.temp), std::string_view{});
+                        auto temp_or = RenderLhsExpr(ctx, ctx.Expr(s.temp));
                         if (!temp_or) {
                           return std::unexpected(std::move(temp_or.error()));
                         }

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -6,6 +6,7 @@
 
 #include "lyra/hir/continuous_assign.hpp"
 #include "lyra/hir/structural_scope.hpp"
+#include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
@@ -42,14 +43,28 @@ auto LowerContinuousAssign(
   const mir::TypeId assign_type = (*rhs_or).type;
   const mir::ExprId rhs_id = body_scope.AddExpr(*std::move(rhs_or));
 
-  auto lhs_or = scope.LowerExpr(hir_scope.GetExpr(src.lhs), body_frame);
+  auto lhs_or = scope.LowerLhsExpr(hir_scope.GetExpr(src.lhs), body_frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const mir::ExprId lhs_id = body_scope.AddExpr(*std::move(lhs_or));
 
-  const mir::ExprId assign_id = body_scope.AddExpr(
-      mir::Expr{
-          .data = mir::AssignExpr{.target = lhs_id, .value = rhs_id},
-          .type = assign_type});
+  // Build `self.Services()` in the body so an observable LHS routes through
+  // `Var<T>::Set` (or `Mutate` for a selector chain). The body's `self` is
+  // already bound at depth 0 via `WithSelfBinding(self_id, ...)` above.
+  const mir::TypeId self_ptr_type = scope.Module().Unit().builtins.self_pointer;
+  const mir::ExprId body_self_ref = body_scope.AddExpr(
+      mir::MakeProceduralVarRefExpr(
+          mir::ProceduralHops{
+              .value = body_frame.procedural_depth.value -
+                       body_frame.self_decl_depth.value},
+          self_id, self_ptr_type));
+  const mir::ExprId body_services_id = body_scope.AddExpr(
+      mir::MakeServicesCallExpr(
+          body_self_ref, scope.Module().Unit().builtins.services));
+
+  const mir::Expr assign_expr = BuildObservableAssignExpr(
+      scope.Module().Unit(), body_scope, body_services_id, lhs_id, rhs_id,
+      std::nullopt, assign_type, scope.Module().Unit().builtins.void_type);
+  const mir::ExprId assign_id = body_scope.AddExpr(assign_expr);
   body_scope.AppendStmt(
       mir::Stmt{
           .label = std::nullopt, .data = mir::ExprStmt{.expr = assign_id}});

--- a/src/lyra/lowering/hir_to_mir/copy_out_desugar.cpp
+++ b/src/lyra/lowering/hir_to_mir/copy_out_desugar.cpp
@@ -9,7 +9,9 @@
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/procedural_body.hpp"
+#include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/stmt.hpp"
@@ -21,18 +23,28 @@ auto BuildOutputArgSlot(
     std::string_view temp_name) -> diag::Result<OutputArgSlot> {
   const auto& hir_body = proc.HirBody();
   auto& wrapper = *frame.current_procedural_scope;
-  auto actual_or = proc.LowerExpr(hir_body.exprs.at(actual_hir.value), frame);
-  if (!actual_or) return std::unexpected(std::move(actual_or.error()));
-  const mir::TypeId actual_type = actual_or->type;
-  const mir::ExprId actual_id = wrapper.AddExpr(*std::move(actual_or));
+  // The actual is written to after the call returns: lower it as a cell-
+  // typed lvalue so an observable destination's writeback routes through
+  // `Var<T>::Set`. For the copy-in initializer the temp wants the current
+  // value, so a separate `LowerExpr` lowering wraps the cell in `Get`.
+  auto target_or =
+      proc.LowerLhsExpr(hir_body.exprs.at(actual_hir.value), frame);
+  if (!target_or) return std::unexpected(std::move(target_or.error()));
+  const mir::TypeId actual_type =
+      proc.Module().TranslateType(hir_body.exprs.at(actual_hir.value).type);
+  const mir::ExprId actual_id = wrapper.AddExpr(*std::move(target_or));
+  auto value_or = proc.LowerExpr(hir_body.exprs.at(actual_hir.value), frame);
+  if (!value_or) return std::unexpected(std::move(value_or.error()));
+  const mir::ExprId init_id = wrapper.AddExpr(*std::move(value_or));
   const mir::ProceduralVarRef temp = wrapper.AppendLocal(
       mir::ProceduralVarDecl{
           .name = std::string{temp_name}, .type = actual_type},
-      actual_id);
+      init_id);
   return OutputArgSlot{.actual = actual_id, .temp = temp, .type = actual_type};
 }
 
 auto BuildCopyOutBlock(
+    const mir::CompilationUnit& unit, mir::ExprId services_id,
     WalkFrame parent_frame, mir::ProceduralScope wrapper,
     std::optional<std::string> label, mir::TypeId result_type,
     mir::Expr call_expr, bool call_suspends,
@@ -40,6 +52,7 @@ auto BuildCopyOutBlock(
     const std::vector<OutputArgSlot>& slots) -> mir::Stmt {
   const mir::TypeId call_type = call_expr.type;
   const mir::ExprId call_id = wrapper.AddExpr(std::move(call_expr));
+  const mir::TypeId void_type = unit.builtins.void_type;
 
   if (assign_target_id.has_value()) {
     mir::ExprId value_id = call_id;
@@ -52,11 +65,10 @@ auto BuildCopyOutBlock(
                       .kind = mir::ConversionKind::kImplicit},
               .type = result_type});
     }
-    const mir::ExprId assign_id = wrapper.AddExpr(
-        mir::Expr{
-            .data =
-                mir::AssignExpr{.target = *assign_target_id, .value = value_id},
-            .type = result_type});
+    const mir::Expr assign_expr = BuildObservableAssignExpr(
+        unit, wrapper, services_id, *assign_target_id, value_id, std::nullopt,
+        result_type, void_type);
+    const mir::ExprId assign_id = wrapper.AddExpr(assign_expr);
     wrapper.AppendStmt(mir::ExprStmt{.expr = assign_id});
   } else if (call_suspends) {
     wrapper.AppendStmt(mir::AwaitStmt{.awaitable = call_id});
@@ -67,10 +79,10 @@ auto BuildCopyOutBlock(
   for (const OutputArgSlot& slot : slots) {
     const mir::ExprId temp_read =
         wrapper.AddExpr(mir::Expr{.data = slot.temp, .type = slot.type});
-    const mir::ExprId copy_out = wrapper.AddExpr(
-        mir::Expr{
-            .data = mir::AssignExpr{.target = slot.actual, .value = temp_read},
-            .type = slot.type});
+    const mir::Expr copy_out_expr = BuildObservableAssignExpr(
+        unit, wrapper, services_id, slot.actual, temp_read, std::nullopt,
+        slot.type, void_type);
+    const mir::ExprId copy_out = wrapper.AddExpr(copy_out_expr);
     wrapper.AppendStmt(mir::ExprStmt{.expr = copy_out});
   }
 

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -17,9 +17,11 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/expression/operators.hpp"
+#include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
+#include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/closure.hpp"
@@ -28,6 +30,7 @@
 #include "lyra/mir/procedural_hops.hpp"
 #include "lyra/mir/runtime_submit.hpp"
 #include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -44,11 +47,14 @@ auto IsExprRootedAtStructuralVar(
           [](const mir::StructuralVarRef&) { return true; },
           [](const mir::MemberAccessExpr&) { return true; },
           [](const mir::ProceduralVarRef&) { return false; },
-          [&](const mir::ElementSelectExpr& s) {
-            return IsExprRootedAtStructuralVar(proc_scope, s.base_value);
-          },
-          [&](const mir::RangeSelectExpr& s) {
-            return IsExprRootedAtStructuralVar(proc_scope, s.base_value);
+          [&](const mir::CallExpr& c) {
+            const auto* callee =
+                std::get_if<mir::BuiltinMethodCallee>(&c.callee);
+            if (callee == nullptr || !mir::IsContainerAccessCall(*callee) ||
+                c.arguments.empty()) {
+              return false;
+            }
+            return IsExprRootedAtStructuralVar(proc_scope, c.arguments.front());
           },
           [&](const mir::ConcatExpr& c) {
             return std::ranges::all_of(c.operands, [&](mir::ExprId op) {
@@ -91,10 +97,11 @@ auto SnapshotNonLhsSubexpr(
 }
 
 // Recursively clone an LHS-shaped expression into the closure body. The LHS
-// structure (PrimaryExpr, ElementSelectExpr, RangeSelectExpr, ConcatExpr) is
+// structure (PrimaryExpr, container-access CallExpr, ConcatExpr) is
 // reproduced as-is; per-layer subexpressions that are NOT part of the LHS
-// structure (selector indices, range bounds) are snapshotted by value so
-// the closure body sees the values that were live at submit time.
+// structure (selector indices, range offsets and count literals) are
+// snapshotted by value so the closure body sees the values that were live
+// at submit time.
 auto CloneLhsExprForNbaBody(
     const mir::ProceduralScope& outer_scope, mir::ProceduralScope& body,
     mir::TypeId self_ptr_type, mir::ProceduralVarId body_self_id,
@@ -103,33 +110,31 @@ auto CloneLhsExprForNbaBody(
   const auto& outer_expr = outer_scope.GetExpr(outer_id);
   return std::visit(
       Overloaded{
-          [&](const mir::ElementSelectExpr& s) -> mir::ExprId {
-            const mir::ExprId base = CloneLhsExprForNbaBody(
+          [&](const mir::CallExpr& c) -> mir::ExprId {
+            const auto* callee =
+                std::get_if<mir::BuiltinMethodCallee>(&c.callee);
+            if (callee == nullptr || !mir::IsContainerAccessCall(*callee) ||
+                c.arguments.empty()) {
+              throw InternalError(
+                  "CloneLhsExprForNbaBody: CallExpr is not a container-access "
+                  "form in NBA LHS clone walk");
+            }
+            std::vector<mir::ExprId> body_args;
+            body_args.reserve(c.arguments.size());
+            body_args.push_back(CloneLhsExprForNbaBody(
                 outer_scope, body, self_ptr_type, body_self_id, captures,
-                snapshot_counter, s.base_value);
-            const mir::ExprId index = SnapshotNonLhsSubexpr(
-                outer_scope, body, captures, snapshot_counter, s.index, "nba");
+                snapshot_counter, c.arguments.front()));
+            for (std::size_t i = 1; i < c.arguments.size(); ++i) {
+              body_args.push_back(SnapshotNonLhsSubexpr(
+                  outer_scope, body, captures, snapshot_counter, c.arguments[i],
+                  "nba"));
+            }
             return body.AddExpr(
                 mir::Expr{
                     .data =
-                        mir::ElementSelectExpr{
-                            .base_value = base, .index = index},
-                    .type = outer_expr.type});
-          },
-          [&](const mir::RangeSelectExpr& s) -> mir::ExprId {
-            const mir::ExprId base = CloneLhsExprForNbaBody(
-                outer_scope, body, self_ptr_type, body_self_id, captures,
-                snapshot_counter, s.base_value);
-            const mir::ExprId offset = SnapshotNonLhsSubexpr(
-                outer_scope, body, captures, snapshot_counter, s.offset_expr,
-                "nba");
-            return body.AddExpr(
-                mir::Expr{
-                    .data =
-                        mir::RangeSelectExpr{
-                            .base_value = base,
-                            .offset_expr = offset,
-                            .count = s.count},
+                        mir::CallExpr{
+                            .callee = c.callee,
+                            .arguments = std::move(body_args)},
                     .type = outer_expr.type});
           },
           [&](const mir::ConcatExpr& c) -> mir::ExprId {
@@ -187,7 +192,7 @@ auto LowerHirAssignExprProc(
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const mir::TypeId rhs_type = (*rhs_or).type;
   const mir::ExprId rhs_id = proc_scope.AddExpr(*std::move(rhs_or));
-  auto lhs_or = process.LowerExpr(
+  auto lhs_or = process.LowerLhsExpr(
       hir_process.exprs.at(a.lhs.value), frame.WithLvalueTarget(true));
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const mir::ExprId lhs_id = proc_scope.AddExpr(*std::move(lhs_or));
@@ -196,11 +201,11 @@ auto LowerHirAssignExprProc(
     const std::optional<mir::BinaryOp> compound_op =
         a.compound_op.has_value() ? std::optional{LowerBinaryOp(*a.compound_op)}
                                   : std::nullopt;
-    return mir::Expr{
-        .data =
-            mir::AssignExpr{
-                .target = lhs_id, .compound_op = compound_op, .value = rhs_id},
-        .type = result_type};
+    const mir::ExprId services_id =
+        proc_scope.AddExpr(BuildServicesCallExpr(process, frame));
+    return BuildObservableAssignExpr(
+        process.Module().Unit(), proc_scope, services_id, lhs_id, rhs_id,
+        compound_op, result_type, process.Module().Unit().builtins.void_type);
   }
 
   if (a.compound_op.has_value()) {
@@ -262,10 +267,23 @@ auto BuildNbaSubmitClosureExpr(
       outer_scope, body, self_ptr_type, self_id, captures, snapshot_counter,
       lhs_in_outer);
 
-  const mir::ExprId assign_id = body.AddExpr(
+  // Body-side `self.Services()` for the observable write. Built only inside
+  // the closure body because the outer scope's `self_binding` and depths do
+  // not reach into the body -- the body captures `self` by value at depth 0.
+  const mir::ExprId body_self_ref = body.AddExpr(
       mir::Expr{
-          .data = mir::AssignExpr{.target = body_lhs_id, .value = rhs_ref_id},
-          .type = rhs_type});
+          .data =
+              mir::ProceduralVarRef{
+                  .hops = mir::ProceduralHops{.value = 0}, .var = self_id},
+          .type = self_ptr_type});
+  const mir::ExprId body_services_id = body.AddExpr(
+      mir::MakeServicesCallExpr(
+          body_self_ref, module.Unit().builtins.services));
+
+  const mir::Expr assign_expr = BuildObservableAssignExpr(
+      module.Unit(), body, body_services_id, body_lhs_id, rhs_ref_id,
+      std::nullopt, rhs_type, module.Unit().builtins.void_type);
+  const mir::ExprId assign_id = body.AddExpr(assign_expr);
   body.AppendStmt(
       mir::Stmt{
           .label = std::nullopt, .data = mir::ExprStmt{.expr = assign_id}});

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -23,6 +23,7 @@
 #include "lyra/lowering/hir_to_mir/expression/system/sformat.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/time.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/timescale.hpp"
+#include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/procedural_depth.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
@@ -33,6 +34,7 @@
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/procedural_hops.hpp"
+#include "lyra/mir/type.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -111,9 +113,6 @@ auto LowerEventMethodKind(hir::EventMethodKind k) -> mir::EventMethodKind {
   throw InternalError("LowerEventMethodKind: unknown hir::EventMethodKind");
 }
 
-// LRM 7.12.1: reduction / ordering / locator family takes a closure
-// (explicit `with` clause or implicit `with (item)`). `kSize`, `kDelete`,
-// `kReverse` do not.
 auto ArrayMethodTakesClosure(hir::ArrayMethodKind k) -> bool {
   switch (k) {
     case hir::ArrayMethodKind::kSize:
@@ -246,6 +245,54 @@ auto LowerIteratorMethodKind(hir::IteratorMethodKind k)
   }
   throw InternalError(
       "LowerIteratorMethodKind: unknown hir::IteratorMethodKind");
+}
+
+// Translates a HIR builtin-method ref to its MIR `BuiltinMethodCallee`. The
+// receiver type is the original HIR type of `c.arguments[0]` so the enum-
+// method case can carry the enum type id MIR needs.
+auto BuildMirBuiltinMethodCallee(
+    const ModuleLowerer& module, const hir::BuiltinMethodRef& b,
+    hir::TypeId hir_receiver_type) -> mir::BuiltinMethodCallee {
+  return std::visit(
+      Overloaded{
+          [&](hir::EnumMethodKind k) -> mir::BuiltinMethodCallee {
+            return {
+                .method = mir::EnumMethodInfo{
+                    .enum_type = module.TranslateType(hir_receiver_type),
+                    .kind = LowerEnumMethodKind(k)}};
+          },
+          [](hir::StringMethodKind k) -> mir::BuiltinMethodCallee {
+            return {
+                .method =
+                    mir::StringMethodInfo{.kind = LowerStringMethodKind(k)}};
+          },
+          [](hir::EventMethodKind k) -> mir::BuiltinMethodCallee {
+            return {
+                .method =
+                    mir::EventMethodInfo{.kind = LowerEventMethodKind(k)}};
+          },
+          [](hir::ArrayMethodKind k) -> mir::BuiltinMethodCallee {
+            return {
+                .method =
+                    mir::ArrayMethodInfo{.kind = LowerArrayMethodKind(k)}};
+          },
+          [](hir::QueueMethodKind k) -> mir::BuiltinMethodCallee {
+            return {
+                .method =
+                    mir::QueueMethodInfo{.kind = LowerQueueMethodKind(k)}};
+          },
+          [](hir::AssociativeMethodKind k) -> mir::BuiltinMethodCallee {
+            return {
+                .method = mir::AssociativeMethodInfo{
+                    .kind = LowerAssociativeMethodKind(k)}};
+          },
+          [](hir::IteratorMethodKind k) -> mir::BuiltinMethodCallee {
+            return {
+                .method = mir::IteratorMethodInfo{
+                    .kind = LowerIteratorMethodKind(k)}};
+          },
+      },
+      b.method);
 }
 
 auto LowerUserCallee(
@@ -462,15 +509,51 @@ auto LowerHirCallExprProc(
             args.reserve(c.arguments.size() + 1);
             args.push_back(proc_scope.AddExpr(
                 BuildSelfRefExpr(frame, module.Unit().builtins.self_pointer)));
-            for (const auto& arg : c.arguments) {
-              if (!arg.has_value()) {
+            for (std::size_t i = 0; i < c.arguments.size(); ++i) {
+              if (!c.arguments[i].has_value()) {
                 throw InternalError(
                     "user-function call argument unexpectedly elided");
               }
-              auto arg_or =
-                  process.LowerExpr(hir_process.exprs.at(arg->value), frame);
-              if (!arg_or) return std::unexpected(std::move(arg_or.error()));
-              args.push_back(proc_scope.AddExpr(*std::move(arg_or)));
+              // A ref / const-ref formal aliases the actual's cell. The
+              // body's `Ref<T>` either binds the wrapped cell directly
+              // (bare observable actual) or holds a `ScopedMutation` snapshot
+              // (selector / range on an observable actual) -- both routed by
+              // the LHS-form lowering plus the observable mutate rewrite.
+              const bool is_ref_formal =
+                  i < decl.params.size() &&
+                  (decl.params[i].direction == hir::ParamDirection::kRef ||
+                   decl.params[i].direction == hir::ParamDirection::kConstRef);
+              mir::ExprId actual_id{};
+              if (is_ref_formal) {
+                auto arg_or = process.LowerLhsExpr(
+                    hir_process.exprs.at(c.arguments[i]->value), frame);
+                if (!arg_or) {
+                  return std::unexpected(std::move(arg_or.error()));
+                }
+                actual_id = proc_scope.AddExpr(*std::move(arg_or));
+                const mir::ExprId root_id =
+                    FindLhsRootId(proc_scope, actual_id);
+                const bool root_is_cell = mir::IsObservableCellType(
+                    module.Unit().GetType(proc_scope.GetExpr(root_id).type));
+                if (root_is_cell && root_id != actual_id) {
+                  // Selector / range on an observable cell -- the body sees
+                  // a `Ref<T>` bound to a `ScopedMutation` snapshot of the
+                  // selected element. Bare cells stay as-is so the body's
+                  // `Ref<T>` binds the underlying `Var<T>` directly.
+                  const mir::ExprId services_id =
+                      proc_scope.AddExpr(BuildServicesCallExpr(process, frame));
+                  actual_id = RewriteLhsRootWithMutate(
+                      module.Unit(), proc_scope, actual_id, services_id);
+                }
+              } else {
+                auto arg_or = process.LowerExpr(
+                    hir_process.exprs.at(c.arguments[i]->value), frame);
+                if (!arg_or) {
+                  return std::unexpected(std::move(arg_or.error()));
+                }
+                actual_id = proc_scope.AddExpr(*std::move(arg_or));
+              }
+              args.push_back(actual_id);
             }
             return mir::Expr{
                 .data =
@@ -509,13 +592,75 @@ auto LowerHirCallExprProc(
                 hir_process.exprs.at(c.arguments.front()->value).type;
             std::vector<mir::ExprId> args;
             args.reserve(c.arguments.size() + 1);
-            for (const auto& arg : c.arguments) {
-              if (!arg.has_value()) {
+
+            // Translate to the MIR callee up front so the same trait
+            // (`mir::IsMutatingBuiltinMethod`) drives both lowering and
+            // backend rendering.
+            const mir::BuiltinMethodCallee mir_callee =
+                BuildMirBuiltinMethodCallee(module, b, hir_receiver_type);
+
+            // Lower the receiver. A mutating method against an observable
+            // cell routes through `Var<T>::Mutate` -- the receiver is the
+            // bare cell expression wrapped in
+            // `DerefExpr(CallExpr(ObservableMethod{kMutate}, [cell,
+            // services]))` so the method body operates on the snapshot and the
+            // destructor commits via `Var::Set`. A non-mutating method consumes
+            // the value, so the default `LowerExpr` path (which auto-wraps in
+            // `Get`) is correct.
+            const bool method_mutates =
+                mir::IsMutatingBuiltinMethod(mir_callee);
+            mir::ExprId receiver_id{};
+            if (method_mutates) {
+              auto recv_or = process.LowerLhsExpr(
+                  hir_process.exprs.at(c.arguments.front()->value), frame);
+              if (!recv_or) {
+                return std::unexpected(std::move(recv_or.error()));
+              }
+              receiver_id = proc_scope.AddExpr(*std::move(recv_or));
+              const mir::ExprId root_id =
+                  FindLhsRootId(proc_scope, receiver_id);
+              const bool root_is_cell = mir::IsObservableCellType(
+                  module.Unit().GetType(proc_scope.GetExpr(root_id).type));
+              if (root_is_cell) {
+                const mir::ExprId services_id =
+                    proc_scope.AddExpr(BuildServicesCallExpr(process, frame));
+                receiver_id = RewriteLhsRootWithMutate(
+                    module.Unit(), proc_scope, receiver_id, services_id);
+              }
+            } else {
+              auto recv_or = process.LowerExpr(
+                  hir_process.exprs.at(c.arguments.front()->value), frame);
+              if (!recv_or) {
+                return std::unexpected(std::move(recv_or.error()));
+              }
+              receiver_id = proc_scope.AddExpr(*std::move(recv_or));
+            }
+            args.push_back(receiver_id);
+
+            // LRM 7.9.4 -- 7.9.7 associative-array traversal methods
+            // (`first` / `last` / `next` / `prev`) take their index argument
+            // as a `ref` so the visited key writes through to the actual --
+            // lower it cell-rooted like any other ref formal.
+            const auto* assoc_kind =
+                std::get_if<hir::AssociativeMethodKind>(&b.method);
+            const bool index_is_ref =
+                assoc_kind != nullptr &&
+                (*assoc_kind == hir::AssociativeMethodKind::kFirst ||
+                 *assoc_kind == hir::AssociativeMethodKind::kLast ||
+                 *assoc_kind == hir::AssociativeMethodKind::kNext ||
+                 *assoc_kind == hir::AssociativeMethodKind::kPrev);
+            for (std::size_t i = 1; i < c.arguments.size(); ++i) {
+              if (!c.arguments[i].has_value()) {
                 throw InternalError(
                     "builtin-method call argument unexpectedly elided");
               }
+              const bool lower_as_lhs = index_is_ref && i == 1;
               auto arg_or =
-                  process.LowerExpr(hir_process.exprs.at(arg->value), frame);
+                  lower_as_lhs
+                      ? process.LowerLhsExpr(
+                            hir_process.exprs.at(c.arguments[i]->value), frame)
+                      : process.LowerExpr(
+                            hir_process.exprs.at(c.arguments[i]->value), frame);
               if (!arg_or) {
                 return std::unexpected(std::move(arg_or.error()));
               }
@@ -553,53 +698,10 @@ auto LowerHirCallExprProc(
                     proc_scope.AddExpr(BuildServicesCallExpr(process, frame)));
               }
             }
-            auto callee = std::visit(
-                Overloaded{
-                    [&](hir::EnumMethodKind k) -> mir::BuiltinMethodCallee {
-                      return {
-                          .method = mir::EnumMethodInfo{
-                              .enum_type =
-                                  module.TranslateType(hir_receiver_type),
-                              .kind = LowerEnumMethodKind(k)}};
-                    },
-                    [&](hir::StringMethodKind k) -> mir::BuiltinMethodCallee {
-                      return {
-                          .method = mir::StringMethodInfo{
-                              .kind = LowerStringMethodKind(k)}};
-                    },
-                    [&](hir::EventMethodKind k) -> mir::BuiltinMethodCallee {
-                      return {
-                          .method = mir::EventMethodInfo{
-                              .kind = LowerEventMethodKind(k)}};
-                    },
-                    [&](hir::ArrayMethodKind k) -> mir::BuiltinMethodCallee {
-                      return {
-                          .method = mir::ArrayMethodInfo{
-                              .kind = LowerArrayMethodKind(k)}};
-                    },
-                    [&](hir::QueueMethodKind k) -> mir::BuiltinMethodCallee {
-                      return {
-                          .method = mir::QueueMethodInfo{
-                              .kind = LowerQueueMethodKind(k)}};
-                    },
-                    [&](hir::AssociativeMethodKind k)
-                        -> mir::BuiltinMethodCallee {
-                      return {
-                          .method = mir::AssociativeMethodInfo{
-                              .kind = LowerAssociativeMethodKind(k)}};
-                    },
-                    [&](hir::IteratorMethodKind k) -> mir::BuiltinMethodCallee {
-                      return {
-                          .method = mir::IteratorMethodInfo{
-                              .kind = LowerIteratorMethodKind(k)}};
-                    },
-                },
-                b.method);
             return mir::Expr{
                 .data =
                     mir::CallExpr{
-                        .callee = std::move(callee),
-                        .arguments = std::move(args)},
+                        .callee = mir_callee, .arguments = std::move(args)},
                 .type = result_type};
           },
       },

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -11,12 +11,16 @@
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/unary_op.hpp"
+#include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/binary_op.hpp"
+#include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/mir/type.hpp"
 #include "lyra/mir/type_id.hpp"
 #include "lyra/mir/unary_op.hpp"
 
@@ -210,13 +214,26 @@ auto LowerHirIncDecExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::IncDecExpr& inc,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& hir_process = process.HirBody();
+  auto& proc_scope = *frame.current_procedural_scope;
   // The target is written in place, so a queue element resolves to its write
   // access method (`WriteRef`) just as an assignment target does.
-  auto target_or = process.LowerExpr(
+  auto target_or = process.LowerLhsExpr(
       hir_process.exprs.at(inc.target.value), frame.WithLvalueTarget(true));
   if (!target_or) return std::unexpected(std::move(target_or.error()));
-  const mir::ExprId target_id =
-      frame.current_procedural_scope->AddExpr(*std::move(target_or));
+  mir::ExprId target_id = proc_scope.AddExpr(*std::move(target_or));
+
+  // If the LHS reaches an observable storage cell, the mutation runs inside
+  // a `ScopedMutation` snapshot so subscribers fire once on destructor commit
+  // (`docs/decisions/value-type-concepts.md`).
+  const mir::ExprId root_id = FindLhsRootId(proc_scope, target_id);
+  if (mir::IsObservableCellType(
+          process.Module().Unit().GetType(proc_scope.GetExpr(root_id).type))) {
+    const mir::ExprId services_id =
+        proc_scope.AddExpr(BuildServicesCallExpr(process, frame));
+    target_id = RewriteLhsRootWithMutate(
+        process.Module().Unit(), proc_scope, target_id, services_id);
+  }
+
   return mir::Expr{
       .data = mir::IncDecExpr{.op = LowerIncDecOp(inc.op), .target = target_id},
       .type = result_type};

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -15,6 +15,8 @@
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/integral_constant.hpp"
+#include "lyra/mir/structural_scope.hpp"
+#include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -94,15 +96,23 @@ auto LowerHirRealLiteral(const hir::RealLiteral& r, mir::TypeId type)
   return mir::Expr{.data = mir::RealLiteral{.value = r.value}, .type = type};
 }
 
+// Reach the storage cell of a structural var: `MemberAccess(self, member)`.
+// `Expr.type` is the var's declared MIR type -- a wrapper
+// (`ObservableType` / `ExternalRefType`) for observable storage, the plain
+// value type otherwise. The dispatcher decides whether to wrap the result
+// in an `ObservableMethod{kGet}` call to unwrap to a value.
 auto LowerStructuralVarRefExpr(
     const StructuralScopeLowerer& scope, const WalkFrame& frame,
-    const hir::StructuralVarRef& m, mir::TypeId type) -> mir::Expr {
+    const hir::StructuralVarRef& m) -> mir::Expr {
   const mir::StructuralVarRef member =
       scope.TranslateStructuralVar(m.hops, m.var);
+  const mir::TypeId field_type = frame.StructuralScopeAtHops(member.hops)
+                                     .GetStructuralVar(member.var)
+                                     .type;
   const mir::TypeId self_ptr_type = scope.Module().Unit().builtins.self_pointer;
   const mir::ExprId receiver = frame.current_procedural_scope->AddExpr(
       BuildSelfRefExpr(frame, self_ptr_type));
-  return mir::MakeMemberAccessExpr(receiver, member, type);
+  return mir::MakeMemberAccessExpr(receiver, member, field_type);
 }
 
 auto LowerProceduralVarRefExpr(
@@ -110,20 +120,19 @@ auto LowerProceduralVarRefExpr(
     const hir::ProceduralVarRef& l, mir::TypeId type) -> mir::Expr {
   const auto& binding = process.LookupProceduralVar(l.var);
   // A static-lifetime local lives as a per-instance structural var on the
-  // owner scope (LRM 13.3.1); body access is a `MemberAccess` through `self`,
-  // identical inside the body, inside a nested block, and inside any closure
-  // -- no hops, no closure capture, the closure's captured `self` is the
-  // receiver.
+  // owner scope (LRM 13.3.1); the read reaches it through `self` like any
+  // structural-var ref.
   if (const auto* sb = std::get_if<StaticVarBinding>(&binding)) {
+    const mir::StructuralVarRef member{
+        .hops = mir::StructuralHops{.value = 0}, .var = sb->var};
+    const mir::TypeId field_type = frame.StructuralScopeAtHops(member.hops)
+                                       .GetStructuralVar(member.var)
+                                       .type;
     const mir::TypeId self_ptr_type =
         process.Module().Unit().builtins.self_pointer;
     const mir::ExprId receiver = frame.current_procedural_scope->AddExpr(
         BuildSelfRefExpr(frame, self_ptr_type));
-    return mir::MakeMemberAccessExpr(
-        receiver,
-        mir::StructuralVarRef{
-            .hops = mir::StructuralHops{.value = 0}, .var = sb->var},
-        type);
+    return mir::MakeMemberAccessExpr(receiver, member, field_type);
   }
   const auto& ab = std::get<AutomaticVarBinding>(binding);
   if (auto* sink = frame.active_closure) {
@@ -146,7 +155,7 @@ auto LowerProceduralVarRefExpr(
 
 auto LowerCrossUnitVarRefExpr(
     const StructuralScopeLowerer& scope, const WalkFrame& frame,
-    const hir::CrossUnitVarRef& c, mir::TypeId type) -> mir::Expr {
+    const hir::CrossUnitVarRef& c) -> mir::Expr {
   const auto& meta = scope.CrossUnitRefTarget(c.id);
   const mir::StructuralVarRef target = meta.target;
   const mir::TypeId self_ptr_type = scope.Module().Unit().builtins.self_pointer;
@@ -157,9 +166,10 @@ auto LowerCrossUnitVarRefExpr(
   if (ptr != nullptr && ptr->ownership == mir::PointerOwnership::kBorrowed) {
     const mir::ExprId pointer = frame.current_procedural_scope->AddExpr(
         mir::MakeMemberAccessExpr(self_ref, target, meta.slot_type));
-    return mir::Expr{.data = mir::DerefExpr{.pointer = pointer}, .type = type};
+    return mir::Expr{
+        .data = mir::DerefExpr{.pointer = pointer}, .type = ptr->pointee};
   }
-  return mir::MakeMemberAccessExpr(self_ref, target, type);
+  return mir::MakeMemberAccessExpr(self_ref, target, meta.slot_type);
 }
 
 auto LowerLoopVarRefExprAsProcedural(
@@ -198,7 +208,7 @@ auto LowerHirPrimaryExprProc(
             return LowerHirRealLiteral(r, result_type);
           },
           [&](const hir::StructuralVarRef& m) -> mir::Expr {
-            return LowerStructuralVarRefExpr(scope, frame, m, result_type);
+            return LowerStructuralVarRefExpr(scope, frame, m);
           },
           [&](const hir::ProceduralVarRef& l) -> mir::Expr {
             return LowerProceduralVarRefExpr(process, frame, l, result_type);
@@ -207,7 +217,7 @@ auto LowerHirPrimaryExprProc(
             return LowerLoopVarRefExprAsStructuralParam(scope, lv, result_type);
           },
           [&](const hir::CrossUnitVarRef& c) -> mir::Expr {
-            return LowerCrossUnitVarRefExpr(scope, frame, c, result_type);
+            return LowerCrossUnitVarRefExpr(scope, frame, c);
           },
       },
       p);
@@ -231,7 +241,7 @@ auto LowerHirPrimaryExprStructural(
             return LowerHirRealLiteral(r, result_type);
           },
           [&](const hir::StructuralVarRef& m) -> mir::Expr {
-            return LowerStructuralVarRefExpr(scope, frame, m, result_type);
+            return LowerStructuralVarRefExpr(scope, frame, m);
           },
           [](const hir::ProceduralVarRef&) -> mir::Expr {
             throw InternalError(
@@ -246,7 +256,7 @@ auto LowerHirPrimaryExprStructural(
             return LowerLoopVarRefExprAsStructuralParam(scope, lv, result_type);
           },
           [&](const hir::CrossUnitVarRef& c) -> mir::Expr {
-            return LowerCrossUnitVarRefExpr(scope, frame, c, result_type);
+            return LowerCrossUnitVarRefExpr(scope, frame, c);
           },
       },
       p);

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -17,11 +17,99 @@
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/binary_op.hpp"
+#include "lyra/mir/builtin_method.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/integral_constant.hpp"
+#include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
+
+namespace {
+
+enum class AccessSide : std::uint8_t { kRead, kLhs };
+
+// Picks the right runtime container method for `arr[i]`. `kRead` /
+// `kElementRef` for an associative array (LRM 7.8.6 / 7.8.7 splits read from
+// write); `kElementAt` for every other container (the read / write surface
+// coincides at runtime).
+auto ElementAccessCallee(const hir::Type& base_hir_type, AccessSide side)
+    -> mir::BuiltinMethodCallee {
+  if (std::holds_alternative<hir::AssociativeArrayType>(base_hir_type.data)) {
+    return mir::BuiltinMethodCallee{
+        .method = mir::AssociativeMethodInfo{
+            .kind = side == AccessSide::kLhs
+                        ? mir::AssociativeMethodKind::kElementRef
+                        : mir::AssociativeMethodKind::kRead}};
+  }
+  if (std::holds_alternative<hir::QueueType>(base_hir_type.data)) {
+    return mir::BuiltinMethodCallee{
+        .method = mir::QueueMethodInfo{
+            .kind = side == AccessSide::kLhs
+                        ? mir::QueueMethodKind::kWriteRef
+                        : mir::QueueMethodKind::kElementAt}};
+  }
+  return mir::BuiltinMethodCallee{
+      .method = mir::ArrayMethodInfo{.kind = mir::ArrayMethodKind::kElementAt}};
+}
+
+// Wraps a `kElementAt` / `kSlice` result with `kToOwned` so the borrowed
+// `PackedArrayRef` materialises into an owning `PackedArray` (Rust's
+// `&[T]::to_owned() -> Vec<T>` pattern). Required in read context; LHS chains
+// keep the view because they write through it.
+auto WrapPackedAsOwned(
+    const mir::CompilationUnit& unit, mir::ProceduralScope& scope,
+    mir::Expr access_call, mir::TypeId result_type) -> mir::Expr {
+  if (!std::holds_alternative<mir::PackedArrayType>(
+          unit.GetType(result_type).data)) {
+    return access_call;
+  }
+  const mir::ExprId access_id = scope.AddExpr(std::move(access_call));
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinMethodCallee{
+                      .method =
+                          mir::ArrayMethodInfo{
+                              .kind = mir::ArrayMethodKind::kToOwned}},
+              .arguments = {access_id}},
+      .type = result_type};
+}
+
+// LRM 7.4.1: part-select returns unsigned. The runtime `Slice` honours this
+// (always returns an unsigned `PackedArrayRef`). When the consumer's MIR type
+// is signed -- a `logic signed [...]` packed-struct / union field per LRM
+// 7.2.1 -- return the unsigned-signedness counterpart so the slice's MIR
+// `.type` matches what the runtime produces; an explicit `ConversionExpr`
+// then re-tags to the consumer's signed type.
+auto UnsignedPackedCounterpart(
+    mir::CompilationUnit& unit, mir::TypeId result_type) -> mir::TypeId {
+  const auto& ty = unit.GetType(result_type);
+  if (!ty.IsPackedArray()) return result_type;
+  const auto& pa = ty.AsPackedArray();
+  if (pa.signedness == mir::Signedness::kUnsigned) return result_type;
+  auto unsigned_pa = pa;
+  unsigned_pa.signedness = mir::Signedness::kUnsigned;
+  return unit.AddType(mir::TypeData{std::move(unsigned_pa)});
+}
+
+// Wraps a slice result that was rendered at `slice_type` (unsigned) with an
+// explicit `ConversionExpr` to `final_type` when the two differ. No-op when
+// the slice already matches the consumer's MIR type.
+auto WrapSliceSignReTag(
+    mir::ProceduralScope& scope, mir::Expr owned, mir::TypeId slice_type,
+    mir::TypeId final_type) -> mir::Expr {
+  if (slice_type == final_type) return owned;
+  const mir::ExprId owned_id = scope.AddExpr(std::move(owned));
+  return mir::Expr{
+      .data =
+          mir::ConversionExpr{
+              .operand = owned_id, .kind = mir::ConversionKind::kImplicit},
+      .type = final_type};
+}
+
+}  // namespace
 
 namespace {
 
@@ -338,13 +426,14 @@ auto LowerHirElementSelectExprProc(
         module.TranslateType(hir_idx.type));
   }
 
-  return mir::Expr{
+  mir::Expr access_call{
       .data =
-          mir::ElementSelectExpr{
-              .base_value = base_id,
-              .index = idx_id,
-          },
+          mir::CallExpr{
+              .callee = ElementAccessCallee(hir_base_ty, AccessSide::kRead),
+              .arguments = {base_id, idx_id}},
       .type = result_type};
+  return WrapPackedAsOwned(
+      module.Unit(), proc_scope, std::move(access_call), result_type);
 }
 
 auto LowerHirRangeSelectExprProc(
@@ -385,24 +474,33 @@ auto LowerHirRangeSelectExprProc(
   }();
   if (!unfolded) return std::unexpected(std::move(unfolded.error()));
 
-  return mir::Expr{
+  const mir::ExprId count_id = proc_scope.AddExpr(
+      mir::MakeInt32Literal(
+          module.Unit().builtins.int32,
+          static_cast<std::int64_t>(unfolded->count)));
+  mir::Expr slice_call{
       .data =
-          mir::RangeSelectExpr{
-              .base_value = base_id,
-              .offset_expr = unfolded->offset_expr,
-              .count = unfolded->count,
-          },
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinMethodCallee{
+                      .method =
+                          mir::ArrayMethodInfo{
+                              .kind = mir::ArrayMethodKind::kSlice}},
+              .arguments = {base_id, unfolded->offset_expr, count_id}},
       .type = result_type};
+  return WrapPackedAsOwned(
+      module.Unit(), proc_scope, std::move(slice_call), result_type);
 }
 
-// LRM 7.2.1: packed struct field access "can be selected as if it were a
-// packed array". HIR -> MIR resolves the field-table index to a concrete
-// (offset, count) RangeSelectExpr -- the same MIR shape `s[hi:lo]` produces.
-// MIR carries no struct-specific node.
+// LRM 7.2.1: packed struct / union field access "can be selected as if it
+// were a packed array". HIR -> MIR resolves the field-table index to a
+// concrete (offset, count) slice -- the same MIR shape `s[hi:lo]` produces.
+// Signedness is preserved through an explicit `ConversionExpr` because the
+// slice itself returns unsigned bits (LRM 7.4.1).
 auto LowerHirMemberAccessExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::MemberAccessExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& module = process.Module();
+  auto& module = process.Module();
   const auto& hir_process = process.HirBody();
   auto& proc_scope = *frame.current_procedural_scope;
   const auto& base_hir_expr = hir_process.exprs.at(sel.base_value.value);
@@ -420,13 +518,140 @@ auto LowerHirMemberAccessExprProc(
       mir::MakeInt32Literal(
           module.Unit().builtins.int32,
           static_cast<std::int64_t>(field.bit_offset)));
+  const auto count_id = proc_scope.AddExpr(
+      mir::MakeInt32Literal(
+          module.Unit().builtins.int32,
+          static_cast<std::int64_t>(field.bit_width)));
+  const mir::TypeId slice_type =
+      UnsignedPackedCounterpart(module.Unit(), result_type);
+  mir::Expr slice_call{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinMethodCallee{
+                      .method =
+                          mir::ArrayMethodInfo{
+                              .kind = mir::ArrayMethodKind::kSlice}},
+              .arguments = {base_id, offset_id, count_id}},
+      .type = slice_type};
+  mir::Expr owned = WrapPackedAsOwned(
+      module.Unit(), proc_scope, std::move(slice_call), slice_type);
+  return WrapSliceSignReTag(
+      proc_scope, std::move(owned), slice_type, result_type);
+}
+
+auto LowerHirElementSelectExprProcLhs(
+    ProcessLowerer& process, WalkFrame frame, const hir::ElementSelectExpr& sel,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  const auto& module = process.Module();
+  const auto& hir_process = process.HirBody();
+  auto& proc_scope = *frame.current_procedural_scope;
+  const auto& hir_base = hir_process.exprs.at(sel.base_value.value);
+  auto base_or = process.LowerLhsExpr(hir_base, frame);
+  if (!base_or) return std::unexpected(std::move(base_or.error()));
+  const mir::ExprId base_id = proc_scope.AddExpr(*std::move(base_or));
+
+  const auto& hir_idx = hir_process.exprs.at(sel.index.value);
+  auto idx_or = process.LowerExpr(hir_idx, frame);
+  if (!idx_or) return std::unexpected(std::move(idx_or.error()));
+  mir::ExprId idx_id = proc_scope.AddExpr(*std::move(idx_or));
+
+  const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
+  if (const auto* ua = std::get_if<hir::UnpackedArrayType>(&hir_base_ty.data)) {
+    idx_id = WrapUnpackedIndex(
+        module, proc_scope, ua->dim, idx_id,
+        module.TranslateType(hir_idx.type));
+  }
+
   return mir::Expr{
       .data =
-          mir::RangeSelectExpr{
-              .base_value = base_id,
-              .offset_expr = offset_id,
-              .count = static_cast<std::uint32_t>(field.bit_width),
-          },
+          mir::CallExpr{
+              .callee = ElementAccessCallee(hir_base_ty, AccessSide::kLhs),
+              .arguments = {base_id, idx_id}},
+      .type = result_type};
+}
+
+auto LowerHirRangeSelectExprProcLhs(
+    ProcessLowerer& process, WalkFrame frame, const hir::RangeSelectExpr& sel,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  const auto& module = process.Module();
+  const auto& hir_process = process.HirBody();
+  auto& proc_scope = *frame.current_procedural_scope;
+  const auto& hir_base = hir_process.exprs.at(sel.base_value.value);
+  auto base_or = process.LowerLhsExpr(hir_base, frame);
+  if (!base_or) return std::unexpected(std::move(base_or.error()));
+  const mir::ExprId base_id = proc_scope.AddExpr(*std::move(base_or));
+
+  auto lower_one = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
+    auto lowered = process.LowerExpr(hir_process.exprs.at(id.value), frame);
+    if (!lowered) return std::unexpected(std::move(lowered.error()));
+    return proc_scope.AddExpr(*std::move(lowered));
+  };
+  const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
+  auto unfolded = [&]() {
+    if (const auto* ua =
+            std::get_if<hir::UnpackedArrayType>(&hir_base_ty.data)) {
+      const auto& result_ty = module.Unit().GetType(result_type);
+      const auto count = static_cast<std::uint32_t>(
+          std::get<mir::UnpackedArrayType>(result_ty.data).size);
+      return UnfoldHirRangeBoundsForUnpacked(
+          module, proc_scope, sel.bounds, ua->dim, count, lower_one);
+    }
+    return UnfoldHirRangeBoundsToOffsetCount(
+        module, proc_scope, sel.bounds, lower_one);
+  }();
+  if (!unfolded) return std::unexpected(std::move(unfolded.error()));
+
+  const mir::ExprId count_id = proc_scope.AddExpr(
+      mir::MakeInt32Literal(
+          module.Unit().builtins.int32,
+          static_cast<std::int64_t>(unfolded->count)));
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinMethodCallee{
+                      .method =
+                          mir::ArrayMethodInfo{
+                              .kind = mir::ArrayMethodKind::kSlice}},
+              .arguments = {base_id, unfolded->offset_expr, count_id}},
+      .type = result_type};
+}
+
+auto LowerHirMemberAccessExprProcLhs(
+    ProcessLowerer& process, WalkFrame frame, const hir::MemberAccessExpr& sel,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  const auto& module = process.Module();
+  const auto& hir_process = process.HirBody();
+  auto& proc_scope = *frame.current_procedural_scope;
+  const auto& base_hir_expr = hir_process.exprs.at(sel.base_value.value);
+  const auto& base_hir_type = module.Hir().GetType(base_hir_expr.type);
+  const auto& fields = GetAggregateFields(base_hir_type);
+  if (sel.field_index >= fields.size()) {
+    throw InternalError(
+        "LowerHirMemberAccessExprProcLhs: field_index out of range");
+  }
+  const auto& field = fields[sel.field_index];
+  auto base_or = process.LowerLhsExpr(base_hir_expr, frame);
+  if (!base_or) return std::unexpected(std::move(base_or.error()));
+  const mir::ExprId base_id = proc_scope.AddExpr(*std::move(base_or));
+  const auto offset_id = proc_scope.AddExpr(
+      mir::MakeInt32Literal(
+          module.Unit().builtins.int32,
+          static_cast<std::int64_t>(field.bit_offset)));
+  const auto count_id = proc_scope.AddExpr(
+      mir::MakeInt32Literal(
+          module.Unit().builtins.int32,
+          static_cast<std::int64_t>(field.bit_width)));
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinMethodCallee{
+                      .method =
+                          mir::ArrayMethodInfo{
+                              .kind = mir::ArrayMethodKind::kSlice}},
+              .arguments = {base_id, offset_id, count_id}},
       .type = result_type};
 }
 
@@ -457,9 +682,14 @@ auto LowerHirElementSelectExprStructural(
         module.TranslateType(hir_idx.type));
   }
 
-  return mir::Expr{
-      .data = mir::ElementSelectExpr{.base_value = base_id, .index = idx_id},
+  mir::Expr access_call{
+      .data =
+          mir::CallExpr{
+              .callee = ElementAccessCallee(hir_base_ty, AccessSide::kRead),
+              .arguments = {base_id, idx_id}},
       .type = result_type};
+  return WrapPackedAsOwned(
+      module.Unit(), proc_scope, std::move(access_call), result_type);
 }
 
 auto LowerHirRangeSelectExprStructural(
@@ -497,21 +727,29 @@ auto LowerHirRangeSelectExprStructural(
   }();
   if (!unfolded) return std::unexpected(std::move(unfolded.error()));
 
-  return mir::Expr{
+  const mir::ExprId count_id = proc_scope.AddExpr(
+      mir::MakeInt32Literal(
+          module.Unit().builtins.int32,
+          static_cast<std::int64_t>(unfolded->count)));
+  mir::Expr slice_call{
       .data =
-          mir::RangeSelectExpr{
-              .base_value = base_id,
-              .offset_expr = unfolded->offset_expr,
-              .count = unfolded->count,
-          },
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinMethodCallee{
+                      .method =
+                          mir::ArrayMethodInfo{
+                              .kind = mir::ArrayMethodKind::kSlice}},
+              .arguments = {base_id, unfolded->offset_expr, count_id}},
       .type = result_type};
+  return WrapPackedAsOwned(
+      module.Unit(), proc_scope, std::move(slice_call), result_type);
 }
 
 auto LowerHirMemberAccessExprStructural(
     const StructuralScopeLowerer& scope, WalkFrame frame,
     const hir::MemberAccessExpr& sel, mir::TypeId result_type)
     -> diag::Result<mir::Expr> {
-  const auto& module = scope.Module();
+  auto& module = scope.Module();
   const auto& hir_scope = scope.HirScope();
   auto& proc_scope = *frame.current_procedural_scope;
   const auto& base_hir_expr = hir_scope.GetExpr(sel.base_value);
@@ -529,13 +767,143 @@ auto LowerHirMemberAccessExprStructural(
       mir::MakeInt32Literal(
           module.Unit().builtins.int32,
           static_cast<std::int64_t>(field.bit_offset)));
+  const auto count_id = proc_scope.AddExpr(
+      mir::MakeInt32Literal(
+          module.Unit().builtins.int32,
+          static_cast<std::int64_t>(field.bit_width)));
+  const mir::TypeId slice_type =
+      UnsignedPackedCounterpart(module.Unit(), result_type);
+  mir::Expr slice_call{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinMethodCallee{
+                      .method =
+                          mir::ArrayMethodInfo{
+                              .kind = mir::ArrayMethodKind::kSlice}},
+              .arguments = {base_id, offset_id, count_id}},
+      .type = slice_type};
+  mir::Expr owned = WrapPackedAsOwned(
+      module.Unit(), proc_scope, std::move(slice_call), slice_type);
+  return WrapSliceSignReTag(
+      proc_scope, std::move(owned), slice_type, result_type);
+}
+
+auto LowerHirElementSelectExprStructuralLhs(
+    const StructuralScopeLowerer& scope, WalkFrame frame,
+    const hir::ElementSelectExpr& sel, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
+  const auto& module = scope.Module();
+  const auto& hir_scope = scope.HirScope();
+  auto& proc_scope = *frame.current_procedural_scope;
+  const auto& hir_base = hir_scope.GetExpr(sel.base_value);
+  auto base_or = scope.LowerLhsExpr(hir_base, frame);
+  if (!base_or) return std::unexpected(std::move(base_or.error()));
+  const mir::ExprId base_id = proc_scope.AddExpr(*std::move(base_or));
+
+  const auto& hir_idx = hir_scope.GetExpr(sel.index);
+  auto idx_or = scope.LowerExpr(hir_idx, frame);
+  if (!idx_or) return std::unexpected(std::move(idx_or.error()));
+  mir::ExprId idx_id = proc_scope.AddExpr(*std::move(idx_or));
+
+  const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
+  if (const auto* ua = std::get_if<hir::UnpackedArrayType>(&hir_base_ty.data)) {
+    idx_id = WrapUnpackedIndex(
+        module, proc_scope, ua->dim, idx_id,
+        module.TranslateType(hir_idx.type));
+  }
+
   return mir::Expr{
       .data =
-          mir::RangeSelectExpr{
-              .base_value = base_id,
-              .offset_expr = offset_id,
-              .count = static_cast<std::uint32_t>(field.bit_width),
-          },
+          mir::CallExpr{
+              .callee = ElementAccessCallee(hir_base_ty, AccessSide::kLhs),
+              .arguments = {base_id, idx_id}},
+      .type = result_type};
+}
+
+auto LowerHirRangeSelectExprStructuralLhs(
+    const StructuralScopeLowerer& scope, WalkFrame frame,
+    const hir::RangeSelectExpr& sel, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
+  const auto& module = scope.Module();
+  const auto& hir_scope = scope.HirScope();
+  auto& proc_scope = *frame.current_procedural_scope;
+  const auto& hir_base = hir_scope.GetExpr(sel.base_value);
+  auto base_or = scope.LowerLhsExpr(hir_base, frame);
+  if (!base_or) return std::unexpected(std::move(base_or.error()));
+  const mir::ExprId base_id = proc_scope.AddExpr(*std::move(base_or));
+
+  auto lower_one = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
+    auto lowered = scope.LowerExpr(hir_scope.GetExpr(id), frame);
+    if (!lowered) return std::unexpected(std::move(lowered.error()));
+    return proc_scope.AddExpr(*std::move(lowered));
+  };
+  const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
+  auto unfolded = [&]() {
+    if (const auto* ua =
+            std::get_if<hir::UnpackedArrayType>(&hir_base_ty.data)) {
+      const auto& result_ty = module.Unit().GetType(result_type);
+      const auto count = static_cast<std::uint32_t>(
+          std::get<mir::UnpackedArrayType>(result_ty.data).size);
+      return UnfoldHirRangeBoundsForUnpacked(
+          module, proc_scope, sel.bounds, ua->dim, count, lower_one);
+    }
+    return UnfoldHirRangeBoundsToOffsetCount(
+        module, proc_scope, sel.bounds, lower_one);
+  }();
+  if (!unfolded) return std::unexpected(std::move(unfolded.error()));
+
+  const mir::ExprId count_id = proc_scope.AddExpr(
+      mir::MakeInt32Literal(
+          module.Unit().builtins.int32,
+          static_cast<std::int64_t>(unfolded->count)));
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinMethodCallee{
+                      .method =
+                          mir::ArrayMethodInfo{
+                              .kind = mir::ArrayMethodKind::kSlice}},
+              .arguments = {base_id, unfolded->offset_expr, count_id}},
+      .type = result_type};
+}
+
+auto LowerHirMemberAccessExprStructuralLhs(
+    const StructuralScopeLowerer& scope, WalkFrame frame,
+    const hir::MemberAccessExpr& sel, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
+  const auto& module = scope.Module();
+  const auto& hir_scope = scope.HirScope();
+  auto& proc_scope = *frame.current_procedural_scope;
+  const auto& base_hir_expr = hir_scope.GetExpr(sel.base_value);
+  const auto& base_hir_type = module.Hir().GetType(base_hir_expr.type);
+  const auto& fields = GetAggregateFields(base_hir_type);
+  if (sel.field_index >= fields.size()) {
+    throw InternalError(
+        "LowerHirMemberAccessExprStructuralLhs: field_index out of range");
+  }
+  const auto& field = fields[sel.field_index];
+  auto base_or = scope.LowerLhsExpr(base_hir_expr, frame);
+  if (!base_or) return std::unexpected(std::move(base_or.error()));
+  const mir::ExprId base_id = proc_scope.AddExpr(*std::move(base_or));
+  const auto offset_id = proc_scope.AddExpr(
+      mir::MakeInt32Literal(
+          module.Unit().builtins.int32,
+          static_cast<std::int64_t>(field.bit_offset)));
+  const auto count_id = proc_scope.AddExpr(
+      mir::MakeInt32Literal(
+          module.Unit().builtins.int32,
+          static_cast<std::int64_t>(field.bit_width)));
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinMethodCallee{
+                      .method =
+                          mir::ArrayMethodInfo{
+                              .kind = mir::ArrayMethodKind::kSlice}},
+              .arguments = {base_id, offset_id, count_id}},
       .type = result_type};
 }
 

--- a/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
@@ -16,11 +16,13 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/copy_out_desugar.hpp"
+#include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -312,15 +314,18 @@ auto LowerFileIOSystemSubroutineCallStmt(
 
   std::optional<mir::ExprId> assign_target_id = std::nullopt;
   if (assign_target.has_value()) {
-    auto lhs_or = process.LowerExpr(
+    auto lhs_or = process.LowerLhsExpr(
         hir_proc.exprs.at(assign_target->value), wrapper_frame);
     if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
     assign_target_id = wrapper.AddExpr(*std::move(lhs_or));
   }
 
+  const mir::ExprId services_id =
+      wrapper.AddExpr(BuildServicesCallExpr(process, wrapper_frame));
   return BuildCopyOutBlock(
-      frame, std::move(wrapper), std::move(label), result_type,
-      std::move(call_expr), false, assign_target_id, slots);
+      process.Module().Unit(), services_id, frame, std::move(wrapper),
+      std::move(label), result_type, std::move(call_expr), false,
+      assign_target_id, slots);
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
@@ -15,8 +15,10 @@
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/capture_sink.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
+#include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
+#include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/closure.hpp"
 #include "lyra/mir/compilation_unit.hpp"
@@ -327,17 +329,20 @@ auto LowerScanSystemSubroutineCall(
     mir::ProceduralScope then_body;
     const WalkFrame then_frame =
         closure_frame.WithProceduralScope(&then_body).Deeper();
-    auto lvalue_or = process.LowerExpr(
+    auto lvalue_or = process.LowerLhsExpr(
         hir_proc.exprs.at(call.arguments[k + 2]->value), then_frame);
     if (!lvalue_or) return std::unexpected(std::move(lvalue_or.error()));
     const mir::ExprId lvalue_id = then_body.AddExpr(*std::move(lvalue_or));
     const mir::ExprId temp_read_id = then_body.AddExpr(
         mir::MakeProceduralVarRefExpr(
             mir::ProceduralHops{.value = 1}, temp_ids[k], metas[k].mir_type));
-    const mir::ExprId assign_id = then_body.AddExpr(
-        mir::Expr{
-            .data = mir::AssignExpr{.target = lvalue_id, .value = temp_read_id},
-            .type = metas[k].mir_type});
+    const mir::ExprId services_id_then =
+        then_body.AddExpr(BuildServicesCallExpr(process, then_frame));
+    const mir::Expr assign_expr = BuildObservableAssignExpr(
+        process.Module().Unit(), then_body, services_id_then, lvalue_id,
+        temp_read_id, std::nullopt, metas[k].mir_type,
+        process.Module().Unit().builtins.void_type);
+    const mir::ExprId assign_id = then_body.AddExpr(assign_expr);
     then_body.AppendStmt(mir::ExprStmt{.expr = assign_id});
 
     body.AppendIfThen(cond_id, std::move(then_body));

--- a/src/lyra/lowering/hir_to_mir/expression/system/sformat.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/sformat.cpp
@@ -14,8 +14,10 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_body.hpp"
+#include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/print_items.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/runtime_sformat.hpp"
 #include "lyra/mir/stmt.hpp"
@@ -101,9 +103,10 @@ auto LowerSFormatSystemSubroutineCallStmt(
         "elided");
   }
   auto out_or =
-      process.LowerExpr(hir_proc.exprs.at(call.arguments[0]->value), frame);
+      process.LowerLhsExpr(hir_proc.exprs.at(call.arguments[0]->value), frame);
   if (!out_or) return std::unexpected(std::move(out_or.error()));
-  const mir::TypeId out_type = out_or->type;
+  const mir::TypeId out_type = process.Module().TranslateType(
+      hir_proc.exprs.at(call.arguments[0]->value).type);
   if (process.Module().Unit().GetType(out_type).Kind() !=
       mir::TypeKind::kString) {
     return RejectNonStringOutput(name, span);
@@ -114,10 +117,12 @@ auto LowerSFormatSystemSubroutineCallStmt(
   if (!call_expr_or) return std::unexpected(std::move(call_expr_or.error()));
   const mir::ExprId call_id = proc_scope.AddExpr(*std::move(call_expr_or));
 
-  const mir::ExprId assign_id = proc_scope.AddExpr(
-      mir::Expr{
-          .data = mir::AssignExpr{.target = out_id, .value = call_id},
-          .type = out_type});
+  const mir::ExprId services_id =
+      proc_scope.AddExpr(BuildServicesCallExpr(process, frame));
+  const mir::Expr assign_expr = BuildObservableAssignExpr(
+      process.Module().Unit(), proc_scope, services_id, out_id, call_id,
+      std::nullopt, out_type, process.Module().Unit().builtins.void_type);
+  const mir::ExprId assign_id = proc_scope.AddExpr(assign_expr);
 
   return mir::Stmt{
       .label = std::move(label), .data = mir::ExprStmt{.expr = assign_id}};

--- a/src/lyra/lowering/hir_to_mir/lhs_observable.cpp
+++ b/src/lyra/lowering/hir_to_mir/lhs_observable.cpp
@@ -1,0 +1,91 @@
+#include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
+
+#include <variant>
+
+#include "lyra/mir/builtin_method.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/type.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+namespace {
+
+// Yields the container access chain's base argument if `expr` is one of the
+// `kElementAt` / `kSlice` / `kRead` / `kElementRef` CallExprs HIR-to-MIR
+// emits for an indexed / sliced LHS path; null otherwise. The first argument
+// of those calls is by construction the container being accessed.
+auto AsContainerAccessBase(const mir::Expr& expr) -> const mir::ExprId* {
+  const auto* call = std::get_if<mir::CallExpr>(&expr.data);
+  if (call == nullptr) return nullptr;
+  const auto* callee = std::get_if<mir::BuiltinMethodCallee>(&call->callee);
+  if (callee == nullptr) return nullptr;
+  if (!mir::IsContainerAccessCall(*callee)) return nullptr;
+  if (call->arguments.empty()) return nullptr;
+  return &call->arguments.front();
+}
+
+}  // namespace
+
+auto FindLhsRootId(const mir::ProceduralScope& scope, mir::ExprId lhs_id)
+    -> mir::ExprId {
+  while (true) {
+    const auto& expr = scope.GetExpr(lhs_id);
+    if (const auto* base = AsContainerAccessBase(expr)) {
+      lhs_id = *base;
+      continue;
+    }
+    return lhs_id;
+  }
+}
+
+auto RewriteLhsRootWithMutate(
+    const mir::CompilationUnit& unit, mir::ProceduralScope& scope,
+    mir::ExprId lhs_id, mir::ExprId services_id) -> mir::ExprId {
+  const auto& expr = scope.GetExpr(lhs_id);
+  if (AsContainerAccessBase(expr) != nullptr) {
+    auto rewritten_call = std::get<mir::CallExpr>(expr.data);
+    rewritten_call.arguments.front() = RewriteLhsRootWithMutate(
+        unit, scope, rewritten_call.arguments.front(), services_id);
+    return scope.AddExpr(
+        mir::Expr{.data = std::move(rewritten_call), .type = expr.type});
+  }
+  const mir::TypeId value_type =
+      mir::ObservableInnerValueType(unit.GetType(expr.type));
+  const mir::ExprId mutate_id = scope.AddExpr(
+      mir::MakeObservableMutateCallExpr(lhs_id, services_id, value_type));
+  return scope.AddExpr(
+      mir::Expr{
+          .data = mir::DerefExpr{.pointer = mutate_id}, .type = value_type});
+}
+
+auto BuildObservableAssignExpr(
+    const mir::CompilationUnit& unit, mir::ProceduralScope& scope,
+    mir::ExprId services_id, mir::ExprId lhs_id, mir::ExprId rhs_id,
+    std::optional<mir::BinaryOp> compound_op, mir::TypeId result_type,
+    mir::TypeId void_type) -> mir::Expr {
+  const mir::ExprId root_id = FindLhsRootId(scope, lhs_id);
+  const bool root_is_cell =
+      mir::IsObservableCellType(unit.GetType(scope.GetExpr(root_id).type));
+  if (!root_is_cell) {
+    return mir::Expr{
+        .data =
+            mir::AssignExpr{
+                .target = lhs_id, .compound_op = compound_op, .value = rhs_id},
+        .type = result_type};
+  }
+  const bool whole_var_simple_write =
+      (root_id == lhs_id) && !compound_op.has_value();
+  if (whole_var_simple_write) {
+    return mir::MakeObservableSetCallExpr(
+        lhs_id, services_id, rhs_id, void_type);
+  }
+  const mir::ExprId rewritten =
+      RewriteLhsRootWithMutate(unit, scope, lhs_id, services_id);
+  return mir::Expr{
+      .data =
+          mir::AssignExpr{
+              .target = rewritten, .compound_op = compound_op, .value = rhs_id},
+      .type = result_type};
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -28,74 +28,133 @@
 #include "lyra/lowering/hir_to_mir/statement/loops.hpp"
 #include "lyra/lowering/hir_to_mir/statement/timing.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
+#include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/process.hpp"
 #include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
+
+namespace {
+
+auto DispatchLowerExpr(
+    ProcessLowerer& process, const hir::Expr& expr, WalkFrame frame,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  return std::visit(
+      Overloaded{
+          [&](const hir::PrimaryExpr& p) -> diag::Result<mir::Expr> {
+            return LowerHirPrimaryExprProc(process, frame, p.data, result_type);
+          },
+          [&](const hir::UnaryExpr& u) -> diag::Result<mir::Expr> {
+            return LowerHirUnaryExprProc(process, frame, u, result_type);
+          },
+          [&](const hir::BinaryExpr& b) -> diag::Result<mir::Expr> {
+            return LowerHirBinaryExprProc(process, frame, b, result_type);
+          },
+          [&](const hir::ConditionalExpr& c) -> diag::Result<mir::Expr> {
+            return LowerHirConditionalExprProc(process, frame, c, result_type);
+          },
+          [&](const hir::AssignExpr& a) -> diag::Result<mir::Expr> {
+            return LowerHirAssignExprProc(
+                process, frame, a, expr.span, result_type);
+          },
+          [&](const hir::IncDecExpr& inc) -> diag::Result<mir::Expr> {
+            return LowerHirIncDecExprProc(process, frame, inc, result_type);
+          },
+          [&](const hir::ConversionExpr& cv) -> diag::Result<mir::Expr> {
+            return LowerHirConversionExprProc(process, frame, cv, result_type);
+          },
+          [&](const hir::CallExpr& c) -> diag::Result<mir::Expr> {
+            return LowerHirCallExprProc(
+                process, frame, c, expr.span, result_type);
+          },
+          [&](const hir::InsideExpr& in) -> diag::Result<mir::Expr> {
+            return LowerHirInsideExprProc(process, frame, in, result_type);
+          },
+          [&](const hir::ElementSelectExpr& sel) -> diag::Result<mir::Expr> {
+            return LowerHirElementSelectExprProc(
+                process, frame, sel, result_type);
+          },
+          [&](const hir::RangeSelectExpr& sel) -> diag::Result<mir::Expr> {
+            return LowerHirRangeSelectExprProc(
+                process, frame, sel, result_type);
+          },
+          [&](const hir::MemberAccessExpr& sel) -> diag::Result<mir::Expr> {
+            return LowerHirMemberAccessExprProc(
+                process, frame, sel, result_type);
+          },
+          [&](const hir::ConcatExpr& c) -> diag::Result<mir::Expr> {
+            return LowerHirConcatExprProc(process, frame, c, result_type);
+          },
+          [&](const hir::ReplicationExpr& r) -> diag::Result<mir::Expr> {
+            return LowerHirReplicationExprProc(process, frame, r, result_type);
+          },
+          [&](const hir::AssignmentPatternExpr& a) -> diag::Result<mir::Expr> {
+            return LowerHirAssignmentPatternExprProc(
+                process, frame, a, result_type);
+          },
+          [&](const hir::AssignmentPatternReplicationExpr& a)
+              -> diag::Result<mir::Expr> {
+            return LowerHirAssignmentPatternReplicationExprProc(
+                process, frame, a, result_type);
+          },
+          [&](const hir::DynamicArrayNewExpr& n) -> diag::Result<mir::Expr> {
+            return LowerHirDynamicArrayNewExprProc(
+                process, frame, n, result_type);
+          },
+      },
+      expr.data);
+}
+
+}  // namespace
 
 auto ProcessLowerer::LowerExpr(const hir::Expr& expr, WalkFrame frame)
     -> diag::Result<mir::Expr> {
   const mir::TypeId result_type = module_->TranslateType(expr.type);
+  auto raw_or = DispatchLowerExpr(*this, expr, frame, result_type);
+  if (!raw_or) return raw_or;
+  if (mir::IsObservableCellType(module_->Unit().GetType(raw_or->type))) {
+    const mir::ExprId cell_id =
+        frame.current_procedural_scope->AddExpr(*std::move(raw_or));
+    return mir::MakeObservableGetCallExpr(cell_id, result_type);
+  }
+  return raw_or;
+}
+
+auto ProcessLowerer::LowerLhsExpr(const hir::Expr& expr, WalkFrame frame)
+    -> diag::Result<mir::Expr> {
+  const mir::TypeId result_type = module_->TranslateType(expr.type);
+  // LHS dispatch: addressable kinds only. The leaf kinds (PrimaryExpr,
+  // ConcatExpr) reach through the standard handlers -- their `Expr.type` is
+  // already cell-typed for observable storage, exactly what the LHS chain
+  // needs. Selector kinds recurse via `LowerLhsExpr` so the base stays
+  // cell-rooted; index / range bounds remain values (lowered via `LowerExpr`).
   return std::visit(
       Overloaded{
           [&](const hir::PrimaryExpr& p) -> diag::Result<mir::Expr> {
             return LowerHirPrimaryExprProc(*this, frame, p.data, result_type);
           },
-          [&](const hir::UnaryExpr& u) -> diag::Result<mir::Expr> {
-            return LowerHirUnaryExprProc(*this, frame, u, result_type);
-          },
-          [&](const hir::BinaryExpr& b) -> diag::Result<mir::Expr> {
-            return LowerHirBinaryExprProc(*this, frame, b, result_type);
-          },
-          [&](const hir::ConditionalExpr& c) -> diag::Result<mir::Expr> {
-            return LowerHirConditionalExprProc(*this, frame, c, result_type);
-          },
-          [&](const hir::AssignExpr& a) -> diag::Result<mir::Expr> {
-            return LowerHirAssignExprProc(
-                *this, frame, a, expr.span, result_type);
-          },
-          [&](const hir::IncDecExpr& inc) -> diag::Result<mir::Expr> {
-            return LowerHirIncDecExprProc(*this, frame, inc, result_type);
-          },
-          [&](const hir::ConversionExpr& cv) -> diag::Result<mir::Expr> {
-            return LowerHirConversionExprProc(*this, frame, cv, result_type);
-          },
-          [&](const hir::CallExpr& c) -> diag::Result<mir::Expr> {
-            return LowerHirCallExprProc(
-                *this, frame, c, expr.span, result_type);
-          },
-          [&](const hir::InsideExpr& in) -> diag::Result<mir::Expr> {
-            return LowerHirInsideExprProc(*this, frame, in, result_type);
-          },
           [&](const hir::ElementSelectExpr& sel) -> diag::Result<mir::Expr> {
-            return LowerHirElementSelectExprProc(
+            return LowerHirElementSelectExprProcLhs(
                 *this, frame, sel, result_type);
           },
           [&](const hir::RangeSelectExpr& sel) -> diag::Result<mir::Expr> {
-            return LowerHirRangeSelectExprProc(*this, frame, sel, result_type);
+            return LowerHirRangeSelectExprProcLhs(
+                *this, frame, sel, result_type);
           },
           [&](const hir::MemberAccessExpr& sel) -> diag::Result<mir::Expr> {
-            return LowerHirMemberAccessExprProc(*this, frame, sel, result_type);
+            return LowerHirMemberAccessExprProcLhs(
+                *this, frame, sel, result_type);
           },
           [&](const hir::ConcatExpr& c) -> diag::Result<mir::Expr> {
             return LowerHirConcatExprProc(*this, frame, c, result_type);
           },
-          [&](const hir::ReplicationExpr& r) -> diag::Result<mir::Expr> {
-            return LowerHirReplicationExprProc(*this, frame, r, result_type);
-          },
-          [&](const hir::AssignmentPatternExpr& a) -> diag::Result<mir::Expr> {
-            return LowerHirAssignmentPatternExprProc(
-                *this, frame, a, result_type);
-          },
-          [&](const hir::AssignmentPatternReplicationExpr& a)
-              -> diag::Result<mir::Expr> {
-            return LowerHirAssignmentPatternReplicationExprProc(
-                *this, frame, a, result_type);
-          },
-          [&](const hir::DynamicArrayNewExpr& n) -> diag::Result<mir::Expr> {
-            return LowerHirDynamicArrayNewExprProc(
-                *this, frame, n, result_type);
+          [](const auto&) -> diag::Result<mir::Expr> {
+            throw InternalError(
+                "ProcessLowerer::LowerLhsExpr: non-addressable HIR expression "
+                "in LHS context (ValidateAssignableProcExpr should have "
+                "rejected it)");
           },
       },
       expr.data);

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -20,8 +20,10 @@
 #include "lyra/lowering/hir_to_mir/expression/assignment.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/file_io.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/sformat.hpp"
+#include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
+#include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/compilation_unit.hpp"
@@ -118,18 +120,23 @@ auto LowerDestructuringAssign(
     const std::uint64_t w = part_widths[i];
     offset -= w;
 
-    auto part_lhs_or = process.LowerExpr(
+    auto part_lhs_or = process.LowerLhsExpr(
         hir_proc.exprs.at(lhs_concat.operands[i].value), wrapper_frame);
     if (!part_lhs_or) {
       return std::unexpected(std::move(part_lhs_or.error()));
     }
-    const mir::TypeId part_mir_type = (*part_lhs_or).type;
+    const mir::TypeId part_mir_type = process.Module().TranslateType(
+        hir_proc.exprs.at(lhs_concat.operands[i].value).type);
     const mir::ExprId part_lhs_id = wrapper.AddExpr(*std::move(part_lhs_or));
 
     const mir::ExprId offset_id = wrapper.AddExpr(
         mir::MakeInt32Literal(
             process.Module().Unit().builtins.int32,
             static_cast<std::int64_t>(offset)));
+    const mir::ExprId count_id = wrapper.AddExpr(
+        mir::MakeInt32Literal(
+            process.Module().Unit().builtins.int32,
+            static_cast<std::int64_t>(w)));
     const mir::ExprId temp_ref =
         wrapper.AddExpr(mir::Expr{.data = snapshot_ref, .type = temp_type});
     const mir::TypeId slice_type = process.Module().Unit().AddType(
@@ -139,13 +146,27 @@ auto LowerDestructuringAssign(
             .dims = {mir::PackedRange{
                 .left = static_cast<std::int64_t>(w) - 1, .right = 0}},
             .form = mir::PackedArrayForm::kExplicit}});
+    const mir::ExprId raw_slice_id = wrapper.AddExpr(
+        mir::Expr{
+            .data =
+                mir::CallExpr{
+                    .callee =
+                        mir::BuiltinMethodCallee{
+                            .method =
+                                mir::ArrayMethodInfo{
+                                    .kind = mir::ArrayMethodKind::kSlice}},
+                    .arguments = {temp_ref, offset_id, count_id}},
+            .type = slice_type});
     const mir::ExprId slice_id = wrapper.AddExpr(
         mir::Expr{
             .data =
-                mir::RangeSelectExpr{
-                    .base_value = temp_ref,
-                    .offset_expr = offset_id,
-                    .count = static_cast<std::uint32_t>(w)},
+                mir::CallExpr{
+                    .callee =
+                        mir::BuiltinMethodCallee{
+                            .method =
+                                mir::ArrayMethodInfo{
+                                    .kind = mir::ArrayMethodKind::kToOwned}},
+                    .arguments = {raw_slice_id}},
             .type = slice_type});
     mir::ExprId rhs_for_part = slice_id;
     if (part_mir_type != slice_type) {
@@ -160,11 +181,13 @@ auto LowerDestructuringAssign(
 
     mir::ExprId per_part_expr_id{};
     if (assign.kind == hir::AssignKind::kBlocking) {
-      per_part_expr_id = wrapper.AddExpr(
-          mir::Expr{
-              .data =
-                  mir::AssignExpr{.target = part_lhs_id, .value = rhs_for_part},
-              .type = part_mir_type});
+      const mir::ExprId services_id =
+          wrapper.AddExpr(BuildServicesCallExpr(process, wrapper_frame));
+      const mir::Expr part_assign_expr = BuildObservableAssignExpr(
+          process.Module().Unit(), wrapper, services_id, part_lhs_id,
+          rhs_for_part, std::nullopt, part_mir_type,
+          process.Module().Unit().builtins.void_type);
+      per_part_expr_id = wrapper.AddExpr(part_assign_expr);
     } else {
       mir::Expr closure_expr = BuildNbaSubmitClosureExpr(
           process.Module(), wrapper_frame, part_lhs_id, rhs_for_part,
@@ -250,6 +273,27 @@ auto LowerSubroutineCallWithWritebacks(
     const hir::Expr& hir_arg = hir_proc.exprs.at(call.arguments[i]->value);
 
     if (!hir::RequiresWriteback(dir)) {
+      // A ref / const-ref formal aliases the actual's cell -- pass the cell
+      // (or a `ScopedMutation` for selector / range chains on an observable
+      // cell) so the body's `Ref<T>` binds the underlying storage.
+      const bool is_ref = dir == hir::ParamDirection::kRef ||
+                          dir == hir::ParamDirection::kConstRef;
+      if (is_ref) {
+        auto arg_or = process.LowerLhsExpr(hir_arg, wrapper_frame);
+        if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+        mir::ExprId actual_id = wrapper.AddExpr(*std::move(arg_or));
+        const mir::ExprId root_id = FindLhsRootId(wrapper, actual_id);
+        const bool root_is_cell = mir::IsObservableCellType(
+            process.Module().Unit().GetType(wrapper.GetExpr(root_id).type));
+        if (root_is_cell && root_id != actual_id) {
+          const mir::ExprId services_id =
+              wrapper.AddExpr(BuildServicesCallExpr(process, wrapper_frame));
+          actual_id = RewriteLhsRootWithMutate(
+              process.Module().Unit(), wrapper, actual_id, services_id);
+        }
+        call_args.push_back(actual_id);
+        continue;
+      }
       auto arg_or = process.LowerExpr(hir_arg, wrapper_frame);
       if (!arg_or) return std::unexpected(std::move(arg_or.error()));
       call_args.push_back(wrapper.AddExpr(*std::move(arg_or)));
@@ -258,15 +302,21 @@ auto LowerSubroutineCallWithWritebacks(
 
     const mir::TypeId formal_type = process.Module().TranslateType(
         decl.body.GetProceduralVar(decl.params[i].var).type);
-    auto actual_or = process.LowerExpr(hir_arg, wrapper_frame);
-    if (!actual_or) return std::unexpected(std::move(actual_or.error()));
-    const mir::ExprId actual_id = wrapper.AddExpr(*std::move(actual_or));
+    // The actual is the writeback target: lower it as a cell-typed lvalue
+    // so an observable destination's writeback fires `Var<T>::Set`.
+    auto target_or = process.LowerLhsExpr(hir_arg, wrapper_frame);
+    if (!target_or) return std::unexpected(std::move(target_or.error()));
+    const mir::ExprId actual_id = wrapper.AddExpr(*std::move(target_or));
 
-    const mir::ExprId init =
-        dir == hir::ParamDirection::kInOut
-            ? actual_id
-            : wrapper.AddExpr(BuildDefaultValueExpr(
-                  process.Module(), wrapper_frame, formal_type));
+    mir::ExprId init{};
+    if (dir == hir::ParamDirection::kInOut) {
+      auto value_or = process.LowerExpr(hir_arg, wrapper_frame);
+      if (!value_or) return std::unexpected(std::move(value_or.error()));
+      init = wrapper.AddExpr(*std::move(value_or));
+    } else {
+      init = wrapper.AddExpr(
+          BuildDefaultValueExpr(process.Module(), wrapper_frame, formal_type));
+    }
     const mir::ProceduralVarRef temp = wrapper.AppendLocal(
         mir::ProceduralVarDecl{
             .name = "_lyra_arg" + std::to_string(i), .type = formal_type},
@@ -287,16 +337,18 @@ auto LowerSubroutineCallWithWritebacks(
 
   std::optional<mir::ExprId> assign_target_id = std::nullopt;
   if (assign_target.has_value()) {
-    auto lhs_or = process.LowerExpr(
+    auto lhs_or = process.LowerLhsExpr(
         hir_proc.exprs.at(assign_target->value), wrapper_frame);
     if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
     assign_target_id = wrapper.AddExpr(*std::move(lhs_or));
   }
 
+  const mir::ExprId services_id =
+      wrapper.AddExpr(BuildServicesCallExpr(process, wrapper_frame));
   return BuildCopyOutBlock(
-      frame, std::move(wrapper), std::move(label), result_type,
-      std::move(call_expr), decl.kind == hir::SubroutineKind::kTask,
-      assign_target_id, writebacks);
+      process.Module().Unit(), services_id, frame, std::move(wrapper),
+      std::move(label), result_type, std::move(call_expr),
+      decl.kind == hir::SubroutineKind::kTask, assign_target_id, writebacks);
 }
 
 }  // namespace

--- a/src/lyra/lowering/hir_to_mir/statement/flow.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/flow.cpp
@@ -10,6 +10,8 @@
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
+#include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
+#include "lyra/lowering/hir_to_mir/procedural_depth.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
@@ -70,8 +72,17 @@ auto LowerStaticVarDeclStmt(
           mir::StructuralVarRef{
               .hops = mir::StructuralHops{.value = 0}, .var = static_var},
           type));
-  const mir::ExprId assign =
-      ctor_scope.AddExpr(mir::MakeAssignExpr(target, init_value, type));
+  // A static-lifetime local lives as a structural var on the owner; if its
+  // declared type is an observable cell wrapper the init must route through
+  // `Var<T>::Set` so subscribers fire on its initial value (LRM 13.3.1 +
+  // `docs/decisions/value-type-concepts.md`).
+  const mir::ExprId services_id = ctor_scope.AddExpr(
+      mir::MakeServicesCallExpr(
+          ctor_self_read, process.Module().Unit().builtins.services));
+  const mir::Expr assign_expr = BuildObservableAssignExpr(
+      process.Module().Unit(), ctor_scope, services_id, target, init_value,
+      std::nullopt, type, process.Module().Unit().builtins.void_type);
+  const mir::ExprId assign = ctor_scope.AddExpr(assign_expr);
   ctor_scope.AppendStmt(
       mir::Stmt{.label = std::nullopt, .data = mir::ExprStmt{.expr = assign}});
   return mir::Stmt{.label = std::move(label), .data = mir::EmptyStmt{}};

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -24,6 +24,7 @@
 #include "lyra/lowering/hir_to_mir/expression/operators.hpp"
 #include "lyra/lowering/hir_to_mir/expression/references.hpp"
 #include "lyra/lowering/hir_to_mir/expression/selects.hpp"
+#include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
@@ -765,8 +766,9 @@ auto StructuralScopeLowerer::Run(
   const mir::ProceduralVarId self_id = ctor_scope.AddProceduralVar(
       mir::ProceduralVarDecl{
           .name = "self", .type = module.Unit().builtins.self_pointer});
+  ScopeChainNode outer_scope_link{};
   const WalkFrame scope_frame =
-      frame.WithStructuralScope(&mir_scope)
+      frame.WithStructuralScope(&mir_scope, outer_scope_link)
           .WithProceduralScope(&ctor_scope)
           .WithSelfBinding(self_id, frame.procedural_depth);
   const mir::TypeId void_type = module.Unit().AddType(mir::VoidType{});
@@ -816,8 +818,17 @@ auto StructuralScopeLowerer::Run(
               self_read(),
               mir::StructuralVarRef{.hops = {.value = 0}, .var = mir_id},
               mir_field_type));
-      const mir::ExprId assign_id = ctor_scope.AddExpr(
-          mir::MakeAssignExpr(init_target, value_id, mir_value_type));
+      // An observable cell init routes through `Var<T>::Set` so the field's
+      // engine-side change-tracking sees the initial value
+      // (`docs/decisions/value-type-concepts.md`). Plain fields use a regular
+      // `AssignExpr`.
+      const mir::ExprId services_id = ctor_scope.AddExpr(
+          mir::MakeServicesCallExpr(
+              self_read(), module.Unit().builtins.services));
+      const mir::Expr init_expr = BuildObservableAssignExpr(
+          module.Unit(), ctor_scope, services_id, init_target, value_id,
+          std::nullopt, mir_value_type, module.Unit().builtins.void_type);
+      const mir::ExprId assign_id = ctor_scope.AddExpr(init_expr);
       ctor_scope.AppendStmt(
           mir::Stmt{
               .label = std::nullopt, .data = mir::ExprStmt{.expr = assign_id}});
@@ -927,7 +938,7 @@ auto StructuralScopeLowerer::Run(
 auto StructuralScopeLowerer::LowerExpr(
     const hir::Expr& expr, WalkFrame frame) const -> diag::Result<mir::Expr> {
   const mir::TypeId result_type = module_->TranslateType(expr.type);
-  return std::visit(
+  auto raw_or = std::visit(
       Overloaded{
           [&](const hir::PrimaryExpr& p) -> diag::Result<mir::Expr> {
             return LowerHirPrimaryExprStructural(
@@ -1007,6 +1018,49 @@ auto StructuralScopeLowerer::LowerExpr(
                 "dynamic-array new[] is not allowed in constructor "
                 "expressions; LRM 7.5.1 restricts it to blocking assignments",
                 diag::UnsupportedCategory::kFeature);
+          },
+      },
+      expr.data);
+  if (!raw_or) return raw_or;
+  // Same as ProcessLowerer::LowerExpr: unwrap an observable cell leaf with
+  // an explicit `Get` call so the surrounding structural expression sees
+  // the value (e.g. a continuous assign whose RHS reads a signal).
+  if (mir::IsObservableCellType(module_->Unit().GetType(raw_or->type))) {
+    const mir::ExprId cell_id =
+        frame.current_procedural_scope->AddExpr(*std::move(raw_or));
+    return mir::MakeObservableGetCallExpr(cell_id, result_type);
+  }
+  return raw_or;
+}
+
+auto StructuralScopeLowerer::LowerLhsExpr(
+    const hir::Expr& expr, WalkFrame frame) const -> diag::Result<mir::Expr> {
+  const mir::TypeId result_type = module_->TranslateType(expr.type);
+  return std::visit(
+      Overloaded{
+          [&](const hir::PrimaryExpr& p) -> diag::Result<mir::Expr> {
+            return LowerHirPrimaryExprStructural(
+                *this, frame, p.data, result_type);
+          },
+          [&](const hir::ElementSelectExpr& s) -> diag::Result<mir::Expr> {
+            return LowerHirElementSelectExprStructuralLhs(
+                *this, frame, s, result_type);
+          },
+          [&](const hir::RangeSelectExpr& s) -> diag::Result<mir::Expr> {
+            return LowerHirRangeSelectExprStructuralLhs(
+                *this, frame, s, result_type);
+          },
+          [&](const hir::MemberAccessExpr& s) -> diag::Result<mir::Expr> {
+            return LowerHirMemberAccessExprStructuralLhs(
+                *this, frame, s, result_type);
+          },
+          [&](const hir::ConcatExpr& c) -> diag::Result<mir::Expr> {
+            return LowerHirConcatExprStructural(*this, frame, c, result_type);
+          },
+          [](const auto&) -> diag::Result<mir::Expr> {
+            throw InternalError(
+                "StructuralScopeLowerer::LowerLhsExpr: non-addressable HIR "
+                "expression in LHS context");
           },
       },
       expr.data);

--- a/src/lyra/mir/builtin_method.cpp
+++ b/src/lyra/mir/builtin_method.cpp
@@ -1,0 +1,81 @@
+#include "lyra/mir/builtin_method.hpp"
+
+#include <variant>
+
+#include "lyra/base/overloaded.hpp"
+
+namespace lyra::mir {
+
+auto IsMutatingBuiltinMethod(const BuiltinMethodCallee& callee) -> bool {
+  return std::visit(
+      Overloaded{
+          [](const EnumMethodInfo&) { return false; },
+          [](const StringMethodInfo& m) {
+            // LRM 6.16: Putc and the int/real-to-string family overwrite the
+            // receiver string.
+            return m.kind == StringMethodKind::kPutc ||
+                   m.kind == StringMethodKind::kItoa ||
+                   m.kind == StringMethodKind::kHextoa ||
+                   m.kind == StringMethodKind::kOcttoa ||
+                   m.kind == StringMethodKind::kBintoa ||
+                   m.kind == StringMethodKind::kRealtoa;
+          },
+          // LRM 15.5 Trigger / Triggered reach into RuntimeServices through an
+          // explicit services argument and do not mutate the named event slot
+          // through the wrapper API.
+          [](const EventMethodInfo&) { return false; },
+          [](const ArrayMethodInfo& m) {
+            // Container-access (`kElementAt`, `kSlice`) and ref-to-value
+            // (`kToOwned`) are non-mutating themselves -- they return a
+            // borrowed view or an owning value; whether the chain ends in a
+            // write is determined by what consumes the result, not by these
+            // methods.
+            return m.kind == ArrayMethodKind::kDelete ||
+                   m.kind == ArrayMethodKind::kReverse ||
+                   m.kind == ArrayMethodKind::kSort ||
+                   m.kind == ArrayMethodKind::kRsort;
+          },
+          [](const QueueMethodInfo& m) {
+            return m.kind != QueueMethodKind::kSize;
+          },
+          [](const AssociativeMethodInfo& m) {
+            // `kRead` returns a borrowed view; `kElementRef` allocates on
+            // miss but the mutation pipeline is closed by an outer
+            // `AssignExpr`, so they read as non-mutating receivers from the
+            // observable-mutate / LHS-render dispatch's point of view.
+            return m.kind == AssociativeMethodKind::kDelete;
+          },
+          [](const ValueMethodInfo&) { return false; },
+          [](const IteratorMethodInfo&) { return false; },
+          [](const ScopeMethodInfo&) { return false; },
+          // Get / Set / Mutate are the observable cell API itself -- their
+          // mutating nature is encoded by which kind is invoked, not by a
+          // surrounding wrapper. The wrap rule that drives this trait does
+          // not recurse into them.
+          [](const ObservableMethodInfo&) { return false; },
+      },
+      callee.method);
+}
+
+auto IsContainerAccessCall(const BuiltinMethodCallee& callee) -> bool {
+  return std::visit(
+      Overloaded{
+          [](const ArrayMethodInfo& m) {
+            return m.kind == ArrayMethodKind::kElementAt ||
+                   m.kind == ArrayMethodKind::kSlice;
+          },
+          [](const AssociativeMethodInfo& m) {
+            return m.kind == AssociativeMethodKind::kRead ||
+                   m.kind == AssociativeMethodKind::kElementRef;
+          },
+          [](const QueueMethodInfo& m) {
+            return m.kind == QueueMethodKind::kElementAt ||
+                   m.kind == QueueMethodKind::kWriteRef ||
+                   m.kind == QueueMethodKind::kSlice;
+          },
+          [](const auto&) { return false; },
+      },
+      callee.method);
+}
+
+}  // namespace lyra::mir

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -420,6 +420,11 @@ class MirDumper {
                             "ScopeMethodInfo[kind={}]",
                             static_cast<int>(m.kind));
                       },
+                      [](const ObservableMethodInfo& m) -> std::string {
+                        return std::format(
+                            "ObservableMethodInfo[kind={}]",
+                            static_cast<int>(m.kind));
+                      },
                   },
                   b.method);
             },
@@ -589,16 +594,6 @@ class MirDumper {
               return std::format(
                   "ClosureExpr captures={} params={}", cl.captures.size(),
                   cl.params.size());
-            },
-            [](const ElementSelectExpr& sel) -> std::string {
-              return std::format(
-                  "ElementSelectExpr base=Expr[{}] index=Expr[{}]",
-                  sel.base_value.value, sel.index.value);
-            },
-            [](const RangeSelectExpr& sel) -> std::string {
-              return std::format(
-                  "RangeSelectExpr base=Expr[{}] offset=Expr[{}] count={}",
-                  sel.base_value.value, sel.offset_expr.value, sel.count);
             },
             [](const ConcatExpr& c) -> std::string {
               std::string operands;

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -138,6 +138,22 @@ auto AsUniquePointee(const CompilationUnit& unit, TypeId type)
 
 }  // namespace
 
+auto IsObservableCellType(const Type& ty) -> bool {
+  return std::holds_alternative<ObservableType>(ty.data) ||
+         std::holds_alternative<ExternalRefType>(ty.data);
+}
+
+auto ObservableInnerValueType(const Type& ty) -> TypeId {
+  if (const auto* ob = std::get_if<ObservableType>(&ty.data)) {
+    return ob->value;
+  }
+  if (const auto* er = std::get_if<ExternalRefType>(&ty.data)) {
+    return er->element;
+  }
+  throw InternalError(
+      "ObservableInnerValueType: type is not an observable cell wrapper");
+}
+
 auto GetChildScope(const CompilationUnit& unit, TypeId type)
     -> std::optional<ChildScope> {
   TypeId leaf = type;

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -557,7 +557,7 @@ auto PackedArray::ConvertFrom(
     const PackedArrayRef& src, std::uint64_t dst_bit_width, bool dst_is_signed,
     bool dst_is_four_state) -> PackedArray {
   return ConvertFrom(
-      src.Clone(), dst_bit_width, dst_is_signed, dst_is_four_state);
+      src.ToOwned(), dst_bit_width, dst_is_signed, dst_is_four_state);
 }
 
 auto PackedArray::ConvertFrom(
@@ -1423,7 +1423,7 @@ PackedArrayRef::PackedArrayRef(
       dims_(std::move(dims)) {
 }
 
-auto PackedArrayRef::Clone() const -> PackedArray {
+auto PackedArrayRef::ToOwned() const -> PackedArray {
   return std::as_const(*root_).ExtractBits(bit_offset_, bit_width_);
 }
 


### PR DESCRIPTION
## Summary

Refactor HIR-to-MIR so every semantic decision the cpp backend used to re-derive at render time is stated explicitly in MIR. Element/range/packed-struct-field access lower to `Call(ArrayMethod{kElementAt|kSlice})` / `Call(AssociativeMethod{kRead|kElementRef})` / `Call(QueueMethod{kElementAt|kWriteRef|kSlice})`, retiring `mir::ElementSelectExpr` and `mir::RangeSelectExpr`. Observable read/write/mutate become explicit `Call(ObservableMethod{kGet|kSet|kMutate})`. Signed packed-struct field access carries an honest unsigned slice plus an explicit `ConversionExpr` re-tag instead of letting render synthesise `PackedArray::ConvertFrom`. The render-side `RenderMethodReceiver` mutates dispatch and the four `*MethodMutatesReceiver` predicates retire; receivers render through plain `RenderExpr`. Runtime `Clone()` is renamed to `ToOwned()` across `PackedArray` / `Unpacked` / `Queue` / `DynamicArray` so the chain end mirrors Rust's `ToOwned` trait (borrowed view -> owning value).

## Design

The driving rule is `mir.md` invariant 10: every semantic fact a backend reads must be explicit in the MIR node, not inferred from surrounding context. Three classes of render-time inference were closed here.

Selector lowering. A read of `arr[i]` / `arr[hi:lo]` / `w.field` was a node kind (`ElementSelectExpr` / `RangeSelectExpr`) whose emit shape (read vs write surface, owning vs borrowed result) was decided by `RenderMethodReceiver` / `ProducesPackedArrayRef` / `RenderRangeSliceSuffix` at render time. After this PR each access is a `CallExpr` against a per-container method enum (`kElementAt` / `kSlice` / `kRead` / `kElementRef` / `kWriteRef`); the LHS-vs-read distinction is baked into the callee picked at lowering, and a borrowed `PackedArrayRef` chain is materialised by an explicit `Call(kToOwned)` wrap (Rust's `ToOwned` semantics). The render emits the call mechanically with no inspection.

Observable storage. Reading or writing an observable cell was an implicit operation the backend translated into `Var<T>::Get` / `Set` / `Mutate` based on `IsObservableScalarType` predicates spread across render. HIR-to-MIR now emits explicit `Call(ObservableMethod{kGet|kSet|kMutate})` against the `MemberAccess` reaching the cell, threading `Services()` as a real argument; the cpp render is a per-kind member-name dispatch with no inference. The `lhs_observable.hpp` helper centralises the LHS-root walk that rewrites a cell-rooted chain into `Deref(Call(kMutate, ...))` so a partial write enters a `ScopedMutation` once.

Signed slice re-interpretation. The runtime `Slice` returns unsigned bits (LRM 7.4.1 part-select), but a signed packed-struct field's MIR result type is signed (LRM 7.2.1 field-typed access). The previous backend papered over the mismatch with a synthesised `PackedArray::ConvertFrom`. HIR-to-MIR now types the slice itself as unsigned (matching the runtime contract) and wraps it with an explicit `ConversionExpr` to the declared signed type, so every backend sees the sign reinterpret as a real node.

Follow-ups land as `R17b` (kSlice count projection still inspects an `IntegerLiteral`), and `C5` in `datatypes.md` tracks observable storage for module-scope `real` / `shortreal` / `realtime` signals, which is blocked on first-class runtime support for the floating-point family.

## Testing

`bazel test //... --test_output=errors` plus all four `tools/policy/check_*.py` gates.