### PR TITLE
Model references as a RefType data type

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -19,19 +19,20 @@ Read top to bottom on first pass:
 5. `specialization_model.md` -- how parameter values refine a unit into specializations
 6. `hir.md` -- source-near semantic IR
 7. `mir.md` -- object-oriented semantic IR (objects, members, callables)
-8. `lir.md` -- execution-oriented IR (CFG, basic blocks, storage)
-9. `scheduling.md` -- stratified event scheduler, regions, suspension protocol
-10. `hierarchy_and_generate.md` -- hierarchy and generate ownership
-11. `reference_resolution.md` -- intra-unit vs cross-unit references; compile-time vs
+8. `closure.md` -- the captured callable value; capture model; references as a field type
+9. `lir.md` -- execution-oriented IR (CFG, basic blocks, storage)
+10. `scheduling.md` -- stratified event scheduler, regions, suspension protocol
+11. `hierarchy_and_generate.md` -- hierarchy and generate ownership
+12. `reference_resolution.md` -- intra-unit vs cross-unit references; compile-time vs
     construction-time resolution
-12. `emission_model.md` -- how a backend emits independent per-unit artifacts and realizes
+13. `emission_model.md` -- how a backend emits independent per-unit artifacts and realizes
     cross-unit resolution through the SDK
-13. `identity_and_ownership.md` -- identity rules and forbidden shapes
-14. `lowering_boundaries.md` -- what each lowering may and may not do
-15. `lowering_organization.md` -- how lowering passes organize their internal objects (facts,
+14. `identity_and_ownership.md` -- identity rules and forbidden shapes
+15. `lowering_boundaries.md` -- what each lowering may and may not do
+16. `lowering_organization.md` -- how lowering passes organize their internal objects (facts,
     registries, builders, walk frame)
-16. `incremental_build.md` -- query-based incremental compilation and caching
-17. `testing_strategy.md` -- test categories and structure
+17. `incremental_build.md` -- query-based incremental compilation and caching
+18. `testing_strategy.md` -- test categories and structure
 
 ## Concept Index
 
@@ -53,8 +54,9 @@ If you are looking for a concept, this table points to the canonical doc.
 | Lowering permissions (what each lowering may and may not do)              | `lowering_boundaries.md`    |
 | Lowering pass organization (facts / registry / builder / walk frame)      | `lowering_organization.md`  |
 | HIR shape (statements, expressions, primaries)                            | `hir.md`                    |
-| MIR shape (objects, members, callables, closures)                         | `mir.md`                    |
+| MIR shape (objects, members, callables)                                   | `mir.md`                    |
 | Member and type model; object types; owning pointer; vector wrapper       | `mir.md`                    |
+| Closure model; captures; by-value vs by-reference as a field type         | `closure.md`                |
 | LIR shape (CFG, basic blocks, storage)                                    | `lir.md`                    |
 | Stratified scheduler; regions; suspension protocol; NBA / closure submit  | `scheduling.md`             |
 | Incremental compilation; query-based caching                              | `incremental_build.md`      |

--- a/docs/architecture/closure.md
+++ b/docs/architecture/closure.md
@@ -1,0 +1,142 @@
+# Closure
+
+## Purpose
+
+A closure is MIR's one shape for "a body bound to its environment, run later." It is a first-class
+callable value with four parts: a list of captured fields, a list of per-invocation parameters, a
+result type, and a procedural-scope body. HIR-to-MIR synthesizes closures to model every
+SystemVerilog construct that defers a body, runs it concurrently, or runs it once per element -- a
+fork-join branch (LRM 9.3.2), a non-blocking assignment, a postponed `$strobe`, a `$sscanf`
+write-back, a with-clause iterator (LRM 7.12), a deferred assertion action. No SystemVerilog source
+construct is itself a closure; the closure is the lowering's encoding.
+
+A closure is a value: it is built, held, and later invoked. What a closure _is_ does not depend on
+who invokes it. How it is invoked -- spawned as a concurrent process, submitted to a scheduling
+region, called once per array element -- lives at the referencing site, not on the closure.
+
+## Owns
+
+- The closure value: its captured fields, its parameters, its result type, its body.
+- The capture model: how a body reaches the environment it was built in.
+- The snapshot-versus-alias distinction for a captured field -- carried by the field's type, not by
+  a separate axis.
+
+## Does Not Own
+
+- Whether and how a closure is spawned, submitted, or iterated. That is the referencing site's
+  concern; `scheduling.md` owns spawn and submission.
+- The suspension protocol of a coroutine body (`scheduling.md`).
+- The runtime realization of a reference cell or an observable cell. A reference type and an
+  observable type are library wrappers named by MIR types and rendered by a backend; their mechanics
+  belong to the runtime, not to the closure.
+- The `self` receiver model in general -- shared with every callable form (`mir.md` invariant 11).
+
+## Core Invariants
+
+Each invariant is a consequence of the closure's identity: a value that owns what its body needs,
+run later and possibly elsewhere, possibly after the frame that built it is gone.
+
+1. **A closure is synthesized only by HIR-to-MIR.** No SystemVerilog source construct lowers to a
+   closure literal; the capture list, parameter list, result type, and body are all
+   compiler-generated. _Consequence: a reader never maps a closure back to source syntax; it is
+   always the lowering's encoding of a deferred / concurrent / iterated body._
+
+2. **A closure owns everything its body needs; the body reaches the environment only through
+   captures and parameters.** A closure value can outlive the frame that built it -- a spawned
+   branch runs after its parent returns, a submitted effect runs in a later region. A body that
+   reached back into that frame would read storage that may be gone. So the body reads outer state
+   only through its own captured fields and its parameters; a `ProceduralVarRef` inside the body
+   stays within the body's own scope nesting and never climbs into the enclosing process scope.
+   _Consequence: the body is self-contained -- its meaning depends on its captures and parameters,
+   not on where it was built._
+
+3. **Whether a captured field is a snapshot or an alias is the field's type, not a separate capture
+   kind.** A closure owns its captured fields. A field whose type is a value type `T` is an
+   independent snapshot taken at construction: later changes to the source are not seen, and the
+   body's writes do not propagate. A field whose type is a reference type aliases the enclosing
+   storage cell: reads see the current value and writes propagate (LRM 6.21). There is one capture
+   mechanism -- the closure owns a field -- and the field's type alone decides snapshot versus
+   alias. _Consequence: there is no "by-value capture" versus "by-reference capture" node kind and
+   no flag beside a field naming its mode; the type carries it. A closure is a struct of owned
+   fields -- a snapshot field has a value type, an alias field has a reference type._
+
+4. **`self` is the first captured field.** Every callable body reaches its enclosing object's
+   members through `self` (`mir.md` invariant 11); a closure carries `self` as `captures[0]`, the
+   enclosing scope's own receiver snapshotted at construction. _Consequence: a closure reaches class
+   state exactly as any callable does, with no special form._
+
+5. **Coroutine-ness is the result type, not a flag.** A closure whose body suspends (a fork-join
+   branch) is a coroutine, and its result type is the coroutine type -- the value its invocation
+   yields. A closure whose body runs to completion has a plain result type (a value, or void). The
+   decision is made at HIR-to-MIR, where the referencing construct is known, and is carried as the
+   closure expression's type. _Consequence: a backend reads "is this a coroutine" from the result
+   type, never from a separate flag and never by scanning the body._
+
+## Boundary to Adjacent Layers
+
+- HIR-to-MIR synthesizes closures and fixes their captures, parameters, result type, and body. The
+  decisions "this body is a coroutine" and "this field aliases" are made here, where the source
+  construct is known, and are recorded in structure -- the result type and the field type
+  respectively, never as side flags.
+- The referencing site decides invocation: a fork statement spawns each branch closure as a
+  concurrent process; a deferred-assignment site submits a closure to a scheduling region; an
+  array-method site iterates a closure. The closure does not know which.
+- A backend realizes the closure from its captures, parameters, result type, and body alone, by a
+  fixed function of each node's kind and type: it reads a field's type to know snapshot versus
+  alias, and the result type to know coroutine versus synchronous.
+- `scheduling.md` owns spawning, submission, and the suspension protocol; the closure is the unit
+  those mechanisms carry.
+
+## Forbidden Shapes
+
+- **A "suspends" / "is-coroutine" flag on the closure node.** Coroutine-ness is already the result
+  type (invariant 5); a flag restates a fact the structure fixes, and two facts that must agree
+  drift apart under maintenance.
+
+- **A capture-kind axis beside the field type** -- a `by_reference` flag, or distinct
+  by-value-capture and by-reference-capture node kinds. Snapshot-versus-alias is the field's type
+  (invariant 3); a parallel axis is the redundant-field shape, and it can contradict the type (a
+  field typed as a value but flagged an alias). One source: the field type.
+
+- **A body that reaches an enclosing procedural variable by hopping out of the closure's own
+  scope.** The frame may be gone when the body runs (invariant 2); outer storage reaches the body
+  only as a captured field.
+
+- **A backend that constructs the reference wrapper itself** -- synthesizing `Ref<T>(...)` from a
+  flag, or from "this operand looks like an lvalue" -- instead of reading the field's reference
+  type. The decision that a field aliases is made at HIR-to-MIR and carried in the field's type; a
+  backend that re-derives it is inventing a library shape, which `mir.md` invariant 10 forbids. The
+  wrapper appears because the field's type is a reference type and the backend renders that type.
+
+## Notes / Examples
+
+Closures across languages share the same core and differ only at the edges, which is why the model
+above is not specific to the C++ backend.
+
+- C++ lambdas capture per variable: `[x]` makes the closure own a copy of `x`; `[&x]` makes it own a
+  reference to `x`. Both are owned fields; the field's type (`T` versus `T&`) is the only
+  difference. `[&x]` is sugar that hides the reference field.
+- Rust closures are structs of owned captured fields; a field's type is `T` (a by-value / move
+  capture) or `&T` / `&mut T` (a borrow). `move` forces ownership. By-value versus by-reference is
+  the field type.
+- Python, JavaScript, and TypeScript closures have one mode: they close over the enclosing
+  variable's cell, always a reference to the binding. They have no by-value capture, because a
+  garbage-collected language with no manual lifetimes keeps a cell alive for as long as a closure
+  refers to it, so there is never a lifetime reason to snapshot.
+
+The by-value/by-reference distinction is a property of value-semantic, lifetime-managed languages
+(C++, Rust); garbage-collected languages collapse it to "always reference the cell." SystemVerilog
+is value-semantic -- a variable holds a value and assignment copies -- so a captured snapshot (a
+value-typed field) is the default, and an alias (a reference-typed field) is the explicit case used
+when a body must share mutable storage with its environment: a fork branch writing a variable its
+parent reads, a `$sscanf` write-back, the `self` receiver into the shared object.
+
+The C++ backend renders every capture as a by-value lambda capture `[name = <init>]`; it never uses
+`[&name]`, `[=]`, or `[this]`. This is a rendering choice with two reasons, not a MIR-level concept.
+First, a `[&name]` reference dangles once the closure outlives the captured variable's frame, which
+a fork-branch coroutine and a deferred-effect closure routinely do; an owned reference value whose
+pointee is long-lived storage (a module signal, a static local) does not. Second, the reference
+wrapper routes a write through the cell's update-event path -- writing a signal through it still
+wakes the signal's subscribers -- which a bare `T&` would bypass. So an alias field renders as an
+owned reference value, not a hidden C++ reference; at the MIR level it is simply a captured field
+whose type is a reference type.

--- a/docs/architecture/mir.md
+++ b/docs/architecture/mir.md
@@ -129,10 +129,11 @@ suspect, not the analysis (`lowering_organization.md` states this discipline in 
     Where `self`'s value comes from differs by callable form, following the natural binding shape of
     each: process, structural subroutine, and constructor bodies receive `self` as their first
     formal parameter (each caller -- the runtime, a call site, the instance constructor -- supplies
-    it); a closure receives `self` as its first by-value capture (the enclosing scope snapshots its
-    own self at closure construction, because no runtime invoker of the closure value knows which
-    receiver to pass). Both supply mechanisms land the same binding at `body.vars[0]`; the body code
-    does not know or care which mechanism filled it. See `docs/decisions/callable-receiver.md`.
+    it); every closure -- including a fork branch -- carries `self` as its first by-value capture
+    (the enclosing scope snapshots its own `self` at construction, because no later invoker of the
+    closure value can be relied on to know the receiver). Both supply mechanisms land the same
+    binding at `body.vars[0]`; the body code does not know or care which one filled it. See
+    `docs/decisions/callable-receiver.md`.
 
     _Programming-language consequence: methods take `self` explicitly. This is the C++ `this`, the
     Python `self`, the Rust `&self`. Languages that hide it behind keyword sugar at source level
@@ -241,23 +242,19 @@ expression set that decomposes the ternary. Value-build primitives for aggregate
 expressions are access primitives. Each of these stays in MIR for the same reason: removing it would
 require expanding into a statement-form rewrite that does not fit the expression context.
 
