### PR TITLE
Refresh decision and refactor docs after R29 lands

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -37,8 +37,9 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
 - [queue-operators](queue-operators.md) -- queue access operators (`$`, slice, concatenation,
   equality, append) lower to built-in method calls; read and write are different methods chosen at
   lowering.
-- [array-method-dispatch](array-method-dispatch.md) -- how the LRM 7.12 array-manipulation method
-  family dispatches per receiver type.
+- [array-method-dispatch](array-method-dispatch.md) -- LRM 7.12 array-method runtime semantics
+  (empty-reduction zero, selection sort over standard introsort); the original per-family dispatch
+  shape is superseded by [builtin-call-identity](builtin-call-identity.md).
 - [format-dispatch](format-dispatch.md) -- value formatting dispatches through `Formatter<T>` and
   `FormatArg`.
 

--- a/docs/decisions/array-method-dispatch.md
+++ b/docs/decisions/array-method-dispatch.md
@@ -1,103 +1,49 @@
-# Array method dispatch
+# Array method runtime semantics
 
-Date: 2026-06-04 Status: accepted
+Date: 2026-06-04 Status: dispatch portion superseded by
+[builtin-call-identity](builtin-call-identity.md); runtime semantics below remain in force
 
 ## Context
 
-LRM 7.5.2 / 7.5.3 attach two methods (`size`, `delete`) to the dynamic-array type, and LRM 7.12
-defines a much larger family (`sort`, `rsort`, `reverse`, `shuffle`, `sum`, `product`, `and`, `or`,
-`xor`, `find` and its variants, `min`, `max`, `unique`, `unique_index`, `map`) that applies
-uniformly to any unpacked array container (fixed unpacked, dynamic, queue, associative). Slang
-implements all of these as `SystemSubroutine` instances registered against each container's
-`SymbolKind`. At the SV call site they share the surface syntax of method dispatch
-(`receiver.method(...)`); at the slang AST they surface as `CallExpression` with
-`isSystemCall() == true`.
+LRM 7.5 / 7.10 / 7.12 define the array method families that apply uniformly across the unpacked
+array containers (fixed unpacked, dynamic, queue, associative). Two runtime-side semantics need to
+be pinned regardless of how the dispatch is modelled in IR.
 
-Lyra already has a first-class home for receiver-type-bound built-in methods:
-`hir::BuiltinMethodRef` (`include/lyra/hir/method.hpp`), which carries the enum / string / event
-method kinds and is found via receiver-type detection in `LowerCallExprProc`
-(`src/lyra/lowering/ast_to_hir/expression/lower.cpp`). The system-subroutine path
-(`SystemSubroutineRef`) is reserved for global `$xxx` functions whose dispatch is name-based.
+## Decisions
 
-This decision pins where the array-method family lives and how the surface area splits across cuts.
+### Empty-array reduction returns element-shape zero
 
-## Decision
+LRM 7.12.3 is silent on the empty-input case. The runtime returns an integral value of the element's
+bit width and signedness filled with zero, regardless of which reduction (`sum`, `product`, `and`,
+`or`, `xor`). The implementation re-uses the receiver's canonical-shape shield slot: copy the slot,
+default-initialise the copy, return.
 
-**Type-bound built-in array methods route through `hir::BuiltinMethodRef`.**
+### Sort uses selection sort, not the standard-library introsort
 
