### PR TITLE
Close AST-to-HIR lowering gaps surfaced by Ibex

### DIFF
--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -1,0 +1,90 @@
+# Ibex bring-up
+
+Tracks the work to simulate the Ibex RISC-V CPU (lowRISC's open-source RISC-V core; top
+`ibex_simple_system_tb`) end-to-end on Lyra. Ibex is the standing real-world integration target: a
+multi-file, vendor-grade design that exercises a broad slice of synthesizable SystemVerilog plus a
+pure-SV testbench. This file is the running inventory of the language features Ibex needs that Lyra
+does not yet support.
+
+Done when `ibex_simple_system_tb` simulates end-to-end with **no source modifications and no
+simulator-specific defines**, using only accepted Lyra compilation options.
+`disable_assertions = true` is an accepted option (a real, intended flag), so skipping concurrent
+assertions does not count as a trick. What does count as a trick, and is never an accepted end
+state: a discovery-only define such as `SYNTHESIS` or `VERILATOR`, stubbing a module, or editing the
+design. Those are only ever used to reveal the next gap during discovery.
+
+## Method
+
+Iterative gap discovery: point the compiler at the design, find the first unsupported construct,
+record it here, support it, then repeat -- each fix reveals the next gap. Because the pipeline stops
+at the first error, the list below is the **observed frontier**, not a closed set: it grows as items
+are closed. To widen each pass, individual modules are compiled as their own top so one module's
+first blocker does not hide every other module's.
+
+The whole Ibex RTL already parses, type-checks, and elaborates through the frontend with no errors
+-- every gap below is in feature lowering or the missing execution path, not in the frontend.
+
+## Two walls
+
+1. **Feature-lowering gaps** -- the unsupported SystemVerilog forms below.
+2. **No execution backend** -- even with every feature supported, there is no way to run the result:
+   only `dump hir` / `dump mir` / `emit cpp` are wired, and there is no LIR / LLVM / JIT / AOT and
+   no project mode. This wall is owned by `architecture-reset.md`; Ibex cannot run until it falls,
+   independently of the feature work here.
+
+## Feature gaps
+
+Ordered by leverage (how much of the design each unblocks). Checkboxes flip as each construct gains
+full support.
+
+### Highest leverage
+
+- [x] **Generate-`for` loops** (`for (genvar ...) begin ... end`). The dominant blocker -- the first
+      stop in roughly a dozen modules and present throughout the design. A generate loop unrolls
+      into elaborated structure at compile time; this is structural elaboration, distinct from a
+      procedural `for`.
+- [ ] **`parameter` / `localparam` referenced inside a continuous-assign expression** (e.g. a
+      part-select bound `x[Aw-1:0]` where `Aw` is a `localparam`). Parameters appear in expressions
+      pervasively, so this reaches far past the leaf modules where it is the first blocker.
+
+### Common forms
+
+- [ ] **Expose `disable_assertions` on the current entry path.** Untouched, the design's first
+      blocker in many modules is a concurrent assertion (the `assert`/`assume`/`cover property`
+      family and the macros wrapping them). The accepted handling is the `disable_assertions`
+      compilation option, but it is not reachable on this branch -- there is no CLI flag and no
+      project mode to set it. Wiring it through is the gap; implementing SVA proper (sampled-value
+      functions `$rose`/`$fell`/`$stable`/`$past`, the `Observed` region) is a separate, optional
+      feature off the critical path to running Ibex.
+- [ ] **Packed array whose element is a struct or enum** (a packed array of a packed aggregate, not
+      just of a scalar bit/logic).
+- [ ] **Net-typed port connections** -- connecting a net (`wire`) across a module port, as the
+      testbench does when wiring the DUT. The first wall the full top-level testbench hits.
+- [x] **`$signed` / `$unsigned`** system functions.
+
+### Localized / long tail
+
+- [ ] **Hierarchical / cross-unit reference to a parameter** (reaching a sub-instance's parameter
+      through a dotted path, e.g. the `mhpmcounter` accessor in the DPI block).
+- [ ] **Constant of aggregate type** (an elaboration-time constant whose type is an array/struct
+      rather than a scalar).
+- [ ] Remaining structural-expression forms surfaced as later passes get deeper (recorded here as
+      discovery continues).
+
+## Robustness (crashes, not missing features)
+
+Some unsupported inputs abort with an internal error instead of a located, graceful diagnostic.
+Independent of whether the feature is supported, each of these should fail cleanly:
+
+- [ ] An out-of-range arena/index access aborts on a few modules instead of reporting the
+      unsupported construct.
+- [x] `$signed` / `$unsigned` aborts as an "unresolved system subroutine" rather than a clean
+      unsupported diagnostic (subsumed once the feature above lands).
+- [x] A non-literal where an integer constant is expected aborts instead of diagnosing.
+
+## Cross-references
+
+- Execution-path wall: `architecture-reset.md`.
+- Net-typed ports and hierarchical references also surface in the hierarchy workstream; close them
+  there if that file's items cover the same construct.
+- The Ibex-side how-to-reproduce and status snapshot live in the Ibex checkout's `LYRA.md`.

