### PR TITLE
Lower diagnostic tasks as Diagnostic-broker methods

### DIFF
--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -451,10 +451,14 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
           print already uses) returning a string; for `$sformat` the call result is assigned to the
           output lvalue. The dedicated `LyraSFormat` runtime entry retires.
   - Diagnostic subsystem (`services.Diagnostic()`):
-    - [ ] `$info` / `$warning` / `$error` / `$fatal`: decompose to `services.Format(items)` for the
-          message text, then `services.Diagnostic().Emit{Info,Warning,Error,Fatal}(text)` for the
-          severity-tagged emit. The four severities are distinct methods (parallel to print's
-          `Write` / `Writeln` split), not a single `Emit(severity, text)` with a tag arg.
+    - [x] `$info` / `$warning` / `$error`: each decomposes to `services.Format(items)` for the
+          message text, then `services.Diagnostic().Emit{Info,Warning,Error}(origin, text)` for the
+          severity-tagged emit, with `origin` carrying the call's `file:line:col` so the dispatcher
+          can prefix the message and key its rate-limit counter per site (LRM 20.10). The
+          severities are distinct `BuiltinFn` methods (parallel to print's `Write` / `Writeln`
+          split), not a single `Emit(severity, text)` with a tag arg. The unique / priority
+          deferred-check cascade synthesizes its warning through the same broker. `$fatal` picks
+          up the shape when it lands.
   - File-IO subsystem (`services.Files()`):
     - [x] `$fopen` / `$fclose` / `$fread` / `$fseek` / `$rewind` / `$ftell` / `$feof` / `$ferror` /
           `$fflush` / `$fgetc` / `$ungetc` / `$fgets`: each lowers to a `BuiltinFnCallee` method on

--- a/include/lyra/lowering/hir_to_mir/deferred_check_cascade.hpp
+++ b/include/lyra/lowering/hir_to_mir/deferred_check_cascade.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_span.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
@@ -23,14 +24,17 @@ struct DeferredCheckBranch {
 // expressions later. Caller stages wrapper with any prelude it needs
 // (case puts its selector snapshot there; unique-if passes a fresh wrapper)
 // and pre-lowers each body with the depth guards the cascade nesting requires.
+// `span` is the source location of the qualified statement (`unique if` /
+// `priority case`); the cascade tags its synthesized warning emit with that
+// location so the diagnostic dispatcher attributes and rate-limits per site.
 auto BuildDeferredCheckCascade(
     ModuleLowerer& module, WalkFrame frame, mir::Block wrapper,
     std::vector<DeferredCheckBranch> branches,
     std::optional<mir::Block> tail_else, hir::UniquePriorityCheck check,
-    std::optional<std::string> outer_label) -> mir::Stmt;
+    std::optional<std::string> outer_label, diag::SourceSpan span) -> mir::Stmt;
 
 auto LowerUniqueIfStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
-    const hir::IfStmt& root) -> diag::Result<mir::Stmt>;
+    const hir::IfStmt& root, diag::SourceSpan span) -> diag::Result<mir::Stmt>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/expression/system/diagnostic.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/system/diagnostic.hpp
@@ -10,14 +10,14 @@
 
 namespace lyra::lowering::hir_to_mir {
 
-// Lower a severity-bearing system subroutine call ($info, $warning, $error)
-// into a generic `CallExpr` whose first argument is `self.Services()` and whose
-// second is the print-item array. Severity travels on `id`; the backend selects
-// the matching diagnostic runtime entry. Shares format-item parsing with the
-// print-task lowering, but routes through the runtime diagnostic channel.
+// Lower $info / $warning / $error into the two-step composition the print
+// family uses: `services.Format(items)` yields the formatted text, then
+// `services.Diagnostic().EmitX(text)` emits at the severity selected by
+// `info.builtin_fn` (LRM 20.10). Shares format-item parsing with the print
+// path; the returned expression is the void Emit call.
 auto LowerDiagnosticSystemSubroutineCall(
     ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& call,
-    support::SystemSubroutineId id, diag::SourceSpan span)
+    const support::DiagnosticSystemSubroutineInfo& info, diag::SourceSpan span)
     -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/module_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/module_lowerer.hpp
@@ -4,6 +4,7 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_manager.hpp"
 #include "lyra/hir/module_unit.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/mir/compilation_unit.hpp"
