### PR TITLE
Re-run clang-format after rebase in pr/commit-pr

### DIFF
--- a/.claude/commands/commit-pr.md
+++ b/.claude/commands/commit-pr.md
@@ -86,7 +86,10 @@ Each tool runs **once**. Formatters run in write mode; rerunning them in check m
 
 ### Phase 2: PR
 
-9. **Rebase if behind main:** If commits behind > 0, run `git rebase origin/main`
+9. **Rebase if behind main:** If commits behind > 0:
+   - `git rebase origin/main`
+   - Re-run clang-format (a rebase can drift C++ formatting against upstream):
+     - `find src include tests -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i`
 10. **Push:** `git push -u origin <branch>`
 11. **Create PR:** `gh pr create --title "..." --body "..."`
 12. **Enable auto-merge:** `gh pr merge --auto --squash`

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -65,7 +65,10 @@ Simple fixes may need only Summary. Don't force sections that have nothing meani
 ## Instructions
 
 1. Check context above; ensure working tree is clean
-2. If commits behind main > 0, rebase first: `git rebase origin/main`
+2. If commits behind main > 0:
+   - `git rebase origin/main`
+   - Re-run clang-format (a rebase can drift C++ formatting against upstream):
+     - `find src include tests -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i`
 3. **Read the full diff** (`git diff origin/main..HEAD`) before writing the PR description. The `--stat` above is not sufficient - you must see the actual code changes.
 4. Push if needed: `git push -u origin <branch>`
 5. Create PR: `gh pr create --title "..." --body "..."`


### PR DESCRIPTION
## Summary

After a rebase, upstream code may have landed under a different clang-format version (CI uses clang-format-20), so commits that were locally clean against an older base can fail CI's `--Werror` style check. The `pr` and `commit-pr` skills now re-run clang-format right after a rebase, before push, so the drift is caught locally.