### PR TITLE
Split value conversion from pointer cast in MIR

### DIFF
--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -586,14 +586,14 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       axis. The destination type is stated on the enclosing `Expr::type`; the source type is read
       off the operand; the `(source, destination)` type pair fully determines the realization
       (integral resize / sign-handling, integral-to-real, real-to-integral, packed-to-enum,
-      pointer-to-different-pointee). Backends consult the type pair to select the emit (C++
-      chooses among `static_cast` and `lyra::value` helpers; LLVM picks `zext` / `sext` / `trunc`
-      / `fptosi` / `bitcast` / `inttoptr`). The earlier `mir::ConversionExpr` (mirroring HIR's
-      LRM-defined `ConversionKind`) and `mir::PointerCastExpr` (the backend type-erasure bridge)
-      retire; HIR's `ConversionExpr` + `ConversionKind` stay as SV vocab in HIR, and the 5 HIR
-      kinds collapse to the one MIR primitive at HIR-to-MIR. The kind axis Clang's AST carries
-      exists because Clang drives LLVM codegen directly; Lyra's MIR is a higher layer and the
-      (src, dst) type pair already names the same dispatch.
+      pointer-to-different-pointee). Backends consult the type pair to select the emit (C++ chooses
+      among `static_cast` and `lyra::value` helpers; LLVM picks `zext` / `sext` / `trunc` / `fptosi`
+      / `bitcast` / `inttoptr`). The earlier `mir::ConversionExpr` (mirroring HIR's LRM-defined
+      `ConversionKind`) and `mir::PointerCastExpr` (the backend type-erasure bridge) retire; HIR's
+      `ConversionExpr` + `ConversionKind` stay as SV vocab in HIR, and the 5 HIR kinds collapse to
+      the one MIR primitive at HIR-to-MIR. The kind axis Clang's AST carries exists because Clang
+      drives LLVM codegen directly; Lyra's MIR is a higher layer and the (src, dst) type pair
+      already names the same dispatch.
 
 - [ ] R47 -- Design the object model that SV classes need, distinct from the module / scope object.
       The MIR concept currently named a "class" is a compiled module / scope, carrying

--- a/include/lyra/lowering/hir_to_mir/cast_lowering.hpp
+++ b/include/lyra/lowering/hir_to_mir/cast_lowering.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/expr_id.hpp"
+#include "lyra/mir/stmt.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// Materializes "view `operand_id` as type `dst_type`" as a value-layer
+// `CallExpr` to the matching `lyra::value` factory: integral-to-integral
+// reshape calls `PackedArray::ConvertFrom`; the real-integral bridge nests
+// `.ToInt64()` / `.Round()` inside a `Real` ctor or `PackedArray::FromInt`;
+// packed bits and unpacked-byte arrays lift to `String::FromPackedArray` /
+// `String::FromByteArray`; cross-precision real reshape calls the
+// `RealValue<Other>` ctor; identical / same-shape inputs return the operand
+// expression unchanged. The (source, destination) type pair fully drives the
+// choice; this helper is the one place that makes it. Pointer reinterpret is
+// a structurally different operation (`mir::CastExpr`, type-level view change
+// only) and is materialized directly at its single producer, not through this
+// helper.
+//
+// `block` is the destination scope for any intermediate `ExprId` the helper
+// interns when the factory call nests an inner one.
+[[nodiscard]] auto BuildValueConversion(
+    const mir::CompilationUnit& unit, mir::Block& block, mir::ExprId operand_id,
+    mir::TypeId dst_type) -> mir::Expr;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -214,6 +214,24 @@ enum class BuiltinFn : std::uint16_t {
   kRegisterSignal,
   kGetSignal,
   kGetChild,
+  // Value-layer conversion factories. HIR-to-MIR dispatches on the (src, dst)
+  // type pair and emits a `CallExpr` to the matching factory; the C++ backend
+  // renders each as the corresponding `lyra::value::T::Method(...)` static call
+  // or instance method, with no type-driven branching. `kToInt64` is the
+  // `PackedArray` accessor that yields a host int64 (used as an inner step of
+  // the integral-to-real path); `kRound` is the `Real` / `ShortReal` accessor
+  // that rounds to int64 per LRM 6.12.1 (used as an inner step of the
+  // real-to-integral path). `kFromInt` / `kConvertFrom` are the static
+  // `PackedArray` factories that build a target-shape vector from an integer
+  // (rounded real value) or reshape another packed vector. `kFromPackedArray`
+  // / `kFromByteArray` are the static `String` factories that build a string
+  // from packed bits (LRM 6.16) or from a byte unpacked array (LRM 21.3.4.3).
+  kToInt64,
+  kRound,
+  kFromInt,
+  kConvertFrom,
+  kFromPackedArray,
+  kFromByteArray,
 };
 
 // True iff `id` is a type-namespace-qualified static call -- no receiver,
