### PR TITLE
Wire $fatal as diagnostic + fatal-finish chain

### DIFF
--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -462,14 +462,16 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
           print already uses) returning a string; for `$sformat` the call result is assigned to the
           output lvalue. The dedicated `LyraSFormat` runtime entry retires.
   - Diagnostic subsystem (`services.Diagnostic()`):
-    - [x] `$info` / `$warning` / `$error`: each decomposes to `services.Format(items)` for the
-          message text, then `services.Diagnostic().Emit{Info,Warning,Error}(origin, text)` for the
+    - [x] `$info` / `$warning` / `$error` / `$fatal`: each decomposes to `services.Format(items)`
+          for the message text, then
+          `services.Diagnostic().Emit{Info,Warning,Error,Fatal}(origin,     text)` for the
           severity-tagged emit, with `origin` carrying the call's `file:line:col` so the dispatcher
           can prefix the message and key its rate-limit counter per site (LRM 20.10). The severities
           are distinct `BuiltinFn` methods (parallel to print's `Write` / `Writeln` split), not a
           single `Emit(severity, text)` with a tag arg. The unique / priority deferred-check cascade
-          synthesizes its warning through the same broker. `$fatal` picks up the shape when it
-          lands.
+          synthesizes its warning through the same broker. `$fatal` chains an implicit
+          `kFatalFinish` after the emit; the engine flags the termination so `Run()` returns a
+          non-zero exit code per LRM 20.10.
   - File-IO subsystem (`services.Files()`):
     - [x] `$fopen` / `$fclose` / `$fread` / `$fseek` / `$rewind` / `$ftell` / `$feof` / `$ferror` /
           `$fflush` / `$fgetc` / `$ungetc` / `$fgets`: each lowers to a `BuiltinFnCallee` method on

--- a/include/lyra/runtime/diagnostic.hpp
+++ b/include/lyra/runtime/diagnostic.hpp
@@ -14,6 +14,7 @@ enum class Severity : std::uint8_t {
   kInfo,
   kWarning,
   kError,
+  kFatal,
 };
 
 struct DiagnosticRecord {
@@ -45,6 +46,8 @@ class DiagnosticDispatcher {
   void EmitWarning(
       const lyra::value::String& origin, const lyra::value::String& text);
   void EmitError(
+      const lyra::value::String& origin, const lyra::value::String& text);
+  void EmitFatal(
       const lyra::value::String& origin, const lyra::value::String& text);
 
  private:

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -93,7 +93,10 @@ class Engine {
   // ScheduleInactive    -- enqueue on the inactive region of the current
   //                        slot (used by `#0` delays).
   // ScheduleAtTime      -- enqueue at a future SimTime (used by `#N`).
-  // RequestFinish       -- tear down the simulation (used by `$finish`).
+  // RequestFinish       -- tear down the simulation (used by `$finish` and
+  //                        the implicit shutdown that `$fatal` chains;
+  //                        `fatal` true makes Run() return a non-zero exit
+  //                        code per LRM 20.10).
   // Now                 -- query current simulation time.
   // Spawn               -- adopt a coroutine created mid-simulation as a
   //                        runnable process and schedule it (used by fork-join
@@ -101,7 +104,7 @@ class Engine {
   void ScheduleNextDelta(CoroutineHandle handle);
   void ScheduleInactive(CoroutineHandle handle);
   void ScheduleAtTime(SimTime when, CoroutineHandle handle);
-  void RequestFinish(int level);
+  void RequestFinish(int level, bool fatal = false);
   void Spawn(Coroutine coroutine);
   [[nodiscard]] auto Now() const -> SimTime {
     return now_;
@@ -184,6 +187,7 @@ class Engine {
   bool bound_ = false;
   bool ran_ = false;
   bool finished_ = false;
+  bool fatal_finish_ = false;
 };
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/finish.hpp
+++ b/include/lyra/runtime/finish.hpp
@@ -6,27 +6,32 @@
 
 namespace lyra::runtime {
 
-// `$finish(level)` -- requests the engine to tear down the simulation after
-// the current slot completes. The awaitable also suspends the calling
-// process; since `finished_` is set before await_suspend returns, the
-// engine drops it on the next dispatch. `level` arrives as a Lyra value, the
-// same as any other call argument (LRM 20.2).
+// `$finish(level)` / implicit shutdown from `$fatal` -- requests the engine
+// to tear down the simulation after the current slot completes. The awaitable
+// also suspends the calling process; since `finished_` is set before
+// await_suspend returns, the engine drops it on the next dispatch. `level`
+// arrives as a Lyra value, the same as any other call argument (LRM 20.2).
+// `fatal` true (LRM 20.10) marks the termination so the engine returns a
+// non-zero exit code.
 class FinishAwaitable {
  public:
   FinishAwaitable(
-      RuntimeServices& services, const lyra::value::PackedArray& level)
-      : services_(&services), level_(static_cast<int>(level.ToInt64())) {
+      RuntimeServices& services, const lyra::value::PackedArray& level,
+      bool fatal)
+      : services_(&services),
+        level_(static_cast<int>(level.ToInt64())),
+        fatal_(fatal) {
   }
 
   [[nodiscard]] static auto await_ready() noexcept -> bool {
     return false;
   }
 
-  // The coroutine protocol passes the awaiting handle, but `$finish` suspends
-  // forever (the engine drops the frame), so the handle is unused.
+  // The coroutine protocol passes the awaiting handle, but the finish-family
+  // suspends forever (the engine drops the frame), so the handle is unused.
   // NOLINTNEXTLINE(readability-named-parameter)
   void await_suspend(CoroutineHandle) noexcept {
-    services_->RequestFinish(level_);
+    services_->RequestFinish(level_, fatal_);
   }
 
   static void await_resume() noexcept {
@@ -35,12 +40,19 @@ class FinishAwaitable {
  private:
   RuntimeServices* services_;
   int level_;
+  bool fatal_;
 };
 
 inline auto Finish(
     RuntimeServices& services, const lyra::value::PackedArray& level)
     -> FinishAwaitable {
-  return FinishAwaitable{services, level};
+  return FinishAwaitable{services, level, false};
+}
+
+inline auto FatalFinish(
+    RuntimeServices& services, const lyra::value::PackedArray& level)
+    -> FinishAwaitable {
+  return FinishAwaitable{services, level, true};
 }
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/runtime_services.hpp
+++ b/include/lyra/runtime/runtime_services.hpp
@@ -74,7 +74,9 @@ class RuntimeServices {
   //                        (`#0` delay).
   // ScheduleAtTime      -- enqueue at a future SimTime (`#N` delay).
   // RequestFinish       -- mark simulation to stop after the current slot
-  //                        completes (`$finish`).
+  //                        completes (`$finish` and the implicit shutdown
+  //                        from `$fatal`; `fatal` true makes the eventual
+  //                        Run() return a non-zero exit code per LRM 20.10).
   // Now                 -- current simulation time.
   //
   // The scheduled unit is the coroutine frame that suspended (the innermost one
@@ -83,7 +85,7 @@ class RuntimeServices {
   void ScheduleNextDelta(CoroutineHandle handle);
   void ScheduleInactive(CoroutineHandle handle);
   void ScheduleAtTime(SimTime when, CoroutineHandle handle);
-  void RequestFinish(int level);
+  void RequestFinish(int level, bool fatal = false);
   void Spawn(Coroutine coroutine);
   [[nodiscard]] auto Now() const -> SimTime;
 

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -135,14 +135,16 @@ enum class BuiltinFn : std::uint16_t {
   kWriteln,
   // Diagnostic subsystem accessor and severity-fixed emit operations.
   // `Diagnostic` is a `RuntimeServices` method returning the
-  // `DiagnosticDispatcher` broker. `EmitInfo` / `EmitWarning` / `EmitError`
-  // are dispatcher methods taking a pre-formatted text (LRM 20.10), one
-  // method per severity rather than a single emit-with-tag, mirroring the
-  // `Write` / `Writeln` split.
+  // `DiagnosticDispatcher` broker. `EmitInfo` / `EmitWarning` / `EmitError` /
+  // `EmitFatal` are dispatcher methods taking a pre-formatted text (LRM 20.10),
+  // one method per severity rather than a single emit-with-tag, mirroring the
+  // `Write` / `Writeln` split. `EmitFatal` pairs with a subsequent `Finish`
+  // call to realize the LRM 20.10 "implicit $finish" requirement.
   kDiagnostic,
   kEmitInfo,
   kEmitWarning,
   kEmitError,
+  kEmitFatal,
   // LRM 21.3.4.3 scan primitives. `Scan` is a pure value-layer parser;
   // `PeekBuffered` / `AdvanceFd` are the file-side bytes-and-position
   // operations a `$fscanf` lowering composes with `Scan`.
@@ -183,8 +185,11 @@ enum class BuiltinFn : std::uint16_t {
   kRealTime,
   // LRM 20.2 simulation termination. Takes the engine handle and the LRM
   // diagnostic level (0 / 1 / 2). The call suspends and never resumes; the
-  // engine drops the process at the next dispatch.
+  // engine drops the process at the next dispatch. `kFatalFinish` is the
+  // $fatal sibling (LRM 20.10): same shutdown protocol, but marks the
+  // termination as a fatal error so the engine returns a non-zero exit code.
   kFinish,
+  kFatalFinish,
   // Resolves an `ExternUp<T>` member into a borrowed pointer to the
   // observable cell it currently refers to. Used by sensitivity-leaf
   // lowering so the wait expression carries an explicit observable handle

--- a/include/lyra/support/system_subroutine.hpp
+++ b/include/lyra/support/system_subroutine.hpp
@@ -817,6 +817,17 @@ inline constexpr std::array kSystemSubroutines = {
         .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 0},
         .semantic = PrintTimescaleSystemSubroutineInfo{},
     },
+    SystemSubroutineDesc{
+        .id = SystemSubroutineId{53},
+        .name = "$fatal",
+        .origin = SystemSubroutineOrigin::kLanguageBuiltin,
+        .kind = SystemSubroutineKind::kFunction,
+        .result_conv = ReturnConvention::kVoid,
+        .arg_policy = ArgCountPolicy{.min_args = 0, .max_args = 255},
+        .semantic =
+            DiagnosticSystemSubroutineInfo{.builtin_fn = BuiltinFn::kEmitFatal},
+        .suspends = true,
+    },
 };
 
 }  // namespace detail

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -671,6 +671,8 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "EmitWarning";
     case support::BuiltinFn::kEmitError:
       return "EmitError";
+    case support::BuiltinFn::kEmitFatal:
+      return "EmitFatal";
     case support::BuiltinFn::kScan:
       return "Scan";
     case support::BuiltinFn::kPeekBuffered:
@@ -815,6 +817,8 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "RealTimeInUnit";
     case support::BuiltinFn::kFinish:
       return "Finish";
+    case support::BuiltinFn::kFatalFinish:
+      return "FatalFinish";
     case support::BuiltinFn::kAsObservable:
       return "AsObservable";
     case support::BuiltinFn::kRegisterSignal:
@@ -871,6 +875,7 @@ auto BuiltinFnCppNamespace(support::BuiltinFn id) -> std::string_view {
     case support::BuiltinFn::kSTime:
     case support::BuiltinFn::kRealTime:
     case support::BuiltinFn::kFinish:
+    case support::BuiltinFn::kFatalFinish:
       return "lyra::runtime";
     default:
       return "";

--- a/src/lyra/lowering/hir_to_mir/expression/system/diagnostic.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/diagnostic.cpp
@@ -2,17 +2,25 @@
 
 #include <cstdint>
 #include <expected>
+#include <optional>
 #include <string>
 #include <utility>
+#include <variant>
 
+#include "lyra/base/internal_error.hpp"
+#include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
+#include "lyra/hir/integral_constant.hpp"
+#include "lyra/hir/primary.hpp"
+#include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/print_items.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
+#include "lyra/mir/stmt.hpp"
 #include "lyra/support/builtin_fn.hpp"
 #include "lyra/support/system_subroutine.hpp"
 
@@ -40,18 +48,59 @@ auto BuildOriginStringExpr(
           .type = string_type});
 }
 
+auto TryExtractLiteralInt(const hir::Expr& expr)
+    -> std::optional<std::int64_t> {
+  const auto* primary = std::get_if<hir::PrimaryExpr>(&expr.data);
+  if (primary == nullptr) return std::nullopt;
+  const auto* lit = std::get_if<hir::IntegerLiteral>(&primary->data);
+  if (lit == nullptr) return std::nullopt;
+  const auto& c = lit->value;
+  if (c.state_kind == hir::IntegralStateKind::kFourState) return std::nullopt;
+  if (c.value_words.empty()) return 0;
+  return static_cast<std::int64_t>(c.value_words[0]);
+}
+
 }  // namespace
 
 auto LowerDiagnosticSystemSubroutineCall(
     ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& call,
     const support::DiagnosticSystemSubroutineInfo& info, diag::SourceSpan span)
     -> diag::Result<mir::Expr> {
-  // $info / $warning / $error format their items with decimal as the bare-arg
-  // default radix (LRM 20.10 / 21.2.1.4), then route through the diagnostic
-  // dispatcher rather than a print sink. The call's source span becomes the
-  // origin tag the dispatcher prepends and uses as its per-site dedup key.
+  // $info / $warning / $error / $fatal format their items with decimal as the
+  // bare-arg default radix (LRM 20.10 / 21.2.1.4), then route through the
+  // diagnostic dispatcher rather than a print sink. The call's source span
+  // becomes the origin tag the dispatcher prepends and uses as its per-site
+  // dedup key. $fatal additionally consumes its first argument as the
+  // `finish_number` (LRM 20.2 verbosity level) and chains an implicit $finish
+  // after the EmitFatal record.
+  const bool is_fatal = info.builtin_fn == support::BuiltinFn::kEmitFatal;
+
+  // LRM 20.2 default verbosity level. Honored only by the $fatal path.
+  int finish_level = 1;
+  std::size_t items_offset = 0;
+  if (is_fatal && !call.arguments.empty()) {
+    if (!call.arguments.front().has_value()) {
+      throw InternalError("$fatal finish_number argument unexpectedly elided");
+    }
+    const hir::Expr& level_expr =
+        process.HirBody().exprs.Get(*call.arguments.front());
+    const auto literal = TryExtractLiteralInt(level_expr);
+    if (!literal.has_value()) {
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "$fatal first argument (finish_number) must be an integer literal");
+    }
+    if (*literal != 0 && *literal != 1 && *literal != 2) {
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          "$fatal finish_number must be 0, 1, or 2");
+    }
+    finish_level = static_cast<int>(*literal);
+    items_offset = 1;
+  }
+
   auto items_or = BuildRuntimePrintItemsFromCallArgs(
-      process, frame, call, support::PrintRadix::kDecimal, 0,
+      process, frame, call, support::PrintRadix::kDecimal, items_offset,
       FormatStringRequirement::kOptional, span);
   if (!items_or) return std::unexpected(std::move(items_or.error()));
 
@@ -77,11 +126,34 @@ auto LowerDiagnosticSystemSubroutineCall(
   const mir::ExprId origin_id = BuildOriginStringExpr(
       unit, block,
       FormatRuntimeOriginString(span, process.Module().SourceManager()));
-  return mir::Expr{
+
+  mir::Expr emit_call{
       .data =
           mir::CallExpr{
               .callee = mir::BuiltinFnCallee{.id = info.builtin_fn},
               .arguments = {diagnostic_id, origin_id, text_id}},
+      .type = unit.builtins.void_type};
+
+  if (!is_fatal) return emit_call;
+
+  // $fatal: emit happens as its own statement, then the implicit $finish call
+  // becomes this lowering's returned expression. The caller wraps the finish
+  // call in an AwaitStmt (the descriptor sets `suspends = true`) and the two
+  // statements land in the enclosing block in source order.
+  const mir::ExprId emit_call_id = block.exprs.Add(std::move(emit_call));
+  block.AppendStmt(mir::ExprStmt{.expr = emit_call_id});
+
+  const mir::ExprId finish_services_id =
+      block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
+  const mir::ExprId level_id = block.exprs.Add(
+      mir::MakeInt32Literal(
+          unit.builtins.int32, static_cast<std::int64_t>(finish_level)));
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::FreeFnCallee{.id = support::BuiltinFn::kFatalFinish},
+              .arguments = {finish_services_id, level_id}},
       .type = unit.builtins.void_type};
 }
 

--- a/src/lyra/runtime/diagnostic.cpp
+++ b/src/lyra/runtime/diagnostic.cpp
@@ -21,6 +21,8 @@ auto SeverityText(Severity s) -> std::string_view {
       return "warning";
     case Severity::kError:
       return "error";
+    case Severity::kFatal:
+      return "fatal";
   }
   return "info";
 }
@@ -63,6 +65,15 @@ void DiagnosticDispatcher::EmitError(
   Emit(
       DiagnosticRecord{
           .severity = Severity::kError,
+          .origin = std::string{origin.View()},
+          .body = std::string{text.View()}});
+}
+
+void DiagnosticDispatcher::EmitFatal(
+    const lyra::value::String& origin, const lyra::value::String& text) {
+  Emit(
+      DiagnosticRecord{
+          .severity = Severity::kFatal,
           .origin = std::string{origin.View()},
           .body = std::string{text.View()}});
 }

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -86,7 +86,7 @@ auto Engine::Run() -> int {
 
   phase_ = SchedulerPhase::kIdle;
   stream_.Drain();
-  return 0;
+  return fatal_finish_ ? 1 : 0;
 }
 
 void Engine::EnsureReadyToRun() {
@@ -326,11 +326,15 @@ void Engine::RunProcess(CoroutineHandle handle) {
   }
 }
 
-void Engine::RequestFinish(int) {  // NOLINT(readability-named-parameter)
+void Engine::RequestFinish(
+    int,  // NOLINT(readability-named-parameter)
+    bool fatal) {
   // The LRM 20.2 `$finish` verbosity argument is validated at lowering and
   // threaded here for interface completeness, but the engine terminates
-  // regardless of its value; acting on it is a known gap.
+  // regardless of its value; acting on it is a known gap. The `fatal` flag
+  // (LRM 20.10) bumps the eventual Run() return to a non-zero exit code.
   finished_ = true;
+  if (fatal) fatal_finish_ = true;
 }
 
 void Engine::TriggerValueChange(

--- a/src/lyra/runtime/runtime_services.cpp
+++ b/src/lyra/runtime/runtime_services.cpp
@@ -77,11 +77,11 @@ void RuntimeServices::ScheduleAtTime(SimTime when, CoroutineHandle handle) {
   engine_->ScheduleAtTime(when, handle);
 }
 
-void RuntimeServices::RequestFinish(int level) {
+void RuntimeServices::RequestFinish(int level, bool fatal) {
   if (engine_ == nullptr) {
     throw InternalError("RuntimeServices::RequestFinish: no Engine bound");
   }
-  engine_->RequestFinish(level);
+  engine_->RequestFinish(level, fatal);
 }
 
 void RuntimeServices::Spawn(Coroutine coroutine) {

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -284,6 +284,8 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "realtime";
     case BuiltinFn::kFinish:
       return "finish";
+    case BuiltinFn::kFatalFinish:
+      return "fatal_finish";
     case BuiltinFn::kAsObservable:
       return "as_observable";
     case BuiltinFn::kRegisterSignal:
@@ -324,6 +326,8 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "emit_warning";
     case BuiltinFn::kEmitError:
       return "emit_error";
+    case BuiltinFn::kEmitFatal:
+      return "emit_fatal";
   }
   throw InternalError("BuiltinFnName: unknown BuiltinFn");
 }

--- a/tests/cases/cpp/fatal_basic/case.yaml
+++ b/tests/cases/cpp/fatal_basic/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.fatal_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 1
+  stdout:
+    exact: "before fatal\n"
+  stderr:
+    exact: "main.sv:4:5: fatal: \n"

--- a/tests/cases/cpp/fatal_basic/main.sv
+++ b/tests/cases/cpp/fatal_basic/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  initial begin
+    $display("before fatal");
+    $fatal;
+    $display("after fatal");
+  end
+endmodule

--- a/tests/cases/cpp/fatal_with_finish_number/case.yaml
+++ b/tests/cases/cpp/fatal_with_finish_number/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.fatal_with_finish_number
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 1
+  stdout:
+    exact: "before\n"
+  stderr:
+    exact: "main.sv:4:5: fatal: code=99\n"

--- a/tests/cases/cpp/fatal_with_finish_number/main.sv
+++ b/tests/cases/cpp/fatal_with_finish_number/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  initial begin
+    $display("before");
+    $fatal(2, "code=%0d", 99);
+    $display("after");
+  end
+endmodule


### PR DESCRIPTION
## Summary

Lands the LRM 20.10 `$fatal` system task. `$fatal` was the last entry in the diagnostic family that the prior broker refactor (#947) deferred. It now emits through the same `services.Diagnostic().EmitFatal(origin, text)` path as `$info` / `$warning` / `$error`, then chains an implicit shutdown so the engine returns a non-zero exit code per the LRM ("terminates the simulation with an error code").

## Design

The lowering sits inside the existing `LowerDiagnosticSystemSubroutineCall` and branches on `info.builtin_fn == kEmitFatal` to (1) consume `arg[0]` as the `finish_number` (validated 0/1/2, default 1), (2) start format items at `arg[1]`, (3) append the `EmitFatal` call as its own `ExprStmt`, and (4) return a `FreeFnCallee{kFatalFinish}` call as the lowering's result so the caller wraps it in the `AwaitStmt` driven by `desc.suspends = true`. The two statements land in the enclosing block in source order.

`kFatalFinish` is a new sibling of `kFinish` rather than a flag on `kFinish` so each runtime entry has one fixed behaviour, matching the severity-fixed `EmitInfo` / `EmitWarning` / `EmitError` / `EmitFatal` split. Both share a single `FinishAwaitable` implementation that threads a `fatal` bool to `Engine::RequestFinish(level, fatal)`, which sets the new `fatal_finish_` flag; `Engine::Run` now returns 1 when that flag is set.

## Testing

Two new cases under `tests/cases/cpp/`:

- `fatal_basic` -- bare `$fatal;` produces `main.sv:4:5: fatal: \n`, suspends the process (the trailing `$display` does not run), and exits 1.
- `fatal_with_finish_number` -- explicit `$fatal(2, "code=%0d", 99);` covers the verbosity-arg path and the formatted-message path.