### PR TITLE
Decouple permanent docs from the progress queue

### DIFF
--- a/docs/decisions/address-of-primitive.md
+++ b/docs/decisions/address-of-primitive.md
@@ -130,5 +130,3 @@ structural fact explicit.
   implicit render to explicit MIR `CallExpr` -- same family of fix on a different axis).
 - `decisions/callable-receiver.md` (the "C++ plumbing, not MIR-modeled" precedent for virtual
   overrides, sharpened above).
-- `progress/refactor.md` R41 / R42 (the entries this decision closes by lowering the
-  sensitivity-leaf and signal-registration paths to MIR-explicit shape).

--- a/docs/decisions/builtin-call-identity.md
+++ b/docs/decisions/builtin-call-identity.md
@@ -219,4 +219,3 @@ applicable. No render-side special case for any entry.
 - `decisions/array-method-dispatch.md` (LRM 7.12 array runtime semantics; its earlier per-family
   dispatch shape is superseded here).
 - `decisions/callable-receiver.md` (`self`; the receiver mechanics this decision keeps unchanged).
-- `progress/refactor.md` R29 (tracking entry for the work that lands this shape).

--- a/docs/decisions/callable-receiver.md
+++ b/docs/decisions/callable-receiver.md
@@ -221,4 +221,3 @@ binding pushes the answer up to one place that every backend just reads.
 - `docs/architecture/callable.md` (closure model: capture, references as a field type,
   coroutine-ness)
 - `docs/architecture/mir.md` (callable shape, expression set)
-- `docs/progress/refactor.md` R16

--- a/docs/decisions/conversion-folding.md
+++ b/docs/decisions/conversion-folding.md
@@ -70,4 +70,3 @@ living in the render layer. Removing it, not relocating it, is the fix.
 
 - `architecture/mir.md` invariant 10 (a backend never re-derives a stated fact) and Notes (MIR is
   primitives shaped for the downstream optimizer to fold).
-- `progress/refactor.md` R7.

--- a/docs/decisions/format-dispatch.md
+++ b/docs/decisions/format-dispatch.md
@@ -147,7 +147,5 @@ Decisions about the OUTPUT shape, independent of dispatch:
 
 ## Cross-references
 
-- `progress/display.md` DI7
-- `progress/aggregate.md` DA4
 - `decisions/unpacked-array-representation.md`
 - `decisions/runtime-shape-and-default-value.md`

--- a/docs/decisions/generic-lowering-machinery.md
+++ b/docs/decisions/generic-lowering-machinery.md
@@ -97,5 +97,3 @@ Make the machinery generic; keep the nodes typed.
   enclosing callable is forbidden).
 - `architecture/lowering_organization.md` (the pass / dispatcher / handler / walk-frame shape this
   refines).
-- `progress/generic-lowering.md` (the staged migration).
-- `progress/refactor.md` R34 (the AST-to-HIR drift-bug slice).

--- a/docs/decisions/hierarchical-reference-resolution.md
+++ b/docs/decisions/hierarchical-reference-resolution.md
@@ -81,7 +81,7 @@ does not depend on. So the referrer holds a wrapper-typed member and the runtime
   generate scope -- resolves at compile time as a typed member access plus a compile-time offset.
   The code currently lowers such a reference through the cross-unit by-name path instead. Closing
   that gap needs a MIR member-access form that descends into an owned child object's member; it is
-  tracked in `refactor.md`, not decided here.
+  tracked separately, not decided here.
 - **A reference whose head is a named procedural block** has no constructed scope to anchor on (its
   locals live on the enclosing unit), so it is not expressible in this model without first giving
   such blocks a navigable scope.

--- a/docs/decisions/lifetime-extended-automatic-scope.md
+++ b/docs/decisions/lifetime-extended-automatic-scope.md
@@ -152,4 +152,3 @@ but no broad "every runtime object is shared" facility is built ahead of a secon
 - `architecture/scheduling.md` -- closure capture lifetime: a lowering capturing a procedural lvalue
   must establish the fire-before-frame-dies guarantee or refuse; this decision is the "establish the
   guarantee" path for the detached-branch case.
-- `progress/fork-join.md` -- FJ4 and the by-reference-capture lifetime cases.

