### PR TITLE
Share HIR-to-MIR expression handlers via templates

### DIFF
--- a/docs/architecture/lowering_organization.md
+++ b/docs/architecture/lowering_organization.md
@@ -188,6 +188,21 @@ threaded down, a per-callable-body temp counter) is defined separately under "Re
     `lowerer.Module().InternType(...)`. `proc.Module()` returns the `ModuleLowerer&` the
     `ProcessLowerer` captured at construction.
 
+13. A per-kind handler whose logic is shared across pass classes is one function template
+    parameterized over the pass class, never a per-pass-class twin. A node's meaning that does not
+    depend on which pass class encloses it -- an expression operating on already-lowered operands --
+    is context-free, and its handler reaches the pass class through a uniform duck-typed surface
+    (the recursion entry point, the sub-node accessor) rather than a shared base class. A handler
+    stays per-pass-class only where the two genuinely differ: name resolution, where a bare name
+    maps to different storage depending on the enclosing scope, and kinds that exist in only one
+    context.
+
+    _Current implementation:_ the HIR-to-MIR expression handlers shared by `ProcessLowerer` and
+    `ClassLowerer` (operators, selects, aggregate value-builds) are single function templates over
+    the pass class, reaching sub-expressions through a uniform `HirExprs()` accessor and recursing
+    through `LowerExpr` / `LowerLhsExpr`; explicit instantiations for the two pass classes live in
+    the subsystem `.cpp`. Name resolution (`references.cpp`) stays a per-pass-class pair.
+
 ## The Walk Position
 
 Every pass over an IR is a recursion, and at each node the recursion needs context that is not in
@@ -339,6 +354,10 @@ structured-IR emit is a construction pass.
 - Per-kind handlers requiring narrowed access (separate facts / registry / builder references in the
   signature). The pass class instance is the single access pass for the task; narrowing the
   signature reproduces the sig-explosion shape this contract exists to escape.
+- A per-kind handler twin: two near-identical handlers for one node kind, one per pass class,
+  differing only in the pass type and how a sub-node is reached. When the logic is context-free, the
+  twin is one function template over the pass class (invariant 13); the twin shape lets the two
+  drift, the exact failure the template removes.
 
 ## Multi-File Organization Within a Pass Layer
 

--- a/docs/progress/generic-lowering.md
+++ b/docs/progress/generic-lowering.md
@@ -10,9 +10,11 @@ rejected alternatives.
 
 ## Actionable
 
