### PR TITLE
Derive diagnostic kind from code, drop category

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -71,6 +71,12 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
   navigation, upward by a runtime self-climb at bind, both by name; and why the cross-unit hop is by
   name, not a typed accessor.
 
+### Diagnostics
+
+- [diagnostic-construction](diagnostic-construction.md) -- a diagnostic's kind is a property of its
+  code, derived at construction; construction is infallible (no re-supplied value, no validating
+  guard); the consumer-less `UnsupportedCategory` axis is removed.
+
 ## File Naming
 
 `kebab-case.md`. The name describes the decision, not when it was made; the date lives inside the

--- a/docs/decisions/diagnostic-construction.md
+++ b/docs/decisions/diagnostic-construction.md
@@ -1,0 +1,148 @@
+# Diagnostic Metadata Derives From the Code; Construction Is Infallible
+
+## Date
+
+2026-06-23
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+A diagnostic's intrinsic metadata -- its severity kind and its classification -- was being
+re-supplied at every emission site and then cross-checked against a central table by guards that
+throw `InternalError` on mismatch. The guards run on the unsupported / error path, which is the
+graceful-degradation path and the least-tested branch, so a call site that names the wrong
+classification turns a clean user-facing diagnostic into a compiler crash. Eleven such drifts were
+found and corrected pointwise, but the design kept re-arming the landmine because the call-site
+value is a second source of truth that can diverge from the table.
+
+This record surveys how mature compilers structure diagnostic metadata, derives the principle they
+share, and applies it: metadata is a property of the code, derived at construction, never
+re-supplied and never validated at the report site; and the one classification axis with no consumer
+is removed rather than carried as a dead field.
+
+## Findings that shaped the design
+
+### F1. Every surveyed compiler derives metadata from the code identity, never from the call site
+
+| Compiler | Registry (single source)                                                                                     | What the emission site supplies                                           |
+| -------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| Clang    | `Diagnostic*Kinds.td` record (tblgen-generated id); severity baked into the id                               | `Diag(Loc, diag::err_xxx) << args` -- location and message args only      |
+| Roslyn   | `DiagnosticDescriptor` (defined once, static); `Id`, `Title`, `MessageFormat`, `Category`, `DefaultSeverity` | `Diagnostic.Create(descriptor, location, args)` -- location and args only |
+| rustc    | `#[derive(Diagnostic)]` struct / lint declaration; `Level` on the definition                                 | `struct_span_err(span, msg).emit()` -- the level is not re-supplied       |
+
+In none of the three does the emission site restate the severity and have it cross-checked. The
+severity is a property of the diagnostic's identity. Clang makes it readable at the call site
+through the id _name_ (`err_` / `warn_` / `ext_` prefix), not through a per-severity factory the
+author selects.
+
+**Consequence:** the prior shape -- a per-kind factory (`Error` / `Unsupported` / `Warning` /
+`HostError`) selected by the author, plus a `RequireKind` guard cross-checking the table -- is the
+outlier. The kind belongs to the code, emitted through one entry, with the code name carrying the
+kind for readability.
+
+### F2. A classification axis exists in mature systems only where an end-user surface consumes it
+
+Roslyn's `Category` is a free-form string (`"Design"`, `"Naming"`, `"Security"`) that earns its
+place by being consumed: `.editorconfig` sets severity in bulk per category
+(`dotnet_analyzer_diagnostic.category-<C>.severity`), and IDEs group analyzers by it. Clang's
+category is surfaced by `-fdiagnostics-show-category`. rustc has no per-error category at all; it
+classifies _lints_ through lint groups, again an end-user configuration surface
+(`#[allow(<group>)]`).
+
+The pattern is uniform: a classification axis is carried only when an end-user-facing consumer
+(severity configuration, grouping, `--explain`) reads it. None of the three carries a classification
+that nothing reads.
+
+**Consequence:** a classification axis is justified by its consumer, not by its plausibility.
+
+### F3. The `UnsupportedCategory` axis has no consumer and does not fit the consumers it mimics
+
+`UnsupportedCategory` (`kType` / `kOperation` / `kFeature`) is read by exactly two things: the
+`RequireCategory` guard (the landmine this decision removes) and a test that asserts the factory
+stored the value the test passed it. The render layer never reads it; there is no severity
+configuration surface, no grouping, no `--explain`. It is a write-only field.
+
+The three classic category consumers were each checked against this compiler's reality and none
+fits:
+
+- **Per-category severity configuration** (Roslyn's `.editorconfig`) presupposes that downgrading a
+  diagnostic lets compilation proceed. An `unsupported` diagnostic means the construct cannot be
+  lowered; downgrading it to a warning produces no IR to continue with. The axis Roslyn's category
+  configures does not exist here.
+- **`--explain <code>`** is served by the code name and message, which already state the nature of
+  the gap; a `[category: type]` tag beside `unsupported_associative_array_type` is redundant.
+- **A maturity / triage summary** ("8 unsupported: 4 type, 3 feature, 1 operation") is the one
+  surface that would fit, but it does not exist and is not on the near-term roadmap.
+
+**Consequence:** the category concept is removed in full. When a real consumer appears (a triage
+summary, or an external user base large enough to want `--explain` grouping), the axis is
+re-introduced on the code registry, derived at construction, with values designed for that consumer
+-- not the present internal three-way split.
+
+### F4. The severity kind is the only call-site distinction that is not already on the code
+
+Two call-site distinctions look like they encode kind but do not need to:
+
+- **Short-circuit versus report-and-continue.** A recoverable failure returns
+  `std::unexpected<Diagnostic>` and unwinds the lowering; a warning is reported to the sink and
+  lowering continues. This is a control-flow distinction, orthogonal to severity, and it is the real
+  reason a call site picks one helper over another.
+- **Span versus no span.** Host-level failures and the no-location unsupported form carry
+  `UnknownSpan`; everything else carries a `SourceSpan`. This is an overload of one entry, not a
+  separate kind.
+
+The severity kind itself (`error` / `unsupported` / `host error` / `warning`) is fully determined by
+the code and is surfaced at the call site by the code name. The production code emits no warning
+today; the only warning code is unreferenced outside tests, confirming that the per-kind factory
+surface was modeling distinctions the call sites do not actually make.
+
+**Consequence:** the construction surface collapses to two kind-neutral helpers split by control
+flow, not four split by severity.
+
+## Decision
+
+The diagnostic subsystem follows these invariants:
+
+1. **The code is the single registry of intrinsic metadata.** Each `DiagCode` carries its `DiagKind`
+   and its `name` in one table. Construction reads the kind from the table
+   (`.kind = DiagCodeKind(code)`); no kind is passed at the call site.
+
+2. **Construction is infallible.** No guard validates a call-site value against the table, because
+   no call-site value is supplied to validate. `RequireKind` and `RequireCategory` are removed.
+   Diagnostic construction, being the graceful-degradation path, never throws.
+
+3. **One kind-neutral construction surface, split by control flow.** `diag::Fail(...)` returns
+   `std::unexpected<Diagnostic>` for the recoverable-failure path; `diag::Make(...)` returns a
+   `Diagnostic` for the report-and-continue path. Each has a with-span and a no-span overload. The
+   severity is not in the helper name; it is on the code. `.WithNote(...)` chaining is unchanged.
+
+4. **The code name carries the kind.** A code's enum name encodes its kind for call-site
+   readability, following Clang's `err_` / `warn_` convention -- the unsupported, host, and warning
+   families are prefixed accordingly, and the error family is prefixed `kError`.
+
+5. **No classification axis without a consumer.** `UnsupportedCategory`, the `category` field on the
+   code table and on `PrimaryDiagItem`, and `DiagCodeCategory` are removed. A future classification
+   axis is added only alongside the end-user surface that reads it, on the code registry, derived at
+   construction.
+
+## Consequences
+
+- `include/lyra/diag/diagnostic.hpp` loses the `detail::RequireKind` / `detail::RequireCategory`
+  guards and the four per-kind factories; it gains `Make` (pure factory, sets kind from the code)
+  and `Fail` (the `unexpected`-returning sugar). The header no longer throws.
+- `PrimaryDiagItem` loses its `category` field; `DiagCodeInfo` loses its `category` field; the
+  `UnsupportedCategory` enum and `DiagCodeCategory` are deleted.
+- Every emission site drops the verb-as-kind selection and, for the unsupported family, the trailing
+  category argument: `diag::Unsupported(span, code, msg, cat)` and `diag::Error(span, code, msg)`
+  both become `diag::Fail(span, code, msg)`. Argument order is unchanged.
+- The render layer is untouched: it already consumes only `kind`, `span`, and `message`.
+- The sink's unused per-kind convenience methods (`Error` / `Unsupported` / `Warning`) are removed;
+  `Report(Diagnostic)` -- the only method production code calls -- stays.
+- The category-round-trip test is removed; a test asserting that a constructed diagnostic's kind
+  matches its code's table kind replaces the role it served.
+- Adding a diagnostic is: one table row (kind + name) and call sites that name the code. There is no
+  second place to keep in sync and no way for a call site to crash the compiler by disagreeing with
+  the table.

--- a/docs/progress/datatypes.md
+++ b/docs/progress/datatypes.md
@@ -48,9 +48,9 @@ LRM 6.12: `real` is IEEE 754 double, `shortreal` is IEEE 754 single, `realtime` 
       conditional), plus `**` via LRM 11.4.3 result-typing, plus shortreal <-> real conversion.
 - [x] C3 -- Cross-family conversions: integral -> real treats `'x` / `'z` as 0 (LRM 6.12.1); real ->
       integral rounds half-away-from-zero (LRM 6.12.1).
-- [x] C4 -- LRM-illegal real forms (LRM 6.12 + 11.3.1 / Table 11-1) diagnose as `diag::Unsupported`
-      with an LRM citation. Slang's frontend filters all but case equality (`===` / `!==`); the
-      case-equality path is guarded at lowering.
+- [x] C4 -- LRM-illegal real forms (LRM 6.12 + 11.3.1 / Table 11-1) diagnose as an unsupported
+      diagnostic with an LRM citation. Slang's frontend filters all but case equality (`===` /
+      `!==`); the case-equality path is guarded at lowering.
 - [x] C5 -- Observable `real` / `shortreal` / `realtime` signals. A module-scope floating-point
       signal is an observable cell (`Var<Real>`): `wait (sig == ...)`, `always_comb` / `@*` reads,
       continuous assignment, non-blocking writes, and the explicit any-change `@(sig)` event control

--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -66,8 +66,8 @@ since the test harness can only probe a variable whose type has an implemented s
 ## Scan family follow-ups
 
 Tracks remaining LRM 21.3.4.3 corners explicitly rejected by the scan family. Each item is a
-user-observable feature gap (lowering-time `diag::Unsupported` or runtime rejection) that should
-close as the corresponding behaviour lands.
+user-observable feature gap (a lowering-time unsupported diagnostic or runtime rejection) that
+should close as the corresponding behaviour lands.
 
 - [x] Expression-position `$sscanf` / `$fscanf` (if-condition, blocking assign-RHS, case selector,
       arithmetic operand). The scan family is modelled per LRM 21.3.4.3 as a system function whose
@@ -120,8 +120,8 @@ close as the corresponding behaviour lands.
 ## String-format family follow-ups
 
 Tracks remaining LRM 21.3.3 corners explicitly rejected by `$sformat` / `$sformatf` / `$swrite*`.
-Each item is a user-observable feature gap (lowering-time `diag::Unsupported`) that should close as
-the corresponding behaviour lands.
+Each item is a user-observable feature gap (a lowering-time unsupported diagnostic) that should
+close as the corresponding behaviour lands.
 
 - [ ] Runtime-evaluated format string for `$sformat` / `$sformatf` (LRM 21.3.3 NOTE: format string
       may be a non-constant expression). Non-literal format expressions are rejected at lowering; a

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -436,25 +436,13 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       variant is `Make<X>Type(...) -> TypeId`. Audit every construction helper and rename it to the
       correct side. **Trigger**: standalone naming cleanup.
 
