### PR TITLE
Normalize parameter direction to a completion payload

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -23,18 +23,20 @@ Read top to bottom on first pass:
 9. `callable.md` -- the one callable concept; callable code vs callable value; capture model;
    references as a field type
 10. `lir.md` -- execution-oriented IR (CFG, basic blocks, storage)
-11. `scheduling.md` -- stratified event scheduler, regions, suspension protocol
-12. `hierarchy_and_generate.md` -- hierarchy and generate ownership
-13. `reference_resolution.md` -- intra-unit vs cross-unit references; compile-time vs
+11. `activation.md` -- the runtime execution instance; completion slot; ownership / continuation /
+    cancellation relations
+12. `scheduling.md` -- stratified event scheduler, regions, suspension protocol
+13. `hierarchy_and_generate.md` -- hierarchy and generate ownership
+14. `reference_resolution.md` -- intra-unit vs cross-unit references; compile-time vs
     construction-time resolution
-14. `emission_model.md` -- how a backend emits independent per-unit artifacts and realizes
+15. `emission_model.md` -- how a backend emits independent per-unit artifacts and realizes
     cross-unit resolution through the SDK
-15. `identity_and_ownership.md` -- identity rules and forbidden shapes
-16. `lowering_boundaries.md` -- what each lowering may and may not do
-17. `lowering_organization.md` -- how lowering passes organize their internal objects (facts,
+16. `identity_and_ownership.md` -- identity rules and forbidden shapes
+17. `lowering_boundaries.md` -- what each lowering may and may not do
+18. `lowering_organization.md` -- how lowering passes organize their internal objects (facts,
     registries, builders, walk frame)
-18. `incremental_build.md` -- query-based incremental compilation and caching
-19. `testing_strategy.md` -- test categories and structure
+19. `incremental_build.md` -- query-based incremental compilation and caching
+20. `testing_strategy.md` -- test categories and structure
 
 ## Concept Index
 
@@ -61,6 +63,7 @@ If you are looking for a concept, this table points to the canonical doc.
 | Member and type model; object types; owning pointer; vector wrapper       | `mir.md`                    |
 | Callable model; code vs value; captures; references as a field type       | `callable.md`               |
 | LIR shape (CFG, basic blocks, storage)                                    | `lir.md`                    |
+| Activation; execution instance; completion slot; cancellation domain      | `activation.md`             |
 | Stratified scheduler; regions; suspension protocol; NBA / closure submit  | `scheduling.md`             |
 | Incremental compilation; query-based caching                              | `incremental_build.md`      |
 | Locating/bundling the C++ runtime; run output contract                    | `runtime_distribution.md`   |

--- a/docs/architecture/activation.md
+++ b/docs/architecture/activation.md
@@ -1,0 +1,180 @@
+# Activation
+
+## Purpose
+
+An activation is the runtime's one shape for "a concrete, in-flight execution instance." A
+SystemVerilog process (`initial`, `always*`, `final`), a task enable, and a fork-join branch are
+each an activation: a specific execution that has begun, can suspend and resume, and settles exactly
+one terminal outcome. An activation is not the callable declaration it runs (that is `callable.md`'s
+subject) -- it is what exists after a callable is invoked.
+
+The activation concept draws three lines that the rest of the runtime depends on:
+
+- **Execution control versus completion.** An activation has a scheduler-visible execution core
+  (suspend / resume / wait state / process identity) that is _payload-neutral_, and a typed
+  completion slot (the value, the exception, or a cancellation) that the scheduler never sees.
+- **The completion is a terminal outcome, not a return register.** Every activation settles one of
+  `Succeeded(T)`, `Faulted(exception)`, or `Cancelled`. A consumer reads that typed outcome; the
+  scheduler reads only "parked / runnable / terminated."
+- **Three relations are distinct.** Who _owns_ an activation, who _consumes_ its outcome, and who
+  _cancels_ it are separate relations that happen to coincide for a direct task enable and diverge
+  for a fork.
+
+This is the runtime peer of how an async runtime separates a task from its scheduler and its result:
+the scheduler parks and resumes opaque execution handles; the typed result is a property of the task
+the awaiter consumes, not of the scheduler.
+
+## Owns
+
+- The **activation**: a concrete suspendable execution instance, distinct from the callable it runs.
+- The **activation token**: the payload-neutral, scheduler-visible handle to an activation's
+  execution core (process identity, wait state, the resume entry). The scheduler holds this and
+  nothing else.
+- The **completion slot**: the single typed terminal outcome an activation settles --
+  `Succeeded(T)`, `Faulted(exception)`, or `Cancelled` -- and the rule that a consumer reads it
+  through the activation, never through the scheduler.
+- The three activation relations: **ownership** (who releases it), **continuation** (who consumes
+  the outcome and resumes on completion), and **cancellation domain** (who is cancelled together).
+- The **registration set**: every external reference to a parked activation (a region queue slot, a
+  delay slot, an event waiter entry, a value-change subscription, a join aggregator entry) as a
+  revocable registration owned by the activation.
+- The **join state**: the completion aggregator for a fork's branches and its join-mode condition.
+
+## Does Not Own
+
+- The stratified region scheduler -- the queues, the region order, the suspension verbs. That is
+  `scheduling.md`. The activation only exposes the token the scheduler parks and resumes.
+- The callable declaration and its signature, environment, and result type (`callable.md`,
+  `mir.md`). An activation runs a callable; it is not one.
+- Deferred effects -- a non-blocking assignment's commit, a postponed `$strobe`, a deferred
+  assertion action. Those are closures submitted to a region (`scheduling.md`), not activations:
+  they capture an environment, run later, and never suspend their submitter or settle a completion
+  an awaiter consumes.
+- Storage layout, frame allocation, and the machine-level suspend/resume protocol (LIR and below).
+
+## Core Invariants
+
+1. **An activation is the minimal suspendable execution entity, and the scheduler sees it through a
+   payload-neutral token.** Process, task enable, and fork branch are all activations. The scheduler
+   parks and resumes an activation token that carries process identity and wait state but never the
+   completion type. _Consequence: one scheduler serves every activation kind; adding a completion
+   shape never touches the scheduler._
+
+2. **Completion is a typed terminal outcome held in the activation's completion slot, invisible to
+   the scheduler.** An activation settles exactly one of `Succeeded(T)`, `Faulted(exception)`, or
+   `Cancelled`. The typed value and the exception live in the completion slot; the scheduler
+   observes only parked / runnable / terminated. _Consequence: the value and the exception travel
+   together as one outcome, read by the activation's consumer, never transported through a side
+   channel the scheduler or a backend invents._
+
+3. **Ownership, continuation, and cancellation membership are three distinct relations.** Ownership
+   decides who releases the activation; continuation decides who consumes its outcome and resumes on
+   completion; cancellation membership decides who is cancelled when a domain is disabled. A direct
+   task enable makes the enabler all three; a fork branch separates them -- owned and cancelled by
+   the fork domain, its outcome aggregated by a join state, with no single resuming continuation.
+   _Consequence: these relations are not one pointer; a model that collapses them cannot express
+   fork or selective cancellation._
+
+4. **Every external reference to a parked activation is a revocable registration, and a frame is
+   destroyed only after no scheduler structure can name its token.** When an activation suspends,
+   each place that can later name it -- a region queue, a delay slot, an event waiter list, a
+   value-change subscription, a join aggregator -- holds a registration the activation can revoke.
+   Destruction is gated on the registration set being empty. _Consequence: an activation can be
+   cancelled and torn down with no dangling token left in any queue, waiter, or subscription._
+
+5. **A typed await consumes the typed terminal outcome.** Awaiting an activation yields its outcome:
+   `Succeeded(T)` produces `T`, `Faulted` re-raises the exception into the awaiter, `Cancelled`
+   propagates cancellation. A pure suspension (a delay, an event control, an output-less task) is
+   the `T = Void` case of the same await. _Consequence: nested enable is one uniform value flow -- a
+   task awaiting a task gets a typed result with no per-call special handling._
+
+6. **The activity taxonomy is a fixed set of activations with different consumers; a deferred effect
+   is not an activation.** A process is owned by its scope, has process identity, completes `Void`,
+   and is observed by the engine (no continuation). A task activation inherits the enabler's process
+   identity, completes with a typed payload, and resumes the enabler. A fork branch has its own
+   process identity, is owned by the fork domain, completes `Void`, and reports to a join state. A
+   deferred effect is a closure submitted to a region, not an activation. _Consequence: each kind
+   reuses the activation core but binds its own ownership / continuation / completion; deferred work
+   never enters the activation/completion model._
+
+## Boundary to Adjacent Layers
+
+- **To the scheduler (`scheduling.md`).** The activation exposes a token the engine parks on a
+  region queue and resumes; the engine reaches process identity and wait state through the token and
+  nothing more. The engine is construct-neutral -- it branches on queue and region, never on the
+  activation's kind or completion type.
+- **To the callable (`callable.md`).** A callable value is invoked to produce an activation. The
+  callable owns the signature and result type (`Coroutine<T>` for a suspending callable); the
+  activation owns the running instance and its terminal outcome.
+- **To MIR (`mir.md`).** The typed completion is MIR semantics: a suspending callable's result type
+  is `Coroutine<T>`, and `await : Coroutine<T> -> T` consumes the terminal outcome. The activation
+  model is how a backend realizes that semantics at runtime; the MIR shape is backend-neutral.
+- **To LIR.** A backend lowers an activation's suspend, resume, success, exception, and cancel
+  points to explicit control edges; the completion slot's outcome is the value an await's resume
+  edge carries.
+
+## Forbidden Shapes
+
+- **A scheduler that branches on completion type or callable kind.** The scheduler parks and resumes
+  a payload-neutral token; an engine that asks "is this a task / does this return a tuple" has let
+  completion shape leak into execution control (invariant 1).
+
+- **A completion value transported outside the completion slot** -- a hidden out-parameter, a
+  backend-invented result sink, a side-channel reference writeback. The terminal outcome is the
+  activation's completion slot; a value reaching the consumer any other way is a backend inventing
+  transport MIR did not state (invariant 2).
+
+- **`output` / `inout` as a live alias of the caller's storage.** They are completion-payload
+  components settled once, not storage the activation writes during its run; only a `ref` is a live
+  alias. A live-alias `output` lets a caller observe an intermediate write while the activation is
+  suspended (invariant 2, `callable.md`).
+
+- **Collapsing ownership, continuation, and cancellation into one relation.** A single "parent
+  pointer" that means owner and consumer and cancellation scope cannot express a fork (owned by the
+  domain, consumed by a join, not resumed as a continuation) or selective cancellation (invariant
+  3).
+
+- **An un-revocable reference to a parked activation** -- a raw token pushed into a queue, waiter
+  list, or subscription set with no registration the activation can later revoke. It dangles the
+  moment the activation is cancelled or destroyed (invariant 4).
+
+- **A deferred effect modeled as an activation with a completion** -- a non-blocking assignment, a
+  postponed `$strobe`, or a deferred assertion action given an activation token, a completion slot,
+  or an await edge. These are closures submitted to a region; they neither suspend their submitter
+  nor settle an outcome a consumer awaits (invariant 6).
+
+- **A fork branch modeled as a task the parent awaits.** A branch has its own process identity, is
+  owned and cancelled by the fork domain, and reports to a join state under a join-mode condition;
+  `join_none` has no parent wait at all. Reusing task-enable ownership for a branch conflates the
+  two (invariant 3, invariant 6).
+
+## Notes / Examples
+
+A direct task enable is the case where the three relations coincide. `int x = <enable t(a)>`:
+
+```text
+enable t(a)  ->  child task activation, completion slot typed `int`
+  ownership            = the enabling frame
+  continuation         = the enabling frame (resumes, consumes the outcome)
+  cancellation domain  = the enabling frame's domain (disabling the enabler cancels the child)
+await  ->  Succeeded(int) yields x ; Faulted re-raises ; Cancelled propagates
+```
+
+A fork splits them:
+
+```text
+fork branch  ->  branch activation, completion slot `Void`, own process identity
+  ownership            = the fork domain
+  continuation         = none (the branch resumes no one)
+  cancellation domain  = the fork domain
+join state  <-  each branch reports terminated / faulted / cancelled
+  join / join_any / join_none decide when the forking process resumes
+```
+
+The C++ backend realizes an activation as a coroutine frame. Its activation token is the coroutine
+promise's non-templated base (the scheduler holds a pointer to it); its completion slot is the typed
+result the promise carries; a task enable is `co_await` of the activation, with symmetric transfer
+realizing the continuation and `await_resume` consuming the terminal outcome. The promise base, the
+`coroutine_handle`, and symmetric transfer are this realization's mechanics; the activation,
+completion slot, registration set, and join state are the model they realize. A future LIR / LLVM
+backend realizes the same model with coroutine intrinsics and explicit control edges instead.

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -13,10 +13,15 @@ detection, and edge detection are separate runtime subsystems.
 
 ## Processes and tasks are coroutines
 
