### PR TITLE
Identify module specializations by parameter-binding hash

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -70,6 +70,10 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
   hierarchical reference resolves once into a stored pointer: downward by emitted constructor
   navigation, upward by a runtime self-climb at bind, both by name; and why the cross-unit hop is by
   name, not a typed accessor.
+- [specialization-identity](specialization-identity.md) -- a specialization's identity is a
+  deterministic name (module name + content hash of a canonical, structural serialization of its
+  parameter bindings), computed independently by producer and consumer and matched by name;
+  injective mangling, body fingerprinting, and a design-global key map are rejected.
 
 ### Diagnostics
 

--- a/docs/decisions/specialization-identity.md
+++ b/docs/decisions/specialization-identity.md
@@ -1,0 +1,143 @@
+# Specialization Identity by Content-Addressed Binding Hash
+
+## Date
+
+2026-06-23
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+A parameterized module instantiated with different bindings must compile to distinct artifacts that
+each behave according to their own parameters. Today a compiled unit's identity is the bare module
+name, so two specializations of one module (e.g. `Reg #(.INIT(3))` and `Reg #(.INIT(7))`) carry the
+same name; emitting more than one collapses them and the last one wins. This record fixes how a
+specialization is identified, named, and reached across the unit boundary. It binds every
+parameterized instantiation and constrains the deferred specialization-dedup optimization
+(`docs/progress/performance.md`).
+
+## Findings that shaped the design
+
+### F1. The identity must be a function of the bindings, not of the body
+
+A cross-unit reference is resolved by the referrer, which cannot see the target's body: a unit
+compiles against another unit's interface (name and signature), never its body or internal layout
+(`compilation_unit_model.md` inv 8, `reference_resolution.md`). So when a parent constructs a child,
+it must be able to name which specialization it wants from what it has -- the module name plus the
+child's parameter bindings -- without inspecting the child's compiled code.
+
+Consequence: the identity is `f(def name, selected bindings)`, never `f(body)`. Fingerprinting the
+lowered body is ruled out, because the consumer that must compute the same identity has no access to
+it.
+
+### F2. The identity is a name, computed independently by both sides
+
+Cross-unit access is by name against the interface; a design-global ordinal, coordinate, or table
+that two units share to refer to each other is forbidden (`compilation_unit_model.md`,
+`emission_model.md`, `identity_and_ownership.md`). The producer (the unit naming itself) and the
+consumer (the parent naming the child it constructs) therefore compute the same name from the same
+bindings by the same deterministic function; they agree with no global view. This rules out an
+opaque key carried in a design-global map (the shape the previous iteration used).
+
+### F3. A binding is one of two recursive structures, encoded structurally
+
+A parameter binding is either a value -- slang resolves it to a `ConstantValue` of any type,
+including unpacked aggregates (LRM 6.20.2) -- or a type -- a data type, recursive, including a
+parameterized class with its own bindings (LRM 6.20.3). The identity encodes the structural content
+of these, and excludes arena ids, source names, and source spans, because identity follows structure
+not position (`identity_and_ownership.md`) and a fingerprint captures semantic meaning not spelling
+(`incremental_build.md` inv 3). Two structurally identical bindings encode identically; an arena id,
+which is a unit-local insertion position, is never part of the encoding.
+
+### F4. Generic-language precedent points to injective mangling for a reason that does not bind us
+
+C++ (Itanium ABI) and Rust (v0) encode template / generic arguments into an injective mangled symbol
+name. They do so because the name must be demanglable for debuggers and must be self-contained for a
+linker that matches symbols across separately compiled units with no global view, and they accept
+that the name grows with argument complexity. Lyra needs neither property: its readable surface is
+the MIR dump, not a demangled symbol, and determinism alone makes the producer and consumer agree on
+a name without a global view. So Lyra can content-address (hash) the binding encoding where C++ and
+Rust cannot.
+
+## The decision
+
+1. **Identity is a deterministic name = module definition name + a content hash of a canonical
+   serialization of the selected parameter bindings.** The producer and the consumer both compute it
+   from the bindings; they match by name.
+
+2. **The serializer canonically encodes the binding structure.** It walks `ConstantValue` on the
+   value side and the data-type structure on the type side, recursively, and excludes arena ids,
+   source names, and source spans. Ordering is normalized so the result does not depend on traversal
+   or enumeration order (`specialization_model.md` inv 6).
+
+3. **The serializer is subset-agnostic; which bindings feed it is policy.** Functional
+   specialization (the current requirement, `docs/progress/hierarchy.md` Stage A) feeds all
+   parameters. The deferred dedup optimization (`docs/progress/performance.md`) feeds only
+   code-shape-affecting bindings and demotes value-only parameters to constructor inputs resolved at
+   construction. The identity mechanism does not change across that shift; only the input subset
+   does.
+
+4. **The identity is computed at AST-to-HIR and carried by name thereafter.** HIR owns identity and
+   frontend ids end there (`hir.md`); the cross-unit reference and the construct carry the name, and
+   the backend renders it as the artifact's name.
+
+5. **Readability is a separable, non-load-bearing decoration.** A human-readable prefix or comment
+   may be added later for the emitted artifact; it never gates the identity, never has to be
+   collision-free, and degrades gracefully on bindings it cannot render. The hash is the
+   load-bearing identity.
+
+## Consequences
+
+- Distinct bindings produce distinct names, hence distinct artifacts; the current name-collision
+  collapse is fixed, including value parameters of any type (unpacked aggregates included) and type
+  parameters.
+- The hash's only failure mode is collision; a wide content hash makes it not a practical concern,
+  and no global view is needed to guarantee that the producer and consumer agree.
+- The deferred dedup optimization reuses the same serializer with a narrower input subset, so it
+  does not discard this work.
+- Type-parameter identity reuses the recursive data-type structure already produced by type
+  lowering; no parallel structure is introduced.
+
+## Open hardening: an incremental-grade fingerprint
+
+The hash must be self-owned, not the frontend's. slang exposes a value/type hash, but it folds raw
+pointers for some type kinds (a virtual-interface type hashes the interface address) and ties the
+result to a frontend-internal algorithm; identity is owned past AST-to-HIR (`hir.md`), so the
+specialization hash is computed here, over content, with a fixed algorithm that is stable across
+sessions (`incremental_build.md` forbids a pointer-derived or process-seeded key).
+
+The first implementation feeds the hash a textual rendering of each binding (the value's and type's
+`toString`). This is deterministic and session-stable, but it is not yet an incremental-grade
+fingerprint: a type rendering can carry source spelling (a typedef name), so a rename would shift
+the key even though the meaning is unchanged, which `incremental_build.md` invariant 3 rules out;
+and a value rendering can be lossy. When aggressive incremental build lands, the encoding is
+hardened to a structural fingerprint that mirrors slang's `==` / `isMatching` equivalence and
+excludes source spelling, so the key changes only when the compiled meaning does. The hash being
+self-owned and the identity being `f(def, bindings)` do not change; only what is fed to the hash
+does. Deferred until incremental build exists, because the encoding's exact obligations are fixed by
+that machinery.
+
+## Alternatives considered
+
+**Injective mangling (C++ / Rust style): the binding encoding is the name.** Rejected. The name
+grows without bound with binding complexity -- an unpacked array of structs or a deeply
+parameterized type produces an enormous name -- and that cost is certain and always present. Lyra
+gains nothing from the self-containedness that motivates it in C++ / Rust, because determinism
+already makes the two sides agree, and it does not need demangling. Trading a certain, ever-present
+cost (name growth) for a vanishing one (hash collision under a wide hash) favors the hash.
+
+**Fingerprint the lowered body.** Rejected. The consumer that must compute the child's identity
+cannot see the child's body under independent compilation (F1).
+
+**Opaque key carried in a design-global map (the previous iteration's `ModuleSpecId`).** Rejected.
+It resolves cross-unit references through a design-global table rather than by name, which
+`compilation_unit_model.md` and `emission_model.md` forbid. The previous iteration's classification
+insight -- fingerprint only code-shape facts, value parameters flow in as runtime data -- is
+retained as the deferred dedup policy, but its mechanism is not.
+
+**A readable name with scalar values baked in (e.g. `Reg__INIT_3`).** Rejected. It is specialized to
+scalar value parameters and cannot express an aggregate value or a type parameter, so it breaks the
+moment a non-scalar binding appears and forces a throwaway rewrite. Readability is recovered as a
+non-load-bearing decoration on top of the general identity instead.

--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -27,6 +27,11 @@ the dedicated file is the source of truth for "what is done, in what order, what
 - [x] R7 -- Test framework variable assertions (`expect.variables`). `tests/framework/runner.cpp`
       rewrites the source with a synthetic `final` probe block keyed on sentinel markers in stdout
       and matches each entry against scalar / SV-literal expectations.
+- [ ] R8 -- Per-unit artifact emission. The C++ backend emits one artifact per unit specialization,
+      assembled into the program by linking, rather than collapsing every unit into one translation
+      unit. Contract in `../architecture/emission_model.md` (inv 1); the current single-`main.cpp`
+      aggregation that transitively includes every unit header is the transitional shortcut that doc
+      marks for removal.
 
 ## SystemVerilog Features
 

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -58,14 +58,20 @@ C  Non-local access substrate
       scheduler on one shared time axis -- there is no single "main" block. This is end-to-end
       testable with no instantiation edge: two independent top modules each run their own processes
       under the shared schedule.
-- [ ] A2 -- Inputs are classified into code-shape-affecting (enter the specialization key) versus
-      constructor/config inputs (flow in at construction). One compiled artifact exists per distinct
-      code shape, not per instance.
-- [ ] A3 -- Two instances whose code-shape inputs match share one compiled artifact; value-only
-      parameters differ per instance without forking the artifact.
+- [ ] A2 -- A module instantiated with different parameter values yields distinct specializations
+      that each behave according to their own values. Parameters are elaborated per instance, so
+      distinct parameter bindings produce distinct compiled artifacts; the open gap is that two
+      specializations of one module are currently indistinguishable because their identity is the
+      module name alone, so emitting more than one collapses them. A specialization needs an
+      identity that separates differing parameter bindings (see
+      `docs/decisions/specialization-identity.md`). Sharing one artifact across bindings whose
+      generated code is identical is a compile-performance optimization, not a functional
+      requirement -- it lives in `performance.md`. Covers value parameters of any type, including
+      unpacked aggregate values (LRM 6.20.2), and type parameters (LRM 6.20.3); an unbounded `$`
+      value (LRM 6.20.7) is just one more distinct binding to the identity and rides on the same
+      path.
 
-Unlocks the compile-time side of `instantiation/specialization_grouping` and
-`instantiation/param_slots`.
+Unlocks the runtime side of `instantiation/param_slots`.
 
 ### Stage B -- Object-graph construction (instantiation)
 
@@ -214,8 +220,6 @@ Unlocks the `ports/*` archive group.
 
 ## Open Questions
 
-- How much of the specialization-key classification (which inputs are code-shape-affecting) is
-  pinned in A2 versus refined as later stages reveal more code-shape-affecting inputs.
 - Connection shorthands (`.*`, `.name` implicit) resolve to the same connection set as explicit
   named connections in the frontend; whether any need distinct handling is open. Positional and
   explicit named connections are both supported.
@@ -226,6 +230,9 @@ Unlocks the `ports/*` archive group.
   `compilation_unit_model.md` but are a separate workstream from module hierarchy. A hierarchical
   reference resolved via an interface port belongs to that workstream.
 - Primitive and gate-level instances (UDPs, built-in gates).
+- Specify parameters (`specparam`, LRM 6.20.5). They carry timing and delay values for specify
+  blocks and belong to the timing domain, not the parameter-specialization path; they wait for a
+  specify-block workstream rather than blocking this one.
 - Bind directives and configuration (`config` / `bind`).
 - Net resolution and net merging: multi-driver resolved nets and net collapsing across ports. A
   single-driver net port behaves as a continuous assignment and is in scope; multi-driver net

--- a/docs/progress/performance.md
+++ b/docs/progress/performance.md
@@ -1,0 +1,45 @@
+# Performance
+
+Tracks performance work that is intentionally deferred behind functionality. An item here is a known
+optimization with a defined target shape, not a correctness gap: the feature already behaves
+correctly without it, and the item only makes the same behavior cheaper. Split into two domains that
+have different cost models and different measurement methods.
+
+## Runtime performance
+
+Simulation execution speed: the cost of running processes, scheduling events, and reading and
+writing state once the object graph is built.
+
+Re-establishing runtime performance tracking on the current architecture is pending the execution
+backends and the benchmark CI jobs that drive it (`architecture-reset.md` R6). No concrete item is
+open here until that lands.
+
+## Construction / compile-time performance
+
+The cost of producing compiled artifacts and of building the object graph at time zero. The primary
+constraint is `north_star.md`: compile-time work scales with the number of distinct unit
+specializations, not with instance count.
+
+- [ ] Specialization dedup. Today every distinct parameter binding produces its own compiled
+      artifact, because unit identity is keyed on the frontend's per-parameter-set elaboration. This
+      over-forks: two instances whose generated code is identical except for a folded constant
+      compile twice. The target is `specialization_model.md`: classify each parameter as a
+      code-shape-affecting input (enters the specialization key) or a constructor/config input
+      (flows in at construction), emit one artifact per distinct code shape, and let value-only
+      parameters differ per instance without forking the artifact (LRM 23.10). Functionality does
+      not depend on this -- a correctly-identified per-binding artifact already behaves correctly
+      (see `hierarchy.md` Stage A); dedup only reduces how many artifacts exist. The identity
+      mechanism is unchanged from the functional case: the same canonical binding serializer
+      (`docs/decisions/specialization-identity.md`) is fed only the code-shape-affecting subset, and
+      value-only parameters are demoted to constructor inputs.
+
+### Open questions
+
+- How thin the specialization key goes. The fat-value runtime representation carries packed width
+  and unpacked size as runtime fields rather than as distinct types
+  (`decisions/integral-representation.md`, `decisions/unpacked-array-representation.md`), so for the
+  C++ backend a width or size parameter does not change generated code and could be a constructor
+  input. A width-templated backend (the future LLVM `iN` lowering) does specialize on width. Whether
+  per-width specialization is a key axis or a backend-internal monomorphization downstream of one
+  width-generic artifact is unresolved, and it conflicts with `specialization_model.md` invariant 3
+  as written (which lists packed width as code-shape-affecting). Resolve before keying on width.

--- a/include/lyra/lowering/ast_to_hir/specialization_name.hpp
+++ b/include/lyra/lowering/ast_to_hir/specialization_name.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+
+namespace slang::ast {
+class InstanceBodySymbol;
+class InstanceSymbol;
+}  // namespace slang::ast
+
+namespace lyra::lowering::ast_to_hir {
+
+// The compiled identity of a module specialization: the module definition name,
+// plus a content hash of its resolved parameter bindings when the module is
+// parameterized (LRM 6.20, 23.10). Instances whose bindings differ get distinct
+// names; instances whose bindings match share slang's one canonical body and so
+// get the same name; a non-parameterized module keeps its definition name. The
+// producer (the unit naming itself) and every consumer (a parent naming a child
+// it instantiates) compute the same name from the same canonical body, so a
+// cross-unit reference matches by name with no shared table. See
+// docs/decisions/specialization-identity.md.
+auto SpecializationName(const slang::ast::InstanceBodySymbol& body)
+    -> std::string;
+
+// Resolves the instance to its canonical body and names that specialization.
+auto SpecializationName(const slang::ast::InstanceSymbol& inst) -> std::string;
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/compilation_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/compilation_lowerer.cpp
@@ -13,6 +13,7 @@
 #include "lyra/hir/module_unit.hpp"
 #include "lyra/lowering/ast_to_hir/lower.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/specialization_name.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -89,7 +90,7 @@ auto TopLevelUnitNames(slang::ast::Compilation& compilation)
   std::vector<std::string> names;
   names.reserve(root.topInstances.size());
   for (const auto* inst : root.topInstances) {
-    names.emplace_back(inst->body.name);
+    names.emplace_back(SpecializationName(*inst));
   }
   return names;
 }

--- a/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
@@ -24,6 +24,7 @@
 #include "lyra/hir/module_unit.hpp"
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/ast_to_hir/sensitivity.hpp"
+#include "lyra/lowering/ast_to_hir/specialization_name.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
@@ -31,7 +32,7 @@ namespace lyra::lowering::ast_to_hir {
 
 ModuleLowerer::ModuleLowerer(
     const LoweringFacts& facts, const slang::ast::InstanceBodySymbol& body)
-    : facts_(facts), body_(&body), unit_{std::string{body.name}} {
+    : facts_(facts), body_(&body), unit_{SpecializationName(body)} {
 }
 
 auto ModuleLowerer::Run() -> diag::Result<hir::ModuleUnit> {

--- a/src/lyra/lowering/ast_to_hir/specialization_name.cpp
+++ b/src/lyra/lowering/ast_to_hir/specialization_name.cpp
@@ -1,0 +1,70 @@
+#include "lyra/lowering/ast_to_hir/specialization_name.hpp"
+
+#include <cstdint>
+#include <format>
+#include <string>
+#include <string_view>
+
+#include <slang/ast/symbols/CompilationUnitSymbols.h>
+#include <slang/ast/symbols/InstanceSymbols.h>
+#include <slang/ast/symbols/ParameterSymbols.h>
+#include <slang/ast/types/DeclaredType.h>
+#include <slang/ast/types/Type.h>
+#include <slang/numeric/ConstantValue.h>
+
+namespace lyra::lowering::ast_to_hir {
+
+namespace {
+
+// FNV-1a, so producer and consumer agree on the name across separately compiled
+// units and across sessions. A process-seeded or pointer-derived hash would not
+// (incremental_build.md forbids it as a key); this folds only the bytes.
+auto Fnv1a64(std::string_view bytes) -> std::uint64_t {
+  std::uint64_t hash = 0xcbf29ce484222325ULL;
+  for (const unsigned char byte : bytes) {
+    hash ^= byte;
+    hash *= 0x100000001b3ULL;
+  }
+  return hash;
+}
+
+// Position-free encoding of one binding: the parameter name, then its resolved
+// value or resolved type, on the same value/type split slang uses to decide
+// canonical-body equivalence (ParameterSymbolBase::allMatching).
+void EncodeBinding(
+    const slang::ast::ParameterSymbolBase& param, std::string& out) {
+  const slang::ast::Symbol& symbol = param.symbol;
+  out += symbol.name;
+  out += '=';
+  if (symbol.kind == slang::ast::SymbolKind::Parameter) {
+    out += symbol.as<slang::ast::ParameterSymbol>().getValue().toString();
+  } else {
+    out += symbol.as<slang::ast::TypeParameterSymbol>()
+               .targetType.getType()
+               .toString();
+  }
+  out += ';';
+}
+
+}  // namespace
+
+auto SpecializationName(const slang::ast::InstanceBodySymbol& body)
+    -> std::string {
+  std::string name{body.getDefinition().name};
+  const auto params = body.getParameters();
+  if (params.empty()) {
+    return name;
+  }
+  std::string encoding;
+  for (const auto* param : params) {
+    EncodeBinding(*param, encoding);
+  }
+  return std::format("{}__{:016x}", name, Fnv1a64(encoding));
+}
+
+auto SpecializationName(const slang::ast::InstanceSymbol& inst) -> std::string {
+  const auto* canonical = inst.getCanonicalBody();
+  return SpecializationName(canonical != nullptr ? *canonical : inst.body);
+}
+
+}  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
@@ -31,6 +31,7 @@
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/specialization_name.hpp"
 #include "lyra/lowering/ast_to_hir/time_resolution.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
@@ -387,7 +388,7 @@ auto StructuralScopeLowerer::PopulateInstanceMember(
       frame.current_structural_scope->instance_members.Add(
           hir::InstanceMemberDecl{
               .instance_name = std::string{inst.name},
-              .target_unit = std::string{inst.getDefinition().name},
+              .target_unit = SpecializationName(inst),
               .array_dims = {}});
   // A downward cross-unit reference (`c.x`) resolves the leading `c` to
   // this member; the binding lets process-body lowering find it regardless
@@ -420,7 +421,7 @@ auto StructuralScopeLowerer::PopulateInstanceArrayMember(
       frame.current_structural_scope->instance_members.Add(
           hir::InstanceMemberDecl{
               .instance_name = std::string{array.name},
-              .target_unit = std::string{leaf.getDefinition().name},
+              .target_unit = SpecializationName(leaf),
               .array_dims = std::move(dims)});
   module_->MapOwnedChildBinding(
       array, frame_, hir::DownwardHead{.child = member_id});

--- a/tests/cases/cpp/specialization_type_param/case.yaml
+++ b/tests/cases/cpp/specialization_type_param/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.specialization_type_param
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "qa=44 qb=300\n"

--- a/tests/cases/cpp/specialization_type_param/main.sv
+++ b/tests/cases/cpp/specialization_type_param/main.sv
@@ -1,0 +1,14 @@
+// A type parameter changes the compiled type, so distinct type bindings are
+// distinct specializations (LRM 6.20.3, 23.10) and must not collapse onto one
+// artifact. The cast truncates under byte (8-bit) but not under int.
+module Box #(parameter type T = int) (output int q);
+  assign q = T'(300);
+endmodule
+
+module Test;
+  int qa;
+  int qb;
+  Box #(.T(byte)) a (.q(qa));
+  Box #(.T(int)) b (.q(qb));
+  final $display("qa=%0d qb=%0d", qa, qb);
+endmodule

--- a/tests/cases/cpp/specialization_value_param/case.yaml
+++ b/tests/cases/cpp/specialization_value_param/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.specialization_value_param
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "qa=3 qb=7\n"

--- a/tests/cases/cpp/specialization_value_param/main.sv
+++ b/tests/cases/cpp/specialization_value_param/main.sv
@@ -1,0 +1,14 @@
+// Two instances of one module with different value-parameter bindings must
+// each behave according to their own binding (LRM 6.20.2, 23.10). They are
+// distinct specializations and must not collapse onto one compiled artifact.
+module Reg #(parameter int INIT = 0) (output int q);
+  assign q = INIT;
+endmodule
+
+module Test;
+  int qa;
+  int qb;
+  Reg #(.INIT(3)) a (.q(qa));
+  Reg #(.INIT(7)) b (.q(qb));
+  final $display("qa=%0d qb=%0d", qa, qb);
+endmodule


### PR DESCRIPTION
## Summary

A parameterized module instantiated with different bindings must compile to distinct artifacts, but a compiled unit's identity was the bare module name, so two specializations of one module (e.g. `Reg #(.INIT(3))` and `Reg #(.INIT(7))`) carried the same name and emit collapsed them onto one artifact, the last one winning. This gives every specialization a deterministic identity: the module definition name plus a content hash of its resolved parameter bindings. Instances whose bindings differ get distinct names; instances whose bindings match share slang's one canonical body and so get the same name; a non-parameterized module keeps its bare definition name.

The identity is computed at AST-to-HIR and carried by name thereafter. The producer (the unit naming itself) and every consumer (a parent naming a child it instantiates) compute the same name from the same canonical body, so the cross-unit reference matches by name with no shared table -- consistent with the compilation-unit and emission models. Emit needs no change: the class name, the construct call, and the per-unit header filename all derive from the unit name, which now carries the specialization identity.

## Design

The encoder mirrors the value/type split slang uses to decide canonical-body equivalence (`ParameterSymbolBase::allMatching`): a value parameter contributes its resolved `ConstantValue`, a type parameter its resolved type. The hash is a self-owned FNV-1a over that encoding, not slang's hash, so it stays stable across sessions and independent of frontend internals. The rationale, the rejected alternatives (injective mangling, body fingerprinting, a design-global key map), and the deferred incremental-grade hardening are recorded in `docs/decisions/specialization-identity.md`. Sharing one artifact across bindings whose generated code is identical (value-only parameters demoted to constructor inputs) is a compile-performance optimization deferred to `docs/progress/performance.md`.

## Testing

`specialization_value_param` covers a scalar value parameter and `specialization_type_param` covers a type parameter (the two encoder branches), both end-to-end through emit and execution. The full suite passes.