--- a/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
+++ b/src/lyra/lowering/ast_to_hir/continuous_assign.cpp
@@ -8,7 +8,6 @@
 #include <slang/ast/expressions/AssignmentExpressions.h>
 #include <slang/ast/symbols/MemberSymbols.h>
 
-#include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
@@ -59,9 +58,12 @@ auto StructuralScopeLowerer::LowerContinuousAssign(
 
   const auto& assignment_expr = sym.getAssignment();
   if (assignment_expr.kind != slang::ast::ExpressionKind::Assignment) {
-    throw InternalError(
-        "StructuralScopeLowerer::LowerContinuousAssign: ContinuousAssignSymbol."
-        "getAssignment() did not return an AssignmentExpression");
+    // slang bound the continuous assignment to a form other than a plain
+    // assignment (a legitimate construct Lyra does not lower yet), not a
+    // compiler-invariant violation.
+    return diag::Fail(
+        span, diag::DiagCode::kUnsupportedContinuousAssignForm,
+        "this continuous-assignment form is not yet supported");
   }
   const auto& assign = assignment_expr.as<slang::ast::AssignmentExpression>();
 

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -325,11 +325,34 @@ auto LowerCallExpr(
       };
     }
 
+    // `$signed` / `$unsigned` reinterpret the operand under the named
+    // signedness. The result type already carries that signedness, so this is a
+    // value conversion to the result type, not a runtime call.
+    if (info.subroutine != nullptr &&
+        (info.subroutine->knownNameId ==
+             slang::parsing::KnownSystemName::Signed ||
+         info.subroutine->knownNameId ==
+             slang::parsing::KnownSystemName::Unsigned)) {
+      auto type_id = module.InternType(*call.type, span);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return hir::Expr{
+          .type = *type_id,
+          .data =
+              hir::ConversionExpr{
+                  .operand = *arg_ids.front(),
+                  .kind = hir::ConversionKind::kImplicit},
+          .span = span,
+      };
+    }
+
     const auto* desc = support::FindSystemSubroutine(name);
     if (desc == nullptr) {
-      throw InternalError(
-          std::string{"AST->HIR call: unresolved system subroutine '"} +
-          std::string{name} + "' after slang resolution");
+      // slang resolved a system task / function that Lyra's registry does not
+      // carry: a legitimate but unimplemented construct, not a compiler bug.
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedExpressionForm,
+          std::string{"system task / function '"} + std::string{name} +
+              "' is not yet supported");
     }
     const auto frontend_kind = FromSlangSubroutineKind(info.subroutine->kind);
     if (desc->kind != frontend_kind) {

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -7,6 +7,7 @@
 #include <slang/ast/expressions/SelectExpressions.h>
 #include <slang/ast/symbols/MemberSymbols.h>
 #include <slang/ast/types/Type.h>
+#include <slang/numeric/ConstantValue.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
@@ -15,6 +16,7 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/expr_builders.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
+#include "lyra/lowering/ast_to_hir/constant_value.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
@@ -110,13 +112,34 @@ auto LowerRangeSelectExpr(
 
   const WalkFrame bound_frame =
       sel.value().type->isQueue() ? frame.WithDollarBase(base_id) : frame;
-  auto left_or = lowerer.LowerExpr(sel.left(), bound_frame);
-  if (!left_or) return std::unexpected(std::move(left_or.error()));
-  const hir::ExprId left_id = frame.Exprs().Add(*std::move(left_or));
 
-  auto right_or = lowerer.LowerExpr(sel.right(), bound_frame);
-  if (!right_or) return std::unexpected(std::move(right_or.error()));
-  const hir::ExprId right_id = frame.Exprs().Add(*std::move(right_or));
+  // A bound slang has evaluated to a constant (an `[msb:lsb]` endpoint or an
+  // indexed-select width, both required constant by LRM 11.5.1) folds to a
+  // literal from slang's value, so the downstream layer reads the constant
+  // directly instead of re-deriving it from a structural parameter expression.
+  // A non-constant bound -- a variable indexed-select base, a queue `$` --
+  // falls back to structural lowering.
+  auto lower_bound =
+      [&](const slang::ast::Expression& bound) -> diag::Result<hir::ExprId> {
+    if (const auto* constant = bound.getConstant(); constant != nullptr) {
+      auto bound_type = lowerer.Module().InternType(*bound.type, span);
+      if (!bound_type) return std::unexpected(std::move(bound_type.error()));
+      auto literal = MakeConstantValueExpr(*constant, *bound_type, span);
+      if (!literal) return std::unexpected(std::move(literal.error()));
+      return frame.Exprs().Add(*std::move(literal));
+    }
+    auto lowered = lowerer.LowerExpr(bound, bound_frame);
+    if (!lowered) return std::unexpected(std::move(lowered.error()));
+    return frame.Exprs().Add(*std::move(lowered));
+  };
+
+  auto left_res = lower_bound(sel.left());
+  if (!left_res) return std::unexpected(std::move(left_res.error()));
+  const hir::ExprId left_id = *left_res;
+
+  auto right_res = lower_bound(sel.right());
+  if (!right_res) return std::unexpected(std::move(right_res.error()));
+  const hir::ExprId right_id = *right_res;
 
   hir::RangeBounds bounds = [&]() -> hir::RangeBounds {
     switch (sel.getSelectionKind()) {

--- a/src/lyra/lowering/ast_to_hir/generate.cpp
+++ b/src/lyra/lowering/ast_to_hir/generate.cpp
@@ -7,6 +7,7 @@
 
 #include <slang/ast/Expression.h>
 #include <slang/ast/expressions/AssignmentExpressions.h>
+#include <slang/ast/expressions/OperatorExpressions.h>
 #include <slang/ast/symbols/BlockSymbols.h>
 #include <slang/ast/symbols/MemberSymbols.h>
 #include <slang/ast/symbols/ParameterSymbols.h>
@@ -14,6 +15,7 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
+#include "lyra/hir/expr_builders.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/lowering/ast_to_hir/expression/slang_atoms.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
@@ -240,14 +242,74 @@ auto StructuralScopeLowerer::BuildCaseGenerate(
 
 namespace {
 
+// Intern a genvar step's non-loop-variable operand, promoting it to the loop
+// variable's type when it differs. A genvar is four-state, so a two-state step
+// amount -- a synthesized one, or a compound right-hand side taken without the
+// promotion slang wraps it in -- must be widened, or the two operands mismatch
+// in state-kind at evaluation.
+auto AddStepOperand(
+    WalkFrame frame, hir::Expr operand, hir::TypeId loop_var_type,
+    diag::SourceSpan span) -> hir::ExprId {
+  const bool needs_promotion = operand.type != loop_var_type;
+  const hir::ExprId operand_id = frame.Exprs().Add(std::move(operand));
+  if (!needs_promotion) {
+    return operand_id;
+  }
+  return frame.Exprs().Add(
+      hir::Expr{
+          .type = loop_var_type,
+          .data =
+              hir::ConversionExpr{
+                  .operand = operand_id,
+                  .kind = hir::ConversionKind::kImplicit},
+          .span = span});
+}
+
 // Lower the iter expression of a loop_generate header into the loop's
-// next-value expression for its loop variable (LRM 27.5).
+// next-value expression for its loop variable (LRM 27.4).
 auto LowerLoopIterNextValue(
     StructuralScopeLowerer& parent, ModuleLowerer& module,
     const slang::ast::Expression& iter, WalkFrame frame)
     -> diag::Result<hir::Expr> {
   const auto& mapper = module.SourceMapper();
   const auto span = mapper.SpanOf(iter.sourceRange);
+
+  // An increment / decrement iter (`i++`, `--i`) carries no right-hand side;
+  // its next value is the loop variable plus or minus one.
+  if (iter.kind == slang::ast::ExpressionKind::UnaryOp) {
+    const auto& un = iter.as<slang::ast::UnaryExpression>();
+    std::optional<hir::BinaryOp> step_op;
+    switch (un.op) {
+      case slang::ast::UnaryOperator::Preincrement:
+      case slang::ast::UnaryOperator::Postincrement:
+        step_op = hir::BinaryOp::kAdd;
+        break;
+      case slang::ast::UnaryOperator::Predecrement:
+      case slang::ast::UnaryOperator::Postdecrement:
+        step_op = hir::BinaryOp::kSub;
+        break;
+      default:
+        break;
+    }
+    if (step_op.has_value()) {
+      auto read = parent.LowerExpr(un.operand(), frame);
+      if (!read) return std::unexpected(std::move(read.error()));
+      const hir::ExprId read_id = frame.Exprs().Add(*std::move(read));
+
+      auto type_id = module.InternType(*iter.type, span);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+
+      const hir::ExprId one_id = AddStepOperand(
+          frame, hir::MakeInt32Literal(1, module.Unit().builtins.int32, span),
+          *type_id, span);
+      return hir::Expr{
+          .type = *type_id,
+          .data =
+              hir::BinaryExpr{.op = *step_op, .lhs = read_id, .rhs = one_id},
+          .span = span,
+      };
+    }
+  }
 
   if (iter.kind != slang::ast::ExpressionKind::Assignment) {
     return diag::Fail(
@@ -264,13 +326,15 @@ auto LowerLoopIterNextValue(
   if (!read) return std::unexpected(std::move(read.error()));
   const hir::ExprId read_id = frame.Exprs().Add(*std::move(read));
 
+  auto type_id = module.InternType(*iter.type, span);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+
   const auto& bare_rhs = BareCompoundUserRhs(assign.right());
   auto rhs = parent.LowerExpr(bare_rhs, frame);
   if (!rhs) return std::unexpected(std::move(rhs.error()));
-  const hir::ExprId rhs_id = frame.Exprs().Add(*std::move(rhs));
+  const hir::ExprId rhs_id =
+      AddStepOperand(frame, *std::move(rhs), *type_id, span);
 
-  auto type_id = module.InternType(*iter.type, span);
-  if (!type_id) return std::unexpected(std::move(type_id.error()));
   return hir::Expr{
       .type = *type_id,
       .data =

--- a/tests/cases/cpp/generate_loop_increment/case.yaml
+++ b/tests/cases/cpp/generate_loop_increment/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.generate_loop_increment
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    inc: 15
+    dec: 15
+    compound: 15
+    assign_form: 15

--- a/tests/cases/cpp/generate_loop_increment/main.sv
+++ b/tests/cases/cpp/generate_loop_increment/main.sv
@@ -1,0 +1,22 @@
+module Top;
+  logic [3:0] inc;
+  logic [3:0] dec;
+  logic [3:0] compound;
+  logic [3:0] assign_form;
+
+  // Every genvar generate-loop iteration form (LRM 27.4). Each instance drives
+  // the bit at its own genvar value, so a fully-set result proves the loop
+  // visited every index exactly once with the right step.
+  for (genvar i = 0; i < 4; i++) begin : g_inc
+    assign inc[i] = 1'b1;
+  end
+  for (genvar i = 3; i >= 0; i--) begin : g_dec
+    assign dec[i] = 1'b1;
+  end
+  for (genvar i = 0; i < 4; i += 1) begin : g_compound
+    assign compound[i] = 1'b1;
+  end
+  for (genvar i = 0; i < 4; i = i + 1) begin : g_assign
+    assign assign_form[i] = 1'b1;
+  end
+endmodule

--- a/tests/cases/cpp/range_select_param_bound/case.yaml
+++ b/tests/cases/cpp/range_select_param_bound/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.range_select_param_bound
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    lo: 5
+    hi: 10

--- a/tests/cases/cpp/range_select_param_bound/main.sv
+++ b/tests/cases/cpp/range_select_param_bound/main.sv
@@ -1,0 +1,12 @@
+module Top;
+  localparam int W = 4;
+  logic [7:0] a;
+  logic [3:0] lo;
+  logic [3:0] hi;
+
+  // Constant range-select bounds built from a parameter (LRM 11.5.1 requires
+  // them constant): the simple `[W-1:0]` and the indexed-up width `[4 +: W]`.
+  assign a = 8'hA5;
+  assign lo = a[W-1:0];
+  assign hi = a[4+:W];
+endmodule

--- a/tests/cases/cpp/system_signed_unsigned/case.yaml
+++ b/tests/cases/cpp/system_signed_unsigned/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.system_signed_unsigned
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    s_ext: 255
+    u_ext: 15

--- a/tests/cases/cpp/system_signed_unsigned/main.sv
+++ b/tests/cases/cpp/system_signed_unsigned/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  logic [3:0] x;
+  logic [7:0] s_ext;
+  logic [7:0] u_ext;
+
+  // $signed reinterprets the operand as signed, so widening to 8 bits
+  // sign-extends (4'b1111 -> -1 -> 8'hFF); $unsigned zero-extends (-> 8'h0F).
+  assign x = 4'b1111;
+  assign s_ext = $signed(x);
+  assign u_ext = $unsigned(x);
+endmodule

--- a/tests/cases/errors/continuous_assign_uninstantiated_branch/case.yaml
+++ b/tests/cases/errors/continuous_assign_uninstantiated_branch/case.yaml
@@ -1,0 +1,16 @@
+id: errors.continuous_assign_uninstantiated_branch
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "continuous-assignment form"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/continuous_assign_uninstantiated_branch/main.sv
+++ b/tests/cases/errors/continuous_assign_uninstantiated_branch/main.sv
@@ -1,0 +1,16 @@
+module Top;
+  logic [3:0] q;
+  logic [3:0] sel;
+
+  // The else branch is uninstantiated for the loop's canonical iteration
+  // (fb == 0), where its part-select bound `fb-1` goes out of range; Lyra does
+  // not yet lower such genvar-conditional generate branches and reports it
+  // gracefully rather than crashing.
+  for (genvar fb = 0; fb < 4; fb++) begin : g
+    if (fb == 0) begin : gz
+      assign sel[fb] = q[fb];
+    end else begin : gr
+      assign sel[fb] = &q[fb-1:0];
+    end
+  end
+endmodule

--- a/tests/cases/errors/system_subroutine_unsupported/case.yaml
+++ b/tests/cases/errors/system_subroutine_unsupported/case.yaml
@@ -1,0 +1,17 @@
+id: errors.system_subroutine_unsupported
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "$readmemh"
+      - "not yet supported"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/system_subroutine_unsupported/main.sv
+++ b/tests/cases/errors/system_subroutine_unsupported/main.sv
@@ -1,0 +1,4 @@
+module Top;
+  logic [7:0] mem [0:3];
+  initial $readmemh("mem.hex", mem);
+endmodule


### PR DESCRIPTION
## Summary

This fills a batch of AST-to-HIR lowering gaps surfaced by compiling the Ibex RISC-V core as a probe. Generate-`for` loops now accept the `i++` / `--i` and `i += k` iteration forms (previously only the spelled-out `i = i + 1` lowered); the synthesized step operand is promoted to the genvar's four-state type so the step never mixes state-kinds at evaluation, which also fixes the same latent mismatch in the compound-assignment form. `$signed` / `$unsigned` lower to a signedness-reinterpreting value conversion rather than aborting as an unresolved system subroutine. Constant range-select bounds built from parameters (the ubiquitous `x[W-1:0]`) fold to a literal from slang's evaluated value, so the downstream layer reads the constant directly instead of crashing on a structural parameter expression; a non-constant bound (a variable indexed-select base, a queue `$`) still lowers structurally.

Two lowering boundaries that previously raised `InternalError` on legitimate-but-unimplemented input now emit a located `unsupported:` diagnostic instead of crashing: an unknown system task / function (for example `$readmemh`), and a continuous-assignment form slang binds to something other than a plain assignment.

## Testing

New `cpp_run` cases assert the runtime values for every genvar iteration form, `$signed` / `$unsigned` sign- and zero-extension, and parameter-bound range selects. New `errors` cases assert the graceful diagnostics for the unknown system task and the unsupported continuous-assignment form. Full `bazel test //...` is green.