@@ -222,7 +240,9 @@ enum class BuiltinFn : std::uint16_t {
 // without re-deriving the family axis.
 [[nodiscard]] constexpr auto IsStaticBuiltinFn(BuiltinFn id) -> bool {
   return id == BuiltinFn::kEnumFirst || id == BuiltinFn::kEnumLast ||
-         id == BuiltinFn::kEnumNum;
+         id == BuiltinFn::kEnumNum || id == BuiltinFn::kFromInt ||
+         id == BuiltinFn::kConvertFrom || id == BuiltinFn::kFromPackedArray ||
+         id == BuiltinFn::kFromByteArray;
 }
 
 // True iff the function modifies its receiver argument's storage in place.

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -518,134 +518,22 @@ auto RenderConditionalExpr(const ScopeView& view, const mir::ConditionalExpr& c)
   return "(" + *cond_or + " ? " + *then_or + " : " + *else_or + ")";
 }
 
-// SV LRM 6.12.1 + 6.22: real-family conversions are a pure float-precision
-// reshape. `realtime` is a synonym for `real`, so both are `lyra::value::Real`
-// and need no conversion; only a `shortreal` <-> `real` change crosses the two
-// `RealValue` instantiations, expressed through the cross-precision ctor.
-auto RenderRealConversion(
-    std::string operand, const mir::Type& src_ty, const mir::Type& dst_ty)
-    -> std::string {
-  const bool src_is_short = src_ty.Kind() == mir::TypeKind::kShortReal;
-  const bool dst_is_short = dst_ty.Kind() == mir::TypeKind::kShortReal;
-  if (src_is_short == dst_is_short) {
-    return operand;
-  }
-  return std::format(
-      "lyra::value::{}{{{}}}", dst_is_short ? "ShortReal" : "Real", operand);
-}
-
-// Integral-to-integral conversions reshape a PackedArray to a possibly-
-// different width / signedness / state. Same-shape is pass-through (slang
-// emits spurious self-conversions). Enum endpoints layer two extra wraps on
-// top of the integral body so the C++ static type matches LRM 6.19.3's
-// explicit-cast requirement: integral -> enum wraps with the enum class's
-// converting ctor; enum -> integral slices the enum subobject into a plain
-// PackedArray for downstream template deduction.
-auto RenderIntegralConversion(
-    const ScopeView& view, mir::TypeId dst_type_id, std::string operand,
-    const mir::PackedArrayType& src_pa, const mir::PackedArrayType& dst_pa,
-    bool src_is_enum, bool dst_is_enum) -> std::string {
-  std::string body;
-  if (src_pa.BitWidth() == dst_pa.BitWidth() &&
-      src_pa.signedness == dst_pa.signedness && src_pa.atom == dst_pa.atom) {
-    body = std::move(operand);
-  } else {
-    body = std::format(
-        "lyra::value::PackedArray::ConvertFrom({}, {})", operand,
-        RenderPackedArrayCtorArgs(dst_pa));
-  }
-  if (dst_is_enum) {
-    return std::format(
-        "{}{{{}}}", RenderEnumClassName(view.Class(), dst_type_id), body);
-  }
-  if (src_is_enum) {
-    return std::format("lyra::value::PackedArray{{{}}}", body);
-  }
-  return body;
-}
-
-// LRM 6.12.1: integer-to-real implicit conversion treats X/Z bits as 0.
-// `PackedArray::ToInt64` already collapses X/Z bits to 0 (packed_array.hpp
-// docstring), so the integer value feeds `RealValue::FromInt64`. `shortreal`
-// builds a `ShortReal`; `real` and `realtime` (LRM 6.12 synonyms) build a
-// `Real`.
-auto RenderIntegralToRealConversion(
-    std::string operand, const mir::Type& dst_ty) -> std::string {
-  const auto* real_ty =
-      dst_ty.Kind() == mir::TypeKind::kShortReal ? "ShortReal" : "Real";
-  return std::format(
-      "lyra::value::{}::FromInt64(({}).ToInt64())", real_ty, operand);
-}
-
-// LRM 6.12.1: real-to-integer implicit conversion rounds the real to the
-// nearest integer with ties rounded away from zero (35.5 -> 36, -1.5 -> -2).
-// `RealValue::Round` applies that rule (via `std::llround`) and returns a
-// `long long` (>= 64 bits), which feeds `PackedArray::FromInt` to land the
-// rounded value into the destination shape. Destination widths > 64 bits would
-// need a wide-int conversion path; that is currently caught by `FromInt`'s own
-// width invariant.
-auto RenderRealToIntegralConversion(
-    std::string operand, const mir::PackedArrayType& dst_pa) -> std::string {
-  return std::format(
-      "lyra::value::PackedArray::FromInt(({}).Round(), {})", operand,
-      RenderPackedArrayCtorArgs(dst_pa));
-}
-
+// `mir::CastExpr` is a type-level view change with no runtime semantic
+// transform -- the C++ peer of `static_cast<T>(x)` and the LLVM peer of
+// `bitcast`. The destination type comes from the enclosing `Expr::type`;
+// render is a fixed function of the node kind, with no type-driven branching.
+// Every other value-shape conversion (integral resize, real <-> integral,
+// packed <-> string, real <-> real precision) is expressed upstream as a
+// `CallExpr` against a `lyra::value` factory and renders through the call
+// path.
 auto RenderCastExpr(
     const ScopeView& view, const mir::Expr& expr, const mir::CastExpr& cast)
     -> diag::Result<std::string> {
-  const auto& src_expr = view.Expr(cast.operand);
-  const auto& src_ty = view.Unit().GetType(src_expr.type);
-  const auto& dst_ty = view.Unit().GetType(expr.type);
-  auto operand_or = RenderExpr(view, src_expr);
+  auto operand_or = RenderExpr(view, view.Expr(cast.operand));
   if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-
-  // Dispatch by (source category, destination category). Each branch is one
-  // (src, dst) emit form.
-  // Pointer-to-pointer reinterpret: the runtime returns a type-erased pointer
-  // (e.g. `void*` from a by-name navigation) and the MIR re-types it at the
-  // call site. The C++ realization is a `static_cast` to the destination
-  // pointer spelling.
-  if (src_ty.Kind() == mir::TypeKind::kPointer &&
-      dst_ty.Kind() == mir::TypeKind::kPointer) {
-    auto dest_or = RenderTypeAsCpp(view.Unit(), view.Class(), expr.type);
-    if (!dest_or) return std::unexpected(std::move(dest_or.error()));
-    return "static_cast<" + *dest_or + ">(" + *std::move(operand_or) + ")";
-  }
-  if (IsRealFamilyType(src_ty) && IsRealFamilyType(dst_ty)) {
-    return RenderRealConversion(*std::move(operand_or), src_ty, dst_ty);
-  }
-  if (src_ty.IsIntegralPacked() && dst_ty.IsIntegralPacked()) {
-    return RenderIntegralConversion(
-        view, expr.type, *std::move(operand_or), src_ty.AsIntegralPacked(),
-        dst_ty.AsIntegralPacked(), src_ty.IsEnum(), dst_ty.IsEnum());
-  }
-  if (src_ty.IsIntegralPacked() && IsRealFamilyType(dst_ty)) {
-    return RenderIntegralToRealConversion(*std::move(operand_or), dst_ty);
-  }
-  if (IsRealFamilyType(src_ty) && dst_ty.IsIntegralPacked()) {
-    return RenderRealToIntegralConversion(
-        *std::move(operand_or), dst_ty.AsIntegralPacked());
-  }
-  // LRM 21.3.4.3: $sscanf unpacked-array-of-byte source lifts to string.
-  // The lowering layer inserts the cast at the call boundary, leaving this
-  // site as the single emit point.
-  if (src_ty.Kind() == mir::TypeKind::kUnpackedArray &&
-      dst_ty.Kind() == mir::TypeKind::kString) {
-    return std::format(
-        "lyra::value::String::FromByteArray({})", *std::move(operand_or));
-  }
-  // LRM 6.16: build a string value from packed bits. FromPackedArray strips
-  // every NUL, so the empty (`8'h00`) and embedded-NUL cases need no operand
-  // special-case -- the render stays a pure type map.
-  if (src_ty.IsIntegralPacked() && dst_ty.Kind() == mir::TypeKind::kString) {
-    return std::format(
-        "lyra::value::String::FromPackedArray({})", *std::move(operand_or));
-  }
-  // Identity / no-op rendering: the cast exists in MIR but the operand's
-  // already-rendered C++ matches the destination shape (e.g. a string -> string
-  // lift).
-  return *std::move(operand_or);
+  auto dest_or = RenderTypeAsCpp(view.Unit(), view.Class(), expr.type);
+  if (!dest_or) return std::unexpected(std::move(dest_or.error()));
+  return "static_cast<" + *dest_or + ">(" + *std::move(operand_or) + ")";
 }
 
 // The bare C++ identifier this backend declares the builtin fn as. One
