### PR TITLE
Add --disable-assertions to skip assertion lowering

### DIFF
--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -49,13 +49,12 @@ full support.
 
 ### Common forms
 
-- [ ] **Expose `disable_assertions` on the current entry path.** Untouched, the design's first
+- [x] **Expose `disable_assertions` on the current entry path.** Untouched, the design's first
       blocker in many modules is a concurrent assertion (the `assert`/`assume`/`cover property`
       family and the macros wrapping them). The accepted handling is the `disable_assertions`
-      compilation option, but it is not reachable on this branch -- there is no CLI flag and no
-      project mode to set it. Wiring it through is the gap; implementing SVA proper (sampled-value
-      functions `$rose`/`$fell`/`$stable`/`$past`, the `Observed` region) is a separate, optional
-      feature off the critical path to running Ibex.
+      compilation option, which skips assertion constructs during lowering. Implementing SVA proper
+      (sampled-value functions `$rose`/`$fell`/`$stable`/`$past`, the `Observed` region) is a
+      separate, optional feature off the critical path to running Ibex.
 - [ ] **Packed array whose element is a struct or enum** (a packed array of a packed aggregate, not
       just of a scalar bit/logic).
 - [ ] **Net-typed port connections** -- connecting a net (`wire`) across a module port, as the

--- a/include/lyra/frontend/load.hpp
+++ b/include/lyra/frontend/load.hpp
@@ -21,6 +21,7 @@ struct CompilationInput {
   std::vector<std::string> defines;
   std::vector<std::string> param_overrides;
   bool single_unit = false;
+  bool disable_assertions = false;
 };
 
 struct ParseResult {

--- a/include/lyra/lowering/ast_to_hir/lower.hpp
+++ b/include/lyra/lowering/ast_to_hir/lower.hpp
@@ -15,16 +15,18 @@ namespace lyra::lowering::ast_to_hir {
 // Driver-supplied facts threaded into AST-to-HIR lowering. `Compilation&` is
 // the slang elaboration root; `SourceMapper&` translates slang source
 // locations; `SensitivityAnalyzer&` is reused across modules so its read
-// cache survives.
+// cache survives. `disable_assertions` is the lowering policy that elides
+// assertion constructs instead of rejecting them.
 class LowerCompilationFacts {
  public:
   LowerCompilationFacts(
       slang::ast::Compilation& compilation,
       const frontend::SlangSourceMapper& source_mapper,
-      SensitivityAnalyzer& sensitivity_analyzer)
+      SensitivityAnalyzer& sensitivity_analyzer, bool disable_assertions)
       : compilation_(&compilation),
         source_mapper_(&source_mapper),
-        sensitivity_analyzer_(&sensitivity_analyzer) {
+        sensitivity_analyzer_(&sensitivity_analyzer),
+        disable_assertions_(disable_assertions) {
   }
 
   [[nodiscard]] auto Compilation() const -> slang::ast::Compilation& {
@@ -37,11 +39,15 @@ class LowerCompilationFacts {
   [[nodiscard]] auto Sensitivity() const -> SensitivityAnalyzer& {
     return *sensitivity_analyzer_;
   }
+  [[nodiscard]] auto DisableAssertions() const -> bool {
+    return disable_assertions_;
+  }
 
  private:
   slang::ast::Compilation* compilation_;
   const frontend::SlangSourceMapper* source_mapper_;
   SensitivityAnalyzer* sensitivity_analyzer_;
+  bool disable_assertions_;
 };
 
 // Lowers the top-level blocks and, transitively, every unit they instantiate.

--- a/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
@@ -80,16 +80,18 @@ struct ScopeEntryLoopVarBinding {
 
 // Shared lowering-pass facts threaded into every ModuleLowerer. SourceMapper
 // translates slang source locations; SensitivityAnalyzer is shared across
-// every module's analysis (caches reads). Subset of `LowerCompilationFacts`
-// that excludes the slang Compilation handle (which only the driver-level
-// CompilationLowerer needs to walk top instances).
+// every module's analysis (caches reads); disable_assertions is the policy
+// that elides assertion constructs instead of rejecting them. Subset of
+// `LowerCompilationFacts` that excludes the slang Compilation handle (which
+// only the driver-level CompilationLowerer needs to walk top instances).
 class LoweringFacts {
  public:
   LoweringFacts(
       const frontend::SlangSourceMapper& source_mapper,
-      SensitivityAnalyzer& sensitivity_analyzer)
+      SensitivityAnalyzer& sensitivity_analyzer, bool disable_assertions)
       : source_mapper_(&source_mapper),
-        sensitivity_analyzer_(&sensitivity_analyzer) {
+        sensitivity_analyzer_(&sensitivity_analyzer),
+        disable_assertions_(disable_assertions) {
   }
 
   [[nodiscard]] auto SourceMapper() const
@@ -101,9 +103,14 @@ class LoweringFacts {
     return *sensitivity_analyzer_;
   }
 
+  [[nodiscard]] auto DisableAssertions() const -> bool {
+    return disable_assertions_;
+  }
+
  private:
   const frontend::SlangSourceMapper* source_mapper_;
   SensitivityAnalyzer* sensitivity_analyzer_;
+  bool disable_assertions_;
 };
 
 // Per-module lowerer.
@@ -145,6 +152,9 @@ class ModuleLowerer {
   }
   [[nodiscard]] auto Sensitivity() const -> SensitivityAnalyzer& {
     return facts_.Sensitivity();
+  }
+  [[nodiscard]] auto DisableAssertions() const -> bool {
+    return facts_.DisableAssertions();
   }
 
   // Binding registries. Each Map* asserts no double-mapping for the same

--- a/src/lyra/compiler/compile.cpp
+++ b/src/lyra/compiler/compile.cpp
@@ -38,7 +38,8 @@ auto Compile(
   auto hir = lowering::ast_to_hir::LowerCompilation(
       lowering::ast_to_hir::LowerCompilationFacts(
           *result.artifacts.parse->compilation,
-          result.artifacts.parse->source_mapper, sensitivity_analyzer));
+          result.artifacts.parse->source_mapper, sensitivity_analyzer,
+          input.disable_assertions));
   if (!hir) {
     sink.Report(std::move(hir.error()));
     return result;

--- a/src/lyra/driver/cli.cpp
+++ b/src/lyra/driver/cli.cpp
@@ -83,6 +83,11 @@ void AddCompilationFlags(argparse::ArgumentParser& cmd) {
       .help("compile all files as a single compilation unit")
       .default_value(false)
       .implicit_value(true);
+  cmd.add_argument("--disable-assertions")
+      .help(
+          "skip assertion constructs during lowering instead of rejecting them")
+      .default_value(false)
+      .implicit_value(true);
   cmd.add_argument("--format")
       .help("reformat the emitted C++ with clang-format (skipped if absent)")
       .default_value(false)
@@ -107,6 +112,7 @@ void BindCompilationFlags(
     out.input.param_overrides = std::move(*ovr);
   }
   out.input.single_unit = cmd.get<bool>("--single-unit");
+  out.input.disable_assertions = cmd.get<bool>("--disable-assertions");
   out.format = cmd.get<bool>("--format");
   if (auto files = cmd.present<std::vector<std::string>>("files")) {
     out.input.files = std::move(*files);

--- a/src/lyra/lowering/ast_to_hir/compilation_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/compilation_lowerer.cpp
@@ -46,7 +46,10 @@ struct UnitCollector
 class CompilationLowerer {
  public:
   explicit CompilationLowerer(const LowerCompilationFacts& facts)
-      : facts_(facts), unit_facts_(facts.SourceMapper(), facts.Sensitivity()) {
+      : facts_(facts),
+        unit_facts_(
+            facts.SourceMapper(), facts.Sensitivity(),
+            facts.DisableAssertions()) {
   }
 
   auto Run() -> diag::Result<std::vector<hir::ModuleUnit>> {

--- a/src/lyra/lowering/ast_to_hir/statement/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/lower.cpp
@@ -10,7 +10,6 @@
 #include <slang/ast/symbols/VariableSymbols.h>
 
 #include "lyra/diag/diag_code.hpp"
-#include "lyra/diag/kind.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/statement/blocks.hpp"
@@ -184,6 +183,19 @@ auto LowerStatement(
     case slang::ast::StatementKind::Return:
       return LowerReturnStmt(
           proc, frame, stmt.as<slang::ast::ReturnStatement>(), span);
+
+    case slang::ast::StatementKind::ImmediateAssertion:
+    case slang::ast::StatementKind::ConcurrentAssertion:
+      // An assertion embedded in surrounding behavior contributes no statement
+      // when disabled; the rest of the process runs. Without the policy it is a
+      // rejected construct, not silently ignored.
+      if (proc.Module().DisableAssertions()) {
+        return LowerEmptyStmt(span);
+      }
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedStatementForm,
+          "assertion statements are not supported; pass --disable-assertions "
+          "to skip them");
 
     default:
       return diag::Fail(

--- a/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
@@ -373,6 +373,14 @@ auto StructuralScopeLowerer::PopulateSubroutineMember(
 auto StructuralScopeLowerer::PopulateProceduralBlockMember(
     const slang::ast::ProceduralBlockSymbol& proc, WalkFrame frame)
     -> diag::Result<void> {
+  // A concurrent assertion declared as a module item becomes a process whose
+  // entire body is the assertion. When assertions are disabled the process
+  // contributes no behavior, so it is dropped at the source rather than emptied
+  // -- an always block with no body and no timing control would be a zero-delay
+  // infinite loop.
+  if (module_->DisableAssertions() && proc.isFromAssertion) {
+    return {};
+  }
   ProcessLowerer proc_lowerer(*module_, proc);
   auto p = proc_lowerer.Run(proc, frame);
   if (!p) return std::unexpected(std::move(p.error()));

--- a/tests/cases/cpp/disable_assertions/case.yaml
+++ b/tests/cases/cpp/disable_assertions/case.yaml
@@ -1,0 +1,13 @@
+id: cpp.disable_assertions
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--disable-assertions"]
+expect:
+  exit: 0
+  stdout:
+    exact: |
+      RUN

--- a/tests/cases/cpp/disable_assertions/main.sv
+++ b/tests/cases/cpp/disable_assertions/main.sv
@@ -1,0 +1,17 @@
+module Top;
+  logic clk = 1'b0;
+  logic a = 1'b0;
+  logic b = 1'b1;
+
+  // Module-item concurrent assertion: without --disable-assertions this blocks
+  // lowering, and an empty always-loop in its place would be a zero-delay hang.
+  // The flag drops the synthesized process entirely.
+  assert property (@(posedge clk) a |-> b);
+
+  initial begin
+    // Immediate assertion with a deliberately false condition. The flag skips
+    // it, so execution falls through to the display rather than stopping.
+    assert (a == b);
+    $display("RUN");
+  end
+endmodule

--- a/tests/cases/errors/assertions_unsupported/case.yaml
+++ b/tests/cases/errors/assertions_unsupported/case.yaml
@@ -1,0 +1,17 @@
+id: errors.assertions_unsupported
+tags: [errors, diag]
+input:
+  command: [emit, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+  args: ["--no-color"]
+expect:
+  exit: 1
+  stderr:
+    contains:
+      - "unsupported:"
+      - "assertion"
+      - "--disable-assertions"
+    not_contains:
+      - "internal error"

--- a/tests/cases/errors/assertions_unsupported/main.sv
+++ b/tests/cases/errors/assertions_unsupported/main.sv
@@ -1,0 +1,7 @@
+module Top;
+  logic clk = 1'b0;
+  logic a = 1'b0;
+  logic b = 1'b1;
+
+  assert property (@(posedge clk) a |-> b);
+endmodule

--- a/tests/framework/runner.cpp
+++ b/tests/framework/runner.cpp
@@ -485,6 +485,9 @@ auto RunCppCase(const std::filesystem::path& lyra_exe, const TestCase& c)
     argv.emplace_back("--top");
     argv.push_back(*c.input.top);
   }
+  for (const auto& a : c.input.extra_args) {
+    argv.push_back(a);
+  }
   for (const auto& f : resolved_input_files) {
     argv.push_back(f.string());
   }


### PR DESCRIPTION
## Summary

Adds a `--disable-assertions` compilation flag that skips SystemVerilog assertions during AST-to-HIR lowering instead of rejecting them. Untouched, a concurrent assertion is the first lowering blocker in many Ibex modules; this flag is the accepted handling that lets those modules compile while implementing SVA proper remains a separate, optional workstream.

## Design

Assertions enter lowering at two surfaces, each handled by the same "an assertion contributes no behavior when disabled" rule applied at the right granularity. A concurrent assertion declared as a module item becomes a process whose entire body is the assertion (slang marks it `isFromAssertion`); that process is dropped at the source, because emptying its body would leave an `always` block with no timing control -- a zero-delay infinite loop. An assertion statement embedded in a real process is lowered to an empty statement so the surrounding behavior survives. Without the flag both kinds produce an actionable diagnostic pointing at `--disable-assertions`.

The policy threads from the CLI through `CompilationInput` into the existing `LowerCompilationFacts` / `LoweringFacts` carriers, reaching both consumers via `ModuleLowerer`, symmetric with how the source mapper and sensitivity analyzer already flow.

## Testing

A run-cpp case exercises both surfaces end-to-end: a module-item concurrent assertion (which would otherwise hang) and a deliberately-false immediate assertion, confirming execution proceeds. An error case asserts the no-flag diagnostic. The run-cpp test path previously dropped per-case `args:`; that gap is fixed so the flag reaches the binary.