### PR TITLE
Gate detached-fork borrow of an enclosing automatic

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -56,6 +56,10 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
   constructor-scope statement.
 - [variable-lifetime-storage](variable-lifetime-storage.md) -- storage of static-lifetime body
   locals.
+- [lifetime-extended-automatic-scope](lifetime-extended-automatic-scope.md) -- an automatic scope
+  borrowed by a process that may outlive it is realized as a shared-owned activation object
+  (`PointerType{kShared}`'s first producer); a borrowed capture carries place identity (`Ref<T>`)
+  and lifetime authority (`Shared<activation>`) separately.
 - [read-set-inference](read-set-inference.md) -- read-set inference via slang flow analysis.
 - [runtime-effects-as-generic-calls](runtime-effects-as-generic-calls.md) -- runtime effects
   (`$display`, `$finish`, file IO) lower to ordinary `CallExpr` with the engine handle as one

--- a/docs/decisions/lifetime-extended-automatic-scope.md
+++ b/docs/decisions/lifetime-extended-automatic-scope.md
@@ -1,0 +1,155 @@
+# Lifetime-extended automatic scope storage
+
+Date: 2026-06-24 Status: accepted
+
+## Context
+
+A `fork ... join_none` (or `join_any`) branch is a concurrent process that can keep running after
+the process / task that spawned it has returned. SystemVerilog LRM 6.21 says: "The lifetime of a
+fork-join block shall encompass the execution of all processes spawned by the block. The lifetime of
+a scope enclosing any fork-join block includes the lifetime of the fork-join block." So an automatic
+variable of the enclosing scope must stay alive for the spawned branch to read or write it -- even
+after the enclosing activation has returned.
+
+In a value-semantic, no-GC compiler whose procedural automatic locals are plain locals in a C++
+coroutine frame, that storage dies when the frame returns; a by-reference capture into the branch
+would then dangle.
+
+[`variable-lifetime-storage`](variable-lifetime-storage.md) already settled the adjacent cases:
+
+- A **bare** declaration (`int x;`, no keyword) resolves to static lifetime and is realized as a
+  per-instance member -- persistent, so a detached branch reading it is already safe.
+- A **fork-scope** loop local is by-value snapshotted into each branch.
+
+It left one case unhandled: an **explicitly `automatic`** local declared in the _enclosing_ scope
+and captured **by reference** by a **detached** branch. It rejected the two mechanisms that would
+handle it -- escape-boxing ("adds a refcount / heap mechanism and ... fights the frontend: it only
+helps if bare stays a per-activation local, which contradicts the resolved static lifetime") and
+keep-the- frame-alive ("semantically wrong: it pins what is an automatic, activation-scoped frame
+and uses it to imitate static"). This decision revisits those rejections for the
+explicitly-automatic case.
+
+Two facts make the revision clean:
+
+1. **Lifetime-extended automatic is not static.** A static local is one shared cell per instance,
+   initialized once, persisting across activations. A lifetime-extended automatic gets a fresh,
+   re-initialized storage per activation; only its _destruction_ is deferred until the spawned
+   branches that borrow it finish. The "fights the frontend / imitate static" objection is about
+   _bare_ locals (which the frontend makes static, so boxing is pointless). For an explicit
+   `automatic`, the variable genuinely _is_ per-activation, so the objection does not apply.
+
+2. **MIR already reserves the ownership mode.** A one-level indirection is
+   `PointerType{pointee, ownership}` with `ownership ::= kUnique | kShared | kBorrowed`; plus a
+   non-owning `RefType` value alias. `kUnique` (owned child instances), `kBorrowed` (`self`), and
+   `RefType` (`ref` formals, by-reference captures) have producers; `kShared` already renders to
+   `std::shared_ptr<T>` but has no producer yet. Shared ownership is an anticipated mode awaiting
+   its first consumer, not a new primitive.
+
+## Decision
+
+**An automatic lexical scope that may be borrowed by a process able to outlive it is realized as an
+explicit, shared-owned activation object rather than as coroutine-frame locals. A borrowed closure
+capture carries two independent things: a place identity and a lifetime authority.**
+
+- **Place identity** is `RefType` (`Ref<T>`): how the body reads and writes the cell. Unchanged.
+- **Lifetime authority** is `PointerType{kShared}` (a shared handle to the activation object): why
+  the cell is still alive. This is the first producer of `kShared`.
+
+The model in detail:
+
+- **Granularity is the lexical automatic scope** -- a begin-end block of automatics, or a task body
+  -- not a single variable, and not automatically the whole task frame. When such a scope has a
+  detached borrowed descendant, the **entire** scope's slots are promoted into one activation
+  object. Promoting the whole scope (rather than only the escaping variable) keeps every reference
+  to a slot resolving to one logical cell, so a parent write and a branch read can never target
+  different backing. A nested automatic block whose lifetime differs gets its own activation owner.
+
+- **The lease is an owned capture field, propagated by the capture layer.** A borrowing branch holds
+  the activation's shared handle as one more owned field on its closure, alongside the `Ref<T>`
+  place fields. Capture resolution forwards the lifetime authority together with the place,
+  transitively through nested closures -- the lease propagates exactly as the place does (place:
+  scope -> outer branch -> inner branch; lease: activation -> outer branch -> inner branch). Their
+  dedup keys differ: a place dedups by visible-binding identity, a lease dedups by **activation
+  identity** -- a branch that borrows several locals of one promoted scope holds **one** lease, not
+  one per variable.
+
+- **Lease lifetime is creation-to-terminal-disposal.** A branch acquires the lease when its closure
+  is constructed (before the parent can return; acquiring a lease does not read the cell, so the
+  branch still observes parent writes made after the fork). It releases the lease when the branch
+  becomes terminally unable to run again -- normal completion, `disable fork`, named-block disable,
+  `$finish` teardown, or any path that destroys the branch process. Because the lease lives as a
+  field of the branch's coroutine frame, this release is RAII: destroying the frame by any path
+  drops the handle, and the activation is freed when the last holder drops.
+
+- **`join_any` needs no special ownership rule.** A completed branch releases its lease; remaining
+  branches keep theirs; the parent may proceed and release its own; the activation survives exactly
+  while any dependent branch retains it.
+
+- **Shared-owned values are constructed by a generic MIR operation**, parallel to the `kUnique`
+  owned-object construction, not by a backend-only `make_shared` trick. Scope-activation lowering is
+  its first producer; the construction story is general so a future consumer reuses it.
+
+- **The ownership graph is a refcounted DAG; no tracing GC.** The invariant that keeps it acyclic:
+  the scheduler owns process objects; a process closure owns its `Shared<activation>` leases; an
+  activation owns **only data slots** -- never a process, a closure, or a join group. The join group
+  stays a pure synchronization object and never owns scope storage, so no
+  `activation -> process -> activation` cycle can form.
+
+The implementation surface is minimal now: the activation object and its lease for the detached-fork
+case. The `kShared` ownership contract is general (a copyable handle that retains on copy, releases
+on destruction, has stable identity, and yields borrowed access) so the mode is not fork-specific,
+but no broad "every runtime object is shared" facility is built ahead of a second consumer.
+
+## Rejected alternatives
+
+- **By-value snapshot at spawn.** Silently diverges from LRM 6.21: if the parent mutates the local
+  after spawning (LRM 9.3.2 starts the branch only once the parent blocks or terminates, by which
+  time the parent may have written the cell), or if two branches share a mutable local, a spawn-time
+  snapshot reads a stale or unshared value. Wrong answers, not a crash.
+
+- **Per-variable boxing.** Promoting only the escaping local risks split-brain storage -- the parent
+  keeps writing the frame slot while the branch reads the box -- and spreads the storage decision
+  across every read, write, reference-construction, and projection of that local. Per-scope
+  promotion keeps one backing per slot.
+
+- **Keep the C++ coroutine frame alive.** Ties SV lifetime correctness to the C++ compiler's
+  coroutine-frame placement, is not portable to a non-coroutine backend, and conflates the SV
+  activation storage with the implementation frame. The activation is an explicit Lyra runtime
+  object instead.
+
+- **The join group owns the scope storage.** Would let an activation be reached through the join
+  group that retains the branches that retain the activation -- the cycle the DAG invariant forbids
+  -- and composes poorly when one branch borrows from several unrelated activations. Closure-held
+  leases compose; the join group stays a synchronization object.
+
+## Consequences
+
+- The detached-borrow-of-enclosing-automatic case (LRM 6.21) is supported; the `unsupported`
+  diagnostic Lyra emits for it is removed once the mechanism lands.
+- A nested fork whose inner branch reaches an outer branch's automatic is no longer a separate
+  problem: the lease propagates transitively exactly as the borrowed place does.
+- `kShared` gains its first producer. The general shared-ownership contract this establishes is
+  available to later consumers (e.g. dynamically allocated, reference-counted runtime objects);
+  cycle collection, if a future consumer needs it, is a separate decision revisited against that
+  consumer's semantics, not assumed here.
+- Only a scope with a detached borrowed descendant is promoted; the common path keeps frame locals,
+  so ordinary procedural code is unchanged. A read or write in a promoted scope carries one pointer
+  indirection.
+- Backend proof obligations the mechanism must satisfy: every reference to a promoted local -- read,
+  write, reference-construction, and member / index projection -- resolves to the activation field,
+  not a bare name; local declarations preserve their initialization order and side effects when
+  realized as activation fields; an activation destroys its fields when the last lease drops, not
+  when the parent returns; and no generated helper, capture wiring, system-task lowering, or debug
+  mapping emits a promoted local's bare name outside the single resolution path.
+
+## Cross-references
+
+- [`variable-lifetime-storage`](variable-lifetime-storage.md) -- settled the bare/static and
+  fork-scope cases; this decision revises its rejection of escape-boxing and frame-retention for the
+  explicitly-automatic case.
+- `architecture/closure.md` -- a capture is an owned field whose type carries its semantics; the
+  lease is an owned field of type `PointerType{kShared}`, needing no new capture-kind axis.
+- `architecture/scheduling.md` -- closure capture lifetime: a lowering capturing a procedural lvalue
+  must establish the fire-before-frame-dies guarantee or refuse; this decision is the "establish the
+  guarantee" path for the detached-branch case.
+- `progress/fork-join.md` -- FJ4 and the by-reference-capture lifetime cases.

--- a/docs/progress/fork-join.md
+++ b/docs/progress/fork-join.md
@@ -47,10 +47,14 @@ long, follows from where the storage lives and how long the enclosing activation
 - Referring to a subroutine's by-reference formal argument from a `join_any` / `join_none` branch is
   illegal unless the formal is declared `ref static` (LRM 9.3.2); the frontend rejects it, so it
   never reaches lowering.
-- A branch inside a task that references the task's own procedural variable is rejected at the
-  frontend, not lowered: a task's automatic locals do not outlive the call, so a detached branch
-  could read them after the call returns. The enclosing-process case above does not have this
-  limitation because process variables are static.
+- An automatic variable owned by an enclosing activation that a branch can outlive -- a `task` /
+  method local, or an outer fork branch's block-item local reached from a nested branch -- is legal
+  (LRM 6.21 requires the lifetime of a scope enclosing a fork-join to encompass every spawned
+  branch), but Lyra does not yet extend a non-persistent activation frame to cover a detached
+  branch. A branch that by-reference aliases such a variable is therefore rejected with an
+  `unsupported` diagnostic rather than left to read freed storage. slang accepts these references;
+  the restriction is Lyra's, pending the LRM 6.21 lifetime extension. The enclosing-process and
+  module-signal cases above do not have this limitation: their storage is persistent.
 
 ## Sub-Steps
 
@@ -90,9 +94,11 @@ long, follows from where the storage lives and how long the enclosing activation
       module-scope signals (LRM 6.21); because a process variable has static lifetime, a detached
       `join_none` / `join_any` branch reaches it correctly even after the process body has
       completed. A reference to a subroutine's by-reference formal from a `join_any` / `join_none`
-      branch stays rejected unless declared `ref static`, and a branch inside a task that references
-      the task's procedural variable stays rejected at the frontend (a task's automatic locals do
-      not outlive the call).
+      branch stays rejected at the frontend unless declared `ref static`. A branch that by-reference
+      aliases an automatic variable of a non-persistent enclosing activation -- a task / method
+      local, or an outer fork branch's local from a nested branch -- is rejected with an
+      `unsupported` diagnostic, pending the LRM 6.21 lifetime extension that would keep that frame
+      alive for the branch.
 
 ### Naming
 

--- a/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
@@ -4,15 +4,22 @@
 #include <optional>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
 #include "lyra/lowering/hir_to_mir/closure_builder.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
+#include "lyra/mir/closure.hpp"
+#include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/expr.hpp"
 #include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -28,6 +35,27 @@ auto LowerJoinMode(hir::JoinMode mode) -> mir::JoinMode {
       return mir::JoinMode::kNone;
   }
   throw InternalError("LowerJoinMode: unknown hir::JoinMode");
+}
+
+// Whether a branch closure aliases an enclosing automatic cell. LRM 6.21
+// requires the scope enclosing a fork-join to keep its automatic storage alive
+// for every spawned branch; Lyra does not yet extend a non-persistent (task or
+// fork-branch) activation frame to cover a detached branch, so a branch that
+// aliases one of its locals would dangle once that frame is gone. The alias is
+// a `RefType` capture binding (LRM 6.21); a static / module variable instead
+// reaches the branch through `self` (captures[0], a pointer, never a
+// `RefType`), so persistent storage never matches.
+auto AliasesEnclosingAutomatic(
+    const mir::CompilationUnit& unit, const mir::Expr& branch) -> bool {
+  const auto& closure = std::get<mir::ClosureExpr>(branch.data);
+  for (const mir::Capture& capture : closure.captures) {
+    const mir::TypeId binding_type =
+        closure.body->vars.Get(capture.binding).type;
+    if (std::holds_alternative<mir::RefType>(unit.GetType(binding_type).data)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 }  // namespace
@@ -69,7 +97,14 @@ auto LowerForkStmt(
       return std::unexpected(std::move(lowered.error()));
     }
     closure.Body().AppendStmt(*std::move(lowered));
-    branches.push_back(fork_block.exprs.Add(closure.BuildCoroutine()));
+    mir::Expr branch_closure = closure.BuildCoroutine();
+    if (AliasesEnclosingAutomatic(process.Module().Unit(), branch_closure)) {
+      return diag::Fail(
+          branch.span, diag::DiagCode::kUnsupportedForkJoinForm,
+          "a fork-join branch by-reference capturing an enclosing automatic "
+          "variable is not yet supported (LRM 6.21)");
+    }
+    branches.push_back(fork_block.exprs.Add(std::move(branch_closure)));
   }
 
   const mir::BlockId scope_id =

--- a/tests/cases/errors/nested_fork_enclosing_automatic/case.yaml
+++ b/tests/cases/errors/nested_fork_enclosing_automatic/case.yaml
@@ -1,0 +1,17 @@
+id: errors.nested_fork_enclosing_automatic
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "fork-join branch"
+      - "automatic"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/nested_fork_enclosing_automatic/main.sv
+++ b/tests/cases/errors/nested_fork_enclosing_automatic/main.sv
@@ -1,0 +1,14 @@
+`timescale 1ns / 1ns
+module Test;
+  initial begin
+    fork
+      begin
+        automatic int outer_k = 7;
+        fork
+          #10 $display("%0d", outer_k);
+        join_none
+      end
+    join_none
+    #20;
+  end
+endmodule


### PR DESCRIPTION
## Summary

A `fork ... join_none` / `join_any` branch is a concurrent process that can outlive the task or branch that spawned it. When such a detached branch by-reference borrows an enclosing `automatic` local, the local's frame is gone by the time the branch runs, so the emitted code held a dangling reference into freed storage. SystemVerilog (LRM 6.21) actually requires the lifetime of the scope enclosing a fork-join to extend to cover every spawned branch, which Lyra does not yet implement. This change replaces the silent dangling lowering with an explicit `unsupported` diagnostic, and records the accepted decision for full support.

## Design

The diagnostic fires when a fork branch closure carries a by-reference (`RefType`) capture of an enclosing automatic; static and module storage instead reach the branch through `self` (a borrowed pointer, never a `RefType`) and are never affected. The accepted decision (`docs/decisions/lifetime-extended-automatic-scope.md`) is to realize a borrowed automatic scope as a shared-owned activation object -- the first producer of MIR's already-reserved `PointerType{kShared}` -- with a borrowed capture carrying place identity (`Ref<T>`) and lifetime authority (`Shared<activation>`) separately. This PR also corrects `docs/progress/fork-join.md`, which mislabeled the rejection as a frontend (slang) one; slang accepts these references and the restriction is Lyra's.

## Testing

Adds an error-case test (`nested_fork_enclosing_automatic`) asserting the diagnostic. Full `bazel test //...` is green.