### PR TITLE
Parameterize the coroutine result type and type await

### DIFF
--- a/docs/decisions/unified-callable-model.md
+++ b/docs/decisions/unified-callable-model.md
@@ -131,9 +131,64 @@ This makes copy-out timing correct by construction (the writes happen after comp
 copy-out ownership at the call site (the caller owns the actual place -- home 3, not the body),
 needs no per-exit-path copy-out epilogue (the output pack rides the existing return mechanism), and
 is the concrete reason `Coroutine<T>` must be parameterized rather than a marker. Only `ref` is a
-true alias and therefore the only direction that becomes a reference-typed parameter. (Lowering
-details -- a function with outputs in expression position, and `output` under an abnormal `disable`
-termination -- are HIR-to-MIR concerns, not part of this contract.)
+true alias and therefore the only direction that becomes a reference-typed parameter.
+
+### The completion payload is one value, normalized by arity
+
+A function's explicit return and its `output` / `inout` formals are not two parallel result
+channels: they are the components of a single **completion payload**, the one value a completion
+yields. The components, in order, are the explicit function return (if the callable returns a
+non-void value) followed by each `output` / `inout` value in formal-declaration order. The payload
+type is then normalized by component count:
+
+| Component count | Completion payload type     |
+| --------------: | --------------------------- |
+|               0 | `Void`                      |
+|               1 | that component's type       |
+|             >=2 | a `Tuple` of the components |
+
+So `function int g(input int a)` keeps a bare `int` result;
+`function int f(input int a, output int b)` has result `Tuple<int, int>` (`[return, b]`);
+`task t(output int b)` has result `Coroutine<int>`; `task t(output int b, inout int c)` has result
+`Coroutine<Tuple<int, int>>`; and `task t(input int a)` has result `Coroutine<Void>`. A
+bare-when-single result keeps the common no-output path off a tuple, and a single coroutine
+completion value (never a return plus a separate output channel) matches `Coroutine<T>` carrying
+exactly one `T`.
+
+The pack is positional. A `Tuple` carries component types only; the meaning of each position is the
+callable's declaration order, which any consumer holding the callee declaration reads directly -- no
+component-name record is stored. Only a consumer that holds a bare result `TypeId` without knowing
+the callee needs the projection spelled explicitly (a tuple-get by index), never inferred by name.
+
+### The await is typed: `Await : Coroutine<T> -> T`
+
+The completion payload reaches the call site through a **typed await**: awaiting a `Coroutine<T>`
+yields a value of `T`, and the output writebacks are projections of that value. A pure suspension
+(an event control, a delay, a `$finish`, a task with no outputs) awaits a `Coroutine<Void>` and
+yields nothing; it is the zero-component case of the same one await, not a separate statement form.
+A task call with outputs awaits a `Coroutine<Tuple<...>>` and the writebacks read its components.
+
+The typed await is what makes the runtime realization a backend choice that does not touch MIR.
+Whether the payload travels through a caller-provided result slot or a value held in the coroutine
+object is home 4; under both, the MIR meaning is identical (`await` of a `Coroutine<T>` is a `T`). A
+backend's hidden result slot is therefore **not** a MIR parameter: putting it into the callable's
+signature would merely rename `output` / `inout` to a synthetic `Ref<pack>` parameter and reinstate
+the abstraction this decision removes. The MIR signature carries `self`, the `input` values, and the
+`ref` aliases; nothing else.
+
+### Two lowering invariants the output pack must hold
+
+These are contracts, not optional lowering details:
+
+- **An output / inout actual place is bound exactly once, at call entry.** `t(arr[i++], obj.f)`
+  evaluates each destination lvalue once before the call; the post-completion writeback writes the
+  already-bound place. Re-evaluating the actual at completion would, after a suspension, write a
+  different place than the one the call named.
+- **The result slot outlives any write the callee can still make to it.** While a callee may still
+  write its completion payload, the storage that receives it is live. For a direct task call the
+  awaiting frame owns that storage and is suspended (alive) until completion, so the contract holds;
+  abnormal termination (`disable`, `disable fork`) and forked task calls are where this needs
+  explicit care, tracked with the object-model and scheduling work, not assumed.
 
 ### Internal versus external callables: DPI is a structural form
 

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -101,18 +101,29 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       flow. It rebases callable machinery across lowering, MIR, the dumper, and the backend (where
       the per-shape `Render*` paths collapse into one generic function renderer), so it lands in
       staged cuts, each its own focused review:
-  - [ ] R8a -- The result type is the sole carrier of the call protocol. A method's coroutine-ness
+  - [x] R8a -- The result type is the sole carrier of the call protocol. A method's coroutine-ness
         is read from its result type (a coroutine result is a task, a value / void result a
         function), not a side enum; `MethodKind` is removed. Behavior-neutral; existing task /
         function tests prove no regression.
 
   - [ ] R8b -- Parameter direction normalizes to data flow. `output` / `inout` formals stop being
-        reference parameters and become components of the callable's result -- an output pack riding
-        the result type, written to the caller's actual after completion -- so copy-out timing is
-        correct under suspension; `ref` / `const ref` stay reference-typed parameters. The `kOutput`
-        / `kInOut` directions are removed (a parameter becomes a typed binding). This is what forces
-        the coroutine result type to be parameterized (`Coroutine<T>`): a task's output pack is its
-        completion payload.
+        reference parameters and become components of the callable's completion payload -- the
+        explicit return (if any) followed by each `output` / `inout` value, normalized by count
+        (zero is `Void`, one is a bare type, two or more a tuple), riding the result type and
+        written to the caller's actual after completion -- so copy-out timing is correct under
+        suspension; `ref` / `const ref` stay reference-typed parameters. The direction enum is
+        removed (a parameter becomes a typed binding). This forces the coroutine result type to be
+        parameterized (`Coroutine<T>`): a task's completion payload is its `T`. Two merge gates make
+        the realization decoupled rather than a relabeled special case: (1) await is a typed,
+        value-yielding form -- awaiting a `Coroutine<T>` yields `T`, and an output writeback is a
+        projection of that value, so a pure suspension is the `Coroutine<Void>` case of the same one
+        await, never a void-only statement with a hidden writeback convention; (2) the C++ backend
+        realizes the payload through a hidden, caller-owned completion slot that is not part of the
+        MIR signature (the monomorphic coroutine handle the scheduler relies on is untouched -- a
+        payload-templated promise is deferred as a backend-only option). The two output-pack
+        invariants from `../decisions/unified-callable-model.md` hold: an output / inout actual
+        place is bound exactly once at call entry, and the completion slot outlives any write the
+        callee can still make. Per `../decisions/unified-callable-model.md`.
 
   - [ ] R8c -- Callable code versus callable value. A closure constructs a callable value (code plus
         a bound environment); a directly-invoked named callable receives its environment from the
@@ -454,11 +465,11 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
     - [x] `$info` / `$warning` / `$error`: each decomposes to `services.Format(items)` for the
           message text, then `services.Diagnostic().Emit{Info,Warning,Error}(origin, text)` for the
           severity-tagged emit, with `origin` carrying the call's `file:line:col` so the dispatcher
-          can prefix the message and key its rate-limit counter per site (LRM 20.10). The
-          severities are distinct `BuiltinFn` methods (parallel to print's `Write` / `Writeln`
-          split), not a single `Emit(severity, text)` with a tag arg. The unique / priority
-          deferred-check cascade synthesizes its warning through the same broker. `$fatal` picks
-          up the shape when it lands.
+          can prefix the message and key its rate-limit counter per site (LRM 20.10). The severities
+          are distinct `BuiltinFn` methods (parallel to print's `Write` / `Writeln` split), not a
+          single `Emit(severity, text)` with a tag arg. The unique / priority deferred-check cascade
+          synthesizes its warning through the same broker. `$fatal` picks up the shape when it
+          lands.
   - File-IO subsystem (`services.Files()`):
     - [x] `$fopen` / `$fclose` / `$fread` / `$fseek` / `$rewind` / `$ftell` / `$feof` / `$ferror` /
           `$fflush` / `$fgetc` / `$ungetc` / `$fgets`: each lowers to a `BuiltinFnCallee` method on

--- a/include/lyra/lowering/hir_to_mir/copy_out_desugar.hpp
+++ b/include/lyra/lowering/hir_to_mir/copy_out_desugar.hpp
@@ -55,8 +55,8 @@ auto BuildOutputArgSlot(
 // statement. The completed `wrapper` is installed as a child of
 // `*parent_frame.current_block`, and the returned Stmt's BlockStmt
 // references it by id. When `call_suspends` (a bare task call -- LRM 13.4), the
-// call statement is emitted as a suspension (`AwaitStmt`); an `lhs = f(...)`
-// shape is a function and never suspends.
+// call is wrapped in an awaited expression whose void completion the statement
+// discards; an `lhs = f(...)` shape is a function and never suspends.
 auto BuildCopyOutBlock(
     const mir::CompilationUnit& unit, mir::ExprId services_id,
     WalkFrame parent_frame, mir::Block wrapper,

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -90,8 +90,14 @@ struct CompilationUnit {
             .format_spec = AddType(
                 TypeData{RuntimeLibraryType{
                     .kind = RuntimeLibraryKind::kFormatSpec}}),
-            .coroutine = AddType(TypeData{CoroutineType{}}),
+            .coroutine = TypeId{},
         } {
+    // A bare coroutine yields nothing, so its completion payload is `Void`. It
+    // is interned in the body rather than the member list because it reads back
+    // the already-interned `void_type`; the member-list value above is an
+    // unused placeholder overwritten here.
+    builtins.coroutine =
+        AddType(TypeData{CoroutineType{.payload = builtins.void_type}});
   }
 
   [[nodiscard]] auto GetType(TypeId id) const -> const Type& {

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -204,12 +204,33 @@ struct TupleExpr {
   std::vector<ExprId> components;
 };
 
+// The suspension protocol applied to an awaitable: entering it yields control
+// until the awaitable completes, then resumes with its completion value
+// (LRM 9.4 timing controls, 13.5 task enable). `Expr::type` is that value's
+// type -- the awaited coroutine's payload, which is a task's output pack or
+// `Void` for a pure suspension (a delay, an event control, a `$finish`, a task
+// with no outputs). Await is an expression, not a statement, because it is a
+// value-producing operation that resumes (a suspending call), not a terminator
+// like `return`: a value-yielding task completion and a void suspension are the
+// same node, distinguished only by the payload type. The C++ backend realizes
+// it as `co_await`.
+//
+// Invariant: an await appears only at statement top level -- as the expression
+// of an `ExprStmt`, or as the right-hand side of the local-decl / assignment
+// that binds its completion value -- never nested inside another expression,
+// because SV suspends only at statement position (LRM 13.4). The node is a
+// general expression for uniformity with the rest of the set; HIR-to-MIR never
+// produces a nested one.
+struct AwaitExpr {
+  ExprId awaitable;
+};
+
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, NullLiteral,
     ParamRef, LocalRef, UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr,
     IncDecExpr, CallExpr, DerefExpr, AddressOfExpr, PointerCastExpr,
     MemberAccessExpr, ConversionExpr, ClosureExpr, ConcatExpr, ReplicationExpr,
-    ArrayLiteralExpr, TupleExpr>;
+    ArrayLiteralExpr, TupleExpr, AwaitExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -158,18 +158,6 @@ struct ReturnStmt {
   bool is_coroutine_return = false;
 };
 
-// `await <awaitable>;` -- a suspension point: the enclosing process yields
-// control until the awaited operand is ready, then resumes where it left off.
-// In SV the only constructs that suspend are void and statement-positioned --
-// LRM 13.4 makes a function, the sole value-yielding call form, unable to
-// suspend -- so await is a statement, the sibling of `return`, never an
-// expression. `awaitable` is the suspension-producing expression (a `$finish`,
-// task, or named-event-await call). The semantic concept is one across
-// consumers (LIR, LLVM); the C++ backend realizes it as `co_await`.
-struct AwaitStmt {
-  ExprId awaitable;
-};
-
 // One leaf entry of a wait's projection set: an expression yielding a
 // borrowed pointer to the observable cell the leaf subscribes to, plus the
 // observed bit projection of its packed encoding as a `(lsb_bit_offset,
@@ -200,8 +188,7 @@ struct SensitivityWaitStmt {
 using StmtData = std::variant<
     EmptyStmt, LocalDeclStmt, ExprStmt, BlockStmt, ForkStmt, IfStmt,
     ConstructOwnedObjectStmt, ConstructExternalUnitStmt, ForStmt, WhileStmt,
-    DoWhileStmt, BreakStmt, ContinueStmt, ReturnStmt, AwaitStmt,
-    SensitivityWaitStmt>;
+    DoWhileStmt, BreakStmt, ContinueStmt, ReturnStmt, SensitivityWaitStmt>;
 
 struct Stmt {
   std::optional<std::string> label;

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -200,12 +200,17 @@ struct RuntimeLibraryType {
   auto operator==(const RuntimeLibraryType&) const -> bool = default;
 };
 
-// The runtime coroutine handle `lyra::runtime::Coroutine`: the value a
-// suspending callable yields when invoked. A fork branch (LRM 9.3.2) is a
-// closure whose result type is this -- invoking it produces a spawned-process
-// coroutine the parent collects and joins. Opaque, like ScopeType /
-// ServicesType; it names a runtime type, never a layout.
+// The call protocol of a coroutine callable: invoking it yields a coroutine the
+// site must await or spawn, and awaiting it produces a value of `payload` --
+// the completion payload (a task's output pack, or `Void` when the completion
+// yields nothing). A fork branch (LRM 9.3.2) is a closure whose result type is
+// this. `payload` is a MIR-level type; the C++ backend realizes every coroutine
+// as one monomorphic `lyra::runtime::Coroutine` and transports the payload
+// through a caller-owned completion slot, so the scheduler holds a single
+// coroutine-handle type regardless of `payload`.
 struct CoroutineType {
+  TypeId payload;
+
   auto operator==(const CoroutineType&) const -> bool = default;
 };
 

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -164,10 +164,10 @@ struct SystemSubroutineDesc {
   SystemSubroutineSemantic semantic;
   // Invoking this subroutine suspends the calling process ($finish suspends
   // and never resumes; the engine drops the process on the next dispatch,
-  // LRM 20.2). Stated as a fact so HIR-to-MIR lowers a suspending call to a
-  // suspension point (`mir::AwaitStmt`) rather than inferring it from the
-  // subroutine's semantic kind; each backend then realizes the await in its
-  // target (C++ `co_await`, LLVM's own mechanism).
+  // LRM 20.2). Stated as a fact so HIR-to-MIR lowers a suspending call through
+  // an awaited expression rather than inferring it from the subroutine's
+  // semantic kind; each backend then realizes the await in its target (C++
+  // `co_await`, LLVM's own mechanism).
   bool suspends = false;
 };
 

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1656,6 +1656,13 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr)
           [&](const mir::TupleExpr& t) -> diag::Result<std::string> {
             return RenderTupleExpr(view, expr, t);
           },
+          [&](const mir::AwaitExpr& a) -> diag::Result<std::string> {
+            auto awaitable_or = RenderExpr(view, view.Expr(a.awaitable));
+            if (!awaitable_or) {
+              return std::unexpected(std::move(awaitable_or.error()));
+            }
+            return "co_await " + *awaitable_or;
+          },
       },
       expr.data);
 }

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -83,18 +83,6 @@ auto RenderExprStmt(
   return Indent(indent) + *rendered_or + ";\n";
 }
 
-// The C++ realization of a suspension point (mir/stmt.hpp): `co_await` the
-// awaitable operand. One uniform site for every suspending construct ($finish,
-// task call, named-event await).
-auto RenderAwaitStmt(
-    const ScopeView& view, const mir::AwaitStmt& s, std::size_t indent)
-    -> diag::Result<std::string> {
-  const auto& expr = view.Block().exprs.Get(s.awaitable);
-  auto rendered_or = RenderExpr(view, expr);
-  if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
-  return Indent(indent) + "co_await " + *rendered_or + ";\n";
-}
-
 auto RenderBlockStmtNode(
     const ScopeView& view, const mir::BlockStmt& s, std::size_t indent)
     -> diag::Result<std::string> {
@@ -429,9 +417,6 @@ auto RenderStmt(
             auto value_or = RenderExpr(view, view.Expr(*s.value));
             if (!value_or) return std::unexpected(std::move(value_or.error()));
             return Indent(indent) + "return " + *value_or + ";\n";
-          },
-          [&](const mir::AwaitStmt& s) -> diag::Result<std::string> {
-            return RenderAwaitStmt(view, s, indent);
           },
           [&](const mir::SensitivityWaitStmt& s) -> diag::Result<std::string> {
             return RenderSensitivityWaitStmt(view, s, indent);

--- a/src/lyra/lowering/hir_to_mir/copy_out_desugar.cpp
+++ b/src/lyra/lowering/hir_to_mir/copy_out_desugar.cpp
@@ -69,7 +69,10 @@ auto BuildCopyOutBlock(
     const mir::ExprId assign_id = wrapper.exprs.Add(assign_expr);
     wrapper.AppendStmt(mir::ExprStmt{.expr = assign_id});
   } else if (call_suspends) {
-    wrapper.AppendStmt(mir::AwaitStmt{.awaitable = call_id});
+    const mir::ExprId await_id = wrapper.exprs.Add(
+        mir::Expr{
+            .data = mir::AwaitExpr{.awaitable = call_id}, .type = void_type});
+    wrapper.AppendStmt(mir::ExprStmt{.expr = await_id});
   } else {
     wrapper.AppendStmt(mir::ExprStmt{.expr = call_id});
   }

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -378,9 +378,10 @@ auto LowerExprStmt(
 
   // A call statement. Resolving the callee here -- once -- decides both the
   // output-arg desugar shape (LRM 13.5) and whether the call is a suspension
-  // point. A suspending callee ($finish, a task) lowers to `AwaitStmt`; LRM
-  // 13.4 keeps every suspending call void and statement-positioned, so a bare
-  // call is the only place suspension arises.
+  // point. A suspending callee ($finish, a task) lowers to an awaited
+  // expression whose completion yields nothing here (a bare call with no
+  // outputs), so the await result is void and the enclosing statement discards
+  // it.
   if (const auto* call = std::get_if<hir::CallExpr>(&inner.data)) {
     if (const auto* decl = SubroutineWithWritebacks(process.Owner(), *call)) {
       return LowerSubroutineCallWithWritebacks(
@@ -417,9 +418,12 @@ auto LowerExprStmt(
     if (!call_or) return std::unexpected(std::move(call_or.error()));
     const mir::ExprId call_id = block.exprs.Add(*std::move(call_or));
     if (suspends) {
+      const mir::ExprId await_id = block.exprs.Add(
+          mir::Expr{
+              .data = mir::AwaitExpr{.awaitable = call_id},
+              .type = process.Module().Unit().builtins.void_type});
       return mir::Stmt{
-          .label = std::move(label),
-          .data = mir::AwaitStmt{.awaitable = call_id}};
+          .label = std::move(label), .data = mir::ExprStmt{.expr = await_id}};
     }
     return mir::Stmt{
         .label = std::move(label), .data = mir::ExprStmt{.expr = call_id}};

--- a/src/lyra/lowering/hir_to_mir/statement/timing.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/timing.cpp
@@ -128,9 +128,13 @@ auto LowerNamedEventTimedStmt(
             .type = process.Module().Unit().builtins.void_type};
         const mir::ExprId await_id =
             child_block.exprs.Add(std::move(await_call));
+        const mir::ExprId await_expr_id = child_block.exprs.Add(
+            mir::Expr{
+                .data = mir::AwaitExpr{.awaitable = await_id},
+                .type = process.Module().Unit().builtins.void_type});
         return mir::Stmt{
             .label = std::nullopt,
-            .data = mir::AwaitStmt{.awaitable = await_id}};
+            .data = mir::ExprStmt{.expr = await_expr_id}};
       });
 }
 
@@ -217,9 +221,13 @@ auto LowerDelayTimedStmt(
                             mir::FreeFnCallee{.id = support::BuiltinFn::kDelay},
                         .arguments = {services_id, duration_id, precision_id}},
                 .type = builtins.void_type});
+        const mir::ExprId await_expr_id = child_block.exprs.Add(
+            mir::Expr{
+                .data = mir::AwaitExpr{.awaitable = call_id},
+                .type = builtins.void_type});
         return mir::Stmt{
             .label = std::nullopt,
-            .data = mir::AwaitStmt{.awaitable = call_id}};
+            .data = mir::ExprStmt{.expr = await_expr_id}};
       });
 }
 

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -197,7 +197,10 @@ class MirDumper {
               }
               throw InternalError("dump: unknown RuntimeLibraryKind");
             },
