### PR TITLE
Support string and real as unpacked-array elements

### DIFF
--- a/docs/decisions/value-type-concepts.md
+++ b/docs/decisions/value-type-concepts.md
@@ -83,12 +83,17 @@ subset LRM defines for it.
 | `AssociativeArray<K,V>` | yes                   | yes                                 | no                   | no                       |
 | `lyra::value::Real`     | yes                   | **no (LRM excludes real from ===)** | no                   | yes                      |
 
-`Real`'s row is the load-bearing case: LRM Table 11-1 says `===` / `!==` apply to "Any except real
-and shortreal". The composable design records this exclusion structurally -- `Real` satisfies
-`LyraValueType` (so `Var<Real>` works and a module-level real signal is observable) but does not
-satisfy `CaseEqualComparable` (so an SV expression `r1 === r2` fails to lower at the C++ emit
-boundary, reflecting that the source program itself is LRM-illegal). The exclusion is not enforced
-by ad-hoc predicates; it follows from which concepts the type declares.
+`Real`'s row is the load-bearing case: LRM Table 11-1 excludes `real` / `shortreal` from `===` /
+`!==`, and the backend follows that strictly -- `Real` does not satisfy `CaseEqualComparable` and
+has no `CaseEqual`. The exclusion is principled, not an oversight: LRM 12.5 defines case equality as
+a bit-by-bit match, but a real has no x/z plane and its two natural readings disagree -- a
+bit-pattern match makes `+0.0 === -0.0` false and `NaN === NaN` true, while a value match makes them
+true and false respectively. The LRM declines to pick, so the operator is simply not defined on
+real. (slang and Verilator accept `r1 === r2` and evaluate it as `r1 == r2`, a value comparison;
+that is a documented deviation from Table 11-1 that the backend does not adopt.) Because the
+frontend does not reject the form, HIR-to-MIR lowering does: a `===` / `!==` whose operand is real,
+or an unpacked array with a real leaf, is an error (LRM Table 11-1). Nothing
+real-case-equality-shaped reaches the backend, so the render path stays mechanical.
 
 ### Universal-equality return type
 
@@ -111,10 +116,12 @@ These are separate methods on a value type even when they share an internal algo
   participates in further SV expression evaluation.
 
 For types that satisfy both concepts the two methods share an internal helper (bit-by-bit identity
-check). For `Real` only `IsBitIdentical` exists -- it implements bit-pattern equality via
+check), because for integral values case equality _is_ bit identity. `Real` satisfies only
+`LyraValueType`, so only `IsBitIdentical` exists -- it implements bit-pattern equality via
 `std::bit_cast<std::uint64_t>(double)` so that `+0.0` and `-0.0` are distinct and NaN bit-patterns
-classify by identity, both required for "did the storage cell's bits change" semantics. No
-`CaseEqual` exists on `Real`; the LRM gives no source-level syntax that would call it.
+classify by identity, both required for "did the storage cell's bits change". There is no
+`Real::CaseEqual`: `===` / `!==` are not defined on real (Table 11-1), and lowering rejects the
+source-level form before it could reach a value-type method.
 
 ### `Var<T>` and `ObservableType{T}` gating
 
@@ -186,7 +193,7 @@ mechanism as a module-level `int` signal.
 ## Implementation status
 
 - `LyraValueType`, `CaseEqualComparable`, `WildcardComparable`, `Ordered` defined in
-  `include/lyra/value/concepts.hpp`.
+  `include/lyra/value/value_concept.hpp`.
 - `PackedArray`, `String`, `UnpackedArray`, `DynamicArray`, `Queue`, `AssociativeArray` updated to
   satisfy the concepts LRM requires. Naming aligned: the host-bool predicate is `IsBitIdentical`
   across every type.
@@ -201,8 +208,13 @@ mechanism as a module-level `int` signal.
   (`IsObservableCell`, `LhsRootIsObservableScalar`, the four `MethodMutatesReceiver` tables,
   `RenderMethodReceiver`). These predicates are transitional residue and retire with the lowering
   change.
-- `lyra::value::Real` / `ShortReal` value classes and the corresponding HIR-to-MIR wrap-rule update
-  have not yet landed.
+- `lyra::value::Real` / `ShortReal` (a single `RealValue<Host>` template, with `RealTime` an alias
+  of `Real`) have landed and back every SV `real` / `shortreal` / `realtime`; the C++ backend
+  renders the real family as these value types rather than bare `double` / `float`. HIR-to-MIR's
+  wrap rule treats them as observable value-storage, so a module-level real signal is a `Var<Real>`,
+  and a real is a legal unpacked-array element. `===` / `!==` on a real (or real-leaf aggregate)
+  operand is rejected in HIR-to-MIR lowering with an error (LRM Table 11-1); the render path is
+  unchanged and never sees the form.
 
 ## Forbidden shapes
 
@@ -214,7 +226,9 @@ mechanism as a module-level `int` signal.
   fact (`ObservableType` wrapping); eligibility to be wrapped is a C++ concept fact
   (`LyraValueType`). The backend reads one or the other; it does not synthesise either.
 - A value type that satisfies `CaseEqualComparable` but whose `CaseEqual` and `IsBitIdentical` give
