### PR TITLE
Lower $clog2 as a runtime value query

### DIFF
--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -53,11 +53,12 @@ C  Non-local access substrate
 - [x] A1 -- More than one module definition compiles in a single run; the design is no longer
       assumed to be a single top module. Each module is its own independently compiled unit. The LRM
       permits multiple top-level blocks (LRM 3.11): every elaborated but uninstantiated module is
-      implicitly a top-level block, and all of them sit under one implicit root scope ($root). The
-      program constructs every top-level block as a child of $root and runs them all under a single
-      scheduler on one shared time axis -- there is no single "main" block. This is end-to-end
-      testable with no instantiation edge: two independent top modules each run their own processes
-      under the shared schedule.
+      implicitly a top-level block, and all of them sit under one implicit root scope
+      ($root). The
+      program constructs every top-level block as a child of $root and runs them
+      all under a single scheduler on one shared time axis -- there is no single "main" block. This
+      is end-to-end testable with no instantiation edge: two independent top modules each run their
+      own processes under the shared schedule.
 - [x] A2 -- A module instantiated with different parameter values yields distinct specializations
       that each behave according to their own values. Distinct parameter bindings produce distinct
       compiled artifacts with distinct identity (see `docs/decisions/specialization-identity.md`),

--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -67,8 +67,11 @@ full support.
 - [ ] **Net-typed port connections** -- connecting a net (`wire`) across a module port, as the
       testbench does when wiring the DUT. The first wall the full top-level testbench hits.
 - [x] **`$signed` / `$unsigned`** system functions.
-- [ ] **`$clog2`** system function (appears in a bit-count select bound). The current ibex_alu
-      frontier once the generate / `genvar` forms above lower.
+- [x] **`$clog2`** system function (LRM 20.8.1). A type-agnostic value query: ceil(log2) of the
+      argument read as unsigned, with `$clog2(0)` defined as 0. It lowers to a runtime value query,
+      so a constant argument folds downstream and a `genvar`-dependent argument (the ibex_alu
+      butterfly bit-count bound) stays runtime. With this, `ibex_alu` lowers and emits C++
+      end-to-end.
 
 ### Localized / long tail
 