-A closure is a captured callable value: a parameter list, a capture list, and a procedural-scope
-body, the one IR shape for "a body bound to a snapshot of its environment, run later." A closure is
-synthesized only by HIR-to-MIR lowering; no source construct produces one. Its body reaches every
-value it needs through its captures and parameters -- captures snapshot the enclosing scope's values
-at construction (including `self`, captured by value as the first capture; see invariant 11),
-parameters carry per-invocation values. Nothing reaches the body implicitly. The closure node
-carries nothing about how it executes: like a language-level lambda, it has no "suspends" property.
-Whether a closure runs synchronously or as a coroutine follows from its use, which is itself
-explicit in MIR -- a closure submitted as a deferred effect (a non-blocking assignment, a postponed
-`$strobe`) runs to completion in a later scheduling region; a closure referenced by a parallel block
-(a fork-join branch, LRM 9.3.2) is spawned as a concurrent process and therefore a coroutine. The
-capture model and the body are identical across both. Process, structural subroutine, and closure
-are three callable forms whose bodies are all the same procedural scope; they differ in how each is
-invoked and in how `self` is supplied -- a process / subroutine / constructor body receives `self`
-as its first formal parameter at every invocation, a closure captures `self` by value at
-construction. Both supply paths end at the same place: `body.vars[0]` is `self`, read identically by
-every member access in the body.
+A closure is a captured callable value: a capture list, a parameter list, a result type (the closure
+expression's own type), and a procedural-scope body. It is the one IR shape for "a body bound to its
+environment, run later," synthesized only by HIR-to-MIR. `closure.md` is the canonical contract: the
+capture model, snapshot-versus-alias as a captured field's type, and coroutine-ness as the result
+type all live there.
+
+Process, structural subroutine, and closure are three callable forms whose bodies are all the same
+procedural scope; they differ in how each is invoked and in how `self` is supplied. A process /
+subroutine / constructor body receives `self` as its first formal parameter at every invocation.
+Every closure -- including a fork branch -- carries `self` as its first by-value capture
+(`captures[0]`): the enclosing scope snapshots its own `self` at construction, because no later
+invoker of the closure value can be relied on to know the receiver. Both supply paths end at the
+same place: `body.vars[0]` is `self`, read identically by every member access in the body.
 
 An access through a runtime library wrapper type illustrates the boundary between MIR's vocabulary
 and a backend's storage realization. The C++ backend wraps an observable signal's storage in

--- a/docs/decisions/callable-receiver.md
+++ b/docs/decisions/callable-receiver.md
@@ -53,11 +53,12 @@ shape:
   supplies it at invocation. The body's binding is filled by the call.
 - **Closure** carries `self` as the first by-value capture (`captures[0]` is a `ByValueCapture`
   whose `value` is the enclosing scope's read of its own `self` and whose `binding` points at the
-  closure body's `vars[0]`). No invoker of a closure value -- the NBA / postponed-`$strobe` /
-  deferred-check region runner, the fork scheduler, the with-clause iterator, an IIFE call site --
-  can be relied on to know which receiver belongs in the body, because a closure value can outlive
-  the enclosing-scope frame that knows. The enclosing scope snapshots its own `self` into the
-  closure at construction; the closure body reads the captured value.
+  closure body's `vars[0]`). This holds for every closure form, the fork branch included. No invoker
+  of a closure value -- the NBA / postponed-`$strobe` / deferred-check region runner, the fork
+  scheduler, the with-clause iterator -- can be relied on to know which receiver belongs in the
+  body, because a closure value can outlive the enclosing-scope frame that knows. The enclosing
+  scope snapshots its own `self` into the closure at construction; the body reads the captured
+  value.
 
 This partition is not a stylistic choice -- it follows from "who knows the receiver?". A method-form
 callable has a caller-who-knows; a closure does not. Forcing both forms onto one supply mechanism
@@ -75,9 +76,13 @@ The C++ backend renders each form in its natural idiom:
   The class still owns the storage; the method body lives on the class so it can name private
   members. The body sees `self->X`, never implicit `this`.
 - **Closure** -> lambda whose capture clause is
-  `[self = <enclosing self expr>, cap1 = ..., &cap2 = ...]`. Every capture is name-explicit; the
+  `[self = <enclosing self expr>, cap1 = ..., cap2 = lyra::runtime::Ref<T>(<lvalue>)]` -- a
+  by-reference capture binds a `Ref<T>` rather than a snapshot. Every capture is name-explicit; the
   clause never contains `[this]`, `[=]`, or `[&]`. The body sees `self->X` through the captured
-  binding, never implicit `this`.
+  binding, never implicit `this`. A coroutine closure (a fork branch) is realized as a stateless
+  lambda whose captures pass as frame-copied parameters supplied by an immediate call -- a backend
+  realization of the same captures, since a capturing coroutine lambda would dangle; the MIR closure
+  still carries `self` and the rest as captures.
 
 The constructor body is the only callable whose corresponding C++ entry cannot be static (the real
 C++ constructor must be an instance constructor for instance creation to work). The constructor body
@@ -160,9 +165,10 @@ binding pushes the answer up to one place that every backend just reads.
   structural scope. The binding's name is `self`; the type makes the pointee unambiguous.
 
 - For method-form callables (process, subroutine, constructor body) the `self` binding is the first
-  formal parameter; the caller supplies it at invocation. For a closure, the `self` binding is the
-  first by-value capture (`captures[0]`); the enclosing scope's read of its own `self` supplies the
-  capture value at construction.
+  formal parameter; the caller supplies it at invocation. For a closure -- every closure, the fork
+  branch included -- the `self` binding is the first by-value capture (`captures[0]`); the enclosing
+  scope's read of its own `self` supplies the capture value at construction. Both land at
+  `body.vars[0]`.
 
 - A new MIR expression `MemberAccessExpr { receiver: ExprId, var: StructuralVarRef-fields }`
   replaces today's implicit-receiver `StructuralVarRef`. The receiver expression is rendered before
@@ -177,9 +183,10 @@ binding pushes the answer up to one place that every backend just reads.
 - C++ emit shape changes: process / subroutine / constructor bodies emit as
   `static auto <name>(M* self, ...) -> ... { ... }`; the C++ constructor delegates the body to a
   static `init(this)` call. Closures emit as
-  `[self = <enclosing self expr>, cap1 = ..., &cap2 = ...](closure_params) -> R { ... }` -- every
-  capture is name-explicit; the clause never contains `[this]`, `[=]`, or `[&]`. `CreateProcesses()`
-  adapts: where it previously emitted `AddProcess(kind, process_N())` it now emits
+  `[self = <enclosing self expr>, cap1 = ..., cap2 = <reference value>](closure_params) -> R { ... }`
+  -- every capture is name-explicit and by-value; an alias capture binds a reference value, never a
+  C++ `[&]` reference (see `docs/architecture/closure.md` for why). `CreateProcesses()` adapts:
+  where it previously emitted `AddProcess(kind, process_N())` it now emits
   `AddProcess(kind, process_N(this))`.
 
 - LIR / LLVM-IR lowering reads the `self` binding directly off MIR. No backend re-derives receiver
@@ -191,5 +198,7 @@ binding pushes the answer up to one place that every backend just reads.
 
 ## Cross-references
 
+- `docs/architecture/closure.md` (closure model: capture, references as a field type,
+  coroutine-ness)
 - `docs/architecture/mir.md` (callable shape, expression set)
 - `docs/progress/refactor.md` R16

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -142,26 +142,22 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       separate types whose bodies are all the same `ProceduralScope`; the code already notes the
       duplication ("a subroutine is a callable peer of a process"). Each hardcodes a fixed point in
       three orthogonal axes: how the body binds outer state (the enclosing object only / named
-      parameters / captured values), whether the body suspends (coroutine vs plain), and whether it
-      is an anonymous value or a named declaration. The combinations in use today are partial --
-      process is (object-only, suspends, value-spawned-at-startup), function is (params, no-suspend,
-      named, returns), task is (params, suspends, named), closure is (captures, no-suspend,
-      anonymous value). A fork-join branch is the missing fourth-axis combination -- an anonymous
-      value, with captured state, that suspends -- which no form provides. This cut fills it the
-      minimal way, by completing `ClosureExpr` with a suspend axis (so a closure value may be
-      suspending or not), which unifies the NBA / `$strobe` closure and the fork branch under one
-      type but leaves the three-way duplication between process, subroutine, and closure standing.
-      Target shape: a single callable concept carrying a `ProceduralScope` body, a list of bound
-      inputs that unifies parameters and captures behind one binding-mode axis, a suspend flag, and
-      an optional result type; the five forms become instances differing only in their axis values
-      and in how the referencing site invokes them (spawn at startup, call, submit, spawn
-      concurrently). **Why deferred**: this rebases the whole process / subroutine / closure
-      machinery across lowering, MIR, the dumper, and the backend; the fork cut needs only the
-      suspend axis on `ClosureExpr` and reaches it without touching processes or subroutines, so
-      folding the full merge into a feature cut is scope explosion. **Trigger**: when a further
-      feature needs yet another axis combination, or when a change has to be made three times across
-      the duplicated forms; the suspending closure this cut introduces is the first concrete
-      cross-form driver, so the unification now has a real motivation rather than being speculative.
+      parameters / captured values), whether the body is a coroutine, and whether it is an anonymous
+      value or a named declaration. The combinations in use today are partial -- process is
+      (object-only, coroutine, value-spawned-at-startup), function is (params, plain, named,
+      returns), task is (params, coroutine, named), closure is (captures or params, anonymous
+      value). A fork-join branch is a closure with a coroutine result type, distinguished from a
+      synchronous closure by that type, not by a flag on the node -- so a closure already spans both
+      coroutine and plain without a suspend axis. Target shape: a single callable concept carrying a
+      `ProceduralScope` body, a list of bound inputs that unifies parameters and captures behind one
+      binding-mode axis, and a result type (the coroutine type when the body suspends); the five
+      forms become instances differing only in their axis values and in how the referencing site
+      invokes them (spawn at startup, call, submit, spawn concurrently). **Why deferred**: this
+      rebases the whole process / subroutine / closure machinery across lowering, MIR, the dumper,
+      and the backend; the fork work needed only a coroutine result type on the closure and reached
+      it without touching processes or subroutines, so folding the full merge in would be scope
+      explosion. **Trigger**: when a further feature needs yet another axis combination, or when a
+      change has to be made three times across the duplicated forms.
 
 - [x] R9 -- AST-to-HIR migration to the class-based organization defined in
       `docs/architecture/lowering_organization.md`. The `*LoweringState` god-objects are gone;
@@ -201,31 +197,27 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       (see R18). The mutable escape hatch is the one shape that is unambiguously wrong from any
       vantage. **Trigger**: standalone -- can be picked up at any time.
 
-- [ ] R12 -- Model the observable (`Var<T>`) storage as a first-class MIR wrapper type so the cpp
-      backend stops re-deriving "is this observable storage" at render time. Today a signal's MIR
-      type is its value type (`PackedArray`, `string`, ...); whether the field is stored as
-      `lyra::runtime::Var<T>` is a backend predicate (`IsObservableScalarType`) computed at render
-      and consulted at every value access -- the field declaration wraps in `Var<T>`, a read appends
-      `.Get()`, a write routes through `.Set()` / `.Mutate()`, and sensitivity subscribes to the
-      cell. `Var<T>` is a template storage wrapper exactly analogous to the `unique_ptr` / `vector`
-      wrappers MIR already models as `PointerType` / `VectorType`, yet it has no MIR type of its
-      own, so the backend keeps asking the value type "are you observable?" in several places
-      instead of reading a concept off the type. Target shape: a first-class observable wrapper type
-      in MIR (sibling to `PointerType` / `VectorType`); a signal field's type becomes that wrapper,
-      `RenderTypeAsCpp` maps it straight to `Var<T>`, and every value access becomes a mechanical
-      switch on the wrapper variant (a read unwraps to the value type, a write targets the cell)
-      rather than an `IsObservableScalarType` call. The one wrinkle the pointer / vector wrappers do
-      not have is the value/storage duality -- a signal is also read as a value, so the wrapper read
-      must unwrap to `T` -- which the read / write nodes resolve by switching on the wrapper type.
-      The backend then never asks "is this observable" anywhere; the type carries it, and render is
-      a pure structural map. **Why deferred**: orthogonal to the cross-unit hierarchical-reference
-      work in flight; it cross-cuts all signal value access (field declaration, read, write,
-      sensitivity) and is its own focused cut, and the current predicate is behaviorally correct.
+- [ ] R12 -- A signal read / write is an explicit access call in MIR, not a render-time decision.
+      The observable-storage wrapper is already a first-class MIR type (sibling to the
+      owning-pointer and vector wrappers): a signal field's type is the wrapper and
+      `RenderTypeAsCpp` maps it straight to `lyra::runtime::Var<T>`. What remains is the access
+      half. The wrapper's `Get` / `Set` / `Mutate` are still injected by the backend -- a value read
+      appends `.Get()`, a write routes through `.Set()` / `.Mutate()`, each gated on the backend
+      reading the wrapper type at the access site. Per the mir.md boundary note these are
+      library-API method calls and belong in MIR: HIR-to-MIR should emit a `Get` call for a value
+      read and a `Set` / `Mutate` call for a write, so the backend renders the call like any other
+      and never asks "is this observable" at access time. The value/storage duality -- a signal is
+      read as a value but its cell is the target of a write or a reference binding -- is then
+      carried by which call wraps the cell, not by a render-time branch. **Known consequence
+      today**: pass-by-reference of an observable scalar (LRM 13.5.2) needs the bare cell, not a
+      value read, so its argument is currently routed through a backend lvalue render to dodge the
+      injected `.Get()`; once reads are explicit calls a bare cell renders directly and that route
+      collapses. **Why deferred**: cross-cuts all signal value access (read, write, sensitivity) and
+      is its own focused cut, and the current render-time decision is behaviorally correct.
       **Trigger**: standalone -- highest leverage taken together with R2, which reworks the same
-      `IsObservableScalarType` decision from the capability-gating angle (wrap every value type
-      uniformly, push unsupported change-tracking to explicit diagnostics). R12 makes the wrapper a
-      type; R2 makes the wrap uniform and capability-honest -- done together they remove
-      `IsObservableScalarType` entirely and leave the backend a pure renderer.
+      observable decision from the capability-gating angle (wrap every value type uniformly, push
+      unsupported change-tracking to explicit diagnostics). Done together they leave the backend a
+      pure renderer of explicit calls.
 
 - [x] R13 -- HIR-to-MIR per-LRM-family subsystem split. Per-kind handlers are now grouped by
       semantic family in

--- a/include/lyra/lowering/hir_to_mir/capture_sink.hpp
+++ b/include/lyra/lowering/hir_to_mir/capture_sink.hpp
@@ -1,24 +1,29 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "lyra/lowering/hir_to_mir/procedural_depth.hpp"
+#include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/procedural_var.hpp"
 #include "lyra/mir/stmt.hpp"
 
+namespace lyra::mir {
+class CompilationUnit;
+}  // namespace lyra::mir
+
 namespace lyra::lowering::hir_to_mir {
 
 // One captured variable, identified while a closure body is lowered. The sink
-// has already allocated `binding` in the body and rewritten the body's
-// references to read it; `source` reaches the captured variable from the
-// enclosing scope and is the same expression whichever way the caller uses it
-// (aliased for a by-reference capture, read for a by-value one). `decl_depth`
-// is the captured variable's declaration depth -- the metadata a caller reads
-// to decide the capture kind. Turning a request into a `mir::Capture` is the
-// caller's job; the sink never decides by value versus by reference.
+// has allocated `binding` in the body and rewritten the body's references to
+// read it; `source` is the enclosing-scope expression bound into the closure --
+// a plain read of the captured variable for a by-value snapshot, or a
+// reference-construct (`Ref<T>`) for a by-reference alias. The caller binds
+// `source` to `binding` uniformly; the snapshot-versus-alias choice is already
+// realized in `binding`'s type and in `source`.
 struct CaptureRequest {
   mir::ProceduralVarId var;
   ProceduralDepth decl_depth;
@@ -27,22 +32,29 @@ struct CaptureRequest {
 };
 
 // Identity-only capture collector for a closure body. Installed on
-// ProcessLowerer for the duration of a single closure construction:
-// during the body's lowering, any procedural-var reference that resolves above
-// the sink's boundary is rerouted here -- a binding in the body scope is
-// allocated (deduplicated by identity), the reference is rewritten to read that
-// binding, and a CaptureRequest is recorded. The sink never inspects how the
-// reference is used or which storage the capture should hold; that is the
-// caller's concern. A fork branch snapshots its block_item_declarations by
-// value and aliases enclosing-process variables by reference; the
-// `$sscanf` / `$fscanf` sync IIFE aliases everything by reference -- each reads
-// the requests and assembles its own captures.
+// ProcessLowerer for the duration of a single closure construction: during the
+// body's lowering, any procedural-var reference that resolves above the sink's
+// boundary is rerouted here -- a binding in the body scope is allocated
+// (deduplicated by identity), the reference is rewritten to read that binding,
+// and a CaptureRequest is recorded. A capture declared at `by_value_depth` is a
+// by-value snapshot (a value-typed binding); any other capture aliases the
+// enclosing storage, so its binding is a `RefType` and its `source` is a
+// reference-construct, and the body's reads / writes route through the live
+// cell (LRM 6.21). A fork branch passes its block_item_declaration depth (those
+// locals snapshot; deeper enclosing variables alias); the `$sscanf` / `$fscanf`
+// sync IIFE and the with-clause body pass no by-value depth (every capture
+// aliases).
 class CaptureSink {
  public:
   CaptureSink(
       ProceduralDepth boundary_depth, mir::ProceduralScope& body,
-      mir::ProceduralScope& outer)
-      : boundary_depth_(boundary_depth), body_(&body), outer_(&outer) {
+      mir::ProceduralScope& outer, mir::CompilationUnit& unit,
+      std::optional<ProceduralDepth> by_value_depth = std::nullopt)
+      : boundary_depth_(boundary_depth),
+        body_(&body),
+        outer_(&outer),
+        unit_(&unit),
+        by_value_depth_(by_value_depth) {
   }
 
   [[nodiscard]] auto BoundaryDepth() const -> ProceduralDepth {
@@ -72,18 +84,30 @@ class CaptureSink {
         return request.binding;
       }
     }
-    const mir::ProceduralVarId binding = body_->AddProceduralVar(
-        mir::ProceduralVarDecl{
-            .name = "_lyra_cap_" + std::to_string(requests_.size()),
-            .type = type});
-    // The source is evaluated one scope outside the body (where the capture is
-    // spawned), so its hops run from there down to the variable.
-    const mir::ExprId source = outer_->AddExpr(
+    // The cell read is evaluated one scope outside the body (where the capture
+    // is spawned), so its hops run from there down to the variable.
+    const mir::ExprId cell = outer_->AddExpr(
         mir::Expr{
             .data =
                 mir::ProceduralVarRef{
                     .hops = boundary_depth_.Outer() - decl_depth, .var = var},
             .type = type});
+    const std::string name = "_lyra_cap_" + std::to_string(requests_.size());
+    mir::ProceduralVarId binding{};
+    mir::ExprId source{};
+    if (by_value_depth_ == decl_depth) {
+      // By-value snapshot: the binding owns a copy; the source is the read.
+      binding = body_->AddProceduralVar(
+          mir::ProceduralVarDecl{.name = name, .type = type});
+      source = cell;
+    } else {
+      // By-reference alias: the source constructs a reference to the cell and
+      // the binding holds that reference (its `RefType`).
+      source = BuildReferenceArg(*unit_, *outer_, cell, type);
+      binding = body_->AddProceduralVar(
+          mir::ProceduralVarDecl{
+              .name = name, .type = outer_->GetExpr(source).type});
+    }
     requests_.push_back(
         CaptureRequest{
             .var = var,
@@ -96,6 +120,8 @@ class CaptureSink {
   ProceduralDepth boundary_depth_;
   mir::ProceduralScope* body_;
   mir::ProceduralScope* outer_;
+  mir::CompilationUnit* unit_;
+  std::optional<ProceduralDepth> by_value_depth_;
   std::vector<CaptureRequest> requests_;
 };
 

--- a/include/lyra/lowering/hir_to_mir/default_value.hpp
+++ b/include/lyra/lowering/hir_to_mir/default_value.hpp
@@ -27,15 +27,15 @@ namespace lyra::lowering::hir_to_mir {
     -> mir::Expr;
 
 // Wraps a list of element ExprIds destined for an array container constructor
-// (`UnpackedArrayType` or `DynamicArrayType`) in
-// `ConstructExpr{[element_default, ArrayLiteralExpr{elements}]}`. This is the
+// (`UnpackedArrayType` or `DynamicArrayType`) in a construction call whose
+// arguments are `[element_default, ArrayLiteralExpr{elements}]`. This is the
 // construction shape every site that produces an array-container value must
 // use: the canonical-default element required by the wrapper's runtime ctor
 // (to seed `oob_slot_`) is supplied here via `BuildDefaultValueExpr` on
 // the element type, and the elements ride in an `ArrayLiteralExpr` that the
 // renderer emits as `std::array<T, N>{...}`. See
 // `docs/decisions/runtime-shape-and-default-value.md`.
-[[nodiscard]] auto BuildArrayConstructExpr(
+[[nodiscard]] auto BuildArrayConstructionCall(
     const ModuleLowerer& module, WalkFrame frame, mir::TypeId array_type,
     std::vector<mir::ExprId> elements) -> mir::Expr;
 

--- a/include/lyra/lowering/hir_to_mir/self_ref.hpp
+++ b/include/lyra/lowering/hir_to_mir/self_ref.hpp
@@ -2,6 +2,13 @@
 
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/mir/expr_id.hpp"
+#include "lyra/mir/type_id.hpp"
+
+namespace lyra::mir {
+class CompilationUnit;
+struct ProceduralScope;
+}  // namespace lyra::mir
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -13,5 +20,14 @@ namespace lyra::lowering::hir_to_mir {
 // effect engine handle starts from it.
 auto BuildSelfRefExpr(const WalkFrame& frame, mir::TypeId self_ptr_type)
     -> mir::Expr;
+
+// Constructs a reference to the cell `cell` denotes (LRM 13.5.2): adds a
+// reference-construction `CallExpr` to `scope` whose result type is a
+// `RefType` over `pointee`, and returns its id. The body that holds the
+// resulting reference reads / writes the live cell through it. Used for a
+// `ref` / `const ref` actual and for a by-reference closure capture.
+auto BuildReferenceArg(
+    mir::CompilationUnit& unit, mir::ProceduralScope& scope, mir::ExprId cell,
+    mir::TypeId pointee) -> mir::ExprId;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/closure.hpp
+++ b/include/lyra/mir/closure.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <memory>
-#include <variant>
 #include <vector>
 
 #include "lyra/mir/expr_id.hpp"
@@ -11,31 +10,22 @@ namespace lyra::mir {
 
 struct ProceduralScope;
 
-struct ByValueCapture {
+// Binds the body's `binding` var to the value of `value` at closure
+// construction. Snapshot or alias is decided by the binding var's type, not by
+// a separate capture kind (closure.md): a value-typed binding owns a snapshot;
+// a `RefType` binding aliases an enclosing cell (`value` constructs the
+// reference, LRM 6.21), so the body's reads / writes route through the live
+// cell. The receiver `self` is always `captures[0]`.
+struct Capture {
   ExprId value{};
   ProceduralVarId binding{};
 };
 
-// A by-reference capture binds the body's `binding` var to an enclosing-scope
-// lvalue (`target`). The spawned body reaches it through a frame-copied
-// reference parameter; the enclosing storage outlives the body (LRM 6.21), so
-// reads and writes share the one live location. Used by fork branches that
-// touch their enclosing process's variables and by synchronous IIFEs (e.g.
-// `$sscanf` / `$fscanf`) whose body writes back to its output args.
-struct ByReferenceCapture {
-  ExprId target{};
-  ProceduralVarId binding{};
-};
-
-using Capture = std::variant<ByValueCapture, ByReferenceCapture>;
-
-// A per-invocation closure parameter (LRM 7.12.4 with-clause `item` /
-// `index`). `binding` is a procedural-var slot in the closure body that
-// holds the per-call argument value; body reads go through
-// `ProceduralVarRef{binding}` -- the same mechanism captures use. The
-// difference between a `Capture` and a `Parameter` is when the binding is
-// filled: captures snapshot once at closure creation, parameters receive a
-// new value on each invocation.
+// A per-invocation closure parameter (LRM 7.12.4 with-clause `item` / `index`).
+// `binding` is a procedural-var slot in the closure body holding the argument
+// value; body reads go through `ProceduralVarRef{binding}`, the same mechanism
+// captures use. A capture is filled once at closure construction; a parameter
+// receives a fresh value on each invocation.
 struct Parameter {
   ProceduralVarId binding{};
 };
@@ -51,19 +41,25 @@ struct Parameter {
 //   1. Each capture's binding and each parameter's binding is a
 //      ProceduralVarId valid in body.vars and is unique across the union of
 //      the two lists.
-//   2. A ByValueCapture binding is read-only inside body. A ByReferenceCapture
-//      binding may be read and written -- it aliases the enclosing storage.
-//      A parameter binding is read-only inside body; the value is supplied
-//      by the caller per invocation.
+//   2. A capture whose binding is a value type is read-only inside body (a
+//      snapshot). A capture whose binding is a `RefType` may be read and
+//      written -- it aliases the enclosing storage through a `Ref<T>`. A
+//      parameter binding is read-only; the value is supplied per invocation.
 //   3. ProceduralVarRef inside body uses hops bounded by body's own scope
 //      nesting and does not escape into the enclosing process scope. Outer
-//      procedural state reaches body only through captures.
-//   4. A closure with non-empty `params` is invoked many times (each call
-//      supplies new parameter values) and renders as a lambda whose `(...)`
-//      clause lists the parameters and whose body ends with a `ReturnStmt`
-//      carrying the result expression. An empty-`params` closure is invoked
-//      once (fork branch / deferred IIFE) and renders as a captures-as-args
-//      IIFE.
+//      procedural state reaches body only through captures and parameters.
+//   4. The closure's result type is the closure expression's own type; a
+//      coroutine closure (a fork branch, LRM 9.3.2) carries the coroutine type,
+//      a synchronous closure its value-result type. The body is rendered from
+//      its own statements alone -- the render reads none of the body's interior
+//      to discover the signature, and nothing about the closure's use. A
+//      backend realizes the closure from its captures, parameters, result type,
+//      and body: a synchronous closure as a capture-clause lambda, a coroutine
+//      closure as a stateless lambda whose captures pass as frame-copied
+//      parameters (so nothing dangles when the spawned coroutine outlives the
+//      referencing site). How the closure is invoked -- called at a fork site,
+//      submitted as a deferred effect, iterated by a with-clause -- lives at
+//      the referencing site, not on the closure.
 //
 // StructuralVarRef inside body may carry hops that reach module-scope storage
 // directly, the same way C++ lambdas may reference globals without capture.

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -32,6 +32,7 @@ struct BuiltinMirTypes {
   TypeId print_literal_item;
   TypeId print_value_item;
   TypeId format_spec;
+  TypeId coroutine;
 };
 
 struct CompilationUnit {
@@ -86,6 +87,7 @@ struct CompilationUnit {
             .format_spec = AddType(
                 TypeData{RuntimeLibraryType{
                     .kind = RuntimeLibraryKind::kFormatSpec}}),
+            .coroutine = AddType(TypeData{CoroutineType{}}),
         } {
   }
 

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -119,9 +119,18 @@ struct RuntimeNavCallee {
   std::string name;
 };
 
+// Constructs a value of the call's result data type from the positional
+// arguments -- the data type's constructor, which is just a call whose callee
+// is the type itself (Python's `T(args)`, Rust's `T::new(args)`). The backend
+// renders it as `<TypeName>(args)`, the type name from the result type; it
+// carries no knowledge of which data type it builds (a reference from a cell, a
+// runtime-sized container from a size, a default value from no arguments). The
+// brace-list aggregate form is `ArrayLiteralExpr`, a value literal, not this.
+struct ConstructorCallee {};
+
 using Callee = std::variant<
     SystemSubroutineCallee, StructuralSubroutineRef, BuiltinMethodCallee,
-    ClosureRef, RuntimeNavCallee>;
+    ClosureRef, RuntimeNavCallee, ConstructorCallee>;
 
 struct CallExpr {
   Callee callee;
@@ -164,33 +173,21 @@ struct ReplicationExpr {
   ExprId concat;
 };
 
-// LRM 10.9.1 array assignment pattern `'{e1, e2, ...}` element list. Always
-// appears as an argument of a `ConstructExpr` whose result is an array
-// container; renders as `std::array<T, N>{e1, ...}` so the surrounding ctor
-// resolves uniformly against a `std::span<const T>` parameter. `Expr::type`
-// is the parent container type (`UnpackedArrayType` / `DynamicArrayType`);
-// the element type is read off it at render time.
+// LRM 10.9.1 array assignment pattern `'{e1, e2, ...}` element list. Feeds an
+// array container's constructor; renders as `std::array<T, N>{e1, ...}` so it
+// resolves uniformly against the ctor's `std::span<const T>` parameter.
+// `Expr::type` is the parent container type (`UnpackedArrayType` /
+// `DynamicArrayType`); the element type is read off it at render time. A value
+// literal (the brace form), distinct from the constructor call it feeds.
 struct ArrayLiteralExpr {
   std::vector<ExprId> elements;
-};
-
-// Invokes the result type's constructor with positional arguments; the result
-// type lives on Expr::type. Used for runtime-sized container construction --
-// LRM 7.5.1 dynamic-array `new[N]` / `new[N](other)`, and the LRM 7.6
-// dynamic-array whole-array assignment that desugars to the same shape.
-// Distinct from ArrayLiteralExpr in semantics: args are constructor
-// arguments, not initializer-list elements, so the brace-vs-paren overload
-// distinction is preserved at the C++ surface.
-struct ConstructExpr {
-  std::vector<ExprId> args;
 };
 
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, StructuralParamRef,
     ProceduralVarRef, UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr,
     IncDecExpr, CallExpr, RuntimeCallExpr, DerefExpr, MemberAccessExpr,
-    ConversionExpr, ClosureExpr, ConcatExpr, ReplicationExpr, ArrayLiteralExpr,
-    ConstructExpr>;
+    ConversionExpr, ClosureExpr, ConcatExpr, ReplicationExpr, ArrayLiteralExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/mir/procedural_var.hpp
+++ b/include/lyra/mir/procedural_var.hpp
@@ -15,23 +15,15 @@ struct ProceduralVarId {
       -> std::strong_ordering = default;
 };
 
-// LRM 13.5.2 pass-by-reference. A kValue var owns its storage; a kReference var
-// (a `ref` / `const ref` formal) is an alias to the actual's cell, so the
-// backend renders it as a `Ref<T>` and reads / writes route through the
-// actual's own access path. The backend distinguishes the two read / write
-// renderings on this axis.
-enum class VariableBinding : std::uint8_t {
-  kValue,
-  kReference,
-};
-
 // Static-lifetime (LRM 13.3.1) body locals do not live here -- HIR-to-MIR
 // realizes them as structural vars on the enclosing structural scope
-// (`docs/decisions/variable-lifetime-storage.md`).
+// (`docs/decisions/variable-lifetime-storage.md`). A pass-by-reference binding
+// (LRM 13.5.2, a `ref` formal or a by-reference capture) carries no flag here:
+// its `type` is a `RefType`, and the backend renders reads / writes through
+// `Ref<T>` from the type alone.
 struct ProceduralVarDecl {
   std::string name;
   TypeId type;
-  VariableBinding binding = VariableBinding::kValue;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -70,12 +70,13 @@ enum class JoinMode : std::uint8_t {
 // (in the enclosing procedural scope's child_scopes) holds the
 // block_item_declaration locals, which are initialized at block entry -- in the
 // parent, before any branch spawns -- giving each spawned branch a by-value
-// snapshot. Each branch is a closure (a captured callable value) in `scope`'s
-// expr arena, referenced here by id; a branch captures a fork-scope local by
-// value (the snapshot) and an enclosing-process variable by reference
-// (LRM 6.21). The backend spawns each branch as a concurrent process and the
-// parent waits per `mode`. Being a fork branch is what makes the closure run as
-// a coroutine -- the closure node itself carries no such property.
+// snapshot. Each branch is a coroutine-typed ClosureExpr in `scope`'s expr
+// arena, referenced here by id; the branch captures its environment (its
+// receiver `self`, a fork-scope local by value, an enclosing variable by
+// reference through a `Ref<T>`, LRM 6.21). The backend spawns each branch's
+// coroutine and the parent waits per `mode`. The branch runs as a coroutine
+// because its result type is the coroutine type, not because of any flag on the
+// closure node.
 struct ForkStmt {
   JoinMode mode;
   ProceduralScopeId scope;
@@ -164,8 +165,8 @@ struct ContinueStmt {};
 // value-returning function; it is absent for `return;` and for void functions
 // / tasks. The semantic concept is one across all consumers (LRM, LIR, LLVM
 // `ret`); `is_coroutine_return` is a render hint for the C++ backend only,
-// distinguishing `co_return` from plain `return`. HIR-to-MIR sets it from the
-// enclosing callable's `is_coroutine`; LIR / LLVM ignore it.
+// distinguishing `co_return` from plain `return`. HIR-to-MIR sets it from
+// whether the enclosing callable body is a coroutine; LIR / LLVM ignore it.
 struct ReturnStmt {
   std::optional<ExprId> value;
   bool is_coroutine_return = false;

--- a/include/lyra/mir/structural_subroutine.hpp
+++ b/include/lyra/mir/structural_subroutine.hpp
@@ -19,13 +19,13 @@ enum class SubroutineKind : std::uint8_t {
 };
 
 // LRM 13.5 argument direction. MIR carries the semantic direction only; the
-// C++ argument-passing mode is the backend's decision.
+// C++ argument-passing mode is the backend's decision. A `ref` / `const ref`
+// formal is not a direction here: its `type` is a `RefType` and it is passed by
+// value (`kInput`) -- the reference value carries the aliasing.
 enum class ParamDirection : std::uint8_t {
   kInput,
   kOutput,
   kInOut,
-  kRef,
-  kConstRef,
 };
 
 // A formal argument of a subroutine. `name` is the procedural var the body

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -31,6 +31,8 @@ enum class TypeKind {
   kSelf,
   kServices,
   kRuntimeLibrary,
+  kCoroutine,
+  kReference,
   kPointer,
   kVector,
   kExternalRef,
@@ -185,6 +187,30 @@ struct RuntimeLibraryType {
   auto operator==(const RuntimeLibraryType&) const -> bool = default;
 };
 
+// The runtime coroutine handle `lyra::runtime::Coroutine`: the value a
+// suspending callable yields when invoked. A fork branch (LRM 9.3.2) is a
+// closure whose result type is this -- invoking it produces a spawned-process
+// coroutine the parent collects and joins. Opaque, like ScopeType /
+// ServicesType; it names a runtime type, never a layout.
+struct CoroutineType {
+  auto operator==(const CoroutineType&) const -> bool = default;
+};
+
+// A reference value aliasing a storage cell of `pointee` type (LRM 13.5.2
+// pass-by-reference; a fork branch / `$sscanf` / with-clause body sharing
+// enclosing storage). The runtime wrapper `lyra::runtime::Ref<T>` routes reads
+// through `Get` and writes through the cell's `Set` (its update-event path), so
+// a value of this type is read and written like an observable cell. `is_const`
+// marks a `const ref` formal (read-only). A library wrapper, like
+// ObservableType; constructing one from a cell is an explicit MIR operation,
+// not a backend-synthesized wrap.
+struct RefType {
+  TypeId pointee;
+  bool is_const = false;
+
+  auto operator==(const RefType&) const -> bool = default;
+};
+
 enum class PointerOwnership {
   kUnique,
   kShared,
@@ -256,8 +282,8 @@ using TypeData = std::variant<
     PackedArrayType, EnumType, UnpackedArrayType, DynamicArrayType, QueueType,
     AssociativeArrayType, StringType, EventType, RealType, ShortRealType,
     RealTimeType, ChandleType, VoidType, ObjectType, ExternalUnitObjectType,
-    ScopeType, SelfType, ServicesType, RuntimeLibraryType, PointerType,
-    VectorType, ExternalRefType, ObservableType>;
+    ScopeType, SelfType, ServicesType, RuntimeLibraryType, CoroutineType,
+    RefType, PointerType, VectorType, ExternalRefType, ObservableType>;
 
 struct Type {
   TypeData data;

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -154,12 +154,10 @@ auto RenderSubroutineMethod(
     auto type_or = RenderTypeAsCpp(unit, s, param.type);
     if (!type_or) return std::unexpected(std::move(type_or.error()));
     sig += ", ";
-    // An `input` formal is a by-value copy (LRM 13.5.1). An `output` / `inout`
-    // formal binds to the caller's writeback temp by reference (`T&`) so body
-    // writes flow back at the copy-out. A `ref` / `const ref` formal aliases
-    // the actual's cell through a `Ref<T>` so writes route through that cell's
-    // update-event path (LRM 13.5.2); `const ref` is `const Ref<T>`, which
-    // makes `Set` ill-formed and enforces the read-only promise.
+    // An `input` formal is by value (LRM 13.5.1); a `ref` / `const ref` formal
+    // is also passed by value, but its type is a `RefType` so `*type_or` is
+    // already `(const) lyra::runtime::Ref<T>` (LRM 13.5.2). An `output` /
+    // `inout` formal binds the caller's writeback temp by reference (`T&`).
     switch (param.direction) {
       case mir::ParamDirection::kInput:
         sig += *type_or + " " + param.name;
@@ -167,12 +165,6 @@ auto RenderSubroutineMethod(
       case mir::ParamDirection::kOutput:
       case mir::ParamDirection::kInOut:
         sig += *type_or + "& " + param.name;
-        break;
-      case mir::ParamDirection::kRef:
-        sig += "lyra::runtime::Ref<" + *type_or + "> " + param.name;
-        break;
-      case mir::ParamDirection::kConstRef:
-        sig += "const lyra::runtime::Ref<" + *type_or + "> " + param.name;
         break;
     }
   }

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -199,13 +199,15 @@ auto LookupProceduralVarName(
   return ctx.ProceduralScopeAtHops(ref.hops).vars.at(ref.var.value).name;
 }
 
-// True iff the procedural var is a `ref` / `const ref` formal, rendered as a
-// `Ref<T>` whose read is `.Get()` and whose write is `.Set(Services(), ...)`
-// (LRM 13.5.2), the same surface as a structural Var.
+// True iff the procedural var holds a reference (its type is a `RefType`),
+// rendered as a `Ref<T>` whose read is `.Get()` and whose write is
+// `.Set(Services(), ...)` (LRM 13.5.2), the same surface as a structural Var.
 auto IsReferenceProceduralVar(
     const RenderContext& ctx, const mir::ProceduralVarRef& ref) -> bool {
-  return ctx.ProceduralScopeAtHops(ref.hops).vars.at(ref.var.value).binding ==
-         mir::VariableBinding::kReference;
+  const mir::TypeId var_type =
+      ctx.ProceduralScopeAtHops(ref.hops).vars.at(ref.var.value).type;
+  return std::holds_alternative<mir::RefType>(
+      ctx.Unit().GetType(var_type).data);
 }
 
 }  // namespace
@@ -1281,6 +1283,33 @@ auto RenderSystemSubroutineCall(
   return out;
 }
 
+// Constructs a value of the call's result data type: `<TypeName>(args)`, the
+// type name from `RenderTypeAsCpp` (a constructor is a call whose callee is the
+// type's constructor), the arguments rendered like any other call's. An empty
+// argument list against a pointer type value-initializes to `nullptr` (the
+// functional-cast `T*()` is ill-formed for a raw pointer). A `RefType` cell
+// argument renders as a bare signal read, which is the cell itself -- the
+// `Ref<T>` constructor binds it.
+auto RenderConstructorCall(
+    const RenderContext& ctx, const mir::CallExpr& call,
+    mir::TypeId result_type) -> diag::Result<std::string> {
+  if (call.arguments.empty() && std::holds_alternative<mir::PointerType>(
+                                    ctx.Unit().GetType(result_type).data)) {
+    return std::string{"nullptr"};
+  }
+  auto type_or =
+      RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), result_type);
+  if (!type_or) return std::unexpected(std::move(type_or.error()));
+  std::string args;
+  for (std::size_t i = 0; i < call.arguments.size(); ++i) {
+    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+    if (i != 0) args += ", ";
+    args += *std::move(arg_or);
+  }
+  return *type_or + "(" + args + ")";
+}
+
 auto RenderCallExpr(
     const RenderContext& ctx, const mir::CallExpr& call,
     mir::TypeId result_type) -> diag::Result<std::string> {
@@ -1302,44 +1331,15 @@ auto RenderCallExpr(
             const auto& scope = ctx.StructuralScopeAtHops(
                 mir::StructuralHops{.value = ref.hops.value});
             const auto& decl = scope.GetStructuralSubroutine(ref.subroutine);
+            // arguments[0] is the callee's `self` handle (mir.md invariant 11);
+            // a ref / const ref actual is already a reference-construct
+            // (`Ref<T>(cell)`) in MIR, so every argument renders uniformly.
             std::string args;
             for (std::size_t i = 0; i < call.arguments.size(); ++i) {
-              const mir::Expr& actual = ctx.Expr(call.arguments[i]);
-              std::string rendered;
-              if (i == 0) {
-                // arguments[0] is the callee's `self` instance handle (mir.md
-                // invariant 11) -- a plain pointer value with no formal.
-                auto self_or = RenderExpr(ctx, actual);
-                if (!self_or)
-                  return std::unexpected(std::move(self_or.error()));
-                rendered = *std::move(self_or);
-              } else {
-                const mir::ParamDirection dir = decl.params[i - 1].direction;
-                if (dir == mir::ParamDirection::kRef ||
-                    dir == mir::ParamDirection::kConstRef) {
-                  // A ref / const-ref actual binds the variable's cell.
-                  // HIR-to-MIR wraps observable selector-chain actuals with
-                  // `DerefExpr(CallExpr(kMutate, ...))`, so render is
-                  // mechanical.
-                  auto lhs_or = RenderLhsExpr(ctx, actual);
-                  if (!lhs_or)
-                    return std::unexpected(std::move(lhs_or.error()));
-                  auto type_or = RenderTypeAsCpp(
-                      ctx.Unit(), ctx.StructuralScope(),
-                      decl.params[i - 1].type);
-                  if (!type_or)
-                    return std::unexpected(std::move(type_or.error()));
-                  rendered =
-                      "lyra::runtime::Ref<" + *type_or + ">(" + *lhs_or + ")";
-                } else {
-                  auto arg_or = RenderExpr(ctx, actual);
-                  if (!arg_or)
-                    return std::unexpected(std::move(arg_or.error()));
-                  rendered = *std::move(arg_or);
-                }
-              }
+              auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+              if (!arg_or) return std::unexpected(std::move(arg_or.error()));
               if (i != 0) args += ", ";
-              args += rendered;
+              args += *std::move(arg_or);
             }
             return std::format("{}({})", decl.name, args);
           },
@@ -1447,6 +1447,9 @@ auto RenderCallExpr(
               }
             }
             throw InternalError("RenderCallExpr: unknown RuntimeFn");
+          },
+          [&](const mir::ConstructorCallee&) -> diag::Result<std::string> {
+            return RenderConstructorCall(ctx, call, result_type);
           },
       },
       call.callee);
@@ -1650,94 +1653,88 @@ auto RenderIncDecExpr(const RenderContext& ctx, const mir::IncDecExpr& inc)
   throw InternalError("RenderIncDecExpr: unknown IncDecOp");
 }
 
-auto RenderClosureExpr(
-    const RenderContext& ctx, const mir::ClosureExpr& closure)
+// Renders a binding's parameter declaration -- its type then its name. A
+// `RefType` binding renders as `Ref<T> name`, a value binding as `T name`;
+// the wrapper comes from the type alone (RenderTypeAsCpp), never hand-written.
+auto RenderBindingParamDecl(
+    const RenderContext& ctx, const mir::ProceduralVarDecl& bind)
     -> diag::Result<std::string> {
+  auto type_or = RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), bind.type);
+  if (!type_or) return std::unexpected(std::move(type_or.error()));
+  return *type_or + " " + bind.name;
+}
+
+// A closure renders from its captures, parameters, result type, and body alone.
+// A synchronous closure is a capture-clause lambda. A coroutine closure (result
+// type `Coroutine`) is a stateless lambda whose captures pass as frame-copied
+// parameters and are supplied by an immediate call -- a capturing coroutine
+// lambda would dangle once the spawned branch outlives the referencing site.
+auto RenderClosureExpr(
+    const RenderContext& ctx, const mir::ClosureExpr& closure,
+    mir::TypeId result_type) -> diag::Result<std::string> {
   if (closure.body == nullptr) {
     throw InternalError("RenderClosureExpr: closure has no body");
   }
 
-  // Every captured value flows through `closure.captures` as a named
-  // by-value or by-reference entry; the receiver `self` is captures[0] (mir.md
-  // invariant 11). The clause never contains `[this]`, `[=]`, or `[&]`.
-  std::string captures_text;
-  for (std::size_t i = 0; i < closure.captures.size(); ++i) {
-    if (i != 0) captures_text += ", ";
-    auto rendered_or = std::visit(
-        Overloaded{
-            [&](const mir::ByValueCapture& bv) -> diag::Result<std::string> {
-              const std::string& bind_name =
-                  closure.body->vars.at(bv.binding.value).name;
-              auto value_or = RenderExpr(ctx, ctx.Expr(bv.value));
-              if (!value_or) {
-                return std::unexpected(std::move(value_or.error()));
-              }
-              return bind_name + " = " + *value_or;
-            },
-            [&](const mir::ByReferenceCapture& br)
-                -> diag::Result<std::string> {
-              const std::string& bind_name =
-                  closure.body->vars.at(br.binding.value).name;
-              auto lvalue_or = RenderLhsExpr(ctx, ctx.Expr(br.target));
-              if (!lvalue_or) {
-                return std::unexpected(std::move(lvalue_or.error()));
-              }
-              return "&" + bind_name + " = " + *lvalue_or;
-            }},
-        closure.captures[i]);
-    if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
-    captures_text += *rendered_or;
-  }
-
-  // LRM 7.12.4 with-clause closures (or any closure built with a non-empty
-  // `params` list) render as a value-returning lambda whose parameter
-  // clause names the bindings in declaration order and whose body ends with
-  // `return <value>;` (lowered from a tail `ReturnStmt`). Closures with no
-  // `params` (fork branches, NBA submit) keep the existing `()` form.
-  std::string params_text;
-  for (std::size_t i = 0; i < closure.params.size(); ++i) {
-    const auto& bind = closure.body->vars.at(closure.params[i].binding.value);
-    auto type_or =
-        RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), bind.type);
-    if (!type_or) return std::unexpected(std::move(type_or.error()));
-    if (i != 0) params_text += ", ";
-    params_text += "const " + *type_or + "& " + bind.name;
-  }
-
-  // Derive the lambda return type from the tail `ReturnStmt`'s value
-  // expression -- closures synthesized for LRM 7.12.2 / 7.12.3 always end
-  // there. An empty-params closure (fork branch / NBA submit) carries no
-  // return value; leave the lambda return type unspecified so C++ deduces
-  // `void`.
-  std::string return_clause;
-  if (!closure.params.empty()) {
-    const auto& root_stmts = closure.body->root_stmts;
-    if (root_stmts.empty()) {
-      throw InternalError(
-          "RenderClosureExpr: with-clause closure body has no root "
-          "statements (expected a tail ReturnStmt)");
-    }
-    const auto& tail = closure.body->stmts.at(root_stmts.back().value);
-    const auto* ret = std::get_if<mir::ReturnStmt>(&tail.data);
-    if (ret == nullptr || !ret->value.has_value()) {
-      throw InternalError(
-          "RenderClosureExpr: with-clause closure body does not end with a "
-          "value-returning `ReturnStmt`");
-    }
-    const auto& ret_expr = closure.body->GetExpr(*ret->value);
-    auto ret_ty_or =
-        RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), ret_expr.type);
-    if (!ret_ty_or) return std::unexpected(std::move(ret_ty_or.error()));
-    return_clause = " -> " + *ret_ty_or;
-  }
+  auto result_ty_or =
+      RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), result_type);
+  if (!result_ty_or) return std::unexpected(std::move(result_ty_or.error()));
+  const std::string return_clause = " -> " + *result_ty_or;
 
   const RenderContext body_ctx =
       RenderContext::ForRoot(ctx.Unit(), ctx.StructuralScope(), *closure.body);
   auto body_or = RenderProceduralScopeStatements(body_ctx, 1);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
+  const std::string body = " {\n" + *body_or + "}";
 
-  return "[" + captures_text + "](" + params_text + ")" + return_clause +
-         " {\n" + *body_or + "}";
+  if (std::holds_alternative<mir::CoroutineType>(
+          ctx.Unit().GetType(result_type).data)) {
+    if (!closure.params.empty()) {
+      throw InternalError(
+          "RenderClosureExpr: coroutine closure has parameters");
+    }
+    std::string params;
+    std::string args;
+    for (std::size_t i = 0; i < closure.captures.size(); ++i) {
+      const auto& bind =
+          closure.body->vars.at(closure.captures[i].binding.value);
+      auto decl_or = RenderBindingParamDecl(ctx, bind);
+      if (!decl_or) return std::unexpected(std::move(decl_or.error()));
+      auto arg_or = RenderExpr(ctx, ctx.Expr(closure.captures[i].value));
+      if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+      if (i != 0) {
+        params += ", ";
+        args += ", ";
+      }
+      params += *decl_or;
+      args += *arg_or;
+    }
+    return "[](" + params + ")" + return_clause + body + "(" + args + ")";
+  }
+
+  // The capture clause never contains `[this]`, `[=]`, or `[&]` -- every entry
+  // is a named by-value binding `name = <value>`; an alias capture's value is a
+  // reference-construct, so it binds a `Ref<T>` without a hidden C++ reference.
+  std::string captures_text;
+  for (std::size_t i = 0; i < closure.captures.size(); ++i) {
+    const std::string& bind_name =
+        closure.body->vars.at(closure.captures[i].binding.value).name;
+    auto source_or = RenderExpr(ctx, ctx.Expr(closure.captures[i].value));
+    if (!source_or) return std::unexpected(std::move(source_or.error()));
+    if (i != 0) captures_text += ", ";
+    captures_text += bind_name + " = " + *source_or;
+  }
+
+  std::string params_text;
+  for (std::size_t i = 0; i < closure.params.size(); ++i) {
+    const auto& bind = closure.body->vars.at(closure.params[i].binding.value);
+    auto decl_or = RenderBindingParamDecl(ctx, bind);
+    if (!decl_or) return std::unexpected(std::move(decl_or.error()));
+    if (i != 0) params_text += ", ";
+    params_text += *decl_or;
+  }
+
+  return "[" + captures_text + "](" + params_text + ")" + return_clause + body;
 }
 
 // LRM 10.10 unpacked array concatenation into a queue. Each operand is spliced
@@ -1811,7 +1808,7 @@ auto RenderConcatExpr(
 // `std::array<T, N>` implicitly
 // converts to the container ctor's `std::span<const T>` parameter, so this
 // rendering is context-independent: the same string is correct standalone
-// and as a `ConstructExpr` argument.
+// and as a construction-call argument.
 auto RenderArrayLiteralExpr(
     const RenderContext& ctx, const mir::Expr& expr,
     const mir::ArrayLiteralExpr& a) -> diag::Result<std::string> {
@@ -1843,32 +1840,6 @@ auto RenderArrayLiteralExpr(
     out += *rendered;
   }
   out += "}";
-  return out;
-}
-
-// LRM 7.5.1 / 7.6: constructor invocation. Emits `RenderType(type)(args...)`
-// -- parenthesised so brace-vs-paren overload resolution is unambiguous and
-// the runtime ctor is selected by arg-list shape.
-auto RenderConstructExpr(
-    const RenderContext& ctx, const mir::Expr& expr,
-    const mir::ConstructExpr& c) -> diag::Result<std::string> {
-  // A pointer value-initializes to null; `nullptr` is the valid spelling of
-  // that (the functional-cast form `T*()` is ill-formed for a raw pointer
-  // type).
-  if (c.args.empty() && std::holds_alternative<mir::PointerType>(
-                            ctx.Unit().GetType(expr.type).data)) {
-    return std::string{"nullptr"};
-  }
-  auto type_or = RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), expr.type);
-  if (!type_or) return std::unexpected(std::move(type_or.error()));
-  std::string out = *type_or + "(";
-  for (std::size_t i = 0; i < c.args.size(); ++i) {
-    auto r = RenderExpr(ctx, ctx.Expr(c.args[i]));
-    if (!r) return std::unexpected(std::move(r.error()));
-    if (i != 0) out += ", ";
-    out += *r;
-  }
-  out += ")";
   return out;
 }
 
@@ -1975,7 +1946,7 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
             return *receiver_or + "->" + var.name;
           },
           [&](const mir::ClosureExpr& cl) -> diag::Result<std::string> {
-            return RenderClosureExpr(ctx, cl);
+            return RenderClosureExpr(ctx, cl, expr.type);
           },
           [&](const mir::ConcatExpr& c) -> diag::Result<std::string> {
             return RenderConcatExpr(ctx, expr, c);
@@ -1985,9 +1956,6 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
           },
           [&](const mir::ArrayLiteralExpr& a) -> diag::Result<std::string> {
             return RenderArrayLiteralExpr(ctx, expr, a);
-          },
-          [&](const mir::ConstructExpr& c) -> diag::Result<std::string> {
-            return RenderConstructExpr(ctx, expr, c);
           },
       },
       expr.data);

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -123,15 +123,11 @@ auto RenderForkJoinModeLiteral(mir::JoinMode mode) -> std::string_view {
 
 // LRM 9.3.2: a fork is a procedural scope, rendered as a block at the fork
 // site. Its block_item_declarations initialize first, in the parent, before any
-// branch spawns -- so a branch's by-value capture of one of them is a snapshot.
-// Each branch is an anonymous ClosureExpr spawned as a concurrent coroutine,
-// rendered inline as a stateless lambda whose parameters are frame-copied -- so
-// the spawned coroutine never dangles the way a captured lambda would. The
-// first parameter is the enclosing scope instance `self`, through which the
-// body reaches module state and Services(); each closure capture adds one more
-// parameter (a `T` snapshot for a by-value capture of a fork-scope local, a
-// `T&` for a by-reference capture of an enclosing variable). The fork waits per
-// the join mode.
+// branch spawns -- so a branch's by-value argument of one of them is a
+// snapshot. Each branch is a coroutine-typed closure; the shared closure
+// renderer emits it as a stateless coroutine lambda invoked on its captures,
+// yielding a `lyra::runtime::Coroutine` collected into `fork_branches`. The
+// fork then waits per the join mode.
 auto RenderForkStmtNode(
     const RenderContext& ctx, const mir::ForkStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
@@ -149,56 +145,9 @@ auto RenderForkStmtNode(
   out += Indent(indent + 1) + "std::vector<lyra::runtime::Coroutine> " + vec +
          ";\n";
   for (const auto branch : s.branches) {
-    const auto* closure =
-        std::get_if<mir::ClosureExpr>(&fork_ctx.Expr(branch).data);
-    if (closure == nullptr) {
-      throw InternalError("RenderForkStmtNode: fork branch is not a closure");
-    }
-    if (closure->body == nullptr) {
-      throw InternalError(
-          "RenderForkStmtNode: fork branch closure has no body");
-    }
-    std::string params;
-    std::string args;
-    for (std::size_t ci = 0; ci < closure->captures.size(); ++ci) {
-      const auto& capture = closure->captures[ci];
-      mir::ProceduralVarId binding{};
-      std::string ref_marker;
-      std::string arg;
-      if (const auto* by_ref = std::get_if<mir::ByReferenceCapture>(&capture)) {
-        binding = by_ref->binding;
-        ref_marker = "& ";
-        auto target_or = RenderExpr(fork_ctx, fork_ctx.Expr(by_ref->target));
-        if (!target_or) return std::unexpected(std::move(target_or.error()));
-        arg = *std::move(target_or);
-      } else {
-        const auto& by_value = std::get<mir::ByValueCapture>(capture);
-        binding = by_value.binding;
-        ref_marker = " ";
-        auto value_or = RenderExpr(fork_ctx, fork_ctx.Expr(by_value.value));
-        if (!value_or) return std::unexpected(std::move(value_or.error()));
-        arg = *std::move(value_or);
-      }
-      const auto& bind = closure->body->vars.at(binding.value);
-      auto type_or =
-          RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), bind.type);
-      if (!type_or) return std::unexpected(std::move(type_or.error()));
-      if (ci != 0) {
-        params += ", ";
-        args += ", ";
-      }
-      params += *type_or + ref_marker + bind.name;
-      args += arg;
-    }
-    const RenderContext branch_ctx =
-        fork_ctx.WithProceduralScope(*closure->body);
-    auto body_or = RenderProceduralScopeStatements(branch_ctx, indent + 2);
-    if (!body_or) return std::unexpected(std::move(body_or.error()));
-    out += Indent(indent + 1) + vec + ".push_back([](" + params +
-           ") -> lyra::runtime::Coroutine {\n";
-    out += *body_or;
-    out += Indent(indent + 2) + "co_return;\n";
-    out += Indent(indent + 1) + "}(" + args + "));\n";
+    auto closure_or = RenderExpr(fork_ctx, fork_ctx.Expr(branch));
+    if (!closure_or) return std::unexpected(std::move(closure_or.error()));
+    out += Indent(indent + 1) + vec + ".push_back(" + *closure_or + ");\n";
   }
   out += Indent(indent + 1) + "co_await lyra::runtime::Fork(" +
          "self->Services()" + ", std::move(" + vec + "), " +

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -135,6 +135,18 @@ auto RenderTypeAsCpp(
             }
             throw InternalError("RenderTypeAsCpp: unknown RuntimeLibraryKind");
           },
+          [](const mir::CoroutineType&) -> diag::Result<std::string> {
+            return std::string{"lyra::runtime::Coroutine"};
+          },
+          [&](const mir::RefType& r) -> diag::Result<std::string> {
+            auto inner_or = RenderTypeAsCpp(unit, owner_scope, r.pointee);
+            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
+            std::string ref = "lyra::runtime::Ref<" + *inner_or + ">";
+            return r.is_const ? "const " + ref : ref;
+          },
+          [](const mir::VoidType&) -> diag::Result<std::string> {
+            return std::string{"void"};
+          },
           [&](const mir::PointerType& p) -> diag::Result<std::string> {
             auto inner_or = RenderTypeAsCpp(unit, owner_scope, p.pointee);
             if (!inner_or) return std::unexpected(std::move(inner_or.error()));

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -94,20 +94,24 @@ auto BuildDefaultValueExpr(
               elements.push_back(scope.AddExpr(
                   BuildDefaultValueExpr(module, frame, ua.element_type)));
             }
-            return BuildArrayConstructExpr(
+            return BuildArrayConstructionCall(
                 module, frame, type, std::move(elements));
           },
           // LRM Table 6-7: a dynamic array's default is the empty array.
           // The wrapper still needs the element type's default supplied at
           // construction so OOB reads and resize-fills have a shape source --
           // see `docs/decisions/runtime-shape-and-default-value.md`. Emit
-          // chain: ConstructExpr{element_default} -> `DynamicArray<T>(...)`
-          // ctor that stores the value and leaves `data_` empty.
+          // chain: a construction call on `element_default` -> the
+          // `DynamicArray<T>(...)` ctor that stores the value and leaves
+          // `data_` empty.
           [&](const mir::DynamicArrayType& da) -> mir::Expr {
             const mir::ExprId element_default = scope.AddExpr(
                 BuildDefaultValueExpr(module, frame, da.element_type));
             return mir::Expr{
-                .data = mir::ConstructExpr{.args = {element_default}},
+                .data =
+                    mir::CallExpr{
+                        .callee = mir::ConstructorCallee{},
+                        .arguments = {element_default}},
                 .type = type};
           },
           // LRM Table 6-7: a queue's default is the empty queue. Same emit
@@ -126,7 +130,10 @@ auto BuildDefaultValueExpr(
                       static_cast<std::int64_t>(*q.max_bound))));
             }
             return mir::Expr{
-                .data = mir::ConstructExpr{.args = std::move(args)},
+                .data =
+                    mir::CallExpr{
+                        .callee = mir::ConstructorCallee{},
+                        .arguments = std::move(args)},
                 .type = type};
           },
           // LRM Table 6-7: an associative array's default is empty. The element
@@ -136,30 +143,45 @@ auto BuildDefaultValueExpr(
             const mir::ExprId element_default = scope.AddExpr(
                 BuildDefaultValueExpr(module, frame, a.element_type));
             return mir::Expr{
-                .data = mir::ConstructExpr{.args = {element_default}},
+                .data =
+                    mir::CallExpr{
+                        .callee = mir::ConstructorCallee{},
+                        .arguments = {element_default}},
                 .type = type};
           },
           // Types whose runtime default is the C++ language-level default
           // (named-event handle, child module instance, `unique_ptr<Child>`,
           // `vector<Child>`). The constructor scope is the real populator
           // for the object family; named-events have no SV initializer
-          // grammar at all. Empty `ConstructExpr` renders as `T()` and
-          // invokes the type's default ctor.
+          // grammar at all. An empty-argument construction call renders as
+          // `T()` and invokes the type's default ctor.
           [&](const mir::EventType&) -> mir::Expr {
             return mir::Expr{
-                .data = mir::ConstructExpr{.args = {}}, .type = type};
+                .data =
+                    mir::CallExpr{
+                        .callee = mir::ConstructorCallee{}, .arguments = {}},
+                .type = type};
           },
           [&](const mir::ObjectType&) -> mir::Expr {
             return mir::Expr{
-                .data = mir::ConstructExpr{.args = {}}, .type = type};
+                .data =
+                    mir::CallExpr{
+                        .callee = mir::ConstructorCallee{}, .arguments = {}},
+                .type = type};
           },
           [&](const mir::PointerType&) -> mir::Expr {
             return mir::Expr{
-                .data = mir::ConstructExpr{.args = {}}, .type = type};
+                .data =
+                    mir::CallExpr{
+                        .callee = mir::ConstructorCallee{}, .arguments = {}},
+                .type = type};
           },
           [&](const mir::VectorType&) -> mir::Expr {
             return mir::Expr{
-                .data = mir::ConstructExpr{.args = {}}, .type = type};
+                .data =
+                    mir::CallExpr{
+                        .callee = mir::ConstructorCallee{}, .arguments = {}},
+                .type = type};
           },
           [&](const auto&) -> mir::Expr {
             throw InternalError(
@@ -170,7 +192,7 @@ auto BuildDefaultValueExpr(
       ty.data);
 }
 
-auto BuildArrayConstructExpr(
+auto BuildArrayConstructionCall(
     const ModuleLowerer& module, WalkFrame frame, mir::TypeId array_type,
     std::vector<mir::ExprId> elements) -> mir::Expr {
   auto& scope = *frame.current_procedural_scope;
@@ -185,7 +207,7 @@ auto BuildArrayConstructExpr(
           return t.element_type;
         } else {
           throw InternalError(
-              "BuildArrayConstructExpr: type is not UnpackedArrayType, "
+              "BuildArrayConstructionCall: type is not UnpackedArrayType, "
               "DynamicArrayType, or QueueType");
         }
       },
@@ -208,7 +230,10 @@ auto BuildArrayConstructExpr(
             static_cast<std::int64_t>(*q->max_bound))));
   }
   return mir::Expr{
-      .data = mir::ConstructExpr{.args = std::move(args)}, .type = array_type};
+      .data =
+          mir::CallExpr{
+              .callee = mir::ConstructorCallee{}, .arguments = std::move(args)},
+      .type = array_type};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
@@ -208,7 +208,7 @@ auto BuildUniqueCheckClosure(
   const mir::ExprId outer_self_read =
       wrapper.AddExpr(BuildSelfRefExpr(wrapper_frame, self_ptr_type));
   closure.captures.emplace_back(
-      mir::ByValueCapture{.value = outer_self_read, .binding = self_binding});
+      mir::Capture{.value = outer_self_read, .binding = self_binding});
 
   std::vector<mir::ExprId> inner_reads;
   inner_reads.reserve(snapshot_vars.size());
