### PR TITLE
Support non-integral value-change observability

### DIFF
--- a/docs/decisions/unpacked-array-representation.md
+++ b/docs/decisions/unpacked-array-representation.md
@@ -202,9 +202,9 @@ Out of scope but unblocked by this design:
 
 - Variable-size container types (dynamic array, queue, associative array). They share the wrapper's
   `std::vector` storage spine and extend it with size-mutation semantics.
-- Element-level observability for whole-array `Var<>` wrapping. The wrapper's `operator==` already
-  returns a 1-bit `PackedArray` (X / Z propagating); observability sits on the same surface when
-  `refactor.md` R2 lands.
+- Whole-array `Var<UnpackedArray<T>>` wrapping is in place and an unpacked signal reacts under
+  `wait` / `always_comb` / `@*` (the wrapper's `IsBitIdentical` drives any-change detection); a
+  non-integral input port is admitted too. See `refactor.md` R2.
 
 ## Alternatives considered
 

--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -232,6 +232,6 @@ the lookup key and imposes an ordering.
 - Decision: `../decisions/runtime-shape-and-default-value.md` -- runtime shape is retained on
   `PackedArray`; collection wrappers carry one `oob_slot_` member that doubles as canonical-default
   source and OOB-write discard target, reset via `T::ResetToDefault` on every OOB access.
-- Cross-cutting: `refactor.md` R2 -- value-typed structural fields uniformly wrapped for
-  observability (the U8 analogue for these container types once they participate in event control,
-  level-sensitive `wait`, `always_comb`, or continuous assignment).
+- Cross-cutting: `refactor.md` R2 (done) -- these container value types are observable cells and
+  react under `wait` / `always_comb` / `@*`, and a non-integral input port is admitted (the U8
+  analogue for these containers).

--- a/docs/progress/datatypes.md
+++ b/docs/progress/datatypes.md
@@ -52,11 +52,11 @@ LRM 6.12: `real` is IEEE 754 double, `shortreal` is IEEE 754 single, `realtime` 
 - [x] C4 -- LRM-illegal real forms (LRM 6.12 + 11.3.1 / Table 11-1) diagnose as `diag::Unsupported`
       with an LRM citation. Slang's frontend filters all but case equality (`===` / `!==`); the
       case-equality path is guarded at lowering.
-- [ ] C5 -- Observable storage for module-scope `real` / `shortreal` / `realtime` signals. Today a
-      module-scope floating-point variable lowers to plain value storage rather than an observable
-      cell, so `@(sig)`, `wait (sig == ...)`, and non-blocking writes do not propagate change events
-      for it. Blocked on first-class runtime support for the floating-point value family; once that
-      lands the observable-storage gate extends uniformly with no further special-casing.
+- [x] C5 -- Observable `real` / `shortreal` / `realtime` signals. A module-scope floating-point
+      signal is an observable cell (`Var<Real>`): `wait (sig == ...)`, `always_comb` / `@*` reads,
+      continuous assignment, non-blocking writes, and the explicit any-change `@(sig)` event control
+      all propagate change events. An edge form (`@(posedge sig)`) stays frontend-rejected per LRM
+      9.4.2 (an edge requires an integral LSB).
 
 ### Cross-references
 

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -26,27 +26,31 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       canonical builtin TypeIds; at that point the per-consumer copy temptation is the smell that
       forces this move.
 
-- [ ] R2 -- Realign the `Var<T>` wrapping gate so the cpp backend stops mixing structural type
-      classification with runtime-capability gating. Today `IsObservableScalarType` returns true
-      only for `IsIntegralPacked()` and the backend uses it to silently skip the wrapper for every
-      other value type (`string`, `real`, unpacked array). The two questions it tangles together --
-      "should this field semantically be a value slot at all (vs an object / sub-hierarchy)?" and
-      "does the runtime currently support change-tracking for this T?" -- have different homes: the
-      first is an intrinsic MIR type classification (value family vs object family); the second is a
-      runtime capability gap that should manifest as an explicit `kUnsupported...` diagnostic at the
-      AST -> HIR / HIR -> MIR sensitivity-lowering sites when a `@(...)`, `wait`, or `always_comb`
-      sensitivity references a type whose `Var<T>` specialization does not yet exist. Target shape:
-      backend wraps every value-typed field uniformly in `Var<T>`, leaving object- family fields
-      plain; runtime grows minimal `Var<String>` / `Var<double>` / `Var<vector<T>>` specializations
-      (storage + assign at first, waiter paths throw `kUnsupportedFeature` until filled in); AST ->
-      HIR rejects the unsupported sensitivity uses upstream with a source span. The backend then
-      becomes a pure renderer, never asking a capability question. **Why deferred**: backend
-      currently sidesteps the issue silently and the sensitivity rejection at AST -> HIR for
-      non-integral leaves already keeps things consistent in practice; the proper fix touches
-      runtime, sensitivity lowering, and backend rendering together. **Trigger**: when the first
-      non-integral runtime change-tracking surface lands (named-event subscription, string
-      `wait (s == "x")`, real value-change detection) -- at that moment the `IsObservableScalarType`
-      shortcut becomes actively wrong and the layering fix has to happen alongside.
+- [x] R2 -- Non-integral value-change observability. The wrapping-gate realignment this entry
+      originally described had already landed under R12: observable storage is a first-class
+      `mir::ObservableType` (R12), `Var<T>` gates on the `LyraValue` concept rather than an
+      integral-packed predicate (`decisions/value-type-concepts.md`), `IsObservableScalarType` is
+      gone, and the runtime cell is uniformly generic over every value type (`PackedArray`,
+      `String`, `Real`, `UnpackedArray<T>`, `DynamicArray<T>`, `Queue<T>`, `AssociativeArray<K,V>`).
+      As a direct consequence of that generality, every implicit value-change construct --
+      `always_comb` / `always_latch`, `@*`, `wait`, and continuous assignment -- already subscribes
+      to and wakes on any value type with no per-type code: the change-detection hook is each type's
+      `IsBitIdentical`, and a non-`PackedArray` cell fires its any-change waiters on every real
+      change. The minimal `Var<String>` / `Var<double>` / `Var<vector<T>>` specializations this
+      entry once anticipated were never needed (the single generic template covers all), and the
+      "reject unsupported sensitivity uses at lowering" half proved unnecessary too -- the slang
+      frontend already rejects every LRM-illegal value-change event source: an edge qualifier on a
+      non-integral operand and an aggregate (non-singular) event expression both fail frontend
+      binding (LRM 9.4.2, "event expressions shall return singular values"). The work was the
+      inverse of the original framing -- two frontend lowering gates were over-broad and rejected
+      forms the architecture and the LRM both allow. Both are now lifted: the `@(expr)`
+      event-control path admits any value-change-observable operand as an any-change event (the
+      legal `@(string)` / `@(real)` / `@(enum)`) while still requiring a packed bit-vector for an
+      edge (the runtime classifies an edge only on a `PackedArray` cell), and the
+      input-port-connection path admits any value type (the driver rides the generic
+      continuous-assign path). `hir::Type::IsValueChangeObservable` is the single HIR-level
+      predicate both gates share. A value-type x construct coverage matrix backs it (`@`, `wait`,
+      `always_comb`, `@*`, continuous assignment, input port over string / real / enum / unpacked).
 
 - [x] R3 -- Collapse the runtime's dual hierarchy into a single object tree. The mirrored
       `RuntimeScope` tree and the bind-time `RuntimeBindContext` are gone; there is now one runtime
@@ -182,9 +186,8 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       value/storage duality -- a signal is read as a value but its cell is the target of a write or
       a reference binding -- is carried by which call wraps the cell, not by a render-time branch.
       The backend's `IsObservableScalarType` predicate is gone. See
-      `docs/decisions/value-type-concepts.md`. R2 still reworks the same observable surface from the
-      capability-gating angle (wrap every value type uniformly, push unsupported change-tracking to
-      explicit diagnostics).
+      `docs/decisions/value-type-concepts.md`. The uniform wrapping this entry set up is what makes
+      R2's residual small -- only two over-broad frontend event-source gates remain.
 
 - [x] R13 -- HIR-to-MIR per-LRM-family subsystem split. Per-kind handlers are now grouped by
       semantic family in
@@ -533,6 +536,40 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       the scope builder (it does the `AddExpr`, with the context argument first); a type-producing
       variant is `Make<X>Type(...) -> TypeId`. Audit every construction helper and rename it to the
       correct side. **Trigger**: standalone naming cleanup.
+
+- [ ] R33 -- Remove the redundant `UnsupportedCategory` argument from the `diag::Unsupported`
+      factory. The category is already declared once per `DiagCode` in the code table; the factory
+      additionally takes a `cat` argument, stores it, and cross-checks it against the table,
+      throwing an `InternalError` on mismatch. A call site that passes the wrong category therefore
+      _crashes_ on the unsupported path instead of emitting the clean diagnostic it intended -- a
+      latent landmine on every untested rejection. Eleven such drifts were found and corrected
+      pointwise, but the design keeps re-arming the class: the call-site category is a second source
+      of truth that can diverge. Target shape: the factory derives
+      `category = DiagCodeCategory(code)` from the table alone, the `cat` parameter and the
+      `RequireCategory` check are deleted, and the ~96 call sites drop their trailing category
+      argument. This is the universal diagnostic-metadata shape -- Clang keys severity / group to
+      the diagnostic id through TableGen records, Roslyn through a `DiagnosticDescriptor`, rustc
+      through the diagnostic's own level: metadata is a property of the id, derived at emit, never
+      re-supplied at the report site. The `diag_code.cpp` table already is that registry; the only
+      flaw is the factory re-takes a value it should read. The same shape applies to the sibling
+      `RequireKind` guard, which should fold in. The load-bearing principle: diagnostic construction
+      is the graceful-degradation path and must be infallible -- it must never throw, least of all
+      on the rarely-exercised unsupported branches. **Trigger**: standalone; mechanical sweep across
+      every lowering file, so it lands as its own cut.
+
+- [ ] R34 -- Unify the procedural and structural HIR expression-lowering paths. AST-to-HIR carries
+      parallel `Lower<Kind>ExprProc` / `Lower<Kind>ExprStructural` handlers that build the same HIR
+      node but guard their accepted operand types independently, so the two drift: the structural
+      element-select rejected an unpacked base the procedural one accepted (now aligned), and a
+      string element-select's getc realization (LRM 6.16.3) lives only on the procedural HIR-to-MIR
+      path, so a structural `assign b = s[i]` lowers to a non-existent `String::Element` instead of
+      `getc`. The realization a node needs (getc for a string base, element access for an array) is
+      a property of the node, not of the procedural-vs-structural origin. Target shape: one
+      select/member lowering shared across scopes, with the value realizations applied uniformly in
+      HIR-to-MIR regardless of origin -- after which a string element read works in a continuous
+      assignment exactly as it does in a process. **Trigger**: when a structural-context string /
+      aggregate element read is needed, or the next time a per-kind guard drifts between the two
+      paths.
 
 ## Out of Scope
 

--- a/docs/progress/unpacked.md
+++ b/docs/progress/unpacked.md
@@ -13,8 +13,7 @@ Done when:
 
 ## Actionable
 
-U1..U7 are done. U8 records a cross-cutting observability gap surfaced by the unpacked-vs-packed
-asymmetry; the implementation lives under `refactor.md` R2. U9 (array manipulation) is done.
+U1..U9 are done. U8 (value-change observability) closed alongside `refactor.md` R2.
 
 | Item | Status                                                         |
 | ---- | -------------------------------------------------------------- |
@@ -25,7 +24,7 @@ asymmetry; the implementation lives under `refactor.md` R2. U9 (array manipulati
 | U5   | Done: array equality, inequality, case-equality                |
 | U6   | Done: constant-width slice (read and write)                    |
 | U7   | Done: invalid-index handling and non-canonical declared ranges |
-| U8   | Open: unpacked vars participate in value-change observability  |
+| U8   | Done: unpacked vars participate in value-change observability  |
 | U9   | Done: array manipulation methods (LRM 7.12)                    |
 
 ## Sub-Steps
@@ -96,15 +95,15 @@ The numeric IDs are stable references and do not imply execution order beyond U1
 
 ### Observability
 
-- [ ] U8 -- Unpacked structural variables participate in value-change observability. Today an
-      unpacked-typed structural variable does not expose the value-change channel that packed
-      scalars use, so any construct that needs to react to a write on one -- event control (`@arr`,
-      `@(arr[i])`), level-sensitive `wait` reading an unpacked operand, always_comb / `@*` reading
-      an unpacked operand, continuous assignment with an unpacked source -- silently misses writes
-      or is rejected at the sensitivity-lowering boundary. The fix is cross-cutting (it also affects
-      strings, reals, and other non-integral value types) and is owned by `refactor.md` R2; this
-      item exists for visibility from the unpacked workstream. Triggered when a concrete consumer
-      needs the capability.
+- [x] U8 -- Unpacked structural variables participate in value-change observability. They are
+      observable cells (`Var<UnpackedArray<T>>`), so always_comb / `@*` / level-sensitive `wait`
+      reading an unpacked operand react to writes (a whole-array or element write fires the cell's
+      any-change waiters), and a non-integral input port drives an unpacked child cell through the
+      generic continuous-assign path. `@(arr)` on a whole unpacked array is frontend-rejected as a
+      non-singular event expression (LRM 9.4.2); `@(arr[i])` on an element rides the shared
+      value-change event-control path. (Selecting an unpacked element on the right-hand side of a
+      _structural_ continuous assignment is a separate structural-expression limitation, unrelated
+      to observability.)
 
 ### Array manipulation methods
 
@@ -127,8 +126,8 @@ The numeric IDs are stable references and do not imply execution order beyond U1
 - Archive items: `datatypes/unpacked/{unpacked_arrays, unpacked_array_constants}`, the unpacked
   subset of `oob_bounds`.
 - Decision: `../decisions/unpacked-array-representation.md`.
-- Cross-cutting: `refactor.md` R2 -- value-typed structural fields uniformly wrapped for
-  observability (U8).
+- Cross-cutting: `refactor.md` R2 (done) -- unpacked fields are observable cells and react under
+  `wait` / `always_comb` / `@*`, and a non-integral input port is admitted (U8).
 - Unblocks: `control-flow.md` C9 / C10 (`foreach` over unpacked).
 - `display.md` DI7 (`%p` assignment-pattern format) delivered alongside this workstream and powers
   the test framework's whole-array `expect.variables` assertion path; init / pattern / whole-assign

--- a/docs/progress/unpacked.md
+++ b/docs/progress/unpacked.md
@@ -96,14 +96,14 @@ The numeric IDs are stable references and do not imply execution order beyond U1
 ### Observability
 
 - [x] U8 -- Unpacked structural variables participate in value-change observability. They are
-      observable cells (`Var<UnpackedArray<T>>`), so always_comb / `@*` / level-sensitive `wait`
+      observable cells (`Var<UnpackedArray<T>>`), so `always_comb` / `@*` / level-sensitive `wait`
       reading an unpacked operand react to writes (a whole-array or element write fires the cell's
       any-change waiters), and a non-integral input port drives an unpacked child cell through the
       generic continuous-assign path. `@(arr)` on a whole unpacked array is frontend-rejected as a
       non-singular event expression (LRM 9.4.2); `@(arr[i])` on an element rides the shared
       value-change event-control path. (Selecting an unpacked element on the right-hand side of a
-      _structural_ continuous assignment is a separate structural-expression limitation, unrelated
-      to observability.)
+      structural continuous assignment is a separate structural-expression limitation, unrelated to
+      observability.)
 
 ### Array manipulation methods
 

--- a/include/lyra/hir/type.hpp
+++ b/include/lyra/hir/type.hpp
@@ -159,6 +159,10 @@ struct Type {
   [[nodiscard]] auto AsPackedUnion() const -> const PackedUnionType&;
   [[nodiscard]] auto IsEnum() const -> bool;
   [[nodiscard]] auto AsEnum() const -> const EnumType&;
+
+  // True for the value types -- those a value-change event can react to (LRM
+  // 9.4.2). A handle / event / void is not a value and drives no such event.
+  [[nodiscard]] auto IsValueChangeObservable() const -> bool;
 };
 
 }  // namespace lyra::hir