@@ -850,6 +738,18 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "GetSignal";
     case support::BuiltinFn::kGetChild:
       return "GetChild";
+    case support::BuiltinFn::kToInt64:
+      return "ToInt64";
+    case support::BuiltinFn::kRound:
+      return "Round";
+    case support::BuiltinFn::kFromInt:
+      return "FromInt";
+    case support::BuiltinFn::kConvertFrom:
+      return "ConvertFrom";
+    case support::BuiltinFn::kFromPackedArray:
+      return "FromPackedArray";
+    case support::BuiltinFn::kFromByteArray:
+      return "FromByteArray";
     case support::BuiltinFn::kFileOpen:
       return "Open";
     case support::BuiltinFn::kFileClose:

--- a/src/lyra/lowering/hir_to_mir/cast_lowering.cpp
+++ b/src/lyra/lowering/hir_to_mir/cast_lowering.cpp
@@ -1,0 +1,216 @@
+#include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/expr_id.hpp"
+#include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type.hpp"
+#include "lyra/support/builtin_fn.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+namespace {
+
+auto IsRealFamilyKind(mir::TypeKind k) -> bool {
+  return k == mir::TypeKind::kReal || k == mir::TypeKind::kShortReal ||
+         k == mir::TypeKind::kRealTime;
+}
+
+// Three trailing operands `PackedArray::FromInt` / `ConvertFrom` consume after
+// the value: `(bit_width, is_signed, is_four_state)`. All three are
+// compile-time facts of the destination packed shape, so the lowering
+// synthesizes int literals here -- the runtime call's signature surfaces them
+// uniformly as plain integer arguments.
+void AppendPackedShapeArgs(
+    const mir::CompilationUnit& unit, mir::Block& block,
+    const mir::PackedArrayType& dst_pa, std::vector<mir::ExprId>& args) {
+  const mir::TypeId int32_type = unit.builtins.int32;
+  args.push_back(block.exprs.Add(
+      mir::MakeInt32Literal(
+          int32_type, static_cast<std::int64_t>(dst_pa.BitWidth()))));
+  args.push_back(block.exprs.Add(
+      mir::MakeInt32Literal(
+          int32_type, dst_pa.signedness == mir::Signedness::kSigned ? 1 : 0)));
+  args.push_back(block.exprs.Add(
+      mir::MakeInt32Literal(int32_type, dst_pa.IsFourState() ? 1 : 0)));
+}
+
+// `Real(operand)` / `ShortReal(operand)` invokes the explicit `RealValue`
+// converting constructor. Used both for cross-precision real reshape and as
+// the outer step of the integral-to-real bridge (Real(packed.ToInt64())).
+auto BuildRealConstructorCall(mir::ExprId operand_id, mir::TypeId dst_type)
+    -> mir::Expr {
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee = mir::ConstructorCallee{}, .arguments = {operand_id}},
+      .type = dst_type};
+}
+
+auto BuildToInt64Call(const mir::CompilationUnit& unit, mir::ExprId operand_id)
+    -> mir::Expr {
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinFnCallee{.id = support::BuiltinFn::kToInt64},
+              .arguments = {operand_id}},
+      .type = unit.builtins.int32};
+}
+
+auto BuildRoundCall(const mir::CompilationUnit& unit, mir::ExprId operand_id)
+    -> mir::Expr {
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee = mir::BuiltinFnCallee{.id = support::BuiltinFn::kRound},
+              .arguments = {operand_id}},
+      .type = unit.builtins.int32};
+}
+
+// `PackedArray::FromInt(int_value, width, signed, four_state)` -- the static
+// factory used by the real-to-integral and small-literal paths.
+auto BuildPackedArrayFromInt(
+    const mir::CompilationUnit& unit, mir::Block& block, mir::ExprId int_value,
+    const mir::PackedArrayType& dst_pa, mir::TypeId dst_type) -> mir::Expr {
+  std::vector<mir::ExprId> args{int_value};
+  AppendPackedShapeArgs(unit, block, dst_pa, args);
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinStaticCallee{
+                      .id = support::BuiltinFn::kFromInt,
+                      .type_qual = dst_type},
+              .arguments = std::move(args)},
+      .type = dst_type};
+}
+
+// `PackedArray::ConvertFrom(other, width, signed, four_state)` -- reshape a
+// packed vector to the target shape.
+auto BuildPackedArrayConvertFrom(
+    const mir::CompilationUnit& unit, mir::Block& block, mir::ExprId src_id,
+    const mir::PackedArrayType& dst_pa, mir::TypeId dst_type) -> mir::Expr {
+  std::vector<mir::ExprId> args{src_id};
+  AppendPackedShapeArgs(unit, block, dst_pa, args);
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinStaticCallee{
+                      .id = support::BuiltinFn::kConvertFrom,
+                      .type_qual = dst_type},
+              .arguments = std::move(args)},
+      .type = dst_type};
+}
+
+// `String::FromPackedArray(bits)` / `String::FromByteArray(bytes)` static
+// factories.
+auto BuildStringFromFactory(
+    const mir::CompilationUnit& unit, mir::ExprId src_id, support::BuiltinFn id)
+    -> mir::Expr {
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinStaticCallee{
+                      .id = id, .type_qual = unit.builtins.string},
+              .arguments = {src_id}},
+      .type = unit.builtins.string};
+}
+
+}  // namespace
+
+auto BuildValueConversion(
+    const mir::CompilationUnit& unit, mir::Block& block, mir::ExprId operand_id,
+    mir::TypeId dst_type) -> mir::Expr {
+  const mir::Expr& operand_expr = block.exprs.Get(operand_id);
+  const mir::TypeId src_type = operand_expr.type;
+  if (src_type == dst_type) {
+    return operand_expr;
+  }
+  const auto& src_ty = unit.GetType(src_type);
+  const auto& dst_ty = unit.GetType(dst_type);
+  const auto src_kind = src_ty.Kind();
+  const auto dst_kind = dst_ty.Kind();
+
+  // Real-family reshape (e.g. `shortreal` <-> `real`): the `RealValue<Other>`
+  // explicit converting ctor handles it; same-precision is identity.
+  if (IsRealFamilyKind(src_kind) && IsRealFamilyKind(dst_kind)) {
+    if (src_kind == dst_kind) {
+      return operand_expr;
+    }
+    return BuildRealConstructorCall(operand_id, dst_type);
+  }
+
+  // Integral -> real: read out the host int64, build the real from it.
+  if (src_ty.IsIntegralPacked() && IsRealFamilyKind(dst_kind)) {
+    const mir::ExprId int_id =
+        block.exprs.Add(BuildToInt64Call(unit, operand_id));
+    return BuildRealConstructorCall(int_id, dst_type);
+  }
+
+  // Real -> integral: round to int64, then `PackedArray::FromInt(...)` lands
+  // the rounded value into the destination shape.
+  if (IsRealFamilyKind(src_kind) && dst_ty.IsIntegralPacked()) {
+    const mir::ExprId rounded_id =
+        block.exprs.Add(BuildRoundCall(unit, operand_id));
+    return BuildPackedArrayFromInt(
+        unit, block, rounded_id, dst_ty.AsIntegralPacked(), dst_type);
+  }
+
+  // Integral -> integral: width / signedness / state reshape, with an enum
+  // wrap at either end if the LRM 6.19.3 type axis crosses the enum class
+  // boundary. The shape-change inner step is `PackedArray::ConvertFrom`; the
+  // enum-wrap outer step is a ConstructorCallee that calls the destination
+  // class's converting ctor (enum class for dst-enum, plain PackedArray for
+  // src-enum slicing).
+  if (src_ty.IsIntegralPacked() && dst_ty.IsIntegralPacked()) {
+    const auto& src_pa = src_ty.AsIntegralPacked();
+    const auto& dst_pa = dst_ty.AsIntegralPacked();
+    const bool same_shape = src_pa.BitWidth() == dst_pa.BitWidth() &&
+                            src_pa.signedness == dst_pa.signedness &&
+                            src_pa.atom == dst_pa.atom;
+    const bool src_is_enum = src_ty.IsEnum();
+    const bool dst_is_enum = dst_ty.IsEnum();
+    mir::ExprId body_id = operand_id;
+    if (!same_shape) {
+      body_id = block.exprs.Add(BuildPackedArrayConvertFrom(
+          unit, block, operand_id, dst_pa, dst_type));
+    }
+    if (dst_is_enum || src_is_enum) {
+      return mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee = mir::ConstructorCallee{}, .arguments = {body_id}},
+          .type = dst_type};
+    }
+    if (same_shape) {
+      return operand_expr;
+    }
+    return block.exprs.Get(body_id);
+  }
+
+  // Unpacked-array-of-byte -> string (LRM 21.3.4.3 $sscanf source lift).
+  if (src_kind == mir::TypeKind::kUnpackedArray &&
+      dst_kind == mir::TypeKind::kString) {
+    return BuildStringFromFactory(
+        unit, operand_id, support::BuiltinFn::kFromByteArray);
+  }
+
+  // Integral -> string (LRM 6.16 bit pattern -> string value).
+  if (src_ty.IsIntegralPacked() && dst_kind == mir::TypeKind::kString) {
+    return BuildStringFromFactory(
+        unit, operand_id, support::BuiltinFn::kFromPackedArray);
+  }
+
+  // Identity fallback: the lowering inserted a conversion the type system
+  // already satisfies (e.g. string -> string lift).
+  return operand_expr;
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -385,6 +385,8 @@ auto BuildDownwardNavValue(
                           .id = support::BuiltinFn::kGetSignal},
                   .arguments = {cur, string_literal(hops.back().name)}},
           .type = void_ptr_type});