-A new `ArrayMethodKind` enum joins the existing variant arms (`EnumMethodKind`, `StringMethodKind`,
-`EventMethodKind`). AST -> HIR detects the receiver type in `LowerCallExprProc` and routes the call
-to `BuiltinMethodRef{ArrayMethodKind::kXxx}`. HIR -> MIR translates the kind through the existing
-`Overloaded` visitor on the `BuiltinMethodRef` callee. The backend renders `(receiver).MethodName()`
-through the one generic method-call rule, doing no representation work: an SV-facing query yields
-the SV value type directly from the runtime method's signature (`size` returns the SV `int` shape; a
-separate `RawSize` serves internal native-count callers).
-
-The enum is named `ArrayMethodKind` (not `DynArrayMethodKind`) because LRM 7.12 defines the
-semantics uniformly across container kinds; only the AST -> HIR receiver-detection block differs per
-container. Fixed-unpacked, queue, and associative array workstreams extend the routing block, not
-the kind enum.
-
-**Superseded by [builtin-call-identity](builtin-call-identity.md).** This decision pinned
-`ArrayMethodKind` and its sibling per-family enums under `hir::BuiltinMethodRef` /
-`mir::BuiltinMethodCallee` at a time when container method APIs were unaligned and
-`runtime-effects-as-generic-calls.md` did not yet exist. Both layers now share one flat
-closed-namespace `support::BuiltinFn` enum; the receiver-type dispatch in AST-to-HIR routes by
-container kind to the right name table, but the resolved callee is a single id rather than a
-per-family variant arm. The "Decision" paragraphs above stand on the dispatch direction (receiver
-type drives routing) and on the LRM 7.12 cross-container sharing semantics; the per-family enum
-structure they describe is no longer the IR shape.
-
-**Empty-array reduction returns element-shape zero.**
-
-LRM 7.12.3 is silent on the empty-input case. Slang's `ArrayReductionMethod::eval` returns an
-`SVInt` of the element's bit width and signedness filled with zero, regardless of which reduction
-(`sum`, `product`, `and`, `or`, `xor`). The runtime implementation re-uses the receiver's
-`oob_slot_` (which already carries the canonical element shape from the DA1 shield protocol): copy
-the slot, call `ResetToDefault()` on the copy, return.
-
-**The method family ships in three cuts.**
-
-The full LRM 7.12 surface mixes three independent architectural foundations: pure method-dispatch
-infrastructure, the `with` clause / iterator binding, and the `Queue<T>` runtime (needed by methods
-whose return type is `queue<elem>` or `queue<int>`). Folding all three into one PR is unmanageable;
-folding none means each follow-up reopens the dispatch plumbing. The sequencing:
-
-- **DA6-a** (this cut): pure method dispatch + the no-`with`, no-queue-return subset (`size`,
-  `delete`, `reverse`, `sort`, `rsort`, `sum`, `product`, `and`, `or`, `xor`).
-- **DA6-b**: `with` clause + iterator binding + the non-queue-return `with` variants (`sort with`,
-  `sum with`, ...).
-- **DA6-c + Q1**: `Queue<T>` runtime + locator family (`find*`, `min`, `max`, `unique*`).
-
-`shuffle()` (RNG) and SV2023 `map()` ship as standalone follow-ups after DA6-c lands.
-
-**Sort uses selection sort, not `std::ranges::sort`.**
-
-`PackedArray::operator=(PackedArray&&)` enforces destination-shape preservation via `AssignFrom`,
-which is the correct semantic for SV-language assignments. `std::ranges::sort` (libstdc++ introsort)
-internally evicts an element into a temporary via move-construct, then move-assigns from another
-element into the now-empty slot; that move-assign tripping the shape check produces an
-`InternalError`. Reverse works (it uses `iter_swap`, which we ADL-hook with a friend `swap` on
-`PackedArray` that exchanges storage directly). Sort cannot be ADL-hooked the same way -- it touches
-elements via `=`, not `swap`. The runtime therefore implements `Sort` / `Rsort` as in-place
-selection sort using ADL `swap`. The asymptotic O(n^2) cost is acceptable because (a) DA arrays in
-the realistic SV workload are small, (b) the alternative (relaxing PackedArray's move-assign) would
-silently weaken the shape-preservation safety net used by user-facing assignments. A future
-PackedArray refactor can introduce an explicit "moved-from" state and a smarter sort if needed.
+The packed-array move-assign operator preserves the destination's declared shape rather than
+adopting the source's; this is the correct semantic for SV-language assignments. The standard
+library's `std::ranges::sort` (libstdc++ introsort) internally evicts an element into a temporary
+via move-construct, then move-assigns from another element into the now-empty slot; that move-
+assign tripping the shape check produces a runtime error. Reverse works because it uses `iter_swap`,
+which is ADL-hooked with a friend `swap` that exchanges storage directly. Sort cannot be ADL-hooked
+the same way -- it touches elements via `=`, not `swap`. The runtime therefore implements `Sort` /
+`Rsort` as in-place selection sort using ADL `swap`. The asymptotic O(n^2) cost is acceptable
+because (a) the realistic SV workload runs sort on small arrays and (b) the alternative -- relaxing
+the move-assign shape check -- would silently weaken the shape-preservation safety net used by
+user-facing assignments.
 
 ## Rejected alternatives
 
-- **Routing array methods through `SystemSubroutineRef`.** That path is keyed on a name in the
-  global `$xxx` namespace; `arr.size()` is keyed on the receiver type. The existing enum / string /
-  event arms already establish the pattern. Forcing all three into one shared system-subroutine
-  registry would conflate two distinct dispatch axes (global function name vs receiver-type method).
-- **Per-container kind enums** (`DynArrayMethodKind`, `UnpackedArrayMethodKind`, ...). The methods'
-  semantics are LRM-uniform across containers; only the receiver-detection block differs. A single
-  `ArrayMethodKind` keeps the kind enum stable as other workstreams open.
-- **Shipping all 18+ methods in one PR.** Even the no-queue-return no-`with` subset is ten methods
-  and ships in one cut here; pulling in queue runtime or `with`-clause infrastructure on top would
-  push the review surface past the point where bisection helps.
-- **Relaxing `PackedArray::operator=(PackedArray&&)` to adopt source shape.** Would let
-  `std::ranges::sort` work directly, but would silently reshape destinations on SV assignments if
-  any backend conversion path failed to insert the matching `Conversion`. Keeping the
-  shape-preservation guarantee in place is worth the O(n^2) sort.
+- Relaxing the packed-array move-assign to adopt the source shape. Would let `std::ranges::sort`
+  work directly, but would silently reshape destinations on SV assignments if any backend conversion
+  path failed to insert the matching conversion. Keeping the shape-preservation guarantee in place
+  is worth the O(n^2) sort.
+
+## Notes
+
+The dispatch shape this decision originally pinned -- a `BuiltinMethodRef` variant carrying a
+per-family kind enum (`ArrayMethodKind`, `StringMethodKind`, `EnumMethodKind`, `EventMethodKind`,
+`QueueMethodKind`, `AssociativeMethodKind`) -- was superseded by
+[builtin-call-identity](builtin-call-identity.md). Both layers now share one flat closed-namespace
+identifier for every built-in call; the receiver-type dispatch in AST-to-HIR routes by container
+kind to the right name, but the resolved callee is a single id rather than a per-family arm.

--- a/docs/decisions/builtin-call-identity.md
+++ b/docs/decisions/builtin-call-identity.md
@@ -214,7 +214,7 @@ applicable. No render-side special case for any entry.
   `callee + arguments` with no family axis at MIR level).
 - `decisions/runtime-effects-as-generic-calls.md` (the flat-callee pattern this decision extends to
   built-in method calls).
-- `decisions/array-method-dispatch.md` (LRM 7.12 family dispatch; its "Subsequent revision" note
-  records this transition for the array family).
+- `decisions/array-method-dispatch.md` (LRM 7.12 array runtime semantics; its earlier per-family
+  dispatch shape is superseded here).
 - `decisions/callable-receiver.md` (`self`; the receiver mechanics this decision keeps unchanged).
 - `progress/refactor.md` R29 (tracking entry for the work that lands this shape).

--- a/docs/decisions/queue-operators.md
+++ b/docs/decisions/queue-operators.md
@@ -20,27 +20,27 @@ unpacked container, so the operators cannot reuse the packed-array operator lowe
 
 ## Decisions
 