--- a/src/lyra/hir/type.cpp
+++ b/src/lyra/hir/type.cpp
@@ -136,6 +136,29 @@ auto Type::AsPackedUnion() const -> const PackedUnionType& {
   throw InternalError("Type::AsPackedUnion called on non-packed-union type");
 }
 
+auto Type::IsValueChangeObservable() const -> bool {
+  switch (Kind()) {
+    case TypeKind::kPackedArray:
+    case TypeKind::kPackedStruct:
+    case TypeKind::kPackedUnion:
+    case TypeKind::kEnum:
+    case TypeKind::kUnpackedArray:
+    case TypeKind::kDynamicArray:
+    case TypeKind::kQueue:
+    case TypeKind::kAssociativeArray:
+    case TypeKind::kString:
+    case TypeKind::kReal:
+    case TypeKind::kShortReal:
+    case TypeKind::kRealTime:
+      return true;
+    case TypeKind::kEvent:
+    case TypeKind::kChandle:
+    case TypeKind::kVoid:
+      return false;
+  }
+  return false;
+}
+
 auto Type::IsEnum() const -> bool {
   return std::holds_alternative<EnumType>(data);
 }

--- a/src/lyra/lowering/ast_to_hir/constant_value.cpp
+++ b/src/lyra/lowering/ast_to_hir/constant_value.cpp
@@ -41,7 +41,7 @@ auto MakeConstantValueExpr(
   return diag::Unsupported(
       span, diag::DiagCode::kUnsupportedExpressionForm,
       "constant of aggregate type is not yet supported",
-      diag::UnsupportedCategory::kFeature);
+      diag::UnsupportedCategory::kOperation);
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
@@ -183,7 +183,7 @@ auto LowerConcatExprStructural(
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
         "concatenation result type is neither string nor packed (LRM 11.4.12)",
-        diag::UnsupportedCategory::kOperation);
+        diag::UnsupportedCategory::kFeature);
   }
   std::vector<hir::ExprId> operand_ids;
   operand_ids.reserve(cc.operands().size());

