### PR TITLE
Strip diagnostic plumbing and lift operator dispatch to MIR

### DIFF
--- a/include/lyra/backend/cpp/api.hpp
+++ b/include/lyra/backend/cpp/api.hpp
@@ -2,10 +2,8 @@
 
 #include <span>
 #include <string>
-#include <vector>
 
 #include "lyra/backend/cpp/artifact.hpp"
-#include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 
 namespace lyra::backend::cpp {
@@ -17,13 +15,12 @@ struct TopInstance {
   const mir::CompilationUnit* unit;
 };
 
-auto EmitCppDeclarations(const mir::CompilationUnit& unit)
-    -> diag::Result<std::vector<CppArtifact>>;
+auto EmitCppDeclarations(const mir::CompilationUnit& unit) -> CppArtifact;
 
 auto EmitCppHostMain(std::span<const TopInstance> tops) -> CppArtifact;
 
 auto EmitCpp(
     std::span<const mir::CompilationUnit> units,
-    std::span<const TopInstance> tops) -> diag::Result<CppArtifactSet>;
+    std::span<const TopInstance> tops) -> CppArtifactSet;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/backend/cpp/render_expr.hpp
+++ b/include/lyra/backend/cpp/render_expr.hpp
@@ -3,27 +3,24 @@
 #include <string>
 
 #include "lyra/backend/cpp/scope_view.hpp"
-#include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/expr.hpp"
 
 namespace lyra::backend::cpp {
 
-auto RenderExpr(const ScopeView& view, const mir::Expr& expr)
-    -> diag::Result<std::string>;
+auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string;
 
 // Renders `expr` as an lvalue: bare root + element / range select suffixes.
 // Throws InternalError on non-addressable forms. The cell's `Mutate(svc)`
 // adapter (if any) is encoded explicitly in MIR as a
 // `DerefExpr(CallExpr(ObservableMethod{kMutate}, ...))` node by HIR-to-MIR,
 // so this render is purely mechanical -- it does not inject any wrapper.
-auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
-    -> diag::Result<std::string>;
+auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr) -> std::string;
 
 // Renders `expr` for use in a C++ boolean context (`if`, `while`, `do`, `for`
 // condition, ternary cond, `&&` / `||` / `!`). When the expression's MIR type
 // is a packed array, `PackedArray`'s `explicit operator bool` fires on the
 // contextual conversion; no explicit wrapping is needed.
 auto RenderConditionAsBool(const ScopeView& view, const mir::Expr& expr)
-    -> diag::Result<std::string>;
+    -> std::string;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/backend/cpp/render_stmt.hpp
+++ b/include/lyra/backend/cpp/render_stmt.hpp
@@ -4,20 +4,19 @@
 #include <string>
 
 #include "lyra/backend/cpp/scope_view.hpp"
