### PR TITLE
Harden compiler warnings and track unpacked struct/union

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,15 @@ load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_static_library.bzl", "cc_static_library")
 
+# Promote a small set of always-real warnings to errors on Lyra's own sources.
+# Scoped per-target so external dependencies keep their own warning policy.
+# -Wswitch catches a no-default switch that omits an enumerator; -Wreturn-type
+# catches falling off the end of a non-void function.
+LYRA_COPTS = [
+    "-Werror=switch",
+    "-Werror=return-type",
+]
+
 filegroup(
     name = "runtime_headers",
     srcs = glob([
@@ -27,6 +36,7 @@ cc_library(
     name = "base",
     srcs = glob(["src/lyra/base/*.cpp"]),
     hdrs = glob(["include/lyra/base/*.hpp"]),
+    copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
 )
@@ -35,6 +45,7 @@ cc_library(
     name = "support",
     srcs = glob(["src/lyra/support/*.cpp"]),
     hdrs = glob(["include/lyra/support/*.hpp"]),
+    copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
@@ -47,6 +58,7 @@ cc_library(
     name = "diag",
     srcs = glob(["src/lyra/diag/*.cpp"]),
     hdrs = glob(["include/lyra/diag/*.hpp"]),
+    copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
@@ -58,6 +70,7 @@ cc_library(
 cc_library(
     name = "slang_source",
     hdrs = ["include/lyra/frontend/slang_source_mapper.hpp"],
+    copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
@@ -70,6 +83,7 @@ cc_library(
     name = "value",
     srcs = glob(["src/lyra/value/*.cpp"]),
     hdrs = glob(["include/lyra/value/*.hpp"]),
+    copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
@@ -81,6 +95,7 @@ cc_library(
     name = "runtime",
     srcs = glob(["src/lyra/runtime/*.cpp"]),
     hdrs = glob(["include/lyra/runtime/*.hpp"]),
+    copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
@@ -100,6 +115,7 @@ cc_library(
     name = "hir",
     srcs = glob(["src/lyra/hir/*.cpp"]),
     hdrs = glob(["include/lyra/hir/*.hpp"]),
+    copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
@@ -112,6 +128,7 @@ cc_library(
     name = "mir",
     srcs = glob(["src/lyra/mir/*.cpp"]),
     hdrs = glob(["include/lyra/mir/*.hpp"]),
+    copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
@@ -124,6 +141,7 @@ cc_library(
     name = "frontend",
     srcs = glob(["src/lyra/frontend/*.cpp"]),
     hdrs = glob(["include/lyra/frontend/*.hpp"]),
+    copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
@@ -139,6 +157,7 @@ cc_library(
     name = "ast_to_hir",
     srcs = glob(["src/lyra/lowering/ast_to_hir/**/*.cpp"]),
     hdrs = glob(["include/lyra/lowering/ast_to_hir/**/*.hpp"]),
+    copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
@@ -154,6 +173,7 @@ cc_library(
     name = "hir_to_mir",
     srcs = glob(["src/lyra/lowering/hir_to_mir/**/*.cpp"]),
     hdrs = glob(["include/lyra/lowering/hir_to_mir/**/*.hpp"]),
+    copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
@@ -168,6 +188,7 @@ cc_library(
     name = "backend_cpp",
     srcs = glob(["src/lyra/backend/cpp/*.cpp"]),
     hdrs = glob(["include/lyra/backend/cpp/*.hpp"]),
+    copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
@@ -180,6 +201,7 @@ cc_library(
     name = "compiler",
     srcs = ["src/lyra/compiler/compile.cpp"],
     hdrs = ["include/lyra/compiler/compile.hpp"],
+    copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
@@ -206,6 +228,7 @@ cc_library(
         "include/lyra/driver/project_layout.hpp",
         "include/lyra/driver/runtime_export.hpp",
     ],
+    copts = LYRA_COPTS,
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
@@ -220,6 +243,7 @@ cc_library(
 cc_binary(
     name = "lyra",
     srcs = ["src/lyra/driver/cli.cpp"],
+    copts = LYRA_COPTS,
     data = [
         ":cpp_runtime",
         ":runtime_headers",

--- a/docs/progress/aggregate.md
+++ b/docs/progress/aggregate.md
@@ -3,9 +3,9 @@
 Tracks the variable-size aggregate types on the current pipeline: dynamic array (`int arr []`),
 queue (`int q [$]`), and associative array (`int m [string]`). Fixed-size unpacked arrays are a
 separate, completed workstream out of scope here. Struct and union are also aggregate types per LRM
-6.5, but their storage and method concerns are unrelated to the variable-size storage problem and
-they will get their own file (`struct_union.md`) when that workstream opens; this file's scope is
-the variable-size subset only.
+6.5, but their storage and method concerns are unrelated to the variable-size storage problem:
+packed struct / union are tracked in `packed.md`, and unpacked struct / union in `struct-union.md`.
+This file's scope is the variable-size subset only.
 
 Done when:
 

--- a/docs/progress/architecture-reset.md
+++ b/docs/progress/architecture-reset.md
@@ -58,13 +58,14 @@ Granular tracking lives in `integral.md` (integral / packed / wide_integral) and
 
 - [ ] datatypes/default_init
 - [x] datatypes/enum
-- [ ] datatypes/general -- `aggregate.md`.
+- [ ] datatypes/general -- chandle (open), parameters (done; `datatypes.md` SI2), typedef.
 - [x] datatypes/integral -- `integral.md`.
 - [ ] datatypes/packed -- `packed.md`.
 - [x] datatypes/real
 - [ ] datatypes/representation
 - [x] datatypes/string -- `datatypes.md` (string family SC1..SC3).
-- [ ] datatypes/unpacked
+- [ ] datatypes/unpacked -- fixed unpacked arrays and the variable-size aggregate family
+      (`aggregate.md`) are done; unpacked struct / union (`struct-union.md`) remain.
 - [ ] datatypes/wide_integral -- non-`packed_2d` archive sub-folders covered (`integral.md` J14);
       `packed_2d` (2D element index / slice) belongs to `datatypes/packed`.
 

--- a/docs/progress/datatypes.md
+++ b/docs/progress/datatypes.md
@@ -2,22 +2,23 @@
 
 Tracks SystemVerilog data type coverage on the current pipeline. The integral family (`int`, `byte`,
 `shortint`, `longint`, `time`, `integer`, `bit [N:0]`, `logic [N:0]`) lives in `integral.md`. This
-file covers every other family: `datatypes/enum`, `datatypes/string`, `datatypes/unpacked`,
-`datatypes/general` (dynamic array / queue / associative), `datatypes/real`,
+file covers every other family: `datatypes/enum`, `datatypes/string`, `datatypes/unpacked` (fixed
+unpacked arrays here; the variable-size aggregate family in `aggregate.md`; unpacked struct / union
+in `struct-union.md`), `datatypes/general` (chandle, parameters, typedef), `datatypes/real`,
 `datatypes/default_init`, `datatypes/representation`.
 
 ## Actionable
 
 Enum, real, string, fixed-size unpacked arrays, the integral-family declaration initializers, and
 parameter references in expressions are complete. The variable-size aggregate family (dynamic array,
-queue, associative array) is in flight under `aggregate.md`. The default-init and representation
-families remain.
+queue, associative array) is complete; see `aggregate.md`. Unpacked struct and union are tracked in
+`struct-union.md`. The default-init and representation families remain.
 
-| Item | Status                                                  |
-| ---- | ------------------------------------------------------- |
-| -    | `datatypes/general` -- `aggregate.md`.                  |
-| -    | `datatypes/default_init`, `datatypes/representation` -- |
-|      | no progress sub-steps opened yet.                       |
+| Item | Status                                                                                    |
+| ---- | ----------------------------------------------------------------------------------------- |
+| -    | Variable-size aggregates (array / queue / assoc) -- `aggregate.md` (complete).            |
+| -    | Unpacked struct / union -- `struct-union.md` (open).                                      |
+| -    | `datatypes/default_init`, `datatypes/representation` -- no progress sub-steps opened yet. |
 
 ## Enum
 

--- a/docs/progress/functions.md
+++ b/docs/progress/functions.md
@@ -90,9 +90,9 @@ everything and the inline "rides on" notes record the real dependencies.
       concatenated and computed string returns.
 - [ ] F8 -- Container arguments and return values: dynamic array, queue, associative array. Managed
       ownership and lifecycle across the boundary, including `output` / `inout` containers and the
-      outdated-reference rules of LRM 13.5.2. Blocked: these container types do not yet exist as
-      runtime values; the boundary work waits on the container datatype workstream, not on the
-      subroutine ABI. See [Blocked](#blocked).
+      outdated-reference rules of LRM 13.5.2. The container value types now exist (`aggregate.md`),
+      so the subroutine ABI carries them by value through the same path as any other type; what
+      remains is the cross-boundary lifecycle and the LRM 13.5.2 outdated-reference rules.
 - [ ] F9 -- `chandle` arguments and return values (LRM 6.14). Identity round-trip and `null`
       handling through the subroutine boundary.
 
@@ -112,10 +112,9 @@ everything and the inline "rides on" notes record the real dependencies.
 
 ## Blocked
 
-| Item                                                    | Blocked on                                                                                                                                                                                                                                                                                            |
-| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Module-scoped subroutine accessing per-instance storage | Module hierarchy. A subroutine declared in a module reads and writes the storage of the specific instance that called it; correct per-instance addressing needs the instantiation / object-tree model that does not yet exist. Tracked under `architecture-reset.md` hierarchy.                       |
-| F8 -- container arguments and returns                   | Dynamic array, queue, and associative array do not yet exist as runtime value types. The cross-boundary lifecycle rides on those types' own copy / move / destroy semantics, so F8 waits on the container datatype workstream. F7 (string) is unblocked because the string value type already exists. |
+| Item                                                    | Blocked on                                                                                                                                                                                                                                                                      |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Module-scoped subroutine accessing per-instance storage | Module hierarchy. A subroutine declared in a module reads and writes the storage of the specific instance that called it; correct per-instance addressing needs the instantiation / object-tree model that does not yet exist. Tracked under `architecture-reset.md` hierarchy. |
 
 ## Out of Scope
 

--- a/docs/progress/struct-union.md
+++ b/docs/progress/struct-union.md
@@ -1,0 +1,95 @@
+# Unpacked Struct and Union
+
+Tracks the unpacked struct and unpacked union data types (LRM 7.2 / 7.3). An unpacked struct is a
+composite value with named, heterogeneous fields; an unpacked union overlays its members on shared
+storage with value semantics. Both are genuinely different from their packed counterparts, whose
+"treated as a single vector" projection is a separate, completed workstream in `packed.md`. Fixed
+unpacked arrays and the variable-size aggregate family (dynamic array, queue, associative array) are
+also separate (the latter in `aggregate.md`); this file's scope is unpacked struct and union only.
+
+Done when:
+
+- `datatypes/unpacked/unpacked_struct` and `datatypes/unpacked/unpacked_union` archive items
+  reproduce on the current pipeline.
+- The dependent items in [Unblocks](#unblocks) can proceed.
+
+When the last item lands, this file is deleted.
+
+## Actionable
+
+The unpacked struct surface comes first: it is the composite-value shape the union and the dependent
+workstreams build on. The union is the same composite value with overlaid members and a first-member
+default. The numeric IDs are stable references and do not imply execution order beyond S1 preceding
+the rest.
+
+## Unpacked Struct
+
+LRM 7.2: a struct groups members of possibly different types under one name. Without the `packed`
+qualifier the struct is unpacked -- its members are stored independently rather than collapsed into
+one vector -- so it is a composite value, not an integral one. Default value is member-wise (LRM
+Table 7-1).
+
+- [ ] S1 -- Type infrastructure, declaration, member read, and blocking member write (LRM 7.2).
+      Whole-struct assignment is value-semantic: a copy is independent of its source. Members may be
+      any supported integral, packed, real, or string type; an unpacked struct nests as a member of
+      another unpacked struct, and a struct is usable as an unpacked-array element and may itself
+      hold an unpacked-array member.
+- [ ] S2 -- Assignment-pattern literals (LRM 10.9): positional `'{a, b, c}`, named `'{field: v}` in
+      any order, type-key and `default:` fill (including mixed field widths), and the type-prefixed
+      self-determined form `T'{...}`.
+- [ ] S3 -- Default initialization (LRM Table 7-1, 7.2.2). Each member defaults to its own type's
+      Table 6-7 value, recursively, unless the member's declaration carries an initial assignment,
+      in which case that value is used. The 2-state / 4-state distinction propagates per member.
+- [ ] S4 -- Aggregate copy and equality (`==` / `!=` / `===` / `!==`), and member access composing
+      with element / range selects on packed members and on either side of an expression
+      (`s.f[3:0]`, `s.f + 1`). A struct field reads and writes correctly in arithmetic, conditional,
+      and other expression contexts.
+- [ ] S5 -- Members with managed lifecycle (string, and any future value type with non-trivial copy
+      semantics). Whole-struct copy gives each copy independent member storage; assignment releases
+      the destination's prior member value; multiple and nested managed members compose.
+
+## Unpacked Union
+
+LRM 7.3: a union holds one of its members at a time over shared storage. An untagged union is not
+type-checked -- reading a member other than the one last written is a type loophole (LRM 7.3) whose
+result is undefined and is not relied upon here. Default value is the first member's default (LRM
+Table 7-1).
+
+- [ ] N1 -- Type infrastructure, declaration, member read and write for an untagged unpacked union
+      (LRM 7.3). Writing then reading the same member round-trips; writing one member then another
+      overwrites. Two- and three-member unions of integral / real / shortreal members.
+- [ ] N2 -- Default initialization to the first member's LRM Table 7-1 default.
+- [ ] N3 -- Whole-union value-semantic copy (independent copies) and member use in arithmetic and
+      other expression contexts.
+
+## Unblocks
+
+- `datatypes.md` `default_init` closure: recursive LRM Table 7-1 defaults for unpacked struct and
+  union members.
+- `functions.md` F8 (a struct or union as a subroutine argument or return) and F10 (a reference
+  formal bound to an unpacked-struct member).
+- `hierarchy.md` E10 (an unpacked-struct port connection).
+
+## Blocked
+
+| Item                                                  | Blocked on                                                                                                                                                                                                          |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tagged unions (LRM 7.3.2)                             | A tagged union stores a tag plus value and is read through tagged expressions and pattern matching (LRM 11.9, 12.6). Needs tag-bit storage and the pattern-matching surface, which untagged unpacked unions do not. |
+| `chandle` and dynamic-typed union members (LRM 7.3.2) | Forbidden in untagged unions by LRM 7.3.2; they ride on tagged-union support.                                                                                                                                       |
+
+## Out of Scope
+
+- Packed struct and union (`packed.md`, complete). Their single-vector projection is a different
+  representation problem.
+- Class types as struct / union members (a separate workstream).
+
+## Cross-references
+
+- LRM anchors: 7.2 (structures), 7.2.1 (packed structures), 7.2.2 (assigning to structures and
+  member initialization), 7.3 (unions), 7.3.1 (packed unions), 7.3.2 (tagged unions), Table 7-1
+  (value read from a nonexistent entry and the unpacked struct / union default), Table 6-7 (default
+  initial values), 10.9 (assignment patterns), 11.9 / 12.6 (tagged-union expressions and pattern
+  matching).
+- Archive items: `datatypes/unpacked/{unpacked_struct, unpacked_union}`.
+- The value-semantic copy of a member whose type has non-trivial copy semantics (string, real)
+  follows `../decisions/value-type-concepts.md`.

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -307,6 +307,10 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "fork_wait_first";
     case BuiltinFn::kSpawnAll:
       return "spawn_all";
+    case BuiltinFn::kRegisterInitial:
+      return "register_initial";
+    case BuiltinFn::kRegisterFinal:
+      return "register_final";
     case BuiltinFn::kParent:
       return "parent";
     case BuiltinFn::kFileOpen:


### PR DESCRIPTION
## Summary

This change came out of a data-type completeness audit. It hardens the build against a class of latent bug found during the audit, opens tracking for the one remaining unpacked data-type family, and reconciles progress-doc drift left over from the aggregate workstream closing.

The MIR/HIR dumper crashed on any design containing an `initial` or `final` block: the lifecycle-registration builtins introduced when `mir::Process` was dissolved were added to the enum and the C++ emit path but not to the dumper's name table. The emit path and tests never exercised the dumper, so it went unnoticed. The dumper now names those builtins.

To make this class of mistake fail at compile time rather than scroll past as an ignored warning, `-Werror=switch` and `-Werror=return-type` are promoted to errors on Lyra's own targets via a shared `LYRA_COPTS`, scoped per-target so external dependencies keep their own warning policy. The whole source tree already builds clean under both flags, so there was no cleanup to do.

On the tracking side, unpacked struct and union were the only data-type family with no progress file; `struct-union.md` now tracks them (packed struct/union remain in `packed.md`). The `datatypes/general` label was being used in two incompatible senses -- the archive folder (chandle / parameters / typedef) versus the variable-size container family -- so the progress docs are reconciled: aggregate is marked complete, the container family is pointed at `aggregate.md`, and `functions.md` F8 no longer claims the container value types are missing.

## Testing

`bazel build //...` and `bazel test //...` both green on the rebased tip; all policy checks pass.