### PR TITLE
Support the LRM 7.12.5 array map projection

### DIFF
--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -28,6 +28,10 @@ follow once dynamic array's storage and runtime conventions are settled and prov
 | DA6a | Done: method dispatch + no-`with` subset.                               |
 | DA6b | Done: `with` clause + iterator on sort / rsort / reduction methods.     |
 | DA6c | Done: locator family (find\*, min, max, unique\*).                      |
+| DA6d | Done: `map` projection (LRM 7.12.5) on the sequence containers.         |
+| DA6e | Open: `shuffle` (LRM 7.12.2); needs a seeded simulation RNG.            |
+| DA6f | Open: two-name iterator / index argument form (LRM 7.12.4).             |
+| DA6g | Open: `real` / `shortreal` / `string` as an unpacked-array element.     |
 | DA7  | Done: invalid-index handling.                                           |
 | Q1   | Done: type, element read/write, native methods, default, case-equality. |
 | Q2   | Done: operator surface (`$`, slice, concat, equality, bound, append).   |
@@ -109,8 +113,32 @@ The numeric IDs are stable references and do not imply execution order beyond DA
 
 - [x] DA6c -- The locator-family methods that return an index or element queue (`find` family,
       `min`, `max`, `unique`, `unique_index`), including the optional `with` clause for `min` /
-      `max` / `unique`. `shuffle()` (needs RNG model) and `map()` (SV2023, needs a version gate) are
-      standalone follow-ups.
+      `max` / `unique`. `shuffle()` (needs an RNG model) remains the standalone follow-up.
+
+- [x] DA6d -- The `map()` projection (LRM 7.12.5) with its mandatory `with` clause. Each element and
+      its index pass through the expression into a result whose shape and index type match the
+      receiver (dynamic array, queue, or fixed unpacked) and whose element type is the expression's
+      self-determined type, so it may differ from the source. An empty receiver yields an empty
+      result. A result element type that is itself a non-class value (`real`, `string`) lowers
+      correctly but is unusable until those types can be unpacked-array elements (see DA6g), the
+      same pre-existing gap that blocks `real` / `string` dynamic arrays generally.
+
+- [ ] DA6e -- `shuffle()` (LRM 7.12.2) on every unpacked container. Needs a seeded simulation RNG;
+      none exists yet (`$random` / `$urandom` are unimplemented), and that same RNG is the
+      foundation for those system functions. `shuffle` is the first array method that consumes
+      simulation state rather than being a pure function of its receiver, so it also introduces
+      threading that state into an array-method call.
+
+- [ ] DA6f -- The two-name iterator / index argument form of the LRM 7.12 family
+      (`a.method(item, idx) with (...)`, LRM 7.12.4), which renames the iterator and the index-query
+      method to avoid clashes with member names of the stored elements. Shared across find / sort /
+      map / reductions; none support it yet.
+
+- [ ] DA6g -- `real` / `shortreal` / `string` as an unpacked-array element (dynamic array, queue,
+      fixed unpacked). These value types do not satisfy the container-element contract -- canonical-
+      default reset and bit-identity change detection -- so `real []` / `string []` cannot be
+      declared, read, or produced as a `map()` result element today. Cross-cutting value-type gap,
+      also surfaced from `unpacked.md`; not specific to one container.
 
 - [x] DA7 -- Invalid-index handling (LRM 7.4.5). Read on an out-of-range index returns the element
       type's Table 7-1 default; write on an out-of-range index is a silent no-op; X / Z bits in the
@@ -146,8 +174,8 @@ optional right bound (`q[$:N]`).
       optional / mandatory `with` clause per LRM 7.12.1 -- 7.12.3 and the `item.index` iterator (LRM
       7.12.4). Locator methods return a queue of elements or of `int` per LRM 7.12.1; reduction
       result width follows the `with`-expression type. The semantics and the `with`-clause closure
-      are the same as for the dynamic-array receiver; `shuffle` and `map` remain the shared
-      follow-ups noted under DA6c.
+      are the same as for the dynamic-array receiver. The `map` projection (LRM 7.12.5) is shared
+      and done on a queue receiver too; `shuffle` remains the shared follow-up noted under DA6c.
 
 ## Associative Array
 
@@ -180,8 +208,9 @@ the lookup key and imposes an ordering.
 
 - [ ] A4 -- Associative-array literals with an optional default (LRM 7.9.11) and whole-array
       associative assignment (LRM 7.9.9); the wildcard `[*]`, class, and other user-defined index
