### PR TITLE
Lower calls context-free across both pass classes

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -40,6 +40,9 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
 - [array-method-dispatch](array-method-dispatch.md) -- LRM 7.12 array-method runtime semantics
   (empty-reduction zero, selection sort over standard introsort); the original per-family dispatch
   shape is superseded by [builtin-call-identity](builtin-call-identity.md).
+- [array-manipulation-entry-stream](array-manipulation-entry-stream.md) -- LRM 7.12 locator /
+  reduction / `map` families operate over an ordered `(index, element)` entry stream modeled on Rust
+  `Iterator` / C++ `std::ranges`; the ordering family stays an in-place positional permutation.
 - [format-dispatch](format-dispatch.md) -- value formatting dispatches through `Formatter<T>` and
   `FormatArg`.
 
@@ -66,6 +69,12 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
   operator (`AddressOfExpr`), dual to `DerefExpr`. Runtime APIs taking pointers receive an explicit
   address-taken operand; the backend never injects `&`.
 - [event-control-unification](event-control-unification.md) -- unified treatment of event control.
+- [generic-lowering-machinery](generic-lowering-machinery.md) -- generic arena and shared
+  context-free expression-handler templates over the pass class; node types stay typed.
+- [context-free-call-lowering](context-free-call-lowering.md) -- one expression dispatcher template
+  per boundary (context-free kinds listed once); the call family becomes a template across pass
+  classes once the `with`-clause element / index are co-equal closure parameters rather than a
+  procedural-body local.
 
 ### References and construction
 

--- a/docs/decisions/context-free-call-lowering.md
+++ b/docs/decisions/context-free-call-lowering.md
@@ -1,0 +1,120 @@
+# Context-free call lowering
+
+Date: 2026-06-23 Status: accepted
+
+## Context
+
+`generic-lowering-machinery.md` established that an expression's meaning does not depend on whether
+a process body or a structural scope encloses it, so each context-free expression family is one
+function template over the pass class (constrained on the `ExprLowerer` duck-typed surface),
+instantiated for both pass classes. The operator, select, member-access, concatenation, conversion,
+and assignment-pattern families all collapsed to single templates on this rule.
+
+Two things were left unfinished, and they reinforced each other:
+
+1. **The dispatcher was still per-context.** Each lowering boundary kept two dispatchers -- one over
+   the procedural pass class, one over the structural pass class -- and each listed its kinds
+   independently. Context-free kinds had to be wired into both by hand, so a kind added to one and
+   forgotten in the other was a silent gap. The call, `inside`, and replication families were
+   exactly that: present procedurally, absent structurally, falling through to an "unsupported
+   expression form" diagnostic even though all three are ordinary value expressions.
+
+2. **The call family was procedural-only.** Beyond the dispatcher gap, the call handlers themselves
+   took the procedural pass class. The single reason they could not be templates was the LRM 7.12
+   `with`-clause iteration variable, which was modeled as a procedural-body local; everything else
+   in call lowering already used only the duck-typed surface.
+
+This bites simulation-time expressions a structural scope owns. A continuous assignment is
+simulation-time behavior -- it lowers to a process that re-drives its net on a value change -- so
+its right-hand side is a simulation-time expression with the full value-expression set: function
+calls, the bit-vector query `$isunknown`, the `inside` operator, replication. `always_comb y = f(x)`
+lowered; the equivalent `assign y = f(x)` did not. The structural / constructor-time constraint that
+a structural expression may not depend on simulation-time state (`runtime_model.md`) applies to
+genuine constructor-time expressions -- generate conditions, parameter values, instance-array
+dimensions, which the frontend already holds constant -- not to the continuous-assign right-hand
+side.
+
+## Decision
+
+### Every context-free kind routes through one shared handler
+
+The silent gaps came from sharing the per-kind handlers but not the dispatch: a context-free kind
+wired into the procedural dispatcher and forgotten in the structural one failed only at runtime. The
+fix is that every context-free kind -- now including the call, `inside`, and replication families --
+is a single template over the pass class, and both pass-class dispatchers route their case to that
+one handler. A kind is implemented once; only the genuine differences stay per-context:
+
+- **Name resolution**, where a bare name maps to different storage depending on the enclosing scope.
+- **Procedural-only legality** -- increment / decrement, the assignment expression, the
+  dynamic-array constructor `new[]`, and the queue `$` -- which the LRM permits only in procedural
+  code; the structural side returns an unsupported diagnostic.
+
+At AST-to-HIR the two pass-class dispatchers, sharing a translation unit, collapse further into one
+dispatcher template the two entries delegate to, so even the dispatch switch is written once. At
+HIR-to-MIR the two dispatchers stay separate functions (they live in different translation units)
+but route every context-free kind through the shared handlers; collapsing them likewise is the
+remaining symmetric step.
+
+The pass classes themselves stay distinct (`generic-lowering-machinery.md`): one builds a callable,
+the other a class. It is the dispatch, not the pass class, that is shared.
+
+### The `with`-clause element and index are co-equal closure parameters
+
+An LRM 7.12 array-manipulation method with a `with` clause iterates an ordered entry stream of
+`(index, element)` pairs (`array-manipulation-entry-stream.md`). At HIR-to-MIR the clause becomes a
+closure (`closure.md`) whose two per-invocation parameters are the element and the index --
+co-equal, exactly as every modern array callback passes them: JavaScript
+`arr.map((element, index) => ...)`, Rust `arr.iter().enumerate()` yielding `(index, element)`,
+Python `enumerate`, C++23 `views::enumerate`. None of these treats the index as an attribute of the
+element; SV's `item.index` member syntax is surface spelling, not a semantic relationship.
+
+So the element (`item`) and the index (`item.index`) both lower to one `IterationBindingRef` value
+reference, naming the clause it belongs to and which of the two roles it is. Neither is a variable
+of the enclosing scope -- they are the clause's own parameters. Naming the clause by identity (not a
+"currently-active" marker) keeps a reference stable however deeply the referencing clause is nested,
+so a clause nested in another's body still names the outer clause's parameter; HIR-to-MIR resolves
+each identity to the synthesized closure's parameter and captures it when the reference sits in a
+deeper clause's closure body. With that, the call handler reaches the pass class only through the
+duck-typed surface and becomes one template like every other family, at both lowering boundaries.
+The frontend's value system functions on the structural path (`$time` and the like) are the one form
+not yet wired and return an unsupported diagnostic.
+
+`$isunknown` falls out as an ordinary instance built-in call `(x).IsUnknown()` returning the SV
+`bit` shape (`builtin-call-identity.md`), now reachable in both procedural and continuous-assign
+positions.
+
+## Rejected
+
+- **Two per-context dispatchers.** The status quo, and the source of the silent gaps: a context-free
+  kind wired into one dispatcher and not the other lowered fine in one position and failed in the
+  other with no compile-time signal. Sharing the handlers but not the dispatch left the dispatch
+  free to drift.
+
+- **The iteration element as a procedural-body local.** Modeling the `with`-clause iteration
+  variable as a local in the enclosing body's arena, resolved through the procedural-var registry,
+  coupled call lowering to a procedural body a structural scope does not have. It was the sole
+  dependency that kept the call family procedural-only, and it misrepresents the variable: a closure
+  parameter scoped to the clause is not a variable of the enclosing scope.
+
+- **The element as a value reference, the index as a member-access call.** Taking SV's `item.index`
+  spelling literally models the index as an attribute reached through the element -- a different IR
+  shape (a value reference versus a call) and a different resolution path for the two. The modern
+  iteration model is unanimous that the index and element are co-equal yielded values; the asymmetry
+  is a syntactic artifact, and encoding it splits one concept ("the current iteration's value")
+  across two node kinds. One `IterationBindingRef` for both, selected by role, keeps them
+  symmetric.
+
+## Cross-references
+
+- `generic-lowering-machinery.md` -- context-free expression handlers are one template over the pass
+  class; this decision completes that migration with the dispatcher and the call family, its last
+  holdouts.
+- `array-manipulation-entry-stream.md` -- the `(index, element)` entry-stream model the element and
+  index refer into.
+- `closure.md` -- the `with` clause lowers to a closure whose per-invocation parameters are the
+  element and the index.
+- `runtime_model.md` -- constructor-time (structural) versus simulation-time (process) expressions;
+  a continuous-assign right-hand side is simulation-time, so it carries the full value-expression
+  set.
+- `builtin-call-identity.md` -- `$isunknown` lowers to a built-in method call on its operand,
+  returning the SV `bit` shape.

--- a/docs/progress/generic-lowering.md
+++ b/docs/progress/generic-lowering.md
@@ -11,11 +11,16 @@ rejected alternatives.
 ## Actionable
 
 The generic arena (Phase 1) and the handler-sharing it enables (Phase 2) have landed in full on both
-lowering boundaries. The context-free expression handlers shared by the procedural and structural
-pass classes are single function templates over the pass class -- never duplicated twins -- at
-HIR-to-MIR and at AST-to-HIR alike. The procedural/structural distinction survives only where the
-two genuinely differ (statements versus members and generates, and name resolution) and is gone from
-the expression layer, where they are identical. This workstream is complete.
+lowering boundaries. Every context-free expression family -- including the call, `inside`, and
+replication families, the last holdouts -- is now a single function template over the pass class, so
+a continuous-assign right-hand side lowers the full value-expression set through the same handlers
+as a process body. The procedural/structural distinction survives only where the two genuinely
+differ (statements versus members and generates, name resolution, and the kinds the LRM allows only
+in procedural code) and is gone from the expression layer, where they are identical. See
+`../decisions/context-free-call-lowering.md`. The dispatch sharing (Phase 3) is complete at
+AST-to-HIR (one dispatcher template) and has one step left at HIR-to-MIR -- collapsing its two
+dispatchers, which sit in separate translation units, into one. The context-free handlers are
+already shared there, so the only remaining drift surface is the duplicated dispatch switch.
 
 The arena's surface is fixed by what consumers actually do: a const lookup by typed id, an append
 that returns the id, a count and an emptiness check, and an indexed iteration (the dumper prints
@@ -56,6 +61,22 @@ underneath.
       recursion entry point; name resolution and single-context kinds stay per-pass.
 - [x] `lowering_organization.md` records that a handler shared across pass classes is one template,
       never a duplicated twin.
+
+### Phase 3 -- Share the dispatch
+
+- [x] The call, `inside`, and replication families -- context-free but left procedural-only --
+      become templates over the pass class, and both pass-class dispatchers route their case through
+      the shared handler, so a continuous-assign right-hand side (a simulation-time expression the
+      structural scope owns) lowers function calls, `$isunknown`, `inside`, and replication through
+      the same handlers as a process body. The `with`-clause element and index become co-equal
+      closure parameters so the call family carries no procedural-body dependency. See
+      `../decisions/context-free-call-lowering.md`.
+- [x] AST-to-HIR collapses its two pass-class dispatchers (which share a translation unit) into one
+      dispatcher template the two entries delegate to, so even the dispatch switch is written once;
+      name resolution and the procedural-only kinds are the only parameterized arms.
+- [ ] HIR-to-MIR: collapse its two dispatchers likewise. They live in separate translation units
+      today, so this is a translation-unit move, not just a template; the context-free handlers are
+      already shared, so the remaining drift surface is only the duplicated dispatch switch.
 
 ## Coordination
 

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -318,15 +318,17 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       `foreach` iterates them -- `foreach` over a fixed array uses its declared range and direction,
       not a count, so that split is a real semantic difference, not the same redundancy).
 
-- [x] R25 -- The two families that do not take a value receiver fit the same generic builtin-call
-      identity as every member-shaped call. An enum type-static method (`first` / `last` / `num`,
-      where the type qualifier is part of the symbol identity) lowers to the static-callee arm with
-      the qualifier on the callee and no receiver in the arguments; the value-static `$isunknown`
-      lowers to an ordinary builtin call returning the SV `bit` type, with no host-bool lift at the
-      backend. The member-shaped families (string, array, queue, associative including traversal,
-      enum instance) render through the one generic handler. Subsumed by R29
-      (`decisions/builtin-call-identity.md`). The all-2-state constant-fold of `$isunknown` is left
-      to the downstream optimizer per R7, not folded at HIR-to-MIR.
+- [x] R25 -- **Closed: both carve-outs resolved.** The two value-query families this entry set aside
+      as not fitting the generic `(receiver).name(args)` member-call rule are both settled. Enum
+      type-static methods (`first` / `last` / `num`, no receiver -- the type qualifier is part of
+      the symbol identity) lower to the `BuiltinStaticCallee` arm R29 introduced and render as
+      `Enum::method(args)`. `$isunknown` needs no special type-static / constant-fold path: it is
+      the generic instance built-in call `(x).IsUnknown()` returning the SV `bit` type (1-bit
+      `PackedArray`, LRM 20.9), now wired end to end -- recognized at AST-to-HIR by
+      `KnownSystemName::IsUnknown`, lowered through the context-free call family in both procedural
+      and continuous-assign positions (`../decisions/context-free-call-lowering.md`). The
+      cross-cutting value-model (SV-typed runtime signatures, the representation bridge inside the
+      method body, the backend reading the stated result type) is settled.
 
 - [x] R26 -- Runtime container protocols are pinned as explicit C++20 concepts in a single
       value-layer concept header; each container `static_assert`s every protocol it satisfies. Slice

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <variant>
 #include <vector>
 
@@ -76,17 +77,15 @@ struct IncDecExpr {
   ExprId target;
 };
 
-// LRM 7.12 array-method `with` clause. Present only on array-method calls
-// (sort, rsort, sum, product, and, or, xor) that take a `with`. `iterator`
-// is a procedural-var entry on the enclosing process body; references to it
-// inside `expr` resolve through the normal `LookupProceduralVar` path.
-// HIR -> MIR pre-allocates a body procedural var for the iterator at
-// closure-construction time and remaps this id to that body var, so the
-// closure's `LowerExpr` walk sees the iterator as a body-local. Captures
-// are discovered automatically by the `CaptureSink` installed around that
-// walk -- they are not pre-listed here.
+// LRM 7.12 array-method `with` clause. `id` names this clause; the element
+// (`item`) and its index (`item.index`) are referenced inside `expr` by that
+// identity and role (`IterationBindingRef`), so a clause nested in `expr` that
+// reads an outer iterator still names the outer clause. `element_name` is the
+// source iterator name, kept so the synthesized iteration closure's element
+// parameter renders readably.
 struct WithClause {
-  ProceduralVarId iterator;
+  WithClauseId id;
+  std::string element_name;
   ExprId expr;
 };
 

