### PR TITLE
Add unpacked union member read and write

### DIFF
--- a/docs/decisions/unpacked-union-representation.md
+++ b/docs/decisions/unpacked-union-representation.md
@@ -1,0 +1,132 @@
+# Unpacked union is overlapping storage realized as an active-member value (MIR `UnionType`)
+
+Date: 2026-06-27 Status: accepted
+
+## Why this decision matters
+
+HIR carries `UnpackedUnionType` (LRM 7.3) as a faithful source construct. HIR-to-MIR must give it a
+generic programming-language representation or reject it. The sibling decision
+[unpacked-struct-representation](unpacked-struct-representation.md) settled the unpacked struct (a
+value product, MIR `TupleType`) and explicitly left the union open: "an untagged unpacked union (LRM
+7.3) is overlapping storage, neither a product nor a sum ... this decision does not anticipate their
+shape." The `mir/type.hpp` type catalogue likewise records the union as "a separate representation
+problem." This entry settles it.
+
+## What an untagged unpacked union is (LRM 7.3)
+
+- A single piece of storage accessed through one of the named member types; only one member is
+  usable at a time.
+- No required representation for how members are stored.
+- Reading a member other than the one last written is a type loophole whose result is undefined (LRM
+  7.3). This is not relied upon.
+- Default value is the first member's Table 7-1 default.
+- Value semantics: a whole-union assignment copies, independent of its source (LRM 7.6, Table 7-1).
+- Union members cannot carry per-member initializers (LRM 7.2.2).
+- Dynamic and chandle members are illegal in an untagged union (only in a tagged one, LRM 7.3.2).
+
+It is not a product: a product holds all members at once. It is not a sum: a sum is a tagged,
+type-checked variant read through tagged expressions and pattern matching (the tagged union, LRM
+7.3.2 / 11.9), a distinct concept. An untagged unpacked union is the C `union` -- N views over one
+storage, type-punned, with cross-view reads undefined.
+
+## The axis that decides it: one member at a time, cross-reads undefined
+
+Because a union holds one member at a time and a cross-member read is undefined, the well-defined
+content of a union value is exactly the pair "(active member, that member's value)". Nothing more is
+observable to a conformant program. That pair is the union's value-level semantic. A product's value
+is the full tuple "(v0, v1, ..., vN)"; the two value spaces are genuinely different, so the union is
+not a product with a different label.
+
+## Decision
+
+1. **HIR untagged `UnpackedUnionType` lowers to a new MIR `UnionType`**, whose component types are
+   the member types in declaration order. A **tagged** union is rejected at the HIR-to-MIR gate: a
+   tagged union is a sum type, a distinct generic-language concept (an SV-visible tag, type
+   checking, pattern matching, LRM 7.3.2 / 11.9) that will be its own future MIR type, not
+   `UnionType` with a flag. `UnionType` carries no `tagged` field -- per `mir.md` invariant 7 the
+   type is the classification, and there is no second union concept hiding behind a flag.
+
+2. **Member access is positional, by declaration-order index**, identical to struct / tuple. Field
+   names are dropped at HIR-to-MIR; the index is the carrier.
+
+3. **A union value is "(active member index, that member's value)" at the MIR semantic level.** This
+   is a semantic statement, not a storage-layout claim; how a backend stores it is a realization
+   concern owned by the backend contract.
+
+4. **Member read is an access primitive `UnionGetExpr{union, index}`**, parallel to `TupleGetExpr`.
+   It is read-only: it never appears as an lvalue or a writable place.
+
+5. **Member write is whole-union replacement.** `u.f = v` lowers to assigning the union _place_ a
+   freshly built single-member union value: `UnionExpr{index, value}`. The member access never
+   survives as a writable place; the write targets the union one level up. This is the same shape as
+   a string element write, which has no element lvalue and realizes as `putc` against the string
+   place (LRM 6.16.2). A compound `u.f op= v` reads the active member through `UnionGetExpr`,
+   applies the operator, and rebuilds the union -- the read side uses `UnionGetExpr`, the write side
+   uses `UnionExpr`, and the two are never conflated. Taking a place or a `ref` / `output` binding
+   to a union member is rejected for now.
+
+6. **Default initialization synthesizes `UnionExpr{0, <member 0's Table 7-1 default>}`** at each
+   default-construct site, never stored on the type. As with the struct, the interned `UnionType`
+   carries component types only; per-member defaults would leak source-level initialization into
+   generic type identity and break canonicalization.
+
+7. **The runtime realization is `lyra::value::Union<Ts...>`, an active-member value** (an active
+   index plus that member's value). It is not a byte overlay: the `lyra::value` types are rich C++
+   objects -- `PackedArray` carries an X/Z plane (and a heap vector for wide values), `String` owns
+   heap storage, `Real` is a `double` -- none can share one storage and be reinterpreted, so a
+   C-style overlay is unrealizable. The active-member realization is sufficient because cross-member
+   reads are undefined. It satisfies `LyraValue` by delegating to the active member: `==` / `!=` are
+   "same active index and equal active value", `IsBitIdentical` likewise, and `HasUnknown` delegates
+   to the active member; the default holds member 0. There is no cross-member equality or
+   conversion.
+
+8. **An inactive-member read returns that member's Table 6-7 default.** This is a deterministic Lyra
+   fallback for an operation SystemVerilog leaves undefined, not a guarantee. SV gives no reliable
+   semantics to a cross-member read, so compiler optimization, tests, and user programs must not
+   depend on the returned value.
+
+## Rejected alternatives
+
+- **Desugar the union to `TupleType` (reuse the struct representation).** A product holds all
+  members; a union holds one. They differ in default initialization (all members vs the first) and
+  in write semantics (an independent slot write vs replacing the active member). A consumer reading
+  `TupleType` could not tell them apart, violating `mir.md` invariant 7 (the type is the
+  classification). It also contradicts the recorded struct decision ("the union does not share the
+  struct representation") and stores every member when only one is live. The observable contract for
+  conformant programs happens to coincide -- because cross-reads are undefined -- but the type
+  identity and the semantics differ, and conflating them is the inverse of the
+  type-is-classification invariant.
+
+- **A `tagged` flag on `UnionType`.** A tagged union is a sum type, a different generic-language
+  concept. A flag beside the type that selects between two concepts is the forbidden "classification
+  outside the type system" shape. Tagged is rejected at the gate and reserved for a future distinct
+  type.
+
+- **A byte-overlay C union at runtime.** The `lyra::value` types are not POD bytes; they cannot
+  share storage and be reinterpreted. The active-member realization is the only workable one and is
+  sufficient under undefined cross-reads.
+
+## Consequences
+
+- A new MIR type variant (`UnionType`) and two expression primitives (`UnionExpr`, `UnionGetExpr`),
+  parallel to the tuple pair.
+- A new runtime value type `lyra::value::Union<Ts...>`, composing `LyraValue` from its active
+  member.
+- `struct-union.md` N1-N3 build on this. A declared union must default-initialize to run, so the
+  first-member default is part of the first cut rather than a separable later one.
+- Whole-union copy is the existing whole-cell write (`u2 = u` assigns the cell a copied union
+  value), and member-in-expression use is the existing member read; neither needs union-specific
+  lowering.
+
+## Cross-references
+
+- `../architecture/mir.md` -- `TupleType` as the single product type; invariant 7 (the type is the
+  classification); the forbidden flag-beside-the-type shape.
+- [unpacked-struct-representation](unpacked-struct-representation.md) -- the sibling product
+  representation, which left the union open.
+- [value-type-concepts](value-type-concepts.md) -- the `LyraValue` lattice the runtime
+  `Union<Ts...>` composes, and the observable read / write pattern member access reuses.
+- LRM anchors: 7.3 (unions), 7.3.2 (tagged unions), 7.2.2 (member-initializer restriction), 7.6
+  (aggregate assignment), Table 7-1 (defaults and nonexistent-entry reads), Table 6-7 (default
+  initial values), 11.4.5 (equality on any data type), 6.16.2 (string element write as `putc`, the
+  no-element-lvalue precedent).

--- a/docs/progress/operators.md
+++ b/docs/progress/operators.md
@@ -14,7 +14,8 @@ Done when:
 
 ## Actionable
 
-All items closed; operator surface in scope is complete.
+The operator surface in scope is complete except W13: compound assignment to a no-element-lvalue
+target evaluates the left-hand index more than once (LRM 11.4.1).
 
 ## Sub-Steps
 
@@ -83,6 +84,13 @@ merged node.
       selector chains (`array[i]++`, `++a[15:8]`) and observable structural roots are covered. NBA
       contexts (`b <= a++`, `var[i++] <= rhs`) evaluate the inc / dec exactly once at submit time.
       Replication / concatenation operands are rejected as targets per LRM 11.4.12.1.
+- [ ] W13 -- Compound assignment to a target that has no element lvalue and so must
+      read-modify-write the whole value -- a string element (`s[i] op= v`), and a union member once
+      a union is usable in that position -- currently evaluates the left-hand index expression more
+      than once, contrary to LRM 11.4.1 (the left-hand index shall be evaluated exactly once). A
+      side-effecting index (e.g. a function call) therefore runs twice. Targets that lower to a
+      native read-modify-write (whole-var, selector) are correct (W11); only the no-element-lvalue
+      targets are affected.
 
 ## Cross-references
 

--- a/docs/progress/struct-union.md
+++ b/docs/progress/struct-union.md
@@ -60,10 +60,12 @@ type-checked -- reading a member other than the one last written is a type looph
 result is undefined and is not relied upon here. Default value is the first member's default (LRM
 Table 7-1).
 
-- [ ] N1 -- Type infrastructure, declaration, member read and write for an untagged unpacked union
+- [x] N1 -- Type infrastructure, declaration, member read and write for an untagged unpacked union
       (LRM 7.3). Writing then reading the same member round-trips; writing one member then another
-      overwrites. Two- and three-member unions of integral / real / shortreal members.
-- [ ] N2 -- Default initialization to the first member's LRM Table 7-1 default.
+      overwrites. Two- and three-member unions of integral / real / shortreal members. A tagged
+      union is a distinct concept and is rejected for now.
+- [x] N2 -- Default initialization to the first member's LRM Table 7-1 default. A declared union
+      must default-initialize to be usable, so this lands with N1.
 - [ ] N3 -- Whole-union value-semantic copy (independent copies) and member use in arithmetic and
       other expression contexts.
 

--- a/include/lyra/mir/expr.hpp
+++ b/include/lyra/mir/expr.hpp
@@ -269,12 +269,34 @@ struct TupleGetExpr {
   std::size_t index;
 };
 
+// Builds a union value whose active member is component `index`, carrying
+// `value`. The value-build primitive for `UnionType`, the active-member
+// analogue of `TupleExpr`: a tuple literal lists every component, a union
+// literal names the one live member. A union member write `u.f = v` lowers to
+// assigning the union place a fresh `UnionExpr{index, value}` -- the member
+// access never survives as a writable place. `Expr::type` is the `UnionType`.
+struct UnionExpr {
+  std::size_t index;
+  ExprId value;
+};
+
+// Reads component `index` out of a union value (`union.index`), the read-only
+// active-member analogue of `TupleGetExpr`. `Expr::type` is the component's
+// type. Never appears as an lvalue: a write is a whole-union replacement via
+// `UnionExpr`, not a projection. Reading a member other than the live one is
+// undefined in SV (LRM 7.3); the backend returns that member's default.
+struct UnionGetExpr {
+  ExprId union_value;
+  std::size_t index;
+};
+
 using ExprData = std::variant<
     IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, NullLiteral,
     HostIntLiteral, ParamRef, LocalRef, UnaryExpr, BinaryExpr, BoolCastExpr,
     ConditionalExpr, AssignExpr, IncDecExpr, CallExpr, DerefExpr, AddressOfExpr,
     PointerCastExpr, CastExpr, MemberAccessExpr, ClosureExpr, ConcatExpr,
-    ReplicationExpr, ArrayLiteralExpr, TupleExpr, AwaitExpr, TupleGetExpr>;
+    ReplicationExpr, ArrayLiteralExpr, TupleExpr, AwaitExpr, TupleGetExpr,
+    UnionExpr, UnionGetExpr>;
 
 struct Expr {
   ExprData data;

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -38,6 +38,7 @@ enum class TypeKind {
   kPointer,
   kVector,
   kTuple,
+  kUnion,
   kExternalRef,
   kObservable,
 };
@@ -316,6 +317,19 @@ struct TupleType {
   auto operator==(const TupleType&) const -> bool = default;
 };
 
+// Overlapping member storage: one of an ordered list of component types is the
+// value at a time (the generic-language C `union`, distinct from the product
+// `TupleType` and from a tagged sum). The value-layer realization of an SV
+// untagged unpacked union (LRM 7.3); the member names are dropped to positions
+// at HIR-to-MIR, the index is the carrier. Built and read by `UnionExpr` /
+// `UnionGetExpr`. Carries component types only: a tagged union is a separate
+// concept rejected at the HIR-to-MIR gate, so no flag distinguishes one here.
+struct UnionType {
+  std::vector<TypeId> elements;
+
+  auto operator==(const UnionType&) const -> bool = default;
+};
+
 // Observable storage wrapper around a value type. Declares that a member's
 // storage is a module-scope cell that exposes Set / Get / Mutate
 // (LRM 9.4.2 update event) -- writes route through the engine so subscribers
@@ -352,7 +366,7 @@ using TypeData = std::variant<
     ShortRealType, RealTimeType, ChandleType, VoidType, ObjectType,
     ExternalUnitObjectType, ScopeType, ServicesType, FilesType, DiagnosticType,
     RuntimeLibraryType, CoroutineType, RefType, PointerType, VectorType,
-    TupleType, ExternalRefType, ObservableType>;
+    TupleType, UnionType, ExternalRefType, ObservableType>;
 
 struct Type {
   TypeData data;

--- a/include/lyra/value/union.hpp
+++ b/include/lyra/value/union.hpp
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include "lyra/value/concepts.hpp"
+#include "lyra/value/packed_array.hpp"
+
+namespace lyra::value {
+
+// An active-member value: holds exactly one of its component value types at a
+// time, identified by a declaration-order index. The value-layer realization of
+// MIR's UnionType -- the runtime form of an SV untagged unpacked union (LRM
+// 7.3), whose member names are erased to positions before this layer. Members
+// are reached by index, never by type, because a union may declare two members
+// of the same type. SystemVerilog gives no reliable semantics to reading a
+// member other than the one last written, so the union stores only the active
+// member; a read of an inactive member returns that member's default -- a
+// deterministic fallback for an operation SV leaves undefined, not a value any
+// program may depend on. The LyraValue contract composes from the active
+// member: equality is same-active-member-and-equal-value, never a cross-member
+// comparison.
+template <typename... Ts>
+class Union {
+ public:
+  // LRM Table 7-1: an unpacked union defaults to its first member. The default
+  // construction is a placeholder; the lowering emits an explicit first-member
+  // default value at each default-init site.
+  Union() = default;
+
+  // Build a union whose active member is component `I`, carrying `value`. The
+  // index form (not a type form) is mandatory because components may repeat.
+  template <std::size_t I, typename V>
+  [[nodiscard]] static auto Make(V&& value) -> Union {
+    Union u;
+    u.data_.template emplace<I>(std::forward<V>(value));
+    return u;
+  }
+
+  // Read component `I`. Returns the value when `I` is the active member;
+  // otherwise returns that component's default, the deterministic stand-in for
+  // an SV-undefined cross-member read.
+  template <std::size_t I>
+  [[nodiscard]] auto Get() const
+      -> std::variant_alternative_t<I, std::variant<Ts...>> {
+    using Member = std::variant_alternative_t<I, std::variant<Ts...>>;
+    if (const auto* active = std::get_if<I>(&data_)) {
+      return *active;
+    }
+    return Member{};
+  }
+
+  // LRM 11.4.5 `==` / `!=` (Any data type). Unions are equal only when the same
+  // member is active and its values compare equal; a mismatched active member
+  // is unequal without any cross-member reinterpretation.
+  [[nodiscard]] auto operator==(const Union& other) const -> PackedArray {
+    if (data_.index() != other.data_.index()) {
+      return PackedArray::Bit(false);
+    }
+    return std::visit(
+        [](const auto& a, const auto& b) -> PackedArray {
+          if constexpr (std::is_same_v<
+                            std::decay_t<decltype(a)>,
+                            std::decay_t<decltype(b)>>) {
+            return a == b;
+          } else {
+            return PackedArray::Bit(false);
+          }
+        },
+        data_, other.data_);
+  }
+  [[nodiscard]] auto operator!=(const Union& other) const -> PackedArray {
+    return !(*this == other);
+  }
+
+  // LRM 11.4.5 `===` / `!==` (case equality): same active member and
+  // bit-for-bit identical value. Instantiated only when the source uses `===`;
+  // a union with a real / shortreal member never reaches it (lowering rejects
+  // case equality on a real leaf, Table 11-1).
+  [[nodiscard]] auto CaseEqual(const Union& other) const -> PackedArray {
+    if (data_.index() != other.data_.index()) {
+      return PackedArray::Bit(false);
+    }
+    return std::visit(
+        [](const auto& a, const auto& b) -> PackedArray {
+          if constexpr (std::is_same_v<
+                            std::decay_t<decltype(a)>,
+                            std::decay_t<decltype(b)>>) {
+            return a.CaseEqual(b);
+          } else {
+            return PackedArray::Bit(false);
+          }
+        },
+        data_, other.data_);
+  }
+
+  // LRM 9.4.2 update-event predicate (engine change-detection hook): the cell
+  // changed when the active member changed or its value's bits changed.
+  [[nodiscard]] auto IsBitIdentical(const Union& other) const -> bool {
+    if (data_.index() != other.data_.index()) {
+      return false;
+    }
+    return std::visit(
+        [](const auto& a, const auto& b) -> bool {
+          if constexpr (std::is_same_v<
+                            std::decay_t<decltype(a)>,
+                            std::decay_t<decltype(b)>>) {
+            return a.IsBitIdentical(b);
+          } else {
+            return false;
+          }
+        },
+        data_, other.data_);
+  }
+
+  // LRM 20.9 `$isunknown`: the active member's unknown bits propagate up.
+  [[nodiscard]] auto HasUnknown() const -> bool {
+    return std::visit(
+        [](const auto& active) -> bool { return active.HasUnknown(); }, data_);
+  }
+
+ private:
+  std::variant<Ts...> data_;
+};
+
+static_assert(LyraValue<Union<PackedArray, PackedArray>>);
+static_assert(CaseEqualComparable<Union<PackedArray, PackedArray>>);
+
+}  // namespace lyra::value

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -353,6 +353,7 @@ auto RenderScopeHeaderFile(
   out += "#include \"lyra/value/string_op.hpp\"\n";
   out += "#include \"lyra/value/unpacked_array.hpp\"\n";
   out += "#include \"lyra/value/dynamic_array.hpp\"\n";
+  out += "#include \"lyra/value/union.hpp\"\n";
   for (const auto& name : CollectExternalUnitNames(unit)) {
     out += std::format("#include \"{}.hpp\"\n", name);
   }

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -830,6 +830,17 @@ auto RenderExpr(const ScopeView& view, const mir::Expr& expr) -> std::string {
                 "({}).template Get<{}>()", RenderExpr(view, view.Expr(g.tuple)),
                 g.index);
           },
+          [&](const mir::UnionExpr& u) -> std::string {
+            return std::format(
+                "{}::Make<{}>({})",
+                RenderTypeAsCpp(view.Unit(), view.Class(), expr.type), u.index,
+                RenderExpr(view, view.Expr(u.value)));
+          },
+          [&](const mir::UnionGetExpr& g) -> std::string {
+            return std::format(
+                "({}).template Get<{}>()",
+                RenderExpr(view, view.Expr(g.union_value)), g.index);
+          },
       },
       expr.data);
 }

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -180,6 +180,14 @@ auto RenderTypeAsCpp(
             }
             return std::format("lyra::value::Tuple<{}>", inners);
           },
