### PR TITLE
Converge all closure construction onto ClosureBuilder

### DIFF
--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -552,19 +552,20 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       member-call rule; the backend no longer fabricates the engine handle or a reference wrapper
       for traversal. Closes R25's traversal carve-out (traversal now fits the generic member rule).
 
-- [ ] R31 -- Converge every closure-construction site onto the one closure builder. Associative
-      traversal (R27) and the scan family introduced and adopted a builder that owns the closure
-      body scope, the `self` capture, and the capture sink: the caller fills the body through it and
-      a terminal assembles the closure value, so the build-the-closure boilerplate lives in one
-      place. The remaining sites still inline that scaffolding -- the fork-join branch (a coroutine
-      closure with a by-value capture depth), the with-clause iterator (LRM 7.12.4, carrying an
-      index binding), the non-blocking-assignment submit (manual value captures, no sink), and the
-      deferred-assertion check. Converging them deletes the duplicated body-scope / self / sink /
-      capture-assembly code and leaves one builder for every closure. Requires generalizing the
-      builder with a coroutine result, a by-value capture depth, manual value captures, an index
-      binding, and a bare closure-value terminal (for spawn / submit, versus the immediately-invoked
-      call the synchronous sites use). **Trigger**: standalone -- the builder exists and the
-      synchronous IIFE sites already use it; R30 builds its new closures on it too.
+- [x] R31 -- **Every closure-construction site now goes through the one closure builder.** The
+      builder owns the body scope, the `self` capture (captures[0]), and the capture sink; the
+      caller fills the body -- by lowering HIR through the builder's frame (the sink turns
+      enclosing-variable reads into captures) or by hand-snapshotting outer expressions by value --
+      and a terminal assembles the closure value. It generalizes over a coroutine result (a fork
+      branch yields the coroutine type via a `co_return` terminal), a by-value capture depth (a
+      fork-scope local snapshots, a deeper enclosing variable aliases), per-invocation parameters
+      (the with-clause iterator and index, LRM 7.12.4), manual by-value captures (the NBA submit and
+      deferred-assertion check, which build their bodies by hand and so use no sink), and three
+      terminals -- a value `return`, a `co_return`, and a bare void body. The fork-join branch,
+      with-clause iterator, NBA submit, and deferred-assertion check all dropped their inline
+      body-scope / self / sink / capture-assembly code; `mir::ClosureExpr` is now constructed in
+      exactly one place. The result type left the constructor -- a synchronous terminal derives it
+      from the result expression, since a closure's result type is just its returned value's type.
 
 - [ ] R32 -- Unify the Expr- / value-construction helper naming, which is ad hoc today (`Make*` and
       `Build*` are both used for the same job). Establish one rule, grounded in the cross-language

--- a/include/lyra/lowering/hir_to_mir/closure_builder.hpp
+++ b/include/lyra/lowering/hir_to_mir/closure_builder.hpp
@@ -1,7 +1,13 @@
 #pragma once
 
+#include <optional>
+#include <string_view>
+#include <vector>
+
+#include "lyra/lowering/hir_to_mir/block_depth.hpp"
 #include "lyra/lowering/hir_to_mir/capture_sink.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