-#include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/stmt.hpp"
 
 namespace lyra::backend::cpp {
 
 auto RenderNestedBlock(
     const ScopeView& parent, const mir::Block& block, std::size_t indent)
-    -> diag::Result<std::string>;
+    -> std::string;
 
 auto RenderBlockStatements(const ScopeView& view, std::size_t indent)
-    -> diag::Result<std::string>;
+    -> std::string;
 
 auto RenderStmt(
     const ScopeView& view, const mir::Stmt& stmt, std::size_t indent)
-    -> diag::Result<std::string>;
+    -> std::string;
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/backend/cpp/render_type.hpp
+++ b/include/lyra/backend/cpp/render_type.hpp
@@ -2,7 +2,6 @@
 
 #include <string>
 
-#include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/type.hpp"
@@ -14,7 +13,7 @@ namespace lyra::backend::cpp {
 // `ObjectType::target` ids are resolved against its nested classes.
 [[nodiscard]] auto RenderTypeAsCpp(
     const mir::CompilationUnit& unit, const mir::Class& owner_class,
-    mir::TypeId type_id) -> diag::Result<std::string>;
+    mir::TypeId type_id) -> std::string;
 
 // Renders the constructor argument list for a `lyra::value::PackedArray`
 // variable declared from a kExplicit packed array type, in the form

--- a/include/lyra/lowering/hir_to_mir/case_cascade.hpp
+++ b/include/lyra/lowering/hir_to_mir/case_cascade.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/lowering/hir_to_mir/expression/operators.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/binary_op.hpp"
@@ -48,7 +49,8 @@ template <typename LabelLowerer>
 auto BuildEqualityChain(
     WalkFrame frame, CaseSnapshotRefs snapshot, mir::TypeId bit_type,
     mir::BinaryOp compare_op, std::uint32_t sel_hops, std::size_t label_count,
-    LabelLowerer&& lower_label) -> diag::Result<mir::ExprId> {
+    LabelLowerer&& lower_label, const mir::CompilationUnit& unit)
+    -> diag::Result<mir::ExprId> {
   auto& enc_scope = *frame.current_block;
   std::optional<mir::ExprId> acc;
   for (std::size_t i = 0; i < label_count; ++i) {
@@ -64,19 +66,11 @@ auto BuildEqualityChain(
                     .hops = mir::BlockHops{.value = sel_hops},
                     .var = snapshot.sel_var},
             .type = snapshot.sel_type});
-    const mir::ExprId cmp = enc_scope.exprs.Add(
-        mir::Expr{
-            .data =
-                mir::BinaryExpr{
-                    .op = compare_op, .lhs = sel_ref, .rhs = label_id},
-            .type = bit_type});
+    const mir::ExprId cmp = enc_scope.exprs.Add(BuildMirBinaryExpr(
+        unit, enc_scope, compare_op, sel_ref, label_id, bit_type));
     if (acc.has_value()) {
-      acc = enc_scope.exprs.Add(
-          mir::Expr{
-              .data =
-                  mir::BinaryExpr{
-                      .op = mir::BinaryOp::kLogicalOr, .lhs = *acc, .rhs = cmp},
-              .type = bit_type});
+      acc = enc_scope.exprs.Add(BuildMirBinaryExpr(
+          unit, enc_scope, mir::BinaryOp::kLogicalOr, *acc, cmp, bit_type));
     } else {
       acc = cmp;
     }

--- a/include/lyra/lowering/hir_to_mir/expression/operators.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/operators.hpp
@@ -22,6 +22,28 @@ namespace lyra::lowering::hir_to_mir {
 // is a legitimate target).
 auto LowerBinaryOp(hir::BinaryOp op) -> mir::BinaryOp;
 
+// HIR-to-MIR binary-operator realization. Takes the lowered operand ids
+// (already in `block`) and dispatches on `(op, lhs_type, rhs_type)`:
+// method-style operators (LRM 11.4 shifts / power / xnor / wildcard / case /
+// implication / equivalence) lift to a `CallExpr` against the matching
+// `BuiltinFn` realization on the receiver value type; real / string
+// comparison and logical operators wrap in `kFromBool` (with `BoolCastExpr`
+// around the operands for the logical family); the rest produce a native
+// `BinaryExpr` for the backend to render mechanically. Shared between
+// `LowerHirBinaryExpr` and the case-cascade builder so every site that
+// produces a binary operator goes through one lift.
+auto BuildMirBinaryExpr(
+    const mir::CompilationUnit& unit, mir::Block& block, mir::BinaryOp op,
+    mir::ExprId lhs_id, mir::ExprId rhs_id, mir::TypeId result_type)
+    -> mir::Expr;
+
+// Symmetric helper for unary operators: reduction ops lift to a `CallExpr`
+// against `BuiltinFn`, a real `kLogicalNot` wraps in `kFromBool`, every
+// other op produces a native `UnaryExpr`.
+auto BuildMirUnaryExpr(
+    const mir::CompilationUnit& unit, mir::Block& block, mir::UnaryOp op,
+    mir::ExprId operand_id, mir::TypeId result_type) -> mir::Expr;
+
 // An operator's meaning is independent of the enclosing scope, so one template
 // over the pass class serves both the procedural and structural contexts. The
 // pass class is reached through a uniform `HirExprs` / `LowerExpr` surface, so

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -45,8 +45,30 @@ struct RealLiteral {
 // produce for a default-init pointer.
 struct NullLiteral {};
 
+// A host-language integer literal: renders as a bare C++ integer (e.g.
+// `42LL`), not as a `PackedArray::Int(42)` runtime value. Used at the
+// boundary between MIR and the runtime when a runtime entry's signature
+// takes a host scalar (`uint64_t` bit-width, `bool` flag) rather than a
+// SV-typed value. `Expr::type` is conventionally `builtins.int32` so
+// downstream type accounting stays uniform; the host-int-ness is implicit
+// from the node kind.
+struct HostIntLiteral {
+  std::int64_t value;
+};
+
 struct UnaryExpr {
   UnaryOp op;
+  ExprId operand;
+};
+
+// Reduces an operand to a host `bool`. Used to bring real / string operands
+// onto the host-bool plane before a C++ native logical operator (`&&`, `||`,
+// `!`), and as the inner argument of `BuiltinFn::kFromBool` when the result
+// must re-shape to a 1-bit packed value. `Expr::type` is conventionally
+// `builtins.bit1` (the result is observable only after `FromBool` re-shapes
+// it; the operand of a `BoolCastExpr` is whatever the host's `bool(...)`
+// conversion accepts).
+struct BoolCastExpr {
   ExprId operand;
 };
 
@@ -224,10 +246,10 @@ struct TupleGetExpr {
 
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, NullLiteral,
-    ParamRef, LocalRef, UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr,
-    IncDecExpr, CallExpr, DerefExpr, AddressOfExpr, CastExpr, MemberAccessExpr,
-    ClosureExpr, ConcatExpr, ReplicationExpr, ArrayLiteralExpr, TupleExpr,
-    AwaitExpr, TupleGetExpr>;
+    HostIntLiteral, ParamRef, LocalRef, UnaryExpr, BinaryExpr, BoolCastExpr,
+    ConditionalExpr, AssignExpr, IncDecExpr, CallExpr, DerefExpr, AddressOfExpr,
+    CastExpr, MemberAccessExpr, ClosureExpr, ConcatExpr, ReplicationExpr,
+    ArrayLiteralExpr, TupleExpr, AwaitExpr, TupleGetExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -232,6 +232,35 @@ enum class BuiltinFn : std::uint16_t {
   kConvertFrom,
   kFromPackedArray,
   kFromByteArray,
+  // Operator realizations on `PackedArray`. HIR-to-MIR lifts the
+  // method-style SV operators (LRM 11.4) into `CallExpr` against these
+  // entries, so the backend renders every operator mechanically: native
+  // forms (`+`, `==`, ...) collapse to a single formatter, method forms
+  // route through the call path. The shift / power / xnor / wildcard /
+  // case / implication / equivalence ids are instance methods on the
+  // receiver (`args[0]`); the reduction ids likewise take the operand as
+  // `args[0]`. `kFromBool` is a static factory that wraps a host bool
+  // into a 1-bit `PackedArray` (used to shape the result of a real /
+  // string comparison or logical operator into the LRM 11.3 / 11.4 1-bit
+  // integral result type).
+  kPow,
+  kShiftLeft,
+  kLogicalShiftRight,
+  kArithmeticShiftRight,
+  kBitwiseXnor,
+  kLogicalImplication,
+  kLogicalEquivalence,
+  kWildcardEquals,
+  kCaseEqual,
+  kCasezEquals,
+  kCasexEquals,
+  kReductionAnd,
+  kReductionOr,
+  kReductionXor,
+  kReductionNand,
+  kReductionNor,
+  kReductionXnor,
+  kFromBool,
 };
 
 // True iff `id` is a type-namespace-qualified static call -- no receiver,
@@ -242,7 +271,7 @@ enum class BuiltinFn : std::uint16_t {
   return id == BuiltinFn::kEnumFirst || id == BuiltinFn::kEnumLast ||
          id == BuiltinFn::kEnumNum || id == BuiltinFn::kFromInt ||
          id == BuiltinFn::kConvertFrom || id == BuiltinFn::kFromPackedArray ||
-         id == BuiltinFn::kFromByteArray;
+         id == BuiltinFn::kFromByteArray || id == BuiltinFn::kFromBool;
 }
 
 // True iff the function modifies its receiver argument's storage in place.

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -85,6 +85,13 @@ class PackedArray {
   // such as `IsUnknown()`. Sibling of `Int(int32_t)` / `Byte`.
   [[nodiscard]] static auto Bit(bool value) -> PackedArray;
 
+  // Same shape as `Bit`, but named after the call-site role: shapes the
+  // host-bool result of a real / string comparison or logical operator into
+  // the LRM 11.3 / 11.4 1-bit integral result. HIR-to-MIR emits this via
+  // `BuiltinFn::kFromBool`; renamed at the call site so reading the emitted
+  // C++ keeps the SV-level reason visible.
+  [[nodiscard]] static auto FromBool(bool value) -> PackedArray;
+
   // Construct a narrow PackedArray (bit_width <= 64) from an integer value.
   // The `std::int64_t` parameter is the carrier type wide enough to cover
   // every narrow width; the resulting shape is set by `bit_width`, with bits
@@ -452,7 +459,7 @@ class PackedArray {
   [[nodiscard]] auto ArithmeticShiftRight(const PackedArray& amount) const
       -> PackedArray;
 
-  [[nodiscard]] auto Power(const PackedArray& exponent) const -> PackedArray;
+  [[nodiscard]] auto Pow(const PackedArray& exponent) const -> PackedArray;
 
   [[nodiscard]] auto ReductionAnd() const -> PackedArray;
   [[nodiscard]] auto ReductionOr() const -> PackedArray;

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -4,7 +4,6 @@
 #include <span>
 #include <string>
 #include <string_view>
-#include <utility>
 #include <variant>
 #include <vector>
 
@@ -16,7 +15,6 @@
 #include "lyra/backend/cpp/scope_view.hpp"
 #include "lyra/backend/cpp/string_literal.hpp"
 #include "lyra/base/internal_error.hpp"
-#include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/member.hpp"
@@ -30,10 +28,9 @@ namespace {
 
 auto RenderField(
     const ScopeView& ctor_view, const mir::MemberDecl& var, std::size_t indent)
-    -> diag::Result<std::string> {
+    -> std::string {
   const auto& unit = ctor_view.Unit();
-  auto type_or = RenderTypeAsCpp(unit, ctor_view.Class(), var.type);
-  if (!type_or) return std::unexpected(std::move(type_or.error()));
+  std::string type = RenderTypeAsCpp(unit, ctor_view.Class(), var.type);
   // An upward reference is an ExternUp member: its constructor takes the
   // symbol payload (ancestor, by-name tail, leaf signal) rather than a value
   // initializer; it registers itself and relocates in the resolve phase.
@@ -42,7 +39,7 @@ auto RenderField(
     std::string tail = "{";
     for (std::size_t i = 0; i < er->tail.size(); ++i) {
       if (i != 0) tail += ", ";
-      tail += "{\"" + er->tail[i].name + "\", {";
+      tail += std::format("{{\"{}\", {{", er->tail[i].name);
       for (std::size_t j = 0; j < er->tail[i].indices.size(); ++j) {
         if (j != 0) tail += ", ";
         tail += std::to_string(er->tail[i].indices[j]);
@@ -53,36 +50,33 @@ auto RenderField(
     const std::string match = er->match == mir::ExternalRefMatch::kDefName
                                   ? "lyra::runtime::UpwardMatch::kDefName"
                                   : "lyra::runtime::UpwardMatch::kScopeName";
-    return Indent(indent) + *type_or + " " + var.name + "{this, \"" +
-           er->ancestor + "\", " + match + ", " + tail + ", \"" + er->signal +
-           "\"};\n";
+    return std::format(
+        "{}{} {}{{this, \"{}\", {}, {}, \"{}\"}};\n", Indent(indent), type,
+        var.name, er->ancestor, match, tail, er->signal);
   }
-  return Indent(indent) + *type_or + " " + var.name + "{};\n";
+  return std::format("{}{} {}{{}};\n", Indent(indent), type, var.name);
 }
 
 auto RenderParamField(
     const mir::CompilationUnit& unit, const mir::Class& owner_class,
-    const mir::ParamDecl& param, std::size_t indent)
-    -> diag::Result<std::string> {
-  auto type_or = RenderTypeAsCpp(unit, owner_class, param.type);
-  if (!type_or) return std::unexpected(std::move(type_or.error()));
-  return Indent(indent) + "const " + *type_or + " " + param.name + ";\n";
+    const mir::ParamDecl& param, std::size_t indent) -> std::string {
+  return std::format(
+      "{}const {} {};\n", Indent(indent),
+      RenderTypeAsCpp(unit, owner_class, param.type), param.name);
 }
 
 auto CtorParamName(std::size_t index) -> std::string {
-  return "param" + std::to_string(index);
+  return std::format("param{}", index);
 }
 
 auto RenderMethodParam(
     const mir::CompilationUnit& unit, const mir::Class& s,
-    const mir::MethodParam& param) -> diag::Result<std::string> {
-  auto type_or = RenderTypeAsCpp(unit, s, param.type);
-  if (!type_or) return std::unexpected(std::move(type_or.error()));
+    const mir::MethodParam& param) -> std::string {
   // Every formal is a value parameter: an `input` by value (LRM 13.5.1), a
   // `ref` / `const ref` whose `RefType` already renders as `(const) Ref<T>` so
   // the reference value carries the aliasing (LRM 13.5.2). `output` / `inout`
   // are not parameters -- they ride the completion payload.
-  return *type_or + " " + param.name;
+  return std::format("{} {}", RenderTypeAsCpp(unit, s, param.type), param.name);
 }
 
 // The one renderer for every method. A method's declaration is rendered from
@@ -96,7 +90,7 @@ auto RenderMethodParam(
 auto RenderMethod(
     const ScopeView* parent_struct_view, const mir::CompilationUnit& unit,
     const mir::Class& s, const mir::MethodDecl& m, std::size_t indent)
-    -> diag::Result<std::string> {
+    -> std::string {
   const bool is_static = m.form == mir::MethodForm::kStatic;
   const ScopeView base_view =
       (parent_struct_view == nullptr)
@@ -105,54 +99,49 @@ auto RenderMethod(
   const ScopeView body_view =
       base_view.WithSelfSpelling(is_static ? "self" : "this");
 
-  auto ret_or = RenderTypeAsCpp(unit, s, m.result_type);
-  if (!ret_or) return std::unexpected(std::move(ret_or.error()));
+  std::string ret = RenderTypeAsCpp(unit, s, m.result_type);
 
   std::string sig =
-      std::string(is_static ? "static auto " : "auto ") + m.name + "(";
+      std::format("{}{}(", is_static ? "static auto " : "auto ", m.name);
   bool first = true;
   if (is_static) {
-    sig += s.name + "* self";
+    sig += std::format("{}* self", s.name);
     first = false;
   }
   for (const auto& param : m.params) {
-    auto param_or = RenderMethodParam(unit, s, param);
-    if (!param_or) return std::unexpected(std::move(param_or.error()));
     if (!first) sig += ", ";
-    sig += *param_or;
+    sig += RenderMethodParam(unit, s, param);
     first = false;
   }
-  sig += ") -> " + *ret_or;
+  sig += std::format(") -> {}", ret);
   if (!is_static) {
     sig += " override";
   }
 
   std::string out;
-  out += Indent(indent) + sig + " {\n";
-  auto body_or = RenderBlockStatements(body_view, indent + 1);
-  if (!body_or) return std::unexpected(std::move(body_or.error()));
-  out += *body_or;
-  out += Indent(indent) + "}\n";
+  out += std::format("{}{} {{\n", Indent(indent), sig);
+  out += RenderBlockStatements(body_view, indent + 1);
+  out += std::format("{}}}\n", Indent(indent));
   return out;
 }
 
 auto RenderConstructor(
     const ScopeView& scope_view, const mir::Class& s,
-    const std::string& base_class, std::size_t indent)
-    -> diag::Result<std::string> {
-  std::string sig = s.name +
-                    "(lyra::runtime::Scope* parent, std::string name, "
-                    "lyra::runtime::RuntimeServices& services";
-  std::string init_list = base_class + "(parent, std::move(name), services)";
+    const std::string& base_class, std::size_t indent) -> std::string {
+  std::string sig = std::format(
+      "{}(lyra::runtime::Scope* parent, std::string name, "
+      "lyra::runtime::RuntimeServices& services",
+      s.name);
+  std::string init_list =
+      std::format("{}(parent, std::move(name), services)", base_class);
   for (std::size_t i = 0; i < s.params.size(); ++i) {
     const auto& p = s.params.Get(mir::ParamId{static_cast<std::uint32_t>(i)});
     const auto param_name = CtorParamName(i);
-    auto type_or = RenderTypeAsCpp(scope_view.Unit(), s, p.type);
-    if (!type_or) return std::unexpected(std::move(type_or.error()));
-    sig += ", " + *type_or + " " + param_name;
-    init_list += ", " + p.name + "(" + param_name + ")";
+    sig += std::format(
+        ", {} {}", RenderTypeAsCpp(scope_view.Unit(), s, p.type), param_name);
+    init_list += std::format(", {}({})", p.name, param_name);
   }
-  sig += ") : " + init_list;
+  sig += std::format(") : {}", init_list);
 
   // The C++ constructor is the one shape that is not an ordinary method: it has
   // no result type and runs a member-init list before its body, so it cannot
@@ -161,15 +150,14 @@ auto RenderConstructor(
   // body -- a static worker over `self`, the same body shape every method uses.
   // An empty body needs no kickoff.
   if (s.constructor_block.root_stmts.empty()) {
-    return Indent(indent) + sig + " {}\n";
+    return std::format("{}{} {{}}\n", Indent(indent), sig);
   }
   std::string out;
-  out += Indent(indent) + sig + " { init(this); }\n";
-  out += Indent(indent) + "static auto init(" + s.name + "* self) -> void {\n";
-  auto body_or = RenderBlockStatements(scope_view, indent + 1);
-  if (!body_or) return std::unexpected(std::move(body_or.error()));
-  out += *body_or;
-  out += Indent(indent) + "}\n";
+  out += std::format("{}{} {{ init(this); }}\n", Indent(indent), sig);
+  out += std::format(
+      "{}static auto init({}* self) -> void {{\n", Indent(indent), s.name);
+  out += RenderBlockStatements(scope_view, indent + 1);
+  out += std::format("{}}}\n", Indent(indent));
   return out;
 }
 
@@ -189,19 +177,19 @@ auto RenderProcessKindLiteral(mir::ProcessKind kind) -> std::string {
 auto RenderCreateProcesses(const mir::Class& s, std::size_t indent)
     -> std::string {
   std::string out;
-  out += Indent(indent) + "void CreateProcesses() override {\n";
+  out += std::format("{}void CreateProcesses() override {{\n", Indent(indent));
   for (const auto& p : s.processes) {
-    out += Indent(indent + 1) + "AddProcess(" +
-           RenderProcessKindLiteral(p.kind) + ", " + p.code.name + "(this));\n";
+    out += std::format(
+        "{}AddProcess({}, {}(this));\n", Indent(indent + 1),
+        RenderProcessKindLiteral(p.kind), p.code.name);
   }
-  out += Indent(indent) + "}\n";
+  out += std::format("{}}}\n", Indent(indent));
   return out;
 }
 
 auto RenderScopeAsClass(
     const mir::CompilationUnit& unit, const mir::Class& s, std::size_t indent,
-    bool is_top_level, const ScopeView* parent_struct_view)
-    -> diag::Result<std::string> {
+    bool is_top_level, const ScopeView* parent_struct_view) -> std::string {
   // `this_anchor` is bound to `s.constructor_block` so it doubles as the
   // view for rendering the constructor body. Children's bodies use it as
   // their enclosing class (one hop above the child).
@@ -216,48 +204,37 @@ auto RenderScopeAsClass(
       is_top_level ? "lyra::runtime::Instance" : "lyra::runtime::GenScope";
 
   std::string out;
-  out += Indent(indent) + "class " + s.name + " final : public " + base_class +
-         " {\n";
-  out += Indent(indent) + " public:\n";
+  out += std::format(
+      "{}class {} final : public {} {{\n", Indent(indent), s.name, base_class);
+  out += std::format("{} public:\n", Indent(indent));
 
   // The scope's own time precision (LRM 3.14.2). The engine takes the minimum
   // across the tree as the design-global tick (LRM 3.14.3); the runtime scales
   // a local-precision delay from this value to that tick.
-  out += Indent(indent + 1) +
-         "auto TimePrecisionPower() const -> std::int8_t override { return " +
-         std::to_string(static_cast<int>(s.time_resolution.precision_power)) +
-         "; }\n\n";
+  out += std::format(
+      "{}auto TimePrecisionPower() const -> std::int8_t override {{ return "
+      "{}; }}\n\n",
+      Indent(indent + 1), static_cast<int>(s.time_resolution.precision_power));
 
   for (const auto& child : s.nested_classes) {
-    auto child_or =
-        RenderScopeAsClass(unit, child, indent + 1, false, &this_anchor);
-    if (!child_or) return std::unexpected(std::move(child_or.error()));
-    out += *child_or;
+    out += RenderScopeAsClass(unit, child, indent + 1, false, &this_anchor);
   }
   if (!s.nested_classes.empty()) {
     out += "\n";
   }
 
-  auto ctor_or = RenderConstructor(this_anchor, s, base_class, indent + 1);
-  if (!ctor_or) return std::unexpected(std::move(ctor_or.error()));
-  out += *ctor_or;
+  out += RenderConstructor(this_anchor, s, base_class, indent + 1);
 
   // The resolve and initialize phases run after construction; each is a
   // virtual override the engine dispatches, present only when the scope has
   // work for that phase. They render through the one method renderer.
   if (s.resolve.has_value()) {
     out += "\n";
-    auto body_or =
-        RenderMethod(parent_struct_view, unit, s, *s.resolve, indent + 1);
-    if (!body_or) return std::unexpected(std::move(body_or.error()));
-    out += *body_or;
+    out += RenderMethod(parent_struct_view, unit, s, *s.resolve, indent + 1);
   }
   if (s.initialize.has_value()) {
     out += "\n";
-    auto body_or =
-        RenderMethod(parent_struct_view, unit, s, *s.initialize, indent + 1);
-    if (!body_or) return std::unexpected(std::move(body_or.error()));
-    out += *body_or;
+    out += RenderMethod(parent_struct_view, unit, s, *s.initialize, indent + 1);
   }
 
   // Child links are registered automatically at construction and walked by the
@@ -270,9 +247,10 @@ auto RenderScopeAsClass(
   // A unit-root scope is a module; its name is the def-name an upward reference
   // matches when climbing the parent chain (LRM 23.8).
   if (is_top_level) {
-    out += Indent(indent + 1) +
-           "auto DefName() const -> std::string_view override { return \"" +
-           s.name + "\"; }\n";
+    out += std::format(
+        "{}auto DefName() const -> std::string_view override {{ return "
+        "\"{}\"; }}\n",
+        Indent(indent + 1), s.name);
   }
 
   // Members follow the constructor and methods. They are public so cross-unit
@@ -281,43 +259,34 @@ auto RenderScopeAsClass(
     out += "\n";
   }
   for (const auto& p : s.params) {
-    auto field_or = RenderParamField(unit, s, p, indent + 1);
-    if (!field_or) return std::unexpected(std::move(field_or.error()));
-    out += *field_or;
+    out += RenderParamField(unit, s, p, indent + 1);
   }
   if (!s.params.empty() && !s.members.empty()) {
     out += "\n";
   }
   for (const auto& v : s.members) {
-    auto field_or = RenderField(this_anchor, v, indent + 1);
-    if (!field_or) return std::unexpected(std::move(field_or.error()));
-    out += *field_or;
+    out += RenderField(this_anchor, v, indent + 1);
   }
 
   if (s.processes.empty() && s.methods.empty()) {
-    out += Indent(indent) + "};\n";
+    out += std::format("{}}};\n", Indent(indent));
     return out;
   }
 
   out += "\n";
-  out += Indent(indent) + " private:\n";
+  out += std::format("{} private:\n", Indent(indent));
 
   for (const auto& p : s.processes) {
     out += "\n";
-    auto body_or =
-        RenderMethod(parent_struct_view, unit, s, p.code, indent + 1);
-    if (!body_or) return std::unexpected(std::move(body_or.error()));
-    out += *body_or;
+    out += RenderMethod(parent_struct_view, unit, s, p.code, indent + 1);
   }
 
   for (const auto& sub : s.methods) {
     out += "\n";
-    auto body_or = RenderMethod(parent_struct_view, unit, s, sub, indent + 1);
-    if (!body_or) return std::unexpected(std::move(body_or.error()));
-    out += *body_or;
+    out += RenderMethod(parent_struct_view, unit, s, sub, indent + 1);
   }
 
-  out += Indent(indent) + "};\n";
+  out += std::format("{}}};\n", Indent(indent));
   return out;
 }
 
@@ -337,8 +306,7 @@ auto CollectExternalUnitNames(const mir::CompilationUnit& unit)
 }
 
 auto RenderScopeHeaderFile(
-    const mir::CompilationUnit& unit, const mir::Class& s)
-    -> diag::Result<std::string> {
+    const mir::CompilationUnit& unit, const mir::Class& s) -> std::string {
   std::string out;
   out += "#pragma once\n";
   out += "#include <array>\n";
@@ -377,7 +345,7 @@ auto RenderScopeHeaderFile(
   out += "#include \"lyra/value/unpacked_array.hpp\"\n";
   out += "#include \"lyra/value/dynamic_array.hpp\"\n";
   for (const auto& name : CollectExternalUnitNames(unit)) {
-    out += "#include \"" + name + ".hpp\"\n";
+    out += std::format("#include \"{}.hpp\"\n", name);
   }
   out += "\n";
   bool any_enum = false;
@@ -418,18 +386,15 @@ auto RenderScopeHeaderFile(
   // for a given target supplies the class name itself).
   bool any_alias = false;
   for (const auto& alias : s.type_aliases) {
-    auto target_or = RenderTypeAsCpp(unit, s, alias.target);
-    if (!target_or) return std::unexpected(std::move(target_or.error()));
-    if (alias.name == *target_or) continue;
-    out += std::format("using {} = {};\n", alias.name, *target_or);
+    std::string target = RenderTypeAsCpp(unit, s, alias.target);
+    if (alias.name == target) continue;
+    out += std::format("using {} = {};\n", alias.name, target);
     any_alias = true;
   }
   if (any_alias) {
     out += "\n";
   }
-  auto class_or = RenderScopeAsClass(unit, s, 0, true, nullptr);
-  if (!class_or) return std::unexpected(std::move(class_or.error()));
-  out += *class_or;
+  out += RenderScopeAsClass(unit, s, 0, true, nullptr);
   return out;
 }
 
@@ -440,18 +405,19 @@ auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
   out += "#include \"lyra/runtime/engine.hpp\"\n";
   out += "#include \"lyra/runtime/simulation_entry.hpp\"\n";
   for (const auto& top : tops) {
-    out += "#include \"" + top.unit->top_class.name + ".hpp\"\n";
+    out += std::format("#include \"{}.hpp\"\n", top.unit->top_class.name);
   }
   out += "\n";
   out += "auto main() -> int {\n";
   out += "  lyra::runtime::Engine engine;\n";
   for (std::size_t i = 0; i < tops.size(); ++i) {
-    out += "  " + tops[i].unit->top_class.name + " top" + std::to_string(i) +
-           "{nullptr, \"" + tops[i].name + "\", engine.Services()};\n";
+    out += std::format(
+        "  {} top{}{{nullptr, \"{}\", engine.Services()}};\n",
+        tops[i].unit->top_class.name, i, tops[i].name);
   }
   out += "  std::vector<lyra::runtime::TopBinding> tops = {\n";
   for (std::size_t i = 0; i < tops.size(); ++i) {
-    out += "      {&top" + std::to_string(i) + "},\n";
+    out += std::format("      {{&top{}}},\n", i);
   }
   out += "  };\n";
   out += "  engine.BindDesign(tops);\n";
@@ -462,15 +428,11 @@ auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
 
 }  // namespace
 
-auto EmitCppDeclarations(const mir::CompilationUnit& unit)
-    -> diag::Result<std::vector<CppArtifact>> {
-  std::vector<CppArtifact> headers;
+auto EmitCppDeclarations(const mir::CompilationUnit& unit) -> CppArtifact {
   const auto& root = unit.top_class;
-  auto content_or = RenderScopeHeaderFile(unit, root);
-  if (!content_or) return std::unexpected(std::move(content_or.error()));
-  headers.push_back(
-      {.relpath = root.name + ".hpp", .content = *std::move(content_or)});
-  return headers;
+  return {
+      .relpath = std::format("{}.hpp", root.name),
+      .content = RenderScopeHeaderFile(unit, root)};
 }
 
 auto EmitCppHostMain(std::span<const TopInstance> tops) -> CppArtifact {
@@ -479,14 +441,10 @@ auto EmitCppHostMain(std::span<const TopInstance> tops) -> CppArtifact {
 
 auto EmitCpp(
     std::span<const mir::CompilationUnit> units,
-    std::span<const TopInstance> tops) -> diag::Result<CppArtifactSet> {
+    std::span<const TopInstance> tops) -> CppArtifactSet {
   CppArtifactSet set;
   for (const auto& unit : units) {
-    auto headers_or = EmitCppDeclarations(unit);
-    if (!headers_or) return std::unexpected(std::move(headers_or.error()));
-    for (auto& h : *headers_or) {
-      set.files.push_back(std::move(h));
-    }
+    set.files.push_back(EmitCppDeclarations(unit));
   }
   set.files.push_back(EmitCppHostMain(tops));
   return set;

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -7,7 +7,6 @@
 #include <span>
 #include <string>
 #include <string_view>
-#include <utility>
 #include <variant>
 
 #include "lyra/backend/cpp/render_stmt.hpp"
@@ -16,8 +15,6 @@
 #include "lyra/backend/cpp/string_literal.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
-#include "lyra/diag/diag_code.hpp"
-#include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/cast.hpp"
 #include "lyra/mir/expr.hpp"
@@ -28,17 +25,6 @@
 namespace lyra::backend::cpp {
 
 namespace {
-
-// Type-kind predicate. `real`, `shortreal`, and `realtime` (LRM 6.12)
-// collectively form the "real family"; arithmetic / relational / logical
-// operator dispatch all branch on this. Taking the full `mir::Type` instead
-// of `TypeKind` keeps the call-site spelling consistent with `IsIntegralPacked`
-// / `IsEnum` on `mir::Type` itself.
-auto IsRealFamilyType(const mir::Type& ty) -> bool {
-  return ty.Kind() == mir::TypeKind::kReal ||
-         ty.Kind() == mir::TypeKind::kShortReal ||
-         ty.Kind() == mir::TypeKind::kRealTime;
-}
 
 auto IntegralConstantToInt64(const mir::IntegralConstant& c) -> std::int64_t {
   if (c.width == 0U) {
@@ -131,7 +117,7 @@ auto RenderPackedArrayIntegerLiteral(
 
 auto RenderIntegerLiteralExpr(
     const ScopeView& view, const mir::Expr& expr,
-    const mir::IntegerLiteral& lit) -> diag::Result<std::string> {
+    const mir::IntegerLiteral& lit) -> std::string {
   const auto& ty = view.Unit().GetType(expr.type);
   if (!ty.IsIntegralPacked()) {
     throw InternalError(
@@ -175,15 +161,14 @@ auto RenderRealLiteralExpr(
 }
 
 auto RenderParamExpr(const ScopeView& view, const mir::ParamRef& r)
-    -> diag::Result<std::string> {
+    -> std::string {
   if (r.hops.value != 0) {
-    return diag::Fail(
-        diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+    throw InternalError(
         "cross-scope param access is not yet implemented in "
         "cpp emit");
   }
   const std::string& name = view.Class().params.Get(r.param).name;
-  return std::string(view.SelfSpelling()) + "->" + name;
+  return std::format("{}->{}", view.SelfSpelling(), name);
 }
 
 auto LookupLocalName(const ScopeView& view, const mir::LocalRef& ref)
@@ -203,309 +188,123 @@ auto LookupLocalName(const ScopeView& view, const mir::LocalRef& ref)
 
 namespace {
 
-// Builds the C++ literal that materializes a 1-bit PackedArray of the SV-typed
-// shape carried by `result_ty`. Used to wrap the C++ `bool` result of a
-// real-operand relational / equality / logical operator into the 1-bit
-// integral PackedArray result type LRM 11.3.1 prescribes.
-auto WrapBoolAsResultShape(
-    const mir::Type& result_ty, std::string_view bool_expr) -> std::string {
-  if (!result_ty.IsIntegralPacked()) {
-    throw InternalError(
-        "WrapBoolAsResultShape: real comparison / logical result type is "
-        "not an integral PackedArray; MIR invariant violated");
-  }
-  return std::format(
-      "lyra::value::PackedArray::FromInt(({}) ? 1LL : 0LL, {})", bool_expr,
-      RenderPackedArrayCtorArgs(result_ty.AsIntegralPacked()));
-}
-
-auto RenderBinaryOpString(
-    mir::BinaryOp op, const std::string& lhs, const std::string& rhs,
-    const mir::Type& result_ty) -> diag::Result<std::string> {
-  // LRM 6.16 Table 6-9: equality compares contents; relational ops use
-  // lexicographic ordering (str.compare semantics). std::string's operator==
-  // and operator< match these directly.
-  switch (op) {
-    case mir::BinaryOp::kEquality:
-      return WrapBoolAsResultShape(result_ty, lhs + " == " + rhs);
-    case mir::BinaryOp::kInequality:
-      return WrapBoolAsResultShape(result_ty, lhs + " != " + rhs);
-    case mir::BinaryOp::kLessThan:
-      return WrapBoolAsResultShape(result_ty, lhs + " < " + rhs);
-    case mir::BinaryOp::kLessEqual:
-      return WrapBoolAsResultShape(result_ty, lhs + " <= " + rhs);
-    case mir::BinaryOp::kGreaterThan:
-      return WrapBoolAsResultShape(result_ty, lhs + " > " + rhs);
-    case mir::BinaryOp::kGreaterEqual:
-      return WrapBoolAsResultShape(result_ty, lhs + " >= " + rhs);
-    default:
-      break;
-  }
-  return diag::Fail(
-      diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-      "binary operator is not legal on string operands per LRM 6.16");
-}
-
-auto RenderBinaryOpReal(
-    mir::BinaryOp op, const std::string& lhs, const std::string& rhs,
-    const mir::Type& result_ty) -> diag::Result<std::string> {
-  // LRM 11.3.1 + Table 11-1: arithmetic on real produces real; relational and
-  // equality return a 1-bit `PackedArray` directly from the `RealValue`
-  // operator. Logical operators reduce each operand to a host bool first, then
-  // re-shape into the result's integral type.
+// The C++ operator token for the SV binary ops that render natively. The
+// method-style ops (shifts, power, xnor, wildcard / case / implication /
+// equivalence) are lifted to `CallExpr` at HIR-to-MIR and never reach this
+// dispatch; reaching one is an MIR-invariant violation.
+auto BinaryOpToken(mir::BinaryOp op) -> std::string_view {
   switch (op) {
     case mir::BinaryOp::kAdd:
-      return "(" + lhs + " + " + rhs + ")";
+      return "+";
     case mir::BinaryOp::kSub:
-      return "(" + lhs + " - " + rhs + ")";
+      return "-";
     case mir::BinaryOp::kMul:
-      return "(" + lhs + " * " + rhs + ")";
+      return "*";
     case mir::BinaryOp::kDiv:
-      return "(" + lhs + " / " + rhs + ")";
-    case mir::BinaryOp::kPower:
-      return "(" + lhs + ").Pow(" + rhs + ")";
-    case mir::BinaryOp::kLessThan:
-      return "(" + lhs + " < " + rhs + ")";
-    case mir::BinaryOp::kLessEqual:
-      return "(" + lhs + " <= " + rhs + ")";
-    case mir::BinaryOp::kGreaterThan:
-      return "(" + lhs + " > " + rhs + ")";
-    case mir::BinaryOp::kGreaterEqual:
-      return "(" + lhs + " >= " + rhs + ")";
-    case mir::BinaryOp::kEquality:
-      return "(" + lhs + " == " + rhs + ")";
-    case mir::BinaryOp::kInequality:
-      return "(" + lhs + " != " + rhs + ")";
-    case mir::BinaryOp::kLogicalAnd:
-      return WrapBoolAsResultShape(
-          result_ty, "bool(" + lhs + ") && bool(" + rhs + ")");
-    case mir::BinaryOp::kLogicalOr:
-      return WrapBoolAsResultShape(
-          result_ty, "bool(" + lhs + ") || bool(" + rhs + ")");
-    case mir::BinaryOp::kLogicalImplication:
-      return WrapBoolAsResultShape(
-          result_ty, "!bool(" + lhs + ") || bool(" + rhs + ")");
-    case mir::BinaryOp::kLogicalEquivalence:
-      return WrapBoolAsResultShape(
-          result_ty, "bool(" + lhs + ") == bool(" + rhs + ")");
-    default:
-      break;
-  }
-  return diag::Fail(
-      diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-      "binary operator is not legal on real operands per LRM 11.3.1");
-}
-
-// LRM 11.2.2 + 11.4.5: aggregate equality / inequality / case-equality /
-// case-inequality. Both `UnpackedArray` and `DynamicArray` overload `==` /
-// `!=` to return a 1-bit `PackedArray` (X / Z propagating) and expose
-// `CaseEqual` as a method returning a 1-bit `PackedArray` (0 / 1 only). The
-// dynamic-array overloads additionally short-circuit on runtime size
-// mismatch -> 0 (industry convention, LRM 11.2.2 is silent). Relational
-// operators are not defined on aggregate operands.
-auto RenderBinaryOpArray(
-    mir::BinaryOp op, const std::string& lhs, const std::string& rhs)
-    -> diag::Result<std::string> {
-  switch (op) {
-    case mir::BinaryOp::kEquality:
-      return "(" + lhs + " == " + rhs + ")";
-    case mir::BinaryOp::kInequality:
-      return "(" + lhs + " != " + rhs + ")";
-    case mir::BinaryOp::kCaseEquality:
-      return "(" + lhs + ").CaseEqual(" + rhs + ")";
-    case mir::BinaryOp::kCaseInequality:
-      return "!(" + lhs + ").CaseEqual(" + rhs + ")";
-    default:
-      break;
-  }
-  return diag::Fail(
-      diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-      "binary operator is not legal on aggregate operands per LRM 11.2.2");
-}
-
-auto RenderBinaryOpIntegral(
-    mir::BinaryOp op, const std::string& lhs, const std::string& rhs)
-    -> diag::Result<std::string> {
-  std::string_view tok;
-  switch (op) {
-    case mir::BinaryOp::kAdd:
-      tok = " + ";
-      break;
-    case mir::BinaryOp::kSub:
-      tok = " - ";
-      break;
-    case mir::BinaryOp::kMul:
-      tok = " * ";
-      break;
-    case mir::BinaryOp::kDiv:
-      tok = " / ";
-      break;
+      return "/";
     case mir::BinaryOp::kMod:
-      tok = " % ";
-      break;
+      return "%";
     case mir::BinaryOp::kBitwiseAnd:
-      tok = " & ";
-      break;
+      return "&";
     case mir::BinaryOp::kBitwiseOr:
-      tok = " | ";
-      break;
+      return "|";
     case mir::BinaryOp::kBitwiseXor:
-      tok = " ^ ";
-      break;
+      return "^";
     case mir::BinaryOp::kEquality:
-      tok = " == ";
-      break;
+      return "==";
     case mir::BinaryOp::kInequality:
-      tok = " != ";
-      break;
+      return "!=";
     case mir::BinaryOp::kLessThan:
-      tok = " < ";
-      break;
+      return "<";
     case mir::BinaryOp::kLessEqual:
-      tok = " <= ";
-      break;
+      return "<=";
     case mir::BinaryOp::kGreaterThan:
-      tok = " > ";
-      break;
+      return ">";
     case mir::BinaryOp::kGreaterEqual:
-      tok = " >= ";
-      break;
+      return ">=";
     case mir::BinaryOp::kLogicalAnd:
-      return "(" + lhs + " && " + rhs + ")";
+      return "&&";
     case mir::BinaryOp::kLogicalOr:
-      return "(" + lhs + " || " + rhs + ")";
-    case mir::BinaryOp::kBitwiseXnor:
-      return "(" + lhs + ").BitwiseXnor(" + rhs + ")";
+      return "||";
     case mir::BinaryOp::kPower:
-      return "(" + lhs + ").Power(" + rhs + ")";
+    case mir::BinaryOp::kBitwiseXnor:
     case mir::BinaryOp::kShiftLeft:
-      return "(" + lhs + ").ShiftLeft(" + rhs + ")";
     case mir::BinaryOp::kLogicalShiftRight:
-      return "(" + lhs + ").LogicalShiftRight(" + rhs + ")";
     case mir::BinaryOp::kArithmeticShiftRight:
-      return "(" + lhs + ").ArithmeticShiftRight(" + rhs + ")";
     case mir::BinaryOp::kLogicalImplication:
-      return "(" + lhs + ").LogicalImplication(" + rhs + ")";
     case mir::BinaryOp::kLogicalEquivalence:
-      return "(" + lhs + ").LogicalEquivalence(" + rhs + ")";
     case mir::BinaryOp::kWildcardEquality:
-      return "(" + lhs + ").WildcardEquals(" + rhs + ")";
     case mir::BinaryOp::kWildcardInequality:
-      return "(!(" + lhs + ").WildcardEquals(" + rhs + "))";
     case mir::BinaryOp::kCaseEquality:
-      return "(" + lhs + ").CaseEqual(" + rhs + ")";
     case mir::BinaryOp::kCaseInequality:
-      return "(!(" + lhs + ").CaseEqual(" + rhs + "))";
     case mir::BinaryOp::kCasezEquality:
-      return "(" + lhs + ").CasezEquals(" + rhs + ")";
     case mir::BinaryOp::kCasexEquality:
-      return "(" + lhs + ").CasexEquals(" + rhs + ")";
+      throw InternalError(
+          "BinaryOpToken: method-style operator reached backend render; "
+          "HIR-to-MIR should have lifted it to a CallExpr");
   }
-  return "(" + lhs + std::string{tok} + rhs + ")";
+  throw InternalError("BinaryOpToken: unknown MIR BinaryOp");
 }
 
-auto RenderUnaryOpReal(
-    mir::UnaryOp op, const std::string& operand, const mir::Type& result_ty)
-    -> diag::Result<std::string> {
+auto UnaryOpToken(mir::UnaryOp op) -> std::string_view {
   switch (op) {
-    case mir::UnaryOp::kPlus:
-      return "(" + operand + ")";
     case mir::UnaryOp::kMinus:
-      return "(-(" + operand + "))";
-    case mir::UnaryOp::kLogicalNot:
-      return WrapBoolAsResultShape(result_ty, "!bool(" + operand + ")");
-    default:
-      break;
-  }
-  return diag::Fail(
-      diag::DiagCode::kCppEmitExpressionFormNotImplemented,
-      "unary operator is not legal on real operands per LRM 11.3.1");
-}
-
-auto RenderUnaryOpIntegral(mir::UnaryOp op, const std::string& operand)
-    -> diag::Result<std::string> {
-  switch (op) {
-    case mir::UnaryOp::kPlus:
-      return "(" + operand + ")";
-    case mir::UnaryOp::kMinus:
-      return "(-" + operand + ")";
+      return "-";
     case mir::UnaryOp::kBitwiseNot:
-      return "(~" + operand + ")";
+      return "~";
     case mir::UnaryOp::kLogicalNot:
-      return "(!(" + operand + "))";
+      return "!";
+    case mir::UnaryOp::kPlus:
+      // kPlus has no C++ token: PackedArray / String have no `operator+()`
+      // (LRM 11.4.3 unary plus is a no-op), so render emits the bare
+      // operand instead -- handled separately in `RenderUnaryExpr`.
     case mir::UnaryOp::kReductionAnd:
-      return "(" + operand + ").ReductionAnd()";
     case mir::UnaryOp::kReductionOr:
-      return "(" + operand + ").ReductionOr()";
     case mir::UnaryOp::kReductionXor:
-      return "(" + operand + ").ReductionXor()";
     case mir::UnaryOp::kReductionNand:
-      return "(" + operand + ").ReductionNand()";
     case mir::UnaryOp::kReductionNor:
-      return "(" + operand + ").ReductionNor()";
     case mir::UnaryOp::kReductionXnor:
-      return "(" + operand + ").ReductionXnor()";
+      throw InternalError(
+          "UnaryOpToken: operator has no native C++ token; "
+          "kPlus is identity (handled by RenderUnaryExpr) and reductions "
+          "lift to CallExpr at HIR-to-MIR");
   }
-  throw InternalError("RenderUnaryOpIntegral: unknown MIR UnaryOp");
+  throw InternalError("UnaryOpToken: unknown MIR UnaryOp");
 }
 
-auto RenderUnaryExpr(
-    const ScopeView& view, const mir::Expr& expr, const mir::UnaryExpr& u)
-    -> diag::Result<std::string> {
-  const auto& operand_expr = view.Expr(u.operand);
-  auto operand_or = RenderExpr(view, operand_expr);
-  if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-  if (IsRealFamilyType(view.Unit().GetType(operand_expr.type))) {
-    return RenderUnaryOpReal(u.op, *operand_or, view.Unit().GetType(expr.type));
+auto RenderUnaryExpr(const ScopeView& view, const mir::UnaryExpr& u)
+    -> std::string {
+  std::string operand = RenderExpr(view, view.Expr(u.operand));
+  // LRM 11.4.3: unary plus is an identity; no C++ `operator+()` exists on
+  // PackedArray / String / RealValue, so render the operand directly.
+  if (u.op == mir::UnaryOp::kPlus) {
+    return std::format("({})", operand);
   }
-  return RenderUnaryOpIntegral(u.op, *operand_or);
+  return std::format("({}{})", UnaryOpToken(u.op), operand);
 }
 
-auto RenderBinaryExpr(
-    const ScopeView& view, const mir::Expr& expr, const mir::BinaryExpr& b)
-    -> diag::Result<std::string> {
-  const auto& lhs_expr = view.Expr(b.lhs);
-  const auto& rhs_expr = view.Expr(b.rhs);
-  auto lhs_or = RenderExpr(view, lhs_expr);
-  if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  auto rhs_or = RenderExpr(view, rhs_expr);
-  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
-  // Slang inserts a propagated `ConversionExpr` on the narrower operand so by
-  // the time we reach a binary op both sides share a precision class. Dispatch
-  // by operand kind: real-family (LRM 11.3.1), string (LRM 6.16 Table 6-9),
-  // else integral PackedArray ops.
-  const auto& lhs_ty = view.Unit().GetType(lhs_expr.type);
-  const auto& rhs_ty = view.Unit().GetType(rhs_expr.type);
-  if (IsRealFamilyType(lhs_ty) || IsRealFamilyType(rhs_ty)) {
-    return RenderBinaryOpReal(
-        b.op, *lhs_or, *rhs_or, view.Unit().GetType(expr.type));
-  }
-  if (lhs_ty.Kind() == mir::TypeKind::kString &&
-      rhs_ty.Kind() == mir::TypeKind::kString) {
-    return RenderBinaryOpString(
-        b.op, *lhs_or, *rhs_or, view.Unit().GetType(expr.type));
-  }
-  const bool lhs_is_array =
-      std::holds_alternative<mir::UnpackedArrayType>(lhs_ty.data) ||
-      std::holds_alternative<mir::DynamicArrayType>(lhs_ty.data);
-  const bool rhs_is_array =
-      std::holds_alternative<mir::UnpackedArrayType>(rhs_ty.data) ||
-      std::holds_alternative<mir::DynamicArrayType>(rhs_ty.data);
-  if (lhs_is_array && rhs_is_array) {
-    return RenderBinaryOpArray(b.op, *lhs_or, *rhs_or);
-  }
-  return RenderBinaryOpIntegral(b.op, *lhs_or, *rhs_or);
+auto RenderBinaryExpr(const ScopeView& view, const mir::BinaryExpr& b)
+    -> std::string {
+  return std::format(
+      "({} {} {})", RenderExpr(view, view.Expr(b.lhs)), BinaryOpToken(b.op),
+      RenderExpr(view, view.Expr(b.rhs)));
+}
+
+// Brings an operand onto the host-bool plane so a native C++ logical
+// operator (`&&` / `||` / `!`) can take it. The wrap is observable only as
+// the operand of `kFromBool` -- the value-shape re-projection back to the
+// SV 1-bit integral lives there.
+auto RenderBoolCastExpr(const ScopeView& view, const mir::BoolCastExpr& b)
+    -> std::string {
+  return std::format("bool({})", RenderExpr(view, view.Expr(b.operand)));
 }
 
 auto RenderConditionalExpr(const ScopeView& view, const mir::ConditionalExpr& c)
-    -> diag::Result<std::string> {
-  auto cond_or = RenderConditionAsBool(view, view.Expr(c.condition));
-  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  auto then_or = RenderExpr(view, view.Expr(c.then_value));
-  if (!then_or) return std::unexpected(std::move(then_or.error()));
-  auto else_or = RenderExpr(view, view.Expr(c.else_value));
-  if (!else_or) return std::unexpected(std::move(else_or.error()));
-  return "(" + *cond_or + " ? " + *then_or + " : " + *else_or + ")";
+    -> std::string {
+  return std::format(
+      "({} ? {} : {})", RenderConditionAsBool(view, view.Expr(c.condition)),
+      RenderExpr(view, view.Expr(c.then_value)),
+      RenderExpr(view, view.Expr(c.else_value)));
 }
 
 // `mir::CastExpr` is a type-level view change with no runtime semantic
@@ -518,12 +317,11 @@ auto RenderConditionalExpr(const ScopeView& view, const mir::ConditionalExpr& c)
 // path.
 auto RenderCastExpr(
     const ScopeView& view, const mir::Expr& expr, const mir::CastExpr& cast)
-    -> diag::Result<std::string> {
-  auto operand_or = RenderExpr(view, view.Expr(cast.operand));
-  if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-  auto dest_or = RenderTypeAsCpp(view.Unit(), view.Class(), expr.type);
-  if (!dest_or) return std::unexpected(std::move(dest_or.error()));
-  return "static_cast<" + *dest_or + ">(" + *std::move(operand_or) + ")";
+    -> std::string {
+  return std::format(
+      "static_cast<{}>({})",
+      RenderTypeAsCpp(view.Unit(), view.Class(), expr.type),
+      RenderExpr(view, view.Expr(cast.operand)));
 }
 
 // The bare C++ identifier this backend declares the builtin fn as. One
@@ -740,6 +538,42 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "FromPackedArray";
     case support::BuiltinFn::kFromByteArray:
       return "FromByteArray";
+    case support::BuiltinFn::kPow:
+      return "Pow";
+    case support::BuiltinFn::kShiftLeft:
+      return "ShiftLeft";
+    case support::BuiltinFn::kLogicalShiftRight:
+      return "LogicalShiftRight";
+    case support::BuiltinFn::kArithmeticShiftRight:
+      return "ArithmeticShiftRight";
+    case support::BuiltinFn::kBitwiseXnor:
+      return "BitwiseXnor";
+    case support::BuiltinFn::kLogicalImplication:
+      return "LogicalImplication";
+    case support::BuiltinFn::kLogicalEquivalence:
+      return "LogicalEquivalence";
+    case support::BuiltinFn::kWildcardEquals:
+      return "WildcardEquals";
+    case support::BuiltinFn::kCaseEqual:
+      return "CaseEqual";
+    case support::BuiltinFn::kCasezEquals:
+      return "CasezEquals";
+    case support::BuiltinFn::kCasexEquals:
+      return "CasexEquals";
+    case support::BuiltinFn::kReductionAnd:
+      return "ReductionAnd";
+    case support::BuiltinFn::kReductionOr:
+      return "ReductionOr";
+    case support::BuiltinFn::kReductionXor:
+      return "ReductionXor";
+    case support::BuiltinFn::kReductionNand:
+      return "ReductionNand";
+    case support::BuiltinFn::kReductionNor:
+      return "ReductionNor";
+    case support::BuiltinFn::kReductionXnor:
+      return "ReductionXnor";
+    case support::BuiltinFn::kFromBool:
+      return "FromBool";
     case support::BuiltinFn::kFileOpen:
       return "Open";
     case support::BuiltinFn::kFileClose:
@@ -802,31 +636,28 @@ auto BuiltinFnCppNamespace(support::BuiltinFn id) -> std::string_view {
 // the separator mechanically.
 auto RenderBuiltinFnCall(
     const ScopeView& view, const mir::CallExpr& call, support::BuiltinFn id)
-    -> diag::Result<std::string> {
+    -> std::string {
   if (call.arguments.empty()) {
     throw InternalError(
         "RenderBuiltinFnCall: instance call expects a receiver argument");
   }
   const mir::Expr& receiver = view.Expr(call.arguments[0]);
-  auto recv_or = RenderExpr(view, receiver);
-  if (!recv_or) return std::unexpected(std::move(recv_or.error()));
+  auto recv = RenderExpr(view, receiver);
   const std::string_view sep =
       view.Unit().GetType(receiver.type).Kind() == mir::TypeKind::kPointer
           ? "->"
           : ".";
   std::string args;
   for (std::size_t i = 1; i < call.arguments.size(); ++i) {
-    auto arg_or = RenderExpr(view, view.Expr(call.arguments[i]));
-    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
     if (i != 1) args += ", ";
-    args += *std::move(arg_or);
+    args += RenderExpr(view, view.Expr(call.arguments[i]));
   }
-  return std::format("({}){}{}({})", *recv_or, sep, BuiltinFnCppName(id), args);
+  return std::format("({}){}{}({})", recv, sep, BuiltinFnCppName(id), args);
 }
 
 auto RenderFreeFnCall(
     const ScopeView& view, const mir::CallExpr& call, support::BuiltinFn id)
-    -> diag::Result<std::string> {
+    -> std::string {
   const std::string_view ns = BuiltinFnCppNamespace(id);
   if (ns.empty()) {
     throw InternalError(
@@ -834,27 +665,33 @@ auto RenderFreeFnCall(
   }
   std::string args;
   for (std::size_t i = 0; i < call.arguments.size(); ++i) {
-    auto arg_or = RenderExpr(view, view.Expr(call.arguments[i]));
-    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
     if (i != 0) args += ", ";
-    args += *std::move(arg_or);
+    args += RenderExpr(view, view.Expr(call.arguments[i]));
   }
   return std::format("{}::{}({})", ns, BuiltinFnCppName(id), args);
 }
 
 auto RenderBuiltinStaticCall(
     const ScopeView& view, const mir::CallExpr& call,
-    const mir::BuiltinStaticCallee& callee) -> diag::Result<std::string> {
+    const mir::BuiltinStaticCallee& callee) -> std::string {
   std::string args;
   for (std::size_t i = 0; i < call.arguments.size(); ++i) {
-    auto arg_or = RenderExpr(view, view.Expr(call.arguments[i]));
-    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
     if (i != 0) args += ", ";
-    args += *std::move(arg_or);
+    args += RenderExpr(view, view.Expr(call.arguments[i]));
   }
+  // The qualifier names the SV type whose static method is being invoked.
+  // Enum-typed qualifiers go through the alias-aware `RenderEnumClassName`
+  // (the alias spelling matches the user's `typedef enum {...}` name); every
+  // other SV type maps to its canonical `lyra::value::...` C++ name via
+  // `RenderTypeAsCpp`. Splitting the two keeps the call-site choice
+  // ("qualified by enum alias vs by runtime library type") visible.
+  const auto& qual_ty = view.Unit().GetType(callee.type_qual);
+  const std::string qualifier =
+      qual_ty.IsEnum()
+          ? RenderEnumClassName(view.Class(), callee.type_qual)
+          : RenderTypeAsCpp(view.Unit(), view.Class(), callee.type_qual);
   return std::format(
-      "{}::{}({})", RenderEnumClassName(view.Class(), callee.type_qual),
-      BuiltinFnCppName(callee.id), args);
+      "{}::{}({})", qualifier, BuiltinFnCppName(callee.id), args);
 }
 
 // Constructs a value of the call's result data type: `<TypeName>(args)`, the
@@ -864,28 +701,24 @@ auto RenderBuiltinStaticCall(
 // itself -- the `Ref<T>` constructor binds it.
 auto RenderConstructorCall(
     const ScopeView& view, const mir::CallExpr& call, mir::TypeId result_type)
-    -> diag::Result<std::string> {
-  auto type_or = RenderTypeAsCpp(view.Unit(), view.Class(), result_type);
-  if (!type_or) return std::unexpected(std::move(type_or.error()));
+    -> std::string {
+  std::string type = RenderTypeAsCpp(view.Unit(), view.Class(), result_type);
   std::string args;
   for (std::size_t i = 0; i < call.arguments.size(); ++i) {
-    auto arg_or = RenderExpr(view, view.Expr(call.arguments[i]));
-    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
     if (i != 0) args += ", ";
-    args += *std::move(arg_or);
+    args += RenderExpr(view, view.Expr(call.arguments[i]));
   }
-  return *type_or + "(" + args + ")";
+  return std::format("{}({})", type, args);
 }
 
 auto RenderCallExpr(
     const ScopeView& view, const mir::CallExpr& call, mir::TypeId result_type)
-    -> diag::Result<std::string> {
+    -> std::string {
   return std::visit(
       Overloaded{
-          [&](const mir::MethodRef& ref) -> diag::Result<std::string> {
+          [&](const mir::MethodRef& ref) -> std::string {
             if (ref.hops.value != 0) {
-              return diag::Fail(
-                  diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+              throw InternalError(
                   "method call across classes is not yet "
                   "implemented in cpp emit");
             }
@@ -897,37 +730,30 @@ auto RenderCallExpr(
             // so every argument renders uniformly.
             std::string args;
             for (std::size_t i = 0; i < call.arguments.size(); ++i) {
-              auto arg_or = RenderExpr(view, view.Expr(call.arguments[i]));
-              if (!arg_or) return std::unexpected(std::move(arg_or.error()));
               if (i != 0) args += ", ";
-              args += *std::move(arg_or);
+              args += RenderExpr(view, view.Expr(call.arguments[i]));
             }
             return std::format("{}({})", decl.name, args);
           },
-          [&](const mir::BuiltinFnCallee& b) -> diag::Result<std::string> {
+          [&](const mir::BuiltinFnCallee& b) -> std::string {
             return RenderBuiltinFnCall(view, call, b.id);
           },
-          [&](const mir::BuiltinStaticCallee& b) -> diag::Result<std::string> {
+          [&](const mir::BuiltinStaticCallee& b) -> std::string {
             return RenderBuiltinStaticCall(view, call, b);
           },
-          [&](const mir::FreeFnCallee& f) -> diag::Result<std::string> {
+          [&](const mir::FreeFnCallee& f) -> std::string {
             return RenderFreeFnCall(view, call, f.id);
           },
-          [&](const mir::ClosureRef& cr) -> diag::Result<std::string> {
-            auto closure_or = RenderExpr(view, view.Expr(cr.closure));
-            if (!closure_or) {
-              return std::unexpected(std::move(closure_or.error()));
-            }
+          [&](const mir::ClosureRef& cr) -> std::string {
+            std::string closure = RenderExpr(view, view.Expr(cr.closure));
             std::string args;
             for (std::size_t i = 0; i < call.arguments.size(); ++i) {
-              auto arg_or = RenderExpr(view, view.Expr(call.arguments[i]));
-              if (!arg_or) return std::unexpected(std::move(arg_or.error()));
               if (i != 0) args += ", ";
-              args += *std::move(arg_or);
+              args += RenderExpr(view, view.Expr(call.arguments[i]));
             }
-            return "(" + *closure_or + ")(" + args + ")";
+            return std::format("({})({})", closure, args);
           },
-          [&](const mir::ConstructorCallee&) -> diag::Result<std::string> {
+          [&](const mir::ConstructorCallee&) -> std::string {
             return RenderConstructorCall(view, call, result_type);
           },
       },
@@ -943,19 +769,16 @@ auto RenderCallExpr(
 // `ObservableMethod{kMutate}` call -- this render emits nothing implicit
 // on top of the explicit MIR shape.
 auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
-    -> diag::Result<std::string> {
+    -> std::string {
   return std::visit(
       Overloaded{
-          [&](const mir::MemberAccessExpr& m) -> diag::Result<std::string> {
-            auto receiver_or = RenderExpr(view, view.Expr(m.receiver));
-            if (!receiver_or) {
-              return std::unexpected(std::move(receiver_or.error()));
-            }
+          [&](const mir::MemberAccessExpr& m) -> std::string {
             const auto& cls = view.EnclosingClassAtHops(m.member.hops);
             const auto& var = cls.members.Get(m.member.var);
-            return *receiver_or + "->" + var.name;
+            return std::format(
+                "{}->{}", RenderExpr(view, view.Expr(m.receiver)), var.name);
           },
-          [&](const mir::LocalRef& l) -> diag::Result<std::string> {
+          [&](const mir::LocalRef& l) -> std::string {
             return LookupLocalName(view, l);
           },
           // HIR-to-MIR lowers an LHS selector chain to a container-access
@@ -963,15 +786,13 @@ auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)
           // returns a write-through reference, so the natural value-side
           // rendering is itself the assignment
           // target; LHS context needs no extra fix-up.
-          [&](const mir::CallExpr&) -> diag::Result<std::string> {
+          [&](const mir::CallExpr&) -> std::string {
             return RenderExpr(view, expr);
           },
-          [&](const mir::DerefExpr& d) -> diag::Result<std::string> {
-            auto ptr = RenderExpr(view, view.Expr(d.pointer));
-            if (!ptr) return std::unexpected(std::move(ptr.error()));
-            return "(*" + *ptr + ")";
+          [&](const mir::DerefExpr& d) -> std::string {
+            return std::format("(*{})", RenderExpr(view, view.Expr(d.pointer)));
           },
-          [&](const auto&) -> diag::Result<std::string> {
+          [&](const auto&) -> std::string {
             throw InternalError(
                 "RenderLhsExpr: expression form is not addressable; the "
                 "assignment target lowering should have produced an "
@@ -1002,27 +823,27 @@ auto RenderCompoundAssign(
     -> std::string {
   switch (op) {
     case mir::BinaryOp::kAdd:
-      return chain + " += " + rhs;
+      return std::format("{} += {}", chain, rhs);
     case mir::BinaryOp::kSub:
-      return chain + " -= " + rhs;
+      return std::format("{} -= {}", chain, rhs);
     case mir::BinaryOp::kMul:
-      return chain + " *= " + rhs;
+      return std::format("{} *= {}", chain, rhs);
     case mir::BinaryOp::kDiv:
-      return chain + " /= " + rhs;
+      return std::format("{} /= {}", chain, rhs);
     case mir::BinaryOp::kMod:
-      return chain + " %= " + rhs;
+      return std::format("{} %= {}", chain, rhs);
     case mir::BinaryOp::kBitwiseAnd:
-      return chain + " &= " + rhs;
+      return std::format("{} &= {}", chain, rhs);
     case mir::BinaryOp::kBitwiseOr:
-      return chain + " |= " + rhs;
+      return std::format("{} |= {}", chain, rhs);
     case mir::BinaryOp::kBitwiseXor:
-      return chain + " ^= " + rhs;
+      return std::format("{} ^= {}", chain, rhs);
     case mir::BinaryOp::kShiftLeft:
-      return chain + ".ShiftLeftAssign(" + rhs + ")";
+      return std::format("{}.ShiftLeftAssign({})", chain, rhs);
     case mir::BinaryOp::kLogicalShiftRight:
-      return chain + ".LogicalShiftRightAssign(" + rhs + ")";
+      return std::format("{}.LogicalShiftRightAssign({})", chain, rhs);
     case mir::BinaryOp::kArithmeticShiftRight:
-      return chain + ".ArithmeticShiftRightAssign(" + rhs + ")";
+      return std::format("{}.ArithmeticShiftRightAssign({})", chain, rhs);
     default:
       throw InternalError(
           "RenderCompoundAssign: BinaryOp is not a legal SV compound "
@@ -1032,9 +853,8 @@ auto RenderCompoundAssign(
 }
 
 auto RenderAssignExpr(const ScopeView& view, const mir::AssignExpr& a)
-    -> diag::Result<std::string> {
-  auto value_or = RenderExpr(view, view.Expr(a.value));
-  if (!value_or) return std::unexpected(std::move(value_or.error()));
+    -> std::string {
+  std::string value = RenderExpr(view, view.Expr(a.value));
 
   const mir::Expr& lhs_expr = view.Expr(a.target);
 
@@ -1044,39 +864,35 @@ auto RenderAssignExpr(const ScopeView& view, const mir::AssignExpr& a)
   // Both shapes arrive from HIR-to-MIR already lowered, so this path emits a
   // plain C++ assignment over whatever the LHS render produces.
   if (IsLhsBarePrimary(lhs_expr)) {
-    auto root_or = RenderLhsExpr(view, lhs_expr);
-    if (!root_or) return std::unexpected(std::move(root_or.error()));
+    std::string root = RenderLhsExpr(view, lhs_expr);
     if (a.compound_op.has_value()) {
-      return "(" + RenderCompoundAssign(*a.compound_op, *root_or, *value_or) +
-             ")";
+      return std::format(
+          "({})", RenderCompoundAssign(*a.compound_op, root, value));
     }
-    return "(" + *root_or + " = " + *value_or + ")";
+    return std::format("({} = {})", root, value);
   }
-  auto chain_or = RenderLhsExpr(view, lhs_expr);
-  if (!chain_or) return std::unexpected(std::move(chain_or.error()));
+  std::string chain = RenderLhsExpr(view, lhs_expr);
   if (a.compound_op.has_value()) {
-    return "(" + RenderCompoundAssign(*a.compound_op, *chain_or, *value_or) +
-           ")";
+    return std::format(
+        "({})", RenderCompoundAssign(*a.compound_op, chain, value));
   }
-  return *chain_or + " = " + *value_or;
+  return std::format("{} = {}", chain, value);
 }
 
 auto RenderIncDecExpr(const ScopeView& view, const mir::IncDecExpr& inc)
-    -> diag::Result<std::string> {
+    -> std::string {
   const mir::Expr& target_expr = view.Expr(inc.target);
-  auto lhs_or = RenderLhsExpr(view, target_expr);
-  if (!lhs_or) return std::unexpected(std::move(lhs_or.error()));
-  std::string lhs = *std::move(lhs_or);
+  std::string lhs = RenderLhsExpr(view, target_expr);
 
   switch (inc.op) {
     case mir::IncDecOp::kPreInc:
-      return "(++" + lhs + ")";
+      return std::format("(++{})", lhs);
     case mir::IncDecOp::kPostInc:
-      return "(" + lhs + "++)";
+      return std::format("({}++)", lhs);
     case mir::IncDecOp::kPreDec:
-      return "(--" + lhs + ")";
+      return std::format("(--{})", lhs);
     case mir::IncDecOp::kPostDec:
-      return "(" + lhs + "--)";
+      return std::format("({}--)", lhs);
   }
   throw InternalError("RenderIncDecExpr: unknown IncDecOp");
 }
@@ -1085,10 +901,10 @@ auto RenderIncDecExpr(const ScopeView& view, const mir::IncDecExpr& inc)
 // `RefType` binding renders as `Ref<T> name`, a value binding as `T name`;
 // the wrapper comes from the type alone (RenderTypeAsCpp), never hand-written.
 auto RenderBindingParamDecl(const ScopeView& view, const mir::LocalDecl& bind)
-    -> diag::Result<std::string> {
-  auto type_or = RenderTypeAsCpp(view.Unit(), view.Class(), bind.type);
-  if (!type_or) return std::unexpected(std::move(type_or.error()));
-  return *type_or + " " + bind.name;
+    -> std::string {
+  return std::format(
+      "{} {}", RenderTypeAsCpp(view.Unit(), view.Class(), bind.type),
+      bind.name);
 }
 
 // A closure renders from its captures, parameters, result type, and body alone.
@@ -1098,20 +914,18 @@ auto RenderBindingParamDecl(const ScopeView& view, const mir::LocalDecl& bind)
 // lambda would dangle once the spawned branch outlives the referencing site.
 auto RenderClosureExpr(
     const ScopeView& view, const mir::ClosureExpr& closure,
-    mir::TypeId result_type) -> diag::Result<std::string> {
+    mir::TypeId result_type) -> std::string {
   if (closure.body == nullptr) {
     throw InternalError("RenderClosureExpr: closure has no body");
   }
 
-  auto result_ty_or = RenderTypeAsCpp(view.Unit(), view.Class(), result_type);
-  if (!result_ty_or) return std::unexpected(std::move(result_ty_or.error()));
-  const std::string return_clause = " -> " + *result_ty_or;
+  const std::string return_clause = std::format(
+      " -> {}", RenderTypeAsCpp(view.Unit(), view.Class(), result_type));
 
   const ScopeView body_view =
       ScopeView::ForRoot(view.Unit(), view.Class(), *closure.body);
-  auto body_or = RenderBlockStatements(body_view, 1);
-  if (!body_or) return std::unexpected(std::move(body_or.error()));
-  const std::string body = " {\n" + *body_or + "}";
+  const std::string body =
+      std::format(" {{\n{}}}", RenderBlockStatements(body_view, 1));
 
   if (std::holds_alternative<mir::CoroutineType>(
           view.Unit().GetType(result_type).data)) {
@@ -1123,18 +937,14 @@ auto RenderClosureExpr(
     std::string args;
     for (std::size_t i = 0; i < closure.captures.size(); ++i) {
       const auto& bind = closure.body->vars.Get(closure.captures[i].binding);
-      auto decl_or = RenderBindingParamDecl(view, bind);
-      if (!decl_or) return std::unexpected(std::move(decl_or.error()));
-      auto arg_or = RenderExpr(view, view.Expr(closure.captures[i].value));
-      if (!arg_or) return std::unexpected(std::move(arg_or.error()));
       if (i != 0) {
         params += ", ";
         args += ", ";
       }
-      params += *decl_or;
-      args += *arg_or;
+      params += RenderBindingParamDecl(view, bind);
+      args += RenderExpr(view, view.Expr(closure.captures[i].value));
     }
-    return "[](" + params + ")" + return_clause + body + "(" + args + ")";
+    return std::format("[]({}){}{}({})", params, return_clause, body, args);
   }
 
   // The capture clause never contains `[this]`, `[=]`, or `[&]` -- every entry
@@ -1144,22 +954,21 @@ auto RenderClosureExpr(
   for (std::size_t i = 0; i < closure.captures.size(); ++i) {
     const std::string& bind_name =
         closure.body->vars.Get(closure.captures[i].binding).name;
-    auto source_or = RenderExpr(view, view.Expr(closure.captures[i].value));
-    if (!source_or) return std::unexpected(std::move(source_or.error()));
     if (i != 0) captures_text += ", ";
-    captures_text += bind_name + " = " + *source_or;
+    captures_text += std::format(
+        "{} = {}", bind_name,
+        RenderExpr(view, view.Expr(closure.captures[i].value)));
   }
 
   std::string params_text;
   for (std::size_t i = 0; i < closure.params.size(); ++i) {
     const auto& bind = closure.body->vars.Get(closure.params[i].binding);
-    auto decl_or = RenderBindingParamDecl(view, bind);
-    if (!decl_or) return std::unexpected(std::move(decl_or.error()));
     if (i != 0) params_text += ", ";
-    params_text += *decl_or;
+    params_text += RenderBindingParamDecl(view, bind);
   }
 
-  return "[" + captures_text + "](" + params_text + ")" + return_clause + body;
+  return std::format(
+      "[{}]({}){}{}", captures_text, params_text, return_clause, body);
 }
 
 // LRM 10.10 unpacked array concatenation into a queue. Each operand is spliced
@@ -1169,12 +978,12 @@ auto RenderClosureExpr(
 // element default is threaded.
 auto RenderQueueConcat(
     const ScopeView& view, const mir::Type& result_ty, const mir::ConcatExpr& c)
-    -> diag::Result<std::string> {
+    -> std::string {
   const mir::TypeId elem_type_id =
       std::get<mir::QueueType>(result_ty.data).element_type;
-  auto elem_cpp = RenderTypeAsCpp(view.Unit(), view.Class(), elem_type_id);
-  if (!elem_cpp) return std::unexpected(std::move(elem_cpp.error()));
-  std::string out = "lyra::value::MakeQueueConcat<" + *elem_cpp + ">(";
+  std::string out = std::format(
+      "lyra::value::MakeQueueConcat<{}>(",
+      RenderTypeAsCpp(view.Unit(), view.Class(), elem_type_id));
   for (std::size_t i = 0; i < c.operands.size(); ++i) {
     const auto& op_expr = view.Expr(c.operands[i]);
     const auto& op_ty = view.Unit().GetType(op_expr.type);
@@ -1182,11 +991,10 @@ auto RenderQueueConcat(
         std::holds_alternative<mir::QueueType>(op_ty.data) ||
         std::holds_alternative<mir::DynamicArrayType>(op_ty.data) ||
         std::holds_alternative<mir::UnpackedArrayType>(op_ty.data);
-    auto rendered = RenderExpr(view, op_expr);
-    if (!rendered) return std::unexpected(std::move(rendered.error()));
+    std::string rendered = RenderExpr(view, op_expr);
     if (i != 0) out += ", ";
-    out += spread ? "lyra::value::QSpread(" + *rendered + ")"
-                  : "lyra::value::QElem(" + *rendered + ")";
+    out += spread ? std::format("lyra::value::QSpread({})", rendered)
+                  : std::format("lyra::value::QElem({})", rendered);
   }
   out += ")";
   return out;
@@ -1194,7 +1002,7 @@ auto RenderQueueConcat(
 
 auto RenderConcatExpr(
     const ScopeView& view, const mir::Expr& expr, const mir::ConcatExpr& c)
-    -> diag::Result<std::string> {
+    -> std::string {
   const auto& result_ty = view.Unit().GetType(expr.type);
   if (std::holds_alternative<mir::QueueType>(result_ty.data)) {
     return RenderQueueConcat(view, result_ty, c);
@@ -1203,13 +1011,11 @@ auto RenderConcatExpr(
     throw InternalError("RenderConcatExpr: hir lowering produced empty concat");
   }
   const auto join = [&](std::string_view open, std::string_view sep,
-                        std::string_view close) -> diag::Result<std::string> {
+                        std::string_view close) -> std::string {
     std::string out{open};
     for (std::size_t i = 0; i < c.operands.size(); ++i) {
-      auto rendered = RenderExpr(view, view.Expr(c.operands[i]));
-      if (!rendered) return std::unexpected(std::move(rendered.error()));
       if (i != 0) out += sep;
-      out += *rendered;
+      out += RenderExpr(view, view.Expr(c.operands[i]));
     }
     out += close;
     return out;
@@ -1235,7 +1041,7 @@ auto RenderConcatExpr(
 // and as a construction-call argument.
 auto RenderArrayLiteralExpr(
     const ScopeView& view, const mir::Expr& expr,
-    const mir::ArrayLiteralExpr& a) -> diag::Result<std::string> {
+    const mir::ArrayLiteralExpr& a) -> std::string {
   const auto& container_ty = view.Unit().GetType(expr.type);
   const mir::TypeId elem_type_id = std::visit(
       [](const auto& ty) -> mir::TypeId {
@@ -1252,15 +1058,13 @@ auto RenderArrayLiteralExpr(
         }
       },
       container_ty.data);
-  auto elem_type_or = RenderTypeAsCpp(view.Unit(), view.Class(), elem_type_id);
-  if (!elem_type_or) return std::unexpected(std::move(elem_type_or.error()));
-  std::string out =
-      std::format("std::array<{}, {}>{{", *elem_type_or, a.elements.size());
+  std::string out = std::format(
+      "std::array<{}, {}>{{",
+      RenderTypeAsCpp(view.Unit(), view.Class(), elem_type_id),
+      a.elements.size());
   for (std::size_t i = 0; i < a.elements.size(); ++i) {
-    auto rendered = RenderExpr(view, view.Expr(a.elements[i]));
-    if (!rendered) return std::unexpected(std::move(rendered.error()));
     if (i != 0) out += ", ";
-    out += *rendered;
+    out += RenderExpr(view, view.Expr(a.elements[i]));
   }
   out += "}";
   return out;
@@ -1271,15 +1075,12 @@ auto RenderArrayLiteralExpr(
 // including when the tuple is an element of an outer array literal.
 auto RenderTupleExpr(
     const ScopeView& view, const mir::Expr& expr, const mir::TupleExpr& t)
-    -> diag::Result<std::string> {
-  auto type_or = RenderTypeAsCpp(view.Unit(), view.Class(), expr.type);
-  if (!type_or) return std::unexpected(std::move(type_or.error()));
-  std::string out = *type_or + "{";
+    -> std::string {
+  std::string out = std::format(
+      "{}{{", RenderTypeAsCpp(view.Unit(), view.Class(), expr.type));
   for (std::size_t i = 0; i < t.components.size(); ++i) {
-    auto rendered = RenderExpr(view, view.Expr(t.components[i]));
-    if (!rendered) return std::unexpected(std::move(rendered.error()));
     if (i != 0) out += ", ";
-    out += *rendered;
+    out += RenderExpr(view, view.Expr(t.components[i]));
   }
   out += "}";
   return out;
@@ -1287,25 +1088,23 @@ auto RenderTupleExpr(
 
 auto RenderReplicationExpr(
     const ScopeView& view, const mir::Expr& expr, const mir::ReplicationExpr& r)
-    -> diag::Result<std::string> {
-  auto count = RenderExpr(view, view.Expr(r.count));
-  if (!count) return std::unexpected(std::move(count.error()));
-  auto concat = RenderExpr(view, view.Expr(r.concat));
-  if (!concat) return std::unexpected(std::move(concat.error()));
+    -> std::string {
+  std::string count = RenderExpr(view, view.Expr(r.count));
+  std::string concat = RenderExpr(view, view.Expr(r.concat));
   const auto& count_ty = view.Unit().GetType(view.Expr(r.count).type);
   std::string count_text = count_ty.IsIntegralPacked()
-                               ? std::format("({}).ToInt64()", *count)
-                               : *count;
+                               ? std::format("({}).ToInt64()", count)
+                               : count;
   const auto& result_ty = view.Unit().GetType(expr.type);
   if (result_ty.IsIntegralPacked()) {
     return std::format(
         "lyra::value::PackedArray::Replicate({}, "
         "static_cast<std::uint64_t>({}))",
-        *concat, count_text);
+        concat, count_text);
   }
   if (result_ty.Kind() == mir::TypeKind::kString) {
     return std::format(
-        "lyra::value::ReplicateString({}, {})", *concat, count_text);
+        "lyra::value::ReplicateString({}, {})", concat, count_text);
   }
   throw InternalError(
       "RenderReplicationExpr: result type must be PackedArrayType or string");
@@ -1316,131 +1115,121 @@ auto RenderReplicationExpr(
 // explicit `ObservableMethod{kGet}` call that HIR-to-MIR wraps around an
 // observable read.
 auto RenderDerefExpr(const ScopeView& view, const mir::DerefExpr& d)
-    -> diag::Result<std::string> {
-  const mir::Expr& ptr_expr = view.Expr(d.pointer);
-  auto ptr_or = RenderExpr(view, ptr_expr);
-  if (!ptr_or) return std::unexpected(std::move(ptr_or.error()));
-  return "(*" + *ptr_or + ")";
+    -> std::string {
+  return std::format("(*{})", RenderExpr(view, view.Expr(d.pointer)));
 }
 
 // `&place` emitted as the C++ address-of operator. Backend-side
 // canonicalization: `&(*p)` collapses to `p` directly, avoiding a no-op
 // round-trip through the address-of/dereference pair.
 auto RenderAddressOfExpr(const ScopeView& view, const mir::AddressOfExpr& a)
-    -> diag::Result<std::string> {
+    -> std::string {
   const mir::Expr& operand_expr = view.Expr(a.operand);
   if (const auto* deref = std::get_if<mir::DerefExpr>(&operand_expr.data)) {
     return RenderExpr(view, view.Expr(deref->pointer));
   }
-  auto operand_or = RenderLhsExpr(view, operand_expr);
-  if (!operand_or) return std::unexpected(std::move(operand_or.error()));
-  return "&" + *operand_or;
+  return std::format("&{}", RenderLhsExpr(view, operand_expr));
 }
 
 }  // namespace
 
-auto RenderExpr(const ScopeView& view, const mir::Expr& expr)
-    -> diag::Result<std::string> {
+auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string {
   return std::visit(
       Overloaded{
-          [&](const mir::IntegerLiteral& lit) -> diag::Result<std::string> {
+          [&](const mir::IntegerLiteral& lit) -> std::string {
             return RenderIntegerLiteralExpr(view, expr, lit);
           },
-          [&](const mir::StringLiteral& s) -> diag::Result<std::string> {
+          [&](const mir::StringLiteral& s) -> std::string {
             return RenderCStringLiteral(s.value);
           },
-          [](const mir::TimeLiteral&) -> diag::Result<std::string> {
-            return diag::Fail(
-                diag::DiagCode::kCppEmitExpressionFormNotImplemented,
+          [](const mir::TimeLiteral&) -> std::string {
+            throw InternalError(
                 "TimeLiteral is not yet implemented in cpp emit");
           },
-          [&](const mir::RealLiteral& r) -> diag::Result<std::string> {
+          [&](const mir::RealLiteral& r) -> std::string {
             return RenderRealLiteralExpr(view, expr, r);
           },
-          [](const mir::NullLiteral&) -> diag::Result<std::string> {
+          [](const mir::NullLiteral&) -> std::string {
             return std::string{"nullptr"};
           },
-          [&](const mir::ParamRef& r) -> diag::Result<std::string> {
+          [](const mir::HostIntLiteral& h) -> std::string {
+            return std::format("{}LL", h.value);
+          },
+          [&](const mir::ParamRef& r) -> std::string {
             return RenderParamExpr(view, r);
           },
-          [&](const mir::LocalRef& l) -> diag::Result<std::string> {
+          [&](const mir::LocalRef& l) -> std::string {
             return LookupLocalName(view, l);
           },
-          [&](const mir::UnaryExpr& u) -> diag::Result<std::string> {
-            return RenderUnaryExpr(view, expr, u);
+          [&](const mir::UnaryExpr& u) -> std::string {
+            return RenderUnaryExpr(view, u);
           },
-          [&](const mir::BinaryExpr& b) -> diag::Result<std::string> {
-            return RenderBinaryExpr(view, expr, b);
+          [&](const mir::BinaryExpr& b) -> std::string {
+            return RenderBinaryExpr(view, b);
           },
-          [&](const mir::ConditionalExpr& c) -> diag::Result<std::string> {
+          [&](const mir::BoolCastExpr& b) -> std::string {
+            return RenderBoolCastExpr(view, b);
+          },
+          [&](const mir::ConditionalExpr& c) -> std::string {
             return RenderConditionalExpr(view, c);
           },
-          [&](const mir::AssignExpr& a) -> diag::Result<std::string> {
+          [&](const mir::AssignExpr& a) -> std::string {
             return RenderAssignExpr(view, a);
           },
-          [&](const mir::IncDecExpr& inc) -> diag::Result<std::string> {
+          [&](const mir::IncDecExpr& inc) -> std::string {
             return RenderIncDecExpr(view, inc);
           },
-          [&](const mir::CastExpr& cast) -> diag::Result<std::string> {
+          [&](const mir::CastExpr& cast) -> std::string {
             return RenderCastExpr(view, expr, cast);
           },
-          [&](const mir::CallExpr& call) -> diag::Result<std::string> {
+          [&](const mir::CallExpr& call) -> std::string {
             return RenderCallExpr(view, call, expr.type);
           },
-          [&](const mir::DerefExpr& d) -> diag::Result<std::string> {
+          [&](const mir::DerefExpr& d) -> std::string {
             return RenderDerefExpr(view, d);
           },
-          [&](const mir::AddressOfExpr& a) -> diag::Result<std::string> {
+          [&](const mir::AddressOfExpr& a) -> std::string {
             return RenderAddressOfExpr(view, a);
           },
-          [&](const mir::MemberAccessExpr& m) -> diag::Result<std::string> {
+          [&](const mir::MemberAccessExpr& m) -> std::string {
             const auto& cls = view.EnclosingClassAtHops(m.member.hops);
             const auto& var = cls.members.Get(m.member.var);
-            auto receiver_or = RenderExpr(view, view.Expr(m.receiver));
-            if (!receiver_or) {
-              return std::unexpected(std::move(receiver_or.error()));
-            }
-            return *receiver_or + "->" + var.name;
+            return std::format(
+                "{}->{}", RenderExpr(view, view.Expr(m.receiver)), var.name);
           },
-          [&](const mir::ClosureExpr& cl) -> diag::Result<std::string> {
+          [&](const mir::ClosureExpr& cl) -> std::string {
             return RenderClosureExpr(view, cl, expr.type);
           },
-          [&](const mir::ConcatExpr& c) -> diag::Result<std::string> {
+          [&](const mir::ConcatExpr& c) -> std::string {
             return RenderConcatExpr(view, expr, c);
           },
-          [&](const mir::ReplicationExpr& r) -> diag::Result<std::string> {
+          [&](const mir::ReplicationExpr& r) -> std::string {
             return RenderReplicationExpr(view, expr, r);
           },
-          [&](const mir::ArrayLiteralExpr& a) -> diag::Result<std::string> {
+          [&](const mir::ArrayLiteralExpr& a) -> std::string {
             return RenderArrayLiteralExpr(view, expr, a);
           },
-          [&](const mir::TupleExpr& t) -> diag::Result<std::string> {
+          [&](const mir::TupleExpr& t) -> std::string {
             return RenderTupleExpr(view, expr, t);
           },
-          [&](const mir::AwaitExpr& a) -> diag::Result<std::string> {
-            auto awaitable_or = RenderExpr(view, view.Expr(a.awaitable));
-            if (!awaitable_or) {
-              return std::unexpected(std::move(awaitable_or.error()));
-            }
-            return "co_await " + *awaitable_or;
+          [&](const mir::AwaitExpr& a) -> std::string {
+            return std::format(
+                "co_await {}", RenderExpr(view, view.Expr(a.awaitable)));
           },
-          [&](const mir::TupleGetExpr& g) -> diag::Result<std::string> {
-            auto tuple_or = RenderExpr(view, view.Expr(g.tuple));
-            if (!tuple_or) return std::unexpected(std::move(tuple_or.error()));
-            return "std::get<" + std::to_string(g.index) + ">(" + *tuple_or +
-                   ")";
+          [&](const mir::TupleGetExpr& g) -> std::string {
+            return std::format(
+                "std::get<{}>({})", g.index,
+                RenderExpr(view, view.Expr(g.tuple)));
           },
       },
       expr.data);
 }
 
 auto RenderConditionAsBool(const ScopeView& view, const mir::Expr& expr)
-    -> diag::Result<std::string> {
-  auto text_or = RenderExpr(view, expr);
-  if (!text_or) return std::unexpected(std::move(text_or.error()));
+    -> std::string {
   // PackedArray's `explicit operator bool` fires in any boolean context (if /
   // while / for / ternary cond / `&&` / `||` / `!`), so no wrapping needed.
-  return *text_or;
+  return RenderExpr(view, expr);
 }
 
 }  // namespace lyra::backend::cpp

--- a/src/lyra/backend/cpp/render_stmt.cpp
+++ b/src/lyra/backend/cpp/render_stmt.cpp
@@ -1,9 +1,9 @@
 #include "lyra/backend/cpp/render_stmt.hpp"
 
 #include <cstddef>
+#include <format>
 #include <string>
 #include <string_view>
-#include <utility>
 #include <variant>
 #include <vector>
 
@@ -13,7 +13,6 @@
 #include "lyra/backend/cpp/scope_view.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
-#include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/stmt.hpp"
 #include "lyra/mir/type.hpp"
@@ -23,10 +22,10 @@ namespace lyra::backend::cpp {
 namespace {
 
 auto RenderForInit(const ScopeView& view, const mir::ForInit& init)
-    -> diag::Result<std::string> {
+    -> std::string {
   return std::visit(
       Overloaded{
-          [&](const mir::ForInitDecl& d) -> diag::Result<std::string> {
+          [&](const mir::ForInitDecl& d) -> std::string {
             // The induction variable's C++ type is whatever the initializer
             // yields (every integral value is a PackedArray), so `auto` is the
             // exact same type as spelling it out -- and reads as the idiomatic
@@ -34,13 +33,10 @@ auto RenderForInit(const ScopeView& view, const mir::ForInit& init)
             const auto& lv = view.BlockAtHops(d.induction_var.hops)
                                  .vars.Get(d.induction_var.var);
             const auto& init_expr = view.Block().exprs.Get(d.init);
-            auto rendered_or = RenderExpr(view, init_expr);
-            if (!rendered_or) {
-              return std::unexpected(std::move(rendered_or.error()));
-            }
-            return "auto " + lv.name + " = " + *rendered_or;
+            return std::format(
+                "auto {} = {}", lv.name, RenderExpr(view, init_expr));
           },
-          [&](const mir::ForInitExpr& e) -> diag::Result<std::string> {
+          [&](const mir::ForInitExpr& e) -> std::string {
             const auto& expr = view.Block().exprs.Get(e.expr);
             return RenderExpr(view, expr);
           },
@@ -64,34 +60,29 @@ auto RenderEventEdgeAsRuntime(mir::EventEdge edge) -> std::string_view {
 
 auto RenderLocalDeclStmt(
     const ScopeView& view, const mir::LocalDeclStmt& s, std::size_t indent)
-    -> diag::Result<std::string> {
+    -> std::string {
   const auto& lv = view.BlockAtHops(s.target.hops).vars.Get(s.target.var);
-  auto type_or = RenderTypeAsCpp(view.Unit(), view.Class(), lv.type);
-  if (!type_or) return std::unexpected(std::move(type_or.error()));
   const auto& init_expr = view.Block().exprs.Get(s.init);
-  auto init_or = RenderExpr(view, init_expr);
-  if (!init_or) return std::unexpected(std::move(init_or.error()));
-  return Indent(indent) + *type_or + " " + lv.name + " = " + *init_or + ";\n";
+  return std::format(
+      "{}{} {} = {};\n", Indent(indent),
+      RenderTypeAsCpp(view.Unit(), view.Class(), lv.type), lv.name,
+      RenderExpr(view, init_expr));
 }
 
 auto RenderExprStmt(
     const ScopeView& view, const mir::ExprStmt& s, std::size_t indent)
-    -> diag::Result<std::string> {
+    -> std::string {
   const auto& expr = view.Block().exprs.Get(s.expr);
-  auto rendered_or = RenderExpr(view, expr);
-  if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
-  return Indent(indent) + *rendered_or + ";\n";
+  return std::format("{}{};\n", Indent(indent), RenderExpr(view, expr));
 }
 
-auto RenderBlockStmtNode(
+auto RenderBlockStmt(
     const ScopeView& view, const mir::BlockStmt& s, std::size_t indent)
-    -> diag::Result<std::string> {
+    -> std::string {
   const auto& child = view.Block().child_scopes.Get(s.scope);
-  std::string result = Indent(indent) + "{\n";
-  auto child_or = RenderNestedBlock(view, child, indent + 1);
-  if (!child_or) return std::unexpected(std::move(child_or.error()));
-  result += *child_or;
-  result += Indent(indent) + "}\n";
+  std::string result = std::format("{}{{\n", Indent(indent));
+  result += RenderNestedBlock(view, child, indent + 1);
+  result += std::format("{}}}\n", Indent(indent));
   return result;
 }
 
@@ -104,7 +95,7 @@ auto RenderForkJoinModeLiteral(mir::JoinMode mode) -> std::string_view {
     case mir::JoinMode::kNone:
       return "lyra::runtime::JoinMode::kNone";
   }
-  return "lyra::runtime::JoinMode::kAll";
+  throw InternalError("RenderForkJoinModeLiteral: unknown JoinMode value");
 }
 
 // LRM 9.3.2: a fork is a block, rendered as a C++ block at the fork
@@ -114,9 +105,9 @@ auto RenderForkJoinModeLiteral(mir::JoinMode mode) -> std::string_view {
 // renderer emits it as a stateless coroutine lambda invoked on its captures,
 // yielding a `lyra::runtime::Coroutine` collected into `fork_branches`. The
 // fork then waits per the join mode.
-auto RenderForkStmtNode(
+auto RenderForkStmt(
     const ScopeView& view, const mir::ForkStmt& s, std::size_t indent)
-    -> diag::Result<std::string> {
+    -> std::string {
   // The fork-branches vector lives in this fork's own `{...}` block scope
   // (opened just below), so a fixed name suffices -- a sibling fork in the
   // surrounding scope, or a nested fork in a branch lambda body, each has
@@ -124,44 +115,38 @@ auto RenderForkStmtNode(
   const std::string vec = "fork_branches";
   const ScopeView fork_view =
       view.WithBlock(view.Block().child_scopes.Get(s.scope));
-  std::string out = Indent(indent) + "{\n";
-  auto locals_or = RenderBlockStatements(fork_view, indent + 1);
-  if (!locals_or) return std::unexpected(std::move(locals_or.error()));
-  out += *locals_or;
-  out += Indent(indent + 1) + "std::vector<lyra::runtime::Coroutine<void>> " +
-         vec + ";\n";
+  std::string out = std::format("{}{{\n", Indent(indent));
+  out += RenderBlockStatements(fork_view, indent + 1);
+  out += std::format(
+      "{}std::vector<lyra::runtime::Coroutine<void>> {};\n", Indent(indent + 1),
+      vec);
   for (const auto branch : s.branches) {
-    auto closure_or = RenderExpr(fork_view, fork_view.Expr(branch));
-    if (!closure_or) return std::unexpected(std::move(closure_or.error()));
-    out += Indent(indent + 1) + vec + ".push_back(" + *closure_or + ");\n";
+    out += std::format(
+        "{}{}.push_back({});\n", Indent(indent + 1), vec,
+        RenderExpr(fork_view, fork_view.Expr(branch)));
   }
-  out += Indent(indent + 1) + "co_await lyra::runtime::Fork(" +
-         "self->Services()" + ", std::move(" + vec + "), " +
-         std::string(RenderForkJoinModeLiteral(s.mode)) + ");\n";
-  out += Indent(indent) + "}\n";
+  out += std::format(
+      "{}co_await lyra::runtime::Fork(self->Services(), std::move({}), {});\n",
+      Indent(indent + 1), vec, RenderForkJoinModeLiteral(s.mode));
+  out += std::format("{}}}\n", Indent(indent));
   return out;
 }
 
-auto RenderIfStmtNode(
+auto RenderIfStmt(
     const ScopeView& view, const mir::IfStmt& s, std::size_t indent)
-    -> diag::Result<std::string> {
+    -> std::string {
   const auto& cond_expr = view.Block().exprs.Get(s.condition);
   const auto& then_scope = view.Block().child_scopes.Get(s.then_scope);
-  auto cond_or = RenderConditionAsBool(view, cond_expr);
-  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-  auto then_or = RenderNestedBlock(view, then_scope, indent + 1);
-  if (!then_or) return std::unexpected(std::move(then_or.error()));
   std::string result;
-  result += Indent(indent) + "if (" + *cond_or + ") {\n";
-  result += *then_or;
-  result += Indent(indent) + "}";
+  result += std::format(
+      "{}if ({}) {{\n", Indent(indent), RenderConditionAsBool(view, cond_expr));
+  result += RenderNestedBlock(view, then_scope, indent + 1);
+  result += std::format("{}}}", Indent(indent));
   if (s.else_scope.has_value()) {
     const auto& else_scope = view.Block().child_scopes.Get(*s.else_scope);
-    auto else_or = RenderNestedBlock(view, else_scope, indent + 1);
-    if (!else_or) return std::unexpected(std::move(else_or.error()));
     result += " else {\n";
-    result += *else_or;
-    result += Indent(indent) + "}";
+    result += RenderNestedBlock(view, else_scope, indent + 1);
+    result += std::format("{}}}", Indent(indent));
   }
   result += "\n";
   return result;
@@ -169,14 +154,12 @@ auto RenderIfStmtNode(
 
 auto RenderConstructOwnedObjectStmt(
     const ScopeView& view, const mir::ConstructOwnedObjectStmt& s,
-    std::size_t indent) -> diag::Result<std::string> {
+    std::size_t indent) -> std::string {
   const auto& var = view.Class().members.Get(s.target);
   const auto& target_scope = view.Class().nested_classes.Get(s.scope_id);
   std::string trailing_args;
   for (const auto arg_id : s.args) {
-    auto arg_or = RenderExpr(view, view.Expr(arg_id));
-    if (!arg_or) return std::unexpected(std::move(arg_or.error()));
-    trailing_args += ", " + *arg_or;
+    trailing_args += std::format(", {}", RenderExpr(view, view.Expr(arg_id)));
   }
   const auto child = mir::GetChildScope(view.Unit(), var.type);
   if (!child.has_value() ||
@@ -184,23 +167,25 @@ auto RenderConstructOwnedObjectStmt(
     throw InternalError(
         "ConstructOwnedObjectStmt target is not an owned object var");
   }
-  const std::string lhs = "self->" + var.name;
+  const std::string lhs = std::format("self->{}", var.name);
   // The runtime scope name is the source-level label (LRM 27.6) -- the name an
   // upward climb and a by-name child lookup match against -- not the emitted
   // class name.
   const std::string reg_name =
       var.source_name.empty() ? var.name : var.source_name;
-  const std::string make = "std::make_unique<" + target_scope.name +
-                           ">(self, \"" + reg_name + "\", self->Services()" +
-                           trailing_args + ")";
+  const std::string make = std::format(
+      "std::make_unique<{}>(self, \"{}\", self->Services(){})",
+      target_scope.name, reg_name, trailing_args);
   if (std::holds_alternative<mir::VectorType>(
           view.Unit().GetType(var.type).data)) {
-    return Indent(indent) + lhs + ".push_back(" + make + ");\n" +
-           Indent(indent) + "self->RegisterChild(\"" + reg_name +
-           "\", std::array{" + lhs + ".size() - 1}, *" + lhs + ".back());\n";
+    return std::format(
+        "{}{}.push_back({});\n{}self->RegisterChild(\"{}\", "
+        "std::array{{{}.size() - 1}}, *{}.back());\n",
+        Indent(indent), lhs, make, Indent(indent), reg_name, lhs, lhs);
   }
-  return Indent(indent) + lhs + " = " + make + ";\n" + Indent(indent) +
-         "self->RegisterChild(\"" + reg_name + "\", {}, *" + lhs + ");\n";
+  return std::format(
+      "{}{} = {};\n{}self->RegisterChild(\"{}\", {{}}, *{});\n", Indent(indent),
+      lhs, make, Indent(indent), reg_name, lhs);
 }
 
 // Materializes an external-unit member by recursing on its type, mirroring the
@@ -216,132 +201,122 @@ auto RenderExternalUnitFill(
     std::size_t indent) -> std::string {
   if (const auto* vec =
           std::get_if<mir::VectorType>(&view.Unit().GetType(type).data)) {
-    const std::string idx = "i" + std::to_string(depth);
+    const std::string idx = std::format("i{}", depth);
     std::string out;
-    out += Indent(indent) + "for (std::size_t " + idx + " = 0; " + idx + " < " +
-           std::to_string(dims.at(depth)) + "; ++" + idx + ") {\n";
-    out += Indent(indent + 1) + lvalue + ".emplace_back();\n";
+    out += std::format(
+        "{}for (std::size_t {} = 0; {} < {}; ++{}) {{\n", Indent(indent), idx,
+        idx, dims.at(depth), idx);
+    out += std::format("{}{}.emplace_back();\n", Indent(indent + 1), lvalue);
     out += RenderExternalUnitFill(
-        view, lvalue + "[" + idx + "]", vec->element, unit_name, label, dims,
-        depth + 1, indent + 1);
-    out += Indent(indent) + "}\n";
+        view, std::format("{}[{}]", lvalue, idx), vec->element, unit_name,
+        label, dims, depth + 1, indent + 1);
+    out += std::format("{}}}\n", Indent(indent));
     return out;
   }
-  std::string out = Indent(indent) + lvalue + " = std::make_unique<" +
-                    unit_name + ">(self, \"" + label +
-                    "\", self->Services());\n";
+  std::string out = std::format(
+      "{}{} = std::make_unique<{}>(self, \"{}\", self->Services());\n",
+      Indent(indent), lvalue, unit_name, label);
   std::string idx = "{}";
   if (depth > 0) {
     idx = "std::array{";
     for (std::size_t d = 0; d < depth; ++d) {
       if (d != 0) idx += ", ";
-      idx += "i" + std::to_string(d);
+      idx += std::format("i{}", d);
     }
     idx += "}";
   }
-  out += Indent(indent) + "self->RegisterChild(\"" + label + "\", " + idx +
-         ", *" + lvalue + ");\n";
+  out += std::format(
+      "{}self->RegisterChild(\"{}\", {}, *{});\n", Indent(indent), label, idx,
+      lvalue);
   return out;
 }
 
 auto RenderConstructExternalUnitStmt(
     const ScopeView& view, const mir::ConstructExternalUnitStmt& s,
-    std::size_t indent) -> diag::Result<std::string> {
+    std::size_t indent) -> std::string {
   const auto& var = view.Class().members.Get(s.target);
   return RenderExternalUnitFill(
-      view, "self->" + var.name, var.type, s.unit_name, var.name, s.dims, 0,
-      indent);
+      view, std::format("self->{}", var.name), var.type, s.unit_name, var.name,
+      s.dims, 0, indent);
 }
 
 // C++ has no labeled break, so a `foreach` break that must leave every nested
 // dimension lowers to a `goto` aimed at a label after the outermost loop. Both
 // the landing label and the jump derive their name from the loop's LoopLabelId.
 auto BreakLandingLabel(mir::LoopLabelId label) -> std::string {
-  return "__lyra_break_" + std::to_string(label.value);
+  return std::format("__lyra_break_{}", label.value);
 }
 
-auto RenderForStmtNode(
+auto RenderForStmt(
     const ScopeView& view, const mir::ForStmt& s, std::size_t indent)
-    -> diag::Result<std::string> {
+    -> std::string {
   std::string init;
   for (std::size_t i = 0; i < s.init.size(); ++i) {
     if (i != 0) init += ", ";
-    auto init_or = RenderForInit(view, s.init[i]);
-    if (!init_or) return std::unexpected(std::move(init_or.error()));
-    init += *init_or;
+    init += RenderForInit(view, s.init[i]);
   }
   std::string cond;
   if (s.condition.has_value()) {
     const auto& cond_expr = view.Block().exprs.Get(*s.condition);
-    auto cond_or = RenderConditionAsBool(view, cond_expr);
-    if (!cond_or) return std::unexpected(std::move(cond_or.error()));
-    cond = *std::move(cond_or);
+    cond = RenderConditionAsBool(view, cond_expr);
   }
   std::string step;
   for (std::size_t i = 0; i < s.step.size(); ++i) {
     if (i != 0) step += ", ";
     const auto& step_expr = view.Block().exprs.Get(s.step[i]);
-    auto step_or = RenderExpr(view, step_expr);
-    if (!step_or) return std::unexpected(std::move(step_or.error()));
-    step += *step_or;
+    step += RenderExpr(view, step_expr);
   }
   const auto& block = view.Block().child_scopes.Get(s.scope);
-  auto body_or = RenderNestedBlock(view, block, indent + 1);
-  if (!body_or) return std::unexpected(std::move(body_or.error()));
   std::string result =
-      Indent(indent) + "for (" + init + "; " + cond + "; " + step + ") {\n";
-  result += *body_or;
-  result += Indent(indent) + "}\n";
+      std::format("{}for ({}; {}; {}) {{\n", Indent(indent), init, cond, step);
+  result += RenderNestedBlock(view, block, indent + 1);
+  result += std::format("{}}}\n", Indent(indent));
   if (s.break_label.has_value()) {
-    result += Indent(indent) + BreakLandingLabel(*s.break_label) + ":;\n";
+    result += std::format(
+        "{}{}:;\n", Indent(indent), BreakLandingLabel(*s.break_label));
   }
   return result;
 }
 
-auto RenderWhileStmtNode(
+auto RenderWhileStmt(
     const ScopeView& view, const mir::WhileStmt& s, std::size_t indent)
-    -> diag::Result<std::string> {
+    -> std::string {
   const auto& cond_expr = view.Block().exprs.Get(s.condition);
-  auto cond_or = RenderConditionAsBool(view, cond_expr);
-  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
   const auto& block = view.Block().child_scopes.Get(s.scope);
-  auto body_or = RenderNestedBlock(view, block, indent + 1);
-  if (!body_or) return std::unexpected(std::move(body_or.error()));
-  std::string result =
-      Indent(indent) + "while (" + *std::move(cond_or) + ") {\n";
-  result += *body_or;
-  result += Indent(indent) + "}\n";
+  std::string result = std::format(
+      "{}while ({}) {{\n", Indent(indent),
+      RenderConditionAsBool(view, cond_expr));
+  result += RenderNestedBlock(view, block, indent + 1);
+  result += std::format("{}}}\n", Indent(indent));
   return result;
 }
 
-auto RenderDoWhileStmtNode(
+auto RenderDoWhileStmt(
     const ScopeView& view, const mir::DoWhileStmt& s, std::size_t indent)
-    -> diag::Result<std::string> {
+    -> std::string {
   const auto& cond_expr = view.Block().exprs.Get(s.condition);
-  auto cond_or = RenderConditionAsBool(view, cond_expr);
-  if (!cond_or) return std::unexpected(std::move(cond_or.error()));
   const auto& block = view.Block().child_scopes.Get(s.scope);
-  auto body_or = RenderNestedBlock(view, block, indent + 1);
-  if (!body_or) return std::unexpected(std::move(body_or.error()));
-  std::string result = Indent(indent) + "do {\n";
-  result += *body_or;
-  result += Indent(indent) + "} while (" + *std::move(cond_or) + ");\n";
+  std::string result = std::format("{}do {{\n", Indent(indent));
+  result += RenderNestedBlock(view, block, indent + 1);
+  result += std::format(
+      "{}}} while ({});\n", Indent(indent),
+      RenderConditionAsBool(view, cond_expr));
   return result;
 }
 
 auto RenderSensitivityWaitStmt(
     const ScopeView& view, const mir::SensitivityWaitStmt& s,
-    std::size_t indent) -> diag::Result<std::string> {
-  std::string result = Indent(indent) + "co_await lyra::runtime::WaitAny({";
+    std::size_t indent) -> std::string {
+  std::string result =
+      std::format("{}co_await lyra::runtime::WaitAny({{", Indent(indent));
   for (std::size_t i = 0; i < s.reads.size(); ++i) {
     const auto& read = s.reads[i];
-    auto ptr_or = RenderExpr(view, view.Expr(read.observable_ptr));
-    if (!ptr_or) return std::unexpected(std::move(ptr_or.error()));
     if (i != 0) result += ", ";
-    result += "{" + *ptr_or + ", " +
-              std::string{RenderEventEdgeAsRuntime(read.edge_kind)} + ", " +
-              std::to_string(read.lsb_bit_offset) + "ULL, " +
-              std::to_string(read.bit_width) + "ULL}";
+    result += std::format(
+        "{{{}, {}, {}ULL, {}ULL}}",
+        RenderExpr(view, view.Expr(read.observable_ptr)),
+        RenderEventEdgeAsRuntime(read.edge_kind), read.lsb_bit_offset,
+        read.bit_width);
   }
   result += "});\n";
   return result;
@@ -351,59 +326,57 @@ auto RenderSensitivityWaitStmt(
 
 auto RenderStmt(
     const ScopeView& view, const mir::Stmt& stmt, std::size_t indent)
-    -> diag::Result<std::string> {
+    -> std::string {
   std::string out;
   if (stmt.label.has_value()) {
-    out += Indent(indent) + *stmt.label + ":\n";
+    out += std::format("{}{}:\n", Indent(indent), *stmt.label);
   }
-  auto rendered_or = std::visit(
+  out += std::visit(
       Overloaded{
-          [&](const mir::EmptyStmt&) -> diag::Result<std::string> {
-            return Indent(indent) + ";\n";
+          [&](const mir::EmptyStmt&) -> std::string {
+            return std::format("{};\n", Indent(indent));
           },
-          [&](const mir::LocalDeclStmt& s) -> diag::Result<std::string> {
+          [&](const mir::LocalDeclStmt& s) -> std::string {
             return RenderLocalDeclStmt(view, s, indent);
           },
-          [&](const mir::ExprStmt& s) -> diag::Result<std::string> {
+          [&](const mir::ExprStmt& s) -> std::string {
             return RenderExprStmt(view, s, indent);
           },
-          [&](const mir::BlockStmt& s) -> diag::Result<std::string> {
-            return RenderBlockStmtNode(view, s, indent);
+          [&](const mir::BlockStmt& s) -> std::string {
+            return RenderBlockStmt(view, s, indent);
           },
-          [&](const mir::ForkStmt& s) -> diag::Result<std::string> {
-            return RenderForkStmtNode(view, s, indent);
+          [&](const mir::ForkStmt& s) -> std::string {
+            return RenderForkStmt(view, s, indent);
           },
-          [&](const mir::IfStmt& s) -> diag::Result<std::string> {
-            return RenderIfStmtNode(view, s, indent);
+          [&](const mir::IfStmt& s) -> std::string {
+            return RenderIfStmt(view, s, indent);
           },
-          [&](const mir::ConstructOwnedObjectStmt& s)
-              -> diag::Result<std::string> {
+          [&](const mir::ConstructOwnedObjectStmt& s) -> std::string {
             return RenderConstructOwnedObjectStmt(view, s, indent);
           },
-          [&](const mir::ConstructExternalUnitStmt& s)
-              -> diag::Result<std::string> {
+          [&](const mir::ConstructExternalUnitStmt& s) -> std::string {
             return RenderConstructExternalUnitStmt(view, s, indent);
           },
-          [&](const mir::ForStmt& s) -> diag::Result<std::string> {
-            return RenderForStmtNode(view, s, indent);
+          [&](const mir::ForStmt& s) -> std::string {
+            return RenderForStmt(view, s, indent);
           },
-          [&](const mir::WhileStmt& s) -> diag::Result<std::string> {
-            return RenderWhileStmtNode(view, s, indent);
+          [&](const mir::WhileStmt& s) -> std::string {
+            return RenderWhileStmt(view, s, indent);
           },
-          [&](const mir::DoWhileStmt& s) -> diag::Result<std::string> {
-            return RenderDoWhileStmtNode(view, s, indent);
+          [&](const mir::DoWhileStmt& s) -> std::string {
+            return RenderDoWhileStmt(view, s, indent);
           },
-          [&](const mir::BreakStmt& s) -> diag::Result<std::string> {
+          [&](const mir::BreakStmt& s) -> std::string {
             if (s.target.has_value()) {
-              return Indent(indent) + "goto " + BreakLandingLabel(*s.target) +
-                     ";\n";
+              return std::format(
+                  "{}goto {};\n", Indent(indent), BreakLandingLabel(*s.target));
             }
-            return Indent(indent) + "break;\n";
+            return std::format("{}break;\n", Indent(indent));
           },
-          [&](const mir::ContinueStmt&) -> diag::Result<std::string> {
-            return Indent(indent) + "continue;\n";
+          [&](const mir::ContinueStmt&) -> std::string {
+            return std::format("{}continue;\n", Indent(indent));
           },
-          [&](const mir::ReturnStmt& s) -> diag::Result<std::string> {
+          [&](const mir::ReturnStmt& s) -> std::string {
             // `is_coroutine_return` (set at HIR-to-MIR from the enclosing
             // callable's coroutine-ness, mir/stmt.hpp) is a C++ render hint --
             // LIR / LLVM ignore it -- choosing `co_return` over `return`. A
@@ -411,24 +384,22 @@ auto RenderStmt(
             const std::string keyword =
                 s.is_coroutine_return ? "co_return" : "return";
             if (!s.value.has_value()) {
-              return Indent(indent) + keyword + ";\n";
+              return std::format("{}{};\n", Indent(indent), keyword);
             }
-            auto value_or = RenderExpr(view, view.Expr(*s.value));
-            if (!value_or) return std::unexpected(std::move(value_or.error()));
-            return Indent(indent) + keyword + " " + *value_or + ";\n";
+            return std::format(
+                "{}{} {};\n", Indent(indent), keyword,
+                RenderExpr(view, view.Expr(*s.value)));
           },
-          [&](const mir::SensitivityWaitStmt& s) -> diag::Result<std::string> {
+          [&](const mir::SensitivityWaitStmt& s) -> std::string {
             return RenderSensitivityWaitStmt(view, s, indent);
           },
       },
       stmt.data);
-  if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
-  out += *rendered_or;
   return out;
 }
 
 auto RenderBlockStatements(const ScopeView& view, std::size_t indent)
-    -> diag::Result<std::string> {
+    -> std::string {
   const auto& block = view.Block();
   // When a scope's whole content is a single begin/end block, the enclosing
   // braces (a function body, a loop or branch body, an outer block) already
@@ -443,16 +414,14 @@ auto RenderBlockStatements(const ScopeView& view, std::size_t indent)
   }
   std::string out;
   for (const auto& sid : block.root_stmts) {
-    auto rendered_or = RenderStmt(view, block.stmts.Get(sid), indent);
-    if (!rendered_or) return std::unexpected(std::move(rendered_or.error()));
-    out += *rendered_or;
+    out += RenderStmt(view, block.stmts.Get(sid), indent);
   }
   return out;
 }
 
 auto RenderNestedBlock(
     const ScopeView& parent, const mir::Block& block, std::size_t indent)
-    -> diag::Result<std::string> {
+    -> std::string {
   const ScopeView child = parent.WithBlock(block);
   return RenderBlockStatements(child, indent);
 }

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -3,12 +3,10 @@
 #include <cstddef>
 #include <format>
 #include <string>
-#include <utility>
 #include <variant>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
-#include "lyra/diag/diagnostic.hpp"
 #include "lyra/mir/class.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/type.hpp"
@@ -24,8 +22,7 @@ auto RenderPackedArrayCtorArgs(const mir::PackedArrayType& pa) -> std::string {
   // PackedArray 3-arg constructor. The dim list ctor would produce the same
   // shape but is less readable for the common case.
   if (pa.dims.size() == 1) {
-    return std::to_string(pa.BitWidth()) + ", " + signed_lit + ", " +
-           four_state_lit;
+    return std::format("{}, {}, {}", pa.BitWidth(), signed_lit, four_state_lit);
   }
 
   // Multi-dim: emit `{{l0, r0}, {l1, r1}, ...}, signed, four_state` for the
@@ -38,7 +35,7 @@ auto RenderPackedArrayCtorArgs(const mir::PackedArrayType& pa) -> std::string {
         std::format("{{ {}LL, {}LL }}", pa.dims[i].left, pa.dims[i].right);
   }
   dim_list += "}";
-  return dim_list + ", " + signed_lit + ", " + four_state_lit;
+  return std::format("{}, {}, {}", dim_list, signed_lit, four_state_lit);
 }
 
 auto RenderEnumClassName(const mir::Class& owner_class, mir::TypeId id)
@@ -55,76 +52,73 @@ auto RenderEnumClassName(const mir::Class& owner_class, mir::TypeId id)
 
 auto RenderTypeAsCpp(
     const mir::CompilationUnit& unit, const mir::Class& owner_class,
-    mir::TypeId type_id) -> diag::Result<std::string> {
+    mir::TypeId type_id) -> std::string {
   return std::visit(
       Overloaded{
-          [](const mir::PackedArrayType&) -> diag::Result<std::string> {
+          [](const mir::PackedArrayType&) -> std::string {
             return std::string{"lyra::value::PackedArray"};
           },
-          [&](const mir::EnumType&) -> diag::Result<std::string> {
+          [&](const mir::EnumType&) -> std::string {
             return RenderEnumClassName(owner_class, type_id);
           },
-          [](const mir::StringType&) -> diag::Result<std::string> {
+          [](const mir::StringType&) -> std::string {
             return std::string{"lyra::value::String"};
           },
-          [](const mir::EventType&) -> diag::Result<std::string> {
+          [](const mir::EventType&) -> std::string {
             return std::string{"lyra::runtime::NamedEvent"};
           },
-          [](const mir::RealType&) -> diag::Result<std::string> {
+          [](const mir::RealType&) -> std::string {
             return std::string{"lyra::value::Real"};
           },
-          [](const mir::ShortRealType&) -> diag::Result<std::string> {
+          [](const mir::ShortRealType&) -> std::string {
             return std::string{"lyra::value::ShortReal"};
           },
-          [](const mir::RealTimeType&) -> diag::Result<std::string> {
+          [](const mir::RealTimeType&) -> std::string {
             return std::string{"lyra::value::Real"};
           },
-          [&](const mir::UnpackedArrayType& ua) -> diag::Result<std::string> {
-            auto inner_or = RenderTypeAsCpp(unit, owner_class, ua.element_type);
-            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
-            return "lyra::value::UnpackedArray<" + *inner_or + ">";
+          [&](const mir::UnpackedArrayType& ua) -> std::string {
+            return std::format(
+                "lyra::value::UnpackedArray<{}>",
+                RenderTypeAsCpp(unit, owner_class, ua.element_type));
           },
-          [&](const mir::DynamicArrayType& da) -> diag::Result<std::string> {
-            auto inner_or = RenderTypeAsCpp(unit, owner_class, da.element_type);
-            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
-            return "lyra::value::DynamicArray<" + *inner_or + ">";
+          [&](const mir::DynamicArrayType& da) -> std::string {
+            return std::format(
+                "lyra::value::DynamicArray<{}>",
+                RenderTypeAsCpp(unit, owner_class, da.element_type));
           },
-          [&](const mir::QueueType& q) -> diag::Result<std::string> {
-            auto inner_or = RenderTypeAsCpp(unit, owner_class, q.element_type);
-            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
-            return "lyra::value::Queue<" + *inner_or + ">";
+          [&](const mir::QueueType& q) -> std::string {
+            return std::format(
+                "lyra::value::Queue<{}>",
+                RenderTypeAsCpp(unit, owner_class, q.element_type));
           },
-          [&](const mir::AssociativeArrayType& a) -> diag::Result<std::string> {
+          [&](const mir::AssociativeArrayType& a) -> std::string {
             if (!a.key_type.has_value()) {
               throw InternalError(
                   "RenderTypeAsCpp: associative array with a wildcard index "
                   "type reached the backend; AST -> HIR rejects it");
             }
-            auto key_or = RenderTypeAsCpp(unit, owner_class, *a.key_type);
-            if (!key_or) return std::unexpected(std::move(key_or.error()));
-            auto elem_or = RenderTypeAsCpp(unit, owner_class, a.element_type);
-            if (!elem_or) return std::unexpected(std::move(elem_or.error()));
-            return "lyra::value::AssociativeArray<" + *key_or + ", " +
-                   *elem_or + ">";
+            return std::format(
+                "lyra::value::AssociativeArray<{}, {}>",
+                RenderTypeAsCpp(unit, owner_class, *a.key_type),
+                RenderTypeAsCpp(unit, owner_class, a.element_type));
           },
-          [](const mir::ObjectType& o) -> diag::Result<std::string> {
-            return o.name;
+          [](const mir::ObjectType& o) -> std::string { return o.name; },
+          [](const mir::ExternalUnitObjectType& e) -> std::string {
+            return e.unit_name;
           },
-          [](const mir::ExternalUnitObjectType& e)
-              -> diag::Result<std::string> { return e.unit_name; },
-          [](const mir::ScopeType&) -> diag::Result<std::string> {
+          [](const mir::ScopeType&) -> std::string {
             return std::string{"lyra::runtime::Scope"};
           },
-          [](const mir::ServicesType&) -> diag::Result<std::string> {
+          [](const mir::ServicesType&) -> std::string {
             return std::string{"lyra::runtime::RuntimeServices&"};
           },
-          [](const mir::FilesType&) -> diag::Result<std::string> {
+          [](const mir::FilesType&) -> std::string {
             return std::string{"lyra::runtime::FileTable&"};
           },
-          [](const mir::DiagnosticType&) -> diag::Result<std::string> {
+          [](const mir::DiagnosticType&) -> std::string {
             return std::string{"lyra::runtime::DiagnosticDispatcher&"};
           },
-          [](const mir::RuntimeLibraryType& r) -> diag::Result<std::string> {
+          [](const mir::RuntimeLibraryType& r) -> std::string {
             switch (r.kind) {
               case mir::RuntimeLibraryKind::kPrintItem:
                 return std::string{"lyra::value::PrintItem"};
@@ -141,65 +135,60 @@ auto RenderTypeAsCpp(
             }
             throw InternalError("RenderTypeAsCpp: unknown RuntimeLibraryKind");
           },
-          [&](const mir::CoroutineType& c) -> diag::Result<std::string> {
-            auto payload_or = RenderTypeAsCpp(unit, owner_class, c.payload);
-            if (!payload_or)
-              return std::unexpected(std::move(payload_or.error()));
-            return "lyra::runtime::Coroutine<" + *payload_or + ">";
+          [&](const mir::CoroutineType& c) -> std::string {
+            return std::format(
+                "lyra::runtime::Coroutine<{}>",
+                RenderTypeAsCpp(unit, owner_class, c.payload));
           },
-          [&](const mir::RefType& r) -> diag::Result<std::string> {
-            auto inner_or = RenderTypeAsCpp(unit, owner_class, r.pointee);
-            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
-            std::string ref = "lyra::runtime::Ref<" + *inner_or + ">";
-            return r.is_const ? "const " + ref : ref;
+          [&](const mir::RefType& r) -> std::string {
+            std::string ref = std::format(
+                "lyra::runtime::Ref<{}>",
+                RenderTypeAsCpp(unit, owner_class, r.pointee));
+            return r.is_const ? std::format("const {}", ref) : ref;
           },
-          [](const mir::VoidType&) -> diag::Result<std::string> {
+          [](const mir::VoidType&) -> std::string {
             return std::string{"void"};
           },
-          [&](const mir::PointerType& p) -> diag::Result<std::string> {
-            auto inner_or = RenderTypeAsCpp(unit, owner_class, p.pointee);
-            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
+          [&](const mir::PointerType& p) -> std::string {
+            std::string inner = RenderTypeAsCpp(unit, owner_class, p.pointee);
             switch (p.ownership) {
               case mir::PointerOwnership::kUnique:
-                return "std::unique_ptr<" + *inner_or + ">";
+                return std::format("std::unique_ptr<{}>", inner);
               case mir::PointerOwnership::kShared:
-                return "std::shared_ptr<" + *inner_or + ">";
+                return std::format("std::shared_ptr<{}>", inner);
               case mir::PointerOwnership::kBorrowed:
                 // A borrowed pointer refers to the pointee's storage cell --
                 // a `Var<T>` if the pointee is an observable wrapper, the
                 // bare type otherwise -- so the slot mirrors what it points
                 // at by recursing.
-                return *inner_or + "*";
+                return std::format("{}*", inner);
             }
             throw InternalError("RenderTypeAsCpp: unknown PointerOwnership");
           },
-          [&](const mir::VectorType& v) -> diag::Result<std::string> {
-            auto inner_or = RenderTypeAsCpp(unit, owner_class, v.element);
-            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
-            return "std::vector<" + *inner_or + ">";
+          [&](const mir::VectorType& v) -> std::string {
+            return std::format(
+                "std::vector<{}>",
+                RenderTypeAsCpp(unit, owner_class, v.element));
           },
-          [&](const mir::TupleType& t) -> diag::Result<std::string> {
+          [&](const mir::TupleType& t) -> std::string {
             std::string inners;
             for (std::size_t i = 0; i < t.elements.size(); ++i) {
-              auto inner_or = RenderTypeAsCpp(unit, owner_class, t.elements[i]);
-              if (!inner_or)
-                return std::unexpected(std::move(inner_or.error()));
               if (i != 0) inners += ", ";
-              inners += *inner_or;
+              inners += RenderTypeAsCpp(unit, owner_class, t.elements[i]);
             }
-            return "std::tuple<" + inners + ">";
+            return std::format("std::tuple<{}>", inners);
           },
-          [&](const mir::ExternalRefType& e) -> diag::Result<std::string> {
-            auto inner_or = RenderTypeAsCpp(unit, owner_class, e.element);
-            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
-            return "lyra::runtime::ExternUp<" + *inner_or + ">";
+          [&](const mir::ExternalRefType& e) -> std::string {
+            return std::format(
+                "lyra::runtime::ExternUp<{}>",
+                RenderTypeAsCpp(unit, owner_class, e.element));
           },
-          [&](const mir::ObservableType& o) -> diag::Result<std::string> {
-            auto inner_or = RenderTypeAsCpp(unit, owner_class, o.value);
-            if (!inner_or) return std::unexpected(std::move(inner_or.error()));
-            return "lyra::runtime::Var<" + *inner_or + ">";
+          [&](const mir::ObservableType& o) -> std::string {
+            return std::format(
+                "lyra::runtime::Var<{}>",
+                RenderTypeAsCpp(unit, owner_class, o.value));
           },
-          [](const auto&) -> diag::Result<std::string> {
+          [](const auto&) -> std::string {
             throw InternalError(
                 "RenderTypeAsCpp: unsupported MIR type for current C++ render "
                 "cut");

--- a/src/lyra/driver/cpp_build.cpp
+++ b/src/lyra/driver/cpp_build.cpp
@@ -157,17 +157,14 @@ auto EmitAndWriteSources(
     std::span<const mir::CompilationUnit> units,
     std::span<const backend::cpp::TopInstance> tops,
     const std::filesystem::path& dir, bool format) -> diag::Result<void> {
-  auto set_or = backend::cpp::EmitCpp(units, tops);
-  if (!set_or) {
-    return std::unexpected(std::move(set_or.error()));
-  }
-  for (const auto& file : set_or->files) {
+  auto set = backend::cpp::EmitCpp(units, tops);
+  for (const auto& file : set.files) {
     if (auto r = WriteFile(dir / file.relpath, file.content); !r) {
       return r;
     }
   }
   if (format) {
-    FormatSources(set_or->files, dir);
+    FormatSources(set.files, dir);
   }
   return {};
 }

--- a/src/lyra/lowering/hir_to_mir/cast_lowering.cpp
+++ b/src/lyra/lowering/hir_to_mir/cast_lowering.cpp
@@ -21,22 +21,23 @@ auto IsRealFamilyKind(mir::TypeKind k) -> bool {
 }
 
 // Three trailing operands `PackedArray::FromInt` / `ConvertFrom` consume after
-// the value: `(bit_width, is_signed, is_four_state)`. All three are
-// compile-time facts of the destination packed shape, so the lowering
-// synthesizes int literals here -- the runtime call's signature surfaces them
-// uniformly as plain integer arguments.
+// the value: `(bit_width, is_signed, is_four_state)`. The runtime entry's
+// signature takes host scalars (`uint64_t`, `bool`, `bool`), not SV-typed
+// `PackedArray` values, so the lowering synthesizes `HostIntLiteral` for
+// each -- they render as bare C++ integer literals that C++ implicitly
+// narrows / converts to the parameter types.
 void AppendPackedShapeArgs(
     const mir::CompilationUnit& unit, mir::Block& block,
     const mir::PackedArrayType& dst_pa, std::vector<mir::ExprId>& args) {
   const mir::TypeId int32_type = unit.builtins.int32;
-  args.push_back(block.exprs.Add(
-      mir::MakeInt32Literal(
-          int32_type, static_cast<std::int64_t>(dst_pa.BitWidth()))));
-  args.push_back(block.exprs.Add(
-      mir::MakeInt32Literal(
-          int32_type, dst_pa.signedness == mir::Signedness::kSigned ? 1 : 0)));
-  args.push_back(block.exprs.Add(
-      mir::MakeInt32Literal(int32_type, dst_pa.IsFourState() ? 1 : 0)));
+  const auto host_lit = [&](std::int64_t v) {
+    return block.exprs.Add(
+        mir::Expr{.data = mir::HostIntLiteral{.value = v}, .type = int32_type});
+  };
+  args.push_back(host_lit(static_cast<std::int64_t>(dst_pa.BitWidth())));
+  args.push_back(
+      host_lit(dst_pa.signedness == mir::Signedness::kSigned ? 1 : 0));
+  args.push_back(host_lit(dst_pa.IsFourState() ? 1 : 0));
 }
 
 // `Real(operand)` / `ShortReal(operand)` invokes the explicit `RealValue`

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -693,7 +693,8 @@ auto LowerCaseGenerate(
             return std::unexpected(std::move(lab_or.error()));
           }
           return label_frame.current_block->exprs.Add(*std::move(lab_or));
-        });
+        },
+        lowerer.Module().Unit());
   };
 
   return BuildCaseCascade(

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -307,14 +307,9 @@ auto LowerStringElementAssign(
     const mir::ExprId base_read_id = block.exprs.Add(*std::move(base_read_or));
     const mir::ExprId cur_id = block.exprs.Add(MakeStringMethodCallExpr(
         support::BuiltinFn::kGetc, {base_read_id, idx_id}, result_type));
-    value_id = block.exprs.Add(
-        mir::Expr{
-            .data =
-                mir::BinaryExpr{
-                    .op = LowerBinaryOp(*a.compound_op),
-                    .lhs = cur_id,
-                    .rhs = value_id},
-            .type = result_type});
+    value_id = block.exprs.Add(BuildMirBinaryExpr(
+        unit, block, LowerBinaryOp(*a.compound_op), cur_id, value_id,
+        result_type));
   }
 
   const std::array<mir::ExprId, 2> operands{idx_id, value_id};

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -2,6 +2,8 @@
 
 #include <expected>
 #include <utility>
+#include <variant>
+#include <vector>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
@@ -21,6 +23,7 @@
 #include "lyra/mir/type.hpp"
 #include "lyra/mir/type_id.hpp"
 #include "lyra/mir/unary_op.hpp"
+#include "lyra/support/builtin_fn.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
@@ -127,21 +130,284 @@ auto LowerIncDecOp(hir::IncDecOp op) -> mir::IncDecOp {
   throw InternalError("LowerIncDecOp: unknown HIR IncDecOp");
 }
 
+auto IsRealFamilyTypeKind(mir::TypeKind k) -> bool {
+  return k == mir::TypeKind::kReal || k == mir::TypeKind::kShortReal ||
+         k == mir::TypeKind::kRealTime;
+}
+
+auto IsRealFamilyType(const mir::Type& ty) -> bool {
+  return IsRealFamilyTypeKind(ty.Kind());
+}
+
+auto IsArrayContainerType(const mir::Type& ty) -> bool {
+  return std::holds_alternative<mir::UnpackedArrayType>(ty.data) ||
+         std::holds_alternative<mir::DynamicArrayType>(ty.data);
+}
+
+// Maps the method-style MIR binary ops to their `BuiltinFn` realization on
+// `PackedArray`. Returns `nullopt` for ops that render natively (`+`, `==`,
+// ...). The negation-then-positive forms (`kWildcardInequality`,
+// `kCaseInequality`) are handled separately by the caller as `!Eq(...)`.
+auto BinaryOpAsBuiltinFn(mir::BinaryOp op)
+    -> std::optional<support::BuiltinFn> {
+  switch (op) {
+    case mir::BinaryOp::kPower:
+      return support::BuiltinFn::kPow;
+    case mir::BinaryOp::kShiftLeft:
+      return support::BuiltinFn::kShiftLeft;
+    case mir::BinaryOp::kLogicalShiftRight:
+      return support::BuiltinFn::kLogicalShiftRight;
+    case mir::BinaryOp::kArithmeticShiftRight:
+      return support::BuiltinFn::kArithmeticShiftRight;
+    case mir::BinaryOp::kBitwiseXnor:
+      return support::BuiltinFn::kBitwiseXnor;
+    case mir::BinaryOp::kLogicalImplication:
+      return support::BuiltinFn::kLogicalImplication;
+    case mir::BinaryOp::kLogicalEquivalence:
+      return support::BuiltinFn::kLogicalEquivalence;
+    case mir::BinaryOp::kWildcardEquality:
+      return support::BuiltinFn::kWildcardEquals;
+    case mir::BinaryOp::kCaseEquality:
+      return support::BuiltinFn::kCaseEqual;
+    case mir::BinaryOp::kCasezEquality:
+      return support::BuiltinFn::kCasezEquals;
+    case mir::BinaryOp::kCasexEquality:
+      return support::BuiltinFn::kCasexEquals;
+    default:
+      return std::nullopt;
+  }
+}
+
+auto UnaryOpAsBuiltinFn(mir::UnaryOp op) -> std::optional<support::BuiltinFn> {
+  switch (op) {
+    case mir::UnaryOp::kReductionAnd:
+      return support::BuiltinFn::kReductionAnd;
+    case mir::UnaryOp::kReductionOr:
+      return support::BuiltinFn::kReductionOr;
+    case mir::UnaryOp::kReductionXor:
+      return support::BuiltinFn::kReductionXor;
+    case mir::UnaryOp::kReductionNand:
+      return support::BuiltinFn::kReductionNand;
+    case mir::UnaryOp::kReductionNor:
+      return support::BuiltinFn::kReductionNor;
+    case mir::UnaryOp::kReductionXnor:
+      return support::BuiltinFn::kReductionXnor;
+    default:
+      return std::nullopt;
+  }
+}
+
+auto MakeBuiltinFnCall(
+    support::BuiltinFn id, std::vector<mir::ExprId> arguments,
+    mir::TypeId result_type) -> mir::Expr {
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee = mir::BuiltinFnCallee{.id = id},
+              .arguments = std::move(arguments)},
+      .type = result_type};
+}
+
+auto MakeFromBoolCall(mir::ExprId bool_expr_id, mir::TypeId result_type)
+    -> mir::Expr {
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee =
+                  mir::BuiltinStaticCallee{
+                      .id = support::BuiltinFn::kFromBool,
+                      .type_qual = result_type},
+              .arguments = {bool_expr_id}},
+      .type = result_type};
+}
+
+// Wraps an operand in `BoolCastExpr` so a host-bool consumer (a native
+// `&&` / `||` / `!`, or `kFromBool`) can take it. The cast's MIR type is
+// the unit's canonical 1-bit packed type because the wrap is observable
+// only after `FromBool` re-shapes it; the bool-ness rides on the node kind,
+// not on the type.
+auto MakeBoolCast(mir::ExprId operand_id, mir::TypeId bit1_type) -> mir::Expr {
+  return mir::Expr{
+      .data = mir::BoolCastExpr{.operand = operand_id}, .type = bit1_type};
+}
+
+// LRM 11.3.1 logical operator on real / string operands: each operand
+// passes through `bool(...)`, then the host-native logical operator
+// composes them, then `kFromBool` re-shapes to a 1-bit integral.
+auto BuildRealOrStringLogicalLift(
+    mir::Block& block, mir::BinaryOp op, mir::ExprId lhs_id, mir::ExprId rhs_id,
+    mir::TypeId result_type, mir::TypeId bit1_type) -> mir::Expr {
+  const mir::ExprId lhs_bool = block.exprs.Add(MakeBoolCast(lhs_id, bit1_type));
+  const mir::ExprId rhs_bool = block.exprs.Add(MakeBoolCast(rhs_id, bit1_type));
+  mir::ExprId inner{};
+  switch (op) {
+    case mir::BinaryOp::kLogicalAnd:
+    case mir::BinaryOp::kLogicalOr:
+    case mir::BinaryOp::kLogicalEquivalence: {
+      inner = block.exprs.Add(
+          mir::Expr{
+              .data =
+                  mir::BinaryExpr{
+                      .op = op == mir::BinaryOp::kLogicalEquivalence
+                                ? mir::BinaryOp::kEquality
+                                : op,
+                      .lhs = lhs_bool,
+                      .rhs = rhs_bool},
+              .type = result_type});
+      break;
+    }
+    case mir::BinaryOp::kLogicalImplication: {
+      // `!lhs || rhs`
+      const mir::ExprId not_lhs = block.exprs.Add(
+          mir::Expr{
+              .data =
+                  mir::UnaryExpr{
+                      .op = mir::UnaryOp::kLogicalNot, .operand = lhs_bool},
+              .type = result_type});
+      inner = block.exprs.Add(
+          mir::Expr{
+              .data =
+                  mir::BinaryExpr{
+                      .op = mir::BinaryOp::kLogicalOr,
+                      .lhs = not_lhs,
+                      .rhs = rhs_bool},
+              .type = result_type});
+      break;
+    }
+    default:
+      throw InternalError(
+          "BuildRealOrStringLogicalLift: unsupported logical operator");
+  }
+  return MakeFromBoolCall(inner, result_type);
+}
+
 }  // namespace
+
+auto BuildMirUnaryExpr(
+    const mir::CompilationUnit& unit, mir::Block& block, mir::UnaryOp op,
+    mir::ExprId operand_id, mir::TypeId result_type) -> mir::Expr {
+  const auto& operand_ty = unit.GetType(block.exprs.Get(operand_id).type);
+
+  // LRM 11.4.9 reduction operators: render as `PackedArray::ReductionX()`,
+  // routed through `BuiltinFnCallee` so the backend's render path collapses
+  // to mechanical method dispatch.
+  if (auto builtin = UnaryOpAsBuiltinFn(op)) {
+    return MakeBuiltinFnCall(*builtin, {operand_id}, result_type);
+  }
+
+  // LRM 11.3.1 real `!`: route through `bool(...)` and wrap the host-bool
+  // result in `FromBool` so the surface type stays the 1-bit integral the
+  // SV semantic prescribes.
+  if (op == mir::UnaryOp::kLogicalNot && IsRealFamilyType(operand_ty)) {
+    const mir::ExprId operand_bool =
+        block.exprs.Add(MakeBoolCast(operand_id, unit.builtins.bit1));
+    const mir::ExprId not_id = block.exprs.Add(
+        mir::Expr{
+            .data =
+                mir::UnaryExpr{
+                    .op = mir::UnaryOp::kLogicalNot, .operand = operand_bool},
+            .type = result_type});
+    return MakeFromBoolCall(not_id, result_type);
+  }
+
+  return mir::Expr{
+      .data = mir::UnaryExpr{.op = op, .operand = operand_id},
+      .type = result_type};
+}
+
+auto BuildMirBinaryExpr(
+    const mir::CompilationUnit& unit, mir::Block& block, mir::BinaryOp op,
+    mir::ExprId lhs_id, mir::ExprId rhs_id, mir::TypeId result_type)
+    -> mir::Expr {
+  const auto& lhs_ty = unit.GetType(block.exprs.Get(lhs_id).type);
+  const auto& rhs_ty = unit.GetType(block.exprs.Get(rhs_id).type);
+  const bool real_lhs = IsRealFamilyType(lhs_ty);
+  const bool real_rhs = IsRealFamilyType(rhs_ty);
+  const bool string_lhs = lhs_ty.Kind() == mir::TypeKind::kString;
+  const bool string_rhs = rhs_ty.Kind() == mir::TypeKind::kString;
+
+  // LRM 11.3.1 / LRM 6.16 logical operator on real / string operands needs
+  // `bool(...)` coercion on each operand before the host-native `&&` / `||`
+  // / `==` composes them; `kFromBool` re-shapes the host bool back to a
+  // 1-bit integral. Comparison / relational operators do NOT need this
+  // lift -- `String::operator==` / `RealValue::operator==` and their
+  // siblings already return a SV `PackedArray<1>` directly per LRM 6.16 /
+  // 11.3.1, so the plain BinaryExpr render does the right thing.
+  if (real_lhs || real_rhs || (string_lhs && string_rhs)) {
+    switch (op) {
+      case mir::BinaryOp::kLogicalAnd:
+      case mir::BinaryOp::kLogicalOr:
+      case mir::BinaryOp::kLogicalImplication:
+      case mir::BinaryOp::kLogicalEquivalence:
+        return BuildRealOrStringLogicalLift(
+            block, op, lhs_id, rhs_id, result_type, unit.builtins.bit1);
+      default:
+        break;
+    }
+  }
+
+  // LRM 11.2.2 / 11.4.5 aggregate `===` / `!==`: routed as `kCaseEqual`
+  // (with a wrapping `!` for the inequality form).
+  if (IsArrayContainerType(lhs_ty) && IsArrayContainerType(rhs_ty)) {
+    if (op == mir::BinaryOp::kCaseEquality) {
+      return MakeBuiltinFnCall(
+          support::BuiltinFn::kCaseEqual, {lhs_id, rhs_id}, result_type);
+    }
+    if (op == mir::BinaryOp::kCaseInequality) {
+      const mir::ExprId inner = block.exprs.Add(MakeBuiltinFnCall(
+          support::BuiltinFn::kCaseEqual, {lhs_id, rhs_id}, result_type));
+      return mir::Expr{
+          .data =
+              mir::UnaryExpr{.op = mir::UnaryOp::kLogicalNot, .operand = inner},
+          .type = result_type};
+    }
+    // kEquality / kInequality on arrays render natively (operator==),
+    // so fall through to the BinaryExpr path.
+  }
+
+  // LRM 11.4 method-style binary ops (shifts, power, xnor, wildcard /
+  // case / implication / equivalence): route through `BuiltinFnCallee`.
+  if (auto builtin = BinaryOpAsBuiltinFn(op)) {
+    return MakeBuiltinFnCall(*builtin, {lhs_id, rhs_id}, result_type);
+  }
+
+  // The `!=` siblings of wildcard / case equality lift to a positive form
+  // wrapped in logical NOT, keeping the backend free of negation knowledge.
+  if (op == mir::BinaryOp::kWildcardInequality) {
+    const mir::ExprId inner = block.exprs.Add(MakeBuiltinFnCall(
+        support::BuiltinFn::kWildcardEquals, {lhs_id, rhs_id}, result_type));
+    return mir::Expr{
+        .data =
+            mir::UnaryExpr{.op = mir::UnaryOp::kLogicalNot, .operand = inner},
+        .type = result_type};
+  }
+  if (op == mir::BinaryOp::kCaseInequality) {
+    const mir::ExprId inner = block.exprs.Add(MakeBuiltinFnCall(
+        support::BuiltinFn::kCaseEqual, {lhs_id, rhs_id}, result_type));
+    return mir::Expr{
+        .data =
+            mir::UnaryExpr{.op = mir::UnaryOp::kLogicalNot, .operand = inner},
+        .type = result_type};
+  }
+
+  return mir::Expr{
+      .data = mir::BinaryExpr{.op = op, .lhs = lhs_id, .rhs = rhs_id},
+      .type = result_type};
+}
 
 template <ExprLowerer Lowerer>
 auto LowerHirUnaryExpr(
     Lowerer& lowerer, WalkFrame frame, const hir::UnaryExpr& u,
     mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  auto& block = *frame.current_block;
   auto operand_or = lowerer.LowerExpr(lowerer.HirExprs().Get(u.operand), frame);
   if (!operand_or) {
     return std::unexpected(std::move(operand_or.error()));
   }
-  const mir::ExprId operand_id =
-      frame.current_block->exprs.Add(*std::move(operand_or));
-  return mir::Expr{
-      .data = mir::UnaryExpr{.op = LowerUnaryOp(u.op), .operand = operand_id},
-      .type = result_type};
+  const mir::ExprId operand_id = block.exprs.Add(*std::move(operand_or));
+  return BuildMirUnaryExpr(
+      lowerer.Module().Unit(), block, LowerUnaryOp(u.op), operand_id,
+      result_type);
 }
 
 template <ExprLowerer Lowerer>
@@ -155,11 +421,9 @@ auto LowerHirBinaryExpr(
   auto rhs_or = lowerer.LowerExpr(lowerer.HirExprs().Get(b.rhs), frame);
   if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
   const mir::ExprId rhs_id = block.exprs.Add(*std::move(rhs_or));
-  return mir::Expr{
-      .data =
-          mir::BinaryExpr{
-              .op = LowerBinaryOp(b.op), .lhs = lhs_id, .rhs = rhs_id},
-      .type = result_type};
+  return BuildMirBinaryExpr(
+      lowerer.Module().Unit(), block, LowerBinaryOp(b.op), lhs_id, rhs_id,
+      result_type);
 }
 
 template <ExprLowerer Lowerer>

--- a/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
+++ b/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
@@ -6,6 +6,7 @@
 #include "lyra/base/overloaded.hpp"
 #include "lyra/hir/inside_item.hpp"
 #include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/expression/operators.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/expr.hpp"
@@ -20,6 +21,7 @@ auto BuildHirInsideItemPredicate(
     -> diag::Result<mir::ExprId> {
   const auto& hir_exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
+  const auto& unit = lowerer.Module().Unit();
   auto lower_id = [&](hir::ExprId id) -> diag::Result<mir::ExprId> {
     auto lowered = lowerer.LowerExpr(hir_exprs.Get(id), frame);
     if (!lowered) {
@@ -33,44 +35,24 @@ auto BuildHirInsideItemPredicate(
           [&](const hir::ExprId& val_id) -> diag::Result<mir::ExprId> {
             auto v = lower_id(val_id);
             if (!v) return std::unexpected(std::move(v.error()));
-            return block.exprs.Add(
-                mir::Expr{
-                    .data =
-                        mir::BinaryExpr{
-                            .op = mir::BinaryOp::kWildcardEquality,
-                            .lhs = lhs_id,
-                            .rhs = *v},
-                    .type = result_type});
+            return block.exprs.Add(BuildMirBinaryExpr(
+                unit, block, mir::BinaryOp::kWildcardEquality, lhs_id, *v,
+                result_type));
           },
           [&](const hir::InsideRangePair& r) -> diag::Result<mir::ExprId> {
             auto lo = lower_id(r.lo);
             if (!lo) return std::unexpected(std::move(lo.error()));
             auto hi = lower_id(r.hi);
             if (!hi) return std::unexpected(std::move(hi.error()));
-            const mir::ExprId ge_id = block.exprs.Add(
-                mir::Expr{
-                    .data =
-                        mir::BinaryExpr{
-                            .op = mir::BinaryOp::kGreaterEqual,
-                            .lhs = lhs_id,
-                            .rhs = *lo},
-                    .type = result_type});
-            const mir::ExprId le_id = block.exprs.Add(
-                mir::Expr{
-                    .data =
-                        mir::BinaryExpr{
-                            .op = mir::BinaryOp::kLessEqual,
-                            .lhs = lhs_id,
-                            .rhs = *hi},
-                    .type = result_type});
-            return block.exprs.Add(
-                mir::Expr{
-                    .data =
-                        mir::BinaryExpr{
-                            .op = mir::BinaryOp::kLogicalAnd,
-                            .lhs = ge_id,
-                            .rhs = le_id},
-                    .type = result_type});
+            const mir::ExprId ge_id = block.exprs.Add(BuildMirBinaryExpr(
+                unit, block, mir::BinaryOp::kGreaterEqual, lhs_id, *lo,
+                result_type));
+            const mir::ExprId le_id = block.exprs.Add(BuildMirBinaryExpr(
+                unit, block, mir::BinaryOp::kLessEqual, lhs_id, *hi,
+                result_type));
+            return block.exprs.Add(BuildMirBinaryExpr(
+                unit, block, mir::BinaryOp::kLogicalAnd, ge_id, le_id,
+                result_type));
           },
       },
       item);

--- a/src/lyra/lowering/hir_to_mir/statement/branches.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/branches.cpp
@@ -161,7 +161,8 @@ auto LowerCaseStmt(
               return std::unexpected(std::move(lab_or.error()));
             }
             return label_frame.current_block->exprs.Add(*std::move(lab_or));
-          });
+          },
+          process.Module().Unit());
       if (!pred_or) return std::unexpected(std::move(pred_or.error()));
       predicates.push_back(*pred_or);
     }
@@ -192,7 +193,8 @@ auto LowerCaseStmt(
             return std::unexpected(std::move(lab_or.error()));
           }
           return label_frame.current_block->exprs.Add(*std::move(lab_or));
-        });
+        },
+        process.Module().Unit());
   };
 
   return BuildCaseCascade(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -473,6 +473,9 @@ class MirDumper {
               return std::format("RealLiteral({})", lit.value);
             },
             [](const NullLiteral&) -> std::string { return "NullLiteral"; },
+            [](const HostIntLiteral& lit) -> std::string {
+              return std::format("HostIntLiteral({})", lit.value);
+            },
             [](const AddressOfExpr& a) -> std::string {
               return std::format(
                   "AddressOfExpr operand=Expr[{}]", a.operand.value);
@@ -503,6 +506,10 @@ class MirDumper {
               return std::format(
                   "BinaryExpr op={} lhs=Expr[{}] rhs=Expr[{}]",
                   FormatBinaryOp(b.op), b.lhs.value, b.rhs.value);
+            },
+            [](const BoolCastExpr& b) -> std::string {
+              return std::format(
+                  "BoolCastExpr operand=Expr[{}]", b.operand.value);
             },
             [](const ConditionalExpr& c) -> std::string {
               return std::format(

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -346,6 +346,42 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "from_packed_array";
     case BuiltinFn::kFromByteArray:
       return "from_byte_array";
+    case BuiltinFn::kPow:
+      return "pow";
+    case BuiltinFn::kShiftLeft:
+      return "shift_left";
+    case BuiltinFn::kLogicalShiftRight:
+      return "logical_shift_right";
+    case BuiltinFn::kArithmeticShiftRight:
+      return "arithmetic_shift_right";
+    case BuiltinFn::kBitwiseXnor:
+      return "bitwise_xnor";
+    case BuiltinFn::kLogicalImplication:
+      return "logical_implication";
+    case BuiltinFn::kLogicalEquivalence:
+      return "logical_equivalence";
+    case BuiltinFn::kWildcardEquals:
+      return "wildcard_equals";
+    case BuiltinFn::kCaseEqual:
+      return "case_equal";
+    case BuiltinFn::kCasezEquals:
+      return "casez_equals";
+    case BuiltinFn::kCasexEquals:
+      return "casex_equals";
+    case BuiltinFn::kReductionAnd:
+      return "reduction_and";
+    case BuiltinFn::kReductionOr:
+      return "reduction_or";
+    case BuiltinFn::kReductionXor:
+      return "reduction_xor";
+    case BuiltinFn::kReductionNand:
+      return "reduction_nand";
+    case BuiltinFn::kReductionNor:
+      return "reduction_nor";
+    case BuiltinFn::kReductionXnor:
+      return "reduction_xnor";
+    case BuiltinFn::kFromBool:
+      return "from_bool";
   }
   throw InternalError("BuiltinFnName: unknown BuiltinFn");
 }

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -117,6 +117,10 @@ auto PackedArray::Bit(bool value) -> PackedArray {
   return FromInt(value ? 1 : 0, 1U, false, false);
 }
 
+auto PackedArray::FromBool(bool value) -> PackedArray {
+  return Bit(value);
+}
+
 auto PackedArray::MakeFromWordPlanes(
     std::uint64_t bit_width, bool is_signed, bool is_four_state,
     std::span<const std::uint64_t> value_words,
@@ -1729,7 +1733,7 @@ auto PackedArray::ArithmeticShiftRight(const PackedArray& amount) const
       std::span<const std::uint64_t>{unk_buf.data(), unk_buf.size()});
 }
 
-auto PackedArray::Power(const PackedArray& exponent) const -> PackedArray {
+auto PackedArray::Pow(const PackedArray& exponent) const -> PackedArray {
   // The exponent is checked before the base so that `X ** 0 = 1` wins
   // over X-propagation from the base (LRM 11.4.10).
   if (exponent.HasUnknown()) {
@@ -1739,7 +1743,7 @@ auto PackedArray::Power(const PackedArray& exponent) const -> PackedArray {
   for (std::size_t i = 1; i < exp_words.size(); ++i) {
     if (exp_words[i] != 0U && exp_words[i] != ~std::uint64_t{0}) {
       throw InternalError(
-          "PackedArray::Power: exponent magnitude exceeds 64 bits");
+          "PackedArray::Pow: exponent magnitude exceeds 64 bits");
     }
   }
   const std::uint64_t exp_low = exp_words.empty() ? 0U : exp_words[0];


### PR DESCRIPTION
## Summary

Two coupled cleanups in the C++ backend that move it closer to the principle established by #955: render is a fixed function of the MIR node kind, with no type-driven dispatch or semantic re-derivation. First, every render function loses its `diag::Result<std::string>` wrapper and returns plain `std::string`, throwing `InternalError` on the few sites that were issuing user-facing diagnostics for backend-only feature gaps. Second, the SV binary and unary operators that previously dispatched at render time on operand type now lower to explicit `CallExpr` shapes at HIR-to-MIR: method-style ops (shifts, power, xnor, wildcard / case / implication / equivalence, reductions) route through new `BuiltinFnCallee` entries; real / string logical ops wrap a `bool(...)`-coerced inner with a `kFromBool` factory call. The eight backend operator helpers (`RenderBinaryOpReal` / `String` / `Array` / `Integral`, `RenderUnaryOpReal` / `Integral`, `WrapBoolAsResultShape`, `IsRealFamilyType`) retire; `RenderBinaryExpr` collapses to a one-line `({lhs} {token} {rhs})` formatter over native ops only.

## Design

### Result drop

The backend is mechanical translation: if a node arrives that it cannot render, that is an MIR invariant violation, not a user-facing diagnostic. The nine `return diag::Fail(kCppEmitExpressionFormNotImplemented, ...)` sites convert directly to `throw InternalError(...)`. The few backend-feature-gap cases (cross-scope param, cross-class method call) currently surface as compiler bugs; moving their rejection to HIR-to-MIR is a follow-up, but the architectural shape is correct now. The `~100` lines of `if (!x_or) return std::unexpected(...)` plumbing across `render_expr.cpp` / `render_stmt.cpp` / `render_type.cpp` / `emit_cpp.cpp` disappear, and `+`-style string concat is also modernized to `std::format` throughout.

### Operator lift

The previous `RenderBinaryExpr` looked at `(lhs_ty, rhs_ty)` and picked among four helpers, each with its own per-`BinaryOp` switch. Each helper mixed native C++ tokens (`lhs + rhs`) with method calls (`.Pow(rhs)`, `.ShiftLeft(rhs)`, `.CaseEqual(rhs)`) -- the backend was re-deciding which runtime spelling to use. HIR-to-MIR is the right place for that decision. `BuildMirBinaryExpr` now dispatches once on `(op, operand types)`:

- **Method-style ops** lift to `CallExpr{BuiltinFnCallee{kPow | kShiftLeft | kBitwiseXnor | kWildcardEquals | kCaseEqual | ...}, [lhs, rhs]}`; the inequality siblings wrap with a `UnaryExpr{kLogicalNot}`. Eleven new `BuiltinFn` entries name the corresponding `lyra::value::PackedArray` methods.
- **Reduction unary ops** lift symmetrically to `CallExpr{BuiltinFnCallee{kReductionAnd | ...}, [operand]}`. Six new `BuiltinFn` entries.
- **Real / string logical ops** (`&&`, `||`, `->`, `<->`, `!`) need host-`bool` coercion on each operand because PackedArray's `explicit operator bool` does not fire as a free function argument. The lift introduces a new `BoolCastExpr{operand}` primitive that renders as `bool(...)`, composes the inner with native MIR `BinaryExpr` / `UnaryExpr`, and wraps the whole thing in a `kFromBool` static factory call (`PackedArray::FromBool(bool)`) to shape the host bool back to a 1-bit packed SV result.
- **Comparison / relational ops** on every operand type (PackedArray, RealValue, String) already return `PackedArray<1>` directly from the C++ overload per LRM 6.16 / 11.3.1, so they render as plain `BinaryExpr` with no wrap.

`RenderBinaryExpr` becomes `std::format("({} {} {})", lhs, BinaryOpToken(op), rhs)`. `RenderUnaryExpr` is symmetric. The eight operator helpers delete entirely.

### Adjacent cleanups

- A new `HostIntLiteral{value}` MIR primitive renders as a bare C++ integer (`42LL`). `cast_lowering.cpp::AppendPackedShapeArgs` switches from `MakeInt32Literal` to `HostIntLiteral` for the `(width, signed, four_state)` triple it passes to `PackedArray::FromInt` / `ConvertFrom`. The previous shape rendered the triple as `PackedArray::Int(64)` etc., which doesn't satisfy `ConvertFrom`'s `(uint64_t, bool, bool)` signature -- a latent bug from #955 that surfaces once the operator lift exercises the path more aggressively.
- `render_stmt.cpp` drops the inconsistent `Node` suffix on six stmt-renderer helpers (`RenderForkStmt`, `RenderIfStmt`, `RenderForStmt`, etc.).
- `RenderForkJoinModeLiteral` replaces a silent default-return fallback with an explicit `InternalError`, matching the project-wide style for switch-exhaustive enum dispatch.
- `EmitCppDeclarations` returns `CppArtifact` instead of a one-element `std::vector<CppArtifact>`.

## Testing

`bazel test //...` is green. Existing operator and cast coverage exercises the lifted paths end-to-end without test edits.