@@ -227,7 +227,7 @@ auto BuildUniqueCheckClosure(
         mir::ProceduralVarDecl{
             .name = std::format("_lyra_unique_bind_{}", i), .type = snap_type});
     closure.captures.emplace_back(
-        mir::ByValueCapture{.value = outer_read_id, .binding = binding});
+        mir::Capture{.value = outer_read_id, .binding = binding});
 
     const mir::ExprId inner_read_id = body.AddExpr(
         mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
@@ -52,7 +52,8 @@ auto BuildArrayReplicationFlatList(
   for (std::uint64_t i = 0; i < count; ++i) {
     flat.insert(flat.end(), items_ids.begin(), items_ids.end());
   }
-  return BuildArrayConstructExpr(module, frame, result_type, std::move(flat));
+  return BuildArrayConstructionCall(
+      module, frame, result_type, std::move(flat));
 }
 
 auto IsArrayContainerType(const mir::Type& ty) -> bool {
@@ -101,7 +102,7 @@ auto LowerHirReplicationExprProc(
 // type's runtime shape: packed targets fold into MIR `ConcatExpr` (bit
 // concatenation matches the packed bit plane), array containers (unpacked,
 // dynamic, queue) land as `ArrayLiteralExpr` over distinct element slots
-// wrapped by a `ConstructExpr` against the container ctor.
+// wrapped by a construction call against the container ctor.
 auto LowerHirAssignmentPatternExprProc(
     ProcessLowerer& process, WalkFrame frame,
     const hir::AssignmentPatternExpr& a, mir::TypeId result_type)
@@ -116,7 +117,7 @@ auto LowerHirAssignmentPatternExprProc(
     element_ids.push_back(proc_scope.AddExpr(*std::move(lowered)));
   }
   if (IsArrayContainerType(process.Module().Unit().GetType(result_type))) {
-    return BuildArrayConstructExpr(
+    return BuildArrayConstructionCall(
         process.Module(), frame, result_type, std::move(element_ids));
   }
   return mir::Expr{
@@ -160,7 +161,7 @@ auto LowerHirAssignmentPatternReplicationExprProc(
 }
 
 // LRM 7.5.1 `new[N]` / `new[N](other)`. The argument list on the lowered
-// `ConstructExpr` is `[size, element-default prototype, optional copy
+// construction call is `[size, element-default prototype, optional copy
 // source]`: the prototype carries the element type's LRM Table 6-7 default
 // so the runtime ctor populates new slots without re-querying the type, and
 // the optional copy source feeds the LRM 7.5.1 truncate / pad behaviour on
@@ -194,7 +195,10 @@ auto LowerHirDynamicArrayNewExprProc(
     args.push_back(proc_scope.AddExpr(*std::move(init_or)));
   }
   return mir::Expr{
-      .data = mir::ConstructExpr{.args = std::move(args)}, .type = result_type};
+      .data =
+          mir::CallExpr{
+              .callee = mir::ConstructorCallee{}, .arguments = std::move(args)},
+      .type = result_type};
 }
 
 auto LowerHirConcatExprStructural(
@@ -229,7 +233,7 @@ auto LowerHirAssignmentPatternExprStructural(
     element_ids.push_back(proc_scope.AddExpr(*std::move(lowered)));
   }
   if (IsArrayContainerType(scope.Module().Unit().GetType(result_type))) {
-    return BuildArrayConstructExpr(
+    return BuildArrayConstructionCall(
         scope.Module(), frame, result_type, std::move(element_ids));
   }
   return mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -86,8 +86,7 @@ auto SnapshotNonLhsSubexpr(
           .name =
               std::format("_lyra_{}_arg{}", name_prefix, snapshot_counter++),
           .type = outer_expr.type});
-  captures.emplace_back(
-      mir::ByValueCapture{.value = outer_id, .binding = binding});
+  captures.emplace_back(mir::Capture{.value = outer_id, .binding = binding});
   return body.AddExpr(
       mir::Expr{
           .data =
@@ -249,12 +248,12 @@ auto BuildNbaSubmitClosureExpr(
   const mir::ExprId outer_self_read =
       outer_scope.AddExpr(BuildSelfRefExpr(frame, self_ptr_type));
   captures.emplace_back(
-      mir::ByValueCapture{.value = outer_self_read, .binding = self_id});
+      mir::Capture{.value = outer_self_read, .binding = self_id});
 
   const mir::ProceduralVarId rhs_binding = body.AddProceduralVar(
       mir::ProceduralVarDecl{.name = "_lyra_nba_rhs", .type = rhs_type});
   captures.emplace_back(
-      mir::ByValueCapture{.value = rhs_id_in_outer, .binding = rhs_binding});
+      mir::Capture{.value = rhs_id_in_outer, .binding = rhs_binding});
   const mir::ExprId rhs_ref_id = body.AddExpr(
       mir::Expr{
           .data =

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -390,7 +390,8 @@ auto BuildArrayMethodClosure(
             .declaration_procedural_depth = body_depth, .var = item_binding});
   }
 
-  CaptureSink sink{body_depth, body_scope, outer_scope};
+  CaptureSink sink{
+      body_depth, body_scope, outer_scope, process.Module().Unit()};
   // A with-clause body is a synchronous predicate / projection closure -- it
   // never suspends; its trailing `return` renders as a plain `return`.
   const WalkFrame closure_frame = body_frame.WithClosure(&sink)
@@ -399,12 +400,15 @@ auto BuildArrayMethodClosure(
                                       .WithCoroutineBody(false);
 
   mir::ExprId body_return_value{};
+  mir::TypeId return_type{};
   if (with_clause != nullptr) {
     auto body_expr_or = process.LowerExpr(
         hir_process.exprs.at(with_clause->expr.value), closure_frame);
     if (!body_expr_or) return std::unexpected(std::move(body_expr_or.error()));
+    return_type = body_expr_or->type;
     body_return_value = body_scope.AddExpr(*std::move(body_expr_or));
   } else {
+    return_type = item_type;
     body_return_value = body_scope.AddExpr(
         mir::Expr{
             .data =
@@ -419,20 +423,18 @@ auto BuildArrayMethodClosure(
           .data = mir::ReturnStmt{.value = body_return_value}});
 
   std::vector<mir::Capture> captures;
-  captures.emplace_back(
-      mir::ByValueCapture{.value = outer_self_read, .binding = self_binding});
+  captures.push_back(
+      mir::Capture{.value = outer_self_read, .binding = self_binding});
   for (const CaptureRequest& request : sink.TakeRequests()) {
-    captures.emplace_back(
-        mir::ByReferenceCapture{
-            .target = request.source, .binding = request.binding});
+    captures.push_back(
+        mir::Capture{.value = request.source, .binding = request.binding});
   }
   mir::ClosureExpr closure;
   closure.captures = std::move(captures);
   closure.params.push_back(mir::Parameter{.binding = item_binding});
   closure.params.push_back(mir::Parameter{.binding = index_binding});
   closure.body = std::make_unique<mir::ProceduralScope>(std::move(body_scope));
-  return mir::Expr{
-      .data = std::move(closure), .type = module.Unit().builtins.void_type};
+  return mir::Expr{.data = std::move(closure), .type = return_type};
 }
 
 // Fans out a system-subroutine call to the per-family handler under
@@ -578,7 +580,13 @@ auto LowerHirCallExprProc(
                 }
                 actual_id = proc_scope.AddExpr(*std::move(arg_or));
               }
-              args.push_back(actual_id);
+              if (is_ref_formal) {
+                args.push_back(BuildReferenceArg(
+                    process.Module().Unit(), proc_scope, actual_id,
+                    proc_scope.GetExpr(actual_id).type));
+              } else {
+                args.push_back(actual_id);
+              }
             }
             return mir::Expr{
                 .data =

--- a/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
@@ -217,7 +217,8 @@ auto LowerScanSystemSubroutineCall(
       mir::ProceduralVarDecl{.name = "self", .type = self_ptr_type});
   const mir::ExprId outer_self_read =
       outer_scope.AddExpr(BuildSelfRefExpr(frame, self_ptr_type));
-  CaptureSink sink{body_frame.procedural_depth, body, outer_scope};
+  CaptureSink sink{
+      body_frame.procedural_depth, body, outer_scope, process.Module().Unit()};
   // The scan IIFE is a synchronous body that returns a count -- no suspends.
   const WalkFrame closure_frame =
       body_frame.WithClosure(&sink)
@@ -353,16 +354,14 @@ auto LowerScanSystemSubroutineCall(
       body.AddExpr(mir::Expr{.data = count_ref, .type = integer_t});
   body.AppendStmt(mir::ReturnStmt{.value = return_value_id});
 
-  // The sync IIFE aliases the caller's storage, which is live throughout the
-  // closure's evaluation -- so every captured identity is a by-reference
-  // capture.
+  // The sync IIFE aliases the caller's storage (live throughout the closure's
+  // evaluation), so the sink gives every captured identity a reference binding.
   std::vector<mir::Capture> captures;
-  captures.emplace_back(
-      mir::ByValueCapture{.value = outer_self_read, .binding = self_binding});
+  captures.push_back(
+      mir::Capture{.value = outer_self_read, .binding = self_binding});
   for (const CaptureRequest& request : sink.TakeRequests()) {
-    captures.emplace_back(
-        mir::ByReferenceCapture{
-            .target = request.source, .binding = request.binding});
+    captures.push_back(
+        mir::Capture{.value = request.source, .binding = request.binding});
   }
   mir::ClosureExpr closure;
   closure.captures = std::move(captures);

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -185,7 +185,9 @@ auto BuildFormatSpecExpr(
     args.push_back(int_lit(is_time ? time_unit_power : 0));
   }
   return mir::Expr{
-      .data = mir::ConstructExpr{.args = std::move(args)},
+      .data =
+          mir::CallExpr{
+              .callee = mir::ConstructorCallee{}, .arguments = std::move(args)},
       .type = unit.builtins.format_spec};
 }
 
@@ -201,14 +203,20 @@ auto BuildPrintItemExpr(
                     .data = mir::StringLiteral{.value = lit.text},
                     .type = unit.builtins.string});
             return mir::Expr{
-                .data = mir::ConstructExpr{.args = {text}},
+                .data =
+                    mir::CallExpr{
+                        .callee = mir::ConstructorCallee{},
+                        .arguments = {text}},
                 .type = unit.builtins.print_literal_item};
           },
           [&](const mir::RuntimePrintValue& v) -> mir::Expr {
             const mir::ExprId spec = scope.AddExpr(
                 BuildFormatSpecExpr(unit, scope, v.spec, time_unit_power));
             return mir::Expr{
-                .data = mir::ConstructExpr{.args = {v.value, spec}},
+                .data =
+                    mir::CallExpr{
+                        .callee = mir::ConstructorCallee{},
+                        .arguments = {v.value, spec}},
                 .type = unit.builtins.print_value_item};
           }},
       item);

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -312,15 +312,15 @@ auto LowerSubroutineKind(hir::SubroutineKind kind) -> mir::SubroutineKind {
 auto LowerParamDirection(hir::ParamDirection dir) -> mir::ParamDirection {
   switch (dir) {
     case hir::ParamDirection::kInput:
+    // A ref / const ref formal is passed by value as a `Ref<T>`; the aliasing
+    // lives in the formal's `RefType`, not in the direction (LRM 13.5.2).
+    case hir::ParamDirection::kRef:
+    case hir::ParamDirection::kConstRef:
       return mir::ParamDirection::kInput;
     case hir::ParamDirection::kOutput:
       return mir::ParamDirection::kOutput;
     case hir::ParamDirection::kInOut:
       return mir::ParamDirection::kInOut;
-    case hir::ParamDirection::kRef:
-      return mir::ParamDirection::kRef;
-    case hir::ParamDirection::kConstRef:
-      return mir::ParamDirection::kConstRef;
   }
   throw InternalError("LowerParamDirection: unknown hir::ParamDirection");
 }
@@ -368,17 +368,21 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
   params.reserve(src.params.size());
   for (const auto& param : src.params) {
     const auto& hir_var = src.body.procedural_vars.at(param.var.value);
-    const mir::TypeId type = module_->TranslateType(hir_var.type);
-    // A ref / const ref formal aliases the actual's cell, so its body var is a
-    // reference binding the backend renders as `Ref<T>` (LRM 13.5.2).
-    const mir::VariableBinding binding =
-        (param.direction == hir::ParamDirection::kRef ||
-         param.direction == hir::ParamDirection::kConstRef)
-            ? mir::VariableBinding::kReference
-            : mir::VariableBinding::kValue;
+    const mir::TypeId value_type = module_->TranslateType(hir_var.type);
+    // A `ref` / `const ref` formal's type is a `Ref<T>` over the value type
+    // (LRM 13.5.2) -- the reference is itself the data type, so the direction
+    // stays `kInput`. Every other direction keeps the value type.
+    const bool by_reference = param.direction == hir::ParamDirection::kRef ||
+                              param.direction == hir::ParamDirection::kConstRef;
+    const mir::TypeId type =
+        by_reference ? module_->Unit().AddType(
+                           mir::TypeData{mir::RefType{
+                               .pointee = value_type,
+                               .is_const = param.direction ==
+                                           hir::ParamDirection::kConstRef}})
+                     : value_type;
     const mir::ProceduralVarId mir_var = body_scope.AddProceduralVar(
-        mir::ProceduralVarDecl{
-            .name = hir_var.name, .type = type, .binding = binding});
+        mir::ProceduralVarDecl{.name = hir_var.name, .type = type});
     MapProceduralVar(
         param.var,
         AutomaticVarBinding{

--- a/src/lyra/lowering/hir_to_mir/self_ref.cpp
+++ b/src/lyra/lowering/hir_to_mir/self_ref.cpp
@@ -1,6 +1,11 @@
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
 
+#include <variant>
+
+#include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -9,6 +14,26 @@ auto BuildSelfRefExpr(const WalkFrame& frame, mir::TypeId self_ptr_type)
   return mir::MakeProceduralVarRefExpr(
       frame.procedural_depth - frame.self_decl_depth, *frame.self_binding,
       self_ptr_type);
+}
+
+auto BuildReferenceArg(
+    mir::CompilationUnit& unit, mir::ProceduralScope& scope, mir::ExprId cell,
+    mir::TypeId pointee) -> mir::ExprId {
+  // The reference aliases the cell's value, not its storage wrapper: a `Ref<T>`
+  // over an observable cell binds the underlying `Var<T>`, so the pointee is
+  // the value type, not the `ObservableType`.
+  const auto& pointee_ty = unit.GetType(pointee);
+  if (std::holds_alternative<mir::ObservableType>(pointee_ty.data)) {
+    pointee = std::get<mir::ObservableType>(pointee_ty.data).value;
+  }
+  const mir::TypeId ref_type = unit.AddType(
+      mir::TypeData{mir::RefType{.pointee = pointee, .is_const = false}});
+  return scope.AddExpr(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee = mir::ConstructorCallee{}, .arguments = {cell}},
+          .type = ref_type});
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -291,7 +291,9 @@ auto LowerSubroutineCallWithWritebacks(
           actual_id = RewriteLhsRootWithMutate(
               process.Module().Unit(), wrapper, actual_id, services_id);
         }
-        call_args.push_back(actual_id);
+        call_args.push_back(BuildReferenceArg(
+            process.Module().Unit(), wrapper, actual_id,
+            wrapper.GetExpr(actual_id).type));
         continue;
       }
       auto arg_or = process.LowerExpr(hir_arg, wrapper_frame);

--- a/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
@@ -39,10 +39,11 @@ auto LowerJoinMode(hir::JoinMode mode) -> mir::JoinMode {
 
 // LRM 9.3.2: a fork is a procedural scope. Its block_item_declarations lower
 // into that scope and initialize at block entry -- in the parent, before any
-// branch spawns. Each branch lowers to a closure composed into the fork
-// scope's expr arena. The capture sink collects every enclosing reference
-// the body makes as an identity; fork then assigns each capture's kind based
-// on its declaration depth (LRM 6.21).
+// branch spawns. Each branch lowers to a coroutine-typed closure composed into
+// the fork scope's expr arena. The capture sink collects every enclosing
+// reference the body makes; a fork-scope-local snapshots by value, a
+// deeper-declared enclosing variable aliases the live cell by reference (LRM
+// 6.21). The receiver `self` is the closure's first by-value capture.
 auto LowerForkStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::ForkStmt& f) -> diag::Result<mir::Stmt> {
@@ -60,8 +61,8 @@ auto LowerForkStmt(
     fork_scope.AppendStmt(*std::move(lowered));
   }
 
-  std::vector<mir::ExprId> branch_ids;
-  branch_ids.reserve(f.branches.size());
+  std::vector<mir::ExprId> branches;
+  branches.reserve(f.branches.size());
   const mir::TypeId self_ptr_type =
       process.Module().Unit().builtins.self_pointer;
   for (const hir::StmtId branch_hir_id : f.branches) {
@@ -73,10 +74,14 @@ auto LowerForkStmt(
     const mir::ExprId outer_self_read =
         fork_scope.AddExpr(BuildSelfRefExpr(fork_frame, self_ptr_type));
 
+    // A fork-scope local is snapshotted by value; a deeper enclosing variable
+    // aliases through a reference capture (LRM 6.21).
     CaptureSink sink{
-        fork_frame.procedural_depth.Inner(), branch_scope, fork_scope};
-    // LRM 9.3.2 fork branch: each branch is a concurrent thread that may
-    // suspend on timing controls / event waits inside its body.
+        fork_frame.procedural_depth.Inner(), branch_scope, fork_scope,
+        process.Module().Unit(), fork_depth};
+    // LRM 9.3.2: a branch is a concurrent thread whose body may suspend on
+    // timing controls / event waits, so it lowers as a coroutine body --
+    // returns inside it become `co_return`.
     const WalkFrame branch_frame =
         fork_frame.WithClosure(&sink)
             .WithProceduralScope(&branch_scope)
@@ -89,30 +94,24 @@ auto LowerForkStmt(
       return std::unexpected(std::move(lowered.error()));
     }
     branch_scope.AppendStmt(*std::move(lowered));
+    branch_scope.AppendStmt(
+        mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
 
     std::vector<mir::Capture> captures;
-    captures.emplace_back(
-        mir::ByValueCapture{
-            .value = outer_self_read, .binding = branch_self_id});
+    captures.push_back(
+        mir::Capture{.value = outer_self_read, .binding = branch_self_id});
     for (const CaptureRequest& request : sink.TakeRequests()) {
-      if (request.decl_depth == fork_depth) {
-        captures.emplace_back(
-            mir::ByValueCapture{
-                .value = request.source, .binding = request.binding});
-      } else {
-        captures.emplace_back(
-            mir::ByReferenceCapture{
-                .target = request.source, .binding = request.binding});
-      }
+      captures.push_back(
+          mir::Capture{.value = request.source, .binding = request.binding});
     }
     mir::ClosureExpr closure;
     closure.captures = std::move(captures);
     closure.body =
         std::make_unique<mir::ProceduralScope>(std::move(branch_scope));
-    branch_ids.push_back(fork_scope.AddExpr(
+    branches.push_back(fork_scope.AddExpr(
         mir::Expr{
             .data = std::move(closure),
-            .type = process.Module().Unit().builtins.void_type}));
+            .type = process.Module().Unit().builtins.coroutine}));
   }
 
   const mir::ProceduralScopeId scope_id =
@@ -122,7 +121,7 @@ auto LowerForkStmt(
       .data = mir::ForkStmt{
           .mode = LowerJoinMode(f.mode),
           .scope = scope_id,
-          .branches = std::move(branch_ids)}};
+          .branches = std::move(branches)}};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -192,6 +192,12 @@ class MirDumper {
               }
               throw InternalError("dump: unknown RuntimeLibraryKind");
             },
