### PR TITLE
Consolidate AST-to-HIR reference-expression builders

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -75,6 +75,14 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
   parameter bindings), computed independently by producer and consumer and matched by name;
   injective mangling, body fingerprinting, and a design-global key map are rejected.
 
+### Compile-time model and specialization
+
+- [parameter-code-shape-over-approximation](parameter-code-shape-over-approximation.md) -- every
+  parameter is treated as code-shape-affecting for now (a conservative over-approximation of the
+  specialization key); parameter classification and constructor-input threading are deferred, and
+  the instance-array storage shape stays forward-compatible (vector wrapper, count as a
+  constructor-side value, never extent-in-the-type).
+
 ### Diagnostics
 
 - [diagnostic-construction](diagnostic-construction.md) -- a diagnostic's kind is a property of its

--- a/docs/decisions/parameter-code-shape-over-approximation.md
+++ b/docs/decisions/parameter-code-shape-over-approximation.md
@@ -1,0 +1,104 @@
+# Treat Every Parameter as Code-Shape-Affecting for Now
+
+## Date
+
+2026-06-23
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+`specialization_model.md` classifies every parameter into one of two axes: a **code-shape-affecting
+input** that enters the specialization key (a packed width, a `parameter type`), or a
+**constructor/config input** that flows in at runtime construction and does not fork the artifact
+(an initial value, a count that only steers how many children are built). The canonical example is
+`parameter int N` controlling a `generate for`: "the unit compiles once for any N."
+
+Realizing that classification -- deciding per parameter which axis it sits on, and threading the
+constructor-input axis as a runtime parameter so one artifact serves every value -- is a significant
+piece of work. This record captures the deliberate choice to defer it and instead **conservatively
+over-approximate the specialization key: treat every parameter as code-shape-affecting**, resolving
+all parameter values at compile time. The current code already behaves this way; this record makes
+it a considered decision, not an unfinished state, so a reader who sees a folded parameter count
+knows it is intended.
+
+## Findings that shaped the design
+
+### F1. The constructor-input vehicle already exists, used narrowly
+
+The architecture's target shape -- a value that flows into the constructor rather than being baked
+-- is already implemented and running: `mir::Class.params` plus the `ParamRef` expression. Today it
+carries exactly one thing: the `generate for` loop variable, threaded as a structural parameter into
+each generate-arm scope so the arm body reads the genvar as a runtime value. The generate loop bound
+is an expression evaluated in the constructor (`hir::LoopGenerate` holds it as an `ExprId`), so
+`generate for` / `generate if` already lower to constructor-time logic. The vehicle is proven;
+module parameters simply do not ride it yet -- they are constant-folded.
+
+### F2. Over-approximating the specialization key is sound, not a hack
+
+Treating every parameter as code-shape-affecting is a conservative over-approximation of the key.
+`specialization_model.md` invariant 3 defines code-shape inputs as "those that change generated
+code"; assuming every parameter changes generated code is a safe over-approximation:
+
+- It is always **correct**. Baking a known parameter value never changes simulation results.
+- It stays **per specialization, never per instance**. The forbidden shape (`north_star.md`) is
+  compile-time work that scales with instance count. Folding a declared parameter value makes
+  compile-time scale with the count of distinct parameter-value combinations -- the specialization
+  axis, which is allowed -- not with instance count.
+- It does not unroll. `generate for` and an instance array both lower to a constructor-side loop
+  with a constant bound; they loop, they do not expand. Compile-time work is O(1) in the iteration
+  count and the element count even under full folding.
+
+### F3. The accepted cost is unshared specializations, not incorrectness
+
+Under this decision, two instantiations whose parameters differ only on the constructor-input axis
+do not share an artifact. `Foo #(4)` and `Foo #(8)` compile as two specializations even where `N`
+only steers construction. This is a deferred optimization -- compile-time sharing across parameter
+values -- not a correctness or soundness gap.
+
+### F4. The storage shape must stay forward-compatible
+
+Instance multiplicity is the vector wrapper (`mir.md`): a runtime-sized member whose per-dimension
+count flows as a value on the construct statement, with construction a constructor-side loop. This
+shape is correct whether the count is a folded constant (today) or a parameter flowed in at
+construction (after classification lands) -- it does not change. Baking the count into the type (a
+fixed-extent array carrying its extent on the type layer, rendered `std::array<T, N>`) is rejected:
+it is valid only while the count is a compile-time constant, and would have to be torn out when the
+count becomes a constructor input. The over-approximation makes the count a constant today, but it
+does **not** license moving the count into the type.
+
+## Decision
+
+Until the parameter classification and the constructor-input threading it enables are built, every
+parameter is treated as code-shape-affecting. Parameter values are resolved at compile time. No
+classification axis exists; the specialization key conservatively includes every parameter. This
+folded shape is the intended state, not a transitional one.
+
+Two constraints bind going forward, so that deferring the optimization does not dig a hole:
+
+1. **Storage stays forward-compatible.** Instance multiplicity is the vector wrapper with the count
+   as a constructor-side value. It is never a fixed-extent array type carrying the count in the
+   type. (This is why the proposed "store an instance array as a fixed-size array, extent in the
+   type" refactor was removed rather than implemented: it is forward-incompatible with the
+   constructor-input end state and contradicts the vector-wrapper invariant.)
+
+2. **Do not widen elaborated-graph consumption.** The instance-array count is currently sourced from
+   slang's elaborated element count rather than the declared dimension expression. This is tolerated
+   only because every parameter is folded anyway; it is the least forward-compatible point and the
+   first thing to revisit when constructor-input threading is built. It must not be generalized into
+   reading more of the elaborated instance graph (expanded per-instance values, materialized
+   sub-instances) as compile-time facts -- that is the `north_star.md` / `compilation_unit_model.md`
+   forbidden shape "the frontend-elaborated instance graph drives compile-time work."
+
+## Consequences
+
+- No classification tool and no module-parameter-as-constructor-input threading are built now. The
+  existing genvar vehicle (`mir::Class.params` / `ParamRef`) is the seam the future work extends.
+- When compile-time sharing across parameter values becomes a turnaround-budget problem, the
+  deferred work is: classify parameters per `specialization_model.md` invariants 2-4; thread the
+  constructor-input axis as runtime parameters by extending the genvar vehicle to module parameters;
+  and source counts from declared dimension expressions instead of the elaborated element count.
+- This decision lives inside the space `specialization_model.md` leaves open -- it over-approximates
+  the key, which the model permits as conservative -- and overrides no `north_star.md` invariant.

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -62,43 +62,13 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       empty today and exists to mark the divergence; it is populated when Stage E (ports) lands --
       ports live on `instance`, never on `gen scope`.
 
