### PR TITLE
Materialize unpacked-array constants in lowering

### DIFF
--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -43,9 +43,11 @@ full support.
       stop in roughly a dozen modules and present throughout the design. A generate loop unrolls
       into elaborated structure at compile time; this is structural elaboration, distinct from a
       procedural `for`.
-- [ ] **`parameter` / `localparam` referenced inside a continuous-assign expression** (e.g. a
+- [x] **`parameter` / `localparam` referenced inside a continuous-assign expression** (e.g. a
       part-select bound `x[Aw-1:0]` where `Aw` is a `localparam`). Parameters appear in expressions
-      pervasively, so this reaches far past the leaf modules where it is the first blocker.
+      pervasively, so this reaches far past the leaf modules where it is the first blocker. Scalar
+      parameters fold in any expression context; an unpacked-array `localparam` referenced and
+      element-selected (the ibex_alu shuffle-mask form) now materializes too.
 
 ### Common forms
 
@@ -65,8 +67,10 @@ full support.
 
 - [ ] **Hierarchical / cross-unit reference to a parameter** (reaching a sub-instance's parameter
       through a dotted path, e.g. the `mhpmcounter` accessor in the DPI block).
-- [ ] **Constant of aggregate type** (an elaboration-time constant whose type is an array/struct
-      rather than a scalar).
+- [x] **Constant of an unpacked array type** -- an elaboration-time `localparam` array referenced
+      (and element-selected) in an expression. An unpacked struct or union constant is still
+      blocked, but on unpacked-struct / union _type_ support rather than on constant
+      materialization.
 - [ ] Remaining structural-expression forms surfaced as later passes get deeper (recorded here as
       discovery continues).
 

--- a/include/lyra/lowering/ast_to_hir/constant_value.hpp
+++ b/include/lyra/lowering/ast_to_hir/constant_value.hpp
@@ -5,16 +5,22 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/expr.hpp"
+#include "lyra/hir/module_unit.hpp"
 #include "lyra/hir/type_id.hpp"
+#include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
-// Materialize an already-evaluated slang ConstantValue as an HIR literal
-// expression of `type`: integral, real, shortreal, or string. Used wherever a
-// slang-folded constant is spliced into the HIR -- parameter and enum-value
-// references, and defaulted port connections. Aggregate constants are not yet
-// supported.
+// Materialize an already-evaluated slang ConstantValue as an HIR expression of
+// `type`. A scalar value (integral, real, shortreal, string) becomes a literal.
+// An unpacked array becomes an AssignmentPatternExpr whose elements are
+// themselves materialized constants, appended to the frame's expr arena; `unit`
+// supplies the element type the recursion descends into. Packed aggregates
+// never reach here -- slang folds them to a single integral value. Used
+// wherever a slang-folded constant is spliced into the HIR -- parameter and
+// enum-value references, and defaulted port connections.
 auto MakeConstantValueExpr(
+    const hir::ModuleUnit& unit, WalkFrame frame,
     const slang::ConstantValue& cv, hir::TypeId type, diag::SourceSpan span)
     -> diag::Result<hir::Expr>;
 

--- a/src/lyra/lowering/ast_to_hir/constant_value.cpp
+++ b/src/lyra/lowering/ast_to_hir/constant_value.cpp
@@ -1,13 +1,53 @@
 #include "lyra/lowering/ast_to_hir/constant_value.hpp"
 
+#include <utility>
+#include <variant>
+#include <vector>
+
 #include "lyra/diag/diag_code.hpp"
-#include "lyra/diag/kind.hpp"
 #include "lyra/hir/primary.hpp"
+#include "lyra/hir/type.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
 
 namespace lyra::lowering::ast_to_hir {
 
+namespace {
+
+// An unpacked array constant folds element-by-element into an
+// AssignmentPatternExpr, the same shape a written `'{...}` pattern lowers to,
+// so the downstream array-construction path is shared. Every element shares the
+// array's element type and recurses, so an array of arrays folds the same way.
+auto MakeUnpackedConstantExpr(
+    const hir::ModuleUnit& unit, WalkFrame frame,
+    const slang::ConstantValue& cv, hir::TypeId type, diag::SourceSpan span)
+    -> diag::Result<hir::Expr> {
+  const auto& ty = unit.GetType(type);
+  const auto* arr = std::get_if<hir::UnpackedArrayType>(&ty.data);
+  if (arr == nullptr) {
+    return diag::Fail(
+        span, diag::DiagCode::kUnsupportedExpressionForm,
+        "constant of aggregate type is not yet supported");
+  }
+  const auto elements = cv.elements();
+  std::vector<hir::ExprId> element_ids;
+  element_ids.reserve(elements.size());
+  for (const auto& elem_cv : elements) {
+    auto elem =
+        MakeConstantValueExpr(unit, frame, elem_cv, arr->element_type, span);
+    if (!elem) return std::unexpected(std::move(elem.error()));
+    element_ids.push_back(frame.Exprs().Add(*std::move(elem)));
+  }
+  return hir::Expr{
+      .type = type,
+      .data = hir::AssignmentPatternExpr{.elements = std::move(element_ids)},
+      .span = span,
+  };
+}
+
+}  // namespace
+
 auto MakeConstantValueExpr(
+    const hir::ModuleUnit& unit, WalkFrame frame,
     const slang::ConstantValue& cv, hir::TypeId type, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
   if (cv.isInteger()) {
@@ -37,6 +77,9 @@ auto MakeConstantValueExpr(
         .data = hir::PrimaryExpr{.data = hir::StringLiteral{.value = cv.str()}},
         .span = span,
     };
+  }
+  if (cv.isUnpacked()) {
+    return MakeUnpackedConstantExpr(unit, frame, cv, type, span);
   }
   return diag::Fail(
       span, diag::DiagCode::kUnsupportedExpressionForm,

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -100,7 +100,8 @@ auto LowerNamedValueProc(
     auto type_id = module.InternType(*named.type, span);
     if (!type_id) return std::unexpected(std::move(type_id.error()));
     return MakeConstantValueExpr(
-        sym.as<slang::ast::ParameterSymbol>().getValue(), *type_id, span);
+        module.Unit(), frame, sym.as<slang::ast::ParameterSymbol>().getValue(),
+        *type_id, span);
   }
 
   // Subroutine formals (LRM 13.5) and foreach iterators (LRM 12.7.3) are
@@ -307,7 +308,8 @@ auto LowerNamedValueStructural(
     auto type_id = module.InternType(*named.type, span);
     if (!type_id) return std::unexpected(std::move(type_id.error()));
     return MakeConstantValueExpr(
-        sym.as<slang::ast::ParameterSymbol>().getValue(), *type_id, span);
+        module.Unit(), frame, sym.as<slang::ast::ParameterSymbol>().getValue(),
+        *type_id, span);
   }
   if (sym.kind != slang::ast::SymbolKind::Variable) {
     return diag::Fail(

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -11,7 +11,6 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
-#include "lyra/diag/kind.hpp"
 #include "lyra/hir/binary_op.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/expr_builders.hpp"
@@ -124,7 +123,8 @@ auto LowerRangeSelectExpr(
     if (const auto* constant = bound.getConstant(); constant != nullptr) {
       auto bound_type = lowerer.Module().InternType(*bound.type, span);
       if (!bound_type) return std::unexpected(std::move(bound_type.error()));
-      auto literal = MakeConstantValueExpr(*constant, *bound_type, span);
+      auto literal = MakeConstantValueExpr(
+          lowerer.Module().Unit(), frame, *constant, *bound_type, span);
       if (!literal) return std::unexpected(std::move(literal.error()));
       return frame.Exprs().Add(*std::move(literal));
     }

--- a/src/lyra/lowering/ast_to_hir/port_connection.cpp
+++ b/src/lyra/lowering/ast_to_hir/port_connection.cpp
@@ -130,7 +130,8 @@ auto ConnectElementPorts(
             throw InternalError(
                 "ConnectElementPorts: port default did not fold to a constant");
           }
-          auto peer_or = MakeConstantValueExpr(*constant, *type_id, span);
+          auto peer_or = MakeConstantValueExpr(
+              module.Unit(), frame, *constant, *type_id, span);
           if (!peer_or) return std::unexpected(std::move(peer_or.error()));
           peer = frame.Exprs().Add(*std::move(peer_or));
         } else {

--- a/tests/cases/cpp/aggregate_constant_reference/case.yaml
+++ b/tests/cases/cpp/aggregate_constant_reference/case.yaml
@@ -1,0 +1,14 @@
+id: cpp.aggregate_constant_reference
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    ca_first: 10
+    ca_last: 40
+    ca_gen0: 11
+    sum: 50

--- a/tests/cases/cpp/aggregate_constant_reference/main.sv
+++ b/tests/cases/cpp/aggregate_constant_reference/main.sv
@@ -1,0 +1,25 @@
+module Top;
+  // Unpacked array constant -- the localparam form ibex_alu's shuffle masks use.
+  localparam logic [31:0] Tbl [4] = '{32'd10, 32'd20, 32'd30, 32'd40};
+
+  // Continuous assign reading the constant array with a constant element index.
+  int ca_first;
+  int ca_last;
+  assign ca_first = Tbl[0];
+  assign ca_last = Tbl[3];
+
+  // Generate loop unrolling an element-select on the constant array -- the exact
+  // form that first surfaced the gap in ibex_alu.
+  logic [31:0] bumped [4];
+  for (genvar i = 0; i < 4; i++) begin : gen_bump
+    assign bumped[i] = Tbl[i] + 32'd1;
+  end
+  int ca_gen0;
+  assign ca_gen0 = bumped[0];
+
+  // Procedural element-select reading the constant array.
+  int sum;
+  initial begin
+    sum = Tbl[1] + Tbl[2];
+  end
+endmodule


### PR DESCRIPTION
## Summary

An elaboration-time `localparam` of unpacked-array type could not be referenced in an expression: any such reference folded the whole array via slang's constant value and `MakeConstantValueExpr` rejected every non-scalar value with "constant of aggregate type is not yet supported". This blocked, among others, the shuffle-mask continuous assigns in `ibex_alu`, where a `localparam logic [31:0] MASK [4]` is element-selected inside a generate loop. Scalar parameters already folded in every expression context; this closes the unpacked-array half of that gap.

## Design

`MakeConstantValueExpr` now materializes an unpacked-array constant element-by-element into an `AssignmentPatternExpr` -- the same shape a written `'{...}` pattern lowers to -- so the existing array-construction path (AssignmentPatternExpr -> MIR ArrayLiteralExpr -> backend std::array) is reused rather than introducing a new IR node. Each element recurses, so a nested array folds the same way. The element type comes from the aggregate's HIR type, so no slang re-interning is needed.

Because the recursion appends child expressions, the function now takes the `WalkFrame` (the codebase's by-value carrier for the expr arena, reached via `frame.Exprs()`) plus the `ModuleUnit` for the type table, instead of the bare arena. This matches how every other expression handler reaches the arena.

Packed aggregates never reach this path -- slang folds them to a single integral value. An unpacked struct or union constant remains blocked, but on unpacked-struct / union type support rather than on constant materialization.

## Testing

New `cpp.aggregate_constant_reference` case exercises an unpacked-array `localparam` read through a constant-index continuous assign, a generate-loop-unrolled element-select (the ibex_alu form), and a procedural element-select, asserting the resulting scalar values. Full `bazel test //...` passes.