### PR TITLE
Pin Make/Build helper naming by scope side effect

### DIFF
--- a/docs/architecture/lowering_organization.md
+++ b/docs/architecture/lowering_organization.md
@@ -421,12 +421,23 @@ keyed on an input `mir::ExprId`:
 
 - **Factory** -- builds a fresh node (or a subtree whose top is a fresh node) from inputs that are
   not an arena handle: a `mir::TypeId`, an HIR node, a literal value, or the body's `self`. A
-  factory returns the top node as a detached `mir::Expr`; the caller interns it with
-  `scope.AddExpr(...)`. A composite factory interns its own children into `frame.current_block` as
-  it builds and returns only the top detached, so interning the result yields a self-contained arena
-  subtree. The `mir::Make*Expr` family (pure stateless constructors) and the lowering `Build*Expr`
-  family (frame-aware) are factories. Examples: `MakeLocalRefExpr`, `BuildSelfRefExpr`,
-  `BuildServicesCallExpr`, `BuildDefaultValueExpr`, `BuildArrayConstructExpr`.
+  factory carries one of two prefixes, split by whether it mutates a scope -- not by whether it
+  reads the frame:
+  - **`Make*`** is pure: it interns nothing. It assembles the returned node from ready-made parts
+    and may read a `const` frame (the `self` hop count, a builtin `mir::TypeId`), but it touches no
+    arena. The caller interns the single returned node with `scope.AddExpr(...)`. Examples:
+    `MakeLocalRefExpr`, `MakeSelfRefExpr`, `MakeServicesCallExpr`.
+  - **`Build*`** is composite: it interns one or more child nodes into a scope
+    (`frame.current_block` or a passed `mir::Block&`) as it builds, then returns the top node --
+    detached as a `mir::Expr` for the caller to intern, or already interned as a `mir::ExprId`.
+    Examples: `BuildServicesCallExpr` (interns the `self` child that `MakeServicesCallExpr` takes
+    ready-made), `BuildDefaultValueExpr`, `BuildElementAccessCallExpr`,
+    `BuildArrayConstructionCall`.
+
+  The distinguishing test is the scope side effect: a helper that reads `self` off a
+  `const WalkFrame&` and returns the node for the caller to intern is `Make*` however much frame
+  state it consults, while one that interns even a single child is `Build*`.
+
 - **Transform** -- keyed on an input `mir::ExprId`: it reads `scope.GetExpr(id)` to decide what to
   build, or may return the input unchanged (pass-through). A transform returns a `mir::ExprId`,
   because it operates on already-interned arena nodes. Examples: `WrapUnpackedIndex` (returns its

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -421,20 +421,17 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       exactly one place. The result type left the constructor -- a synchronous terminal derives it
       from the result expression, since a closure's result type is just its returned value's type.
 
-- [ ] R32 -- Unify the Expr- / value-construction helper naming, which is ad hoc today (`Make*` and
-      `Build*` are both used for the same job). Establish one rule, grounded in the cross-language
-      norm: every IR / value system separates a **pure node factory** -- assembles a node from
-      ready-made parts, no scope or arena side effect, returns by value -- from a **scope-using
-      builder** -- allocates sub-nodes into a scope and assembles, side-effecting. C++ `std::make_*`
-      (pure) versus the builder pattern; LLVM `Type::get` / `ConstantInt::get` (pure, interned)
-      versus `IRBuilder::Create*` (inserts into a block); rustc `T::new` versus `tcx.mk_*` (interns
-      into the arena); MLIR / Clang `builder.create` / `Expr::Create(ctx, ...)` (arena). Keep both
-      -- the pure-versus-stateful split is load-bearing, since it tells the reader whether the
-      helper mutates a scope -- and pin the rule: `Make<Node>(parts...) -> Expr` is the pure factory
-      (the caller does the `AddExpr`); `Build<Node>(scope-or-frame, inputs...) -> Expr | ExprId` is
-      the scope builder (it does the `AddExpr`, with the context argument first); a type-producing
-      variant is `Make<X>Type(...) -> TypeId`. Audit every construction helper and rename it to the
-      correct side. **Trigger**: standalone naming cleanup.
+- [x] R32 -- The Expr- / value-construction helper naming is pinned to one load-bearing rule: a
+      `Make<Node>` is a pure factory (assembles a node from ready-made parts, reads at most a
+      `const` frame for the body's `self` or a builtin type, interns nothing -- the caller does the
+      `AddExpr`), and a `Build<Node>` is a scope builder (interns one or more child nodes into the
+      scope as it builds, returning the top node detached or its id, context argument first); a
+      type-producing variant is `Make<X>Type`. The distinguishing axis is the scope side effect, not
+      whether the helper consults the frame -- a factory that reads `self` off a `const` frame and
+      interns nothing is `Make`. A full audit of the construction helpers found the codebase already
+      largely conformant; the few pure factories mislabelled `Build` were renamed to `Make`. The
+      rule now lives as an invariant in `lowering_organization.md` (Expression-Builder Helpers), so
+      it outlives this entry.
 
 - [ ] R33 -- Remove the redundant `UnsupportedCategory` argument from the `diag::Unsupported`
       factory. The category is already declared once per `DiagCode` in the code table; the factory

--- a/include/lyra/lowering/hir_to_mir/self_ref.hpp
+++ b/include/lyra/lowering/hir_to_mir/self_ref.hpp
@@ -13,13 +13,13 @@ struct MemberRef;
 
 namespace lyra::lowering::hir_to_mir {
 
-// Builds a read of the current body's `self` binding (mir.md invariant 11): a
+// Makes a read of the current body's `self` binding (mir.md invariant 11): a
 // `ProceduralVarRef` whose hop count is the distance from the reading site back
 // to where `self` was declared. The caller adds the returned expression to the
 // scope it is composing. This is the one place the self-read shape lives --
 // every member access, cross-unit deref, closure self-capture, and runtime-
 // effect engine handle starts from it.
-auto BuildSelfRefExpr(const WalkFrame& frame, mir::TypeId self_ptr_type)
+auto MakeSelfRefExpr(const WalkFrame& frame, mir::TypeId self_ptr_type)
     -> mir::Expr;
 
 // Builds a read of a structural var through the current body's `self`:

--- a/include/lyra/lowering/hir_to_mir/sensitivity_wait.hpp
+++ b/include/lyra/lowering/hir_to_mir/sensitivity_wait.hpp
@@ -14,7 +14,7 @@ class ClassLowerer;
 // an expression for explicit `@(...)`). The single point where always_comb /
 // always_latch (LRM 9.2.2.2.1, procedure-attached) and `@*` (LRM 9.4.2.2,
 // TimedStmt-attached) converge onto the same MIR runtime construct.
-auto BuildSensitivityWaitStmt(
+auto MakeSensitivityWaitStmt(
     const ClassLowerer& lowerer,
     const std::vector<hir::SensitivityEntry>& sensitivity_list) -> mir::Stmt;
 

--- a/include/lyra/lowering/hir_to_mir/services_call.hpp
+++ b/include/lyra/lowering/hir_to_mir/services_call.hpp
@@ -7,7 +7,7 @@
 namespace lyra::lowering::hir_to_mir {
 
 // Builds the engine-handle expression `self.Services()`: a `Services`
-// scope-method call whose receiver is the body's self read (BuildSelfRefExpr,
+// scope-method call whose receiver is the body's self read (MakeSelfRefExpr,
 // interned as a child). Returns the call node detached; the caller interns it.
 // Runtime-effect generic calls -- $finish, the $time family, named-event
 // trigger / triggered -- thread it as the engine handle

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -344,8 +344,7 @@ auto BuildDownwardNavValue(
         "owned child");
   }
 
-  mir::ExprId cur =
-      ctor_block.exprs.Add(BuildSelfRefExpr(frame, self_ptr_type));
+  mir::ExprId cur = ctor_block.exprs.Add(MakeSelfRefExpr(frame, self_ptr_type));
   for (std::size_t i = 0; i + 1 < hops.size(); ++i) {
     std::vector<mir::ExprId> args;
     args.push_back(cur);
@@ -415,7 +414,7 @@ void InstallCrossUnitRefs(
     const mir::ExprId nav = ctor_block.exprs.Add(BuildDownwardNavValue(
         module, frame, head_name, cu.path, slot_type, scope_ptr_type));
     const mir::ExprId self_for_target = ctor_block.exprs.Add(
-        BuildSelfRefExpr(frame, mir_class.self_pointer_type));
+        MakeSelfRefExpr(frame, mir_class.self_pointer_type));
     const mir::ExprId target = ctor_block.exprs.Add(
         mir::Expr{
             .data =
@@ -770,7 +769,7 @@ auto ClassLowerer::Run(
   const mir::TypeId void_type = module.Unit().AddType(mir::VoidType{});
   const mir::TypeId self_ptr_type = mir_class.self_pointer_type;
   const auto self_read = [&]() -> mir::ExprId {
-    return ctor_block.exprs.Add(BuildSelfRefExpr(scope_frame, self_ptr_type));
+    return ctor_block.exprs.Add(MakeSelfRefExpr(scope_frame, self_ptr_type));
   };
   for (std::size_t i = 0; i < hir_scope.structural_vars.size(); ++i) {
     const hir::StructuralVarId hir_id{static_cast<std::uint32_t>(i)};

--- a/src/lyra/lowering/hir_to_mir/closure_builder.cpp
+++ b/src/lyra/lowering/hir_to_mir/closure_builder.cpp
@@ -27,7 +27,7 @@ ClosureBuilder::ClosureBuilder(
   self_binding_ =
       body_.vars.Add(mir::LocalDecl{.name = "self", .type = self_pointer_type});
   const mir::ExprId outer_self_read =
-      outer_->exprs.Add(BuildSelfRefExpr(enclosing, self_pointer_type));
+      outer_->exprs.Add(MakeSelfRefExpr(enclosing, self_pointer_type));
   captures_.push_back(
       mir::Capture{.value = outer_self_read, .binding = self_binding_});
   frame_ = enclosing.WithBlock(&body_)

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -52,7 +52,7 @@ auto LowerContinuousAssign(
   // already bound via `WithSelfBinding(self_id, ...)` above, so the self read
   // resolves through the frame the same way a process body's does.
   const mir::ExprId body_self_ref = body_block.exprs.Add(
-      BuildSelfRefExpr(body_frame, frame.current_class->self_pointer_type));
+      MakeSelfRefExpr(body_frame, frame.current_class->self_pointer_type));
   const mir::ExprId body_services_id = body_block.exprs.Add(
       mir::MakeServicesCallExpr(
           body_self_ref, lowerer.Module().Unit().builtins.services));
@@ -65,8 +65,7 @@ auto LowerContinuousAssign(
       mir::Stmt{
           .label = std::nullopt, .data = mir::ExprStmt{.expr = assign_id}});
 
-  body_block.AppendStmt(
-      BuildSensitivityWaitStmt(lowerer, src.sensitivity_list));
+  body_block.AppendStmt(MakeSensitivityWaitStmt(lowerer, src.sensitivity_list));
 
   const mir::BlockId body_scope_id =
       process_block.child_scopes.Add(std::move(body_block));

--- a/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
@@ -311,7 +311,7 @@ auto BuildDeferredCheckCascade(
 
   const mir::DeferredCheckSiteId site_id =
       module.Unit().AllocateDeferredCheckSiteId();
-  const mir::ExprId self_id = wrapper.exprs.Add(BuildSelfRefExpr(
+  const mir::ExprId self_id = wrapper.exprs.Add(MakeSelfRefExpr(
       wrapper_frame, wrapper_frame.current_class->self_pointer_type));
   const mir::ExprId site_id_expr = wrapper.exprs.Add(
       mir::MakeInt32Literal(

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -148,7 +148,7 @@ auto CloneLhsExprForNbaBody(
       outer_expr.data);
 }
 
-auto BuildStringMethodCallExpr(
+auto MakeStringMethodCallExpr(
     support::BuiltinFn fn, std::vector<mir::ExprId> args, mir::TypeId type)
     -> mir::Expr {
   return mir::Expr{
@@ -306,7 +306,7 @@ auto LowerStringElementAssign(
     auto base_read_or = process.LowerExpr(base_hir, frame);
     if (!base_read_or) return std::unexpected(std::move(base_read_or.error()));
     const mir::ExprId base_read_id = block.exprs.Add(*std::move(base_read_or));
-    const mir::ExprId cur_id = block.exprs.Add(BuildStringMethodCallExpr(
+    const mir::ExprId cur_id = block.exprs.Add(MakeStringMethodCallExpr(
         support::BuiltinFn::kGetc, {base_read_id, idx_id}, result_type));
     value_id = block.exprs.Add(
         mir::Expr{
@@ -329,7 +329,7 @@ auto LowerStringElementAssign(
         if (mir::IsObservableCellType(unit.GetType(blk.exprs.Get(root).type))) {
           recv = RewriteLhsRootWithMutate(unit, blk, target, services);
         }
-        return BuildStringMethodCallExpr(
+        return MakeStringMethodCallExpr(
             support::BuiltinFn::kPutc, {recv, ops[0], ops[1]},
             unit.builtins.void_type);
       });

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -137,7 +137,7 @@ auto LowerAssociativeTraversal(
 // is the flat `support::BuiltinFn`; the only decision here is whether the
 // id names a type-namespace-qualified static call (e.g. `MyEnum::first()`)
 // or an instance call.
-auto BuildBuiltinMirCallee(
+auto MakeBuiltinMirCallee(
     const ModuleLowerer& module, const hir::BuiltinMethodRef& b,
     hir::TypeId hir_dispatch_type) -> mir::Callee {
   if (support::IsStaticBuiltinFn(b.method)) {
@@ -339,7 +339,7 @@ auto LowerStructuralSubroutineCall(
   std::vector<mir::ExprId> args;
   args.reserve(c.arguments.size() + 1);
   args.push_back(block.exprs.Add(
-      BuildSelfRefExpr(frame, frame.current_class->self_pointer_type)));
+      MakeSelfRefExpr(frame, frame.current_class->self_pointer_type)));
   for (std::size_t i = 0; i < c.arguments.size(); ++i) {
     if (!c.arguments[i].has_value()) {
       throw InternalError("user-function call argument unexpectedly elided");
@@ -420,7 +420,7 @@ auto LowerBuiltinMethodCall(
   // Translate the callee up front so the same trait (`mir::IsMutatingCallee`)
   // drives both lowering and backend rendering.
   const mir::Callee mir_callee =
-      BuildBuiltinMirCallee(module, b, hir_dispatch_type);
+      MakeBuiltinMirCallee(module, b, hir_dispatch_type);
 
   // A static call has no value receiver -- `args[0]` is the discardable
   // type-bearer, the type-namespace qualifier rides on the callee. An

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -194,7 +194,7 @@ auto LowerCrossUnitVarRefExpr(
   const mir::MemberRef target = meta.target;
   const mir::TypeId self_ptr_type = frame.current_class->self_pointer_type;
   const mir::ExprId self_ref =
-      frame.current_block->exprs.Add(BuildSelfRefExpr(frame, self_ptr_type));
+      frame.current_block->exprs.Add(MakeSelfRefExpr(frame, self_ptr_type));
   const auto* ptr = std::get_if<mir::PointerType>(
       &lowerer.Module().Unit().GetType(meta.slot_type).data);
   if (ptr != nullptr && ptr->ownership == mir::PointerOwnership::kBorrowed) {

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -337,7 +337,7 @@ auto ProcessLowerer::Run(const hir::Process& src)
     case hir::ProcessKind::kAlwaysLatch:
       return LowerForeverProcess(
           *this,
-          BuildSensitivityWaitStmt(*owner_, src.implicit_sensitivity_list));
+          MakeSensitivityWaitStmt(*owner_, src.implicit_sensitivity_list));
   }
   throw InternalError("ProcessLowerer::Run: unknown HIR ProcessKind");
 }

--- a/src/lyra/lowering/hir_to_mir/self_ref.cpp
+++ b/src/lyra/lowering/hir_to_mir/self_ref.cpp
@@ -10,7 +10,7 @@
 
 namespace lyra::lowering::hir_to_mir {
 
-auto BuildSelfRefExpr(const WalkFrame& frame, mir::TypeId self_ptr_type)
+auto MakeSelfRefExpr(const WalkFrame& frame, mir::TypeId self_ptr_type)
     -> mir::Expr {
   return mir::MakeLocalRefExpr(
       frame.block_depth - frame.self_decl_depth, *frame.self_binding,
@@ -22,7 +22,7 @@ auto BuildStructuralMemberAccessExpr(
   const mir::TypeId field_type =
       frame.EnclosingClassAtHops(member.hops).members.Get(member.var).type;
   const mir::ExprId receiver = frame.current_block->exprs.Add(
-      BuildSelfRefExpr(frame, frame.current_class->self_pointer_type));
+      MakeSelfRefExpr(frame, frame.current_class->self_pointer_type));
   return mir::MakeMemberAccessExpr(receiver, member, field_type);
 }
 

--- a/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
+++ b/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
@@ -31,7 +31,7 @@ auto LowerEventEdge(hir::EventEdge edge) -> mir::EventEdge {
 
 }  // namespace
 
-auto BuildSensitivityWaitStmt(
+auto MakeSensitivityWaitStmt(
     const ClassLowerer& lowerer,
     const std::vector<hir::SensitivityEntry>& sensitivity_list) -> mir::Stmt {
   std::vector<mir::SensitivityRead> reads;

--- a/src/lyra/lowering/hir_to_mir/services_call.cpp
+++ b/src/lyra/lowering/hir_to_mir/services_call.cpp
@@ -11,7 +11,7 @@ auto BuildServicesCallExpr(
   auto& body = *frame.current_block;
   const auto& builtins = process.Module().Unit().builtins;
   const mir::ExprId self_id = body.exprs.Add(
-      BuildSelfRefExpr(frame, frame.current_class->self_pointer_type));
+      MakeSelfRefExpr(frame, frame.current_class->self_pointer_type));
   return mir::MakeServicesCallExpr(self_id, builtins.services);
 }
 

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -258,7 +258,7 @@ auto LowerSubroutineCallWithWritebacks(
   // invariant 11); the SV actuals (with output / inout temps) follow.
   std::vector<mir::ExprId> call_args;
   call_args.reserve(call.arguments.size() + 1);
-  call_args.push_back(wrapper.exprs.Add(BuildSelfRefExpr(
+  call_args.push_back(wrapper.exprs.Add(MakeSelfRefExpr(
       wrapper_frame, wrapper_frame.current_class->self_pointer_type)));
   std::vector<OutputArgSlot> writebacks;
 

--- a/src/lyra/lowering/hir_to_mir/statement/flow.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/flow.cpp
@@ -63,7 +63,7 @@ auto LowerStaticVarDeclStmt(
   }
 
   const mir::ExprId ctor_self_read =
-      ctor_block.exprs.Add(BuildSelfRefExpr(ctor_frame, self_ptr_type));
+      ctor_block.exprs.Add(MakeSelfRefExpr(ctor_frame, self_ptr_type));
   const mir::ExprId target = ctor_block.exprs.Add(
       mir::MakeMemberAccessExpr(
           ctor_self_read,

--- a/src/lyra/lowering/hir_to_mir/statement/timing.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/timing.cpp
@@ -165,7 +165,7 @@ auto LowerEventTimedStmt(
             union_reads.push_back(leaf);
           }
         }
-        return BuildSensitivityWaitStmt(process.Owner(), union_reads);
+        return MakeSensitivityWaitStmt(process.Owner(), union_reads);
       });
 }
 
@@ -177,7 +177,7 @@ auto LowerImplicitEventTimedStmt(
   return LowerTimedWaitWrapper(
       process, frame, std::move(label), t.stmt,
       [&](mir::Block&, WalkFrame) -> diag::Result<mir::Stmt> {
-        return BuildSensitivityWaitStmt(process.Owner(), ie.sensitivity_list);
+        return MakeSensitivityWaitStmt(process.Owner(), ie.sensitivity_list);
       });
 }
 
@@ -273,7 +273,7 @@ auto LowerWaitStmt(
   const auto& reads = w.sensitivity_list;
 
   mir::Block inner_block;
-  inner_block.AppendStmt(BuildSensitivityWaitStmt(process.Owner(), reads));
+  inner_block.AppendStmt(MakeSensitivityWaitStmt(process.Owner(), reads));
 
   const mir::BlockId inner_scope_id =
       wrapper.child_scopes.Add(std::move(inner_block));


### PR DESCRIPTION
## Summary

The Expr- / value-construction helper prefix is meant to encode one load-bearing fact: does calling the helper mutate a scope (intern child nodes into it)? That signal had drifted -- a handful of pure factories carried the `Build` prefix while interning nothing, so a reader could not trust the name. This pins the rule and corrects the drift. A `Make<Node>` is a pure factory: it assembles the returned node from ready-made parts, may read a `const` frame for the body's `self` or a builtin type, but interns nothing and the caller does the `AddExpr`. A `Build<Node>` is a scope builder: it interns one or more child nodes into the scope as it builds. The distinguishing axis is the scope side effect, not whether the helper consults the frame.

A full audit of the construction helpers found the codebase already largely conformant; the few pure factories mislabelled `Build` (the self-read, the sensitivity-wait statement, the builtin-callee translation, and the string-method call) were renamed to `Make`. The rule now lives as an invariant in `lowering_organization.md` (Expression-Builder Helpers), replacing the previous imprecise "frame-aware" framing and its now-stale examples, so it outlives the R32 tracking entry. Closes R32 in `docs/progress/refactor.md`.

## Testing

`bazel test //...` -- all green.