### PR TITLE
Give each scope a structural HierarchySegment identity

### DIFF
--- a/docs/architecture/hierarchy_and_generate.md
+++ b/docs/architecture/hierarchy_and_generate.md
@@ -32,7 +32,10 @@ shared by all consumers: external references, child routing, and construction.
 3. A named generate scope is a first-class constructed object. An unnamed generate scope is not
    addressable and is not materialized as an object.
 4. External references, runtime child routing, and the runtime constructor all navigate the same
-   object tree. No consumer has its own topology representation.
+   object tree. Typed members on the derived class are the ownership locus; a single non-owning
+   generic adjacency list on the base scope, populated by one attachment operation per child, serves
+   both deterministic traversal and by-name lookup. No second list of child pointers is maintained
+   in parallel, and the parent never restates a child's identity that the child already carries.
 5. The same compilation unit compiled once serves every instance of that unit. Hierarchy does not
    fork the unit's compile-time artifacts.
 6. Parameters affect constructor-time construction, not compile-time identity. A parameter value
@@ -55,6 +58,13 @@ shared by all consumers: external references, child routing, and construction.
    generate construct. A generate builds named child scopes as constructor-time logic; an array
    replicates one child member. Either may appear without the other, and a generate scope may itself
    contain instance arrays. Neither axis subsumes the other.
+10. Scope identity is structural and complete at construction. A child's identity at one hierarchy
+    edge is the pair `(parent, segment)`, where the segment is the source-level label plus any
+    per-dimension elaborated indices. The child receives that segment from its constructor's caller,
+    holds it for its lifetime, and remains the sole authoritative source of its own identity; no
+    consumer reconstructs the bracketed name by reverse-searching a parent registry, and the parent
+    never re-states an identity the child already carries. `%m`, hierarchical paths, debug output,
+    and by-name lookup all read from this single source.
 
 ## Boundary to Adjacent Layers
 
@@ -78,7 +88,10 @@ shared by all consumers: external references, child routing, and construction.
 - A topology representation owned by the driver or a central map instead of by the object tree
   itself.
 - Separate hierarchy models for compile-time and runtime. Only one model exists.
-- Dual representation (object tree plus a coordinate or ordinal system).
+- Two independently maintained runtime child views that can drift -- e.g., one list for traversal
+  plus a separate registry for by-name lookup, each written by a distinct opcode and at a distinct
+  construction-time moment. One non-owning adjacency relation serves both, populated by one
+  attachment operation per child.
 - A child-routing or external-reference path that reconstructs hierarchy from flattened symbol
   names.
 - Per-instance generate trees that duplicate the unit's construction logic.
@@ -87,6 +100,13 @@ shared by all consumers: external references, child routing, and construction.
   construction. The two axes must not be conflated or made to subsume each other.
 - Parameter values used as part of compile-time identity. Parameters are constructor inputs that
   steer construction, not identity keys that fork compile-time artifacts.
+- Splitting a child's hierarchy identity between the child and a parent-side registry -- the child
+  carrying only an un-indexed label while bracketed indices live in a parent table that consumers
+  reverse-search to recover the full name. The child carries its complete `(base, indices)` segment;
+  any per-dim decoration is the child's own property, never parent metadata about the child.
+- A scope's base constructor side-effecting its own attachment into the parent. Attachment is one
+  explicit operation the parent performs once the child is fully constructed and its typed owner has
+  committed, so a partially-built child is never visible in the parent's adjacency relation.
 
 ## Notes / Examples
 

--- a/docs/decisions/callable-receiver.md
+++ b/docs/decisions/callable-receiver.md
@@ -97,17 +97,18 @@ not MIR-modeled.
 ### Child-instance construction receiver triple
 
 When a parent scope instantiates an owned child or external-unit child, the call carries the
-parent's `self`, the child's source-level label, and the engine handle as the first three arguments
-before any user-supplied structural parameters. The MIR shape is one explicit `CallExpr` against
-`ConstructorCallee` whose result type is `unique_ptr<Child>` and whose arguments are
-`[self, "label", services, structural_args...]`. The render is mechanical: it reads the
-unique-pointer result type and emits
-`std::make_unique<Child>(self, "label", services, structural_args...)`. After the construction
-returns its `unique_ptr<Child>` -- assigned to the slot for a scalar member, pushed into the vector
-for an array element -- an explicit `RegisterChild` call records the new instance under its label so
-a sibling's cross-unit `GetChild` lookup reaches it by name. Neither the receiver triple nor the
-register call lives in any stmt-kind dispatch; both are ordinary `CallExpr` nodes, and every backend
-reads them the same way.
+parent's `self`, the child's structural `HierarchySegment` (label plus per-dim elaborated indices),
+and the engine handle as the first three arguments before any user-supplied structural parameters.
+The MIR shape is one explicit `CallExpr` against `ConstructorCallee` whose result type is
+`unique_ptr<Child>` and whose arguments are `[self, segment, services, structural_args...]`. The
+render is mechanical: it reads the unique-pointer result type and emits
+`std::make_unique<Child>(self, HierarchySegment{...}, services, structural_args...)`. After the
+construction returns its `unique_ptr<Child>` -- assigned to the slot for a scalar member, pushed
+into the vector for an array element -- an explicit `AttachChild` call wires the parent edge.
+Identity rides on the child (its segment is the single source of `%m`, by-name lookup, and debug
+output); the parent never re-states the label or indices. Neither the receiver triple nor the attach
+call lives in any stmt-kind dispatch; both are ordinary `CallExpr` nodes, and every backend reads
+them the same way.
 
 ### Why always include `self`, not derive from "body touches class state"
 

--- a/docs/decisions/variable-initialization.md
+++ b/docs/decisions/variable-initialization.md
@@ -22,7 +22,7 @@ Before this decision, MIR carried the variable initializer two ways:
 
 1. `mir::MemberDecl.initializer: ExprId` -- the init expression as a field on the declaration
    itself.
-2. `constructor_block.root_stmts` -- the constructor-time statement sequence (`RegisterChild`,
+2. `constructor_block.root_stmts` -- the constructor-time statement sequence (`AttachChild`,
    `RegisterSignal`, `CreateProcesses`, generate construction, ...).
 
 The C++ backend plucked path (1) into an inline class-body NSDMI (`Var<int> a{1};`) and rendered
@@ -39,7 +39,7 @@ to a C++-specific syntactic mode dependency that a LIR / LLVM-IR backend would h
 **MIR has exactly one shape for construction-time work: statements in
 `constructor_block.root_stmts`. For every value-assignable member, HIR-to-MIR inserts an
 `AssignExpr(MemberAccess(self, var), value)` statement at the position the variable is declared in
-source order, before any `RegisterSignal` / `RegisterChild` / `CreateProcesses` for the same scope.
+source order, before any `RegisterSignal` / `AttachChild` / `CreateProcesses` for the same scope.
 The value is the user-supplied expression when present, otherwise the LRM Table 6-7 type default;
 the statement shape is uniform either way. The `mir::MemberDecl.initializer` field is removed; a
 member declaration carries name and type only.**

--- a/docs/progress/display.md
+++ b/docs/progress/display.md
@@ -16,8 +16,11 @@ since the test harness can only probe a variable whose type has an implemented s
       20.4.3), applied design-wide.
 - [x] DI3 -- `%f` / `%e` / `%g` (real). Default precision 6 per LRM Table 21-2. Coverage tracked
       under `datatypes.md` Real C1.
