### PR TITLE
Bind upward extern references as MIR method calls

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -33,6 +33,8 @@ Read top to bottom on first pass:
     construction-time resolution
 16. `emission_model.md` -- how a backend emits independent per-unit artifacts and realizes
     cross-unit resolution through the SDK
+16. `backend_contract.md` -- per-node within-artifact realization rules; type mapping vs value
+    emission; what a backend may and may not name in render
 17. `identity_and_ownership.md` -- identity rules and forbidden shapes
 18. `lowering_boundaries.md` -- what each lowering may and may not do
 19. `lowering_organization.md` -- how lowering passes organize their internal objects (facts,
@@ -56,6 +58,7 @@ If you are looking for a concept, this table points to the canonical doc.
 | Instance array as a data type; multiplicity vs generate axes              | `hierarchy_and_generate.md` |
 | Intra-unit vs cross-unit references; compile-time vs construction resolve | `reference_resolution.md`   |
 | Per-unit artifact emission; cross-unit realization via the SDK; no wiring | `emission_model.md`         |
+| Per-node within-artifact render; type mapping vs value emission           | `backend_contract.md`       |
 | Parameter values, specialization keys, per-specialization artifacts       | `specialization_model.md`   |
 | Identity rules; ownership; forbidden identity shapes                      | `identity_and_ownership.md` |
 | Lowering permissions (what each lowering may and may not do)              | `lowering_boundaries.md`    |
@@ -83,14 +86,14 @@ the decision's subject, top to bottom, and **check the design against every rele
 "Forbidden Shapes" before proposing it**. A design that matches a Forbidden Shape is wrong even if
 it compiles and passes tests.
 
-| Decision touches...                                          | Binding docs (read all, top-down)                                                                         |
-| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| Cross-unit access / hierarchical refs / ports / connectivity | `north_star`, `compilation_unit_model`, `reference_resolution`, `emission_model`, `elaboration_lifecycle` |
-| Backend emit / artifact structure / SDK boundary             | `north_star`, `compilation_unit_model`, `reference_resolution`, `emission_model`, `runtime_distribution`  |
-| Compilation boundaries / unit dependencies / incrementality  | `north_star`, `compilation_unit_model`, `incremental_build`                                               |
-| Hierarchy / generate / object graph / construction           | `north_star`, `hierarchy_and_generate`, `runtime_model`, `elaboration_lifecycle`                          |
-| Identity / ownership / id kinds                              | `north_star`, `identity_and_ownership`                                                                    |
-| Object model / classes / inheritance / dispatch / handles    | `north_star`, `object_model`, `mir`, `callable`, `runtime_model`                                          |
+| Decision touches...                                          | Binding docs (read all, top-down)                                                                                            |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| Cross-unit access / hierarchical refs / ports / connectivity | `north_star`, `compilation_unit_model`, `reference_resolution`, `emission_model`, `elaboration_lifecycle`                    |
+| Backend emit / artifact structure / SDK boundary             | `north_star`, `compilation_unit_model`, `reference_resolution`, `emission_model`, `backend_contract`, `runtime_distribution` |
+| Compilation boundaries / unit dependencies / incrementality  | `north_star`, `compilation_unit_model`, `incremental_build`                                                                  |
+| Hierarchy / generate / object graph / construction           | `north_star`, `hierarchy_and_generate`, `runtime_model`, `elaboration_lifecycle`                                             |
+| Identity / ownership / id kinds                              | `north_star`, `identity_and_ownership`                                                                                       |
+| Object model / classes / inheritance / dispatch / handles    | `north_star`, `object_model`, `mir`, `callable`, `runtime_model`                                                             |
 
 The failure mode this guards against: anchoring on current code -- which may be a transitional
 shortcut -- instead of the contract. Current code that contradicts a contract is wrong; read the

--- a/docs/architecture/backend_contract.md
+++ b/docs/architecture/backend_contract.md
@@ -1,0 +1,160 @@
+# Backend Contract
+
+## Purpose
+
+Define the mechanical-translation contract a backend must satisfy when consuming per-unit MIR.
+
+The architectural target of the compiler is HIR -> MIR -> LIR -> LLVM IR. The C++ backend is a
+transitional realization: it consumes the same MIR but renders to C++ source instead of descending
+through LIR and LLVM IR. The C++ backend's emitted output is **how MIR is observed during the
+architecture reset** -- a developer reads the emitted C++ to validate that MIR's shape faithfully
+represents the source SystemVerilog through MIR's semantic model (`compiler_overview.md`).
+
+The transitional status does **not** loosen the mechanical-translation discipline. The contract in
+this doc is exactly the discipline an eventual LLVM IR backend will need: every render rule is a
+fixed function of one MIR node. If the C++ backend's render needs any decision logic -- an `if` on a
+node's payload, a ternary inferring construction shape, a switch on type variant whose arms produce
+different syntactic structure -- the LLVM IR backend will need the same logic in its target. Both
+backends pay the cost; the cost is a MIR design failure visible from the backend side.
+
+The C++ backend's render therefore serves as the cross-check on MIR shape today: any place where its
+render is not a mechanical single-node translation is a place where the next stage (LIR / LLVM IR)
+will hit the same obstruction. The bug is in MIR, not in render.
+
+## Owns
+
+- The principle that a backend render entry is a **fixed function of one MIR node**: input is the
+  MIR node and its structural context (its children, the node consuming it); output is determined by
+  that input alone. The recursion structure follows the MIR node tree; the render of each node
+  composes target-language wrapping around recursive renders of its child nodes.
+- The boundary between two backend entry kinds:
+  - **Type mapping** -- one dispatch per MIR type variant returning a target representation (a
+    target-language type literal for C++, a size + an LLVM type for LLVM IR). This is the only entry
+    that names a target-language runtime library type.
+  - **Value emission** -- the entries that translate MIR expression, statement, member, and body
+    nodes into target-language form. They compose mechanical syntactic wrappers around recursive
+    renders; they make no decisions about what the program means.
+- The contract that MIR's primitive set is closed for backends: if a backend's render entry cannot
+  produce its output from the node's structural fields plus subordinate renders, the missing
+  semantic is upstream (MIR's primitive set or HIR-to-MIR's lowering), not in render.
+
+## Does Not Own
+
+- Which primitives MIR has (see `mir.md`).
+- Which target language a backend chooses.
+- The per-artifact and cross-unit boundary (see `emission_model.md`).
+- The runtime library a particular backend chooses to wrap target-side storage realizations in.
+- Where the runtime library lives and how a binary locates it (see `runtime_distribution.md`).
+
+## Core Invariants
+
+1. **A backend render entry is a fixed function of one MIR node.** Two MIR nodes of the same kind
+   with the same structural fields produce the same target-language output, every time, in every
+   backend.
+
+2. **Any decision logic inside a value-emission entry is a MIR design failure.** An `if`-branch,
+   ternary, or switch whose arms produce different syntactic shape in a value-emission entry is
+   render making a semantic decision. Render does not decide; it translates. If a render needs to
+   branch, MIR is not stating something the program needs to say, and HIR-to-MIR's output is leaving
+   render to fabricate it. The fix is upstream: extend MIR to state the missing semantic explicitly,
+   then render becomes uniform.
+
+3. **Type mapping is the only entry that names a runtime library type literal.** Every MIR type
+   variant maps to a target-language type representation through one dispatch. Value emission
+   entries render types only via that dispatch; they never compose a target-language type literal
+   directly. A runtime library type's spelling lives at one place; nowhere else.
+
+4. **Member declaration is (name, type) -- nothing else reaches member render.** A member's
+   target-language declaration form is determined by its name and its type alone (the type carries
+   size, offset, and target type form; the name carries the source identifier). Wrapper-typed
+   members are no exception: any per-member construction state arrives later as ordinary MIR
+   expressions in the constructor body, never as type payload that member render reads.
+
+5. **The LLVM IR backend is the canonical cross-check.** When the C++ backend's render needs an
+   `if`-branch or a payload-driven shape decision, ask: could a mechanical LLVM IR backend translate
+   the same MIR node without that decision? If not, the MIR shape is wrong. The C++ backend's
+   transitional status does not relax this check; it sharpens it, because the C++ backend's output
+   is how MIR's correctness is currently observed.
+
+6. **The set of backends consuming MIR is open.** No MIR primitive and no contract entry is
+   specialized for one backend. A new backend reads the same MIR; the only thing it brings is its
+   own type-mapping dispatch and value-emission rules for its target's syntactic form.
+
+## Boundary to Adjacent Layers
+
+- `compiler_overview.md` defines the pipeline (HIR -> MIR -> LIR -> LLVM IR) and the transitional
+  status of the C++ backend within it.
+- `mir.md` defines the primitive set this contract realizes. A render entry that needs anything
+  beyond the node's structural fields is one of two failures: a missing MIR primitive (extend MIR)
+  or a missed HIR-to-MIR lowering (extend HIR-to-MIR). Render absorbs neither.
+- `lowering_boundaries.md` requires HIR-to-MIR to produce MIR that satisfies this contract: the
+  output MIR must be mechanically translatable by any backend, including a mechanical LLVM IR
+  backend.
+- `emission_model.md` owns the per-artifact and cross-unit boundary. Within an artifact, this doc
+  owns the per-node translation rules.
+- `runtime_distribution.md` owns where the runtime library lives; this doc owns how a backend may
+  reference runtime library types (only through type mapping).
+
+## Forbidden Shapes
+
+- **An `if`-branch, ternary, or switch in a value-emission entry whose arms produce different
+  syntactic shapes.** This is the canonical render-side defect: render is making a decision that
+  should be a MIR-level distinction. The fix is upstream, never inside render.
+
+- A value-emission entry that composes a target-language type literal as a string. Every
+  target-language type literal a backend emits comes from the type-mapping dispatch.
+
+- A value-emission entry that names a runtime library identifier (wrapper type, helper function,
+  helper struct, method spelling) directly. The runtime library's identifiers appear at render
+  through the MIR types and MIR calls that map onto them.
+
+- A value-emission entry that switches on a MIR type's payload to choose a non-mechanical emission
+  form. Type payload is for type-mapping; value emission acting on it reads value-layer data carried
+  in a type.
+
+- A member render entry that emits constructor arguments built from the member's type payload. A
+  member is (name, type). Construction state arrives as ordinary MIR primitives in the constructor
+  body, never as type payload.
+
+- A render entry whose output depends on the node tree outside the node's own structural fields and
+  its subordinate renders.
+
+- An architecture doc, a glossary entry, or a MIR invariant that names a backend's runtime library
+  type by its target-language spelling. Those names are implementation detail of one backend's
+  choice; architecture refers to MIR types and their type-mapping role.
+
+- A new MIR node or MIR primitive added to make one backend's render simpler. MIR's primitive set is
+  uniform across backends. A primitive earns its place by being a generic programming-language
+  concept (`mir.md`), not by being convenient for one backend.
+
+- A render entry that fabricates an expression from MIR data (composing constructor arguments,
+  inlining a struct literal, deriving navigation steps from a payload). Render translates existing
+  expressions, never invents them. An invented expression is HIR-to-MIR's job.
+
+## Notes / Examples
+
+The canonical write rule for any value-emission entry: write it as if the target were LLVM IR. If
+you cannot write a mechanical translation rule for it -- if your draft contains an `if` whose arms
+produce different LLVM instruction sequences -- the MIR primitive set is incomplete. Fix MIR; render
+then writes itself.
+
+A read of an observable signal is a `CallExpr` whose callee is the wrapper type's read method
+against the receiver expression that reaches the wrapper-typed field. The backend renders this
+`CallExpr` by rendering the callee, the receiver, the argument list, and the call syntax of its
+target form. The wrapper-type spelling reaches the call only through the type-mapping dispatch on
+the receiver's type; the call render itself does not separately know the wrapper's name.
+
+A wrapper-typed member's construction follows the same shape. Construction state arrives as ordinary
+MIR primitives in the constructor body (a `CallExpr` to an initialize method on the wrapper, with
+primitive arguments -- string literals, array literals, member references); the field declaration
+itself is uniform `<type> <name>{};` (C++) or its LLVM IR equivalent (an alloca sized by the
+type-mapping result, plus a `call` to the initialize method). Render never composes the wrapper's
+name or constructor arguments from type payload.
+
+When render needs to name a runtime library type to fabricate construction arguments, MIR is missing
+the right primitive -- usually a way to express the per-member initialization as a call against the
+wrapper's own API. The fix is to redesign the wrapper API so MIR can call it through existing
+primitives (one initialize method per construction variant, taking flat primitive arguments), then
+HIR-to-MIR emits the call, then render translates uniformly. The asymmetry between "some members are
+default-initialized, some need construction" is expressed in MIR's expression set, not in render's
+branch tables.

--- a/docs/architecture/compiler_overview.md
+++ b/docs/architecture/compiler_overview.md
@@ -15,12 +15,18 @@ compile-time and runtime.
 - The contract that separates semantic modeling (HIR, MIR) from execution modeling (LIR, LLVM IR).
 - The contract that separates compile-time artifacts (class-level) from runtime artifacts
   (object-level).
-- The positioning of the C++ backend: a first-class MIR consumer that emits C++ code, serving as
-  both an execution artifact and the human-readable rendering of MIR. The latter is how MIR's
-  semantic correctness is validated by a developer reading from SystemVerilog source through MIR's
-  semantic model. Debug inspection of HIR and MIR is separate: dumpers produce textual traversals
-  for reading and golden testing, while `backend::cpp` is the real emitter. Dumpers and backends are
-  both pure over their input IR and must not introduce or reinterpret semantics.
+- The positioning of the C++ backend: a transitional realization of the MIR consumer. The
+  architectural target is HIR -> MIR -> LIR -> LLVM IR; the C++ backend exists today because LIR and
+  the LLVM IR backend are not yet built. The C++ backend's output serves two roles -- an executable
+  artifact, and the human-readable surface against which MIR's shape is validated from SystemVerilog
+  source through MIR's semantic model. This transitional status does **not** loosen the
+  mechanical-translation discipline: the C++ backend's render must remain mechanical at the LLVM-IR
+  level (no decision logic in render, every entry a fixed function of one MIR node), so the same MIR
+  feeds an eventual LLVM IR backend without rework. `backend_contract.md` owns this discipline; this
+  doc owns its position in the pipeline. Debug inspection of HIR and MIR is separate: dumpers
+  produce textual traversals for reading and golden testing, while `backend::cpp` is the real
+  emitter. Dumpers and backends are both pure over their input IR and must not introduce or
+  reinterpret semantics.
 
 ## Does Not Own
 
@@ -46,7 +52,11 @@ compile-time and runtime.
 8. HIR and MIR dumpers are debug-facing textual serialization. They are not compilation paths and
    are not consumed by any lowering step. They must remain semantically faithful to their input IR.
 9. Backend emitters (today: `backend::cpp`) consume MIR and produce executable artifacts. A backend
-   is a first-class compilation stage, not a debug view.
+   is a first-class compilation stage, not a debug view. Every backend render entry is a fixed
+   function of one MIR node; decision logic in render is a MIR design failure (see
+   `backend_contract.md`). The C++ backend's transitional status as the current observation surface
+   for MIR sharpens this discipline rather than relaxing it: a place where the C++ render would need
+   decision logic is a place where the eventual LLVM IR backend would too.
 
 ## Boundary to Adjacent Layers
 
@@ -71,6 +81,10 @@ compile-time and runtime.
   semantic correctness is validated; compile-time wins must come from the runtime library, build
   infrastructure (precompiled headers, parallel compilation), or backend-internal organization that
   does not change the emitted form.
+- Treating the C++ backend as a permanent realization that justifies non-mechanical render. The C++
+  backend is transitional; the MIR shape it consumes must be the same MIR an eventual LLVM IR
+  backend consumes. A render entry that would need extra logic in LLVM IR is a render entry that is
+  already wrong today; the MIR is the suspect, not the render.
 
 ## Notes / Examples
 

--- a/docs/architecture/emission_model.md
+++ b/docs/architecture/emission_model.md
@@ -86,6 +86,9 @@ non-conforming code, not as a relaxation of the contract.
   stored direct reference; this doc defines how a backend realizes that without breaking unit
   independence (downward link-binding into a slot vs upward runtime navigation through an extern
   member).
+- `backend_contract.md` defines the per-node within-an-artifact realization rules: how a MIR node
+  becomes target-language source. This doc draws the artifact boundary; `backend_contract.md`
+  governs what happens inside.
 - `runtime_distribution.md` owns where the SDK/runtime lives; this doc owns the SDK's role as the
   resolution substrate.
 - `runtime_model.md` places the fill in the constructor context and the read in the simulation
@@ -116,10 +119,14 @@ emits a by-name access; the link resolves it; the parent's own output carries no
 `always_comb x = Top.g;` (upward): `Top` is an ancestor the referrer does not instantiate, so the
 referrer knows nothing about `Top` at compile time. It cannot name `Top` or include its artifact.
 The referrer holds the reference as an ordinary member whose type marks it external; at Bind that
-member climbs the parent chain to the ancestor whose instance or module name matches, obtains the
-`g` signal from that node through the SDK, and stores the direct reference. The simulation-time read
-and change observation then read that member directly (`reference_resolution.md` inv 5); no
-cross-unit slot or side table records the reference.
+member climbs the enclosing chain to the scope denoted by the head's canonical structural identity
+(the frontend resolves and canonicalizes the head; runtime does not re-implement name-resolution
+semantics), obtains the `g` signal from that scope through the SDK, and stores the direct reference.
+The simulation-time read and change observation then read that member directly
+(`reference_resolution.md` inv 5); no cross-unit slot or side table records the reference.
+Construction state for the extern member (the canonical head identity, the descent suffix, the leaf
+signal name) arrives as ordinary MIR primitives in the constructor body, not as type payload --
+`backend_contract.md` keeps render mechanical.
 
 The current C++ backend collapses all units into a single translation unit (one `main.cpp` that
 transitively includes every unit header, with bodies inline). That is a transitional convenience of

--- a/docs/architecture/hir.md
+++ b/docs/architecture/hir.md
@@ -77,6 +77,12 @@ that identity is the suspect, not the analysis.
   generic programming-language vocabulary. Every SV-specific concept that does not appear in MIR is
   translated at this boundary or rejected as unsupported. HIR-to-MIR holds the SV knowledge; MIR
   does not.
+- HIR-to-MIR's output is consumed by backends through `backend_contract.md`. If a backend would need
+  decision logic to render the produced MIR, HIR-to-MIR is failing to emit the right combination of
+  MIR primitives. The lowering's correctness is validated against the mechanical-translation
+  invariant: the MIR it produces must be translatable by a mechanical LLVM IR backend without
+  payload-driven branches. When extending HIR-to-MIR, read `backend_contract.md` before adding a
+  lowering rule that produces a MIR node a backend cannot realize mechanically.
 
 ## Forbidden Shapes
 

--- a/docs/architecture/lowering_boundaries.md
+++ b/docs/architecture/lowering_boundaries.md
@@ -33,14 +33,17 @@ set of allowed transformations.
 6. Lowering does not introduce new semantic identity. The target layer's identity kinds are defined
    by the target layer's contract; a lowering may only use identity kinds that belong to the input
    or output layer.
-7. The pipeline branches at MIR into two backends: the C++ emitter (MIR-to-C++, the path used today)
-   and the LIR-then-LLVM path. A backend emit makes no semantic decisions -- every semantic fact is
-   fixed in MIR -- and chooses only how to represent each MIR node in its target, a representation
-   fixed by the node's kind. The two backends represent the same node differently (a coroutine
-   method versus an LLVM coroutine frame) yet realize the same behaviour, which holds only because
-   neither adds, infers, or re-derives a semantic fact. MIR-to-C++ is not as mechanical as
-   LIR-to-LLVM -- it still chooses C++ forms for higher-level MIR nodes -- but the choice is a fixed
-   function of the node, never a judgement about what the program means.
+7. The pipeline branches at MIR into two backends: the LIR-then-LLVM path (the architectural target)
+   and the C++ emitter (a transitional realization that consumes the same MIR while LIR is being
+   built). A backend emit makes no semantic decisions -- every semantic fact is fixed in MIR -- and
+   chooses only how to represent each MIR node in its target, a representation fixed by the node's
+   kind. The two backends represent the same node differently (a coroutine method versus an LLVM
+   coroutine frame) yet realize the same behaviour, which holds only because neither adds, infers,
+   or re-derives a semantic fact. **Both backends are mechanical at the same discipline.** The C++
+   backend's transitional status does not loosen this -- if its render needs decision logic in value
+   emission (an `if` whose arms produce different syntactic shapes), the MIR is wrong, and the
+   LIR/LLVM path would face the same obstruction. The C++ backend's render is therefore the
+   cross-check on MIR shape today (`backend_contract.md`).
 
 ## Boundary to Adjacent Layers
 
