### PR TITLE
Split container default slot into default and sink

### DIFF
--- a/docs/decisions/runtime-shape-and-default-value.md
+++ b/docs/decisions/runtime-shape-and-default-value.md
@@ -1,6 +1,10 @@
-# Packed Array runtime shape and collection OOB shield
+# Packed Array runtime shape and collection default value
 
-Date: 2026-06-03 Status: accepted
+Date: 2026-06-03 (revised 2026-06-22) Status: accepted
+
+The 2026-06-22 revision splits the container's single `mutable` default slot into two fields -- an
+immutable canonical default and a separate write-discard sink -- so the read path is genuinely
+`const`. Decision points 2 and 4 and the rejected-alternatives list are updated accordingly.
 
 ## Context
 
@@ -40,13 +44,16 @@ Three questions surface:
    operator-overload growth infeasible at scale. Runtime-shape is the correct engineering trade-off
    given this cardinality property.
 
-2. **Every container wrapper carries one `oob_slot_` field of type `T`, declared `mutable`.** The
-   slot is seeded to the canonical default at construction (so initial OOB reads return the LRM
-   Table 7-1 default) and doubles as the discard target for OOB writes (so the proxy / forwarding
-   layer the wrapper would otherwise need vanishes). The wrapper restores the slot to canonical
-   state via `T::ResetToDefault` on every OOB access before handing out a reference, so any write
-   accumulated in the slot is erased before the next access observes it. Single field, single
-   responsibility: "the LRM 7.4.5 shield for this container."
+2. **Every container wrapper carries two element-typed fields: an immutable `element_default_` and a
+   scratch `discard_sink_`.** Both are seeded to the canonical default at construction.
+   `element_default_` is the LRM Table 7-1 value a read of a nonexistent / invalid entry returns and
+   the prototype every fill / grow / slice / locator copies; it is only ever read or copied, never
+   written, so it stays canonical for the container's life and a const read returns it by direct
+   reference with no scrub. `discard_sink_` is the throwaway an invalid write lands on; the
+   non-const write path scrubs it to canonical via `T::ResetToDefault` before handing out the
+   reference, so a discarded write never leaks into a later access. The two fields are two distinct
+   responsibilities -- the canonical default value versus the throwaway write target -- not a
+   duplicated value.
 
 3. **Every value type that can be an element provides `ResetToDefault()`.** `PackedArray` in-place
    zero-fills (2-state) or X-fills (4-state) the data bits while preserving shape; `DynamicArray<T>`
@@ -57,24 +64,23 @@ Three questions surface:
 
 4. **The positional element accessor returns `T&` directly; element-level proxy classes are
    absent.** Compound semantics (`+=`, `&=`, the shift-assign family, the increment / decrement
-   pair) live on `PackedArray` where they belong; the container layer never reimplements them. OOB
-   read is a reference to the shield slot in canonical state, OOB write mutates the shield slot
-   which is then reset on the next access. The non-const overload returns `T&` for the write path;
-   the const overload returns `const T&` and is permitted by the `mutable` qualifier on the shield
-   slot.
+   pair) live on `PackedArray` where they belong; the container layer never reimplements them. An
+   invalid read returns `const T&` to `element_default_`; an invalid write returns `T&` to the
+   scrubbed `discard_sink_`. Because the read path never touches the sink and the write path is
+   non-const, no field needs the `mutable` qualifier -- the const read is genuinely const.
 
 5. **Container construction API aligns with `std::vector(n, value)`.** The canonical default is a
    required constructor argument, not optional. Wrappers offer a one-argument form for the
    declare-empty case (`Wrapper(canonical_default)`), a two-argument form for sized construction
    (`Wrapper(n, canonical_default)`), and additional forms as element semantics require. The
-   parameter is stored as `oob_slot_` rather than consumed during the fill, so the same value is
-   available for later resize and OOB paths.
+   parameter seeds both `element_default_` and `discard_sink_` rather than being consumed during the
+   fill, so the canonical default is available for later resize and miss paths.
 
 6. **The canonical default flows from MIR lowering.** `SynthesizeDefaultValueExpr` (HIR-to-MIR)
    already produces shape-correct default expressions from MIR type information. The emit chain is:
-   MIR type -> default-value expression -> wrapper-constructor argument -> stored `oob_slot_`
-   member. The shape information that is "lost" at the C++ template-parameter level is restored via
-   this explicit channel; no separate channel is introduced.
+   MIR type -> default-value expression -> wrapper-constructor argument -> stored `element_default_`
+   / `discard_sink_` members. The shape information that is "lost" at the C++ template-parameter
+   level is restored via this explicit channel; no separate channel is introduced.
 
 _Rejected alternatives:_
 
@@ -86,11 +92,15 @@ _Rejected alternatives:_
   flag and forwarded compound operators.** Mixes layer responsibilities -- the container's OOB
   concern leaks into a per-T forwarder set that duplicates `PackedArray`'s compound operators on
   every container type and grows by ~11 method definitions per new container. Replaced by direct
-  `T&` return + shield slot.
+  `T&` return + the default / sink fields.
 
-- **Two separate fields: `default_value_` (immutable canonical) plus `scratch_` (mutable write
-  target).** Twice the per-wrapper memory cost for no observable behavior difference -- the
-  canonical can be recovered from the shield via `ResetToDefault` whenever needed.
+- **A single `mutable` slot fusing the canonical default and the write-discard sink.** Saves one
+  element-sized field per wrapper, but because the write path dirties the shared slot the const read
+  must scrub it before returning -- a const method that mutates, which forces the `mutable`
+  qualifier and pays a `ResetToDefault` on every read miss. The saved field is one `T` per container
+  instance (not per element), negligible against the `std::vector` / `std::map` / `std::deque` each
+  wrapper already holds; the const-correctness and the eliminated reset-on-read outweigh it. This
+  was the original choice and is revised here.
 
 - **Store a callable (`std::function<T()>` or lambda) instead of a `T` instance.** Type-erasure
   overhead, no shape introspection from the stored callable, idiomatic mismatch with the
@@ -105,24 +115,25 @@ _Rejected alternatives:_
 
 - **Emit-side validity gate (`if (in_bounds(idx)) arr.RawAt(idx) op= rhs;` instead of returning
   `T&`).** Pushes LRM 7.4.5 semantics into every codegen site, complicates NBA capture (validity has
-  to be re-derived at fire time), and explodes for multi-dim chains. The shield slot keeps codegen
-  uniform across in-bounds and OOB.
+  to be re-derived at fire time), and explodes for multi-dim chains. The default / sink fields keep
+  codegen uniform across in-bounds and OOB.
 
 - **Throw on empty-container OOB read.** Violates LRM 7.4.5, which mandates the element type's Table
   7-1 default.
 
 ## Consequences
 
-- Every container wrapper carries one extra `T` member (`oob_slot_`). The size cost is one
-  element-sized object per wrapper, independent of element count.
+- Every container wrapper carries two extra `T` members (`element_default_`, `discard_sink_`). The
+  size cost is two element-sized objects per wrapper, independent of element count.
 
 - Every value type usable as a container element implements `ResetToDefault()`. The contract is
   in-place restoration to the LRM Table 6-7 / Table 7-1 canonical default while preserving any shape
   information embedded in the value (bit width / signedness / state kind for `PackedArray`).
 
 - `UnpackedArray<T>::ResetToDefault` is O(N) where N is the array's fixed size; this cost is paid
-  only on OOB access to the outer container and is the LRM-mandated cost of materializing "all
-  elements at default." In-bounds access pays no shield cost.
+  only when the array is an outer container's `discard_sink_` being scrubbed on an invalid-index
+  write, and is the LRM-mandated cost of materializing "all elements at default." In-bounds access
+  and invalid reads pay no scrub cost (the read returns the pristine `element_default_` directly).
 
 - All container construction sites -- emit-generated and direct C++ -- must provide
   `canonical_default` explicitly. Container wrappers no longer expose a zero-argument default
@@ -133,10 +144,11 @@ _Rejected alternatives:_
 
 - The pattern extends naturally to queue, associative array, packed-struct collection,
   unpacked-struct collection, and any future wrapper whose element type requires runtime
