### PR TITLE
Add a unit-wide class registry and identity

### DIFF
--- a/docs/decisions/object-model-storage.md
+++ b/docs/decisions/object-model-storage.md
@@ -14,10 +14,14 @@ anywhere through a handle, with no lexical parent. This decision settles the sto
 model so one model serves every object type, and records why a single registry -- not two storage
 systems, not a second identity -- is the answer.
 
-A related factual correction sharpened the problem: a local object type already has a stable
-unit-local identity today (its type-system id; name resolution compares ids, not strings, and the
-name on an object type is an emission / dump convenience). So the gap is not "string identity"; it
-is that the **declaration storage and lookup model** is lexical-tree-only.
+A code-level check sharpened the problem: a local object type has no canonical per-declaration
+identity today. Object types are synthesized by name, and the type arena does not deduplicate, so
+one declaration is reached through several content-equal type entries tied together only by a name
+string -- there is no id that resolves to the declaration on its own. This suffices for modules and
+generate scopes, which are reached by hierarchical navigation and backend name nesting and never by
+resolving an object-type identity; it cannot carry classes, which are named by identity from
+arbitrary positions. So the gap is twofold: there is no canonical identity, and the **declaration
+storage and lookup model** is lexical-tree-only.
 
 ## Decision
 

--- a/docs/progress/object-model.md
+++ b/docs/progress/object-model.md
@@ -17,11 +17,11 @@ each stage establishes, not how.
 - [ ] An object's base is one generic nominal-object reference -- a runtime-library, intra-unit, or
       cross-unit base -- rendered through one path, not a closed runtime-base classification. A
       runtime-library base is an imported library declaration; a cross-unit base stays a by-name