+  // Pointer-to-pointer reinterpret of the void* slot to the typed pointer
+  // the call site expects -- the one true MIR cast (`static_cast<T>(...)`).
   return mir::Expr{
       .data = mir::CastExpr{.operand = get_signal_id}, .type = slot_type};
 }

--- a/src/lyra/lowering/hir_to_mir/copy_out_desugar.cpp
+++ b/src/lyra/lowering/hir_to_mir/copy_out_desugar.cpp
@@ -9,9 +9,9 @@
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/procedural_body.hpp"
+#include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
-#include "lyra/mir/cast.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/stmt.hpp"
@@ -56,8 +56,7 @@ auto BuildCopyOutBlock(
     mir::ExprId value_id = call_id;
     if (call_type != result_type) {
       value_id = wrapper.exprs.Add(
-          mir::Expr{
-              .data = mir::CastExpr{.operand = call_id}, .type = result_type});
+          BuildValueConversion(unit, wrapper, call_id, result_type));
     }
     const mir::Expr assign_expr = BuildObservableAssignExpr(
         unit, wrapper, services_id, *assign_target_id, value_id, std::nullopt,

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -9,13 +9,13 @@
 #include "lyra/hir/conversion.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/unary_op.hpp"
+#include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
 #include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/binary_op.hpp"
-#include "lyra/mir/cast.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/type.hpp"
@@ -223,8 +223,8 @@ auto LowerHirConversionExpr(
   }
   const mir::ExprId operand_id =
       frame.current_block->exprs.Add(*std::move(operand_or));
-  return mir::Expr{
-      .data = mir::CastExpr{.operand = operand_id}, .type = result_type};
+  return BuildValueConversion(
+      lowerer.Module().Unit(), *frame.current_block, operand_id, result_type);
 }
 
 // One concrete instantiation per pass class. The handler templates are defined

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -10,6 +10,7 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/hir/expr.hpp"
+#include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
 #include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
