### PR TITLE
Make Tuple value type default-resettable

### DIFF
--- a/docs/progress/struct-union.md
+++ b/docs/progress/struct-union.md
@@ -29,7 +29,7 @@ qualifier the struct is unpacked -- its members are stored independently rather 
 one vector -- so it is a composite value, not an integral one. Default value is member-wise (LRM
 Table 7-1).
 
-- [ ] S1 -- Type infrastructure, declaration, member read, and blocking member write (LRM 7.2).
+- [x] S1 -- Type infrastructure, declaration, member read, and blocking member write (LRM 7.2).
       Whole-struct assignment is value-semantic: a copy is independent of its source. Members may be
       any supported integral, packed, real, or string type; an unpacked struct nests as a member of
       another unpacked struct, and a struct is usable as an unpacked-array element and may itself
@@ -47,9 +47,11 @@ Table 7-1).
       (`s.f[3:0]`, `s.f + 1`). A struct field reads and writes correctly in arithmetic, conditional,
       and other expression contexts. Case equality on a struct with a real / shortreal leaf is
       rejected, per the LRM (Table 11-1).
-- [ ] S5 -- Members with managed lifecycle (string, and any future value type with non-trivial copy
+- [x] S5 -- Members with managed lifecycle (string, and any future value type with non-trivial copy
       semantics). Whole-struct copy gives each copy independent member storage; assignment releases
-      the destination's prior member value; multiple and nested managed members compose.
+      the destination's prior member value; multiple and nested managed members compose. A struct is
+      also usable as an unpacked-array element with the same value-independent copy on element
+      write.
 
 ## Unpacked Union
 

--- a/include/lyra/value/tuple.hpp
+++ b/include/lyra/value/tuple.hpp
@@ -81,11 +81,22 @@ class Tuple {
     }(std::index_sequence_for<Ts...>{});
   }
 
+  // LRM Table 7-1 unpacked-struct default: member-wise reset, each component to
+  // its own Table 6-7 default. In-place rather than reconstruct, so a container
+  // can scrub a reused discard slot to canonical before handing out a
+  // reference.
+  auto ResetToDefault() -> void {
+    [&]<std::size_t... I>(std::index_sequence<I...>) {
+      (std::get<I>(data_).ResetToDefault(), ...);
+    }(std::index_sequence_for<Ts...>{});
+  }
+
  private:
   std::tuple<Ts...> data_;
 };
 
 static_assert(LyraValue<Tuple<PackedArray, PackedArray>>);
 static_assert(CaseEqualComparable<Tuple<PackedArray, PackedArray>>);
+static_assert(Defaultable<Tuple<PackedArray, PackedArray>>);
 
 }  // namespace lyra::value

--- a/tests/cases/cpp/unpacked_struct_managed_members/case.yaml
+++ b/tests/cases/cpp/unpacked_struct_managed_members/case.yaml
@@ -1,0 +1,17 @@
+id: cpp.unpacked_struct_managed_members
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    a_first: "ann"
+    a_last: "lee"
+    b_first: "bob"
+    b_id: 3
+    eq_ab: 0
+    arr0_last: "dog"
+    arr1_first: "cat"

--- a/tests/cases/cpp/unpacked_struct_managed_members/main.sv
+++ b/tests/cases/cpp/unpacked_struct_managed_members/main.sv
@@ -1,0 +1,40 @@
+module Top;
+  typedef struct {
+    string first;
+    string last;
+  } name_t;
+
+  typedef struct {
+    name_t nm;
+    int    id;
+  } rec_t;
+
+  rec_t a;
+  rec_t b;
+  string a_first;
+  string a_last;
+  string b_first;
+  int    b_id;
+  int    eq_ab;
+
+  name_t arr[2];
+  string arr0_last;
+  string arr1_first;
+
+  initial begin
+    a = '{nm: '{first: "ann", last: "lee"}, id: 3};
+    b = a;
+    b.nm.first = "bob";
+    a_first = a.nm.first;
+    a_last = a.nm.last;
+    b_first = b.nm.first;
+    b_id = b.id;
+    eq_ab = (a == b);
+
+    arr[0] = '{first: "cat", last: "dog"};
+    arr[1] = arr[0];
+    arr[0].last = "fox";
+    arr0_last = arr[1].last;
+    arr1_first = arr[1].first;
+  end
+endmodule


### PR DESCRIPTION
## Summary

Completes the unpacked-struct workstream (S1-S5) by closing the one gap that kept a struct from being used as an unpacked-array element. The runtime product type `lyra::value::Tuple<Ts...>` already composed equality, case equality, bit-identity, and unknown detection from its components, but it never implemented `ResetToDefault`, so it was the only value type that did not satisfy the `Defaultable` concept. A container that holds tuples (`UnpackedArray<Tuple<...>>`) scrubs its out-of-bounds discard slot to canonical via `ResetToDefault` before handing out a reference, so writing through a struct-array element failed to compile. This was latent since S1 and is independent of the member types: a struct of plain `int` members hit it just as a struct with `string` members did.

The fix adds `Tuple::ResetToDefault`, which resets each component to its own LRM Table 6-7 default member-wise, mirroring the existing compose pattern for the other aggregate contracts. Recursion closes because every component (packed, real, string, nested tuple) already supplies the reset.

## Design

S5's managed-lifecycle contract (whole-struct copy gives independent member storage, assignment releases the destination's prior member value, multiple and nested managed members compose) needs no compiler-layer work: `Tuple` holds its members by value, so a `string` member is an owned value whose deep-copy and release semantics flow through ordinary C++ copy and assignment. There is no lifecycle concept in HIR or MIR; it is purely a runtime value-type property, consistent with the value-type concept lattice.

## Testing

New case `unpacked_struct_managed_members` exercises string-member copy independence, prior-value release on member write, nested and multiple string members, a whole-struct equality after mutation, and a struct used as an unpacked-array element with value-independent copy on element write. `bazel test //...` passes.