### PR TITLE
Establish object model and generic base reference

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -22,21 +22,23 @@ Read top to bottom on first pass:
 8. `mir.md` -- object-oriented semantic IR (objects, members, callables)
 9. `callable.md` -- the one callable concept; callable code vs callable value; capture model;
    references as a field type
-10. `lir.md` -- execution-oriented IR (CFG, basic blocks, storage)
-11. `activation.md` -- the runtime execution instance; completion slot; ownership / continuation /
+10. `object_model.md` -- the one nominal object model; module / scope / class as one object type;
+    inheritance, dispatch, construction, references and handles
+11. `lir.md` -- execution-oriented IR (CFG, basic blocks, storage)
+12. `activation.md` -- the runtime execution instance; completion slot; ownership / continuation /
     cancellation relations
-12. `scheduling.md` -- stratified event scheduler, regions, suspension protocol
-13. `hierarchy_and_generate.md` -- hierarchy and generate ownership
-14. `reference_resolution.md` -- intra-unit vs cross-unit references; compile-time vs
+13. `scheduling.md` -- stratified event scheduler, regions, suspension protocol
+14. `hierarchy_and_generate.md` -- hierarchy and generate ownership
+15. `reference_resolution.md` -- intra-unit vs cross-unit references; compile-time vs
     construction-time resolution
-15. `emission_model.md` -- how a backend emits independent per-unit artifacts and realizes
+16. `emission_model.md` -- how a backend emits independent per-unit artifacts and realizes
     cross-unit resolution through the SDK