@@ -115,12 +116,11 @@ auto UnsignedPackedCounterpart(
 // explicit `ConversionExpr` to `final_type` when the two differ. No-op when
 // the slice already matches the consumer's MIR type.
 auto WrapSliceSignReTag(
-    mir::Block& block, mir::Expr owned, mir::TypeId slice_type,
-    mir::TypeId final_type) -> mir::Expr {
+    const mir::CompilationUnit& unit, mir::Block& block, mir::Expr owned,
+    mir::TypeId slice_type, mir::TypeId final_type) -> mir::Expr {
   if (slice_type == final_type) return owned;
   const mir::ExprId owned_id = block.exprs.Add(std::move(owned));
-  return mir::Expr{
-      .data = mir::CastExpr{.operand = owned_id}, .type = final_type};
+  return BuildValueConversion(unit, block, owned_id, final_type);
 }
 
 struct RangeLoHi {
@@ -658,7 +658,8 @@ auto LowerMemberAccessInner(
       side);
   mir::Expr owned = WrapPackedAsOwned(
       module.Unit(), block, std::move(slice_call), slice_type);
-  return WrapSliceSignReTag(block, std::move(owned), slice_type, result_type);
+  return WrapSliceSignReTag(
+      module.Unit(), block, std::move(owned), slice_type, result_type);
 }
 
 }  // namespace