--- a/include/lyra/support/builtin_fn.hpp
+++ b/include/lyra/support/builtin_fn.hpp
@@ -100,6 +100,9 @@ enum class BuiltinFn : std::uint16_t {
   // LRM 20.9 / 21.3.4.3. 2-state packed types return false; downstream
   // constant-folds those calls.
   kIsUnknown,
+  // LRM 20.8.1. ceil(log2) of the operand read as unsigned; $clog2(0) is 0.
+  // A constant argument is folded downstream, never in lowering.
+  kClog2,
   // Observable storage cell operations. `Set` / `Mutate` thread services
   // as the second argument.
   kGet,

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -307,6 +307,12 @@ class PackedArray {
     return Bit(HasUnknown());
   }
 
+  // LRM 20.8.1 `$clog2` -- the SV-surface query. ceil(log2) of the operand
+  // read as unsigned (X/Z bits collapse to 0), with $clog2(0) == 0. Returns a
+  // 32-bit `integer` so the MIR call's result type matches the C++ return type
+  // with no backend lift.
+  [[nodiscard]] auto Clog2() const -> PackedArray;
+
   // Operands are assumed to share the same shape (slang's promotion
   // contract). Comparison / logical results are 1-bit, 4-state when any
   // operand is 4-state (so they can carry an X under LRM 11.4

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -82,6 +82,8 @@ auto BuiltinFnCppName(support::BuiltinFn id) -> std::string_view {
       return "Triggered";
     case support::BuiltinFn::kIsUnknown:
       return "IsUnknown";
+    case support::BuiltinFn::kClog2:
+      return "Clog2";
     case support::BuiltinFn::kEnumFirst:
       return "First";
     case support::BuiltinFn::kEnumLast:

--- a/src/lyra/lowering/ast_to_hir/expression/calls.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/calls.cpp
@@ -291,6 +291,28 @@ auto LowerCallExpr(
       };
     }
 
+    // LRM 20.8.1 `$clog2`: ceil(log2) of the operand read as unsigned. A
+    // type-agnostic value query -- every value type exposes it -- so it lowers
+    // to the generic instance builtin call on its operand. A constant argument
+    // is folded by the downstream optimizer, never in lowering.
+    if (info.subroutine != nullptr &&
+        info.subroutine->knownNameId ==
+            slang::parsing::KnownSystemName::Clog2) {
+      auto type_id = module.InternType(*call.type, span);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return hir::Expr{
+          .type = *type_id,
+          .data =
+              hir::CallExpr{
+                  .callee =
+                      hir::BuiltinMethodRef{
+                          .method = support::BuiltinFn::kClog2},
+                  .arguments = std::move(arg_ids),
+              },
+          .span = span,
+      };
+    }
+
     // LRM 7.12.4 `item.index`: slang dresses the iteration index as a method on
     // the iterator (a SystemSubroutine with `KnownSystemName::Index`) whose
     // receiver value is discarded. It is the index iteration parameter -- a

--- a/src/lyra/support/builtin_fn.cpp
+++ b/src/lyra/support/builtin_fn.cpp
@@ -243,6 +243,8 @@ auto BuiltinFnName(BuiltinFn id) -> std::string_view {
       return "enum_prev";
     case BuiltinFn::kIsUnknown:
       return "is_unknown";
+    case BuiltinFn::kClog2:
+      return "clog2";
     case BuiltinFn::kGet:
       return "get";
     case BuiltinFn::kSet:

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -481,6 +481,36 @@ auto PackedArray::HasUnknown() const -> bool {
       UnknownWords(), [](std::uint64_t w) { return w != 0U; });
 }
 
+auto PackedArray::Clog2() const -> PackedArray {
+  // ceil(log2(n)) is the index of n's highest set bit, plus one unless n is an
+  // exact power of two; n in {0, 1} yields 0. Read the operand as unsigned:
+  // X/Z bits collapse to 0 (value plane masked by ~unknown) and the declared
+  // width bounds the top word.
+  const auto value_words = ValueWords();
+  const auto unknown_words = UnknownWords();
+  std::int64_t high_bit = -1;
+  int set_bits = 0;
+  for (std::size_t i = 0; i < value_words.size(); ++i) {
+    const std::uint64_t unk =
+        i < unknown_words.size() ? unknown_words[i] : std::uint64_t{0};
+    std::uint64_t word = value_words[i] & ~unk;
+    if (i + 1U == value_words.size()) {
+      word &= MaskForWidth(bit_width_ - (64U * i));
+    }
+    if (word == 0U) {
+      continue;
+    }
+    set_bits += std::popcount(word);
+    high_bit =
+        static_cast<std::int64_t>((64U * i) + 63U - std::countl_zero(word));
+  }
+  const std::int32_t result =
+      high_bit < 0
+          ? 0
+          : static_cast<std::int32_t>(high_bit + (set_bits > 1 ? 1 : 0));
+  return Integer(result);
+}
+
 namespace {
 
 // Word-level shift-and-OR copy: writes `src_bit_width` bits from `src` into

--- a/tests/cases/cpp/clog2/case.yaml
+++ b/tests/cases/cpp/clog2/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.clog2
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    c_const: 3
+    c_zero: 0
+    c_seven: 3
+    c_sixteen: 4
+    genvar_out: "32'h04030200"

--- a/tests/cases/cpp/clog2/main.sv
+++ b/tests/cases/cpp/clog2/main.sv
@@ -1,0 +1,27 @@
+module Top;
+  parameter int unsigned BYTES = 8;
+
+  // LRM 20.8.1: $clog2 returns ceil(log2(arg)); arg is unsigned and $clog2(0)
+  // is 0. These exercise the constant-argument path (folded downstream, never
+  // in lowering): an exact power of two, a value forcing the ceiling, the zero
+  // special case, and a wider value.
+  int c_const;
+  int c_zero;
+  int c_seven;
+  int c_sixteen;
+
+  initial begin
+    c_const = $clog2(BYTES);
+    c_zero = $clog2(0);
+    c_seven = $clog2(7);
+    c_sixteen = $clog2(16);
+  end
+
+  // Genvar-dependent argument: `i` is a runtime induction value, so the
+  // argument is a runtime expression and $clog2 must lower to a runtime call,
+  // not a constant. Lane i holds $clog2((2**(i+1)) - 1): 0, 2, 3, 4.
+  logic [31:0] genvar_out;
+  for (genvar i = 0; i < 4; i++) begin : gen
+    assign genvar_out[8 * i +: 8] = $clog2((1 << (i + 1)) - 1);
+  end
+endmodule


### PR DESCRIPTION
## Summary

Adds support for the `$clog2` system function (LRM 20.8.1). It is a type-agnostic value query -- ceil(log2) of the argument read as unsigned, with `$clog2(0)` defined as 0 -- so it lowers exactly like `$isunknown`: a generic instance builtin call on its operand, recognized at AST-to-HIR by slang's known-system-name and carried through HIR-to-MIR unchanged. The backend renders it as `(operand).Clog2()`.

## Design

Constant folding is left to the downstream optimizer, never performed in lowering (the same principle the conversion-folding decision establishes). One lowering path handles both cases uniformly: a constant argument folds in the emitted C++/LLVM, and a `genvar`-dependent argument -- where the genvar is a runtime induction value -- stays a runtime call. The runtime `PackedArray::Clog2` is width-general: it reads the operand as unsigned (X/Z bits collapse to 0), finds the highest set bit, and adds one unless the value is an exact power of two, returning a 32-bit `integer`.

With this, `ibex_alu` lowers and emits C++ end-to-end; the genvar-dependent butterfly bit-count bound (`$clog2(16 >> stg)`) composes with the existing runtime-genvar part-select model.

## Testing

New end-to-end case `cpp.clog2` covers constant arguments (an exact power of two, a ceiling case, the zero special case, a wider value) and a `genvar`-dependent argument. Full `bazel test //...` passes.