+The execution instance a process or task runs as -- its identity, completion outcome, ownership, and
+cancellation -- is the activation, defined in `activation.md`. This doc owns the engine that parks
+and resumes activations; `activation.md` owns what an activation is. The scheduler holds an
+activation token (a payload-neutral handle) and never sees an activation's completion type.
+
 A process body -- and a task body, which may consume time -- compiles into a `Coroutine`. The
-scheduler holds a `std::coroutine_handle` and calls `.resume()` to continue the body; a `co_await`
-in the body suspends it again. Process state -- procedural locals, the implicit program counter --
-lives in the coroutine frame, which the engine does not introspect.
+scheduler holds the activation token and resumes the body; a `co_await` in the body suspends it
+again. Process state -- procedural locals, the implicit program counter -- lives in the coroutine
+frame, which the engine does not introspect.
 
 A task is enabled with `co_await`: enabling a time-consuming task suspends the enabling process
 until the task completes (LRM 13.3). The scheduler resumes the innermost suspended frame, and each

--- a/docs/progress/activation.md
+++ b/docs/progress/activation.md
@@ -1,0 +1,49 @@
+# Activation model: gaps to the contract
+
+Tracks where the runtime's execution code differs from the golden activation model in
+`../architecture/activation.md`. Each entry names the current shape, the contract shape it must
+reach, and what (if anything) blocks it. Entries get checked off as their PRs land; when the last
+lands, this file is deleted.
+
+The runtime already realizes the load-bearing core of the contract: an activation is a coroutine
+frame; the scheduler holds a payload-neutral activation token and never sees the completion type; a
+suspending callable's result type is `Coroutine<T>` and a typed await consumes its value; a fork
+branch is owned by the fork domain and reports to a join state. The gaps below are where the current
+shape is still wrong or incomplete relative to the contract.
+
+## Items
+
+- [ ] **The terminal outcome is split, not unified.** Contract invariant 2: an activation settles
+      one completion slot holding `Succeeded(T)` / `Faulted(exception)` / `Cancelled`, and the
+      scheduler-visible execution core carries none of it. Current shape: the success value lives in
+      the typed completion storage, but the exception is carried by the scheduler-visible execution
+      core, separate from the value. That is wrong -- the exception is part of the terminal outcome,
+      not execution control. Target: one completion slot owns the whole outcome (value and
+      exception, later cancellation); a consumer reads a single terminal outcome; the execution core
+      the scheduler sees is purely suspend / resume / wait state / identity. Unblocked; doable now.
+
+- [ ] **Registrations are only partly revocable.** Contract invariant 4: every external reference to
+      a parked activation -- a region queue slot, a delay slot, an event waiter entry, a
+      value-change subscription, a join aggregator entry -- is a revocable registration the
+      activation owns, and a frame is destroyed only after the registration set is empty. Current
+      shape: value-change subscriptions are tracked and revocable, but region-queue membership and
+      event-waiter entries hold references the activation cannot itself revoke. Target: one
+      revocable registration set covering every registration kind, with destruction gated on it.
+      Until then, no new registration kind may be added that an activation cannot revoke. Partly
+      gated on cancellation (below), but the general registration-set contract should land first.
+
+- [ ] **Cancellation is absent.** Contract: the terminal outcome includes `Cancelled`; a
+      cancellation domain -- a relation distinct from ownership and continuation -- decides which
+      activations are cancelled together; disabling settles `Cancelled`, revokes every registration,
+      cancels the owned descendants, then releases the frame. Current shape: there is no
+      cancellation path, no `Cancelled` outcome, and no cancellation-domain relation. Target: the
+      full cancellation model behind `disable` / `disable fork` (LRM 9.6.x). Blocked on the
+      `disable` language feature; the activation lifetime must not foreclose it (it does not --
+      frame ownership already cascades, and the registration-set and outcome-unification items above
+      are the remaining prerequisites).
+
+- [ ] **Runtime vocabulary trails the model.** The execution code names the activation and its core
+      in coroutine-implementation terms; the contract's vocabulary is activation / completion slot /
+      cancellation domain / join state, with the coroutine mechanics as one realization. Rename to
+      the model's vocabulary where it clarifies the boundary between execution control and
+      completion. Low priority; unblocked.

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -106,7 +106,7 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
         function), not a side enum; `MethodKind` is removed. Behavior-neutral; existing task /
         function tests prove no regression.
 
-  - [ ] R8b -- Parameter direction normalizes to data flow. `output` / `inout` formals stop being
+  - [x] R8b -- Parameter direction normalizes to data flow. `output` / `inout` formals stop being
         reference parameters and become components of the callable's completion payload -- the
         explicit return (if any) followed by each `output` / `inout` value, normalized by count
         (zero is `Void`, one is a bare type, two or more a tuple), riding the result type and

--- a/include/lyra/lowering/hir_to_mir/completion_payload.hpp
+++ b/include/lyra/lowering/hir_to_mir/completion_payload.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <vector>
+
+#include "lyra/hir/subroutine.hpp"
+#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
+#include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/type_id.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// The completion-payload component types of a subroutine, in payload order: the
+// function return (when the subroutine is a non-void function) followed by each
+// `output` / `inout` formal in declaration order. The single source of truth
+// the callee body and every call site share, so neither re-derives the layout
+// independently (LRM 13.5).
+auto CompletionComponentTypes(
+    const ModuleLowerer& module, const hir::StructuralSubroutineDecl& decl)
+    -> std::vector<mir::TypeId>;
+
+// Normalizes a completion payload by component count: no component is `Void`,
+// one is that component's bare type, two or more a tuple of them.
+auto NormalizeCompletionPayload(
+    mir::CompilationUnit& unit, const std::vector<mir::TypeId>& components)
+    -> mir::TypeId;
+
+// The coroutine call protocol carrying a completion payload. A `Void` payload
+// reuses the interned bare coroutine so no-output tasks and processes share one
+// type identity.
+auto CoroutineOf(mir::CompilationUnit& unit, mir::TypeId payload)
+    -> mir::TypeId;
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <utility>
 #include <variant>
@@ -188,6 +189,19 @@ class ProcessLowerer {
     return owner_ctor_frame_;
   }
 
+  // Assembles the completion-payload value a `return` should carry in the
+  // subroutine being lowered: the function's explicit return value (or its
+  // implicit result variable when a `return` supplies none) followed by each
+  // `output` / `inout` local, normalized to a bare value (one component) or a
+  // `TupleExpr` (two or more). Returns nullopt when the payload is empty -- a
+  // void function or a task with no outputs -- so the caller emits a plain
+  // `return;`. `explicit_value` is the lowered `return expr` operand, absent
+  // for a bare `return;`. Reads the pack locals at `frame`'s depth, so a return
+  // nested in an inner block resolves the correct hops.
+  [[nodiscard]] auto BuildReturnPayload(
+      mir::Block& block, const WalkFrame& frame,
+      std::optional<mir::ExprId> explicit_value) -> std::optional<mir::ExprId>;
+
  private:
   ModuleLowerer* module_;
   const ClassLowerer* owner_;
