### PR TITLE
Add case equality for unpacked struct values

### DIFF
--- a/docs/progress/struct-union.md
+++ b/docs/progress/struct-union.md
@@ -42,10 +42,11 @@ Table 7-1).
       in which case that value is used. The 2-state / 4-state distinction propagates per member. A
       member's initial assignment may itself be an aggregate literal (a struct- or array-typed
       member default).
-- [ ] S4 -- Aggregate copy and equality (`==` / `!=` / `===` / `!==`), and member access composing
+- [x] S4 -- Aggregate copy and equality (`==` / `!=` / `===` / `!==`), and member access composing
       with element / range selects on packed members and on either side of an expression
       (`s.f[3:0]`, `s.f + 1`). A struct field reads and writes correctly in arithmetic, conditional,
-      and other expression contexts.
+      and other expression contexts. Case equality on a struct with a real / shortreal leaf is
+      rejected, per the LRM (Table 11-1).
 - [ ] S5 -- Members with managed lifecycle (string, and any future value type with non-trivial copy
       semantics). Whole-struct copy gives each copy independent member storage; assignment releases
       the destination's prior member value; multiple and nested managed members compose.

--- a/include/lyra/value/tuple.hpp
+++ b/include/lyra/value/tuple.hpp
@@ -51,6 +51,20 @@ class Tuple {
     return !(*this == other);
   }
 
+  // LRM 11.4.5 `===` / `!==` (case equality): member-wise bit-for-bit identity,
+  // AND-reduced to a 1-bit PackedArray that is always a known 0 or 1. A real /
+  // shortreal leaf has no case-equality meaning and is rejected before
+  // lowering, so every component itself supplies case equality.
+  [[nodiscard]] auto CaseEqual(const Tuple& other) const -> PackedArray {
+    return [&]<std::size_t... I>(std::index_sequence<I...>) {
+      PackedArray result = PackedArray::Bit(true);
+      ((result =
+            result && std::get<I>(data_).CaseEqual(std::get<I>(other.data_))),
+       ...);
+      return result;
+    }(std::index_sequence_for<Ts...>{});
+  }
+
   // LRM 9.4.2 update-event predicate (engine change-detection hook): are the
   // two values member-wise bit-identical.
   [[nodiscard]] auto IsBitIdentical(const Tuple& other) const -> bool {
@@ -72,5 +86,6 @@ class Tuple {
 };
 
 static_assert(LyraValue<Tuple<PackedArray, PackedArray>>);
+static_assert(CaseEqualComparable<Tuple<PackedArray, PackedArray>>);
 
 }  // namespace lyra::value

--- a/tests/cases/cpp/unpacked_struct_equality/case.yaml
+++ b/tests/cases/cpp/unpacked_struct_equality/case.yaml
@@ -1,0 +1,24 @@
+id: cpp.unpacked_struct_equality
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    eq_same: 1
+    eq_diff: 0
+    ne_same: 0
+    ne_diff: 1
+    ceq_same: 1
+    ceq_diff: 0
+    cne_same: 0
+    cne_diff: 1
+    ceq_nest: 1
+    ceq_nest_diff: 0
+    ceq_x: 1
+    ceq_x_diff: 0
+    sum: 6
+    slc: 6

--- a/tests/cases/cpp/unpacked_struct_equality/main.sv
+++ b/tests/cases/cpp/unpacked_struct_equality/main.sv
@@ -1,0 +1,71 @@
+module Top;
+  typedef struct {
+    int  a;
+    byte b;
+  } pair_t;
+
+  typedef struct {
+    pair_t inner;
+    int    tag;
+  } nest_t;
+
+  typedef struct {
+    int        a;
+    logic [7:0] b;
+  } lt_t;
+
+  pair_t p1;
+  pair_t p2;
+  pair_t p3;
+  nest_t n1;
+  nest_t n2;
+  nest_t n3;
+  lt_t   x1;
+  lt_t   x2;
+  lt_t   x3;
+
+  int eq_same;
+  int eq_diff;
+  int ne_same;
+  int ne_diff;
+  int ceq_same;
+  int ceq_diff;
+  int cne_same;
+  int cne_diff;
+  int ceq_nest;
+  int ceq_nest_diff;
+  int ceq_x;
+  int ceq_x_diff;
+  int sum;
+  logic [3:0] slc;
+
+  initial begin
+    p1 = '{a: 5, b: 8'd6};
+    p2 = '{a: 5, b: 8'd6};
+    p3 = '{a: 5, b: 8'd7};
+
+    eq_same = (p1 == p2);
+    eq_diff = (p1 == p3);
+    ne_same = (p1 != p2);
+    ne_diff = (p1 != p3);
+    ceq_same = (p1 === p2);
+    ceq_diff = (p1 === p3);
+    cne_same = (p1 !== p2);
+    cne_diff = (p1 !== p3);
+
+    n1 = '{inner: '{a: 7, b: 8'd8}, tag: 9};
+    n2 = n1;
+    n3 = '{inner: '{a: 7, b: 8'd8}, tag: 10};
+    ceq_nest = (n1 === n2);
+    ceq_nest_diff = (n1 === n3);
+
+    x1 = '{a: 5, b: 8'bx};
+    x2 = '{a: 5, b: 8'bx};
+    x3 = '{a: 6, b: 8'bx};
+    ceq_x = (x1 === x2);
+    ceq_x_diff = (x1 === x3);
+
+    sum = p1.a + 1;
+    slc = p1.b[3:0];
+  end
+endmodule


### PR DESCRIPTION
## Summary

Completes S4 of the unpacked-struct workstream: the case equality operators (`===` / `!==`) now work on whole unpacked struct values. slang lowers struct case equality to a type-agnostic `CaseEqual` call, but the runtime `Tuple` value supplied `==` / `!=` and bit-identity without the `CaseEqual` form, so any struct `===` failed to compile in the emitted C++. `Tuple::CaseEqual` adds the missing form as member-wise bit-for-bit identity, AND-reduced to a 1-bit `PackedArray` that is always a known 0 or 1, mirroring the existing `operator==` and `IsBitIdentical`.

The remaining S4 surface already worked and is now locked by tests: `==` / `!=` on whole structs, member access composing inside an expression (`s.f + 1`), and a range select on a packed member (`s.f[3:0]`). Case equality on a struct with a real or shortreal leaf has no single correct meaning and is already rejected at AST-to-HIR (LRM Table 11-1), so every component that reaches `Tuple::CaseEqual` itself supplies case equality and the recursion closes through nested structs.

## Testing

New `unpacked_struct_equality` case asserts `==` / `!=` / `===` / `!==` on a struct, nested-struct case equality, 4-state x-bit matching (where `===` stays deterministic while `==` would not), and the member-access composition forms. Full `bazel test //...` is green.