### PR TITLE
Lift ref access onto the cell-access protocol

### DIFF
--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -516,18 +516,25 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       `TimeFormat` operand. This makes "pure value ops live at `lyra::value`, engine state is
       reached through `services`" consistent everywhere, closing the last exception R37 left open.
 
-- [ ] R39 -- Lift the implicit `Ref<T>` access into explicit MIR calls. R12 / the
-      value-type-concepts cut lifted observable-cell reads / writes / mutations into explicit
-      `BuiltinFnCallee` (`kGet` / `kSet` / `kMutate`) calls at HIR-to-MIR so the backend renders
-      them mechanically. The sibling axis -- a procedural `ref` / `const ref` formal (LRM 13.5.2),
-      whose binding kind is `ParamDirection::kRef` / `kConstRef` and whose MIR type is `RefType{T}`
-      -- is still implicit: a read of such a local is silently rendered with a `.Get()` suffix, and
-      a whole-cell write through one conjures an engine handle argument the MIR call does not carry.
-      Both are `mir.md` invariant 10 violations of the same shape the observable axis just resolved.
-      Apply the same lift: HIR-to-MIR emits `BuiltinFnCallee{kRefGet}` / `BuiltinFnCallee{kRefSet}`
-      whose argument vector is complete (services included). Compound / partial writes through a ref
-      formal become well-defined in the same step (today the render path bails). See
-      `decisions/value-type-concepts.md` for the pattern this generalizes.
+- [x] R39 -- The implicit `Ref<T>` access is lifted into explicit MIR calls, reusing the observable
+      cell protocol rather than inventing a parallel one. R12 lifted observable-cell reads / writes
+      / mutations into explicit `BuiltinFnCallee` (`kGet` / `kSet` / `kMutate`) calls at HIR-to-MIR
+      so the backend renders them mechanically. A `ref` / `const ref` formal (LRM 13.5.2) and a
+      by-reference capture (LRM 6.21) carry a `RefType` whose access -- by
+      `reference-as-data-type.md` F3 -- is the same cell protocol (read, update-event `Set`,
+      partial-write `Mutate`). The lift therefore routes through the same three callees: the callee
+      names the access; the receiver's `RefType` (vs `ObservableType`) selects `Ref<T>` vs `Var<T>`
+      at render, exactly as `builtin-call-identity.md` D3 prescribes -- no `RefType`-specific
+      callee. The root cause was a single typing asymmetry: a reference-to-a-ref-binding was typed
+      with the unwrapped value, so the auto-`kGet` wrap and the `Set` / `Mutate` write-routing
+      (which already admit every cell-type, including `RefType`) skipped it, forcing the render path
+      to re-derive ref-ness from the slot type and inject `.Get()` / a spliced engine handle -- a
+      `mir.md` invariant 10 violation. Typing the reference with its `RefType` slot makes the
+      existing lift catch it; whole writes, compound / partial writes, and increment / decrement
+      through a ref are now all well-defined (the render previously bailed on the latter two). The
+      runtime `Ref<T>` gained `Mutate`, and `ScopedMutation` now commits through a `Ref<T>` so
+      observable and reference partial writes share one handle. See
+      `decisions/value-type-concepts.md` and `decisions/reference-as-data-type.md`.
 
 - [ ] R40 -- Retire the construct- / control-stmt shapes that the backend completes from outside
       MIR. `ForkStmt`, `ConstructOwnedObjectStmt`, and `ConstructExternalUnitStmt` each name a

--- a/include/lyra/lowering/hir_to_mir/capture_sink.hpp
+++ b/include/lyra/lowering/hir_to_mir/capture_sink.hpp
@@ -61,14 +61,20 @@ class CaptureSink {
     return boundary_depth_;
   }
 