-      reference. Behavior-neutral: the emitted module shape is unchanged. (A local object type
-      already carries a stable unit-local identity today, so a separate intra-unit id is not this
-      step; that identity becomes the registry's canonical id below. Runtime-tree membership is read
-      adequately from how a member is owned today; a base-lineage read is a later purity refinement,
-      not done as a standalone non-neutral change.)
+      reference. Behavior-neutral: the emitted module shape is unchanged. (The intra-unit and
+      cross-unit base arms are not this step; an intra-unit base names the registry's canonical
+      local identity, established below. Runtime-tree membership is read adequately from how a
+      member is owned today; a base-lineage read is a later purity refinement, not done as a
+      standalone non-neutral change.)
 
 - [x] Each post-construction lifecycle body (the scope's resolve / initialize / activate work) is an
       ordinary method that records, as a first-class fact, which runtime-base method it overrides --
@@ -29,20 +29,24 @@ each stage establishes, not how.
       object declaration are gone. The full dynamic-dispatch slot machinery is not introduced here;
       only the override relation. Behavior-neutral.
 
-- [ ] Object construction -- including a module's owned children -- is one generic construction form
-      that allocates the object and runs its constructor, with optional base-constructor chaining.
-      Construction is a concept distinct from an ordinary callable, carrying allocation and
-      initialization ordering. The existing module-child construction is expressed through it.
+- [x] Object construction is already one generic, type-directed form -- what it builds (a value, an
+      owned child, a managed handle) follows the result type, and a module's owned children
+      construct through it today -- so no separate construction node is needed. The gap this stage
+      closes is the foundation every object-naming site depends on once classes arrive: a unit-level
+      identity for each local nominal object, and one nominal-object reference used wherever a
+      member's pointee, a constructed type, or a receiver names an object, so one relation is never
+      encoded two ways. The base naming role is unified separately when an object extends a local or
+      cross-unit base. A user-written constructor body lands with the class; base-constructor
+      chaining lands with inheritance.
 
-- [ ] A compilation unit owns one canonical registry of its local nominal object declarations: every
+- [x] A compilation unit owns one canonical registry of its local nominal object declarations: every
       object type -- module, generate scope, class -- is one record with one canonical local
-      identity a reference names; a lexical scope resolves a name to an identity; structural
-      containment and backend emission nesting are separate relations over identities. A forward
-      (incomplete) declaration is a record that exists before its body, so mutually-referential and
-      forward-declared types resolve. The current lexical-tree object storage becomes
-      registry-backed, with structural containment retained for construction and for nested
-      emission. This lands before SystemVerilog classes; it is not a standalone flatten of the
-      existing storage.
+      identity a reference names; structural containment and backend emission nesting are separate
+      relations over identities. A forward (incomplete) declaration is a record that exists before
+      its body, so mutually-referential and forward-declared types resolve. The lexical-tree object
+      storage is now registry-backed, with structural containment retained for construction and for
+      nested emission. Resolving a source name to an identity by lexical scope lands with
+      SystemVerilog classes, the first references resolved by name.
 
 - [ ] A SystemVerilog class is the same generic object type, reached through a managed object
       reference: nullable as a value, identity-comparable, shallow-copied, participating in managed
@@ -73,11 +77,9 @@ each stage establishes, not how.
 - Renaming the object declaration to a name that reads as generic (it will hold both modules and
   SystemVerilog classes) is a separate mechanical change, deferred until it holds both. The registry
   slice is its natural home.
-- The registry's canonical local identity is either the object type's existing type-system id
-  reused, or a dedicated object id the object type carries. The principle (one identity, no second
-  inter-convertible id) is settled; the mechanism is pending whether an object declaration has a
-  single canonical type-system id today (type interning does not deduplicate, so it may have several
-  content-equal ones). The lean is the dedicated id.
+- The registry's canonical local identity is a dedicated object id, separate from the type-system id
+  (resolved). The type pool interns by content, but a class declaration's identity must be
+  independent of any one type node, so it carries its own id; an object type names that id.
 
 ## Cross-references
 

--- a/include/lyra/backend/cpp/scope_view.hpp
+++ b/include/lyra/backend/cpp/scope_view.hpp
@@ -82,25 +82,13 @@ class ScopeView {
   }
 
   // The class a member access reaches, resolved from the receiver's object
-  // type: the member belongs to the receiver's class. A receiver is `self`
-  // (the current class), an `(Outer*)self->Parent()` navigation (an enclosing
-  // class), or a handle to a nested object (a nested class). Searched among the
-  // current class, its nested classes, and its enclosing chain -- the classes
-  // reachable from this render position.
+  // type: an object type names a local object declaration by identity, and the
+  // unit's registry maps that identity to the declaration.
   [[nodiscard]] auto ClassByObjectType(mir::TypeId object_type) const
       -> const mir::Class& {
-    if (ObjectTypeOf(*class_) == object_type) {
-      return *class_;
-    }
-    for (const auto& nested : class_->nested_classes) {
-      if (ObjectTypeOf(nested) == object_type) {
-        return nested;
-      }
-    }
-    if (class_parent_ != nullptr) {
-      return class_parent_->ClassByObjectType(object_type);
-    }
-    throw InternalError("ScopeView::ClassByObjectType: no class for type");
+    const auto& obj =
+        std::get<mir::ObjectType>(unit_->types.Get(object_type).data);
+    return unit_->GetClass(obj.class_id);
   }
 
   [[nodiscard]] auto Expr(mir::ExprId id) const -> const mir::Expr& {
@@ -108,13 +96,6 @@ class ScopeView {
   }
 
  private:
-  // The object type a class instance has -- the pointee of its self pointer.
-  [[nodiscard]] auto ObjectTypeOf(const mir::Class& cls) const -> mir::TypeId {
-    return std::get<mir::PointerType>(
-               unit_->types.Get(cls.self_pointer_type).data)
-        .pointee;
-  }
-
   ScopeView(
       const mir::CompilationUnit& unit, const mir::Class& cls,
       const mir::Block& block)

--- a/include/lyra/base/registry.hpp
+++ b/include/lyra/base/registry.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "lyra/base/internal_error.hpp"
+
+namespace lyra::base {
+
+// A pool of `T` indexed by a typed id `Id`, where an identity is minted before
+// its value exists: `Declare` mints an id whose value is absent, `Define` fills
+// it exactly once, and `Get` reads a defined value. This serves entities that
+// must be referable before they are complete -- a forward or mutually recursive
+// declaration names another's identity before either body is built. `Id` is a
+// struct carrying a single `std::uint32_t value`, its position in the pool; an
+// identity, once minted, is stable for the pool's life.
+template <typename T, typename Id>
+class Registry {
+ public:
+  auto Declare() -> Id {
+    const Id id{static_cast<std::uint32_t>(slots_.size())};
+    slots_.emplace_back(std::nullopt);
+    return id;
+  }
+
+  void Define(Id id, T value) {
+    auto& slot = slots_.at(id.value);
+    if (slot.has_value()) {
+      throw InternalError("Registry::Define: identity already defined");
+    }
+    slot = std::move(value);
+  }
+
+  [[nodiscard]] auto IsDefined(Id id) const -> bool {
+    return slots_.at(id.value).has_value();
+  }
+
+  [[nodiscard]] auto Get(Id id) const -> const T& {
+    const auto& slot = slots_.at(id.value);
+    if (!slot.has_value()) {
+      throw InternalError(
+          "Registry::Get: identity is declared but not defined");
+    }
+    return *slot;
+  }
+
+ private:
+  std::vector<std::optional<T>> slots_;
+};
+
+}  // namespace lyra::base

--- a/include/lyra/lowering/hir_to_mir/class_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/class_lowerer.hpp
@@ -16,7 +16,6 @@
 #include "lyra/hir/structural_var.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
-#include "lyra/mir/class.hpp"
 #include "lyra/mir/class_id.hpp"
 #include "lyra/mir/enclosing_hops.hpp"
 #include "lyra/mir/expr.hpp"
@@ -61,14 +60,14 @@ class ClassLowerer {
         hir_scope_(&hir_scope) {
   }
 
-  // Constructs the `mir::Class` on the stack, walks the HIR scope
-  // body, and returns the result. Handlers reached through dispatch write to
-  // `frame.current_class`. `entry_bindings` are the structural
-  // params injected by an enclosing for-generate iteration.
+  // Registers this object in the unit, walks the HIR scope body to build its
+  // declaration, and returns its identity. Handlers reached through dispatch
+  // write to `frame.current_class`. `entry_bindings` are the structural params
+  // injected by an enclosing for-generate iteration.
   auto Run(
       WalkFrame parent_frame,
       std::span<const ScopeEntryStructuralParamBinding> entry_bindings = {})
-      -> diag::Result<mir::Class>;
+      -> diag::Result<mir::ClassId>;
 
   // Central scope-level expression dispatcher. One switch over `hir::Expr::
   // data` routing each kind to the per-family handler in `expression/*.cpp`.

--- a/include/lyra/mir/class.hpp
+++ b/include/lyra/mir/class.hpp
@@ -47,7 +47,11 @@ struct Class {
   // constructor is the allocation shell that kicks this off; an empty body
   // needs no kickoff.
   Block constructor_block;
-  base::Arena<Class, ClassId> nested_classes;
+  // The classes this one structurally owns -- the children it builds and, for a
+  // backend that nests, emits inside itself. Each names a registry identity, in
+  // construction order. Ownership of the declarations is the unit's registry;
+  // this is the containment relation over those identities.
+  std::vector<ClassId> contained;
   base::Arena<MethodDecl, MethodId> methods;
   std::vector<TypeAliasDecl> type_aliases;
 

--- a/include/lyra/mir/class_id.hpp
+++ b/include/lyra/mir/class_id.hpp
@@ -5,6 +5,13 @@
 
 namespace lyra::mir {
 
+// Identity of a class declaration within a compilation unit -- a module, a
+// named generate scope, or a SystemVerilog class. A reference to a class (a
+// member's pointee, a constructed type, a receiver type) names this id, and the
+// unit's class registry resolves it to the declaration. Unlike the scope-local
+// arena ids (an expression, a statement, a member), this id is unit-wide: it
+// resolves without holding the class's container, since a class can be named
+// from a position that does not enclose it.
 struct ClassId {
   std::uint32_t value;
 

--- a/include/lyra/mir/compilation_unit.hpp
+++ b/include/lyra/mir/compilation_unit.hpp
@@ -3,7 +3,9 @@
 #include <cstdint>
 #include <vector>
 
+#include "lyra/base/registry.hpp"
 #include "lyra/mir/class.hpp"
+#include "lyra/mir/class_id.hpp"
 #include "lyra/mir/deferred_check_site.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/integral_constant.hpp"
@@ -48,7 +50,12 @@ struct BuiltinMirTypes {
 struct CompilationUnit {
   TypeInterner types;
   BuiltinMirTypes builtins;
-  Class top_class;
+  // Every class declaration of this unit, owned here exactly once and reached
+  // by its identity, with a declare-then-define lifecycle so a class can be
+  // named before its body is built. `root` identifies the unit's top class, the
+  // module declaration.
+  base::Registry<Class, ClassId> classes;
+  ClassId root{};
   std::vector<DeferredCheckSite> deferred_check_sites;
 
   CompilationUnit()
@@ -113,6 +120,18 @@ struct CompilationUnit {
     // instance, not a deduplication mechanism -- interning `Coroutine<void>`
     // anywhere returns this same id.
     builtins.coroutine_void = types.CoroutineOf(builtins.void_type);
+  }
+
+  [[nodiscard]] auto GetClass(ClassId id) const -> const Class& {
+    return classes.Get(id);
+  }
+
+  auto DeclareClass() -> ClassId {
+    return classes.Declare();
+  }
+
+  void DefineClass(ClassId id, Class value) {
+    classes.Define(id, std::move(value));
   }
 
   // Backing-vector position is the id, matching TypeId / LocalId.

--- a/include/lyra/mir/stmt.hpp
+++ b/include/lyra/mir/stmt.hpp
@@ -9,10 +9,8 @@
 #include <vector>
 
 #include "lyra/base/arena.hpp"
-#include "lyra/mir/class_id.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/local.hpp"
-#include "lyra/mir/member.hpp"
 #include "lyra/mir/value_ref.hpp"
 
 namespace lyra::mir {

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -6,6 +6,7 @@
 #include <variant>
 #include <vector>
 
+#include "lyra/mir/class_id.hpp"
 #include "lyra/mir/type_id.hpp"
 
 namespace lyra::mir {
@@ -167,8 +168,13 @@ struct VoidType {
   auto operator==(const VoidType&) const -> bool = default;
 };
 
+// The type of an instance of a class of this compilation unit -- a module
+// instance, a named generate scope, or a SystemVerilog class. It names the
+// class by its unit-wide identity; the unit's class registry resolves the id to
+// the declaration. The name is not here -- it is a property of the registered
+// declaration, read through the id.
 struct ObjectType {
-  std::string name;
+  ClassId class_id;
 
   auto operator==(const ObjectType&) const -> bool = default;
 };

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -241,10 +241,11 @@ auto RenderScopeAsClass(
            "; }\n\n";
   }
 
-  for (const auto& child : s.nested_classes) {
-    out += RenderScopeAsClass(unit, child, indent + 1, &this_anchor);
+  for (const mir::ClassId child_id : s.contained) {
+    out += RenderScopeAsClass(
+        unit, unit.GetClass(child_id), indent + 1, &this_anchor);
   }
-  if (!s.nested_classes.empty()) {
+  if (!s.contained.empty()) {
     out += "\n";
   }
 
@@ -414,7 +415,8 @@ auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
   out += "#include \"lyra/runtime/engine.hpp\"\n";
   out += "#include \"lyra/runtime/simulation_entry.hpp\"\n";
   for (const auto& top : tops) {
-    out += std::format("#include \"{}.hpp\"\n", top.unit->top_class.name);
+    out += std::format(
+        "#include \"{}.hpp\"\n", top.unit->GetClass(top.unit->root).name);
   }
   out += "\n";
   out += "auto main() -> int {\n";
@@ -427,11 +429,12 @@ auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
     // so this harness file does not repeat a type literal already owned
     // by MIR's builtin TypeId table.
     const auto& unit = *tops[i].unit;
+    const auto& top_class = unit.GetClass(unit.root);
     const std::string segment_cpp =
-        RenderTypeAsCpp(unit, unit.top_class, unit.builtins.hierarchy_segment);
+        RenderTypeAsCpp(unit, top_class, unit.builtins.hierarchy_segment);
     out += std::format(
         "  {0} top{1}{{nullptr, {2}{{\"{3}\", {{}}}}, engine.Services()}};\n",
-        tops[i].unit->top_class.name, i, segment_cpp, tops[i].name);
+        top_class.name, i, segment_cpp, tops[i].name);
   }
   out += "  std::vector<lyra::runtime::TopBinding> tops = {\n";
   for (std::size_t i = 0; i < tops.size(); ++i) {
@@ -447,7 +450,7 @@ auto RenderHostMain(std::span<const TopInstance> tops) -> std::string {
 }  // namespace
 
 auto EmitCppDeclarations(const mir::CompilationUnit& unit) -> CppArtifact {
-  const auto& root = unit.top_class;
+  const auto& root = unit.GetClass(unit.root);
   return {
       .relpath = std::format("{}.hpp", root.name),
       .content = RenderScopeHeaderFile(unit, root)};

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -100,7 +100,9 @@ auto RenderTypeAsCpp(
           [](const mir::WildcardIndexType&) -> std::string {
             return "lyra::value::WildcardKey";
           },
-          [](const mir::ObjectType& o) -> std::string { return o.name; },
+          [&unit](const mir::ObjectType& o) -> std::string {
+            return unit.GetClass(o.class_id).name;
+          },
           [](const mir::ExternalUnitObjectType& e) -> std::string {
             return e.unit_name;
           },

--- a/src/lyra/driver/cli.cpp
+++ b/src/lyra/driver/cli.cpp
@@ -384,9 +384,9 @@ auto main(int argc, char** argv) -> int {
                          const std::vector<std::string>& top_names) {
       std::vector<lyra::backend::cpp::TopInstance> tops;
       for (const auto& unit : units) {
-        if (std::ranges::find(top_names, unit.top_class.name) !=
-            top_names.end()) {
-          tops.push_back({.name = unit.top_class.name, .unit = &unit});
+        const auto& top_class = unit.GetClass(unit.root);
+        if (std::ranges::find(top_names, top_class.name) != top_names.end()) {
+          tops.push_back({.name = top_class.name, .unit = &unit});
         }
       }
       return tops;

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -1,5 +1,6 @@
 #include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <expected>
@@ -72,8 +73,8 @@ auto CompanionVarNameFor(std::string_view child_scope_name) -> std::string {
 }
 
 void CheckNoNameCollision(
-    const mir::Class& owner_class, std::string_view child_scope_name,
-    std::string_view companion_var_name) {
+    const mir::CompilationUnit& unit, const mir::Class& owner_class,
+    std::string_view child_scope_name, std::string_view companion_var_name) {
   for (const auto& v : owner_class.members) {
     if (v.name == companion_var_name || v.name == child_scope_name) {
       throw InternalError(
@@ -81,8 +82,8 @@ void CheckNoNameCollision(
           "member declaration in the enclosing class");
     }
   }
-  for (const auto& c : owner_class.nested_classes) {
-    if (c.name == child_scope_name) {
+  for (const mir::ClassId child : owner_class.contained) {
+    if (unit.GetClass(child).name == child_scope_name) {
       throw InternalError(
           "child class name collides with an existing nested class "
           "declaration in the enclosing class");
@@ -170,10 +171,10 @@ auto EnumerateGenerateChildSpecs(
   return specs;
 }
 
-auto MakeUniqueObjectPointer(ModuleLowerer& module, std::string scope_name)
+auto MakeUniqueObjectPointer(ModuleLowerer& module, mir::ClassId class_id)
     -> mir::TypeId {
-  const mir::TypeId object_type = module.Unit().types.Intern(
-      mir::ObjectType{.name = std::move(scope_name)});
+  const mir::TypeId object_type =
+      module.Unit().types.Intern(mir::ObjectType{.class_id = class_id});
   return module.Unit().types.PointerTo(
       object_type, mir::PointerOwnership::kUnique);
 }
@@ -902,7 +903,8 @@ void ValidateOwnedChildConstruction(
     const mir::CompilationUnit& unit, const mir::Class& owner_class,
     const mir::Block& block, mir::MemberId target_var,
     mir::ClassId child_scope_id, std::span<const mir::ExprId> ctor_args) {
-  if (child_scope_id.value >= owner_class.nested_classes.size()) {
+  if (std::ranges::find(owner_class.contained, child_scope_id) ==
+      owner_class.contained.end()) {
     throw InternalError(
         "owned-child construction: child scope is not a direct child of the "
         "enclosing class");
@@ -916,7 +918,7 @@ void ValidateOwnedChildConstruction(
   const auto child = mir::GetChildScope(unit, var.type);
   const auto* generate =
       child ? std::get_if<mir::GenerateScopeChild>(&*child) : nullptr;
-  const auto& child_scope = owner_class.nested_classes.Get(child_scope_id);
+  const auto& child_scope = unit.GetClass(child_scope_id);
   if (generate == nullptr || generate->name != child_scope.name) {
     throw InternalError(
         "owned-child construction: target var does not own the requested "
@@ -1369,17 +1371,17 @@ auto InstallGenerateOwnedChildScopes(ClassLowerer& lowerer, WalkFrame frame)
     auto specs = EnumerateGenerateChildSpecs(gen, gen_idx, hir_scope, module);
     for (auto& spec : specs) {
       const auto companion_name = CompanionVarNameFor(spec.scope_name);
-      CheckNoNameCollision(mir_class, spec.scope_name, companion_name);
+      CheckNoNameCollision(
+          module.Unit(), mir_class, spec.scope_name, companion_name);
 
       ClassLowerer child_scope(
           module, &lowerer, std::move(spec.scope_name), *spec.scope);
       auto child_r = child_scope.Run(frame, spec.entry_bindings);
       if (!child_r) return std::unexpected(std::move(child_r.error()));
 
-      const mir::ClassId child_id =
-          mir_class.nested_classes.Add(*std::move(child_r));
-      mir::TypeId var_type = MakeUniqueObjectPointer(
-          module, mir_class.nested_classes.Get(child_id).name);
+      const mir::ClassId child_id = *child_r;
+      mir_class.contained.push_back(child_id);
+      mir::TypeId var_type = MakeUniqueObjectPointer(module, child_id);
       if (spec.is_repeated) {
         var_type =
             module.Unit().types.Intern(mir::VectorType{.element = var_type});
@@ -1404,13 +1406,16 @@ auto InstallGenerateOwnedChildScopes(ClassLowerer& lowerer, WalkFrame frame)
 auto ClassLowerer::Run(
     WalkFrame frame,
     std::span<const ScopeEntryStructuralParamBinding> entry_bindings)
-    -> diag::Result<mir::Class> {
+    -> diag::Result<mir::ClassId> {
   ModuleLowerer& module = *module_;
   const hir::StructuralScope& hir_scope = *hir_scope_;
   ClassLowerer& lowerer = *this;
 
+  // The identity is minted before the body so the object's own self type names
+  // it; the registry slot is filled from the finished declaration below.
+  const mir::ClassId own_id = module.Unit().DeclareClass();
   const mir::TypeId self_object_type =
-      module.Unit().types.Intern(mir::ObjectType{.name = name_});
+      module.Unit().types.Intern(mir::ObjectType{.class_id = own_id});
   const mir::TypeId self_pointer_type = module.Unit().types.PointerTo(
       self_object_type, mir::PointerOwnership::kBorrowed);
   mir::Class mir_class{
@@ -1424,7 +1429,7 @@ auto ClassLowerer::Run(
       .params = {},
       .members = {},
       .constructor_block = {},
-      .nested_classes = {},
+      .contained = {},
       .methods = {},
       .type_aliases = {}};
 
@@ -1731,7 +1736,8 @@ auto ClassLowerer::Run(
                 .method = mir::RuntimeMethod::kActivate}}});
   }
 
-  return mir_class;
+  module.Unit().DefineClass(own_id, std::move(mir_class));
+  return own_id;
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
@@ -28,7 +28,7 @@ auto ModuleLowerer::Run() -> diag::Result<mir::CompilationUnit> {
   auto top_r = root.Run(root_frame);
   if (!top_r) return std::unexpected(std::move(top_r.error()));
 
-  unit_.top_class = *std::move(top_r);
+  unit_.root = *top_r;
   return std::move(unit_);
 }
 

--- a/src/lyra/lowering/hir_to_mir/statement/blocks.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/blocks.cpp
@@ -52,7 +52,8 @@ void OpenActivationScope(
 
   // Build the box fully, then append it (the class arena is append-only).
   const std::string box_name = std::string(process.CallableName()) + "__act" +
-                               std::to_string(owner.nested_classes.size());
+                               std::to_string(owner.contained.size());
+  const mir::ClassId box_id = unit.DeclareClass();
   mir::Class box;
   box.name = box_name;
   box.base = std::nullopt;
@@ -66,10 +67,11 @@ void OpenActivationScope(
             .name = decl.name, .type = module.TranslateType(decl.type)}));
   }
   const mir::TypeId box_object =
-      unit.types.Intern(mir::ObjectType{.name = box_name});
+      unit.types.Intern(mir::ObjectType{.class_id = box_id});
   box.self_pointer_type =
       unit.types.PointerTo(box_object, mir::PointerOwnership::kBorrowed);
-  owner.nested_classes.Add(std::move(box));
+  unit.DefineClass(box_id, std::move(box));
+  owner.contained.push_back(box_id);
 
   // The handle: a shared pointer to the box, allocated by make_shared. Declared
   // first in the scope, before the promoted locals it stands in for.

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -33,6 +33,7 @@ namespace {
 class MirDumper {
  public:
   auto Dump(const CompilationUnit& unit) -> std::string {
+    unit_ = &unit;
     Line("CompilationUnit");
     Indent();
     Line("Types:");
@@ -47,7 +48,7 @@ class MirDumper {
     Dedent();
     Line("Class:");
     Indent();
-    DumpClass(unit.top_class);
+    DumpClass(unit.root, unit.GetClass(unit.root));
     Dedent();
     Dedent();
     return std::move(out_);
@@ -174,7 +175,7 @@ class MirDumper {
             [](const ChandleType&) -> std::string { return "ChandleType"; },
             [](const VoidType&) -> std::string { return "VoidType"; },
             [](const ObjectType& o) -> std::string {
-              return std::format("Object(name=\"{}\")", o.name);
+              return std::format("Object(#{})", o.class_id.value);
             },
             [](const ExternalUnitObjectType& e) -> std::string {
               return std::format(
@@ -625,9 +626,9 @@ class MirDumper {
     return std::format("Type[{}]", type.value);
   }
 
-  void DumpClass(const Class& s) {
+  void DumpClass(ClassId id, const Class& s) {
     scope_stack_.push_back(&s);
-    Line(std::format("Class \"{}\"", s.name));
+    Line(std::format("Class \"{}\" (#{})", s.name, id.value));
     Indent();
 
     if (s.base.has_value()) {
@@ -639,12 +640,12 @@ class MirDumper {
                               : "GenScope"));
     }
 
-    Line("NestedClasses:");
+    Line("Contained:");
     Indent();
-    for (std::size_t i = 0; i < s.nested_classes.size(); ++i) {
-      Line(std::format("[{}]", i));
+    for (const ClassId child : s.contained) {
+      Line(std::format("[#{}]", child.value));
       Indent();
-      DumpClass(s.nested_classes.Get(ClassId{static_cast<std::uint32_t>(i)}));
+      DumpClass(child, unit_->GetClass(child));
       Dedent();
     }
     Dedent();
@@ -1099,6 +1100,7 @@ class MirDumper {
   std::string out_;
   int indent_ = 0;
   std::vector<const Class*> scope_stack_;
+  const CompilationUnit* unit_ = nullptr;
   std::vector<const Block*> block_stack_;
 };
 

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -176,7 +176,8 @@ auto GetChildScope(const CompilationUnit& unit, TypeId type)
   }
   const auto& data = unit.types.Get(*pointee).data;
   if (const auto* obj = std::get_if<ObjectType>(&data)) {
-    return ChildScope{GenerateScopeChild{.name = obj->name}};
+    return ChildScope{
+        GenerateScopeChild{.name = unit.GetClass(obj->class_id).name}};
   }
   if (std::holds_alternative<ExternalUnitObjectType>(data)) {
     return ChildScope{ModuleInstanceChild{}};

--- a/src/lyra/mir/type_interner.cpp
+++ b/src/lyra/mir/type_interner.cpp
@@ -72,7 +72,7 @@ auto SemanticTypeHash::operator()(const TypeData& data) const -> std::size_t {
           HashId(seed, t.element_type);
           HashId(seed, t.key_type);
         } else if constexpr (std::is_same_v<T, ObjectType>) {
-          HashField(seed, t.name);
+          HashField(seed, t.class_id.value);
         } else if constexpr (std::is_same_v<T, ExternalUnitObjectType>) {
           HashField(seed, t.unit_name);
         } else if constexpr (std::is_same_v<T, RuntimeLibraryType>) {


### PR DESCRIPTION
## Summary

MIR now gives every local class declaration -- a module, a generate scope, and (soon) a SystemVerilog class -- a unit-wide identity (`ClassId`) owned by a per-unit registry, replacing the per-parent nested-class storage and the name-string object type. An `ObjectType` names a `ClassId`, so a member's pointee, a constructed type, and a receiver all resolve to one declaration through the registry, and `ClassByObjectType` becomes a direct id lookup instead of a lexical search. This rides the new MIR type interner: an `ObjectType` interns by its class identity, so the same class no longer produces duplicate type ids.

## Design

`base::Registry<T, Id>` is the declare-then-define sibling of `base::Arena`: an identity is minted (`Declare`) before its body exists, so a class can name its own identity (its self type) and forward or mutually recursive references resolve before either body is built; the body fills exactly once (`Define`). This is the storage SystemVerilog classes need for forward declarations, kept distinct from the append-only `Arena`. A class's structural containment is a `contained` list of `ClassId`s, a separate relation from registry ownership and from backend emission nesting.

## Testing

Behavior-neutral: emitted C++ is unchanged. Full `bazel test //...` is green.
