### PR TITLE
Unify callable code and render bodies as static self

### DIFF
--- a/docs/decisions/callable-receiver.md
+++ b/docs/decisions/callable-receiver.md
@@ -51,14 +51,15 @@ shape:
   parameter. Each caller knows its own receiver -- the runtime constructing a process coroutine, a
   call site invoking a method, the C++ constructor running the init body -- and supplies it at
   invocation. The body's binding is filled by the call.
-- **Closure** carries `self` as the first by-value capture (`captures[0]` is a `ByValueCapture`
-  whose `value` is the enclosing scope's read of its own `self` and whose `binding` points at the
-  closure body's `vars[0]`). This holds for every closure form, the fork branch included. No invoker
-  of a closure value -- the NBA / postponed-`$strobe` / deferred-check region runner, the fork
-  scheduler, the with-clause iterator -- can be relied on to know which receiver belongs in the
-  body, because a closure value can outlive the enclosing-scope frame that knows. The enclosing
-  scope snapshots its own `self` into the closure at construction; the body reads the captured
-  value.
+- **Closure** binds `self` -- the code's first parameter (`code.params[0]`, landing at the body's
+  `vars[0]`) -- into its environment, the enclosing scope's read of its own `self` supplying the
+  bound value at construction. `self` is an ordinary environment field, bound like any other
+  captured variable, not a privileged slot (see `unified-callable-model.md`). This holds for every
+  closure form, the fork branch included. No invoker of a closure value -- the NBA /
+  postponed-`$strobe` / deferred-check region runner, the fork scheduler, the with-clause iterator
+  -- can be relied on to know which receiver belongs in the body, because a closure value can
+  outlive the enclosing-scope frame that knows. The enclosing scope snapshots its own `self` into
+  the closure's environment at construction; the body reads the bound value.
 
 This partition is not a stylistic choice -- it follows from "who knows the receiver?". A method-form
 callable has a caller-who-knows; a closure does not. Forcing both forms onto one supply mechanism
@@ -84,13 +85,14 @@ The C++ backend renders each form in its natural idiom:
   realization of the same captures, since a capturing coroutine lambda would dangle; the MIR closure
   still carries `self` and the rest as captures.
 
-The constructor body is the only callable whose corresponding C++ entry cannot be static (the real
-C++ constructor must be an instance constructor for instance creation to work). The constructor body
-lowers to a static `init(M* self)` that the C++ constructor invokes with `init(this)`; the
-constructor itself is the only place where C++'s implicit `this` is used at all, and only as the
-argument to `init`. `CreateProcesses()` (and any other Scope-base virtual override) is C++ plumbing,
-not an SV-derived callable; it remains a virtual instance method, and its body's implicit `this` is
-C++-language-required, not MIR-modeled.
+Every callable body lowers to a static function over the explicit receiver `self`. The callables an
+engine or the C++ language reaches through an instance entry -- the C++ constructor (instance
+creation requires a real constructor), the post-construction lifecycle hooks (`ResolveState` /
+`InitializeState`), and `CreateProcesses` -- keep that uniform static body and add a thin non-static
+shim that forwards to it: the constructor runs `init(this)`, a lifecycle override runs
+`ResolveState(this)`. C++'s implicit `this` appears only in these dispatch shims, as the argument to
+the static body, never inside a body. The shims are C++ plumbing, not SV-derived callables, and are
+not MIR-modeled.
 
 ### Why always include `self`, not derive from "body touches class state"
 
@@ -164,11 +166,12 @@ binding pushes the answer up to one place that every backend just reads.
   `self` binding at `body.vars[0]` whose type is the borrowed-pointer to the enclosing class. The
   binding's name is `self`; the type makes the pointee unambiguous.
 
-- For method-form callables (process, method, constructor body) the `self` binding is the first
-  formal parameter; the caller supplies it at invocation. For a closure -- every closure, the fork
-  branch included -- the `self` binding is the first by-value capture (`captures[0]`); the enclosing
-  scope's read of its own `self` supplies the capture value at construction. Both land at
-  `body.vars[0]`.
+- `self` is the code's first parameter (`code.params[0]`) for every callable, landing at
+  `body.vars[0]`. For method-form callables (process, method, constructor body) the caller supplies
+  it at invocation. For a closure -- every closure, the fork branch included -- the closure value
+  binds it into its environment, the enclosing scope's read of its own `self` supplying the bound
+  value at construction. It is an ordinary environment field, not a privileged slot
+  (`unified-callable-model.md`).
 
 - A new MIR expression `MemberAccessExpr { receiver: ExprId, var: MemberRef-fields }` replaces the
   implicit-receiver member reference. The receiver expression is rendered before the access; the
@@ -180,9 +183,11 @@ binding pushes the answer up to one place that every backend just reads.
   `ServicesRef()`, and `DeferredByValueCapture()` are removed. Receiver-related walker state on
   `RenderContext` is gone.
 
-- C++ emit shape changes: process / method / constructor bodies emit as
-  `static auto <name>(M* self, ...) -> ... { ... }`; the C++ constructor delegates the body to a
-  static `init(this)` call. Closures emit as
+- C++ emit shape changes: every callable body -- process, function / task, constructor, and the
+  resolve / initialize lifecycle hooks -- emits as
+  `static auto <name>(M* self, ...) -> ... { ... }`. An engine-dispatched entry adds a thin
+  non-static shim forwarding to the static body: the C++ constructor runs `init(this)`, a lifecycle
+  override runs `<name>(this)`. Closures emit as
   `[self = <enclosing self expr>, cap1 = ..., cap2 = <reference value>](closure_params) -> R { ... }`
   -- every capture is name-explicit and by-value; an alias capture binds a reference value, never a
   C++ `[&]` reference (see `docs/architecture/callable.md` for why). `CreateProcesses()` adapts:

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -125,7 +125,7 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
         place is bound exactly once at call entry, and the completion slot outlives any write the
         callee can still make. Per `../decisions/unified-callable-model.md`.
 
