### PR TITLE
Render every scope callable through one method path

### DIFF
--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -138,6 +138,17 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
         DPI import is a bodyless external callable; a virtual call is an explicit call form resolved
         against the object's vtable layout.
 
+  - [x] R8f -- The scope's callables render through one backend method path. A process body and the
+        synthesized resolve / initialize lifecycle bodies join functions and tasks as one
+        `mir::MethodDecl` carrying a `MethodForm` -- a static function over an explicit `self`, or a
+        virtual instance method that overrides a runtime-base slot and reaches the scope through the
+        implicit receiver. The per-shape backend renderers collapse into one that reads the method's
+        fields (result type, name, parameters, body): `void` and the coroutine type are ordinary
+        result types, `co_return` is a body statement rather than a render-time epilogue, and the
+        receiver is spelled from the form. `mir::Process` now carries only its activation kind and
+        the body method; the two remaining backend-synthesized remnants -- process activation
+        registration and the upward-reference member initializer -- retire under R8d and R40.
+
 - [x] R9 -- AST-to-HIR migration to the class-based organization defined in
       `docs/architecture/lowering_organization.md`. The `*LoweringState` god-objects are gone;
       per-task-instance `ModuleLowerer`, `StructuralScopeLowerer`, `ProcessLowerer`, and

--- a/include/lyra/backend/cpp/scope_view.hpp
+++ b/include/lyra/backend/cpp/scope_view.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 #include "lyra/base/internal_error.hpp"
 #include "lyra/mir/block_hops.hpp"
 #include "lyra/mir/class.hpp"
@@ -29,13 +31,30 @@ class ScopeView {
   }
 
   [[nodiscard]] auto WithBlock(const mir::Block& child) const -> ScopeView {
-    return ScopeView{*unit_, *class_, child, this, class_parent_};
+    return ScopeView{*unit_, *class_,       child,
+                     this,   class_parent_, self_spelling_};
   }
 
   [[nodiscard]] auto WithClass(
       const mir::Class& child_class, const mir::Block& root_block) const
       -> ScopeView {
-    return ScopeView{*unit_, child_class, root_block, nullptr, this};
+    return ScopeView{*unit_,  child_class, root_block,
+                     nullptr, this,        self_spelling_};
+  }
+
+  // How the receiver `self` (the body's `vars[0]`, MIR invariant 11) is spelled
+  // in C++. A static method receives `self` as its first parameter, so it is
+  // spelled `self`; a virtual instance method takes the receiver implicitly, so
+  // it is spelled `this`. A nested block inherits the enclosing method's
+  // spelling.
+  [[nodiscard]] auto WithSelfSpelling(std::string_view spelling) const
+      -> ScopeView {
+    return ScopeView{*unit_,        *class_,       *block_,
+                     block_parent_, class_parent_, spelling};
+  }
+
+  [[nodiscard]] auto SelfSpelling() const -> std::string_view {
+    return self_spelling_;
   }
 
   ScopeView(const ScopeView&) = delete;
@@ -97,12 +116,13 @@ class ScopeView {
   ScopeView(
       const mir::CompilationUnit& unit, const mir::Class& cls,
       const mir::Block& block, const ScopeView* block_parent,
-      const ScopeView* class_parent)
+      const ScopeView* class_parent, std::string_view self_spelling)
       : unit_(&unit),
         class_(&cls),
         block_(&block),
         block_parent_(block_parent),