+            [](const CoroutineType&) -> std::string { return "Coroutine"; },
+            [](const RefType& r) -> std::string {
+              return std::format(
+                  "Ref({}pointee=Type[{}])", r.is_const ? "const, " : "",
+                  r.pointee.value);
+            },
             [](const PointerType& p) -> std::string {
               switch (p.ownership) {
                 case PointerOwnership::kUnique:
@@ -428,6 +434,9 @@ class MirDumper {
                   },
                   b.method);
             },
+            [](const ConstructorCallee&) -> std::string {
+              return "ConstructorCallee";
+            },
         },
         callee);
   }
@@ -620,16 +629,6 @@ class MirDumper {
               }
               return std::format("ArrayLiteralExpr elements=[{}]", elements);
             },
-            [](const ConstructExpr& c) -> std::string {
-              std::string args;
-              for (std::size_t i = 0; i < c.args.size(); ++i) {
-                if (i != 0) {
-                  args += ", ";
-                }
-                args += std::format("Expr[{}]", c.args[i].value);
-              }
-              return std::format("ConstructExpr args=[{}]", args);
-            },
         },
         e.data);
     return std::format("{} type=Type[{}]", formatted, e.type.value);
@@ -738,10 +737,6 @@ class MirDumper {
         return "output";
       case ParamDirection::kInOut:
         return "inout";
-      case ParamDirection::kRef:
-        return "ref";
-      case ParamDirection::kConstRef:
-        return "const ref";
     }
     throw InternalError("FormatParamDirection: unknown mir::ParamDirection");
   }
