### PR TITLE
Add associative array 7.12 methods over an entry stream

### DIFF
--- a/docs/decisions/array-manipulation-entry-stream.md
+++ b/docs/decisions/array-manipulation-entry-stream.md
@@ -1,0 +1,126 @@
+# Array manipulation over an entry stream
+
+Date: 2026-06-22 Status: accepted
+
+## Context
+
+LRM 7.12 defines the array-manipulation method families that apply across the unpacked-array
+containers: the locator family (`find` / `find_index` / `find_first` / `min` / `max` / `unique` /
+...), the reduction family (`sum` / `product` / `and` / `or` / `xor`), the `map` projection, and the
+ordering family (`reverse` / `sort` / `rsort` / `shuffle`). The first three apply to every unpacked
+container including the associative array; the ordering family is defined only on the ordinally
+indexed containers (LRM 7.12.2), and the frontend rejects it on an associative receiver.
+
+The four containers differ along exactly one axis that the algorithms see: how an entry is indexed.
+
+| Container         | Enumeration order   | Entry index | Index-locator result | `map` result          |
+| ----------------- | ------------------- | ----------- | -------------------- | --------------------- |
+| fixed unpacked    | declared position   | ordinal int | queue of int         | fixed unpacked of `U` |
+| dynamic array     | position            | ordinal int | queue of int         | dynamic array of `U`  |
+| queue             | position            | ordinal int | queue of int         | queue of `U`          |
+| associative array | key order (LRM 7.8) | the key `K` | queue of `K`         | same-key assoc of `U` |
+
+The locator / reduction / `map` scan logic is identical across all four: a predicate match, an
+extremum, a first-occurrence pass, a fold, or a projection. Nothing in the scan branches on the
+container. The only variation is (1) what an entry's index is, (2) what container the result shapes
+into. Both are properties of the container, not of the algorithm.
+
+The ordering family is a different requirement entirely: an in-place permutation of storage that
+needs random-access exchange of element cells. It is not a function of an index stream, and it never
+runs on an associative array.
+
+## Decision
+
+### Two abstractions, one per requirement cluster
+
+1. **The locator / reduction / `map` families operate over an ordered entry stream** -- a lazily
+   iterated sequence of `(index, element)` pairs in the container's natural order, modelled the way
+   Rust's `Iterator` and C++ `std::ranges` model iteration. The index is a first-class value of the
+   container's index type. The shared algorithm never synthesizes the index and never names a
+   container type; each container exposes its stream as a lazy view (a sequence container is
+   `views::enumerate` over its storage so the index is the ordinal; the associative array is a
+   transform over its `std::map`, whose entries are natively `(key, value)`, so the index is the
+   key). The algorithms are generic combinators over that view -- the locator family filters the
+   entries (`find_first` adds `views::take(1)`, `find_last` adds `views::reverse`), `min` / `max`
+   are `ranges::min_element` / `max_element` under a key projection, reduction is
+   `ranges::fold_left` seeded by the first element, and `map` is a transform -- and each container's
+   thin wrapper shapes the result.
+
+2. **The ordering family stays an in-place positional permutation** on the sequence containers'
+   storage. It is sequence-only; the associative array never participates, and the frontend enforces
+   that. Rust draws the same line: `sort` lives on the mutable slice, not on `Iterator`.
+
+The ordinal-index synthesis that the read-only algorithms once baked in (`int(i)` computed inside
+the shared loop) lives only in the sequence containers' `views::enumerate`, not in any algorithm.
+
+### The entry handle is a Regular value
+
+An entry carries the element by `const`-pointer, not by reference. The algorithms feed entries
+through `std::ranges` machinery, which assumes a Regular (copyable, assignable,
+default-constructible) value; a reference member would forfeit Regularity (a reference cannot be
+rebound) and cap which combinators an entry can flow through. The pointer is a non-owning handle
+produced transiently by the view, never materialised into a stored collection.
+
+### The producer supplies every result's default prototype
+
+Every value-producing method receives the canonical default of its result's element (or scalar) type
+as an argument, built by HIR-to-MIR from the call's result type. The result's runtime shape (bit
+width, signedness, 2/4-state for an integral; the key shape for an index locator) is known at the
+call site and is not always recoverable from the receiver: an index locator on an associative array
+returns a queue of the key type, a `map` returns an element type the `with` expression chose, and a
+reduction over an empty receiver must still carry the result's shape. One rule covers all three --
+the producer supplies the result prototype -- so the runtime never self-derives a result shape from
+the receiver and never fabricates a zero entry to recover one. The ordering family produces no new
+value and takes no prototype.
+
+### The closure index is the container's index type
+
+The `with`-clause closure takes the iterator and its index (LRM 7.12.4 `item.index`). The index
+parameter is typed as the container's index type: an ordinal int for the sequence containers, the
+key type for the associative array. The runtime passes each entry's index straight into the closure,
+so `item.index` reads the key on an associative receiver and the ordinal on a sequence receiver with
+no special-casing.
+
+## Rejected alternatives
+
+- **A parallel associative algorithm family.** Duplicates the match / extremum / first-occurrence /
+  fold / projection logic, which is provably identical across containers. The only differences
+  (index type, enumeration source, result shaping) are container properties already expressible
+  through the entry stream and the thin result wrappers. A second family is the parallel-structure
+  shape the project forbids.
+
+- **Injecting an index function into position-based loops.** Keeping the algorithms on a
+  random-access `Seq&` and passing an `index_of(i)` closure fails for the associative map, whose
+  `std::map` storage has no random-access-by-position. The honest shared input is the ordered entry
+  stream, not a random-access sequence with an index side-channel.
+
+- **Eager materialisation of the entry stream into a vector.** Building a `vector<Entry>` per call,
+  then looping over it, is the "materialise then iterate" shape both Rust iterators and
+  `std::ranges` deliberately avoid: it allocates a throwaway buffer and computes every index up
+  front even when the consumer reads none. The stream is a lazy view instead, so a reduction that
+  ignores the index never builds one and no buffer is allocated.
+
+- **A key-shape prototype field on the associative container.** Carrying a `key_default_` so index
+  locators could self-supply their result shape is unnecessary once the producer supplies result
+  prototypes. An associative array's key shape is carried by its stored keys; any result that needs
+  a key shape (an index locator's queue, including the empty case) receives it from the producer, so
+  the container needs no extra key-shape state.
+
+## Forbidden shapes
+
+- A locator / reduction / `map` algorithm that assumes random-access storage or synthesizes an
+  ordinal index. The index is an entry attribute the container supplies.
+- A value-producing array method that derives its result's runtime shape from the receiver (copying
+  the receiver's element default, or folding a fabricated zero entry to recover a shape). The result
+  shape is producer-supplied.
+- An associative array method that re-implements a 7.12 scan rather than feeding its entry stream
+  through the shared algorithm.
+
+## Notes
+
+The empty-receiver reduction value (LRM 7.12.3 is silent) remains an element-shaped zero; under this
+decision that zero is the producer-supplied result prototype rather than a copy of the receiver's
+shield reset in place, which is the same value reached more directly. The sort-uses-selection-sort
+and empty-reduction-is-zero runtime semantics pinned in
+[array-method-dispatch](array-method-dispatch.md) are unchanged; this decision governs the algorithm
+input shape, not those semantics.

--- a/docs/decisions/array-manipulation-entry-stream.md
+++ b/docs/decisions/array-manipulation-entry-stream.md
@@ -116,6 +116,17 @@ no special-casing.
 - An associative array method that re-implements a 7.12 scan rather than feeding its entry stream
   through the shared algorithm.
 
+## Portability floor
+
+The value layer is compiled under two toolchains -- the bazel library build (GCC) and the clang the
+emitted user program uses -- so it may rely only on the C++23 library features present in both
+standard libraries. The ranges adaptors and algorithms this decision uses (`views::enumerate` /
+`filter` / `transform` / `take` / `reverse`, `ranges::fold_left_first`, `ranges::min_element` /
+`max_element`) are available on both; `std::ranges::to` is not (it lands a standard-library version
+later than the GCC build provides), so the collect step is a small local helper rather than
+`ranges::to`. A new ranges feature is admissible here only once it compiles under both toolchains; a
+quick `g++ -std=c++23 -fsyntax-only` over the value headers reproduces the GCC side locally.
+
 ## Notes
 
 The empty-receiver reduction value (LRM 7.12.3 is silent) remains an element-shaped zero; under this

--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -41,7 +41,7 @@ follow once dynamic array's storage and runtime conventions are settled and prov
 | A2   | Done: traversal protocol (`first` / `last` / `next` / `prev`).          |
 | A3   | Done: `foreach` over an associative array (any dimensionality).         |
 | A4   | Done: literals with optional default, whole-array assignment.           |
-| A5   | Open: locator / reduction / map manipulation methods (key-indexed).     |
+| A5   | Done: locator / reduction / map manipulation methods (key-indexed).     |
 | A6   | Open: wildcard `[*]` index; struct / class index families.              |
 
 ## Dynamic Array
@@ -223,7 +223,7 @@ the lookup key and imposes an ordering.
       arrays of the same index type clears the target and copies every source entry (LRM 7.9.9); an
       associative array is assignment-compatible only with an associative array.
 
-- [ ] A5 -- The associative-array manipulation-method family (LRM 7.12): the locator family (`find`,
+- [x] A5 -- The associative-array manipulation-method family (LRM 7.12): the locator family (`find`,
       `find_index`, `find_first`, `find_first_index`, `find_last`, `find_last_index`, `min`, `max`,
       `unique`, `unique_index`), the reduction family (`sum`, `product`, `and`, `or`, `xor`), and
       the `map` projection, each with the `with`-clause and iterator-index forms shared with the
@@ -254,8 +254,11 @@ the lookup key and imposes an ordering.
 - Archive items: `datatypes/general/*`.
 - Unblocks: `control-flow.md` C10 (foreach over dynamic / queue / associative subset).
 - Decision: `../decisions/runtime-shape-and-default-value.md` -- runtime shape is retained on
-  `PackedArray`; collection wrappers carry one `oob_slot_` member that doubles as canonical-default
-  source and OOB-write discard target, reset via `T::ResetToDefault` on every OOB access.
+  `PackedArray`; each collection wrapper carries an immutable element-default prototype and a
+  separate write-discard sink, so the read path is pure.
+- Decision: `../decisions/array-manipulation-entry-stream.md` -- the LRM 7.12 locator / reduction /
+  map family runs over an ordered `(index, element)` entry stream the container supplies (the key
+  for an associative receiver), and the producer supplies every result's default prototype.
 - Cross-cutting: `refactor.md` R2 (done) -- these container value types are observable cells and
   react under `wait` / `always_comb` / `@*`, and a non-integral input port is admitted (the U8
   analogue for these containers).

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -160,6 +160,11 @@ enum class BuiltinFn : std::uint16_t {
 // `reverse`) take no closure.
 [[nodiscard]] auto ArrayMethodTakesClosure(BuiltinFn id) -> bool;
 
+// True iff the LRM 7.12 method yields a new value whose result shape the
+// producer supplies (the reduction, locator, and map families). The ordering
+// family (`sort` / `rsort` / `reverse`) mutates in place and yields none.
+[[nodiscard]] auto ArrayMethodProducesValue(BuiltinFn id) -> bool;
+
 // True iff `id` is an associative-array traversal entry (LRM 7.9.4 -- 7.9.7).
 // The traversal family lowers to an immediately-invoked closure (mutates the
 // index argument and runs the write-back inline).

--- a/include/lyra/value/array_manipulation.hpp
+++ b/include/lyra/value/array_manipulation.hpp
@@ -75,6 +75,20 @@ template <typename K>
   return false;
 }
 
+// Collect a lazy view into a vector. The value layer is built under two
+// toolchains (the emit clang and the bazel GCC); `std::ranges::to` is absent on
+// the GCC libstdc++ the bazel build uses, and a 7.12 result is shaped into an
+// SV container by the caller anyway, so the projected values are gathered here.
+template <typename V>
+[[nodiscard]] auto ToVector(V view)
+    -> std::vector<std::ranges::range_value_t<V>> {
+  std::vector<std::ranges::range_value_t<V>> out;
+  for (auto&& x : view) {
+    out.push_back(static_cast<decltype(x)>(x));
+  }
+  return out;
+}
+
 // LRM 7.12.1 find core: the entries satisfying `pred`, as a lazy view. The
 // locator family composes over it -- `find` collects every match, `find_first`
 // is `take(1)`, `find_last` is `reverse | take(1)` -- so "leftmost" and
@@ -88,42 +102,42 @@ template <typename R, typename Pred>
 
 template <typename R, typename F>
 [[nodiscard]] auto ArrayFind(R entries, F pred) -> std::vector<ElementOf<R>> {
-  return std::ranges::to<std::vector>(
+  return ToVector(
       Matching(entries, pred) |
       std::views::transform([](const auto& e) { return *e.element; }));
 }
 template <typename R, typename F>
 [[nodiscard]] auto ArrayFindIndex(R entries, F pred)
     -> std::vector<IndexOf<R>> {
-  return std::ranges::to<std::vector>(
+  return ToVector(
       Matching(entries, pred) |
       std::views::transform([](const auto& e) { return e.index; }));
 }
 template <typename R, typename F>
 [[nodiscard]] auto ArrayFindFirst(R entries, F pred)
     -> std::vector<ElementOf<R>> {
-  return std::ranges::to<std::vector>(
+  return ToVector(
       Matching(entries, pred) | std::views::take(1) |
       std::views::transform([](const auto& e) { return *e.element; }));
 }
 template <typename R, typename F>
 [[nodiscard]] auto ArrayFindFirstIndex(R entries, F pred)
     -> std::vector<IndexOf<R>> {
-  return std::ranges::to<std::vector>(
+  return ToVector(
       Matching(entries, pred) | std::views::take(1) |
       std::views::transform([](const auto& e) { return e.index; }));
 }
 template <typename R, typename F>
 [[nodiscard]] auto ArrayFindLast(R entries, F pred)
     -> std::vector<ElementOf<R>> {
-  return std::ranges::to<std::vector>(
+  return ToVector(
       Matching(entries, pred) | std::views::reverse | std::views::take(1) |
       std::views::transform([](const auto& e) { return *e.element; }));
 }
 template <typename R, typename F>
 [[nodiscard]] auto ArrayFindLastIndex(R entries, F pred)
     -> std::vector<IndexOf<R>> {
-  return std::ranges::to<std::vector>(
+  return ToVector(
       Matching(entries, pred) | std::views::reverse | std::views::take(1) |
       std::views::transform([](const auto& e) { return e.index; }));
 }
@@ -176,14 +190,14 @@ template <typename R, typename F>
 }
 template <typename R, typename F>
 [[nodiscard]] auto ArrayUnique(R entries, F key) -> std::vector<ElementOf<R>> {
-  return std::ranges::to<std::vector>(
+  return ToVector(
       UniqueEntries(entries, key) |
       std::views::transform([](const auto& e) { return *e.element; }));
 }
 template <typename R, typename F>
 [[nodiscard]] auto ArrayUniqueIndex(R entries, F key)
     -> std::vector<IndexOf<R>> {
-  return std::ranges::to<std::vector>(
+  return ToVector(
       UniqueEntries(entries, key) |
       std::views::transform([](const auto& e) { return e.index; }));
 }

--- a/include/lyra/value/array_manipulation.hpp
+++ b/include/lyra/value/array_manipulation.hpp
@@ -3,26 +3,50 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <ranges>
 #include <type_traits>
-#include <utility>
 #include <vector>
 
 #include "lyra/value/packed_array.hpp"
 
-// LRM 7.12 array manipulation algorithms, shared by every indexable sequence
-// container (dynamic array, queue, and -- when wired -- fixed unpacked array).
-// The algorithms read the receiver only through `data[i]` and `data.size()`, so
-// one template body serves `std::vector` and `std::deque` element storage
-// alike. Each container exposes the LRM-named methods as thin wrappers over
-// these; the value/index shaping (a result queue of elements vs of `int`) is
-// the container's concern, so the algorithms return a plain `std::vector` or a
-// scalar and never name a container type.
+// LRM 7.12 array manipulation algorithms. The locator / reduction / map family
+// runs over a container's entry stream -- a lazily iterated sequence of
+// `(index, element)` pairs in the container's natural order. The index is the
+// container's index type (an ordinal int for the sequence containers, the key
+// for an associative array), so these algorithms never synthesize it and never
+// name a container type; they are generic combinators over any range whose
+// element is an `Entry`. The container supplies that range (see each
+// container's `Entries()`), and shapes the result. The ordering family
+// (`reverse` / `sort`) is a separate, sequence-only in-place permutation that
+// needs random-access storage; it stays on the positional `Seq&` form below.
+// See `docs/decisions/array-manipulation-entry-stream.md`.
 namespace lyra::value::detail {
+
+// One entry of a container's 7.12 stream: the element by const pointer (a
+// Regular non-owning handle, so an Entry composes with every generic algorithm)
+// and its index value. The handle is a pointer rather than a reference because
+// the algorithms below feed entries through `std::ranges` machinery that
+// assumes a Regular (copyable, assignable) value; a reference member would
+// forfeit that.
+template <typename Index, typename Element>
+struct Entry {
+  using IndexType = Index;
+  using ElementType = Element;
+  Index index;
+  const Element* element;
+};
+
+template <typename R>
+using EntryOf = std::ranges::range_value_t<std::remove_cvref_t<R>>;
+template <typename R>
+using IndexOf = typename EntryOf<R>::IndexType;
+template <typename R>
+using ElementOf = typename EntryOf<R>::ElementType;
 
 // LRM 7.12.1 locator comparison over a key type (the element itself for the
 // no-`with` form, or the `with`-expression result otherwise). `PackedArray`
 // returns a 1-bit truth value whose X/Z collapses to false in a boolean
-// context; `String` / `double` return a plain `bool`.
+// context; `String` / `Real` return a plain `bool`.
 template <typename K>
 [[nodiscard]] auto LocatorKeyLess(const K& a, const K& b) -> bool {
   return static_cast<bool>(a < b);
@@ -40,84 +64,6 @@ template <typename K>
   }
 }
 
-// The per-element index handed to every `with`-clause closure. A `PackedArray`
-// so `item.index` reads as a regular integral value in SV semantics (LRM
-// 7.12.4).
-[[nodiscard]] inline auto LocatorIndex(std::size_t i) -> PackedArray {
-  return PackedArray::Int(static_cast<int>(i));
-}
-
-template <typename Seq>
-[[nodiscard]] auto ElementsAtIndices(
-    const Seq& data, const std::vector<std::size_t>& indices)
-    -> std::vector<typename Seq::value_type> {
-  std::vector<typename Seq::value_type> out;
-  out.reserve(indices.size());
-  for (std::size_t i : indices) {
-    out.push_back(data[i]);
-  }
-  return out;
-}
-
-[[nodiscard]] inline auto IndicesAsPacked(
-    const std::vector<std::size_t>& indices) -> std::vector<PackedArray> {
-  std::vector<PackedArray> out;
-  out.reserve(indices.size());
-  for (std::size_t i : indices) {
-    out.push_back(LocatorIndex(i));
-  }
-  return out;
-}
-
-enum class LocatorScan : std::uint8_t { kAll, kFirst, kLast };
-
-// LRM 7.12.1 find family core: positions satisfying `pred`, collecting every
-// match (`kAll`), the leftmost (`kFirst`), or the rightmost (`kLast`).
-template <typename Seq, typename F>
-[[nodiscard]] auto MatchingIndices(const Seq& data, F& pred, LocatorScan scan)
-    -> std::vector<std::size_t> {
-  std::vector<std::size_t> out;
-  if (scan == LocatorScan::kLast) {
-    for (std::size_t i = data.size(); i-- > 0;) {
-      if (static_cast<bool>(pred(data[i], LocatorIndex(i)))) {
-        out.push_back(i);
-        break;
-      }
-    }
-    return out;
-  }
-  for (std::size_t i = 0; i < data.size(); ++i) {
-    if (static_cast<bool>(pred(data[i], LocatorIndex(i)))) {
-      out.push_back(i);
-      if (scan == LocatorScan::kFirst) {
-        break;
-      }
-    }
-  }
-  return out;
-}
-
-// LRM 7.12.1 min / max core: the single position whose key the `prefer`
-// comparator ranks first. Empty receiver yields no position.
-template <typename Seq, typename F, typename Prefer>
-[[nodiscard]] auto ExtremumIndex(const Seq& data, F& key, Prefer prefer)
-    -> std::vector<std::size_t> {
-  std::vector<std::size_t> out;
-  if (!data.empty()) {
-    std::size_t pick = 0;
-    auto best = key(data[0], LocatorIndex(0));
-    for (std::size_t i = 1; i < data.size(); ++i) {
-      auto k = key(data[i], LocatorIndex(i));
-      if (prefer(k, best)) {
-        best = k;
-        pick = i;
-      }
-    }
-    out.push_back(pick);
-  }
-  return out;
-}
-
 template <typename K>
 [[nodiscard]] auto SeenContains(const std::vector<K>& seen, const K& k)
     -> bool {
@@ -129,84 +75,144 @@ template <typename K>
   return false;
 }
 
-// LRM 7.12.1 unique / unique_index core: the position of the first occurrence
-// of each distinct key value, in first-seen order.
-template <typename Seq, typename F>
-[[nodiscard]] auto UniqueRepresentativeIndices(const Seq& data, F& key)
-    -> std::vector<std::size_t> {
-  using KeyT = std::invoke_result_t<
-      F&, const typename Seq::value_type&, const PackedArray&>;
-  std::vector<std::size_t> out;
-  std::vector<KeyT> seen;
-  for (std::size_t i = 0; i < data.size(); ++i) {
-    auto k = key(data[i], LocatorIndex(i));
-    if (!SeenContains(seen, k)) {
-      seen.push_back(k);
-      out.push_back(i);
-    }
+// LRM 7.12.1 find core: the entries satisfying `pred`, as a lazy view. The
+// locator family composes over it -- `find` collects every match, `find_first`
+// is `take(1)`, `find_last` is `reverse | take(1)` -- so "leftmost" and
+// "rightmost" are view adaptors rather than a hand-rolled scan mode.
+template <typename R, typename Pred>
+[[nodiscard]] auto Matching(R entries, Pred pred) {
+  return entries | std::views::filter([pred](const auto& e) {
+           return static_cast<bool>(pred(*e.element, e.index));
+         });
+}
+
+template <typename R, typename F>
+[[nodiscard]] auto ArrayFind(R entries, F pred) -> std::vector<ElementOf<R>> {
+  return std::ranges::to<std::vector>(
+      Matching(entries, pred) |
+      std::views::transform([](const auto& e) { return *e.element; }));
+}
+template <typename R, typename F>
+[[nodiscard]] auto ArrayFindIndex(R entries, F pred)
+    -> std::vector<IndexOf<R>> {
+  return std::ranges::to<std::vector>(
+      Matching(entries, pred) |
+      std::views::transform([](const auto& e) { return e.index; }));
+}
+template <typename R, typename F>
+[[nodiscard]] auto ArrayFindFirst(R entries, F pred)
+    -> std::vector<ElementOf<R>> {
+  return std::ranges::to<std::vector>(
+      Matching(entries, pred) | std::views::take(1) |
+      std::views::transform([](const auto& e) { return *e.element; }));
+}
+template <typename R, typename F>
+[[nodiscard]] auto ArrayFindFirstIndex(R entries, F pred)
+    -> std::vector<IndexOf<R>> {
+  return std::ranges::to<std::vector>(
+      Matching(entries, pred) | std::views::take(1) |
+      std::views::transform([](const auto& e) { return e.index; }));
+}
+template <typename R, typename F>
+[[nodiscard]] auto ArrayFindLast(R entries, F pred)
+    -> std::vector<ElementOf<R>> {
+  return std::ranges::to<std::vector>(
+      Matching(entries, pred) | std::views::reverse | std::views::take(1) |
+      std::views::transform([](const auto& e) { return *e.element; }));
+}
+template <typename R, typename F>
+[[nodiscard]] auto ArrayFindLastIndex(R entries, F pred)
+    -> std::vector<IndexOf<R>> {
+  return std::ranges::to<std::vector>(
+      Matching(entries, pred) | std::views::reverse | std::views::take(1) |
+      std::views::transform([](const auto& e) { return e.index; }));
+}
+
+// LRM 7.12.1 min / max: the element of the entry whose projected key is least
+// (`min`) or greatest (`max`), first on ties. Empty receiver yields an empty
+// queue.
+template <typename R, typename F>
+[[nodiscard]] auto ArrayMin(R entries, F key) -> std::vector<ElementOf<R>> {
+  auto proj = [&](const auto& e) { return key(*e.element, e.index); };
+  auto cmp = [](const auto& a, const auto& b) { return LocatorKeyLess(a, b); };
+  std::vector<ElementOf<R>> out;
+  auto it = std::ranges::min_element(entries, cmp, proj);
+  if (it != std::ranges::end(entries)) {
+    auto e = *it;
+    out.push_back(*e.element);
+  }
+  return out;
+}
+template <typename R, typename F>
+[[nodiscard]] auto ArrayMax(R entries, F key) -> std::vector<ElementOf<R>> {
+  auto proj = [&](const auto& e) { return key(*e.element, e.index); };
+  auto cmp = [](const auto& a, const auto& b) { return LocatorKeyLess(a, b); };
+  std::vector<ElementOf<R>> out;
+  auto it = std::ranges::max_element(entries, cmp, proj);
+  if (it != std::ranges::end(entries)) {
+    auto e = *it;
+    out.push_back(*e.element);
   }
   return out;
 }
 
-template <typename Seq, typename F>
-[[nodiscard]] auto ArrayFind(const Seq& data, F pred)
-    -> std::vector<typename Seq::value_type> {
-  return ElementsAtIndices(
-      data, MatchingIndices(data, pred, LocatorScan::kAll));
+// LRM 7.12.1 unique core: the first-occurrence entry of each distinct
+// projected-key value, in first-seen order. The standard library offers only
+// adjacent de-duplication, so the first-occurrence pass is explicit; the
+// element / index split is then the same `transform` the find family uses.
+template <typename R, typename F>
+[[nodiscard]] auto UniqueEntries(R entries, F key) -> std::vector<EntryOf<R>> {
+  using KeyT = std::invoke_result_t<F&, const ElementOf<R>&, const IndexOf<R>&>;
+  std::vector<EntryOf<R>> out;
+  std::vector<KeyT> seen;
+  for (const auto& e : entries) {
+    auto k = key(*e.element, e.index);
+    if (!SeenContains(seen, k)) {
+      seen.push_back(k);
+      out.push_back(e);
+    }
+  }
+  return out;
 }
-template <typename Seq, typename F>
-[[nodiscard]] auto ArrayFindIndex(const Seq& data, F pred)
-    -> std::vector<PackedArray> {
-  return IndicesAsPacked(MatchingIndices(data, pred, LocatorScan::kAll));
+template <typename R, typename F>
+[[nodiscard]] auto ArrayUnique(R entries, F key) -> std::vector<ElementOf<R>> {
+  return std::ranges::to<std::vector>(
+      UniqueEntries(entries, key) |
+      std::views::transform([](const auto& e) { return *e.element; }));
 }
-template <typename Seq, typename F>
-[[nodiscard]] auto ArrayFindFirst(const Seq& data, F pred)
-    -> std::vector<typename Seq::value_type> {
-  return ElementsAtIndices(
-      data, MatchingIndices(data, pred, LocatorScan::kFirst));
-}
-template <typename Seq, typename F>
-[[nodiscard]] auto ArrayFindFirstIndex(const Seq& data, F pred)
-    -> std::vector<PackedArray> {
-  return IndicesAsPacked(MatchingIndices(data, pred, LocatorScan::kFirst));
-}
-template <typename Seq, typename F>
-[[nodiscard]] auto ArrayFindLast(const Seq& data, F pred)
-    -> std::vector<typename Seq::value_type> {
-  return ElementsAtIndices(
-      data, MatchingIndices(data, pred, LocatorScan::kLast));
-}
-template <typename Seq, typename F>
-[[nodiscard]] auto ArrayFindLastIndex(const Seq& data, F pred)
-    -> std::vector<PackedArray> {
-  return IndicesAsPacked(MatchingIndices(data, pred, LocatorScan::kLast));
+template <typename R, typename F>
+[[nodiscard]] auto ArrayUniqueIndex(R entries, F key)
+    -> std::vector<IndexOf<R>> {
+  return std::ranges::to<std::vector>(
+      UniqueEntries(entries, key) |
+      std::views::transform([](const auto& e) { return e.index; }));
 }
 
-template <typename Seq, typename F>
-[[nodiscard]] auto ArrayMin(const Seq& data, F key)
-    -> std::vector<typename Seq::value_type> {
-  return ElementsAtIndices(
-      data, ExtremumIndex(data, key, [](const auto& a, const auto& b) {
-        return LocatorKeyLess(a, b);
-      }));
+// LRM 7.12.3 reduction: fold the closure-projected values with `comb`, seeded
+// by the first projected value so an empty receiver yields `proto` (LRM is
+// silent on empty input; the producer supplies the result-shaped zero -- see
+// the decision doc). The result type follows the closure's return type, so a
+// width-widening `with`-expression widens the result.
+template <typename R, typename Key, typename Comb, typename Acc>
+[[nodiscard]] auto ArrayFold(R entries, Acc proto, Key key, Comb comb) -> Acc {
+  auto vals = entries | std::views::transform([&](const auto& e) {
+                return key(*e.element, e.index);
+              });
+  return std::ranges::fold_left_first(vals, comb).value_or(std::move(proto));
 }
-template <typename Seq, typename F>
-[[nodiscard]] auto ArrayMax(const Seq& data, F key)
-    -> std::vector<typename Seq::value_type> {
-  return ElementsAtIndices(
-      data, ExtremumIndex(data, key, [](const auto& a, const auto& b) {
-        return LocatorKeyLess(b, a);
-      }));
-}
-template <typename Seq, typename F>
-[[nodiscard]] auto ArrayUnique(const Seq& data, F key)
-    -> std::vector<typename Seq::value_type> {
-  return ElementsAtIndices(data, UniqueRepresentativeIndices(data, key));
-}
-template <typename Seq, typename F>
-[[nodiscard]] auto ArrayUniqueIndex(const Seq& data, F key)
-    -> std::vector<PackedArray> {
-  return IndicesAsPacked(UniqueRepresentativeIndices(data, key));
+
+// LRM 7.12.5 projection into the closure's return type, in entry order. The
+// caller pairs the result with each entry's index when the result container is
+// keyed (associative); a sequence container drops the index.
+template <typename R, typename F>
+[[nodiscard]] auto ArrayMap(R entries, F closure) -> std::vector<
+    std::invoke_result_t<F&, const ElementOf<R>&, const IndexOf<R>&>> {
+  using U = std::invoke_result_t<F&, const ElementOf<R>&, const IndexOf<R>&>;
+  std::vector<U> out;
+  for (const auto& e : entries) {
+    out.push_back(closure(*e.element, e.index));
+  }
+  return out;
 }
 
 // LRM 7.12.2 reverse: in-place reversal. `iter_swap` exchanges element storage
@@ -222,7 +228,9 @@ auto ArrayReverse(Seq& data) -> void {
 // introsort move-assigns elements, which trips `PackedArray`'s
 // shape-preservation invariant; exchanging storage via the ADL `swap` stays
 // shape-safe, and test-sized arrays make the asymptotic cost a non-issue. The
-// per-element key is materialised once, then the elements move in sync.
+// per-element key is materialised once, then the elements move in sync. The
+// ordering family is positional (LRM 7.12.2 is sequence-only), so the index
+// passed to the key closure is the ordinal position.
 template <typename Seq, typename F, typename Compare>
 auto ArraySortByKey(Seq& data, F key, Compare cmp) -> void {
   using KeyT = std::invoke_result_t<
@@ -230,7 +238,7 @@ auto ArraySortByKey(Seq& data, F key, Compare cmp) -> void {
   std::vector<KeyT> keys;
   keys.reserve(data.size());
   for (std::size_t i = 0; i < data.size(); ++i) {
-    keys.push_back(key(data[i], LocatorIndex(i)));
+    keys.push_back(key(data[i], PackedArray::Int(static_cast<int>(i))));
   }
   using std::swap;
   for (std::size_t i = 0; i + 1 < data.size(); ++i) {
@@ -245,47 +253,6 @@ auto ArraySortByKey(Seq& data, F key, Compare cmp) -> void {
       swap(data[i], data[pick]);
     }
   }
-}
-
-// LRM 7.12.3 reduction: fold the closure-projected values with `combine`. The
-// result type follows the closure's return type, so a width-widening
-// `with`-expression (`sum with (int'(item))`) widens the result (LRM 7.12.3).
-// An empty receiver yields the closure-shaped zero (slang behaviour; LRM is
-// silent), synthesised from the element shield slot.
-template <typename Seq, typename T, typename F, typename Combine>
-[[nodiscard]] auto ArrayFold(
-    const Seq& data, const T& oob_slot, F key, Combine combine)
-    -> std::invoke_result_t<F&, const T&, const PackedArray&> {
-  if (data.empty()) {
-    T zero = oob_slot;
-    zero.ResetToDefault();
-    auto acc = key(zero, LocatorIndex(0));
-    acc.ResetToDefault();
-    return acc;
-  }
-  auto acc = key(data[0], LocatorIndex(0));
-  for (std::size_t i = 1; i < data.size(); ++i) {
-    auto v = key(data[i], LocatorIndex(i));
-    combine(acc, v);
-  }
-  return acc;
-}
-
-// LRM 7.12.5 projection into the closure's return type. The caller seeds the
-// result container with a producer-supplied shield because that element type's
-// runtime shape is not recoverable from the C++ type alone.
-template <typename Seq, typename F>
-[[nodiscard]] auto ArrayMap(const Seq& data, F& closure)
-    -> std::vector<std::invoke_result_t<
-        F&, const typename Seq::value_type&, const PackedArray&>> {
-  using U = std::invoke_result_t<
-      F&, const typename Seq::value_type&, const PackedArray&>;
-  std::vector<U> out;
-  out.reserve(data.size());
-  for (std::size_t i = 0; i < data.size(); ++i) {
-    out.push_back(closure(data[i], LocatorIndex(i)));
-  }
-  return out;
 }
 
 // LRM 7.4.5 contiguous-range gather. The slice is `count` elements starting at

--- a/include/lyra/value/associative_array.hpp
+++ b/include/lyra/value/associative_array.hpp
@@ -4,15 +4,19 @@
 #include <iterator>
 #include <map>
 #include <optional>
+#include <ranges>
 #include <span>
 #include <string>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 #include "lyra/value/array_case_equal.hpp"
+#include "lyra/value/array_manipulation.hpp"
 #include "lyra/value/concepts.hpp"
 #include "lyra/value/format.hpp"
 #include "lyra/value/packed_array.hpp"
+#include "lyra/value/queue.hpp"
 #include "lyra/value/string.hpp"
 
 namespace lyra::value {
@@ -246,6 +250,107 @@ class AssociativeArray {
     return WriteVisited(probe, PrevKey(probe));
   }
 
+  // LRM 7.12.3 reduction over the entry stream. LRM 7.12.3 permits reduction on
+  // any integral-valued unpacked array, the associative array included; the
+  // ordering family (LRM 7.12.2) is excluded and rejected upstream by slang.
+  // The closure receives each value and its key; `proto` is the
+  // producer-supplied result default returned for an empty array.
+  template <typename F, typename R>
+  [[nodiscard]] auto Sum(F&& key, R proto) const -> R {
+    return detail::ArrayFold(
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a + v; });
+  }
+  template <typename F, typename R>
+  [[nodiscard]] auto Product(F&& key, R proto) const -> R {
+    return detail::ArrayFold(
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a * v; });
+  }
+  template <typename F, typename R>
+  [[nodiscard]] auto And(F&& key, R proto) const -> R {
+    return detail::ArrayFold(
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a & v; });
+  }
+  template <typename F, typename R>
+  [[nodiscard]] auto Or(F&& key, R proto) const -> R {
+    return detail::ArrayFold(
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a | v; });
+  }
+  template <typename F, typename R>
+  [[nodiscard]] auto Xor(F&& key, R proto) const -> R {
+    return detail::ArrayFold(
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a ^ v; });
+  }
+
+  // LRM 7.12.1 locator family over the entry stream. Value locators return a
+  // queue of values; index locators return a queue of the KEY, since an
+  // associative receiver's index is its key (LRM 7.12.1), not an ordinal int.
+  // Both seed the result with the producer-supplied `proto`.
+  template <typename F>
+  [[nodiscard]] auto Find(F pred, V proto) const -> Queue<V> {
+    return Queue<V>(std::move(proto), detail::ArrayFind(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindIndex(F pred, K proto) const -> Queue<K> {
+    return Queue<K>(std::move(proto), detail::ArrayFindIndex(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindFirst(F pred, V proto) const -> Queue<V> {
+    return Queue<V>(std::move(proto), detail::ArrayFindFirst(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindFirstIndex(F pred, K proto) const -> Queue<K> {
+    return Queue<K>(
+        std::move(proto), detail::ArrayFindFirstIndex(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindLast(F pred, V proto) const -> Queue<V> {
+    return Queue<V>(std::move(proto), detail::ArrayFindLast(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindLastIndex(F pred, K proto) const -> Queue<K> {
+    return Queue<K>(
+        std::move(proto), detail::ArrayFindLastIndex(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto Min(F&& key, V proto) const -> Queue<V> {
+    return Queue<V>(
+        std::move(proto), detail::ArrayMin(Entries(), std::forward<F>(key)));
+  }
+  template <typename F>
+  [[nodiscard]] auto Max(F&& key, V proto) const -> Queue<V> {
+    return Queue<V>(
+        std::move(proto), detail::ArrayMax(Entries(), std::forward<F>(key)));
+  }
+  template <typename F>
+  [[nodiscard]] auto Unique(F key, V proto) const -> Queue<V> {
+    return Queue<V>(
+        std::move(proto), detail::ArrayUnique(Entries(), std::move(key)));
+  }
+  template <typename F>
+  [[nodiscard]] auto UniqueIndex(F key, K proto) const -> Queue<K> {
+    return Queue<K>(
+        std::move(proto), detail::ArrayUniqueIndex(Entries(), std::move(key)));
+  }
+
+  // LRM 7.12.5 projection into a same-key associative array: each value maps
+  // through the closure and keeps its key, so the result is keyed identically
+  // with the `with`-expression's element type. `proto` seeds that element
+  // type's canonical default (producer-supplied).
+  template <typename F, typename U>
+  [[nodiscard]] auto Map(F closure, U proto) const -> AssociativeArray<K, U> {
+    std::vector<std::tuple<K, U>> pairs;
+    for (const auto& [k, v] : data_) {
+      pairs.emplace_back(k, closure(v, k));
+    }
+    return AssociativeArray<K, U>(
+        std::move(proto), std::span<const std::tuple<K, U>>{pairs});
+  }
+
   // LRM 11.2.2 aggregate equality / 11.4.5: same key set and each paired value
   // compares equal. A different key set or a different size yields 0; matching
   // empties yield 1. `==` / `!=` propagate X / Z through the per-value `==`;
@@ -356,6 +461,17 @@ class AssociativeArray {
   // default. `element_default_` is never written, so it is returned directly.
   [[nodiscard]] auto MissValue() const -> const V& {
     return user_default_.has_value() ? *user_default_ : element_default_;
+  }
+
+  // The LRM 7.12 entry stream (decision: array-manipulation-entry-stream): a
+  // lazy view pairing each value with its key, in LRM 7.8 key order (the map's
+  // iteration order). The key is the entry index, so an index locator yields
+  // keys and `item.index` reads the key. The map already stores (key, value)
+  // pairs, so the view is a direct transform over its entries.
+  [[nodiscard]] auto Entries() const {
+    return data_ | std::views::transform([](const auto& kv) {
+             return detail::Entry<K, V>{kv.first, &kv.second};
+           });
   }
 
   V element_default_;

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -3,9 +3,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <ranges>
 #include <span>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -255,14 +255,10 @@ class DynamicArray {
     data_.clear();
   }
 
-  // LRM 7.12 ordering and reduction, each a thin wrapper over the shared
-  // `detail::Array*` algorithms. HIR-to-MIR always supplies the closure (the
-  // `with`-clause body or the LRM-default identity), so the runtime exposes
-  // only the closure-taking form; `reverse` takes none -- its `with` clause is
-  // a compiler error filtered upstream by slang. The closure receives each
-  // element and its index and returns a key (ordering) or a summand
-  // (reduction); the reduction result type follows the closure's return type,
-  // so a width-widening `with`-expression widens the result.
+  // LRM 7.12.2 ordering: an in-place positional permutation. `reverse` takes no
+  // closure (its `with` clause is a compiler error filtered upstream by slang);
+  // `sort` / `rsort` order by the closure-projected key, the index passed to
+  // the closure being the ordinal position.
   auto Reverse() -> void {
     detail::ArrayReverse(data_);
   }
@@ -274,113 +270,122 @@ class DynamicArray {
   auto Rsort(F&& key) -> void {
     detail::ArraySortByKey(data_, std::forward<F>(key), std::greater<>{});
   }
-  template <typename F>
-  [[nodiscard]] auto Sum(F&& key) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+
+  // LRM 7.12.3 reduction over the entry stream. The closure receives each
+  // element and its ordinal index; `proto` is the producer-supplied result
+  // default returned for an empty receiver, and otherwise carries the result
+  // shape the fold accumulates into.
+  template <typename F, typename R>
+  [[nodiscard]] auto Sum(F&& key, R proto) const -> R {
     return detail::ArrayFold(
-        data_, element_default_, std::forward<F>(key),
-        [](auto& acc, auto& v) { acc = acc + v; });
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a + v; });
   }
-  template <typename F>
-  [[nodiscard]] auto Product(F&& key) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+  template <typename F, typename R>
+  [[nodiscard]] auto Product(F&& key, R proto) const -> R {
     return detail::ArrayFold(
-        data_, element_default_, std::forward<F>(key),
-        [](auto& acc, auto& v) { acc = acc * v; });
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a * v; });
   }
-  template <typename F>
-  [[nodiscard]] auto And(F&& key) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+  template <typename F, typename R>
+  [[nodiscard]] auto And(F&& key, R proto) const -> R {
     return detail::ArrayFold(
-        data_, element_default_, std::forward<F>(key),
-        [](auto& acc, auto& v) { acc = acc & v; });
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a & v; });
   }
-  template <typename F>
-  [[nodiscard]] auto Or(F&& key) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+  template <typename F, typename R>
+  [[nodiscard]] auto Or(F&& key, R proto) const -> R {
     return detail::ArrayFold(
-        data_, element_default_, std::forward<F>(key),
-        [](auto& acc, auto& v) { acc = acc | v; });
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a | v; });
   }
-  template <typename F>
-  [[nodiscard]] auto Xor(F&& key) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+  template <typename F, typename R>
+  [[nodiscard]] auto Xor(F&& key, R proto) const -> R {
     return detail::ArrayFold(
-        data_, element_default_, std::forward<F>(key),
-        [](auto& acc, auto& v) { acc = acc ^ v; });
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a ^ v; });
   }
 
-  // LRM 7.12.1 locator methods, thin wrappers over the shared `detail::Array*`
-  // algorithms. The value locators (`find`, `find_first`, `find_last`, `min`,
-  // `max`, `unique`) return a queue of elements carrying this array's element
-  // shape via `element_default_`; the index locators return a queue of `int`
-  // whose element default is a plain zero. No match or an empty receiver yields
-  // an empty queue. The `with` clause is mandatory for the find family (a
-  // Boolean predicate) and optional for `min` / `max` / `unique` (a comparison
-  // key, defaulting to the element).
+  // LRM 7.12.1 locator methods over the entry stream. The value locators
+  // (`find`, `find_first`, `find_last`, `min`, `max`, `unique`) return a queue
+  // of elements; the index locators return a queue of the ordinal index. Both
+  // seed the result queue with the producer-supplied `proto`. No match or an
+  // empty receiver yields an empty queue. The `with` clause is mandatory for
+  // the find family (a Boolean predicate) and optional for `min` / `max` /
+  // `unique` (a comparison key, defaulting to the element).
   template <typename F>
-  [[nodiscard]] auto Find(F pred) const -> Queue<T> {
+  [[nodiscard]] auto Find(F pred, T proto) const -> Queue<T> {
+    return Queue<T>(std::move(proto), detail::ArrayFind(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindIndex(F pred, PackedArray proto) const
+      -> Queue<PackedArray> {
+    return Queue<PackedArray>(
+        std::move(proto), detail::ArrayFindIndex(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindFirst(F pred, T proto) const -> Queue<T> {
+    return Queue<T>(std::move(proto), detail::ArrayFindFirst(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindFirstIndex(F pred, PackedArray proto) const
+      -> Queue<PackedArray> {
+    return Queue<PackedArray>(
+        std::move(proto), detail::ArrayFindFirstIndex(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindLast(F pred, T proto) const -> Queue<T> {
+    return Queue<T>(std::move(proto), detail::ArrayFindLast(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindLastIndex(F pred, PackedArray proto) const
+      -> Queue<PackedArray> {
+    return Queue<PackedArray>(
+        std::move(proto), detail::ArrayFindLastIndex(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto Min(F&& key, T proto) const -> Queue<T> {
     return Queue<T>(
-        element_default_, detail::ArrayFind(data_, std::move(pred)));
+        std::move(proto), detail::ArrayMin(Entries(), std::forward<F>(key)));
   }
   template <typename F>
-  [[nodiscard]] auto FindIndex(F pred) const -> Queue<PackedArray> {
-    return {
-        PackedArray::Int(0), detail::ArrayFindIndex(data_, std::move(pred))};
-  }
-  template <typename F>
-  [[nodiscard]] auto FindFirst(F pred) const -> Queue<T> {
+  [[nodiscard]] auto Max(F&& key, T proto) const -> Queue<T> {
     return Queue<T>(
-        element_default_, detail::ArrayFindFirst(data_, std::move(pred)));
+        std::move(proto), detail::ArrayMax(Entries(), std::forward<F>(key)));
   }
   template <typename F>
-  [[nodiscard]] auto FindFirstIndex(F pred) const -> Queue<PackedArray> {
-    return {
-        PackedArray::Int(0),
-        detail::ArrayFindFirstIndex(data_, std::move(pred))};
-  }
-  template <typename F>
-  [[nodiscard]] auto FindLast(F pred) const -> Queue<T> {
+  [[nodiscard]] auto Unique(F key, T proto) const -> Queue<T> {
     return Queue<T>(
-        element_default_, detail::ArrayFindLast(data_, std::move(pred)));
+        std::move(proto), detail::ArrayUnique(Entries(), std::move(key)));
   }
   template <typename F>
-  [[nodiscard]] auto FindLastIndex(F pred) const -> Queue<PackedArray> {
-    return {
-        PackedArray::Int(0),
-        detail::ArrayFindLastIndex(data_, std::move(pred))};
-  }
-  template <typename F>
-  [[nodiscard]] auto Min(F&& key) const -> Queue<T> {
-    return Queue<T>(
-        element_default_, detail::ArrayMin(data_, std::forward<F>(key)));
-  }
-  template <typename F>
-  [[nodiscard]] auto Max(F&& key) const -> Queue<T> {
-    return Queue<T>(
-        element_default_, detail::ArrayMax(data_, std::forward<F>(key)));
-  }
-  template <typename F>
-  [[nodiscard]] auto Unique(F key) const -> Queue<T> {
-    return Queue<T>(
-        element_default_, detail::ArrayUnique(data_, std::move(key)));
-  }
-  template <typename F>
-  [[nodiscard]] auto UniqueIndex(F key) const -> Queue<PackedArray> {
-    return {
-        PackedArray::Int(0), detail::ArrayUniqueIndex(data_, std::move(key))};
+  [[nodiscard]] auto UniqueIndex(F key, PackedArray proto) const
+      -> Queue<PackedArray> {
+    return Queue<PackedArray>(
+        std::move(proto), detail::ArrayUniqueIndex(Entries(), std::move(key)));
   }
 
-  // LRM 7.12.5 projection into a same-shape dynamic array; `element_default`
-  // seeds the result element type's canonical default.
+  // LRM 7.12.5 projection into a same-shape dynamic array; `proto` seeds the
+  // result element type's canonical default (the producer supplies it because
+  // the result element type may differ from this array's).
   template <typename F, typename U>
-  [[nodiscard]] auto Map(F closure, U element_default) const
-      -> DynamicArray<U> {
+  [[nodiscard]] auto Map(F closure, U proto) const -> DynamicArray<U> {
     return DynamicArray<U>(
-        std::move(element_default), detail::ArrayMap(data_, closure));
+        std::move(proto), detail::ArrayMap(Entries(), closure));
   }
 
  private:
+  // The LRM 7.12 entry stream (decision: array-manipulation-entry-stream): a
+  // lazy view pairing each element with its ordinal index, in storage order.
+  [[nodiscard]] auto Entries() const {
+    return std::views::enumerate(data_) |
+           std::views::transform([](auto&& pair) {
+             auto&& [i, e] = pair;
+             return detail::Entry<PackedArray, T>{
+                 PackedArray::Int(static_cast<int>(i)), &e};
+           });
+  }
+
   [[nodiscard]] auto IsInvalidIndex(const PackedArray& idx) const -> bool {
     if (idx.HasUnknown()) return true;
     const auto v = idx.ToInt64();

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -7,9 +7,9 @@
 #include <functional>
 #include <iostream>
 #include <optional>
+#include <ranges>
 #include <span>
 #include <string>
-#include <type_traits>
 #include <utility>
 
 #include "lyra/value/array_case_equal.hpp"
@@ -335,12 +335,9 @@ class Queue {
     data_.erase(data_.begin() + static_cast<std::ptrdiff_t>(index.ToInt64()));
   }
 
-  // LRM 7.12 ordering and reduction (queues are unpacked arrays, LRM 7.10.1),
-  // each a thin wrapper over the shared `detail::Array*` algorithms. HIR-to-MIR
-  // always supplies the closure (the `with`-clause body or the LRM-default
-  // identity); `reverse` takes none -- its `with` clause is a compiler error
-  // filtered upstream by slang. The reduction result type follows the closure's
-  // return type, so a width-widening `with`-expression widens the result.
+  // LRM 7.12.2 ordering: an in-place positional permutation (queues are
+  // unpacked arrays, LRM 7.10.1). `reverse` takes no closure; `sort` / `rsort`
+  // order by the closure-projected key with the ordinal position as index.
   auto Reverse() -> void {
     detail::ArrayReverse(data_);
   }
@@ -352,108 +349,117 @@ class Queue {
   auto Rsort(F&& key) -> void {
     detail::ArraySortByKey(data_, std::forward<F>(key), std::greater<>{});
   }
-  template <typename F>
-  [[nodiscard]] auto Sum(F&& key) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+
+  // LRM 7.12.3 reduction over the entry stream. `proto` is the
+  // producer-supplied result default for an empty receiver and carries the
+  // result shape otherwise.
+  template <typename F, typename R>
+  [[nodiscard]] auto Sum(F&& key, R proto) const -> R {
     return detail::ArrayFold(
-        data_, element_default_, std::forward<F>(key),
-        [](auto& acc, auto& v) { acc = acc + v; });
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a + v; });
   }
-  template <typename F>
-  [[nodiscard]] auto Product(F&& key) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+  template <typename F, typename R>
+  [[nodiscard]] auto Product(F&& key, R proto) const -> R {
     return detail::ArrayFold(
-        data_, element_default_, std::forward<F>(key),
-        [](auto& acc, auto& v) { acc = acc * v; });
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a * v; });
   }
-  template <typename F>
-  [[nodiscard]] auto And(F&& key) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+  template <typename F, typename R>
+  [[nodiscard]] auto And(F&& key, R proto) const -> R {
     return detail::ArrayFold(
-        data_, element_default_, std::forward<F>(key),
-        [](auto& acc, auto& v) { acc = acc & v; });
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a & v; });
   }
-  template <typename F>
-  [[nodiscard]] auto Or(F&& key) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+  template <typename F, typename R>
+  [[nodiscard]] auto Or(F&& key, R proto) const -> R {
     return detail::ArrayFold(
-        data_, element_default_, std::forward<F>(key),
-        [](auto& acc, auto& v) { acc = acc | v; });
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a | v; });
   }
-  template <typename F>
-  [[nodiscard]] auto Xor(F&& key) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+  template <typename F, typename R>
+  [[nodiscard]] auto Xor(F&& key, R proto) const -> R {
     return detail::ArrayFold(
-        data_, element_default_, std::forward<F>(key),
-        [](auto& acc, auto& v) { acc = acc ^ v; });
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a ^ v; });
   }
 
-  // LRM 7.12.1 locator methods. Value locators return a queue of elements
-  // carrying this queue's element shape via `element_default_`; index locators
-  // return a queue of `int`. No match or an empty receiver yields an empty
-  // queue.
+  // LRM 7.12.1 locator methods over the entry stream. Value locators return a
+  // queue of elements; index locators return a queue of the ordinal index.
+  // Both seed the result with the producer-supplied `proto`. No match or an
+  // empty receiver yields an empty queue.
   template <typename F>
-  [[nodiscard]] auto Find(F pred) const -> Queue<T> {
+  [[nodiscard]] auto Find(F pred, T proto) const -> Queue<T> {
+    return Queue<T>(std::move(proto), detail::ArrayFind(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindIndex(F pred, PackedArray proto) const
+      -> Queue<PackedArray> {
+    return Queue<PackedArray>(
+        std::move(proto), detail::ArrayFindIndex(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindFirst(F pred, T proto) const -> Queue<T> {
+    return Queue<T>(std::move(proto), detail::ArrayFindFirst(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindFirstIndex(F pred, PackedArray proto) const
+      -> Queue<PackedArray> {
+    return Queue<PackedArray>(
+        std::move(proto), detail::ArrayFindFirstIndex(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindLast(F pred, T proto) const -> Queue<T> {
+    return Queue<T>(std::move(proto), detail::ArrayFindLast(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindLastIndex(F pred, PackedArray proto) const
+      -> Queue<PackedArray> {
+    return Queue<PackedArray>(
+        std::move(proto), detail::ArrayFindLastIndex(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto Min(F&& key, T proto) const -> Queue<T> {
     return Queue<T>(
-        element_default_, detail::ArrayFind(data_, std::move(pred)));
+        std::move(proto), detail::ArrayMin(Entries(), std::forward<F>(key)));
   }
   template <typename F>
-  [[nodiscard]] auto FindIndex(F pred) const -> Queue<PackedArray> {
-    return {
-        PackedArray::Int(0), detail::ArrayFindIndex(data_, std::move(pred))};
-  }
-  template <typename F>
-  [[nodiscard]] auto FindFirst(F pred) const -> Queue<T> {
+  [[nodiscard]] auto Max(F&& key, T proto) const -> Queue<T> {
     return Queue<T>(
-        element_default_, detail::ArrayFindFirst(data_, std::move(pred)));
+        std::move(proto), detail::ArrayMax(Entries(), std::forward<F>(key)));
   }
   template <typename F>
-  [[nodiscard]] auto FindFirstIndex(F pred) const -> Queue<PackedArray> {
-    return {
-        PackedArray::Int(0),
-        detail::ArrayFindFirstIndex(data_, std::move(pred))};
-  }
-  template <typename F>
-  [[nodiscard]] auto FindLast(F pred) const -> Queue<T> {
+  [[nodiscard]] auto Unique(F key, T proto) const -> Queue<T> {
     return Queue<T>(
-        element_default_, detail::ArrayFindLast(data_, std::move(pred)));
+        std::move(proto), detail::ArrayUnique(Entries(), std::move(key)));
   }
   template <typename F>
-  [[nodiscard]] auto FindLastIndex(F pred) const -> Queue<PackedArray> {
-    return {
-        PackedArray::Int(0),
-        detail::ArrayFindLastIndex(data_, std::move(pred))};
-  }
-  template <typename F>
-  [[nodiscard]] auto Min(F&& key) const -> Queue<T> {
-    return Queue<T>(
-        element_default_, detail::ArrayMin(data_, std::forward<F>(key)));
-  }
-  template <typename F>
-  [[nodiscard]] auto Max(F&& key) const -> Queue<T> {
-    return Queue<T>(
-        element_default_, detail::ArrayMax(data_, std::forward<F>(key)));
-  }
-  template <typename F>
-  [[nodiscard]] auto Unique(F key) const -> Queue<T> {
-    return Queue<T>(
-        element_default_, detail::ArrayUnique(data_, std::move(key)));
-  }
-  template <typename F>
-  [[nodiscard]] auto UniqueIndex(F key) const -> Queue<PackedArray> {
-    return {
-        PackedArray::Int(0), detail::ArrayUniqueIndex(data_, std::move(key))};
+  [[nodiscard]] auto UniqueIndex(F key, PackedArray proto) const
+      -> Queue<PackedArray> {
+    return Queue<PackedArray>(
+        std::move(proto), detail::ArrayUniqueIndex(Entries(), std::move(key)));
   }
 
-  // LRM 7.12.5 projection into a same-shape queue; `element_default` seeds the
-  // result element type's canonical default.
+  // LRM 7.12.5 projection into a same-shape queue; `proto` seeds the result
+  // element type's canonical default (producer-supplied, since the result
+  // element type may differ from this queue's).
   template <typename F, typename U>
-  [[nodiscard]] auto Map(F closure, U element_default) const -> Queue<U> {
-    return Queue<U>(
-        std::move(element_default), detail::ArrayMap(data_, closure));
+  [[nodiscard]] auto Map(F closure, U proto) const -> Queue<U> {
+    return Queue<U>(std::move(proto), detail::ArrayMap(Entries(), closure));
   }
 
  private:
+  // The LRM 7.12 entry stream (decision: array-manipulation-entry-stream): a
+  // lazy view pairing each element with its ordinal index, front-to-back.
+  [[nodiscard]] auto Entries() const {
+    return std::views::enumerate(data_) |
+           std::views::transform([](auto&& pair) {
+             auto&& [i, e] = pair;
+             return detail::Entry<PackedArray, T>{
+                 PackedArray::Int(static_cast<int>(i)), &e};
+           });
+  }
+
   [[nodiscard]] auto IsInvalidIndex(const PackedArray& idx) const -> bool {
     if (idx.HasUnknown()) {
       return true;

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -3,9 +3,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <ranges>
 #include <span>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -207,15 +207,10 @@ class UnpackedArray {
     return PackedArray::Bit(HasUnknown());
   }
 
-  // LRM 7.12 ordering and reduction, each a thin wrapper over the shared
-  // `detail::Array*` algorithms. HIR-to-MIR always supplies the closure (the
-  // `with`-clause body or the LRM-default identity), so the runtime exposes
-  // only the closure-taking form; `reverse` takes none -- its `with` clause is
-  // a compiler error filtered upstream by slang. Ordering mutates in place at
-  // constant size (a fixed array never grows or shrinks). The closure receives
-  // each element and its index and returns a key (ordering) or a summand
-  // (reduction); the reduction result type follows the closure's return type,
-  // so a width-widening `with`-expression widens the result.
+  // LRM 7.12.2 ordering: an in-place positional permutation at constant size (a
+  // fixed array never grows or shrinks). `reverse` takes no closure; `sort` /
+  // `rsort` order by the closure-projected key with the ordinal position as
+  // index.
   auto Reverse() -> void {
     detail::ArrayReverse(data_);
   }
@@ -227,113 +222,120 @@ class UnpackedArray {
   auto Rsort(F&& key) -> void {
     detail::ArraySortByKey(data_, std::forward<F>(key), std::greater<>{});
   }
-  template <typename F>
-  [[nodiscard]] auto Sum(F&& key) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+
+  // LRM 7.12.3 reduction over the entry stream. `proto` is the
+  // producer-supplied result default for an empty receiver and carries the
+  // result shape otherwise.
+  template <typename F, typename R>
+  [[nodiscard]] auto Sum(F&& key, R proto) const -> R {
     return detail::ArrayFold(
-        data_, element_default_, std::forward<F>(key),
-        [](auto& acc, auto& v) { acc = acc + v; });
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a + v; });
   }
-  template <typename F>
-  [[nodiscard]] auto Product(F&& key) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+  template <typename F, typename R>
+  [[nodiscard]] auto Product(F&& key, R proto) const -> R {
     return detail::ArrayFold(
-        data_, element_default_, std::forward<F>(key),
-        [](auto& acc, auto& v) { acc = acc * v; });
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a * v; });
   }
-  template <typename F>
-  [[nodiscard]] auto And(F&& key) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+  template <typename F, typename R>
+  [[nodiscard]] auto And(F&& key, R proto) const -> R {
     return detail::ArrayFold(
-        data_, element_default_, std::forward<F>(key),
-        [](auto& acc, auto& v) { acc = acc & v; });
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a & v; });
   }
-  template <typename F>
-  [[nodiscard]] auto Or(F&& key) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+  template <typename F, typename R>
+  [[nodiscard]] auto Or(F&& key, R proto) const -> R {
     return detail::ArrayFold(
-        data_, element_default_, std::forward<F>(key),
-        [](auto& acc, auto& v) { acc = acc | v; });
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a | v; });
   }
-  template <typename F>
-  [[nodiscard]] auto Xor(F&& key) const
-      -> std::invoke_result_t<F&, const T&, const PackedArray&> {
+  template <typename F, typename R>
+  [[nodiscard]] auto Xor(F&& key, R proto) const -> R {
     return detail::ArrayFold(
-        data_, element_default_, std::forward<F>(key),
-        [](auto& acc, auto& v) { acc = acc ^ v; });
+        Entries(), std::move(proto), std::forward<F>(key),
+        [](auto a, auto v) { return a ^ v; });
   }
 
-  // LRM 7.12.1 locator methods, thin wrappers over the shared `detail::Array*`
-  // algorithms. The value locators (`find`, `find_first`, `find_last`, `min`,
-  // `max`, `unique`) return a queue of elements carrying this array's element
-  // shape via `element_default_`; the index locators return a queue of `int`
-  // whose element default is a plain zero. No match yields an empty queue. The
-  // `with` clause is mandatory for the find family (a Boolean predicate) and
-  // optional for `min` / `max` / `unique` (a comparison key, defaulting to the
-  // element).
+  // LRM 7.12.1 locator methods over the entry stream. Value locators return a
+  // queue of elements; index locators return a queue of the ordinal index.
+  // Both seed the result with the producer-supplied `proto`. No match yields an
+  // empty queue. The `with` clause is mandatory for the find family (a Boolean
+  // predicate) and optional for `min` / `max` / `unique` (a comparison key,
+  // defaulting to the element).
   template <typename F>
-  [[nodiscard]] auto Find(F pred) const -> Queue<T> {
+  [[nodiscard]] auto Find(F pred, T proto) const -> Queue<T> {
+    return Queue<T>(std::move(proto), detail::ArrayFind(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindIndex(F pred, PackedArray proto) const
+      -> Queue<PackedArray> {
+    return Queue<PackedArray>(
+        std::move(proto), detail::ArrayFindIndex(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindFirst(F pred, T proto) const -> Queue<T> {
+    return Queue<T>(std::move(proto), detail::ArrayFindFirst(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindFirstIndex(F pred, PackedArray proto) const
+      -> Queue<PackedArray> {
+    return Queue<PackedArray>(
+        std::move(proto), detail::ArrayFindFirstIndex(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindLast(F pred, T proto) const -> Queue<T> {
+    return Queue<T>(std::move(proto), detail::ArrayFindLast(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto FindLastIndex(F pred, PackedArray proto) const
+      -> Queue<PackedArray> {
+    return Queue<PackedArray>(
+        std::move(proto), detail::ArrayFindLastIndex(Entries(), pred));
+  }
+  template <typename F>
+  [[nodiscard]] auto Min(F&& key, T proto) const -> Queue<T> {
     return Queue<T>(
-        element_default_, detail::ArrayFind(data_, std::move(pred)));
+        std::move(proto), detail::ArrayMin(Entries(), std::forward<F>(key)));
   }
   template <typename F>
-  [[nodiscard]] auto FindIndex(F pred) const -> Queue<PackedArray> {
-    return {
-        PackedArray::Int(0), detail::ArrayFindIndex(data_, std::move(pred))};
-  }
-  template <typename F>
-  [[nodiscard]] auto FindFirst(F pred) const -> Queue<T> {
+  [[nodiscard]] auto Max(F&& key, T proto) const -> Queue<T> {
     return Queue<T>(
-        element_default_, detail::ArrayFindFirst(data_, std::move(pred)));
+        std::move(proto), detail::ArrayMax(Entries(), std::forward<F>(key)));
   }
   template <typename F>
-  [[nodiscard]] auto FindFirstIndex(F pred) const -> Queue<PackedArray> {
-    return {
-        PackedArray::Int(0),
-        detail::ArrayFindFirstIndex(data_, std::move(pred))};
-  }
-  template <typename F>
-  [[nodiscard]] auto FindLast(F pred) const -> Queue<T> {
+  [[nodiscard]] auto Unique(F key, T proto) const -> Queue<T> {
     return Queue<T>(
-        element_default_, detail::ArrayFindLast(data_, std::move(pred)));
+        std::move(proto), detail::ArrayUnique(Entries(), std::move(key)));
   }
   template <typename F>
-  [[nodiscard]] auto FindLastIndex(F pred) const -> Queue<PackedArray> {
-    return {
-        PackedArray::Int(0),
-        detail::ArrayFindLastIndex(data_, std::move(pred))};
-  }
-  template <typename F>
-  [[nodiscard]] auto Min(F&& key) const -> Queue<T> {
-    return Queue<T>(
-        element_default_, detail::ArrayMin(data_, std::forward<F>(key)));
-  }
-  template <typename F>
-  [[nodiscard]] auto Max(F&& key) const -> Queue<T> {
-    return Queue<T>(
-        element_default_, detail::ArrayMax(data_, std::forward<F>(key)));
-  }
-  template <typename F>
-  [[nodiscard]] auto Unique(F key) const -> Queue<T> {
-    return Queue<T>(
-        element_default_, detail::ArrayUnique(data_, std::move(key)));
-  }
-  template <typename F>
-  [[nodiscard]] auto UniqueIndex(F key) const -> Queue<PackedArray> {
-    return {
-        PackedArray::Int(0), detail::ArrayUniqueIndex(data_, std::move(key))};
+  [[nodiscard]] auto UniqueIndex(F key, PackedArray proto) const
+      -> Queue<PackedArray> {
+    return Queue<PackedArray>(
+        std::move(proto), detail::ArrayUniqueIndex(Entries(), std::move(key)));
   }
 
-  // LRM 7.12.5 projection into a same-range fixed unpacked array;
-  // `element_default` seeds the result element type's canonical default.
+  // LRM 7.12.5 projection into a same-range fixed unpacked array; `proto` seeds
+  // the result element type's canonical default (producer-supplied, since the
+  // result element type may differ from this array's).
   template <typename F, typename U>
-  [[nodiscard]] auto Map(F closure, U element_default) const
-      -> UnpackedArray<U> {
+  [[nodiscard]] auto Map(F closure, U proto) const -> UnpackedArray<U> {
     return UnpackedArray<U>(
-        std::move(element_default), detail::ArrayMap(data_, closure));
+        std::move(proto), detail::ArrayMap(Entries(), closure));
   }
 
  private:
+  // The LRM 7.12 entry stream (decision: array-manipulation-entry-stream): a
+  // lazy view pairing each element with its ordinal index, in declared order.
+  [[nodiscard]] auto Entries() const {
+    return std::views::enumerate(data_) |
+           std::views::transform([](auto&& pair) {
+             auto&& [i, e] = pair;
+             return detail::Entry<PackedArray, T>{
+                 PackedArray::Int(static_cast<int>(i)), &e};
+           });
+  }
+
   [[nodiscard]] auto IsInvalidIndex(const PackedArray& idx) const -> bool {
     if (idx.HasUnknown()) return true;
     const auto v = idx.ToInt64();

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -187,19 +187,24 @@ auto LowerCallExprProc(
 
     // LRM 7.12 array-manipulation family, defined for any unpacked array: a
     // fixed-size unpacked array (LRM 7.12.1 / 7.12.2 operate on "any unpacked
-    // array"), a dynamic array, and a queue (LRM 7.10.1 gives it the same
-    // operations as an unpacked array). For dynamic array and queue the LRM
-    // 7.5.2 / 7.5.3 / 7.10.2 `size` / `delete` are resolved earlier as native
-    // methods; slang rejects them on a fixed array. The no-`with` form takes
-    // only the receiver; the `with` form (LRM 7.12.4) binds an iterator and a
-    // body expression carried as the optional `WithClause`, which HIR -> MIR
-    // turns into a closure argument.
+    // array"), a dynamic array, a queue (LRM 7.10.1 gives it the same
+    // operations as an unpacked array), and an associative array (LRM 7.12.1 /
+    // 7.12.3 / 7.12.5 reduction / locator / map; the ordering family is
+    // rejected on it by slang). For dynamic array and queue the LRM 7.5.2 /
+    // 7.5.3 / 7.10.2 `size` / `delete` are resolved earlier as native methods,
+    // and the associative-array LRM 7.9 methods (`exists` / traversal / `num`)
+    // resolve in the block below; only the 7.12 names reach this dispatch. The
+    // no-`with` form takes only the receiver; the `with` form (LRM 7.12.4)
+    // binds an iterator and a body expression carried as the optional
+    // `WithClause`, which HIR -> MIR turns into a closure argument.
     if (receiver_type.has_value() &&
         (std::holds_alternative<hir::UnpackedArrayType>(
              module.Unit().GetType(*receiver_type).data) ||
          std::holds_alternative<hir::DynamicArrayType>(
              module.Unit().GetType(*receiver_type).data) ||
          std::holds_alternative<hir::QueueType>(
+             module.Unit().GetType(*receiver_type).data) ||
+         std::holds_alternative<hir::AssociativeArrayType>(
              module.Unit().GetType(*receiver_type).data))) {
       if (auto kind = LowerArrayMethodName(name); kind.has_value()) {
         auto type_id = module.InternType(*call.type, span);

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -161,27 +161,29 @@ auto ArrayMethodReceiverElementType(const hir::Type& ty)
   if (const auto* q = std::get_if<hir::QueueType>(&ty.data)) {
     return q->element_type;
   }
+  if (const auto* aa = std::get_if<hir::AssociativeArrayType>(&ty.data)) {
+    return aa->element_type;
+  }
   return std::nullopt;
 }
 
-// The element type of `map`'s result container (LRM 7.12.5), used to build its
-// shield.
-auto ArrayContainerElementType(const mir::Type& ty) -> mir::TypeId {
+// The canonical-default prototype type for a value-producing LRM 7.12 method
+// (decision: array-manipulation-entry-stream): a locator / map result is a
+// container, so its element type is the prototype; a reduction result is the
+// scalar itself. The producer supplies the prototype because the result shape
+// (an index locator's key, a map's chosen element, an empty reduction's zero)
+// is not always recoverable from the receiver.
+auto ArrayMethodResultProtoType(
+    const ModuleLowerer& module, mir::TypeId result_type) -> mir::TypeId {
   return std::visit(
-      [](const auto& t) -> mir::TypeId {
-        using TyT = std::decay_t<decltype(t)>;
-        if constexpr (
-            std::same_as<TyT, mir::UnpackedArrayType> ||
-            std::same_as<TyT, mir::DynamicArrayType> ||
-            std::same_as<TyT, mir::QueueType>) {
-          return t.element_type;
-        } else {
-          throw InternalError(
-              "ArrayContainerElementType: map result is not an unpacked-array "
-              "container type");
-        }
+      Overloaded{
+          [](const mir::UnpackedArrayType& t) { return t.element_type; },
+          [](const mir::DynamicArrayType& t) { return t.element_type; },
+          [](const mir::QueueType& t) { return t.element_type; },
+          [](const mir::AssociativeArrayType& t) { return t.element_type; },
+          [result_type](const auto&) { return result_type; },
       },
-      ty.data);
+      module.Unit().GetType(result_type).data);
 }
 
 // LRM 7.12.1 / 7.12.2 / 7.12.3 with-clause closure synthesis. The iterator and
@@ -204,7 +206,14 @@ auto BuildArrayMethodClosure(
         "BuildArrayMethodClosure: receiver is not an unpacked-array type");
   }
   const mir::TypeId item_type = module.TranslateType(*element_type);
-  const mir::TypeId index_type = module.Unit().builtins.int32;
+  // LRM 7.12.4 `item.index`: the ordinal position for a sequence container, the
+  // key for an associative receiver.
+  mir::TypeId index_type = module.Unit().builtins.int32;
+  if (const auto* assoc =
+          std::get_if<hir::AssociativeArrayType>(&hir_recv_ty.data);
+      assoc != nullptr && assoc->key_type.has_value()) {
+    index_type = module.TranslateType(*assoc->key_type);
+  }
   const std::string iterator_name =
       with_clause != nullptr
           ? hir_process.procedural_vars.Get(with_clause->iterator).name
@@ -465,15 +474,16 @@ auto LowerBuiltinMethodCall(
         c.with_clause.has_value() ? &*c.with_clause : nullptr);
     if (!closure_or) return std::unexpected(std::move(closure_or.error()));
     args.push_back(block.exprs.Add(*std::move(closure_or)));
-    // LRM 7.12.5: `map`'s result element type may differ from the
-    // receiver's, so its shield is supplied here as that type's canonical
-    // default -- the runtime shape is not recoverable from the C++ type
-    // alone.
-    if (b.method == support::BuiltinFn::kMap) {
-      const mir::TypeId result_elem =
-          ArrayContainerElementType(module.Unit().GetType(result_type));
+    // LRM 7.12 reduction / locator / map: the producer supplies the result's
+    // canonical default, since the result shape (an index locator's key, a
+    // map's chosen element, an empty reduction's zero) is not recoverable from
+    // the receiver (decision: array-manipulation-entry-stream). The ordering
+    // family produces no value and takes none.
+    if (support::ArrayMethodProducesValue(b.method)) {
+      const mir::TypeId proto_type =
+          ArrayMethodResultProtoType(module, result_type);
       args.push_back(
-          block.exprs.Add(BuildDefaultValueExpr(module, frame, result_elem)));
+          block.exprs.Add(BuildDefaultValueExpr(module, frame, proto_type)));
     }
   } else if (c.with_clause.has_value()) {
     throw InternalError(

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -65,6 +65,30 @@ auto ArrayMethodTakesClosure(BuiltinFn id) -> bool {
   }
 }
 
+auto ArrayMethodProducesValue(BuiltinFn id) -> bool {
+  switch (id) {
+    case BuiltinFn::kSum:
+    case BuiltinFn::kProduct:
+    case BuiltinFn::kAnd:
+    case BuiltinFn::kOr:
+    case BuiltinFn::kXor:
+    case BuiltinFn::kFind:
+    case BuiltinFn::kFindIndex:
+    case BuiltinFn::kFindFirst:
+    case BuiltinFn::kFindFirstIndex:
+    case BuiltinFn::kFindLast:
+    case BuiltinFn::kFindLastIndex:
+    case BuiltinFn::kMin:
+    case BuiltinFn::kMax:
+    case BuiltinFn::kUnique:
+    case BuiltinFn::kUniqueIndex:
+    case BuiltinFn::kMap:
+      return true;
+    default:
+      return false;
+  }
+}
+
 auto IsAssociativeTraversalFn(BuiltinFn id) -> bool {
   switch (id) {
     case BuiltinFn::kAssocFirst:

--- a/tests/cases/cpp/assoc_method_manipulation/case.yaml
+++ b/tests/cases/cpp/assoc_method_manipulation/case.yaml
@@ -1,0 +1,29 @@
+id: cpp.assoc_method_manipulation
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r_sum: 6
+    r_prod: 6
+    r_xor: 0
+    r_and: 0
+    r_or: 3
+    v_find: [2, 3]
+    v_find_idx: ["b", "c"]
+    v_first: [2]
+    v_first_idx: ["b"]
+    v_last: [3]
+    v_last_idx: ["c"]
+    v_min: [1]
+    v_max: [3]
+    v_unique: [1, 2, 3]
+    i_find_idx: [20, 30]
+    i_sum_key: 60
+    m_a: 11
+    m_b: 12
+    m_c: 13

--- a/tests/cases/cpp/assoc_method_manipulation/main.sv
+++ b/tests/cases/cpp/assoc_method_manipulation/main.sv
@@ -1,0 +1,57 @@
+module Top;
+  // LRM 7.12 array-manipulation methods on an associative receiver: reduction
+  // (LRM 7.12.3), the locator family (LRM 7.12.1), and map (LRM 7.12.5). The
+  // entry index is the key (LRM 7.12.1 / 7.12.4), so an index locator yields a
+  // queue of the key type and `item.index` reads the key. Traversal follows the
+  // array's key order (LRM 7.8). The ordering family (LRM 7.12.2) is excluded
+  // for associative arrays and rejected by the frontend.
+  int sa [string] = '{"a": 1, "b": 2, "c": 3};
+  int ia [int] = '{10: 5, 20: 7, 30: 9};
+
+  int r_sum, r_prod, r_xor, r_and, r_or;
+
+  int v_find [$];
+  string v_find_idx [$];
+  int v_first [$];
+  string v_first_idx [$];
+  int v_last [$];
+  string v_last_idx [$];
+  int v_min [$];
+  int v_max [$];
+  int v_unique [$];
+
+  int i_find_idx [$];
+  int i_sum_key;
+
+  int mapped [string];
+  int m_a, m_b, m_c;
+
+  initial begin
+    r_sum = sa.sum;
+    r_prod = sa.product;
+    r_xor = sa.xor;
+    r_and = sa.and;
+    r_or = sa.or;
+
+    v_find = sa.find with (item > 1);
+    v_find_idx = sa.find_index with (item > 1);
+    v_first = sa.find_first with (item > 1);
+    v_first_idx = sa.find_first_index with (item > 1);
+    v_last = sa.find_last with (item > 1);
+    v_last_idx = sa.find_last_index with (item > 1);
+    v_min = sa.min;
+    v_max = sa.max;
+    v_unique = sa.unique;
+
+    // The index locator returns the integral keys, and `item.index` reads the
+    // key inside the reduction.
+    i_find_idx = ia.find_index with (item > 5);
+    i_sum_key = ia.sum with (item.index);
+
+    // map keeps the key set; the result is read back by key.
+    mapped = sa.map with (item + 10);
+    m_a = mapped["a"];
+    m_b = mapped["b"];
+    m_c = mapped["c"];
+  end
+endmodule


### PR DESCRIPTION
## Summary

This adds the LRM 7.12 array-manipulation method family (the locator, reduction, and `map` projection) to SystemVerilog associative arrays (`aggregate.md` A5), and in doing so rewrites the shared algorithm layer into the shape modern iterator libraries use. An index locator on an associative receiver returns a queue of the key type, `item.index` inside a `with` clause reads the key, and `map` yields a same-key associative array whose element type is the `with`-expression type; the ordering family stays excluded on associative arrays and is rejected by the frontend.

## Design

The locator, reduction, and `map` families now run over a container's entry stream -- a lazily iterated sequence of `(index, element)` pairs that each container exposes the way Rust's `Iterator` and C++ `std::ranges` model iteration. A sequence container is `views::enumerate` over its storage so the index is the ordinal; the associative array is a transform over its `std::map`, whose entries are natively `(key, value)`, so the index is the key. The shared algorithms never synthesize the index and never name a container type: the locator family filters the entry view (`find_first` adds `views::take(1)`, `find_last` adds `views::reverse`), reduction is `ranges::fold_left` seeded by the first element, `min`/`max` are `ranges::min_element`/`max_element` under a key projection, and each container's thin wrapper shapes the result. The ordering family (`sort`/`reverse`) stays an in-place positional permutation on sequence storage -- the same line Rust draws by putting `sort` on the mutable slice rather than on `Iterator`. Every value-producing method receives its result's canonical-default prototype from the producer, since a result's runtime shape (an index locator's key, a `map`'s chosen element, an empty reduction's zero) is known at the call site and not always recoverable from the receiver. The rationale and the rejected alternatives are recorded in `docs/decisions/array-manipulation-entry-stream.md`.

## Testing

`bazel test //...` passes. A new `assoc_method_manipulation` case exercises reduction, the value and index locators, `item.index` as the key, and `map` on both string-keyed and integral-keyed associative arrays; the existing dynamic-array, queue, and fixed-unpacked method suites confirm the shared-algorithm rewrite is behavior-preserving.