-- [ ] R33 -- Remove the redundant `UnsupportedCategory` argument from the `diag::Unsupported`
-      factory. The category is already declared once per `DiagCode` in the code table; the factory
-      additionally takes a `cat` argument, stores it, and cross-checks it against the table,
-      throwing an `InternalError` on mismatch. A call site that passes the wrong category therefore
-      _crashes_ on the unsupported path instead of emitting the clean diagnostic it intended -- a
-      latent landmine on every untested rejection. Eleven such drifts were found and corrected
-      pointwise, but the design keeps re-arming the class: the call-site category is a second source
-      of truth that can diverge. Target shape: the factory derives
-      `category = DiagCodeCategory(code)` from the table alone, the `cat` parameter and the
-      `RequireCategory` check are deleted, and the ~96 call sites drop their trailing category
-      argument. This is the universal diagnostic-metadata shape -- Clang keys severity / group to
-      the diagnostic id through TableGen records, Roslyn through a `DiagnosticDescriptor`, rustc
-      through the diagnostic's own level: metadata is a property of the id, derived at emit, never
-      re-supplied at the report site. The `diag_code.cpp` table already is that registry; the only
-      flaw is the factory re-takes a value it should read. The same shape applies to the sibling
-      `RequireKind` guard, which should fold in. The load-bearing principle: diagnostic construction
-      is the graceful-degradation path and must be infallible -- it must never throw, least of all
-      on the rarely-exercised unsupported branches. **Trigger**: standalone; mechanical sweep across
-      every lowering file, so it lands as its own cut.
+- [x] R33 -- A diagnostic's metadata is a property of its code, derived at construction, never
+      re-supplied at the report site, and construction never throws. The per-kind factories and the
+      `RequireKind` / `RequireCategory` cross-check guards (which threw on the rarely-exercised
+      unsupported path) are gone; one kind-neutral surface (`diag::Fail` for the recoverable-failure
+      path, `diag::Make` for report-and-continue) reads the kind from the code table. The
+      consumer-less `UnsupportedCategory` classification axis is removed in full rather than
+      retained. See `../decisions/diagnostic-construction.md`.
 
 - [x] R34 -- Unify the procedural and structural AST-to-HIR expression-lowering paths. The two
       carried parallel handlers per expression family that built the same HIR node but guarded their

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -35,13 +35,13 @@ enum class DiagCode : std::uint32_t {
   kUnsupportedSubroutineArgument,
   kUnsupportedForkJoinForm,
 
-  kDelayValueOutOfRange,
-  kCaseEqualityOnRealOperand,
-  kFormatStringTrailingPercent,
-  kFormatStringMissingSpecifier,
-  kFormatStringWidthOverflow,
-  kFormatStringUnknownSpecifier,
-  kDisplayMissingArg,
+  kErrorDelayValueOutOfRange,
+  kErrorCaseEqualityOnRealOperand,
+  kErrorFormatStringTrailingPercent,
+  kErrorFormatStringMissingSpecifier,
+  kErrorFormatStringWidthOverflow,
+  kErrorFormatStringUnknownSpecifier,
+  kErrorDisplayMissingArg,
   kFormatModulePathNotImplemented,
   kSystemSubroutineExecutionNotImplemented,
 
@@ -58,14 +58,12 @@ enum class DiagCode : std::uint32_t {
 
 struct DiagCodeInfo {
   DiagKind kind;
-  std::optional<UnsupportedCategory> category;
   std::string_view name;
 };
 
 auto Info(DiagCode code) -> const DiagCodeInfo&;
 auto DiagCodeName(DiagCode code) -> std::string_view;
 auto DiagCodeKind(DiagCode code) -> DiagKind;
-auto DiagCodeCategory(DiagCode code) -> std::optional<UnsupportedCategory>;
 auto ParseDiagCode(std::string_view text) -> std::optional<DiagCode>;
 
 }  // namespace lyra::diag

--- a/include/lyra/diag/diagnostic.hpp
+++ b/include/lyra/diag/diagnostic.hpp
@@ -1,43 +1,16 @@
 #pragma once
 
 #include <expected>
-#include <format>
-#include <optional>
 #include <string>
 #include <utility>
 #include <variant>
 #include <vector>
 
-#include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/kind.hpp"
 #include "lyra/diag/source_span.hpp"
 
 namespace lyra::diag {
-
-namespace detail {
-
-inline void RequireKind(DiagCode code, DiagKind expected) {
-  if (DiagCodeKind(code) != expected) {
-    throw InternalError(
-        std::format(
-            "Diagnostic factory: code '{}' is not of the expected kind",
-            DiagCodeName(code)));
-  }
-}
-
-inline void RequireCategory(
-    DiagCode code, std::optional<UnsupportedCategory> expected) {
-  if (DiagCodeCategory(code) != expected) {
-    throw InternalError(
-        std::format(
-            "Diagnostic factory: code '{}' has a different category than the "
-            "factory call site claims",
-            DiagCodeName(code)));
-  }
-}
-
-}  // namespace detail
 
 struct UnknownSpan {
   auto operator==(const UnknownSpan&) const -> bool = default;
@@ -45,13 +18,14 @@ struct UnknownSpan {
 
 using DiagSpan = std::variant<SourceSpan, UnknownSpan>;
 
-// A primary diagnostic body. Always has a stable DiagCode identity.
+// A primary diagnostic body. Always has a stable DiagCode identity. Its kind is
+// a property of the code, read from the code table at construction; no caller
+// supplies or restates it.
 struct PrimaryDiagItem {
   DiagKind kind;
   DiagSpan span;
   DiagCode code;
   std::string message;
-  std::optional<UnsupportedCategory> category;
 
   auto operator==(const PrimaryDiagItem&) const -> bool = default;
 };
@@ -71,92 +45,6 @@ struct Diagnostic {
 
   auto operator==(const Diagnostic&) const -> bool = default;
 
-  static auto Error(SourceSpan span, DiagCode code, std::string msg)
-      -> Diagnostic {
-    detail::RequireKind(code, DiagKind::kError);
-    return Diagnostic{
-        .primary =
-            {.kind = DiagKind::kError,
-             .span = span,
-             .code = code,
-             .message = std::move(msg),
-             .category = std::nullopt},
-        .notes = {},
-    };
-  }
-
-  static auto Unsupported(
-      SourceSpan span, DiagCode code, std::string msg, UnsupportedCategory cat)
-      -> Diagnostic {
-    detail::RequireKind(code, DiagKind::kUnsupported);
-    detail::RequireCategory(code, cat);
-    return Diagnostic{
-        .primary =
-            {.kind = DiagKind::kUnsupported,
-             .span = span,
-             .code = code,
-             .message = std::move(msg),
-             .category = cat},
-        .notes = {},
-    };
-  }
-
-  static auto Unsupported(
-      DiagCode code, std::string msg, UnsupportedCategory cat) -> Diagnostic {
-    detail::RequireKind(code, DiagKind::kUnsupported);
-    detail::RequireCategory(code, cat);
-    return Diagnostic{
-        .primary =
-            {.kind = DiagKind::kUnsupported,
-             .span = UnknownSpan{},
-             .code = code,
-             .message = std::move(msg),
-             .category = cat},
-        .notes = {},
-    };
-  }
-
-  static auto HostError(DiagCode code, std::string msg) -> Diagnostic {
-    detail::RequireKind(code, DiagKind::kHostError);
-    return Diagnostic{
-        .primary =
-            {.kind = DiagKind::kHostError,
-             .span = UnknownSpan{},
-             .code = code,
-             .message = std::move(msg),
-             .category = std::nullopt},
-        .notes = {},
-    };
-  }
-
-  static auto HostError(SourceSpan span, DiagCode code, std::string msg)
-      -> Diagnostic {
-    detail::RequireKind(code, DiagKind::kHostError);
-    return Diagnostic{
-        .primary =
-            {.kind = DiagKind::kHostError,
-             .span = span,
-             .code = code,
-             .message = std::move(msg),
-             .category = std::nullopt},
-        .notes = {},
-    };
-  }
-
-  static auto Warning(SourceSpan span, DiagCode code, std::string msg)
-      -> Diagnostic {
-    detail::RequireKind(code, DiagKind::kWarning);
-    return Diagnostic{
-        .primary =
-            {.kind = DiagKind::kWarning,
-             .span = span,
-             .code = code,
-             .message = std::move(msg),
-             .category = std::nullopt},
-        .notes = {},
-    };
-  }
-
   auto WithNote(SourceSpan span, std::string msg) && -> Diagnostic {
     notes.push_back(NoteDiagItem{.span = span, .message = std::move(msg)});
     return std::move(*this);
@@ -172,34 +60,34 @@ struct Diagnostic {
 template <typename T>
 using Result = std::expected<T, Diagnostic>;
 
-// Construction helpers: build a std::unexpected<Diagnostic> directly so
-// lowering call sites read `return diag::Unsupported(...)` instead of
-// `return std::unexpected(diag::Diagnostic::Unsupported(...))`.
-inline auto Unsupported(
-    SourceSpan span, DiagCode code, std::string msg, UnsupportedCategory cat)
-    -> std::unexpected<Diagnostic> {
-  return std::unexpected(
-      Diagnostic::Unsupported(span, code, std::move(msg), cat));
+// Builds a Diagnostic for the report-and-continue path (a warning, or a
+// diagnostic handed straight to a sink). The kind comes from the code.
+inline auto Make(DiagSpan span, DiagCode code, std::string msg) -> Diagnostic {
+  return Diagnostic{
+      .primary =
+          {.kind = DiagCodeKind(code),
+           .span = span,
+           .code = code,
+           .message = std::move(msg)},
+      .notes = {},
+  };
 }
 
-inline auto Unsupported(DiagCode code, std::string msg, UnsupportedCategory cat)
-    -> std::unexpected<Diagnostic> {
-  return std::unexpected(Diagnostic::Unsupported(code, std::move(msg), cat));
+inline auto Make(DiagCode code, std::string msg) -> Diagnostic {
+  return Make(UnknownSpan{}, code, std::move(msg));
 }
 
-inline auto Error(SourceSpan span, DiagCode code, std::string msg)
+// Builds a std::unexpected<Diagnostic> for the recoverable-failure path, so a
+// lowering call site reads `return diag::Fail(...)` instead of
+// `return std::unexpected(diag::Make(...))`.
+inline auto Fail(DiagSpan span, DiagCode code, std::string msg)
     -> std::unexpected<Diagnostic> {
-  return std::unexpected(Diagnostic::Error(span, code, std::move(msg)));
+  return std::unexpected(Make(span, code, std::move(msg)));
 }
 
-inline auto HostError(DiagCode code, std::string msg)
+inline auto Fail(DiagCode code, std::string msg)
     -> std::unexpected<Diagnostic> {
-  return std::unexpected(Diagnostic::HostError(code, std::move(msg)));
-}
-
-inline auto HostError(SourceSpan span, DiagCode code, std::string msg)
-    -> std::unexpected<Diagnostic> {
-  return std::unexpected(Diagnostic::HostError(span, code, std::move(msg)));
+  return std::unexpected(Make(UnknownSpan{}, code, std::move(msg)));
 }
 
 }  // namespace lyra::diag

--- a/include/lyra/diag/kind.hpp
+++ b/include/lyra/diag/kind.hpp
@@ -12,11 +12,4 @@ enum class DiagKind : std::uint8_t {
   kNote,
 };
 
-// Set iff PrimaryDiagItem::kind == kUnsupported.
-enum class UnsupportedCategory : std::uint8_t {
-  kType,
-  kOperation,
-  kFeature,
-};
-
 }  // namespace lyra::diag

--- a/include/lyra/diag/sink.hpp
+++ b/include/lyra/diag/sink.hpp
@@ -1,11 +1,9 @@
 #pragma once
 
-#include <string>
 #include <utility>
 #include <vector>
 
 #include "lyra/diag/diagnostic.hpp"
-#include "lyra/diag/source_span.hpp"
 
 namespace lyra::diag {
 
@@ -18,20 +16,6 @@ class DiagnosticSink {
       has_errors_ = true;
     }
     diagnostics_.push_back(std::move(diag));
-  }
-
-  void Error(SourceSpan span, DiagCode code, std::string msg) {
-    Report(Diagnostic::Error(span, code, std::move(msg)));
-  }
-
-  void Unsupported(
-      SourceSpan span, DiagCode code, std::string msg,
-      UnsupportedCategory cat) {
-    Report(Diagnostic::Unsupported(span, code, std::move(msg), cat));
-  }
-
-  void Warning(SourceSpan span, DiagCode code, std::string msg) {
-    Report(Diagnostic::Warning(span, code, std::move(msg)));
   }
 
   [[nodiscard]] auto HasErrors() const -> bool {

--- a/include/lyra/lowering/hir_to_mir/expression/system/file_io.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/system/file_io.hpp
@@ -20,7 +20,8 @@ namespace lyra::lowering::hir_to_mir {
 // mir::CallExpr whose first argument is the engine handle (self.Services())
 // and whose remaining arguments are the task operands. Output-arg tasks
 // ($fgets / $fread / $ferror) reach this path only when nested inside a
-// larger expression and return diag::Unsupported -- the statement-position
+// larger expression and return an unsupported diagnostic -- the
+// statement-position
 // desugaring runs upstream via LowerFileIOSystemSubroutineCallStmt.
 auto LowerFileIOSystemSubroutineCall(
     ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& call,

--- a/include/lyra/lowering/hir_to_mir/print_items.hpp
+++ b/include/lyra/lowering/hir_to_mir/print_items.hpp
@@ -43,9 +43,9 @@ auto RadixToFormatKind(support::PrintRadix r) -> value::FormatKind;
 //     and remaining arguments are consumed by its directives;
 //   - else if `fmt_req == kOptional`, every argument from `arg_offset`
 //     onward is rendered with `default_radix` (LRM 21.2.1.1);
-//   - else (`fmt_req == kRequired`) lowering returns
-//     `diag::Unsupported` -- a runtime-evaluated format string is not
-//     yet supported.
+//   - else (`fmt_req == kRequired`) lowering returns an unsupported
+//     diagnostic -- a runtime-evaluated format string is not yet
+//     supported.
 // `arg_offset` is 1 for file-output variants whose first call argument
 // is the MCD/FD descriptor, or for `$sformat` / `$swrite*` whose first
 // argument is the output_var lvalue; 0 otherwise.

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -180,11 +180,10 @@ auto RenderRealLiteralExpr(
 auto RenderParamExpr(const ScopeView& view, const mir::ParamRef& r)
     -> diag::Result<std::string> {
   if (r.hops.value != 0) {
-    return diag::Unsupported(
+    return diag::Fail(
         diag::DiagCode::kCppEmitExpressionFormNotImplemented,
         "cross-scope param access is not yet implemented in "
-        "cpp emit",
-        diag::UnsupportedCategory::kFeature);
+        "cpp emit");
   }
   const std::string& name = view.Class().params.Get(r.param).name;
   return "self->" + name;
@@ -210,11 +209,10 @@ auto IsReferenceLocal(const ScopeView& view, const mir::LocalRef& ref) -> bool {
 auto RenderMemberName(const ScopeView& view, const mir::MemberRef& ref)
     -> diag::Result<std::string> {
   if (ref.hops.value != 0) {
-    return diag::Unsupported(
+    return diag::Fail(
         diag::DiagCode::kCppEmitExpressionFormNotImplemented,
         "cross-scope member access is not yet implemented in cpp "
-        "emit",
-        diag::UnsupportedCategory::kFeature);
+        "emit");
   }
   return "self->" + view.Class().members.Get(ref.var).name;
 }
@@ -259,10 +257,9 @@ auto RenderBinaryOpString(
     default:
       break;
   }
-  return diag::Unsupported(
+  return diag::Fail(
       diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-      "binary operator is not legal on string operands per LRM 6.16",
-      diag::UnsupportedCategory::kFeature);
+      "binary operator is not legal on string operands per LRM 6.16");
 }
 
 auto RenderBinaryOpReal(
@@ -310,10 +307,9 @@ auto RenderBinaryOpReal(
     default:
       break;
   }
-  return diag::Unsupported(
+  return diag::Fail(
       diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-      "binary operator is not legal on real operands per LRM 11.3.1",
-      diag::UnsupportedCategory::kFeature);
+      "binary operator is not legal on real operands per LRM 11.3.1");
 }
 
 // LRM 11.2.2 + 11.4.5: aggregate equality / inequality / case-equality /
@@ -338,10 +334,9 @@ auto RenderBinaryOpArray(
     default:
       break;
   }
-  return diag::Unsupported(
+  return diag::Fail(
       diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-      "binary operator is not legal on aggregate operands per LRM 11.2.2",
-      diag::UnsupportedCategory::kFeature);
+      "binary operator is not legal on aggregate operands per LRM 11.2.2");
 }
 
 auto RenderBinaryOpIntegral(
@@ -438,10 +433,9 @@ auto RenderUnaryOpReal(
     default:
       break;
   }
-  return diag::Unsupported(
+  return diag::Fail(
       diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-      "unary operator is not legal on real operands per LRM 11.3.1",
-      diag::UnsupportedCategory::kFeature);
+      "unary operator is not legal on real operands per LRM 11.3.1");
 }
 
 auto RenderUnaryOpIntegral(mir::UnaryOp op, const std::string& operand)
@@ -954,13 +948,12 @@ auto RenderSystemSubroutineEntryName(const support::SystemSubroutineDesc& desc)
                 "RenderSystemSubroutineEntryName: unknown FileIOKind");
           },
           [&](const auto&) -> diag::Result<std::string_view> {
-            return diag::Unsupported(
+            return diag::Fail(
                 diag::DiagCode::kCppEmitExpressionFormNotImplemented,
                 std::format(
                     "system subroutine '{}' is not yet lowered to a generic "
                     "call",
-                    desc.name),
-                diag::UnsupportedCategory::kFeature);
+                    desc.name));
           },
       },
       desc.semantic);
@@ -1028,11 +1021,10 @@ auto RenderCallExpr(
           },
           [&](const mir::MethodRef& ref) -> diag::Result<std::string> {
             if (ref.hops.value != 0) {
-              return diag::Unsupported(
+              return diag::Fail(
                   diag::DiagCode::kCppEmitExpressionFormNotImplemented,
                   "method call across classes is not yet "
-                  "implemented in cpp emit",
-                  diag::UnsupportedCategory::kFeature);
+                  "implemented in cpp emit");
             }
             const auto& cls = view.EnclosingClassAtHops(
                 mir::EnclosingHops{.value = ref.hops.value});
@@ -1258,11 +1250,10 @@ auto RenderAssignExpr(const ScopeView& view, const mir::AssignExpr& a)
   // supported.
   if (const auto* ref_root = LhsRootReferenceLocal(view, lhs_expr)) {
     if (!IsLhsBarePrimary(lhs_expr) || a.compound_op.has_value()) {
-      return diag::Unsupported(
+      return diag::Fail(
           diag::DiagCode::kCppEmitExpressionFormNotImplemented,
           "compound or partial assignment through a ref / const ref formal is "
-          "not yet implemented in cpp emit",
-          diag::UnsupportedCategory::kFeature);
+          "not yet implemented in cpp emit");
     }
     return LookupLocalName(view, *ref_root) + ".Set(" + "self->Services()" +
            ", " + *value_or + ")";
@@ -1296,11 +1287,10 @@ auto RenderIncDecExpr(const ScopeView& view, const mir::IncDecExpr& inc)
     -> diag::Result<std::string> {
   const mir::Expr& target_expr = view.Expr(inc.target);
   if (LhsRootReferenceLocal(view, target_expr) != nullptr) {
-    return diag::Unsupported(
+    return diag::Fail(
         diag::DiagCode::kCppEmitExpressionFormNotImplemented,
         "increment / decrement of a ref / const ref formal is not yet "
-        "implemented in cpp emit",
-        diag::UnsupportedCategory::kFeature);
+        "implemented in cpp emit");
   }
   auto lhs_or = RenderLhsExpr(view, target_expr);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
@@ -1574,10 +1564,9 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr)
             return RenderCStringLiteral(s.value);
           },
           [](const mir::TimeLiteral&) -> diag::Result<std::string> {
-            return diag::Unsupported(
+            return diag::Fail(
                 diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-                "TimeLiteral is not yet implemented in cpp emit",
-                diag::UnsupportedCategory::kFeature);
+                "TimeLiteral is not yet implemented in cpp emit");
           },
           [&](const mir::RealLiteral& r) -> diag::Result<std::string> {
             return RenderRealLiteralExpr(view, expr, r);

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -15,240 +15,188 @@ constexpr std::array kEntries{
         DiagCode::kUnsupportedPackedArrayElementType,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kType,
             .name = "unsupported_packed_array_element_type"}},
     std::pair{
         DiagCode::kUnsupportedTaggedPackedUnion,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kType,
             .name = "unsupported_tagged_packed_union"}},
     std::pair{
         DiagCode::kUnsupportedFixedSizeUnpackedArrayType,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kType,
             .name = "unsupported_fixed_size_unpacked_array_type"}},
     std::pair{
         DiagCode::kUnsupportedDynamicArrayType,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kType,
             .name = "unsupported_dynamic_array_type"}},
     std::pair{
         DiagCode::kUnsupportedAssociativeArrayType,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kType,
             .name = "unsupported_associative_array_type"}},
     std::pair{
         DiagCode::kUnsupportedUnpackedStructType,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kType,
             .name = "unsupported_unpacked_struct_type"}},
     std::pair{
         DiagCode::kUnsupportedUnpackedUnionType,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kType,
             .name = "unsupported_unpacked_union_type"}},
     std::pair{
         DiagCode::kUnsupportedTypeKind,
         DiagCodeInfo{
-            .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kType,
-            .name = "unsupported_type_kind"}},
+            .kind = DiagKind::kUnsupported, .name = "unsupported_type_kind"}},
 
     std::pair{
         DiagCode::kUnsupportedNonStaticVariableLifetime,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
             .name = "unsupported_non_static_variable_lifetime"}},
     std::pair{
         DiagCode::kUnsupportedStatementForm,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
             .name = "unsupported_statement_form"}},
     std::pair{
         DiagCode::kUnsupportedExpressionForm,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kOperation,
             .name = "unsupported_expression_form"}},
     std::pair{
         DiagCode::kUnsupportedStructuralExpressionForm,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
             .name = "unsupported_structural_expression_form"}},
     std::pair{
         DiagCode::kUnsupportedNonVariableNamedReference,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
             .name = "unsupported_non_variable_named_reference"}},
     std::pair{
         DiagCode::kUnsupportedAssignmentTarget,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
             .name = "unsupported_assignment_target"}},
     std::pair{
         DiagCode::kUnsupportedBinaryOperator,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kOperation,
             .name = "unsupported_binary_operator"}},
     std::pair{
         DiagCode::kUnsupportedTimingControlKind,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
             .name = "unsupported_timing_control_kind"}},
     std::pair{
         DiagCode::kUnsupportedDelayExpressionForm,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
             .name = "unsupported_delay_expression_form"}},
     std::pair{
         DiagCode::kUnsupportedEventTriggerForm,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
             .name = "unsupported_event_trigger_form"}},
     std::pair{
         DiagCode::kUnsupportedContinuousAssignForm,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
             .name = "unsupported_continuous_assign_form"}},
     std::pair{
         DiagCode::kUnsupportedPortConnectionForm,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
             .name = "unsupported_port_connection_form"}},
     std::pair{
         DiagCode::kUnsupportedAssignmentPatternKind,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kOperation,
             .name = "unsupported_assignment_pattern_kind"}},
     std::pair{
         DiagCode::kUnsupportedSubroutineArgument,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
             .name = "unsupported_subroutine_argument"}},
     std::pair{
         DiagCode::kUnsupportedForkJoinForm,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
             .name = "unsupported_fork_join_form"}},
 
     std::pair{
-        DiagCode::kDelayValueOutOfRange,
+        DiagCode::kErrorDelayValueOutOfRange,
         DiagCodeInfo{
-            .kind = DiagKind::kError,
-            .category = std::nullopt,
-            .name = "delay_value_out_of_range"}},
+            .kind = DiagKind::kError, .name = "delay_value_out_of_range"}},
     std::pair{
-        DiagCode::kCaseEqualityOnRealOperand,
+        DiagCode::kErrorCaseEqualityOnRealOperand,
         DiagCodeInfo{
-            .kind = DiagKind::kError,
-            .category = std::nullopt,
-            .name = "case_equality_on_real_operand"}},
+            .kind = DiagKind::kError, .name = "case_equality_on_real_operand"}},
     std::pair{
-        DiagCode::kFormatStringTrailingPercent,
+        DiagCode::kErrorFormatStringTrailingPercent,
         DiagCodeInfo{
             .kind = DiagKind::kError,
-            .category = std::nullopt,
             .name = "format_string_trailing_percent"}},
     std::pair{
-        DiagCode::kFormatStringMissingSpecifier,
+        DiagCode::kErrorFormatStringMissingSpecifier,
         DiagCodeInfo{
             .kind = DiagKind::kError,
-            .category = std::nullopt,
             .name = "format_string_missing_specifier"}},
     std::pair{
-        DiagCode::kFormatStringWidthOverflow,
+        DiagCode::kErrorFormatStringWidthOverflow,
         DiagCodeInfo{
-            .kind = DiagKind::kError,
-            .category = std::nullopt,
-            .name = "format_string_width_overflow"}},
+            .kind = DiagKind::kError, .name = "format_string_width_overflow"}},
     std::pair{
-        DiagCode::kFormatStringUnknownSpecifier,
+        DiagCode::kErrorFormatStringUnknownSpecifier,
         DiagCodeInfo{
             .kind = DiagKind::kError,
-            .category = std::nullopt,
             .name = "format_string_unknown_specifier"}},
     std::pair{
-        DiagCode::kDisplayMissingArg,
-        DiagCodeInfo{
-            .kind = DiagKind::kError,
-            .category = std::nullopt,
-            .name = "display_missing_arg"}},
+        DiagCode::kErrorDisplayMissingArg,
+        DiagCodeInfo{.kind = DiagKind::kError, .name = "display_missing_arg"}},
     std::pair{
         DiagCode::kFormatModulePathNotImplemented,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
             .name = "format_module_path_not_implemented"}},
     std::pair{
         DiagCode::kSystemSubroutineExecutionNotImplemented,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
             .name = "system_subroutine_execution_not_implemented"}},
 
     std::pair{
         DiagCode::kCppEmitExpressionFormNotImplemented,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
-            .category = UnsupportedCategory::kFeature,
             .name = "cpp_emit_expression_form_not_implemented"}},
     std::pair{
         DiagCode::kHostInvalidCliArgs,
         DiagCodeInfo{
-            .kind = DiagKind::kHostError,
-            .category = std::nullopt,
-            .name = "host_invalid_cli_args"}},
+            .kind = DiagKind::kHostError, .name = "host_invalid_cli_args"}},
     std::pair{
         DiagCode::kHostProjectModeUnimplemented,
         DiagCodeInfo{
             .kind = DiagKind::kHostError,
-            .category = std::nullopt,
             .name = "host_project_mode_unimplemented"}},
     std::pair{
         DiagCode::kHostNoInputFiles,
         DiagCodeInfo{
-            .kind = DiagKind::kHostError,
-            .category = std::nullopt,
-            .name = "host_no_input_files"}},
+            .kind = DiagKind::kHostError, .name = "host_no_input_files"}},
     std::pair{
         DiagCode::kHostIoError,
-        DiagCodeInfo{
-            .kind = DiagKind::kHostError,
-            .category = std::nullopt,
-            .name = "host_io_error"}},
+        DiagCodeInfo{.kind = DiagKind::kHostError, .name = "host_io_error"}},
     std::pair{
         DiagCode::kHostBuildFailed,
         DiagCodeInfo{
-            .kind = DiagKind::kHostError,
-            .category = std::nullopt,
-            .name = "host_build_failed"}},
+            .kind = DiagKind::kHostError, .name = "host_build_failed"}},
 
     std::pair{
         DiagCode::kWarningPedantic,
-        DiagCodeInfo{
-            .kind = DiagKind::kWarning,
-            .category = std::nullopt,
-            .name = "warning_pedantic"}},
+        DiagCodeInfo{.kind = DiagKind::kWarning, .name = "warning_pedantic"}},
 };
 
 }  // namespace
