### PR TITLE
Connect ports on arrays of instances

### DIFF
--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -197,7 +197,12 @@ Unlocks `refs/hierarchical_refs`, `refs/upward_refs`, and `instantiation/hierarc
       at the data type's default initial value (LRM 23.3.2.2 / 23.3.3.2), as does an unconnected
       port with no default; an explicit expression overrides. Defaults are permitted only on input
       ports (LRM 23.2.2.4), which the frontend enforces.
-- [ ] E9 -- A port connection on an instance array drives each element.
+- [x] E9 -- A port connection on an instance array drives each element's own cell (LRM 23.3.3.5).
+      The connection is distributed per element -- replicated to every element when its size matches
+      a single port, or mapped element to element when it matches the array dimensions -- and each
+      element's port is then the same implied continuous assignment a scalar instance gets, in
+      either direction. Covered for one- and multi-dimensional arrays, replicated and array-matched
+      connections, on inputs and outputs.
 - [x] E10 -- A port connection whose type is non-integral resolves as the same implied continuous
       assignment an integral port does (LRM 23.3.3), with no dependence on the data type: the child
       cell is driven from, or drives, the parent-side storage, and the output side re-triggers the

--- a/include/lyra/lowering/ast_to_hir/continuous_assign.hpp
+++ b/include/lyra/lowering/ast_to_hir/continuous_assign.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <vector>
+
+#include "lyra/diag/source_span.hpp"
+#include "lyra/hir/continuous_assign.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/lowering/ast_to_hir/sensitivity.hpp"
+#include "lyra/lowering/ast_to_hir/walk_frame.hpp"
+
+namespace lyra::lowering::ast_to_hir {
+
+class ModuleLowerer;
+
+// Assembles a continuous assignment (LRM 10.3.2) from its two already-built
+// operand expressions and the read set its sensitivity derives from. The
+// operands are interned into the frame's structural scope; the sensitivity list
+// is always `ModuleLowerer::TranslateSensitivityReads(reads)` -- the single
+// place a read set is mapped to its runtime projection -- so every source of a
+// continuous assignment (an `assign` statement, a port connection in either
+// direction) shares one type-independent sensitivity contract. The returned
+// node is detached; the caller interns it into the scope.
+auto BuildContinuousAssign(
+    ModuleLowerer& module, WalkFrame frame, diag::SourceSpan span,
+    hir::Expr lhs, hir::Expr rhs, const std::vector<SensitivityRead>& reads)
+    -> hir::ContinuousAssign;
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
+++ b/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
@@ -1,7 +1,8 @@
-#include "lyra/hir/continuous_assign.hpp"
+#include "lyra/lowering/ast_to_hir/continuous_assign.hpp"
 
 #include <expected>
 #include <utility>
+#include <vector>
 
 #include <slang/ast/Expression.h>
 #include <slang/ast/expressions/AssignmentExpressions.h>
@@ -11,10 +12,28 @@
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/kind.hpp"
+#include "lyra/hir/continuous_assign.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
+
+auto BuildContinuousAssign(
+    ModuleLowerer& module, WalkFrame frame, diag::SourceSpan span,
+    hir::Expr lhs, hir::Expr rhs, const std::vector<SensitivityRead>& reads)
+    -> hir::ContinuousAssign {
+  const hir::ExprId lhs_id =
+      frame.current_structural_scope->exprs.Add(std::move(lhs));
+  const hir::ExprId rhs_id =
+      frame.current_structural_scope->exprs.Add(std::move(rhs));
+  return hir::ContinuousAssign{
+      .span = span,
+      .lhs = lhs_id,
+      .rhs = rhs_id,
+      .sensitivity_list = module.TranslateSensitivityReads(reads, frame),
+  };
+}
 
 auto StructuralScopeLowerer::LowerContinuousAssign(
     const slang::ast::ContinuousAssignSymbol& sym, WalkFrame frame)
@@ -51,26 +70,17 @@ auto StructuralScopeLowerer::LowerContinuousAssign(
   }
   auto lhs_or = LowerExpr(assign.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  const hir::ExprId lhs_id =
-      frame.current_structural_scope->exprs.Add(*std::move(lhs_or));
 
   auto rhs_or = LowerExpr(assign.right(), frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  const hir::ExprId rhs_id =
-      frame.current_structural_scope->exprs.Add(*std::move(rhs_or));
 
   // LRM 10.3.2: continuous assignment sensitivity is the read set of the
   // RHS expression. slang treats the ContinuousAssignSymbol as the
   // procedural scope for analysis purposes.
   const auto& reads = module_->Sensitivity().AnalyzeReads(assignment_expr, sym);
-  auto sensitivity = module_->TranslateSensitivityReads(reads, frame);
 
-  return hir::ContinuousAssign{
-      .span = span,
-      .lhs = lhs_id,
-      .rhs = rhs_id,
-      .sensitivity_list = std::move(sensitivity),
-  };
+  return BuildContinuousAssign(
+      *module_, frame, span, *std::move(lhs_or), *std::move(rhs_or), reads);
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/port_connection.cpp
+++ b/src/lyra/lowering/ast_to_hir/port_connection.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <expected>
 #include <optional>
 #include <string>
@@ -18,9 +19,9 @@
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/kind.hpp"
-#include "lyra/hir/continuous_assign.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/ast_to_hir/constant_value.hpp"
+#include "lyra/lowering/ast_to_hir/continuous_assign.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
@@ -36,32 +37,17 @@ auto PortConnectionUnsupported(diag::SourceSpan span, std::string message)
       diag::UnsupportedCategory::kFeature);
 }
 
-// Descends nested array dimensions to the per-element instance.
-auto ArrayElementInstance(const slang::ast::InstanceArraySymbol& array)
-    -> const slang::ast::InstanceSymbol* {
-  if (array.elements.empty()) {
-    return nullptr;
-  }
-  const auto* first = array.elements.front();
-  if (first->kind == slang::ast::SymbolKind::InstanceArray) {
-    return ArrayElementInstance(first->as<slang::ast::InstanceArraySymbol>());
-  }
-  return &first->as<slang::ast::InstanceSymbol>();
-}
-
-auto PopulateInstancePortConnections(
+// Connects one instance's ports, the instance reached from its owning scope by
+// navigating `head` then `index_prefix` (empty for a scalar instance, one
+// `IndexHop` per dimension for an array element). Each port appends its own
+// member hop, so a connection is the same continuous assignment whether the
+// instance stands alone or sits at `c[i][j]` in an array.
+auto ConnectElementPorts(
     StructuralScopeLowerer& scope, ModuleLowerer& module,
-    const slang::ast::InstanceSymbol& inst, WalkFrame frame)
-    -> diag::Result<void> {
+    const slang::ast::InstanceSymbol& inst, hir::DownwardHead head,
+    ScopeFrameId home_frame, const std::vector<hir::PathStep>& index_prefix,
+    WalkFrame frame) -> diag::Result<void> {
   const auto span = module.SourceMapper().PointSpanOf(inst.location);
-
-  // The instance member is bound in the pre-pass; a downward port reach
-  // cannot miss it, so absence is a compiler-bug invariant.
-  const auto binding = module.LookupOwnedChildBinding(inst);
-  if (!binding.has_value()) {
-    throw InternalError(
-        "PopulateInstancePortConnections: instance member has no binding");
-  }
 
   for (const auto* conn : inst.getPortConnections()) {
     if (conn->port.kind != slang::ast::SymbolKind::Port) {
@@ -108,9 +94,10 @@ auto PopulateInstancePortConnections(
       continue;
     }
 
+    std::vector<hir::PathStep> path = index_prefix;
+    path.emplace_back(hir::MemberHop{std::string{internal->name}});
     hir::Expr child_ref = module.MakeCrossUnitMemberRef(
-        *internal, binding->home_frame, binding->head,
-        {hir::MemberHop{std::string{internal->name}}}, *type_id, span);
+        *internal, home_frame, head, std::move(path), *type_id, span);
 
     if (port.direction == slang::ast::ArgumentDirection::In) {
       // The child port is driven by the connection's value: the parent-side
@@ -126,7 +113,7 @@ auto PopulateInstancePortConnections(
         const auto* constant = expr->getConstant();
         if (constant == nullptr) {
           throw InternalError(
-              "PopulateInstancePortConnections: port default did not fold to a "
+              "ConnectElementPorts: port default did not fold to a "
               "constant");
         }
         auto rhs_or = MakeConstantValueExpr(*constant, *type_id, span);
@@ -138,17 +125,10 @@ auto PopulateInstancePortConnections(
         rhs = *std::move(rhs_or);
         reads = module.Sensitivity().AnalyzeReads(*expr, inst);
       }
-      const hir::ExprId lhs_id =
-          frame.current_structural_scope->exprs.Add(std::move(child_ref));
-      const hir::ExprId rhs_id =
-          frame.current_structural_scope->exprs.Add(std::move(rhs));
       frame.current_structural_scope->continuous_assigns.Add(
-          hir::ContinuousAssign{
-              .span = span,
-              .lhs = lhs_id,
-              .rhs = rhs_id,
-              .sensitivity_list =
-                  module.TranslateSensitivityReads(reads, frame)});
+          BuildContinuousAssign(
+              module, frame, span, std::move(child_ref), std::move(rhs),
+              reads));
       continue;
     }
 
@@ -157,28 +137,50 @@ auto PopulateInstancePortConnections(
     // the parent target.
     if (expr->kind != slang::ast::ExpressionKind::Assignment) {
       throw InternalError(
-          "PopulateInstancePortConnections: output port connection expression "
+          "ConnectElementPorts: output port connection expression "
           "is not an assignment");
     }
     const auto& assign = expr->as<slang::ast::AssignmentExpression>();
     auto lhs_or = scope.LowerExpr(assign.left(), frame);
     if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-    const hir::ExprId lhs_id =
-        frame.current_structural_scope->exprs.Add(*std::move(lhs_or));
-    const hir::ExprId rhs_id =
-        frame.current_structural_scope->exprs.Add(std::move(child_ref));
     // The output port observes the child's whole internal signal on any change.
     // It is not a bit-addressed read, so it carries no footprint regardless of
     // the port's data type.
     const std::vector<SensitivityRead> reads{
         SensitivityRead{.symbol = internal, .footprint = std::nullopt}};
     frame.current_structural_scope->continuous_assigns.Add(
-        hir::ContinuousAssign{
-            .span = span,
-            .lhs = lhs_id,
-            .rhs = rhs_id,
-            .sensitivity_list =
-                module.TranslateSensitivityReads(reads, frame)});
+        BuildContinuousAssign(
+            module, frame, span, *std::move(lhs_or), std::move(child_ref),
+            reads));
+  }
+  return {};
+}
+
+// Walks an instance array's elements, extending `index_prefix` by one
+// `IndexHop` per dimension, and connects each leaf element's ports. slang
+// distributes the connection per element (LRM 23.3.3.5), so each element
+// carries its own already index-matched connection expressions; this only
+// routes each to the right cell.
+auto ConnectArrayElements(
+    StructuralScopeLowerer& scope, ModuleLowerer& module,
+    const slang::ast::InstanceArraySymbol& array, hir::DownwardHead head,
+    ScopeFrameId home_frame, const std::vector<hir::PathStep>& index_prefix,
+    WalkFrame frame) -> diag::Result<void> {
+  for (std::uint32_t i = 0; i < array.elements.size(); ++i) {
+    std::vector<hir::PathStep> element_prefix = index_prefix;
+    element_prefix.emplace_back(hir::IndexHop{i});
+    const auto* element = array.elements[i];
+    if (element->kind == slang::ast::SymbolKind::InstanceArray) {
+      auto r = ConnectArrayElements(
+          scope, module, element->as<slang::ast::InstanceArraySymbol>(), head,
+          home_frame, element_prefix, frame);
+      if (!r) return std::unexpected(std::move(r.error()));
+      continue;
+    }
+    auto r = ConnectElementPorts(
+        scope, module, element->as<slang::ast::InstanceSymbol>(), head,
+        home_frame, element_prefix, frame);
+    if (!r) return std::unexpected(std::move(r.error()));
   }
   return {};
 }
@@ -190,17 +192,28 @@ auto StructuralScopeLowerer::PopulatePortConnections(
     -> diag::Result<void> {
   for (const auto& member : slang_scope.members()) {
     if (member.kind == slang::ast::SymbolKind::Instance) {
-      auto r = PopulateInstancePortConnections(
-          *this, *module_, member.as<slang::ast::InstanceSymbol>(), frame);
+      // The instance member is bound in the pre-pass; a downward port reach
+      // cannot miss it, so absence is a compiler-bug invariant.
+      const auto binding = module_->LookupOwnedChildBinding(member);
+      if (!binding.has_value()) {
+        throw InternalError(
+            "PopulatePortConnections: instance member has no binding");
+      }
+      auto r = ConnectElementPorts(
+          *this, *module_, member.as<slang::ast::InstanceSymbol>(),
+          binding->head, binding->home_frame, {}, frame);
       if (!r) return std::unexpected(std::move(r.error()));
     } else if (member.kind == slang::ast::SymbolKind::InstanceArray) {
-      const auto& array = member.as<slang::ast::InstanceArraySymbol>();
-      const auto* element = ArrayElementInstance(array);
-      if (element != nullptr && !element->getPortConnections().empty()) {
-        return PortConnectionUnsupported(
-            module_->SourceMapper().PointSpanOf(array.location),
-            "instance-array port connection is not yet supported");
+      // A zero-element array (`Child c[0]`, LRM 23.3.2) constructs no element
+      // and binds no member, so there is nothing to connect.
+      const auto binding = module_->LookupOwnedChildBinding(member);
+      if (!binding.has_value()) {
+        continue;
       }
+      auto r = ConnectArrayElements(
+          *this, *module_, member.as<slang::ast::InstanceArraySymbol>(),
+          binding->head, binding->home_frame, {}, frame);
+      if (!r) return std::unexpected(std::move(r.error()));
     }
   }
   return {};

--- a/tests/cases/cpp/port_instance_array/case.yaml
+++ b/tests/cases/cpp/port_instance_array/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.port_instance_array
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "o1=1,11,21\no2=8,8\no3=1,101,201,301\n"

--- a/tests/cases/cpp/port_instance_array/main.sv
+++ b/tests/cases/cpp/port_instance_array/main.sv
@@ -1,0 +1,36 @@
+// A port connection on an array of instances drives each element's own cell
+// (LRM 23.3.3.5). slang distributes the connection per element: when the
+// connection's size matches a single port it replicates to every element; when
+// it is an array matching the instance-array dimensions it maps element to
+// element. Either way each element's port is the same implied continuous
+// assignment a scalar instance gets, in either direction, including a
+// multidimensional array.
+module Adder(input int a, output int b);
+  always_comb b = a + 1;
+endmodule
+
+module Test;
+  int in1 [3];
+  int o1 [3];
+  int shared;
+  int o2 [2];
+  int in2 [2][2];
+  int o3 [2][2];
+
+  Adder u [3] (.a(in1), .b(o1));
+  Adder r [2] (.a(shared), .b(o2));
+  Adder g [2][2] (.a(in2), .b(o3));
+
+  initial begin
+    for (int i = 0; i < 3; i++) in1[i] = i * 10;
+    shared = 7;
+    for (int i = 0; i < 2; i++)
+      for (int j = 0; j < 2; j++) in2[i][j] = (i * 2 + j) * 100;
+  end
+
+  final begin
+    $display("o1=%0d,%0d,%0d", o1[0], o1[1], o1[2]);
+    $display("o2=%0d,%0d", o2[0], o2[1]);
+    $display("o3=%0d,%0d,%0d,%0d", o3[0][0], o3[0][1], o3[1][0], o3[1][1]);
+  end
+endmodule


### PR DESCRIPTION
## Summary

A port connection on an array of instances now drives each element's own cell (LRM 23.3.3.5), closing E9 of the hierarchy workstream. slang fully elaborates the array and distributes the connection per element -- replicating a single-port-sized connection to every element, or mapping an array-sized connection element to element -- so each element's port is the same implied continuous assignment a scalar instance already gets. Reaching an element reuses the existing cross-unit navigation: the array member's head plus one `IndexHop` per dimension, then the port's member hop. The runtime navigation, MIR lowering, and reference resolution are unchanged; the prior bail-out was the only missing piece. Covered for one- and multi-dimensional arrays, replicated and array-matched connections, on both inputs and outputs.

## Design

The per-element connection logic is parameterized by an index prefix, so a scalar instance is the empty-prefix case of the same code path and the array walk just accumulates one `IndexHop` per dimension. This PR also extracts `BuildContinuousAssign`, the shared factory that assembles a continuous assignment from its two operand expressions and a read set: the sensitivity list is always `TranslateSensitivityReads(reads)`, the single place a read set maps to its runtime projection. Every source of a continuous assignment -- an `assign` statement and a port connection in either direction -- now routes through it, so the type-independent sensitivity contract cannot be bypassed at a new connection site.

## Testing

`bazel test //...` green. New `port_instance_array` case asserts 1D distribution (in and out), replication of a scalar connection across elements, and 2D distribution.