-        class_parent_(class_parent) {
+        class_parent_(class_parent),
+        self_spelling_(self_spelling) {
   }
 
   const mir::CompilationUnit* unit_;
@@ -110,6 +130,7 @@ class ScopeView {
   const mir::Block* block_;
   const ScopeView* block_parent_;
   const ScopeView* class_parent_;
+  std::string_view self_spelling_ = "self";
 };
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/mir/class.hpp
+++ b/include/lyra/mir/class.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -25,13 +26,17 @@ struct Class {
   TimeResolution time_resolution;
   base::Arena<ParamDecl, ParamId> params;
   base::Arena<MemberDecl, MemberId> members;
+  // Construction logic, run when the object is allocated. The backend's C++
+  // constructor is the allocation shell that kicks this off; an empty body
+  // needs no kickoff.
   Block constructor_block;
   // Cross-instance binding (a `ref` port aliases the child's reference member
-  // to the connected variable, LRM 23.3.3.2), run after the tree is built.
-  Block resolve_block;
+  // to the connected variable, LRM 23.3.3.2), run after the whole tree is
+  // built. Absent when the scope binds no cross-instance reference.
+  std::optional<MethodDecl> resolve;
   // Variable initializers (LRM 6.8), run after resolution so they observe bound
-  // values.
-  Block initialize_block;
+  // values. Absent when the scope has no value initializers.
+  std::optional<MethodDecl> initialize;
   base::Arena<Process, ProcessId> processes;
   base::Arena<Class, ClassId> nested_classes;
   base::Arena<MethodDecl, MethodId> methods;

--- a/include/lyra/mir/method.hpp
+++ b/include/lyra/mir/method.hpp
@@ -27,19 +27,36 @@ struct MethodParam {
   ParamDirection direction = ParamDirection::kInput;
 };
 
-// A method is a callable peer of a process: its body is a Block, the same shape
-// a process body uses. `result_type` carries the call protocol -- a coroutine
-// type for a time-consuming task (LRM 13.3), a value or void type for a
-// zero-time function (LRM 13.4) -- so the backend reads task-versus-function
-// from the result type, not a side enum. `params` names which of the body's
-// locals are formals (the rest are interior locals). Static-lifetime body
-// locals are realized as members on the enclosing class at HIR -> MIR; they do
-// not appear here.
+// How a method binds its receiver and dispatches -- a generic object-oriented
+// distinction (static function versus virtual instance method), not a C++
+// keyword. `kStatic`: the receiver `self` is the method's explicit first
+// parameter and the call is direct; this is every SystemVerilog function, task,
+// and process body. `kVirtual`: `self` is the implicit receiver and the method
+// overrides a runtime-base slot the engine calls polymorphically; this is the
+// synthesized lifecycle bodies (the resolve and initialize phases). The backend
+// reads the form to spell the receiver and the dispatch, never re-derives it.
+enum class MethodForm : std::uint8_t {
+  kStatic,
+  kVirtual,
+};
+
+// The single callable shape MIR carries: a signature plus a body. Every
+// SystemVerilog function and task, every process body, and the synthesized
+// lifecycle bodies are this one concept, distinguished only by `form` (receiver
+// binding) and by how a referencing site uses them. `result_type` carries the
+// call protocol -- a coroutine type for a time-consuming task or a process (LRM
+// 13.3), a value or void type for a zero-time function (LRM 13.4) -- so the
+// backend reads task-versus-function from the result type, not a side enum.
+// `params` names which of the body's locals are formals (the rest are interior
+// locals); the receiver `self` is `root_block.vars[0]`, not a formal here.
+// Static-lifetime body locals are realized as members on the enclosing class at
+// HIR -> MIR; they do not appear here.
 struct MethodDecl {
   std::string name;
   TypeId result_type;
   std::vector<MethodParam> params;
   Block root_block;
+  MethodForm form = MethodForm::kStatic;
 };
 
 }  // namespace lyra::mir

--- a/include/lyra/mir/process.hpp
+++ b/include/lyra/mir/process.hpp
@@ -2,9 +2,8 @@
 
 #include <compare>
 #include <cstdint>
-#include <string>
 
-#include "lyra/mir/stmt.hpp"
+#include "lyra/mir/method.hpp"
 
 namespace lyra::mir {
 
@@ -19,10 +18,14 @@ enum class ProcessKind : std::uint8_t {
   kFinal,
 };
 
+// An activation registration: the scope's constructor-time decision to run
+// `code` (a coroutine callable) at simulation start (`kInitial`) or shutdown
+// (`kFinal`, LRM 9.2.3). The kind is the lifecycle registration, not a property
+// of the callable body; `code` is an ordinary `MethodDecl` rendered like any
+// other method.
 struct Process {
   ProcessKind kind = ProcessKind::kInitial;
-  std::string name;
-  Block root_block;
+  MethodDecl code;
 };
 
 }  // namespace lyra::mir

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -3,6 +3,7 @@
 #include <format>
 #include <span>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -72,6 +73,76 @@ auto CtorParamName(std::size_t index) -> std::string {
   return "param" + std::to_string(index);
 }
 
