### PR TITLE
Resolve method-call class from the receiver, not hops

### DIFF
--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -616,6 +616,21 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       (`../decisions/unified-callable-model.md`). No implementation until the object model is
       designed.
 
+- [ ] R48 -- Let an object type name its class directly, so emit resolves the owning class in O(1)
+      instead of searching. A member or method reference names only its class-local id; the class it
+      belongs to is the receiver's class, which the backend recovers by matching the receiver's
+      `ObjectType` against every class reachable from the render position (current class, its nested
+      classes, the enclosing chain) -- a linear search per access. `ObjectType` carries only a name
+      string today; giving it a unit-unique class identity would make the receiver-to-class step a
+      direct lookup and delete the search entirely. **Blocker**: class identity is parent-local --
+      each scope owns its nested classes in its own arena, and a class's self object type is built
+      before the class is appended -- so a unit-wide class id needs a flat unit-level class table or
+      an equivalent identity assigned before layout. Correctness is unaffected (the search is
+      sound); this is an emit-time resolution cleanup that also removes the one remaining place the
+      backend re-derives information the lowering already had. **Trigger**: standalone; pairs
+      naturally with R45's call-shape work, which also moves per-symbol resolution off the reference
+      node.
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/lowering/hir_to_mir/class_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/class_lowerer.hpp
@@ -238,8 +238,7 @@ class ClassLowerer {
       hir::StructuralHops hops, hir::StructuralSubroutineId hir_id) const
       -> mir::MethodRef {
     const mir::MethodId mir_id = LookupStructuralSubroutineAtHops(hops, hir_id);
-    return mir::MethodRef{
-        .hops = mir::EnclosingHops{.value = hops.value}, .method = mir_id};
+    return mir::MethodRef{.method = mir_id};
   }
 
  private:

