### PR TITLE
Retire SystemSubroutineCallee from MIR

### DIFF
--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -17,7 +17,6 @@
 #include "lyra/mir/unary_op.hpp"
 #include "lyra/mir/value_ref.hpp"
 #include "lyra/support/builtin_fn.hpp"
-#include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::mir {
 
@@ -88,10 +87,6 @@ struct IncDecExpr {
   ExprId target;
 };
 
-struct SystemSubroutineCallee {
-  support::SystemSubroutineId id;
-};
-
 // Calls a compiler-recognized runtime entry whose identity is a closed-
 // namespace `support::BuiltinFn`. Instance form: `args[0]` is the value
 // receiver; remaining args are the SV arguments.
@@ -132,8 +127,8 @@ struct ClosureRef {
 struct ConstructorCallee {};
 
 using Callee = std::variant<
-    SystemSubroutineCallee, MethodRef, BuiltinFnCallee, BuiltinStaticCallee,
-    FreeFnCallee, ClosureRef, ConstructorCallee>;
+    MethodRef, BuiltinFnCallee, BuiltinStaticCallee, FreeFnCallee, ClosureRef,
+    ConstructorCallee>;
 
 struct CallExpr {
   Callee callee;

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -24,7 +24,6 @@
 #include "lyra/mir/integral_constant.hpp"
 #include "lyra/mir/type.hpp"
 #include "lyra/mir/unary_op.hpp"
-#include "lyra/support/system_subroutine.hpp"
 
 namespace lyra::backend::cpp {
 
@@ -947,97 +946,6 @@ auto RenderBuiltinStaticCall(
       BuiltinFnCppName(callee.id), args);
 }
 
-// The C++ runtime entry this backend realizes a system subroutine with. Pure
-// representation -- this backend's spelling of the stated id; a LIR -> LLVM
-// backend resolves the same id to its own entry. An id whose family is not yet
-// on the generic-call shape returns a feature diagnostic.
-auto RenderSystemSubroutineEntryName(const support::SystemSubroutineDesc& desc)
-    -> diag::Result<std::string_view> {
-  return std::visit(
-      Overloaded{
-          [](const support::TerminationSystemSubroutineInfo&)
-              -> diag::Result<std::string_view> {
-            throw InternalError(
-                "RenderSystemSubroutineEntryName: termination id reached "
-                "system subroutine render path; finish family is "
-                "BuiltinFn-routed");
-          },
-          [](const support::PrintSystemSubroutineInfo&)
-              -> diag::Result<std::string_view> {
-            throw InternalError(
-                "RenderSystemSubroutineEntryName: print id reached system "
-                "subroutine render path; print family is BuiltinFn-routed");
-          },
-          [](const support::DiagnosticSystemSubroutineInfo&)
-              -> diag::Result<std::string_view> {
-            throw InternalError(
-                "RenderSystemSubroutineEntryName: diagnostic id reached "
-                "system subroutine render path; diagnostic family is "
-                "BuiltinFn-routed");
-          },
-          [](const support::SFormatSystemSubroutineInfo&)
-              -> diag::Result<std::string_view> {
-            throw InternalError(
-                "RenderSystemSubroutineEntryName: sformat id reached system "
-                "subroutine render path; sformat family is BuiltinFn-routed");
-          },
-          [](const support::PrintTimescaleSystemSubroutineInfo&)
-              -> diag::Result<std::string_view> {
-            throw InternalError(
-                "RenderSystemSubroutineEntryName: printtimescale id reached "
-                "system subroutine render path; printtimescale lowers to a "
-                "Files().Writeln of a compile-time message");
-          },
-          [](const support::TimeFormatSystemSubroutineInfo&)
-              -> diag::Result<std::string_view> {
-            throw InternalError(
-                "RenderSystemSubroutineEntryName: timeformat id reached "
-                "system subroutine render path; timeformat family is "
-                "BuiltinFn-routed");
-          },
-          [](const support::TimeSystemSubroutineInfo&)
-              -> diag::Result<std::string_view> {
-            throw InternalError(
-                "RenderSystemSubroutineEntryName: time id reached system "
-                "subroutine render path; time family is BuiltinFn-routed");
-          },
-          [&](const auto&) -> diag::Result<std::string_view> {
-            return diag::Fail(
-                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-                std::format(
-                    "system subroutine '{}' is not yet lowered to a generic "
-                    "call",
-                    desc.name));
-          },
-      },
-      desc.semantic);
-}
-
-// A system subroutine renders as one generic call: the runtime entry name
-// followed by every argument rendered uniformly. The engine handle is not
-// injected here -- it is `arguments[0]` (a `self.Services()` expression) and
-// renders like any other argument.
-auto RenderSystemSubroutineCall(
-    const ScopeView& view, const mir::CallExpr& call,
-    const mir::SystemSubroutineCallee& callee) -> diag::Result<std::string> {
-  const support::SystemSubroutineDesc& desc =
-      support::LookupSystemSubroutine(callee.id);
-  auto name_or = RenderSystemSubroutineEntryName(desc);
-  if (!name_or) return std::unexpected(std::move(name_or.error()));
-
-  std::string out;
-  out += *name_or;
-  out += "(";
-  for (std::size_t i = 0; i < call.arguments.size(); ++i) {
-    auto arg_or = RenderExpr(view, view.Expr(call.arguments[i]));
-    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
-    if (i != 0) out += ", ";
-    out += *std::move(arg_or);
-  }
-  out += ")";
-  return out;
-}
-
 // Constructs a value of the call's result data type: `<TypeName>(args)`, the
 // type name from `RenderTypeAsCpp` (a constructor is a call whose callee is the
 // type's constructor), the arguments rendered like any other call's. A
@@ -1063,10 +971,6 @@ auto RenderCallExpr(
     -> diag::Result<std::string> {
   return std::visit(
       Overloaded{
-          [&](const mir::SystemSubroutineCallee& s)
-              -> diag::Result<std::string> {
-            return RenderSystemSubroutineCall(view, call, s);
-          },
           [&](const mir::MethodRef& ref) -> diag::Result<std::string> {
             if (ref.hops.value != 0) {
               return diag::Fail(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -381,9 +381,6 @@ class MirDumper {
   [[nodiscard]] auto FormatCallee(const Callee& callee) const -> std::string {
     return std::visit(
         Overloaded{
-            [](const SystemSubroutineCallee& s) -> std::string {
-              return std::format("SystemSubroutineCallee[id={}]", s.id.value);
-            },
             [this](const MethodRef& r) -> std::string {
               const auto& owner = ResolveScopeAtHops(r.hops.value);
               const auto& target = owner.methods.Get(r.method);


### PR DESCRIPTION
## Summary

R37 left `mir::SystemSubroutineCallee` with no producers (every SV system task now lowers through a `BuiltinFn`-routed callee) and with every variant arm of `RenderSystemSubroutineEntryName` throwing. This PR deletes the now-dead state: the struct, the variant arm, the dump arm, the render dispatch arm, and the two `RenderSystemSubroutine*` helpers (~110 lines of unreachable code).

## Design

Pure dead-code removal -- a `grep` for `SystemSubroutineCallee` returns only the declaration and its variant / dump / render consumers; no lowering pass constructs one anywhere. Removing the struct narrows `mir::Callee` from a 7-arm variant to a 6-arm one, which is the first step of R45 (Callee unification). The remaining six arms keep their identities so the structural shape of R45 -- collapsing the four "direct named" arms (`MethodRef` / `BuiltinFnCallee` / `BuiltinStaticCallee` / `FreeFnCallee`) into a single `Direct{symbol}` -- can land as its own focused review.