--- a/src/lyra/lowering/ast_to_hir/expression/inside.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/inside.cpp
@@ -51,7 +51,7 @@ auto LowerInsideItemImpl(
           module.SourceMapper().SpanOf(vr.sourceRange),
           diag::DiagCode::kUnsupportedExpressionForm,
           "tolerance-range form in inside operator is not yet supported",
-          diag::UnsupportedCategory::kFeature);
+          diag::UnsupportedCategory::kOperation);
     }
     auto lo_or = proc.LowerExpr(vr.left(), frame);
     if (!lo_or) return std::unexpected(std::move(lo_or.error()));

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -322,7 +322,7 @@ auto LowerStructuralExpr(
             span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
             "increment / decrement is not legal outside procedural code "
             "(LRM 11.3.6, 11.4.2)",
-            diag::UnsupportedCategory::kOperation);
+            diag::UnsupportedCategory::kFeature);
       }
       return LowerUnaryExprStructural(scope, frame, un, span);
     }

--- a/src/lyra/lowering/ast_to_hir/expression/operators.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/operators.cpp
@@ -159,13 +159,13 @@ auto LowerConditionalExprProc(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "conditional operator with `&&&` multi-condition is not yet "
         "supported",
-        diag::UnsupportedCategory::kFeature);
+        diag::UnsupportedCategory::kOperation);
   }
   if (cond.conditions[0].pattern != nullptr) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "conditional operator with `matches` pattern is not yet supported",
