### PR TITLE
Model lifecycle bodies as override methods

### DIFF
--- a/docs/progress/object-model.md
+++ b/docs/progress/object-model.md
@@ -23,7 +23,7 @@ each stage establishes, not how.
       adequately from how a member is owned today; a base-lineage read is a later purity refinement,
       not done as a standalone non-neutral change.)
 
-- [ ] Each post-construction lifecycle body (the scope's resolve / initialize / activate work) is an
+- [x] Each post-construction lifecycle body (the scope's resolve / initialize / activate work) is an
       ordinary method that records, as a first-class fact, which runtime-base method it overrides --
       a resolved declaration reference, not a textual name. The per-phase special fields on the
       object declaration are gone. The full dynamic-dispatch slot machinery is not introduced here;

--- a/include/lyra/mir/class.hpp
+++ b/include/lyra/mir/class.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <cstdint>
 #include <optional>
 #include <string>
-#include <variant>
 #include <vector>
 
 #include "lyra/base/arena.hpp"
 #include "lyra/base/time.hpp"
 #include "lyra/mir/class_id.hpp"
+#include "lyra/mir/class_ref.hpp"
 #include "lyra/mir/member.hpp"
 #include "lyra/mir/method.hpp"
 #include "lyra/mir/param.hpp"
@@ -17,27 +16,6 @@
 #include "lyra/mir/type_id.hpp"
 
 namespace lyra::mir {
-
-// A fixed runtime-library base class. These are object types the runtime
-// library provides, not classes of any compilation unit: `kInstance` is a
-// module / interface / program instance and `kGenScope` a named generate scope,
-// both nodes in the runtime object tree.
-enum class RuntimeClassKind : std::uint8_t {
-  kInstance,
-  kGenScope,
-};
-
-// A reference to a runtime-library base class.
-struct RuntimeLibraryClassRef {
-  RuntimeClassKind kind;
-
-  auto operator==(const RuntimeLibraryClassRef&) const -> bool = default;
-};
-
-// A reference to the object type an object extends. A consumer resolves it
-// through one path rather than switching a closed classification; a base is a
-// runtime-library class.
-using ClassRef = std::variant<RuntimeLibraryClassRef>;
 
 struct Class {
   std::string name;
@@ -69,18 +47,6 @@ struct Class {
   // constructor is the allocation shell that kicks this off; an empty body
   // needs no kickoff.
   Block constructor_block;
-  // Cross-instance binding (a `ref` port aliases the child's reference member
-  // to the connected variable, LRM 23.3.3.2), run after the whole tree is
-  // built. Absent when the scope binds no cross-instance reference.
-  std::optional<MethodDecl> resolve;
-  // Variable initializers (LRM 6.8), run after resolution so they observe bound
-  // values. Absent when the scope has no value initializers.
-  std::optional<MethodDecl> initialize;
-  // Process activation (LRM 9.2): the scope's startup and shutdown lifecycle
-  // registrations for its `initial` / `final` / `always*` / continuous-assign
-  // bodies, run after initialization. The bodies are ordinary callables; this
-  // body holds their registrations. Absent when the scope has no process.
-  std::optional<MethodDecl> activate;
   base::Arena<Class, ClassId> nested_classes;
   base::Arena<MethodDecl, MethodId> methods;
   std::vector<TypeAliasDecl> type_aliases;

--- a/include/lyra/mir/class_ref.hpp
+++ b/include/lyra/mir/class_ref.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstdint>
+#include <variant>
+
+namespace lyra::mir {
+
+// A fixed runtime-library base class. These are object types the runtime
+// library provides, not classes of any compilation unit: `kInstance` is a
+// module / interface / program instance and `kGenScope` a named generate scope,
+// both nodes in the runtime object tree.
+enum class RuntimeClassKind : std::uint8_t {
+  kInstance,
+  kGenScope,
+};
+
+// A reference to a runtime-library base class.
+struct RuntimeLibraryClassRef {
+  RuntimeClassKind kind;
+
+  auto operator==(const RuntimeLibraryClassRef&) const -> bool = default;
+};
+
+// A reference to the object type an object extends. A consumer resolves it
+// through one path rather than switching a closed classification; a base is a
+// runtime-library class.
+using ClassRef = std::variant<RuntimeLibraryClassRef>;
+
+// A virtual hook the runtime base declares and the engine invokes after
+// construction: `kResolve` binds cross-instance references, `kInitialize` runs
+// variable initializers, and `kActivate` registers processes (the Resolve /
+// Initialize / Activate phases of the elaboration lifecycle).
+enum class RuntimeMethod : std::uint8_t {
+  kResolve,
+  kInitialize,
+  kActivate,
+};
+
+// A reference to a runtime-library method.
+struct RuntimeLibraryMethodRef {
+  RuntimeMethod method;
+
+  auto operator==(const RuntimeLibraryMethodRef&) const -> bool = default;
+};
+
+// A reference to the base method an instance method overrides, resolved to a
+// declaration rather than a textual name. A consumer reads the override target
+// through one path; the only base method is a runtime-library lifecycle hook.
+using OverriddenMethodRef = std::variant<RuntimeLibraryMethodRef>;
+
+}  // namespace lyra::mir

--- a/include/lyra/mir/method.hpp
+++ b/include/lyra/mir/method.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include "lyra/mir/callable_code.hpp"
+#include "lyra/mir/class_ref.hpp"
 
 namespace lyra::mir {
 
@@ -16,11 +18,17 @@ namespace lyra::mir {
 // callable: a static function over the explicit receiver `self`. How a
 // referencing site reaches the callable -- a direct call, a constructor-time
 // process registration, an engine-dispatched lifecycle hook -- is the
-// referencing site's concern, realized as separate dispatch plumbing, not a
-// property carried on the body.
+// referencing site's concern, realized as separate dispatch plumbing. The
+// declaration records one dispatch fact of its own, the base method it
+// overrides when it overrides one, which leaves the uniform body untouched.
 struct MethodDecl {
   std::string name;
   CallableCode code;
+  // The base method this declaration overrides, resolved to a declaration
+  // reference, or absent for a method that introduces no override. A lifecycle
+  // body overrides the runtime base's matching hook; a backend reads the
+  // override target here rather than re-deriving it from the method name.
+  std::optional<OverriddenMethodRef> overrides;
 };
 
 }  // namespace lyra::mir

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -15,6 +15,7 @@
 #include "lyra/backend/cpp/string_literal.hpp"
 #include "lyra/base/internal_error.hpp"
 #include "lyra/mir/class.hpp"
+#include "lyra/mir/class_ref.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/member.hpp"
 #include "lyra/mir/param.hpp"
@@ -77,14 +78,29 @@ auto RenderMethodParam(
   return std::format("{} {}", RenderTypeAsCpp(unit, s, param.type), param.name);
 }
 
+// The C++ name of a runtime-base virtual hook. The mapping from the resolved
+// override reference to the emitted token lives only here, so the override
+// relation stays a declaration reference everywhere else.
+auto RenderRuntimeMethodName(mir::RuntimeMethod method) -> std::string_view {
+  switch (method) {
+    case mir::RuntimeMethod::kResolve:
+      return "ResolveState";
+    case mir::RuntimeMethod::kInitialize:
+      return "InitializeState";
+    case mir::RuntimeMethod::kActivate:
+      return "CreateProcesses";
+  }
+  throw InternalError("RenderRuntimeMethodName: unknown RuntimeMethod");
+}
+
 // The one renderer for every callable body. A body renders uniformly as a
 // static function over the explicit receiver `self`: the result type (whose
 // `void` and coroutine cases are ordinary types, handled in `RenderTypeAsCpp`),
 // the name, every parameter (`self` is `params[0]`, rendered like any other),
 // and the body (a plain statement render, including any `co_return` that is
-// itself a body statement). How the engine or a call site reaches the body --
-// a direct call, a process registration, a lifecycle shim -- is separate
-// dispatch plumbing, not a property of the body.
+// itself a body statement). A method that overrides a runtime-base hook also
+// emits the thin virtual shim the engine dispatches through; it forwards to the
+// static body over `this`, the same plumbing the constructor uses for `init`.
 auto RenderMethod(
     const ScopeView* parent_struct_view, const mir::CompilationUnit& unit,
     const mir::Class& s, const mir::MethodDecl& m, std::size_t indent)
@@ -107,6 +123,15 @@ auto RenderMethod(
   out += std::format("{}{} {{\n", Indent(indent), sig);
   out += RenderBlockStatements(body_view, indent + 1);
   out += std::format("{}}}\n", Indent(indent));
+  if (m.overrides.has_value()) {
+    const std::string_view hook = std::visit(
+        [](const mir::RuntimeLibraryMethodRef& ref) {
+          return RenderRuntimeMethodName(ref.method);
+        },
+        *m.overrides);
+    out += std::format(
+        "{}void {}() override {{ {}(this); }}\n", Indent(indent), hook, m.name);
+  }
   return out;
 }
 
@@ -251,33 +276,6 @@ auto RenderScopeAsClass(
   if (s.base.has_value()) {
     out +=
         RenderConstructor(this_anchor, s, RenderBaseClass(*s.base), indent + 1);
-  }
-
-  // The resolve and initialize phases run after construction, present only
-  // when the scope has work for that phase. Each body renders as the uniform
-  // static callable; the engine dispatches it through a thin virtual override
-  // that forwards to the static body over `this`, the same plumbing pattern the
-  // constructor uses for `init`.
-  const auto render_lifecycle = [&](const mir::MethodDecl& m) -> std::string {
-    return RenderMethod(parent_struct_view, unit, s, m, indent + 1) +
-           std::format(
-               "{}void {}() override {{ {}(this); }}\n", Indent(indent + 1),
-               m.name, m.name);
-  };
-  if (s.resolve.has_value()) {
-    out += "\n";
-    out += render_lifecycle(*s.resolve);
-  }
-  if (s.initialize.has_value()) {
-    out += "\n";
-    out += render_lifecycle(*s.initialize);
-  }
-  // The activate body registers this scope's processes (its `CreateProcesses`
-  // override); child links are registered automatically at construction and
-  // walked by the base, so only a scope with its own processes has one.
-  if (s.activate.has_value()) {
-    out += "\n";
-    out += render_lifecycle(*s.activate);
   }
 
   // A unit-root scope is a module instance; its name is the def-name an upward

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -26,6 +26,7 @@
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/block_hops.hpp"
 #include "lyra/mir/class.hpp"
+#include "lyra/mir/class_ref.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/local.hpp"
@@ -1308,9 +1309,6 @@ auto ClassLowerer::Run(
       .params = {},
       .members = {},
       .constructor_block = {},
-      .resolve = std::nullopt,
-      .initialize = std::nullopt,
-      .activate = std::nullopt,
       .nested_classes = {},
       .methods = {},
       .type_aliases = {}};
@@ -1576,33 +1574,45 @@ auto ClassLowerer::Run(
   mir_class.constructor_block = std::move(ctor_block);
   // The resolve, initialize, and activate phases are synthesized callables run
   // by the engine after construction (LRM 23.3.3.2 / 6.8 / 9.2), present only
-  // when the scope has work for that phase. Their bodies are uniform callables
-  // over the explicit `self` (`code.params[0]`); the engine reaches them
-  // through a virtual-dispatch shim the backend emits as separate plumbing, the
-  // same way the constructor delegates to its static body.
+  // when the scope has work for that phase. Each is an ordinary method that
+  // overrides the matching runtime-base hook; the override target is a resolved
+  // reference, so the engine reaches the body through one override-driven shim
+  // -- the same machinery a user-defined virtual method uses.
   if (!resolve_block.root_stmts.empty()) {
-    mir_class.resolve = mir::MethodDecl{
-        .name = "ResolveState",
-        .code = mir::CallableCode{
-            .params = {resolve_self_id},
-            .result_type = void_type,
-            .body = std::move(resolve_block)}};
+    mir_class.methods.Add(
+        mir::MethodDecl{
+            .name = "ResolveState",
+            .code =
+                mir::CallableCode{
+                    .params = {resolve_self_id},
+                    .result_type = void_type,
+                    .body = std::move(resolve_block)},
+            .overrides = mir::OverriddenMethodRef{mir::RuntimeLibraryMethodRef{
+                .method = mir::RuntimeMethod::kResolve}}});
   }
   if (!initialize_block.root_stmts.empty()) {
-    mir_class.initialize = mir::MethodDecl{
-        .name = "InitializeState",
-        .code = mir::CallableCode{
-            .params = {init_self_id},
-            .result_type = void_type,
-            .body = std::move(initialize_block)}};
+    mir_class.methods.Add(
+        mir::MethodDecl{
+            .name = "InitializeState",
+            .code =
+                mir::CallableCode{
+                    .params = {init_self_id},
+                    .result_type = void_type,
+                    .body = std::move(initialize_block)},
+            .overrides = mir::OverriddenMethodRef{mir::RuntimeLibraryMethodRef{
+                .method = mir::RuntimeMethod::kInitialize}}});
   }
   if (!activate_block.root_stmts.empty()) {
-    mir_class.activate = mir::MethodDecl{
-        .name = "CreateProcesses",
-        .code = mir::CallableCode{
-            .params = {activate_self_id},
-            .result_type = void_type,
-            .body = std::move(activate_block)}};
+    mir_class.methods.Add(
+        mir::MethodDecl{
+            .name = "CreateProcesses",
+            .code =
+                mir::CallableCode{
+                    .params = {activate_self_id},
+                    .result_type = void_type,
+                    .body = std::move(activate_block)},
+            .overrides = mir::OverriddenMethodRef{mir::RuntimeLibraryMethodRef{
+                .method = mir::RuntimeMethod::kActivate}}});
   }
 
   return mir_class;

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -83,10 +83,12 @@ auto LowerContinuousAssign(
       mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
   return mir::MethodDecl{
       .name = std::move(name),
-      .code = mir::CallableCode{
-          .params = {self_id},
-          .result_type = lowerer.Module().Unit().builtins.coroutine,
-          .body = std::move(process_block)}};
+      .code =
+          mir::CallableCode{
+              .params = {self_id},
+              .result_type = lowerer.Module().Unit().builtins.coroutine,
+              .body = std::move(process_block)},
+      .overrides = std::nullopt};
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -121,10 +121,12 @@ auto LowerStraightLineProcess(ProcessLowerer& process)
       mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
   return mir::MethodDecl{
       .name = std::string{process.CallableName()},
-      .code = mir::CallableCode{
-          .params = {self_id},
-          .result_type = process.Module().Unit().builtins.coroutine,
-          .body = std::move(process_block)}};
+      .code =
+          mir::CallableCode{
+              .params = {self_id},
+              .result_type = process.Module().Unit().builtins.coroutine,
+              .body = std::move(process_block)},
+      .overrides = std::nullopt};
 }
 
 // Wraps the body in a `forever` loop. `implicit_sensitivity`, if present,
@@ -169,10 +171,12 @@ auto LowerForeverProcess(
       mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
   return mir::MethodDecl{
       .name = std::string{process.CallableName()},
-      .code = mir::CallableCode{
-          .params = {self_id},
-          .result_type = process.Module().Unit().builtins.coroutine,
-          .body = std::move(process_block)}};
+      .code =
+          mir::CallableCode{
+              .params = {self_id},
+              .result_type = process.Module().Unit().builtins.coroutine,
+              .body = std::move(process_block)},
+      .overrides = std::nullopt};
 }
 
 }  // namespace
@@ -318,10 +322,12 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
 
   return mir::MethodDecl{
       .name = src.name,
-      .code = mir::CallableCode{
-          .params = std::move(params),
-          .result_type = result_type,
-          .body = std::move(body_block)}};
+      .code =
+          mir::CallableCode{
+              .params = std::move(params),
+              .result_type = result_type,
+              .body = std::move(body_block)},
+      .overrides = std::nullopt};
 }
 
 auto ProcessLowerer::BuildReturnPayload(

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -13,6 +13,7 @@
 #include "lyra/base/overloaded.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/class.hpp"
+#include "lyra/mir/class_ref.hpp"
 #include "lyra/mir/closure.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
@@ -691,27 +692,6 @@ class MirDumper {
     DumpBlock(s.constructor_block);
     Dedent();
 
-    if (s.resolve.has_value()) {
-      Line("Resolve:");
-      Indent();
-      DumpMethod(*s.resolve, 0);
-      Dedent();
-    }
-
-    if (s.initialize.has_value()) {
-      Line("Initialize:");
-      Indent();
-      DumpMethod(*s.initialize, 0);
-      Dedent();
-    }
-
-    if (s.activate.has_value()) {
-      Line("Activate:");
-      Indent();
-      DumpMethod(*s.activate, 0);
-      Dedent();
-    }
-
     Dedent();
     scope_stack_.pop_back();
   }
@@ -721,6 +701,16 @@ class MirDumper {
         std::format(
             "[{}] \"{}\" : Type[{}]", index, d.name, d.code.result_type.value));
     Indent();
+    if (d.overrides.has_value()) {
+      const auto& ref = std::get<RuntimeLibraryMethodRef>(*d.overrides);
+      std::string_view target = "Resolve";
+      if (ref.method == RuntimeMethod::kInitialize) {
+        target = "Initialize";
+      } else if (ref.method == RuntimeMethod::kActivate) {
+        target = "Activate";
+      }
+      Line(std::format("Overrides: {}", target));
+    }
     for (std::size_t i = 0; i < d.code.params.size(); ++i) {
       const auto& param = d.code.body.vars.Get(d.code.params[i]);
       Line(


### PR DESCRIPTION
## Summary

A scope's post-construction lifecycle bodies (resolve, initialize, activate) were special optional fields on the object declaration, and the backend recovered the runtime hook each one overrode from a textual method name. This makes each lifecycle body an ordinary method that records, as a first-class fact, which runtime-base method it overrides -- a resolved declaration reference rather than a name. The per-phase special fields are gone, and the override relation is the one machinery a user-defined virtual method will reuse.

## Design

A new `OverriddenMethodRef` mirrors the existing `ClassRef`: a variant whose only arm today is a runtime-library reference (`RuntimeLibraryMethodRef` over a `RuntimeMethod` hook). `MethodDecl` gains an optional override target, so the three lifecycle bodies now live in the class's method list carrying their override reference, and the emitter renders every method through one path -- the static body plus, when an override is present, the thin virtual shim the engine dispatches through. The C++ token for each runtime hook is resolved from the enum in exactly one place, so the override stays a declaration reference everywhere else. `ClassRef` and the new method-reference types move into a shared header so the class and method declarations can both name them.

## Testing

`bazel test //...` passes. The change is behavior-neutral: the emitted lifecycle shims are identical in form, and only the MIR dump changes (lifecycle bodies now appear under the method list with an explicit override line).