@@ -774,9 +769,8 @@ class MirDumper {
         const auto& v = scope.vars[i];
         Line(
             std::format(
-                "ProceduralVar[{}] \"{}\" : Type[{}]{}", i, v.name,
-                v.type.value,
-                v.binding == VariableBinding::kReference ? " ref" : ""));
+                "ProceduralVar[{}] \"{}\" : Type[{}]", i, v.name,
+                v.type.value));
       }
       Dedent();
     }
@@ -1075,36 +1069,16 @@ class MirDumper {
   void DumpCapture(
       std::size_t index, const Capture& capture,
       const ProceduralScope& enclosing) {
-    std::visit(
-        Overloaded{
-            [&](const ByValueCapture& bv) {
-              Line(
-                  std::format(
-                      "[{}] ByValueCapture value=Expr[{}] binding="
-                      "ProceduralVarId{{{}}}",
-                      index, bv.value.value, bv.binding.value));
-              Indent();
-              Line(
-                  std::format(
-                      "Expr[{}] {}", bv.value.value,
-                      FormatExpr(enclosing, bv.value)));
-              Dedent();
-            },
-            [&](const ByReferenceCapture& br) {
-              Line(
-                  std::format(
-                      "[{}] ByReferenceCapture target=Expr[{}] binding="
-                      "ProceduralVarId{{{}}}",
-                      index, br.target.value, br.binding.value));
-              Indent();
-              Line(
-                  std::format(
-                      "Expr[{}] {}", br.target.value,
-                      FormatExpr(enclosing, br.target)));
-              Dedent();
-            },
-        },
-        capture);
+    Line(
+        std::format(
+            "[{}] Capture value=Expr[{}] binding=ProceduralVarId{{{}}}", index,
+            capture.value.value, capture.binding.value));
+    Indent();
+    Line(
+        std::format(
+            "Expr[{}] {}", capture.value.value,
+            FormatExpr(enclosing, capture.value)));
+    Dedent();
   }
 
   void DumpRuntimePrintCallItems(

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -78,6 +78,8 @@ auto Type::Kind() const -> TypeKind {
           [](const SelfType&) { return TypeKind::kSelf; },
           [](const ServicesType&) { return TypeKind::kServices; },
           [](const RuntimeLibraryType&) { return TypeKind::kRuntimeLibrary; },
+          [](const CoroutineType&) { return TypeKind::kCoroutine; },
+          [](const RefType&) { return TypeKind::kReference; },
           [](const PointerType&) { return TypeKind::kPointer; },
           [](const VectorType&) { return TypeKind::kVector; },
           [](const ExternalRefType&) { return TypeKind::kExternalRef; },


### PR DESCRIPTION
## Summary

A SystemVerilog reference -- `ref` / `const ref` formals and fork-branch by-reference captures -- is now a first-class `RefType` MIR data type, a library wrapper alongside the observable cell, rather than a flag on a procedural-var binding or a parameter direction. A value of this type is read through `.Get()` and written through `.Set()` exactly like an observable cell, driven by its type alone, so the backend never re-derives reference-ness; a `ref` formal's MIR type is the `RefType` and its direction stays `kInput`. Constructing one from a cell is an explicit MIR operation, not a backend-synthesized wrap.

## Design

Closures now render mechanically from their captures, parameters, result type, and body alone. The lambda return type comes from the closure expression's own type (a coroutine fork branch carries the coroutine result type), never by diving into the body to find a return statement. By-value versus by-reference capture is the captured binding's type (a value type versus a `RefType`), not a separate capture kind, so the capture list collapses to a single shape and the C++ clause never needs `[&]`.

Construction folds into a generic constructor call: a constructor is just a call whose callee is the type itself (Python's `T(args)`, Rust's `T::new(args)`), so the old `ConstructExpr` primitive is replaced by a `ConstructorCallee` on the existing call node. A reference argument is built as such a construction over the actual's cell, which renders directly now that observable reads are explicit `Get` calls in MIR.