### PR TITLE
Canonicalize MIR types through a type interner

### DIFF
--- a/docs/architecture/emission_model.md
+++ b/docs/architecture/emission_model.md
@@ -128,8 +128,6 @@ Construction state for the extern member (the canonical head identity, the desce
 signal name) arrives as ordinary MIR primitives in the constructor body, not as type payload --
 `backend_contract.md` keeps render mechanical.
 
-The current C++ backend collapses all units into a single translation unit (one `main.cpp` that
-transitively includes every unit header, with bodies inline). That is a transitional convenience of
-the C++ build step, not a relaxation of invariant 1: any artifact that aggregates multiple units'
-bodies is still wrong and is marked for removal. The per-unit artifact boundary and the resolution
-rules above are the contract the LLVM backend must satisfy and the C++ backend must converge to.
+Any artifact that aggregates multiple units' bodies into one is forbidden, however a build step
+packages the emitted sources: the per-unit artifact boundary and the resolution rules above are the
+contract every backend must satisfy.

--- a/docs/architecture/runtime_distribution.md
+++ b/docs/architecture/runtime_distribution.md
@@ -25,13 +25,13 @@ compile, or run paths.
 
 Resolution strategies:
 
-- **Runfiles (current).** When `lyra` is built and run by Bazel -- the development binary and the
-  test suite -- the runtime is staged in the binary's runfiles tree and resolved from there.
-- **Install-relative (release; not yet built).** A released `lyra` is a plain binary with no
-  runfiles. It locates its runtime relative to its own executable path -- the convention clang, gcc,
-  and rustc use for their resource and sysroot directories. A distribution ships the binary
-  alongside its runtime, and the binary finds it from `argv0` / the executable path. This strategy
-  drops into the same resolver; the emit, compile, and run paths are unaffected.
+- **Runfiles (development).** When `lyra` is built and run by Bazel -- the development binary and
+  the test suite -- the runtime is staged in the binary's runfiles tree and resolved from there.
+- **Install-relative (release).** A released `lyra` is a plain binary with no runfiles. It locates
+  its runtime relative to its own executable path -- the convention clang, gcc, and rustc use for
+  their resource and sysroot directories. A distribution ships the binary alongside its runtime, and
+  the binary finds it from `argv0` / the executable path. This strategy drops into the same
+  resolver; the emit, compile, and run paths are unaffected.
 
 Until the install-relative strategy exists, `run`, `emit cpp`, and `compile` work only where
 runfiles are present (the Bazel build tree and the tests). This is a property of how `lyra` locates
@@ -45,7 +45,7 @@ diagnostics do not bleed into them -- warnings are not shown during `run` (use `
 or `compile` to see them), and compile errors are reported and abort before any simulation begins.
 This keeps `run` faithfully pipeable and testable as "the simulation's output".
 
-## Out of scope (for now)
+## Out of scope
 
 - The install layout and packaging of a `lyra` distribution: where the runtime sits relative to the
   installed binary and how the two are packaged together. The resolver above is the single seam

--- a/docs/architecture/runtime_model.md
+++ b/docs/architecture/runtime_model.md
@@ -64,10 +64,9 @@ an upward reference to an ancestor, a `$root`-anchored path (see `reference_reso
 `emission_model.md`).
 
 `elaboration_lifecycle.md` refines this construction-vs-simulation boundary into ordered phases
-(build / resolve / initialize / activate) and is the authority on _when_ each piece runs. It
-supersedes the "downward resolved in the constructor, upward at bind" split described historically
-here: all cross-instance references resolve in one resolve phase after the shell graph is built, and
-variable initializers run in the initialize phase after resolution, not inside the constructor. The
+(build / resolve / initialize / activate) and is the authority on _when_ each piece runs: all
+cross-instance references resolve in one resolve phase after the shell graph is built, and variable
+initializers run in the initialize phase after resolution, not inside the constructor. The
 constructor allocates the shell; it is not the executor of elaboration semantics.
 
 ## Generate is not compile-time expansion

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -92,9 +92,9 @@ earlier, defeating the intent.
 
 ## `$finish`
 
-`$finish` reaches the engine's stop verb, which sets a `finished_` flag; the time-slot loop then
-exits without running further regions in the in-progress slot. Pending NBA writes for that slot do
-not commit; queued active processes do not resume.
+`$finish` reaches the engine's stop verb, which sets a stop flag; the time-slot loop then exits
+without running further regions in the in-progress slot. Pending NBA writes for that slot do not
+commit; queued active processes do not resume.
 
 Registered `final` actions then run in registration order. A `$finish` raised from inside a `final`
 aborts the remaining finals. This three-cornered behavior (active shutdown, NBA discard, final

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -83,6 +83,12 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
 - [event-control-unification](event-control-unification.md) -- unified treatment of event control.
 - [generic-lowering-machinery](generic-lowering-machinery.md) -- generic arena and shared
   context-free expression-handler templates over the pass class; node types stay typed.
+- [arena-reference-lifetime](arena-reference-lifetime.md) -- `Arena::Get` is a transient view; a
+  same-arena `Add` invalidates prior references, and the `Id` is the only durable handle, so
+  lowering projects value facts before mutating; stable-reference storage is rejected.
+- [mir-type-interning](mir-type-interning.md) -- the MIR type pool is a structural-equality
+  interner, not a plain arena: each semantic type has one canonical `TypeId`, object types keyed by
+  class identity (enums by their scope-unique enumerators), enabling recursive class types.
 - [context-free-call-lowering](context-free-call-lowering.md) -- one expression dispatcher template
   per boundary (context-free kinds listed once); the call family becomes a template across pass
   classes once the `with`-clause element / index are co-equal closure parameters rather than a

--- a/docs/decisions/arena-reference-lifetime.md
+++ b/docs/decisions/arena-reference-lifetime.md
@@ -1,0 +1,95 @@
+# Arena reference lifetime: `Get` is a transient view
+
+Date: 2026-06-26 Status: accepted
+
+## Context
+
+`Arena<T, Id>` (the universal append-only pool from
+[generic-lowering-machinery](generic-lowering-machinery.md)) backs its elements in a relocatable
+`std::vector<T>` and exposes `Get(id) -> const T&`. A `Get` reference therefore points into storage
+that a later `Add` can relocate, so holding a `Get` reference across an `Add` to the same arena is a
+dangling reference. Whether it actually faults depends on allocator timing, so the hazard is latent
+until an unrelated change perturbs the growth pattern.
+
+The design question this raises is whether the arena should guarantee reference stability -- backing
+elements in storage that never relocates on append (a deque, a segmented or paged arena) -- so that
+a `Get` reference stays valid across an `Add`.
+
+The decision rests on what lowering actually needs. Every site that held a `Get` reference across a
+same-arena `Add` was inspected. In every case the value still needed past the `Add` was a small,
+projectable fact -- a `TypeId`, a `TypeKind`, an already-copied payload -- never the whole node held
+as a live reference:
+
+- An owned-child construction needed the slot pointer's pointee `TypeId` after interning the child's
+  index-array type.
+- An lvalue rewrite needed the operand's result `TypeId` after a recursive rewrite appended nodes.
+- A structural signal needed the value type's `TypeKind` after interning the field's wrapper type.
+
+No site needed a stable borrow of a whole node across a mutation. The recurring shape is "project a
+fact from an existing node, then intern the sibling or derived nodes the lowering is building" --
+the inspection and the interning are interleaved by narrative order, not by a data dependency on the
+live reference.
+
+## Decision
+
+`Get` is a transient view; the `Id` is the only durable handle.
+
+1. **The arena stays a relocatable `vector`.** Dense contiguous storage, the cheapest `Id -> T`
+   indexing, and good iteration locality are kept. The arena does not promise that a `Get` reference
+   survives an `Add`.
+
+2. **Same-arena mutation invalidates prior `Get` results.** Any `Add` may relocate the backing
+   storage, invalidating every reference, pointer, and iterator a prior `Get` returned to that
+   arena. This contract lives on the `Arena` type.
+
+3. **Lowering projects facts before mutating.** To carry information from a node past an `Add`, a
+   caller projects the value it needs -- an `Id`, a kind, a copied field -- before the `Add`, and
+   uses that value afterward. The currency that flows across lowering steps is ids and value facts,
+   not node references. This is the same id-first model the identity rules already establish; the
+   reference is an implementation-local view, not a unit of data flow.
+
+4. **Value immutability is distinct from address stability.** An appended node's _value_ is final
+   (load-bearing for id references and ownership-keyed caching). Its _address_ is not stable. The
+   arena promises the former and explicitly not the latter.
+
+## Rejected
+
+- **Stable-reference storage (deque / segmented / paged) so `Get` references survive `Add`.** This
+  extends the contract of every arena -- system-wide -- to serve a capability no site requires: the
+  usage evidence shows the value needed past a mutation is always a projectable fact, never a live
+  whole-node borrow. It trades contiguity, locality, and the cheapest indexing on a read-heavy hot
+  path for a guarantee nothing depends on, and over-extends the abstraction from an incidental code
+  shape. Reconsider only if a genuine need for a stable cross-mutation whole-node borrow appears.
+
+- **`Get` returns by value.** Safe by construction, but copies a fat node (`Type`, `Expr`) on every
+  read, on the hot path, when most reads touch a single field. The need is to copy the _one fact_
+  that must outlive a mutation, not the whole node on every access.
+
+- **Discipline alone ("remember to copy before `Add`").** Necessary but not sufficient as the only
+  safeguard: an unwritten rule rots. It is paired with the contract stated on the type, projection
+  at the call site, and review; a value fact projected before the mutation is the normal shape, and
+  a `Get` reference read after a same-arena `Add` is the forbidden one.
+
+## Consequences
+
+- The `Arena` header states the contract: `Get` is a transient view; a same-arena `Add` invalidates
+  prior references, pointers, and iterators; the `Id` is the only durable handle.
+- A lowering routine reads a node, projects the facts that must outlive any interning it does, then
+  interns / appends / recurses. Reads after a same-arena mutation go through the id or a projected
+  value.
+- High-frequency, semantically-meaningful projections (a type's kind, a pointer's pointee, an
+  expression's type) may gain value-returning accessors as consumers appear, so the projecting shape
+  reads cleanly; they are not added pre-emptively.
+- Holding a `Get` reference across a same-arena `Add` and reading it afterward is a forbidden shape.
+  Absent a reliable static check, it is caught by the contract and review, not by the data
+  structure.
+
+## Cross-references
+
+- [generic-lowering-machinery](generic-lowering-machinery.md) (the universal `Arena<T>` this
+  constrains).
+- `architecture/identity_and_ownership.md` (local entities are referenced by typed id, not by
+  pointer).
+- `architecture/incremental_build.md` (caching keys are ownership-based; raw pointer identity is a
+  forbidden key).
+- `architecture/mir.md` (MIR ids are the single source of identity at that layer).

--- a/docs/decisions/mir-type-interning.md
+++ b/docs/decisions/mir-type-interning.md
@@ -1,0 +1,134 @@
+# MIR type pool is a structural-equality interner
+
+Date: 2026-06-26 Status: accepted
+
+## Context
+
+MIR's unit-wide type pool is a plain append-only `Arena<Type, TypeId>`: every construction appends
+and mints a fresh `TypeId`, with no deduplication. So the same semantic type -- `Coroutine<void>`, a
+borrowed pointer to the scope type, `Ref<T>` -- is interned to multiple distinct `TypeId`s. The
+hottest few are hand-cached as fields on a builtin table to avoid the duplication, and the
+coroutine-type constructor special-cases a `void` payload to return the cached instance. This
+conflates three distinct concepts: an **arena** (append -> new local id), an **interner** (a
+semantic key -> one canonical id), and a **builtin registry** (named handles for atomic types).
+
+A committed downstream consumer forces the question. A class is a data type: its MIR type is an
+object type naming the class's declaration. A class can reference itself (a member that is a pointer
+to its own type) or participate in a cycle with another class (mutual reference). Lowering such a
+class is the MIR analogue of a C++ forward declaration: a reference to the class's type is formed
+_before_ the class body exists, and it must denote the **same** type as the class's own definition
+uses. A plain arena cannot provide this -- each `Add(ObjectType{...})` yields a different `TypeId`,
+so a forward reference and the definition would carry unequal type identities and not be recognized
+as the same type. Only canonicalization -- interning an object type by the class's declaration
+identity, which exists before the body -- gives the forward reference and the definition one shared
+`TypeId`.
+
+The same property makes `TypeId` equality a valid, cheap semantic-equality test (`if (a == b)` means
+"the same MIR type"), which a non-canonicalizing arena cannot offer.
+
+The hard requirement is the nominal half of this canonicalization, and it bites on object types: a
+class's type must share one `TypeId` across its references and its definition -- what the
+recursive-class consumer needs -- and a class needs an explicit declaration identity because two
+classes with identical members are distinct types. Interning every other constructed type -- the
+structural types, and enum types whose enumerators already form a scope-unique key (see the
+Decision) -- is the consistent extension of the same mechanism: not separately forced by a consumer,
+but it removes the manual builtin caches for hot composites and makes `TypeId` equality uniform, at
+the marginal cost of keying a few more variants through the same path.
+
+## Decision
+
+The MIR type pool is a **type interner**: arena storage for the canonical representatives plus a
+structural-key index that maps each semantic type to one canonical `TypeId`.
+
+1. **Interning is the type-construction API.** Constructing a type returns the canonical `TypeId`
+   for its semantic identity; two requests for the same semantic type return the same `TypeId`. Raw
+   append (mint a new id unconditionally) is not how a type is obtained.
+
+2. **The key encodes MIR semantic equality, not layout.** A nominal type is keyed by its declaration
+   identity wherever a structural key could otherwise merge it with a genuinely different type:
+   - An **object type** (a class) is keyed by its **class id**. Two classes with identical members
+     are different types and may coexist in one scope, so a structural expansion of the members is
+     not a valid identity -- only the declaration id is.
+   - An **enum type** is keyed by its base and its enumerators (names and values). SystemVerilog
+     inserts enumerator names into the enclosing scope and forbids two enumerations in one scope
+     from sharing a name (LRM 6.19), so an enumerator set is a scope-unique fingerprint: it _is_ the
+     enum's declaration identity, and keying on it cannot merge two distinct enums. An explicit
+     enum-definition id would be the same identity by a different key; it is added only if a
+     consumer needs an enum identity the enumerators do not already carry (such as the source type
+     name), not speculatively.
+   - **Structural types** -- pointer, reference, vector, coroutine, packed/unpacked array, tuple --
+     are keyed by the constructor plus the canonical `TypeId`s of their children plus their semantic
+     modifiers (ownership, dimensions, signedness, const-ness).
+
+3. **The key excludes non-semantic fields.** Source locations, debug/display names, and derived or
+   cached data do not participate. Two types equal in semantics but differing only in such a field
+   canonicalize to one `TypeId`.
+
+4. **`TypeId` is the unit-local canonical handle.** Within one compilation unit, `TypeId` equality
+   implies semantic-type equality, and the converse holds by construction. `TypeId` is not a
+   cross-revision or incremental key: it depends on construction order within a build, so the same
+   semantic type may carry a different `TypeId` in the next build. Cross-revision identity is a
+   separate semantic key / fingerprint, computed on demand, not the `TypeId`.
+
+5. **Object identity breaks recursion.** A self- or mutually-referential type reaches the cycle only
+   through an object type, which is keyed by a class id that exists before the body is built.
+   Interning an object type therefore needs no completed body, and no anonymous structural type
+   forms a cycle. This is what makes the forward-declaration use case work.
+
+6. **Builtins hold only atomic canonical types.** The builtin table names language and runtime
+   atomic types (void, the literals, string, time, ...). A composite type that is materialized
+   pervasively -- `Coroutine<void>`, the borrowed scope pointer -- is obtained through interning
+   like any other composite; a retained named handle for it is a convenience alias produced via the
+   same interning path, never a separate allocation and never a deduplication mechanism. The
+   coroutine constructor has no `void`-payload special case.
+
+## Rejected
+
+- **Plain append-only arena plus manual builtin caches (status quo).** Cannot canonicalize, so a
+  forward-declared or recursive class cannot share one `TypeId` between its references and its
+  definition -- the committed consumer is unserviceable. Duplication of every other synthesized type
+  persists, and the builtin table accretes composite caches that misrepresent instantiations as
+  primitives.
+
+- **Naive structural deduplication for object types (fold classes whose members match).** Two
+  classes with identical members are distinct types, so folding them by structure corrupts type
+  identity; an object type must be keyed by its class id. This hazard is specific to types whose
+  structure can collide with a different type's. An enum cannot: LRM 6.19 makes its enumerator set
+  scope-unique, so keying an enum by its enumerators is its declaration identity, not naive
+  structural dedup.
+
+- **Keep the arena, document "do not compare `TypeId`s for semantic equality."** Sufficient if the
+  only goal were to avoid a latent trap, but it cannot serve the class consumer: a documented
+  prohibition does not give a forward reference and a definition a shared type identity. Once a
+  consumer needs canonical type identity, the pool must canonicalize.
+
+## Consequences
+
+- The same semantic type maps to one `TypeId`; `if (a == b)` is a valid, cheap semantic-equality
+  fast path, available to type comparisons, dispatch, and future type-keyed caches.
+- A forward reference to a class type and the class's definition resolve to the same `TypeId`,
+  enabling self- and mutually-recursive class types.
+- The coroutine constructor's `void` branch and the composite builtin caches (`Coroutine<void>`, the
+  borrowed scope pointer) are removed or become convenience aliases produced through interning.
+- Each `TypeData` variant must state which of its fields determine semantic identity. This is a
+  per-variant audit governed by the key rules above (object types by class id, enum types by their
+  scope-unique enumerators, structural types by constructor plus canonical children plus modifiers,
+  non-semantic fields excluded).
+- The interner is unit-global, single-writer-during-construction, mutable state. Under future
+  body-level parallel lowering it is a shared-state boundary; its concurrency model is decided
+  together with the body-level ownership model, not assumed lock-free.
+- The arena remains the storage primitive beneath the interner; the interner adds the key index. The
+  arena's reference-lifetime contract is unchanged: a lookup returns a transient view, the canonical
+  `TypeId` is the durable handle.
+
+## Cross-references
+
+- [generic-lowering-machinery](generic-lowering-machinery.md) (the arena versus interning-table
+  distinction; this realizes the interning-table shape for the type pool).
+- [arena-reference-lifetime](arena-reference-lifetime.md) (the underlying arena's `Get`/`Add`
+  contract).
+- `architecture/identity_and_ownership.md` (typed compilation-unit-local identity; nominal identity
+  follows declaration, not structure).
+- `architecture/incremental_build.md` (`TypeId` is not a cross-revision or cache key;
+  ownership-based keys are).
+- `architecture/mir.md` (an object type names a class of the unit; nominal type identity).