-  construction parameters. Each new wrapper introduces an `oob_slot_` member following the same
-  shape and implements its own `ResetToDefault`. Associative array's "auto-allocate on write" rule
-  (LRM 7.8.7) is a different element-access contract and requires its own design when that
-  workstream opens.
+  construction parameters. Each new wrapper introduces `element_default_` / `discard_sink_` members
+  following the same shape and implements its own `ResetToDefault`. (Associative array names its
+  immutable default `element_default_` too, paired with the LRM 7.9.11 `user_default_` override.)
+  Associative array's "auto-allocate on write" rule (LRM 7.8.7) is a different element-access
+  contract and requires its own design when that workstream opens.
 
 - Shape uniformity within a collection is enforced by convention -- lowering supplies the same
   canonical default for all writes and never mixes shapes in one container -- not by the C++ type
@@ -150,5 +162,5 @@ _Rejected alternatives:_
 - `include/lyra/value/packed_array.hpp` -- runtime-shape `PackedArray` definition and
   `ResetToDefault`.
 - `include/lyra/value/dynamic_array.hpp`, `include/lyra/value/unpacked_array.hpp` -- first wrappers
-  to adopt the shield pattern.
+  to adopt the default / sink pattern.
 - `docs/progress/aggregate.md` -- variable-size aggregate workstream.

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -35,6 +35,12 @@ Each file contains:
 - Any blockers, open design questions, or cross-references to architecture contracts the work must
   satisfy.
 
+Write each item at the semantic level -- the problem and the target shape, not the field names,
+helpers, or keywords, and not the full rationale (that lives in `../decisions/`). A well-written
+item reads the same before and after the work, so completing it is flipping `[ ]` to `[x]` and
+nothing more -- never a rewrite into a past-tense account of what landed. The resulting behavior is
+recorded in the code and the decision doc; that the work happened is recorded in git.
+
 When the last item lands, the file is deleted, and any cross-reference to it from another progress
 file is updated in the same change so no dangling pointer remains. The git history is the record
 that the work happened.

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -484,28 +484,10 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       class and cannot descend, so this rests on a new member-access capability that touches the
       member-access model. **Trigger**: when that descend capability is designed and built.
 
-- [ ] R36 -- Split the container default-value slot's two roles so the read path stops mutating. The
-      four unpacked-container wrappers (fixed-size array, dynamic array, queue, associative array)
-      each carry one `mutable` slot that fuses three jobs: the immutable canonical default that also
-      carries the element's runtime shape (the construction prototype), the immutable value a read
-      of a nonexistent / invalid entry returns (LRM 7.4.5 / 7.8.6 / Table 7-1), and the mutable
-      discard target an invalid write lands on and that is thrown away. Because the read path is
-      `const` yet the slot doubles as the write sink a prior invalid write may have dirtied, the
-      const read must reset the slot before returning a reference to it -- a const method that
-      mutates, which is the sole reason the slot is `mutable` and the reason every read miss pays a
-      reset. The forcing constraint is correct and stays: SystemVerilog has no exceptions, so an
-      invalid read yields the element default and an invalid write is a no-op, both expressed as a
-      returned reference so codegen stays uniform (no per-site validity gate). Target shape:
-      separate the immutable default (prototype plus read-miss value) from the write-discard sink,
-      so the const read returns the pristine default with no reset, the sink is reset only on an
-      invalid write (where a compound op must read the default first), and the `mutable` qualifier
-      disappears from all four wrappers. The "two fields" this introduces are two distinct
-      responsibilities -- the element default versus the throwaway scratch -- not a duplicated
-      value. This reverses `../decisions/runtime-shape-and-default-value.md`, which chose one slot
-      to save one element-sized field per wrapper; that cost is one object per container instance
-      (not per element) and is negligible against the const-correctness and readability gain, and
-      the decision weighed only memory while omitting the mutable / reset-on-read cost. Revise that
-      decision doc alongside. **Trigger**: standalone; mechanical across the four wrappers.
+- [x] R36 -- The container default-value slot fused the read-miss value with the discarded-write
+      target, forcing the const read to scrub the slot a prior write may have dirtied before
+      returning -- a const method that mutates. Split the read role from the write role so the read
+      path is pure. See `../decisions/runtime-shape-and-default-value.md`.
 
 ## Out of Scope
 

