### PR TITLE
Share AST-to-HIR expression handlers across pass classes

### DIFF
--- a/docs/architecture/lowering_organization.md
+++ b/docs/architecture/lowering_organization.md
@@ -210,11 +210,16 @@ threaded down, a per-callable-body temp counter) is defined separately under "Re
     maps to different storage depending on the enclosing scope, and kinds that exist in only one
     context.
 
-    _Current implementation:_ the HIR-to-MIR expression handlers shared by `ProcessLowerer` and
-    `ClassLowerer` (operators, selects, aggregate value-builds) are single function templates over
-    the pass class, reaching sub-expressions through a uniform `HirExprs()` accessor and recursing
-    through `LowerExpr` / `LowerLhsExpr`; explicit instantiations for the two pass classes live in
-    the subsystem `.cpp`. Name resolution (`references.cpp`) stays a per-pass-class pair.
+    _Current implementation:_ the context-free expression handlers (operators, selects, aggregate
+    value-builds) are single function templates over the pass class on both lowering boundaries. At
+    HIR-to-MIR the template recurses through `LowerExpr` / `LowerLhsExpr` and reaches
+    sub-expressions through a uniform `HirExprs()` accessor; at AST-to-HIR it recurses through
+    `LowerExpr` and interns through the walk position's single expression arena, so the pass class's
+    own surface is just `LowerExpr` and `Module()`. Each is constrained on an `ExprLowerer` concept,
+    with explicit instantiations for the two pass classes in the subsystem `.cpp`. Name resolution
+    (`references.cpp` on each boundary) stays a per-pass-class pair, and kinds that exist in only
+    one context (increment / decrement, replication, the dynamic-array constructor, queue `$`) stay
+    procedural-only handlers.
 
 ## The Walk Position
 

--- a/docs/decisions/generic-lowering-machinery.md
+++ b/docs/decisions/generic-lowering-machinery.md
@@ -98,4 +98,4 @@ Make the machinery generic; keep the nodes typed.
 - `architecture/lowering_organization.md` (the pass / dispatcher / handler / walk-frame shape this
   refines).
 - `progress/generic-lowering.md` (the staged migration).
-- `progress/refactor.md` R34 (the AST-to-HIR drift-bug slice, in flight separately).
+- `progress/refactor.md` R34 (the AST-to-HIR drift-bug slice).

--- a/docs/progress/generic-lowering.md
+++ b/docs/progress/generic-lowering.md
@@ -10,12 +10,12 @@ rejected alternatives.
 
 ## Actionable
 
-The generic arena (Phase 1) has landed in full, including the AST-to-HIR walk position now carrying
-a single expression write target. The HIR-to-MIR handler-sharing it enables (Phase 2) has also
-landed: the context-free HIR-to-MIR expression handlers shared by the procedural and structural pass
-classes are now single function templates. What remains is the AST-to-HIR half of Phase 2 --
-collapsing that pass's handler twins the same way -- which is gated on the in-flight drift-bug
-alignment (see Coordination).
+The generic arena (Phase 1) and the handler-sharing it enables (Phase 2) have landed in full on both
+lowering boundaries. The context-free expression handlers shared by the procedural and structural
+pass classes are single function templates over the pass class -- never duplicated twins -- at
+HIR-to-MIR and at AST-to-HIR alike. The procedural/structural distinction survives only where the
+two genuinely differ (statements versus members and generates, and name resolution) and is gone from
+the expression layer, where they are identical. This workstream is complete.
 
 The arena's surface is fixed by what consumers actually do: a const lookup by typed id, an append
 that returns the id, a count and an emptiness check, and an indexed iteration (the dumper prints
@@ -51,17 +51,18 @@ underneath.
 - [x] HIR-to-MIR: each expression family's procedural and structural handlers become one function
       template over the pass class. Pilot with the select family (the largest duplication), then the
       remaining families.
-- [ ] AST-to-HIR: the same collapse, sequenced after the in-flight drift-bug alignment lands (see
-      Coordination).
+- [x] AST-to-HIR: the same collapse. Each context-free expression family's procedural and structural
+      handlers become one function template over the pass class, reached through the uniform
+      recursion entry point; name resolution and single-context kinds stay per-pass.
 - [x] `lowering_organization.md` records that a handler shared across pass classes is one template,
       never a duplicated twin.
 
 ## Coordination
 
-- The AST-to-HIR slice overlaps `refactor.md` R34 (the procedural/structural HIR expression-lowering
-  drift bugs, in flight separately). Sequence the AST-to-HIR templating after R34's operand-guard
-  and value-realization alignment lands, so the two efforts do not edit the same handlers at once.
-  The HIR-to-MIR slice is independent and unblocked.
+- The AST-to-HIR slice and `refactor.md` R34 (the procedural/structural expression-lowering drift
+  bugs) were the same work and landed together: collapsing each twin to one template per family
+  removes the drift surface by construction, so there is no separate guard-alignment step to
+  sequence before it. The HIR-to-MIR slice landed independently earlier.
 
 ## Out of Scope
 

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -456,19 +456,15 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       on the rarely-exercised unsupported branches. **Trigger**: standalone; mechanical sweep across
       every lowering file, so it lands as its own cut.
 
-- [ ] R34 -- Unify the procedural and structural HIR expression-lowering paths. AST-to-HIR carries
-      parallel `Lower<Kind>ExprProc` / `Lower<Kind>ExprStructural` handlers that build the same HIR
-      node but guard their accepted operand types independently, so the two drift: the structural
-      element-select rejected an unpacked base the procedural one accepted (now aligned), and a
-      string element-select's getc realization (LRM 6.16.3) lives only on the procedural HIR-to-MIR
-      path, so a structural `assign b = s[i]` lowers to a non-existent `String::Element` instead of
-      `getc`. The realization a node needs (getc for a string base, element access for an array) is
-      a property of the node, not of the procedural-vs-structural origin. Target shape: one
-      select/member lowering shared across scopes, with the value realizations applied uniformly in
-      HIR-to-MIR regardless of origin -- after which a string element read works in a continuous
-      assignment exactly as it does in a process. **Trigger**: when a structural-context string /
-      aggregate element read is needed, or the next time a per-kind guard drifts between the two
-      paths.
+- [x] R34 -- Unify the procedural and structural AST-to-HIR expression-lowering paths. The two
+      carried parallel handlers per expression family that built the same HIR node but guarded their
+      accepted operand types independently, so the two drifted. Resolved as the AST-to-HIR slice of
+      `generic-lowering.md` Phase 2: each context-free family is now one function template over the
+      pass class, so there is a single guard and the drift cannot recur. The specific string
+      element-select concern turned out to need no separate fix -- slang rejects an element of a
+      dynamic type outside procedural code, so a structural string `s[i]` never reaches lowering,
+      and the value realization (getc for a string base, element access for an array) was already a
+      property of the node at HIR-to-MIR, applied regardless of origin.
 
 - [ ] R35 -- Resolve the intra-unit part of a hierarchical reference at compile time as typed member
       access, not by name at construction. `reference_resolution.md` invariant 2 says an intra-unit

--- a/include/lyra/lowering/ast_to_hir/expression/aggregates.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/aggregates.hpp
@@ -9,8 +9,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
-#include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace slang::ast {
@@ -24,48 +23,41 @@ class StructuredAssignmentPatternExpression;
 
 namespace lyra::lowering::ast_to_hir {
 
-// Procedural-context handlers.
-auto LowerConcatExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
+class ProcessLowerer;
+
+// An aggregate's value-construction is independent of the enclosing scope, so
+// one template over the pass class serves both the procedural and structural
+// contexts; explicit instantiations live in the implementation file.
+template <ExprLowerer Lowerer>
+auto LowerConcatExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::ConcatenationExpression& cc, diag::SourceSpan span)
     -> diag::Result<hir::Expr>;
+template <ExprLowerer Lowerer>
+auto LowerAssignmentPatternFromElements(
+    Lowerer& lowerer, WalkFrame frame,
+    const slang::ast::AssignmentPatternExpressionBase& ap,
+    diag::SourceSpan span) -> diag::Result<hir::Expr>;
+template <ExprLowerer Lowerer>
+auto LowerReplicatedAssignmentPatternExpr(
+    Lowerer& lowerer, WalkFrame frame,
+    const slang::ast::ReplicatedAssignmentPatternExpression& rp,
+    diag::SourceSpan span) -> diag::Result<hir::Expr>;
+template <ExprLowerer Lowerer>
+auto LowerAssociativeAssignmentPattern(
+    Lowerer& lowerer, WalkFrame frame,
+    const slang::ast::StructuredAssignmentPatternExpression& ap,
+    diag::SourceSpan span) -> diag::Result<hir::Expr>;
+
+// Replication (LRM 11.4.12.1) and the dynamic-array constructor `new[N]`
+// (LRM 7.5.1) have no structural form, so they stay procedural-only handlers.
 auto LowerReplicationExprProc(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::ReplicationExpression& rp, diag::SourceSpan span)
     -> diag::Result<hir::Expr>;
-auto LowerAssignmentPatternFromElementsProc(
-    ProcessLowerer& proc, WalkFrame frame,
-    const slang::ast::AssignmentPatternExpressionBase& ap,
-    diag::SourceSpan span) -> diag::Result<hir::Expr>;
-auto LowerReplicatedAssignmentPatternExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
-    const slang::ast::ReplicatedAssignmentPatternExpression& rp,
-    diag::SourceSpan span) -> diag::Result<hir::Expr>;
 auto LowerNewArrayExprProc(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::NewArrayExpression& na, diag::SourceSpan span)
     -> diag::Result<hir::Expr>;
