### PR TITLE
Lower generate genvars as runtime values

### DIFF
--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -48,6 +48,11 @@ full support.
       pervasively, so this reaches far past the leaf modules where it is the first blocker. Scalar
       parameters fold in any expression context; an unpacked-array `localparam` referenced and
       element-selected (the ibex_alu shuffle-mask form) now materializes too.
+- [x] **Enclosing-`genvar` references in nested generate** -- an inner generate whose loop bound or
+      body reads an outer generate's `genvar`, and `genvar`-dependent part-select bounds (the
+      ibex_alu butterfly form, e.g. `mask[stg][N*(2*seg+1)-1 : N*2*seg]`). A generate scope's
+      `genvar` is a runtime induction value reached across scopes, so a `genvar`-dependent bound
+      stays runtime rather than folding to a single elaboration constant.
 
 ### Common forms
 
@@ -62,6 +67,8 @@ full support.
 - [ ] **Net-typed port connections** -- connecting a net (`wire`) across a module port, as the
       testbench does when wiring the DUT. The first wall the full top-level testbench hits.
 - [x] **`$signed` / `$unsigned`** system functions.
+- [ ] **`$clog2`** system function (appears in a bit-count select bound). The current ibex_alu
+      frontier once the generate / `genvar` forms above lower.
 
 ### Localized / long tail
 

--- a/include/lyra/lowering/hir_to_mir/class_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/class_lowerer.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstdint>
 #include <optional>
 #include <span>
 #include <string>
@@ -47,6 +46,14 @@ struct ScopeEntryStructuralParamBinding {
   hir::LoopVarDeclId source_loop_var = {};
 };
 
+// A located structural param: the enclosing-scope distance to the scope that
+// owns it and the param's id on that scope. The reading site turns it into a
+// receiver-addressed `mir::ParamRef` via `BuildStructuralParamAccessExpr`.
+struct StructuralParamLocation {
+  mir::EnclosingHops hops = {};
+  mir::ParamId param = {};
+};
+
 // Per-scope lowering registries for one `mir::Class`. Carries
 // scope-local HIR-to-MIR translation maps and the cross-unit-ref slot table.
 // Holds no pointer to the IR scope being built: handlers reach it through