-1. **A queue access operator is a built-in method call, not a select node.** `q[i]` and `q[a:b]`
-   have no native C++ expression -- each realizes as `receiver.Method(args)` on the runtime
-   `Queue<T>` (`ElementAt`, `WriteRef`, `Slice`). So they lower to the existing call primitive: a
-   `CallExpr` whose callee is a `QueueMethodKind` (the same first-class home as `size` /
-   `push_back`), with the receiver as `arguments[0]` and the index or bounds as the remaining
-   arguments. The element-access methods carry no SystemVerilog syntax -- they are compiler-internal
-   -- but they sit at the same level as the SV-callable queue methods because both are function
-   calls. The backend render is the one generic built-in-method-call render
-   (`(arg0).Name(arg1, ...)`); no queue-specific access node or render path exists. A dedicated MIR
-   node was rejected: it would duplicate an existing primitive (a select, or a call) and freeze one
-   receiver type's argument shape -- packed part-select's `(offset, compile-time width)` -- into the
-   IR, which is exactly what does not fit a queue's runtime `(lo, hi)` bounds. The LRM 7.10.1
-   clamping and the append-vs-discard rules live in the runtime method, the same way packed
-   bit-extraction lives in `PackedArray::Slice`; each backend realizes the method per receiver type.
+1. **A queue access operator is a built-in method call, not a select node.** Indexed and slice
+   access on a queue have no native C++ expression -- each realizes as a method call on the runtime
+   queue value. They therefore lower to the existing call primitive: a call whose callee is a
+   built-in method identifier (the same first-class home as `size` / `push_back`), with the receiver
+   as the first argument and the index or bounds as the remaining arguments. The element-access
+   entries carry no SystemVerilog syntax -- they are compiler-internal -- but they sit at the same
+   level as the SV-callable queue methods because both are function calls. The backend renders
+   through the one generic built-in-method-call rule; no queue-specific access node or render path
+   exists. A dedicated MIR node was rejected: it would duplicate an existing primitive (a select, or
+   a call) and freeze one receiver type's argument shape -- a packed part-select's
+   `(offset, compile-time width)` -- into the IR, which is exactly what does not fit a queue's
+   runtime `(lo, hi)` bounds. The LRM 7.10.1 clamping and the append-vs-discard rules live in the
+   runtime method, the same way packed bit-extraction lives in the packed array's slice method; each
+   backend realizes the method per receiver type.
 
 2. **Read and write are different methods, chosen at lowering.** A read takes the default-on-miss
-   `ElementAt`; a write (and the `q[$+1]` append) takes the append-aware `WriteRef`. The distinction
-   is resolved where it is known -- the assignment lowering marks its left-hand side as a write
-   target, and the queue element-select lowers to `WriteRef` under that flag and `ElementAt`
-   otherwise. Keeping the choice at lowering leaves the backend render purely mechanical: it emits
-   the method the node names and never re-decides read versus write.
+   element accessor; a write (and the `q[$+1]` append) takes the append-aware write-side accessor.
+   The distinction is resolved where it is known -- the assignment lowering marks its left-hand side
+   as a write target, and the queue element-select picks the write-side method under that flag and
+   the read-side otherwise. Keeping the choice at lowering leaves the backend render purely
+   mechanical: it emits the method the node names and never re-decides read versus write.
 
 3. **Unpacked concatenation reuses the concatenation value-build primitive.** Packed, string, and
    queue `{...}` are the same `ConcatExpr` primitive, realized per result type -- a bit join, a
@@ -90,5 +90,5 @@ unpacked container, so the operators cannot reuse the packed-array operator lowe
 - `value-assignment-and-moved-from.md` -- the type-vs-value distinction the queue's shape and bound
   follow.
 - `runtime-shape-and-default-value.md` -- the element-shape shield slot a queue carries.
-- `array-method-dispatch.md` -- the built-in method-call mechanism these operators reuse rather than
+- `builtin-call-identity.md` -- the built-in method-call mechanism these operators reuse rather than
   adding select nodes beside.

--- a/docs/decisions/runtime-shape-and-default-value.md
+++ b/docs/decisions/runtime-shape-and-default-value.md
@@ -55,12 +55,13 @@ Three questions surface:
    specified ... for that array's element type" -- there is no way to express that default cheaper
    than initializing N elements.
 
-4. **`ElementAt` returns `T&` directly; element-level proxy classes are absent.** Compound semantics
-   (`+=`, `&=`, the shift-assign family, the increment / decrement pair) live on `PackedArray` where
-   they belong; the container layer never reimplements them. OOB read is a reference to the shield
-   slot in canonical state, OOB write mutates the shield slot which is then reset on the next
-   access. The non-const overload returns `T&` for the write path; the const overload returns
-   `const T&` and is permitted by the `mutable` qualifier on `oob_slot_`.
+4. **The positional element accessor returns `T&` directly; element-level proxy classes are
+   absent.** Compound semantics (`+=`, `&=`, the shift-assign family, the increment / decrement
+   pair) live on `PackedArray` where they belong; the container layer never reimplements them. OOB
+   read is a reference to the shield slot in canonical state, OOB write mutates the shield slot
+   which is then reset on the next access. The non-const overload returns `T&` for the write path;
+   the const overload returns `const T&` and is permitted by the `mutable` qualifier on the shield
+   slot.
 
 5. **Container construction API aligns with `std::vector(n, value)`.** The canonical default is a
    required constructor argument, not optional. Wrappers offer a one-argument form for the
@@ -134,8 +135,8 @@ _Rejected alternatives:_
   unpacked-struct collection, and any future wrapper whose element type requires runtime
   construction parameters. Each new wrapper introduces an `oob_slot_` member following the same
   shape and implements its own `ResetToDefault`. Associative array's "auto-allocate on write" rule
