### PR TITLE
Model unpacked struct and union in HIR

### DIFF
--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -115,9 +115,12 @@ struct RangeSelectExpr {
   RangeBounds bounds;
 };
 
-// LRM 7.2.1 packed struct field access. `field_index` identifies the member
-// in the base expression's PackedStructType field table; offset / width come
-// from that table at every consumer site.
+// Struct / union field access (LRM 7.2 / 7.3). `field_index` identifies the
+// member by its declaration-order position in the base expression's aggregate
+// type. How a consumer resolves that index depends on the base type: a packed
+// aggregate reads the field's offset / width from its field table (a bit
+// slice), while an unpacked aggregate selects the member's independent storage
+// by index.
 struct MemberAccessExpr {
   ExprId base_value;
   std::uint32_t field_index;

--- a/include/lyra/hir/module_unit.hpp
+++ b/include/lyra/hir/module_unit.hpp
@@ -62,9 +62,10 @@ struct ModuleUnit {
     return types.at(id.value);
   }
 
-  auto AddType(TypeData data) -> TypeId {
+  auto AddType(TypeData data, diag::DiagSpan span = diag::UnknownSpan{})
+      -> TypeId {
     const TypeId id{static_cast<std::uint32_t>(types.size())};
-    types.push_back(Type{.data = std::move(data)});
+    types.push_back(Type{.data = std::move(data), .span = span});
     return id;
   }
 };

--- a/include/lyra/hir/type.hpp
+++ b/include/lyra/hir/type.hpp
@@ -6,6 +6,7 @@
 #include <variant>
 #include <vector>
 
+#include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/integral_constant.hpp"
 #include "lyra/hir/type_id.hpp"
 
@@ -16,6 +17,8 @@ enum class TypeKind {
   kPackedStruct,
   kPackedUnion,
   kEnum,
+  kUnpackedStruct,
+  kUnpackedUnion,
   kUnpackedArray,
   kDynamicArray,
   kQueue,
@@ -110,6 +113,34 @@ struct PackedUnionType {
   std::vector<PackedAggregateField> fields;
 };
 
+// A named member of an unpacked aggregate (struct or union). Unlike a packed
+// aggregate field, an unpacked member has its own independent storage of its
+// declared type -- there is no shared bit vector, so no offset or width. The
+// member is identified by its position in declaration order (LRM 7.2 / 7.3),
+// the same index a member-access expression carries.
+struct UnpackedAggregateField {
+  std::string name;
+  TypeId type;
+};
+
+// LRM 7.2 unpacked structure: a heterogeneous aggregate whose members each hold
+// independent storage of their declared type. Distinct from a packed struct,
+// whose members share one bit vector; an unpacked member may be any type,
+// including a string, another unpacked aggregate, or a variable-size container.
+struct UnpackedStructType {
+  std::vector<UnpackedAggregateField> fields;
+};
+
+// LRM 7.3 unpacked union: one storage shared across the member types, with one
+// member usable at a time. `tagged` (LRM 7.3.2) marks a type-checked union that
+// carries a tag identifying the active member; an untagged union (the default)
+// is the type-loophole form with no tag. A tagged union may declare a `void`
+// member (LRM 7.3.2) when all information is in the tag.
+struct UnpackedUnionType {
+  std::vector<UnpackedAggregateField> fields;
+  bool tagged;
+};
+
 struct UnpackedRange {
   std::int64_t left;
   std::int64_t right;
@@ -151,12 +182,17 @@ struct VoidType {};
 
 using TypeData = std::variant<
     PackedArrayType, PackedStructType, PackedUnionType, EnumType,
-    UnpackedArrayType, DynamicArrayType, QueueType, AssociativeArrayType,
-    WildcardIndexType, StringType, EventType, RealType, ShortRealType,
-    RealTimeType, ChandleType, VoidType>;
+    UnpackedStructType, UnpackedUnionType, UnpackedArrayType, DynamicArrayType,
+    QueueType, AssociativeArrayType, WildcardIndexType, StringType, EventType,
+    RealType, ShortRealType, RealTimeType, ChandleType, VoidType>;
 
 struct Type {
   TypeData data;
+
+  // The declaration site that first interned this type. A downstream layer
+  // that cannot represent the type anchors its diagnostic here. Builtin types
+  // have no source and carry `UnknownSpan`.
+  diag::DiagSpan span;
 
   [[nodiscard]] auto Kind() const -> TypeKind;
   [[nodiscard]] auto IsPackedArray() const -> bool;

--- a/include/lyra/lowering/hir_to_mir/module_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/module_lowerer.hpp
@@ -70,8 +70,9 @@ class ModuleLowerer {
   }
 
  private:
-  [[nodiscard]] auto TranslateTypeData(const hir::TypeData& data) const
-      -> mir::TypeData;
+  [[nodiscard]] auto TranslateTypeData(
+      const hir::TypeData& data, diag::DiagSpan type_span) const
+      -> diag::Result<mir::TypeData>;
 
   const hir::ModuleUnit* hir_;
   const diag::SourceManager* source_manager_;

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -183,6 +183,25 @@ class HirDumper {
                   "Enum(base=Type[{}], members=[{}])", e.base_type.value,
                   members);
             },
+            [](const UnpackedStructType& s) -> std::string {
+              std::string fields;
+              for (std::size_t i = 0; i < s.fields.size(); ++i) {
+                if (i > 0) fields += ", ";
+                fields += std::format(
+                    "{}:Type[{}]", s.fields[i].name, s.fields[i].type.value);
+              }
+              return std::format("UnpackedStruct(fields=[{}])", fields);
+            },
+            [](const UnpackedUnionType& u) -> std::string {
+              std::string fields;
+              for (std::size_t i = 0; i < u.fields.size(); ++i) {
+                if (i > 0) fields += ", ";
+                fields += std::format(
+                    "{}:Type[{}]", u.fields[i].name, u.fields[i].type.value);
+              }
+              return std::format(
+                  "UnpackedUnion(tagged={}, fields=[{}])", u.tagged, fields);
+            },
             [](const UnpackedArrayType& u) -> std::string {
               return std::format(
                   "UnpackedArray(elem=Type[{}], dim=[{}:{}])",

--- a/src/lyra/hir/type.cpp
+++ b/src/lyra/hir/type.cpp
@@ -86,6 +86,8 @@ auto Type::Kind() const -> TypeKind {
           [](const PackedStructType&) { return TypeKind::kPackedStruct; },
           [](const PackedUnionType&) { return TypeKind::kPackedUnion; },
           [](const EnumType&) { return TypeKind::kEnum; },
+          [](const UnpackedStructType&) { return TypeKind::kUnpackedStruct; },
+          [](const UnpackedUnionType&) { return TypeKind::kUnpackedUnion; },
           [](const UnpackedArrayType&) { return TypeKind::kUnpackedArray; },
           [](const DynamicArrayType&) { return TypeKind::kDynamicArray; },
           [](const QueueType&) { return TypeKind::kQueue; },
@@ -143,6 +145,8 @@ auto Type::IsValueChangeObservable() const -> bool {
     case TypeKind::kPackedStruct:
     case TypeKind::kPackedUnion:
     case TypeKind::kEnum:
+    case TypeKind::kUnpackedStruct:
+    case TypeKind::kUnpackedUnion:
     case TypeKind::kUnpackedArray:
     case TypeKind::kDynamicArray:
     case TypeKind::kQueue:

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
@@ -203,6 +204,48 @@ auto LowerPackedUnion(
   };
 }
 
+auto LowerUnpackedAggregateFields(
+    std::span<const slang::ast::FieldSymbol* const> fields,
+    diag::SourceSpan decl_span, ModuleLowerer& module)
+    -> diag::Result<std::vector<hir::UnpackedAggregateField>> {
+  std::vector<hir::UnpackedAggregateField> out;
+  out.reserve(fields.size());
+  for (const auto* field : fields) {
+    auto field_type_or = module.InternType(field->getType(), decl_span);
+    if (!field_type_or) {
+      return std::unexpected(std::move(field_type_or.error()));
+    }
+    out.push_back(
+        hir::UnpackedAggregateField{
+            .name = std::string(field->name),
+            .type = *field_type_or,
+        });
+  }
+  return out;
+}
+
+auto LowerUnpackedStruct(
+    const slang::ast::UnpackedStructType& struct_type,
+    diag::SourceSpan decl_span, ModuleLowerer& module)
+    -> diag::Result<hir::UnpackedStructType> {
+  auto fields_or =
+      LowerUnpackedAggregateFields(struct_type.fields, decl_span, module);
+  if (!fields_or) return std::unexpected(std::move(fields_or.error()));
+  return hir::UnpackedStructType{.fields = *std::move(fields_or)};
+}
+
+auto LowerUnpackedUnion(
+    const slang::ast::UnpackedUnionType& union_type, diag::SourceSpan decl_span,
+    ModuleLowerer& module) -> diag::Result<hir::UnpackedUnionType> {
+  auto fields_or =
+      LowerUnpackedAggregateFields(union_type.fields, decl_span, module);
+  if (!fields_or) return std::unexpected(std::move(fields_or.error()));
+  return hir::UnpackedUnionType{
+      .fields = *std::move(fields_or),
+      .tagged = union_type.isTagged,
+  };
+}
+
 auto LowerEnum(
     const slang::ast::EnumType& enum_type, diag::SourceSpan decl_span,
     ModuleLowerer& module) -> diag::Result<hir::EnumType> {
@@ -368,14 +411,18 @@ auto TranslateTypeData(
           .key_type = *key_id_or,
       }};
     }
-    case slang::ast::SymbolKind::UnpackedStructType:
-      return diag::Fail(
-          decl_span, diag::DiagCode::kUnsupportedUnpackedStructType,
-          "unpacked struct types are not supported");
-    case slang::ast::SymbolKind::UnpackedUnionType:
-      return diag::Fail(
-          decl_span, diag::DiagCode::kUnsupportedUnpackedUnionType,
-          "unpacked union types are not supported");
+    case slang::ast::SymbolKind::UnpackedStructType: {
+      auto s = LowerUnpackedStruct(
+          canonical.as<slang::ast::UnpackedStructType>(), decl_span, module);
+      if (!s) return std::unexpected(std::move(s.error()));
+      return hir::TypeData{*std::move(s)};
+    }
+    case slang::ast::SymbolKind::UnpackedUnionType: {
+      auto u = LowerUnpackedUnion(
+          canonical.as<slang::ast::UnpackedUnionType>(), decl_span, module);
+      if (!u) return std::unexpected(std::move(u.error()));
+      return hir::TypeData{*std::move(u)};
+    }
     default:
       return diag::Fail(
           decl_span, diag::DiagCode::kUnsupportedTypeKind,
@@ -394,7 +441,7 @@ auto ModuleLowerer::InternType(
   }
   auto data_or = TranslateTypeData(*this, type, span);
   if (!data_or) return std::unexpected(std::move(data_or.error()));
-  const hir::TypeId id = unit_.AddType(*std::move(data_or));
+  const hir::TypeId id = unit_.AddType(*std::move(data_or), span);
   type_cache_.emplace(canonical, id);
   return id;
 }

--- a/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
@@ -17,8 +17,9 @@ auto ModuleLowerer::Run() -> diag::Result<mir::CompilationUnit> {
 
   for (std::size_t i = 0; i < hir_->types.size(); ++i) {
     const hir::TypeId hir_id{static_cast<std::uint32_t>(i)};
-    auto mir_data = TranslateTypeData(hir_->types[i].data);
-    const mir::TypeId mir_id = unit_.AddType(std::move(mir_data));
+    auto mir_data = TranslateTypeData(hir_->types[i].data, hir_->types[i].span);
+    if (!mir_data) return std::unexpected(std::move(mir_data.error()));
+    const mir::TypeId mir_id = unit_.AddType(*std::move(mir_data));
     MapType(hir_id, mir_id);
   }
 

--- a/src/lyra/lowering/hir_to_mir/translate_type.cpp
+++ b/src/lyra/lowering/hir_to_mir/translate_type.cpp
@@ -3,6 +3,7 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
+#include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/mir/type.hpp"
@@ -60,11 +61,12 @@ auto TranslatePackedRanges(const std::vector<hir::PackedRange>& src)
 
 }  // namespace
 
-auto ModuleLowerer::TranslateTypeData(const hir::TypeData& data) const
-    -> mir::TypeData {
+auto ModuleLowerer::TranslateTypeData(
+    const hir::TypeData& data, diag::DiagSpan type_span) const
+    -> diag::Result<mir::TypeData> {
   return std::visit(
       Overloaded{
-          [&](const hir::PackedArrayType& src) -> mir::TypeData {
+          [&](const hir::PackedArrayType& src) -> diag::Result<mir::TypeData> {
             return mir::PackedArrayType{
                 .atom = TranslateBitAtom(src.atom),
                 .signedness = TranslateSignedness(src.signedness),
@@ -72,7 +74,7 @@ auto ModuleLowerer::TranslateTypeData(const hir::TypeData& data) const
                 .form = TranslatePackedArrayForm(src.form),
             };
           },
-          [&](const hir::PackedStructType& src) -> mir::TypeData {
+          [&](const hir::PackedStructType& src) -> diag::Result<mir::TypeData> {
             // LRM 7.2.1: "treated as a single vector". MIR keeps only that
             // projection -- a PackedArrayType. Per-field offset / width get
             // baked into constant-bounds RangeSelect at expression
@@ -84,7 +86,7 @@ auto ModuleLowerer::TranslateTypeData(const hir::TypeData& data) const
                 .form = TranslatePackedArrayForm(src.base.form),
             };
           },
-          [&](const hir::PackedUnionType& src) -> mir::TypeData {
+          [&](const hir::PackedUnionType& src) -> diag::Result<mir::TypeData> {
             // LRM 7.3.1: untagged packed union "appears as a primary" is
             // "treated as a single vector". Same MIR shape as packed
             // struct -- the per-member (offset=0, width) table flows
@@ -96,7 +98,7 @@ auto ModuleLowerer::TranslateTypeData(const hir::TypeData& data) const
                 .form = TranslatePackedArrayForm(src.base.form),
             };
           },
-          [&](const hir::EnumType& src) -> mir::TypeData {
+          [&](const hir::EnumType& src) -> diag::Result<mir::TypeData> {
             // Enum is kept as a distinct mir::EnumType wrapping its base
             // PackedArray plus the member table. Value-level operations
             // unwrap via Type::AsIntegralPacked(); method dispatch reads the
@@ -125,7 +127,20 @@ auto ModuleLowerer::TranslateTypeData(const hir::TypeData& data) const
                 .members = std::move(members),
             };
           },
-          [&](const hir::UnpackedArrayType& src) -> mir::TypeData {
+          [type_span](
+              const hir::UnpackedStructType&) -> diag::Result<mir::TypeData> {
+            return diag::Fail(
+                type_span, diag::DiagCode::kUnsupportedUnpackedStructType,
+                "unpacked struct types are not yet supported");
+          },
+          [type_span](
+              const hir::UnpackedUnionType&) -> diag::Result<mir::TypeData> {
+            return diag::Fail(
+                type_span, diag::DiagCode::kUnsupportedUnpackedUnionType,
+                "unpacked union types are not yet supported");
+          },
+          [&](const hir::UnpackedArrayType& src)
+              -> diag::Result<mir::TypeData> {
             const std::int64_t span = (src.dim.left >= src.dim.right)
                                           ? (src.dim.left - src.dim.right)
                                           : (src.dim.right - src.dim.left);
@@ -134,43 +149,48 @@ auto ModuleLowerer::TranslateTypeData(const hir::TypeData& data) const
                 .size = static_cast<std::uint64_t>(span) + 1U,
             };
           },
-          [&](const hir::DynamicArrayType& src) -> mir::TypeData {
+          [&](const hir::DynamicArrayType& src) -> diag::Result<mir::TypeData> {
             return mir::DynamicArrayType{
                 .element_type = TranslateType(src.element_type),
             };
           },
-          [&](const hir::QueueType& src) -> mir::TypeData {
+          [&](const hir::QueueType& src) -> diag::Result<mir::TypeData> {
             return mir::QueueType{
                 .element_type = TranslateType(src.element_type),
                 .max_bound = src.max_bound,
             };
           },
-          [&](const hir::AssociativeArrayType& src) -> mir::TypeData {
+          [&](const hir::AssociativeArrayType& src)
+              -> diag::Result<mir::TypeData> {
             return mir::AssociativeArrayType{
                 .element_type = TranslateType(src.element_type),
                 .key_type = TranslateType(src.key_type),
             };
           },
-          [](const hir::WildcardIndexType&) -> mir::TypeData {
+          [](const hir::WildcardIndexType&) -> diag::Result<mir::TypeData> {
             return mir::WildcardIndexType{};
           },
-          [](const hir::StringType&) -> mir::TypeData {
+          [](const hir::StringType&) -> diag::Result<mir::TypeData> {
             return mir::StringType{};
           },
-          [](const hir::EventType&) -> mir::TypeData {
+          [](const hir::EventType&) -> diag::Result<mir::TypeData> {
             return mir::EventType{};
           },
-          [](const hir::RealType&) -> mir::TypeData { return mir::RealType{}; },
-          [](const hir::ShortRealType&) -> mir::TypeData {
+          [](const hir::RealType&) -> diag::Result<mir::TypeData> {
+            return mir::RealType{};
+          },
+          [](const hir::ShortRealType&) -> diag::Result<mir::TypeData> {
             return mir::ShortRealType{};
           },
-          [](const hir::RealTimeType&) -> mir::TypeData {
+          [](const hir::RealTimeType&) -> diag::Result<mir::TypeData> {
             return mir::RealTimeType{};
           },
-          [](const hir::ChandleType&) -> mir::TypeData {
+          [](const hir::ChandleType&) -> diag::Result<mir::TypeData> {
             return mir::ChandleType{};
           },
-          [](const hir::VoidType&) -> mir::TypeData { return mir::VoidType{}; },
+          [](const hir::VoidType&) -> diag::Result<mir::TypeData> {
+            return mir::VoidType{};
+          },
       },
       data);
 }

--- a/tests/cases/errors/unsupported_unpacked_union/case.yaml
+++ b/tests/cases/errors/unsupported_unpacked_union/case.yaml
@@ -1,4 +1,4 @@
-id: errors.unsupported_type
+id: errors.unsupported_unpacked_union
 tags: [errors, diag]
 input:
   command: [emit, cpp]
@@ -12,8 +12,8 @@ expect:
     contains:
       - "main.sv:2:"
       - "unsupported:"
-      - "unpacked struct types are not yet supported"
-      - "struct { int a; int b; } s;"
+      - "unpacked union types are not yet supported"
+      - "union { int a; int b; } u;"
     not_contains:
       - "internal error"
       - "\x1b["

--- a/tests/cases/errors/unsupported_unpacked_union/main.sv
+++ b/tests/cases/errors/unsupported_unpacked_union/main.sv
@@ -1,0 +1,3 @@
+module Top;
+  union { int a; int b; } u;
+endmodule


### PR DESCRIPTION
## Summary

HIR now models unpacked structures and unions (LRM 7.2 / 7.3) faithfully: a new `UnpackedStructType` and `UnpackedUnionType` (the latter carrying a `tagged` flag for untagged vs LRM 7.3.2 tagged unions) join the HIR type system, each member a `(name, type)` pair with independent storage and no shared bit vector. Field access on these aggregates already flows through the existing member-access lowering, so `s.x` and nested `n.inner.x` lower into HIR with no new expression node.

The "unsupported" reject for these types moves from AST-to-HIR down to HIR-to-MIR, where the type translation now fails cleanly rather than rejecting at intern time. This keeps HIR a faithful mirror of the source (dump hir shows the full type) and places the "cannot lower this yet" decision at the layer that owns the translation, matching the HIR-to-MIR contract.

## Design

Moving the reject to HIR-to-MIR would have dropped the diagnostic's source location, since HIR types previously carried no span. To preserve a located error, `hir::Type` now carries the declaration site that first interned it (builtins carry `UnknownSpan`), and the type-translation reject anchors its diagnostic there. The reject still reports the same `file:line` and source snippet as before.

## Testing

`bazel test //...` green. Updated the existing unpacked-struct error case for the reworded message and added an unpacked-union error case (a distinct reject path). Tagged-union construction (`tagged a 5`) and pattern matching (LRM 12.6) remain unsupported expression/statement forms, gated behind this same type reject.