--- a/include/lyra/lowering/hir_to_mir/default_value.hpp
+++ b/include/lyra/lowering/hir_to_mir/default_value.hpp
@@ -33,7 +33,7 @@ namespace lyra::lowering::hir_to_mir {
 // arguments are `[element_default, ArrayLiteralExpr{elements}]`. This is the
 // construction shape every site that produces an array-container value must
 // use: the canonical-default element required by the wrapper's runtime ctor
-// (to seed `oob_slot_`) is supplied here via `BuildDefaultValueExpr` on
+// (to seed `element_default_`) is supplied here via `BuildDefaultValueExpr` on
 // the element type, and the elements ride in an `ArrayLiteralExpr` that the
 // renderer emits as `std::array<T, N>{...}`. See
 // `docs/decisions/runtime-shape-and-default-value.md`.

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -146,8 +146,8 @@ class Var : public Observable {
   // 9.4.2 `===` semantics for @() detection -- the engine fires subscribers
   // only on a real change). The store always happens so a freshly-defaulted
   // cell adopts shape and implementation-side seeds (e.g. an
-  // `AssociativeArray`'s `oob_slot_`) from the source on the first write,
-  // even when the SV-visible content compares identical (both empty).
+  // `AssociativeArray`'s `element_default_`) from the source on the first
+  // write, even when the SV-visible content compares identical (both empty).
   auto AssignIfChanged(const T& v) -> bool {
     const bool changed = !value_.IsBitIdentical(v);
     value_ = v;

--- a/include/lyra/value/associative_array.hpp
+++ b/include/lyra/value/associative_array.hpp
@@ -59,36 +59,41 @@ struct AssocKeyTraits<PackedArray> {
 // is an ordered `std::map` so iteration and `%p` formatting follow the LRM 7.8
 // key ordering and stay deterministic.
 //
-// `type_default_` holds the element-type default -- the LRM Table 7-1 value
-// read from a nonexistent array entry (supplied at construction because
-// `V = PackedArray` carries runtime shape the C++ type cannot recover; see
-// `docs/decisions/runtime-shape-and-default-value.md`). A read of a nonexistent
-// or invalid key (LRM 7.8.6) returns it unless `user_default_` overrides it
-// (LRM 7.9.11); an invalid-key write lands on it and is discarded. There is no
-// out-of-bounds concept here: an associative array has no index bounds, so the
-// trigger is a missing or invalid key, never a boundary.
+// `element_default_` holds the element-type default -- the LRM Table 7-1 value
+// read from a nonexistent array entry. It carries the element's runtime shape
+// (supplied at construction because `V = PackedArray` carries shape the C++
+// type cannot recover; see `docs/decisions/runtime-shape-and-default-value.md`)
+// and is only ever read or copied, never written, so a read returns it
+// directly. A read of a nonexistent or invalid key (LRM 7.8.6) returns it
+// unless `user_default_` overrides it (LRM 7.9.11). `discard_sink_` is the
+// throwaway an invalid-key write lands on, scrubbed to canonical by the
+// non-const write path. There is no out-of-bounds concept here: an associative
+// array has no index bounds, so the trigger is a missing or invalid key, never
+// a boundary.
 template <typename K, typename V>
 class AssociativeArray {
  public:
   using KeyType = K;
   using ElementType = V;
 
-  // Sentinel "uninitialized" form -- empty map with a default-constructed
-  // type-default slot, used as the declared default state of an associative
+  // Sentinel "uninitialized" form -- empty map with default-constructed
+  // default / sink slots, used as the declared default state of an associative
   // field before the constructor scope seeds the element shape.
   AssociativeArray() = default;
 
-  // Empty map with the type-default slot seeded, used for declarations like
+  // Empty map with the default / sink slots seeded, used for declarations like
   // `int m[string];` where the element shape is known at lowering time.
-  explicit AssociativeArray(V type_default)
-      : type_default_(std::move(type_default)) {
+  explicit AssociativeArray(V element_default)
+      : element_default_(element_default),
+        discard_sink_(std::move(element_default)) {
   }
 
   // LRM 7.9.11 associative literal `'{key: value, ...}`: seed the map from the
-  // (key, value) entries. The type-default slot still carries the element-type
+  // (key, value) entries. The default slots still carry the element-type
   // default for a read of an absent key.
-  AssociativeArray(V type_default, std::span<const std::tuple<K, V>> entries)
-      : type_default_(std::move(type_default)) {
+  AssociativeArray(V element_default, std::span<const std::tuple<K, V>> entries)
+      : element_default_(element_default),
+        discard_sink_(std::move(element_default)) {
     for (const auto& [key, value] : entries) {
       data_.insert_or_assign(key, value);
     }
@@ -98,8 +103,10 @@ class AssociativeArray {
   // of an absent key returns (LRM 7.8.6) and the seed for an entry allocated on
   // a later write (LRM 7.8.7).
   AssociativeArray(
-      V type_default, std::span<const std::tuple<K, V>> entries, V user_default)
-      : type_default_(std::move(type_default)),
+      V element_default, std::span<const std::tuple<K, V>> entries,
+      V user_default)
+      : element_default_(element_default),
+        discard_sink_(std::move(element_default)),
         user_default_(std::move(user_default)) {
     for (const auto& [key, value] : entries) {
       data_.insert_or_assign(key, value);
@@ -162,19 +169,18 @@ class AssociativeArray {
   // LRM 7.8.7 / 7.9.11: a write target allocates the absent entry seeded with
   // the user-specified default if one was set, otherwise the element-type
   // default, then yields a reference the caller stores into. An invalid key
-  // (LRM 7.8.6) yields the type-default slot instead, so the write is
-  // discarded.
+  // (LRM 7.8.6) yields the discard sink instead, so the write is discarded.
   [[nodiscard]] auto ElementRef(const K& key) -> V& {
     if (IsInvalidKey(key)) {
-      type_default_.ResetToDefault();
-      return type_default_;
+      discard_sink_.ResetToDefault();
+      return discard_sink_;
     }
     auto it = data_.find(key);
     if (it == data_.end()) {
       it = data_
                .emplace(
-                   key,
-                   user_default_.has_value() ? *user_default_ : type_default_)
+                   key, user_default_.has_value() ? *user_default_
+                                                  : element_default_)
                .first;
     }
     return it->second;
@@ -347,17 +353,13 @@ class AssociativeArray {
 
   // The value a read of an absent or invalid key yields (LRM 7.8.6 / 7.9.11):
   // the persistent user default when one was set, otherwise the element-type
-  // default. The type-default slot is restored first so a prior discarded write
-  // does not leak into the result.
+  // default. `element_default_` is never written, so it is returned directly.
   [[nodiscard]] auto MissValue() const -> const V& {
-    if (user_default_.has_value()) {
-      return *user_default_;
-    }
-    type_default_.ResetToDefault();
-    return type_default_;
+    return user_default_.has_value() ? *user_default_ : element_default_;
   }
 
-  mutable V type_default_;
+  V element_default_;
+  V discard_sink_;
   std::optional<V> user_default_;
   std::map<K, V, typename AssocKeyTraits<K>::Less> data_;
 };

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -23,63 +23,72 @@ namespace lyra::value {
 // SystemVerilog dynamic array (LRM 7.5). Size set at run time via `new[N]` /
 // `new[N](other)` constructors; default is the empty array (LRM Table 6-7).
 //
-// `oob_slot_` is the LRM 7.4.5 invalid-index shield. Its state is restored
-// to the canonical default on every OOB access via `T::ResetToDefault`, so
-// reads after an OOB write observe the LRM Table 7-1 default rather than
-// whatever the prior write left in the slot. It is supplied at construction
-// because `T = PackedArray` requires runtime shape parameters (bit width,
-// signedness, 2/4-state) that cannot be recovered from the C++ type alone.
-// See `docs/decisions/runtime-shape-and-default-value.md`.
+// `element_default_` holds the LRM Table 7-1 default an invalid-index read
+// returns (LRM 7.4.5) and the prototype every fill / slice / locator copies.
+// It carries the element's runtime shape (bit width, signedness, 2/4-state for
+// `T = PackedArray`) that the C++ type alone cannot recover, so it is supplied
+// at construction. It is only ever read or copied, never written, so a const
+// read returns it directly with no scrub. `discard_sink_` is the throwaway an
+// invalid-index write lands on; the non-const write path scrubs it to canonical
+// via `T::ResetToDefault` before handing out the reference, so a discarded
+// write never leaks into a later access. See
+// `docs/decisions/runtime-shape-and-default-value.md`.
 template <typename T>
 class DynamicArray {
  public:
   using ElementType = T;
 
   // Sentinel "uninitialized" form -- empty container with default-constructed
-  // OOB slot. Used as the declared default state of a `Var<DynamicArray<T>>`
-  // field; the first MIR-level assignment overwrites the whole array (LRM
-  // 10.5 variable initialization).
+  // default / sink slots. Used as the declared default state of a
+  // `Var<DynamicArray<T>>` field; the first MIR-level assignment overwrites the
+  // whole array (LRM 10.5 variable initialization).
   DynamicArray() = default;
 
-  // Empty container with the shield slot seeded. Used for declarations like
-  // `int arr[];` where the array starts empty but the element shape is
+  // Empty container with the default / sink slots seeded. Used for declarations
+  // like `int arr[];` where the array starts empty but the element shape is
   // known at lowering time.
-  explicit DynamicArray(T oob_slot) : oob_slot_(std::move(oob_slot)) {
+  explicit DynamicArray(T element_default)
+      : element_default_(element_default),
+        discard_sink_(std::move(element_default)) {
   }
 
-  // LRM 7.5.1 `new[N]`: build `n` elements, each a copy of the shield-slot
-  // seed (which is also the canonical default). `n` is a longint per LRM
-  // 7.5.1; the negative-N case throws at construction.
-  DynamicArray(const PackedArray& n, T oob_slot)
-      : oob_slot_(std::move(oob_slot)) {
+  // LRM 7.5.1 `new[N]`: build `n` elements, each a copy of the element default.
+  // `n` is a longint per LRM 7.5.1; the negative-N case throws at construction.
+  DynamicArray(const PackedArray& n, T element_default)
+      : element_default_(element_default),
+        discard_sink_(std::move(element_default)) {
     const std::int64_t n_val = n.ToInt64();
     if (n_val < 0) {
       throw InternalError(
           "DynamicArray::new[N]: size operand is negative (LRM 7.5.1)");
     }
-    data_.assign(static_cast<std::size_t>(n_val), oob_slot_);
+    data_.assign(static_cast<std::size_t>(n_val), element_default_);
   }
 
-  // LRM 7.5.1 `new[N](other)`: copy `other` then `resize(N, oob_slot_)` --
-  // `std::vector::resize` truncates when target is smaller and pads with
-  // the fill value when target is larger, covering both halves of LRM
-  // 7.5.1 in one call.
-  DynamicArray(const PackedArray& n, T oob_slot, const DynamicArray& src)
-      : oob_slot_(std::move(oob_slot)), data_(src.data_) {
+  // LRM 7.5.1 `new[N](other)`: copy `other` then `resize(N, element_default_)`
+  // -- `std::vector::resize` truncates when target is smaller and pads with the
+  // fill value when target is larger, covering both halves of LRM 7.5.1 in one
+  // call.
+  DynamicArray(const PackedArray& n, T element_default, const DynamicArray& src)
+      : element_default_(element_default),
+        discard_sink_(std::move(element_default)),
+        data_(src.data_) {
     const std::int64_t n_val = n.ToInt64();
     if (n_val < 0) {
       throw InternalError(
           "DynamicArray::new[N](src): size operand is negative (LRM 7.5.1)");
     }
-    data_.resize(static_cast<std::size_t>(n_val), oob_slot_);
+    data_.resize(static_cast<std::size_t>(n_val), element_default_);
   }
 
-  // LRM 10.9.1 assignment-pattern construction: shield slot seeded, size
-  // taken from the pattern's element list. Mirrors `UnpackedArray`'s span
+  // LRM 10.9.1 assignment-pattern construction: default / sink slots seeded,
+  // size taken from the pattern's element list. Mirrors `UnpackedArray`'s span
   // ctor so a single emit path produces `std::array<T, N>{...}` as the
   // second argument for either container.
-  DynamicArray(T oob_slot, std::span<const T> init)
-      : oob_slot_(std::move(oob_slot)), data_(init.begin(), init.end()) {
+  DynamicArray(T element_default, std::span<const T> init)
+      : element_default_(element_default),
+        discard_sink_(std::move(element_default)),
+        data_(init.begin(), init.end()) {
   }
 
   DynamicArray(const DynamicArray&) = default;
@@ -99,7 +108,8 @@ class DynamicArray {
   // NOLINTNEXTLINE(readability-identifier-naming)
   friend auto swap(DynamicArray& a, DynamicArray& b) noexcept -> void {
     using std::swap;
-    swap(a.oob_slot_, b.oob_slot_);
+    swap(a.element_default_, b.element_default_);
+    swap(a.discard_sink_, b.discard_sink_);
     swap(a.data_, b.data_);
   }
 
@@ -121,31 +131,31 @@ class DynamicArray {
   }
 
   // LRM Table 6-7: dynamic array default is the empty array. When this
-  // container is itself an OOB shield slot of an outer container, the outer
-  // calls this method to restore canonical state before handing out a
-  // reference; any subsequent inner access then re-OOBs naturally (data_ is
-  // empty), so chained access through the shield never observes a stale
+  // container is itself the discard sink of an outer container, the outer
+  // scrubs it to canonical state before handing out a reference; any subsequent
+  // inner access then re-misses naturally (data_ is empty), so chained access
+  // through the sink never observes a stale
   // write.
   auto ResetToDefault() -> void {
     data_.clear();
   }
 
-  // LRM 7.4.5: an invalid index routes through `oob_slot_`. The slot is
-  // restored to canonical state before the reference is handed out, so OOB
-  // writes that mutate it are erased on the next OOB access -- the shield
-  // never accumulates state.
+  // LRM 7.4.5: an invalid-index write lands on `discard_sink_`, scrubbed to
+  // canonical first so a compound write reads the element default before the
+  // result is thrown away.
   [[nodiscard]] auto ElementRef(const PackedArray& idx) -> T& {
     if (IsInvalidIndex(idx)) {
-      oob_slot_.ResetToDefault();
-      return oob_slot_;
+      discard_sink_.ResetToDefault();
+      return discard_sink_;
     }
     return data_[static_cast<std::size_t>(idx.ToInt64())];
   }
 
+  // LRM 7.4.5: an invalid-index read returns the element default (LRM Table
+  // 7-1) directly -- `element_default_` is never written, so no scrub.
   [[nodiscard]] auto Element(const PackedArray& idx) const -> const T& {
     if (IsInvalidIndex(idx)) {
-      oob_slot_.ResetToDefault();
-      return oob_slot_;
+      return element_default_;
     }
     return data_[static_cast<std::size_t>(idx.ToInt64())];
   }
@@ -158,16 +168,16 @@ class DynamicArray {
       const PackedArray& offset, const PackedArray& count_pa) const
       -> UnpackedArray<T> {
     const auto count = static_cast<std::uint32_t>(count_pa.ToInt64());
-    const T canonical = MakeCanonicalElement();
     return UnpackedArray<T>(
-        canonical, detail::ArraySliceGather(data_, canonical, offset, count));
+        element_default_,
+        detail::ArraySliceGather(data_, element_default_, offset, count));
   }
 
   [[nodiscard]] auto SliceRef(
       const PackedArray& offset, const PackedArray& count_pa)
       -> ArraySliceRef<T> {
     const auto count = static_cast<std::uint32_t>(count_pa.ToInt64());
-    return ArraySliceRef<T>{data_, MakeCanonicalElement(), offset, count};
+    return ArraySliceRef<T>{data_, element_default_, offset, count};
   }
 
   // LRM 11.2.2 + 11.4.5 aggregate equality. Runtime size mismatch yields
@@ -239,8 +249,8 @@ class DynamicArray {
   // LRM 7.5.3: empties the array, resulting in a zero-sized array. Body is
   // identical to ResetToDefault (LRM Table 6-7 default for dynamic array is
   // the empty array), but the two surface names track distinct contracts:
-  // Delete is the user-facing method name; ResetToDefault is the OOB-shield
-  // protocol shared with PackedArray / UnpackedArray.
+  // Delete is the user-facing method name; ResetToDefault is the
+  // canonical-reset protocol shared with PackedArray / UnpackedArray.
   auto Delete() -> void {
     data_.clear();
   }
@@ -268,49 +278,50 @@ class DynamicArray {
   [[nodiscard]] auto Sum(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return detail::ArrayFold(
-        data_, oob_slot_, std::forward<F>(key),
+        data_, element_default_, std::forward<F>(key),
         [](auto& acc, auto& v) { acc = acc + v; });
   }
   template <typename F>
   [[nodiscard]] auto Product(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return detail::ArrayFold(
-        data_, oob_slot_, std::forward<F>(key),
+        data_, element_default_, std::forward<F>(key),
         [](auto& acc, auto& v) { acc = acc * v; });
   }
   template <typename F>
   [[nodiscard]] auto And(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return detail::ArrayFold(
-        data_, oob_slot_, std::forward<F>(key),
+        data_, element_default_, std::forward<F>(key),
         [](auto& acc, auto& v) { acc = acc & v; });
   }
   template <typename F>
   [[nodiscard]] auto Or(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return detail::ArrayFold(
-        data_, oob_slot_, std::forward<F>(key),
+        data_, element_default_, std::forward<F>(key),
         [](auto& acc, auto& v) { acc = acc | v; });
   }
   template <typename F>
   [[nodiscard]] auto Xor(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return detail::ArrayFold(
-        data_, oob_slot_, std::forward<F>(key),
+        data_, element_default_, std::forward<F>(key),
         [](auto& acc, auto& v) { acc = acc ^ v; });
   }
 
   // LRM 7.12.1 locator methods, thin wrappers over the shared `detail::Array*`
   // algorithms. The value locators (`find`, `find_first`, `find_last`, `min`,
   // `max`, `unique`) return a queue of elements carrying this array's element
-  // shape via `oob_slot_`; the index locators return a queue of `int` whose
-  // shield is a plain zero. No match or an empty receiver yields an empty
-  // queue. The `with` clause is mandatory for the find family (a Boolean
-  // predicate) and optional for `min` / `max` / `unique` (a comparison key,
-  // defaulting to the element).
+  // shape via `element_default_`; the index locators return a queue of `int`
+  // whose element default is a plain zero. No match or an empty receiver yields
+  // an empty queue. The `with` clause is mandatory for the find family (a
+  // Boolean predicate) and optional for `min` / `max` / `unique` (a comparison
+  // key, defaulting to the element).
   template <typename F>
   [[nodiscard]] auto Find(F pred) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayFind(data_, std::move(pred)));
+    return Queue<T>(
+        element_default_, detail::ArrayFind(data_, std::move(pred)));
   }
   template <typename F>
   [[nodiscard]] auto FindIndex(F pred) const -> Queue<PackedArray> {
@@ -319,7 +330,8 @@ class DynamicArray {
   }
   template <typename F>
   [[nodiscard]] auto FindFirst(F pred) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayFindFirst(data_, std::move(pred)));
+    return Queue<T>(
+        element_default_, detail::ArrayFindFirst(data_, std::move(pred)));
   }
   template <typename F>
   [[nodiscard]] auto FindFirstIndex(F pred) const -> Queue<PackedArray> {
@@ -329,7 +341,8 @@ class DynamicArray {
   }
   template <typename F>
   [[nodiscard]] auto FindLast(F pred) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayFindLast(data_, std::move(pred)));
+    return Queue<T>(
+        element_default_, detail::ArrayFindLast(data_, std::move(pred)));
   }
   template <typename F>
   [[nodiscard]] auto FindLastIndex(F pred) const -> Queue<PackedArray> {
@@ -339,15 +352,18 @@ class DynamicArray {
   }
   template <typename F>
   [[nodiscard]] auto Min(F&& key) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayMin(data_, std::forward<F>(key)));
+    return Queue<T>(
+        element_default_, detail::ArrayMin(data_, std::forward<F>(key)));
   }
   template <typename F>
   [[nodiscard]] auto Max(F&& key) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayMax(data_, std::forward<F>(key)));
+    return Queue<T>(
+        element_default_, detail::ArrayMax(data_, std::forward<F>(key)));
   }
   template <typename F>
   [[nodiscard]] auto Unique(F key) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayUnique(data_, std::move(key)));
+    return Queue<T>(
+        element_default_, detail::ArrayUnique(data_, std::move(key)));
   }
   template <typename F>
   [[nodiscard]] auto UniqueIndex(F key) const -> Queue<PackedArray> {
@@ -355,11 +371,13 @@ class DynamicArray {
         PackedArray::Int(0), detail::ArrayUniqueIndex(data_, std::move(key))};
   }
 
-  // LRM 7.12.5 projection into a same-shape dynamic array; `shield` seeds the
-  // result element type's canonical default.
+  // LRM 7.12.5 projection into a same-shape dynamic array; `element_default`
+  // seeds the result element type's canonical default.
   template <typename F, typename U>
-  [[nodiscard]] auto Map(F closure, U shield) const -> DynamicArray<U> {
-    return DynamicArray<U>(std::move(shield), detail::ArrayMap(data_, closure));
+  [[nodiscard]] auto Map(F closure, U element_default) const
+      -> DynamicArray<U> {
+    return DynamicArray<U>(
+        std::move(element_default), detail::ArrayMap(data_, closure));
   }
 
  private:
@@ -370,15 +388,8 @@ class DynamicArray {
                         static_cast<std::uint64_t>(data_.size());
   }
 
-  // Returns a fresh `T` at this container's element shape in LRM Table 7-1
-  // canonical state, disconnected from the OOB shield identity (slice fill).
-  [[nodiscard]] auto MakeCanonicalElement() const -> T {
-    T fresh = oob_slot_;
-    fresh.ResetToDefault();
-    return fresh;
-  }
-
-  mutable T oob_slot_;
+  T element_default_;
+  T discard_sink_;
   std::vector<T> data_;
 };
 

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -25,55 +25,65 @@ namespace lyra::value {
 // `std::deque<T>` rather than the `std::vector<T>` the dynamic array uses.
 // Default value is the empty queue (LRM Table 6-7).
 //
-// `oob_slot_` is the LRM 7.4.5 invalid-index shield seed, supplied at
-// construction because `T = PackedArray` carries runtime shape parameters
-// (bit width, signedness, 2/4-state) that cannot be recovered from the C++
-// type alone. See `docs/decisions/runtime-shape-and-default-value.md`. It
-// holds the element's canonical default for construction and the OOB-shield
-// protocol (`ResetToDefault`) shared with the other container wrappers.
+// `element_default_` holds the LRM Table 7-1 default an invalid-index read
+// returns (LRM 7.4.5 / 7.10.1) and the prototype that seeds construction,
+// growth (the `q[$+1]` append), slice / locator results, and an empty-queue
+// pop. It carries the element's runtime shape (bit width, signedness,
+// 2/4-state for `T = PackedArray`) that the C++ type alone cannot recover, so
+// it is supplied at construction; it is only ever read or copied, never
+// written, so a const read returns it directly with no scrub. `discard_sink_`
+// is the throwaway an invalid-index write lands on; the non-const write path
+// scrubs it to canonical via `T::ResetToDefault` before handing out the
+// reference. See `docs/decisions/runtime-shape-and-default-value.md`.
 template <typename T>
 class Queue {
  public:
   using ElementType = T;
 
-  // Sentinel "uninitialized" form -- empty queue with a default-constructed
-  // OOB slot. Used as the declared default state of a queue field; the first
-  // MIR-level assignment overwrites the whole queue (LRM 10.5 variable
-  // initialization).
+  // Sentinel "uninitialized" form -- empty queue with default-constructed
+  // default / sink slots. Used as the declared default state of a queue field;
+  // the first MIR-level assignment overwrites the whole queue (LRM 10.5
+  // variable initialization).
   Queue() = default;
 
-  // Empty queue with the shield slot seeded. Used for declarations like
-  // `int q[$];` where the queue starts empty but the element shape is known
-  // at lowering time.
-  explicit Queue(T oob_slot)
-      : oob_slot_(std::move(oob_slot)), oob_seeded_(true) {
+  // Empty queue with the default / sink slots seeded. Used for declarations
+  // like `int q[$];` where the queue starts empty but the element shape is
+  // known at lowering time.
+  explicit Queue(T element_default)
+      : element_default_(element_default),
+        discard_sink_(std::move(element_default)),
+        default_seeded_(true) {
   }
 
-  // LRM 10.9.1 assignment-pattern construction: shield slot seeded, elements
-  // taken from the pattern's list. The list is a span so the emit side hands
-  // in a `std::array<T, N>{...}` literal, mirroring `DynamicArray`.
-  Queue(T oob_slot, std::span<const T> init)
-      : oob_slot_(std::move(oob_slot)),
+  // LRM 10.9.1 assignment-pattern construction: default / sink slots seeded,
+  // elements taken from the pattern's list. The list is a span so the emit side
+  // hands in a `std::array<T, N>{...}` literal, mirroring `DynamicArray`.
+  Queue(T element_default, std::span<const T> init)
+      : element_default_(element_default),
+        discard_sink_(std::move(element_default)),
         data_(init.begin(), init.end()),
-        oob_seeded_(true) {
+        default_seeded_(true) {
   }
 
   // LRM 7.10.5 bounded queue `int q[$:N]`: the empty start is unchanged, but
   // the maximum index N is recorded so growth past N+1 elements is discarded
   // with a warning. The bound arrives as a PackedArray construction argument.
-  Queue(T oob_slot, const PackedArray& max_bound)
-      : oob_slot_(std::move(oob_slot)),
+  Queue(T element_default, const PackedArray& max_bound)
+      : element_default_(element_default),
+        discard_sink_(std::move(element_default)),
         max_bound_(static_cast<std::uint64_t>(max_bound.ToInt64())),
-        oob_seeded_(true) {
+        default_seeded_(true) {
   }
 
   // LRM 7.10.5 bounded queue initialized by an assignment pattern: take the
   // pattern's elements, record the bound, and trim any overflow on entry.
-  Queue(T oob_slot, std::span<const T> init, const PackedArray& max_bound)
-      : oob_slot_(std::move(oob_slot)),
+  Queue(
+      T element_default, std::span<const T> init, const PackedArray& max_bound)
+      : element_default_(element_default),
+        discard_sink_(std::move(element_default)),
         data_(init.begin(), init.end()),
         max_bound_(static_cast<std::uint64_t>(max_bound.ToInt64())),
-        oob_seeded_(true) {
+        default_seeded_(true) {
     EnforceBound();
   }
 
@@ -89,9 +99,10 @@ class Queue {
   // concat result preserves the variable's shape rather than overwriting it.
   auto operator=(const Queue& other) -> Queue& {
     if (this != &other) {
-      if (!oob_seeded_ && other.oob_seeded_) {
-        oob_slot_ = other.oob_slot_;
-        oob_seeded_ = true;
+      if (!default_seeded_ && other.default_seeded_) {
+        element_default_ = other.element_default_;
+        discard_sink_ = other.element_default_;
+        default_seeded_ = true;
       }
       data_ = other.data_;
       if (!max_bound_.has_value()) {
@@ -103,9 +114,10 @@ class Queue {
   }
   auto operator=(Queue&& other) noexcept -> Queue& {
     if (this != &other) {
-      if (!oob_seeded_ && other.oob_seeded_) {
-        oob_slot_ = std::move(other.oob_slot_);
-        oob_seeded_ = true;
+      if (!default_seeded_ && other.default_seeded_) {
+        element_default_ = other.element_default_;
+        discard_sink_ = std::move(other.element_default_);
+        default_seeded_ = true;
       }
       data_ = std::move(other.data_);
       if (!max_bound_.has_value()) {
@@ -196,35 +208,34 @@ class Queue {
   }
 
   // LRM Table 6-7: a queue's default is the empty queue. When this container
-  // is itself an OOB shield slot of an outer container, the outer calls this
-  // to restore canonical state before handing out a reference.
+  // is itself the discard sink of an outer container, the outer scrubs it to
+  // canonical state before handing out a reference.
   auto ResetToDefault() -> void {
     data_.clear();
   }
 
-  // LRM 7.10.1 / 7.4.5 read: an index outside `0..size-1` (or carrying
-  // x/z) routes through `oob_slot_`, restored to canonical state first.
-  // Reads never grow the queue -- the write path owns the `q[$+1]` append
-  // semantic.
+  // LRM 7.10.1 / 7.4.5 read: an index outside `0..size-1` (or carrying x/z)
+  // misses. Reads never grow the queue -- the write path owns the `q[$+1]`
+  // append semantic. The non-const overload returns the writable scratch sink;
+  // the const overload returns the element default by direct reference.
   [[nodiscard]] auto Element(const PackedArray& idx) -> T& {
     if (IsInvalidIndex(idx)) {
-      oob_slot_.ResetToDefault();
-      return oob_slot_;
+      discard_sink_.ResetToDefault();
+      return discard_sink_;
     }
     return data_[static_cast<std::size_t>(idx.ToInt64())];
   }
 
   [[nodiscard]] auto Element(const PackedArray& idx) const -> const T& {
     if (IsInvalidIndex(idx)) {
-      oob_slot_.ResetToDefault();
-      return oob_slot_;
+      return element_default_;
     }
     return data_[static_cast<std::size_t>(idx.ToInt64())];
   }
 
   // LRM 7.10.1 write: `q[$+1] = v` (index == size) appends a default-shaped
   // slot and returns it. An x/z, negative, or beyond-`$+1` index lands on
-  // the discarded shield so the write is ignored. The backend routes here
+  // the discard sink so the write is ignored. The backend routes here
   // only for an element-write lvalue, so a read of `index == size` still
   // sees the default rather than growing the queue.
   [[nodiscard]] auto ElementRef(const PackedArray& idx) -> T& {
@@ -234,27 +245,27 @@ class Queue {
         return data_[static_cast<std::size_t>(v)];
       }
       if (v >= 0 && static_cast<std::uint64_t>(v) == data_.size()) {
-        oob_slot_.ResetToDefault();
-        data_.push_back(oob_slot_);
+        data_.push_back(element_default_);
         EnforceBound();
         if (static_cast<std::uint64_t>(v) < data_.size()) {
           return data_[static_cast<std::size_t>(v)];
         }
-        oob_slot_.ResetToDefault();
-        return oob_slot_;
+        discard_sink_.ResetToDefault();
+        return discard_sink_;
       }
     }
-    oob_slot_.ResetToDefault();
-    return oob_slot_;
+    discard_sink_.ResetToDefault();
+    return discard_sink_;
   }
 
   // LRM 7.10.1 queue slice `q[lo:hi]`. An x/z bound, or `lo > hi` after
   // clamping, yields the empty queue. `lo` clamps up to 0 and `hi` clamps down
   // to the last index (`q[a:b]` with `a < 0` is `q[0:b]`, with `b > $` is
-  // `q[a:$]`). The result carries this queue's element shape via `oob_slot_`.
+  // `q[a:$]`). The result carries this queue's element shape via
+  // `element_default_`.
   [[nodiscard]] auto Slice(const PackedArray& lo, const PackedArray& hi) const
       -> Queue {
-    Queue out(oob_slot_);
+    Queue out(element_default_);
     if (lo.HasUnknown() || hi.HasUnknown() || data_.empty()) {
       return out;
     }
@@ -278,12 +289,11 @@ class Queue {
   }
 
   // LRM 7.10.2.4 / 7.10.2.5: remove and return the first / last element. On an
-  // empty queue the result is the element type's LRM Table 7-1 default (the
-  // canonical seed held by `oob_slot_`) and the queue is left unchanged.
+  // empty queue the result is the element type's LRM Table 7-1 default (a copy
+  // of `element_default_`) and the queue is left unchanged.
   auto PopFront() -> T {
     if (data_.empty()) {
-      oob_slot_.ResetToDefault();
-      return oob_slot_;
+      return element_default_;
     }
     T front = std::move(data_.front());
     data_.pop_front();
@@ -291,8 +301,7 @@ class Queue {
   }
   auto PopBack() -> T {
     if (data_.empty()) {
-      oob_slot_.ResetToDefault();
-      return oob_slot_;
+      return element_default_;
     }
     T back = std::move(data_.back());
     data_.pop_back();
@@ -347,44 +356,46 @@ class Queue {
   [[nodiscard]] auto Sum(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return detail::ArrayFold(
-        data_, oob_slot_, std::forward<F>(key),
+        data_, element_default_, std::forward<F>(key),
         [](auto& acc, auto& v) { acc = acc + v; });
   }
   template <typename F>
   [[nodiscard]] auto Product(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return detail::ArrayFold(
-        data_, oob_slot_, std::forward<F>(key),
+        data_, element_default_, std::forward<F>(key),
         [](auto& acc, auto& v) { acc = acc * v; });
   }
   template <typename F>
   [[nodiscard]] auto And(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return detail::ArrayFold(
-        data_, oob_slot_, std::forward<F>(key),
+        data_, element_default_, std::forward<F>(key),
         [](auto& acc, auto& v) { acc = acc & v; });
   }
   template <typename F>
   [[nodiscard]] auto Or(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return detail::ArrayFold(
-        data_, oob_slot_, std::forward<F>(key),
+        data_, element_default_, std::forward<F>(key),
         [](auto& acc, auto& v) { acc = acc | v; });
   }
   template <typename F>
   [[nodiscard]] auto Xor(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return detail::ArrayFold(
-        data_, oob_slot_, std::forward<F>(key),
+        data_, element_default_, std::forward<F>(key),
         [](auto& acc, auto& v) { acc = acc ^ v; });
   }
 
   // LRM 7.12.1 locator methods. Value locators return a queue of elements
-  // carrying this queue's element shape via `oob_slot_`; index locators return
-  // a queue of `int`. No match or an empty receiver yields an empty queue.
+  // carrying this queue's element shape via `element_default_`; index locators
+  // return a queue of `int`. No match or an empty receiver yields an empty
+  // queue.
   template <typename F>
   [[nodiscard]] auto Find(F pred) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayFind(data_, std::move(pred)));
+    return Queue<T>(
+        element_default_, detail::ArrayFind(data_, std::move(pred)));
   }
   template <typename F>
   [[nodiscard]] auto FindIndex(F pred) const -> Queue<PackedArray> {
@@ -393,7 +404,8 @@ class Queue {
   }
   template <typename F>
   [[nodiscard]] auto FindFirst(F pred) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayFindFirst(data_, std::move(pred)));
+    return Queue<T>(
+        element_default_, detail::ArrayFindFirst(data_, std::move(pred)));
   }
   template <typename F>
   [[nodiscard]] auto FindFirstIndex(F pred) const -> Queue<PackedArray> {
@@ -403,7 +415,8 @@ class Queue {
   }
   template <typename F>
   [[nodiscard]] auto FindLast(F pred) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayFindLast(data_, std::move(pred)));
+    return Queue<T>(
+        element_default_, detail::ArrayFindLast(data_, std::move(pred)));
   }
   template <typename F>
   [[nodiscard]] auto FindLastIndex(F pred) const -> Queue<PackedArray> {
@@ -413,15 +426,18 @@ class Queue {
   }
   template <typename F>
   [[nodiscard]] auto Min(F&& key) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayMin(data_, std::forward<F>(key)));
+    return Queue<T>(
+        element_default_, detail::ArrayMin(data_, std::forward<F>(key)));
   }
   template <typename F>
   [[nodiscard]] auto Max(F&& key) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayMax(data_, std::forward<F>(key)));
+    return Queue<T>(
+        element_default_, detail::ArrayMax(data_, std::forward<F>(key)));
   }
   template <typename F>
   [[nodiscard]] auto Unique(F key) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayUnique(data_, std::move(key)));
+    return Queue<T>(
+        element_default_, detail::ArrayUnique(data_, std::move(key)));
   }
   template <typename F>
   [[nodiscard]] auto UniqueIndex(F key) const -> Queue<PackedArray> {
@@ -429,11 +445,12 @@ class Queue {
         PackedArray::Int(0), detail::ArrayUniqueIndex(data_, std::move(key))};
   }
 
-  // LRM 7.12.5 projection into a same-shape queue; `shield` seeds the result
-  // element type's canonical default.
+  // LRM 7.12.5 projection into a same-shape queue; `element_default` seeds the
+  // result element type's canonical default.
   template <typename F, typename U>
-  [[nodiscard]] auto Map(F closure, U shield) const -> Queue<U> {
-    return Queue<U>(std::move(shield), detail::ArrayMap(data_, closure));
+  [[nodiscard]] auto Map(F closure, U element_default) const -> Queue<U> {
+    return Queue<U>(
+        std::move(element_default), detail::ArrayMap(data_, closure));
   }
 
  private:
@@ -461,10 +478,11 @@ class Queue {
     }
   }
 
-  mutable T oob_slot_;
+  T element_default_;
+  T discard_sink_;
   std::deque<T> data_;
   std::optional<std::uint64_t> max_bound_ = std::nullopt;
-  bool oob_seeded_ = false;
+  bool default_seeded_ = false;
 };
 
 // LRM 10.10 unpacked array concatenation builder. The backend wraps each part

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -32,37 +32,44 @@ class ArraySliceRef;
 // 1-bit `PackedArray` so equality on aggregates propagates through the same
 // value-type the integral surface uses.
 //
-// `oob_slot_` is the LRM 7.4.5 invalid-index shield. Its state is restored
-// to the canonical default on every OOB access via `T::ResetToDefault`, so
-// reads after an OOB write observe the LRM Table 7-1 default rather than
-// whatever the prior write left in the slot. It is supplied at construction
-// because `T = PackedArray` requires runtime shape parameters (bit width,
-// signedness, 2/4-state) that cannot be recovered from the C++ type alone.
-// See `docs/decisions/runtime-shape-and-default-value.md`.
+// `element_default_` holds the LRM Table 7-1 default an invalid-index read
+// returns (LRM 7.4.5) and the prototype every fill / slice / locator copies.
+// It carries the element's runtime shape (bit width, signedness, 2/4-state for
+// `T = PackedArray`) that the C++ type alone cannot recover, so it is supplied
+// at construction. It is only ever read or copied, never written, so a const
+// read returns it directly with no scrub. `discard_sink_` is the throwaway an
+// invalid-index write lands on; the non-const write path scrubs it to canonical
+// via `T::ResetToDefault` before handing out the reference, so a discarded
+// write never leaks into a later access. See
+// `docs/decisions/runtime-shape-and-default-value.md`.
 template <typename T>
 class UnpackedArray {
  public:
   using ElementType = T;
 
   // Sentinel "uninitialized" form -- empty container with default-constructed
-  // OOB slot. Used as the declared default state of a `Var<UnpackedArray<T>>`
-  // field; the first MIR-level assignment overwrites the whole array (LRM
-  // 10.5 variable initialization).
+  // default / sink slots. Used as the declared default state of a
+  // `Var<UnpackedArray<T>>` field; the first MIR-level assignment overwrites
+  // the whole array (LRM 10.5 variable initialization).
   UnpackedArray() = default;
 
-  // Empty container with the shield slot seeded. Internal use only -- SV
-  // fixed-size arrays are always non-empty; this form serves `Slice` and
+  // Empty container with the default / sink slots seeded. Internal use only --
+  // SV fixed-size arrays are always non-empty; this form serves `Slice` and
   // similar paths that build a fresh `UnpackedArray` element-by-element.
-  explicit UnpackedArray(T oob_slot) : oob_slot_(std::move(oob_slot)) {
+  explicit UnpackedArray(T element_default)
+      : element_default_(element_default),
+        discard_sink_(std::move(element_default)) {
   }
 
-  // Element-list construction: shield slot seeded, plus the explicit
+  // Element-list construction: default / sink slots seeded, plus the explicit
   // initial elements (LRM 10.9 assignment pattern lowering). The element
   // list is taken as a span so the emit side can hand in a `std::array<T,
   // N>{...}` literal whose self-determined type is unambiguous, rather
   // than relying on context-dependent braced-init binding.
-  UnpackedArray(T oob_slot, std::span<const T> init)
-      : oob_slot_(std::move(oob_slot)), data_(init.begin(), init.end()) {
+  UnpackedArray(T element_default, std::span<const T> init)
+      : element_default_(element_default),
+        discard_sink_(std::move(element_default)),
+        data_(init.begin(), init.end()) {
   }
 
   UnpackedArray(const UnpackedArray&) = default;
@@ -96,32 +103,32 @@ class UnpackedArray {
 
   // LRM Table 7-1 default for a fixed-size unpacked array is "Array, all of
   // whose elements have the value specified in this table for that array's
-  // element type." When this container is itself the OOB shield slot of an
-  // outer container, the outer calls this method to restore the canonical
-  // all-defaults state before handing out a reference. This is O(N) in the
-  // unpacked dim and is the LRM-mandated cost of "all elements at default."
+  // element type." When this container is itself the discard sink of an outer
+  // container, the outer scrubs it to the canonical all-defaults state before
+  // handing out a reference. This is O(N) in the unpacked dim and is the
+  // LRM-mandated cost of "all elements at default."
   auto ResetToDefault() -> void {
     for (auto& elem : data_) {
       elem.ResetToDefault();
     }
   }
 
-  // LRM 7.4.5: an invalid index routes through `oob_slot_`. The slot is
-  // restored to canonical state before the reference is handed out, so OOB
-  // writes that mutate it are erased on the next OOB access -- the shield
-  // never accumulates state.
+  // LRM 7.4.5: an invalid-index write lands on `discard_sink_`, scrubbed to
+  // canonical first so a compound write reads the element default before the
+  // result is thrown away.
   [[nodiscard]] auto ElementRef(const PackedArray& idx) -> T& {
     if (IsInvalidIndex(idx)) {
-      oob_slot_.ResetToDefault();
-      return oob_slot_;
+      discard_sink_.ResetToDefault();
+      return discard_sink_;
     }
     return data_[static_cast<std::size_t>(idx.ToInt64())];
   }
 
+  // LRM 7.4.5: an invalid-index read returns the element default (LRM Table
+  // 7-1) directly -- `element_default_` is never written, so no scrub.
   [[nodiscard]] auto Element(const PackedArray& idx) const -> const T& {
     if (IsInvalidIndex(idx)) {
-      oob_slot_.ResetToDefault();
-      return oob_slot_;
+      return element_default_;
     }
     return data_[static_cast<std::size_t>(idx.ToInt64())];
   }
@@ -134,16 +141,16 @@ class UnpackedArray {
       const PackedArray& offset, const PackedArray& count_pa) const
       -> UnpackedArray {
     const auto count = static_cast<std::uint32_t>(count_pa.ToInt64());
-    const T canonical = MakeCanonicalElement();
     return UnpackedArray(
-        canonical, detail::ArraySliceGather(data_, canonical, offset, count));
+        element_default_,
+        detail::ArraySliceGather(data_, element_default_, offset, count));
   }
 
   [[nodiscard]] auto SliceRef(
       const PackedArray& offset, const PackedArray& count_pa)
       -> ArraySliceRef<T> {
     const auto count = static_cast<std::uint32_t>(count_pa.ToInt64());
-    return ArraySliceRef<T>{data_, MakeCanonicalElement(), offset, count};
+    return ArraySliceRef<T>{data_, element_default_, offset, count};
   }
 
   // LRM 11.2.2 + 11.4.5 aggregate equality / case-equality. Slang's binding
@@ -224,48 +231,50 @@ class UnpackedArray {
   [[nodiscard]] auto Sum(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return detail::ArrayFold(
-        data_, oob_slot_, std::forward<F>(key),
+        data_, element_default_, std::forward<F>(key),
         [](auto& acc, auto& v) { acc = acc + v; });
   }
   template <typename F>
   [[nodiscard]] auto Product(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return detail::ArrayFold(
-        data_, oob_slot_, std::forward<F>(key),
+        data_, element_default_, std::forward<F>(key),
         [](auto& acc, auto& v) { acc = acc * v; });
   }
   template <typename F>
   [[nodiscard]] auto And(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return detail::ArrayFold(
-        data_, oob_slot_, std::forward<F>(key),
+        data_, element_default_, std::forward<F>(key),
         [](auto& acc, auto& v) { acc = acc & v; });
   }
   template <typename F>
   [[nodiscard]] auto Or(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return detail::ArrayFold(
-        data_, oob_slot_, std::forward<F>(key),
+        data_, element_default_, std::forward<F>(key),
         [](auto& acc, auto& v) { acc = acc | v; });
   }
   template <typename F>
   [[nodiscard]] auto Xor(F&& key) const
       -> std::invoke_result_t<F&, const T&, const PackedArray&> {
     return detail::ArrayFold(
-        data_, oob_slot_, std::forward<F>(key),
+        data_, element_default_, std::forward<F>(key),
         [](auto& acc, auto& v) { acc = acc ^ v; });
   }
 
   // LRM 7.12.1 locator methods, thin wrappers over the shared `detail::Array*`
   // algorithms. The value locators (`find`, `find_first`, `find_last`, `min`,
   // `max`, `unique`) return a queue of elements carrying this array's element
-  // shape via `oob_slot_`; the index locators return a queue of `int` whose
-  // shield is a plain zero. No match yields an empty queue. The `with` clause
-  // is mandatory for the find family (a Boolean predicate) and optional for
-  // `min` / `max` / `unique` (a comparison key, defaulting to the element).
+  // shape via `element_default_`; the index locators return a queue of `int`
+  // whose element default is a plain zero. No match yields an empty queue. The
+  // `with` clause is mandatory for the find family (a Boolean predicate) and
+  // optional for `min` / `max` / `unique` (a comparison key, defaulting to the
+  // element).
   template <typename F>
   [[nodiscard]] auto Find(F pred) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayFind(data_, std::move(pred)));
+    return Queue<T>(
+        element_default_, detail::ArrayFind(data_, std::move(pred)));
   }
   template <typename F>
   [[nodiscard]] auto FindIndex(F pred) const -> Queue<PackedArray> {
@@ -274,7 +283,8 @@ class UnpackedArray {
   }
   template <typename F>
   [[nodiscard]] auto FindFirst(F pred) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayFindFirst(data_, std::move(pred)));
+    return Queue<T>(
+        element_default_, detail::ArrayFindFirst(data_, std::move(pred)));
   }
   template <typename F>
   [[nodiscard]] auto FindFirstIndex(F pred) const -> Queue<PackedArray> {
@@ -284,7 +294,8 @@ class UnpackedArray {
   }
   template <typename F>
   [[nodiscard]] auto FindLast(F pred) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayFindLast(data_, std::move(pred)));
+    return Queue<T>(
+        element_default_, detail::ArrayFindLast(data_, std::move(pred)));
   }
   template <typename F>
   [[nodiscard]] auto FindLastIndex(F pred) const -> Queue<PackedArray> {
@@ -294,15 +305,18 @@ class UnpackedArray {
   }
   template <typename F>
   [[nodiscard]] auto Min(F&& key) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayMin(data_, std::forward<F>(key)));
+    return Queue<T>(
+        element_default_, detail::ArrayMin(data_, std::forward<F>(key)));
   }
   template <typename F>
   [[nodiscard]] auto Max(F&& key) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayMax(data_, std::forward<F>(key)));
+    return Queue<T>(
+        element_default_, detail::ArrayMax(data_, std::forward<F>(key)));
   }
   template <typename F>
   [[nodiscard]] auto Unique(F key) const -> Queue<T> {
-    return Queue<T>(oob_slot_, detail::ArrayUnique(data_, std::move(key)));
+    return Queue<T>(
+        element_default_, detail::ArrayUnique(data_, std::move(key)));
   }
   template <typename F>
   [[nodiscard]] auto UniqueIndex(F key) const -> Queue<PackedArray> {
@@ -310,12 +324,13 @@ class UnpackedArray {
         PackedArray::Int(0), detail::ArrayUniqueIndex(data_, std::move(key))};
   }
 
-  // LRM 7.12.5 projection into a same-range fixed unpacked array; `shield`
-  // seeds the result element type's canonical default.
+  // LRM 7.12.5 projection into a same-range fixed unpacked array;
+  // `element_default` seeds the result element type's canonical default.
   template <typename F, typename U>
-  [[nodiscard]] auto Map(F closure, U shield) const -> UnpackedArray<U> {
+  [[nodiscard]] auto Map(F closure, U element_default) const
+      -> UnpackedArray<U> {
     return UnpackedArray<U>(
-        std::move(shield), detail::ArrayMap(data_, closure));
+        std::move(element_default), detail::ArrayMap(data_, closure));
   }
 
  private:
@@ -326,16 +341,8 @@ class UnpackedArray {
                         static_cast<std::uint64_t>(data_.size());
   }
 
-  // Returns a fresh `T` at this container's element shape in LRM Table 7-1
-  // canonical state. Used by paths that need a default element disconnected
-  // from the OOB shield identity (Slice fill, Slice-ref Clone).
-  [[nodiscard]] auto MakeCanonicalElement() const -> T {
-    T fresh = oob_slot_;
-    fresh.ResetToDefault();
-    return fresh;
-  }
-
-  mutable T oob_slot_;
+  T element_default_;
+  T discard_sink_;
   std::vector<T> data_;
 
   friend class ArraySliceRef<T>;


### PR DESCRIPTION
## Summary

Each variable-size container wrapper (fixed-size unpacked array, dynamic array, queue, associative array) carried a single `mutable` slot that fused three jobs: the immutable canonical default carrying the element's runtime shape, the value a read of a nonexistent or invalid entry returns (LRM 7.4.5 / 7.8.6 / Table 7-1), and the discard target an invalid write lands on. Because the write path dirtied the shared slot, the `const` read had to scrub it before returning a reference -- a const method that mutates, which is the only reason the slot needed `mutable` and the reason every read miss paid a `ResetToDefault`. This splits the slot into two fields, `element_default_` (immutable, returned directly by the const read) and `discard_sink_` (scrubbed only by the non-const write path), so the read path is genuinely const and the `mutable` qualifier disappears from all four wrappers.

## Design

The two fields are two distinct responsibilities, not a duplicated value: `element_default_` is the canonical default and the construction / grow / slice / locator prototype, never written so it stays pristine; `discard_sink_` is the throwaway an invalid write lands on, scrubbed to canonical before each hand-out so a compound op still reads the element default. Both are seeded from the same constructor argument. This reverses the prior "one mutable slot" choice in `docs/decisions/runtime-shape-and-default-value.md`, which weighed only the one-element-per-container memory cost and omitted the mutable / reset-on-read cost; the decision doc is revised to the two-field design.

The change also sharpens the progress-doc convention in `docs/progress/README.md`: items are written at the semantic level (problem and target shape, no field names or rationale), so completing one is flipping the checkbox rather than rewriting it into a past-tense account.

## Testing

`bazel build //...` and `bazel test //...` both pass.