-  // Capture `var` (declared at `decl_depth`) and return the body-side reference
-  // -- a binding local to the body, read at `current_depth`.
+  // Capture `var` (declared at `decl_depth`) and return the body-side
+  // reference -- a binding local to the body, read at `current_depth`. The
+  // expr carries the binding slot's declared type: a `RefType` for a
+  // by-reference alias, the value type for a by-value snapshot, so the read
+  // lifts to the cell protocol exactly when the binding aliases live storage.
   auto Capture(
       mir::LocalId var, BlockDepth decl_depth, mir::TypeId type,
-      BlockDepth current_depth) -> mir::LocalRef {
+      BlockDepth current_depth) -> mir::Expr {
     mir::LocalId binding = FindOrCreate(var, decl_depth, type);
-    return mir::LocalRef{
-        .hops = current_depth - boundary_depth_, .var = binding};
+    return mir::Expr{
+        .data =
+            mir::LocalRef{
+                .hops = current_depth - boundary_depth_, .var = binding},
+        .type = body_->vars.Get(binding).type};
   }
 
   auto TakeRequests() -> std::vector<CaptureRequest> {

--- a/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
@@ -30,6 +30,13 @@ namespace lyra::lowering::hir_to_mir {
 struct AutomaticVarBinding {
   BlockDepth declaration_procedural_depth;
   mir::LocalId var;
+  // The slot's declared MIR type, carried here because the declaring block is
+  // not reachable while the enclosing body is still being lowered -- unlike a
+  // static var, whose member type is read live from the already-built class
+  // arena. A `ref` / `const ref` formal's slot is a `RefType`, so a reference
+  // to it lifts to the cell protocol (`kGet` / `kSet` / `kMutate`) instead of
+  // reading the unwrapped value.
+  mir::TypeId type;
 };
 
 struct StaticVarBinding {

--- a/include/lyra/mir/local.hpp
+++ b/include/lyra/mir/local.hpp
@@ -17,8 +17,9 @@ struct LocalId {
 // Static-lifetime (LRM 13.3.1) body locals do not live here -- HIR-to-MIR
 // realizes them as members on the enclosing class. A pass-by-reference
 // binding (LRM 13.5.2, a `ref` formal or a by-reference capture) carries no
-// flag here: its `type` is a `RefType`, and the backend renders reads /
-// writes through `Ref<T>` from the type alone.
+// flag here: its `type` is a `RefType`, and a reference to it lifts to the
+// cell access protocol (`kGet` / `kSet` / `kMutate`) at HIR-to-MIR, the same
+// as an observable cell.
 struct LocalDecl {
   std::string name;
   TypeId type;

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -217,6 +217,14 @@ class Ref {
     }
   }
 
+  // RAII entry to partial-write context, mirroring `Var<T>::Mutate`: the
+  // returned handle snapshots the referenced cell, forwards chain methods so a
+  // selector chain lands in the snapshot, and writes the snapshot back through
+  // `Ref::Set` in its destructor (firing subscribers when the backing is
+  // observable).
+  [[nodiscard]] auto Mutate(RuntimeServices& services) const
+      -> ScopedMutation<T>;
+
  private:
   Var<T>* signal_ = nullptr;
   T* plain_ = nullptr;
@@ -319,21 +327,22 @@ void Var<T>::Set(RuntimeServices& services, const T& new_val) {
   }
 }
 
-// RAII handle that owns a snapshot of `var.Get()` for the lifetime of one
-// partial-write expression. The destructor calls `Var::Set` with the
-// (possibly mutated) snapshot -- subscribers fire on change. Non-copyable
-// and non-movable: the contract is that it lives only until the end of the
-// constructing full expression. Returning it by value from `Var<T>::Mutate`
-// relies on C++17 mandatory copy elision (prvalues are materialized in the
-// caller's storage with no copy/move).
+// RAII handle that owns a snapshot of the referenced cell for the lifetime of
+// one partial-write expression. The destructor writes the (possibly mutated)
+// snapshot back through `Ref<T>::Set` -- subscribers fire on change when the
+// backing is observable, a raw store when it is plain. Non-copyable and
+// non-movable: the contract is that it lives only until the end of the
+// constructing full expression. Returning it by value from `Var<T>::Mutate` /
+// `Ref<T>::Mutate` relies on C++17 mandatory copy elision (prvalues are
+// materialized in the caller's storage with no copy/move).
 //
 // `operator*` is the single access point -- all chain methods, operators,
 // and selectors are reached through the deref'd T directly.
 template <value::LyraValue T>
 class ScopedMutation {
  public:
-  ScopedMutation(RuntimeServices& services, Var<T>& var)
-      : services_(&services), var_(&var), snapshot_(var.Get()) {
+  ScopedMutation(RuntimeServices& services, Ref<T> ref)
+      : services_(&services), ref_(ref), snapshot_(ref.Get()) {
   }
 
   ScopedMutation(const ScopedMutation&) = delete;
@@ -342,7 +351,7 @@ class ScopedMutation {
   auto operator=(ScopedMutation&&) -> ScopedMutation& = delete;
 
   ~ScopedMutation() {
-    var_->Set(*services_, std::move(snapshot_));
+    ref_.Set(*services_, std::move(snapshot_));
   }
 
   auto operator*() -> T& {
@@ -351,12 +360,17 @@ class ScopedMutation {
 
  private:
   RuntimeServices* services_;
-  Var<T>* var_;
+  Ref<T> ref_;
   T snapshot_;
 };
 
 template <value::LyraValue T>
 auto Var<T>::Mutate(RuntimeServices& services) -> ScopedMutation<T> {
+  return ScopedMutation<T>{services, Ref<T>{*this}};
+}
+
+template <value::LyraValue T>
+auto Ref<T>::Mutate(RuntimeServices& services) const -> ScopedMutation<T> {
   return ScopedMutation<T>{services, *this};
 }
 

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -199,16 +199,6 @@ auto LookupLocalName(const ScopeView& view, const mir::LocalRef& ref)
   return name;
 }
 
-// True iff the local holds a reference (its type is a `RefType`),
-// rendered as a `Ref<T>` whose read is `.Get()` and whose write is
-// `.Set(Services(), ...)` (LRM 13.5.2), the same surface as a member.
-auto IsReferenceLocal(const ScopeView& view, const mir::LocalRef& ref) -> bool {
-  const mir::TypeId var_type =
-      view.BlockAtHops(ref.hops).vars.Get(ref.var).type;
-  return std::holds_alternative<mir::RefType>(
-      view.Unit().GetType(var_type).data);
-}
-
 }  // namespace
 
 namespace {
@@ -993,37 +983,10 @@ auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
 
 namespace {
 
-// Walks an LHS expression through container-access calls (per
-// `mir::IsContainerAccessCall`) to its root primary. Whether a write
-// touches a reference formal is decided by what that root is.
-auto LhsRootPrimary(const ScopeView& view, const mir::Expr& expr)
-    -> const mir::Expr& {
-  const mir::Expr* current = &expr;
-  while (true) {
-    const auto* call = std::get_if<mir::CallExpr>(&current->data);
-    if (call == nullptr) return *current;
-    if (!mir::IsContainerAccessCallee(call->callee) ||
-        call->arguments.empty()) {
-      return *current;
-    }
-    current = &view.Expr(call->arguments.front());
-  }
-}
-
 auto IsLhsBarePrimary(const mir::Expr& expr) -> bool {
   return std::holds_alternative<mir::MemberAccessExpr>(expr.data) ||
          std::holds_alternative<mir::DerefExpr>(expr.data) ||
          std::holds_alternative<mir::LocalRef>(expr.data);
-}
-
-// The root local iff the LHS root is a `ref` / `const ref` formal,
-// else nullptr. A write whose root is a reference formal must route through
-// `Ref::Set` (LRM 13.5.2).
-auto LhsRootReferenceLocal(const ScopeView& view, const mir::Expr& expr)
-    -> const mir::LocalRef* {
-  const auto* pvr =
-      std::get_if<mir::LocalRef>(&LhsRootPrimary(view, expr).data);
-  return pvr != nullptr && IsReferenceLocal(view, *pvr) ? pvr : nullptr;
 }
 
 // Render a compound op suffix for the SV `op=` family. Arithmetic /
@@ -1075,21 +1038,6 @@ auto RenderAssignExpr(const ScopeView& view, const mir::AssignExpr& a)
 
   const mir::Expr& lhs_expr = view.Expr(a.target);
 
-  // A `ref` / `const ref` formal aliases the actual's cell; a whole write
-  // routes through `Ref::Set` so the actual's update-event path fires (LRM
-  // 13.5.2). Compound and partial writes through a ref formal are not yet
-  // supported.
-  if (const auto* ref_root = LhsRootReferenceLocal(view, lhs_expr)) {
-    if (!IsLhsBarePrimary(lhs_expr) || a.compound_op.has_value()) {
-      return diag::Fail(
-          diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-          "compound or partial assignment through a ref / const ref formal is "
-          "not yet implemented in cpp emit");
-    }
-    return LookupLocalName(view, *ref_root) + ".Set(" + "self->Services()" +
-           ", " + *value_or + ")";
-  }
-
   // Mechanical render: an observable cell's write surfaces in MIR as an
   // explicit `CallExpr` against the cell type's `Set` method, and a partial
   // mutation surfaces as `DerefExpr` over a `Mutate` call at the chain root.
@@ -1116,12 +1064,6 @@ auto RenderAssignExpr(const ScopeView& view, const mir::AssignExpr& a)
 auto RenderIncDecExpr(const ScopeView& view, const mir::IncDecExpr& inc)
     -> diag::Result<std::string> {
   const mir::Expr& target_expr = view.Expr(inc.target);
-  if (LhsRootReferenceLocal(view, target_expr) != nullptr) {
-    return diag::Fail(
-        diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-        "increment / decrement of a ref / const ref formal is not yet "
-        "implemented in cpp emit");
-  }
   auto lhs_or = RenderLhsExpr(view, target_expr);
   if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
   std::string lhs = *std::move(lhs_or);
@@ -1422,8 +1364,7 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr)
             return RenderParamExpr(view, r);
           },
           [&](const mir::LocalRef& l) -> diag::Result<std::string> {
-            const std::string name = LookupLocalName(view, l);
-            return IsReferenceLocal(view, l) ? name + ".Get()" : name;
+            return LookupLocalName(view, l);
           },
           [&](const mir::UnaryExpr& u) -> diag::Result<std::string> {
             return RenderUnaryExpr(view, expr, u);

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -173,10 +173,8 @@ auto LowerProceduralVarRefExpr(
   const auto& ab = std::get<AutomaticVarBinding>(binding);
   if (auto* sink = frame.capture_sink) {
     if (ab.declaration_procedural_depth < sink->BoundaryDepth()) {
-      return mir::Expr{
-          .data = sink->Capture(
-              ab.var, ab.declaration_procedural_depth, type, frame.block_depth),
-          .type = type};
+      return sink->Capture(
+          ab.var, ab.declaration_procedural_depth, type, frame.block_depth);
     }
   }
   if (ab.declaration_procedural_depth > frame.block_depth) {
@@ -185,7 +183,7 @@ auto LowerProceduralVarRefExpr(
         "(forward reference into a child scope)");
   }
   return mir::MakeLocalRefExpr(
-      frame.block_depth - ab.declaration_procedural_depth, ab.var, type);
+      frame.block_depth - ab.declaration_procedural_depth, ab.var, ab.type);
 }
 
 auto LowerCrossUnitVarRefExpr(
@@ -240,10 +238,8 @@ auto LowerIterationBindingRefExpr(
       frame.iteration_bindings->Lookup(ref.clause, ref.role);
   if (auto* sink = frame.capture_sink) {
     if (binding.decl_depth < sink->BoundaryDepth()) {
-      return mir::Expr{
-          .data = sink->Capture(
-              binding.var, binding.decl_depth, type, frame.block_depth),
-          .type = type};
+      return sink->Capture(
+          binding.var, binding.decl_depth, type, frame.block_depth);
     }
   }
   return mir::MakeLocalRefExpr(

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -383,7 +383,8 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
     MapProceduralVar(
         param.var, AutomaticVarBinding{
                        .declaration_procedural_depth = body_frame.block_depth,
-                       .var = mir_var});
+                       .var = mir_var,
+                       .type = type});
     params.push_back(
         mir::MethodParam{
             .name = hir_var.name,
@@ -416,7 +417,8 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
         *src.result_var,
         AutomaticVarBinding{
             .declaration_procedural_depth = body_frame.block_depth,
-            .var = result_ref->var});
+            .var = result_ref->var,
+            .type = result_type});
   }
 
   auto lowered = LowerStraightLineBodyInto(*this, body_frame);

--- a/src/lyra/lowering/hir_to_mir/statement/flow.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/flow.cpp
@@ -92,9 +92,10 @@ auto LowerAutomaticVarDeclStmt(
   const mir::LocalId local_id =
       block.vars.Add(mir::LocalDecl{.name = hir_local.name, .type = type});
   process.MapProceduralVar(
-      v.var,
-      AutomaticVarBinding{
-          .declaration_procedural_depth = frame.block_depth, .var = local_id});
+      v.var, AutomaticVarBinding{
+                 .declaration_procedural_depth = frame.block_depth,
+                 .var = local_id,
+                 .type = type});
 
   mir::ExprId init_value{};
   if (v.init.has_value()) {

--- a/src/lyra/lowering/hir_to_mir/statement/loops.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/loops.cpp
@@ -44,7 +44,8 @@ auto LowerForStmt(
               process.MapProceduralVar(
                   d.var, AutomaticVarBinding{
                              .declaration_procedural_depth = frame.block_depth,
-                             .var = local_id});
+                             .var = local_id,
+                             .type = type});
               mir::ExprId init_id{};
               if (d.init.has_value()) {
                 auto init_or =

--- a/tests/cases/cpp/function_ref_compound_partial/case.yaml
+++ b/tests/cases/cpp/function_ref_compound_partial/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.function_ref_compound_partial
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    p: 17
+    q: 15

--- a/tests/cases/cpp/function_ref_compound_partial/main.sv
+++ b/tests/cases/cpp/function_ref_compound_partial/main.sv
@@ -1,0 +1,23 @@
+module Top;
+  int p;
+  int q;
+
+  // Compound assignment through a ref formal: routes through the cell's
+  // partial-write proxy (LRM 11.4 op-assign over a ref, LRM 13.5.2).
+  function automatic void add_into(ref int x);
+    x += 7;
+  endfunction
+
+  // Partial (bit-select) write through a ref formal: the selector chain roots
+  // in the ref and lands in the mutation snapshot.
+  function automatic void set_low_nibble(ref int x);
+    x[3:0] = 4'hf;
+  endfunction
+
+  initial begin
+    p = 10;
+    add_into(p);
+    q = 0;
+    set_low_nibble(q);
+  end
+endmodule


### PR DESCRIPTION
## Summary

A `ref` / `const ref` formal (LRM 13.5.2) and a by-reference capture (LRM 6.21) carry a `RefType` whose access -- per `reference-as-data-type.md` F3 -- is the same cell protocol as an observable signal: a read, an update-event `Set`, and a partial-write `Mutate`. R12 already lifted that protocol for observable cells into explicit `BuiltinFnCallee` (`kGet` / `kSet` / `kMutate`) calls at HIR-to-MIR. This change routes references through those same three callees instead of letting the C++ backend re-derive ref-ness and inject `.Get()` / a spliced engine handle at render time -- the `mir.md` invariant 10 violation this closes (R39).

## Design

The root cause was a single typing asymmetry: a reference-to-a-ref-binding was typed with the unwrapped value type, so the central auto-`kGet` wrap and the `Set` / `Mutate` write-routing -- which already admit every cell type, including `RefType` -- skipped it. Typing the `LocalRef` with its `RefType` slot makes the existing lift catch it, with no new callee. Per `builtin-call-identity.md` D3 the callee names the access and the receiver's type (`RefType` vs `ObservableType`) selects `Ref<T>` vs `Var<T>` at render, so no `RefType`-specific callee is introduced. The slot type is carried on the automatic-var binding because the declaring block is not navigable while the body is still being lowered (unlike a static var's class member, read live from the built class arena). On the runtime side `Ref<T>` gains `Mutate`, and `ScopedMutation` now commits through a `Ref<T>` so observable and reference partial writes share one handle.

Whole writes, compound / partial writes, and increment / decrement through a ref are now all well-defined; the render path previously bailed on the latter two.

## Testing

`bazel test //...` passes, including a new `function_ref_compound_partial` case covering compound (`x += 7`) and bit-select (`x[3:0] = ...`) writes through a ref formal.