@@ -73,11 +80,6 @@ class ClassLowerer {
 
   // Central scope-level expression dispatcher. One switch over `hir::Expr::
   // data` routing each kind to the per-family handler in `expression/*.cpp`.
-  // `LoopVarRef` resolution is selected by `frame.loop_var_mode` so the same
-  // recursion path serves both generate-header (procedural induction) and
-  // generate-control (structural-param) contexts. Per-kind handlers reach
-  // recursion back through this method, so the mode persists across
-  // sub-expressions until the caller resets it.
   [[nodiscard]] auto LowerExpr(const hir::Expr& expr, WalkFrame frame) const
       -> diag::Result<mir::Expr>;
 
@@ -208,9 +210,11 @@ class ClassLowerer {
 
   // HIR places `LoopVarDecl` in the for-generate's parent scope; MIR re-homes
   // the same value into the constructed child scope. MIR hops = HIR hops - 1.
+  // The caller turns the located (hops, param) into a receiver-addressed read
+  // via `BuildStructuralParamAccessExpr`.
   [[nodiscard]] auto TranslateLoopVarAsStructuralParam(
       hir::StructuralHops hir_hops, hir::LoopVarDeclId hir_id) const
-      -> mir::ParamRef {
+      -> StructuralParamLocation {
     if (hir_hops.value == 0) {
       throw InternalError(
           "ClassLowerer::TranslateLoopVarAsStructuralParam: "
@@ -218,11 +222,10 @@ class ClassLowerer {
           "child-owned in MIR; header expressions must use the procedural "
           "induction var path)");
     }
-    const std::uint32_t mir_hops = hir_hops.value - 1;
-    const mir::ParamId mir_id = LookupStructuralParamAtMirHops(
-        mir::EnclosingHops{.value = mir_hops}, hir_id);
-    return mir::ParamRef{
-        .hops = mir::EnclosingHops{.value = mir_hops}, .param = mir_id};
+    const mir::EnclosingHops mir_hops{.value = hir_hops.value - 1};
+    return StructuralParamLocation{
+        .hops = mir_hops,
+        .param = LookupStructuralParamAtMirHops(mir_hops, hir_id)};
   }
 
   // Records the MIR slot a HIR owned-child reference resolves to. An instance

--- a/include/lyra/lowering/hir_to_mir/module_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/module_lowerer.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
@@ -69,6 +72,15 @@ class ModuleLowerer {
     type_map_.emplace_back(mir_id);
   }
 
+  // Mints a collision-free class name for one generate scope, tagged by its
+  // arm kind (`loop` / `then` / `else` / ...). The name is only an
+  // implementation handle for the emitted type -- a generate scope's runtime
+  // identity is its HierarchySegment -- so it need only be unit-unique and
+  // deterministic, which a monotonic count over the deterministic lowering walk
+  // provides.
+  [[nodiscard]] auto NextGenerateScopeName(std::string_view arm_tag)
+      -> std::string;
+
  private:
   [[nodiscard]] auto TranslateTypeData(
       const hir::TypeData& data, diag::DiagSpan type_span) const
@@ -78,6 +90,7 @@ class ModuleLowerer {
   const diag::SourceManager* source_manager_;
   mir::CompilationUnit unit_;
   std::vector<mir::TypeId> type_map_;
+  std::uint32_t next_generate_scope_name_ = 0;
 };
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/self_ref.hpp
+++ b/include/lyra/lowering/hir_to_mir/self_ref.hpp
@@ -46,6 +46,14 @@ auto BuildStructuralMemberAccessExpr(
     const WalkFrame& frame, const mir::CompilationUnit& unit,
     mir::EnclosingHops hops, mir::MemberId var) -> mir::Expr;
 
+// Builds a read of a constructor-bound structural param (a generate `genvar`,
+// LRM 27.4) at `hops` enclosing-class levels up: the same enclosing-scope
+// receiver as a member access, with the param named as a field on it. The
+// result type is the param's declared type, read from the scope at `hops`.
+auto BuildStructuralParamAccessExpr(
+    const WalkFrame& frame, const mir::CompilationUnit& unit,
+    mir::EnclosingHops hops, mir::ParamId param) -> mir::Expr;
+
 // Constructs a reference to the cell `cell` denotes (LRM 13.5.2): adds a
 // reference-construction `CallExpr` to `block` whose result type is a
 // `RefType` over `pointee`, and returns its id. The body that holds the

--- a/include/lyra/lowering/hir_to_mir/walk_frame.hpp
+++ b/include/lyra/lowering/hir_to_mir/walk_frame.hpp
@@ -30,18 +30,6 @@ struct ScopeChainNode {
   const ScopeChainNode* parent;
 };
 
-// How a HIR `LoopVarRef` resolves in the `ClassLowerer` dispatcher. The two
-// values correspond to the two structural contexts a constructor expression
-// can sit in: a for-generate header (where the loop variable lowers to the
-// constructor's induction local) and a generate-control / continuous assign
-// (where the loop variable lowers to a structural param on the constructed
-// child object). Meaningful only in `ClassLowerer::LowerExpr`; ignored by the
-// `ProcessLowerer` dispatcher.
-enum class LoopVarLoweringMode : std::uint8_t {
-  kProceduralInduction,
-  kStructuralParam,
-};
-
 // Per-recursion traversal context for HIR-to-MIR. Carried by value through
 // every dispatcher method and per-kind handler. Walk-invariant facts (the
 // compilation unit being constructed, builtins) live on the Lowerer class,
@@ -103,13 +91,6 @@ struct WalkFrame {
   // The `ReturnStmt` lowering reads this to fill the stmt's
   // `is_coroutine_return` attribute (a C++ render hint, ignored by LIR / LLVM).
   bool is_coroutine_body = false;
-
-  // How a `LoopVarRef` resolves in `ClassLowerer::LowerExpr`. Set
-  // by the caller before dispatching a constructor expression. The default
-  // (`kStructuralParam`) matches the common generate-control / continuous
-  // assign context; for-generate header lowering switches to
-  // `kProceduralInduction`. Ignored by `ProcessLowerer::LowerExpr`.
-  LoopVarLoweringMode loop_var_mode = LoopVarLoweringMode::kStructuralParam;
 
   // True while lowering an assignment's left-hand side. A queue
   // element-select dispatches to its write-side callee (LRM 7.10.1
@@ -188,13 +169,6 @@ struct WalkFrame {
       IterationBindingRegistry* registry) const -> WalkFrame {
     WalkFrame next = *this;
     next.iteration_bindings = registry;
-    return next;
-  }
-
-  [[nodiscard]] auto WithLoopVarMode(LoopVarLoweringMode mode) const
-      -> WalkFrame {
-    WalkFrame next = *this;
-    next.loop_var_mode = mode;
     return next;
   }
 

--- a/include/lyra/mir/param.hpp
+++ b/include/lyra/mir/param.hpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <string>
 
-#include "lyra/mir/enclosing_hops.hpp"
+#include "lyra/mir/expr_id.hpp"
 #include "lyra/mir/type_id.hpp"
 
 namespace lyra::mir {
@@ -20,8 +20,14 @@ struct ParamDecl {
   TypeId type;
 };
 
+// A read of a constructor-bound structural param (a generate `genvar` per LRM
+// 27.4), addressed like a member field: `receiver` is the scope object that
+// owns the param -- `self` for a same-scope read, an enclosing-scope object
+// reached by climbing the object tree for a cross-scope read -- and `param`
+// names the field on that object. The climb is baked into `receiver`, parallel
+// to `MemberAccessExpr`, so the read needs no enclosing-hop count of its own.
 struct ParamRef {
-  EnclosingHops hops = {};
+  ExprId receiver = {};
   ParamId param = {};
 };
 

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -164,13 +164,12 @@ auto RenderRealLiteralExpr(
 
 auto RenderParamExpr(const ScopeView& view, const mir::ParamRef& r)
     -> std::string {
-  if (r.hops.value != 0) {
-    throw InternalError(
-        "cross-scope param access is not yet implemented in "
-        "cpp emit");
-  }
-  const std::string& name = view.Class().params.Get(r.param).name;
-  return std::format("self->{}", name);
+  const mir::Expr& receiver = view.Expr(r.receiver);
+  const auto& ptr =
+      std::get<mir::PointerType>(view.Unit().types.Get(receiver.type).data);
+  const std::string& name =
+      view.ClassByObjectType(ptr.pointee).params.Get(r.param).name;
+  return std::format("{}->{}", RenderExpr(view, receiver), name);
 }
 
 auto LookupLocalName(const ScopeView& view, const mir::LocalRef& ref)

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -7,7 +7,6 @@
 #include <slang/ast/expressions/SelectExpressions.h>
 #include <slang/ast/symbols/MemberSymbols.h>
 #include <slang/ast/types/Type.h>
-#include <slang/numeric/ConstantValue.h>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
@@ -15,7 +14,6 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/expr_builders.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
-#include "lyra/lowering/ast_to_hir/constant_value.hpp"
 #include "lyra/lowering/ast_to_hir/module_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
 #include "lyra/lowering/ast_to_hir/structural_scope_lowerer.hpp"
@@ -112,22 +110,16 @@ auto LowerRangeSelectExpr(
   const WalkFrame bound_frame =
       sel.value().type->isQueue() ? frame.WithDollarBase(base_id) : frame;
 
-  // A bound slang has evaluated to a constant (an `[msb:lsb]` endpoint or an
-  // indexed-select width, both required constant by LRM 11.5.1) folds to a
-  // literal from slang's value, so the downstream layer reads the constant
-  // directly instead of re-deriving it from a structural parameter expression.
-  // A non-constant bound -- a variable indexed-select base, a queue `$` --
-  // falls back to structural lowering.
+  // A select bound lowers as an ordinary expression, the same faithful lowering
+  // any operand gets. A genuinely constant bound (LRM 11.5.1) becomes a
+  // constant expression the downstream optimizer folds; a genvar-dependent
+  // bound stays a runtime read of the constructor's induction variable, since a
+  // for-generate is a runtime constructor loop, not unrolled. The bound is
+  // never collapsed to slang's elaboration-time constant here -- leaning on the
+  // frontend's folding to stand in for lowering Lyra has not implemented would
+  // hide the real gap.
   auto lower_bound =
       [&](const slang::ast::Expression& bound) -> diag::Result<hir::ExprId> {
-    if (const auto* constant = bound.getConstant(); constant != nullptr) {
-      auto bound_type = lowerer.Module().InternType(*bound.type, span);
-      if (!bound_type) return std::unexpected(std::move(bound_type.error()));
-      auto literal = MakeConstantValueExpr(
-          lowerer.Module().Unit(), frame, *constant, *bound_type, span);
-      if (!literal) return std::unexpected(std::move(literal.error()));
-      return frame.Exprs().Add(*std::move(literal));
-    }
     auto lowered = lowerer.LowerExpr(bound, bound_frame);
     if (!lowered) return std::unexpected(std::move(lowered.error()));
     return frame.Exprs().Add(*std::move(lowered));

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -63,11 +63,6 @@ auto MaybeWrapObservable(ModuleLowerer& module, mir::TypeId t) -> mir::TypeId {
   return module.Unit().types.Intern(mir::ObservableType{.value = t});
 }
 
-auto ChildScopeNameFor(std::size_t gen_index, std::string_view arm_tag)
-    -> std::string {
-  return std::format("gen{}_{}", gen_index, arm_tag);
-}
-
 auto CompanionVarNameFor(std::string_view child_scope_name) -> std::string {
   return std::string(child_scope_name) + "_obj";
 }
@@ -100,9 +95,8 @@ struct GenerateChildSpec {
 };
 
 auto EnumerateGenerateChildSpecs(
-    const hir::Generate& gen, std::size_t gen_index,
-    const hir::StructuralScope& enclosing_scope, ModuleLowerer& module)
-    -> std::vector<GenerateChildSpec> {
+    const hir::Generate& gen, const hir::StructuralScope& enclosing_scope,
+    ModuleLowerer& module) -> std::vector<GenerateChildSpec> {
   std::vector<GenerateChildSpec> specs;
   std::visit(
       Overloaded{
@@ -111,7 +105,7 @@ auto EnumerateGenerateChildSpecs(
             specs.push_back(
                 {.scope_id = if_gen.then_scope,
                  .scope = &then_scope,
-                 .scope_name = ChildScopeNameFor(gen_index, "then"),
+                 .scope_name = module.NextGenerateScopeName("then"),
                  .is_repeated = false,
                  .entry_bindings = {}});
             if (if_gen.else_scope.has_value()) {
@@ -119,7 +113,7 @@ auto EnumerateGenerateChildSpecs(
               specs.push_back(
                   {.scope_id = *if_gen.else_scope,
                    .scope = &else_scope,
-                   .scope_name = ChildScopeNameFor(gen_index, "else"),
+                   .scope_name = module.NextGenerateScopeName("else"),
                    .is_repeated = false,
                    .entry_bindings = {}});
             }
@@ -132,7 +126,7 @@ auto EnumerateGenerateChildSpecs(
                   {.scope_id = case_gen.items[k].scope,
                    .scope = &item_scope,
                    .scope_name =
-                       ChildScopeNameFor(gen_index, std::format("case{}", k)),
+                       module.NextGenerateScopeName(std::format("case{}", k)),
                    .is_repeated = false,
                    .entry_bindings = {}});
             }
@@ -142,7 +136,7 @@ auto EnumerateGenerateChildSpecs(
               specs.push_back(
                   {.scope_id = *case_gen.default_scope,
                    .scope = &default_scope,
-                   .scope_name = ChildScopeNameFor(gen_index, "default"),
+                   .scope_name = module.NextGenerateScopeName("default"),
                    .is_repeated = false,
                    .entry_bindings = {}});
             }
@@ -162,7 +156,7 @@ auto EnumerateGenerateChildSpecs(
             specs.push_back(
                 {.scope_id = loop_gen.scope,
                  .scope = &loop_scope,
-                 .scope_name = ChildScopeNameFor(gen_index, "loop"),
+                 .scope_name = module.NextGenerateScopeName("loop"),
                  .is_repeated = true,
                  .entry_bindings = std::move(bindings)});
           },
@@ -1404,22 +1398,19 @@ auto LowerLoopGenerate(
 
   lowerer.MapLoopVarAsProcedural(loop.loop_var, loop_local);
 
-  const WalkFrame proc_frame =
-      frame.WithLoopVarMode(LoopVarLoweringMode::kProceduralInduction);
   auto init_or =
-      lowerer.LowerExpr(enclosing_scope.exprs.Get(loop.initial), proc_frame);
+      lowerer.LowerExpr(enclosing_scope.exprs.Get(loop.initial), frame);
   if (!init_or) return std::unexpected(std::move(init_or.error()));
   const mir::ExprId init_id = block.exprs.Add(*std::move(init_or));
 
-  auto cond_or =
-      lowerer.LowerExpr(enclosing_scope.exprs.Get(loop.stop), proc_frame);
+  auto cond_or = lowerer.LowerExpr(enclosing_scope.exprs.Get(loop.stop), frame);
   if (!cond_or) return std::unexpected(std::move(cond_or.error()));
   const mir::ExprId cond_id = block.exprs.Add(*std::move(cond_or));
 
   // HIR carries the iter as the next-value expression for the loop variable;
   // the loop semantic (this lowering) owns the actual write back.
   auto step_value_or =
-      lowerer.LowerExpr(enclosing_scope.exprs.Get(loop.iter), proc_frame);
+      lowerer.LowerExpr(enclosing_scope.exprs.Get(loop.iter), frame);
   if (!step_value_or) {
     return std::unexpected(std::move(step_value_or.error()));
   }
@@ -1491,7 +1482,7 @@ auto InstallGenerateOwnedChildScopes(ClassLowerer& lowerer, WalkFrame frame)
     GenerateBindings gen_bindings;
     gen_bindings.by_scope_id.resize(gen.child_scopes.size());
 
-    auto specs = EnumerateGenerateChildSpecs(gen, gen_idx, hir_scope, module);
+    auto specs = EnumerateGenerateChildSpecs(gen, hir_scope, module);
     for (auto& spec : specs) {
       const auto companion_name = CompanionVarNameFor(spec.scope_name);
       CheckNoNameCollision(
@@ -1648,6 +1639,7 @@ auto ClassLowerer::Run(
     const mir::TypeKind var_kind =
         module.Unit().types.Get(mir_value_type).Kind();
     const bool is_reference = d.reference.has_value();
+
     // A `ref` / `const ref` port member aliases the connected variable, filled
     // by the parent at construction (LRM 23.3.3.2): its type is a reference,
     // not its own cell, so it owns no storage and takes no value initializer.

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -215,19 +215,25 @@ auto LowerCrossUnitVarRefExpr(
   return mir::MakeMemberAccessExpr(self_ref, target, meta.slot_type);
 }
 
-auto LowerLoopVarRefExprAsProcedural(
-    const ClassLowerer& lowerer, const hir::LoopVarRef& lv, mir::TypeId type)
-    -> mir::Expr {
-  return mir::Expr{
-      .data = lowerer.TranslateLoopVarAsProcedural(lv.loop_var), .type = type};
-}
-
-auto LowerLoopVarRefExprAsStructuralParam(
-    const ClassLowerer& lowerer, const hir::LoopVarRef& lv, mir::TypeId type)
-    -> mir::Expr {
-  return mir::Expr{
-      .data = lowerer.TranslateLoopVarAsStructuralParam(lv.hops, lv.loop_var),
-      .type = type};
+// A loop variable referenced at `hops == 0` is the induction variable of the
+// for-generate whose header is being lowered: its declaration sits in the same
+// scope as the reference, so the constructor reads it as the procedural
+// induction local. Every reference at `hops > 0` -- an enclosing genvar named
+// in a nested header, a body continuous assign, or a generate-control condition
+// -- resolves to the structural param the constructed child binds the genvar to
+// (LRM 27.4). The hop count alone selects the path.
+auto LowerLoopVarRefExpr(
+    const ClassLowerer& lowerer, const WalkFrame& frame,
+    const hir::LoopVarRef& lv, mir::TypeId type) -> mir::Expr {
+  if (lv.hops.value == 0) {
+    return mir::Expr{
+        .data = lowerer.TranslateLoopVarAsProcedural(lv.loop_var),
+        .type = type};
+  }
+  const auto loc =
+      lowerer.TranslateLoopVarAsStructuralParam(lv.hops, lv.loop_var);
+  return BuildStructuralParamAccessExpr(
+      frame, lowerer.Module().Unit(), loc.hops, loc.param);
 }
 
 // LRM 7.12.4: a with-clause iteration reference reads the named clause's
@@ -295,8 +301,7 @@ auto LowerHirPrimaryExprProc(
             return LowerProceduralVarRefExpr(process, frame, l, result_type);
           },
           [&](const hir::LoopVarRef& lv) -> mir::Expr {
-            return LowerLoopVarRefExprAsStructuralParam(
-                lowerer, lv, result_type);
+            return LowerLoopVarRefExpr(lowerer, frame, lv, result_type);
           },
           [&](const hir::CrossUnitVarRef& c) -> mir::Expr {
             return LowerCrossUnitVarRefExpr(lowerer, frame, c);
@@ -335,12 +340,7 @@ auto LowerHirPrimaryExprStructural(
                 "appear in structural expressions");
           },
           [&](const hir::LoopVarRef& lv) -> mir::Expr {
-            if (frame.loop_var_mode ==
-                LoopVarLoweringMode::kProceduralInduction) {
-              return LowerLoopVarRefExprAsProcedural(lowerer, lv, result_type);
-            }
-            return LowerLoopVarRefExprAsStructuralParam(
-                lowerer, lv, result_type);
+            return LowerLoopVarRefExpr(lowerer, frame, lv, result_type);
           },
           [&](const hir::CrossUnitVarRef& c) -> mir::Expr {
             return LowerCrossUnitVarRefExpr(lowerer, frame, c);

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -1,6 +1,5 @@
 #include "lyra/lowering/hir_to_mir/expression/selects.hpp"
 
-#include <algorithm>
 #include <cstdint>
 #include <expected>
 #include <utility>
@@ -62,15 +61,6 @@ auto GetAggregateFields(const hir::Type& t)
   if (t.IsPackedUnion()) return t.AsPackedUnion().fields;
   throw InternalError(
       "GetAggregateFields: base type is not a packed struct or union");
-}
-
-// Compile-time map of a declared packed index to its LSB-relative offset.
-// Packed bit numbering counts from the LSB, which is the declared `right`
-// bound; a descending zero-based range is the identity.
-auto PackedPhysOffset(const hir::PackedRange& declared, std::int64_t index)
-    -> std::int64_t {
-  return declared.left >= declared.right ? index - declared.right
-                                         : declared.right - index;
 }
 
 // Read-side wrap that materialises a borrowed `PackedArrayRef` result into
@@ -340,12 +330,43 @@ auto BuildQueueRangeLoHi(
 // then `[min, max]` gives the physical range the runtime Slice consumes. A
 // descending zero-based range is the identity, so this is transparent for the
 // common case.
+// Orders two already-rebased endpoint offsets into `(lo, hi)` at runtime: `lo`
+// is the lower offset, the physical start the Slice protocol consumes. Picked
+// with a conditional rather than a compile-time min / max so a constant slice
+// folds downstream (the optimizer's job) and a genvar slice stays runtime,
+// without assuming a static ordering -- a packed descending range, a
+// dynamic-array ascending range, and a raw `[width-1:0]` projection each order
+// their endpoints differently.
+auto OrderRebasedEndpoints(
+    const ModuleLowerer& module, mir::Block& block, mir::ExprId a,
+    mir::ExprId b) -> RangeLoHi {
+  const mir::TypeId off_type = block.exprs.Get(a).type;
+  const mir::ExprId le = block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::BinaryExpr{
+                  .op = mir::BinaryOp::kLessEqual, .lhs = a, .rhs = b},
+          .type = module.Unit().builtins.bit1});
+  return RangeLoHi{
+      .lo = block.exprs.Add(
+          mir::Expr{
+              .data =
+                  mir::ConditionalExpr{
+                      .condition = le, .then_value = a, .else_value = b},
+              .type = off_type}),
+      .hi = block.exprs.Add(
+          mir::Expr{
+              .data =
+                  mir::ConditionalExpr{
+                      .condition = le, .then_value = b, .else_value = a},
+              .type = off_type})};
+}
+
 template <typename LowerOne>
 auto BuildPackedRangeLoHi(
     const ModuleLowerer& module, mir::Block& block,
     const hir::RangeBounds& bounds, const hir::PackedRange& declared,
     LowerOne lower_one) -> diag::Result<RangeLoHi> {
-  const mir::TypeId int32_type = module.Unit().builtins.int32;
   return std::visit(
       Overloaded{
           [&](const hir::RangeConstantBounds& b) -> diag::Result<RangeLoHi> {
@@ -353,17 +374,16 @@ auto BuildPackedRangeLoHi(
             if (!msb) return std::unexpected(std::move(msb.error()));
             auto lsb = lower_one(b.lsb_expr);
             if (!lsb) return std::unexpected(std::move(lsb.error()));
-            const auto msb_off = PackedPhysOffset(
-                declared, IntConstFromMirExpr(block.exprs.Get(*msb)));
-            const auto lsb_off = PackedPhysOffset(
-                declared, IntConstFromMirExpr(block.exprs.Get(*lsb)));
-            return RangeLoHi{
-                .lo = block.exprs.Add(
-                    mir::MakeInt32Literal(
-                        int32_type, std::min(msb_off, lsb_off))),
-                .hi = block.exprs.Add(
-                    mir::MakeInt32Literal(
-                        int32_type, std::max(msb_off, lsb_off)))};
+            // Rebase each declared endpoint to its LSB-relative offset at
+            // runtime (the same mapping `WrapPackedIndex` applies to an element
+            // index), then order them, so a constant bound folds downstream and
+            // a genvar-dependent bound stays a runtime read.
+            return OrderRebasedEndpoints(
+                module, block,
+                WrapPackedIndex(
+                    module, block, declared, *msb, block.exprs.Get(*msb).type),
+                WrapPackedIndex(
+                    module, block, declared, *lsb, block.exprs.Get(*lsb).type));
           },
           [&](const hir::RangeIndexedUpBounds& b) -> diag::Result<RangeLoHi> {
             auto base = lower_one(b.base_index);

--- a/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
@@ -3,6 +3,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <expected>
+#include <format>
+#include <string>
+#include <string_view>
 #include <utility>
 
 #include "lyra/diag/diagnostic.hpp"
@@ -30,6 +33,11 @@ auto ModuleLowerer::Run() -> diag::Result<mir::CompilationUnit> {
 
   unit_.root = *top_r;
   return std::move(unit_);
+}
+
+auto ModuleLowerer::NextGenerateScopeName(std::string_view arm_tag)
+    -> std::string {
+  return std::format("gen{}_{}", next_generate_scope_name_++, arm_tag);
 }
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/self_ref.cpp
+++ b/src/lyra/lowering/hir_to_mir/self_ref.cpp
@@ -54,6 +54,17 @@ auto BuildStructuralMemberAccessExpr(
       receiver, mir::MemberRef{.var = var}, field_type);
 }
 
+auto BuildStructuralParamAccessExpr(
+    const WalkFrame& frame, const mir::CompilationUnit& unit,
+    mir::EnclosingHops hops, mir::ParamId param) -> mir::Expr {
+  const mir::TypeId field_type =
+      frame.EnclosingClassAtHops(hops).params.Get(param).type;
+  const mir::ExprId receiver = BuildEnclosingScopeReceiver(frame, unit, hops);
+  return mir::Expr{
+      .data = mir::ParamRef{.receiver = receiver, .param = param},
+      .type = field_type};
+}
+
 auto BuildReferenceArg(
     mir::CompilationUnit& unit, mir::Block& block, mir::ExprId cell,
     mir::TypeId pointee) -> mir::ExprId {

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -489,12 +489,10 @@ class MirDumper {
             [](const CastExpr& c) -> std::string {
               return std::format("CastExpr operand=Expr[{}]", c.operand.value);
             },
-            [this](const ParamRef& r) -> std::string {
-              const auto& owner = ResolveScopeAtHops(r.hops.value);
-              const auto& param = owner.params.Get(r.param);
+            [](const ParamRef& r) -> std::string {
               return std::format(
-                  "ParamRef[hops={}, param={}] \"{}\"", r.hops.value,
-                  r.param.value, param.name);
+                  "ParamRef receiver=Expr[{}] param=Param[{}]",
+                  r.receiver.value, r.param.value);
             },
             [this](const LocalRef& r) -> std::string {
               const auto& owner = ResolveBlockAtHops(r.hops.value);

--- a/tests/cases/cpp/nested_generate_outer_genvar/case.yaml
+++ b/tests/cases/cpp/nested_generate_outer_genvar/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.nested_generate_outer_genvar
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    m0: 15
+    e0: 15

--- a/tests/cases/cpp/nested_generate_outer_genvar/main.sv
+++ b/tests/cases/cpp/nested_generate_outer_genvar/main.sv
@@ -1,0 +1,26 @@
+module Top;
+  // Nested generate-for whose INNER stop bound references the OUTER genvar
+  // `stg` (LRM 27.4): stage stg runs (4 - stg) segments. Stage 0 runs four
+  // segments and drives every bit of mask[0] / emask[0], so each is fully
+  // driven and fully defined (4'hF) in both 2-state and 4-state. Resolving
+  // `stg` in the inner bound as the inner loop's own `seg` would change the
+  // iteration count and the result.
+  //
+  // Both genvar-indexed write forms are exercised: a range select on `mask`
+  // (whose bound must stay runtime, not fold to one elaboration constant) and a
+  // bare element select on `emask` (whose nested place must lower without the
+  // owned-child construction reading a stale type reference).
+  logic [3:0] mask [3];
+  logic [3:0] emask [3];
+  for (genvar stg = 0; stg < 3; stg++) begin : gen_stage
+    for (genvar seg = 0; seg < 4 - stg; seg++) begin : gen_seg
+      assign mask[stg][seg +: 1] = 1'b1;
+      assign emask[stg][seg] = 1'b1;
+    end
+  end
+
+  int m0;
+  int e0;
+  assign m0 = mask[0];
+  assign e0 = emask[0];
+endmodule

--- a/tests/cases/cpp/range_select_genvar_bound/case.yaml
+++ b/tests/cases/cpp/range_select_genvar_bound/case.yaml
@@ -1,0 +1,11 @@
+id: cpp.range_select_genvar_bound
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    packed_out: "32'hABCDABCD"

--- a/tests/cases/cpp/range_select_genvar_bound/main.sv
+++ b/tests/cases/cpp/range_select_genvar_bound/main.sv
@@ -1,0 +1,11 @@
+module Top;
+  // Packed simple-range `[msb:lsb]` whose endpoints are genvar arithmetic (the
+  // ibex butterfly form). Each generate instance writes a distinct 16-bit lane,
+  // so all 32 bits are driven and the result is fully defined. The bounds stay
+  // runtime expressions reading the constructor's induction variable -- they are
+  // not folded to a single elaboration-time constant.
+  logic [31:0] packed_out;
+  for (genvar i = 0; i < 2; i++) begin : gen_lane
+    assign packed_out[16*i + 15 : 16*i] = 16'hABCD;
+  end
+endmodule


### PR DESCRIPTION
## Summary

A generate-loop genvar is a runtime induction value in Lyra (the loop is a runtime constructor, not an elaboration-time unrolling), so a reference to a genvar from a nested scope must flow through the scope chain rather than fold to a constant. This resolves loop-var references by structural hops, makes `ParamRef` receiver-based so a cross-scope genvar read navigates to the enclosing scope, and lowers packed range-select bounds faithfully -- each endpoint is rebased at runtime and the physical start is a runtime min -- so a constant bound folds downstream while a genvar-dependent bound stays a runtime read. Nested generate scopes also carry unique names so the emitted C++ no longer collides.

## Testing

Added cases for a nested generate-for whose inner bound reads the outer genvar, and for a packed range-select whose endpoints are genvar arithmetic (the ibex butterfly form). Full `bazel test //...` passes.