### PR TITLE
Model the C++ backend as a rendering fold

### DIFF
--- a/docs/architecture/lowering_organization.md
+++ b/docs/architecture/lowering_organization.md
@@ -35,14 +35,26 @@ ruled out by the constraint, irrespective of how the constraint is currently rea
 
 ## Purpose
 
-Define how a lowering or rendering pass is structured: the class shape, the dispatcher method
-signature, the three kinds of fields a class member may be, the per-kind handler shape, and the
-rules that keep new concepts cheap to add and the class bounded.
+A pass over one IR comes in two kinds, divided by whether it accumulates task-lifetime shared state:
+
+- A **construction pass** builds a structured output whose parts cross-reference each other and
+  accumulates shared registries (a dedup cache, a binding table) as it walks. HIR-to-MIR lowering is
+  one; a future MIR-to-LLVM backend -- accumulating an SSA value map, building a cross-referenced
+  function -- is another.
+- A **rendering fold** maps each node to a fragment of an unstructured medium and composes the
+  fragments by concatenation, accumulating nothing. The MIR-to-C++ text backend is one: a node's
+  rendered text never references another node's, so there is no shared output to own.
+
+The dividing question is always "what task-lifetime shared mutable state exists?" -- registries
+justify the class; their absence is what makes a fold a fold. This document defines the
+construction-pass shape (the class, the dispatcher signature, the three member kinds, the per-kind
+handler shape, the `WalkFrame`); the rendering-fold shape (free functions, a read-only lookup
+threaded down, a per-callable-body temp counter) is defined separately under "Rendering Folds."
 
 ## Owns
 
-- The pattern that every lowering or rendering pass is implemented as a class scoped to one task
-  instance (one process, one scope, one unit, etc.).
+- The pattern that every construction pass is implemented as a class scoped to one task instance
+  (one process, one scope, one unit, etc.).
 - The classification of every class member into one of three kinds: facts, registries, and the owned
   root output. Nested builders opened during the walk are stack-allocated inside the walker that
   opens them; they are never class members.
@@ -52,8 +64,9 @@ rules that keep new concepts cheap to add and the class bounded.
 - The constructor convention: facts are injected at construction; registries are owned by the class;
   the root output is constructed in the constructor (or at `Run`'s entry) and moved out of the class
   by `Run`'s return.
-- The rule that the pattern is shared across lowering and rendering passes while concrete types are
-  per pass.
+- The rule that the construction-pass pattern is shared by every accumulating pass (HIR-to-MIR
+  lowering, a future IR-emitting backend) while concrete types are per pass, and that a rendering
+  fold is a distinct shape, not an instance of it.
 
 ## Does Not Own
 
@@ -63,10 +76,10 @@ rules that keep new concepts cheap to add and the class bounded.
 
 ## Core Invariants
 
-1. Every lowering or rendering pass is implemented as a class named for the unit of work it
-   processes and the action it performs (`ProcessLowerer`, `CppProcessRenderer`,
-   `StructuralScopeLowerer`). The class is constructed once per task instance and destroyed when
-   that task completes; one class instance does not span multiple task instances.
+1. Every construction pass is implemented as a class named for the unit of work it processes and the
+   action it performs (`ProcessLowerer`, `StructuralScopeLowerer`). The class is constructed once
+   per task instance and destroyed when that task completes; one class instance does not span
+   multiple task instances. A rendering fold is not a class (see "Rendering Folds").
 
 2. The class constructor receives the read-only facts the pass depends on. After construction those
    facts are not mutated. Registries the pass accumulates and the root output the pass is
@@ -117,13 +130,14 @@ rules that keep new concepts cheap to add and the class bounded.
    contract, so there is only one unit per pass, never a "current vs other" notion. Owning the root
    on the class corrects that misplacement.
 
-6. `WalkFrame` is a small value type holding **per-recursion traversal context only**: a pointer to
-   the current write-target nested builder, the current procedural depth, an optional closure
-   context, and any future stack-discipline state. It is passed by value between walker methods.
-   Each recursion may construct a new frame with different fields set; the cost of copying is
-   trivial. Walk-invariant facts (the unit currently being constructed, source mapper, builtins
-   table) are class members on the pass class, not `WalkFrame` fields -- only state that genuinely
-   changes from one recursion to the next belongs on `WalkFrame`. Writes to nested scopes go through
+6. `WalkFrame` is a construction pass's **walk position** (see "The Walk Position"): a small value
+   type holding **per-recursion traversal context only** -- the scope chain plus a pointer to the
+   current write-target nested builder, the current procedural depth, an optional closure context,
+   and any future stack-discipline state. It is passed by value between walker methods. Each
+   recursion may construct a new frame with different fields set; the cost of copying is trivial.
+   Walk-invariant facts (the unit currently being constructed, source mapper, builtins table) are
+   class members on the pass class, not `WalkFrame` fields -- only state that genuinely changes from
+   one recursion to the next belongs on `WalkFrame`. Writes to nested scopes go through
    `frame.current_*_scope->Add...`; writes to the root output go through the pass class's narrow
    methods (see invariant 5).
 
@@ -136,9 +150,15 @@ rules that keep new concepts cheap to add and the class bounded.
    appear on any pass class, any member type, or any field name. Type names describe what the type
    represents.
 
-9. The pattern (class plus dispatcher methods plus per-kind handler free functions plus `WalkFrame`)
-   is identical across lowering and rendering passes. Concrete types (`ProcessLowerer`,
-   `CppProcessRenderer`) are per pass; no base type spans lowering or rendering pass boundaries.
+9. The dividing line between the class pattern and the fold shape is whether the pass accumulates
+   task-lifetime shared state -- not whether it is called "lowering" or "rendering." Every
+   construction pass (accumulates registries, builds a cross-referenced output) takes the
+   class-plus-dispatcher-plus-handler-plus-`WalkFrame` shape, whether it lowers HIR to MIR or emits
+   MIR to a structured backend IR. A rendering fold (composes an unstructured medium, accumulates
+   nothing) takes the fold shape instead (see "Rendering Folds"). The earlier formulation claimed
+   the class pattern was identical across lowering and rendering; that conflated a structured
+   backend (which does accumulate, so is a construction pass) with a text fold (which does not).
+   Concrete types are per pass; no base type spans pass boundaries.
 
 10. Per-kind dispatch is centralised in exactly one location, and that location is decoupled from
     the pass class header so the header does not grow per kind. Per-kind handlers form a layer the
@@ -169,6 +189,85 @@ rules that keep new concepts cheap to add and the class bounded.
     `lowerer.Module().InternType(...)`. `proc.Module()` returns the `ModuleLowerer&` the
     `ProcessLowerer` captured at construction.
 
+## The Walk Position
+
+Every pass over an IR is a recursion, and at each node the recursion needs context that is not in
+the node but follows from where the node sits in the tree. That context is the **walk position**,
+threaded by value down the recursion. Its universal core is the **scope chain**: a hops-relative
+reference (a procedural-var reference at `hops > 0`, a structural-var reference at `hops > 0`)
+resolves only by climbing the chain of enclosing scopes. Every pass -- lowering, fold, or a future
+structured backend -- carries this chain and resolves hops the same way (`StructuralScopeAtHops`,
+`ProceduralScopeAtHops`).
+
+What a pass adds on top of the scope chain follows from what it does:
+
+- A **construction pass** adds write-targets (the nested scope being built) and the decision state
+  it uses to compute what to build: the procedural depth (to _compute_ a reference's hop count at
+  the write site), the active capture sink, the lvalue-target flag, the `self` binding, the
+  coroutine-body flag. This is the fat walk position -- `WalkFrame` in HIR-to-MIR.
+- A **fold** adds nothing. Its walk position is the read-only scope chain alone, because every
+  decision the construction pass made is already baked into the MIR it reads. It does not _compute_
+  a hop count; it _resolves_ an already-baked one to a name. This is the thin walk position -- the
+  MIR-to-C++ read-only scope view.
+
+The walk position thins as the pipeline descends: each pass that bakes a decision into the IR
+removes state a later pass would otherwise carry. HIR-to-MIR carries a fat frame because it is still
+deciding hops, captures, and callees; the C++ fold carries almost nothing because those decisions
+are now MIR nodes. The same force that let R12 / R16 / R17 strip render-time decisions is what thins
+the walk position.
+
+Two consequences for type structure:
+
+- **The concept is shared; the type is per pass.** A construction pass's `WalkFrame` and the fold's
+  scope view are two instances of one concept, not one type. Merging them would drag the
+  construction-only fields (write-targets, depth, capture sink) into a fold that never uses them.
+  The structural-scope-chain mirror is already deliberate -- `WalkFrame`'s scope-chain node carries
+  a comment that it mirrors the render side's parent link so both reach the same `StructuralVarDecl`
+  -- and naming the render side to match makes that mirror explicit instead of comment-enforced.
+- **A fold need not split invariant facts from the walk position.** A construction pass keeps
+  walk-invariant facts (the unit, builtins) on its class and only per-recursion state on
+  `WalkFrame`, because facts must stay immutable and stay out of the copied-per-recursion frame. A
+  fold has no class and mutates nothing, so its one immutable threaded value carries both the
+  walk-invariant lookup (the unit, for type and arena reads) and the per-recursion scope chain. The
+  split that protects a construction pass buys a fold nothing.
+- **The two passes resolve the chain differently per axis, and that is correct.** For a procedural
+  reference, a construction pass computes the hop count from a depth counter plus its binding
+  registry (symbol -> declaration depth) and never reads the ancestor procedural scope; the fold has
+  no registry, so it climbs the procedural chain to read the referenced var's name. The fold's
+  procedural chain is the read-side substitute for the construction pass's binding registry -- the
+  same registry-presence distinction that separates the two pass kinds. The structural chain, by
+  contrast, both passes climb, because a structural var's declared MIR storage type lives only in
+  the constructed scope and must be read there by whoever needs it (a structural reference, or a
+  static-lifetime local promoted to a per-instance structural var). Forcing the two axes onto one
+  mechanism would either carry a chain a construction pass never reads or demand a name a counter
+  cannot produce.
+
+## Rendering Folds
+
+A rendering fold emits an unstructured medium (today, C++ text) from an IR. It is not a construction
+pass and does not take the class shape, because the two things the class exists to own are both
+absent: there is no shared registry to accumulate (a node's text is computed and returned, never
+written into a cross-walk accumulator), and there is no structured root to own (the output is text
+composed by concatenation, with no node referencing another). What remains is genuinely small:
+
+- Per-kind handlers are free functions that return the rendered fragment for their node; a parent
+  composes its children's fragments.
+- The only context threaded down is the fold's thin **walk position** (see "The Walk Position"): a
+  read-only lookup carrying the unit (for type and arena reads) and the chain of enclosing scopes
+  (to resolve a hops-relative reference to a name). It is immutable, it accumulates nothing, and it
+  grows no member per concept -- so it is not the forbidden `*Context`, which is banned for being a
+  mutable, growing carrier that stands in for a class. Threading an immutable lookup down a fold is
+  the ordinary functional shape, not that anti-pattern.
+- The one piece of mutable state -- a temp-name counter -- is local to a single callable body's
+  render, declared where that body's render begins and threaded by reference through its statement
+  handlers. It is not task-lifetime state and lives on no context object.
+
+The fold has no `WalkFrame` (no traversal-position state beyond the scope chain in the lookup), no
+registries, and no owned root. The opposite case is a structured backend (MIR to LLVM IR): it
+accumulates an SSA value map and builds a cross-referenced function, so it is a construction pass
+and takes the class shape above. "Backend" is therefore not one shape -- a text emit is a fold, a
+structured-IR emit is a construction pass.
+
 ## Boundary to Adjacent Layers
 
 - A pass class is a layer-internal artifact. It is not exposed across lowering or rendering
@@ -179,9 +278,14 @@ rules that keep new concepts cheap to add and the class bounded.
 
 ## Forbidden Shapes
 
-- A pass implemented as free functions threading a context-like object as a separate parameter.
+- A construction pass implemented as free functions threading a context-like object as a separate
+  parameter. The constraint is that an accumulating pass must be a class; it is not that free
+  functions are forbidden everywhere -- a rendering fold is free functions by nature (see "Rendering
+  Folds").
 - A `RenderContext`, `LoweringContext`, or any other `*Context` type used as the carrier for facts,
-  builders, or walk-frame state. The name is an open invitation to unbounded growth.
+  registries, builders, or walk-frame state -- anything the pass accumulates or mutates. The name is
+  an open invitation to unbounded growth. A rendering fold's immutable read-only lookup (the unit
+  plus the scope chain, growing no member per concept) is not this shape.
 - A class instance shared across multiple task instances (one `ProcessLowerer` reused for several
   processes).
 - A class member whose lifetime exceeds the class's task instance.
@@ -190,10 +294,12 @@ rules that keep new concepts cheap to add and the class bounded.
   handler free functions are a different shape: they take the pass class instance explicitly because
   they live outside the class, but the instance is the single access channel -- no further narrowed
   references.)
-- An immutable-context-with-`With*()` copy-on-descend pattern. The pattern's superficial appeal is
-  symmetry with the walk frame; its cost is the Context name's open invitation, the `mutable` escape
-  hatch required for accumulating state, and the parallel structure needed for the class that owns
-  the accumulators.
+- An immutable-context-with-`With*()` copy-on-descend pattern used to carry a construction pass's
+  state. Its cost is the Context name's open invitation, the `mutable` escape hatch a construction
+  pass needs for its accumulators, and the parallel structure for the class that owns them. A
+  rendering fold threading an immutable scope-chain lookup down with copy-on-descend is the ordinary
+  functional shape, not this anti-pattern: a fold accumulates nothing, so there is no mutable escape
+  hatch and no parallel accumulator class.
 - A walker struct passed as the single fat parameter. Same pathology as a context, with a different
   name.
 - A `*State` suffix on a class, a member, or a field.
@@ -220,8 +326,7 @@ rules that keep new concepts cheap to add and the class bounded.
   `Build*` factory and interned by the caller; `mir::ExprId`-returning helpers are reserved for
   transforms keyed on an input `mir::ExprId` (which read or pass through an existing arena node).
   See "Expression-Builder Helpers".
-- A shared base class spanning lowering and rendering pass classes. The pattern is shared; types are
-  per pass.
+- A shared base class spanning construction-pass classes. The pattern is shared; types are per pass.
 - A dispatcher method or per-kind handler that mutates the class's fact members. Facts are mutated
   only by the constructor.
 - A bundle of multiple kinds (facts + registry + builder) into one type. Each member of a class is a

--- a/docs/decisions/lowering-organization.md
+++ b/docs/decisions/lowering-organization.md
@@ -1,6 +1,6 @@
 # Lowering organization
 
-Date: 2026-06-08 Status: accepted
+Date: 2026-06-08 Status: accepted (rendering classification revised 2026-06-19 -- see "Revision")
 
 ## Context
 
@@ -264,3 +264,43 @@ stylistic.
 - The architecture contract `lowering_organization.md` gains invariants 10-12 and the "Multi-File
   Organization Within a Pass Layer" section codifying this shape so the HIR-to-MIR (R10) and
   MIR-to-cpp (R11) migrations land on the same pattern.