-  (LRM 7.8.7) is a different ElementAt contract and requires its own design when that workstream
-  opens.
+  (LRM 7.8.7) is a different element-access contract and requires its own design when that
+  workstream opens.
 
 - Shape uniformity within a collection is enforced by convention -- lowering supplies the same
   canonical default for all writes and never mixes shapes in one container -- not by the C++ type

--- a/docs/decisions/unpacked-array-representation.md
+++ b/docs/decisions/unpacked-array-representation.md
@@ -127,18 +127,19 @@ Unpacked array support follows these invariants:
 
    `mir::UnpackedArrayType { dim, element_type }` -> `lyra::value::UnpackedArray<` +
    `render(element_type)` + `>`. The wrapper owns a private `std::vector<T>` and exposes a surface
-   symmetric with `PackedArray` -- `ElementAt(const PackedArray&)`, `Slice(offset, count)`,
-   `operator==` and `CaseEqual` returning a 1-bit `PackedArray` -- so the substrate-asymmetric
-   operations (equality with X / Z propagation, range selectors, observability hooks) live behind a
-   single uniform method surface. LRM 7.4.5 invalid-index handling lives in the wrapper too:
-   `ElementAt` returns `T&` (or `const T&` from the const overload); on an invalid index the
-   returned reference is to the wrapper's `oob_slot_` shield, restored to canonical state via
-   `T::ResetToDefault` immediately before being handed out so any prior OOB write is erased.
-   Element-level compound semantics live on `PackedArray` directly -- the wrapper carries no per-T
-   forwarder. `Slice` (non-const) returns an `UnpackedArrayRef<T>` proxy for slice writeback; slice
-   reads on partially-OOB positions handle the in-range and OOB elements per-element rather than at
-   slice granularity, matching `PackedArray::ExtractBits` / `AssignSlice`'s per-bit OOB treatment.
-   See `docs/decisions/runtime-shape-and-default-value.md` for the shield contract.
+   symmetric with `PackedArray` -- element access by position, slice, `operator==` and `CaseEqual`
+   returning a 1-bit `PackedArray` -- so the substrate-asymmetric operations (equality with X / Z
+   propagation, range selectors, observability hooks) live behind a single uniform method surface.
+   LRM 7.4.5 invalid-index handling lives in the wrapper too: positional access returns `T&` (or
+   `const T&` from the const overload); on an invalid index the returned reference is to the
+   wrapper's shield slot, restored to canonical state via `T::ResetToDefault` immediately before
+   being handed out so any prior OOB write is erased. Element-level compound semantics live on
+   `PackedArray` directly -- the wrapper carries no per-T forwarder. The write-side slice
+   (`SliceRef`) returns a write-through proxy whose destructor scatters back into the receiver's
+   storage; slice reads on partially-OOB positions handle the in-range and OOB elements per-element
+   rather than at slice granularity, matching the packed array's per-bit OOB treatment in
+   bit-extract and slice-assign. See `docs/decisions/runtime-shape-and-default-value.md` for the
+   shield contract.
 
 3. **Default initialization emits a `ConstructExpr` whose first positional argument is the
    canonical-default element and whose second is an `ArrayLiteralExpr` rendered as
@@ -193,8 +194,8 @@ Closed under this decision:
 - `UnpackedArrayType.dims: vector<UnpackedRange>` collapses to a single `dim: UnpackedRange` field
   at both HIR and MIR.
 - Backend cpp gains unpacked type rendering, unpacked default-init emit, and unpacked literal-init
-  emit. Element-read on unpacked bases routes through
-  `UnpackedArray<T>::ElementAt(const PackedArray&)`, symmetric with `PackedArray::ElementAt`.
+  emit. Element access on unpacked bases routes through the wrapper's positional accessor, symmetric
+  with the packed-array positional accessor.
 - 1D and multi-dim fall out at every layer from the recursive shape -- no separate code path per dim
   count.
 

--- a/docs/decisions/value-type-concepts.md
+++ b/docs/decisions/value-type-concepts.md
@@ -191,31 +191,6 @@ conversions. HIR-to-MIR's observable wrap rule treats `RealType` / `ShortRealTyp
 like any other value-storage type; a module-level `real` signal is observable through the same
 mechanism as a module-level `int` signal.
 
-## Implementation status
-
-- `Storable`, `LyraValue`, `CaseEqualComparable`, `WildcardComparable`, `Ordered` defined in
-  `include/lyra/value/concepts.hpp`.
-- `PackedArray`, `String`, `UnpackedArray`, `DynamicArray`, `Queue`, `AssociativeArray` updated to
-  satisfy the concepts LRM requires. Naming aligned: the host-bool predicate is `IsBitIdentical`
-  across every type.
-- `lyra::runtime::Var<T>` requires `LyraValue` and reads change-detection through `IsBitIdentical`.
-- `IsObservableScalarType` removed from `backend::cpp`.
-- `mir::ObservableType` added; HIR-to-MIR's structural-var lowering wraps eligible value types; the
-  C++ render emits `Var<T_cpp>` for an `ObservableType{T_mir}` field declaration.
-- The HIR-to-MIR generic-`CallExpr` lowering for observable reads / writes (the `Get` / `Set` /
-  `Mutate` shapes above) and the corresponding render simplification have not yet landed; the C++
-  backend currently re-derives the dispatch through a set of per-site predicates
-  (`IsObservableCell`, `LhsRootIsObservableScalar`, the four `MethodMutatesReceiver` tables,
-  `RenderMethodReceiver`). These predicates are transitional residue and retire with the lowering
-  change.
-- `lyra::value::Real` / `ShortReal` (a single `RealValue<Host>` template, with `RealTime` an alias
-  of `Real`) have landed and back every SV `real` / `shortreal` / `realtime`; the C++ backend
-  renders the real family as these value types rather than bare `double` / `float`. HIR-to-MIR's
-  wrap rule treats them as observable value-storage, so a module-level real signal is a `Var<Real>`,
-  and a real is a legal unpacked-array element. `===` / `!==` on a real (or real-leaf aggregate)
-  operand is rejected in HIR-to-MIR lowering with an error (LRM Table 11-1); the render path is
-  unchanged and never sees the form.
-
 ## Forbidden shapes
 
 - A method on `lyra::value::*` whose name borrows an LRM operator's terminology while serving the