+auto RenderMethodParam(
+    const mir::CompilationUnit& unit, const mir::Class& s,
+    const mir::MethodParam& param) -> diag::Result<std::string> {
+  auto type_or = RenderTypeAsCpp(unit, s, param.type);
+  if (!type_or) return std::unexpected(std::move(type_or.error()));
+  // An `input` formal is by value (LRM 13.5.1); a `ref` / `const ref` formal is
+  // also by value, but its `RefType` already renders as `(const) Ref<T>` so the
+  // reference value carries the aliasing (LRM 13.5.2). An `output` / `inout`
+  // formal binds the caller's writeback temp by reference (`T&`).
+  switch (param.direction) {
+    case mir::ParamDirection::kInput:
+      return *type_or + " " + param.name;
+    case mir::ParamDirection::kOutput:
+    case mir::ParamDirection::kInOut:
+      return *type_or + "& " + param.name;
+  }
+  throw InternalError("RenderMethodParam: unknown ParamDirection");
+}
+
+// The one renderer for every method. A method's declaration is rendered from
+// its fields: the result type (whose `void` and coroutine cases are ordinary
+// types, handled in `RenderTypeAsCpp`), the name, the parameters, and the body
+// (a plain statement render, including any `co_return` that is itself a body
+// statement). The `form` decides how the receiver `self` is bound: a `kStatic`
+// method takes it as an explicit first parameter and spells it `self`; a
+// `kVirtual` method takes it implicitly, spells it `this`, and overrides a
+// runtime-base slot.
+auto RenderMethod(
+    const ScopeView* parent_struct_view, const mir::CompilationUnit& unit,
+    const mir::Class& s, const mir::MethodDecl& m, std::size_t indent)
+    -> diag::Result<std::string> {
+  const bool is_static = m.form == mir::MethodForm::kStatic;
+  const ScopeView base_view =
+      (parent_struct_view == nullptr)
+          ? ScopeView::ForRoot(unit, s, m.root_block)
+          : parent_struct_view->WithClass(s, m.root_block);
+  const ScopeView body_view =
+      base_view.WithSelfSpelling(is_static ? "self" : "this");
+
+  auto ret_or = RenderTypeAsCpp(unit, s, m.result_type);
+  if (!ret_or) return std::unexpected(std::move(ret_or.error()));
+
+  std::string sig =
+      std::string(is_static ? "static auto " : "auto ") + m.name + "(";
+  bool first = true;
+  if (is_static) {
+    sig += s.name + "* self";
+    first = false;
+  }
+  for (const auto& param : m.params) {
+    auto param_or = RenderMethodParam(unit, s, param);
+    if (!param_or) return std::unexpected(std::move(param_or.error()));
+    if (!first) sig += ", ";
+    sig += *param_or;
+    first = false;
+  }
+  sig += ") -> " + *ret_or;
+  if (!is_static) {
+    sig += " override";
+  }
+
+  std::string out;
+  out += Indent(indent) + sig + " {\n";
+  auto body_or = RenderBlockStatements(body_view, indent + 1);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+  out += *body_or;
+  out += Indent(indent) + "}\n";
+  return out;
+}
+
 auto RenderConstructor(
     const ScopeView& scope_view, const mir::Class& s,
     const std::string& base_class, std::size_t indent)
@@ -90,131 +161,21 @@ auto RenderConstructor(
   }
   sig += ") : " + init_list;
 
+  // The C++ constructor is the one shape that is not an ordinary method: it has
+  // no result type and runs a member-init list before its body, so it cannot
+  // run a virtual override during construction. It is an allocation shell that
+  // forwards to the base and the param members, then kicks off the construction
+  // body -- a static worker over `self`, the same body shape every method uses.
+  // An empty body needs no kickoff.
   if (s.constructor_block.root_stmts.empty()) {
     return Indent(indent) + sig + " {}\n";
   }
   std::string out;
   out += Indent(indent) + sig + " { init(this); }\n";
