### PR TITLE
Support wildcard-indexed associative arrays

### DIFF
--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -42,7 +42,7 @@ follow once dynamic array's storage and runtime conventions are settled and prov
 | A3   | Done: `foreach` over an associative array (any dimensionality).         |
 | A4   | Done: literals with optional default, whole-array assignment.           |
 | A5   | Done: locator / reduction / map manipulation methods (key-indexed).     |
-| A6   | Open: wildcard `[*]` index; struct / class index families.              |
+| A6   | Done: wildcard `[*]` and packed-struct index; class index deferred.     |
 
 ## Dynamic Array
 
@@ -235,12 +235,14 @@ the lookup key and imposes an ordering.
       `shuffle`) is excluded for associative arrays (LRM 7.12.2) and is not part of this step;
       reduction is included because LRM 7.12.3 permits it on any integral-valued unpacked array.
 
-- [ ] A6 -- The remaining associative index families. The wildcard `[*]` index admits any integral
-      expression, normalizing each index to its minimal-width canonical form (LRM 7.8.1); a
-      wildcard-indexed array is barred from `foreach` and from any manipulation method that returns
-      an index (LRM 7.8.1 / 7.12.1). The other user-defined index types (a packed struct key, LRM
-      7.8.5) require the index type's equality and ordering. The class index (LRM 7.8.3) is blocked
-      on class support and deferred to that workstream.
+- [x] A6 -- The remaining associative index families. A wildcard `[*]` index admits any integral
+      expression and identifies an entry by its unsigned numerical value, so two indices of the same
+      value but different widths name one entry and ordering is by magnitude (LRM 7.8.1). The
+      frontend rejects a wildcard-indexed array used in `foreach` or with a manipulation method that
+      returns an index (LRM 7.8.1 / 7.12.1), so those illegal forms never reach lowering. A
+      packed-struct key (LRM 7.8.5) is an integral index, keyed and ordered by its bit-pattern
+      value. The class index (LRM 7.8.3) stays blocked on class support and is deferred to that
+      workstream.
 
 ## Cross-references
 

--- a/include/lyra/hir/module_unit.hpp
+++ b/include/lyra/hir/module_unit.hpp
@@ -21,6 +21,7 @@ struct BuiltinHirTypes {
   TypeId string;
   TypeId time;
   TypeId realtime;
+  TypeId wildcard_index;
 };
 
 struct ModuleUnit {
@@ -53,6 +54,7 @@ struct ModuleUnit {
                     .dims = {PackedRange{.left = 63, .right = 0}},
                     .form = PackedArrayForm::kTime}}),
             .realtime = AddType(TypeData{RealTimeType{}}),
+            .wildcard_index = AddType(TypeData{WildcardIndexType{}}),
         } {
   }
 

