### PR TITLE
Move Format from RuntimeServices to the value layer

### DIFF
--- a/docs/decisions/format-dispatch.md
+++ b/docs/decisions/format-dispatch.md
@@ -41,9 +41,10 @@ struct FormatArg {
 };
 ```
 
-The runtime loop calls `Format(spec, arg, ctx)` once per `PrintValueItem`; the call resolves through
-`arg.format_fn` into the right `Formatter<T>::Format` specialization. The dispatch table is the
-function pointer; there is no central catalog of formattable types.
+The value-layer format walk (`value::Format(items, time_format)`) calls `Format(spec, arg, ctx)`
+once per `PrintValueItem`; the call resolves through `arg.format_fn` into the right
+`Formatter<T>::Format` specialization. The dispatch table is the function pointer; there is no
+central catalog of formattable types.
 
 Each `Formatter<T>` declares the signature it actually needs. Formatters that consult design-wide
 context (`%t` needs `TimeFormat`, future `%m` would need the scope) take `FormatContext`; those that
@@ -93,9 +94,13 @@ struct FormatContext {
 };
 ```
 
-Runtime callers pass `&services.TimeFormat()` once per `PrintItem`-walk. Formatters that consult
-context for the requested spec kind check the relevant pointer and throw on `nullptr`; the test
-framework passes the default `{}` because its specs never reach those paths.
+The value-layer items-walk takes the `TimeFormat` by reference and builds one
+`FormatContext{&time_format}` for the whole walk. The `time_format` is reached from the Engine-owned
+record through a `TimeFormat` accessor on `services` and threaded into the walk as an explicit
+operand at lowering, rather than pulled from inside the walk -- so the format step itself holds no
+engine state. Formatters that consult context for the requested spec kind check the relevant pointer
+and throw on `nullptr`; the test framework passes the default `{}` because its specs never reach
+those paths.
 
 ### Test framework integration
 

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -507,14 +507,14 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
           `$display` lands on. The `LyraTimeFormat` and `LyraPrintTimescale` runtime free functions
           retire; the timescale runtime header is deleted.
 
-- [ ] R38 -- Move `Format` from `RuntimeServices` to the value layer. Today `services.Format(items)`
-      pulls `TimeFormat()` from engine state and runs a per-item value-format walk; the engine-state
-      pull is the only reason it lives on services rather than as a pure
-      `value::Format(items, time_format)` free function the caller threads explicitly. With R37
-      complete the pattern of "pure value ops live at `lyra::value`, engine state is reached through
-      `services`" is consistent everywhere except Format; this entry closes the exception. **Blocked
-      on R37**: once it lands and the value-layer free-function surface is the established pattern,
-      the exception closes.
+- [x] R38 -- `Format` moved from `RuntimeServices` to the value layer. The per-item value-format
+      walk is now the pure free function `value::Format(items, time_format)`; the engine's
+      `$timeformat` state is reached through a `TimeFormat` reader on `services` and threaded into
+      the call as an explicit operand at lowering, so the format step holds no engine state of its
+      own. The four format sites (`$display` family, `$info` family, `$sformat` family, the
+      deferred-check cascade) share one lowering builder that assembles the call and its
+      `TimeFormat` operand. This makes "pure value ops live at `lyra::value`, engine state is
+      reached through `services`" consistent everywhere, closing the last exception R37 left open.
 
 - [ ] R39 -- Lift the implicit `Ref<T>` access into explicit MIR calls. R12 / the
       value-type-concepts cut lifted observable-cell reads / writes / mutations into explicit

--- a/include/lyra/lowering/hir_to_mir/services_call.hpp
+++ b/include/lyra/lowering/hir_to_mir/services_call.hpp
@@ -8,6 +8,11 @@
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
 
