### PR TITLE
Add string indexing, foreach, and a faithful string value model

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -24,6 +24,9 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
 - [runtime-shape-and-default-value](runtime-shape-and-default-value.md) -- runtime shape lives on
   `PackedArray`; collections carry one OOB shield slot that is both the canonical-default source and
   the out-of-bounds-write discard target.
+- [string-packed-conversion](string-packed-conversion.md) -- a `value::String` holds no NUL;
+  packed-to-string conversion strips NUL (LRM 6.16) while `%s` formats bits without building a
+  string value (LRM 21.2.1.7).
 
 ### Aggregate types and access
 

--- a/docs/decisions/string-packed-conversion.md
+++ b/docs/decisions/string-packed-conversion.md
@@ -1,0 +1,143 @@
+# String values, the no-NUL invariant, and packed conversion
+
+## Date
+
+2026-06-20
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+A SystemVerilog string literal and a string variable are different things (LRM 5.9 vs 6.16), and the
+conversion between bits and a string value has precise, NUL-sensitive rules. The codebase had
+collapsed two genuinely different operations -- building a string value from bits, and formatting
+bits as `%s` -- onto one path that implemented neither rule, so the empty string, embedded NULs, and
+`%s` of a packed value were all wrong. A first attempt fixed the empty string with an operand-aware
+special-case in the conversion render, which both contradicted `conversion-folding.md` and stayed
+wrong for embedded NULs. This record pins the LRM rules, names the two operations, and fixes the
+boundary that actually owns the semantics.
+
+## Findings that shaped the design
+
+### F1. A string literal is a packed bit-vector constant (LRM 5.9, 11.10.3)
+
+A string literal's type is `bit[N:0]` in every context except a `string`-typed one; slang only
+inserts a conversion to `string` when the context demands it. The empty literal `""` is special: LRM
+11.10.3 gives it the value `"\0"` -- 8 zero bits. The slang frontend encodes exactly this
+(`source/ast/expressions/LiteralExpressions.cpp`: an empty literal takes `width = 8`,
+`SVInt(8, 0)`), citing 11.10.3 directly.
+
+**Consequence:** a string literal is an integral value whose bits are its bytes, MSB-first. For the
+non-empty case the width is `8 * len`; the empty case is padded to one zero byte.
+
+### F2. A string variable never contains NUL (LRM 6.16)
+
+LRM 6.16 is explicit: "A string variable shall not contain the special character `"\0"`. Assigning
+the value 0 to a string character shall be ignored." A string variable can hold `""` (length 0); its
+default value is `""` (Table 7-1). Indexing reads a byte and equals `getc` (Table 6-9, LRM 6.16.3);
+`putc(i, 0)` is ignored (LRM 6.16.2).
+
+**Consequence:** "no NUL byte" is not an edge rule -- it is the defining invariant of the string
+value type.
+
+### F3. Building a string value from bits strips every NUL (LRM 6.16)
+
+The conversion of a string literal, or of an integral value, to a string variable is defined
+verbatim: all `"\0"` characters are removed; if nothing remains, the result is the empty string;
+otherwise the remaining characters. Casting an integral value first left-extends it with zeros to a
+multiple of 8 bits, then applies the same removal.
+
+**Consequence:** `""` (the `8'h00` of F1) strips its one NUL and becomes the empty string;
+`"hello\0world"` becomes `"helloworld"`; `string'(16'h0041)` strips the leading zero byte and
+becomes `"A"`. The empty string is not a special case in the conversion -- it is the NUL-strip rule
+applied to F1's encoding.
+
+### F4. `%s` is a presentation operation with different NUL semantics (LRM 21.2.1.7)
+
+`%s` prints a value's bytes as ASCII characters; "no termination character or value is required at
+the end of a string, and leading zeros are never printed." This is a display rule, not the
+string-value conversion of F3, and it differs on embedded and trailing NULs: for `16'h4100` the F3
+conversion yields `"A"` (the trailing NUL stripped), while `%s` keeps the trailing byte. The exact
+rendering of a non-leading NUL under `%s` is not pinned by the LRM and diverges across simulators.
+
+**Consequence:** "format bits as `%s`" and "build a string value from bits" are two operations with
+two rules. Neither subsumes the other.
+
+### F5. The codebase conflated F3 and F4 onto one lossy path
+
+Both the packed-to-string conversion render and `%s` of a non-string operand route through a single
+`ConversionExpr` to `StringType`, emitted as `String::FromPackedArray`, which copies every byte
+verbatim -- it implements neither F3's NUL strip nor F4's leading-zero rule. The integral formatter
+refuses `kString` outright (it throws, forcing `%s` back through the conversion). So the empty
+string and embedded NULs came out wrong, and `%s` of a packed value rendered a literal NUL byte
+rather than following 21.2.1.7.
+
+**Consequence:** one shared path cannot be correct, because F3 and F4 want different NUL handling.
+
+## Decision
+
+1. **A `value::String` never contains a NUL byte (F2).** It is the runtime model of an SV string
+   variable, and the no-NUL property is its invariant. Every boundary that constructs a `String`
+   from arbitrary bits is responsible for enforcing it.
+2. **Packed-to-string is one conversion that strips NUL (F3).** `String::FromPackedArray` -- the
+   construction-from-bits boundary -- removes every NUL. It is used by the explicit cast, implicit
+   assignment, a string literal in a string context, and `$sformat` / `$swrite` output. Because the
+   NUL strip is the conversion's own semantics, the conversion render stays a pure
+   `(source kind, destination kind)` map and never inspects its operand (it composes cleanly with
+   `conversion-folding.md`). The `$sscanf` source lift of an unpacked byte array
+   (`String::FromByteArray`) is a separate operation -- it views bytes as a scan stream where NUL is
+   whitespace (LRM 21.3.4), so it preserves NUL and is not a string-value construction.
+3. **HIR-to-MIR lowers a string literal to its decided MIR primitive (F1).** An integral-typed
+   literal -- the default in every non-string context -- lowers to an `IntegerLiteral` carrying the
+   integer constant of its bytes. A `mir::StringLiteral` is a software string literal (a plain
+   `"text"`), not a built value: a `value::String` value is constructed from it through the generic
+   `CallExpr` + `ConstructorCallee` shape (`String("text")`), the same construction path every other
+   runtime value uses. The representation decision is in MIR's structure, so each backend renders
+   mechanically by node kind and never re-derives it from the type, and never bakes a library
+   constructor into a literal's rendering (`architecture/mir.md` invariant 10). The literal reaches
+   a `String` only through the F3 conversion or this construction; the empty and embedded-NUL cases
+   are handled by F3 in one place rather than by the literal's raw text.
+4. **`%s` is presentation, not conversion (F4).** `%s` of a `String` prints its content (NUL-free by
+   the invariant). `%s` of a packed value formats the packed value under LRM 21.2.1.7 through its
+   own `Formatter` path, not by first converting to a string value. The LRM leaves a NUL byte's `%s`
+   rendering unpinned; it renders as a space (the de-facto convention), so the empty literal prints
+   one space and a byte sequence keeps its column count.
+
+## Rejected
+
+- **An operand-aware special-case in the conversion render** -- `Conversion(string, StringLiteral)`
+  emitting the literal's raw text. It handles `""` only by accident (the literal has no characters),
+  keeps embedded NULs (a C string literal truncates `"hello\0world"` to `"hello"`), and reintroduces
+  the operand inspection `conversion-folding.md` forbids. The empty-string failure it targeted is
+  really F3 not being implemented at the construction boundary.
+- **One shared packed-to-string path for both the cast and `%s`.** F3 and F4 have different NUL
+  semantics, so a single `FromPackedArray` can serve at most one of them correctly. Sharing it is
+  the reason neither was right.
+
+## Consequences
+
+- The packed-to-string conversion is correct for every case in one place: `""`, `"hello\0world"`,
+  and `string'(16'h0041)` all follow F3, and the empty string stops being a special case.
+- The conversion render is a pure type map with no operand inspection; the literal-text special-case
+  is removed.
+- `value::String` is a faithful SV string value: downstream operations (concatenation, `substr`,
+  comparison, `%s`) may assume it holds no NUL.
+- `%s` and the string cast are decoupled, each matching its own LRM rule. `%s` of a packed value
+  formats through a `Formatter` rather than fabricating a string value, so the integral formatter no
+  longer has to refuse `kString`.
+
+## Cross-references
+
+- `conversion-folding.md` -- the conversion render is a pure `(source, destination)` map; this
+  decision keeps that property by making the NUL strip the conversion's semantics rather than an
+  operand-aware exception.
+- `format-dispatch.md` -- `%s` resolves through `Formatter<T>`; this decision adds the
+  packed-operand `%s` path (LRM 21.2.1.7) instead of routing it through a string conversion.
+- `runtime-effects-as-generic-calls.md` -- value construction is a generic `CallExpr` +
+  `ConstructorCallee`; a `value::String` is built that way rather than by a backend-baked literal.
+- `value-type-concepts.md` -- the `value::String` no-NUL invariant joins the value-type contracts.
+- LRM 5.9 (string literals), 11.10.3 (empty string literal value), 6.16 (string data type and
+  conversion), 21.2.1.7 (`%s` string format), Table 6-9 (string operators), Table 7-1 (default
+  value).