--- a/include/lyra/hir/type.hpp
+++ b/include/lyra/hir/type.hpp
@@ -20,6 +20,7 @@ enum class TypeKind {
   kDynamicArray,
   kQueue,
   kAssociativeArray,
+  kWildcardIndex,
   kString,
   kEvent,
   kReal,
@@ -130,8 +131,15 @@ struct QueueType {
 
 struct AssociativeArrayType {
   TypeId element_type;
-  std::optional<TypeId> key_type;
+  TypeId key_type;
 };
+
+// LRM 7.8.1 wildcard index type (`[*]`): the key type of an associative array
+// indexed by any integral value, identified by magnitude regardless of the
+// index expression's width. It declares no member structure of its own; it is
+// the type that distinguishes a wildcard-keyed array from a string- or
+// integral-keyed one.
+struct WildcardIndexType {};
 
 struct StringType {};
 struct EventType {};
@@ -144,8 +152,8 @@ struct VoidType {};
 using TypeData = std::variant<
     PackedArrayType, PackedStructType, PackedUnionType, EnumType,
     UnpackedArrayType, DynamicArrayType, QueueType, AssociativeArrayType,
-    StringType, EventType, RealType, ShortRealType, RealTimeType, ChandleType,
-    VoidType>;
+    WildcardIndexType, StringType, EventType, RealType, ShortRealType,
+    RealTimeType, ChandleType, VoidType>;
 
 struct Type {
   TypeData data;

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -36,6 +36,7 @@ struct BuiltinMirTypes {
   TypeId format_spec;
   TypeId time_format;
   TypeId coroutine;
+  TypeId wildcard_index;
 };
 
 struct CompilationUnit {
@@ -95,6 +96,7 @@ struct CompilationUnit {
                 TypeData{RuntimeLibraryType{
                     .kind = RuntimeLibraryKind::kTimeFormat}}),
             .coroutine = TypeId{},
+            .wildcard_index = AddType(TypeData{WildcardIndexType{}}),
         } {
     // A bare coroutine yields nothing, so its completion payload is `Void`. It
     // is interned in the body rather than the member list because it reads back

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -17,6 +17,7 @@ enum class TypeKind {
   kDynamicArray,
   kQueue,
   kAssociativeArray,
+  kWildcardIndex,
   kString,
   kEvent,
   kReal,
@@ -119,8 +120,16 @@ struct QueueType {
 
 struct AssociativeArrayType {
   TypeId element_type;
-  std::optional<TypeId> key_type;
+  TypeId key_type;
 };
+
+// LRM 7.8.1 wildcard index type (`[*]`): the key type of an associative array
+// indexed by any integral value, identified by magnitude regardless of the
+// index expression's width. A parameter-less value type whose C++ realization
+// is `lyra::value::WildcardKey`; it is the key type that selects the
+// magnitude-identified, width-independent ordering instead of the fixed-shape
+// integral or lexicographic-string orderings.
+struct WildcardIndexType {};
 
 struct StringType {};
 struct EventType {};
@@ -321,11 +330,11 @@ struct ExternalRefType {
 
 using TypeData = std::variant<
     PackedArrayType, EnumType, UnpackedArrayType, DynamicArrayType, QueueType,
-    AssociativeArrayType, StringType, EventType, RealType, ShortRealType,
-    RealTimeType, ChandleType, VoidType, ObjectType, ExternalUnitObjectType,
-    ScopeType, ServicesType, FilesType, DiagnosticType, RuntimeLibraryType,
-    CoroutineType, RefType, PointerType, VectorType, TupleType, ExternalRefType,
-    ObservableType>;
+    AssociativeArrayType, WildcardIndexType, StringType, EventType, RealType,
+    ShortRealType, RealTimeType, ChandleType, VoidType, ObjectType,
+    ExternalUnitObjectType, ScopeType, ServicesType, FilesType, DiagnosticType,
+    RuntimeLibraryType, CoroutineType, RefType, PointerType, VectorType,
+    TupleType, ExternalRefType, ObservableType>;
 
 struct Type {
   TypeData data;

--- a/include/lyra/value/associative_array.hpp
+++ b/include/lyra/value/associative_array.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <concepts>
 #include <iterator>
 #include <map>
@@ -43,6 +44,53 @@ struct StringKeyLess {
   }
 };
 
+// LRM 7.8.1 wildcard index `[*]`: the key is an integral value identified by
+// its numerical magnitude, independent of the width the index expression
+// happened to carry -- `8'd5` and `16'd5` are the same key. The index is
+// self-determined and treated as unsigned, so the source is reinterpreted as
+// unsigned on construction (same bits, same width, no sign extension) and keys
+// order by unsigned numerical value across widths. x/z in the source is
+// preserved so the invalid-key check (LRM 7.8.6) can still see it.
+//
+// The conversion from a plain index value is implicit so that every key-taking
+// operation (element access, `exists`, `delete`) accepts the index expression
+// directly, with no caller and no per-call-site wrap to distinguish a wildcard
+// array from a string- or integral-keyed one.
+class WildcardKey {
+ public:
+  WildcardKey(const PackedArray& index)  // NOLINT(google-explicit-constructor)
+      : value_(
+            PackedArray::ConvertFrom(
+                index, index.BitWidth(), false, index.IsFourState())) {
+  }
+
+  [[nodiscard]] auto Value() const -> const PackedArray& {
+    return value_;
+  }
+  [[nodiscard]] auto HasUnknown() const -> bool {
+    return value_.HasUnknown();
+  }
+
+ private:
+  PackedArray value_;
+};
+
+// Orders two wildcard keys by unsigned numerical value. The widths may differ,
+// so both are zero-extended to the wider before the unsigned comparison; the
+// reinterpret-as-unsigned at construction makes the extension zero-fill.
+struct WildcardKeyLess {
+  [[nodiscard]] auto operator()(
+      const WildcardKey& a, const WildcardKey& b) const -> bool {
+    const std::uint64_t width =
+        std::max(a.Value().BitWidth(), b.Value().BitWidth());
+    const PackedArray wide_a =
+        PackedArray::ConvertFrom(a.Value(), width, false, false);
+    const PackedArray wide_b =
+        PackedArray::ConvertFrom(b.Value(), width, false, false);
+    return static_cast<bool>(wide_a < wide_b);
+  }
+};
+
 template <typename K>
 struct AssocKeyTraits;
 
@@ -57,11 +105,27 @@ struct AssocKeyTraits<PackedArray> {
   using Less = PackedArrayKeyLess;
 };
 
+template <>
+struct AssocKeyTraits<WildcardKey> {
+  using Less = WildcardKeyLess;
+};
+
+// A wildcard key formats as its underlying integral value (LRM 21.2.1.6 prints
+// associative entries in key order; the key prints in the element format).
+template <>
+struct Formatter<WildcardKey> {
+  static auto Format(const FormatSpec& spec, const WildcardKey& key)
+      -> std::string {
+    return lyra::value::Format(spec, MakeFormatArg(key.Value()));
+  }
+};
+
 // SystemVerilog associative array (LRM 7.8): a sparse lookup table allocated
 // entry-by-entry. `K` is the index type (`String` for string-indexed arrays,
-// `PackedArray` for integral-indexed arrays) and `V` the element type. Storage
-// is an ordered `std::map` so iteration and `%p` formatting follow the LRM 7.8
-// key ordering and stay deterministic.
+// `PackedArray` for integral-indexed arrays, `WildcardKey` for the wildcard
+// index) and `V` the element type. Storage is an ordered `std::map` so
+// iteration and `%p` formatting follow the LRM 7.8 key ordering and stay
+// deterministic.
 //
 // `element_default_` holds the element-type default -- the LRM Table 7-1
 // value read from a nonexistent array entry. It carries the element's
@@ -440,7 +504,11 @@ class AssociativeArray {
 
  private:
   [[nodiscard]] auto IsInvalidKey(const K& key) const -> bool {
-    if constexpr (std::same_as<K, PackedArray>) {
+    // LRM 7.8.6: a key carrying x/z is invalid. Decided by the key's own x/z
+    // predicate where it has one (an integral or wildcard key reports its
+    // unknown bits; a string's is always false); a key type with no notion of
+    // x/z is always valid.
+    if constexpr (requires { key.HasUnknown(); }) {
       return key.HasUnknown();
     } else {
       return false;

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -92,15 +92,13 @@ auto RenderTypeAsCpp(
                 RenderTypeAsCpp(unit, owner_class, q.element_type));
           },
           [&](const mir::AssociativeArrayType& a) -> std::string {
-            if (!a.key_type.has_value()) {
-              throw InternalError(
-                  "RenderTypeAsCpp: associative array with a wildcard index "
-                  "type reached the backend; AST -> HIR rejects it");
-            }
             return std::format(
                 "lyra::value::AssociativeArray<{}, {}>",
-                RenderTypeAsCpp(unit, owner_class, *a.key_type),
+                RenderTypeAsCpp(unit, owner_class, a.key_type),
                 RenderTypeAsCpp(unit, owner_class, a.element_type));
+          },
+          [](const mir::WildcardIndexType&) -> std::string {
+            return "lyra::value::WildcardKey";
           },
           [](const mir::ObjectType& o) -> std::string { return o.name; },
           [](const mir::ExternalUnitObjectType& e) -> std::string {

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -201,14 +201,12 @@ class HirDumper {
               return std::format("Queue(elem=Type[{}])", q.element_type.value);
             },
             [](const AssociativeArrayType& a) -> std::string {
-              if (a.key_type.has_value()) {
-                return std::format(
-                    "AssociativeArray(elem=Type[{}], key=Type[{}])",
-                    a.element_type.value, a.key_type->value);
-              }
               return std::format(
-                  "AssociativeArray(elem=Type[{}], key=wildcard)",
-                  a.element_type.value);
+                  "AssociativeArray(elem=Type[{}], key=Type[{}])",
+                  a.element_type.value, a.key_type.value);
+            },
+            [](const WildcardIndexType&) -> std::string {
+              return "WildcardIndexType";
             },
             [](const StringType&) -> std::string { return "StringType"; },
             [](const EventType&) -> std::string { return "EventType"; },

--- a/src/lyra/hir/type.cpp
+++ b/src/lyra/hir/type.cpp
@@ -92,6 +92,7 @@ auto Type::Kind() const -> TypeKind {
           [](const AssociativeArrayType&) {
             return TypeKind::kAssociativeArray;
           },
+          [](const WildcardIndexType&) { return TypeKind::kWildcardIndex; },
           [](const StringType&) { return TypeKind::kString; },
           [](const EventType&) { return TypeKind::kEvent; },
           [](const RealType&) { return TypeKind::kReal; },
@@ -151,6 +152,7 @@ auto Type::IsValueChangeObservable() const -> bool {
     case TypeKind::kShortReal:
     case TypeKind::kRealTime:
       return true;
+    case TypeKind::kWildcardIndex:
     case TypeKind::kEvent:
     case TypeKind::kChandle:
     case TypeKind::kVoid:

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -337,20 +337,27 @@ auto TranslateTypeData(
     }
     case slang::ast::SymbolKind::AssociativeArrayType: {
       const auto& aa = canonical.as<slang::ast::AssociativeArrayType>();
-      // LRM 7.8.1 wildcard index (`[*]`) carries no index type and has its own
-      // minimal-length normalization rules; LRM 7.8.3 / 7.8.5 class and other
-      // user-defined indices have their own ordering contracts. Only the string
-      // (LRM 7.8.2) and integral (LRM 7.8.4) index families are in scope.
-      if (aa.indexType == nullptr ||
-          !(aa.indexType->isIntegral() || aa.indexType->isString())) {
-        return diag::Fail(
-            decl_span, diag::DiagCode::kUnsupportedAssociativeArrayType,
-            "associative arrays are only supported with a string or integral "
-            "index type");
-      }
       auto elem_id_or = module.InternType(aa.elementType, decl_span);
       if (!elem_id_or) {
         return std::unexpected(std::move(elem_id_or.error()));
+      }
+      // LRM 7.8.1 wildcard index (`[*]`) declares no index type: the key is any
+      // integral value identified by its magnitude, carried by the dedicated
+      // wildcard-index key type.
+      if (aa.indexType == nullptr) {
+        return hir::TypeData{hir::AssociativeArrayType{
+            .element_type = *elem_id_or,
+            .key_type = module.Unit().builtins.wildcard_index,
+        }};
+      }
+      // A declared index covers string (LRM 7.8.2) and integral, which includes
+      // a packed struct / enum (LRM 7.8.4 / 7.8.5). A class index (LRM 7.8.3)
+      // and a real index are rejected.
+      if (!(aa.indexType->isIntegral() || aa.indexType->isString())) {
+        return diag::Fail(
+            decl_span, diag::DiagCode::kUnsupportedAssociativeArrayType,
+            "associative arrays are only supported with a string, integral, or "
+            "wildcard index type");
       }
       auto key_id_or = module.InternType(*aa.indexType, decl_span);
       if (!key_id_or) {

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -251,12 +251,7 @@ auto BuildAssociativeConstructionCall(
         "BuildAssociativeConstructionCall: result type is not "
         "AssociativeArrayType");
   }
-  if (!assoc->key_type.has_value()) {
-    throw InternalError(
-        "BuildAssociativeConstructionCall: associative array has no key type "
-        "(wildcard index); AST -> HIR rejects it");
-  }
-  const mir::TypeId key_type = *assoc->key_type;
+  const mir::TypeId key_type = assoc->key_type;
   const mir::TypeId element_type = assoc->element_type;
 
   const mir::TypeId tuple_type = module.Unit().AddType(

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -211,8 +211,8 @@ auto BuildArrayMethodClosure(
   mir::TypeId index_type = module.Unit().builtins.int32;
   if (const auto* assoc =
           std::get_if<hir::AssociativeArrayType>(&hir_recv_ty.data);
-      assoc != nullptr && assoc->key_type.has_value()) {
-    index_type = module.TranslateType(*assoc->key_type);
+      assoc != nullptr) {
+    index_type = module.TranslateType(assoc->key_type);
   }
   const std::string iterator_name =
       with_clause != nullptr ? with_clause->element_name : std::string{"item"};

--- a/src/lyra/lowering/hir_to_mir/translate_type.cpp
+++ b/src/lyra/lowering/hir_to_mir/translate_type.cpp
@@ -148,11 +148,11 @@ auto ModuleLowerer::TranslateTypeData(const hir::TypeData& data) const
           [&](const hir::AssociativeArrayType& src) -> mir::TypeData {
             return mir::AssociativeArrayType{
                 .element_type = TranslateType(src.element_type),
-                .key_type = src.key_type.has_value()
-                                ? std::optional<mir::TypeId>{TranslateType(
-                                      *src.key_type)}
-                                : std::nullopt,
+                .key_type = TranslateType(src.key_type),
             };
+          },
+          [](const hir::WildcardIndexType&) -> mir::TypeData {
+            return mir::WildcardIndexType{};
           },
           [](const hir::StringType&) -> mir::TypeData {
             return mir::StringType{};

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -155,14 +155,12 @@ class MirDumper {
               return std::format("Queue(elem=Type[{}])", q.element_type.value);
             },
             [](const AssociativeArrayType& a) -> std::string {
-              if (a.key_type.has_value()) {
-                return std::format(
-                    "AssociativeArray(elem=Type[{}], key=Type[{}])",
-                    a.element_type.value, a.key_type->value);
-              }
               return std::format(
-                  "AssociativeArray(elem=Type[{}], key=wildcard)",
-                  a.element_type.value);
+                  "AssociativeArray(elem=Type[{}], key=Type[{}])",
+                  a.element_type.value, a.key_type.value);
+            },
+            [](const WildcardIndexType&) -> std::string {
+              return "WildcardIndexType";
             },
             [](const StringType&) -> std::string { return "StringType"; },
             [](const EventType&) -> std::string { return "EventType"; },

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -63,6 +63,7 @@ auto Type::Kind() const -> TypeKind {
           [](const AssociativeArrayType&) {
             return TypeKind::kAssociativeArray;
           },
+          [](const WildcardIndexType&) { return TypeKind::kWildcardIndex; },
           [](const StringType&) { return TypeKind::kString; },
           [](const EventType&) { return TypeKind::kEvent; },
           [](const RealType&) { return TypeKind::kReal; },

--- a/tests/cases/cpp/assoc_packed_struct_key/case.yaml
+++ b/tests/cases/cpp/assoc_packed_struct_key/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.assoc_packed_struct_key
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    va: 42
+    vb: 43
+    n: 2
+    ex_present: 1
+    ex_absent: 0

--- a/tests/cases/cpp/assoc_packed_struct_key/main.sv
+++ b/tests/cases/cpp/assoc_packed_struct_key/main.sv
@@ -1,0 +1,31 @@
+module Top;
+  // LRM 7.8.5: a packed struct is an integral index type, so it indexes an
+  // associative array by its bit-pattern value with numerical ordering.
+  typedef struct packed {
+    bit [7:0] hi;
+    bit [7:0] lo;
+  } Pair;
+
+  int by_struct [Pair];
+
+  int va;
+  int vb;
+  int n;
+  int ex_present;
+  int ex_absent;
+
+  initial begin
+    Pair a;
+    Pair b;
+    a = '{hi: 8'd1, lo: 8'd2};
+    b = '{hi: 8'd1, lo: 8'd3};
+    by_struct[a] = 42;
+    by_struct[b] = 43;
+    va = by_struct[a];
+    vb = by_struct[b];
+    n = by_struct.num();
+    ex_present = by_struct.exists(a);
+    by_struct.delete(a);
+    ex_absent = by_struct.exists(a);
+  end
+endmodule

--- a/tests/cases/cpp/assoc_wildcard/case.yaml
+++ b/tests/cases/cpp/assoc_wildcard/case.yaml
@@ -1,0 +1,18 @@
+id: cpp.assoc_wildcard
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    v5: 200
+    n_after_collapse: 1
+    v300: 7
+    n_two: 2
+    ex5: 1
+    ex7: 0
+    v_unsigned: 42
+    n_after_delete: 2

--- a/tests/cases/cpp/assoc_wildcard/main.sv
+++ b/tests/cases/cpp/assoc_wildcard/main.sv
@@ -1,0 +1,39 @@
+module Top;
+  // LRM 7.8.1 wildcard index: any integral expression indexes the array, and
+  // the key is the numerical value independent of the index expression's width.
+  int w [*];
+
+  int v5;
+  int n_after_collapse;
+  int v300;
+  int n_two;
+  int ex5;
+  int ex7;
+  int v_unsigned;
+  int n_after_delete;
+
+  initial begin
+    // Two indices of the same value but different widths name the same entry
+    // (LRM 7.8.1), so the second write overwrites the first.
+    w[8'd5] = 100;
+    w[16'd5] = 200;
+    v5 = w[5];
+    n_after_collapse = w.num();
+
+    // A distinct value is a distinct entry.
+    w[300] = 7;
+    v300 = w[300];
+    n_two = w.num();
+
+    ex5 = w.exists(5);
+    ex7 = w.exists(7);
+
+    // The index is treated as unsigned (LRM 7.8.1): -1 and its unsigned
+    // bit-pattern name the same entry.
+    w[-1] = 42;
+    v_unsigned = w[32'hFFFFFFFF];
+
+    w.delete(5);
+    n_after_delete = w.num();
+  end
+endmodule


### PR DESCRIPTION
## What

Implements the wildcard index family for associative arrays (`int m [*];`, LRM 7.8.1) and confirms packed-struct keys (LRM 7.8.5), completing the in-scope part of the associative index workstream (aggregate A6). The class index (LRM 7.8.3) stays deferred to the class workstream.

## Design

A wildcard array keys on the index's unsigned numerical value independent of the index expression's width, so `m[8'd5]` and `m[16'd5]` name one entry. The distinction from a string- or integral-keyed array is carried entirely in the key type, not as a nullable side-field:

- `WildcardIndexType` is a first-class nullary value type in HIR and MIR (interned once as a unit builtin, like `StringType`).
- `AssociativeArrayType.key_type` becomes a plain `TypeId` everywhere (was `optional<TypeId>`), so every consumer (render, dump, default-value, calls) drops its `has_value()` branch.
- `RenderTypeAsCpp` maps it to `lyra::value::WildcardKey` with no decision in the emit layer.
- Runtime `WildcardKey` reinterprets the index as unsigned and orders keys by unsigned numerical value across widths; `IsInvalidKey` is generalized to any key exposing an x/z predicate.

The frontend already rejects `foreach` / traversal / index-returning methods on a wildcard array (LRM 7.8.1 / 7.12.1), so no Lyra-side rejection is needed.

## Tests

- `assoc_wildcard`: same-value/different-width collapse, distinct values, unsigned treatment of a negative index, `exists` / `num` / `delete`.
- `assoc_packed_struct_key`: a packed struct as an integral key.

## Note

While validating, I found a pre-existing regression from the recent MIR cast-primitive unification: value conversions emit invalid C++ for any non-enum conversion target (integral reshape, string-from-bits/bytes, real/int bridge). It is broad but invisible to CI (the host-C++ run is excluded). It is unrelated to this change and recorded as integral J20 for its owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)