### PR TITLE
Lift render-conjured operands into explicit MIR primitives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,7 @@ against them.
   - `std::array` over C arrays
   - `std::optional`, `std::expected` for error handling
   - Structured bindings, range-based for loops
-- No block-comment parameter labels at call sites (`/*param=*/value`). IDE inlay hints make them
-  redundant.
+- Comments: follow `docs/code-comments.md` (read pre-plan, pre-write, post-edit).
 
 ## Error Handling
 

--- a/docs/code-comments.md
+++ b/docs/code-comments.md
@@ -1,0 +1,53 @@
+# Code comments
+
+The rules for any comment in `src/` or `include/`. When and how often to re-read this doc is
+specified in `CLAUDE.local.md`.
+
+## The three kinds (Clean Code framing)
+
+- **Why** -- motivation, hidden constraint, non-obvious choice. The code shows what; this explains
+  why. **Write these.**
+- **How** -- short algorithm sketch for a procedure complex enough that line-by-line reading is
+  painful. A summary, not a play-by-play. **Write these when genuinely non-trivial.**
+- **What** -- restates what the code already says. **Forbidden.** The fix is renaming the symbol
+  until the code is self-explanatory, not writing a comment to compensate.
+
+Comments fill what the language cannot express -- intent, context, the algorithm's shape.
+
+## Hard bans
+
+1. **No project-documentation references.** No `docs/` path, no decision-doc / architecture-doc /
+   progress-doc name, no "invariant N", no "see the decision on X". The **LRM** (IEEE 1800
+   SystemVerilog spec) is the one exception -- it is the external spec the code implements, and
+   `LRM 21.3.4.3`-style citations are required for any SV-grounded comment. Why: docs rename and
+   move; back-references rot and lie.
+
+2. **No implementation-name coupling.** A comment that names a sister helper, accessor, or member
+   couples to a rename. State the stable contract instead. Architecture-level vocabulary (a MIR
+   primitive, a runtime type, an LRM concept) is fine; internal helper names are not.
+
+3. **No What-comments restating the code.** Rename the symbol.
+
+4. **No section-separator comments.** `// === X ===`, `// --- title ---`, any region-marker line.
+   Use blank lines.
+
+5. **No migration / progress narration.** `// Cut 1`, `// migrated in phase 3`,
+   `// later cuts will extend this`. Source comments are timeless; progress lives in
+   `docs/progress/`, in PRs, and in conversation.
+
+6. **No `/*param=*/value` at call sites.** IDE inlay hints do this.
+
+7. **No inline comments on struct fields or variable declarations.** Put the comment on the line
+   above.
+
+## Litmus checklist
+
+Run per comment before keeping it:
+
+1. **Cite check** -- names any project doc, decision-doc, architecture-doc, progress-doc, or
+   "invariant N"? Cut. (LRM is the only exception.)
+2. **Rename check** -- would renaming any sister symbol named in this comment force an edit? Cut the
+   name; rewrite to the stable contract.
+3. **Why/How check** -- is this Why, How, or LRM citation? If none, it is a What. Cut and rename the
+   symbol so the code self-explains.
+4. **Drift check** -- does the comment still match the code as it stands now? Update or cut.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -62,6 +62,9 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
 - [builtin-call-identity](builtin-call-identity.md) -- built-in method calls carry a flat
   closed-namespace identifier (`support::BuiltinFn`) shared between HIR and MIR; per-family enum
   splits are out.
+- [address-of-primitive](address-of-primitive.md) -- MIR carries an explicit place-to-pointer
+  operator (`AddressOfExpr`), dual to `DerefExpr`. Runtime APIs taking pointers receive an explicit
+  address-taken operand; the backend never injects `&`.
 - [event-control-unification](event-control-unification.md) -- unified treatment of event control.
 
 ### References and construction

--- a/docs/decisions/address-of-primitive.md
+++ b/docs/decisions/address-of-primitive.md
@@ -1,0 +1,134 @@
+# Address-of primitive in MIR
+
+Date: 2026-06-23 Status: accepted
+
+## Context
+
+MIR has long carried `DerefExpr` (pointer -> place) but no operator for the dual direction (place ->
+pointer). The shape that filled the gap was render-time injection: the C++ backend, on seeing a
+runtime call whose signature takes a pointer (`RegisterSignal(void*)`,
+`WaitAny({Observable*, ...})`), looked at the call's argument, recognised it was a
+`MemberAccessExpr`, and prepended `&`. For an `ExternalRef` member the same render switched to
+`<member>.AsObservable()`. The choice of shape lived in render; MIR's argument vector was a bare
+`MemberAccessExpr` in every case.
+
+This violates `mir.md` invariant 10 (a backend never re-derives a fact MIR did not state). The
+violation is masked in the C++ backend because C++ has the `&` operator and reference-parameter
+auto-binding. Any other backend has to redo the same reasoning -- LLVM IR has no C++ reference sugar
+and would, given the same MIR, independently decide to take the address.
+
+## Decision
+
+**MIR grows `AddressOfExpr` as the dual of `DerefExpr`.** A single-operand node that takes a place
+expression and yields a borrowed pointer to that storage:
+
+```text
+AddressOfExpr { operand: ExprId }
+type: PointerType { pointee = operand.type, ownership = kBorrowed }
+```
+
+The operand must be an addressable place (`LocalRef`, `MemberAccess`, `DerefExpr`, or any
+place-producing access primitive). Value expressions are not addressable; the verifier rejects them.
+
+Two HIR-to-MIR lowering sites are immediately reshaped to use the new primitive:
+
+1. **`kRegisterSignal`** -- the second argument is wrapped in `AddressOfExpr` at lowering time. The
+   render path stops prepending `&`.
+
+2. **Sensitivity wait leaves** -- the leaf carries an explicit observable-pointer expression chosen
+   by lowering, one of three shapes by the leaf's MIR type:
+   - Plain value member (`ObservableType<T>`): `AddressOfExpr(MemberAccess(self, member))`.
+   - Borrowed-pointer slot (`PointerType{kBorrowed}`, the cross-unit-ref case): bare `MemberAccess`
+     -- the slot already holds the pointer.
+   - `ExternalRefType` member: `CallExpr(BuiltinFn::kAsObservable, [MemberAccess(self, member)])` --
+     the runtime resolves the upward reference to its current observable.
+
+The render-side type-kind dispatch (`RenderSensitivityRefPtr`) disappears. Render walks the
+expression tree the lowering already shaped.
+
+### Canonicalization
+
+`AddressOf(Deref(p))` collapses to `p` -- mechanically applied by each backend's lowering of
+`AddressOfExpr`. The C++ backend skips the `&(*p)` round-trip and emits `p` directly. LLVM backends
+drop the round-trip the same way.
+
+### Borrow kind
+
+Lyra has no borrow checker and no source-level aliasing or lifetime system. `AddressOfExpr` does not
+encode a shared / mutable distinction today. The runtime ABI takes `Observable*` and the distinction
+would have no consumer. If a later borrow / lifetime system arrives, the node can grow a
+`BorrowKind` field without callers having to migrate; until then the absence is principled, not
+provisional.
+
+## Rejected alternatives
+
+### A. "Runtime takes references instead of pointers; no AddressOf needed"
+
+Initially preferred. The runtime API changes from `RegisterSignal(name, void*)` to
+`RegisterSignal(name, Observable&)`. The render emits a bare `MemberAccess`; C++ auto-binds the
+reference parameter; for cases where the runtime stores the address internally
+(`SubscriptionRequest` in an array passed to `WaitAny`), a wrapper struct's constructor takes
+`Observable&` and stores `&observable` in a private field. No render-side `&`, no MIR-level
+operation.
+
+Rejected because the address-taking is not eliminated; it is hidden inside C++ language sugar
+(reference parameter binding). The LIR -> LLVM backend has no reference sugar to hide behind: it
+must (1) recognise that the runtime ABI takes a pointer-shaped parameter, (2) treat the
+`MemberAccess` argument as a place, and (3) emit the address-taking lowering. That is exactly the
+"every backend re-derives the same fact" failure invariant 10 calls out. Position A is clean only in
+the C++ backend's spelling; the underlying violation is unchanged and propagates to every future
+backend.
+
+### B. "Python / TypeScript don't have AddressOf, so MIR shouldn't either"
+
+The original framing. Rejected because Python / TS lack AddressOf as a consequence of having no
+notion of memory locations at all -- variables bind to heap values, there is no place model. MIR is
+not in that family. MIR already carries `PointerType { kBorrowed }`, `DerefExpr`, `self : M*`, and
+`MemberAccess` as a place primitive. The closer reference class is Rust MIR (which has the
+`Rvalue::Ref` / borrow operator) and LLVM IR (which does not need a separate operator only because
+every variable is already an `alloca` -- effectively pre-typed as pointer). Both languages that
+share MIR's value model state the place-to-pointer conversion explicitly.
+
+### C. Generic conversion node (extend `ConversionExpr` to cover place-to-pointer)
+
+Considered briefly. Rejected because `ConversionExpr` models value-to-value translations (numeric,
+signedness, width). A place-to-pointer step is structurally distinct -- it changes the expression's
+category (place -> value of pointer type), not just its numeric encoding. Folding both into one node
+forces every consumer to disambiguate per case; keeping them as separate node kinds keeps the
+structural fact explicit.
+
+## Consequences
+
+- Both backends consume the same MIR; neither runs a "is this argument a place that needs its
+  address taken" analysis. The C++ render emits `&place` (or skips the round-trip via the
+  canonicalization); the LIR / LLVM backend emits a GEP-style pointer computation. Both reach the
+  same emitted shape mechanically.
+
+- The sensitivity-leaf type-kind switch (`RenderSensitivityRefPtr`) is gone. The three
+  observable-pointer shapes (`AddressOf(MemberAccess)`, bare `MemberAccess`,
+  `Call(kAsObservable, ...)`) are chosen at lowering, stored as an `ExprId` on `SensitivityRead`,
+  and rendered through the ordinary expression path.
+
+- A future audit of the `RuntimeNavCallee::kGetSignal` `void*` -> `static_cast<Var<T>*>` injection
+  is now scoped: the right fix is to make the runtime API return the typed pointer (eliminating the
+  cast), not to grow a generic `CastExpr` primitive in MIR. The principle the engineer flagged --
+  avoid `void*` at the MIR/runtime boundary because it forces every backend to re-derive the cast --
+  is the same one this decision rests on.
+
+- Render-side scaffolding that produces an entire C++ method declaration as a string template (e.g.
+  `TimePrecisionPower()` virtual override) stays "C++ plumbing" under
+  `decisions/callable-receiver.md`'s precedent. The sharpened boundary: plumbing is allowed only
+  when it does not change the semantic shape of any MIR operand and does not require the backend to
+  derive a new value-level operation. The `&` injection failed both tests; class-layout boilerplate
+  that mechanically materialises an already-MIR-stated fact does not.
+
+## Cross-references
+
+- `architecture/mir.md` invariant 10 (a backend never re-derives a fact MIR did not state) and the
+  closed-primitive-set property (the set grows only for a genuinely new generic-language concept).
+- `decisions/value-type-concepts.md` (the parallel lift of `Var<T>::Get` / `Set` / `Mutate` from
+  implicit render to explicit MIR `CallExpr` -- same family of fix on a different axis).
+- `decisions/callable-receiver.md` (the "C++ plumbing, not MIR-modeled" precedent for virtual
+  overrides, sharpened above).
+- `progress/refactor.md` R41 / R42 (the entries this decision closes by lowering the
+  sensitivity-leaf and signal-registration paths to MIR-explicit shape).

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -456,10 +456,12 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
           `BuiltinFnCallee` method on `files` (`files.Open`, `files.Close`, `files.Read`, ...).
           Runtime free-function `Lyra*` entries retire; the methods are the only surface.
   - Engine forwarders on `services`:
-    - [ ] `$time` / `$stime` / `$realtime`: read engine state through services methods.
-    - [ ] `$finish` / `$exit` / `$stop`: engine-side control through services methods (today the
-          control flow goes through an await-shape; that stays, the callee identity is what
-          changes).
+    - [x] `$time` / `$stime` / `$realtime`: each lowers to a `FreeFnCallee` against the matching
+          runtime entry with the engine handle and the calling scope's unit power as ordinary
+          operands.
+    - [x] `$finish` / `$exit` / `$stop`: `$finish` is on the same `FreeFnCallee` shape; the
+          await-suspension wrapping is unchanged. `$exit` / `$stop` are not yet wired and pick up
+          the shape when they land.
     - [ ] `$timeformat` / `$printtimescale`: state setter / formatted-print compositions through
           services + files in the same shape as print.
 
@@ -471,6 +473,85 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       `services`" is consistent everywhere except Format; this entry closes the exception.
       **Trigger**: after R37 lands and the value-layer free-function surface is the established
       pattern.
+
+- [ ] R39 -- Lift the implicit `Ref<T>` access into explicit MIR calls. R12 / the
+      value-type-concepts cut lifted observable-cell reads / writes / mutations into explicit
+      `BuiltinFnCallee` (`kGet` / `kSet` / `kMutate`) calls at HIR-to-MIR so the backend renders
+      them mechanically. The sibling axis -- a procedural `ref` / `const ref` formal (LRM 13.5.2),
+      whose binding kind is `ParamDirection::kRef` / `kConstRef` and whose MIR type is `RefType{T}`
+      -- is still implicit: a read of such a local is silently rendered with a `.Get()` suffix, and
+      a whole-cell write through one conjures an engine handle argument the MIR call does not carry.
+      Both are `mir.md` invariant 10 violations of the same shape the observable axis just resolved.
+      Apply the same lift: HIR-to-MIR emits `BuiltinFnCallee{kRefGet}` / `BuiltinFnCallee{kRefSet}`
+      whose argument vector is complete (services included). Compound / partial writes through a ref
+      formal become well-defined in the same step (today the render path bails). See
+      `decisions/value-type-concepts.md` for the pattern this generalizes.
+
+- [ ] R40 -- Retire the construct- / control-stmt shapes that the backend completes from outside
+      MIR. `ForkStmt`, `ConstructOwnedObjectStmt`, and `ConstructExternalUnitStmt` each name a
+      runtime entry the render path looks up by stmt kind and string-injects a `self->Services()`
+      argument the MIR did not state. `ConstructOwnedObjectStmt` additionally emits a companion
+      `RegisterChild` call after the construction -- a runtime mutation that exists nowhere in MIR.
+      `DelayStmt` has already retired this way: `#N` now lowers to `AwaitStmt` over a
+      `FreeFnCallee{kDelay}` call whose argument vector states services, the literal duration, and
+      the calling scope's precision power. Apply the same frame to the remaining three: each stmt
+      decomposes to `AwaitStmt` plus a generic `CallExpr` (or a sequence of them) whose argument
+      vector is complete; services flows as an explicit operand; companion runtime registrations are
+      MIR statements of their own. The stmt-kind-as-runtime-entry-tag layer disappears; the
+      constructor receiver pattern aligns with `decisions/callable-receiver.md`.
+
+- [x] R41 -- Push the sensitivity-leaf subscription target into MIR. Each `SensitivityRead` carries
+      an explicit observable-pointer expression chosen at HIR-to-MIR: an `AddressOf` of the cell
+      member, a bare borrowed-pointer slot, or a `Call(kAsObservable, ...)` for an upward reference.
+      The render-side type-kind dispatch is gone. Address-of itself was lifted to MIR via the new
+      primitive (see `decisions/address-of-primitive.md`).
+
+- [x] R42 -- Retired `RuntimeNavCallee`. The three by-name scope operations (`kRegisterSignal` /
+      `kGetSignal` / `kGetChild`) now ride `BuiltinFnCallee` with the signal / child name as a
+      regular `StringLiteral` argument and the index list as an `ArrayLiteralExpr`. The `kGetSignal`
+      cast is lifted to a new MIR `PointerCastExpr` primitive whose destination type is the call
+      site's slot type; the backend emits `static_cast<T>(...)` mechanically from a stated MIR fact.
+      The `kGetChild` index conversion moved into the runtime (which now accepts
+      `std::span<const value::PackedArray>` and calls `.ToInt64()` itself), so the render side has
+      no `.ToInt64()` injection and no `std::array{...}` wrapper. Every call -- regardless of callee
+      variant -- now renders as `fn(rendered_args...)`.
+
+- [x] R43 -- Replace the constructor-of-pointer fallback. The expression set grew a `NullLiteral`
+      primitive that the default-value lowering emits directly for borrowed-pointer members; the
+      `ConstructorCallee` render path no longer pattern-matches on empty-args-against-pointer.
+
+- [x] R44 -- Swept the pre-existing code-comment doc-reference violations alongside the policy
+      landing. Every comment in `src/` and `include/` now states the code's own contract; no
+      `docs/`, decision-doc name, or "invariant N" back-references remain.
+
+- [ ] R45 -- Unify MIR's call shape. Today `mir::Callee` is a 7-arm `std::variant`
+      (`SystemSubroutineCallee` / `MethodRef` / `BuiltinFnCallee` / `BuiltinStaticCallee` /
+      `FreeFnCallee` / `ClosureRef` / `ConstructorCallee`); four of those arms (System / Method /
+      Builtin / BuiltinStatic / FreeFn -- 5 actually) are sub-categorizations of the same structural
+      concept "a direct call to a named symbol", differing only in C++ rendering convention. The
+      `mir.md` identity ("a generic programming-language IR") admits three call shapes: direct
+      (named symbol), indirect (computed callable, currently `ClosureRef`), and type-driven
+      (constructor of the result type, currently `ConstructorCallee`). The 5-way splintering is SV
+      organizational scheme leaking into MIR -- a real architectural mismatch. Target:
+      `Callee = variant<Direct{symbol}, Indirect{expr},     Constructor{}>`; per-symbol metadata
+      (instance-method-form, namespace path, qualifier) moves into a backend-side table extending
+      today's `BuiltinFnCppName`. Each backend reads the symbol id and consults its own table --
+      LLVM doesn't consult at all, since `call     @symbol(args)` has no method/free distinction.
+      **Blocker**: R37 still in flight retiring `SystemSubroutineCallee`; do that first so the
+      call-shape unification sees the final set of named-symbol callees.
+
+- [ ] R46 -- Unify `ConversionExpr` and `PointerCastExpr` into one `CastExpr { operand, kind }`.
+      Both primitives produce a value of a different type from their operand; both render as
+      `static_cast<DestType>(operand)` in the C++ backend; both lower to a cast-family instruction
+      in LLVM (`zext` / `sext` / `bitcast` / ...). The split is conceptual ("ConversionExpr is
+      LRM-defined value conversion, PointerCastExpr is backend type-erasure bridge") but the
+      emission shape is identical -- Clang AST and Rust MIR both consolidate this into one cast
+      primitive with a kind axis. Today's `ConversionKind` has 5 LRM-specific kinds (`kImplicit` /
+      `kPropagated` / `kStreamingConcat` / `kExplicit` / `kBitstreamCast`); the unified kind axis
+      would add `kPointerReinterpret` (and likely future `kIntToInt`, `kFloatToInt` etc. as the LIR
+      / LLVM backend appears and needs explicit kinds for the cast-family instruction selection).
+      **Trigger**: when the LIR backend wants explicit cast kinds for instruction selection, or when
+      a third cast-like primitive is about to be added (whichever comes first).
 
 ## Out of Scope
 