-        diag::UnsupportedCategory::kFeature);
+        diag::UnsupportedCategory::kOperation);
   }
   auto cond_or = proc.LowerExpr(*cond.conditions[0].expr, frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -154,13 +154,13 @@ auto LowerMemberAccessExprProc(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::MemberAccessExpression& sel, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  const auto* field = &sel.member.as<slang::ast::FieldSymbol>();
   if (sel.member.kind != slang::ast::SymbolKind::Field) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "member access target is not a struct field",
         diag::UnsupportedCategory::kOperation);
   }
+  const auto* field = &sel.member.as<slang::ast::FieldSymbol>();
   auto base_or = proc.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const hir::ExprId base_id =
@@ -182,11 +182,15 @@ auto LowerElementSelectExprStructural(
     StructuralScopeLowerer& scope, WalkFrame frame,
     const slang::ast::ElementSelectExpression& sel, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  if (!sel.value().type->isIntegral()) {
+  // A string element-select needs the getc realization, which the structural
+  // expression path does not yet carry (LRM 6.16.3); only integral and unpacked
+  // bases lower here.
+  if (!sel.value().type->isIntegral() && !sel.value().type->isUnpackedArray()) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
-        "element-select on non-integral operand is not yet supported",
-        diag::UnsupportedCategory::kOperation);
+        "element-select on this operand is not yet supported outside "
+        "procedural code",
+        diag::UnsupportedCategory::kFeature);
   }
   auto base_or = scope.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