@@ -266,10 +214,6 @@ auto DiagCodeName(DiagCode code) -> std::string_view {
 
 auto DiagCodeKind(DiagCode code) -> DiagKind {
   return Info(code).kind;
-}
-
-auto DiagCodeCategory(DiagCode code) -> std::optional<UnsupportedCategory> {
-  return Info(code).category;
 }
 
 auto ParseDiagCode(std::string_view text) -> std::optional<DiagCode> {

--- a/src/lyra/driver/cli.cpp
+++ b/src/lyra/driver/cli.cpp
@@ -267,7 +267,7 @@ auto main(int argc, char** argv) -> int {
 
     if (!parsed) {
       report(
-          lyra::diag::Diagnostic::HostError(
+          lyra::diag::Make(
               lyra::diag::DiagCode::kHostInvalidCliArgs, parsed.error()));
       return 1;
     }
@@ -307,7 +307,7 @@ auto main(int argc, char** argv) -> int {
 
     if (!args.no_project) {
       report(
-          lyra::diag::Diagnostic::HostError(
+          lyra::diag::Make(
               lyra::diag::DiagCode::kHostProjectModeUnimplemented,
               "project mode is not implemented yet; pass --no-project to "
               "run in direct file mode"));
@@ -315,7 +315,7 @@ auto main(int argc, char** argv) -> int {
     }
     if (args.input.files.empty()) {
       report(
-          lyra::diag::Diagnostic::HostError(
+          lyra::diag::Make(
               lyra::diag::DiagCode::kHostNoInputFiles, "no input files"));
       return 1;
     }
@@ -367,7 +367,7 @@ auto main(int argc, char** argv) -> int {
       auto loc_or = lyra::driver::ResolveRuntimeLocation(program_path);
       if (!loc_or) {
         report(
-            lyra::diag::Diagnostic::HostError(
+            lyra::diag::Make(
                 lyra::diag::DiagCode::kHostIoError, std::move(loc_or.error())));
         return std::nullopt;
       }
@@ -439,7 +439,7 @@ auto main(int argc, char** argv) -> int {
         auto tmp_or = lyra::support::MakeTempDir();
         if (!tmp_or) {
           report(
-              lyra::diag::Diagnostic::HostError(
+              lyra::diag::Make(
                   lyra::diag::DiagCode::kHostIoError,
                   std::move(tmp_or.error())));
           return 1;

--- a/src/lyra/driver/cpp_build.cpp
+++ b/src/lyra/driver/cpp_build.cpp
@@ -24,7 +24,7 @@ namespace lyra::driver {
 namespace {
 
 auto IoError(std::string message) {
-  return diag::HostError(diag::DiagCode::kHostIoError, std::move(message));
+  return diag::Fail(diag::DiagCode::kHostIoError, std::move(message));
 }
 
 auto WriteFile(const std::filesystem::path& path, std::string_view content)
@@ -196,7 +196,7 @@ auto CompileProgram(
     return IoError(std::move(result_or.error()));
   }
   if (result_or->exit_code != 0) {
-    return diag::HostError(
+    return diag::Fail(
         diag::DiagCode::kHostBuildFailed,
         std::format(
             "C++ compiler exited with {}:\n{}", result_or->exit_code,

--- a/src/lyra/driver/pch.cpp
+++ b/src/lyra/driver/pch.cpp
@@ -26,7 +26,7 @@ namespace lyra::driver::pch {
 namespace {
 
 auto IoError(std::string message) {
-  return diag::HostError(diag::DiagCode::kHostIoError, std::move(message));
+  return diag::Fail(diag::DiagCode::kHostIoError, std::move(message));
 }
 
 // True when the resolved compiler is clang-based. PCH file format and the
@@ -198,7 +198,7 @@ auto BuildAt(
     return IoError(std::move(result_or.error()));
   }
   if (result_or->exit_code != 0) {
-    return diag::HostError(
+    return diag::Fail(
         diag::DiagCode::kHostBuildFailed,
         std::format(
             "PCH build exited with {}:\n{}", result_or->exit_code,

--- a/src/lyra/frontend/parse_unit.cpp
+++ b/src/lyra/frontend/parse_unit.cpp
@@ -67,7 +67,7 @@ auto ExecuteParseUnit(
           auto buffer_or = source_manager.readSource(path, nullptr);
           if (!buffer_or) {
             sink.Report(
-                diag::Diagnostic::HostError(
+                diag::Make(
                     diag::DiagCode::kHostIoError,
                     fmt::format("cannot read '{}'", u.file)));
             return false;
@@ -93,7 +93,7 @@ auto ExecuteParseUnit(
             auto buffer_or = source_manager.readSource(path, nullptr);
             if (!buffer_or) {
               sink.Report(
-                  diag::Diagnostic::HostError(
+                  diag::Make(
                       diag::DiagCode::kHostIoError,
                       fmt::format("cannot read '{}'", file)));
               return false;

--- a/src/lyra/lowering/ast_to_hir/constant_value.cpp
+++ b/src/lyra/lowering/ast_to_hir/constant_value.cpp
@@ -38,10 +38,9 @@ auto MakeConstantValueExpr(
         .span = span,
     };
   }
-  return diag::Unsupported(
+  return diag::Fail(
       span, diag::DiagCode::kUnsupportedExpressionForm,
-      "constant of aggregate type is not yet supported",
-      diag::UnsupportedCategory::kOperation);
+      "constant of aggregate type is not yet supported");
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
+++ b/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
@@ -40,17 +40,15 @@ auto StructuralScopeLowerer::LowerContinuousAssign(
   const auto span = mapper.PointSpanOf(sym.location);
 
   if (sym.getDelay() != nullptr) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedContinuousAssignForm,
-        "delay on continuous assignment is not yet supported",
-        diag::UnsupportedCategory::kFeature);
+        "delay on continuous assignment is not yet supported");
   }
   const auto strength = sym.getDriveStrength();
   if (strength.first.has_value() || strength.second.has_value()) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedContinuousAssignForm,
-        "drive strength on continuous assignment is not yet supported",
-        diag::UnsupportedCategory::kFeature);
+        "drive strength on continuous assignment is not yet supported");
   }
 
   const auto& assignment_expr = sym.getAssignment();

--- a/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
@@ -30,11 +30,10 @@ auto LowerConcatExpr(
   const auto kind = module.Unit().GetType(*type_id).Kind();
   if (kind != hir::TypeKind::kString && kind != hir::TypeKind::kPackedArray &&
       kind != hir::TypeKind::kQueue) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "concatenation result type is not string, packed, or a queue (LRM "
-        "11.4.12 / 10.10)",
-        diag::UnsupportedCategory::kOperation);
+        "11.4.12 / 10.10)");
   }
   std::vector<hir::ExprId> operand_ids;
   operand_ids.reserve(cc.operands().size());
@@ -68,11 +67,10 @@ auto LowerReplicationExprProc(
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   const auto kind = module.Unit().GetType(*type_id).Kind();
   if (kind != hir::TypeKind::kString && kind != hir::TypeKind::kPackedArray) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "replication result type is neither string nor packed "
-        "(LRM 11.4.12.1)",
-        diag::UnsupportedCategory::kOperation);
+        "(LRM 11.4.12.1)");
   }
   auto count_or = proc.LowerExpr(rp.count(), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));

--- a/src/lyra/lowering/ast_to_hir/expression/assignment.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/assignment.cpp
@@ -121,9 +121,8 @@ auto ValidateAssignableImpl(
   const auto& mapper = module.SourceMapper();
   const auto span = mapper.SpanOf(expr.sourceRange);
   auto reject = [&](std::string_view why) -> diag::Result<void> {
-    return diag::Unsupported(
-        span, diag::DiagCode::kUnsupportedAssignmentTarget, std::string{why},
-        diag::UnsupportedCategory::kFeature);
+    return diag::Fail(
+        span, diag::DiagCode::kUnsupportedAssignmentTarget, std::string{why});
   };
 
   switch (expr.kind) {
@@ -179,11 +178,10 @@ auto ValidateAssignableImpl(
       for (const auto* op : cc.operands()) {
         if (op->kind == EK::Replication) {
           const auto op_span = mapper.SpanOf(op->sourceRange);
-          return diag::Unsupported(
+          return diag::Fail(
               op_span, diag::DiagCode::kUnsupportedAssignmentTarget,
               "replication is not allowed inside a destructuring "
-              "assignment target (LRM 11.4.12.1)",
-              diag::UnsupportedCategory::kFeature);
+              "assignment target (LRM 11.4.12.1)");
         }
         auto sub = ValidateAssignableImpl(module, procedural_context, *op);
         if (!sub) return sub;

--- a/src/lyra/lowering/ast_to_hir/expression/inside.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/inside.cpp
@@ -46,11 +46,10 @@ auto LowerInsideItemImpl(
   if (item_expr.kind == slang::ast::ExpressionKind::ValueRange) {
     const auto& vr = item_expr.as<slang::ast::ValueRangeExpression>();
     if (vr.rangeKind != slang::ast::ValueRangeKind::Simple) {
-      return diag::Unsupported(
+      return diag::Fail(
           module.SourceMapper().SpanOf(vr.sourceRange),
           diag::DiagCode::kUnsupportedExpressionForm,
-          "tolerance-range form in inside operator is not yet supported",
-          diag::UnsupportedCategory::kOperation);
+          "tolerance-range form in inside operator is not yet supported");
     }
     auto lo_or = proc.LowerExpr(vr.left(), frame);
     if (!lo_or) return std::unexpected(std::move(lo_or.error()));

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -225,10 +225,9 @@ auto LowerProcExpr(
       const auto& sap =
           expr.as<slang::ast::SimpleAssignmentPatternExpression>();
       if (sap.isLValue) {
-        return diag::Unsupported(
+        return diag::Fail(
             span, diag::DiagCode::kUnsupportedAssignmentPatternKind,
-            "assignment pattern as LHS destructuring is not yet supported",
-            diag::UnsupportedCategory::kOperation);
+            "assignment pattern as LHS destructuring is not yet supported");
       }
       return LowerAssignmentPatternFromElements(proc, frame, sap, span);
     }
@@ -248,11 +247,10 @@ auto LowerProcExpr(
       // positional and adds no expressive power; rejecting it here keeps the
       // dispatch narrow until a consumer needs the structured form.
       if (target_kind == slang::ast::SymbolKind::DynamicArrayType) {
-        return diag::Unsupported(
+        return diag::Fail(
             span, diag::DiagCode::kUnsupportedAssignmentPatternKind,
             "index-keyed assignment pattern on a dynamic array is not yet "
-            "supported; use positional form",
-            diag::UnsupportedCategory::kOperation);
+            "supported; use positional form");
       }
       return LowerAssignmentPatternFromElements(proc, frame, sap, span);
     }
@@ -267,10 +265,9 @@ auto LowerProcExpr(
           proc, frame, expr.as<slang::ast::NewArrayExpression>(), span);
 
     default:
-      return diag::Unsupported(
+      return diag::Fail(
           span, diag::DiagCode::kUnsupportedExpressionForm,
-          "this expression form is not supported yet",
-          diag::UnsupportedCategory::kOperation);
+          "this expression form is not supported yet");
   }
 }
 
@@ -326,11 +323,10 @@ auto LowerStructuralExpr(
     case slang::ast::ExpressionKind::UnaryOp: {
       const auto& un = expr.as<slang::ast::UnaryExpression>();
       if (slang::ast::OpInfo::isLValue(un.op)) {
-        return diag::Unsupported(
+        return diag::Fail(
             span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
             "increment / decrement is not legal outside procedural code "
-            "(LRM 11.3.6, 11.4.2)",
-            diag::UnsupportedCategory::kFeature);
+            "(LRM 11.3.6, 11.4.2)");
       }
       return LowerUnaryExpr(scope, frame, un, span);
     }
@@ -363,10 +359,9 @@ auto LowerStructuralExpr(
       const auto& sap =
           expr.as<slang::ast::SimpleAssignmentPatternExpression>();
       if (sap.isLValue) {
-        return diag::Unsupported(
+        return diag::Fail(
             span, diag::DiagCode::kUnsupportedAssignmentPatternKind,
-            "assignment pattern as LHS destructuring is not yet supported",
-            diag::UnsupportedCategory::kOperation);
+            "assignment pattern as LHS destructuring is not yet supported");
       }
       return LowerAssignmentPatternFromElements(scope, frame, sap, span);
     }
@@ -379,11 +374,10 @@ auto LowerStructuralExpr(
         return LowerAssociativeAssignmentPattern(scope, frame, sap, span);
       }
       if (target_kind == slang::ast::SymbolKind::DynamicArrayType) {
-        return diag::Unsupported(
+        return diag::Fail(
             span, diag::DiagCode::kUnsupportedAssignmentPatternKind,
             "index-keyed assignment pattern on a dynamic array is not yet "
-            "supported; use positional form",
-            diag::UnsupportedCategory::kOperation);
+            "supported; use positional form");
       }
       return LowerAssignmentPatternFromElements(scope, frame, sap, span);
     }
@@ -394,10 +388,9 @@ auto LowerStructuralExpr(
           expr.as<slang::ast::ReplicatedAssignmentPatternExpression>(), span);
 
     default:
-      return diag::Unsupported(
+      return diag::Fail(
           span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
-          "this structural expression form is not supported yet",
-          diag::UnsupportedCategory::kFeature);
+          "this structural expression form is not supported yet");
   }
 }
 

--- a/src/lyra/lowering/ast_to_hir/expression/operators.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/operators.cpp
@@ -65,8 +65,8 @@ auto CheckBinaryOperands(
       bin.op == slang::ast::BinaryOperator::CaseInequality;
   if (is_case_equality && (TypeHasRealLeaf(*bin.left().type) ||
                            TypeHasRealLeaf(*bin.right().type))) {
-    return diag::Error(
-        span, diag::DiagCode::kCaseEqualityOnRealOperand,
+    return diag::Fail(
+        span, diag::DiagCode::kErrorCaseEqualityOnRealOperand,
         "case equality (=== / !==) is not defined on real or shortreal "
         "operands (LRM Table 11-1)");
   }
@@ -146,17 +146,15 @@ auto LowerConditionalExpr(
     const slang::ast::ConditionalExpression& cond, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
   if (cond.conditions.size() != 1) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "conditional operator with `&&&` multi-condition is not yet "
-        "supported",
-        diag::UnsupportedCategory::kOperation);
+        "supported");
   }
   if (cond.conditions[0].pattern != nullptr) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
-        "conditional operator with `matches` pattern is not yet supported",
-        diag::UnsupportedCategory::kOperation);
+        "conditional operator with `matches` pattern is not yet supported");
   }
   auto cond_or = lowerer.LowerExpr(*cond.conditions[0].expr, frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -100,10 +100,9 @@ auto LowerNamedValueProc(
   if (sym.kind != slang::ast::SymbolKind::Variable &&
       sym.kind != slang::ast::SymbolKind::FormalArgument &&
       sym.kind != slang::ast::SymbolKind::Iterator) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedNonVariableNamedReference,
-        "reference to non-variable declaration is not supported",
-        diag::UnsupportedCategory::kFeature);
+        "reference to non-variable declaration is not supported");
   }
   const auto& var = sym.as<slang::ast::VariableSymbol>();
 
@@ -115,11 +114,10 @@ auto LowerNamedValueProc(
     // spawned branches.
     if (frame.InForkBranch() &&
         proc.ContainingSymbol().kind == slang::ast::SymbolKind::Subroutine) {
-      return diag::Unsupported(
+      return diag::Fail(
           span, diag::DiagCode::kUnsupportedForkJoinForm,
           "a fork-join branch inside a task referencing a procedural variable "
-          "is not yet supported",
-          diag::UnsupportedCategory::kFeature);
+          "is not yet supported");
     }
     const hir::TypeId type_id =
         frame.current_procedural_body->procedural_vars.Get(*local).type;
@@ -157,19 +155,17 @@ auto LowerHierarchicalValueProc(
   const auto& ref = hve.ref;
 
   if (ref.isViaIfacePort()) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
-        "interface-port hierarchical reference is not yet supported",
-        diag::UnsupportedCategory::kOperation);
+        "interface-port hierarchical reference is not yet supported");
   }
 
   const auto& target = hve.symbol;
   if (target.kind != slang::ast::SymbolKind::Variable) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "cross-unit reference to a non-variable declaration is not yet "
-        "supported",
-        diag::UnsupportedCategory::kOperation);
+        "supported");
   }
 
   auto type_id = module.InternType(*hve.type, span);
@@ -191,11 +187,10 @@ auto LowerHierarchicalValueProc(
           hir::IndexHop{static_cast<std::uint32_t>(
               std::get<std::int32_t>(step.selector))});
     } else {
-      return diag::Unsupported(
+      return diag::Fail(
           span, diag::DiagCode::kUnsupportedExpressionForm,
           "instance-array range select in a hierarchical path is not yet "
-          "supported",
-          diag::UnsupportedCategory::kOperation);
+          "supported");
     }
   }
 
@@ -237,12 +232,11 @@ auto LowerHierarchicalValueProc(
         // Any other head -- an indexed loop-generate block, or a named
         // procedural block whose locals live on the enclosing unit rather than
         // in a constructed scope -- does not resolve to a climb target yet.
-        return diag::Unsupported(
+        return diag::Fail(
             span, diag::DiagCode::kUnsupportedExpressionForm,
             "upward hierarchical reference whose head is not a module "
             "instance, "
-            "a named generate block, or $root is not yet supported",
-            diag::UnsupportedCategory::kOperation);
+            "a named generate block, or $root is not yet supported");
     }
     return module.MakeCrossUnitMemberRef(
         var, frame.Current(), *std::move(head), std::move(path), *type_id,
@@ -259,10 +253,9 @@ auto LowerHierarchicalValueProc(
       head_sym.kind == slang::ast::SymbolKind::GenerateBlock ||
       head_sym.kind == slang::ast::SymbolKind::GenerateBlockArray;
   if (!head_is_owned_child) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
-        "hierarchical reference through this scope kind is not yet supported",
-        diag::UnsupportedCategory::kOperation);
+        "hierarchical reference through this scope kind is not yet supported");
   }
   const auto binding = module.LookupOwnedChildBinding(head_sym);
   if (!binding.has_value()) {
@@ -275,11 +268,10 @@ auto LowerHierarchicalValueProc(
   // generate frame (`hops != 0`) is a separate, unsupported case.
   const auto hops = frame.HopsTo(binding->home_frame);
   if (!hops.has_value() || hops->value != 0) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "hierarchical reference reaching an owned child from a nested generate "
-        "scope is not yet supported",
-        diag::UnsupportedCategory::kOperation);
+        "scope is not yet supported");
   }
   return module.MakeCrossUnitMemberRef(
       var, binding->home_frame, binding->head, std::move(path), *type_id, span);
@@ -319,10 +311,9 @@ auto LowerNamedValueStructural(
         sym.as<slang::ast::ParameterSymbol>().getValue(), *type_id, span);
   }
   if (sym.kind != slang::ast::SymbolKind::Variable) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedNonVariableNamedReference,
-        "reference to non-variable declaration is not supported",
-        diag::UnsupportedCategory::kFeature);
+        "reference to non-variable declaration is not supported");
   }
   const auto& var = sym.as<slang::ast::VariableSymbol>();
   const auto binding = module.LookupStructuralVarBinding(var);

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -28,10 +28,9 @@ auto LowerUnboundedLiteralProc(
     ProcessLowerer& proc, WalkFrame frame, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
   if (!frame.dollar_base.has_value()) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
-        "`$` is only supported as a queue index or slice bound (LRM 7.10)",
-        diag::UnsupportedCategory::kOperation);
+        "`$` is only supported as a queue index or slice bound (LRM 7.10)");
   }
   const hir::TypeId int32_type = proc.Module().Unit().builtins.int32;
   const hir::ExprId size_id = frame.Exprs().Add(
@@ -66,10 +65,9 @@ auto LowerElementSelectExpr(
   const auto& base_canonical = sel.value().type->getCanonicalType();
   if (!base_canonical.isString() && !sel.value().type->isIntegral() &&
       !sel.value().type->isUnpackedArray()) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
-        "element-select on non-integral operand is not yet supported",
-        diag::UnsupportedCategory::kOperation);
+        "element-select on non-integral operand is not yet supported");
   }
   auto base_or = lowerer.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
@@ -100,11 +98,10 @@ auto LowerRangeSelectExpr(
     const slang::ast::RangeSelectExpression& sel, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
   if (!sel.value().type->isIntegral() && !sel.value().type->isUnpackedArray()) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "range-select on non-integral, non-unpacked operand is not yet "
-        "supported",
-        diag::UnsupportedCategory::kOperation);
+        "supported");
   }
 
   auto base_or = lowerer.LowerExpr(sel.value(), frame);
@@ -156,10 +153,9 @@ auto LowerMemberAccessExpr(
     const slang::ast::MemberAccessExpression& sel, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
   if (sel.member.kind != slang::ast::SymbolKind::Field) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
-        "member access target is not a struct field",
-        diag::UnsupportedCategory::kOperation);
+        "member access target is not a struct field");
   }
   const auto* field = &sel.member.as<slang::ast::FieldSymbol>();
   auto base_or = lowerer.LowerExpr(sel.value(), frame);