@@ -196,6 +210,17 @@ class ProcessLowerer {
   std::string callable_name_;
   WalkFrame owner_ctor_frame_;
   std::vector<ProceduralVarBinding> bindings_;
+
+  // Completion-payload shape of the subroutine being lowered, set by
+  // Run(subroutine) before its body walks and read by every return site. All
+  // default for a process or an empty-payload callable: no result var, no pack
+  // locals, so BuildReturnPayload yields a plain `return;`.
+  BlockDepth completion_decl_depth_{};
+  std::optional<mir::LocalId> result_var_;
+  mir::TypeId result_value_type_{};
+  std::vector<mir::LocalId> output_pack_vars_;
+  std::vector<mir::TypeId> output_pack_types_;
+  mir::TypeId completion_payload_type_{};
 };
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -211,12 +211,23 @@ struct AwaitExpr {
   ExprId awaitable;
 };
 
+// Projects one component out of a tuple value by position: `tuple.index`. The
+// inverse of `TupleExpr`, used to read a single field from a heterogeneous
+// product -- a task completion's output pack, where each `output` / `inout`
+// writeback reads its component. `Expr::type` is the component's type (the
+// `index`-th element of the operand's `TupleType`). The C++ backend realizes it
+// as `std::get<index>`.
+struct TupleGetExpr {
+  ExprId tuple;
+  std::size_t index;
+};
+
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, NullLiteral,
     ParamRef, LocalRef, UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr,
     IncDecExpr, CallExpr, DerefExpr, AddressOfExpr, CastExpr, MemberAccessExpr,
     ClosureExpr, ConcatExpr, ReplicationExpr, ArrayLiteralExpr, TupleExpr,