@@ -23,7 +24,9 @@ namespace lyra::lowering::hir_to_mir {
 // the const overload, which is the same shape they hold post-move.
 class ModuleLowerer {
  public:
-  explicit ModuleLowerer(const hir::ModuleUnit& hir) : hir_(&hir) {
+  ModuleLowerer(
+      const hir::ModuleUnit& hir, const diag::SourceManager& source_manager)
+      : hir_(&hir), source_manager_(&source_manager) {
   }
 
   auto Run() -> diag::Result<mir::CompilationUnit>;
@@ -42,6 +45,13 @@ class ModuleLowerer {
 
   [[nodiscard]] auto Hir() const -> const hir::ModuleUnit& {
     return *hir_;
+  }
+
+  // Resolves a `SourceSpan` to a "file:line:col" string for diagnostic
+  // origin tagging (LRM 20.10 source identification). Returned by value so
+  // the caller can intern it as a MIR `StringLiteral` at the emit site.
+  [[nodiscard]] auto SourceManager() const -> const diag::SourceManager& {
+    return *source_manager_;
   }
 
   [[nodiscard]] auto TranslateType(hir::TypeId hir_id) const -> mir::TypeId {
@@ -64,6 +74,7 @@ class ModuleLowerer {
       -> mir::TypeData;
 
   const hir::ModuleUnit* hir_;
+  const diag::SourceManager* source_manager_;
   mir::CompilationUnit unit_;
   std::vector<mir::TypeId> type_map_;
 };

--- a/include/lyra/lowering/hir_to_mir/services_call.hpp
+++ b/include/lyra/lowering/hir_to_mir/services_call.hpp
@@ -1,10 +1,23 @@
 #pragma once
 
+#include <string>
+
+#include "lyra/diag/source_manager.hpp"
+#include "lyra/diag/source_span.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
 
 namespace lyra::lowering::hir_to_mir {
+
+// Formats `span` as "basename:line:col" for the runtime diagnostic origin tag.
+// SV simulators print diagnostics with the source file name, not its absolute
+// path (LRM 20.10 examples and the Verilator / VCS / Modelsim convention), so
+// the runtime origin uses the basename rather than
+// `diag::FormatSourceLocation`'s full path. Empty when the span has no
+// resolvable file.
+[[nodiscard]] auto FormatRuntimeOriginString(
+    diag::SourceSpan span, const diag::SourceManager& mgr) -> std::string;
 
 // Builds the engine-handle expression `self.Services()`: a `Services`
 // scope-method call whose receiver is the body's self read, interned as a
@@ -24,5 +37,14 @@ auto BuildServicesCallExpr(const ModuleLowerer& module, const WalkFrame& frame)
 // of their FileTable methods.
 auto BuildFilesCallExpr(const ModuleLowerer& module, const WalkFrame& frame)
     -> mir::Expr;
+
+// Builds the diagnostic broker expression `services.Diagnostic()`: a
+// `Diagnostic` method call on the engine handle, typed as the unit's
+// `diagnostic` builtin. Returns the outer call detached; the caller interns
+// it. The inner services call is interned into `frame.current_block` as a
+// child. LRM 20.10 `$info` / `$warning` / `$error` thread the resulting
+// handle as the receiver of their severity-fixed Emit methods.
+auto BuildDiagnosticCallExpr(
+    const ModuleLowerer& module, const WalkFrame& frame) -> mir::Expr;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/statement/branches.hpp
+++ b/include/lyra/lowering/hir_to_mir/statement/branches.hpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/diag/source_span.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
@@ -18,14 +19,15 @@ namespace lyra::lowering::hir_to_mir {
 
 auto LowerIfStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
-    const hir::IfStmt& i) -> diag::Result<mir::Stmt>;
+    const hir::IfStmt& i, diag::SourceSpan span) -> diag::Result<mir::Stmt>;
 
 auto LowerCaseStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
-    const hir::CaseStmt& c) -> diag::Result<mir::Stmt>;
+    const hir::CaseStmt& c, diag::SourceSpan span) -> diag::Result<mir::Stmt>;
 
 auto LowerCaseInsideStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
-    const hir::CaseInsideStmt& c) -> diag::Result<mir::Stmt>;
+    const hir::CaseInsideStmt& c, diag::SourceSpan span)
+    -> diag::Result<mir::Stmt>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -28,6 +28,7 @@ struct BuiltinMirTypes {
   TypeId time;
   TypeId services;
   TypeId files;
+  TypeId diagnostic;
   TypeId channel_cancellation;
   TypeId print_item;
   TypeId print_literal_item;
@@ -73,6 +74,7 @@ struct CompilationUnit {
                     .form = PackedArrayForm::kTime}}),
             .services = AddType(TypeData{ServicesType{}}),
             .files = AddType(TypeData{FilesType{}}),