-Phase 1 (the generic arena) is standalone and can start immediately. The arena swap is mechanical
-and behavior-preserving; the bulk of the work is paying down the existing accessor-bypass debt that
-the swap surfaces (see below). Phases 2 and 3 build on it.
+The generic arena (Phase 1) and the HIR-to-MIR handler-sharing it enables (Phase 2) have landed: the
+context-free HIR-to-MIR expression handlers shared by the procedural and structural pass classes are
+now single function templates. What remains is the AST-to-HIR slice -- unifying that pass's
+expression write target and collapsing its handler twins the same way -- which is gated on the
+in-flight drift-bug alignment (see Coordination).
 
 The arena's surface is fixed by what consumers actually do: a const lookup by typed id, an append
 that returns the id, a count and an emptiness check, and an indexed iteration (the dumper prints
@@ -27,30 +29,30 @@ underneath.
 
 ### Phase 1 -- Generic arena and uniform access
 
-- [ ] Introduce one generic append-only, id-indexed pool abstraction with the surface above (const
+- [x] Introduce one generic append-only, id-indexed pool abstraction with the surface above (const
       lookup, append, count, indexed iteration; no raw index, no mutable lookup).
-- [ ] Route every hand-rolled HIR pool through it: the procedural body's expression, statement, and
+- [x] Route every hand-rolled HIR pool through it: the procedural body's expression, statement, and
       local pools; every append-only pool on the structural scope.
-- [ ] Route every hand-rolled MIR pool through it: the block's expression, statement, and local
+- [x] Route every hand-rolled MIR pool through it: the block's expression, statement, and local
       pools, the class's pools, and the unit's append-only pools.
-- [ ] Replace the raw-index accessor bypass (sub-nodes read by indexing the pool's backing vector
+- [x] Replace the raw-index accessor bypass (sub-nodes read by indexing the pool's backing vector
       directly rather than through the typed lookup) with the typed lookup. This is pre-existing
       debt, not new work; fixing it also collapses the procedural/structural read-access divergence,
       so the read side of sub-node access is uniform once this lands.
 - [ ] AST-to-HIR: the walk position carries one expression write target instead of two parallel
       ones, with the statement and member write targets kept separate. With both scopes' expression
       pools now the same arena type, the read and write sides of sub-node access are both uniform.
-- [ ] Leave deduplicating pools (type interning), id-sequence fields, and composite append helpers
+- [x] Leave deduplicating pools (type interning), id-sequence fields, and composite append helpers
       in their own shapes (see Actionable).
 
 ### Phase 2 -- Share the expression handlers
 
-- [ ] HIR-to-MIR: each expression family's procedural and structural handlers become one function
+- [x] HIR-to-MIR: each expression family's procedural and structural handlers become one function
       template over the pass class. Pilot with the select family (the largest duplication), then the
       remaining families.
 - [ ] AST-to-HIR: the same collapse, sequenced after the in-flight drift-bug alignment lands (see
       Coordination).
-- [ ] `lowering_organization.md` records that a handler shared across pass classes is one template,
+- [x] `lowering_organization.md` records that a handler shared across pass classes is one template,
       never a duplicated twin.
 
 ## Coordination

--- a/include/lyra/lowering/hir_to_mir/class_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/class_lowerer.hpp
@@ -101,6 +101,14 @@ class ClassLowerer {
     return *hir_scope_;
   }
 
+  // The expression arena of the scope being lowered. The single uniform
+  // sub-expression accessor the context-free expression handler templates
+  // reach through, identical in shape to `ProcessLowerer::HirExprs`.
+  [[nodiscard]] auto HirExprs() const
+      -> const base::Arena<hir::Expr, hir::ExprId>& {
+    return hir_scope_->exprs;
+  }
+
   // Resolve a subroutine reference to its HIR declaration by walking `hops`
   // scopes outward. The HIR declaration is complete before any body is lowered,
   // so a call can read a peer's formals even when the peer's MIR declaration is

--- a/include/lyra/lowering/hir_to_mir/expression/aggregates.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/aggregates.hpp
@@ -8,7 +8,7 @@
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
@@ -16,42 +16,35 @@
 
 namespace lyra::lowering::hir_to_mir {
 
-auto LowerHirConcatExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::ConcatExpr& c,
+// An aggregate value-build's meaning is independent of the enclosing scope, so
+// one template over the pass class serves both contexts. Explicit
+// instantiations for the two pass classes live in the implementation file.
+template <ExprLowerer Lowerer>
+auto LowerHirConcatExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::ConcatExpr& c,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
-auto LowerHirReplicationExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::ReplicationExpr& r,
+template <ExprLowerer Lowerer>
+auto LowerHirAssignmentPatternExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::AssignmentPatternExpr& a,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
-auto LowerHirAssignmentPatternExprProc(
-    ProcessLowerer& process, WalkFrame frame,
-    const hir::AssignmentPatternExpr& a, mir::TypeId result_type)
-    -> diag::Result<mir::Expr>;
-auto LowerHirAssignmentPatternReplicationExprProc(
-    ProcessLowerer& process, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerHirAssignmentPatternReplicationExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const hir::AssignmentPatternReplicationExpr& a, mir::TypeId result_type)
     -> diag::Result<mir::Expr>;
-auto LowerHirDynamicArrayNewExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::DynamicArrayNewExpr& n,
-    mir::TypeId result_type) -> diag::Result<mir::Expr>;
-auto LowerHirAssociativeAssignmentPatternExprProc(
-    ProcessLowerer& process, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerHirAssociativeAssignmentPatternExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const hir::AssociativeAssignmentPatternExpr& a, mir::TypeId result_type)
     -> diag::Result<mir::Expr>;
 
-auto LowerHirConcatExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame, const hir::ConcatExpr& c,
+// Replication and `new[]` appear only in procedural value-build positions, so
+// they stay procedural-only handlers rather than shared templates.
+auto LowerHirReplicationExprProc(
+    ProcessLowerer& process, WalkFrame frame, const hir::ReplicationExpr& r,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
-auto LowerHirAssignmentPatternExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::AssignmentPatternExpr& a, mir::TypeId result_type)
-    -> diag::Result<mir::Expr>;
-auto LowerHirAssignmentPatternReplicationExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::AssignmentPatternReplicationExpr& a, mir::TypeId result_type)
-    -> diag::Result<mir::Expr>;
-auto LowerHirAssociativeAssignmentPatternExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::AssociativeAssignmentPatternExpr& a, mir::TypeId result_type)
-    -> diag::Result<mir::Expr>;
+auto LowerHirDynamicArrayNewExprProc(
+    ProcessLowerer& process, WalkFrame frame, const hir::DynamicArrayNewExpr& n,
+    mir::TypeId result_type) -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <concepts>
+
+#include "lyra/base/arena.hpp"
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/expr_id.hpp"
+#include "lyra/lowering/hir_to_mir/walk_frame.hpp"
+#include "lyra/mir/expr.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// The duck-typed contract a pass class fulfils for context-free expression
+// lowering: recurse into a sub-expression (read or lhs context), reach the HIR
+// expression arena, and reach the enclosing module. `ProcessLowerer`
+// (procedural bodies) and `ClassLowerer` (structural scopes) both satisfy it;
+// the shared per-expression handler templates are constrained on it so the
+// surface they depend on is named and checked rather than surfacing as a deep
+// template error. It is deliberately not a base class -- the two pass classes
+// build different things and share no v-table
+// (decisions/generic-lowering-machinery.md).
+template <typename L>
+concept ExprLowerer =
+    requires(L& lowerer, const hir::Expr& expr, WalkFrame frame) {
+      {
+        lowerer.LowerExpr(expr, frame)
+      } -> std::same_as<diag::Result<mir::Expr>>;
+      {
+        lowerer.LowerLhsExpr(expr, frame)
+      } -> std::same_as<diag::Result<mir::Expr>>;
+      {
+        lowerer.HirExprs()
+      } -> std::convertible_to<const base::Arena<hir::Expr, hir::ExprId>&>;
+      lowerer.Module();
+    };
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/expression/operators.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/operators.hpp
@@ -6,7 +6,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/binary_op.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/binary_op.hpp"
@@ -22,37 +22,32 @@ namespace lyra::lowering::hir_to_mir {
 // is a legitimate target).
 auto LowerBinaryOp(hir::BinaryOp op) -> mir::BinaryOp;
 
-// Procedural-context handlers.
-auto LowerHirUnaryExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::UnaryExpr& u,
+// An operator's meaning is independent of the enclosing scope, so one template
+// over the pass class serves both the procedural and structural contexts. The
+// pass class is reached through a uniform `HirExprs` / `LowerExpr` surface, so
+// the body deduces from the argument; explicit instantiations for the two pass
+// classes live in the implementation file.
+template <ExprLowerer Lowerer>
+auto LowerHirUnaryExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::UnaryExpr& u,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
-auto LowerHirBinaryExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::BinaryExpr& b,
+template <ExprLowerer Lowerer>
+auto LowerHirBinaryExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::BinaryExpr& b,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
-auto LowerHirConditionalExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::ConditionalExpr& c,
+template <ExprLowerer Lowerer>
+auto LowerHirConditionalExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::ConditionalExpr& c,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
-auto LowerHirIncDecExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::IncDecExpr& inc,
-    mir::TypeId result_type) -> diag::Result<mir::Expr>;
-auto LowerHirConversionExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::ConversionExpr& cv,
+template <ExprLowerer Lowerer>
+auto LowerHirConversionExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::ConversionExpr& cv,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
 
-// Structural-context handlers (constructor / generate-control / continuous
-// assign). `IncDecExpr` and `AssignExpr` have no structural form -- those
-// kinds are diagnosed at the dispatcher.
-auto LowerHirUnaryExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame, const hir::UnaryExpr& u,
-    mir::TypeId result_type) -> diag::Result<mir::Expr>;
-auto LowerHirBinaryExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame, const hir::BinaryExpr& b,
-    mir::TypeId result_type) -> diag::Result<mir::Expr>;
-auto LowerHirConditionalExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame, const hir::ConditionalExpr& c,
-    mir::TypeId result_type) -> diag::Result<mir::Expr>;
-auto LowerHirConversionExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame, const hir::ConversionExpr& cv,
+// Increment / decrement is a write (LRM 11.4.2) and has no structural form, so
+// it stays a procedural-only handler rather than a shared template.
+auto LowerHirIncDecExprProc(
+    ProcessLowerer& process, WalkFrame frame, const hir::IncDecExpr& inc,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/expression/selects.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/selects.hpp
@@ -6,61 +6,43 @@
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
-#include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/type_id.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
-auto LowerHirElementSelectExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::ElementSelectExpr& sel,
+// A select's meaning is independent of the enclosing scope, so one template
+// over the pass class serves both the procedural and structural contexts;
+// explicit instantiations live in the implementation file.
+template <ExprLowerer Lowerer>
+auto LowerHirElementSelectExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::ElementSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
-auto LowerHirRangeSelectExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::RangeSelectExpr& sel,
+template <ExprLowerer Lowerer>
+auto LowerHirRangeSelectExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::RangeSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
-auto LowerHirMemberAccessExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::MemberAccessExpr& sel,
+template <ExprLowerer Lowerer>
+auto LowerHirMemberAccessExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::MemberAccessExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
 
 // LHS-context selector lowerings: like the read-context handlers but the
 // base lowers through `LowerLhsExpr`, leaving the chain cell-rooted with no
 // `ObservableMethod{kGet}` wrap.
-auto LowerHirElementSelectExprProcLhs(
-    ProcessLowerer& process, WalkFrame frame, const hir::ElementSelectExpr& sel,
+template <ExprLowerer Lowerer>
+auto LowerHirElementSelectExprLhs(
+    Lowerer& lowerer, WalkFrame frame, const hir::ElementSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
-auto LowerHirRangeSelectExprProcLhs(
-    ProcessLowerer& process, WalkFrame frame, const hir::RangeSelectExpr& sel,
+template <ExprLowerer Lowerer>
+auto LowerHirRangeSelectExprLhs(
+    Lowerer& lowerer, WalkFrame frame, const hir::RangeSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
-auto LowerHirMemberAccessExprProcLhs(
-    ProcessLowerer& process, WalkFrame frame, const hir::MemberAccessExpr& sel,
+template <ExprLowerer Lowerer>
+auto LowerHirMemberAccessExprLhs(
+    Lowerer& lowerer, WalkFrame frame, const hir::MemberAccessExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
-
-auto LowerHirElementSelectExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::ElementSelectExpr& sel, mir::TypeId result_type)
-    -> diag::Result<mir::Expr>;
-auto LowerHirRangeSelectExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::RangeSelectExpr& sel, mir::TypeId result_type)
-    -> diag::Result<mir::Expr>;
-auto LowerHirMemberAccessExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::MemberAccessExpr& sel, mir::TypeId result_type)
-    -> diag::Result<mir::Expr>;
-
-auto LowerHirElementSelectExprStructuralLhs(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::ElementSelectExpr& sel, mir::TypeId result_type)
-    -> diag::Result<mir::Expr>;
-auto LowerHirRangeSelectExprStructuralLhs(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::RangeSelectExpr& sel, mir::TypeId result_type)
-    -> diag::Result<mir::Expr>;
-auto LowerHirMemberAccessExprStructuralLhs(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::MemberAccessExpr& sel, mir::TypeId result_type)
-    -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
@@ -106,6 +106,14 @@ class ProcessLowerer {
     return *hir_body_;
   }
 
+  // The expression arena of the body being lowered. The single uniform
+  // sub-expression accessor the context-free expression handler templates
+  // reach through, identical in shape to `ClassLowerer::HirExprs`.
+  [[nodiscard]] auto HirExprs() const
+      -> const base::Arena<hir::Expr, hir::ExprId>& {
+    return hir_body_->exprs;
+  }
+
   [[nodiscard]] auto Module() -> ModuleLowerer& {
     return *module_;
   }

--- a/include/lyra/lowering/hir_to_mir/snapshot_local.hpp
+++ b/include/lyra/lowering/hir_to_mir/snapshot_local.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+
+#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/walk_frame.hpp"
+#include "lyra/mir/expr_id.hpp"
+#include "lyra/mir/local.hpp"
+#include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type_id.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// Materialises an already-lowered expression into a fresh zero-hop local in
+// `wrapper`: declares the local with its type's default initialiser, then
+// assigns `expr_id` to it. The decl and assign are split (rather than a single
+// var-decl-with-init) so the cpp backend's packed-init gap does not bite when
+// the type unifies to a packed-explicit form. Cascade lowerings use this to
+// snapshot a selector or predicate once before an if-then-else chain reads it
+// repeatedly.
+auto SnapshotExprToLocal(
+    const ModuleLowerer& module, WalkFrame frame, mir::Block& wrapper,
+    std::string name, mir::TypeId type, mir::ExprId expr_id) -> mir::LocalId;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/walk_frame.hpp
+++ b/include/lyra/lowering/hir_to_mir/walk_frame.hpp
@@ -165,6 +165,17 @@ struct WalkFrame {
     return next;
   }
 
+  // Descend `extras` block-nesting levels at once. A construct lowered as a
+  // chain of nested scopes (a case cascade's if-then-else chain) enters its
+  // Nth body `extras = N` levels below the wrapper.
+  [[nodiscard]] auto DeeperBy(std::size_t extras) const -> WalkFrame {
+    WalkFrame next = *this;
+    for (std::size_t i = 0; i < extras; ++i) {
+      next.block_depth = next.block_depth.Inner();
+    }
+    return next;
+  }
+
   [[nodiscard]] auto WithCaptureSink(CaptureSink* sink) const -> WalkFrame {
     WalkFrame next = *this;
     next.capture_sink = sink;

--- a/src/lyra/lowering/hir_to_mir/case_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/case_cascade.cpp
@@ -1,9 +1,6 @@
 #include "lyra/lowering/hir_to_mir/case_cascade.hpp"
 
-#include <optional>
-
-#include "lyra/lowering/hir_to_mir/default_value.hpp"
-#include "lyra/mir/block_hops.hpp"
+#include "lyra/lowering/hir_to_mir/snapshot_local.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/local.hpp"
 #include "lyra/mir/stmt.hpp"
@@ -15,34 +12,8 @@ auto AppendCaseSnapshot(
     -> CaseSnapshotRefs {
   auto& wrapper = *frame.current_block;
   const mir::TypeId sel_type = wrapper.exprs.Get(cond_expr_id).type;
-
-  const mir::LocalId sel_var = wrapper.vars.Add(
-      mir::LocalDecl{.name = "_lyra_case_sel", .type = sel_type});
-  const mir::ExprId sel_default_init =
-      wrapper.exprs.Add(BuildDefaultValueExpr(module, frame, sel_type));
-  wrapper.AppendStmt(
-      mir::Stmt{
-          .label = std::nullopt,
-          .data = mir::LocalDeclStmt{
-              .target =
-                  mir::LocalRef{
-                      .hops = mir::BlockHops{.value = 0}, .var = sel_var},
-              .init = sel_default_init}});
-
-  const mir::ExprId sel_target_id = wrapper.exprs.Add(
-      mir::Expr{
-          .data =
-              mir::LocalRef{.hops = mir::BlockHops{.value = 0}, .var = sel_var},
-          .type = sel_type});
-  const mir::ExprId sel_assign_id = wrapper.exprs.Add(
-      mir::Expr{
-          .data =
-              mir::AssignExpr{.target = sel_target_id, .value = cond_expr_id},
-          .type = sel_type});
-  wrapper.AppendStmt(
-      mir::Stmt{
-          .label = std::nullopt, .data = mir::ExprStmt{.expr = sel_assign_id}});
-
+  const mir::LocalId sel_var = SnapshotExprToLocal(
+      module, frame, wrapper, "_lyra_case_sel", sel_type, cond_expr_id);
   return CaseSnapshotRefs{.sel_var = sel_var, .sel_type = sel_type};
 }
 

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -943,14 +943,13 @@ auto ClassLowerer::LowerExpr(const hir::Expr& expr, WalkFrame frame) const
                 *this, frame, p.data, result_type);
           },
           [&](const hir::UnaryExpr& u) -> diag::Result<mir::Expr> {
-            return LowerHirUnaryExprStructural(*this, frame, u, result_type);
+            return LowerHirUnaryExpr(*this, frame, u, result_type);
           },
           [&](const hir::BinaryExpr& b) -> diag::Result<mir::Expr> {
-            return LowerHirBinaryExprStructural(*this, frame, b, result_type);
+            return LowerHirBinaryExpr(*this, frame, b, result_type);
           },
           [&](const hir::ConditionalExpr& c) -> diag::Result<mir::Expr> {
-            return LowerHirConditionalExprStructural(
-                *this, frame, c, result_type);
+            return LowerHirConditionalExpr(*this, frame, c, result_type);
           },
           [](const hir::AssignExpr&) -> diag::Result<mir::Expr> {
             throw InternalError(
@@ -965,8 +964,7 @@ auto ClassLowerer::LowerExpr(const hir::Expr& expr, WalkFrame frame) const
                 "no increment / decrement");
           },
           [&](const hir::ConversionExpr& cv) -> diag::Result<mir::Expr> {
-            return LowerHirConversionExprStructural(
-                *this, frame, cv, result_type);
+            return LowerHirConversionExpr(*this, frame, cv, result_type);
           },
           [](const hir::CallExpr&) -> diag::Result<mir::Expr> {
             return diag::Unsupported(
@@ -981,19 +979,16 @@ auto ClassLowerer::LowerExpr(const hir::Expr& expr, WalkFrame frame) const
                 diag::UnsupportedCategory::kFeature);
           },
           [&](const hir::ElementSelectExpr& s) -> diag::Result<mir::Expr> {
-            return LowerHirElementSelectExprStructural(
-                *this, frame, s, result_type);
+            return LowerHirElementSelectExpr(*this, frame, s, result_type);
           },
           [&](const hir::RangeSelectExpr& s) -> diag::Result<mir::Expr> {
-            return LowerHirRangeSelectExprStructural(
-                *this, frame, s, result_type);
+            return LowerHirRangeSelectExpr(*this, frame, s, result_type);
           },
           [&](const hir::MemberAccessExpr& s) -> diag::Result<mir::Expr> {
-            return LowerHirMemberAccessExprStructural(
-                *this, frame, s, result_type);
+            return LowerHirMemberAccessExpr(*this, frame, s, result_type);
           },
           [&](const hir::ConcatExpr& c) -> diag::Result<mir::Expr> {
-            return LowerHirConcatExprStructural(*this, frame, c, result_type);
+            return LowerHirConcatExpr(*this, frame, c, result_type);
           },
           [](const hir::ReplicationExpr&) -> diag::Result<mir::Expr> {
             return diag::Unsupported(
@@ -1002,12 +997,11 @@ auto ClassLowerer::LowerExpr(const hir::Expr& expr, WalkFrame frame) const
                 diag::UnsupportedCategory::kFeature);
           },
           [&](const hir::AssignmentPatternExpr& a) -> diag::Result<mir::Expr> {
-            return LowerHirAssignmentPatternExprStructural(
-                *this, frame, a, result_type);
+            return LowerHirAssignmentPatternExpr(*this, frame, a, result_type);
           },
           [&](const hir::AssignmentPatternReplicationExpr& a)
               -> diag::Result<mir::Expr> {
-            return LowerHirAssignmentPatternReplicationExprStructural(
+            return LowerHirAssignmentPatternReplicationExpr(
                 *this, frame, a, result_type);
           },
           [](const hir::DynamicArrayNewExpr&) -> diag::Result<mir::Expr> {
@@ -1019,7 +1013,7 @@ auto ClassLowerer::LowerExpr(const hir::Expr& expr, WalkFrame frame) const
           },
           [&](const hir::AssociativeAssignmentPatternExpr& a)
               -> diag::Result<mir::Expr> {
-            return LowerHirAssociativeAssignmentPatternExprStructural(
+            return LowerHirAssociativeAssignmentPatternExpr(
                 *this, frame, a, result_type);
           },
       },
@@ -1046,19 +1040,16 @@ auto ClassLowerer::LowerLhsExpr(const hir::Expr& expr, WalkFrame frame) const
                 *this, frame, p.data, result_type);
           },
           [&](const hir::ElementSelectExpr& s) -> diag::Result<mir::Expr> {
-            return LowerHirElementSelectExprStructuralLhs(
-                *this, frame, s, result_type);
+            return LowerHirElementSelectExprLhs(*this, frame, s, result_type);
           },
           [&](const hir::RangeSelectExpr& s) -> diag::Result<mir::Expr> {
-            return LowerHirRangeSelectExprStructuralLhs(
-                *this, frame, s, result_type);
+            return LowerHirRangeSelectExprLhs(*this, frame, s, result_type);
           },
           [&](const hir::MemberAccessExpr& s) -> diag::Result<mir::Expr> {
-            return LowerHirMemberAccessExprStructuralLhs(
-                *this, frame, s, result_type);
+            return LowerHirMemberAccessExprLhs(*this, frame, s, result_type);
           },
           [&](const hir::ConcatExpr& c) -> diag::Result<mir::Expr> {
-            return LowerHirConcatExprStructural(*this, frame, c, result_type);
+            return LowerHirConcatExpr(*this, frame, c, result_type);
           },
           [](const auto&) -> diag::Result<mir::Expr> {
             throw InternalError(

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -7,6 +7,7 @@
 #include "lyra/hir/continuous_assign.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
+#include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
@@ -48,14 +49,10 @@ auto LowerContinuousAssign(
 
   // Build `self.Services()` in the body so an observable LHS routes through
   // `Var<T>::Set` (or `Mutate` for a selector chain). The body's `self` is
-  // already bound at depth 0 via `WithSelfBinding(self_id, ...)` above.
-  const mir::TypeId self_ptr_type = frame.current_class->self_pointer_type;
+  // already bound via `WithSelfBinding(self_id, ...)` above, so the self read
+  // resolves through the frame the same way a process body's does.
   const mir::ExprId body_self_ref = body_block.exprs.Add(
-      mir::MakeLocalRefExpr(
-          mir::BlockHops{
-              .value = body_frame.block_depth.value -
-                       body_frame.self_decl_depth.value},
-          self_id, self_ptr_type));
+      BuildSelfRefExpr(body_frame, frame.current_class->self_pointer_type));
   const mir::ExprId body_services_id = body_block.exprs.Add(
       mir::MakeServicesCallExpr(
           body_self_ref, lowerer.Module().Unit().builtins.services));

--- a/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
@@ -12,8 +12,8 @@
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/closure_builder.hpp"
-#include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/print_items.hpp"
+#include "lyra/lowering/hir_to_mir/snapshot_local.hpp"
 #include "lyra/lowering/hir_to_mir/statement/blocks.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/block_hops.hpp"
@@ -98,37 +98,9 @@ auto SnapshotPredicate(
     const ModuleLowerer& module, WalkFrame frame, mir::Block& wrapper,
     std::size_t index, mir::TypeId predicate_type,
     mir::ExprId predicate_expr_id) -> mir::LocalId {
-  const std::string var_name = std::format("_lyra_unique_cond_{}", index);
-  const mir::LocalId snap_var = wrapper.vars.Add(
-      mir::LocalDecl{.name = var_name, .type = predicate_type});
-  const mir::ExprId snap_default_init =
-      wrapper.exprs.Add(BuildDefaultValueExpr(module, frame, predicate_type));
-  wrapper.AppendStmt(
-      mir::Stmt{
-          .label = std::nullopt,
-          .data = mir::LocalDeclStmt{
-              .target =
-                  mir::LocalRef{
-                      .hops = mir::BlockHops{.value = 0}, .var = snap_var},
-              .init = snap_default_init}});
-
-  const mir::ExprId snap_target_id = wrapper.exprs.Add(
-      mir::Expr{
-          .data =
-              mir::LocalRef{
-                  .hops = mir::BlockHops{.value = 0}, .var = snap_var},
-          .type = predicate_type});
-  const mir::ExprId assign_id = wrapper.exprs.Add(
-      mir::Expr{
-          .data =
-              mir::AssignExpr{
-                  .target = snap_target_id, .value = predicate_expr_id},
-          .type = predicate_type});
-  wrapper.AppendStmt(
-      mir::Stmt{
-          .label = std::nullopt, .data = mir::ExprStmt{.expr = assign_id}});
-
-  return snap_var;
+  return SnapshotExprToLocal(
+      module, frame, wrapper, std::format("_lyra_unique_cond_{}", index),
+      predicate_type, predicate_expr_id);
 }
 
 auto BuildDiagnosticThenScope(
@@ -436,18 +408,11 @@ auto LowerUniqueIfStmt(
   // Lower each body into its own child scope. Cascade level i sits i scopes
   // deeper than wrapper, so each body lowering descends i extra frames before
   // opening its own child scope (LowerStmtIntoChildScope adds one more).
-  auto deeper_by = [](WalkFrame f, std::size_t extras) {
-    for (std::size_t i = 0; i < extras; ++i) {
-      f = f.Deeper();
-    }
-    return f;
-  };
-
   std::vector<DeferredCheckBranch> branches;
   branches.reserve(cascade.bodies.size());
   for (std::size_t i = 0; i < cascade.bodies.size(); ++i) {
     auto body_or = LowerStmtIntoChildScope(
-        process, deeper_by(wrapper_frame, i), cascade.bodies[i]);
+        process, wrapper_frame.DeeperBy(i), cascade.bodies[i]);
     if (!body_or) return std::unexpected(std::move(body_or.error()));
     branches.push_back(
         DeferredCheckBranch{
@@ -462,7 +427,7 @@ auto LowerUniqueIfStmt(
     const WalkFrame tail_enter_frame =
         cascade.bodies.empty()
             ? wrapper_frame
-            : deeper_by(wrapper_frame, cascade.bodies.size() - 1);
+            : wrapper_frame.DeeperBy(cascade.bodies.size() - 1);
     auto tail_or =
         LowerStmtIntoChildScope(process, tail_enter_frame, *cascade.tail_else);
     if (!tail_or) return std::unexpected(std::move(tail_or.error()));

--- a/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
@@ -10,8 +10,6 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/procedural_body.hpp"
-#include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
@@ -65,15 +63,15 @@ auto IsArrayContainerType(const mir::Type& ty) -> bool {
 
 }  // namespace
 
-auto LowerHirConcatExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::ConcatExpr& c,
+template <ExprLowerer Lowerer>
+auto LowerHirConcatExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::ConcatExpr& c,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
   std::vector<mir::ExprId> operand_ids;
   operand_ids.reserve(c.operands.size());
   for (const auto& id : c.operands) {
-    auto lowered = process.LowerExpr(hir_process.exprs.Get(id), frame);
+    auto lowered = lowerer.LowerExpr(lowerer.HirExprs().Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     operand_ids.push_back(block.exprs.Add(*std::move(lowered)));
   }
@@ -85,12 +83,11 @@ auto LowerHirConcatExprProc(
 auto LowerHirReplicationExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::ReplicationExpr& r,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
-  auto count_or = process.LowerExpr(hir_process.exprs.Get(r.count), frame);
+  auto count_or = process.LowerExpr(process.HirExprs().Get(r.count), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
   const mir::ExprId count_id = block.exprs.Add(*std::move(count_or));
-  auto concat_or = process.LowerExpr(hir_process.exprs.Get(r.concat), frame);
+  auto concat_or = process.LowerExpr(process.HirExprs().Get(r.concat), frame);
   if (!concat_or) return std::unexpected(std::move(concat_or.error()));
   const mir::ExprId concat_id = block.exprs.Add(*std::move(concat_or));
   return mir::Expr{
@@ -103,52 +100,51 @@ auto LowerHirReplicationExprProc(
 // concatenation matches the packed bit plane), array containers (unpacked,
 // dynamic, queue) land as `ArrayLiteralExpr` over distinct element slots
 // wrapped by a construction call against the container ctor.
-auto LowerHirAssignmentPatternExprProc(
-    ProcessLowerer& process, WalkFrame frame,
-    const hir::AssignmentPatternExpr& a, mir::TypeId result_type)
-    -> diag::Result<mir::Expr> {
-  const auto& hir_process = process.HirBody();
+template <ExprLowerer Lowerer>
+auto LowerHirAssignmentPatternExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::AssignmentPatternExpr& a,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto& block = *frame.current_block;
   std::vector<mir::ExprId> element_ids;
   element_ids.reserve(a.elements.size());
   for (const auto& id : a.elements) {
-    auto lowered = process.LowerExpr(hir_process.exprs.Get(id), frame);
+    auto lowered = lowerer.LowerExpr(lowerer.HirExprs().Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     element_ids.push_back(block.exprs.Add(*std::move(lowered)));
   }
-  if (IsArrayContainerType(process.Module().Unit().GetType(result_type))) {
+  if (IsArrayContainerType(lowerer.Module().Unit().GetType(result_type))) {
     return BuildArrayConstructionCall(
-        process.Module(), frame, result_type, std::move(element_ids));
+        lowerer.Module(), frame, result_type, std::move(element_ids));
   }
   return mir::Expr{
       .data = mir::ConcatExpr{.operands = std::move(element_ids)},
       .type = result_type};
 }
 
-auto LowerHirAssignmentPatternReplicationExprProc(
-    ProcessLowerer& process, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerHirAssignmentPatternReplicationExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const hir::AssignmentPatternReplicationExpr& a, mir::TypeId result_type)
     -> diag::Result<mir::Expr> {
-  const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
   std::vector<mir::ExprId> item_ids;
   item_ids.reserve(a.items.size());
   for (const auto& id : a.items) {
-    auto lowered = process.LowerExpr(hir_process.exprs.Get(id), frame);
+    auto lowered = lowerer.LowerExpr(lowerer.HirExprs().Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     item_ids.push_back(block.exprs.Add(*std::move(lowered)));
   }
-  if (IsArrayContainerType(process.Module().Unit().GetType(result_type))) {
+  if (IsArrayContainerType(lowerer.Module().Unit().GetType(result_type))) {
     const std::uint64_t count =
-        ExtractHirLiteralUint64(hir_process.exprs.Get(a.count));
+        ExtractHirLiteralUint64(lowerer.HirExprs().Get(a.count));
     return BuildArrayReplicationFlatList(
-        process.Module(), frame, item_ids, count, result_type);
+        lowerer.Module(), frame, item_ids, count, result_type);
   }
   const mir::ExprId inner_concat_id = block.exprs.Add(
       mir::Expr{
           .data = mir::ConcatExpr{.operands = std::move(item_ids)},
           .type = result_type});
-  auto count_or = process.LowerExpr(hir_process.exprs.Get(a.count), frame);
+  auto count_or = lowerer.LowerExpr(lowerer.HirExprs().Get(a.count), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
   const mir::ExprId count_id = block.exprs.Add(*std::move(count_or));
   return mir::Expr{
@@ -169,9 +165,8 @@ auto LowerHirAssignmentPatternReplicationExprProc(
 auto LowerHirDynamicArrayNewExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::DynamicArrayNewExpr& n,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
-  auto size_or = process.LowerExpr(hir_process.exprs.Get(n.size), frame);
+  auto size_or = process.LowerExpr(process.HirExprs().Get(n.size), frame);
   if (!size_or) return std::unexpected(std::move(size_or.error()));
   const mir::ExprId size_id = block.exprs.Add(*std::move(size_or));
 
@@ -190,7 +185,7 @@ auto LowerHirDynamicArrayNewExprProc(
   args.push_back(prototype_id);
   if (n.initializer.has_value()) {
     auto init_or =
-        process.LowerExpr(hir_process.exprs.Get(*n.initializer), frame);
+        process.LowerExpr(process.HirExprs().Get(*n.initializer), frame);
     if (!init_or) return std::unexpected(std::move(init_or.error()));
     args.push_back(block.exprs.Add(*std::move(init_or)));
   }
@@ -205,20 +200,20 @@ auto LowerHirDynamicArrayNewExprProc(
 // pair of MIR ExprIds and handed to the shared construction helper, which wraps
 // them as tuples and threads the optional persistent default through the
 // associative constructor.
-auto LowerHirAssociativeAssignmentPatternExprProc(
-    ProcessLowerer& process, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerHirAssociativeAssignmentPatternExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const hir::AssociativeAssignmentPatternExpr& a, mir::TypeId result_type)
     -> diag::Result<mir::Expr> {
-  const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
   std::vector<std::pair<mir::ExprId, mir::ExprId>> entries;
   entries.reserve(a.entries.size());
   for (const auto& entry : a.entries) {
-    auto key_or = process.LowerExpr(hir_process.exprs.Get(entry.key), frame);
+    auto key_or = lowerer.LowerExpr(lowerer.HirExprs().Get(entry.key), frame);
     if (!key_or) return std::unexpected(std::move(key_or.error()));
     const mir::ExprId key_id = block.exprs.Add(*std::move(key_or));
     auto value_or =
-        process.LowerExpr(hir_process.exprs.Get(entry.value), frame);
+        lowerer.LowerExpr(lowerer.HirExprs().Get(entry.value), frame);
     if (!value_or) return std::unexpected(std::move(value_or.error()));
     const mir::ExprId value_id = block.exprs.Add(*std::move(value_or));
     entries.emplace_back(key_id, value_id);
@@ -226,114 +221,43 @@ auto LowerHirAssociativeAssignmentPatternExprProc(
   std::optional<mir::ExprId> user_default;
   if (a.default_value.has_value()) {
     auto default_or =
-        process.LowerExpr(hir_process.exprs.Get(*a.default_value), frame);
-    if (!default_or) return std::unexpected(std::move(default_or.error()));
-    user_default = block.exprs.Add(*std::move(default_or));
-  }
-  return BuildAssociativeConstructionCall(
-      process.Module(), frame, result_type, std::move(entries), user_default);
-}
-
-auto LowerHirConcatExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame, const hir::ConcatExpr& c,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_scope = lowerer.HirScope();
-  auto& block = *frame.current_block;
-  std::vector<mir::ExprId> operand_ids;
-  operand_ids.reserve(c.operands.size());
-  for (const auto& id : c.operands) {
-    auto lowered = lowerer.LowerExpr(hir_scope.exprs.Get(id), frame);
-    if (!lowered) return std::unexpected(std::move(lowered.error()));
-    operand_ids.push_back(block.exprs.Add(*std::move(lowered)));
-  }
-  return mir::Expr{
-      .data = mir::ConcatExpr{.operands = std::move(operand_ids)},
-      .type = result_type};
-}
-
-auto LowerHirAssignmentPatternExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::AssignmentPatternExpr& a, mir::TypeId result_type)
-    -> diag::Result<mir::Expr> {
-  const auto& hir_scope = lowerer.HirScope();
-  auto& block = *frame.current_block;
-  std::vector<mir::ExprId> element_ids;
-  element_ids.reserve(a.elements.size());
-  for (const auto& id : a.elements) {
-    auto lowered = lowerer.LowerExpr(hir_scope.exprs.Get(id), frame);
-    if (!lowered) return std::unexpected(std::move(lowered.error()));
-    element_ids.push_back(block.exprs.Add(*std::move(lowered)));
-  }
-  if (IsArrayContainerType(lowerer.Module().Unit().GetType(result_type))) {
-    return BuildArrayConstructionCall(
-        lowerer.Module(), frame, result_type, std::move(element_ids));
-  }
-  return mir::Expr{
-      .data = mir::ConcatExpr{.operands = std::move(element_ids)},
-      .type = result_type};
-}
-
-auto LowerHirAssignmentPatternReplicationExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::AssignmentPatternReplicationExpr& a, mir::TypeId result_type)
-    -> diag::Result<mir::Expr> {
-  const auto& hir_scope = lowerer.HirScope();
-  auto& block = *frame.current_block;
-  std::vector<mir::ExprId> item_ids;
-  item_ids.reserve(a.items.size());
-  for (const auto& id : a.items) {
-    auto lowered = lowerer.LowerExpr(hir_scope.exprs.Get(id), frame);
-    if (!lowered) return std::unexpected(std::move(lowered.error()));
-    item_ids.push_back(block.exprs.Add(*std::move(lowered)));
-  }
-  if (IsArrayContainerType(lowerer.Module().Unit().GetType(result_type))) {
-    const std::uint64_t count =
-        ExtractHirLiteralUint64(hir_scope.exprs.Get(a.count));
-    return BuildArrayReplicationFlatList(
-        lowerer.Module(), frame, item_ids, count, result_type);
-  }
-  const mir::ExprId inner_concat_id = block.exprs.Add(
-      mir::Expr{
-          .data = mir::ConcatExpr{.operands = std::move(item_ids)},
-          .type = result_type});
-  auto count_or = lowerer.LowerExpr(hir_scope.exprs.Get(a.count), frame);
-  if (!count_or) return std::unexpected(std::move(count_or.error()));
-  const mir::ExprId count_id = block.exprs.Add(*std::move(count_or));
-  return mir::Expr{
-      .data =
-          mir::ReplicationExpr{
-              .count = count_id,
-              .concat = inner_concat_id,
-          },
-      .type = result_type};
-}
-
-auto LowerHirAssociativeAssignmentPatternExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::AssociativeAssignmentPatternExpr& a, mir::TypeId result_type)
-    -> diag::Result<mir::Expr> {
-  const auto& hir_scope = lowerer.HirScope();
-  auto& block = *frame.current_block;
-  std::vector<std::pair<mir::ExprId, mir::ExprId>> entries;
-  entries.reserve(a.entries.size());
-  for (const auto& entry : a.entries) {
-    auto key_or = lowerer.LowerExpr(hir_scope.exprs.Get(entry.key), frame);
-    if (!key_or) return std::unexpected(std::move(key_or.error()));
-    const mir::ExprId key_id = block.exprs.Add(*std::move(key_or));
-    auto value_or = lowerer.LowerExpr(hir_scope.exprs.Get(entry.value), frame);
-    if (!value_or) return std::unexpected(std::move(value_or.error()));
-    const mir::ExprId value_id = block.exprs.Add(*std::move(value_or));
-    entries.emplace_back(key_id, value_id);
-  }
-  std::optional<mir::ExprId> user_default;
-  if (a.default_value.has_value()) {
-    auto default_or =
-        lowerer.LowerExpr(hir_scope.exprs.Get(*a.default_value), frame);
+        lowerer.LowerExpr(lowerer.HirExprs().Get(*a.default_value), frame);
     if (!default_or) return std::unexpected(std::move(default_or.error()));
     user_default = block.exprs.Add(*std::move(default_or));
   }
   return BuildAssociativeConstructionCall(
       lowerer.Module(), frame, result_type, std::move(entries), user_default);
 }
+
+// One concrete instantiation per pass class. The handler templates are defined
+// in this file rather than the header so the file-local helpers stay private,
+// so the dispatchers in process_lowerer.cpp / class_lowerer.cpp link against
+// the symbols emitted here.
+template auto LowerHirConcatExpr(
+    ProcessLowerer&, WalkFrame, const hir::ConcatExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirConcatExpr(
+    const ClassLowerer&, WalkFrame, const hir::ConcatExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirAssignmentPatternExpr(
+    ProcessLowerer&, WalkFrame, const hir::AssignmentPatternExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirAssignmentPatternExpr(
+    const ClassLowerer&, WalkFrame, const hir::AssignmentPatternExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
+template auto LowerHirAssignmentPatternReplicationExpr(
+    ProcessLowerer&, WalkFrame, const hir::AssignmentPatternReplicationExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
+template auto LowerHirAssignmentPatternReplicationExpr(
+    const ClassLowerer&, WalkFrame,
+    const hir::AssignmentPatternReplicationExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirAssociativeAssignmentPatternExpr(
+    ProcessLowerer&, WalkFrame, const hir::AssociativeAssignmentPatternExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
+template auto LowerHirAssociativeAssignmentPatternExpr(
+    const ClassLowerer&, WalkFrame,
+    const hir::AssociativeAssignmentPatternExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -8,8 +8,6 @@
 #include "lyra/hir/binary_op.hpp"
 #include "lyra/hir/conversion.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/procedural_body.hpp"
-#include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/unary_op.hpp"
 #include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
@@ -147,11 +145,11 @@ auto LowerHirConversionKind(hir::ConversionKind k) -> mir::ConversionKind {
 
 }  // namespace
 
-auto LowerHirUnaryExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::UnaryExpr& u,
+template <ExprLowerer Lowerer>
+auto LowerHirUnaryExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::UnaryExpr& u,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_process = process.HirBody();
-  auto operand_or = process.LowerExpr(hir_process.exprs.Get(u.operand), frame);
+  auto operand_or = lowerer.LowerExpr(lowerer.HirExprs().Get(u.operand), frame);
   if (!operand_or) {
     return std::unexpected(std::move(operand_or.error()));
   }
@@ -162,16 +160,17 @@ auto LowerHirUnaryExprProc(
       .type = result_type};
 }
 
-auto LowerHirBinaryExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::BinaryExpr& b,
+template <ExprLowerer Lowerer>
+auto LowerHirBinaryExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::BinaryExpr& b,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_process = process.HirBody();
-  auto lhs_or = process.LowerExpr(hir_process.exprs.Get(b.lhs), frame);
+  auto& block = *frame.current_block;
+  auto lhs_or = lowerer.LowerExpr(lowerer.HirExprs().Get(b.lhs), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  const mir::ExprId lhs_id = frame.current_block->exprs.Add(*std::move(lhs_or));
-  auto rhs_or = process.LowerExpr(hir_process.exprs.Get(b.rhs), frame);
+  const mir::ExprId lhs_id = block.exprs.Add(*std::move(lhs_or));
+  auto rhs_or = lowerer.LowerExpr(lowerer.HirExprs().Get(b.rhs), frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  const mir::ExprId rhs_id = frame.current_block->exprs.Add(*std::move(rhs_or));
+  const mir::ExprId rhs_id = block.exprs.Add(*std::move(rhs_or));
   return mir::Expr{
       .data =
           mir::BinaryExpr{
@@ -179,22 +178,20 @@ auto LowerHirBinaryExprProc(
       .type = result_type};
 }
 
-auto LowerHirConditionalExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::ConditionalExpr& c,
+template <ExprLowerer Lowerer>
+auto LowerHirConditionalExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::ConditionalExpr& c,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_process = process.HirBody();
-  auto cond_or = process.LowerExpr(hir_process.exprs.Get(c.condition), frame);
+  auto& block = *frame.current_block;
+  auto cond_or = lowerer.LowerExpr(lowerer.HirExprs().Get(c.condition), frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const mir::ExprId cond_id =
-      frame.current_block->exprs.Add(*std::move(cond_or));
-  auto then_or = process.LowerExpr(hir_process.exprs.Get(c.then_value), frame);
+  const mir::ExprId cond_id = block.exprs.Add(*std::move(cond_or));
+  auto then_or = lowerer.LowerExpr(lowerer.HirExprs().Get(c.then_value), frame);
   if (!then_or) return std::unexpected(std::move(then_or.error()));
-  const mir::ExprId then_id =
-      frame.current_block->exprs.Add(*std::move(then_or));
-  auto else_or = process.LowerExpr(hir_process.exprs.Get(c.else_value), frame);
+  const mir::ExprId then_id = block.exprs.Add(*std::move(then_or));
+  auto else_or = lowerer.LowerExpr(lowerer.HirExprs().Get(c.else_value), frame);
   if (!else_or) return std::unexpected(std::move(else_or.error()));
-  const mir::ExprId else_id =
-      frame.current_block->exprs.Add(*std::move(else_or));
+  const mir::ExprId else_id = block.exprs.Add(*std::move(else_or));
   return mir::Expr{
       .data =
           mir::ConditionalExpr{
@@ -207,12 +204,11 @@ auto LowerHirConditionalExprProc(
 auto LowerHirIncDecExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::IncDecExpr& inc,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_process = process.HirBody();
   auto& block = *frame.current_block;
   // The target is written in place, so a queue element dispatches to its
   // write-side access just as an assignment target does.
   auto target_or = process.LowerLhsExpr(
-      hir_process.exprs.Get(inc.target), frame.WithLvalueTarget(true));
+      process.HirExprs().Get(inc.target), frame.WithLvalueTarget(true));
   if (!target_or) return std::unexpected(std::move(target_or.error()));
   mir::ExprId target_id = block.exprs.Add(*std::move(target_or));
 
@@ -233,11 +229,12 @@ auto LowerHirIncDecExprProc(
       .type = result_type};
 }
 
-auto LowerHirConversionExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::ConversionExpr& cv,
+template <ExprLowerer Lowerer>
+auto LowerHirConversionExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::ConversionExpr& cv,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_process = process.HirBody();
-  auto operand_or = process.LowerExpr(hir_process.exprs.Get(cv.operand), frame);
+  auto operand_or =
+      lowerer.LowerExpr(lowerer.HirExprs().Get(cv.operand), frame);
   if (!operand_or) {
     return std::unexpected(std::move(operand_or.error()));
   }
@@ -250,77 +247,33 @@ auto LowerHirConversionExprProc(
       .type = result_type};
 }
 
-auto LowerHirUnaryExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame, const hir::UnaryExpr& u,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_scope = lowerer.HirScope();
-  auto operand_or = lowerer.LowerExpr(hir_scope.exprs.Get(u.operand), frame);
-  if (!operand_or) {
-    return std::unexpected(std::move(operand_or.error()));
-  }
-  const mir::ExprId operand_id =
-      frame.current_block->exprs.Add(*std::move(operand_or));
-  return mir::Expr{
-      .data = mir::UnaryExpr{.op = LowerUnaryOp(u.op), .operand = operand_id},
-      .type = result_type};
-}
-
-auto LowerHirBinaryExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame, const hir::BinaryExpr& b,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_scope = lowerer.HirScope();
-  auto& block = *frame.current_block;
-  auto lhs_or = lowerer.LowerExpr(hir_scope.exprs.Get(b.lhs), frame);
-  if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  const mir::ExprId lhs_id = block.exprs.Add(*std::move(lhs_or));
-  auto rhs_or = lowerer.LowerExpr(hir_scope.exprs.Get(b.rhs), frame);
-  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  const mir::ExprId rhs_id = block.exprs.Add(*std::move(rhs_or));
-  return mir::Expr{
-      .data =
-          mir::BinaryExpr{
-              .op = LowerBinaryOp(b.op), .lhs = lhs_id, .rhs = rhs_id},
-      .type = result_type};
-}
-
-auto LowerHirConditionalExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame, const hir::ConditionalExpr& c,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_scope = lowerer.HirScope();
-  auto& block = *frame.current_block;
-  auto cond_or = lowerer.LowerExpr(hir_scope.exprs.Get(c.condition), frame);
-  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const mir::ExprId cond_id = block.exprs.Add(*std::move(cond_or));
-  auto then_or = lowerer.LowerExpr(hir_scope.exprs.Get(c.then_value), frame);
-  if (!then_or) return std::unexpected(std::move(then_or.error()));
-  const mir::ExprId then_id = block.exprs.Add(*std::move(then_or));
-  auto else_or = lowerer.LowerExpr(hir_scope.exprs.Get(c.else_value), frame);
-  if (!else_or) return std::unexpected(std::move(else_or.error()));
-  const mir::ExprId else_id = block.exprs.Add(*std::move(else_or));
-  return mir::Expr{
-      .data =
-          mir::ConditionalExpr{
-              .condition = cond_id,
-              .then_value = then_id,
-              .else_value = else_id},
-      .type = result_type};
-}
-
-auto LowerHirConversionExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame, const hir::ConversionExpr& cv,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_scope = lowerer.HirScope();
-  auto operand_or = lowerer.LowerExpr(hir_scope.exprs.Get(cv.operand), frame);
-  if (!operand_or) {
-    return std::unexpected(std::move(operand_or.error()));
-  }
-  const mir::ExprId operand_id =
-      frame.current_block->exprs.Add(*std::move(operand_or));
-  return mir::Expr{
-      .data =
-          mir::ConversionExpr{
-              .operand = operand_id, .kind = LowerHirConversionKind(cv.kind)},
-      .type = result_type};
-}
+// One concrete instantiation per pass class. The handler templates are defined
+// in this file rather than the header so the file-local helpers stay private,
+// so the dispatchers in process_lowerer.cpp / class_lowerer.cpp link against
+// the symbols emitted here.
+template auto LowerHirUnaryExpr(
+    ProcessLowerer&, WalkFrame, const hir::UnaryExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirUnaryExpr(
+    const ClassLowerer&, WalkFrame, const hir::UnaryExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirBinaryExpr(
+    ProcessLowerer&, WalkFrame, const hir::BinaryExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirBinaryExpr(
+    const ClassLowerer&, WalkFrame, const hir::BinaryExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirConditionalExpr(
+    ProcessLowerer&, WalkFrame, const hir::ConditionalExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirConditionalExpr(
+    const ClassLowerer&, WalkFrame, const hir::ConditionalExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirConversionExpr(
+    ProcessLowerer&, WalkFrame, const hir::ConversionExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirConversionExpr(
+    const ClassLowerer&, WalkFrame, const hir::ConversionExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -10,8 +10,6 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/procedural_body.hpp"
-#include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
@@ -23,11 +21,11 @@
 #include "lyra/mir/type.hpp"
 
 // HIR-to-MIR lowering for the three select families (`a[i]`, `a[hi:lo]`,
-// `s.field`). Each family has four entry points: read / write side and
-// procedural / structural source context. The four-axis surface arises only
-// because the source side and lowerer differ; the underlying MIR shape is
-// identical, so the bodies fan into a single per-family `Build*` factory plus
-// a per-family inner helper that handles the wrapping decisions.
+// `s.field`). Each family has a read-side and a write-side entry point; a
+// select's meaning is independent of whether a process or a structural scope
+// encloses it, so each entry point is one template over the pass class. The
+// bodies fan into a single per-family `Build*` factory plus a per-family inner
+// helper that handles the wrapping decisions.
 //
 // Naming convention used here, matching the rest of HIR-to-MIR:
 //   - `Lower*` -- top-level HIR-to-MIR for a HIR construct, returns
@@ -668,30 +666,23 @@ auto LowerMemberAccessInner(
 
 }  // namespace
 
-// The twelve entry points below all share the same skeleton: lower
-// container-specific sub-expressions (base, index, bound expressions) via
-// the appropriate lowerer, commit them into the current block,
-// then delegate to one of the inner helpers above. The four-axis surface
-// (3 kinds * 2 sides * 2 source contexts) arises only because the
-// `ProcessLowerer` / `ClassLowerer` interfaces differ slightly;
-// the underlying MIR shape is identical across all twelve.
-
-auto LowerHirElementSelectExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::ElementSelectExpr& sel,
+template <ExprLowerer Lowerer>
+auto LowerHirElementSelectExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::ElementSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& module = process.Module();
-  const auto& hir_process = process.HirBody();
+  const auto& module = lowerer.Module();
+  const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
   const bool is_write = frame.is_lvalue_target;
   const WalkFrame sub_frame = frame.WithLvalueTarget(false);
 
-  const auto& hir_base = hir_process.exprs.Get(sel.base_value);
-  auto base_or = process.LowerExpr(hir_base, sub_frame);
+  const auto& hir_base = exprs.Get(sel.base_value);
+  auto base_or = lowerer.LowerExpr(hir_base, sub_frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
 
-  const auto& hir_idx = hir_process.exprs.Get(sel.index);
-  auto idx_or = process.LowerExpr(hir_idx, sub_frame);
+  const auto& hir_idx = exprs.Get(sel.index);
+  auto idx_or = lowerer.LowerExpr(hir_idx, sub_frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
 
@@ -708,9 +699,10 @@ auto LowerHirElementSelectExprProc(
   }
   // LRM 7.10.1: queue's `q[$+1] = v` appends, so a queue element write
   // must dispatch as LHS even from this RHS entry point. The lvalue-target
-  // marker carried on the walk frame surfaces that case. AA / packed /
-  // unpacked already route their write side through the explicit LHS
-  // lowerers below.
+  // marker carried on the walk frame surfaces that case. The string and queue
+  // arms are reachable only in a procedural scope: slang forbids referencing
+  // an element of a dynamic-typed variable outside a procedural context, so a
+  // structural instantiation never takes them.
   const AccessSide side =
       (is_write && std::holds_alternative<hir::QueueType>(hir_base_ty.data))
           ? AccessSide::kLhs
@@ -720,20 +712,21 @@ auto LowerHirElementSelectExprProc(
       idx_id, side, result_type, true);
 }
 
-auto LowerHirRangeSelectExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::RangeSelectExpr& sel,
+template <ExprLowerer Lowerer>
+auto LowerHirRangeSelectExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::RangeSelectExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& module = process.Module();
-  const auto& hir_process = process.HirBody();
+  const auto& module = lowerer.Module();
+  const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
 
-  const auto& hir_base = hir_process.exprs.Get(sel.base_value);
-  auto base_or = process.LowerExpr(hir_base, frame);
+  const auto& hir_base = exprs.Get(sel.base_value);
+  auto base_or = lowerer.LowerExpr(hir_base, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
 
   auto lower_one = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
-    auto lowered = process.LowerExpr(hir_process.exprs.Get(id), frame);
+    auto lowered = lowerer.LowerExpr(exprs.Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     return block.exprs.Add(*std::move(lowered));
   };
@@ -747,160 +740,18 @@ auto LowerHirRangeSelectExprProc(
 // were a packed array". HIR -> MIR resolves the field-table index to a
 // concrete `(offset, count)` slice -- the same MIR shape `s[hi:lo]`
 // produces.
-auto LowerHirMemberAccessExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::MemberAccessExpr& sel,
+template <ExprLowerer Lowerer>
+auto LowerHirMemberAccessExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::MemberAccessExpr& sel,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  auto& module = process.Module();
-  const auto& hir_process = process.HirBody();
-  auto& block = *frame.current_block;
-  const auto& base_hir_expr = hir_process.exprs.Get(sel.base_value);
-  const auto& fields =
-      GetAggregateFields(module.Hir().GetType(base_hir_expr.type));
-  if (sel.field_index >= fields.size()) {
-    throw InternalError(
-        "LowerHirMemberAccessExprProc: field_index out of range");
-  }
-  auto base_or = process.LowerExpr(base_hir_expr, frame);
-  if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
-  return LowerMemberAccessInner(
-      module, block, fields[sel.field_index], base_id, result_type,
-      AccessSide::kRead);
-}
-
-auto LowerHirElementSelectExprProcLhs(
-    ProcessLowerer& process, WalkFrame frame, const hir::ElementSelectExpr& sel,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& module = process.Module();
-  const auto& hir_process = process.HirBody();
-  auto& block = *frame.current_block;
-
-  const auto& hir_base = hir_process.exprs.Get(sel.base_value);
-  auto base_or = process.LowerLhsExpr(hir_base, frame);
-  if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
-
-  const auto& hir_idx = hir_process.exprs.Get(sel.index);
-  auto idx_or = process.LowerExpr(hir_idx, frame);
-  if (!idx_or) return std::unexpected(std::move(idx_or.error()));
-  const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
-
-  const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
-  return LowerElementSelectInner(
-      module, block, hir_base_ty, module.TranslateType(hir_idx.type), base_id,
-      idx_id, AccessSide::kLhs, result_type, false);
-}
-
-auto LowerHirRangeSelectExprProcLhs(
-    ProcessLowerer& process, WalkFrame frame, const hir::RangeSelectExpr& sel,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& module = process.Module();
-  const auto& hir_process = process.HirBody();
-  auto& block = *frame.current_block;
-
-  const auto& hir_base = hir_process.exprs.Get(sel.base_value);
-  auto base_or = process.LowerLhsExpr(hir_base, frame);
-  if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
-
-  auto lower_one = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
-    auto lowered = process.LowerExpr(hir_process.exprs.Get(id), frame);
-    if (!lowered) return std::unexpected(std::move(lowered.error()));
-    return block.exprs.Add(*std::move(lowered));
-  };
-  const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
-  return LowerRangeSelectInner(
-      module, block, hir_base_ty, sel.bounds, base_id, result_type, lower_one,
-      AccessSide::kLhs);
-}
-
-auto LowerHirMemberAccessExprProcLhs(
-    ProcessLowerer& process, WalkFrame frame, const hir::MemberAccessExpr& sel,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  auto& module = process.Module();
-  const auto& hir_process = process.HirBody();
-  auto& block = *frame.current_block;
-  const auto& base_hir_expr = hir_process.exprs.Get(sel.base_value);
-  const auto& fields =
-      GetAggregateFields(module.Hir().GetType(base_hir_expr.type));
-  if (sel.field_index >= fields.size()) {
-    throw InternalError(
-        "LowerHirMemberAccessExprProcLhs: field_index out of range");
-  }
-  auto base_or = process.LowerLhsExpr(base_hir_expr, frame);
-  if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
-  return LowerMemberAccessInner(
-      module, block, fields[sel.field_index], base_id, result_type,
-      AccessSide::kLhs);
-}
-
-auto LowerHirElementSelectExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::ElementSelectExpr& sel, mir::TypeId result_type)
-    -> diag::Result<mir::Expr> {
-  const auto& module = lowerer.Module();
-  const auto& hir_scope = lowerer.HirScope();
-  auto& block = *frame.current_block;
-
-  const auto& hir_base = hir_scope.exprs.Get(sel.base_value);
-  auto base_or = lowerer.LowerExpr(hir_base, frame);
-  if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
-
-  const auto& hir_idx = hir_scope.exprs.Get(sel.index);
-  auto idx_or = lowerer.LowerExpr(hir_idx, frame);
-  if (!idx_or) return std::unexpected(std::move(idx_or.error()));
-  const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
-
-  // A queue element select cannot reach the structural path: slang forbids
-  // referencing an element of a dynamic-typed variable outside a procedural
-  // context, so no queue branch is needed here.
-  const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
-  return LowerElementSelectInner(
-      module, block, hir_base_ty, module.TranslateType(hir_idx.type), base_id,
-      idx_id, AccessSide::kRead, result_type, true);
-}
-
-auto LowerHirRangeSelectExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::RangeSelectExpr& sel, mir::TypeId result_type)
-    -> diag::Result<mir::Expr> {
-  const auto& module = lowerer.Module();
-  const auto& hir_scope = lowerer.HirScope();
-  auto& block = *frame.current_block;
-
-  const auto& hir_base = hir_scope.exprs.Get(sel.base_value);
-  auto base_or = lowerer.LowerExpr(hir_base, frame);
-  if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
-
-  auto lower_one = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
-    auto lowered = lowerer.LowerExpr(hir_scope.exprs.Get(id), frame);
-    if (!lowered) return std::unexpected(std::move(lowered.error()));
-    return block.exprs.Add(*std::move(lowered));
-  };
-  // Queue slice cannot reach the structural path for the same reason as the
-  // element-select case above.
-  const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
-  return LowerRangeSelectInner(
-      module, block, hir_base_ty, sel.bounds, base_id, result_type, lower_one,
-      AccessSide::kRead);
-}
-
-auto LowerHirMemberAccessExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::MemberAccessExpr& sel, mir::TypeId result_type)
-    -> diag::Result<mir::Expr> {
   auto& module = lowerer.Module();
-  const auto& hir_scope = lowerer.HirScope();
+  const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
-  const auto& base_hir_expr = hir_scope.exprs.Get(sel.base_value);
+  const auto& base_hir_expr = exprs.Get(sel.base_value);
   const auto& fields =
       GetAggregateFields(module.Hir().GetType(base_hir_expr.type));
   if (sel.field_index >= fields.size()) {
-    throw InternalError(
-        "LowerHirMemberAccessExprStructural: field_index out of range");
+    throw InternalError("LowerHirMemberAccessExpr: field_index out of range");
   }
   auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
@@ -910,20 +761,20 @@ auto LowerHirMemberAccessExprStructural(
       AccessSide::kRead);
 }
 
-auto LowerHirElementSelectExprStructuralLhs(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::ElementSelectExpr& sel, mir::TypeId result_type)
-    -> diag::Result<mir::Expr> {
+template <ExprLowerer Lowerer>
+auto LowerHirElementSelectExprLhs(
+    Lowerer& lowerer, WalkFrame frame, const hir::ElementSelectExpr& sel,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& module = lowerer.Module();
-  const auto& hir_scope = lowerer.HirScope();
+  const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
 
-  const auto& hir_base = hir_scope.exprs.Get(sel.base_value);
+  const auto& hir_base = exprs.Get(sel.base_value);
   auto base_or = lowerer.LowerLhsExpr(hir_base, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
 
-  const auto& hir_idx = hir_scope.exprs.Get(sel.index);
+  const auto& hir_idx = exprs.Get(sel.index);
   auto idx_or = lowerer.LowerExpr(hir_idx, frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
@@ -934,21 +785,21 @@ auto LowerHirElementSelectExprStructuralLhs(
       idx_id, AccessSide::kLhs, result_type, false);
 }
 
-auto LowerHirRangeSelectExprStructuralLhs(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::RangeSelectExpr& sel, mir::TypeId result_type)
-    -> diag::Result<mir::Expr> {
+template <ExprLowerer Lowerer>
+auto LowerHirRangeSelectExprLhs(
+    Lowerer& lowerer, WalkFrame frame, const hir::RangeSelectExpr& sel,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
   const auto& module = lowerer.Module();
-  const auto& hir_scope = lowerer.HirScope();
+  const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
 
-  const auto& hir_base = hir_scope.exprs.Get(sel.base_value);
+  const auto& hir_base = exprs.Get(sel.base_value);
   auto base_or = lowerer.LowerLhsExpr(hir_base, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
 
   auto lower_one = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
-    auto lowered = lowerer.LowerExpr(hir_scope.exprs.Get(id), frame);
+    auto lowered = lowerer.LowerExpr(exprs.Get(id), frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     return block.exprs.Add(*std::move(lowered));
   };
@@ -958,19 +809,19 @@ auto LowerHirRangeSelectExprStructuralLhs(
       AccessSide::kLhs);
 }
 
-auto LowerHirMemberAccessExprStructuralLhs(
-    const ClassLowerer& lowerer, WalkFrame frame,
-    const hir::MemberAccessExpr& sel, mir::TypeId result_type)
-    -> diag::Result<mir::Expr> {
+template <ExprLowerer Lowerer>
+auto LowerHirMemberAccessExprLhs(
+    Lowerer& lowerer, WalkFrame frame, const hir::MemberAccessExpr& sel,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto& module = lowerer.Module();
-  const auto& hir_scope = lowerer.HirScope();
+  const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
-  const auto& base_hir_expr = hir_scope.exprs.Get(sel.base_value);
+  const auto& base_hir_expr = exprs.Get(sel.base_value);
   const auto& fields =
       GetAggregateFields(module.Hir().GetType(base_hir_expr.type));
   if (sel.field_index >= fields.size()) {
     throw InternalError(
-        "LowerHirMemberAccessExprStructuralLhs: field_index out of range");
+        "LowerHirMemberAccessExprLhs: field_index out of range");
   }
   auto base_or = lowerer.LowerLhsExpr(base_hir_expr, frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
@@ -979,5 +830,46 @@ auto LowerHirMemberAccessExprStructuralLhs(
       module, block, fields[sel.field_index], base_id, result_type,
       AccessSide::kLhs);
 }
+
+// One concrete instantiation per pass class. The handler templates are defined
+// in this file rather than the header so the file-local helpers stay private,
+// so the dispatchers in process_lowerer.cpp / class_lowerer.cpp link against
+// the symbols emitted here.
+template auto LowerHirElementSelectExpr(
+    ProcessLowerer&, WalkFrame, const hir::ElementSelectExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirElementSelectExpr(
+    const ClassLowerer&, WalkFrame, const hir::ElementSelectExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirRangeSelectExpr(
+    ProcessLowerer&, WalkFrame, const hir::RangeSelectExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirRangeSelectExpr(
+    const ClassLowerer&, WalkFrame, const hir::RangeSelectExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirMemberAccessExpr(
+    ProcessLowerer&, WalkFrame, const hir::MemberAccessExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirMemberAccessExpr(
+    const ClassLowerer&, WalkFrame, const hir::MemberAccessExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirElementSelectExprLhs(
+    ProcessLowerer&, WalkFrame, const hir::ElementSelectExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirElementSelectExprLhs(
+    const ClassLowerer&, WalkFrame, const hir::ElementSelectExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirRangeSelectExprLhs(
+    ProcessLowerer&, WalkFrame, const hir::RangeSelectExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirRangeSelectExprLhs(
+    const ClassLowerer&, WalkFrame, const hir::RangeSelectExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirMemberAccessExprLhs(
+    ProcessLowerer&, WalkFrame, const hir::MemberAccessExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirMemberAccessExprLhs(
+    const ClassLowerer&, WalkFrame, const hir::MemberAccessExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -47,13 +47,13 @@ auto DispatchLowerExpr(
             return LowerHirPrimaryExprProc(process, frame, p.data, result_type);
           },
           [&](const hir::UnaryExpr& u) -> diag::Result<mir::Expr> {
-            return LowerHirUnaryExprProc(process, frame, u, result_type);
+            return LowerHirUnaryExpr(process, frame, u, result_type);
           },
           [&](const hir::BinaryExpr& b) -> diag::Result<mir::Expr> {
-            return LowerHirBinaryExprProc(process, frame, b, result_type);
+            return LowerHirBinaryExpr(process, frame, b, result_type);
           },
           [&](const hir::ConditionalExpr& c) -> diag::Result<mir::Expr> {
-            return LowerHirConditionalExprProc(process, frame, c, result_type);
+            return LowerHirConditionalExpr(process, frame, c, result_type);
           },
           [&](const hir::AssignExpr& a) -> diag::Result<mir::Expr> {
             return LowerHirAssignExprProc(
@@ -63,7 +63,7 @@ auto DispatchLowerExpr(
             return LowerHirIncDecExprProc(process, frame, inc, result_type);
           },
           [&](const hir::ConversionExpr& cv) -> diag::Result<mir::Expr> {
-            return LowerHirConversionExprProc(process, frame, cv, result_type);
+            return LowerHirConversionExpr(process, frame, cv, result_type);
           },
           [&](const hir::CallExpr& c) -> diag::Result<mir::Expr> {
             return LowerHirCallExprProc(
@@ -73,30 +73,27 @@ auto DispatchLowerExpr(
             return LowerHirInsideExprProc(process, frame, in, result_type);
           },
           [&](const hir::ElementSelectExpr& sel) -> diag::Result<mir::Expr> {
-            return LowerHirElementSelectExprProc(
-                process, frame, sel, result_type);
+            return LowerHirElementSelectExpr(process, frame, sel, result_type);
           },
           [&](const hir::RangeSelectExpr& sel) -> diag::Result<mir::Expr> {
-            return LowerHirRangeSelectExprProc(
-                process, frame, sel, result_type);
+            return LowerHirRangeSelectExpr(process, frame, sel, result_type);
           },
           [&](const hir::MemberAccessExpr& sel) -> diag::Result<mir::Expr> {
-            return LowerHirMemberAccessExprProc(
-                process, frame, sel, result_type);
+            return LowerHirMemberAccessExpr(process, frame, sel, result_type);
           },
           [&](const hir::ConcatExpr& c) -> diag::Result<mir::Expr> {
-            return LowerHirConcatExprProc(process, frame, c, result_type);
+            return LowerHirConcatExpr(process, frame, c, result_type);
           },
           [&](const hir::ReplicationExpr& r) -> diag::Result<mir::Expr> {
             return LowerHirReplicationExprProc(process, frame, r, result_type);
           },
           [&](const hir::AssignmentPatternExpr& a) -> diag::Result<mir::Expr> {
-            return LowerHirAssignmentPatternExprProc(
+            return LowerHirAssignmentPatternExpr(
                 process, frame, a, result_type);
           },
           [&](const hir::AssignmentPatternReplicationExpr& a)
               -> diag::Result<mir::Expr> {
-            return LowerHirAssignmentPatternReplicationExprProc(
+            return LowerHirAssignmentPatternReplicationExpr(
                 process, frame, a, result_type);
           },
           [&](const hir::DynamicArrayNewExpr& n) -> diag::Result<mir::Expr> {
@@ -105,7 +102,7 @@ auto DispatchLowerExpr(
           },
           [&](const hir::AssociativeAssignmentPatternExpr& a)
               -> diag::Result<mir::Expr> {
-            return LowerHirAssociativeAssignmentPatternExprProc(
+            return LowerHirAssociativeAssignmentPatternExpr(
                 process, frame, a, result_type);
           },
       },
@@ -141,19 +138,16 @@ auto ProcessLowerer::LowerLhsExpr(const hir::Expr& expr, WalkFrame frame)
             return LowerHirPrimaryExprProc(*this, frame, p.data, result_type);
           },
           [&](const hir::ElementSelectExpr& sel) -> diag::Result<mir::Expr> {
-            return LowerHirElementSelectExprProcLhs(
-                *this, frame, sel, result_type);
+            return LowerHirElementSelectExprLhs(*this, frame, sel, result_type);
           },
           [&](const hir::RangeSelectExpr& sel) -> diag::Result<mir::Expr> {
-            return LowerHirRangeSelectExprProcLhs(
-                *this, frame, sel, result_type);
+            return LowerHirRangeSelectExprLhs(*this, frame, sel, result_type);
           },
           [&](const hir::MemberAccessExpr& sel) -> diag::Result<mir::Expr> {
-            return LowerHirMemberAccessExprProcLhs(
-                *this, frame, sel, result_type);
+            return LowerHirMemberAccessExprLhs(*this, frame, sel, result_type);
           },
           [&](const hir::ConcatExpr& c) -> diag::Result<mir::Expr> {
-            return LowerHirConcatExprProc(*this, frame, c, result_type);
+            return LowerHirConcatExpr(*this, frame, c, result_type);
           },
           [](const auto&) -> diag::Result<mir::Expr> {
             throw InternalError(

--- a/src/lyra/lowering/hir_to_mir/snapshot_local.cpp
+++ b/src/lyra/lowering/hir_to_mir/snapshot_local.cpp
@@ -1,0 +1,46 @@
+#include "lyra/lowering/hir_to_mir/snapshot_local.hpp"
+
+#include <optional>
+#include <utility>
+
+#include "lyra/lowering/hir_to_mir/default_value.hpp"
+#include "lyra/mir/block_hops.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/stmt.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+auto SnapshotExprToLocal(
+    const ModuleLowerer& module, WalkFrame frame, mir::Block& wrapper,
+    std::string name, mir::TypeId type, mir::ExprId expr_id) -> mir::LocalId {
+  const mir::LocalId snap_var =
+      wrapper.vars.Add(mir::LocalDecl{.name = std::move(name), .type = type});
+  const mir::ExprId default_init =
+      wrapper.exprs.Add(BuildDefaultValueExpr(module, frame, type));
+  wrapper.AppendStmt(
+      mir::Stmt{
+          .label = std::nullopt,
+          .data = mir::LocalDeclStmt{
+              .target =
+                  mir::LocalRef{
+                      .hops = mir::BlockHops{.value = 0}, .var = snap_var},
+              .init = default_init}});
+
+  const mir::ExprId target_id = wrapper.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::LocalRef{
+                  .hops = mir::BlockHops{.value = 0}, .var = snap_var},
+          .type = type});
+  const mir::ExprId assign_id = wrapper.exprs.Add(
+      mir::Expr{
+          .data = mir::AssignExpr{.target = target_id, .value = expr_id},
+          .type = type});
+  wrapper.AppendStmt(
+      mir::Stmt{
+          .label = std::nullopt, .data = mir::ExprStmt{.expr = assign_id}});
+
+  return snap_var;
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/statement/branches.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/branches.cpp
@@ -119,18 +119,11 @@ auto LowerCaseStmt(
   const CaseSnapshotRefs snapshot =
       AppendCaseSnapshot(process.Module(), wrapper_frame, cond_expr_id);
 
-  auto deeper_by = [](WalkFrame f, std::size_t extras) {
-    for (std::size_t i = 0; i < extras; ++i) {
-      f = f.Deeper();
-    }
-    return f;
-  };
-
   std::vector<mir::Block> body_scopes;
   body_scopes.reserve(c.items.size());
   for (std::size_t i = 0; i < c.items.size(); ++i) {
     auto body_or = LowerStmtIntoChildScope(
-        process, deeper_by(wrapper_frame, i), c.items[i].stmt);
+        process, wrapper_frame.DeeperBy(i), c.items[i].stmt);
     if (!body_or) {
       return std::unexpected(std::move(body_or.error()));
     }
@@ -143,7 +136,7 @@ auto LowerCaseStmt(
   // degenerate `if (true) default` form at the wrapper depth.
   const WalkFrame default_enter_frame =
       c.items.empty() ? wrapper_frame
-                      : deeper_by(wrapper_frame, c.items.size() - 1);
+                      : wrapper_frame.DeeperBy(c.items.size() - 1);
   std::optional<mir::Block> default_scope;
   if (c.default_stmt.has_value()) {
     auto def_or =
@@ -187,7 +180,7 @@ auto LowerCaseStmt(
 
   auto build_predicate = [&](WalkFrame enc_frame, std::size_t item_idx,
                              std::uint32_t sel_hops) {
-    const WalkFrame level_frame = deeper_by(enc_frame, item_idx);
+    const WalkFrame level_frame = enc_frame.DeeperBy(item_idx);
     return BuildEqualityChain(
         level_frame, snapshot, bit_type, compare_op, sel_hops,
         c.items[item_idx].labels.size(),
@@ -229,18 +222,11 @@ auto LowerCaseInsideStmt(
   const CaseSnapshotRefs snapshot =
       AppendCaseSnapshot(process.Module(), wrapper_frame, cond_expr_id);
 
-  auto deeper_by = [](WalkFrame f, std::size_t extras) {
-    for (std::size_t i = 0; i < extras; ++i) {
-      f = f.Deeper();
-    }
-    return f;
-  };
-
   std::vector<mir::Block> body_scopes;
   body_scopes.reserve(c.items.size());
   for (std::size_t i = 0; i < c.items.size(); ++i) {
     auto body_or = LowerStmtIntoChildScope(
-        process, deeper_by(wrapper_frame, i), c.items[i].stmt);
+        process, wrapper_frame.DeeperBy(i), c.items[i].stmt);
     if (!body_or) {
       return std::unexpected(std::move(body_or.error()));
     }
@@ -249,7 +235,7 @@ auto LowerCaseInsideStmt(
 
   const WalkFrame default_enter_frame =
       c.items.empty() ? wrapper_frame
-                      : deeper_by(wrapper_frame, c.items.size() - 1);
+                      : wrapper_frame.DeeperBy(c.items.size() - 1);
   std::optional<mir::Block> default_scope;
   if (c.default_stmt.has_value()) {
     auto def_or =
@@ -263,7 +249,7 @@ auto LowerCaseInsideStmt(
   auto build_item_predicate =
       [&](WalkFrame enc_frame, std::size_t item_idx,
           std::uint32_t sel_hops) -> diag::Result<mir::ExprId> {
-    const WalkFrame level_frame = deeper_by(enc_frame, item_idx);
+    const WalkFrame level_frame = enc_frame.DeeperBy(item_idx);
     auto& enc = *level_frame.current_block;
     const mir::ExprId sel_ref = enc.exprs.Add(
         mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/statement/timing.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/timing.cpp
@@ -77,44 +77,60 @@ auto ResolveDelayTicks(ProcessLowerer& process, const hir::DelayControl& d)
       resolver, process.HirBody().exprs.Get(d.duration));
 }
 
-// LRM 15.5.2 `@e body;`. HIR -> MIR expands the timed statement into a
-// Block { AwaitStmt(MethodCall(Await)); body; } inside a fresh child scope --
-// the same shape used for `@*` (LRM 9.4.2.2), substituting a suspending
-// named-event await in place of SensitivityWaitStmt.
-auto LowerNamedEventTimedStmt(
+// LRM 9.4.2.2 `@*`-shaped timed statement: a fresh child scope holding a
+// prepended wait / control statement followed by the lowered body. The four
+// timing forms differ only in that control statement; `build_wait` produces it
+// and may lower sub-expressions into the child block (the named-event form
+// awaits a lowered event expression).
+auto LowerTimedWaitWrapper(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
-    const hir::TimedStmt& t, const hir::NamedEventControl& nec)
-    -> diag::Result<mir::Stmt> {
-  const hir::ProceduralBody& hir_proc = process.HirBody();
+    hir::StmtId inner_stmt, auto build_wait) -> diag::Result<mir::Stmt> {
   mir::Block child_block;
   const WalkFrame child_frame = frame.WithBlock(&child_block).Deeper();
-  auto receiver_or =
-      process.LowerExpr(hir_proc.exprs.Get(nec.event), child_frame);
-  if (!receiver_or) return std::unexpected(std::move(receiver_or.error()));
-  const mir::ExprId receiver_id =
-      child_block.exprs.Add(*std::move(receiver_or));
-  mir::Expr await_call{
-      .data =
-          mir::CallExpr{
-              .callee = mir::BuiltinFnCallee{.id = support::BuiltinFn::kAwait},
-              .arguments = {receiver_id},
-          },
-      .type = process.Module().Unit().builtins.void_type};
-  const mir::ExprId await_id = child_block.exprs.Add(std::move(await_call));
-  child_block.AppendStmt(
-      mir::Stmt{
-          .label = std::nullopt,
-          .data = mir::AwaitStmt{.awaitable = await_id}});
-  const hir::Stmt& inner_hir = hir_proc.stmts.Get(t.stmt);
+  auto wait_or = build_wait(child_block, child_frame);
+  if (!wait_or) return std::unexpected(std::move(wait_or.error()));
+  child_block.AppendStmt(*std::move(wait_or));
+  const hir::Stmt& inner_hir = process.HirBody().stmts.Get(inner_stmt);
   auto inner_or = process.LowerStmt(inner_hir, child_frame);
-  if (!inner_or) {
-    return std::unexpected(std::move(inner_or.error()));
-  }
+  if (!inner_or) return std::unexpected(std::move(inner_or.error()));
   child_block.AppendStmt(*std::move(inner_or));
   const mir::BlockId scope_id =
       frame.current_block->child_scopes.Add(std::move(child_block));
   return mir::Stmt{
       .label = std::move(label), .data = mir::BlockStmt{.scope = scope_id}};
+}
+
+// LRM 15.5.2 `@e body;`: a suspending named-event await in place of the `@*`
+// SensitivityWaitStmt.
+auto LowerNamedEventTimedStmt(
+    ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
+    const hir::TimedStmt& t, const hir::NamedEventControl& nec)
+    -> diag::Result<mir::Stmt> {
+  return LowerTimedWaitWrapper(
+      process, frame, std::move(label), t.stmt,
+      [&](mir::Block& child_block,
+          WalkFrame child_frame) -> diag::Result<mir::Stmt> {
+        auto receiver_or = process.LowerExpr(
+            process.HirBody().exprs.Get(nec.event), child_frame);
+        if (!receiver_or) {
+          return std::unexpected(std::move(receiver_or.error()));
+        }
+        const mir::ExprId receiver_id =
+            child_block.exprs.Add(*std::move(receiver_or));
+        mir::Expr await_call{
+            .data =
+                mir::CallExpr{
+                    .callee =
+                        mir::BuiltinFnCallee{.id = support::BuiltinFn::kAwait},
+                    .arguments = {receiver_id},
+                },
+            .type = process.Module().Unit().builtins.void_type};
+        const mir::ExprId await_id =
+            child_block.exprs.Add(std::move(await_call));
+        return mir::Stmt{
+            .label = std::nullopt,
+            .data = mir::AwaitStmt{.awaitable = await_id}};
+      });
 }
 
 // LRM 9.4.2 `@(...) body`. Single-leaf trigger expressions lower directly to
@@ -124,42 +140,33 @@ auto LowerEventTimedStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     diag::SourceSpan span, const hir::TimedStmt& t, const hir::EventControl& ec)
     -> diag::Result<mir::Stmt> {
-  std::vector<hir::SensitivityEntry> union_reads;
-  union_reads.reserve(ec.triggers.size());
-  for (const auto& trigger : ec.triggers) {
-    if (trigger.sensitivity_list.size() > 1) {
-      return diag::Unsupported(
-          span, diag::DiagCode::kUnsupportedEventTriggerForm,
-          "compound event expressions (concatenation, arithmetic, dynamic "
-          "index) are not yet supported",
-          diag::UnsupportedCategory::kFeature);
-    }
-    for (auto leaf : trigger.sensitivity_list) {
-      // LRM 9.4.2 LSB-reduce: an edge event monitors only the LSB of the
-      // expression. A whole-signal footprint already reduces to the LSB at the
-      // runtime trigger, so only a bit-addressed footprint needs collapsing.
-      if (leaf.edge_kind != hir::EventEdge::kAnyChange &&
-          leaf.footprint.has_value()) {
-        leaf.footprint = {{leaf.footprint->first, leaf.footprint->first}};
-      }
-      union_reads.push_back(leaf);
-    }
-  }
-
-  mir::Block child_block;
-  const WalkFrame child_frame = frame.WithBlock(&child_block).Deeper();
-  child_block.AppendStmt(
-      BuildSensitivityWaitStmt(process.Owner(), union_reads));
-  const hir::Stmt& inner_hir = process.HirBody().stmts.Get(t.stmt);
-  auto inner_or = process.LowerStmt(inner_hir, child_frame);
-  if (!inner_or) {
-    return std::unexpected(std::move(inner_or.error()));
-  }
-  child_block.AppendStmt(*std::move(inner_or));
-  const mir::BlockId scope_id =
-      frame.current_block->child_scopes.Add(std::move(child_block));
-  return mir::Stmt{
-      .label = std::move(label), .data = mir::BlockStmt{.scope = scope_id}};
+  return LowerTimedWaitWrapper(
+      process, frame, std::move(label), t.stmt,
+      [&](mir::Block&, WalkFrame) -> diag::Result<mir::Stmt> {
+        std::vector<hir::SensitivityEntry> union_reads;
+        union_reads.reserve(ec.triggers.size());
+        for (const auto& trigger : ec.triggers) {
+          if (trigger.sensitivity_list.size() > 1) {
+            return diag::Unsupported(
+                span, diag::DiagCode::kUnsupportedEventTriggerForm,
+                "compound event expressions (concatenation, arithmetic, "
+                "dynamic index) are not yet supported",
+                diag::UnsupportedCategory::kFeature);
+          }
+          for (auto leaf : trigger.sensitivity_list) {
+            // LRM 9.4.2 LSB-reduce: an edge event monitors only the LSB of
+            // the expression. A whole-signal footprint already reduces to the
+            // LSB at the runtime trigger, so only a bit-addressed footprint
+            // needs collapsing.
+            if (leaf.edge_kind != hir::EventEdge::kAnyChange &&
+                leaf.footprint.has_value()) {
+              leaf.footprint = {{leaf.footprint->first, leaf.footprint->first}};
+            }
+            union_reads.push_back(leaf);
+          }
+        }
+        return BuildSensitivityWaitStmt(process.Owner(), union_reads);
+      });
 }
 
 // LRM 9.4.2.2 `@* body`.
@@ -167,20 +174,11 @@ auto LowerImplicitEventTimedStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::TimedStmt& t, const hir::ImplicitEventControl& ie)
     -> diag::Result<mir::Stmt> {
-  mir::Block child_block;
-  const WalkFrame child_frame = frame.WithBlock(&child_block).Deeper();
-  child_block.AppendStmt(
-      BuildSensitivityWaitStmt(process.Owner(), ie.sensitivity_list));
-  const hir::Stmt& inner_hir = process.HirBody().stmts.Get(t.stmt);
-  auto inner_or = process.LowerStmt(inner_hir, child_frame);
-  if (!inner_or) {
-    return std::unexpected(std::move(inner_or.error()));
-  }
-  child_block.AppendStmt(*std::move(inner_or));
-  const mir::BlockId scope_id =
-      frame.current_block->child_scopes.Add(std::move(child_block));
-  return mir::Stmt{
-      .label = std::move(label), .data = mir::BlockStmt{.scope = scope_id}};
+  return LowerTimedWaitWrapper(
+      process, frame, std::move(label), t.stmt,
+      [&](mir::Block&, WalkFrame) -> diag::Result<mir::Stmt> {
+        return BuildSensitivityWaitStmt(process.Owner(), ie.sensitivity_list);
+      });
 }
 
 // LRM 9.4.1 `#N body`.
@@ -188,26 +186,15 @@ auto LowerDelayTimedStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::TimedStmt& t, const hir::DelayControl& d)
     -> diag::Result<mir::Stmt> {
-  auto ticks_or = ResolveDelayTicks(process, d);
-  if (!ticks_or) {
-    return std::unexpected(std::move(ticks_or.error()));
-  }
-  mir::Block child_block;
-  const WalkFrame child_frame = frame.WithBlock(&child_block).Deeper();
-  child_block.AppendStmt(
-      mir::Stmt{
-          .label = std::nullopt,
-          .data = mir::DelayStmt{.duration = *ticks_or}});
-  const hir::Stmt& inner_hir = process.HirBody().stmts.Get(t.stmt);
-  auto inner_or = process.LowerStmt(inner_hir, child_frame);
-  if (!inner_or) {
-    return std::unexpected(std::move(inner_or.error()));
-  }
-  child_block.AppendStmt(*std::move(inner_or));
-  const mir::BlockId scope_id =
-      frame.current_block->child_scopes.Add(std::move(child_block));
-  return mir::Stmt{
-      .label = std::move(label), .data = mir::BlockStmt{.scope = scope_id}};
+  return LowerTimedWaitWrapper(
+      process, frame, std::move(label), t.stmt,
+      [&](mir::Block&, WalkFrame) -> diag::Result<mir::Stmt> {
+        auto ticks_or = ResolveDelayTicks(process, d);
+        if (!ticks_or) return std::unexpected(std::move(ticks_or.error()));
+        return mir::Stmt{
+            .label = std::nullopt,
+            .data = mir::DelayStmt{.duration = *ticks_or}};
+      });
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

The procedural and structural HIR-to-MIR lowering passes carried two near-identical handlers for every context-free expression family (operators, selects, aggregate value-builds), differing only in the pass-class type and the sub-expression accessor. This collapses each pair into one function template over the pass class, reached through a uniform `HirExprs()` / `LowerExpr` surface named by a new `ExprLowerer` concept. Name resolution stays a per-pass-class pair, because a bare name maps to different storage depending on the enclosing scope -- the one place the two genuinely diverge.

## Cleanups

Bundled in are a few independent DRY consolidations in the statement and cascade machinery, surfaced while sweeping for the same twin pattern: a `WalkFrame::DeeperBy` method replacing three copies of a descend-N-levels lambda; a shared `LowerTimedWaitWrapper` skeleton behind the four timed-statement forms; a shared `SnapshotExprToLocal` behind the case-selector and unique-check snapshots; and continuous-assign reusing `BuildSelfRefExpr` instead of recomputing the self hops by hand.

## Design

The handler templates are declared in the subsystem headers but defined in the `.cpp` and explicitly instantiated for the two pass classes, so the large file-local helpers stay private and the header does not pull them in. The `ExprLowerer` concept names the duck-typed contract both pass classes satisfy without a shared base class or v-table; `lowering_organization.md` records the rule as a new invariant.

## Testing

`bazel test //...` green; clang-format, buildifier, and the architecture / ascii / cpp-style / exceptions policy checks pass.