### PR TITLE
Build unpacked-struct assignment patterns and default init

### DIFF
--- a/docs/progress/struct-union.md
+++ b/docs/progress/struct-union.md
@@ -34,12 +34,14 @@ Table 7-1).
       any supported integral, packed, real, or string type; an unpacked struct nests as a member of
       another unpacked struct, and a struct is usable as an unpacked-array element and may itself
       hold an unpacked-array member.
-- [ ] S2 -- Assignment-pattern literals (LRM 10.9): positional `'{a, b, c}`, named `'{field: v}` in
+- [x] S2 -- Assignment-pattern literals (LRM 10.9): positional `'{a, b, c}`, named `'{field: v}` in
       any order, type-key and `default:` fill (including mixed field widths), and the type-prefixed
       self-determined form `T'{...}`.
-- [ ] S3 -- Default initialization (LRM Table 7-1, 7.2.2). Each member defaults to its own type's
+- [x] S3 -- Default initialization (LRM Table 7-1, 7.2.2). Each member defaults to its own type's
       Table 6-7 value, recursively, unless the member's declaration carries an initial assignment,
-      in which case that value is used. The 2-state / 4-state distinction propagates per member.
+      in which case that value is used. The 2-state / 4-state distinction propagates per member. A
+      member's initial assignment may itself be an aggregate literal (a struct- or array-typed
+      member default).
 - [ ] S4 -- Aggregate copy and equality (`==` / `!=` / `===` / `!==`), and member access composing
       with element / range selects on packed members and on either side of an expression
       (`s.f[3:0]`, `s.f + 1`). A struct field reads and writes correctly in arithmetic, conditional,