--- a/include/lyra/hir/primary.hpp
+++ b/include/lyra/hir/primary.hpp
@@ -40,6 +40,6 @@ struct RealLiteral {
 // tag.
 using Primary = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, StructuralVarRef,
-    ProceduralVarRef, LoopVarRef, CrossUnitVarRef>;
+    ProceduralVarRef, LoopVarRef, CrossUnitVarRef, IterationBindingRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/subroutine_ref.hpp
+++ b/include/lyra/hir/subroutine_ref.hpp
@@ -30,17 +30,7 @@ struct BuiltinMethodRef {
   support::BuiltinFn method;
 };
 
-// LRM 7.12.4 `item.index` (also written `item.<user-named-index>`). SV
-// dresses it as a method on the iterator binding, but no runtime function
-// exists -- the receiver value is discarded and the call resolves to the
-// closure's index parameter. HIR-to-MIR rewrites it to a `LocalRef`; no
-// MIR `CallExpr` survives. Kept as its own callee arm so the translation
-// behaviour ("rewrites away") is visible in the type rather than hidden
-// inside `BuiltinMethodRef`.
-struct IteratorIndexRef {};
-
 using SubroutineRef = std::variant<
-    StructuralSubroutineRef, SystemSubroutineRef, BuiltinMethodRef,
-    IteratorIndexRef>;
+    StructuralSubroutineRef, SystemSubroutineRef, BuiltinMethodRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/value_ref.hpp
+++ b/include/lyra/hir/value_ref.hpp
@@ -8,6 +8,7 @@
 #include "lyra/hir/procedural_var.hpp"
 #include "lyra/hir/structural_hops.hpp"
 #include "lyra/hir/structural_var.hpp"
+#include "lyra/hir/with_clause_id.hpp"
 
 namespace lyra::hir {
 
@@ -46,6 +47,17 @@ struct LoopVarRef {
   LoopVarDeclId loop_var;
 
   auto operator==(const LoopVarRef&) const -> bool = default;
+};
+
+// A reference to a `with`-clause iteration value (LRM 7.12.4), named by the
+// owning clause's identity and the role. Both element and index are closure
+// parameters; HIR-to-MIR resolves this to that clause's parameter, capturing it
+// when the reference sits inside a deeper clause's closure body.
+struct IterationBindingRef {
+  WithClauseId clause;
+  IterationBindingRole role;
+
+  auto operator==(const IterationBindingRef&) const -> bool = default;
 };
 
 // A sensitivity leaf observes either a this-unit structural var or a cross-unit

--- a/include/lyra/hir/with_clause_id.hpp
+++ b/include/lyra/hir/with_clause_id.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace lyra::hir {
+
+// Identity of one LRM 7.12 array-method `with` clause, assigned per clause at
+// AST-to-HIR. A reference to the clause's element or index names this identity
+// (not a nesting position), so the binding a reference points at stays stable
+// however deeply the referencing clause is nested.
+struct WithClauseId {
+  std::uint32_t value;
+
+  auto operator<=>(const WithClauseId&) const -> std::strong_ordering = default;
+};
+
+// The two values an LRM 7.12 array-method `with` clause provides per iteration:
+// the element (`item`) and its index / key (`item.index`).
+enum class IterationBindingRole : std::uint8_t { kElement, kIndex };
+
+}  // namespace lyra::hir

--- a/include/lyra/lowering/ast_to_hir/expression/aggregates.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/aggregates.hpp
@@ -49,12 +49,18 @@ auto LowerAssociativeAssignmentPattern(
     const slang::ast::StructuredAssignmentPatternExpression& ap,
     diag::SourceSpan span) -> diag::Result<hir::Expr>;
 
-// Replication (LRM 11.4.12.1) and the dynamic-array constructor `new[N]`
-// (LRM 7.5.1) have no structural form, so they stay procedural-only handlers.
-auto LowerReplicationExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
+// Replication (LRM 11.4.12.1) is an ordinary value expression, legal wherever a
+// value is, so it is one template over the pass class like the other aggregate
+// families.
+template <ExprLowerer Lowerer>
+auto LowerReplicationExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::ReplicationExpression& rp, diag::SourceSpan span)
     -> diag::Result<hir::Expr>;
+
+// The dynamic-array constructor `new[N]` (LRM 7.5.1) allocates simulation-time
+// storage, which a constructor-time structural expression cannot do, so it
+// stays a procedural-only handler.
 auto LowerNewArrayExprProc(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::NewArrayExpression& na, diag::SourceSpan span)

--- a/include/lyra/lowering/ast_to_hir/expression/calls.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/calls.hpp
@@ -7,7 +7,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace slang::ast {
@@ -16,9 +16,14 @@ class CallExpression;
 
 namespace lyra::lowering::ast_to_hir {
 
-auto LowerCallExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
-    const slang::ast::CallExpression& call, diag::SourceSpan span)
-    -> diag::Result<hir::Expr>;
+// A call's meaning is independent of the enclosing scope, so one template over
+// the pass class serves both the procedural and structural contexts; explicit
+// instantiations live in the implementation file. The LRM 7.12 `with`-clause
+// iteration element is the clause's own binding, reached without the enclosing
+// scope's variable storage, so nothing here is procedural-only.
+template <ExprLowerer Lowerer>
+auto LowerCallExpr(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
+    diag::SourceSpan span) -> diag::Result<hir::Expr>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/expression/inside.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/inside.hpp
@@ -7,7 +7,7 @@
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/inside_item.hpp"
-#include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace slang::ast {
@@ -17,16 +17,20 @@ class InsideExpression;
 
 namespace lyra::lowering::ast_to_hir {
 
-auto LowerInsideExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
-    const slang::ast::InsideExpression& in, diag::SourceSpan span)
-    -> diag::Result<hir::Expr>;
+// The `inside` operator's meaning is independent of the enclosing scope, so one
+// template over the pass class serves both contexts; explicit instantiations
+// live in the implementation file.
+template <ExprLowerer Lowerer>
+auto LowerInsideExpr(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::InsideExpression& in,
+    diag::SourceSpan span) -> diag::Result<hir::Expr>;
 
 // Lower one slang range_list entry. A ValueRange entry becomes an
 // InsideRangePair; any other expression becomes a plain ExprId. Used by
 // `inside` operator lowering and by `case ... inside` statement lowering.
+template <ExprLowerer Lowerer>
 auto LowerInsideItemImpl(
-    ProcessLowerer& proc, WalkFrame frame,
-    const slang::ast::Expression& item_expr) -> diag::Result<hir::InsideItem>;
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::Expression& item_expr)
+    -> diag::Result<hir::InsideItem>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
@@ -188,6 +188,11 @@ class ModuleLowerer {
   // Frame minting for scope entry.
   [[nodiscard]] auto NextScopeFrameId() -> ScopeFrameId;
 
+  // Identity minting for an array-method `with` clause (LRM 7.12). Unique
+  // within the unit, so HIR-to-MIR can key its iteration-binding registry on
+  // it.
+  [[nodiscard]] auto NextWithClauseId() -> hir::WithClauseId;
+
   // Builds a HIR Expr referring to a leaf reached by navigating `path` down
   // from `head`. `target` is the leaf value symbol (cross-unit dedup key);
   // `home_frame` is the owning structural scope's frame.
@@ -232,6 +237,7 @@ class ModuleLowerer {
   std::map<ScopeFrameId, std::vector<hir::CrossUnitRefDecl>>
       cross_unit_refs_by_frame_;
   std::uint32_t next_scope_frame_ = 0;
+  std::uint32_t next_with_clause_ = 0;
 };
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/walk_frame.hpp
+++ b/include/lyra/lowering/ast_to_hir/walk_frame.hpp
@@ -12,12 +12,17 @@
 #include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/loop_label_id.hpp"
 #include "lyra/hir/structural_hops.hpp"
+#include "lyra/hir/with_clause_id.hpp"
 
 namespace lyra::hir {
 struct Expr;
 struct StructuralScope;
 struct ProceduralBody;
 }  // namespace lyra::hir
+
+namespace slang::ast {
+class Symbol;
+}  // namespace slang::ast
 
 namespace lyra::lowering::ast_to_hir {
 
@@ -27,6 +32,15 @@ namespace lyra::lowering::ast_to_hir {
 struct ScopeFrameId {
   std::uint32_t value;
   auto operator<=>(const ScopeFrameId&) const -> std::strong_ordering = default;
+};
+
+// One active array-method `with` clause whose body is being lowered: its slang
+// iterator symbol paired with the HIR identity assigned to the clause. A
+// reference whose symbol matches the iterator resolves to this clause's
+// element and index bindings.
+struct ActiveIterationClause {
+  const slang::ast::Symbol* element;
+  hir::WithClauseId clause;
 };
 
 // Per-recursion traversal context for AST-to-HIR. Carried by value through
@@ -90,6 +104,14 @@ struct WalkFrame {
   // Null outside a queue index / bound expression. Re-set per select, so each
   // `$` in a nested `q[r[$]]` binds to the array its own select indexes.
   std::optional<hir::ExprId> dollar_base = std::nullopt;
+
+  // The active LRM 7.12 array-method `with`-clause iterators whose bodies are
+  // being lowered, each enclosing clause kept so an inner body can still name
+  // an outer iterator. A reference matching a clause's element symbol resolves
+  // to that clause's `IterationBindingRef`, not the procedural-var path;
+  // foreach loop variables are also slang Iterator symbols, so the match is by
+  // symbol identity. Empty outside a with-clause body.
+  std::vector<ActiveIterationClause> active_iteration_clauses;
 
   [[nodiscard]] auto Current() const -> ScopeFrameId {
     if (structural_chain.empty()) {
@@ -166,6 +188,31 @@ struct WalkFrame {
     WalkFrame next = *this;
     next.dollar_base = base;
     return next;
+  }
+
+  // Marks the given `with` clause and its iterator symbol active while its body
+  // subtree is lowered (LRM 7.12.4). Pushed so a clause nested in the body sees
+  // every enclosing clause.
+  [[nodiscard]] auto WithIterationClause(
+      const slang::ast::Symbol& element, hir::WithClauseId clause) const
+      -> WalkFrame {
+    WalkFrame next = *this;
+    next.active_iteration_clauses.push_back(
+        ActiveIterationClause{.element = &element, .clause = clause});
+    return next;
+  }
+
+  // The active clause whose iterator is the given symbol, if any. Both an
+  // element read (`item`) and an index read (`item.index`, keyed by its
+  // receiver) resolve their clause through this.
+  [[nodiscard]] auto FindIterationClause(const slang::ast::Symbol& sym) const
+      -> std::optional<hir::WithClauseId> {
+    for (const auto& active : active_iteration_clauses) {
+      if (active.element == &sym) {
+        return active.clause;
+      }
+    }
+    return std::nullopt;
   }
 
   // Establishes `label` as the break target for the body being lowered. `used`

--- a/include/lyra/lowering/hir_to_mir/expression/aggregates.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/aggregates.hpp
@@ -38,11 +38,17 @@ auto LowerHirAssociativeAssignmentPatternExpr(
     const hir::AssociativeAssignmentPatternExpr& a, mir::TypeId result_type)
     -> diag::Result<mir::Expr>;
 
-// Replication and `new[]` appear only in procedural value-build positions, so
-// they stay procedural-only handlers rather than shared templates.
-auto LowerHirReplicationExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::ReplicationExpr& r,
+// Replication (LRM 11.4.12.1) is an ordinary value expression, legal wherever a
+// value is, so it is one template over the pass class like the other aggregate
+// families.
+template <ExprLowerer Lowerer>
+auto LowerHirReplicationExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::ReplicationExpr& r,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
+
+// The dynamic-array constructor `new[]` (LRM 7.5.1) allocates simulation-time
+// storage, which a constructor-time structural expression cannot do, so it
+// stays a procedural-only handler.
 auto LowerHirDynamicArrayNewExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::DynamicArrayNewExpr& n,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;

--- a/include/lyra/lowering/hir_to_mir/expression/calls.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/calls.hpp
@@ -9,15 +9,21 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/type_id.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
-auto LowerHirCallExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& c,
+// A call's meaning is independent of the enclosing scope, so one template over
+// the pass class serves both the process body and the structural-scope
+// (continuous-assign) contexts; explicit instantiations live in the
+// implementation file. Value system subroutines on the structural path are the
+// one form not yet wired.
+template <ExprLowerer Lowerer>
+auto LowerHirCallExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
     diag::SourceSpan span, mir::TypeId result_type) -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/expression/inside.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/inside.hpp
@@ -6,15 +6,19 @@
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/type_id.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
-auto LowerHirInsideExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::InsideExpr& in,
+// The `inside` operator's meaning is independent of the enclosing scope, so one
+// template over the pass class serves both contexts; explicit instantiations
+// live in the implementation file.
+template <ExprLowerer Lowerer>
+auto LowerHirInsideExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::InsideExpr& in,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/inside_predicate.hpp
+++ b/include/lyra/lowering/hir_to_mir/inside_predicate.hpp
@@ -2,7 +2,7 @@
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/inside_item.hpp"
-#include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/type_id.hpp"
@@ -15,9 +15,11 @@ namespace lyra::lowering::hir_to_mir {
 //   - range items lower to `(lhs >= lo) && (lhs <= hi)`.
 // Shared between the inside operator (LRM 11.4.13) and the case-inside
 // cascade (LRM 12.5.4). Callers OR-chain the per-item results to obtain the
-// final inside predicate.
+// final inside predicate. One template over the pass class serves both
+// contexts; explicit instantiations live in the implementation file.
+template <ExprLowerer Lowerer>
 auto BuildHirInsideItemPredicate(
-    ProcessLowerer& proc, WalkFrame frame, mir::ExprId lhs_id,
+    Lowerer& lowerer, WalkFrame frame, mir::ExprId lhs_id,
     const hir::InsideItem& item, mir::TypeId result_type)
     -> diag::Result<mir::ExprId>;
 

--- a/include/lyra/lowering/hir_to_mir/iteration_binding_registry.hpp
+++ b/include/lyra/lowering/hir_to_mir/iteration_binding_registry.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "lyra/base/internal_error.hpp"
+#include "lyra/hir/with_clause_id.hpp"
+#include "lyra/lowering/hir_to_mir/block_depth.hpp"
+#include "lyra/mir/local.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// One synthesized closure parameter for an array-method `with` clause (LRM
+// 7.12.4): the body slot it lives in and the depth it was declared at, which is
+// all the capture decision needs (a reference from a deeper clause's closure
+// captures it; one at the same depth reads it directly).
+struct IterationBinding {
+  mir::LocalId var;
+  BlockDepth decl_depth;
+};
+
+// Maps each active `with` clause's identity to its element and index closure
+// parameters. A reference resolves purely by clause identity and role, so a
+// clause nested in another's body still reaches the outer parameter -- the
+// registry is shared down the nesting, every enclosing clause stays reachable.
+// Entries are appended as closures are built and never collide (clause ids are
+// unique within the unit).
+class IterationBindingRegistry {
+ public:
+  void Register(
+      hir::WithClauseId clause, IterationBinding element,
+      IterationBinding index) {
+    clauses_.push_back({clause, {.element = element, .index = index}});
+  }
+
+  [[nodiscard]] auto Lookup(
+      hir::WithClauseId clause, hir::IterationBindingRole role) const
+      -> IterationBinding {
+    for (const auto& [id, bindings] : clauses_) {
+      if (id == clause) {
+        return role == hir::IterationBindingRole::kElement ? bindings.element
+                                                           : bindings.index;
+      }
+    }
+    throw InternalError(
+        "IterationBindingRegistry::Lookup: with-clause iteration reference "
+        "names an unregistered clause");
+  }
+
+ private:
+  struct ClauseBindings {
+    IterationBinding element;
+    IterationBinding index;
+  };
+
+  std::vector<std::pair<hir::WithClauseId, ClauseBindings>> clauses_;
+};
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
@@ -124,6 +124,20 @@ class ProcessLowerer {
     return *owner_;
   }
 
+  // The structural-subroutine tables live on the owning `ClassLowerer`; expose
+  // them here too so a templated call handler reaches a user subroutine through
+  // the same surface on either pass class (`ClassLowerer` has them directly).
+  [[nodiscard]] auto LookupHirSubroutine(
+      hir::StructuralHops hops, hir::StructuralSubroutineId id) const
+      -> const hir::StructuralSubroutineDecl& {
+    return owner_->LookupHirSubroutine(hops, id);
+  }
+  [[nodiscard]] auto TranslateStructuralSubroutine(
+      hir::StructuralHops hops, hir::StructuralSubroutineId id) const
+      -> mir::MethodRef {
+    return owner_->TranslateStructuralSubroutine(hops, id);
+  }
+
   [[nodiscard]] auto Resolution() const -> TimeResolution {
     return time_resolution_;
   }

--- a/include/lyra/lowering/hir_to_mir/services_call.hpp
+++ b/include/lyra/lowering/hir_to_mir/services_call.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
 
@@ -8,10 +8,12 @@ namespace lyra::lowering::hir_to_mir {
 
 // Builds the engine-handle expression `self.Services()`: a `Services`
 // scope-method call whose receiver is the body's self read, interned as a
-// child. Returns the call node detached; the caller interns it. Runtime-
-// effect generic calls -- $finish, the $time family, named-event trigger /
-// triggered -- thread it as the engine handle.
-auto BuildServicesCallExpr(
-    const ProcessLowerer& process, const WalkFrame& frame) -> mir::Expr;
+// child. Returns the call node detached; the caller interns it. Runtime-effect
+// generic calls -- $finish, the $time family, named-event trigger / triggered
+// -- thread it as the engine handle. It needs only the module and the walk
+// frame, not the pass class, so it serves the process body and structural-scope
+// (continuous-assign) call paths identically.
+auto BuildServicesCallExpr(const ModuleLowerer& module, const WalkFrame& frame)
+    -> mir::Expr;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/walk_frame.hpp
+++ b/include/lyra/lowering/hir_to_mir/walk_frame.hpp
@@ -16,6 +16,7 @@ struct Block;
 namespace lyra::lowering::hir_to_mir {
 
 class CaptureSink;
+class IterationBindingRegistry;
 
 // Singly-linked node carrying a class's parent chain so a leaf reference
 // can read the declared type of a member at `hops > 0`. Each node lives on
@@ -80,10 +81,12 @@ struct WalkFrame {
   // closure body.
   CaptureSink* capture_sink = nullptr;
 
-  // The iterator-index binding active while lowering an array-method
-  // with-clause body (LRM 7.12.4). Read by the `item.index` reference
-  // lowering. Empty outside a with-clause body.
-  std::optional<mir::LocalId> active_index_binding;
+  // The array-method `with`-clause iteration parameters reachable while
+  // lowering a clause body (LRM 7.12.4), keyed by clause identity. An `item` /
+  // `item.index` reference resolves through it by identity, so a clause nested
+  // in the body can still reach an outer clause's parameter. Null outside a
+  // with-clause body.
+  IterationBindingRegistry* iteration_bindings = nullptr;
 
   // The `self` binding at the root of the current body. Set at body entry
   // (process / method / constructor / closure) and unchanged through the
@@ -180,9 +183,12 @@ struct WalkFrame {
     return next;
   }
 
-  [[nodiscard]] auto WithIndexBinding(mir::LocalId id) const -> WalkFrame {
+  // Threads the registry of active `with`-clause iteration parameters into the
+  // body subtree being lowered (LRM 7.12.4).
+  [[nodiscard]] auto WithIterationBindings(
+      IterationBindingRegistry* registry) const -> WalkFrame {
     WalkFrame next = *this;
-    next.active_index_binding = id;
+    next.iteration_bindings = registry;
     return next;
   }
 

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -399,6 +399,12 @@ class HirDumper {
             [](const CrossUnitVarRef& r) -> std::string {
               return std::format("CrossUnitRef[{}]", r.id.value);
             },
+            [](const IterationBindingRef& r) -> std::string {
+              const char* role = r.role == IterationBindingRole::kElement
+                                     ? "Element"
+                                     : "Index";
+              return std::format("Iteration[{}].{}", r.clause.value, role);
+            },
         },
         p);
   }
@@ -526,9 +532,6 @@ class HirDumper {
               return std::format(
                   "BuiltinFn \"{}\"", support::BuiltinFnName(b.method));
             },
-            [](const IteratorIndexRef&) -> std::string {
-              return "IteratorIndexRef";
-            },
         },
         callee);
   }
@@ -627,8 +630,8 @@ class HirDumper {
               std::string with_text;
               if (c.with_clause.has_value()) {
                 with_text = std::format(
-                    " with={{iterator=ProceduralVarId[{}], expr=Expr[{}]}}",
-                    c.with_clause->iterator.value, c.with_clause->expr.value);
+                    " with={{element=\"{}\", expr=Expr[{}]}}",
+                    c.with_clause->element_name, c.with_clause->expr.value);
               }
               return std::format(
                   "CallExpr callee={} args=[{}]{}",

--- a/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
@@ -11,7 +11,6 @@
 #include <slang/ast/types/Type.h>
 
 #include "lyra/diag/diag_code.hpp"
-#include "lyra/diag/kind.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
@@ -58,11 +57,12 @@ auto LowerConcatExpr(
   };
 }
 
-auto LowerReplicationExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
+template <ExprLowerer Lowerer>
+auto LowerReplicationExpr(
+    Lowerer& lowerer, WalkFrame frame,
     const slang::ast::ReplicationExpression& rp, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  auto& module = proc.Module();
+  auto& module = lowerer.Module();
   auto type_id = module.InternType(*rp.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   const auto kind = module.Unit().GetType(*type_id).Kind();
@@ -72,10 +72,10 @@ auto LowerReplicationExprProc(
         "replication result type is neither string nor packed "
         "(LRM 11.4.12.1)");
   }
-  auto count_or = proc.LowerExpr(rp.count(), frame);
+  auto count_or = lowerer.LowerExpr(rp.count(), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
   const hir::ExprId count_id = frame.Exprs().Add(*std::move(count_or));
-  auto concat_or = proc.LowerExpr(rp.concat(), frame);
+  auto concat_or = lowerer.LowerExpr(rp.concat(), frame);
   if (!concat_or) return std::unexpected(std::move(concat_or.error()));
   const hir::ExprId concat_id = frame.Exprs().Add(*std::move(concat_or));
   return hir::Expr{
@@ -231,6 +231,13 @@ template auto LowerAssociativeAssignmentPattern(
 template auto LowerAssociativeAssignmentPattern(
     StructuralScopeLowerer&, WalkFrame,
     const slang::ast::StructuredAssignmentPatternExpression&, diag::SourceSpan)
+    -> diag::Result<hir::Expr>;
+template auto LowerReplicationExpr(
+    ProcessLowerer&, WalkFrame, const slang::ast::ReplicationExpression&,
+    diag::SourceSpan) -> diag::Result<hir::Expr>;
+template auto LowerReplicationExpr(
+    StructuralScopeLowerer&, WalkFrame,
+    const slang::ast::ReplicationExpression&, diag::SourceSpan)
     -> diag::Result<hir::Expr>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -13,15 +13,18 @@
 #include <slang/ast/SystemSubroutine.h>
 #include <slang/ast/expressions/AssignmentExpressions.h>
 #include <slang/ast/expressions/CallExpression.h>
+#include <slang/ast/expressions/MiscExpressions.h>
 #include <slang/ast/symbols/SubroutineSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/hir/type.hpp"
+#include "lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/expression/slang_atoms.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::ast_to_hir {
@@ -52,11 +55,11 @@ auto MakeReturnConventionType(
 
 }  // namespace
 
-auto LowerCallExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
-    const slang::ast::CallExpression& call, diag::SourceSpan span)
-    -> diag::Result<hir::Expr> {
-  auto& module = proc.Module();
+template <ExprLowerer Lowerer>
+auto LowerCallExpr(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::CallExpression& call,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  auto& module = lowerer.Module();
   std::vector<std::optional<hir::ExprId>> arg_ids;
   arg_ids.reserve(call.arguments().size());
   std::optional<hir::TypeId> receiver_type;
@@ -81,7 +84,7 @@ auto LowerCallExprProc(
       arg_ids.emplace_back(std::nullopt);
       continue;
     }
-    auto arg_or = proc.LowerExpr(*arg, frame);
+    auto arg_or = lowerer.LowerExpr(*arg, frame);
     if (!arg_or) return std::unexpected(std::move(arg_or.error()));
     if (i == 0) {
       receiver_type = arg_or->type;
@@ -216,17 +219,21 @@ auto LowerCallExprProc(
                   info.extraInfo);
           const auto& iter_var =
               iter_info.iterVar->as<slang::ast::VariableSymbol>();
-          auto iter_type = module.InternType(iter_var.getType(), span);
-          if (!iter_type) {
-            return std::unexpected(std::move(iter_type.error()));
-          }
-          const hir::ProceduralVarId iterator_id = proc.AddProceduralVar(
-              *frame.current_procedural_body, iter_var, *iter_type);
-          auto body_or = proc.LowerExpr(*iter_info.iterExpr, frame);
+          // The clause's element and index references resolve to this id while
+          // the body is lowered; marking the iterator by identity on the frame
+          // distinguishes it from a foreach loop variable (also a slang
+          // Iterator symbol) and lets a clause nested in the body name this
+          // outer one.
+          const hir::WithClauseId clause_id = module.NextWithClauseId();
+          auto body_or = lowerer.LowerExpr(
+              *iter_info.iterExpr,
+              frame.WithIterationClause(iter_var, clause_id));
           if (!body_or) return std::unexpected(std::move(body_or.error()));
           const auto body_expr_id = frame.Exprs().Add(*std::move(body_or));
-          with_clause =
-              hir::WithClause{.iterator = iterator_id, .expr = body_expr_id};
+          with_clause = hir::WithClause{
+              .id = clause_id,
+              .element_name = std::string{iter_var.name},
+              .expr = body_expr_id};
         }
         return hir::Expr{
             .type = *type_id,
@@ -262,28 +269,58 @@ auto LowerCallExprProc(
       }
     }
 
-    // LRM 7.12.4 `item.index`: SV dresses the iteration-index access as a
-    // method on the iterator binding (slang parses it as a SystemSubroutine
-    // with `KnownSystemName::Index`), but no runtime function exists -- the
-    // receiver value is discarded and the call resolves to the enclosing
-    // closure's index parameter. HIR keeps the method-call shape (LRM 7.12
-    // grammar level) with a dedicated `IteratorIndexRef` callee; HIR-to-MIR
-    // rewrites it to a `LocalRef` on that parameter binding. The dedicated
-    // callee arm encodes the "rewrites away" translation behaviour in the
-    // type, so it is structurally distinct from runtime-backed builtin
-    // methods.
+    // LRM 20.9 `$isunknown`: 1 if any bit of the operand is X or Z. A
+    // type-agnostic value query -- every value type exposes the query -- so it
+    // lowers to the generic instance builtin call on its operand, not through a
+    // receiver-type-keyed method table.
     if (info.subroutine != nullptr &&
         info.subroutine->knownNameId ==
-            slang::parsing::KnownSystemName::Index) {
+            slang::parsing::KnownSystemName::IsUnknown) {
       auto type_id = module.InternType(*call.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return hir::Expr{
           .type = *type_id,
           .data =
               hir::CallExpr{
-                  .callee = hir::IteratorIndexRef{},
-                  .arguments = {},
+                  .callee =
+                      hir::BuiltinMethodRef{
+                          .method = support::BuiltinFn::kIsUnknown},
+                  .arguments = std::move(arg_ids),
               },
+          .span = span,
+      };
+    }
+
+    // LRM 7.12.4 `item.index`: slang dresses the iteration index as a method on
+    // the iterator (a SystemSubroutine with `KnownSystemName::Index`) whose
+    // receiver value is discarded. It is the index iteration parameter -- a
+    // value co-equal with the element -- so it lowers to an
+    // `IterationBindingRef` value reference, not a call. Its clause is the one
+    // whose iterator is the receiver, so a nested clause's `item.index` still
+    // names the right clause.
+    if (info.subroutine != nullptr &&
+        info.subroutine->knownNameId ==
+            slang::parsing::KnownSystemName::Index) {
+      const auto& receiver = *call.arguments()[0];
+      if (receiver.kind != slang::ast::ExpressionKind::NamedValue) {
+        throw InternalError("item.index receiver is not a named iterator");
+      }
+      const auto clause = frame.FindIterationClause(
+          receiver.as<slang::ast::NamedValueExpression>().symbol);
+      if (!clause) {
+        throw InternalError(
+            "item.index receiver is not an active with-clause iterator");
+      }
+      auto type_id = module.InternType(*call.type, span);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return hir::Expr{
+          .type = *type_id,
+          .data =
+              hir::PrimaryExpr{
+                  .data =
+                      hir::IterationBindingRef{
+                          .clause = *clause,
+                          .role = hir::IterationBindingRole::kIndex}},
           .span = span,
       };
     }
@@ -352,5 +389,14 @@ auto LowerCallExprProc(
       .span = span,
   };
 }
+
+template auto LowerCallExpr(
+    ProcessLowerer& lowerer, WalkFrame frame,
+    const slang::ast::CallExpression& call, diag::SourceSpan span)
+    -> diag::Result<hir::Expr>;
+template auto LowerCallExpr(
+    StructuralScopeLowerer& lowerer, WalkFrame frame,
+    const slang::ast::CallExpression& call, diag::SourceSpan span)
+    -> diag::Result<hir::Expr>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/expression/inside.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/inside.cpp
@@ -8,29 +8,29 @@
 #include <slang/ast/expressions/OperatorExpressions.h>
 
 #include "lyra/diag/diag_code.hpp"
-#include "lyra/diag/kind.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
+#include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
-auto LowerInsideExprProc(
-    ProcessLowerer& proc, WalkFrame frame,
-    const slang::ast::InsideExpression& in, diag::SourceSpan span)
-    -> diag::Result<hir::Expr> {
-  auto lhs_or = proc.LowerExpr(in.left(), frame);
+template <ExprLowerer Lowerer>
+auto LowerInsideExpr(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::InsideExpression& in,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  auto lhs_or = lowerer.LowerExpr(in.left(), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const hir::ExprId lhs_id = frame.Exprs().Add(*std::move(lhs_or));
 
   std::vector<hir::InsideItem> items;
   items.reserve(in.rangeList().size());
   for (const auto* item : in.rangeList()) {
-    auto item_or = LowerInsideItemImpl(proc, frame, *item);
+    auto item_or = LowerInsideItemImpl(lowerer, frame, *item);
     if (!item_or) return std::unexpected(std::move(item_or.error()));
     items.push_back(*std::move(item_or));
   }
 
-  auto type_id = proc.Module().InternType(*in.type, span);
+  auto type_id = lowerer.Module().InternType(*in.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
@@ -39,10 +39,11 @@ auto LowerInsideExprProc(
   };
 }
 
+template <ExprLowerer Lowerer>
 auto LowerInsideItemImpl(
-    ProcessLowerer& proc, WalkFrame frame,
-    const slang::ast::Expression& item_expr) -> diag::Result<hir::InsideItem> {
-  auto& module = proc.Module();
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::Expression& item_expr)
+    -> diag::Result<hir::InsideItem> {
+  auto& module = lowerer.Module();
   if (item_expr.kind == slang::ast::ExpressionKind::ValueRange) {
     const auto& vr = item_expr.as<slang::ast::ValueRangeExpression>();
     if (vr.rangeKind != slang::ast::ValueRangeKind::Simple) {
@@ -51,17 +52,32 @@ auto LowerInsideItemImpl(
           diag::DiagCode::kUnsupportedExpressionForm,
           "tolerance-range form in inside operator is not yet supported");
     }
-    auto lo_or = proc.LowerExpr(vr.left(), frame);
+    auto lo_or = lowerer.LowerExpr(vr.left(), frame);
     if (!lo_or) return std::unexpected(std::move(lo_or.error()));
     const hir::ExprId lo_id = frame.Exprs().Add(*std::move(lo_or));
-    auto hi_or = proc.LowerExpr(vr.right(), frame);
+    auto hi_or = lowerer.LowerExpr(vr.right(), frame);
     if (!hi_or) return std::unexpected(std::move(hi_or.error()));
     const hir::ExprId hi_id = frame.Exprs().Add(*std::move(hi_or));
     return hir::InsideRangePair{.lo = lo_id, .hi = hi_id};
   }
-  auto val_or = proc.LowerExpr(item_expr, frame);
+  auto val_or = lowerer.LowerExpr(item_expr, frame);
   if (!val_or) return std::unexpected(std::move(val_or.error()));
   return frame.Exprs().Add(*std::move(val_or));
 }
+
+template auto LowerInsideExpr(
+    ProcessLowerer& lowerer, WalkFrame frame,
+    const slang::ast::InsideExpression& in, diag::SourceSpan span)
+    -> diag::Result<hir::Expr>;
+template auto LowerInsideExpr(
+    StructuralScopeLowerer& lowerer, WalkFrame frame,
+    const slang::ast::InsideExpression& in, diag::SourceSpan span)
+    -> diag::Result<hir::Expr>;
+template auto LowerInsideItemImpl(
+    ProcessLowerer& lowerer, WalkFrame frame,
+    const slang::ast::Expression& item_expr) -> diag::Result<hir::InsideItem>;
+template auto LowerInsideItemImpl(
+    StructuralScopeLowerer& lowerer, WalkFrame frame,
+    const slang::ast::Expression& item_expr) -> diag::Result<hir::InsideItem>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -1,3 +1,4 @@
+#include <concepts>
 #include <expected>
 #include <string>
 #include <utility>
@@ -17,11 +18,11 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
-#include "lyra/diag/kind.hpp"
 #include "lyra/hir/primary.hpp"
 #include "lyra/lowering/ast_to_hir/expression/aggregates.hpp"
 #include "lyra/lowering/ast_to_hir/expression/assignment.hpp"
 #include "lyra/lowering/ast_to_hir/expression/calls.hpp"
+#include "lyra/lowering/ast_to_hir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/expression/inside.hpp"
 #include "lyra/lowering/ast_to_hir/expression/operators.hpp"
 #include "lyra/lowering/ast_to_hir/expression/references.hpp"
@@ -105,13 +106,24 @@ auto MakeRealLiteralExpr(double value, hir::TypeId type, diag::SourceSpan span)
   };
 }
 
-}  // namespace
-
-auto LowerProcExpr(
-    ProcessLowerer& proc, WalkFrame frame, const slang::ast::Expression& expr)
+// The one expression dispatcher, shared by both pass classes. An expression's
+// meaning does not depend on whether a process body or a structural scope
+// encloses it, so every context-free kind routes to one template handler listed
+// exactly once -- a kind cannot be wired in one context and forgotten in the
+// other. The only two real differences are parameterized inline: name
+// resolution (a bare name maps to different storage per scope) and the kinds
+// LRM allows only in procedural code (increment / decrement, the assignment
+// expression, the dynamic-array constructor, the queue `$`), which a structural
+// expression rejects. Constructor-time constness is enforced upstream by slang,
+// so a structural expression never carries a simulation-time call /
+// `$isunknown` even though this dispatcher would lower one.
+template <ExprLowerer Lowerer>
+auto LowerExprImpl(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::Expression& expr)
     -> diag::Result<hir::Expr> {
-  auto& module = proc.Module();
+  auto& module = lowerer.Module();
   const auto span = module.SourceMapper().SpanOf(expr.sourceRange);
+  constexpr bool kProcedural = std::same_as<Lowerer, ProcessLowerer>;
 
   switch (expr.kind) {
     case slang::ast::ExpressionKind::IntegerLiteral: {
@@ -152,8 +164,13 @@ auto LowerProcExpr(
     }
 
     case slang::ast::ExpressionKind::NamedValue:
-      return LowerNamedValueProc(
-          proc, frame, expr.as<slang::ast::NamedValueExpression>());
+      if constexpr (kProcedural) {
+        return LowerNamedValueProc(
+            lowerer, frame, expr.as<slang::ast::NamedValueExpression>());
+      } else {
+        return LowerNamedValueStructural(
+            module, frame, expr.as<slang::ast::NamedValueExpression>());
+      }
 
     case slang::ast::ExpressionKind::HierarchicalValue:
       return LowerHierarchicalValueProc(
@@ -161,65 +178,86 @@ auto LowerProcExpr(
 
     case slang::ast::ExpressionKind::LValueReference:
       throw InternalError(
-          "LowerProcExpr: slang LValueReference must not reach HIR; "
-          "compound assignment is lowered as a single AssignExpr with "
-          "compound_op, and the LValueReference-bearing BinaryOp tree slang "
-          "constructed is discarded at AST -> HIR");
+          "LowerExpr: slang LValueReference must not reach HIR; compound "
+          "assignment is lowered as a single AssignExpr with compound_op, and "
+          "the LValueReference-bearing BinaryOp tree slang constructed is "
+          "discarded at AST -> HIR");
 
     case slang::ast::ExpressionKind::Conversion:
       return LowerConversionExpr(
-          proc, frame, expr.as<slang::ast::ConversionExpression>(), span);
+          lowerer, frame, expr.as<slang::ast::ConversionExpression>(), span);
 
     case slang::ast::ExpressionKind::UnaryOp: {
       const auto& un = expr.as<slang::ast::UnaryExpression>();
       if (slang::ast::OpInfo::isLValue(un.op)) {
-        return LowerIncDecExprProc(proc, frame, un, span);
+        if constexpr (kProcedural) {
+          return LowerIncDecExprProc(lowerer, frame, un, span);
+        } else {
+          return diag::Fail(
+              span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
+              "increment / decrement is not legal outside procedural code "
+              "(LRM 11.3.6, 11.4.2)");
+        }
       }
-      return LowerUnaryExpr(proc, frame, un, span);
+      return LowerUnaryExpr(lowerer, frame, un, span);
     }
 
     case slang::ast::ExpressionKind::BinaryOp:
       return LowerBinaryExpr(
-          proc, frame, expr.as<slang::ast::BinaryExpression>(), span);
+          lowerer, frame, expr.as<slang::ast::BinaryExpression>(), span);
 
     case slang::ast::ExpressionKind::ConditionalOp:
       return LowerConditionalExpr(
-          proc, frame, expr.as<slang::ast::ConditionalExpression>(), span);
+          lowerer, frame, expr.as<slang::ast::ConditionalExpression>(), span);
 
     case slang::ast::ExpressionKind::Call:
-      return LowerCallExprProc(
-          proc, frame, expr.as<slang::ast::CallExpression>(), span);
+      return LowerCallExpr(
+          lowerer, frame, expr.as<slang::ast::CallExpression>(), span);
 
     case slang::ast::ExpressionKind::Assignment:
-      return LowerAssignmentExprProc(
-          proc, frame, expr.as<slang::ast::AssignmentExpression>(), span);
+      if constexpr (kProcedural) {
+        return LowerAssignmentExprProc(
+            lowerer, frame, expr.as<slang::ast::AssignmentExpression>(), span);
+      } else {
+        return diag::Fail(
+            span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
+            "an assignment expression is not legal in a structural expression "
+            "(LRM 10.3); structural code has no general assignment");
+      }
 
     case slang::ast::ExpressionKind::Inside:
-      return LowerInsideExprProc(
-          proc, frame, expr.as<slang::ast::InsideExpression>(), span);
+      return LowerInsideExpr(
+          lowerer, frame, expr.as<slang::ast::InsideExpression>(), span);
 
     case slang::ast::ExpressionKind::ElementSelect:
       return LowerElementSelectExpr(
-          proc, frame, expr.as<slang::ast::ElementSelectExpression>(), span);
+          lowerer, frame, expr.as<slang::ast::ElementSelectExpression>(), span);
 
     case slang::ast::ExpressionKind::RangeSelect:
       return LowerRangeSelectExpr(
-          proc, frame, expr.as<slang::ast::RangeSelectExpression>(), span);
+          lowerer, frame, expr.as<slang::ast::RangeSelectExpression>(), span);
 
     case slang::ast::ExpressionKind::MemberAccess:
       return LowerMemberAccessExpr(
-          proc, frame, expr.as<slang::ast::MemberAccessExpression>(), span);
+          lowerer, frame, expr.as<slang::ast::MemberAccessExpression>(), span);
 
     case slang::ast::ExpressionKind::UnboundedLiteral:
-      return LowerUnboundedLiteralProc(proc, frame, span);
+      if constexpr (kProcedural) {
+        return LowerUnboundedLiteralProc(lowerer, frame, span);
+      } else {
+        return diag::Fail(
+            span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
+            "`$` is only legal as a procedural queue index or slice bound "
+            "(LRM 7.10)");
+      }
 
     case slang::ast::ExpressionKind::Concatenation:
       return LowerConcatExpr(
-          proc, frame, expr.as<slang::ast::ConcatenationExpression>(), span);
+          lowerer, frame, expr.as<slang::ast::ConcatenationExpression>(), span);
 
     case slang::ast::ExpressionKind::Replication:
-      return LowerReplicationExprProc(
-          proc, frame, expr.as<slang::ast::ReplicationExpression>(), span);
+      return LowerReplicationExpr(
+          lowerer, frame, expr.as<slang::ast::ReplicationExpression>(), span);
 
     case slang::ast::ExpressionKind::SimpleAssignmentPattern: {
       const auto& sap =
@@ -229,7 +267,7 @@ auto LowerProcExpr(
             span, diag::DiagCode::kUnsupportedAssignmentPatternKind,
             "assignment pattern as LHS destructuring is not yet supported");
       }
-      return LowerAssignmentPatternFromElements(proc, frame, sap, span);
+      return LowerAssignmentPatternFromElements(lowerer, frame, sap, span);
     }
 
     case slang::ast::ExpressionKind::StructuredAssignmentPattern: {
@@ -240,10 +278,10 @@ auto LowerProcExpr(
       // optional default; lower the keyed form, not the positional one that
       // would drop both.
       if (target_kind == slang::ast::SymbolKind::AssociativeArrayType) {
-        return LowerAssociativeAssignmentPattern(proc, frame, sap, span);
+        return LowerAssociativeAssignmentPattern(lowerer, frame, sap, span);
       }
-      // Slang accepts `'{idx:val, ...}` for a dynamic-array target as long
-      // as indices cover a dense `0..N-1`. The legal subset is equivalent to
+      // Slang accepts `'{idx:val, ...}` for a dynamic-array target as long as
+      // indices cover a dense `0..N-1`. The legal subset is equivalent to
       // positional and adds no expressive power; rejecting it here keeps the
       // dispatch narrow until a consumer needs the structured form.
       if (target_kind == slang::ast::SymbolKind::DynamicArrayType) {
@@ -252,156 +290,48 @@ auto LowerProcExpr(
             "index-keyed assignment pattern on a dynamic array is not yet "
             "supported; use positional form");
       }
-      return LowerAssignmentPatternFromElements(proc, frame, sap, span);
+      return LowerAssignmentPatternFromElements(lowerer, frame, sap, span);
     }
 
     case slang::ast::ExpressionKind::ReplicatedAssignmentPattern:
       return LowerReplicatedAssignmentPatternExpr(
-          proc, frame,
+          lowerer, frame,
           expr.as<slang::ast::ReplicatedAssignmentPatternExpression>(), span);
 
     case slang::ast::ExpressionKind::NewArray:
-      return LowerNewArrayExprProc(
-          proc, frame, expr.as<slang::ast::NewArrayExpression>(), span);
-
-    default:
-      return diag::Fail(
-          span, diag::DiagCode::kUnsupportedExpressionForm,
-          "this expression form is not supported yet");
-  }
-}
-
-auto LowerStructuralExpr(
-    StructuralScopeLowerer& scope, WalkFrame frame,
-    const slang::ast::Expression& expr) -> diag::Result<hir::Expr> {
-  auto& module = scope.Module();
-  const auto span = module.SourceMapper().SpanOf(expr.sourceRange);
-
-  switch (expr.kind) {
-    case slang::ast::ExpressionKind::IntegerLiteral: {
-      auto type_id = module.InternType(*expr.type, span);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return MakeIntegerLiteralExpr(
-          expr.as<slang::ast::IntegerLiteral>(), *type_id, span);
-    }
-
-    case slang::ast::ExpressionKind::UnbasedUnsizedIntegerLiteral: {
-      auto type_id = module.InternType(*expr.type, span);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return MakeUnbasedUnsizedLiteralExpr(
-          expr.as<slang::ast::UnbasedUnsizedIntegerLiteral>(), *type_id, span);
-    }
-
-    case slang::ast::ExpressionKind::RealLiteral: {
-      const auto& rl = expr.as<slang::ast::RealLiteral>();
-      auto type_id = module.InternType(*expr.type, span);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return MakeRealLiteralExpr(rl.getValue(), *type_id, span);
-    }
-
-    case slang::ast::ExpressionKind::StringLiteral: {
-      const auto& sl = expr.as<slang::ast::StringLiteral>();
-      auto type_id = module.InternType(*expr.type, span);
-      if (!type_id) return std::unexpected(std::move(type_id.error()));
-      return MakeStringLiteralExpr(std::string{sl.getValue()}, *type_id, span);
-    }
-
-    case slang::ast::ExpressionKind::NamedValue:
-      return LowerNamedValueStructural(
-          module, frame, expr.as<slang::ast::NamedValueExpression>());
-
-    case slang::ast::ExpressionKind::LValueReference:
-      throw InternalError(
-          "LowerStructuralExpr: slang LValueReference must not reach HIR; "
-          "generate-iter compound is rewritten as the next-value BinaryExpr "
-          "directly");
-
-    case slang::ast::ExpressionKind::Conversion:
-      return LowerConversionExpr(
-          scope, frame, expr.as<slang::ast::ConversionExpression>(), span);
-
-    case slang::ast::ExpressionKind::UnaryOp: {
-      const auto& un = expr.as<slang::ast::UnaryExpression>();
-      if (slang::ast::OpInfo::isLValue(un.op)) {
+      if constexpr (kProcedural) {
+        return LowerNewArrayExprProc(
+            lowerer, frame, expr.as<slang::ast::NewArrayExpression>(), span);
+      } else {
         return diag::Fail(
             span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
-            "increment / decrement is not legal outside procedural code "
-            "(LRM 11.3.6, 11.4.2)");
+            "dynamic-array new[] is not legal in a structural expression; "
+            "LRM 7.5.1 restricts it to blocking assignments");
       }
-      return LowerUnaryExpr(scope, frame, un, span);
-    }
-
-    case slang::ast::ExpressionKind::BinaryOp:
-      return LowerBinaryExpr(
-          scope, frame, expr.as<slang::ast::BinaryExpression>(), span);
-
-    case slang::ast::ExpressionKind::ConditionalOp:
-      return LowerConditionalExpr(
-          scope, frame, expr.as<slang::ast::ConditionalExpression>(), span);
-
-    case slang::ast::ExpressionKind::ElementSelect:
-      return LowerElementSelectExpr(
-          scope, frame, expr.as<slang::ast::ElementSelectExpression>(), span);
-
-    case slang::ast::ExpressionKind::RangeSelect:
-      return LowerRangeSelectExpr(
-          scope, frame, expr.as<slang::ast::RangeSelectExpression>(), span);
-
-    case slang::ast::ExpressionKind::MemberAccess:
-      return LowerMemberAccessExpr(
-          scope, frame, expr.as<slang::ast::MemberAccessExpression>(), span);
-
-    case slang::ast::ExpressionKind::Concatenation:
-      return LowerConcatExpr(
-          scope, frame, expr.as<slang::ast::ConcatenationExpression>(), span);
-
-    case slang::ast::ExpressionKind::SimpleAssignmentPattern: {
-      const auto& sap =
-          expr.as<slang::ast::SimpleAssignmentPatternExpression>();
-      if (sap.isLValue) {
-        return diag::Fail(
-            span, diag::DiagCode::kUnsupportedAssignmentPatternKind,
-            "assignment pattern as LHS destructuring is not yet supported");
-      }
-      return LowerAssignmentPatternFromElements(scope, frame, sap, span);
-    }
-
-    case slang::ast::ExpressionKind::StructuredAssignmentPattern: {
-      const auto& sap =
-          expr.as<slang::ast::StructuredAssignmentPatternExpression>();
-      const auto target_kind = expr.type->getCanonicalType().kind;
-      if (target_kind == slang::ast::SymbolKind::AssociativeArrayType) {
-        return LowerAssociativeAssignmentPattern(scope, frame, sap, span);
-      }
-      if (target_kind == slang::ast::SymbolKind::DynamicArrayType) {
-        return diag::Fail(
-            span, diag::DiagCode::kUnsupportedAssignmentPatternKind,
-            "index-keyed assignment pattern on a dynamic array is not yet "
-            "supported; use positional form");
-      }
-      return LowerAssignmentPatternFromElements(scope, frame, sap, span);
-    }
-
-    case slang::ast::ExpressionKind::ReplicatedAssignmentPattern:
-      return LowerReplicatedAssignmentPatternExpr(
-          scope, frame,
-          expr.as<slang::ast::ReplicatedAssignmentPatternExpression>(), span);
 
     default:
-      return diag::Fail(
-          span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
-          "this structural expression form is not supported yet");
+      if constexpr (kProcedural) {
+        return diag::Fail(
+            span, diag::DiagCode::kUnsupportedExpressionForm,
+            "this expression form is not supported yet");
+      } else {
+        return diag::Fail(
+            span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
+            "this structural expression form is not supported yet");
+      }
   }
 }
 
-// Class method wrappers. The pass-class entries delegate to the free-function
-// dispatchers above; this keeps per-kind handlers free from class-method
-// declaration growth.
+}  // namespace
+
+// Class method wrappers. Both pass-class entries delegate to the one
+// dispatcher template above; this keeps per-kind handlers free from
+// class-method declaration growth and forces the two instantiations here.
 
 auto ProcessLowerer::LowerExpr(
     const slang::ast::Expression& expr, WalkFrame frame)
     -> diag::Result<hir::Expr> {
-  return LowerProcExpr(*this, frame, expr);
+  return LowerExprImpl(*this, frame, expr);
 }
 
 auto ProcessLowerer::LowerInsideItem(
@@ -418,7 +348,7 @@ auto ProcessLowerer::ValidateAssignableProcedural(
 auto StructuralScopeLowerer::LowerExpr(
     const slang::ast::Expression& expr, WalkFrame frame)
     -> diag::Result<hir::Expr> {
-  return LowerStructuralExpr(*this, frame, expr);
+  return LowerExprImpl(*this, frame, expr);
 }
 
 auto StructuralScopeLowerer::ValidateAssignableStructural(

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -42,6 +42,23 @@ auto MakeEnumValueExpr(
   return MakeIntegralLiteralExpr(cv.integer(), type, span);
 }
 
+// LRM 7.12.4: a reference to an array-method `with`-clause iteration element
+// (`item`) lowers to an `IterationBindingRef` naming `clause` and the element
+// role, typed by its own reference type. The element is one of the clause's two
+// iteration parameters, not a variable of the enclosing scope, so neither pass
+// class's variable storage is consulted.
+auto MakeIterationElementRefExpr(
+    ModuleLowerer& module, const slang::ast::NamedValueExpression& named,
+    hir::WithClauseId clause, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  auto type_id = module.InternType(*named.type, span);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return MakeRefExpr(
+      hir::IterationBindingRef{
+          .clause = clause, .role = hir::IterationBindingRole::kElement},
+      *type_id, span);
+}
+
 }  // namespace
 
 auto LowerNamedValueProc(
@@ -51,6 +68,10 @@ auto LowerNamedValueProc(
   const auto& mapper = module.SourceMapper();
   const auto span = mapper.SpanOf(named.sourceRange);
   const auto& sym = named.symbol;
+
+  if (auto clause = frame.FindIterationClause(sym)) {
+    return MakeIterationElementRefExpr(module, named, *clause, span);
+  }
 
   if (sym.kind == slang::ast::SymbolKind::EnumValue) {
     auto type_id = module.InternType(*named.type, span);
@@ -271,6 +292,9 @@ auto LowerNamedValueStructural(
   const auto& mapper = module.SourceMapper();
   const auto span = mapper.SpanOf(named.sourceRange);
   const auto& sym = named.symbol;
+  if (auto clause = frame.FindIterationClause(sym)) {
+    return MakeIterationElementRefExpr(module, named, *clause, span);
+  }
   if (sym.kind == slang::ast::SymbolKind::EnumValue) {
     auto type_id = module.InternType(*named.type, span);
     if (!type_id) return std::unexpected(std::move(type_id.error()));

--- a/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
@@ -50,6 +50,10 @@ auto ModuleLowerer::NextScopeFrameId() -> ScopeFrameId {
   return ScopeFrameId{.value = next_scope_frame_++};
 }
 
+auto ModuleLowerer::NextWithClauseId() -> hir::WithClauseId {
+  return hir::WithClauseId{.value = next_with_clause_++};
+}
+
 void ModuleLowerer::MapStructuralVarBinding(
     const slang::ast::VariableSymbol& var, ScopeFrameId home_frame,
     hir::StructuralVarId local, hir::TypeId type) {

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -21,6 +21,8 @@
 #include "lyra/lowering/hir_to_mir/continuous_assign.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/expression/aggregates.hpp"
+#include "lyra/lowering/hir_to_mir/expression/calls.hpp"
+#include "lyra/lowering/hir_to_mir/expression/inside.hpp"
 #include "lyra/lowering/hir_to_mir/expression/operators.hpp"
 #include "lyra/lowering/hir_to_mir/expression/references.hpp"
 #include "lyra/lowering/hir_to_mir/expression/selects.hpp"
@@ -988,15 +990,11 @@ auto ClassLowerer::LowerExpr(const hir::Expr& expr, WalkFrame frame) const
           [&](const hir::ConversionExpr& cv) -> diag::Result<mir::Expr> {
             return LowerHirConversionExpr(*this, frame, cv, result_type);
           },
-          [](const hir::CallExpr&) -> diag::Result<mir::Expr> {
-            return diag::Fail(
-                diag::DiagCode::kUnsupportedStructuralExpressionForm,
-                "calls are not allowed in constructor expressions");
+          [&](const hir::CallExpr& c) -> diag::Result<mir::Expr> {
+            return LowerHirCallExpr(*this, frame, c, expr.span, result_type);
           },
-          [](const hir::InsideExpr&) -> diag::Result<mir::Expr> {
-            return diag::Fail(
-                diag::DiagCode::kUnsupportedStructuralExpressionForm,
-                "inside operator is not allowed in constructor expressions");
+          [&](const hir::InsideExpr& in) -> diag::Result<mir::Expr> {
+            return LowerHirInsideExpr(*this, frame, in, result_type);
           },
           [&](const hir::ElementSelectExpr& s) -> diag::Result<mir::Expr> {
             return LowerHirElementSelectExpr(*this, frame, s, result_type);
@@ -1010,10 +1008,8 @@ auto ClassLowerer::LowerExpr(const hir::Expr& expr, WalkFrame frame) const
           [&](const hir::ConcatExpr& c) -> diag::Result<mir::Expr> {
             return LowerHirConcatExpr(*this, frame, c, result_type);
           },
-          [](const hir::ReplicationExpr&) -> diag::Result<mir::Expr> {
-            return diag::Fail(
-                diag::DiagCode::kUnsupportedStructuralExpressionForm,
-                "replication in constructor expressions is not yet supported");
+          [&](const hir::ReplicationExpr& r) -> diag::Result<mir::Expr> {
+            return LowerHirReplicationExpr(*this, frame, r, result_type);
           },
           [&](const hir::AssignmentPatternExpr& a) -> diag::Result<mir::Expr> {
             return LowerHirAssignmentPatternExpr(*this, frame, a, result_type);

--- a/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
@@ -80,14 +80,15 @@ auto LowerHirConcatExpr(
       .type = result_type};
 }
 
-auto LowerHirReplicationExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::ReplicationExpr& r,
+template <ExprLowerer Lowerer>
+auto LowerHirReplicationExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::ReplicationExpr& r,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
   auto& block = *frame.current_block;
-  auto count_or = process.LowerExpr(process.HirExprs().Get(r.count), frame);
+  auto count_or = lowerer.LowerExpr(lowerer.HirExprs().Get(r.count), frame);
   if (!count_or) return std::unexpected(std::move(count_or.error()));
   const mir::ExprId count_id = block.exprs.Add(*std::move(count_or));
-  auto concat_or = process.LowerExpr(process.HirExprs().Get(r.concat), frame);
+  auto concat_or = lowerer.LowerExpr(lowerer.HirExprs().Get(r.concat), frame);
   if (!concat_or) return std::unexpected(std::move(concat_or.error()));
   const mir::ExprId concat_id = block.exprs.Add(*std::move(concat_or));
   return mir::Expr{
@@ -258,6 +259,12 @@ template auto LowerHirAssociativeAssignmentPatternExpr(
 template auto LowerHirAssociativeAssignmentPatternExpr(
     const ClassLowerer&, WalkFrame,
     const hir::AssociativeAssignmentPatternExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirReplicationExpr(
+    ProcessLowerer&, WalkFrame, const hir::ReplicationExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirReplicationExpr(
+    const ClassLowerer&, WalkFrame, const hir::ReplicationExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -218,7 +218,7 @@ auto ApplyAssignEffect(
   auto& block = *frame.current_block;
   if (kind == hir::AssignKind::kBlocking) {
     const mir::ExprId services_id =
-        block.exprs.Add(BuildServicesCallExpr(process, frame));
+        block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
     return effect_fn(block, target_in_outer, operands_in_outer, services_id);
   }
   if (!IsExprRootedAtStructuralVar(block, target_in_outer)) {
@@ -230,7 +230,7 @@ auto ApplyAssignEffect(
       process.Module(), frame, target_in_outer, operands_in_outer, effect_fn);
   const mir::ExprId closure_id = block.exprs.Add(std::move(closure));
   const mir::ExprId services_id =
-      block.exprs.Add(BuildServicesCallExpr(process, frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
   return mir::Expr{
       .data =
           mir::CallExpr{

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -10,12 +10,11 @@
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/closure_builder.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
+#include "lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/control.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/diagnostic.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/file_io.hpp"
@@ -24,6 +23,7 @@
 #include "lyra/lowering/hir_to_mir/expression/system/sformat.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/time.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/timescale.hpp"
+#include "lyra/lowering/hir_to_mir/iteration_binding_registry.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
@@ -48,17 +48,18 @@ namespace {
 // gates its call on `root_id != lhs_id` because a bare observable cell
 // should bind `Ref<T>` directly to the underlying `Var<T>&`, not via a
 // snapshot.
+template <ExprLowerer Lowerer>
 auto MaybeWrapObservableLhsWithMutate(
-    ProcessLowerer& process, WalkFrame frame, mir::Block& block,
-    mir::ExprId lhs_id) -> mir::ExprId {
+    Lowerer& lowerer, WalkFrame frame, mir::Block& block, mir::ExprId lhs_id)
+    -> mir::ExprId {
   const mir::ExprId root_id = FindLhsRootId(block, lhs_id);
   const bool root_is_cell = mir::IsObservableCellType(
-      process.Module().Unit().GetType(block.exprs.Get(root_id).type));
+      lowerer.Module().Unit().GetType(block.exprs.Get(root_id).type));
   if (!root_is_cell) return lhs_id;
   const mir::ExprId services_id =
-      block.exprs.Add(BuildServicesCallExpr(process, frame));
+      block.exprs.Add(BuildServicesCallExpr(lowerer.Module(), frame));
   return RewriteLhsRootWithMutate(
-      process.Module().Unit(), block, lhs_id, services_id);
+      lowerer.Module().Unit(), block, lhs_id, services_id);
 }
 
 // LRM 7.9.4 -- 7.9.7 associative traversal (`m.first(idx)` / `last` / `next` /
@@ -69,36 +70,35 @@ auto MaybeWrapObservableLhsWithMutate(
 // fires -- so it lowers to an immediately-invoked closure. The query is a pure
 // value member that mutates a plain body-local probe; the event-firing lives in
 // the ordinary observable write-back assignment, not in the query.
+template <ExprLowerer Lowerer>
 auto LowerAssociativeTraversal(
-    ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& c,
+    Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
     support::BuiltinFn fn, mir::TypeId result_type) -> diag::Result<mir::Expr> {
   if (!c.arguments[1].has_value()) {
     throw InternalError(
         "LowerAssociativeTraversal: index argument unexpectedly elided");
   }
-  const auto& module = process.Module();
-  const auto& hir_proc = process.HirBody();
+  const auto& module = lowerer.Module();
+  const auto& hir_exprs = lowerer.HirExprs();
   const auto recv_hir = *c.arguments[0];
   const auto idx_hir = *c.arguments[1];
   const mir::TypeId key_type =
-      module.TranslateType(hir_proc.exprs.Get(idx_hir).type);
+      module.TranslateType(hir_exprs.Get(idx_hir).type);
   const mir::TypeId void_t = module.Unit().builtins.void_type;
 
-  ClosureBuilder closure(process.Module().Unit(), frame);
+  ClosureBuilder closure(lowerer.Module().Unit(), frame);
   mir::Block& body = closure.Body();
   const WalkFrame& closure_frame = closure.Frame();
 
   // probe = idx -- snapshot the current index value into a plain local.
-  auto idx_read_or =
-      process.LowerExpr(hir_proc.exprs.Get(idx_hir), closure_frame);
+  auto idx_read_or = lowerer.LowerExpr(hir_exprs.Get(idx_hir), closure_frame);
   if (!idx_read_or) return std::unexpected(std::move(idx_read_or.error()));
   const mir::LocalRef probe_ref = body.AppendLocal(
       mir::LocalDecl{.name = "_lyra_trav_probe", .type = key_type},
       body.exprs.Add(*std::move(idx_read_or)));
 
   // found = (map).<kind>(probe) -- pure query: mutates probe, yields 1/0.
-  auto map_read_or =
-      process.LowerExpr(hir_proc.exprs.Get(recv_hir), closure_frame);
+  auto map_read_or = lowerer.LowerExpr(hir_exprs.Get(recv_hir), closure_frame);
   if (!map_read_or) return std::unexpected(std::move(map_read_or.error()));
   const mir::ExprId map_read_id = body.exprs.Add(*std::move(map_read_or));
   const mir::ExprId probe_read_id =
@@ -115,14 +115,13 @@ auto LowerAssociativeTraversal(
       query_id);
 
   // idx = probe -- observable write-back fires the LRM 4.3 update event.
-  auto idx_lhs_or =
-      process.LowerLhsExpr(hir_proc.exprs.Get(idx_hir), closure_frame);
+  auto idx_lhs_or = lowerer.LowerLhsExpr(hir_exprs.Get(idx_hir), closure_frame);
   if (!idx_lhs_or) return std::unexpected(std::move(idx_lhs_or.error()));
   const mir::ExprId idx_lhs_id = body.exprs.Add(*std::move(idx_lhs_or));
   const mir::ExprId probe_writeback_id =
       body.exprs.Add(mir::Expr{.data = probe_ref, .type = key_type});
   const mir::ExprId services_id =
-      body.exprs.Add(BuildServicesCallExpr(process, closure_frame));
+      body.exprs.Add(BuildServicesCallExpr(lowerer.Module(), closure_frame));
   const mir::Expr assign_expr = BuildObservableAssignExpr(
       module.Unit(), body, services_id, idx_lhs_id, probe_writeback_id,
       std::nullopt, key_type, void_t);
@@ -186,19 +185,20 @@ auto ArrayMethodResultProtoType(
       module.Unit().GetType(result_type).data);
 }
 
-// LRM 7.12.1 / 7.12.2 / 7.12.3 with-clause closure synthesis. The iterator and
-// index are the closure's two parameters (LRM 7.12.4): the iterator HIR id
-// remaps to the `item` parameter and the index parameter resolves the
-// `IteratorIndexRef` callee. The body is a normal expression lowered through
-// `process.LowerExpr`. When the source has no `with` clause LRM 7.12.1 defines
-// the default as `with (item)`; this synthesises the identity closure (body
-// returns the iterator binding) so MIR always carries the closure argument and
-// downstream consumers see one uniform shape.
+// LRM 7.12.1 / 7.12.2 / 7.12.3 with-clause closure synthesis. The element and
+// index are the closure's two parameters (LRM 7.12.4); an `IterationBindingRef`
+// in the body resolves to one of them by the clause identity registered here.
+// The body is a normal expression lowered through `lowerer.LowerExpr`. When the
+// source has no `with` clause LRM 7.12.1 defines the default as `with (item)`;
+// this synthesises the identity closure (body returns the element parameter) so
+// MIR always carries the closure argument and downstream consumers see one
+// uniform shape.
+template <ExprLowerer Lowerer>
 auto BuildArrayMethodClosure(
-    ProcessLowerer& process, WalkFrame frame, hir::TypeId hir_receiver_type,
+    Lowerer& lowerer, WalkFrame frame, hir::TypeId hir_receiver_type,
     const hir::WithClause* with_clause) -> diag::Result<mir::Expr> {
-  const auto& module = process.Module();
-  const auto& hir_process = process.HirBody();
+  const auto& module = lowerer.Module();
+  const auto& hir_exprs = lowerer.HirExprs();
   const auto& hir_recv_ty = module.Hir().GetType(hir_receiver_type);
   const auto element_type = ArrayMethodReceiverElementType(hir_recv_ty);
   if (!element_type.has_value()) {
@@ -215,28 +215,31 @@ auto BuildArrayMethodClosure(
     index_type = module.TranslateType(*assoc->key_type);
   }
   const std::string iterator_name =
-      with_clause != nullptr
-          ? hir_process.procedural_vars.Get(with_clause->iterator).name
-          : std::string{"item"};
+      with_clause != nullptr ? with_clause->element_name : std::string{"item"};
 
-  ClosureBuilder closure(process.Module().Unit(), frame);
+  ClosureBuilder closure(lowerer.Module().Unit(), frame);
   const mir::LocalId item_binding = closure.AddParam(iterator_name, item_type);
   const mir::LocalId index_binding = closure.AddParam("index", index_type);
   mir::Block& body = closure.Body();
 
   mir::ExprId body_return_value{};
   if (with_clause != nullptr) {
-    process.MapProceduralVar(
-        with_clause->iterator,
-        AutomaticVarBinding{
-            .declaration_procedural_depth = closure.Frame().block_depth,
-            .var = item_binding});
-    // `item.index` (LRM 7.12.4) resolves to the index parameter -- a
-    // with-clause-specific role, so the body lowers through a frame carrying
-    // that binding rather than the builder knowing about it.
-    auto body_expr_or = process.LowerExpr(
-        hir_process.exprs.Get(with_clause->expr),
-        closure.Frame().WithIndexBinding(index_binding));
+    // `item` and `item.index` (LRM 7.12.4) are this clause's two closure
+    // parameters; register them by clause identity so the body resolves each
+    // reference by identity and captures it when it crosses a closure boundary.
+    // The registry is shared down the nesting (an inner clause adds to the same
+    // one), so a clause nested in the body still reaches this outer iterator.
+    const BlockDepth decl_depth = closure.Frame().block_depth;
+    IterationBindingRegistry owned_registry;
+    IterationBindingRegistry* registry = frame.iteration_bindings != nullptr
+                                             ? frame.iteration_bindings
+                                             : &owned_registry;
+    registry->Register(
+        with_clause->id, {.var = item_binding, .decl_depth = decl_depth},
+        {.var = index_binding, .decl_depth = decl_depth});
+    auto body_expr_or = lowerer.LowerExpr(
+        hir_exprs.Get(with_clause->expr),
+        closure.Frame().WithIterationBindings(registry));
     if (!body_expr_or) return std::unexpected(std::move(body_expr_or.error()));
     body_return_value = body.exprs.Add(*std::move(body_expr_or));
   } else {
@@ -316,12 +319,12 @@ auto LowerSystemSubroutineCall(
 // ref alias the actual and copy nothing back (LRM 13.5.2), so they fall
 // through to the value-only lowering. The callee body receives its
 // instance handle as `arguments[0]`; SV actuals follow.
+template <ExprLowerer Lowerer>
 auto LowerStructuralSubroutineCall(
-    ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& c,
+    Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
     const hir::StructuralSubroutineRef& usr, diag::SourceSpan span,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& lowerer = process.Owner();
-  const auto& hir_process = process.HirBody();
+  const auto& hir_exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
   const hir::StructuralSubroutineDecl& decl =
       lowerer.LookupHirSubroutine(usr.hops, usr.subroutine);
@@ -353,21 +356,19 @@ auto LowerStructuralSubroutineCall(
          decl.params[i].direction == hir::ParamDirection::kConstRef);
     mir::ExprId actual_id{};
     if (is_ref_formal) {
-      auto arg_or =
-          process.LowerLhsExpr(hir_process.exprs.Get(*c.arguments[i]), frame);
+      auto arg_or = lowerer.LowerLhsExpr(hir_exprs.Get(*c.arguments[i]), frame);
       if (!arg_or) return std::unexpected(std::move(arg_or.error()));
       actual_id = block.exprs.Add(*std::move(arg_or));
       const mir::ExprId root_id = FindLhsRootId(block, actual_id);
       if (root_id != actual_id) {
         actual_id =
-            MaybeWrapObservableLhsWithMutate(process, frame, block, actual_id);
+            MaybeWrapObservableLhsWithMutate(lowerer, frame, block, actual_id);
       }
       args.push_back(BuildReferenceArg(
-          process.Module().Unit(), block, actual_id,
+          lowerer.Module().Unit(), block, actual_id,
           block.exprs.Get(actual_id).type));
     } else {
-      auto arg_or =
-          process.LowerExpr(hir_process.exprs.Get(*c.arguments[i]), frame);
+      auto arg_or = lowerer.LowerExpr(hir_exprs.Get(*c.arguments[i]), frame);
       if (!arg_or) return std::unexpected(std::move(arg_or.error()));
       args.push_back(block.exprs.Add(*std::move(arg_or)));
     }
@@ -387,8 +388,9 @@ auto LowerStructuralSubroutineCall(
 // call (`MyEnum::first()`) it is a discardable bearer whose type supplies
 // the static callee's `type_qual`. Either way, the for-loop below skips
 // index 0 and starts the real user-argument scan at index 1.
+template <ExprLowerer Lowerer>
 auto LowerBuiltinMethodCall(
-    ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& c,
+    Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
     const hir::BuiltinMethodRef& b, mir::TypeId result_type)
     -> diag::Result<mir::Expr> {
   if (c.arguments.empty()) {
@@ -404,13 +406,13 @@ auto LowerBuiltinMethodCall(
   // expression position. The other associative methods are plain member
   // calls handled by the generic path below.
   if (support::IsAssociativeTraversalFn(b.method)) {
-    return LowerAssociativeTraversal(process, frame, c, b.method, result_type);
+    return LowerAssociativeTraversal(lowerer, frame, c, b.method, result_type);
   }
-  const auto& module = process.Module();
-  const auto& hir_process = process.HirBody();
+  const auto& module = lowerer.Module();
+  const auto& hir_exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
   const hir::TypeId hir_dispatch_type =
-      hir_process.exprs.Get(*c.arguments.front()).type;
+      hir_exprs.Get(*c.arguments.front()).type;
   std::vector<mir::ExprId> args;
   args.reserve(c.arguments.size() + 1);
 
@@ -433,15 +435,15 @@ auto LowerBuiltinMethodCall(
     const bool method_mutates = mir::IsMutatingCallee(mir_callee);
     mir::ExprId receiver_id{};
     if (method_mutates) {
-      auto recv_or = process.LowerLhsExpr(
-          hir_process.exprs.Get(*c.arguments.front()), frame);
+      auto recv_or =
+          lowerer.LowerLhsExpr(hir_exprs.Get(*c.arguments.front()), frame);
       if (!recv_or) return std::unexpected(std::move(recv_or.error()));
       receiver_id = block.exprs.Add(*std::move(recv_or));
       receiver_id =
-          MaybeWrapObservableLhsWithMutate(process, frame, block, receiver_id);
+          MaybeWrapObservableLhsWithMutate(lowerer, frame, block, receiver_id);
     } else {
       auto recv_or =
-          process.LowerExpr(hir_process.exprs.Get(*c.arguments.front()), frame);
+          lowerer.LowerExpr(hir_exprs.Get(*c.arguments.front()), frame);
       if (!recv_or) return std::unexpected(std::move(recv_or.error()));
       receiver_id = block.exprs.Add(*std::move(recv_or));
     }
@@ -454,8 +456,7 @@ auto LowerBuiltinMethodCall(
     if (!c.arguments[i].has_value()) {
       throw InternalError("builtin-method call argument unexpectedly elided");
     }
-    auto arg_or =
-        process.LowerExpr(hir_process.exprs.Get(*c.arguments[i]), frame);
+    auto arg_or = lowerer.LowerExpr(hir_exprs.Get(*c.arguments[i]), frame);
     if (!arg_or) return std::unexpected(std::move(arg_or.error()));
     args.push_back(block.exprs.Add(*std::move(arg_or)));
   }
@@ -467,7 +468,7 @@ auto LowerBuiltinMethodCall(
   // one uniform shape per kind.
   if (support::ArrayMethodTakesClosure(b.method)) {
     auto closure_or = BuildArrayMethodClosure(
-        process, frame, hir_dispatch_type,
+        lowerer, frame, hir_dispatch_type,
         c.with_clause.has_value() ? &*c.with_clause : nullptr);
     if (!closure_or) return std::unexpected(std::move(closure_or.error()));
     args.push_back(block.exprs.Add(*std::move(closure_or)));
@@ -494,7 +495,8 @@ auto LowerBuiltinMethodCall(
   // one. (`-> e` is the only producer of the trigger kind and lowers through
   // the event-trigger stmt path; `await` takes no services.)
   if (b.method == support::BuiltinFn::kTriggered) {
-    args.push_back(block.exprs.Add(BuildServicesCallExpr(process, frame)));
+    args.push_back(
+        block.exprs.Add(BuildServicesCallExpr(lowerer.Module(), frame)));
   }
 
   return mir::Expr{
@@ -502,49 +504,47 @@ auto LowerBuiltinMethodCall(
       .type = result_type};
 }
 
-// LRM 7.12.4 `item.index` reads the second parameter of the enclosing
-// array-method with-clause closure (LRM 7.12 closures pass both `item`
-// and `index` to each invocation). The binding is installed by
-// `BuildArrayMethodClosure`; reaching here without it is an upstream
-// lowering bug.
-auto LowerIteratorIndexCall(WalkFrame frame, mir::TypeId result_type)
-    -> diag::Result<mir::Expr> {
-  if (!frame.active_index_binding.has_value()) {
-    throw InternalError(
-        "LowerIteratorIndexCall: IteratorIndexRef outside an array-method "
-        "`with` body (LRM 7.12.4)");
-  }
-  return mir::Expr{
-      .data =
-          mir::LocalRef{
-              .hops = mir::BlockHops{.value = 0},
-              .var = *frame.active_index_binding},
-      .type = result_type};
-}
-
 }  // namespace
 
-auto LowerHirCallExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& c,
+template <ExprLowerer Lowerer>
+auto LowerHirCallExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
     diag::SourceSpan span, mir::TypeId result_type) -> diag::Result<mir::Expr> {
   return std::visit(
       Overloaded{
           [&](const hir::SystemSubroutineRef& sys) -> diag::Result<mir::Expr> {
-            return LowerSystemSubroutineCall(process, frame, c, sys, span);
+            // System subroutines (the print / scan / file families plus the
+            // value functions) are lowered through statement-flavored handlers
+            // bound to a process body; a continuous-assign RHS reaching one is
+            // a value system function ($time and the like), which is the only
+            // form legal in expression position there but not yet wired on the
+            // structural path.
+            if constexpr (std::same_as<Lowerer, ProcessLowerer>) {
+              return LowerSystemSubroutineCall(lowerer, frame, c, sys, span);
+            } else {
+              return diag::Fail(
+                  span, diag::DiagCode::kUnsupportedStructuralExpressionForm,
+                  "a system subroutine call is not yet supported in a "
+                  "continuous assignment");
+            }
           },
           [&](const hir::StructuralSubroutineRef& usr)
               -> diag::Result<mir::Expr> {
             return LowerStructuralSubroutineCall(
-                process, frame, c, usr, span, result_type);
+                lowerer, frame, c, usr, span, result_type);
           },
           [&](const hir::BuiltinMethodRef& b) -> diag::Result<mir::Expr> {
-            return LowerBuiltinMethodCall(process, frame, c, b, result_type);
-          },
-          [&](const hir::IteratorIndexRef&) -> diag::Result<mir::Expr> {
-            return LowerIteratorIndexCall(frame, result_type);
+            return LowerBuiltinMethodCall(lowerer, frame, c, b, result_type);
           },
       },
       c.callee);
 }
+
+template auto LowerHirCallExpr(
+    ProcessLowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
+    diag::SourceSpan span, mir::TypeId result_type) -> diag::Result<mir::Expr>;
+template auto LowerHirCallExpr(
+    const ClassLowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
+    diag::SourceSpan span, mir::TypeId result_type) -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/inside.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/inside.cpp
@@ -6,7 +6,7 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/hir/procedural_body.hpp"
+#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/inside_predicate.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
@@ -15,23 +15,24 @@
 
 namespace lyra::lowering::hir_to_mir {
 
-auto LowerHirInsideExprProc(
-    ProcessLowerer& process, WalkFrame frame, const hir::InsideExpr& in,
+template <ExprLowerer Lowerer>
+auto LowerHirInsideExpr(
+    Lowerer& lowerer, WalkFrame frame, const hir::InsideExpr& in,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
-  const auto& hir_process = process.HirBody();
+  const auto& hir_exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
-  auto lhs_or = process.LowerExpr(hir_process.exprs.Get(in.lhs), frame);
+  auto lhs_or = lowerer.LowerExpr(hir_exprs.Get(in.lhs), frame);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   const mir::ExprId lhs_id = block.exprs.Add(*std::move(lhs_or));
 
   if (in.items.empty()) {
     throw InternalError(
-        "LowerHirInsideExprProc: hir::InsideExpr has empty item list");
+        "LowerHirInsideExpr: hir::InsideExpr has empty item list");
   }
   std::optional<mir::ExprId> acc;
   for (const auto& item : in.items) {
     auto pred_or =
-        BuildHirInsideItemPredicate(process, frame, lhs_id, item, result_type);
+        BuildHirInsideItemPredicate(lowerer, frame, lhs_id, item, result_type);
     if (!pred_or) return std::unexpected(std::move(pred_or.error()));
     if (acc.has_value()) {
       acc = block.exprs.Add(
@@ -48,5 +49,12 @@ auto LowerHirInsideExprProc(
   }
   return mir::Expr{block.exprs.Get(*acc)};
 }
+
+template auto LowerHirInsideExpr(
+    ProcessLowerer&, WalkFrame, const hir::InsideExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
+template auto LowerHirInsideExpr(
+    const ClassLowerer&, WalkFrame, const hir::InsideExpr&, mir::TypeId)
+    -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -218,7 +218,7 @@ auto LowerHirIncDecExprProc(
   if (mir::IsObservableCellType(
           process.Module().Unit().GetType(block.exprs.Get(root_id).type))) {
     const mir::ExprId services_id =
-        block.exprs.Add(BuildServicesCallExpr(process, frame));
+        block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
     target_id = RewriteLhsRootWithMutate(
         process.Module().Unit(), block, target_id, services_id);
   }

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -13,6 +13,7 @@
 #include "lyra/lowering/hir_to_mir/block_depth.hpp"
 #include "lyra/lowering/hir_to_mir/capture_sink.hpp"
 #include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/iteration_binding_registry.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
@@ -221,6 +222,34 @@ auto LowerLoopVarRefExprAsStructuralParam(
       .type = type};
 }
 
+// LRM 7.12.4: a with-clause iteration reference reads the named clause's
+// element or index closure parameter. The parameter is found by clause
+// identity, then resolved by the same rule as any body-local: read directly
+// when the reference is in the clause's own closure, captured when it is inside
+// a deeper clause's closure (the parameter's declaration sits above that
+// closure's boundary).
+auto LowerIterationBindingRefExpr(
+    const hir::IterationBindingRef& ref, WalkFrame frame, mir::TypeId type)
+    -> mir::Expr {
+  if (frame.iteration_bindings == nullptr) {
+    throw InternalError(
+        "LowerIterationBindingRefExpr: with-clause iteration reference outside "
+        "an array-method `with` body (LRM 7.12.4)");
+  }
+  const IterationBinding binding =
+      frame.iteration_bindings->Lookup(ref.clause, ref.role);
+  if (auto* sink = frame.capture_sink) {
+    if (binding.decl_depth < sink->BoundaryDepth()) {
+      return mir::Expr{
+          .data = sink->Capture(
+              binding.var, binding.decl_depth, type, frame.block_depth),
+          .type = type};
+    }
+  }
+  return mir::MakeLocalRefExpr(
+      frame.block_depth - binding.decl_depth, binding.var, type);
+}
+
 }  // namespace
 
 auto LowerHirPrimaryExprProc(
@@ -254,6 +283,9 @@ auto LowerHirPrimaryExprProc(
           },
           [&](const hir::CrossUnitVarRef& c) -> mir::Expr {
             return LowerCrossUnitVarRefExpr(lowerer, frame, c);
+          },
+          [&](const hir::IterationBindingRef& r) -> mir::Expr {
+            return LowerIterationBindingRefExpr(r, frame, result_type);
           },
       },
       p);
@@ -295,6 +327,9 @@ auto LowerHirPrimaryExprStructural(
           },
           [&](const hir::CrossUnitVarRef& c) -> mir::Expr {
             return LowerCrossUnitVarRefExpr(lowerer, frame, c);
+          },
+          [&](const hir::IterationBindingRef& r) -> mir::Expr {
+            return LowerIterationBindingRefExpr(r, frame, result_type);
           },
       },
       p);

--- a/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/control.cpp
@@ -67,8 +67,8 @@ auto LowerFinishSystemSubroutineCall(
     level = static_cast<int>(*literal);
   }
   const auto& builtins = process.Module().Unit().builtins;
-  const mir::ExprId services_id =
-      frame.current_block->exprs.Add(BuildServicesCallExpr(process, frame));
+  const mir::ExprId services_id = frame.current_block->exprs.Add(
+      BuildServicesCallExpr(process.Module(), frame));
   const mir::ExprId level_id = frame.current_block->exprs.Add(
       mir::MakeInt32Literal(builtins.int32, static_cast<std::int64_t>(level)));
   return mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/expression/system/diagnostic.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/diagnostic.cpp
@@ -37,7 +37,8 @@ auto LowerDiagnosticSystemSubroutineCall(
       BuildPrintItemsArray(unit, block, *items_or, time_unit_power));
 
   std::vector<mir::ExprId> args;
-  args.push_back(block.exprs.Add(BuildServicesCallExpr(process, frame)));
+  args.push_back(
+      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame)));
   args.push_back(items_array);
 
   return mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
@@ -39,7 +39,8 @@ auto BuildFileIoCall(
   auto& block = *frame.current_block;
   std::vector<mir::ExprId> args;
   args.reserve(operands.size() + 1);
-  args.push_back(block.exprs.Add(BuildServicesCallExpr(process, frame)));
+  args.push_back(
+      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame)));
   for (const mir::ExprId operand : operands) {
     args.push_back(operand);
   }
@@ -314,7 +315,7 @@ auto LowerFileIOSystemSubroutineCallStmt(
   }
 
   const mir::ExprId services_id =
-      wrapper.exprs.Add(BuildServicesCallExpr(process, wrapper_frame));
+      wrapper.exprs.Add(BuildServicesCallExpr(process.Module(), wrapper_frame));
   return BuildCopyOutBlock(
       process.Module().Unit(), services_id, frame, std::move(wrapper),
       std::move(label), result_type, std::move(call_expr), false,

--- a/src/lyra/lowering/hir_to_mir/expression/system/print.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/print.cpp
@@ -32,7 +32,7 @@ auto BuildFilesCall(
     ProcessLowerer& process, const WalkFrame& frame, mir::Block& block)
     -> mir::ExprId {
   const mir::ExprId services =
-      block.exprs.Add(BuildServicesCallExpr(process, frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
   return block.exprs.Add(
       mir::Expr{
           .data =
@@ -73,7 +73,7 @@ auto EmitFormatThenWrite(
     -> mir::ExprId {
   auto& unit = process.Module().Unit();
   const mir::ExprId services =
-      block.exprs.Add(BuildServicesCallExpr(process, frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
   const mir::ExprId text = block.exprs.Add(
       mir::Expr{
           .data =
@@ -179,7 +179,7 @@ auto LowerStrobeCall(
 
   const mir::ExprId closure_id = block.exprs.Add(closure.BuildVoid());
   const mir::ExprId services =
-      block.exprs.Add(BuildServicesCallExpr(process, frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
   return mir::Expr{
       .data =
           mir::CallExpr{

--- a/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
@@ -188,7 +188,7 @@ auto LowerScanSystemSubroutineCall(
     }
     fd_id = raw_source_id;
     const mir::ExprId services_id =
-        body.exprs.Add(BuildServicesCallExpr(process, closure_frame));
+        body.exprs.Add(BuildServicesCallExpr(process.Module(), closure_frame));
     const mir::ExprId files_id = body.exprs.Add(
         mir::Expr{
             .data =
@@ -267,7 +267,7 @@ auto LowerScanSystemSubroutineCall(
 
   if (is_file) {
     const mir::ExprId services_after =
-        body.exprs.Add(BuildServicesCallExpr(process, closure_frame));
+        body.exprs.Add(BuildServicesCallExpr(process.Module(), closure_frame));
     const mir::ExprId files_after = body.exprs.Add(
         mir::Expr{
             .data =
@@ -315,8 +315,8 @@ auto LowerScanSystemSubroutineCall(
     const mir::ExprId temp_read_id = then_body.exprs.Add(
         mir::MakeLocalRefExpr(
             mir::BlockHops{.value = 1}, temp_ids[k], target_types[k]));
-    const mir::ExprId services_id_then =
-        then_body.exprs.Add(BuildServicesCallExpr(process, then_frame));
+    const mir::ExprId services_id_then = then_body.exprs.Add(
+        BuildServicesCallExpr(process.Module(), then_frame));
     const mir::Expr assign_expr = BuildObservableAssignExpr(
         unit, then_body, services_id_then, lvalue_id, temp_read_id,
         std::nullopt, target_types[k], void_t);

--- a/src/lyra/lowering/hir_to_mir/expression/system/sformat.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/sformat.cpp
@@ -48,7 +48,7 @@ auto BuildSFormatCallExpr(
       BuildPrintItemsArray(unit, block, *items_or, time_unit_power));
 
   const mir::ExprId services_id =
-      block.exprs.Add(BuildServicesCallExpr(process, frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
 
   return mir::Expr{
       .data =
@@ -128,7 +128,7 @@ auto LowerSFormatSystemSubroutineCallStmt(
   const mir::ExprId call_id = block.exprs.Add(*std::move(call_expr_or));
 
   const mir::ExprId services_id =
-      block.exprs.Add(BuildServicesCallExpr(process, frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
   const mir::Expr assign_expr = BuildObservableAssignExpr(
       process.Module().Unit(), block, services_id, out_id, call_id,
       std::nullopt, out_type, process.Module().Unit().builtins.void_type);

--- a/src/lyra/lowering/hir_to_mir/expression/system/time.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/time.cpp
@@ -41,7 +41,7 @@ auto LowerTimeSystemSubroutineCall(
   const TimeFnInfo fn = SelectTimeFn(builtins, info.kind);
   auto& body = *frame.current_block;
   const mir::ExprId services_id =
-      body.exprs.Add(BuildServicesCallExpr(process, frame));
+      body.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
   const mir::ExprId unit_power_id = body.exprs.Add(
       mir::MakeInt32Literal(
           builtins.int32,

--- a/src/lyra/lowering/hir_to_mir/expression/system/timescale.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/timescale.cpp
@@ -32,7 +32,8 @@ auto LowerTimeFormatSystemSubroutineCall(
   }
 
   std::vector<mir::ExprId> call_args;
-  call_args.push_back(body.exprs.Add(BuildServicesCallExpr(process, frame)));
+  call_args.push_back(
+      body.exprs.Add(BuildServicesCallExpr(process.Module(), frame)));
   for (const auto& arg : args) {
     if (!arg.has_value()) {
       throw InternalError(
@@ -59,7 +60,7 @@ auto LowerPrintTimescaleSystemSubroutineCall(
   const auto resolution = process.Resolution();
 
   const mir::ExprId services_id =
-      body.exprs.Add(BuildServicesCallExpr(process, frame));
+      body.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
   const mir::ExprId scope_name_lit = body.exprs.Add(
       mir::Expr{
           .data =

--- a/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
+++ b/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
@@ -5,7 +5,7 @@
 
 #include "lyra/base/overloaded.hpp"
 #include "lyra/hir/inside_item.hpp"
-#include "lyra/hir/procedural_body.hpp"
+#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/expr.hpp"
@@ -13,14 +13,15 @@
 
 namespace lyra::lowering::hir_to_mir {
 
+template <ExprLowerer Lowerer>
 auto BuildHirInsideItemPredicate(
-    ProcessLowerer& proc, WalkFrame frame, mir::ExprId lhs_id,
+    Lowerer& lowerer, WalkFrame frame, mir::ExprId lhs_id,
     const hir::InsideItem& item, mir::TypeId result_type)
     -> diag::Result<mir::ExprId> {
-  const auto& hir_body = proc.HirBody();
+  const auto& hir_exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
   auto lower_id = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
-    auto lowered = proc.LowerExpr(hir_body.exprs.Get(id), frame);
+    auto lowered = lowerer.LowerExpr(hir_exprs.Get(id), frame);
     if (!lowered) {
       return std::unexpected(std::move(lowered.error()));
     }
@@ -74,5 +75,12 @@ auto BuildHirInsideItemPredicate(
       },
       item);
 }
+
+template auto BuildHirInsideItemPredicate(
+    ProcessLowerer&, WalkFrame, mir::ExprId, const hir::InsideItem&,
+    mir::TypeId) -> diag::Result<mir::ExprId>;
+template auto BuildHirInsideItemPredicate(
+    const ClassLowerer&, WalkFrame, mir::ExprId, const hir::InsideItem&,
+    mir::TypeId) -> diag::Result<mir::ExprId>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -66,11 +66,10 @@ auto DispatchLowerExpr(
             return LowerHirConversionExpr(process, frame, cv, result_type);
           },
           [&](const hir::CallExpr& c) -> diag::Result<mir::Expr> {
-            return LowerHirCallExprProc(
-                process, frame, c, expr.span, result_type);
+            return LowerHirCallExpr(process, frame, c, expr.span, result_type);
           },
           [&](const hir::InsideExpr& in) -> diag::Result<mir::Expr> {
-            return LowerHirInsideExprProc(process, frame, in, result_type);
+            return LowerHirInsideExpr(process, frame, in, result_type);
           },
           [&](const hir::ElementSelectExpr& sel) -> diag::Result<mir::Expr> {
             return LowerHirElementSelectExpr(process, frame, sel, result_type);
@@ -85,7 +84,7 @@ auto DispatchLowerExpr(
             return LowerHirConcatExpr(process, frame, c, result_type);
           },
           [&](const hir::ReplicationExpr& r) -> diag::Result<mir::Expr> {
-            return LowerHirReplicationExprProc(process, frame, r, result_type);
+            return LowerHirReplicationExpr(process, frame, r, result_type);
           },
           [&](const hir::AssignmentPatternExpr& a) -> diag::Result<mir::Expr> {
             return LowerHirAssignmentPatternExpr(

--- a/src/lyra/lowering/hir_to_mir/services_call.cpp
+++ b/src/lyra/lowering/hir_to_mir/services_call.cpp
@@ -1,15 +1,17 @@
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
 
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
+#include "lyra/mir/class.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/mir/stmt.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
-auto BuildServicesCallExpr(
-    const ProcessLowerer& process, const WalkFrame& frame) -> mir::Expr {
+auto BuildServicesCallExpr(const ModuleLowerer& module, const WalkFrame& frame)
+    -> mir::Expr {
   auto& body = *frame.current_block;
-  const auto& builtins = process.Module().Unit().builtins;
+  const auto& builtins = module.Unit().builtins;
   const mir::ExprId self_id = body.exprs.Add(
       MakeSelfRefExpr(frame, frame.current_class->self_pointer_type));
   return mir::MakeServicesCallExpr(self_id, builtins.services);

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -175,8 +175,8 @@ auto LowerDestructuringAssign(
 
     mir::ExprId per_part_expr_id{};
     if (assign.kind == hir::AssignKind::kBlocking) {
-      const mir::ExprId services_id =
-          wrapper.exprs.Add(BuildServicesCallExpr(process, wrapper_frame));
+      const mir::ExprId services_id = wrapper.exprs.Add(
+          BuildServicesCallExpr(process.Module(), wrapper_frame));
       const mir::Expr part_assign_expr = BuildObservableAssignExpr(
           process.Module().Unit(), wrapper, services_id, part_lhs_id,
           rhs_for_part, std::nullopt, part_mir_type,
@@ -187,8 +187,8 @@ auto LowerDestructuringAssign(
           process.Module(), wrapper_frame, part_lhs_id, rhs_for_part,
           part_mir_type);
       const mir::ExprId closure_id = wrapper.exprs.Add(std::move(closure_expr));
-      const mir::ExprId services_id =
-          wrapper.exprs.Add(BuildServicesCallExpr(process, wrapper_frame));
+      const mir::ExprId services_id = wrapper.exprs.Add(
+          BuildServicesCallExpr(process.Module(), wrapper_frame));
       per_part_expr_id = wrapper.exprs.Add(
           mir::Expr{
               .data =
@@ -285,8 +285,8 @@ auto LowerSubroutineCallWithWritebacks(
         const bool root_is_cell = mir::IsObservableCellType(
             process.Module().Unit().GetType(wrapper.exprs.Get(root_id).type));
         if (root_is_cell && root_id != actual_id) {
-          const mir::ExprId services_id =
-              wrapper.exprs.Add(BuildServicesCallExpr(process, wrapper_frame));
+          const mir::ExprId services_id = wrapper.exprs.Add(
+              BuildServicesCallExpr(process.Module(), wrapper_frame));
           actual_id = RewriteLhsRootWithMutate(
               process.Module().Unit(), wrapper, actual_id, services_id);
         }
@@ -345,7 +345,7 @@ auto LowerSubroutineCallWithWritebacks(
   }
 
   const mir::ExprId services_id =
-      wrapper.exprs.Add(BuildServicesCallExpr(process, wrapper_frame));
+      wrapper.exprs.Add(BuildServicesCallExpr(process.Module(), wrapper_frame));
   return BuildCopyOutBlock(
       process.Module().Unit(), services_id, frame, std::move(wrapper),
       std::move(label), result_type, std::move(call_expr),

--- a/src/lyra/lowering/hir_to_mir/statement/timing.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/timing.cpp
@@ -200,8 +200,8 @@ auto LowerDelayTimedStmt(
         auto ticks_or = ResolveDelayTicks(process, d);
         if (!ticks_or) return std::unexpected(std::move(ticks_or.error()));
         const auto& builtins = process.Module().Unit().builtins;
-        const mir::ExprId services_id =
-            child_block.exprs.Add(BuildServicesCallExpr(process, child_frame));
+        const mir::ExprId services_id = child_block.exprs.Add(
+            BuildServicesCallExpr(process.Module(), child_frame));
         const mir::ExprId duration_id = child_block.exprs.Add(
             mir::MakeInt32Literal(
                 builtins.int32, static_cast<std::int64_t>(*ticks_or)));
@@ -258,7 +258,7 @@ auto LowerEventTriggerStmt(
   // engine handle is a real trailing argument, threaded the same way every
   // runtime effect threads it.
   const mir::ExprId services_id =
-      block.exprs.Add(BuildServicesCallExpr(process, frame));
+      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
   mir::Expr call{
       .data =
           mir::CallExpr{

--- a/tests/cases/cpp/continuous_assign_calls/case.yaml
+++ b/tests/cases/cpp/continuous_assign_calls/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.continuous_assign_calls
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    fn_result: 10
+    rep: 1365
+    in_set: 1

--- a/tests/cases/cpp/continuous_assign_calls/main.sv
+++ b/tests/cases/cpp/continuous_assign_calls/main.sv
@@ -1,0 +1,22 @@
+module Top;
+  function automatic int dbl(int x);
+    return x * 2;
+  endfunction
+
+  logic [3:0] a;
+  int fn_result;
+  logic [11:0] rep;
+  bit in_set;
+
+  // Simulation-time value expressions in continuous-assignment position: a user
+  // function call (LRM 13.4), a replication (LRM 11.4.12.1), and the inside
+  // operator (LRM 11.4.13). All lower through the same context-free handlers as
+  // their procedural counterparts.
+  assign fn_result = dbl(a);
+  assign rep = {3{a}};
+  assign in_set = (a inside {4'd1, 4'd5, 4'd9});
+
+  initial begin
+    a = 4'd5;
+  end
+endmodule

--- a/tests/cases/cpp/isunknown/case.yaml
+++ b/tests/cases/cpp/isunknown/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.isunknown
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    r_known: 0
+    r_x: 1
+    r_z: 1
+    ca_known: 0
+    ca_xz: 1

--- a/tests/cases/cpp/isunknown/main.sv
+++ b/tests/cases/cpp/isunknown/main.sv
@@ -1,0 +1,28 @@
+module Top;
+  logic [3:0] a;
+  bit r_known;
+  bit r_x;
+  bit r_z;
+
+  logic [3:0] bus_known;
+  logic [3:0] bus_xz;
+  bit ca_known;
+  bit ca_xz;
+
+  // LRM 20.9 $isunknown in a continuous assignment (simulation-time value
+  // expression driving a net).
+  assign ca_known = $isunknown(bus_known);
+  assign ca_xz = $isunknown(bus_xz);
+
+  // LRM 20.9 $isunknown in procedural code over known, x, and z operands.
+  initial begin
+    a = 4'b0101;
+    r_known = $isunknown(a);
+    a = 4'b01x1;
+    r_x = $isunknown(a);
+    a = 4'b01z1;
+    r_z = $isunknown(a);
+    bus_known = 4'b1010;
+    bus_xz = 4'b1z10;
+  end
+endmodule

--- a/tests/cases/cpp/nested_array_method_with/case.yaml
+++ b/tests/cases/cpp/nested_array_method_with/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.nested_array_method_with
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    inner_uses_outer_element: 69
+    inner_uses_outer_index: 62
+    shadow_default: 63

--- a/tests/cases/cpp/nested_array_method_with/main.sv
+++ b/tests/cases/cpp/nested_array_method_with/main.sv
@@ -1,0 +1,26 @@
+module Top;
+  int outer[2];
+  int inner[2];
+
+  int inner_uses_outer_element;
+  int inner_uses_outer_index;
+  int shadow_default;
+
+  initial begin
+    outer = '{1, 2};
+    inner = '{10, 20};
+
+    // LRM 7.12.4: the inner clause reads the outer element `x`, captured into
+    // the inner closure. x=1: 1+(11+21)=33; x=2: 2+(12+22)=36; total 69.
+    inner_uses_outer_element = outer.sum(x) with (x + inner.sum(y) with (y + x));
+
+    // The inner clause reads the outer index `x.index`.
+    // x.index=0: 10+20=30; x.index=1: 11+21=32; total 62.
+    inner_uses_outer_index =
+        outer.sum(x) with (inner.sum(y) with (y + x.index));
+
+    // Default `item` in both clauses: the inner `item` shadows the outer one.
+    // x=1: 1+(10+20)=31; x=2: 2+30=32; total 63.
+    shadow_default = outer.sum() with (item + inner.sum() with (item));
+  end
+endmodule


### PR DESCRIPTION
## Summary

This makes the call, `inside`, and replication expression families lower context-free across both pass classes, so they work in a continuous assignment (a simulation-time expression a structural scope owns), not only in procedural code. The enabling change is that an LRM 7.12 array-method `with` clause's element and index become co-equal closure parameters referenced by clause identity rather than a procedural-body local; this removes the sole coupling that kept call lowering procedural-only and, as a side effect, fixes nested `with` clauses that read an outer iterator. `$isunknown` falls out as an ordinary value-layer builtin call usable in both positions.

## Design

At AST-to-HIR a `with`-clause iterator is a clause-scoped identity (a `WithClauseId` plus an element/index role), not a closure parameter -- HIR stays SV-faithful and synthesizes no closure. At HIR-to-MIR the clause becomes a closure whose element and index are real parameters; a reference resolves by clause identity through a registry and reuses the existing capture machinery, so a reference from a clause nested in another's body is captured exactly like any other crossing of a closure boundary. Capturing across two or more closure boundaries at once (three-deep nesting reading the outermost iterator) is an existing limitation of that shared capture machinery, not specific to `with` clauses.

## Testing

`bazel test //...` is green. New cases cover `$isunknown` in procedural and continuous-assign positions, context-free calls / replication / `inside` in continuous assignments, and nested `with` clauses (inner reads outer element, inner reads outer index, and default-`item` shadowing).