-  out += Indent(indent) + "static void init(" + s.name + "* self) {\n";
-  auto rendered_or = RenderBlockStatements(scope_view, indent + 1);
-  if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
-  out += *rendered_or;
-  out += Indent(indent) + "}\n";
-  return out;
-}
-
-auto RenderResolveState(
-    const ScopeView& resolve_view, const mir::Class& s, std::size_t indent)
-    -> diag::Result<std::string> {
-  if (s.resolve_block.root_stmts.empty()) {
-    return std::string{};
-  }
-  std::string out;
-  out += Indent(indent) + "void ResolveState() override { resolve(this); }\n";
-  out += Indent(indent) + "static void resolve(" + s.name + "* self) {\n";
-  auto rendered_or = RenderBlockStatements(resolve_view, indent + 1);
-  if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
-  out += *rendered_or;
-  out += Indent(indent) + "}\n";
-  return out;
-}
-
-auto RenderInitializeState(
-    const ScopeView& init_view, const mir::Class& s, std::size_t indent)
-    -> diag::Result<std::string> {
-  if (s.initialize_block.root_stmts.empty()) {
-    return std::string{};
-  }
-  std::string out;
-  out += Indent(indent) +
-         "void InitializeState() override { init_state(this); }\n";
-  out += Indent(indent) + "static void init_state(" + s.name + "* self) {\n";
-  auto rendered_or = RenderBlockStatements(init_view, indent + 1);
-  if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
-  out += *rendered_or;
-  out += Indent(indent) + "}\n";
-  return out;
-}
-
-auto RenderProcessMethod(
-    const ScopeView* parent_struct_view, const mir::CompilationUnit& unit,
-    const mir::Class& s, const mir::Process& process, std::size_t indent)
-    -> diag::Result<std::string> {
-  const ScopeView proc_view =
-      (parent_struct_view == nullptr)
-          ? ScopeView::ForRoot(unit, s, process.root_block)
-          : parent_struct_view->WithClass(s, process.root_block);
-
-  std::string out;
-  out += Indent(indent) + "static auto " + process.name + "(" + s.name +
-         "* self) -> lyra::runtime::Coroutine {\n";
-  auto rendered_or = RenderBlockStatements(proc_view, indent + 1);
-  if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
-  out += *rendered_or;
-  out += Indent(indent + 1) + "co_return;\n";
-  out += Indent(indent) + "}\n";
-  return out;
-}
-
-// A value-returning function renders its result type; a void function or task
-// renders C++ `void`.
-auto RenderMethodResultType(
-    const mir::CompilationUnit& unit, const mir::Class& s,
-    mir::TypeId result_type) -> diag::Result<std::string> {
-  if (std::holds_alternative<mir::VoidType>(unit.GetType(result_type).data)) {
-    return std::string{"void"};
-  }
-  return RenderTypeAsCpp(unit, s, result_type);
-}
-
-auto RenderMethod(
-    const ScopeView* parent_struct_view, const mir::CompilationUnit& unit,
-    const mir::Class& s, const mir::MethodDecl& sub, std::size_t indent)
-    -> diag::Result<std::string> {
-  // The result type carries the call protocol: a coroutine type renders a
-  // `co_await`-enabled coroutine (a time-consuming task, LRM 13.3), any other
-  // type a zero-time function returning that type (LRM 13.4).
-  const bool is_coroutine = std::holds_alternative<mir::CoroutineType>(
-      unit.GetType(sub.result_type).data);
-  auto return_or = RenderMethodResultType(unit, s, sub.result_type);
-  if (!return_or) return std::unexpected(std::move(return_or.error()));
-  const std::string return_type = *std::move(return_or);
-
-  std::string sig =
-      "static " + return_type + " " + sub.name + "(" + s.name + "* self";
-  for (const auto& param : sub.params) {
-    auto type_or = RenderTypeAsCpp(unit, s, param.type);
-    if (!type_or) return std::unexpected(std::move(type_or.error()));
-    sig += ", ";
-    // An `input` formal is by value (LRM 13.5.1); a `ref` / `const ref` formal
-    // is also passed by value, but its type is a `RefType` so `*type_or` is
-    // already `(const) lyra::runtime::Ref<T>` (LRM 13.5.2). An `output` /
-    // `inout` formal binds the caller's writeback temp by reference (`T&`).
-    switch (param.direction) {
-      case mir::ParamDirection::kInput:
-        sig += *type_or + " " + param.name;
-        break;
-      case mir::ParamDirection::kOutput:
-      case mir::ParamDirection::kInOut:
-        sig += *type_or + "& " + param.name;
-        break;
-    }
-  }
-  sig += ")";
-
-  const ScopeView sub_view =
-      parent_struct_view == nullptr
-          ? ScopeView::ForRoot(unit, s, sub.root_block)
-          : parent_struct_view->WithClass(s, sub.root_block);
-
-  std::string out;
-  out += Indent(indent) + sig + " {\n";
-  auto rendered_or = RenderBlockStatements(sub_view, indent + 1);
-  if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
-  out += *rendered_or;
-  if (is_coroutine) {
-    out += Indent(indent + 1) + "co_return;\n";
-  }
+  out += Indent(indent) + "static auto init(" + s.name + "* self) -> void {\n";
+  auto body_or = RenderBlockStatements(scope_view, indent + 1);
+  if (!body_or) return std::unexpected(std::move(body_or.error()));
+  out += *body_or;
   out += Indent(indent) + "}\n";
   return out;
 }