-- [ ] R4 -- Store an instance array as a fixed-size array, not a growable vector with a side dim
-      list. Today `Child c[2][3]` lowers to a nested `VectorType` (`std::vector`) and the
-      per-dimension element counts ride as a separate `dims` list on the construct statement; the
-      backend peels that list into nested container loops at render time. The extent is a
-      compile-time constant, so the storage should be a fixed-size array (`std::array`) carrying its
-      extent on each type layer -- a new array type symmetric with `VectorType`, with the count
-      living in the type (one container layer per dimension) rather than in a side list. Each
-      pre-sized slot is then assigned directly, with no grow step. This is the same
-      size-belongs-in-the-type, one-layer-per-dimension shape the unpacked-array decision fixes; the
-      flat dim list is the rejected form. **Why deferred**: the vector form is behaviorally correct
-      and the instance-array feature ships on it; the array-type refinement is contained but not
-      needed for correctness. **Trigger**: when a second fixed-extent object-collection consumer
-      appears.
-
-- [ ] R6 -- Consolidate the "synthesize an expression of canonical type X" helpers that lowerings
-      reach for whenever they need a temporary, sentinel, or computed bound. The HIR -> MIR side
-      already exposes `UnitLoweringState::MakeInt32LiteralExpr(int64)` and has ~8 consumers across
-      the `expression/`, `statement/`, and `deferred_check_cascade` files. The AST -> HIR side has
-      no equivalent public helper: `expression/lower.cpp` carries an anonymous-namespace
-      `MakeIntegerLiteralExpr` that takes a slang `IntegerLiteral&` (no raw-int64 entry point) and
-      an anonymous `MakeRefExpr` for procedural / structural / loop var refs. New consumers that
-      can't see those private helpers (most recently `statement/foreach.cpp`) reroll their own
-      copies inline -- `MakeInt32Constant` + `MakeInt32LiteralExpr` + `MakeProcVarRefExpr` are all
-      sitting in foreach's anonymous namespace today, and similar copies will accumulate at every
-      future desugar site that needs a synthetic counter, sentinel, or width-constant. Target shape:
-      a small set of public helpers on each layer's `UnitLoweringState` mirroring the MIR-side
-      `MakeInt32LiteralExpr` -- minimally a raw-int64 int32 literal expr builder, a bool literal
-      expr builder, and ref-expr builders for the three var families -- with the `IntegralConstant`
-      construction (the masked-word layout) factored into a single function rather than copy-pasted
-      at every site. **Why deferred**: foreach's local helpers are correct, scoped to one TU, and
-      shipping them inline kept the immediate PR focused. The duplication only becomes painful when
-      the next consumer arrives. **Trigger**: when a second AST -> HIR lowering needs a raw-int64
-      int32 literal expr (or a synthetic ProceduralVarRef expr), at which point the per-consumer
-      copy is the smell that forces extraction. Related to R1, which is the further move of
-      promoting the canonical `Builtins` table and these helpers from the lowering-state scope to
-      the IR (`mir::CompilationUnit` and the AST -> HIR analogue) -- R6 is the prerequisite cleanup;
-      R1 is the architectural promotion.
+- [x] R6 -- The synthetic-expression builders an AST-to-HIR lowering reaches for (a counter,
+      sentinel, or computed bound) are public, pure, and have one definition each. A raw-int64
+      `int`-typed literal builder folds the masked-word `IntegralConstant` layout into a single
+      function, and one generic reference-expression builder wraps any named-value reference primary
+      (procedural / structural / loop var) -- the three families build through the one builder
+      rather than a per-file copy. A bool-literal builder was not added: no lowering synthesizes
+      one, and surface without a consumer is not introduced.
 
 - [x] R7 -- The literal conversion keeps its faithful shape in MIR; constant folding is the
       downstream optimizer's job, not HIR-to-MIR's. A conversion of an integer literal to a