+            .diagnostic = AddType(TypeData{DiagnosticType{}}),
             .channel_cancellation = AddType(
                 TypeData{RuntimeLibraryType{
                     .kind = RuntimeLibraryKind::kChannelCancellation}}),

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -29,6 +29,7 @@ enum class TypeKind {
   kScope,
   kServices,
   kFiles,
+  kDiagnostic,
   kRuntimeLibrary,
   kCoroutine,
   kReference,
@@ -165,6 +166,15 @@ struct ServicesType {
 // future `Open` / `Close` / ...). Opaque, never inspected by MIR.
 struct FilesType {
   auto operator==(const FilesType&) const -> bool = default;
+};
+
+// The diagnostic subsystem handle `lyra::runtime::DiagnosticDispatcher`,
+// reached from `RuntimeServices` through its `Diagnostic` method. The
+// receiver of severity-fixed emit methods (`EmitInfo` / `EmitWarning` /
+// `EmitError`) carrying a pre-formatted text. Opaque, never inspected by
+// MIR.
+struct DiagnosticType {
+  auto operator==(const DiagnosticType&) const -> bool = default;
 };
 
 // A pass-through value type from the runtime library that MIR never inspects:
@@ -304,8 +314,8 @@ using TypeData = std::variant<
     PackedArrayType, EnumType, UnpackedArrayType, DynamicArrayType, QueueType,
     AssociativeArrayType, StringType, EventType, RealType, ShortRealType,
     RealTimeType, ChandleType, VoidType, ObjectType, ExternalUnitObjectType,
-    ScopeType, ServicesType, FilesType, RuntimeLibraryType, CoroutineType,
-    RefType, PointerType, VectorType, TupleType, ExternalRefType,
+    ScopeType, ServicesType, FilesType, DiagnosticType, RuntimeLibraryType,
+    CoroutineType, RefType, PointerType, VectorType, TupleType, ExternalRefType,
     ObservableType>;
 
 struct Type {

--- a/include/lyra/runtime/diagnostic.hpp
+++ b/include/lyra/runtime/diagnostic.hpp
@@ -2,17 +2,13 @@
 
 #include <cstdint>
 #include <functional>
-#include <optional>
-#include <span>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 
-#include "lyra/value/format.hpp"
+#include "lyra/value/string.hpp"
 
 namespace lyra::runtime {
-
-class RuntimeServices;
 
 enum class Severity : std::uint8_t {
   kInfo,
@@ -20,34 +16,40 @@ enum class Severity : std::uint8_t {
   kError,
 };
 
-struct SourceLocation {
-  std::string file;
-  std::uint32_t line;
-  std::uint32_t col;
-
-  auto operator==(const SourceLocation&) const -> bool = default;
-};
-
 struct DiagnosticRecord {
   Severity severity;
-  std::optional<SourceLocation> origin;
+  std::string origin;
   std::string body;
 };
 
+// LRM 20.10 severity-fixed emit surface. The three EmitX methods are the
+// generated-code entry points: each takes the pre-formatted origin string
+// ("file:line:col", produced at lowering from the call's source span) and a
+// pre-formatted body string (from `services.Format(items)`), and routes a
+// record at its fixed severity through Emit. The dispatcher uses the origin
+// directly for both the message prefix and the rate-limit dedup key, so
+// distinct call sites get distinct counters.
 class DiagnosticDispatcher {
  public:
   using DiagnosticSink = std::function<void(std::string_view)>;
 
-  // Per-(file:line, severity) suppression after this many emits in one run.
+  // Per-(origin, severity) suppression after this many emits in one run.
   // Zero disables rate limiting.
   static constexpr std::uint32_t kDefaultRateLimit = 10;
 
   explicit DiagnosticDispatcher(
       DiagnosticSink sink, std::uint32_t rate_limit = kDefaultRateLimit);
 
-  void Emit(DiagnosticRecord record);
+  void EmitInfo(
+      const lyra::value::String& origin, const lyra::value::String& text);
+  void EmitWarning(
+      const lyra::value::String& origin, const lyra::value::String& text);
+  void EmitError(
+      const lyra::value::String& origin, const lyra::value::String& text);
 
  private:
+  void Emit(DiagnosticRecord record);
+
   struct CountKey {
     std::string origin;
     Severity severity;
@@ -63,25 +65,5 @@ class DiagnosticDispatcher {
   std::uint32_t rate_limit_;
   std::unordered_map<CountKey, std::uint32_t, CountKeyHash> emit_counts_;
 };
-
-// Formats `items` via value::Format, builds a DiagnosticRecord, and emits
-// it through services.Diagnostic(). The body is fully formatted before being
-// handed to the dispatcher so the dispatcher can prepend its own envelope
-// (origin, severity prefix) without re-parsing user content.
-void LyraDiagnostic(
-    RuntimeServices& services, Severity severity,
-    std::optional<SourceLocation> origin,
-    std::span<const value::PrintItem> items);
-
-// The severity-fixed diagnostic entries for $info / $warning / $error. The
-// severity is encoded by the entry, so the call carries none -- the lowering
-// selects the entry. Source location is not yet resolved at lowering, so these
-// emit with no origin (LRM 20.10).
-void LyraInfo(
-    RuntimeServices& services, std::span<const value::PrintItem> items);
-void LyraWarning(
-    RuntimeServices& services, std::span<const value::PrintItem> items);
-void LyraError(
-    RuntimeServices& services, std::span<const value::PrintItem> items);
 
 }  // namespace lyra::runtime

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -133,6 +133,16 @@ enum class BuiltinFn : std::uint16_t {
   kFormat,
   kWrite,
   kWriteln,
+  // Diagnostic subsystem accessor and severity-fixed emit operations.
+  // `Diagnostic` is a `RuntimeServices` method returning the
+  // `DiagnosticDispatcher` broker. `EmitInfo` / `EmitWarning` / `EmitError`
+  // are dispatcher methods taking a pre-formatted text (LRM 20.10), one
+  // method per severity rather than a single emit-with-tag, mirroring the
+  // `Write` / `Writeln` split.
+  kDiagnostic,
+  kEmitInfo,
+  kEmitWarning,
+  kEmitError,
   // LRM 21.3.4.3 scan primitives. `Scan` is a pure value-layer parser;
   // `PeekBuffered` / `AdvanceFd` are the file-side bytes-and-position
   // operations a `$fscanf` lowering composes with `Scan`.

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -83,14 +83,12 @@ struct TerminationSystemSubroutineInfo {
   int default_level;
 };
 
-enum class DiagnosticSeverityKind : std::uint8_t {
-  kInfo,
-  kWarning,
-  kError,
-};
-
+// LRM 20.10 severity-fixed diagnostic tasks. The MIR-side identity is the
+// `BuiltinFn` Emit method on the diagnostic broker; the descriptor stores it
+// directly so the lowering reads `info.builtin_fn` and routes the runtime
+// call without a parallel severity enum.
 struct DiagnosticSystemSubroutineInfo {
-  DiagnosticSeverityKind severity;
+  BuiltinFn builtin_fn;
 };
 
 // The MIR-side callee identity for the SV system task. The same closed
@@ -420,8 +418,7 @@ inline constexpr std::array kSystemSubroutines = {
         .result_conv = ReturnConvention::kVoid,
         .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 255},
         .semantic =
-            DiagnosticSystemSubroutineInfo{
-                .severity = DiagnosticSeverityKind::kInfo},
+            DiagnosticSystemSubroutineInfo{.builtin_fn = BuiltinFn::kEmitInfo},
     },
     SystemSubroutineDesc{
         .id = SystemSubroutineId{18},
@@ -432,7 +429,7 @@ inline constexpr std::array kSystemSubroutines = {
         .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 255},
         .semantic =
             DiagnosticSystemSubroutineInfo{
-                .severity = DiagnosticSeverityKind::kWarning},
+                .builtin_fn = BuiltinFn::kEmitWarning},
     },
     SystemSubroutineDesc{
         .id = SystemSubroutineId{19},
@@ -442,8 +439,7 @@ inline constexpr std::array kSystemSubroutines = {
         .result_conv = ReturnConvention::kVoid,
         .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 255},
         .semantic =
-            DiagnosticSystemSubroutineInfo{
-                .severity = DiagnosticSeverityKind::kError},
+            DiagnosticSystemSubroutineInfo{.builtin_fn = BuiltinFn::kEmitError},
     },
     SystemSubroutineDesc{
         .id = SystemSubroutineId{20},

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -663,6 +663,14 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "Write";
     case support::BuiltinFn::kWriteln:
       return "Writeln";
+    case support::BuiltinFn::kDiagnostic:
+      return "Diagnostic";
+    case support::BuiltinFn::kEmitInfo:
+      return "EmitInfo";
+    case support::BuiltinFn::kEmitWarning:
+      return "EmitWarning";
+    case support::BuiltinFn::kEmitError:
+      return "EmitError";
     case support::BuiltinFn::kScan:
       return "Scan";
     case support::BuiltinFn::kPeekBuffered:
@@ -951,18 +959,12 @@ auto RenderSystemSubroutineEntryName(const support::SystemSubroutineDesc& desc)
                 "RenderSystemSubroutineEntryName: print id reached system "
                 "subroutine render path; print family is BuiltinFn-routed");
           },
-          [](const support::DiagnosticSystemSubroutineInfo& diagnostic)
+          [](const support::DiagnosticSystemSubroutineInfo&)
               -> diag::Result<std::string_view> {
-            switch (diagnostic.severity) {
-              case support::DiagnosticSeverityKind::kInfo:
-                return std::string_view{"lyra::runtime::LyraInfo"};
-              case support::DiagnosticSeverityKind::kWarning:
-                return std::string_view{"lyra::runtime::LyraWarning"};
-              case support::DiagnosticSeverityKind::kError:
-                return std::string_view{"lyra::runtime::LyraError"};
-            }
             throw InternalError(
-                "RenderSystemSubroutineEntryName: unknown DiagnosticSeverity");
+                "RenderSystemSubroutineEntryName: diagnostic id reached "
+                "system subroutine render path; diagnostic family is "
+                "BuiltinFn-routed");
           },
           [](const support::SFormatSystemSubroutineInfo&)
               -> diag::Result<std::string_view> {

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -121,6 +121,9 @@ auto RenderTypeAsCpp(
           [](const mir::FilesType&) -> diag::Result<std::string> {
             return std::string{"lyra::runtime::FileTable&"};
           },
+          [](const mir::DiagnosticType&) -> diag::Result<std::string> {
+            return std::string{"lyra::runtime::DiagnosticDispatcher&"};
+          },
           [](const mir::RuntimeLibraryType& r) -> diag::Result<std::string> {
             switch (r.kind) {
               case mir::RuntimeLibraryKind::kPrintItem:

--- a/src/lyra/compiler/compile.cpp
+++ b/src/lyra/compiler/compile.cpp
@@ -54,7 +54,8 @@ auto Compile(
   std::vector<mir::CompilationUnit> units;
   units.reserve(result.artifacts.hir_units->size());
   for (const auto& hir_unit : *result.artifacts.hir_units) {
-    lowering::hir_to_mir::ModuleLowerer module(hir_unit);
+    lowering::hir_to_mir::ModuleLowerer module(
+        hir_unit, result.artifacts.parse->diag_sources);
     auto unit_or = module.Run();
     if (!unit_or) {
       sink.Report(std::move(unit_or.error()));

--- a/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
@@ -9,11 +9,13 @@
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/diag/source_span.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/closure_builder.hpp"
 #include "lyra/lowering/hir_to_mir/print_items.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
+#include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/lowering/hir_to_mir/snapshot_local.hpp"
 #include "lyra/lowering/hir_to_mir/statement/blocks.hpp"
 #include "lyra/mir/binary_op.hpp"
@@ -27,7 +29,6 @@
 #include "lyra/mir/stmt.hpp"
 #include "lyra/mir/value_ref.hpp"
 #include "lyra/support/builtin_fn.hpp"
-#include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -108,7 +109,7 @@ auto SnapshotPredicate(
 auto BuildDiagnosticThenScope(
     mir::CompilationUnit& unit, mir::TypeId self_pointer_type,
     mir::LocalId self_binding, mir::LocalId count_var,
-    const CheckVerdict& verdict) -> mir::Block {
+    const CheckVerdict& verdict, std::string origin) -> mir::Block {
   mir::Block block;
   const mir::TypeId int32_type = unit.builtins.int32;
 
@@ -145,29 +146,56 @@ auto BuildDiagnosticThenScope(
   const mir::ExprId services = block.exprs.Add(
       mir::MakeServicesCallExpr(self_read, unit.builtins.services));
 
-  const support::SystemSubroutineDesc* warning_desc =
-      support::FindSystemSubroutine("$warning");
-  if (warning_desc == nullptr) {
-    throw InternalError(
-        "BuildDiagnosticThenScope: $warning system subroutine not registered");
-  }
-
-  std::vector<mir::ExprId> args{services, items_array};
-  const mir::ExprId diag_call_id = block.exprs.Add(
+  // Format the verdict text, then route through the diagnostic broker's
+  // EmitWarning method (LRM 20.10): unique / priority deferred-check failures
+  // are warning-severity by spec. The origin tag is the qualified statement's
+  // source location, threaded in from the cascade entry.
+  const mir::ExprId text_id = block.exprs.Add(
       mir::Expr{
           .data =
               mir::CallExpr{
-                  .callee = mir::SystemSubroutineCallee{.id = warning_desc->id},
-                  .arguments = std::move(args)},
+                  .callee =
+                      mir::BuiltinFnCallee{.id = support::BuiltinFn::kFormat},
+                  .arguments = {services, items_array}},
+          .type = unit.builtins.string});
+  const mir::ExprId diagnostic_id = block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee =
+                      mir::BuiltinFnCallee{
+                          .id = support::BuiltinFn::kDiagnostic},
+                  .arguments = {services}},
+          .type = unit.builtins.diagnostic});
+  const mir::ExprId origin_lit = block.exprs.Add(
+      mir::Expr{
+          .data = mir::StringLiteral{.value = std::move(origin)},
+          .type = unit.builtins.string});
+  const mir::ExprId origin_id = block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee = mir::ConstructorCallee{},
+                  .arguments = {origin_lit}},
+          .type = unit.builtins.string});
+  const mir::ExprId emit_call_id = block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee =
+                      mir::BuiltinFnCallee{
+                          .id = support::BuiltinFn::kEmitWarning},
+                  .arguments = {diagnostic_id, origin_id, text_id}},
           .type = unit.builtins.void_type});
-  block.AppendStmt(mir::ExprStmt{.expr = diag_call_id});
+  block.AppendStmt(mir::ExprStmt{.expr = emit_call_id});
   return block;
 }
 
 auto BuildUniqueCheckClosure(
     ModuleLowerer& module, const WalkFrame& wrapper_frame, mir::Block& wrapper,
     hir::UniquePriorityCheck check,
-    const std::vector<mir::LocalId>& snapshot_vars) -> mir::Expr {
+    const std::vector<mir::LocalId>& snapshot_vars, std::string origin)
+    -> mir::Expr {
   ClosureBuilder closure(module.Unit(), wrapper_frame);
   mir::Block& body = closure.Body();
 
@@ -264,7 +292,8 @@ auto BuildUniqueCheckClosure(
           .type = int32_type});
 
   mir::Block diag_block = BuildDiagnosticThenScope(
-      module.Unit(), self_ptr_type, self_binding, count_var, verdict);
+      module.Unit(), self_ptr_type, self_binding, count_var, verdict,
+      std::move(origin));
 
   const mir::BlockId diag_scope_id =
       body.child_scopes.Add(std::move(diag_block));
@@ -284,7 +313,8 @@ auto BuildDeferredCheckCascade(
     ModuleLowerer& module, WalkFrame frame, mir::Block wrapper,
     std::vector<DeferredCheckBranch> branches,
     std::optional<mir::Block> tail_else, hir::UniquePriorityCheck check,
-    std::optional<std::string> outer_label) -> mir::Stmt {
+    std::optional<std::string> outer_label, diag::SourceSpan span)
+    -> mir::Stmt {
   const mir::TypeId void_type = module.Unit().builtins.void_type;
   const mir::TypeId int32_type = module.Unit().builtins.int32;
 
@@ -306,7 +336,8 @@ auto BuildDeferredCheckCascade(
   }
 
   mir::Expr closure = BuildUniqueCheckClosure(
-      module, wrapper_frame, wrapper, check, snapshot_vars);
+      module, wrapper_frame, wrapper, check, snapshot_vars,
+      FormatRuntimeOriginString(span, module.SourceManager()));
   const mir::ExprId closure_expr_id = wrapper.exprs.Add(std::move(closure));
 
   const mir::DeferredCheckSiteId site_id =
@@ -395,7 +426,7 @@ auto BuildDeferredCheckCascade(
 
 auto LowerUniqueIfStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
-    const hir::IfStmt& root) -> diag::Result<mir::Stmt> {
+    const hir::IfStmt& root, diag::SourceSpan span) -> diag::Result<mir::Stmt> {
   const auto& hir_proc = process.HirBody();
   const auto cascade = FlattenUniqueCascade(hir_proc, root);
 
@@ -444,7 +475,7 @@ auto LowerUniqueIfStmt(
 
   return BuildDeferredCheckCascade(
       process.Module(), frame, std::move(wrapper), std::move(branches),
-      std::move(tail_scope), *root.check, std::move(label));
+      std::move(tail_scope), *root.check, std::move(label), span);
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -274,10 +274,10 @@ auto LowerSystemSubroutineCall(
             return LowerFinishSystemSubroutineCall(
                 process, frame, call, desc.name, term, span);
           },
-          [&](const support::DiagnosticSystemSubroutineInfo&)
+          [&](const support::DiagnosticSystemSubroutineInfo& diag_info)
               -> diag::Result<mir::Expr> {
             return LowerDiagnosticSystemSubroutineCall(
-                process, frame, call, desc.id, span);
+                process, frame, call, diag_info, span);
           },
           [&](const support::FileIOSystemSubroutineInfo& file_io)
               -> diag::Result<mir::Expr> {

--- a/src/lyra/lowering/hir_to_mir/expression/system/diagnostic.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/diagnostic.cpp
@@ -2,8 +2,8 @@
 
 #include <cstdint>
 #include <expected>
+#include <string>
 #include <utility>
-#include <vector>
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
@@ -13,17 +13,43 @@
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/support/builtin_fn.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
+namespace {
+
+// Materializes `origin` as a `value::String` MIR expression: a `StringLiteral`
+// renders as a raw C string in C++, so a `ConstructorCallee` of `string` type
+// wraps it to satisfy the runtime method's `const value::String&` parameter.
+auto BuildOriginStringExpr(
+    const mir::CompilationUnit& unit, mir::Block& block, std::string origin)
+    -> mir::ExprId {
+  const mir::TypeId string_type = unit.builtins.string;
+  const mir::ExprId origin_lit = block.exprs.Add(
+      mir::Expr{
+          .data = mir::StringLiteral{.value = std::move(origin)},
+          .type = string_type});
+  return block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee = mir::ConstructorCallee{},
+                  .arguments = {origin_lit}},
+          .type = string_type});
+}
+
+}  // namespace
+
 auto LowerDiagnosticSystemSubroutineCall(
     ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& call,
-    support::SystemSubroutineId id, diag::SourceSpan span)
+    const support::DiagnosticSystemSubroutineInfo& info, diag::SourceSpan span)
     -> diag::Result<mir::Expr> {
-  // $info/$warning/$error use display-style format (LRM 20.10) with decimal as
-  // the bare-arg default radix; the diagnostic sink runs separately. Severity
-  // is carried by `id` -- the backend selects the matching runtime entry.
+  // $info / $warning / $error format their items with decimal as the bare-arg
+  // default radix (LRM 20.10 / 21.2.1.4), then route through the diagnostic
+  // dispatcher rather than a print sink. The call's source span becomes the
+  // origin tag the dispatcher prepends and uses as its per-site dedup key.
   auto items_or = BuildRuntimePrintItemsFromCallArgs(
       process, frame, call, support::PrintRadix::kDecimal, 0,
       FormatStringRequirement::kOptional, span);
@@ -36,16 +62,26 @@ auto LowerDiagnosticSystemSubroutineCall(
   const mir::ExprId items_array = block.exprs.Add(
       BuildPrintItemsArray(unit, block, *items_or, time_unit_power));
 
-  std::vector<mir::ExprId> args;
-  args.push_back(
-      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame)));
-  args.push_back(items_array);
-
+  const mir::ExprId services_id =
+      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+  const mir::ExprId text_id = block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee =
+                      mir::BuiltinFnCallee{.id = support::BuiltinFn::kFormat},
+                  .arguments = {services_id, items_array}},
+          .type = unit.builtins.string});
+  const mir::ExprId diagnostic_id =
+      block.exprs.Add(BuildDiagnosticCallExpr(process.Module(), frame));
+  const mir::ExprId origin_id = BuildOriginStringExpr(
+      unit, block,
+      FormatRuntimeOriginString(span, process.Module().SourceManager()));
   return mir::Expr{
       .data =
           mir::CallExpr{
-              .callee = mir::SystemSubroutineCallee{.id = id},
-              .arguments = std::move(args)},
+              .callee = mir::BuiltinFnCallee{.id = info.builtin_fn},
+              .arguments = {diagnostic_id, origin_id, text_id}},
       .type = unit.builtins.void_type};
 }
 

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -176,13 +176,13 @@ auto ProcessLowerer::LowerStmt(const hir::Stmt& stmt, WalkFrame frame)
             return LowerForkStmt(*this, frame, stmt.label, f);
           },
           [&](const hir::IfStmt& i) {
-            return LowerIfStmt(*this, frame, stmt.label, i);
+            return LowerIfStmt(*this, frame, stmt.label, i, stmt.span);
           },
           [&](const hir::CaseStmt& c) {
-            return LowerCaseStmt(*this, frame, stmt.label, c);
+            return LowerCaseStmt(*this, frame, stmt.label, c, stmt.span);
           },
           [&](const hir::CaseInsideStmt& c) {
-            return LowerCaseInsideStmt(*this, frame, stmt.label, c);
+            return LowerCaseInsideStmt(*this, frame, stmt.label, c, stmt.span);
           },
           [&](const hir::ForStmt& f) {
             return LowerForStmt(*this, frame, stmt.label, f);

--- a/src/lyra/lowering/hir_to_mir/services_call.cpp
+++ b/src/lyra/lowering/hir_to_mir/services_call.cpp
@@ -1,5 +1,11 @@
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
 
+#include <filesystem>
+#include <format>
+#include <string>
+
+#include "lyra/diag/source_manager.hpp"
+#include "lyra/diag/source_span.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/compilation_unit.hpp"
@@ -8,6 +14,16 @@
 #include "lyra/support/builtin_fn.hpp"
 
 namespace lyra::lowering::hir_to_mir {
+
+auto FormatRuntimeOriginString(
+    diag::SourceSpan span, const diag::SourceManager& mgr) -> std::string {
+  const diag::FileInfo* file = mgr.GetFile(span.file_id);
+  if (file == nullptr) return {};
+  const auto loc = mgr.OffsetToLineCol(span.file_id, span.begin);
+  return std::format(
+      "{}:{}:{}", std::filesystem::path{file->path}.filename().string(),
+      loc.line, loc.col);
+}
 
 auto BuildServicesCallExpr(const ModuleLowerer& module, const WalkFrame& frame)
     -> mir::Expr {
@@ -30,6 +46,21 @@ auto BuildFilesCallExpr(const ModuleLowerer& module, const WalkFrame& frame)
               .callee = mir::BuiltinFnCallee{.id = support::BuiltinFn::kFiles},
               .arguments = {services_id}},
       .type = builtins.files};
+}
+
+auto BuildDiagnosticCallExpr(
+    const ModuleLowerer& module, const WalkFrame& frame) -> mir::Expr {
+  auto& body = *frame.current_block;
+  const auto& builtins = module.Unit().builtins;
+  const mir::ExprId services_id =
+      body.exprs.Add(BuildServicesCallExpr(module, frame));
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinFnCallee{.id = support::BuiltinFn::kDiagnostic},
+              .arguments = {services_id}},
+      .type = builtins.diagnostic};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/statement/branches.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/branches.cpp
@@ -30,9 +30,9 @@ namespace lyra::lowering::hir_to_mir {
 
 auto LowerIfStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
-    const hir::IfStmt& i) -> diag::Result<mir::Stmt> {
+    const hir::IfStmt& i, diag::SourceSpan span) -> diag::Result<mir::Stmt> {
   if (i.check.has_value()) {
-    return LowerUniqueIfStmt(process, frame, std::move(label), i);
+    return LowerUniqueIfStmt(process, frame, std::move(label), i, span);
   }
   auto& block = *frame.current_block;
   auto cond_expr_or =
@@ -64,7 +64,7 @@ auto LowerIfStmt(
 
 auto LowerCaseStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
-    const hir::CaseStmt& c) -> diag::Result<mir::Stmt> {
+    const hir::CaseStmt& c, diag::SourceSpan span) -> diag::Result<mir::Stmt> {
   const hir::ProceduralBody& hir_proc = process.HirBody();
   const mir::TypeId bit_type = process.Module().Unit().builtins.bit1;
   const mir::BinaryOp compare_op = [&] {
@@ -175,7 +175,7 @@ auto LowerCaseStmt(
     }
     return BuildDeferredCheckCascade(
         process.Module(), frame, std::move(wrapper), std::move(branches),
-        std::move(default_scope), *c.check, std::move(label));
+        std::move(default_scope), *c.check, std::move(label), span);
   }
 
   auto build_predicate = [&](WalkFrame enc_frame, std::size_t item_idx,
@@ -202,7 +202,8 @@ auto LowerCaseStmt(
 
 auto LowerCaseInsideStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
-    const hir::CaseInsideStmt& c) -> diag::Result<mir::Stmt> {
+    const hir::CaseInsideStmt& c, diag::SourceSpan span)
+    -> diag::Result<mir::Stmt> {
   const hir::ProceduralBody& hir_proc = process.HirBody();
   const mir::TypeId bit_type = process.Module().Unit().builtins.bit1;
 
@@ -302,7 +303,7 @@ auto LowerCaseInsideStmt(
     }
     return BuildDeferredCheckCascade(
         process.Module(), frame, std::move(wrapper), std::move(branches),
-        std::move(default_scope), *c.check, std::move(label));
+        std::move(default_scope), *c.check, std::move(label), span);
   }
 
   return BuildCaseCascade(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -181,6 +181,7 @@ class MirDumper {
             [](const ScopeType&) -> std::string { return "Scope"; },
             [](const ServicesType&) -> std::string { return "Services"; },
             [](const FilesType&) -> std::string { return "Files"; },
+            [](const DiagnosticType&) -> std::string { return "Diagnostic"; },
             [](const RuntimeLibraryType& r) -> std::string {
               switch (r.kind) {
                 case RuntimeLibraryKind::kPrintItem:

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -77,6 +77,7 @@ auto Type::Kind() const -> TypeKind {
           [](const ScopeType&) { return TypeKind::kScope; },
           [](const ServicesType&) { return TypeKind::kServices; },
           [](const FilesType&) { return TypeKind::kFiles; },
+          [](const DiagnosticType&) { return TypeKind::kDiagnostic; },
           [](const RuntimeLibraryType&) { return TypeKind::kRuntimeLibrary; },
           [](const CoroutineType&) { return TypeKind::kCoroutine; },
           [](const RefType&) { return TypeKind::kReference; },

--- a/src/lyra/runtime/diagnostic.cpp
+++ b/src/lyra/runtime/diagnostic.cpp
@@ -3,16 +3,11 @@
 #include <cstdint>
 #include <format>
 #include <functional>
-#include <optional>
-#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
-#include <variant>
 
-#include "lyra/base/overloaded.hpp"
-#include "lyra/runtime/runtime_services.hpp"
-#include "lyra/value/format.hpp"
+#include "lyra/value/string.hpp"
 
 namespace lyra::runtime {
 
@@ -30,10 +25,6 @@ auto SeverityText(Severity s) -> std::string_view {
   return "info";
 }
 
-auto FormatOrigin(const SourceLocation& loc) -> std::string {
-  return std::format("{}:{}:{}", loc.file, loc.line, loc.col);
-}
-
 }  // namespace
 
 auto DiagnosticDispatcher::CountKeyHash::operator()(
@@ -49,12 +40,36 @@ DiagnosticDispatcher::DiagnosticDispatcher(
     : sink_(std::move(sink)), rate_limit_(rate_limit) {
 }
 
-void DiagnosticDispatcher::Emit(DiagnosticRecord record) {
-  const std::string origin_text =
-      record.origin.has_value() ? FormatOrigin(*record.origin) : std::string{};
+void DiagnosticDispatcher::EmitInfo(
+    const lyra::value::String& origin, const lyra::value::String& text) {
+  Emit(
+      DiagnosticRecord{
+          .severity = Severity::kInfo,
+          .origin = std::string{origin.View()},
+          .body = std::string{text.View()}});
+}
 
+void DiagnosticDispatcher::EmitWarning(
+    const lyra::value::String& origin, const lyra::value::String& text) {
+  Emit(
+      DiagnosticRecord{
+          .severity = Severity::kWarning,
+          .origin = std::string{origin.View()},
+          .body = std::string{text.View()}});
+}
+
+void DiagnosticDispatcher::EmitError(
+    const lyra::value::String& origin, const lyra::value::String& text) {
+  Emit(
+      DiagnosticRecord{
+          .severity = Severity::kError,
+          .origin = std::string{origin.View()},
+          .body = std::string{text.View()}});
+}
+
+void DiagnosticDispatcher::Emit(DiagnosticRecord record) {
   if (rate_limit_ > 0) {
-    const CountKey key{.origin = origin_text, .severity = record.severity};
+    const CountKey key{.origin = record.origin, .severity = record.severity};
     auto& count = emit_counts_[key];
     if (count >= rate_limit_) {
       if (count == rate_limit_) {
@@ -73,8 +88,8 @@ void DiagnosticDispatcher::Emit(DiagnosticRecord record) {
   }
 
   std::string line;
-  if (!origin_text.empty()) {
-    line += origin_text;
+  if (!record.origin.empty()) {
+    line += record.origin;
     line += ": ";
   }
   line += SeverityText(record.severity);
@@ -82,49 +97,6 @@ void DiagnosticDispatcher::Emit(DiagnosticRecord record) {
   line += record.body;
   line += "\n";
   sink_(line);
-}
-
-void LyraDiagnostic(
-    RuntimeServices& services, Severity severity,
-    std::optional<SourceLocation> origin,
-    std::span<const value::PrintItem> items) {
-  std::string body;
-  for (const value::PrintItem& item : items) {
-    std::visit(
-        Overloaded{
-            [&](const value::PrintLiteralItem& lit) {
-              body.append(std::string_view{lit.data, lit.size});
-            },
-            [&](const value::PrintValueItem& v) {
-              body.append(
-                  value::Format(
-                      v.spec, v.arg,
-                      value::FormatContext{
-                          .time_format = &services.TimeFormat()}));
-            },
-        },
-        item);
-  }
-  services.Diagnostic().Emit(
-      DiagnosticRecord{
-          .severity = severity,
-          .origin = std::move(origin),
-          .body = std::move(body)});
-}
-
-void LyraInfo(
-    RuntimeServices& services, std::span<const value::PrintItem> items) {
-  LyraDiagnostic(services, Severity::kInfo, std::nullopt, items);
-}
-
-void LyraWarning(
-    RuntimeServices& services, std::span<const value::PrintItem> items) {
-  LyraDiagnostic(services, Severity::kWarning, std::nullopt, items);
-}
-
-void LyraError(
-    RuntimeServices& services, std::span<const value::PrintItem> items) {
-  LyraDiagnostic(services, Severity::kError, std::nullopt, items);
 }
 
 }  // namespace lyra::runtime

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -316,6 +316,14 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "file_error";
     case BuiltinFn::kFileFlush:
       return "file_flush";
+    case BuiltinFn::kDiagnostic:
+      return "diagnostic";
+    case BuiltinFn::kEmitInfo:
+      return "emit_info";
+    case BuiltinFn::kEmitWarning:
+      return "emit_warning";
+    case BuiltinFn::kEmitError:
+      return "emit_error";
   }
   throw InternalError("BuiltinFnName: unknown BuiltinFn");
 }

--- a/tests/cases/cpp/diagnostic_rate_limit/case.yaml
+++ b/tests/cases/cpp/diagnostic_rate_limit/case.yaml
@@ -9,14 +9,14 @@ expect:
   exit: 0
   stderr:
     exact: |
-      warning: repeating
-      warning: repeating
-      warning: repeating
-      warning: repeating
-      warning: repeating
-      warning: repeating
-      warning: repeating
-      warning: repeating
-      warning: repeating
-      warning: repeating
+      main.sv:4:7: warning: repeating
+      main.sv:4:7: warning: repeating
+      main.sv:4:7: warning: repeating
+      main.sv:4:7: warning: repeating
+      main.sv:4:7: warning: repeating
+      main.sv:4:7: warning: repeating
+      main.sv:4:7: warning: repeating
+      main.sv:4:7: warning: repeating
+      main.sv:4:7: warning: repeating
+      main.sv:4:7: warning: repeating
       lyra: warning: further messages from this site suppressed after 10 occurrences

--- a/tests/cases/cpp/diagnostic_separate_from_stdout/case.yaml
+++ b/tests/cases/cpp/diagnostic_separate_from_stdout/case.yaml
@@ -12,4 +12,4 @@ expect:
       on stdout
       still on stdout
   stderr:
-    exact: "warning: on stderr\n"
+    exact: "main.sv:4:5: warning: on stderr\n"

--- a/tests/cases/cpp/error_basic/case.yaml
+++ b/tests/cases/cpp/error_basic/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stderr:
-    exact: "error: something bad\n"
+    exact: "main.sv:3:5: error: something bad\n"

--- a/tests/cases/cpp/hierarchy_instance_deferred_check/case.yaml
+++ b/tests/cases/cpp/hierarchy_instance_deferred_check/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stderr:
-    exact: "warning: unique check failed: matched 3 of 3 conditions\n"
+    exact: "main.sv:5:5: warning: unique check failed: matched 3 of 3 conditions\n"

--- a/tests/cases/cpp/info_basic/case.yaml
+++ b/tests/cases/cpp/info_basic/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stderr:
-    exact: "info: hello info\n"
+    exact: "main.sv:3:5: info: hello info\n"

--- a/tests/cases/cpp/warning_with_format/case.yaml
+++ b/tests/cases/cpp/warning_with_format/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stderr:
-    exact: "warning: value is 42\n"
+    exact: "main.sv:3:5: warning: value is 42\n"


### PR DESCRIPTION
## Summary

Retires `SystemSubroutineCallee` from the `$info` / `$warning` / `$error` family and routes each through the broker pattern that print and file-IO already follow: `services.Format(items)` for the message text, `services.Diagnostic()` for the dispatcher handle, and `EmitInfo` / `EmitWarning` / `EmitError` for the severity-tagged emit. In doing so, threads the call's source span into the runtime as a `file:line:col` origin tag so the dispatcher can prefix messages (LRM 20.10 source identification) and key its rate-limit counter per call site.

## Design

The MIR side mirrors the file-IO broker shape: `mir::DiagnosticType{}` is the `DiagnosticDispatcher&` handle reached by `services.Diagnostic()`, and three new `BuiltinFn::kEmitInfo / kEmitWarning / kEmitError` methods take it as the receiver. `DiagnosticSystemSubroutineInfo` keeps its variant arm but now carries a single `BuiltinFn` field (mirroring `FileIOSystemSubroutineInfo`), so the lowering dispatch reads `info.builtin_fn` instead of a parallel `DiagnosticSeverityKind` enum.

Source-location threading needed `hir_to_mir::ModuleLowerer` to hold a `SourceManager` reference so the lowering can resolve a span without re-plumbing the diag layer. A small `FormatRuntimeOriginString` helper in `services_call` formats the span as `basename:line:col` -- SV simulators print just the filename, not the full path (Verilator / VCS / Modelsim convention), and using the basename also makes test output stable across bazel sandbox paths.

The previously broken rate-limit dedup is the direct payoff: with `origin` always empty, every `$error` in the design shared one counter and a hot site silenced all sibling sites after 10 hits. With per-site origins the dispatcher's `(origin, severity)` key behaves the way the LRM expects.

The unique / priority deferred-check cascade synthesizes a `$warning` internally; that path now uses the same `EmitWarning` broker call and carries the qualified statement's span as its origin, so deferred-check failures are attributed to the right `unique if` / `priority case` source line.

`$fatal` is not yet wired into the SV system task table; it picks up the same shape when it lands.

## Testing

Updated the six existing diagnostic test fixtures to expect the new `main.sv:line:col:` prefix. `bazel test //...` was running locally at commit time; affected diagnostic / deferred-check tests passed individually.