-auto LowerAssociativeAssignmentPatternProc(
-    ProcessLowerer& proc, WalkFrame frame,
-    const slang::ast::StructuredAssignmentPatternExpression& ap,
-    diag::SourceSpan span) -> diag::Result<hir::Expr>;
-
-// Structural-context handlers.
-auto LowerConcatExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::ConcatenationExpression& cc, diag::SourceSpan span)
-    -> diag::Result<hir::Expr>;
-auto LowerAssignmentPatternFromElementsStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::AssignmentPatternExpressionBase& ap,
-    diag::SourceSpan span) -> diag::Result<hir::Expr>;
-auto LowerReplicatedAssignmentPatternExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::ReplicatedAssignmentPatternExpression& rp,
-    diag::SourceSpan span) -> diag::Result<hir::Expr>;
-auto LowerAssociativeAssignmentPatternStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::StructuredAssignmentPatternExpression& ap,
-    diag::SourceSpan span) -> diag::Result<hir::Expr>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <concepts>
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/lowering/ast_to_hir/walk_frame.hpp"
+
+namespace slang::ast {
+class Expression;
+}  // namespace slang::ast
+
+namespace lyra::lowering::ast_to_hir {
+
+class ModuleLowerer;
+
+// The duck-typed contract a pass class fulfils for context-free expression
+// lowering: recurse into a sub-expression and reach the enclosing module. Both
+// `ProcessLowerer` (procedural bodies) and `StructuralScopeLowerer` (structural
+// scopes) satisfy it; the shared per-expression handler templates are
+// constrained on it so the surface they depend on is named and checked rather
+// than surfacing as a deep template error. Sub-expressions are interned through
+// the walk frame's single expression arena, so the lowerer's own surface is
+// only the recursion and the module. It is deliberately not a base class -- the
+// two pass classes build different things and share no v-table
+// (decisions/generic-lowering-machinery.md).
+template <typename L>
+concept ExprLowerer =
+    requires(L& lowerer, const slang::ast::Expression& expr, WalkFrame frame) {
+      {
+        lowerer.LowerExpr(expr, frame)
+      } -> std::same_as<diag::Result<hir::Expr>>;
+      lowerer.Module();
+    };
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/expression/operators.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/operators.hpp
@@ -6,8 +6,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
-#include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace slang::ast {
@@ -19,39 +18,26 @@ class UnaryExpression;
 
 namespace lyra::lowering::ast_to_hir {
 
-// Procedural-context handlers.
-auto LowerUnaryExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
-    const slang::ast::UnaryExpression& un, diag::SourceSpan span)
-    -> diag::Result<hir::Expr>;
-auto LowerBinaryExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
-    const slang::ast::BinaryExpression& bin, diag::SourceSpan span)
-    -> diag::Result<hir::Expr>;
-auto LowerConditionalExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
+// An operator's meaning is independent of the enclosing scope, so one template
+// over the pass class serves both the procedural and structural contexts. The
+// pass class is reached through the uniform `LowerExpr` recursion; explicit
+// instantiations for the two pass classes live in the implementation file.
+template <ExprLowerer Lowerer>
+auto LowerUnaryExpr(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::UnaryExpression& un,
+    diag::SourceSpan span) -> diag::Result<hir::Expr>;
+template <ExprLowerer Lowerer>
+auto LowerBinaryExpr(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::BinaryExpression& bin,
+    diag::SourceSpan span) -> diag::Result<hir::Expr>;
+template <ExprLowerer Lowerer>
+auto LowerConditionalExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::ConditionalExpression& cond, diag::SourceSpan span)
     -> diag::Result<hir::Expr>;
-auto LowerConversionExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
-    const slang::ast::ConversionExpression& conv, diag::SourceSpan span)
-    -> diag::Result<hir::Expr>;
-
-// Structural-context handlers.
-auto LowerUnaryExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::UnaryExpression& un, diag::SourceSpan span)
-    -> diag::Result<hir::Expr>;
-auto LowerBinaryExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::BinaryExpression& bin, diag::SourceSpan span)
-    -> diag::Result<hir::Expr>;
-auto LowerConditionalExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::ConditionalExpression& cond, diag::SourceSpan span)
-    -> diag::Result<hir::Expr>;
-auto LowerConversionExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerConversionExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::ConversionExpression& conv, diag::SourceSpan span)
     -> diag::Result<hir::Expr>;
 