--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -99,11 +99,10 @@ The numeric IDs are stable references and do not imply execution order beyond DA
       `.size()` and `.delete()` (LRM 7.5.2 / 7.5.3); the LRM 7.12.2 ordering subset that takes no
       `with` clause (`.reverse()`, `.sort()`, `.rsort()`); the LRM 7.12.3 reduction subset that
       takes no `with` clause (`.sum()`, `.product()`, `.and()`, `.or()`, `.xor()`). Dispatch routes
-      receiver-type-bound calls through the existing `BuiltinMethodRef` first-class home alongside
-      enum / string / event methods; system-function array-querying counterparts (`$size`,
-      `$dimensions`, etc. -- LRM 7.11 / 20.7) are a separate dispatch path and not bundled here.
-      Slang gates element-type constraints upstream (integral element for reductions, comparable for
-      sort).
+      receiver-type-bound calls through the same built-in-method call mechanism that serves enum /
+      string / event methods; system-function array-querying counterparts (`$size`, `$dimensions`,
+      etc. -- LRM 7.11 / 20.7) are a separate dispatch path and not bundled here. Slang gates
+      element-type constraints upstream (integral element for reductions, comparable for sort).
 
 - [x] DA6b -- The `with`-clause variants of the methods that accept one (`sort`, `rsort`, and the
       reductions), plus the LRM 7.12.4 `item.index` iterator method. The `with` expression is

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -247,49 +247,30 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       in lockstep. See `docs/decisions/callable-receiver.md`. **Trigger**: scheduled in front of
       R18.
 
-- [x] R17 -- Selector and packed-struct field access lower to explicit
-      `Call(ArrayMethod{kElementAt|kSlice})` / `Call(AssociativeMethod{kRead|kElementRef})`, and
-      HIR-to-MIR materialises a borrowed `PackedArrayRef` chain with an explicit
-      `Call(ArrayMethod{kToOwned})` wrap. `mir::ElementSelectExpr` and `mir::RangeSelectExpr` are
-      retired; the render decides the emit shape from the callee alone. The runtime mirrors Rust's
-      `ToOwned` trait -- ref types expose `ToOwned()` for materialisation, owning types expose the
-      same name as an explicit copy.
+- [x] R17 -- Selector and packed-struct field access lower to explicit built-in method calls for
+      element access, slice, and the borrowed-to-owned materialisation. The dedicated element-select
+      and range-select MIR nodes are retired; the render decides the emit shape from the callee
+      alone. The runtime mirrors Rust's `ToOwned` trait -- ref types expose `ToOwned()` for
+      materialisation, owning types expose the same name as an explicit copy.
 
 - [x] R17a -- Signed-slice re-interpretation is explicit in MIR. HIR-to-MIR types a packed struct /
       union field slice with the runtime-honest unsigned signedness and wraps signed-field accesses
       with an explicit `ConversionExpr` re-tag to the declared field type. Render is a pure
       mechanical translation of `Call(kSlice)` / `Call(kToOwned)` / `ConversionExpr` independently.
 
-- [ ] R17b -- **SUBSUMED by R26.** The narrow "make `Slice`'s `count` argument a `PackedArray`"
-      target only fixes half of the slice asymmetry -- the underlying problem is that runtime
-      containers carry no formal protocol forcing `Slice` (and every other shared family) to one
-      signature shape. Original text retained for history: Stop window-projecting the `kSlice`
-      `count` argument from an `IntegerLiteral` in the C++ backend. Today `RenderArrayMethodCall`
-      peeks at the third argument of a `Call(ArrayMethod{kSlice})` and -- only when that argument is
-      a literal -- emits a raw `N U` integer, because the runtime `Slice` signature takes
-      `std::uint32_t`. The peek is a backend re-derivation that no other backend will replicate
-      uniformly, violating `mir.md` Core Invariant 10. Target shape: the runtime `Slice` accepts a
-      `PackedArray` for `count` and projects to `std::uint32_t` internally (matching how the
-      `offset` argument already flows); render renders the `Call` mechanically with no peek.
+- [x] R17b -- Slice's `count` argument flows as a `PackedArray` value end to end (subsumed by R26).
+      The backend-side window-projection peek that emitted a raw native integer for a literal count
+      is gone; render reads the call's argument list mechanically.
 
-- [x] R17c -- Render-side method-receiver dispatch is gone. `RenderMethodReceiver` retired and every
-      method-call render path (`String` / `Array` / `Queue` / `Associative` / `Observable`) renders
-      its receiver through plain `RenderExpr`. The read-vs-write decision lives entirely on the MIR
-      receiver chain (LHS-side callees, `Deref(Mutate)` wraps) produced by HIR-to-MIR.
+- [x] R17c -- Render-side method-receiver dispatch is gone; every method-call render path renders
+      its receiver through the generic expression renderer. The read-vs-write decision lives
+      entirely on the MIR receiver chain (LHS-side callees, mutate-deref wraps) produced by
+      HIR-to-MIR.
 