--- a/include/lyra/backend/cpp/render_expr.hpp
+++ b/include/lyra/backend/cpp/render_expr.hpp
@@ -11,11 +11,6 @@ namespace lyra::backend::cpp {
 auto RenderExpr(const ScopeView& view, const mir::Expr& expr)
     -> diag::Result<std::string>;
 
-// Bare field name (no `.Get()` wrap) for callsites that need the Var place
-// itself rather than its value, e.g. the trigger pointers inside `WaitAny`.
-auto RenderMemberName(const ScopeView& view, const mir::MemberRef& ref)
-    -> diag::Result<std::string>;
-
 // Renders `expr` as an lvalue: bare root + element / range select suffixes.
 // Throws InternalError on non-addressable forms. The cell's `Mutate(svc)`
 // adapter (if any) is encoded explicitly in MIR as a

--- a/include/lyra/backend/cpp/scope_view.hpp
+++ b/include/lyra/backend/cpp/scope_view.hpp
@@ -11,17 +11,15 @@
 
 namespace lyra::backend::cpp {
 
-// The rendering fold's walk position
-// (docs/architecture/lowering_organization.md "The Walk Position"). The
-// MIR-to-C++ emit is a fold, not a construction pass: it accumulates nothing
-// and owns no output, so this carries only what reading a node needs -- the
-// unit (for type and arena lookups) and the chain of enclosing scopes. A
-// hops-relative reference resolves by climbing that chain, exactly as the
-// construction-side `WalkFrame` resolves it; this is the read-only twin of that
-// frame, thin because every decision is already baked into the MIR it reads.
-// Immutable and copied on descent (`WithBlock` /
-// `WithClass`); it grows no member per concept, so it is not the
-// forbidden growing `*Context`.
+// The rendering fold's walk position. The MIR-to-C++ emit is a fold, not a
+// construction pass: it accumulates nothing and owns no output, so this
+// carries only what reading a node needs -- the unit (for type and arena
+// lookups) and the chain of enclosing scopes. A hops-relative reference
+// resolves by climbing that chain, exactly as the construction-side
+// `WalkFrame` resolves it; this is the read-only twin of that frame, thin
+// because every decision is already baked into the MIR it reads. Immutable
+// and copied on descent (`WithBlock` / `WithClass`); it grows no member per
+// concept, so it is not the forbidden growing `*Context`.
 class ScopeView {
  public:
   static auto ForRoot(

--- a/include/lyra/backend/cpp/string_literal.hpp
+++ b/include/lyra/backend/cpp/string_literal.hpp
@@ -6,9 +6,9 @@
 namespace lyra::backend::cpp {
 
 // Render a string as a C string literal: `"..."` with control characters,
-// quotes, and backslashes escaped. This is how a `mir::StringLiteral` renders
-// -- a software string literal -- which a `ConstructorCallee` then turns into a
-// `value::String` (see decisions/string-packed-conversion.md).
+// quotes, and backslashes escaped. This is how a `mir::StringLiteral`
+// renders -- a software string literal -- which a `ConstructorCallee` then
+// turns into a `value::String`.
 auto RenderCStringLiteral(std::string_view s) -> std::string;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/driver/runtime_export.hpp
+++ b/include/lyra/driver/runtime_export.hpp
@@ -15,10 +15,10 @@ struct RuntimeLocation {
   std::filesystem::path lib;
 };
 
-// Locate the Lyra C++ runtime for the binary at `binary_path`. Resolution is a
-// single seam (see docs/architecture/runtime_distribution.md): today it reads
-// the binary's Bazel runfiles tree; a released binary will resolve relative to
-// its own install location. Callers depend only on the returned paths.
+// Locate the Lyra C++ runtime for the binary at `binary_path`. Resolution is
+// a single seam: today it reads the binary's Bazel runfiles tree; a released
+// binary will resolve relative to its own install location. Callers depend
+// only on the returned paths.
 auto ResolveRuntimeLocation(std::string_view binary_path)
     -> std::expected<RuntimeLocation, std::string>;
 

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -57,15 +57,14 @@ using PathStep = std::variant<MemberHop, IndexHop>;
 // Where a cross-unit reference starts its navigation. A downward reference
 // reaches into an owned child the referrer's own scope declares -- an
 // instance/instance-array member, or a generate block (LRM 27) identified by
-// its position in the scope. Both resolve to one owned-child companion var at
-// construction, so the navigation past the head is identical. An upward
-// reference (LRM 23.6) climbs the parent chain at construction to the nearest
-// matching ancestor named `ancestor_name`; from there both directions share
-// `path` to reach the leaf, by name across the unit boundary -- the referrer
-// never names the ancestor's unit type, which it does not depend on
-// (docs/architecture/emission_model.md). The child cannot know its depth at
-// compile time, so it locates the ancestor by name rather than a baked-in
-// offset.
+// its position in the scope. Both resolve to one owned-child companion var
+// at construction, so the navigation past the head is identical. An upward
+// reference (LRM 23.6) climbs the parent chain at construction to the
+// nearest matching ancestor named `ancestor_name`; from there both
+// directions share `path` to reach the leaf, by name across the unit
+// boundary -- the referrer never names the ancestor's unit type, which it
+// does not depend on. The child cannot know its depth at compile time, so it
+// locates the ancestor by name rather than a baked-in offset.
 struct GenerateChildRef {
   GenerateId generate;
   StructuralScopeId scope;
@@ -90,11 +89,11 @@ struct UpwardHead {
 };
 using CrossUnitRefHead = std::variant<DownwardHead, UpwardHead>;
 
-// A cross-unit reference resolved once at construction (see
-// reference_resolution.md). `head` is where navigation starts; `path` carries
-// the shared navigation from the head down to the referenced leaf, by name
-// across the unit boundary; `type` is the slang-resolved leaf type. The slot is
-// read / written / observed through one stored direct reference.
+// A cross-unit reference resolved once at construction. `head` is where
+// navigation starts; `path` carries the shared navigation from the head down
+// to the referenced leaf, by name across the unit boundary; `type` is the
+// slang-resolved leaf type. The slot is read / written / observed through
+// one stored direct reference.
 struct CrossUnitRefDecl {
   CrossUnitRefHead head;
   std::vector<PathStep> path;

--- a/include/lyra/hir/subroutine_ref.hpp
+++ b/include/lyra/hir/subroutine_ref.hpp
@@ -24,8 +24,8 @@ struct SystemSubroutineRef {
 
 // Calls a built-in runtime method (LRM 6.16 string, 6.19.5 enum, 7.9
 // associative, 7.10 queue, 7.12 unpacked-array shared family, 15.5 named
-// event). The id is the flat closed namespace `support::BuiltinFn`,
-// shared with MIR (see `docs/decisions/builtin-call-identity.md`).
+// event). The id is the flat closed namespace `support::BuiltinFn`, shared
+// with MIR.
 struct BuiltinMethodRef {
   support::BuiltinFn method;
 };

--- a/include/lyra/hir/value_ref.hpp
+++ b/include/lyra/hir/value_ref.hpp
@@ -28,7 +28,7 @@ struct CrossUnitRefId {
 // A reference whose target lives in another compilation unit (a child
 // instance's member). Resolved once at construction into a stored direct
 // reference; the navigation recipe lives in the enclosing scope's
-// `cross_unit_refs` table keyed by this id (see reference_resolution.md).
+// `cross_unit_refs` table keyed by this id.
 struct CrossUnitVarRef {
   CrossUnitRefId id;
 

--- a/include/lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp
@@ -18,12 +18,12 @@ class ModuleLowerer;
 // lowering: recurse into a sub-expression and reach the enclosing module. Both
 // `ProcessLowerer` (procedural bodies) and `StructuralScopeLowerer` (structural
 // scopes) satisfy it; the shared per-expression handler templates are
-// constrained on it so the surface they depend on is named and checked rather
-// than surfacing as a deep template error. Sub-expressions are interned through
-// the walk frame's single expression arena, so the lowerer's own surface is
-// only the recursion and the module. It is deliberately not a base class -- the
-// two pass classes build different things and share no v-table
-// (decisions/generic-lowering-machinery.md).
+// constrained on it so the surface they depend on is named and checked
+// rather than surfacing as a deep template error. Sub-expressions are
+// interned through the walk frame's single expression arena, so the
+// lowerer's own surface is only the recursion and the module. It is
+// deliberately not a base class -- the two pass classes build different
+// things and share no v-table.
 template <typename L>
 concept ExprLowerer =
     requires(L& lowerer, const slang::ast::Expression& expr, WalkFrame frame) {

--- a/include/lyra/lowering/ast_to_hir/specialization_name.hpp
+++ b/include/lyra/lowering/ast_to_hir/specialization_name.hpp
@@ -11,13 +11,13 @@ namespace lyra::lowering::ast_to_hir {
 
 // The compiled identity of a module specialization: the module definition name,
 // plus a content hash of its resolved parameter bindings when the module is
-// parameterized (LRM 6.20, 23.10). Instances whose bindings differ get distinct
-// names; instances whose bindings match share slang's one canonical body and so
-// get the same name; a non-parameterized module keeps its definition name. The
-// producer (the unit naming itself) and every consumer (a parent naming a child
-// it instantiates) compute the same name from the same canonical body, so a
-// cross-unit reference matches by name with no shared table. See
-// docs/decisions/specialization-identity.md.
+// parameterized (LRM 6.20, 23.10). Instances whose bindings differ get
+// distinct names; instances whose bindings match share slang's one canonical
+// body and so get the same name; a non-parameterized module keeps its
+// definition name. The producer (the unit naming itself) and every consumer
+// (a parent naming a child it instantiates) compute the same name from the
+// same canonical body, so a cross-unit reference matches by name with no
+// shared table.
 auto SpecializationName(const slang::ast::InstanceBodySymbol& body)
     -> std::string;
 

--- a/include/lyra/lowering/hir_to_mir/class_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/class_lowerer.hpp
@@ -135,12 +135,11 @@ class ClassLowerer {
   // with the slot's MIR type so a body reader can decide whether the read
   // dereferences without re-touching the structural scope.
   struct CrossUnitRefMeta {
-    mir::SensitivityRef target;
+    mir::MemberRef target;
     mir::TypeId slot_type;
   };
 
-  void AddCrossUnitRefTarget(
-      mir::SensitivityRef target, mir::TypeId slot_type) {
+  void AddCrossUnitRefTarget(mir::MemberRef target, mir::TypeId slot_type) {
     cross_unit_ref_targets_.push_back(
         CrossUnitRefMeta{.target = std::move(target), .slot_type = slot_type});
   }

--- a/include/lyra/lowering/hir_to_mir/closure_builder.hpp
+++ b/include/lyra/lowering/hir_to_mir/closure_builder.hpp
@@ -20,25 +20,24 @@ class CompilationUnit;
 
 namespace lyra::lowering::hir_to_mir {
 
-// A closure under construction (closure.md). The constructor opens a fresh body
-// scope with `self` as captures[0] and installs a capture sink, so a read of an
+// A closure under construction. The constructor opens a fresh body scope
+// with `self` as captures[0] and installs a capture sink, so a read of an
 // enclosing variable while lowering the body through `Frame()` becomes a
-// capture (LRM 6.21). A site that authors the body by hand instead of lowering
-// HIR snapshots specific outer expressions with `CaptureByValue`; the two
-// capture paths coexist, and `self` is always first.
+// capture (LRM 6.21). A site that authors the body by hand instead of
+// lowering HIR snapshots specific outer expressions with `CaptureByValue`;
+// the two capture paths coexist, and `self` is always first.
 //
-// `coroutine` selects a fork-branch body (LRM 9.3.2): its `return`s render as
-// `co_return` and the terminal is `BuildCoroutine`. `by_value_depth` is the
-// sink snapshot boundary -- a capture declared at that depth is snapshotted by
-// value, any deeper-enclosing capture aliases the live cell; pass it for a fork
-// branch (block-item locals snapshot) and leave it empty for a synchronous body
-// (every sink capture aliases).
+// `coroutine` selects a fork-branch body (LRM 9.3.2): its `return`s render
+// as `co_return` and the terminal is `BuildCoroutine`. `by_value_depth` is
+// the sink snapshot boundary -- a capture declared at that depth is
+// snapshotted by value, any deeper-enclosing capture aliases the live cell;
+// pass it for a fork branch (block-item locals snapshot) and leave it empty
+// for a synchronous body (every sink capture aliases).
 //
-// A closure is a value; how it is invoked -- an immediately-invoked call
-// (`BuildClosureCallExpr`), a fork spawn, a deferred submit, a with-clause
-// iteration -- is the caller's concern, not the builder's (mir.md).
-// Non-movable: `Frame()` hands out a frame that points into the owned body
-// scope and sink.
+// A closure is a value; how it is invoked -- an immediately-invoked call, a
+// fork spawn, a deferred submit, a with-clause iteration -- is the caller's
+// concern, not the builder's. Non-movable: `Frame()` hands out a frame that
+// points into the owned body scope and sink.
 class ClosureBuilder {
  public:
   ClosureBuilder(

--- a/include/lyra/lowering/hir_to_mir/default_value.hpp
+++ b/include/lyra/lowering/hir_to_mir/default_value.hpp
@@ -33,10 +33,9 @@ namespace lyra::lowering::hir_to_mir {
 // arguments are `[element_default, ArrayLiteralExpr{elements}]`. This is the
 // construction shape every site that produces an array-container value must
 // use: the canonical-default element required by the wrapper's runtime ctor
-// (to seed `element_default_`) is supplied here via `BuildDefaultValueExpr` on
-// the element type, and the elements ride in an `ArrayLiteralExpr` that the
-// renderer emits as `std::array<T, N>{...}`. See
-// `docs/decisions/runtime-shape-and-default-value.md`.
+// is supplied here via `BuildDefaultValueExpr` on the element type, and the
+// elements ride in an `ArrayLiteralExpr` that the renderer emits as
+// `std::array<T, N>{...}`.
 [[nodiscard]] auto BuildArrayConstructionCall(
     const ModuleLowerer& module, WalkFrame frame, mir::TypeId array_type,
     std::vector<mir::ExprId> elements) -> mir::Expr;

--- a/include/lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp
@@ -12,14 +12,13 @@
 namespace lyra::lowering::hir_to_mir {
 
 // The duck-typed contract a pass class fulfils for context-free expression
-// lowering: recurse into a sub-expression (read or lhs context), reach the HIR
-// expression arena, and reach the enclosing module. `ProcessLowerer`
-// (procedural bodies) and `ClassLowerer` (structural scopes) both satisfy it;
-// the shared per-expression handler templates are constrained on it so the
-// surface they depend on is named and checked rather than surfacing as a deep
-// template error. It is deliberately not a base class -- the two pass classes
-// build different things and share no v-table
-// (decisions/generic-lowering-machinery.md).
+// lowering: recurse into a sub-expression (read or lhs context), reach the
+// HIR expression arena, and reach the enclosing module. `ProcessLowerer`
+// (procedural bodies) and `ClassLowerer` (structural scopes) both satisfy
+// it; the shared per-expression handler templates are constrained on it so
+// the surface they depend on is named and checked rather than surfacing as a
+// deep template error. It is deliberately not a base class -- the two pass
+// classes build different things and share no v-table.
 template <typename L>
 concept ExprLowerer =
     requires(L& lowerer, const hir::Expr& expr, WalkFrame frame) {

--- a/include/lyra/lowering/hir_to_mir/expression/system/control.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/system/control.hpp
@@ -19,8 +19,8 @@ namespace lyra::lowering::hir_to_mir {
 // user diagnostic if the level arg is non-literal or out of range.
 auto LowerFinishSystemSubroutineCall(
     const ProcessLowerer& process, const WalkFrame& frame,
-    const hir::CallExpr& call, support::SystemSubroutineId id,
-    std::string_view name, const support::TerminationSystemSubroutineInfo& info,
-    diag::SourceSpan span) -> diag::Result<mir::Expr>;
+    const hir::CallExpr& call, std::string_view name,
+    const support::TerminationSystemSubroutineInfo& info, diag::SourceSpan span)
+    -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/expression/system/time.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/system/time.hpp
@@ -15,7 +15,6 @@ namespace lyra::lowering::hir_to_mir {
 // kind: 64-bit time, 32-bit int, or real.
 auto LowerTimeSystemSubroutineCall(
     const ProcessLowerer& process, const WalkFrame& frame,
-    support::SystemSubroutineId id,
     const support::TimeSystemSubroutineInfo& info) -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
@@ -36,10 +36,9 @@ struct StaticVarBinding {
   mir::MemberId var;
 };
 
-// LRM 13.3.1: a static-lifetime body local is realized as a member on
-// the callable's owner class, so a HIR procedural-var-ref dispatches to a
-// MemberAccess instead of a LocalRef
-// (`docs/decisions/variable-lifetime-storage.md`).
+// LRM 13.3.1: a static-lifetime body local is realized as a member on the
+// callable's owner class, so a HIR procedural-var-ref dispatches to a
+// MemberAccess instead of a LocalRef.
 using ProceduralVarBinding =
     std::variant<AutomaticVarBinding, StaticVarBinding>;
 

--- a/include/lyra/lowering/hir_to_mir/self_ref.hpp
+++ b/include/lyra/lowering/hir_to_mir/self_ref.hpp
@@ -13,12 +13,12 @@ struct MemberRef;
 
 namespace lyra::lowering::hir_to_mir {
 
-// Makes a read of the current body's `self` binding (mir.md invariant 11): a
-// `ProceduralVarRef` whose hop count is the distance from the reading site back
-// to where `self` was declared. The caller adds the returned expression to the
-// scope it is composing. This is the one place the self-read shape lives --
-// every member access, cross-unit deref, closure self-capture, and runtime-
-// effect engine handle starts from it.
+// Makes a read of the current body's `self` binding: a `ProceduralVarRef`
+// whose hop count is the distance from the reading site back to where `self`
+// was declared. The caller adds the returned expression to the scope it is
+// composing. This is the one place the self-read shape lives -- every
+// member access, cross-unit deref, closure self-capture, and runtime-effect
+// engine handle starts from it.
 auto MakeSelfRefExpr(const WalkFrame& frame, mir::TypeId self_ptr_type)
     -> mir::Expr;
 

--- a/include/lyra/lowering/hir_to_mir/sensitivity_wait.hpp
+++ b/include/lyra/lowering/hir_to_mir/sensitivity_wait.hpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/stmt.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -10,11 +11,15 @@ namespace lyra::lowering::hir_to_mir {
 class ClassLowerer;
 
 // Materialises a mir::SensitivityWaitStmt from a HIR sensitivity entry list.
-// Identity-shaped end-to-end (distinct from mir::EventTrigger which carries
-// an expression for explicit `@(...)`). The single point where always_comb /
-// always_latch (LRM 9.2.2.2.1, procedure-attached) and `@*` (LRM 9.4.2.2,
-// TimedStmt-attached) converge onto the same MIR runtime construct.
+// Lowering picks the observable-pointer expression per leaf so the backend
+// renders one stored expression rather than re-deriving the shape from the
+// leaf's type: a plain member becomes an `AddressOf(MemberAccess(...))`; a
+// borrowed-pointer slot (cross-unit referent) is the bare `MemberAccess`; an
+// upward `ExternalRef` member becomes a `Call(kAsObservable, ...)`. The
+// single convergence point for always_comb / always_latch (LRM 9.2.2.2.1)
+// and `@*` (LRM 9.4.2.2).
 auto MakeSensitivityWaitStmt(
+    mir::Block& target_block, const WalkFrame& frame,
     const ClassLowerer& lowerer,
     const std::vector<hir::SensitivityEntry>& sensitivity_list) -> mir::Stmt;
 

--- a/include/lyra/lowering/hir_to_mir/services_call.hpp
+++ b/include/lyra/lowering/hir_to_mir/services_call.hpp
@@ -7,11 +7,10 @@
 namespace lyra::lowering::hir_to_mir {
 
 // Builds the engine-handle expression `self.Services()`: a `Services`
-// scope-method call whose receiver is the body's self read (MakeSelfRefExpr,
-// interned as a child). Returns the call node detached; the caller interns it.
-// Runtime-effect generic calls -- $finish, the $time family, named-event
-// trigger / triggered -- thread it as the engine handle
-// (docs/decisions/runtime-effects-as-generic-calls.md).
+// scope-method call whose receiver is the body's self read, interned as a
+// child. Returns the call node detached; the caller interns it. Runtime-
+// effect generic calls -- $finish, the $time family, named-event trigger /
+// triggered -- thread it as the engine handle.
 auto BuildServicesCallExpr(
     const ProcessLowerer& process, const WalkFrame& frame) -> mir::Expr;
 

--- a/include/lyra/lowering/hir_to_mir/walk_frame.hpp
+++ b/include/lyra/lowering/hir_to_mir/walk_frame.hpp
@@ -17,15 +17,13 @@ namespace lyra::lowering::hir_to_mir {
 
 class CaptureSink;
 
-// Singly-linked node carrying a class's parent chain so a leaf reference can
-// read the declared type of a member at `hops > 0`. Each node lives on the
-// stack of the `ClassLowerer::Run` that pushed it; the chain extends one node
-// per class opened during traversal. This is the construction-side half of the
-// shared walk position
-// (docs/architecture/lowering_organization.md "The Walk Position"): the
-// rendering fold's read-only `ScopeView` resolves the same (hops, var)
-// reference by climbing its own parent link, so both reach the same
-// `mir::MemberDecl`.
+// Singly-linked node carrying a class's parent chain so a leaf reference
+// can read the declared type of a member at `hops > 0`. Each node lives on
+// the stack of the `ClassLowerer::Run` that pushed it; the chain extends
+// one node per class opened during traversal. This is the construction-side
+// half of the shared walk position: the rendering fold's read-only
+// `ScopeView` resolves the same (hops, var) reference by climbing its own
+// parent link, so both reach the same `mir::MemberDecl`.
 struct ScopeChainNode {
   const mir::Class* cls;
   const ScopeChainNode* parent;
@@ -87,11 +85,11 @@ struct WalkFrame {
   // lowering. Empty outside a with-clause body.
   std::optional<mir::LocalId> active_index_binding;
 
-  // The `self` binding (mir.md invariant 11) at the root of the current body.
-  // Set at body entry (process / method / constructor / closure) and
-  // unchanged through the body walk; updated on entry into a fresh body to
-  // that body's own self id. Empty before any body has been entered. The
-  // declaration depth records where the binding was declared so a deeper
+  // The `self` binding at the root of the current body. Set at body entry
+  // (process / method / constructor / closure) and unchanged through the
+  // body walk; updated on entry into a fresh body to that body's own self
+  // id. Empty before any body has been entered. The declaration depth
+  // records where the binding was declared so a deeper
   // reader can compute hops as `current_depth - self_decl_depth`.
   std::optional<mir::LocalId> self_binding;
   BlockDepth self_decl_depth{};

--- a/include/lyra/mir/closure.hpp
+++ b/include/lyra/mir/closure.hpp
@@ -11,9 +11,9 @@ namespace lyra::mir {
 struct Block;
 
 // Binds the body's `binding` var to the value of `value` at closure
-// construction. Snapshot or alias is decided by the binding var's type, not by
-// a separate capture kind (closure.md): a value-typed binding owns a snapshot;
-// a `RefType` binding aliases an enclosing cell (`value` constructs the
+// construction. Snapshot or alias is decided by the binding var's type, not
+// by a separate capture kind: a value-typed binding owns a snapshot; a
+// `RefType` binding aliases an enclosing cell (`value` constructs the
 // reference, LRM 6.21), so the body's reads / writes route through the live
 // cell. The receiver `self` is always `captures[0]`.
 struct Capture {

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -40,6 +40,12 @@ struct RealLiteral {
   double value;
 };
 
+// The null borrowed-pointer value. Distinct from `IntegerLiteral{0}`: the
+// type system carries the pointee identity, and C++ rejects the functional-
+// cast construction (`T*()`) that the constructor primitive would otherwise
+// produce for a default-init pointer.
+struct NullLiteral {};
+
 struct UnaryExpr {
   UnaryOp op;
   ExprId operand;
@@ -116,28 +122,6 @@ struct ClosureRef {
   ExprId closure{};
 };
 
-enum class RuntimeFn : std::uint8_t {
-  kGetChild,
-  kGetSignal,
-  kRegisterSignal,
-};
-
-// Calls a runtime by-name interface method on a scope handle. `fn` selects the
-// method; `name` is the compile-time signal / child name. Argument 0 is the
-// scope handle the method is invoked on:
-//   - `kGetChild`: the remaining arguments are the per-dimension array indices
-//     (none for a scalar), each a runtime expression; renders
-//     `<scope>->GetChild(name, {indices})`.
-//   - `kGetSignal`: renders `<scope>->GetSignal(name)`.
-//   - `kRegisterSignal`: argument 1 is the signal var whose address is
-//     registered under `name`; renders `<scope>->RegisterSignal(name, &<var>)`.
-//     A scope records its own by-name interface during construction with this.
-// The name and indices are never bundled into one struct.
-struct RuntimeNavCallee {
-  RuntimeFn fn;
-  std::string name;
-};
-
 // Constructs a value of the call's result data type from the positional
 // arguments -- the data type's constructor, which is just a call whose callee
 // is the type itself (Python's `T(args)`, Rust's `T::new(args)`). The backend
@@ -149,7 +133,7 @@ struct ConstructorCallee {};
 
 using Callee = std::variant<
     SystemSubroutineCallee, MethodRef, BuiltinFnCallee, BuiltinStaticCallee,
-    FreeFnCallee, ClosureRef, RuntimeNavCallee, ConstructorCallee>;
+    FreeFnCallee, ClosureRef, ConstructorCallee>;
 
 struct CallExpr {
   Callee callee;
@@ -161,6 +145,25 @@ struct CallExpr {
 // pointee value type.
 struct DerefExpr {
   ExprId pointer;
+};
+
+// Takes the address of a place expression, yielding a borrowed pointer to
+// that storage. The dual of `DerefExpr`. `operand` must be an addressable
+// place (a primary value reference, a member access, a dereference, or a
+// place-producing access primitive); a value expression is not addressable.
+// `Expr::type` is `PointerType{ ownership = kBorrowed, pointee = operand.type
+// }`. `AddressOf(Deref(p))` collapses to `p` at backend lowering.
+struct AddressOfExpr {
+  ExprId operand;
+};
+
+// Reinterprets a borrowed pointer as a pointer to a different pointee type.
+// `operand` is a pointer-typed expression; `Expr::type` is the destination
+// `PointerType`. Used when a runtime entry returns a type-erased pointer
+// (`void*`) that the call site re-types -- the lowering states the
+// destination type in MIR so the backend never picks it from context.
+struct PointerCastExpr {
+  ExprId operand;
 };
 
 // Class-member access through an explicit receiver expression. `receiver`
@@ -202,10 +205,11 @@ struct TupleExpr {
 };
 
 using ExprData = std::variant<
-    IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, ParamRef, LocalRef,
-    UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr, IncDecExpr, CallExpr,
-    DerefExpr, MemberAccessExpr, ConversionExpr, ClosureExpr, ConcatExpr,
-    ReplicationExpr, ArrayLiteralExpr, TupleExpr>;
+    IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, NullLiteral,
+    ParamRef, LocalRef, UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr,
+    IncDecExpr, CallExpr, DerefExpr, AddressOfExpr, PointerCastExpr,
+    MemberAccessExpr, ConversionExpr, ClosureExpr, ConcatExpr, ReplicationExpr,
+    ArrayLiteralExpr, TupleExpr>;
 
 struct Expr {
   ExprData data;
@@ -284,6 +288,14 @@ struct Expr {
               .callee = BuiltinFnCallee{.id = support::BuiltinFn::kMutate},
               .arguments = {cell, services}},
       .type = value_type};
+}
+
+// `&place` -- the address-of dual of `DerefExpr`. `pointer_type` must be
+// `PointerType{ kBorrowed, pointee = <operand expr's type> }`; the caller
+// supplies it so this helper need not look up the operand's type.
+[[nodiscard]] inline auto MakeAddressOfExpr(ExprId operand, TypeId pointer_type)
+    -> Expr {
+  return Expr{.data = AddressOfExpr{.operand = operand}, .type = pointer_type};
 }
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/local.hpp
+++ b/include/lyra/mir/local.hpp
@@ -15,11 +15,10 @@ struct LocalId {
 };
 
 // Static-lifetime (LRM 13.3.1) body locals do not live here -- HIR-to-MIR
-// realizes them as members on the enclosing class
-// (`docs/decisions/variable-lifetime-storage.md`). A pass-by-reference binding
-// (LRM 13.5.2, a `ref` formal or a by-reference capture) carries no flag here:
-// its `type` is a `RefType`, and the backend renders reads / writes through
-// `Ref<T>` from the type alone.
+// realizes them as members on the enclosing class. A pass-by-reference
+// binding (LRM 13.5.2, a `ref` formal or a by-reference capture) carries no
+// flag here: its `type` is a `RefType`, and the backend renders reads /
+// writes through `Ref<T>` from the type alone.
 struct LocalDecl {
   std::string name;
   TypeId type;

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "lyra/base/arena.hpp"
-#include "lyra/base/time.hpp"
 #include "lyra/mir/class_id.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/local.hpp"
@@ -30,7 +29,7 @@ struct StmtId {
 // Identifies a loop as a non-local break target (the outermost loop of a
 // multi-dimensional `foreach`). The universal labeled-break primitive; the C++
 // backend renders it as a `goto` to a label after the loop, an LLVM backend as
-// a branch. See `docs/decisions/foreach-lowering.md`.
+// a branch.
 struct LoopLabelId {
   std::uint32_t value;
 
@@ -132,19 +131,6 @@ enum class EventEdge : std::uint8_t {
   kBothEdges,
 };
 
-// LRM 9.4.1 `#N`. A time-anchored suspension: the engine schedules the next
-// resume at `now + duration`. Standalone -- the controlled body (if any) is
-// a separate statement in the enclosing block. Disjoint from the value-change
-// suspension family (`SensitivityWaitStmt`) and the named-event method-call
-// family: those are data-dependency anchored, this one is clock anchored.
-// See `docs/decisions/event-control-unification.md` for the rationale.
-struct DelayStmt {
-  // `duration` is in the declaring scope's time-precision steps. The scope owns
-  // its precision (emitted as a class constant); the runtime scales from there
-  // to the design-global tick (LRM 3.14.3).
-  SimDuration duration;
-};
-
 struct WhileStmt {
   ExprId condition;
   BlockId scope;
@@ -184,15 +170,20 @@ struct AwaitStmt {
   ExprId awaitable;
 };
 
-// One leaf entry of a wait's projection set. Identity-only: which member, the
+// One leaf entry of a wait's projection set: an expression yielding a
+// borrowed pointer to the observable cell the leaf subscribes to, plus the
 // observed bit projection of its packed encoding as a `(lsb_bit_offset,
-// bit_width)` pair, and what edge polarity the leaf was subscribed under (LRM
-// 9.4.2 / 9.4.2.2 / 9.4.3). A `bit_width` of 0 is the whole signal observed on
-// any change; an edge reduces to the bit at `lsb_bit_offset`. The projection is
-// resolved at HIR-to-MIR from the SV-level footprint so a backend emits the
-// pair directly. `kAnyChange` is the edge for implicit sensitivity.
+// bit_width)` pair, and the edge polarity the leaf was subscribed under (LRM
+// 9.4.2 / 9.4.2.2 / 9.4.3). A `bit_width` of 0 is the whole signal observed
+// on any change; an edge reduces to the bit at `lsb_bit_offset`. The
+// projection is resolved at HIR-to-MIR from the SV-level footprint so a
+// backend emits the pair directly. `kAnyChange` is the edge for implicit
+// sensitivity. The pointer expression's exact shape -- `AddressOf` of a
+// place, a bare borrowed-pointer member access, or a call that resolves an
+// upward reference to its current observable -- is stated by HIR-to-MIR so
+// the backend never re-derives it from the leaf's type.
 struct SensitivityRead {
-  SensitivityRef ref;
+  ExprId observable_ptr{};
   std::uint64_t lsb_bit_offset = 0;
   std::uint64_t bit_width = 0;
   EventEdge edge_kind = EventEdge::kAnyChange;
@@ -208,8 +199,8 @@ struct SensitivityWaitStmt {
 
 using StmtData = std::variant<
     EmptyStmt, LocalDeclStmt, ExprStmt, BlockStmt, ForkStmt, IfStmt,
-    ConstructOwnedObjectStmt, ConstructExternalUnitStmt, ForStmt, DelayStmt,
-    WhileStmt, DoWhileStmt, BreakStmt, ContinueStmt, ReturnStmt, AwaitStmt,
+    ConstructOwnedObjectStmt, ConstructExternalUnitStmt, ForStmt, WhileStmt,
+    DoWhileStmt, BreakStmt, ContinueStmt, ReturnStmt, AwaitStmt,
     SensitivityWaitStmt>;
 
 struct Stmt {

--- a/include/lyra/mir/value_ref.hpp
+++ b/include/lyra/mir/value_ref.hpp
@@ -17,10 +17,4 @@ struct LocalRef {
   LocalId var{};
 };
 
-// A sensitivity leaf observes a member that resolves to a stored
-// `Observable` the scheduler subscribes to: a plain signal, an upward
-// ExternalRef member, or a downward borrowed-pointer slot. All three are
-// MemberRefs; the var's type tells the renderer how to reach the cell.
-using SensitivityRef = MemberRef;
-
 }  // namespace lyra::mir

--- a/include/lyra/runtime/delay.hpp
+++ b/include/lyra/runtime/delay.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <cstdint>
+
 #include "lyra/base/time.hpp"
 #include "lyra/runtime/coroutine.hpp"
 #include "lyra/runtime/runtime_services.hpp"
+#include "lyra/value/packed_array.hpp"
 
 namespace lyra::runtime {
 
@@ -60,9 +63,11 @@ class DelayAwaitable {
 };
 
 inline auto Delay(
-    RuntimeServices& services, SimDuration duration,
-    std::int8_t precision_power) -> DelayAwaitable {
-  return DelayAwaitable{services, duration, precision_power};
+    RuntimeServices& services, const value::PackedArray& duration,
+    const value::PackedArray& precision_power) -> DelayAwaitable {
+  return DelayAwaitable{
+      services, static_cast<SimDuration>(duration.ToInt64()),
+      static_cast<std::int8_t>(precision_power.ToInt64())};
 }
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/extern_up.hpp
+++ b/include/lyra/runtime/extern_up.hpp
@@ -35,11 +35,11 @@ struct ChildStep {
 // An upward hierarchical reference modeled as an extern member: it holds the
 // symbol -- the ancestor name, how that name is matched on the parent chain,
 // the by-name tail down through the ancestor's owned children, and the leaf
-// signal name -- and at Bind climbs to the ancestor, walks the tail, and binds
-// a direct pointer to the leaf. Reads, writes, and sensitivity forward to that
-// resolved cell, so the member behaves like the referenced `Var<T>` while
-// naming no ancestor type (docs/architecture/emission_model.md). Non-movable:
-// it registers `this`, and is owned by the stable scope node that declares it.
+// signal name -- and at Bind climbs to the ancestor, walks the tail, and
+// binds a direct pointer to the leaf. Reads, writes, and sensitivity forward
+// to that resolved cell, so the member behaves like the referenced `Var<T>`
+// while naming no ancestor type. Non-movable: it registers `this`, and is
+// owned by the stable scope node that declares it.
 template <value::LyraValue T>
 class ExternUp : public ExternBase {
  public:
@@ -56,8 +56,16 @@ class ExternUp : public ExternBase {
 
   void Relocate() override {
     Scope* scope = owner_->ResolveUpwardScope(ancestor_, match_);
+    std::vector<value::PackedArray> packed_indices;
     for (const ChildStep& hop : tail_) {
-      scope = scope->GetChild(hop.name, hop.indices);
+      packed_indices.clear();
+      packed_indices.reserve(hop.indices.size());
+      for (const std::size_t idx : hop.indices) {
+        packed_indices.push_back(
+            value::PackedArray::FromInt(
+                static_cast<std::int64_t>(idx), 32, true, false));
+      }
+      scope = scope->GetChild(hop.name, packed_indices);
     }
     cell_ = static_cast<Var<T>*>(scope->GetSignal(signal_));
   }

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -59,11 +59,11 @@ class Scope {
     return {};
   }
 
-  // Records, during construction, the address of a signal this scope owns under
-  // its source name, and the owned child reachable at `name` plus one index per
-  // array dimension (empty for a scalar). A unit answers by-name queries about
-  // its own interface from these registrations; it never inspects who asks
-  // (reference_resolution.md). `name` points at an emitted string literal; the
+  // Records, during construction, the address of a signal this scope owns
+  // under its source name, and the owned child reachable at `name` plus one
+  // index per array dimension (empty for a scalar). A unit answers by-name
+  // queries about its own interface from these registrations; it never
+  // inspects who asks. `name` points at an emitted string literal; the
   // indices are copied so the entry outlives the constructor's arguments.
   void RegisterSignal(std::string_view name, void* address);
   void RegisterChild(
@@ -78,7 +78,8 @@ class Scope {
   // the simulation path.
   [[nodiscard]] auto GetSignal(std::string_view name) -> void*;
   [[nodiscard]] auto GetChild(
-      std::string_view name, std::span<const std::size_t> indices) -> Scope*;
+      std::string_view name, std::span<const lyra::value::PackedArray> indices)
+      -> Scope*;
 
   // Climbs the parent chain to the nearest ancestor named `key` and returns it
   // (LRM 23.8). `match` selects the name compared: `kDefName` matches an
@@ -111,9 +112,8 @@ class Scope {
 
   // Last-write-wins per site within a time slot: re-submit at the same site
   // overwrites the prior closure, which suppresses settle-time glitches. The
-  // site id is the compile-time-fixed slot index passed as an SV integer
-  // (`value-type-concepts.md`); the runtime projects to `std::size_t`
-  // internally at the API boundary.
+  // site id is the compile-time-fixed slot index passed as an SV integer;
+  // the runtime projects to `std::size_t` internally at the API boundary.
   void SubmitObserved(
       const lyra::value::PackedArray& site_id, std::function<void()> fn);
   void DrainObserved();
@@ -175,9 +175,8 @@ class Scope {
   std::vector<ExternBase*> externs_;
 };
 
-// A module / interface / program instance: an owned child built from another
-// compilation unit, reached across the unit boundary
-// (hierarchy_and_generate.md).
+// A module / interface / program instance: an owned child built from
+// another compilation unit, reached across the unit boundary.
 class Instance : public Scope {
  public:
   using Scope::Scope;

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -10,8 +10,7 @@ namespace lyra::support {
 // imports the other's. The receiver type at the call site names the runtime
 // library type whose method is being invoked (value-layer containers,
 // observable storage cells, runtime services, scope handle); this enum
-// carries only the method identity. See
-// `docs/decisions/builtin-call-identity.md`.
+// carries only the method identity.
 enum class BuiltinFn : std::uint16_t {
   // LRM 7.4 / 7.8 / 7.10 / 11.5 positional access. Bare returns value
   // form; `Ref` returns write-through reference. `Slice` is read,
@@ -140,6 +139,36 @@ enum class BuiltinFn : std::uint16_t {
   kScan,
   kPeekBuffered,
   kAdvanceFd,
+  // LRM 9.4.1 `#N`. The runtime free function the scheduler suspends on.
+  // The call takes the engine handle, the duration in the calling scope's
+  // precision steps, and the calling scope's precision power; the runtime
+  // scales to the design-global tick (LRM 3.14.3).
+  kDelay,
+  // LRM 20.3 simulation-time read functions. Each takes the engine handle
+  // and the calling scope's unit power; the runtime scales the design-global
+  // tick down to that unit. `$time` rounds and yields a 64-bit `time`,
+  // `$stime` yields the low 32 bits as an `int`, `$realtime` keeps the
+  // fractional part as a `realtime`.
+  kSimTime,
+  kSTime,
+  kRealTime,
+  // LRM 20.2 simulation termination. Takes the engine handle and the LRM
+  // diagnostic level (0 / 1 / 2). The call suspends and never resumes; the
+  // engine drops the process at the next dispatch.
+  kFinish,
+  // Resolves an `ExternUp<T>` member into a borrowed pointer to the
+  // observable cell it currently refers to. Used by sensitivity-leaf
+  // lowering so the wait expression carries an explicit observable handle
+  // rather than letting the backend derive one from the member's type.
+  kAsObservable,
+  // By-name scope navigation: a constructor walks a sibling unit's
+  // interface, looks up an owned child by name (and per-dimension index),
+  // looks up a signal by name, or registers its own signal under a name.
+  // All three are instance methods on the scope handle (`args[0]`); the
+  // name (and the index array for `kGetChild`) is a regular argument.
+  kRegisterSignal,
+  kGetSignal,
+  kGetChild,
 };
 
 // True iff `id` is a type-namespace-qualified static call -- no receiver,

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -183,12 +183,12 @@ struct SystemSubroutineDesc {
   ReturnConvention result_conv;
   ArgCountPolicy arg_policy;
   SystemSubroutineSemantic semantic;
-  // Invoking this subroutine suspends the calling process ($finish suspends and
-  // never resumes; the engine drops the process on the next dispatch, LRM
-  // 20.2). Stated as a fact so HIR-to-MIR lowers a suspending call to a
+  // Invoking this subroutine suspends the calling process ($finish suspends
+  // and never resumes; the engine drops the process on the next dispatch,
+  // LRM 20.2). Stated as a fact so HIR-to-MIR lowers a suspending call to a
   // suspension point (`mir::AwaitStmt`) rather than inferring it from the
-  // subroutine's semantic kind (mir.md invariant 10); each backend then
-  // realizes the await in its target (C++ `co_await`, LLVM's own mechanism).
+  // subroutine's semantic kind; each backend then realizes the await in its
+  // target (C++ `co_await`, LLVM's own mechanism).
   bool suspends = false;
 };
 

--- a/include/lyra/value/array_manipulation.hpp
+++ b/include/lyra/value/array_manipulation.hpp
@@ -12,14 +12,14 @@
 // LRM 7.12 array manipulation algorithms. The locator / reduction / map family
 // runs over a container's entry stream -- a lazily iterated sequence of
 // `(index, element)` pairs in the container's natural order. The index is the
-// container's index type (an ordinal int for the sequence containers, the key
-// for an associative array), so these algorithms never synthesize it and never
-// name a container type; they are generic combinators over any range whose
-// element is an `Entry`. The container supplies that range (see each
+// container's index type (an ordinal int for the sequence containers, the
+// key for an associative array), so these algorithms never synthesize it and
+// never name a container type; they are generic combinators over any range
+// whose element is an `Entry`. The container supplies that range (see each
 // container's `Entries()`), and shapes the result. The ordering family
-// (`reverse` / `sort`) is a separate, sequence-only in-place permutation that
-// needs random-access storage; it stays on the positional `Seq&` form below.
-// See `docs/decisions/array-manipulation-entry-stream.md`.
+// (`reverse` / `sort`) is a separate, sequence-only in-place permutation
+// that needs random-access storage; it stays on the positional `Seq&` form
+// below.
 namespace lyra::value::detail {
 
 // One entry of a container's 7.12 stream: the element by const pointer (a

--- a/include/lyra/value/associative_array.hpp
+++ b/include/lyra/value/associative_array.hpp
@@ -63,15 +63,15 @@ struct AssocKeyTraits<PackedArray> {
 // is an ordered `std::map` so iteration and `%p` formatting follow the LRM 7.8
 // key ordering and stay deterministic.
 //
-// `element_default_` holds the element-type default -- the LRM Table 7-1 value
-// read from a nonexistent array entry. It carries the element's runtime shape
-// (supplied at construction because `V = PackedArray` carries shape the C++
-// type cannot recover; see `docs/decisions/runtime-shape-and-default-value.md`)
-// and is only ever read or copied, never written, so a read returns it
-// directly. A read of a nonexistent or invalid key (LRM 7.8.6) returns it
-// unless `user_default_` overrides it (LRM 7.9.11). `discard_sink_` is the
-// throwaway an invalid-key write lands on, scrubbed to canonical by the
-// non-const write path. There is no out-of-bounds concept here: an associative
+// `element_default_` holds the element-type default -- the LRM Table 7-1
+// value read from a nonexistent array entry. It carries the element's
+// runtime shape (supplied at construction because `V = PackedArray` carries
+// shape the C++ type cannot recover) and is only ever read or copied, never
+// written, so a read returns it directly. A read of a nonexistent or invalid
+// key (LRM 7.8.6) returns it unless `user_default_` overrides it (LRM
+// 7.9.11). `discard_sink_` is the throwaway an invalid-key write lands on,
+// scrubbed to canonical by the non-const write path. There is no
+// out-of-bounds concept here: an associative
 // array has no index bounds, so the trigger is a missing or invalid key, never
 // a boundary.
 template <typename K, typename V>

--- a/include/lyra/value/concepts.hpp
+++ b/include/lyra/value/concepts.hpp
@@ -38,8 +38,8 @@ class PackedArray;
 // This is a C++-mechanics contract, NOT a statement about assignment
 // meaning. For shape-bearing types like `PackedArray`, assignment preserves
 // the destination's declared shape and copies the source's bits in (it is
-// not a pure value adopt); see docs/decisions/integral-representation.md.
-// The concept only guarantees the operations exist and relocation is safe.
+// not a pure value adopt). The concept only guarantees the operations exist
+// and relocation is safe.
 template <typename T>
 concept Storable = std::copyable<T>;
 
@@ -47,8 +47,7 @@ concept Storable = std::copyable<T>;
 // row). A type that satisfies this concept provides the universal equality
 // operators plus the engine's bit-pattern change-detection predicate. This
 // is the concept `lyra::runtime::Var<T>` requires, so wrapping a
-// structural-var in observable storage gates on it. See
-// `docs/decisions/value-type-concepts.md`.
+// structural-var in observable storage gates on it.
 template <typename T>
 concept LyraValue = Storable<T> && requires(const T& a, const T& b) {
   // LRM 11.4.5 `==` / `!=` (Any data type). Uniform return type: every

--- a/include/lyra/value/dynamic_array.hpp
+++ b/include/lyra/value/dynamic_array.hpp
@@ -28,11 +28,10 @@ namespace lyra::value {
 // It carries the element's runtime shape (bit width, signedness, 2/4-state for
 // `T = PackedArray`) that the C++ type alone cannot recover, so it is supplied
 // at construction. It is only ever read or copied, never written, so a const
-// read returns it directly with no scrub. `discard_sink_` is the throwaway an
-// invalid-index write lands on; the non-const write path scrubs it to canonical
-// via `T::ResetToDefault` before handing out the reference, so a discarded
-// write never leaks into a later access. See
-// `docs/decisions/runtime-shape-and-default-value.md`.
+// read returns it directly with no scrub. `discard_sink_` is the throwaway
+// an invalid-index write lands on; the non-const write path scrubs it to
+// canonical via `T::ResetToDefault` before handing out the reference, so a
+// discarded write never leaks into a later access.
 template <typename T>
 class DynamicArray {
  public:

--- a/include/lyra/value/format.hpp
+++ b/include/lyra/value/format.hpp
@@ -178,8 +178,8 @@ struct PrintLiteralItem {
 
   // Borrows the text bytes of `text`. The caller materializes `text` as a
   // temporary in the same full-expression as the runtime print call, so the
-  // borrowed bytes outlive the walk (the same lifetime contract FormatArg
-  // relies on; see docs/decisions/format-dispatch.md).
+  // borrowed bytes outlive the walk (the same lifetime contract `FormatArg`
+  // relies on).
   explicit PrintLiteralItem(const String& text);
 };
 

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -226,8 +226,7 @@ class PackedArray {
   // View the bit vector as a byte sequence, most significant byte first
   // (`bit_width / 8` bytes; a byte with any x or z bit yields `0x00`). The
   // shared producer for the LRM 6.16 string lift and the LRM 21.2.1.7 `%s`
-  // formatter, which post-process the NUL byte differently
-  // (decisions/string-packed-conversion.md).
+  // formatter, which post-process the NUL byte differently.
   [[nodiscard]] auto ByteString() const -> std::string;
 
   // Typed view accessors. The atom encoded in `is_four_state_` selects which
@@ -253,8 +252,7 @@ class PackedArray {
   // Width-aware copy preserving THIS object's shape. The shape
   // (bit_width / signedness / 4-state / dims) is declared type information
   // fixed at construction; assignment keeps it and copies the source's bits
-  // in (docs/decisions/integral-representation.md). ExpectSameShape guards a
-  // missing upstream ConvertFrom.
+  // in. ExpectSameShape guards a missing upstream ConvertFrom.
   auto AssignFrom(const PackedArray& other) -> void;
 
   // Storage-level swap, bypassing AssignFrom's shape-preservation rule.

--- a/include/lyra/value/queue.hpp
+++ b/include/lyra/value/queue.hpp
@@ -34,7 +34,7 @@ namespace lyra::value {
 // written, so a const read returns it directly with no scrub. `discard_sink_`
 // is the throwaway an invalid-index write lands on; the non-const write path
 // scrubs it to canonical via `T::ResetToDefault` before handing out the
-// reference. See `docs/decisions/runtime-shape-and-default-value.md`.
+// reference.
 template <typename T>
 class Queue {
  public:
@@ -89,10 +89,10 @@ class Queue {
 
   Queue(const Queue&) = default;
   Queue(Queue&&) noexcept = default;
-  // LRM 10.6.1 / `value-assignment-and-moved-from.md`: the element shape and
-  // the LRM 7.10.5 bound are declared-type properties of the variable, not
-  // value content. A declared queue is default-constructed and then initialized
-  // by assignment, so an as-yet-unseeded target adopts the source's element
+  // LRM 10.6.1: the element shape and the LRM 7.10.5 bound are declared-type
+  // properties of the variable, not value content. A declared queue is
+  // default-constructed and then initialized by assignment, so an as-yet-
+  // unseeded target adopts the source's element
   // shape (and an unbounded target the source's bound) on that first store;
   // once seeded it keeps its own shape and bound on every later assignment and
   // copies only the elements in -- so assigning the empty `{}` or an unbounded

--- a/include/lyra/value/real.hpp
+++ b/include/lyra/value/real.hpp
@@ -147,9 +147,8 @@ class RealValue {
     return PackedArray::Bit(false);
   }
 
-  // LRM Table 6-7: the real default is 0.0. This is the container OOB-shield
-  // contract (docs/decisions/runtime-shape-and-default-value.md), so a real can
-  // be an unpacked-array element.
+  // LRM Table 6-7: the real default is 0.0. Satisfies the container
+  // OOB-shield contract so a real can be an unpacked-array element.
   auto ResetToDefault() -> void {
     v_ = Host{0};
   }

--- a/include/lyra/value/string.hpp
+++ b/include/lyra/value/string.hpp
@@ -48,9 +48,8 @@ class String {
   }
 
   // LRM 6.16: a string value holds no NUL, so building one from bits strips
-  // every NUL byte -- which is also why the empty `""` (the packed `8'h00` of
-  // LRM 11.10.3) strips to the empty string. See
-  // decisions/string-packed-conversion.md.
+  // every NUL byte -- which is also why the empty `""` (the packed `8'h00`
+  // of LRM 11.10.3) strips to the empty string.
   [[nodiscard]] static auto FromPackedArray(const PackedArray& bits) -> String {
     std::string out;
     for (char c : bits.ByteString()) {
@@ -91,10 +90,9 @@ class String {
     return PackedArray::Bit(false);
   }
 
-  // LRM Table 6-7: the string default is the empty string. This is the
-  // container OOB-shield contract shared with the other value types
-  // (docs/decisions/runtime-shape-and-default-value.md), so a `string` can be
-  // an unpacked-array element.
+  // LRM Table 6-7: the string default is the empty string. Satisfies the
+  // container OOB-shield contract shared with the other value types, so a
+  // `string` can be an unpacked-array element.
   auto ResetToDefault() -> void {
     impl_.clear();
   }

--- a/include/lyra/value/unpacked_array.hpp
+++ b/include/lyra/value/unpacked_array.hpp
@@ -35,13 +35,12 @@ class ArraySliceRef;
 // `element_default_` holds the LRM Table 7-1 default an invalid-index read
 // returns (LRM 7.4.5) and the prototype every fill / slice / locator copies.
 // It carries the element's runtime shape (bit width, signedness, 2/4-state for
-// `T = PackedArray`) that the C++ type alone cannot recover, so it is supplied
-// at construction. It is only ever read or copied, never written, so a const
-// read returns it directly with no scrub. `discard_sink_` is the throwaway an
-// invalid-index write lands on; the non-const write path scrubs it to canonical
-// via `T::ResetToDefault` before handing out the reference, so a discarded
-// write never leaks into a later access. See
-// `docs/decisions/runtime-shape-and-default-value.md`.
+// `T = PackedArray`) that the C++ type alone cannot recover, so it is
+// supplied at construction. It is only ever read or copied, never written,
+// so a const read returns it directly with no scrub. `discard_sink_` is the
+// throwaway an invalid-index write lands on; the non-const write path
+// scrubs it to canonical via `T::ResetToDefault` before handing out the
+// reference, so a discarded write never leaks into a later access.
 template <typename T>
 class UnpackedArray {
  public:

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -235,24 +235,12 @@ auto RenderScopeAsClass(
   out += Indent(indent) + " public:\n";
 
   // The scope's own time precision (LRM 3.14.2). The engine takes the minimum
-  // across the tree as the design-global tick (LRM 3.14.3); a delay in this
-  // scope scales from this precision to that tick.
+  // across the tree as the design-global tick (LRM 3.14.3); the runtime scales
+  // a local-precision delay from this value to that tick.
   out += Indent(indent + 1) +
-         "static constexpr std::int8_t kTimePrecisionPower = " +
+         "auto TimePrecisionPower() const -> std::int8_t override { return " +
          std::to_string(static_cast<int>(s.time_resolution.precision_power)) +
-         ";\n";
-  out += Indent(indent + 1) +
-         "auto TimePrecisionPower() const -> std::int8_t override {\n";
-  out += Indent(indent + 2) + "return kTimePrecisionPower;\n";
-  out += Indent(indent + 1) + "}\n\n";
-
-  // The scope's own time unit (LRM 3.14.2). $time / $realtime read here to
-  // scale the design-global tick back to this design element's unit (LRM
-  // 20.3); an unqualified reference in a process or method body resolves
-  // to the lexically enclosing scope's value.
-  out += Indent(indent + 1) + "static constexpr std::int8_t kTimeUnitPower = " +
-         std::to_string(static_cast<int>(s.time_resolution.unit_power)) +
-         ";\n\n";
+         "; }\n\n";
 
   for (const auto& child : s.nested_classes) {
     auto child_or =
@@ -283,7 +271,7 @@ auto RenderScopeAsClass(
   }
 
   // Members follow the constructor and methods. They are public so cross-unit
-  // references can reach them directly (see reference_resolution.md).
+  // references can reach them directly.
   if (!s.params.empty() || !s.members.empty()) {
     out += "\n";
   }

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -18,7 +18,6 @@
 #include "lyra/base/overloaded.hpp"
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
-#include "lyra/diag/kind.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/conversion.hpp"
 #include "lyra/mir/expr.hpp"
@@ -204,17 +203,6 @@ auto IsReferenceLocal(const ScopeView& view, const mir::LocalRef& ref) -> bool {
 }
 
 }  // namespace
-
-auto RenderMemberName(const ScopeView& view, const mir::MemberRef& ref)
-    -> diag::Result<std::string> {
-  if (ref.hops.value != 0) {
-    return diag::Fail(
-        diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-        "cross-scope member access is not yet implemented in cpp "
-        "emit");
-  }
-  return "self->" + view.Class().members.Get(ref.var).name;
-}
 
 namespace {
 
@@ -632,8 +620,7 @@ auto RenderConversionExpr(
   }
   // LRM 6.16: build a string value from packed bits. FromPackedArray strips
   // every NUL, so the empty (`8'h00`) and embedded-NUL cases need no operand
-  // special-case -- the render stays a pure type map (conversion-folding.md;
-  // decisions/string-packed-conversion.md).
+  // special-case -- the render stays a pure type map.
   if (src_ty.IsIntegralPacked() && dst_ty.Kind() == mir::TypeKind::kString) {
     return std::format(
         "lyra::value::String::FromPackedArray({})", *std::move(operand_or));
@@ -810,6 +797,24 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "Next";
     case support::BuiltinFn::kAssocPrev:
       return "Prev";
+    case support::BuiltinFn::kDelay:
+      return "Delay";
+    case support::BuiltinFn::kSimTime:
+      return "SimTimeInUnit";
+    case support::BuiltinFn::kSTime:
+      return "STimeInUnit";
+    case support::BuiltinFn::kRealTime:
+      return "RealTimeInUnit";
+    case support::BuiltinFn::kFinish:
+      return "Finish";
+    case support::BuiltinFn::kAsObservable:
+      return "AsObservable";
+    case support::BuiltinFn::kRegisterSignal:
+      return "RegisterSignal";
+    case support::BuiltinFn::kGetSignal:
+      return "GetSignal";
+    case support::BuiltinFn::kGetChild:
+      return "GetChild";
   }
   throw InternalError("BuiltinFnCppName: unknown BuiltinFn");
 }
@@ -829,16 +834,21 @@ auto BuiltinFnCppNamespace(support::BuiltinFn id) -> std::string_view {
   switch (id) {
     case support::BuiltinFn::kScan:
       return "lyra::value";
+    case support::BuiltinFn::kDelay:
+    case support::BuiltinFn::kSimTime:
+    case support::BuiltinFn::kSTime:
+    case support::BuiltinFn::kRealTime:
+    case support::BuiltinFn::kFinish:
+      return "lyra::runtime";
     default:
       return "";
   }
 }
 
 // `recv.name(args)` or `recv->name(args)` -- the receiver's MIR type
-// (pointer vs value) selects the C++ separator. Reading the type is reading
-// a fact MIR already states (mir.md invariant 10); a backend never
-// re-derives, but mechanical translation of stated structure is its job.
-// See `docs/decisions/builtin-call-identity.md` for the rendering rationale.
+// (pointer vs value) selects the C++ separator. The pointer-vs-value fact is
+// already on the receiver expression's type; the backend reads it and picks
+// the separator mechanically.
 auto RenderBuiltinFnCall(
     const ScopeView& view, const mir::CallExpr& call, support::BuiltinFn id)
     -> diag::Result<std::string> {
@@ -906,7 +916,10 @@ auto RenderSystemSubroutineEntryName(const support::SystemSubroutineDesc& desc)
       Overloaded{
           [](const support::TerminationSystemSubroutineInfo&)
               -> diag::Result<std::string_view> {
-            return std::string_view{"lyra::runtime::Finish"};
+            throw InternalError(
+                "RenderSystemSubroutineEntryName: termination id reached "
+                "system subroutine render path; finish family is "
+                "BuiltinFn-routed");
           },
           [](const support::PrintSystemSubroutineInfo&)
               -> diag::Result<std::string_view> {
@@ -944,18 +957,11 @@ auto RenderSystemSubroutineEntryName(const support::SystemSubroutineDesc& desc)
             // resolves.
             return std::string_view{"lyra::runtime::LyraTimeFormat"};
           },
-          [](const support::TimeSystemSubroutineInfo& time)
+          [](const support::TimeSystemSubroutineInfo&)
               -> diag::Result<std::string_view> {
-            switch (time.kind) {
-              case support::TimeKind::kTime:
-                return std::string_view{"lyra::runtime::SimTimeInUnit"};
-              case support::TimeKind::kStime:
-                return std::string_view{"lyra::runtime::STimeInUnit"};
-              case support::TimeKind::kRealtime:
-                return std::string_view{"lyra::runtime::RealTimeInUnit"};
-            }
             throw InternalError(
-                "RenderSystemSubroutineEntryName: unknown TimeKind");
+                "RenderSystemSubroutineEntryName: time id reached system "
+                "subroutine render path; time family is BuiltinFn-routed");
           },
           [](const support::FileIOSystemSubroutineInfo& file_io)
               -> diag::Result<std::string_view> {
@@ -1027,18 +1033,12 @@ auto RenderSystemSubroutineCall(
 
 // Constructs a value of the call's result data type: `<TypeName>(args)`, the
 // type name from `RenderTypeAsCpp` (a constructor is a call whose callee is the
-// type's constructor), the arguments rendered like any other call's. An empty
-// argument list against a pointer type value-initializes to `nullptr` (the
-// functional-cast `T*()` is ill-formed for a raw pointer). A `RefType` cell
-// argument renders as a bare signal read, which is the cell itself -- the
-// `Ref<T>` constructor binds it.
+// type's constructor), the arguments rendered like any other call's. A
+// `RefType` cell argument renders as a bare signal read, which is the cell
+// itself -- the `Ref<T>` constructor binds it.
 auto RenderConstructorCall(
     const ScopeView& view, const mir::CallExpr& call, mir::TypeId result_type)
     -> diag::Result<std::string> {
-  if (call.arguments.empty() && std::holds_alternative<mir::PointerType>(
-                                    view.Unit().GetType(result_type).data)) {
-    return std::string{"nullptr"};
-  }
   auto type_or = RenderTypeAsCpp(view.Unit(), view.Class(), result_type);
   if (!type_or) return std::unexpected(std::move(type_or.error()));
   std::string args;
@@ -1070,9 +1070,9 @@ auto RenderCallExpr(
             const auto& cls = view.EnclosingClassAtHops(
                 mir::EnclosingHops{.value = ref.hops.value});
             const auto& decl = cls.methods.Get(ref.method);
-            // arguments[0] is the callee's `self` handle (mir.md invariant 11);
-            // a ref / const ref actual is already a reference-construct
-            // (`Ref<T>(cell)`) in MIR, so every argument renders uniformly.
+            // arguments[0] is the callee's `self` handle; a ref / const ref
+            // actual is already a reference-construct (`Ref<T>(cell)`) in MIR,
+            // so every argument renders uniformly.
             std::string args;
             for (std::size_t i = 0; i < call.arguments.size(); ++i) {
               auto arg_or = RenderExpr(view, view.Expr(call.arguments[i]));
@@ -1104,51 +1104,6 @@ auto RenderCallExpr(
               args += *std::move(arg_or);
             }
             return "(" + *closure_or + ")(" + args + ")";
-          },
-          [&](const mir::RuntimeNavCallee& nav) -> diag::Result<std::string> {
-            auto base_or = RenderExpr(view, view.Expr(call.arguments.at(0)));
-            if (!base_or) return std::unexpected(std::move(base_or.error()));
-            switch (nav.fn) {
-              case mir::RuntimeFn::kGetChild: {
-                std::string indices = "{}";
-                if (call.arguments.size() > 1) {
-                  indices = "std::array{";
-                  for (std::size_t i = 1; i < call.arguments.size(); ++i) {
-                    auto idx_or =
-                        RenderExpr(view, view.Expr(call.arguments.at(i)));
-                    if (!idx_or)
-                      return std::unexpected(std::move(idx_or.error()));
-                    if (i != 1) indices += ", ";
-                    indices +=
-                        "std::size_t((" + *std::move(idx_or) + ").ToInt64())";
-                  }
-                  indices += "}";
-                }
-                return *base_or + "->GetChild(\"" + nav.name + "\", " +
-                       indices + ")";
-              }
-              case mir::RuntimeFn::kGetSignal: {
-                // GetSignal returns an untyped storage pointer; the call's
-                // result type names the cell, so the cast is fixed by that
-                // type.
-                auto cell_or =
-                    RenderTypeAsCpp(view.Unit(), view.Class(), result_type);
-                if (!cell_or)
-                  return std::unexpected(std::move(cell_or.error()));
-                return "static_cast<" + *cell_or + ">(" + *base_or +
-                       "->GetSignal(\"" + nav.name + "\"))";
-              }
-              case mir::RuntimeFn::kRegisterSignal: {
-                // Registers the signal's own cell address under its name; the
-                // var argument renders as a bare lvalue so `&` takes the cell.
-                auto var_or =
-                    RenderLhsExpr(view, view.Expr(call.arguments.at(1)));
-                if (!var_or) return std::unexpected(std::move(var_or.error()));
-                return *base_or + "->RegisterSignal(\"" + nav.name + "\", &" +
-                       *var_or + ")";
-              }
-            }
-            throw InternalError("RenderCallExpr: unknown RuntimeFn");
           },
           [&](const mir::ConstructorCallee&) -> diag::Result<std::string> {
             return RenderConstructorCall(view, call, result_type);
@@ -1303,12 +1258,11 @@ auto RenderAssignExpr(const ScopeView& view, const mir::AssignExpr& a)
            ", " + *value_or + ")";
   }
 
-  // Mechanical render: the observable cell's `Set` is now an explicit
-  // `CallExpr(ObservableMethod{kSet}, ...)` and `Mutate` shows up as a
-  // `DerefExpr(CallExpr(ObservableMethod{kMutate}, ...))` at the chain root
-  // -- both injected at HIR-to-MIR
-  // (`docs/decisions/value-type-concepts.md`). This render emits a plain
-  // C++ assignment over whatever `RenderLhsExpr` produces.
+  // Mechanical render: an observable cell's write surfaces in MIR as an
+  // explicit `CallExpr` against the cell type's `Set` method, and a partial
+  // mutation surfaces as `DerefExpr` over a `Mutate` call at the chain root.
+  // Both shapes arrive from HIR-to-MIR already lowered, so this path emits a
+  // plain C++ assignment over whatever the LHS render produces.
   if (IsLhsBarePrimary(lhs_expr)) {
     auto root_or = RenderLhsExpr(view, lhs_expr);
     if (!root_or) return std::unexpected(std::move(root_or.error()));
@@ -1586,13 +1540,41 @@ auto RenderReplicationExpr(
 // Read-side render of a borrowed-pointer dereference: the cell is reached
 // with `(*ptr)`. The `.Get()` unwrap, if applicable, is emitted by the
 // explicit `ObservableMethod{kGet}` call that HIR-to-MIR wraps around an
-// observable read (`docs/decisions/value-type-concepts.md`).
+// observable read.
 auto RenderDerefExpr(const ScopeView& view, const mir::DerefExpr& d)
     -> diag::Result<std::string> {
   const mir::Expr& ptr_expr = view.Expr(d.pointer);
   auto ptr_or = RenderExpr(view, ptr_expr);
   if (!ptr_or) return std::unexpected(std::move(ptr_or.error()));
   return "(*" + *ptr_or + ")";
+}
+
+// `&place` emitted as the C++ address-of operator. Backend-side
+// canonicalization: `&(*p)` collapses to `p` directly, avoiding a no-op
+// round-trip through the address-of/dereference pair.
+auto RenderAddressOfExpr(const ScopeView& view, const mir::AddressOfExpr& a)
+    -> diag::Result<std::string> {
+  const mir::Expr& operand_expr = view.Expr(a.operand);
+  if (const auto* deref = std::get_if<mir::DerefExpr>(&operand_expr.data)) {
+    return RenderExpr(view, view.Expr(deref->pointer));
+  }
+  auto operand_or = RenderLhsExpr(view, operand_expr);
+  if (!operand_or) return std::unexpected(std::move(operand_or.error()));
+  return "&" + *operand_or;
+}
+
+// Reinterprets a borrowed pointer as a different pointer type stated by the
+// expression's `type`. Renders as `static_cast<DestType>(operand)`; the
+// destination spelling comes from the type table, not from any local
+// inference.
+auto RenderPointerCastExpr(
+    const ScopeView& view, const mir::PointerCastExpr& cast, mir::TypeId dest)
+    -> diag::Result<std::string> {
+  auto operand_or = RenderExpr(view, view.Expr(cast.operand));
+  if (!operand_or) return std::unexpected(std::move(operand_or.error()));
+  auto dest_or = RenderTypeAsCpp(view.Unit(), view.Class(), dest);
+  if (!dest_or) return std::unexpected(std::move(dest_or.error()));
+  return "static_cast<" + *dest_or + ">(" + *operand_or + ")";
 }
 
 }  // namespace
@@ -1614,6 +1596,9 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr)
           },
           [&](const mir::RealLiteral& r) -> diag::Result<std::string> {
             return RenderRealLiteralExpr(view, expr, r);
+          },
+          [](const mir::NullLiteral&) -> diag::Result<std::string> {
+            return std::string{"nullptr"};
           },
           [&](const mir::ParamRef& r) -> diag::Result<std::string> {
             return RenderParamExpr(view, r);
@@ -1645,6 +1630,12 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr)
           },
           [&](const mir::DerefExpr& d) -> diag::Result<std::string> {
             return RenderDerefExpr(view, d);
+          },
+          [&](const mir::AddressOfExpr& a) -> diag::Result<std::string> {
+            return RenderAddressOfExpr(view, a);
+          },
+          [&](const mir::PointerCastExpr& c) -> diag::Result<std::string> {
+            return RenderPointerCastExpr(view, c, expr.type);
           },
           [&](const mir::MemberAccessExpr& m) -> diag::Result<std::string> {
             const auto& cls = view.EnclosingClassAtHops(m.member.hops);

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -341,37 +341,13 @@ auto RenderDoWhileStmtNode(
   return result;
 }
 
-// The Observable pointer a sensitivity leaf subscribes to: a plain member
-// yields the address of its own field; an ExternalRef member subscribes
-// through its resolved cell (AsObservable); a downward slot is already a
-// resolved `Var<T>*`, so the slot name is the pointer.
-auto RenderSensitivityRefPtr(
-    const ScopeView& view, const mir::SensitivityRef& ref)
-    -> diag::Result<std::string> {
-  auto name = RenderMemberName(view, ref);
-  if (!name) return std::unexpected(std::move(name.error()));
-  const auto& var = view.EnclosingClassAtHops(ref.hops).members.Get(ref.var);
-  if (std::holds_alternative<mir::ExternalRefType>(
-          view.Unit().GetType(var.type).data)) {
-    return *name + ".AsObservable()";
-  }
-  // A borrowed-pointer slot already holds a `Var<T>*` (= Observable*); the
-  // pointer value is the subscription target, no address-of.
-  if (const auto* ptr =
-          std::get_if<mir::PointerType>(&view.Unit().GetType(var.type).data);
-      ptr != nullptr && ptr->ownership == mir::PointerOwnership::kBorrowed) {
-    return *name;
-  }
-  return "&" + *name;
-}
-
 auto RenderSensitivityWaitStmt(
     const ScopeView& view, const mir::SensitivityWaitStmt& s,
     std::size_t indent) -> diag::Result<std::string> {
   std::string result = Indent(indent) + "co_await lyra::runtime::WaitAny({";
   for (std::size_t i = 0; i < s.reads.size(); ++i) {
     const auto& read = s.reads[i];
-    auto ptr_or = RenderSensitivityRefPtr(view, read.ref);
+    auto ptr_or = RenderExpr(view, view.Expr(read.observable_ptr));
     if (!ptr_or) return std::unexpected(std::move(ptr_or.error()));
     if (i != 0) result += ", ";
     result += "{" + *ptr_or + ", " +
@@ -396,11 +372,6 @@ auto RenderStmt(
       Overloaded{
           [&](const mir::EmptyStmt&) -> diag::Result<std::string> {
             return Indent(indent) + ";\n";
-          },
-          [&](const mir::DelayStmt& s) -> diag::Result<std::string> {
-            return Indent(indent) + "co_await lyra::runtime::Delay(" +
-                   "self->Services()" + ", " + std::to_string(s.duration) +
-                   ", kTimePrecisionPower);\n";
           },
           [&](const mir::LocalDeclStmt& s) -> diag::Result<std::string> {
             return RenderLocalDeclStmt(view, s, indent);

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -134,8 +134,7 @@ auto LowerNamedValueProc(
 // owned child -- an instance member or a generate block; an upward path
 // (`Top.g`, `Top.sib.y`) starts by climbing the parent chain to the named
 // ancestor -- a module instance, a named generate block, or the root. The
-// shared tail (`path.subspan(1)`) reaches the leaf in both directions. See
-// reference_resolution.md, docs/decisions/hierarchical-reference-resolution.md.
+// shared tail (`path.subspan(1)`) reaches the leaf in both directions.
 auto LowerHierarchicalValueProc(
     ModuleLowerer& module, WalkFrame frame,
     const slang::ast::HierarchicalValueExpression& hve)

--- a/src/lyra/lowering/ast_to_hir/specialization_name.cpp
+++ b/src/lyra/lowering/ast_to_hir/specialization_name.cpp
@@ -16,9 +16,9 @@ namespace lyra::lowering::ast_to_hir {
 
 namespace {
 
-// FNV-1a, so producer and consumer agree on the name across separately compiled
-// units and across sessions. A process-seeded or pointer-derived hash would not
-// (incremental_build.md forbids it as a key); this folds only the bytes.
+// FNV-1a, so producer and consumer agree on the name across separately
+// compiled units and across sessions. A process-seeded or pointer-derived
+// hash would not be reproducible across runs; this folds only the bytes.
 auto Fnv1a64(std::string_view bytes) -> std::uint64_t {
   std::uint64_t hash = 0xcbf29ce484222325ULL;
   for (const unsigned char byte : bytes) {

--- a/src/lyra/lowering/ast_to_hir/statement/timing.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/timing.cpp
@@ -12,7 +12,6 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
-#include "lyra/diag/kind.hpp"
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 
@@ -236,9 +235,8 @@ auto LowerEventTriggerStmt(
 }
 
 // LRM 9.4.3 `wait (cond) body`. Sensitivity is precomputed by driving slang's
-// flow analysis on `w.cond` via a per-wait `DefaultDFA` run inside
-// `BuildSensitivityReadStore` (see `docs/decisions/read-set-inference.md`).
-// We look up the result here keyed by the cond expression.
+// flow analysis on `w.cond` via a per-wait `DefaultDFA` run upstream; the
+// result is looked up here keyed by the cond expression.
 auto LowerWaitStmt(
     ProcessLowerer& proc, WalkFrame frame, const slang::ast::WaitStatement& w,
     diag::SourceSpan span) -> diag::Result<hir::Stmt> {

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -44,8 +44,7 @@ namespace {
 // Wrap a value type in `ObservableType` iff it is a SystemVerilog value-storage
 // data type (LRM 6.5 / 7.x). Handle / wrapper types (pointer / vector / object
 // / external ref / external unit object) and named events (LRM 15 -- carry
-// their own subscribe mechanism) pass through unwrapped. See
-// `docs/decisions/value-type-concepts.md`.
+// their own subscribe mechanism) pass through unwrapped.
 auto MaybeWrapObservable(ModuleLowerer& module, mir::TypeId t) -> mir::TypeId {
   const auto& data = module.Unit().GetType(t).data;
   const bool wrap = std::holds_alternative<mir::PackedArrayType>(data) ||
@@ -242,13 +241,13 @@ auto InstallInstanceMembers(ClassLowerer& lowerer, WalkFrame frame)
 // An upward cross-unit reference materializes as an ExternalRef member: the
 // symbol -- ancestor name, by-name tail through its owned children, and leaf
 // signal -- lives on its type, and the runtime ExternUp member self-relocates
-// at Bind by climbing the parent chain then walking the tail
-// (docs/architecture/emission_model.md). A downward reference gets a borrowed-
-// pointer slot member, null until the constructor resolves it. Both
-// run before processes so reads resolve to the slot; both record their MIR read
-// target as a StructuralVarRef to that member, in HIR slot order. The returned
-// vector carries the downward slot var per ref (nullopt for upward), consumed
-// by InstallCrossUnitRefs once the children exist.
+// at Bind by climbing the parent chain then walking the tail. A downward
+// reference gets a borrowed-pointer slot member, null until the constructor
+// resolves it. Both run before processes so reads resolve to the slot; both
+// record their MIR read target as a StructuralVarRef to that member, in HIR
+// slot order. The returned vector carries the downward slot var per ref
+// (nullopt for upward), consumed by InstallCrossUnitRefs once the children
+// exist.
 auto MaterializeCrossUnitRefTargets(ClassLowerer& lowerer, WalkFrame frame)
     -> std::vector<std::optional<mir::MemberId>> {
   ModuleLowerer& module = lowerer.Module();
@@ -317,7 +316,7 @@ auto MaterializeCrossUnitRefTargets(ClassLowerer& lowerer, WalkFrame frame)
 // so render casts the untyped storage pointer mechanically. Per-dimension array
 // indices are ordinary integer-literal arguments, never bundled with the name.
 auto BuildDownwardNavValue(
-    const ModuleLowerer& module, WalkFrame frame, const std::string& head_name,
+    ModuleLowerer& module, WalkFrame frame, const std::string& head_name,
     const std::vector<hir::PathStep>& path, mir::TypeId slot_type,
     mir::TypeId scope_ptr_type) -> mir::Expr {
   mir::Block& ctor_block = *frame.current_block;
@@ -344,39 +343,55 @@ auto BuildDownwardNavValue(
         "owned child");
   }
 
+  const auto& builtins = module.Unit().builtins;
+  const auto string_literal = [&](const std::string& s) -> mir::ExprId {
+    return ctor_block.exprs.Add(
+        mir::Expr{
+            .data = mir::StringLiteral{.value = s}, .type = builtins.string});
+  };
+
   mir::ExprId cur = ctor_block.exprs.Add(MakeSelfRefExpr(frame, self_ptr_type));
   for (std::size_t i = 0; i + 1 < hops.size(); ++i) {
-    std::vector<mir::ExprId> args;
-    args.push_back(cur);
-    for (const mir::ExprId idx : hops[i].indices) {
-      args.push_back(idx);
-    }
+    const mir::TypeId indices_type = module.Unit().AddType(
+        mir::UnpackedArrayType{
+            .element_type = builtins.int32, .size = hops[i].indices.size()});
+    const mir::ExprId indices_id = ctor_block.exprs.Add(
+        mir::Expr{
+            .data = mir::ArrayLiteralExpr{.elements = hops[i].indices},
+            .type = indices_type});
     cur = ctor_block.exprs.Add(
         mir::Expr{
             .data =
                 mir::CallExpr{
                     .callee =
-                        mir::RuntimeNavCallee{
-                            .fn = mir::RuntimeFn::kGetChild,
-                            .name = hops[i].name},
-                    .arguments = std::move(args)},
+                        mir::BuiltinFnCallee{
+                            .id = support::BuiltinFn::kGetChild},
+                    .arguments =
+                        {cur, string_literal(hops[i].name), indices_id}},
             .type = scope_ptr_type});
   }
+  const mir::TypeId void_ptr_type = module.Unit().AddType(
+      mir::PointerType{
+          .pointee = builtins.void_type,
+          .ownership = mir::PointerOwnership::kBorrowed});
+  const mir::ExprId get_signal_id = ctor_block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee =
+                      mir::BuiltinFnCallee{
+                          .id = support::BuiltinFn::kGetSignal},
+                  .arguments = {cur, string_literal(hops.back().name)}},
+          .type = void_ptr_type});
   return mir::Expr{
-      .data =
-          mir::CallExpr{
-              .callee =
-                  mir::RuntimeNavCallee{
-                      .fn = mir::RuntimeFn::kGetSignal,
-                      .name = hops.back().name},
-              .arguments = {cur}},
+      .data = mir::PointerCastExpr{.operand = get_signal_id},
       .type = slot_type};
 }
 
 // A downward slot resolves in the constructor by navigating from the enclosing
-// scope after the children are built (reference_resolution.md): an ordinary
-// assignment of the navigation value into the borrowed-pointer slot. Upward
-// slots are materialized as ExternalRef members upstream and skipped here.
+// scope after the children are built: an ordinary assignment of the navigation
+// value into the borrowed-pointer slot. Upward slots are materialized as
+// ExternalRef members upstream and skipped here.
 void InstallCrossUnitRefs(
     ClassLowerer& lowerer, WalkFrame frame,
     const std::vector<mir::MemberId>& instance_member_vars,
@@ -813,9 +828,8 @@ auto ClassLowerer::Run(
               self_read(), mir::MemberRef{.hops = {.value = 0}, .var = mir_id},
               mir_field_type));
       // An observable cell init routes through `Var<T>::Set` so the field's
-      // engine-side change-tracking sees the initial value
-      // (`docs/decisions/value-type-concepts.md`). Plain fields use a regular
-      // `AssignExpr`.
+      // engine-side change-tracking sees the initial value. Plain fields use
+      // a regular `AssignExpr`.
       const mir::ExprId services_id = ctor_block.exprs.Add(
           mir::MakeServicesCallExpr(
               self_read(), module.Unit().builtins.services));
@@ -843,15 +857,24 @@ auto ClassLowerer::Run(
           mir::MakeMemberAccessExpr(
               self_read(), mir::MemberRef{.hops = {.value = 0}, .var = mir_id},
               mir_field_type));
+      const mir::TypeId var_ptr_type = module.Unit().AddType(
+          mir::PointerType{
+              .pointee = mir_field_type,
+              .ownership = mir::PointerOwnership::kBorrowed});
+      const mir::ExprId addr_id =
+          ctor_block.exprs.Add(mir::MakeAddressOfExpr(var_ref, var_ptr_type));
+      const mir::ExprId name_id = ctor_block.exprs.Add(
+          mir::Expr{
+              .data = mir::StringLiteral{.value = d.name},
+              .type = module.Unit().builtins.string});
       const mir::ExprId call = ctor_block.exprs.Add(
           mir::Expr{
               .data =
                   mir::CallExpr{
                       .callee =
-                          mir::RuntimeNavCallee{
-                              .fn = mir::RuntimeFn::kRegisterSignal,
-                              .name = d.name},
-                      .arguments = {self_read(), var_ref}},
+                          mir::BuiltinFnCallee{
+                              .id = support::BuiltinFn::kRegisterSignal},
+                      .arguments = {self_read(), name_id, addr_id}},
               .type = void_type});
       ctor_block.AppendStmt(
           mir::Stmt{

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -65,7 +65,8 @@ auto LowerContinuousAssign(
       mir::Stmt{
           .label = std::nullopt, .data = mir::ExprStmt{.expr = assign_id}});
 
-  body_block.AppendStmt(MakeSensitivityWaitStmt(lowerer, src.sensitivity_list));
+  body_block.AppendStmt(MakeSensitivityWaitStmt(
+      body_block, body_frame, lowerer, src.sensitivity_list));
 
   const mir::BlockId body_scope_id =
       process_block.child_scopes.Add(std::move(body_block));

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -107,9 +107,8 @@ auto BuildDefaultValueExpr(
           },
           // LRM Table 6-7: a dynamic array's default is the empty array.
           // The wrapper still needs the element type's default supplied at
-          // construction so OOB reads and resize-fills have a shape source --
-          // see `docs/decisions/runtime-shape-and-default-value.md`. Emit
-          // chain: a construction call on `element_default` -> the
+          // construction so OOB reads and resize-fills have a shape source.
+          // Emit chain: a construction call on `element_default` -> the
           // `DynamicArray<T>(...)` ctor that stores the value and leaves
           // `data_` empty.
           [&](const mir::DynamicArrayType& da) -> mir::Expr {
@@ -178,11 +177,7 @@ auto BuildDefaultValueExpr(
                 .type = type};
           },
           [&](const mir::PointerType&) -> mir::Expr {
-            return mir::Expr{
-                .data =
-                    mir::CallExpr{
-                        .callee = mir::ConstructorCallee{}, .arguments = {}},
-                .type = type};
+            return mir::Expr{.data = mir::NullLiteral{}, .type = type};
           },
           [&](const mir::VectorType&) -> mir::Expr {
             return mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -269,7 +269,7 @@ auto LowerSystemSubroutineCall(
           [&](const support::TerminationSystemSubroutineInfo& term)
               -> diag::Result<mir::Expr> {
             return LowerFinishSystemSubroutineCall(
-                process, frame, call, desc.id, desc.name, term, span);
+                process, frame, call, desc.name, term, span);
           },
           [&](const support::DiagnosticSystemSubroutineInfo&)
               -> diag::Result<mir::Expr> {
@@ -293,8 +293,7 @@ auto LowerSystemSubroutineCall(
           },
           [&](const support::TimeSystemSubroutineInfo& time_info)
               -> diag::Result<mir::Expr> {
-            return LowerTimeSystemSubroutineCall(
-                process, frame, desc.id, time_info);
+            return LowerTimeSystemSubroutineCall(process, frame, time_info);
           },
           [&](const support::TimeFormatSystemSubroutineInfo&)
               -> diag::Result<mir::Expr> {
@@ -316,8 +315,7 @@ auto LowerSystemSubroutineCall(
 // where the copy-out statement has nowhere to be sequenced. ref / const
 // ref alias the actual and copy nothing back (LRM 13.5.2), so they fall
 // through to the value-only lowering. The callee body receives its
-// instance handle as `arguments[0]` (mir.md invariant 11); SV actuals
-// follow.
+// instance handle as `arguments[0]`; SV actuals follow.
 auto LowerStructuralSubroutineCall(
     ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& c,
     const hir::StructuralSubroutineRef& usr, diag::SourceSpan span,
@@ -491,11 +489,10 @@ auto LowerBuiltinMethodCall(
   }
 
   // LRM 15.5.3: `e.triggered` reads the triggered flag out of
-  // RuntimeServices. The engine handle is a real trailing argument,
-  // threaded the same way every runtime effect threads it
-  // (docs/decisions/runtime-effects-as-generic-calls.md), not a backend-
-  // fabricated one. (`-> e` is the only producer of the trigger kind and
-  // lowers through LowerEventTriggerStmt; `await` takes no services.)
+  // RuntimeServices. The engine handle is a real trailing argument, threaded
+  // the same way every runtime effect threads it -- not a backend-fabricated
+  // one. (`-> e` is the only producer of the trigger kind and lowers through
+  // the event-trigger stmt path; `await` takes no services.)
   if (b.method == support::BuiltinFn::kTriggered) {
     args.push_back(block.exprs.Add(BuildServicesCallExpr(process, frame)));
   }

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -213,8 +213,7 @@ auto LowerHirIncDecExprProc(
   mir::ExprId target_id = block.exprs.Add(*std::move(target_or));
 
   // If the LHS reaches an observable storage cell, the mutation runs inside
-  // a `ScopedMutation` snapshot so subscribers fire once on destructor commit
-  // (`docs/decisions/value-type-concepts.md`).
+  // a `ScopedMutation` snapshot so subscribers fire once on destructor commit.
   const mir::ExprId root_id = FindLhsRootId(block, target_id);
   if (mir::IsObservableCellType(
           process.Module().Unit().GetType(block.exprs.Get(root_id).type))) {

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -108,7 +108,7 @@ auto StringBytesToConstant(
 // An SV string literal is a packed bit-vector constant (LRM 5.9), so MIR
 // carries it as the integer constant of its bytes. A string-typed literal (a
 // string parameter's value) instead builds a `value::String` via the
-// constructor. See decisions/string-packed-conversion.md.
+// constructor.
 auto LowerHirStringLiteral(
     const ModuleLowerer& module, const WalkFrame& frame,
     const hir::StringLiteral& s, mir::TypeId type) -> mir::Expr {

--- a/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
@@ -18,6 +18,7 @@
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/support/builtin_fn.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -40,9 +41,9 @@ auto TryExtractLiteralInt(const hir::Expr& expr)
 
 auto LowerFinishSystemSubroutineCall(
     const ProcessLowerer& process, const WalkFrame& frame,
-    const hir::CallExpr& call, support::SystemSubroutineId id,
-    std::string_view name, const support::TerminationSystemSubroutineInfo& info,
-    diag::SourceSpan span) -> diag::Result<mir::Expr> {
+    const hir::CallExpr& call, std::string_view name,
+    const support::TerminationSystemSubroutineInfo& info, diag::SourceSpan span)
+    -> diag::Result<mir::Expr> {
   const auto& hir_proc = process.HirBody();
   int level = info.default_level;
   if (!call.arguments.empty()) {
@@ -73,7 +74,7 @@ auto LowerFinishSystemSubroutineCall(
   return mir::Expr{
       .data =
           mir::CallExpr{
-              .callee = mir::SystemSubroutineCallee{.id = id},
+              .callee = mir::FreeFnCallee{.id = support::BuiltinFn::kFinish},
               .arguments = {services_id, level_id}},
       .type = builtins.void_type};
 }

--- a/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
@@ -29,10 +29,9 @@ namespace lyra::lowering::hir_to_mir {
 namespace {
 
 // Assembles the generic file-IO call: the engine handle (self.Services()) as
-// argument 0, then the task operands in runtime-signature order. Every file-IO
-// runtime entry takes RuntimeServices& first, so the handle is a leading
-// argument, not a backend-injected fact
-// (docs/decisions/runtime-effects-as-generic-calls.md).
+// argument 0, then the task operands in runtime-signature order. Every
+// file-IO runtime entry takes RuntimeServices& first, so the handle is a
+// leading argument, not a backend-injected fact.
 auto BuildFileIoCall(
     const ProcessLowerer& process, const WalkFrame& frame,
     support::SystemSubroutineId id, std::vector<mir::ExprId> operands,

--- a/src/lyra/lowering/hir_to_mir/expression/system/time.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/time.cpp
@@ -2,29 +2,43 @@
 
 #include <cstdint>
 
+#include "lyra/base/internal_error.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/support/builtin_fn.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
+namespace {
+
+struct TimeFnInfo {
+  support::BuiltinFn id;
+  mir::TypeId result_type;
+};
+
+auto SelectTimeFn(const mir::BuiltinMirTypes& builtins, support::TimeKind kind)
+    -> TimeFnInfo {
+  switch (kind) {
+    case support::TimeKind::kTime:
+      return {.id = support::BuiltinFn::kSimTime, .result_type = builtins.time};
+    case support::TimeKind::kStime:
+      return {.id = support::BuiltinFn::kSTime, .result_type = builtins.int32};
+    case support::TimeKind::kRealtime:
+      return {
+          .id = support::BuiltinFn::kRealTime,
+          .result_type = builtins.realtime};
+  }
+  throw InternalError("SelectTimeFn: unknown TimeKind");
+}
+
+}  // namespace
+
 auto LowerTimeSystemSubroutineCall(
     const ProcessLowerer& process, const WalkFrame& frame,
-    support::SystemSubroutineId id,
     const support::TimeSystemSubroutineInfo& info) -> diag::Result<mir::Expr> {
   const auto& builtins = process.Module().Unit().builtins;
-  mir::TypeId result_type = builtins.time;
-  switch (info.kind) {
-    case support::TimeKind::kTime:
-      result_type = builtins.time;
-      break;
-    case support::TimeKind::kStime:
-      result_type = builtins.int32;
-      break;
-    case support::TimeKind::kRealtime:
-      result_type = builtins.realtime;
-      break;
-  }
+  const TimeFnInfo fn = SelectTimeFn(builtins, info.kind);
   auto& body = *frame.current_block;
   const mir::ExprId services_id =
       body.exprs.Add(BuildServicesCallExpr(process, frame));
@@ -35,9 +49,9 @@ auto LowerTimeSystemSubroutineCall(
   return mir::Expr{
       .data =
           mir::CallExpr{
-              .callee = mir::SystemSubroutineCallee{.id = id},
+              .callee = mir::FreeFnCallee{.id = fn.id},
               .arguments = {services_id, unit_power_id}},
-      .type = result_type};
+      .type = fn.result_type};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -77,10 +77,10 @@ auto BuildPrintValueItem(
   if (!lowered_or) return std::unexpected(std::move(lowered_or.error()));
   mir::Expr lowered = *std::move(lowered_or);
 
-  // %s formats by operand type (LRM 21.2.1.7,
-  // decisions/string-packed-conversion.md): a String and a packed value each
-  // format directly, without building a string value. Only an unpacked byte
-  // array is not directly formattable, so it lifts to a string value here.
+  // %s formats by operand type (LRM 21.2.1.7): a String and a packed value
+  // each format directly, without building a string value. Only an unpacked
+  // byte array is not directly formattable, so it lifts to a string value
+  // here.
   const auto& value_type = process.Module().Unit().GetType(lowered.type);
   if (spec.kind == value::FormatKind::kString &&
       value_type.Kind() != mir::TypeKind::kString &&

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -252,13 +252,13 @@ auto LowerStraightLineProcess(ProcessLowerer& process, mir::ProcessKind kind)
       .root_block = std::move(process_block)};
 }
 
-// Wraps the body in a `forever` loop. `tail_stmt`, if present, is appended
-// after the lowered body inside the loop -- carries the materialised
-// SensitivityWaitStmt for always_comb / always_latch (LRM 9.2.2.2.1),
-// nullopt for `always` / `always_ff` where the body itself carries any
-// timing.
+// Wraps the body in a `forever` loop. `implicit_sensitivity`, if present,
+// is materialised into a `SensitivityWaitStmt` appended after the lowered
+// body -- the always_comb / always_latch (LRM 9.2.2.2.1) tail. `always` /
+// `always_ff` pass nullptr because the body itself carries any timing.
 auto LowerForeverProcess(
-    ProcessLowerer& process, std::optional<mir::Stmt> tail_stmt)
+    ProcessLowerer& process,
+    const std::vector<hir::SensitivityEntry>* implicit_sensitivity)
     -> diag::Result<mir::Process> {
   const WalkFrame& parent = process.OwnerCtorFrame();
   mir::Block process_block;
@@ -274,8 +274,9 @@ auto LowerForeverProcess(
             .Deeper();
     auto lowered = LowerStraightLineBodyInto(process, body_frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
-    if (tail_stmt.has_value()) {
-      body_block.AppendStmt(*std::move(tail_stmt));
+    if (implicit_sensitivity != nullptr) {
+      body_block.AppendStmt(MakeSensitivityWaitStmt(
+          body_block, body_frame, process.Owner(), *implicit_sensitivity));
     }
   }
 
@@ -332,12 +333,10 @@ auto ProcessLowerer::Run(const hir::Process& src)
       return LowerStraightLineProcess(*this, mir::ProcessKind::kFinal);
     case hir::ProcessKind::kAlways:
     case hir::ProcessKind::kAlwaysFf:
-      return LowerForeverProcess(*this, std::nullopt);
+      return LowerForeverProcess(*this, nullptr);
     case hir::ProcessKind::kAlwaysComb:
     case hir::ProcessKind::kAlwaysLatch:
-      return LowerForeverProcess(
-          *this,
-          MakeSensitivityWaitStmt(*owner_, src.implicit_sensitivity_list));
+      return LowerForeverProcess(*this, &src.implicit_sensitivity_list);
   }
   throw InternalError("ProcessLowerer::Run: unknown HIR ProcessKind");
 }

--- a/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
+++ b/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
@@ -1,5 +1,6 @@
 #include "lyra/lowering/hir_to_mir/sensitivity_wait.hpp"
 
+#include <cstdint>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -8,8 +9,14 @@
 #include "lyra/base/overloaded.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/self_ref.hpp"
+#include "lyra/lowering/hir_to_mir/walk_frame.hpp"
+#include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/expr.hpp"
 #include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type.hpp"
 #include "lyra/mir/value_ref.hpp"
+#include "lyra/support/builtin_fn.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -29,27 +36,70 @@ auto LowerEventEdge(hir::EventEdge edge) -> mir::EventEdge {
   throw InternalError("LowerEventEdge: unknown hir::EventEdge value");
 }
 
+// Selects the observable-pointer expression for one sensitivity leaf, given
+// the lowered MIR member ref and its slot type. Adds the chosen expression
+// (and any sub-expressions it needs) to `block` and returns its id. The
+// three cases mirror the runtime's three storage shapes for an observable:
+// upward-ref slot (needs `AsObservable` resolution), pre-resolved borrowed
+// pointer (already an observable*), and a directly owned cell (address-of).
+auto BuildObservablePtrExpr(
+    mir::Block& block, const WalkFrame& frame, mir::CompilationUnit& unit,
+    const mir::MemberRef& member) -> mir::ExprId {
+  const mir::TypeId field_type =
+      frame.EnclosingClassAtHops(member.hops).members.Get(member.var).type;
+  const mir::ExprId member_access_id =
+      block.exprs.Add(BuildStructuralMemberAccessExpr(frame, member));
+  const auto& field_type_data = unit.GetType(field_type).data;
+
+  if (std::holds_alternative<mir::ExternalRefType>(field_type_data)) {
+    return block.exprs.Add(
+        mir::Expr{
+            .data =
+                mir::CallExpr{
+                    .callee =
+                        mir::BuiltinFnCallee{
+                            .id = support::BuiltinFn::kAsObservable},
+                    .arguments = {member_access_id}},
+            .type = field_type});
+  }
+
+  if (const auto* ptr = std::get_if<mir::PointerType>(&field_type_data);
+      ptr != nullptr && ptr->ownership == mir::PointerOwnership::kBorrowed) {
+    return member_access_id;
+  }
+
+  const mir::TypeId ptr_type = unit.AddType(
+      mir::PointerType{
+          .pointee = field_type,
+          .ownership = mir::PointerOwnership::kBorrowed});
+  return block.exprs.Add(mir::MakeAddressOfExpr(member_access_id, ptr_type));
+}
+
 }  // namespace
 
 auto MakeSensitivityWaitStmt(
+    mir::Block& target_block, const WalkFrame& frame,
     const ClassLowerer& lowerer,
     const std::vector<hir::SensitivityEntry>& sensitivity_list) -> mir::Stmt {
+  auto& unit = lowerer.Module().Unit();
   std::vector<mir::SensitivityRead> reads;
   reads.reserve(sensitivity_list.size());
   for (const auto& entry : sensitivity_list) {
-    mir::SensitivityRef ref = std::visit(
+    const mir::MemberRef member = std::visit(
         Overloaded{
-            [&](const hir::StructuralVarRef& r) -> mir::SensitivityRef {
+            [&](const hir::StructuralVarRef& r) -> mir::MemberRef {
               return lowerer.TranslateStructuralVar(r.hops, r.var);
             },
-            [&](const hir::CrossUnitVarRef& r) -> mir::SensitivityRef {
+            [&](const hir::CrossUnitVarRef& r) -> mir::MemberRef {
               return lowerer.CrossUnitRefTarget(r.id).target;
             },
         },
         entry.ref);
-    // Resolve the SV-level footprint into the runtime projection a backend
-    // emits directly: a bit-addressed read becomes `(lsb, hi - lsb + 1)`; a
-    // whole-signal read (no footprint) becomes width 0, the any-change form.
+    const mir::ExprId observable_ptr_id =
+        BuildObservablePtrExpr(target_block, frame, unit, member);
+    // LRM 9.4.2 / 9.4.2.2 / 9.4.3: a bit-addressed footprint becomes
+    // `(lsb, hi - lsb + 1)`; a whole-signal read (no footprint) is encoded
+    // as width 0 (the any-change form at the runtime trigger).
     const std::uint64_t lsb_bit_offset =
         entry.footprint.has_value() ? entry.footprint->first : 0;
     const std::uint64_t bit_width =
@@ -58,7 +108,7 @@ auto MakeSensitivityWaitStmt(
             : 0;
     reads.push_back(
         mir::SensitivityRead{
-            .ref = std::move(ref),
+            .observable_ptr = observable_ptr_id,
             .lsb_bit_offset = lsb_bit_offset,
             .bit_width = bit_width,
             .edge_kind = LowerEventEdge(entry.edge_kind)});

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -254,8 +254,8 @@ auto LowerSubroutineCallWithWritebacks(
   mir::Block wrapper;
   const WalkFrame wrapper_frame = frame.WithBlock(&wrapper).Deeper();
 
-  // The callee body takes its instance handle as `arguments[0]` (mir.md
-  // invariant 11); the SV actuals (with output / inout temps) follow.
+  // The callee body takes its instance handle as `arguments[0]`; the SV
+  // actuals (with output / inout temps) follow.
   std::vector<mir::ExprId> call_args;
   call_args.reserve(call.arguments.size() + 1);
   call_args.push_back(wrapper.exprs.Add(MakeSelfRefExpr(

--- a/src/lyra/lowering/hir_to_mir/statement/flow.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/flow.cpp
@@ -34,8 +34,7 @@ namespace {
 // declaration itself emits nothing. The mangled name carries
 // `<callable>__<source>_<hir_var_id>` so sibling callables sharing a source
 // name (`static int x;` in two processes of the same module) and nested
-// blocks repeating an identifier do not collide on the owner's
-// member arena (`docs/decisions/variable-lifetime-storage.md`).
+// blocks repeating an identifier do not collide on the owner's member arena.
 auto LowerStaticVarDeclStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::VarDeclStmt& v, const hir::ProceduralVarDecl& hir_local,
@@ -70,10 +69,9 @@ auto LowerStaticVarDeclStmt(
           mir::MemberRef{
               .hops = mir::EnclosingHops{.value = 0}, .var = static_var},
           type));
-  // A static-lifetime local lives as a member on the owner; if its
-  // declared type is an observable cell wrapper the init must route through
-  // `Var<T>::Set` so subscribers fire on its initial value (LRM 13.3.1 +
-  // `docs/decisions/value-type-concepts.md`).
+  // A static-lifetime local lives as a member on the owner; if its declared
+  // type is an observable cell wrapper the init must route through
+  // `Var<T>::Set` so subscribers fire on its initial value (LRM 13.3.1).
   const mir::ExprId services_id = ctor_block.exprs.Add(
       mir::MakeServicesCallExpr(
           ctor_self_read, process.Module().Unit().builtins.services));

--- a/src/lyra/lowering/hir_to_mir/statement/timing.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/timing.cpp
@@ -24,6 +24,7 @@
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/stmt.hpp"
+#include "lyra/support/builtin_fn.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -142,7 +143,8 @@ auto LowerEventTimedStmt(
     -> diag::Result<mir::Stmt> {
   return LowerTimedWaitWrapper(
       process, frame, std::move(label), t.stmt,
-      [&](mir::Block&, WalkFrame) -> diag::Result<mir::Stmt> {
+      [&](mir::Block& child_block,
+          WalkFrame child_frame) -> diag::Result<mir::Stmt> {
         std::vector<hir::SensitivityEntry> union_reads;
         union_reads.reserve(ec.triggers.size());
         for (const auto& trigger : ec.triggers) {
@@ -164,7 +166,8 @@ auto LowerEventTimedStmt(
             union_reads.push_back(leaf);
           }
         }
-        return MakeSensitivityWaitStmt(process.Owner(), union_reads);
+        return MakeSensitivityWaitStmt(
+            child_block, child_frame, process.Owner(), union_reads);
       });
 }
 
@@ -175,24 +178,48 @@ auto LowerImplicitEventTimedStmt(
     -> diag::Result<mir::Stmt> {
   return LowerTimedWaitWrapper(
       process, frame, std::move(label), t.stmt,
-      [&](mir::Block&, WalkFrame) -> diag::Result<mir::Stmt> {
-        return MakeSensitivityWaitStmt(process.Owner(), ie.sensitivity_list);
+      [&](mir::Block& child_block,
+          WalkFrame child_frame) -> diag::Result<mir::Stmt> {
+        return MakeSensitivityWaitStmt(
+            child_block, child_frame, process.Owner(), ie.sensitivity_list);
       });
 }
 
-// LRM 9.4.1 `#N body`.
+// LRM 9.4.1 `#N body`. The wait lowers to a coroutine-suspending free-function
+// call whose argument vector states services, the literal tick count in the
+// enclosing scope's precision, and that scope's precision power (LRM 3.14.2);
+// the runtime scales from precision to the design-global tick (LRM 3.14.3).
 auto LowerDelayTimedStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::TimedStmt& t, const hir::DelayControl& d)
     -> diag::Result<mir::Stmt> {
   return LowerTimedWaitWrapper(
       process, frame, std::move(label), t.stmt,
-      [&](mir::Block&, WalkFrame) -> diag::Result<mir::Stmt> {
+      [&](mir::Block& child_block,
+          WalkFrame child_frame) -> diag::Result<mir::Stmt> {
         auto ticks_or = ResolveDelayTicks(process, d);
         if (!ticks_or) return std::unexpected(std::move(ticks_or.error()));
+        const auto& builtins = process.Module().Unit().builtins;
+        const mir::ExprId services_id =
+            child_block.exprs.Add(BuildServicesCallExpr(process, child_frame));
+        const mir::ExprId duration_id = child_block.exprs.Add(
+            mir::MakeInt32Literal(
+                builtins.int32, static_cast<std::int64_t>(*ticks_or)));
+        const mir::ExprId precision_id = child_block.exprs.Add(
+            mir::MakeInt32Literal(
+                builtins.int32, static_cast<std::int64_t>(
+                                    process.Resolution().precision_power)));
+        const mir::ExprId call_id = child_block.exprs.Add(
+            mir::Expr{
+                .data =
+                    mir::CallExpr{
+                        .callee =
+                            mir::FreeFnCallee{.id = support::BuiltinFn::kDelay},
+                        .arguments = {services_id, duration_id, precision_id}},
+                .type = builtins.void_type});
         return mir::Stmt{
             .label = std::nullopt,
-            .data = mir::DelayStmt{.duration = *ticks_or}};
+            .data = mir::AwaitStmt{.awaitable = call_id}};
       });
 }
 
@@ -229,8 +256,7 @@ auto LowerEventTriggerStmt(
   const mir::ExprId receiver_id = block.exprs.Add(*std::move(receiver_or));
   // LRM 15.5.1: triggering reaches RuntimeServices to wake subscribers. The
   // engine handle is a real trailing argument, threaded the same way every
-  // runtime effect threads it
-  // (docs/decisions/runtime-effects-as-generic-calls.md).
+  // runtime effect threads it.
   const mir::ExprId services_id =
       block.exprs.Add(BuildServicesCallExpr(process, frame));
   mir::Expr call{
@@ -272,7 +298,9 @@ auto LowerWaitStmt(
   const auto& reads = w.sensitivity_list;
 
   mir::Block inner_block;
-  inner_block.AppendStmt(MakeSensitivityWaitStmt(process.Owner(), reads));
+  const WalkFrame inner_frame = wrapper_frame.WithBlock(&inner_block).Deeper();
+  inner_block.AppendStmt(MakeSensitivityWaitStmt(
+      inner_block, inner_frame, process.Owner(), reads));
 
   const mir::BlockId inner_scope_id =
       wrapper.child_scopes.Add(std::move(inner_block));

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -391,11 +391,6 @@ class MirDumper {
               return std::format(
                   "ClosureRef[closure=Expr[{}]]", cr.closure.value);
             },
-            [](const RuntimeNavCallee& nav) -> std::string {
-              return std::format(
-                  "RuntimeNavCallee[fn={}, name=\"{}\"]",
-                  static_cast<int>(nav.fn), nav.name);
-            },
             [](const BuiltinFnCallee& b) -> std::string {
               return std::format(
                   "BuiltinFnCallee[id=\"{}\"]", support::BuiltinFnName(b.id));
@@ -489,6 +484,15 @@ class MirDumper {
             },
             [](const RealLiteral& lit) -> std::string {
               return std::format("RealLiteral({})", lit.value);
+            },
+            [](const NullLiteral&) -> std::string { return "NullLiteral"; },
+            [](const AddressOfExpr& a) -> std::string {
+              return std::format(
+                  "AddressOfExpr operand=Expr[{}]", a.operand.value);
+            },
+            [](const PointerCastExpr& c) -> std::string {
+              return std::format(
+                  "PointerCastExpr operand=Expr[{}]", c.operand.value);
             },
             [this](const ParamRef& r) -> std::string {
               const auto& owner = ResolveScopeAtHops(r.hops.value);
@@ -848,11 +852,6 @@ class MirDumper {
               DumpConstructExternalUnitStmt(id, s);
             },
             [&](const ForStmt& s) { DumpForStmt(enclosing, s, id); },
-            [&](const DelayStmt& d) {
-              Line(
-                  std::format(
-                      "Stmt[{}] DelayStmt ticks={}", id.value, d.duration));
-            },
             [&](const WhileStmt& s) { DumpWhileStmt(enclosing, s, id); },
             [&](const DoWhileStmt& s) { DumpDoWhileStmt(enclosing, s, id); },
             [&](const BreakStmt& s) {
@@ -900,13 +899,13 @@ class MirDumper {
               Line(std::format("Stmt[{}] SensitivityWaitStmt", id.value));
               Indent();
               for (const auto& r : s.reads) {
-                const std::string ref_str = std::format(
-                    "MemberRef hops={} var=Member[{}]", r.ref.hops.value,
-                    r.ref.var.value);
                 Line(
                     std::format(
-                        "{} lsb={} width={} edge={}", ref_str, r.lsb_bit_offset,
-                        r.bit_width, FormatEventEdge(r.edge_kind)));
+                        "observable=Expr[{}] {} lsb={} width={} edge={}",
+                        r.observable_ptr.value,
+                        FormatExpr(enclosing, r.observable_ptr),
+                        r.lsb_bit_offset, r.bit_width,
+                        FormatEventEdge(r.edge_kind)));
               }
               Dedent();
             },

--- a/src/lyra/runtime/scope.cpp
+++ b/src/lyra/runtime/scope.cpp
@@ -1,6 +1,5 @@
 #include "lyra/runtime/scope.hpp"
 
-#include <algorithm>
 #include <cstddef>
 #include <functional>
 #include <memory>
@@ -29,9 +28,8 @@ Scope::Scope(Scope* parent, std::string name, RuntimeServices& services)
 void Scope::AddChild(Scope& child) {
   // Linking establishes the full bidirectional edge. A child built under a
   // parent already set `parent_` in its constructor; a top-level block is
-  // constructed parentless and adopts `$root` as its parent here, so an upward
-  // climb from inside a top reaches the root (LRM 23.6, hierarchy_and_generate
-  // invariant 8).
+  // constructed parentless and adopts `$root` as its parent here, so an
+  // upward climb from inside a top reaches the root (LRM 23.6).
   child.parent_ = this;
   children_.push_back(&child);
 }
@@ -65,9 +63,20 @@ auto Scope::GetSignal(std::string_view name) -> void* {
 }
 
 auto Scope::GetChild(
-    std::string_view name, std::span<const std::size_t> indices) -> Scope* {
+    std::string_view name, std::span<const lyra::value::PackedArray> indices)
+    -> Scope* {
   for (const ChildEntry& child : child_entries_) {
-    if (child.name == name && std::ranges::equal(child.indices, indices)) {
+    if (child.name != name || child.indices.size() != indices.size()) {
+      continue;
+    }
+    bool matched = true;
+    for (std::size_t i = 0; i < indices.size(); ++i) {
+      if (child.indices[i] != static_cast<std::size_t>(indices[i].ToInt64())) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) {
       return child.scope;
     }
   }

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -263,6 +263,24 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "peek_buffered";
     case BuiltinFn::kAdvanceFd:
       return "advance_fd";
+    case BuiltinFn::kDelay:
+      return "delay";
+    case BuiltinFn::kSimTime:
+      return "sim_time";
+    case BuiltinFn::kSTime:
+      return "stime";
+    case BuiltinFn::kRealTime:
+      return "realtime";
+    case BuiltinFn::kFinish:
+      return "finish";
+    case BuiltinFn::kAsObservable:
+      return "as_observable";
+    case BuiltinFn::kRegisterSignal:
+      return "register_signal";
+    case BuiltinFn::kGetSignal:
+      return "get_signal";
+    case BuiltinFn::kGetChild:
+      return "get_child";
   }
   throw InternalError("BuiltinFnName: unknown BuiltinFn");
 }


### PR DESCRIPTION
## Summary

The C++ backend was injecting operands MIR did not state -- `&` for register-signal, `static_cast` for get-signal, `std::array{...}` for child indices, `self->Services()` for `#N` delays, `void*` cell-pointer lookups -- and translating SV-task ids back into runtime entry names in render. Each is the same `mir.md` invariant 10 failure (a backend re-derives a fact MIR did not state); each is masked in the C++ backend by some C++ language convenience (`&` operator, reference parameter binding, ABI-implicit conversions) and would propagate to every other backend independently. This PR lifts those operations into MIR so render becomes pure mechanical translation: `fn(rendered_args)` for every call, `static_cast<T>(operand)` for every cast, `&place` for every address-of.

## Design

### New MIR primitives

`AddressOfExpr` is the place-to-pointer dual of `DerefExpr`; HIR-to-MIR wraps it around member access at sites that need a stable cell pointer (sensitivity-leaf subscription, `kRegisterSignal`). `NullLiteral` retires the render-side `T()` -> `nullptr` pattern for default-init pointers. `PointerCastExpr` reinterprets the result of `kGetSignal` (returns `void*`) into the call site's slot type at the MIR layer, so the cast destination is a stated MIR fact rather than render-inferred.

### `RuntimeNavCallee` retired

The three by-name scope operations -- `kRegisterSignal` / `kGetSignal` / `kGetChild` -- now ride `BuiltinFnCallee`. The signal / child name moved from callee metadata to a regular `StringLiteral` argument; child indices ride as an `ArrayLiteralExpr`; the `kGetSignal` cast is an explicit `PointerCastExpr`. Render's 4-arm switch on the dedicated callee variant is gone -- every call renders through the same `(receiver)->Method(rendered_args)` path. Runtime `Scope::GetChild` now takes `std::span<const value::PackedArray>` and does the `.ToInt64()` projection itself.

### Sensitivity-leaf and Delay generalized

Each sensitivity leaf carries an explicit observable-pointer expression chosen at HIR-to-MIR -- `AddressOf(MemberAccess)` for a plain member, bare `MemberAccess` for a borrowed-pointer slot, `Call(kAsObservable, ...)` for an upward `ExternalRef`. `DelayStmt` retired entirely; `#N` lowers to `AwaitStmt` over a generic `Call(kDelay, [services, duration, precision])`. Several R37 system-subroutine families (`$time` / `$stime` / `$realtime` / `$finish`) migrated off `SystemSubroutineCallee` to `FreeFnCallee`.

### Comment-rules infrastructure (separate axis)

The repo's recurring code-comment violations (doc-citation back-references, implementation-name coupling, drift) had no central rules doc and no enforcement loop. This PR lands `docs/code-comments.md` as the single source of truth (Clean Code Why/How/What framing, 7 hard bans, per-comment litmus) and updates `CLAUDE.local.md` to require three mandatory re-reads (pre-plan, pre-write, post-edit). The 70 pre-existing doc-reference violations across `src/` and `include/` were swept as dogfooding for the new rules.

## Testing

`bazel build //...` and `bazel test //... --test_output=errors` both green. Architecture / ASCII / C++ style / exception-policy checks all clean.