+#include "lyra/mir/closure.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/local.hpp"
@@ -14,21 +20,31 @@ class CompilationUnit;
 
 namespace lyra::lowering::hir_to_mir {
 
-// A synchronous closure under construction (closure.md). The constructor opens
-// a fresh body scope with `self` as captures[0] and installs a capture sink, so
-// a read of an enclosing variable while lowering the body becomes a capture
-// (LRM 6.21). The caller lowers the body through `Frame()` into `Body()`, then
-// `Build()` closes it with the result `return` and yields the closure value.
+// A closure under construction (closure.md). The constructor opens a fresh body
+// scope with `self` as captures[0] and installs a capture sink, so a read of an
+// enclosing variable while lowering the body through `Frame()` becomes a
+// capture (LRM 6.21). A site that authors the body by hand instead of lowering
+// HIR snapshots specific outer expressions with `CaptureByValue`; the two
+// capture paths coexist, and `self` is always first.
+//
+// `coroutine` selects a fork-branch body (LRM 9.3.2): its `return`s render as
+// `co_return` and the terminal is `BuildCoroutine`. `by_value_depth` is the
+// sink snapshot boundary -- a capture declared at that depth is snapshotted by
+// value, any deeper-enclosing capture aliases the live cell; pass it for a fork
+// branch (block-item locals snapshot) and leave it empty for a synchronous body
+// (every sink capture aliases).
 //
 // A closure is a value; how it is invoked -- an immediately-invoked call
-// (`BuildClosureCallExpr`), a fork spawn, a deferred submit -- is the caller's
-// concern, not the builder's (mir.md). Non-movable: `Frame()` hands out a frame
-// that points into the owned body scope and capture sink.
+// (`BuildClosureCallExpr`), a fork spawn, a deferred submit, a with-clause
+// iteration -- is the caller's concern, not the builder's (mir.md).
+// Non-movable: `Frame()` hands out a frame that points into the owned body
+// scope and sink.
 class ClosureBuilder {
  public:
   ClosureBuilder(
       mir::CompilationUnit& unit, const WalkFrame& enclosing,
-      mir::TypeId result_type);
+      bool coroutine = false,
+      std::optional<BlockDepth> by_value_depth = std::nullopt);
 
   ClosureBuilder(const ClosureBuilder&) = delete;
   auto operator=(const ClosureBuilder&) -> ClosureBuilder& = delete;
@@ -37,7 +53,9 @@ class ClosureBuilder {
   ~ClosureBuilder() = default;
 
   // The frame to lower the body through: the body scope is current, `self` is
-  // bound, and the capture sink intercepts enclosing-variable reads.
+  // bound, and the sink intercepts enclosing-variable reads. A caller that
+  // needs a parameter to play a frame-level role (an `item.index` index)
+  // decorates this frame at its own lowering call site.
   [[nodiscard]] auto Frame() const -> const WalkFrame& {
     return frame_;
   }
@@ -45,19 +63,48 @@ class ClosureBuilder {
   [[nodiscard]] auto Body() -> mir::Block& {
     return body_;
   }
+  // The `self` receiver binding (captures[0]), for a hand-authored body that
+  // builds its own `self` reads.
+  [[nodiscard]] auto SelfBinding() const -> mir::LocalId {
+    return self_binding_;
+  }
 
-  // Closes the body with `return result`, assembles the captures (self plus the
-  // sink's), and yields the closure value. Single-use.
+  // Declares a per-invocation parameter (LRM 7.12.4 with-clause). Allocates the
+  // body slot and records the parameter; the caller maps any HIR iterator to
+  // the returned binding before lowering the body. Any role a parameter plays
+  // in the body -- a with-clause iterator, the `item.index` index -- is the
+  // caller's to wire onto the frame it lowers through, not the builder's.
+  auto AddParam(std::string_view name, mir::TypeId type) -> mir::LocalId;
+
+  // Snapshots an outer-scope expression into the body by value: allocates a
+  // body binding, records a by-value capture of `outer_id`, and returns the
+  // body-side read. An integer literal clones verbatim so the body still sees a
+  // literal (constant-extracting passes depend on that shape) and no capture is
+  // made.
+  auto CaptureByValue(mir::ExprId outer_id, std::string_view name)
+      -> mir::ExprId;
+
+  // Closes the body with `return result`, assembles the captures, and yields
+  // the closure value typed as the result expression. Single-use.
   [[nodiscard]] auto Build(mir::ExprId result) -> mir::Expr;
+  // Closes a fork-branch body with `co_return` and yields the coroutine-typed
+  // closure value. Single-use.
+  [[nodiscard]] auto BuildCoroutine() -> mir::Expr;
+  // Yields a void-typed closure whose body is already self-contained (no result
+  // expression). Single-use.
+  [[nodiscard]] auto BuildVoid() -> mir::Expr;
 
  private:
+  auto Finish(mir::TypeId result_type) -> mir::Expr;
+
+  mir::CompilationUnit* unit_;
   mir::Block* outer_;
-  mir::TypeId result_type_;
   mir::Block body_;
   mir::LocalId self_binding_{};
-  mir::ExprId outer_self_read_{};
   CaptureSink sink_;
   WalkFrame frame_;
+  std::vector<mir::Capture> captures_;
+  std::vector<mir::Parameter> params_;
 };
 
 // Builds the immediately-invoked call of `closure` (the IIFE shape): adds the

--- a/include/lyra/lowering/hir_to_mir/expression/assignment.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/assignment.hpp
@@ -28,7 +28,7 @@ auto LowerHirAssignExprProc(
 // (procedural-local NBA is not supported). Used by the AssignExpr handler
 // and the LHS-destructuring desugar.
 auto BuildNbaSubmitClosureExpr(
-    const ModuleLowerer& module, WalkFrame frame, mir::ExprId lhs_in_outer,
+    ModuleLowerer& module, WalkFrame frame, mir::ExprId lhs_in_outer,
     mir::ExprId rhs_id_in_outer, mir::TypeId rhs_type) -> mir::Expr;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/closure_builder.cpp
+++ b/src/lyra/lowering/hir_to_mir/closure_builder.cpp
@@ -1,8 +1,9 @@
 #include "lyra/lowering/hir_to_mir/closure_builder.hpp"
 
 #include <memory>
+#include <string>
 #include <utility>
-#include <vector>
+#include <variant>
 
 #include "lyra/lowering/hir_to_mir/capture_sink.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
@@ -15,41 +16,77 @@
 namespace lyra::lowering::hir_to_mir {
 
 ClosureBuilder::ClosureBuilder(
-    mir::CompilationUnit& unit, const WalkFrame& enclosing,
-    mir::TypeId result_type)
-    : outer_(enclosing.current_block),
-      result_type_(result_type),
-      sink_(enclosing.block_depth.Inner(), body_, *outer_, unit) {
-  const mir::TypeId self_ptr_type = enclosing.current_class->self_pointer_type;
+    mir::CompilationUnit& unit, const WalkFrame& enclosing, bool coroutine,
+    std::optional<BlockDepth> by_value_depth)
+    : unit_(&unit),
+      outer_(enclosing.current_block),
+      sink_(
+          enclosing.block_depth.Inner(), body_, *outer_, unit, by_value_depth) {
+  const mir::TypeId self_pointer_type =
+      enclosing.current_class->self_pointer_type;
   self_binding_ =
-      body_.AddLocal(mir::LocalDecl{.name = "self", .type = self_ptr_type});
-  outer_self_read_ =
-      outer_->AddExpr(BuildSelfRefExpr(enclosing, self_ptr_type));
-  // A synchronous IIFE aliases the caller's storage, live throughout the
-  // closure's evaluation, so every sink capture is a reference (no by-value
-  // depth) and the body never suspends.
+      body_.AddLocal(mir::LocalDecl{.name = "self", .type = self_pointer_type});
+  const mir::ExprId outer_self_read =
+      outer_->AddExpr(BuildSelfRefExpr(enclosing, self_pointer_type));
+  captures_.push_back(
+      mir::Capture{.value = outer_self_read, .binding = self_binding_});
   frame_ = enclosing.WithBlock(&body_)
                .Deeper()
                .WithCaptureSink(&sink_)
                .WithSelfBinding(self_binding_, enclosing.block_depth.Inner())
-               .WithCoroutineBody(false);
+               .WithCoroutineBody(coroutine);
 }
 
-auto ClosureBuilder::Build(mir::ExprId result) -> mir::Expr {
-  body_.AppendStmt(mir::ReturnStmt{.value = result});
+auto ClosureBuilder::AddParam(std::string_view name, mir::TypeId type)
+    -> mir::LocalId {
+  const mir::LocalId binding =
+      body_.AddLocal(mir::LocalDecl{.name = std::string(name), .type = type});
+  params_.push_back(mir::Parameter{.binding = binding});
+  return binding;
+}
 
-  std::vector<mir::Capture> captures;
-  captures.push_back(
-      mir::Capture{.value = outer_self_read_, .binding = self_binding_});
+auto ClosureBuilder::CaptureByValue(mir::ExprId outer_id, std::string_view name)
+    -> mir::ExprId {
+  const mir::Expr& outer_expr = outer_->GetExpr(outer_id);
+  if (std::holds_alternative<mir::IntegerLiteral>(outer_expr.data)) {
+    return body_.AddExpr(outer_expr);
+  }
+  const mir::LocalId binding = body_.AddLocal(
+      mir::LocalDecl{.name = std::string(name), .type = outer_expr.type});
+  captures_.push_back(mir::Capture{.value = outer_id, .binding = binding});
+  return body_.AddExpr(
+      mir::Expr{
+          .data =
+              mir::LocalRef{.hops = mir::BlockHops{.value = 0}, .var = binding},
+          .type = outer_expr.type});
+}
+
+auto ClosureBuilder::Finish(mir::TypeId result_type) -> mir::Expr {
   for (const CaptureRequest& request : sink_.TakeRequests()) {
-    captures.push_back(
+    captures_.push_back(
         mir::Capture{.value = request.source, .binding = request.binding});
   }
   mir::ClosureExpr closure;
-  closure.captures = std::move(captures);
+  closure.captures = std::move(captures_);
+  closure.params = std::move(params_);
   closure.body = std::make_unique<mir::Block>(std::move(body_));
+  return mir::Expr{.data = std::move(closure), .type = result_type};
+}
 
-  return mir::Expr{.data = std::move(closure), .type = result_type_};
+auto ClosureBuilder::Build(mir::ExprId result) -> mir::Expr {
+  const mir::TypeId result_type = body_.GetExpr(result).type;
+  body_.AppendStmt(mir::ReturnStmt{.value = result});
+  return Finish(result_type);
+}
+
+auto ClosureBuilder::BuildCoroutine() -> mir::Expr {
+  body_.AppendStmt(
+      mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
+  return Finish(unit_->builtins.coroutine);
+}
+
+auto ClosureBuilder::BuildVoid() -> mir::Expr {
+  return Finish(unit_->builtins.void_type);
 }
 
 auto BuildClosureCallExpr(mir::Block& block, mir::Expr closure) -> mir::Expr {

--- a/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
@@ -3,7 +3,6 @@
 #include <cstdint>
 #include <expected>
 #include <format>
-#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
@@ -12,13 +11,12 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/closure_builder.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/print_items.hpp"
-#include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/statement/blocks.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/block_hops.hpp"
-#include "lyra/mir/closure.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/expr_id.hpp"
@@ -195,20 +193,14 @@ auto BuildDiagnosticThenScope(
 auto BuildUniqueCheckClosure(
     ModuleLowerer& module, const WalkFrame& wrapper_frame, mir::Block& wrapper,
     hir::UniquePriorityCheck check,
-    const std::vector<mir::LocalId>& snapshot_vars) -> mir::ClosureExpr {
-  mir::ClosureExpr closure;
-  closure.body = std::make_unique<mir::Block>();
-  auto& body = *closure.body;
+    const std::vector<mir::LocalId>& snapshot_vars) -> mir::Expr {
+  ClosureBuilder closure(module.Unit(), wrapper_frame);
+  mir::Block& body = closure.Body();
 
   const mir::TypeId int32_type = module.Unit().builtins.int32;
   const mir::TypeId self_ptr_type =
       wrapper_frame.current_class->self_pointer_type;
-  const mir::LocalId self_binding =
-      body.AddLocal(mir::LocalDecl{.name = "self", .type = self_ptr_type});
-  const mir::ExprId outer_self_read =
-      wrapper.AddExpr(BuildSelfRefExpr(wrapper_frame, self_ptr_type));
-  closure.captures.emplace_back(
-      mir::Capture{.value = outer_self_read, .binding = self_binding});
+  const mir::LocalId self_binding = closure.SelfBinding();
 
   std::vector<mir::ExprId> inner_reads;
   inner_reads.reserve(snapshot_vars.size());
@@ -221,20 +213,8 @@ auto BuildUniqueCheckClosure(
                     .hops = mir::BlockHops{.value = 0},
                     .var = snapshot_vars[i]},
             .type = snap_type});
-
-    const mir::LocalId binding = body.AddLocal(
-        mir::LocalDecl{
-            .name = std::format("_lyra_unique_bind_{}", i), .type = snap_type});
-    closure.captures.emplace_back(
-        mir::Capture{.value = outer_read_id, .binding = binding});
-
-    const mir::ExprId inner_read_id = body.AddExpr(
-        mir::Expr{
-            .data =
-                mir::LocalRef{
-                    .hops = mir::BlockHops{.value = 0}, .var = binding},
-            .type = snap_type});
-    inner_reads.push_back(inner_read_id);
+    inner_reads.push_back(closure.CaptureByValue(
+        outer_read_id, std::format("_lyra_unique_bind_{}", i)));
   }
 
   const mir::LocalId count_var = body.AddLocal(
@@ -320,7 +300,7 @@ auto BuildUniqueCheckClosure(
           .then_scope = diag_scope_id,
           .else_scope = std::nullopt});
 
-  return closure;
+  return closure.BuildVoid();
 }
 
 }  // namespace
@@ -350,10 +330,9 @@ auto BuildDeferredCheckCascade(
         branches[i].predicate));
   }
 
-  mir::ClosureExpr closure = BuildUniqueCheckClosure(
+  mir::Expr closure = BuildUniqueCheckClosure(
       module, wrapper_frame, wrapper, check, snapshot_vars);
-  const mir::ExprId closure_expr_id =
-      wrapper.AddExpr(mir::Expr{.data = std::move(closure), .type = void_type});
+  const mir::ExprId closure_expr_id = wrapper.AddExpr(std::move(closure));
 
   const mir::DeferredCheckSiteId site_id =
       module.Unit().AllocateDeferredCheckSiteId();

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -4,8 +4,6 @@
 #include <cstdint>
 #include <expected>
 #include <format>
-#include <memory>
-#include <string_view>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -16,16 +14,15 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_body.hpp"
+#include "lyra/lowering/hir_to_mir/closure_builder.hpp"
 #include "lyra/lowering/hir_to_mir/expression/operators.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
-#include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/block_hops.hpp"
-#include "lyra/mir/closure.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/runtime_submit.hpp"
@@ -66,44 +63,18 @@ auto IsExprRootedAtStructuralVar(const mir::Block& block, mir::ExprId expr_id)
       expr.data);
 }
 
-// Snapshot a single outer-scope subexpression into the closure body. Literal
-// values clone verbatim so the body still sees an IntegerLiteral (some
-// downstream code paths extract constants from literal-shape exprs). Other
-// expressions are captured by value into a fresh local so the body
-// reads the value as it stood at submit time. `name_prefix` distinguishes
-// the caller so the synthesized binding names stay readable when MIR dumps
-// are inspected.
-auto SnapshotNonLhsSubexpr(
-    const mir::Block& outer_block, mir::Block& body,
-    std::vector<mir::Capture>& captures, std::uint32_t& snapshot_counter,
-    mir::ExprId outer_id, std::string_view name_prefix) -> mir::ExprId {
-  const auto& outer_expr = outer_block.GetExpr(outer_id);
-  if (std::holds_alternative<mir::IntegerLiteral>(outer_expr.data)) {
-    return body.AddExpr(outer_expr);
-  }
-  const auto binding = body.AddLocal(
-      mir::LocalDecl{
-          .name =
-              std::format("_lyra_{}_arg{}", name_prefix, snapshot_counter++),
-          .type = outer_expr.type});
-  captures.emplace_back(mir::Capture{.value = outer_id, .binding = binding});
-  return body.AddExpr(
-      mir::Expr{
-          .data =
-              mir::LocalRef{.hops = mir::BlockHops{.value = 0}, .var = binding},
-          .type = outer_expr.type});
-}
-
 // Recursively clone an LHS-shaped expression into the closure body. The LHS
 // structure (PrimaryExpr, container-access CallExpr, ConcatExpr) is
 // reproduced as-is; per-layer subexpressions that are NOT part of the LHS
 // structure (selector indices, range offsets and count literals) are
-// snapshotted by value so the closure body sees the values that were live
-// at submit time.
+// snapshotted by value through the builder so the closure body sees the values
+// that were live at submit time.
 auto CloneLhsExprForNbaBody(
-    const mir::Block& outer_block, mir::Block& body, mir::TypeId self_ptr_type,
-    mir::LocalId body_self_id, std::vector<mir::Capture>& captures,
-    std::uint32_t& snapshot_counter, mir::ExprId outer_id) -> mir::ExprId {
+    ClosureBuilder& closure, const mir::Block& outer_block,
+    mir::TypeId self_ptr_type, std::uint32_t& snapshot_counter,
+    mir::ExprId outer_id) -> mir::ExprId {
+  mir::Block& body = closure.Body();
+  const mir::LocalId body_self_id = closure.SelfBinding();
   const auto& outer_expr = outer_block.GetExpr(outer_id);
   return std::visit(
       Overloaded{
@@ -119,12 +90,12 @@ auto CloneLhsExprForNbaBody(
             std::vector<mir::ExprId> body_args;
             body_args.reserve(c.arguments.size());
             body_args.push_back(CloneLhsExprForNbaBody(
-                outer_block, body, self_ptr_type, body_self_id, captures,
-                snapshot_counter, c.arguments.front()));
+                closure, outer_block, self_ptr_type, snapshot_counter,
+                c.arguments.front()));
             for (std::size_t i = 1; i < c.arguments.size(); ++i) {
-              body_args.push_back(SnapshotNonLhsSubexpr(
-                  outer_block, body, captures, snapshot_counter, c.arguments[i],
-                  "nba"));
+              body_args.push_back(closure.CaptureByValue(
+                  c.arguments[i],
+                  std::format("_lyra_nba_arg{}", snapshot_counter++)));
             }
             return body.AddExpr(
                 mir::Expr{
@@ -139,8 +110,8 @@ auto CloneLhsExprForNbaBody(
             body_operands.reserve(c.operands.size());
             for (const mir::ExprId op_id : c.operands) {
               body_operands.push_back(CloneLhsExprForNbaBody(
-                  outer_block, body, self_ptr_type, body_self_id, captures,
-                  snapshot_counter, op_id));
+                  closure, outer_block, self_ptr_type, snapshot_counter,
+                  op_id));
             }
             return body.AddExpr(
                 mir::Expr{
@@ -228,45 +199,26 @@ auto LowerHirAssignExprProc(
       .type = process.Module().Unit().builtins.void_type};
 }
 
-// Builds a ClosureExpr that snapshots the RHS by value into the body and
-// writes the snapshot to the LHS. The closure is the deferred-write vehicle
-// the NBA region invokes. The returned Expr has type `void` -- the closure
-// value flows only into RuntimeSubmitNbaCall. `lhs_in_outer` must be an
-// addressable expression.
+// Builds the deferred-write closure that snapshots the RHS by value into the
+// body and writes the snapshot to the LHS. It is the vehicle the NBA region
+// invokes. The returned Expr has type `void` -- the closure value flows only
+// into RuntimeSubmitNbaCall. `lhs_in_outer` must be an addressable expression.
 auto BuildNbaSubmitClosureExpr(
-    const ModuleLowerer& module, WalkFrame frame, mir::ExprId lhs_in_outer,
+    ModuleLowerer& module, WalkFrame frame, mir::ExprId lhs_in_outer,
     mir::ExprId rhs_id_in_outer, mir::TypeId rhs_type) -> mir::Expr {
   auto& outer_block = *frame.current_block;
-  mir::Block body;
-  std::vector<mir::Capture> captures;
-
+  ClosureBuilder closure(module.Unit(), frame);
+  mir::Block& body = closure.Body();
   const mir::TypeId self_ptr_type = frame.current_class->self_pointer_type;
-  const mir::LocalId self_id =
-      body.AddLocal(mir::LocalDecl{.name = "self", .type = self_ptr_type});
-  const mir::ExprId outer_self_read =
-      outer_block.AddExpr(BuildSelfRefExpr(frame, self_ptr_type));
-  captures.emplace_back(
-      mir::Capture{.value = outer_self_read, .binding = self_id});
+  const mir::LocalId self_id = closure.SelfBinding();
 
-  const mir::LocalId rhs_binding =
-      body.AddLocal(mir::LocalDecl{.name = "_lyra_nba_rhs", .type = rhs_type});
-  captures.emplace_back(
-      mir::Capture{.value = rhs_id_in_outer, .binding = rhs_binding});
-  const mir::ExprId rhs_ref_id = body.AddExpr(
-      mir::Expr{
-          .data =
-              mir::LocalRef{
-                  .hops = mir::BlockHops{.value = 0}, .var = rhs_binding},
-          .type = rhs_type});
+  const mir::ExprId rhs_ref_id =
+      closure.CaptureByValue(rhs_id_in_outer, "_lyra_nba_rhs");
 
   std::uint32_t snapshot_counter = 0;
   const mir::ExprId body_lhs_id = CloneLhsExprForNbaBody(
-      outer_block, body, self_ptr_type, self_id, captures, snapshot_counter,
-      lhs_in_outer);
+      closure, outer_block, self_ptr_type, snapshot_counter, lhs_in_outer);
 
-  // Body-side `self.Services()` for the observable write. Built only inside
-  // the closure body because the outer scope's `self_binding` and depths do
-  // not reach into the body -- the body captures `self` by value at depth 0.
   const mir::ExprId body_self_ref = body.AddExpr(
       mir::Expr{
           .data =
@@ -284,12 +236,7 @@ auto BuildNbaSubmitClosureExpr(
       mir::Stmt{
           .label = std::nullopt, .data = mir::ExprStmt{.expr = assign_id}});
 
-  mir::ClosureExpr closure;
-  closure.captures = std::move(captures);
-  closure.body = std::make_unique<mir::Block>(std::move(body));
-
-  return mir::Expr{
-      .data = std::move(closure), .type = module.Unit().builtins.void_type};
+  return closure.BuildVoid();
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -1,7 +1,6 @@
 #include "lyra/lowering/hir_to_mir/expression/calls.hpp"
 
 #include <expected>
-#include <memory>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -14,8 +13,6 @@
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
-#include "lyra/lowering/hir_to_mir/block_depth.hpp"
-#include "lyra/lowering/hir_to_mir/capture_sink.hpp"
 #include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/closure_builder.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
@@ -33,7 +30,6 @@
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/block_hops.hpp"
-#include "lyra/mir/closure.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/type.hpp"
@@ -273,7 +269,7 @@ auto LowerAssociativeTraversal(
       module.TranslateType(hir_proc.exprs.at(idx_hir).type);
   const mir::TypeId void_t = module.Unit().builtins.void_type;
 
-  ClosureBuilder closure(process.Module().Unit(), frame, result_type);
+  ClosureBuilder closure(process.Module().Unit(), frame);
   mir::Block& body = closure.Body();
   const WalkFrame& closure_frame = closure.Frame();
 
@@ -425,21 +421,19 @@ auto ArrayContainerElementType(const mir::Type& ty) -> mir::TypeId {
       ty.data);
 }
 
-// LRM 7.12.1 / 7.12.2 / 7.12.3 with-clause closure synthesis. The body is a
-// normal expression lowered through `process.LowerExpr`; only the
-// closure-specific leaf behaviour lives elsewhere -- captures via
-// `CaptureSink`, iterator and index resolution via pre-allocated body
-// procedural-var bindings remapped for the iterator HIR id and tracked on
-// the walk frame for the kIndex call. When the source has no `with` clause
-// LRM 7.12.1 defines the default as `with (item)`; this synthesises the
-// identity closure (body returns the iterator binding) so MIR always carries
-// the closure argument and downstream consumers see one uniform shape.
+// LRM 7.12.1 / 7.12.2 / 7.12.3 with-clause closure synthesis. The iterator and
+// index are the closure's two parameters (LRM 7.12.4): the iterator HIR id
+// remaps to the `item` parameter and the index parameter resolves the `kIndex`
+// reference. The body is a normal expression lowered through
+// `process.LowerExpr`. When the source has no `with` clause LRM 7.12.1 defines
+// the default as `with (item)`; this synthesises the identity closure (body
+// returns the iterator binding) so MIR always carries the closure argument and
+// downstream consumers see one uniform shape.
 auto BuildArrayMethodClosure(
     ProcessLowerer& process, WalkFrame frame, hir::TypeId hir_receiver_type,
     const hir::WithClause* with_clause) -> diag::Result<mir::Expr> {
   const auto& module = process.Module();
   const auto& hir_process = process.HirBody();
-  auto& outer_block = *frame.current_block;
   const auto& hir_recv_ty = module.Hir().GetType(hir_receiver_type);
   const auto element_type = ArrayMethodReceiverElementType(hir_recv_ty);
   if (!element_type.has_value()) {
@@ -453,70 +447,35 @@ auto BuildArrayMethodClosure(
           ? hir_process.procedural_vars.at(with_clause->iterator.value).name
           : std::string{"item"};
 
-  const mir::TypeId self_ptr_type = frame.current_class->self_pointer_type;
-  mir::Block body_block;
-  const WalkFrame body_frame = frame.WithBlock(&body_block).Deeper();
-  const BlockDepth body_depth = body_frame.block_depth;
+  ClosureBuilder closure(process.Module().Unit(), frame);
+  const mir::LocalId item_binding = closure.AddParam(iterator_name, item_type);
+  const mir::LocalId index_binding = closure.AddParam("index", index_type);
+  mir::Block& body = closure.Body();
 
-  const mir::LocalId self_binding = body_block.AddLocal(
-      mir::LocalDecl{.name = "self", .type = self_ptr_type});
-  const mir::ExprId outer_self_read =
-      outer_block.AddExpr(BuildSelfRefExpr(frame, self_ptr_type));
-  const mir::LocalId item_binding = body_block.AddLocal(
-      mir::LocalDecl{.name = iterator_name, .type = item_type});
-  const mir::LocalId index_binding =
-      body_block.AddLocal(mir::LocalDecl{.name = "index", .type = index_type});
+  mir::ExprId body_return_value{};
   if (with_clause != nullptr) {
     process.MapProceduralVar(
         with_clause->iterator,
         AutomaticVarBinding{
-            .declaration_procedural_depth = body_depth, .var = item_binding});
-  }
-
-  CaptureSink sink{
-      body_depth, body_block, outer_block, process.Module().Unit()};
-  // A with-clause body is a synchronous predicate / projection closure -- it
-  // never suspends; its trailing `return` renders as a plain `return`.
-  const WalkFrame closure_frame = body_frame.WithCaptureSink(&sink)
-                                      .WithIndexBinding(index_binding)
-                                      .WithSelfBinding(self_binding, body_depth)
-                                      .WithCoroutineBody(false);
-
-  mir::ExprId body_return_value{};
-  mir::TypeId return_type{};
-  if (with_clause != nullptr) {
+            .declaration_procedural_depth = closure.Frame().block_depth,
+            .var = item_binding});
+    // `item.index` (LRM 7.12.4) resolves to the index parameter -- a
+    // with-clause-specific role, so the body lowers through a frame carrying
+    // that binding rather than the builder knowing about it.
     auto body_expr_or = process.LowerExpr(
-        hir_process.exprs.at(with_clause->expr.value), closure_frame);
+        hir_process.exprs.at(with_clause->expr.value),
+        closure.Frame().WithIndexBinding(index_binding));
     if (!body_expr_or) return std::unexpected(std::move(body_expr_or.error()));
-    return_type = body_expr_or->type;
-    body_return_value = body_block.AddExpr(*std::move(body_expr_or));
+    body_return_value = body.AddExpr(*std::move(body_expr_or));
   } else {
-    return_type = item_type;
-    body_return_value = body_block.AddExpr(
+    body_return_value = body.AddExpr(
         mir::Expr{
             .data =
                 mir::LocalRef{
                     .hops = mir::BlockHops{.value = 0}, .var = item_binding},
             .type = item_type});
   }
-  body_block.AppendStmt(
-      mir::Stmt{
-          .label = std::nullopt,
-          .data = mir::ReturnStmt{.value = body_return_value}});
-
-  std::vector<mir::Capture> captures;
-  captures.push_back(
-      mir::Capture{.value = outer_self_read, .binding = self_binding});
-  for (const CaptureRequest& request : sink.TakeRequests()) {
-    captures.push_back(
-        mir::Capture{.value = request.source, .binding = request.binding});
-  }
-  mir::ClosureExpr closure;
-  closure.captures = std::move(captures);
-  closure.params.push_back(mir::Parameter{.binding = item_binding});
-  closure.params.push_back(mir::Parameter{.binding = index_binding});
-  closure.body = std::make_unique<mir::Block>(std::move(body_block));
-  return mir::Expr{.data = std::move(closure), .type = return_type};
+  return closure.Build(body_return_value);
 }
 
 // Fans out a system-subroutine call to the per-family handler under

--- a/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
@@ -203,7 +203,7 @@ auto LowerScanSystemSubroutineCall(
   // LRM 21.3.4.3: the call is an IIFE -- a synchronous closure invoked at once.
   // The body parses into procedural-local temps, conditionally writes them back
   // to the output lvalues, and yields the matched-conversion count.
-  ClosureBuilder closure(process.Module().Unit(), frame, integer_t);
+  ClosureBuilder closure(process.Module().Unit(), frame);
   mir::Block& body = closure.Body();
   const WalkFrame& closure_frame = closure.Frame();
 

--- a/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
@@ -1,7 +1,6 @@
 #include "lyra/lowering/hir_to_mir/statement/fork_join.hpp"
 
 #include <expected>
-#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
@@ -10,13 +9,9 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
-#include "lyra/lowering/hir_to_mir/capture_sink.hpp"
+#include "lyra/lowering/hir_to_mir/closure_builder.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
-#include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
-#include "lyra/mir/closure.hpp"
-#include "lyra/mir/compilation_unit.hpp"
-#include "lyra/mir/expr.hpp"
 #include "lyra/mir/stmt.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -37,13 +32,10 @@ auto LowerJoinMode(hir::JoinMode mode) -> mir::JoinMode {
 
 }  // namespace
 
-// LRM 9.3.2: a fork is a block. Its block_item_declarations lower
-// into that block and initialize at block entry -- in the parent, before any
-// branch spawns. Each branch lowers to a coroutine-typed closure composed into
-// the fork scope's expr arena. The capture sink collects every enclosing
-// reference the body makes; a fork-scope-local snapshots by value, a
-// deeper-declared enclosing variable aliases the live cell by reference (LRM
-// 6.21). The receiver `self` is the closure's first by-value capture.
+// LRM 9.3.2: a fork is a block whose block_item_declarations lower into that
+// block and initialize at block entry -- in the parent, before any branch
+// spawns. Each branch lowers to a coroutine closure composed into the fork
+// block's expr arena.
 auto LowerForkStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::ForkStmt& f) -> diag::Result<mir::Stmt> {
@@ -63,52 +55,21 @@ auto LowerForkStmt(
 
   std::vector<mir::ExprId> branches;
   branches.reserve(f.branches.size());
-  const mir::TypeId self_ptr_type = frame.current_class->self_pointer_type;
   for (const hir::StmtId branch_hir_id : f.branches) {
     const hir::Stmt& branch = hir_proc.stmts.at(branch_hir_id.value);
-    mir::Block branch_block;
-
-    const mir::LocalId branch_self_id = branch_block.AddLocal(
-        mir::LocalDecl{.name = "self", .type = self_ptr_type});
-    const mir::ExprId outer_self_read =
-        fork_block.AddExpr(BuildSelfRefExpr(fork_frame, self_ptr_type));
-
-    // A fork-scope local is snapshotted by value; a deeper enclosing variable
-    // aliases through a reference capture (LRM 6.21).
-    CaptureSink sink{
-        fork_frame.block_depth.Inner(), branch_block, fork_block,
-        process.Module().Unit(), fork_depth};
     // LRM 9.3.2: a branch is a concurrent thread whose body may suspend on
-    // timing controls / event waits, so it lowers as a coroutine body --
-    // returns inside it become `co_return`.
-    const WalkFrame branch_frame =
-        fork_frame.WithCaptureSink(&sink)
-            .WithBlock(&branch_block)
-            .WithSelfBinding(branch_self_id, fork_frame.block_depth.Inner())
-            .WithCoroutineBody(true)
-            .Deeper();
-    auto lowered = process.LowerStmt(branch, branch_frame);
+    // timing controls / event waits, so it lowers as a coroutine closure --
+    // returns inside it become `co_return`. A fork-scope local is snapshotted
+    // by value (the `fork_depth` boundary); a deeper enclosing variable aliases
+    // the live cell through a reference capture (LRM 6.21).
+    ClosureBuilder closure(
+        process.Module().Unit(), fork_frame, true, fork_depth);
+    auto lowered = process.LowerStmt(branch, closure.Frame());
     if (!lowered) {
       return std::unexpected(std::move(lowered.error()));
     }
-    branch_block.AppendStmt(*std::move(lowered));
-    branch_block.AppendStmt(
-        mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
-
-    std::vector<mir::Capture> captures;
-    captures.push_back(
-        mir::Capture{.value = outer_self_read, .binding = branch_self_id});
-    for (const CaptureRequest& request : sink.TakeRequests()) {
-      captures.push_back(
-          mir::Capture{.value = request.source, .binding = request.binding});
-    }
-    mir::ClosureExpr closure;
-    closure.captures = std::move(captures);
-    closure.body = std::make_unique<mir::Block>(std::move(branch_block));
-    branches.push_back(fork_block.AddExpr(
-        mir::Expr{
-            .data = std::move(closure),
-            .type = process.Module().Unit().builtins.coroutine}));
+    closure.Body().AppendStmt(*std::move(lowered));
+    branches.push_back(fork_block.AddExpr(closure.BuildCoroutine()));
   }
 
   const mir::BlockId scope_id =


### PR DESCRIPTION
## Summary

Every closure-construction site in HIR-to-MIR now goes through the one `ClosureBuilder`, so `mir::ClosureExpr` is constructed in exactly one place. The fork-join branch, with-clause iterator, non-blocking-assignment submit, and deferred-assertion check each used to inline their own body-scope / `self` capture / capture-sink / capture-assembly scaffolding; they now fill a builder and call a terminal. This closes R31.

The builder generalizes over the axes those sites need: a coroutine result (a fork branch yields the coroutine type via a `co_return` terminal), a by-value capture depth (a fork-scope local snapshots, a deeper enclosing variable aliases the live cell), per-invocation parameters, manual by-value captures (the NBA submit and deferred check author their bodies by hand and so use no sink), and three terminals -- a value `return`, a `co_return`, and a bare void body. The result type left the constructor: a synchronous terminal derives it from the result expression, since a closure's result type is just its returned value's type.

## Design

The builder carries only concepts true of every closure. `self` is always injected because lowering any member access in the body needs `frame.self_binding` set to a captured `self`, and establishing that is inseparable from handing out a usable `Frame()`. Conversely the with-clause index is a plain parameter (`AddParam`); the with-clause-specific role of being what `item.index` resolves to (LRM 7.12.4) lives in the with-clause caller, which decorates the frame it lowers through rather than the builder knowing about it.

Two body-authoring modes coexist through the shared `self` capture and final assembly: a site either lowers HIR through the builder's frame (the sink turns enclosing-variable reads into snapshot-or-alias captures per their declaration depth) or hand-snapshots specific outer expressions by value. Alias captures still flow exclusively through the sink, which interns the reference type -- which is why closure construction takes a mutable `CompilationUnit`.

## Testing

`bazel test //...` -- all four test targets pass, including `cpp_tests` (emit + build + run of the generated C++).