-      families (LRM 7.8.1 / 7.8.3 / 7.8.5); and the locator-family methods that return an index
-      queue of the key type (LRM 7.12.1).
+      families (LRM 7.8.1 / 7.8.3 / 7.8.5); the locator-family methods that return an index queue of
+      the key type (LRM 7.12.1); and the `map` projection (LRM 7.12.5), whose result is a same-key
+      associative array.
 
 ## Cross-references
 
@@ -189,8 +218,9 @@ the lookup key and imposes an ordering.
   arrays), 7.5.2 (`size()`), 7.5.3 (`delete()`), 7.6 (Array assignments), 7.8 (Associative arrays),
   7.9 (Associative array methods), 7.10 (Queues), 7.11 (Array querying functions), 7.12 (Array
   manipulation methods), 7.12.1 (Locator), 7.12.2 (Ordering), 7.12.3 (Reduction), 7.12.4 (Iterator
-  index), 10.9 (Assignment patterns), 11.4.1 (Assignment operators), 11.4.5 (Equality operators),
-  Table 6-7 (Default initial values), Table 7-1 (Value read from a nonexistent array entry).
+  index), 7.12.5 (Mapping), 10.9 (Assignment patterns), 11.4.1 (Assignment operators), 11.4.5
+  (Equality operators), Table 6-7 (Default initial values), Table 7-1 (Value read from a nonexistent
+  array entry).
 - Archive items: `datatypes/general/*`.
 - Unblocks: `control-flow.md` C10 (foreach over dynamic / queue / associative subset).
 - Decision: `../decisions/runtime-shape-and-default-value.md` -- runtime shape is retained on

--- a/include/lyra/hir/method.hpp
+++ b/include/lyra/hir/method.hpp
@@ -46,17 +46,8 @@ enum class EventMethodKind : std::uint8_t {
   kTriggered,
 };
 