@@ -214,7 +218,7 @@ auto LowerRangeSelectExprStructural(
         span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
         "range-select on non-integral, non-unpacked operand is not yet "
         "supported",
-        diag::UnsupportedCategory::kOperation);
+        diag::UnsupportedCategory::kFeature);
   }
   auto base_or = scope.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
@@ -262,7 +266,7 @@ auto LowerMemberAccessExprStructural(
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
         "member access target is not a struct field",
-        diag::UnsupportedCategory::kOperation);
+        diag::UnsupportedCategory::kFeature);
   }
   const auto& field = sel.member.as<slang::ast::FieldSymbol>();
   auto base_or = scope.LowerExpr(sel.value(), frame);

--- a/src/lyra/lowering/ast_to_hir/port_connection.cpp
+++ b/src/lyra/lowering/ast_to_hir/port_connection.cpp
@@ -93,9 +93,12 @@ auto PopulateInstancePortConnections(
           "port not bound to a connectable variable is not yet supported");
     }
     const auto& port_type = port.getType();
-    if (!port_type.isIntegral()) {
+    auto type_id = module.InternType(port_type, span);
+    if (!type_id) return std::unexpected(std::move(type_id.error()));
+    if (!module.Unit().GetType(*type_id).IsValueChangeObservable()) {
       return PortConnectionUnsupported(
-          span, "non-integral port connection is not yet supported");
+          span,
+          "port connection of a handle / event type is not yet supported");
     }
     const auto* expr = conn->getExpression();
     if (expr == nullptr) {
@@ -105,8 +108,6 @@ auto PopulateInstancePortConnections(
       continue;
     }
 
-    auto type_id = module.InternType(port_type, span);
-    if (!type_id) return std::unexpected(std::move(type_id.error()));
     hir::Expr child_ref = module.MakeCrossUnitMemberRef(
         *internal, binding->home_frame, binding->head,
         {hir::MemberHop{std::string{internal->name}}}, *type_id, span);

--- a/src/lyra/lowering/ast_to_hir/statement/timing.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/timing.cpp
@@ -48,11 +48,21 @@ auto LowerSignalEventTrigger(
   auto expr_or = proc.LowerExpr(sig.expr, frame);
   if (!expr_or) return std::unexpected(std::move(expr_or.error()));
 
-  if (!proc.Module().Unit().GetType(expr_or->type).IsPackedArray()) {
+  const auto& expr_type = proc.Module().Unit().GetType(expr_or->type);
+  if (sig.edge != slang::ast::EdgeKind::None) {
+    // The runtime classifies an edge only on a packed bit-vector cell (LRM
+    // 9.4.2 Table 9-2); slang already restricts an edge to an integral operand.
+    if (!expr_type.IsPackedArray()) {
+      return diag::Unsupported(
+          span, diag::DiagCode::kUnsupportedEventTriggerForm,
+          "edge event control is only supported on a packed bit-vector operand",
+          diag::UnsupportedCategory::kFeature);
+    }
+  } else if (!expr_type.IsValueChangeObservable()) {
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedEventTriggerForm,
-        "event trigger expression must have an integral type; non-integral "
-        "trigger types are not yet supported",
+        "value-change event control on a non-value operand is not yet "
+        "supported",
         diag::UnsupportedCategory::kFeature);
   }
 

--- a/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
@@ -58,13 +58,13 @@ auto LowerFinishSystemSubroutineCall(
           std::format(
               "{} argument must be an integer literal in this build",
               std::string{name}),
-          diag::UnsupportedCategory::kFeature);
+          diag::UnsupportedCategory::kOperation);
     }
     if (*literal != 0 && *literal != 1 && *literal != 2) {
       return diag::Unsupported(
           span, diag::DiagCode::kUnsupportedExpressionForm,
           std::format("{} argument must be 0, 1, or 2", std::string{name}),
-          diag::UnsupportedCategory::kFeature);
+          diag::UnsupportedCategory::kOperation);
     }
     level = static_cast<int>(*literal);
   }