--- a/src/lyra/lowering/ast_to_hir/generate.cpp
+++ b/src/lyra/lowering/ast_to_hir/generate.cpp
@@ -250,10 +250,9 @@ auto LowerLoopIterNextValue(
   const auto span = mapper.SpanOf(iter.sourceRange);
 
   if (iter.kind != slang::ast::ExpressionKind::Assignment) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
-        "this generate iteration form is not supported yet",
-        diag::UnsupportedCategory::kFeature);
+        "this generate iteration form is not supported yet");
   }
 
   const auto& assign = iter.as<slang::ast::AssignmentExpression>();

--- a/src/lyra/lowering/ast_to_hir/port_connection.cpp
+++ b/src/lyra/lowering/ast_to_hir/port_connection.cpp
@@ -32,9 +32,8 @@ namespace {
 
 auto PortConnectionUnsupported(diag::SourceSpan span, std::string message)
     -> diag::Result<void> {
-  return diag::Unsupported(
-      span, diag::DiagCode::kUnsupportedPortConnectionForm, std::move(message),
-      diag::UnsupportedCategory::kFeature);
+  return diag::Fail(
+      span, diag::DiagCode::kUnsupportedPortConnectionForm, std::move(message));
 }
 
 // Connects one instance's ports, the instance reached from its owning scope by

--- a/src/lyra/lowering/ast_to_hir/statement/blocks.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/blocks.cpp
@@ -32,16 +32,14 @@ auto LowerForkStmt(
       proc.ContainingSymbol()
               .as<slang::ast::SubroutineSymbol>()
               .subroutineKind == slang::ast::SubroutineKind::Function) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedForkJoinForm,
-        "a fork-join block inside a function is not yet supported",
-        diag::UnsupportedCategory::kFeature);
+        "a fork-join block inside a function is not yet supported");
   }
   if (block.blockSymbol != nullptr && !block.blockSymbol->name.empty()) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedForkJoinForm,
