### PR TITLE
Introduce a generic Arena pool for HIR and MIR nodes

### DIFF
--- a/docs/decisions/generic-lowering-machinery.md
+++ b/docs/decisions/generic-lowering-machinery.md
@@ -1,0 +1,101 @@
+# Generic lowering machinery, typed IR nodes
+
+Date: 2026-06-22 Status: accepted
+
+## Context
+
+Lowering is organized as a construction pass per unit of work: a procedural body (a process or
+subroutine) and a structural scope (a module or class body) are separate passes, because one lowers
+to a callable and the other to a class -- object versus callable, a real distinction that survives
+into MIR. Expressions, statements, members, and generate constructs all appear inside those scopes.
+
+Two kinds of duplication have accumulated around that split:
+
+1. **The arena pattern is hand-rolled everywhere.** A flat, id-indexed, append-only pool -- a
+   `vector<T>` plus `Get(Id)` that indexes it and `Add(T)` that pushes and returns the id -- is
+   written out by hand for every pool: the procedural body's expressions, statements, and locals;
+   the structural scope's roughly ten pools (members, generates, processes, continuous assigns,
+   ...); the MIR block's expressions, statements, and locals. The same three-line shape appears
+   twenty-odd times across HIR and MIR.
+
+2. **Every shared handler is duplicated along the procedural/structural axis.** Each expression
+   family carries two near-identical handlers -- one taking the procedural pass class, one taking
+   the structural pass class -- whose bodies differ only in the pass type and in how a
+   sub-expression is reached (read accessor at HIR-to-MIR, write target at AST-to-HIR). The
+   expression-lowering logic itself is identical, because an expression's meaning does not depend on
+   whether a process or a structural scope encloses it. The twins drift: a guard or a value
+   realization added on one path is missed on the other.
+
+The design question is how generic to make this. Two failure modes bracket the answer: leaving the
+duplication, and collapsing every IR node into one generic node so that containment and traversal
+are uniform but nothing is typed.
+
+## Decision
+
+Make the machinery generic; keep the nodes typed.
+
+1. **A universal `Arena<T>`.** One generic flat, id-indexed, append-only pool replaces every
+   hand-rolled `vector<T>` + `Get` + `Add`. It is layer-agnostic and node-agnostic: it carries no
+   knowledge of what it stores, only that the pool is indexed by a typed id. A pool that
+   deduplicates on insert (type interning) is not this shape -- it is an interning table (an arena
+   plus a key-to-id cache) and keeps its own type.
+
+2. **Context-free expression lowering, shared across pass classes.** Because an expression's meaning
+   is independent of the enclosing scope, the handler that lowers an expression family is written
+   once as a function template parameterized over the pass class, reaching its sub-expressions
+   through one uniform accessor. The two pass classes are not merged: they build genuinely different
+   things (a callable body versus a class) and accumulate different state. The template shares the
+   code without erasing the distinction; it is duck-typed, with no shared base class.
+
+3. **Typed nodes; the distinction lives at the scope level.** HIR nodes stay SV-faithful and typed
+   -- loops are loops, generate is generate -- and MIR nodes are the generic programming-language
+   set. The procedural/structural distinction belongs where the two genuinely differ: a procedural
+   body holds statements and locals, a structural scope holds members, generates, and child scopes.
+   It never belongs at the expression level, where the two are identical. The generic `Arena<T>` and
+   the shared handler templates are how that uniformity is expressed without flattening the node
+   types.
+
+## Rejected
+
+- **Status quo: per-pass-class handler twins and per-pool hand-rolled arenas.** Every new expression
+  kind doubles the handler count; every pool re-rolls the same boilerplate; the twin handlers drift
+  silently. This is the debt being paid down.
+- **Merge the two pass classes (or the two scope types) into one.** A procedural body lowers to a
+  callable and a structural scope to a class -- object versus callable, a distinction MIR carries as
+  a first-class fact. Merging them blurs it and forces a scope type that is a union of
+  statements-or-members, generate-or-control-flow, pushing a `which-kind` branch into every consumer
+  that the type system would otherwise carry.
+- **A fully generic uniform node (one node kind with generic nested regions).** Maximally DRY, but
+  it discards type safety and the SV-faithfulness HIR exists to provide: "loops are loops, generate
+  is generate" becomes "everything is a node." HIR's typed SV constructs and MIR's typed entity set
+  are deliberate; a uniform node model reverses both. Genericity belongs in the machinery that
+  carries and traverses nodes, not in the node identities themselves. This is the line between the
+  chosen design and the rejected one: generic container, typed contents.
+- **A one-off shared arena for expressions only.** The arena pattern is pervasive, not
+  expression-specific; a bespoke expression arena repeats the same hand-rolling at smaller scale.
+  The right generic is `Arena<T>`, applied to every pool.
+
+## Consequences
+
+- `Arena<T>` replaces every append-only id-indexed pool across HIR and MIR. Interning tables keep
+  their dedup shape.
+- With both scopes' expression pools typed as the same `Arena<Expr>`, the procedural and structural
+  expression handlers collapse to one template per family, reached through a uniform accessor.
+  Statement, generate, and member handlers stay distinct, because those constructs genuinely differ.
+- The pass classes stay distinct; the node types stay typed. Generate keeps its SV-faithful form in
+  HIR and is lowered at HIR-to-MIR into ordinary `if` and loop statements in a constructor callable,
+  so MIR has no generate node -- the SV-distinct HIR constructs converge onto the generic MIR set
+  exactly where the layer identities require.
+- `lowering_organization.md` gains a clause: a handler shared across pass classes is one function
+  template, never a duplicated twin.
+
+## Cross-references
+
+- `architecture/north_star.md` (compile per unit; class-level artifacts versus callables).
+- `architecture/hir.md` (SV-faithful, typed constructs).
+- `architecture/mir.md` (object versus callable; an expression node whose meaning depends on the
+  enclosing callable is forbidden).
+- `architecture/lowering_organization.md` (the pass / dispatcher / handler / walk-frame shape this
+  refines).
+- `progress/generic-lowering.md` (the staged migration).
+- `progress/refactor.md` R34 (the AST-to-HIR drift-bug slice, in flight separately).

--- a/docs/progress/generic-lowering.md
+++ b/docs/progress/generic-lowering.md
@@ -10,30 +10,40 @@ rejected alternatives.
 
 ## Actionable
 
-Phase 1 (the generic arena) is standalone and can start immediately -- it is a mechanical,
-behavior-preserving container swap that touches no handler logic. Phases 2 and 3 build on it.
+Phase 1 (the generic arena) is standalone and can start immediately. The arena swap is mechanical
+and behavior-preserving; the bulk of the work is paying down the existing accessor-bypass debt that
+the swap surfaces (see below). Phases 2 and 3 build on it.
+
+The arena's surface is fixed by what consumers actually do: a const lookup by typed id, an append
+that returns the id, a count and an emptiness check, and an indexed iteration (the dumper prints
+each node with its id). It exposes no raw integer index and no mutable lookup -- nothing mutates a
+node in place. Three shapes are deliberately not this arena: a deduplicating pool (type interning, a
+lookup-or-insert with a key cache); a field that holds a sequence of ids rather than owned nodes (a
+body's top-level statement order, an entry-statement id); and the composite append helpers that
+build on a pool (declare-a-local, append-an-if), which keep their logic and delegate to the pool
+underneath.
 
 ## Sub-Steps
 
-### Phase 1 -- Generic arena
+### Phase 1 -- Generic arena and uniform access
 
-- [ ] Introduce one generic append-only, id-indexed pool abstraction (a value pool with a typed-id
-      lookup and an append that returns the id).
+- [ ] Introduce one generic append-only, id-indexed pool abstraction with the surface above (const
+      lookup, append, count, indexed iteration; no raw index, no mutable lookup).
 - [ ] Route every hand-rolled HIR pool through it: the procedural body's expression, statement, and
       local pools; every append-only pool on the structural scope.
 - [ ] Route every hand-rolled MIR pool through it: the block's expression, statement, and local
-      pools, and the unit's append-only pools.
-- [ ] Leave deduplicating pools (type interning) on their interning-table shape, not the plain
-      arena.
-
-### Phase 2 -- Uniform sub-node access
-
-- [ ] HIR-to-MIR: both pass classes reach a sub-expression through one uniform accessor; the
-      divergent read styles are gone.
+      pools, the class's pools, and the unit's append-only pools.
+- [ ] Replace the raw-index accessor bypass (sub-nodes read by indexing the pool's backing vector
+      directly rather than through the typed lookup) with the typed lookup. This is pre-existing
+      debt, not new work; fixing it also collapses the procedural/structural read-access divergence,
+      so the read side of sub-node access is uniform once this lands.
 - [ ] AST-to-HIR: the walk position carries one expression write target instead of two parallel
-      ones, with the statement and member write targets kept separate.
+      ones, with the statement and member write targets kept separate. With both scopes' expression
+      pools now the same arena type, the read and write sides of sub-node access are both uniform.
+- [ ] Leave deduplicating pools (type interning), id-sequence fields, and composite append helpers
+      in their own shapes (see Actionable).
 
-### Phase 3 -- Share the expression handlers
+### Phase 2 -- Share the expression handlers
 
 - [ ] HIR-to-MIR: each expression family's procedural and structural handlers become one function
       template over the pass class. Pilot with the select family (the largest duplication), then the

--- a/docs/progress/generic-lowering.md
+++ b/docs/progress/generic-lowering.md
@@ -1,0 +1,58 @@
+# Generic Lowering
+
+Makes the lowering machinery generic while keeping the IR node types typed. Done when every
+append-only id-indexed pool in HIR and MIR is one generic arena, and the expression-lowering
+handlers shared across the procedural and structural pass classes are single function templates
+rather than duplicated twins. The procedural/structural distinction is preserved where the two
+genuinely differ (statements versus members and generates) and removed from the expression layer,
+where they are identical. See `decisions/generic-lowering-machinery.md` for the rationale and the
+rejected alternatives.
+
+## Actionable
+
+Phase 1 (the generic arena) is standalone and can start immediately -- it is a mechanical,
+behavior-preserving container swap that touches no handler logic. Phases 2 and 3 build on it.
+
+## Sub-Steps
+
+### Phase 1 -- Generic arena
+
+- [ ] Introduce one generic append-only, id-indexed pool abstraction (a value pool with a typed-id
+      lookup and an append that returns the id).
+- [ ] Route every hand-rolled HIR pool through it: the procedural body's expression, statement, and
+      local pools; every append-only pool on the structural scope.
+- [ ] Route every hand-rolled MIR pool through it: the block's expression, statement, and local
+      pools, and the unit's append-only pools.
+- [ ] Leave deduplicating pools (type interning) on their interning-table shape, not the plain
+      arena.
+
+### Phase 2 -- Uniform sub-node access
+
+- [ ] HIR-to-MIR: both pass classes reach a sub-expression through one uniform accessor; the
+      divergent read styles are gone.
+- [ ] AST-to-HIR: the walk position carries one expression write target instead of two parallel
+      ones, with the statement and member write targets kept separate.
+
+### Phase 3 -- Share the expression handlers
+
+- [ ] HIR-to-MIR: each expression family's procedural and structural handlers become one function
+      template over the pass class. Pilot with the select family (the largest duplication), then the
+      remaining families.
+- [ ] AST-to-HIR: the same collapse, sequenced after the in-flight drift-bug alignment lands (see
+      Coordination).
+- [ ] `lowering_organization.md` records that a handler shared across pass classes is one template,
+      never a duplicated twin.
+
+## Coordination
+
+- The AST-to-HIR slice overlaps `refactor.md` R34 (the procedural/structural HIR expression-lowering
+  drift bugs, in flight separately). Sequence the AST-to-HIR templating after R34's operand-guard
+  and value-realization alignment lands, so the two efforts do not edit the same handlers at once.
+  The HIR-to-MIR slice is independent and unblocked.
+
+## Out of Scope
+
+- Merging the pass classes or the scope types. A procedural body lowers to a callable and a
+  structural scope to a class; that distinction is real and stays.
+- A fully generic uniform IR node. The node types are deliberately typed and SV-faithful; only the
+  machinery that carries and traverses them is made generic.

--- a/include/lyra/backend/cpp/scope_view.hpp
+++ b/include/lyra/backend/cpp/scope_view.hpp
@@ -82,7 +82,7 @@ class ScopeView {
   }
 
   [[nodiscard]] auto Expr(mir::ExprId id) const -> const mir::Expr& {
-    return block_->GetExpr(id);
+    return block_->exprs.Get(id);
   }
 
  private:

--- a/include/lyra/base/arena.hpp
+++ b/include/lyra/base/arena.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace lyra::base {
+
+// A flat, append-only pool of `T` indexed by a typed id `Id`. `Id` is a struct
+// carrying a single `std::uint32_t value` (its position in the pool). One id is
+// minted per append, in insertion order, and stays valid for the life of the
+// arena. Lookup is by id only -- there is no raw integer index -- so the typed
+// id is the one handle a consumer holds. There is no mutable lookup: a node is
+// built before it is appended and is never edited in place.
+template <typename T, typename Id>
+class Arena {
+ public:
+  [[nodiscard]] auto Get(Id id) const -> const T& {
+    return items_.at(id.value);
+  }
+
+  auto Add(T value) -> Id {
+    const Id id{static_cast<std::uint32_t>(items_.size())};
+    items_.push_back(std::move(value));
+    return id;
+  }
+
+  [[nodiscard]] auto size() const -> std::size_t {
+    return items_.size();
+  }
+
+  [[nodiscard]] auto empty() const -> bool {
+    return items_.empty();
+  }
+
+  [[nodiscard]] auto begin() const {
+    return items_.begin();
+  }
+
+  [[nodiscard]] auto end() const {
+    return items_.end();
+  }
+
+ private:
+  std::vector<T> items_;
+};
+
+}  // namespace lyra::base

--- a/include/lyra/hir/expr_builders.hpp
+++ b/include/lyra/hir/expr_builders.hpp
@@ -11,9 +11,8 @@
 #include "lyra/hir/value_ref.hpp"
 
 // Pure builders for the synthetic HIR expressions a lowering reaches for
-// whenever it needs a counter, bound, or sentinel -- each a function of its
-// inputs plus a type and span, with no lowering state. The caller owns the
-// `AddExpr` into its body. The AST-to-HIR counterpart of
+// whenever it needs a counter, bound, or sentinel -- stateless, unlike the
+// lowering passes that own them. The AST-to-HIR counterpart of
 // `mir::MakeInt32Literal`.
 namespace lyra::hir {
 

--- a/include/lyra/hir/procedural_body.hpp
+++ b/include/lyra/hir/procedural_body.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <vector>
+#include <cstdint>
 
+#include "lyra/base/arena.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/stmt.hpp"
@@ -14,38 +15,11 @@ namespace lyra::hir {
 // body (a process kind and sensitivity, or a subroutine signature).
 struct ProceduralBody {
   StmtId root_stmt{};
-  std::vector<Expr> exprs;
-  std::vector<Stmt> stmts;
-  std::vector<ProceduralVarDecl> procedural_vars;
+  base::Arena<Expr, ExprId> exprs;
+  base::Arena<Stmt, StmtId> stmts;
+  base::Arena<ProceduralVarDecl, ProceduralVarId> procedural_vars;
   std::uint32_t loop_label_count = 0;
 
-  [[nodiscard]] auto GetExpr(ExprId id) const -> const Expr& {
-    return exprs.at(id.value);
-  }
-  [[nodiscard]] auto GetStmt(StmtId id) const -> const Stmt& {
-    return stmts.at(id.value);
-  }
-  [[nodiscard]] auto GetProceduralVar(ProceduralVarId id) const
-      -> const ProceduralVarDecl& {
-    return procedural_vars.at(id.value);
-  }
-
-  auto AddExpr(Expr expr) -> ExprId {
-    const ExprId id{static_cast<std::uint32_t>(exprs.size())};
-    exprs.push_back(std::move(expr));
-    return id;
-  }
-  auto AddStmt(Stmt stmt) -> StmtId {
-    const StmtId id{static_cast<std::uint32_t>(stmts.size())};
-    stmts.push_back(std::move(stmt));
-    return id;
-  }
-  auto AddProceduralVar(ProceduralVarDecl decl) -> ProceduralVarId {
-    const ProceduralVarId id{
-        static_cast<std::uint32_t>(procedural_vars.size())};
-    procedural_vars.push_back(std::move(decl));
-    return id;
-  }
   auto AddLoopLabel() -> LoopLabelId {
     return LoopLabelId{loop_label_count++};
   }

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -7,6 +7,7 @@
 #include <variant>
 #include <vector>
 
+#include "lyra/base/arena.hpp"
 #include "lyra/base/time.hpp"
 #include "lyra/hir/continuous_assign.hpp"
 #include "lyra/hir/expr.hpp"
@@ -140,10 +141,7 @@ using GenerateData = std::variant<IfGenerate, CaseGenerate, LoopGenerate>;
 
 struct Generate {
   GenerateData data;
-  std::vector<StructuralScope> child_scopes;
-
-  [[nodiscard]] auto GetChildScope(StructuralScopeId id) const
-      -> const StructuralScope&;
+  base::Arena<StructuralScope, StructuralScopeId> child_scopes;
 };
 
 struct StructuralScope {
@@ -152,103 +150,20 @@ struct StructuralScope {
   // LRM 27.6); empty for other scopes.
   std::string source_name;
   TimeResolution time_resolution;
-  std::vector<StructuralVarDecl> structural_vars;
-  std::vector<LoopVarDecl> loop_var_decls;
-  std::vector<Expr> exprs;
-  std::vector<Process> processes;
-  std::vector<ContinuousAssign> continuous_assigns;
-  std::vector<Generate> generates;
-  std::vector<InstanceMemberDecl> instance_members;
-  std::vector<CrossUnitRefDecl> cross_unit_refs;
-  std::vector<StructuralSubroutineDecl> structural_subroutines;
+  base::Arena<StructuralVarDecl, StructuralVarId> structural_vars;
+  base::Arena<LoopVarDecl, LoopVarDeclId> loop_var_decls;
+  base::Arena<Expr, ExprId> exprs;
+  base::Arena<Process, ProcessId> processes;
+  base::Arena<ContinuousAssign, ContinuousAssignId> continuous_assigns;
+  base::Arena<Generate, GenerateId> generates;
+  base::Arena<InstanceMemberDecl, InstanceMemberId> instance_members;
+  base::Arena<CrossUnitRefDecl, CrossUnitRefId> cross_unit_refs;
+  base::Arena<StructuralSubroutineDecl, StructuralSubroutineId>
+      structural_subroutines;
   std::vector<TypeAliasDecl> type_aliases;
 
-  [[nodiscard]] auto GetStructuralVar(StructuralVarId id) const
-      -> const StructuralVarDecl& {
-    return structural_vars.at(id.value);
-  }
-  [[nodiscard]] auto GetLoopVarDecl(LoopVarDeclId id) const
-      -> const LoopVarDecl& {
-    return loop_var_decls.at(id.value);
-  }
-  [[nodiscard]] auto GetExpr(ExprId id) const -> const Expr& {
-    return exprs.at(id.value);
-  }
-  [[nodiscard]] auto GetProcess(ProcessId id) const -> const Process& {
-    return processes.at(id.value);
-  }
-  [[nodiscard]] auto GetContinuousAssign(ContinuousAssignId id) const
-      -> const ContinuousAssign& {
-    return continuous_assigns.at(id.value);
-  }
-  [[nodiscard]] auto GetGenerate(GenerateId id) const -> const Generate& {
-    return generates.at(id.value);
-  }
-  [[nodiscard]] auto GetInstanceMember(InstanceMemberId id) const
-      -> const InstanceMemberDecl& {
-    return instance_members.at(id.value);
-  }
-  [[nodiscard]] auto GetCrossUnitRef(CrossUnitRefId id) const
-      -> const CrossUnitRefDecl& {
-    return cross_unit_refs.at(id.value);
-  }
-  [[nodiscard]] auto GetStructuralSubroutine(StructuralSubroutineId id) const
-      -> const StructuralSubroutineDecl& {
-    return structural_subroutines.at(id.value);
-  }
-
-  auto AddStructuralVar(StructuralVarDecl decl) -> StructuralVarId {
-    const StructuralVarId id{
-        static_cast<std::uint32_t>(structural_vars.size())};
-    structural_vars.push_back(std::move(decl));
-    return id;
-  }
-  auto AddLoopVarDecl(LoopVarDecl decl) -> LoopVarDeclId {
-    const LoopVarDeclId id{static_cast<std::uint32_t>(loop_var_decls.size())};
-    loop_var_decls.push_back(std::move(decl));
-    return id;
-  }
-  auto AddExpr(Expr expr) -> ExprId {
-    const ExprId id{static_cast<std::uint32_t>(exprs.size())};
-    exprs.push_back(std::move(expr));
-    return id;
-  }
-  auto AddProcess(Process process) -> ProcessId {
-    const ProcessId id{static_cast<std::uint32_t>(processes.size())};
-    processes.push_back(std::move(process));
-    return id;
-  }
-  auto AddContinuousAssign(ContinuousAssign ca) -> ContinuousAssignId {
-    const ContinuousAssignId id{
-        static_cast<std::uint32_t>(continuous_assigns.size())};
-    continuous_assigns.push_back(std::move(ca));
-    return id;
-  }
-  auto AddGenerate(Generate generate) -> GenerateId {
-    const GenerateId id{static_cast<std::uint32_t>(generates.size())};
-    generates.push_back(std::move(generate));
-    return id;
-  }
   [[nodiscard]] auto NextGenerateId() const -> GenerateId {
     return GenerateId{static_cast<std::uint32_t>(generates.size())};
-  }
-  auto AddInstanceMember(InstanceMemberDecl decl) -> InstanceMemberId {
-    const InstanceMemberId id{
-        static_cast<std::uint32_t>(instance_members.size())};
-    instance_members.push_back(std::move(decl));
-    return id;
-  }
-  auto AddCrossUnitRef(CrossUnitRefDecl decl) -> CrossUnitRefId {
-    const CrossUnitRefId id{static_cast<std::uint32_t>(cross_unit_refs.size())};
-    cross_unit_refs.push_back(std::move(decl));
-    return id;
-  }
-  auto AddStructuralSubroutine(StructuralSubroutineDecl decl)
-      -> StructuralSubroutineId {
-    const StructuralSubroutineId id{
-        static_cast<std::uint32_t>(structural_subroutines.size())};
-    structural_subroutines.push_back(std::move(decl));
-    return id;
   }
   [[nodiscard]] auto NextStructuralSubroutineId() const
       -> StructuralSubroutineId {
@@ -259,10 +174,5 @@ struct StructuralScope {
     type_aliases.push_back(std::move(decl));
   }
 };
-
-inline auto Generate::GetChildScope(StructuralScopeId id) const
-    -> const StructuralScope& {
-  return child_scopes.at(id.value);
-}
 
 }  // namespace lyra::hir

--- a/include/lyra/lowering/hir_to_mir/capture_sink.hpp
+++ b/include/lyra/lowering/hir_to_mir/capture_sink.hpp
@@ -85,7 +85,7 @@ class CaptureSink {
     }
     // The cell read is evaluated one scope outside the body (where the capture
     // is spawned), so its hops run from there down to the variable.
-    const mir::ExprId cell = outer_->AddExpr(
+    const mir::ExprId cell = outer_->exprs.Add(
         mir::Expr{
             .data =
                 mir::LocalRef{
@@ -96,14 +96,14 @@ class CaptureSink {
     mir::ExprId source{};
     if (by_value_depth_ == decl_depth) {
       // By-value snapshot: the binding owns a copy; the source is the read.
-      binding = body_->AddLocal(mir::LocalDecl{.name = name, .type = type});
+      binding = body_->vars.Add(mir::LocalDecl{.name = name, .type = type});
       source = cell;
     } else {
       // By-reference alias: the source constructs a reference to the cell and
       // the binding holds that reference (its `RefType`).
       source = BuildReferenceArg(*unit_, *outer_, cell, type);
-      binding = body_->AddLocal(
-          mir::LocalDecl{.name = name, .type = outer_->GetExpr(source).type});
+      binding = body_->vars.Add(
+          mir::LocalDecl{.name = name, .type = outer_->exprs.Get(source).type});
     }
     requests_.push_back(
         CaptureRequest{

--- a/include/lyra/lowering/hir_to_mir/case_cascade.hpp
+++ b/include/lyra/lowering/hir_to_mir/case_cascade.hpp
@@ -57,21 +57,21 @@ auto BuildEqualityChain(
       return std::unexpected(std::move(label_or.error()));
     }
     const mir::ExprId label_id = *label_or;
-    const mir::ExprId sel_ref = enc_scope.AddExpr(
+    const mir::ExprId sel_ref = enc_scope.exprs.Add(
         mir::Expr{
             .data =
                 mir::LocalRef{
                     .hops = mir::BlockHops{.value = sel_hops},
                     .var = snapshot.sel_var},
             .type = snapshot.sel_type});
-    const mir::ExprId cmp = enc_scope.AddExpr(
+    const mir::ExprId cmp = enc_scope.exprs.Add(
         mir::Expr{
             .data =
                 mir::BinaryExpr{
                     .op = compare_op, .lhs = sel_ref, .rhs = label_id},
             .type = bit_type});
     if (acc.has_value()) {
-      acc = enc_scope.AddExpr(
+      acc = enc_scope.exprs.Add(
           mir::Expr{
               .data =
                   mir::BinaryExpr{
@@ -119,10 +119,10 @@ auto BuildCaseCascade(
     }
 
     const mir::BlockId body_scope_id =
-        level_block.AddChildScope(std::move(body_scopes[i]));
+        level_block.child_scopes.Add(std::move(body_scopes[i]));
     std::optional<mir::BlockId> else_scope_id;
     if (tail.has_value()) {
-      else_scope_id = level_block.AddChildScope(std::move(*tail));
+      else_scope_id = level_block.child_scopes.Add(std::move(*tail));
     }
 
     level_block.AppendStmt(
@@ -145,10 +145,10 @@ auto BuildCaseCascade(
     }
 
     const mir::BlockId body0_id =
-        wrapper_block.AddChildScope(std::move(body_scopes[0]));
+        wrapper_block.child_scopes.Add(std::move(body_scopes[0]));
     std::optional<mir::BlockId> else0_id;
     if (tail.has_value()) {
-      else0_id = wrapper_block.AddChildScope(std::move(*tail));
+      else0_id = wrapper_block.child_scopes.Add(std::move(*tail));
     }
 
     wrapper_block.AppendStmt(
@@ -159,14 +159,15 @@ auto BuildCaseCascade(
                 .then_scope = body0_id,
                 .else_scope = else0_id}});
   } else if (tail.has_value()) {
-    const mir::BlockId def_id = wrapper_block.AddChildScope(std::move(*tail));
+    const mir::BlockId def_id =
+        wrapper_block.child_scopes.Add(std::move(*tail));
     wrapper_block.AppendStmt(
         mir::Stmt{
             .label = std::nullopt, .data = mir::BlockStmt{.scope = def_id}});
   }
 
   const mir::BlockId wrapper_scope_id =
-      frame.current_block->AddChildScope(std::move(wrapper_block));
+      frame.current_block->child_scopes.Add(std::move(wrapper_block));
 
   return mir::Stmt{
       .label = outer_label, .data = mir::BlockStmt{.scope = wrapper_scope_id}};

--- a/include/lyra/lowering/hir_to_mir/class_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/class_lowerer.hpp
@@ -110,7 +110,7 @@ class ClassLowerer {
       hir::StructuralHops hops, hir::StructuralSubroutineId id) const
       -> const hir::StructuralSubroutineDecl& {
     if (hops.value == 0) {
-      return hir_scope_->structural_subroutines.at(id.value);
+      return hir_scope_->structural_subroutines.Get(id);
     }
     if (parent_ == nullptr) {
       throw InternalError(

--- a/include/lyra/mir/class.hpp
+++ b/include/lyra/mir/class.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include "lyra/base/arena.hpp"
 #include "lyra/base/time.hpp"
 #include "lyra/mir/class_id.hpp"
 #include "lyra/mir/member.hpp"
@@ -22,55 +23,14 @@ struct Class {
   // class exposes the precision so the engine can take the design-global
   // minimum (LRM 3.14.3) and so delays scale to it.
   TimeResolution time_resolution;
-  std::vector<ParamDecl> params;
-  std::vector<MemberDecl> members;
+  base::Arena<ParamDecl, ParamId> params;
+  base::Arena<MemberDecl, MemberId> members;
   Block constructor_block;
-  std::vector<Process> processes;
-  std::vector<Class> nested_classes;
-  std::vector<MethodDecl> methods;
+  base::Arena<Process, ProcessId> processes;
+  base::Arena<Class, ClassId> nested_classes;
+  base::Arena<MethodDecl, MethodId> methods;
   std::vector<TypeAliasDecl> type_aliases;
 
-  [[nodiscard]] auto GetParam(ParamId id) const -> const ParamDecl& {
-    return params.at(id.value);
-  }
-  [[nodiscard]] auto GetMember(MemberId id) const -> const MemberDecl& {
-    return members.at(id.value);
-  }
-  [[nodiscard]] auto GetProcess(ProcessId id) const -> const Process& {
-    return processes.at(id.value);
-  }
-  [[nodiscard]] auto GetNestedClass(ClassId id) const -> const Class& {
-    return nested_classes.at(id.value);
-  }
-  [[nodiscard]] auto GetMethod(MethodId id) const -> const MethodDecl& {
-    return methods.at(id.value);
-  }
-
-  auto AddParam(ParamDecl decl) -> ParamId {
-    const ParamId id{static_cast<std::uint32_t>(params.size())};
-    params.push_back(std::move(decl));
-    return id;
-  }
-  auto AddMember(MemberDecl decl) -> MemberId {
-    const MemberId id{static_cast<std::uint32_t>(members.size())};
-    members.push_back(std::move(decl));
-    return id;
-  }
-  auto AddProcess(Process process) -> ProcessId {
-    const ProcessId id{static_cast<std::uint32_t>(processes.size())};
-    processes.push_back(std::move(process));
-    return id;
-  }
-  auto AddNestedClass(Class child) -> ClassId {
-    const ClassId id{static_cast<std::uint32_t>(nested_classes.size())};
-    nested_classes.push_back(std::move(child));
-    return id;
-  }
-  auto AddMethod(MethodDecl decl) -> MethodId {
-    const MethodId id{static_cast<std::uint32_t>(methods.size())};
-    methods.push_back(std::move(decl));
-    return id;
-  }
   void AddTypeAlias(TypeAliasDecl decl) {
     type_aliases.push_back(std::move(decl));
   }

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -104,8 +104,6 @@ struct CompilationUnit {
   }
 };
 
-// Synthesize a 32-bit signed two-state `int`-typed `IntegerLiteral` Expr. The
-// caller does the `AddExpr` on whichever scope they own.
 [[nodiscard]] inline auto MakeInt32Literal(
     TypeId int32_type, std::int64_t value) -> Expr {
   return Expr{

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -8,6 +8,7 @@
 #include <variant>
 #include <vector>
 
+#include "lyra/base/arena.hpp"
 #include "lyra/base/time.hpp"
 #include "lyra/mir/class_id.hpp"
 #include "lyra/mir/expr.hpp"
@@ -213,7 +214,7 @@ struct Stmt {
   StmtData data;
 };
 
-// `{...}` in MIR: an arena for the four kinds of locally-owned IR nodes (vars,
+// `{...}` in MIR: arenas for the four kinds of locally-owned IR nodes (vars,
 // exprs, stmts, child scopes) plus the ordered execution sequence at this
 // brace level (`root_stmts`). All four IDs are scope-local: `ExprId`, `StmtId`,
 // `LocalId`, and `BlockId` resolve against the same
@@ -221,63 +222,28 @@ struct Stmt {
 // hops; cross-scope statement / expression / scope references do not exist --
 // each Block is a self-contained subtree.
 struct Block {
-  std::vector<LocalDecl> vars;
-  std::vector<Expr> exprs;
-  std::vector<Stmt> stmts;
-  std::vector<Block> child_scopes;
+  base::Arena<LocalDecl, LocalId> vars;
+  base::Arena<Expr, ExprId> exprs;
+  base::Arena<Stmt, StmtId> stmts;
+  base::Arena<Block, BlockId> child_scopes;
   std::vector<StmtId> root_stmts;
 
-  [[nodiscard]] auto GetExpr(ExprId id) const -> const Expr& {
-    return exprs.at(id.value);
-  }
-
   [[nodiscard]] auto GetExprType(ExprId id) const -> TypeId {
-    return GetExpr(id).type;
+    return exprs.Get(id).type;
   }
 
-  [[nodiscard]] auto GetStmt(StmtId id) const -> const Stmt& {
-    return stmts.at(id.value);
-  }
-
-  [[nodiscard]] auto GetChildScope(BlockId id) const -> const Block& {
-    return child_scopes.at(id.value);
-  }
-
-  auto AddLocal(LocalDecl decl) -> LocalId {
-    const LocalId id{static_cast<std::uint32_t>(vars.size())};
-    vars.push_back(std::move(decl));
-    return id;
-  }
-  [[nodiscard]] auto GetLocal(LocalId id) const -> const LocalDecl& {
-    return vars.at(id.value);
-  }
-  auto AddExpr(Expr expr) -> ExprId {
-    const ExprId id{static_cast<std::uint32_t>(exprs.size())};
-    exprs.push_back(std::move(expr));
-    return id;
-  }
-  auto AddStmt(Stmt stmt) -> StmtId {
-    const StmtId id{static_cast<std::uint32_t>(stmts.size())};
-    stmts.push_back(std::move(stmt));
-    return id;
-  }
-  auto AddChildScope(Block scope) -> BlockId {
-    const BlockId id{static_cast<std::uint32_t>(child_scopes.size())};
-    child_scopes.push_back(std::move(scope));
-    return id;
-  }
   void AddRootStmt(StmtId id) {
     root_stmts.push_back(id);
   }
   auto AppendStmt(Stmt stmt) -> StmtId {
-    const StmtId id = AddStmt(std::move(stmt));
+    const StmtId id = stmts.Add(std::move(stmt));
     root_stmts.push_back(id);
     return id;
   }
 
   // Append a label-less statement to the body in one step: stage it in the
   // stmts arena and register it as a root statement. Encapsulates the
-  // AddStmt-then-push pairing so a synthesized statement cannot be added to
+  // stage-then-register pairing so a synthesized statement cannot be added to
   // the arena yet left out of the executed sequence.
   auto AppendStmt(StmtData data) -> StmtId {
     return AppendStmt(Stmt{.label = std::nullopt, .data = std::move(data)});
@@ -286,9 +252,10 @@ struct Block {
   // Declare a body-local variable: register it in the var arena and emit its
   // declaration statement in the body. The two must co-occur for a genuine
   // local, so they are exposed as one operation. (A method formal is a local
-  // declared in the signature, not the body, and uses bare AddLocal instead.)
+  // declared in the signature, not the body, so it is registered without a
+  // declaration statement.)
   auto AppendLocal(LocalDecl decl, ExprId init) -> LocalRef {
-    const LocalId var = AddLocal(std::move(decl));
+    const LocalId var = vars.Add(std::move(decl));
     const LocalRef ref{.hops = BlockHops{.value = 0}, .var = var};
     AppendStmt(LocalDeclStmt{.target = ref, .init = init});
     return ref;
@@ -298,7 +265,7 @@ struct Block {
   // child scope of this scope and consuming it. The IfStmt's then_scope id
   // resolves against this scope's child_scopes.
   auto AppendIfThen(ExprId cond, Block then_body) -> StmtId {
-    const BlockId then_scope_id = AddChildScope(std::move(then_body));
+    const BlockId then_scope_id = child_scopes.Add(std::move(then_body));
     return AppendStmt(
         IfStmt{
             .condition = cond,

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -81,7 +81,7 @@ auto RenderConstructor(
                     "lyra::runtime::RuntimeServices& services";
   std::string init_list = base_class + "(parent, std::move(name), services)";
   for (std::size_t i = 0; i < s.params.size(); ++i) {
-    const auto& p = s.params[i];
+    const auto& p = s.params.Get(mir::ParamId{static_cast<std::uint32_t>(i)});
     const auto param_name = CtorParamName(i);
     auto type_or = RenderTypeAsCpp(scope_view.Unit(), s, p.type);
     if (!type_or) return std::unexpected(std::move(type_or.error()));

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -186,13 +186,13 @@ auto RenderParamExpr(const ScopeView& view, const mir::ParamRef& r)
         "cpp emit",
         diag::UnsupportedCategory::kFeature);
   }
-  const std::string& name = view.Class().GetParam(r.param).name;
+  const std::string& name = view.Class().params.Get(r.param).name;
   return "self->" + name;
 }
 
 auto LookupLocalName(const ScopeView& view, const mir::LocalRef& ref)
     -> std::string {
-  return view.BlockAtHops(ref.hops).vars.at(ref.var.value).name;
+  return view.BlockAtHops(ref.hops).vars.Get(ref.var).name;
 }
 
 // True iff the local holds a reference (its type is a `RefType`),
@@ -200,7 +200,7 @@ auto LookupLocalName(const ScopeView& view, const mir::LocalRef& ref)
 // `.Set(Services(), ...)` (LRM 13.5.2), the same surface as a member.
 auto IsReferenceLocal(const ScopeView& view, const mir::LocalRef& ref) -> bool {
   const mir::TypeId var_type =
-      view.BlockAtHops(ref.hops).vars.at(ref.var.value).type;
+      view.BlockAtHops(ref.hops).vars.Get(ref.var).type;
   return std::holds_alternative<mir::RefType>(
       view.Unit().GetType(var_type).data);
 }
@@ -216,7 +216,7 @@ auto RenderMemberName(const ScopeView& view, const mir::MemberRef& ref)
         "emit",
         diag::UnsupportedCategory::kFeature);
   }
-  return "self->" + view.Class().GetMember(ref.var).name;
+  return "self->" + view.Class().members.Get(ref.var).name;
 }
 
 namespace {
@@ -1019,7 +1019,7 @@ auto RenderCallExpr(
             }
             const auto& cls = view.EnclosingClassAtHops(
                 mir::EnclosingHops{.value = ref.hops.value});
-            const auto& decl = cls.GetMethod(ref.method);
+            const auto& decl = cls.methods.Get(ref.method);
             // arguments[0] is the callee's `self` handle (mir.md invariant 11);
             // a ref / const ref actual is already a reference-construct
             // (`Ref<T>(cell)`) in MIR, so every argument renders uniformly.
@@ -1122,7 +1122,7 @@ auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
               return std::unexpected(std::move(receiver_or.error()));
             }
             const auto& cls = view.EnclosingClassAtHops(m.member.hops);
-            const auto& var = cls.GetMember(m.member.var);
+            const auto& var = cls.members.Get(m.member.var);
             return *receiver_or + "->" + var.name;
           },
           [&](const mir::LocalRef& l) -> diag::Result<std::string> {
@@ -1343,8 +1343,7 @@ auto RenderClosureExpr(
     std::string params;
     std::string args;
     for (std::size_t i = 0; i < closure.captures.size(); ++i) {
-      const auto& bind =
-          closure.body->vars.at(closure.captures[i].binding.value);
+      const auto& bind = closure.body->vars.Get(closure.captures[i].binding);
       auto decl_or = RenderBindingParamDecl(view, bind);
       if (!decl_or) return std::unexpected(std::move(decl_or.error()));
       auto arg_or = RenderExpr(view, view.Expr(closure.captures[i].value));
@@ -1365,7 +1364,7 @@ auto RenderClosureExpr(
   std::string captures_text;
   for (std::size_t i = 0; i < closure.captures.size(); ++i) {
     const std::string& bind_name =
-        closure.body->vars.at(closure.captures[i].binding.value).name;
+        closure.body->vars.Get(closure.captures[i].binding).name;
     auto source_or = RenderExpr(view, view.Expr(closure.captures[i].value));
     if (!source_or) return std::unexpected(std::move(source_or.error()));
     if (i != 0) captures_text += ", ";
@@ -1374,7 +1373,7 @@ auto RenderClosureExpr(
 
   std::string params_text;
   for (std::size_t i = 0; i < closure.params.size(); ++i) {
-    const auto& bind = closure.body->vars.at(closure.params[i].binding.value);
+    const auto& bind = closure.body->vars.Get(closure.params[i].binding);
     auto decl_or = RenderBindingParamDecl(view, bind);
     if (!decl_or) return std::unexpected(std::move(decl_or.error()));
     if (i != 0) params_text += ", ";
@@ -1602,7 +1601,7 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr)
           },
           [&](const mir::MemberAccessExpr& m) -> diag::Result<std::string> {
             const auto& cls = view.EnclosingClassAtHops(m.member.hops);
-            const auto& var = cls.GetMember(m.member.var);
+            const auto& var = cls.members.Get(m.member.var);
             auto receiver_or = RenderExpr(view, view.Expr(m.receiver));
             if (!receiver_or) {
               return std::unexpected(std::move(receiver_or.error()));

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -32,8 +32,8 @@ auto RenderForInit(const ScopeView& view, const mir::ForInit& init)
             // exact same type as spelling it out -- and reads as the idiomatic
             // loop counter.
             const auto& lv = view.BlockAtHops(d.induction_var.hops)
-                                 .vars.at(d.induction_var.var.value);
-            const auto& init_expr = view.Block().exprs.at(d.init.value);
+                                 .vars.Get(d.induction_var.var);
+            const auto& init_expr = view.Block().exprs.Get(d.init);
             auto rendered_or = RenderExpr(view, init_expr);
             if (!rendered_or) {
               return std::unexpected(std::move(rendered_or.error()));
@@ -41,7 +41,7 @@ auto RenderForInit(const ScopeView& view, const mir::ForInit& init)
             return "auto " + lv.name + " = " + *rendered_or;
           },
           [&](const mir::ForInitExpr& e) -> diag::Result<std::string> {
-            const auto& expr = view.Block().exprs.at(e.expr.value);
+            const auto& expr = view.Block().exprs.Get(e.expr);
             return RenderExpr(view, expr);
           },
       },
@@ -65,10 +65,10 @@ auto RenderEventEdgeAsRuntime(mir::EventEdge edge) -> std::string_view {
 auto RenderLocalDeclStmt(
     const ScopeView& view, const mir::LocalDeclStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
-  const auto& lv = view.BlockAtHops(s.target.hops).vars.at(s.target.var.value);
+  const auto& lv = view.BlockAtHops(s.target.hops).vars.Get(s.target.var);
   auto type_or = RenderTypeAsCpp(view.Unit(), view.Class(), lv.type);
   if (!type_or) return std::unexpected(std::move(type_or.error()));
-  const auto& init_expr = view.Block().exprs.at(s.init.value);
+  const auto& init_expr = view.Block().exprs.Get(s.init);
   auto init_or = RenderExpr(view, init_expr);
   if (!init_or) return std::unexpected(std::move(init_or.error()));
   return Indent(indent) + *type_or + " " + lv.name + " = " + *init_or + ";\n";
@@ -77,7 +77,7 @@ auto RenderLocalDeclStmt(
 auto RenderExprStmt(
     const ScopeView& view, const mir::ExprStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
-  const auto& expr = view.Block().exprs.at(s.expr.value);
+  const auto& expr = view.Block().exprs.Get(s.expr);
   auto rendered_or = RenderExpr(view, expr);
   if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
   return Indent(indent) + *rendered_or + ";\n";
@@ -89,7 +89,7 @@ auto RenderExprStmt(
 auto RenderAwaitStmt(
     const ScopeView& view, const mir::AwaitStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
-  const auto& expr = view.Block().exprs.at(s.awaitable.value);
+  const auto& expr = view.Block().exprs.Get(s.awaitable);
   auto rendered_or = RenderExpr(view, expr);
   if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
   return Indent(indent) + "co_await " + *rendered_or + ";\n";
@@ -98,7 +98,7 @@ auto RenderAwaitStmt(
 auto RenderBlockStmtNode(
     const ScopeView& view, const mir::BlockStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
-  const auto& child = view.Block().GetChildScope(s.scope);
+  const auto& child = view.Block().child_scopes.Get(s.scope);
   std::string result = Indent(indent) + "{\n";
   auto child_or = RenderNestedBlock(view, child, indent + 1);
   if (!child_or) return std::unexpected(std::move(child_or.error()));
@@ -135,7 +135,7 @@ auto RenderForkStmtNode(
   // its own `fork_branches` in its own C++ scope.
   const std::string vec = "fork_branches";
   const ScopeView fork_view =
-      view.WithBlock(view.Block().GetChildScope(s.scope));
+      view.WithBlock(view.Block().child_scopes.Get(s.scope));
   std::string out = Indent(indent) + "{\n";
   auto locals_or = RenderBlockStatements(fork_view, indent + 1);
   if (!locals_or) return std::unexpected(std::move(locals_or.error()));
@@ -157,8 +157,8 @@ auto RenderForkStmtNode(
 auto RenderIfStmtNode(
     const ScopeView& view, const mir::IfStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
-  const auto& cond_expr = view.Block().exprs.at(s.condition.value);
-  const auto& then_scope = view.Block().GetChildScope(s.then_scope);
+  const auto& cond_expr = view.Block().exprs.Get(s.condition);
+  const auto& then_scope = view.Block().child_scopes.Get(s.then_scope);
   auto cond_or = RenderConditionAsBool(view, cond_expr);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
   auto then_or = RenderNestedBlock(view, then_scope, indent + 1);
@@ -168,7 +168,7 @@ auto RenderIfStmtNode(
   result += *then_or;
   result += Indent(indent) + "}";
   if (s.else_scope.has_value()) {
-    const auto& else_scope = view.Block().GetChildScope(*s.else_scope);
+    const auto& else_scope = view.Block().child_scopes.Get(*s.else_scope);
     auto else_or = RenderNestedBlock(view, else_scope, indent + 1);
     if (!else_or) return std::unexpected(std::move(else_or.error()));
     result += " else {\n";
@@ -182,8 +182,8 @@ auto RenderIfStmtNode(
 auto RenderConstructOwnedObjectStmt(
     const ScopeView& view, const mir::ConstructOwnedObjectStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
-  const auto& var = view.Class().GetMember(s.target);
-  const auto& target_scope = view.Class().GetNestedClass(s.scope_id);
+  const auto& var = view.Class().members.Get(s.target);
+  const auto& target_scope = view.Class().nested_classes.Get(s.scope_id);
   std::string trailing_args;
   for (const auto arg_id : s.args) {
     auto arg_or = RenderExpr(view, view.Expr(arg_id));
@@ -259,7 +259,7 @@ auto RenderExternalUnitFill(
 auto RenderConstructExternalUnitStmt(
     const ScopeView& view, const mir::ConstructExternalUnitStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
-  const auto& var = view.Class().GetMember(s.target);
+  const auto& var = view.Class().members.Get(s.target);
   return RenderExternalUnitFill(
       view, "self->" + var.name, var.type, s.unit_name, var.name, s.dims, 0,
       indent);
@@ -284,7 +284,7 @@ auto RenderForStmtNode(
   }
   std::string cond;
   if (s.condition.has_value()) {
-    const auto& cond_expr = view.Block().exprs.at(s.condition->value);
+    const auto& cond_expr = view.Block().exprs.Get(*s.condition);
     auto cond_or = RenderConditionAsBool(view, cond_expr);
     if (!cond_or) return std::unexpected(std::move(cond_or.error()));
     cond = *std::move(cond_or);
@@ -292,12 +292,12 @@ auto RenderForStmtNode(
   std::string step;
   for (std::size_t i = 0; i < s.step.size(); ++i) {
     if (i != 0) step += ", ";
-    const auto& step_expr = view.Block().exprs.at(s.step[i].value);
+    const auto& step_expr = view.Block().exprs.Get(s.step[i]);
     auto step_or = RenderExpr(view, step_expr);
     if (!step_or) return std::unexpected(std::move(step_or.error()));
     step += *step_or;
   }
-  const auto& block = view.Block().GetChildScope(s.scope);
+  const auto& block = view.Block().child_scopes.Get(s.scope);
   auto body_or = RenderNestedBlock(view, block, indent + 1);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   std::string result =
@@ -313,10 +313,10 @@ auto RenderForStmtNode(
 auto RenderWhileStmtNode(
     const ScopeView& view, const mir::WhileStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
-  const auto& cond_expr = view.Block().exprs.at(s.condition.value);
+  const auto& cond_expr = view.Block().exprs.Get(s.condition);
   auto cond_or = RenderConditionAsBool(view, cond_expr);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const auto& block = view.Block().GetChildScope(s.scope);
+  const auto& block = view.Block().child_scopes.Get(s.scope);
   auto body_or = RenderNestedBlock(view, block, indent + 1);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   std::string result =
@@ -329,10 +329,10 @@ auto RenderWhileStmtNode(
 auto RenderDoWhileStmtNode(
     const ScopeView& view, const mir::DoWhileStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
-  const auto& cond_expr = view.Block().exprs.at(s.condition.value);
+  const auto& cond_expr = view.Block().exprs.Get(s.condition);
   auto cond_or = RenderConditionAsBool(view, cond_expr);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const auto& block = view.Block().GetChildScope(s.scope);
+  const auto& block = view.Block().child_scopes.Get(s.scope);
   auto body_or = RenderNestedBlock(view, block, indent + 1);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   std::string result = Indent(indent) + "do {\n";
@@ -350,7 +350,7 @@ auto RenderSensitivityRefPtr(
     -> diag::Result<std::string> {
   auto name = RenderMemberName(view, ref);
   if (!name) return std::unexpected(std::move(name.error()));
-  const auto& var = view.EnclosingClassAtHops(ref.hops).GetMember(ref.var);
+  const auto& var = view.EnclosingClassAtHops(ref.hops).members.Get(ref.var);
   if (std::holds_alternative<mir::ExternalRefType>(
           view.Unit().GetType(var.type).data)) {
     return *name + ".AsObservable()";
@@ -483,15 +483,15 @@ auto RenderBlockStatements(const ScopeView& view, std::size_t indent)
   // scope it; render the block's body directly instead of emitting a redundant
   // `{ }`. Recursing collapses a chain of such blocks.
   if (block.root_stmts.size() == 1) {
-    const auto& only = block.stmts.at(block.root_stmts.front().value);
+    const auto& only = block.stmts.Get(block.root_stmts.front());
     if (const auto* block_stmt = std::get_if<mir::BlockStmt>(&only.data)) {
-      const auto& inner = block.GetChildScope(block_stmt->scope);
+      const auto& inner = block.child_scopes.Get(block_stmt->scope);
       return RenderBlockStatements(view.WithBlock(inner), indent);
     }
   }
   std::string out;
   for (const auto& sid : block.root_stmts) {
-    auto rendered_or = RenderStmt(view, block.stmts.at(sid.value), indent);
+    auto rendered_or = RenderStmt(view, block.stmts.Get(sid), indent);
     if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
     out += *rendered_or;
   }

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -504,7 +504,7 @@ class HirDumper {
         Overloaded{
             [this](const StructuralSubroutineRef& u) -> std::string {
               const auto& owner = ResolveScope(u.hops);
-              const auto& decl = owner.GetStructuralSubroutine(u.subroutine);
+              const auto& decl = owner.structural_subroutines.Get(u.subroutine);
               return std::format(
                   "StructuralSubroutine[{}](hops={}) \"{}\"",
                   u.subroutine.value, u.hops.value, decl.name);
@@ -744,12 +744,12 @@ class HirDumper {
 
   [[nodiscard]] auto FormatProcExpr(const ProceduralBody& p, ExprId id) const
       -> std::string {
-    return FormatExpr(p.exprs.at(id.value));
+    return FormatExpr(p.exprs.Get(id));
   }
 
   [[nodiscard]] auto FormatScopeExpr(const StructuralScope& s, ExprId id) const
       -> std::string {
-    return FormatExpr(s.GetExpr(id));
+    return FormatExpr(s.exprs.Get(id));
   }
 
   void DumpUnit(const ModuleUnit& u) {
@@ -777,7 +777,8 @@ class HirDumper {
     Line("Scope:");
     Indent();
     for (std::size_t i = 0; i < s.structural_vars.size(); ++i) {
-      const auto& v = s.structural_vars[i];
+      const auto& v =
+          s.structural_vars.Get(StructuralVarId{static_cast<std::uint32_t>(i)});
       std::string init_suffix;
       if (v.initializer.has_value()) {
         init_suffix = std::format(" init=Expr[{}]", v.initializer->value);
@@ -788,19 +789,26 @@ class HirDumper {
               init_suffix));
     }
     for (std::size_t i = 0; i < s.loop_var_decls.size(); ++i) {
-      const auto& lv = s.loop_var_decls[i];
+      const auto& lv =
+          s.loop_var_decls.Get(LoopVarDeclId{static_cast<std::uint32_t>(i)});
       Line(
           std::format(
               "LoopVarDecl[{}] \"{}\" : Type[{}]", i, lv.name, lv.type.value));
     }
     for (std::size_t i = 0; i < s.structural_subroutines.size(); ++i) {
-      DumpStructuralSubroutine(i, s.structural_subroutines[i]);
+      DumpStructuralSubroutine(
+          i, s.structural_subroutines.Get(
+                 StructuralSubroutineId{static_cast<std::uint32_t>(i)}));
     }
     if (!s.exprs.empty()) {
       Line("Exprs:");
       Indent();
       for (std::size_t i = 0; i < s.exprs.size(); ++i) {
-        Line(std::format("Expr[{}] {}", i, FormatExpr(s.exprs[i])));
+        Line(
+            std::format(
+                "Expr[{}] {}", i,
+                FormatExpr(
+                    s.exprs.Get(ExprId{static_cast<std::uint32_t>(i)}))));
       }
       Dedent();
     }
@@ -814,7 +822,8 @@ class HirDumper {
       DumpGenerate(s, g);
     }
     for (std::size_t i = 0; i < s.instance_members.size(); ++i) {
-      const auto& im = s.instance_members[i];
+      const auto& im = s.instance_members.Get(
+          InstanceMemberId{static_cast<std::uint32_t>(i)});
       std::string array_suffix;
       for (const auto dim : im.array_dims) {
         array_suffix += std::format("[{}]", dim);
@@ -909,7 +918,8 @@ class HirDumper {
       Line("ProceduralVars:");
       Indent();
       for (std::size_t i = 0; i < body.procedural_vars.size(); ++i) {
-        const auto& lv = body.procedural_vars[i];
+        const auto& lv = body.procedural_vars.Get(
+            ProceduralVarId{static_cast<std::uint32_t>(i)});
         Line(
             std::format(
                 "ProceduralVar[{}] \"{}\" : Type[{}]{}", i, lv.name,
@@ -922,7 +932,11 @@ class HirDumper {
       Line("Exprs:");
       Indent();
       for (std::size_t i = 0; i < body.exprs.size(); ++i) {
-        Line(std::format("Expr[{}] {}", i, FormatExpr(body.exprs[i])));
+        Line(
+            std::format(
+                "Expr[{}] {}", i,
+                FormatExpr(
+                    body.exprs.Get(ExprId{static_cast<std::uint32_t>(i)}))));
       }
       Dedent();
     }
@@ -1259,7 +1273,7 @@ class HirDumper {
   }
 
   void DumpStmt(const ProceduralBody& p, StmtId id) {
-    const auto& s = p.stmts.at(id.value);
+    const auto& s = p.stmts.Get(id);
     std::visit(
         Overloaded{
             [&](const EmptyStmt&) {
@@ -1345,12 +1359,12 @@ class HirDumper {
     Indent();
     Line("then_scope:");
     Indent();
-    DumpScope(g.GetChildScope(ig.then_scope));
+    DumpScope(g.child_scopes.Get(ig.then_scope));
     Dedent();
     if (ig.else_scope.has_value()) {
       Line("else_scope:");
       Indent();
-      DumpScope(g.GetChildScope(*ig.else_scope));
+      DumpScope(g.child_scopes.Get(*ig.else_scope));
       Dedent();
     } else {
       Line("else_scope: <none>");
@@ -1374,13 +1388,13 @@ class HirDumper {
       }
       Line(std::format("item[{}] labels=[{}]", i, labels));
       Indent();
-      DumpScope(g.GetChildScope(item.scope));
+      DumpScope(g.child_scopes.Get(item.scope));
       Dedent();
     }
     if (cg.default_scope.has_value()) {
       Line("default_scope:");
       Indent();
-      DumpScope(g.GetChildScope(*cg.default_scope));
+      DumpScope(g.child_scopes.Get(*cg.default_scope));
       Dedent();
     } else {
       Line("default_scope: <none>");
@@ -1397,7 +1411,7 @@ class HirDumper {
     Indent();
     Line("scope:");
     Indent();
-    DumpScope(g.GetChildScope(lg.scope));
+    DumpScope(g.child_scopes.Get(lg.scope));
     Dedent();
     Dedent();
   }

--- a/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
+++ b/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
@@ -52,12 +52,12 @@ auto StructuralScopeLowerer::LowerContinuousAssign(
   auto lhs_or = LowerExpr(assign.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const hir::ExprId lhs_id =
-      frame.current_structural_scope->AddExpr(*std::move(lhs_or));
+      frame.current_structural_scope->exprs.Add(*std::move(lhs_or));
 
   auto rhs_or = LowerExpr(assign.right(), frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const hir::ExprId rhs_id =
-      frame.current_structural_scope->AddExpr(*std::move(rhs_or));
+      frame.current_structural_scope->exprs.Add(*std::move(rhs_or));
 
   // LRM 10.3.2: continuous assignment sensitivity is the read set of the
   // RHS expression. slang treats the ContinuousAssignSymbol as the

--- a/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
@@ -50,7 +50,7 @@ auto LowerConcatExprProc(
     auto operand_or = proc.LowerExpr(*op, frame);
     if (!operand_or) return std::unexpected(std::move(operand_or.error()));
     operand_ids.push_back(
-        frame.current_procedural_body->AddExpr(*std::move(operand_or)));
+        frame.current_procedural_body->exprs.Add(*std::move(operand_or)));
   }
   return hir::Expr{
       .type = *type_id,
@@ -77,11 +77,11 @@ auto LowerReplicationExprProc(
   auto count_or = proc.LowerExpr(rp.count(), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
   const hir::ExprId count_id =
-      frame.current_procedural_body->AddExpr(*std::move(count_or));
+      frame.current_procedural_body->exprs.Add(*std::move(count_or));
   auto concat_or = proc.LowerExpr(rp.concat(), frame);
   if (!concat_or) return std::unexpected(std::move(concat_or.error()));
   const hir::ExprId concat_id =
-      frame.current_procedural_body->AddExpr(*std::move(concat_or));
+      frame.current_procedural_body->exprs.Add(*std::move(concat_or));
   return hir::Expr{
       .type = *type_id,
       .data = hir::ReplicationExpr{.count = count_id, .concat = concat_id},
@@ -101,7 +101,7 @@ auto LowerAssignmentPatternFromElementsProc(
     auto lowered = proc.LowerExpr(*elem, frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     element_ids.push_back(
-        frame.current_procedural_body->AddExpr(*std::move(lowered)));
+        frame.current_procedural_body->exprs.Add(*std::move(lowered)));
   }
   return hir::Expr{
       .type = *type_id,
@@ -122,18 +122,19 @@ auto LowerAssociativeAssignmentPatternProc(
     auto key_or = proc.LowerExpr(*setter.index, frame);
     if (!key_or) return std::unexpected(std::move(key_or.error()));
     const hir::ExprId key_id =
-        frame.current_procedural_body->AddExpr(*std::move(key_or));
+        frame.current_procedural_body->exprs.Add(*std::move(key_or));
     auto value_or = proc.LowerExpr(*setter.expr, frame);
     if (!value_or) return std::unexpected(std::move(value_or.error()));
     const hir::ExprId value_id =
-        frame.current_procedural_body->AddExpr(*std::move(value_or));
+        frame.current_procedural_body->exprs.Add(*std::move(value_or));
     entries.push_back({.key = key_id, .value = value_id});
   }
   std::optional<hir::ExprId> default_id;
   if (ap.defaultSetter != nullptr) {
     auto default_or = proc.LowerExpr(*ap.defaultSetter, frame);
     if (!default_or) return std::unexpected(std::move(default_or.error()));
-    default_id = frame.current_procedural_body->AddExpr(*std::move(default_or));
+    default_id =
+        frame.current_procedural_body->exprs.Add(*std::move(default_or));
   }
   return hir::Expr{
       .type = *type_id,
@@ -155,14 +156,14 @@ auto LowerReplicatedAssignmentPatternExprProc(
   auto count_or = proc.LowerExpr(rp.count(), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
   const hir::ExprId count_id =
-      frame.current_procedural_body->AddExpr(*std::move(count_or));
+      frame.current_procedural_body->exprs.Add(*std::move(count_or));
   std::vector<hir::ExprId> item_ids;
   item_ids.reserve(rp.elements().size());
   for (const auto* elem : rp.elements()) {
     auto lowered = proc.LowerExpr(*elem, frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     item_ids.push_back(
-        frame.current_procedural_body->AddExpr(*std::move(lowered)));
+        frame.current_procedural_body->exprs.Add(*std::move(lowered)));
   }
   return hir::Expr{
       .type = *type_id,
@@ -188,13 +189,13 @@ auto LowerNewArrayExprProc(
   auto size_or = proc.LowerExpr(na.sizeExpr(), frame);
   if (!size_or) return std::unexpected(std::move(size_or.error()));
   const hir::ExprId size_id =
-      frame.current_procedural_body->AddExpr(*std::move(size_or));
+      frame.current_procedural_body->exprs.Add(*std::move(size_or));
   std::optional<hir::ExprId> initializer_id;
   if (na.initExpr() != nullptr) {
     auto init_or = proc.LowerExpr(*na.initExpr(), frame);
     if (!init_or) return std::unexpected(std::move(init_or.error()));
     initializer_id =
-        frame.current_procedural_body->AddExpr(*std::move(init_or));
+        frame.current_procedural_body->exprs.Add(*std::move(init_or));
   }
   return hir::Expr{
       .type = *type_id,
@@ -231,7 +232,7 @@ auto LowerConcatExprStructural(
     auto operand_or = scope.LowerExpr(*op, frame);
     if (!operand_or) return std::unexpected(std::move(operand_or.error()));
     operand_ids.push_back(
-        frame.current_structural_scope->AddExpr(*std::move(operand_or)));
+        frame.current_structural_scope->exprs.Add(*std::move(operand_or)));
   }
   return hir::Expr{
       .type = *type_id,
@@ -252,7 +253,7 @@ auto LowerAssignmentPatternFromElementsStructural(
     auto lowered = scope.LowerExpr(*elem, frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     element_ids.push_back(
-        frame.current_structural_scope->AddExpr(*std::move(lowered)));
+        frame.current_structural_scope->exprs.Add(*std::move(lowered)));
   }
   return hir::Expr{
       .type = *type_id,
@@ -273,11 +274,11 @@ auto LowerAssociativeAssignmentPatternStructural(
     auto key_or = scope.LowerExpr(*setter.index, frame);
     if (!key_or) return std::unexpected(std::move(key_or.error()));
     const hir::ExprId key_id =
-        frame.current_structural_scope->AddExpr(*std::move(key_or));
+        frame.current_structural_scope->exprs.Add(*std::move(key_or));
     auto value_or = scope.LowerExpr(*setter.expr, frame);
     if (!value_or) return std::unexpected(std::move(value_or.error()));
     const hir::ExprId value_id =
-        frame.current_structural_scope->AddExpr(*std::move(value_or));
+        frame.current_structural_scope->exprs.Add(*std::move(value_or));
     entries.push_back({.key = key_id, .value = value_id});
   }
   std::optional<hir::ExprId> default_id;
@@ -285,7 +286,7 @@ auto LowerAssociativeAssignmentPatternStructural(
     auto default_or = scope.LowerExpr(*ap.defaultSetter, frame);
     if (!default_or) return std::unexpected(std::move(default_or.error()));
     default_id =
-        frame.current_structural_scope->AddExpr(*std::move(default_or));
+        frame.current_structural_scope->exprs.Add(*std::move(default_or));
   }
   return hir::Expr{
       .type = *type_id,
@@ -307,14 +308,14 @@ auto LowerReplicatedAssignmentPatternExprStructural(
   auto count_or = scope.LowerExpr(rp.count(), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
   const hir::ExprId count_id =
-      frame.current_structural_scope->AddExpr(*std::move(count_or));
+      frame.current_structural_scope->exprs.Add(*std::move(count_or));
   std::vector<hir::ExprId> item_ids;
   item_ids.reserve(rp.elements().size());
   for (const auto* elem : rp.elements()) {
     auto lowered = scope.LowerExpr(*elem, frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     item_ids.push_back(
-        frame.current_structural_scope->AddExpr(*std::move(lowered)));
+        frame.current_structural_scope->exprs.Add(*std::move(lowered)));
   }
   return hir::Expr{
       .type = *type_id,

--- a/src/lyra/lowering/ast_to_hir/expression/assignment.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/assignment.cpp
@@ -35,7 +35,7 @@ auto LowerAssignmentExprProc(
   auto lhs_or = proc.LowerExpr(as.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const hir::ExprId lhs_id =
-      frame.current_procedural_body->AddExpr(*std::move(lhs_or));
+      frame.current_procedural_body->exprs.Add(*std::move(lhs_or));
 
   auto type_id = module.InternType(*as.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
@@ -47,7 +47,7 @@ auto LowerAssignmentExprProc(
     auto rhs_or = proc.LowerExpr(as.right(), frame);
     if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
     const hir::ExprId rhs_id =
-        frame.current_procedural_body->AddExpr(*std::move(rhs_or));
+        frame.current_procedural_body->exprs.Add(*std::move(rhs_or));
     return hir::Expr{
         .type = *type_id,
         .data =
@@ -72,7 +72,7 @@ auto LowerAssignmentExprProc(
   hir::Expr rhs_expr = *std::move(rhs_or);
   if (rhs_expr.type.value != type_id->value) {
     const hir::ExprId inner_id =
-        frame.current_procedural_body->AddExpr(std::move(rhs_expr));
+        frame.current_procedural_body->exprs.Add(std::move(rhs_expr));
     rhs_expr = hir::Expr{
         .type = *type_id,
         .data =
@@ -82,7 +82,7 @@ auto LowerAssignmentExprProc(
     };
   }
   const hir::ExprId rhs_id =
-      frame.current_procedural_body->AddExpr(std::move(rhs_expr));
+      frame.current_procedural_body->exprs.Add(std::move(rhs_expr));
   return hir::Expr{
       .type = *type_id,
       .data =
@@ -106,7 +106,7 @@ auto LowerIncDecExprProc(
   auto target_or = proc.LowerExpr(un.operand(), frame);
   if (!target_or) return std::unexpected(std::move(target_or.error()));
   const hir::ExprId target_id =
-      frame.current_procedural_body->AddExpr(*std::move(target_or));
+      frame.current_procedural_body->exprs.Add(*std::move(target_or));
 
   auto type_id = module.InternType(*un.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -87,7 +87,7 @@ auto LowerCallExprProc(
       receiver_type = arg_or->type;
     }
     arg_ids.emplace_back(
-        frame.current_procedural_body->AddExpr(*std::move(arg_or)));
+        frame.current_procedural_body->exprs.Add(*std::move(arg_or)));
   }
 
   if (call.isSystemCall()) {
@@ -221,7 +221,7 @@ auto LowerCallExprProc(
           auto body_or = proc.LowerExpr(*iter_info.iterExpr, frame);
           if (!body_or) return std::unexpected(std::move(body_or.error()));
           const auto body_expr_id =
-              frame.current_procedural_body->AddExpr(*std::move(body_or));
+              frame.current_procedural_body->exprs.Add(*std::move(body_or));
           with_clause =
               hir::WithClause{.iterator = iterator_id, .expr = body_expr_id};
         }

--- a/src/lyra/lowering/ast_to_hir/expression/inside.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/inside.cpp
@@ -21,7 +21,7 @@ auto LowerInsideExprProc(
   auto lhs_or = proc.LowerExpr(in.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const hir::ExprId lhs_id =
-      frame.current_procedural_body->AddExpr(*std::move(lhs_or));
+      frame.current_procedural_body->exprs.Add(*std::move(lhs_or));
 
   std::vector<hir::InsideItem> items;
   items.reserve(in.rangeList().size());
@@ -56,16 +56,16 @@ auto LowerInsideItemImpl(
     auto lo_or = proc.LowerExpr(vr.left(), frame);
     if (!lo_or) return std::unexpected(std::move(lo_or.error()));
     const hir::ExprId lo_id =
-        frame.current_procedural_body->AddExpr(*std::move(lo_or));
+        frame.current_procedural_body->exprs.Add(*std::move(lo_or));
     auto hi_or = proc.LowerExpr(vr.right(), frame);
     if (!hi_or) return std::unexpected(std::move(hi_or.error()));
     const hir::ExprId hi_id =
-        frame.current_procedural_body->AddExpr(*std::move(hi_or));
+        frame.current_procedural_body->exprs.Add(*std::move(hi_or));
     return hir::InsideRangePair{.lo = lo_id, .hi = hi_id};
   }
   auto val_or = proc.LowerExpr(item_expr, frame);
   if (!val_or) return std::unexpected(std::move(val_or.error()));
-  return frame.current_procedural_body->AddExpr(*std::move(val_or));
+  return frame.current_procedural_body->exprs.Add(*std::move(val_or));
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/expression/operators.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/operators.cpp
@@ -89,7 +89,7 @@ auto LowerConversionExprProc(
   auto operand_or = proc.LowerExpr(conv.operand(), frame);
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
   const hir::ExprId operand_id =
-      frame.current_procedural_body->AddExpr(*std::move(operand_or));
+      frame.current_procedural_body->exprs.Add(*std::move(operand_or));
   auto type_id = proc.Module().InternType(*conv.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -111,7 +111,7 @@ auto LowerUnaryExprProc(
   auto operand_or = proc.LowerExpr(un.operand(), frame);
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
   const hir::ExprId operand_id =
-      frame.current_procedural_body->AddExpr(*std::move(operand_or));
+      frame.current_procedural_body->exprs.Add(*std::move(operand_or));
   auto type_id = proc.Module().InternType(*un.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -131,11 +131,11 @@ auto LowerBinaryExprProc(
   auto lhs_or = proc.LowerExpr(bin.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const hir::ExprId lhs_id =
-      frame.current_procedural_body->AddExpr(*std::move(lhs_or));
+      frame.current_procedural_body->exprs.Add(*std::move(lhs_or));
   auto rhs_or = proc.LowerExpr(bin.right(), frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const hir::ExprId rhs_id =
-      frame.current_procedural_body->AddExpr(*std::move(rhs_or));
+      frame.current_procedural_body->exprs.Add(*std::move(rhs_or));
   auto type_id = proc.Module().InternType(*bin.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -170,15 +170,15 @@ auto LowerConditionalExprProc(
   auto cond_or = proc.LowerExpr(*cond.conditions[0].expr, frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
   const hir::ExprId cond_id =
-      frame.current_procedural_body->AddExpr(*std::move(cond_or));
+      frame.current_procedural_body->exprs.Add(*std::move(cond_or));
   auto then_or = proc.LowerExpr(cond.left(), frame);
   if (!then_or) return std::unexpected(std::move(then_or.error()));
   const hir::ExprId then_id =
-      frame.current_procedural_body->AddExpr(*std::move(then_or));
+      frame.current_procedural_body->exprs.Add(*std::move(then_or));
   auto else_or = proc.LowerExpr(cond.right(), frame);
   if (!else_or) return std::unexpected(std::move(else_or.error()));
   const hir::ExprId else_id =
-      frame.current_procedural_body->AddExpr(*std::move(else_or));
+      frame.current_procedural_body->exprs.Add(*std::move(else_or));
   auto type_id = proc.Module().InternType(*cond.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -200,7 +200,7 @@ auto LowerConversionExprStructural(
   auto operand_or = scope.LowerExpr(conv.operand(), frame);
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
   const hir::ExprId operand_id =
-      frame.current_structural_scope->AddExpr(*std::move(operand_or));
+      frame.current_structural_scope->exprs.Add(*std::move(operand_or));
   auto type_id = scope.Module().InternType(*conv.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -222,7 +222,7 @@ auto LowerUnaryExprStructural(
   auto operand_or = scope.LowerExpr(un.operand(), frame);
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
   const hir::ExprId operand_id =
-      frame.current_structural_scope->AddExpr(*std::move(operand_or));
+      frame.current_structural_scope->exprs.Add(*std::move(operand_or));
   auto type_id = scope.Module().InternType(*un.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -242,11 +242,11 @@ auto LowerBinaryExprStructural(
   auto lhs_or = scope.LowerExpr(bin.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const hir::ExprId lhs_id =
-      frame.current_structural_scope->AddExpr(*std::move(lhs_or));
+      frame.current_structural_scope->exprs.Add(*std::move(lhs_or));
   auto rhs_or = scope.LowerExpr(bin.right(), frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const hir::ExprId rhs_id =
-      frame.current_structural_scope->AddExpr(*std::move(rhs_or));
+      frame.current_structural_scope->exprs.Add(*std::move(rhs_or));
   auto type_id = scope.Module().InternType(*bin.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -281,15 +281,15 @@ auto LowerConditionalExprStructural(
   auto cond_or = scope.LowerExpr(*cond.conditions[0].expr, frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
   const hir::ExprId cond_id =
-      frame.current_structural_scope->AddExpr(*std::move(cond_or));
+      frame.current_structural_scope->exprs.Add(*std::move(cond_or));
   auto then_or = scope.LowerExpr(cond.left(), frame);
   if (!then_or) return std::unexpected(std::move(then_or.error()));
   const hir::ExprId then_id =
-      frame.current_structural_scope->AddExpr(*std::move(then_or));
+      frame.current_structural_scope->exprs.Add(*std::move(then_or));
   auto else_or = scope.LowerExpr(cond.right(), frame);
   if (!else_or) return std::unexpected(std::move(else_or.error()));
   const hir::ExprId else_id =
-      frame.current_structural_scope->AddExpr(*std::move(else_or));
+      frame.current_structural_scope->exprs.Add(*std::move(else_or));
   auto type_id = scope.Module().InternType(*cond.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -122,7 +122,7 @@ auto LowerNamedValueProc(
           diag::UnsupportedCategory::kFeature);
     }
     const hir::TypeId type_id =
-        frame.current_procedural_body->procedural_vars.at(local->value).type;
+        frame.current_procedural_body->procedural_vars.Get(*local).type;
     return MakeRefExpr(hir::ProceduralVarRef{.var = *local}, type_id, span);
   }
 

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -35,7 +35,7 @@ auto LowerUnboundedLiteralProc(
   }
   auto& body = *frame.current_procedural_body;
   const hir::TypeId int32_type = proc.Module().Unit().builtins.int32;
-  const hir::ExprId size_id = body.AddExpr(
+  const hir::ExprId size_id = body.exprs.Add(
       hir::Expr{
           .type = int32_type,
           .data =
@@ -45,7 +45,7 @@ auto LowerUnboundedLiteralProc(
                   .arguments = {*frame.dollar_base}},
           .span = span});
   const hir::ExprId one_id =
-      body.AddExpr(hir::MakeInt32Literal(1, int32_type, span));
+      body.exprs.Add(hir::MakeInt32Literal(1, int32_type, span));
   return hir::Expr{
       .type = int32_type,
       .data =
@@ -69,14 +69,14 @@ auto LowerElementSelectExprProc(
   auto base_or = proc.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const hir::ExprId base_id =
-      frame.current_procedural_body->AddExpr(*std::move(base_or));
+      frame.current_procedural_body->exprs.Add(*std::move(base_or));
 
   const WalkFrame idx_frame =
       sel.value().type->isQueue() ? frame.WithDollarBase(base_id) : frame;
   auto idx_or = proc.LowerExpr(sel.selector(), idx_frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const hir::ExprId idx_id =
-      frame.current_procedural_body->AddExpr(*std::move(idx_or));
+      frame.current_procedural_body->exprs.Add(*std::move(idx_or));
 
   auto type_id = proc.Module().InternType(*sel.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
@@ -106,19 +106,19 @@ auto LowerRangeSelectExprProc(
   auto base_or = proc.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const hir::ExprId base_id =
-      frame.current_procedural_body->AddExpr(*std::move(base_or));
+      frame.current_procedural_body->exprs.Add(*std::move(base_or));
 
   const WalkFrame bound_frame =
       sel.value().type->isQueue() ? frame.WithDollarBase(base_id) : frame;
   auto left_or = proc.LowerExpr(sel.left(), bound_frame);
   if (!left_or) return std::unexpected(std::move(left_or.error()));
   const hir::ExprId left_id =
-      frame.current_procedural_body->AddExpr(*std::move(left_or));
+      frame.current_procedural_body->exprs.Add(*std::move(left_or));
 
   auto right_or = proc.LowerExpr(sel.right(), bound_frame);
   if (!right_or) return std::unexpected(std::move(right_or.error()));
   const hir::ExprId right_id =
-      frame.current_procedural_body->AddExpr(*std::move(right_or));
+      frame.current_procedural_body->exprs.Add(*std::move(right_or));
 
   hir::RangeBounds bounds = [&]() -> hir::RangeBounds {
     switch (sel.getSelectionKind()) {
@@ -163,7 +163,7 @@ auto LowerMemberAccessExprProc(
   auto base_or = proc.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const hir::ExprId base_id =
-      frame.current_procedural_body->AddExpr(*std::move(base_or));
+      frame.current_procedural_body->exprs.Add(*std::move(base_or));
   auto type_id = proc.Module().InternType(*sel.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -194,11 +194,11 @@ auto LowerElementSelectExprStructural(
   auto base_or = scope.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const hir::ExprId base_id =
-      frame.current_structural_scope->AddExpr(*std::move(base_or));
+      frame.current_structural_scope->exprs.Add(*std::move(base_or));
   auto idx_or = scope.LowerExpr(sel.selector(), frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const hir::ExprId idx_id =
-      frame.current_structural_scope->AddExpr(*std::move(idx_or));
+      frame.current_structural_scope->exprs.Add(*std::move(idx_or));
   auto type_id = scope.Module().InternType(*sel.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -222,15 +222,15 @@ auto LowerRangeSelectExprStructural(
   auto base_or = scope.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const hir::ExprId base_id =
-      frame.current_structural_scope->AddExpr(*std::move(base_or));
+      frame.current_structural_scope->exprs.Add(*std::move(base_or));
   auto left_or = scope.LowerExpr(sel.left(), frame);
   if (!left_or) return std::unexpected(std::move(left_or.error()));
   const hir::ExprId left_id =
-      frame.current_structural_scope->AddExpr(*std::move(left_or));
+      frame.current_structural_scope->exprs.Add(*std::move(left_or));
   auto right_or = scope.LowerExpr(sel.right(), frame);
   if (!right_or) return std::unexpected(std::move(right_or.error()));
   const hir::ExprId right_id =
-      frame.current_structural_scope->AddExpr(*std::move(right_or));
+      frame.current_structural_scope->exprs.Add(*std::move(right_or));
   hir::RangeBounds bounds = [&]() -> hir::RangeBounds {
     switch (sel.getSelectionKind()) {
       case slang::ast::RangeSelectionKind::Simple:
@@ -271,7 +271,7 @@ auto LowerMemberAccessExprStructural(
   auto base_or = scope.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const hir::ExprId base_id =
-      frame.current_structural_scope->AddExpr(*std::move(base_or));
+      frame.current_structural_scope->exprs.Add(*std::move(base_or));
   auto type_id = scope.Module().InternType(*sel.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{

--- a/src/lyra/lowering/ast_to_hir/generate.cpp
+++ b/src/lyra/lowering/ast_to_hir/generate.cpp
@@ -28,7 +28,7 @@ auto AddChildStructuralScope(hir::Generate& gen, hir::StructuralScope scope)
   const hir::StructuralScopeId id{
       static_cast<std::uint32_t>(gen.child_scopes.size())};
   scope.id = id;
-  gen.child_scopes.push_back(std::move(scope));
+  gen.child_scopes.Add(std::move(scope));
   return id;
 }
 
@@ -132,7 +132,7 @@ auto StructuralScopeLowerer::BuildIfGenerate(
   auto cond_expr = LowerExpr(*cond, frame);
   if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
   const hir::ExprId cond_id =
-      frame.current_structural_scope->AddExpr(*std::move(cond_expr));
+      frame.current_structural_scope->exprs.Add(*std::move(cond_expr));
 
   hir::Generate gen{};
   const ScopeFrameId gen_frame = frame_;
@@ -182,7 +182,7 @@ auto StructuralScopeLowerer::BuildCaseGenerate(
   auto cond_expr = LowerExpr(*discriminator, frame);
   if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
   const hir::ExprId cond_id =
-      frame.current_structural_scope->AddExpr(*std::move(cond_expr));
+      frame.current_structural_scope->exprs.Add(*std::move(cond_expr));
 
   hir::Generate gen{};
   const ScopeFrameId gen_frame = frame_;
@@ -202,7 +202,7 @@ auto StructuralScopeLowerer::BuildCaseGenerate(
           if (!label_expr_lowered) {
             return std::unexpected(std::move(label_expr_lowered.error()));
           }
-          labels.push_back(frame.current_structural_scope->AddExpr(
+          labels.push_back(frame.current_structural_scope->exprs.Add(
               *std::move(label_expr_lowered)));
         }
         auto item_id =
@@ -267,13 +267,13 @@ auto LowerLoopIterNextValue(
   auto read = parent.LowerExpr(assign.left(), frame);
   if (!read) return std::unexpected(std::move(read.error()));
   const hir::ExprId read_id =
-      frame.current_structural_scope->AddExpr(*std::move(read));
+      frame.current_structural_scope->exprs.Add(*std::move(read));
 
   const auto& bare_rhs = BareCompoundUserRhs(assign.right());
   auto rhs = parent.LowerExpr(bare_rhs, frame);
   if (!rhs) return std::unexpected(std::move(rhs.error()));
   const hir::ExprId rhs_id =
-      frame.current_structural_scope->AddExpr(*std::move(rhs));
+      frame.current_structural_scope->exprs.Add(*std::move(rhs));
 
   auto type_id = module.InternType(*iter.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
@@ -309,7 +309,7 @@ auto StructuralScopeLowerer::BuildLoopGenerate(
   }
 
   const hir::LoopVarDeclId loop_var_id =
-      frame.current_structural_scope->AddLoopVarDecl(
+      frame.current_structural_scope->loop_var_decls.Add(
           hir::LoopVarDecl{
               .name = std::string{loop_var_sym->name},
               .type = *loop_var_type_or});
@@ -319,18 +319,18 @@ auto StructuralScopeLowerer::BuildLoopGenerate(
   auto initial_expr = LowerExpr(*array.initialExpression, frame);
   if (!initial_expr) return std::unexpected(std::move(initial_expr.error()));
   const hir::ExprId initial_id =
-      frame.current_structural_scope->AddExpr(*std::move(initial_expr));
+      frame.current_structural_scope->exprs.Add(*std::move(initial_expr));
 
   auto stop_expr = LowerExpr(*array.stopExpression, frame);
   if (!stop_expr) return std::unexpected(std::move(stop_expr.error()));
   const hir::ExprId stop_id =
-      frame.current_structural_scope->AddExpr(*std::move(stop_expr));
+      frame.current_structural_scope->exprs.Add(*std::move(stop_expr));
 
   auto iter_expr =
       LowerLoopIterNextValue(*this, *module_, *array.iterExpression, frame);
   if (!iter_expr) return std::unexpected(std::move(iter_expr.error()));
   const hir::ExprId iter_id =
-      frame.current_structural_scope->AddExpr(*std::move(iter_expr));
+      frame.current_structural_scope->exprs.Add(*std::move(iter_expr));
 
   hir::StructuralScope loop_scope;
   if (!array.entries.empty()) {

--- a/src/lyra/lowering/ast_to_hir/port_connection.cpp
+++ b/src/lyra/lowering/ast_to_hir/port_connection.cpp
@@ -139,10 +139,10 @@ auto PopulateInstancePortConnections(
         reads = module.Sensitivity().AnalyzeReads(*expr, inst);
       }
       const hir::ExprId lhs_id =
-          frame.current_structural_scope->AddExpr(std::move(child_ref));
+          frame.current_structural_scope->exprs.Add(std::move(child_ref));
       const hir::ExprId rhs_id =
-          frame.current_structural_scope->AddExpr(std::move(rhs));
-      frame.current_structural_scope->AddContinuousAssign(
+          frame.current_structural_scope->exprs.Add(std::move(rhs));
+      frame.current_structural_scope->continuous_assigns.Add(
           hir::ContinuousAssign{
               .span = span,
               .lhs = lhs_id,
@@ -164,13 +164,13 @@ auto PopulateInstancePortConnections(
     auto lhs_or = scope.LowerExpr(assign.left(), frame);
     if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
     const hir::ExprId lhs_id =
-        frame.current_structural_scope->AddExpr(*std::move(lhs_or));
+        frame.current_structural_scope->exprs.Add(*std::move(lhs_or));
     const hir::ExprId rhs_id =
-        frame.current_structural_scope->AddExpr(std::move(child_ref));
+        frame.current_structural_scope->exprs.Add(std::move(child_ref));
     const std::uint64_t width = port_type.getBitWidth();
     const std::vector<SensitivityRead> reads{
         SensitivityRead{.symbol = internal, .bit_range = {0, width - 1}}};
-    frame.current_structural_scope->AddContinuousAssign(
+    frame.current_structural_scope->continuous_assigns.Add(
         hir::ContinuousAssign{
             .span = span,
             .lhs = lhs_id,

--- a/src/lyra/lowering/ast_to_hir/process_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/process_lowerer.cpp
@@ -90,7 +90,7 @@ auto ProcessLowerer::Run(
 
   auto root_stmt = LowerStmt(proc.getBody(), frame);
   if (!root_stmt) return std::unexpected(std::move(root_stmt.error()));
-  body.root_stmt = body.AddStmt(*std::move(root_stmt));
+  body.root_stmt = body.stmts.Add(*std::move(root_stmt));
 
   const auto& mapper = module_->SourceMapper();
   const auto span = mapper.PointSpanOf(proc.location);
@@ -123,7 +123,7 @@ auto ProcessLowerer::Run(
 auto ProcessLowerer::AddProceduralVar(
     hir::ProceduralBody& body, const slang::ast::VariableSymbol& var,
     hir::TypeId type) -> hir::ProceduralVarId {
-  const hir::ProceduralVarId id = body.AddProceduralVar(
+  const hir::ProceduralVarId id = body.procedural_vars.Add(
       hir::ProceduralVarDecl{
           .name = std::string{var.name},
           .type = type,

--- a/src/lyra/lowering/ast_to_hir/statement/blocks.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/blocks.cpp
@@ -82,7 +82,7 @@ auto LowerForkStmt(
         return std::unexpected(std::move(local_stmt.error()));
       }
       locals.push_back(
-          frame.current_procedural_body->AddStmt(*std::move(local_stmt)));
+          frame.current_procedural_body->stmts.Add(*std::move(local_stmt)));
     } else {
       branch_stmts.push_back(child);
     }
@@ -94,8 +94,8 @@ auto LowerForkStmt(
   for (const auto* child : branch_stmts) {
     auto child_stmt = proc.LowerStmt(*child, branch_frame);
     if (!child_stmt) return std::unexpected(std::move(child_stmt.error()));
-    branches.push_back(
-        branch_frame.current_procedural_body->AddStmt(*std::move(child_stmt)));
+    branches.push_back(branch_frame.current_procedural_body->stmts.Add(
+        *std::move(child_stmt)));
   }
 
   return hir::Stmt{
@@ -120,7 +120,7 @@ auto LowerStatementListStmt(
     auto child_stmt = proc.LowerStmt(*child, frame);
     if (!child_stmt) return std::unexpected(std::move(child_stmt.error()));
     kids.push_back(
-        frame.current_procedural_body->AddStmt(*std::move(child_stmt)));
+        frame.current_procedural_body->stmts.Add(*std::move(child_stmt)));
   }
   return hir::Stmt{
       .label = std::nullopt,
@@ -143,13 +143,13 @@ auto LowerBlockStmt(
       auto child_stmt = proc.LowerStmt(*child, frame);
       if (!child_stmt) return std::unexpected(std::move(child_stmt.error()));
       kids.push_back(
-          frame.current_procedural_body->AddStmt(*std::move(child_stmt)));
+          frame.current_procedural_body->stmts.Add(*std::move(child_stmt)));
     }
   } else {
     auto child_stmt = proc.LowerStmt(block.body, frame);
     if (!child_stmt) return std::unexpected(std::move(child_stmt.error()));
     kids.push_back(
-        frame.current_procedural_body->AddStmt(*std::move(child_stmt)));
+        frame.current_procedural_body->stmts.Add(*std::move(child_stmt)));
   }
   return hir::Stmt{
       .label = std::nullopt,

--- a/src/lyra/lowering/ast_to_hir/statement/branches.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/branches.cpp
@@ -39,7 +39,7 @@ auto LowerCaseInsideStmt(
   auto cond_expr = proc.LowerExpr(cs.expr, frame);
   if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
   const hir::ExprId cond_id =
-      frame.current_procedural_body->AddExpr(*std::move(cond_expr));
+      frame.current_procedural_body->exprs.Add(*std::move(cond_expr));
   std::vector<hir::CaseInsideItem> items;
   items.reserve(cs.items.size());
   for (const auto& item : cs.items) {
@@ -53,7 +53,7 @@ auto LowerCaseInsideStmt(
     auto item_stmt = proc.LowerStmt(*item.stmt, frame);
     if (!item_stmt) return std::unexpected(std::move(item_stmt.error()));
     const hir::StmtId item_id =
-        frame.current_procedural_body->AddStmt(*std::move(item_stmt));
+        frame.current_procedural_body->stmts.Add(*std::move(item_stmt));
     items.push_back(
         hir::CaseInsideItem{.items = std::move(inside_items), .stmt = item_id});
   }
@@ -62,7 +62,7 @@ auto LowerCaseInsideStmt(
     auto default_stmt = proc.LowerStmt(*cs.defaultCase, frame);
     if (!default_stmt) return std::unexpected(std::move(default_stmt.error()));
     default_id =
-        frame.current_procedural_body->AddStmt(*std::move(default_stmt));
+        frame.current_procedural_body->stmts.Add(*std::move(default_stmt));
   }
   return hir::Stmt{
       .label = std::nullopt,
@@ -101,7 +101,7 @@ auto LowerCaseStmt(
   auto cond_expr = proc.LowerExpr(cs.expr, frame);
   if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
   const hir::ExprId cond_id =
-      frame.current_procedural_body->AddExpr(*std::move(cond_expr));
+      frame.current_procedural_body->exprs.Add(*std::move(cond_expr));
   std::vector<hir::CaseItem> items;
   items.reserve(cs.items.size());
   for (const auto& item : cs.items) {
@@ -111,12 +111,12 @@ auto LowerCaseStmt(
       auto label_or = proc.LowerExpr(*label_expr, frame);
       if (!label_or) return std::unexpected(std::move(label_or.error()));
       label_ids.push_back(
-          frame.current_procedural_body->AddExpr(*std::move(label_or)));
+          frame.current_procedural_body->exprs.Add(*std::move(label_or)));
     }
     auto item_stmt = proc.LowerStmt(*item.stmt, frame);
     if (!item_stmt) return std::unexpected(std::move(item_stmt.error()));
     const hir::StmtId item_id =
-        frame.current_procedural_body->AddStmt(*std::move(item_stmt));
+        frame.current_procedural_body->stmts.Add(*std::move(item_stmt));
     items.push_back(
         hir::CaseItem{.labels = std::move(label_ids), .stmt = item_id});
   }
@@ -125,7 +125,7 @@ auto LowerCaseStmt(
     auto default_stmt = proc.LowerStmt(*cs.defaultCase, frame);
     if (!default_stmt) return std::unexpected(std::move(default_stmt.error()));
     default_id =
-        frame.current_procedural_body->AddStmt(*std::move(default_stmt));
+        frame.current_procedural_body->stmts.Add(*std::move(default_stmt));
   }
   return hir::Stmt{
       .label = std::nullopt,
@@ -160,16 +160,16 @@ auto LowerConditionalStmt(
   auto cond_expr = proc.LowerExpr(*cond.expr, frame);
   if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
   const hir::ExprId cond_id =
-      frame.current_procedural_body->AddExpr(*std::move(cond_expr));
+      frame.current_procedural_body->exprs.Add(*std::move(cond_expr));
   auto then_stmt = proc.LowerStmt(cs.ifTrue, frame);
   if (!then_stmt) return std::unexpected(std::move(then_stmt.error()));
   const hir::StmtId then_id =
-      frame.current_procedural_body->AddStmt(*std::move(then_stmt));
+      frame.current_procedural_body->stmts.Add(*std::move(then_stmt));
   std::optional<hir::StmtId> else_id;
   if (cs.ifFalse != nullptr) {
     auto else_stmt = proc.LowerStmt(*cs.ifFalse, frame);
     if (!else_stmt) return std::unexpected(std::move(else_stmt.error()));
-    else_id = frame.current_procedural_body->AddStmt(*std::move(else_stmt));
+    else_id = frame.current_procedural_body->stmts.Add(*std::move(else_stmt));
   }
   return hir::Stmt{
       .label = std::nullopt,

--- a/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
@@ -71,13 +71,13 @@ auto BuildIntegerLevel(
   if (dim.range.has_value()) {
     const auto& declared = *dim.range;
     first_id =
-        body.AddExpr(hir::MakeInt32Literal(declared.left, int32_type, span));
+        body.exprs.Add(hir::MakeInt32Literal(declared.left, int32_type, span));
     last_id =
-        body.AddExpr(hir::MakeInt32Literal(declared.right, int32_type, span));
+        body.exprs.Add(hir::MakeInt32Literal(declared.right, int32_type, span));
     ascending = declared.left <= declared.right;
   } else {
     hir::SubroutineRef size_callee = SizeMethodFor(*array_type);
-    const hir::ExprId size_id = body.AddExpr(
+    const hir::ExprId size_id = body.exprs.Add(
         hir::Expr{
             .type = int32_type,
             .data =
@@ -85,26 +85,27 @@ auto BuildIntegerLevel(
                     .callee = std::move(size_callee), .arguments = {*array}},
             .span = span});
     const hir::ExprId one_id =
-        body.AddExpr(hir::MakeInt32Literal(1, int32_type, span));
-    const hir::ExprId last_value_id = body.AddExpr(
+        body.exprs.Add(hir::MakeInt32Literal(1, int32_type, span));
+    const hir::ExprId last_value_id = body.exprs.Add(
         hir::Expr{
             .type = int32_type,
             .data =
                 hir::BinaryExpr{
                     .op = hir::BinaryOp::kSub, .lhs = size_id, .rhs = one_id},
             .span = span});
-    const hir::ProceduralVarId last_var = body.AddProceduralVar(
+    const hir::ProceduralVarId last_var = body.procedural_vars.Add(
         hir::ProceduralVarDecl{
             .name = std::string{kLastIndexName},
             .type = int32_type,
             .lifetime = hir::VariableLifetime::kAutomatic});
-    setup.push_back(body.AddStmt(
+    setup.push_back(body.stmts.Add(
         hir::Stmt{
             .label = std::nullopt,
             .data = hir::VarDeclStmt{.var = last_var, .init = last_value_id},
             .span = span}));
-    first_id = body.AddExpr(hir::MakeInt32Literal(0, int32_type, span));
-    last_id = body.AddExpr(hir::MakeProcVarRefExpr(last_var, int32_type, span));
+    first_id = body.exprs.Add(hir::MakeInt32Literal(0, int32_type, span));
+    last_id =
+        body.exprs.Add(hir::MakeProcVarRefExpr(last_var, int32_type, span));
   }
 
   const hir::ProceduralVarId loop_var =
@@ -112,8 +113,8 @@ auto BuildIntegerLevel(
   std::vector<hir::ForInit> init;
   init.emplace_back(hir::ForInitDecl{.var = loop_var, .init = first_id});
   const hir::ExprId cond_ref =
-      body.AddExpr(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
-  const hir::ExprId cond_id = body.AddExpr(
+      body.exprs.Add(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
+  const hir::ExprId cond_id = body.exprs.Add(
       hir::Expr{
           .type = int32_type,
           .data =
@@ -124,8 +125,8 @@ auto BuildIntegerLevel(
                   .rhs = last_id},
           .span = span});
   const hir::ExprId step_ref =
-      body.AddExpr(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
-  const hir::ExprId step_id = body.AddExpr(
+      body.exprs.Add(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
+  const hir::ExprId step_id = body.exprs.Add(
       hir::Expr{
           .type = int32_type,
           .data =
@@ -160,12 +161,12 @@ auto BuildAssociativeLevel(
 
   const hir::ProceduralVarId key_var =
       proc.AddProceduralVar(body, *dim.loopVar, key_type);
-  setup.push_back(body.AddStmt(
+  setup.push_back(body.stmts.Add(
       hir::Stmt{
           .label = std::nullopt,
           .data = hir::VarDeclStmt{.var = key_var, .init = std::nullopt},
           .span = span}));
-  const hir::ProceduralVarId more_var = body.AddProceduralVar(
+  const hir::ProceduralVarId more_var = body.procedural_vars.Add(
       hir::ProceduralVarDecl{
           .name = std::string{kMoreFlagName},
           .type = int32_type,
@@ -173,8 +174,8 @@ auto BuildAssociativeLevel(
 
   auto walk_call = [&](support::BuiltinFn method) -> hir::ExprId {
     const hir::ExprId key_ref =
-        body.AddExpr(hir::MakeProcVarRefExpr(key_var, key_type, span));
-    return body.AddExpr(
+        body.exprs.Add(hir::MakeProcVarRefExpr(key_var, key_type, span));
+    return body.exprs.Add(
         hir::Expr{
             .type = int32_type,
             .data =
@@ -190,10 +191,10 @@ auto BuildAssociativeLevel(
       hir::ForInitDecl{
           .var = more_var, .init = walk_call(support::BuiltinFn::kAssocFirst)});
   const hir::ExprId cond_id =
-      body.AddExpr(hir::MakeProcVarRefExpr(more_var, int32_type, span));
+      body.exprs.Add(hir::MakeProcVarRefExpr(more_var, int32_type, span));
   const hir::ExprId more_lhs =
-      body.AddExpr(hir::MakeProcVarRefExpr(more_var, int32_type, span));
-  const hir::ExprId step_id = body.AddExpr(
+      body.exprs.Add(hir::MakeProcVarRefExpr(more_var, int32_type, span));
+  const hir::ExprId step_id = body.exprs.Add(
       hir::Expr{
           .type = int32_type,
           .data =
@@ -244,7 +245,7 @@ auto BuildForeachNest(
     auto body_or = proc.LowerStmt(
         fs.body, frame.WithBreakLabel(foreach_label, label_used));
     if (!body_or) return std::unexpected(std::move(body_or.error()));
-    return std::vector<hir::StmtId>{body.AddStmt(*std::move(body_or))};
+    return std::vector<hir::StmtId>{body.stmts.Add(*std::move(body_or))};
   }
 
   const LoopDim& dim = *levels[level];
@@ -282,9 +283,9 @@ auto BuildForeachNest(
     if (!inner_hir_type) {
       return std::unexpected(std::move(inner_hir_type.error()));
     }
-    const hir::ExprId index_id = body.AddExpr(
+    const hir::ExprId index_id = body.exprs.Add(
         hir::MakeProcVarRefExpr(loop.loop_var, loop.loop_var_type, span));
-    inner_array = body.AddExpr(
+    inner_array = body.exprs.Add(
         hir::Expr{
             .type = *inner_hir_type,
             .data =
@@ -299,13 +300,13 @@ auto BuildForeachNest(
   const hir::StmtId inner_body =
       inner_or->size() == 1
           ? inner_or->front()
-          : body.AddStmt(
+          : body.stmts.Add(
                 hir::Stmt{
                     .label = std::nullopt,
                     .data = hir::BlockStmt{.statements = std::move(*inner_or)},
                     .span = span});
 
-  stmts.push_back(body.AddStmt(
+  stmts.push_back(body.stmts.Add(
       hir::Stmt{
           .label = std::nullopt,
           .data =
@@ -354,14 +355,14 @@ auto ProcessLowerer::LowerForeachStmt(
   if (levels.empty()) {
     auto array_or = proc.LowerExpr(fs.arrayRef, frame);
     if (!array_or) return std::unexpected(std::move(array_or.error()));
-    const auto array_eval_stmt = body.AddStmt(
+    const auto array_eval_stmt = body.stmts.Add(
         hir::Stmt{
             .label = std::nullopt,
-            .data = hir::ExprStmt{.expr = body.AddExpr(*std::move(array_or))},
+            .data = hir::ExprStmt{.expr = body.exprs.Add(*std::move(array_or))},
             .span = span});
     auto body_or = proc.LowerStmt(fs.body, frame.WithoutBreakLabel());
     if (!body_or) return std::unexpected(std::move(body_or.error()));
-    const auto body_stmt_id = body.AddStmt(*std::move(body_or));
+    const auto body_stmt_id = body.stmts.Add(*std::move(body_or));
     return hir::Stmt{
         .label = std::nullopt,
         .data = hir::BlockStmt{.statements = {array_eval_stmt, body_stmt_id}},
@@ -376,7 +377,7 @@ auto ProcessLowerer::LowerForeachStmt(
   if (needs_array) {
     auto array_or = proc.LowerExpr(fs.arrayRef, frame);
     if (!array_or) return std::unexpected(std::move(array_or.error()));
-    array = body.AddExpr(*std::move(array_or));
+    array = body.exprs.Add(*std::move(array_or));
     array_type = fs.arrayRef.type;
   }
 

--- a/src/lyra/lowering/ast_to_hir/statement/loops.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/loops.cpp
@@ -27,13 +27,13 @@ auto LowerForLoopStmt(
     hir_init.emplace_back(
         hir::ForInitExpr{
             .expr =
-                frame.current_procedural_body->AddExpr(*std::move(init_or))});
+                frame.current_procedural_body->exprs.Add(*std::move(init_or))});
   }
   std::optional<hir::ExprId> cond_id;
   if (fs.stopExpr != nullptr) {
     auto cond_or = proc.LowerExpr(*fs.stopExpr, frame);
     if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-    cond_id = frame.current_procedural_body->AddExpr(*std::move(cond_or));
+    cond_id = frame.current_procedural_body->exprs.Add(*std::move(cond_or));
   }
   std::vector<hir::ExprId> step_ids;
   step_ids.reserve(fs.steps.size());
@@ -41,12 +41,12 @@ auto LowerForLoopStmt(
     auto step_or = proc.LowerExpr(*step_expr, frame);
     if (!step_or) return std::unexpected(std::move(step_or.error()));
     step_ids.push_back(
-        frame.current_procedural_body->AddExpr(*std::move(step_or)));
+        frame.current_procedural_body->exprs.Add(*std::move(step_or)));
   }
   auto body_stmt = proc.LowerStmt(fs.body, frame.WithoutBreakLabel());
   if (!body_stmt) return std::unexpected(std::move(body_stmt.error()));
   const hir::StmtId body_id =
-      frame.current_procedural_body->AddStmt(*std::move(body_stmt));
+      frame.current_procedural_body->stmts.Add(*std::move(body_stmt));
   return hir::Stmt{
       .label = std::nullopt,
       .data =
@@ -65,11 +65,11 @@ auto LowerWhileLoopStmt(
   auto cond_or = proc.LowerExpr(ws.cond, frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
   const hir::ExprId cond_id =
-      frame.current_procedural_body->AddExpr(*std::move(cond_or));
+      frame.current_procedural_body->exprs.Add(*std::move(cond_or));
   auto body_or = proc.LowerStmt(ws.body, frame.WithoutBreakLabel());
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   const hir::StmtId body_id =
-      frame.current_procedural_body->AddStmt(*std::move(body_or));
+      frame.current_procedural_body->stmts.Add(*std::move(body_or));
   return hir::Stmt{
       .label = std::nullopt,
       .data = hir::WhileStmt{.condition = cond_id, .body = body_id},
@@ -83,11 +83,11 @@ auto LowerRepeatLoopStmt(
   auto count_or = proc.LowerExpr(rs.count, frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
   const hir::ExprId count_id =
-      frame.current_procedural_body->AddExpr(*std::move(count_or));
+      frame.current_procedural_body->exprs.Add(*std::move(count_or));
   auto body_or = proc.LowerStmt(rs.body, frame.WithoutBreakLabel());
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   const hir::StmtId body_id =
-      frame.current_procedural_body->AddStmt(*std::move(body_or));
+      frame.current_procedural_body->stmts.Add(*std::move(body_or));
   return hir::Stmt{
       .label = std::nullopt,
       .data = hir::RepeatStmt{.count = count_id, .body = body_id},
@@ -101,11 +101,11 @@ auto LowerDoWhileLoopStmt(
   auto body_or = proc.LowerStmt(ds.body, frame.WithoutBreakLabel());
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   const hir::StmtId body_id =
-      frame.current_procedural_body->AddStmt(*std::move(body_or));
+      frame.current_procedural_body->stmts.Add(*std::move(body_or));
   auto cond_or = proc.LowerExpr(ds.cond, frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
   const hir::ExprId cond_id =
-      frame.current_procedural_body->AddExpr(*std::move(cond_or));
+      frame.current_procedural_body->exprs.Add(*std::move(cond_or));
   return hir::Stmt{
       .label = std::nullopt,
       .data = hir::DoWhileStmt{.condition = cond_id, .body = body_id},
@@ -119,7 +119,7 @@ auto LowerForeverLoopStmt(
   auto body_or = proc.LowerStmt(fs.body, frame.WithoutBreakLabel());
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   const hir::StmtId body_id =
-      frame.current_procedural_body->AddStmt(*std::move(body_or));
+      frame.current_procedural_body->stmts.Add(*std::move(body_or));
   return hir::Stmt{
       .label = std::nullopt,
       .data = hir::ForeverStmt{.body = body_id},

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -66,7 +66,7 @@ auto LowerVariableDeclStmt(
   if (const auto* init_expr = sym.getInitializer()) {
     auto init_or = proc.LowerExpr(*init_expr, frame);
     if (!init_or) return std::unexpected(std::move(init_or.error()));
-    init_id = frame.current_procedural_body->AddExpr(*std::move(init_or));
+    init_id = frame.current_procedural_body->exprs.Add(*std::move(init_or));
   }
   return hir::Stmt{
       .label = std::nullopt,
@@ -81,7 +81,7 @@ auto LowerExpressionStmt(
   auto expr = proc.LowerExpr(es.expr, frame);
   if (!expr) return std::unexpected(std::move(expr.error()));
   const hir::ExprId id =
-      frame.current_procedural_body->AddExpr(*std::move(expr));
+      frame.current_procedural_body->exprs.Add(*std::move(expr));
   return hir::Stmt{
       .label = std::nullopt, .data = hir::ExprStmt{.expr = id}, .span = span};
 }
@@ -97,7 +97,7 @@ auto LowerReturnStmt(
   if (rs.expr != nullptr) {
     auto expr_or = proc.LowerExpr(*rs.expr, frame);
     if (!expr_or) return std::unexpected(std::move(expr_or.error()));
-    value = frame.current_procedural_body->AddExpr(*std::move(expr_or));
+    value = frame.current_procedural_body->exprs.Add(*std::move(expr_or));
   }
   return hir::Stmt{
       .label = std::nullopt,

--- a/src/lyra/lowering/ast_to_hir/statement/timing.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/timing.cpp
@@ -79,7 +79,7 @@ auto LowerSignalEventTrigger(
   }
 
   return hir::EventTrigger{
-      .signal = frame.current_procedural_body->AddExpr(*std::move(expr_or)),
+      .signal = frame.current_procedural_body->exprs.Add(*std::move(expr_or)),
       .edge = edge_kind,
       .sensitivity_list = std::move(sensitivity_list),
   };
@@ -117,7 +117,7 @@ auto LowerNamedEventControl(
         diag::UnsupportedCategory::kFeature);
   }
   return hir::NamedEventControl{
-      .event = frame.current_procedural_body->AddExpr(*std::move(expr_or)),
+      .event = frame.current_procedural_body->exprs.Add(*std::move(expr_or)),
   };
 }
 
@@ -131,7 +131,7 @@ auto LowerTimingControl(
       if (!duration) return std::unexpected(std::move(duration.error()));
       return hir::TimingControl{hir::DelayControl{
           .duration =
-              frame.current_procedural_body->AddExpr(*std::move(duration))}};
+              frame.current_procedural_body->exprs.Add(*std::move(duration))}};
     }
     case slang::ast::TimingControlKind::SignalEvent: {
       const auto& sig = tc.as<slang::ast::SignalEventControl>();
@@ -202,7 +202,7 @@ auto LowerTimedStmt(
   auto inner_stmt = proc.LowerStmt(ts.stmt, frame);
   if (!inner_stmt) return std::unexpected(std::move(inner_stmt.error()));
   const hir::StmtId inner_id =
-      frame.current_procedural_body->AddStmt(*std::move(inner_stmt));
+      frame.current_procedural_body->stmts.Add(*std::move(inner_stmt));
   return hir::Stmt{
       .label = std::nullopt,
       .data = hir::TimedStmt{.timing = *std::move(timing), .stmt = inner_id},
@@ -243,7 +243,7 @@ auto LowerEventTriggerStmt(
       .data =
           hir::EventTriggerStmt{
               .event =
-                  frame.current_procedural_body->AddExpr(*std::move(expr_or)),
+                  frame.current_procedural_body->exprs.Add(*std::move(expr_or)),
           },
       .span = span};
 }
@@ -258,11 +258,11 @@ auto LowerWaitStmt(
   auto cond_or = proc.LowerExpr(w.cond, frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
   const hir::ExprId cond_id =
-      frame.current_procedural_body->AddExpr(*std::move(cond_or));
+      frame.current_procedural_body->exprs.Add(*std::move(cond_or));
   auto body_or = proc.LowerStmt(w.stmt, frame);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   const hir::StmtId body_id =
-      frame.current_procedural_body->AddStmt(*std::move(body_or));
+      frame.current_procedural_body->stmts.Add(*std::move(body_or));
   const auto& reads =
       proc.Module().Sensitivity().AnalyzeReads(w.cond, proc.ContainingSymbol());
   auto sensitivity = proc.Module().TranslateSensitivityReads(reads, frame);

--- a/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
@@ -178,7 +178,9 @@ auto StructuralScopeLowerer::Run(WalkFrame parent_frame)
   auto pc = PopulatePortConnections(*slang_scope_, frame);
   if (!pc) return std::unexpected(std::move(pc.error()));
 
-  scope.cross_unit_refs = module_->TakeCrossUnitRefsForFrame(frame_);
+  for (auto& ref : module_->TakeCrossUnitRefsForFrame(frame_)) {
+    scope.cross_unit_refs.Add(std::move(ref));
+  }
   return scope;
 }
 
@@ -253,10 +255,10 @@ auto StructuralScopeLowerer::PopulateVariableMember(
     auto init_or = LowerExpr(*init, frame);
     if (!init_or) return std::unexpected(std::move(init_or.error()));
     initializer_id =
-        frame.current_structural_scope->AddExpr(*std::move(init_or));
+        frame.current_structural_scope->exprs.Add(*std::move(init_or));
   }
   const hir::StructuralVarId local =
-      frame.current_structural_scope->AddStructuralVar(
+      frame.current_structural_scope->structural_vars.Add(
           hir::StructuralVarDecl{
               .name = std::string{var.name},
               .type = *type_id_or,
@@ -305,7 +307,7 @@ auto StructuralScopeLowerer::PopulateSubroutineMember(
 
   auto body_stmt_or = sub_lowerer.LowerStmt(sym.getBody(), sub_frame);
   if (!body_stmt_or) return std::unexpected(std::move(body_stmt_or.error()));
-  sub_body.root_stmt = sub_body.AddStmt(*std::move(body_stmt_or));
+  sub_body.root_stmt = sub_body.stmts.Add(*std::move(body_stmt_or));
 
   const auto binding = module_->LookupSubroutineBinding(sym);
   if (!binding.has_value() ||
@@ -318,7 +320,7 @@ auto StructuralScopeLowerer::PopulateSubroutineMember(
         "reserved order; ReserveSubroutineBinding must run first in the same "
         "order");
   }
-  frame.current_structural_scope->AddStructuralSubroutine(
+  frame.current_structural_scope->structural_subroutines.Add(
       hir::StructuralSubroutineDecl{
           .name = std::string{sym.name},
           .kind = ToHirSubroutineKind(sym.subroutineKind),
@@ -335,7 +337,7 @@ auto StructuralScopeLowerer::PopulateProceduralBlockMember(
   ProcessLowerer proc_lowerer(*module_, proc);
   auto p = proc_lowerer.Run(proc, frame);
   if (!p) return std::unexpected(std::move(p.error()));
-  frame.current_structural_scope->AddProcess(*std::move(p));
+  frame.current_structural_scope->processes.Add(*std::move(p));
   return {};
 }
 
@@ -344,7 +346,7 @@ auto StructuralScopeLowerer::PopulateContinuousAssignMember(
     -> diag::Result<void> {
   auto ca = LowerContinuousAssign(sym, frame);
   if (!ca) return std::unexpected(std::move(ca.error()));
-  frame.current_structural_scope->AddContinuousAssign(*std::move(ca));
+  frame.current_structural_scope->continuous_assigns.Add(*std::move(ca));
   return {};
 }
 
@@ -353,7 +355,7 @@ auto StructuralScopeLowerer::PopulateLoopGenerateMember(
     -> diag::Result<void> {
   auto g = BuildLoopGenerate(array, frame);
   if (!g) return std::unexpected(std::move(g.error()));
-  frame.current_structural_scope->AddGenerate(*std::move(g));
+  frame.current_structural_scope->generates.Add(*std::move(g));
   return {};
 }
 
@@ -374,7 +376,7 @@ auto StructuralScopeLowerer::PopulateIfOrCaseGenerateMember(
   auto g = IsCaseConstruct(siblings) ? BuildCaseGenerate(siblings, frame)
                                      : BuildIfGenerate(siblings, frame);
   if (!g) return std::unexpected(std::move(g.error()));
-  frame.current_structural_scope->AddGenerate(*std::move(g));
+  frame.current_structural_scope->generates.Add(*std::move(g));
   return {};
 }
 
@@ -382,7 +384,7 @@ auto StructuralScopeLowerer::PopulateInstanceMember(
     const slang::ast::InstanceSymbol& inst, WalkFrame frame)
     -> diag::Result<void> {
   const hir::InstanceMemberId member_id =
-      frame.current_structural_scope->AddInstanceMember(
+      frame.current_structural_scope->instance_members.Add(
           hir::InstanceMemberDecl{
               .instance_name = std::string{inst.name},
               .target_unit = std::string{inst.getDefinition().name},
@@ -415,7 +417,7 @@ auto StructuralScopeLowerer::PopulateInstanceArrayMember(
   }
   const auto& leaf = level->as<slang::ast::InstanceSymbol>();
   const hir::InstanceMemberId member_id =
-      frame.current_structural_scope->AddInstanceMember(
+      frame.current_structural_scope->instance_members.Add(
           hir::InstanceMemberDecl{
               .instance_name = std::string{array.name},
               .target_unit = std::string{leaf.getDefinition().name},

--- a/src/lyra/lowering/hir_to_mir/case_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/case_cascade.cpp
@@ -14,12 +14,12 @@ auto AppendCaseSnapshot(
     const ModuleLowerer& module, WalkFrame frame, mir::ExprId cond_expr_id)
     -> CaseSnapshotRefs {
   auto& wrapper = *frame.current_block;
-  const mir::TypeId sel_type = wrapper.GetExpr(cond_expr_id).type;
+  const mir::TypeId sel_type = wrapper.exprs.Get(cond_expr_id).type;
 
-  const mir::LocalId sel_var = wrapper.AddLocal(
+  const mir::LocalId sel_var = wrapper.vars.Add(
       mir::LocalDecl{.name = "_lyra_case_sel", .type = sel_type});
   const mir::ExprId sel_default_init =
-      wrapper.AddExpr(BuildDefaultValueExpr(module, frame, sel_type));
+      wrapper.exprs.Add(BuildDefaultValueExpr(module, frame, sel_type));
   wrapper.AppendStmt(
       mir::Stmt{
           .label = std::nullopt,
@@ -29,12 +29,12 @@ auto AppendCaseSnapshot(
                       .hops = mir::BlockHops{.value = 0}, .var = sel_var},
               .init = sel_default_init}});
 
-  const mir::ExprId sel_target_id = wrapper.AddExpr(
+  const mir::ExprId sel_target_id = wrapper.exprs.Add(
       mir::Expr{
           .data =
               mir::LocalRef{.hops = mir::BlockHops{.value = 0}, .var = sel_var},
           .type = sel_type});
-  const mir::ExprId sel_assign_id = wrapper.AddExpr(
+  const mir::ExprId sel_assign_id = wrapper.exprs.Add(
       mir::Expr{
           .data =
               mir::AssignExpr{.target = sel_target_id, .value = cond_expr_id},

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -108,7 +108,7 @@ auto EnumerateGenerateChildSpecs(
   std::visit(
       Overloaded{
           [&](const hir::IfGenerate& if_gen) {
-            const auto& then_scope = gen.GetChildScope(if_gen.then_scope);
+            const auto& then_scope = gen.child_scopes.Get(if_gen.then_scope);
             specs.push_back(
                 {.scope_id = if_gen.then_scope,
                  .scope = &then_scope,
@@ -116,7 +116,7 @@ auto EnumerateGenerateChildSpecs(
                  .is_repeated = false,
                  .entry_bindings = {}});
             if (if_gen.else_scope.has_value()) {
-              const auto& else_scope = gen.GetChildScope(*if_gen.else_scope);
+              const auto& else_scope = gen.child_scopes.Get(*if_gen.else_scope);
               specs.push_back(
                   {.scope_id = *if_gen.else_scope,
                    .scope = &else_scope,
@@ -128,7 +128,7 @@ auto EnumerateGenerateChildSpecs(
           [&](const hir::CaseGenerate& case_gen) {
             for (std::size_t k = 0; k < case_gen.items.size(); ++k) {
               const auto& item_scope =
-                  gen.GetChildScope(case_gen.items[k].scope);
+                  gen.child_scopes.Get(case_gen.items[k].scope);
               specs.push_back(
                   {.scope_id = case_gen.items[k].scope,
                    .scope = &item_scope,
@@ -139,7 +139,7 @@ auto EnumerateGenerateChildSpecs(
             }
             if (case_gen.default_scope.has_value()) {
               const auto& default_scope =
-                  gen.GetChildScope(*case_gen.default_scope);
+                  gen.child_scopes.Get(*case_gen.default_scope);
               specs.push_back(
                   {.scope_id = *case_gen.default_scope,
                    .scope = &default_scope,
@@ -149,9 +149,9 @@ auto EnumerateGenerateChildSpecs(
             }
           },
           [&](const hir::LoopGenerate& loop_gen) {
-            const auto& loop_scope = gen.GetChildScope(loop_gen.scope);
+            const auto& loop_scope = gen.child_scopes.Get(loop_gen.scope);
             const auto& var_decl =
-                enclosing_scope.GetLoopVarDecl(loop_gen.loop_var);
+                enclosing_scope.loop_var_decls.Get(loop_gen.loop_var);
             std::vector<ScopeEntryStructuralParamBinding> bindings;
             bindings.push_back(
                 ScopeEntryStructuralParamBinding{
@@ -224,7 +224,7 @@ auto InstallInstanceMembers(ClassLowerer& lowerer, WalkFrame frame)
     }
     const mir::TypeId var_type = MakeExternalUnitMemberType(
         lowerer.Module(), im.target_unit, im.array_dims.size());
-    const mir::MemberId var_id = mir_class.AddMember(
+    const mir::MemberId var_id = mir_class.members.Add(
         mir::MemberDecl{.name = im.instance_name, .type = var_type});
     instance_member_vars.push_back(var_id);
 
@@ -285,7 +285,7 @@ auto MaterializeCrossUnitRefTargets(ClassLowerer& lowerer, WalkFrame frame)
               .match = match,
               .tail = std::move(tail),
               .signal = std::move(signal)});
-      const mir::MemberId var = mir_class.AddMember(
+      const mir::MemberId var = mir_class.members.Add(
           mir::MemberDecl{.name = std::move(member_name), .type = ext_type});
       lowerer.AddCrossUnitRefTarget(
           mir::MemberRef{.hops = {.value = 0}, .var = var}, ext_type);
@@ -300,7 +300,7 @@ auto MaterializeCrossUnitRefTargets(ClassLowerer& lowerer, WalkFrame frame)
       const mir::TypeId slot_type = module.Unit().AddType(
           mir::PointerType{
               .pointee = leaf, .ownership = mir::PointerOwnership::kBorrowed});
-      const mir::MemberId slot = mir_class.AddMember(
+      const mir::MemberId slot = mir_class.members.Add(
           mir::MemberDecl{.name = std::move(member_name), .type = slot_type});
       lowerer.AddCrossUnitRefTarget(
           mir::MemberRef{.hops = {.value = 0}, .var = slot}, slot_type);
@@ -333,7 +333,7 @@ auto BuildDownwardNavValue(
       hops.push_back(NavHop{.name = member->name, .indices = {}});
     } else {
       const std::uint32_t index = std::get<hir::IndexHop>(step).index;
-      hops.back().indices.push_back(ctor_block.AddExpr(
+      hops.back().indices.push_back(ctor_block.exprs.Add(
           mir::MakeInt32Literal(
               module.Unit().builtins.int32, static_cast<std::int64_t>(index))));
     }
@@ -344,14 +344,15 @@ auto BuildDownwardNavValue(
         "owned child");
   }
 
-  mir::ExprId cur = ctor_block.AddExpr(BuildSelfRefExpr(frame, self_ptr_type));
+  mir::ExprId cur =
+      ctor_block.exprs.Add(BuildSelfRefExpr(frame, self_ptr_type));
   for (std::size_t i = 0; i + 1 < hops.size(); ++i) {
     std::vector<mir::ExprId> args;
     args.push_back(cur);
     for (const mir::ExprId idx : hops[i].indices) {
       args.push_back(idx);
     }
-    cur = ctor_block.AddExpr(
+    cur = ctor_block.exprs.Add(
         mir::Expr{
             .data =
                 mir::CallExpr{
@@ -391,7 +392,8 @@ void InstallCrossUnitRefs(
           .pointee = module.Unit().AddType(mir::ScopeType{}),
           .ownership = mir::PointerOwnership::kBorrowed});
   for (std::size_t ci = 0; ci < hir_scope.cross_unit_refs.size(); ++ci) {
-    const auto& cu = hir_scope.cross_unit_refs[ci];
+    const auto& cu = hir_scope.cross_unit_refs.Get(
+        hir::CrossUnitRefId{static_cast<std::uint32_t>(ci)});
     const auto* down = std::get_if<hir::DownwardHead>(&cu.head);
     if (down == nullptr) {
       continue;
@@ -406,15 +408,15 @@ void InstallCrossUnitRefs(
                      .by_scope_id.at(g.scope.value)
                      .var_id;
     }
-    const auto& head = mir_class.GetMember(head_var);
+    const auto& head = mir_class.members.Get(head_var);
     const std::string head_name =
         head.source_name.empty() ? head.name : head.source_name;
-    const mir::TypeId slot_type = mir_class.GetMember(slot).type;
-    const mir::ExprId nav = ctor_block.AddExpr(BuildDownwardNavValue(
+    const mir::TypeId slot_type = mir_class.members.Get(slot).type;
+    const mir::ExprId nav = ctor_block.exprs.Add(BuildDownwardNavValue(
         module, frame, head_name, cu.path, slot_type, scope_ptr_type));
-    const mir::ExprId self_for_target = ctor_block.AddExpr(
+    const mir::ExprId self_for_target = ctor_block.exprs.Add(
         BuildSelfRefExpr(frame, mir_class.self_pointer_type));
-    const mir::ExprId target = ctor_block.AddExpr(
+    const mir::ExprId target = ctor_block.exprs.Add(
         mir::Expr{
             .data =
                 mir::MemberAccessExpr{
@@ -422,7 +424,7 @@ void InstallCrossUnitRefs(
                     .member =
                         mir::MemberRef{.hops = {.value = 0}, .var = slot}},
             .type = slot_type});
-    const mir::ExprId assign = ctor_block.AddExpr(
+    const mir::ExprId assign = ctor_block.exprs.Add(
         mir::Expr{
             .data = mir::AssignExpr{.target = target, .value = nav},
             .type = slot_type});
@@ -445,11 +447,11 @@ void ValidateConstructOwnedObjectStmt(
         "ConstructOwnedObjectStmt: target is out of range in the enclosing "
         "class");
   }
-  const auto& var = owner_class.GetMember(stmt.target);
+  const auto& var = owner_class.members.Get(stmt.target);
   const auto child = mir::GetChildScope(unit, var.type);
   const auto* generate =
       child ? std::get_if<mir::GenerateScopeChild>(&*child) : nullptr;
-  const auto& child_scope = owner_class.GetNestedClass(stmt.scope_id);
+  const auto& child_scope = owner_class.nested_classes.Get(stmt.scope_id);
   if (generate == nullptr || generate->name != child_scope.name) {
     throw InternalError(
         "ConstructOwnedObjectStmt: target var does not own the requested "
@@ -461,8 +463,9 @@ void ValidateConstructOwnedObjectStmt(
         "param count");
   }
   for (std::size_t i = 0; i < stmt.args.size(); ++i) {
-    const auto& arg = block.GetExpr(stmt.args[i]);
-    const auto& param = child_scope.params[i];
+    const auto& arg = block.exprs.Get(stmt.args[i]);
+    const auto& param =
+        child_scope.params.Get(mir::ParamId{static_cast<std::uint32_t>(i)});
     if (arg.type != param.type) {
       throw InternalError(
           "ConstructOwnedObjectStmt: arg type does not match structural "
@@ -493,7 +496,7 @@ auto BuildGenerateArmBody(
   std::vector<mir::ExprId> arg_ids;
   arg_ids.reserve(args.size());
   for (auto& arg : args) {
-    arg_ids.push_back(arm_block.AddExpr(std::move(arg)));
+    arg_ids.push_back(arm_block.exprs.Add(std::move(arg)));
   }
 
   const mir::ConstructOwnedObjectStmt construct_stmt{
@@ -516,16 +519,16 @@ auto LowerIfGenerate(
   mir::Block& block = *frame.current_block;
 
   auto cond_or =
-      lowerer.LowerExpr(enclosing_scope.GetExpr(if_gen.condition), frame);
+      lowerer.LowerExpr(enclosing_scope.exprs.Get(if_gen.condition), frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const mir::ExprId cond_id = block.AddExpr(*std::move(cond_or));
+  const mir::ExprId cond_id = block.exprs.Add(*std::move(cond_or));
 
-  const mir::BlockId then_id = block.AddChildScope(BuildGenerateArmBody(
+  const mir::BlockId then_id = block.child_scopes.Add(BuildGenerateArmBody(
       lowerer.Module(), frame, gen_bindings, if_gen.then_scope, {}));
 
   std::optional<mir::BlockId> else_id;
   if (if_gen.else_scope.has_value()) {
-    else_id = block.AddChildScope(BuildGenerateArmBody(
+    else_id = block.child_scopes.Add(BuildGenerateArmBody(
         lowerer.Module(), frame, gen_bindings, *if_gen.else_scope, {}));
   }
 
@@ -546,9 +549,9 @@ auto LowerCaseGenerate(
   const WalkFrame wrapper_frame = frame.WithBlock(&wrapper_block);
 
   auto cond_or = lowerer.LowerExpr(
-      enclosing_scope.GetExpr(case_gen.condition), wrapper_frame);
+      enclosing_scope.exprs.Get(case_gen.condition), wrapper_frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const mir::ExprId cond_expr_id = wrapper_block.AddExpr(*std::move(cond_or));
+  const mir::ExprId cond_expr_id = wrapper_block.exprs.Add(*std::move(cond_or));
 
   const CaseSnapshotRefs snapshot =
       AppendCaseSnapshot(lowerer.Module(), wrapper_frame, cond_expr_id);
@@ -575,12 +578,12 @@ auto LowerCaseGenerate(
         [&](WalkFrame label_frame,
             std::size_t li) -> diag::Result<mir::ExprId> {
           auto lab_or = lowerer.LowerExpr(
-              enclosing_scope.GetExpr(case_gen.items[item_idx].labels[li]),
+              enclosing_scope.exprs.Get(case_gen.items[item_idx].labels[li]),
               label_frame);
           if (!lab_or) {
             return std::unexpected(std::move(lab_or.error()));
           }
-          return label_frame.current_block->AddExpr(*std::move(lab_or));
+          return label_frame.current_block->exprs.Add(*std::move(lab_or));
         });
   };
 
@@ -596,10 +599,10 @@ auto LowerLoopGenerate(
   const hir::StructuralScope& enclosing_scope = lowerer.HirScope();
   mir::Block& block = *frame.current_block;
 
-  const auto& var_decl = enclosing_scope.GetLoopVarDecl(loop.loop_var);
+  const auto& var_decl = enclosing_scope.loop_var_decls.Get(loop.loop_var);
   const mir::TypeId genvar_type = lowerer.Module().TranslateType(var_decl.type);
 
-  const mir::LocalId loop_local_id = block.AddLocal(
+  const mir::LocalId loop_local_id = block.vars.Add(
       mir::LocalDecl{.name = var_decl.name, .type = genvar_type});
   const mir::LocalRef loop_local{
       .hops = mir::BlockHops{.value = 0}, .var = loop_local_id};
@@ -609,27 +612,27 @@ auto LowerLoopGenerate(
   const WalkFrame proc_frame =
       frame.WithLoopVarMode(LoopVarLoweringMode::kProceduralInduction);
   auto init_or =
-      lowerer.LowerExpr(enclosing_scope.GetExpr(loop.initial), proc_frame);
+      lowerer.LowerExpr(enclosing_scope.exprs.Get(loop.initial), proc_frame);
   if (!init_or) return std::unexpected(std::move(init_or.error()));
-  const mir::ExprId init_id = block.AddExpr(*std::move(init_or));
+  const mir::ExprId init_id = block.exprs.Add(*std::move(init_or));
 
   auto cond_or =
-      lowerer.LowerExpr(enclosing_scope.GetExpr(loop.stop), proc_frame);
+      lowerer.LowerExpr(enclosing_scope.exprs.Get(loop.stop), proc_frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const mir::ExprId cond_id = block.AddExpr(*std::move(cond_or));
+  const mir::ExprId cond_id = block.exprs.Add(*std::move(cond_or));
 
   // HIR carries the iter as the next-value expression for the loop variable;
   // the loop semantic (this lowering) owns the actual write back.
   auto step_value_or =
-      lowerer.LowerExpr(enclosing_scope.GetExpr(loop.iter), proc_frame);
+      lowerer.LowerExpr(enclosing_scope.exprs.Get(loop.iter), proc_frame);
   if (!step_value_or) {
     return std::unexpected(std::move(step_value_or.error()));
   }
   const mir::TypeId step_type = (*step_value_or).type;
-  const mir::ExprId step_value_id = block.AddExpr(*std::move(step_value_or));
+  const mir::ExprId step_value_id = block.exprs.Add(*std::move(step_value_or));
   const mir::ExprId step_target_id =
-      block.AddExpr(mir::Expr{.data = loop_local, .type = genvar_type});
-  const mir::ExprId step_id = block.AddExpr(
+      block.exprs.Add(mir::Expr{.data = loop_local, .type = genvar_type});
+  const mir::ExprId step_id = block.exprs.Add(
       mir::Expr{
           .data =
               mir::AssignExpr{.target = step_target_id, .value = step_value_id},
@@ -638,8 +641,10 @@ auto LowerLoopGenerate(
   std::vector<mir::Expr> body_args;
   body_args.push_back(MakeForBodyInductionVarArg(loop_local_id, genvar_type));
 
-  const mir::BlockId loop_scope_id = block.AddChildScope(BuildGenerateArmBody(
-      lowerer.Module(), frame, gen_bindings, loop.scope, std::move(body_args)));
+  const mir::BlockId loop_scope_id =
+      block.child_scopes.Add(BuildGenerateArmBody(
+          lowerer.Module(), frame, gen_bindings, loop.scope,
+          std::move(body_args)));
 
   return mir::Stmt{
       .label = std::nullopt,
@@ -679,7 +684,8 @@ auto InstallGenerateOwnedChildScopes(ClassLowerer& lowerer, WalkFrame frame)
 
   for (std::size_t gen_idx = 0; gen_idx < hir_scope.generates.size();
        ++gen_idx) {
-    const auto& gen = hir_scope.generates[gen_idx];
+    const auto& gen = hir_scope.generates.Get(
+        hir::GenerateId{static_cast<std::uint32_t>(gen_idx)});
     GenerateBindings gen_bindings;
     gen_bindings.by_scope_id.resize(gen.child_scopes.size());
 
@@ -694,13 +700,13 @@ auto InstallGenerateOwnedChildScopes(ClassLowerer& lowerer, WalkFrame frame)
       if (!child_r) return std::unexpected(std::move(child_r.error()));
 
       const mir::ClassId child_id =
-          mir_class.AddNestedClass(*std::move(child_r));
+          mir_class.nested_classes.Add(*std::move(child_r));
       mir::TypeId var_type = MakeUniqueObjectPointer(
-          module, mir_class.GetNestedClass(child_id).name);
+          module, mir_class.nested_classes.Get(child_id).name);
       if (spec.is_repeated) {
         var_type = module.Unit().AddType(mir::VectorType{.element = var_type});
       }
-      const mir::MemberId var_id = mir_class.AddMember(
+      const mir::MemberId var_id = mir_class.members.Add(
           mir::MemberDecl{
               .name = companion_name,
               .source_name = spec.scope->source_name,
@@ -749,12 +755,12 @@ auto ClassLowerer::Run(
   }
 
   for (const auto& binding : entry_bindings) {
-    const mir::ParamId mir_id = mir_class.AddParam(binding.param);
+    const mir::ParamId mir_id = mir_class.params.Add(binding.param);
     lowerer.MapLoopVarAsStructuralParam(binding.source_loop_var, mir_id);
   }
 
   mir::Block ctor_block;
-  const mir::LocalId self_id = ctor_block.AddLocal(
+  const mir::LocalId self_id = ctor_block.vars.Add(
       mir::LocalDecl{.name = "self", .type = mir_class.self_pointer_type});
   ScopeChainNode outer_scope_link{};
   const WalkFrame scope_frame =
@@ -764,11 +770,11 @@ auto ClassLowerer::Run(
   const mir::TypeId void_type = module.Unit().AddType(mir::VoidType{});
   const mir::TypeId self_ptr_type = mir_class.self_pointer_type;
   const auto self_read = [&]() -> mir::ExprId {
-    return ctor_block.AddExpr(BuildSelfRefExpr(scope_frame, self_ptr_type));
+    return ctor_block.exprs.Add(BuildSelfRefExpr(scope_frame, self_ptr_type));
   };
   for (std::size_t i = 0; i < hir_scope.structural_vars.size(); ++i) {
     const hir::StructuralVarId hir_id{static_cast<std::uint32_t>(i)};
-    const auto& d = hir_scope.structural_vars[i];
+    const auto& d = hir_scope.structural_vars.Get(hir_id);
     const mir::TypeId mir_value_type = module.TranslateType(d.type);
 
     const auto& var_data = module.Unit().GetType(mir_value_type).data;
@@ -776,7 +782,7 @@ auto ClassLowerer::Run(
     // writes route through `Var<T>::Set` and subscribers fire.
     const mir::TypeId mir_field_type =
         MaybeWrapObservable(module, mir_value_type);
-    const mir::MemberId mir_id = mir_class.AddMember(
+    const mir::MemberId mir_id = mir_class.members.Add(
         mir::MemberDecl{.name = d.name, .type = mir_field_type});
     lowerer.MapStructuralVar(hir_id, mir_id);
 
@@ -796,14 +802,14 @@ auto ClassLowerer::Run(
       mir::ExprId value_id{};
       if (d.initializer.has_value()) {
         auto value_or =
-            lowerer.LowerExpr(hir_scope.GetExpr(*d.initializer), scope_frame);
+            lowerer.LowerExpr(hir_scope.exprs.Get(*d.initializer), scope_frame);
         if (!value_or) return std::unexpected(std::move(value_or.error()));
-        value_id = ctor_block.AddExpr(*std::move(value_or));
+        value_id = ctor_block.exprs.Add(*std::move(value_or));
       } else {
-        value_id = ctor_block.AddExpr(
+        value_id = ctor_block.exprs.Add(
             BuildDefaultValueExpr(module, scope_frame, mir_value_type));
       }
-      const mir::ExprId init_target = ctor_block.AddExpr(
+      const mir::ExprId init_target = ctor_block.exprs.Add(
           mir::MakeMemberAccessExpr(
               self_read(), mir::MemberRef{.hops = {.value = 0}, .var = mir_id},
               mir_field_type));
@@ -811,13 +817,13 @@ auto ClassLowerer::Run(
       // engine-side change-tracking sees the initial value
       // (`docs/decisions/value-type-concepts.md`). Plain fields use a regular
       // `AssignExpr`.
-      const mir::ExprId services_id = ctor_block.AddExpr(
+      const mir::ExprId services_id = ctor_block.exprs.Add(
           mir::MakeServicesCallExpr(
               self_read(), module.Unit().builtins.services));
       const mir::Expr init_expr = BuildObservableAssignExpr(
           module.Unit(), ctor_block, services_id, init_target, value_id,
           std::nullopt, mir_value_type, module.Unit().builtins.void_type);
-      const mir::ExprId assign_id = ctor_block.AddExpr(init_expr);
+      const mir::ExprId assign_id = ctor_block.exprs.Add(init_expr);
       ctor_block.AppendStmt(
           mir::Stmt{
               .label = std::nullopt, .data = mir::ExprStmt{.expr = assign_id}});
@@ -834,11 +840,11 @@ auto ClassLowerer::Run(
         !std::holds_alternative<mir::ObjectType>(var_data) &&
         !std::holds_alternative<mir::ExternalUnitObjectType>(var_data);
     if (is_signal) {
-      const mir::ExprId var_ref = ctor_block.AddExpr(
+      const mir::ExprId var_ref = ctor_block.exprs.Add(
           mir::MakeMemberAccessExpr(
               self_read(), mir::MemberRef{.hops = {.value = 0}, .var = mir_id},
               mir_field_type));
-      const mir::ExprId call = ctor_block.AddExpr(
+      const mir::ExprId call = ctor_block.exprs.Add(
           mir::Expr{
               .data =
                   mir::CallExpr{
@@ -871,13 +877,14 @@ auto ClassLowerer::Run(
         mir::MethodId{static_cast<std::uint32_t>(i)});
   }
   for (std::size_t i = 0; i < hir_scope.structural_subroutines.size(); ++i) {
-    const auto& src = hir_scope.structural_subroutines[i];
+    const auto& src = hir_scope.structural_subroutines.Get(
+        hir::StructuralSubroutineId{static_cast<std::uint32_t>(i)});
     ProcessLowerer subroutine_lowerer(
         module, lowerer, hir_scope.time_resolution, src.body, src.name,
         scope_frame);
     auto decl_or = subroutine_lowerer.Run(src);
     if (!decl_or) return std::unexpected(std::move(decl_or.error()));
-    const mir::MethodId added = mir_class.AddMethod(*std::move(decl_or));
+    const mir::MethodId added = mir_class.methods.Add(*std::move(decl_or));
     if (added.value != i) {
       throw InternalError(
           "ClassLowerer::Run: subroutine added out of mapped "
@@ -892,7 +899,7 @@ auto ClassLowerer::Run(
         scope_frame);
     auto proc_or = process_lowerer.Run(p);
     if (!proc_or) return std::unexpected(std::move(proc_or.error()));
-    mir_class.AddProcess(*std::move(proc_or));
+    mir_class.processes.Add(*std::move(proc_or));
   }
 
   for (const auto& ca : hir_scope.continuous_assigns) {
@@ -900,7 +907,7 @@ auto ClassLowerer::Run(
     auto proc_or =
         LowerContinuousAssign(lowerer, scope_frame, std::move(name), ca);
     if (!proc_or) return std::unexpected(std::move(proc_or.error()));
-    mir_class.AddProcess(*std::move(proc_or));
+    mir_class.processes.Add(*std::move(proc_or));
   }
 
   auto bindings_r = InstallGenerateOwnedChildScopes(lowerer, scope_frame);
@@ -908,7 +915,9 @@ auto ClassLowerer::Run(
 
   for (std::size_t i = 0; i < hir_scope.generates.size(); ++i) {
     auto stmt = LowerGenerateAsStmt(
-        lowerer, scope_frame, hir_scope.generates[i], bindings_r->at(i));
+        lowerer, scope_frame,
+        hir_scope.generates.Get(hir::GenerateId{static_cast<std::uint32_t>(i)}),
+        bindings_r->at(i));
     if (!stmt) return std::unexpected(std::move(stmt.error()));
     ctor_block.AppendStmt(*std::move(stmt));
   }
@@ -1021,7 +1030,7 @@ auto ClassLowerer::LowerExpr(const hir::Expr& expr, WalkFrame frame) const
   // the value (e.g. a continuous assign whose RHS reads a signal).
   if (mir::IsObservableCellType(module_->Unit().GetType(raw_or->type))) {
     const mir::ExprId cell_id =
-        frame.current_block->AddExpr(*std::move(raw_or));
+        frame.current_block->exprs.Add(*std::move(raw_or));
     return mir::MakeObservableGetCallExpr(cell_id, result_type);
   }
   return raw_or;

--- a/src/lyra/lowering/hir_to_mir/closure_builder.cpp
+++ b/src/lyra/lowering/hir_to_mir/closure_builder.cpp
@@ -25,9 +25,9 @@ ClosureBuilder::ClosureBuilder(
   const mir::TypeId self_pointer_type =
       enclosing.current_class->self_pointer_type;
   self_binding_ =
-      body_.AddLocal(mir::LocalDecl{.name = "self", .type = self_pointer_type});
+      body_.vars.Add(mir::LocalDecl{.name = "self", .type = self_pointer_type});
   const mir::ExprId outer_self_read =
-      outer_->AddExpr(BuildSelfRefExpr(enclosing, self_pointer_type));
+      outer_->exprs.Add(BuildSelfRefExpr(enclosing, self_pointer_type));
   captures_.push_back(
       mir::Capture{.value = outer_self_read, .binding = self_binding_});
   frame_ = enclosing.WithBlock(&body_)
@@ -40,21 +40,21 @@ ClosureBuilder::ClosureBuilder(
 auto ClosureBuilder::AddParam(std::string_view name, mir::TypeId type)
     -> mir::LocalId {
   const mir::LocalId binding =
-      body_.AddLocal(mir::LocalDecl{.name = std::string(name), .type = type});
+      body_.vars.Add(mir::LocalDecl{.name = std::string(name), .type = type});
   params_.push_back(mir::Parameter{.binding = binding});
   return binding;
 }
 
 auto ClosureBuilder::CaptureByValue(mir::ExprId outer_id, std::string_view name)
     -> mir::ExprId {
-  const mir::Expr& outer_expr = outer_->GetExpr(outer_id);
+  const mir::Expr& outer_expr = outer_->exprs.Get(outer_id);
   if (std::holds_alternative<mir::IntegerLiteral>(outer_expr.data)) {
-    return body_.AddExpr(outer_expr);
+    return body_.exprs.Add(outer_expr);
   }
-  const mir::LocalId binding = body_.AddLocal(
+  const mir::LocalId binding = body_.vars.Add(
       mir::LocalDecl{.name = std::string(name), .type = outer_expr.type});
   captures_.push_back(mir::Capture{.value = outer_id, .binding = binding});
-  return body_.AddExpr(
+  return body_.exprs.Add(
       mir::Expr{
           .data =
               mir::LocalRef{.hops = mir::BlockHops{.value = 0}, .var = binding},
@@ -74,7 +74,7 @@ auto ClosureBuilder::Finish(mir::TypeId result_type) -> mir::Expr {
 }
 
 auto ClosureBuilder::Build(mir::ExprId result) -> mir::Expr {
-  const mir::TypeId result_type = body_.GetExpr(result).type;
+  const mir::TypeId result_type = body_.exprs.Get(result).type;
   body_.AppendStmt(mir::ReturnStmt{.value = result});
   return Finish(result_type);
 }
@@ -91,7 +91,7 @@ auto ClosureBuilder::BuildVoid() -> mir::Expr {
 
 auto BuildClosureCallExpr(mir::Block& block, mir::Expr closure) -> mir::Expr {
   const mir::TypeId result_type = closure.type;
-  const mir::ExprId closure_id = block.AddExpr(std::move(closure));
+  const mir::ExprId closure_id = block.exprs.Add(std::move(closure));
   return mir::Expr{
       .data =
           mir::CallExpr{

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -27,7 +27,7 @@ auto LowerContinuousAssign(
     const ClassLowerer& lowerer, WalkFrame frame, std::string name,
     const hir::ContinuousAssign& src) -> diag::Result<mir::Process> {
   mir::Block process_block;
-  const mir::LocalId self_id = process_block.AddLocal(
+  const mir::LocalId self_id = process_block.vars.Add(
       mir::LocalDecl{
           .name = "self", .type = frame.current_class->self_pointer_type});
   mir::Block body_block;
@@ -37,33 +37,33 @@ auto LowerContinuousAssign(
 
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
 
-  auto rhs_or = lowerer.LowerExpr(hir_scope.GetExpr(src.rhs), body_frame);
+  auto rhs_or = lowerer.LowerExpr(hir_scope.exprs.Get(src.rhs), body_frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const mir::TypeId assign_type = (*rhs_or).type;
-  const mir::ExprId rhs_id = body_block.AddExpr(*std::move(rhs_or));
+  const mir::ExprId rhs_id = body_block.exprs.Add(*std::move(rhs_or));
 
-  auto lhs_or = lowerer.LowerLhsExpr(hir_scope.GetExpr(src.lhs), body_frame);
+  auto lhs_or = lowerer.LowerLhsExpr(hir_scope.exprs.Get(src.lhs), body_frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  const mir::ExprId lhs_id = body_block.AddExpr(*std::move(lhs_or));
+  const mir::ExprId lhs_id = body_block.exprs.Add(*std::move(lhs_or));
 
   // Build `self.Services()` in the body so an observable LHS routes through
   // `Var<T>::Set` (or `Mutate` for a selector chain). The body's `self` is
   // already bound at depth 0 via `WithSelfBinding(self_id, ...)` above.
   const mir::TypeId self_ptr_type = frame.current_class->self_pointer_type;
-  const mir::ExprId body_self_ref = body_block.AddExpr(
+  const mir::ExprId body_self_ref = body_block.exprs.Add(
       mir::MakeLocalRefExpr(
           mir::BlockHops{
               .value = body_frame.block_depth.value -
                        body_frame.self_decl_depth.value},
           self_id, self_ptr_type));
-  const mir::ExprId body_services_id = body_block.AddExpr(
+  const mir::ExprId body_services_id = body_block.exprs.Add(
       mir::MakeServicesCallExpr(
           body_self_ref, lowerer.Module().Unit().builtins.services));
 
   const mir::Expr assign_expr = BuildObservableAssignExpr(
       lowerer.Module().Unit(), body_block, body_services_id, lhs_id, rhs_id,
       std::nullopt, assign_type, lowerer.Module().Unit().builtins.void_type);
-  const mir::ExprId assign_id = body_block.AddExpr(assign_expr);
+  const mir::ExprId assign_id = body_block.exprs.Add(assign_expr);
   body_block.AppendStmt(
       mir::Stmt{
           .label = std::nullopt, .data = mir::ExprStmt{.expr = assign_id}});
@@ -72,7 +72,7 @@ auto LowerContinuousAssign(
       BuildSensitivityWaitStmt(lowerer, src.sensitivity_list));
 
   const mir::BlockId body_scope_id =
-      process_block.AddChildScope(std::move(body_block));
+      process_block.child_scopes.Add(std::move(body_block));
   process_block.AppendStmt(
       mir::Stmt{
           .label = std::nullopt,

--- a/src/lyra/lowering/hir_to_mir/copy_out_desugar.cpp
+++ b/src/lyra/lowering/hir_to_mir/copy_out_desugar.cpp
@@ -27,15 +27,14 @@ auto BuildOutputArgSlot(
   // typed lvalue so an observable destination's writeback routes through
   // `Var<T>::Set`. For the copy-in initializer the temp wants the current
   // value, so a separate `LowerExpr` lowering wraps the cell in `Get`.
-  auto target_or =
-      proc.LowerLhsExpr(hir_body.exprs.at(actual_hir.value), frame);
+  auto target_or = proc.LowerLhsExpr(hir_body.exprs.Get(actual_hir), frame);
   if (!target_or) return std::unexpected(std::move(target_or.error()));
   const mir::TypeId actual_type =
-      proc.Module().TranslateType(hir_body.exprs.at(actual_hir.value).type);
-  const mir::ExprId actual_id = wrapper.AddExpr(*std::move(target_or));
-  auto value_or = proc.LowerExpr(hir_body.exprs.at(actual_hir.value), frame);
+      proc.Module().TranslateType(hir_body.exprs.Get(actual_hir).type);
+  const mir::ExprId actual_id = wrapper.exprs.Add(*std::move(target_or));
+  auto value_or = proc.LowerExpr(hir_body.exprs.Get(actual_hir), frame);
   if (!value_or) return std::unexpected(std::move(value_or.error()));
-  const mir::ExprId init_id = wrapper.AddExpr(*std::move(value_or));
+  const mir::ExprId init_id = wrapper.exprs.Add(*std::move(value_or));
   const mir::LocalRef temp = wrapper.AppendLocal(
       mir::LocalDecl{.name = std::string{temp_name}, .type = actual_type},
       init_id);
@@ -50,13 +49,13 @@ auto BuildCopyOutBlock(
     std::optional<mir::ExprId> assign_target_id,
     const std::vector<OutputArgSlot>& slots) -> mir::Stmt {
   const mir::TypeId call_type = call_expr.type;
-  const mir::ExprId call_id = wrapper.AddExpr(std::move(call_expr));
+  const mir::ExprId call_id = wrapper.exprs.Add(std::move(call_expr));
   const mir::TypeId void_type = unit.builtins.void_type;
 
   if (assign_target_id.has_value()) {
     mir::ExprId value_id = call_id;
     if (call_type != result_type) {
-      value_id = wrapper.AddExpr(
+      value_id = wrapper.exprs.Add(
           mir::Expr{
               .data =
                   mir::ConversionExpr{
@@ -67,7 +66,7 @@ auto BuildCopyOutBlock(
     const mir::Expr assign_expr = BuildObservableAssignExpr(
         unit, wrapper, services_id, *assign_target_id, value_id, std::nullopt,
         result_type, void_type);
-    const mir::ExprId assign_id = wrapper.AddExpr(assign_expr);
+    const mir::ExprId assign_id = wrapper.exprs.Add(assign_expr);
     wrapper.AppendStmt(mir::ExprStmt{.expr = assign_id});
   } else if (call_suspends) {
     wrapper.AppendStmt(mir::AwaitStmt{.awaitable = call_id});
@@ -77,16 +76,16 @@ auto BuildCopyOutBlock(
 
   for (const OutputArgSlot& slot : slots) {
     const mir::ExprId temp_read =
-        wrapper.AddExpr(mir::Expr{.data = slot.temp, .type = slot.type});
+        wrapper.exprs.Add(mir::Expr{.data = slot.temp, .type = slot.type});
     const mir::Expr copy_out_expr = BuildObservableAssignExpr(
         unit, wrapper, services_id, slot.actual, temp_read, std::nullopt,
         slot.type, void_type);
-    const mir::ExprId copy_out = wrapper.AddExpr(copy_out_expr);
+    const mir::ExprId copy_out = wrapper.exprs.Add(copy_out_expr);
     wrapper.AppendStmt(mir::ExprStmt{.expr = copy_out});
   }
 
   const mir::BlockId scope_id =
-      parent_frame.current_block->AddChildScope(std::move(wrapper));
+      parent_frame.current_block->child_scopes.Add(std::move(wrapper));
   return mir::Stmt{
       .label = std::move(label), .data = mir::BlockStmt{.scope = scope_id}};
 }

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -73,7 +73,7 @@ auto BuildDefaultValueExpr(
           [&](const mir::StringType&) -> mir::Expr {
             // Software string literal -> `value::String("")` via the
             // constructor.
-            const mir::ExprId lit = block.AddExpr(
+            const mir::ExprId lit = block.exprs.Add(
                 mir::Expr{
                     .data = mir::StringLiteral{.value = std::string{}},
                     .type = type});
@@ -99,7 +99,7 @@ auto BuildDefaultValueExpr(
             std::vector<mir::ExprId> elements;
             elements.reserve(ua.size);
             for (std::uint64_t i = 0; i < ua.size; ++i) {
-              elements.push_back(block.AddExpr(
+              elements.push_back(block.exprs.Add(
                   BuildDefaultValueExpr(module, frame, ua.element_type)));
             }
             return BuildArrayConstructionCall(
@@ -113,7 +113,7 @@ auto BuildDefaultValueExpr(
           // `DynamicArray<T>(...)` ctor that stores the value and leaves
           // `data_` empty.
           [&](const mir::DynamicArrayType& da) -> mir::Expr {
-            const mir::ExprId element_default = block.AddExpr(
+            const mir::ExprId element_default = block.exprs.Add(
                 BuildDefaultValueExpr(module, frame, da.element_type));
             return mir::Expr{
                 .data =
@@ -126,13 +126,13 @@ auto BuildDefaultValueExpr(
           // chain as the dynamic array -- the element default seeds the
           // wrapper's shield slot while storage starts empty.
           [&](const mir::QueueType& q) -> mir::Expr {
-            const mir::ExprId element_default = block.AddExpr(
+            const mir::ExprId element_default = block.exprs.Add(
                 BuildDefaultValueExpr(module, frame, q.element_type));
             std::vector<mir::ExprId> args = {element_default};
             // LRM 7.10.5: a bounded queue `int q[$:N]` carries its max index N
             // as a second construction argument so the runtime can enforce it.
             if (q.max_bound.has_value()) {
-              args.push_back(block.AddExpr(
+              args.push_back(block.exprs.Add(
                   mir::MakeInt32Literal(
                       module.Unit().builtins.int32,
                       static_cast<std::int64_t>(*q.max_bound))));
@@ -148,7 +148,7 @@ auto BuildDefaultValueExpr(
           // default seeds the wrapper's shield slot (the source of nonexistent-
           // entry reads, LRM 7.8.6) while storage starts empty.
           [&](const mir::AssociativeArrayType& a) -> mir::Expr {
-            const mir::ExprId element_default = block.AddExpr(
+            const mir::ExprId element_default = block.exprs.Add(
                 BuildDefaultValueExpr(module, frame, a.element_type));
             return mir::Expr{
                 .data =
@@ -221,8 +221,8 @@ auto BuildArrayConstructionCall(
       },
       ty.data);
   const mir::ExprId element_default =
-      block.AddExpr(BuildDefaultValueExpr(module, frame, element_type));
-  const mir::ExprId list_id = block.AddExpr(
+      block.exprs.Add(BuildDefaultValueExpr(module, frame, element_type));
+  const mir::ExprId list_id = block.exprs.Add(
       mir::Expr{
           .data = mir::ArrayLiteralExpr{.elements = std::move(elements)},
           .type = array_type});
@@ -232,7 +232,7 @@ auto BuildArrayConstructionCall(
   // and the runtime trims an over-long initializer.
   if (const auto* q = std::get_if<mir::QueueType>(&ty.data);
       q != nullptr && q->max_bound.has_value()) {
-    args.push_back(block.AddExpr(
+    args.push_back(block.exprs.Add(
         mir::MakeInt32Literal(
             module.Unit().builtins.int32,
             static_cast<std::int64_t>(*q->max_bound))));
@@ -269,7 +269,7 @@ auto BuildAssociativeConstructionCall(
   std::vector<mir::ExprId> tuple_ids;
   tuple_ids.reserve(entries.size());
   for (const auto& [key_id, value_id] : entries) {
-    tuple_ids.push_back(block.AddExpr(
+    tuple_ids.push_back(block.exprs.Add(
         mir::Expr{
             .data = mir::TupleExpr{.components = {key_id, value_id}},
             .type = tuple_type}));
@@ -278,13 +278,13 @@ auto BuildAssociativeConstructionCall(
       mir::UnpackedArrayType{
           .element_type = tuple_type,
           .size = static_cast<std::uint64_t>(tuple_ids.size())});
-  const mir::ExprId entries_id = block.AddExpr(
+  const mir::ExprId entries_id = block.exprs.Add(
       mir::Expr{
           .data = mir::ArrayLiteralExpr{.elements = std::move(tuple_ids)},
           .type = entries_type});
 
   const mir::ExprId element_default =
-      block.AddExpr(BuildDefaultValueExpr(module, frame, element_type));
+      block.exprs.Add(BuildDefaultValueExpr(module, frame, element_type));
   std::vector<mir::ExprId> args;
   args.reserve(user_default.has_value() ? 3U : 2U);
   args.push_back(element_default);

--- a/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
@@ -45,7 +45,7 @@ auto FlattenUniqueCascade(
   out.bodies.push_back(root.then_stmt);
   std::optional<hir::StmtId> cur_else = root.else_stmt;
   while (cur_else.has_value()) {
-    const hir::Stmt& s = proc.stmts.at(cur_else->value);
+    const hir::Stmt& s = proc.stmts.Get(*cur_else);
     const auto* nested = std::get_if<hir::IfStmt>(&s.data);
     if (nested == nullptr || nested->check.has_value()) {
       out.tail_else = cur_else;
@@ -99,10 +99,10 @@ auto SnapshotPredicate(
     std::size_t index, mir::TypeId predicate_type,
     mir::ExprId predicate_expr_id) -> mir::LocalId {
   const std::string var_name = std::format("_lyra_unique_cond_{}", index);
-  const mir::LocalId snap_var = wrapper.AddLocal(
+  const mir::LocalId snap_var = wrapper.vars.Add(
       mir::LocalDecl{.name = var_name, .type = predicate_type});
   const mir::ExprId snap_default_init =
-      wrapper.AddExpr(BuildDefaultValueExpr(module, frame, predicate_type));
+      wrapper.exprs.Add(BuildDefaultValueExpr(module, frame, predicate_type));
   wrapper.AppendStmt(
       mir::Stmt{
           .label = std::nullopt,
@@ -112,13 +112,13 @@ auto SnapshotPredicate(
                       .hops = mir::BlockHops{.value = 0}, .var = snap_var},
               .init = snap_default_init}});
 
-  const mir::ExprId snap_target_id = wrapper.AddExpr(
+  const mir::ExprId snap_target_id = wrapper.exprs.Add(
       mir::Expr{
           .data =
               mir::LocalRef{
                   .hops = mir::BlockHops{.value = 0}, .var = snap_var},
           .type = predicate_type});
-  const mir::ExprId assign_id = wrapper.AddExpr(
+  const mir::ExprId assign_id = wrapper.exprs.Add(
       mir::Expr{
           .data =
               mir::AssignExpr{
@@ -141,7 +141,7 @@ auto BuildDiagnosticThenScope(
   std::vector<mir::RuntimePrintItem> items;
   items.emplace_back(mir::RuntimePrintLiteral{.text = verdict.prefix_text});
   if (verdict.include_count_value) {
-    const mir::ExprId count_read_id = block.AddExpr(
+    const mir::ExprId count_read_id = block.exprs.Add(
         mir::Expr{
             .data =
                 mir::LocalRef{
@@ -158,17 +158,17 @@ auto BuildDiagnosticThenScope(
   // The verdict text is fixed-format decimal, so no %t directive is possible
   // and the time-unit power is unread.
   const mir::ExprId items_array =
-      block.AddExpr(BuildPrintItemsArray(unit, block, items, 0));
+      block.exprs.Add(BuildPrintItemsArray(unit, block, items, 0));
 
   // `self` lives in the enclosing closure body; this then-scope sits one level
   // deeper, so the read climbs one hop -- matching the count_var read above.
-  const mir::ExprId self_read = block.AddExpr(
+  const mir::ExprId self_read = block.exprs.Add(
       mir::Expr{
           .data =
               mir::LocalRef{
                   .hops = mir::BlockHops{.value = 1}, .var = self_binding},
           .type = self_pointer_type});
-  const mir::ExprId services = block.AddExpr(
+  const mir::ExprId services = block.exprs.Add(
       mir::MakeServicesCallExpr(self_read, unit.builtins.services));
 
   const support::SystemSubroutineDesc* warning_desc =
@@ -179,7 +179,7 @@ auto BuildDiagnosticThenScope(
   }
 
   std::vector<mir::ExprId> args{services, items_array};
-  const mir::ExprId diag_call_id = block.AddExpr(
+  const mir::ExprId diag_call_id = block.exprs.Add(
       mir::Expr{
           .data =
               mir::CallExpr{
@@ -205,8 +205,8 @@ auto BuildUniqueCheckClosure(
   std::vector<mir::ExprId> inner_reads;
   inner_reads.reserve(snapshot_vars.size());
   for (std::size_t i = 0; i < snapshot_vars.size(); ++i) {
-    const mir::TypeId snap_type = wrapper.GetLocal(snapshot_vars[i]).type;
-    const mir::ExprId outer_read_id = wrapper.AddExpr(
+    const mir::TypeId snap_type = wrapper.vars.Get(snapshot_vars[i]).type;
+    const mir::ExprId outer_read_id = wrapper.exprs.Add(
         mir::Expr{
             .data =
                 mir::LocalRef{
@@ -217,11 +217,11 @@ auto BuildUniqueCheckClosure(
         outer_read_id, std::format("_lyra_unique_bind_{}", i)));
   }
 
-  const mir::LocalId count_var = body.AddLocal(
+  const mir::LocalId count_var = body.vars.Add(
       mir::LocalDecl{.name = "_lyra_unique_count", .type = int32_type});
 
   const mir::ExprId zero_init_id =
-      body.AddExpr(mir::MakeInt32Literal(int32_type, 0));
+      body.exprs.Add(mir::MakeInt32Literal(int32_type, 0));
   body.AppendStmt(
       mir::LocalDeclStmt{
           .target =
@@ -231,10 +231,10 @@ auto BuildUniqueCheckClosure(
 
   for (const mir::ExprId bit_read : inner_reads) {
     const mir::ExprId one_lit =
-        body.AddExpr(mir::MakeInt32Literal(int32_type, 1));
+        body.exprs.Add(mir::MakeInt32Literal(int32_type, 1));
     const mir::ExprId zero_lit =
-        body.AddExpr(mir::MakeInt32Literal(int32_type, 0));
-    const mir::ExprId cond_value = body.AddExpr(
+        body.exprs.Add(mir::MakeInt32Literal(int32_type, 0));
+    const mir::ExprId cond_value = body.exprs.Add(
         mir::Expr{
             .data =
                 mir::ConditionalExpr{
@@ -242,13 +242,13 @@ auto BuildUniqueCheckClosure(
                     .then_value = one_lit,
                     .else_value = zero_lit},
             .type = int32_type});
-    const mir::ExprId count_read = body.AddExpr(
+    const mir::ExprId count_read = body.exprs.Add(
         mir::Expr{
             .data =
                 mir::LocalRef{
                     .hops = mir::BlockHops{.value = 0}, .var = count_var},
             .type = int32_type});
-    const mir::ExprId added = body.AddExpr(
+    const mir::ExprId added = body.exprs.Add(
         mir::Expr{
             .data =
                 mir::BinaryExpr{
@@ -256,13 +256,13 @@ auto BuildUniqueCheckClosure(
                     .lhs = count_read,
                     .rhs = cond_value},
             .type = int32_type});
-    const mir::ExprId count_target = body.AddExpr(
+    const mir::ExprId count_target = body.exprs.Add(
         mir::Expr{
             .data =
                 mir::LocalRef{
                     .hops = mir::BlockHops{.value = 0}, .var = count_var},
             .type = int32_type});
-    const mir::ExprId assign = body.AddExpr(
+    const mir::ExprId assign = body.exprs.Add(
         mir::Expr{
             .data = mir::AssignExpr{.target = count_target, .value = added},
             .type = int32_type});
@@ -271,16 +271,16 @@ auto BuildUniqueCheckClosure(
 
   const CheckVerdict verdict = VerdictFor(check, snapshot_vars.size());
 
-  const mir::ExprId final_count_read = body.AddExpr(
+  const mir::ExprId final_count_read = body.exprs.Add(
       mir::Expr{
           .data =
               mir::LocalRef{
                   .hops = mir::BlockHops{.value = 0}, .var = count_var},
           .type = int32_type});
-  const mir::ExprId expected_lit = body.AddExpr(
+  const mir::ExprId expected_lit = body.exprs.Add(
       mir::MakeInt32Literal(
           int32_type, static_cast<std::int64_t>(verdict.expected)));
-  const mir::ExprId predicate_id = body.AddExpr(
+  const mir::ExprId predicate_id = body.exprs.Add(
       mir::Expr{
           .data =
               mir::BinaryExpr{
@@ -292,7 +292,8 @@ auto BuildUniqueCheckClosure(
   mir::Block diag_block = BuildDiagnosticThenScope(
       module.Unit(), self_ptr_type, self_binding, count_var, verdict);
 
-  const mir::BlockId diag_scope_id = body.AddChildScope(std::move(diag_block));
+  const mir::BlockId diag_scope_id =
+      body.child_scopes.Add(std::move(diag_block));
 
   body.AppendStmt(
       mir::IfStmt{
@@ -324,7 +325,7 @@ auto BuildDeferredCheckCascade(
   snapshot_vars.reserve(branches.size());
   for (std::size_t i = 0; i < branches.size(); ++i) {
     const mir::TypeId predicate_type =
-        wrapper.GetExpr(branches[i].predicate).type;
+        wrapper.exprs.Get(branches[i].predicate).type;
     snapshot_vars.push_back(SnapshotPredicate(
         module, wrapper_frame, wrapper, i, predicate_type,
         branches[i].predicate));
@@ -332,11 +333,11 @@ auto BuildDeferredCheckCascade(
 
   mir::Expr closure = BuildUniqueCheckClosure(
       module, wrapper_frame, wrapper, check, snapshot_vars);
-  const mir::ExprId closure_expr_id = wrapper.AddExpr(std::move(closure));
+  const mir::ExprId closure_expr_id = wrapper.exprs.Add(std::move(closure));
 
   const mir::DeferredCheckSiteId site_id =
       module.Unit().AllocateDeferredCheckSiteId();
-  const mir::ExprId submit_expr_id = wrapper.AddExpr(
+  const mir::ExprId submit_expr_id = wrapper.exprs.Add(
       mir::Expr{
           .data =
               mir::RuntimeCallExpr{
@@ -353,7 +354,7 @@ auto BuildDeferredCheckCascade(
   std::optional<mir::Block> tail = std::move(tail_else);
   for (std::size_t i = branches.size(); i-- > 1;) {
     mir::Block level_block;
-    const mir::ExprId cond_read = level_block.AddExpr(
+    const mir::ExprId cond_read = level_block.exprs.Add(
         mir::Expr{
             .data =
                 mir::LocalRef{
@@ -363,10 +364,10 @@ auto BuildDeferredCheckCascade(
             .type = int32_type});
 
     const mir::BlockId body_scope_id =
-        level_block.AddChildScope(std::move(branches[i].body));
+        level_block.child_scopes.Add(std::move(branches[i].body));
     std::optional<mir::BlockId> else_scope_id;
     if (tail.has_value()) {
-      else_scope_id = level_block.AddChildScope(std::move(*tail));
+      else_scope_id = level_block.child_scopes.Add(std::move(*tail));
     }
 
     level_block.AppendStmt(
@@ -380,7 +381,7 @@ auto BuildDeferredCheckCascade(
   }
 
   if (!branches.empty()) {
-    const mir::ExprId cond_read0 = wrapper.AddExpr(
+    const mir::ExprId cond_read0 = wrapper.exprs.Add(
         mir::Expr{
             .data =
                 mir::LocalRef{
@@ -389,10 +390,10 @@ auto BuildDeferredCheckCascade(
             .type = int32_type});
 
     const mir::BlockId body0_id =
-        wrapper.AddChildScope(std::move(branches[0].body));
+        wrapper.child_scopes.Add(std::move(branches[0].body));
     std::optional<mir::BlockId> else0_id;
     if (tail.has_value()) {
-      else0_id = wrapper.AddChildScope(std::move(*tail));
+      else0_id = wrapper.child_scopes.Add(std::move(*tail));
     }
 
     wrapper.AppendStmt(
@@ -405,7 +406,7 @@ auto BuildDeferredCheckCascade(
   }
 
   const mir::BlockId wrapper_scope_id =
-      frame.current_block->AddChildScope(std::move(wrapper));
+      frame.current_block->child_scopes.Add(std::move(wrapper));
 
   return mir::Stmt{
       .label = std::move(outer_label),
@@ -427,9 +428,9 @@ auto LowerUniqueIfStmt(
   predicates.reserve(cascade.conditions.size());
   for (const hir::ExprId hir_cond : cascade.conditions) {
     auto cond_or =
-        process.LowerExpr(hir_proc.exprs.at(hir_cond.value), wrapper_frame);
+        process.LowerExpr(hir_proc.exprs.Get(hir_cond), wrapper_frame);
     if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-    predicates.push_back(wrapper.AddExpr(*std::move(cond_or)));
+    predicates.push_back(wrapper.exprs.Add(*std::move(cond_or)));
   }
 
   // Lower each body into its own child scope. Cascade level i sits i scopes

--- a/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
@@ -73,9 +73,9 @@ auto LowerHirConcatExprProc(
   std::vector<mir::ExprId> operand_ids;
   operand_ids.reserve(c.operands.size());
   for (const auto& id : c.operands) {
-    auto lowered = process.LowerExpr(hir_process.exprs.at(id.value), frame);
+    auto lowered = process.LowerExpr(hir_process.exprs.Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    operand_ids.push_back(block.AddExpr(*std::move(lowered)));
+    operand_ids.push_back(block.exprs.Add(*std::move(lowered)));
   }
   return mir::Expr{
       .data = mir::ConcatExpr{.operands = std::move(operand_ids)},
@@ -87,13 +87,12 @@ auto LowerHirReplicationExprProc(
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
-  auto count_or = process.LowerExpr(hir_process.exprs.at(r.count.value), frame);
+  auto count_or = process.LowerExpr(hir_process.exprs.Get(r.count), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
-  const mir::ExprId count_id = block.AddExpr(*std::move(count_or));
-  auto concat_or =
-      process.LowerExpr(hir_process.exprs.at(r.concat.value), frame);
+  const mir::ExprId count_id = block.exprs.Add(*std::move(count_or));
+  auto concat_or = process.LowerExpr(hir_process.exprs.Get(r.concat), frame);
   if (!concat_or) return std::unexpected(std::move(concat_or.error()));
-  const mir::ExprId concat_id = block.AddExpr(*std::move(concat_or));
+  const mir::ExprId concat_id = block.exprs.Add(*std::move(concat_or));
   return mir::Expr{
       .data = mir::ReplicationExpr{.count = count_id, .concat = concat_id},
       .type = result_type};
@@ -113,9 +112,9 @@ auto LowerHirAssignmentPatternExprProc(
   std::vector<mir::ExprId> element_ids;
   element_ids.reserve(a.elements.size());
   for (const auto& id : a.elements) {
-    auto lowered = process.LowerExpr(hir_process.exprs.at(id.value), frame);
+    auto lowered = process.LowerExpr(hir_process.exprs.Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    element_ids.push_back(block.AddExpr(*std::move(lowered)));
+    element_ids.push_back(block.exprs.Add(*std::move(lowered)));
   }
   if (IsArrayContainerType(process.Module().Unit().GetType(result_type))) {
     return BuildArrayConstructionCall(
@@ -135,23 +134,23 @@ auto LowerHirAssignmentPatternReplicationExprProc(
   std::vector<mir::ExprId> item_ids;
   item_ids.reserve(a.items.size());
   for (const auto& id : a.items) {
-    auto lowered = process.LowerExpr(hir_process.exprs.at(id.value), frame);
+    auto lowered = process.LowerExpr(hir_process.exprs.Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    item_ids.push_back(block.AddExpr(*std::move(lowered)));
+    item_ids.push_back(block.exprs.Add(*std::move(lowered)));
   }
   if (IsArrayContainerType(process.Module().Unit().GetType(result_type))) {
     const std::uint64_t count =
-        ExtractHirLiteralUint64(hir_process.exprs.at(a.count.value));
+        ExtractHirLiteralUint64(hir_process.exprs.Get(a.count));
     return BuildArrayReplicationFlatList(
         process.Module(), frame, item_ids, count, result_type);
   }
-  const mir::ExprId inner_concat_id = block.AddExpr(
+  const mir::ExprId inner_concat_id = block.exprs.Add(
       mir::Expr{
           .data = mir::ConcatExpr{.operands = std::move(item_ids)},
           .type = result_type});
-  auto count_or = process.LowerExpr(hir_process.exprs.at(a.count.value), frame);
+  auto count_or = process.LowerExpr(hir_process.exprs.Get(a.count), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
-  const mir::ExprId count_id = block.AddExpr(*std::move(count_or));
+  const mir::ExprId count_id = block.exprs.Add(*std::move(count_or));
   return mir::Expr{
       .data =
           mir::ReplicationExpr{
@@ -172,9 +171,9 @@ auto LowerHirDynamicArrayNewExprProc(
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
-  auto size_or = process.LowerExpr(hir_process.exprs.at(n.size.value), frame);
+  auto size_or = process.LowerExpr(hir_process.exprs.Get(n.size), frame);
   if (!size_or) return std::unexpected(std::move(size_or.error()));
-  const mir::ExprId size_id = block.AddExpr(*std::move(size_or));
+  const mir::ExprId size_id = block.exprs.Add(*std::move(size_or));
 
   const auto& result_ty = process.Module().Unit().GetType(result_type);
   const auto* da = std::get_if<mir::DynamicArrayType>(&result_ty.data);
@@ -182,7 +181,7 @@ auto LowerHirDynamicArrayNewExprProc(
     throw InternalError(
         "LowerHirDynamicArrayNewExprProc: result type is not DynamicArrayType");
   }
-  const mir::ExprId prototype_id = block.AddExpr(
+  const mir::ExprId prototype_id = block.exprs.Add(
       BuildDefaultValueExpr(process.Module(), frame, da->element_type));
 
   std::vector<mir::ExprId> args;
@@ -191,9 +190,9 @@ auto LowerHirDynamicArrayNewExprProc(
   args.push_back(prototype_id);
   if (n.initializer.has_value()) {
     auto init_or =
-        process.LowerExpr(hir_process.exprs.at(n.initializer->value), frame);
+        process.LowerExpr(hir_process.exprs.Get(*n.initializer), frame);
     if (!init_or) return std::unexpected(std::move(init_or.error()));
-    args.push_back(block.AddExpr(*std::move(init_or)));
+    args.push_back(block.exprs.Add(*std::move(init_or)));
   }
   return mir::Expr{
       .data =
@@ -215,22 +214,21 @@ auto LowerHirAssociativeAssignmentPatternExprProc(
   std::vector<std::pair<mir::ExprId, mir::ExprId>> entries;
   entries.reserve(a.entries.size());
   for (const auto& entry : a.entries) {
-    auto key_or =
-        process.LowerExpr(hir_process.exprs.at(entry.key.value), frame);
+    auto key_or = process.LowerExpr(hir_process.exprs.Get(entry.key), frame);
     if (!key_or) return std::unexpected(std::move(key_or.error()));
-    const mir::ExprId key_id = block.AddExpr(*std::move(key_or));
+    const mir::ExprId key_id = block.exprs.Add(*std::move(key_or));
     auto value_or =
-        process.LowerExpr(hir_process.exprs.at(entry.value.value), frame);
+        process.LowerExpr(hir_process.exprs.Get(entry.value), frame);
     if (!value_or) return std::unexpected(std::move(value_or.error()));
-    const mir::ExprId value_id = block.AddExpr(*std::move(value_or));
+    const mir::ExprId value_id = block.exprs.Add(*std::move(value_or));
     entries.emplace_back(key_id, value_id);
   }
   std::optional<mir::ExprId> user_default;
   if (a.default_value.has_value()) {
     auto default_or =
-        process.LowerExpr(hir_process.exprs.at(a.default_value->value), frame);
+        process.LowerExpr(hir_process.exprs.Get(*a.default_value), frame);
     if (!default_or) return std::unexpected(std::move(default_or.error()));
-    user_default = block.AddExpr(*std::move(default_or));
+    user_default = block.exprs.Add(*std::move(default_or));
   }
   return BuildAssociativeConstructionCall(
       process.Module(), frame, result_type, std::move(entries), user_default);
@@ -244,9 +242,9 @@ auto LowerHirConcatExprStructural(
   std::vector<mir::ExprId> operand_ids;
   operand_ids.reserve(c.operands.size());
   for (const auto& id : c.operands) {
-    auto lowered = lowerer.LowerExpr(hir_scope.GetExpr(id), frame);
+    auto lowered = lowerer.LowerExpr(hir_scope.exprs.Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    operand_ids.push_back(block.AddExpr(*std::move(lowered)));
+    operand_ids.push_back(block.exprs.Add(*std::move(lowered)));
   }
   return mir::Expr{
       .data = mir::ConcatExpr{.operands = std::move(operand_ids)},
@@ -262,9 +260,9 @@ auto LowerHirAssignmentPatternExprStructural(
   std::vector<mir::ExprId> element_ids;
   element_ids.reserve(a.elements.size());
   for (const auto& id : a.elements) {
-    auto lowered = lowerer.LowerExpr(hir_scope.GetExpr(id), frame);
+    auto lowered = lowerer.LowerExpr(hir_scope.exprs.Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    element_ids.push_back(block.AddExpr(*std::move(lowered)));
+    element_ids.push_back(block.exprs.Add(*std::move(lowered)));
   }
   if (IsArrayContainerType(lowerer.Module().Unit().GetType(result_type))) {
     return BuildArrayConstructionCall(
@@ -284,23 +282,23 @@ auto LowerHirAssignmentPatternReplicationExprStructural(
   std::vector<mir::ExprId> item_ids;
   item_ids.reserve(a.items.size());
   for (const auto& id : a.items) {
-    auto lowered = lowerer.LowerExpr(hir_scope.GetExpr(id), frame);
+    auto lowered = lowerer.LowerExpr(hir_scope.exprs.Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    item_ids.push_back(block.AddExpr(*std::move(lowered)));
+    item_ids.push_back(block.exprs.Add(*std::move(lowered)));
   }
   if (IsArrayContainerType(lowerer.Module().Unit().GetType(result_type))) {
     const std::uint64_t count =
-        ExtractHirLiteralUint64(hir_scope.GetExpr(a.count));
+        ExtractHirLiteralUint64(hir_scope.exprs.Get(a.count));
     return BuildArrayReplicationFlatList(
         lowerer.Module(), frame, item_ids, count, result_type);
   }
-  const mir::ExprId inner_concat_id = block.AddExpr(
+  const mir::ExprId inner_concat_id = block.exprs.Add(
       mir::Expr{
           .data = mir::ConcatExpr{.operands = std::move(item_ids)},
           .type = result_type});
-  auto count_or = lowerer.LowerExpr(hir_scope.GetExpr(a.count), frame);
+  auto count_or = lowerer.LowerExpr(hir_scope.exprs.Get(a.count), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
-  const mir::ExprId count_id = block.AddExpr(*std::move(count_or));
+  const mir::ExprId count_id = block.exprs.Add(*std::move(count_or));
   return mir::Expr{
       .data =
           mir::ReplicationExpr{
@@ -319,20 +317,20 @@ auto LowerHirAssociativeAssignmentPatternExprStructural(
   std::vector<std::pair<mir::ExprId, mir::ExprId>> entries;
   entries.reserve(a.entries.size());
   for (const auto& entry : a.entries) {
-    auto key_or = lowerer.LowerExpr(hir_scope.GetExpr(entry.key), frame);
+    auto key_or = lowerer.LowerExpr(hir_scope.exprs.Get(entry.key), frame);
     if (!key_or) return std::unexpected(std::move(key_or.error()));
-    const mir::ExprId key_id = block.AddExpr(*std::move(key_or));
-    auto value_or = lowerer.LowerExpr(hir_scope.GetExpr(entry.value), frame);
+    const mir::ExprId key_id = block.exprs.Add(*std::move(key_or));
+    auto value_or = lowerer.LowerExpr(hir_scope.exprs.Get(entry.value), frame);
     if (!value_or) return std::unexpected(std::move(value_or.error()));
-    const mir::ExprId value_id = block.AddExpr(*std::move(value_or));
+    const mir::ExprId value_id = block.exprs.Add(*std::move(value_or));
     entries.emplace_back(key_id, value_id);
   }
   std::optional<mir::ExprId> user_default;
   if (a.default_value.has_value()) {
     auto default_or =
-        lowerer.LowerExpr(hir_scope.GetExpr(*a.default_value), frame);
+        lowerer.LowerExpr(hir_scope.exprs.Get(*a.default_value), frame);
     if (!default_or) return std::unexpected(std::move(default_or.error()));
-    user_default = block.AddExpr(*std::move(default_or));
+    user_default = block.exprs.Add(*std::move(default_or));
   }
   return BuildAssociativeConstructionCall(
       lowerer.Module(), frame, result_type, std::move(entries), user_default);

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -42,7 +42,7 @@ namespace {
 // target; procedural-local NBA is a known gap.
 auto IsExprRootedAtStructuralVar(const mir::Block& block, mir::ExprId expr_id)
     -> bool {
-  const auto& expr = block.GetExpr(expr_id);
+  const auto& expr = block.exprs.Get(expr_id);
   return std::visit(
       Overloaded{
           [](const mir::MemberRef&) { return true; },
@@ -77,7 +77,7 @@ auto CloneLhsExprForNbaBody(
     mir::ExprId outer_id) -> mir::ExprId {
   mir::Block& body = closure.Body();
   const mir::LocalId body_self_id = closure.SelfBinding();
-  const auto& outer_expr = outer_block.GetExpr(outer_id);
+  const auto& outer_expr = outer_block.exprs.Get(outer_id);
   return std::visit(
       Overloaded{
           [&](const mir::CallExpr& c) -> mir::ExprId {
@@ -97,7 +97,7 @@ auto CloneLhsExprForNbaBody(
                   c.arguments[i],
                   std::format("_lyra_nba_arg{}", snapshot_counter++)));
             }
-            return body.AddExpr(
+            return body.exprs.Add(
                 mir::Expr{
                     .data =
                         mir::CallExpr{
@@ -113,24 +113,24 @@ auto CloneLhsExprForNbaBody(
                   closure, outer_block, self_ptr_type, snapshot_counter,
                   op_id));
             }
-            return body.AddExpr(
+            return body.exprs.Add(
                 mir::Expr{
                     .data =
                         mir::ConcatExpr{.operands = std::move(body_operands)},
                     .type = outer_expr.type});
           },
           [&](const mir::MemberRef&) -> mir::ExprId {
-            return body.AddExpr(outer_expr);
+            return body.exprs.Add(outer_expr);
           },
           [&](const mir::MemberAccessExpr& m) -> mir::ExprId {
-            const mir::ExprId body_receiver = body.AddExpr(
+            const mir::ExprId body_receiver = body.exprs.Add(
                 mir::Expr{
                     .data =
                         mir::LocalRef{
                             .hops = mir::BlockHops{.value = 0},
                             .var = body_self_id},
                     .type = self_ptr_type});
-            return body.AddExpr(
+            return body.exprs.Add(
                 mir::Expr{
                     .data =
                         mir::MemberAccessExpr{
@@ -138,7 +138,7 @@ auto CloneLhsExprForNbaBody(
                     .type = outer_expr.type});
           },
           [&](const mir::LocalRef&) -> mir::ExprId {
-            return body.AddExpr(outer_expr);
+            return body.exprs.Add(outer_expr);
           },
           [&](const auto&) -> mir::ExprId {
             throw InternalError(
@@ -187,17 +187,17 @@ auto BuildDeferredAssignClosure(
         op, std::format("_lyra_nba_arg{}", snapshot_counter++)));
   }
 
-  const mir::ExprId body_self_ref = body.AddExpr(
+  const mir::ExprId body_self_ref = body.exprs.Add(
       mir::Expr{
           .data =
               mir::LocalRef{
                   .hops = mir::BlockHops{.value = 0},
                   .var = closure.SelfBinding()},
           .type = self_ptr_type});
-  const mir::ExprId body_services = body.AddExpr(
+  const mir::ExprId body_services = body.exprs.Add(
       mir::MakeServicesCallExpr(
           body_self_ref, module.Unit().builtins.services));
-  const mir::ExprId effect_id = body.AddExpr(effect_fn(
+  const mir::ExprId effect_id = body.exprs.Add(effect_fn(
       body, body_target, std::span<const mir::ExprId>(body_operands),
       body_services));
   body.AppendStmt(
@@ -219,7 +219,7 @@ auto ApplyAssignEffect(
   auto& block = *frame.current_block;
   if (kind == hir::AssignKind::kBlocking) {
     const mir::ExprId services_id =
-        block.AddExpr(BuildServicesCallExpr(process, frame));
+        block.exprs.Add(BuildServicesCallExpr(process, frame));
     return effect_fn(block, target_in_outer, operands_in_outer, services_id);
   }
   if (!IsExprRootedAtStructuralVar(block, target_in_outer)) {
@@ -230,7 +230,7 @@ auto ApplyAssignEffect(
   }
   mir::Expr closure = BuildDeferredAssignClosure(
       process.Module(), frame, target_in_outer, operands_in_outer, effect_fn);
-  const mir::ExprId closure_id = block.AddExpr(std::move(closure));
+  const mir::ExprId closure_id = block.exprs.Add(std::move(closure));
   return mir::Expr{
       .data =
           mir::RuntimeCallExpr{
@@ -247,13 +247,13 @@ auto LowerObservableAssign(
   const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
 
-  auto rhs_or = process.LowerExpr(hir_process.exprs.at(a.rhs.value), frame);
+  auto rhs_or = process.LowerExpr(hir_process.exprs.Get(a.rhs), frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  const mir::ExprId rhs_id = block.AddExpr(*std::move(rhs_or));
+  const mir::ExprId rhs_id = block.exprs.Add(*std::move(rhs_or));
   auto lhs_or = process.LowerLhsExpr(
-      hir_process.exprs.at(a.lhs.value), frame.WithLvalueTarget(true));
+      hir_process.exprs.Get(a.lhs), frame.WithLvalueTarget(true));
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  const mir::ExprId lhs_id = block.AddExpr(*std::move(lhs_or));
+  const mir::ExprId lhs_id = block.exprs.Add(*std::move(lhs_or));
 
   const std::optional<mir::BinaryOp> compound_op =
       a.compound_op.has_value() ? std::optional{LowerBinaryOp(*a.compound_op)}
@@ -283,18 +283,18 @@ auto LowerStringElementAssign(
   const auto& unit = process.Module().Unit();
   auto& block = *frame.current_block;
 
-  const auto& base_hir = hir_process.exprs.at(sel.base_value.value);
+  const auto& base_hir = hir_process.exprs.Get(sel.base_value);
   auto cell_or = process.LowerLhsExpr(base_hir, frame.WithLvalueTarget(true));
   if (!cell_or) return std::unexpected(std::move(cell_or.error()));
-  const mir::ExprId cell_id = block.AddExpr(*std::move(cell_or));
+  const mir::ExprId cell_id = block.exprs.Add(*std::move(cell_or));
 
-  auto idx_or = process.LowerExpr(hir_process.exprs.at(sel.index.value), frame);
+  auto idx_or = process.LowerExpr(hir_process.exprs.Get(sel.index), frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
-  const mir::ExprId idx_id = block.AddExpr(*std::move(idx_or));
+  const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
 
-  auto rhs_or = process.LowerExpr(hir_process.exprs.at(a.rhs.value), frame);
+  auto rhs_or = process.LowerExpr(hir_process.exprs.Get(a.rhs), frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  mir::ExprId value_id = block.AddExpr(*std::move(rhs_or));
+  mir::ExprId value_id = block.exprs.Add(*std::move(rhs_or));
 
   // A compound write only ever reaches here blocking (compound + NBA is not a
   // legal SV form, rejected upstream), so the read-modify lands in the active
@@ -302,10 +302,10 @@ auto LowerStringElementAssign(
   if (a.compound_op.has_value()) {
     auto base_read_or = process.LowerExpr(base_hir, frame);
     if (!base_read_or) return std::unexpected(std::move(base_read_or.error()));
-    const mir::ExprId base_read_id = block.AddExpr(*std::move(base_read_or));
-    const mir::ExprId cur_id = block.AddExpr(BuildStringMethodCallExpr(
+    const mir::ExprId base_read_id = block.exprs.Add(*std::move(base_read_or));
+    const mir::ExprId cur_id = block.exprs.Add(BuildStringMethodCallExpr(
         support::BuiltinFn::kGetc, {base_read_id, idx_id}, result_type));
-    value_id = block.AddExpr(
+    value_id = block.exprs.Add(
         mir::Expr{
             .data =
                 mir::BinaryExpr{
@@ -323,7 +323,7 @@ auto LowerStringElementAssign(
           mir::ExprId services) -> mir::Expr {
         mir::ExprId recv = target;
         const mir::ExprId root = FindLhsRootId(blk, target);
-        if (mir::IsObservableCellType(unit.GetType(blk.GetExpr(root).type))) {
+        if (mir::IsObservableCellType(unit.GetType(blk.exprs.Get(root).type))) {
           recv = RewriteLhsRootWithMutate(unit, blk, target, services);
         }
         return BuildStringMethodCallExpr(
@@ -347,10 +347,10 @@ auto LowerHirAssignExprProc(
   // it realizes as putc (LRM 6.16.2); every other target is an observable cell
   // or a local. Axis B (blocking vs deferred) is handled uniformly inside each.
   const auto& hir_process = process.HirBody();
-  const hir::Expr& hir_lhs = hir_process.exprs.at(a.lhs.value);
+  const hir::Expr& hir_lhs = hir_process.exprs.Get(a.lhs);
   if (const auto* sel = std::get_if<hir::ElementSelectExpr>(&hir_lhs.data)) {
     const hir::Type& base_ty = process.Module().Hir().GetType(
-        hir_process.exprs.at(sel->base_value.value).type);
+        hir_process.exprs.Get(sel->base_value).type);
     if (base_ty.Kind() == hir::TypeKind::kString) {
       return LowerStringElementAssign(
           process, frame, a, *sel, span, result_type);

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -53,10 +53,10 @@ auto MaybeWrapObservableLhsWithMutate(
     mir::ExprId lhs_id) -> mir::ExprId {
   const mir::ExprId root_id = FindLhsRootId(block, lhs_id);
   const bool root_is_cell = mir::IsObservableCellType(
-      process.Module().Unit().GetType(block.GetExpr(root_id).type));
+      process.Module().Unit().GetType(block.exprs.Get(root_id).type));
   if (!root_is_cell) return lhs_id;
   const mir::ExprId services_id =
-      block.AddExpr(BuildServicesCallExpr(process, frame));
+      block.exprs.Add(BuildServicesCallExpr(process, frame));
   return RewriteLhsRootWithMutate(
       process.Module().Unit(), block, lhs_id, services_id);
 }
@@ -78,10 +78,10 @@ auto LowerAssociativeTraversal(
   }
   const auto& module = process.Module();
   const auto& hir_proc = process.HirBody();
-  const auto recv_hir = c.arguments[0]->value;
-  const auto idx_hir = c.arguments[1]->value;
+  const auto recv_hir = *c.arguments[0];
+  const auto idx_hir = *c.arguments[1];
   const mir::TypeId key_type =
-      module.TranslateType(hir_proc.exprs.at(idx_hir).type);
+      module.TranslateType(hir_proc.exprs.Get(idx_hir).type);
   const mir::TypeId void_t = module.Unit().builtins.void_type;
 
   ClosureBuilder closure(process.Module().Unit(), frame);
@@ -90,20 +90,20 @@ auto LowerAssociativeTraversal(
 
   // probe = idx -- snapshot the current index value into a plain local.
   auto idx_read_or =
-      process.LowerExpr(hir_proc.exprs.at(idx_hir), closure_frame);
+      process.LowerExpr(hir_proc.exprs.Get(idx_hir), closure_frame);
   if (!idx_read_or) return std::unexpected(std::move(idx_read_or.error()));
   const mir::LocalRef probe_ref = body.AppendLocal(
       mir::LocalDecl{.name = "_lyra_trav_probe", .type = key_type},
-      body.AddExpr(*std::move(idx_read_or)));
+      body.exprs.Add(*std::move(idx_read_or)));
 
   // found = (map).<kind>(probe) -- pure query: mutates probe, yields 1/0.
   auto map_read_or =
-      process.LowerExpr(hir_proc.exprs.at(recv_hir), closure_frame);
+      process.LowerExpr(hir_proc.exprs.Get(recv_hir), closure_frame);
   if (!map_read_or) return std::unexpected(std::move(map_read_or.error()));
-  const mir::ExprId map_read_id = body.AddExpr(*std::move(map_read_or));
+  const mir::ExprId map_read_id = body.exprs.Add(*std::move(map_read_or));
   const mir::ExprId probe_read_id =
-      body.AddExpr(mir::Expr{.data = probe_ref, .type = key_type});
-  const mir::ExprId query_id = body.AddExpr(
+      body.exprs.Add(mir::Expr{.data = probe_ref, .type = key_type});
+  const mir::ExprId query_id = body.exprs.Add(
       mir::Expr{
           .data =
               mir::CallExpr{
@@ -116,20 +116,20 @@ auto LowerAssociativeTraversal(
 
   // idx = probe -- observable write-back fires the LRM 4.3 update event.
   auto idx_lhs_or =
-      process.LowerLhsExpr(hir_proc.exprs.at(idx_hir), closure_frame);
+      process.LowerLhsExpr(hir_proc.exprs.Get(idx_hir), closure_frame);
   if (!idx_lhs_or) return std::unexpected(std::move(idx_lhs_or.error()));
-  const mir::ExprId idx_lhs_id = body.AddExpr(*std::move(idx_lhs_or));
+  const mir::ExprId idx_lhs_id = body.exprs.Add(*std::move(idx_lhs_or));
   const mir::ExprId probe_writeback_id =
-      body.AddExpr(mir::Expr{.data = probe_ref, .type = key_type});
+      body.exprs.Add(mir::Expr{.data = probe_ref, .type = key_type});
   const mir::ExprId services_id =
-      body.AddExpr(BuildServicesCallExpr(process, closure_frame));
+      body.exprs.Add(BuildServicesCallExpr(process, closure_frame));
   const mir::Expr assign_expr = BuildObservableAssignExpr(
       module.Unit(), body, services_id, idx_lhs_id, probe_writeback_id,
       std::nullopt, key_type, void_t);
-  body.AppendStmt(mir::ExprStmt{.expr = body.AddExpr(assign_expr)});
+  body.AppendStmt(mir::ExprStmt{.expr = body.exprs.Add(assign_expr)});
 
   const mir::ExprId found_id =
-      body.AddExpr(mir::Expr{.data = found_ref, .type = result_type});
+      body.exprs.Add(mir::Expr{.data = found_ref, .type = result_type});
   return BuildClosureCallExpr(*frame.current_block, closure.Build(found_id));
 }
 
@@ -207,7 +207,7 @@ auto BuildArrayMethodClosure(
   const mir::TypeId index_type = module.Unit().builtins.int32;
   const std::string iterator_name =
       with_clause != nullptr
-          ? hir_process.procedural_vars.at(with_clause->iterator.value).name
+          ? hir_process.procedural_vars.Get(with_clause->iterator).name
           : std::string{"item"};
 
   ClosureBuilder closure(process.Module().Unit(), frame);
@@ -226,12 +226,12 @@ auto BuildArrayMethodClosure(
     // with-clause-specific role, so the body lowers through a frame carrying
     // that binding rather than the builder knowing about it.
     auto body_expr_or = process.LowerExpr(
-        hir_process.exprs.at(with_clause->expr.value),
+        hir_process.exprs.Get(with_clause->expr),
         closure.Frame().WithIndexBinding(index_binding));
     if (!body_expr_or) return std::unexpected(std::move(body_expr_or.error()));
-    body_return_value = body.AddExpr(*std::move(body_expr_or));
+    body_return_value = body.exprs.Add(*std::move(body_expr_or));
   } else {
-    body_return_value = body.AddExpr(
+    body_return_value = body.exprs.Add(
         mir::Expr{
             .data =
                 mir::LocalRef{
@@ -329,7 +329,7 @@ auto LowerStructuralSubroutineCall(
   }
   std::vector<mir::ExprId> args;
   args.reserve(c.arguments.size() + 1);
-  args.push_back(block.AddExpr(
+  args.push_back(block.exprs.Add(
       BuildSelfRefExpr(frame, frame.current_class->self_pointer_type)));
   for (std::size_t i = 0; i < c.arguments.size(); ++i) {
     if (!c.arguments[i].has_value()) {
@@ -347,10 +347,10 @@ auto LowerStructuralSubroutineCall(
          decl.params[i].direction == hir::ParamDirection::kConstRef);
     mir::ExprId actual_id{};
     if (is_ref_formal) {
-      auto arg_or = process.LowerLhsExpr(
-          hir_process.exprs.at(c.arguments[i]->value), frame);
+      auto arg_or =
+          process.LowerLhsExpr(hir_process.exprs.Get(*c.arguments[i]), frame);
       if (!arg_or) return std::unexpected(std::move(arg_or.error()));
-      actual_id = block.AddExpr(*std::move(arg_or));
+      actual_id = block.exprs.Add(*std::move(arg_or));
       const mir::ExprId root_id = FindLhsRootId(block, actual_id);
       if (root_id != actual_id) {
         actual_id =
@@ -358,12 +358,12 @@ auto LowerStructuralSubroutineCall(
       }
       args.push_back(BuildReferenceArg(
           process.Module().Unit(), block, actual_id,
-          block.GetExpr(actual_id).type));
+          block.exprs.Get(actual_id).type));
     } else {
       auto arg_or =
-          process.LowerExpr(hir_process.exprs.at(c.arguments[i]->value), frame);
+          process.LowerExpr(hir_process.exprs.Get(*c.arguments[i]), frame);
       if (!arg_or) return std::unexpected(std::move(arg_or.error()));
-      args.push_back(block.AddExpr(*std::move(arg_or)));
+      args.push_back(block.exprs.Add(*std::move(arg_or)));
     }
   }
   return mir::Expr{
@@ -404,7 +404,7 @@ auto LowerBuiltinMethodCall(
   const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
   const hir::TypeId hir_dispatch_type =
-      hir_process.exprs.at(c.arguments.front()->value).type;
+      hir_process.exprs.Get(*c.arguments.front()).type;
   std::vector<mir::ExprId> args;
   args.reserve(c.arguments.size() + 1);
 
@@ -428,16 +428,16 @@ auto LowerBuiltinMethodCall(
     mir::ExprId receiver_id{};
     if (method_mutates) {
       auto recv_or = process.LowerLhsExpr(
-          hir_process.exprs.at(c.arguments.front()->value), frame);
+          hir_process.exprs.Get(*c.arguments.front()), frame);
       if (!recv_or) return std::unexpected(std::move(recv_or.error()));
-      receiver_id = block.AddExpr(*std::move(recv_or));
+      receiver_id = block.exprs.Add(*std::move(recv_or));
       receiver_id =
           MaybeWrapObservableLhsWithMutate(process, frame, block, receiver_id);
     } else {
-      auto recv_or = process.LowerExpr(
-          hir_process.exprs.at(c.arguments.front()->value), frame);
+      auto recv_or =
+          process.LowerExpr(hir_process.exprs.Get(*c.arguments.front()), frame);
       if (!recv_or) return std::unexpected(std::move(recv_or.error()));
-      receiver_id = block.AddExpr(*std::move(recv_or));
+      receiver_id = block.exprs.Add(*std::move(recv_or));
     }
     args.push_back(receiver_id);
   }
@@ -449,9 +449,9 @@ auto LowerBuiltinMethodCall(
       throw InternalError("builtin-method call argument unexpectedly elided");
     }
     auto arg_or =
-        process.LowerExpr(hir_process.exprs.at(c.arguments[i]->value), frame);
+        process.LowerExpr(hir_process.exprs.Get(*c.arguments[i]), frame);
     if (!arg_or) return std::unexpected(std::move(arg_or.error()));
-    args.push_back(block.AddExpr(*std::move(arg_or)));
+    args.push_back(block.exprs.Add(*std::move(arg_or)));
   }
 
   // LRM 7.12.1: reduction / ordering / locator array methods take a
@@ -464,7 +464,7 @@ auto LowerBuiltinMethodCall(
         process, frame, hir_dispatch_type,
         c.with_clause.has_value() ? &*c.with_clause : nullptr);
     if (!closure_or) return std::unexpected(std::move(closure_or.error()));
-    args.push_back(block.AddExpr(*std::move(closure_or)));
+    args.push_back(block.exprs.Add(*std::move(closure_or)));
     // LRM 7.12.5: `map`'s result element type may differ from the
     // receiver's, so its shield is supplied here as that type's canonical
     // default -- the runtime shape is not recoverable from the C++ type
@@ -473,7 +473,7 @@ auto LowerBuiltinMethodCall(
       const mir::TypeId result_elem =
           ArrayContainerElementType(module.Unit().GetType(result_type));
       args.push_back(
-          block.AddExpr(BuildDefaultValueExpr(module, frame, result_elem)));
+          block.exprs.Add(BuildDefaultValueExpr(module, frame, result_elem)));
     }
   } else if (c.with_clause.has_value()) {
     throw InternalError(
@@ -488,7 +488,7 @@ auto LowerBuiltinMethodCall(
   // fabricated one. (`-> e` is the only producer of the trigger kind and
   // lowers through LowerEventTriggerStmt; `await` takes no services.)
   if (b.method == support::BuiltinFn::kTriggered) {
-    args.push_back(block.AddExpr(BuildServicesCallExpr(process, frame)));
+    args.push_back(block.exprs.Add(BuildServicesCallExpr(process, frame)));
   }
 
   return mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/expression/inside.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/inside.cpp
@@ -20,9 +20,9 @@ auto LowerHirInsideExprProc(
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
-  auto lhs_or = process.LowerExpr(hir_process.exprs.at(in.lhs.value), frame);
+  auto lhs_or = process.LowerExpr(hir_process.exprs.Get(in.lhs), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  const mir::ExprId lhs_id = block.AddExpr(*std::move(lhs_or));
+  const mir::ExprId lhs_id = block.exprs.Add(*std::move(lhs_or));
 
   if (in.items.empty()) {
     throw InternalError(
@@ -34,7 +34,7 @@ auto LowerHirInsideExprProc(
         BuildHirInsideItemPredicate(process, frame, lhs_id, item, result_type);
     if (!pred_or) return std::unexpected(std::move(pred_or.error()));
     if (acc.has_value()) {
-      acc = block.AddExpr(
+      acc = block.exprs.Add(
           mir::Expr{
               .data =
                   mir::BinaryExpr{
@@ -46,7 +46,7 @@ auto LowerHirInsideExprProc(
       acc = *pred_or;
     }
   }
-  return mir::Expr{block.GetExpr(*acc)};
+  return mir::Expr{block.exprs.Get(*acc)};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -151,13 +151,12 @@ auto LowerHirUnaryExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::UnaryExpr& u,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& hir_process = process.HirBody();
-  auto operand_or =
-      process.LowerExpr(hir_process.exprs.at(u.operand.value), frame);
+  auto operand_or = process.LowerExpr(hir_process.exprs.Get(u.operand), frame);
   if (!operand_or) {
     return std::unexpected(std::move(operand_or.error()));
   }
   const mir::ExprId operand_id =
-      frame.current_block->AddExpr(*std::move(operand_or));
+      frame.current_block->exprs.Add(*std::move(operand_or));
   return mir::Expr{
       .data = mir::UnaryExpr{.op = LowerUnaryOp(u.op), .operand = operand_id},
       .type = result_type};
@@ -167,12 +166,12 @@ auto LowerHirBinaryExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::BinaryExpr& b,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& hir_process = process.HirBody();
-  auto lhs_or = process.LowerExpr(hir_process.exprs.at(b.lhs.value), frame);
+  auto lhs_or = process.LowerExpr(hir_process.exprs.Get(b.lhs), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  const mir::ExprId lhs_id = frame.current_block->AddExpr(*std::move(lhs_or));
-  auto rhs_or = process.LowerExpr(hir_process.exprs.at(b.rhs.value), frame);
+  const mir::ExprId lhs_id = frame.current_block->exprs.Add(*std::move(lhs_or));
+  auto rhs_or = process.LowerExpr(hir_process.exprs.Get(b.rhs), frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  const mir::ExprId rhs_id = frame.current_block->AddExpr(*std::move(rhs_or));
+  const mir::ExprId rhs_id = frame.current_block->exprs.Add(*std::move(rhs_or));
   return mir::Expr{
       .data =
           mir::BinaryExpr{
@@ -184,18 +183,18 @@ auto LowerHirConditionalExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::ConditionalExpr& c,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& hir_process = process.HirBody();
-  auto cond_or =
-      process.LowerExpr(hir_process.exprs.at(c.condition.value), frame);
+  auto cond_or = process.LowerExpr(hir_process.exprs.Get(c.condition), frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const mir::ExprId cond_id = frame.current_block->AddExpr(*std::move(cond_or));
-  auto then_or =
-      process.LowerExpr(hir_process.exprs.at(c.then_value.value), frame);
+  const mir::ExprId cond_id =
+      frame.current_block->exprs.Add(*std::move(cond_or));
+  auto then_or = process.LowerExpr(hir_process.exprs.Get(c.then_value), frame);
   if (!then_or) return std::unexpected(std::move(then_or.error()));
-  const mir::ExprId then_id = frame.current_block->AddExpr(*std::move(then_or));
-  auto else_or =
-      process.LowerExpr(hir_process.exprs.at(c.else_value.value), frame);
+  const mir::ExprId then_id =
+      frame.current_block->exprs.Add(*std::move(then_or));
+  auto else_or = process.LowerExpr(hir_process.exprs.Get(c.else_value), frame);
   if (!else_or) return std::unexpected(std::move(else_or.error()));
-  const mir::ExprId else_id = frame.current_block->AddExpr(*std::move(else_or));
+  const mir::ExprId else_id =
+      frame.current_block->exprs.Add(*std::move(else_or));
   return mir::Expr{
       .data =
           mir::ConditionalExpr{
@@ -213,18 +212,18 @@ auto LowerHirIncDecExprProc(
   // The target is written in place, so a queue element dispatches to its
   // write-side access just as an assignment target does.
   auto target_or = process.LowerLhsExpr(
-      hir_process.exprs.at(inc.target.value), frame.WithLvalueTarget(true));
+      hir_process.exprs.Get(inc.target), frame.WithLvalueTarget(true));
   if (!target_or) return std::unexpected(std::move(target_or.error()));
-  mir::ExprId target_id = block.AddExpr(*std::move(target_or));
+  mir::ExprId target_id = block.exprs.Add(*std::move(target_or));
 
   // If the LHS reaches an observable storage cell, the mutation runs inside
   // a `ScopedMutation` snapshot so subscribers fire once on destructor commit
   // (`docs/decisions/value-type-concepts.md`).
   const mir::ExprId root_id = FindLhsRootId(block, target_id);
   if (mir::IsObservableCellType(
-          process.Module().Unit().GetType(block.GetExpr(root_id).type))) {
+          process.Module().Unit().GetType(block.exprs.Get(root_id).type))) {
     const mir::ExprId services_id =
-        block.AddExpr(BuildServicesCallExpr(process, frame));
+        block.exprs.Add(BuildServicesCallExpr(process, frame));
     target_id = RewriteLhsRootWithMutate(
         process.Module().Unit(), block, target_id, services_id);
   }
@@ -238,13 +237,12 @@ auto LowerHirConversionExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::ConversionExpr& cv,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& hir_process = process.HirBody();
-  auto operand_or =
-      process.LowerExpr(hir_process.exprs.at(cv.operand.value), frame);
+  auto operand_or = process.LowerExpr(hir_process.exprs.Get(cv.operand), frame);
   if (!operand_or) {
     return std::unexpected(std::move(operand_or.error()));
   }
   const mir::ExprId operand_id =
-      frame.current_block->AddExpr(*std::move(operand_or));
+      frame.current_block->exprs.Add(*std::move(operand_or));
   return mir::Expr{
       .data =
           mir::ConversionExpr{
@@ -256,12 +254,12 @@ auto LowerHirUnaryExprStructural(
     const ClassLowerer& lowerer, WalkFrame frame, const hir::UnaryExpr& u,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& hir_scope = lowerer.HirScope();
-  auto operand_or = lowerer.LowerExpr(hir_scope.GetExpr(u.operand), frame);
+  auto operand_or = lowerer.LowerExpr(hir_scope.exprs.Get(u.operand), frame);
   if (!operand_or) {
     return std::unexpected(std::move(operand_or.error()));
   }
   const mir::ExprId operand_id =
-      frame.current_block->AddExpr(*std::move(operand_or));
+      frame.current_block->exprs.Add(*std::move(operand_or));
   return mir::Expr{
       .data = mir::UnaryExpr{.op = LowerUnaryOp(u.op), .operand = operand_id},
       .type = result_type};
@@ -272,12 +270,12 @@ auto LowerHirBinaryExprStructural(
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& hir_scope = lowerer.HirScope();
   auto& block = *frame.current_block;
-  auto lhs_or = lowerer.LowerExpr(hir_scope.GetExpr(b.lhs), frame);
+  auto lhs_or = lowerer.LowerExpr(hir_scope.exprs.Get(b.lhs), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  const mir::ExprId lhs_id = block.AddExpr(*std::move(lhs_or));
-  auto rhs_or = lowerer.LowerExpr(hir_scope.GetExpr(b.rhs), frame);
+  const mir::ExprId lhs_id = block.exprs.Add(*std::move(lhs_or));
+  auto rhs_or = lowerer.LowerExpr(hir_scope.exprs.Get(b.rhs), frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  const mir::ExprId rhs_id = block.AddExpr(*std::move(rhs_or));
+  const mir::ExprId rhs_id = block.exprs.Add(*std::move(rhs_or));
   return mir::Expr{
       .data =
           mir::BinaryExpr{
@@ -290,15 +288,15 @@ auto LowerHirConditionalExprStructural(
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& hir_scope = lowerer.HirScope();
   auto& block = *frame.current_block;
-  auto cond_or = lowerer.LowerExpr(hir_scope.GetExpr(c.condition), frame);
+  auto cond_or = lowerer.LowerExpr(hir_scope.exprs.Get(c.condition), frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const mir::ExprId cond_id = block.AddExpr(*std::move(cond_or));
-  auto then_or = lowerer.LowerExpr(hir_scope.GetExpr(c.then_value), frame);
+  const mir::ExprId cond_id = block.exprs.Add(*std::move(cond_or));
+  auto then_or = lowerer.LowerExpr(hir_scope.exprs.Get(c.then_value), frame);
   if (!then_or) return std::unexpected(std::move(then_or.error()));
-  const mir::ExprId then_id = block.AddExpr(*std::move(then_or));
-  auto else_or = lowerer.LowerExpr(hir_scope.GetExpr(c.else_value), frame);
+  const mir::ExprId then_id = block.exprs.Add(*std::move(then_or));
+  auto else_or = lowerer.LowerExpr(hir_scope.exprs.Get(c.else_value), frame);
   if (!else_or) return std::unexpected(std::move(else_or.error()));
-  const mir::ExprId else_id = block.AddExpr(*std::move(else_or));
+  const mir::ExprId else_id = block.exprs.Add(*std::move(else_or));
   return mir::Expr{
       .data =
           mir::ConditionalExpr{
@@ -312,12 +310,12 @@ auto LowerHirConversionExprStructural(
     const ClassLowerer& lowerer, WalkFrame frame, const hir::ConversionExpr& cv,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& hir_scope = lowerer.HirScope();
-  auto operand_or = lowerer.LowerExpr(hir_scope.GetExpr(cv.operand), frame);
+  auto operand_or = lowerer.LowerExpr(hir_scope.exprs.Get(cv.operand), frame);
   if (!operand_or) {
     return std::unexpected(std::move(operand_or.error()));
   }
   const mir::ExprId operand_id =
-      frame.current_block->AddExpr(*std::move(operand_or));
+      frame.current_block->exprs.Add(*std::move(operand_or));
   return mir::Expr{
       .data =
           mir::ConversionExpr{

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -124,7 +124,7 @@ auto LowerHirStringLiteral(
   // `value::String` from the software literal via the constructor, on the
   // block that holds the surrounding expression.
   auto& block = *frame.current_block;
-  const mir::ExprId lit = block.AddExpr(
+  const mir::ExprId lit = block.exprs.Add(
       mir::Expr{.data = mir::StringLiteral{.value = s.value}, .type = type});
   return mir::Expr{
       .data =
@@ -194,11 +194,11 @@ auto LowerCrossUnitVarRefExpr(
   const mir::MemberRef target = meta.target;
   const mir::TypeId self_ptr_type = frame.current_class->self_pointer_type;
   const mir::ExprId self_ref =
-      frame.current_block->AddExpr(BuildSelfRefExpr(frame, self_ptr_type));
+      frame.current_block->exprs.Add(BuildSelfRefExpr(frame, self_ptr_type));
   const auto* ptr = std::get_if<mir::PointerType>(
       &lowerer.Module().Unit().GetType(meta.slot_type).data);
   if (ptr != nullptr && ptr->ownership == mir::PointerOwnership::kBorrowed) {
-    const mir::ExprId pointer = frame.current_block->AddExpr(
+    const mir::ExprId pointer = frame.current_block->exprs.Add(
         mir::MakeMemberAccessExpr(self_ref, target, meta.slot_type));
     return mir::Expr{
         .data = mir::DerefExpr{.pointer = pointer}, .type = ptr->pointee};

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -86,7 +86,7 @@ auto WrapPackedAsOwned(
           unit.GetType(result_type).data)) {
     return access_call;
   }
-  const mir::ExprId access_id = block.AddExpr(std::move(access_call));
+  const mir::ExprId access_id = block.exprs.Add(std::move(access_call));
   return mir::Expr{
       .data =
           mir::CallExpr{
@@ -120,7 +120,7 @@ auto WrapSliceSignReTag(
     mir::Block& block, mir::Expr owned, mir::TypeId slice_type,
     mir::TypeId final_type) -> mir::Expr {
   if (slice_type == final_type) return owned;
-  const mir::ExprId owned_id = block.AddExpr(std::move(owned));
+  const mir::ExprId owned_id = block.exprs.Add(std::move(owned));
   return mir::Expr{
       .data =
           mir::ConversionExpr{
@@ -177,11 +177,11 @@ auto IntConstFromMirExpr(const mir::Expr& expr) -> std::int64_t {
 auto BuildOffsetDeltaExpr(
     const ModuleLowerer& module, mir::Block& block, mir::ExprId base,
     std::int64_t value, mir::BinaryOp op) -> mir::Expr {
-  const auto base_type = block.GetExpr(base).type;
+  const auto base_type = block.exprs.Get(base).type;
   const auto& base_ty = module.Unit().GetType(base_type);
   const bool four_state =
       base_ty.IsIntegralPacked() && base_ty.AsIntegralPacked().IsFourState();
-  const auto delta_lit = block.AddExpr(
+  const auto delta_lit = block.exprs.Add(
       four_state
           ? mir::MakeIntegerLiteral(module.Unit().builtins.integer, value)
           : mir::MakeInt32Literal(module.Unit().builtins.int32, value));
@@ -202,10 +202,10 @@ auto WrapUnpackedIndex(
   if (declared.left == 0 && declared.right >= 0) {
     return raw_idx;
   }
-  const mir::ExprId literal_id = block.AddExpr(
+  const mir::ExprId literal_id = block.exprs.Add(
       mir::MakeInt32Literal(module.Unit().builtins.int32, declared.left));
   const bool descending = declared.left >= declared.right;
-  return block.AddExpr(
+  return block.exprs.Add(
       mir::Expr{
           .data =
               mir::BinaryExpr{
@@ -230,9 +230,9 @@ auto WrapPackedIndex(
   if (descending && declared.right == 0) {
     return raw_idx;
   }
-  const mir::ExprId literal_id = block.AddExpr(
+  const mir::ExprId literal_id = block.exprs.Add(
       mir::MakeInt32Literal(module.Unit().builtins.int32, declared.right));
-  return block.AddExpr(
+  return block.exprs.Add(
       mir::Expr{
           .data =
               mir::BinaryExpr{
@@ -249,7 +249,7 @@ auto BuildHiFromLoAndCount(
     const ModuleLowerer& module, mir::Block& block, mir::ExprId lo,
     std::int64_t count) -> mir::ExprId {
   if (count == 1) return lo;
-  return block.AddExpr(
+  return block.exprs.Add(
       BuildOffsetDeltaExpr(module, block, lo, count - 1, mir::BinaryOp::kAdd));
 }
 
@@ -266,15 +266,15 @@ auto PackedIndexedLoHi(
     const hir::PackedRange& declared, mir::ExprId base, std::int64_t count,
     IndexedDir dir) -> RangeLoHi {
   const bool descending = declared.left >= declared.right;
-  const mir::ExprId pbase =
-      WrapPackedIndex(module, block, declared, base, block.GetExpr(base).type);
+  const mir::ExprId pbase = WrapPackedIndex(
+      module, block, declared, base, block.exprs.Get(base).type);
   const bool extend_up = (dir == IndexedDir::kUp) == descending;
   if (extend_up) {
     return RangeLoHi{
         .lo = pbase, .hi = BuildHiFromLoAndCount(module, block, pbase, count)};
   }
   return RangeLoHi{
-      .lo = block.AddExpr(BuildOffsetDeltaExpr(
+      .lo = block.exprs.Add(BuildOffsetDeltaExpr(
           module, block, pbase, count - 1, mir::BinaryOp::kSub)),
       .hi = pbase};
 }
@@ -294,16 +294,16 @@ auto BuildQueueRangeLoHi(
   // literal.
   auto build_base_at_width_offset = [&](mir::ExprId base, mir::ExprId width,
                                         mir::BinaryOp op) -> mir::ExprId {
-    const auto base_type = block.GetExpr(base).type;
-    const auto width_type = block.GetExpr(width).type;
-    const auto one = block.AddExpr(mir::MakeInt32Literal(int32_type, 1));
-    const auto w_minus_1 = block.AddExpr(
+    const auto base_type = block.exprs.Get(base).type;
+    const auto width_type = block.exprs.Get(width).type;
+    const auto one = block.exprs.Add(mir::MakeInt32Literal(int32_type, 1));
+    const auto w_minus_1 = block.exprs.Add(
         mir::Expr{
             .data =
                 mir::BinaryExpr{
                     .op = mir::BinaryOp::kSub, .lhs = width, .rhs = one},
             .type = width_type});
-    return block.AddExpr(
+    return block.exprs.Add(
         mir::Expr{
             .data = mir::BinaryExpr{.op = op, .lhs = base, .rhs = w_minus_1},
             .type = base_type});
@@ -360,14 +360,14 @@ auto BuildPackedRangeLoHi(
             auto lsb = lower_one(b.lsb_expr);
             if (!lsb) return std::unexpected(std::move(lsb.error()));
             const auto msb_off = PackedPhysOffset(
-                declared, IntConstFromMirExpr(block.GetExpr(*msb)));
+                declared, IntConstFromMirExpr(block.exprs.Get(*msb)));
             const auto lsb_off = PackedPhysOffset(
-                declared, IntConstFromMirExpr(block.GetExpr(*lsb)));
+                declared, IntConstFromMirExpr(block.exprs.Get(*lsb)));
             return RangeLoHi{
-                .lo = block.AddExpr(
+                .lo = block.exprs.Add(
                     mir::MakeInt32Literal(
                         int32_type, std::min(msb_off, lsb_off))),
-                .hi = block.AddExpr(
+                .hi = block.exprs.Add(
                     mir::MakeInt32Literal(
                         int32_type, std::max(msb_off, lsb_off)))};
           },
@@ -376,7 +376,7 @@ auto BuildPackedRangeLoHi(
             if (!base) return std::unexpected(std::move(base.error()));
             auto width = lower_one(b.width);
             if (!width) return std::unexpected(std::move(width.error()));
-            const auto count = IntConstFromMirExpr(block.GetExpr(*width));
+            const auto count = IntConstFromMirExpr(block.exprs.Get(*width));
             return PackedIndexedLoHi(
                 module, block, declared, *base, count, IndexedDir::kUp);
           },
@@ -385,7 +385,7 @@ auto BuildPackedRangeLoHi(
             if (!base) return std::unexpected(std::move(base.error()));
             auto width = lower_one(b.width);
             if (!width) return std::unexpected(std::move(width.error()));
-            const auto count = IntConstFromMirExpr(block.GetExpr(*width));
+            const auto count = IntConstFromMirExpr(block.exprs.Get(*width));
             return PackedIndexedLoHi(
                 module, block, declared, *base, count, IndexedDir::kDown);
           },
@@ -407,7 +407,7 @@ auto BuildUnpackedRangeLoHi(
   const std::int64_t count = count_u32;
   const bool descending = declared.left >= declared.right;
   auto project_sv = [&](mir::ExprId sv_expr) -> mir::ExprId {
-    const auto type = block.GetExpr(sv_expr).type;
+    const auto type = block.exprs.Get(sv_expr).type;
     return WrapUnpackedIndex(module, block, declared, sv_expr, type);
   };
   return std::visit(
@@ -425,7 +425,7 @@ auto BuildUnpackedRangeLoHi(
             if (!base) return std::unexpected(std::move(base.error()));
             const auto leftmost_sv =
                 descending
-                    ? block.AddExpr(BuildOffsetDeltaExpr(
+                    ? block.exprs.Add(BuildOffsetDeltaExpr(
                           module, block, *base, count - 1, mir::BinaryOp::kAdd))
                     : *base;
             const auto lo = project_sv(leftmost_sv);
@@ -438,7 +438,7 @@ auto BuildUnpackedRangeLoHi(
             if (!base) return std::unexpected(std::move(base.error()));
             const auto leftmost_sv = descending
                                          ? *base
-                                         : block.AddExpr(BuildOffsetDeltaExpr(
+                                         : block.exprs.Add(BuildOffsetDeltaExpr(
                                                module, block, *base, count - 1,
                                                mir::BinaryOp::kSub));
             const auto lo = project_sv(leftmost_sv);
@@ -490,10 +490,6 @@ auto SliceResultOuterCount(const mir::Type& result_ty) -> std::uint32_t {
   throw InternalError(
       "SliceResultOuterCount: result type is not a fixed-width slice");
 }
-
-// Per-kind MIR-node factories. None of these commit the returned node; the
-// caller (typically a `Lower*` entry point or an inner helper) is
-// responsible for `AddExpr` or further wrapping.
 
 // `arr[i]` element access (LRM 7.4.5 / 7.5 / 7.10). The callee carries
 // just read-vs-write (`kElement` / `kElementRef`); the receiver's container
@@ -573,7 +569,7 @@ auto BuildRangeSliceCallExpr(
         .type = result_type};
   }
   const auto count = SliceResultOuterCount(module.Unit().GetType(result_type));
-  const auto count_id = block.AddExpr(
+  const auto count_id = block.exprs.Add(
       mir::MakeInt32Literal(
           module.Unit().builtins.int32, static_cast<std::int64_t>(count)));
   return mir::Expr{
@@ -597,9 +593,9 @@ auto BuildFieldSliceCallExpr(
     std::uint32_t bit_offset, std::uint32_t bit_width, mir::TypeId result_type,
     AccessSide side) -> mir::Expr {
   const mir::TypeId int32_type = module.Unit().builtins.int32;
-  const auto offset_id = block.AddExpr(
+  const auto offset_id = block.exprs.Add(
       mir::MakeInt32Literal(int32_type, static_cast<std::int64_t>(bit_offset)));
-  const auto count_id = block.AddExpr(
+  const auto count_id = block.exprs.Add(
       mir::MakeInt32Literal(int32_type, static_cast<std::int64_t>(bit_width)));
   return mir::Expr{
       .data =
@@ -689,15 +685,15 @@ auto LowerHirElementSelectExprProc(
   const bool is_write = frame.is_lvalue_target;
   const WalkFrame sub_frame = frame.WithLvalueTarget(false);
 
-  const auto& hir_base = hir_process.exprs.at(sel.base_value.value);
+  const auto& hir_base = hir_process.exprs.Get(sel.base_value);
   auto base_or = process.LowerExpr(hir_base, sub_frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.AddExpr(*std::move(base_or));
+  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
 
-  const auto& hir_idx = hir_process.exprs.at(sel.index.value);
+  const auto& hir_idx = hir_process.exprs.Get(sel.index);
   auto idx_or = process.LowerExpr(hir_idx, sub_frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
-  const mir::ExprId idx_id = block.AddExpr(*std::move(idx_or));
+  const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
 
   const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
   // LRM 6.16.3: a string has no element lvalue, so an index read realizes as
@@ -731,15 +727,15 @@ auto LowerHirRangeSelectExprProc(
   const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
 
-  const auto& hir_base = hir_process.exprs.at(sel.base_value.value);
+  const auto& hir_base = hir_process.exprs.Get(sel.base_value);
   auto base_or = process.LowerExpr(hir_base, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.AddExpr(*std::move(base_or));
+  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
 
   auto lower_one = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
-    auto lowered = process.LowerExpr(hir_process.exprs.at(id.value), frame);
+    auto lowered = process.LowerExpr(hir_process.exprs.Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    return block.AddExpr(*std::move(lowered));
+    return block.exprs.Add(*std::move(lowered));
   };
   const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
   return LowerRangeSelectInner(
@@ -757,7 +753,7 @@ auto LowerHirMemberAccessExprProc(
   auto& module = process.Module();
   const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
-  const auto& base_hir_expr = hir_process.exprs.at(sel.base_value.value);
+  const auto& base_hir_expr = hir_process.exprs.Get(sel.base_value);
   const auto& fields =
       GetAggregateFields(module.Hir().GetType(base_hir_expr.type));
   if (sel.field_index >= fields.size()) {
@@ -766,7 +762,7 @@ auto LowerHirMemberAccessExprProc(
   }
   auto base_or = process.LowerExpr(base_hir_expr, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.AddExpr(*std::move(base_or));
+  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
   return LowerMemberAccessInner(
       module, block, fields[sel.field_index], base_id, result_type,
       AccessSide::kRead);
@@ -779,15 +775,15 @@ auto LowerHirElementSelectExprProcLhs(
   const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
 
-  const auto& hir_base = hir_process.exprs.at(sel.base_value.value);
+  const auto& hir_base = hir_process.exprs.Get(sel.base_value);
   auto base_or = process.LowerLhsExpr(hir_base, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.AddExpr(*std::move(base_or));
+  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
 
-  const auto& hir_idx = hir_process.exprs.at(sel.index.value);
+  const auto& hir_idx = hir_process.exprs.Get(sel.index);
   auto idx_or = process.LowerExpr(hir_idx, frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
-  const mir::ExprId idx_id = block.AddExpr(*std::move(idx_or));
+  const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
 
   const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
   return LowerElementSelectInner(
@@ -802,15 +798,15 @@ auto LowerHirRangeSelectExprProcLhs(
   const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
 
-  const auto& hir_base = hir_process.exprs.at(sel.base_value.value);
+  const auto& hir_base = hir_process.exprs.Get(sel.base_value);
   auto base_or = process.LowerLhsExpr(hir_base, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.AddExpr(*std::move(base_or));
+  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
 
   auto lower_one = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
-    auto lowered = process.LowerExpr(hir_process.exprs.at(id.value), frame);
+    auto lowered = process.LowerExpr(hir_process.exprs.Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    return block.AddExpr(*std::move(lowered));
+    return block.exprs.Add(*std::move(lowered));
   };
   const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
   return LowerRangeSelectInner(
@@ -824,7 +820,7 @@ auto LowerHirMemberAccessExprProcLhs(
   auto& module = process.Module();
   const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
-  const auto& base_hir_expr = hir_process.exprs.at(sel.base_value.value);
+  const auto& base_hir_expr = hir_process.exprs.Get(sel.base_value);
   const auto& fields =
       GetAggregateFields(module.Hir().GetType(base_hir_expr.type));
   if (sel.field_index >= fields.size()) {
@@ -833,7 +829,7 @@ auto LowerHirMemberAccessExprProcLhs(
   }
   auto base_or = process.LowerLhsExpr(base_hir_expr, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.AddExpr(*std::move(base_or));
+  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
   return LowerMemberAccessInner(
       module, block, fields[sel.field_index], base_id, result_type,
       AccessSide::kLhs);
@@ -847,15 +843,15 @@ auto LowerHirElementSelectExprStructural(
   const auto& hir_scope = lowerer.HirScope();
   auto& block = *frame.current_block;
 
-  const auto& hir_base = hir_scope.GetExpr(sel.base_value);
+  const auto& hir_base = hir_scope.exprs.Get(sel.base_value);
   auto base_or = lowerer.LowerExpr(hir_base, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.AddExpr(*std::move(base_or));
+  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
 
-  const auto& hir_idx = hir_scope.GetExpr(sel.index);
+  const auto& hir_idx = hir_scope.exprs.Get(sel.index);
   auto idx_or = lowerer.LowerExpr(hir_idx, frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
-  const mir::ExprId idx_id = block.AddExpr(*std::move(idx_or));
+  const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
 
   // A queue element select cannot reach the structural path: slang forbids
   // referencing an element of a dynamic-typed variable outside a procedural
@@ -874,15 +870,15 @@ auto LowerHirRangeSelectExprStructural(
   const auto& hir_scope = lowerer.HirScope();
   auto& block = *frame.current_block;
 
-  const auto& hir_base = hir_scope.GetExpr(sel.base_value);
+  const auto& hir_base = hir_scope.exprs.Get(sel.base_value);
   auto base_or = lowerer.LowerExpr(hir_base, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.AddExpr(*std::move(base_or));
+  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
 
   auto lower_one = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
-    auto lowered = lowerer.LowerExpr(hir_scope.GetExpr(id), frame);
+    auto lowered = lowerer.LowerExpr(hir_scope.exprs.Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    return block.AddExpr(*std::move(lowered));
+    return block.exprs.Add(*std::move(lowered));
   };
   // Queue slice cannot reach the structural path for the same reason as the
   // element-select case above.
@@ -899,7 +895,7 @@ auto LowerHirMemberAccessExprStructural(
   auto& module = lowerer.Module();
   const auto& hir_scope = lowerer.HirScope();
   auto& block = *frame.current_block;
-  const auto& base_hir_expr = hir_scope.GetExpr(sel.base_value);
+  const auto& base_hir_expr = hir_scope.exprs.Get(sel.base_value);
   const auto& fields =
       GetAggregateFields(module.Hir().GetType(base_hir_expr.type));
   if (sel.field_index >= fields.size()) {
@@ -908,7 +904,7 @@ auto LowerHirMemberAccessExprStructural(
   }
   auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.AddExpr(*std::move(base_or));
+  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
   return LowerMemberAccessInner(
       module, block, fields[sel.field_index], base_id, result_type,
       AccessSide::kRead);
@@ -922,15 +918,15 @@ auto LowerHirElementSelectExprStructuralLhs(
   const auto& hir_scope = lowerer.HirScope();
   auto& block = *frame.current_block;
 
-  const auto& hir_base = hir_scope.GetExpr(sel.base_value);
+  const auto& hir_base = hir_scope.exprs.Get(sel.base_value);
   auto base_or = lowerer.LowerLhsExpr(hir_base, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.AddExpr(*std::move(base_or));
+  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
 
-  const auto& hir_idx = hir_scope.GetExpr(sel.index);
+  const auto& hir_idx = hir_scope.exprs.Get(sel.index);
   auto idx_or = lowerer.LowerExpr(hir_idx, frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
-  const mir::ExprId idx_id = block.AddExpr(*std::move(idx_or));
+  const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
 
   const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
   return LowerElementSelectInner(
@@ -946,15 +942,15 @@ auto LowerHirRangeSelectExprStructuralLhs(
   const auto& hir_scope = lowerer.HirScope();
   auto& block = *frame.current_block;
 
-  const auto& hir_base = hir_scope.GetExpr(sel.base_value);
+  const auto& hir_base = hir_scope.exprs.Get(sel.base_value);
   auto base_or = lowerer.LowerLhsExpr(hir_base, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.AddExpr(*std::move(base_or));
+  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
 
   auto lower_one = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
-    auto lowered = lowerer.LowerExpr(hir_scope.GetExpr(id), frame);
+    auto lowered = lowerer.LowerExpr(hir_scope.exprs.Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    return block.AddExpr(*std::move(lowered));
+    return block.exprs.Add(*std::move(lowered));
   };
   const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
   return LowerRangeSelectInner(
@@ -969,7 +965,7 @@ auto LowerHirMemberAccessExprStructuralLhs(
   auto& module = lowerer.Module();
   const auto& hir_scope = lowerer.HirScope();
   auto& block = *frame.current_block;
-  const auto& base_hir_expr = hir_scope.GetExpr(sel.base_value);
+  const auto& base_hir_expr = hir_scope.exprs.Get(sel.base_value);
   const auto& fields =
       GetAggregateFields(module.Hir().GetType(base_hir_expr.type));
   if (sel.field_index >= fields.size()) {
@@ -978,7 +974,7 @@ auto LowerHirMemberAccessExprStructuralLhs(
   }
   auto base_or = lowerer.LowerLhsExpr(base_hir_expr, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.AddExpr(*std::move(base_or));
+  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
   return LowerMemberAccessInner(
       module, block, fields[sel.field_index], base_id, result_type,
       AccessSide::kLhs);

--- a/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
@@ -50,7 +50,7 @@ auto LowerFinishSystemSubroutineCall(
       throw InternalError("$finish argument unexpectedly elided");
     }
     const hir::ExprId arg_id = *call.arguments.front();
-    const hir::Expr& arg_expr = hir_proc.exprs.at(arg_id.value);
+    const hir::Expr& arg_expr = hir_proc.exprs.Get(arg_id);
     const auto literal = TryExtractLiteralInt(arg_expr);
     if (!literal.has_value()) {
       return diag::Unsupported(
@@ -69,8 +69,8 @@ auto LowerFinishSystemSubroutineCall(
   }
   const auto& builtins = process.Module().Unit().builtins;
   const mir::ExprId services_id =
-      frame.current_block->AddExpr(BuildServicesCallExpr(process, frame));
-  const mir::ExprId level_id = frame.current_block->AddExpr(
+      frame.current_block->exprs.Add(BuildServicesCallExpr(process, frame));
+  const mir::ExprId level_id = frame.current_block->exprs.Add(
       mir::MakeInt32Literal(builtins.int32, static_cast<std::int64_t>(level)));
   return mir::Expr{
       .data =

--- a/src/lyra/lowering/hir_to_mir/expression/system/diagnostic.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/diagnostic.cpp
@@ -33,11 +33,11 @@ auto LowerDiagnosticSystemSubroutineCall(
   auto& block = *frame.current_block;
   const auto time_unit_power =
       static_cast<std::int64_t>(process.Resolution().unit_power);
-  const mir::ExprId items_array = block.AddExpr(
+  const mir::ExprId items_array = block.exprs.Add(
       BuildPrintItemsArray(unit, block, *items_or, time_unit_power));
 
   std::vector<mir::ExprId> args;
-  args.push_back(block.AddExpr(BuildServicesCallExpr(process, frame)));
+  args.push_back(block.exprs.Add(BuildServicesCallExpr(process, frame)));
   args.push_back(items_array);
 
   return mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
@@ -40,7 +40,7 @@ auto BuildFileIoCall(
   auto& block = *frame.current_block;
   std::vector<mir::ExprId> args;
   args.reserve(operands.size() + 1);
-  args.push_back(block.AddExpr(BuildServicesCallExpr(process, frame)));
+  args.push_back(block.exprs.Add(BuildServicesCallExpr(process, frame)));
   for (const mir::ExprId operand : operands) {
     args.push_back(operand);
   }
@@ -56,8 +56,7 @@ auto LowerOperand(
     ProcessLowerer& process, const WalkFrame& frame, const hir::CallExpr& call,
     std::size_t index) -> diag::Result<mir::Expr> {
   const auto& hir_proc = process.HirBody();
-  return process.LowerExpr(
-      hir_proc.exprs.at(call.arguments[index]->value), frame);
+  return process.LowerExpr(hir_proc.exprs.Get(*call.arguments[index]), frame);
 }
 
 auto LowerFixedOperandCall(
@@ -70,7 +69,7 @@ auto LowerFixedOperandCall(
   for (std::size_t i = 0; i < operand_count; ++i) {
     auto operand_or = LowerOperand(process, frame, call, i);
     if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-    operands.push_back(block.AddExpr(*std::move(operand_or)));
+    operands.push_back(block.exprs.Add(*std::move(operand_or)));
   }
   return BuildFileIoCall(process, frame, id, std::move(operands), result_type);
 }
@@ -83,11 +82,11 @@ auto LowerFileOpenCall(
   auto& block = *frame.current_block;
   auto name_or = LowerOperand(process, frame, call, 0);
   if (!name_or) return std::unexpected(std::move(name_or.error()));
-  std::vector<mir::ExprId> operands{block.AddExpr(*std::move(name_or))};
+  std::vector<mir::ExprId> operands{block.exprs.Add(*std::move(name_or))};
   if (call.arguments.size() == 2) {
     auto mode_or = LowerOperand(process, frame, call, 1);
     if (!mode_or) return std::unexpected(std::move(mode_or.error()));
-    operands.push_back(block.AddExpr(*std::move(mode_or)));
+    operands.push_back(block.exprs.Add(*std::move(mode_or)));
   }
   return BuildFileIoCall(
       process, frame, id, std::move(operands),
@@ -103,7 +102,7 @@ auto LowerFileFlushCall(
   if (!call.arguments.empty()) {
     auto fd_or = LowerOperand(process, frame, call, 0);
     if (!fd_or) return std::unexpected(std::move(fd_or.error()));
-    operands.push_back(frame.current_block->AddExpr(*std::move(fd_or)));
+    operands.push_back(frame.current_block->exprs.Add(*std::move(fd_or)));
   }
   return BuildFileIoCall(
       process, frame, id, std::move(operands),
@@ -197,10 +196,10 @@ auto LowerFileIOSystemSubroutineCallStmt(
       if (!slot_or) return std::unexpected(std::move(slot_or.error()));
       slots.push_back(*slot_or);
       auto fd_or = process.LowerExpr(
-          hir_proc.exprs.at(call.arguments[1]->value), wrapper_frame);
+          hir_proc.exprs.Get(*call.arguments[1]), wrapper_frame);
       if (!fd_or) return std::unexpected(std::move(fd_or.error()));
-      const mir::ExprId fd_id = wrapper.AddExpr(*std::move(fd_or));
-      const mir::ExprId temp_ref = wrapper.AddExpr(
+      const mir::ExprId fd_id = wrapper.exprs.Add(*std::move(fd_or));
+      const mir::ExprId temp_ref = wrapper.exprs.Add(
           mir::Expr{.data = slots[0].temp, .type = slots[0].type});
       call_expr = BuildFileIoCall(
           process, wrapper_frame, id, {temp_ref, fd_id},
@@ -213,7 +212,7 @@ auto LowerFileIOSystemSubroutineCallStmt(
       // so both round-trip through a copy-out temp; the runtime call is a
       // generic CallExpr whose operands are the temp, the descriptor, and --
       // for the memory form -- the declared bounds plus start / count.
-      const auto& dest_hir = hir_proc.exprs.at(call.arguments[0]->value);
+      const auto& dest_hir = hir_proc.exprs.Get(*call.arguments[0]);
       const auto& dest_hir_ty = module.Hir().GetType(dest_hir.type);
       const auto& builtins = process.Module().Unit().builtins;
       const auto* unpacked =
@@ -246,42 +245,42 @@ auto LowerFileIOSystemSubroutineCallStmt(
       }
 
       auto fd_or = process.LowerExpr(
-          hir_proc.exprs.at(call.arguments[1]->value), wrapper_frame);
+          hir_proc.exprs.Get(*call.arguments[1]), wrapper_frame);
       if (!fd_or) return std::unexpected(std::move(fd_or.error()));
-      const mir::ExprId fd_id = wrapper.AddExpr(*std::move(fd_or));
+      const mir::ExprId fd_id = wrapper.exprs.Add(*std::move(fd_or));
 
       auto slot_or = BuildOutputArgSlot(
           process, wrapper_frame, *call.arguments[0], "_lyra_fread_dest");
       if (!slot_or) return std::unexpected(std::move(slot_or.error()));
       slots.push_back(*slot_or);
-      const mir::ExprId temp_ref = wrapper.AddExpr(
+      const mir::ExprId temp_ref = wrapper.exprs.Add(
           mir::Expr{.data = slots[0].temp, .type = slots[0].type});
 
       std::vector<mir::ExprId> operands{temp_ref, fd_id};
       if (unpacked != nullptr) {
-        operands.push_back(wrapper.AddExpr(
+        operands.push_back(wrapper.exprs.Add(
             mir::MakeInt32Literal(builtins.int32, unpacked->dim.left)));
-        operands.push_back(wrapper.AddExpr(
+        operands.push_back(wrapper.exprs.Add(
             mir::MakeInt32Literal(builtins.int32, unpacked->dim.right)));
         // start: the SV index, or the lowest declared index when omitted
         // (LRM 21.3.4.4 default). Synthesizing it keeps count the only
         // trailing-optional operand.
         if (call.arguments.size() > 2 && call.arguments[2].has_value()) {
           auto start_or = process.LowerExpr(
-              hir_proc.exprs.at(call.arguments[2]->value), wrapper_frame);
+              hir_proc.exprs.Get(*call.arguments[2]), wrapper_frame);
           if (!start_or) return std::unexpected(std::move(start_or.error()));
-          operands.push_back(wrapper.AddExpr(*std::move(start_or)));
+          operands.push_back(wrapper.exprs.Add(*std::move(start_or)));
         } else {
-          operands.push_back(wrapper.AddExpr(
+          operands.push_back(wrapper.exprs.Add(
               mir::MakeInt32Literal(
                   builtins.int32,
                   std::min(unpacked->dim.left, unpacked->dim.right))));
         }
         if (call.arguments.size() > 3 && call.arguments[3].has_value()) {
           auto count_or = process.LowerExpr(
-              hir_proc.exprs.at(call.arguments[3]->value), wrapper_frame);
+              hir_proc.exprs.Get(*call.arguments[3]), wrapper_frame);
           if (!count_or) return std::unexpected(std::move(count_or.error()));
-          operands.push_back(wrapper.AddExpr(*std::move(count_or)));
+          operands.push_back(wrapper.exprs.Add(*std::move(count_or)));
         }
       }
       call_expr = BuildFileIoCall(
@@ -291,14 +290,14 @@ auto LowerFileIOSystemSubroutineCallStmt(
     case support::FileIOKind::kError: {
       // $ferror(fd, str_lvalue) -- arg[1] is the output string lvalue.
       auto fd_or = process.LowerExpr(
-          hir_proc.exprs.at(call.arguments[0]->value), wrapper_frame);
+          hir_proc.exprs.Get(*call.arguments[0]), wrapper_frame);
       if (!fd_or) return std::unexpected(std::move(fd_or.error()));
-      const mir::ExprId fd_id = wrapper.AddExpr(*std::move(fd_or));
+      const mir::ExprId fd_id = wrapper.exprs.Add(*std::move(fd_or));
       auto slot_or = BuildOutputArgSlot(
           process, wrapper_frame, *call.arguments[1], "_lyra_ferror_dest");
       if (!slot_or) return std::unexpected(std::move(slot_or.error()));
       slots.push_back(*slot_or);
-      const mir::ExprId temp_ref = wrapper.AddExpr(
+      const mir::ExprId temp_ref = wrapper.exprs.Add(
           mir::Expr{.data = slots[0].temp, .type = slots[0].type});
       call_expr = BuildFileIoCall(
           process, wrapper_frame, id, {fd_id, temp_ref},
@@ -312,14 +311,14 @@ auto LowerFileIOSystemSubroutineCallStmt(
 
   std::optional<mir::ExprId> assign_target_id = std::nullopt;
   if (assign_target.has_value()) {
-    auto lhs_or = process.LowerLhsExpr(
-        hir_proc.exprs.at(assign_target->value), wrapper_frame);
+    auto lhs_or =
+        process.LowerLhsExpr(hir_proc.exprs.Get(*assign_target), wrapper_frame);
     if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-    assign_target_id = wrapper.AddExpr(*std::move(lhs_or));
+    assign_target_id = wrapper.exprs.Add(*std::move(lhs_or));
   }
 
   const mir::ExprId services_id =
-      wrapper.AddExpr(BuildServicesCallExpr(process, wrapper_frame));
+      wrapper.exprs.Add(BuildServicesCallExpr(process, wrapper_frame));
   return BuildCopyOutBlock(
       process.Module().Unit(), services_id, frame, std::move(wrapper),
       std::move(label), result_type, std::move(call_expr), false,

--- a/src/lyra/lowering/hir_to_mir/expression/system/print.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/print.cpp
@@ -57,9 +57,9 @@ auto LowerPrintSystemSubroutineCall(
       throw InternalError("$f-print descriptor argument unexpectedly elided");
     }
     auto lowered_or =
-        process.LowerExpr(hir_proc.exprs.at(call.arguments[0]->value), frame);
+        process.LowerExpr(hir_proc.exprs.Get(*call.arguments[0]), frame);
     if (!lowered_or) return std::unexpected(std::move(lowered_or.error()));
-    descriptor = block.AddExpr(*std::move(lowered_or));
+    descriptor = block.exprs.Add(*std::move(lowered_or));
     arg_offset = 1;
   }
 
@@ -87,11 +87,11 @@ auto LowerPrintSystemSubroutineCall(
   auto& unit = process.Module().Unit();
   const auto time_unit_power =
       static_cast<std::int64_t>(process.Resolution().unit_power);
-  const mir::ExprId items_array = block.AddExpr(
+  const mir::ExprId items_array = block.exprs.Add(
       BuildPrintItemsArray(unit, block, *items_or, time_unit_power));
 
   std::vector<mir::ExprId> args;
-  args.push_back(block.AddExpr(BuildServicesCallExpr(process, frame)));
+  args.push_back(block.exprs.Add(BuildServicesCallExpr(process, frame)));
   if (descriptor.has_value()) {
     args.push_back(*descriptor);
   }

--- a/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
@@ -54,7 +54,7 @@ auto LiftStringSource(
         "unpacked array of byte (LRM 21.3.4.3)");
   }
 
-  return frame.current_block->AddExpr(
+  return frame.current_block->exprs.Add(
       mir::Expr{
           .data =
               mir::ConversionExpr{
@@ -74,7 +74,7 @@ auto LiftStringFormat(
         "LiftStringFormat: scan format is not string or integral (LRM "
         "21.3.4.3)");
   }
-  return frame.current_block->AddExpr(
+  return frame.current_block->exprs.Add(
       mir::Expr{
           .data =
               mir::ConversionExpr{
@@ -99,7 +99,7 @@ auto EmitIsUnknownGuard(
     const ModuleLowerer& module, WalkFrame frame, mir::TypeId bit_t,
     mir::ExprId operand_id) -> void {
   auto& body = *frame.current_block;
-  const mir::ExprId guard_id = body.AddExpr(
+  const mir::ExprId guard_id = body.exprs.Add(
       mir::Expr{
           .data =
               mir::CallExpr{
@@ -110,7 +110,7 @@ auto EmitIsUnknownGuard(
           .type = bit_t});
 
   mir::Block then_body;
-  const mir::ExprId minus_one = then_body.AddExpr(
+  const mir::ExprId minus_one = then_body.exprs.Add(
       mir::MakeIntegerLiteral(
           module.Unit().builtins.integer, static_cast<std::int64_t>(-1)));
   then_body.AppendStmt(mir::ReturnStmt{.value = minus_one});
@@ -188,7 +188,7 @@ auto LowerScanSystemSubroutineCall(
     if (!call.arguments[i].has_value()) {
       throw InternalError("LowerScanSystemSubroutineCall: output arg elided");
     }
-    const auto& hir_arg = hir_proc.exprs.at(call.arguments[i]->value);
+    const auto& hir_arg = hir_proc.exprs.Get(*call.arguments[i]);
     const mir::TypeId mir_type = module.TranslateType(hir_arg.type);
     auto meta_or = ComputeSlotMeta(module.Unit(), mir_type, info.source, span);
     if (!meta_or) return std::unexpected(std::move(meta_or.error()));
@@ -211,11 +211,11 @@ auto LowerScanSystemSubroutineCall(
   // conversion lift to string. The guard reads the raw PackedArray; the lift is
   // post-guard because conversion to string silently drops x/z bits and would
   // defeat the LRM 21.3.4.3 EOF rule.
-  auto source_or = process.LowerExpr(
-      hir_proc.exprs.at(call.arguments[0]->value), closure_frame);
+  auto source_or =
+      process.LowerExpr(hir_proc.exprs.Get(*call.arguments[0]), closure_frame);
   if (!source_or) return std::unexpected(std::move(source_or.error()));
   const mir::TypeId source_type = source_or->type;
-  mir::ExprId source_id = body.AddExpr(*std::move(source_or));
+  mir::ExprId source_id = body.exprs.Add(*std::move(source_or));
   if (info.source == support::ScanSourceKind::kString) {
     EmitIsUnknownGuard(module, closure_frame, bit_t, source_id);
     source_id = LiftStringSource(module, closure_frame, source_type, source_id);
@@ -226,11 +226,11 @@ auto LowerScanSystemSubroutineCall(
         "LowerScanSystemSubroutineCall: $fscanf fd is not packed-integer");
   }
 
-  auto format_or = process.LowerExpr(
-      hir_proc.exprs.at(call.arguments[1]->value), closure_frame);
+  auto format_or =
+      process.LowerExpr(hir_proc.exprs.Get(*call.arguments[1]), closure_frame);
   if (!format_or) return std::unexpected(std::move(format_or.error()));
   const mir::TypeId format_type = format_or->type;
-  mir::ExprId format_id = body.AddExpr(*std::move(format_or));
+  mir::ExprId format_id = body.exprs.Add(*std::move(format_or));
   EmitIsUnknownGuard(module, closure_frame, bit_t, format_id);
   format_id = LiftStringFormat(module, closure_frame, format_type, format_id);
 
@@ -241,7 +241,7 @@ auto LowerScanSystemSubroutineCall(
   std::vector<mir::LocalId> temp_ids;
   temp_ids.reserve(metas.size());
   for (std::size_t k = 0; k < metas.size(); ++k) {
-    const mir::ExprId init_id = body.AddExpr(
+    const mir::ExprId init_id = body.exprs.Add(
         BuildDefaultValueExpr(module, closure_frame, metas[k].mir_type));
     const mir::LocalRef temp_ref = body.AppendLocal(
         mir::LocalDecl{
@@ -256,7 +256,7 @@ auto LowerScanSystemSubroutineCall(
   std::vector<mir::ScanSlotDesc> mir_slots;
   mir_slots.reserve(metas.size());
   for (std::size_t k = 0; k < metas.size(); ++k) {
-    const mir::ExprId temp_ref_id = body.AddExpr(
+    const mir::ExprId temp_ref_id = body.exprs.Add(
         mir::MakeLocalRefExpr(
             mir::BlockHops{.value = 0}, temp_ids[k], metas[k].mir_type));
     if (metas[k].is_string) {
@@ -271,7 +271,7 @@ auto LowerScanSystemSubroutineCall(
     }
   }
 
-  const mir::ExprId parse_call_id = body.AddExpr(
+  const mir::ExprId parse_call_id = body.exprs.Add(
       mir::Expr{
           .data =
               mir::RuntimeCallExpr{
@@ -294,11 +294,11 @@ auto LowerScanSystemSubroutineCall(
   // propagate to the caller's storage.
   for (std::size_t k = 0; k < metas.size(); ++k) {
     const mir::ExprId count_read_id =
-        body.AddExpr(mir::Expr{.data = count_ref, .type = integer_t});
-    const mir::ExprId k_lit_id = body.AddExpr(
+        body.exprs.Add(mir::Expr{.data = count_ref, .type = integer_t});
+    const mir::ExprId k_lit_id = body.exprs.Add(
         mir::MakeIntegerLiteral(
             module.Unit().builtins.integer, static_cast<std::int64_t>(k + 1)));
-    const mir::ExprId cond_id = body.AddExpr(
+    const mir::ExprId cond_id = body.exprs.Add(
         mir::Expr{
             .data =
                 mir::BinaryExpr{
@@ -310,19 +310,19 @@ auto LowerScanSystemSubroutineCall(
     mir::Block then_body;
     const WalkFrame then_frame = closure_frame.WithBlock(&then_body).Deeper();
     auto lvalue_or = process.LowerLhsExpr(
-        hir_proc.exprs.at(call.arguments[k + 2]->value), then_frame);
+        hir_proc.exprs.Get(*call.arguments[k + 2]), then_frame);
     if (!lvalue_or) return std::unexpected(std::move(lvalue_or.error()));
-    const mir::ExprId lvalue_id = then_body.AddExpr(*std::move(lvalue_or));
-    const mir::ExprId temp_read_id = then_body.AddExpr(
+    const mir::ExprId lvalue_id = then_body.exprs.Add(*std::move(lvalue_or));
+    const mir::ExprId temp_read_id = then_body.exprs.Add(
         mir::MakeLocalRefExpr(
             mir::BlockHops{.value = 1}, temp_ids[k], metas[k].mir_type));
     const mir::ExprId services_id_then =
-        then_body.AddExpr(BuildServicesCallExpr(process, then_frame));
+        then_body.exprs.Add(BuildServicesCallExpr(process, then_frame));
     const mir::Expr assign_expr = BuildObservableAssignExpr(
         process.Module().Unit(), then_body, services_id_then, lvalue_id,
         temp_read_id, std::nullopt, metas[k].mir_type,
         process.Module().Unit().builtins.void_type);
-    const mir::ExprId assign_id = then_body.AddExpr(assign_expr);
+    const mir::ExprId assign_id = then_body.exprs.Add(assign_expr);
     then_body.AppendStmt(mir::ExprStmt{.expr = assign_id});
 
     body.AppendIfThen(cond_id, std::move(then_body));
@@ -330,7 +330,7 @@ auto LowerScanSystemSubroutineCall(
 
   // Yield the matched-conversion count.
   const mir::ExprId count_id =
-      body.AddExpr(mir::Expr{.data = count_ref, .type = integer_t});
+      body.exprs.Add(mir::Expr{.data = count_ref, .type = integer_t});
   return BuildClosureCallExpr(*frame.current_block, closure.Build(count_id));
 }
 

--- a/src/lyra/lowering/hir_to_mir/expression/system/sformat.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/sformat.cpp
@@ -45,11 +45,11 @@ auto BuildSFormatCallExpr(
   auto& block = *frame.current_block;
   const auto time_unit_power =
       static_cast<std::int64_t>(process.Resolution().unit_power);
-  const mir::ExprId items_array = block.AddExpr(
+  const mir::ExprId items_array = block.exprs.Add(
       BuildPrintItemsArray(unit, block, *items_or, time_unit_power));
 
   std::vector<mir::ExprId> args;
-  args.push_back(block.AddExpr(BuildServicesCallExpr(process, frame)));
+  args.push_back(block.exprs.Add(BuildServicesCallExpr(process, frame)));
   args.push_back(items_array);
 
   return mir::Expr{
@@ -102,7 +102,7 @@ auto LowerSFormatSystemSubroutineCallStmt(
     auto call_expr_or =
         BuildSFormatCallExpr(process, frame, call, id, info, 0, span);
     if (!call_expr_or) return std::unexpected(std::move(call_expr_or.error()));
-    const mir::ExprId expr_id = block.AddExpr(*std::move(call_expr_or));
+    const mir::ExprId expr_id = block.exprs.Add(*std::move(call_expr_or));
     return mir::Stmt{
         .label = std::move(label), .data = mir::ExprStmt{.expr = expr_id}};
   }
@@ -120,27 +120,27 @@ auto LowerSFormatSystemSubroutineCallStmt(
         "elided");
   }
   auto out_or =
-      process.LowerLhsExpr(hir_proc.exprs.at(call.arguments[0]->value), frame);
+      process.LowerLhsExpr(hir_proc.exprs.Get(*call.arguments[0]), frame);
   if (!out_or) return std::unexpected(std::move(out_or.error()));
   const mir::TypeId out_type = process.Module().TranslateType(
-      hir_proc.exprs.at(call.arguments[0]->value).type);
+      hir_proc.exprs.Get(*call.arguments[0]).type);
   if (process.Module().Unit().GetType(out_type).Kind() !=
       mir::TypeKind::kString) {
     return RejectNonStringOutput(name, span);
   }
-  const mir::ExprId out_id = block.AddExpr(*std::move(out_or));
+  const mir::ExprId out_id = block.exprs.Add(*std::move(out_or));
 
   auto call_expr_or =
       BuildSFormatCallExpr(process, frame, call, id, info, 1, span);
   if (!call_expr_or) return std::unexpected(std::move(call_expr_or.error()));
-  const mir::ExprId call_id = block.AddExpr(*std::move(call_expr_or));
+  const mir::ExprId call_id = block.exprs.Add(*std::move(call_expr_or));
 
   const mir::ExprId services_id =
-      block.AddExpr(BuildServicesCallExpr(process, frame));
+      block.exprs.Add(BuildServicesCallExpr(process, frame));
   const mir::Expr assign_expr = BuildObservableAssignExpr(
       process.Module().Unit(), block, services_id, out_id, call_id,
       std::nullopt, out_type, process.Module().Unit().builtins.void_type);
-  const mir::ExprId assign_id = block.AddExpr(assign_expr);
+  const mir::ExprId assign_id = block.exprs.Add(assign_expr);
 
   return mir::Stmt{
       .label = std::move(label), .data = mir::ExprStmt{.expr = assign_id}};

--- a/src/lyra/lowering/hir_to_mir/expression/system/time.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/time.cpp
@@ -27,8 +27,8 @@ auto LowerTimeSystemSubroutineCall(
   }
   auto& body = *frame.current_block;
   const mir::ExprId services_id =
-      body.AddExpr(BuildServicesCallExpr(process, frame));
-  const mir::ExprId unit_power_id = body.AddExpr(
+      body.exprs.Add(BuildServicesCallExpr(process, frame));
+  const mir::ExprId unit_power_id = body.exprs.Add(
       mir::MakeInt32Literal(
           builtins.int32,
           static_cast<std::int64_t>(process.Resolution().unit_power)));

--- a/src/lyra/lowering/hir_to_mir/expression/system/timescale.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/timescale.cpp
@@ -33,15 +33,15 @@ auto LowerTimeFormatSystemSubroutineCall(
   }
 
   std::vector<mir::ExprId> call_args;
-  call_args.push_back(body.AddExpr(BuildServicesCallExpr(process, frame)));
+  call_args.push_back(body.exprs.Add(BuildServicesCallExpr(process, frame)));
   for (const auto& arg : args) {
     if (!arg.has_value()) {
       throw InternalError(
           "$timeformat positional argument unexpectedly elided");
     }
-    auto lowered = process.LowerExpr(hir_proc.exprs.at(arg->value), frame);
+    auto lowered = process.LowerExpr(hir_proc.exprs.Get(*arg), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    call_args.push_back(body.AddExpr(*std::move(lowered)));
+    call_args.push_back(body.exprs.Add(*std::move(lowered)));
   }
 
   return mir::Expr{
@@ -60,23 +60,23 @@ auto LowerPrintTimescaleSystemSubroutineCall(
   const auto resolution = process.Resolution();
 
   const mir::ExprId services_id =
-      body.AddExpr(BuildServicesCallExpr(process, frame));
-  const mir::ExprId scope_name_lit = body.AddExpr(
+      body.exprs.Add(BuildServicesCallExpr(process, frame));
+  const mir::ExprId scope_name_lit = body.exprs.Add(
       mir::Expr{
           .data =
               mir::StringLiteral{.value = std::string(process.Owner().Name())},
           .type = builtins.string});
-  const mir::ExprId scope_name_id = body.AddExpr(
+  const mir::ExprId scope_name_id = body.exprs.Add(
       mir::Expr{
           .data =
               mir::CallExpr{
                   .callee = mir::ConstructorCallee{},
                   .arguments = {scope_name_lit}},
           .type = builtins.string});
-  const mir::ExprId unit_power_id = body.AddExpr(
+  const mir::ExprId unit_power_id = body.exprs.Add(
       mir::MakeInt32Literal(
           builtins.int32, static_cast<std::int64_t>(resolution.unit_power)));
-  const mir::ExprId precision_power_id = body.AddExpr(
+  const mir::ExprId precision_power_id = body.exprs.Add(
       mir::MakeInt32Literal(
           builtins.int32,
           static_cast<std::int64_t>(resolution.precision_power)));

--- a/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
+++ b/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
@@ -20,11 +20,11 @@ auto BuildHirInsideItemPredicate(
   const auto& hir_body = proc.HirBody();
   auto& block = *frame.current_block;
   auto lower_id = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
-    auto lowered = proc.LowerExpr(hir_body.exprs.at(id.value), frame);
+    auto lowered = proc.LowerExpr(hir_body.exprs.Get(id), frame);
     if (!lowered) {
       return std::unexpected(std::move(lowered.error()));
     }
-    return block.AddExpr(*std::move(lowered));
+    return block.exprs.Add(*std::move(lowered));
   };
 
   return std::visit(
@@ -32,7 +32,7 @@ auto BuildHirInsideItemPredicate(
           [&](const hir::ExprId& val_id) -> diag::Result<mir::ExprId> {
             auto v = lower_id(val_id);
             if (!v) return std::unexpected(std::move(v.error()));
-            return block.AddExpr(
+            return block.exprs.Add(
                 mir::Expr{
                     .data =
                         mir::BinaryExpr{
@@ -46,7 +46,7 @@ auto BuildHirInsideItemPredicate(
             if (!lo) return std::unexpected(std::move(lo.error()));
             auto hi = lower_id(r.hi);
             if (!hi) return std::unexpected(std::move(hi.error()));
-            const mir::ExprId ge_id = block.AddExpr(
+            const mir::ExprId ge_id = block.exprs.Add(
                 mir::Expr{
                     .data =
                         mir::BinaryExpr{
@@ -54,7 +54,7 @@ auto BuildHirInsideItemPredicate(
                             .lhs = lhs_id,
                             .rhs = *lo},
                     .type = result_type});
-            const mir::ExprId le_id = block.AddExpr(
+            const mir::ExprId le_id = block.exprs.Add(
                 mir::Expr{
                     .data =
                         mir::BinaryExpr{
@@ -62,7 +62,7 @@ auto BuildHirInsideItemPredicate(
                             .lhs = lhs_id,
                             .rhs = *hi},
                     .type = result_type});
-            return block.AddExpr(
+            return block.exprs.Add(
                 mir::Expr{
                     .data =
                         mir::BinaryExpr{

--- a/src/lyra/lowering/hir_to_mir/lhs_observable.cpp
+++ b/src/lyra/lowering/hir_to_mir/lhs_observable.cpp
@@ -23,7 +23,7 @@ auto AsContainerAccessBase(const mir::Expr& expr) -> const mir::ExprId* {
 
 auto FindLhsRootId(const mir::Block& block, mir::ExprId lhs_id) -> mir::ExprId {
   while (true) {
-    const auto& expr = block.GetExpr(lhs_id);
+    const auto& expr = block.exprs.Get(lhs_id);
     if (const auto* base = AsContainerAccessBase(expr)) {
       lhs_id = *base;
       continue;
@@ -35,19 +35,19 @@ auto FindLhsRootId(const mir::Block& block, mir::ExprId lhs_id) -> mir::ExprId {
 auto RewriteLhsRootWithMutate(
     const mir::CompilationUnit& unit, mir::Block& block, mir::ExprId lhs_id,
     mir::ExprId services_id) -> mir::ExprId {
-  const auto& expr = block.GetExpr(lhs_id);
+  const auto& expr = block.exprs.Get(lhs_id);
   if (AsContainerAccessBase(expr) != nullptr) {
     auto rewritten_call = std::get<mir::CallExpr>(expr.data);
     rewritten_call.arguments.front() = RewriteLhsRootWithMutate(
         unit, block, rewritten_call.arguments.front(), services_id);
-    return block.AddExpr(
+    return block.exprs.Add(
         mir::Expr{.data = std::move(rewritten_call), .type = expr.type});
   }
   const mir::TypeId value_type =
       mir::ObservableInnerValueType(unit.GetType(expr.type));
-  const mir::ExprId mutate_id = block.AddExpr(
+  const mir::ExprId mutate_id = block.exprs.Add(
       mir::MakeObservableMutateCallExpr(lhs_id, services_id, value_type));
-  return block.AddExpr(
+  return block.exprs.Add(
       mir::Expr{
           .data = mir::DerefExpr{.pointer = mutate_id}, .type = value_type});
 }
@@ -59,7 +59,7 @@ auto BuildObservableAssignExpr(
     mir::TypeId void_type) -> mir::Expr {
   const mir::ExprId root_id = FindLhsRootId(block, lhs_id);
   const bool root_is_cell =
-      mir::IsObservableCellType(unit.GetType(block.GetExpr(root_id).type));
+      mir::IsObservableCellType(unit.GetType(block.exprs.Get(root_id).type));
   if (!root_is_cell) {
     return mir::Expr{
         .data =

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -73,7 +73,7 @@ auto BuildPrintValueItem(
     mir::FormatSpec spec) -> diag::Result<mir::RuntimePrintItem> {
   const auto& hir_proc = process.HirBody();
   auto& block = *frame.current_block;
-  auto lowered_or = process.LowerExpr(hir_proc.exprs.at(hir_arg.value), frame);
+  auto lowered_or = process.LowerExpr(hir_proc.exprs.Get(hir_arg), frame);
   if (!lowered_or) return std::unexpected(std::move(lowered_or.error()));
   mir::Expr lowered = *std::move(lowered_or);
 
@@ -85,7 +85,7 @@ auto BuildPrintValueItem(
   if (spec.kind == value::FormatKind::kString &&
       value_type.Kind() != mir::TypeKind::kString &&
       !value_type.IsIntegralPacked()) {
-    const mir::ExprId inner = block.AddExpr(std::move(lowered));
+    const mir::ExprId inner = block.exprs.Add(std::move(lowered));
     lowered = mir::Expr{
         .data =
             mir::ConversionExpr{
@@ -94,7 +94,7 @@ auto BuildPrintValueItem(
   }
 
   const mir::TypeId type = lowered.type;
-  const mir::ExprId value = block.AddExpr(std::move(lowered));
+  const mir::ExprId value = block.exprs.Add(std::move(lowered));
   return mir::RuntimePrintValue(value, type, std::move(spec));
 }
 
@@ -149,7 +149,7 @@ struct LiteralFormatStringRef {
 auto TryGetHirStringLiteral(
     const hir::ProceduralBody& proc, hir::ExprId expr_id)
     -> std::optional<LiteralFormatStringRef> {
-  const auto& expr = proc.exprs.at(expr_id.value);
+  const auto& expr = proc.exprs.Get(expr_id);
   const auto* primary = std::get_if<hir::PrimaryExpr>(&expr.data);
   if (primary == nullptr) return std::nullopt;
   const auto* sl = std::get_if<hir::StringLiteral>(&primary->data);
@@ -166,7 +166,7 @@ auto BuildFormatSpecExpr(
     mir::CompilationUnit& unit, mir::Block& block, const mir::FormatSpec& spec,
     std::int64_t time_unit_power) -> mir::Expr {
   const auto int_lit = [&](std::int64_t v) {
-    return block.AddExpr(mir::MakeInt32Literal(unit.builtins.int32, v));
+    return block.exprs.Add(mir::MakeInt32Literal(unit.builtins.int32, v));
   };
   std::vector<mir::ExprId> args;
   args.push_back(int_lit(static_cast<std::int64_t>(spec.kind)));
@@ -195,11 +195,11 @@ auto BuildPrintItemExpr(
   return std::visit(
       Overloaded{
           [&](const mir::RuntimePrintLiteral& lit) -> mir::Expr {
-            const mir::ExprId text_lit = block.AddExpr(
+            const mir::ExprId text_lit = block.exprs.Add(
                 mir::Expr{
                     .data = mir::StringLiteral{.value = lit.text},
                     .type = unit.builtins.string});
-            const mir::ExprId text = block.AddExpr(
+            const mir::ExprId text = block.exprs.Add(
                 mir::Expr{
                     .data =
                         mir::CallExpr{
@@ -214,7 +214,7 @@ auto BuildPrintItemExpr(
                 .type = unit.builtins.print_literal_item};
           },
           [&](const mir::RuntimePrintValue& v) -> mir::Expr {
-            const mir::ExprId spec = block.AddExpr(
+            const mir::ExprId spec = block.exprs.Add(
                 BuildFormatSpecExpr(unit, block, v.spec, time_unit_power));
             return mir::Expr{
                 .data =
@@ -269,9 +269,9 @@ auto BuildRuntimePrintItemsFromCallArgs(
   }
   if (!literal.has_value() && fmt_req == FormatStringRequirement::kRequired) {
     // LRM 21.3.3 NOTE permits a non-literal format string; not yet supported.
-    const diag::SourceSpan span =
-        cursor < args.size() ? hir_proc.exprs.at(args[cursor].value).span
-                             : call_span;
+    const diag::SourceSpan span = cursor < args.size()
+                                      ? hir_proc.exprs.Get(args[cursor]).span
+                                      : call_span;
     return diag::Unsupported(
         span, diag::DiagCode::kUnsupportedSubroutineArgument,
         "format string must be a string literal; a runtime-evaluated format "
@@ -315,8 +315,8 @@ auto BuildPrintItemsArray(
   std::vector<mir::ExprId> elements;
   elements.reserve(items.size());
   for (const mir::RuntimePrintItem& item : items) {
-    elements.push_back(
-        block.AddExpr(BuildPrintItemExpr(unit, block, item, time_unit_power)));
+    elements.push_back(block.exprs.Add(
+        BuildPrintItemExpr(unit, block, item, time_unit_power)));
   }
   const mir::TypeId array_type = unit.AddType(
       mir::TypeData{mir::UnpackedArrayType{

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -121,7 +121,7 @@ auto ProcessLowerer::LowerExpr(const hir::Expr& expr, WalkFrame frame)
   if (!raw_or) return raw_or;
   if (mir::IsObservableCellType(module_->Unit().GetType(raw_or->type))) {
     const mir::ExprId cell_id =
-        frame.current_block->AddExpr(*std::move(raw_or));
+        frame.current_block->exprs.Add(*std::move(raw_or));
     return mir::MakeObservableGetCallExpr(cell_id, result_type);
   }
   return raw_or;
@@ -233,7 +233,7 @@ namespace {
 auto LowerStraightLineBodyInto(ProcessLowerer& process, WalkFrame frame)
     -> diag::Result<void> {
   const hir::ProceduralBody& body = process.HirBody();
-  auto lowered = process.LowerStmt(body.stmts.at(body.root_stmt.value), frame);
+  auto lowered = process.LowerStmt(body.stmts.Get(body.root_stmt), frame);
   if (!lowered) return std::unexpected(std::move(lowered.error()));
   auto& body_block = *frame.current_block;
   body_block.AppendStmt(*std::move(lowered));
@@ -244,7 +244,7 @@ auto LowerStraightLineProcess(ProcessLowerer& process, mir::ProcessKind kind)
     -> diag::Result<mir::Process> {
   const WalkFrame& parent = process.OwnerCtorFrame();
   mir::Block process_block;
-  const mir::LocalId self_id = process_block.AddLocal(
+  const mir::LocalId self_id = process_block.vars.Add(
       mir::LocalDecl{
           .name = "self", .type = parent.current_class->self_pointer_type});
   const WalkFrame body_frame = parent.WithBlock(&process_block)
@@ -268,7 +268,7 @@ auto LowerForeverProcess(
     -> diag::Result<mir::Process> {
   const WalkFrame& parent = process.OwnerCtorFrame();
   mir::Block process_block;
-  const mir::LocalId self_id = process_block.AddLocal(
+  const mir::LocalId self_id = process_block.vars.Add(
       mir::LocalDecl{
           .name = "self", .type = parent.current_class->self_pointer_type});
   mir::Block body_block;
@@ -286,7 +286,7 @@ auto LowerForeverProcess(
   }
 
   const mir::BlockId body_scope_id =
-      process_block.AddChildScope(std::move(body_block));
+      process_block.child_scopes.Add(std::move(body_block));
   process_block.AppendStmt(
       mir::Stmt{
           .label = std::nullopt,
@@ -352,7 +352,7 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
     -> diag::Result<mir::MethodDecl> {
   const WalkFrame& parent = owner_ctor_frame_;
   mir::Block body_block;
-  const mir::LocalId self_id = body_block.AddLocal(
+  const mir::LocalId self_id = body_block.vars.Add(
       mir::LocalDecl{
           .name = "self", .type = parent.current_class->self_pointer_type});
   // A task body suspends on timing controls and renders as a coroutine; a
@@ -368,7 +368,7 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
   std::vector<mir::MethodParam> params;
   params.reserve(src.params.size());
   for (const auto& param : src.params) {
-    const auto& hir_var = src.body.procedural_vars.at(param.var.value);
+    const auto& hir_var = src.body.procedural_vars.Get(param.var);
     const mir::TypeId value_type = module_->TranslateType(hir_var.type);
     // A `ref` / `const ref` formal's type is a `Ref<T>` over the value type
     // (LRM 13.5.2) -- the reference is itself the data type, so the direction
@@ -383,7 +383,7 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
                                            hir::ParamDirection::kConstRef}})
                      : value_type;
     const mir::LocalId mir_var =
-        body_block.AddLocal(mir::LocalDecl{.name = hir_var.name, .type = type});
+        body_block.vars.Add(mir::LocalDecl{.name = hir_var.name, .type = type});
     MapProceduralVar(
         param.var, AutomaticVarBinding{
                        .declaration_procedural_depth = body_frame.block_depth,
@@ -406,7 +406,7 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
   const mir::TypeId result_type = module_->TranslateType(src.result_type);
   std::optional<mir::LocalRef> result_ref;
   if (src.result_var.has_value()) {
-    const mir::ExprId default_init = body_block.AddExpr(
+    const mir::ExprId default_init = body_block.exprs.Add(
         BuildDefaultValueExpr(*module_, body_frame, result_type));
     result_ref = body_block.AppendLocal(
         mir::LocalDecl{.name = "_lyra_result", .type = result_type},
@@ -422,8 +422,8 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
   if (!lowered) return std::unexpected(std::move(lowered.error()));
 
   if (result_ref.has_value()) {
-    const mir::ExprId result_read =
-        body_block.AddExpr(mir::Expr{.data = *result_ref, .type = result_type});
+    const mir::ExprId result_read = body_block.exprs.Add(
+        mir::Expr{.data = *result_ref, .type = result_type});
     body_block.AppendStmt(
         mir::ReturnStmt{
             .value = result_read,

--- a/src/lyra/lowering/hir_to_mir/self_ref.cpp
+++ b/src/lyra/lowering/hir_to_mir/self_ref.cpp
@@ -20,8 +20,8 @@ auto BuildSelfRefExpr(const WalkFrame& frame, mir::TypeId self_ptr_type)
 auto BuildStructuralMemberAccessExpr(
     const WalkFrame& frame, const mir::MemberRef& member) -> mir::Expr {
   const mir::TypeId field_type =
-      frame.EnclosingClassAtHops(member.hops).GetMember(member.var).type;
-  const mir::ExprId receiver = frame.current_block->AddExpr(
+      frame.EnclosingClassAtHops(member.hops).members.Get(member.var).type;
+  const mir::ExprId receiver = frame.current_block->exprs.Add(
       BuildSelfRefExpr(frame, frame.current_class->self_pointer_type));
   return mir::MakeMemberAccessExpr(receiver, member, field_type);
 }
@@ -38,7 +38,7 @@ auto BuildReferenceArg(
   }
   const mir::TypeId ref_type = unit.AddType(
       mir::TypeData{mir::RefType{.pointee = pointee, .is_const = false}});
-  return block.AddExpr(
+  return block.exprs.Add(
       mir::Expr{
           .data =
               mir::CallExpr{

--- a/src/lyra/lowering/hir_to_mir/services_call.cpp
+++ b/src/lyra/lowering/hir_to_mir/services_call.cpp
@@ -10,7 +10,7 @@ auto BuildServicesCallExpr(
     const ProcessLowerer& process, const WalkFrame& frame) -> mir::Expr {
   auto& body = *frame.current_block;
   const auto& builtins = process.Module().Unit().builtins;
-  const mir::ExprId self_id = body.AddExpr(
+  const mir::ExprId self_id = body.exprs.Add(
       BuildSelfRefExpr(frame, frame.current_class->self_pointer_type));
   return mir::MakeServicesCallExpr(self_id, builtins.services);
 }

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -57,7 +57,7 @@ auto LowerDestructuringAssign(
   bool any_four_state = false;
   std::uint64_t total_width = 0;
   for (const hir::ExprId op_id : lhs_concat.operands) {
-    const hir::Expr& op = hir_proc.exprs.at(op_id.value);
+    const hir::Expr& op = hir_proc.exprs.Get(op_id);
     const hir::Type& op_ty = process.Module().Hir().GetType(op.type);
     if (!op_ty.IsPackedArray()) {
       throw InternalError(
@@ -83,7 +83,7 @@ auto LowerDestructuringAssign(
               .left = static_cast<std::int64_t>(total_width) - 1, .right = 0}},
           .form = mir::PackedArrayForm::kExplicit}});
 
-  const mir::ExprId temp_default_init = wrapper.AddExpr(
+  const mir::ExprId temp_default_init = wrapper.exprs.Add(
       BuildDefaultValueExpr(process.Module(), wrapper_frame, temp_type));
   const mir::LocalRef snapshot_ref = wrapper.AppendLocal(
       mir::LocalDecl{.name = "_lyra_destruct_rhs", .type = temp_type},
@@ -92,11 +92,11 @@ auto LowerDestructuringAssign(
   // RHS is evaluated once; the snapshot temp is what gets distributed,
   // which is what makes `{a, b} = {b, a}` swap correctly.
   auto rhs_or =
-      process.LowerExpr(hir_proc.exprs.at(assign.rhs.value), wrapper_frame);
+      process.LowerExpr(hir_proc.exprs.Get(assign.rhs), wrapper_frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  mir::ExprId rhs_id = wrapper.AddExpr(*std::move(rhs_or));
-  if (wrapper.GetExpr(rhs_id).type != temp_type) {
-    rhs_id = wrapper.AddExpr(
+  mir::ExprId rhs_id = wrapper.exprs.Add(*std::move(rhs_or));
+  if (wrapper.exprs.Get(rhs_id).type != temp_type) {
+    rhs_id = wrapper.exprs.Add(
         mir::Expr{
             .data =
                 mir::ConversionExpr{
@@ -105,8 +105,8 @@ auto LowerDestructuringAssign(
   }
 
   const mir::ExprId temp_assign_target =
-      wrapper.AddExpr(mir::Expr{.data = snapshot_ref, .type = temp_type});
-  const mir::ExprId temp_assign_id = wrapper.AddExpr(
+      wrapper.exprs.Add(mir::Expr{.data = snapshot_ref, .type = temp_type});
+  const mir::ExprId temp_assign_id = wrapper.exprs.Add(
       mir::Expr{
           .data =
               mir::AssignExpr{.target = temp_assign_target, .value = rhs_id},
@@ -121,24 +121,24 @@ auto LowerDestructuringAssign(
     offset -= w;
 
     auto part_lhs_or = process.LowerLhsExpr(
-        hir_proc.exprs.at(lhs_concat.operands[i].value), wrapper_frame);
+        hir_proc.exprs.Get(lhs_concat.operands[i]), wrapper_frame);
     if (!part_lhs_or) {
       return std::unexpected(std::move(part_lhs_or.error()));
     }
     const mir::TypeId part_mir_type = process.Module().TranslateType(
-        hir_proc.exprs.at(lhs_concat.operands[i].value).type);
-    const mir::ExprId part_lhs_id = wrapper.AddExpr(*std::move(part_lhs_or));
+        hir_proc.exprs.Get(lhs_concat.operands[i]).type);
+    const mir::ExprId part_lhs_id = wrapper.exprs.Add(*std::move(part_lhs_or));
 
-    const mir::ExprId offset_id = wrapper.AddExpr(
+    const mir::ExprId offset_id = wrapper.exprs.Add(
         mir::MakeInt32Literal(
             process.Module().Unit().builtins.int32,
             static_cast<std::int64_t>(offset)));
-    const mir::ExprId count_id = wrapper.AddExpr(
+    const mir::ExprId count_id = wrapper.exprs.Add(
         mir::MakeInt32Literal(
             process.Module().Unit().builtins.int32,
             static_cast<std::int64_t>(w)));
     const mir::ExprId temp_ref =
-        wrapper.AddExpr(mir::Expr{.data = snapshot_ref, .type = temp_type});
+        wrapper.exprs.Add(mir::Expr{.data = snapshot_ref, .type = temp_type});
     const mir::TypeId slice_type = process.Module().Unit().AddType(
         mir::TypeData{mir::PackedArrayType{
             .atom = any_four_state ? mir::BitAtom::kLogic : mir::BitAtom::kBit,
@@ -146,7 +146,7 @@ auto LowerDestructuringAssign(
             .dims = {mir::PackedRange{
                 .left = static_cast<std::int64_t>(w) - 1, .right = 0}},
             .form = mir::PackedArrayForm::kExplicit}});
-    const mir::ExprId raw_slice_id = wrapper.AddExpr(
+    const mir::ExprId raw_slice_id = wrapper.exprs.Add(
         mir::Expr{
             .data =
                 mir::CallExpr{
@@ -154,7 +154,7 @@ auto LowerDestructuringAssign(
                         mir::BuiltinFnCallee{.id = support::BuiltinFn::kSlice},
                     .arguments = {temp_ref, offset_id, count_id}},
             .type = slice_type});
-    const mir::ExprId slice_id = wrapper.AddExpr(
+    const mir::ExprId slice_id = wrapper.exprs.Add(
         mir::Expr{
             .data =
                 mir::CallExpr{
@@ -165,7 +165,7 @@ auto LowerDestructuringAssign(
             .type = slice_type});
     mir::ExprId rhs_for_part = slice_id;
     if (part_mir_type != slice_type) {
-      rhs_for_part = wrapper.AddExpr(
+      rhs_for_part = wrapper.exprs.Add(
           mir::Expr{
               .data =
                   mir::ConversionExpr{
@@ -177,18 +177,18 @@ auto LowerDestructuringAssign(
     mir::ExprId per_part_expr_id{};
     if (assign.kind == hir::AssignKind::kBlocking) {
       const mir::ExprId services_id =
-          wrapper.AddExpr(BuildServicesCallExpr(process, wrapper_frame));
+          wrapper.exprs.Add(BuildServicesCallExpr(process, wrapper_frame));
       const mir::Expr part_assign_expr = BuildObservableAssignExpr(
           process.Module().Unit(), wrapper, services_id, part_lhs_id,
           rhs_for_part, std::nullopt, part_mir_type,
           process.Module().Unit().builtins.void_type);
-      per_part_expr_id = wrapper.AddExpr(part_assign_expr);
+      per_part_expr_id = wrapper.exprs.Add(part_assign_expr);
     } else {
       mir::Expr closure_expr = BuildNbaSubmitClosureExpr(
           process.Module(), wrapper_frame, part_lhs_id, rhs_for_part,
           part_mir_type);
-      const mir::ExprId closure_id = wrapper.AddExpr(std::move(closure_expr));
-      per_part_expr_id = wrapper.AddExpr(
+      const mir::ExprId closure_id = wrapper.exprs.Add(std::move(closure_expr));
+      per_part_expr_id = wrapper.exprs.Add(
           mir::Expr{
               .data =
                   mir::RuntimeCallExpr{
@@ -199,7 +199,7 @@ auto LowerDestructuringAssign(
   }
 
   const mir::BlockId wrapper_scope_id =
-      frame.current_block->AddChildScope(std::move(wrapper));
+      frame.current_block->child_scopes.Add(std::move(wrapper));
 
   return mir::Stmt{
       .label = std::move(label),
@@ -254,7 +254,7 @@ auto LowerSubroutineCallWithWritebacks(
   // invariant 11); the SV actuals (with output / inout temps) follow.
   std::vector<mir::ExprId> call_args;
   call_args.reserve(call.arguments.size() + 1);
-  call_args.push_back(wrapper.AddExpr(BuildSelfRefExpr(
+  call_args.push_back(wrapper.exprs.Add(BuildSelfRefExpr(
       wrapper_frame, wrapper_frame.current_class->self_pointer_type)));
   std::vector<OutputArgSlot> writebacks;
 
@@ -265,7 +265,7 @@ auto LowerSubroutineCallWithWritebacks(
           "LowerSubroutineCallWithWritebacks: user-call positional arg "
           "unexpectedly elided");
     }
-    const hir::Expr& hir_arg = hir_proc.exprs.at(call.arguments[i]->value);
+    const hir::Expr& hir_arg = hir_proc.exprs.Get(*call.arguments[i]);
 
     if (!hir::RequiresWriteback(dir)) {
       // A ref / const-ref formal aliases the actual's cell -- pass the cell
@@ -276,42 +276,42 @@ auto LowerSubroutineCallWithWritebacks(
       if (is_ref) {
         auto arg_or = process.LowerLhsExpr(hir_arg, wrapper_frame);
         if (!arg_or) return std::unexpected(std::move(arg_or.error()));
-        mir::ExprId actual_id = wrapper.AddExpr(*std::move(arg_or));
+        mir::ExprId actual_id = wrapper.exprs.Add(*std::move(arg_or));
         const mir::ExprId root_id = FindLhsRootId(wrapper, actual_id);
         const bool root_is_cell = mir::IsObservableCellType(
-            process.Module().Unit().GetType(wrapper.GetExpr(root_id).type));
+            process.Module().Unit().GetType(wrapper.exprs.Get(root_id).type));
         if (root_is_cell && root_id != actual_id) {
           const mir::ExprId services_id =
-              wrapper.AddExpr(BuildServicesCallExpr(process, wrapper_frame));
+              wrapper.exprs.Add(BuildServicesCallExpr(process, wrapper_frame));
           actual_id = RewriteLhsRootWithMutate(
               process.Module().Unit(), wrapper, actual_id, services_id);
         }
         call_args.push_back(BuildReferenceArg(
             process.Module().Unit(), wrapper, actual_id,
-            wrapper.GetExpr(actual_id).type));
+            wrapper.exprs.Get(actual_id).type));
         continue;
       }
       auto arg_or = process.LowerExpr(hir_arg, wrapper_frame);
       if (!arg_or) return std::unexpected(std::move(arg_or.error()));
-      call_args.push_back(wrapper.AddExpr(*std::move(arg_or)));
+      call_args.push_back(wrapper.exprs.Add(*std::move(arg_or)));
       continue;
     }
 
     const mir::TypeId formal_type = process.Module().TranslateType(
-        decl.body.GetProceduralVar(decl.params[i].var).type);
+        decl.body.procedural_vars.Get(decl.params[i].var).type);
     // The actual is the writeback target: lower it as a cell-typed lvalue
     // so an observable destination's writeback fires `Var<T>::Set`.
     auto target_or = process.LowerLhsExpr(hir_arg, wrapper_frame);
     if (!target_or) return std::unexpected(std::move(target_or.error()));
-    const mir::ExprId actual_id = wrapper.AddExpr(*std::move(target_or));
+    const mir::ExprId actual_id = wrapper.exprs.Add(*std::move(target_or));
 
     mir::ExprId init{};
     if (dir == hir::ParamDirection::kInOut) {
       auto value_or = process.LowerExpr(hir_arg, wrapper_frame);
       if (!value_or) return std::unexpected(std::move(value_or.error()));
-      init = wrapper.AddExpr(*std::move(value_or));
+      init = wrapper.exprs.Add(*std::move(value_or));
     } else {
-      init = wrapper.AddExpr(
+      init = wrapper.exprs.Add(
           BuildDefaultValueExpr(process.Module(), wrapper_frame, formal_type));
     }
     const mir::LocalRef temp = wrapper.AppendLocal(
@@ -319,7 +319,7 @@ auto LowerSubroutineCallWithWritebacks(
             .name = "_lyra_arg" + std::to_string(i), .type = formal_type},
         init);
     call_args.push_back(
-        wrapper.AddExpr(mir::Expr{.data = temp, .type = formal_type}));
+        wrapper.exprs.Add(mir::Expr{.data = temp, .type = formal_type}));
     writebacks.push_back(
         {.actual = actual_id, .temp = temp, .type = formal_type});
   }
@@ -334,14 +334,14 @@ auto LowerSubroutineCallWithWritebacks(
 
   std::optional<mir::ExprId> assign_target_id = std::nullopt;
   if (assign_target.has_value()) {
-    auto lhs_or = process.LowerLhsExpr(
-        hir_proc.exprs.at(assign_target->value), wrapper_frame);
+    auto lhs_or =
+        process.LowerLhsExpr(hir_proc.exprs.Get(*assign_target), wrapper_frame);
     if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-    assign_target_id = wrapper.AddExpr(*std::move(lhs_or));
+    assign_target_id = wrapper.exprs.Add(*std::move(lhs_or));
   }
 
   const mir::ExprId services_id =
-      wrapper.AddExpr(BuildServicesCallExpr(process, wrapper_frame));
+      wrapper.exprs.Add(BuildServicesCallExpr(process, wrapper_frame));
   return BuildCopyOutBlock(
       process.Module().Unit(), services_id, frame, std::move(wrapper),
       std::move(label), result_type, std::move(call_expr),
@@ -358,9 +358,9 @@ auto LowerExprStmt(
 
   // LRM 11.4.12 LHS destructuring: detect AssignExpr-with-ConcatExpr-LHS
   // and dispatch to the snapshot+distribute desugar.
-  const hir::Expr& inner = hir_proc.exprs.at(e.expr.value);
+  const hir::Expr& inner = hir_proc.exprs.Get(e.expr);
   if (const auto* assign = std::get_if<hir::AssignExpr>(&inner.data)) {
-    const hir::Expr& lhs = hir_proc.exprs.at(assign->lhs.value);
+    const hir::Expr& lhs = hir_proc.exprs.Get(assign->lhs);
     if (const auto* concat = std::get_if<hir::ConcatExpr>(&lhs.data)) {
       if (assign->compound_op.has_value()) {
         throw InternalError(
@@ -414,7 +414,7 @@ auto LowerExprStmt(
     }
     auto call_or = process.LowerExpr(inner, frame);
     if (!call_or) return std::unexpected(std::move(call_or.error()));
-    const mir::ExprId call_id = block.AddExpr(*std::move(call_or));
+    const mir::ExprId call_id = block.exprs.Add(*std::move(call_or));
     if (suspends) {
       return mir::Stmt{
           .label = std::move(label),
@@ -429,12 +429,12 @@ auto LowerExprStmt(
       // Peek through an implicit conversion wrapper that slang inserts when
       // the call's return type does not match the LHS type bit-for-bit.
       hir::ExprId rhs_id = assign->rhs;
-      const hir::Expr* rhs = &hir_proc.exprs.at(rhs_id.value);
+      const hir::Expr* rhs = &hir_proc.exprs.Get(rhs_id);
       const hir::Expr* call_carrier = rhs;
       std::optional<hir::TypeId> conv_target_type = std::nullopt;
       if (const auto* conv = std::get_if<hir::ConversionExpr>(&rhs->data)) {
         rhs_id = conv->operand;
-        call_carrier = &hir_proc.exprs.at(rhs_id.value);
+        call_carrier = &hir_proc.exprs.Get(rhs_id);
         conv_target_type = rhs->type;
       }
       if (const auto* call = std::get_if<hir::CallExpr>(&call_carrier->data)) {
@@ -466,13 +466,13 @@ auto LowerExprStmt(
     }
   }
 
-  auto expr_or = process.LowerExpr(hir_proc.exprs.at(e.expr.value), frame);
+  auto expr_or = process.LowerExpr(hir_proc.exprs.Get(e.expr), frame);
   if (!expr_or) {
     return std::unexpected(std::move(expr_or.error()));
   }
   return mir::Stmt{
       .label = std::move(label),
-      .data = mir::ExprStmt{.expr = block.AddExpr(*std::move(expr_or))}};
+      .data = mir::ExprStmt{.expr = block.exprs.Add(*std::move(expr_or))}};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/statement/blocks.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/blocks.cpp
@@ -25,7 +25,7 @@ auto LowerBlockStmt(
   mir::Block child_block;
   const WalkFrame child_frame = frame.WithBlock(&child_block).Deeper();
   for (const hir::StmtId child_hir_id : b.statements) {
-    const hir::Stmt& child = hir_proc.stmts.at(child_hir_id.value);
+    const hir::Stmt& child = hir_proc.stmts.Get(child_hir_id);
     auto lowered = process.LowerStmt(child, child_frame);
     if (!lowered) {
       return std::unexpected(std::move(lowered.error()));
@@ -33,7 +33,7 @@ auto LowerBlockStmt(
     child_block.AppendStmt(*std::move(lowered));
   }
   const mir::BlockId scope_id =
-      frame.current_block->AddChildScope(std::move(child_block));
+      frame.current_block->child_scopes.Add(std::move(child_block));
   return mir::Stmt{
       .label = std::move(label), .data = mir::BlockStmt{.scope = scope_id}};
 }
@@ -43,7 +43,7 @@ auto LowerStmtIntoChildScope(
     -> diag::Result<mir::Block> {
   mir::Block child_block;
   const WalkFrame child_frame = frame.WithBlock(&child_block).Deeper();
-  const hir::Stmt& hir_stmt = process.HirBody().stmts.at(hir_stmt_id.value);
+  const hir::Stmt& hir_stmt = process.HirBody().stmts.Get(hir_stmt_id);
   auto lowered = process.LowerStmt(hir_stmt, child_frame);
   if (!lowered) {
     return std::unexpected(std::move(lowered.error()));

--- a/src/lyra/lowering/hir_to_mir/statement/branches.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/branches.cpp
@@ -36,22 +36,22 @@ auto LowerIfStmt(
   }
   auto& block = *frame.current_block;
   auto cond_expr_or =
-      process.LowerExpr(process.HirBody().exprs.at(i.condition.value), frame);
+      process.LowerExpr(process.HirBody().exprs.Get(i.condition), frame);
   if (!cond_expr_or) {
     return std::unexpected(std::move(cond_expr_or.error()));
   }
-  const mir::ExprId cond_id = block.AddExpr(*std::move(cond_expr_or));
+  const mir::ExprId cond_id = block.exprs.Add(*std::move(cond_expr_or));
 
   auto then_or = LowerStmtIntoChildScope(process, frame, i.then_stmt);
   if (!then_or) return std::unexpected(std::move(then_or.error()));
   const mir::BlockId then_scope_id =
-      frame.current_block->AddChildScope(std::move(*then_or));
+      frame.current_block->child_scopes.Add(std::move(*then_or));
 
   std::optional<mir::BlockId> else_scope_id;
   if (i.else_stmt.has_value()) {
     auto else_or = LowerStmtIntoChildScope(process, frame, *i.else_stmt);
     if (!else_or) return std::unexpected(std::move(else_or.error()));
-    else_scope_id = frame.current_block->AddChildScope(std::move(*else_or));
+    else_scope_id = frame.current_block->child_scopes.Add(std::move(*else_or));
   }
 
   return mir::Stmt{
@@ -83,11 +83,11 @@ auto LowerCaseStmt(
   const WalkFrame wrapper_frame = frame.WithBlock(&wrapper).Deeper();
 
   auto cond_or =
-      process.LowerExpr(hir_proc.exprs.at(c.condition.value), wrapper_frame);
+      process.LowerExpr(hir_proc.exprs.Get(c.condition), wrapper_frame);
   if (!cond_or) {
     return std::unexpected(std::move(cond_or.error()));
   }
-  mir::ExprId cond_expr_id = wrapper.AddExpr(*std::move(cond_or));
+  mir::ExprId cond_expr_id = wrapper.exprs.Add(*std::move(cond_or));
 
   // Peel an outer ConversionExpr widening the selector when state-kind is
   // preserved -- the cpp backend cannot init form=explicit from form=int,
@@ -105,9 +105,9 @@ auto LowerCaseStmt(
     return std::nullopt;
   };
   if (const auto* cv = std::get_if<mir::ConversionExpr>(
-          &wrapper.GetExpr(cond_expr_id).data)) {
-    const mir::TypeId dst_tid = wrapper.GetExpr(cond_expr_id).type;
-    const mir::TypeId src_tid = wrapper.GetExpr(cv->operand).type;
+          &wrapper.exprs.Get(cond_expr_id).data)) {
+    const mir::TypeId dst_tid = wrapper.exprs.Get(cond_expr_id).type;
+    const mir::TypeId src_tid = wrapper.exprs.Get(cv->operand).type;
     const auto dst_state = packed_state(dst_tid);
     const auto src_state = packed_state(src_tid);
     if (dst_state.has_value() && src_state.has_value() &&
@@ -163,11 +163,11 @@ auto LowerCaseStmt(
           [&](WalkFrame label_frame,
               std::size_t li) -> diag::Result<mir::ExprId> {
             auto lab_or = process.LowerExpr(
-                hir_proc.exprs.at(item.labels[li].value), label_frame);
+                hir_proc.exprs.Get(item.labels[li]), label_frame);
             if (!lab_or) {
               return std::unexpected(std::move(lab_or.error()));
             }
-            return label_frame.current_block->AddExpr(*std::move(lab_or));
+            return label_frame.current_block->exprs.Add(*std::move(lab_or));
           });
       if (!pred_or) return std::unexpected(std::move(pred_or.error()));
       predicates.push_back(*pred_or);
@@ -194,12 +194,11 @@ auto LowerCaseStmt(
         [&](WalkFrame label_frame,
             std::size_t li) -> diag::Result<mir::ExprId> {
           auto lab_or = process.LowerExpr(
-              hir_proc.exprs.at(c.items[item_idx].labels[li].value),
-              label_frame);
+              hir_proc.exprs.Get(c.items[item_idx].labels[li]), label_frame);
           if (!lab_or) {
             return std::unexpected(std::move(lab_or.error()));
           }
-          return label_frame.current_block->AddExpr(*std::move(lab_or));
+          return label_frame.current_block->exprs.Add(*std::move(lab_or));
         });
   };
 
@@ -218,12 +217,12 @@ auto LowerCaseInsideStmt(
   const WalkFrame wrapper_frame = frame.WithBlock(&wrapper).Deeper();
 
   auto cond_or =
-      process.LowerExpr(hir_proc.exprs.at(c.condition.value), wrapper_frame);
+      process.LowerExpr(hir_proc.exprs.Get(c.condition), wrapper_frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  mir::ExprId cond_expr_id = wrapper.AddExpr(*std::move(cond_or));
+  mir::ExprId cond_expr_id = wrapper.exprs.Add(*std::move(cond_or));
 
   if (const auto* cv = std::get_if<mir::ConversionExpr>(
-          &wrapper.GetExpr(cond_expr_id).data)) {
+          &wrapper.exprs.Get(cond_expr_id).data)) {
     cond_expr_id = cv->operand;
   }
 
@@ -266,7 +265,7 @@ auto LowerCaseInsideStmt(
           std::uint32_t sel_hops) -> diag::Result<mir::ExprId> {
     const WalkFrame level_frame = deeper_by(enc_frame, item_idx);
     auto& enc = *level_frame.current_block;
-    const mir::ExprId sel_ref = enc.AddExpr(
+    const mir::ExprId sel_ref = enc.exprs.Add(
         mir::Expr{
             .data =
                 mir::LocalRef{
@@ -284,7 +283,7 @@ auto LowerCaseInsideStmt(
           process, level_frame, sel_ref, inside_item, bit_type);
       if (!pred_or) return std::unexpected(std::move(pred_or.error()));
       if (acc.has_value()) {
-        acc = enc.AddExpr(
+        acc = enc.exprs.Add(
             mir::Expr{
                 .data =
                     mir::BinaryExpr{

--- a/src/lyra/lowering/hir_to_mir/statement/flow.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/flow.cpp
@@ -48,23 +48,23 @@ auto LowerStaticVarDeclStmt(
   const std::string mangled = std::format(
       "{}__{}_{}", process.CallableName(), hir_local.name, v.var.value);
   const mir::MemberId static_var =
-      owner_class->AddMember(mir::MemberDecl{.name = mangled, .type = type});
+      owner_class->members.Add(mir::MemberDecl{.name = mangled, .type = type});
   process.MapProceduralVar(v.var, StaticVarBinding{.var = static_var});
 
   mir::ExprId init_value{};
   if (v.init.has_value()) {
-    auto init_or = process.LowerExpr(
-        process.HirBody().exprs.at(v.init->value), ctor_frame);
+    auto init_or =
+        process.LowerExpr(process.HirBody().exprs.Get(*v.init), ctor_frame);
     if (!init_or) return std::unexpected(std::move(init_or.error()));
-    init_value = ctor_block.AddExpr(*std::move(init_or));
+    init_value = ctor_block.exprs.Add(*std::move(init_or));
   } else {
-    init_value = ctor_block.AddExpr(
+    init_value = ctor_block.exprs.Add(
         BuildDefaultValueExpr(process.Module(), ctor_frame, type));
   }
 
   const mir::ExprId ctor_self_read =
-      ctor_block.AddExpr(BuildSelfRefExpr(ctor_frame, self_ptr_type));
-  const mir::ExprId target = ctor_block.AddExpr(
+      ctor_block.exprs.Add(BuildSelfRefExpr(ctor_frame, self_ptr_type));
+  const mir::ExprId target = ctor_block.exprs.Add(
       mir::MakeMemberAccessExpr(
           ctor_self_read,
           mir::MemberRef{
@@ -74,13 +74,13 @@ auto LowerStaticVarDeclStmt(
   // declared type is an observable cell wrapper the init must route through
   // `Var<T>::Set` so subscribers fire on its initial value (LRM 13.3.1 +
   // `docs/decisions/value-type-concepts.md`).
-  const mir::ExprId services_id = ctor_block.AddExpr(
+  const mir::ExprId services_id = ctor_block.exprs.Add(
       mir::MakeServicesCallExpr(
           ctor_self_read, process.Module().Unit().builtins.services));
   const mir::Expr assign_expr = BuildObservableAssignExpr(
       process.Module().Unit(), ctor_block, services_id, target, init_value,
       std::nullopt, type, process.Module().Unit().builtins.void_type);
-  const mir::ExprId assign = ctor_block.AddExpr(assign_expr);
+  const mir::ExprId assign = ctor_block.exprs.Add(assign_expr);
   ctor_block.AppendStmt(
       mir::Stmt{.label = std::nullopt, .data = mir::ExprStmt{.expr = assign}});
   return mir::Stmt{.label = std::move(label), .data = mir::EmptyStmt{}};
@@ -92,7 +92,7 @@ auto LowerAutomaticVarDeclStmt(
     mir::TypeId type) -> diag::Result<mir::Stmt> {
   auto& block = *frame.current_block;
   const mir::LocalId local_id =
-      block.AddLocal(mir::LocalDecl{.name = hir_local.name, .type = type});
+      block.vars.Add(mir::LocalDecl{.name = hir_local.name, .type = type});
   process.MapProceduralVar(
       v.var,
       AutomaticVarBinding{
@@ -101,12 +101,12 @@ auto LowerAutomaticVarDeclStmt(
   mir::ExprId init_value{};
   if (v.init.has_value()) {
     auto init_or =
-        process.LowerExpr(process.HirBody().exprs.at(v.init->value), frame);
+        process.LowerExpr(process.HirBody().exprs.Get(*v.init), frame);
     if (!init_or) return std::unexpected(std::move(init_or.error()));
-    init_value = block.AddExpr(*std::move(init_or));
+    init_value = block.exprs.Add(*std::move(init_or));
   } else {
     init_value =
-        block.AddExpr(BuildDefaultValueExpr(process.Module(), frame, type));
+        block.exprs.Add(BuildDefaultValueExpr(process.Module(), frame, type));
   }
 
   return mir::Stmt{
@@ -123,7 +123,7 @@ auto LowerAutomaticVarDeclStmt(
 auto LowerVarDeclStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::VarDeclStmt& v) -> diag::Result<mir::Stmt> {
-  const auto& hir_local = process.HirBody().procedural_vars.at(v.var.value);
+  const auto& hir_local = process.HirBody().procedural_vars.Get(v.var);
   const mir::TypeId type = process.Module().TranslateType(hir_local.type);
   if (hir_local.lifetime == hir::VariableLifetime::kStatic) {
     return LowerStaticVarDeclStmt(
@@ -140,9 +140,9 @@ auto LowerReturnStmt(
   std::optional<mir::ExprId> value;
   if (r.value.has_value()) {
     auto value_or =
-        process.LowerExpr(process.HirBody().exprs.at(r.value->value), frame);
+        process.LowerExpr(process.HirBody().exprs.Get(*r.value), frame);
     if (!value_or) return std::unexpected(std::move(value_or.error()));
-    value = block.AddExpr(*std::move(value_or));
+    value = block.exprs.Add(*std::move(value_or));
   }
   return mir::Stmt{
       .label = std::move(label),

--- a/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
@@ -46,7 +46,7 @@ auto LowerForkStmt(
 
   for (const hir::StmtId local_hir_id : f.locals) {
     auto lowered =
-        process.LowerStmt(hir_proc.stmts.at(local_hir_id.value), fork_frame);
+        process.LowerStmt(hir_proc.stmts.Get(local_hir_id), fork_frame);
     if (!lowered) {
       return std::unexpected(std::move(lowered.error()));
     }
@@ -56,7 +56,7 @@ auto LowerForkStmt(
   std::vector<mir::ExprId> branches;
   branches.reserve(f.branches.size());
   for (const hir::StmtId branch_hir_id : f.branches) {
-    const hir::Stmt& branch = hir_proc.stmts.at(branch_hir_id.value);
+    const hir::Stmt& branch = hir_proc.stmts.Get(branch_hir_id);
     // LRM 9.3.2: a branch is a concurrent thread whose body may suspend on
     // timing controls / event waits, so it lowers as a coroutine closure --
     // returns inside it become `co_return`. A fork-scope local is snapshotted
@@ -69,11 +69,11 @@ auto LowerForkStmt(
       return std::unexpected(std::move(lowered.error()));
     }
     closure.Body().AppendStmt(*std::move(lowered));
-    branches.push_back(fork_block.AddExpr(closure.BuildCoroutine()));
+    branches.push_back(fork_block.exprs.Add(closure.BuildCoroutine()));
   }
 
   const mir::BlockId scope_id =
-      frame.current_block->AddChildScope(std::move(fork_block));
+      frame.current_block->child_scopes.Add(std::move(fork_block));
   return mir::Stmt{
       .label = std::move(label),
       .data = mir::ForkStmt{

--- a/src/lyra/lowering/hir_to_mir/statement/loops.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/loops.cpp
@@ -36,10 +36,10 @@ auto LowerForStmt(
     auto item_or = std::visit(
         Overloaded{
             [&](const hir::ForInitDecl& d) -> diag::Result<mir::ForInit> {
-              const auto& hir_local = hir_proc.procedural_vars.at(d.var.value);
+              const auto& hir_local = hir_proc.procedural_vars.Get(d.var);
               const mir::TypeId type =
                   process.Module().TranslateType(hir_local.type);
-              const mir::LocalId local_id = block.AddLocal(
+              const mir::LocalId local_id = block.vars.Add(
                   mir::LocalDecl{.name = hir_local.name, .type = type});
               process.MapProceduralVar(
                   d.var, AutomaticVarBinding{
@@ -48,13 +48,13 @@ auto LowerForStmt(
               mir::ExprId init_id{};
               if (d.init.has_value()) {
                 auto init_or =
-                    process.LowerExpr(hir_proc.exprs.at(d.init->value), frame);
+                    process.LowerExpr(hir_proc.exprs.Get(*d.init), frame);
                 if (!init_or) {
                   return std::unexpected(std::move(init_or.error()));
                 }
-                init_id = block.AddExpr(*std::move(init_or));
+                init_id = block.exprs.Add(*std::move(init_or));
               } else {
-                init_id = block.AddExpr(
+                init_id = block.exprs.Add(
                     BuildDefaultValueExpr(process.Module(), frame, type));
               }
               return mir::ForInit{mir::ForInitDecl{
@@ -65,12 +65,12 @@ auto LowerForStmt(
             },
             [&](const hir::ForInitExpr& e) -> diag::Result<mir::ForInit> {
               auto expr_or =
-                  process.LowerExpr(hir_proc.exprs.at(e.expr.value), frame);
+                  process.LowerExpr(hir_proc.exprs.Get(e.expr), frame);
               if (!expr_or) {
                 return std::unexpected(std::move(expr_or.error()));
               }
-              return mir::ForInit{
-                  mir::ForInitExpr{.expr = block.AddExpr(*std::move(expr_or))}};
+              return mir::ForInit{mir::ForInitExpr{
+                  .expr = block.exprs.Add(*std::move(expr_or))}};
             },
         },
         hinit);
@@ -80,22 +80,21 @@ auto LowerForStmt(
 
   std::optional<mir::ExprId> cond_id;
   if (f.condition.has_value()) {
-    auto cond_or =
-        process.LowerExpr(hir_proc.exprs.at(f.condition->value), frame);
+    auto cond_or = process.LowerExpr(hir_proc.exprs.Get(*f.condition), frame);
     if (!cond_or) {
       return std::unexpected(std::move(cond_or.error()));
     }
-    cond_id = block.AddExpr(*std::move(cond_or));
+    cond_id = block.exprs.Add(*std::move(cond_or));
   }
 
   std::vector<mir::ExprId> step_ids;
   step_ids.reserve(f.step.size());
   for (const hir::ExprId step_hid : f.step) {
-    auto step_or = process.LowerExpr(hir_proc.exprs.at(step_hid.value), frame);
+    auto step_or = process.LowerExpr(hir_proc.exprs.Get(step_hid), frame);
     if (!step_or) {
       return std::unexpected(std::move(step_or.error()));
     }
-    step_ids.push_back(block.AddExpr(*std::move(step_or)));
+    step_ids.push_back(block.exprs.Add(*std::move(step_or)));
   }
 
   auto body_or = LowerStmtIntoChildScope(process, frame, f.body);
@@ -104,7 +103,7 @@ auto LowerForStmt(
   }
 
   const mir::BlockId body_scope_id =
-      frame.current_block->AddChildScope(std::move(*body_or));
+      frame.current_block->child_scopes.Add(std::move(*body_or));
 
   return mir::Stmt{
       .label = std::move(label),
@@ -124,11 +123,11 @@ auto LowerWhileStmt(
     const hir::WhileStmt& w) -> diag::Result<mir::Stmt> {
   auto& block = *frame.current_block;
   auto cond_or =
-      process.LowerExpr(process.HirBody().exprs.at(w.condition.value), frame);
+      process.LowerExpr(process.HirBody().exprs.Get(w.condition), frame);
   if (!cond_or) {
     return std::unexpected(std::move(cond_or.error()));
   }
-  const mir::ExprId cond_id = block.AddExpr(*std::move(cond_or));
+  const mir::ExprId cond_id = block.exprs.Add(*std::move(cond_or));
 
   auto body_or = LowerStmtIntoChildScope(process, frame, w.body);
   if (!body_or) {
@@ -136,7 +135,7 @@ auto LowerWhileStmt(
   }
 
   const mir::BlockId body_scope_id =
-      frame.current_block->AddChildScope(std::move(*body_or));
+      frame.current_block->child_scopes.Add(std::move(*body_or));
 
   return mir::Stmt{
       .label = std::move(label),
@@ -153,14 +152,14 @@ auto LowerDoWhileStmt(
   }
 
   auto cond_or =
-      process.LowerExpr(process.HirBody().exprs.at(d.condition.value), frame);
+      process.LowerExpr(process.HirBody().exprs.Get(d.condition), frame);
   if (!cond_or) {
     return std::unexpected(std::move(cond_or.error()));
   }
-  const mir::ExprId cond_id = block.AddExpr(*std::move(cond_or));
+  const mir::ExprId cond_id = block.exprs.Add(*std::move(cond_or));
 
   const mir::BlockId body_scope_id =
-      frame.current_block->AddChildScope(std::move(*body_or));
+      frame.current_block->child_scopes.Add(std::move(*body_or));
 
   return mir::Stmt{
       .label = std::move(label),
@@ -176,14 +175,14 @@ auto LowerRepeatStmt(
   mir::Block wrapper;
   const WalkFrame wrapper_frame = frame.WithBlock(&wrapper).Deeper();
 
-  auto count_or = process.LowerExpr(
-      process.HirBody().exprs.at(r.count.value), wrapper_frame);
+  auto count_or =
+      process.LowerExpr(process.HirBody().exprs.Get(r.count), wrapper_frame);
   if (!count_or) {
     return std::unexpected(std::move(count_or.error()));
   }
-  mir::ExprId count_expr_id = wrapper.AddExpr(*std::move(count_or));
-  if (wrapper.GetExpr(count_expr_id).type != int_type) {
-    count_expr_id = wrapper.AddExpr(
+  mir::ExprId count_expr_id = wrapper.exprs.Add(*std::move(count_or));
+  if (wrapper.exprs.Get(count_expr_id).type != int_type) {
+    count_expr_id = wrapper.exprs.Add(
         mir::Expr{
             .data =
                 mir::ConversionExpr{
@@ -192,7 +191,7 @@ auto LowerRepeatStmt(
             .type = int_type});
   }
 
-  const mir::LocalId count_var = wrapper.AddLocal(
+  const mir::LocalId count_var = wrapper.vars.Add(
       mir::LocalDecl{.name = "_lyra_repeat_count", .type = int_type});
 
   wrapper.AppendStmt(
@@ -204,26 +203,26 @@ auto LowerRepeatStmt(
                       .hops = mir::BlockHops{.value = 0}, .var = count_var},
               .init = count_expr_id}});
 
-  const mir::LocalId idx_var = wrapper.AddLocal(
+  const mir::LocalId idx_var = wrapper.vars.Add(
       mir::LocalDecl{.name = "_lyra_repeat_index", .type = int_type});
 
-  const mir::ExprId zero_id = wrapper.AddExpr(
+  const mir::ExprId zero_id = wrapper.exprs.Add(
       mir::MakeInt32Literal(process.Module().Unit().builtins.int32, 0));
-  const mir::ExprId one_id = wrapper.AddExpr(
+  const mir::ExprId one_id = wrapper.exprs.Add(
       mir::MakeInt32Literal(process.Module().Unit().builtins.int32, 1));
 
-  const mir::ExprId idx_ref_cond = wrapper.AddExpr(
+  const mir::ExprId idx_ref_cond = wrapper.exprs.Add(
       mir::Expr{
           .data =
               mir::LocalRef{.hops = mir::BlockHops{.value = 0}, .var = idx_var},
           .type = int_type});
-  const mir::ExprId count_ref_cond = wrapper.AddExpr(
+  const mir::ExprId count_ref_cond = wrapper.exprs.Add(
       mir::Expr{
           .data =
               mir::LocalRef{
                   .hops = mir::BlockHops{.value = 0}, .var = count_var},
           .type = int_type});
-  const mir::ExprId cond_id = wrapper.AddExpr(
+  const mir::ExprId cond_id = wrapper.exprs.Add(
       mir::Expr{
           .data =
               mir::BinaryExpr{
@@ -232,12 +231,12 @@ auto LowerRepeatStmt(
                   .rhs = count_ref_cond},
           .type = bit_type});
 
-  const mir::ExprId idx_ref_step = wrapper.AddExpr(
+  const mir::ExprId idx_ref_step = wrapper.exprs.Add(
       mir::Expr{
           .data =
               mir::LocalRef{.hops = mir::BlockHops{.value = 0}, .var = idx_var},
           .type = int_type});
-  const mir::ExprId add_id = wrapper.AddExpr(
+  const mir::ExprId add_id = wrapper.exprs.Add(
       mir::Expr{
           .data =
               mir::BinaryExpr{
@@ -245,12 +244,12 @@ auto LowerRepeatStmt(
                   .lhs = idx_ref_step,
                   .rhs = one_id},
           .type = int_type});
-  const mir::ExprId step_target_id = wrapper.AddExpr(
+  const mir::ExprId step_target_id = wrapper.exprs.Add(
       mir::Expr{
           .data =
               mir::LocalRef{.hops = mir::BlockHops{.value = 0}, .var = idx_var},
           .type = int_type});
-  const mir::ExprId step_id = wrapper.AddExpr(
+  const mir::ExprId step_id = wrapper.exprs.Add(
       mir::Expr{
           .data = mir::AssignExpr{.target = step_target_id, .value = add_id},
           .type = int_type});
@@ -260,7 +259,8 @@ auto LowerRepeatStmt(
     return std::unexpected(std::move(body_or.error()));
   }
 
-  const mir::BlockId body_scope_id = wrapper.AddChildScope(std::move(*body_or));
+  const mir::BlockId body_scope_id =
+      wrapper.child_scopes.Add(std::move(*body_or));
 
   std::vector<mir::ForInit> for_init;
   for_init.emplace_back(
@@ -279,7 +279,7 @@ auto LowerRepeatStmt(
               .scope = body_scope_id}});
 
   const mir::BlockId wrapper_scope_id =
-      frame.current_block->AddChildScope(std::move(wrapper));
+      frame.current_block->child_scopes.Add(std::move(wrapper));
 
   return mir::Stmt{
       .label = std::move(label),
@@ -295,7 +295,7 @@ auto LowerForeverStmt(
   }
 
   const mir::BlockId body_scope_id =
-      frame.current_block->AddChildScope(std::move(*body_or));
+      frame.current_block->child_scopes.Add(std::move(*body_or));
 
   return mir::Stmt{
       .label = std::move(label),

--- a/src/lyra/lowering/hir_to_mir/statement/timing.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/timing.cpp
@@ -74,7 +74,7 @@ auto ResolveDelayTicks(ProcessLowerer& process, const hir::DelayControl& d)
     -> diag::Result<SimDuration> {
   const DelayTimeResolver resolver{process.Resolution()};
   return ResolveDelayDuration(
-      resolver, process.HirBody().exprs.at(d.duration.value));
+      resolver, process.HirBody().exprs.Get(d.duration));
 }
 
 // LRM 15.5.2 `@e body;`. HIR -> MIR expands the timed statement into a
@@ -89,9 +89,10 @@ auto LowerNamedEventTimedStmt(
   mir::Block child_block;
   const WalkFrame child_frame = frame.WithBlock(&child_block).Deeper();
   auto receiver_or =
-      process.LowerExpr(hir_proc.exprs.at(nec.event.value), child_frame);
+      process.LowerExpr(hir_proc.exprs.Get(nec.event), child_frame);
   if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
-  const mir::ExprId receiver_id = child_block.AddExpr(*std::move(receiver_or));
+  const mir::ExprId receiver_id =
+      child_block.exprs.Add(*std::move(receiver_or));
   mir::Expr await_call{
       .data =
           mir::CallExpr{
@@ -99,19 +100,19 @@ auto LowerNamedEventTimedStmt(
               .arguments = {receiver_id},
           },
       .type = process.Module().Unit().builtins.void_type};
-  const mir::ExprId await_id = child_block.AddExpr(std::move(await_call));
+  const mir::ExprId await_id = child_block.exprs.Add(std::move(await_call));
   child_block.AppendStmt(
       mir::Stmt{
           .label = std::nullopt,
           .data = mir::AwaitStmt{.awaitable = await_id}});
-  const hir::Stmt& inner_hir = hir_proc.stmts.at(t.stmt.value);
+  const hir::Stmt& inner_hir = hir_proc.stmts.Get(t.stmt);
   auto inner_or = process.LowerStmt(inner_hir, child_frame);
   if (!inner_or) {
     return std::unexpected(std::move(inner_or.error()));
   }
   child_block.AppendStmt(*std::move(inner_or));
   const mir::BlockId scope_id =
-      frame.current_block->AddChildScope(std::move(child_block));
+      frame.current_block->child_scopes.Add(std::move(child_block));
   return mir::Stmt{
       .label = std::move(label), .data = mir::BlockStmt{.scope = scope_id}};
 }
@@ -147,14 +148,14 @@ auto LowerEventTimedStmt(
   const WalkFrame child_frame = frame.WithBlock(&child_block).Deeper();
   child_block.AppendStmt(
       BuildSensitivityWaitStmt(process.Owner(), union_reads));
-  const hir::Stmt& inner_hir = process.HirBody().stmts.at(t.stmt.value);
+  const hir::Stmt& inner_hir = process.HirBody().stmts.Get(t.stmt);
   auto inner_or = process.LowerStmt(inner_hir, child_frame);
   if (!inner_or) {
     return std::unexpected(std::move(inner_or.error()));
   }
   child_block.AppendStmt(*std::move(inner_or));
   const mir::BlockId scope_id =
-      frame.current_block->AddChildScope(std::move(child_block));
+      frame.current_block->child_scopes.Add(std::move(child_block));
   return mir::Stmt{
       .label = std::move(label), .data = mir::BlockStmt{.scope = scope_id}};
 }
@@ -168,14 +169,14 @@ auto LowerImplicitEventTimedStmt(
   const WalkFrame child_frame = frame.WithBlock(&child_block).Deeper();
   child_block.AppendStmt(
       BuildSensitivityWaitStmt(process.Owner(), ie.sensitivity_list));
-  const hir::Stmt& inner_hir = process.HirBody().stmts.at(t.stmt.value);
+  const hir::Stmt& inner_hir = process.HirBody().stmts.Get(t.stmt);
   auto inner_or = process.LowerStmt(inner_hir, child_frame);
   if (!inner_or) {
     return std::unexpected(std::move(inner_or.error()));
   }
   child_block.AppendStmt(*std::move(inner_or));
   const mir::BlockId scope_id =
-      frame.current_block->AddChildScope(std::move(child_block));
+      frame.current_block->child_scopes.Add(std::move(child_block));
   return mir::Stmt{
       .label = std::move(label), .data = mir::BlockStmt{.scope = scope_id}};
 }
@@ -195,14 +196,14 @@ auto LowerDelayTimedStmt(
       mir::Stmt{
           .label = std::nullopt,
           .data = mir::DelayStmt{.duration = *ticks_or}});
-  const hir::Stmt& inner_hir = process.HirBody().stmts.at(t.stmt.value);
+  const hir::Stmt& inner_hir = process.HirBody().stmts.Get(t.stmt);
   auto inner_or = process.LowerStmt(inner_hir, child_frame);
   if (!inner_or) {
     return std::unexpected(std::move(inner_or.error()));
   }
   child_block.AppendStmt(*std::move(inner_or));
   const mir::BlockId scope_id =
-      frame.current_block->AddChildScope(std::move(child_block));
+      frame.current_block->child_scopes.Add(std::move(child_block));
   return mir::Stmt{
       .label = std::move(label), .data = mir::BlockStmt{.scope = scope_id}};
 }
@@ -235,15 +236,15 @@ auto LowerEventTriggerStmt(
     const hir::EventTriggerStmt& et) -> diag::Result<mir::Stmt> {
   auto& block = *frame.current_block;
   auto receiver_or =
-      process.LowerExpr(process.HirBody().exprs.at(et.event.value), frame);
+      process.LowerExpr(process.HirBody().exprs.Get(et.event), frame);
   if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
-  const mir::ExprId receiver_id = block.AddExpr(*std::move(receiver_or));
+  const mir::ExprId receiver_id = block.exprs.Add(*std::move(receiver_or));
   // LRM 15.5.1: triggering reaches RuntimeServices to wake subscribers. The
   // engine handle is a real trailing argument, threaded the same way every
   // runtime effect threads it
   // (docs/decisions/runtime-effects-as-generic-calls.md).
   const mir::ExprId services_id =
-      block.AddExpr(BuildServicesCallExpr(process, frame));
+      block.exprs.Add(BuildServicesCallExpr(process, frame));
   mir::Expr call{
       .data =
           mir::CallExpr{
@@ -252,7 +253,7 @@ auto LowerEventTriggerStmt(
               .arguments = {receiver_id, services_id},
           },
       .type = process.Module().Unit().builtins.void_type};
-  const mir::ExprId call_id = block.AddExpr(std::move(call));
+  const mir::ExprId call_id = block.exprs.Add(std::move(call));
   return mir::Stmt{
       .label = std::move(label), .data = mir::ExprStmt{.expr = call_id}};
 }
@@ -265,15 +266,15 @@ auto LowerWaitStmt(
   mir::Block wrapper;
   const WalkFrame wrapper_frame = frame.WithBlock(&wrapper).Deeper();
 
-  const hir::Expr& hir_cond = hir_proc.exprs.at(w.cond.value);
+  const hir::Expr& hir_cond = hir_proc.exprs.Get(w.cond);
   auto cond_or = process.LowerExpr(hir_cond, wrapper_frame);
   if (!cond_or) {
     return std::unexpected(std::move(cond_or.error()));
   }
-  const mir::ExprId cond_id = wrapper.AddExpr(*std::move(cond_or));
-  const mir::TypeId cond_type = wrapper.GetExpr(cond_id).type;
+  const mir::ExprId cond_id = wrapper.exprs.Add(*std::move(cond_or));
+  const mir::TypeId cond_type = wrapper.exprs.Get(cond_id).type;
 
-  const mir::ExprId not_cond_id = wrapper.AddExpr(
+  const mir::ExprId not_cond_id = wrapper.exprs.Add(
       mir::Expr{
           .data =
               mir::UnaryExpr{
@@ -286,7 +287,7 @@ auto LowerWaitStmt(
   inner_block.AppendStmt(BuildSensitivityWaitStmt(process.Owner(), reads));
 
   const mir::BlockId inner_scope_id =
-      wrapper.AddChildScope(std::move(inner_block));
+      wrapper.child_scopes.Add(std::move(inner_block));
 
   wrapper.AppendStmt(
       mir::Stmt{
@@ -294,7 +295,7 @@ auto LowerWaitStmt(
           .data = mir::WhileStmt{
               .condition = not_cond_id, .scope = inner_scope_id}});
 
-  const hir::Stmt& body_hir = hir_proc.stmts.at(w.body.value);
+  const hir::Stmt& body_hir = hir_proc.stmts.Get(w.body);
   auto body_or = process.LowerStmt(body_hir, wrapper_frame);
   if (!body_or) {
     return std::unexpected(std::move(body_or.error()));
@@ -302,7 +303,7 @@ auto LowerWaitStmt(
   wrapper.AppendStmt(*std::move(body_or));
 
   const mir::BlockId wrapper_scope_id =
-      frame.current_block->AddChildScope(std::move(wrapper));
+      frame.current_block->child_scopes.Add(std::move(wrapper));
 
   return mir::Stmt{
       .label = std::move(label),

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -377,7 +377,7 @@ class MirDumper {
             },
             [this](const MethodRef& r) -> std::string {
               const auto& owner = ResolveScopeAtHops(r.hops.value);
-              const auto& target = owner.GetMethod(r.method);
+              const auto& target = owner.methods.Get(r.method);
               return std::format(
                   "MethodRef[hops={}, method={}] \"{}\"", r.hops.value,
                   r.method.value, target.name);
@@ -463,7 +463,7 @@ class MirDumper {
 
   [[nodiscard]] auto FormatExpr(const Block& scope, ExprId id) const
       -> std::string {
-    const auto& e = scope.exprs.at(id.value);
+    const auto& e = scope.exprs.Get(id);
     std::string formatted = std::visit(
         Overloaded{
             [](const IntegerLiteral& lit) -> std::string {
@@ -483,14 +483,14 @@ class MirDumper {
             },
             [this](const ParamRef& r) -> std::string {
               const auto& owner = ResolveScopeAtHops(r.hops.value);
-              const auto& param = owner.GetParam(r.param);
+              const auto& param = owner.params.Get(r.param);
               return std::format(
                   "ParamRef[hops={}, param={}] \"{}\"", r.hops.value,
                   r.param.value, param.name);
             },
             [this](const LocalRef& r) -> std::string {
               const auto& owner = ResolveBlockAtHops(r.hops.value);
-              const auto& var = owner.vars.at(r.var.value);
+              const auto& var = owner.vars.Get(r.var);
               return std::format(
                   "LocalRef[hops={}, var={}] \"{}\"", r.hops.value, r.var.value,
                   var.name);
@@ -633,7 +633,7 @@ class MirDumper {
     for (std::size_t i = 0; i < s.nested_classes.size(); ++i) {
       Line(std::format("[{}]", i));
       Indent();
-      DumpClass(s.nested_classes[i]);
+      DumpClass(s.nested_classes.Get(ClassId{static_cast<std::uint32_t>(i)}));
       Dedent();
     }
     Dedent();
@@ -642,7 +642,7 @@ class MirDumper {
       Line("Params:");
       Indent();
       for (std::size_t i = 0; i < s.params.size(); ++i) {
-        const auto& p = s.params[i];
+        const auto& p = s.params.Get(ParamId{static_cast<std::uint32_t>(i)});
         Line(std::format("[{}] \"{}\" : {}", i, p.name, FormatVarType(p.type)));
       }
       Dedent();
@@ -651,7 +651,7 @@ class MirDumper {
     Line("Members:");
     Indent();
     for (std::size_t i = 0; i < s.members.size(); ++i) {
-      const auto& v = s.members[i];
+      const auto& v = s.members.Get(MemberId{static_cast<std::uint32_t>(i)});
       const std::string as =
           v.source_name.empty() ? "" : std::format(" as \"{}\"", v.source_name);
       Line(
@@ -663,7 +663,7 @@ class MirDumper {
     Line("Methods:");
     Indent();
     for (std::size_t i = 0; i < s.methods.size(); ++i) {
-      DumpMethod(s.methods[i], i);
+      DumpMethod(s.methods.Get(MethodId{static_cast<std::uint32_t>(i)}), i);
     }
     Dedent();
 
@@ -675,7 +675,7 @@ class MirDumper {
     Line("Processes:");
     Indent();
     for (std::size_t i = 0; i < s.processes.size(); ++i) {
-      DumpProcess(s.processes[i], i);
+      DumpProcess(s.processes.Get(ProcessId{static_cast<std::uint32_t>(i)}), i);
     }
     Dedent();
 
@@ -740,7 +740,7 @@ class MirDumper {
       Line("Locals:");
       Indent();
       for (std::size_t i = 0; i < scope.vars.size(); ++i) {
-        const auto& v = scope.vars[i];
+        const auto& v = scope.vars.Get(LocalId{static_cast<std::uint32_t>(i)});
         Line(
             std::format(
                 "Local[{}] \"{}\" : Type[{}]", i, v.name, v.type.value));
@@ -753,7 +753,7 @@ class MirDumper {
       for (std::size_t i = 0; i < scope.exprs.size(); ++i) {
         const ExprId id{static_cast<std::uint32_t>(i)};
         Line(std::format("Expr[{}] {}", i, FormatExpr(scope, id)));
-        const auto& expr = scope.exprs[i];
+        const auto& expr = scope.exprs.Get(id);
         if (const auto* rc = std::get_if<RuntimeCallExpr>(&expr.data)) {
           Indent();
           std::visit(
@@ -841,7 +841,7 @@ class MirDumper {
   void DumpLocalDeclStmt(
       const Block& enclosing, StmtId id, const LocalDeclStmt& s) {
     const auto& owner = ResolveBlockAtHops(s.target.hops.value);
-    const auto& var = owner.vars.at(s.target.var.value);
+    const auto& var = owner.vars.Get(s.target.var);
     Line(
         std::format(
             "Stmt[{}] LocalDeclStmt "
@@ -882,7 +882,7 @@ class MirDumper {
   }
 
   void DumpStmt(const Block& enclosing, StmtId id) {
-    const auto& stmt = enclosing.stmts.at(id.value);
+    const auto& stmt = enclosing.stmts.Get(id);
     if (stmt.label.has_value()) {
       Line(std::format("label: \"{}\"", *stmt.label));
     }
@@ -980,7 +980,7 @@ class MirDumper {
             FormatExpr(enclosing, s.condition)));
     Line(std::format("scope (BlockId={}):", s.scope.value));
     Indent();
-    DumpBlock(enclosing.GetChildScope(s.scope));
+    DumpBlock(enclosing.child_scopes.Get(s.scope));
     Dedent();
     Dedent();
   }
@@ -995,7 +995,7 @@ class MirDumper {
             FormatExpr(enclosing, s.condition)));
     Line(std::format("scope (BlockId={}):", s.scope.value));
     Indent();
-    DumpBlock(enclosing.GetChildScope(s.scope));
+    DumpBlock(enclosing.child_scopes.Get(s.scope));
     Dedent();
     Dedent();
   }
@@ -1196,7 +1196,7 @@ class MirDumper {
                     FormatExpr(enclosing, d.init));
                 const auto& owner =
                     ResolveBlockAtHops(d.induction_var.hops.value);
-                const auto& var = owner.vars.at(d.induction_var.var.value);
+                const auto& var = owner.vars.Get(d.induction_var.var);
                 Line(
                     std::format(
                         "[{}] decl LocalRef[hops={}, var={}] \"{}\"{}", i,
@@ -1232,7 +1232,7 @@ class MirDumper {
     Dedent();
     Line(std::format("scope (BlockId={}):", s.scope.value));
     Indent();
-    DumpBlock(enclosing.GetChildScope(s.scope));
+    DumpBlock(enclosing.child_scopes.Get(s.scope));
     Dedent();
     Dedent();
   }
@@ -1242,7 +1242,7 @@ class MirDumper {
         std::format(
             "Stmt[{}] BlockStmt scope=BlockId{{{}}}", id.value, s.scope.value));
     Indent();
-    DumpBlock(enclosing.GetChildScope(s.scope));
+    DumpBlock(enclosing.child_scopes.Get(s.scope));
     Dedent();
   }
 
@@ -1257,7 +1257,7 @@ class MirDumper {
     }
     Line(std::format("scope (BlockId={}):", s.scope.value));
     Indent();
-    DumpBlock(enclosing.GetChildScope(s.scope));
+    DumpBlock(enclosing.child_scopes.Get(s.scope));
     Dedent();
     Dedent();
   }
@@ -1280,12 +1280,12 @@ class MirDumper {
     Indent();
     Line(std::format("then_scope (BlockId={}):", s.then_scope.value));
     Indent();
-    DumpBlock(enclosing.GetChildScope(s.then_scope));
+    DumpBlock(enclosing.child_scopes.Get(s.then_scope));
     Dedent();
     if (s.else_scope.has_value()) {
       Line(std::format("else_scope (BlockId={}):", s.else_scope->value));
       Indent();
-      DumpBlock(enclosing.GetChildScope(*s.else_scope));
+      DumpBlock(enclosing.child_scopes.Get(*s.else_scope));
       Dedent();
     } else {
       Line("else_scope: <none>");


### PR DESCRIPTION
## Summary

This refactor replaces the many hand-rolled append-only, id-indexed pools across HIR and MIR with a single generic `base::Arena<T, Id>`. Each IR struct -- the HIR procedural body and structural scope, the MIR block and class -- now holds typed `Arena` members directly instead of raw `std::vector`s fronted by per-pool `GetX` / `AddX` forwarder methods. Consumers go through `pool.Get(id)` and `pool.Add(value)` directly, and the forwarders are removed, so each struct becomes a transparent aggregate of its pools.

## Design

The arena's surface is fixed by what consumers actually do: a const lookup by typed id, an append that returns the id, a count and emptiness check, and indexed iteration. It exposes no raw integer index and no mutable lookup. Three shapes are deliberately left in their own form: deduplicating interning tables (type interning), id-sequence fields (a body's root-statement order), and the composite append helpers that coordinate several pools at once (declare-a-local, append-an-if). The change also pays down pre-existing accessor-bypass debt, where sub-nodes were read by indexing a pool's backing vector directly rather than through the typed lookup.