--- a/docs/decisions/lowering-organization.md
+++ b/docs/decisions/lowering-organization.md
@@ -6,10 +6,9 @@ Date: 2026-06-08 Status: accepted (rendering classification revised 2026-06-19 -
 
 The lowering layer carried god-objects -- `ProcessLoweringState`, `UnitLoweringState`,
 `StructuralScopeLoweringState`, `ProceduralScopeLoweringState` -- each mixing several categories of
-state. R9 and R10 in `docs/progress/refactor.md` identified the smell: `const ProcessLoweringState&`
-qualifiers compensating for a misleading `*State` name; helper signatures threading four references
-where typically one is the real input; ambient mutable state on objects whose names claimed to be
-const-friendly.
+state. The smell was concrete: `const ProcessLoweringState&` qualifiers compensating for a
+misleading `*State` name; helper signatures threading four references where typically one is the
+real input; ambient mutable state on objects whose names claimed to be const-friendly.
 
 Successive closure-shaped features (NBA submit, fork-join branch, scan IIFE, with-clause plus
 iterator index) each added a new ambient field to `ProcessLoweringState` and a parallel install /
@@ -160,8 +159,8 @@ share only the pattern shape.
   registries, and walk-frame fields are layer-specific. Nested builders are never class members at
   any layer; the root output is always a class member.
 
-- The R9 and R10 entries in `refactor.md` close at the target-shape level. Their implementation PRs
-  remain open until the migration lands across all three passes.
+- This decision fixes the target shape; adopting it across all three passes is incremental
+  implementation work.
 
 ## Follow-up Decision: Multi-File Organization Within an Expression / Statement Layer
 

--- a/docs/decisions/reference-as-data-type.md
+++ b/docs/decisions/reference-as-data-type.md
@@ -14,8 +14,7 @@ A SystemVerilog `ref` formal argument (LRM 13.5.2) and a `ref` port (LRM 23.3.3.
 owned somewhere else: reading the alias reads that storage, writing it writes that storage, and the
 alias holds no storage of its own. This record fixes which layer a reference lives in, why it is a
 data type and not a borrowed pointer, and that the two SystemVerilog constructs share one
-representation. It binds the `ref`-port work (`docs/progress/hierarchy.md` E7) and the existing
-pass-by-reference formal lowering.
+representation. It binds the `ref`-port work and the existing pass-by-reference formal lowering.
 
 ## Findings that shaped the design
 

--- a/docs/decisions/runtime-effects-as-generic-calls.md
+++ b/docs/decisions/runtime-effects-as-generic-calls.md
@@ -90,5 +90,3 @@ the argument vector.
   item still uses at execution time).
 - `decisions/callable-receiver.md` (`self` binding; `self.Services()` reaches the engine through
   it).
-- `progress/refactor.md` R20 (tracks which runtime-effect families have moved onto this shape and
-  which remain).

--- a/docs/decisions/runtime-shape-and-default-value.md
+++ b/docs/decisions/runtime-shape-and-default-value.md
@@ -163,4 +163,3 @@ _Rejected alternatives:_
   `ResetToDefault`.
 - `include/lyra/value/dynamic_array.hpp`, `include/lyra/value/unpacked_array.hpp` -- first wrappers
   to adopt the default / sink pattern.
-- `docs/progress/aggregate.md` -- variable-size aggregate workstream.

--- a/docs/decisions/specialization-identity.md
+++ b/docs/decisions/specialization-identity.md
@@ -15,8 +15,7 @@ each behave according to their own parameters. Today a compiled unit's identity 
 name, so two specializations of one module (e.g. `Reg #(.INIT(3))` and `Reg #(.INIT(7))`) carry the
 same name; emitting more than one collapses them and the last one wins. This record fixes how a
 specialization is identified, named, and reached across the unit boundary. It binds every
-parameterized instantiation and constrains the deferred specialization-dedup optimization
-(`docs/progress/performance.md`).
+parameterized instantiation and constrains the deferred specialization-dedup optimization.
 
 ## Findings that shaped the design
 
@@ -73,11 +72,10 @@ Rust cannot.
    or enumeration order (`specialization_model.md` inv 6).
 
 3. **The serializer is subset-agnostic; which bindings feed it is policy.** Functional
-   specialization (the current requirement, `docs/progress/hierarchy.md` Stage A) feeds all
-   parameters. The deferred dedup optimization (`docs/progress/performance.md`) feeds only
-   code-shape-affecting bindings and demotes value-only parameters to constructor inputs resolved at
-   construction. The identity mechanism does not change across that shift; only the input subset
-   does.
+   specialization (the current requirement) feeds all parameters. The deferred dedup optimization
+   feeds only code-shape-affecting bindings and demotes value-only parameters to constructor inputs
+   resolved at construction. The identity mechanism does not change across that shift; only the
+   input subset does.
 
 4. **The identity is computed at AST-to-HIR and carried by name thereafter.** HIR owns identity and
    frontend ids end there (`hir.md`); the cross-unit reference and the construct carry the name, and

--- a/docs/decisions/unified-callable-model.md
+++ b/docs/decisions/unified-callable-model.md
@@ -1,7 +1,6 @@
 # Unified callable model
 
-Date: 2026-06-24 Status: accepted as the target model; not yet implemented (gap tracked in
-`../progress/refactor.md` R8 and the object-model entry).
+Date: 2026-06-24 Status: accepted as the target model; not yet implemented.
 
 ## Context
 
@@ -242,8 +241,7 @@ object identity, reference-lifetime policy). The likely factoring is an `ObjectT
 methods, and a dispatch/virtual layout where applicable) shared by both, plus a separate
 module-specific instance/elaboration plan -- "a module is an object type plus an instance plan," not
 "an SV class is a module in another mode" -- so that module construction policy does not contaminate
-heap classes. Designing this is a separate effort tracked in `../progress/refactor.md`; the callable
-model rides on its result.
+heap classes. Designing this is a separate effort; the callable model rides on its result.
 
 ## Rejected alternatives
 
@@ -291,4 +289,3 @@ model rides on its result.
   receiver to a uniform code-level parameter.
 - `decisions/address-of-primitive.md` -- MIR's place model (the reference class is Rust MIR / LLVM
   IR), which supports reference-typed `ref` parameters.
-- `progress/refactor.md` -- R8 (the implementation gap) and the object-model design entry.

--- a/docs/decisions/unpacked-array-representation.md
+++ b/docs/decisions/unpacked-array-representation.md
@@ -205,7 +205,7 @@ Out of scope but unblocked by this design:
   `std::vector` storage spine and extend it with size-mutation semantics.
 - Whole-array `Var<UnpackedArray<T>>` wrapping is in place and an unpacked signal reacts under
   `wait` / `always_comb` / `@*` (the wrapper's `IsBitIdentical` drives any-change detection); a
-  non-integral input port is admitted too. See `refactor.md` R2.
+  non-integral input port is admitted too.
 
 ## Alternatives considered
 

--- a/docs/decisions/value-type-concepts.md
+++ b/docs/decisions/value-type-concepts.md
@@ -33,7 +33,7 @@ The entanglement surfaces as two visible smells:
   is "is this storage a module-level cell", not "is its value type integral" -- and it leaks because
   the value-type layer never declared which types are eligible for observable wrapping.
 
-`refactor.md` R12 plans to lift the observable wrapping into MIR's type system as a first-class
+A planned refactor will lift the observable wrapping into MIR's type system as a first-class
 `ObservableType`. That cleanup is blocked on a clean answer to "which value types are eligible to be
 wrapped". The answer cannot be a predicate the backend recomputes -- it must be a contract the value
 types declare and the type system enforces.

--- a/docs/decisions/variable-initialization.md
+++ b/docs/decisions/variable-initialization.md
@@ -194,4 +194,3 @@ pointers). The filter is structural: any var whose MIR type is in the set
 - LRM 10.6.1 -- Variable declaration assignment shape preservation
 - `docs/architecture/mir.md` -- invariant 11 (`self` binding); Forbidden Shapes
 - `docs/decisions/callable-receiver.md` -- explicit `self` first binding
-- `docs/progress/refactor.md` -- R19

--- a/docs/decisions/variable-lifetime-storage.md
+++ b/docs/decisions/variable-lifetime-storage.md
@@ -20,7 +20,8 @@ Two forces made the storage of static locals a real decision:
    branch is a separate coroutine that may run after the parent `initial` has returned. For it to
    observe the local (LRM 9.3.2 reads the enclosing loop variable's final value after the loop), the
    local's storage must outlive the parent's activation -- i.e. it must be genuinely static, not a
-   parent-frame local. This is the case that forced the issue (`fork-join.md` FJ4).
+   parent-frame local. This is the case that forced the issue (a detached fork branch capturing a
+   parent loop variable).
 2. **The frontend resolves a bare declaration (`int x = 0;`, no keyword) to static lifetime** and
    only warns (it does not reject). So static-lifetime body locals are pervasive, not rare, and they
    reach lowering already classified as static.
@@ -100,14 +101,7 @@ is out.
   still live in the postponed region; it is not snapshotted at the call. A later same-timestep write
   is therefore observed.
 - **The emitted static local is not in place.** It appears as a per-instance member with an id
-  suffix, away from its source position. This is inherent to per-instance static storage and is
-  recorded as out of scope in `emit-readability.md`.
+  suffix, away from its source position. This is inherent to per-instance static storage and is out
+  of scope here.
 - **An automatic local in a trace task (`$strobe` / `$monitor`) is rejected**, since it is not live
   in the postponed region.
-
-## Cross-references
-
-- `progress/processes.md` P15
-- `progress/functions.md` F3
-- `progress/fork-join.md` FJ4
-- `progress/emit-readability.md`

--- a/docs/progress/README.md
+++ b/docs/progress/README.md
@@ -42,5 +42,7 @@ nothing more -- never a rewrite into a past-tense account of what landed. The re
 recorded in the code and the decision doc; that the work happened is recorded in git.
 
 When the last item lands, the file is deleted, and any cross-reference to it from another progress
-file is updated in the same change so no dangling pointer remains. The git history is the record
-that the work happened.
+file is updated in the same change so no dangling pointer remains. Only another progress file can
+hold such a pointer: architecture, decision, and glossary docs are forbidden from referencing a
+progress file (see `../style.md`), so deletion never strands a permanent doc. The git history is the
+record that the work happened.

--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -30,7 +30,6 @@ follow once dynamic array's storage and runtime conventions are settled and prov
 | DA6b | Done: `with` clause + iterator on sort / rsort / reduction methods.     |
 | DA6c | Done: locator family (find\*, min, max, unique\*).                      |
 | DA6d | Done: `map` projection (LRM 7.12.5) on the sequence containers.         |
-| DA6e | Open: `shuffle` (LRM 7.12.2); needs a seeded simulation RNG.            |
 | DA6f | Done: two-name iterator / index argument form (LRM 7.12.4).             |
 | DA6g | Done: `string` / `real` / `shortreal` as an unpacked-array element.     |
 | DA7  | Done: invalid-index handling.                                           |
@@ -115,19 +114,14 @@ The numeric IDs are stable references and do not imply execution order beyond DA
 
 - [x] DA6c -- The locator-family methods that return an index or element queue (`find` family,
       `min`, `max`, `unique`, `unique_index`), including the optional `with` clause for `min` /
-      `max` / `unique`. `shuffle()` (needs an RNG model) remains the standalone follow-up.
+      `max` / `unique`. `shuffle()` consumes a simulation RNG and is tracked under
+      `simulation-rng.md`.
 
 - [x] DA6d -- The `map()` projection (LRM 7.12.5) with its mandatory `with` clause. Each element and
       its index pass through the expression into a result whose shape and index type match the
       receiver (dynamic array, queue, or fixed unpacked) and whose element type is the expression's
       self-determined type, so it may differ from the source (e.g. `int` to `bit`, `string`, or
       `real`). An empty receiver yields an empty result.
-
-- [ ] DA6e -- `shuffle()` (LRM 7.12.2) on every unpacked container. Needs a seeded simulation RNG;
-      none exists yet (`$random` / `$urandom` are unimplemented), and that same RNG is the
-      foundation for those system functions. `shuffle` is the first array method that consumes
-      simulation state rather than being a pure function of its receiver, so it also introduces
-      threading that state into an array-method call.
 
 - [x] DA6f -- The two-name iterator / index argument form of the LRM 7.12 family
       (`a.method(item, idx) with (...)`, LRM 7.12.4), which renames the iterator and the index-query
@@ -183,7 +177,7 @@ optional right bound (`q[$:N]`).
       7.12.4). Locator methods return a queue of elements or of `int` per LRM 7.12.1; reduction
       result width follows the `with`-expression type. The semantics and the `with`-clause closure
       are the same as for the dynamic-array receiver. The `map` projection (LRM 7.12.5) is shared
-      and done on a queue receiver too; `shuffle` remains the shared follow-up noted under DA6c.
+      and done on a queue receiver too; `shuffle` is tracked under `simulation-rng.md`.
 
 ## Associative Array
 

--- a/docs/progress/simulation-rng.md
+++ b/docs/progress/simulation-rng.md
@@ -1,0 +1,39 @@
+# Simulation RNG
+
+Tracks the seeded simulation random number generator and the language features built directly on it.
+None of these exist yet: the RNG is the shared foundation, and each consumer below is blocked until
+it lands. Constraint-based randomization is a separate, larger workstream (see Out of Scope).
+
+Done when:
+
+- A seeded, reproducible simulation RNG exists, with the per-thread / per-object stability and
+  hierarchical seeding the LRM requires (LRM 18.14), reachable from the call sites that consume it.
+- The system functions and the array method below reproduce their LRM-defined behavior on it.
+
+## Sub-Steps
+
+- [ ] RNG core. A seeded, reproducible random number generator with the random-stability model of
+      LRM 18.14: an initialization RNG per module / instance, an independent per-thread and
+      per-object RNG, and hierarchical seeding (a new thread or object draws its seed from its
+      parent). Manual seeding and state save / restore through `srandom` / `get_randstate` /
+      `set_randstate` (LRM 18.13.3 -- 18.13.5). This is the first state an array method or system
+      function consumes that is not a pure function of its arguments, so it also establishes how
+      that state threads into those call sites.
+
+- [ ] The random number system functions: `$urandom` and `$urandom_range` (LRM 18.13.1 -- 18.13.2),
+      plus the legacy signed `$random`. Each draws from the RNG core and observes its thread /
+      object stability.
+
+- [ ] `shuffle()` (LRM 7.12.2) on every unpacked container (dynamic array, queue, fixed unpacked).
+      The array-manipulation method family is otherwise complete (see `aggregate.md`); `shuffle` is
+      the one member held back here because it permutes its receiver using the RNG rather than being
+      a pure function of it.
+
+## Out of Scope
+
+- Constraint-based randomization: `rand` / `randc` class members, `constraint` blocks, the
+  `randomize()` method, and `std::randomize()` (LRM 18, excluding the random-number functions
+  above). This needs a constraint solver and is gated on the object model; it is a separate
+  workstream.
+- The `randcase` (LRM 18.16) and `randsequence` statements. They consume the RNG but are
+  procedural-control / grammar features, tracked with control flow when picked up.

--- a/docs/style.md
+++ b/docs/style.md
@@ -63,15 +63,19 @@ reason and any rejected alternative that is non-obvious.
 ## Architecture vs Other Docs
 
 Architecture docs under `architecture/` are the source of truth for the system's target shape. The
-dependency between doc kinds is strictly one-way:
+dependency between doc kinds is strictly one-way, from permanent to ephemeral:
 
 - `architecture/` defines the system.
-- `decisions/` records dated decisions with rationale. Entries may reference architecture docs.
+- `decisions/` records dated decisions with rationale. Entries may reference architecture docs and
+  other decisions.
 - `glossary/` defines terminology used by architecture docs.
-- Any future working docs reference architecture, never the other way around.
+- `progress/` tracks the delta between current code and the target. It is the most downstream doc
+  kind: it may reference architecture and decisions, never the reverse.
 
-An architecture doc that cites a decision, a queue, or a working doc is a violation of this rule.
-Architecture is upstream of everything else in `docs/`.
+An architecture doc that cites a decision, a queue, or a working doc is a violation of this rule. A
+decision or glossary doc that cites a `progress/` file is the same violation: a permanent doc must
+not depend on an ephemeral queue. Because nothing permanent points at `progress/`, a completed
+progress file can be deleted with no dangling pointer left behind.
 
 ## Editing Discipline
 


### PR DESCRIPTION
## Summary

Establishes a one-way dependency rule for the docs taxonomy: the permanent docs (`architecture/`, `decisions/`, `glossary/`) must never reference a `progress/` file. `progress/` is the most downstream, ephemeral kind, deleted when its work lands; because nothing permanent points at it, a completed progress file can be removed with no dangling pointer. This is the missing half of the rule already stated in `docs/style.md` for `architecture/`, now extended to cover decisions and glossary, with the consequence (safe deletion) made explicit. The convention also lands in the personal `CLAUDE.local.md` (outside this repo).

The audit found 21 reverse references across 18 decision docs (Cross-references footers, inline parentheticals, and bare-name pointers). All are removed: each now states the permanent fact directly (e.g. "not yet implemented" rather than "tracked in refactor.md R8") instead of pointing at an ephemeral tracker.

The change also finishes the aggregate workstream cleanup it started from: `shuffle()`, which is blocked on a seeded simulation RNG, moves out of `aggregate.md` into a new `simulation-rng.md` (RNG core, `$urandom` / `$urandom_range` / `$random`, and `shuffle`), leaving `aggregate.md` with no open items.

## Testing

`bazel build //...` and `bazel test //...` pass; prettier, buildifier, and the ASCII / architecture / cpp-style / exception policy checks are clean. Docs-only change.