--- a/docs/progress/datatypes.md
+++ b/docs/progress/datatypes.md
@@ -106,6 +106,19 @@ frontend inserts an implicit conversion when a literal participates in an expres
       Out-of-range indices and zero-byte writes follow LRM no-op rules; `substr(i, j)` returns the
       empty string for `i < 0`, `j < i`, or `j >= len`.
 
+- [x] SC4 -- Indexing operator `s[i]` (LRM 6.16, Table 6-9) as a byte read and byte write, sharing
+      the out-of-range no-op semantics of the `getc` / `putc` methods, plus `foreach (s[i])` which
+      walks the string by byte (LRM 6.16). A blocking write and its compound forms are covered; a
+      nonblocking write to a single byte is permitted by LRM 10.4.2 but diagnosed as not yet
+      supported.
+
+- [x] SC5 -- A string literal carries its LRM 5.9 dual nature: slang types it as a packed bit vector
+      in every context except a `string`-typed one, so it serves both as an integral constant (a
+      direct operand of an integral operator such as `byte == "x"`, an integral assignment, or a
+      `byte` element write `s[i] = "x"`) and as text (a `string` value or a format / `%s` argument).
+      The empty literal `""` stays the empty string through a `string` conversion, where the packed
+      encoding alone would lose it.
+
 ### Cross-references
 
 - LRM 6.16 (String data type), Table 6-9 (String operators), 6.16.1 -- 6.16.15 (String methods),

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -529,6 +529,21 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       call the synchronous sites use). **Trigger**: standalone -- the builder exists and the
       synchronous IIFE sites already use it; R30 builds its new closures on it too.
 