--- a/include/lyra/lowering/ast_to_hir/expression/selects.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/selects.hpp
@@ -8,8 +8,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
-#include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace slang::ast {
@@ -20,37 +19,31 @@ class RangeSelectExpression;
 
 namespace lyra::lowering::ast_to_hir {
 
+class ProcessLowerer;
+
 // LRM 7.10 `$` (UnboundedLiteral) in a queue index / slice bound. Resolves to
-// the queue's last index via the base bound on the walk frame.
+// the queue's last index via the base bound on the walk frame. A queue is a
+// dynamic type, so `$` only ever appears in procedural code (LRM 7.10.1).
 auto LowerUnboundedLiteralProc(
     ProcessLowerer& proc, WalkFrame frame, diag::SourceSpan span)
     -> diag::Result<hir::Expr>;
 
-// Procedural-context handlers.
-auto LowerElementSelectExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
+// An access/projection's meaning is independent of the enclosing scope, so one
+// template over the pass class serves both the procedural and structural
+// contexts; explicit instantiations live in the implementation file.
+template <ExprLowerer Lowerer>
+auto LowerElementSelectExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::ElementSelectExpression& sel, diag::SourceSpan span)
     -> diag::Result<hir::Expr>;
-auto LowerRangeSelectExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerRangeSelectExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::RangeSelectExpression& sel, diag::SourceSpan span)
     -> diag::Result<hir::Expr>;
-auto LowerMemberAccessExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
-    const slang::ast::MemberAccessExpression& sel, diag::SourceSpan span)
-    -> diag::Result<hir::Expr>;
-
-// Structural-context handlers.
-auto LowerElementSelectExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::ElementSelectExpression& sel, diag::SourceSpan span)
-    -> diag::Result<hir::Expr>;
-auto LowerRangeSelectExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::RangeSelectExpression& sel, diag::SourceSpan span)
-    -> diag::Result<hir::Expr>;
-auto LowerMemberAccessExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerMemberAccessExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::MemberAccessExpression& sel, diag::SourceSpan span)
     -> diag::Result<hir::Expr>;
 

--- a/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
@@ -19,11 +19,12 @@
 
 namespace lyra::lowering::ast_to_hir {
 
-auto LowerConcatExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerConcatExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::ConcatenationExpression& cc, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  auto& module = proc.Module();
+  auto& module = lowerer.Module();
   auto type_id = module.InternType(*cc.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   const auto kind = module.Unit().GetType(*type_id).Kind();
@@ -47,7 +48,7 @@ auto LowerConcatExprProc(
         op->type->isVoid()) {
       continue;
     }
-    auto operand_or = proc.LowerExpr(*op, frame);
+    auto operand_or = lowerer.LowerExpr(*op, frame);
     if (!operand_or) return std::unexpected(std::move(operand_or.error()));
     operand_ids.push_back(frame.Exprs().Add(*std::move(operand_or)));
   }
@@ -86,16 +87,17 @@ auto LowerReplicationExprProc(
   };
 }
 