-// LRM 7.5.2 / 7.5.3 dynamic-array methods plus the LRM 7.12 array-method
-// family (ordering, reduction, and the 7.12.1 locator methods). The arms
-// are named for "array" rather than "dynamic array" because the method
-// semantics are LRM-uniform across container kinds (fixed unpacked, queue);
-// only the AST -> HIR receiver-detection block differs per container, and
-// other containers will extend the routing without renaming this enum.
-//
-// The 7.12.1 locator arms (`kFind` onward) return a queue: an element queue
-// for the value locators (`find`, `find_first`, `find_last`, `min`, `max`,
-// `unique`) and an `int` queue for the index locators (`find_index`,
-// `find_first_index`, `find_last_index`, `unique_index`).
+// LRM 7.5.2 / 7.5.3 plus the LRM 7.12 array-method family, uniform across
+// container kinds -- hence "array", not "dynamic array".
 enum class ArrayMethodKind : std::uint8_t {
   kSize,
   kDelete,
@@ -78,16 +69,13 @@ enum class ArrayMethodKind : std::uint8_t {
   kMax,
   kUnique,
   kUniqueIndex,
+  kMap,
 };
 
-// LRM 7.10.2 queue-native methods plus the compiler-internal access methods a
-// queue's operators lower to. The named methods (`size` .. `push_back`) are the
-// SV-callable family; `kElementAt` / `kWriteRef` / `kSlice` carry no SV syntax
-// but realize `q[i]` (read), `q[i] = v` (write / `q[$+1]` append), and `q[a:b]`
-// as ordinary built-in method calls -- the operators have no native C++
-// expression, so they are function calls like `size` (LRM 7.10.1). The LRM 7.12
-// ordering / reduction / locator family shared with other unpacked arrays stays
-// in `ArrayMethodKind`.
+// LRM 7.10.2 queue methods. `kElementAt` / `kWriteRef` / `kSlice` have no SV
+// method syntax -- they carry `q[i]` read, `q[i] = v` write, and `q[a:b]`
+// slice, which lower to calls because a queue has no native C++ subscript
+// (LRM 7.10.1).
 enum class QueueMethodKind : std::uint8_t {
   kSize,
   kInsert,
@@ -101,12 +89,7 @@ enum class QueueMethodKind : std::uint8_t {
   kSlice,
 };
 
-// LRM 7.9 associative-array methods. Exclusive to the associative container:
-// `num` / `size` query the entry count, `exists` tests a key, and `delete`
-// removes one entry (with index) or clears the array (without). Like the
-// queue-native family they mutate or query the receiver and have no analogue
-// in the other containers; the shared LRM 7.12 family stays in
-// `ArrayMethodKind`.
+// LRM 7.9 associative-array query and traversal methods.
 enum class AssociativeMethodKind : std::uint8_t {
   kNum,
   kSize,
@@ -118,8 +101,7 @@ enum class AssociativeMethodKind : std::uint8_t {
   kPrev,
 };
 
-// LRM 7.12.4 iterator intrinsic methods (only `index` is in scope today;
-// extends naturally if SV adds more iterator methods).
+// LRM 7.12.4 iterator intrinsic methods.
 enum class IteratorMethodKind : std::uint8_t {
   kIndex,
 };

--- a/include/lyra/mir/builtin_method.hpp
+++ b/include/lyra/mir/builtin_method.hpp
@@ -59,9 +59,10 @@ enum class EventMethodKind : std::uint8_t {
 // implicitly materialised by the C++ copy constructor.
 //
 // `kSize` is the LRM 7.9.1 element count. The shared LRM 7.12 family
-// (ordering, reduction, locator) carries one closure as the second argument
-// -- the source `with` clause or the LRM 7.12.1 default `with (item)`. The
-// locator arms (`kFind` onward) return a queue.
+// (ordering, reduction, locator, `kMap`) carries one closure as the second
+// argument -- the source `with` clause or the LRM 7.12.1 default `with (item)`.
+// The locator arms (`kFind` onward) return a queue; `kMap` returns a same-shape
+// container of the closure's result type.
 enum class ArrayMethodKind : std::uint8_t {
   kElementAt,
   kSlice,
@@ -86,13 +87,13 @@ enum class ArrayMethodKind : std::uint8_t {
   kMax,
   kUnique,
   kUniqueIndex,
+  kMap,
 };
 
-// LRM 7.10.2 queue-native methods plus the compiler-internal access methods the
-// queue operators lower to. `size` .. `push_back` are SV-callable; `kElementAt`
-// / `kWriteRef` / `kSlice` realize `q[i]` read, `q[i] = v` write (and `q[$+1]`
-// append), and `q[a:b]` as built-in method calls (LRM 7.10.1). The shared LRM
-// 7.12 family stays in `ArrayMethodKind`.
+// LRM 7.10.2 queue methods. `kElementAt` / `kWriteRef` / `kSlice` have no SV
+// method syntax -- they carry `q[i]` read, `q[i] = v` write, and `q[a:b]`
+// slice, which lower to calls because a queue has no native C++ subscript
+// (LRM 7.10.1).
 enum class QueueMethodKind : std::uint8_t {
   kSize,
   kInsert,

--- a/include/lyra/value/array_manipulation.hpp
+++ b/include/lyra/value/array_manipulation.hpp
@@ -271,6 +271,23 @@ template <typename Seq, typename T, typename F, typename Combine>
   return acc;
 }
 
+// LRM 7.12.5 projection into the closure's return type. The caller seeds the
+// result container with a producer-supplied shield because that element type's
+// runtime shape is not recoverable from the C++ type alone.
+template <typename Seq, typename F>
+[[nodiscard]] auto ArrayMap(const Seq& data, F& closure)
+    -> std::vector<std::invoke_result_t<
+        F&, const typename Seq::value_type&, const PackedArray&>> {
+  using U = std::invoke_result_t<
+      F&, const typename Seq::value_type&, const PackedArray&>;
+  std::vector<U> out;
+  out.reserve(data.size());
+  for (std::size_t i = 0; i < data.size(); ++i) {
+    out.push_back(closure(data[i], LocatorIndex(i)));
+  }
+  return out;
+}
+
 // LRM 7.4.5 contiguous-range gather. The slice is `count` elements starting at
 // `offset`; an out-of-range position yields `canonical` and an x / z offset
 // (an invalid position) makes the whole result canonical. The flat vector is

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -343,6 +343,13 @@ class DynamicArray {
         PackedArray::Int(0), detail::ArrayUniqueIndex(data_, std::move(key))};
   }
 
+  // LRM 7.12.5 projection into a same-shape dynamic array; `shield` seeds the
+  // result element type's canonical default.
+  template <typename F, typename U>
+  [[nodiscard]] auto Map(F closure, U shield) const -> DynamicArray<U> {
+    return DynamicArray<U>(std::move(shield), detail::ArrayMap(data_, closure));
+  }
+
  private:
   [[nodiscard]] auto IsInvalidIndex(const PackedArray& idx) const -> bool {
     if (idx.HasUnknown()) return true;

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -416,6 +416,13 @@ class Queue {
         PackedArray::Int(0), detail::ArrayUniqueIndex(data_, std::move(key))};
   }
 
+  // LRM 7.12.5 projection into a same-shape queue; `shield` seeds the result
+  // element type's canonical default.
+  template <typename F, typename U>
+  [[nodiscard]] auto Map(F closure, U shield) const -> Queue<U> {
+    return Queue<U>(std::move(shield), detail::ArrayMap(data_, closure));
+  }
+
  private:
   [[nodiscard]] auto IsInvalidIndex(const PackedArray& idx) const -> bool {
     if (idx.HasUnknown()) {

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -297,6 +297,14 @@ class UnpackedArray {
         PackedArray::Int(0), detail::ArrayUniqueIndex(data_, std::move(key))};
   }
 
+  // LRM 7.12.5 projection into a same-range fixed unpacked array; `shield`
+  // seeds the result element type's canonical default.
+  template <typename F, typename U>
+  [[nodiscard]] auto Map(F closure, U shield) const -> UnpackedArray<U> {
+    return UnpackedArray<U>(
+        std::move(shield), detail::ArrayMap(data_, closure));
+  }
+
  private:
   [[nodiscard]] auto IsInvalidIndex(const PackedArray& idx) const -> bool {
     if (idx.HasUnknown()) return true;

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -777,6 +777,8 @@ auto ArrayMethodMemberName(mir::ArrayMethodKind k) -> std::string_view {
       return "Unique";
     case mir::ArrayMethodKind::kUniqueIndex:
       return "UniqueIndex";
+    case mir::ArrayMethodKind::kMap:
+      return "Map";
   }
   throw InternalError("ArrayMethodMemberName: unknown kind");
 }

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -218,6 +218,8 @@ class HirDumper {
         return "unique";
       case ArrayMethodKind::kUniqueIndex:
         return "unique_index";
+      case ArrayMethodKind::kMap:
+        return "map";
     }
     throw InternalError(
         "HirDumper::FormatArrayMethodKind: unknown ArrayMethodKind");

--- a/src/lyra/lowering/ast_to_hir/expression/slang_atoms.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/slang_atoms.cpp
@@ -241,6 +241,7 @@ auto LowerArrayMethodName(std::string_view name)
   if (name == "max") return hir::ArrayMethodKind::kMax;
   if (name == "unique") return hir::ArrayMethodKind::kUnique;
   if (name == "unique_index") return hir::ArrayMethodKind::kUniqueIndex;
+  if (name == "map") return hir::ArrayMethodKind::kMap;
   return std::nullopt;
 }
 

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -15,6 +15,7 @@
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/lowering/hir_to_mir/capture_sink.hpp"
+#include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/control.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/diagnostic.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/file_io.hpp"
@@ -136,6 +137,7 @@ auto ArrayMethodTakesClosure(hir::ArrayMethodKind k) -> bool {
     case hir::ArrayMethodKind::kMax:
     case hir::ArrayMethodKind::kUnique:
     case hir::ArrayMethodKind::kUniqueIndex:
+    case hir::ArrayMethodKind::kMap:
       return true;
   }
   throw InternalError("ArrayMethodTakesClosure: unknown hir::ArrayMethodKind");
@@ -183,6 +185,8 @@ auto LowerArrayMethodKind(hir::ArrayMethodKind k) -> mir::ArrayMethodKind {
       return mir::ArrayMethodKind::kUnique;
     case hir::ArrayMethodKind::kUniqueIndex:
       return mir::ArrayMethodKind::kUniqueIndex;
+    case hir::ArrayMethodKind::kMap:
+      return mir::ArrayMethodKind::kMap;
   }
   throw InternalError("LowerArrayMethodKind: unknown hir::ArrayMethodKind");
 }
@@ -316,6 +320,26 @@ auto ArrayMethodReceiverElementType(const hir::Type& ty)
     return q->element_type;
   }
   return std::nullopt;
+}
+
+// The element type of `map`'s result container (LRM 7.12.5), used to build its
+// shield.
+auto ArrayContainerElementType(const mir::Type& ty) -> mir::TypeId {
+  return std::visit(
+      [](const auto& t) -> mir::TypeId {
+        using TyT = std::decay_t<decltype(t)>;
+        if constexpr (
+            std::same_as<TyT, mir::UnpackedArrayType> ||
+            std::same_as<TyT, mir::DynamicArrayType> ||
+            std::same_as<TyT, mir::QueueType>) {
+          return t.element_type;
+        } else {
+          throw InternalError(
+              "ArrayContainerElementType: map result is not an unpacked-array "
+              "container type");
+        }
+      },
+      ty.data);
 }
 
 // LRM 7.12.1 / 7.12.2 / 7.12.3 with-clause closure synthesis. The body is a
@@ -680,6 +704,16 @@ auto LowerHirCallExprProc(
                 return std::unexpected(std::move(closure_or.error()));
               }
               args.push_back(proc_scope.AddExpr(*std::move(closure_or)));
+              // LRM 7.12.5: `map`'s result element type may differ from the
+              // receiver's, so its shield is supplied here as that type's
+              // canonical default -- the runtime shape is not recoverable from
+              // the C++ type alone.
+              if (*ak == hir::ArrayMethodKind::kMap) {
+                const mir::TypeId result_elem = ArrayContainerElementType(
+                    module.Unit().GetType(result_type));
+                args.push_back(proc_scope.AddExpr(
+                    BuildDefaultValueExpr(module, frame, result_elem)));
+              }
             } else if (c.with_clause.has_value()) {
               throw InternalError(
                   "BuiltinMethodRef with-clause on a method kind that does "

--- a/tests/cases/cpp/array_map/case.yaml
+++ b/tests/cases/cpp/array_map/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.array_map
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sum_ab: [11, 22, 33]
+    gt: [0, 1, 1]
+    qd: [8, 10]
+    fad: [8, 9, 10]
+    em: []
+    rowsum: [6, 9]

--- a/tests/cases/cpp/array_map/main.sv
+++ b/tests/cases/cpp/array_map/main.sv
@@ -1,0 +1,35 @@
+module Top;
+  // LRM 7.12.5: map() returns an unpacked array with the same shape and index
+  // type as the source, each element replaced by the mandatory with-expression.
+  // The result element type is the self-determined type of that expression, so
+  // it may differ from the source element type. The result container kind
+  // follows the receiver: dynamic -> dynamic, queue -> queue, fixed -> fixed.
+  int a[] = '{1, 2, 3};
+  int b[] = '{10, 20, 30};
+  int q[$] = '{4, 5};
+  int fa[3] = '{7, 8, 9};
+  int empty[];
+  int m[][] = '{'{1, 2, 3}, '{4, 5}};
+
+  int sum_ab[];
+  bit gt[];
+  int qd[$];
+  int fad[3];
+  int em[];
+  int rowsum[];
+
+  initial begin
+    // LRM 7.12.4 item.index, reaching across to a sibling array.
+    sum_ab = a.map(x) with (x + b[x.index]);
+    // Result element type narrows int -> bit.
+    gt = a.map(x) with (x > 1);
+    // Queue receiver yields a queue.
+    qd = q.map(x) with (x * 2);
+    // Fixed receiver yields a same-range fixed array.
+    fad = fa.map(x) with (x + 1);
+    // Empty receiver yields an empty result.
+    em = empty.map(x) with (x + 1);
+    // The element is itself an array; the closure reduces each row.
+    rowsum = m.map(row) with (row.sum());
+  end
+endmodule


### PR DESCRIPTION
## Summary

`map()` (LRM 7.12.5) projects every element of an unpacked array through a mandatory `with` expression into a new container of the same shape and index type, with the element type taken from the expression rather than the source. This adds it for the three sequence containers -- dynamic array, queue, and fixed unpacked array -- covering element-type changes (e.g. `int` to `bit`), `item.index` reaching across to sibling arrays, an empty receiver yielding an empty result, and an element that is itself an array reduced by the closure.

## Design

`map` joins the existing LRM 7.12 array-method family, so it routes through the same receiver-detection and `with`-clause closure machinery as `sort` / `find` and renders as one generic method call. Its one distinguishing need is that the result element type may differ from the receiver's, so the result container's shield -- the canonical default that seeds out-of-bounds reads and resize fills -- cannot be recovered from the C++ element type alone. The lowering builds that shield from the result element type and passes it to the runtime `Map`, matching the producer-supplied-shield contract in `runtime-shape-and-default-value.md`. The runtime projection is one shared algorithm wrapped per container.

A result element type that is itself a non-class value (`real`, `string`) lowers correctly but is unusable until those types can be unpacked-array elements, a pre-existing cross-cutting gap now tracked alongside the remaining `shuffle` and two-name iterator follow-ups in the aggregate progress doc.

## Testing

A new end-to-end case exercises map across all three receivers, the int-to-bit element-type change, cross-array index access, an empty receiver, and an element-is-array reduction. The full `bazel test //...` suite passes.