-- [ ] R17d -- Lift the remaining backend-side post-process wraps in the method-call render paths
-      into explicit MIR. Today `RenderArrayMethodCall` / `RenderQueueMethodCall` /
-      `RenderAssociativeMethodCall` synthesise `lyra::value::PackedArray::Int(...)` around the
-      result of size-style methods (`kSize` on Array / Queue; `kNum` / `kSize` / `kExists` on
-      Associative) because the runtime returns `std::size_t` / `bool`, and `RenderStringMethodCall`
-      projects integral string-method arguments through `static_cast<std::int32_t>((...).ToInt64())`
-      because the runtime method takes `std::int32_t`. Both are backend re-derivations of facts MIR
-      did not state, violating `mir.md` Core Invariant 10. Target shape: either the runtime APIs
-      change to take and return `PackedArray` uniformly (the cleanest bridge), or HIR-to-MIR wraps
-      the corresponding `Call(...)` with an explicit `ConversionExpr` so render is purely
-      mechanical. After this, the five method-call render paths share an identical 5-step shape
-      (receiver / `.` / name+`(` / args / `)`) and can collapse into one shared helper parameterised
-      by the per-family member-name table. **Trigger**: batches with R17b as one render-cleanup cut.
+- [x] R17d -- An SV-facing runtime method's signature carries the SV value types directly:
+      size-style queries return a `PackedArray`, and integral arguments to string methods arrive as
+      `PackedArray`. The backend post-process casts that wrapped a host integer back into an SV
+      shape are gone; render reads call result and argument types straight from MIR.
 
 - [ ] R18 -- Rewrite the MIR-to-C++ backend to free functions per node kind, with no
       `RenderContext`, no class hierarchy, and no `WalkFrame`. Once R11 has removed the mutable
@@ -361,127 +342,52 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       wrap at the read boundary; render is a mechanical translation. The `RenderExpr` /
       `RenderExprNatural` split and `ProducesPackedArrayRef` predicate are gone.
 
-- [ ] R24 -- Dispatch the "sized collection" concept (`.size()` / `.num()`) through one resolver
-      instead of branching on the concrete container at each call site. Today the element-count
-      query is a separate enum value on every container's method family (`ArrayMethodKind::kSize`,
-      `QueueMethodKind::kSize`, `AssociativeMethodKind::kSize` / `kNum`), and a caller that wants a
-      count branches on the receiver type to pick the right one -- the `foreach` synthetic bound
-      does exactly this (`isQueue() ? QueueMethodKind::kSize : ArrayMethodKind::kSize`). The concept
-      is "any collection with an element count exposes `size()`", and the key modeling point (from
-      how Rust generics, C++ templates + concepts, TypeScript interfaces, and Python protocols are
-      implemented) is that under **static dispatch** -- which is our regime, the receiver's concrete
-      type is always known at lowering -- the concept is a **compile-time resolver that is erased in
-      the backend IR**, not a persistent IR node. So the per-container method enums stay (they are
-      the concrete implementations, like Rust `impl` blocks / C++ members), and MIR keeps carrying
-      the concrete per-type method; the concept lives only as a single lowering-time
-      `ResolveSized(type) -> that type's size method` table -- the one place the type-to-method
-      branch lives. The earlier mistake to avoid: extracting `size` into a flat
-      `CollectionMethodKind` that removed it from each container's method set (that loses dimension
-      one -- an array genuinely has a `size` method -- and persists a concept node in MIR, which the
-      static-dispatch model says should be erased). **Why deferred**: only one consumer (`foreach`)
-      today, so the resolver is a one-caller function -- the interface payoff is multiple generic
-      callers sharing the table, which do not exist yet. **Trigger**: a second generic consumer of
-      collection-size dispatch (a locator / reduction lowering, an array-querying system function,
-      or a generic-algorithm pass). A separate, structural sub-question rides along: whether fixed
-      unpacked and packed arrays should also be "sized collections" with a runtime `.size()` (a
-      type-model decision, distinct from how `foreach` iterates them -- `foreach` over a fixed array
-      uses its declared range and direction, not a count, so that split is a real semantic
-      difference, not the same redundancy).
+- [ ] R24 -- Dispatch the "sized collection" concept through one resolver instead of branching on
+      the concrete container at each call site. R29 absorbed the cross-container collapse for the
+      shared method (every container's element count is one `BuiltinFn` identity now), so the only
+      remaining branch is `Size` (LRM 7.4.3 / 7.5 / 7.10.2 dynamic / associative / queue) vs `Len`
+      (LRM 6.16.1 string-mandated name); a single lowering site handles it today and serves as the
+      one place that translates "sized collection" to its container's element-count method. Under
+      static dispatch the concept is a compile-time resolver and never persists as an IR node. **Why
+      deferred**: only one consumer today, so the resolver is a one-caller function -- the interface
+      payoff is multiple generic callers sharing the table, which do not exist yet. **Trigger**: a
+      second generic consumer of collection-size dispatch (a locator / reduction lowering, an
+      array-querying system function, or a generic-algorithm pass). A separate, structural
+      sub-question rides along: whether fixed unpacked and packed arrays should also be "sized
+      collections" with a runtime element-count query (a type-model decision, distinct from how
+      `foreach` iterates them -- `foreach` over a fixed array uses its declared range and direction,
+      not a count, so that split is a real semantic difference, not the same redundancy).
 