--- a/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
@@ -13,6 +13,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/procedural_body.hpp"
+#include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
 #include "lyra/lowering/hir_to_mir/closure_builder.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
@@ -54,10 +55,9 @@ auto LiftStringSource(
         "unpacked array of byte (LRM 21.3.4.3)");
   }
 
-  return frame.current_block->exprs.Add(
-      mir::Expr{
-          .data = mir::CastExpr{.operand = source_id},
-          .type = module.Unit().builtins.string});
+  return frame.current_block->exprs.Add(BuildValueConversion(
+      module.Unit(), *frame.current_block, source_id,
+      module.Unit().builtins.string));
 }
 
 // LRM 21.3.4.3 permits string or integral as the format argument; the
@@ -72,10 +72,9 @@ auto LiftStringFormat(
         "LiftStringFormat: scan format is not string or integral (LRM "
         "21.3.4.3)");
   }
-  return frame.current_block->exprs.Add(
-      mir::Expr{
-          .data = mir::CastExpr{.operand = format_id},
-          .type = module.Unit().builtins.string});
+  return frame.current_block->exprs.Add(BuildValueConversion(
+      module.Unit(), *frame.current_block, format_id,
+      module.Unit().builtins.string));
 }
 
 // LRM 21.3.4.3: a source or format string that contains x or z makes

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -17,8 +17,8 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/procedural_body.hpp"
+#include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
-#include "lyra/mir/cast.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/runtime_print.hpp"
@@ -86,9 +86,9 @@ auto BuildPrintValueItem(
       value_type.Kind() != mir::TypeKind::kString &&
       !value_type.IsIntegralPacked()) {
     const mir::ExprId inner = block.exprs.Add(std::move(lowered));
-    lowered = mir::Expr{
-        .data = mir::CastExpr{.operand = inner},
-        .type = process.Module().Unit().builtins.string};
+    lowered = BuildValueConversion(
+        process.Module().Unit(), block, inner,
+        process.Module().Unit().builtins.string);
   }
 
   const mir::TypeId type = lowered.type;

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -15,6 +15,7 @@
 #include "lyra/hir/stmt.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
