### PR TITLE
Lower sibling-of-ancestor hier refs via typed enclosing access

### DIFF
--- a/include/lyra/hir/structural_scope.hpp
+++ b/include/lyra/hir/structural_scope.hpp
@@ -13,6 +13,7 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/loop_var.hpp"
 #include "lyra/hir/process.hpp"
+#include "lyra/hir/structural_hops.hpp"
 #include "lyra/hir/structural_var.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/type_alias.hpp"
@@ -65,7 +66,15 @@ struct GenerateChildRef {
   GenerateId generate;
   StructuralScopeId scope;
 };
+// A downward head can sit in the current scope (`hops == 0`) or in an
+// enclosing scope (`hops > 0`). The enclosing case covers references that
+// reach an owned child of an ancestor scope without leaving the compilation
+// unit -- e.g. one generate block reading a signal in a sibling generate
+// block of their common ancestor. `child` identifies the head as one of
+// the owning scope's HIR-level identities; the install resolves it through
+// the enclosing class's owned-child binding table.
 struct DownwardHead {
+  StructuralHops hops = {};
   std::variant<InstanceMemberId, GenerateChildRef> child;
 };
 

--- a/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
@@ -185,14 +185,17 @@ class ModuleLowerer {
   [[nodiscard]] auto LookupOwnedChildBinding(const slang::ast::Symbol& child)
       const -> std::optional<OwnedChildBinding>;
 
-  // Cross-unit reference dedup. The slot itself is accumulated keyed by its
-  // owning scope's frame; the owning StructuralScopeLowerer drains it via
-  // TakeCrossUnitRefsForFrame at scope finalization.
+  // Cross-unit reference dedup. `slot_owner_frame` is the frame whose
+  // `cross_unit_refs` arena holds the slot -- the scope whose MIR class
+  // receives the slot member and whose constructor body installs it. For an
+  // intra-unit sibling-of-ancestor reference (`DownwardHead.hops > 0`) the
+  // slot owner is the referrer's frame while the head lives in an enclosing
+  // frame; for every other shape the slot owner is also the head's owner.
   auto MapOrGetCrossUnitRef(
-      const slang::ast::ValueSymbol& target, ScopeFrameId home_frame,
+      const slang::ast::ValueSymbol& target, ScopeFrameId slot_owner_frame,
       hir::CrossUnitRefHead head, std::vector<hir::PathStep> path,
       hir::TypeId type) -> hir::CrossUnitRefId;
-  auto TakeCrossUnitRefsForFrame(ScopeFrameId frame)
+  auto TakeCrossUnitRefsForFrame(ScopeFrameId slot_owner_frame)
       -> std::vector<hir::CrossUnitRefDecl>;
 
   // Frame minting for scope entry.
@@ -205,9 +208,10 @@ class ModuleLowerer {
 
   // Builds a HIR Expr referring to a leaf reached by navigating `path` down
   // from `head`. `target` is the leaf value symbol (cross-unit dedup key);
-  // `home_frame` is the owning structural scope's frame.
+  // `slot_owner_frame` is the frame whose `cross_unit_refs` arena holds the
+  // slot (see `MapOrGetCrossUnitRef`).
   auto MakeCrossUnitMemberRef(
-      const slang::ast::ValueSymbol& target, ScopeFrameId home_frame,
+      const slang::ast::ValueSymbol& target, ScopeFrameId slot_owner_frame,
       hir::CrossUnitRefHead head, std::vector<hir::PathStep> path,
       hir::TypeId type, diag::SourceSpan span) -> hir::Expr;
 

--- a/include/lyra/lowering/hir_to_mir/class_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/class_lowerer.hpp
@@ -5,9 +5,11 @@
 #include <span>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
+#include "lyra/base/overloaded.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/loop_var.hpp"
@@ -223,6 +225,42 @@ class ClassLowerer {
         .hops = mir::EnclosingHops{.value = mir_hops}, .param = mir_id};
   }
 
+  // Records the MIR slot a HIR owned-child reference resolves to. An instance
+  // member maps to one `mir::MemberId`; a generate maps to a per-arm table
+  // (`GenerateBindings`) so that a `GenerateChildRef` picks the arm's member.
+  // Callers register in HIR-id order during scope materialization; a nested
+  // scope reads them back through the parent chain when it needs to resolve
+  // a head that lives in an enclosing scope.
+  void MapInstanceMember(hir::InstanceMemberId hir_id, mir::MemberId mir_id) {
+    if (hir_id.value != instance_member_map_.size()) {
+      throw InternalError(
+          "ClassLowerer::MapInstanceMember: HIR instance members must be "
+          "mapped in HIR id order");
+    }
+    instance_member_map_.push_back(mir_id);
+  }
+
+  void MapGenerate(hir::GenerateId hir_id, GenerateBindings bindings) {
+    if (hir_id.value != generate_map_.size()) {
+      throw InternalError(
+          "ClassLowerer::MapGenerate: HIR generates must be mapped in HIR id "
+          "order");
+    }
+    generate_map_.push_back(std::move(bindings));
+  }
+
+  // Resolves an owned-child reference (the `child` field of a
+  // `hir::DownwardHead`) to the MIR member that owns the child. `hops == 0`
+  // reads this scope's own table; `hops > 0` walks the parent chain to an
+  // enclosing scope, used by the sibling-of-ancestor install when the head
+  // lives outside the referrer's frame.
+  [[nodiscard]] auto TranslateOwnedChild(
+      hir::StructuralHops hops,
+      const std::variant<hir::InstanceMemberId, hir::GenerateChildRef>& child)
+      const -> mir::MemberId {
+    return LookupOwnedChildAtHops(hops, child);
+  }
+
   void MapStructuralSubroutine(
       hir::StructuralSubroutineId hir_id, mir::MethodId mir_id) {
     if (hir_id.value != structural_subroutine_map_.size()) {
@@ -241,6 +279,42 @@ class ClassLowerer {
   }
 
  private:
+  [[nodiscard]] auto LookupOwnedChildAtHops(
+      hir::StructuralHops hops,
+      const std::variant<hir::InstanceMemberId, hir::GenerateChildRef>& child)
+      const -> mir::MemberId {
+    if (hops.value == 0) {
+      return std::visit(
+          Overloaded{
+              [&](const hir::InstanceMemberId& id) -> mir::MemberId {
+                if (id.value >= instance_member_map_.size()) {
+                  throw InternalError(
+                      "ClassLowerer::TranslateOwnedChild: unmapped HIR "
+                      "instance member");
+                }
+                return instance_member_map_[id.value];
+              },
+              [&](const hir::GenerateChildRef& g) -> mir::MemberId {
+                if (g.generate.value >= generate_map_.size()) {
+                  throw InternalError(
+                      "ClassLowerer::TranslateOwnedChild: unmapped HIR "
+                      "generate");
+                }
+                return generate_map_[g.generate.value]
+                    .by_scope_id.at(g.scope.value)
+                    .var_id;
+              },
+          },
+          child);
+    }
+    if (parent_ == nullptr) {
+      throw InternalError(
+          "ClassLowerer::TranslateOwnedChild: hops exceed scope chain depth");
+    }
+    return parent_->LookupOwnedChildAtHops(
+        hir::StructuralHops{hops.value - 1}, child);
+  }
+
   [[nodiscard]] auto LookupStructuralVarAtHops(
       hir::StructuralHops hops, hir::StructuralVarId hir_id) const
       -> mir::MemberId {
@@ -311,6 +385,8 @@ class ClassLowerer {
   std::vector<mir::MethodId> structural_subroutine_map_;
   std::vector<CrossUnitRefMeta> cross_unit_ref_targets_;
   std::vector<std::optional<mir::LocalRef>> loop_var_procedural_map_;
+  std::vector<mir::MemberId> instance_member_map_;
+  std::vector<GenerateBindings> generate_map_;
 };
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/ast_to_hir/expression/references.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/references.cpp
@@ -271,19 +271,39 @@ auto LowerHierarchicalValue(
         "LowerHierarchicalValue: downward owned-child head has no binding");
   }
 
-  // The owner navigates its own storage, so the head must live on the
-  // referencing frame. A reference reaching the owned child from a nested
-  // generate frame (`hops != 0`) is a separate, unsupported case.
   const auto hops = frame.HopsTo(binding->home_frame);
-  if (!hops.has_value() || hops->value != 0) {
+  if (!hops.has_value()) {
+    throw InternalError(
+        "LowerHierarchicalValue: downward owned-child head's home frame is not "
+        "on the current scope stack");
+  }
+  if (hops->value == 0) {
+    return module.MakeCrossUnitMemberRef(
+        var, binding->home_frame, binding->head, std::move(*path), *type_id,
+        span);
+  }
+
+  // Sibling-of-ancestor: the head sits in an enclosing scope of the referrer.
+  // For an intra-unit owned child (a generate block; its layout is part of
+  // this unit's emitted artifact) the install climbs the runtime parent edge
+  // and composes a typed downward MemberAccess chain on the enclosing class.
+  // A module-instance head with `hops > 0` would require a hybrid typed-climb
+  // / by-name-descent because the instance's body is in another unit;
+  // unsupported here.
+  const bool head_is_intra_unit =
+      head_sym.kind == slang::ast::SymbolKind::GenerateBlock ||
+      head_sym.kind == slang::ast::SymbolKind::GenerateBlockArray;
+  if (!head_is_intra_unit) {
     return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
-        "hierarchical reference reaching an owned child from a nested generate "
-        "scope is not yet supported");
+        "hierarchical reference reaching an owned module instance from a "
+        "nested generate scope is not yet supported");
   }
+  hir::DownwardHead enclosing_head = binding->head;
+  enclosing_head.hops = *hops;
   return module.MakeCrossUnitMemberRef(
-      var, binding->home_frame, binding->head, std::move(*path), *type_id,
-      span);
+      var, frame.Current(), std::move(enclosing_head), std::move(*path),
+      *type_id, span);
 }
 
 auto LowerNamedValueStructural(

--- a/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
+++ b/src/lyra/lowering/ast_to_hir/module_lowerer.cpp
@@ -144,14 +144,14 @@ auto ModuleLowerer::LookupOwnedChildBinding(
 }
 
 auto ModuleLowerer::MapOrGetCrossUnitRef(
-    const slang::ast::ValueSymbol& target, ScopeFrameId home_frame,
+    const slang::ast::ValueSymbol& target, ScopeFrameId slot_owner_frame,
     hir::CrossUnitRefHead head, std::vector<hir::PathStep> path,
     hir::TypeId type) -> hir::CrossUnitRefId {
-  auto& frame_dedup = cross_unit_ref_dedup_[home_frame];
+  auto& frame_dedup = cross_unit_ref_dedup_[slot_owner_frame];
   if (const auto it = frame_dedup.find(&target); it != frame_dedup.end()) {
     return it->second;
   }
-  auto& slots = cross_unit_refs_by_frame_[home_frame];
+  auto& slots = cross_unit_refs_by_frame_[slot_owner_frame];
   const hir::CrossUnitRefId id{static_cast<std::uint32_t>(slots.size())};
   slots.push_back(
       hir::CrossUnitRefDecl{
@@ -174,9 +174,9 @@ auto ModuleLowerer::LookupCrossUnitRef(
   return it->second;
 }
 
-auto ModuleLowerer::TakeCrossUnitRefsForFrame(ScopeFrameId frame)
+auto ModuleLowerer::TakeCrossUnitRefsForFrame(ScopeFrameId slot_owner_frame)
     -> std::vector<hir::CrossUnitRefDecl> {
-  const auto it = cross_unit_refs_by_frame_.find(frame);
+  const auto it = cross_unit_refs_by_frame_.find(slot_owner_frame);
   if (it == cross_unit_refs_by_frame_.end()) {
     return {};
   }
@@ -186,11 +186,11 @@ auto ModuleLowerer::TakeCrossUnitRefsForFrame(ScopeFrameId frame)
 }
 
 auto ModuleLowerer::MakeCrossUnitMemberRef(
-    const slang::ast::ValueSymbol& target, ScopeFrameId home_frame,
+    const slang::ast::ValueSymbol& target, ScopeFrameId slot_owner_frame,
     hir::CrossUnitRefHead head, std::vector<hir::PathStep> path,
     hir::TypeId type, diag::SourceSpan span) -> hir::Expr {
   const hir::CrossUnitRefId slot = MapOrGetCrossUnitRef(
-      target, home_frame, std::move(head), std::move(path), type);
+      target, slot_owner_frame, std::move(head), std::move(path), type);
   return hir::Expr{
       .type = type,
       .data = hir::PrimaryExpr{.data = hir::CrossUnitVarRef{.id = slot}},

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -443,6 +443,10 @@ auto InstallInstanceMembers(ClassLowerer& lowerer, WalkFrame frame)
     const mir::MemberId var_id = mir_class.members.Add(
         mir::MemberDecl{.name = im.instance_name, .type = var_type});
     instance_member_vars.push_back(var_id);
+    lowerer.MapInstanceMember(
+        hir::InstanceMemberId{
+            static_cast<std::uint32_t>(instance_member_vars.size() - 1)},
+        var_id);
 
     AppendExternalUnitConstruction(
         lowerer.Module(), frame, var_id, im.instance_name, im.array_dims);
@@ -573,6 +577,119 @@ auto BuildDownwardNavValue(
   // the call site expects -- the one true MIR cast (`static_cast<T>(...)`).
   return mir::Expr{
       .data = mir::CastExpr{.operand = get_signal_id}, .type = slot_type};
+}
+
+// Linear search for a member by its source name (or by the synthesized name
+// if no source name was recorded). Per-class member arenas are small enough
+// that O(N) at construction time is irrelevant. The within-class name is
+// unique by the structural-scope lowering's allocation rule, so this is a
+// deterministic lookup despite the linear scan.
+auto FindMemberByName(const mir::Class& cls, std::string_view name)
+    -> std::optional<mir::MemberId> {
+  for (std::size_t i = 0; i < cls.members.size(); ++i) {
+    const mir::MemberId id{static_cast<std::uint32_t>(i)};
+    const auto& m = cls.members.Get(id);
+    const std::string_view key = m.source_name.empty() ? m.name : m.source_name;
+    if (key == name) {
+      return id;
+    }
+  }
+  return std::nullopt;
+}
+
+// Builds the resolve value for an intra-unit sibling-of-ancestor reference.
+// The install climbs `down.hops` parent edges (`kParent` calls cast to the
+// enclosing class's typed pointer) and then composes a chain of typed
+// `MemberAccess` through the head and each descent step. Every receiver in
+// the chain is a pointer (`Top*` -> `Pointer<unique, gen_a>` -> ...), so
+// the C++ render emits `->` for every hop and the chain never needs an
+// explicit `DerefExpr` between steps; the leaf `MemberAccess` yields the
+// observable cell field whose address goes into the slot.
+//
+// The parent cast is sound because the structural-containment relation
+// built at HIR-to-MIR proves the receiver's N-th runtime parent is exactly
+// that enclosing specialization. The same invariant grounds the typed
+// enclosing access used for bare-name reads through `StructuralVarRef`;
+// this path extends it one `MemberAccess` further.
+auto BuildTypedEnclosingNavValue(
+    const ClassLowerer& lowerer, WalkFrame frame, const hir::DownwardHead& down,
+    const std::vector<hir::PathStep>& path, mir::TypeId slot_type)
+    -> mir::ExprId {
+  ModuleLowerer& module = lowerer.Module();
+  mir::Block& ctor_block = *frame.current_block;
+  const mir::EnclosingHops mir_hops{.value = down.hops.value};
+  const mir::ExprId typed_enclosing =
+      BuildEnclosingScopeReceiver(frame, module.Unit(), mir_hops);
+  const mir::Class& enclosing_cls = frame.EnclosingClassAtHops(mir_hops);
+  const mir::MemberId head_member =
+      lowerer.TranslateOwnedChild(down.hops, down.child);
+  const mir::TypeId head_field_type =
+      enclosing_cls.members.Get(head_member).type;
+  mir::ExprId receiver = ctor_block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::MemberAccessExpr{
+                  .receiver = typed_enclosing,
+                  .member = mir::MemberRef{.var = head_member}},
+          .type = head_field_type});
+  const auto* head_ptr_ty = std::get_if<mir::PointerType>(
+      &module.Unit().types.Get(head_field_type).data);
+  if (head_ptr_ty == nullptr) {
+    throw InternalError(
+        "BuildTypedEnclosingNavValue: head member is not a pointer type");
+  }
+  const auto* head_obj_ty = std::get_if<mir::ObjectType>(
+      &module.Unit().types.Get(head_ptr_ty->pointee).data);
+  if (head_obj_ty == nullptr) {
+    throw InternalError(
+        "BuildTypedEnclosingNavValue: head pointee is not an intra-unit "
+        "object type");
+  }
+  const mir::Class* current_class =
+      &module.Unit().GetClass(head_obj_ty->class_id);
+  for (std::size_t i = 0; i < path.size(); ++i) {
+    const auto& step = path[i];
+    const auto* mh = std::get_if<hir::MemberHop>(&step);
+    if (mh == nullptr) {
+      throw InternalError(
+          "BuildTypedEnclosingNavValue: index hop in typed intra-unit descent "
+          "is not yet supported");
+    }
+    const auto step_member = FindMemberByName(*current_class, mh->name);
+    if (!step_member.has_value()) {
+      throw InternalError(
+          "BuildTypedEnclosingNavValue: descent step member not found");
+    }
+    const mir::TypeId step_type = current_class->members.Get(*step_member).type;
+    receiver = ctor_block.exprs.Add(
+        mir::Expr{
+            .data =
+                mir::MemberAccessExpr{
+                    .receiver = receiver,
+                    .member = mir::MemberRef{.var = *step_member}},
+            .type = step_type});
+    if (i + 1 == path.size()) {
+      break;
+    }
+    const auto* step_ptr_ty =
+        std::get_if<mir::PointerType>(&module.Unit().types.Get(step_type).data);
+    if (step_ptr_ty == nullptr) {
+      throw InternalError(
+          "BuildTypedEnclosingNavValue: intermediate descent step is not a "
+          "pointer to an instance");
+    }
+    const auto* step_obj_ty = std::get_if<mir::ObjectType>(
+        &module.Unit().types.Get(step_ptr_ty->pointee).data);
+    if (step_obj_ty == nullptr) {
+      throw InternalError(
+          "BuildTypedEnclosingNavValue: intermediate descent into a non-"
+          "object type");
+    }
+    current_class = &module.Unit().GetClass(step_obj_ty->class_id);
+  }
+  return ctor_block.exprs.Add(
+      mir::Expr{
+          .data = mir::AddressOfExpr{.operand = receiver}, .type = slot_type});
 }
 
 // Builds an `UnpackedArray<int32, N>` literal expression holding one element
@@ -739,21 +856,27 @@ void InstallCrossUnitRefs(
       continue;
     }
     const mir::MemberId slot = member;
-    mir::MemberId head_var{};
-    if (const auto* im = std::get_if<hir::InstanceMemberId>(&down->child)) {
-      head_var = instance_member_vars.at(im->value);
-    } else {
-      const auto& g = std::get<hir::GenerateChildRef>(down->child);
-      head_var = gen_bindings.at(g.generate.value)
-                     .by_scope_id.at(g.scope.value)
-                     .var_id;
-    }
-    const auto& head = mir_class.members.Get(head_var);
-    const std::string head_name =
-        head.source_name.empty() ? head.name : head.source_name;
     const mir::TypeId slot_type = mir_class.members.Get(slot).type;
-    const mir::ExprId nav = ctor_block.exprs.Add(BuildDownwardNavValue(
-        module, frame, head_name, cu.path, slot_type, scope_ptr_type));
+    mir::ExprId nav{};
+    if (down->hops.value != 0) {
+      nav = BuildTypedEnclosingNavValue(
+          lowerer, frame, *down, cu.path, slot_type);
+    } else {
+      mir::MemberId head_var{};
+      if (const auto* im = std::get_if<hir::InstanceMemberId>(&down->child)) {
+        head_var = instance_member_vars.at(im->value);
+      } else {
+        const auto& g = std::get<hir::GenerateChildRef>(down->child);
+        head_var = gen_bindings.at(g.generate.value)
+                       .by_scope_id.at(g.scope.value)
+                       .var_id;
+      }
+      const auto& head = mir_class.members.Get(head_var);
+      const std::string head_name =
+          head.source_name.empty() ? head.name : head.source_name;
+      nav = ctor_block.exprs.Add(BuildDownwardNavValue(
+          module, frame, head_name, cu.path, slot_type, scope_ptr_type));
+    }
     const mir::ExprId self_for_target = ctor_block.exprs.Add(
         MakeSelfRefExpr(frame, mir_class.self_pointer_type));
     const mir::ExprId target = ctor_block.exprs.Add(
@@ -1396,6 +1519,8 @@ auto InstallGenerateOwnedChildScopes(ClassLowerer& lowerer, WalkFrame frame)
           ChildStructuralScopeBinding{.scope_id = child_id, .var_id = var_id};
     }
 
+    lowerer.MapGenerate(
+        hir::GenerateId{static_cast<std::uint32_t>(gen_idx)}, gen_bindings);
     bindings_by_generate.push_back(std::move(gen_bindings));
   }
   return bindings_by_generate;

--- a/tests/cases/cpp/hierarchy_upward_visible_child/case.yaml
+++ b/tests/cases/cpp/hierarchy_upward_visible_child/case.yaml
@@ -8,4 +8,4 @@ input:
 expect:
   exit: 0
   stdout:
-    exact: "shallow=7 deep=22 a=11 b_inst=99\n"
+    exact: "up=7 down=33 deep=22 a=11 b_inst=99\n"

--- a/tests/cases/cpp/hierarchy_upward_visible_child/main.sv
+++ b/tests/cases/cpp/hierarchy_upward_visible_child/main.sv
@@ -1,13 +1,19 @@
-// One elaboration covers every shape of LRM 23.8 step b/c upward
-// visible-child resolution. The runtime climb walks each enclosing level
-// and matches a child by its canonical instance name; this case bites
-// every code path that walk exercises, with values chosen so a wrong
-// lookup observably fails:
+// One elaboration covers every shape of LRM 23.8 step b/c visible-child
+// resolution -- semantically symmetric across slang's `isUpward` flag, so
+// both directions of the same generate-sibling read appear here:
 //
-//   - Shallow sibling generate (block `a` reads `b.bx == 7`). `a` is
-//     declared before `b`, so slang classifies the reference as upward
-//     (the converse `b -> a` rides slang's downward path, an unrelated
-//     lowering limitation tracked separately).
+//   - Shallow sibling generate, slang-upward (block `a` reads `b.bx == 7`).
+//     `a` is declared before `b`, so slang's lexical resolution walks out
+//     to find `b`; the install rides the upward path (runtime climb-by-
+//     name through `ExternUp`).
+//
+//   - Shallow sibling generate, slang-downward (block `b` reads
+//     `a.ax == 33`). `a` is already visible at `b`'s lexical resolution,
+//     so slang flags it downward with the head in an enclosing scope; the
+//     install climbs the typed parent edge (`kParent` + `PointerCastExpr`)
+//     and composes a typed `MemberAccess` chain into the head's owned
+//     child. Same semantic target as the upward case, different install
+//     mechanism driven only by slang's source-order classification.
 //
 //   - Sibling-of-ancestor at depth (Leaf reads `my_foo.v == 22`). From
 //     inside `mid.leaf`, my_foo is neither on the chain nor in a closer
@@ -32,11 +38,14 @@ endmodule
 
 module Top;
   if (1) begin : a
+    int ax;
     int from_b;
     always_comb from_b = b.bx;
   end
   if (1) begin : b
     int bx;
+    int from_a;
+    always_comb from_a = a.ax;
   end
 
   if (1) begin : reader
@@ -53,12 +62,13 @@ module Top;
 
   initial begin
     b.bx = 7;
+    a.ax = 33;
     my_foo.v = 22;
     foo_a.v = 11;
     foo_b.v = 99;
     #1;
-    $display("shallow=%0d deep=%0d a=%0d b_inst=%0d",
-             a.from_b, mid.leaf.from_top_my_foo,
+    $display("up=%0d down=%0d deep=%0d a=%0d b_inst=%0d",
+             a.from_b, b.from_a, mid.leaf.from_top_my_foo,
              reader.from_a, reader.from_b);
   end
 endmodule


### PR DESCRIPTION
## Summary

Completes the symmetric counterpart of last week's `D2d` sibling-of-ancestor support. The PR shipped covered the case where slang flags the reference as upward (e.g. `a -> b.bx` when `b` is declared after `a`), riding the `ExternUp` wrapper's runtime by-name climb. The reverse direction (`b -> a.ax` when `a` is declared first) was classified as downward by slang and bailed at `hops != 0` in the lowering. SystemVerilog semantically treats both as the same sibling-generate read; this change makes the compiler treat them that way too. The failing case now lowers to a typed pointer chain (`static_cast<Top*>(self->Parent())->a->ax`) -- no runtime by-name lookup, no slot wrapper, just three pointer hops the C++ inliner can collapse.

## Design

The typed climb is composed from primitives that already exist in the codebase. `BuildEnclosingScopeReceiver` (in `src/lyra/lowering/hir_to_mir/self_ref.cpp`) implements `kParent`-then-`PointerCastExpr` and has been in production use to lower `StructuralVarRef` reads at `hops > 0` (the bare-name enclosing access path). The new `BuildTypedEnclosingNavValue` extends that chain one or more `MemberAccess` further: typed parent pointer -> head's owned-child field -> descent path -> address-of the leaf cell -> assign into the slot. No new MIR primitive, no new HIR ref kind, no new runtime SDK call.

`DownwardHead` gains a `hops` field so the head can sit in an enclosing scope rather than the referrer's own frame. For `hops == 0` the existing SDK-by-name install path is unchanged. For `hops > 0` with a generate-block head, the typed install path runs; for `hops > 0` with a module-instance head, the lowering still bails (that case needs a hybrid typed-climb / by-name-descent because the instance's body is in another unit).

`ClassLowerer` gains `MapInstanceMember` / `MapGenerate` / `TranslateOwnedChild`, mirroring the existing `StructuralVar` / `LoopVarAsStructuralParam` / `StructuralSubroutine` translation pattern. The typed install resolves the head's MIR member through the parent-chain accessor, not through a source-name lookup, so the head's identity travels as a HIR-level id all the way to MIR emission. The `home_frame` parameter on `MapOrGetCrossUnitRef` / `MakeCrossUnitMemberRef` / `TakeCrossUnitRefsForFrame` is renamed to `slot_owner_frame` -- the slot owner and the head owner coincide only when `hops == 0`, and the former name conflated them.

## Testing

The consolidated `hierarchy_upward_visible_child` test grew to cover both directions of the same generate-sibling read in one elaboration. Header comment updated to describe the symmetry explicitly. The same Top-level elaboration also covers sibling-of-ancestor at depth (Leaf reading `my_foo.v`) and canonical-name discrimination across instances of the same module, neither of which changed shape. `bazel test //...` is green.