-- [ ] R25 -- Collapse the per-data-type builtin-method render handlers onto the single generic
-      `(receiver).name(args)` rule (R20's rule, now also carrying user-subroutine calls and the
-      event family). **Value-model decision settled** (it was the blocker): an SV-facing runtime
-      method's return and parameter types _are_ the SV value types; the representation bridge lives
-      inside the method body, compiled once, an internal detail of the value layer. It is neither a
-      MIR `ConversionExpr` (the call's SV type does not change, so there is nothing to convert) nor
-      an emit-side wrap (forbidden by `decisions/integral-representation.md`: no native-scalar
-      bridges in emit). This follows from `mir.md` invariant 10 -- the backend reads the call's
-      stated result type and emits it, never re-deciding a representation. Internal native-count
-      callers use a separate `Raw*` accessor. **Landed on this thread**: the integral-query surface
-      (container `size`, associative `num` / `size` / `exists`, string `len` / `getc` / `compare` /
-      `atoi` family, enum `num`) and the integral-argument surface (string index / byte args, enum
-      next / prev step) now return / take SV value types directly; the member-shaped families
-      (string, array, queue, associative non-traversal, enum instance) render through one generic
-      handler whose only per-kind inputs are the member name and a mutates flag; all
-      `PackedArray::Int(...)` result wraps and `static_cast<...>(ToInt64())` argument casts are gone
-      from emit; user calls carry `self` and event trigger / triggered carry the engine handle as
-      real arguments. **Remaining**: three families do not fit `(receiver).name(args)` and still
-      need their own decision -- enum static methods (`Class::first()`, no receiver), associative
-      traversal (a free runtime call still splicing the engine handle, the one remaining services
-      fabrication), and value `$isunknown` (type-static, no call in the all-2-state case).
-      **Structural prerequisite**: R29 -- it collapses the per-family enums whose existence forces
-      R25's handler to keep per-family member-name tables; the per-family `Render*MethodCall`
-      wrappers then collapse mechanically. R29 itself rests on R26 / R28. **Trigger**: continuation
+- [ ] R25 -- Two families still do not fit the generic `(receiver).name(args)` member-call rule and
+      need their own lowering decision: enum type-static methods (no receiver -- the qualifier is
+      part of the symbol identity, surfaced as a static-callee arm) and the value-static
+      `$isunknown` query (type-static in the all-2-state case, constant-folded). The cross-cutting
+      value-model decision is settled: an SV-facing runtime method's return and parameter types are
+      the SV value types, the representation bridge lives inside the method body (an internal detail
+      of the value layer), and the backend reads the call's stated result type and emits it
+      mechanically. The integral-query surface and integral-argument surface flow through SV value
+      types directly; the member-shaped families (string, array, queue, associative including
+      traversal, enum instance) render through one generic handler; user calls carry `self` and
+      event trigger / triggered carry the engine handle as real arguments. **Trigger**: continuation
       of `decisions/runtime-effects-as-generic-calls.md`.
 
-- [ ] R26 -- Define runtime container protocols as explicit C++20 concepts, pin the
-      currently-conforming surface, and complete `Sliceable` alignment. Today five containers
-      (`PackedArray`, `DynamicArray`, `UnpackedArray`, `Queue`, `AssociativeArray`, plus `String` as
-      a sixth member-shaped surface) share method families with no compile-time contract forcing the
-      signatures into one shape. Most families already align de-facto (`ResetToDefault`, `ToOwned`,
-      the equality / case-equal / bit-identical surface, the with-clause reduction and search
-      families); two have drifted -- `Sliceable` is fixed in this entry, `Writable` defers to R28 (a
-      pure rename pass, independent). The full protocol inventory derived from the audit:
+- [x] R26 -- Runtime container protocols are pinned as explicit C++20 concepts in a single
+      value-layer concept header; each container `static_assert`s every protocol it satisfies. Slice
+      is aligned across the four conforming containers: the signature is
+      `Slice(PackedArray, PackedArray)`, with Queue's two arguments meaning inclusive bounds (LRM
+      7.10.1) and the three fixed-width containers meaning `(offset, count)` (LRM 7.4.5 / 11.5.2
+      require canonical-fill at the type-fixed width, which is not derivable from `(lo, hi)`). A
+      single HIR-to-MIR range-bounds unfolder dispatches by container kind; the call's argument list
+      flows through render with no type-dependent argument projection. Signature drift on any pinned
+      protocol is now a compile-time failure. Subsumes R17b.
 