--- a/tests/cases/cpp/continuous_assign_unpacked_element/case.yaml
+++ b/tests/cases/cpp/continuous_assign_unpacked_element/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.continuous_assign_unpacked_element
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    usum: 14

--- a/tests/cases/cpp/continuous_assign_unpacked_element/main.sv
+++ b/tests/cases/cpp/continuous_assign_unpacked_element/main.sv
@@ -1,0 +1,14 @@
+// A continuous assignment whose right-hand side selects an unpacked-array
+// element (LRM 7.4.5 in a structural context, LRM 10.3).
+module Top;
+  int ua[2];
+  int usum;
+  assign usum = ua[0] + ua[1];
+
+  initial begin
+    ua[0] = 3;
+    ua[1] = 4;
+    #5;
+    ua[0] = 10;
+  end
+endmodule

--- a/tests/cases/cpp/event_value_change_nonintegral/case.yaml
+++ b/tests/cases/cpp/event_value_change_nonintegral/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.event_value_change_nonintegral
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    sw: 1
+    rw: 1
+    cw: 1

--- a/tests/cases/cpp/event_value_change_nonintegral/main.sv
+++ b/tests/cases/cpp/event_value_change_nonintegral/main.sv
@@ -1,0 +1,38 @@
+// LRM 9.4.2: `@(expr)` with no edge is any-change on a singular value cell --
+// legal for string / real / enum, not only packed bit vectors.
+typedef enum logic [1:0] { RED, GRN, BLU } col_t;
+
+module Top;
+  string s;
+  real r;
+  col_t c;
+  int sw, rw, cw;
+
+  initial begin
+    s = "x";
+    sw = 0;
+    @(s);
+    sw = 1;
+  end
+
+  initial begin
+    r = 0.0;
+    rw = 0;
+    @(r);
+    rw = 1;
+  end
+
+  initial begin
+    c = RED;
+    cw = 0;
+    @(c);
+    cw = 1;
+  end
+
+  initial begin
+    #5;
+    s = "y";
+    r = 1.0;
+    c = BLU;
+  end
+endmodule