-  different answers. The two methods may share an internal helper; they may not diverge.
+  different answers. The two methods may share an internal helper; they may not diverge. (`Real`
+  sidesteps this by not satisfying `CaseEqualComparable` at all -- it has no `CaseEqual`, only the
+  engine's bit-pattern `IsBitIdentical`.)
 - A value type that implements an LRM operator method (e.g., `WildcardEquals`) without declaring the
   corresponding concept membership. The concept system is the contract; the methods exist to satisfy
   the concept.

--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -18,28 +18,28 @@ element-access shape is closest to fixed unpacked (already complete in U1..U7), 
 natural reuse for procedural read / write and aggregate operations. Queue and associative array
 follow once dynamic array's storage and runtime conventions are settled and proven against tests.
 
-| Item | Status                                                                  |
-| ---- | ----------------------------------------------------------------------- |
-| DA1  | Done: construction, element read, blocking element write, multi-dim.    |
-| DA2  | Done: NBA, compound element write, whole-array assignment.              |
-| DA3  | Done: positional and replicated assignment patterns (LRM 10.9.1).       |
-| DA4  | Done: aggregate equality, inequality, case-equality.                    |
-| DA5  | Done: constant-width slice (read and write).                            |
-| DA6a | Done: method dispatch + no-`with` subset.                               |
-| DA6b | Done: `with` clause + iterator on sort / rsort / reduction methods.     |
-| DA6c | Done: locator family (find\*, min, max, unique\*).                      |
-| DA6d | Done: `map` projection (LRM 7.12.5) on the sequence containers.         |
-| DA6e | Open: `shuffle` (LRM 7.12.2); needs a seeded simulation RNG.            |
-| DA6f | Open: two-name iterator / index argument form (LRM 7.12.4).             |
-| DA6g | Open: `real` / `shortreal` / `string` as an unpacked-array element.     |
-| DA7  | Done: invalid-index handling.                                           |
-| Q1   | Done: type, element read/write, native methods, default, case-equality. |
-| Q2   | Done: operator surface (`$`, slice, concat, equality, bound, append).   |
-| Q3   | Done: array-manipulation method family (LRM 7.12).                      |
-| A1   | Done: string / integral index, element read / write, query methods.     |
-| A2   | Done: traversal protocol (`first` / `last` / `next` / `prev`).          |
-| A3   | Done: `foreach` over an associative array (any dimensionality).         |
-| A4.. | Open: literals, whole-array assignment, locators.                       |
+| Item | Status                                                                   |
+| ---- | ------------------------------------------------------------------------ |
+| DA1  | Done: construction, element read, blocking element write, multi-dim.     |
+| DA2  | Done: NBA, compound element write, whole-array assignment.               |
+| DA3  | Done: positional and replicated assignment patterns (LRM 10.9.1).        |
+| DA4  | Done: aggregate equality, inequality, case-equality.                     |
+| DA5  | Done: constant-width slice (read and write).                             |
+| DA6a | Done: method dispatch + no-`with` subset.                                |
+| DA6b | Done: `with` clause + iterator on sort / rsort / reduction methods.      |
+| DA6c | Done: locator family (find\*, min, max, unique\*).                       |
+| DA6d | Done: `map` projection (LRM 7.12.5) on the sequence containers.          |
+| DA6e | Open: `shuffle` (LRM 7.12.2); needs a seeded simulation RNG.             |
+| DA6f | Open: two-name iterator / index argument form (LRM 7.12.4).              |
+| DA6g | `string` element done; `real` / `shortreal` element open (needs `Real`). |
+| DA7  | Done: invalid-index handling.                                            |
+| Q1   | Done: type, element read/write, native methods, default, case-equality.  |
+| Q2   | Done: operator surface (`$`, slice, concat, equality, bound, append).    |
+| Q3   | Done: array-manipulation method family (LRM 7.12).                       |
+| A1   | Done: string / integral index, element read / write, query methods.      |
+| A2   | Done: traversal protocol (`first` / `last` / `next` / `prev`).           |
+| A3   | Done: `foreach` over an associative array (any dimensionality).          |
+| A4.. | Open: literals, whole-array assignment, locators.                        |
 
 ## Dynamic Array
 
@@ -118,10 +118,10 @@ The numeric IDs are stable references and do not imply execution order beyond DA
 - [x] DA6d -- The `map()` projection (LRM 7.12.5) with its mandatory `with` clause. Each element and
       its index pass through the expression into a result whose shape and index type match the
       receiver (dynamic array, queue, or fixed unpacked) and whose element type is the expression's
-      self-determined type, so it may differ from the source. An empty receiver yields an empty
-      result. A result element type that is itself a non-class value (`real`, `string`) lowers
-      correctly but is unusable until those types can be unpacked-array elements (see DA6g), the
-      same pre-existing gap that blocks `real` / `string` dynamic arrays generally.
+      self-determined type, so it may differ from the source (e.g. `int` to `bit`, or to `string`).
+      An empty receiver yields an empty result. A `real` / `shortreal` result element lowers
+      correctly but is unusable until `real` becomes a value type that can be an unpacked-array
+      element (see DA6g).
 
 - [ ] DA6e -- `shuffle()` (LRM 7.12.2) on every unpacked container. Needs a seeded simulation RNG;
       none exists yet (`$random` / `$urandom` are unimplemented), and that same RNG is the
@@ -134,11 +134,18 @@ The numeric IDs are stable references and do not imply execution order beyond DA
       method to avoid clashes with member names of the stored elements. Shared across find / sort /
       map / reductions; none support it yet.
 
-- [ ] DA6g -- `real` / `shortreal` / `string` as an unpacked-array element (dynamic array, queue,
-      fixed unpacked). These value types do not satisfy the container-element contract -- canonical-
-      default reset and bit-identity change detection -- so `real []` / `string []` cannot be
-      declared, read, or produced as a `map()` result element today. Cross-cutting value-type gap,
-      also surfaced from `unpacked.md`; not specific to one container.
+- [x] DA6g (`string`) -- `string` as an unpacked-array element (dynamic array, queue, fixed
+      unpacked): declaration, element read / write, the empty-string OOB default (LRM Table 6-7),
+      aggregate equality, `%p` formatting, and as a `map()` result element type. `string` already
+      carried the universal-equality and change-detection surface; the element gap was only the
+      canonical-default reset.
+
+- [ ] DA6g (`real` / `shortreal`) -- `real` / `shortreal` as an unpacked-array element. Blocked on
+      the `real` value type itself: `real` is currently a bare host `double`, which carries none of
+      the container-element contract (canonical-default reset, bit-identity change detection,
+      universal equality). Introducing the `lyra::value::Real` value type (see
+      `../decisions/value-type-concepts.md`) is the prerequisite; once it lands, `real []` falls out
+      through the same shield pattern as every other element type.
 
 - [x] DA7 -- Invalid-index handling (LRM 7.4.5). Read on an out-of-range index returns the element
       type's Table 7-1 default; write on an out-of-range index is a silent no-op; X / Z bits in the

--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -18,28 +18,28 @@ element-access shape is closest to fixed unpacked (already complete in U1..U7), 
 natural reuse for procedural read / write and aggregate operations. Queue and associative array
 follow once dynamic array's storage and runtime conventions are settled and proven against tests.
 
-| Item | Status                                                                   |
-| ---- | ------------------------------------------------------------------------ |
-| DA1  | Done: construction, element read, blocking element write, multi-dim.     |
-| DA2  | Done: NBA, compound element write, whole-array assignment.               |
-| DA3  | Done: positional and replicated assignment patterns (LRM 10.9.1).        |
-| DA4  | Done: aggregate equality, inequality, case-equality.                     |
-| DA5  | Done: constant-width slice (read and write).                             |
-| DA6a | Done: method dispatch + no-`with` subset.                                |
-| DA6b | Done: `with` clause + iterator on sort / rsort / reduction methods.      |
-| DA6c | Done: locator family (find\*, min, max, unique\*).                       |
-| DA6d | Done: `map` projection (LRM 7.12.5) on the sequence containers.          |
-| DA6e | Open: `shuffle` (LRM 7.12.2); needs a seeded simulation RNG.             |
-| DA6f | Open: two-name iterator / index argument form (LRM 7.12.4).              |
-| DA6g | `string` element done; `real` / `shortreal` element open (needs `Real`). |
-| DA7  | Done: invalid-index handling.                                            |
-| Q1   | Done: type, element read/write, native methods, default, case-equality.  |
-| Q2   | Done: operator surface (`$`, slice, concat, equality, bound, append).    |
-| Q3   | Done: array-manipulation method family (LRM 7.12).                       |
-| A1   | Done: string / integral index, element read / write, query methods.      |
-| A2   | Done: traversal protocol (`first` / `last` / `next` / `prev`).           |
-| A3   | Done: `foreach` over an associative array (any dimensionality).          |
-| A4.. | Open: literals, whole-array assignment, locators.                        |
+| Item | Status                                                                  |
+| ---- | ----------------------------------------------------------------------- |
+| DA1  | Done: construction, element read, blocking element write, multi-dim.    |
+| DA2  | Done: NBA, compound element write, whole-array assignment.              |
+| DA3  | Done: positional and replicated assignment patterns (LRM 10.9.1).       |
+| DA4  | Done: aggregate equality, inequality, case-equality.                    |
+| DA5  | Done: constant-width slice (read and write).                            |
+| DA6a | Done: method dispatch + no-`with` subset.                               |
+| DA6b | Done: `with` clause + iterator on sort / rsort / reduction methods.     |
+| DA6c | Done: locator family (find\*, min, max, unique\*).                      |
+| DA6d | Done: `map` projection (LRM 7.12.5) on the sequence containers.         |
+| DA6e | Open: `shuffle` (LRM 7.12.2); needs a seeded simulation RNG.            |
+| DA6f | Open: two-name iterator / index argument form (LRM 7.12.4).             |
+| DA6g | Done: `string` / `real` / `shortreal` as an unpacked-array element.     |
+| DA7  | Done: invalid-index handling.                                           |
+| Q1   | Done: type, element read/write, native methods, default, case-equality. |
+| Q2   | Done: operator surface (`$`, slice, concat, equality, bound, append).   |
+| Q3   | Done: array-manipulation method family (LRM 7.12).                      |
+| A1   | Done: string / integral index, element read / write, query methods.     |
+| A2   | Done: traversal protocol (`first` / `last` / `next` / `prev`).          |
+| A3   | Done: `foreach` over an associative array (any dimensionality).         |
+| A4.. | Open: literals, whole-array assignment, locators.                       |
 
 ## Dynamic Array
 
@@ -118,10 +118,8 @@ The numeric IDs are stable references and do not imply execution order beyond DA
 - [x] DA6d -- The `map()` projection (LRM 7.12.5) with its mandatory `with` clause. Each element and
       its index pass through the expression into a result whose shape and index type match the
       receiver (dynamic array, queue, or fixed unpacked) and whose element type is the expression's
-      self-determined type, so it may differ from the source (e.g. `int` to `bit`, or to `string`).
-      An empty receiver yields an empty result. A `real` / `shortreal` result element lowers
-      correctly but is unusable until `real` becomes a value type that can be an unpacked-array
-      element (see DA6g).
+      self-determined type, so it may differ from the source (e.g. `int` to `bit`, `string`, or
+      `real`). An empty receiver yields an empty result.
 
 - [ ] DA6e -- `shuffle()` (LRM 7.12.2) on every unpacked container. Needs a seeded simulation RNG;
       none exists yet (`$random` / `$urandom` are unimplemented), and that same RNG is the
@@ -134,18 +132,15 @@ The numeric IDs are stable references and do not imply execution order beyond DA
       method to avoid clashes with member names of the stored elements. Shared across find / sort /
       map / reductions; none support it yet.
 
-- [x] DA6g (`string`) -- `string` as an unpacked-array element (dynamic array, queue, fixed
-      unpacked): declaration, element read / write, the empty-string OOB default (LRM Table 6-7),
-      aggregate equality, `%p` formatting, and as a `map()` result element type. `string` already
-      carried the universal-equality and change-detection surface; the element gap was only the
-      canonical-default reset.
-
-- [ ] DA6g (`real` / `shortreal`) -- `real` / `shortreal` as an unpacked-array element. Blocked on
-      the `real` value type itself: `real` is currently a bare host `double`, which carries none of
-      the container-element contract (canonical-default reset, bit-identity change detection,
-      universal equality). Introducing the `lyra::value::Real` value type (see
-      `../decisions/value-type-concepts.md`) is the prerequisite; once it lands, `real []` falls out
-      through the same shield pattern as every other element type.
+- [x] DA6g -- `string`, `real`, and `shortreal` as unpacked-array elements (dynamic array, queue,
+      fixed unpacked): declaration, element read / write, the element-type OOB default (LRM Table
+      6-7: `""` for string, 0.0 for real), aggregate equality, `%p` formatting, and as a `map()`
+      result element type. `string` only needed its canonical-default reset. `real` / `shortreal`
+      first needed to become value types at all -- they were bare host `double` / `float` -- so the
+      `lyra::value::Real` value type was introduced (see `../decisions/value-type-concepts.md`),
+      after which the element support falls out through the same shield pattern as every other type.
+      Case equality (`===` / `!==`) on a real or real-element aggregate is rejected in lowering: LRM
+      Table 11-1 excludes real / shortreal from case equality.
 
 - [x] DA7 -- Invalid-index handling (LRM 7.4.5). Read on an out-of-range index returns the element
       type's Table 7-1 default; write on an out-of-range index is a silent no-op; X / Z bits in the

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -36,6 +36,7 @@ enum class DiagCode : std::uint32_t {
   kUnsupportedForkJoinForm,
 
   kDelayValueOutOfRange,
+  kCaseEqualityOnRealOperand,
   kFormatStringTrailingPercent,
   kFormatStringMissingSpecifier,
   kFormatStringWidthOverflow,

--- a/include/lyra/runtime/sim_time.hpp
+++ b/include/lyra/runtime/sim_time.hpp
@@ -5,6 +5,7 @@
 #include "lyra/base/time.hpp"
 #include "lyra/runtime/runtime_services.hpp"
 #include "lyra/value/packed_array.hpp"
+#include "lyra/value/real.hpp"
 
 namespace lyra::runtime {
 
@@ -52,11 +53,13 @@ inline auto STimeInUnit(
 // $realtime (LRM 20.3.3): the current time scaled to `unit_power` as a real,
 // keeping any fractional part.
 inline auto RealTimeInUnit(
-    RuntimeServices& services, const value::PackedArray& unit_power) -> double {
+    RuntimeServices& services, const value::PackedArray& unit_power)
+    -> value::Real {
   const auto power = static_cast<std::int8_t>(unit_power.ToInt64());
   const SimDuration divisor =
       TimeUnitDivisor(power, services.GlobalPrecisionPower());
-  return static_cast<double>(services.Now()) / static_cast<double>(divisor);
+  return value::Real{
+      static_cast<double>(services.Now()) / static_cast<double>(divisor)};
 }
 
 }  // namespace lyra::runtime

--- a/include/lyra/value/format.hpp
+++ b/include/lyra/value/format.hpp
@@ -8,6 +8,8 @@ namespace lyra::value {
 
 class PackedArray;
 class String;
+template <typename Host>
+class RealValue;
 template <typename T>
 class UnpackedArray;
 template <typename T>
@@ -206,10 +208,8 @@ struct PrintValueItem {
   PrintValueItem(const String& value, FormatSpec spec)
       : spec(spec), arg(MakeFormatArg(value)) {
   }
-  PrintValueItem(const double& value, FormatSpec spec)
-      : spec(spec), arg(MakeFormatArg(value)) {
-  }
-  PrintValueItem(const float& value, FormatSpec spec)
+  template <typename Host>
+  PrintValueItem(const RealValue<Host>& value, FormatSpec spec)
       : spec(spec), arg(MakeFormatArg(value)) {
   }
   template <typename T>

--- a/include/lyra/value/real.hpp
+++ b/include/lyra/value/real.hpp
@@ -1,0 +1,183 @@
+#pragma once
+
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <type_traits>
+
+#include "lyra/value/format.hpp"
+#include "lyra/value/packed_array.hpp"
+#include "lyra/value/value_concept.hpp"
+
+namespace lyra::value {
+
+// Runtime representation of the SystemVerilog real family (LRM 6.12).
+// `RealValue<double>` is `real` / `realtime` (LRM 6.12.1 makes them one type);
+// `RealValue<float>` is `shortreal`. The two differ only in host precision, so
+// one template carries both. The operator surface mirrors LRM Table 11-1: real
+// satisfies the universal-equality and relational families but NOT case
+// equality (`===` / `!==` are excluded from real operands), so this type has no
+// `CaseEqual` and does not model `CaseEqualComparable`.
+template <typename Host>
+class RealValue {
+ public:
+  using HostType = Host;
+
+  RealValue() = default;
+  explicit RealValue(Host v) : v_(v) {
+  }
+
+  // LRM 6.12.1: a `shortreal` <-> `real` reshape is a host float-precision
+  // cast. Explicit so the two precisions never convert implicitly.
+  template <typename Other>
+  explicit RealValue(const RealValue<Other>& o)
+      : v_(static_cast<Host>(o.Value())) {
+  }
+
+  [[nodiscard]] auto Value() const -> Host {
+    return v_;
+  }
+
+  // LRM 6.12.1: integer-to-real keeps the integer value (the caller collapses
+  // X/Z bits to 0 before this); real-to-integer rounds to nearest, ties away
+  // from zero, which is `std::llround`.
+  [[nodiscard]] static auto FromInt64(std::int64_t i) -> RealValue {
+    return RealValue{static_cast<Host>(i)};
+  }
+  [[nodiscard]] auto Round() const -> std::int64_t {
+    return std::llround(v_);
+  }
+
+  // LRM 11.3.1 arithmetic on real produces real.
+  [[nodiscard]] auto operator+(const RealValue& o) const -> RealValue {
+    return RealValue{static_cast<Host>(v_ + o.v_)};
+  }
+  [[nodiscard]] auto operator-(const RealValue& o) const -> RealValue {
+    return RealValue{static_cast<Host>(v_ - o.v_)};
+  }
+  [[nodiscard]] auto operator*(const RealValue& o) const -> RealValue {
+    return RealValue{static_cast<Host>(v_ * o.v_)};
+  }
+  [[nodiscard]] auto operator/(const RealValue& o) const -> RealValue {
+    return RealValue{static_cast<Host>(v_ / o.v_)};
+  }
+  [[nodiscard]] auto operator-() const -> RealValue {
+    return RealValue{static_cast<Host>(-v_)};
+  }
+  [[nodiscard]] auto Pow(const RealValue& o) const -> RealValue {
+    return RealValue{static_cast<Host>(std::pow(v_, o.v_))};
+  }
+
+  // LRM 11.4.1 Table 11-1: `+= -= *= /=` apply to real operands.
+  auto operator+=(const RealValue& o) -> RealValue& {
+    v_ = static_cast<Host>(v_ + o.v_);
+    return *this;
+  }
+  auto operator-=(const RealValue& o) -> RealValue& {
+    v_ = static_cast<Host>(v_ - o.v_);
+    return *this;
+  }
+  auto operator*=(const RealValue& o) -> RealValue& {
+    v_ = static_cast<Host>(v_ * o.v_);
+    return *this;
+  }
+  auto operator/=(const RealValue& o) -> RealValue& {
+    v_ = static_cast<Host>(v_ / o.v_);
+    return *this;
+  }
+
+  // LRM 11.4.2: increment / decrement on a real operand changes it by 1.0.
+  auto operator++() -> RealValue& {
+    v_ = static_cast<Host>(v_ + 1);
+    return *this;
+  }
+  auto operator--() -> RealValue& {
+    v_ = static_cast<Host>(v_ - 1);
+    return *this;
+  }
+  auto operator++(int) -> RealValue {
+    RealValue old = *this;
+    ++(*this);
+    return old;
+  }
+  auto operator--(int) -> RealValue {
+    RealValue old = *this;
+    --(*this);
+    return old;
+  }
+
+  // LRM 11.4.4 relational: a 1-bit 2-state result (real carries no x/z).
+  [[nodiscard]] auto operator<(const RealValue& o) const -> PackedArray {
+    return PackedArray::Bit(v_ < o.v_);
+  }
+  [[nodiscard]] auto operator<=(const RealValue& o) const -> PackedArray {
+    return PackedArray::Bit(v_ <= o.v_);
+  }
+  [[nodiscard]] auto operator>(const RealValue& o) const -> PackedArray {
+    return PackedArray::Bit(v_ > o.v_);
+  }
+  [[nodiscard]] auto operator>=(const RealValue& o) const -> PackedArray {
+    return PackedArray::Bit(v_ >= o.v_);
+  }
+
+  // LRM 11.4.5 `==` / `!=` (Any data type), compared as real values.
+  [[nodiscard]] auto operator==(const RealValue& o) const -> PackedArray {
+    return PackedArray::Bit(v_ == o.v_);
+  }
+  [[nodiscard]] auto operator!=(const RealValue& o) const -> PackedArray {
+    return PackedArray::Bit(v_ != o.v_);
+  }
+
+  // LRM 9.4.2 update event predicate (engine change-detection hook): compares
+  // the raw bit pattern, so +0.0 / -0.0 differ and a NaN classifies by its
+  // bits, both required for "did the storage cell's bits change". This is an
+  // engine hook, not an SV operator: real has no LRM `===` (Table 11-1 excludes
+  // it), so there is no `CaseEqual` here for it to coincide with or diverge
+  // from.
+  [[nodiscard]] auto IsBitIdentical(const RealValue& o) const -> bool {
+    return std::bit_cast<BitsType>(v_) == std::bit_cast<BitsType>(o.v_);
+  }
+
+  // LRM Table 6-7: the real default is 0.0. This is the container OOB-shield
+  // contract (docs/decisions/runtime-shape-and-default-value.md), so a real can
+  // be an unpacked-array element.
+  auto ResetToDefault() -> void {
+    v_ = Host{0};
+  }
+
+  // LRM 11.4.7 / 12.4: a real in a boolean context is true when non-zero.
+  explicit operator bool() const {
+    return v_ != Host{0};
+  }
+
+ private:
+  using BitsType =
+      std::conditional_t<sizeof(Host) == 8, std::uint64_t, std::uint32_t>;
+
+  Host v_ = Host{0};
+};
+
+using Real = RealValue<double>;
+using ShortReal = RealValue<float>;
+using RealTime = Real;
+
+// LRM 21.2.1 real formatting. Delegates to the host-precision formatter
+// (`Formatter<double>` / `Formatter<float>`); the %f / %e / %g precision comes
+// from the spec, not the host width.
+template <typename Host>
+struct Formatter<RealValue<Host>> {
+  static auto Format(
+      const FormatSpec& spec, const RealValue<Host>& value,
+      const FormatContext& ctx) -> std::string {
+    return Formatter<Host>::Format(spec, value.Value(), ctx);
+  }
+};
+
+static_assert(LyraValueType<Real>);
+static_assert(LyraValueType<ShortReal>);
+static_assert(Ordered<Real>);
+static_assert(Ordered<ShortReal>);
+static_assert(!CaseEqualComparable<Real>);
+static_assert(!CaseEqualComparable<ShortReal>);
+
+}  // namespace lyra::value

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -107,6 +107,14 @@ class String {
     return impl_ == o.impl_;
   }
 
+  // LRM Table 6-7: the string default is the empty string. This is the
+  // container OOB-shield contract shared with the other value types
+  // (docs/decisions/runtime-shape-and-default-value.md), so a `string` can be
+  // an unpacked-array element.
+  auto ResetToDefault() -> void {
+    impl_.clear();
+  }
+
   // LRM 11.4.4 relational operators on `String` (LRM 6.16). The result is
   // 2-state.
   [[nodiscard]] auto operator<(const String& o) const -> PackedArray {

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "lyra/value/packed_array.hpp"
+#include "lyra/value/real.hpp"
 #include "lyra/value/unpacked_array.hpp"
 #include "lyra/value/value_concept.hpp"
 
@@ -224,12 +225,12 @@ class String {
   }
 
   // LRM 6.16.10. Parse leading real-number syntax; 0.0 if none.
-  [[nodiscard]] auto Atoreal() const -> double {
-    if (impl_.empty()) return 0.0;
+  [[nodiscard]] auto Atoreal() const -> Real {
+    if (impl_.empty()) return Real{0.0};
     char* end_ptr = nullptr;
     const double v = std::strtod(impl_.c_str(), &end_ptr);
-    if (end_ptr == impl_.c_str()) return 0.0;
-    return v;
+    if (end_ptr == impl_.c_str()) return Real{0.0};
+    return Real{v};
   }
 
   // LRM 6.16.11 through 6.16.15. Each replaces receiver with the ASCII
@@ -240,7 +241,7 @@ class String {
   void Hextoa(const PackedArray& i);
   void Octtoa(const PackedArray& i);
   void Bintoa(const PackedArray& i);
-  void Realtoa(double r);
+  void Realtoa(const Real& r);
 
   [[nodiscard]] auto View() const -> std::string_view {
     return impl_;

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -388,6 +388,7 @@ auto RenderScopeHeaderFile(
   out += "#include \"lyra/value/packed_bitwise.hpp\"\n";
   out += "#include \"lyra/value/packed_convert.hpp\"\n";
   out += "#include \"lyra/value/packed_reduction.hpp\"\n";
+  out += "#include \"lyra/value/real.hpp\"\n";
   out += "#include \"lyra/value/string.hpp\"\n";
   out += "#include \"lyra/value/string_op.hpp\"\n";
   out += "#include \"lyra/value/unpacked_array.hpp\"\n";

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -156,9 +156,9 @@ auto RenderRealLiteralExpr(
     -> std::string {
   // `std::format` with `{:.{}g}` and precision=17 round-trips a double;
   // precision=9 round-trips a float (IEEE 754 minimum representable-pair
-  // widths). The trailing 'f' suffix on the float form keeps the C++ literal
-  // type matched to the destination `float` so overload resolution and
-  // initialization both land on the shortreal path.
+  // widths). The trailing 'f' suffix keeps the shortreal body a `float` literal
+  // so the wrapping `ShortReal{...}` constructs from a float, with no
+  // double -> float narrowing.
   //
   // `g` strips trailing zeros and the decimal point for whole-number values,
   // which would produce literals like `0f` or `42e3f` that the C++ lexer
@@ -175,7 +175,8 @@ auto RenderRealLiteralExpr(
   if (is_short) {
     body += "f";
   }
-  return body;
+  return std::format(
+      "lyra::value::{}{{{}}}", is_short ? "ShortReal" : "Real", body);
 }
 
 auto RenderStructuralParamExpr(
@@ -271,11 +272,10 @@ auto RenderBinaryOpString(
 auto RenderBinaryOpReal(
     mir::BinaryOp op, const std::string& lhs, const std::string& rhs,
     const mir::Type& result_ty) -> diag::Result<std::string> {
-  // LRM 11.3.1 + Table 11-1: arithmetic on real produces real; relational /
-  // logical / equality produce a 1-bit integral that the runtime sees as a
-  // PackedArray view. `std::pow` overload resolution picks (float, float) ->
-  // float and (double, double) -> double, matching LRM 11.3.1's result type
-  // for shortreal-only vs any-real expressions.
+  // LRM 11.3.1 + Table 11-1: arithmetic on real produces real; relational and
+  // equality return a 1-bit `PackedArray` directly from the `RealValue`
+  // operator. Logical operators reduce each operand to a host bool first, then
+  // re-shape into the result's integral type.
   switch (op) {
     case mir::BinaryOp::kAdd:
       return "(" + lhs + " + " + rhs + ")";
@@ -286,19 +286,19 @@ auto RenderBinaryOpReal(
     case mir::BinaryOp::kDiv:
       return "(" + lhs + " / " + rhs + ")";
     case mir::BinaryOp::kPower:
-      return "std::pow(" + lhs + ", " + rhs + ")";
+      return "(" + lhs + ").Pow(" + rhs + ")";
     case mir::BinaryOp::kLessThan:
-      return WrapBoolAsResultShape(result_ty, lhs + " < " + rhs);
+      return "(" + lhs + " < " + rhs + ")";
     case mir::BinaryOp::kLessEqual:
-      return WrapBoolAsResultShape(result_ty, lhs + " <= " + rhs);
+      return "(" + lhs + " <= " + rhs + ")";
     case mir::BinaryOp::kGreaterThan:
-      return WrapBoolAsResultShape(result_ty, lhs + " > " + rhs);
+      return "(" + lhs + " > " + rhs + ")";
     case mir::BinaryOp::kGreaterEqual:
-      return WrapBoolAsResultShape(result_ty, lhs + " >= " + rhs);
+      return "(" + lhs + " >= " + rhs + ")";
     case mir::BinaryOp::kEquality:
-      return WrapBoolAsResultShape(result_ty, lhs + " == " + rhs);
+      return "(" + lhs + " == " + rhs + ")";
     case mir::BinaryOp::kInequality:
-      return WrapBoolAsResultShape(result_ty, lhs + " != " + rhs);
+      return "(" + lhs + " != " + rhs + ")";
     case mir::BinaryOp::kLogicalAnd:
       return WrapBoolAsResultShape(
           result_ty, "bool(" + lhs + ") && bool(" + rhs + ")");
@@ -535,10 +535,10 @@ auto RenderConditionalExpr(
   return "(" + *cond_or + " ? " + *then_or + " : " + *else_or + ")";
 }
 
-// SV LRM 6.12.1 + 6.22: real-family conversions are pure float-precision
-// reshape. `realtime` is a synonym for `real`, so both share `double`. The
-// only emit-time work is on shortreal <-> real: insert an explicit
-// `static_cast` so the C++ compiler does not flag the narrowing direction.
+// SV LRM 6.12.1 + 6.22: real-family conversions are a pure float-precision
+// reshape. `realtime` is a synonym for `real`, so both are `lyra::value::Real`
+// and need no conversion; only a `shortreal` <-> `real` change crosses the two
+// `RealValue` instantiations, expressed through the cross-precision ctor.
 auto RenderRealConversion(
     std::string operand, const mir::Type& src_ty, const mir::Type& dst_ty)
     -> std::string {
@@ -548,7 +548,7 @@ auto RenderRealConversion(
     return operand;
   }
   return std::format(
-      "static_cast<{}>({})", dst_is_short ? "float" : "double", operand);
+      "lyra::value::{}{{{}}}", dst_is_short ? "ShortReal" : "Real", operand);
 }
 
 // Integral-to-integral conversions reshape a PackedArray to a possibly-
@@ -584,27 +584,28 @@ auto RenderIntegralConversion(
 
 // LRM 6.12.1: integer-to-real implicit conversion treats X/Z bits as 0.
 // `PackedArray::ToInt64` already collapses X/Z bits to 0 (packed_array.hpp
-// docstring), so a plain `static_cast` to the destination real precision is
-// the full conversion. `shortreal` casts to `float`; `real` and `realtime`
-// (LRM 6.12 synonyms) cast to `double`.
+// docstring), so the integer value feeds `RealValue::FromInt64`. `shortreal`
+// builds a `ShortReal`; `real` and `realtime` (LRM 6.12 synonyms) build a
+// `Real`.
 auto RenderIntegralToRealConversion(
     std::string operand, const mir::Type& dst_ty) -> std::string {
-  const auto* cpp_ty =
-      dst_ty.Kind() == mir::TypeKind::kShortReal ? "float" : "double";
-  return std::format("static_cast<{}>(({}).ToInt64())", cpp_ty, operand);
+  const auto* real_ty =
+      dst_ty.Kind() == mir::TypeKind::kShortReal ? "ShortReal" : "Real";
+  return std::format(
+      "lyra::value::{}::FromInt64(({}).ToInt64())", real_ty, operand);
 }
 
 // LRM 6.12.1: real-to-integer implicit conversion rounds the real to the
 // nearest integer with ties rounded away from zero (35.5 -> 36, -1.5 -> -2).
-// `std::llround` is the standard library function with exactly that rounding
-// rule; it returns `long long` (>= 64 bits), which feeds `PackedArray::FromInt`
-// to land the rounded value into the destination shape. Destination widths >
-// 64 bits would need a wide-int conversion path; that is currently caught by
-// `FromInt`'s own width invariant.
+// `RealValue::Round` applies that rule (via `std::llround`) and returns a
+// `long long` (>= 64 bits), which feeds `PackedArray::FromInt` to land the
+// rounded value into the destination shape. Destination widths > 64 bits would
+// need a wide-int conversion path; that is currently caught by `FromInt`'s own
+// width invariant.
 auto RenderRealToIntegralConversion(
     std::string operand, const mir::PackedArrayType& dst_pa) -> std::string {
   return std::format(
-      "lyra::value::PackedArray::FromInt(std::llround({}), {})", operand,
+      "lyra::value::PackedArray::FromInt(({}).Round(), {})", operand,
       RenderPackedArrayCtorArgs(dst_pa));
 }
 

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -71,13 +71,13 @@ auto RenderTypeAsCpp(
             return std::string{"lyra::runtime::NamedEvent"};
           },
           [](const mir::RealType&) -> diag::Result<std::string> {
-            return std::string{"double"};
+            return std::string{"lyra::value::Real"};
           },
           [](const mir::ShortRealType&) -> diag::Result<std::string> {
-            return std::string{"float"};
+            return std::string{"lyra::value::ShortReal"};
           },
           [](const mir::RealTimeType&) -> diag::Result<std::string> {
-            return std::string{"double"};
+            return std::string{"lyra::value::Real"};
           },
           [&](const mir::UnpackedArrayType& ua) -> diag::Result<std::string> {
             auto inner_or = RenderTypeAsCpp(unit, owner_scope, ua.element_type);

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -158,6 +158,12 @@ constexpr std::array kEntries{
             .category = std::nullopt,
             .name = "delay_value_out_of_range"}},
     std::pair{
+        DiagCode::kCaseEqualityOnRealOperand,
+        DiagCodeInfo{
+            .kind = DiagKind::kError,
+            .category = std::nullopt,
+            .name = "case_equality_on_real_operand"}},
+    std::pair{
         DiagCode::kFormatStringTrailingPercent,
         DiagCodeInfo{
             .kind = DiagKind::kError,

--- a/src/lyra/lowering/ast_to_hir/expression/operators.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/operators.cpp
@@ -4,8 +4,12 @@
 #include <utility>
 
 #include <slang/ast/Expression.h>
+#include <slang/ast/Symbol.h>
 #include <slang/ast/expressions/ConversionExpression.h>
 #include <slang/ast/expressions/OperatorExpressions.h>
+#include <slang/ast/symbols/VariableSymbols.h>
+#include <slang/ast/types/AllTypes.h>
+#include <slang/ast/types/Type.h>
 
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/kind.hpp"
@@ -15,6 +19,68 @@
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
+
+namespace {
+
+// Whether `type` is a real-family type, or a composite (any depth) with a
+// real-family leaf. Recurses the two ways a value type nests other value types:
+// unpacked array elements and unpacked struct / union members. A packed
+// struct / union cannot hold a real (packed members are integral); a class is a
+// handle whose `===` compares identity, not members, so neither is recursed.
+auto TypeHasRealLeaf(const slang::ast::Type& type) -> bool {
+  const auto& canonical = type.getCanonicalType();
+  if (canonical.kind == slang::ast::SymbolKind::FloatingType) {
+    return true;
+  }
+  if (const auto* element = canonical.getArrayElementType();
+      element != nullptr) {
+    return TypeHasRealLeaf(*element);
+  }
+  if (canonical.isUnpackedStruct()) {
+    for (const auto* field :
+         canonical.as<slang::ast::UnpackedStructType>().fields) {
+      if (TypeHasRealLeaf(field->getType())) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (canonical.isUnpackedUnion()) {
+    for (const auto* field :
+         canonical.as<slang::ast::UnpackedUnionType>().fields) {
+      if (TypeHasRealLeaf(field->getType())) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return false;
+}
+
+// LRM Table 11-1: case equality (`===` / `!==`) is not defined on real /
+// shortreal operands. slang accepts the form and evaluates it as a value
+// comparison, but that is a deviation from the standard the backend does not
+// follow: for a real there is no x/z plane, so the bit-matching the case
+// operators specify (LRM 12.5) has no single correct meaning. Lowering rejects
+// it here -- including a real-element aggregate, where case equality would
+// recurse element-wise into the same undefined comparison.
+auto CheckBinaryOperands(
+    const slang::ast::BinaryExpression& bin, diag::SourceSpan span)
+    -> diag::Result<void> {
+  const bool is_case_equality =
+      bin.op == slang::ast::BinaryOperator::CaseEquality ||
+      bin.op == slang::ast::BinaryOperator::CaseInequality;
+  if (is_case_equality && (TypeHasRealLeaf(*bin.left().type) ||
+                           TypeHasRealLeaf(*bin.right().type))) {
+    return diag::Error(
+        span, diag::DiagCode::kCaseEqualityOnRealOperand,
+        "case equality (=== / !==) is not defined on real or shortreal "
+        "operands (LRM Table 11-1)");
+  }
+  return {};
+}
+
+}  // namespace
 
 auto LowerConversionExprProc(
     ProcessLowerer& proc, WalkFrame frame,
@@ -59,6 +125,9 @@ auto LowerBinaryExprProc(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::BinaryExpression& bin, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
+  if (auto check = CheckBinaryOperands(bin, span); !check) {
+    return std::unexpected(std::move(check.error()));
+  }
   auto lhs_or = proc.LowerExpr(bin.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const hir::ExprId lhs_id =
@@ -167,6 +236,9 @@ auto LowerBinaryExprStructural(
     StructuralScopeLowerer& scope, WalkFrame frame,
     const slang::ast::BinaryExpression& bin, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
+  if (auto check = CheckBinaryOperands(bin, span); !check) {
+    return std::unexpected(std::move(check.error()));
+  }
   auto lhs_or = scope.LowerExpr(bin.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const hir::ExprId lhs_id =

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -43,15 +43,17 @@ namespace {
 
 // Wrap a value type in `ObservableType` iff it is a SystemVerilog value-storage
 // data type (LRM 6.5 / 7.x). Handle / wrapper types (pointer / vector / object
-// / external ref / external unit object), named events (LRM 15 -- carry their
-// own subscribe mechanism), and presently `real` / `shortreal` / `realtime`
-// (deferred until `lyra::value::Real` lands -- see
-// `docs/decisions/value-type-concepts.md`) pass through unwrapped.
+// / external ref / external unit object) and named events (LRM 15 -- carry
+// their own subscribe mechanism) pass through unwrapped. See
+// `docs/decisions/value-type-concepts.md`.
 auto MaybeWrapObservable(ModuleLowerer& module, mir::TypeId t) -> mir::TypeId {
   const auto& data = module.Unit().GetType(t).data;
   const bool wrap = std::holds_alternative<mir::PackedArrayType>(data) ||
                     std::holds_alternative<mir::EnumType>(data) ||
                     std::holds_alternative<mir::StringType>(data) ||
+                    std::holds_alternative<mir::RealType>(data) ||
+                    std::holds_alternative<mir::ShortRealType>(data) ||
+                    std::holds_alternative<mir::RealTimeType>(data) ||
                     std::holds_alternative<mir::UnpackedArrayType>(data) ||
                     std::holds_alternative<mir::DynamicArrayType>(data) ||
                     std::holds_alternative<mir::QueueType>(data) ||

--- a/src/lyra/value/string.cpp
+++ b/src/lyra/value/string.cpp
@@ -21,8 +21,8 @@ void String::Bintoa(const PackedArray& i) {
   impl_ = std::format("{:b}", static_cast<std::uint32_t>(i.ToInt64()));
 }
 
-void String::Realtoa(double r) {
-  impl_ = std::format("{}", r);
+void String::Realtoa(const Real& r) {
+  impl_ = std::format("{}", r.Value());
 }
 
 }  // namespace lyra::value

--- a/tests/cases/cpp/array_map/case.yaml
+++ b/tests/cases/cpp/array_map/case.yaml
@@ -14,3 +14,4 @@ expect:
     fad: [8, 9, 10]
     em: []
     rowsum: [6, 9]
+    upper: ["A", "BB"]

--- a/tests/cases/cpp/array_map/main.sv
+++ b/tests/cases/cpp/array_map/main.sv
@@ -10,6 +10,7 @@ module Top;
   int fa[3] = '{7, 8, 9};
   int empty[];
   int m[][] = '{'{1, 2, 3}, '{4, 5}};
+  string names[] = '{"a", "bb"};
 
   int sum_ab[];
   bit gt[];
@@ -17,6 +18,7 @@ module Top;
   int fad[3];
   int em[];
   int rowsum[];
+  string upper[];
 
   initial begin
     // LRM 7.12.4 item.index, reaching across to a sibling array.
@@ -31,5 +33,7 @@ module Top;
     em = empty.map(x) with (x + 1);
     // The element is itself an array; the closure reduces each row.
     rowsum = m.map(row) with (row.sum());
+    // The result element type is itself a value type other than the source's.
+    upper = names.map(s) with (s.toupper());
   end
 endmodule

--- a/tests/cases/cpp/real_array/case.yaml
+++ b/tests/cases/cpp/real_array/case.yaml
@@ -1,0 +1,18 @@
+id: cpp.real_array
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      ra='{1.500000, 2.500000, 3.000000}
+      rq='{4.000000, 5.000000, 6.000000}
+      rf='{7.500000, 8.500000}
+      written='{1.500000, 9.000000, 3.000000}
+      scaled='{1.000000, 2.000000}
+      oob=0.000000
+      eq=1

--- a/tests/cases/cpp/real_array/main.sv
+++ b/tests/cases/cpp/real_array/main.sv
@@ -1,0 +1,27 @@
+module Top;
+  // LRM 7.4 / Table 6-7: `real` is a value type, so it is a legal element of an
+  // unpacked array (dynamic, queue, fixed). The OOB shield default is 0.0, and
+  // a `map()` may produce a real element from a non-real source.
+  real ra[] = '{1.5, 2.5, 3.0};
+  real rq[$] = '{4.0, 5.0};
+  real rf[2] = '{7.5, 8.5};
+  real ra2[] = '{1.5, 2.5, 3.0};
+  real written[];
+  int n[] = '{2, 4};
+  real scaled[];
+
+  initial begin
+    written = ra;
+    written[1] = 9.0;
+    rq.push_back(6.0);
+    scaled = n.map(x) with (x * 0.5);
+    $display("ra=%p", ra);
+    $display("rq=%p", rq);
+    $display("rf=%p", rf);
+    $display("written=%p", written);
+    $display("scaled=%p", scaled);
+    // LRM 7.4.5: read on an invalid index returns the element default (0.0).
+    $display("oob=%f", ra[99]);
+    $display("eq=%b", ra == ra2);
+  end
+endmodule

--- a/tests/cases/cpp/string_array/case.yaml
+++ b/tests/cases/cpp/string_array/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.string_array
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sa: ["alpha", "beta", "gamma"]
+    sq: ["one", "two", "three"]
+    sf: ["x", "y"]
+    written: ["alpha", "BETA", "gamma"]
+    oob: ""
+    eq: 1

--- a/tests/cases/cpp/string_array/main.sv
+++ b/tests/cases/cpp/string_array/main.sv
@@ -1,0 +1,22 @@
+module Top;
+  // LRM 7.4 / Table 6-7: `string` is a value type, so it is a legal element of
+  // an unpacked array (dynamic, queue, fixed). The OOB shield default is the
+  // empty string `""`.
+  string sa[] = '{"alpha", "beta", "gamma"};
+  string sa2[] = '{"alpha", "beta", "gamma"};
+  string sq[$] = '{"one", "two"};
+  string sf[2] = '{"x", "y"};
+
+  string written[];
+  string oob;
+  bit eq;
+
+  initial begin
+    written = sa;
+    written[1] = "BETA";
+    sq.push_back("three");
+    // LRM 7.4.5: read on an invalid index returns the element default ("").
+    oob = sa[99];
+    eq = (sa == sa2);
+  end
+endmodule

--- a/tests/cases/errors/real_array_case_equality_rejected/case.yaml
+++ b/tests/cases/errors/real_array_case_equality_rejected/case.yaml
@@ -1,0 +1,17 @@
+id: errors.real_array_case_equality_rejected
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "error:"
+      - "case equality"
+      - "real"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/real_array_case_equality_rejected/main.sv
+++ b/tests/cases/errors/real_array_case_equality_rejected/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  // The real-operand rejection propagates element-wise: an unpacked array with
+  // a real leaf is rejected the same as a scalar real (LRM Table 11-1).
+  real a[], b[];
+  bit r;
+  initial r = (a === b);
+endmodule

--- a/tests/cases/errors/real_case_equality_rejected/case.yaml
+++ b/tests/cases/errors/real_case_equality_rejected/case.yaml
@@ -1,4 +1,4 @@
-id: errors.real_case_equality_unsupported
+id: errors.real_case_equality_rejected
 tags: [errors, diag]
 input:
   command: [emit, cpp]
@@ -10,7 +10,8 @@ expect:
   exit: 1
   stderr:
     contains:
-      - "unsupported:"
+      - "error:"
+      - "case equality"
       - "real"
     not_contains:
       - "internal error"

--- a/tests/cases/errors/real_case_equality_rejected/main.sv
+++ b/tests/cases/errors/real_case_equality_rejected/main.sv
@@ -1,0 +1,8 @@
+module Top;
+  // LRM Table 11-1: case equality (=== / !==) is not defined on real /
+  // shortreal operands. slang accepts and evaluates it as `==`, but the backend
+  // follows the LRM strictly and rejects it in lowering.
+  real a, b;
+  bit r;
+  initial r = (a === b);
+endmodule

--- a/tests/cases/errors/real_case_equality_unsupported/main.sv
+++ b/tests/cases/errors/real_case_equality_unsupported/main.sv
@@ -1,5 +1,0 @@
-module Top;
-  real a, b;
-  bit r;
-  initial r = (a === b);
-endmodule


### PR DESCRIPTION
## Summary

Non-integral value types can now be unpacked-array elements. `string` already carried the value-type surface and only needed a canonical-default reset; `real` / `shortreal` / `realtime` were bare host `double` / `float` and are now backed by a single `lyra::value::Real` value type (with `RealTime` an alias of `Real`), after which they fall out as array elements and observable signals through the same shield pattern as every other element type. The `map()` projection can now produce a `string` result element.

## Design

LRM Table 11-1 excludes `real` / `shortreal` from case equality (`===` / `!==`). slang and Verilator accept the form and evaluate it as a value comparison, but that is a documented deviation from the standard: a real has no x/z plane, so the bit-by-bit match LRM 12.5 specifies has no single correct reading -- a bit-pattern match makes `+0.0 === -0.0` false and `NaN === NaN` true, while a value match makes them true and false respectively, and the LRM declines to pick. The backend follows the LRM strictly and rejects `===` / `!==` on any real operand -- scalar or an aggregate with a real leaf -- with an error in HIR-to-MIR lowering, so the render path stays purely mechanical. The real-leaf check recurses unpacked array elements and unpacked struct / union members, so it stays correct as those container types are supported.

## Testing

Added end-to-end cases for `string` and `real` array elements (declaration, read / write, OOB default, equality, `%p`) and the `map()` result element, plus error cases asserting `===` rejection on scalar and array real operands. Full `bazel test //...` passes.