-            [](const CoroutineType&) -> std::string { return "Coroutine"; },
+            [](const CoroutineType& c) -> std::string {
+              return std::format(
+                  "Coroutine(payload=Type[{}])", c.payload.value);
+            },
             [](const RefType& r) -> std::string {
               return std::format(
                   "Ref({}pointee=Type[{}])", r.is_const ? "const, " : "",
@@ -615,6 +618,10 @@ class MirDumper {
               }
               return std::format("TupleExpr components=[{}]", components);
             },
+            [](const AwaitExpr& a) -> std::string {
+              return std::format(
+                  "AwaitExpr awaitable=Expr[{}]", a.awaitable.value);
+            },
         },
         e.data);
     return std::format("{} type=Type[{}]", formatted, e.type.value);
@@ -881,18 +888,6 @@ class MirDumper {
               } else {
                 Line(std::format("Stmt[{}] ReturnStmt{}", id.value, flavor));
               }
-            },
-            [&](const AwaitStmt& s) {
-              Line(
-                  std::format(
-                      "Stmt[{}] AwaitStmt awaitable=Expr[{}]", id.value,
-                      s.awaitable.value));
-              Indent();
-              Line(
-                  std::format(
-                      "Expr[{}] {}", s.awaitable.value,
-                      FormatExpr(enclosing, s.awaitable)));
-              Dedent();
             },
             [&](const SensitivityWaitStmt& s) {
               Line(std::format("Stmt[{}] SensitivityWaitStmt", id.value));


### PR DESCRIPTION
## Summary

This is the first cut of R8b (parameter direction as data flow) from the unified callable model: a behavior-neutral foundation that establishes the two structures the output-pack work needs, without yet changing any parameter-passing semantics. The coroutine result type gains a completion-payload type -- `CoroutineType` now carries the value a completion yields, which is `Void` everywhere today since no outputs ride a result yet -- so a task's result is `Coroutine<Void>` rather than a content-free marker. Await becomes a typed expression: awaiting a coroutine yields its payload, so a value-yielding task completion and a void suspension (a delay, an event control, a `$finish`, a task with no outputs) are the same node distinguished only by the payload type. The former `AwaitStmt` is removed; a pure suspension is now an `ExprStmt` wrapping the await, which renders identically. The emitted C++ is unchanged: every coroutine still realizes as one monomorphic `lyra::runtime::Coroutine` and every await as `co_await`.

## Design

Await is classified as an expression, not a statement, because it is a value-producing operation that resumes (a suspending call), not a terminator like `return`. An invariant keeps it faithful to SystemVerilog, where suspension is only ever statement-positioned (LRM 13.4): the lowering places an await only at statement top level -- an `ExprStmt`, or the right-hand side of the local-decl or assignment that binds its completion value -- never nested inside another expression. This makes the later output-pack writeback a projection of the typed await result rather than a task-special-case void await with a hidden writeback convention, which is the merge gate that keeps the runtime realization (a caller-owned completion slot versus a payload held in the coroutine object) a backend choice that does not touch MIR.

The decision doc records the frozen R8b contract this foundation builds toward: the completion payload is one value normalized by arity (zero is `Void`, one a bare type, two or more a tuple), the await is typed, the backend's completion slot is not a MIR parameter, and the two output-pack invariants (an output / inout actual place is bound once at call entry, and the completion slot outlives any write the callee can still make).

## Testing

The cut is behavior-neutral: the payload is `Void` and the await yields void everywhere, so the emitted C++ matches the prior output. `bazel build //...` passes; the existing task, timing, and `$finish` tests exercise the new await lowering.