@@ -348,18 +318,15 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       `foreach` iterates them -- `foreach` over a fixed array uses its declared range and direction,
       not a count, so that split is a real semantic difference, not the same redundancy).
 
-- [ ] R25 -- Two families still do not fit the generic `(receiver).name(args)` member-call rule and
-      need their own lowering decision: enum type-static methods (no receiver -- the qualifier is
-      part of the symbol identity, surfaced as a static-callee arm) and the value-static
-      `$isunknown` query (type-static in the all-2-state case, constant-folded). The cross-cutting
-      value-model decision is settled: an SV-facing runtime method's return and parameter types are
-      the SV value types, the representation bridge lives inside the method body (an internal detail
-      of the value layer), and the backend reads the call's stated result type and emits it
-      mechanically. The integral-query surface and integral-argument surface flow through SV value
-      types directly; the member-shaped families (string, array, queue, associative including
-      traversal, enum instance) render through one generic handler; user calls carry `self` and
-      event trigger / triggered carry the engine handle as real arguments. **Trigger**: continuation
-      of `decisions/runtime-effects-as-generic-calls.md`.
+- [x] R25 -- The two families that do not take a value receiver fit the same generic builtin-call
+      identity as every member-shaped call. An enum type-static method (`first` / `last` / `num`,
+      where the type qualifier is part of the symbol identity) lowers to the static-callee arm with
+      the qualifier on the callee and no receiver in the arguments; the value-static `$isunknown`
+      lowers to an ordinary builtin call returning the SV `bit` type, with no host-bool lift at the
+      backend. The member-shaped families (string, array, queue, associative including traversal,
+      enum instance) render through the one generic handler. Subsumed by R29
+      (`decisions/builtin-call-identity.md`). The all-2-state constant-fold of `$isunknown` is left
+      to the downstream optimizer per R7, not folded at HIR-to-MIR.
 
 - [x] R26 -- Runtime container protocols are pinned as explicit C++20 concepts in a single
       value-layer concept header; each container `static_assert`s every protocol it satisfies. Slice

--- a/include/lyra/hir/expr_builders.hpp
+++ b/include/lyra/hir/expr_builders.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
 #include <cstdint>
+#include <utility>
 
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/integral_constant.hpp"
 #include "lyra/hir/primary.hpp"
-#include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/type_id.hpp"
-#include "lyra/hir/value_ref.hpp"
 
 // Pure builders for the synthetic HIR expressions a lowering reaches for
 // whenever it needs a counter, bound, or sentinel -- stateless, unlike the
@@ -39,13 +38,13 @@ namespace lyra::hir {
       .span = span};
 }
 