+- [ ] R30 -- Unify the Expr- / value-construction helper naming, which is ad hoc today (`Make*` and
+      `Build*` are both used for the same job). Establish one rule, grounded in the cross-language
+      norm: every IR / value system separates a **pure node factory** -- assembles a node from
+      ready-made parts, no scope or arena side effect, returns by value -- from a **scope-using
+      builder** -- allocates sub-nodes into a scope and assembles, side-effecting. C++ `std::make_*`
+      (pure) versus the builder pattern; LLVM `Type::get` / `ConstantInt::get` (pure, interned)
+      versus `IRBuilder::Create*` (inserts into a block); rustc `T::new` versus `tcx.mk_*` (interns
+      into the arena); MLIR / Clang `builder.create` / `Expr::Create(ctx, ...)` (arena). Keep both
+      -- the pure-versus-stateful split is load-bearing, since it tells the reader whether the
+      helper mutates a scope -- and pin the rule: `Make<Node>(parts...) -> Expr` is the pure factory
+      (the caller does the `AddExpr`); `Build<Node>(scope-or-frame, inputs...) -> Expr | ExprId` is
+      the scope builder (it does the `AddExpr`, with the context argument first); a type-producing
+      variant is `Make<X>Type(...) -> TypeId`. Audit every construction helper and rename it to the
+      correct side. **Trigger**: standalone naming cleanup.
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/backend/cpp/string_literal.hpp
+++ b/include/lyra/backend/cpp/string_literal.hpp
@@ -6,13 +6,9 @@
 namespace lyra::backend::cpp {
 
 // Render a string as a C string literal: `"..."` with control characters,
-// quotes, and backslashes escaped. Used for `PrintItem::Literal(...)` arguments
-// and as the inner form of `RenderSvStringLiteral`.
+// quotes, and backslashes escaped. This is how a `mir::StringLiteral` renders
+// -- a software string literal -- which a `ConstructorCallee` then turns into a
+// `value::String` (see decisions/string-packed-conversion.md).
 auto RenderCStringLiteral(std::string_view s) -> std::string;
-
-// Render a string as a `lyra::value::String{"..."}` initializer expression.
-// Used for `mir::StringLiteral` operand emission so the resulting value
-// matches the SystemVerilog `string` data type's runtime representation.
-auto RenderSvStringLiteral(std::string_view s) -> std::string;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -223,6 +223,13 @@ class PackedArray {
   [[nodiscard]] auto ValueWords() const -> std::span<const std::uint64_t>;
   [[nodiscard]] auto UnknownWords() const -> std::span<const std::uint64_t>;
 
+  // View the bit vector as a byte sequence, most significant byte first
+  // (`bit_width / 8` bytes; a byte with any x or z bit yields `0x00`). The
+  // shared producer for the LRM 6.16 string lift and the LRM 21.2.1.7 `%s`
+  // formatter, which post-process the NUL byte differently
+  // (decisions/string-packed-conversion.md).
+  [[nodiscard]] auto ByteString() const -> std::string;
+
   // Typed view accessors. The atom encoded in `is_four_state_` selects which
   // overload is callable: 2-state stores expose Bit views, 4-state stores
   // expose Logic views. Calling the wrong one throws InternalError.

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -47,40 +47,14 @@ class String {
     return String{std::move(out)};
   }
 
-  // LRM 5.9 / 21.3.4.3: a packed bit vector viewed as a contiguous byte
-  // sequence. The byte at offset 0 of the result is the destination's most
-  // significant byte (matches PackedArray::FromBytes' MSB-first convention).
-  // Bits below the lowest 8-bit boundary are dropped: only bit_width / 8
-  // bytes are produced. Any byte whose 8 source bits contain x or z values
-  // yields '\0' for that byte. $sscanf / $fscanf never observe the x/z
-  // fallback because the closure-IIFE body emits an
-  // `if (operand.HasUnknown()) return -1` guard at body entry before the
-  // conversion runs (LRM 21.3.4.3 unknown-bits-imply-EOF rule); $display
-  // "%s" on an x/z-bearing packed operand sees the fallback (LRM does not
-  // pin %s rendering for 4-state operands).
+  // LRM 6.16: a string value holds no NUL, so building one from bits strips
+  // every NUL byte -- which is also why the empty `""` (the packed `8'h00` of
+  // LRM 11.10.3) strips to the empty string. See
+  // decisions/string-packed-conversion.md.
   [[nodiscard]] static auto FromPackedArray(const PackedArray& bits) -> String {
-    const std::uint64_t bit_width = bits.BitWidth();
-    const std::uint64_t byte_count = bit_width / 8U;
     std::string out;
-    out.reserve(static_cast<std::size_t>(byte_count));
-    const auto val_words = bits.ValueWords();
-    const auto unk_words = bits.UnknownWords();
-    for (std::uint64_t byte_i = 0; byte_i < byte_count; ++byte_i) {
-      unsigned char byte = 0;
-      bool any_unknown = false;
-      for (std::uint64_t bit_in_byte = 0; bit_in_byte < 8U; ++bit_in_byte) {
-        const std::uint64_t bit_pos =
-            (bit_width - 1U) - (byte_i * 8U) - bit_in_byte;
-        const auto word_ix = static_cast<std::size_t>(bit_pos / 64U);
-        const auto bit_ix = static_cast<std::size_t>(bit_pos % 64U);
-        if (!unk_words.empty() && ((unk_words[word_ix] >> bit_ix) & 1U) != 0U) {
-          any_unknown = true;
-        }
-        if (((val_words[word_ix] >> bit_ix) & 1U) != 0U) {
-          byte |= static_cast<unsigned char>(1U << (7U - bit_in_byte));
-        }
-      }
-      out.push_back(any_unknown ? '\0' : static_cast<char>(byte));
+    for (char c : bits.ByteString()) {
+      if (c != '\0') out.push_back(c);
     }
     return String{std::move(out)};
   }

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -644,30 +644,17 @@ auto RenderConversionExpr(
     return std::format(
         "lyra::value::String::FromByteArray({})", *std::move(operand_or));
   }
-  // LRM 5.9 / 21.3.4.3: packed integral source / format lifts to string by
-  // viewing the bit vector as an MSB-first byte sequence. The $sscanf /
-  // $fscanf body emits an unknown-bits guard before this conversion runs,
-  // so x/z is never observed in the scan path; $display "%s" on an x/z-
-  // bearing packed operand sees `'\0'` per the policy documented at the
-  // String::FromPackedArray declaration.
-  //
-  // SV string literals are typed by slang as `bit[N:0]` packed (LRM 5.9)
-  // but the emitter renders them directly as `lyra::value::String{"..."}`,
-  // so the operand at C++ level is already a String when the source is a
-  // StringLiteral node -- the conversion is a slang-typing artifact, not a
-  // real byte-unpacking need. Skip the wrap in that case; the rendered
-  // operand is the lift's result.
+  // LRM 6.16: build a string value from packed bits. FromPackedArray strips
+  // every NUL, so the empty (`8'h00`) and embedded-NUL cases need no operand
+  // special-case -- the render stays a pure type map (conversion-folding.md;
+  // decisions/string-packed-conversion.md).
   if (src_ty.IsIntegralPacked() && dst_ty.Kind() == mir::TypeKind::kString) {
-    if (std::holds_alternative<mir::StringLiteral>(src_expr.data)) {
-      return *std::move(operand_or);
-    }
     return std::format(
         "lyra::value::String::FromPackedArray({})", *std::move(operand_or));
   }
   // Identity / no-op rendering: the conversion exists in MIR but the
-  // operand's already-rendered C++ matches the destination shape. Covers
-  // string -> string identity, and slang's `bit[N-1:0]` string literal ->
-  // `string` lift where RenderExpr already returns a `value::String{...}`.
+  // operand's already-rendered C++ matches the destination shape (e.g. a
+  // string -> string lift).
   return *std::move(operand_or);
 }
 
@@ -1722,7 +1709,7 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr)
             return RenderIntegerLiteralExpr(view, expr, lit);
           },
           [&](const mir::StringLiteral& s) -> diag::Result<std::string> {
-            return RenderSvStringLiteral(s.value);
+            return RenderCStringLiteral(s.value);
           },
           [](const mir::TimeLiteral&) -> diag::Result<std::string> {
             return diag::Unsupported(

--- a/src/lyra/backend/cpp/string_literal.cpp
+++ b/src/lyra/backend/cpp/string_literal.cpp
@@ -39,8 +39,4 @@ auto RenderCStringLiteral(std::string_view s) -> std::string {
   return out;
 }
 
-auto RenderSvStringLiteral(std::string_view s) -> std::string {
-  return "lyra::value::String{" + RenderCStringLiteral(s) + "}";
-}
-
 }  // namespace lyra::backend::cpp

--- a/src/lyra/lowering/ast_to_hir/expression/assignment.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/assignment.cpp
@@ -13,15 +13,101 @@
 #include <slang/ast/expressions/SelectExpressions.h>
 #include <slang/ast/symbols/MemberSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
+#include <slang/ast/types/Type.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/kind.hpp"
 #include "lyra/hir/conversion.hpp"
+#include "lyra/hir/method.hpp"
 #include "lyra/lowering/ast_to_hir/expression/slang_atoms.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
+
+namespace {
+
+// LRM 6.16.2: writing `s[i]` mutates one byte through putc, the symmetric
+// counterpart of the getc index read, because a string exposes no element
+// lvalue (include/lyra/value/concepts.hpp). A compound `s[i] op= rhs` reads the
+// current byte with getc, applies the operator, and writes the result back.
+auto LowerStringElementWrite(
+    ProcessLowerer& proc, WalkFrame frame,
+    const slang::ast::AssignmentExpression& as,
+    const slang::ast::ElementSelectExpression& sel, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  if (as.isNonBlocking()) {
+    // LRM 10.4.2 permits a nonblocking string-element write (a string is not a
+    // dynamically sized array), but scheduling a deferred putc into the NBA
+    // region is not yet modeled.
+    return diag::Unsupported(
+        span, diag::DiagCode::kUnsupportedAssignmentTarget,
+        "nonblocking assignment to a string element is not yet supported",
+        diag::UnsupportedCategory::kFeature);
+  }
+  auto& module = proc.Module();
+  auto& body = *frame.current_procedural_body;
+
+  auto base_or = proc.LowerExpr(sel.value(), frame);
+  if (!base_or) return std::unexpected(std::move(base_or.error()));
+  const hir::ExprId base_id = body.AddExpr(*std::move(base_or));
+  auto idx_or = proc.LowerExpr(sel.selector(), frame);
+  if (!idx_or) return std::unexpected(std::move(idx_or.error()));
+  const hir::ExprId idx_id = body.AddExpr(*std::move(idx_or));
+
+  auto elem_type = module.InternType(*sel.type, span);
+  if (!elem_type) return std::unexpected(std::move(elem_type.error()));
+
+  hir::ExprId value_id{};
+  if (as.op.has_value()) {
+    const hir::ExprId cur_id = body.AddExpr(
+        hir::Expr{
+            .type = *elem_type,
+            .data =
+                hir::CallExpr{
+                    .callee =
+                        hir::BuiltinMethodRef{
+                            .method = hir::StringMethodKind::kGetc},
+                    .arguments = {base_id, idx_id}},
+            .span = span});
+    auto rhs_or = proc.LowerExpr(BareCompoundUserRhs(as.right()), frame);
+    if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+    hir::Expr rhs_expr = *std::move(rhs_or);
+    if (rhs_expr.type.value != elem_type->value) {
+      const hir::ExprId inner_id = body.AddExpr(std::move(rhs_expr));
+      rhs_expr = hir::Expr{
+          .type = *elem_type,
+          .data =
+              hir::ConversionExpr{
+                  .operand = inner_id, .kind = hir::ConversionKind::kImplicit},
+          .span = span};
+    }
+    const hir::ExprId rhs_id = body.AddExpr(std::move(rhs_expr));
+    value_id = body.AddExpr(
+        hir::Expr{
+            .type = *elem_type,
+            .data =
+                hir::BinaryExpr{
+                    .op = LowerBinaryOp(*as.op), .lhs = cur_id, .rhs = rhs_id},
+            .span = span});
+  } else {
+    auto rhs_or = proc.LowerExpr(as.right(), frame);
+    if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+    value_id = body.AddExpr(*std::move(rhs_or));
+  }
+
+  return hir::Expr{
+      .type = module.Unit().builtins.void_type,
+      .data =
+          hir::CallExpr{
+              .callee =
+                  hir::BuiltinMethodRef{.method = hir::StringMethodKind::kPutc},
+              .arguments = {base_id, idx_id, value_id}},
+      .span = span,
+  };
+}
+
+}  // namespace
 
 auto LowerAssignmentExprProc(
     ProcessLowerer& proc, WalkFrame frame,
@@ -30,6 +116,14 @@ auto LowerAssignmentExprProc(
   auto& module = proc.Module();
   auto validate = ValidateAssignableImpl(module, true, as.left());
   if (!validate) return std::unexpected(std::move(validate.error()));
+
+  if (as.left().kind == slang::ast::ExpressionKind::ElementSelect) {
+    const auto& sel = as.left().as<slang::ast::ElementSelectExpression>();
+    if (sel.value().type->getCanonicalType().isString()) {
+      return LowerStringElementWrite(proc, frame, as, sel, span);
+    }
+  }
+
   auto lhs_or = proc.LowerExpr(as.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const hir::ExprId lhs_id =

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -59,6 +59,31 @@ auto LowerElementSelectExprProc(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::ElementSelectExpression& sel, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
+  if (sel.value().type->getCanonicalType().isString()) {
+    // LRM 6.16.3: a string is a byte sequence with no element lvalue, so an
+    // index read is the getc query, not an addressed element select. The
+    // write side lowers symmetrically to putc in the assignment path.
+    auto base_or = proc.LowerExpr(sel.value(), frame);
+    if (!base_or) return std::unexpected(std::move(base_or.error()));
+    const hir::ExprId base_id =
+        frame.current_procedural_body->AddExpr(*std::move(base_or));
+    auto idx_or = proc.LowerExpr(sel.selector(), frame);
+    if (!idx_or) return std::unexpected(std::move(idx_or.error()));
+    const hir::ExprId idx_id =
+        frame.current_procedural_body->AddExpr(*std::move(idx_or));
+    auto type_id = proc.Module().InternType(*sel.type, span);
+    if (!type_id) return std::unexpected(std::move(type_id.error()));
+    return hir::Expr{
+        .type = *type_id,
+        .data =
+            hir::CallExpr{
+                .callee =
+                    hir::BuiltinMethodRef{
+                        .method = hir::StringMethodKind::kGetc},
+                .arguments = {base_id, idx_id}},
+        .span = span,
+    };
+  }
   if (!sel.value().type->isIntegral() && !sel.value().type->isUnpackedArray()) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedExpressionForm,

--- a/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
@@ -11,9 +11,7 @@
 #include <slang/ast/types/AllTypes.h>
 #include <slang/ast/types/Type.h>
 
-#include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
-#include "lyra/diag/kind.hpp"
 #include "lyra/hir/binary_op.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/expr_builders.hpp"
@@ -48,13 +46,24 @@ struct LevelLoop {
   std::vector<hir::ExprId> step;
 };
 
+// The element-count query for a runtime-sized dimension: queue and dynamic
+// array expose `size`; a string exposes `len` (LRM 6.16.1).
+auto SizeMethodFor(const slang::ast::Type& array_type)
+    -> hir::BuiltinMethodRef {
+  if (array_type.getCanonicalType().isString()) {
+    return {.method = hir::StringMethodKind::kLen};
+  }
+  if (array_type.isQueue()) {
+    return {.method = hir::QueueMethodKind::kSize};
+  }
+  return {.method = hir::ArrayMethodKind::kSize};
+}
+
 // Build the loop for one index-counted dimension. A fixed dimension iterates
 // its declared range and direction; a dynamically sized one (queue / dynamic
-// array) counts 0..size-1 ascending, sampling the count once on entry
+// array / string) counts 0..size-1 ascending, sampling the count once on entry
 // (LRM 12.7.3) into a `setup` local that the condition then reads. The loop
-// variable is the counter, declared in the `for`. `array` is the receiver whose
-// `.size()` bounds a dynamic dimension (queue and dynamic array both expose it;
-// the type only names the builtin-method kind).
+// variable is the counter, declared in the `for`.
 auto BuildIntegerLevel(
     ProcessLowerer& proc, hir::ProceduralBody& body, const LoopDim& dim,
     std::optional<hir::ExprId> array, const slang::ast::Type* array_type,
@@ -71,11 +80,7 @@ auto BuildIntegerLevel(
         body.AddExpr(hir::MakeInt32Literal(declared.right, int32_type, span));
     ascending = declared.left <= declared.right;
   } else {
-    hir::SubroutineRef size_callee =
-        array_type->isQueue() ? hir::SubroutineRef{hir::BuiltinMethodRef{
-                                    .method = hir::QueueMethodKind::kSize}}
-                              : hir::SubroutineRef{hir::BuiltinMethodRef{
-                                    .method = hir::ArrayMethodKind::kSize}};
+    hir::SubroutineRef size_callee = SizeMethodFor(*array_type);
     const hir::ExprId size_id = body.AddExpr(
         hir::Expr{
             .type = int32_type,
@@ -271,10 +276,12 @@ auto BuildForeachNest(
 
   // Descend: the inner levels iterate `array[loop_var]`, one type peel deeper.
   // Only built while the array is being threaded (some inner level is runtime
-  // sized); a deeper fixed-only tail leaves it absent.
+  // sized) and a deeper iterated level remains; the innermost level peels no
+  // element type, which also keeps a string (a terminal byte sequence with no
+  // array element type) from descending.
   std::optional<hir::ExprId> inner_array;
   const slang::ast::Type* inner_array_type = nullptr;
-  if (array.has_value()) {
+  if (array.has_value() && level + 1 < levels.size()) {
     inner_array_type = array_type->getCanonicalType().getArrayElementType();
     auto inner_hir_type = proc.Module().InternType(*inner_array_type, span);
     if (!inner_hir_type) {
@@ -319,24 +326,6 @@ auto BuildForeachNest(
   return stmts;
 }
 
-// Iterating a string itself walks by byte (LRM 6.16), a distinct model from the
-// index-counted and key-walked array families handled here; it stays rejected
-// until its own lowering lands.
-auto RejectUnsupportedArrayType(
-    const slang::ast::Type& canonical, diag::SourceSpan span)
-    -> diag::Result<void> {
-  using slang::ast::SymbolKind;
-  switch (canonical.kind) {
-    case SymbolKind::StringType:
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedStatementForm,
-          "foreach over string is not yet supported",
-          diag::UnsupportedCategory::kFeature);
-    default:
-      return {};
-  }
-}
-
 }  // namespace
 
 auto ProcessLowerer::LowerForeachStmt(
@@ -346,10 +335,6 @@ auto ProcessLowerer::LowerForeachStmt(
   auto& module = proc.Module();
   auto& body = *frame.current_procedural_body;
   const auto span = module.SourceMapper().SpanOf(fs.sourceRange);
-  const auto& canonical = fs.arrayRef.type->getCanonicalType();
-  if (auto check = RejectUnsupportedArrayType(canonical, span); !check) {
-    return std::unexpected(std::move(check.error()));
-  }
 
   const hir::TypeId int32_type = module.Unit().builtins.int32;
 

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -71,8 +71,16 @@ auto BuildDefaultValueExpr(
                 .type = type};
           },
           [&](const mir::StringType&) -> mir::Expr {
+            // Software string literal -> `value::String("")` via the
+            // constructor.
+            const mir::ExprId lit = scope.AddExpr(
+                mir::Expr{
+                    .data = mir::StringLiteral{.value = std::string{}},
+                    .type = type});
             return mir::Expr{
-                .data = mir::StringLiteral{.value = std::string{}},
+                .data =
+                    mir::CallExpr{
+                        .callee = mir::ConstructorCallee{}, .arguments = {lit}},
                 .type = type};
           },
           [&](const mir::RealType&) -> mir::Expr {

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -1,5 +1,10 @@
 #include "lyra/lowering/hir_to_mir/expression/references.hpp"
 
+#include <cstdint>
+#include <string_view>
+#include <utility>
+#include <vector>
+
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/hir/integral_constant.hpp"
@@ -15,7 +20,6 @@
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/integral_constant.hpp"
-#include "lyra/mir/structural_scope.hpp"
 #include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -78,9 +82,54 @@ auto LowerHirIntegerLiteral(const hir::IntegerLiteral& i, mir::TypeId type)
       .type = type};
 }
 
-auto LowerHirStringLiteral(const hir::StringLiteral& s, mir::TypeId type)
-    -> mir::Expr {
-  return mir::Expr{.data = mir::StringLiteral{.value = s.value}, .type = type};
+// LRM 5.9: pack a string literal's bytes into the integer constant they denote,
+// the first byte most significant. A byte is 8-bit-aligned, so it never
+// straddles a 64-bit word.
+auto StringBytesToConstant(
+    std::string_view text, const mir::PackedArrayType& pa)
+    -> mir::IntegralConstant {
+  const auto width = static_cast<std::uint32_t>(pa.BitWidth());
+  std::vector<std::uint64_t> value_words((width + 63U) / 64U, 0U);
+  for (std::size_t i = 0; i < text.size(); ++i) {
+    const std::uint64_t bit_offset = width - (8U * (i + 1U));
+    value_words[bit_offset / 64U] |=
+        static_cast<std::uint64_t>(static_cast<unsigned char>(text[i]))
+        << (bit_offset % 64U);
+  }
+  return mir::IntegralConstant{
+      .value_words = std::move(value_words),
+      .state_words = {},
+      .width = width,
+      .signedness = pa.signedness,
+      .state_kind = mir::IntegralStateKind::kTwoState,
+  };
+}
+
+// An SV string literal is a packed bit-vector constant (LRM 5.9), so MIR
+// carries it as the integer constant of its bytes. A string-typed literal (a
+// string parameter's value) instead builds a `value::String` via the
+// constructor. See decisions/string-packed-conversion.md.
+auto LowerHirStringLiteral(
+    const ModuleLowerer& module, const WalkFrame& frame,
+    const hir::StringLiteral& s, mir::TypeId type) -> mir::Expr {
+  const auto& ty = module.Unit().GetType(type);
+  if (ty.IsIntegralPacked()) {
+    return mir::Expr{
+        .data =
+            mir::IntegerLiteral{
+                .value = StringBytesToConstant(s.value, ty.AsIntegralPacked())},
+        .type = type};
+  }
+  // A string-typed literal (e.g. a string parameter's value) builds a
+  // `value::String` from the software literal via the constructor, on the
+  // procedural scope that holds the surrounding expression.
+  auto& scope = *frame.current_procedural_scope;
+  const mir::ExprId lit = scope.AddExpr(
+      mir::Expr{.data = mir::StringLiteral{.value = s.value}, .type = type});
+  return mir::Expr{
+      .data =
+          mir::CallExpr{.callee = mir::ConstructorCallee{}, .arguments = {lit}},
+      .type = type};
 }
 
 auto LowerHirTimeLiteral(const ModuleLowerer& module, const hir::TimeLiteral& t)
@@ -187,7 +236,8 @@ auto LowerHirPrimaryExprProc(
             return LowerHirIntegerLiteral(i, result_type);
           },
           [&](const hir::StringLiteral& s) -> mir::Expr {
-            return LowerHirStringLiteral(s, result_type);
+            return LowerHirStringLiteral(
+                process.Module(), frame, s, result_type);
           },
           [&](const hir::TimeLiteral& t) -> mir::Expr {
             return LowerHirTimeLiteral(process.Module(), t);
@@ -220,7 +270,7 @@ auto LowerHirPrimaryExprStructural(
             return LowerHirIntegerLiteral(i, result_type);
           },
           [&](const hir::StringLiteral& s) -> mir::Expr {
-            return LowerHirStringLiteral(s, result_type);
+            return LowerHirStringLiteral(scope.Module(), frame, s, result_type);
           },
           [&](const hir::TimeLiteral& t) -> mir::Expr {
             return LowerHirTimeLiteral(scope.Module(), t);

--- a/src/lyra/lowering/hir_to_mir/expression/system/timescale.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/timescale.cpp
@@ -61,10 +61,17 @@ auto LowerPrintTimescaleSystemSubroutineCall(
 
   const mir::ExprId services_id =
       body.AddExpr(BuildServicesCallExpr(process, frame));
-  const mir::ExprId scope_name_id = body.AddExpr(
+  const mir::ExprId scope_name_lit = body.AddExpr(
       mir::Expr{
           .data =
               mir::StringLiteral{.value = std::string(process.Scope().Name())},
+          .type = builtins.string});
+  const mir::ExprId scope_name_id = body.AddExpr(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee = mir::ConstructorCallee{},
+                  .arguments = {scope_name_lit}},
           .type = builtins.string});
   const mir::ExprId unit_power_id = body.AddExpr(
       mir::MakeInt32Literal(

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -77,17 +77,14 @@ auto BuildPrintValueItem(
   if (!lowered_or) return std::unexpected(std::move(lowered_or.error()));
   mir::Expr lowered = *std::move(lowered_or);
 
-  // %s consumes a runtime String. Slang types SV string literals as packed
-  // bit vectors (LRM 5.9), so a `$display("%s", "hello")` arg arrives here
-  // with a packed-array type. Insert an implicit ConversionExpr targeting
-  // StringType so the backend's RuntimePrintValue rendering stays purely
-  // type-driven. Non-literal integral operands also flow through this same
-  // path -- when slang's bit-vector-to-string conversion lands at the
-  // operand level, this becomes a no-op; until then the conversion is the
-  // single chokepoint that records the semantic.
+  // %s formats by operand type (LRM 21.2.1.7,
+  // decisions/string-packed-conversion.md): a String and a packed value each
+  // format directly, without building a string value. Only an unpacked byte
+  // array is not directly formattable, so it lifts to a string value here.
+  const auto& value_type = process.Module().Unit().GetType(lowered.type);
   if (spec.kind == value::FormatKind::kString &&
-      process.Module().Unit().GetType(lowered.type).Kind() !=
-          mir::TypeKind::kString) {
+      value_type.Kind() != mir::TypeKind::kString &&
+      !value_type.IsIntegralPacked()) {
     const mir::ExprId inner = proc_scope.AddExpr(std::move(lowered));
     lowered = mir::Expr{
         .data =
@@ -198,9 +195,16 @@ auto BuildPrintItemExpr(
   return std::visit(
       Overloaded{
           [&](const mir::RuntimePrintLiteral& lit) -> mir::Expr {
-            const mir::ExprId text = scope.AddExpr(
+            const mir::ExprId text_lit = scope.AddExpr(
                 mir::Expr{
                     .data = mir::StringLiteral{.value = lit.text},
+                    .type = unit.builtins.string});
+            const mir::ExprId text = scope.AddExpr(
+                mir::Expr{
+                    .data =
+                        mir::CallExpr{
+                            .callee = mir::ConstructorCallee{},
+                            .arguments = {text_lit}},
                     .type = unit.builtins.string});
             return mir::Expr{
                 .data =

--- a/src/lyra/value/integral_format.cpp
+++ b/src/lyra/value/integral_format.cpp
@@ -364,6 +364,18 @@ auto FormatCharBody(const PackedArray& pa) -> std::string {
   return out;
 }
 
+auto FormatStringBody(const PackedArray& pa) -> std::string {
+  // LRM 21.2.1.7: the value's bytes render as ASCII characters, most
+  // significant byte first. The LRM leaves a NUL byte's rendering unpinned;
+  // match the de-facto convention -- a NUL (and an x/z byte, which reaches here
+  // as 0x00) renders as a space, so it stays one column rather than vanishing.
+  std::string out = pa.ByteString();
+  for (char& c : out) {
+    if (c == '\0') c = ' ';
+  }
+  return out;
+}
+
 auto FormatDecimalBody(const PackedArray& pa) -> std::string {
   switch (SummarizeUnknowns(pa)) {
     case UnknownSummary::kNone:
@@ -463,8 +475,8 @@ auto FormatIntegral(const FormatSpec& spec, const PackedArray& value)
       body = FormatCharBody(value);
       break;
     case FormatKind::kString:
-      throw InternalError(
-          "FormatIntegral: kString must route through Formatter<String>");
+      body = FormatStringBody(value);
+      break;
     case FormatKind::kRealDecimal:
     case FormatKind::kRealExponential:
     case FormatKind::kRealGeneral:

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -271,6 +271,33 @@ auto PackedArray::UnknownWords() const -> std::span<const std::uint64_t> {
   return {};
 }
 
+auto PackedArray::ByteString() const -> std::string {
+  const std::uint64_t bit_width = BitWidth();
+  const std::uint64_t byte_count = bit_width / 8U;
+  std::string out;
+  out.reserve(static_cast<std::size_t>(byte_count));
+  const auto val_words = ValueWords();
+  const auto unk_words = UnknownWords();
+  for (std::uint64_t byte_i = 0; byte_i < byte_count; ++byte_i) {
+    unsigned char byte = 0;
+    bool any_unknown = false;
+    for (std::uint64_t bit_in_byte = 0; bit_in_byte < 8U; ++bit_in_byte) {
+      const std::uint64_t bit_pos =
+          (bit_width - 1U) - (byte_i * 8U) - bit_in_byte;
+      const auto word_ix = static_cast<std::size_t>(bit_pos / 64U);
+      const auto bit_ix = static_cast<std::size_t>(bit_pos % 64U);
+      if (!unk_words.empty() && ((unk_words[word_ix] >> bit_ix) & 1U) != 0U) {
+        any_unknown = true;
+      }
+      if (((val_words[word_ix] >> bit_ix) & 1U) != 0U) {
+        byte |= static_cast<unsigned char>(1U << (7U - bit_in_byte));
+      }
+    }
+    out.push_back(any_unknown ? '\0' : static_cast<char>(byte));
+  }
+  return out;
+}
+
 auto PackedArray::IsBitIdentical(const PackedArray& other) const -> bool {
   if (bit_width_ != other.bit_width_) return false;
   if (is_four_state_ != other.is_four_state_) return false;

--- a/tests/cases/cpp/foreach_string/case.yaml
+++ b/tests/cases/cpp/foreach_string/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.foreach_string
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sum: 294
+    last: 99
+    s: "bcd"

--- a/tests/cases/cpp/foreach_string/main.sv
+++ b/tests/cases/cpp/foreach_string/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  string s;
+  int sum;
+  byte last;
+
+  initial begin
+    s = "abc";
+    // LRM 6.16 foreach over a string walks by byte. Each iteration reads s[i]
+    // (sum 'a'+'b'+'c' = 294, last 'c' = 99) and writes it back incremented,
+    // exercising subscript read and write inside the loop: "abc" -> "bcd".
+    foreach (s[i]) begin
+      sum += s[i];
+      last = s[i];
+      s[i] = s[i] + 1;
+    end
+  end
+endmodule

--- a/tests/cases/cpp/string_format_packed/case.yaml
+++ b/tests/cases/cpp/string_format_packed/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.string_format_packed
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "[ A]\n[ABC]\n[ ]\n"

--- a/tests/cases/cpp/string_format_packed/main.sv
+++ b/tests/cases/cpp/string_format_packed/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  initial begin
+    // LRM 21.2.1.7: %s renders a packed value's bytes as ASCII, MSB-first,
+    // without building a string value. A NUL byte renders as a space, so a
+    // leading zero byte stays one column.
+    $display("[%s]", 16'h0041);
+    $display("[%s]", 24'h414243);
+    // "" is the packed 8'h00 (LRM 11.10.3); under %s its one NUL is a space.
+    $display("[%s]", "");
+  end
+endmodule

--- a/tests/cases/cpp/string_index/case.yaml
+++ b/tests/cases/cpp/string_index/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.string_index
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    first: 101
+    mid: 108
+    oob: 0
+    s: "Hellp"

--- a/tests/cases/cpp/string_index/main.sv
+++ b/tests/cases/cpp/string_index/main.sv
@@ -1,0 +1,22 @@
+module Top;
+  string s;
+  byte first;
+  byte mid;
+  byte oob;
+
+  initial begin
+    s = "hello";
+    // LRM 6.16.3 indexing read: s[1] is 'e' (101).
+    first = s[1];
+    // LRM 6.16.2 indexing write: s[0] becomes 'H' (72) -> "Hello".
+    s[0] = "H";
+    // Compound write reads then writes: s[4] 'o' (111) -> 'p' (112) -> "Hellp".
+    s[4] += 1;
+    // Read after the writes: s[2] is still 'l' (108).
+    mid = s[2];
+    // LRM 6.16.3 out-of-range read returns 0; LRM 6.16.2 out-of-range write is
+    // a no-op, so "Hellp" is unchanged.
+    oob = s[99];
+    s[99] = "Z";
+  end
+endmodule

--- a/tests/cases/cpp/string_nul_handling/case.yaml
+++ b/tests/cases/cpp/string_nul_handling/case.yaml
@@ -1,0 +1,16 @@
+id: cpp.string_nul_handling
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    embedded: "helloworld"
+    len_embedded: 10
+    leading: "A"
+    len_leading: 1
+    empty: ""
+    len_empty: 0

--- a/tests/cases/cpp/string_nul_handling/main.sv
+++ b/tests/cases/cpp/string_nul_handling/main.sv
@@ -1,0 +1,23 @@
+module Top;
+  string embedded;
+  string leading;
+  string empty;
+  int len_embedded;
+  int len_leading;
+  int len_empty;
+
+  initial begin
+    // LRM 6.16: building a string value strips every NUL. The embedded NUL is
+    // removed, not a truncation point: "hello\0world" -> "helloworld" (len 10).
+    embedded = "hello\0world";
+    len_embedded = embedded.len();
+    // LRM 6.16 integral cast: 16'h0041 is bytes 0x00, 0x41; the leading NUL
+    // strips, leaving "A" (len 1).
+    leading = string'(16'h0041);
+    len_leading = leading.len();
+    // LRM 11.10.3: "" is the packed 8'h00, whose one NUL strips to the empty
+    // string (len 0).
+    empty = "";
+    len_empty = empty.len();
+  end
+endmodule

--- a/tests/cases/errors/string_element_nba_rejected/case.yaml
+++ b/tests/cases/errors/string_element_nba_rejected/case.yaml
@@ -1,4 +1,4 @@
-id: errors.foreach_string_rejected
+id: errors.string_element_nba_rejected
 tags: [errors, diag]
 input:
   command: [emit, cpp]
@@ -11,6 +11,6 @@ expect:
   stderr:
     contains:
       - "main.sv:"
-      - "foreach over string is not yet supported"
+      - "nonblocking assignment to a string element is not yet supported"
     not_contains:
       - "internal error"

--- a/tests/cases/errors/string_element_nba_rejected/main.sv
+++ b/tests/cases/errors/string_element_nba_rejected/main.sv
@@ -1,8 +1,6 @@
 module Top;
   string s = "hello";
   initial begin
-    foreach (s[i]) begin
-      s[i] = "x";
-    end
+    s[0] <= "H";
   end
 endmodule


### PR DESCRIPTION
## Summary

Adds the SystemVerilog string `s[i]` indexing operator (byte read via `getc`, byte write via `putc`, with the LRM 6.16 out-of-range no-op rules) and `foreach (s[i])` byte-walk iteration, and reworks how string literals and string values flow through the pipeline so the model is correct end to end.

## Design

An SV string literal is a packed bit-vector constant (LRM 5.9), so it lowers to an `IntegerLiteral` in every integral context (a comparison like `byte == "x"`, arithmetic, an integral assignment); a `value::String` value is built from a software string literal through the generic `CallExpr` + `ConstructorCallee` shape (`String("text")`) rather than a backend-baked `String{}`, so construction stays a real MIR node that both backends render. The packed-to-string conversion strips NUL per LRM 6.16, which is what makes `""`, an embedded NUL, and `string'(16'h0041)` all resolve correctly and is the enforcer of the `value::String` no-NUL invariant; `%s` of a packed value formats it directly (LRM 21.2.1.7) instead of fabricating a string value. The rationale is recorded in `docs/decisions/string-packed-conversion.md`. A follow-up to unify the ad-hoc `Make*` / `Build*` construction-helper naming is tracked as `refactor.md` R30.

## Testing

`bazel test //...` green (full suite). New cases cover `s[i]` read/write, `foreach` over string, NUL handling (empty / embedded / leading-zero cast), `%s` of a packed value, and the nonblocking-string-element rejection.