+          [&](const mir::UnionType& u) -> std::string {
+            std::string inners;
+            for (std::size_t i = 0; i < u.elements.size(); ++i) {
+              if (i != 0) inners += ", ";
+              inners += RenderTypeAsCpp(unit, owner_class, u.elements[i]);
+            }
+            return std::format("lyra::value::Union<{}>", inners);
+          },
           [&](const mir::ExternalRefType& e) -> std::string {
             return std::format(
                 "lyra::runtime::ExternUp<{}>",

--- a/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_lowerer.cpp
@@ -56,7 +56,8 @@ auto MaybeWrapObservable(ModuleLowerer& module, mir::TypeId t) -> mir::TypeId {
                     std::holds_alternative<mir::DynamicArrayType>(data) ||
                     std::holds_alternative<mir::QueueType>(data) ||
                     std::holds_alternative<mir::AssociativeArrayType>(data) ||
-                    std::holds_alternative<mir::TupleType>(data);
+                    std::holds_alternative<mir::TupleType>(data) ||
+                    std::holds_alternative<mir::UnionType>(data);
   if (!wrap) {
     return t;
   }

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -214,6 +214,17 @@ auto BuildDefaultValueExpr(
                 .data = mir::TupleExpr{.components = std::move(components)},
                 .type = type};
           },
+          // LRM Table 7-1: an unpacked union defaults to its first member's
+          // default. Synthesized as a UnionExpr over component 0 at each use,
+          // never stored on the interned UnionType (same rationale as the
+          // struct's member-wise default).
+          [&](const mir::UnionType& u) -> mir::Expr {
+            const mir::ExprId member_default = block.exprs.Add(
+                BuildDefaultValueExpr(module, frame, u.elements.front()));
+            return mir::Expr{
+                .data = mir::UnionExpr{.index = 0, .value = member_default},
+                .type = type};
+          },
           // LRM Table 6-7: a dynamic array's default is the empty array.
           // The wrapper still needs the element type's default supplied at
           // construction so OOB reads and resize-fills have a shape source.

--- a/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/assignment.cpp
@@ -314,8 +314,7 @@ auto LowerStringElementAssign(
   const std::array<mir::ExprId, 2> operands{idx_id, value_id};
   return ApplyAssignEffect(
       process, frame, a.kind, span, cell_id, operands,
-      [&unit](
-          mir::Block& blk, mir::ExprId target, std::span<const mir::ExprId> ops,
+      [&](mir::Block& blk, mir::ExprId target, std::span<const mir::ExprId> ops,
           mir::ExprId services) -> mir::Expr {
         mir::ExprId recv = target;
         const mir::ExprId root = FindLhsRootId(blk, target);
@@ -326,6 +325,62 @@ auto LowerStringElementAssign(
         return MakeStringMethodCallExpr(
             support::BuiltinFn::kPutc, {recv, ops[0], ops[1]},
             unit.builtins.void_type);
+      });
+}
+
+// Axis A for a union member target: a whole-union replacement (LRM 7.3). A
+// union holds one member at a time, so `u.f = v` is the union place taking a
+// fresh single-member value `UnionExpr{f, v}` -- the member access is never a
+// writable place, the same shape as a string element write that has no element
+// lvalue. A compound `u.f op= v` reads the active member, applies the operator,
+// and rebuilds; the receiver routes through the cell's Set / Mutate path so the
+// timing envelope and observable wakeup are shared with every other target.
+auto LowerUnionMemberAssign(
+    ProcessLowerer& process, WalkFrame frame, const hir::AssignExpr& a,
+    const hir::MemberAccessExpr& sel, diag::SourceSpan span,
+    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+  const auto& hir_process = process.HirBody();
+  const auto& unit = process.Module().Unit();
+  auto& block = *frame.current_block;
+
+  const auto& base_hir = hir_process.exprs.Get(sel.base_value);
+  auto place_or = process.LowerLhsExpr(base_hir, frame.WithLvalueTarget(true));
+  if (!place_or) return std::unexpected(std::move(place_or.error()));
+  const mir::ExprId place_id = block.exprs.Add(*std::move(place_or));
+  const mir::TypeId union_type = process.Module().TranslateType(base_hir.type);
+
+  auto rhs_or = process.LowerExpr(hir_process.exprs.Get(a.rhs), frame);
+  if (!rhs_or) return std::unexpected(std::move(rhs_or.error()));
+  mir::ExprId member_value_id = block.exprs.Add(*std::move(rhs_or));
+
+  // A compound write only ever reaches here blocking (compound + NBA is not a
+  // legal SV form, rejected upstream), so the read of the active member lands
+  // in the active region before the effect runs.
+  if (a.compound_op.has_value()) {
+    auto cur_or = process.LowerExpr(hir_process.exprs.Get(a.lhs), frame);
+    if (!cur_or) return std::unexpected(std::move(cur_or.error()));
+    const mir::ExprId cur_id = block.exprs.Add(*std::move(cur_or));
+    member_value_id = block.exprs.Add(BuildMirBinaryExpr(
+        unit, block, LowerBinaryOp(*a.compound_op), cur_id, member_value_id,
+        result_type));
+  }
+
+  const mir::ExprId union_value_id = block.exprs.Add(
+      mir::Expr{
+          .data =
+              mir::UnionExpr{
+                  .index = sel.field_index, .value = member_value_id},
+          .type = union_type});
+
+  const std::array<mir::ExprId, 1> operands{union_value_id};
+  const mir::TypeId void_type = unit.builtins.void_type;
+  return ApplyAssignEffect(
+      process, frame, a.kind, span, place_id, operands,
+      [&](mir::Block& blk, mir::ExprId target, std::span<const mir::ExprId> ops,
+          mir::ExprId services) -> mir::Expr {
+        return BuildObservableAssignExpr(
+            unit, blk, services, target, ops[0], std::nullopt, union_type,
+            void_type);
       });
 }
 
@@ -353,6 +408,15 @@ auto LowerHirAssignExprProc(
           process, frame, a, *sel, span, result_type);
     }
   }
+  // A union member write is a whole-union replacement, not a place projection,
+  // so it is intercepted here before the generic place-based path (LRM 7.3).
+  if (const auto* sel = std::get_if<hir::MemberAccessExpr>(&hir_lhs.data)) {
+    const hir::Type& base_ty = process.Module().Hir().types.Get(
+        hir_process.exprs.Get(sel->base_value).type);
+    if (base_ty.Kind() == hir::TypeKind::kUnpackedUnion) {
+      return LowerUnionMemberAssign(process, frame, a, *sel, span, result_type);
+    }
+  }
   return LowerObservableAssign(process, frame, a, span, result_type);
 }
 
@@ -367,8 +431,7 @@ auto BuildNbaSubmitClosureExpr(
   const std::array<mir::ExprId, 1> operands{rhs_id_in_outer};
   return BuildDeferredAssignClosure(
       module, frame, lhs_in_outer, operands,
-      [&module, rhs_type](
-          mir::Block& blk, mir::ExprId target, std::span<const mir::ExprId> ops,
+      [&](mir::Block& blk, mir::ExprId target, std::span<const mir::ExprId> ops,
           mir::ExprId services) -> mir::Expr {
         return BuildObservableAssignExpr(
             module.Unit(), blk, services, target, ops[0], std::nullopt,

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -9,6 +9,8 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
+#include "lyra/diag/diag_code.hpp"
+#include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
 #include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
@@ -756,6 +758,19 @@ auto LowerHirMemberAccessExpr(
         .data = mir::TupleGetExpr{.tuple = base_id, .index = sel.field_index},
         .type = result_type};
   }
+  // LRM 7.3: an unpacked union member read projects the active member by index
+  // out of the overlapping-storage value (`UnionGetExpr`); reading an inactive
+  // member is undefined and the backend returns that member's default.
+  if (module.Hir().types.Get(base_hir_expr.type).Kind() ==
+      hir::TypeKind::kUnpackedUnion) {
+    auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
+    if (!base_or) return std::unexpected(std::move(base_or.error()));
+    const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
+    return mir::Expr{
+        .data =
+            mir::UnionGetExpr{.union_value = base_id, .index = sel.field_index},
+        .type = result_type};
+  }
   const auto& fields =
       GetAggregateFields(module.Hir().types.Get(base_hir_expr.type));
   if (sel.field_index >= fields.size()) {
@@ -836,6 +851,16 @@ auto LowerHirMemberAccessExprLhs(
     return mir::Expr{
         .data = mir::TupleGetExpr{.tuple = base_id, .index = sel.field_index},
         .type = result_type};
+  }
+  // A union member write is a whole-union replacement, intercepted at
+  // assignment lowering before any place is built; a union member never yields
+  // a writable place. Reaching here means a ref / output binding to a union
+  // member (LRM 7.3), which is not yet supported.
+  if (module.Hir().types.Get(base_hir_expr.type).Kind() ==
+      hir::TypeKind::kUnpackedUnion) {
+    return diag::Fail(
+        base_hir_expr.span, diag::DiagCode::kUnsupportedAssignmentTarget,
+        "a reference or output binding to a union member is not yet supported");
   }
   const auto& fields =
       GetAggregateFields(module.Hir().types.Get(base_hir_expr.type));

--- a/src/lyra/lowering/hir_to_mir/translate_type.cpp
+++ b/src/lyra/lowering/hir_to_mir/translate_type.cpp
@@ -136,11 +136,21 @@ auto ModuleLowerer::TranslateTypeData(
             }
             return mir::TupleType{.elements = std::move(elements)};
           },
-          [type_span](
-              const hir::UnpackedUnionType&) -> diag::Result<mir::TypeData> {
-            return diag::Fail(
-                type_span, diag::DiagCode::kUnsupportedUnpackedUnionType,
-                "unpacked union types are not yet supported");
+          [&](const hir::UnpackedUnionType& src)
+              -> diag::Result<mir::TypeData> {
+            // A tagged union is a sum type, a separate concept; only the
+            // untagged overlapping-storage form maps to `UnionType` (LRM 7.3).
+            if (src.tagged) {
+              return diag::Fail(
+                  type_span, diag::DiagCode::kUnsupportedUnpackedUnionType,
+                  "tagged unions are not yet supported");
+            }
+            std::vector<mir::TypeId> elements;
+            elements.reserve(src.fields.size());
+            for (const auto& field : src.fields) {
+              elements.push_back(TranslateType(field.type));
+            }
+            return mir::UnionType{.elements = std::move(elements)};
           },
           [&](const hir::UnpackedArrayType& src)
               -> diag::Result<mir::TypeData> {

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -240,6 +240,16 @@ class MirDumper {
               }
               return std::format("Tuple(elems=[{}])", elements);
             },
+            [](const UnionType& u) -> std::string {
+              std::string elements;
+              for (std::size_t i = 0; i < u.elements.size(); ++i) {
+                if (i != 0) {
+                  elements += ", ";
+                }
+                elements += std::format("Type[{}]", u.elements[i].value);
+              }
+              return std::format("Union(elems=[{}])", elements);
+            },
             [](const ExternalRefType& e) -> std::string {
               return std::format("ExternalRef(elem=Type[{}])", e.element.value);
             },
@@ -615,6 +625,15 @@ class MirDumper {
             [](const TupleGetExpr& g) -> std::string {
               return std::format(
                   "TupleGetExpr tuple=Expr[{}] index={}", g.tuple.value,
+                  g.index);
+            },
+            [](const UnionExpr& u) -> std::string {
+              return std::format(
+                  "UnionExpr index={} value=Expr[{}]", u.index, u.value.value);
+            },
+            [](const UnionGetExpr& g) -> std::string {
+              return std::format(
+                  "UnionGetExpr union=Expr[{}] index={}", g.union_value.value,
                   g.index);
             },
         },

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -85,6 +85,7 @@ auto Type::Kind() const -> TypeKind {
           [](const PointerType&) { return TypeKind::kPointer; },
           [](const VectorType&) { return TypeKind::kVector; },
           [](const TupleType&) { return TypeKind::kTuple; },
+          [](const UnionType&) { return TypeKind::kUnion; },
           [](const ExternalRefType&) { return TypeKind::kExternalRef; },
           [](const ObservableType&) { return TypeKind::kObservable; },
       },

--- a/src/lyra/mir/type_interner.cpp
+++ b/src/lyra/mir/type_interner.cpp
@@ -91,6 +91,10 @@ auto SemanticTypeHash::operator()(const TypeData& data) const -> std::size_t {
           for (TypeId element : t.elements) {
             HashId(seed, element);
           }
+        } else if constexpr (std::is_same_v<T, UnionType>) {
+          for (TypeId element : t.elements) {
+            HashId(seed, element);
+          }
         } else if constexpr (std::is_same_v<T, ObservableType>) {
           HashId(seed, t.value);
         } else if constexpr (std::is_same_v<T, ExternalRefType>) {

--- a/tests/cases/cpp/unpacked_union_member_access/case.yaml
+++ b/tests/cases/cpp/unpacked_union_member_access/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.unpacked_union_member_access
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    def_i: 0
+    a_rt: 42
+    t_rt: 0x0AABBCCD
+    t_ovr: 0x7f
+    t_h: 0xBEEF

--- a/tests/cases/cpp/unpacked_union_member_access/main.sv
+++ b/tests/cases/cpp/unpacked_union_member_access/main.sv
@@ -1,0 +1,37 @@
+module Top;
+  typedef union {
+    int        i;
+    bit [15:0] h;
+  } two_t;
+
+  typedef union {
+    byte       b;
+    int        w;
+    bit [15:0] h;
+  } three_t;
+
+  two_t   a;
+  two_t   d;
+  three_t t;
+  int     def_i;
+  int     a_rt;
+  int     t_rt;
+  int     t_ovr;
+  int     t_h;
+
+  initial begin
+    def_i = d.i;
+
+    a.i = 42;
+    a_rt = a.i;
+
+    t.w = 32'h0AABBCCD;
+    t_rt = t.w;
+
+    t.b = 8'h7F;
+    t_ovr = t.b;
+
+    t.h = 16'hBEEF;
+    t_h = t.h;
+  end
+endmodule

--- a/tests/cases/cpp/unpacked_union_real_member/case.yaml
+++ b/tests/cases/cpp/unpacked_union_real_member/case.yaml
@@ -1,0 +1,12 @@
+id: cpp.unpacked_union_real_member
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    i_rt: 9
+    f_ok: 1

--- a/tests/cases/cpp/unpacked_union_real_member/main.sv
+++ b/tests/cases/cpp/unpacked_union_real_member/main.sv
@@ -1,0 +1,18 @@
+module Top;
+  typedef union {
+    int       i;
+    shortreal f;
+  } num_t;
+
+  num_t n;
+  int   i_rt;
+  int   f_ok;
+
+  initial begin
+    n.i = 9;
+    i_rt = n.i;
+
+    n.f = 2.5;
+    f_ok = (n.f == 2.5);
+  end
+endmodule

--- a/tests/cases/errors/unsupported_tagged_union/case.yaml
+++ b/tests/cases/errors/unsupported_tagged_union/case.yaml
@@ -1,4 +1,4 @@
-id: errors.unsupported_unpacked_union
+id: errors.unsupported_tagged_union
 tags: [errors, diag]
 input:
   command: [emit, cpp]
@@ -12,8 +12,8 @@ expect:
     contains:
       - "main.sv:2:"
       - "unsupported:"
-      - "unpacked union types are not yet supported"
-      - "union { int a; int b; } u;"
+      - "tagged unions are not yet supported"
+      - "union tagged { int a; int b; } u;"
     not_contains:
       - "internal error"
       - "\x1b["

--- a/tests/cases/errors/unsupported_tagged_union/main.sv
+++ b/tests/cases/errors/unsupported_tagged_union/main.sv
@@ -1,0 +1,3 @@
+module Top;
+  union tagged { int a; int b; } u;
+endmodule

--- a/tests/cases/errors/unsupported_unpacked_union/main.sv
+++ b/tests/cases/errors/unsupported_unpacked_union/main.sv
@@ -1,3 +1,0 @@
-module Top;
-  union { int a; int b; } u;
-endmodule


### PR DESCRIPTION
## Summary

Adds support for the untagged unpacked union (LRM 7.3) end to end: declaration, default initialization, member read, and member write. An untagged unpacked union is overlapping storage where one member is usable at a time and a cross-member read is undefined; it is neither a product (struct/tuple) nor a sum (tagged union), so it gets its own representation rather than reusing the struct's. A tagged union is a distinct sum-type concept and is rejected at the HIR-to-MIR gate.

## Design

The decision is recorded in `docs/decisions/unpacked-union-representation.md`. HIR untagged `UnpackedUnionType` lowers to a new MIR `UnionType` (component types in declaration order, no tagged flag). Two value-build/access primitives parallel the tuple pair: `UnionExpr{index, value}` builds a value whose active member is `index`, and `UnionGetExpr{union, index}` reads the active member. A union member read is `UnionGetExpr`; a union member write is a whole-union replacement (`u.f = v` assigns the union place a fresh single-member `UnionExpr`), because a union member has no writable lvalue, mirroring how a string element write realizes as `putc`. Default initialization synthesizes the first member's default. The runtime realization `lyra::value::Union<Ts...>` holds the active member and composes `LyraValue` by delegating to it (equality is same-active-member-and-equal-value, never a cross-member reinterpretation); it is not a byte overlay because the value types are rich C++ objects. An inactive-member read returns that member's default as a deterministic but unreliable fallback for an SV-undefined operation.

## Testing

`bazel test //...` passes. New `cpp_run` cases cover 2- and 3-member integral unions (round-trip, overwrite, first-member default) and a real/shortreal-member union. The previous negative test asserting unpacked unions are unsupported is repurposed to assert the tagged-union rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)