--- a/include/lyra/backend/cpp/scope_view.hpp
+++ b/include/lyra/backend/cpp/scope_view.hpp
@@ -111,7 +111,7 @@ class ScopeView {
   // The object type a class instance has -- the pointee of its self pointer.
   [[nodiscard]] auto ObjectTypeOf(const mir::Class& cls) const -> mir::TypeId {
     return std::get<mir::PointerType>(
-               unit_->GetType(cls.self_pointer_type).data)
+               unit_->types.Get(cls.self_pointer_type).data)
         .pointee;
   }
 

--- a/include/lyra/base/arena.hpp
+++ b/include/lyra/base/arena.hpp
@@ -2,24 +2,45 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <format>
 #include <utility>
 #include <vector>
+
+#include "lyra/base/internal_error.hpp"
 
 namespace lyra::base {
 
 // A flat, append-only pool of `T` indexed by a typed id `Id`. `Id` is a struct
 // carrying a single `std::uint32_t value` (its position in the pool). One id is
-// minted per append, in insertion order, and stays valid for the life of the
-// arena. Lookup is by id only -- there is no raw integer index -- so the typed
-// id is the one handle a consumer holds. There is no mutable lookup: a node is
-// built before it is appended and is never edited in place. This immutability
-// is load-bearing -- an appended node is final, so other nodes may reference it
-// and a later shard may cache it without coordination.
+// minted per append, in insertion order, and is the only durable handle: it
+// stays valid for the life of the arena, lookup is by id alone, and one element
+// references another by id, never by pointer.
+//
+// A node is built before it is appended and is never edited in place. This
+// value immutability is load-bearing: an appended node's value is final, so
+// other nodes reference it by id and a later shard caches it without
+// coordination.
+//
+// Value immutability is not address stability. `Get` returns a transient view
+// into relocatable backing storage; any `Add` may relocate that storage and so
+// invalidates every reference, pointer, and iterator a prior `Get` returned. To
+// use a fact past an `Add`, project it to a value -- an `Id`, a kind, a copied
+// field -- before the `Add`; never hold a `Get` reference across one.
 template <typename T, typename Id>
 class Arena {
  public:
   [[nodiscard]] auto Get(Id id) const -> const T& {
-    return items_.at(id.value);
+    // A typed id that overruns the pool is a compiler-invariant violation -- it
+    // was minted for a different arena or carried past its arena's lifetime --
+    // so report the id and pool size rather than let the bare bounds check
+    // throw a contextless std::out_of_range.
+    if (id.value >= items_.size()) {
+      throw InternalError(
+          std::format(
+              "Arena::Get: id {} is out of range; the arena holds {} elements",
+              id.value, items_.size()));
+    }
+    return items_[id.value];
   }
 
   auto Add(T value) -> Id {

--- a/include/lyra/hir/module_unit.hpp
+++ b/include/lyra/hir/module_unit.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <cstdint>
 #include <string>
 #include <utility>
-#include <vector>
 
+#include "lyra/base/arena.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/hir/type_id.hpp"
@@ -26,47 +25,42 @@ struct BuiltinHirTypes {
 
 struct ModuleUnit {
   std::string name;
-  std::vector<Type> types;
+  base::Arena<Type, TypeId> types;
   BuiltinHirTypes builtins;
   StructuralScope root_scope;
 
   explicit ModuleUnit(std::string name)
       : name(std::move(name)),
         builtins{
-            .void_type = AddType(TypeData{VoidType{}}),
-            .int32 = AddType(
-                TypeData{PackedArrayType{
-                    .atom = BitAtom::kBit,
-                    .signedness = Signedness::kSigned,
-                    .dims = {PackedRange{.left = 31, .right = 0}},
-                    .form = PackedArrayForm::kInt}}),
-            .integer = AddType(
-                TypeData{PackedArrayType{
-                    .atom = BitAtom::kLogic,
-                    .signedness = Signedness::kSigned,
-                    .dims = {PackedRange{.left = 31, .right = 0}},
-                    .form = PackedArrayForm::kInteger}}),
-            .string = AddType(TypeData{StringType{}}),
-            .time = AddType(
-                TypeData{PackedArrayType{
-                    .atom = BitAtom::kLogic,
-                    .signedness = Signedness::kUnsigned,
-                    .dims = {PackedRange{.left = 63, .right = 0}},
-                    .form = PackedArrayForm::kTime}}),
-            .realtime = AddType(TypeData{RealTimeType{}}),
-            .wildcard_index = AddType(TypeData{WildcardIndexType{}}),
+            .void_type = types.Add(Type{.data = VoidType{}}),
+            .int32 = types.Add(
+                Type{
+                    .data =
+                        PackedArrayType{
+                            .atom = BitAtom::kBit,
+                            .signedness = Signedness::kSigned,
+                            .dims = {PackedRange{.left = 31, .right = 0}},
+                            .form = PackedArrayForm::kInt}}),
+            .integer = types.Add(
+                Type{
+                    .data =
+                        PackedArrayType{
+                            .atom = BitAtom::kLogic,
+                            .signedness = Signedness::kSigned,
+                            .dims = {PackedRange{.left = 31, .right = 0}},
+                            .form = PackedArrayForm::kInteger}}),
+            .string = types.Add(Type{.data = StringType{}}),
+            .time = types.Add(
+                Type{
+                    .data =
+                        PackedArrayType{
+                            .atom = BitAtom::kLogic,
+                            .signedness = Signedness::kUnsigned,
+                            .dims = {PackedRange{.left = 63, .right = 0}},
+                            .form = PackedArrayForm::kTime}}),
+            .realtime = types.Add(Type{.data = RealTimeType{}}),
+            .wildcard_index = types.Add(Type{.data = WildcardIndexType{}}),
         } {
-  }
-
-  [[nodiscard]] auto GetType(TypeId id) const -> const Type& {
-    return types.at(id.value);
-  }
-
-  auto AddType(TypeData data, diag::DiagSpan span = diag::UnknownSpan{})
-      -> TypeId {
-    const TypeId id{static_cast<std::uint32_t>(types.size())};
-    types.push_back(Type{.data = std::move(data), .span = span});
-    return id;
   }
 };
 

--- a/include/lyra/lowering/hir_to_mir/completion_payload.hpp
+++ b/include/lyra/lowering/hir_to_mir/completion_payload.hpp
@@ -24,10 +24,4 @@ auto NormalizeCompletionPayload(
     mir::CompilationUnit& unit, const std::vector<mir::TypeId>& components)
     -> mir::TypeId;
 
-// The coroutine call protocol carrying a completion payload. A `Void` payload
-// reuses the interned bare coroutine so no-output tasks and processes share one
-// type identity.
-auto CoroutineOf(mir::CompilationUnit& unit, mir::TypeId payload)
-    -> mir::TypeId;
-
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/module_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/module_lowerer.hpp
@@ -31,11 +31,11 @@ class ModuleLowerer {
 
   auto Run() -> diag::Result<mir::CompilationUnit>;
 
-  // Access to the in-progress compilation unit. The const overload mirrors the
-  // interface downstream consumers see post-`Run`; the mutable overload lets
-  // handlers reach the unit's own append-only API (e.g. `AddType`,
-  // `AllocateDeferredCheckSiteId`) directly, matching the discipline used for
-  // nested-scope writes through `frame.current_*_scope`.
+  // Access to the in-progress compilation unit. The const overload is the
+  // read-only view downstream consumers see once lowering finishes; the mutable
+  // overload lets a handler append unit-wide output -- a synthesized type, a
+  // deferred-check site -- to the unit, the same discipline by which nested IR
+  // is written through the frame's current targets.
   [[nodiscard]] auto Unit() const -> const mir::CompilationUnit& {
     return unit_;
   }

--- a/include/lyra/lowering/hir_to_mir/walk_frame.hpp
+++ b/include/lyra/lowering/hir_to_mir/walk_frame.hpp
@@ -48,11 +48,10 @@ enum class LoopVarLoweringMode : std::uint8_t {
 // not here. WalkFrame holds only state that genuinely changes from one
 // recursion to the next.
 //
-// Handlers reach nested write targets through `frame.current_class->Add...` /
-// `frame.current_block->Add...`;
-// writes to the root output go through the unit's own append-only API reached
-// via `module.Unit().AddType(...)` for synthesized types,
-// `module.Unit().AllocateDeferredCheckSiteId()` for deferred-check site ids.
+// A handler writes nested IR through the frame's current targets; output that
+// belongs to the compilation unit as a whole -- a synthesized type, a
+// deferred-check site -- is appended to the unit directly, since it has no
+// place on a per-recursion frame.
 struct WalkFrame {
   // The current class write target. Set when a class-constructing task builds
   // its class and entered via `WithClass`. Null outside class handlers.

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <utility>
 #include <vector>
 
 #include "lyra/mir/class.hpp"
@@ -9,15 +8,20 @@
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/integral_constant.hpp"
 #include "lyra/mir/type.hpp"
+#include "lyra/mir/type_interner.hpp"
 
 namespace lyra::mir {
 
 struct DeferredCheckSite {};
 
-// Canonical TypeIds for primitives the lowering and rendering frequently
-// materialize (literal `int` type, 1-bit selector type, void result of system
-// tasks, etc.). Populated by `CompilationUnit`'s constructor; consumers read
-// them off the unit.
+// Named TypeIds the lowering and rendering reuse. Most are language or runtime
+// atomic types (the literal `int` type, the 1-bit selector type, the `void`
+// result of system tasks). `scope_ptr` and `coroutine_void` are not atomic:
+// they are convenience aliases for canonical instances of composite types
+// (`Pointer<Scope>`, `Coroutine<void>`) that nearly every scope and process
+// materializes -- the interner gives them their identity, these fields only
+// name them. Populated by `CompilationUnit`'s constructor; consumers read them
+// off the unit.
 struct BuiltinMirTypes {
   TypeId int32;
   TypeId integer;
@@ -37,92 +41,78 @@ struct BuiltinMirTypes {
   TypeId format_spec;
   TypeId time_format;
   TypeId hierarchy_segment;
-  TypeId coroutine;
+  TypeId coroutine_void;
   TypeId wildcard_index;
 };
 
 struct CompilationUnit {
-  std::vector<Type> types;
+  TypeInterner types;
   BuiltinMirTypes builtins;
   Class top_class;
   std::vector<DeferredCheckSite> deferred_check_sites;
 
   CompilationUnit()
       : builtins{
-            .int32 = AddType(
-                TypeData{PackedArrayType{
+            .int32 = types.Intern(
+                PackedArrayType{
                     .atom = BitAtom::kBit,
                     .signedness = Signedness::kSigned,
                     .dims = {PackedRange{.left = 31, .right = 0}},
-                    .form = PackedArrayForm::kInt}}),
-            .integer = AddType(
-                TypeData{PackedArrayType{
+                    .form = PackedArrayForm::kInt}),
+            .integer = types.Intern(
+                PackedArrayType{
                     .atom = BitAtom::kLogic,
                     .signedness = Signedness::kSigned,
                     .dims = {PackedRange{.left = 31, .right = 0}},
-                    .form = PackedArrayForm::kInteger}}),
-            .bit1 = AddType(
-                TypeData{PackedArrayType{
+                    .form = PackedArrayForm::kInteger}),
+            .bit1 = types.Intern(
+                PackedArrayType{
                     .atom = BitAtom::kBit,
                     .signedness = Signedness::kUnsigned,
                     .dims = {PackedRange{.left = 0, .right = 0}},
-                    .form = PackedArrayForm::kExplicit}}),
-            .string = AddType(TypeData{StringType{}}),
-            .void_type = AddType(TypeData{VoidType{}}),
-            .realtime = AddType(TypeData{RealTimeType{}}),
-            .time = AddType(
-                TypeData{PackedArrayType{
+                    .form = PackedArrayForm::kExplicit}),
+            .string = types.Intern(StringType{}),
+            .void_type = types.Intern(VoidType{}),
+            .realtime = types.Intern(RealTimeType{}),
+            .time = types.Intern(
+                PackedArrayType{
                     .atom = BitAtom::kLogic,
                     .signedness = Signedness::kUnsigned,
                     .dims = {PackedRange{.left = 63, .right = 0}},
-                    .form = PackedArrayForm::kTime}}),
-            .services = AddType(TypeData{ServicesType{}}),
-            .scope_ptr = AddType(
-                TypeData{PointerType{
-                    .pointee = AddType(TypeData{ScopeType{}}),
-                    .ownership = PointerOwnership::kBorrowed}}),
-            .files = AddType(TypeData{FilesType{}}),
-            .diagnostic = AddType(TypeData{DiagnosticType{}}),
-            .channel_cancellation = AddType(
-                TypeData{RuntimeLibraryType{
-                    .kind = RuntimeLibraryKind::kChannelCancellation}}),
-            .print_item = AddType(
-                TypeData{RuntimeLibraryType{
-                    .kind = RuntimeLibraryKind::kPrintItem}}),
-            .print_literal_item = AddType(
-                TypeData{RuntimeLibraryType{
-                    .kind = RuntimeLibraryKind::kPrintLiteralItem}}),
-            .print_value_item = AddType(
-                TypeData{RuntimeLibraryType{
-                    .kind = RuntimeLibraryKind::kPrintValueItem}}),
-            .format_spec = AddType(
-                TypeData{RuntimeLibraryType{
-                    .kind = RuntimeLibraryKind::kFormatSpec}}),
-            .time_format = AddType(
-                TypeData{RuntimeLibraryType{
-                    .kind = RuntimeLibraryKind::kTimeFormat}}),
-            .hierarchy_segment = AddType(
-                TypeData{RuntimeLibraryType{
-                    .kind = RuntimeLibraryKind::kHierarchySegment}}),
-            .coroutine = TypeId{},
-            .wildcard_index = AddType(TypeData{WildcardIndexType{}}),
+                    .form = PackedArrayForm::kTime}),
+            .services = types.Intern(ServicesType{}),
+            .scope_ptr = types.PointerTo(
+                types.Intern(ScopeType{}), PointerOwnership::kBorrowed),
+            .files = types.Intern(FilesType{}),
+            .diagnostic = types.Intern(DiagnosticType{}),
+            .channel_cancellation = types.Intern(
+                RuntimeLibraryType{
+                    .kind = RuntimeLibraryKind::kChannelCancellation}),
+            .print_item = types.Intern(
+                RuntimeLibraryType{.kind = RuntimeLibraryKind::kPrintItem}),
+            .print_literal_item = types.Intern(
+                RuntimeLibraryType{
+                    .kind = RuntimeLibraryKind::kPrintLiteralItem}),
+            .print_value_item = types.Intern(
+                RuntimeLibraryType{
+                    .kind = RuntimeLibraryKind::kPrintValueItem}),
+            .format_spec = types.Intern(
+                RuntimeLibraryType{.kind = RuntimeLibraryKind::kFormatSpec}),
+            .time_format = types.Intern(
+                RuntimeLibraryType{.kind = RuntimeLibraryKind::kTimeFormat}),
+            .hierarchy_segment = types.Intern(
+                RuntimeLibraryType{
+                    .kind = RuntimeLibraryKind::kHierarchySegment}),
+            .coroutine_void = TypeId{},
+            .wildcard_index = types.Intern(WildcardIndexType{}),
         } {
-    // A bare coroutine yields nothing, so its completion payload is `Void`. It
-    // is interned in the body rather than the member list because it reads back
-    // the already-interned `void_type`; the member-list value above is an
-    // unused placeholder overwritten here.
-    builtins.coroutine =
-        AddType(TypeData{CoroutineType{.payload = builtins.void_type}});
-  }
-
-  [[nodiscard]] auto GetType(TypeId id) const -> const Type& {
-    return types.at(id.value);
-  }
-
-  auto AddType(TypeData data) -> TypeId {
-    const TypeId id{static_cast<std::uint32_t>(types.size())};
-    types.push_back(Type{.data = std::move(data)});
-    return id;
+    // `Coroutine<void>` is the completion type of a process or void task. It is
+    // built in the constructor body because it reads back the already-interned
+    // `void_type`; the member-list entry above is an unused placeholder
+    // overwritten here. The field is a convenience alias for the canonical
+    // instance, not a deduplication mechanism -- interning `Coroutine<void>`
+    // anywhere returns this same id.
+    builtins.coroutine_void = types.CoroutineOf(builtins.void_type);
   }
 
   // Backing-vector position is the id, matching TypeId / LocalId.

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -70,6 +70,8 @@ struct PackedRange {
   [[nodiscard]] auto IsAscending() const -> bool;
   [[nodiscard]] auto Contains(std::int64_t index) const -> bool;
   [[nodiscard]] auto LinearOffset(std::int64_t index) const -> std::uint64_t;
+
+  auto operator==(const PackedRange&) const -> bool = default;
 };
 
 struct PackedArrayType {
@@ -85,6 +87,8 @@ struct PackedArrayType {
 struct EnumMember {
   std::string name;
   std::int64_t value;
+
+  auto operator==(const EnumMember&) const -> bool = default;
 };
 
 struct EnumType {
@@ -107,20 +111,28 @@ struct EnumType {
 struct UnpackedArrayType {
   TypeId element_type;
   std::uint64_t size;
+
+  auto operator==(const UnpackedArrayType&) const -> bool = default;
 };
 
 struct DynamicArrayType {
   TypeId element_type;
+
+  auto operator==(const DynamicArrayType&) const -> bool = default;
 };
 
 struct QueueType {
   TypeId element_type;
   std::optional<std::uint64_t> max_bound;
+
+  auto operator==(const QueueType&) const -> bool = default;
 };
 
 struct AssociativeArrayType {
   TypeId element_type;
   TypeId key_type;
+
+  auto operator==(const AssociativeArrayType&) const -> bool = default;
 };
 
 // LRM 7.8.1 wildcard index type (`[*]`): the key type of an associative array
@@ -129,15 +141,31 @@ struct AssociativeArrayType {
 // is `lyra::value::WildcardKey`; it is the key type that selects the
 // magnitude-identified, width-independent ordering instead of the fixed-shape
 // integral or lexicographic-string orderings.
-struct WildcardIndexType {};
+struct WildcardIndexType {
+  auto operator==(const WildcardIndexType&) const -> bool = default;
+};
 
-struct StringType {};
-struct EventType {};
-struct RealType {};
-struct ShortRealType {};
-struct RealTimeType {};
-struct ChandleType {};
-struct VoidType {};
+struct StringType {
+  auto operator==(const StringType&) const -> bool = default;
+};
+struct EventType {
+  auto operator==(const EventType&) const -> bool = default;
+};
+struct RealType {
+  auto operator==(const RealType&) const -> bool = default;
+};
+struct ShortRealType {
+  auto operator==(const ShortRealType&) const -> bool = default;
+};
+struct RealTimeType {
+  auto operator==(const RealTimeType&) const -> bool = default;
+};
+struct ChandleType {
+  auto operator==(const ChandleType&) const -> bool = default;
+};
+struct VoidType {
+  auto operator==(const VoidType&) const -> bool = default;
+};
 
 struct ObjectType {
   std::string name;

--- a/include/lyra/mir/type_interner.hpp
+++ b/include/lyra/mir/type_interner.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <cstddef>
+#include <unordered_map>
+
+#include "lyra/base/arena.hpp"
+#include "lyra/mir/type.hpp"
+#include "lyra/mir/type_id.hpp"
+
+namespace lyra::mir {
+
+// Interning equality over MIR types: the rule that decides which `TypeData`
+// requests collapse to one canonical id. A nominal type compares by its
+// declaration identity; a structural type by its constructor, the canonical
+// `TypeId`s of its children, and its semantic modifiers. A packed array's slang
+// syntactic-origin marker carries no semantic content and is excluded, so `int`
+// and `bit signed [31:0]` canonicalize together. These functors are the
+// definition of that equality; everything else follows from them.
+struct SemanticTypeHash {
+  auto operator()(const TypeData& data) const -> std::size_t;
+};
+
+struct SemanticTypeEqual {
+  auto operator()(const TypeData& a, const TypeData& b) const -> bool;
+};
+
+// The MIR type pool. Interning canonicalizes: within one compilation unit a
+// semantic type maps to one canonical `TypeId`, so equal types share an id and
+// a `TypeId` comparison is a semantic-type comparison.
+//
+// Storage and canonicalization are separate concerns: a plain append-only arena
+// holds the canonical representatives and mints the dense `TypeId`; a key index
+// keyed by semantic identity decides which requests collapse to one id. The
+// `TypeId` is the local handle; the equality functor is the definition of
+// interning equality.
+//
+// Only complete type requests are interned -- there is no reserve-then-fill or
+// placeholder. A recursive type graph is broken by a nominal type, whose
+// declaration identity exists before the body, so no incomplete request arises.
+//
+// `Get` keeps the arena's transient-view contract: the `TypeId` is durable, a
+// reference it returns must not be held across a later `Intern`.
+class TypeInterner {
+ public:
+  auto Intern(TypeData data) -> TypeId;
+
+  [[nodiscard]] auto Get(TypeId id) const -> const Type& {
+    return storage_.Get(id);
+  }
+
+  [[nodiscard]] auto size() const -> std::size_t {
+    return storage_.size();
+  }
+
+  [[nodiscard]] auto begin() const {
+    return storage_.begin();
+  }
+
+  [[nodiscard]] auto end() const {
+    return storage_.end();
+  }
+
+  // Typed constructors for the composite types lowering materializes
+  // repeatedly. Each interns its constructor, so a repeated request returns the
+  // one canonical id rather than a duplicate.
+  auto CoroutineOf(TypeId payload) -> TypeId {
+    return Intern(CoroutineType{.payload = payload});
+  }
+
+  auto PointerTo(TypeId pointee, PointerOwnership ownership) -> TypeId {
+    return Intern(PointerType{.pointee = pointee, .ownership = ownership});
+  }
+
+ private:
+  base::Arena<Type, TypeId> storage_;
+  std::unordered_map<TypeData, TypeId, SemanticTypeHash, SemanticTypeEqual>
+      index_;
+};
+
+}  // namespace lyra::mir

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -358,11 +358,12 @@ auto RenderScopeHeaderFile(
   out += "\n";
   bool any_enum = false;
   for (std::size_t i = 0; i < unit.types.size(); ++i) {
-    const auto* enum_type = std::get_if<mir::EnumType>(&unit.types[i].data);
+    const mir::TypeId type_id{static_cast<std::uint32_t>(i)};
+    const auto* enum_type =
+        std::get_if<mir::EnumType>(&unit.types.Get(type_id).data);
     if (enum_type == nullptr) continue;
     any_enum = true;
-    const auto class_name =
-        RenderEnumClassName(s, mir::TypeId{static_cast<std::uint32_t>(i)});
+    const auto class_name = RenderEnumClassName(s, type_id);
     const auto& base = enum_type->base;
     const char* signed_lit =
         base.signedness == mir::Signedness::kSigned ? "true" : "false";

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -381,7 +381,7 @@ auto RenderDirectMethodCall(
   }
   const mir::Expr& receiver = view.Expr(call.arguments[0]);
   const mir::TypeId object_type =
-      std::get<mir::PointerType>(view.Unit().GetType(receiver.type).data)
+      std::get<mir::PointerType>(view.Unit().types.Get(receiver.type).data)
           .pointee;
   const auto& cls = view.ClassByObjectType(object_type);
   return {
@@ -420,7 +420,7 @@ auto RenderDirectBuiltinCall(
   }
   const mir::Expr& receiver = view.Expr(call.arguments[0]);
   const std::string_view sep =
-      view.Unit().GetType(receiver.type).Kind() == mir::TypeKind::kPointer
+      view.Unit().types.Get(receiver.type).Kind() == mir::TypeKind::kPointer
           ? "->"
           : ".";
   return {
@@ -459,7 +459,7 @@ auto RenderCalleePart(
             // `unique_ptr<T>` constructor is `std::make_unique<T>` -- it
             // forwards the arguments to T's constructor and heap-allocates --
             // so which C++ syntax to spell is read off the result type.
-            const auto& result_ty = view.Unit().GetType(result_type);
+            const auto& result_ty = view.Unit().types.Get(result_type);
             if (const auto* ptr =
                     std::get_if<mir::PointerType>(&result_ty.data);
                 ptr != nullptr &&

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -120,7 +120,7 @@ auto RenderPackedArrayIntegerLiteral(
 auto RenderIntegerLiteralExpr(
     const ScopeView& view, const mir::Expr& expr,
     const mir::IntegerLiteral& lit) -> std::string {
-  const auto& ty = view.Unit().GetType(expr.type);
+  const auto& ty = view.Unit().types.Get(expr.type);
   if (!ty.IsIntegralPacked()) {
     throw InternalError(
         "RenderIntegerLiteralExpr: IntegerLiteral not typed as "
@@ -148,7 +148,7 @@ auto RenderRealLiteralExpr(
   // rejects (a digit sequence followed by `f` is not a valid float suffix).
   // Force a decimal point when the formatted body has neither `.` nor an
   // exponent, so `0` -> `0.0`, `42` -> `42.0`.
-  const auto& ty = view.Unit().GetType(expr.type);
+  const auto& ty = view.Unit().types.Get(expr.type);
   const bool is_short = ty.Kind() == mir::TypeKind::kShortReal;
   std::string body = is_short ? std::format("{:.9g}", r.value)
                               : std::format("{:.17g}", r.value);
@@ -340,7 +340,7 @@ auto MemberFieldName(const ScopeView& view, const mir::MemberAccessExpr& m)
     -> const std::string& {
   const mir::TypeId recv_type = view.Expr(m.receiver).type;
   const auto& ptr =
-      std::get<mir::PointerType>(view.Unit().GetType(recv_type).data);
+      std::get<mir::PointerType>(view.Unit().types.Get(recv_type).data);
   return view.ClassByObjectType(ptr.pointee).members.Get(m.member.var).name;
 }
 
@@ -521,7 +521,7 @@ auto RenderClosureExpr(
   };
 
   if (std::holds_alternative<mir::CoroutineType>(
-          view.Unit().GetType(result_type).data)) {
+          view.Unit().types.Get(result_type).data)) {
     for (const mir::LocalId param : code.params) {
       if (!is_bound(param)) {
         throw InternalError(
@@ -583,7 +583,7 @@ auto RenderQueueConcat(
       RenderTypeAsCpp(view.Unit(), view.Class(), elem_type_id));
   for (std::size_t i = 0; i < c.operands.size(); ++i) {
     const auto& op_expr = view.Expr(c.operands[i]);
-    const auto& op_ty = view.Unit().GetType(op_expr.type);
+    const auto& op_ty = view.Unit().types.Get(op_expr.type);
     const bool spread =
         std::holds_alternative<mir::QueueType>(op_ty.data) ||
         std::holds_alternative<mir::DynamicArrayType>(op_ty.data) ||
@@ -600,7 +600,7 @@ auto RenderQueueConcat(
 auto RenderConcatExpr(
     const ScopeView& view, const mir::Expr& expr, const mir::ConcatExpr& c)
     -> std::string {
-  const auto& result_ty = view.Unit().GetType(expr.type);
+  const auto& result_ty = view.Unit().types.Get(expr.type);
   if (std::holds_alternative<mir::QueueType>(result_ty.data)) {
     return RenderQueueConcat(view, result_ty, c);
   }
@@ -639,7 +639,7 @@ auto RenderConcatExpr(
 auto RenderArrayLiteralExpr(
     const ScopeView& view, const mir::Expr& expr,
     const mir::ArrayLiteralExpr& a) -> std::string {
-  const auto& container_ty = view.Unit().GetType(expr.type);
+  const auto& container_ty = view.Unit().types.Get(expr.type);
   const mir::TypeId elem_type_id = std::visit(
       [](const auto& ty) -> mir::TypeId {
         using TyT = std::decay_t<decltype(ty)>;
@@ -688,11 +688,11 @@ auto RenderReplicationExpr(
     -> std::string {
   std::string count = RenderExpr(view, view.Expr(r.count));
   std::string concat = RenderExpr(view, view.Expr(r.concat));
-  const auto& count_ty = view.Unit().GetType(view.Expr(r.count).type);
+  const auto& count_ty = view.Unit().types.Get(view.Expr(r.count).type);
   std::string count_text = count_ty.IsIntegralPacked()
                                ? std::format("({}).ToInt64()", count)
                                : count;
-  const auto& result_ty = view.Unit().GetType(expr.type);
+  const auto& result_ty = view.Unit().types.Get(expr.type);
   if (result_ty.IsIntegralPacked()) {
     return std::format(
         "lyra::value::PackedArray::Replicate({}, "

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -194,7 +194,7 @@ auto RenderTypeAsCpp(
                 "cut");
           },
       },
-      unit.GetType(type_id).data);
+      unit.types.Get(type_id).data);
 }
 
 }  // namespace lyra::backend::cpp

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -788,7 +788,10 @@ class HirDumper {
     Line("Types:");
     Indent();
     for (std::size_t i = 0; i < u.types.size(); ++i) {
-      Line(std::format("[{}] {}", i, FormatType(u.types[i])));
+      Line(
+          std::format(
+              "[{}] {}", i,
+              FormatType(u.types.Get(TypeId{static_cast<std::uint32_t>(i)}))));
     }
     Dedent();
 

--- a/src/lyra/lowering/ast_to_hir/constant_value.cpp
+++ b/src/lyra/lowering/ast_to_hir/constant_value.cpp
@@ -21,7 +21,7 @@ auto MakeUnpackedConstantExpr(
     const hir::ModuleUnit& unit, WalkFrame frame,
     const slang::ConstantValue& cv, hir::TypeId type, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  const auto& ty = unit.GetType(type);
+  const auto& ty = unit.types.Get(type);
   const auto* arr = std::get_if<hir::UnpackedArrayType>(&ty.data);
   if (arr == nullptr) {
     return diag::Fail(

--- a/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
@@ -26,7 +26,7 @@ auto LowerConcatExpr(
   auto& module = lowerer.Module();
   auto type_id = module.InternType(*cc.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
-  const auto kind = module.Unit().GetType(*type_id).Kind();
+  const auto kind = module.Unit().types.Get(*type_id).Kind();
   if (kind != hir::TypeKind::kString && kind != hir::TypeKind::kPackedArray &&
       kind != hir::TypeKind::kQueue) {
     return diag::Fail(
@@ -65,7 +65,7 @@ auto LowerReplicationExpr(
   auto& module = lowerer.Module();
   auto type_id = module.InternType(*rp.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
-  const auto kind = module.Unit().GetType(*type_id).Kind();
+  const auto kind = module.Unit().types.Get(*type_id).Kind();
   if (kind != hir::TypeKind::kString && kind != hir::TypeKind::kPackedArray) {
     return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -98,7 +98,7 @@ auto LowerCallExpr(
     const std::string_view name = info.subroutine->name;
 
     if (receiver_type.has_value() &&
-        module.Unit().GetType(*receiver_type).IsEnum()) {
+        module.Unit().types.Get(*receiver_type).IsEnum()) {
       if (auto kind = LowerEnumMethodName(name); kind.has_value()) {
         // `next` / `prev` have an optional `int unsigned step = 1` (LRM
         // 6.19.5.3/4). When the user omits the step, the lowering hands the
@@ -120,7 +120,7 @@ auto LowerCallExpr(
     }
 
     if (receiver_type.has_value() &&
-        module.Unit().GetType(*receiver_type).Kind() ==
+        module.Unit().types.Get(*receiver_type).Kind() ==
             hir::TypeKind::kString) {
       if (auto kind = LowerStringMethodName(name); kind.has_value()) {
         // LRM 6.16.1 through 6.16.15 -- string intrinsic methods. The
@@ -142,7 +142,7 @@ auto LowerCallExpr(
 
     if (receiver_type.has_value() &&
         std::holds_alternative<hir::EventType>(
-            module.Unit().GetType(*receiver_type).data) &&
+            module.Unit().types.Get(*receiver_type).data) &&
         name == "triggered") {
       // LRM 15.5.3: `e.triggered` returns true for the duration of the time
       // slot in which the event was last triggered. Result type is bit (1'b0
@@ -166,7 +166,7 @@ auto LowerCallExpr(
 
     if (receiver_type.has_value() &&
         std::holds_alternative<hir::QueueType>(
-            module.Unit().GetType(*receiver_type).data)) {
+            module.Unit().types.Get(*receiver_type).data)) {
       // LRM 7.10.2 queue-native methods. The receiver is arguments[0]; any
       // method parameters (insert's index and item, push's item) follow as the
       // remaining arguments. These methods take no `with` clause and are tried
@@ -201,13 +201,13 @@ auto LowerCallExpr(
     // `WithClause`, which HIR -> MIR turns into a closure argument.
     if (receiver_type.has_value() &&
         (std::holds_alternative<hir::UnpackedArrayType>(
-             module.Unit().GetType(*receiver_type).data) ||
+             module.Unit().types.Get(*receiver_type).data) ||
          std::holds_alternative<hir::DynamicArrayType>(
-             module.Unit().GetType(*receiver_type).data) ||
+             module.Unit().types.Get(*receiver_type).data) ||
          std::holds_alternative<hir::QueueType>(
-             module.Unit().GetType(*receiver_type).data) ||
+             module.Unit().types.Get(*receiver_type).data) ||
          std::holds_alternative<hir::AssociativeArrayType>(
-             module.Unit().GetType(*receiver_type).data))) {
+             module.Unit().types.Get(*receiver_type).data))) {
       if (auto kind = LowerArrayMethodName(name); kind.has_value()) {
         auto type_id = module.InternType(*call.type, span);
         if (!type_id) return std::unexpected(std::move(type_id.error()));
@@ -250,7 +250,7 @@ auto LowerCallExpr(
 
     if (receiver_type.has_value() &&
         std::holds_alternative<hir::AssociativeArrayType>(
-            module.Unit().GetType(*receiver_type).data)) {
+            module.Unit().types.Get(*receiver_type).data)) {
       if (auto kind = LowerAssociativeMethodName(name); kind.has_value()) {
         // LRM 7.9 associative-array methods. The receiver is arguments[0]; the
         // key (exists / delete-by-index) follows as the next argument. The

--- a/src/lyra/lowering/ast_to_hir/port_connection.cpp
+++ b/src/lyra/lowering/ast_to_hir/port_connection.cpp
@@ -74,7 +74,7 @@ auto ConnectElementPorts(
     }
     auto type_id = module.InternType(port.getType(), span);
     if (!type_id) return std::unexpected(std::move(type_id.error()));
-    if (!module.Unit().GetType(*type_id).IsValueChangeObservable()) {
+    if (!module.Unit().types.Get(*type_id).IsValueChangeObservable()) {
       return PortConnectionUnsupported(
           span,
           "port connection of a handle / event type is not yet supported");

--- a/src/lyra/lowering/ast_to_hir/statement/timing.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/timing.cpp
@@ -46,7 +46,7 @@ auto LowerSignalEventTrigger(
   auto expr_or = proc.LowerExpr(sig.expr, frame);
   if (!expr_or) return std::unexpected(std::move(expr_or.error()));
 
-  const auto& expr_type = proc.Module().Unit().GetType(expr_or->type);
+  const auto& expr_type = proc.Module().Unit().types.Get(expr_or->type);
   if (sig.edge != slang::ast::EdgeKind::None) {
     // The runtime classifies an edge only on a packed bit-vector cell (LRM
     // 9.4.2 Table 9-2); slang already restricts an edge to an integral operand.

--- a/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/structural_scope_lowerer.cpp
@@ -281,7 +281,7 @@ auto StructuralScopeLowerer::PopulateVariableMember(
   // elaboration, so a void-typed VariableSymbol can only reach this path
   // via a slang/Lyra integration bug.
   if (std::holds_alternative<hir::VoidType>(
-          module_->Unit().GetType(*type_id_or).data)) {
+          module_->Unit().types.Get(*type_id_or).data)) {
     throw InternalError(
         "StructuralScopeLowerer::PopulateVariableMember: variable declaration "
         "produced "

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -441,7 +441,8 @@ auto ModuleLowerer::InternType(
   }
   auto data_or = TranslateTypeData(*this, type, span);
   if (!data_or) return std::unexpected(std::move(data_or.error()));
-  const hir::TypeId id = unit_.AddType(*std::move(data_or), span);
+  const hir::TypeId id =
+      unit_.types.Add(hir::Type{.data = *std::move(data_or), .span = span});
   type_cache_.emplace(canonical, id);
   return id;
 }

--- a/src/lyra/lowering/hir_to_mir/cast_lowering.cpp
+++ b/src/lyra/lowering/hir_to_mir/cast_lowering.cpp
@@ -134,8 +134,8 @@ auto BuildValueConversion(
   if (src_type == dst_type) {
     return operand_expr;
   }
-  const auto& src_ty = unit.GetType(src_type);
-  const auto& dst_ty = unit.GetType(dst_type);
+  const auto& src_ty = unit.types.Get(src_type);
+  const auto& dst_ty = unit.types.Get(dst_type);
   const auto src_kind = src_ty.Kind();
   const auto dst_kind = dst_ty.Kind();
 

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -44,7 +44,7 @@ namespace {
 // / external ref / external unit object) and named events (LRM 15 -- carry
 // their own subscribe mechanism) pass through unwrapped.
 auto MaybeWrapObservable(ModuleLowerer& module, mir::TypeId t) -> mir::TypeId {
-  const auto& data = module.Unit().GetType(t).data;
+  const auto& data = module.Unit().types.Get(t).data;
   const bool wrap = std::holds_alternative<mir::PackedArrayType>(data) ||
                     std::holds_alternative<mir::EnumType>(data) ||
                     std::holds_alternative<mir::StringType>(data) ||
@@ -59,7 +59,7 @@ auto MaybeWrapObservable(ModuleLowerer& module, mir::TypeId t) -> mir::TypeId {
   if (!wrap) {
     return t;
   }
-  return module.Unit().AddType(mir::TypeData{mir::ObservableType{.value = t}});
+  return module.Unit().types.Intern(mir::ObservableType{.value = t});
 }
 
 auto ChildScopeNameFor(std::size_t gen_index, std::string_view arm_tag)
@@ -172,20 +172,18 @@ auto EnumerateGenerateChildSpecs(
 
 auto MakeUniqueObjectPointer(ModuleLowerer& module, std::string scope_name)
     -> mir::TypeId {
-  const mir::TypeId object_type =
-      module.Unit().AddType(mir::ObjectType{.name = std::move(scope_name)});
-  return module.Unit().AddType(
-      mir::PointerType{
-          .pointee = object_type, .ownership = mir::PointerOwnership::kUnique});
+  const mir::TypeId object_type = module.Unit().types.Intern(
+      mir::ObjectType{.name = std::move(scope_name)});
+  return module.Unit().types.PointerTo(
+      object_type, mir::PointerOwnership::kUnique);
 }
 
 auto MakeUniqueExternalUnitPointer(ModuleLowerer& module, std::string unit_name)
     -> mir::TypeId {
-  const mir::TypeId object_type = module.Unit().AddType(
+  const mir::TypeId object_type = module.Unit().types.Intern(
       mir::ExternalUnitObjectType{.unit_name = std::move(unit_name)});
-  return module.Unit().AddType(
-      mir::PointerType{
-          .pointee = object_type, .ownership = mir::PointerOwnership::kUnique});
+  return module.Unit().types.PointerTo(
+      object_type, mir::PointerOwnership::kUnique);
 }
 
 // Builds an external-unit member type: a unique pointer to the unit's object,
@@ -197,7 +195,7 @@ auto MakeExternalUnitMemberType(
   mir::TypeId type =
       MakeUniqueExternalUnitPointer(module, std::move(unit_name));
   for (std::size_t i = 0; i < num_dims; ++i) {
-    type = module.Unit().AddType(mir::VectorType{.element = type});
+    type = module.Unit().types.Intern(mir::VectorType{.element = type});
   }
   return type;
 }
@@ -237,7 +235,7 @@ void EmitExternalUnitDimLevel(
     // The child's structural identity, fixed before its constructor runs.
     // Indices reflect the position this leaf occupies in its enclosing
     // dim chain (empty for a scalar instance).
-    const mir::TypeId indices_type = module.Unit().AddType(
+    const mir::TypeId indices_type = module.Unit().types.Intern(
         mir::UnpackedArrayType{
             .element_type = builtins.int32, .size = indices.size()});
     const mir::ExprId indices_id = block.exprs.Add(
@@ -307,7 +305,7 @@ void EmitExternalUnitDimLevel(
     }
     const mir::TypeId leaf_object_type =
         std::get<mir::PointerType>(
-            module.Unit().GetType(leaf_pointer_type).data)
+            module.Unit().types.Get(leaf_pointer_type).data)
             .pointee;
     const mir::ExprId leaf_deref_id = block.exprs.Add(
         mir::Expr{
@@ -329,7 +327,8 @@ void EmitExternalUnitDimLevel(
   }
 
   const mir::TypeId inner_type =
-      std::get<mir::VectorType>(module.Unit().GetType(chain_type).data).element;
+      std::get<mir::VectorType>(module.Unit().types.Get(chain_type).data)
+          .element;
   const std::span<const std::uint32_t> remaining_dims = dims.subspan(1);
   const std::uint32_t count = dims.front();
   for (std::uint32_t i = 0; i < count; ++i) {
@@ -402,7 +401,7 @@ void AppendExternalUnitConstruction(
   // the chain operations propagate down to it.
   mir::TypeId leaf_pointer_type = var.type;
   for (std::size_t i = 0; i < dims.size(); ++i) {
-    const auto& chain_data = module.Unit().GetType(leaf_pointer_type).data;
+    const auto& chain_data = module.Unit().types.Get(leaf_pointer_type).data;
     if (!std::holds_alternative<mir::VectorType>(chain_data)) {
       throw InternalError(
           "AppendExternalUnitConstruction: dims exceed member vector depth");
@@ -476,7 +475,7 @@ auto MaterializeCrossUnitRefTargets(ClassLowerer& lowerer, WalkFrame frame)
       // constructor body (see `InstallCrossUnitRefs`).
       const mir::TypeId leaf = module.TranslateType(cu.type);
       const mir::TypeId ext_type =
-          module.Unit().AddType(mir::ExternalRefType{.element = leaf});
+          module.Unit().types.Intern(mir::ExternalRefType{.element = leaf});
       const mir::MemberId var = mir_class.members.Add(
           mir::MemberDecl{.name = std::move(member_name), .type = ext_type});
       lowerer.AddCrossUnitRefTarget(mir::MemberRef{.var = var}, ext_type);
@@ -488,9 +487,8 @@ auto MaterializeCrossUnitRefTargets(ClassLowerer& lowerer, WalkFrame frame)
       // at the same wrapped cell -- otherwise the C++ types mismatch.
       const mir::TypeId leaf =
           MaybeWrapObservable(module, module.TranslateType(cu.type));
-      const mir::TypeId slot_type = module.Unit().AddType(
-          mir::PointerType{
-              .pointee = leaf, .ownership = mir::PointerOwnership::kBorrowed});
+      const mir::TypeId slot_type =
+          module.Unit().types.PointerTo(leaf, mir::PointerOwnership::kBorrowed);
       const mir::MemberId slot = mir_class.members.Add(
           mir::MemberDecl{.name = std::move(member_name), .type = slot_type});
       lowerer.AddCrossUnitRefTarget(mir::MemberRef{.var = slot}, slot_type);
@@ -543,7 +541,7 @@ auto BuildDownwardNavValue(
 
   mir::ExprId cur = ctor_block.exprs.Add(MakeSelfRefExpr(frame, self_ptr_type));
   for (std::size_t i = 0; i + 1 < hops.size(); ++i) {
-    const mir::TypeId indices_type = module.Unit().AddType(
+    const mir::TypeId indices_type = module.Unit().types.Intern(
         mir::UnpackedArrayType{
             .element_type = builtins.int32, .size = hops[i].indices.size()});
     const mir::ExprId indices_id = ctor_block.exprs.Add(
@@ -560,10 +558,8 @@ auto BuildDownwardNavValue(
                         {cur, string_literal(hops[i].name), indices_id}},
             .type = scope_ptr_type});
   }
-  const mir::TypeId void_ptr_type = module.Unit().AddType(
-      mir::PointerType{
-          .pointee = builtins.void_type,
-          .ownership = mir::PointerOwnership::kBorrowed});
+  const mir::TypeId void_ptr_type = module.Unit().types.PointerTo(
+      builtins.void_type, mir::PointerOwnership::kBorrowed);
   const mir::ExprId get_signal_id = ctor_block.exprs.Add(
       mir::Expr{
           .data =
@@ -592,7 +588,7 @@ auto BuildIndicesArrayExpr(
     index_exprs.push_back(block.exprs.Add(
         mir::MakeInt32Literal(builtins.int32, static_cast<std::int64_t>(idx))));
   }
-  const mir::TypeId indices_type = module.Unit().AddType(
+  const mir::TypeId indices_type = module.Unit().types.Intern(
       mir::UnpackedArrayType{
           .element_type = builtins.int32, .size = indices.size()});
   return block.exprs.Add(
@@ -708,10 +704,7 @@ void InstallCrossUnitRefs(
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
   ModuleLowerer& module = lowerer.Module();
   const auto& builtins = module.Unit().builtins;
-  const mir::TypeId scope_ptr_type = module.Unit().AddType(
-      mir::PointerType{
-          .pointee = module.Unit().AddType(mir::ScopeType{}),
-          .ownership = mir::PointerOwnership::kBorrowed});
+  const mir::TypeId scope_ptr_type = builtins.scope_ptr;
   const auto string_literal = [&](const std::string& s) -> mir::ExprId {
     return ctor_block.exprs.Add(
         mir::Expr{
@@ -798,7 +791,7 @@ void AppendProcessRegistration(
               mir::CallExpr{
                   .callee = mir::Direct{.target = body},
                   .arguments = {body_self}},
-          .type = module.Unit().builtins.coroutine});
+          .type = module.Unit().builtins.coroutine_void});
   const mir::ExprId reg_self =
       block.exprs.Add(MakeSelfRefExpr(activate_frame, self_ptr_type));
   const mir::ExprId reg_call = block.exprs.Add(
@@ -833,10 +826,7 @@ auto InstallPortConnections(
   mir::Block& resolve_block = *resolve_frame.current_block;
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
   ModuleLowerer& module = lowerer.Module();
-  const mir::TypeId scope_ptr_type = module.Unit().AddType(
-      mir::PointerType{
-          .pointee = module.Unit().AddType(mir::ScopeType{}),
-          .ownership = mir::PointerOwnership::kBorrowed});
+  const mir::TypeId scope_ptr_type = module.Unit().builtins.scope_ptr;
   for (const auto& pc : hir_scope.port_connections) {
     if (pc.direction == hir::PortDirection::kRef) {
       // Bind the child's reference member to the connected variable's cell in
@@ -863,13 +853,10 @@ auto InstallPortConnections(
                                         : head_member.source_name;
 
       const mir::TypeId value_type = module.TranslateType(alias.type);
-      const mir::TypeId ref_type = module.Unit().AddType(
-          mir::TypeData{
-              mir::RefType{.pointee = value_type, .is_const = false}});
-      const mir::TypeId slot_type = module.Unit().AddType(
-          mir::PointerType{
-              .pointee = ref_type,
-              .ownership = mir::PointerOwnership::kBorrowed});
+      const mir::TypeId ref_type = module.Unit().types.Intern(
+          mir::RefType{.pointee = value_type, .is_const = false});
+      const mir::TypeId slot_type = module.Unit().types.PointerTo(
+          ref_type, mir::PointerOwnership::kBorrowed);
       const mir::ExprId nav = resolve_block.exprs.Add(BuildDownwardNavValue(
           module, resolve_frame, head_name, alias.path, slot_type,
           scope_ptr_type));
@@ -983,17 +970,22 @@ void AppendOwnedChildConstruction(
   // these slots, the scalar holds one directly).
   const mir::TypeId child_ptr_type =
       std::holds_alternative<mir::VectorType>(
-          module.Unit().GetType(var.type).data)
-          ? std::get<mir::VectorType>(module.Unit().GetType(var.type).data)
+          module.Unit().types.Get(var.type).data)
+          ? std::get<mir::VectorType>(module.Unit().types.Get(var.type).data)
                 .element
           : var.type;
-  const auto& child_ptr_data = module.Unit().GetType(child_ptr_type).data;
+  const auto& child_ptr_data = module.Unit().types.Get(child_ptr_type).data;
   if (!std::holds_alternative<mir::PointerType>(child_ptr_data) ||
       std::get<mir::PointerType>(child_ptr_data).ownership !=
           mir::PointerOwnership::kUnique) {
     throw InternalError(
         "owned-child construction: target slot type is not a unique pointer");
   }
+  // Capture the pointee by id now. A reference into the type arena is a
+  // transient view: interning any later type into the arena invalidates it, and
+  // that happens below. Reads after that point go through the id.
+  const mir::TypeId child_pointee =
+      std::get<mir::PointerType>(child_ptr_data).pointee;
 
   const auto string_literal = [&](const std::string& s) -> mir::ExprId {
     return arm_block.exprs.Add(
@@ -1014,7 +1006,7 @@ void AppendOwnedChildConstruction(
   if (array_index.has_value()) {
     index_elems.push_back(*array_index);
   }
-  const mir::TypeId indices_type = module.Unit().AddType(
+  const mir::TypeId indices_type = module.Unit().types.Intern(
       mir::UnpackedArrayType{
           .element_type = builtins.int32, .size = index_elems.size()});
   const mir::ExprId indices_id = arm_block.exprs.Add(
@@ -1060,7 +1052,7 @@ void AppendOwnedChildConstruction(
   // half-attached scope in the parent's child relation.
   mir::ExprId child_ref_id{};
   if (std::holds_alternative<mir::VectorType>(
-          module.Unit().GetType(var.type).data)) {
+          module.Unit().types.Get(var.type).data)) {
     const mir::ExprId emplace_call_id = arm_block.exprs.Add(
         mir::Expr{
             .data =
@@ -1091,7 +1083,7 @@ void AppendOwnedChildConstruction(
     child_ref_id = arm_block.exprs.Add(
         mir::Expr{
             .data = mir::DerefExpr{.pointer = back_call_id},
-            .type = std::get<mir::PointerType>(child_ptr_data).pointee});
+            .type = child_pointee});
   } else {
     const mir::ExprId assign_id = arm_block.exprs.Add(
         mir::Expr{
@@ -1109,7 +1101,7 @@ void AppendOwnedChildConstruction(
     child_ref_id = arm_block.exprs.Add(
         mir::Expr{
             .data = mir::DerefExpr{.pointer = scalar_access_id},
-            .type = std::get<mir::PointerType>(child_ptr_data).pointee});
+            .type = child_pointee});
   }
 
   const mir::ExprId attach_call_id = arm_block.exprs.Add(
@@ -1389,7 +1381,8 @@ auto InstallGenerateOwnedChildScopes(ClassLowerer& lowerer, WalkFrame frame)
       mir::TypeId var_type = MakeUniqueObjectPointer(
           module, mir_class.nested_classes.Get(child_id).name);
       if (spec.is_repeated) {
-        var_type = module.Unit().AddType(mir::VectorType{.element = var_type});
+        var_type =
+            module.Unit().types.Intern(mir::VectorType{.element = var_type});
       }
       const mir::MemberId var_id = mir_class.members.Add(
           mir::MemberDecl{
@@ -1417,11 +1410,9 @@ auto ClassLowerer::Run(
   ClassLowerer& lowerer = *this;
 
   const mir::TypeId self_object_type =
-      module.Unit().AddType(mir::ObjectType{.name = name_});
-  const mir::TypeId self_pointer_type = module.Unit().AddType(
-      mir::PointerType{
-          .pointee = self_object_type,
-          .ownership = mir::PointerOwnership::kBorrowed});
+      module.Unit().types.Intern(mir::ObjectType{.name = name_});
+  const mir::TypeId self_pointer_type = module.Unit().types.PointerTo(
+      self_object_type, mir::PointerOwnership::kBorrowed);
   mir::Class mir_class{
       .name = name_,
       .base = mir::ClassRef{mir::RuntimeLibraryClassRef{
@@ -1470,7 +1461,7 @@ auto ClassLowerer::Run(
       frame.WithClass(&mir_class, outer_scope_link)
           .WithBlock(&ctor_block)
           .WithSelfBinding(self_id, frame.block_depth);
-  const mir::TypeId void_type = module.Unit().AddType(mir::VoidType{});
+  const mir::TypeId void_type = module.Unit().builtins.void_type;
   const mir::TypeId self_ptr_type = mir_class.self_pointer_type;
   const auto self_read = [&]() -> mir::ExprId {
     return ctor_block.exprs.Add(MakeSelfRefExpr(scope_frame, self_ptr_type));
@@ -1521,7 +1512,11 @@ auto ClassLowerer::Run(
     const auto& d = hir_scope.structural_vars.Get(hir_id);
     const mir::TypeId mir_value_type = module.TranslateType(d.type);
 
-    const auto& var_data = module.Unit().GetType(mir_value_type).data;
+    // The value type's kind classifies the member in the checks below: a plain
+    // value is an assignable signal; a pointer / vector / object / ref slot is
+    // not.
+    const mir::TypeKind var_kind =
+        module.Unit().types.Get(mir_value_type).Kind();
     const bool is_reference = d.reference.has_value();
     // A `ref` / `const ref` port member aliases the connected variable, filled
     // by the parent at construction (LRM 23.3.3.2): its type is a reference,
@@ -1529,11 +1524,11 @@ auto ClassLowerer::Run(
     // Any other module-scope value-storage signal becomes an observable cell so
     // writes route through `Var<T>::Set` and subscribers fire.
     const mir::TypeId mir_field_type =
-        is_reference ? module.Unit().AddType(
-                           mir::TypeData{mir::RefType{
+        is_reference ? module.Unit().types.Intern(
+                           mir::RefType{
                                .pointee = mir_value_type,
                                .is_const = *d.reference ==
-                                           hir::ReferenceBinding::kConstRef}})
+                                           hir::ReferenceBinding::kConstRef})
                      : MaybeWrapObservable(module, mir_value_type);
     const mir::MemberId mir_id = mir_class.members.Add(
         mir::MemberDecl{.name = d.name, .type = mir_field_type});
@@ -1546,12 +1541,12 @@ auto ClassLowerer::Run(
     // initialization statement, run in the initialize phase after the tree's
     // references resolve, not in the constructor.
     const bool is_assignable_value =
-        !is_reference && !std::holds_alternative<mir::PointerType>(var_data) &&
-        !std::holds_alternative<mir::VectorType>(var_data) &&
-        !std::holds_alternative<mir::ExternalRefType>(var_data) &&
-        !std::holds_alternative<mir::ObjectType>(var_data) &&
-        !std::holds_alternative<mir::ExternalUnitObjectType>(var_data) &&
-        !std::holds_alternative<mir::EventType>(var_data);
+        !is_reference && var_kind != mir::TypeKind::kPointer &&
+        var_kind != mir::TypeKind::kVector &&
+        var_kind != mir::TypeKind::kExternalRef &&
+        var_kind != mir::TypeKind::kObject &&
+        var_kind != mir::TypeKind::kExternalUnitObject &&
+        var_kind != mir::TypeKind::kEvent;
     if (is_assignable_value) {
       mir::ExprId value_id{};
       if (d.initializer.has_value()) {
@@ -1585,20 +1580,17 @@ auto ClassLowerer::Run(
     // cross-unit referrer resolves it by name at construction. The excluded
     // members -- owned children and cross-unit reference slots -- are not
     // signals.
-    const bool is_signal =
-        !std::holds_alternative<mir::PointerType>(var_data) &&
-        !std::holds_alternative<mir::VectorType>(var_data) &&
-        !std::holds_alternative<mir::ExternalRefType>(var_data) &&
-        !std::holds_alternative<mir::ObjectType>(var_data) &&
-        !std::holds_alternative<mir::ExternalUnitObjectType>(var_data);
+    const bool is_signal = var_kind != mir::TypeKind::kPointer &&
+                           var_kind != mir::TypeKind::kVector &&
+                           var_kind != mir::TypeKind::kExternalRef &&
+                           var_kind != mir::TypeKind::kObject &&
+                           var_kind != mir::TypeKind::kExternalUnitObject;
     if (is_signal) {
       const mir::ExprId var_ref = ctor_block.exprs.Add(
           mir::MakeMemberAccessExpr(
               self_read(), mir::MemberRef{.var = mir_id}, mir_field_type));
-      const mir::TypeId var_ptr_type = module.Unit().AddType(
-          mir::PointerType{
-              .pointee = mir_field_type,
-              .ownership = mir::PointerOwnership::kBorrowed});
+      const mir::TypeId var_ptr_type = module.Unit().types.PointerTo(
+          mir_field_type, mir::PointerOwnership::kBorrowed);
       const mir::ExprId addr_id =
           ctor_block.exprs.Add(mir::MakeAddressOfExpr(var_ref, var_ptr_type));
       const mir::ExprId name_id = ctor_block.exprs.Add(

--- a/src/lyra/lowering/hir_to_mir/closure_builder.cpp
+++ b/src/lyra/lowering/hir_to_mir/closure_builder.cpp
@@ -95,7 +95,7 @@ auto ClosureBuilder::Build(mir::ExprId result) -> mir::Expr {
 auto ClosureBuilder::BuildCoroutine() -> mir::Expr {
   body_.AppendStmt(
       mir::ReturnStmt{.value = std::nullopt, .is_coroutine_return = true});
-  return Finish(unit_->builtins.coroutine);
+  return Finish(unit_->builtins.coroutine_void);
 }
 
 auto ClosureBuilder::BuildVoid() -> mir::Expr {

--- a/src/lyra/lowering/hir_to_mir/completion_payload.cpp
+++ b/src/lyra/lowering/hir_to_mir/completion_payload.cpp
@@ -29,13 +29,7 @@ auto NormalizeCompletionPayload(
     -> mir::TypeId {
   if (components.empty()) return unit.builtins.void_type;
   if (components.size() == 1) return components.front();
-  return unit.AddType(mir::TypeData{mir::TupleType{.elements = components}});
-}
-
-auto CoroutineOf(mir::CompilationUnit& unit, mir::TypeId payload)
-    -> mir::TypeId {
-  if (payload == unit.builtins.void_type) return unit.builtins.coroutine;
-  return unit.AddType(mir::TypeData{mir::CoroutineType{.payload = payload}});
+  return unit.types.Intern(mir::TupleType{.elements = components});
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -86,7 +86,7 @@ auto LowerContinuousAssign(
       .code =
           mir::CallableCode{
               .params = {self_id},
-              .result_type = lowerer.Module().Unit().builtins.coroutine,
+              .result_type = lowerer.Module().Unit().builtins.coroutine_void,
               .body = std::move(process_block)},
       .overrides = std::nullopt};
 }

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -54,7 +54,7 @@ auto BuildDefaultValueExpr(
     const ModuleLowerer& module, WalkFrame frame, mir::TypeId type)
     -> mir::Expr {
   auto& block = *frame.current_block;
-  const auto& ty = module.Unit().GetType(type);
+  const auto& ty = module.Unit().types.Get(type);
   return std::visit(
       Overloaded{
           [&](const mir::PackedArrayType& pa) -> mir::Expr {
@@ -212,7 +212,7 @@ auto BuildArrayConstructionCall(
     const ModuleLowerer& module, WalkFrame frame, mir::TypeId array_type,
     std::vector<mir::ExprId> elements) -> mir::Expr {
   auto& block = *frame.current_block;
-  const auto& ty = module.Unit().GetType(array_type);
+  const auto& ty = module.Unit().types.Get(array_type);
   const mir::TypeId element_type = std::visit(
       [](const auto& t) -> mir::TypeId {
         using TyT = std::decay_t<decltype(t)>;
@@ -258,7 +258,7 @@ auto BuildAssociativeConstructionCall(
     std::optional<mir::ExprId> user_default) -> mir::Expr {
   auto& block = *frame.current_block;
   const auto* assoc = std::get_if<mir::AssociativeArrayType>(
-      &module.Unit().GetType(assoc_type).data);
+      &module.Unit().types.Get(assoc_type).data);
   if (assoc == nullptr) {
     throw InternalError(
         "BuildAssociativeConstructionCall: result type is not "
@@ -267,7 +267,7 @@ auto BuildAssociativeConstructionCall(
   const mir::TypeId key_type = assoc->key_type;
   const mir::TypeId element_type = assoc->element_type;
 
-  const mir::TypeId tuple_type = module.Unit().AddType(
+  const mir::TypeId tuple_type = module.Unit().types.Intern(
       mir::TupleType{.elements = {key_type, element_type}});
   std::vector<mir::ExprId> tuple_ids;
   tuple_ids.reserve(entries.size());
@@ -277,7 +277,7 @@ auto BuildAssociativeConstructionCall(
             .data = mir::TupleExpr{.components = {key_id, value_id}},
             .type = tuple_type}));
   }
-  const mir::TypeId entries_type = module.Unit().AddType(
+  const mir::TypeId entries_type = module.Unit().types.Intern(
       mir::UnpackedArrayType{
           .element_type = tuple_type,
           .size = static_cast<std::uint64_t>(tuple_ids.size())});

--- a/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
@@ -113,7 +113,7 @@ auto LowerHirAssignmentPatternExpr(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     element_ids.push_back(block.exprs.Add(*std::move(lowered)));
   }
-  if (IsArrayContainerType(lowerer.Module().Unit().GetType(result_type))) {
+  if (IsArrayContainerType(lowerer.Module().Unit().types.Get(result_type))) {
     return BuildArrayConstructionCall(
         lowerer.Module(), frame, result_type, std::move(element_ids));
   }
@@ -135,7 +135,7 @@ auto LowerHirAssignmentPatternReplicationExpr(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     item_ids.push_back(block.exprs.Add(*std::move(lowered)));
   }
-  if (IsArrayContainerType(lowerer.Module().Unit().GetType(result_type))) {
+  if (IsArrayContainerType(lowerer.Module().Unit().types.Get(result_type))) {
     const std::uint64_t count =
         ExtractHirLiteralUint64(lowerer.HirExprs().Get(a.count));
     return BuildArrayReplicationFlatList(
@@ -171,7 +171,7 @@ auto LowerHirDynamicArrayNewExprProc(
   if (!size_or) return std::unexpected(std::move(size_or.error()));
   const mir::ExprId size_id = block.exprs.Add(*std::move(size_or));
 
-  const auto& result_ty = process.Module().Unit().GetType(result_type);
+  const auto& result_ty = process.Module().Unit().types.Get(result_type);
   const auto* da = std::get_if<mir::DynamicArrayType>(&result_ty.data);
   if (da == nullptr) {
     throw InternalError(

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -319,7 +319,8 @@ auto LowerStringElementAssign(
           mir::ExprId services) -> mir::Expr {
         mir::ExprId recv = target;
         const mir::ExprId root = FindLhsRootId(blk, target);
-        if (mir::IsObservableCellType(unit.GetType(blk.exprs.Get(root).type))) {
+        if (mir::IsObservableCellType(
+                unit.types.Get(blk.exprs.Get(root).type))) {
           recv = RewriteLhsRootWithMutate(unit, blk, target, services);
         }
         return MakeStringMethodCallExpr(
@@ -345,7 +346,7 @@ auto LowerHirAssignExprProc(
   const auto& hir_process = process.HirBody();
   const hir::Expr& hir_lhs = hir_process.exprs.Get(a.lhs);
   if (const auto* sel = std::get_if<hir::ElementSelectExpr>(&hir_lhs.data)) {
-    const hir::Type& base_ty = process.Module().Hir().GetType(
+    const hir::Type& base_ty = process.Module().Hir().types.Get(
         hir_process.exprs.Get(sel->base_value).type);
     if (base_ty.Kind() == hir::TypeKind::kString) {
       return LowerStringElementAssign(

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -55,7 +55,7 @@ auto MaybeWrapObservableLhsWithMutate(
     -> mir::ExprId {
   const mir::ExprId root_id = FindLhsRootId(block, lhs_id);
   const bool root_is_cell = mir::IsObservableCellType(
-      lowerer.Module().Unit().GetType(block.exprs.Get(root_id).type));
+      lowerer.Module().Unit().types.Get(block.exprs.Get(root_id).type));
   if (!root_is_cell) return lhs_id;
   const mir::ExprId services_id =
       block.exprs.Add(BuildServicesCallExpr(lowerer.Module(), frame));
@@ -185,7 +185,7 @@ auto ArrayMethodResultProtoType(
           [](const mir::AssociativeArrayType& t) { return t.element_type; },
           [result_type](const auto&) { return result_type; },
       },
-      module.Unit().GetType(result_type).data);
+      module.Unit().types.Get(result_type).data);
 }
 
 // LRM 7.12.1 / 7.12.2 / 7.12.3 with-clause closure synthesis. The element and
@@ -202,7 +202,7 @@ auto BuildArrayMethodClosure(
     const hir::WithClause* with_clause) -> diag::Result<mir::Expr> {
   const auto& module = lowerer.Module();
   const auto& hir_exprs = lowerer.HirExprs();
-  const auto& hir_recv_ty = module.Hir().GetType(hir_receiver_type);
+  const auto& hir_recv_ty = module.Hir().types.Get(hir_receiver_type);
   const auto element_type = ArrayMethodReceiverElementType(hir_recv_ty);
   if (!element_type.has_value()) {
     throw InternalError(

--- a/src/lyra/lowering/hir_to_mir/expression/dispatch.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/dispatch.cpp
@@ -133,7 +133,7 @@ auto LowerExprImpl(L& lowerer, const hir::Expr& expr, WalkFrame frame)
       expr.data);
   if (!raw_or) return raw_or;
   if (mir::IsObservableCellType(
-          lowerer.Module().Unit().GetType(raw_or->type))) {
+          lowerer.Module().Unit().types.Get(raw_or->type))) {
     const mir::ExprId cell_id =
         frame.current_block->exprs.Add(*std::move(raw_or));
     return mir::MakeObservableGetCallExpr(cell_id, result_type);

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -286,7 +286,7 @@ auto BuildRealOrStringLogicalLift(
 auto BuildMirUnaryExpr(
     const mir::CompilationUnit& unit, mir::Block& block, mir::UnaryOp op,
     mir::ExprId operand_id, mir::TypeId result_type) -> mir::Expr {
-  const auto& operand_ty = unit.GetType(block.exprs.Get(operand_id).type);
+  const auto& operand_ty = unit.types.Get(block.exprs.Get(operand_id).type);
 
   // LRM 11.4.9 reduction operators: render as `PackedArray::ReductionX()`,
   // routed through a `Direct` builtin call so the backend's render path
@@ -319,8 +319,8 @@ auto BuildMirBinaryExpr(
     const mir::CompilationUnit& unit, mir::Block& block, mir::BinaryOp op,
     mir::ExprId lhs_id, mir::ExprId rhs_id, mir::TypeId result_type)
     -> mir::Expr {
-  const auto& lhs_ty = unit.GetType(block.exprs.Get(lhs_id).type);
-  const auto& rhs_ty = unit.GetType(block.exprs.Get(rhs_id).type);
+  const auto& lhs_ty = unit.types.Get(block.exprs.Get(lhs_id).type);
+  const auto& rhs_ty = unit.types.Get(block.exprs.Get(rhs_id).type);
   const bool real_lhs = IsRealFamilyType(lhs_ty);
   const bool real_rhs = IsRealFamilyType(rhs_ty);
   const bool string_lhs = lhs_ty.Kind() == mir::TypeKind::kString;
@@ -464,7 +464,7 @@ auto LowerHirIncDecExprProc(
   // a `ScopedMutation` snapshot so subscribers fire once on destructor commit.
   const mir::ExprId root_id = FindLhsRootId(block, target_id);
   if (mir::IsObservableCellType(
-          process.Module().Unit().GetType(block.exprs.Get(root_id).type))) {
+          process.Module().Unit().types.Get(block.exprs.Get(root_id).type))) {
     const mir::ExprId services_id =
         block.exprs.Add(BuildServicesCallExpr(process.Module(), frame));
     target_id = RewriteLhsRootWithMutate(

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -113,7 +113,7 @@ auto StringBytesToConstant(
 auto LowerHirStringLiteral(
     const ModuleLowerer& module, const WalkFrame& frame,
     const hir::StringLiteral& s, mir::TypeId type) -> mir::Expr {
-  const auto& ty = module.Unit().GetType(type);
+  const auto& ty = module.Unit().types.Get(type);
   if (ty.IsIntegralPacked()) {
     return mir::Expr{
         .data =
@@ -216,7 +216,7 @@ auto LowerCrossUnitVarRefExpr(
   const mir::ExprId self_ref =
       frame.current_block->exprs.Add(MakeSelfRefExpr(frame, self_ptr_type));
   const auto* ptr = std::get_if<mir::PointerType>(
-      &lowerer.Module().Unit().GetType(meta.slot_type).data);
+      &lowerer.Module().Unit().types.Get(meta.slot_type).data);
   if (ptr != nullptr && ptr->ownership == mir::PointerOwnership::kBorrowed) {
     const mir::ExprId pointer = frame.current_block->exprs.Add(
         mir::MakeMemberAccessExpr(self_ref, target, meta.slot_type));

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -82,7 +82,7 @@ auto WrapPackedAsOwned(
     const mir::CompilationUnit& unit, mir::Block& block, mir::Expr access_call,
     mir::TypeId result_type) -> mir::Expr {
   if (!std::holds_alternative<mir::PackedArrayType>(
-          unit.GetType(result_type).data)) {
+          unit.types.Get(result_type).data)) {
     return access_call;
   }
   const mir::ExprId access_id = block.exprs.Add(std::move(access_call));
@@ -102,13 +102,13 @@ auto WrapPackedAsOwned(
 // then re-tags to the consumer's signed type.
 auto UnsignedPackedCounterpart(
     mir::CompilationUnit& unit, mir::TypeId result_type) -> mir::TypeId {
-  const auto& ty = unit.GetType(result_type);
+  const auto& ty = unit.types.Get(result_type);
   if (!ty.IsPackedArray()) return result_type;
   const auto& pa = ty.AsPackedArray();
   if (pa.signedness == mir::Signedness::kUnsigned) return result_type;
   auto unsigned_pa = pa;
   unsigned_pa.signedness = mir::Signedness::kUnsigned;
-  return unit.AddType(mir::TypeData{std::move(unsigned_pa)});
+  return unit.types.Intern(std::move(unsigned_pa));
 }
 
 // Wraps a slice result that was rendered at `slice_type` (unsigned) with an
@@ -172,7 +172,7 @@ auto BuildOffsetDeltaExpr(
     const ModuleLowerer& module, mir::Block& block, mir::ExprId base,
     std::int64_t value, mir::BinaryOp op) -> mir::Expr {
   const auto base_type = block.exprs.Get(base).type;
-  const auto& base_ty = module.Unit().GetType(base_type);
+  const auto& base_ty = module.Unit().types.Get(base_type);
   const bool four_state =
       base_ty.IsIntegralPacked() && base_ty.AsIntegralPacked().IsFourState();
   const auto delta_lit = block.exprs.Add(
@@ -531,7 +531,7 @@ auto BuildRangeSliceCallExpr(
     strategy.container = RangeContainer::kQueue;
   } else if (
       const auto* ua = std::get_if<hir::UnpackedArrayType>(&hir_base_ty.data)) {
-    const auto& result_ty = module.Unit().GetType(result_type);
+    const auto& result_ty = module.Unit().types.Get(result_type);
     strategy.container = RangeContainer::kUnpacked;
     strategy.unpacked_declared = &ua->dim;
     strategy.unpacked_count = static_cast<std::uint32_t>(
@@ -561,7 +561,8 @@ auto BuildRangeSliceCallExpr(
                 .arguments = {base_id, bounds_or->lo, bounds_or->hi}},
         .type = result_type};
   }
-  const auto count = SliceResultOuterCount(module.Unit().GetType(result_type));
+  const auto count =
+      SliceResultOuterCount(module.Unit().types.Get(result_type));
   const auto count_id = block.exprs.Add(
       mir::MakeInt32Literal(
           module.Unit().builtins.int32, static_cast<std::int64_t>(count)));
@@ -682,7 +683,7 @@ auto LowerHirElementSelectExpr(
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
 
-  const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
+  const auto& hir_base_ty = module.Hir().types.Get(hir_base.type);
   // LRM 6.16.3: a string has no element lvalue, so an index read realizes as
   // the getc query (the write side realizes as putc in the assignment path).
   if (hir_base_ty.Kind() == hir::TypeKind::kString) {
@@ -726,7 +727,7 @@ auto LowerHirRangeSelectExpr(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     return block.exprs.Add(*std::move(lowered));
   };
-  const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
+  const auto& hir_base_ty = module.Hir().types.Get(hir_base.type);
   return LowerRangeSelectInner(
       module, block, hir_base_ty, sel.bounds, base_id, result_type, lower_one,
       AccessSide::kRead);
@@ -746,7 +747,7 @@ auto LowerHirMemberAccessExpr(
   const auto& base_hir_expr = exprs.Get(sel.base_value);
   // LRM 7.2: an unpacked struct lowers to a generic product (`TupleType`);
   // member access is a positional projection by declaration-order index.
-  if (module.Hir().GetType(base_hir_expr.type).Kind() ==
+  if (module.Hir().types.Get(base_hir_expr.type).Kind() ==
       hir::TypeKind::kUnpackedStruct) {
     auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
     if (!base_or) return std::unexpected(std::move(base_or.error()));
@@ -756,7 +757,7 @@ auto LowerHirMemberAccessExpr(
         .type = result_type};
   }
   const auto& fields =
-      GetAggregateFields(module.Hir().GetType(base_hir_expr.type));
+      GetAggregateFields(module.Hir().types.Get(base_hir_expr.type));
   if (sel.field_index >= fields.size()) {
     throw InternalError("LowerHirMemberAccessExpr: field_index out of range");
   }
@@ -786,7 +787,7 @@ auto LowerHirElementSelectExprLhs(
   if (!idx_or) return std::unexpected(std::move(idx_or.error()));
   const mir::ExprId idx_id = block.exprs.Add(*std::move(idx_or));
 
-  const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
+  const auto& hir_base_ty = module.Hir().types.Get(hir_base.type);
   return LowerElementSelectInner(
       module, block, hir_base_ty, module.TranslateType(hir_idx.type), base_id,
       idx_id, AccessSide::kLhs, result_type, false);
@@ -810,7 +811,7 @@ auto LowerHirRangeSelectExprLhs(
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     return block.exprs.Add(*std::move(lowered));
   };
-  const auto& hir_base_ty = module.Hir().GetType(hir_base.type);
+  const auto& hir_base_ty = module.Hir().types.Get(hir_base.type);
   return LowerRangeSelectInner(
       module, block, hir_base_ty, sel.bounds, base_id, result_type, lower_one,
       AccessSide::kLhs);
@@ -827,7 +828,7 @@ auto LowerHirMemberAccessExprLhs(
   // LRM 7.2: an unpacked-struct member write is a positional projection by
   // index over the base place. The observable root's write routes through the
   // cell's mutate path later, so the place is just the projection here.
-  if (module.Hir().GetType(base_hir_expr.type).Kind() ==
+  if (module.Hir().types.Get(base_hir_expr.type).Kind() ==
       hir::TypeKind::kUnpackedStruct) {
     auto base_or = lowerer.LowerLhsExpr(base_hir_expr, frame);
     if (!base_or) return std::unexpected(std::move(base_or.error()));
@@ -837,7 +838,7 @@ auto LowerHirMemberAccessExprLhs(
         .type = result_type};
   }
   const auto& fields =
-      GetAggregateFields(module.Hir().GetType(base_hir_expr.type));
+      GetAggregateFields(module.Hir().types.Get(base_hir_expr.type));
   if (sel.field_index >= fields.size()) {
     throw InternalError(
         "LowerHirMemberAccessExprLhs: field_index out of range");

--- a/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
@@ -216,7 +216,7 @@ auto LowerFileIOSystemSubroutineCallStmt(
       // generic CallExpr whose operands are the temp, the descriptor, and --
       // for the memory form -- the declared bounds plus start / count.
       const auto& dest_hir = hir_proc.exprs.Get(*call.arguments[0]);
-      const auto& dest_hir_ty = module.Hir().GetType(dest_hir.type);
+      const auto& dest_hir_ty = module.Hir().types.Get(dest_hir.type);
       const auto& builtins = process.Module().Unit().builtins;
       const auto* unpacked =
           std::get_if<hir::UnpackedArrayType>(&dest_hir_ty.data);
@@ -236,7 +236,7 @@ auto LowerFileIOSystemSubroutineCallStmt(
         // Memory form. Only 1D unpacked of integral packed elements is in
         // scope; struct / union / multi-dim / dynamic-array element types
         // are deferred.
-        const auto& elem_ty = module.Hir().GetType(unpacked->element_type);
+        const auto& elem_ty = module.Hir().types.Get(unpacked->element_type);
         if (!std::holds_alternative<hir::PackedArrayType>(elem_ty.data)) {
           return diag::Fail(
               diag::DiagCode::kUnsupportedSubroutineArgument,

--- a/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/scan.cpp
@@ -37,13 +37,13 @@ namespace {
 auto LiftStringSource(
     const ModuleLowerer& module, WalkFrame frame, mir::TypeId source_type,
     mir::ExprId source_id) -> mir::ExprId {
-  const mir::TypeKind kind = module.Unit().GetType(source_type).Kind();
+  const mir::TypeKind kind = module.Unit().types.Get(source_type).Kind();
   if (kind == mir::TypeKind::kString) return source_id;
 
   if (kind == mir::TypeKind::kUnpackedArray) {
     const auto& ua = std::get<mir::UnpackedArrayType>(
-        module.Unit().GetType(source_type).data);
-    const auto& elem = module.Unit().GetType(ua.element_type);
+        module.Unit().types.Get(source_type).data);
+    const auto& elem = module.Unit().types.Get(ua.element_type);
     if (!elem.IsIntegralPacked() || elem.AsIntegralPacked().BitWidth() != 8U) {
       throw InternalError(
           "LiftStringSource: $sscanf unpacked-array source must have an "
@@ -65,7 +65,7 @@ auto LiftStringSource(
 auto LiftStringFormat(
     const ModuleLowerer& module, WalkFrame frame, mir::TypeId format_type,
     mir::ExprId format_id) -> mir::ExprId {
-  const auto& t = module.Unit().GetType(format_type);
+  const auto& t = module.Unit().types.Get(format_type);
   if (t.Kind() == mir::TypeKind::kString) return format_id;
   if (!t.IsIntegralPacked()) {
     throw InternalError(
@@ -106,7 +106,7 @@ auto ValidateTargetType(
     const mir::CompilationUnit& unit, mir::TypeId mir_type,
     support::ScanSourceKind source_kind, diag::SourceSpan span)
     -> diag::Result<void> {
-  const auto& target = unit.GetType(mir_type);
+  const auto& target = unit.types.Get(mir_type);
   if (target.Kind() == mir::TypeKind::kString) return {};
   if (target.IsIntegralPacked()) return {};
   return diag::Fail(
@@ -176,7 +176,7 @@ auto LowerScanSystemSubroutineCall(
   mir::ExprId source_id{};
   mir::ExprId fd_id{};
   if (is_file) {
-    if (unit.GetType(raw_source_type).Kind() != mir::TypeKind::kPackedArray) {
+    if (unit.types.Get(raw_source_type).Kind() != mir::TypeKind::kPackedArray) {
       throw InternalError(
           "LowerScanSystemSubroutineCall: $fscanf fd is not packed-integer");
     }

--- a/src/lyra/lowering/hir_to_mir/expression/system/sformat.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/sformat.cpp
@@ -112,7 +112,7 @@ auto LowerSFormatSystemSubroutineCallStmt(
   if (!out_or) return std::unexpected(std::move(out_or.error()));
   const mir::TypeId out_type = process.Module().TranslateType(
       hir_proc.exprs.Get(*call.arguments[0]).type);
-  if (process.Module().Unit().GetType(out_type).Kind() !=
+  if (process.Module().Unit().types.Get(out_type).Kind() !=
       mir::TypeKind::kString) {
     return RejectNonStringOutput(name, span);
   }

--- a/src/lyra/lowering/hir_to_mir/lhs_observable.cpp
+++ b/src/lyra/lowering/hir_to_mir/lhs_observable.cpp
@@ -52,13 +52,17 @@ auto RewriteLhsRootWithMutate(
   }
   if (AsContainerAccessBase(expr) != nullptr) {
     auto rewritten_call = std::get<mir::CallExpr>(expr.data);
+    // Read the type out before the recursive rewrite below: that recursion
+    // appends to the same expression arena, which invalidates the `expr`
+    // reference.
+    const mir::TypeId expr_type = expr.type;
     rewritten_call.arguments.front() = RewriteLhsRootWithMutate(
         unit, block, rewritten_call.arguments.front(), services_id);
     return block.exprs.Add(
-        mir::Expr{.data = std::move(rewritten_call), .type = expr.type});
+        mir::Expr{.data = std::move(rewritten_call), .type = expr_type});
   }
   const mir::TypeId value_type =
-      mir::ObservableInnerValueType(unit.GetType(expr.type));
+      mir::ObservableInnerValueType(unit.types.Get(expr.type));
   const mir::ExprId mutate_id = block.exprs.Add(
       mir::MakeObservableMutateCallExpr(lhs_id, services_id, value_type));
   return block.exprs.Add(
@@ -73,7 +77,7 @@ auto BuildObservableAssignExpr(
     mir::TypeId void_type) -> mir::Expr {
   const mir::ExprId root_id = FindLhsRootId(block, lhs_id);
   const bool root_is_cell =
-      mir::IsObservableCellType(unit.GetType(block.exprs.Get(root_id).type));
+      mir::IsObservableCellType(unit.types.Get(block.exprs.Get(root_id).type));
   if (!root_is_cell) {
     return mir::Expr{
         .data =

--- a/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
@@ -17,9 +17,10 @@ auto ModuleLowerer::Run() -> diag::Result<mir::CompilationUnit> {
 
   for (std::size_t i = 0; i < hir_->types.size(); ++i) {
     const hir::TypeId hir_id{static_cast<std::uint32_t>(i)};
-    auto mir_data = TranslateTypeData(hir_->types[i].data, hir_->types[i].span);
+    const hir::Type& hir_type = hir_->types.Get(hir_id);
+    auto mir_data = TranslateTypeData(hir_type.data, hir_type.span);
     if (!mir_data) return std::unexpected(std::move(mir_data.error()));
-    const mir::TypeId mir_id = unit_.AddType(*std::move(mir_data));
+    const mir::TypeId mir_id = unit_.types.Intern(*std::move(mir_data));
     MapType(hir_id, mir_id);
   }
 

--- a/src/lyra/lowering/hir_to_mir/print_items.cpp
+++ b/src/lyra/lowering/hir_to_mir/print_items.cpp
@@ -83,7 +83,7 @@ auto BuildPrintValueItem(
   // each format directly, without building a string value. Only an unpacked
   // byte array is not directly formattable, so it lifts to a string value
   // here.
-  const auto& value_type = process.Module().Unit().GetType(lowered.type);
+  const auto& value_type = process.Module().Unit().types.Get(lowered.type);
   if (spec.kind == value::FormatKind::kString &&
       value_type.Kind() != mir::TypeKind::kString &&
       !value_type.IsIntegralPacked()) {
@@ -338,9 +338,9 @@ auto BuildPrintItemsArray(
     elements.push_back(block.exprs.Add(
         BuildPrintItemExpr(unit, block, item, time_unit_power)));
   }
-  const mir::TypeId array_type = unit.AddType(
-      mir::TypeData{mir::UnpackedArrayType{
-          .element_type = unit.builtins.print_item, .size = items.size()}});
+  const mir::TypeId array_type = unit.types.Intern(
+      mir::UnpackedArrayType{
+          .element_type = unit.builtins.print_item, .size = items.size()});
   return mir::Expr{
       .data = mir::ArrayLiteralExpr{.elements = std::move(elements)},
       .type = array_type};

--- a/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/process_lowerer.cpp
@@ -124,7 +124,7 @@ auto LowerStraightLineProcess(ProcessLowerer& process)
       .code =
           mir::CallableCode{
               .params = {self_id},
-              .result_type = process.Module().Unit().builtins.coroutine,
+              .result_type = process.Module().Unit().builtins.coroutine_void,
               .body = std::move(process_block)},
       .overrides = std::nullopt};
 }
@@ -174,7 +174,7 @@ auto LowerForeverProcess(
       .code =
           mir::CallableCode{
               .params = {self_id},
-              .result_type = process.Module().Unit().builtins.coroutine,
+              .result_type = process.Module().Unit().builtins.coroutine_void,
               .body = std::move(process_block)},
       .overrides = std::nullopt};
 }
@@ -246,10 +246,10 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
                               dir == hir::ParamDirection::kConstRef;
     const mir::TypeId type =
         by_reference
-            ? module_->Unit().AddType(
-                  mir::TypeData{mir::RefType{
+            ? module_->Unit().types.Intern(
+                  mir::RefType{
                       .pointee = value_type,
-                      .is_const = dir == hir::ParamDirection::kConstRef}})
+                      .is_const = dir == hir::ParamDirection::kConstRef})
             : value_type;
     const mir::LocalId mir_var =
         body_block.vars.Add(mir::LocalDecl{.name = hir_var.name, .type = type});
@@ -297,8 +297,9 @@ auto ProcessLowerer::Run(const hir::StructuralSubroutineDecl& src)
   completion_payload_type_ =
       NormalizeCompletionPayload(module_->Unit(), payload_components);
   const mir::TypeId result_type =
-      body_is_coroutine ? CoroutineOf(module_->Unit(), completion_payload_type_)
-                        : completion_payload_type_;
+      body_is_coroutine
+          ? module_->Unit().types.CoroutineOf(completion_payload_type_)
+          : completion_payload_type_;
 
   auto lowered = LowerStraightLineBodyInto(*this, body_frame);
   if (!lowered) return std::unexpected(std::move(lowered.error()));

--- a/src/lyra/lowering/hir_to_mir/self_ref.cpp
+++ b/src/lyra/lowering/hir_to_mir/self_ref.cpp
@@ -57,7 +57,7 @@ auto BuildStructuralMemberAccessExpr(
 auto BuildReferenceArg(
     mir::CompilationUnit& unit, mir::Block& block, mir::ExprId cell,
     mir::TypeId pointee) -> mir::ExprId {
-  const auto& pointee_ty = unit.GetType(pointee);
+  const auto& pointee_ty = unit.types.Get(pointee);
   // Referencing a value that is itself a reference seals to the same final
   // cell: a `Ref<T>` taken over a `Ref<T>` aliases what that reference aliases,
   // never nesting into `Ref<Ref<T>>` (LRM 23.3.3.2). The argument is the
@@ -75,8 +75,8 @@ auto BuildReferenceArg(
   if (std::holds_alternative<mir::ObservableType>(pointee_ty.data)) {
     pointee = std::get<mir::ObservableType>(pointee_ty.data).value;
   }
-  const mir::TypeId ref_type = unit.AddType(
-      mir::TypeData{mir::RefType{.pointee = pointee, .is_const = false}});
+  const mir::TypeId ref_type =
+      unit.types.Intern(mir::RefType{.pointee = pointee, .is_const = false});
   return block.exprs.Add(
       mir::Expr{
           .data =

--- a/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
+++ b/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
@@ -49,7 +49,7 @@ auto BuildObservablePtrExpr(
       frame.EnclosingClassAtHops(hops).members.Get(var).type;
   const mir::ExprId member_access_id =
       block.exprs.Add(BuildStructuralMemberAccessExpr(frame, unit, hops, var));
-  const auto& field_type_data = unit.GetType(field_type).data;
+  const auto& field_type_data = unit.types.Get(field_type).data;
 
   if (std::holds_alternative<mir::ExternalRefType>(field_type_data)) {
     return block.exprs.Add(
@@ -68,10 +68,8 @@ auto BuildObservablePtrExpr(
     return member_access_id;
   }
 
-  const mir::TypeId ptr_type = unit.AddType(
-      mir::PointerType{
-          .pointee = field_type,
-          .ownership = mir::PointerOwnership::kBorrowed});
+  const mir::TypeId ptr_type =
+      unit.types.PointerTo(field_type, mir::PointerOwnership::kBorrowed);
   return block.exprs.Add(mir::MakeAddressOfExpr(member_access_id, ptr_type));
 }
 

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -57,7 +57,7 @@ auto LowerDestructuringAssign(
   std::uint64_t total_width = 0;
   for (const hir::ExprId op_id : lhs_concat.operands) {
     const hir::Expr& op = hir_proc.exprs.Get(op_id);
-    const hir::Type& op_ty = process.Module().Hir().GetType(op.type);
+    const hir::Type& op_ty = process.Module().Hir().types.Get(op.type);
     if (!op_ty.IsPackedArray()) {
       throw InternalError(
           "LowerDestructuringAssign: destructuring operand is not "
@@ -74,13 +74,13 @@ auto LowerDestructuringAssign(
         "LowerDestructuringAssign: destructuring total width must be positive");
   }
 
-  const mir::TypeId temp_type = process.Module().Unit().AddType(
-      mir::TypeData{mir::PackedArrayType{
+  const mir::TypeId temp_type = process.Module().Unit().types.Intern(
+      mir::PackedArrayType{
           .atom = any_four_state ? mir::BitAtom::kLogic : mir::BitAtom::kBit,
           .signedness = mir::Signedness::kUnsigned,
           .dims = {mir::PackedRange{
               .left = static_cast<std::int64_t>(total_width) - 1, .right = 0}},
-          .form = mir::PackedArrayForm::kExplicit}});
+          .form = mir::PackedArrayForm::kExplicit});
 
   const mir::ExprId temp_default_init = wrapper.exprs.Add(
       BuildDefaultValueExpr(process.Module(), wrapper_frame, temp_type));
@@ -134,13 +134,13 @@ auto LowerDestructuringAssign(
             static_cast<std::int64_t>(w)));
     const mir::ExprId temp_ref =
         wrapper.exprs.Add(mir::Expr{.data = snapshot_ref, .type = temp_type});
-    const mir::TypeId slice_type = process.Module().Unit().AddType(
-        mir::TypeData{mir::PackedArrayType{
+    const mir::TypeId slice_type = process.Module().Unit().types.Intern(
+        mir::PackedArrayType{
             .atom = any_four_state ? mir::BitAtom::kLogic : mir::BitAtom::kBit,
             .signedness = mir::Signedness::kUnsigned,
             .dims = {mir::PackedRange{
                 .left = static_cast<std::int64_t>(w) - 1, .right = 0}},
-            .form = mir::PackedArrayForm::kExplicit}});
+            .form = mir::PackedArrayForm::kExplicit});
     const mir::ExprId raw_slice_id = wrapper.exprs.Add(
         mir::Expr{
             .data =
@@ -258,7 +258,7 @@ auto LowerSubroutineCallWithWritebacks(
   const mir::TypeId payload_type = NormalizeCompletionPayload(unit, components);
   const bool is_task = decl.kind == hir::SubroutineKind::kTask;
   const mir::TypeId call_result_type =
-      is_task ? CoroutineOf(unit, payload_type) : payload_type;
+      is_task ? unit.types.CoroutineOf(payload_type) : payload_type;
 
   std::vector<mir::ExprId> call_args;
   call_args.reserve(call.arguments.size() + 1);
@@ -324,7 +324,7 @@ auto LowerSubroutineCallWithWritebacks(
       mir::ExprId actual_id = wrapper.exprs.Add(*std::move(arg_or));
       const mir::ExprId root_id = FindLhsRootId(wrapper, actual_id);
       const bool root_is_cell = mir::IsObservableCellType(
-          unit.GetType(wrapper.exprs.Get(root_id).type));
+          unit.types.Get(wrapper.exprs.Get(root_id).type));
       if (root_is_cell && root_id != actual_id) {
         const mir::ExprId services_id =
             wrapper.exprs.Add(BuildServicesCallExpr(module, wrapper_frame));

--- a/src/lyra/lowering/hir_to_mir/statement/blocks.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/blocks.cpp
@@ -66,18 +66,15 @@ void OpenActivationScope(
             .name = decl.name, .type = module.TranslateType(decl.type)}));
   }
   const mir::TypeId box_object =
-      unit.AddType(mir::ObjectType{.name = box_name});
-  box.self_pointer_type = unit.AddType(
-      mir::PointerType{
-          .pointee = box_object,
-          .ownership = mir::PointerOwnership::kBorrowed});
+      unit.types.Intern(mir::ObjectType{.name = box_name});
+  box.self_pointer_type =
+      unit.types.PointerTo(box_object, mir::PointerOwnership::kBorrowed);
   owner.nested_classes.Add(std::move(box));
 
   // The handle: a shared pointer to the box, allocated by make_shared. Declared
   // first in the scope, before the promoted locals it stands in for.
-  const mir::TypeId handle_type = unit.AddType(
-      mir::PointerType{
-          .pointee = box_object, .ownership = mir::PointerOwnership::kShared});
+  const mir::TypeId handle_type =
+      unit.types.PointerTo(box_object, mir::PointerOwnership::kShared);
   mir::Block& block = *frame.current_block;
   const mir::ExprId init = block.exprs.Add(
       mir::Expr{

--- a/src/lyra/lowering/hir_to_mir/statement/branches.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/branches.cpp
@@ -95,7 +95,7 @@ auto LowerCaseStmt(
   // would make the snapshot 2-state while wildcard labels are 4-state and
   // PackedArray::ExpectSameShape rejects the per-label compare.
   auto packed_state = [&](mir::TypeId tid) -> std::optional<bool> {
-    const auto& ty = process.Module().Unit().GetType(tid);
+    const auto& ty = process.Module().Unit().types.Get(tid);
     if (const auto* pa = std::get_if<mir::PackedArrayType>(&ty.data)) {
       return pa->IsFourState();
     }

--- a/src/lyra/lowering/hir_to_mir/translate_type.cpp
+++ b/src/lyra/lowering/hir_to_mir/translate_type.cpp
@@ -104,7 +104,7 @@ auto ModuleLowerer::TranslateTypeData(
             // unwrap via Type::AsIntegralPacked(); method dispatch reads the
             // members from this struct directly.
             const auto& base_mir_data =
-                Unit().GetType(TranslateType(src.base_type)).data;
+                Unit().types.Get(TranslateType(src.base_type)).data;
             const auto* base_pa =
                 std::get_if<mir::PackedArrayType>(&base_mir_data);
             if (base_pa == nullptr) {

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -38,7 +38,11 @@ class MirDumper {
     Line("Types:");
     Indent();
     for (std::size_t i = 0; i < unit.types.size(); ++i) {
-      Line(std::format("[{}] {}", i, FormatType(unit.types[i])));
+      Line(
+          std::format(
+              "[{}] {}", i,
+              FormatType(
+                  unit.types.Get(TypeId{static_cast<std::uint32_t>(i)}))));
     }
     Dedent();
     Line("Class:");

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -134,7 +134,7 @@ namespace {
 
 auto AsUniquePointee(const CompilationUnit& unit, TypeId type)
     -> std::optional<TypeId> {
-  const auto* ptr = std::get_if<PointerType>(&unit.GetType(type).data);
+  const auto* ptr = std::get_if<PointerType>(&unit.types.Get(type).data);
   if (ptr == nullptr || ptr->ownership != PointerOwnership::kUnique) {
     return std::nullopt;
   }
@@ -166,14 +166,15 @@ auto ObservableInnerValueType(const Type& ty) -> TypeId {
 auto GetChildScope(const CompilationUnit& unit, TypeId type)
     -> std::optional<ChildScope> {
   TypeId leaf = type;
-  while (const auto* vec = std::get_if<VectorType>(&unit.GetType(leaf).data)) {
+  while (const auto* vec =
+             std::get_if<VectorType>(&unit.types.Get(leaf).data)) {
     leaf = vec->element;
   }
   const auto pointee = AsUniquePointee(unit, leaf);
   if (!pointee.has_value()) {
     return std::nullopt;
   }
-  const auto& data = unit.GetType(*pointee).data;
+  const auto& data = unit.types.Get(*pointee).data;
   if (const auto* obj = std::get_if<ObjectType>(&data)) {
     return ChildScope{GenerateScopeChild{.name = obj->name}};
   }

--- a/src/lyra/mir/type_interner.cpp
+++ b/src/lyra/mir/type_interner.cpp
@@ -1,0 +1,139 @@
+#include "lyra/mir/type_interner.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include "lyra/mir/type.hpp"
+
+namespace lyra::mir {
+
+namespace {
+
+void HashCombine(std::size_t& seed, std::size_t value) {
+  seed ^= value + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+}
+
+template <typename T>
+void HashField(std::size_t& seed, const T& value) {
+  HashCombine(seed, std::hash<T>{}(value));
+}
+
+void HashId(std::size_t& seed, TypeId id) {
+  HashCombine(seed, std::hash<std::uint32_t>{}(id.value));
+}
+
+// Hashes a packed array's semantic shape, excluding its slang syntactic-origin
+// marker: the marker carries no semantic content, so two arrays differing only
+// there must hash equal to share one canonical id.
+void HashPackedShape(std::size_t& seed, const PackedArrayType& packed) {
+  HashCombine(seed, std::hash<int>{}(static_cast<int>(packed.atom)));
+  HashCombine(seed, std::hash<int>{}(static_cast<int>(packed.signedness)));
+  for (const PackedRange& dim : packed.dims) {
+    HashCombine(seed, std::hash<std::int64_t>{}(dim.left));
+    HashCombine(seed, std::hash<std::int64_t>{}(dim.right));
+  }
+}
+
+auto PackedShapeEqual(const PackedArrayType& a, const PackedArrayType& b)
+    -> bool {
+  return a.atom == b.atom && a.signedness == b.signedness && a.dims == b.dims;
+}
+
+}  // namespace
+
+auto SemanticTypeHash::operator()(const TypeData& data) const -> std::size_t {
+  std::size_t seed = std::hash<std::size_t>{}(data.index());
+  std::visit(
+      [&](const auto& t) {
+        using T = std::decay_t<decltype(t)>;
+        if constexpr (std::is_same_v<T, PackedArrayType>) {
+          HashPackedShape(seed, t);
+        } else if constexpr (std::is_same_v<T, EnumType>) {
+          HashPackedShape(seed, t.base);
+          for (const EnumMember& m : t.members) {
+            HashField(seed, m.name);
+            HashField(seed, m.value);
+          }
+        } else if constexpr (std::is_same_v<T, UnpackedArrayType>) {
+          HashId(seed, t.element_type);
+          HashField(seed, t.size);
+        } else if constexpr (std::is_same_v<T, DynamicArrayType>) {
+          HashId(seed, t.element_type);
+        } else if constexpr (std::is_same_v<T, QueueType>) {
+          HashId(seed, t.element_type);
+          if (t.max_bound) {
+            HashField(seed, *t.max_bound);
+          }
+        } else if constexpr (std::is_same_v<T, AssociativeArrayType>) {
+          HashId(seed, t.element_type);
+          HashId(seed, t.key_type);
+        } else if constexpr (std::is_same_v<T, ObjectType>) {
+          HashField(seed, t.name);
+        } else if constexpr (std::is_same_v<T, ExternalUnitObjectType>) {
+          HashField(seed, t.unit_name);
+        } else if constexpr (std::is_same_v<T, RuntimeLibraryType>) {
+          HashCombine(seed, std::hash<int>{}(static_cast<int>(t.kind)));
+        } else if constexpr (std::is_same_v<T, CoroutineType>) {
+          HashId(seed, t.payload);
+        } else if constexpr (std::is_same_v<T, RefType>) {
+          HashId(seed, t.pointee);
+          HashField(seed, t.is_const);
+        } else if constexpr (std::is_same_v<T, PointerType>) {
+          HashId(seed, t.pointee);
+          HashCombine(seed, std::hash<int>{}(static_cast<int>(t.ownership)));
+        } else if constexpr (std::is_same_v<T, VectorType>) {
+          HashId(seed, t.element);
+        } else if constexpr (std::is_same_v<T, TupleType>) {
+          for (TypeId element : t.elements) {
+            HashId(seed, element);
+          }
+        } else if constexpr (std::is_same_v<T, ObservableType>) {
+          HashId(seed, t.value);
+        } else if constexpr (std::is_same_v<T, ExternalRefType>) {
+          HashId(seed, t.element);
+        }
+        // The remaining variants are parameter-less; the variant index above
+        // is their whole identity.
+      },
+      data);
+  return seed;
+}
+
+auto SemanticTypeEqual::operator()(const TypeData& a, const TypeData& b) const
+    -> bool {
+  if (a.index() != b.index()) {
+    return false;
+  }
+  return std::visit(
+      [&](const auto& lhs) -> bool {
+        using T = std::decay_t<decltype(lhs)>;
+        const auto& rhs = std::get<T>(b);
+        // The two integral variants drop the non-semantic syntactic-origin
+        // marker; every other variant's own equality already compares exactly
+        // its semantic fields.
+        if constexpr (std::is_same_v<T, PackedArrayType>) {
+          return PackedShapeEqual(lhs, rhs);
+        } else if constexpr (std::is_same_v<T, EnumType>) {
+          return PackedShapeEqual(lhs.base, rhs.base) &&
+                 lhs.members == rhs.members;
+        } else {
+          return lhs == rhs;
+        }
+      },
+      a);
+}
+
+auto TypeInterner::Intern(TypeData data) -> TypeId {
+  if (const auto it = index_.find(data); it != index_.end()) {
+    return it->second;
+  }
+  const TypeId id = storage_.Add(Type{.data = data});
+  index_.emplace(std::move(data), id);
+  return id;
+}
+
+}  // namespace lyra::mir


### PR DESCRIPTION
## Summary

The MIR type pool becomes a canonicalizing interner instead of a plain append-only arena: each semantic type maps to one canonical `TypeId`, so `TypeId` equality is a valid, cheap semantic-type comparison. This is the structural prerequisite for recursive and forward-declared class types -- a forward reference to a class and the class's own definition now resolve to the same `TypeId`, which a non-canonicalizing arena cannot provide. It also removes the manual builtin caches for hot composites and the coroutine constructor's `void`-payload special case, and hardens the underlying arena's reference-lifetime contract.

## Design

Interning equality is defined by two typed functors over `TypeData` (`SemanticTypeHash` / `SemanticTypeEqual`): an object type keys on its class identity, an enum on its scope-unique enumerators (LRM 6.19 forbids two enumerations in a scope from sharing a name, so the enumerator set is the enum's identity), and a structural type on its constructor plus the canonical `TypeId`s of its children plus its semantic modifiers. The non-semantic packed-array origin marker is excluded, so `int` and `bit signed [31:0]` canonicalize together.

Type construction goes through `Intern`, with typed constructors (`CoroutineOf`, `PointerTo`) at the common call sites; `scope_ptr` and `coroutine_void` remain as convenience aliases produced through interning rather than separate dedup caches. Two decision docs record the rationale: `mir-type-interning` and `arena-reference-lifetime`.

## Testing

`bazel test //...` green.