### PR TITLE
Decouple sensitivity footprint from data type

### DIFF
--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -198,7 +198,12 @@ Unlocks `refs/hierarchical_refs`, `refs/upward_refs`, and `instantiation/hierarc
       port with no default; an explicit expression overrides. Defaults are permitted only on input
       ports (LRM 23.2.2.4), which the frontend enforces.
 - [ ] E9 -- A port connection on an instance array drives each element.
-- [ ] E10 -- A port connection whose type is non-integral (an unpacked struct or array).
+- [x] E10 -- A port connection whose type is non-integral resolves as the same implied continuous
+      assignment an integral port does (LRM 23.3.3), with no dependence on the data type: the child
+      cell is driven from, or drives, the parent-side storage, and the output side re-triggers the
+      parent when the child re-drives the whole signal. Covered for a string and an unpacked array
+      connected in both directions. An unpacked struct port rides on unpacked-struct type support
+      and lands with it.
 
 Unlocks the `ports/*` archive group.
 

--- a/include/lyra/hir/stmt.hpp
+++ b/include/lyra/hir/stmt.hpp
@@ -180,14 +180,16 @@ enum class EventEdge : std::uint8_t {
 };
 
 // One leaf entry of a wait's projection set. Identity-only: which structural
-// variable, which flat bit range of its packed encoding, and what edge
-// polarity the leaf was subscribed under. Implicit sensitivity sources
-// (always_comb / always_latch / `@*` / wait cond / continuous assignment)
-// supply leaves with `edge_kind == kAnyChange`. Explicit event control
-// `@(posedge ...)` / `@(negedge ...)` / `@(edge ...)` set the per-leaf edge.
+// variable, the flat-bit footprint of its packed encoding the leaf observes,
+// and what edge polarity the leaf was subscribed under. An absent footprint
+// means the whole signal is observed; an edge then reduces to its LSB. Implicit
+// sensitivity sources (always_comb / always_latch / `@*` / wait cond /
+// continuous assignment) supply leaves with `edge_kind == kAnyChange`. Explicit
+// event control `@(posedge ...)` / `@(negedge ...)` / `@(edge ...)` set the
+// per-leaf edge.
 struct SensitivityEntry {
   SensitivityRef ref;
-  std::pair<std::uint64_t, std::uint64_t> bit_range;
+  std::optional<std::pair<std::uint64_t, std::uint64_t>> footprint;
   EventEdge edge_kind = EventEdge::kAnyChange;
 };
 

--- a/include/lyra/lowering/ast_to_hir/sensitivity.hpp
+++ b/include/lyra/lowering/ast_to_hir/sensitivity.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -20,10 +21,13 @@ class ValueSymbol;
 
 namespace lyra::lowering::ast_to_hir {
 
-// One leaf read produced by `SensitivityAnalyzer`.
+// One leaf read produced by `SensitivityAnalyzer`. `footprint` is the flat-bit
+// range of the read within the symbol's encoding; an absent footprint means the
+// whole signal is observed on any change, the form a non-bit-addressed
+// observation (e.g. a port connection) produces.
 struct SensitivityRead {
-  const slang::ast::ValueSymbol* symbol;
-  std::pair<std::uint64_t, std::uint64_t> bit_range;
+  const slang::ast::ValueSymbol* symbol = nullptr;
+  std::optional<std::pair<std::uint64_t, std::uint64_t>> footprint;
 };
 
 // Reports every value read inside an arbitrary `slang::ast::Expression` or

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -184,14 +184,17 @@ struct AwaitStmt {
   ExprId awaitable;
 };
 
-// One leaf entry of a wait's projection set. Identity-only: which member,
-// which flat bit range of its packed encoding, and what edge
-// polarity the leaf was subscribed under (LRM 9.4.2 / 9.4.2.2 / 9.4.3). slang
-// DFA produces the (var, bit_range) pairs; the SV edge identifier (or
-// `kAnyChange` for implicit sensitivity) attaches per leaf at AST lowering.
+// One leaf entry of a wait's projection set. Identity-only: which member, the
+// observed bit projection of its packed encoding as a `(lsb_bit_offset,
+// bit_width)` pair, and what edge polarity the leaf was subscribed under (LRM
+// 9.4.2 / 9.4.2.2 / 9.4.3). A `bit_width` of 0 is the whole signal observed on
+// any change; an edge reduces to the bit at `lsb_bit_offset`. The projection is
+// resolved at HIR-to-MIR from the SV-level footprint so a backend emits the
+// pair directly. `kAnyChange` is the edge for implicit sensitivity.
 struct SensitivityRead {
   SensitivityRef ref;
-  std::pair<std::uint64_t, std::uint64_t> bit_range;
+  std::uint64_t lsb_bit_offset = 0;
+  std::uint64_t bit_width = 0;
   EventEdge edge_kind = EventEdge::kAnyChange;
 };
 

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -374,13 +374,10 @@ auto RenderSensitivityWaitStmt(
     auto ptr_or = RenderSensitivityRefPtr(view, read.ref);
     if (!ptr_or) return std::unexpected(std::move(ptr_or.error()));
     if (i != 0) result += ", ";
-    // bit_range follows slang's `(lo_bit, hi_bit)` inclusive convention; the
-    // runtime Trigger takes `(lsb_offset, width)`.
-    const auto lsb = read.bit_range.first;
-    const auto width = read.bit_range.second - read.bit_range.first + 1;
     result += "{" + *ptr_or + ", " +
               std::string{RenderEventEdgeAsRuntime(read.edge_kind)} + ", " +
-              std::to_string(lsb) + "ULL, " + std::to_string(width) + "ULL}";
+              std::to_string(read.lsb_bit_offset) + "ULL, " +
+              std::to_string(read.bit_width) + "ULL}";
   }
   result += "});\n";
   return result;

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -417,6 +417,15 @@ class HirDumper {
         ref);
   }
 
+  static auto FormatFootprint(
+      const std::optional<std::pair<std::uint64_t, std::uint64_t>>& footprint)
+      -> std::string {
+    if (!footprint.has_value()) {
+      return "[whole]";
+    }
+    return std::format("[{}:{}]", footprint->first, footprint->second);
+  }
+
   static auto FormatEventEdge(EventEdge edge) -> std::string_view {
     switch (edge) {
       case EventEdge::kAnyChange:
@@ -452,9 +461,9 @@ class HirDumper {
                   if (j != 0) out += ", ";
                   const auto& r = e.triggers[i].sensitivity_list[j];
                   out += std::format(
-                      "{{{} bits=[{}:{}] edge={}}}",
-                      FormatSensitivityRef(r.ref), r.bit_range.first,
-                      r.bit_range.second, FormatEventEdge(r.edge_kind));
+                      "{{{} bits={} edge={}}}", FormatSensitivityRef(r.ref),
+                      FormatFootprint(r.footprint),
+                      FormatEventEdge(r.edge_kind));
                 }
                 out += "]}";
               }
@@ -467,9 +476,8 @@ class HirDumper {
                 if (i != 0) out += ", ";
                 const auto& r = ie.sensitivity_list[i];
                 out += std::format(
-                    "{{{} bits=[{}:{}] edge={}}}", FormatSensitivityRef(r.ref),
-                    r.bit_range.first, r.bit_range.second,
-                    FormatEventEdge(r.edge_kind));
+                    "{{{} bits={} edge={}}}", FormatSensitivityRef(r.ref),
+                    FormatFootprint(r.footprint), FormatEventEdge(r.edge_kind));
               }
               out += "]";
               return out;
@@ -904,8 +912,8 @@ class HirDumper {
       for (const auto& r : p.implicit_sensitivity_list) {
         Line(
             std::format(
-                "{} bits=[{}:{}]", FormatSensitivityRef(r.ref),
-                r.bit_range.first, r.bit_range.second));
+                "{} bits={}", FormatSensitivityRef(r.ref),
+                FormatFootprint(r.footprint)));
       }
       Dedent();
     }
@@ -955,8 +963,8 @@ class HirDumper {
       for (const auto& r : ca.sensitivity_list) {
         Line(
             std::format(
-                "{} bits=[{}:{}]", FormatSensitivityRef(r.ref),
-                r.bit_range.first, r.bit_range.second));
+                "{} bits={}", FormatSensitivityRef(r.ref),
+                FormatFootprint(r.footprint)));
       }
       Dedent();
     }
@@ -1331,8 +1339,8 @@ class HirDumper {
                 if (i != 0) sens += ", ";
                 const auto& r = w.sensitivity_list[i];
                 sens += std::format(
-                    "{{{} bits=[{}:{}]}}", FormatSensitivityRef(r.ref),
-                    r.bit_range.first, r.bit_range.second);
+                    "{{{} bits={}}}", FormatSensitivityRef(r.ref),
+                    FormatFootprint(r.footprint));
               }
               sens += "]";
               Line(

--- a/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
@@ -201,6 +201,16 @@ auto ModuleLowerer::TranslateSensitivityReads(
   for (const auto& read : reads) {
     const auto* var = read.symbol->as_if<slang::ast::VariableSymbol>();
     if (var == nullptr) continue;
+    // A footprint is meaningful only for a signal the runtime bit-addresses: a
+    // packed bit vector, which renders to one observable cell whose change set
+    // is read per bit. For an enum, unpacked aggregate, string, or real the
+    // runtime observes the whole signal on any change, so the read carries no
+    // footprint regardless of the flat-bit view the DFA computed over its own
+    // encoding.
+    const auto& read_type = var->getType();
+    const std::optional<std::pair<std::uint64_t, std::uint64_t>> footprint =
+        read_type.isIntegral() && !read_type.isEnum() ? read.footprint
+                                                      : std::nullopt;
     if (const auto binding = LookupStructuralVarBinding(*var)) {
       const auto hops = frame.HopsTo(binding->home_frame);
       if (!hops.has_value()) continue;
@@ -208,7 +218,7 @@ auto ModuleLowerer::TranslateSensitivityReads(
           hir::SensitivityEntry{
               .ref =
                   hir::StructuralVarRef{.hops = *hops, .var = binding->var_id},
-              .bit_range = read.bit_range});
+              .footprint = footprint});
       continue;
     }
     // A read of a cross-unit member resolves to the slot that body lowering
@@ -218,7 +228,7 @@ auto ModuleLowerer::TranslateSensitivityReads(
       out.push_back(
           hir::SensitivityEntry{
               .ref = hir::CrossUnitVarRef{.id = *slot},
-              .bit_range = read.bit_range});
+              .footprint = footprint});
     }
   }
   return out;

--- a/src/lyra/lowering/ast_to_hir/port_connection.cpp
+++ b/src/lyra/lowering/ast_to_hir/port_connection.cpp
@@ -1,5 +1,5 @@
-#include <cstdint>
 #include <expected>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -167,9 +167,11 @@ auto PopulateInstancePortConnections(
         frame.current_structural_scope->exprs.Add(*std::move(lhs_or));
     const hir::ExprId rhs_id =
         frame.current_structural_scope->exprs.Add(std::move(child_ref));
-    const std::uint64_t width = port_type.getBitWidth();
+    // The output port observes the child's whole internal signal on any change.
+    // It is not a bit-addressed read, so it carries no footprint regardless of
+    // the port's data type.
     const std::vector<SensitivityRead> reads{
-        SensitivityRead{.symbol = internal, .bit_range = {0, width - 1}}};
+        SensitivityRead{.symbol = internal, .footprint = std::nullopt}};
     frame.current_structural_scope->continuous_assigns.Add(
         hir::ContinuousAssign{
             .span = span,

--- a/src/lyra/lowering/ast_to_hir/sensitivity.cpp
+++ b/src/lyra/lowering/ast_to_hir/sensitivity.cpp
@@ -24,7 +24,7 @@ auto FlattenReadSet(const slang::analysis::DFAResults::ReadSet& reads)
   std::vector<SensitivityRead> out;
   for (const auto& [symbol, bitmap] : reads) {
     for (auto it = bitmap.begin(); it != bitmap.end(); ++it) {
-      out.push_back({.symbol = symbol, .bit_range = it.bounds()});
+      out.push_back({.symbol = symbol, .footprint = it.bounds()});
     }
   }
   return out;

--- a/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
+++ b/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
@@ -47,10 +47,20 @@ auto BuildSensitivityWaitStmt(
             },
         },
         entry.ref);
+    // Resolve the SV-level footprint into the runtime projection a backend
+    // emits directly: a bit-addressed read becomes `(lsb, hi - lsb + 1)`; a
+    // whole-signal read (no footprint) becomes width 0, the any-change form.
+    const std::uint64_t lsb_bit_offset =
+        entry.footprint.has_value() ? entry.footprint->first : 0;
+    const std::uint64_t bit_width =
+        entry.footprint.has_value()
+            ? entry.footprint->second - entry.footprint->first + 1
+            : 0;
     reads.push_back(
         mir::SensitivityRead{
             .ref = std::move(ref),
-            .bit_range = entry.bit_range,
+            .lsb_bit_offset = lsb_bit_offset,
+            .bit_width = bit_width,
             .edge_kind = LowerEventEdge(entry.edge_kind)});
   }
   return mir::Stmt{

--- a/src/lyra/lowering/hir_to_mir/statement/timing.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/timing.cpp
@@ -136,9 +136,11 @@ auto LowerEventTimedStmt(
     }
     for (auto leaf : trigger.sensitivity_list) {
       // LRM 9.4.2 LSB-reduce: an edge event monitors only the LSB of the
-      // expression.
-      if (leaf.edge_kind != hir::EventEdge::kAnyChange) {
-        leaf.bit_range = {leaf.bit_range.first, leaf.bit_range.first};
+      // expression. A whole-signal footprint already reduces to the LSB at the
+      // runtime trigger, so only a bit-addressed footprint needs collapsing.
+      if (leaf.edge_kind != hir::EventEdge::kAnyChange &&
+          leaf.footprint.has_value()) {
+        leaf.footprint = {{leaf.footprint->first, leaf.footprint->first}};
       }
       union_reads.push_back(leaf);
     }

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -962,8 +962,8 @@ class MirDumper {
                     r.ref.var.value);
                 Line(
                     std::format(
-                        "{} bits=[{}:{}] edge={}", ref_str, r.bit_range.first,
-                        r.bit_range.second, FormatEventEdge(r.edge_kind)));
+                        "{} lsb={} width={} edge={}", ref_str, r.lsb_bit_offset,
+                        r.bit_width, FormatEventEdge(r.edge_kind)));
               }
               Dedent();
             },

--- a/tests/cases/cpp/port_nonintegral/case.yaml
+++ b/tests/cases/cpp/port_nonintegral/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stdout:
-    exact: "len=5\n"
+    exact: "back=hello sum=34\n"

--- a/tests/cases/cpp/port_nonintegral/main.sv
+++ b/tests/cases/cpp/port_nonintegral/main.sv
@@ -1,19 +1,30 @@
-// A non-integral input port (here a string) drives the child cell like an
-// integral one (LRM 23.3.3).
-module Child(input string label, output int outlen);
-  always_comb outlen = label.len();
+// A non-integral port drives the child cell like an integral one (LRM 23.3.3):
+// the connection is a continuous assignment between the two objects' own
+// storage, in either direction. Covers a string and an unpacked array, each
+// connected as both an input and an output, with an integral output as the
+// control. The output side re-triggers when the child re-drives it.
+module Child(
+    input string label, output string echo, input int din [2],
+    output int dsum);
+  always_comb echo = label;
+  always_comb dsum = din[0] + din[1];
 endmodule
 
 module Top;
   string s;
-  int len;
-  Child u(.label(s), .outlen(len));
+  string back;
+  int arr [2];
+  int sum;
+  Child u(.label(s), .echo(back), .din(arr), .dsum(sum));
 
   initial begin
     s = "hi";
+    arr[0] = 3;
+    arr[1] = 4;
     #5;
     s = "hello";
+    arr[0] = 30;
   end
 
-  final $display("len=%0d", len);
+  final $display("back=%s sum=%0d", back, sum);
 endmodule


### PR DESCRIPTION
## Summary

A combinational process's sensitivity leaf carried a mandatory bit range, which forced the only producer without a source expression -- an output port connection -- to fabricate one from the port type's bit width. For a non-integral type that width is zero, so the fabrication underflowed into a meaningless range that the runtime silently ignored. This coupled the type-agnostic port layer to a data-type concept and left the sensitivity model unable to express "observe the whole signal."

The sensitivity leaf now carries an optional footprint: present (with an inclusive bit range) only when the observed signal is bit-addressed, absent when the whole signal is observed on any change. An output port produces no footprint regardless of its data type, so a string, an unpacked array, or any other non-integral port connects in either direction with no special handling. As a side effect this completes E10 (non-integral port connections).

## Design

The footprint stays optional across AST and HIR, where it is the SV-level "which bits" concept. At HIR-to-MIR it resolves once into the runtime projection `(lsb_bit_offset, bit_width)` -- a whole-signal read becomes width 0 -- so the backend renders the trigger mechanically with no per-backend decision, matching the MIR contract that every semantic decision is explicit in MIR's structure.

A footprint is meaningful only for a signal the runtime bit-addresses (a packed bit vector). The single translation point drops the footprint for an enum, unpacked aggregate, string, or real, so the invariant "a non-zero-width footprint exists exactly when the runtime monitors those bits" holds and no dead, type-derived bit coordinate reaches the emitted code.

## Testing

`bazel test //...`. The non-integral port case now covers a string and an unpacked array connected as both input and output, with an integral output as the control.