+#include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
 #include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/copy_out_desugar.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
@@ -26,7 +27,6 @@
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
-#include "lyra/mir/cast.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/stmt.hpp"
@@ -95,8 +95,8 @@ auto LowerDestructuringAssign(
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   mir::ExprId rhs_id = wrapper.exprs.Add(*std::move(rhs_or));
   if (wrapper.exprs.Get(rhs_id).type != temp_type) {
-    rhs_id = wrapper.exprs.Add(
-        mir::Expr{.data = mir::CastExpr{.operand = rhs_id}, .type = temp_type});
+    rhs_id = wrapper.exprs.Add(BuildValueConversion(
+        process.Module().Unit(), wrapper, rhs_id, temp_type));
   }
 
   const mir::ExprId temp_assign_target =
@@ -160,10 +160,8 @@ auto LowerDestructuringAssign(
             .type = slice_type});
     mir::ExprId rhs_for_part = slice_id;
     if (part_mir_type != slice_type) {
-      rhs_for_part = wrapper.exprs.Add(
-          mir::Expr{
-              .data = mir::CastExpr{.operand = slice_id},
-              .type = part_mir_type});
+      rhs_for_part = wrapper.exprs.Add(BuildValueConversion(
+          process.Module().Unit(), wrapper, slice_id, part_mir_type));
     }
 
     mir::ExprId per_part_expr_id{};

