### PR TITLE
Confirm two-name array iterator and index argument form

### DIFF
--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -30,7 +30,7 @@ follow once dynamic array's storage and runtime conventions are settled and prov
 | DA6c | Done: locator family (find\*, min, max, unique\*).                      |
 | DA6d | Done: `map` projection (LRM 7.12.5) on the sequence containers.         |
 | DA6e | Open: `shuffle` (LRM 7.12.2); needs a seeded simulation RNG.            |
-| DA6f | Open: two-name iterator / index argument form (LRM 7.12.4).             |
+| DA6f | Done: two-name iterator / index argument form (LRM 7.12.4).             |
 | DA6g | Done: `string` / `real` / `shortreal` as an unpacked-array element.     |
 | DA7  | Done: invalid-index handling.                                           |
 | Q1   | Done: type, element read/write, native methods, default, case-equality. |
@@ -127,10 +127,14 @@ The numeric IDs are stable references and do not imply execution order beyond DA
       simulation state rather than being a pure function of its receiver, so it also introduces
       threading that state into an array-method call.
 
-- [ ] DA6f -- The two-name iterator / index argument form of the LRM 7.12 family
+- [x] DA6f -- The two-name iterator / index argument form of the LRM 7.12 family
       (`a.method(item, idx) with (...)`, LRM 7.12.4), which renames the iterator and the index-query
-      method to avoid clashes with member names of the stored elements. Shared across find / sort /
-      map / reductions; none support it yet.
+      method to avoid clashes with member names of the stored elements. The frontend normalizes the
+      form away: the renamed iterator flows through as the with-clause iterator name, and a renamed
+      index method resolves back to the canonical index query, so the existing closure synthesis
+      handles it with no new lowering. Shared across find / sort / map / reductions. The clash it
+      exists to resolve only arises once an element type has its own members (struct / class /
+      union), which the array-method family does not yet take.
 
 - [x] DA6g -- `string`, `real`, and `shortreal` as unpacked-array elements (dynamic array, queue,
       fixed unpacked): declaration, element read / write, the element-type OOB default (LRM Table

--- a/tests/cases/cpp/dynamic_array_method_with_index/case.yaml
+++ b/tests/cases/cpp/dynamic_array_method_with_index/case.yaml
@@ -10,3 +10,4 @@ expect:
   variables:
     weighted_sum: 80
     first_two_sum: 30
+    weighted_sum_renamed: 80

--- a/tests/cases/cpp/dynamic_array_method_with_index/main.sv
+++ b/tests/cases/cpp/dynamic_array_method_with_index/main.sv
@@ -2,6 +2,7 @@ module Top;
   int arr [];
   int weighted_sum;
   int first_two_sum;
+  int weighted_sum_renamed;
 
   initial begin
     arr = new[4];
@@ -14,5 +15,9 @@ module Top;
     // LRM 7.12.4 `item.index`: only the first two elements (index < 2)
     // contribute: 10 + 20 = 30.
     first_two_sum = arr.sum with (item.index < 2 ? item : 0);
+    // LRM 7.12.4 two-name iterator/index argument form: rename the iterator to
+    // `val` and the index method to `pos`. Same semantics as the default-name
+    // form, so this matches `weighted_sum` at 80.
+    weighted_sum_renamed = arr.sum(val, pos) with (val * val.pos);
   end
 endmodule


### PR DESCRIPTION
## Summary

The LRM 7.12.4 two-name iterator/index argument form (`a.method(item, idx) with (...)`) renames the with-clause iterator and the index-query method to avoid clashes with the stored element type's own members. This form already works end to end with no new lowering, because the boundary it needs lives entirely on the closure call side. slang's frontend normalizes the form away: a renamed iterator flows through as the with-clause iterator name, and a renamed index method resolves back to the canonical index query during member-access resolution. Lyra's existing closure synthesis already reads the actual iterator name from the with-clause rather than assuming `item`, and already routes every index access through the closure's index binding regardless of the source name, so the renamed variations collapse onto the same machinery.

This change locks that behavior with a regression test and marks DA6f done. The clash the form exists to resolve only arises once an element type carries its own members (struct / class / union), which the array-method family does not yet take, so there is nothing to revisit when those land.

## Testing

Extended the existing LRM 7.12.4 iterator-index case with a two-name assertion (`arr.sum(val, pos) with (val * val.pos)`) that matches the default-name result, grouping the coverage by concept rather than adding a new case.