-16. `identity_and_ownership.md` -- identity rules and forbidden shapes
-17. `lowering_boundaries.md` -- what each lowering may and may not do
-18. `lowering_organization.md` -- how lowering passes organize their internal objects (facts,
+17. `identity_and_ownership.md` -- identity rules and forbidden shapes
+18. `lowering_boundaries.md` -- what each lowering may and may not do
+19. `lowering_organization.md` -- how lowering passes organize their internal objects (facts,
     registries, builders, walk frame)
-19. `incremental_build.md` -- query-based incremental compilation and caching
-20. `testing_strategy.md` -- test categories and structure
+20. `incremental_build.md` -- query-based incremental compilation and caching
+21. `testing_strategy.md` -- test categories and structure
 
 ## Concept Index
 
@@ -62,6 +64,7 @@ If you are looking for a concept, this table points to the canonical doc.
 | MIR shape (objects, members, callables)                                   | `mir.md`                    |
 | Member and type model; object types; owning pointer; vector wrapper       | `mir.md`                    |
 | Callable model; code vs value; captures; references as a field type       | `callable.md`               |
+| Object model; nominal object types; inheritance; dispatch; handles        | `object_model.md`           |
 | LIR shape (CFG, basic blocks, storage)                                    | `lir.md`                    |
 | Activation; execution instance; completion slot; cancellation domain      | `activation.md`             |
 | Stratified scheduler; regions; suspension protocol; NBA / closure submit  | `scheduling.md`             |
@@ -87,6 +90,7 @@ it compiles and passes tests.
 | Compilation boundaries / unit dependencies / incrementality  | `north_star`, `compilation_unit_model`, `incremental_build`                                               |
 | Hierarchy / generate / object graph / construction           | `north_star`, `hierarchy_and_generate`, `runtime_model`, `elaboration_lifecycle`                          |
 | Identity / ownership / id kinds                              | `north_star`, `identity_and_ownership`                                                                    |
+| Object model / classes / inheritance / dispatch / handles    | `north_star`, `object_model`, `mir`, `callable`, `runtime_model`                                          |
 
 The failure mode this guards against: anchoring on current code -- which may be a transitional
 shortcut -- instead of the contract. Current code that contradicts a contract is wrong; read the

--- a/docs/architecture/callable.md
+++ b/docs/architecture/callable.md
@@ -52,12 +52,14 @@ closure is code plus a captured environment, and "async" is the result type (`as
    callable value's construction, not to a code declaration; one body can take different bound
    environments._
 
-2. **`self` is the code's first parameter.** Every callable body reaches its enclosing object's
-   members through `self`, the code's first ordinary parameter, read as `body.vars[0]` by every
-   member access. A callable value binds `self` into its environment; a direct call supplies it per
-   invocation. Whether a bound `self` is realized as a passed parameter or a captured field is a
-   backend realization driven by lifetime, not a MIR distinction. _Consequence: there is no
-   privileged `self` capture slot and no per-form receiver mechanism; `self` is uniform._
+2. **`self` is an instance method's first parameter.** Every instance-method body reaches its
+   enclosing object's members through `self`, the code's first ordinary parameter, read as
+   `body.vars[0]` by every member access. A callable value binds `self` into its environment; a
+   direct call supplies it per invocation. Whether a bound `self` is realized as a passed parameter
+   or a captured field is a backend realization driven by lifetime, not a MIR distinction. A
+   type-associated (static) function has no receiver and no `self`. _Consequence: there is no
+   privileged `self` capture slot and no per-form receiver mechanism; `self` is uniform across
+   instance methods, and a static function simply omits it._
 
 3. **The result type is the call protocol.** A coroutine result type means the callable is entered
    and completed through the coroutine protocol -- the invocation yields a coroutine object the site

--- a/docs/architecture/mir.md
+++ b/docs/architecture/mir.md
@@ -120,20 +120,22 @@ suspect, not the analysis (`lowering_organization.md` states this discipline in 
     instead. The primitive set does grow, but only for a genuinely new generic-language concept,
     never to model a backend / library / sugar shape (see Owns). _Programming-language consequence:
     the program text is the program; consumers do not invent vocabulary the language does not have._
-11. Every callable body's first binding is `self`, a pointer to its enclosing class --
-    `body.vars[0]` is a local declaration of that pointer type, named `self`. Access to any class
+11. Every instance-method callable body's first binding is `self`, a pointer to its enclosing class
+    -- `body.vars[0]` is a local declaration of that pointer type, named `self`. Access to any class
     member -- a member variable, a service call, a child instance -- flows through `MemberAccess`
-    whose receiver expression reaches the class by traversing from `self`. A callable has no
+    whose receiver expression reaches the class by traversing from `self`. An instance method has no
     implicit access to its enclosing state; the receiver is reached through an explicit binding,
     never through an expression that means "look around and figure it out". `self` is uniform across
-    every callable: it is the code's first parameter, read as `vars[0]` the same way in every body,
-    and a callable value binds it like any other environment field. `callable.md` is the canonical
-    callable contract.
+    every instance method: it is the code's first parameter, read as `vars[0]` the same way in every
+    body, and a callable value binds it like any other environment field. A type-associated (static)
+    function has no receiver and no `self` binding; the receiver is a property of an instance
+    method, not of every callable. `object_model.md` owns the receiver rule; `callable.md` is the
+    canonical callable contract.
 
-    _Programming-language consequence: methods take `self` explicitly. This is the C++ `this`, the
-    Python `self`, the Rust `&self`. Languages that hide it behind keyword sugar at source level
-    still expose it explicitly in their IRs (LLVM IR's first parameter, Python's
-    `__call__(self, ...)`); MIR does the same._
+    _Programming-language consequence: instance methods take `self` explicitly. This is the C++
+    `this`, the Python `self`, the Rust `&self`. Languages that hide it behind keyword sugar at
+    source level still expose it explicitly in their IRs (LLVM IR's first parameter, Python's
+    `__call__(self, ...)`); MIR does the same. A static method, like a free function, takes none._
 
 ## Boundary to Adjacent Layers
 

--- a/docs/architecture/object_model.md
+++ b/docs/architecture/object_model.md
@@ -1,0 +1,214 @@
+# Object Model
+
+## Purpose
+
+The object model is MIR's one shape for a nominal object type. A module instance, a generate scope,
+and a SystemVerilog class are the same kind of entity: a named type with fields, methods, a base
+lineage, and a construction protocol. They are not three object systems sharing some helpers; they
+are one object system whose members differ only in which base they extend, which reference reaches
+their instances, and which lifecycle they participate in.
+
+The model is generic object-oriented -- its peers are the class systems of C++, Rust, and Python --
+not a SystemVerilog construct and not a C++ class. SystemVerilog `class`, `extends`, `virtual`,
+`interface class`, and `new` flow in through HIR and are translated into this generic vocabulary at
+HIR-to-MIR; a module read as a class (see `runtime_model.md`) is the same translation from the other
+direction. The governing thesis:
+
+> One nominal-object reference, one generic declaration-level override relation, and one
+> construction model. Compilation-unit boundaries determine how an object type's identity is
+> represented, never its semantic category.
+
+## Owns
+
+- The nominal object type declaration: a name, instance fields, instance methods, an optional single
+  concrete base, a set of interface conformances, and an associated namespace of type-level members.
+- The nominal object reference: how one object type names another -- as a base, a field's pointee, a
+  receiver type, a constructed type -- carrying identity whose representation follows the
+  compilation-unit boundary.
+- The reference kinds that reach an object instance and the lifetime / reachability each denotes:
+  owning, borrowed, shared, and managed.
+- The construction model: allocation, the constructor, and optional base-constructor chaining, as a
+  concept distinct from an ordinary callable.
+- The dispatch model: the override relation between a method and the base method it overrides, the
+  logical dispatch slot, and the virtual and interface call forms.
+- The receiver rule: an instance method carries a receiver; a type-associated (static) function does
+  not.
+- Type-associated storage and type-associated functions (static properties and static methods).
+- Runtime-tree participation as a base-lineage fact: an object that extends the runtime scope base
+  is a node in the runtime object tree and participates in the elaboration lifecycle.
+- The unit-wide registry of local nominal object declarations, the single canonical local identity
+  of each, and the separation of that identity from lexical name resolution and from backend
+  emission nesting.
+
+## Does Not Own
+
+- The value-type system (integral, real, string, aggregates) and the non-object wrappers. Those are
+  `mir.md`. The object model is the object half of MIR's type system; the value half stays there.
+- The callable concept -- callable code versus value, the result type as call protocol, the
+  environment and capture model. That is `callable.md`. Methods and constructors are callables; the
+  object model uses them and does not redefine them.
+- The ordering of the elaboration phases (build, resolve, initialize, activate) and when each runs.
+  That is `elaboration_lifecycle.md`. The object model states that the lifecycle bodies are method
+  overrides; that doc states when they execute.
+- The runtime object tree's shape and its faithfulness to elaboration. That is
+  `hierarchy_and_generate.md`.
+- When and into what a cross-unit reference resolves, and the by-name mechanism. That is
+  `reference_resolution.md` and `emission_model.md`. The object model states that a cross-unit
+  object reference is by-name; those docs own the resolution.
+- Physical layout: object storage layout, dispatch-table layout, frame allocation, and the
+  realization of managed reachability (reference counting versus tracing collection). Those are LIR
+  and the runtime.
+
+## Core Invariants
+
+1. **One nominal object type.** A module instance, a generate scope, and a SystemVerilog class are
+   one declaration kind -- name, instance fields, instance methods, an optional concrete base,
+   interface conformances, and an associated type-level namespace. There is no second object IR and
+   no flag classifying a declaration as a module versus a class. _Object-model consequence: the
+   differences between these objects are expressed through generic mechanisms -- which base, which
+   reference, which lifecycle -- never through a source-category discriminator on the declaration._
+
+2. **One nominal-object reference; identity representation follows the unit boundary.** Every place
+   one object type names another uses one reference abstraction. Its identity is a stable
+   compiler-owned id when the target is intra-unit, a by-name reference resolved against an imported
+   interface when the target is in another compilation unit, and an imported library declaration
+   when the target is a runtime-library type. Intra-unit and cross-unit identities never share a key
+   space. _Object-model consequence: a consumer resolves any object reference through one entry
+   point; the local-versus-external split lives in the resolver, not in three incompatible reference
+   forms scattered across consumers._
+
+3. **Inheritance is one concrete base plus a set of interface conformances.** The concrete base
+   determines instance layout and constructor chaining; an interface conformance is a method
+   contract that introduces no instance storage. These are two distinct relations, not one list of
+   bases. _Object-model consequence: a class may conform to several interfaces while extending at
+   most one concrete base; the two relations are represented separately because they carry different
+   facts._
+
+4. **The reference reaching an instance carries its lifetime, orthogonal to the object's category.**
+   The kinds are owning (one owner controls the lifetime), borrowed (refers, owns nothing), shared
+   (a reference-counted, acyclic-by-construction owner), and managed (a language-managed object
+   handle: null is a legal value, identity is comparable, copies are shallow, the object is
+   reachable while any handle reaches it, it is created by construction, and it is never explicitly
+   freed). A SystemVerilog class handle is a managed reference, distinct from a shared one. Whether
+   an object is a node in the runtime tree is read from its base lineage, never from the reference
+   kind that reaches it. _Object-model consequence: topology, lifetime, and category are three axes;
+   collapsing any two -- "a unique reference means a tree child", "a class handle is a shared
+   pointer" -- loses a distinction a backend must read._
+
+5. **Construction is its own concept.** Allocating an object and running its constructor, with
+   optional base-constructor chaining and a defined initialization ordering, is a construction form
+   distinct from an ordinary callable. A constructor body may reuse callable-body machinery, but a
+   construction is never represented as a plain call to an ordinary method, and base-constructor
+   ordering is stated, never left to a backend convention. _Object-model consequence: every object
+   -- an owned module child and a heap class object alike -- is built through the one construction
+   form._
+
+6. **Override is a resolved relation; dispatch is by logical slot.** A method that overrides a base
+   method records the overridden method as a resolved declaration reference, never a textual name. A
+   dynamic call names a receiver and a logical dispatch slot; a method introduces, overrides, or
+   finalizes a slot. The slot is a logical identity, not a physical table index. _Object-model
+   consequence: a backend reads the override family and the dispatch target from stated structure;
+   it never re-derives "which method does this override" or "is this call virtual" by matching
+   names, signatures, or receiver types._
+
+7. **The receiver is a property of instance methods only.** An instance method's first binding is
+   its receiver, the pointer to the enclosing object, reached uniformly by every member access. A
+   type-associated function has no receiver. _Object-model consequence: a static method is an
+   associated function called without an instance; no fabricated receiver stands in for "no
+   object"._
+
+8. **Type-associated state is not an instance member.** A static property and a static method belong
+   to the type's associated namespace, shared across instances, not to each instance's field or
+   method set. The instance member is a (name, type) pair; type-associated storage is a separate
+   category. _Object-model consequence: a static property is one cell owned by the type, never a
+   field replicated into every instance._
+
+9. **Managed reachability is the contract; its realization is not.** The model commits to the
+   semantics that a managed object lives while any handle reaches it. Whether a backend realizes
+   that by reference counting or tracing collection, and whether cyclic garbage is reclaimed, are
+   realization choices outside the contract. _Object-model consequence: MIR states "managed
+   reachability" and a backend chooses the mechanism; MIR never states "reference counted" as the
+   meaning._
+
+10. **A compilation unit owns one canonical registry of its local nominal object declarations, and
+    identity, lexical name resolution, and emission nesting are three separate relations.** Every
+    object type -- a module, a generate scope, a class -- is one registry record with one canonical
+    local identity, and a reference names that identity. A lexical scope resolves a source name to
+    an identity; the registry is not a flat global name table. Structural containment (which object
+    builds or owns which) and a backend's emission nesting are separate relations over identities,
+    neither of which is the identity. A forward (incomplete) declaration is a registry record that
+    exists before its body, so mutually-referential and forward-declared types resolve against a
+    stable identity. _Object-model consequence: declarations are owned and identified once,
+    uniformly; lexical position, name, and emission layout are properties read off that identity,
+    never substitutes for it, and one storage serves every object type._
+
+## Boundary to Adjacent Layers
+
+- **Peer to `mir.md` and `callable.md`.** `mir.md` owns the overall MIR shape and the value-type
+  system; this doc owns the object model within it and is the canonical elaboration of MIR's object
+  types. `callable.md` owns the callable concept that methods and constructors are; its receiver
+  rule is the instance-method case of invariant 7, and a type-associated function is the case with
+  no receiver.
+- **HIR carries the source vocabulary.** `class`, `extends`, `virtual`, `interface class`, and `new`
+  survive verbatim in HIR (`hir.md`); HIR-to-MIR translates each into this generic object model.
+- **`elaboration_lifecycle.md` owns when the lifecycle runs.** This doc owns that the
+  post-construction lifecycle bodies are method overrides of the runtime base; that doc owns their
+  phase ordering.
+- **`reference_resolution.md` and `emission_model.md` own cross-unit resolution.** This doc owns
+  that a cross-unit object reference is by-name against an imported interface; those docs own when
+  and how it resolves.
+- **LIR owns physical realization.** Object layout, dispatch-table layout, and the
+  managed-reachability mechanism are introduced below MIR.
+
+## Forbidden Shapes
+
+- A second object IR, or a flag on a declaration classifying it as a module versus a class. The
+  category is expressed through base, reference, and lifecycle. (Invariant 1.)
+- A global object-id space, or a cross-unit object reference that names another unit's internal id
+  rather than its public name. (Invariant 2.)
+- One flat list of bases mixing the concrete base with interface conformances; an interface
+  conformance that introduces instance storage. (Invariant 3.)
+- Deriving runtime-tree membership from a reference's ownership kind. (Invariant 4.)
+- Reaching a SystemVerilog class handle through the shared (reference-counted,
+  acyclic-by-construction) reference instead of the managed reference. (Invariant 4.)
+- Representing construction as a plain call to an ordinary method, or leaving base-constructor
+  ordering to a backend convention. (Invariant 5.)
+- An override recorded as a textual method name; a backend re-deriving the override family by name
+  or signature matching; whether a call is dynamic inferred from the receiver's type rather than
+  stated at the call site. (Invariant 6.)
+- A type-associated function carrying a receiver, or a fabricated receiver standing in for "no
+  instance". (Invariant 7.)
+- A static property modeled as an instance field replicated per object. (Invariant 8.)
+- MIR stating a reference-counted realization, or the absence of cyclic reclamation, as the meaning
+  of a managed reference rather than as a realization detail. (Invariant 9.)
+- Two declaration-storage systems -- one for module and generate-scope objects, another for classes.
+  There is one registry. (Invariant 10.)
+- An object's lexical position or its emission nesting used as its identity; a second local identity
+  inter-convertible with the first. (Invariant 10.)
+- A backend-emission nesting parent stored on the generic object declaration; it is a backend
+  relation derived from structural containment, not a field of the declaration. (Invariant 10.)
+
+## Notes / Examples
+
+A module instance, a generate scope, and a SystemVerilog class differ only along the three generic
+axes:
+
+- A module instance extends the runtime instance base, participates in the elaboration lifecycle,
+  and is reached from its parent by an owning reference.
+- A generate scope extends the runtime generate-scope base, participates in the same lifecycle, and
+  is likewise an owning child.
+- A SystemVerilog class extends another class or no class, is reached by a managed reference, and is
+  built by `new`.
+
+The same field, method, override, and construction machinery serves all three; none has a private
+object system.
+
+The post-construction lifecycle bodies are overrides of the runtime base's lifecycle methods,
+through the same override relation a SystemVerilog `virtual` method uses. There is one override
+machinery: the lifecycle is its first user, a user-defined virtual method is another, and a backend
+renders both the same way.
+
+A static method is an associated function under the type, invoked without an instance. A static
+property is a single cell the type owns, observed identically from every instance. Neither is part
+of an instance's member set, so the instance-member (name, type) rule is never bent to accommodate
+them.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -98,6 +98,12 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
 - [reference-as-data-type](reference-as-data-type.md) -- a reference is a direction at HIR and a
   data type at MIR; one reference type serves both `ref` formals (body local) and `ref` ports (unit
   member), distinct from a borrowed pointer because it preserves the observable-cell protocol.
+- [object-model](object-model.md) -- a module / scope and an SV class are one generic nominal object
+  type; an SV class handle is a managed reference, not the acyclic shared one; the receiver is an
+  instance-method property, not every callable's.
+- [object-model-storage](object-model-storage.md) -- a compilation unit owns one canonical registry
+  of local nominal object declarations; identity, lexical name resolution, and backend emission
+  nesting are separate relations; the lexical-tree-only storage and a second identity are rejected.
 - [elaboration-lifecycle-phases](elaboration-lifecycle-phases.md) -- a generated constructor only
   allocates; SystemVerilog elaboration is a staged build / resolve / initialize / activate protocol,
   with connections declarative until a single resolve phase and initializers running after it;

--- a/docs/decisions/object-model-storage.md
+++ b/docs/decisions/object-model-storage.md
@@ -1,0 +1,94 @@
+# Object model storage: a unit-wide nominal-object registry
+
+Date: 2026-06-25 Status: accepted (one mechanism detail open, noted below)
+
+## Why this decision matters
+
+`../architecture/object_model.md` makes a module, a generate scope, and a SystemVerilog class one
+generic nominal object type. That contract says nothing about **where** those declarations are
+stored or **how** one is identified. The current implementation stores them as a **lexical tree** --
+a top module object owning nested generate-scope objects, resolved by walking the enclosing chain.
+That fits owned, lexically nested generate scopes, but it cannot carry SystemVerilog classes: unit-
+or package-level types that reference one another, forward-declare (LRM 8.27), and are reached from
+anywhere through a handle, with no lexical parent. This decision settles the storage and identity
+model so one model serves every object type, and records why a single registry -- not two storage
+systems, not a second identity -- is the answer.
+
+A related factual correction sharpened the problem: a local object type already has a stable
+unit-local identity today (its type-system id; name resolution compares ids, not strings, and the
+name on an object type is an emission / dump convenience). So the gap is not "string identity"; it
+is that the **declaration storage and lookup model** is lexical-tree-only.
+
+## Decision
+
+A compilation unit owns **one canonical registry of its local nominal object declarations**. Three
+relations the lexical-tree model conflated are kept separate:
+
+- **Canonical identity.** The registry owns every object declaration exactly once and gives each one
+  canonical local identity. There is exactly one local nominal identity per declaration, and a
+  reference -- a base, a field's object type, a receiver, a constructed type -- names that identity.
+- **Lexical name resolution.** A separate lexical scope graph resolves a source name to a registry
+  identity (a unit scope, a module scope, a package scope). The registry is not a flat global name
+  table: "which declaration does `A` name here" is a lexical-scope question, answered against the
+  enclosing scope, not a registry question.
+- **Structural containment and backend emission nesting.** Which object builds or owns which (the
+  runtime object tree) and how a backend nests its emitted code are separate relations over registry
+  identities; neither is the identity. The current nested C++ class emission is preserved by
+  deriving it from the structural relation, not by storing an emission parent on the declaration.
+
+Incomplete (forward) declarations are first-class: a registry record exists before its body, in a
+declared-but-undefined state, so mutually-referential and forward-declared types (LRM 8.27) resolve
+against a stable identity. A parameterized class is a generic declaration plus, per specialization,
+a distinct materialized object record in the registry, its identity aligned with the
+compilation-unit specialization model (a stable id within a unit, a canonical public key across
+units) -- the same "generic declaration plus materialized specializations" shape a parameterized
+module uses.
+
+**One mechanism detail is open.** Whether the canonical local identity is the object type's existing
+type-system id reused directly, or a dedicated object id the object type carries, is pending. The
+**principle** -- one canonical identity, no second inter-convertible id -- is settled; the mechanism
+turns on whether an object declaration has a single canonical type-system id today (it may have
+several content-equal ones, since type interning does not deduplicate). The lean is the dedicated
+id, because the object type's payload is already moving off a name to a direct nominal reference,
+and a dedicated id absorbs those content-equal type-system ids cleanly.
+
+## Rejected alternatives
+
+- **Two declaration-storage systems** (a lexical tree for module / generate-scope objects, a flat
+  table for classes). Every consumer -- reference resolution, base, override, construction, dispatch
+  -- would branch on which storage holds the target, and every later feature (nested classes,
+  interface classes, specializations) widens the split. It contradicts the single generic object
+  model.
+- **The lexical tree as canonical storage and identity.** It cannot express a class with no lexical
+  parent, a mutual reference, or a forward declaration, because resolution is a walk from a lexical
+  position. Identity must not be a lexical position.
+- **A second local identity inter-convertible with the existing one.** Dual identity forces every
+  consumer (base reference, specialization key, dump, incremental rebuild) to choose which is
+  canonical; the duplication has no value. (This is why the open mechanism above resolves to a
+  single identity either way, never both.)
+- **An emission-nesting parent stored on the generic object declaration.** Emission nesting is a C++
+  backend layout decision a future LLVM backend does not need; it is derived from the structural
+  relation, not a field on the declaration.
+
+## Consequences
+
+- The lexical-tree class storage is replaced by a unit-wide registry; generate-scope objects become
+  registry records, with structural containment retained as a relation for construction and for
+  nested emission. This lands as its own slice before SystemVerilog classes (see
+  `../progress/object-model.md`); it is not pulled ahead of the lifecycle-override and construction
+  cuts, and the existing non-registry storage is not flattened as a standalone change (a flatten
+  would alter emitted C++ nesting for no behavioral gain).
+- `object_model.md` invariant 10 states the registry and the three-relation separation as contract.
+- Cross-unit references stay by public name (unit independence); the registry is unit-local.
+
+## Cross-references
+
+- `../architecture/object_model.md` -- the object-model contract; invariant 10 is this decision's
+  contract form.
+- `../architecture/identity_and_ownership.md` -- identity is self-sufficient for resolution and not
+  inferred from position or name; the registry is that self-sufficiency for object declarations.
+- `../architecture/reference_resolution.md`, `../architecture/compilation_unit_model.md` --
+  cross-unit by name; the registry is unit-local.
+- `specialization-identity.md` -- the canonical-key model a parameterized class's specializations
+  align with.
+- `object-model.md` -- the managed-handle and receiver decisions in the same object model.

--- a/docs/decisions/object-model.md
+++ b/docs/decisions/object-model.md
@@ -1,0 +1,75 @@
+# Object model: managed handle, and the receiver is an instance-method property
+
+Date: 2026-06-25 Status: accepted
+
+## Why this decision matters
+
+The object model -- a module instance, a generate scope, and a SystemVerilog class as one generic
+nominal object type -- is a contract in `../architecture/object_model.md`. Most of that model is
+stated there as invariants and forbidden shapes and needs no trade-off record: the shape is the
+shape. Two choices inside it have a plausible alternative that a future reader will re-propose, and
+the contract deliberately states only the rule, not the rejected option. This entry records the two,
+so the rule is not relaxed back into the alternative it was chosen over. The rest of the design
+journey (the two-IR split we declined, an early parallel reference-type hierarchy we drafted and
+withdrew) left no load-bearing residue and is not recorded here.
+
+## Decision 1: a SystemVerilog class handle is a managed reference, not the shared one
+
+The references that reach an object instance are owning, borrowed, shared, and managed. A
+SystemVerilog class handle (LRM 8.3) is the **managed** kind: null is a legal value, identity is
+comparable, copies are shallow, the object is reachable while any handle reaches it, it is created
+by `new`, and it is never explicitly freed.
+
+The tempting alternative is to reuse the existing **shared** reference: it is already present and
+already lowers to a reference-counted pointer, so an SV handle could ride it with no new kind. It is
+rejected because the shared reference is **already committed**, by
+[`lifetime-extended-automatic-scope`](lifetime-extended-automatic-scope.md), to a reference-counted
+DAG that is **acyclic by construction** (an activation owns only data slots, never a process, a
+closure, or a join group, so no ownership cycle can form). SystemVerilog class objects routinely
+form reference cycles -- two handles pointing at each other is ordinary LRM 8 code. Placing cyclic
+object graphs under a reference whose contract promises acyclicity would break that prior decision's
+invariant. The managed kind carries the reachability semantics SystemVerilog classes need; whether a
+backend realizes it by reference counting (the current realization) or tracing collection (a future
+one) is a realization choice, and reclaiming cyclic garbage is not part of the contract.
+
+A second alternative -- a separate parallel object-reference type carrying its own kind and
+nullability axes -- is also rejected: it would fold the deliberately distinct reference type (the
+observable-cell alias of [`reference-as-data-type`](reference-as-data-type.md)), the plain pointer,
+and the observable storage wrapper into one classifier and lose the observable-cell-protocol
+distinction that decision established. The managed kind rides the existing one-level-pointer
+ownership axis instead; nullability stays a value-level fact (a null literal), not a type axis,
+until an analysis that reads it exists.
+
+## Decision 2: the receiver is a property of an instance method, not of every callable
+
+The receiver `self` is an **instance method's** first parameter. A type-associated (static) function
+(LRM 8.10) -- a method called on the type, with no object -- has no receiver and no `self`.
+
+This scopes a prior wording. The callable contract stated that _every_ callable body's first binding
+is `self`; with static methods that becomes false, because a static method has no instance to
+receive. The alternative -- give a static method a fabricated, unused `self` -- is rejected: it
+encodes "there is no instance" as "there is an instance nobody uses," which is semantically false
+and forces every backend and every call site to carry and supply a receiver a static call does not
+have. `mir.md` invariant 11 and `callable.md` invariant 2 are scoped accordingly: an instance method
+has `self`, a static function does not.
+
+## Consequences
+
+- `../architecture/object_model.md` states the managed reference (invariants 4 and 9) and the
+  instance-method receiver rule (invariant 7) as contract; this entry holds the rejected
+  alternatives behind them.
+- `mir.md` invariant 11 and `callable.md` invariant 2 are scoped to instance methods; a static
+  function is the no-receiver callable.
+- The managed reference is the SystemVerilog class handle's reference kind, distinct from the shared
+  (acyclic, reference-counted) one; cyclic class garbage is not yet reclaimed, and that is a
+  realization gap, not a semantic commitment.
+
+## Cross-references
+
+- `../architecture/object_model.md` -- the object-model contract these two choices sit inside.
+- `lifetime-extended-automatic-scope.md` -- the shared reference's acyclic-DAG contract that
+  Decision 1 declines to violate.
+- `reference-as-data-type.md` -- the observable-cell reference type Decision 1 declines to fold
+  away.
+- `../architecture/callable.md`, `../architecture/mir.md` -- the receiver invariants Decision 2
+  scopes.

--- a/docs/progress/object-model.md
+++ b/docs/progress/object-model.md
@@ -1,0 +1,96 @@
+# Object Model
+
+Build one generic object model and put SystemVerilog class support on it. Module / scope objects and
+SystemVerilog classes (LRM 8) are the same generic nominal object type -- fields, methods,
+inheritance, dynamic dispatch, construction -- differing only by which base they extend, which
+reference reaches their instances, and which lifecycle they participate in. Done when the last item
+lands: a SystemVerilog class with fields, `new`, single inheritance, dynamic dispatch, interface
+conformance, static members, and parameterization is supported, and module / scope objects share the
+same object model with no separate object IR.
+
+The converged design (the contract and the resolved trade-offs) lives in `../architecture` and
+`../decisions`; see Cross-references. Items here are the staged implementation; they say what shape
+each stage establishes, not how.
+
+## Sub-Steps
+
+- [ ] An object's base is one generic nominal-object reference -- a runtime-library, intra-unit, or
+      cross-unit base -- rendered through one path, not a closed runtime-base classification. A
+      runtime-library base is an imported library declaration; a cross-unit base stays a by-name
+      reference. Behavior-neutral: the emitted module shape is unchanged. (A local object type
+      already carries a stable unit-local identity today, so a separate intra-unit id is not this
+      step; that identity becomes the registry's canonical id below. Runtime-tree membership is read
+      adequately from how a member is owned today; a base-lineage read is a later purity refinement,
+      not done as a standalone non-neutral change.)
+
+- [ ] Each post-construction lifecycle body (the scope's resolve / initialize / activate work) is an
+      ordinary method that records, as a first-class fact, which runtime-base method it overrides --
+      a resolved declaration reference, not a textual name. The per-phase special fields on the
+      object declaration are gone. The full dynamic-dispatch slot machinery is not introduced here;
+      only the override relation. Behavior-neutral.
+
+- [ ] Object construction -- including a module's owned children -- is one generic construction form
+      that allocates the object and runs its constructor, with optional base-constructor chaining.
+      Construction is a concept distinct from an ordinary callable, carrying allocation and
+      initialization ordering. The existing module-child construction is expressed through it.
+
+- [ ] A compilation unit owns one canonical registry of its local nominal object declarations: every
+      object type -- module, generate scope, class -- is one record with one canonical local
+      identity a reference names; a lexical scope resolves a name to an identity; structural
+      containment and backend emission nesting are separate relations over identities. A forward
+      (incomplete) declaration is a record that exists before its body, so mutually-referential and
+      forward-declared types resolve. The current lexical-tree object storage becomes
+      registry-backed, with structural containment retained for construction and for nested
+      emission. This lands before SystemVerilog classes; it is not a standalone flatten of the
+      existing storage.
+
+- [ ] A SystemVerilog class is the same generic object type, reached through a managed object
+      reference: nullable as a value, identity-comparable, shallow-copied, participating in managed
+      reachability, allocated by `new`, never explicitly freed -- distinct from an owning, a
+      borrowed, and a shared reference. The reachability semantics are the contract; a
+      reference-counted realization is not part of it, and cyclic garbage is not yet reclaimed.
+      Minimal surface: fields, `new`, direct instance-method call, handle equality against another
+      handle and against null.
+
+- [ ] Class inheritance: a single concrete base, `super` and the base-constructor call, and dynamic
+      dispatch through logical method slots -- a method introduces, overrides, or finalizes a slot,
+      and a virtual call names a receiver and a slot rather than a fixed callee. Pure-virtual /
+      abstract classes. The override relation established earlier feeds slot inheritance.
+
+- [ ] Interface-class conformance: a class may conform to several interfaces, a relation distinct
+      from its single concrete base and carrying no second instance storage. Type-associated static
+      storage and static methods, where a static method has no receiver. Parameterized-class
+      specialization: a generic declaration plus, per specialization, a distinct materialized object
+      record, its identity aligned with compilation-unit specialization (a stable id within a unit,
+      a by-name canonical key across units) -- the same shape a parameterized module uses.
+
+## Open Questions and Deferred Choices
+
+- Nullability stays a value-level fact, not a type axis, until an analysis that reads it (e.g.
+  static null-safety) exists.
+- The reference-representation axis gains a managed kind whose name no longer reads as pure
+  ownership; renaming that axis is deferred to when the managed kind lands.
+- Renaming the object declaration to a name that reads as generic (it will hold both modules and
+  SystemVerilog classes) is a separate mechanical change, deferred until it holds both. The registry
+  slice is its natural home.
+- The registry's canonical local identity is either the object type's existing type-system id
+  reused, or a dedicated object id the object type carries. The principle (one identity, no second
+  inter-convertible id) is settled; the mechanism is pending whether an object declaration has a
+  single canonical type-system id today (type interning does not deduplicate, so it may have several
+  content-equal ones). The lean is the dedicated id.
+
+## Cross-references
+
+- `../architecture/object_model.md` -- the object-model contract: the one nominal-object reference,
+  the override relation, the construction model, the reference kinds, and the registry (invariant
+  10).
+- `../architecture/mir.md`, `../architecture/callable.md`, `../architecture/runtime_model.md`,
+  `../architecture/elaboration_lifecycle.md` -- the contracts this work satisfies and that the
+  object model doc is a peer to.
+- `../decisions/object-model.md` -- the managed-reference and instance-method-receiver trade-offs.
+- `../decisions/object-model-storage.md` -- the unit-wide registry, the single canonical identity,
+  and the identity / lexical-scope / emission-nesting separation.
+- `../decisions/unified-callable-model.md` -- the callable contract this rides on; virtual
+  dispatch's forward-looking shape is settled there.
+- `refactor.md` R47 (the object-model design that this workstream implements) and R8e (external
+  callable and virtual dispatch, realized here).

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -134,9 +134,10 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
         (per-instance, generate-dependent), with `initial` and `final` as distinct lifecycle
         registrations. `ProcessKind` is removed.
 
-  - [ ] R8e -- External callables and virtual dispatch, gated on the object-model design (R47): a
-        DPI import is a bodyless external callable; a virtual call is an explicit call form resolved
-        against the object's vtable layout.
+  - [ ] R8e -- A DPI import is a bodyless external callable: the foreign-symbol implementation form,
+        the external twin of an internal body. The virtual-dispatch facet this entry once bundled is
+        the object model's dynamic dispatch, now tracked in `object-model.md`; with the object model
+        designed, the external-callable work is no longer gated.
 
   - [x] R8f -- The scope's callables render through one backend method path. A process body and the
         synthesized resolve / initialize lifecycle bodies join functions and tasks as one uniform
@@ -634,18 +635,14 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       this is a refactor of MIR's existing qualifier shape to match the feature's needs, not an
       independent migration.
 
-- [ ] R47 -- Design the object model that SV classes need, distinct from the module / scope object.
-      The MIR concept currently named a "class" is a compiled module / scope, carrying
-      module-specific structure (an elaboration and construction graph, owned children, generated
-      members, lifecycle registrations). An SV class (LRM 8) needs heap allocation, handles and
-      null, inheritance, dynamic dispatch, object identity, and a reference-lifetime policy. The
-      likely factoring is a shared object type (fields, methods, and a virtual / dispatch layout
-      where applicable) plus a separate module-specific instance / elaboration plan -- "a module is
-      an object type plus an instance plan," not "an SV class is a module in another mode" -- so
-      module construction policy does not contaminate heap classes. **Design first**: this is the
-      gating prerequisite for SV classes and for the virtual-dispatch facet of R8
-      (`../decisions/unified-callable-model.md`). No implementation until the object model is
-      designed.
+- [ ] R47 -- The object model is designed: a module instance, a generate scope, and a SystemVerilog
+      class are one generic nominal object type, differing only in which base they extend, which
+      reference reaches their instances, and which lifecycle they participate in -- not a
+      module-specific object set against a class-specific one. The contract is
+      `../architecture/object_model.md` and the resolved trade-offs are
+      `../decisions/object-model.md`. The staged implementation -- generalizing the module-side
+      object model, then putting SystemVerilog classes on it -- is tracked in `object-model.md`. The
+      design gate this entry held over SV classes and over R8's virtual-dispatch facet is lifted.
 
 - [ ] R48 -- Let an object type name its class directly, so emit resolves the owning class in O(1)
       instead of searching. A member or method reference names only its class-local id; the class it

--- a/include/lyra/mir/class.hpp
+++ b/include/lyra/mir/class.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include "lyra/base/arena.hpp"
@@ -17,23 +18,34 @@
 
 namespace lyra::mir {
 
-// The base class a class extends. A class is a generic object type; whether it
-// is a node in the runtime object tree, and which runtime base it inherits, is
-// stated here rather than inferred by a backend. `kInstance` is a top-level
-// module instance, `kGenScope` a nested generate scope (both runtime Scope
-// subclasses). A class with no base is a plain object -- members only, not a
-// tree node -- constructed and held directly rather than registered.
-enum class RuntimeBaseClass : std::uint8_t {
+// A fixed runtime-library base class. These are object types the runtime
+// library provides, not classes of any compilation unit: `kInstance` is a
+// module / interface / program instance and `kGenScope` a named generate scope,
+// both nodes in the runtime object tree.
+enum class RuntimeClassKind : std::uint8_t {
   kInstance,
   kGenScope,
 };
 
+// A reference to a runtime-library base class.
+struct RuntimeLibraryClassRef {
+  RuntimeClassKind kind;
+
+  auto operator==(const RuntimeLibraryClassRef&) const -> bool = default;
+};
+
+// A reference to the object type an object extends. A consumer resolves it
+// through one path rather than switching a closed classification; a base is a
+// runtime-library class.
+using ClassRef = std::variant<RuntimeLibraryClassRef>;
+
 struct Class {
   std::string name;
-  // The runtime base this class extends, or absent for a plain object. A
-  // backend realizes the base, the registering constructor, and the tree-node
-  // overrides only when a base is present; a baseless class is a plain struct.
-  std::optional<RuntimeBaseClass> base;
+  // The base this object extends, or absent for a plain object that is not a
+  // tree node. A backend realizes the base, the registering constructor, and
+  // the tree-node overrides only when a base is present; a baseless object is a
+  // plain struct.
+  std::optional<ClassRef> base;
   TypeId self_pointer_type;
   // The class's resolved time unit and precision (LRM 3.14.2). The emitted
   // class exposes the precision so the engine can take the design-global

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -195,14 +195,18 @@ auto RenderConstructor(
       RenderBlockStatements(scope_view, indent + 1));
 }
 
-auto RenderRuntimeBaseClass(mir::RuntimeBaseClass base) -> std::string {
-  switch (base) {
-    case mir::RuntimeBaseClass::kInstance:
-      return "lyra::runtime::Instance";
-    case mir::RuntimeBaseClass::kGenScope:
-      return "lyra::runtime::GenScope";
-  }
-  throw InternalError("RenderRuntimeBaseClass: unknown RuntimeBaseClass");
+auto RenderBaseClass(const mir::ClassRef& base) -> std::string {
+  return std::visit(
+      [](const mir::RuntimeLibraryClassRef& ref) -> std::string {
+        switch (ref.kind) {
+          case mir::RuntimeClassKind::kInstance:
+            return "lyra::runtime::Instance";
+          case mir::RuntimeClassKind::kGenScope:
+            return "lyra::runtime::GenScope";
+        }
+        throw InternalError("RenderBaseClass: unknown RuntimeClassKind");
+      },
+      base);
 }
 
 auto RenderScopeAsClass(
@@ -219,7 +223,7 @@ auto RenderScopeAsClass(
   std::string out;
   out += Indent(indent) + "class " + s.name + " final";
   if (s.base.has_value()) {
-    out += " : public " + RenderRuntimeBaseClass(*s.base);
+    out += " : public " + RenderBaseClass(*s.base);
   }
   out += " {\n";
   out += Indent(indent) + " public:\n";
@@ -245,8 +249,8 @@ auto RenderScopeAsClass(
   // A plain object (no runtime base) is not a tree node: it needs no
   // registering constructor, only the implicit default one.
   if (s.base.has_value()) {
-    out += RenderConstructor(
-        this_anchor, s, RenderRuntimeBaseClass(*s.base), indent + 1);
+    out +=
+        RenderConstructor(this_anchor, s, RenderBaseClass(*s.base), indent + 1);
   }
 
   // The resolve and initialize phases run after construction, present only
@@ -278,7 +282,11 @@ auto RenderScopeAsClass(
 
   // A unit-root scope is a module instance; its name is the def-name an upward
   // reference matches when climbing the parent chain (LRM 23.8).
-  if (s.base == mir::RuntimeBaseClass::kInstance) {
+  const auto* base_instance =
+      s.base.has_value() ? std::get_if<mir::RuntimeLibraryClassRef>(&*s.base)
+                         : nullptr;
+  if (base_instance != nullptr &&
+      base_instance->kind == mir::RuntimeClassKind::kInstance) {
     out += Indent(indent + 1) +
            "auto DefName() const -> std::string_view override { return \"" +
            s.name + "\"; }\n";

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -1299,8 +1299,9 @@ auto ClassLowerer::Run(
           .ownership = mir::PointerOwnership::kBorrowed});
   mir::Class mir_class{
       .name = name_,
-      .base = parent_ == nullptr ? mir::RuntimeBaseClass::kInstance
-                                 : mir::RuntimeBaseClass::kGenScope,
+      .base = mir::ClassRef{mir::RuntimeLibraryClassRef{
+          .kind = parent_ == nullptr ? mir::RuntimeClassKind::kInstance
+                                     : mir::RuntimeClassKind::kGenScope}},
       .self_pointer_type = self_pointer_type,
       .time_resolution = hir_scope.time_resolution,
       .ctor_prefix_params = {},

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -639,10 +639,12 @@ class MirDumper {
     Indent();
 
     if (s.base.has_value()) {
+      const auto& ref = std::get<RuntimeLibraryClassRef>(*s.base);
       Line(
           std::format(
-              "Base: {}", *s.base == RuntimeBaseClass::kInstance ? "Instance"
-                                                                 : "GenScope"));
+              "Base: {}", ref.kind == RuntimeClassKind::kInstance
+                              ? "Instance"
+                              : "GenScope"));
     }
 
     Line("NestedClasses:");


### PR DESCRIPTION
## Summary

Records the object model as an architecture contract and lands its first behavior-neutral cut, opening the workstream that puts SystemVerilog class support on the same generic object model that modules and generate scopes already use.

## Design

The new contract (object_model.md) makes a module, a generate scope, and a SystemVerilog class one generic nominal object type, differing only in which base they extend, which reference reaches their instances, and which lifecycle they participate in. Two decision docs record the settled trade-offs: an SV class handle is a managed reference distinct from the acyclic shared one and the receiver is an instance-method property (object-model.md), and a compilation unit owns one canonical nominal-object registry with identity, lexical name resolution, and backend emission nesting kept separate (object-model-storage.md). The code cut replaces Class.base's closed RuntimeBaseClass enum with a generic ClassRef rendered through one path, so the backend's base-class switch is gone.

## Testing

bazel test //... passes; emitted C++ is unchanged.