@@ -63,3 +66,10 @@ set of allowed transformations.
 
 If HIR-to-MIR needs to emit a CFG node, the boundary has been violated. Either the node belongs in
 MIR in a non-CFG form, or the lowering is doing MIR-to-LIR's work.
+
+When extending HIR-to-MIR, the lowering's output is also validated against `backend_contract.md`'s
+mechanical-translation invariant: the produced MIR must be translatable by a mechanical LLVM IR
+backend without payload-driven branches in value emission. The C++ backend's transitional status as
+the current observation surface for MIR makes this check operational today -- if the C++ render
+would need decision logic to consume a proposed MIR shape, the MIR is wrong, and the lowering is
+what produced it.

--- a/docs/architecture/mir.md
+++ b/docs/architecture/mir.md
@@ -118,8 +118,14 @@ suspect, not the analysis (`lowering_organization.md` states this discipline in 
     source-language sugar -- a fact of that kind is already expressible by combining existing
     primitives, so if it is missing, HIR-to-MIR is incomplete and should emit that combination
     instead. The primitive set does grow, but only for a genuinely new generic-language concept,
-    never to model a backend / library / sugar shape (see Owns). _Programming-language consequence:
-    the program text is the program; consumers do not invent vocabulary the language does not have._
+    never to model a backend / library / sugar shape (see Owns). The backend-side consequence is
+    owned by `backend_contract.md`: render is mechanical (a fixed function of one MIR node, no
+    decision logic in value emission), and the canonical falsifier for a MIR shape is "could a
+    mechanical LLVM IR backend translate this without decisions?" When designing or extending a MIR
+    primitive, every binding `mir.md` invariant cross-checks against `backend_contract.md`'s
+    mechanical-translation invariant; the two are halves of the same contract. _Programming-
+    language consequence: the program text is the program; consumers do not invent vocabulary the
+    language does not have._
 11. Every instance-method callable body's first binding is `self`, a pointer to its enclosing class
     -- `body.vars[0]` is a local declaration of that pointer type, named `self`. Access to any class
     member -- a member variable, a service call, a child instance -- flows through `MemberAccess`
@@ -147,6 +153,17 @@ suspect, not the analysis (`lowering_organization.md` states this discipline in 
 - Produces input to LIR. MIR-to-LIR is the layer where the programming language gets translated into
   a machine-execution model. CFG structure, storage placement, and execution-oriented details are
   introduced at this boundary; MIR does not predict them.
+- Consumed by backends. `backend_contract.md` owns the rules under which a MIR-consuming backend
+  realizes per-unit MIR as target-language source: type mapping (one dispatch per MIR type variant
+  returning a target-language type representation) and value emission (mechanical translation of MIR
+  primitives, with no runtime library names appearing outside the type-mapping dispatch, and no
+  decision logic anywhere). A render that needs anything beyond the node's structural fields is
+  reading something MIR has not stated; the fix is upstream of render, never inside it. **Any MIR
+  design decision is validated against the backend contract**: if the proposed shape forces a
+  backend to branch in value emission (an `if` in render whose arms produce different syntactic
+  shapes, a payload-driven decision, a fabricated expression), the MIR design is wrong even if the
+  C++ backend can express it. The canonical check is "could a mechanical LLVM IR backend translate
+  this without decisions?".
 
 ## Forbidden Shapes
 
@@ -246,11 +263,14 @@ type is the call protocol, and a bound field is a snapshot or an alias by its ty
 the canonical contract.
 
 An access through a runtime library wrapper type illustrates the boundary between MIR's vocabulary
-and a backend's storage realization. The C++ backend wraps an observable signal's storage in
-`Var<T>`, exposing `Get` / `Set` / `Mutate` on the wrapper. MIR does not have a "cell access" node:
-a read of an observable signal is a `CallExpr` whose callee is the wrapper type's `Get` method and
-whose receiver is the `MemberAccess` reaching the signal; a write is a `CallExpr` to `Set`. The
-decision that an observable read is a method call -- not an implicit value-read -- is made at
-HIR-to-MIR, which sees that the signal's MIR type is the wrapper type and emits the corresponding
-call. By the time MIR is read by any backend, the program already says `wrapper.Get(...)` or
-`wrapper.Set(...)`; the backend reads the call and emits it the same way it emits any other call.
+and a backend's storage realization. A backend may choose to wrap observable storage in a
+target-side wrapper type that exposes read / write / mutate methods through its runtime library; MIR
+has no "cell access" node. A read of an observable signal is a `CallExpr` whose callee is the
+wrapper type's read method and whose receiver is the `MemberAccess` reaching the signal; a write is
+a `CallExpr` to the wrapper's write method. The decision that an observable read is a method call --
+not an implicit value-read -- is made at HIR-to-MIR, which sees that the signal's MIR type is the
+wrapper type and emits the corresponding call. By the time MIR is read by any backend, the program
+already says `wrapper.<read>(...)` or `wrapper.<write>(...)`; the backend reads the call and emits
+it the same way it emits any other call. The wrapper type's target-language spelling and the method
+spellings are backend-internal -- `backend_contract.md` owns the rules that keep those out of
+value-emission sites.

--- a/docs/decisions/hierarchical-reference-resolution.md
+++ b/docs/decisions/hierarchical-reference-resolution.md
@@ -20,10 +20,9 @@ reference reaches its target, once, and where that resolution runs.
 
 A cross-unit reference resolves **once** into a stored direct pointer to the leaf cell, read
 directly on the simulation hot path with no per-access lookup (`reference_resolution.md`). It
-reaches the leaf **by name** through the runtime scope SDK (`GetChild` / `GetSignal`), because the
-referrer knows the target's name but not its layout (`emission_model.md`,
-`compilation_unit_model.md`). The two directions differ in where the navigation is composed and when
-it runs, by necessity:
+reaches the leaf **by name** through the runtime scope SDK, because the referrer knows the target's
+name but not its layout (`emission_model.md`, `compilation_unit_model.md`). The two directions
+differ in where the navigation is composed and when it runs, by necessity:
 
 - **Downward** (`c.x`): the referrer owns the head child, so the path from `self` is known at the
   referrer's compile time. The navigation is emitted as MIR by-name calls and runs in the referrer's
@@ -32,9 +31,12 @@ it runs, by necessity:
   ancestor, and the same artifact sits at many depths, so the path needs the whole tree -- which
   does not exist when the referrer constructs. The reference is carried as a member whose **type**
   is a runtime wrapper, and the climb-and-fetch runs as library behavior at the **bind step**, after
-  the whole tree exists (`runtime_model.md`). The climb matches the ancestor by its module
-  **definition** name (a module-instance head) or by the scope's **own** name (a named generate
-  block, or the root).
+  the whole tree exists (`runtime_model.md`). The frontend has already resolved the head to a
+  specific scope and canonicalized its identity (LRM 23.8 / 23.9 instance-name precedence is a
+  frontend responsibility); the runtime climb walks the enclosing chain by that canonical identity
+  and never re-implements name-resolution semantics. Wrapper-construction arguments reach the
+  backend through MIR's value-expression primitives, not through the wrapper type's payload
+  (`backend_contract.md`).
 
 This asymmetry -- emitted constructor navigation downward, library climb at bind upward -- is
 `emission_model.md`'s "storage and fill by direction." Both share the single by-name SDK and the