--- a/include/lyra/hir/constant_value.hpp
+++ b/include/lyra/hir/constant_value.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "lyra/hir/integral_constant.hpp"
+
+namespace lyra::hir {
+
+struct ConstantValue;
+
+// A folded elaboration constant: a scalar leaf (integral, real / shortreal /
+// realtime as one `double`, or string) or, for an unpacked aggregate, the
+// ordered component values. The enclosing type disambiguates a component list
+// as a struct's members or an array's elements; the value carries only the
+// folded data, the same way an enum member carries an `IntegralConstant`. This
+// is the value form of a type-level constant (LRM 7.2.2 member default), not an
+// expression -- a data type carries constant values as metadata, never an
+// expression.
+using ConstantValueData = std::variant<
+    IntegralConstant, double, std::string, std::vector<ConstantValue>>;
+
+struct ConstantValue {
+  ConstantValueData data;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/loop_var.hpp
+++ b/include/lyra/hir/loop_var.hpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <string>
 
-#include "lyra/hir/type.hpp"
+#include "lyra/hir/type_id.hpp"
 
 namespace lyra::hir {
 

--- a/include/lyra/hir/type.hpp
+++ b/include/lyra/hir/type.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/constant_value.hpp"
 #include "lyra/hir/integral_constant.hpp"
 #include "lyra/hir/type_id.hpp"
 
@@ -117,10 +118,15 @@ struct PackedUnionType {
 // aggregate field, an unpacked member has its own independent storage of its
 // declared type -- there is no shared bit vector, so no offset or width. The
 // member is identified by its position in declaration order (LRM 7.2 / 7.3),
-// the same index a member-access expression carries.
+// the same index a member-access expression carries. `default_init` holds the
+// member's own declaration initializer (LRM 7.2.2) as a folded constant value
+// -- type metadata, like an enum member's value -- which takes precedence over
+// the member type's Table 7-1 default when the enclosing struct is
+// default-constructed; absent when the member has no initializer.
 struct UnpackedAggregateField {
   std::string name;
   TypeId type;
+  std::optional<ConstantValue> default_init;
 };
 
 // LRM 7.2 unpacked structure: a heterogeneous aggregate whose members each hold

--- a/include/lyra/lowering/ast_to_hir/constant_value.hpp
+++ b/include/lyra/lowering/ast_to_hir/constant_value.hpp
@@ -4,12 +4,23 @@
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
+#include "lyra/hir/constant_value.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/module_unit.hpp"
 #include "lyra/hir/type_id.hpp"
 #include "lyra/lowering/ast_to_hir/walk_frame.hpp"
 
 namespace lyra::lowering::ast_to_hir {
+
+// Fold an already-evaluated slang ConstantValue into its HIR value form: a
+// scalar leaf, or an unpacked aggregate's ordered component values (recursively
+// folded). This is the value the metadata of a type carries -- an unpacked
+// struct member default (LRM 7.2.2) -- as opposed to the expression form below
+// that a constant takes when it enters an expression context. Self-contained:
+// no expr arena, because a value references nothing. Packed aggregates never
+// reach here -- slang folds them to a single integral value.
+auto MakeConstantValue(const slang::ConstantValue& cv, diag::SourceSpan span)
+    -> diag::Result<hir::ConstantValue>;
 
 // Materialize an already-evaluated slang ConstantValue as an HIR expression of
 // `type`. A scalar value (integral, real, shortreal, string) becomes a literal.

--- a/include/lyra/lowering/ast_to_hir/integral_constant.hpp
+++ b/include/lyra/lowering/ast_to_hir/integral_constant.hpp
@@ -16,6 +16,14 @@ namespace lyra::lowering::ast_to_hir {
 auto LowerSVIntToIntegralConstant(const slang::SVInt& sv)
     -> hir::IntegralConstant;
 
+// Wrap a folded HIR integral constant as an integer-literal expression of
+// `type`. The single place the integer-literal expression shape is built,
+// reached from a slang `SVInt` (after folding) or from an already-folded
+// `IntegralConstant`.
+auto MakeIntegerLiteralFromConstant(
+    hir::IntegralConstant value, hir::TypeId type, diag::SourceSpan span)
+    -> hir::Expr;
+
 // Materialize an already-evaluated slang integral constant as an HIR
 // integer-literal expression of `type`. Shared by every site that splices a
 // constant slang has folded into the HIR: parameter and enum-value references,

--- a/include/lyra/lowering/hir_to_mir/default_value.hpp
+++ b/include/lyra/lowering/hir_to_mir/default_value.hpp
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "lyra/hir/type_id.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
@@ -26,6 +27,17 @@ namespace lyra::lowering::hir_to_mir {
 // downstream layers see one shape (an Expr) instead of two.
 [[nodiscard]] auto BuildDefaultValueExpr(
     const ModuleLowerer& module, WalkFrame frame, mir::TypeId type)
+    -> mir::Expr;
+
+// Default-construct a value from its source (HIR) type, honoring
+// unpacked-struct member declaration initializers (LRM 7.2.2). Use this at
+// every site that materializes the SV default initial value of a declared
+// variable, member, or element. The MIR-type-keyed default builder above cannot
+// honor member initializers -- the canonicalized MIR type drops them -- so it
+// serves only placeholder and transient-product defaults, where the source
+// initializer does not apply.
+[[nodiscard]] auto BuildDefaultValueFromHir(
+    const ModuleLowerer& module, WalkFrame frame, hir::TypeId hir_type)
     -> mir::Expr;
 
 // Wraps a list of element ExprIds destined for an array container constructor

--- a/include/lyra/lowering/hir_to_mir/expression/aggregates.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/aggregates.hpp
@@ -51,6 +51,7 @@ auto LowerHirReplicationExpr(
 // stays a procedural-only handler.
 auto LowerHirDynamicArrayNewExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::DynamicArrayNewExpr& n,
-    mir::TypeId result_type) -> diag::Result<mir::Expr>;
+    hir::TypeId hir_result_type, mir::TypeId result_type)
+    -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/expression/references.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/references.hpp
@@ -27,4 +27,9 @@ auto LowerHirPrimaryExprStructural(
     const ClassLowerer& lowerer, WalkFrame frame, const hir::Primary& p,
     mir::TypeId result_type) -> diag::Result<mir::Expr>;
 
+// Translate a folded HIR integral constant to its MIR form. Shared by
+// primary-literal lowering and member-default materialization.
+auto LowerHirIntegralConstant(const hir::IntegralConstant& c)
+    -> mir::IntegralConstant;
+
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/ast_to_hir/constant_value.cpp
+++ b/src/lyra/lowering/ast_to_hir/constant_value.cpp
@@ -1,9 +1,12 @@
 #include "lyra/lowering/ast_to_hir/constant_value.hpp"
 
+#include <cstddef>
+#include <string>
 #include <utility>
 #include <variant>
 #include <vector>
 
+#include "lyra/base/overloaded.hpp"
 #include "lyra/diag/diag_code.hpp"
 #include "lyra/hir/primary.hpp"
 #include "lyra/hir/type.hpp"
@@ -13,77 +16,108 @@ namespace lyra::lowering::ast_to_hir {
 
 namespace {
 
-// An unpacked array constant folds element-by-element into an
-// AssignmentPatternExpr, the same shape a written `'{...}` pattern lowers to,
-// so the downstream array-construction path is shared. Every element shares the
-// array's element type and recurses, so an array of arrays folds the same way.
-auto MakeUnpackedConstantExpr(
+// Materialize a folded constant value as its HIR expression form: a scalar leaf
+// becomes a literal; an unpacked aggregate becomes an AssignmentPatternExpr
+// (the shape a written `'{...}` pattern lowers to) over recursively
+// materialized components, with the type giving each component's type -- a
+// struct's field i, an array's shared element. This is the value's realization
+// in an expression context; the value itself is folded once, at the sole
+// boundary that reads slang's constant representation.
+auto MaterializeConstantExpr(
     const hir::ModuleUnit& unit, WalkFrame frame,
-    const slang::ConstantValue& cv, hir::TypeId type, diag::SourceSpan span)
+    const hir::ConstantValue& value, hir::TypeId type, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  const auto& ty = unit.types.Get(type);
-  const auto* arr = std::get_if<hir::UnpackedArrayType>(&ty.data);
-  if (arr == nullptr) {
-    return diag::Fail(
-        span, diag::DiagCode::kUnsupportedExpressionForm,
-        "constant of aggregate type is not yet supported");
-  }
-  const auto elements = cv.elements();
-  std::vector<hir::ExprId> element_ids;
-  element_ids.reserve(elements.size());
-  for (const auto& elem_cv : elements) {
-    auto elem =
-        MakeConstantValueExpr(unit, frame, elem_cv, arr->element_type, span);
-    if (!elem) return std::unexpected(std::move(elem.error()));
-    element_ids.push_back(frame.Exprs().Add(*std::move(elem)));
-  }
-  return hir::Expr{
-      .type = type,
-      .data = hir::AssignmentPatternExpr{.elements = std::move(element_ids)},
-      .span = span,
-  };
+  return std::visit(
+      Overloaded{
+          [&](const hir::IntegralConstant& integral)
+              -> diag::Result<hir::Expr> {
+            return MakeIntegerLiteralFromConstant(integral, type, span);
+          },
+          [&](double real) -> diag::Result<hir::Expr> {
+            return hir::Expr{
+                .type = type,
+                .data =
+                    hir::PrimaryExpr{.data = hir::RealLiteral{.value = real}},
+                .span = span};
+          },
+          [&](const std::string& text) -> diag::Result<hir::Expr> {
+            return hir::Expr{
+                .type = type,
+                .data =
+                    hir::PrimaryExpr{.data = hir::StringLiteral{.value = text}},
+                .span = span};
+          },
+          [&](const std::vector<hir::ConstantValue>& components)
+              -> diag::Result<hir::Expr> {
+            const auto& ty = unit.types.Get(type);
+            const auto* arr = std::get_if<hir::UnpackedArrayType>(&ty.data);
+            const auto* st = std::get_if<hir::UnpackedStructType>(&ty.data);
+            if (arr == nullptr && st == nullptr) {
+              return diag::Fail(
+                  span, diag::DiagCode::kUnsupportedExpressionForm,
+                  "constant of aggregate type is not yet supported");
+            }
+            std::vector<hir::ExprId> element_ids;
+            element_ids.reserve(components.size());
+            for (std::size_t i = 0; i < components.size(); ++i) {
+              const hir::TypeId component_type =
+                  arr != nullptr ? arr->element_type : st->fields[i].type;
+              auto element = MaterializeConstantExpr(
+                  unit, frame, components[i], component_type, span);
+              if (!element) return std::unexpected(std::move(element.error()));
+              element_ids.push_back(frame.Exprs().Add(*std::move(element)));
+            }
+            return hir::Expr{
+                .type = type,
+                .data =
+                    hir::AssignmentPatternExpr{
+                        .elements = std::move(element_ids)},
+                .span = span};
+          },
+      },
+      value.data);
 }
 
 }  // namespace
+
+auto MakeConstantValue(const slang::ConstantValue& cv, diag::SourceSpan span)
+    -> diag::Result<hir::ConstantValue> {
+  if (cv.isInteger()) {
+    return hir::ConstantValue{
+        .data = LowerSVIntToIntegralConstant(cv.integer())};
+  }
+  if (cv.isReal()) {
+    return hir::ConstantValue{.data = cv.real()};
+  }
+  if (cv.isShortReal()) {
+    return hir::ConstantValue{.data = static_cast<double>(cv.shortReal())};
+  }
+  if (cv.isString()) {
+    return hir::ConstantValue{.data = cv.str()};
+  }
+  if (cv.isUnpacked()) {
+    std::vector<hir::ConstantValue> components;
+    const auto elements = cv.elements();
+    components.reserve(elements.size());
+    for (const auto& element : elements) {
+      auto component = MakeConstantValue(element, span);
+      if (!component) return std::unexpected(std::move(component.error()));
+      components.push_back(*std::move(component));
+    }
+    return hir::ConstantValue{.data = std::move(components)};
+  }
+  return diag::Fail(
+      span, diag::DiagCode::kUnsupportedExpressionForm,
+      "constant of this type is not yet supported");
+}
 
 auto MakeConstantValueExpr(
     const hir::ModuleUnit& unit, WalkFrame frame,
     const slang::ConstantValue& cv, hir::TypeId type, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  if (cv.isInteger()) {
-    return MakeIntegralLiteralExpr(cv.integer(), type, span);
-  }
-  if (cv.isReal()) {
-    return hir::Expr{
-        .type = type,
-        .data = hir::PrimaryExpr{.data = hir::RealLiteral{.value = cv.real()}},
-        .span = span,
-    };
-  }
-  if (cv.isShortReal()) {
-    return hir::Expr{
-        .type = type,
-        .data =
-            hir::PrimaryExpr{
-                .data =
-                    hir::RealLiteral{
-                        .value = static_cast<double>(cv.shortReal())}},
-        .span = span,
-    };
-  }
-  if (cv.isString()) {
-    return hir::Expr{
-        .type = type,
-        .data = hir::PrimaryExpr{.data = hir::StringLiteral{.value = cv.str()}},
-        .span = span,
-    };
-  }
-  if (cv.isUnpacked()) {
-    return MakeUnpackedConstantExpr(unit, frame, cv, type, span);
-  }
-  return diag::Fail(
-      span, diag::DiagCode::kUnsupportedExpressionForm,
-      "constant of aggregate type is not yet supported");
+  auto value = MakeConstantValue(cv, span);
+  if (!value) return std::unexpected(std::move(value.error()));
+  return MaterializeConstantExpr(unit, frame, *value, type, span);
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/integral_constant.cpp
+++ b/src/lyra/lowering/ast_to_hir/integral_constant.cpp
@@ -72,8 +72,8 @@ auto LowerSVIntToIntegralConstant(const slang::SVInt& sv)
   return out;
 }
 
-auto MakeIntegralLiteralExpr(
-    const slang::SVInt& sv, hir::TypeId type, diag::SourceSpan span)
+auto MakeIntegerLiteralFromConstant(
+    hir::IntegralConstant value, hir::TypeId type, diag::SourceSpan span)
     -> hir::Expr {
   return hir::Expr{
       .type = type,
@@ -81,12 +81,19 @@ auto MakeIntegralLiteralExpr(
           hir::PrimaryExpr{
               .data =
                   hir::IntegerLiteral{
-                      .value = LowerSVIntToIntegralConstant(sv),
+                      .value = std::move(value),
                       .base = hir::IntegerLiteralBase::kDecimal,
                       .declared_unsized = false,
                   }},
       .span = span,
   };
+}
+
+auto MakeIntegralLiteralExpr(
+    const slang::SVInt& sv, hir::TypeId type, diag::SourceSpan span)
+    -> hir::Expr {
+  return MakeIntegerLiteralFromConstant(
+      LowerSVIntToIntegralConstant(sv), type, span);
 }
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -7,6 +7,8 @@
 #include <utility>
 #include <vector>
 
+#include <slang/ast/EvalContext.h>
+#include <slang/ast/Expression.h>
 #include <slang/ast/Symbol.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/AllTypes.h>
@@ -18,6 +20,7 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/integral_constant.hpp"
+#include "lyra/lowering/ast_to_hir/constant_value.hpp"
 #include "lyra/lowering/ast_to_hir/integral_constant.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 
@@ -204,6 +207,28 @@ auto LowerPackedUnion(
   };
 }
 
+// LRM 7.2.2: a member declaration may carry a constant default value, used in
+// place of the member type's Table 7-1 default when the enclosing struct is
+// default-constructed. Slang has bound and constant-checked it; evaluate it and
+// fold it into the member's value-form metadata, the same shape an enum member
+// carries its value -- the default is a value the type holds, not an
+// expression.
+auto LowerMemberDefault(
+    const slang::ast::FieldSymbol& field, diag::SourceSpan span)
+    -> diag::Result<std::optional<hir::ConstantValue>> {
+  const auto* init = field.getInitializer();
+  if (init == nullptr) {
+    return std::optional<hir::ConstantValue>{};
+  }
+  slang::ast::EvalContext eval_context(field);
+  const slang::ConstantValue constant = init->eval(eval_context);
+  auto value_or = MakeConstantValue(constant, span);
+  if (!value_or) {
+    return std::unexpected(std::move(value_or.error()));
+  }
+  return std::optional<hir::ConstantValue>{*std::move(value_or)};
+}
+
 auto LowerUnpackedAggregateFields(
     std::span<const slang::ast::FieldSymbol* const> fields,
     diag::SourceSpan decl_span, ModuleLowerer& module)
@@ -215,10 +240,15 @@ auto LowerUnpackedAggregateFields(
     if (!field_type_or) {
       return std::unexpected(std::move(field_type_or.error()));
     }
+    auto default_or = LowerMemberDefault(*field, decl_span);
+    if (!default_or) {
+      return std::unexpected(std::move(default_or.error()));
+    }
     out.push_back(
         hir::UnpackedAggregateField{
             .name = std::string(field->name),
             .type = *field_type_or,
+            .default_init = *std::move(default_or),
         });
   }
   return out;

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -1561,7 +1561,7 @@ auto ClassLowerer::Run(
         value_id = initialize_block.exprs.Add(*std::move(value_or));
       } else {
         value_id = initialize_block.exprs.Add(
-            BuildDefaultValueExpr(module, init_frame, mir_value_type));
+            BuildDefaultValueFromHir(module, init_frame, d.type));
       }
       const mir::ExprId init_target = initialize_block.exprs.Add(
           mir::MakeMemberAccessExpr(

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -2,12 +2,15 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <string>
 #include <utility>
 #include <variant>
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
+#include "lyra/hir/type.hpp"
+#include "lyra/lowering/hir_to_mir/expression/references.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/integral_constant.hpp"
@@ -46,6 +49,96 @@ auto DefaultIntegralConstant(const mir::PackedArrayType& pa)
     c.state_words.back() &= mask;
   }
   return c;
+}
+
+// Wrap element exprs into an unpacked-array construction: the element type's
+// default prototype (honoring its own member inits) plus the element list.
+// Shared by the type-default array path and the explicit-constant array path.
+auto BuildUnpackedArrayValue(
+    const ModuleLowerer& module, WalkFrame frame, mir::TypeId array_type,
+    hir::TypeId element_type, std::vector<mir::ExprId> element_ids)
+    -> mir::Expr {
+  auto& block = *frame.current_block;
+  const mir::ExprId element_default =
+      block.exprs.Add(BuildDefaultValueFromHir(module, frame, element_type));
+  const mir::ExprId list_id = block.exprs.Add(
+      mir::Expr{
+          .data = mir::ArrayLiteralExpr{.elements = std::move(element_ids)},
+          .type = array_type});
+  return mir::Expr{
+      .data =
+          mir::CallExpr{
+              .callee = mir::Construct{},
+              .arguments = {element_default, list_id}},
+      .type = array_type};
+}
+
+// Materialize a folded member-default constant (LRM 7.2.2) as a MIR value of
+// its type. A scalar leaf becomes a literal (a string constructs the runtime
+// String); an unpacked aggregate becomes a TupleExpr (struct) or an array
+// construction (array) over the recursively materialized components, with the
+// type disambiguating a component list as struct members or array elements.
+auto MaterializeConstant(
+    const ModuleLowerer& module, WalkFrame frame, hir::TypeId hir_type,
+    const hir::ConstantValue& value) -> mir::Expr {
+  auto& block = *frame.current_block;
+  const mir::TypeId mir_type = module.TranslateType(hir_type);
+  return std::visit(
+      Overloaded{
+          [&](const hir::IntegralConstant& c) -> mir::Expr {
+            return mir::Expr{
+                .data =
+                    mir::IntegerLiteral{.value = LowerHirIntegralConstant(c)},
+                .type = mir_type};
+          },
+          [&](double real) -> mir::Expr {
+            return mir::Expr{
+                .data = mir::RealLiteral{.value = real}, .type = mir_type};
+          },
+          [&](const std::string& text) -> mir::Expr {
+            const mir::ExprId literal = block.exprs.Add(
+                mir::Expr{
+                    .data = mir::StringLiteral{.value = text},
+                    .type = mir_type});
+            return mir::Expr{
+                .data =
+                    mir::CallExpr{
+                        .callee = mir::Construct{}, .arguments = {literal}},
+                .type = mir_type};
+          },
+          [&](const std::vector<hir::ConstantValue>& components) -> mir::Expr {
+            const auto& hir_ty = module.Hir().types.Get(hir_type);
+            if (const auto* st =
+                    std::get_if<hir::UnpackedStructType>(&hir_ty.data)) {
+              std::vector<mir::ExprId> component_ids;
+              component_ids.reserve(components.size());
+              for (std::size_t i = 0; i < components.size(); ++i) {
+                component_ids.push_back(block.exprs.Add(MaterializeConstant(
+                    module, frame, st->fields[i].type, components[i])));
+              }
+              return mir::Expr{
+                  .data =
+                      mir::TupleExpr{.components = std::move(component_ids)},
+                  .type = mir_type};
+            }
+            if (const auto* ua =
+                    std::get_if<hir::UnpackedArrayType>(&hir_ty.data)) {
+              std::vector<mir::ExprId> element_ids;
+              element_ids.reserve(components.size());
+              for (const auto& component : components) {
+                element_ids.push_back(block.exprs.Add(MaterializeConstant(
+                    module, frame, ua->element_type, component)));
+              }
+              return BuildUnpackedArrayValue(
+                  module, frame, mir_type, ua->element_type,
+                  std::move(element_ids));
+            }
+            throw InternalError(
+                "MaterializeConstant: aggregate value for a non-aggregate "
+                "type");
+          },
+      },
+      value.data);
 }
 
 }  // namespace
@@ -206,6 +299,54 @@ auto BuildDefaultValueExpr(
           },
       },
       ty.data);
+}
+
+// LRM 7.2.2 / Table 7-1: default-construct a value from its source (HIR) type
+// so member declaration initializers are honored. An unpacked struct takes each
+// member's own default (its declaration initializer, else the member type's
+// recursive default); a fixed unpacked array fills every element with the
+// element type's source default. Every other type carries no source-level
+// initializer, so its default is the canonical type default.
+auto BuildDefaultValueFromHir(
+    const ModuleLowerer& module, WalkFrame frame, hir::TypeId hir_type)
+    -> mir::Expr {
+  auto& block = *frame.current_block;
+  const auto& hir_ty = module.Hir().types.Get(hir_type);
+  const mir::TypeId mir_type = module.TranslateType(hir_type);
+
+  if (const auto* st = std::get_if<hir::UnpackedStructType>(&hir_ty.data)) {
+    std::vector<mir::ExprId> components;
+    components.reserve(st->fields.size());
+    for (const auto& field : st->fields) {
+      const mir::ExprId component =
+          field.default_init.has_value()
+              ? block.exprs.Add(MaterializeConstant(
+                    module, frame, field.type, *field.default_init))
+              : block.exprs.Add(
+                    BuildDefaultValueFromHir(module, frame, field.type));
+      components.push_back(component);
+    }
+    return mir::Expr{
+        .data = mir::TupleExpr{.components = std::move(components)},
+        .type = mir_type};
+  }
+
+  if (const auto* ua = std::get_if<hir::UnpackedArrayType>(&hir_ty.data)) {
+    const std::int64_t span = (ua->dim.left >= ua->dim.right)
+                                  ? (ua->dim.left - ua->dim.right)
+                                  : (ua->dim.right - ua->dim.left);
+    const auto size = static_cast<std::uint64_t>(span) + 1U;
+    std::vector<mir::ExprId> elements;
+    elements.reserve(size);
+    for (std::uint64_t i = 0; i < size; ++i) {
+      elements.push_back(block.exprs.Add(
+          BuildDefaultValueFromHir(module, frame, ua->element_type)));
+    }
+    return BuildUnpackedArrayValue(
+        module, frame, mir_type, ua->element_type, std::move(elements));
+  }
+
+  return BuildDefaultValueExpr(module, frame, mir_type);
 }
 
 auto BuildArrayConstructionCall(

--- a/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
@@ -10,6 +10,7 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/hir/expr.hpp"
+#include "lyra/hir/type.hpp"
 #include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
@@ -96,11 +97,15 @@ auto LowerHirReplicationExpr(
       .type = result_type};
 }
 
-// Lowers an HIR AssignmentPatternExpr by dispatching on the destination
-// type's runtime shape: packed targets fold into MIR `ConcatExpr` (bit
-// concatenation matches the packed bit plane), array containers (unpacked,
-// dynamic, queue) land as `ArrayLiteralExpr` over distinct element slots
-// wrapped by a construction call against the container ctor.
+// Lowers an HIR AssignmentPatternExpr by dispatching on the destination type's
+// runtime shape. Slang has already resolved any named / type-key / `default`
+// keys into a member-ordered positional element list (LRM 10.9.2), so the
+// shapes differ only in how they package those positional elements: a packed
+// target folds into a MIR `ConcatExpr` because its members share one bit plane,
+// an array container (unpacked, dynamic, queue) lands as `ArrayLiteralExpr`
+// slots wrapped by a construction call, and an unpacked struct -- whose members
+// are independent value slots, not a shared bit plane -- folds into a
+// positional `TupleExpr`.
 template <ExprLowerer Lowerer>
 auto LowerHirAssignmentPatternExpr(
     Lowerer& lowerer, WalkFrame frame, const hir::AssignmentPatternExpr& a,
@@ -113,9 +118,15 @@ auto LowerHirAssignmentPatternExpr(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     element_ids.push_back(block.exprs.Add(*std::move(lowered)));
   }
-  if (IsArrayContainerType(lowerer.Module().Unit().types.Get(result_type))) {
+  const auto& result_ty = lowerer.Module().Unit().types.Get(result_type);
+  if (IsArrayContainerType(result_ty)) {
     return BuildArrayConstructionCall(
         lowerer.Module(), frame, result_type, std::move(element_ids));
+  }
+  if (std::holds_alternative<mir::TupleType>(result_ty.data)) {
+    return mir::Expr{
+        .data = mir::TupleExpr{.components = std::move(element_ids)},
+        .type = result_type};
   }
   return mir::Expr{
       .data = mir::ConcatExpr{.operands = std::move(element_ids)},
@@ -135,11 +146,24 @@ auto LowerHirAssignmentPatternReplicationExpr(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     item_ids.push_back(block.exprs.Add(*std::move(lowered)));
   }
-  if (IsArrayContainerType(lowerer.Module().Unit().types.Get(result_type))) {
+  const auto& result_ty = lowerer.Module().Unit().types.Get(result_type);
+  if (IsArrayContainerType(result_ty)) {
     const std::uint64_t count =
         ExtractHirLiteralUint64(lowerer.HirExprs().Get(a.count));
     return BuildArrayReplicationFlatList(
         lowerer.Module(), frame, item_ids, count, result_type);
+  }
+  if (std::holds_alternative<mir::TupleType>(result_ty.data)) {
+    const std::uint64_t count =
+        ExtractHirLiteralUint64(lowerer.HirExprs().Get(a.count));
+    std::vector<mir::ExprId> components;
+    components.reserve(item_ids.size() * count);
+    for (std::uint64_t i = 0; i < count; ++i) {
+      components.insert(components.end(), item_ids.begin(), item_ids.end());
+    }
+    return mir::Expr{
+        .data = mir::TupleExpr{.components = std::move(components)},
+        .type = result_type};
   }
   const mir::ExprId inner_concat_id = block.exprs.Add(
       mir::Expr{
@@ -159,26 +183,28 @@ auto LowerHirAssignmentPatternReplicationExpr(
 
 // LRM 7.5.1 `new[N]` / `new[N](other)`. The argument list on the lowered
 // construction call is `[size, element-default prototype, optional copy
-// source]`: the prototype carries the element type's LRM Table 6-7 default
-// so the runtime ctor populates new slots without re-querying the type, and
-// the optional copy source feeds the LRM 7.5.1 truncate / pad behaviour on
+// source]`: the prototype carries the element type's default value -- a
+// struct element's own member initializers included (LRM 7.2.2) -- so the
+// runtime ctor populates new slots without re-querying the type, and the
+// optional copy source feeds the LRM 7.5.1 truncate / pad behaviour on
 // `new[N](other)`.
 auto LowerHirDynamicArrayNewExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::DynamicArrayNewExpr& n,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+    hir::TypeId hir_result_type, mir::TypeId result_type)
+    -> diag::Result<mir::Expr> {
   auto& block = *frame.current_block;
   auto size_or = process.LowerExpr(process.HirExprs().Get(n.size), frame);
   if (!size_or) return std::unexpected(std::move(size_or.error()));
   const mir::ExprId size_id = block.exprs.Add(*std::move(size_or));
 
-  const auto& result_ty = process.Module().Unit().types.Get(result_type);
-  const auto* da = std::get_if<mir::DynamicArrayType>(&result_ty.data);
-  if (da == nullptr) {
+  const auto& hir_result_ty = process.Module().Hir().types.Get(hir_result_type);
+  const auto* hir_da = std::get_if<hir::DynamicArrayType>(&hir_result_ty.data);
+  if (hir_da == nullptr) {
     throw InternalError(
         "LowerHirDynamicArrayNewExprProc: result type is not DynamicArrayType");
   }
   const mir::ExprId prototype_id = block.exprs.Add(
-      BuildDefaultValueExpr(process.Module(), frame, da->element_type));
+      BuildDefaultValueFromHir(process.Module(), frame, hir_da->element_type));
 
   std::vector<mir::ExprId> args;
   args.reserve(n.initializer.has_value() ? 3U : 2U);

--- a/src/lyra/lowering/hir_to_mir/expression/dispatch.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/dispatch.cpp
@@ -116,7 +116,7 @@ auto LowerExprImpl(L& lowerer, const hir::Expr& expr, WalkFrame frame)
           [&](const hir::DynamicArrayNewExpr& n) -> diag::Result<mir::Expr> {
             if constexpr (kProcedural) {
               return LowerHirDynamicArrayNewExprProc(
-                  lowerer, frame, n, result_type);
+                  lowerer, frame, n, expr.type, result_type);
             } else {
               throw InternalError(
                   "structural expression lowering: HIR DynamicArrayNewExpr is "

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -65,17 +65,6 @@ auto LowerStateKind(hir::IntegralStateKind k) -> mir::IntegralStateKind {
   throw InternalError("LowerStateKind: unknown HIR IntegralStateKind");
 }
 
-auto LowerHirIntegralConstant(const hir::IntegralConstant& c)
-    -> mir::IntegralConstant {
-  return mir::IntegralConstant{
-      .value_words = c.value_words,
-      .state_words = c.state_words,
-      .width = c.width,
-      .signedness = LowerSignedness(c.signedness),
-      .state_kind = LowerStateKind(c.state_kind),
-  };
-}
-
 auto LowerHirIntegerLiteral(const hir::IntegerLiteral& i, mir::TypeId type)
     -> mir::Expr {
   return mir::Expr{
@@ -268,6 +257,17 @@ auto LowerIterationBindingRefExpr(
 }
 
 }  // namespace
+
+auto LowerHirIntegralConstant(const hir::IntegralConstant& c)
+    -> mir::IntegralConstant {
+  return mir::IntegralConstant{
+      .value_words = c.value_words,
+      .state_words = c.state_words,
+      .width = c.width,
+      .signedness = LowerSignedness(c.signedness),
+      .state_kind = LowerStateKind(c.state_kind),
+  };
+}
 
 auto LowerHirPrimaryExprProc(
     ProcessLowerer& process, WalkFrame frame, const hir::Primary& p,

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -226,7 +226,7 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
 
     if (dir == hir::ParamDirection::kOutput) {
       const mir::ExprId default_init = body_block.exprs.Add(
-          BuildDefaultValueExpr(*module_, body_frame, value_type));
+          BuildDefaultValueFromHir(*module_, body_frame, hir_var.type));
       const mir::LocalRef local = body_block.AppendLocal(
           mir::LocalDecl{.name = hir_var.name, .type = value_type},
           default_init);
@@ -274,7 +274,7 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
   if (src.result_var.has_value()) {
     const mir::TypeId ret_type = module_->TranslateType(src.result_type);
     const mir::ExprId default_init = body_block.exprs.Add(
-        BuildDefaultValueExpr(*module_, body_frame, ret_type));
+        BuildDefaultValueFromHir(*module_, body_frame, src.result_type));
     const mir::LocalRef result_ref = body_block.AppendLocal(
         mir::LocalDecl{.name = "_lyra_result", .type = ret_type}, default_init);
     MapProceduralVar(

--- a/src/lyra/lowering/hir_to_mir/statement/flow.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/flow.cpp
@@ -57,7 +57,7 @@ auto LowerStaticVarDeclStmt(
     init_value = ctor_block.exprs.Add(*std::move(init_or));
   } else {
     init_value = ctor_block.exprs.Add(
-        BuildDefaultValueExpr(process.Module(), ctor_frame, type));
+        BuildDefaultValueFromHir(process.Module(), ctor_frame, hir_local.type));
   }
 
   const mir::ExprId ctor_self_read =
@@ -100,8 +100,8 @@ auto LowerAutomaticVarDeclStmt(
     if (!init_or) return std::unexpected(std::move(init_or.error()));
     init_value = block.exprs.Add(*std::move(init_or));
   } else {
-    init_value =
-        block.exprs.Add(BuildDefaultValueExpr(process.Module(), frame, type));
+    init_value = block.exprs.Add(
+        BuildDefaultValueFromHir(process.Module(), frame, hir_local.type));
   }
 
   return mir::Stmt{
@@ -120,7 +120,8 @@ auto LowerAutomaticVarDeclStmt(
 // HIR id order, to register the binding its references resolve through.
 auto LowerPromotedVarDeclStmt(
     ProcessLowerer& process, WalkFrame frame, std::optional<std::string> label,
-    const hir::VarDeclStmt& v, mir::TypeId type) -> diag::Result<mir::Stmt> {
+    const hir::VarDeclStmt& v, hir::TypeId hir_type, mir::TypeId type)
+    -> diag::Result<mir::Stmt> {
   const PromotedVarBinding pb = process.TakePendingActivation(v.var);
   process.MapProceduralVar(v.var, pb);
   auto& block = *frame.current_block;
@@ -137,8 +138,8 @@ auto LowerPromotedVarDeclStmt(
     if (!init_or) return std::unexpected(std::move(init_or.error()));
     init_value = block.exprs.Add(*std::move(init_or));
   } else {
-    init_value =
-        block.exprs.Add(BuildDefaultValueExpr(process.Module(), frame, type));
+    init_value = block.exprs.Add(
+        BuildDefaultValueFromHir(process.Module(), frame, hir_type));
   }
   const mir::ExprId assign =
       block.exprs.Add(mir::MakeAssignExpr(target, init_value, type));
@@ -154,7 +155,8 @@ auto LowerVarDeclStmt(
   const auto& hir_local = process.HirBody().procedural_vars.Get(v.var);
   const mir::TypeId type = process.Module().TranslateType(hir_local.type);
   if (hir_local.lifetime_extended) {
-    return LowerPromotedVarDeclStmt(process, frame, std::move(label), v, type);
+    return LowerPromotedVarDeclStmt(
+        process, frame, std::move(label), v, hir_local.type, type);
   }
   if (hir_local.lifetime == hir::VariableLifetime::kStatic) {
     return LowerStaticVarDeclStmt(

--- a/src/lyra/lowering/hir_to_mir/statement/loops.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/loops.cpp
@@ -55,8 +55,8 @@ auto LowerForStmt(
                 }
                 init_id = block.exprs.Add(*std::move(init_or));
               } else {
-                init_id = block.exprs.Add(
-                    BuildDefaultValueExpr(process.Module(), frame, type));
+                init_id = block.exprs.Add(BuildDefaultValueFromHir(
+                    process.Module(), frame, hir_local.type));
               }
               return mir::ForInit{mir::ForInitDecl{
                   .induction_var =

--- a/tests/cases/cpp/unpacked_struct_default_init/case.yaml
+++ b/tests/cases/cpp/unpacked_struct_default_init/case.yaml
@@ -1,0 +1,25 @@
+id: cpp.unpacked_struct_default_init
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    d_a: 42
+    d_b: 0
+    d_g: 12
+    d_nx: 0
+    d_ny: 5
+    e_a: 1
+    e_ny: 8
+    arr_a: 42
+    arr_ny: 5
+    loc_a: 42
+    loc_ny: 5
+    ad_nx: 11
+    ad_ny: 12
+    ad_a0: 20
+    ad_a1: 21

--- a/tests/cases/cpp/unpacked_struct_default_init/main.sv
+++ b/tests/cases/cpp/unpacked_struct_default_init/main.sv
@@ -1,0 +1,65 @@
+module Top;
+  typedef struct {
+    int  x;
+    byte y = 8'd5;
+  } inner_t;
+
+  typedef struct {
+    int         a = 42;
+    byte        b;
+    logic [3:0] g = 4'hC;
+    inner_t     nested;
+  } pair_t;
+
+  // A member whose own declared default is itself an aggregate literal: a
+  // struct-typed member and an array-typed member (LRM 7.2.2). The explicit
+  // member default overrides the member type's own recursive default.
+  typedef struct {
+    inner_t agg_n = '{x: 11, y: 8'd12};
+    int     agg_arr[2] = '{20, 21};
+  } aggdef_t;
+
+  pair_t s;
+  pair_t s2 = '{a: 1, b: 8'd2, g: 4'h3, nested: '{x: 7, y: 8'd8}};
+  pair_t arr[2];
+  aggdef_t ad;
+
+  int d_a;
+  int d_b;
+  int d_g;
+  int d_nx;
+  int d_ny;
+  int e_a;
+  int e_ny;
+  int arr_a;
+  int arr_ny;
+  int loc_a;
+  int loc_ny;
+  int ad_nx;
+  int ad_ny;
+  int ad_a0;
+  int ad_a1;
+
+  initial begin
+    pair_t loc;
+    loc_a = loc.a;
+    loc_ny = loc.nested.y;
+
+    d_a = s.a;
+    d_b = s.b;
+    d_g = s.g;
+    d_nx = s.nested.x;
+    d_ny = s.nested.y;
+
+    e_a = s2.a;
+    e_ny = s2.nested.y;
+
+    arr_a = arr[1].a;
+    arr_ny = arr[0].nested.y;
+
+    ad_nx = ad.agg_n.x;
+    ad_ny = ad.agg_n.y;
+    ad_a0 = ad.agg_arr[0];
+    ad_a1 = ad.agg_arr[1];
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_struct_param/case.yaml
+++ b/tests/cases/cpp/unpacked_struct_param/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.unpacked_struct_param
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    p_a: 5
+    p_b: 6
+    q_ia: 7
+    q_ib: 8
+    q_tag: 9

--- a/tests/cases/cpp/unpacked_struct_param/main.sv
+++ b/tests/cases/cpp/unpacked_struct_param/main.sv
@@ -1,0 +1,30 @@
+module Top;
+  typedef struct {
+    int a;
+    byte b;
+  } pair_t;
+
+  typedef struct {
+    pair_t inner;
+    int    tag;
+  } nest_t;
+
+  // A struct-typed parameter folds its constant value into a struct literal
+  // (LRM 6.20). Reading a member substitutes the folded component.
+  parameter pair_t P = '{a: 5, b: 8'd6};
+  parameter nest_t Q = '{inner: '{a: 7, b: 8'd8}, tag: 9};
+
+  int p_a;
+  int p_b;
+  int q_ia;
+  int q_ib;
+  int q_tag;
+
+  initial begin
+    p_a = P.a;
+    p_b = P.b;
+    q_ia = Q.inner.a;
+    q_ib = Q.inner.b;
+    q_tag = Q.tag;
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_struct_pattern/case.yaml
+++ b/tests/cases/cpp/unpacked_struct_pattern/case.yaml
@@ -1,0 +1,32 @@
+id: cpp.unpacked_struct_pattern
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    pos_a: 1
+    pos_b: 2
+    pos_c: 3
+    nm_a: 10
+    nm_b: 20
+    nm_c: 30
+    tk_a: 7
+    tk_b: 8
+    tk_c: 7
+    df_a: 5
+    df_b: 5
+    df_c: 5
+    ns_ia: 100
+    ns_ib: 101
+    ns_ic: 102
+    ns_tag: 9
+    rp_a: 7
+    rp_b: 7
+    pw_ia: 55
+    pw_tag: 1
+    eq_same: 1
+    eq_diff: 0

--- a/tests/cases/cpp/unpacked_struct_pattern/main.sv
+++ b/tests/cases/cpp/unpacked_struct_pattern/main.sv
@@ -1,0 +1,90 @@
+module Top;
+  typedef struct {
+    int  a;
+    byte b;
+    int  c;
+  } tri_t;
+
+  typedef struct {
+    tri_t inner;
+    int   tag;
+  } nest_t;
+
+  typedef struct {
+    int a;
+    int b;
+  } dup_t;
+
+  tri_t  pos;
+  tri_t  nm;
+  tri_t  tk;
+  tri_t  df;
+  nest_t ns;
+  dup_t  rp;
+  nest_t pw;
+  tri_t  cmp;
+
+  int pos_a;
+  int pos_b;
+  int pos_c;
+  int nm_a;
+  int nm_b;
+  int nm_c;
+  int tk_a;
+  int tk_b;
+  int tk_c;
+  int df_a;
+  int df_b;
+  int df_c;
+  int ns_ia;
+  int ns_ib;
+  int ns_ic;
+  int ns_tag;
+  int rp_a;
+  int rp_b;
+  int pw_ia;
+  int pw_tag;
+  int eq_same;
+  int eq_diff;
+
+  initial begin
+    pos = '{1, 8'd2, 3};
+    pos_a = pos.a;
+    pos_b = pos.b;
+    pos_c = pos.c;
+
+    nm = '{c: 30, a: 10, b: 8'd20};
+    nm_a = nm.a;
+    nm_b = nm.b;
+    nm_c = nm.c;
+
+    tk = '{int: 7, byte: 8'd8};
+    tk_a = tk.a;
+    tk_b = tk.b;
+    tk_c = tk.c;
+
+    df = '{default: 5};
+    df_a = df.a;
+    df_b = df.b;
+    df_c = df.c;
+
+    ns = '{inner: '{a: 100, b: 8'd101, c: 102}, tag: 9};
+    ns_ia = ns.inner.a;
+    ns_ib = ns.inner.b;
+    ns_ic = ns.inner.c;
+    ns_tag = ns.tag;
+
+    rp = '{2{7}};
+    rp_a = rp.a;
+    rp_b = rp.b;
+
+    pw.tag = 1;
+    pw.inner = '{a: 55, b: 8'd0, c: 0};
+    pw_ia = pw.inner.a;
+    pw_tag = pw.tag;
+
+    cmp = '{1, 8'd2, 3};
+    eq_same = (cmp == tri_t'{1, 8'd2, 3});
+    eq_diff = (cmp == tri_t'{9, 8'd2, 3});
+  end
+endmodule


### PR DESCRIPTION
## Summary

Builds out two facets of unpacked-struct support on top of the existing `TupleType` representation: assignment-pattern literals (LRM 10.9) and default initialization with member declaration initializers (LRM 7.2.2). An unpacked struct can now be constructed in one expression and a declared struct receives the correct member-wise initial value.

Assignment patterns lower to a `TupleExpr`. Slang resolves every keyed form (positional, named in any order, type-key, `default:` fill, and the type-prefixed `T'{...}`) into a member-ordered element list before HIR, so all forms reduce to one new dispatch branch in the assignment-pattern lowering; the replication form gets the symmetric branch so no path is left crashing on a tuple target.

Default initialization honors a member's own declaration initializer over the member type's Table 7-1 default, recursively through nested struct members and fixed-array elements, with the 2-state / 4-state distinction preserved per member. Because the canonicalized MIR `TupleType` deliberately drops member initializers, the default is synthesized from the source HIR type at HIR-to-MIR: a dedicated builder reads each field's folded initializer (or recurses for the type default) and emits a `TupleExpr`. The folded member default is carried into HIR as a constant-literal expression through the same path a parameter or enum value takes, and it is lowered back to MIR through the shared literal-lowering machinery, so no parallel constant-dispatch or rejection path is introduced. A member whose own default is an aggregate literal is not yet representable and is rejected with a clear diagnostic.

## Testing

Two grouped run tests cover the surface: `unpacked_struct_pattern` (positional, named out-of-order, type-key, `default:`, nested, replication, `T'{...}` in an expression context) and `unpacked_struct_default_init` (scalar and 4-state member defaults, nested recursion, explicit-initializer suppression, fixed array-of-struct, and a process-local). Full `bazel test //...` passes.