-- [ ] DI4 -- `%m` (hierarchical name). Requires runtime exposure of the current scope's hierarchical
-      path; shares its mechanism with archive item `hierarchy/refs`.
+- [x] DI4 -- `%m` (hierarchical name). HIR-to-MIR lowers `%m` to a plain string-valued `CallExpr`
+      against the enclosing scope's `self`, so the format pipeline carries no `%m`-specific arm and
+      the runtime returns an ordinary SV string; the path itself derives from object-tree ownership
+      (closes `hierarchy.md` D5). Width modifiers on `%m` are rejected at the slang frontend per LRM
+      21.2.1.1.
 - [x] DI5 -- File sink. Twelve `$display` / `$write` / `$fdisplay` / `$fwrite` variants
       (default-decimal plus `b` / `h` / `o` radix variants per LRM 21.2.1.1); descriptors per LRM
       21.3.1 (MCD with bit 0 = stdout, FD with bit 31 set, OR-able MCDs that fan output across

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -159,8 +159,17 @@ consume. Coverage is demonstrated through Stage D and Stage E.
       signal changes, across paths spanning multiple levels, several instances read within one
       process, and upward references alongside downward ones. The process subscribes to every
       referenced signal regardless of direction or depth, and each source re-triggers independently.
-- [ ] D5 -- The hierarchical path of an instance (for `%m`, display, and scope queries) derives from
-      object-tree ownership.
+- [x] D5 -- The hierarchical path of an instance (for `%m`, display, and scope queries) derives from
+      object-tree ownership. Each runtime scope receives its complete `HierarchySegment` (base label
+      plus per-dimension elaborated indices) from its parent at construction; `%m` walks the parent
+      chain and joins each scope's own segment, never reverse-searching a parent registry for a
+      child's bracketed name. A generate-loop iteration's identity therefore lives entirely on
+      itself: `loop[0]` is what the iteration scope holds, not metadata the parent decorates onto an
+      un-indexed `"loop"`. The walk stops at the implicit `$root` so multi-top output reads `Top.x`
+      rather than `$root.Top.x`. Closure-deferred prints (`$strobe`) capture `self` via the closure
+      builder, so the path printed is the issuing scope's, not whatever scope is active when the
+      postponed region drains. VPI-style scope queries (`$scope`, `$function`) stay out of scope --
+      they belong to the assertion/debug workstream.
 - [x] D6 -- A hierarchical path that indexes an instance array (`c[i].x`) resolves to the selected
       element, including multi-dimensional arrays (`c[i][j].x`).
 - [x] D7 -- A hierarchical reference crosses a generate-block scope boundary. A by-name reference

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -662,6 +662,25 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       naturally with R45's call-shape work, which also moves per-symbol resolution off the reference
       node.
 
+- [ ] R51 -- Close R45's last asymmetry: a class constructor should be a `mir::MethodDecl` whose
+      signature MIR states in full, not a special `Block` on the side. R45 unified the call side
+      onto `Direct / Indirect / Construct`, so a child construction at a parent's body already emits
+      a generic `Construct(self, segment, services, structural...)` callee whose args are plain MIR
+      primitives. The receiver side -- the constructor declaration -- is still a bare
+      `Class::constructor_block` with `body.vars[0] = self`; the C++ ctor entry args
+      (`parent / segment / services / structural...`) are not in MIR at all. The interim shape lands
+      the prefix args as `Class::ctor_prefix_params` so the render can iterate without restating any
+      type literal, and the render forwards each prefix arg to the base by pure name pass-through
+      (no `std::move`) -- which causes one `HierarchySegment` copy per scope construction. The
+      principled close: make the constructor a `MethodDecl` carrying its full signature, let the
+      call site's `Construct` callee resolve to it like any other callable, and let the C++ render
+      share the generic method renderer with one C++-specific mem-init mapping. Moving args into the
+      base init list then becomes an explicit MIR primitive (a `Move(expr)` wrapper or equivalent
+      data-flow encoding) rather than a render-time type-kind heuristic, so the copy can be elided
+      without the render learning what `HierarchySegment` / `Scope*` / `RuntimeServices&` mean.
+      **Likely interacts with**: R8 (callable-model unification) and R47 (SV class object model),
+      since both touch what "a class with a body" looks like at MIR.
+
 ## Out of Scope
 
 - Per-feature workstreams. Those live in the dedicated feature files (`control-flow.md`,

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -42,7 +42,6 @@ enum class DiagCode : std::uint32_t {
   kErrorFormatStringWidthOverflow,
   kErrorFormatStringUnknownSpecifier,
   kErrorDisplayMissingArg,
-  kFormatModulePathNotImplemented,
   kSystemSubroutineExecutionNotImplemented,
 
   kCppEmitExpressionFormNotImplemented,

--- a/include/lyra/lowering/hir_to_mir/expression/system/print.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/system/print.hpp
@@ -12,7 +12,7 @@ namespace lyra::lowering::hir_to_mir {
 
 // Lower a print-like system subroutine ($display / $write / $fdisplay /
 // $fwrite / $strobe family) into a generic `CallExpr`. Returns a user
-// diagnostic for unsupported shapes (`%m`, malformed format string, ...).
+// diagnostic for malformed or unsupported format strings.
 auto LowerPrintSystemSubroutineCall(
     ProcessLowerer& process, WalkFrame frame, const hir::CallExpr& call,
     const support::PrintSystemSubroutineInfo& print, diag::SourceSpan span)

--- a/include/lyra/mir/class.hpp
+++ b/include/lyra/mir/class.hpp
@@ -39,6 +39,18 @@ struct Class {
   // class exposes the precision so the engine can take the design-global
   // minimum (LRM 3.14.3) and so delays scale to it.
   TimeResolution time_resolution;
+  // The C++ ctor params that forward to the runtime base ctor -- the
+  // `(parent, segment, services)` trio for a Scope-derived class, the
+  // empty list for a baseless plain object. The lowering populates them
+  // by reading the runtime SDK contract for the chosen base; the render
+  // walks the list to emit the prefix signature and the base init list
+  // generically. Decoupling type names from the render layer: the only
+  // place that knows "Scope* / HierarchySegment / RuntimeServices&" mean
+  // those C++ tokens is the MIR-level RenderTypeAsCpp dispatch.
+  base::Arena<ParamDecl, ParamId> ctor_prefix_params;
+  // Structural ctor params that also install a same-named member field
+  // (a genvar binding, an upward-class param). Each renders as a ctor
+  // param after the prefix list and as a `field(param)` mem-init entry.
   base::Arena<ParamDecl, ParamId> params;
   base::Arena<MemberDecl, MemberId> members;
   // Construction logic, run when the object is allocated. The backend's C++

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -36,6 +36,7 @@ struct BuiltinMirTypes {
   TypeId print_value_item;
   TypeId format_spec;
   TypeId time_format;
+  TypeId hierarchy_segment;
   TypeId coroutine;
   TypeId wildcard_index;
 };
@@ -100,6 +101,9 @@ struct CompilationUnit {
             .time_format = AddType(
                 TypeData{RuntimeLibraryType{
                     .kind = RuntimeLibraryKind::kTimeFormat}}),
+            .hierarchy_segment = AddType(
+                TypeData{RuntimeLibraryType{
+                    .kind = RuntimeLibraryKind::kHierarchySegment}}),
             .coroutine = TypeId{},
             .wildcard_index = AddType(TypeData{WildcardIndexType{}}),
         } {

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -205,6 +205,12 @@ enum class RuntimeLibraryKind : std::uint8_t {
   // the value-layer format step for `%t` directives. Threaded into `Format` as
   // an explicit operand from the engine's current state.
   kTimeFormat,
+  // LRM 23.3.3.5 / 27.6 elaborated hierarchy segment:
+  // `lyra::runtime::HierarchySegment`, the per-scope structured identity each
+  // child carries from construction (base name plus per-dimension indices).
+  // The owner of a child threads this into the child's constructor as a
+  // single packaged value.
+  kHierarchySegment,
 };
 
 struct RuntimeLibraryType {

--- a/include/lyra/runtime/hierarchy_segment.hpp
+++ b/include/lyra/runtime/hierarchy_segment.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "lyra/value/packed_array.hpp"
+
+namespace lyra::runtime {
+
+// LRM 23.3.3.5 / 27.6 elaborated identity of a single hierarchy edge: the
+// base label registered at the parent (`"loop"`, `"m"`, `"leaf"`) together
+// with any per-dimension indices the elaboration assigns (`{0}` for the
+// first iteration of a generate-for, `{i, j}` for a multi-dim instance
+// array, `{}` for a scalar). Each scope owns one of these from the moment
+// its constructor returns; `%m`, debug, and by-name lookup all read it.
+class HierarchySegment {
+ public:
+  HierarchySegment() = default;
+
+  // The emit passes indices as a `std::array<PackedArray, N>` so the span
+  // ctor absorbs every fixed-shape literal. The PackedArrays are copied
+  // into the segment's owning vector; the source array can be a temporary.
+  HierarchySegment(
+      std::string base_name, std::span<const value::PackedArray> indices)
+      : base_name_(std::move(base_name)),
+        indices_(indices.begin(), indices.end()) {
+  }
+
+  [[nodiscard]] auto BaseName() const -> std::string_view {
+    return base_name_;
+  }
+  [[nodiscard]] auto Indices() const -> std::span<const value::PackedArray> {
+    return indices_;
+  }
+
+  // The LRM 27.6 display form: `base[i0][i1]...`. Empty indices yield the
+  // bare base label; scalar instances render as their source identifier.
+  [[nodiscard]] auto Display() const -> std::string;
+
+ private:
+  std::string base_name_;
+  std::vector<value::PackedArray> indices_;
+};
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/prelude.hpp
+++ b/include/lyra/runtime/prelude.hpp
@@ -29,6 +29,7 @@
 #include "lyra/runtime/file_table.hpp"         // IWYU pragma: keep
 #include "lyra/runtime/finish.hpp"             // IWYU pragma: keep
 #include "lyra/runtime/fork.hpp"               // IWYU pragma: keep
+#include "lyra/runtime/hierarchy_segment.hpp"  // IWYU pragma: keep
 #include "lyra/runtime/named_event.hpp"        // IWYU pragma: keep
 #include "lyra/runtime/process_kind.hpp"       // IWYU pragma: keep
 #include "lyra/runtime/runtime_process.hpp"    // IWYU pragma: keep

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -11,8 +10,10 @@
 #include <vector>
 
 #include "lyra/runtime/coroutine.hpp"
+#include "lyra/runtime/hierarchy_segment.hpp"
 #include "lyra/runtime/runtime_process.hpp"
 #include "lyra/value/packed_array.hpp"
+#include "lyra/value/string.hpp"
 
 namespace lyra::runtime {
 
@@ -26,20 +27,21 @@ inline constexpr std::int8_t kUnspecifiedTimePrecisionPower = 127;
 
 // How an upward hierarchical reference matches its ancestor while climbing the
 // parent chain (LRM 23.8): against the ancestor's module definition name
-// (`DefName()`, a module-instance head) or against the scope's own name
-// (`Name()`, a named generate block or `$root`).
+// (`DefName()`, a module-instance head) or against the scope's own segment
+// base name (`Segment().BaseName()`, a named generate block or `$root`).
 enum class UpwardMatch : std::uint8_t { kDefName, kScopeName };
 
 // A node in the one canonical object tree. Every constructed SystemVerilog
 // scope -- a module instance, a generate block, the implicit `$root` -- is a
-// Scope. It carries the scope's identity (name, parent), the services handle
-// its bodies reach through, its own processes, and the observed-region pending
-// closures. The scheduler walks this same tree; there is no parallel topology.
+// Scope. It carries the scope's structural identity (parent plus
+// HierarchySegment), the services handle its bodies reach through, its own
+// processes, and the observed-region pending closures. The scheduler walks
+// this same tree; there is no parallel topology.
 class Scope {
  public:
   using ChildVisitor = std::function<void(Scope&)>;
 
-  Scope(Scope* parent, std::string name, RuntimeServices& services);
+  Scope(Scope* parent, HierarchySegment segment, RuntimeServices& services);
   virtual ~Scope() = default;
   Scope(const Scope&) = delete;
   auto operator=(const Scope&) -> Scope& = delete;
@@ -47,7 +49,27 @@ class Scope {
   auto operator=(Scope&&) -> Scope& = delete;
 
   [[nodiscard]] auto Parent() const -> Scope*;
+
+  // The scope's structural identity at this level: the parent-side label
+  // plus per-dimension indices (empty for a scalar, `{i}` for a generate-for
+  // iteration, `{i, j}` for a multi-dim instance array). Fixed at
+  // construction and never observed before then.
+  [[nodiscard]] auto Segment() const -> const HierarchySegment&;
+
+  // The LRM 27.6 display form of `Segment()` -- `loop[0]`, `m`, `gblk`.
+  [[nodiscard]] auto DisplaySegment() const -> std::string;
+
+  // The base label of `Segment()`. Carries the source-level identifier
+  // without any per-dimension index decoration; used by cross-unit by-name
+  // lookup keys and by upward `kScopeName` resolution.
   [[nodiscard]] auto Name() const -> std::string_view;
+
+  // Joins each ancestor's display segment with `.`, ordered from the
+  // outermost named ancestor inward (LRM 21.2.1.1; `%m` resolves to this
+  // string). The walk stops at the implicit `$root` so multi-top output
+  // reads `Top.mid.x` rather than `$root.Top.mid.x`. Walked on demand:
+  // the object tree is sealed by Activate.
+  [[nodiscard]] auto HierarchicalPath() const -> lyra::value::String;
 
   // The scope's module definition name. An upward hierarchical reference climbs
   // the parent chain matching against this (LRM 23.8): the referrer's emitted
@@ -58,16 +80,19 @@ class Scope {
     return {};
   }
 
-  // Records, during construction, the address of a signal this scope owns under
-  // its source name, and the owned child reachable at `name` plus one index per
-  // array dimension (empty for a scalar). A unit answers by-name queries about
-  // its own interface from these registrations; it never inspects who asks.
-  // `name` points at an emitted string literal; the indices are copied so the
-  // entry outlives the constructor's arguments.
+  // Records, during construction, the address of a signal this scope owns
+  // under its source name. A unit answers by-name signal queries from these
+  // registrations; it never inspects who asks. `name` points at an emitted
+  // string literal.
   void RegisterSignal(std::string_view name, void* address);
-  void RegisterChild(
-      std::string_view name, std::span<const lyra::value::PackedArray> indices,
-      Scope& child);
+
+  // Wires `child` into this scope's object-tree edge: sets `child.parent_`
+  // to `this`, places `child` in the attached-children relation, and makes
+  // it findable through `GetChild` (key derived from `child.Segment()`).
+  // One write point per child edge; the parent never re-states identity
+  // the child already holds. Called after the typed owner commits the
+  // child, so a thrown ctor leaves no half-attached scope.
+  void AttachChild(Scope& child);
 
   // Returns the address of the signal registered under `name`, or the owned
   // child registered at `name` with `indices`; nullptr if none. A cross-unit
@@ -125,9 +150,6 @@ class Scope {
       const lyra::value::PackedArray& site_id, std::function<void()> fn);
   void DrainObserved();
 
-  // Links a child into this scope. Owned children register themselves here
-  // from their constructor; the engine adds the top-level blocks to `$root`.
-  void AddChild(Scope& child);
   void ForEachChild(const ChildVisitor& fn);
 
   template <typename Fn>
@@ -173,24 +195,20 @@ class Scope {
     std::string_view name;
     void* address;
   };
-  struct ChildEntry {
-    std::string_view name;
-    std::vector<std::size_t> indices;
-    Scope* scope;
-  };
 
   Scope* parent_ = nullptr;
-  std::string name_;
+  HierarchySegment segment_;
   // Borrowed; set in the constructor.
   RuntimeServices* services_ = nullptr;
-  // Non-owning child links; the typed members on the derived class own the
-  // children. This is the object tree's own structure, not a parallel one.
-  std::vector<Scope*> children_;
-  // By-name interface this scope answers cross-unit queries from. Filled during
-  // construction; scanned only at construction-time resolution, never on the
-  // simulation path.
+  // The single object-tree edge: every child this scope owns appears here
+  // once, with its `Segment()` carrying both the LRM display name and the
+  // by-name lookup key. Traversal walks this in deterministic attach order;
+  // by-name lookup scans it and compares each child's segment.
+  std::vector<Scope*> attached_children_;
+  // By-name interface this scope answers cross-unit signal queries from.
+  // Filled during construction; scanned only at construction-time
+  // resolution, never on the simulation path.
   std::vector<SignalEntry> signals_;
-  std::vector<ChildEntry> child_entries_;
   std::vector<std::unique_ptr<RuntimeProcess>> processes_;
   // Empty std::function == clean slot; no parallel dirty bitmap needed.
   std::vector<std::function<void()>> observed_pending_;

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -208,14 +208,15 @@ enum class BuiltinFn : std::uint16_t {
   kAsObservable,
   // By-name scope navigation: a constructor walks a sibling unit's
   // interface, looks up an owned child by name (and per-dimension index),
-  // looks up a signal by name, or registers its own signal / child under a
-  // name. All four are instance methods on the scope handle (`args[0]`);
-  // the name (and the index array for `kGetChild` / `kRegisterChild`) is a
-  // regular argument. `kRegisterChild` records an owned child instance
-  // (scalar: empty index array; vector dimension: one entry per axis) so
-  // by-name lookup from a sibling reaches it.
+  // looks up a signal by name, or attaches a freshly-built child into its
+  // parent. All four are instance methods on the scope handle (`args[0]`).
+  // `kRegisterSignal` and `kGetSignal` carry the signal name as a regular
+  // argument. `kGetChild` carries the lookup name and per-axis index array.
+  // `kAttachChild` carries only the borrowed reference to the already-built
+  // child -- the child's own `Segment()` supplies both the by-name lookup
+  // key and the LRM display form, so the parent never re-states them.
   kRegisterSignal,
-  kRegisterChild,
+  kAttachChild,
   kGetSignal,
   kGetChild,
   // C++ `std::vector` operations exposed to MIR so the constructor
@@ -303,6 +304,12 @@ enum class BuiltinFn : std::uint16_t {
   // owns the enclosing class's layout); distinct from the by-name `kGetSignal`
   // / `kGetChild` cross-unit navigation.
   kParent,
+  // LRM 21.2.1.1 `%m` source: yields the receiver scope's hierarchical name
+  // as an SV `string`. Walks `Parent()` from the receiver up to the implicit
+  // root and joins each scope's own name with `.`; `%m` lowering reads it as
+  // an ordinary value-string print item rather than as a context-dependent
+  // format kind.
+  kHierarchicalPath,
 };
 
 // True iff `id` is a type-namespace-qualified static call -- no receiver,

--- a/include/lyra/value/format.hpp
+++ b/include/lyra/value/format.hpp
@@ -81,10 +81,10 @@ struct TimeFormat {
 
 // Per-call context routed alongside the spec into every Formatter::Format.
 // Holds the design-wide bits that a formatter sometimes needs but the spec
-// itself cannot carry (the spec is closed and shared across call sites). At
-// present only `%t` consults it; future kinds (e.g. `%m` hierarchical name)
-// will add fields here. `time_format == nullptr` means the calling context
-// has no time-format vocabulary; a formatter that needs one throws.
+// itself cannot carry (the spec is closed and shared across call sites).
+// `%t` is the only consumer today. `time_format == nullptr` means the
+// calling context has no time-format vocabulary; a formatter that needs one
+// throws.
 struct FormatContext {
   const TimeFormat* time_format = nullptr;
 };
@@ -124,11 +124,11 @@ template <typename T>
                       const FormatContext& ctx) -> std::string {
         const T& v = *static_cast<const T*>(p);
         // Per-formatter signature lookup: those that consult design-wide
-        // context (`%t` needing `TimeFormat`, future `%m` needing scope)
-        // declare `Format(spec, value, ctx)`; those that do not (string,
-        // aggregate -- never reach a context-bound kind) declare just
-        // `Format(spec, value)`. The lambda absorbs both shapes so the
-        // `FormatArg.format_fn` signature stays uniform.
+        // context (`%t` needing `TimeFormat`) declare `Format(spec, value,
+        // ctx)`; those that do not (string, aggregate -- never reach a
+        // context-bound kind) declare just `Format(spec, value)`. The lambda
+        // absorbs both shapes so the `FormatArg.format_fn` signature stays
+        // uniform.
         if constexpr (requires { Formatter<T>::Format(spec, v, ctx); }) {
           return Formatter<T>::Format(spec, v, ctx);
         } else {

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -110,40 +110,89 @@ auto RenderMethod(
   return out;
 }
 
+// Joins string parts with ", " for emission of ctor sig args, base init
+// forwards, and member-init list entries. Local to RenderConstructor; the
+// rest of the file does not yet need a shared helper.
+auto JoinCommaSeparated(const std::vector<std::string>& parts) -> std::string {
+  std::string out;
+  for (const auto& part : parts) {
+    if (!out.empty()) {
+      out.append(", ");
+    }
+    out.append(part);
+  }
+  return out;
+}
+
 auto RenderConstructor(
     const ScopeView& scope_view, const mir::Class& s,
     const std::string& base_class, std::size_t indent) -> std::string {
-  std::string sig = std::format(
-      "{}(lyra::runtime::Scope* parent, std::string name, "
-      "lyra::runtime::RuntimeServices& services",
-      s.name);
-  std::string init_list =
-      std::format("{}(parent, std::move(name), services)", base_class);
+  // The render iterates every ctor entry in MIR-stated order without
+  // switching on what each type means: ctor_prefix_params forward to the
+  // base by name, structural params bind to same-named member fields.
+  // Each type goes through the single RenderTypeAsCpp dispatch, so the
+  // C++ form of every type lives in exactly one place. Base forwarding is
+  // plain pass-through (no std::move) -- C++ may copy a HierarchySegment
+  // once at construction, which the iteration-time budget can absorb.
+  // The follow-up that retires this interim is tracked under R51.
+  const auto& unit = scope_view.Unit();
+  const auto render_typed_name = [&](mir::TypeId type, std::string_view name) {
+    return std::format("{} {}", RenderTypeAsCpp(unit, s, type), name);
+  };
+
+  std::vector<std::string> sig_args;
+  std::vector<std::string> base_forwards;
+  std::vector<std::string> field_inits;
+  sig_args.reserve(s.ctor_prefix_params.size() + s.params.size());
+  base_forwards.reserve(s.ctor_prefix_params.size());
+  field_inits.reserve(s.params.size());
+
+  for (std::size_t i = 0; i < s.ctor_prefix_params.size(); ++i) {
+    const auto& p =
+        s.ctor_prefix_params.Get(mir::ParamId{static_cast<std::uint32_t>(i)});
+    sig_args.push_back(render_typed_name(p.type, p.name));
+    base_forwards.push_back(p.name);
+  }
   for (std::size_t i = 0; i < s.params.size(); ++i) {
     const auto& p = s.params.Get(mir::ParamId{static_cast<std::uint32_t>(i)});
     const auto param_name = CtorParamName(i);
-    sig += std::format(
-        ", {} {}", RenderTypeAsCpp(scope_view.Unit(), s, p.type), param_name);
-    init_list += std::format(", {}({})", p.name, param_name);
+    sig_args.push_back(render_typed_name(p.type, param_name));
+    field_inits.push_back(std::format("{}({})", p.name, param_name));
   }
-  sig += std::format(") : {}", init_list);
 
-  // The C++ constructor is the one shape that is not an ordinary method: it has
-  // no result type and runs a member-init list before its body, so it cannot
-  // run a virtual override during construction. It is an allocation shell that
-  // forwards to the base and the param members, then kicks off the construction
-  // body -- a static worker over `self`, the same body shape every method uses.
-  // An empty body needs no kickoff.
+  std::vector<std::string> init_parts;
+  init_parts.reserve(1 + field_inits.size());
+  if (!s.ctor_prefix_params.empty()) {
+    init_parts.push_back(
+        std::format("{}({})", base_class, JoinCommaSeparated(base_forwards)));
+  }
+  for (auto& f : field_inits) {
+    init_parts.push_back(std::move(f));
+  }
+
+  const std::string sig =
+      init_parts.empty()
+          ? std::format("{}({})", s.name, JoinCommaSeparated(sig_args))
+          : std::format(
+                "{}({}) : {}", s.name, JoinCommaSeparated(sig_args),
+                JoinCommaSeparated(init_parts));
+
+  // The C++ constructor is the one shape that is not an ordinary method:
+  // it has no result type and runs a member-init list before its body, so
+  // it cannot run a virtual override during construction. It is an
+  // allocation shell that forwards to the base and the field members, then
+  // kicks off the body -- a static worker over `self`, the same shape
+  // every method uses. An empty body needs no kickoff.
   if (s.constructor_block.root_stmts.empty()) {
     return std::format("{}{} {{}}\n", Indent(indent), sig);
   }
-  std::string out;
-  out += std::format("{}{} {{ init(this); }}\n", Indent(indent), sig);
-  out += std::format(
-      "{}static auto init({}* self) -> void {{\n", Indent(indent), s.name);
-  out += RenderBlockStatements(scope_view, indent + 1);
-  out += std::format("{}}}\n", Indent(indent));
-  return out;
+  return std::format(
+      "{0}{1} {{ init(this); }}\n"
+      "{0}static auto init({2}* self) -> void {{\n"
+      "{3}"
+      "{0}}}\n",
+      Indent(indent), sig, s.name,
+      RenderBlockStatements(scope_view, indent + 1));
 }
 
 auto RenderRuntimeBaseClass(mir::RuntimeBaseClass base) -> std::string {
@@ -387,9 +436,18 @@ auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
   out += "auto main() -> int {\n";
   out += "  lyra::runtime::Engine engine;\n";
   for (std::size_t i = 0; i < tops.size(); ++i) {
+    // A top instance's structural identity is fixed at this construction
+    // site: the segment carries the top's source name with no per-dimension
+    // indices, which $root then reads back when binding the design. The
+    // segment type name comes from the canonical RenderTypeAsCpp mapping
+    // so this harness file does not repeat a type literal already owned
+    // by MIR's builtin TypeId table.
+    const auto& unit = *tops[i].unit;
+    const std::string segment_cpp =
+        RenderTypeAsCpp(unit, unit.top_class, unit.builtins.hierarchy_segment);
     out += std::format(
-        "  {} top{}{{nullptr, \"{}\", engine.Services()}};\n",
-        tops[i].unit->top_class.name, i, tops[i].name);
+        "  {0} top{1}{{nullptr, {2}{{\"{3}\", {{}}}}, engine.Services()}};\n",
+        tops[i].unit->top_class.name, i, segment_cpp, tops[i].name);
   }
   out += "  std::vector<lyra::runtime::TopBinding> tops = {\n";
   for (std::size_t i = 0; i < tops.size(); ++i) {

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -218,8 +218,8 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "AsObservable";
     case support::BuiltinFn::kRegisterSignal:
       return "RegisterSignal";
-    case support::BuiltinFn::kRegisterChild:
-      return "RegisterChild";
+    case support::BuiltinFn::kAttachChild:
+      return "AttachChild";
     case support::BuiltinFn::kGetSignal:
       return "GetSignal";
     case support::BuiltinFn::kGetChild:
@@ -310,6 +310,8 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "Error";
     case support::BuiltinFn::kFileFlush:
       return "Flush";
+    case support::BuiltinFn::kHierarchicalPath:
+      return "HierarchicalPath";
   }
   throw InternalError("BuiltinFnCppName: unknown BuiltinFn");
 }

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -130,6 +130,8 @@ auto RenderTypeAsCpp(
                 return std::string{"lyra::runtime::ChannelCancellation"};
               case mir::RuntimeLibraryKind::kTimeFormat:
                 return std::string{"lyra::value::TimeFormat"};
+              case mir::RuntimeLibraryKind::kHierarchySegment:
+                return std::string{"lyra::runtime::HierarchySegment"};
             }
             throw InternalError("RenderTypeAsCpp: unknown RuntimeLibraryKind");
           },

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -158,11 +158,6 @@ constexpr std::array kEntries{
         DiagCode::kErrorDisplayMissingArg,
         DiagCodeInfo{.kind = DiagKind::kError, .name = "display_missing_arg"}},
     std::pair{
-        DiagCode::kFormatModulePathNotImplemented,
-        DiagCodeInfo{
-            .kind = DiagKind::kUnsupported,
-            .name = "format_module_path_not_implemented"}},
-    std::pair{
         DiagCode::kSystemSubroutineExecutionNotImplemented,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -232,8 +232,26 @@ void EmitExternalUnitDimLevel(
   };
 
   if (dims.empty()) {
+    // The child's structural identity, fixed before its constructor runs.
+    // Indices reflect the position this leaf occupies in its enclosing
+    // dim chain (empty for a scalar instance).
+    const mir::TypeId indices_type = module.Unit().AddType(
+        mir::UnpackedArrayType{
+            .element_type = builtins.int32, .size = indices.size()});
+    const mir::ExprId indices_id = block.exprs.Add(
+        mir::Expr{
+            .data = mir::ArrayLiteralExpr{.elements = indices},
+            .type = indices_type});
+    const mir::ExprId segment_id = block.exprs.Add(
+        mir::Expr{
+            .data =
+                mir::CallExpr{
+                    .callee = mir::Construct{},
+                    .arguments = {string_literal(runtime_label), indices_id}},
+            .type = builtins.hierarchy_segment});
+
     std::vector<mir::ExprId> ctor_args = {
-        self_id_for_register, string_literal(runtime_label),
+        self_id_for_register, segment_id,
         block.exprs.Add(BuildServicesCallExpr(module, frame))};
     const mir::ExprId ctor_call_id = block.exprs.Add(
         mir::Expr{
@@ -272,7 +290,7 @@ void EmitExternalUnitDimLevel(
 
     // The just-built child is reachable via the scalar slot directly or via
     // `chain.back()` for the vector case; either way one dereference yields
-    // the ExternalUnitObject reference `RegisterChild` consumes.
+    // the ExternalUnitObject reference `AttachChild` consumes.
     mir::ExprId leaf_handle_id = chain_expr_id;
     if (!indices.empty()) {
       leaf_handle_id = block.exprs.Add(
@@ -294,28 +312,17 @@ void EmitExternalUnitDimLevel(
             .data = mir::DerefExpr{.pointer = leaf_handle_id},
             .type = leaf_object_type});
 
-    const mir::TypeId indices_type = module.Unit().AddType(
-        mir::UnpackedArrayType{
-            .element_type = builtins.int32, .size = indices.size()});
-    const mir::ExprId indices_id = block.exprs.Add(
-        mir::Expr{
-            .data = mir::ArrayLiteralExpr{.elements = indices},
-            .type = indices_type});
-
-    const mir::ExprId register_id = block.exprs.Add(
+    const mir::ExprId attach_id = block.exprs.Add(
         mir::Expr{
             .data =
                 mir::CallExpr{
                     .callee =
-                        mir::Direct{
-                            .target = support::BuiltinFn::kRegisterChild},
-                    .arguments =
-                        {self_read(), string_literal(runtime_label), indices_id,
-                         leaf_deref_id}},
+                        mir::Direct{.target = support::BuiltinFn::kAttachChild},
+                    .arguments = {self_read(), leaf_deref_id}},
             .type = builtins.void_type});
     block.AppendStmt(
         mir::Stmt{
-            .label = std::nullopt, .data = mir::ExprStmt{.expr = register_id}});
+            .label = std::nullopt, .data = mir::ExprStmt{.expr = attach_id}});
     return;
   }
 
@@ -821,14 +828,15 @@ void ValidateOwnedChildConstruction(
 }
 
 // Lowers an owned-child construction site to the explicit MIR call shape:
-// `make_unique<Child>(self, label, services, ctor_args...)` produces the
-// child instance and `RegisterChild(self, label, indices, *child)` records
-// it on the parent for by-name lookup. A scalar member assigns the unique
-// pointer to its slot; a vector member emplaces into the storage vector and
-// the register call reaches the just-pushed element through `vector_back`.
-// `arm_frame` must point at the block where the stmts land and carry the
-// correct hop count to `self` (the parent constructor's first local) for
-// the lowering site's depth.
+// `make_unique<Child>(self, HierarchySegment{label, indices}, services,
+// ctor_args...)` produces the child instance carrying its complete
+// hierarchy identity, then `AttachChild(self, *child)` wires the parent
+// edge for traversal and by-name lookup. A scalar member assigns the
+// unique pointer to its slot; a vector member emplaces into the storage
+// vector and the attach call reaches the just-pushed element through
+// `vector_back`. `arm_frame` must point at the block where the stmts land
+// and carry the correct hop count to `self` (the parent constructor's
+// first local) for the lowering site's depth.
 void AppendOwnedChildConstruction(
     ModuleLowerer& module, const WalkFrame& arm_frame, mir::MemberId target_var,
     mir::ClassId child_scope_id, std::vector<mir::ExprId> ctor_args,
@@ -871,10 +879,35 @@ void AppendOwnedChildConstruction(
     return arm_block.exprs.Add(MakeSelfRefExpr(arm_frame, self_ptr_type));
   };
 
+  // Build the child's structural identity once and pass it as the child's
+  // own ctor argument. The child holds onto it from the moment its
+  // constructor returns; %m, by-name lookup, and debug traces all read
+  // from that single source. A scalar member yields an empty index list;
+  // a vector member yields a one-entry list with the iteration's induction
+  // value; a multi-dim member would extend it per axis.
+  std::vector<mir::ExprId> index_elems;
+  if (array_index.has_value()) {
+    index_elems.push_back(*array_index);
+  }
+  const mir::TypeId indices_type = module.Unit().AddType(
+      mir::UnpackedArrayType{
+          .element_type = builtins.int32, .size = index_elems.size()});
+  const mir::ExprId indices_id = arm_block.exprs.Add(
+      mir::Expr{
+          .data = mir::ArrayLiteralExpr{.elements = std::move(index_elems)},
+          .type = indices_type});
+  const mir::ExprId segment_id = arm_block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee = mir::Construct{},
+                  .arguments = {string_literal(runtime_label), indices_id}},
+          .type = builtins.hierarchy_segment});
+
   std::vector<mir::ExprId> ctor_call_args;
   ctor_call_args.reserve(3 + ctor_args.size());
   ctor_call_args.push_back(self_read());
-  ctor_call_args.push_back(string_literal(runtime_label));
+  ctor_call_args.push_back(segment_id);
   ctor_call_args.push_back(
       arm_block.exprs.Add(BuildServicesCallExpr(module, arm_frame)));
   for (const mir::ExprId arg : ctor_args) {
@@ -895,9 +928,11 @@ void AppendOwnedChildConstruction(
       mir::MakeMemberAccessExpr(
           self_read(), mir::MemberRef{.var = target_var}, var.type));
 
-  // The child slot we hand to `RegisterChild` is `*self->member` for the
-  // scalar case and `*self->member.back()` for the vector case (the vector
-  // already grew by `push_back` of the just-built pointer).
+  // The child reference we hand to `AttachChild` is `*self->member` for a
+  // scalar slot and `*self->member.back()` for a vector slot (the vector
+  // already grew by `push_back` of the just-built pointer). Attach runs
+  // after the typed owner commits, so a thrown subobject ctor leaves no
+  // half-attached scope in the parent's child relation.
   mir::ExprId child_ref_id{};
   if (std::holds_alternative<mir::VectorType>(
           module.Unit().GetType(var.type).data)) {
@@ -952,36 +987,18 @@ void AppendOwnedChildConstruction(
             .type = std::get<mir::PointerType>(child_ptr_data).pointee});
   }
 
-  // Index array argument: an empty `UnpackedArray<int32, 0>` for a scalar
-  // member, a single-element array carrying the loop-induction value for a
-  // vector member. The runtime walks the span and calls `.ToInt64()` per
-  // entry, matching the `kGetChild` by-name lookup signature.
-  std::vector<mir::ExprId> index_elems;
-  if (array_index.has_value()) {
-    index_elems.push_back(*array_index);
-  }
-  const mir::TypeId indices_type = module.Unit().AddType(
-      mir::UnpackedArrayType{
-          .element_type = builtins.int32, .size = index_elems.size()});
-  const mir::ExprId indices_id = arm_block.exprs.Add(
-      mir::Expr{
-          .data = mir::ArrayLiteralExpr{.elements = std::move(index_elems)},
-          .type = indices_type});
-
-  const mir::ExprId register_call_id = arm_block.exprs.Add(
+  const mir::ExprId attach_call_id = arm_block.exprs.Add(
       mir::Expr{
           .data =
               mir::CallExpr{
                   .callee =
-                      mir::Direct{.target = support::BuiltinFn::kRegisterChild},
-                  .arguments =
-                      {self_read(), string_literal(runtime_label), indices_id,
-                       child_ref_id}},
+                      mir::Direct{.target = support::BuiltinFn::kAttachChild},
+                  .arguments = {self_read(), child_ref_id}},
           .type = builtins.void_type});
   arm_block.AppendStmt(
       mir::Stmt{
           .label = std::nullopt,
-          .data = mir::ExprStmt{.expr = register_call_id}});
+          .data = mir::ExprStmt{.expr = attach_call_id}});
 }
 
 // The for-stmt body block is one level below the parent constructor block where
@@ -1176,9 +1193,9 @@ auto LowerLoopGenerate(
 
   // The induction variable feeds two slots: as a structural-param ctor arg
   // (so each generated child binds its `genvar` per LRM 27.4) and as the
-  // array index `RegisterChild` records (so a hierarchical lookup `c[i]`
-  // reaches the same slot). Build two fresh reads so each consumer reaches
-  // the loop local through its own MIR node.
+  // index entry the child's `HierarchySegment` carries (so a hierarchical
+  // lookup `c[i]` reaches the same slot). Build two fresh reads so each
+  // consumer reaches the loop local through its own MIR node.
   std::vector<mir::Expr> body_args;
   body_args.push_back(MakeForBodyInductionVarArg(loop_local_id, genvar_type));
   mir::Expr array_index_arg =
@@ -1286,6 +1303,7 @@ auto ClassLowerer::Run(
                                  : mir::RuntimeBaseClass::kGenScope,
       .self_pointer_type = self_pointer_type,
       .time_resolution = hir_scope.time_resolution,
+      .ctor_prefix_params = {},
       .params = {},
       .members = {},
       .constructor_block = {},
@@ -1295,6 +1313,21 @@ auto ClassLowerer::Run(
       .nested_classes = {},
       .methods = {},
       .type_aliases = {}};
+
+  // The runtime Scope-base contract: every Scope-derived class takes the
+  // parent pointer, its own HierarchySegment, and the engine services
+  // handle as the first three ctor params, forwarded straight to the
+  // base. The order and types are the SDK convention; the lowering states
+  // them once here so the render reads them like any other params.
+  if (mir_class.base.has_value()) {
+    const auto& builtins = module.Unit().builtins;
+    mir_class.ctor_prefix_params.Add(
+        mir::ParamDecl{.name = "parent", .type = builtins.scope_ptr});
+    mir_class.ctor_prefix_params.Add(
+        mir::ParamDecl{.name = "segment", .type = builtins.hierarchy_segment});
+    mir_class.ctor_prefix_params.Add(
+        mir::ParamDecl{.name = "services", .type = builtins.services});
+  }
   for (const auto& alias : hir_scope.type_aliases) {
     mir_class.type_aliases.push_back(
         mir::TypeAliasDecl{

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -19,11 +19,13 @@
 #include "lyra/hir/procedural_body.hpp"
 #include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/runtime_print.hpp"
 #include "lyra/mir/stmt.hpp"
 #include "lyra/mir/type.hpp"
+#include "lyra/support/builtin_fn.hpp"
 #include "lyra/support/format.hpp"
 
 namespace lyra::lowering::hir_to_mir {
@@ -105,10 +107,33 @@ auto BuildPrintItemFromDirective(
     case support::FormatDirectiveKind::kLiteral:
       return mir::RuntimePrintLiteral{.text = directive.literal};
 
-    case support::FormatDirectiveKind::kModulePath:
-      return diag::Fail(
-          span, diag::DiagCode::kFormatModulePathNotImplemented,
-          "format specifier %m is not yet supported");
+    case support::FormatDirectiveKind::kModulePath: {
+      // LRM 21.2.1.1: the hierarchical name of the enclosing scope. Reach it
+      // through `self`, the body's first binding -- the same receiver pattern
+      // every other scope-method call uses. A deferred caller ($strobe, NBA)
+      // captures `self` via the closure builder, so a delayed fire still
+      // reads the issuing scope's path. The directive carries no operand, so
+      // the print loop's value_index is untouched; the receiver's modifiers
+      // ride through the string-format spec like an ordinary `%s` argument.
+      auto& block = *frame.current_block;
+      const auto& builtins = process.Module().Unit().builtins;
+      const mir::ExprId self_id = block.exprs.Add(
+          MakeSelfRefExpr(frame, frame.current_class->self_pointer_type));
+      const mir::ExprId path_id = block.exprs.Add(
+          mir::Expr{
+              .data =
+                  mir::CallExpr{
+                      .callee =
+                          mir::Direct{
+                              .target = support::BuiltinFn::kHierarchicalPath},
+                      .arguments = {self_id}},
+              .type = builtins.string});
+      return mir::RuntimePrintValue(
+          path_id, builtins.string,
+          mir::FormatSpec(
+              value::FormatKind::kString,
+              ToMirFormatModifiers(directive.modifiers)));
+    }
 
     case support::FormatDirectiveKind::kTime:
     case support::FormatDirectiveKind::kChar:

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -193,6 +193,8 @@ class MirDumper {
                   return "RuntimeLibrary(ChannelCancellation)";
                 case RuntimeLibraryKind::kTimeFormat:
                   return "RuntimeLibrary(TimeFormat)";
+                case RuntimeLibraryKind::kHierarchySegment:
+                  return "RuntimeLibrary(HierarchySegment)";
               }
               throw InternalError("dump: unknown RuntimeLibraryKind");
             },

--- a/src/lyra/runtime/engine.cpp
+++ b/src/lyra/runtime/engine.cpp
@@ -42,12 +42,14 @@ void Engine::BindDesign(std::span<const TopBinding> tops) {
     throw InternalError("Engine::BindDesign called more than once");
   }
   bound_ = true;
-  root_ = std::make_unique<Scope>(nullptr, "$root", services_);
+  root_ = std::make_unique<Scope>(
+      nullptr, HierarchySegment{"$root", {}}, services_);
   for (const auto& top : tops) {
-    root_->AddChild(*top.scope);
-    // A `$root`-anchored absolute path descends from the root by name, so the
-    // root answers GetChild for each top under its name (LRM 23.6).
-    root_->RegisterChild(top.scope->Name(), {}, *top.scope);
+    // A `$root`-anchored absolute path descends from the root by name, so
+    // the root answers GetChild for each top under its segment (LRM 23.6).
+    // AttachChild reads the top's own Segment() -- the base name set when
+    // main constructed it -- and uses that as the lookup key.
+    root_->AttachChild(*top.scope);
   }
   // Link every top before any phase runs, so an upward climb during resolution
   // sees the whole tree (the root and all sibling tops already exist). The

--- a/src/lyra/runtime/hierarchy_segment.cpp
+++ b/src/lyra/runtime/hierarchy_segment.cpp
@@ -1,0 +1,17 @@
+#include "lyra/runtime/hierarchy_segment.hpp"
+
+#include <string>
+
+namespace lyra::runtime {
+
+auto HierarchySegment::Display() const -> std::string {
+  std::string out(base_name_);
+  for (const auto& idx : indices_) {
+    out.push_back('[');
+    out.append(std::to_string(idx.ToInt64()));
+    out.push_back(']');
+  }
+  return out;
+}
+
+}  // namespace lyra::runtime

--- a/src/lyra/runtime/scope.cpp
+++ b/src/lyra/runtime/scope.cpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <ranges>
 #include <span>
 #include <string>
 #include <string_view>
@@ -18,43 +19,23 @@
 
 namespace lyra::runtime {
 
-Scope::Scope(Scope* parent, std::string name, RuntimeServices& services)
-    : parent_(parent), name_(std::move(name)), services_(&services) {
-  if (parent_ != nullptr) {
-    parent_->AddChild(*this);
-  }
+Scope::Scope(Scope* parent, HierarchySegment segment, RuntimeServices& services)
+    : parent_(parent), segment_(std::move(segment)), services_(&services) {
 }
 
-void Scope::AddChild(Scope& child) {
-  // Linking establishes the full bidirectional edge. A child built under a
-  // parent already set `parent_` in its constructor; a top-level block is
-  // constructed parentless and adopts `$root` as its parent here, so an
-  // upward climb from inside a top reaches the root (LRM 23.6).
+void Scope::AttachChild(Scope& child) {
   child.parent_ = this;
-  children_.push_back(&child);
+  attached_children_.push_back(&child);
 }
 
 void Scope::ForEachChild(const ChildVisitor& fn) {
-  for (Scope* child : children_) {
+  for (Scope* child : attached_children_) {
     fn(*child);
   }
 }
 
 void Scope::RegisterSignal(std::string_view name, void* address) {
   signals_.push_back(SignalEntry{.name = name, .address = address});
-}
-
-void Scope::RegisterChild(
-    std::string_view name, std::span<const lyra::value::PackedArray> indices,
-    Scope& child) {
-  std::vector<std::size_t> host_indices;
-  host_indices.reserve(indices.size());
-  for (const auto& idx : indices) {
-    host_indices.push_back(static_cast<std::size_t>(idx.ToInt64()));
-  }
-  child_entries_.push_back(
-      ChildEntry{
-          .name = name, .indices = std::move(host_indices), .scope = &child});
 }
 
 auto Scope::GetSignal(std::string_view name) -> void* {
@@ -69,19 +50,24 @@ auto Scope::GetSignal(std::string_view name) -> void* {
 auto Scope::GetChild(
     std::string_view name, std::span<const lyra::value::PackedArray> indices)
     -> Scope* {
-  for (const ChildEntry& child : child_entries_) {
-    if (child.name != name || child.indices.size() != indices.size()) {
+  for (Scope* child : attached_children_) {
+    const HierarchySegment& seg = child->segment_;
+    if (seg.BaseName() != name) {
+      continue;
+    }
+    const auto child_indices = seg.Indices();
+    if (child_indices.size() != indices.size()) {
       continue;
     }
     bool matched = true;
     for (std::size_t i = 0; i < indices.size(); ++i) {
-      if (child.indices[i] != static_cast<std::size_t>(indices[i].ToInt64())) {
+      if (child_indices[i].ToInt64() != indices[i].ToInt64()) {
         matched = false;
         break;
       }
     }
     if (matched) {
-      return child.scope;
+      return child;
     }
   }
   return nullptr;
@@ -91,8 +77,37 @@ auto Scope::Parent() const -> Scope* {
   return parent_;
 }
 
+auto Scope::Segment() const -> const HierarchySegment& {
+  return segment_;
+}
+
+auto Scope::DisplaySegment() const -> std::string {
+  return segment_.Display();
+}
+
 auto Scope::Name() const -> std::string_view {
-  return name_;
+  return segment_.BaseName();
+}
+
+auto Scope::HierarchicalPath() const -> lyra::value::String {
+  // Each segment is the scope's own LRM display form (carrying any per-dim
+  // bracketed index it acquired at construction). Stopping at
+  // `parent_ == nullptr` drops the implicit `$root` from the joined output
+  // -- the root anchors top-level adoption but is not part of a
+  // user-visible hierarchical path.
+  std::vector<std::string> parts;
+  for (const Scope* cur = this; cur != nullptr && cur->parent_ != nullptr;
+       cur = cur->parent_) {
+    parts.push_back(cur->segment_.Display());
+  }
+  std::string out;
+  for (const std::string& part : std::views::reverse(parts)) {
+    if (!out.empty()) {
+      out.push_back('.');
+    }
+    out.append(part);
+  }
+  return lyra::value::String(std::move(out));
 }
 
 void Scope::Resolve() {

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -291,8 +291,8 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "as_observable";
     case BuiltinFn::kRegisterSignal:
       return "register_signal";
-    case BuiltinFn::kRegisterChild:
-      return "register_child";
+    case BuiltinFn::kAttachChild:
+      return "attach_child";
     case BuiltinFn::kGetSignal:
       return "get_signal";
     case BuiltinFn::kGetChild:
@@ -401,6 +401,8 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "reduction_xnor";
     case BuiltinFn::kFromBool:
       return "from_bool";
+    case BuiltinFn::kHierarchicalPath:
+      return "hierarchical_path";
   }
   throw InternalError("BuiltinFnName: unknown BuiltinFn");
 }

--- a/tests/cases/cpp/percent_m_hierarchical_name/case.yaml
+++ b/tests/cases/cpp/percent_m_hierarchical_name/case.yaml
@@ -1,0 +1,18 @@
+id: cpp.percent_m_hierarchical_name
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      top=Top
+      mid=Top.m
+      leaf=Top.m.l
+      gblk=Top.m.gblk
+      loop=Top.m.loop[0]
+      c0=100 c1=200 g0=10 g1=11
+      strobe=Top

--- a/tests/cases/cpp/percent_m_hierarchical_name/main.sv
+++ b/tests/cases/cpp/percent_m_hierarchical_name/main.sv
@@ -1,0 +1,48 @@
+module Leaf;
+  initial begin
+    #2 $display("leaf=%m");
+  end
+endmodule
+
+module Mid;
+  Leaf l();
+  initial begin
+    #1 $display("mid=%m");
+  end
+  generate
+    if (1) begin : gblk
+      initial begin
+        #3 $display("gblk=%m");
+      end
+    end
+    for (genvar i = 0; i < 1; i = i + 1) begin : loop
+      initial begin
+        #4 $display("loop=%m");
+      end
+    end
+  endgenerate
+endmodule
+
+module Cell;
+  int v;
+endmodule
+
+module Top;
+  Mid m();
+  Cell c[2]();
+  generate
+    for (genvar i = 0; i < 2; i = i + 1) begin : g
+      int x = i + 10;
+    end
+  endgenerate
+  initial begin
+    $display("top=%m");
+    #5;
+    c[0].v = 100;
+    c[1].v = 200;
+    $display("c0=%0d c1=%0d g0=%0d g1=%0d",
+             c[0].v, c[1].v, g[0].x, g[1].x);
+    $strobe("strobe=%m");
+    #1;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Lands `%m` (LRM 21.2.1.1) end-to-end and, in the same cut, closes the scope-identity smell `%m` surfaced: a runtime `Scope`'s "what am I" was split between an un-indexed `Name()` on the child and a `RegisterChild(name, indices, scope)` table on the parent, with a parallel `children_` list mirroring topology that typed members already own. After this change a scope receives its complete `HierarchySegment` (source label plus per-dimension elaborated indices) at construction, `%m` walks the parent chain and reads each scope's own display segment, and a single `AttachChild` operation wires the parent edge for both deterministic traversal and by-name lookup.

## Design

`HierarchySegment` lives in the runtime layer as an ordinary value type (`string` plus `vector<value::PackedArray>`); MIR carries it as a new `RuntimeLibraryKind` so the lowering can build a segment as a regular `Construct` call and forward it through MIR primitives, and `RenderTypeAsCpp` is the one place that knows its C++ name. The constructor's prefix args (`parent`, `segment`, `services`) are stated explicitly on `mir::Class::ctor_prefix_params` so the render iterates the full ctor entry list rather than hardcoding three positional concepts. `Scope::AttachChild` replaces the former `AddChild` (auto-called from the child ctor) and `RegisterChild` pair: a single `attached_children_` vector serves both `ForEachChild` traversal and `GetChild(name, indices)` lookup, scanning by comparing each child's own `Segment()`. Architectural invariants in `hierarchy_and_generate.md` are rephrased to forbid the two-write-points shape and to add the new "scope identity is structural and complete at construction" rule.

`RenderConstructor` is now generic over the param list -- it emits each param's type via `RenderTypeAsCpp` and forwards prefix args to the base by pure name pass-through, with no `std::move` and no switching on type kind. This costs one `HierarchySegment` copy per scope construction (a one-time cost not in any hot path); R51 tracks the principled close where `mir::Class::constructor_block` becomes a `MethodDecl` and the render shares the generic method renderer.

## Testing

New `tests/cases/cpp/percent_m_hierarchical_name` covers `%m` at every scope shape: top-level, child module, grandchild, named generate-if, generate-for iteration with indexed name, `\$strobe` capturing the issuing scope, and cross-unit `GetChild` lookups across an instance array and a multi-iteration generate-for (verifying the merged `attached_children_` distinguishes `loop[0]` from `loop[1]`). Full `bazel test //...` passes; format and policy checks clean.