--- a/include/lyra/lowering/hir_to_mir/self_ref.hpp
+++ b/include/lyra/lowering/hir_to_mir/self_ref.hpp
@@ -22,6 +22,18 @@ namespace lyra::lowering::hir_to_mir {
 auto MakeSelfRefExpr(const WalkFrame& frame, mir::TypeId self_ptr_type)
     -> mir::Expr;
 
+// The receiver object that owns something at `hops` enclosing-class levels up.
+// At hops 0 it is the current body's `self`; above that the thing lives in an
+// enclosing class whose runtime object is this scope's ancestor, reached by
+// navigating up the object tree `hops` times through the runtime
+// `Scope::Parent()` handle and casting to the enclosing class. The cast is
+// sound because the reference is intra-unit -- the unit owns the enclosing
+// class's layout. Shared by a structural member access and a call to a
+// subroutine declared in an enclosing scope.
+auto BuildEnclosingScopeReceiver(
+    const WalkFrame& frame, const mir::CompilationUnit& unit,
+    mir::EnclosingHops hops) -> mir::ExprId;
+
 // Builds a read of a structural var through the current body's `self`:
 // `MemberAccess(self, member)`. The result type is the var's declared MIR
 // storage type, read from the constructed scope at `member.hops` (a wrapper

--- a/include/lyra/mir/method_ref.hpp
+++ b/include/lyra/mir/method_ref.hpp
@@ -3,8 +3,6 @@
 #include <compare>
 #include <cstdint>
 
-#include "lyra/mir/enclosing_hops.hpp"
-
 namespace lyra::mir {
 
 struct MethodId {
@@ -13,8 +11,10 @@ struct MethodId {
   auto operator<=>(const MethodId&) const -> std::strong_ordering = default;
 };
 
+// A method of a class, named by its class-local id. The class a call reaches is
+// determined by the call's receiver (the method belongs to the receiver's
+// class), not carried here -- a reference names the method, not its owner.
 struct MethodRef {
-  EnclosingHops hops = {};
   MethodId method = {};
 };
 

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -362,17 +362,24 @@ auto RenderCalleePart(
   return std::visit(
       Overloaded{
           [&](const mir::MethodRef& ref) -> CalleeRender {
-            if (ref.hops.value != 0) {
-              throw InternalError(
-                  "method call across classes is not yet "
-                  "implemented in cpp emit");
+            // The callee's class is named by the `self` handle threaded as the
+            // first argument: the method belongs to the receiver's class. The
+            // class qualifies the emitted static call, and `self` stays an
+            // ordinary leading argument (no skip).
+            if (call.arguments.empty()) {
+              throw InternalError("MethodRef call expects a receiver argument");
             }
-            const auto& cls = view.EnclosingClassAtHops(
-                mir::EnclosingHops{.value = ref.hops.value});
-            // The first argument is the callee's `self` handle, threaded as
-            // an ordinary argument; no leading skip.
+            const mir::Expr& receiver = view.Expr(call.arguments[0]);
+            const mir::TypeId object_type =
+                std::get<mir::PointerType>(
+                    view.Unit().GetType(receiver.type).data)
+                    .pointee;
+            const auto& cls = view.ClassByObjectType(object_type);
             return {
-                .expr = std::string(cls.methods.Get(ref.method).name),
+                .expr = std::format(
+                    "{}::{}",
+                    RenderTypeAsCpp(view.Unit(), view.Class(), object_type),
+                    cls.methods.Get(ref.method).name),
                 .leading_arg_count = 0};
           },
           [&](const mir::BuiltinFnCallee& b) -> CalleeRender {

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -676,7 +676,7 @@ void AppendProcessRegistration(
       mir::Expr{
           .data =
               mir::CallExpr{
-                  .callee = mir::MethodRef{.hops = {}, .method = body},
+                  .callee = mir::MethodRef{.method = body},
                   .arguments = {body_self}},
           .type = module.Unit().builtins.coroutine});
   const mir::ExprId reg_self =

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -31,6 +31,7 @@
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/block_hops.hpp"
 #include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/enclosing_hops.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/type.hpp"
 #include "lyra/support/builtin_fn.hpp"
@@ -337,8 +338,13 @@ auto LowerStructuralSubroutineCall(
   }
   std::vector<mir::ExprId> args;
   args.reserve(c.arguments.size() + 1);
-  args.push_back(block.exprs.Add(
-      MakeSelfRefExpr(frame, frame.current_class->self_pointer_type)));
+  // The callee is reached through the object that owns it: at hops 0 the
+  // current body's `self`, above that an enclosing scope's object navigated
+  // through `Parent()`. The same receiver path a structural member access
+  // takes, so the callee's class is named by this receiver's type.
+  args.push_back(BuildEnclosingScopeReceiver(
+      frame, lowerer.Module().Unit(),
+      mir::EnclosingHops{.value = usr.hops.value}));
   for (std::size_t i = 0; i < c.arguments.size(); ++i) {
     if (!c.arguments[i].has_value()) {
       throw InternalError("user-function call argument unexpectedly elided");

--- a/src/lyra/lowering/hir_to_mir/self_ref.cpp
+++ b/src/lyra/lowering/hir_to_mir/self_ref.cpp
@@ -19,13 +19,6 @@ auto MakeSelfRefExpr(const WalkFrame& frame, mir::TypeId self_ptr_type)
       self_ptr_type);
 }
 
-// The receiver object that owns a member at `hops` enclosing-class levels up.
-// At hops 0 it is the current body's `self`. Above that, the member lives in an
-// enclosing class whose runtime object is this scope's ancestor: navigate up
-// the object tree `hops` times through the runtime `Scope::Parent()` handle and
-// cast the result to the enclosing class. The cast is sound because the
-// reference is intra-unit -- the unit owns the enclosing class's layout, so the
-// ancestor's concrete type is known at compile time.
 auto BuildEnclosingScopeReceiver(
     const WalkFrame& frame, const mir::CompilationUnit& unit,
     mir::EnclosingHops hops) -> mir::ExprId {

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -377,15 +377,11 @@ class MirDumper {
     throw InternalError("MirDumper: unknown BinaryOp");
   }
 
-  [[nodiscard]] auto FormatCallee(const Callee& callee) const -> std::string {
+  [[nodiscard]] static auto FormatCallee(const Callee& callee) -> std::string {
     return std::visit(
         Overloaded{
-            [this](const MethodRef& r) -> std::string {
-              const auto& owner = ResolveScopeAtHops(r.hops.value);
-              const auto& target = owner.methods.Get(r.method);
-              return std::format(
-                  "MethodRef[hops={}, method={}] \"{}\"", r.hops.value,
-                  r.method.value, target.name);
+            [](const MethodRef& r) -> std::string {
+              return std::format("MethodRef[method={}]", r.method.value);
             },
             [](const ClosureRef& cr) -> std::string {
               return std::format(
@@ -543,7 +539,7 @@ class MirDumper {
               return std::format(
                   "IncDecExpr op={} target=Expr[{}]", op_str, inc.target.value);
             },
-            [this](const CallExpr& c) -> std::string {
+            [](const CallExpr& c) -> std::string {
               std::string args;
               for (std::size_t i = 0; i < c.arguments.size(); ++i) {
                 if (i != 0) {

--- a/tests/cases/cpp/call_enclosing_scope_subroutine/case.yaml
+++ b/tests/cases/cpp/call_enclosing_scope_subroutine/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.call_enclosing_scope_subroutine
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Test
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      r=42

--- a/tests/cases/cpp/call_enclosing_scope_subroutine/main.sv
+++ b/tests/cases/cpp/call_enclosing_scope_subroutine/main.sv
@@ -1,0 +1,13 @@
+module Test;
+  function automatic int add(int a, int b);
+    return a + b;
+  endfunction
+
+  if (1) begin : g
+    initial begin
+      int r;
+      r = add(40, 2);
+      $display("r=%0d", r);
+    end
+  end
+endmodule


### PR DESCRIPTION
## Summary

`mir::MethodRef` carried an `EnclosingHops` field that duplicated information the call's receiver already encodes. `MemberRef` was cleaned up to resolve its owning class from the receiver's object type; this brings `MethodRef` to the same shape. The reference now names only the class-local method id, and the backend recovers the owning class from the `self` handle threaded as the call's first argument -- so method access and member access share one receiver-to-class resolution path.

To make the receiver actually name the right class, a structural-subroutine call now builds its receiver through the same enclosing-scope navigation a structural member access uses: at hops 0 the current `self`, above that the enclosing scope's object reached through `Parent()`. The emit renders a qualified `Class::method` static call resolved from the receiver's object type.

This also fixes a latent gap: calling a subroutine declared in an enclosing scope (for example, an `initial` inside a generate block calling a module-level function) previously navigated to the wrong receiver and hit a `method call across classes is not yet implemented` throw in the C++ backend. It now emits correctly, e.g. `Test::f(static_cast<Test*>(self->Parent()))`. The cross-class throw is deleted.

## Testing

Added `cpp.call_enclosing_scope_subroutine`, exercising a generate-scope `initial` that calls an enclosing module function with arguments. No existing case crossed a scope boundary on a call (all were same-scope, hops 0), so this path was previously unexercised -- the throw plus a green suite confirmed the gap. `bazel test //...` passes.

The O(1) follow-on -- letting an object type name its class directly so the backend stops searching the scope chain to resolve the owning class -- is registered as R48 in the refactor queue; it depends on a unit-level class identity model and is out of scope here.