### PR TITLE
Cover multi-instance combinational re-trigger

### DIFF
--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -151,10 +151,10 @@ consume. Coverage is demonstrated through Stage D and Stage E.
       navigable scopes or a member-name-aware resolution -- a model question deferred from D2c.
 - [x] D3 -- Multi-level dotted paths resolve through the object tree across more than one level.
       Landed for downward paths through scalar instances.
-- [ ] D4 -- A combinational process reading a hierarchical reference re-triggers when the referenced
-      signal changes, including paths spanning multiple levels and reads from several instances.
-      Downward paths re-trigger today at any depth; reads from several instances within one process
-      remain.
+- [x] D4 -- A combinational process reading a hierarchical reference re-triggers when the referenced
+      signal changes, across paths spanning multiple levels, several instances read within one
+      process, and upward references alongside downward ones. The process subscribes to every
+      referenced signal regardless of direction or depth, and each source re-triggers independently.
 - [ ] D5 -- The hierarchical path of an instance (for `%m`, display, and scope queries) derives from
       object-tree ownership.
 - [x] D6 -- A hierarchical path that indexes an instance array (`c[i].x`) resolves to the selected

--- a/tests/cases/cpp/hierarchy_xunit_comb/case.yaml
+++ b/tests/cases/cpp/hierarchy_xunit_comb/case.yaml
@@ -8,4 +8,7 @@ input:
 expect:
   exit: 0
   stdout:
-    exact: "r=7\n"
+    exact: |
+      r=14
+      r=107
+      r=300

--- a/tests/cases/cpp/hierarchy_xunit_comb/main.sv
+++ b/tests/cases/cpp/hierarchy_xunit_comb/main.sv
@@ -7,11 +7,15 @@ module Child;
 endmodule
 
 module Top;
-  Child c();
+  Child a();
+  Child b();
   int r;
-  always_comb r = c.x;
+  always_comb r = a.x + b.x;
   initial begin
-    #2;
-    $display("r=%0d", r);
+    #2 $display("r=%0d", r);
+    a.x = 100;
+    #1 $display("r=%0d", r);
+    b.x = 200;
+    #1 $display("r=%0d", r);
   end
 endmodule


### PR DESCRIPTION
## Summary

A combinational process that reads hierarchical references from several instances must re-trigger when any of those signals change, and each source must be in the wake-up set independently. Every existing cross-unit combinational test read exactly one hierarchical signal per process, so the multi-observable case -- one `always_comb` whose sensitivity list spans several instances -- was unverified. This strengthens the existing cross-unit combinational case to read two child instances instead of one, proving both that their autonomous writes re-trigger the parent process and that each instance re-triggers it independently. Hierarchy D4 is marked done; upward-reference re-trigger and multi-level re-trigger already had their own coverage, so no new file is added.

## Testing

`bazel test //... --test_output=errors` (all four targets pass).