### PR TITLE
Lay groundwork for generic builtin-method calls

### DIFF
--- a/docs/decisions/array-method-dispatch.md
+++ b/docs/decisions/array-method-dispatch.md
@@ -38,6 +38,15 @@ semantics uniformly across container kinds; only the AST -> HIR receiver-detecti
 container. Fixed-unpacked, queue, and associative array workstreams extend the routing block, not
 the kind enum.
 
+**Subsequent revision.** This decision pinned `ArrayMethodKind` and its sibling per-family enums
+under `hir::BuiltinMethodRef` / `mir::BuiltinMethodCallee` at a time when container method APIs were
+unaligned and `runtime-effects-as-generic-calls.md` did not yet exist. Once R26
+(`progress/refactor.md`) formalized the cross-container concept system and the generic-call pattern
+became the MIR-wide rule, the per-family enum carries family information the receiver expression's
+type already states -- the same fact in two places, which the generic-call pattern forbids (`mir.md`
+invariant 10). The receiver-type dispatch in `LowerCallExprProc` still routes, but the resolved
+callee is a flat closed-namespace `BuiltinFn` ID; see `progress/refactor.md` R29.
+
 **Empty-array reduction returns element-shape zero.**
 
 LRM 7.12.3 is silent on the empty-input case. Slang's `ArrayReductionMethod::eval` returns an

--- a/docs/decisions/value-assignment-and-moved-from.md
+++ b/docs/decisions/value-assignment-and-moved-from.md
@@ -73,8 +73,8 @@ value type whose shape is declared rather than value-derived) follow these invar
 3. **A moved-from object is a valid value of the same shape**, never an empty husk: the move
    constructor keeps the source's `dims` and rebuilds its storage to the canonical zero of its
    width. This is the property that makes the type safe inside STL containers; it is the
-   C++-mechanics half of the `LyraValue` concept (`std::copyable`) asserted on every value type. The
-   concept is a relocation-safety guarantee, not a claim that assignment is value-adopt.
+   C++-mechanics base (`Storable`, the `std::copyable` half of `LyraValue`) asserted on every value
+   type. The concept is a relocation-safety guarantee, not a claim that assignment is value-adopt.
 4. **Cross-shape coercion is an explicit `ConvertFrom`, not assignment.** When a value must change
    width / state to reach the destination's shape, the lowering emits `PackedArray::ConvertFrom`
    ahead of the store; `AssignFrom` then runs same-shape and asserts (`ExpectSameShape`) that the

--- a/docs/decisions/value-type-concepts.md
+++ b/docs/decisions/value-type-concepts.md
@@ -49,30 +49,31 @@ concept; LRM-specific lowering paths gate on the relevant per-family concept.
 ### Concept lattice
 
 ```
-LyraValueType            -- the storage + universal-equality contract
-  std::copyable          -- container-safe relocation (existing `LyraValue`)
+LyraValue                -- the SV value contract every runtime value type realises
+  Storable               -- `std::copyable`, container-safe relocation
   operator==(T) const -> PackedArray   // LRM 11.4.5 == (Any data type)
   operator!=(T) const -> PackedArray   // LRM 11.4.5 != (Any data type)
   IsBitIdentical(T) const -> bool      // engine change-detection hook
                                        // (LRM 9.4.2 update event predicate)
+  HasUnknown() const -> bool           // LRM 20.9 $isunknown predicate
 
-CaseEqualComparable : LyraValueType
+CaseEqualComparable : LyraValue
   CaseEqual(T) const -> PackedArray    // LRM 11.4.5 === (Any except real/shortreal)
                                        // by convention shares internal impl with IsBitIdentical
 
-WildcardComparable : LyraValueType
+WildcardComparable : LyraValue
   WildcardEquals(T) const -> PackedArray  // LRM 11.4.5 ==? (Integral only)
 
-Ordered : LyraValueType
+Ordered : LyraValue
   operator< / <= / > / >= -> PackedArray  // LRM 11.4.4 relational (Integral / Real / String)
 ```
 
-The four concepts are independent refinements of `LyraValueType`. Each value type opts in to the
-subset LRM defines for it.
+The four concepts are independent refinements of `LyraValue`. Each value type opts in to the subset
+LRM defines for it.
 
 ### Per-type concept membership
 
-| Type                    | `LyraValueType`       | `CaseEqualComparable`               | `WildcardComparable` | `Ordered`                |
+| Type                    | `LyraValue`           | `CaseEqualComparable`               | `WildcardComparable` | `Ordered`                |
 | ----------------------- | --------------------- | ----------------------------------- | -------------------- | ------------------------ |
 | `PackedArray`           | yes                   | yes                                 | yes                  | yes                      |
 | `Enum<Derived>`         | yes (via inheritance) | yes                                 | yes                  | yes                      |
@@ -108,16 +109,16 @@ runtime; the entire compiler-and-emit pipeline above it stays uniform.
 
 These are separate methods on a value type even when they share an internal algorithm:
 
-- `IsBitIdentical(T) const -> bool` is a member of `LyraValueType`. It is the engine's
-  change-detection question ("did the cell's bit-pattern change between two writes"). Its name
-  reflects its role, not an LRM operator. It returns the truthful host-bool result.
+- `IsBitIdentical(T) const -> bool` is a member of `LyraValue`. It is the engine's change-detection
+  question ("did the cell's bit-pattern change between two writes"). Its name reflects its role, not
+  an LRM operator. It returns the truthful host-bool result.
 - `CaseEqual(T) const -> PackedArray` is a member of `CaseEqualComparable`. It is the LRM `===`
   operator's value-type realisation. The result type carries the SV-typed 1-bit packed value that
   participates in further SV expression evaluation.
 
 For types that satisfy both concepts the two methods share an internal helper (bit-by-bit identity
 check), because for integral values case equality _is_ bit identity. `Real` satisfies only
-`LyraValueType`, so only `IsBitIdentical` exists -- it implements bit-pattern equality via
+`LyraValue`, so only `IsBitIdentical` exists -- it implements bit-pattern equality via
 `std::bit_cast<std::uint64_t>(double)` so that `+0.0` and `-0.0` are distinct and NaN bit-patterns
 classify by identity, both required for "did the storage cell's bits change". There is no
 `Real::CaseEqual`: `===` / `!==` are not defined on real (Table 11-1), and lowering rejects the
@@ -125,18 +126,18 @@ source-level form before it could reach a value-type method.
 
 ### `Var<T>` and `ObservableType{T}` gating
 
-`Var<T>` requires only `LyraValueType`. Every type that can be wrapped as observable storage
-satisfies this concept, no more.
+`Var<T>` requires only `LyraValue`. Every type that can be wrapped as observable storage satisfies
+this concept, no more.
 
 MIR's `ObservableType{T_mir}` (R12) wraps an MIR value type to declare module-scope observable
 storage. HIR-to-MIR's wrap rule is structural -- a structural-var declaration whose value type is a
 "data storage" kind is wrapped; pointer / vector / object-handle / external-ref / event / chandle /
 void / scope / self types are not. The C++ emit then sees `ObservableType{T_mir}` and renders
-`Var<T_cpp>`. The C++ template instantiation `Var<T_cpp>` requires `LyraValueType<T_cpp>`; a value
-type that forgot to implement the contract triggers a compile-time concept failure at the
-instantiation site. The MIR type system gates "this storage is observable"; the C++ concept system
-gates "this value type can fulfill the observable contract". Both gates compose without duplicating
-the predicate.
+`Var<T_cpp>`. The C++ template instantiation `Var<T_cpp>` requires `LyraValue<T_cpp>`; a value type
+that forgot to implement the contract triggers a compile-time concept failure at the instantiation
+site. The MIR type system gates "this storage is observable"; the C++ concept system gates "this
+value type can fulfill the observable contract". Both gates compose without duplicating the
+predicate.
 
 The old backend predicate `IsObservableScalarType(mir::Type)` is removed.
 
@@ -179,7 +180,7 @@ just another runtime library API.
 
 ### `lyra::value::Real` / `ShortReal` / `RealTime`
 