--- a/tests/cases/cpp/implicit_sensitivity_nonintegral/case.yaml
+++ b/tests/cases/cpp/implicit_sensitivity_nonintegral/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.implicit_sensitivity_nonintegral
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    clen: 6
+    rflag: 1
+    wgot: 1
+    ds2: "high"
+    usum: 12

--- a/tests/cases/cpp/implicit_sensitivity_nonintegral/main.sv
+++ b/tests/cases/cpp/implicit_sensitivity_nonintegral/main.sv
@@ -1,0 +1,42 @@
+// always_comb / `@*` / `wait` / continuous-assign derive sensitivity from the
+// read set, which covers any value type -- each reacts to a non-integral write.
+module Top;
+  string cs;
+  int clen;
+  always_comb clen = cs.len();
+
+  real rs;
+  int rflag;
+  always @* rflag = (rs > 2.0) ? 1 : 0;
+
+  string ws;
+  int wgot;
+  initial begin
+    ws = "no";
+    wgot = 0;
+    wait (ws == "go");
+    wgot = 1;
+  end
+
+  string ds;
+  string ds2;
+  assign ds2 = ds;
+
+  int ua[2];
+  int usum;
+  always_comb usum = ua[0] + ua[1];
+
+  initial begin
+    cs = "ab";
+    rs = 0.0;
+    ds = "lo";
+    ua[0] = 1;
+    ua[1] = 2;
+    #5;
+    cs = "abcdef";
+    rs = 5.0;
+    ws = "go";
+    ds = "high";
+    ua[0] = 10;
+  end
+endmodule