-  - [ ] R8c -- Callable code versus callable value. A closure constructs a callable value (code plus
+  - [x] R8c -- Callable code versus callable value. A closure constructs a callable value (code plus
         a bound environment); a directly-invoked named callable receives its environment from the
         caller. `self` is the code's first parameter, bound into a value's environment when needed,
         not a privileged `captures[0]` slot.
@@ -139,14 +139,15 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
         against the object's vtable layout.
 
   - [x] R8f -- The scope's callables render through one backend method path. A process body and the
-        synthesized resolve / initialize lifecycle bodies join functions and tasks as one
-        `mir::MethodDecl` carrying a `MethodForm` -- a static function over an explicit `self`, or a
-        virtual instance method that overrides a runtime-base slot and reaches the scope through the
-        implicit receiver. The per-shape backend renderers collapse into one that reads the method's
+        synthesized resolve / initialize lifecycle bodies join functions and tasks as one uniform
+        callable: a static function over the explicit receiver `self`, with no per-shape kind tag.
+        The per-shape backend renderers collapse into one mechanical fold that reads the body's
         fields (result type, name, parameters, body): `void` and the coroutine type are ordinary
         result types, `co_return` is a body statement rather than a render-time epilogue, and the
-        receiver is spelled from the form. `mir::Process` now carries only its activation kind and
-        the body method; the two remaining backend-synthesized remnants -- process activation
+        receiver is always `self`. How a referencing site reaches a body -- a direct call, a process
+        registration, an engine-dispatched lifecycle hook -- is separate dispatch plumbing (a thin
+        virtual shim forwarding to the static body, the pattern the constructor already uses), never
+        a property of the body. The two remaining backend-synthesized remnants -- process activation
         registration and the upward-reference member initializer -- retire under R8d and R40.
 
 - [x] R9 -- AST-to-HIR migration to the class-based organization defined in

--- a/include/lyra/backend/cpp/scope_view.hpp
+++ b/include/lyra/backend/cpp/scope_view.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <string_view>
-
 #include "lyra/base/internal_error.hpp"
 #include "lyra/mir/block_hops.hpp"
 #include "lyra/mir/class.hpp"
@@ -31,30 +29,13 @@ class ScopeView {
   }
 
   [[nodiscard]] auto WithBlock(const mir::Block& child) const -> ScopeView {
-    return ScopeView{*unit_, *class_,       child,
-                     this,   class_parent_, self_spelling_};
+    return ScopeView{*unit_, *class_, child, this, class_parent_};
   }
 
   [[nodiscard]] auto WithClass(
       const mir::Class& child_class, const mir::Block& root_block) const
       -> ScopeView {
-    return ScopeView{*unit_,  child_class, root_block,
-                     nullptr, this,        self_spelling_};
-  }
-
-  // How the receiver `self` (the body's `vars[0]`, MIR invariant 11) is spelled
-  // in C++. A static method receives `self` as its first parameter, so it is
-  // spelled `self`; a virtual instance method takes the receiver implicitly, so
-  // it is spelled `this`. A nested block inherits the enclosing method's
-  // spelling.
-  [[nodiscard]] auto WithSelfSpelling(std::string_view spelling) const
-      -> ScopeView {
-    return ScopeView{*unit_,        *class_,       *block_,
-                     block_parent_, class_parent_, spelling};
-  }
-
-  [[nodiscard]] auto SelfSpelling() const -> std::string_view {
-    return self_spelling_;
+    return ScopeView{*unit_, child_class, root_block, nullptr, this};
   }
 
   ScopeView(const ScopeView&) = delete;
@@ -116,13 +97,12 @@ class ScopeView {
   ScopeView(
       const mir::CompilationUnit& unit, const mir::Class& cls,
       const mir::Block& block, const ScopeView* block_parent,
-      const ScopeView* class_parent, std::string_view self_spelling)
+      const ScopeView* class_parent)
       : unit_(&unit),
         class_(&cls),
         block_(&block),
         block_parent_(block_parent),
-        class_parent_(class_parent),
-        self_spelling_(self_spelling) {
+        class_parent_(class_parent) {
   }
 
   const mir::CompilationUnit* unit_;
@@ -130,7 +110,6 @@ class ScopeView {
   const mir::Block* block_;
   const ScopeView* block_parent_;
   const ScopeView* class_parent_;
-  std::string_view self_spelling_ = "self";
 };
 
 }  // namespace lyra::backend::cpp

--- a/include/lyra/lowering/hir_to_mir/closure_builder.hpp
+++ b/include/lyra/lowering/hir_to_mir/closure_builder.hpp
@@ -20,12 +20,13 @@ class CompilationUnit;
 
 namespace lyra::lowering::hir_to_mir {
 
-// A closure under construction. The constructor opens a fresh body scope
-// with `self` as captures[0] and installs a capture sink, so a read of an
-// enclosing variable while lowering the body through `Frame()` becomes a
-// capture (LRM 6.21). A site that authors the body by hand instead of
-// lowering HIR snapshots specific outer expressions with `CaptureByValue`;
-// the two capture paths coexist, and `self` is always first.
+// A closure under construction. The constructor opens a fresh body scope, makes
+// `self` the code's first parameter (`code.params[0]`), binds it into the
+// environment, and installs a capture sink, so a read of an enclosing variable
+// while lowering the body through `Frame()` becomes an environment binding
+// (LRM 6.21). A site that authors the body by hand instead of lowering HIR
+// snapshots specific outer expressions with `CaptureByValue`; the two binding
+// paths coexist, and `self` is always the first bound parameter.
 //
 // `coroutine` selects a fork-branch body (LRM 9.3.2): its `return`s render
 // as `co_return` and the terminal is `BuildCoroutine`. `by_value_depth` is
@@ -62,8 +63,8 @@ class ClosureBuilder {
   [[nodiscard]] auto Body() -> mir::Block& {
     return body_;
   }
-  // The `self` receiver binding (captures[0]), for a hand-authored body that
-  // builds its own `self` reads.
+  // The `self` receiver binding (`code.params[0]`), for a hand-authored body
+  // that builds its own `self` reads.
   [[nodiscard]] auto SelfBinding() const -> mir::LocalId {
     return self_binding_;
   }
@@ -76,14 +77,14 @@ class ClosureBuilder {
   auto AddParam(std::string_view name, mir::TypeId type) -> mir::LocalId;
 
   // Snapshots an outer-scope expression into the body by value: allocates a
-  // body binding, records a by-value capture of `outer_id`, and returns the
+  // body parameter, binds it to `outer_id` in the environment, and returns the
   // body-side read. An integer literal clones verbatim so the body still sees a
-  // literal (constant-extracting passes depend on that shape) and no capture is
+  // literal (constant-extracting passes depend on that shape) and no binding is
   // made.
   auto CaptureByValue(mir::ExprId outer_id, std::string_view name)
       -> mir::ExprId;
 
-  // Closes the body with `return result`, assembles the captures, and yields
+  // Closes the body with `return result`, assembles the environment, and yields
   // the closure value typed as the result expression. Single-use.
   [[nodiscard]] auto Build(mir::ExprId result) -> mir::Expr;
   // Closes a fork-branch body with `co_return` and yields the coroutine-typed
@@ -102,8 +103,8 @@ class ClosureBuilder {
   mir::LocalId self_binding_{};
   CaptureSink sink_;
   WalkFrame frame_;
-  std::vector<mir::Capture> captures_;
-  std::vector<mir::Parameter> params_;
+  std::vector<mir::EnvBinding> environment_;
+  std::vector<mir::LocalId> invocation_params_;
 };
 
 // Builds the immediately-invoked call of `closure` (the IIFE shape): adds the

--- a/include/lyra/mir/callable_code.hpp
+++ b/include/lyra/mir/callable_code.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <vector>
+
+#include "lyra/mir/local.hpp"
+#include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type_id.hpp"
+
+namespace lyra::mir {
+
+// The code half of a callable: a signature plus an internal body. The
+// signature is `params` (a prefix of `body.vars`, identified by `LocalId`) and
+// `result_type` (the call protocol -- a coroutine type for a time-consuming
+// task or process, a value or void type for a zero-time function -- and the
+// completion payload). `params[0]` is always the receiver `self`; the remaining
+// entries are the call-supplied or environment-bound formals in signature
+// order. A backend looks each parameter's name and type up from `body.vars`.
+//
+// A directly-invoked callable receives every parameter from the caller. A
+// callable value (a closure) binds a prefix of these into its environment and
+// leaves the rest to be supplied per invocation; which parameter is realized as
+// a passed argument versus a captured field is a backend choice, not encoded
+// here.
+struct CallableCode {
+  std::vector<LocalId> params;
+  TypeId result_type;
+  Block body;
+};
+
+}  // namespace lyra::mir

--- a/include/lyra/mir/closure.hpp
+++ b/include/lyra/mir/closure.hpp
@@ -8,65 +8,62 @@
 
 namespace lyra::mir {
 
-struct Block;
+struct CallableCode;
 
-// Binds the body's `binding` var to the value of `value` at closure
-// construction. Snapshot or alias is decided by the binding var's type, not
-// by a separate capture kind: a value-typed binding owns a snapshot; a
-// `RefType` binding aliases an enclosing cell (`value` constructs the
-// reference, LRM 6.21), so the body's reads / writes route through the live
-// cell. The receiver `self` is always `captures[0]`.
-struct Capture {
+// One field of a closure's bound environment: at construction the body's
+// `param` (a parameter of the closure's `code`, identified by `LocalId`) is
+// bound to the value of `value`. Snapshot or alias is decided by the parameter
+// var's type, not by a separate capture kind: a value-typed parameter owns a
+// snapshot; a `RefType` parameter aliases an enclosing cell (`value` constructs
+// the reference, LRM 6.21), so the body's reads / writes route through the live
+// cell. The receiver `self` is the binding for `code.params[0]` -- an ordinary
+// environment field, not a privileged slot.
+struct EnvBinding {
+  LocalId param{};
   ExprId value{};
-  LocalId binding{};
 };
 
-// A per-invocation closure parameter (LRM 7.12.4 with-clause `item` / `index`).
-// `binding` is a local slot in the closure body holding the argument
-// value; body reads go through `LocalRef{binding}`, the same mechanism
-// captures use. A capture is filled once at closure construction; a parameter
-// receives a fresh value on each invocation.
-struct Parameter {
-  LocalId binding{};
-};
-
-// A callable value with captured state, per-invocation parameters, and a
-// block body.
+// A callable value: callable code plus a bound environment. A closure binds a
+// prefix of its `code`'s parameters (`self` followed by any captured locals)
+// into `environment`; the remaining parameters (a with-clause `item` / `index`,
+// LRM 7.12.4) are supplied per invocation by the referencing site.
 //
 // Closures are synthesized exclusively by HIR-to-MIR lowering. No SystemVerilog
-// source construct produces one directly; the capture list, parameter list,
-// and body statements are all compiler-generated.
+// source construct produces one directly; the environment, the code's
+// parameters, and the body statements are all compiler-generated.
 //
 // Invariants enforced by lowering (violations are compiler-bug class):
-//   1. Each capture's binding and each parameter's binding is a
-//      LocalId valid in body.vars and is unique across the union of
-//      the two lists.
-//   2. A capture whose binding is a value type is read-only inside body (a
-//      snapshot). A capture whose binding is a `RefType` may be read and
-//      written -- it aliases the enclosing storage through a `Ref<T>`. A
-//      parameter binding is read-only; the value is supplied per invocation.
-//   3. LocalRef inside body uses hops bounded by body's own scope
+//   1. Each environment binding's `param` is one of `code.params`, each bound
+//      at most once. The bound parameters are a prefix of `code.params`; the
+//      unbound suffix is supplied per invocation.
+//   2. A bound parameter whose type is a value type is read-only inside the
+//      body (a snapshot). A bound parameter whose type is a `RefType` may be
+//      read and written -- it aliases the enclosing storage through a `Ref<T>`.
+//      An unbound (per-invocation) parameter is read-only; the value is
+//      supplied at each call.
+//   3. LocalRef inside the body uses hops bounded by the body's own scope
 //      nesting and does not escape into the enclosing process scope. Outer
-//      local state reaches body only through captures and parameters.
-//   4. The closure's result type is the closure expression's own type; a
-//      coroutine closure (a fork branch, LRM 9.3.2) carries the coroutine type,
-//      a synchronous closure its value-result type. The body is rendered from
-//      its own statements alone -- the render reads none of the body's interior
-//      to discover the signature, and nothing about the closure's use. A
-//      backend realizes the closure from its captures, parameters, result type,
-//      and body: a synchronous closure as a capture-clause lambda, a coroutine
-//      closure as a stateless lambda whose captures pass as frame-copied
-//      parameters (so nothing dangles when the spawned coroutine outlives the
-//      referencing site). How the closure is invoked -- called at a fork site,
-//      submitted as a deferred effect, iterated by a with-clause -- lives at
-//      the referencing site, not on the closure.
+//      local state reaches the body only through the bound environment and the
+//      per-invocation parameters.
+//   4. The value's result type is `code.result_type`, the closure expression's
+//      own type; a coroutine closure (a fork branch, LRM 9.3.2) carries the
+//      coroutine type, a synchronous closure its value-result type. The body is
+//      rendered from its own statements alone -- the render reads none of the
+//      body's interior to discover the signature, and nothing about the
+//      closure's use. A backend realizes the value from its code and
+//      environment: a synchronous closure as a capture-clause lambda whose
+//      captures are the bound parameters, a coroutine closure as a stateless
+//      lambda whose captures pass as frame-copied parameters (so nothing
+//      dangles when the spawned coroutine outlives the referencing site). How
+//      the closure is invoked -- called at a fork site, submitted as a deferred
+//      effect, iterated by a with-clause -- lives at the referencing site, not
+//      on the value.
 //
 // MemberRef inside body may carry hops that reach module-scope storage
 // directly, the same way C++ lambdas may reference globals without capture.
 struct ClosureExpr {
-  std::vector<Capture> captures;
-  std::vector<Parameter> params;
-  std::unique_ptr<Block> body;
+  std::unique_ptr<CallableCode> code;
+  std::vector<EnvBinding> environment;
 
   ClosureExpr();
   ~ClosureExpr();

--- a/include/lyra/mir/method.hpp
+++ b/include/lyra/mir/method.hpp
@@ -1,57 +1,26 @@
 #pragma once
 
-#include <cstdint>
 #include <string>
-#include <vector>
 
-#include "lyra/mir/stmt.hpp"
-#include "lyra/mir/type_id.hpp"
+#include "lyra/mir/callable_code.hpp"
 
 namespace lyra::mir {
 
-// A formal argument of a method. Parameter direction is data flow, carried by
-// the signature, not a side enum: an `input` is a value parameter and a `ref` /
-// `const ref` a `Ref<T>` parameter (the reference value carries the aliasing,
-// LRM 13.5.2). `output` / `inout` are not parameters at all -- they ride the
-// completion payload (`result_type`), so they never appear here. `name` is the
-// local the body reads through; the backend renders it as the C++ parameter of
-// that name.
-struct MethodParam {
-  std::string name;
-  TypeId type;
-};
-
-// How a method binds its receiver and dispatches -- a generic object-oriented
-// distinction (static function versus virtual instance method), not a C++
-// keyword. `kStatic`: the receiver `self` is the method's explicit first
-// parameter and the call is direct; this is every SystemVerilog function, task,
-// and process body. `kVirtual`: `self` is the implicit receiver and the method
-// overrides a runtime-base slot the engine calls polymorphically; this is the
-// synthesized lifecycle bodies (the resolve and initialize phases). The backend
-// reads the form to spell the receiver and the dispatch, never re-derives it.
-enum class MethodForm : std::uint8_t {
-  kStatic,
-  kVirtual,
-};
-
-// The single callable shape MIR carries: a signature plus a body. Every
-// SystemVerilog function and task, every process body, and the synthesized
-// lifecycle bodies are this one concept, distinguished only by `form` (receiver
-// binding) and by how a referencing site uses them. `result_type` carries the
-// call protocol and the completion payload -- a coroutine type for a
-// time-consuming task or a process (LRM 13.3), a value or void type for a
-// zero-time function (LRM 13.4) -- so the backend reads task-versus-function
-// and the output pack from the result type, not a side enum. `params` names
-// which of the body's locals are formals (the rest are interior locals); the
-// receiver `self` is `root_block.vars[0]`, not a formal here. Static-lifetime
-// body locals are realized as members on the enclosing class at HIR -> MIR;
-// they do not appear here.
+// A named, class-level callable: callable code plus a name. Every SystemVerilog
+// function and task, every process body, and the synthesized lifecycle bodies
+// are this one concept, distinguished only by how a referencing site uses them.
+// The signature -- the parameter list (with `self` at `code.params[0]`) and the
+// result type that carries the call protocol and completion payload -- lives in
+// `code`, so the backend reads task-versus-function and the output pack from
+// `code.result_type`, not a side enum. The body is uniform across every
+// callable: a static function over the explicit receiver `self`. How a
+// referencing site reaches the callable -- a direct call, a constructor-time
+// process registration, an engine-dispatched lifecycle hook -- is the
+// referencing site's concern, realized as separate dispatch plumbing, not a
+// property carried on the body.
 struct MethodDecl {
   std::string name;
-  TypeId result_type;
-  std::vector<MethodParam> params;
-  Block root_block;
-  MethodForm form = MethodForm::kStatic;
+  CallableCode code;
 };
 
 }  // namespace lyra::mir

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -3,7 +3,6 @@
 #include <format>
 #include <span>
 #include <string>
-#include <string_view>
 #include <variant>
 #include <vector>
 
@@ -71,7 +70,7 @@ auto CtorParamName(std::size_t index) -> std::string {
 
 auto RenderMethodParam(
     const mir::CompilationUnit& unit, const mir::Class& s,
-    const mir::MethodParam& param) -> std::string {
+    const mir::LocalDecl& param) -> std::string {
   // Every formal is a value parameter: an `input` by value (LRM 13.5.1), a
   // `ref` / `const ref` whose `RefType` already renders as `(const) Ref<T>` so
   // the reference value carries the aliasing (LRM 13.5.2). `output` / `inout`
@@ -79,44 +78,31 @@ auto RenderMethodParam(
   return std::format("{} {}", RenderTypeAsCpp(unit, s, param.type), param.name);
 }
 
-// The one renderer for every method. A method's declaration is rendered from
-// its fields: the result type (whose `void` and coroutine cases are ordinary
-// types, handled in `RenderTypeAsCpp`), the name, the parameters, and the body
-// (a plain statement render, including any `co_return` that is itself a body
-// statement). The `form` decides how the receiver `self` is bound: a `kStatic`
-// method takes it as an explicit first parameter and spells it `self`; a
-// `kVirtual` method takes it implicitly, spells it `this`, and overrides a
-// runtime-base slot.
+// The one renderer for every callable body. A body renders uniformly as a
+// static function over the explicit receiver `self`: the result type (whose
+// `void` and coroutine cases are ordinary types, handled in `RenderTypeAsCpp`),
+// the name, every parameter (`self` is `params[0]`, rendered like any other),
+// and the body (a plain statement render, including any `co_return` that is
+// itself a body statement). How the engine or a call site reaches the body --
+// a direct call, a process registration, a lifecycle shim -- is separate
+// dispatch plumbing, not a property of the body.
 auto RenderMethod(
     const ScopeView* parent_struct_view, const mir::CompilationUnit& unit,
     const mir::Class& s, const mir::MethodDecl& m, std::size_t indent)
     -> std::string {
-  const bool is_static = m.form == mir::MethodForm::kStatic;
-  const ScopeView base_view =
-      (parent_struct_view == nullptr)
-          ? ScopeView::ForRoot(unit, s, m.root_block)
-          : parent_struct_view->WithClass(s, m.root_block);
   const ScopeView body_view =
-      base_view.WithSelfSpelling(is_static ? "self" : "this");
+      (parent_struct_view == nullptr)
+          ? ScopeView::ForRoot(unit, s, m.code.body)
+          : parent_struct_view->WithClass(s, m.code.body);
 
-  std::string ret = RenderTypeAsCpp(unit, s, m.result_type);
+  std::string ret = RenderTypeAsCpp(unit, s, m.code.result_type);
 
-  std::string sig =
-      std::format("{}{}(", is_static ? "static auto " : "auto ", m.name);
-  bool first = true;
-  if (is_static) {
-    sig += std::format("{}* self", s.name);
-    first = false;
-  }
-  for (const auto& param : m.params) {
-    if (!first) sig += ", ";
-    sig += RenderMethodParam(unit, s, param);
-    first = false;
+  std::string sig = std::format("static auto {}(", m.name);
+  for (std::size_t i = 0; i < m.code.params.size(); ++i) {
+    if (i != 0) sig += ", ";
+    sig += RenderMethodParam(unit, s, m.code.body.vars.Get(m.code.params[i]));
   }
   sig += std::format(") -> {}", ret);
-  if (!is_static) {
-    sig += " override";
-  }
 
   std::string out;
   out += std::format("{}{} {{\n", Indent(indent), sig);
@@ -225,16 +211,24 @@ auto RenderScopeAsClass(
 
   out += RenderConstructor(this_anchor, s, base_class, indent + 1);
 
-  // The resolve and initialize phases run after construction; each is a
-  // virtual override the engine dispatches, present only when the scope has
-  // work for that phase. They render through the one method renderer.
+  // The resolve and initialize phases run after construction, present only
+  // when the scope has work for that phase. Each body renders as the uniform
+  // static callable; the engine dispatches it through a thin virtual override
+  // that forwards to the static body over `this`, the same plumbing pattern the
+  // constructor uses for `init`.
+  const auto render_lifecycle = [&](const mir::MethodDecl& m) -> std::string {
+    return RenderMethod(parent_struct_view, unit, s, m, indent + 1) +
+           std::format(
+               "{}void {}() override {{ {}(this); }}\n", Indent(indent + 1),
+               m.name, m.name);
+  };
   if (s.resolve.has_value()) {
     out += "\n";
-    out += RenderMethod(parent_struct_view, unit, s, *s.resolve, indent + 1);
+    out += render_lifecycle(*s.resolve);
   }
   if (s.initialize.has_value()) {
     out += "\n";
-    out += RenderMethod(parent_struct_view, unit, s, *s.initialize, indent + 1);
+    out += render_lifecycle(*s.initialize);
   }
 
   // Child links are registered automatically at construction and walked by the

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -1,5 +1,6 @@
 #include "lyra/backend/cpp/render_expr.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <format>
@@ -168,20 +169,15 @@ auto RenderParamExpr(const ScopeView& view, const mir::ParamRef& r)
         "cpp emit");
   }
   const std::string& name = view.Class().params.Get(r.param).name;
-  return std::format("{}->{}", view.SelfSpelling(), name);
+  return std::format("self->{}", name);
 }
 
 auto LookupLocalName(const ScopeView& view, const mir::LocalRef& ref)
     -> std::string {
-  // The receiver is the body's `vars[0]`, named `self` in MIR (invariant 11).
-  // How it spells in C++ depends on the enclosing method's form: a static
-  // method's first parameter (`self`) or a virtual method's implicit receiver
-  // (`this`).
-  const std::string& name = view.BlockAtHops(ref.hops).vars.Get(ref.var).name;
-  if (name == "self") {
-    return std::string(view.SelfSpelling());
-  }
-  return name;
+  // Every callable body is a static function over the explicit receiver `self`
+  // (its `vars[0]`), so a local reference renders as its own name -- `self`
+  // included, which is just the first parameter's name.
+  return view.BlockAtHops(ref.hops).vars.Get(ref.var).name;
 }
 
 }  // namespace
@@ -907,64 +903,77 @@ auto RenderBindingParamDecl(const ScopeView& view, const mir::LocalDecl& bind)
       bind.name);
 }
 
-// A closure renders from its captures, parameters, result type, and body alone.
-// A synchronous closure is a capture-clause lambda. A coroutine closure (result
-// type `Coroutine`) is a stateless lambda whose captures pass as frame-copied
-// parameters and are supplied by an immediate call -- a capturing coroutine
-// lambda would dangle once the spawned branch outlives the referencing site.
+// A closure renders from its code (parameters, result type, body) and its bound
+// environment alone. A synchronous closure is a capture-clause lambda whose
+// captures are the bound parameters and whose lambda parameters are the unbound
+// (per-invocation) ones. A coroutine closure (result type `Coroutine`) is a
+// stateless lambda whose bound parameters pass as frame-copied lambda
+// parameters supplied by an immediate call -- a capturing coroutine lambda
+// would dangle once the spawned branch outlives the referencing site.
 auto RenderClosureExpr(
     const ScopeView& view, const mir::ClosureExpr& closure,
     mir::TypeId result_type) -> std::string {
-  if (closure.body == nullptr) {
-    throw InternalError("RenderClosureExpr: closure has no body");
+  if (closure.code == nullptr) {
+    throw InternalError("RenderClosureExpr: closure has no code");
   }
+  const mir::CallableCode& code = *closure.code;
 
   const std::string return_clause = std::format(
       " -> {}", RenderTypeAsCpp(view.Unit(), view.Class(), result_type));
 
   const ScopeView body_view =
-      ScopeView::ForRoot(view.Unit(), view.Class(), *closure.body);
+      ScopeView::ForRoot(view.Unit(), view.Class(), code.body);
   const std::string body =
       std::format(" {{\n{}}}", RenderBlockStatements(body_view, 1));
 
+  const auto is_bound = [&](mir::LocalId param) {
+    return std::ranges::any_of(
+        closure.environment,
+        [&](const mir::EnvBinding& b) { return b.param == param; });
+  };
+
   if (std::holds_alternative<mir::CoroutineType>(
           view.Unit().GetType(result_type).data)) {
-    if (!closure.params.empty()) {
-      throw InternalError(
-          "RenderClosureExpr: coroutine closure has parameters");
+    for (const mir::LocalId param : code.params) {
+      if (!is_bound(param)) {
+        throw InternalError(
+            "RenderClosureExpr: coroutine closure has an unbound parameter");
+      }
     }
     std::string params;
     std::string args;
-    for (std::size_t i = 0; i < closure.captures.size(); ++i) {
-      const auto& bind = closure.body->vars.Get(closure.captures[i].binding);
+    for (std::size_t i = 0; i < closure.environment.size(); ++i) {
+      const auto& bind = code.body.vars.Get(closure.environment[i].param);
       if (i != 0) {
         params += ", ";
         args += ", ";
       }
       params += RenderBindingParamDecl(view, bind);
-      args += RenderExpr(view, view.Expr(closure.captures[i].value));
+      args += RenderExpr(view, view.Expr(closure.environment[i].value));
     }
     return std::format("[]({}){}{}({})", params, return_clause, body, args);
   }
 
   // The capture clause never contains `[this]`, `[=]`, or `[&]` -- every entry
-  // is a named by-value binding `name = <value>`; an alias capture's value is a
+  // is a named by-value binding `name = <value>`; an alias binding's value is a
   // reference-construct, so it binds a `Ref<T>` without a hidden C++ reference.
   std::string captures_text;
-  for (std::size_t i = 0; i < closure.captures.size(); ++i) {
+  for (std::size_t i = 0; i < closure.environment.size(); ++i) {
     const std::string& bind_name =
-        closure.body->vars.Get(closure.captures[i].binding).name;
+        code.body.vars.Get(closure.environment[i].param).name;
     if (i != 0) captures_text += ", ";
     captures_text += std::format(
         "{} = {}", bind_name,
-        RenderExpr(view, view.Expr(closure.captures[i].value)));
+        RenderExpr(view, view.Expr(closure.environment[i].value)));
   }
 
   std::string params_text;
-  for (std::size_t i = 0; i < closure.params.size(); ++i) {
-    const auto& bind = closure.body->vars.Get(closure.params[i].binding);
-    if (i != 0) params_text += ", ";
-    params_text += RenderBindingParamDecl(view, bind);
+  bool first_param = true;
+  for (const mir::LocalId param : code.params) {
+    if (is_bound(param)) continue;
+    if (!first_param) params_text += ", ";
+    params_text += RenderBindingParamDecl(view, code.body.vars.Get(param));
+    first_param = false;
   }
 
   return std::format(

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -1094,25 +1094,26 @@ auto ClassLowerer::Run(
 
   mir_class.constructor_block = std::move(ctor_block);
   // The resolve and initialize phases are synthesized callables run by the
-  // engine after construction (LRM 23.3.3.2 / 6.8): each is a virtual override
-  // the runtime base dispatches, present only when the scope has work for that
-  // phase. They reach the scope through the implicit receiver, so `self` is
-  // bound as the body's receiver rather than passed as a parameter.
+  // engine after construction (LRM 23.3.3.2 / 6.8), present only when the scope
+  // has work for that phase. Their bodies are uniform callables over the
+  // explicit `self` (`code.params[0]`); the engine reaches them through a
+  // virtual-dispatch shim the backend emits as separate plumbing, the same way
+  // the constructor delegates to its static body.
   if (!resolve_block.root_stmts.empty()) {
     mir_class.resolve = mir::MethodDecl{
         .name = "ResolveState",
-        .result_type = void_type,
-        .params = {},
-        .root_block = std::move(resolve_block),
-        .form = mir::MethodForm::kVirtual};
+        .code = mir::CallableCode{
+            .params = {resolve_self_id},
+            .result_type = void_type,
+            .body = std::move(resolve_block)}};
   }
   if (!initialize_block.root_stmts.empty()) {
     mir_class.initialize = mir::MethodDecl{
         .name = "InitializeState",
-        .result_type = void_type,
-        .params = {},
-        .root_block = std::move(initialize_block),
-        .form = mir::MethodForm::kVirtual};
+        .code = mir::CallableCode{
+            .params = {init_self_id},
+            .result_type = void_type,
+            .body = std::move(initialize_block)}};
   }
 
   return mir_class;

--- a/src/lyra/lowering/hir_to_mir/closure_builder.cpp
+++ b/src/lyra/lowering/hir_to_mir/closure_builder.cpp
@@ -7,6 +7,7 @@
 
 #include "lyra/lowering/hir_to_mir/capture_sink.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
+#include "lyra/mir/callable_code.hpp"
 #include "lyra/mir/closure.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
@@ -28,8 +29,8 @@ ClosureBuilder::ClosureBuilder(
       body_.vars.Add(mir::LocalDecl{.name = "self", .type = self_pointer_type});
   const mir::ExprId outer_self_read =
       outer_->exprs.Add(MakeSelfRefExpr(enclosing, self_pointer_type));
-  captures_.push_back(
-      mir::Capture{.value = outer_self_read, .binding = self_binding_});
+  environment_.push_back(
+      mir::EnvBinding{.param = self_binding_, .value = outer_self_read});
   frame_ = enclosing.WithBlock(&body_)
                .Deeper()
                .WithCaptureSink(&sink_)
@@ -41,7 +42,7 @@ auto ClosureBuilder::AddParam(std::string_view name, mir::TypeId type)
     -> mir::LocalId {
   const mir::LocalId binding =
       body_.vars.Add(mir::LocalDecl{.name = std::string(name), .type = type});
-  params_.push_back(mir::Parameter{.binding = binding});
+  invocation_params_.push_back(binding);
   return binding;
 }
 
@@ -53,7 +54,7 @@ auto ClosureBuilder::CaptureByValue(mir::ExprId outer_id, std::string_view name)
   }
   const mir::LocalId binding = body_.vars.Add(
       mir::LocalDecl{.name = std::string(name), .type = outer_expr.type});
-  captures_.push_back(mir::Capture{.value = outer_id, .binding = binding});
+  environment_.push_back(mir::EnvBinding{.param = binding, .value = outer_id});
   return body_.exprs.Add(
       mir::Expr{
           .data =
@@ -63,13 +64,25 @@ auto ClosureBuilder::CaptureByValue(mir::ExprId outer_id, std::string_view name)
 
 auto ClosureBuilder::Finish(mir::TypeId result_type) -> mir::Expr {
   for (const CaptureRequest& request : sink_.TakeRequests()) {
-    captures_.push_back(
-        mir::Capture{.value = request.source, .binding = request.binding});
+    environment_.push_back(
+        mir::EnvBinding{.param = request.binding, .value = request.source});
   }
+  // The signature is `self` (always `params[0]`) followed by the per-invocation
+  // parameters. Captured locals are not parameters -- they are the bound
+  // environment, reached as fields, distinct from the call signature.
+  std::vector<mir::LocalId> params;
+  params.reserve(1 + invocation_params_.size());
+  params.push_back(self_binding_);
+  for (const mir::LocalId param : invocation_params_) {
+    params.push_back(param);
+  }
+  auto code = std::make_unique<mir::CallableCode>(mir::CallableCode{
+      .params = std::move(params),
+      .result_type = result_type,
+      .body = std::move(body_)});
   mir::ClosureExpr closure;
-  closure.captures = std::move(captures_);
-  closure.params = std::move(params_);
-  closure.body = std::make_unique<mir::Block>(std::move(body_));
+  closure.code = std::move(code);
+  closure.environment = std::move(environment_);
   return mir::Expr{.data = std::move(closure), .type = result_type};
 }
 

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -84,10 +84,10 @@ auto LowerContinuousAssign(
       .kind = mir::ProcessKind::kInitial,
       .code = mir::MethodDecl{
           .name = std::move(name),
-          .result_type = lowerer.Module().Unit().builtins.coroutine,
-          .params = {},
-          .root_block = std::move(process_block),
-          .form = mir::MethodForm::kStatic}};
+          .code = mir::CallableCode{
+              .params = {self_id},
+              .result_type = lowerer.Module().Unit().builtins.coroutine,
+              .body = std::move(process_block)}}};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -254,10 +254,10 @@ auto LowerStraightLineProcess(ProcessLowerer& process, mir::ProcessKind kind)
       .kind = kind,
       .code = mir::MethodDecl{
           .name = std::string{process.CallableName()},
-          .result_type = process.Module().Unit().builtins.coroutine,
-          .params = {},
-          .root_block = std::move(process_block),
-          .form = mir::MethodForm::kStatic}};
+          .code = mir::CallableCode{
+              .params = {self_id},
+              .result_type = process.Module().Unit().builtins.coroutine,
+              .body = std::move(process_block)}}};
 }
 
 // Wraps the body in a `forever` loop. `implicit_sensitivity`, if present,
@@ -304,10 +304,10 @@ auto LowerForeverProcess(
       .kind = mir::ProcessKind::kInitial,
       .code = mir::MethodDecl{
           .name = std::string{process.CallableName()},
-          .result_type = process.Module().Unit().builtins.coroutine,
-          .params = {},
-          .root_block = std::move(process_block),
-          .form = mir::MethodForm::kStatic}};
+          .code = mir::CallableCode{
+              .params = {self_id},
+              .result_type = process.Module().Unit().builtins.coroutine,
+              .body = std::move(process_block)}}};
 }
 
 }  // namespace
@@ -350,7 +350,7 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
   // live alias); an `inout` is both an input parameter and a payload component.
   // Every formal is a body local at depth 0 so the body's references resolve.
   completion_decl_depth_ = body_frame.block_depth;
-  std::vector<mir::MethodParam> params;
+  std::vector<mir::LocalId> params{self_id};
   for (const auto& param : src.params) {
     const auto& hir_var = src.body.procedural_vars.Get(param.var);
     const mir::TypeId value_type = module_->TranslateType(hir_var.type);
@@ -390,7 +390,7 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
                        .declaration_procedural_depth = body_frame.block_depth,
                        .var = mir_var,
                        .type = type});
-    params.push_back(mir::MethodParam{.name = hir_var.name, .type = type});
+    params.push_back(mir_var);
     if (dir == hir::ParamDirection::kInOut) {
       output_pack_vars_.push_back(mir_var);
       output_pack_types_.push_back(value_type);
@@ -454,10 +454,10 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
 
   return mir::MethodDecl{
       .name = src.name,
-      .result_type = result_type,
-      .params = std::move(params),
-      .root_block = std::move(body_block),
-      .form = mir::MethodForm::kStatic};
+      .code = mir::CallableCode{
+          .params = std::move(params),
+          .result_type = result_type,
+          .body = std::move(body_block)}};
 }
 
 auto ProcessLowerer::BuildReturnPayload(

--- a/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/fork_join.cpp
@@ -42,15 +42,15 @@ auto LowerJoinMode(hir::JoinMode mode) -> mir::JoinMode {
 // for every spawned branch; Lyra does not yet extend a non-persistent (task or
 // fork-branch) activation frame to cover a detached branch, so a branch that
 // aliases one of its locals would dangle once that frame is gone. The alias is
-// a `RefType` capture binding (LRM 6.21); a static / module variable instead
-// reaches the branch through `self` (captures[0], a pointer, never a
-// `RefType`), so persistent storage never matches.
+// a `RefType` environment binding (LRM 6.21); a static / module variable
+// instead reaches the branch through `self` (the receiver binding, a pointer,
+// never a `RefType`), so persistent storage never matches.
 auto AliasesEnclosingAutomatic(
     const mir::CompilationUnit& unit, const mir::Expr& branch) -> bool {
   const auto& closure = std::get<mir::ClosureExpr>(branch.data);
-  for (const mir::Capture& capture : closure.captures) {
+  for (const mir::EnvBinding& binding : closure.environment) {
     const mir::TypeId binding_type =
-        closure.body->vars.Get(capture.binding).type;
+        closure.code->body.vars.Get(binding.param).type;
     if (std::holds_alternative<mir::RefType>(unit.GetType(binding_type).data)) {
       return true;
     }

--- a/src/lyra/mir/closure.cpp
+++ b/src/lyra/mir/closure.cpp
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-#include "lyra/mir/stmt.hpp"
+#include "lyra/mir/callable_code.hpp"
 
 namespace lyra::mir {
 
@@ -12,19 +12,17 @@ ClosureExpr::ClosureExpr(ClosureExpr&&) noexcept = default;
 auto ClosureExpr::operator=(ClosureExpr&&) noexcept -> ClosureExpr& = default;
 
 ClosureExpr::ClosureExpr(const ClosureExpr& other)
-    : captures(other.captures),
-      params(other.params),
-      body(
-          other.body == nullptr ? nullptr
-                                : std::make_unique<Block>(*other.body)) {
+    : code(
+          other.code == nullptr ? nullptr
+                                : std::make_unique<CallableCode>(*other.code)),
+      environment(other.environment) {
 }
 
 auto ClosureExpr::operator=(const ClosureExpr& other) -> ClosureExpr& {
   if (this != &other) {
-    captures = other.captures;
-    params = other.params;
-    body =
-        other.body == nullptr ? nullptr : std::make_unique<Block>(*other.body);
+    code = other.code == nullptr ? nullptr
+                                 : std::make_unique<CallableCode>(*other.code);
+    environment = other.environment;
   }
   return *this;
 }

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -562,8 +562,9 @@ class MirDumper {
             },
             [](const ClosureExpr& cl) -> std::string {
               return std::format(
-                  "ClosureExpr captures={} params={}", cl.captures.size(),
-                  cl.params.size());
+                  "ClosureExpr params={} environment={}",
+                  cl.code == nullptr ? 0 : cl.code->params.size(),
+                  cl.environment.size());
             },
             [](const ConcatExpr& c) -> std::string {
               std::string operands;
@@ -709,30 +710,18 @@ class MirDumper {
     Dedent();
   }
 
-  [[nodiscard]] static auto FormatMethodForm(MethodForm form)
-      -> std::string_view {
-    switch (form) {
-      case MethodForm::kStatic:
-        return "static";
-      case MethodForm::kVirtual:
-        return "virtual";
-    }
-    throw InternalError("FormatMethodForm: unknown mir::MethodForm");
-  }
-
   void DumpMethod(const MethodDecl& d, std::size_t index) {
     Line(
         std::format(
-            "[{}] {} \"{}\" : Type[{}]", index, FormatMethodForm(d.form),
-            d.name, d.result_type.value));
+            "[{}] \"{}\" : Type[{}]", index, d.name, d.code.result_type.value));
     Indent();
-    for (std::size_t i = 0; i < d.params.size(); ++i) {
-      const auto& param = d.params[i];
+    for (std::size_t i = 0; i < d.code.params.size(); ++i) {
+      const auto& param = d.code.body.vars.Get(d.code.params[i]);
       Line(
           std::format(
               "Param[{}] \"{}\" : Type[{}]", i, param.name, param.type.value));
     }
-    DumpBlock(d.root_block);
+    DumpBlock(d.code.body);
     Dedent();
   }
 
@@ -923,50 +912,48 @@ class MirDumper {
   }
 
   void DumpClosureExpr(const ClosureExpr& closure, const Block& enclosing) {
-    if (closure.captures.empty()) {
-      Line("captures: (none)");
-    } else {
-      Line("captures:");
-      Indent();
-      for (std::size_t i = 0; i < closure.captures.size(); ++i) {
-        DumpCapture(i, closure.captures[i], enclosing);
-      }
-      Dedent();
+    if (closure.code == nullptr) {
+      Line("code: <null>");
+      return;
     }
-    if (closure.params.empty()) {
+    const std::vector<LocalId>& params = closure.code->params;
+    if (params.empty()) {
       Line("params: (none)");
     } else {
       Line("params:");
       Indent();
-      for (std::size_t i = 0; i < closure.params.size(); ++i) {
-        Line(
-            std::format(
-                "[{}] Parameter binding=LocalId{{{}}}", i,
-                closure.params[i].binding.value));
+      for (std::size_t i = 0; i < params.size(); ++i) {
+        Line(std::format("[{}] Param LocalId{{{}}}", i, params[i].value));
       }
       Dedent();
     }
-    if (closure.body == nullptr) {
-      Line("body: <null>");
+    if (closure.environment.empty()) {
+      Line("environment: (none)");
     } else {
-      Line("body:");
+      Line("environment:");
       Indent();
-      DumpBlock(*closure.body);
+      for (std::size_t i = 0; i < closure.environment.size(); ++i) {
+        DumpEnvBinding(i, closure.environment[i], enclosing);
+      }
       Dedent();
     }
+    Line("body:");
+    Indent();
+    DumpBlock(closure.code->body);
+    Dedent();
   }
 
-  void DumpCapture(
-      std::size_t index, const Capture& capture, const Block& enclosing) {
+  void DumpEnvBinding(
+      std::size_t index, const EnvBinding& binding, const Block& enclosing) {
     Line(
         std::format(
-            "[{}] Capture value=Expr[{}] binding=LocalId{{{}}}", index,
-            capture.value.value, capture.binding.value));
+            "[{}] EnvBinding param=LocalId{{{}}} value=Expr[{}]", index,
+            binding.param.value, binding.value.value));
     Indent();
     Line(
         std::format(
-            "Expr[{}] {}", capture.value.value,
-            FormatExpr(enclosing, capture.value)));
+            "Expr[{}] {}", binding.value.value,
+            FormatExpr(enclosing, binding.value)));
     Dedent();
   }
 


### PR DESCRIPTION
## Summary

This completes the callable code/value split and makes every callable body render uniformly. `self` becomes the code's first parameter (`code.params[0]`) instead of a privileged `captures[0]` slot, a closure's captures are separated from its call parameters, and `MethodForm` is removed so the backend renders every body as one mechanical fold. The engine-dispatched lifecycle phases are reached through a thin virtual shim rather than a per-form distinction on the body.

## Design

The callable model now has two structural levels: callable code (a signature plus a body) and a callable value (code plus a bound environment). A new `CallableCode` carries the parameter list (with `self` at `params[0]`) and the result type, shared by named methods and closures. A closure's `environment` binds parameters as fields, distinct from the per-invocation call parameters (a with-clause `item` / `index`), so captures and parameters are no longer conflated. Removing `MethodForm` collapses the method renderer into a pure fold -- result type, then every parameter rendered identically (`self` is just `params[0]`), then the body -- and retires the `SelfSpelling` walk state. The constructor's static-body-plus-shim pattern extends to the `resolve` / `initialize` lifecycle hooks: each body is a static function over the explicit `self`, and the engine reaches it through a thin `void Phase() override { Phase(this); }` shim, so implicit `this` survives only in the dispatch plumbing, never in a body.

## Testing

`bazel test //...` passes.