-        "a named fork-join block is not yet supported",
-        diag::UnsupportedCategory::kFeature);
+        "a named fork-join block is not yet supported");
   }
 
   hir::JoinMode mode = hir::JoinMode::kAll;

--- a/src/lyra/lowering/ast_to_hir/statement/branches.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/branches.cpp
@@ -142,17 +142,15 @@ auto LowerConditionalStmt(
     -> diag::Result<hir::Stmt> {
   const auto if_check = LowerUniquePriorityCheck(cs.check);
   if (cs.conditions.size() != 1) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedStatementForm,
-        "multi-condition if expressions are not yet supported",
-        diag::UnsupportedCategory::kFeature);
+        "multi-condition if expressions are not yet supported");
   }
   const auto& cond = cs.conditions.front();
   if (cond.pattern != nullptr) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedStatementForm,
-        "pattern matching in if conditions is not yet supported",
-        diag::UnsupportedCategory::kFeature);
+        "pattern matching in if conditions is not yet supported");
   }
   auto cond_expr = proc.LowerExpr(*cond.expr, frame);
   if (!cond_expr) return std::unexpected(std::move(cond_expr.error()));

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -186,10 +186,9 @@ auto LowerStatement(
           proc, frame, stmt.as<slang::ast::ReturnStatement>(), span);
 
     default:
-      return diag::Unsupported(
+      return diag::Fail(
           span, diag::DiagCode::kUnsupportedStatementForm,
-          "this statement form is not supported yet",
-          diag::UnsupportedCategory::kFeature);
+          "this statement form is not supported yet");
   }
 }
 

--- a/src/lyra/lowering/ast_to_hir/statement/timing.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/timing.cpp
@@ -39,10 +39,9 @@ auto LowerSignalEventTrigger(
     const slang::ast::SignalEventControl& sig, diag::SourceSpan span)
     -> diag::Result<hir::EventTrigger> {
   if (sig.iffCondition != nullptr) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedEventTriggerForm,
-        "`iff` qualifier on event control is not yet supported",
-        diag::UnsupportedCategory::kFeature);
+        "`iff` qualifier on event control is not yet supported");
   }
 
   auto expr_or = proc.LowerExpr(sig.expr, frame);
@@ -53,17 +52,16 @@ auto LowerSignalEventTrigger(
     // The runtime classifies an edge only on a packed bit-vector cell (LRM
     // 9.4.2 Table 9-2); slang already restricts an edge to an integral operand.
     if (!expr_type.IsPackedArray()) {
-      return diag::Unsupported(
+      return diag::Fail(
           span, diag::DiagCode::kUnsupportedEventTriggerForm,
-          "edge event control is only supported on a packed bit-vector operand",
-          diag::UnsupportedCategory::kFeature);
+          "edge event control is only supported on a packed bit-vector "
+          "operand");
     }
   } else if (!expr_type.IsValueChangeObservable()) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedEventTriggerForm,
         "value-change event control on a non-value operand is not yet "
-        "supported",
-        diag::UnsupportedCategory::kFeature);
+        "supported");
   }
 
   const auto edge_kind = LowerEventEdge(sig.edge);
@@ -93,16 +91,14 @@ auto LowerNamedEventControl(
     const slang::ast::SignalEventControl& sig, diag::SourceSpan span)
     -> diag::Result<hir::NamedEventControl> {
   if (sig.iffCondition != nullptr) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedEventTriggerForm,
-        "`iff` qualifier on event control is not yet supported",
-        diag::UnsupportedCategory::kFeature);
+        "`iff` qualifier on event control is not yet supported");
   }
   if (sig.edge != slang::ast::EdgeKind::None) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedEventTriggerForm,
-        "edge specifier is not valid on a named event",
-        diag::UnsupportedCategory::kFeature);
+        "edge specifier is not valid on a named event");
   }
 
   auto expr_or = proc.LowerExpr(sig.expr, frame);