--- a/tests/cases/cpp/port_nonintegral/case.yaml
+++ b/tests/cases/cpp/port_nonintegral/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.port_nonintegral
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "len=5\n"

--- a/tests/cases/cpp/port_nonintegral/main.sv
+++ b/tests/cases/cpp/port_nonintegral/main.sv
@@ -1,0 +1,19 @@
+// A non-integral input port (here a string) drives the child cell like an
+// integral one (LRM 23.3.3).
+module Child(input string label, output int outlen);
+  always_comb outlen = label.len();
+endmodule
+
+module Top;
+  string s;
+  int len;
+  Child u(.label(s), .outlen(len));
+
+  initial begin
+    s = "hi";
+    #5;
+    s = "hello";
+  end
+
+  final $display("len=%0d", len);
+endmodule


### PR DESCRIPTION
## Summary

String, real, enum, and the aggregate value types are already observable cells at the runtime level, and the implicit value-change constructs (`always_comb` / `always_latch`, `@*`, level-sensitive `wait`, continuous assignment) already subscribe to and wake on any value type with no per-type code. Two frontend lowering gates were over-broad and rejected forms the architecture and the LRM both allow: the `@(expr)` event-control path rejected any non-integral operand, and the input-port-connection path rejected any non-integral port. This lifts both. `@(string)` / `@(real)` / `@(enum)` now subscribe as any-change events while an edge qualifier still requires a packed bit-vector (the runtime classifies an edge only on a `PackedArray` cell), and a non-integral input port drives the child cell through the generic continuous-assign path. A new `hir::Type::IsValueChangeObservable` predicate is the single HIR-level classification both gates share. This closes `refactor.md` R2, `datatypes.md` C5 (observable real), and `unpacked.md` U8.

## Design

slang already rejects every LRM-illegal value-change event source upstream -- an edge on a non-integral operand and an aggregate (non-singular) event expression both fail frontend binding (LRM 9.4.2) -- so the gates only needed to stop rejecting the legal non-integral cases, not add new rejection logic. The two reachable feature gaps remain honest `diag::Unsupported` diagnostics rather than crashes: an edge on an integral-but-not-packed operand (enum / packed struct) and a value-change event on a handle.

While verifying the gates, the diagnostic factory was found to crash on several unsupported paths: `diag::Unsupported` takes an `UnsupportedCategory` argument that must equal the category declared for the code in the table, and cross-checks it at runtime, throwing `InternalError` on mismatch. Eleven call sites had drifted and would crash on their unsupported branch instead of reporting cleanly; all are aligned here. The root design flaw -- the category is a property of the code and should not be re-supplied at the call site -- is tracked as R33, and the procedural-vs-structural lowering duplication surfaced alongside is tracked as R34. As a contained instance of R34, an unpacked element-select is now accepted on the right-hand side of a structural continuous assignment.

## Testing

New end-to-end cases cover the matrix: `@(string/real/enum)` any-change wake, the implicit constructs reading string / real / unpacked operands, a non-integral input port, and a continuous assignment selecting an unpacked element. Full `bazel test //...` passes.