### PR TITLE
Carry one expression write target in AST-to-HIR

### DIFF
--- a/docs/architecture/lowering_organization.md
+++ b/docs/architecture/lowering_organization.md
@@ -140,6 +140,19 @@ threaded down, a per-callable-body temp counter) is defined separately under "Re
    `frame.current_*_scope->Add...`; writes to the root output go through the pass class's narrow
    methods (see invariant 5).
 
+   _Current implementation:_ AST-to-HIR splits the walk position's write target by what the write
+   needs, not into one uniform handle. Lowering an expression is a single arena append and is
+   identical in either pass class, so the frame carries one shared expression sink (the current expr
+   arena, reached through `Exprs()` and set on scope/body entry) that every expression handler
+   appends into regardless of context -- this is precisely what lets the expression handlers be one
+   template per kind rather than a procedural/structural pair (invariant 13). Statements, locals,
+   and members stay behind the owning write target (the procedural body or the structural scope)
+   because their writes are compound, not bare arena appends: declaring a local also registers a
+   symbol binding on the pass class, a loop label bumps a counter on the body, a member append feeds
+   scope-specific arenas. The asymmetry is intended -- the expression sink is shared because the
+   write is context-free; the statement and member targets stay context-bound because the writes are
+   not.
+
 7. Adding a new fact is a class-member addition and a constructor-parameter addition. It does not
    change dispatcher or per-kind-handler signatures. Adding a new traversal-time concept is a
    `WalkFrame` struct-field addition. It does not change dispatcher or per-kind-handler signatures

--- a/docs/progress/generic-lowering.md
+++ b/docs/progress/generic-lowering.md
@@ -10,11 +10,12 @@ rejected alternatives.
 
 ## Actionable
 
-The generic arena (Phase 1) and the HIR-to-MIR handler-sharing it enables (Phase 2) have landed: the
-context-free HIR-to-MIR expression handlers shared by the procedural and structural pass classes are
-now single function templates. What remains is the AST-to-HIR slice -- unifying that pass's
-expression write target and collapsing its handler twins the same way -- which is gated on the
-in-flight drift-bug alignment (see Coordination).
+The generic arena (Phase 1) has landed in full, including the AST-to-HIR walk position now carrying
+a single expression write target. The HIR-to-MIR handler-sharing it enables (Phase 2) has also
+landed: the context-free HIR-to-MIR expression handlers shared by the procedural and structural pass
+classes are now single function templates. What remains is the AST-to-HIR half of Phase 2 --
+collapsing that pass's handler twins the same way -- which is gated on the in-flight drift-bug
+alignment (see Coordination).
 
 The arena's surface is fixed by what consumers actually do: a const lookup by typed id, an append
 that returns the id, a count and an emptiness check, and an indexed iteration (the dumper prints
@@ -39,7 +40,7 @@ underneath.
       directly rather than through the typed lookup) with the typed lookup. This is pre-existing
       debt, not new work; fixing it also collapses the procedural/structural read-access divergence,
       so the read side of sub-node access is uniform once this lands.
-- [ ] AST-to-HIR: the walk position carries one expression write target instead of two parallel
+- [x] AST-to-HIR: the walk position carries one expression write target instead of two parallel
       ones, with the statement and member write targets kept separate. With both scopes' expression
       pools now the same arena type, the read and write sides of sub-node access are both uniform.
 - [x] Leave deduplicating pools (type interning), id-sequence fields, and composite append helpers

--- a/include/lyra/lowering/ast_to_hir/walk_frame.hpp
+++ b/include/lyra/lowering/ast_to_hir/walk_frame.hpp
@@ -7,12 +7,14 @@
 #include <ranges>
 #include <vector>
 
+#include "lyra/base/arena.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/loop_label_id.hpp"
 #include "lyra/hir/structural_hops.hpp"
 
 namespace lyra::hir {
+struct Expr;
 struct StructuralScope;
 struct ProceduralBody;
 }  // namespace lyra::hir