-// A reference to a procedural variable.
-[[nodiscard]] inline auto MakeProcVarRefExpr(
-    ProceduralVarId var, TypeId type, diag::SourceSpan span) -> Expr {
+// Wraps a named-value reference primary (a procedural, structural, or loop-var
+// reference) as an Expr. The caller builds the specific primary; one builder
+// serves every reference family.
+[[nodiscard]] inline auto MakeRefExpr(
+    Primary ref, TypeId type, diag::SourceSpan span) -> Expr {
   return Expr{
-      .type = type,
-      .data = PrimaryExpr{.data = ProceduralVarRef{.var = var}},
-      .span = span};
+      .type = type, .data = PrimaryExpr{.data = std::move(ref)}, .span = span};
 }
 
 }  // namespace lyra::hir

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -23,8 +23,7 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
-#include "lyra/diag/kind.hpp"
-#include "lyra/hir/primary.hpp"
+#include "lyra/hir/expr_builders.hpp"
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/ast_to_hir/constant_value.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
@@ -32,17 +31,6 @@
 namespace lyra::lowering::ast_to_hir {
 
 namespace {
-
-// HIR primitive constructor used by every named-value reference. Local to the
-// references subsystem (no other consumer); other subsystems do not need it.
-auto MakeRefExpr(hir::Primary ref, hir::TypeId type, diag::SourceSpan span)
-    -> hir::Expr {
-  return hir::Expr{
-      .type = type,
-      .data = hir::PrimaryExpr{.data = std::move(ref)},
-      .span = span,
-  };
-}
 
 auto MakeEnumValueExpr(
     const slang::ast::EnumValueSymbol& sym, hir::TypeId type,
@@ -81,7 +69,7 @@ auto LowerNamedValueProc(
             "LowerNamedValueProc: loop-var binding home frame is not on the "
             "current scope stack");
       }
-      return MakeRefExpr(
+      return hir::MakeRefExpr(
           hir::LoopVarRef{.hops = *hops, .loop_var = loop_binding->loop_var_id},
           loop_binding->type, span);
     }
@@ -121,7 +109,8 @@ auto LowerNamedValueProc(
     }
     const hir::TypeId type_id =
         frame.current_procedural_body->procedural_vars.Get(*local).type;
-    return MakeRefExpr(hir::ProceduralVarRef{.var = *local}, type_id, span);
+    return hir::MakeRefExpr(
+        hir::ProceduralVarRef{.var = *local}, type_id, span);
   }
 
   const auto binding = module.LookupStructuralVarBinding(var);
@@ -135,7 +124,7 @@ auto LowerNamedValueProc(
         "LowerNamedValueProc: variable home frame is not on the current scope "
         "stack");
   }
-  return MakeRefExpr(
+  return hir::MakeRefExpr(
       hir::StructuralVarRef{.hops = *hops, .var = binding->var_id},
       binding->type, span);
 }
@@ -299,7 +288,7 @@ auto LowerNamedValueStructural(
             "LowerNamedValueStructural: loop-var binding home frame is not on "
             "the current scope stack");
       }
-      return MakeRefExpr(
+      return hir::MakeRefExpr(
           hir::LoopVarRef{.hops = *hops, .loop_var = loop_binding->loop_var_id},
           loop_binding->type, span);
     }
@@ -328,7 +317,7 @@ auto LowerNamedValueStructural(
         "LowerNamedValueStructural: variable home frame is not on the current "
         "scope stack");
   }
-  return MakeRefExpr(
+  return hir::MakeRefExpr(
       hir::StructuralVarRef{.hops = *hops, .var = binding->var_id},
       binding->type, span);
 }

--- a/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/foreach.cpp
@@ -18,6 +18,7 @@
 #include "lyra/hir/inc_dec_op.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
+#include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 
@@ -105,16 +106,18 @@ auto BuildIntegerLevel(
             .data = hir::VarDeclStmt{.var = last_var, .init = last_value_id},
             .span = span}));
     first_id = frame.Exprs().Add(hir::MakeInt32Literal(0, int32_type, span));
-    last_id =
-        frame.Exprs().Add(hir::MakeProcVarRefExpr(last_var, int32_type, span));
+    last_id = frame.Exprs().Add(
+        hir::MakeRefExpr(
+            hir::ProceduralVarRef{.var = last_var}, int32_type, span));
   }
 
   const hir::ProceduralVarId loop_var =
       proc.AddProceduralVar(body, *dim.loopVar, int32_type);
   std::vector<hir::ForInit> init;
   init.emplace_back(hir::ForInitDecl{.var = loop_var, .init = first_id});