-auto LowerAssignmentPatternFromElementsProc(
-    ProcessLowerer& proc, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerAssignmentPatternFromElements(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::AssignmentPatternExpressionBase& ap,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto type_id = proc.Module().InternType(*ap.type, span);
+  auto type_id = lowerer.Module().InternType(*ap.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   std::vector<hir::ExprId> element_ids;
   element_ids.reserve(ap.elements().size());
   for (const auto* elem : ap.elements()) {
-    auto lowered = proc.LowerExpr(*elem, frame);
+    auto lowered = lowerer.LowerExpr(*elem, frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     element_ids.push_back(frame.Exprs().Add(*std::move(lowered)));
   }
@@ -106,26 +108,27 @@ auto LowerAssignmentPatternFromElementsProc(
   };
 }
 
-auto LowerAssociativeAssignmentPatternProc(
-    ProcessLowerer& proc, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerAssociativeAssignmentPattern(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::StructuredAssignmentPatternExpression& ap,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto type_id = proc.Module().InternType(*ap.type, span);
+  auto type_id = lowerer.Module().InternType(*ap.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   std::vector<hir::AssociativeAssignmentPatternExpr::Entry> entries;
   entries.reserve(ap.indexSetters.size());
   for (const auto& setter : ap.indexSetters) {
-    auto key_or = proc.LowerExpr(*setter.index, frame);
+    auto key_or = lowerer.LowerExpr(*setter.index, frame);
     if (!key_or) return std::unexpected(std::move(key_or.error()));
     const hir::ExprId key_id = frame.Exprs().Add(*std::move(key_or));
-    auto value_or = proc.LowerExpr(*setter.expr, frame);
+    auto value_or = lowerer.LowerExpr(*setter.expr, frame);
     if (!value_or) return std::unexpected(std::move(value_or.error()));
     const hir::ExprId value_id = frame.Exprs().Add(*std::move(value_or));
     entries.push_back({.key = key_id, .value = value_id});
   }
   std::optional<hir::ExprId> default_id;
   if (ap.defaultSetter != nullptr) {
-    auto default_or = proc.LowerExpr(*ap.defaultSetter, frame);
+    auto default_or = lowerer.LowerExpr(*ap.defaultSetter, frame);
     if (!default_or) return std::unexpected(std::move(default_or.error()));
     default_id = frame.Exprs().Add(*std::move(default_or));
   }
@@ -140,19 +143,20 @@ auto LowerAssociativeAssignmentPatternProc(
   };
 }
 
-auto LowerReplicatedAssignmentPatternExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerReplicatedAssignmentPatternExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::ReplicatedAssignmentPatternExpression& rp,
     diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto type_id = proc.Module().InternType(*rp.type, span);
+  auto type_id = lowerer.Module().InternType(*rp.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
-  auto count_or = proc.LowerExpr(rp.count(), frame);
+  auto count_or = lowerer.LowerExpr(rp.count(), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
   const hir::ExprId count_id = frame.Exprs().Add(*std::move(count_or));
   std::vector<hir::ExprId> item_ids;
   item_ids.reserve(rp.elements().size());
   for (const auto* elem : rp.elements()) {
-    auto lowered = proc.LowerExpr(*elem, frame);
+    auto lowered = lowerer.LowerExpr(*elem, frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     item_ids.push_back(frame.Exprs().Add(*std::move(lowered)));
   }
@@ -197,117 +201,38 @@ auto LowerNewArrayExprProc(
   };
 }
 
-auto LowerConcatExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::ConcatenationExpression& cc, diag::SourceSpan span)
-    -> diag::Result<hir::Expr> {
-  auto& module = scope.Module();
-  auto type_id = module.InternType(*cc.type, span);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-  const auto kind = module.Unit().GetType(*type_id).Kind();
-  if (kind != hir::TypeKind::kString && kind != hir::TypeKind::kPackedArray) {
-    return diag::Unsupported(
-        span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
-        "concatenation result type is neither string nor packed (LRM 11.4.12)",
-        diag::UnsupportedCategory::kFeature);
-  }
-  std::vector<hir::ExprId> operand_ids;
-  operand_ids.reserve(cc.operands().size());
-  for (const auto* op : cc.operands()) {
-    if (op->kind == slang::ast::ExpressionKind::Replication &&
-        op->type->isVoid()) {
-      continue;
-    }
-    auto operand_or = scope.LowerExpr(*op, frame);
-    if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-    operand_ids.push_back(frame.Exprs().Add(*std::move(operand_or)));
-  }
-  return hir::Expr{
-      .type = *type_id,
-      .data = hir::ConcatExpr{.operands = std::move(operand_ids)},
-      .span = span,
-  };
-}
-
-auto LowerAssignmentPatternFromElementsStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::AssignmentPatternExpressionBase& ap,
-    diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto type_id = scope.Module().InternType(*ap.type, span);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-  std::vector<hir::ExprId> element_ids;
-  element_ids.reserve(ap.elements().size());
-  for (const auto* elem : ap.elements()) {
-    auto lowered = scope.LowerExpr(*elem, frame);
-    if (!lowered) return std::unexpected(std::move(lowered.error()));
-    element_ids.push_back(frame.Exprs().Add(*std::move(lowered)));
-  }
-  return hir::Expr{
-      .type = *type_id,
-      .data = hir::AssignmentPatternExpr{.elements = std::move(element_ids)},
-      .span = span,
-  };
-}
-
-auto LowerAssociativeAssignmentPatternStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::StructuredAssignmentPatternExpression& ap,
-    diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto type_id = scope.Module().InternType(*ap.type, span);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-  std::vector<hir::AssociativeAssignmentPatternExpr::Entry> entries;
-  entries.reserve(ap.indexSetters.size());
-  for (const auto& setter : ap.indexSetters) {
-    auto key_or = scope.LowerExpr(*setter.index, frame);
-    if (!key_or) return std::unexpected(std::move(key_or.error()));
-    const hir::ExprId key_id = frame.Exprs().Add(*std::move(key_or));
-    auto value_or = scope.LowerExpr(*setter.expr, frame);
-    if (!value_or) return std::unexpected(std::move(value_or.error()));
-    const hir::ExprId value_id = frame.Exprs().Add(*std::move(value_or));
-    entries.push_back({.key = key_id, .value = value_id});
-  }
-  std::optional<hir::ExprId> default_id;
-  if (ap.defaultSetter != nullptr) {
-    auto default_or = scope.LowerExpr(*ap.defaultSetter, frame);
-    if (!default_or) return std::unexpected(std::move(default_or.error()));
-    default_id = frame.Exprs().Add(*std::move(default_or));
-  }
-  return hir::Expr{
-      .type = *type_id,
-      .data =
-          hir::AssociativeAssignmentPatternExpr{
-              .entries = std::move(entries),
-              .default_value = default_id,
-          },
-      .span = span,
-  };
-}
-
-auto LowerReplicatedAssignmentPatternExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::ReplicatedAssignmentPatternExpression& rp,
-    diag::SourceSpan span) -> diag::Result<hir::Expr> {
-  auto type_id = scope.Module().InternType(*rp.type, span);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-  auto count_or = scope.LowerExpr(rp.count(), frame);
-  if (!count_or) return std::unexpected(std::move(count_or.error()));
-  const hir::ExprId count_id = frame.Exprs().Add(*std::move(count_or));
-  std::vector<hir::ExprId> item_ids;
-  item_ids.reserve(rp.elements().size());
-  for (const auto* elem : rp.elements()) {
-    auto lowered = scope.LowerExpr(*elem, frame);
-    if (!lowered) return std::unexpected(std::move(lowered.error()));
-    item_ids.push_back(frame.Exprs().Add(*std::move(lowered)));
-  }
-  return hir::Expr{
-      .type = *type_id,
-      .data =
-          hir::AssignmentPatternReplicationExpr{
-              .count = count_id,
-              .items = std::move(item_ids),
-          },
-      .span = span,
-  };
-}
+// One concrete instantiation per pass class; the templates are defined here so
+// the dispatchers in lower.cpp link against the symbols emitted in this file.
+template auto LowerConcatExpr(
+    ProcessLowerer&, WalkFrame, const slang::ast::ConcatenationExpression&,
+    diag::SourceSpan) -> diag::Result<hir::Expr>;
+template auto LowerConcatExpr(
+    StructuralScopeLowerer&, WalkFrame,
+    const slang::ast::ConcatenationExpression&, diag::SourceSpan)
+    -> diag::Result<hir::Expr>;
+template auto LowerAssignmentPatternFromElements(
+    ProcessLowerer&, WalkFrame,
+    const slang::ast::AssignmentPatternExpressionBase&, diag::SourceSpan)
+    -> diag::Result<hir::Expr>;
+template auto LowerAssignmentPatternFromElements(
+    StructuralScopeLowerer&, WalkFrame,
+    const slang::ast::AssignmentPatternExpressionBase&, diag::SourceSpan)
+    -> diag::Result<hir::Expr>;
+template auto LowerReplicatedAssignmentPatternExpr(
+    ProcessLowerer&, WalkFrame,
+    const slang::ast::ReplicatedAssignmentPatternExpression&, diag::SourceSpan)
+    -> diag::Result<hir::Expr>;
+template auto LowerReplicatedAssignmentPatternExpr(
+    StructuralScopeLowerer&, WalkFrame,
+    const slang::ast::ReplicatedAssignmentPatternExpression&, diag::SourceSpan)
+    -> diag::Result<hir::Expr>;
+template auto LowerAssociativeAssignmentPattern(
+    ProcessLowerer&, WalkFrame,
+    const slang::ast::StructuredAssignmentPatternExpression&, diag::SourceSpan)
+    -> diag::Result<hir::Expr>;
+template auto LowerAssociativeAssignmentPattern(
+    StructuralScopeLowerer&, WalkFrame,
+    const slang::ast::StructuredAssignmentPatternExpression&, diag::SourceSpan)
+    -> diag::Result<hir::Expr>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -29,6 +29,8 @@
 #include "lyra/lowering/ast_to_hir/expression/slang_atoms.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -165,7 +167,7 @@ auto LowerProcExpr(
           "constructed is discarded at AST -> HIR");
 
     case slang::ast::ExpressionKind::Conversion:
-      return LowerConversionExprProc(
+      return LowerConversionExpr(
           proc, frame, expr.as<slang::ast::ConversionExpression>(), span);
 
     case slang::ast::ExpressionKind::UnaryOp: {
@@ -173,15 +175,15 @@ auto LowerProcExpr(
       if (slang::ast::OpInfo::isLValue(un.op)) {
         return LowerIncDecExprProc(proc, frame, un, span);
       }
-      return LowerUnaryExprProc(proc, frame, un, span);
+      return LowerUnaryExpr(proc, frame, un, span);
     }
 
     case slang::ast::ExpressionKind::BinaryOp:
-      return LowerBinaryExprProc(
+      return LowerBinaryExpr(
           proc, frame, expr.as<slang::ast::BinaryExpression>(), span);
 
     case slang::ast::ExpressionKind::ConditionalOp:
-      return LowerConditionalExprProc(
+      return LowerConditionalExpr(
           proc, frame, expr.as<slang::ast::ConditionalExpression>(), span);
 
     case slang::ast::ExpressionKind::Call:
@@ -197,22 +199,22 @@ auto LowerProcExpr(
           proc, frame, expr.as<slang::ast::InsideExpression>(), span);
 
     case slang::ast::ExpressionKind::ElementSelect:
-      return LowerElementSelectExprProc(
+      return LowerElementSelectExpr(
           proc, frame, expr.as<slang::ast::ElementSelectExpression>(), span);
 
     case slang::ast::ExpressionKind::RangeSelect:
-      return LowerRangeSelectExprProc(
+      return LowerRangeSelectExpr(
           proc, frame, expr.as<slang::ast::RangeSelectExpression>(), span);
 
     case slang::ast::ExpressionKind::MemberAccess:
-      return LowerMemberAccessExprProc(
+      return LowerMemberAccessExpr(
           proc, frame, expr.as<slang::ast::MemberAccessExpression>(), span);
 
     case slang::ast::ExpressionKind::UnboundedLiteral:
       return LowerUnboundedLiteralProc(proc, frame, span);
 
     case slang::ast::ExpressionKind::Concatenation:
-      return LowerConcatExprProc(
+      return LowerConcatExpr(
           proc, frame, expr.as<slang::ast::ConcatenationExpression>(), span);
 
     case slang::ast::ExpressionKind::Replication:
@@ -228,7 +230,7 @@ auto LowerProcExpr(
             "assignment pattern as LHS destructuring is not yet supported",
             diag::UnsupportedCategory::kOperation);
       }
-      return LowerAssignmentPatternFromElementsProc(proc, frame, sap, span);
+      return LowerAssignmentPatternFromElements(proc, frame, sap, span);
     }
 
     case slang::ast::ExpressionKind::StructuredAssignmentPattern: {
@@ -239,7 +241,7 @@ auto LowerProcExpr(
       // optional default; lower the keyed form, not the positional one that
       // would drop both.
       if (target_kind == slang::ast::SymbolKind::AssociativeArrayType) {
-        return LowerAssociativeAssignmentPatternProc(proc, frame, sap, span);
+        return LowerAssociativeAssignmentPattern(proc, frame, sap, span);
       }
       // Slang accepts `'{idx:val, ...}` for a dynamic-array target as long
       // as indices cover a dense `0..N-1`. The legal subset is equivalent to
@@ -252,11 +254,11 @@ auto LowerProcExpr(
             "supported; use positional form",
             diag::UnsupportedCategory::kOperation);
       }
-      return LowerAssignmentPatternFromElementsProc(proc, frame, sap, span);
+      return LowerAssignmentPatternFromElements(proc, frame, sap, span);
     }
 
     case slang::ast::ExpressionKind::ReplicatedAssignmentPattern:
-      return LowerReplicatedAssignmentPatternExprProc(
+      return LowerReplicatedAssignmentPatternExpr(
           proc, frame,
           expr.as<slang::ast::ReplicatedAssignmentPatternExpression>(), span);
 
@@ -318,7 +320,7 @@ auto LowerStructuralExpr(
           "directly");
 
     case slang::ast::ExpressionKind::Conversion:
-      return LowerConversionExprStructural(
+      return LowerConversionExpr(
           scope, frame, expr.as<slang::ast::ConversionExpression>(), span);
 
     case slang::ast::ExpressionKind::UnaryOp: {
@@ -330,31 +332,31 @@ auto LowerStructuralExpr(
             "(LRM 11.3.6, 11.4.2)",
             diag::UnsupportedCategory::kFeature);
       }
-      return LowerUnaryExprStructural(scope, frame, un, span);
+      return LowerUnaryExpr(scope, frame, un, span);
     }
 
     case slang::ast::ExpressionKind::BinaryOp:
-      return LowerBinaryExprStructural(
+      return LowerBinaryExpr(
           scope, frame, expr.as<slang::ast::BinaryExpression>(), span);
 
     case slang::ast::ExpressionKind::ConditionalOp:
-      return LowerConditionalExprStructural(
+      return LowerConditionalExpr(
           scope, frame, expr.as<slang::ast::ConditionalExpression>(), span);
 
     case slang::ast::ExpressionKind::ElementSelect:
-      return LowerElementSelectExprStructural(
+      return LowerElementSelectExpr(
           scope, frame, expr.as<slang::ast::ElementSelectExpression>(), span);
 
     case slang::ast::ExpressionKind::RangeSelect:
-      return LowerRangeSelectExprStructural(
+      return LowerRangeSelectExpr(
           scope, frame, expr.as<slang::ast::RangeSelectExpression>(), span);
 
     case slang::ast::ExpressionKind::MemberAccess:
-      return LowerMemberAccessExprStructural(
+      return LowerMemberAccessExpr(
           scope, frame, expr.as<slang::ast::MemberAccessExpression>(), span);
 
     case slang::ast::ExpressionKind::Concatenation:
-      return LowerConcatExprStructural(
+      return LowerConcatExpr(
           scope, frame, expr.as<slang::ast::ConcatenationExpression>(), span);
 
     case slang::ast::ExpressionKind::SimpleAssignmentPattern: {
@@ -366,8 +368,7 @@ auto LowerStructuralExpr(
             "assignment pattern as LHS destructuring is not yet supported",
             diag::UnsupportedCategory::kOperation);
       }
-      return LowerAssignmentPatternFromElementsStructural(
-          scope, frame, sap, span);
+      return LowerAssignmentPatternFromElements(scope, frame, sap, span);
     }
 
     case slang::ast::ExpressionKind::StructuredAssignmentPattern: {
@@ -375,8 +376,7 @@ auto LowerStructuralExpr(
           expr.as<slang::ast::StructuredAssignmentPatternExpression>();
       const auto target_kind = expr.type->getCanonicalType().kind;
       if (target_kind == slang::ast::SymbolKind::AssociativeArrayType) {
-        return LowerAssociativeAssignmentPatternStructural(
-            scope, frame, sap, span);
+        return LowerAssociativeAssignmentPattern(scope, frame, sap, span);
       }
       if (target_kind == slang::ast::SymbolKind::DynamicArrayType) {
         return diag::Unsupported(
@@ -385,12 +385,11 @@ auto LowerStructuralExpr(
             "supported; use positional form",
             diag::UnsupportedCategory::kOperation);
       }
-      return LowerAssignmentPatternFromElementsStructural(
-          scope, frame, sap, span);
+      return LowerAssignmentPatternFromElements(scope, frame, sap, span);
     }
 
     case slang::ast::ExpressionKind::ReplicatedAssignmentPattern:
-      return LowerReplicatedAssignmentPatternExprStructural(
+      return LowerReplicatedAssignmentPatternExpr(
           scope, frame,
           expr.as<slang::ast::ReplicatedAssignmentPatternExpression>(), span);
 

--- a/src/lyra/lowering/ast_to_hir/expression/operators.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/operators.cpp
@@ -75,14 +75,15 @@ auto CheckBinaryOperands(
 
 }  // namespace
 
-auto LowerConversionExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerConversionExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::ConversionExpression& conv, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  auto operand_or = proc.LowerExpr(conv.operand(), frame);
+  auto operand_or = lowerer.LowerExpr(conv.operand(), frame);
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
   const hir::ExprId operand_id = frame.Exprs().Add(*std::move(operand_or));
-  auto type_id = proc.Module().InternType(*conv.type, span);
+  auto type_id = lowerer.Module().InternType(*conv.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
@@ -95,15 +96,15 @@ auto LowerConversionExprProc(
   };
 }
 
-auto LowerUnaryExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
-    const slang::ast::UnaryExpression& un, diag::SourceSpan span)
-    -> diag::Result<hir::Expr> {
+template <ExprLowerer Lowerer>
+auto LowerUnaryExpr(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::UnaryExpression& un,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
   const hir::UnaryOp op = LowerUnaryOp(un.op);
-  auto operand_or = proc.LowerExpr(un.operand(), frame);
+  auto operand_or = lowerer.LowerExpr(un.operand(), frame);
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
   const hir::ExprId operand_id = frame.Exprs().Add(*std::move(operand_or));
-  auto type_id = proc.Module().InternType(*un.type, span);
+  auto type_id = lowerer.Module().InternType(*un.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
@@ -112,20 +113,20 @@ auto LowerUnaryExprProc(
   };
 }
 
-auto LowerBinaryExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
-    const slang::ast::BinaryExpression& bin, diag::SourceSpan span)
-    -> diag::Result<hir::Expr> {
+template <ExprLowerer Lowerer>
+auto LowerBinaryExpr(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::BinaryExpression& bin,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
   if (auto check = CheckBinaryOperands(bin, span); !check) {
     return std::unexpected(std::move(check.error()));
   }
-  auto lhs_or = proc.LowerExpr(bin.left(), frame);
+  auto lhs_or = lowerer.LowerExpr(bin.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const hir::ExprId lhs_id = frame.Exprs().Add(*std::move(lhs_or));
-  auto rhs_or = proc.LowerExpr(bin.right(), frame);
+  auto rhs_or = lowerer.LowerExpr(bin.right(), frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const hir::ExprId rhs_id = frame.Exprs().Add(*std::move(rhs_or));
-  auto type_id = proc.Module().InternType(*bin.type, span);
+  auto type_id = lowerer.Module().InternType(*bin.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
@@ -139,8 +140,9 @@ auto LowerBinaryExprProc(
   };
 }
 
-auto LowerConditionalExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerConditionalExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::ConditionalExpression& cond, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
   if (cond.conditions.size() != 1) {
@@ -156,16 +158,16 @@ auto LowerConditionalExprProc(
         "conditional operator with `matches` pattern is not yet supported",
         diag::UnsupportedCategory::kOperation);
   }
-  auto cond_or = proc.LowerExpr(*cond.conditions[0].expr, frame);
+  auto cond_or = lowerer.LowerExpr(*cond.conditions[0].expr, frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
   const hir::ExprId cond_id = frame.Exprs().Add(*std::move(cond_or));
-  auto then_or = proc.LowerExpr(cond.left(), frame);
+  auto then_or = lowerer.LowerExpr(cond.left(), frame);
   if (!then_or) return std::unexpected(std::move(then_or.error()));
   const hir::ExprId then_id = frame.Exprs().Add(*std::move(then_or));
-  auto else_or = proc.LowerExpr(cond.right(), frame);
+  auto else_or = lowerer.LowerExpr(cond.right(), frame);
   if (!else_or) return std::unexpected(std::move(else_or.error()));
   const hir::ExprId else_id = frame.Exprs().Add(*std::move(else_or));
-  auto type_id = proc.Module().InternType(*cond.type, span);
+  auto type_id = lowerer.Module().InternType(*cond.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
@@ -179,108 +181,33 @@ auto LowerConditionalExprProc(
   };
 }
 
-auto LowerConversionExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::ConversionExpression& conv, diag::SourceSpan span)
-    -> diag::Result<hir::Expr> {
-  auto operand_or = scope.LowerExpr(conv.operand(), frame);
-  if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-  const hir::ExprId operand_id = frame.Exprs().Add(*std::move(operand_or));
-  auto type_id = scope.Module().InternType(*conv.type, span);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-  return hir::Expr{
-      .type = *type_id,
-      .data =
-          hir::ConversionExpr{
-              .operand = operand_id,
-              .kind = LowerConversionKind(conv.conversionKind),
-          },
-      .span = span,
-  };
-}
-
-auto LowerUnaryExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::UnaryExpression& un, diag::SourceSpan span)
-    -> diag::Result<hir::Expr> {
-  const hir::UnaryOp op = LowerUnaryOp(un.op);
-  auto operand_or = scope.LowerExpr(un.operand(), frame);
-  if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-  const hir::ExprId operand_id = frame.Exprs().Add(*std::move(operand_or));
-  auto type_id = scope.Module().InternType(*un.type, span);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-  return hir::Expr{
-      .type = *type_id,
-      .data = hir::UnaryExpr{.op = op, .operand = operand_id},
-      .span = span,
-  };
-}
-
-auto LowerBinaryExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::BinaryExpression& bin, diag::SourceSpan span)
-    -> diag::Result<hir::Expr> {
-  if (auto check = CheckBinaryOperands(bin, span); !check) {
-    return std::unexpected(std::move(check.error()));
-  }
-  auto lhs_or = scope.LowerExpr(bin.left(), frame);
-  if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  const hir::ExprId lhs_id = frame.Exprs().Add(*std::move(lhs_or));
-  auto rhs_or = scope.LowerExpr(bin.right(), frame);
-  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  const hir::ExprId rhs_id = frame.Exprs().Add(*std::move(rhs_or));
-  auto type_id = scope.Module().InternType(*bin.type, span);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-  return hir::Expr{
-      .type = *type_id,
-      .data =
-          hir::BinaryExpr{
-              .op = LowerBinaryOp(bin.op),
-              .lhs = lhs_id,
-              .rhs = rhs_id,
-          },
-      .span = span,
-  };
-}
-
-auto LowerConditionalExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::ConditionalExpression& cond, diag::SourceSpan span)
-    -> diag::Result<hir::Expr> {
-  if (cond.conditions.size() != 1) {
-    return diag::Unsupported(
-        span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
-        "conditional operator with `&&&` multi-condition is not yet "
-        "supported",
-        diag::UnsupportedCategory::kFeature);
-  }
-  if (cond.conditions[0].pattern != nullptr) {
-    return diag::Unsupported(
-        span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
-        "conditional operator with `matches` pattern is not yet supported",
-        diag::UnsupportedCategory::kFeature);
-  }
-  auto cond_or = scope.LowerExpr(*cond.conditions[0].expr, frame);
-  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  const hir::ExprId cond_id = frame.Exprs().Add(*std::move(cond_or));
-  auto then_or = scope.LowerExpr(cond.left(), frame);
-  if (!then_or) return std::unexpected(std::move(then_or.error()));
-  const hir::ExprId then_id = frame.Exprs().Add(*std::move(then_or));
-  auto else_or = scope.LowerExpr(cond.right(), frame);
-  if (!else_or) return std::unexpected(std::move(else_or.error()));
-  const hir::ExprId else_id = frame.Exprs().Add(*std::move(else_or));
-  auto type_id = scope.Module().InternType(*cond.type, span);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-  return hir::Expr{
-      .type = *type_id,
-      .data =
-          hir::ConditionalExpr{
-              .condition = cond_id,
-              .then_value = then_id,
-              .else_value = else_id,
-          },
-      .span = span,
-  };
-}
+// One concrete instantiation per pass class. The handler templates are defined
+// in this file rather than the header so the file-local helpers stay private;
+// the dispatchers in lower.cpp link against the symbols emitted here.
+template auto LowerConversionExpr(
+    ProcessLowerer&, WalkFrame, const slang::ast::ConversionExpression&,
+    diag::SourceSpan) -> diag::Result<hir::Expr>;
+template auto LowerConversionExpr(
+    StructuralScopeLowerer&, WalkFrame, const slang::ast::ConversionExpression&,
+    diag::SourceSpan) -> diag::Result<hir::Expr>;
+template auto LowerUnaryExpr(
+    ProcessLowerer&, WalkFrame, const slang::ast::UnaryExpression&,
+    diag::SourceSpan) -> diag::Result<hir::Expr>;
+template auto LowerUnaryExpr(
+    StructuralScopeLowerer&, WalkFrame, const slang::ast::UnaryExpression&,
+    diag::SourceSpan) -> diag::Result<hir::Expr>;
+template auto LowerBinaryExpr(
+    ProcessLowerer&, WalkFrame, const slang::ast::BinaryExpression&,
+    diag::SourceSpan) -> diag::Result<hir::Expr>;
+template auto LowerBinaryExpr(
+    StructuralScopeLowerer&, WalkFrame, const slang::ast::BinaryExpression&,
+    diag::SourceSpan) -> diag::Result<hir::Expr>;
+template auto LowerConditionalExpr(
+    ProcessLowerer&, WalkFrame, const slang::ast::ConditionalExpression&,
+    diag::SourceSpan) -> diag::Result<hir::Expr>;
+template auto LowerConditionalExpr(
+    StructuralScopeLowerer&, WalkFrame,
+    const slang::ast::ConditionalExpression&, diag::SourceSpan)
+    -> diag::Result<hir::Expr>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -53,8 +53,14 @@ auto LowerUnboundedLiteralProc(
       .span = span};
 }
 
-auto LowerElementSelectExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
+// The string base realizes as a `getc` query at HIR -> MIR (LRM 6.16.3); the
+// queue base ($-index handling) is dynamic-only. slang rejects an element of a
+// dynamic type outside procedural code, so those operands never arrive in a
+// structural scope -- the guard and the $-base threading are uniform and the
+// dynamic branches are simply dead there.
+template <ExprLowerer Lowerer>
+auto LowerElementSelectExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::ElementSelectExpression& sel, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
   const auto& base_canonical = sel.value().type->getCanonicalType();
@@ -65,17 +71,17 @@ auto LowerElementSelectExprProc(
         "element-select on non-integral operand is not yet supported",
         diag::UnsupportedCategory::kOperation);
   }
-  auto base_or = proc.LowerExpr(sel.value(), frame);
+  auto base_or = lowerer.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const hir::ExprId base_id = frame.Exprs().Add(*std::move(base_or));
 
   const WalkFrame idx_frame =
       sel.value().type->isQueue() ? frame.WithDollarBase(base_id) : frame;
-  auto idx_or = proc.LowerExpr(sel.selector(), idx_frame);
+  auto idx_or = lowerer.LowerExpr(sel.selector(), idx_frame);
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const hir::ExprId idx_id = frame.Exprs().Add(*std::move(idx_or));
 
-  auto type_id = proc.Module().InternType(*sel.type, span);
+  auto type_id = lowerer.Module().InternType(*sel.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
@@ -88,8 +94,9 @@ auto LowerElementSelectExprProc(
   };
 }
 
-auto LowerRangeSelectExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerRangeSelectExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::RangeSelectExpression& sel, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
   if (!sel.value().type->isIntegral() && !sel.value().type->isUnpackedArray()) {
@@ -100,17 +107,17 @@ auto LowerRangeSelectExprProc(
         diag::UnsupportedCategory::kOperation);
   }
 
-  auto base_or = proc.LowerExpr(sel.value(), frame);
+  auto base_or = lowerer.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const hir::ExprId base_id = frame.Exprs().Add(*std::move(base_or));
 
   const WalkFrame bound_frame =
       sel.value().type->isQueue() ? frame.WithDollarBase(base_id) : frame;
-  auto left_or = proc.LowerExpr(sel.left(), bound_frame);
+  auto left_or = lowerer.LowerExpr(sel.left(), bound_frame);
   if (!left_or) return std::unexpected(std::move(left_or.error()));
   const hir::ExprId left_id = frame.Exprs().Add(*std::move(left_or));
 
-  auto right_or = proc.LowerExpr(sel.right(), bound_frame);
+  auto right_or = lowerer.LowerExpr(sel.right(), bound_frame);
   if (!right_or) return std::unexpected(std::move(right_or.error()));
   const hir::ExprId right_id = frame.Exprs().Add(*std::move(right_or));
 
@@ -127,10 +134,10 @@ auto LowerRangeSelectExprProc(
             .base_index = left_id, .width = right_id};
     }
     throw InternalError(
-        "LowerRangeSelectExprProc: unknown slang RangeSelectionKind");
+        "LowerRangeSelectExpr: unknown slang RangeSelectionKind");
   }();
 
-  auto type_id = proc.Module().InternType(*sel.type, span);
+  auto type_id = lowerer.Module().InternType(*sel.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
@@ -143,8 +150,9 @@ auto LowerRangeSelectExprProc(
   };
 }
 
-auto LowerMemberAccessExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerMemberAccessExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::MemberAccessExpression& sel, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
   if (sel.member.kind != slang::ast::SymbolKind::Field) {
@@ -154,10 +162,10 @@ auto LowerMemberAccessExprProc(
         diag::UnsupportedCategory::kOperation);
   }
   const auto* field = &sel.member.as<slang::ast::FieldSymbol>();
-  auto base_or = proc.LowerExpr(sel.value(), frame);
+  auto base_or = lowerer.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const hir::ExprId base_id = frame.Exprs().Add(*std::move(base_or));
-  auto type_id = proc.Module().InternType(*sel.type, span);
+  auto type_id = lowerer.Module().InternType(*sel.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
@@ -170,106 +178,28 @@ auto LowerMemberAccessExprProc(
   };
 }
 
-auto LowerElementSelectExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::ElementSelectExpression& sel, diag::SourceSpan span)
-    -> diag::Result<hir::Expr> {
-  // A string element-select needs the getc realization, which the structural
-  // expression path does not yet carry (LRM 6.16.3); only integral and unpacked
-  // bases lower here.
-  if (!sel.value().type->isIntegral() && !sel.value().type->isUnpackedArray()) {
-    return diag::Unsupported(
-        span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
-        "element-select on this operand is not yet supported outside "
-        "procedural code",
-        diag::UnsupportedCategory::kFeature);
-  }
-  auto base_or = scope.LowerExpr(sel.value(), frame);
-  if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const hir::ExprId base_id = frame.Exprs().Add(*std::move(base_or));
-  auto idx_or = scope.LowerExpr(sel.selector(), frame);
-  if (!idx_or) return std::unexpected(std::move(idx_or.error()));
-  const hir::ExprId idx_id = frame.Exprs().Add(*std::move(idx_or));
-  auto type_id = scope.Module().InternType(*sel.type, span);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-  return hir::Expr{
-      .type = *type_id,
-      .data = hir::ElementSelectExpr{.base_value = base_id, .index = idx_id},
-      .span = span,
-  };
-}
-
-auto LowerRangeSelectExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::RangeSelectExpression& sel, diag::SourceSpan span)
-    -> diag::Result<hir::Expr> {
-  if (!sel.value().type->isIntegral() && !sel.value().type->isUnpackedArray()) {
-    return diag::Unsupported(
-        span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
-        "range-select on non-integral, non-unpacked operand is not yet "
-        "supported",
-        diag::UnsupportedCategory::kFeature);
-  }
-  auto base_or = scope.LowerExpr(sel.value(), frame);
-  if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const hir::ExprId base_id = frame.Exprs().Add(*std::move(base_or));
-  auto left_or = scope.LowerExpr(sel.left(), frame);
-  if (!left_or) return std::unexpected(std::move(left_or.error()));
-  const hir::ExprId left_id = frame.Exprs().Add(*std::move(left_or));
-  auto right_or = scope.LowerExpr(sel.right(), frame);
-  if (!right_or) return std::unexpected(std::move(right_or.error()));
-  const hir::ExprId right_id = frame.Exprs().Add(*std::move(right_or));
-  hir::RangeBounds bounds = [&]() -> hir::RangeBounds {
-    switch (sel.getSelectionKind()) {
-      case slang::ast::RangeSelectionKind::Simple:
-        return hir::RangeConstantBounds{
-            .msb_expr = left_id, .lsb_expr = right_id};
-      case slang::ast::RangeSelectionKind::IndexedUp:
-        return hir::RangeIndexedUpBounds{
-            .base_index = left_id, .width = right_id};
-      case slang::ast::RangeSelectionKind::IndexedDown:
-        return hir::RangeIndexedDownBounds{
-            .base_index = left_id, .width = right_id};
-    }
-    throw InternalError(
-        "LowerRangeSelectExprStructural: unknown slang RangeSelectionKind");
-  }();
-  auto type_id = scope.Module().InternType(*sel.type, span);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-  return hir::Expr{
-      .type = *type_id,
-      .data =
-          hir::RangeSelectExpr{
-              .base_value = base_id, .bounds = std::move(bounds)},
-      .span = span,
-  };
-}
-
-auto LowerMemberAccessExprStructural(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::MemberAccessExpression& sel, diag::SourceSpan span)
-    -> diag::Result<hir::Expr> {
-  if (sel.member.kind != slang::ast::SymbolKind::Field) {
-    return diag::Unsupported(
-        span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
-        "member access target is not a struct field",
-        diag::UnsupportedCategory::kFeature);
-  }
-  const auto& field = sel.member.as<slang::ast::FieldSymbol>();
-  auto base_or = scope.LowerExpr(sel.value(), frame);
-  if (!base_or) return std::unexpected(std::move(base_or.error()));
-  const hir::ExprId base_id = frame.Exprs().Add(*std::move(base_or));
-  auto type_id = scope.Module().InternType(*sel.type, span);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
-  return hir::Expr{
-      .type = *type_id,
-      .data =
-          hir::MemberAccessExpr{
-              .base_value = base_id,
-              .field_index = field.fieldIndex,
-          },
-      .span = span,
-  };
-}
+// One concrete instantiation per pass class; the templates are defined here so
+// the dispatchers in lower.cpp link against the symbols emitted in this file.
+template auto LowerElementSelectExpr(
+    ProcessLowerer&, WalkFrame, const slang::ast::ElementSelectExpression&,
+    diag::SourceSpan) -> diag::Result<hir::Expr>;
+template auto LowerElementSelectExpr(
+    StructuralScopeLowerer&, WalkFrame,
+    const slang::ast::ElementSelectExpression&, diag::SourceSpan)
+    -> diag::Result<hir::Expr>;
+template auto LowerRangeSelectExpr(
+    ProcessLowerer&, WalkFrame, const slang::ast::RangeSelectExpression&,
+    diag::SourceSpan) -> diag::Result<hir::Expr>;
+template auto LowerRangeSelectExpr(
+    StructuralScopeLowerer&, WalkFrame,
+    const slang::ast::RangeSelectExpression&, diag::SourceSpan)
+    -> diag::Result<hir::Expr>;
+template auto LowerMemberAccessExpr(
+    ProcessLowerer&, WalkFrame, const slang::ast::MemberAccessExpression&,
+    diag::SourceSpan) -> diag::Result<hir::Expr>;
+template auto LowerMemberAccessExpr(
+    StructuralScopeLowerer&, WalkFrame,
+    const slang::ast::MemberAccessExpression&, diag::SourceSpan)
+    -> diag::Result<hir::Expr>;
 
 }  // namespace lyra::lowering::ast_to_hir


### PR DESCRIPTION
## Summary

Collapses the AST-to-HIR procedural/structural expression-handler twins into one function template per family, mirroring the shape already in place at HIR-to-MIR. Each context-free expression family (operators, selects, aggregate value-builds) previously carried two near-identical handlers -- one taking the procedural pass class, one the structural -- that guarded their accepted operand types independently and so drifted. They are now a single template over the pass class, constrained on a new `ExprLowerer` concept that both `ProcessLowerer` and `StructuralScopeLowerer` satisfy through a uniform `LowerExpr` / `Module()` surface, with sub-expressions interned through the walk position's single expression arena (the enabler that landed in the prior cut). Name resolution and single-context kinds (increment / decrement, replication, the dynamic-array constructor, queue `$`) stay procedural-only handlers.

This is the AST-to-HIR slice of `generic-lowering.md` Phase 2 and resolves `refactor.md` R34: with one source of truth per family there is a single operand guard, so the procedural/structural drift cannot recur. The specific string-element-select concern R34 named needed no separate fix -- slang rejects an element of a dynamic type outside procedural code, so a structural string `s[i]` never reaches lowering, and the getc-vs-element realization was already a property of the node at HIR-to-MIR, applied regardless of origin.

Net effect is subtraction: the twin bodies are deleted and replaced by one template plus a two-line explicit instantiation per family.

## Testing

`bazel test //...` green. The collapse is behavior-preserving for every reachable input; the only changed diagnostics are on structural error paths that slang already rejects upstream, so no golden output moves.