@@ -229,13 +190,16 @@ auto RenderProcessKindLiteral(mir::ProcessKind kind) -> std::string {
   throw InternalError("RenderProcessKindLiteral: unknown ProcessKind");
 }
 
+// Process activation: the constructor-time registration of each process body
+// with the engine, by lifecycle kind. The bodies themselves are ordinary
+// methods rendered by `RenderMethod`; this only wires their registration.
 auto RenderCreateProcesses(const mir::Class& s, std::size_t indent)
     -> std::string {
   std::string out;
   out += Indent(indent) + "void CreateProcesses() override {\n";
   for (const auto& p : s.processes) {
     out += Indent(indent + 1) + "AddProcess(" +
-           RenderProcessKindLiteral(p.kind) + ", " + p.name + "(this));\n";
+           RenderProcessKindLiteral(p.kind) + ", " + p.code.name + "(this));\n";
   }
   out += Indent(indent) + "}\n";
   return out;
@@ -285,30 +249,22 @@ auto RenderScopeAsClass(
   if (!ctor_or) return std::unexpected(std::move(ctor_or.error()));
   out += *ctor_or;
 
-  // Cross-instance binding (ref ports) is a separate method the engine runs
-  // after the whole tree is constructed; the constructor only allocates.
-  const ScopeView resolve_anchor =
-      (parent_struct_view == nullptr)
-          ? ScopeView::ForRoot(unit, s, s.resolve_block)
-          : parent_struct_view->WithClass(s, s.resolve_block);
-  auto resolve_or = RenderResolveState(resolve_anchor, s, indent + 1);
-  if (!resolve_or) return std::unexpected(std::move(resolve_or.error()));
-  if (!resolve_or->empty()) {
+  // The resolve and initialize phases run after construction; each is a
+  // virtual override the engine dispatches, present only when the scope has
+  // work for that phase. They render through the one method renderer.
+  if (s.resolve.has_value()) {
     out += "\n";
-    out += *resolve_or;
+    auto body_or =
+        RenderMethod(parent_struct_view, unit, s, *s.resolve, indent + 1);
+    if (!body_or) return std::unexpected(std::move(body_or.error()));
+    out += *body_or;
   }
-
-  // Variable initialization is a separate method the engine runs after the
-  // resolve phase; the constructor only allocates and registers.
-  const ScopeView init_anchor =
-      (parent_struct_view == nullptr)
-          ? ScopeView::ForRoot(unit, s, s.initialize_block)
-          : parent_struct_view->WithClass(s, s.initialize_block);
-  auto init_or = RenderInitializeState(init_anchor, s, indent + 1);
-  if (!init_or) return std::unexpected(std::move(init_or.error()));
-  if (!init_or->empty()) {
+  if (s.initialize.has_value()) {
     out += "\n";
-    out += *init_or;
+    auto body_or =
+        RenderMethod(parent_struct_view, unit, s, *s.initialize, indent + 1);
+    if (!body_or) return std::unexpected(std::move(body_or.error()));
+    out += *body_or;
   }
 
   // Child links are registered automatically at construction and walked by the
@@ -355,17 +311,17 @@ auto RenderScopeAsClass(
 
   for (const auto& p : s.processes) {
     out += "\n";
-    auto method_or =
-        RenderProcessMethod(parent_struct_view, unit, s, p, indent + 1);
-    if (!method_or) return std::unexpected(std::move(method_or.error()));
-    out += *method_or;
+    auto body_or =
+        RenderMethod(parent_struct_view, unit, s, p.code, indent + 1);
+    if (!body_or) return std::unexpected(std::move(body_or.error()));
+    out += *body_or;
   }
 
   for (const auto& sub : s.methods) {
     out += "\n";
-    auto method_or = RenderMethod(parent_struct_view, unit, s, sub, indent + 1);
-    if (!method_or) return std::unexpected(std::move(method_or.error()));
-    out += *method_or;
+    auto body_or = RenderMethod(parent_struct_view, unit, s, sub, indent + 1);
+    if (!body_or) return std::unexpected(std::move(body_or.error()));
+    out += *body_or;
   }
 
   out += Indent(indent) + "};\n";

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -183,12 +183,20 @@ auto RenderParamExpr(const ScopeView& view, const mir::ParamRef& r)
         "cpp emit");
   }
   const std::string& name = view.Class().params.Get(r.param).name;
-  return "self->" + name;
+  return std::string(view.SelfSpelling()) + "->" + name;
 }
 
 auto LookupLocalName(const ScopeView& view, const mir::LocalRef& ref)
     -> std::string {
-  return view.BlockAtHops(ref.hops).vars.Get(ref.var).name;
+  // The receiver is the body's `vars[0]`, named `self` in MIR (invariant 11).
+  // How it spells in C++ depends on the enclosing method's form: a static
+  // method's first parameter (`self`) or a virtual method's implicit receiver
+  // (`this`).
+  const std::string& name = view.BlockAtHops(ref.hops).vars.Get(ref.var).name;
+  if (name == "self") {
+    return std::string(view.SelfSpelling());
+  }
+  return name;
 }
 
 // True iff the local holds a reference (its type is a `RefType`),

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -852,8 +852,8 @@ auto ClassLowerer::Run(
       .params = {},
       .members = {},
       .constructor_block = {},
-      .resolve_block = {},
-      .initialize_block = {},
+      .resolve = std::nullopt,
+      .initialize = std::nullopt,
       .processes = {},
       .nested_classes = {},
       .methods = {},
@@ -1091,8 +1091,27 @@ auto ClassLowerer::Run(
   if (!port_conn_r) return std::unexpected(std::move(port_conn_r.error()));
 
   mir_class.constructor_block = std::move(ctor_block);
-  mir_class.resolve_block = std::move(resolve_block);
-  mir_class.initialize_block = std::move(initialize_block);
+  // The resolve and initialize phases are synthesized callables run by the
+  // engine after construction (LRM 23.3.3.2 / 6.8): each is a virtual override
+  // the runtime base dispatches, present only when the scope has work for that
+  // phase. They reach the scope through the implicit receiver, so `self` is
+  // bound as the body's receiver rather than passed as a parameter.
+  if (!resolve_block.root_stmts.empty()) {
+    mir_class.resolve = mir::MethodDecl{
+        .name = "ResolveState",
+        .result_type = void_type,
+        .params = {},
+        .root_block = std::move(resolve_block),
+        .form = mir::MethodForm::kVirtual};
+  }
+  if (!initialize_block.root_stmts.empty()) {
+    mir_class.initialize = mir::MethodDecl{
+        .name = "InitializeState",
+        .result_type = void_type,
+        .params = {},
+        .root_block = std::move(initialize_block),
+        .form = mir::MethodForm::kVirtual};
+  }
 
   return mir_class;
 }

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -78,10 +78,16 @@ auto LowerContinuousAssign(
               .condition = std::nullopt,
               .step = {},
               .scope = body_scope_id}});
+  process_block.AppendStmt(
+      mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
   return mir::Process{
       .kind = mir::ProcessKind::kInitial,
-      .name = std::move(name),
-      .root_block = std::move(process_block)};
+      .code = mir::MethodDecl{
+          .name = std::move(name),
+          .result_type = lowerer.Module().Unit().builtins.coroutine,
+          .params = {},
+          .root_block = std::move(process_block),
+          .form = mir::MethodForm::kStatic}};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -245,10 +245,18 @@ auto LowerStraightLineProcess(ProcessLowerer& process, mir::ProcessKind kind)
                                    .WithCoroutineBody(true);
   auto lowered = LowerStraightLineBodyInto(process, body_frame);
   if (!lowered) return std::unexpected(std::move(lowered.error()));
+  // A process is a coroutine; it completes by falling off its end through
+  // `co_return`, a real body statement (LRM 9.2).
+  process_block.AppendStmt(
+      mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
   return mir::Process{
       .kind = kind,
-      .name = std::string{process.CallableName()},
-      .root_block = std::move(process_block)};
+      .code = mir::MethodDecl{
+          .name = std::string{process.CallableName()},
+          .result_type = process.Module().Unit().builtins.coroutine,
+          .params = {},
+          .root_block = std::move(process_block),
+          .form = mir::MethodForm::kStatic}};
 }
 
 // Wraps the body in a `forever` loop. `implicit_sensitivity`, if present,