@@ -55,12 +57,13 @@ call a getter on in any case.
 
 ## Why an upward reference is a self-climb
 
-The referrer resolves alone, by climbing its own parent chain; the ancestor is never involved. The
-depth is not a compile-time constant -- one artifact sits at many depths -- so it cannot be baked
-in. The reference cannot be threaded down from the ancestor, because a unit does not know which
-descendants reference it (a referrer list is forbidden, `compilation_unit_model.md`). And the climb
-matches by name, never by a typed cast to the ancestor's class, which would name a unit the referrer
-does not depend on. So the referrer holds a wrapper-typed member and the runtime climbs at bind.
+The referrer resolves alone, by climbing its own enclosing chain; the ancestor is never involved.
+The depth is not a compile-time constant -- one artifact sits at many depths -- so it cannot be
+baked in. The reference cannot be threaded down from the ancestor, because a unit does not know
+which descendants reference it (a referrer list is forbidden, `compilation_unit_model.md`). And the
+climb matches by name, never by a typed cast to the ancestor's class, which would name a unit the
+referrer does not depend on. So the referrer holds a wrapper-typed member and the runtime climbs at
+bind.
 
 ## Rejected alternatives
 

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -141,12 +141,17 @@ consume. Coverage is demonstrated through Stage D and Stage E.
       by-name walk. A top-level block now adopts `$root` as its parent so an upward climb from
       inside a top reaches the root. Covered for a scalar named generate block; an indexed
       loop-generate head (`blk[i].x`) is rejected with a clean diagnostic and remains.