@@ -111,10 +107,9 @@ auto LowerNamedEventControl(
   const auto* primary = std::get_if<hir::PrimaryExpr>(&expr_or->data);
   if (primary == nullptr ||
       !std::holds_alternative<hir::StructuralVarRef>(primary->data)) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedEventTriggerForm,
-        "named event reference must be a plain structural variable",
-        diag::UnsupportedCategory::kFeature);
+        "named event reference must be a plain structural variable");
   }
   return hir::NamedEventControl{
       .event = frame.Exprs().Add(*std::move(expr_or)),
@@ -153,11 +148,10 @@ auto LowerTimingControl(
       triggers.reserve(list.events.size());
       for (const auto* event : list.events) {
         if (event->kind != slang::ast::TimingControlKind::SignalEvent) {
-          return diag::Unsupported(
+          return diag::Fail(
               span, diag::DiagCode::kUnsupportedTimingControlKind,
               "event list entries must be signal events; nested timing "
-              "controls are not yet supported",
-              diag::UnsupportedCategory::kFeature);
+              "controls are not yet supported");
         }
         const auto& sig = event->as<slang::ast::SignalEventControl>();
         auto trigger_or = LowerSignalEventTrigger(proc, frame, sig, span);
@@ -170,15 +164,13 @@ auto LowerTimingControl(
     case slang::ast::TimingControlKind::ImplicitEvent:
       return hir::TimingControl{hir::ImplicitEventControl{}};
     case slang::ast::TimingControlKind::RepeatedEvent:
-      return diag::Unsupported(
+      return diag::Fail(
           span, diag::DiagCode::kUnsupportedTimingControlKind,
-          "repeated event control (`repeat (N) @(...)`) is not yet supported",
-          diag::UnsupportedCategory::kFeature);
+          "repeated event control (`repeat (N) @(...)`) is not yet supported");
     default:
-      return diag::Unsupported(
+      return diag::Fail(
           span, diag::DiagCode::kUnsupportedTimingControlKind,
-          "this timing control kind is not yet supported",
-          diag::UnsupportedCategory::kFeature);
+          "this timing control kind is not yet supported");
   }
 }
 
@@ -215,27 +207,24 @@ auto LowerEventTriggerStmt(
     const slang::ast::EventTriggerStatement& et, diag::SourceSpan span)
     -> diag::Result<hir::Stmt> {
   if (et.isNonBlocking) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedStatementForm,
-        "non-blocking event trigger `->>` is not yet supported",
-        diag::UnsupportedCategory::kFeature);
+        "non-blocking event trigger `->>` is not yet supported");
   }
   if (et.timing != nullptr) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedStatementForm,
         "delayed event trigger (with intra-trigger timing control) is not yet "
-        "supported",
-        diag::UnsupportedCategory::kFeature);
+        "supported");
   }
   auto expr_or = proc.LowerExpr(et.target, frame);
   if (!expr_or) return std::unexpected(std::move(expr_or.error()));
   const auto* primary = std::get_if<hir::PrimaryExpr>(&expr_or->data);
   if (primary == nullptr ||
       !std::holds_alternative<hir::StructuralVarRef>(primary->data)) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedStatementForm,