-  const hir::ExprId cond_ref =
-      frame.Exprs().Add(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
+  const hir::ExprId cond_ref = frame.Exprs().Add(
+      hir::MakeRefExpr(
+          hir::ProceduralVarRef{.var = loop_var}, int32_type, span));
   const hir::ExprId cond_id = frame.Exprs().Add(
       hir::Expr{
           .type = int32_type,
@@ -125,8 +128,9 @@ auto BuildIntegerLevel(
                   .lhs = cond_ref,
                   .rhs = last_id},
           .span = span});
-  const hir::ExprId step_ref =
-      frame.Exprs().Add(hir::MakeProcVarRefExpr(loop_var, int32_type, span));
+  const hir::ExprId step_ref = frame.Exprs().Add(
+      hir::MakeRefExpr(
+          hir::ProceduralVarRef{.var = loop_var}, int32_type, span));
   const hir::ExprId step_id = frame.Exprs().Add(
       hir::Expr{
           .type = int32_type,
@@ -175,8 +179,9 @@ auto BuildAssociativeLevel(
           .lifetime = hir::VariableLifetime::kAutomatic});
 
   auto walk_call = [&](support::BuiltinFn method) -> hir::ExprId {
-    const hir::ExprId key_ref =
-        frame.Exprs().Add(hir::MakeProcVarRefExpr(key_var, key_type, span));
+    const hir::ExprId key_ref = frame.Exprs().Add(
+        hir::MakeRefExpr(
+            hir::ProceduralVarRef{.var = key_var}, key_type, span));
     return frame.Exprs().Add(
         hir::Expr{
             .type = int32_type,
@@ -192,10 +197,12 @@ auto BuildAssociativeLevel(
   init.emplace_back(
       hir::ForInitDecl{
           .var = more_var, .init = walk_call(support::BuiltinFn::kAssocFirst)});
-  const hir::ExprId cond_id =
-      frame.Exprs().Add(hir::MakeProcVarRefExpr(more_var, int32_type, span));
-  const hir::ExprId more_lhs =
-      frame.Exprs().Add(hir::MakeProcVarRefExpr(more_var, int32_type, span));
+  const hir::ExprId cond_id = frame.Exprs().Add(
+      hir::MakeRefExpr(
+          hir::ProceduralVarRef{.var = more_var}, int32_type, span));
+  const hir::ExprId more_lhs = frame.Exprs().Add(
+      hir::MakeRefExpr(
+          hir::ProceduralVarRef{.var = more_var}, int32_type, span));
   const hir::ExprId step_id = frame.Exprs().Add(
       hir::Expr{
           .type = int32_type,
@@ -286,7 +293,9 @@ auto BuildForeachNest(
       return std::unexpected(std::move(inner_hir_type.error()));
     }
     const hir::ExprId index_id = frame.Exprs().Add(
-        hir::MakeProcVarRefExpr(loop.loop_var, loop.loop_var_type, span));
+        hir::MakeRefExpr(
+            hir::ProceduralVarRef{.var = loop.loop_var}, loop.loop_var_type,
+            span));
     inner_array = frame.Exprs().Add(
         hir::Expr{
             .type = *inner_hir_type,


### PR DESCRIPTION
## Summary

AST-to-HIR built reference expressions (a read of a procedural, structural, or loop variable) two different ways: a public proc-only `MakeProcVarRefExpr` in the HIR builder header, and a private generic `MakeRefExpr` local to the references subsystem. This unifies them on one public generic builder that wraps any named-value reference primary, so the three variable families build through a single definition; both `foreach` and the named-value reference lowering route through it. This is the remaining piece of refactor item R6 -- the raw-int64 int32-literal builder and the masked-word `IntegralConstant` factoring already landed -- and a bool-literal builder was deliberately not added, since no lowering synthesizes one. Pure helper consolidation, no behavior change.

## Decision

While scoping refactor item R4 (store an instance array as a fixed-size array with its extent in the type), the specialization and runtime models showed that R4 conflicts with the architecture: an instance-array or generate-for count is a constructor input -- the unit compiles once for any N -- so baking the extent into the type would fork the compiled artifact per value. R4 is removed rather than implemented. The accompanying decision doc records the deliberate stance for now: treat every parameter as code-shape-affecting, a conservative over-approximation that is always correct and stays per-specialization, never per-instance. It pins the two constraints that keep the door open to the eventual constructor-input model -- storage stays the runtime-sized vector wrapper, never extent-in-the-type, and consumption of slang's elaborated instance graph is not widened. R25 is also marked done (its two families were subsumed by R29).

## Testing

`bazel build //...` and `bazel test //...` pass; the touched files report zero diagnostics.