-- [ ] D2d -- LRM 23.9 instance-name precedence: when the first component is written as an instance
-      name and several instances of the same module nest on the chain, the reference must bind the
-      named instance. Today the climb keys on the module name, so it can silently bind the nearer
-      same-module ancestor instead -- the one form that resolves wrong without an error. The common
-      module-name form is correct at any depth; this gap needs the source-written first identifier,
-      which the elaborated AST does not retain.
+- [x] D2d -- LRM 23.8 step b / 23.9: the climb visits each enclosing scope's children rather than
+      the ancestor itself, so the head can be a sibling of any enclosing scope rather than the
+      closest enclosing scope. Two generate blocks at the same level reading each other's state
+      through `<sibling_label>.<member>` resolves through this path; sibling-of-grandparent at any
+      depth resolves through the same path. The frontend canonicalizes the head's identity (LRM 23.9
+      instance-name precedence applies at slang's resolution step), so the runtime walks to the
+      canonical scope by name. The per-reference plan (which climb shape, the canonical head name
+      plus any indices, the descent suffix, the leaf signal) emits as ordinary `CallExpr` statements
+      against the wrapper member in the constructor body (`BindVisibleChild` / `BindRoot` followed
+      by zero or more `AddSuffixStep`), carrying only flat MIR primitives -- the wrapper type itself
+      carries only the element type.
 - [ ] D2e -- An upward reference whose head is a named procedural block (a named `begin`/`end` or
       `fork`/`join`, LRM 23.9). Unlike a module or generate scope, a named procedural block is not a
       constructed object today: its static-lifetime locals live as members on the enclosing unit

--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -57,14 +57,10 @@ using PathStep = std::variant<MemberHop, IndexHop>;
 // Where a cross-unit reference starts its navigation. A downward reference
 // reaches into an owned child the referrer's own scope declares -- an
 // instance/instance-array member, or a generate block (LRM 27) identified by