--- a/src/lyra/lowering/hir_to_mir/statement/loops.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/loops.cpp
@@ -10,13 +10,13 @@
 #include "lyra/base/overloaded.hpp"
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/statement/blocks.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/block_hops.hpp"
-#include "lyra/mir/cast.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/local.hpp"
@@ -182,9 +182,8 @@ auto LowerRepeatStmt(
   }
   mir::ExprId count_expr_id = wrapper.exprs.Add(*std::move(count_or));
   if (wrapper.exprs.Get(count_expr_id).type != int_type) {
-    count_expr_id = wrapper.exprs.Add(
-        mir::Expr{
-            .data = mir::CastExpr{.operand = count_expr_id}, .type = int_type});
+    count_expr_id = wrapper.exprs.Add(BuildValueConversion(
+        process.Module().Unit(), wrapper, count_expr_id, int_type));
   }
 
   const mir::LocalId count_var = wrapper.vars.Add(

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -334,6 +334,18 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "set_time_format";
     case BuiltinFn::kResetTimeFormat:
       return "reset_time_format";
+    case BuiltinFn::kToInt64:
+      return "to_int64";
+    case BuiltinFn::kRound:
+      return "round";
+    case BuiltinFn::kFromInt:
+      return "from_int";
+    case BuiltinFn::kConvertFrom:
+      return "convert_from";
+    case BuiltinFn::kFromPackedArray:
+      return "from_packed_array";
+    case BuiltinFn::kFromByteArray:
+      return "from_byte_array";
   }
   throw InternalError("BuiltinFnName: unknown BuiltinFn");
 }


### PR DESCRIPTION
## Summary

Pulls every value-shape conversion (integral resize, real <-> integral, packed <-> string, real <-> real precision) from a backend type-dispatching helper down to HIR-to-MIR, where the (source, destination) type pair is the dispatch key. The backend's `RenderCastExpr` collapses to a five-line mechanical render -- `static_cast<DstType>(operand)` -- and the four conversion render helpers (`RenderRealConversion` / `RenderIntegralConversion` / `RenderIntegralToRealConversion` / `RenderRealToIntegralConversion`) retire.

## Design

`mir::CastExpr` was carrying two conceptually distinct operations: pointer reinterpret (a true type-level view change, `static_cast<T*>(...)`) and value conversion (factory construction -- `PackedArray::FromInt(...)` and friends, which the backend rendered as method calls under the cast's coat). The render helper had to look at `(src_ty, dst_ty)` and pick which of seven realizations to emit, re-deriving a semantic decision the MIR didn't state -- a direct violation of `mir.md` invariant 10 ("a backend reads a semantic fact from a MIR node or reference; it never re-derives or re-decides one").

Splitting them removes the conflation:

- **Value conversions** lower at HIR-to-MIR through a new `BuildValueConversion` helper. The (src, dst) pair selects the right factory: integral-to-integral reshape calls `PackedArray::ConvertFrom`; the real-integral bridge nests `.ToInt64()` / `.Round()` inside a `Real` ctor or `PackedArray::FromInt`; packed bits and unpacked-byte arrays lift to `String::FromPackedArray` / `String::FromByteArray`; cross-precision real reshape calls the `RealValue<Other>` ctor. Each lowers to an ordinary `CallExpr` against a runtime factory -- six new `BuiltinFn` entries (`kToInt64`, `kRound`, `kFromInt`, `kConvertFrom`, `kFromPackedArray`, `kFromByteArray`) name the entries the runtime already exports. Backend renders them through the existing call paths with no per-call dispatch.
- **`mir::CastExpr` now represents only true type-level view change** -- currently the void* / typed-pointer reinterpret at `class_lowerer.cpp`'s `kGetSignal` call site, the one true cast in MIR vocabulary. `RenderCastExpr` is a fixed function of the node kind: render operand, render destination type, wrap.

The MIR vocabulary stays generic-software (no SV-flavored `ConversionKind` enum, no "real-to-int" kind values that leak SV semantics). The runtime library carries the "how" (factory implementations live in `lyra::value`), HIR-to-MIR carries the "which" (the dispatch decision is the lowering's job), and the backend carries the "where" (mechanical translation to C++ syntax). Three layers, three responsibilities, no overlap.

## Testing

`bazel test //...` is green. No new test cases: the existing conversion / pointer-cast coverage continues to pass against the split shape -- a strong signal because each migrated producer site exercises the same end-to-end conversion behavior.