+
+## Revision (2026-06-19): rendering is a fold, not a construction pass
+
+The original decision pinned one shape across "every lowering or rendering pass" and prescribed that
+`RenderContext` become `CppProcessRenderer` (a class), with `mutable owned_temp_counter_` becoming a
+class-owned registry. That classification of the MIR-to-C++ backend is revised here. The lowering
+half of the decision is unchanged.
+
+What actually happened diverged from the prescription. The render-to-class migration never landed:
+the backend stayed free functions with an immutable threaded lookup, and R11 made the temp counter a
+callable-body **local** (`std::size_t temp_counter` threaded by reference), not a class-owned
+registry. The implementation had already chosen the fold shape.
+
+The original rationale has thinned. The rejection of the immutable-Context shape rested on three
+costs: the `Context` name as a hospitality desk; the `mutable` escape hatch "the moment accumulation
+is needed (the backend's `owned_temp_counter_` is exactly that breach)"; and a parallel accumulator
+class beside the Context. The second and third costs presuppose that rendering accumulates state.
+Four cuts landed after this decision and removed every accumulation and every render-time decision
+from the backend: R11 (temp counter to a local), R12 (observable `Get` / `Set` / `Mutate` to
+explicit MIR calls), R16 (receiver to an explicit `self` member access in MIR), R17 (selector and
+field access to explicit MIR calls). With no accumulation left, there is no `mutable` breach and no
+accumulator class -- a render class would own only facts, with neither a registry nor a structured
+root to justify it. Only the first cost (the name's invitation to grow) survives, and it is answered
+by keeping the threaded lookup immutable and member-bounded rather than by wrapping the fold in a
+class.
+
+The corrected dividing line is whether a pass accumulates task-lifetime shared state, not whether it
+is called lowering or rendering. A **construction pass** -- one that accumulates registries and
+builds a cross-referenced output -- keeps the class shape from this decision; HIR-to-MIR lowering is
+one, and a future MIR-to-LLVM backend (accumulating an SSA value map, building a cross-referenced
+function) is another. The MIR-to-C++ text emit is a **rendering fold**: it composes an unstructured
+medium by concatenation, accumulates nothing, and so is free functions with an immutable read-only
+lookup (the unit plus the scope chain for hops resolution) threaded down and a callable-body-local
+temp counter. The architecture contract reflects this in `lowering_organization.md` (invariant 9,
+the "Rendering Folds" section, and the narrowed `*Context` forbidden shapes).
+
+Everything else in this decision stands: the god-object / `*State` removal, class-per-task for every
+accumulating pass, the constructor-injects-facts rule, the three member kinds, `WalkFrame` for
+per-recursion traversal state, the two-parameter dispatcher signature, and the multi-file subsystem
+organization.

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -197,27 +197,18 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       (see R18). The mutable escape hatch is the one shape that is unambiguously wrong from any
       vantage. **Trigger**: standalone -- can be picked up at any time.
 
-- [ ] R12 -- A signal read / write is an explicit access call in MIR, not a render-time decision.
-      The observable-storage wrapper is already a first-class MIR type (sibling to the
-      owning-pointer and vector wrappers): a signal field's type is the wrapper and
-      `RenderTypeAsCpp` maps it straight to `lyra::runtime::Var<T>`. What remains is the access
-      half. The wrapper's `Get` / `Set` / `Mutate` are still injected by the backend -- a value read
-      appends `.Get()`, a write routes through `.Set()` / `.Mutate()`, each gated on the backend
-      reading the wrapper type at the access site. Per the mir.md boundary note these are
-      library-API method calls and belong in MIR: HIR-to-MIR should emit a `Get` call for a value
-      read and a `Set` / `Mutate` call for a write, so the backend renders the call like any other
-      and never asks "is this observable" at access time. The value/storage duality -- a signal is
-      read as a value but its cell is the target of a write or a reference binding -- is then
-      carried by which call wraps the cell, not by a render-time branch. **Known consequence
-      today**: pass-by-reference of an observable scalar (LRM 13.5.2) needs the bare cell, not a
-      value read, so its argument is currently routed through a backend lvalue render to dodge the
-      injected `.Get()`; once reads are explicit calls a bare cell renders directly and that route
-      collapses. **Why deferred**: cross-cuts all signal value access (read, write, sensitivity) and
-      is its own focused cut, and the current render-time decision is behaviorally correct.
-      **Trigger**: standalone -- highest leverage taken together with R2, which reworks the same
-      observable decision from the capability-gating angle (wrap every value type uniformly, push
-      unsupported change-tracking to explicit diagnostics). Done together they leave the backend a
-      pure renderer of explicit calls.
+- [x] R12 -- A signal read / write is an explicit access call in MIR, not a render-time decision.
+      The observable-storage wrapper is a first-class MIR type (sibling to the owning-pointer and
+      vector wrappers): a signal field's type is the wrapper and `RenderTypeAsCpp` maps it straight
+      to `lyra::runtime::Var<T>`. The access half is now explicit too -- HIR-to-MIR emits an
+      observable `Get` call for a value read and a `Set` / `Mutate` call for a write, so the backend
+      renders each like any other call and never asks "is this observable" at access time. The
+      value/storage duality -- a signal is read as a value but its cell is the target of a write or
+      a reference binding -- is carried by which call wraps the cell, not by a render-time branch.
+      The backend's `IsObservableScalarType` predicate is gone. See
+      `docs/decisions/value-type-concepts.md`. R2 still reworks the same observable surface from the
+      capability-gating angle (wrap every value type uniformly, push unsupported change-tracking to
+      explicit diagnostics).
 
 - [x] R13 -- HIR-to-MIR per-LRM-family subsystem split. Per-kind handlers are now grouped by
       semantic family in
@@ -329,11 +320,11 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       both local to one callable body, both plain locals in the callable's render function. Each
       callable kind (process, task, function, constructor, fork-branch, deferred closure) becomes
       one render function; per-node-kind handlers are free functions taking only what they read. The
-      result is the mechanical-translation shape rendering should always have had;
-      `lowering_organization.md` invariant 9 (which today claims lowering and rendering share the
-      same pattern) is updated in this cut to reflect that the patterns are distinct -- lowering
-      makes semantic decisions, rendering doesn't. **Trigger**: scheduled after R11, R12, R14, R15,
-      R16, R17 all land.
+      result is the mechanical-translation shape rendering should always have had: a rendering fold,
+      not a construction pass. `lowering_organization.md` already reflects this distinction
+      (invariant 9, the "Rendering Folds" section, and the narrowed `*Context` forbidden shapes);
+      this cut brings the code to the fold shape the contract now describes. **Trigger**: R11, R12,
+      R14, R15, R16, R17 have all landed; ready to pick up.
 
 - [x] R19 -- LRM 10.5 variable initialization lowers to an `AssignExpr` statement at the top of
       `constructor_scope.root_stmts`, with the value being the user-supplied expression when present

--- a/include/lyra/backend/cpp/render_expr.hpp
+++ b/include/lyra/backend/cpp/render_expr.hpp
@@ -2,19 +2,19 @@
 
 #include <string>
 
-#include "lyra/backend/cpp/render_context.hpp"
+#include "lyra/backend/cpp/scope_view.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/expr.hpp"
 
 namespace lyra::backend::cpp {
 
-auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
+auto RenderExpr(const ScopeView& view, const mir::Expr& expr)
     -> diag::Result<std::string>;
 
 // Bare field name (no `.Get()` wrap) for callsites that need the Var place
 // itself rather than its value, e.g. the trigger pointers inside `WaitAny`.
 auto RenderStructuralVarName(
-    const RenderContext& ctx, const mir::StructuralVarRef& ref)
+    const ScopeView& view, const mir::StructuralVarRef& ref)
     -> diag::Result<std::string>;
 
 // Renders `expr` as an lvalue: bare root + element / range select suffixes.
@@ -22,14 +22,14 @@ auto RenderStructuralVarName(
 // adapter (if any) is encoded explicitly in MIR as a
 // `DerefExpr(CallExpr(ObservableMethod{kMutate}, ...))` node by HIR-to-MIR,
 // so this render is purely structural -- it does not inject any wrapper.
-auto RenderLhsExpr(const RenderContext& ctx, const mir::Expr& expr)
+auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
     -> diag::Result<std::string>;
 
 // Renders `expr` for use in a C++ boolean context (`if`, `while`, `do`, `for`
 // condition, ternary cond, `&&` / `||` / `!`). When the expression's MIR type
 // is a packed array, `PackedArray`'s `explicit operator bool` fires on the
 // contextual conversion; no explicit wrapping is needed.
-auto RenderConditionAsBool(const RenderContext& ctx, const mir::Expr& expr)
+auto RenderConditionAsBool(const ScopeView& view, const mir::Expr& expr)
     -> diag::Result<std::string>;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/backend/cpp/render_print.hpp
+++ b/include/lyra/backend/cpp/render_print.hpp
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "lyra/backend/cpp/render_context.hpp"
+#include "lyra/backend/cpp/scope_view.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/expr.hpp"
 
@@ -12,7 +12,7 @@ namespace lyra::backend::cpp {
 // RenderExpr's RuntimeCallExpr arm; the surrounding RenderStmt::ExprStmt path
 // adds the trailing `;` like for any other expression.
 auto RenderRuntimeCallExpr(
-    const RenderContext& ctx, const mir::RuntimeCallExpr& expr)
+    const ScopeView& view, const mir::RuntimeCallExpr& expr)
     -> diag::Result<std::string>;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/backend/cpp/render_stmt.hpp
+++ b/include/lyra/backend/cpp/render_stmt.hpp
@@ -3,21 +3,21 @@
 #include <cstddef>
 #include <string>
 
-#include "lyra/backend/cpp/render_context.hpp"
+#include "lyra/backend/cpp/scope_view.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/stmt.hpp"
 
 namespace lyra::backend::cpp {
 
 auto RenderNestedProceduralScope(
-    const RenderContext& parent, const mir::ProceduralScope& scope,
+    const ScopeView& parent, const mir::ProceduralScope& scope,
     std::size_t indent) -> diag::Result<std::string>;
 
-auto RenderProceduralScopeStatements(
-    const RenderContext& ctx, std::size_t indent) -> diag::Result<std::string>;
+auto RenderProceduralScopeStatements(const ScopeView& view, std::size_t indent)
+    -> diag::Result<std::string>;
 
 auto RenderStmt(
-    const RenderContext& ctx, const mir::Stmt& stmt, std::size_t indent)
+    const ScopeView& view, const mir::Stmt& stmt, std::size_t indent)
     -> diag::Result<std::string>;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/backend/cpp/scope_view.hpp
+++ b/include/lyra/backend/cpp/scope_view.hpp
@@ -11,31 +11,42 @@
 
 namespace lyra::backend::cpp {
 
-class RenderContext {
+// The rendering fold's walk position
+// (docs/architecture/lowering_organization.md "The Walk Position"). The
+// MIR-to-C++ emit is a fold, not a construction pass: it accumulates nothing
+// and owns no output, so this carries only what reading a node needs -- the
+// unit (for type and arena lookups) and the chain of enclosing scopes. A
+// hops-relative reference resolves by climbing that chain, exactly as the
+// construction-side `WalkFrame` resolves it; this is the read-only twin of that
+// frame, thin because every decision is already baked into the MIR it reads.
+// Immutable and copied on descent (`WithProceduralScope` /
+// `WithStructuralScope`); it grows no member per concept, so it is not the
+// forbidden growing `*Context`.
+class ScopeView {
  public:
   static auto ForRoot(
       const mir::CompilationUnit& unit,
       const mir::StructuralScope& structural_scope,
-      const mir::ProceduralScope& procedural_scope) -> RenderContext {
-    return RenderContext{unit, structural_scope, procedural_scope};
+      const mir::ProceduralScope& procedural_scope) -> ScopeView {
+    return ScopeView{unit, structural_scope, procedural_scope};
   }
 
   [[nodiscard]] auto WithProceduralScope(
-      const mir::ProceduralScope& child) const -> RenderContext {
-    return RenderContext{*unit_, *scope_, child, this, structural_parent_};
+      const mir::ProceduralScope& child) const -> ScopeView {
+    return ScopeView{*unit_, *scope_, child, this, structural_parent_};
   }
 
   [[nodiscard]] auto WithStructuralScope(
       const mir::StructuralScope& child_scope,
-      const mir::ProceduralScope& root_proc_scope) const -> RenderContext {
-    return RenderContext{*unit_, child_scope, root_proc_scope, nullptr, this};
+      const mir::ProceduralScope& root_proc_scope) const -> ScopeView {
+    return ScopeView{*unit_, child_scope, root_proc_scope, nullptr, this};
   }
 
-  RenderContext(const RenderContext&) = delete;
-  auto operator=(const RenderContext&) -> RenderContext& = delete;
-  RenderContext(RenderContext&&) = delete;
-  auto operator=(RenderContext&&) -> RenderContext& = delete;
-  ~RenderContext() = default;
+  ScopeView(const ScopeView&) = delete;
+  auto operator=(const ScopeView&) -> ScopeView& = delete;
+  ScopeView(ScopeView&&) = delete;
+  auto operator=(ScopeView&&) -> ScopeView& = delete;
+  ~ScopeView() = default;
 
   [[nodiscard]] auto Unit() const -> const mir::CompilationUnit& {
     return *unit_;
@@ -56,7 +67,7 @@ class RenderContext {
     }
     if (procedural_parent_ == nullptr) {
       throw InternalError(
-          "RenderContext::ProceduralScopeAtHops: hops out of range");
+          "ScopeView::ProceduralScopeAtHops: hops out of range");
     }
     return procedural_parent_->ProceduralScopeAtHops(
         mir::ProceduralHops{.value = hops.value - 1});
@@ -69,7 +80,7 @@ class RenderContext {
     }
     if (structural_parent_ == nullptr) {
       throw InternalError(
-          "RenderContext::StructuralScopeAtHops: hops out of range");
+          "ScopeView::StructuralScopeAtHops: hops out of range");
     }
     return structural_parent_->StructuralScopeAtHops(
         mir::StructuralHops{.value = hops.value - 1});
@@ -80,7 +91,7 @@ class RenderContext {
   }
 
  private:
-  RenderContext(
+  ScopeView(
       const mir::CompilationUnit& unit, const mir::StructuralScope& scope,
       const mir::ProceduralScope& proc_scope)
       : unit_(&unit),
@@ -90,11 +101,10 @@ class RenderContext {
         structural_parent_(nullptr) {
   }
 
-  RenderContext(
+  ScopeView(
       const mir::CompilationUnit& unit, const mir::StructuralScope& scope,
       const mir::ProceduralScope& proc_scope,
-      const RenderContext* procedural_parent,
-      const RenderContext* structural_parent)
+      const ScopeView* procedural_parent, const ScopeView* structural_parent)
       : unit_(&unit),
         scope_(&scope),
         proc_scope_(&proc_scope),
@@ -105,8 +115,8 @@ class RenderContext {
   const mir::CompilationUnit* unit_;
   const mir::StructuralScope* scope_;
   const mir::ProceduralScope* proc_scope_;
-  const RenderContext* procedural_parent_;
-  const RenderContext* structural_parent_;
+  const ScopeView* procedural_parent_;
+  const ScopeView* structural_parent_;
 };
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/lowering/hir_to_mir/self_ref.hpp
+++ b/include/lyra/lowering/hir_to_mir/self_ref.hpp
@@ -8,6 +8,7 @@
 namespace lyra::mir {
 class CompilationUnit;
 struct ProceduralScope;
+struct StructuralVarRef;
 }  // namespace lyra::mir
 
 namespace lyra::lowering::hir_to_mir {
@@ -20,6 +21,18 @@ namespace lyra::lowering::hir_to_mir {
 // effect engine handle starts from it.
 auto BuildSelfRefExpr(const WalkFrame& frame, mir::TypeId self_ptr_type)
     -> mir::Expr;
+
+// Builds a read of a structural var through the current body's `self`:
+// `MemberAccess(self, member)`. The result type is the var's declared MIR
+// storage type, read from the constructed scope at `member.hops` (a wrapper
+// type for observable storage, the value type otherwise) -- a fact that lives
+// only in the MIR scope, not in HIR, so it is read here rather than passed
+// down. Serves both a structural-var reference and a static-lifetime local
+// promoted to a per-instance structural var (LRM 13.3.1), which reach their
+// storage identically.
+auto BuildStructuralMemberAccessExpr(
+    const WalkFrame& frame, const mir::CompilationUnit& unit,
+    const mir::StructuralVarRef& member) -> mir::Expr;
 
 // Constructs a reference to the cell `cell` denotes (LRM 13.5.2): adds a
 // reference-construction `CallExpr` to `scope` whose result type is a

--- a/include/lyra/lowering/hir_to_mir/walk_frame.hpp
+++ b/include/lyra/lowering/hir_to_mir/walk_frame.hpp
@@ -21,8 +21,11 @@ class CaptureSink;
 // reference can read the declared type of a `StructuralVar` at `hops > 0`.
 // Each node lives on the stack of the `StructuralScopeLowerer::Run` that
 // pushed it; the chain extends one node per scope opened during traversal.
-// Mirrors `RenderContext`'s `structural_parent_` link so lowering and render
-// reach the same `mir::StructuralVarDecl` for any (hops, var) reference.
+// This is the construction-side half of the shared walk position
+// (docs/architecture/lowering_organization.md "The Walk Position"): the
+// rendering fold's read-only `ScopeView` resolves the same (hops, var)
+// reference by climbing its own parent link, so both reach the same
+// `mir::StructuralVarDecl`.
 struct ScopeChainNode {
   const mir::StructuralScope* scope;
   const ScopeChainNode* parent;

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -10,9 +10,9 @@
 #include "lyra/backend/cpp/api.hpp"
 #include "lyra/backend/cpp/artifact.hpp"
 #include "lyra/backend/cpp/formatting.hpp"
-#include "lyra/backend/cpp/render_context.hpp"
 #include "lyra/backend/cpp/render_stmt.hpp"
 #include "lyra/backend/cpp/render_type.hpp"
+#include "lyra/backend/cpp/scope_view.hpp"
 #include "lyra/backend/cpp/string_literal.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
@@ -28,10 +28,10 @@ namespace lyra::backend::cpp {
 namespace {
 
 auto RenderField(
-    const RenderContext& ctor_ctx, const mir::StructuralVarDecl& var,
+    const ScopeView& ctor_view, const mir::StructuralVarDecl& var,
     std::size_t indent) -> diag::Result<std::string> {
-  const auto& unit = ctor_ctx.Unit();
-  auto type_or = RenderTypeAsCpp(unit, ctor_ctx.StructuralScope(), var.type);
+  const auto& unit = ctor_view.Unit();
+  auto type_or = RenderTypeAsCpp(unit, ctor_view.StructuralScope(), var.type);
   if (!type_or) return std::unexpected(std::move(type_or.error()));
   // An upward reference is an ExternUp member: its constructor takes the
   // symbol payload (ancestor, by-name tail, leaf signal) rather than a value
@@ -69,7 +69,7 @@ auto CtorParamName(std::size_t index) -> std::string {
 }
 
 auto RenderConstructor(
-    const RenderContext& scope_ctx, const mir::StructuralScope& s,
+    const ScopeView& scope_view, const mir::StructuralScope& s,
     const std::string& base_class, std::size_t indent)
     -> diag::Result<std::string> {
   std::string sig = s.name +
@@ -79,7 +79,7 @@ auto RenderConstructor(
   for (std::size_t i = 0; i < s.structural_params.size(); ++i) {
     const auto& p = s.structural_params[i];
     const auto param_name = CtorParamName(i);
-    auto type_or = RenderTypeAsCpp(scope_ctx.Unit(), s, p.type);
+    auto type_or = RenderTypeAsCpp(scope_view.Unit(), s, p.type);
     if (!type_or) return std::unexpected(std::move(type_or.error()));
     sig += ", " + *type_or + " " + param_name;
     init_list += ", " + p.name + "(" + param_name + ")";
@@ -92,7 +92,7 @@ auto RenderConstructor(
   std::string out;
   out += Indent(indent) + sig + " { init(this); }\n";
   out += Indent(indent) + "static void init(" + s.name + "* self) {\n";
-  auto rendered_or = RenderProceduralScopeStatements(scope_ctx, indent + 1);
+  auto rendered_or = RenderProceduralScopeStatements(scope_view, indent + 1);
   if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
   out += *rendered_or;
   out += Indent(indent) + "}\n";
@@ -100,19 +100,19 @@ auto RenderConstructor(
 }
 
 auto RenderProcessMethod(
-    const RenderContext* parent_struct_ctx, const mir::CompilationUnit& unit,
+    const ScopeView* parent_struct_view, const mir::CompilationUnit& unit,
     const mir::StructuralScope& s, const mir::Process& process,
     std::size_t indent) -> diag::Result<std::string> {
-  const RenderContext proc_ctx =
-      (parent_struct_ctx == nullptr)
-          ? RenderContext::ForRoot(unit, s, process.root_procedural_scope)
-          : parent_struct_ctx->WithStructuralScope(
+  const ScopeView proc_view =
+      (parent_struct_view == nullptr)
+          ? ScopeView::ForRoot(unit, s, process.root_procedural_scope)
+          : parent_struct_view->WithStructuralScope(
                 s, process.root_procedural_scope);
 
   std::string out;
   out += Indent(indent) + "static auto " + process.name + "(" + s.name +
          "* self) -> lyra::runtime::Coroutine {\n";
-  auto rendered_or = RenderProceduralScopeStatements(proc_ctx, indent + 1);
+  auto rendered_or = RenderProceduralScopeStatements(proc_view, indent + 1);
   if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
   out += *rendered_or;
   out += Indent(indent + 1) + "co_return;\n";
@@ -132,7 +132,7 @@ auto RenderSubroutineResultType(
 }
 
 auto RenderSubroutineMethod(
-    const RenderContext* parent_struct_ctx, const mir::CompilationUnit& unit,
+    const ScopeView* parent_struct_view, const mir::CompilationUnit& unit,
     const mir::StructuralScope& s, const mir::StructuralSubroutineDecl& sub,
     std::size_t indent) -> diag::Result<std::string> {
   // A task may suspend on timing controls, so it is a coroutine enabled with
@@ -170,15 +170,15 @@ auto RenderSubroutineMethod(
   }
   sig += ")";
 
-  const RenderContext sub_ctx =
-      parent_struct_ctx == nullptr
-          ? RenderContext::ForRoot(unit, s, sub.root_procedural_scope)
-          : parent_struct_ctx->WithStructuralScope(
+  const ScopeView sub_view =
+      parent_struct_view == nullptr
+          ? ScopeView::ForRoot(unit, s, sub.root_procedural_scope)
+          : parent_struct_view->WithStructuralScope(
                 s, sub.root_procedural_scope);
 
   std::string out;
   out += Indent(indent) + sig + " {\n";
-  auto rendered_or = RenderProceduralScopeStatements(sub_ctx, indent + 1);
+  auto rendered_or = RenderProceduralScopeStatements(sub_view, indent + 1);
   if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
   out += *rendered_or;
   if (is_task) {
@@ -212,15 +212,15 @@ auto RenderCreateProcesses(const mir::StructuralScope& s, std::size_t indent)
 
 auto RenderScopeAsClass(
     const mir::CompilationUnit& unit, const mir::StructuralScope& s,
-    std::size_t indent, bool is_top_level,
-    const RenderContext* parent_struct_ctx) -> diag::Result<std::string> {
+    std::size_t indent, bool is_top_level, const ScopeView* parent_struct_view)
+    -> diag::Result<std::string> {
   // `this_anchor` is bound to `s.constructor_scope` so it doubles as the
-  // ctx for rendering the constructor body. Children's bodies use it as
+  // view for rendering the constructor body. Children's bodies use it as
   // their structural parent (one hop above the child).
-  const RenderContext this_anchor =
-      (parent_struct_ctx == nullptr)
-          ? RenderContext::ForRoot(unit, s, s.constructor_scope)
-          : parent_struct_ctx->WithStructuralScope(s, s.constructor_scope);
+  const ScopeView this_anchor =
+      (parent_struct_view == nullptr)
+          ? ScopeView::ForRoot(unit, s, s.constructor_scope)
+          : parent_struct_view->WithStructuralScope(s, s.constructor_scope);
 
   // A unit-root scope is an instance; a nested generate block is a generate
   // scope. The base type carries the kind.
@@ -310,7 +310,7 @@ auto RenderScopeAsClass(
   for (const auto& p : s.processes) {
     out += "\n";
     auto method_or =
-        RenderProcessMethod(parent_struct_ctx, unit, s, p, indent + 1);
+        RenderProcessMethod(parent_struct_view, unit, s, p, indent + 1);
     if (!method_or) return std::unexpected(std::move(method_or.error()));
     out += *method_or;
   }
@@ -318,7 +318,7 @@ auto RenderScopeAsClass(
   for (const auto& sub : s.structural_subroutines) {
     out += "\n";
     auto method_or =
-        RenderSubroutineMethod(parent_struct_ctx, unit, s, sub, indent + 1);
+        RenderSubroutineMethod(parent_struct_view, unit, s, sub, indent + 1);
     if (!method_or) return std::unexpected(std::move(method_or.error()));
     out += *method_or;
   }

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -10,10 +10,10 @@
 #include <utility>
 #include <variant>
 
-#include "lyra/backend/cpp/render_context.hpp"
 #include "lyra/backend/cpp/render_print.hpp"
 #include "lyra/backend/cpp/render_stmt.hpp"
 #include "lyra/backend/cpp/render_type.hpp"
+#include "lyra/backend/cpp/scope_view.hpp"
 #include "lyra/backend/cpp/string_literal.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
@@ -134,9 +134,9 @@ auto RenderPackedArrayIntegerLiteral(
 }
 
 auto RenderIntegerLiteralExpr(
-    const RenderContext& ctx, const mir::Expr& expr,
+    const ScopeView& view, const mir::Expr& expr,
     const mir::IntegerLiteral& lit) -> diag::Result<std::string> {
-  const auto& ty = ctx.Unit().GetType(expr.type);
+  const auto& ty = view.Unit().GetType(expr.type);
   if (!ty.IsIntegralPacked()) {
     throw InternalError(
         "RenderIntegerLiteralExpr: IntegerLiteral not typed as "
@@ -145,14 +145,14 @@ auto RenderIntegerLiteralExpr(
   auto body = RenderPackedArrayIntegerLiteral(ty.AsIntegralPacked(), lit.value);
   if (ty.IsEnum()) {
     return std::format(
-        "{}{{{}}}", RenderEnumClassName(ctx.StructuralScope(), expr.type),
+        "{}{{{}}}", RenderEnumClassName(view.StructuralScope(), expr.type),
         body);
   }
   return body;
 }
 
 auto RenderRealLiteralExpr(
-    const RenderContext& ctx, const mir::Expr& expr, const mir::RealLiteral& r)
+    const ScopeView& view, const mir::Expr& expr, const mir::RealLiteral& r)
     -> std::string {
   // `std::format` with `{:.{}g}` and precision=17 round-trips a double;
   // precision=9 round-trips a float (IEEE 754 minimum representable-pair
@@ -165,7 +165,7 @@ auto RenderRealLiteralExpr(
   // rejects (a digit sequence followed by `f` is not a valid float suffix).
   // Force a decimal point when the formatted body has neither `.` nor an
   // exponent, so `0` -> `0.0`, `42` -> `42.0`.
-  const auto& ty = ctx.Unit().GetType(expr.type);
+  const auto& ty = view.Unit().GetType(expr.type);
   const bool is_short = ty.Kind() == mir::TypeKind::kShortReal;
   std::string body = is_short ? std::format("{:.9g}", r.value)
                               : std::format("{:.17g}", r.value);
@@ -180,7 +180,7 @@ auto RenderRealLiteralExpr(
 }
 
 auto RenderStructuralParamExpr(
-    const RenderContext& ctx, const mir::StructuralParamRef& r)
+    const ScopeView& view, const mir::StructuralParamRef& r)
     -> diag::Result<std::string> {
   if (r.hops.value != 0) {
     return diag::Unsupported(
@@ -190,30 +190,30 @@ auto RenderStructuralParamExpr(
         diag::UnsupportedCategory::kFeature);
   }
   const std::string& name =
-      ctx.StructuralScope().GetStructuralParam(r.param).name;
+      view.StructuralScope().GetStructuralParam(r.param).name;
   return "self->" + name;
 }
 
 auto LookupProceduralVarName(
-    const RenderContext& ctx, const mir::ProceduralVarRef& ref) -> std::string {
-  return ctx.ProceduralScopeAtHops(ref.hops).vars.at(ref.var.value).name;
+    const ScopeView& view, const mir::ProceduralVarRef& ref) -> std::string {
+  return view.ProceduralScopeAtHops(ref.hops).vars.at(ref.var.value).name;
 }
 
 // True iff the procedural var holds a reference (its type is a `RefType`),
 // rendered as a `Ref<T>` whose read is `.Get()` and whose write is
 // `.Set(Services(), ...)` (LRM 13.5.2), the same surface as a structural Var.
 auto IsReferenceProceduralVar(
-    const RenderContext& ctx, const mir::ProceduralVarRef& ref) -> bool {
+    const ScopeView& view, const mir::ProceduralVarRef& ref) -> bool {
   const mir::TypeId var_type =
-      ctx.ProceduralScopeAtHops(ref.hops).vars.at(ref.var.value).type;
+      view.ProceduralScopeAtHops(ref.hops).vars.at(ref.var.value).type;
   return std::holds_alternative<mir::RefType>(
-      ctx.Unit().GetType(var_type).data);
+      view.Unit().GetType(var_type).data);
 }
 
 }  // namespace
 
 auto RenderStructuralVarName(
-    const RenderContext& ctx, const mir::StructuralVarRef& ref)
+    const ScopeView& view, const mir::StructuralVarRef& ref)
     -> diag::Result<std::string> {
   if (ref.hops.value != 0) {
     return diag::Unsupported(
@@ -222,7 +222,7 @@ auto RenderStructuralVarName(
         "emit",
         diag::UnsupportedCategory::kFeature);
   }
-  return "self->" + ctx.StructuralScope().GetStructuralVar(ref.var).name;
+  return "self->" + view.StructuralScope().GetStructuralVar(ref.var).name;
 }
 
 namespace {
@@ -478,40 +478,40 @@ auto RenderUnaryOpIntegral(mir::UnaryOp op, const std::string& operand)
 }
 
 auto RenderUnaryExpr(
-    const RenderContext& ctx, const mir::Expr& expr, const mir::UnaryExpr& u)
+    const ScopeView& view, const mir::Expr& expr, const mir::UnaryExpr& u)
     -> diag::Result<std::string> {
-  const auto& operand_expr = ctx.Expr(u.operand);
-  auto operand_or = RenderExpr(ctx, operand_expr);
+  const auto& operand_expr = view.Expr(u.operand);
+  auto operand_or = RenderExpr(view, operand_expr);
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-  if (IsRealFamilyType(ctx.Unit().GetType(operand_expr.type))) {
-    return RenderUnaryOpReal(u.op, *operand_or, ctx.Unit().GetType(expr.type));
+  if (IsRealFamilyType(view.Unit().GetType(operand_expr.type))) {
+    return RenderUnaryOpReal(u.op, *operand_or, view.Unit().GetType(expr.type));
   }
   return RenderUnaryOpIntegral(u.op, *operand_or);
 }
 
 auto RenderBinaryExpr(
-    const RenderContext& ctx, const mir::Expr& expr, const mir::BinaryExpr& b)
+    const ScopeView& view, const mir::Expr& expr, const mir::BinaryExpr& b)
     -> diag::Result<std::string> {
-  const auto& lhs_expr = ctx.Expr(b.lhs);
-  const auto& rhs_expr = ctx.Expr(b.rhs);
-  auto lhs_or = RenderExpr(ctx, lhs_expr);
+  const auto& lhs_expr = view.Expr(b.lhs);
+  const auto& rhs_expr = view.Expr(b.rhs);
+  auto lhs_or = RenderExpr(view, lhs_expr);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  auto rhs_or = RenderExpr(ctx, rhs_expr);
+  auto rhs_or = RenderExpr(view, rhs_expr);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   // Slang inserts a propagated `ConversionExpr` on the narrower operand so by
   // the time we reach a binary op both sides share a precision class. Dispatch
   // by operand kind: real-family (LRM 11.3.1), string (LRM 6.16 Table 6-9),
   // else integral PackedArray ops.
-  const auto& lhs_ty = ctx.Unit().GetType(lhs_expr.type);
-  const auto& rhs_ty = ctx.Unit().GetType(rhs_expr.type);
+  const auto& lhs_ty = view.Unit().GetType(lhs_expr.type);
+  const auto& rhs_ty = view.Unit().GetType(rhs_expr.type);
   if (IsRealFamilyType(lhs_ty) || IsRealFamilyType(rhs_ty)) {
     return RenderBinaryOpReal(
-        b.op, *lhs_or, *rhs_or, ctx.Unit().GetType(expr.type));
+        b.op, *lhs_or, *rhs_or, view.Unit().GetType(expr.type));
   }
   if (lhs_ty.Kind() == mir::TypeKind::kString &&
       rhs_ty.Kind() == mir::TypeKind::kString) {
     return RenderBinaryOpString(
-        b.op, *lhs_or, *rhs_or, ctx.Unit().GetType(expr.type));
+        b.op, *lhs_or, *rhs_or, view.Unit().GetType(expr.type));
   }
   const bool lhs_is_array =
       std::holds_alternative<mir::UnpackedArrayType>(lhs_ty.data) ||
@@ -525,14 +525,13 @@ auto RenderBinaryExpr(
   return RenderBinaryOpIntegral(b.op, *lhs_or, *rhs_or);
 }
 
-auto RenderConditionalExpr(
-    const RenderContext& ctx, const mir::ConditionalExpr& c)
+auto RenderConditionalExpr(const ScopeView& view, const mir::ConditionalExpr& c)
     -> diag::Result<std::string> {
-  auto cond_or = RenderConditionAsBool(ctx, ctx.Expr(c.condition));
+  auto cond_or = RenderConditionAsBool(view, view.Expr(c.condition));
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  auto then_or = RenderExpr(ctx, ctx.Expr(c.then_value));
+  auto then_or = RenderExpr(view, view.Expr(c.then_value));
   if (!then_or) return std::unexpected(std::move(then_or.error()));
-  auto else_or = RenderExpr(ctx, ctx.Expr(c.else_value));
+  auto else_or = RenderExpr(view, view.Expr(c.else_value));
   if (!else_or) return std::unexpected(std::move(else_or.error()));
   return "(" + *cond_or + " ? " + *then_or + " : " + *else_or + ")";
 }
@@ -561,7 +560,7 @@ auto RenderRealConversion(
 // converting ctor; enum -> integral slices the enum subobject into a plain
 // PackedArray for downstream template deduction.
 auto RenderIntegralConversion(
-    const RenderContext& ctx, mir::TypeId dst_type_id, std::string operand,
+    const ScopeView& view, mir::TypeId dst_type_id, std::string operand,
     const mir::PackedArrayType& src_pa, const mir::PackedArrayType& dst_pa,
     bool src_is_enum, bool dst_is_enum) -> std::string {
   std::string body;
@@ -575,7 +574,7 @@ auto RenderIntegralConversion(
   }
   if (dst_is_enum) {
     return std::format(
-        "{}{{{}}}", RenderEnumClassName(ctx.StructuralScope(), dst_type_id),
+        "{}{{{}}}", RenderEnumClassName(view.StructuralScope(), dst_type_id),
         body);
   }
   if (src_is_enum) {
@@ -612,12 +611,12 @@ auto RenderRealToIntegralConversion(
 }
 
 auto RenderConversionExpr(
-    const RenderContext& ctx, const mir::Expr& expr,
-    const mir::ConversionExpr& cv) -> diag::Result<std::string> {
-  const auto& src_expr = ctx.Expr(cv.operand);
-  const auto& src_ty = ctx.Unit().GetType(src_expr.type);
-  const auto& dst_ty = ctx.Unit().GetType(expr.type);
-  auto operand_or = RenderExpr(ctx, src_expr);
+    const ScopeView& view, const mir::Expr& expr, const mir::ConversionExpr& cv)
+    -> diag::Result<std::string> {
+  const auto& src_expr = view.Expr(cv.operand);
+  const auto& src_ty = view.Unit().GetType(src_expr.type);
+  const auto& dst_ty = view.Unit().GetType(expr.type);
+  auto operand_or = RenderExpr(view, src_expr);
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
 
   // Dispatch by (source category, destination category). Each branch is
@@ -627,7 +626,7 @@ auto RenderConversionExpr(
   }
   if (src_ty.IsIntegralPacked() && dst_ty.IsIntegralPacked()) {
     return RenderIntegralConversion(
-        ctx, expr.type, *std::move(operand_or), src_ty.AsIntegralPacked(),
+        view, expr.type, *std::move(operand_or), src_ty.AsIntegralPacked(),
         dst_ty.AsIntegralPacked(), src_ty.IsEnum(), dst_ty.IsEnum());
   }
   if (src_ty.IsIntegralPacked() && IsRealFamilyType(dst_ty)) {
@@ -803,7 +802,7 @@ auto EventMethodMemberName(mir::EventMethodKind k) -> std::string_view {
 }
 
 auto RenderMethodCall(
-    const RenderContext& ctx, const mir::CallExpr& call,
+    const ScopeView& view, const mir::CallExpr& call,
     std::string_view member_name) -> diag::Result<std::string>;
 
 // True iff the enum method is a class-level static (LRM 6.19.5 `first` /
@@ -822,17 +821,17 @@ auto IsStaticEnumMethod(mir::EnumMethodKind k) -> bool {
 // `Deref(Mutate)` wraps for observable cells); the backend reads the chain
 // and emits it.
 auto RenderMethodCall(
-    const RenderContext& ctx, const mir::CallExpr& call,
+    const ScopeView& view, const mir::CallExpr& call,
     std::string_view member_name) -> diag::Result<std::string> {
   if (call.arguments.empty()) {
     throw InternalError(
         "RenderMethodCall: a method call expects a receiver argument");
   }
-  auto recv_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
+  auto recv_or = RenderExpr(view, view.Expr(call.arguments[0]));
   if (!recv_or) return std::unexpected(std::move(recv_or.error()));
   std::string args;
   for (std::size_t i = 1; i < call.arguments.size(); ++i) {
-    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+    auto arg_or = RenderExpr(view, view.Expr(call.arguments[i]));
     if (!arg_or) return std::unexpected(std::move(arg_or.error()));
     if (i != 1) args += ", ";
     args += *std::move(arg_or);
@@ -923,31 +922,31 @@ auto AssociativeTraversalFunctionName(mir::AssociativeMethodKind k)
 // receivers such as `mm[i]`, so the call lands on the stored sub-map without a
 // detached clone.
 auto RenderAssociativeTraversalCall(
-    const RenderContext& ctx, const mir::CallExpr& call,
+    const ScopeView& view, const mir::CallExpr& call,
     std::string_view function_name) -> diag::Result<std::string> {
   if (call.arguments.size() != 2) {
     throw InternalError(
         "RenderAssociativeTraversalCall: traversal method expects a receiver "
         "and an index argument");
   }
-  auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
+  auto receiver_or = RenderExpr(view, view.Expr(call.arguments[0]));
   if (!receiver_or) {
     return std::unexpected(std::move(receiver_or.error()));
   }
-  const mir::Expr& index = ctx.Expr(call.arguments[1]);
-  auto index_or = RenderLhsExpr(ctx, index);
+  const mir::Expr& index = view.Expr(call.arguments[1]);
+  auto index_or = RenderLhsExpr(view, index);
   if (!index_or) {
     return std::unexpected(std::move(index_or.error()));
   }
   // `Ref<T>` is templated on the inner value type, not the observable wrapper.
   // The index's MIR type carries the wrapper for an observable cell -- unwrap
   // it before rendering the C++ type so `Ref<T>(Var<T>&)` resolves correctly.
-  const mir::Type& index_ty = ctx.Unit().GetType(index.type);
+  const mir::Type& index_ty = view.Unit().GetType(index.type);
   const mir::TypeId key_type_id = mir::IsObservableCellType(index_ty)
                                       ? mir::ObservableInnerValueType(index_ty)
                                       : index.type;
   auto key_type_or =
-      RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), key_type_id);
+      RenderTypeAsCpp(view.Unit(), view.StructuralScope(), key_type_id);
   if (!key_type_or) {
     return std::unexpected(std::move(key_type_or.error()));
   }
@@ -964,18 +963,18 @@ auto RenderAssociativeTraversalCall(
 // (.IsUnknown()) return -1;`) while making the guard a trivial constant the
 // C++ optimizer dead-code-eliminates. The runtime helper retains its
 // historical `HasUnknown` spelling.
-auto RenderIsUnknownCall(const RenderContext& ctx, const mir::CallExpr& call)
+auto RenderIsUnknownCall(const ScopeView& view, const mir::CallExpr& call)
     -> diag::Result<std::string> {
   if (call.arguments.empty()) {
     throw InternalError(
         "RenderIsUnknownCall: $isunknown expects a receiver argument");
   }
-  const mir::Expr& receiver = ctx.Expr(call.arguments[0]);
-  const auto& ty = ctx.Unit().GetType(receiver.type);
+  const mir::Expr& receiver = view.Expr(call.arguments[0]);
+  const auto& ty = view.Unit().GetType(receiver.type);
   if (!(ty.IsIntegralPacked() && ty.AsIntegralPacked().IsFourState())) {
     return std::string{"lyra::value::PackedArray::Bit(false)"};
   }
-  auto receiver_or = RenderExpr(ctx, receiver);
+  auto receiver_or = RenderExpr(view, receiver);
   if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
   return std::format(
       "lyra::value::PackedArray::Bit(({}).HasUnknown())", *receiver_or);
@@ -985,13 +984,13 @@ auto RenderIsUnknownCall(const RenderContext& ctx, const mir::CallExpr& call)
 // receiver (arguments[0]) is the `self` pointer, so the call is `->`. This
 // is the engine handle every runtime-effect call threads as a plain
 // argument.
-auto RenderServicesCall(const RenderContext& ctx, const mir::CallExpr& call)
+auto RenderServicesCall(const ScopeView& view, const mir::CallExpr& call)
     -> diag::Result<std::string> {
   if (call.arguments.empty()) {
     throw InternalError(
         "RenderServicesCall: services accessor expects a receiver argument");
   }
-  auto receiver_or = RenderExpr(ctx, ctx.Expr(call.arguments[0]));
+  auto receiver_or = RenderExpr(view, view.Expr(call.arguments[0]));
   if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
   return std::format("({})->Services()", *receiver_or);
 }
@@ -1122,7 +1121,7 @@ auto RenderSystemSubroutineEntryName(const support::SystemSubroutineDesc& desc)
 // injected here -- it is `arguments[0]` (a `self.Services()` expression) and
 // renders like any other argument.
 auto RenderSystemSubroutineCall(
-    const RenderContext& ctx, const mir::CallExpr& call,
+    const ScopeView& view, const mir::CallExpr& call,
     const mir::SystemSubroutineCallee& callee) -> diag::Result<std::string> {
   const support::SystemSubroutineDesc& desc =
       support::LookupSystemSubroutine(callee.id);
@@ -1133,7 +1132,7 @@ auto RenderSystemSubroutineCall(
   out += *name_or;
   out += "(";
   for (std::size_t i = 0; i < call.arguments.size(); ++i) {
-    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+    auto arg_or = RenderExpr(view, view.Expr(call.arguments[i]));
     if (!arg_or) return std::unexpected(std::move(arg_or.error()));
     if (i != 0) out += ", ";
     out += *std::move(arg_or);
@@ -1150,18 +1149,18 @@ auto RenderSystemSubroutineCall(
 // argument renders as a bare signal read, which is the cell itself -- the
 // `Ref<T>` constructor binds it.
 auto RenderConstructorCall(
-    const RenderContext& ctx, const mir::CallExpr& call,
-    mir::TypeId result_type) -> diag::Result<std::string> {
+    const ScopeView& view, const mir::CallExpr& call, mir::TypeId result_type)
+    -> diag::Result<std::string> {
   if (call.arguments.empty() && std::holds_alternative<mir::PointerType>(
-                                    ctx.Unit().GetType(result_type).data)) {
+                                    view.Unit().GetType(result_type).data)) {
     return std::string{"nullptr"};
   }
   auto type_or =
-      RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), result_type);
+      RenderTypeAsCpp(view.Unit(), view.StructuralScope(), result_type);
   if (!type_or) return std::unexpected(std::move(type_or.error()));
   std::string args;
   for (std::size_t i = 0; i < call.arguments.size(); ++i) {
-    auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+    auto arg_or = RenderExpr(view, view.Expr(call.arguments[i]));
     if (!arg_or) return std::unexpected(std::move(arg_or.error()));
     if (i != 0) args += ", ";
     args += *std::move(arg_or);
@@ -1170,13 +1169,13 @@ auto RenderConstructorCall(
 }
 
 auto RenderCallExpr(
-    const RenderContext& ctx, const mir::CallExpr& call,
-    mir::TypeId result_type) -> diag::Result<std::string> {
+    const ScopeView& view, const mir::CallExpr& call, mir::TypeId result_type)
+    -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
           [&](const mir::SystemSubroutineCallee& s)
               -> diag::Result<std::string> {
-            return RenderSystemSubroutineCall(ctx, call, s);
+            return RenderSystemSubroutineCall(view, call, s);
           },
           [&](const mir::StructuralSubroutineRef& ref)
               -> diag::Result<std::string> {
@@ -1187,7 +1186,7 @@ auto RenderCallExpr(
                   "implemented in cpp emit",
                   diag::UnsupportedCategory::kFeature);
             }
-            const auto& scope = ctx.StructuralScopeAtHops(
+            const auto& scope = view.StructuralScopeAtHops(
                 mir::StructuralHops{.value = ref.hops.value});
             const auto& decl = scope.GetStructuralSubroutine(ref.subroutine);
             // arguments[0] is the callee's `self` handle (mir.md invariant 11);
@@ -1195,7 +1194,7 @@ auto RenderCallExpr(
             // (`Ref<T>(cell)`) in MIR, so every argument renders uniformly.
             std::string args;
             for (std::size_t i = 0; i < call.arguments.size(); ++i) {
-              auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+              auto arg_or = RenderExpr(view, view.Expr(call.arguments[i]));
               if (!arg_or) return std::unexpected(std::move(arg_or.error()));
               if (i != 0) args += ", ";
               args += *std::move(arg_or);
@@ -1221,42 +1220,42 @@ auto RenderCallExpr(
                         return std::format(
                             "{}::{}()",
                             RenderEnumClassName(
-                                ctx.StructuralScope(), m.enum_type),
+                                view.StructuralScope(), m.enum_type),
                             member);
                       }
-                      return RenderMethodCall(ctx, call, member);
+                      return RenderMethodCall(view, call, member);
                     },
                     [&](const mir::StringMethodInfo& m) {
                       return RenderMethodCall(
-                          ctx, call, StringMethodMemberName(m.kind));
+                          view, call, StringMethodMemberName(m.kind));
                     },
                     [&](const mir::EventMethodInfo& m) {
                       return RenderMethodCall(
-                          ctx, call, EventMethodMemberName(m.kind));
+                          view, call, EventMethodMemberName(m.kind));
                     },
                     [&](const mir::ArrayMethodInfo& m) {
                       return RenderMethodCall(
-                          ctx, call, ArrayMethodMemberName(m.kind));
+                          view, call, ArrayMethodMemberName(m.kind));
                     },
                     [&](const mir::QueueMethodInfo& m) {
                       return RenderMethodCall(
-                          ctx, call, QueueMethodMemberName(m.kind));
+                          view, call, QueueMethodMemberName(m.kind));
                     },
                     [&](const mir::AssociativeMethodInfo& m)
                         -> diag::Result<std::string> {
                       if (auto traversal =
                               AssociativeTraversalFunctionName(m.kind)) {
                         return RenderAssociativeTraversalCall(
-                            ctx, call, *traversal);
+                            view, call, *traversal);
                       }
                       return RenderMethodCall(
-                          ctx, call, AssociativeMethodMemberName(m.kind));
+                          view, call, AssociativeMethodMemberName(m.kind));
                     },
                     [&](const mir::ValueMethodInfo& m)
                         -> diag::Result<std::string> {
                       switch (m.kind) {
                         case mir::ValueMethodKind::kIsUnknown:
-                          return RenderIsUnknownCall(ctx, call);
+                          return RenderIsUnknownCall(view, call);
                       }
                       throw InternalError(
                           "RenderCallExpr: unknown ValueMethodKind");
@@ -1277,26 +1276,26 @@ auto RenderCallExpr(
                         -> diag::Result<std::string> {
                       switch (m.kind) {
                         case mir::ScopeMethodKind::kServices:
-                          return RenderServicesCall(ctx, call);
+                          return RenderServicesCall(view, call);
                       }
                       throw InternalError(
                           "RenderCallExpr: unknown ScopeMethodKind");
                     },
                     [&](const mir::ObservableMethodInfo& m) {
                       return RenderMethodCall(
-                          ctx, call, ObservableMethodMemberName(m.kind));
+                          view, call, ObservableMethodMemberName(m.kind));
                     },
                 },
                 b.method);
           },
           [&](const mir::ClosureRef& cr) -> diag::Result<std::string> {
-            auto closure_or = RenderExpr(ctx, ctx.Expr(cr.closure));
+            auto closure_or = RenderExpr(view, view.Expr(cr.closure));
             if (!closure_or) {
               return std::unexpected(std::move(closure_or.error()));
             }
             std::string args;
             for (std::size_t i = 0; i < call.arguments.size(); ++i) {
-              auto arg_or = RenderExpr(ctx, ctx.Expr(call.arguments[i]));
+              auto arg_or = RenderExpr(view, view.Expr(call.arguments[i]));
               if (!arg_or) return std::unexpected(std::move(arg_or.error()));
               if (i != 0) args += ", ";
               args += *std::move(arg_or);
@@ -1304,7 +1303,7 @@ auto RenderCallExpr(
             return "(" + *closure_or + ")(" + args + ")";
           },
           [&](const mir::RuntimeNavCallee& nav) -> diag::Result<std::string> {
-            auto base_or = RenderExpr(ctx, ctx.Expr(call.arguments.at(0)));
+            auto base_or = RenderExpr(view, view.Expr(call.arguments.at(0)));
             if (!base_or) return std::unexpected(std::move(base_or.error()));
             switch (nav.fn) {
               case mir::RuntimeFn::kGetChild: {
@@ -1313,7 +1312,7 @@ auto RenderCallExpr(
                   indices = "std::array{";
                   for (std::size_t i = 1; i < call.arguments.size(); ++i) {
                     auto idx_or =
-                        RenderExpr(ctx, ctx.Expr(call.arguments.at(i)));
+                        RenderExpr(view, view.Expr(call.arguments.at(i)));
                     if (!idx_or)
                       return std::unexpected(std::move(idx_or.error()));
                     if (i != 1) indices += ", ";
@@ -1330,7 +1329,7 @@ auto RenderCallExpr(
                 // result type names the cell, so the cast is fixed by that
                 // type.
                 auto cell_or = RenderTypeAsCpp(
-                    ctx.Unit(), ctx.StructuralScope(), result_type);
+                    view.Unit(), view.StructuralScope(), result_type);
                 if (!cell_or)
                   return std::unexpected(std::move(cell_or.error()));
                 return "static_cast<" + *cell_or + ">(" + *base_or +
@@ -1340,7 +1339,7 @@ auto RenderCallExpr(
                 // Registers the signal's own cell address under its name; the
                 // var argument renders as a bare lvalue so `&` takes the cell.
                 auto var_or =
-                    RenderLhsExpr(ctx, ctx.Expr(call.arguments.at(1)));
+                    RenderLhsExpr(view, view.Expr(call.arguments.at(1)));
                 if (!var_or) return std::unexpected(std::move(var_or.error()));
                 return *base_or + "->RegisterSignal(\"" + nav.name + "\", &" +
                        *var_or + ")";
@@ -1349,7 +1348,7 @@ auto RenderCallExpr(
             throw InternalError("RenderCallExpr: unknown RuntimeFn");
           },
           [&](const mir::ConstructorCallee&) -> diag::Result<std::string> {
-            return RenderConstructorCall(ctx, call, result_type);
+            return RenderConstructorCall(view, call, result_type);
           },
       },
       call.callee);
@@ -1363,21 +1362,21 @@ auto RenderCallExpr(
 // `Mutate(svc)` adapter is already in MIR as a `DerefExpr` wrapping an
 // `ObservableMethod{kMutate}` call -- this render emits nothing implicit
 // on top of the explicit MIR shape.
-auto RenderLhsExpr(const RenderContext& ctx, const mir::Expr& expr)
+auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
     -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
           [&](const mir::MemberAccessExpr& m) -> diag::Result<std::string> {
-            auto receiver_or = RenderExpr(ctx, ctx.Expr(m.receiver));
+            auto receiver_or = RenderExpr(view, view.Expr(m.receiver));
             if (!receiver_or) {
               return std::unexpected(std::move(receiver_or.error()));
             }
-            const auto& scope = ctx.StructuralScopeAtHops(m.member.hops);
+            const auto& scope = view.StructuralScopeAtHops(m.member.hops);
             const auto& var = scope.GetStructuralVar(m.member.var);
             return *receiver_or + "->" + var.name;
           },
           [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
-            return LookupProceduralVarName(ctx, l);
+            return LookupProceduralVarName(view, l);
           },
           // HIR-to-MIR lowers an LHS selector chain to a container-access
           // `CallExpr` (per `mir::IsContainerAccessCall`). The C++ surface
@@ -1385,10 +1384,10 @@ auto RenderLhsExpr(const RenderContext& ctx, const mir::Expr& expr)
           // rendering is itself the assignment
           // target; LHS context needs no extra fix-up.
           [&](const mir::CallExpr&) -> diag::Result<std::string> {
-            return RenderExpr(ctx, expr);
+            return RenderExpr(view, expr);
           },
           [&](const mir::DerefExpr& d) -> diag::Result<std::string> {
-            auto ptr = RenderExpr(ctx, ctx.Expr(d.pointer));
+            auto ptr = RenderExpr(view, view.Expr(d.pointer));
             if (!ptr) return std::unexpected(std::move(ptr.error()));
             return "(*" + *ptr + ")";
           },
@@ -1407,7 +1406,7 @@ namespace {
 // Walks an LHS expression through container-access calls (per
 // `mir::IsContainerAccessCall`) to its root primary. Whether a write
 // touches a reference formal is decided by what that root is.
-auto LhsRootPrimary(const RenderContext& ctx, const mir::Expr& expr)
+auto LhsRootPrimary(const ScopeView& view, const mir::Expr& expr)
     -> const mir::Expr& {
   const mir::Expr* current = &expr;
   while (true) {
@@ -1418,7 +1417,7 @@ auto LhsRootPrimary(const RenderContext& ctx, const mir::Expr& expr)
         call->arguments.empty()) {
       return *current;
     }
-    current = &ctx.Expr(call->arguments.front());
+    current = &view.Expr(call->arguments.front());
   }
 }
 
@@ -1431,12 +1430,11 @@ auto IsLhsBarePrimary(const mir::Expr& expr) -> bool {
 // The root procedural var iff the LHS root is a `ref` / `const ref` formal,
 // else nullptr. A write whose root is a reference formal must route through
 // `Ref::Set` (LRM 13.5.2).
-auto LhsRootReferenceProceduralVar(
-    const RenderContext& ctx, const mir::Expr& expr)
+auto LhsRootReferenceProceduralVar(const ScopeView& view, const mir::Expr& expr)
     -> const mir::ProceduralVarRef* {
   const auto* pvr =
-      std::get_if<mir::ProceduralVarRef>(&LhsRootPrimary(ctx, expr).data);
-  return pvr != nullptr && IsReferenceProceduralVar(ctx, *pvr) ? pvr : nullptr;
+      std::get_if<mir::ProceduralVarRef>(&LhsRootPrimary(view, expr).data);
+  return pvr != nullptr && IsReferenceProceduralVar(view, *pvr) ? pvr : nullptr;
 }
 
 // Render a compound op suffix for the SV `op=` family. Arithmetic /
@@ -1481,18 +1479,18 @@ auto RenderCompoundAssign(
   }
 }
 
-auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
+auto RenderAssignExpr(const ScopeView& view, const mir::AssignExpr& a)
     -> diag::Result<std::string> {
-  auto value_or = RenderExpr(ctx, ctx.Expr(a.value));
+  auto value_or = RenderExpr(view, view.Expr(a.value));
   if (!value_or) return std::unexpected(std::move(value_or.error()));
 
-  const mir::Expr& lhs_expr = ctx.Expr(a.target);
+  const mir::Expr& lhs_expr = view.Expr(a.target);
 
   // A `ref` / `const ref` formal aliases the actual's cell; a whole write
   // routes through `Ref::Set` so the actual's update-event path fires (LRM
   // 13.5.2). Compound and partial writes through a ref formal are not yet
   // supported.
-  if (const auto* ref_root = LhsRootReferenceProceduralVar(ctx, lhs_expr)) {
+  if (const auto* ref_root = LhsRootReferenceProceduralVar(view, lhs_expr)) {
     if (!IsLhsBarePrimary(lhs_expr) || a.compound_op.has_value()) {
       return diag::Unsupported(
           diag::DiagCode::kCppEmitExpressionFormNotImplemented,
@@ -1500,7 +1498,7 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
           "not yet implemented in cpp emit",
           diag::UnsupportedCategory::kFeature);
     }
-    return LookupProceduralVarName(ctx, *ref_root) + ".Set(" +
+    return LookupProceduralVarName(view, *ref_root) + ".Set(" +
            "self->Services()" + ", " + *value_or + ")";
   }
 
@@ -1511,7 +1509,7 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
   // (`docs/decisions/value-type-concepts.md`). This render emits a plain
   // C++ assignment over whatever `RenderLhsExpr` produces.
   if (IsLhsBarePrimary(lhs_expr)) {
-    auto root_or = RenderLhsExpr(ctx, lhs_expr);
+    auto root_or = RenderLhsExpr(view, lhs_expr);
     if (!root_or) return std::unexpected(std::move(root_or.error()));
     if (a.compound_op.has_value()) {
       return "(" + RenderCompoundAssign(*a.compound_op, *root_or, *value_or) +
@@ -1519,7 +1517,7 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
     }
     return "(" + *root_or + " = " + *value_or + ")";
   }
-  auto chain_or = RenderLhsExpr(ctx, lhs_expr);
+  auto chain_or = RenderLhsExpr(view, lhs_expr);
   if (!chain_or) return std::unexpected(std::move(chain_or.error()));
   if (a.compound_op.has_value()) {
     return "(" + RenderCompoundAssign(*a.compound_op, *chain_or, *value_or) +
@@ -1528,17 +1526,17 @@ auto RenderAssignExpr(const RenderContext& ctx, const mir::AssignExpr& a)
   return *chain_or + " = " + *value_or;
 }
 
-auto RenderIncDecExpr(const RenderContext& ctx, const mir::IncDecExpr& inc)
+auto RenderIncDecExpr(const ScopeView& view, const mir::IncDecExpr& inc)
     -> diag::Result<std::string> {
-  const mir::Expr& target_expr = ctx.Expr(inc.target);
-  if (LhsRootReferenceProceduralVar(ctx, target_expr) != nullptr) {
+  const mir::Expr& target_expr = view.Expr(inc.target);
+  if (LhsRootReferenceProceduralVar(view, target_expr) != nullptr) {
     return diag::Unsupported(
         diag::DiagCode::kCppEmitExpressionFormNotImplemented,
         "increment / decrement of a ref / const ref formal is not yet "
         "implemented in cpp emit",
         diag::UnsupportedCategory::kFeature);
   }
-  auto lhs_or = RenderLhsExpr(ctx, target_expr);
+  auto lhs_or = RenderLhsExpr(view, target_expr);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   std::string lhs = *std::move(lhs_or);
 
@@ -1559,9 +1557,10 @@ auto RenderIncDecExpr(const RenderContext& ctx, const mir::IncDecExpr& inc)
 // `RefType` binding renders as `Ref<T> name`, a value binding as `T name`;
 // the wrapper comes from the type alone (RenderTypeAsCpp), never hand-written.
 auto RenderBindingParamDecl(
-    const RenderContext& ctx, const mir::ProceduralVarDecl& bind)
+    const ScopeView& view, const mir::ProceduralVarDecl& bind)
     -> diag::Result<std::string> {
-  auto type_or = RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), bind.type);
+  auto type_or =
+      RenderTypeAsCpp(view.Unit(), view.StructuralScope(), bind.type);
   if (!type_or) return std::unexpected(std::move(type_or.error()));
   return *type_or + " " + bind.name;
 }
@@ -1572,25 +1571,25 @@ auto RenderBindingParamDecl(
 // parameters and are supplied by an immediate call -- a capturing coroutine
 // lambda would dangle once the spawned branch outlives the referencing site.
 auto RenderClosureExpr(
-    const RenderContext& ctx, const mir::ClosureExpr& closure,
+    const ScopeView& view, const mir::ClosureExpr& closure,
     mir::TypeId result_type) -> diag::Result<std::string> {
   if (closure.body == nullptr) {
     throw InternalError("RenderClosureExpr: closure has no body");
   }
 
   auto result_ty_or =
-      RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), result_type);
+      RenderTypeAsCpp(view.Unit(), view.StructuralScope(), result_type);
   if (!result_ty_or) return std::unexpected(std::move(result_ty_or.error()));
   const std::string return_clause = " -> " + *result_ty_or;
 
-  const RenderContext body_ctx =
-      RenderContext::ForRoot(ctx.Unit(), ctx.StructuralScope(), *closure.body);
-  auto body_or = RenderProceduralScopeStatements(body_ctx, 1);
+  const ScopeView body_view =
+      ScopeView::ForRoot(view.Unit(), view.StructuralScope(), *closure.body);
+  auto body_or = RenderProceduralScopeStatements(body_view, 1);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   const std::string body = " {\n" + *body_or + "}";
 
   if (std::holds_alternative<mir::CoroutineType>(
-          ctx.Unit().GetType(result_type).data)) {
+          view.Unit().GetType(result_type).data)) {
     if (!closure.params.empty()) {
       throw InternalError(
           "RenderClosureExpr: coroutine closure has parameters");
@@ -1600,9 +1599,9 @@ auto RenderClosureExpr(
     for (std::size_t i = 0; i < closure.captures.size(); ++i) {
       const auto& bind =
           closure.body->vars.at(closure.captures[i].binding.value);
-      auto decl_or = RenderBindingParamDecl(ctx, bind);
+      auto decl_or = RenderBindingParamDecl(view, bind);
       if (!decl_or) return std::unexpected(std::move(decl_or.error()));
-      auto arg_or = RenderExpr(ctx, ctx.Expr(closure.captures[i].value));
+      auto arg_or = RenderExpr(view, view.Expr(closure.captures[i].value));
       if (!arg_or) return std::unexpected(std::move(arg_or.error()));
       if (i != 0) {
         params += ", ";
@@ -1621,7 +1620,7 @@ auto RenderClosureExpr(
   for (std::size_t i = 0; i < closure.captures.size(); ++i) {
     const std::string& bind_name =
         closure.body->vars.at(closure.captures[i].binding.value).name;
-    auto source_or = RenderExpr(ctx, ctx.Expr(closure.captures[i].value));
+    auto source_or = RenderExpr(view, view.Expr(closure.captures[i].value));
     if (!source_or) return std::unexpected(std::move(source_or.error()));
     if (i != 0) captures_text += ", ";
     captures_text += bind_name + " = " + *source_or;
@@ -1630,7 +1629,7 @@ auto RenderClosureExpr(
   std::string params_text;
   for (std::size_t i = 0; i < closure.params.size(); ++i) {
     const auto& bind = closure.body->vars.at(closure.params[i].binding.value);
-    auto decl_or = RenderBindingParamDecl(ctx, bind);
+    auto decl_or = RenderBindingParamDecl(view, bind);
     if (!decl_or) return std::unexpected(std::move(decl_or.error()));
     if (i != 0) params_text += ", ";
     params_text += *decl_or;
@@ -1645,22 +1644,22 @@ auto RenderClosureExpr(
 // the assignment destination keeps its own element shape (LRM 10.6.1) -- so no
 // element default is threaded.
 auto RenderQueueConcat(
-    const RenderContext& ctx, const mir::Type& result_ty,
-    const mir::ConcatExpr& c) -> diag::Result<std::string> {
+    const ScopeView& view, const mir::Type& result_ty, const mir::ConcatExpr& c)
+    -> diag::Result<std::string> {
   const mir::TypeId elem_type_id =
       std::get<mir::QueueType>(result_ty.data).element_type;
   auto elem_cpp =
-      RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), elem_type_id);
+      RenderTypeAsCpp(view.Unit(), view.StructuralScope(), elem_type_id);
   if (!elem_cpp) return std::unexpected(std::move(elem_cpp.error()));
   std::string out = "lyra::value::MakeQueueConcat<" + *elem_cpp + ">(";
   for (std::size_t i = 0; i < c.operands.size(); ++i) {
-    const auto& op_expr = ctx.Expr(c.operands[i]);
-    const auto& op_ty = ctx.Unit().GetType(op_expr.type);
+    const auto& op_expr = view.Expr(c.operands[i]);
+    const auto& op_ty = view.Unit().GetType(op_expr.type);
     const bool spread =
         std::holds_alternative<mir::QueueType>(op_ty.data) ||
         std::holds_alternative<mir::DynamicArrayType>(op_ty.data) ||
         std::holds_alternative<mir::UnpackedArrayType>(op_ty.data);
-    auto rendered = RenderExpr(ctx, op_expr);
+    auto rendered = RenderExpr(view, op_expr);
     if (!rendered) return std::unexpected(std::move(rendered.error()));
     if (i != 0) out += ", ";
     out += spread ? "lyra::value::QSpread(" + *rendered + ")"
@@ -1671,11 +1670,11 @@ auto RenderQueueConcat(
 }
 
 auto RenderConcatExpr(
-    const RenderContext& ctx, const mir::Expr& expr, const mir::ConcatExpr& c)
+    const ScopeView& view, const mir::Expr& expr, const mir::ConcatExpr& c)
     -> diag::Result<std::string> {
-  const auto& result_ty = ctx.Unit().GetType(expr.type);
+  const auto& result_ty = view.Unit().GetType(expr.type);
   if (std::holds_alternative<mir::QueueType>(result_ty.data)) {
-    return RenderQueueConcat(ctx, result_ty, c);
+    return RenderQueueConcat(view, result_ty, c);
   }
   if (c.operands.empty()) {
     throw InternalError("RenderConcatExpr: hir lowering produced empty concat");
@@ -1684,7 +1683,7 @@ auto RenderConcatExpr(
                         std::string_view close) -> diag::Result<std::string> {
     std::string out{open};
     for (std::size_t i = 0; i < c.operands.size(); ++i) {
-      auto rendered = RenderExpr(ctx, ctx.Expr(c.operands[i]));
+      auto rendered = RenderExpr(view, view.Expr(c.operands[i]));
       if (!rendered) return std::unexpected(std::move(rendered.error()));
       if (i != 0) out += sep;
       out += *rendered;
@@ -1712,9 +1711,9 @@ auto RenderConcatExpr(
 // rendering is context-independent: the same string is correct standalone
 // and as a construction-call argument.
 auto RenderArrayLiteralExpr(
-    const RenderContext& ctx, const mir::Expr& expr,
+    const ScopeView& view, const mir::Expr& expr,
     const mir::ArrayLiteralExpr& a) -> diag::Result<std::string> {
-  const auto& container_ty = ctx.Unit().GetType(expr.type);
+  const auto& container_ty = view.Unit().GetType(expr.type);
   const mir::TypeId elem_type_id = std::visit(
       [](const auto& ty) -> mir::TypeId {
         using TyT = std::decay_t<decltype(ty)>;
@@ -1731,12 +1730,12 @@ auto RenderArrayLiteralExpr(
       },
       container_ty.data);
   auto elem_type_or =
-      RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), elem_type_id);
+      RenderTypeAsCpp(view.Unit(), view.StructuralScope(), elem_type_id);
   if (!elem_type_or) return std::unexpected(std::move(elem_type_or.error()));
   std::string out =
       std::format("std::array<{}, {}>{{", *elem_type_or, a.elements.size());
   for (std::size_t i = 0; i < a.elements.size(); ++i) {
-    auto rendered = RenderExpr(ctx, ctx.Expr(a.elements[i]));
+    auto rendered = RenderExpr(view, view.Expr(a.elements[i]));
     if (!rendered) return std::unexpected(std::move(rendered.error()));
     if (i != 0) out += ", ";
     out += *rendered;
@@ -1746,17 +1745,17 @@ auto RenderArrayLiteralExpr(
 }
 
 auto RenderReplicationExpr(
-    const RenderContext& ctx, const mir::Expr& expr,
-    const mir::ReplicationExpr& r) -> diag::Result<std::string> {
-  auto count = RenderExpr(ctx, ctx.Expr(r.count));
+    const ScopeView& view, const mir::Expr& expr, const mir::ReplicationExpr& r)
+    -> diag::Result<std::string> {
+  auto count = RenderExpr(view, view.Expr(r.count));
   if (!count) return std::unexpected(std::move(count.error()));
-  auto concat = RenderExpr(ctx, ctx.Expr(r.concat));
+  auto concat = RenderExpr(view, view.Expr(r.concat));
   if (!concat) return std::unexpected(std::move(concat.error()));
-  const auto& count_ty = ctx.Unit().GetType(ctx.Expr(r.count).type);
+  const auto& count_ty = view.Unit().GetType(view.Expr(r.count).type);
   std::string count_text = count_ty.IsIntegralPacked()
                                ? std::format("({}).ToInt64()", *count)
                                : *count;
-  const auto& result_ty = ctx.Unit().GetType(expr.type);
+  const auto& result_ty = view.Unit().GetType(expr.type);
   if (result_ty.IsIntegralPacked()) {
     return std::format(
         "lyra::value::PackedArray::Replicate({}, "
@@ -1775,22 +1774,22 @@ auto RenderReplicationExpr(
 // with `(*ptr)`. The `.Get()` unwrap, if applicable, is emitted by the
 // explicit `ObservableMethod{kGet}` call that HIR-to-MIR wraps around an
 // observable read (`docs/decisions/value-type-concepts.md`).
-auto RenderDerefExpr(const RenderContext& ctx, const mir::DerefExpr& d)
+auto RenderDerefExpr(const ScopeView& view, const mir::DerefExpr& d)
     -> diag::Result<std::string> {
-  const mir::Expr& ptr_expr = ctx.Expr(d.pointer);
-  auto ptr_or = RenderExpr(ctx, ptr_expr);
+  const mir::Expr& ptr_expr = view.Expr(d.pointer);
+  auto ptr_or = RenderExpr(view, ptr_expr);
   if (!ptr_or) return std::unexpected(std::move(ptr_or.error()));
   return "(*" + *ptr_or + ")";
 }
 
 }  // namespace
 
-auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
+auto RenderExpr(const ScopeView& view, const mir::Expr& expr)
     -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
           [&](const mir::IntegerLiteral& lit) -> diag::Result<std::string> {
-            return RenderIntegerLiteralExpr(ctx, expr, lit);
+            return RenderIntegerLiteralExpr(view, expr, lit);
           },
           [&](const mir::StringLiteral& s) -> diag::Result<std::string> {
             return RenderSvStringLiteral(s.value);
@@ -1802,70 +1801,70 @@ auto RenderExpr(const RenderContext& ctx, const mir::Expr& expr)
                 diag::UnsupportedCategory::kFeature);
           },
           [&](const mir::RealLiteral& r) -> diag::Result<std::string> {
-            return RenderRealLiteralExpr(ctx, expr, r);
+            return RenderRealLiteralExpr(view, expr, r);
           },
           [&](const mir::StructuralParamRef& r) -> diag::Result<std::string> {
-            return RenderStructuralParamExpr(ctx, r);
+            return RenderStructuralParamExpr(view, r);
           },
           [&](const mir::ProceduralVarRef& l) -> diag::Result<std::string> {
-            const std::string name = LookupProceduralVarName(ctx, l);
-            return IsReferenceProceduralVar(ctx, l) ? name + ".Get()" : name;
+            const std::string name = LookupProceduralVarName(view, l);
+            return IsReferenceProceduralVar(view, l) ? name + ".Get()" : name;
           },
           [&](const mir::UnaryExpr& u) -> diag::Result<std::string> {
-            return RenderUnaryExpr(ctx, expr, u);
+            return RenderUnaryExpr(view, expr, u);
           },
           [&](const mir::BinaryExpr& b) -> diag::Result<std::string> {
-            return RenderBinaryExpr(ctx, expr, b);
+            return RenderBinaryExpr(view, expr, b);
           },
           [&](const mir::ConditionalExpr& c) -> diag::Result<std::string> {
-            return RenderConditionalExpr(ctx, c);
+            return RenderConditionalExpr(view, c);
           },
           [&](const mir::AssignExpr& a) -> diag::Result<std::string> {
-            return RenderAssignExpr(ctx, a);
+            return RenderAssignExpr(view, a);
           },
           [&](const mir::IncDecExpr& inc) -> diag::Result<std::string> {
-            return RenderIncDecExpr(ctx, inc);
+            return RenderIncDecExpr(view, inc);
           },
           [&](const mir::ConversionExpr& cv) -> diag::Result<std::string> {
-            return RenderConversionExpr(ctx, expr, cv);
+            return RenderConversionExpr(view, expr, cv);
           },
           [&](const mir::CallExpr& call) -> diag::Result<std::string> {
-            return RenderCallExpr(ctx, call, expr.type);
+            return RenderCallExpr(view, call, expr.type);
           },
           [&](const mir::RuntimeCallExpr& rc) -> diag::Result<std::string> {
-            return RenderRuntimeCallExpr(ctx, rc);
+            return RenderRuntimeCallExpr(view, rc);
           },
           [&](const mir::DerefExpr& d) -> diag::Result<std::string> {
-            return RenderDerefExpr(ctx, d);
+            return RenderDerefExpr(view, d);
           },
           [&](const mir::MemberAccessExpr& m) -> diag::Result<std::string> {
-            const auto& scope = ctx.StructuralScopeAtHops(m.member.hops);
+            const auto& scope = view.StructuralScopeAtHops(m.member.hops);
             const auto& var = scope.GetStructuralVar(m.member.var);
-            auto receiver_or = RenderExpr(ctx, ctx.Expr(m.receiver));
+            auto receiver_or = RenderExpr(view, view.Expr(m.receiver));
             if (!receiver_or) {
               return std::unexpected(std::move(receiver_or.error()));
             }
             return *receiver_or + "->" + var.name;
           },
           [&](const mir::ClosureExpr& cl) -> diag::Result<std::string> {
-            return RenderClosureExpr(ctx, cl, expr.type);
+            return RenderClosureExpr(view, cl, expr.type);
           },
           [&](const mir::ConcatExpr& c) -> diag::Result<std::string> {
-            return RenderConcatExpr(ctx, expr, c);
+            return RenderConcatExpr(view, expr, c);
           },
           [&](const mir::ReplicationExpr& r) -> diag::Result<std::string> {
-            return RenderReplicationExpr(ctx, expr, r);
+            return RenderReplicationExpr(view, expr, r);
           },
           [&](const mir::ArrayLiteralExpr& a) -> diag::Result<std::string> {
-            return RenderArrayLiteralExpr(ctx, expr, a);
+            return RenderArrayLiteralExpr(view, expr, a);
           },
       },
       expr.data);
 }
 
-auto RenderConditionAsBool(const RenderContext& ctx, const mir::Expr& expr)
+auto RenderConditionAsBool(const ScopeView& view, const mir::Expr& expr)
     -> diag::Result<std::string> {
-  auto text_or = RenderExpr(ctx, expr);
+  auto text_or = RenderExpr(view, expr);
   if (!text_or) return std::unexpected(std::move(text_or.error()));
   // PackedArray's `explicit operator bool` fires in any boolean context (if /
   // while / for / ternary cond / `&&` / `||` / `!`), so no wrapping needed.

--- a/src/lyra/backend/cpp/render_print.cpp
+++ b/src/lyra/backend/cpp/render_print.cpp
@@ -8,8 +8,8 @@
 #include <variant>
 #include <vector>
 
-#include "lyra/backend/cpp/render_context.hpp"
 #include "lyra/backend/cpp/render_expr.hpp"
+#include "lyra/backend/cpp/scope_view.hpp"
 #include "lyra/backend/cpp/string_literal.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
@@ -67,17 +67,16 @@ auto RenderFormatSpecInit(const mir::FormatSpec& spec) -> std::string {
       from_int(is_time ? "kTimeUnitPower" : "0LL"));
 }
 
-auto RenderPrintValueArg(
-    const RenderContext& ctx, const mir::RuntimePrintValue& v)
+auto RenderPrintValueArg(const ScopeView& view, const mir::RuntimePrintValue& v)
     -> diag::Result<std::string> {
-  const auto& type = ctx.Unit().GetType(v.type);
+  const auto& type = view.Unit().GetType(v.type);
 
   // The argument is type-driven: the `PrintValue` overload set selects the
   // right `Formatter<T>` from the operand's C++ type, so the backend only
   // hands it the bare operand. Any spec/operand mismatch (e.g. `%s` on a bit
   // vector) must be resolved upstream of the backend -- at HIR -> MIR via an
   // explicit ConversionExpr, or rejected.
-  auto operand_or = RenderExpr(ctx, ctx.Expr(v.value));
+  auto operand_or = RenderExpr(view, view.Expr(v.value));
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
 
   if (type.IsIntegralPacked() || type.Kind() == mir::TypeKind::kReal ||
@@ -94,7 +93,7 @@ auto RenderPrintValueArg(
 }
 
 auto RenderPrintItemInit(
-    const RenderContext& ctx, const mir::RuntimePrintItem& item)
+    const ScopeView& view, const mir::RuntimePrintItem& item)
     -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
@@ -105,7 +104,7 @@ auto RenderPrintItemInit(
                 RenderCStringLiteral(lit.text), lit.text.size());
           },
           [&](const mir::RuntimePrintValue& v) -> diag::Result<std::string> {
-            auto arg_or = RenderPrintValueArg(ctx, v);
+            auto arg_or = RenderPrintValueArg(view, v);
             if (!arg_or) return std::unexpected(std::move(arg_or.error()));
             return std::format(
                 "lyra::value::PrintValueItem({}, {})", *arg_or,
@@ -120,7 +119,7 @@ auto RenderPrintItemInit(
 namespace {
 
 auto RenderRuntimePrintCall(
-    const RenderContext& ctx, const mir::RuntimePrintCall& call)
+    const ScopeView& view, const mir::RuntimePrintCall& call)
     -> diag::Result<std::string> {
   const std::string_view kind_literal = RenderPrintKindLiteral(call.kind);
 
@@ -129,7 +128,7 @@ auto RenderRuntimePrintCall(
   std::string descriptor_arg;
   std::string_view call_target = "lyra::runtime::LyraPrint";
   if (call.descriptor.has_value()) {
-    auto desc_or = RenderExpr(ctx, ctx.Expr(*call.descriptor));
+    auto desc_or = RenderExpr(view, view.Expr(*call.descriptor));
     if (!desc_or) return std::unexpected(std::move(desc_or.error()));
     descriptor_arg = std::format("{}, ", *desc_or);
     call_target = "lyra::runtime::LyraFPrint";
@@ -151,7 +150,7 @@ auto RenderRuntimePrintCall(
   std::vector<std::string> item_inits;
   item_inits.reserve(call.items.size());
   for (const mir::RuntimePrintItem& item : call.items) {
-    auto init_or = RenderPrintItemInit(ctx, item);
+    auto init_or = RenderPrintItemInit(view, item);
     if (!init_or) return std::unexpected(std::move(init_or.error()));
     item_inits.push_back(*std::move(init_or));
   }
@@ -172,16 +171,16 @@ auto RenderRuntimePrintCall(
 }  // namespace
 
 auto RenderRuntimeCallExpr(
-    const RenderContext& ctx, const mir::RuntimeCallExpr& expr)
+    const ScopeView& view, const mir::RuntimeCallExpr& expr)
     -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
           [&](const mir::RuntimePrintCall& pc) -> diag::Result<std::string> {
-            return RenderRuntimePrintCall(ctx, pc);
+            return RenderRuntimePrintCall(view, pc);
           },
           [&](const mir::RuntimeSubmitObservedCall& sc)
               -> diag::Result<std::string> {
-            auto closure_or = RenderExpr(ctx, ctx.Expr(sc.closure));
+            auto closure_or = RenderExpr(view, view.Expr(sc.closure));
             if (!closure_or) {
               return std::unexpected(std::move(closure_or.error()));
             }
@@ -191,7 +190,7 @@ auto RenderRuntimeCallExpr(
           },
           [&](const mir::RuntimeSubmitNbaCall& nc)
               -> diag::Result<std::string> {
-            auto closure_or = RenderExpr(ctx, ctx.Expr(nc.closure));
+            auto closure_or = RenderExpr(view, view.Expr(nc.closure));
             if (!closure_or) {
               return std::unexpected(std::move(closure_or.error()));
             }
@@ -209,7 +208,7 @@ auto RenderRuntimeCallExpr(
             // at fire time. LRM 21.3.2 cancellation on $fclose is the
             // file-sink entry's responsibility.
             const std::string_view capture{"[=]"};
-            auto print_or = RenderRuntimePrintCall(ctx, pc.print);
+            auto print_or = RenderRuntimePrintCall(view, pc.print);
             if (!print_or) {
               return std::unexpected(std::move(print_or.error()));
             }
@@ -218,7 +217,7 @@ auto RenderRuntimeCallExpr(
                   "lyra::runtime::LyraSubmitStrobe({}, {}() {{ {}; }})",
                   "self->Services()", capture, *print_or);
             }
-            auto desc_or = RenderExpr(ctx, ctx.Expr(*pc.print.descriptor));
+            auto desc_or = RenderExpr(view, view.Expr(*pc.print.descriptor));
             if (!desc_or) {
               return std::unexpected(std::move(desc_or.error()));
             }
@@ -227,11 +226,11 @@ auto RenderRuntimeCallExpr(
                 "self->Services()", *desc_or, capture, *print_or);
           },
           [&](const mir::RuntimeScanCall& ss) -> diag::Result<std::string> {
-            auto source_or = RenderExpr(ctx, ctx.Expr(ss.source));
+            auto source_or = RenderExpr(view, view.Expr(ss.source));
             if (!source_or) {
               return std::unexpected(std::move(source_or.error()));
             }
-            auto format_or = RenderExpr(ctx, ctx.Expr(ss.format));
+            auto format_or = RenderExpr(view, view.Expr(ss.format));
             if (!format_or) {
               return std::unexpected(std::move(format_or.error()));
             }
@@ -245,7 +244,7 @@ auto RenderRuntimeCallExpr(
                   Overloaded{
                       [&](const mir::IntegralScanSlot& s)
                           -> diag::Result<std::string> {
-                        auto temp_or = RenderLhsExpr(ctx, ctx.Expr(s.temp));
+                        auto temp_or = RenderLhsExpr(view, view.Expr(s.temp));
                         if (!temp_or) {
                           return std::unexpected(std::move(temp_or.error()));
                         }
@@ -259,7 +258,7 @@ auto RenderRuntimeCallExpr(
                       },
                       [&](const mir::StringScanSlot& s)
                           -> diag::Result<std::string> {
-                        auto temp_or = RenderLhsExpr(ctx, ctx.Expr(s.temp));
+                        auto temp_or = RenderLhsExpr(view, view.Expr(s.temp));
                         if (!temp_or) {
                           return std::unexpected(std::move(temp_or.error()));
                         }

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -8,9 +8,9 @@
 #include <vector>
 
 #include "lyra/backend/cpp/formatting.hpp"
-#include "lyra/backend/cpp/render_context.hpp"
 #include "lyra/backend/cpp/render_expr.hpp"
 #include "lyra/backend/cpp/render_type.hpp"
+#include "lyra/backend/cpp/scope_view.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/diag/diagnostic.hpp"
@@ -22,7 +22,7 @@ namespace lyra::backend::cpp {
 
 namespace {
 
-auto RenderForInit(const RenderContext& ctx, const mir::ForInit& init)
+auto RenderForInit(const ScopeView& view, const mir::ForInit& init)
     -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
@@ -31,19 +31,19 @@ auto RenderForInit(const RenderContext& ctx, const mir::ForInit& init)
             // yields (every integral value is a PackedArray), so `auto` is the
             // exact same type as spelling it out -- and reads as the idiomatic
             // loop counter.
-            const auto& lv = ctx.ProceduralScopeAtHops(d.induction_var.hops)
+            const auto& lv = view.ProceduralScopeAtHops(d.induction_var.hops)
                                  .vars.at(d.induction_var.var.value);
             const auto& init_expr =
-                ctx.ProceduralScope().exprs.at(d.init.value);
-            auto rendered_or = RenderExpr(ctx, init_expr);
+                view.ProceduralScope().exprs.at(d.init.value);
+            auto rendered_or = RenderExpr(view, init_expr);
             if (!rendered_or) {
               return std::unexpected(std::move(rendered_or.error()));
             }
             return "auto " + lv.name + " = " + *rendered_or;
           },
           [&](const mir::ForInitExpr& e) -> diag::Result<std::string> {
-            const auto& expr = ctx.ProceduralScope().exprs.at(e.expr.value);
-            return RenderExpr(ctx, expr);
+            const auto& expr = view.ProceduralScope().exprs.at(e.expr.value);
+            return RenderExpr(view, expr);
           },
       },
       init);
@@ -64,23 +64,23 @@ auto RenderEventEdgeAsRuntime(mir::EventEdge edge) -> std::string_view {
 }
 
 auto RenderProceduralVarDeclStmt(
-    const RenderContext& ctx, const mir::ProceduralVarDeclStmt& s,
+    const ScopeView& view, const mir::ProceduralVarDeclStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
   const auto& lv =
-      ctx.ProceduralScopeAtHops(s.target.hops).vars.at(s.target.var.value);
-  auto type_or = RenderTypeAsCpp(ctx.Unit(), ctx.StructuralScope(), lv.type);
+      view.ProceduralScopeAtHops(s.target.hops).vars.at(s.target.var.value);
+  auto type_or = RenderTypeAsCpp(view.Unit(), view.StructuralScope(), lv.type);
   if (!type_or) return std::unexpected(std::move(type_or.error()));
-  const auto& init_expr = ctx.ProceduralScope().exprs.at(s.init.value);
-  auto init_or = RenderExpr(ctx, init_expr);
+  const auto& init_expr = view.ProceduralScope().exprs.at(s.init.value);
+  auto init_or = RenderExpr(view, init_expr);
   if (!init_or) return std::unexpected(std::move(init_or.error()));
   return Indent(indent) + *type_or + " " + lv.name + " = " + *init_or + ";\n";
 }
 
 auto RenderExprStmt(
-    const RenderContext& ctx, const mir::ExprStmt& s, std::size_t indent)
+    const ScopeView& view, const mir::ExprStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
-  const auto& expr = ctx.ProceduralScope().exprs.at(s.expr.value);
-  auto rendered_or = RenderExpr(ctx, expr);
+  const auto& expr = view.ProceduralScope().exprs.at(s.expr.value);
+  auto rendered_or = RenderExpr(view, expr);
   if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
   return Indent(indent) + *rendered_or + ";\n";
 }
@@ -89,20 +89,20 @@ auto RenderExprStmt(
 // awaitable operand. One uniform site for every suspending construct ($finish,
 // task call, named-event await).
 auto RenderAwaitStmt(
-    const RenderContext& ctx, const mir::AwaitStmt& s, std::size_t indent)
+    const ScopeView& view, const mir::AwaitStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
-  const auto& expr = ctx.ProceduralScope().exprs.at(s.awaitable.value);
-  auto rendered_or = RenderExpr(ctx, expr);
+  const auto& expr = view.ProceduralScope().exprs.at(s.awaitable.value);
+  auto rendered_or = RenderExpr(view, expr);
   if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
   return Indent(indent) + "co_await " + *rendered_or + ";\n";
 }
 
 auto RenderBlockStmtNode(
-    const RenderContext& ctx, const mir::BlockStmt& s, std::size_t indent)
+    const ScopeView& view, const mir::BlockStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
-  const auto& child = ctx.ProceduralScope().GetChildScope(s.scope);
+  const auto& child = view.ProceduralScope().GetChildScope(s.scope);
   std::string result = Indent(indent) + "{\n";
-  auto child_or = RenderNestedProceduralScope(ctx, child, indent + 1);
+  auto child_or = RenderNestedProceduralScope(view, child, indent + 1);
   if (!child_or) return std::unexpected(std::move(child_or.error()));
   result += *child_or;
   result += Indent(indent) + "}\n";
@@ -129,23 +129,23 @@ auto RenderForkJoinModeLiteral(mir::JoinMode mode) -> std::string_view {
 // yielding a `lyra::runtime::Coroutine` collected into `fork_branches`. The
 // fork then waits per the join mode.
 auto RenderForkStmtNode(
-    const RenderContext& ctx, const mir::ForkStmt& s, std::size_t indent)
+    const ScopeView& view, const mir::ForkStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
   // The fork-branches vector lives in this fork's own `{...}` block scope
   // (opened just below), so a fixed name suffices -- a sibling fork in the
   // surrounding scope, or a nested fork in a branch lambda body, each has
   // its own `fork_branches` in its own C++ scope.
   const std::string vec = "fork_branches";
-  const RenderContext fork_ctx =
-      ctx.WithProceduralScope(ctx.ProceduralScope().GetChildScope(s.scope));
+  const ScopeView fork_view =
+      view.WithProceduralScope(view.ProceduralScope().GetChildScope(s.scope));
   std::string out = Indent(indent) + "{\n";
-  auto locals_or = RenderProceduralScopeStatements(fork_ctx, indent + 1);
+  auto locals_or = RenderProceduralScopeStatements(fork_view, indent + 1);
   if (!locals_or) return std::unexpected(std::move(locals_or.error()));
   out += *locals_or;
   out += Indent(indent + 1) + "std::vector<lyra::runtime::Coroutine> " + vec +
          ";\n";
   for (const auto branch : s.branches) {
-    auto closure_or = RenderExpr(fork_ctx, fork_ctx.Expr(branch));
+    auto closure_or = RenderExpr(fork_view, fork_view.Expr(branch));
     if (!closure_or) return std::unexpected(std::move(closure_or.error()));
     out += Indent(indent + 1) + vec + ".push_back(" + *closure_or + ");\n";
   }
@@ -157,21 +157,22 @@ auto RenderForkStmtNode(
 }
 
 auto RenderIfStmtNode(
-    const RenderContext& ctx, const mir::IfStmt& s, std::size_t indent)
+    const ScopeView& view, const mir::IfStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
-  const auto& cond_expr = ctx.ProceduralScope().exprs.at(s.condition.value);
-  const auto& then_scope = ctx.ProceduralScope().GetChildScope(s.then_scope);
-  auto cond_or = RenderConditionAsBool(ctx, cond_expr);
+  const auto& cond_expr = view.ProceduralScope().exprs.at(s.condition.value);
+  const auto& then_scope = view.ProceduralScope().GetChildScope(s.then_scope);
+  auto cond_or = RenderConditionAsBool(view, cond_expr);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  auto then_or = RenderNestedProceduralScope(ctx, then_scope, indent + 1);
+  auto then_or = RenderNestedProceduralScope(view, then_scope, indent + 1);
   if (!then_or) return std::unexpected(std::move(then_or.error()));
   std::string result;
   result += Indent(indent) + "if (" + *cond_or + ") {\n";
   result += *then_or;
   result += Indent(indent) + "}";
   if (s.else_scope.has_value()) {
-    const auto& else_scope = ctx.ProceduralScope().GetChildScope(*s.else_scope);
-    auto else_or = RenderNestedProceduralScope(ctx, else_scope, indent + 1);
+    const auto& else_scope =
+        view.ProceduralScope().GetChildScope(*s.else_scope);
+    auto else_or = RenderNestedProceduralScope(view, else_scope, indent + 1);
     if (!else_or) return std::unexpected(std::move(else_or.error()));
     result += " else {\n";
     result += *else_or;
@@ -182,21 +183,21 @@ auto RenderIfStmtNode(
 }
 
 auto RenderConstructOwnedObjectStmt(
-    const RenderContext& ctx, const mir::ConstructOwnedObjectStmt& s,
+    const ScopeView& view, const mir::ConstructOwnedObjectStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
-  const auto& var = ctx.StructuralScope().GetStructuralVar(s.target);
+  const auto& var = view.StructuralScope().GetStructuralVar(s.target);
   const auto& target_scope =
-      ctx.StructuralScope().GetChildStructuralScope(s.scope_id);
+      view.StructuralScope().GetChildStructuralScope(s.scope_id);
   std::string trailing_args;
   for (const auto arg_id : s.args) {
-    auto arg_or = RenderExpr(ctx, ctx.Expr(arg_id));
+    auto arg_or = RenderExpr(view, view.Expr(arg_id));
     if (!arg_or) return std::unexpected(std::move(arg_or.error()));
     trailing_args += ", " + *arg_or;
   }
   const std::string make = "std::make_unique<" + target_scope.name +
                            ">(self, \"" + target_scope.name +
                            "\", self->Services()" + trailing_args + ")";
-  const auto child = mir::GetChildScope(ctx.Unit(), var.type);
+  const auto child = mir::GetChildScope(view.Unit(), var.type);
   if (!child.has_value() ||
       !std::holds_alternative<mir::GenerateScopeChild>(*child)) {
     throw InternalError(
@@ -206,7 +207,7 @@ auto RenderConstructOwnedObjectStmt(
   const std::string reg_name =
       var.source_name.empty() ? var.name : var.source_name;
   if (std::holds_alternative<mir::VectorType>(
-          ctx.Unit().GetType(var.type).data)) {
+          view.Unit().GetType(var.type).data)) {
     return Indent(indent) + lhs + ".push_back(" + make + ");\n" +
            Indent(indent) + "self->RegisterChild(\"" + reg_name +
            "\", std::array{" + lhs + ".size() - 1}, *" + lhs + ".back());\n";
@@ -222,19 +223,19 @@ auto RenderConstructOwnedObjectStmt(
 // the member's compile-time label. `dims` carries one element count per vector
 // layer, so a scalar (no vector layer) renders just the leaf.
 auto RenderExternalUnitFill(
-    const RenderContext& ctx, const std::string& lvalue, mir::TypeId type,
+    const ScopeView& view, const std::string& lvalue, mir::TypeId type,
     const std::string& unit_name, const std::string& label,
     const std::vector<std::uint32_t>& dims, std::size_t depth,
     std::size_t indent) -> std::string {
   if (const auto* vec =
-          std::get_if<mir::VectorType>(&ctx.Unit().GetType(type).data)) {
+          std::get_if<mir::VectorType>(&view.Unit().GetType(type).data)) {
     const std::string idx = "i" + std::to_string(depth);
     std::string out;
     out += Indent(indent) + "for (std::size_t " + idx + " = 0; " + idx + " < " +
            std::to_string(dims.at(depth)) + "; ++" + idx + ") {\n";
     out += Indent(indent + 1) + lvalue + ".emplace_back();\n";
     out += RenderExternalUnitFill(
-        ctx, lvalue + "[" + idx + "]", vec->element, unit_name, label, dims,
+        view, lvalue + "[" + idx + "]", vec->element, unit_name, label, dims,
         depth + 1, indent + 1);
     out += Indent(indent) + "}\n";
     return out;
@@ -257,11 +258,11 @@ auto RenderExternalUnitFill(
 }
 
 auto RenderConstructExternalUnitStmt(
-    const RenderContext& ctx, const mir::ConstructExternalUnitStmt& s,
+    const ScopeView& view, const mir::ConstructExternalUnitStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
-  const auto& var = ctx.StructuralScope().GetStructuralVar(s.target);
+  const auto& var = view.StructuralScope().GetStructuralVar(s.target);
   return RenderExternalUnitFill(
-      ctx, "self->" + var.name, var.type, s.unit_name, var.name, s.dims, 0,
+      view, "self->" + var.name, var.type, s.unit_name, var.name, s.dims, 0,
       indent);
 }
 
@@ -273,32 +274,32 @@ auto BreakLandingLabel(mir::LoopLabelId label) -> std::string {
 }
 
 auto RenderForStmtNode(
-    const RenderContext& ctx, const mir::ForStmt& s, std::size_t indent)
+    const ScopeView& view, const mir::ForStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
   std::string init;
   for (std::size_t i = 0; i < s.init.size(); ++i) {
     if (i != 0) init += ", ";
-    auto init_or = RenderForInit(ctx, s.init[i]);
+    auto init_or = RenderForInit(view, s.init[i]);
     if (!init_or) return std::unexpected(std::move(init_or.error()));
     init += *init_or;
   }
   std::string cond;
   if (s.condition.has_value()) {
-    const auto& cond_expr = ctx.ProceduralScope().exprs.at(s.condition->value);
-    auto cond_or = RenderConditionAsBool(ctx, cond_expr);
+    const auto& cond_expr = view.ProceduralScope().exprs.at(s.condition->value);
+    auto cond_or = RenderConditionAsBool(view, cond_expr);
     if (!cond_or) return std::unexpected(std::move(cond_or.error()));
     cond = *std::move(cond_or);
   }
   std::string step;
   for (std::size_t i = 0; i < s.step.size(); ++i) {
     if (i != 0) step += ", ";
-    const auto& step_expr = ctx.ProceduralScope().exprs.at(s.step[i].value);
-    auto step_or = RenderExpr(ctx, step_expr);
+    const auto& step_expr = view.ProceduralScope().exprs.at(s.step[i].value);
+    auto step_or = RenderExpr(view, step_expr);
     if (!step_or) return std::unexpected(std::move(step_or.error()));
     step += *step_or;
   }
-  const auto& scope = ctx.ProceduralScope().GetChildScope(s.scope);
-  auto body_or = RenderNestedProceduralScope(ctx, scope, indent + 1);
+  const auto& scope = view.ProceduralScope().GetChildScope(s.scope);
+  auto body_or = RenderNestedProceduralScope(view, scope, indent + 1);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   std::string result =
       Indent(indent) + "for (" + init + "; " + cond + "; " + step + ") {\n";
@@ -311,13 +312,13 @@ auto RenderForStmtNode(
 }
 
 auto RenderWhileStmtNode(
-    const RenderContext& ctx, const mir::WhileStmt& s, std::size_t indent)
+    const ScopeView& view, const mir::WhileStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
-  const auto& cond_expr = ctx.ProceduralScope().exprs.at(s.condition.value);
-  auto cond_or = RenderConditionAsBool(ctx, cond_expr);
+  const auto& cond_expr = view.ProceduralScope().exprs.at(s.condition.value);
+  auto cond_or = RenderConditionAsBool(view, cond_expr);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const auto& scope = ctx.ProceduralScope().GetChildScope(s.scope);
-  auto body_or = RenderNestedProceduralScope(ctx, scope, indent + 1);
+  const auto& scope = view.ProceduralScope().GetChildScope(s.scope);
+  auto body_or = RenderNestedProceduralScope(view, scope, indent + 1);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   std::string result =
       Indent(indent) + "while (" + *std::move(cond_or) + ") {\n";
@@ -327,13 +328,13 @@ auto RenderWhileStmtNode(
 }
 
 auto RenderDoWhileStmtNode(
-    const RenderContext& ctx, const mir::DoWhileStmt& s, std::size_t indent)
+    const ScopeView& view, const mir::DoWhileStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
-  const auto& cond_expr = ctx.ProceduralScope().exprs.at(s.condition.value);
-  auto cond_or = RenderConditionAsBool(ctx, cond_expr);
+  const auto& cond_expr = view.ProceduralScope().exprs.at(s.condition.value);
+  auto cond_or = RenderConditionAsBool(view, cond_expr);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const auto& scope = ctx.ProceduralScope().GetChildScope(s.scope);
-  auto body_or = RenderNestedProceduralScope(ctx, scope, indent + 1);
+  const auto& scope = view.ProceduralScope().GetChildScope(s.scope);
+  auto body_or = RenderNestedProceduralScope(view, scope, indent + 1);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   std::string result = Indent(indent) + "do {\n";
   result += *body_or;
@@ -346,20 +347,20 @@ auto RenderDoWhileStmtNode(
 // through its resolved cell (AsObservable); a downward slot is already a
 // resolved `Var<T>*`, so the slot name is the pointer.
 auto RenderSensitivityRefPtr(
-    const RenderContext& ctx, const mir::SensitivityRef& ref)
+    const ScopeView& view, const mir::SensitivityRef& ref)
     -> diag::Result<std::string> {
-  auto name = RenderStructuralVarName(ctx, ref);
+  auto name = RenderStructuralVarName(view, ref);
   if (!name) return std::unexpected(std::move(name.error()));
   const auto& var =
-      ctx.StructuralScopeAtHops(ref.hops).GetStructuralVar(ref.var);
+      view.StructuralScopeAtHops(ref.hops).GetStructuralVar(ref.var);
   if (std::holds_alternative<mir::ExternalRefType>(
-          ctx.Unit().GetType(var.type).data)) {
+          view.Unit().GetType(var.type).data)) {
     return *name + ".AsObservable()";
   }
   // A borrowed-pointer slot already holds a `Var<T>*` (= Observable*); the
   // pointer value is the subscription target, no address-of.
   if (const auto* ptr =
-          std::get_if<mir::PointerType>(&ctx.Unit().GetType(var.type).data);
+          std::get_if<mir::PointerType>(&view.Unit().GetType(var.type).data);
       ptr != nullptr && ptr->ownership == mir::PointerOwnership::kBorrowed) {
     return *name;
   }
@@ -367,12 +368,12 @@ auto RenderSensitivityRefPtr(
 }
 
 auto RenderSensitivityWaitStmt(
-    const RenderContext& ctx, const mir::SensitivityWaitStmt& s,
+    const ScopeView& view, const mir::SensitivityWaitStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
   std::string result = Indent(indent) + "co_await lyra::runtime::WaitAny({";
   for (std::size_t i = 0; i < s.reads.size(); ++i) {
     const auto& read = s.reads[i];
-    auto ptr_or = RenderSensitivityRefPtr(ctx, read.ref);
+    auto ptr_or = RenderSensitivityRefPtr(view, read.ref);
     if (!ptr_or) return std::unexpected(std::move(ptr_or.error()));
     if (i != 0) result += ", ";
     // bit_range follows slang's `(lo_bit, hi_bit)` inclusive convention; the
@@ -390,7 +391,7 @@ auto RenderSensitivityWaitStmt(
 }  // namespace
 
 auto RenderStmt(
-    const RenderContext& ctx, const mir::Stmt& stmt, std::size_t indent)
+    const ScopeView& view, const mir::Stmt& stmt, std::size_t indent)
     -> diag::Result<std::string> {
   std::string out;
   if (stmt.label.has_value()) {
@@ -408,36 +409,36 @@ auto RenderStmt(
           },
           [&](const mir::ProceduralVarDeclStmt& s)
               -> diag::Result<std::string> {
-            return RenderProceduralVarDeclStmt(ctx, s, indent);
+            return RenderProceduralVarDeclStmt(view, s, indent);
           },
           [&](const mir::ExprStmt& s) -> diag::Result<std::string> {
-            return RenderExprStmt(ctx, s, indent);
+            return RenderExprStmt(view, s, indent);
           },
           [&](const mir::BlockStmt& s) -> diag::Result<std::string> {
-            return RenderBlockStmtNode(ctx, s, indent);
+            return RenderBlockStmtNode(view, s, indent);
           },
           [&](const mir::ForkStmt& s) -> diag::Result<std::string> {
-            return RenderForkStmtNode(ctx, s, indent);
+            return RenderForkStmtNode(view, s, indent);
           },
           [&](const mir::IfStmt& s) -> diag::Result<std::string> {
-            return RenderIfStmtNode(ctx, s, indent);
+            return RenderIfStmtNode(view, s, indent);
           },
           [&](const mir::ConstructOwnedObjectStmt& s)
               -> diag::Result<std::string> {
-            return RenderConstructOwnedObjectStmt(ctx, s, indent);
+            return RenderConstructOwnedObjectStmt(view, s, indent);
           },
           [&](const mir::ConstructExternalUnitStmt& s)
               -> diag::Result<std::string> {
-            return RenderConstructExternalUnitStmt(ctx, s, indent);
+            return RenderConstructExternalUnitStmt(view, s, indent);
           },
           [&](const mir::ForStmt& s) -> diag::Result<std::string> {
-            return RenderForStmtNode(ctx, s, indent);
+            return RenderForStmtNode(view, s, indent);
           },
           [&](const mir::WhileStmt& s) -> diag::Result<std::string> {
-            return RenderWhileStmtNode(ctx, s, indent);
+            return RenderWhileStmtNode(view, s, indent);
           },
           [&](const mir::DoWhileStmt& s) -> diag::Result<std::string> {
-            return RenderDoWhileStmtNode(ctx, s, indent);
+            return RenderDoWhileStmtNode(view, s, indent);
           },
           [&](const mir::BreakStmt& s) -> diag::Result<std::string> {
             if (s.target.has_value()) {
@@ -460,15 +461,15 @@ auto RenderStmt(
             if (!s.value.has_value()) {
               return Indent(indent) + "return;\n";
             }
-            auto value_or = RenderExpr(ctx, ctx.Expr(*s.value));
+            auto value_or = RenderExpr(view, view.Expr(*s.value));
             if (!value_or) return std::unexpected(std::move(value_or.error()));
             return Indent(indent) + "return " + *value_or + ";\n";
           },
           [&](const mir::AwaitStmt& s) -> diag::Result<std::string> {
-            return RenderAwaitStmt(ctx, s, indent);
+            return RenderAwaitStmt(view, s, indent);
           },
           [&](const mir::SensitivityWaitStmt& s) -> diag::Result<std::string> {
-            return RenderSensitivityWaitStmt(ctx, s, indent);
+            return RenderSensitivityWaitStmt(view, s, indent);
           },
       },
       stmt.data);
@@ -477,9 +478,9 @@ auto RenderStmt(
   return out;
 }
 
-auto RenderProceduralScopeStatements(
-    const RenderContext& ctx, std::size_t indent) -> diag::Result<std::string> {
-  const auto& scope = ctx.ProceduralScope();
+auto RenderProceduralScopeStatements(const ScopeView& view, std::size_t indent)
+    -> diag::Result<std::string> {
+  const auto& scope = view.ProceduralScope();
   // When a scope's whole content is a single begin/end block, the enclosing
   // braces (a function body, a loop or branch body, an outer block) already
   // scope it; render the block's body directly instead of emitting a redundant
@@ -489,12 +490,12 @@ auto RenderProceduralScopeStatements(
     if (const auto* block = std::get_if<mir::BlockStmt>(&only.data)) {
       const auto& inner = scope.GetChildScope(block->scope);
       return RenderProceduralScopeStatements(
-          ctx.WithProceduralScope(inner), indent);
+          view.WithProceduralScope(inner), indent);
     }
   }
   std::string out;
   for (const auto& sid : scope.root_stmts) {
-    auto rendered_or = RenderStmt(ctx, scope.stmts.at(sid.value), indent);
+    auto rendered_or = RenderStmt(view, scope.stmts.at(sid.value), indent);
     if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
     out += *rendered_or;
   }
@@ -502,9 +503,9 @@ auto RenderProceduralScopeStatements(
 }
 
 auto RenderNestedProceduralScope(
-    const RenderContext& parent, const mir::ProceduralScope& scope,
+    const ScopeView& parent, const mir::ProceduralScope& scope,
     std::size_t indent) -> diag::Result<std::string> {
-  const RenderContext child = parent.WithProceduralScope(scope);
+  const ScopeView child = parent.WithProceduralScope(scope);
   return RenderProceduralScopeStatements(child, indent);
 }
 

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -106,13 +106,7 @@ auto LowerStructuralVarRefExpr(
     const hir::StructuralVarRef& m) -> mir::Expr {
   const mir::StructuralVarRef member =
       scope.TranslateStructuralVar(m.hops, m.var);
-  const mir::TypeId field_type = frame.StructuralScopeAtHops(member.hops)
-                                     .GetStructuralVar(member.var)
-                                     .type;
-  const mir::TypeId self_ptr_type = scope.Module().Unit().builtins.self_pointer;
-  const mir::ExprId receiver = frame.current_procedural_scope->AddExpr(
-      BuildSelfRefExpr(frame, self_ptr_type));
-  return mir::MakeMemberAccessExpr(receiver, member, field_type);
+  return BuildStructuralMemberAccessExpr(frame, scope.Module().Unit(), member);
 }
 
 auto LowerProceduralVarRefExpr(
@@ -125,14 +119,8 @@ auto LowerProceduralVarRefExpr(
   if (const auto* sb = std::get_if<StaticVarBinding>(&binding)) {
     const mir::StructuralVarRef member{
         .hops = mir::StructuralHops{.value = 0}, .var = sb->var};
-    const mir::TypeId field_type = frame.StructuralScopeAtHops(member.hops)
-                                       .GetStructuralVar(member.var)
-                                       .type;
-    const mir::TypeId self_ptr_type =
-        process.Module().Unit().builtins.self_pointer;
-    const mir::ExprId receiver = frame.current_procedural_scope->AddExpr(
-        BuildSelfRefExpr(frame, self_ptr_type));
-    return mir::MakeMemberAccessExpr(receiver, member, field_type);
+    return BuildStructuralMemberAccessExpr(
+        frame, process.Module().Unit(), member);
   }
   const auto& ab = std::get<AutomaticVarBinding>(binding);
   if (auto* sink = frame.active_closure) {

--- a/src/lyra/lowering/hir_to_mir/self_ref.cpp
+++ b/src/lyra/lowering/hir_to_mir/self_ref.cpp
@@ -5,6 +5,7 @@
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/stmt.hpp"
+#include "lyra/mir/structural_scope.hpp"
 #include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -14,6 +15,17 @@ auto BuildSelfRefExpr(const WalkFrame& frame, mir::TypeId self_ptr_type)
   return mir::MakeProceduralVarRefExpr(
       frame.procedural_depth - frame.self_decl_depth, *frame.self_binding,
       self_ptr_type);
+}
+
+auto BuildStructuralMemberAccessExpr(
+    const WalkFrame& frame, const mir::CompilationUnit& unit,
+    const mir::StructuralVarRef& member) -> mir::Expr {
+  const mir::TypeId field_type = frame.StructuralScopeAtHops(member.hops)
+                                     .GetStructuralVar(member.var)
+                                     .type;
+  const mir::ExprId receiver = frame.current_procedural_scope->AddExpr(
+      BuildSelfRefExpr(frame, unit.builtins.self_pointer));
+  return mir::MakeMemberAccessExpr(receiver, member, field_type);
 }
 
 auto BuildReferenceArg(


### PR DESCRIPTION
## Summary

The MIR-to-C++ backend was already free functions with an immutable threaded `RenderContext` and no remaining render-time decisions, yet `lowering_organization.md` claimed every rendering pass takes the same class shape as lowering while its Forbidden Shapes banned exactly the `RenderContext` + `With*()` shape the backend used. This resolves that contradiction by establishing what the backend actually is: a rendering fold, not a construction pass.

The dividing line between the two pass kinds is whether a pass accumulates task-lifetime shared state. A construction pass (HIR-to-MIR lowering, a future MIR-to-LLVM backend) accumulates registries and builds a cross-referenced output, so it takes the class plus `WalkFrame` shape. A rendering fold composes an unstructured medium by concatenation and accumulates nothing, so it is free functions threading a thin read-only lookup. `RenderContext` is renamed to `ScopeView` and reframed as that lookup -- the rendering fold's read-only walk position, the read-only twin of the construction-side `WalkFrame`.

## Design

The contract gains a "The Walk Position" section establishing the concept shared across every pass: a value threaded by recursion whose universal core is the scope chain for resolving hops-relative references. A construction pass's walk position is fat (write-targets plus the decision state it uses to compute what to build); a fold's is thin (the read-only scope chain alone), because every decision is already baked into the MIR it reads. The walk position thins as the pipeline descends. Invariant 9 is rewritten to divide on accumulation rather than on the lowering-versus-rendering label, the `*Context` Forbidden Shapes are narrowed to mutable/growing carriers, and the accepted decision doc records the reclassification with its original rationale preserved.

The section also pins why the two passes resolve the chain differently per axis and that this is correct: a construction pass computes a procedural hop count from a depth counter plus its binding registry and never reads the ancestor procedural scope, while the fold has no registry so it climbs the procedural chain to read the name -- the fold's procedural chain is the read-side substitute for the binding registry. While confirming this, a real duplication surfaced: the structural-var reference and the static-lifetime-local reference hand-built the same self-receiver member access, now factored into one `BuildStructuralMemberAccessExpr`.

## Testing

`bazel build //...` and `bazel test //... --test_output=errors` both green; the emit-and-run golden suite passes unchanged, confirming the rename is behavior-neutral.