-`Real` / `ShortReal` wrap `double` / `float` and satisfy `LyraValueType` + `Ordered`, not
+`Real` / `ShortReal` wrap `double` / `float` and satisfy `LyraValue` + `Ordered`, not
 `CaseEqualComparable` (LRM Table 11-1 excludes `real` / `shortreal` from `===`). `RealTime` is the
 same C++ type as `Real` per LRM 6.12.1. The runtime exposes the full LRM operator surface --
 arithmetic (`+` / `-` / `*` / `/` / `**`), unary negation, relational (`<` / `<=` / `>` / `>=`
@@ -192,13 +193,12 @@ mechanism as a module-level `int` signal.
 
 ## Implementation status
 
-- `LyraValueType`, `CaseEqualComparable`, `WildcardComparable`, `Ordered` defined in
-  `include/lyra/value/value_concept.hpp`.
+- `Storable`, `LyraValue`, `CaseEqualComparable`, `WildcardComparable`, `Ordered` defined in
+  `include/lyra/value/concepts.hpp`.
 - `PackedArray`, `String`, `UnpackedArray`, `DynamicArray`, `Queue`, `AssociativeArray` updated to
   satisfy the concepts LRM requires. Naming aligned: the host-bool predicate is `IsBitIdentical`
   across every type.
-- `lyra::runtime::Var<T>` requires `LyraValueType` and reads change-detection through
-  `IsBitIdentical`.
+- `lyra::runtime::Var<T>` requires `LyraValue` and reads change-detection through `IsBitIdentical`.
 - `IsObservableScalarType` removed from `backend::cpp`.
 - `mir::ObservableType` added; HIR-to-MIR's structural-var lowering wraps eligible value types; the
   C++ render emits `Var<T_cpp>` for an `ObservableType{T_mir}` field declaration.
@@ -223,8 +223,8 @@ mechanism as a module-level `int` signal.
   realisation is `CaseEqual`. They are separate even when their internal algorithm coincides.
 - A backend predicate that decides "is this storage observable" by inspecting the value type's
   variant kind (the removed `IsObservableScalarType` shape). Observability is an MIR-type-system
-  fact (`ObservableType` wrapping); eligibility to be wrapped is a C++ concept fact
-  (`LyraValueType`). The backend reads one or the other; it does not synthesise either.
+  fact (`ObservableType` wrapping); eligibility to be wrapped is a C++ concept fact (`LyraValue`).
+  The backend reads one or the other; it does not synthesise either.
 - A value type that satisfies `CaseEqualComparable` but whose `CaseEqual` and `IsBitIdentical` give
   different answers. The two methods may share an internal helper; they may not diverge. (`Real`
   sidesteps this by not satisfying `CaseEqualComparable` at all -- it has no `CaseEqual`, only the

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -526,6 +526,11 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
         five `Render*MethodCall` wrappers, five `*MemberName` tables,
         `RenderAssociativeTraversalCall`, `RenderServicesCall`, and `RenderIsUnknownCall`
         all collapse into these realization tables.
+      - HIR's `BuiltinMethodRef` carries the same per-family enum redundancy and collapses
+        to a flat closed-namespace identifier in lockstep with the MIR-side change. The
+        per-family `Lower*MethodName` lookup tables in `slang_atoms` remain (the SV
+        spelling is the source-language identifier), but the resolved HIR callee is a
+        single id rather than a variant arm.
 
       R25's render-handler collapse falls out mechanically once this lands. Subsumes the
       earlier "shared kinds only" framing of R29 (rejected as a half-measure: a per-family

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -472,30 +472,65 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       Subsumes R17b. After R26 + R28 lands, every signature drift becomes a compile-time
       failure rather than a silent regression. **Trigger**: standalone; before R28 / R29.
 
-- [ ] R28 -- Align the `Writable` protocol's naming across the three array containers.
-      `Queue::WriteRef(idx)` and `AssociativeArray::ElementRef(K)` carry the "write-side has extra
-      semantics" intent (queue auto-pushes on out-of-bound write, AA creates the key);
-      `PackedArray`, `DynamicArray`, and `UnpackedArray` overload the non-const `ElementAt(idx)`
-      form for the same role. Target shape: rename the non-const `ElementAt` overload on the three
-      array containers to `WriteRef`, aligning the protocol on `ElementAt(pos) -> ConstView` for
-      read and `WriteRef(pos) -> MutView` for write. The `kElementAt` / `kWriteRef` enum asymmetry
-      in MIR's `BuiltinMethodCallee` dissolves -- HIR-to-MIR's LHS-side dispatch produces
-      `kWriteRef` for every array container, not just Queue. `static_assert(Writable<...>)` lands on
-      all four array containers. **Trigger**: after R26 lands.
+- [x] R28 -- The read-vs-write access surface is aligned across every container at the noun-level
+      naming axis: `Element(pos) -> value` for read, `ElementRef(pos) -> ref` for write. The earlier
+      `ElementAt` (read) / `WriteRef` (write) split is gone; the runtime, MIR's `ArrayMethodKind` /
+      `QueueMethodKind` / `AssociativeMethodKind`, and HIR's `QueueMethodKind` all use `kElement` /
+      `kElementRef`. The slice axis follows the same pattern -- `Slice` for read, `SliceRef` for
+      write -- so `MakeRangeSliceCallExpr` / `MakeFieldSliceCallExpr` route through one `AccessSide`
+      enum at the lowering boundary. `concepts.hpp` pins `Indexable` (bare + `Ref` pair),
+      `Sliceable` (bare), and `SliceableRef` (Ref form); Queue opts out of `SliceableRef` because
+      LRM 7.10 defines no write-side queue slice. The `Writable` concept is intentionally not minted
+      -- the bare-vs-`Ref` pair is now part of `Indexable` itself.
 
-- [ ] R29 -- Collapse per-family MIR `BuiltinMethodCallee` enum redundancy. After R26 / R28 the
-      containers share fully-aligned signatures, and the per-family enums (`ArrayMethodKind`,
-      `QueueMethodKind`, `AssociativeMethodKind`) then double-encode "what is the receiver's
-      container type" -- a fact MIR already carries on the receiver expression's type. For shared
-      kinds (`kSlice`, `kElementAt`, `kSize`, `kReverse`, `kSort`, the with-clause reduction and
-      search families) the per-family split is pure redundancy; for non-shared kinds (associative
-      traversal, queue-only push / pop / insert, AA-only `Read` / `ElementRef` / `Exists`,
-      string-only `Substr` / `Toupper` / `Itoa` etc.) the family identity is real. Target shape:
-      audit each per-family kind, collapse the shared ones onto a single `BuiltinMemberKind` (or
-      carry the C++ member name directly as a `string_view` -- the audit picks between these), and
-      keep the non-shared kinds where family identity is real. The backend's five
-      `Render*MethodCall` wrappers then collapse onto one generic `(receiver).name(args)` handler.
-      Structural prerequisite for R25's clean landing. **Trigger**: after R26 / R28.
+- [ ] R29 -- Collapse `BuiltinMethodCallee` into closed-ID generic-call callees, and lift pointer
+      dereference into MIR structure. MIR is a generic programming-language IR (`mir.md`); it has no
+      node concept for "method call" versus "free function call" versus "static method" -- in LLVM
+      lowering all three are the same `call <symbol>(<args>)`, with any receiver passed as the first
+      argument. The current `BuiltinMethodCallee` arm with ten per-family `*MethodInfo` variants
+      encodes facts MIR does not need to carry: the family (already on the receiver expression's MIR
+      type) and a syntactic spelling preference (a per-backend localization, not a MIR axis --
+      invariant 10). Target shape:
+
+      - One flat `BuiltinFn` enum covering every compiler-internal runtime entry. Closed
+        namespace, same shape as `support::SystemSubroutineId`. Sections within the enum
+        mirror the `concepts.hpp` (R26) protocol grouping via comments; protocol membership
+        itself is a derived `ConceptOf(BuiltinFn)` helper, not a structural arm -- the source
+        of truth for the concept structure already lives in `concepts.hpp`, and encoding it
+        again as a MIR variant would put the same fact in two places.
+      - `BuiltinMethodCallee` retires. Two sibling callee arms replace it:
+        `BuiltinFnCallee { BuiltinFn id }` (receiver via `args[0]`, used for instance methods
+        and free functions alike) and `BuiltinStaticCallee { BuiltinFn id; TypeId type_qual }`
+        (no value receiver; `type_qual` is the type-namespace identity that LLVM also reads
+        for symbol mangling, not a render hint). Both sit beside `SystemSubroutineCallee` as
+        closed-ID runtime-entry callees.
+      - Pointer dereference becomes structural in MIR. A call whose receiver reaches the
+        pointee through a pointer wraps the receiver in `DerefExpr` at HIR-to-MIR; today
+        `MakeServicesCallExpr` and any sibling site that hands the C++ backend a pointer
+        receiver directly forces the backend to derive `->` vs `.` from receiver-type
+        inspection, which LIR / LLVM would have to repeat (invariant 10).
+      - No upstream constant folding of LRM type-static queries. Enum statics
+        (LRM 6.19.5 `first` / `last` / `num`) lower as ordinary `BuiltinStaticCallee` calls
+        whose symbols are `constexpr` / inlinable in the runtime; the C++ compiler and LLVM
+        fold them downstream. `$isunknown` (LRM 20.9) lowers as a uniform `BuiltinFnCallee`
+        call; the runtime exposes `HasUnknown()` on every packed value type (always-false
+        impl on 2-state), and downstream optimization folds the 2-state case. Follows the
+        `decisions/conversion-folding.md` precedent ("MIR is the program in primitives;
+        constant folding is the downstream optimizer's job, not HIR-to-MIR's") and removes
+        the `RenderIsUnknownCall` peephole, which was the same invariant-10 violation as the
+        retired literal-conversion peephole.
+      - Each backend owns a single `(BuiltinFn, receiver_type)` -> realization table for
+        `BuiltinFnCallee` and a `(BuiltinFn, type_qual)` -> realization table for
+        `BuiltinStaticCallee`. The C++ realization is `{ syntax: member / free / static,
+        name }`; the LLVM realization is a mangled symbol. MIR carries no syntactic hint. The
+        five `Render*MethodCall` wrappers, five `*MemberName` tables,
+        `RenderAssociativeTraversalCall`, `RenderServicesCall`, and `RenderIsUnknownCall`
+        all collapse into these realization tables.
+
+      R25's render-handler collapse falls out mechanically once this lands. Subsumes the
+      earlier "shared kinds only" framing of R29 (rejected as a half-measure: a per-family
+      split kept around "non-shared" kinds restates receiver-type information the same way
+      the shared kinds do). **Trigger**: standalone after R26 / R28.
 
 - [ ] R30 -- **Runtime effects as generic calls: the closure-bearing subset** (carve-out of R20,
       same decision). Each of these lowers to a generic `CallExpr` over a compiler-synthesized

--- a/include/lyra/lowering/hir_to_mir/closure_builder.hpp
+++ b/include/lyra/lowering/hir_to_mir/closure_builder.hpp
@@ -51,7 +51,6 @@ class ClosureBuilder {
   [[nodiscard]] auto Build(mir::ExprId result) -> mir::Expr;
 
  private:
-  mir::CompilationUnit* unit_;
   mir::ProceduralScope* outer_;
   mir::TypeId result_type_;
   mir::ProceduralScope body_;

--- a/include/lyra/lowering/hir_to_mir/self_ref.hpp
+++ b/include/lyra/lowering/hir_to_mir/self_ref.hpp
@@ -31,8 +31,7 @@ auto BuildSelfRefExpr(const WalkFrame& frame, mir::TypeId self_ptr_type)
 // promoted to a per-instance structural var (LRM 13.3.1), which reach their
 // storage identically.
 auto BuildStructuralMemberAccessExpr(
-    const WalkFrame& frame, const mir::CompilationUnit& unit,
-    const mir::StructuralVarRef& member) -> mir::Expr;
+    const WalkFrame& frame, const mir::StructuralVarRef& member) -> mir::Expr;
 
 // Constructs a reference to the cell `cell` denotes (LRM 13.5.2): adds a
 // reference-construction `CallExpr` to `scope` whose result type is a

--- a/include/lyra/mir/builtin_method.hpp
+++ b/include/lyra/mir/builtin_method.hpp
@@ -135,16 +135,14 @@ enum class IteratorMethodKind : std::uint8_t {
 
 // Methods on the runtime scope handle (the `self` receiver). `kServices`
 // reaches the engine facade `RuntimeServices` -- the engine handle every
-// runtime-effect call threads as a plain argument
-// (docs/decisions/runtime-effects-as-generic-calls.md).
+// runtime-effect call threads as a plain argument.
 enum class ScopeMethodKind : std::uint8_t {
   kServices,
 };
 
 // Operations on an observable storage cell (`ObservableType` /
 // `ExternalRefType`). The cell is the first argument; `kSet` / `kMutate`
-// thread the engine handle as the second. See
-// docs/decisions/value-type-concepts.md.
+// thread the engine handle as the second.
 enum class ObservableMethodKind : std::uint8_t {
   kGet,
   kSet,
@@ -210,41 +208,33 @@ struct BuiltinMethodCallee {
 [[nodiscard]] auto IsContainerAccessCall(const BuiltinMethodCallee& callee)
     -> bool;
 
-// Closed namespace of compiler-internal runtime entries. Same identity
-// shape as `support::SystemSubroutineId`; sections below mirror the
-// protocol grouping in `value/concepts.hpp`. Resolution to a concrete
-// C++ method or LLVM symbol is per-backend, keyed by `(BuiltinFn,
-// receiver_type)` for `BuiltinFnCallee` and `(BuiltinFn, type_qual)` for
-// `BuiltinStaticCallee`.
 enum class BuiltinFn : std::uint16_t {
-  // Indexable / SliceableRef (LRM 7.4 / 7.8 / 7.10 / 11.5). Universal
-  // positional access -- bare returns value form, `Ref` returns
-  // write-through reference. `Slice` is read; `SliceRef` is write.
+  // LRM 7.4 / 7.8 / 7.10 / 11.5 positional access. Bare returns value
+  // form; `Ref` returns write-through reference. `Slice` is read,
+  // `SliceRef` is write.
   kElement,
   kElementRef,
   kSlice,
   kSliceRef,
-  // Sized -- LRM 7.4.3 / 7.5 / 7.10.2 element-count query. Universal
-  // across Dynamic / Unpacked / Queue / AA (AA's LRM 7.9 `num` is the
-  // same symbol). `String::Len` (LRM 6.16.1) is a sibling under its own
-  // mandated spelling.
+  // LRM 7.4.3 / 7.5 / 7.9 / 7.10.2. AA's `num` is an alias of `size`;
+  // String's LRM 6.16.1 `len` is its own mandated spelling.
   kSize,
   kLen,
-  // Ownable / mutating container ops (LRM 7.12 + 7.5 / 7.10).
+  // LRM 7.12 / 7.5 / 7.10 container ops.
   kToOwned,
   kDelete,
-  // Sortable (LRM 7.12). The closure-bearing siblings (`Sort` /
-  // `Rsort`) take a `with`-clause closure as the second argument.
+  // LRM 7.12 ordering. `Sort` / `Rsort` take a `with`-clause closure as
+  // the second argument.
   kReverse,
   kSort,
   kRsort,
-  // Reducible (LRM 7.12.3). All take a `with`-clause closure.
+  // LRM 7.12.3 reductions. All take a `with`-clause closure.
   kSum,
   kProduct,
   kAnd,
   kOr,
   kXor,
-  // Searchable (LRM 7.12.1).
+  // LRM 7.12.1 search.
   kFind,
   kFindIndex,
   kFindFirst,
@@ -255,23 +245,22 @@ enum class BuiltinFn : std::uint16_t {
   kMax,
   kUnique,
   kUniqueIndex,
-  // LRM 7.12.5 array projection.
+  // LRM 7.12.5.
   kMap,
-  // Queue insertion / removal (LRM 7.10).
+  // LRM 7.10 queue insertion / removal.
   kInsert,
   kPopFront,
   kPopBack,
   kPushFront,
   kPushBack,
-  // Associative-array keyed queries (LRM 7.9). `Exists` is keyed
-  // membership; the traversal family (LRM 7.9.4 -- 7.9.7) assigns the
+  // LRM 7.9. The traversal family (LRM 7.9.4 -- 7.9.7) writes the
   // visited key through a `ref` index argument and returns 0 / 1 / -1.
   kExists,
   kAssocFirst,
   kAssocLast,
   kAssocNext,
   kAssocPrev,
-  // String character / case / compare / substring (LRM 6.16).
+  // LRM 6.16 string methods.
   kGetc,
   kPutc,
   kToupper,
@@ -279,78 +268,56 @@ enum class BuiltinFn : std::uint16_t {
   kCompare,
   kIcompare,
   kSubstr,
-  // String numeric parse (LRM 6.16.9 -- 6.16.13).
+  // LRM 6.16.9 -- 6.16.13 string parse.
   kAtoi,
   kAtohex,
   kAtooct,
   kAtobin,
   kAtoreal,
-  // String numeric format (LRM 6.16.14 -- 6.16.18). Mutate the receiver.
+  // LRM 6.16.14 -- 6.16.18 string format. Mutates the receiver.
   kItoa,
   kHextoa,
   kOcttoa,
   kBintoa,
   kRealtoa,
-  // Named-event operations (LRM 15.5). `Trigger` and `Await` arise from
-  // `-> e;` / `@e;` collapsing at HIR -> MIR; `Triggered` surfaces from
-  // the slang `e.triggered` method call.
+  // LRM 15.5 named-event operations. `Trigger` / `Await` arise from
+  // `-> e;` / `@e;` collapsing at HIR -> MIR.
   kTrigger,
   kAwait,
   kTriggered,
-  // Enum type-static queries (LRM 6.19.5). Lowered as
-  // `BuiltinStaticCallee` -- the enum type is the call's identity
-  // qualifier, not a value receiver. `constexpr` in the runtime so
-  // downstream optimizers fold.
+  // LRM 6.19.5 enum type-static queries. `constexpr` in the runtime so
+  // downstream optimizers fold the call.
   kEnumFirst,
   kEnumLast,
   kEnumNum,
-  // Enum instance methods (LRM 6.19.5). Lowered as `BuiltinFnCallee` --
-  // the enum value is the receiver at args[0].
+  // LRM 6.19.5 enum instance methods.
   kEnumName,
   kEnumNext,
   kEnumPrev,
-  // LRM 20.9 `$isunknown` plus the LRM 21.3.4.3 internal `$sscanf` /
-  // `$fscanf` EOF guard. Runtime exposes `HasUnknown()` uniformly on
-  // every packed value type (always-false impl on 2-state); the call
-  // shape is uniform and downstream constant-folds the 2-state case.
+  // LRM 20.9 / 21.3.4.3. 2-state packed types return false; downstream
+  // constant-folds those calls.
   kIsUnknown,
-  // Observable storage cell (`Var<T>` / `ExternalRef<T>`). The cell is
-  // the receiver; `Set` / `Mutate` take services as the second argument.
+  // Observable storage cell operations. `Set` / `Mutate` thread services
+  // as the second argument.
   kGet,
   kSet,
   kMutate,
-  // Scope handle -- reaches the engine facade `RuntimeServices` so every
-  // runtime-effect call can thread it as a plain argument
-  // (`decisions/runtime-effects-as-generic-calls.md`).
   kServices,
 };
 
-// Instance method or free-function call against a closed-namespace
-// runtime entry. The receiver, if any, is `args[0]`; remaining args are
-// the method parameters. The (`BuiltinFn`, `args[0].type`) pair fully
-// identifies the runtime symbol; the per-backend realization table maps
-// it to a method, free-function, or other C++ shape.
 struct BuiltinFnCallee {
   BuiltinFn id;
 };
 
-// Type-static runtime entry -- no value receiver. `type_qual` names the
-// type whose static is invoked (e.g. `MyEnum::First()`), and is part of
-// the symbol's identity that LLVM also reads for mangling.
+// Type-static entry: `type_qual` is part of the symbol identity (the
+// type-namespace qualifier for the method), read by every backend.
 struct BuiltinStaticCallee {
   BuiltinFn id;
   TypeId type_qual;
 };
 
-// Whether a `BuiltinFn` mutates its receiver in place. Drives the
-// LHS-chain walker that decides whether an observable receiver needs the
-// `Mutate` wrap. Same predicate role as `IsMutatingBuiltinMethod` for the
-// legacy callee shape.
 [[nodiscard]] auto IsMutatingBuiltinFn(BuiltinFn id) -> bool;
 
-// Whether a `BuiltinFn` is an indexed / sliced container access whose
-// receiver is `args[0]`. LHS-chain walkers use this to reach the root
-// primary.
 [[nodiscard]] auto IsContainerAccessFn(BuiltinFn id) -> bool;
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/builtin_method.hpp
+++ b/include/lyra/mir/builtin_method.hpp
@@ -210,4 +210,147 @@ struct BuiltinMethodCallee {
 [[nodiscard]] auto IsContainerAccessCall(const BuiltinMethodCallee& callee)
     -> bool;
 
+// Closed namespace of compiler-internal runtime entries. Same identity
+// shape as `support::SystemSubroutineId`; sections below mirror the
+// protocol grouping in `value/concepts.hpp`. Resolution to a concrete
+// C++ method or LLVM symbol is per-backend, keyed by `(BuiltinFn,
+// receiver_type)` for `BuiltinFnCallee` and `(BuiltinFn, type_qual)` for
+// `BuiltinStaticCallee`.
+enum class BuiltinFn : std::uint16_t {
+  // Indexable / SliceableRef (LRM 7.4 / 7.8 / 7.10 / 11.5). Universal
+  // positional access -- bare returns value form, `Ref` returns
+  // write-through reference. `Slice` is read; `SliceRef` is write.
+  kElement,
+  kElementRef,
+  kSlice,
+  kSliceRef,
+  // Sized -- LRM 7.4.3 / 7.5 / 7.10.2 element-count query. Universal
+  // across Dynamic / Unpacked / Queue / AA (AA's LRM 7.9 `num` is the
+  // same symbol). `String::Len` (LRM 6.16.1) is a sibling under its own
+  // mandated spelling.
+  kSize,
+  kLen,
+  // Ownable / mutating container ops (LRM 7.12 + 7.5 / 7.10).
+  kToOwned,
+  kDelete,
+  // Sortable (LRM 7.12). The closure-bearing siblings (`Sort` /
+  // `Rsort`) take a `with`-clause closure as the second argument.
+  kReverse,
+  kSort,
+  kRsort,
+  // Reducible (LRM 7.12.3). All take a `with`-clause closure.
+  kSum,
+  kProduct,
+  kAnd,
+  kOr,
+  kXor,
+  // Searchable (LRM 7.12.1).
+  kFind,
+  kFindIndex,
+  kFindFirst,
+  kFindFirstIndex,
+  kFindLast,
+  kFindLastIndex,
+  kMin,
+  kMax,
+  kUnique,
+  kUniqueIndex,
+  // LRM 7.12.5 array projection.
+  kMap,
+  // Queue insertion / removal (LRM 7.10).
+  kInsert,
+  kPopFront,
+  kPopBack,
+  kPushFront,
+  kPushBack,
+  // Associative-array keyed queries (LRM 7.9). `Exists` is keyed
+  // membership; the traversal family (LRM 7.9.4 -- 7.9.7) assigns the
+  // visited key through a `ref` index argument and returns 0 / 1 / -1.
+  kExists,
+  kAssocFirst,
+  kAssocLast,
+  kAssocNext,
+  kAssocPrev,
+  // String character / case / compare / substring (LRM 6.16).
+  kGetc,
+  kPutc,
+  kToupper,
+  kTolower,
+  kCompare,
+  kIcompare,
+  kSubstr,
+  // String numeric parse (LRM 6.16.9 -- 6.16.13).
+  kAtoi,
+  kAtohex,
+  kAtooct,
+  kAtobin,
+  kAtoreal,
+  // String numeric format (LRM 6.16.14 -- 6.16.18). Mutate the receiver.
+  kItoa,
+  kHextoa,
+  kOcttoa,
+  kBintoa,
+  kRealtoa,
+  // Named-event operations (LRM 15.5). `Trigger` and `Await` arise from
+  // `-> e;` / `@e;` collapsing at HIR -> MIR; `Triggered` surfaces from
+  // the slang `e.triggered` method call.
+  kTrigger,
+  kAwait,
+  kTriggered,
+  // Enum type-static queries (LRM 6.19.5). Lowered as
+  // `BuiltinStaticCallee` -- the enum type is the call's identity
+  // qualifier, not a value receiver. `constexpr` in the runtime so
+  // downstream optimizers fold.
+  kEnumFirst,
+  kEnumLast,
+  kEnumNum,
+  // Enum instance methods (LRM 6.19.5). Lowered as `BuiltinFnCallee` --
+  // the enum value is the receiver at args[0].
+  kEnumName,
+  kEnumNext,
+  kEnumPrev,
+  // LRM 20.9 `$isunknown` plus the LRM 21.3.4.3 internal `$sscanf` /
+  // `$fscanf` EOF guard. Runtime exposes `HasUnknown()` uniformly on
+  // every packed value type (always-false impl on 2-state); the call
+  // shape is uniform and downstream constant-folds the 2-state case.
+  kIsUnknown,
+  // Observable storage cell (`Var<T>` / `ExternalRef<T>`). The cell is
+  // the receiver; `Set` / `Mutate` take services as the second argument.
+  kGet,
+  kSet,
+  kMutate,
+  // Scope handle -- reaches the engine facade `RuntimeServices` so every
+  // runtime-effect call can thread it as a plain argument
+  // (`decisions/runtime-effects-as-generic-calls.md`).
+  kServices,
+};
+
+// Instance method or free-function call against a closed-namespace
+// runtime entry. The receiver, if any, is `args[0]`; remaining args are
+// the method parameters. The (`BuiltinFn`, `args[0].type`) pair fully
+// identifies the runtime symbol; the per-backend realization table maps
+// it to a method, free-function, or other C++ shape.
+struct BuiltinFnCallee {
+  BuiltinFn id;
+};
+
+// Type-static runtime entry -- no value receiver. `type_qual` names the
+// type whose static is invoked (e.g. `MyEnum::First()`), and is part of
+// the symbol's identity that LLVM also reads for mangling.
+struct BuiltinStaticCallee {
+  BuiltinFn id;
+  TypeId type_qual;
+};
+
+// Whether a `BuiltinFn` mutates its receiver in place. Drives the
+// LHS-chain walker that decides whether an observable receiver needs the
+// `Mutate` wrap. Same predicate role as `IsMutatingBuiltinMethod` for the
+// legacy callee shape.
+[[nodiscard]] auto IsMutatingBuiltinFn(BuiltinFn id) -> bool;
+
+// Whether a `BuiltinFn` is an indexed / sliced container access whose
+// receiver is `args[0]`. LHS-chain walkers use this to reach the root
+// primary.
+[[nodiscard]] auto IsContainerAccessFn(BuiltinFn id) -> bool;
+
 }  // namespace lyra::mir

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -26,7 +26,6 @@ struct BuiltinMirTypes {
   TypeId void_type;
   TypeId realtime;
   TypeId time;
-  TypeId self_pointer;
   TypeId services;
   TypeId print_item;
   TypeId print_literal_item;
@@ -70,10 +69,6 @@ struct CompilationUnit {
                     .signedness = Signedness::kUnsigned,
                     .dims = {PackedRange{.left = 63, .right = 0}},
                     .form = PackedArrayForm::kTime}}),
-            .self_pointer = AddType(
-                TypeData{PointerType{
-                    .pointee = AddType(TypeData{SelfType{}}),
-                    .ownership = PointerOwnership::kBorrowed}}),
             .services = AddType(TypeData{ServicesType{}}),
             .print_item = AddType(
                 TypeData{RuntimeLibraryType{

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -131,7 +131,8 @@ struct ConstructorCallee {};
 
 using Callee = std::variant<
     SystemSubroutineCallee, StructuralSubroutineRef, BuiltinMethodCallee,
-    ClosureRef, RuntimeNavCallee, ConstructorCallee>;
+    BuiltinFnCallee, BuiltinStaticCallee, ClosureRef, RuntimeNavCallee,
+    ConstructorCallee>;
 
 struct CallExpr {
   Callee callee;

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -157,8 +157,7 @@ struct DerefExpr {
 // Class-member access through an explicit receiver expression. `receiver`
 // evaluates to a class-instance value (typically `ProceduralVarRef(self)`);
 // `member` names which structural var of the receiver's class to reach. The
-// receiver is explicit -- a backend never asks "what is the current receiver?"
-// (mir.md invariant 11).
+// receiver is explicit -- a backend never asks "what is the current receiver?".
 struct MemberAccessExpr {
   ExprId receiver;
   StructuralVarRef member;
@@ -217,7 +216,7 @@ struct Expr {
 // `self.Services()` -- reaches the engine facade from the scope handle.
 // `self` is the receiver ExprId; `services` is ServicesType. The caller does
 // the AddExpr. Every runtime-effect call threads the result as its engine
-// handle (docs/decisions/runtime-effects-as-generic-calls.md).
+// handle.
 [[nodiscard]] inline auto MakeServicesCallExpr(ExprId self, TypeId services)
     -> Expr {
   return Expr{

--- a/include/lyra/mir/structural_scope.hpp
+++ b/include/lyra/mir/structural_scope.hpp
@@ -11,11 +11,13 @@
 #include "lyra/mir/structural_subroutine.hpp"
 #include "lyra/mir/structural_var.hpp"
 #include "lyra/mir/type_alias.hpp"
+#include "lyra/mir/type_id.hpp"
 
 namespace lyra::mir {
 
 struct StructuralScope {
   std::string name;
+  TypeId self_pointer_type;
   // The scope's resolved time unit and precision (LRM 3.14.2). The emitted
   // class exposes the precision so the engine can take the design-global
   // minimum (LRM 3.14.3) and so delays scale to it.

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -240,7 +240,7 @@ struct VectorType {
 // SystemVerilog data type (not a handle, child instance, or external ref) in
 // this wrapper. The C++ backend renders the wrapper as `lyra::runtime::Var<T>`
 // where T is the inner value type; the C++ template requires `T` to satisfy
-// `lyra::value::LyraValueType`, so a value type that forgot to implement the
+// `lyra::value::LyraValue`, so a value type that forgot to implement the
 // contract fails at template instantiation. See
 // `docs/decisions/value-type-concepts.md`.
 struct ObservableType {

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -6,7 +6,6 @@
 #include <variant>
 #include <vector>
 
-#include "lyra/mir/structural_scope_id.hpp"
 #include "lyra/mir/type_id.hpp"
 
 namespace lyra::mir {
@@ -28,7 +27,6 @@ enum class TypeKind {
   kObject,
   kExternalUnitObject,
   kScope,
-  kSelf,
   kServices,
   kRuntimeLibrary,
   kCoroutine,
@@ -130,7 +128,7 @@ struct ChandleType {};
 struct VoidType {};
 
 struct ObjectType {
-  StructuralScopeId target;
+  std::string name;
 
   auto operator==(const ObjectType&) const -> bool = default;
 };
@@ -152,17 +150,9 @@ struct ScopeType {
   auto operator==(const ScopeType&) const -> bool = default;
 };
 
-// Pointee of `self` (mir.md invariant 11). Distinct from `ScopeType` (the
-// type-erased runtime base) and `ObjectType` (a child of the owner): names
-// the concrete scope this declaration sits in, resolved lexically.
-struct SelfType {
-  auto operator==(const SelfType&) const -> bool = default;
-};
-
 // The engine facade `lyra::runtime::RuntimeServices`. A callable body reaches
 // it from `self` through the `Services` scope method; it is the engine handle
-// every runtime-effect call threads as a plain argument
-// (docs/decisions/runtime-effects-as-generic-calls.md).
+// every runtime-effect call threads as a plain argument.
 struct ServicesType {
   auto operator==(const ServicesType&) const -> bool = default;
 };
@@ -172,8 +162,7 @@ struct ServicesType {
 // and MIR makes no decision on its contents. The branch selects which library
 // type, and the backend maps the branch to the concrete library name. Distinct
 // from ServicesType / ScopeType, which are runtime object-model handles the
-// receiver semantics reason about; these are inert payloads
-// (docs/decisions/runtime-effects-as-generic-calls.md).
+// receiver semantics reason about; these are inert payloads.
 enum class RuntimeLibraryKind : std::uint8_t {
   kPrintItem,
   kPrintLiteralItem,
@@ -241,8 +230,7 @@ struct VectorType {
 // this wrapper. The C++ backend renders the wrapper as `lyra::runtime::Var<T>`
 // where T is the inner value type; the C++ template requires `T` to satisfy
 // `lyra::value::LyraValue`, so a value type that forgot to implement the
-// contract fails at template instantiation. See
-// `docs/decisions/value-type-concepts.md`.
+// contract fails at template instantiation.
 struct ObservableType {
   TypeId value;
 
@@ -282,8 +270,8 @@ using TypeData = std::variant<
     PackedArrayType, EnumType, UnpackedArrayType, DynamicArrayType, QueueType,
     AssociativeArrayType, StringType, EventType, RealType, ShortRealType,
     RealTimeType, ChandleType, VoidType, ObjectType, ExternalUnitObjectType,
-    ScopeType, SelfType, ServicesType, RuntimeLibraryType, CoroutineType,
-    RefType, PointerType, VectorType, ExternalRefType, ObservableType>;
+    ScopeType, ServicesType, RuntimeLibraryType, CoroutineType, RefType,
+    PointerType, VectorType, ExternalRefType, ObservableType>;
 
 struct Type {
   TypeData data;
@@ -305,9 +293,9 @@ class CompilationUnit;
 
 // A child-scope member, classified by the leaf object type after stripping any
 // vector layers: an intra-unit object is a generate scope (carrying its target
-// scope), an external-unit object is a module instance.
+// scope's class name), an external-unit object is a module instance.
 struct GenerateScopeChild {
-  StructuralScopeId target;
+  std::string name;
 };
 struct ModuleInstanceChild {};
 using ChildScope = std::variant<GenerateScopeChild, ModuleInstanceChild>;

--- a/include/lyra/runtime/extern_up.hpp
+++ b/include/lyra/runtime/extern_up.hpp
@@ -40,7 +40,7 @@ struct ChildStep {
 // the member behaves like the referenced `Var<T>` while naming no ancestor
 // type (docs/architecture/emission_model.md). Non-movable: it registers `this`,
 // and is owned by the stable scope node that declares it.
-template <value::LyraValueType T>
+template <value::LyraValue T>
 class ExternUp : public ExternBase {
  public:
   ExternUp(

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -124,10 +124,10 @@ class Observable {
   std::vector<Waiter> waiters_;
 };
 
-template <value::LyraValueType T>
+template <value::LyraValue T>
 class ScopedMutation;
 
-template <value::LyraValueType T>
+template <value::LyraValue T>
 class Var : public Observable {
  public:
   Var() = default;
@@ -188,7 +188,7 @@ class Var : public Observable {
 // event fires and subscribers wake), or a plain `T` cell (raw read / write,
 // no observers). Copyable, so a ref formal can be forwarded as a ref
 // argument to a nested call.
-template <value::LyraValueType T>
+template <value::LyraValue T>
 class Ref {
  public:
   explicit Ref(Var<T>& cell) : signal_(&cell) {
@@ -295,7 +295,7 @@ inline auto MakePackedArrayEdgeClassifier(
   };
 }
 
-template <value::LyraValueType T>
+template <value::LyraValue T>
 void Var<T>::Set(RuntimeServices& services, const T& new_val) {
   // A PackedArray write classifies the LSB transition per waiter (LRM 9.4.2
   // Table 9-2); every other cell type only has any-change waiters.
@@ -325,7 +325,7 @@ void Var<T>::Set(RuntimeServices& services, const T& new_val) {
 //
 // `operator*` is the single access point -- all chain methods, operators,
 // and selectors are reached through the deref'd T directly.
-template <value::LyraValueType T>
+template <value::LyraValue T>
 class ScopedMutation {
  public:
   ScopedMutation(RuntimeServices& services, Var<T>& var)
@@ -351,7 +351,7 @@ class ScopedMutation {
   T snapshot_;
 };
 
-template <value::LyraValueType T>
+template <value::LyraValue T>
 auto Var<T>::Mutate(RuntimeServices& services) -> ScopedMutation<T> {
   return ScopedMutation<T>{services, *this};
 }

--- a/include/lyra/value/associative_array.hpp
+++ b/include/lyra/value/associative_array.hpp
@@ -273,6 +273,16 @@ class AssociativeArray {
     return true;
   }
 
+  // LRM 20.9: any value carrying an unknown bit propagates up. Keys with
+  // unknown bits are rejected at write time (LRM 7.8.1), so they cannot
+  // appear here.
+  [[nodiscard]] auto HasUnknown() const -> bool {
+    for (const auto& [k, v] : data_) {
+      if (v.HasUnknown()) return true;
+    }
+    return false;
+  }
+
  private:
   [[nodiscard]] auto IsInvalidKey(const K& key) const -> bool {
     if constexpr (std::same_as<K, PackedArray>) {

--- a/include/lyra/value/concepts.hpp
+++ b/include/lyra/value/concepts.hpp
@@ -28,10 +28,10 @@ namespace lyra::value {
 
 class PackedArray;
 
-// The contract every Lyra runtime value type satisfies so it can live in the
-// STL containers the runtime stores it in (`std::vector` / `std::deque` /
-// `std::map`) and survive their relocation (insert / erase / grow).
-// `std::copyable` requires move- and copy-construction, move- and
+// C++ storage mechanics every runtime value type must satisfy so it can
+// live in the STL containers the runtime stores it in (`std::vector` /
+// `std::deque` / `std::map`) and survive their relocation (insert / erase /
+// grow). `std::copyable` requires move- and copy-construction, move- and
 // copy-assignment, and swappability -- and, per the standard library
 // contract it builds on, a moved-from object that remains valid for
 // assignment and destruction. That moved-from validity is the property that
@@ -44,7 +44,7 @@ class PackedArray;
 // not a pure value adopt); see docs/decisions/integral-representation.md.
 // The concept only guarantees the operations exist and relocation is safe.
 template <typename T>
-concept LyraValue = std::copyable<T>;
+concept Storable = std::copyable<T>;
 
 // The SV data type contract every value type realises (LRM Table 11-1 "Any"
 // row). A type that satisfies this concept provides the universal equality
@@ -53,7 +53,7 @@ concept LyraValue = std::copyable<T>;
 // structural-var in observable storage gates on it. See
 // `docs/decisions/value-type-concepts.md`.
 template <typename T>
-concept LyraValueType = LyraValue<T> && requires(const T& a, const T& b) {
+concept LyraValue = Storable<T> && requires(const T& a, const T& b) {
   // LRM 11.4.5 `==` / `!=` (Any data type). Uniform return type: every
   // value type yields a 1-bit `PackedArray`; 2-state types yield a 2-state
   // packed result. The uniform type lets lowering and emit treat every
@@ -65,28 +65,33 @@ concept LyraValueType = LyraValue<T> && requires(const T& a, const T& b) {
   // operator (`CaseEqualComparable`) even when their internal algorithm
   // coincides.
   { a.IsBitIdentical(b) } -> std::same_as<bool>;
+  // LRM 20.9 `$isunknown` predicate: does any bit of this value's
+  // representation carry an X or Z. Universal: 2-state types implement
+  // it as `return false`; 4-state types scan their bit pattern;
+  // aggregate types recurse into elements. Lowering emits the call
+  // uniformly across every value type, and downstream optimization
+  // constant-folds the 2-state case.
+  { a.HasUnknown() } -> std::same_as<bool>;
 };
 
 // LRM 11.4.5 `===` / `!==` (Any data type except `real` and `shortreal`). A
 // value type opts in when its SV counterpart admits case equality; `real` /
 // `shortreal` does not.
 template <typename T>
-concept CaseEqualComparable =
-    LyraValueType<T> && requires(const T& a, const T& b) {
-      { a.CaseEqual(b) } -> std::same_as<PackedArray>;
-    };
+concept CaseEqualComparable = LyraValue<T> && requires(const T& a, const T& b) {
+  { a.CaseEqual(b) } -> std::same_as<PackedArray>;
+};
 
 // LRM 11.4.5 `==?` / `!=?` wildcard equality (Integral only).
 template <typename T>
-concept WildcardComparable =
-    LyraValueType<T> && requires(const T& a, const T& b) {
-      { a.WildcardEquals(b) } -> std::same_as<PackedArray>;
-    };
+concept WildcardComparable = LyraValue<T> && requires(const T& a, const T& b) {
+  { a.WildcardEquals(b) } -> std::same_as<PackedArray>;
+};
 
 // LRM 11.4.4 relational `<` / `<=` / `>` / `>=` (Integral, real /
 // shortreal, `String`).
 template <typename T>
-concept Ordered = LyraValueType<T> && requires(const T& a, const T& b) {
+concept Ordered = LyraValue<T> && requires(const T& a, const T& b) {
   { a < b } -> std::same_as<PackedArray>;
   { a <= b } -> std::same_as<PackedArray>;
   { a > b } -> std::same_as<PackedArray>;

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -224,6 +224,14 @@ class DynamicArray {
     return true;
   }
 
+  // LRM 20.9: any element carrying an unknown bit propagates up.
+  [[nodiscard]] auto HasUnknown() const -> bool {
+    for (const auto& e : data_) {
+      if (e.HasUnknown()) return true;
+    }
+    return false;
+  }
+
   // LRM 7.5.3: empties the array, resulting in a zero-sized array. Body is
   // identical to ResetToDefault (LRM Table 6-7 default for dynamic array is
   // the empty array), but the two surface names track distinct contracts:

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -183,6 +183,14 @@ class Queue {
     return true;
   }
 
+  // LRM 20.9: any element carrying an unknown bit propagates up.
+  [[nodiscard]] auto HasUnknown() const -> bool {
+    for (const auto& e : data_) {
+      if (e.HasUnknown()) return true;
+    }
+    return false;
+  }
+
   // LRM Table 6-7: a queue's default is the empty queue. When this container
   // is itself an OOB shield slot of an outer container, the outer calls this
   // to restore canonical state before handing out a reference.

--- a/include/lyra/value/real.hpp
+++ b/include/lyra/value/real.hpp
@@ -138,6 +138,11 @@ class RealValue {
     return std::bit_cast<BitsType>(v_) == std::bit_cast<BitsType>(o.v_);
   }
 
+  // LRM 6.12 reals have no X/Z plane.
+  [[nodiscard]] static auto HasUnknown() -> bool {
+    return false;
+  }
+
   // LRM Table 6-7: the real default is 0.0. This is the container OOB-shield
   // contract (docs/decisions/runtime-shape-and-default-value.md), so a real can
   // be an unpacked-array element.
@@ -173,8 +178,8 @@ struct Formatter<RealValue<Host>> {
   }
 };
 
-static_assert(LyraValueType<Real>);
-static_assert(LyraValueType<ShortReal>);
+static_assert(LyraValue<Real>);
+static_assert(LyraValue<ShortReal>);
 static_assert(Ordered<Real>);
 static_assert(Ordered<ShortReal>);
 static_assert(!CaseEqualComparable<Real>);

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -108,6 +108,11 @@ class String {
     return impl_ == o.impl_;
   }
 
+  // LRM 6.16 strings have no X/Z plane.
+  [[nodiscard]] static auto HasUnknown() -> bool {
+    return false;
+  }
+
   // LRM Table 6-7: the string default is the empty string. This is the
   // container OOB-shield contract shared with the other value types
   // (docs/decisions/runtime-shape-and-default-value.md), so a `string` can be

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -188,6 +188,14 @@ class UnpackedArray {
     return true;
   }
 
+  // LRM 20.9: any element carrying an unknown bit propagates up.
+  [[nodiscard]] auto HasUnknown() const -> bool {
+    for (const auto& e : data_) {
+      if (e.HasUnknown()) return true;
+    }
+    return false;
+  }
+
   // LRM 7.12 ordering and reduction, each a thin wrapper over the shared
   // `detail::Array*` algorithms. HIR-to-MIR always supplies the closure (the
   // `with`-clause body or the LRM-default identity), so the runtime exposes

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1137,6 +1137,15 @@ auto RenderCallExpr(
             }
             return std::format("{}({})", decl.name, args);
           },
+          [&](const mir::BuiltinFnCallee&) -> diag::Result<std::string> {
+            throw InternalError(
+                "RenderCallExpr: BuiltinFnCallee has no realization path yet");
+          },
+          [&](const mir::BuiltinStaticCallee&) -> diag::Result<std::string> {
+            throw InternalError(
+                "RenderCallExpr: BuiltinStaticCallee has no realization path "
+                "yet");
+          },
           [&](const mir::BuiltinMethodCallee& b) -> diag::Result<std::string> {
             // Most method families fit the generic `(receiver).name(args)`
             // shape and resolve through `RenderMethodCall` with a per-kind

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -107,17 +107,13 @@ auto RenderTypeAsCpp(
             return "lyra::value::AssociativeArray<" + *key_or + ", " +
                    *elem_or + ">";
           },
-          [&](const mir::ObjectType& o) -> diag::Result<std::string> {
-            return std::string{
-                owner_scope.GetChildStructuralScope(o.target).name};
+          [](const mir::ObjectType& o) -> diag::Result<std::string> {
+            return o.name;
           },
           [](const mir::ExternalUnitObjectType& e)
               -> diag::Result<std::string> { return e.unit_name; },
           [](const mir::ScopeType&) -> diag::Result<std::string> {
             return std::string{"lyra::runtime::Scope"};
-          },
-          [&](const mir::SelfType&) -> diag::Result<std::string> {
-            return std::string{owner_scope.name};
           },
           [](const mir::ServicesType&) -> diag::Result<std::string> {
             return std::string{"lyra::runtime::RuntimeServices&"};

--- a/src/lyra/lowering/hir_to_mir/closure_builder.cpp
+++ b/src/lyra/lowering/hir_to_mir/closure_builder.cpp
@@ -17,11 +17,11 @@ namespace lyra::lowering::hir_to_mir {
 ClosureBuilder::ClosureBuilder(
     mir::CompilationUnit& unit, const WalkFrame& enclosing,
     mir::TypeId result_type)
-    : unit_(&unit),
-      outer_(enclosing.current_procedural_scope),
+    : outer_(enclosing.current_procedural_scope),
       result_type_(result_type),
       sink_(enclosing.procedural_depth.Inner(), body_, *outer_, unit) {
-  const mir::TypeId self_ptr_type = unit_->builtins.self_pointer;
+  const mir::TypeId self_ptr_type =
+      enclosing.current_structural_scope->self_pointer_type;
   self_binding_ = body_.AddProceduralVar(
       mir::ProceduralVarDecl{.name = "self", .type = self_ptr_type});
   outer_self_read_ =

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -29,7 +29,8 @@ auto LowerContinuousAssign(
   mir::ProceduralScope process_scope;
   const mir::ProceduralVarId self_id = process_scope.AddProceduralVar(
       mir::ProceduralVarDecl{
-          .name = "self", .type = scope.Module().Unit().builtins.self_pointer});
+          .name = "self",
+          .type = frame.current_structural_scope->self_pointer_type});
   mir::ProceduralScope body_scope;
   const WalkFrame body_frame =
       frame.WithProceduralScope(&body_scope)
@@ -50,7 +51,8 @@ auto LowerContinuousAssign(
   // Build `self.Services()` in the body so an observable LHS routes through
   // `Var<T>::Set` (or `Mutate` for a selector chain). The body's `self` is
   // already bound at depth 0 via `WithSelfBinding(self_id, ...)` above.
-  const mir::TypeId self_ptr_type = scope.Module().Unit().builtins.self_pointer;
+  const mir::TypeId self_ptr_type =
+      frame.current_structural_scope->self_pointer_type;
   const mir::ExprId body_self_ref = body_scope.AddExpr(
       mir::MakeProceduralVarRefExpr(
           mir::ProceduralHops{

--- a/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
@@ -134,9 +134,9 @@ auto SnapshotPredicate(
 }
 
 auto BuildDiagnosticThenScope(
-    mir::CompilationUnit& unit, mir::ProceduralVarId self_binding,
-    mir::ProceduralVarId count_var, const CheckVerdict& verdict)
-    -> mir::ProceduralScope {
+    mir::CompilationUnit& unit, mir::TypeId self_pointer_type,
+    mir::ProceduralVarId self_binding, mir::ProceduralVarId count_var,
+    const CheckVerdict& verdict) -> mir::ProceduralScope {
   mir::ProceduralScope scope;
   const mir::TypeId int32_type = unit.builtins.int32;
 
@@ -169,7 +169,7 @@ auto BuildDiagnosticThenScope(
           .data =
               mir::ProceduralVarRef{
                   .hops = mir::ProceduralHops{.value = 1}, .var = self_binding},
-          .type = unit.builtins.self_pointer});
+          .type = self_pointer_type});
   const mir::ExprId services = scope.AddExpr(
       mir::MakeServicesCallExpr(self_read, unit.builtins.services));
 
@@ -202,7 +202,8 @@ auto BuildUniqueCheckClosure(
   auto& body = *closure.body;
 
   const mir::TypeId int32_type = module.Unit().builtins.int32;
-  const mir::TypeId self_ptr_type = module.Unit().builtins.self_pointer;
+  const mir::TypeId self_ptr_type =
+      wrapper_frame.current_structural_scope->self_pointer_type;
   const mir::ProceduralVarId self_binding = body.AddProceduralVar(
       mir::ProceduralVarDecl{.name = "self", .type = self_ptr_type});
   const mir::ExprId outer_self_read =
@@ -310,8 +311,8 @@ auto BuildUniqueCheckClosure(
                   .rhs = expected_lit},
           .type = int32_type});
 
-  mir::ProceduralScope diag_scope =
-      BuildDiagnosticThenScope(module.Unit(), self_binding, count_var, verdict);
+  mir::ProceduralScope diag_scope = BuildDiagnosticThenScope(
+      module.Unit(), self_ptr_type, self_binding, count_var, verdict);
 
   const mir::ProceduralScopeId diag_scope_id =
       body.AddChildScope(std::move(diag_scope));

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -242,7 +242,8 @@ auto BuildNbaSubmitClosureExpr(
   mir::ProceduralScope body;
   std::vector<mir::Capture> captures;
 
-  const mir::TypeId self_ptr_type = module.Unit().builtins.self_pointer;
+  const mir::TypeId self_ptr_type =
+      frame.current_structural_scope->self_pointer_type;
   const mir::ProceduralVarId self_id = body.AddProceduralVar(
       mir::ProceduralVarDecl{.name = "self", .type = self_ptr_type});
   const mir::ExprId outer_self_read =

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -454,7 +454,8 @@ auto BuildArrayMethodClosure(
           ? hir_process.procedural_vars.at(with_clause->iterator.value).name
           : std::string{"item"};
 
-  const mir::TypeId self_ptr_type = module.Unit().builtins.self_pointer;
+  const mir::TypeId self_ptr_type =
+      frame.current_structural_scope->self_pointer_type;
   mir::ProceduralScope body_scope;
   const WalkFrame body_frame = frame.WithProceduralScope(&body_scope).Deeper();
   const ProceduralDepth body_depth = body_frame.procedural_depth;
@@ -618,8 +619,8 @@ auto LowerHirCallExprProc(
             // (mir.md invariant 11); the SV actuals follow.
             std::vector<mir::ExprId> args;
             args.reserve(c.arguments.size() + 1);
-            args.push_back(proc_scope.AddExpr(
-                BuildSelfRefExpr(frame, module.Unit().builtins.self_pointer)));
+            args.push_back(proc_scope.AddExpr(BuildSelfRefExpr(
+                frame, frame.current_structural_scope->self_pointer_type)));
             for (std::size_t i = 0; i < c.arguments.size(); ++i) {
               if (!c.arguments[i].has_value()) {
                 throw InternalError(

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -106,7 +106,7 @@ auto LowerStructuralVarRefExpr(
     const hir::StructuralVarRef& m) -> mir::Expr {
   const mir::StructuralVarRef member =
       scope.TranslateStructuralVar(m.hops, m.var);
-  return BuildStructuralMemberAccessExpr(frame, scope.Module().Unit(), member);
+  return BuildStructuralMemberAccessExpr(frame, member);
 }
 
 auto LowerProceduralVarRefExpr(
@@ -119,8 +119,7 @@ auto LowerProceduralVarRefExpr(
   if (const auto* sb = std::get_if<StaticVarBinding>(&binding)) {
     const mir::StructuralVarRef member{
         .hops = mir::StructuralHops{.value = 0}, .var = sb->var};
-    return BuildStructuralMemberAccessExpr(
-        frame, process.Module().Unit(), member);
+    return BuildStructuralMemberAccessExpr(frame, member);
   }
   const auto& ab = std::get<AutomaticVarBinding>(binding);
   if (auto* sink = frame.capture_sink) {
@@ -146,7 +145,8 @@ auto LowerCrossUnitVarRefExpr(
     const hir::CrossUnitVarRef& c) -> mir::Expr {
   const auto& meta = scope.CrossUnitRefTarget(c.id);
   const mir::StructuralVarRef target = meta.target;
-  const mir::TypeId self_ptr_type = scope.Module().Unit().builtins.self_pointer;
+  const mir::TypeId self_ptr_type =
+      frame.current_structural_scope->self_pointer_type;
   const mir::ExprId self_ref = frame.current_procedural_scope->AddExpr(
       BuildSelfRefExpr(frame, self_ptr_type));
   const auto* ptr = std::get_if<mir::PointerType>(

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -242,7 +242,7 @@ auto LowerStraightLineProcess(ProcessLowerer& process, mir::ProcessKind kind)
   const mir::ProceduralVarId self_id = process_scope.AddProceduralVar(
       mir::ProceduralVarDecl{
           .name = "self",
-          .type = process.Module().Unit().builtins.self_pointer});
+          .type = parent.current_structural_scope->self_pointer_type});
   const WalkFrame body_frame =
       parent.WithProceduralScope(&process_scope)
           .WithSelfBinding(self_id, parent.procedural_depth)
@@ -268,7 +268,7 @@ auto LowerForeverProcess(
   const mir::ProceduralVarId self_id = process_scope.AddProceduralVar(
       mir::ProceduralVarDecl{
           .name = "self",
-          .type = process.Module().Unit().builtins.self_pointer});
+          .type = parent.current_structural_scope->self_pointer_type});
   mir::ProceduralScope body_scope;
   {
     const WalkFrame body_frame =
@@ -352,7 +352,8 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
   mir::ProceduralScope body_scope;
   const mir::ProceduralVarId self_id = body_scope.AddProceduralVar(
       mir::ProceduralVarDecl{
-          .name = "self", .type = module_->Unit().builtins.self_pointer});
+          .name = "self",
+          .type = parent.current_structural_scope->self_pointer_type});
   // A task body suspends on timing controls and renders as a coroutine; a
   // function body executes synchronously.
   const bool body_is_coroutine = src.kind == hir::SubroutineKind::kTask;

--- a/src/lyra/lowering/hir_to_mir/self_ref.cpp
+++ b/src/lyra/lowering/hir_to_mir/self_ref.cpp
@@ -22,8 +22,8 @@ auto BuildStructuralMemberAccessExpr(
   const mir::TypeId field_type = frame.StructuralScopeAtHops(member.hops)
                                      .GetStructuralVar(member.var)
                                      .type;
-  const mir::ExprId receiver = frame.current_procedural_scope->AddExpr(
-      BuildSelfRefExpr(
+  const mir::ExprId receiver =
+      frame.current_procedural_scope->AddExpr(BuildSelfRefExpr(
           frame, frame.current_structural_scope->self_pointer_type));
   return mir::MakeMemberAccessExpr(receiver, member, field_type);
 }

--- a/src/lyra/lowering/hir_to_mir/self_ref.cpp
+++ b/src/lyra/lowering/hir_to_mir/self_ref.cpp
@@ -18,13 +18,13 @@ auto BuildSelfRefExpr(const WalkFrame& frame, mir::TypeId self_ptr_type)
 }
 
 auto BuildStructuralMemberAccessExpr(
-    const WalkFrame& frame, const mir::CompilationUnit& unit,
-    const mir::StructuralVarRef& member) -> mir::Expr {
+    const WalkFrame& frame, const mir::StructuralVarRef& member) -> mir::Expr {
   const mir::TypeId field_type = frame.StructuralScopeAtHops(member.hops)
                                      .GetStructuralVar(member.var)
                                      .type;
   const mir::ExprId receiver = frame.current_procedural_scope->AddExpr(
-      BuildSelfRefExpr(frame, unit.builtins.self_pointer));
+      BuildSelfRefExpr(
+          frame, frame.current_structural_scope->self_pointer_type));
   return mir::MakeMemberAccessExpr(receiver, member, field_type);
 }
 

--- a/src/lyra/lowering/hir_to_mir/services_call.cpp
+++ b/src/lyra/lowering/hir_to_mir/services_call.cpp
@@ -10,8 +10,8 @@ auto BuildServicesCallExpr(
     const ProcessLowerer& process, const WalkFrame& frame) -> mir::Expr {
   auto& body = *frame.current_procedural_scope;
   const auto& builtins = process.Module().Unit().builtins;
-  const mir::ExprId self_id =
-      body.AddExpr(BuildSelfRefExpr(frame, builtins.self_pointer));
+  const mir::ExprId self_id = body.AddExpr(BuildSelfRefExpr(
+      frame, frame.current_structural_scope->self_pointer_type));
   return mir::MakeServicesCallExpr(self_id, builtins.services);
 }
 

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -260,7 +260,8 @@ auto LowerSubroutineCallWithWritebacks(
   std::vector<mir::ExprId> call_args;
   call_args.reserve(call.arguments.size() + 1);
   call_args.push_back(wrapper.AddExpr(BuildSelfRefExpr(
-      wrapper_frame, process.Module().Unit().builtins.self_pointer)));
+      wrapper_frame,
+      wrapper_frame.current_structural_scope->self_pointer_type)));
   std::vector<OutputArgSlot> writebacks;
 
   for (std::size_t i = 0; i < call.arguments.size(); ++i) {

--- a/src/lyra/lowering/hir_to_mir/statement/flow.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/flow.cpp
@@ -44,8 +44,7 @@ auto LowerStaticVarDeclStmt(
   auto* owner_scope = frame.current_structural_scope;
   const auto& ctor_frame = process.OwnerCtorFrame();
   auto& ctor_scope = *ctor_frame.current_procedural_scope;
-  const mir::TypeId self_ptr_type =
-      process.Module().Unit().builtins.self_pointer;
+  const mir::TypeId self_ptr_type = owner_scope->self_pointer_type;
 
   const std::string mangled = std::format(
       "{}__{}_{}", process.CallableName(), hir_local.name, v.var.value);

--- a/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
@@ -64,7 +64,7 @@ auto LowerForkStmt(
   std::vector<mir::ExprId> branches;
   branches.reserve(f.branches.size());
   const mir::TypeId self_ptr_type =
-      process.Module().Unit().builtins.self_pointer;
+      frame.current_structural_scope->self_pointer_type;
   for (const hir::StmtId branch_hir_id : f.branches) {
     const hir::Stmt& branch = hir_proc.stmts.at(branch_hir_id.value);
     mir::ProceduralScope branch_scope;

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -172,10 +172,10 @@ auto EnumerateGenerateChildSpecs(
   return specs;
 }
 
-auto MakeUniqueObjectPointer(
-    ModuleLowerer& module, mir::StructuralScopeId child_id) -> mir::TypeId {
+auto MakeUniqueObjectPointer(ModuleLowerer& module, std::string scope_name)
+    -> mir::TypeId {
   const mir::TypeId object_type =
-      module.Unit().AddType(mir::ObjectType{.target = child_id});
+      module.Unit().AddType(mir::ObjectType{.name = std::move(scope_name)});
   return module.Unit().AddType(
       mir::PointerType{
           .pointee = object_type, .ownership = mir::PointerOwnership::kUnique});
@@ -329,7 +329,8 @@ auto BuildDownwardNavValue(
     const std::vector<hir::PathStep>& path, mir::TypeId slot_type,
     mir::TypeId scope_ptr_type) -> mir::Expr {
   mir::ProceduralScope& ctor_scope = *frame.current_procedural_scope;
-  const mir::TypeId self_ptr_type = module.Unit().builtins.self_pointer;
+  const mir::TypeId self_ptr_type =
+      frame.current_structural_scope->self_pointer_type;
   struct NavHop {
     std::string name;
     std::vector<mir::ExprId> indices;
@@ -421,7 +422,7 @@ void InstallCrossUnitRefs(
     const mir::ExprId nav = ctor_scope.AddExpr(BuildDownwardNavValue(
         module, frame, head_name, cu.path, slot_type, scope_ptr_type));
     const mir::ExprId self_for_target = ctor_scope.AddExpr(
-        BuildSelfRefExpr(frame, module.Unit().builtins.self_pointer));
+        BuildSelfRefExpr(frame, mir_scope.self_pointer_type));
     const mir::ExprId target = ctor_scope.AddExpr(
         mir::Expr{
             .data =
@@ -459,12 +460,12 @@ void ValidateConstructOwnedObjectStmt(
   const auto child = mir::GetChildScope(unit, var.type);
   const auto* generate =
       child ? std::get_if<mir::GenerateScopeChild>(&*child) : nullptr;
-  if (generate == nullptr || generate->target != stmt.scope_id) {
+  const auto& child_scope = owner_scope.GetChildStructuralScope(stmt.scope_id);
+  if (generate == nullptr || generate->name != child_scope.name) {
     throw InternalError(
         "ConstructOwnedObjectStmt: target var does not own the requested "
         "scope");
   }
-  const auto& child_scope = owner_scope.GetChildStructuralScope(stmt.scope_id);
   if (stmt.args.size() != child_scope.structural_params.size()) {
     throw InternalError(
         "ConstructOwnedObjectStmt: args count does not match child scope "
@@ -713,7 +714,8 @@ auto InstallGenerateOwnedChildScopes(
 
       const mir::StructuralScopeId child_id =
           mir_scope.AddChildStructuralScope(*std::move(child_r));
-      mir::TypeId var_type = MakeUniqueObjectPointer(module, child_id);
+      mir::TypeId var_type = MakeUniqueObjectPointer(
+          module, mir_scope.GetChildStructuralScope(child_id).name);
       if (spec.is_repeated) {
         var_type = module.Unit().AddType(mir::VectorType{.element = var_type});
       }
@@ -742,8 +744,15 @@ auto StructuralScopeLowerer::Run(
   const hir::StructuralScope& hir_scope = *hir_scope_;
   StructuralScopeLowerer& scope = *this;
 
+  const mir::TypeId self_object_type =
+      module.Unit().AddType(mir::ObjectType{.name = name_});
+  const mir::TypeId self_pointer_type = module.Unit().AddType(
+      mir::PointerType{
+          .pointee = self_object_type,
+          .ownership = mir::PointerOwnership::kBorrowed});
   mir::StructuralScope mir_scope{
       .name = name_,
+      .self_pointer_type = self_pointer_type,
       .time_resolution = hir_scope.time_resolution,
       .structural_params = {},
       .structural_vars = {},
@@ -767,14 +776,14 @@ auto StructuralScopeLowerer::Run(
   mir::ProceduralScope ctor_scope;
   const mir::ProceduralVarId self_id = ctor_scope.AddProceduralVar(
       mir::ProceduralVarDecl{
-          .name = "self", .type = module.Unit().builtins.self_pointer});
+          .name = "self", .type = mir_scope.self_pointer_type});
   ScopeChainNode outer_scope_link{};
   const WalkFrame scope_frame =
       frame.WithStructuralScope(&mir_scope, outer_scope_link)
           .WithProceduralScope(&ctor_scope)
           .WithSelfBinding(self_id, frame.procedural_depth);
   const mir::TypeId void_type = module.Unit().AddType(mir::VoidType{});
-  const mir::TypeId self_ptr_type = module.Unit().builtins.self_pointer;
+  const mir::TypeId self_ptr_type = mir_scope.self_pointer_type;
   const auto self_read = [&]() -> mir::ExprId {
     return ctor_scope.AddExpr(BuildSelfRefExpr(scope_frame, self_ptr_type));
   };

--- a/src/lyra/mir/builtin_method.cpp
+++ b/src/lyra/mir/builtin_method.cpp
@@ -77,4 +77,39 @@ auto IsContainerAccessCall(const BuiltinMethodCallee& callee) -> bool {
       callee.method);
 }
 
+auto IsMutatingBuiltinFn(BuiltinFn id) -> bool {
+  switch (id) {
+    case BuiltinFn::kPutc:
+    case BuiltinFn::kItoa:
+    case BuiltinFn::kHextoa:
+    case BuiltinFn::kOcttoa:
+    case BuiltinFn::kBintoa:
+    case BuiltinFn::kRealtoa:
+    case BuiltinFn::kDelete:
+    case BuiltinFn::kReverse:
+    case BuiltinFn::kSort:
+    case BuiltinFn::kRsort:
+    case BuiltinFn::kInsert:
+    case BuiltinFn::kPopFront:
+    case BuiltinFn::kPopBack:
+    case BuiltinFn::kPushFront:
+    case BuiltinFn::kPushBack:
+      return true;
+    default:
+      return false;
+  }
+}
+
+auto IsContainerAccessFn(BuiltinFn id) -> bool {
+  switch (id) {
+    case BuiltinFn::kElement:
+    case BuiltinFn::kElementRef:
+    case BuiltinFn::kSlice:
+    case BuiltinFn::kSliceRef:
+      return true;
+    default:
+      return false;
+  }
+}
+
 }  // namespace lyra::mir

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -378,6 +378,15 @@ class MirDumper {
                   "RuntimeNavCallee[fn={}, name=\"{}\"]",
                   static_cast<int>(nav.fn), nav.name);
             },
+            [](const BuiltinFnCallee& b) -> std::string {
+              return std::format(
+                  "BuiltinFnCallee[id={}]", static_cast<int>(b.id));
+            },
+            [](const BuiltinStaticCallee& b) -> std::string {
+              return std::format(
+                  "BuiltinStaticCallee[id={}, type_qual=Type[{}]]",
+                  static_cast<int>(b.id), b.type_qual.value);
+            },
             [](const BuiltinMethodCallee& b) -> std::string {
               return std::visit(
                   Overloaded{

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -169,15 +169,13 @@ class MirDumper {
             [](const ChandleType&) -> std::string { return "ChandleType"; },
             [](const VoidType&) -> std::string { return "VoidType"; },
             [](const ObjectType& o) -> std::string {
-              return std::format(
-                  "Object(scope=ChildStructuralScope[{}])", o.target.value);
+              return std::format("Object(name=\"{}\")", o.name);
             },
             [](const ExternalUnitObjectType& e) -> std::string {
               return std::format(
                   "ExternalUnitObject(unit=\"{}\")", e.unit_name);
             },
             [](const ScopeType&) -> std::string { return "Scope"; },
-            [](const SelfType&) -> std::string { return "Self"; },
             [](const ServicesType&) -> std::string { return "Services"; },
             [](const RuntimeLibraryType& r) -> std::string {
               switch (r.kind) {

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -75,7 +75,6 @@ auto Type::Kind() const -> TypeKind {
             return TypeKind::kExternalUnitObject;
           },
           [](const ScopeType&) { return TypeKind::kScope; },
-          [](const SelfType&) { return TypeKind::kSelf; },
           [](const ServicesType&) { return TypeKind::kServices; },
           [](const RuntimeLibraryType&) { return TypeKind::kRuntimeLibrary; },
           [](const CoroutineType&) { return TypeKind::kCoroutine; },
@@ -168,7 +167,7 @@ auto GetChildScope(const CompilationUnit& unit, TypeId type)
   }
   const auto& data = unit.GetType(*pointee).data;
   if (const auto* obj = std::get_if<ObjectType>(&data)) {
-    return ChildScope{GenerateScopeChild{.target = obj->target}};
+    return ChildScope{GenerateScopeChild{.name = obj->name}};
   }
   if (std::holds_alternative<ExternalUnitObjectType>(data)) {
     return ChildScope{ModuleInstanceChild{}};


### PR DESCRIPTION
## Summary

Three preparatory cuts toward replacing the per-family `BuiltinMethodCallee` arms with a single closed-namespace `BuiltinFn` callee. Nothing in this PR routes through the new shape yet -- the existing per-family path stays the load-bearing producer until later cuts migrate the lowering and backend together.

## Cuts

**1. Flat `BuiltinFn` vocabulary alongside the legacy callee.** Adds `BuiltinFn` (one enum covering every compiler-internal runtime entry), plus two sibling callee arms in the `Callee` variant: `BuiltinFnCallee { BuiltinFn id }` for receiver-bound entries and `BuiltinStaticCallee { BuiltinFn id; TypeId type_qual }` for type-namespace-qualified statics (LLVM also reads `type_qual` for symbol mangling, not a render hint). The backend stubs the two new arms with `throw InternalError` -- nothing produces them yet, so the stubs are unreachable, and migrations land cut-by-cut.

**2. `HasUnknown()` becomes part of `LyraValue`.** The `lyra::value::*` universal contract gains `HasUnknown() -> bool` (LRM 20.9). All six value types that satisfied the contract implicitly now do so explicitly: `static_assert(LyraValue<...>)` on each header pins the surface, and any future drift becomes a compile failure rather than a runtime divergence. Renames the underlying weak concept to `Storable` (the `std::copyable` half) and uses `LyraValue` for the SV-semantics contract; the old `LyraValue` / `LyraValueType` naming swap fixes the previous confusion where the stronger contract had the longer name.

**3. `SelfType` retires.** Each `StructuralScope` owns a distinct `self_pointer_type` TypeId (`Pointer<ObjectType{name=this.name}>`, borrowed); the legacy `SelfType{}` placeholder is gone, along with the unit-wide `builtins.self_pointer` it backed. `ObjectType` carries the scope's class name directly, so the C++ render of an `ObjectType` no longer needs walker-state context to recover the class. This aligns intra-unit object typing with `mir.md` invariant 8 (one intra-unit form, not two), and follows the general PL-IR pattern where method bodies see `this` typed as the defining class concretely -- LLVM and Java bytecode have no `Self` placeholder, and Python / Rust only need `Self` for return-type polymorphism that SV does not have.

## Design

Why not fold the type-static queries (enum `first`/`last`/`num`, `$isunknown` on 2-state) at lowering? `decisions/conversion-folding.md` already pinned the precedent: MIR keeps the call as stated, and the downstream optimizer folds the constant. The runtime exposes `HasUnknown()` uniformly across every packed value type (always-false impl on 2-state), so the call shape is the same everywhere and constant-folding falls out of the C++ compiler / LLVM.

The `Real` / `String` `HasUnknown()` impls are `static` (no `this` use, clang-tidy-clean) -- the concept-required `a.HasUnknown()` syntax remains valid C++ for static methods called through an instance.