@@ -289,10 +297,16 @@ auto LowerForeverProcess(
               .condition = std::nullopt,
               .step = {},
               .scope = body_scope_id}});
+  process_block.AppendStmt(
+      mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
   return mir::Process{
       .kind = mir::ProcessKind::kInitial,
-      .name = std::string{process.CallableName()},
-      .root_block = std::move(process_block)};
+      .code = mir::MethodDecl{
+          .name = std::string{process.CallableName()},
+          .result_type = process.Module().Unit().builtins.coroutine,
+          .params = {},
+          .root_block = std::move(process_block),
+          .form = mir::MethodForm::kStatic}};
 }
 
 auto LowerParamDirection(hir::ParamDirection dir) -> mir::ParamDirection {
@@ -415,13 +429,20 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
         mir::ReturnStmt{
             .value = result_read,
             .is_coroutine_return = body_frame.is_coroutine_body});
+  } else if (body_is_coroutine) {
+    // A task is a coroutine with no result value: it completes by falling off
+    // its end through `co_return` (LRM 13.3). The completion is a real body
+    // statement, not a backend-appended epilogue.
+    body_block.AppendStmt(
+        mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
   }
 
   return mir::MethodDecl{
       .name = src.name,
       .result_type = result_type,
       .params = std::move(params),
-      .root_block = std::move(body_block)};
+      .root_block = std::move(body_block),
+      .form = mir::MethodForm::kStatic};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -687,15 +687,19 @@ class MirDumper {
     DumpBlock(s.constructor_block);
     Dedent();
 
-    Line("Resolve:");
-    Indent();
-    DumpBlock(s.resolve_block);
-    Dedent();
+    if (s.resolve.has_value()) {
+      Line("Resolve:");
+      Indent();
+      DumpMethod(*s.resolve, 0);
+      Dedent();
+    }
 
-    Line("Initialize:");
-    Indent();
-    DumpBlock(s.initialize_block);
-    Dedent();
+    if (s.initialize.has_value()) {
+      Line("Initialize:");
+      Indent();
+      DumpMethod(*s.initialize, 0);
+      Dedent();
+    }
 
     Line("Processes:");
     Indent();
@@ -709,11 +713,9 @@ class MirDumper {
   }
 
   void DumpProcess(const Process& p, std::size_t index) {
-    Line(
-        std::format(
-            "Process[{}] {} name={}", index, FormatProcessKind(p), p.name));
+    Line(std::format("Process[{}] {}", index, FormatProcessKind(p)));
     Indent();
-    DumpBlock(p.root_block);
+    DumpMethod(p.code, index);
     Dedent();
   }
 
@@ -730,10 +732,22 @@ class MirDumper {
     throw InternalError("FormatParamDirection: unknown mir::ParamDirection");
   }
 
+  [[nodiscard]] static auto FormatMethodForm(MethodForm form)
+      -> std::string_view {
+    switch (form) {
+      case MethodForm::kStatic:
+        return "static";
+      case MethodForm::kVirtual:
+        return "virtual";
+    }
+    throw InternalError("FormatMethodForm: unknown mir::MethodForm");
+  }
+
   void DumpMethod(const MethodDecl& d, std::size_t index) {
     Line(
         std::format(
-            "[{}] \"{}\" : Type[{}]", index, d.name, d.result_type.value));
+            "[{}] {} \"{}\" : Type[{}]", index, FormatMethodForm(d.form),
+            d.name, d.result_type.value));
     Indent();
     for (std::size_t i = 0; i < d.params.size(); ++i) {
       const auto& param = d.params[i];

--- a/tests/cases/cpp/hierarchy_generate_deferred_check/case.yaml
+++ b/tests/cases/cpp/hierarchy_generate_deferred_check/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stderr:
-    exact: "warning: unique check failed: matched 3 of 3 conditions\n"
+    exact: "main.sv:6:7: warning: unique check failed: matched 3 of 3 conditions\n"

--- a/tests/cases/cpp/priority_case_violation_no_match/case.yaml
+++ b/tests/cases/cpp/priority_case_violation_no_match/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stderr:
-    exact: "warning: priority check failed: no condition matched\n"
+    exact: "main.sv:5:5: warning: priority check failed: no condition matched\n"

--- a/tests/cases/cpp/priority_if_violation_no_match/case.yaml
+++ b/tests/cases/cpp/priority_if_violation_no_match/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stderr:
-    exact: "warning: priority check failed: no condition matched\n"
+    exact: "main.sv:5:5: warning: priority check failed: no condition matched\n"

--- a/tests/cases/cpp/unique0_if_violation_multi/case.yaml
+++ b/tests/cases/cpp/unique0_if_violation_multi/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stderr:
-    exact: "warning: unique0 check failed: matched 2 of 2 conditions\n"
+    exact: "main.sv:5:5: warning: unique0 check failed: matched 2 of 2 conditions\n"

--- a/tests/cases/cpp/unique_case_violation_no_match/case.yaml
+++ b/tests/cases/cpp/unique_case_violation_no_match/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stderr:
-    exact: "warning: unique check failed: matched 0 of 2 conditions\n"
+    exact: "main.sv:5:5: warning: unique check failed: matched 0 of 2 conditions\n"

--- a/tests/cases/cpp/unique_if_violation_multi/case.yaml
+++ b/tests/cases/cpp/unique_if_violation_multi/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stderr:
-    exact: "warning: unique check failed: matched 3 of 3 conditions\n"
+    exact: "main.sv:5:5: warning: unique check failed: matched 3 of 3 conditions\n"

--- a/tests/cases/cpp/unique_if_violation_no_match/case.yaml
+++ b/tests/cases/cpp/unique_if_violation_no_match/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stderr:
-    exact: "warning: unique check failed: matched 0 of 2 conditions\n"
+    exact: "main.sv:5:5: warning: unique check failed: matched 0 of 2 conditions\n"


### PR DESCRIPTION
## Summary

This unifies how a scope's callables are represented and rendered. A process body and the synthesized resolve / initialize lifecycle bodies now join SystemVerilog functions and tasks as one `mir::MethodDecl`, distinguished by a new `MethodForm`: a static function over an explicit `self`, or a virtual instance method that overrides a runtime-base slot and reaches the scope through the implicit receiver. The five per-shape backend renderers collapse into a single `RenderMethod` driven entirely by the method's fields -- result type, name, parameters, and body. `void` and the coroutine type are ordinary result types resolved through `RenderTypeAsCpp` (no result-type special-casing), `co_return` is lowered as a real body statement at HIR-to-MIR rather than appended at render time, and the receiver is spelled `self` or `this` from the form via the `ScopeView` walk position.

This is the backend-rebase and callable-body-unification slice of R8 (`docs/decisions/unified-callable-model.md`), tracked as R8f. It is behavior-neutral. `mir::Process` now carries only its activation kind and the body method; dissolving that activation registration into constructor-time code (R8d) and lifting the upward-reference member initializer into MIR (R40) are the two backend-synthesized remnants this leaves, both already tracked.

## Testing

`bazel test //...` passes. The deferred-check violation test expectations (priority / unique / unique0, if / case, generate) were updated to carry the diagnostic location prefix that the diagnostic rework on main added but had not yet been applied to that test family.