-    AwaitExpr>;
+    AwaitExpr, TupleGetExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/mir/method.hpp
+++ b/include/lyra/mir/method.hpp
@@ -9,22 +9,16 @@
 
 namespace lyra::mir {
 
-// LRM 13.5 argument direction. MIR carries the semantic direction only; the
-// C++ argument-passing mode is the backend's decision. A `ref` / `const ref`
-// formal is not a direction here: its `type` is a `RefType` and it is passed by
-// value (`kInput`) -- the reference value carries the aliasing.
-enum class ParamDirection : std::uint8_t {
-  kInput,
-  kOutput,
-  kInOut,
-};
-
-// A formal argument of a method. `name` is the local the body reads through;
-// the backend renders it as the C++ parameter of that name.
+// A formal argument of a method. Parameter direction is data flow, carried by
+// the signature, not a side enum: an `input` is a value parameter and a `ref` /
+// `const ref` a `Ref<T>` parameter (the reference value carries the aliasing,
+// LRM 13.5.2). `output` / `inout` are not parameters at all -- they ride the
+// completion payload (`result_type`), so they never appear here. `name` is the
+// local the body reads through; the backend renders it as the C++ parameter of
+// that name.
 struct MethodParam {
   std::string name;
   TypeId type;
-  ParamDirection direction = ParamDirection::kInput;
 };
 
 // How a method binds its receiver and dispatches -- a generic object-oriented
@@ -44,13 +38,14 @@ enum class MethodForm : std::uint8_t {
 // SystemVerilog function and task, every process body, and the synthesized
 // lifecycle bodies are this one concept, distinguished only by `form` (receiver
 // binding) and by how a referencing site uses them. `result_type` carries the
-// call protocol -- a coroutine type for a time-consuming task or a process (LRM
-// 13.3), a value or void type for a zero-time function (LRM 13.4) -- so the
-// backend reads task-versus-function from the result type, not a side enum.
-// `params` names which of the body's locals are formals (the rest are interior
-// locals); the receiver `self` is `root_block.vars[0]`, not a formal here.
-// Static-lifetime body locals are realized as members on the enclosing class at
-// HIR -> MIR; they do not appear here.
+// call protocol and the completion payload -- a coroutine type for a
+// time-consuming task or a process (LRM 13.3), a value or void type for a
+// zero-time function (LRM 13.4) -- so the backend reads task-versus-function
+// and the output pack from the result type, not a side enum. `params` names
+// which of the body's locals are formals (the rest are interior locals); the
+// receiver `self` is `root_block.vars[0]`, not a formal here. Static-lifetime
+// body locals are realized as members on the enclosing class at HIR -> MIR;
+// they do not appear here.
 struct MethodDecl {
   std::string name;
   TypeId result_type;

--- a/include/lyra/runtime/coroutine.hpp
+++ b/include/lyra/runtime/coroutine.hpp
@@ -3,6 +3,8 @@
 #include <coroutine>
 #include <exception>
 #include <functional>
+#include <optional>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -13,88 +15,108 @@ namespace lyra::runtime {
 class Observable;
 class RuntimeProcess;
 
-// The single coroutine type for every suspendable activation: a process body
-// (`initial` / `always`) and a task subroutine body both compile to it. A
-// function body is a plain C++ function and never becomes a Coroutine.
+// Non-templated scheduling state shared by every coroutine frame -- a process
+// body, a task body, a fork branch -- regardless of the value the frame
+// completes with. The engine and the awaitables hold a `PromiseBase*` as the
+// universal wakeup token and read scheduling state through it, never naming the
+// frame's result type. `self` is this frame's own handle, type-erased, so the
+// engine resumes and queries completion without knowing the result type
+// (recovering a promise from a frame address is not a portable ABI, so the
+// handle is stored at construction, not derived).
+struct PromiseBase {
+  std::exception_ptr pending_exception;
+  RuntimeProcess* process = nullptr;
+  std::coroutine_handle<> continuation;
+  std::vector<Observable*> pending_value_change_subscriptions;
+  std::function<void()> on_complete;
+  std::coroutine_handle<> self;
+
+  static auto initial_suspend() noexcept -> std::suspend_always {
+    return {};
+  }
+
+  // On completion, run the completion hook (a fork branch reports to its join
+  // group) then transfer to the enabler if there is one (a task returning to
+  // its caller); a top-level process has no continuation and suspends so the
+  // engine sees `done()`.
+  struct FinalAwaiter {
+    PromiseBase* promise;
+    [[nodiscard]] static auto await_ready() noexcept -> bool {
+      return false;
+    }
+    // NOLINTNEXTLINE(readability-named-parameter)
+    [[nodiscard]] auto await_suspend(std::coroutine_handle<>) const noexcept
+        -> std::coroutine_handle<> {
+      if (promise->on_complete) {
+        promise->on_complete();
+      }
+      if (promise->continuation) {
+        return promise->continuation;
+      }
+      return std::noop_coroutine();
+    }
+    static void await_resume() noexcept {
+    }
+  };
+  auto final_suspend() noexcept -> FinalAwaiter {
+    return FinalAwaiter{.promise = this};
+  }
+
+  void unhandled_exception() noexcept {
+    pending_exception = std::current_exception();
+  }
+
+  [[nodiscard]] auto Process() const -> RuntimeProcess& {
+    if (process == nullptr) {
+      throw InternalError(
+          "PromiseBase::Process: no RuntimeProcess back-pointer set");
+    }
+    return *process;
+  }
+};
+
+// The universal wakeup / scheduling token: a pointer to a suspended frame's
+// scheduling state. The engine queues it, awaitables register it, and resuming
+// a frame goes through `token->self`.
+using CoroutineHandle = PromiseBase*;
+
+// The completion-value storage split, kept off `PromiseBase` so the scheduler
+// never sees `T`: a value-completing frame keeps the produced value until the
+// awaiter moves it out; a void-completing frame keeps nothing. `std::optional`
+// because `T` need not be default-constructible and "not yet produced" (e.g. an
+// exceptional exit) is a real state.
+template <class T>
+struct CoroutineResult {
+  std::optional<T> result;
+  void return_value(T value) {
+    result = std::move(value);
+  }
+};
+
+template <>
+struct CoroutineResult<void> {
+  void return_void() {
+  }
+};
+
+// A suspendable activation that completes with a value of `T` -- a task body,
+// or a process body with `T = void`. The completion value travels through the
+// promise: the body's `co_return v` stores it, and the awaiting frame moves it
+// out in `await_resume` before this `Coroutine` (which owns the frame) is
+// destroyed. All scheduling lives on the non-templated `PromiseBase` the engine
+// sees; nothing per-`T` reaches the scheduler.
 //
-// A Coroutine is lazy (suspends before its first statement) and is its own
-// awaiter, so a task is enabled with `co_await drive(args)`. When a task
-// finishes it transfers control back to its enabling coroutine via the
-// continuation stored in the promise (symmetric transfer); a top-level process
-// has no continuation and simply suspends at completion for the engine to
-// observe.
+// A `Coroutine` is lazy (suspends before its first statement) and is its own
+// awaiter, so a task is enabled with `co_await task(args)`. The awaiting
+// frame's receiver is a single consumer of the completion value.
+template <class T>
 class Coroutine {
  public:
-  struct promise_type {
-    // Captures any exception that escapes the coroutine body so the original
-    // `what()` and type reach the engine unchanged. A task's exception is
-    // rethrown into its enabler at `await_resume`, so it propagates up to the
-    // top-level promise where the engine reads it after resuming.
-    std::exception_ptr pending_exception;
-    // Set on the top-level promise at RuntimeProcess construction and inherited
-    // by each enabled task in `await_suspend`, so any frame can recover the
-    // owning RuntimeProcess identity from within an awaitable.
-    RuntimeProcess* process = nullptr;
-    // The coroutine to resume when this one completes; empty for a top-level
-    // process. A task records its enabler here when it is co_awaited.
-    std::coroutine_handle<promise_type> continuation;
-    // Observables this frame subscribed to for its current multi-trigger wait
-    // (`@(a or b)`); when one fires the engine sweeps the rest to drop the
-    // stale subscriptions. Per-wait state, so it lives on the frame.
-    std::vector<Observable*> pending_value_change_subscriptions;
-    // Run when this frame completes, before transferring to any continuation. A
-    // spawned fork branch sets this to report completion to its join group; the
-    // callback owns whatever state it needs (a shared_ptr keeping that group
-    // alive), so the coroutine machinery never names the construct.
-    std::function<void()> on_complete;
-
+  struct promise_type : PromiseBase, CoroutineResult<T> {
     auto get_return_object() -> Coroutine {
-      return Coroutine{
-          std::coroutine_handle<promise_type>::from_promise(*this)};
-    }
-    static auto initial_suspend() noexcept -> std::suspend_always {
-      return {};
-    }
-
-    // On completion, transfer to the enabler if there is one (a task returning
-    // to its caller); otherwise suspend so the engine sees `done()` (a
-    // top-level process).
-    struct FinalAwaiter {
-      [[nodiscard]] static auto await_ready() noexcept -> bool {
-        return false;
-      }
-      static auto await_suspend(
-          std::coroutine_handle<promise_type> handle) noexcept
-          -> std::coroutine_handle<> {
-        if (auto& on_complete = handle.promise().on_complete) {
-          on_complete();
-        }
-        std::coroutine_handle<promise_type> cont =
-            handle.promise().continuation;
-        if (cont) {
-          return cont;
-        }
-        return std::noop_coroutine();
-      }
-      static void await_resume() noexcept {
-      }
-    };
-    static auto final_suspend() noexcept -> FinalAwaiter {
-      return {};
-    }
-    static void return_void() {
-    }
-    void unhandled_exception() noexcept {
-      pending_exception = std::current_exception();
-    }
-
-    [[nodiscard]] auto Process() const -> RuntimeProcess& {
-      if (process == nullptr) {
-        throw InternalError(
-            "Coroutine::promise_type::Process: no RuntimeProcess back-pointer "
-            "set");
-      }
-      return *process;
+      auto handle = std::coroutine_handle<promise_type>::from_promise(*this);
+      self = handle;
+      return Coroutine{handle};
     }
   };
 
@@ -118,27 +140,37 @@ class Coroutine {
     }
   }
 
-  // Awaiter surface: `co_await drive(args)` enables a task. Starting the task
-  // is a symmetric transfer to its handle; the task carries this enabler as its
-  // continuation and inherits its RuntimeProcess identity.
+  // Awaiter surface: `co_await task(args)` enables the task. Starting it is a
+  // symmetric transfer to its handle; the task carries this enabler as its
+  // continuation and inherits its RuntimeProcess identity. The enabler may be a
+  // process or another task, so the promise type is deduced.
   [[nodiscard]] auto await_ready() const noexcept -> bool {
     return !handle_ || handle_.done();
   }
-  auto await_suspend(std::coroutine_handle<promise_type> caller) noexcept
+  template <class P>
+  auto await_suspend(std::coroutine_handle<P> caller) noexcept
       -> std::coroutine_handle<promise_type> {
     handle_.promise().continuation = caller;
     handle_.promise().process = caller.promise().process;
     return handle_;
   }
-  void await_resume() const {
+  auto await_resume() -> T {
     if (auto exc =
             std::exchange(handle_.promise().pending_exception, nullptr)) {
       std::rethrow_exception(exc);
+    }
+    if constexpr (!std::is_void_v<T>) {
+      return std::move(*handle_.promise().result);
     }
   }
 
   [[nodiscard]] auto Handle() const -> std::coroutine_handle<promise_type> {
     return handle_;
+  }
+
+  // The scheduling token for this frame -- what the engine queues and resumes.
+  [[nodiscard]] auto Token() const -> CoroutineHandle {
+    return handle_ ? &handle_.promise() : nullptr;
   }
 
   [[nodiscard]] auto Done() const -> bool {
@@ -154,15 +186,11 @@ class Coroutine {
   }
 
  private:
-  explicit Coroutine(std::coroutine_handle<promise_type> h) : handle_(h) {
+  explicit Coroutine(std::coroutine_handle<promise_type> handle)
+      : handle_(handle) {
   }
 
   std::coroutine_handle<promise_type> handle_;
 };
-
-// The wait / wakeup token throughout the runtime: the specific coroutine frame
-// that suspended (the innermost one when tasks are nested), which is what the
-// engine resumes and what awaitables register for wakeup.
-using CoroutineHandle = std::coroutine_handle<Coroutine::promise_type>;
 
 }  // namespace lyra::runtime

--- a/include/lyra/runtime/delay.hpp
+++ b/include/lyra/runtime/delay.hpp
@@ -43,13 +43,15 @@ class DelayAwaitable {
     return false;
   }
 
-  void await_suspend(CoroutineHandle handle) noexcept {
+  template <class P>
+  void await_suspend(std::coroutine_handle<P> handle) noexcept {
+    CoroutineHandle token = &handle.promise();
     if (duration_ == 0) {
-      services_->ScheduleInactive(handle);
+      services_->ScheduleInactive(token);
     } else {
       const SimDuration global_ticks = ScaleToGlobalTicks(
           duration_, precision_power_, services_->GlobalPrecisionPower());
-      services_->ScheduleAtTime(services_->Now() + global_ticks, handle);
+      services_->ScheduleAtTime(services_->Now() + global_ticks, token);
     }
   }
 

--- a/include/lyra/runtime/engine.hpp
+++ b/include/lyra/runtime/engine.hpp
@@ -105,7 +105,7 @@ class Engine {
   void ScheduleInactive(CoroutineHandle handle);
   void ScheduleAtTime(SimTime when, CoroutineHandle handle);
   void RequestFinish(int level, bool fatal = false);
-  void Spawn(Coroutine coroutine);
+  void Spawn(Coroutine<void> coroutine);
   [[nodiscard]] auto Now() const -> SimTime {
     return now_;
   }

--- a/include/lyra/runtime/finish.hpp
+++ b/include/lyra/runtime/finish.hpp
@@ -30,7 +30,7 @@ class FinishAwaitable {
   // The coroutine protocol passes the awaiting handle, but the finish-family
   // suspends forever (the engine drops the frame), so the handle is unused.
   // NOLINTNEXTLINE(readability-named-parameter)
-  void await_suspend(CoroutineHandle) noexcept {
+  void await_suspend(std::coroutine_handle<>) noexcept {
     services_->RequestFinish(level_, fatal_);
   }
 

--- a/include/lyra/runtime/fork.hpp
+++ b/include/lyra/runtime/fork.hpp
@@ -86,8 +86,9 @@ class JoinAwaitable {
     return !group_->NeedsPark();
   }
 
-  void await_suspend(CoroutineHandle parent) noexcept {
-    group_->ParkParent(parent);
+  template <class P>
+  void await_suspend(std::coroutine_handle<P> parent) noexcept {
+    group_->ParkParent(&parent.promise());
   }
 
   void await_resume() const noexcept {
@@ -103,12 +104,11 @@ class JoinAwaitable {
 // snapshot-drain, since a branch enqueued while the parent runs is reached only
 // on the next drain pass, after the parent has parked or moved on.
 inline auto Fork(
-    RuntimeServices& services, std::vector<Coroutine> branches, JoinMode mode)
-    -> JoinAwaitable {
+    RuntimeServices& services, std::vector<Coroutine<void>> branches,
+    JoinMode mode) -> JoinAwaitable {
   auto group = std::make_shared<ForkGroup>(services, branches.size(), mode);
   for (auto& branch : branches) {
-    CoroutineHandle handle = branch.Handle();
-    handle.promise().on_complete = [group] { group->OnBranchDone(); };
+    branch.Handle().promise().on_complete = [group] { group->OnBranchDone(); };
     services.Spawn(std::move(branch));
   }
   return JoinAwaitable{group};

--- a/include/lyra/runtime/named_event.hpp
+++ b/include/lyra/runtime/named_event.hpp
@@ -24,8 +24,9 @@ class EventAwaitable {
     return false;
   }
 
-  void await_suspend(CoroutineHandle handle) noexcept {
-    event_->AddWaiter(handle);
+  template <class P>
+  void await_suspend(std::coroutine_handle<P> handle) noexcept {
+    event_->AddWaiter(&handle.promise());
   }
 
   static void await_resume() noexcept {

--- a/include/lyra/runtime/runtime_process.hpp
+++ b/include/lyra/runtime/runtime_process.hpp
@@ -16,7 +16,7 @@ enum class ProcessState : std::uint8_t {
 
 class RuntimeProcess {
  public:
-  RuntimeProcess(ProcessKind kind, Coroutine coroutine);
+  RuntimeProcess(ProcessKind kind, Coroutine<void> coroutine);
 
   RuntimeProcess(const RuntimeProcess&) = delete;
   auto operator=(const RuntimeProcess&) -> RuntimeProcess& = delete;
@@ -41,12 +41,12 @@ class RuntimeProcess {
   // wakeup; this is what the engine schedules to start the process and what
   // completion is judged against.
   [[nodiscard]] auto TopHandle() const -> CoroutineHandle {
-    return coroutine_.Handle();
+    return coroutine_.Token();
   }
 
  private:
   ProcessKind kind_;
-  Coroutine coroutine_;
+  Coroutine<void> coroutine_;
   ProcessState state_ = ProcessState::kCreated;
 };
 

--- a/include/lyra/runtime/runtime_services.hpp
+++ b/include/lyra/runtime/runtime_services.hpp
@@ -80,7 +80,7 @@ class RuntimeServices {
   void ScheduleInactive(CoroutineHandle handle);
   void ScheduleAtTime(SimTime when, CoroutineHandle handle);
   void RequestFinish(int level, bool fatal = false);
-  void Spawn(Coroutine coroutine);
+  void Spawn(Coroutine<void> coroutine);
   [[nodiscard]] auto Now() const -> SimTime;
 
   // The design-global time precision (LRM 3.14.3) the delay awaitable scales a

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -140,7 +140,8 @@ class Scope {
   }
 
  protected:
-  auto AddProcess(ProcessKind kind, Coroutine coroutine) -> RuntimeProcess&;
+  auto AddProcess(ProcessKind kind, Coroutine<void> coroutine)
+      -> RuntimeProcess&;
 
   // Reached by emitted process and subroutine bodies for every runtime
   // service call (print, delay, NBA submit, file I/O, the deferred-check

--- a/include/lyra/runtime/var.hpp
+++ b/include/lyra/runtime/var.hpp
@@ -249,7 +249,9 @@ class EventControlAwaitable {
     return false;
   }
 
-  void await_suspend(CoroutineHandle handle) {
+  template <class P>
+  void await_suspend(std::coroutine_handle<P> handle) {
+    CoroutineHandle token = &handle.promise();
     std::vector<Observable*> subs;
     subs.reserve(triggers_.size());
     for (const auto& trigger : triggers_) {
@@ -259,10 +261,10 @@ class EventControlAwaitable {
             "null");
       }
       trigger.observable->Subscribe(
-          handle, trigger.edge, trigger.lsb_bit_offset, trigger.bit_width);
+          token, trigger.edge, trigger.lsb_bit_offset, trigger.bit_width);
       subs.push_back(trigger.observable);
     }
-    handle.promise().pending_value_change_subscriptions = std::move(subs);
+    token->pending_value_change_subscriptions = std::move(subs);
   }
 
   static void await_resume() noexcept {

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -78,18 +78,11 @@ auto RenderMethodParam(
     const mir::MethodParam& param) -> diag::Result<std::string> {
   auto type_or = RenderTypeAsCpp(unit, s, param.type);
   if (!type_or) return std::unexpected(std::move(type_or.error()));
-  // An `input` formal is by value (LRM 13.5.1); a `ref` / `const ref` formal is
-  // also by value, but its `RefType` already renders as `(const) Ref<T>` so the
-  // reference value carries the aliasing (LRM 13.5.2). An `output` / `inout`
-  // formal binds the caller's writeback temp by reference (`T&`).
-  switch (param.direction) {
-    case mir::ParamDirection::kInput:
-      return *type_or + " " + param.name;
-    case mir::ParamDirection::kOutput:
-    case mir::ParamDirection::kInOut:
-      return *type_or + "& " + param.name;
-  }
-  throw InternalError("RenderMethodParam: unknown ParamDirection");
+  // Every formal is a value parameter: an `input` by value (LRM 13.5.1), a
+  // `ref` / `const ref` whose `RefType` already renders as `(const) Ref<T>` so
+  // the reference value carries the aliasing (LRM 13.5.2). `output` / `inout`
+  // are not parameters -- they ride the completion payload.
+  return *type_or + " " + param.name;
 }
 
 // The one renderer for every method. A method's declaration is rendered from

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1424,6 +1424,12 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr)
             }
             return "co_await " + *awaitable_or;
           },
+          [&](const mir::TupleGetExpr& g) -> diag::Result<std::string> {
+            auto tuple_or = RenderExpr(view, view.Expr(g.tuple));
+            if (!tuple_or) return std::unexpected(std::move(tuple_or.error()));
+            return "std::get<" + std::to_string(g.index) + ">(" + *tuple_or +
+                   ")";
+          },
       },
       expr.data);
 }

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -128,8 +128,8 @@ auto RenderForkStmtNode(
   auto locals_or = RenderBlockStatements(fork_view, indent + 1);
   if (!locals_or) return std::unexpected(std::move(locals_or.error()));
   out += *locals_or;
-  out += Indent(indent + 1) + "std::vector<lyra::runtime::Coroutine> " + vec +
-         ";\n";
+  out += Indent(indent + 1) + "std::vector<lyra::runtime::Coroutine<void>> " +
+         vec + ";\n";
   for (const auto branch : s.branches) {
     auto closure_or = RenderExpr(fork_view, fork_view.Expr(branch));
     if (!closure_or) return std::unexpected(std::move(closure_or.error()));
@@ -404,19 +404,18 @@ auto RenderStmt(
             return Indent(indent) + "continue;\n";
           },
           [&](const mir::ReturnStmt& s) -> diag::Result<std::string> {
-            // The `is_coroutine_return` attribute (set at HIR-to-MIR from the
-            // enclosing callable's coroutine-ness, mir/stmt.hpp) is a C++
-            // render hint -- LIR / LLVM ignore it. A task's `return` is
-            // `co_return` and carries no value (LRM 13.3 / 13.4.1).
-            if (s.is_coroutine_return) {
-              return Indent(indent) + "co_return;\n";
-            }
+            // `is_coroutine_return` (set at HIR-to-MIR from the enclosing
+            // callable's coroutine-ness, mir/stmt.hpp) is a C++ render hint --
+            // LIR / LLVM ignore it -- choosing `co_return` over `return`. A
+            // value rides the result either way (LRM 13.3 / 13.4.1).
+            const std::string keyword =
+                s.is_coroutine_return ? "co_return" : "return";
             if (!s.value.has_value()) {
-              return Indent(indent) + "return;\n";
+              return Indent(indent) + keyword + ";\n";
             }
             auto value_or = RenderExpr(view, view.Expr(*s.value));
             if (!value_or) return std::unexpected(std::move(value_or.error()));
-            return Indent(indent) + "return " + *value_or + ";\n";
+            return Indent(indent) + keyword + " " + *value_or + ";\n";
           },
           [&](const mir::SensitivityWaitStmt& s) -> diag::Result<std::string> {
             return RenderSensitivityWaitStmt(view, s, indent);

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -141,8 +141,11 @@ auto RenderTypeAsCpp(
             }
             throw InternalError("RenderTypeAsCpp: unknown RuntimeLibraryKind");
           },
-          [](const mir::CoroutineType&) -> diag::Result<std::string> {
-            return std::string{"lyra::runtime::Coroutine"};
+          [&](const mir::CoroutineType& c) -> diag::Result<std::string> {
+            auto payload_or = RenderTypeAsCpp(unit, owner_class, c.payload);
+            if (!payload_or)
+              return std::unexpected(std::move(payload_or.error()));
+            return "lyra::runtime::Coroutine<" + *payload_or + ">";
           },
           [&](const mir::RefType& r) -> diag::Result<std::string> {
             auto inner_or = RenderTypeAsCpp(unit, owner_class, r.pointee);

--- a/src/lyra/lowering/hir_to_mir/completion_payload.cpp
+++ b/src/lyra/lowering/hir_to_mir/completion_payload.cpp
@@ -1,0 +1,41 @@
+#include "lyra/lowering/hir_to_mir/completion_payload.hpp"
+
+#include <vector>
+
+#include "lyra/hir/subroutine.hpp"
+#include "lyra/mir/type.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+auto CompletionComponentTypes(
+    const ModuleLowerer& module, const hir::StructuralSubroutineDecl& decl)
+    -> std::vector<mir::TypeId> {
+  std::vector<mir::TypeId> components;
+  if (decl.result_var.has_value()) {
+    components.push_back(module.TranslateType(decl.result_type));
+  }
+  for (const auto& param : decl.params) {
+    if (param.direction == hir::ParamDirection::kOutput ||
+        param.direction == hir::ParamDirection::kInOut) {
+      components.push_back(
+          module.TranslateType(decl.body.procedural_vars.Get(param.var).type));
+    }
+  }
+  return components;
+}
+
+auto NormalizeCompletionPayload(
+    mir::CompilationUnit& unit, const std::vector<mir::TypeId>& components)
+    -> mir::TypeId {
+  if (components.empty()) return unit.builtins.void_type;
+  if (components.size() == 1) return components.front();
+  return unit.AddType(mir::TypeData{mir::TupleType{.elements = components}});
+}
+
+auto CoroutineOf(mir::CompilationUnit& unit, mir::TypeId payload)
+    -> mir::TypeId {
+  if (payload == unit.builtins.void_type) return unit.builtins.coroutine;
+  return unit.AddType(mir::TypeData{mir::CoroutineType{.payload = payload}});
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -11,6 +11,7 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/process.hpp"
 #include "lyra/hir/stmt.hpp"
+#include "lyra/lowering/hir_to_mir/completion_payload.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/expression/aggregates.hpp"
 #include "lyra/lowering/hir_to_mir/expression/assignment.hpp"
@@ -309,22 +310,6 @@ auto LowerForeverProcess(
           .form = mir::MethodForm::kStatic}};
 }
 
-auto LowerParamDirection(hir::ParamDirection dir) -> mir::ParamDirection {
-  switch (dir) {
-    case hir::ParamDirection::kInput:
-    // A ref / const ref formal is passed by value as a `Ref<T>`; the aliasing
-    // lives in the formal's `RefType`, not in the direction (LRM 13.5.2).
-    case hir::ParamDirection::kRef:
-    case hir::ParamDirection::kConstRef:
-      return mir::ParamDirection::kInput;
-    case hir::ParamDirection::kOutput:
-      return mir::ParamDirection::kOutput;
-    case hir::ParamDirection::kInOut:
-      return mir::ParamDirection::kInOut;
-  }
-  throw InternalError("LowerParamDirection: unknown hir::ParamDirection");
-}
-
 }  // namespace
 
 auto ProcessLowerer::Run(const hir::Process& src)
@@ -358,26 +343,46 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
                                    .WithSelfBinding(self_id, parent.block_depth)
                                    .WithCoroutineBody(body_is_coroutine);
 
-  // Formals are procedural vars of the body with no VarDeclStmt: pre-register
-  // them in the body scope at depth 0 so the body's references resolve. The
-  // backend renders these as C++ parameters rather than in-body declarations.
+  // Formals normalize into the signature's data flow (LRM 13.5). An `input` and
+  // a `ref` / `const ref` are parameters (the latter carries a `Ref<T>`); an
+  // `output` is not a parameter but a default-initialized body local whose
+  // final value rides the completion payload (copy-out at completion, not a
+  // live alias); an `inout` is both an input parameter and a payload component.
+  // Every formal is a body local at depth 0 so the body's references resolve.
+  completion_decl_depth_ = body_frame.block_depth;
   std::vector<mir::MethodParam> params;
-  params.reserve(src.params.size());
   for (const auto& param : src.params) {
     const auto& hir_var = src.body.procedural_vars.Get(param.var);
     const mir::TypeId value_type = module_->TranslateType(hir_var.type);
-    // A `ref` / `const ref` formal's type is a `Ref<T>` over the value type
-    // (LRM 13.5.2) -- the reference is itself the data type, so the direction
-    // stays `kInput`. Every other direction keeps the value type.
-    const bool by_reference = param.direction == hir::ParamDirection::kRef ||
-                              param.direction == hir::ParamDirection::kConstRef;
+    const hir::ParamDirection dir = param.direction;
+
+    if (dir == hir::ParamDirection::kOutput) {
+      const mir::ExprId default_init = body_block.exprs.Add(
+          BuildDefaultValueExpr(*module_, body_frame, value_type));
+      const mir::LocalRef local = body_block.AppendLocal(
+          mir::LocalDecl{.name = hir_var.name, .type = value_type},
+          default_init);
+      MapProceduralVar(
+          param.var, AutomaticVarBinding{
+                         .declaration_procedural_depth = body_frame.block_depth,
+                         .var = local.var,
+                         .type = value_type});
+      output_pack_vars_.push_back(local.var);
+      output_pack_types_.push_back(value_type);
+      continue;
+    }
+
+    // A `ref` / `const ref` formal's parameter type is a `Ref<T>` over the
+    // value type (LRM 13.5.2); every other parameter carries the value type.
+    const bool by_reference = dir == hir::ParamDirection::kRef ||
+                              dir == hir::ParamDirection::kConstRef;
     const mir::TypeId type =
-        by_reference ? module_->Unit().AddType(
-                           mir::TypeData{mir::RefType{
-                               .pointee = value_type,
-                               .is_const = param.direction ==
-                                           hir::ParamDirection::kConstRef}})
-                     : value_type;
+        by_reference
+            ? module_->Unit().AddType(
+                  mir::TypeData{mir::RefType{
+                      .pointee = value_type,
+                      .is_const = dir == hir::ParamDirection::kConstRef}})
+            : value_type;
     const mir::LocalId mir_var =
         body_block.vars.Add(mir::LocalDecl{.name = hir_var.name, .type = type});
     MapProceduralVar(
@@ -385,51 +390,59 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
                        .declaration_procedural_depth = body_frame.block_depth,
                        .var = mir_var,
                        .type = type});
-    params.push_back(
-        mir::MethodParam{
-            .name = hir_var.name,
-            .type = type,
-            .direction = LowerParamDirection(param.direction)});
+    params.push_back(mir::MethodParam{.name = hir_var.name, .type = type});
+    if (dir == hir::ParamDirection::kInOut) {
+      output_pack_vars_.push_back(mir_var);
+      output_pack_types_.push_back(value_type);
+    }
   }
 
-  // LRM 13.4.1 implicit result variable desugar. A non-void function returns
-  // the current value of its implicit same-name variable on fall-through; an
-  // assignment to the function name is a write to that variable, and an
-  // explicit `return expr` overrides it because it exits before the trailing
-  // read. Materialize the variable as a default-initialized body local
-  // (named distinctly from the C++ method so a self-recursive call still
-  // resolves to the method), then close the body with `return <result>`.
-  // void functions and tasks have no result variable and no trailing return.
-  // A task's call protocol is the coroutine type (LRM 13.3); a function's is
-  // its declared value or void type (LRM 13.4). The result type is the sole
-  // carrier of that protocol.
-  const mir::TypeId result_type = body_is_coroutine
-                                      ? module_->Unit().builtins.coroutine
-                                      : module_->TranslateType(src.result_type);
-  std::optional<mir::LocalRef> result_ref;
+  // LRM 13.4.1 implicit result variable. A non-void function's same-name var is
+  // a default-initialized body local (named distinctly from the C++ method so a
+  // self-recursive call still resolves to the method): the leading
+  // completion-payload component, the value a fall-through or value-less
+  // `return` carries. void functions and tasks have none.
+  std::vector<mir::TypeId> payload_components;
   if (src.result_var.has_value()) {
+    const mir::TypeId ret_type = module_->TranslateType(src.result_type);
     const mir::ExprId default_init = body_block.exprs.Add(
-        BuildDefaultValueExpr(*module_, body_frame, result_type));
-    result_ref = body_block.AppendLocal(
-        mir::LocalDecl{.name = "_lyra_result", .type = result_type},
-        default_init);
+        BuildDefaultValueExpr(*module_, body_frame, ret_type));
+    const mir::LocalRef result_ref = body_block.AppendLocal(
+        mir::LocalDecl{.name = "_lyra_result", .type = ret_type}, default_init);
     MapProceduralVar(
         *src.result_var,
         AutomaticVarBinding{
             .declaration_procedural_depth = body_frame.block_depth,
-            .var = result_ref->var,
-            .type = result_type});
+            .var = result_ref.var,
+            .type = ret_type});
+    result_var_ = result_ref.var;
+    result_value_type_ = ret_type;
+    payload_components.push_back(ret_type);
   }
+  for (const mir::TypeId t : output_pack_types_) {
+    payload_components.push_back(t);
+  }
+
+  // The completion payload is the function return (if any) plus each output /
+  // inout value, normalized by count. A task wraps it in the coroutine call
+  // protocol (LRM 13.3); a function's result is the payload itself (LRM 13.4).
+  completion_payload_type_ =
+      NormalizeCompletionPayload(module_->Unit(), payload_components);
+  const mir::TypeId result_type =
+      body_is_coroutine ? CoroutineOf(module_->Unit(), completion_payload_type_)
+                        : completion_payload_type_;
 
   auto lowered = LowerStraightLineBodyInto(*this, body_frame);
   if (!lowered) return std::unexpected(std::move(lowered.error()));
 
-  if (result_ref.has_value()) {
-    const mir::ExprId result_read = body_block.exprs.Add(
-        mir::Expr{.data = *result_ref, .type = result_type});
+  // Close the body with a trailing return of the fall-through payload. Absent
+  // when the payload is empty (a void function or a task with no outputs); the
+  // backend then supplies the bare `co_return;` for a coroutine.
+  if (auto trailing =
+          BuildReturnPayload(body_block, body_frame, std::nullopt)) {
     body_block.AppendStmt(
         mir::ReturnStmt{
-            .value = result_read,
+            .value = trailing,
             .is_coroutine_return = body_frame.is_coroutine_body});
   } else if (body_is_coroutine) {
     // A task is a coroutine with no result value: it completes by falling off
@@ -445,6 +458,33 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
       .params = std::move(params),
       .root_block = std::move(body_block),
       .form = mir::MethodForm::kStatic};
+}
+
+auto ProcessLowerer::BuildReturnPayload(
+    mir::Block& block, const WalkFrame& frame,
+    std::optional<mir::ExprId> explicit_value) -> std::optional<mir::ExprId> {
+  std::vector<mir::ExprId> components;
+  if (result_var_.has_value()) {
+    components.push_back(
+        explicit_value.has_value()
+            ? *explicit_value
+            : block.exprs.Add(
+                  mir::MakeLocalRefExpr(
+                      frame.block_depth - completion_decl_depth_, *result_var_,
+                      result_value_type_)));
+  }
+  for (std::size_t i = 0; i < output_pack_vars_.size(); ++i) {
+    components.push_back(block.exprs.Add(
+        mir::MakeLocalRefExpr(
+            frame.block_depth - completion_decl_depth_, output_pack_vars_[i],
+            output_pack_types_[i])));
+  }
+  if (components.empty()) return std::nullopt;
+  if (components.size() == 1) return components.front();
+  return block.exprs.Add(
+      mir::Expr{
+          .data = mir::TupleExpr{.components = std::move(components)},
+          .type = completion_payload_type_});
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -17,7 +17,7 @@
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
 #include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
-#include "lyra/lowering/hir_to_mir/copy_out_desugar.hpp"
+#include "lyra/lowering/hir_to_mir/completion_payload.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/expression/assignment.hpp"
 #include "lyra/lowering/hir_to_mir/expression/system/file_io.hpp"
@@ -222,36 +222,69 @@ auto SubroutineWithWritebacks(
   return nullptr;
 }
 
-// LRM 13.5 output / inout argument passing. A subroutine call whose formals
-// take values out is desugared into a block: a fresh local per writeback
-// formal (default-initialized for `output`, copy-in initialized for
-// `inout`), the call with those locals bound to the formals, then a
-// copy-out assignment of each local back to its actual lvalue.
+// One value the completion payload carries back to a caller place: the actual
+// lvalue to write and which payload component supplies it.
+struct CompletionWriteback {
+  mir::ExprId place{};
+  std::size_t component_index = 0;
+  mir::TypeId type{};
+};
+
+// LRM 13.5 output / inout argument passing. The callable's `output` / `inout`
+// values ride its completion payload: the call passes only the `input` values,
+// the `ref` aliases, and an `inout`'s incoming value; the payload's components
+// are then written back to the actual places after completion. A task awaits
+// the payload; a function's result is the payload directly. The whole thing
+// desugars into a block so the writebacks are explicit statements.
 //
-// `assign_target` is the lvalue for a `lhs = f(...)` statement, or nullopt
-// for a bare call statement (void function or discarded result).
+// `assign_target` is the lvalue for a `lhs = f(...)` statement -- it receives
+// the function-return component -- or nullopt for a bare call.
 auto LowerSubroutineCallWithWritebacks(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::CallExpr& call, const hir::StructuralSubroutineRef& callee_ref,
     const hir::StructuralSubroutineDecl& decl,
-    std::optional<hir::ExprId> assign_target, mir::TypeId result_type)
-    -> diag::Result<mir::Stmt> {
+    std::optional<hir::ExprId> assign_target) -> diag::Result<mir::Stmt> {
   if (call.arguments.size() != decl.params.size()) {
     throw InternalError(
         "LowerSubroutineCallWithWritebacks: argument / formal count mismatch");
   }
 
+  ModuleLowerer& module = process.Module();
+  mir::CompilationUnit& unit = module.Unit();
   const hir::ProceduralBody& hir_proc = process.HirBody();
   mir::Block wrapper;
   const WalkFrame wrapper_frame = frame.WithBlock(&wrapper).Deeper();
 
-  // The callee body takes its instance handle as `arguments[0]`; the SV
-  // actuals (with output / inout temps) follow.
+  // The completion layout the callee body and this call site share.
+  const std::vector<mir::TypeId> components =
+      CompletionComponentTypes(module, decl);
+  const mir::TypeId payload_type = NormalizeCompletionPayload(unit, components);
+  const bool is_task = decl.kind == hir::SubroutineKind::kTask;
+  const mir::TypeId call_result_type =
+      is_task ? CoroutineOf(unit, payload_type) : payload_type;
+
   std::vector<mir::ExprId> call_args;
   call_args.reserve(call.arguments.size() + 1);
   call_args.push_back(wrapper.exprs.Add(MakeSelfRefExpr(
       wrapper_frame, wrapper_frame.current_class->self_pointer_type)));
-  std::vector<OutputArgSlot> writebacks;
+
+  std::vector<CompletionWriteback> writebacks;
+  std::size_t next_component = 0;
+
+  // A non-void function's return is payload component 0; `lhs = f(...)` writes
+  // it back, a discarded result skips it.
+  if (decl.result_var.has_value()) {
+    if (assign_target.has_value()) {
+      auto lhs_or = process.LowerLhsExpr(
+          hir_proc.exprs.Get(*assign_target), wrapper_frame);
+      if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
+      writebacks.push_back(
+          {.place = wrapper.exprs.Add(*std::move(lhs_or)),
+           .component_index = 0,
+           .type = components.front()});
+    }
+    next_component = 1;
+  }
 
   for (std::size_t i = 0; i < call.arguments.size(); ++i) {
     const hir::ParamDirection dir = decl.params[i].direction;
@@ -261,86 +294,108 @@ auto LowerSubroutineCallWithWritebacks(
           "unexpectedly elided");
     }
     const hir::Expr& hir_arg = hir_proc.exprs.Get(*call.arguments[i]);
+    const mir::TypeId formal_type = module.TranslateType(
+        decl.body.procedural_vars.Get(decl.params[i].var).type);
 
-    if (!hir::RequiresWriteback(dir)) {
-      // A ref / const-ref formal aliases the actual's cell -- pass the cell
-      // (or a `ScopedMutation` for selector / range chains on an observable
-      // cell) so the body's `Ref<T>` binds the underlying storage.
-      const bool is_ref = dir == hir::ParamDirection::kRef ||
-                          dir == hir::ParamDirection::kConstRef;
-      if (is_ref) {
-        auto arg_or = process.LowerLhsExpr(hir_arg, wrapper_frame);
-        if (!arg_or) return std::unexpected(std::move(arg_or.error()));
-        mir::ExprId actual_id = wrapper.exprs.Add(*std::move(arg_or));
-        const mir::ExprId root_id = FindLhsRootId(wrapper, actual_id);
-        const bool root_is_cell = mir::IsObservableCellType(
-            process.Module().Unit().GetType(wrapper.exprs.Get(root_id).type));
-        if (root_is_cell && root_id != actual_id) {
-          const mir::ExprId services_id = wrapper.exprs.Add(
-              BuildServicesCallExpr(process.Module(), wrapper_frame));
-          actual_id = RewriteLhsRootWithMutate(
-              process.Module().Unit(), wrapper, actual_id, services_id);
-        }
-        call_args.push_back(BuildReferenceArg(
-            process.Module().Unit(), wrapper, actual_id,
-            wrapper.exprs.Get(actual_id).type));
-        continue;
+    // An `output` passes no argument; an `inout` passes its incoming value.
+    // Both bind the actual place for a post-completion writeback.
+    if (dir == hir::ParamDirection::kOutput ||
+        dir == hir::ParamDirection::kInOut) {
+      auto place_or = process.LowerLhsExpr(hir_arg, wrapper_frame);
+      if (!place_or) return std::unexpected(std::move(place_or.error()));
+      const mir::ExprId place = wrapper.exprs.Add(*std::move(place_or));
+      if (dir == hir::ParamDirection::kInOut) {
+        auto value_or = process.LowerExpr(hir_arg, wrapper_frame);
+        if (!value_or) return std::unexpected(std::move(value_or.error()));
+        call_args.push_back(wrapper.exprs.Add(*std::move(value_or)));
       }
-      auto arg_or = process.LowerExpr(hir_arg, wrapper_frame);
-      if (!arg_or) return std::unexpected(std::move(arg_or.error()));
-      call_args.push_back(wrapper.exprs.Add(*std::move(arg_or)));
+      writebacks.push_back(
+          {.place = place,
+           .component_index = next_component++,
+           .type = formal_type});
       continue;
     }
 
-    const mir::TypeId formal_type = process.Module().TranslateType(
-        decl.body.procedural_vars.Get(decl.params[i].var).type);
-    // The actual is the writeback target: lower it as a cell-typed lvalue
-    // so an observable destination's writeback fires `Var<T>::Set`.
-    auto target_or = process.LowerLhsExpr(hir_arg, wrapper_frame);
-    if (!target_or) return std::unexpected(std::move(target_or.error()));
-    const mir::ExprId actual_id = wrapper.exprs.Add(*std::move(target_or));
-
-    mir::ExprId init{};
-    if (dir == hir::ParamDirection::kInOut) {
-      auto value_or = process.LowerExpr(hir_arg, wrapper_frame);
-      if (!value_or) return std::unexpected(std::move(value_or.error()));
-      init = wrapper.exprs.Add(*std::move(value_or));
-    } else {
-      init = wrapper.exprs.Add(
-          BuildDefaultValueExpr(process.Module(), wrapper_frame, formal_type));
+    // A `ref` / const-ref formal aliases the actual's cell -- pass the cell
+    // (or a `ScopedMutation` for selector / range chains on an observable
+    // cell) so the body's `Ref<T>` binds the underlying storage.
+    const bool is_ref = dir == hir::ParamDirection::kRef ||
+                        dir == hir::ParamDirection::kConstRef;
+    if (is_ref) {
+      auto arg_or = process.LowerLhsExpr(hir_arg, wrapper_frame);
+      if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+      mir::ExprId actual_id = wrapper.exprs.Add(*std::move(arg_or));
+      const mir::ExprId root_id = FindLhsRootId(wrapper, actual_id);
+      const bool root_is_cell = mir::IsObservableCellType(
+          unit.GetType(wrapper.exprs.Get(root_id).type));
+      if (root_is_cell && root_id != actual_id) {
+        const mir::ExprId services_id =
+            wrapper.exprs.Add(BuildServicesCallExpr(module, wrapper_frame));
+        actual_id =
+            RewriteLhsRootWithMutate(unit, wrapper, actual_id, services_id);
+      }
+      call_args.push_back(BuildReferenceArg(
+          unit, wrapper, actual_id, wrapper.exprs.Get(actual_id).type));
+      continue;
     }
-    const mir::LocalRef temp = wrapper.AppendLocal(
-        mir::LocalDecl{
-            .name = "_lyra_arg" + std::to_string(i), .type = formal_type},
-        init);
-    call_args.push_back(
-        wrapper.exprs.Add(mir::Expr{.data = temp, .type = formal_type}));
-    writebacks.push_back(
-        {.actual = actual_id, .temp = temp, .type = formal_type});
+
+    auto arg_or = process.LowerExpr(hir_arg, wrapper_frame);
+    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
+    call_args.push_back(wrapper.exprs.Add(*std::move(arg_or)));
   }
 
-  mir::Expr call_expr{
-      .data =
-          mir::CallExpr{
-              .callee = process.Owner().TranslateStructuralSubroutine(
-                  callee_ref.hops, callee_ref.subroutine),
-              .arguments = std::move(call_args)},
-      .type = result_type};
+  const mir::ExprId call_id = wrapper.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee = process.Owner().TranslateStructuralSubroutine(
+                      callee_ref.hops, callee_ref.subroutine),
+                  .arguments = std::move(call_args)},
+          .type = call_result_type});
 
-  std::optional<mir::ExprId> assign_target_id = std::nullopt;
-  if (assign_target.has_value()) {
-    auto lhs_or =
-        process.LowerLhsExpr(hir_proc.exprs.Get(*assign_target), wrapper_frame);
-    if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-    assign_target_id = wrapper.exprs.Add(*std::move(lhs_or));
-  }
+  // The completion value is the awaited payload for a task, the call result for
+  // a function; bind it to a local that every writeback projects from (and that
+  // the backend reuses as the task's completion slot).
+  const mir::ExprId completion_value =
+      is_task ? wrapper.exprs.Add(
+                    mir::Expr{
+                        .data = mir::AwaitExpr{.awaitable = call_id},
+                        .type = payload_type})
+              : call_id;
+  const mir::LocalRef completion = wrapper.AppendLocal(
+      mir::LocalDecl{.name = "_lyra_completion", .type = payload_type},
+      completion_value);
 
   const mir::ExprId services_id =
-      wrapper.exprs.Add(BuildServicesCallExpr(process.Module(), wrapper_frame));
-  return BuildCopyOutBlock(
-      process.Module().Unit(), services_id, frame, std::move(wrapper),
-      std::move(label), result_type, std::move(call_expr),
-      decl.kind == hir::SubroutineKind::kTask, assign_target_id, writebacks);
+      wrapper.exprs.Add(BuildServicesCallExpr(module, wrapper_frame));
+  const mir::TypeId void_type = unit.builtins.void_type;
+  for (const CompletionWriteback& wb : writebacks) {
+    // A single-component payload is the bare value; otherwise project the
+    // component out of the tuple.
+    mir::ExprId value_id{};
+    if (components.size() == 1) {
+      value_id =
+          wrapper.exprs.Add(mir::Expr{.data = completion, .type = wb.type});
+    } else {
+      const mir::ExprId tuple_read = wrapper.exprs.Add(
+          mir::Expr{.data = completion, .type = payload_type});
+      value_id = wrapper.exprs.Add(
+          mir::Expr{
+              .data =
+                  mir::TupleGetExpr{
+                      .tuple = tuple_read, .index = wb.component_index},
+              .type = wb.type});
+    }
+    const mir::Expr assign_expr = BuildObservableAssignExpr(
+        unit, wrapper, services_id, wb.place, value_id, std::nullopt, wb.type,
+        void_type);
+    wrapper.AppendStmt(mir::ExprStmt{.expr = wrapper.exprs.Add(assign_expr)});
+  }
+
+  const mir::BlockId scope_id =
+      frame.current_block->child_scopes.Add(std::move(wrapper));
+  return mir::Stmt{
+      .label = std::move(label), .data = mir::BlockStmt{.scope = scope_id}};
 }
 
 }  // namespace
@@ -378,7 +433,7 @@ auto LowerExprStmt(
       return LowerSubroutineCallWithWritebacks(
           process, frame, std::move(label), *call,
           std::get<hir::StructuralSubroutineRef>(call->callee), *decl,
-          std::nullopt, process.Module().TranslateType(inner.type));
+          std::nullopt);
     }
     bool suspends = false;
     if (const auto* sys_ref =
@@ -440,8 +495,7 @@ auto LowerExprStmt(
             return LowerSubroutineCallWithWritebacks(
                 process, frame, std::move(label), *call,
                 std::get<hir::StructuralSubroutineRef>(call->callee), *decl,
-                assign->lhs,
-                process.Module().TranslateType(call_carrier->type));
+                assign->lhs);
           }
         }
         if (const auto* sys_ref =

--- a/src/lyra/lowering/hir_to_mir/statement/flow.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/flow.cpp
@@ -136,17 +136,22 @@ auto LowerReturnStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
     const hir::ReturnStmt& r) -> diag::Result<mir::Stmt> {
   auto& block = *frame.current_block;
-  std::optional<mir::ExprId> value;
+  std::optional<mir::ExprId> explicit_value;
   if (r.value.has_value()) {
     auto value_or =
         process.LowerExpr(process.HirBody().exprs.Get(*r.value), frame);
     if (!value_or) return std::unexpected(std::move(value_or.error()));
-    value = block.exprs.Add(*std::move(value_or));
+    explicit_value = block.exprs.Add(*std::move(value_or));
   }
+  // The returned value is the completion payload: this return's explicit value
+  // (or the implicit result variable) plus each output / inout local, assembled
+  // by the subroutine's lowering so the copy-out rides the result (LRM 13.5).
+  const std::optional<mir::ExprId> payload =
+      process.BuildReturnPayload(block, frame, explicit_value);
   return mir::Stmt{
       .label = std::move(label),
       .data = mir::ReturnStmt{
-          .value = value, .is_coroutine_return = frame.is_coroutine_body}};
+          .value = payload, .is_coroutine_return = frame.is_coroutine_body}};
 }
 
 auto LowerBreakStmt(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -599,6 +599,11 @@ class MirDumper {
               return std::format(
                   "AwaitExpr awaitable=Expr[{}]", a.awaitable.value);
             },
+            [](const TupleGetExpr& g) -> std::string {
+              return std::format(
+                  "TupleGetExpr tuple=Expr[{}] index={}", g.tuple.value,
+                  g.index);
+            },
         },
         e.data);
     return std::format("{} type=Type[{}]", formatted, e.type.value);
@@ -699,19 +704,6 @@ class MirDumper {
     Dedent();
   }
 
-  [[nodiscard]] static auto FormatParamDirection(ParamDirection dir)
-      -> std::string_view {
-    switch (dir) {
-      case ParamDirection::kInput:
-        return "input";
-      case ParamDirection::kOutput:
-        return "output";
-      case ParamDirection::kInOut:
-        return "inout";
-    }
-    throw InternalError("FormatParamDirection: unknown mir::ParamDirection");
-  }
-
   [[nodiscard]] static auto FormatMethodForm(MethodForm form)
       -> std::string_view {
     switch (form) {
@@ -733,9 +725,7 @@ class MirDumper {
       const auto& param = d.params[i];
       Line(
           std::format(
-              "Param[{}] {} \"{}\" : Type[{}]", i,
-              FormatParamDirection(param.direction), param.name,
-              param.type.value));
+              "Param[{}] \"{}\" : Type[{}]", i, param.name, param.type.value));
     }
     DumpBlock(d.root_block);
     Dedent();

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -234,7 +234,7 @@ void Engine::ExecutePostponedRegion() {
 void Engine::ExecuteFinalProcesses() {
   phase_ = SchedulerPhase::kPostponed;
   for (CoroutineHandle handle : queues_.finals) {
-    const bool completed = handle.promise().Process().ResumeWith(handle);
+    const bool completed = handle->Process().ResumeWith(handle);
     if (completed) {
       continue;
     }
@@ -313,7 +313,7 @@ void Engine::RunProcess(CoroutineHandle handle) {
   // during await_suspend. Capture the owning process before resuming, since
   // `handle` may be an enabled task's frame that is destroyed as control
   // returns up the enable chain.
-  RuntimeProcess& process = handle.promise().Process();
+  RuntimeProcess& process = handle->Process();
   const bool completed = process.ResumeWith(handle);
   // A spawned process (a fork-join branch) is owned by the engine for its
   // dynamic lifetime; drop it the moment it finishes -- executor-standard
@@ -342,8 +342,8 @@ void Engine::TriggerValueChange(
   for (CoroutineHandle handle : observable.TakeMatchingWaiters(classify)) {
     // Clean up sibling subscriptions so they don't leak across waits when this
     // frame re-enters the runnable queue.
-    for (Observable* other : std::exchange(
-             handle.promise().pending_value_change_subscriptions, {})) {
+    for (Observable* other :
+         std::exchange(handle->pending_value_change_subscriptions, {})) {
       if (other != &observable) {
         other->Unsubscribe(handle);
       }
@@ -368,7 +368,7 @@ void Engine::ScheduleAtTime(SimTime when, CoroutineHandle handle) {
   queues_.delayed[when].push_back(handle);
 }
 
-void Engine::Spawn(Coroutine coroutine) {
+void Engine::Spawn(Coroutine<void> coroutine) {
   auto process = std::make_unique<RuntimeProcess>(
       ProcessKind::kSpawned, std::move(coroutine));
   const CoroutineHandle handle = process->TopHandle();

--- a/src/lyra/runtime/runtime_process.cpp
+++ b/src/lyra/runtime/runtime_process.cpp
@@ -8,7 +8,7 @@
 
 namespace lyra::runtime {
 
-RuntimeProcess::RuntimeProcess(ProcessKind kind, Coroutine coroutine)
+RuntimeProcess::RuntimeProcess(ProcessKind kind, Coroutine<void> coroutine)
     : kind_(kind), coroutine_(std::move(coroutine)) {
   // Wire the promise's back-pointer so coroutine-side code (awaitables)
   // can recover the RuntimeProcess identity from within await_suspend.
@@ -28,7 +28,7 @@ auto RuntimeProcess::ResumeWith(CoroutineHandle handle) -> bool {
     throw InternalError("RuntimeProcess::ResumeWith: reentrant resume");
   }
   state_ = ProcessState::kRunning;
-  handle.resume();
+  handle->self.resume();
   // A task's exception propagates up the enable chain to the top-level promise,
   // so it is read there regardless of which frame threw.
   if (auto exc = std::exchange(

--- a/src/lyra/runtime/runtime_services.cpp
+++ b/src/lyra/runtime/runtime_services.cpp
@@ -61,7 +61,7 @@ void RuntimeServices::RequestFinish(int level, bool fatal) {
   engine_->RequestFinish(level, fatal);
 }
 
-void RuntimeServices::Spawn(Coroutine coroutine) {
+void RuntimeServices::Spawn(Coroutine<void> coroutine) {
   if (engine_ == nullptr) {
     throw InternalError("RuntimeServices::Spawn: no Engine bound");
   }

--- a/src/lyra/runtime/scope.cpp
+++ b/src/lyra/runtime/scope.cpp
@@ -136,7 +136,7 @@ auto Scope::Services() -> RuntimeServices& {
   return *services_;
 }
 
-auto Scope::AddProcess(ProcessKind kind, Coroutine coroutine)
+auto Scope::AddProcess(ProcessKind kind, Coroutine<void> coroutine)
     -> RuntimeProcess& {
   processes_.push_back(
       std::make_unique<RuntimeProcess>(kind, std::move(coroutine)));


### PR DESCRIPTION
## Summary

Parameter direction becomes data flow on the callable's completion payload. An `output` or `inout` no longer lowers to a by-reference C++ parameter; its final value rides the callable's typed result, normalized by arity -- zero components is void, one is the bare component, two or more a tuple. A `ref` / `const ref` stays the one live alias, carried as a `Ref<T>` parameter, and `mir::ParamDirection` is removed. The runtime realizes this with a typed `Coroutine<T>` whose promise carries the completion payload, so `co_await` of a call yields the value directly and the backend render stays a mechanical reflection of MIR.

## Design

A new architecture contract documents the runtime execution model -- the activation as the one suspendable execution instance, its completion slot as the typed terminal outcome, and the distinct ownership / continuation / cancellation relations -- in backend-neutral vocabulary, with the C++ coroutine as one realization. A companion progress doc records where the current runtime still differs from that contract.

## Testing

`bazel test //...` passes for every target except `cpp_tests`, which fails on 317 cases that fail identically on `main` today -- a pre-existing packed-reshape codegen defect unrelated to this change, with a separate cast-rendering fix in flight. This branch adds zero new failures relative to `main`.