@@ -50,14 +52,21 @@ struct WalkFrame {
   // hops: HopsTo(target) walks back to find target in the chain.
   std::vector<ScopeFrameId> structural_chain;
 
-  // The current structural-scope write target. Set when a StructuralScope
-  // task constructs its scope on the stack and entered via
-  // `WithStructuralFrame`. Null outside structural-scope handlers.
+  // The current expression write target: the expr arena every expression
+  // handler appends lowered sub-expressions into, regardless of procedural or
+  // structural context. Set alongside the owning write target on scope/body
+  // entry. Expression handlers reach it through `Exprs()` and never touch the
+  // owning pointers below.
+  base::Arena<hir::Expr, hir::ExprId>* current_exprs = nullptr;
+
+  // The current structural-scope write target for member and generate handlers.
+  // Set when a StructuralScope task constructs its scope on the stack and
+  // entered via `WithStructuralFrame`. Null outside structural-scope handlers.
   hir::StructuralScope* current_structural_scope = nullptr;
 
-  // The current procedural-body write target. Set when a ProcessLowerer
-  // constructs its body on the stack and entered via `WithProceduralBody`.
-  // Null outside a process or subroutine body.
+  // The current procedural-body write target for statement and local handlers.
+  // Set when a ProcessLowerer constructs its body on the stack and entered via
+  // `WithProceduralBody`. Null outside a process or subroutine body.
   hir::ProceduralBody* current_procedural_body = nullptr;
 
   // Nonzero while a fork-join branch body is being lowered. A procedural-var
@@ -105,16 +114,28 @@ struct WalkFrame {
     return std::nullopt;
   }
 
+  // The expr arena the current scope or body appends lowered sub-expressions
+  // into. Reached by every expression handler regardless of context.
+  [[nodiscard]] auto Exprs() const -> base::Arena<hir::Expr, hir::ExprId>& {
+    if (current_exprs == nullptr) {
+      throw InternalError("WalkFrame::Exprs: no expression write target");
+    }
+    return *current_exprs;
+  }
+
   // Pushes a new structural scope onto the chain and points
   // current_structural_scope at the new scope. The scope is owned by the
   // caller's stack frame (typically a Lowerer's Run); this frame just
-  // borrows it for the duration of the walk.
+  // borrows it for the duration of the walk. `exprs` is the scope's expr arena,
+  // passed by the caller (which holds the complete scope type) so this header
+  // stays free of the HIR scope definition.
   [[nodiscard]] auto WithStructuralFrame(
-      ScopeFrameId child_frame, hir::StructuralScope* scope) const
-      -> WalkFrame {
+      ScopeFrameId child_frame, hir::StructuralScope* scope,
+      base::Arena<hir::Expr, hir::ExprId>* exprs) const -> WalkFrame {
     WalkFrame next = *this;
     next.structural_chain.push_back(child_frame);
     next.current_structural_scope = scope;
+    next.current_exprs = exprs;
     return next;
   }
 
@@ -122,11 +143,14 @@ struct WalkFrame {
   // stack-allocates a hir::ProceduralBody and dispatches into it. The body
   // pointer is unchanged for the lifetime of the process / subroutine walk;
   // nested control flow does not push procedural bodies because HIR's
-  // procedural body is flat.
-  [[nodiscard]] auto WithProceduralBody(hir::ProceduralBody* body) const
-      -> WalkFrame {
+  // procedural body is flat. `exprs` is the body's expr arena, passed by the
+  // caller for the same reason as `WithStructuralFrame`.
+  [[nodiscard]] auto WithProceduralBody(
+      hir::ProceduralBody* body,
+      base::Arena<hir::Expr, hir::ExprId>* exprs) const -> WalkFrame {
     WalkFrame next = *this;
     next.current_procedural_body = body;
+    next.current_exprs = exprs;
     return next;
   }
 

--- a/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
+++ b/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
@@ -23,10 +23,8 @@ auto BuildContinuousAssign(
     ModuleLowerer& module, WalkFrame frame, diag::SourceSpan span,
     hir::Expr lhs, hir::Expr rhs, const std::vector<SensitivityRead>& reads)
     -> hir::ContinuousAssign {
-  const hir::ExprId lhs_id =
-      frame.current_structural_scope->exprs.Add(std::move(lhs));
-  const hir::ExprId rhs_id =
-      frame.current_structural_scope->exprs.Add(std::move(rhs));
+  const hir::ExprId lhs_id = frame.Exprs().Add(std::move(lhs));
+  const hir::ExprId rhs_id = frame.Exprs().Add(std::move(rhs));
   return hir::ContinuousAssign{
       .span = span,
       .lhs = lhs_id,

--- a/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
@@ -49,8 +49,7 @@ auto LowerConcatExprProc(
     }
     auto operand_or = proc.LowerExpr(*op, frame);
     if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-    operand_ids.push_back(
-        frame.current_procedural_body->exprs.Add(*std::move(operand_or)));
+    operand_ids.push_back(frame.Exprs().Add(*std::move(operand_or)));
   }
   return hir::Expr{
       .type = *type_id,
@@ -76,12 +75,10 @@ auto LowerReplicationExprProc(
   }
   auto count_or = proc.LowerExpr(rp.count(), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
-  const hir::ExprId count_id =
-      frame.current_procedural_body->exprs.Add(*std::move(count_or));
+  const hir::ExprId count_id = frame.Exprs().Add(*std::move(count_or));
   auto concat_or = proc.LowerExpr(rp.concat(), frame);
   if (!concat_or) return std::unexpected(std::move(concat_or.error()));
-  const hir::ExprId concat_id =
-      frame.current_procedural_body->exprs.Add(*std::move(concat_or));
+  const hir::ExprId concat_id = frame.Exprs().Add(*std::move(concat_or));
   return hir::Expr{
       .type = *type_id,
       .data = hir::ReplicationExpr{.count = count_id, .concat = concat_id},
@@ -100,8 +97,7 @@ auto LowerAssignmentPatternFromElementsProc(
   for (const auto* elem : ap.elements()) {
     auto lowered = proc.LowerExpr(*elem, frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    element_ids.push_back(
-        frame.current_procedural_body->exprs.Add(*std::move(lowered)));
+    element_ids.push_back(frame.Exprs().Add(*std::move(lowered)));
   }
   return hir::Expr{
       .type = *type_id,
@@ -121,20 +117,17 @@ auto LowerAssociativeAssignmentPatternProc(
   for (const auto& setter : ap.indexSetters) {
     auto key_or = proc.LowerExpr(*setter.index, frame);
     if (!key_or) return std::unexpected(std::move(key_or.error()));
-    const hir::ExprId key_id =
-        frame.current_procedural_body->exprs.Add(*std::move(key_or));
+    const hir::ExprId key_id = frame.Exprs().Add(*std::move(key_or));
     auto value_or = proc.LowerExpr(*setter.expr, frame);
     if (!value_or) return std::unexpected(std::move(value_or.error()));
-    const hir::ExprId value_id =
-        frame.current_procedural_body->exprs.Add(*std::move(value_or));
+    const hir::ExprId value_id = frame.Exprs().Add(*std::move(value_or));
     entries.push_back({.key = key_id, .value = value_id});
   }
   std::optional<hir::ExprId> default_id;
   if (ap.defaultSetter != nullptr) {
     auto default_or = proc.LowerExpr(*ap.defaultSetter, frame);
     if (!default_or) return std::unexpected(std::move(default_or.error()));
-    default_id =
-        frame.current_procedural_body->exprs.Add(*std::move(default_or));
+    default_id = frame.Exprs().Add(*std::move(default_or));
   }
   return hir::Expr{
       .type = *type_id,
@@ -155,15 +148,13 @@ auto LowerReplicatedAssignmentPatternExprProc(
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   auto count_or = proc.LowerExpr(rp.count(), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
-  const hir::ExprId count_id =
-      frame.current_procedural_body->exprs.Add(*std::move(count_or));
+  const hir::ExprId count_id = frame.Exprs().Add(*std::move(count_or));
   std::vector<hir::ExprId> item_ids;
   item_ids.reserve(rp.elements().size());
   for (const auto* elem : rp.elements()) {
     auto lowered = proc.LowerExpr(*elem, frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    item_ids.push_back(
-        frame.current_procedural_body->exprs.Add(*std::move(lowered)));
+    item_ids.push_back(frame.Exprs().Add(*std::move(lowered)));
   }
   return hir::Expr{
       .type = *type_id,
@@ -188,14 +179,12 @@ auto LowerNewArrayExprProc(
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   auto size_or = proc.LowerExpr(na.sizeExpr(), frame);
   if (!size_or) return std::unexpected(std::move(size_or.error()));
-  const hir::ExprId size_id =
-      frame.current_procedural_body->exprs.Add(*std::move(size_or));
+  const hir::ExprId size_id = frame.Exprs().Add(*std::move(size_or));
   std::optional<hir::ExprId> initializer_id;
   if (na.initExpr() != nullptr) {
     auto init_or = proc.LowerExpr(*na.initExpr(), frame);
     if (!init_or) return std::unexpected(std::move(init_or.error()));
-    initializer_id =
-        frame.current_procedural_body->exprs.Add(*std::move(init_or));
+    initializer_id = frame.Exprs().Add(*std::move(init_or));
   }
   return hir::Expr{
       .type = *type_id,
@@ -231,8 +220,7 @@ auto LowerConcatExprStructural(
     }
     auto operand_or = scope.LowerExpr(*op, frame);
     if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-    operand_ids.push_back(
-        frame.current_structural_scope->exprs.Add(*std::move(operand_or)));
+    operand_ids.push_back(frame.Exprs().Add(*std::move(operand_or)));
   }
   return hir::Expr{
       .type = *type_id,
@@ -252,8 +240,7 @@ auto LowerAssignmentPatternFromElementsStructural(
   for (const auto* elem : ap.elements()) {
     auto lowered = scope.LowerExpr(*elem, frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    element_ids.push_back(
-        frame.current_structural_scope->exprs.Add(*std::move(lowered)));
+    element_ids.push_back(frame.Exprs().Add(*std::move(lowered)));
   }
   return hir::Expr{
       .type = *type_id,
@@ -273,20 +260,17 @@ auto LowerAssociativeAssignmentPatternStructural(
   for (const auto& setter : ap.indexSetters) {
     auto key_or = scope.LowerExpr(*setter.index, frame);
     if (!key_or) return std::unexpected(std::move(key_or.error()));
-    const hir::ExprId key_id =
-        frame.current_structural_scope->exprs.Add(*std::move(key_or));
+    const hir::ExprId key_id = frame.Exprs().Add(*std::move(key_or));
     auto value_or = scope.LowerExpr(*setter.expr, frame);
     if (!value_or) return std::unexpected(std::move(value_or.error()));
-    const hir::ExprId value_id =
-        frame.current_structural_scope->exprs.Add(*std::move(value_or));
+    const hir::ExprId value_id = frame.Exprs().Add(*std::move(value_or));
     entries.push_back({.key = key_id, .value = value_id});
   }
   std::optional<hir::ExprId> default_id;
   if (ap.defaultSetter != nullptr) {
     auto default_or = scope.LowerExpr(*ap.defaultSetter, frame);
     if (!default_or) return std::unexpected(std::move(default_or.error()));
-    default_id =
-        frame.current_structural_scope->exprs.Add(*std::move(default_or));
+    default_id = frame.Exprs().Add(*std::move(default_or));
   }
   return hir::Expr{
       .type = *type_id,
@@ -307,15 +291,13 @@ auto LowerReplicatedAssignmentPatternExprStructural(
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   auto count_or = scope.LowerExpr(rp.count(), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
-  const hir::ExprId count_id =
-      frame.current_structural_scope->exprs.Add(*std::move(count_or));
+  const hir::ExprId count_id = frame.Exprs().Add(*std::move(count_or));
   std::vector<hir::ExprId> item_ids;
   item_ids.reserve(rp.elements().size());
   for (const auto* elem : rp.elements()) {
     auto lowered = scope.LowerExpr(*elem, frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    item_ids.push_back(
-        frame.current_structural_scope->exprs.Add(*std::move(lowered)));
+    item_ids.push_back(frame.Exprs().Add(*std::move(lowered)));
   }
   return hir::Expr{
       .type = *type_id,

--- a/src/lyra/lowering/ast_to_hir/expression/assignment.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/assignment.cpp
@@ -34,8 +34,7 @@ auto LowerAssignmentExprProc(
 
   auto lhs_or = proc.LowerExpr(as.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  const hir::ExprId lhs_id =
-      frame.current_procedural_body->exprs.Add(*std::move(lhs_or));
+  const hir::ExprId lhs_id = frame.Exprs().Add(*std::move(lhs_or));
 
   auto type_id = module.InternType(*as.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
@@ -46,8 +45,7 @@ auto LowerAssignmentExprProc(
   if (!as.op.has_value()) {
     auto rhs_or = proc.LowerExpr(as.right(), frame);
     if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-    const hir::ExprId rhs_id =
-        frame.current_procedural_body->exprs.Add(*std::move(rhs_or));
+    const hir::ExprId rhs_id = frame.Exprs().Add(*std::move(rhs_or));
     return hir::Expr{
         .type = *type_id,
         .data =
@@ -71,8 +69,7 @@ auto LowerAssignmentExprProc(
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   hir::Expr rhs_expr = *std::move(rhs_or);
   if (rhs_expr.type.value != type_id->value) {
-    const hir::ExprId inner_id =
-        frame.current_procedural_body->exprs.Add(std::move(rhs_expr));
+    const hir::ExprId inner_id = frame.Exprs().Add(std::move(rhs_expr));
     rhs_expr = hir::Expr{
         .type = *type_id,
         .data =
@@ -81,8 +78,7 @@ auto LowerAssignmentExprProc(
         .span = span,
     };
   }
-  const hir::ExprId rhs_id =
-      frame.current_procedural_body->exprs.Add(std::move(rhs_expr));
+  const hir::ExprId rhs_id = frame.Exprs().Add(std::move(rhs_expr));
   return hir::Expr{
       .type = *type_id,
       .data =
@@ -105,8 +101,7 @@ auto LowerIncDecExprProc(
 
   auto target_or = proc.LowerExpr(un.operand(), frame);
   if (!target_or) return std::unexpected(std::move(target_or.error()));
-  const hir::ExprId target_id =
-      frame.current_procedural_body->exprs.Add(*std::move(target_or));
+  const hir::ExprId target_id = frame.Exprs().Add(*std::move(target_or));
 
   auto type_id = module.InternType(*un.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -86,8 +86,7 @@ auto LowerCallExprProc(
     if (i == 0) {
       receiver_type = arg_or->type;
     }
-    arg_ids.emplace_back(
-        frame.current_procedural_body->exprs.Add(*std::move(arg_or)));
+    arg_ids.emplace_back(frame.Exprs().Add(*std::move(arg_or)));
   }
 
   if (call.isSystemCall()) {
@@ -225,8 +224,7 @@ auto LowerCallExprProc(
               *frame.current_procedural_body, iter_var, *iter_type);
           auto body_or = proc.LowerExpr(*iter_info.iterExpr, frame);
           if (!body_or) return std::unexpected(std::move(body_or.error()));
-          const auto body_expr_id =
-              frame.current_procedural_body->exprs.Add(*std::move(body_or));
+          const auto body_expr_id = frame.Exprs().Add(*std::move(body_or));
           with_clause =
               hir::WithClause{.iterator = iterator_id, .expr = body_expr_id};
         }

--- a/src/lyra/lowering/ast_to_hir/expression/inside.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/inside.cpp
@@ -20,8 +20,7 @@ auto LowerInsideExprProc(
     -> diag::Result<hir::Expr> {
   auto lhs_or = proc.LowerExpr(in.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  const hir::ExprId lhs_id =
-      frame.current_procedural_body->exprs.Add(*std::move(lhs_or));
+  const hir::ExprId lhs_id = frame.Exprs().Add(*std::move(lhs_or));
 
   std::vector<hir::InsideItem> items;
   items.reserve(in.rangeList().size());
@@ -55,17 +54,15 @@ auto LowerInsideItemImpl(
     }
     auto lo_or = proc.LowerExpr(vr.left(), frame);
     if (!lo_or) return std::unexpected(std::move(lo_or.error()));
-    const hir::ExprId lo_id =
-        frame.current_procedural_body->exprs.Add(*std::move(lo_or));
+    const hir::ExprId lo_id = frame.Exprs().Add(*std::move(lo_or));
     auto hi_or = proc.LowerExpr(vr.right(), frame);
     if (!hi_or) return std::unexpected(std::move(hi_or.error()));
-    const hir::ExprId hi_id =
-        frame.current_procedural_body->exprs.Add(*std::move(hi_or));
+    const hir::ExprId hi_id = frame.Exprs().Add(*std::move(hi_or));
     return hir::InsideRangePair{.lo = lo_id, .hi = hi_id};
   }
   auto val_or = proc.LowerExpr(item_expr, frame);
   if (!val_or) return std::unexpected(std::move(val_or.error()));
-  return frame.current_procedural_body->exprs.Add(*std::move(val_or));
+  return frame.Exprs().Add(*std::move(val_or));
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/expression/operators.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/operators.cpp
@@ -1,5 +1,6 @@
 #include "lyra/lowering/ast_to_hir/expression/operators.hpp"
 
+#include <algorithm>
 #include <expected>
 #include <utility>
 
@@ -37,22 +38,14 @@ auto TypeHasRealLeaf(const slang::ast::Type& type) -> bool {
     return TypeHasRealLeaf(*element);
   }
   if (canonical.isUnpackedStruct()) {
-    for (const auto* field :
-         canonical.as<slang::ast::UnpackedStructType>().fields) {
-      if (TypeHasRealLeaf(field->getType())) {
-        return true;
-      }
-    }
-    return false;
+    return std::ranges::any_of(
+        canonical.as<slang::ast::UnpackedStructType>().fields,
+        [](const auto* field) { return TypeHasRealLeaf(field->getType()); });
   }
   if (canonical.isUnpackedUnion()) {
-    for (const auto* field :
-         canonical.as<slang::ast::UnpackedUnionType>().fields) {
-      if (TypeHasRealLeaf(field->getType())) {
-        return true;
-      }
-    }
-    return false;
+    return std::ranges::any_of(
+        canonical.as<slang::ast::UnpackedUnionType>().fields,
+        [](const auto* field) { return TypeHasRealLeaf(field->getType()); });
   }
   return false;
 }
@@ -88,8 +81,7 @@ auto LowerConversionExprProc(
     -> diag::Result<hir::Expr> {
   auto operand_or = proc.LowerExpr(conv.operand(), frame);
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-  const hir::ExprId operand_id =
-      frame.current_procedural_body->exprs.Add(*std::move(operand_or));
+  const hir::ExprId operand_id = frame.Exprs().Add(*std::move(operand_or));
   auto type_id = proc.Module().InternType(*conv.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -110,8 +102,7 @@ auto LowerUnaryExprProc(
   const hir::UnaryOp op = LowerUnaryOp(un.op);
   auto operand_or = proc.LowerExpr(un.operand(), frame);
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-  const hir::ExprId operand_id =
-      frame.current_procedural_body->exprs.Add(*std::move(operand_or));
+  const hir::ExprId operand_id = frame.Exprs().Add(*std::move(operand_or));
   auto type_id = proc.Module().InternType(*un.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -130,12 +121,10 @@ auto LowerBinaryExprProc(
   }
   auto lhs_or = proc.LowerExpr(bin.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  const hir::ExprId lhs_id =
-      frame.current_procedural_body->exprs.Add(*std::move(lhs_or));
+  const hir::ExprId lhs_id = frame.Exprs().Add(*std::move(lhs_or));
   auto rhs_or = proc.LowerExpr(bin.right(), frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  const hir::ExprId rhs_id =
-      frame.current_procedural_body->exprs.Add(*std::move(rhs_or));
+  const hir::ExprId rhs_id = frame.Exprs().Add(*std::move(rhs_or));
   auto type_id = proc.Module().InternType(*bin.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -169,16 +158,13 @@ auto LowerConditionalExprProc(
   }
   auto cond_or = proc.LowerExpr(*cond.conditions[0].expr, frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const hir::ExprId cond_id =
-      frame.current_procedural_body->exprs.Add(*std::move(cond_or));
+  const hir::ExprId cond_id = frame.Exprs().Add(*std::move(cond_or));
   auto then_or = proc.LowerExpr(cond.left(), frame);
   if (!then_or) return std::unexpected(std::move(then_or.error()));
-  const hir::ExprId then_id =
-      frame.current_procedural_body->exprs.Add(*std::move(then_or));
+  const hir::ExprId then_id = frame.Exprs().Add(*std::move(then_or));
   auto else_or = proc.LowerExpr(cond.right(), frame);
   if (!else_or) return std::unexpected(std::move(else_or.error()));
-  const hir::ExprId else_id =
-      frame.current_procedural_body->exprs.Add(*std::move(else_or));
+  const hir::ExprId else_id = frame.Exprs().Add(*std::move(else_or));
   auto type_id = proc.Module().InternType(*cond.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -199,8 +185,7 @@ auto LowerConversionExprStructural(
     -> diag::Result<hir::Expr> {
   auto operand_or = scope.LowerExpr(conv.operand(), frame);
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-  const hir::ExprId operand_id =
-      frame.current_structural_scope->exprs.Add(*std::move(operand_or));
+  const hir::ExprId operand_id = frame.Exprs().Add(*std::move(operand_or));
   auto type_id = scope.Module().InternType(*conv.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -221,8 +206,7 @@ auto LowerUnaryExprStructural(
   const hir::UnaryOp op = LowerUnaryOp(un.op);
   auto operand_or = scope.LowerExpr(un.operand(), frame);
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-  const hir::ExprId operand_id =
-      frame.current_structural_scope->exprs.Add(*std::move(operand_or));
+  const hir::ExprId operand_id = frame.Exprs().Add(*std::move(operand_or));
   auto type_id = scope.Module().InternType(*un.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -241,12 +225,10 @@ auto LowerBinaryExprStructural(
   }
   auto lhs_or = scope.LowerExpr(bin.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  const hir::ExprId lhs_id =
-      frame.current_structural_scope->exprs.Add(*std::move(lhs_or));
+  const hir::ExprId lhs_id = frame.Exprs().Add(*std::move(lhs_or));
   auto rhs_or = scope.LowerExpr(bin.right(), frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  const hir::ExprId rhs_id =
-      frame.current_structural_scope->exprs.Add(*std::move(rhs_or));
+  const hir::ExprId rhs_id = frame.Exprs().Add(*std::move(rhs_or));
   auto type_id = scope.Module().InternType(*bin.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -280,16 +262,13 @@ auto LowerConditionalExprStructural(
   }
   auto cond_or = scope.LowerExpr(*cond.conditions[0].expr, frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const hir::ExprId cond_id =
-      frame.current_structural_scope->exprs.Add(*std::move(cond_or));
+  const hir::ExprId cond_id = frame.Exprs().Add(*std::move(cond_or));
   auto then_or = scope.LowerExpr(cond.left(), frame);
   if (!then_or) return std::unexpected(std::move(then_or.error()));
-  const hir::ExprId then_id =
-      frame.current_structural_scope->exprs.Add(*std::move(then_or));
+  const hir::ExprId then_id = frame.Exprs().Add(*std::move(then_or));
   auto else_or = scope.LowerExpr(cond.right(), frame);
   if (!else_or) return std::unexpected(std::move(else_or.error()));
-  const hir::ExprId else_id =
-      frame.current_structural_scope->exprs.Add(*std::move(else_or));
+  const hir::ExprId else_id = frame.Exprs().Add(*std::move(else_or));
   auto type_id = scope.Module().InternType(*cond.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -33,9 +33,8 @@ auto LowerUnboundedLiteralProc(
         "`$` is only supported as a queue index or slice bound (LRM 7.10)",
         diag::UnsupportedCategory::kOperation);
   }
-  auto& body = *frame.current_procedural_body;
   const hir::TypeId int32_type = proc.Module().Unit().builtins.int32;
-  const hir::ExprId size_id = body.exprs.Add(
+  const hir::ExprId size_id = frame.Exprs().Add(
       hir::Expr{
           .type = int32_type,
           .data =
@@ -45,7 +44,7 @@ auto LowerUnboundedLiteralProc(
                   .arguments = {*frame.dollar_base}},
           .span = span});
   const hir::ExprId one_id =
-      body.exprs.Add(hir::MakeInt32Literal(1, int32_type, span));
+      frame.Exprs().Add(hir::MakeInt32Literal(1, int32_type, span));
   return hir::Expr{
       .type = int32_type,
       .data =
@@ -68,15 +67,13 @@ auto LowerElementSelectExprProc(
   }
   auto base_or = proc.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const hir::ExprId base_id =
-      frame.current_procedural_body->exprs.Add(*std::move(base_or));
+  const hir::ExprId base_id = frame.Exprs().Add(*std::move(base_or));
 
   const WalkFrame idx_frame =
       sel.value().type->isQueue() ? frame.WithDollarBase(base_id) : frame;
   auto idx_or = proc.LowerExpr(sel.selector(), idx_frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
-  const hir::ExprId idx_id =
-      frame.current_procedural_body->exprs.Add(*std::move(idx_or));
+  const hir::ExprId idx_id = frame.Exprs().Add(*std::move(idx_or));
 
   auto type_id = proc.Module().InternType(*sel.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
@@ -105,20 +102,17 @@ auto LowerRangeSelectExprProc(
 
   auto base_or = proc.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const hir::ExprId base_id =
-      frame.current_procedural_body->exprs.Add(*std::move(base_or));
+  const hir::ExprId base_id = frame.Exprs().Add(*std::move(base_or));
 
   const WalkFrame bound_frame =
       sel.value().type->isQueue() ? frame.WithDollarBase(base_id) : frame;
   auto left_or = proc.LowerExpr(sel.left(), bound_frame);
   if (!left_or) return std::unexpected(std::move(left_or.error()));
-  const hir::ExprId left_id =
-      frame.current_procedural_body->exprs.Add(*std::move(left_or));
+  const hir::ExprId left_id = frame.Exprs().Add(*std::move(left_or));
 
   auto right_or = proc.LowerExpr(sel.right(), bound_frame);
   if (!right_or) return std::unexpected(std::move(right_or.error()));
-  const hir::ExprId right_id =
-      frame.current_procedural_body->exprs.Add(*std::move(right_or));
+  const hir::ExprId right_id = frame.Exprs().Add(*std::move(right_or));
 
   hir::RangeBounds bounds = [&]() -> hir::RangeBounds {
     switch (sel.getSelectionKind()) {
@@ -162,8 +156,7 @@ auto LowerMemberAccessExprProc(
   const auto* field = &sel.member.as<slang::ast::FieldSymbol>();
   auto base_or = proc.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const hir::ExprId base_id =
-      frame.current_procedural_body->exprs.Add(*std::move(base_or));
+  const hir::ExprId base_id = frame.Exprs().Add(*std::move(base_or));
   auto type_id = proc.Module().InternType(*sel.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -193,12 +186,10 @@ auto LowerElementSelectExprStructural(
   }
   auto base_or = scope.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const hir::ExprId base_id =
-      frame.current_structural_scope->exprs.Add(*std::move(base_or));
+  const hir::ExprId base_id = frame.Exprs().Add(*std::move(base_or));
   auto idx_or = scope.LowerExpr(sel.selector(), frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
-  const hir::ExprId idx_id =
-      frame.current_structural_scope->exprs.Add(*std::move(idx_or));
+  const hir::ExprId idx_id = frame.Exprs().Add(*std::move(idx_or));
   auto type_id = scope.Module().InternType(*sel.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
@@ -221,16 +212,13 @@ auto LowerRangeSelectExprStructural(
   }
   auto base_or = scope.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const hir::ExprId base_id =
-      frame.current_structural_scope->exprs.Add(*std::move(base_or));
+  const hir::ExprId base_id = frame.Exprs().Add(*std::move(base_or));
   auto left_or = scope.LowerExpr(sel.left(), frame);
   if (!left_or) return std::unexpected(std::move(left_or.error()));
-  const hir::ExprId left_id =
-      frame.current_structural_scope->exprs.Add(*std::move(left_or));
+  const hir::ExprId left_id = frame.Exprs().Add(*std::move(left_or));
   auto right_or = scope.LowerExpr(sel.right(), frame);
   if (!right_or) return std::unexpected(std::move(right_or.error()));
-  const hir::ExprId right_id =
-      frame.current_structural_scope->exprs.Add(*std::move(right_or));
+  const hir::ExprId right_id = frame.Exprs().Add(*std::move(right_or));
   hir::RangeBounds bounds = [&]() -> hir::RangeBounds {
     switch (sel.getSelectionKind()) {
       case slang::ast::RangeSelectionKind::Simple:
@@ -270,8 +258,7 @@ auto LowerMemberAccessExprStructural(
   const auto& field = sel.member.as<slang::ast::FieldSymbol>();
   auto base_or = scope.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const hir::ExprId base_id =
-      frame.current_structural_scope->exprs.Add(*std::move(base_or));
+  const hir::ExprId base_id = frame.Exprs().Add(*std::move(base_or));
   auto type_id = scope.Module().InternType(*sel.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{

--- a/src/lyra/lowering/ast_to_hir/generate.cpp
+++ b/src/lyra/lowering/ast_to_hir/generate.cpp
@@ -131,8 +131,7 @@ auto StructuralScopeLowerer::BuildIfGenerate(
 
   auto cond_expr = LowerExpr(*cond, frame);
   if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
-  const hir::ExprId cond_id =
-      frame.current_structural_scope->exprs.Add(*std::move(cond_expr));
+  const hir::ExprId cond_id = frame.Exprs().Add(*std::move(cond_expr));
 
   hir::Generate gen{};
   const ScopeFrameId gen_frame = frame_;
@@ -181,8 +180,7 @@ auto StructuralScopeLowerer::BuildCaseGenerate(
 
   auto cond_expr = LowerExpr(*discriminator, frame);
   if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
-  const hir::ExprId cond_id =
-      frame.current_structural_scope->exprs.Add(*std::move(cond_expr));
+  const hir::ExprId cond_id = frame.Exprs().Add(*std::move(cond_expr));
 
   hir::Generate gen{};
   const ScopeFrameId gen_frame = frame_;
@@ -202,8 +200,7 @@ auto StructuralScopeLowerer::BuildCaseGenerate(
           if (!label_expr_lowered) {
             return std::unexpected(std::move(label_expr_lowered.error()));
           }
-          labels.push_back(frame.current_structural_scope->exprs.Add(
-              *std::move(label_expr_lowered)));
+          labels.push_back(frame.Exprs().Add(*std::move(label_expr_lowered)));
         }
         auto item_id =
             AddChildScope(*module_, gen, gen_frame, gen_id, *block, frame);
@@ -266,14 +263,12 @@ auto LowerLoopIterNextValue(
 
   auto read = parent.LowerExpr(assign.left(), frame);
   if (!read) return std::unexpected(std::move(read.error()));
-  const hir::ExprId read_id =
-      frame.current_structural_scope->exprs.Add(*std::move(read));
+  const hir::ExprId read_id = frame.Exprs().Add(*std::move(read));
 
   const auto& bare_rhs = BareCompoundUserRhs(assign.right());
   auto rhs = parent.LowerExpr(bare_rhs, frame);
   if (!rhs) return std::unexpected(std::move(rhs.error()));
-  const hir::ExprId rhs_id =
-      frame.current_structural_scope->exprs.Add(*std::move(rhs));
+  const hir::ExprId rhs_id = frame.Exprs().Add(*std::move(rhs));
 
   auto type_id = module.InternType(*iter.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
@@ -318,19 +313,16 @@ auto StructuralScopeLowerer::BuildLoopGenerate(
 
   auto initial_expr = LowerExpr(*array.initialExpression, frame);
   if (!initial_expr) return std::unexpected(std::move(initial_expr.error()));
-  const hir::ExprId initial_id =
-      frame.current_structural_scope->exprs.Add(*std::move(initial_expr));
+  const hir::ExprId initial_id = frame.Exprs().Add(*std::move(initial_expr));
 
   auto stop_expr = LowerExpr(*array.stopExpression, frame);
   if (!stop_expr) return std::unexpected(std::move(stop_expr.error()));
-  const hir::ExprId stop_id =
-      frame.current_structural_scope->exprs.Add(*std::move(stop_expr));
+  const hir::ExprId stop_id = frame.Exprs().Add(*std::move(stop_expr));
 
   auto iter_expr =
       LowerLoopIterNextValue(*this, *module_, *array.iterExpression, frame);
   if (!iter_expr) return std::unexpected(std::move(iter_expr.error()));
-  const hir::ExprId iter_id =
-      frame.current_structural_scope->exprs.Add(*std::move(iter_expr));
+  const hir::ExprId iter_id = frame.Exprs().Add(*std::move(iter_expr));
 
   hir::StructuralScope loop_scope;
   if (!array.entries.empty()) {

--- a/src/lyra/lowering/ast_to_hir/process_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/process_lowerer.cpp
@@ -86,7 +86,7 @@ auto ProcessLowerer::Run(
     const slang::ast::ProceduralBlockSymbol& proc, WalkFrame parent_frame)
     -> diag::Result<hir::Process> {
   hir::ProceduralBody body;
-  const WalkFrame frame = parent_frame.WithProceduralBody(&body);
+  const WalkFrame frame = parent_frame.WithProceduralBody(&body, &body.exprs);
 
   auto root_stmt = LowerStmt(proc.getBody(), frame);
   if (!root_stmt) return std::unexpected(std::move(root_stmt.error()));

--- a/src/lyra/lowering/ast_to_hir/statement/branches.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/branches.cpp
@@ -38,8 +38,7 @@ auto LowerCaseInsideStmt(
   const auto case_check = LowerUniquePriorityCheck(cs.check);
   auto cond_expr = proc.LowerExpr(cs.expr, frame);
   if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
-  const hir::ExprId cond_id =
-      frame.current_procedural_body->exprs.Add(*std::move(cond_expr));
+  const hir::ExprId cond_id = frame.Exprs().Add(*std::move(cond_expr));
   std::vector<hir::CaseInsideItem> items;
   items.reserve(cs.items.size());
   for (const auto& item : cs.items) {
@@ -100,8 +99,7 @@ auto LowerCaseStmt(
   const auto case_check = LowerUniquePriorityCheck(cs.check);
   auto cond_expr = proc.LowerExpr(cs.expr, frame);
   if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
-  const hir::ExprId cond_id =
-      frame.current_procedural_body->exprs.Add(*std::move(cond_expr));
+  const hir::ExprId cond_id = frame.Exprs().Add(*std::move(cond_expr));
   std::vector<hir::CaseItem> items;
   items.reserve(cs.items.size());
   for (const auto& item : cs.items) {
@@ -110,8 +108,7 @@ auto LowerCaseStmt(
     for (const auto* label_expr : item.expressions) {
       auto label_or = proc.LowerExpr(*label_expr, frame);
       if (!label_or) return std::unexpected(std::move(label_or.error()));
-      label_ids.push_back(
-          frame.current_procedural_body->exprs.Add(*std::move(label_or)));
+      label_ids.push_back(frame.Exprs().Add(*std::move(label_or)));
     }
     auto item_stmt = proc.LowerStmt(*item.stmt, frame);
     if (!item_stmt) return std::unexpected(std::move(item_stmt.error()));
@@ -159,8 +156,7 @@ auto LowerConditionalStmt(
   }
   auto cond_expr = proc.LowerExpr(*cond.expr, frame);
   if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));
-  const hir::ExprId cond_id =
-      frame.current_procedural_body->exprs.Add(*std::move(cond_expr));
+  const hir::ExprId cond_id = frame.Exprs().Add(*std::move(cond_expr));
   auto then_stmt = proc.LowerStmt(cs.ifTrue, frame);
   if (!then_stmt) return std::unexpected(std::move(then_stmt.error()));
   const hir::StmtId then_id =

--- a/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
@@ -61,23 +61,24 @@ auto SizeMethodFor(const slang::ast::Type& array_type)
 // (LRM 12.7.3) into a `setup` local that the condition then reads. The loop
 // variable is the counter, declared in the `for`.
 auto BuildIntegerLevel(
-    ProcessLowerer& proc, hir::ProceduralBody& body, const LoopDim& dim,
+    ProcessLowerer& proc, WalkFrame frame, const LoopDim& dim,
     std::optional<hir::ExprId> array, const slang::ast::Type* array_type,
     hir::TypeId int32_type, diag::SourceSpan span,
     std::vector<hir::StmtId>& setup) -> LevelLoop {
+  auto& body = *frame.current_procedural_body;
   hir::ExprId first_id{};
   hir::ExprId last_id{};
   bool ascending = true;
   if (dim.range.has_value()) {
     const auto& declared = *dim.range;
-    first_id =
-        body.exprs.Add(hir::MakeInt32Literal(declared.left, int32_type, span));
-    last_id =
-        body.exprs.Add(hir::MakeInt32Literal(declared.right, int32_type, span));
+    first_id = frame.Exprs().Add(
+        hir::MakeInt32Literal(declared.left, int32_type, span));
+    last_id = frame.Exprs().Add(
+        hir::MakeInt32Literal(declared.right, int32_type, span));
     ascending = declared.left <= declared.right;
   } else {
     hir::SubroutineRef size_callee = SizeMethodFor(*array_type);
-    const hir::ExprId size_id = body.exprs.Add(
+    const hir::ExprId size_id = frame.Exprs().Add(
         hir::Expr{
             .type = int32_type,
             .data =
@@ -85,8 +86,8 @@ auto BuildIntegerLevel(
                     .callee = std::move(size_callee), .arguments = {*array}},
             .span = span});
     const hir::ExprId one_id =
-        body.exprs.Add(hir::MakeInt32Literal(1, int32_type, span));
-    const hir::ExprId last_value_id = body.exprs.Add(
+        frame.Exprs().Add(hir::MakeInt32Literal(1, int32_type, span));
+    const hir::ExprId last_value_id = frame.Exprs().Add(
         hir::Expr{
             .type = int32_type,
             .data =
@@ -103,9 +104,9 @@ auto BuildIntegerLevel(
             .label = std::nullopt,
             .data = hir::VarDeclStmt{.var = last_var, .init = last_value_id},
             .span = span}));
-    first_id = body.exprs.Add(hir::MakeInt32Literal(0, int32_type, span));
+    first_id = frame.Exprs().Add(hir::MakeInt32Literal(0, int32_type, span));
     last_id =
-        body.exprs.Add(hir::MakeProcVarRefExpr(last_var, int32_type, span));
+        frame.Exprs().Add(hir::MakeProcVarRefExpr(last_var, int32_type, span));
   }
 
   const hir::ProceduralVarId loop_var =
@@ -113,8 +114,8 @@ auto BuildIntegerLevel(
   std::vector<hir::ForInit> init;
   init.emplace_back(hir::ForInitDecl{.var = loop_var, .init = first_id});
   const hir::ExprId cond_ref =
-      body.exprs.Add(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
-  const hir::ExprId cond_id = body.exprs.Add(
+      frame.Exprs().Add(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
+  const hir::ExprId cond_id = frame.Exprs().Add(
       hir::Expr{
           .type = int32_type,
           .data =
@@ -125,8 +126,8 @@ auto BuildIntegerLevel(
                   .rhs = last_id},
           .span = span});
   const hir::ExprId step_ref =
-      body.exprs.Add(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
-  const hir::ExprId step_id = body.exprs.Add(
+      frame.Exprs().Add(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
+  const hir::ExprId step_id = frame.Exprs().Add(
       hir::Expr{
           .type = int32_type,
           .data =
@@ -152,9 +153,10 @@ auto BuildIntegerLevel(
 // The key is declared in `setup` rather than the `for` init because its type
 // differs from the counter and cannot share one C++ init declaration.
 auto BuildAssociativeLevel(
-    ProcessLowerer& proc, hir::ProceduralBody& body, const LoopDim& dim,
+    ProcessLowerer& proc, WalkFrame frame, const LoopDim& dim,
     hir::ExprId array, hir::TypeId int32_type, diag::SourceSpan span,
     std::vector<hir::StmtId>& setup) -> diag::Result<LevelLoop> {
+  auto& body = *frame.current_procedural_body;
   auto key_type_or = proc.Module().InternType(dim.loopVar->getType(), span);
   if (!key_type_or) return std::unexpected(std::move(key_type_or.error()));
   const hir::TypeId key_type = *key_type_or;
@@ -174,8 +176,8 @@ auto BuildAssociativeLevel(
 
   auto walk_call = [&](support::BuiltinFn method) -> hir::ExprId {
     const hir::ExprId key_ref =
-        body.exprs.Add(hir::MakeProcVarRefExpr(key_var, key_type, span));
-    return body.exprs.Add(
+        frame.Exprs().Add(hir::MakeProcVarRefExpr(key_var, key_type, span));
+    return frame.Exprs().Add(
         hir::Expr{
             .type = int32_type,
             .data =
@@ -191,10 +193,10 @@ auto BuildAssociativeLevel(
       hir::ForInitDecl{
           .var = more_var, .init = walk_call(support::BuiltinFn::kAssocFirst)});
   const hir::ExprId cond_id =
-      body.exprs.Add(hir::MakeProcVarRefExpr(more_var, int32_type, span));
+      frame.Exprs().Add(hir::MakeProcVarRefExpr(more_var, int32_type, span));
   const hir::ExprId more_lhs =
-      body.exprs.Add(hir::MakeProcVarRefExpr(more_var, int32_type, span));
-  const hir::ExprId step_id = body.exprs.Add(
+      frame.Exprs().Add(hir::MakeProcVarRefExpr(more_var, int32_type, span));
+  const hir::ExprId step_id = frame.Exprs().Add(
       hir::Expr{
           .type = int32_type,
           .data =
@@ -261,13 +263,13 @@ auto BuildForeachNest(
       array_type->getCanonicalType().isAssociativeArray();
   LevelLoop loop{};
   if (is_associative) {
-    auto loop_or =
-        BuildAssociativeLevel(proc, body, dim, *array, int32_type, span, stmts);
+    auto loop_or = BuildAssociativeLevel(
+        proc, frame, dim, *array, int32_type, span, stmts);
     if (!loop_or) return std::unexpected(std::move(loop_or.error()));
     loop = std::move(*loop_or);
   } else {
     loop = BuildIntegerLevel(
-        proc, body, dim, array, array_type, int32_type, span, stmts);
+        proc, frame, dim, array, array_type, int32_type, span, stmts);
   }
 
   // Descend: the inner levels iterate `array[loop_var]`, one type peel deeper.
@@ -283,9 +285,9 @@ auto BuildForeachNest(
     if (!inner_hir_type) {
       return std::unexpected(std::move(inner_hir_type.error()));
     }
-    const hir::ExprId index_id = body.exprs.Add(
+    const hir::ExprId index_id = frame.Exprs().Add(
         hir::MakeProcVarRefExpr(loop.loop_var, loop.loop_var_type, span));
-    inner_array = body.exprs.Add(
+    inner_array = frame.Exprs().Add(
         hir::Expr{
             .type = *inner_hir_type,
             .data =
@@ -358,7 +360,8 @@ auto ProcessLowerer::LowerForeachStmt(
     const auto array_eval_stmt = body.stmts.Add(
         hir::Stmt{
             .label = std::nullopt,
-            .data = hir::ExprStmt{.expr = body.exprs.Add(*std::move(array_or))},
+            .data =
+                hir::ExprStmt{.expr = frame.Exprs().Add(*std::move(array_or))},
             .span = span});
     auto body_or = proc.LowerStmt(fs.body, frame.WithoutBreakLabel());
     if (!body_or) return std::unexpected(std::move(body_or.error()));
@@ -377,7 +380,7 @@ auto ProcessLowerer::LowerForeachStmt(
   if (needs_array) {
     auto array_or = proc.LowerExpr(fs.arrayRef, frame);
     if (!array_or) return std::unexpected(std::move(array_or.error()));
-    array = body.exprs.Add(*std::move(array_or));
+    array = frame.Exprs().Add(*std::move(array_or));
     array_type = fs.arrayRef.type;
   }
 

--- a/src/lyra/lowering/ast_to_hir/statement/loops.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/loops.cpp
@@ -25,23 +25,20 @@ auto LowerForLoopStmt(
     auto init_or = proc.LowerExpr(*init_expr, frame);
     if (!init_or) return std::unexpected(std::move(init_or.error()));
     hir_init.emplace_back(
-        hir::ForInitExpr{
-            .expr =
-                frame.current_procedural_body->exprs.Add(*std::move(init_or))});
+        hir::ForInitExpr{.expr = frame.Exprs().Add(*std::move(init_or))});
   }
   std::optional<hir::ExprId> cond_id;
   if (fs.stopExpr != nullptr) {
     auto cond_or = proc.LowerExpr(*fs.stopExpr, frame);
     if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-    cond_id = frame.current_procedural_body->exprs.Add(*std::move(cond_or));
+    cond_id = frame.Exprs().Add(*std::move(cond_or));
   }
   std::vector<hir::ExprId> step_ids;
   step_ids.reserve(fs.steps.size());
   for (const auto* step_expr : fs.steps) {
     auto step_or = proc.LowerExpr(*step_expr, frame);
     if (!step_or) return std::unexpected(std::move(step_or.error()));
-    step_ids.push_back(
-        frame.current_procedural_body->exprs.Add(*std::move(step_or)));
+    step_ids.push_back(frame.Exprs().Add(*std::move(step_or)));
   }
   auto body_stmt = proc.LowerStmt(fs.body, frame.WithoutBreakLabel());
   if (!body_stmt) return std::unexpected(std::move(body_stmt.error()));
@@ -64,8 +61,7 @@ auto LowerWhileLoopStmt(
     -> diag::Result<hir::Stmt> {
   auto cond_or = proc.LowerExpr(ws.cond, frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const hir::ExprId cond_id =
-      frame.current_procedural_body->exprs.Add(*std::move(cond_or));
+  const hir::ExprId cond_id = frame.Exprs().Add(*std::move(cond_or));
   auto body_or = proc.LowerStmt(ws.body, frame.WithoutBreakLabel());
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   const hir::StmtId body_id =
@@ -82,8 +78,7 @@ auto LowerRepeatLoopStmt(
     -> diag::Result<hir::Stmt> {
   auto count_or = proc.LowerExpr(rs.count, frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
-  const hir::ExprId count_id =
-      frame.current_procedural_body->exprs.Add(*std::move(count_or));
+  const hir::ExprId count_id = frame.Exprs().Add(*std::move(count_or));
   auto body_or = proc.LowerStmt(rs.body, frame.WithoutBreakLabel());
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   const hir::StmtId body_id =
@@ -104,8 +99,7 @@ auto LowerDoWhileLoopStmt(
       frame.current_procedural_body->stmts.Add(*std::move(body_or));
   auto cond_or = proc.LowerExpr(ds.cond, frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const hir::ExprId cond_id =
-      frame.current_procedural_body->exprs.Add(*std::move(cond_or));
+  const hir::ExprId cond_id = frame.Exprs().Add(*std::move(cond_or));
   return hir::Stmt{
       .label = std::nullopt,
       .data = hir::DoWhileStmt{.condition = cond_id, .body = body_id},

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -66,7 +66,7 @@ auto LowerVariableDeclStmt(
   if (const auto* init_expr = sym.getInitializer()) {
     auto init_or = proc.LowerExpr(*init_expr, frame);
     if (!init_or) return std::unexpected(std::move(init_or.error()));
-    init_id = frame.current_procedural_body->exprs.Add(*std::move(init_or));
+    init_id = frame.Exprs().Add(*std::move(init_or));
   }
   return hir::Stmt{
       .label = std::nullopt,
@@ -80,8 +80,7 @@ auto LowerExpressionStmt(
     -> diag::Result<hir::Stmt> {
   auto expr = proc.LowerExpr(es.expr, frame);
   if (!expr) return std::unexpected(std::move(expr.error()));
-  const hir::ExprId id =
-      frame.current_procedural_body->exprs.Add(*std::move(expr));
+  const hir::ExprId id = frame.Exprs().Add(*std::move(expr));
   return hir::Stmt{
       .label = std::nullopt, .data = hir::ExprStmt{.expr = id}, .span = span};
 }
@@ -97,7 +96,7 @@ auto LowerReturnStmt(
   if (rs.expr != nullptr) {
     auto expr_or = proc.LowerExpr(*rs.expr, frame);
     if (!expr_or) return std::unexpected(std::move(expr_or.error()));
-    value = frame.current_procedural_body->exprs.Add(*std::move(expr_or));
+    value = frame.Exprs().Add(*std::move(expr_or));
   }
   return hir::Stmt{
       .label = std::nullopt,

--- a/src/lyra/lowering/ast_to_hir/statement/timing.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/timing.cpp
@@ -79,7 +79,7 @@ auto LowerSignalEventTrigger(
   }
 
   return hir::EventTrigger{
-      .signal = frame.current_procedural_body->exprs.Add(*std::move(expr_or)),
+      .signal = frame.Exprs().Add(*std::move(expr_or)),
       .edge = edge_kind,
       .sensitivity_list = std::move(sensitivity_list),
   };
@@ -117,7 +117,7 @@ auto LowerNamedEventControl(
         diag::UnsupportedCategory::kFeature);
   }
   return hir::NamedEventControl{
-      .event = frame.current_procedural_body->exprs.Add(*std::move(expr_or)),
+      .event = frame.Exprs().Add(*std::move(expr_or)),
   };
 }
 
@@ -130,8 +130,7 @@ auto LowerTimingControl(
       auto duration = proc.LowerExpr(delay.expr, frame);
       if (!duration) return std::unexpected(std::move(duration.error()));
       return hir::TimingControl{hir::DelayControl{
-          .duration =
-              frame.current_procedural_body->exprs.Add(*std::move(duration))}};
+          .duration = frame.Exprs().Add(*std::move(duration))}};
     }
     case slang::ast::TimingControlKind::SignalEvent: {
       const auto& sig = tc.as<slang::ast::SignalEventControl>();
@@ -242,8 +241,7 @@ auto LowerEventTriggerStmt(
       .label = std::nullopt,
       .data =
           hir::EventTriggerStmt{
-              .event =
-                  frame.current_procedural_body->exprs.Add(*std::move(expr_or)),
+              .event = frame.Exprs().Add(*std::move(expr_or)),
           },
       .span = span};
 }
@@ -257,8 +255,7 @@ auto LowerWaitStmt(
     diag::SourceSpan span) -> diag::Result<hir::Stmt> {
   auto cond_or = proc.LowerExpr(w.cond, frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const hir::ExprId cond_id =
-      frame.current_procedural_body->exprs.Add(*std::move(cond_or));
+  const hir::ExprId cond_id = frame.Exprs().Add(*std::move(cond_or));
   auto body_or = proc.LowerStmt(w.stmt, frame);
   if (!body_or) return std::unexpected(std::move(body_or.error()));
   const hir::StmtId body_id =

--- a/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
@@ -97,7 +97,8 @@ StructuralScopeLowerer::StructuralScopeLowerer(
 auto StructuralScopeLowerer::Run(WalkFrame parent_frame)
     -> diag::Result<hir::StructuralScope> {
   hir::StructuralScope scope;
-  const WalkFrame frame = parent_frame.WithStructuralFrame(frame_, &scope);
+  const WalkFrame frame =
+      parent_frame.WithStructuralFrame(frame_, &scope, &scope.exprs);
   scope.time_resolution = ResolveTimeResolution(slang_scope_->getTimeScale());
   // Apply any loop-generate entry bindings (loop-generate body inherits the
   // loop var from its parent's frame so body refs compute correct hops up).
@@ -254,8 +255,7 @@ auto StructuralScopeLowerer::PopulateVariableMember(
   if (const auto* init = var.getInitializer(); init != nullptr) {
     auto init_or = LowerExpr(*init, frame);
     if (!init_or) return std::unexpected(std::move(init_or.error()));
-    initializer_id =
-        frame.current_structural_scope->exprs.Add(*std::move(init_or));
+    initializer_id = frame.Exprs().Add(*std::move(init_or));
   }
   const hir::StructuralVarId local =
       frame.current_structural_scope->structural_vars.Add(
@@ -279,7 +279,8 @@ auto StructuralScopeLowerer::PopulateSubroutineMember(
 
   hir::ProceduralBody sub_body;
   ProcessLowerer sub_lowerer(*module_, sym);
-  const WalkFrame sub_frame = frame.WithProceduralBody(&sub_body);
+  const WalkFrame sub_frame =
+      frame.WithProceduralBody(&sub_body, &sub_body.exprs);
 
   std::vector<hir::SubroutineParam> params;
   params.reserve(sym.getArguments().size());


### PR DESCRIPTION
## Summary

The AST-to-HIR walk position carried two parallel expression write targets -- a procedural body and a structural scope -- and every expression handler reached its expr arena by first selecting one of those owning pointers (`current_procedural_body->exprs` / `current_structural_scope->exprs`). This made the two pass classes' expression handlers diverge only by which owning pointer they dereferenced, and leaked the whole owning structure to a handler that only ever wanted to append a sub-expression.

`WalkFrame` now carries a single expression write target (`Exprs()`, a `base::Arena<hir::Expr, hir::ExprId>&` set on scope/body entry). Every expression handler appends through `Exprs()` regardless of procedural or structural context, so the same lowered node is written the same way in either pass class. The owning pointers stay on the frame but are downgraded to serve only the statement, local, and member handlers -- whose writes are compound (a local declaration also registers a symbol binding on the pass class, a loop label bumps a body counter, a member append feeds scope-specific arenas) and therefore are not expressible as a bare arena.

This is the AST-to-HIR half of generic-lowering Phase 1. By making the two contexts append identically, it is the prerequisite that lets the next step collapse the procedural/structural expression-handler twins into one template per kind, mirroring what already landed on the HIR-to-MIR side.

## Design

The asymmetry between the shared expression sink and the context-bound statement/member targets is intended and now documented in `lowering_organization.md` invariant 6: the expression sink is shared because its write is context-free; the statement and member targets stay context-bound because theirs are not. `walk_frame.hpp` stays free of the HIR scope/body definitions -- the entry points (`WithProceduralBody` / `WithStructuralFrame`) receive the expr arena from the caller, which holds the complete type.