-        "event trigger target must be a plain named-event reference",
-        diag::UnsupportedCategory::kFeature);
+        "event trigger target must be a plain named-event reference");
   }
   return hir::Stmt{
       .label = std::nullopt,

--- a/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
@@ -232,11 +232,10 @@ auto StructuralScopeLowerer::PopulateVariableMember(
     -> diag::Result<void> {
   const auto& mapper = module_->SourceMapper();
   if (var.lifetime != slang::ast::VariableLifetime::Static) {
-    return diag::Unsupported(
+    return diag::Fail(
         mapper.PointSpanOf(var.location),
         diag::DiagCode::kUnsupportedNonStaticVariableLifetime,
-        "only static variables are supported",
-        diag::UnsupportedCategory::kFeature);
+        "only static variables are supported");
   }
   auto type_id_or =
       module_->InternType(var.getType(), mapper.PointSpanOf(var.location));

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -104,10 +104,9 @@ auto LowerExplicitPackedArray(
     cur = &pa.elementType.getCanonicalType();
   }
   if (cur->kind != slang::ast::SymbolKind::ScalarType) {
-    return diag::Unsupported(
+    return diag::Fail(
         decl_span, diag::DiagCode::kUnsupportedPackedArrayElementType,
-        "packed array element must be a bit, logic, or reg scalar",
-        diag::UnsupportedCategory::kType);
+        "packed array element must be a bit, logic, or reg scalar");
   }
   const auto& scalar = cur->as<slang::ast::ScalarType>();
   return hir::PackedArrayType{
@@ -163,10 +162,9 @@ auto LowerPackedUnion(
     const slang::ast::PackedUnionType& union_type, diag::SourceSpan decl_span,
     ModuleLowerer& module) -> diag::Result<hir::PackedUnionType> {
   if (union_type.isTagged) {
-    return diag::Unsupported(
+    return diag::Fail(
         decl_span, diag::DiagCode::kUnsupportedTaggedPackedUnion,
-        "tagged packed unions are not yet supported",
-        diag::UnsupportedCategory::kType);
+        "tagged packed unions are not yet supported");
   }
   const auto width = static_cast<std::int64_t>(union_type.bitWidth);
   if (width <= 0) {
@@ -345,11 +343,10 @@ auto TranslateTypeData(
       // (LRM 7.8.2) and integral (LRM 7.8.4) index families are in scope.
       if (aa.indexType == nullptr ||
           !(aa.indexType->isIntegral() || aa.indexType->isString())) {
-        return diag::Unsupported(
+        return diag::Fail(
             decl_span, diag::DiagCode::kUnsupportedAssociativeArrayType,
             "associative arrays are only supported with a string or integral "
-            "index type",
-            diag::UnsupportedCategory::kType);
+            "index type");
       }
       auto elem_id_or = module.InternType(aa.elementType, decl_span);
       if (!elem_id_or) {
@@ -365,19 +362,17 @@ auto TranslateTypeData(
       }};
     }
     case slang::ast::SymbolKind::UnpackedStructType:
-      return diag::Unsupported(
+      return diag::Fail(
           decl_span, diag::DiagCode::kUnsupportedUnpackedStructType,
-          "unpacked struct types are not supported",
-          diag::UnsupportedCategory::kType);
+          "unpacked struct types are not supported");
     case slang::ast::SymbolKind::UnpackedUnionType:
-      return diag::Unsupported(
+      return diag::Fail(
           decl_span, diag::DiagCode::kUnsupportedUnpackedUnionType,
-          "unpacked union types are not supported",
-          diag::UnsupportedCategory::kType);
+          "unpacked union types are not supported");
     default:
-      return diag::Unsupported(
+      return diag::Fail(
           decl_span, diag::DiagCode::kUnsupportedTypeKind,
-          "unsupported type kind", diag::UnsupportedCategory::kType);
+          "unsupported type kind");
   }
 }
 

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -967,16 +967,14 @@ auto ClassLowerer::LowerExpr(const hir::Expr& expr, WalkFrame frame) const
             return LowerHirConversionExpr(*this, frame, cv, result_type);
           },
           [](const hir::CallExpr&) -> diag::Result<mir::Expr> {
-            return diag::Unsupported(
+            return diag::Fail(
                 diag::DiagCode::kUnsupportedStructuralExpressionForm,
-                "calls are not allowed in constructor expressions",
-                diag::UnsupportedCategory::kFeature);
+                "calls are not allowed in constructor expressions");
           },
           [](const hir::InsideExpr&) -> diag::Result<mir::Expr> {
-            return diag::Unsupported(
+            return diag::Fail(
                 diag::DiagCode::kUnsupportedStructuralExpressionForm,
-                "inside operator is not allowed in constructor expressions",
-                diag::UnsupportedCategory::kFeature);
+                "inside operator is not allowed in constructor expressions");
           },
           [&](const hir::ElementSelectExpr& s) -> diag::Result<mir::Expr> {
             return LowerHirElementSelectExpr(*this, frame, s, result_type);
@@ -991,10 +989,9 @@ auto ClassLowerer::LowerExpr(const hir::Expr& expr, WalkFrame frame) const
             return LowerHirConcatExpr(*this, frame, c, result_type);
           },
           [](const hir::ReplicationExpr&) -> diag::Result<mir::Expr> {
-            return diag::Unsupported(
+            return diag::Fail(
                 diag::DiagCode::kUnsupportedStructuralExpressionForm,
-                "replication in constructor expressions is not yet supported",
-                diag::UnsupportedCategory::kFeature);
+                "replication in constructor expressions is not yet supported");
           },
           [&](const hir::AssignmentPatternExpr& a) -> diag::Result<mir::Expr> {
             return LowerHirAssignmentPatternExpr(*this, frame, a, result_type);
@@ -1005,11 +1002,10 @@ auto ClassLowerer::LowerExpr(const hir::Expr& expr, WalkFrame frame) const
                 *this, frame, a, result_type);
           },
           [](const hir::DynamicArrayNewExpr&) -> diag::Result<mir::Expr> {
-            return diag::Unsupported(
+            return diag::Fail(
                 diag::DiagCode::kUnsupportedStructuralExpressionForm,
                 "dynamic-array new[] is not allowed in constructor "
-                "expressions; LRM 7.5.1 restricts it to blocking assignments",
-                diag::UnsupportedCategory::kFeature);
+                "expressions; LRM 7.5.1 restricts it to blocking assignments");
           },
           [&](const hir::AssociativeAssignmentPatternExpr& a)
               -> diag::Result<mir::Expr> {

--- a/src/lyra/lowering/hir_to_mir/delay_time_resolver.cpp
+++ b/src/lyra/lowering/hir_to_mir/delay_time_resolver.cpp
@@ -58,27 +58,27 @@ auto DelayTimeResolver::ResolveIntegerDelay(
     std::int64_t value, diag::SourceSpan span) const
     -> diag::Result<SimDuration> {
   if (value < 0) {
-    return diag::Error(
-        span, diag::DiagCode::kDelayValueOutOfRange,
+    return diag::Fail(
+        span, diag::DiagCode::kErrorDelayValueOutOfRange,
         "delay value must be non-negative");
   }
   const int ratio_exp = resolution_.unit_power - resolution_.precision_power;
   if (ratio_exp < 0) {
-    return diag::Error(
-        span, diag::DiagCode::kDelayValueOutOfRange,
+    return diag::Fail(
+        span, diag::DiagCode::kErrorDelayValueOutOfRange,
         "delay value cannot be represented under the active time precision");
   }
   const auto ratio_or = IntegerPow10(ratio_exp);
   if (!ratio_or) {
-    return diag::Error(
-        span, diag::DiagCode::kDelayValueOutOfRange,
+    return diag::Fail(
+        span, diag::DiagCode::kErrorDelayValueOutOfRange,
         "delay value overflows internal tick representation");
   }
   const auto unsigned_value = static_cast<std::uint64_t>(value);
   if (*ratio_or != 0 &&
       unsigned_value > std::numeric_limits<std::uint64_t>::max() / *ratio_or) {
-    return diag::Error(
-        span, diag::DiagCode::kDelayValueOutOfRange,
+    return diag::Fail(
+        span, diag::DiagCode::kErrorDelayValueOutOfRange,
         "delay value overflows internal tick representation");
   }
   return static_cast<SimDuration>(unsigned_value * *ratio_or);
@@ -88,13 +88,13 @@ auto DelayTimeResolver::ResolveTimeLiteral(
     double value, hir::TimeScale literal_unit, diag::SourceSpan span) const
     -> diag::Result<SimDuration> {
   if (!std::isfinite(value)) {
-    return diag::Error(
-        span, diag::DiagCode::kDelayValueOutOfRange,
+    return diag::Fail(
+        span, diag::DiagCode::kErrorDelayValueOutOfRange,
         "delay value is not a finite real number");
   }
   if (value < 0.0) {
-    return diag::Error(
-        span, diag::DiagCode::kDelayValueOutOfRange,
+    return diag::Fail(
+        span, diag::DiagCode::kErrorDelayValueOutOfRange,
         "delay value must be non-negative");
   }
   const int ratio_exp = static_cast<int>(HirTimeScaleToPower(literal_unit)) -
@@ -103,8 +103,8 @@ auto DelayTimeResolver::ResolveTimeLiteral(
       std::pow(10.0L, static_cast<long double>(ratio_exp));
   const long double ticks_f = static_cast<long double>(value) * ratio;
   if (!std::isfinite(ticks_f)) {
-    return diag::Error(
-        span, diag::DiagCode::kDelayValueOutOfRange,
+    return diag::Fail(
+        span, diag::DiagCode::kErrorDelayValueOutOfRange,
         "delay value overflows internal tick representation");
   }
   // Cap at int64_t::max() because std::llroundl returns long long, not the
@@ -112,8 +112,8 @@ auto DelayTimeResolver::ResolveTimeLiteral(
   if (ticks_f < 0.0L ||
       ticks_f >
           static_cast<long double>(std::numeric_limits<std::int64_t>::max())) {
-    return diag::Error(
-        span, diag::DiagCode::kDelayValueOutOfRange,
+    return diag::Fail(
+        span, diag::DiagCode::kErrorDelayValueOutOfRange,
         "delay value overflows internal tick representation");
   }
   const std::int64_t ticks = std::llroundl(ticks_f);

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -222,10 +222,9 @@ auto ApplyAssignEffect(
     return effect_fn(block, target_in_outer, operands_in_outer, services_id);
   }
   if (!IsExprRootedAtStructuralVar(block, target_in_outer)) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedAssignmentTarget,
-        "non-blocking assignment to procedural local is not supported yet",
-        diag::UnsupportedCategory::kFeature);
+        "non-blocking assignment to procedural local is not supported yet");
   }
   mir::Expr closure = BuildDeferredAssignClosure(
       process.Module(), frame, target_in_outer, operands_in_outer, effect_fn);

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -329,11 +329,10 @@ auto LowerStructuralSubroutineCall(
       lowerer.LookupHirSubroutine(usr.hops, usr.subroutine);
   for (const auto& param : decl.params) {
     if (hir::RequiresWriteback(param.direction)) {
-      return diag::Unsupported(
+      return diag::Fail(
           span, diag::DiagCode::kUnsupportedSubroutineArgument,
           "a call with output / inout arguments is only supported in "
-          "statement position, not as a nested expression",
-          diag::UnsupportedCategory::kFeature);
+          "statement position, not as a nested expression");
     }
   }
   std::vector<mir::ExprId> args;

--- a/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
@@ -53,17 +53,15 @@ auto LowerFinishSystemSubroutineCall(
     const hir::Expr& arg_expr = hir_proc.exprs.Get(arg_id);
     const auto literal = TryExtractLiteralInt(arg_expr);
     if (!literal.has_value()) {
-      return diag::Unsupported(
+      return diag::Fail(
           span, diag::DiagCode::kUnsupportedExpressionForm,
           std::format(
-              "{} argument must be an integer literal", std::string{name}),
-          diag::UnsupportedCategory::kOperation);
+              "{} argument must be an integer literal", std::string{name}));
     }
     if (*literal != 0 && *literal != 1 && *literal != 2) {
-      return diag::Unsupported(
+      return diag::Fail(
           span, diag::DiagCode::kUnsupportedExpressionForm,
-          std::format("{} argument must be 0, 1, or 2", std::string{name}),
-          diag::UnsupportedCategory::kOperation);
+          std::format("{} argument must be 0, 1, or 2", std::string{name}));
     }
     level = static_cast<int>(*literal);
   }

--- a/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
@@ -117,14 +117,13 @@ auto LowerFileFlushCall(
 // to a statement-position call.
 auto RejectOutputArgFileCallInExprPosition(
     std::string_view name, diag::SourceSpan span) -> diag::Result<mir::Expr> {
-  return diag::Unsupported(
+  return diag::Fail(
       span, diag::DiagCode::kUnsupportedSubroutineArgument,
       std::format(
           "{} writes through an output argument and is only supported as a "
           "bare call or as the right-hand side of a blocking assignment "
           "(LRM 13.5 copy-out semantics)",
-          std::string{name}),
-      diag::UnsupportedCategory::kFeature);
+          std::string{name}));
 }
 
 }  // namespace
@@ -223,12 +222,11 @@ auto LowerFileIOSystemSubroutineCallStmt(
         // loading an integral variable" -- reject the tolerant case so the
         // user gets a clear diagnostic instead of silent arg-dropping.
         if (call.arguments.size() != 2) {
-          return diag::Unsupported(
+          return diag::Fail(
               diag::DiagCode::kUnsupportedSubroutineArgument,
               "$fread: integral form does not accept start/count "
               "arguments (LRM 21.3.4.4 says they are ignored; we reject "
-              "to surface the mistake)",
-              diag::UnsupportedCategory::kFeature);
+              "to surface the mistake)");
         }
       } else {
         // Memory form. Only 1D unpacked of integral packed elements is in
@@ -236,11 +234,10 @@ auto LowerFileIOSystemSubroutineCallStmt(
         // are deferred.
         const auto& elem_ty = module.Hir().GetType(unpacked->element_type);
         if (!std::holds_alternative<hir::PackedArrayType>(elem_ty.data)) {
-          return diag::Unsupported(
+          return diag::Fail(
               diag::DiagCode::kUnsupportedSubroutineArgument,
               "$fread memory form: only 1D unpacked arrays of integral "
-              "packed elements are supported (LRM 21.3.4.4)",
-              diag::UnsupportedCategory::kFeature);
+              "packed elements are supported (LRM 21.3.4.4)");
         }
       }
 

--- a/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
@@ -151,14 +151,13 @@ auto ComputeSlotMeta(
     meta.is_four_state = pa.IsFourState();
     return meta;
   }
-  return diag::Unsupported(
+  return diag::Fail(
       span, diag::DiagCode::kUnsupportedSubroutineArgument,
       std::format(
           "{} output argument must be an integral or string lvalue "
           "(LRM 21.3.4.3)",
           source_kind == support::ScanSourceKind::kFile ? "$fscanf"
-                                                        : "$sscanf"),
-      diag::UnsupportedCategory::kFeature);
+                                                        : "$sscanf"));
 }
 
 }  // namespace

--- a/src/lyra/lowering/hir_to_mir/expression/system/sformat.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/sformat.cpp
@@ -62,15 +62,14 @@ auto BuildSFormatCallExpr(
 
 auto RejectNonStringOutput(std::string_view name, diag::SourceSpan span)
     -> diag::Result<mir::Stmt> {
-  return diag::Unsupported(
+  return diag::Fail(
       span, diag::DiagCode::kUnsupportedSubroutineArgument,
       std::format(
           "{} output_var must be string-typed; integral and "
           "unpacked-byte-array "
           "outputs (LRM 21.3.3 via the LRM 5.9 assignment rules) are not yet "
           "supported",
-          std::string{name}),
-      diag::UnsupportedCategory::kFeature);
+          std::string{name}));
 }
 
 }  // namespace

--- a/src/lyra/lowering/hir_to_mir/expression/system/timescale.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/timescale.cpp
@@ -26,10 +26,9 @@ auto LowerTimeFormatSystemSubroutineCall(
   auto& body = *frame.current_block;
   const auto& args = call.arguments;
   if (!args.empty() && args.size() != 4) {
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedSubroutineArgument,
-        "$timeformat takes either no arguments or exactly four (LRM 20.4.3)",
-        diag::UnsupportedCategory::kFeature);
+        "$timeformat takes either no arguments or exactly four (LRM 20.4.3)");
   }
 
   std::vector<mir::ExprId> call_args;

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -108,10 +108,9 @@ auto BuildPrintItemFromDirective(
       return mir::RuntimePrintLiteral{.text = directive.literal};
 
     case support::FormatDirectiveKind::kModulePath:
-      return diag::Unsupported(
+      return diag::Fail(
           span, diag::DiagCode::kFormatModulePathNotImplemented,
-          "format specifier %m is not yet supported",
-          diag::UnsupportedCategory::kFeature);
+          "format specifier %m is not yet supported");
 
     case support::FormatDirectiveKind::kTime:
     case support::FormatDirectiveKind::kChar:
@@ -125,8 +124,8 @@ auto BuildPrintItemFromDirective(
     case support::FormatDirectiveKind::kRealGeneral:
     case support::FormatDirectiveKind::kAssignmentPattern: {
       if (value_index >= args.size()) {
-        return diag::Error(
-            span, diag::DiagCode::kDisplayMissingArg,
+        return diag::Fail(
+            span, diag::DiagCode::kErrorDisplayMissingArg,
             "format string consumes more arguments than provided");
       }
       const hir::ExprId hir_arg = args[value_index++];
@@ -272,11 +271,10 @@ auto BuildRuntimePrintItemsFromCallArgs(
     const diag::SourceSpan span = cursor < args.size()
                                       ? hir_proc.exprs.Get(args[cursor]).span
                                       : call_span;
-    return diag::Unsupported(
+    return diag::Fail(
         span, diag::DiagCode::kUnsupportedSubroutineArgument,
         "format string must be a string literal; a runtime-evaluated format "
-        "string is not yet supported (LRM 21.3.3)",
-        diag::UnsupportedCategory::kFeature);
+        "string is not yet supported (LRM 21.3.3)");
   }
   if (literal.has_value()) {
     auto parsed_or =

--- a/src/lyra/lowering/hir_to_mir/statement/timing.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/timing.cpp
@@ -64,10 +64,10 @@ auto ResolveDelayDuration(
           time_lit->value, time_lit->scale, duration.span);
     }
   }
-  return diag::Unsupported(
+  return diag::Fail(
       duration.span, diag::DiagCode::kUnsupportedDelayExpressionForm,
-      "delay durations beyond an integer or time literal are not yet supported",
-      diag::UnsupportedCategory::kFeature);
+      "delay durations beyond an integer or time literal are not yet "
+      "supported");
 }
 
 auto ResolveDelayTicks(ProcessLowerer& process, const hir::DelayControl& d)
@@ -147,11 +147,10 @@ auto LowerEventTimedStmt(
         union_reads.reserve(ec.triggers.size());
         for (const auto& trigger : ec.triggers) {
           if (trigger.sensitivity_list.size() > 1) {
-            return diag::Unsupported(
+            return diag::Fail(
                 span, diag::DiagCode::kUnsupportedEventTriggerForm,
                 "compound event expressions (concatenation, arithmetic, "
-                "dynamic index) are not yet supported",
-                diag::UnsupportedCategory::kFeature);
+                "dynamic index) are not yet supported");
           }
           for (auto leaf : trigger.sensitivity_list) {
             // LRM 9.4.2 LSB-reduce: an edge event monitors only the LSB of

--- a/src/lyra/support/format.cpp
+++ b/src/lyra/support/format.cpp
@@ -158,8 +158,8 @@ auto ParseLiteralFormatString(
         mods.width = 0;
         // Fall through to spec char read below; do not parse a width run.
         if (pos >= text.size()) {
-          return diag::Error(
-              format_span, diag::DiagCode::kFormatStringMissingSpecifier,
+          return diag::Fail(
+              format_span, diag::DiagCode::kErrorFormatStringMissingSpecifier,
               "format directive '%' is missing its specifier character");
         }
       }
@@ -167,8 +167,8 @@ auto ParseLiteralFormatString(
       if (mods.width != 0) {
         auto width_or = ParseInt32(text, pos);
         if (!width_or.has_value()) {
-          return diag::Error(
-              format_span, diag::DiagCode::kFormatStringWidthOverflow,
+          return diag::Fail(
+              format_span, diag::DiagCode::kErrorFormatStringWidthOverflow,
               "format directive width does not fit in int32");
         }
         if (*width_or != -1) {
@@ -180,29 +180,29 @@ auto ParseLiteralFormatString(
         ++pos;
         auto prec_or = ParseInt32(text, pos);
         if (!prec_or.has_value()) {
-          return diag::Error(
-              format_span, diag::DiagCode::kFormatStringWidthOverflow,
+          return diag::Fail(
+              format_span, diag::DiagCode::kErrorFormatStringWidthOverflow,
               "format directive precision does not fit in int32");
         }
         if (*prec_or == -1) {
-          return diag::Error(
-              format_span, diag::DiagCode::kFormatStringMissingSpecifier,
+          return diag::Fail(
+              format_span, diag::DiagCode::kErrorFormatStringMissingSpecifier,
               "format directive '.' is missing precision digits");
         }
         mods.precision = *prec_or;
       }
 
       if (pos >= text.size()) {
-        return diag::Error(
-            format_span, diag::DiagCode::kFormatStringTrailingPercent,
+        return diag::Fail(
+            format_span, diag::DiagCode::kErrorFormatStringTrailingPercent,
             "format string ends with unfinished '%' directive");
       }
 
       const char spec_char = text[pos];
       auto kind_or = SpecCharToKind(spec_char);
       if (!kind_or.has_value()) {
-        return diag::Error(
-            format_span, diag::DiagCode::kFormatStringUnknownSpecifier,
+        return diag::Fail(
+            format_span, diag::DiagCode::kErrorFormatStringUnknownSpecifier,
             std::format("unknown format specifier '%{}'", spec_char));
       }
       ++pos;

--- a/tests/diag/render_test.cpp
+++ b/tests/diag/render_test.cpp
@@ -6,6 +6,7 @@
 
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/kind.hpp"
 #include "lyra/diag/sink.hpp"
 #include "lyra/diag/source_manager.hpp"
 #include "lyra/diag/source_span.hpp"
@@ -20,7 +21,7 @@ auto Has(const std::string& s, const std::string& needle) -> bool {
 
 TEST(DiagRender, HostErrorPlain) {
   const auto out = lyra::diag::RenderDiagnostic(
-      lyra::diag::Diagnostic::HostError(
+      lyra::diag::Make(
           lyra::diag::DiagCode::kHostNoInputFiles, "no input files"),
       nullptr, lyra::diag::RenderOptions{.use_color = false});
   EXPECT_EQ(out, "lyra: error: no input files\n");
@@ -28,9 +29,8 @@ TEST(DiagRender, HostErrorPlain) {
 
 TEST(DiagRender, HostErrorColored) {
   const auto out = lyra::diag::RenderDiagnostic(
-      lyra::diag::Diagnostic::HostError(
-          lyra::diag::DiagCode::kHostIoError, "boom"),
-      nullptr, lyra::diag::RenderOptions{.use_color = true});
+      lyra::diag::Make(lyra::diag::DiagCode::kHostIoError, "boom"), nullptr,
+      lyra::diag::RenderOptions{.use_color = true});
   EXPECT_TRUE(Has(out, "lyra"));
   EXPECT_TRUE(Has(out, "error:"));
   EXPECT_TRUE(Has(out, "boom"));
@@ -43,10 +43,9 @@ TEST(DiagRender, InternalErrorIsAlwaysPlain) {
 }
 
 TEST(DiagRender, UnsupportedWithUnknownSpan) {
-  const auto diag = lyra::diag::Diagnostic::Unsupported(
+  const auto diag = lyra::diag::Make(
       lyra::diag::DiagCode::kUnsupportedStatementForm,
-      "for-generate is not supported yet",
-      lyra::diag::UnsupportedCategory::kFeature);
+      "for-generate is not supported yet");
   const auto out = lyra::diag::RenderDiagnostic(
       diag, nullptr, lyra::diag::RenderOptions{.use_color = false});
   EXPECT_EQ(out, "lyra: unsupported: for-generate is not supported yet\n");
@@ -61,10 +60,9 @@ TEST(DiagRender, ErrorWithSpanIncludesSnippetAndLocation) {
   const auto end = begin + 11;
   const lyra::diag::SourceSpan span{.file_id = fid, .begin = begin, .end = end};
 
-  const auto diag = lyra::diag::Diagnostic::Unsupported(
+  const auto diag = lyra::diag::Make(
       span, lyra::diag::DiagCode::kUnsupportedTypeKind,
-      "only `int` and `logic` types are supported",
-      lyra::diag::UnsupportedCategory::kType);
+      "only `int` and `logic` types are supported");
   const auto out = lyra::diag::RenderDiagnostic(
       diag, &mgr, lyra::diag::RenderOptions{.use_color = false});
 
@@ -82,9 +80,8 @@ TEST(DiagRender, ColoredOutputContainsAnsi) {
   const lyra::diag::SourceSpan span{.file_id = fid, .begin = 0, .end = 3};
 
   const auto out = lyra::diag::RenderDiagnostic(
-      lyra::diag::Diagnostic::HostError(
-          span, lyra::diag::DiagCode::kHostIoError, "boom"),
-      &mgr, lyra::diag::RenderOptions{.use_color = true});
+      lyra::diag::Make(span, lyra::diag::DiagCode::kHostIoError, "boom"), &mgr,
+      lyra::diag::RenderOptions{.use_color = true});
 
   EXPECT_NE(out.find(kAnsiEsc), std::string::npos);
 }
@@ -94,9 +91,7 @@ TEST(DiagRender, NoSnippetWhenDisabled) {
   const auto fid = mgr.AddFile("main.sv", "int x;\n");
   const lyra::diag::SourceSpan span{.file_id = fid, .begin = 0, .end = 3};
   const auto out = lyra::diag::RenderDiagnostic(
-      lyra::diag::Diagnostic::HostError(
-          span, lyra::diag::DiagCode::kHostIoError, "boom"),
-      &mgr,
+      lyra::diag::Make(span, lyra::diag::DiagCode::kHostIoError, "boom"), &mgr,
       lyra::diag::RenderOptions{
           .use_color = false, .show_source_snippet = false});
   EXPECT_TRUE(Has(out, "main.sv:1:1:"));
@@ -108,15 +103,14 @@ TEST(DiagRender, NoSnippetWhenDisabled) {
 TEST(DiagRender, SinkSummaryAggregatesCounts) {
   lyra::diag::DiagnosticSink sink;
   sink.Report(
-      lyra::diag::Diagnostic::Unsupported(
+      lyra::diag::Make(
           lyra::diag::DiagCode::kUnsupportedStatementForm,
-          "feature A is not supported yet",
-          lyra::diag::UnsupportedCategory::kFeature));
+          "feature A is not supported yet"));
   sink.Report(
-      lyra::diag::Diagnostic::HostError(
+      lyra::diag::Make(
           lyra::diag::DiagCode::kHostIoError, "cannot read 'foo.sv'"));
   sink.Report(
-      lyra::diag::Diagnostic::Warning(
+      lyra::diag::Make(
           lyra::diag::SourceSpan{}, lyra::diag::DiagCode::kWarningPedantic,
           "pedantic"));
 
@@ -134,11 +128,10 @@ TEST(DiagRender, SinkEmptyHasNoSummary) {
 }
 
 TEST(DiagRender, NoteAttachesAfterPrimary) {
-  auto diag =
-      lyra::diag::Diagnostic::Unsupported(
-          lyra::diag::DiagCode::kUnsupportedStatementForm,
-          "feature is not supported", lyra::diag::UnsupportedCategory::kFeature)
-          .WithNote("see related design discussion");
+  auto diag = lyra::diag::Make(
+                  lyra::diag::DiagCode::kUnsupportedStatementForm,
+                  "feature is not supported")
+                  .WithNote("see related design discussion");
   const auto out = lyra::diag::RenderDiagnostic(
       diag, nullptr, lyra::diag::RenderOptions{.use_color = false});
   const auto primary_pos = out.find("unsupported:");
@@ -148,45 +141,28 @@ TEST(DiagRender, NoteAttachesAfterPrimary) {
   EXPECT_LT(primary_pos, note_pos);
 }
 
-TEST(DiagRender, UnsupportedCategoryPreservedAcrossKinds) {
-  const auto type_diag = lyra::diag::Diagnostic::Unsupported(
-      lyra::diag::SourceSpan{}, lyra::diag::DiagCode::kUnsupportedTypeKind,
-      "wide types not supported", lyra::diag::UnsupportedCategory::kType);
-  ASSERT_TRUE(type_diag.primary.category.has_value());
+TEST(DiagRender, KindDerivesFromCode) {
+  using lyra::diag::DiagCode;
+  using lyra::diag::DiagCodeKind;
+  using lyra::diag::DiagKind;
+  using lyra::diag::Make;
+
   EXPECT_EQ(
-      *type_diag.primary.category, lyra::diag::UnsupportedCategory::kType);
-
-  const auto op_diag = lyra::diag::Diagnostic::Unsupported(
-      lyra::diag::DiagCode::kUnsupportedExpressionForm, "weird expression form",
-      lyra::diag::UnsupportedCategory::kOperation);
-  ASSERT_TRUE(op_diag.primary.category.has_value());
+      Make(DiagCode::kUnsupportedTypeKind, "x").primary.kind,
+      DiagKind::kUnsupported);
   EXPECT_EQ(
-      *op_diag.primary.category, lyra::diag::UnsupportedCategory::kOperation);
-
-  const auto feature_diag = lyra::diag::Diagnostic::Unsupported(
-      lyra::diag::DiagCode::kUnsupportedStatementForm, "language feature gap",
-      lyra::diag::UnsupportedCategory::kFeature);
-  ASSERT_TRUE(feature_diag.primary.category.has_value());
+      Make(DiagCode::kErrorDelayValueOutOfRange, "x").primary.kind,
+      DiagKind::kError);
   EXPECT_EQ(
-      *feature_diag.primary.category,
-      lyra::diag::UnsupportedCategory::kFeature);
+      Make(DiagCode::kHostIoError, "x").primary.kind, DiagKind::kHostError);
+  EXPECT_EQ(
+      Make(DiagCode::kWarningPedantic, "x").primary.kind, DiagKind::kWarning);
 
-  EXPECT_FALSE(
-      lyra::diag::Diagnostic::HostError(
-          lyra::diag::DiagCode::kHostIoError, "io")
-          .primary.category.has_value());
-  EXPECT_FALSE(
-      lyra::diag::Diagnostic::Warning(
-          lyra::diag::SourceSpan{}, lyra::diag::DiagCode::kWarningPedantic,
-          "warn")
-          .primary.category.has_value());
-
-  // Notes carry only span+message; they have no category field by design.
-  auto with_note = lyra::diag::Diagnostic::Unsupported(
-                       lyra::diag::DiagCode::kUnsupportedStatementForm, "x",
-                       lyra::diag::UnsupportedCategory::kFeature)
-                       .WithNote("y");
-  EXPECT_EQ(with_note.notes.front().message, "y");
+  for (const DiagCode code :
+       {DiagCode::kUnsupportedTypeKind, DiagCode::kErrorDelayValueOutOfRange,
+        DiagCode::kHostIoError, DiagCode::kWarningPedantic}) {
+    EXPECT_EQ(Make(code, "x").primary.kind, DiagCodeKind(code));
+  }
 }
 
 }  // namespace

--- a/tools/policy/check_architecture.py
+++ b/tools/policy/check_architecture.py
@@ -27,11 +27,11 @@ Rules:
         Scope: every .hpp under src/lyra/lowering/**.
 
   A006  No `support::Unsupported(...)` helper. Unsupported features go
-        through diag::Unsupported(...).
+        through diag::Fail(...).
 
   A007  std::unexpected(...) is allowed only for direct propagation. New
-        diagnostics must be built via diag::Unsupported / diag::Error /
-        diag::HostError.
+        diagnostics must be built via diag::Fail (or diag::Make for the
+        report-and-continue path).
 
   A008  A function whose name starts with `Lower` and returns an ID
         (`...Id`) must include Append|Add|Intern|Declare|Insert in its
@@ -52,7 +52,7 @@ Rules:
 
   A012  Append* function bodies in the lowering layer must be thin
         storage. They may not call `Lower*(`, inspect `.kind`, downcast
-        `.as<`, emit `diag::Unsupported`/`Error`/`HostError`, or throw
+        `.as<`, emit `diag::Fail`/`diag::Make`, or throw
         `support::InternalError`. Pure semantic lowering happens before
         Append; Append only stores already-lowered objects.
         Scope: src/lyra/lowering/**, include/lyra/lowering/**.
@@ -133,8 +133,8 @@ FORBIDDEN_IN_APPEND = (
      "inspects .kind; AST/HIR inspection belongs in Lower*"),
     (re.compile(r"\.as<"),
      "downcasts via .as<>; Append must store already-lowered objects"),
-    (re.compile(r"\bdiag::(?:Unsupported|Error|HostError)\b"),
-     "emits diag::Unsupported|Error|HostError; Append must not error"),
+    (re.compile(r"\bdiag::(?:Fail|Make)\b"),
+     "emits diag::Fail|Make; Append must not error"),
     (re.compile(r"\bthrow\s+support::InternalError\b"),
      "throws support::InternalError; Append must not enforce semantic "
      "invariants -- check those at the lowering boundary"),
@@ -187,8 +187,8 @@ This usually means:
 - append/add/insert functions must only store already-lowered objects
   and return IDs;
 - raw std::expected must be wrapped as diag::Result;
-- diagnostics must be built with diag::Unsupported / diag::Error /
-  diag::HostError, not std::unexpected of a raw Diagnostic;
+- diagnostics must be built with diag::Fail (or diag::Make), not
+  std::unexpected of a raw Diagnostic;
 - arena allocation belongs at the owner boundary, not inside semantic
   lowering.
 
@@ -299,7 +299,7 @@ def check_a006(repo_root: Path) -> list[str]:
             code = strip_comment(line)
             if SUPPORT_UNSUPPORTED_PATTERN.search(code):
                 errors.append(
-                    f"  {rel}:{lineno}: A006 use diag::Unsupported(...) instead"
+                    f"  {rel}:{lineno}: A006 use diag::Fail(...) instead"
                 )
     return errors
 
@@ -492,13 +492,13 @@ def run_self_tests() -> bool:
     ok &= expect(
         SUPPORT_UNSUPPORTED_PATTERN.search("support::Unsupported(\"x\");"),
         "A006 helper")
-    ok &= expect(not SUPPORT_UNSUPPORTED_PATTERN.search("diag::Unsupported(...)"),
+    ok &= expect(not SUPPORT_UNSUPPORTED_PATTERN.search("diag::Fail(...)"),
                  "A006 false-pos")
 
     # A007
     ok &= expect(
         RAW_UNEXPECTED_PATTERN.search(
-            "return std::unexpected(diag::Diagnostic::Error(...));"),
+            "return std::unexpected(diag::Diagnostic{...});"),
         "A007 raw construction")
     ok &= expect(
         not RAW_UNEXPECTED_PATTERN.search(
@@ -604,13 +604,13 @@ def run_self_tests() -> bool:
         FORBIDDEN_IN_APPEND[2][0].search("e.as<slang::ast::Foo>()") is not None,
         "A012 detects .as<>")
     ok &= expect(
-        FORBIDDEN_IN_APPEND[3][0].search("return diag::Unsupported(\"x\")")
+        FORBIDDEN_IN_APPEND[3][0].search("return diag::Fail(\"x\")")
         is not None,
-        "A012 detects diag::Unsupported")
+        "A012 detects diag::Fail")
     ok &= expect(
-        FORBIDDEN_IN_APPEND[3][0].search("return diag::Error(span, \"x\")")
+        FORBIDDEN_IN_APPEND[3][0].search("return diag::Make(span, \"x\")")
         is not None,
-        "A012 detects diag::Error")
+        "A012 detects diag::Make")
     ok &= expect(
         FORBIDDEN_IN_APPEND[4][0].search(
             "throw support::InternalError(\"oops\");") is not None,


### PR DESCRIPTION
## Summary

A diagnostic's intrinsic metadata is now a property of its code, derived at construction and never re-supplied at the report site, and construction never throws. Previously each emission site re-stated the classification (an `UnsupportedCategory` argument) and selected a per-kind factory verb, both cross-checked against a central table by guards that threw `InternalError` on mismatch. Because those guards ran on the unsupported/error path -- the graceful-degradation path and the least-tested branch -- a call site that named the wrong classification turned a clean user-facing diagnostic into a compiler crash. This was a latent landmine on every untested rejection.

The direction follows how mature compilers structure diagnostic metadata: Clang bakes severity into the diagnostic id (the `err_`/`warn_` name), Roslyn carries it on a `DiagnosticDescriptor`, rustc on the diagnostic definition -- none re-supplies it at the emission site, and none carries a classification axis without an end-user consumer (severity configuration, grouping, `--explain`). Lyra had copied the shape of a category field without the consumer that justifies it, so it was a write-only field read by nothing but a tautological test and the throwing guard.

The per-kind factories collapse into two kind-neutral helpers split by control flow, not severity: `diag::Fail` for the recoverable-failure path (returns `std::unexpected`) and `diag::Make` for report-and-continue. The kind comes from the code table; the `UnsupportedCategory` axis and both `Require*` guards are removed; and the error-family codes gain a `kError` prefix so the kind stays readable at the call site. The rationale and the surveyed-compiler comparison are recorded in `docs/decisions/diagnostic-construction.md`.

## Testing

`bazel build //...` and `bazel test //...` pass. Beyond sampling the transformed call sites, a full census reconciled all 118 old call sites against the new tree: counts are conserved (111 `Fail` + 7 `Make`), and at every old site the verb's kind equalled its code's table kind -- so deriving the kind from the table is provably behaviour-preserving. The architecture policy checker's diagnostic rules (A006/A007/A012) were updated to the new helper names.