-      - `Sized` -- `Size() -> PackedArray`: Dynamic / Unpacked / Queue / AA. PackedArray opts out
-        (its "size" is ambiguous between bit count, element count, and outer-dim count; SV does
-        not expose `.size()` on packed types).
-      - `Lengthable` -- `Len() -> PackedArray`: String (LRM 6.16.1 mandates the name).
-      - `Indexable` -- `ElementAt(pos) -> ConstView`: Packed / Dynamic / Unpacked / Queue; String
-        carries the LRM-named variant `Getc`.
-      - `Writable` -- `WriteRef(pos) -> MutView`: Queue conforms today, AA's `ElementRef(K)` is
-        the keyed sibling; the three array containers conform after R28's rename.
-      - `AssocRead` -- `Read(K) -> ConstView`: AA only (the key is not a position; separate
-        protocol from `Indexable`).
-      - `Sliceable` -- `Slice(PackedArray, PackedArray) -> Window`: after this entry's
-        alignment, Packed / Dynamic / Unpacked / Queue all conform structurally. The two
-        arguments mean different things per LRM contract: Queue takes inclusive bounds
-        `(lo, hi)` (LRM 7.10.1); Packed / Dynamic / Unpacked take `(offset, count)` because
-        LRM 7.4.5 / 11.5.2 require canonical-fill at the type-fixed width even when bounds
-        carry X/Z, and that width is not derivable from `(lo, hi)` alone. String's
-        `Substr(i, j)` uses the queue's `(lo, hi)` shape but does not claim the protocol
-        (the method name differs per LRM 6.16.8).
-      - `Ownable` -- `ToOwned() -> Self`: Packed / Dynamic / Unpacked / Queue.
-      - `Defaultable` -- `ResetToDefault()`: all five containers plus selected ref views.
-      - `Equatable` -- `==`, `!=`, `CaseEqual`, `IsBitIdentical`: universal.
-      - `Sortable` -- `Sort(F)`, `Rsort(F)`, `Reverse()`: Dynamic / Unpacked / Queue.
-      - `Reducible` -- `Sum/Product/And/Or/Xor(F)`: Dynamic / Unpacked / Queue.
-      - `Searchable` -- `Find/FindIndex/FindFirst/FindLast/Min/Max/Unique(F)`: Dynamic /
-        Unpacked / Queue.
-      - `KeyTraversal` -- `FirstKey/LastKey/NextKey/PrevKey -> optional<K>`: AA only.
-
-      Target shape:
-
-      - A new runtime header defines all 13 concepts in their final-aligned form
-      - Every container header carries a matching `static_assert(<Concept><...>)` for each
-        protocol it satisfies (12 of 13 pinnable after this entry; `Writable` waits for R28)
-      - `Sliceable` alignment: `PackedArray`, `DynamicArray`, and `UnpackedArray` change their
-        `Slice` signature's second argument from `std::uint32_t count` to
-        `const PackedArray& count`. The runtime projects to `std::uint32_t` internally at the
-        API boundary. Queue keeps its `(lo, hi)` form; both fixed-width and queue containers
-        now share the structural `Slice(PackedArray, PackedArray)` shape.
-      - HIR-to-MIR's three parallel range-unfold helpers collapse onto a single
-        `UnfoldRangeBoundsToLoHi` that dispatches by container kind. The MIR `Call(kSlice,
-        ...)` argument list carries `[base, offset, count_pa]` for fixed-width containers
-        (count is a PackedArray-typed literal for static-width slices) and `[base, lo, hi]`
-        for Queue.
-      - The backend's `RenderArrayMethodCall` Slice argument peek (the only emit-side
-        type-dependent argument projection) disappears; arguments render uniformly through
-        `RenderExpr`.
-
-      Subsumes R17b. After R26 + R28 lands, every signature drift becomes a compile-time
-      failure rather than a silent regression. **Trigger**: standalone; before R28 / R29.
-
-- [x] R28 -- The read-vs-write access surface is aligned across every container at the noun-level
-      naming axis: `Element(pos) -> value` for read, `ElementRef(pos) -> ref` for write. The earlier
-      `ElementAt` (read) / `WriteRef` (write) split is gone; the runtime, MIR's `ArrayMethodKind` /
-      `QueueMethodKind` / `AssociativeMethodKind`, and HIR's `QueueMethodKind` all use `kElement` /
-      `kElementRef`. The slice axis follows the same pattern -- `Slice` for read, `SliceRef` for
-      write -- so `MakeRangeSliceCallExpr` / `MakeFieldSliceCallExpr` route through one `AccessSide`
-      enum at the lowering boundary. `concepts.hpp` pins `Indexable` (bare + `Ref` pair),
-      `Sliceable` (bare), and `SliceableRef` (Ref form); Queue opts out of `SliceableRef` because
-      LRM 7.10 defines no write-side queue slice. The `Writable` concept is intentionally not minted
-      -- the bare-vs-`Ref` pair is now part of `Indexable` itself.
+- [x] R28 -- The read-vs-write access surface is aligned at the noun-level naming axis across every
+      container and across both lowering and runtime: bare `Element` / `Slice` for read,
+      `ElementRef` / `SliceRef` for write. Lowering carries the read-vs-write choice as one
+      access-side parameter at the slice-builder boundary; the runtime concepts pin the
+      bare-and-`Ref` pair as part of `Indexable` (write-side present on every keyed container) and
+      split `Sliceable` from `SliceableRef` because LRM 7.10 defines no write-side queue slice. No
+      separate `Writable` concept: the pair belongs with the read-side concept it shadows.
 
 - [x] R29 -- Built-in method calls and runtime entries carry one flat closed-namespace identifier
       shared between HIR and MIR. Two MIR callee arms (instance, type-namespace-qualified static)


### PR DESCRIPTION
## Summary

Cleans up doc-side staleness that accumulated as R26 / R28 / R29 landed in code without the docs catching up. No code changes. Touches nine files across `docs/decisions/` and `docs/progress/` to remove references to retired per-family enum / helper names, mark already-landed refactor entries as done, and excise an "Implementation status" section that had drifted into describing a state the code no longer matches.

## Changes

`docs/progress/refactor.md` -- R17b, R17d, R26 marked done with concise summaries of the landed shape (the bodies described work that completed in PR #921 and earlier). R17 / R17c / R24 / R25 / R28 prose rewritten to use concept vocabulary instead of retired per-family enum names (`ArrayMethodKind`, `QueueMethodKind`, `AssociativeMethodKind`, etc.) and retired helper names (`RenderMethodReceiver`, `ElementAt`, `WriteRef`).

`docs/decisions/array-method-dispatch.md` -- Title and body collapsed onto the still-current runtime semantics (empty-reduction zero, selection sort over standard introsort). The per-family dispatch shape this doc originally pinned is now a one-paragraph supersedence pointer to `builtin-call-identity.md`; the old mid-document "Subsequent revision" patch is gone.

`docs/decisions/value-type-concepts.md` -- "Implementation status" section deleted. It was describing transitional residue (`IsObservableCell`, `LhsRootIsObservableScalar`, four `MethodMutatesReceiver` tables, `RenderMethodReceiver`) that retired with PR #904's observable-as-generic-call lowering.

`docs/decisions/queue-operators.md` -- Points 1 and 2 rewritten with concept terms instead of retired identifiers (`QueueMethodKind`, `ElementAt`, `WriteRef`); cross-reference retargeted from `array-method-dispatch.md` to `builtin-call-identity.md`.

`docs/decisions/unpacked-array-representation.md` and `runtime-shape-and-default-value.md` -- `ElementAt` and `UnpackedArrayRef<T>` references reworded to concept-level terms ("positional element accessor", "write-side slice proxy").

`docs/decisions/README.md` and `docs/decisions/builtin-call-identity.md` -- Index entry and cross-reference updated to reflect the array-method-dispatch supersedence.

`docs/progress/aggregate.md` -- DA6a entry's reference to `BuiltinMethodRef` swapped for the concept-level "built-in-method call mechanism".

## Design

The CLAUDE.local.md rule against naming concrete identifiers in `docs/progress/` already exists; the recurring failure mode is that decision docs are not held to the same standard. Every stale reference fixed here was a class name, helper name, or file path written into prose that subsequent refactors then renamed or removed. The cleanup follows one rule: describe the decided steady state in concept terms; reserve concrete identifier names for explicit historical supersedence notes where naming the old shape is the whole point.