+namespace lyra::mir {
+struct CompilationUnit;
+struct Block;
+}  // namespace lyra::mir
+
 namespace lyra::lowering::hir_to_mir {
 
 // Formats `span` as "basename:line:col" for the runtime diagnostic origin tag.
@@ -46,5 +51,18 @@ auto BuildFilesCallExpr(const ModuleLowerer& module, const WalkFrame& frame)
 // handle as the receiver of their severity-fixed Emit methods.
 auto BuildDiagnosticCallExpr(
     const ModuleLowerer& module, const WalkFrame& frame) -> mir::Expr;
+
+// Builds the format-text expression `value::Format(items,
+// services.TimeFormat())`: a value-layer free call over the print-item array
+// that yields an SV `string`, taking the engine's `$timeformat` state as an
+// explicit operand. The `TimeFormat` reader call is interned into `block` as a
+// child; the outer Format call is returned detached for the caller to intern.
+// The caller supplies `services_id` because its hop depth varies by call site
+// (a process body reads `self` directly, a deferred-check cascade body one hop
+// up). LRM 20.4.3 / 21.2.1: the `$display`, `$info`, and `$sformat` families
+// and the deferred-check cascade all format through this one path.
+auto BuildFormatCallExpr(
+    const mir::CompilationUnit& unit, mir::Block& block,
+    mir::ExprId services_id, mir::ExprId items_array) -> mir::Expr;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -34,6 +34,7 @@ struct BuiltinMirTypes {
   TypeId print_literal_item;
   TypeId print_value_item;
   TypeId format_spec;
+  TypeId time_format;
   TypeId coroutine;
 };
 
@@ -90,6 +91,9 @@ struct CompilationUnit {
             .format_spec = AddType(
                 TypeData{RuntimeLibraryType{
                     .kind = RuntimeLibraryKind::kFormatSpec}}),
+            .time_format = AddType(
+                TypeData{RuntimeLibraryType{
+                    .kind = RuntimeLibraryKind::kTimeFormat}}),
             .coroutine = TypeId{},
         } {
     // A bare coroutine yields nothing, so its completion payload is `Void`. It

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -192,6 +192,10 @@ enum class RuntimeLibraryKind : std::uint8_t {
   // acquired by `FileTable::CancellationFor(fd)` at `$fstrobe` submit time
   // and queried in the postponed-body guard.
   kChannelCancellation,
+  // LRM 20.4.3 `$timeformat` display state: `lyra::value::TimeFormat`, read by
+  // the value-layer format step for `%t` directives. Threaded into `Format` as
+  // an explicit operand from the engine's current state.
+  kTimeFormat,
 };
 
 struct RuntimeLibraryType {

--- a/include/lyra/runtime/runtime_services.hpp
+++ b/include/lyra/runtime/runtime_services.hpp
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 #include <functional>
-#include <span>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/time.hpp"
@@ -54,12 +53,6 @@ class RuntimeServices {
 
   void SubmitNba(std::function<void()> closure);
   void SubmitPostponed(std::function<void()> closure);
-
-  // Formats the SV print items into a string per their FormatSpec, honoring
-  // the engine's current $timeformat state for `%t` directives (LRM 20.4.3 /
-  // 21.2.1). Pure-value step that pairs with a separate sink write.
-  [[nodiscard]] auto Format(std::span<const value::PrintItem> items) const
-      -> value::String;
 
   void TriggerValueChange(
       Observable& observable, const EdgeClassifier& classify);

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -125,11 +125,12 @@ enum class BuiltinFn : std::uint16_t {
   kCancellationFor,
   kIsCancelled,
   // Print decomposes into a pure-value format step and a sink-write step.
-  // `Format` is a `RuntimeServices` method that walks the items, honoring
-  // the engine's `$timeformat` for `%t`, and yields an SV `string`.
-  // `Write` / `Writeln` are `FileTable` methods that emit that string to
-  // the descriptor's sink (LRM 21.2.1 / 21.3.1); the `ln` variant appends
-  // a trailing newline.
+  // `Format` is a `lyra::value` free function that walks the items and yields
+  // an SV `string`; it takes the engine's `$timeformat` state (for `%t`) as an
+  // explicit operand the caller supplies from `TimeFormat`, so the format step
+  // holds no engine state of its own. `Write` / `Writeln` are `FileTable`
+  // methods that emit that string to the descriptor's sink (LRM 21.2.1 /
+  // 21.3.1); the `ln` variant appends a trailing newline.
   kFormat,
   kWrite,
   kWriteln,
@@ -145,12 +146,14 @@ enum class BuiltinFn : std::uint16_t {
   kEmitWarning,
   kEmitError,
   kEmitFatal,
-  // LRM 20.4.3 `$timeformat` state setter / reset on `RuntimeServices`. The
+  // LRM 20.4.3 `$timeformat` display state on `RuntimeServices`. `TimeFormat`
+  // reads the current state, threaded into `Format` as the `%t` operand. The
   // setter takes the four `%t` display arguments (units power, precision,
   // suffix, minimum field width) as SV values; the reset form takes none and
-  // restores the LRM Table 20-3 defaults. Two distinct methods rather than
-  // one with arity-driven branching, mirroring the print `Write` / `Writeln`
-  // and diagnostic `EmitX` splits.
+  // restores the LRM Table 20-3 defaults. Distinct methods rather than one with
+  // arity-driven branching, mirroring the print `Write` / `Writeln` and
+  // diagnostic `EmitX` splits.
+  kTimeFormat,
   kSetTimeFormat,
   kResetTimeFormat,
   // LRM 21.3.4.3 scan primitives. `Scan` is a pure value-layer parser;

--- a/include/lyra/value/format.hpp
+++ b/include/lyra/value/format.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 #include <string>
 #include <variant>
 
@@ -231,5 +232,13 @@ struct PrintValueItem {
 };
 
 using PrintItem = std::variant<PrintLiteralItem, PrintValueItem>;
+
+// Walks the print items into one SV string per their FormatSpec, appending
+// literal items verbatim and formatting each value item through the per-arg
+// Format overload. `time_format` supplies the `$timeformat` display state `%t`
+// reads (LRM 20.4.3 / 21.2.1); the caller threads it from the engine, so this
+// step holds no engine state.
+[[nodiscard]] auto Format(
+    std::span<const PrintItem> items, const TimeFormat& time_format) -> String;
 
 }  // namespace lyra::value

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -690,6 +690,8 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "EmitError";
     case support::BuiltinFn::kEmitFatal:
       return "EmitFatal";
+    case support::BuiltinFn::kTimeFormat:
+      return "TimeFormat";
     case support::BuiltinFn::kSetTimeFormat:
       return "SetTimeFormat";
     case support::BuiltinFn::kResetTimeFormat:
@@ -890,6 +892,7 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
 auto BuiltinFnCppNamespace(support::BuiltinFn id) -> std::string_view {
   switch (id) {
     case support::BuiltinFn::kScan:
+    case support::BuiltinFn::kFormat:
       return "lyra::value";
     case support::BuiltinFn::kDelay:
     case support::BuiltinFn::kSimTime:

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -136,6 +136,8 @@ auto RenderTypeAsCpp(
                 return std::string{"lyra::value::FormatSpec"};
               case mir::RuntimeLibraryKind::kChannelCancellation:
                 return std::string{"lyra::runtime::ChannelCancellation"};
+              case mir::RuntimeLibraryKind::kTimeFormat:
+                return std::string{"lyra::value::TimeFormat"};
             }
             throw InternalError("RenderTypeAsCpp: unknown RuntimeLibraryKind");
           },

--- a/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
+++ b/src/lyra/lowering/hir_to_mir/deferred_check_cascade.cpp
@@ -150,14 +150,8 @@ auto BuildDiagnosticThenScope(
   // EmitWarning method (LRM 20.10): unique / priority deferred-check failures
   // are warning-severity by spec. The origin tag is the qualified statement's
   // source location, threaded in from the cascade entry.
-  const mir::ExprId text_id = block.exprs.Add(
-      mir::Expr{
-          .data =
-              mir::CallExpr{
-                  .callee =
-                      mir::BuiltinFnCallee{.id = support::BuiltinFn::kFormat},
-                  .arguments = {services, items_array}},
-          .type = unit.builtins.string});
+  const mir::ExprId text_id =
+      block.exprs.Add(BuildFormatCallExpr(unit, block, services, items_array));
   const mir::ExprId diagnostic_id = block.exprs.Add(
       mir::Expr{
           .data =

--- a/src/lyra/lowering/hir_to_mir/expression/system/diagnostic.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/diagnostic.cpp
@@ -114,13 +114,7 @@ auto LowerDiagnosticSystemSubroutineCall(
   const mir::ExprId services_id =
       block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
   const mir::ExprId text_id = block.exprs.Add(
-      mir::Expr{
-          .data =
-              mir::CallExpr{
-                  .callee =
-                      mir::BuiltinFnCallee{.id = support::BuiltinFn::kFormat},
-                  .arguments = {services_id, items_array}},
-          .type = unit.builtins.string});
+      BuildFormatCallExpr(unit, block, services_id, items_array));
   const mir::ExprId diagnostic_id =
       block.exprs.Add(BuildDiagnosticCallExpr(process.Module(), frame));
   const mir::ExprId origin_id = BuildOriginStringExpr(

--- a/src/lyra/lowering/hir_to_mir/expression/system/print.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/print.cpp
@@ -59,14 +59,8 @@ auto EmitFormatThenWrite(
   auto& unit = process.Module().Unit();
   const mir::ExprId services =
       block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
-  const mir::ExprId text = block.exprs.Add(
-      mir::Expr{
-          .data =
-              mir::CallExpr{
-                  .callee =
-                      mir::BuiltinFnCallee{.id = support::BuiltinFn::kFormat},
-                  .arguments = {services, items_array}},
-          .type = unit.builtins.string});
+  const mir::ExprId text =
+      block.exprs.Add(BuildFormatCallExpr(unit, block, services, items_array));
   const mir::ExprId files =
       block.exprs.Add(BuildFilesCallExpr(process.Module(), frame));
   return block.exprs.Add(

--- a/src/lyra/lowering/hir_to_mir/expression/system/sformat.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/sformat.cpp
@@ -50,12 +50,7 @@ auto BuildSFormatCallExpr(
   const mir::ExprId services_id =
       block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
 
-  return mir::Expr{
-      .data =
-          mir::CallExpr{
-              .callee = mir::BuiltinFnCallee{.id = support::BuiltinFn::kFormat},
-              .arguments = {services_id, items_array}},
-      .type = unit.builtins.string};
+  return BuildFormatCallExpr(unit, block, services_id, items_array);
 }
 
 auto RejectNonStringOutput(std::string_view name, diag::SourceSpan span)

--- a/src/lyra/lowering/hir_to_mir/services_call.cpp
+++ b/src/lyra/lowering/hir_to_mir/services_call.cpp
@@ -63,4 +63,25 @@ auto BuildDiagnosticCallExpr(
       .type = builtins.diagnostic};
 }
 
+auto BuildFormatCallExpr(
+    const mir::CompilationUnit& unit, mir::Block& block,
+    mir::ExprId services_id, mir::ExprId items_array) -> mir::Expr {
+  const auto& builtins = unit.builtins;
+  const mir::ExprId time_format_id = block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee =
+                      mir::BuiltinFnCallee{
+                          .id = support::BuiltinFn::kTimeFormat},
+                  .arguments = {services_id}},
+          .type = builtins.time_format});
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee = mir::FreeFnCallee{.id = support::BuiltinFn::kFormat},
+              .arguments = {items_array, time_format_id}},
+      .type = builtins.string};
+}
+
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -194,6 +194,8 @@ class MirDumper {
                   return "RuntimeLibrary(FormatSpec)";
                 case RuntimeLibraryKind::kChannelCancellation:
                   return "RuntimeLibrary(ChannelCancellation)";
+                case RuntimeLibraryKind::kTimeFormat:
+                  return "RuntimeLibrary(TimeFormat)";
               }
               throw InternalError("dump: unknown RuntimeLibraryKind");
             },

--- a/src/lyra/runtime/runtime_services.cpp
+++ b/src/lyra/runtime/runtime_services.cpp
@@ -2,14 +2,10 @@
 
 #include <cstdint>
 #include <functional>
-#include <span>
 #include <string>
-#include <string_view>
 #include <utility>
-#include <variant>
 
 #include "lyra/base/internal_error.hpp"
-#include "lyra/base/overloaded.hpp"
 #include "lyra/runtime/engine.hpp"
 #include "lyra/value/format.hpp"
 
@@ -27,25 +23,6 @@ void RuntimeServices::SubmitPostponed(std::function<void()> closure) {
     throw InternalError("RuntimeServices::SubmitPostponed: no Engine bound");
   }
   engine_->SubmitPostponed(std::move(closure));
-}
-
-auto RuntimeServices::Format(std::span<const value::PrintItem> items) const
-    -> value::String {
-  const value::FormatContext ctx{.time_format = &TimeFormat()};
-  std::string out;
-  for (const value::PrintItem& item : items) {
-    std::visit(
-        Overloaded{
-            [&](const value::PrintLiteralItem& lit) {
-              out.append(std::string_view{lit.data, lit.size});
-            },
-            [&](const value::PrintValueItem& v) {
-              out.append(value::Format(v.spec, v.arg, ctx));
-            },
-        },
-        item);
-  }
-  return value::String(std::move(out));
 }
 
 void RuntimeServices::TriggerValueChange(

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -328,6 +328,8 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "emit_error";
     case BuiltinFn::kEmitFatal:
       return "emit_fatal";
+    case BuiltinFn::kTimeFormat:
+      return "time_format";
     case BuiltinFn::kSetTimeFormat:
       return "set_time_format";
     case BuiltinFn::kResetTimeFormat:

--- a/src/lyra/value/format.cpp
+++ b/src/lyra/value/format.cpp
@@ -4,11 +4,14 @@
 #include <cstddef>
 #include <cstdint>
 #include <format>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/base/overloaded.hpp"
 #include "lyra/value/integral_format.hpp"
 #include "lyra/value/packed_array.hpp"
 #include "lyra/value/string.hpp"
@@ -72,6 +75,25 @@ auto PackedArrayLowWord(const PackedArray& pa) -> std::uint64_t {
 auto Format(const FormatSpec& spec, FormatArg arg, const FormatContext& ctx)
     -> std::string {
   return arg.format_fn(spec, arg.ptr, ctx);
+}
+
+auto Format(std::span<const PrintItem> items, const TimeFormat& time_format)
+    -> String {
+  const FormatContext ctx{.time_format = &time_format};
+  std::string out;
+  for (const PrintItem& item : items) {
+    std::visit(
+        Overloaded{
+            [&](const PrintLiteralItem& lit) {
+              out.append(std::string_view{lit.data, lit.size});
+            },
+            [&](const PrintValueItem& v) {
+              out.append(Format(v.spec, v.arg, ctx));
+            },
+        },
+        item);
+  }
+  return String(std::move(out));
 }
 
 auto Formatter<PackedArray>::Format(


### PR DESCRIPTION
## Summary

`Format` no longer lives on `RuntimeServices`. The per-item value-format walk is now the pure free function `value::Format(items, time_format)`, and the engine's `$timeformat` state is reached through a `TimeFormat` reader on `services` and threaded into the call as an explicit operand at lowering. The format step holds no engine state of its own, which restores the layering the rest of the runtime already follows after R37: pure value ops live at `lyra::value`, engine state is reached through `services`. This closes the last exception that file (R38) tracked.

## Design

`services.Format(items)` previously pulled `TimeFormat()` from engine state internally, which was the only reason a pure value walk lived on the engine-services object. MIR now models the dependency explicitly: a new `time_format` runtime-library type, a `kTimeFormat` reader callee on `services`, and `kFormat` as a `lyra::value` free function whose second argument is `services.TimeFormat()`. The four format sites (`$display` family, `$info` family, `$sformat` family, and the deferred-check cascade) share one lowering builder that assembles the call and its `TimeFormat` operand, replacing four inline copies.

## Testing

Behavior-neutral: the same string is produced and `%t` honors the same `$timeformat` state; verification is the existing print / diagnostic / sformat / timeformat corpus staying green. `bazel build //...` and `bazel test //...` pass; policy checks pass.