-// its position in the scope. Both resolve to one owned-child companion var at
-// construction, so the navigation past the head is identical. An upward
-// reference (LRM 23.6) climbs the parent chain at construction to the nearest
-// matching ancestor named `ancestor_name`; from there both directions share
-// `path` to reach the leaf, by name across the unit boundary -- the referrer
-// never names the ancestor's unit type, which it does not depend on. The child
-// cannot know its depth at compile time, so it locates the ancestor by name
-// rather than a baked-in offset.
+// its position in the scope. An upward reference (LRM 23.6) locates its
+// starting scope at construction by climbing the enclosing chain. The child
+// cannot know its depth at compile time, so it locates the scope by name (or
+// as the `$root` anchor) rather than a baked-in offset.
 struct GenerateChildRef {
   GenerateId generate;
   StructuralScopeId scope;
@@ -73,21 +69,25 @@ struct DownwardHead {
   std::variant<InstanceMemberId, GenerateChildRef> child;
 };
 
-// How an upward reference's head identifies its ancestor on the parent chain.
-// A module-instance head matches the ancestor's module definition name (LRM
-// 23.8): the key is class-level, so one artifact serves every depth, and an
-// ancestor whose instance name merely equals it does not match. A named
-// generate block or a `$root`-anchored path instead matches the ancestor
-// scope's own name -- the generate-block label or `$root` -- because that name
-// is itself the lookup key (LRM 23.6, 23.8). The two keys compare against
-// different scopes at runtime, so the axis rides the head.
-enum class UpwardMatch : std::uint8_t { kDefName, kScopeName };
-
-struct UpwardHead {
-  std::string ancestor_name;
-  UpwardMatch match;
+// Where an upward cross-unit reference's navigation starts (LRM 23.8 / 23.9).
+// `UpwardRootHead` denotes the parent-less topmost scope -- the `$root`
+// source token identifies the climb target itself, so the descent suffix
+// starts past it. `UpwardNamedHead` carries the canonical structural identity
+// of the head -- its instance / generate-block name plus any per-dimension
+// index. In both cases the descent suffix is strictly below the anchor.
+struct UpwardRootHead {
+  auto operator==(const UpwardRootHead&) const -> bool = default;
 };
-using CrossUnitRefHead = std::variant<DownwardHead, UpwardHead>;
+
+struct UpwardNamedHead {
+  std::string head_name;
+  std::vector<std::uint32_t> head_indices;
+
+  auto operator==(const UpwardNamedHead&) const -> bool = default;
+};
+
+using CrossUnitRefHead =
+    std::variant<DownwardHead, UpwardRootHead, UpwardNamedHead>;
 
 // A cross-unit reference resolved once at construction. `head` is where
 // navigation starts; `path` carries the shared navigation from the head down to

--- a/include/lyra/lowering/ast_to_hir/expression/references.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/references.hpp
@@ -23,7 +23,11 @@ auto LowerNamedValueProc(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::NamedValueExpression& named) -> diag::Result<hir::Expr>;
 
-auto LowerHierarchicalValueProc(
+// A hierarchical reference has the same shape across procedural and
+// structural contexts (it always resolves into a cross-unit member binding on
+// the referrer's structural scope), so this entry is generic over the calling
+// context rather than split into Proc / Structural variants.
+auto LowerHierarchicalValue(
     ModuleLowerer& module, WalkFrame frame,
     const slang::ast::HierarchicalValueExpression& hve)
     -> diag::Result<hir::Expr>;

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -297,39 +297,17 @@ struct ObservableType {
   auto operator==(const ObservableType&) const -> bool = default;
 };
 
-// One by-name step from a resolved scope into an owned child it answers for:
-// the child member's name plus one index per array dimension (empty for a
-// scalar child). The ancestor answers by name from the children it registered,
-// so a multi-dimensional instance array is just more indices, never a flattened
-// offset. (Distinct from EnclosingHops, which is a count of lexical frames
-// climbed, not a path step.)
-struct ChildStep {
-  std::string name;
-  std::vector<std::uint32_t> indices;
-
-  auto operator==(const ChildStep&) const -> bool = default;
-};
-
-// How the climb matches the ancestor named `ancestor` (LRM 23.8): against the
-// ancestor's module definition name (a module-instance head) or against the
-// scope's own name (a named generate block, or the `$root` absolute-path
-// anchor). The two keys compare against different runtime accessors, so the
-// axis rides the type.
-enum class ExternalRefMatch : std::uint8_t { kDefName, kScopeName };
-
-// An upward hierarchical reference's storage: a resolved pointer to a leaf of
-// `element`, reached by climbing to the ancestor named `ancestor` (matched by
-// `match`), walking `tail` down through its owned children by name, then
-// fetching `signal` (LRM 23.8). `tail` is empty when the leaf sits directly on
-// the ancestor. Like ExternalUnitObjectType it carries the cross-unit symbol on
-// the type; the address binds at construction, never the layout. Emitted as the
-// runtime `ExternUp<element>` member.
+// An upward cross-unit reference's storage type: a wrapper around `element`
+// that the runtime relocates at the bind step. The wrapper exposes its
+// per-reference state (the climb shape, the descent path, the leaf signal
+// name) through method calls (`BindRoot`, `BindVisibleChild`); MIR carries
+// no per-reference data in the type itself. The construction state is
+// emitted in the constructor body as ordinary `CallExpr` against one of
+// those methods, with `StringLiteral` / `ArrayLiteralExpr` primitives for
+// the arguments. The type carries only the classification (this member is an
+// upward extern reference of `element`).
 struct ExternalRefType {
   TypeId element;
-  std::string ancestor;
-  ExternalRefMatch match;
-  std::vector<ChildStep> tail;
-  std::string signal;
 
   auto operator==(const ExternalRefType&) const -> bool = default;
 };

--- a/include/lyra/runtime/extern_up.hpp
+++ b/include/lyra/runtime/extern_up.hpp
@@ -1,17 +1,18 @@
 #pragma once
 
-#include <cstddef>
-#include <initializer_list>
+#include <span>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "lyra/runtime/scope.hpp"
 #include "lyra/runtime/var.hpp"
+#include "lyra/value/packed_array.hpp"
 
 namespace lyra::runtime {
 
-// A registered upward-reference member. Scope::Bind walks every ExternUp on a
-// scope and relocates it once the whole object tree exists.
+// A registered upward-reference member. Scope walks every ExternUp on a scope
+// and relocates it once the whole object tree exists.
 struct ExternBase {
   ExternBase() = default;
   ExternBase(const ExternBase&) = delete;
@@ -23,49 +24,72 @@ struct ExternBase {
   virtual void Relocate() = 0;
 };
 
-// One by-name step of an extern reference's tail: an owned child of the
-// resolved ancestor, named and indexed once per array dimension. Names point at
-// emitted string literals; the indices it owns so the ExternUp outlives its
-// constructor arguments.
-struct ChildStep {
-  std::string_view name;
-  std::vector<std::size_t> indices;
-};
-
-// An upward hierarchical reference modeled as an extern member: it holds the
-// symbol -- the ancestor name, how that name is matched on the parent chain,
-// the by-name tail down through the ancestor's owned children, and the leaf
-// signal name -- and in the resolve phase climbs to the ancestor, walks the
-// tail, and binds a direct pointer to the leaf. Reads, writes, and sensitivity
-// forward to that resolved cell, so the member behaves like the referenced
-// `Var<T>` while naming no ancestor type. Non-movable: it registers `this`, and
-// is owned by the stable scope node that declares it.
+// An upward hierarchical reference modeled as an extern member. Default-
+// constructed in the field declaration like any other wrapper-typed member;
+// the per-reference state arrives through ordinary method calls in the
+// owning scope's constructor body. At the resolve phase the wrapper climbs
+// and descends, fetching a typed pointer to the leaf cell; reads, writes,
+// and sensitivity then forward to that cell while the member names no
+// ancestor type.
+//
+// `lookup_origin` is passed explicitly to every bind method rather than
+// taken as `this`: the navigation starts from the scope where the SV
+// hierarchical reference is lexically evaluated, which a caller may need to
+// pass independently of where the wrapper is stored.
+//
+// String arguments (`head_name`, `signal`, suffix step `name`) are
+// `string_view`s the wrapper stores by reference; their storage must outlive
+// the wrapper. The emitted code supplies static string literals, which
+// satisfies the requirement. PackedArray index spans are copied into
+// wrapper-owned vectors at the call.
 template <value::LyraValue T>
 class ExternUp : public ExternBase {
  public:
-  ExternUp(
-      Scope* owner, std::string_view ancestor, UpwardMatch match,
-      std::initializer_list<ChildStep> tail, std::string_view signal)
-      : owner_(owner),
-        ancestor_(ancestor),
-        match_(match),
-        tail_(tail),
-        signal_(signal) {
-    owner_->RegisterExtern(this);
+  ExternUp() = default;
+
+  // Install the by-name climb start: at bind, walk the lookup origin's
+  // enclosing chain and find the child whose canonical instance name (and
+  // per-dimension index) matches `head_name` + `head_indices`. `signal` is
+  // the leaf cell's registered name on the matched scope.
+  void BindVisibleChild(
+      Scope* lookup_origin, std::string_view head_name,
+      std::span<const value::PackedArray> head_indices,
+      std::string_view signal) {
+    lookup_origin_ = lookup_origin;
+    is_root_ = false;
+    head_name_ = head_name;
+    head_indices_.assign(head_indices.begin(), head_indices.end());
+    signal_ = signal;
+    lookup_origin_->RegisterExtern(this);
+  }
+
+  // Install the `$root` anchor: at bind, walk to the parent-less topmost
+  // scope. `signal` is the leaf cell's registered name on the scope reached
+  // after the suffix walks down.
+  void BindRoot(Scope* lookup_origin, std::string_view signal) {
+    lookup_origin_ = lookup_origin;
+    is_root_ = true;
+    signal_ = signal;
+    lookup_origin_->RegisterExtern(this);
+  }
+
+  // Append one descent step below the anchor, applied in call order. Each
+  // step is a named child of the previous scope, optionally per-dimension
+  // indexed.
+  void AddSuffixStep(
+      std::string_view name, std::span<const value::PackedArray> indices) {
+    SuffixStep step;
+    step.name = name;
+    step.indices.assign(indices.begin(), indices.end());
+    suffix_.push_back(std::move(step));
   }
 
   void Relocate() override {
-    Scope* scope = owner_->ResolveUpwardScope(ancestor_, match_);
-    std::vector<value::PackedArray> packed_indices;
-    for (const ChildStep& hop : tail_) {
-      packed_indices.clear();
-      packed_indices.reserve(hop.indices.size());
-      for (const std::size_t idx : hop.indices) {
-        packed_indices.push_back(
-            value::PackedArray::FromInt(
-                static_cast<std::int64_t>(idx), 32, true, false));
-      }
-      scope = scope->GetChild(hop.name, packed_indices);
+    Scope* scope = is_root_ ? lookup_origin_->ResolveRoot()
+                            : lookup_origin_->ResolveVisibleChild(
+                                  head_name_, head_indices_);
+    for (const SuffixStep& step : suffix_) {
+      scope = scope->GetChild(step.name, step.indices);
     }
     cell_ = static_cast<Var<T>*>(scope->GetSignal(signal_));
   }
@@ -87,11 +111,17 @@ class ExternUp : public ExternBase {
   }
 
  private:
-  Scope* owner_;
-  std::string_view ancestor_;
-  UpwardMatch match_;
-  std::vector<ChildStep> tail_;
+  struct SuffixStep {
+    std::string_view name;
+    std::vector<value::PackedArray> indices;
+  };
+
+  Scope* lookup_origin_ = nullptr;
+  bool is_root_ = false;
+  std::string_view head_name_;
+  std::vector<value::PackedArray> head_indices_;
   std::string_view signal_;
+  std::vector<SuffixStep> suffix_;
   Var<T>* cell_ = nullptr;
 };
 

--- a/include/lyra/runtime/scope.hpp
+++ b/include/lyra/runtime/scope.hpp
@@ -25,12 +25,6 @@ class ExternBase;
 // purely structural node does not pull the simulation tick finer.
 inline constexpr std::int8_t kUnspecifiedTimePrecisionPower = 127;
 
-// How an upward hierarchical reference matches its ancestor while climbing the
-// parent chain (LRM 23.8): against the ancestor's module definition name
-// (`DefName()`, a module-instance head) or against the scope's own segment
-// base name (`Segment().BaseName()`, a named generate block or `$root`).
-enum class UpwardMatch : std::uint8_t { kDefName, kScopeName };
-
 // A node in the one canonical object tree. Every constructed SystemVerilog
 // scope -- a module instance, a generate block, the implicit `$root` -- is a
 // Scope. It carries the scope's structural identity (parent plus
@@ -60,8 +54,8 @@ class Scope {
   [[nodiscard]] auto DisplaySegment() const -> std::string;
 
   // The base label of `Segment()`. Carries the source-level identifier
-  // without any per-dimension index decoration; used by cross-unit by-name
-  // lookup keys and by upward `kScopeName` resolution.
+  // without any per-dimension index decoration; the canonical key both
+  // `GetChild` and the upward visible-child climb use to match a child.
   [[nodiscard]] auto Name() const -> std::string_view;
 
   // Joins each ancestor's display segment with `.`, ordered from the
@@ -71,11 +65,11 @@ class Scope {
   // the object tree is sealed by Activate.
   [[nodiscard]] auto HierarchicalPath() const -> lyra::value::String;
 
-  // The scope's module definition name. An upward hierarchical reference climbs
-  // the parent chain matching against this (LRM 23.8): the referrer's emitted
-  // code keys the climb on the target's definition name, so an ancestor matches
-  // by its definition name, never by its instance name. The base never matches;
-  // a generated unit class overrides it.
+  // The scope's module definition name -- carried by every module instance,
+  // empty for a generate block or `$root`. Used by dump output and debug
+  // surfaces; the upward by-name climb consults `Name()` only, since slang
+  // canonicalizes every head identity to a resolved symbol's name before the
+  // lowering encodes the anchor.
   [[nodiscard]] virtual auto DefName() const -> std::string_view {
     return {};
   }
@@ -105,19 +99,25 @@ class Scope {
       std::string_view name, std::span<const lyra::value::PackedArray> indices)
       -> Scope*;
 
-  // Climbs the parent chain to the nearest ancestor named `key` and returns it
-  // (LRM 23.8). `match` selects the name compared: `kDefName` matches an
-  // ancestor's module definition name (`DefName()`, a module-instance head), so
-  // an ancestor whose instance name merely equals it does not match;
-  // `kScopeName` matches the scope's own name (`Name()`, a named generate block
-  // or `$root`), whose name is itself the lookup key. The shared start of an
-  // upward reference's runtime navigation; from there an `ExternUp` member
-  // walks any by-name tail and fetches the leaf, once in the resolve phase.
-  [[nodiscard]] auto ResolveUpwardScope(std::string_view key, UpwardMatch match)
-      -> Scope*;
+  // Walks the enclosing chain (starting at `this`) and at each level scans
+  // the level's children for one whose canonical instance name plus indices
+  // match. Returns the matched child itself, so the caller's descent suffix
+  // is strictly below it. Matching by instance name only -- not by module
+  // definition name -- is correct because the frontend has already
+  // canonicalized the head per LRM 23.9 instance-name precedence; the
+  // runtime does not re-implement that resolution.
+  [[nodiscard]] auto ResolveVisibleChild(
+      std::string_view head_name,
+      std::span<const lyra::value::PackedArray> head_indices) -> Scope*;
 
-  // An `ExternUp` member registers itself here from its constructor; the
-  // resolve phase relocates all registered members once the whole tree exists.
+  // Walks the enclosing chain to the topmost scope -- the parent-less `$root`
+  // (LRM 23.6 absolute-path anchor) -- and returns it. The caller's descent
+  // suffix is strictly below `$root`.
+  [[nodiscard]] auto ResolveRoot() -> Scope*;
+
+  // A wrapper-typed cross-unit member registers itself here at its bind call;
+  // the resolve phase relocates all registered members once the whole tree
+  // exists.
   void RegisterExtern(ExternBase* member);
 
   // The scope's declared time precision as a power of ten (LRM Table 20-2).

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -206,6 +206,18 @@ enum class BuiltinFn : std::uint16_t {
   // lowering so the wait expression carries an explicit observable handle
   // rather than letting the backend derive one from the member's type.
   kAsObservable,
+  // Per-reference initialization of an `ExternUp<T>` member. `kBindRoot`
+  // installs the `$root` anchor and the leaf signal name; `kBindVisibleChild`
+  // installs the canonical-name climb start (head name + head indices) and
+  // the leaf signal. `kAddSuffixStep` appends one descent step
+  // (`name, indices`) below the anchor; emitted once per intermediate hop in
+  // the descent path, in left-to-right order. All three are instance methods
+  // on the member; their arguments are flat MIR primitives (string literals,
+  // integer-array literals, self ref) so MIR carries the per-reference
+  // symbol without learning the wrapper's internal anchor shape.
+  kBindVisibleChild,
+  kBindRoot,
+  kAddSuffixStep,
   // By-name scope navigation: a constructor walks a sibling unit's
   // interface, looks up an owned child by name (and per-dimension index),
   // looks up a signal by name, or attaches a freshly-built child into its

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -29,30 +29,7 @@ auto RenderField(
     const ScopeView& ctor_view, const mir::MemberDecl& var, std::size_t indent)
     -> std::string {
   const auto& unit = ctor_view.Unit();
-  std::string type = RenderTypeAsCpp(unit, ctor_view.Class(), var.type);
-  // An upward reference is an ExternUp member: its constructor takes the
-  // symbol payload (ancestor, by-name tail, leaf signal) rather than a value
-  // initializer; it registers itself and relocates in the resolve phase.
-  if (const auto* er =
-          std::get_if<mir::ExternalRefType>(&unit.GetType(var.type).data)) {
-    std::string tail = "{";
-    for (std::size_t i = 0; i < er->tail.size(); ++i) {
-      if (i != 0) tail += ", ";
-      tail += std::format("{{\"{}\", {{", er->tail[i].name);
-      for (std::size_t j = 0; j < er->tail[i].indices.size(); ++j) {
-        if (j != 0) tail += ", ";
-        tail += std::to_string(er->tail[i].indices[j]);
-      }
-      tail += "}}";
-    }
-    tail += "}";
-    const std::string match = er->match == mir::ExternalRefMatch::kDefName
-                                  ? "lyra::runtime::UpwardMatch::kDefName"
-                                  : "lyra::runtime::UpwardMatch::kScopeName";
-    return std::format(
-        "{}{} {}{{this, \"{}\", {}, {}, \"{}\"}};\n", Indent(indent), type,
-        var.name, er->ancestor, match, tail, er->signal);
-  }
+  const std::string type = RenderTypeAsCpp(unit, ctor_view.Class(), var.type);
   return std::format("{}{} {}{{}};\n", Indent(indent), type, var.name);
 }
 

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -216,6 +216,12 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "FatalFinish";
     case support::BuiltinFn::kAsObservable:
       return "AsObservable";
+    case support::BuiltinFn::kBindVisibleChild:
+      return "BindVisibleChild";
+    case support::BuiltinFn::kBindRoot:
+      return "BindRoot";
+    case support::BuiltinFn::kAddSuffixStep:
+      return "AddSuffixStep";
     case support::BuiltinFn::kRegisterSignal:
       return "RegisterSignal";
     case support::BuiltinFn::kAttachChild:

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -173,7 +173,7 @@ auto LowerExprImpl(
       }
 
     case slang::ast::ExpressionKind::HierarchicalValue:
-      return LowerHierarchicalValueProc(
+      return LowerHierarchicalValue(
           module, frame, expr.as<slang::ast::HierarchicalValueExpression>());
 
     case slang::ast::ExpressionKind::LValueReference:

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -138,13 +138,12 @@ auto LowerNamedValueProc(
       binding->type, span);
 }
 
-// LRM 23.6 hierarchical reference. The head of the navigation differs by
-// direction: a downward path (`c.x`, `c[1].x`, `g[1].u.x`) starts at a local
-// owned child -- an instance member or a generate block; an upward path
-// (`Top.g`, `Top.sib.y`) starts by climbing the parent chain to the named
-// ancestor -- a module instance, a named generate block, or the root. The
-// shared tail (`path.subspan(1)`) reaches the leaf in both directions.
-auto LowerHierarchicalValueProc(
+// LRM 23.6 hierarchical reference. A downward path is rooted in a local
+// owned child identified by binding; an upward path carries an anchor (a
+// `$root` token or a canonical named head with any per-dimension index) and
+// a descent suffix that walks by name from the anchor down to the leaf
+// signal.
+auto LowerHierarchicalValue(
     ModuleLowerer& module, WalkFrame frame,
     const slang::ast::HierarchicalValueExpression& hve)
     -> diag::Result<hir::Expr> {
@@ -168,77 +167,89 @@ auto LowerHierarchicalValueProc(
   auto type_id = module.InternType(*hve.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
 
-  // ref.path is slang's resolved top-down navigation: path.front() is the head
-  // (a local member downward, the named ancestor upward); the rest navigate
-  // down to the leaf (path.back() is `target`), each step a named member or an
-  // instance-array index. The tail is shared by both directions.
-  std::vector<hir::PathStep> path;
-  path.reserve(ref.path.size() - 1);
-  for (const auto& step : ref.path.subspan(1)) {
-    if (std::holds_alternative<std::string_view>(step.selector)) {
-      path.emplace_back(
-          hir::MemberHop{
-              std::string{std::get<std::string_view>(step.selector)}});
-    } else if (std::holds_alternative<std::int32_t>(step.selector)) {
-      path.emplace_back(
-          hir::IndexHop{static_cast<std::uint32_t>(
-              std::get<std::int32_t>(step.selector))});
-    } else {
-      return diag::Fail(
-          span, diag::DiagCode::kUnsupportedExpressionForm,
-          "instance-array range select in a hierarchical path is not yet "
-          "supported");
-    }
-  }
-
   const auto& var = target.as<slang::ast::VariableSymbol>();
   const slang::ast::Symbol& head_sym = *ref.path.front().symbol;
 
+  // ref.path is slang's resolved top-down navigation: path.front() is the
+  // head, path.back() is `target`, and each name selector is the resolved
+  // symbol's canonical name. Carrying those selectors verbatim into the HIR
+  // descent makes the runtime by-name navigation hit each scope by the same
+  // key the parent registered under.
+  const auto build_path =
+      [&](std::span<const slang::ast::HierarchicalReference::Element> steps)
+      -> diag::Result<std::vector<hir::PathStep>> {
+    std::vector<hir::PathStep> path;
+    path.reserve(steps.size());
+    for (const auto& step : steps) {
+      if (std::holds_alternative<std::string_view>(step.selector)) {
+        path.emplace_back(
+            hir::MemberHop{
+                std::string{std::get<std::string_view>(step.selector)}});
+      } else if (std::holds_alternative<std::int32_t>(step.selector)) {
+        path.emplace_back(
+            hir::IndexHop{static_cast<std::uint32_t>(
+                std::get<std::int32_t>(step.selector))});
+      } else {
+        return diag::Fail(
+            span, diag::DiagCode::kUnsupportedExpressionForm,
+            "instance-array range select in a hierarchical path is not yet "
+            "supported");
+      }
+    }
+    return path;
+  };
+
   if (ref.isUpward()) {
-    // An upward reference (LRM 23.8) climbs the parent chain to the matching
-    // ancestor, then shares `path` with the downward direction to reach the
-    // leaf. The head selects how the climb matches. A module instance keys on
-    // the ancestor's module definition name -- class-level, so one artifact
-    // serves every depth and a wrapped sub-expression like `Top.g[3]` needs no
-    // syntax. A named generate block or a `$root`-anchored absolute path keys
-    // on the ancestor scope's own name (LRM 23.6): the generate-block label, or
-    // the root's reserved name. The extern member is synthesized on the
-    // referrer's own structural scope (`frame.Current()`), whether the unit
-    // root or a generate block, so a reference written inside a generate block
-    // resolves the same way (its member rides the generate-scope class).
-    std::optional<hir::UpwardHead> head;
+    // The named arm carries the canonical head name plus any per-dimension
+    // index that immediately follows it in `ref.path` (e.g. `bank[2].x`); the
+    // root arm carries no key. The suffix is `ref.path` strictly past the
+    // head element(s). Synthesizing the extern member on the referrer's own
+    // structural scope keeps the lexical lookup origin coincident with the
+    // structural class that owns this member, including for references
+    // written inside a generate block.
+    hir::CrossUnitRefHead anchor;
+    std::span<const slang::ast::HierarchicalReference::Element> suffix_steps;
     switch (head_sym.kind) {
       case slang::ast::SymbolKind::Instance:
-        head = hir::UpwardHead{
-            .ancestor_name =
-                std::string{head_sym.as<slang::ast::InstanceSymbol>()
-                                .getDefinition()
-                                .name},
-            .match = hir::UpwardMatch::kDefName};
+      case slang::ast::SymbolKind::GenerateBlock: {
+        // Gather the head's per-dimension indices from the index selectors
+        // immediately following `path[0]`; the next name selector marks the
+        // start of the descent suffix.
+        hir::UpwardNamedHead named{
+            .head_name = std::string{head_sym.name}, .head_indices = {}};
+        std::size_t suffix_start = 1;
+        while (suffix_start < ref.path.size() &&
+               std::holds_alternative<std::int32_t>(
+                   ref.path[suffix_start].selector)) {
+          named.head_indices.push_back(
+              static_cast<std::uint32_t>(
+                  std::get<std::int32_t>(ref.path[suffix_start].selector)));
+          ++suffix_start;
+        }
+        anchor = std::move(named);
+        suffix_steps = ref.path.subspan(suffix_start);
         break;
-      case slang::ast::SymbolKind::GenerateBlock:
-        head = hir::UpwardHead{
-            .ancestor_name = std::string{head_sym.name},
-            .match = hir::UpwardMatch::kScopeName};
-        break;
+      }
       case slang::ast::SymbolKind::Root:
-        head = hir::UpwardHead{
-            .ancestor_name = "$root", .match = hir::UpwardMatch::kScopeName};
+        anchor = hir::UpwardRootHead{};
+        suffix_steps = ref.path.subspan(1);
         break;
       default:
-        // Any other head -- an indexed loop-generate block, or a named
-        // procedural block whose locals live on the enclosing unit rather than
-        // in a constructed scope -- does not resolve to a climb target yet.
         return diag::Fail(
             span, diag::DiagCode::kUnsupportedExpressionForm,
             "upward hierarchical reference whose head is not a module "
             "instance, "
             "a named generate block, or $root is not yet supported");
     }
+    auto path = build_path(suffix_steps);
+    if (!path) return std::unexpected(std::move(path.error()));
     return module.MakeCrossUnitMemberRef(
-        var, frame.Current(), *std::move(head), std::move(path), *type_id,
+        var, frame.Current(), std::move(anchor), std::move(*path), *type_id,
         span);
   }
+
+  auto path = build_path(ref.path.subspan(1));
+  if (!path) return std::unexpected(std::move(path.error()));
 
   // Downward: the head is an owned child this unit's scope declares -- an
   // instance / instance-array member, or a generate block (LRM 27). Both are
@@ -257,7 +268,7 @@ auto LowerHierarchicalValueProc(
   const auto binding = module.LookupOwnedChildBinding(head_sym);
   if (!binding.has_value()) {
     throw InternalError(
-        "LowerHierarchicalValueProc: downward owned-child head has no binding");
+        "LowerHierarchicalValue: downward owned-child head has no binding");
   }
 
   // The owner navigates its own storage, so the head must live on the
@@ -271,7 +282,8 @@ auto LowerHierarchicalValueProc(
         "scope is not yet supported");
   }
   return module.MakeCrossUnitMemberRef(
-      var, binding->home_frame, binding->head, std::move(path), *type_id, span);
+      var, binding->home_frame, binding->head, std::move(*path), *type_id,
+      span);
 }
 
 auto LowerNamedValueStructural(

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -450,56 +450,37 @@ auto InstallInstanceMembers(ClassLowerer& lowerer, WalkFrame frame)
   return instance_member_vars;
 }
 
-// An upward cross-unit reference materializes as an ExternalRef member: the
-// symbol -- ancestor name, by-name tail through its owned children, and leaf
-// signal -- lives on its type, and the runtime ExternUp member self-relocates
-// in the resolve phase by climbing the parent chain then walking the tail. A
-// downward reference gets a borrowed-pointer slot member, null until the
-// constructor resolves it. Both run before processes so reads resolve to the
-// slot; both record their MIR read target as a StructuralVarRef to that member,
-// in HIR slot order. The returned vector carries the downward slot var per ref
-// (nullopt for upward), consumed by InstallCrossUnitRefs once the children
-// exist.
+// Allocates one MIR member per cross-unit reference. Upward references take
+// the wrapper-typed ExternUp form whose per-reference state lands as ordinary
+// `CallExpr` statements in the constructor body. Downward references take a
+// borrowed-pointer slot the constructor fills by navigating from `self` once
+// the children are built. Both run before processes so reads resolve to the
+// member; both record their MIR read target as a StructuralVarRef to that
+// member, in HIR slot order. The returned vector carries the allocated member
+// per ref in HIR order.
 auto MaterializeCrossUnitRefTargets(ClassLowerer& lowerer, WalkFrame frame)
-    -> std::vector<std::optional<mir::MemberId>> {
+    -> std::vector<mir::MemberId> {
   ModuleLowerer& module = lowerer.Module();
   mir::Class& mir_class = *frame.current_class;
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
-  std::vector<std::optional<mir::MemberId>> slot_vars;
+  std::vector<mir::MemberId> slot_vars;
   std::uint32_t slot_index = 0;
   for (const auto& cu : hir_scope.cross_unit_refs) {
     std::string member_name = "xref" + std::to_string(slot_index++);
-    if (const auto* up = std::get_if<hir::UpwardHead>(&cu.head)) {
-      // `cu.path` runs from the ancestor down to the leaf, shared with the
-      // downward direction. Fold it into by-name child hops (each member opens
-      // a hop, following array indices attach to it) and the final leaf signal.
-      std::vector<mir::ChildStep> tail;
-      for (const auto& step : cu.path) {
-        if (const auto* member = std::get_if<hir::MemberHop>(&step)) {
-          tail.push_back(mir::ChildStep{.name = member->name, .indices = {}});
-        } else {
-          tail.back().indices.push_back(std::get<hir::IndexHop>(step).index);
-        }
-      }
-      std::string signal = std::move(tail.back().name);
-      tail.pop_back();
-
-      const mir::ExternalRefMatch match =
-          up->match == hir::UpwardMatch::kDefName
-              ? mir::ExternalRefMatch::kDefName
-              : mir::ExternalRefMatch::kScopeName;
+    const bool is_upward =
+        std::holds_alternative<hir::UpwardRootHead>(cu.head) ||
+        std::holds_alternative<hir::UpwardNamedHead>(cu.head);
+    if (is_upward) {
+      // The member's type carries only the wrapped element; the per-reference
+      // navigation plan is emitted as ordinary `CallExpr` statements in the
+      // constructor body (see `InstallCrossUnitRefs`).
       const mir::TypeId leaf = module.TranslateType(cu.type);
-      const mir::TypeId ext_type = module.Unit().AddType(
-          mir::ExternalRefType{
-              .element = leaf,
-              .ancestor = up->ancestor_name,
-              .match = match,
-              .tail = std::move(tail),
-              .signal = std::move(signal)});
+      const mir::TypeId ext_type =
+          module.Unit().AddType(mir::ExternalRefType{.element = leaf});
       const mir::MemberId var = mir_class.members.Add(
           mir::MemberDecl{.name = std::move(member_name), .type = ext_type});
       lowerer.AddCrossUnitRefTarget(mir::MemberRef{.var = var}, ext_type);
-      slot_vars.emplace_back(std::nullopt);
+      slot_vars.push_back(var);
     } else {
       // The pointee matches the producer's storage cell. A producer-side
       // value-storage signal is wrapped in `ObservableType` at its declaration
@@ -513,7 +494,7 @@ auto MaterializeCrossUnitRefTargets(ClassLowerer& lowerer, WalkFrame frame)
       const mir::MemberId slot = mir_class.members.Add(
           mir::MemberDecl{.name = std::move(member_name), .type = slot_type});
       lowerer.AddCrossUnitRefTarget(mir::MemberRef{.var = slot}, slot_type);
-      slot_vars.emplace_back(slot);
+      slot_vars.push_back(slot);
     }
   }
   return slot_vars;
@@ -597,31 +578,173 @@ auto BuildDownwardNavValue(
       .data = mir::CastExpr{.operand = get_signal_id}, .type = slot_type};
 }
 
+// Builds an `UnpackedArray<int32, N>` literal expression holding one element
+// per supplied index. Used as the per-step indices argument to the runtime
+// bind / suffix-step methods; an empty index list still produces a typed
+// zero-element array so the call's signature is uniform.
+auto BuildIndicesArrayExpr(
+    ModuleLowerer& module, mir::Block& block,
+    std::span<const std::uint32_t> indices) -> mir::ExprId {
+  const auto& builtins = module.Unit().builtins;
+  std::vector<mir::ExprId> index_exprs;
+  index_exprs.reserve(indices.size());
+  for (const std::uint32_t idx : indices) {
+    index_exprs.push_back(block.exprs.Add(
+        mir::MakeInt32Literal(builtins.int32, static_cast<std::int64_t>(idx))));
+  }
+  const mir::TypeId indices_type = module.Unit().AddType(
+      mir::UnpackedArrayType{
+          .element_type = builtins.int32, .size = indices.size()});
+  return block.exprs.Add(
+      mir::Expr{
+          .data = mir::ArrayLiteralExpr{.elements = std::move(index_exprs)},
+          .type = indices_type});
+}
+
+// Emits one `CallExpr` statement against the ExternUp member: the receiver
+// is `self->member`, the callee is the named builtin method, the arguments
+// run through the ordinary primitive forms (string literal, indices array
+// literal, self ref). Used for the bind and per-suffix-step calls.
+void AppendExternUpMethodCall(
+    ModuleLowerer& module, WalkFrame frame, mir::MemberId extern_member,
+    support::BuiltinFn method, std::vector<mir::ExprId> arguments) {
+  mir::Block& block = *frame.current_block;
+  mir::Class& mir_class = *frame.current_class;
+  const mir::TypeId self_ptr_type = mir_class.self_pointer_type;
+  const mir::TypeId void_type = module.Unit().builtins.void_type;
+
+  const mir::ExprId self_ref =
+      block.exprs.Add(MakeSelfRefExpr(frame, self_ptr_type));
+  const mir::TypeId receiver_type = mir_class.members.Get(extern_member).type;
+  std::vector<mir::ExprId> args;
+  args.reserve(arguments.size() + 1);
+  args.push_back(block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::MemberAccessExpr{
+                  .receiver = self_ref,
+                  .member = mir::MemberRef{.var = extern_member}},
+          .type = receiver_type}));
+  for (const mir::ExprId arg : arguments) {
+    args.push_back(arg);
+  }
+  const mir::ExprId call = block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::CallExpr{
+                  .callee = mir::Direct{.target = method},
+                  .arguments = std::move(args)},
+          .type = void_type});
+  block.AppendStmt(
+      mir::Stmt{.label = std::nullopt, .data = mir::ExprStmt{.expr = call}});
+}
+
+// `path_after_anchor` excludes the anchor (the `$root` token for a root
+// anchor; the named head and any per-dimension indices attached to it for a
+// named anchor) and ends with the leaf signal. The leaf step must carry no
+// indices -- array selection on a cross-unit-ref leaf is an expression-level
+// access, not part of the descent -- enforced as a compiler invariant.
+void AppendExternUpBinding(
+    ModuleLowerer& module, WalkFrame frame, mir::MemberId member,
+    std::span<const hir::PathStep> path_after_anchor,
+    support::BuiltinFn bind_callee,
+    std::vector<mir::ExprId> bind_args_before_signal) {
+  mir::Block& block = *frame.current_block;
+  const auto& builtins = module.Unit().builtins;
+  const auto string_literal = [&](std::string s) -> mir::ExprId {
+    return block.exprs.Add(
+        mir::Expr{
+            .data = mir::StringLiteral{.value = std::move(s)},
+            .type = builtins.string});
+  };
+
+  struct DescentStep {
+    std::string name;
+    std::vector<std::uint32_t> indices;
+  };
+  std::vector<DescentStep> steps;
+  for (const auto& step : path_after_anchor) {
+    if (const auto* m = std::get_if<hir::MemberHop>(&step)) {
+      steps.push_back(DescentStep{.name = m->name, .indices = {}});
+    } else {
+      steps.back().indices.push_back(std::get<hir::IndexHop>(step).index);
+    }
+  }
+  if (!steps.back().indices.empty()) {
+    throw InternalError(
+        "AppendExternUpBinding: leaf signal step carries indices; "
+        "array selection on a cross-unit-ref leaf belongs to an "
+        "expression-level access, not the descent");
+  }
+  std::string signal = std::move(steps.back().name);
+  steps.pop_back();
+
+  bind_args_before_signal.push_back(string_literal(std::move(signal)));
+  AppendExternUpMethodCall(
+      module, frame, member, bind_callee, std::move(bind_args_before_signal));
+
+  for (const auto& step : steps) {
+    AppendExternUpMethodCall(
+        module, frame, member, support::BuiltinFn::kAddSuffixStep,
+        {string_literal(step.name),
+         BuildIndicesArrayExpr(module, block, step.indices)});
+  }
+}
+
 // A downward slot resolves in the constructor by navigating from the enclosing
 // scope after the children are built: an ordinary assignment of the navigation
-// value into the borrowed-pointer slot. Upward slots are materialized as
-// ExternalRef members upstream and skipped here.
+// value into the borrowed-pointer slot. An upward ExternUp member's
+// per-reference plan emits as a `BindVisibleChild` or `BindRoot` call against
+// the member, followed by one `AddSuffixStep` call per descent step -- ordinary
+// `CallExpr` carrying flat MIR primitives, so the backend renders them
+// uniformly with every other call.
 void InstallCrossUnitRefs(
     ClassLowerer& lowerer, WalkFrame frame,
     const std::vector<mir::MemberId>& instance_member_vars,
     const std::vector<GenerateBindings>& gen_bindings,
-    const std::vector<std::optional<mir::MemberId>>& slot_vars) {
+    const std::vector<mir::MemberId>& slot_vars) {
   mir::Class& mir_class = *frame.current_class;
   mir::Block& ctor_block = *frame.current_block;
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
   ModuleLowerer& module = lowerer.Module();
+  const auto& builtins = module.Unit().builtins;
   const mir::TypeId scope_ptr_type = module.Unit().AddType(
       mir::PointerType{
           .pointee = module.Unit().AddType(mir::ScopeType{}),
           .ownership = mir::PointerOwnership::kBorrowed});
+  const auto string_literal = [&](const std::string& s) -> mir::ExprId {
+    return ctor_block.exprs.Add(
+        mir::Expr{
+            .data = mir::StringLiteral{.value = s}, .type = builtins.string});
+  };
   for (std::size_t ci = 0; ci < hir_scope.cross_unit_refs.size(); ++ci) {
     const auto& cu = hir_scope.cross_unit_refs.Get(
         hir::CrossUnitRefId{static_cast<std::uint32_t>(ci)});
+    const mir::MemberId member = slot_vars.at(ci);
+    if (std::holds_alternative<hir::UpwardRootHead>(cu.head)) {
+      const mir::ExprId origin_self = ctor_block.exprs.Add(
+          MakeSelfRefExpr(frame, mir_class.self_pointer_type));
+      AppendExternUpBinding(
+          module, frame, member, cu.path, support::BuiltinFn::kBindRoot,
+          {origin_self});
+      continue;
+    }
+    if (const auto* up_named = std::get_if<hir::UpwardNamedHead>(&cu.head)) {
+      const mir::ExprId origin_self = ctor_block.exprs.Add(
+          MakeSelfRefExpr(frame, mir_class.self_pointer_type));
+      const mir::ExprId head_name = string_literal(up_named->head_name);
+      const mir::ExprId head_indices =
+          BuildIndicesArrayExpr(module, ctor_block, up_named->head_indices);
+      AppendExternUpBinding(
+          module, frame, member, cu.path, support::BuiltinFn::kBindVisibleChild,
+          {origin_self, head_name, head_indices});
+      continue;
+    }
     const auto* down = std::get_if<hir::DownwardHead>(&cu.head);
     if (down == nullptr) {
       continue;
     }
-    const mir::MemberId slot = *slot_vars.at(ci);
+    const mir::MemberId slot = member;
     mir::MemberId head_var{};
     if (const auto* im = std::get_if<hir::InstanceMemberId>(&down->child)) {
       head_var = instance_member_vars.at(im->value);

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -236,20 +236,7 @@ class MirDumper {
               return std::format("Tuple(elems=[{}])", elements);
             },
             [](const ExternalRefType& e) -> std::string {
-              std::string tail;
-              for (const auto& hop : e.tail) {
-                tail += "." + hop.name;
-                for (const std::uint32_t index : hop.indices) {
-                  tail += std::format("[{}]", index);
-                }
-              }
-              const std::string_view match =
-                  e.match == ExternalRefMatch::kDefName ? "DefName"
-                                                        : "ScopeName";
-              return std::format(
-                  "ExternalRef(elem=Type[{}], ancestor={}, match={}, tail={}, "
-                  "signal={})",
-                  e.element.value, e.ancestor, match, tail, e.signal);
+              return std::format("ExternalRef(elem=Type[{}])", e.element.value);
             },
             [](const ObservableType& o) -> std::string {
               return std::format("Observable(value=Type[{}])", o.value.value);

--- a/src/lyra/runtime/scope.cpp
+++ b/src/lyra/runtime/scope.cpp
@@ -137,18 +137,25 @@ void Scope::RegisterExtern(ExternBase* member) {
   externs_.push_back(member);
 }
 
-auto Scope::ResolveUpwardScope(std::string_view key, UpwardMatch match)
-    -> Scope* {
-  for (Scope* s = parent_; s != nullptr; s = s->Parent()) {
-    const std::string_view name =
-        match == UpwardMatch::kDefName ? s->DefName() : s->Name();
-    if (name == key) {
-      return s;
+auto Scope::ResolveVisibleChild(
+    std::string_view head_name,
+    std::span<const lyra::value::PackedArray> head_indices) -> Scope* {
+  for (Scope* level = this; level != nullptr; level = level->Parent()) {
+    if (Scope* child = level->GetChild(head_name, head_indices)) {
+      return child;
     }
   }
   throw InternalError(
-      "Scope::ResolveUpwardScope: no ancestor named " + std::string(key) +
-      " on the parent chain");
+      "Scope::ResolveVisibleChild: no child named " + std::string(head_name) +
+      " visible from this scope's enclosing chain");
+}
+
+auto Scope::ResolveRoot() -> Scope* {
+  Scope* level = this;
+  while (level->parent_ != nullptr) {
+    level = level->parent_;
+  }
+  return level;
 }
 
 auto Scope::Services() -> RuntimeServices& {

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -289,6 +289,12 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "fatal_finish";
     case BuiltinFn::kAsObservable:
       return "as_observable";
+    case BuiltinFn::kBindVisibleChild:
+      return "bind_visible_child";
+    case BuiltinFn::kBindRoot:
+      return "bind_root";
+    case BuiltinFn::kAddSuffixStep:
+      return "add_suffix_step";
     case BuiltinFn::kRegisterSignal:
       return "register_signal";
     case BuiltinFn::kAttachChild:

--- a/tests/cases/cpp/hierarchy_upward_visible_child/case.yaml
+++ b/tests/cases/cpp/hierarchy_upward_visible_child/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.hierarchy_upward_visible_child
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  stdout:
+    exact: "shallow=7 deep=22 a=11 b_inst=99\n"

--- a/tests/cases/cpp/hierarchy_upward_visible_child/main.sv
+++ b/tests/cases/cpp/hierarchy_upward_visible_child/main.sv
@@ -1,0 +1,64 @@
+// One elaboration covers every shape of LRM 23.8 step b/c upward
+// visible-child resolution. The runtime climb walks each enclosing level
+// and matches a child by its canonical instance name; this case bites
+// every code path that walk exercises, with values chosen so a wrong
+// lookup observably fails:
+//
+//   - Shallow sibling generate (block `a` reads `b.bx == 7`). `a` is
+//     declared before `b`, so slang classifies the reference as upward
+//     (the converse `b -> a` rides slang's downward path, an unrelated
+//     lowering limitation tracked separately).
+//
+//   - Sibling-of-ancestor at depth (Leaf reads `my_foo.v == 22`). From
+//     inside `mid.leaf`, my_foo is neither on the chain nor in a closer
+//     enclosing scope -- the climb scans Top's children to find it.
+//
+//   - Two siblings of the same module distinguished by canonical instance
+//     name. `reader` (declared before foo_a/foo_b so the references are
+//     forward, upward) reads `foo_a.v == 11` and `foo_b.v == 99`; a
+//     def-name-based climb would collapse both onto the same Foo.
+module Foo;
+  int v;
+endmodule
+
+module Leaf;
+  int from_top_my_foo;
+  always_comb from_top_my_foo = my_foo.v;
+endmodule
+
+module Mid;
+  Leaf leaf();
+endmodule
+
+module Top;
+  if (1) begin : a
+    int from_b;
+    always_comb from_b = b.bx;
+  end
+  if (1) begin : b
+    int bx;
+  end
+
+  if (1) begin : reader
+    int from_a;
+    int from_b;
+    always_comb from_a = foo_a.v;
+    always_comb from_b = foo_b.v;
+  end
+
+  Foo my_foo();
+  Mid mid();
+  Foo foo_a();
+  Foo foo_b();
+
+  initial begin
+    b.bx = 7;
+    my_foo.v = 22;
+    foo_a.v = 11;
+    foo_b.v = 99;
+    #1;
+    $display("shallow=%0d deep=%0d a=%0d b_inst=%0d",
+             a.from_b, mid.leaf.from_top_my_foo,
+             reader.from_a, reader.from_b);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Aligns `ExternUp<T>` with the existing `Var<T>` pattern: the wrapper is default-constructed in the field declaration, and its per-reference state arrives through ordinary method calls in the owning scope's constructor body. The MIR type system carries only the wrapped element; the navigation plan (anchor, descent suffix, leaf signal) is expressed as MIR `CallExpr` statements against three new `BuiltinFn` entries (`kBindRoot`, `kBindVisibleChild`, `kAddSuffixStep`). The C++ backend's `RenderField` becomes a uniform format string with no per-type branches; the type-mapping dispatch is the only place runtime library type names appear.

The runtime climb is also rewritten to scan each enclosing level's children rather than walking ancestors and matching by name. This fixes the LRM 23.8 step b/c semantics for sibling-of-ancestor references (one generate block reading another's signal, or any reference whose head is a sibling of an enclosing scope).

## Design

`backend_contract.md` (new) codifies the rule that a backend render is a fixed function of one MIR node: any decision logic in a value-emission entry is a MIR design failure. The C++ backend's transitional status (a stand-in until LIR/LLVM are built) does not loosen the discipline -- any place where C++ render would need a branch is a place where the eventual LLVM IR backend would need the same branch. The wrapper-API redesign moves construction state off the MIR type system so MIR's existing primitive set can express the bind sequence; no new MIR primitive was introduced.

## Testing

A consolidated `hierarchy_upward_visible_child` test covers shallow sibling generate, deep sibling-of-ancestor, and canonical-name distinction of same-def siblings in one elaboration. Existing `hierarchy_upward_*` tests cover head-on-chain and descent-through-generate cases. Full test suite green.