### PR TITLE
Add object-lifetime contract and MIR managed reference type

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -24,23 +24,25 @@ Read top to bottom on first pass:
    references as a field type
 10. `object_model.md` -- the one nominal object model; module / scope / class as one object type;
     inheritance, dispatch, construction, references and handles
-11. `lir.md` -- execution-oriented IR (CFG, basic blocks, storage)
-12. `activation.md` -- the runtime execution instance; completion slot; ownership / continuation /
+11. `object_lifetime.md` -- managed object lifetime; reachability and precise tracing; activation
+    frames; safepoints and roots
+12. `lir.md` -- execution-oriented IR (CFG, basic blocks, storage)
+13. `activation.md` -- the runtime execution instance; completion slot; ownership / continuation /
     cancellation relations
-13. `scheduling.md` -- stratified event scheduler, regions, suspension protocol
-14. `hierarchy_and_generate.md` -- hierarchy and generate ownership
-15. `reference_resolution.md` -- intra-unit vs cross-unit references; compile-time vs
+14. `scheduling.md` -- stratified event scheduler, regions, suspension protocol
+15. `hierarchy_and_generate.md` -- hierarchy and generate ownership
+16. `reference_resolution.md` -- intra-unit vs cross-unit references; compile-time vs
     construction-time resolution
-16. `emission_model.md` -- how a backend emits independent per-unit artifacts and realizes
+17. `emission_model.md` -- how a backend emits independent per-unit artifacts and realizes
     cross-unit resolution through the SDK
-17. `backend_contract.md` -- per-node within-artifact realization rules; type mapping vs value
+18. `backend_contract.md` -- per-node within-artifact realization rules; type mapping vs value
     emission; what a backend may and may not name in render
-18. `identity_and_ownership.md` -- identity rules and forbidden shapes
-19. `lowering_boundaries.md` -- what each lowering may and may not do
-20. `lowering_organization.md` -- how lowering passes organize their internal objects (facts,
+19. `identity_and_ownership.md` -- identity rules and forbidden shapes
+20. `lowering_boundaries.md` -- what each lowering may and may not do
+21. `lowering_organization.md` -- how lowering passes organize their internal objects (facts,
     registries, builders, walk frame)
-21. `incremental_build.md` -- query-based incremental compilation and caching
-22. `testing_strategy.md` -- test categories and structure
+22. `incremental_build.md` -- query-based incremental compilation and caching
+23. `testing_strategy.md` -- test categories and structure
 
 ## Concept Index
 
@@ -68,6 +70,7 @@ If you are looking for a concept, this table points to the canonical doc.
 | Member and type model; object types; owning pointer; vector wrapper       | `mir.md`                    |
 | Callable model; code vs value; captures; references as a field type       | `callable.md`               |
 | Object model; nominal object types; inheritance; dispatch; handles        | `object_model.md`           |
+| Object lifetime; managed reclamation; tracing GC; activation frames       | `object_lifetime.md`        |
 | LIR shape (CFG, basic blocks, storage)                                    | `lir.md`                    |
 | Activation; execution instance; completion slot; cancellation domain      | `activation.md`             |
 | Stratified scheduler; regions; suspension protocol; NBA / closure submit  | `scheduling.md`             |
@@ -86,14 +89,15 @@ the decision's subject, top to bottom, and **check the design against every rele
 "Forbidden Shapes" before proposing it**. A design that matches a Forbidden Shape is wrong even if
 it compiles and passes tests.
 
-| Decision touches...                                          | Binding docs (read all, top-down)                                                                                            |
-| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| Cross-unit access / hierarchical refs / ports / connectivity | `north_star`, `compilation_unit_model`, `reference_resolution`, `emission_model`, `elaboration_lifecycle`                    |
-| Backend emit / artifact structure / SDK boundary             | `north_star`, `compilation_unit_model`, `reference_resolution`, `emission_model`, `backend_contract`, `runtime_distribution` |
-| Compilation boundaries / unit dependencies / incrementality  | `north_star`, `compilation_unit_model`, `incremental_build`                                                                  |
-| Hierarchy / generate / object graph / construction           | `north_star`, `hierarchy_and_generate`, `runtime_model`, `elaboration_lifecycle`                                             |
-| Identity / ownership / id kinds                              | `north_star`, `identity_and_ownership`                                                                                       |
-| Object model / classes / inheritance / dispatch / handles    | `north_star`, `object_model`, `mir`, `callable`, `runtime_model`                                                             |
+| Decision touches...                                            | Binding docs (read all, top-down)                                                                                            |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Cross-unit access / hierarchical refs / ports / connectivity   | `north_star`, `compilation_unit_model`, `reference_resolution`, `emission_model`, `elaboration_lifecycle`                    |
+| Backend emit / artifact structure / SDK boundary               | `north_star`, `compilation_unit_model`, `reference_resolution`, `emission_model`, `backend_contract`, `runtime_distribution` |
+| Compilation boundaries / unit dependencies / incrementality    | `north_star`, `compilation_unit_model`, `incremental_build`                                                                  |
+| Hierarchy / generate / object graph / construction             | `north_star`, `hierarchy_and_generate`, `runtime_model`, `elaboration_lifecycle`                                             |
+| Identity / ownership / id kinds                                | `north_star`, `identity_and_ownership`                                                                                       |
+| Object model / classes / inheritance / dispatch / handles      | `north_star`, `object_model`, `object_lifetime`, `mir`, `callable`, `runtime_model`                                          |
+| Object lifetime / managed reclamation / GC / activation frames | `north_star`, `object_lifetime`, `object_model`, `mir`, `runtime_model`, `scheduling`                                        |
 
 The failure mode this guards against: anchoring on current code -- which may be a transitional
 shortcut -- instead of the contract. Current code that contradicts a contract is wrong; read the

--- a/docs/architecture/object_lifetime.md
+++ b/docs/architecture/object_lifetime.md
@@ -1,0 +1,190 @@
+# Object Lifetime
+
+## Purpose
+
+A SystemVerilog class object is a dynamically allocated, language-managed object: created by `new`
+at arbitrary simulation time, never explicitly freed, with no user-visible destructor, freely
+copyable by handle, identity-comparable, and free to form arbitrary object graphs including cycles.
+The simulator -- not the SystemVerilog program -- owns reclamation.
+
+This document fixes the lifetime model for such objects and the storage discipline that makes
+precise reclamation possible:
+
+> Managed object liveness is reachability. A managed object is retained while reachable from runtime
+> roots through managed-reference edges; an unreachable object is eligible for reclamation by a
+> precise tracing collector at a runtime safepoint. A backend's control-flow mechanism may implement
+> suspension and resumption, but every language-visible value that can survive a safepoint lives in
+> compiler-described, runtime-traceable, Lyra-owned storage -- never in opaque backend execution
+> state.
+
+The governing split: Lyra owns semantic state; the backend owns control-flow realization. The
+collector sees every managed edge precisely; backend-private state may never hide one.
+
+The model is a generic managed-runtime concept -- the object references of Java, C#, Go, and Python
+-- not a SystemVerilog-specific mechanism. SystemVerilog classes are the first Lyra feature that
+requires it.
+
+## Owns
+
+- The lifetime meaning of the **managed reference** (`gc<T>`): a traced edge that retains its
+  target, with shallow-copy and identity that perform no retain/release, null a legal value, and
+  cycles permitted. The reference _kind_ on the reference-kind axis is owned by `object_model.md`;
+  this document owns only what the reference means for lifetime.
+- The **managed heap** and its **reachability semantics**: a managed object is retained while
+  reachable from a root through managed-reference edges; an unreachable object -- including an
+  unreachable cycle -- is eligible for reclamation.
+- The **activation frame**: the Lyra-owned, compiler-described, traceable storage holding the
+  language-visible values of a suspendable or allocating callable -- the home of every managed value
+  that can be live at a safepoint.
+- The **traceable representation** of deferred or scheduled work whose environment can contain a
+  managed reference.
+- The **root categories** collection starts from, and the **safepoint** contract: where collection
+  may run and what must be reachable there.
+- The **trace contract**: every traceable object can have its outgoing managed edges enumerated
+  exactly. The trace _mechanism_ is not owned here.
+- The separation of **control flow** (the backend's mechanism) from **semantic state** (Lyra's).
+
+## Does Not Own
+
+- The collector **algorithm and policy**: mark-sweep internals, collection cadence, and any
+  generational, incremental, concurrent, or moving strategy. The contract is reachability-based
+  reclamation; the algorithm is a realization choice.
+- The **object structure** -- members, methods, base, dispatch, and the construction protocol. That
+  is `object_model.md`. This document owns only how long an object lives and how it is found.
+- The backend's **control-flow machinery** (its coroutine mechanism, awaiter and continuation
+  plumbing). A backend may use it, constrained by the invariants below.
+- **Physical layout**: managed-heap layout, frame field offsets, and trace-metadata encoding. Those
+  are LIR and the runtime.
+- The exact **MIR encoding** of `gc<T>` -- a kind on the reference-kind axis versus a distinct
+  reference family. That is `mir.md` / `object_model.md`.
+- The **static instance hierarchy's lifetime**. Module and generate-scope objects are owning, built
+  at time zero, and torn down at simulation end; they are roots into the managed heap, not residents
+  of it.
+
+## Core Invariants
+
+1. **Liveness is reachability; reclamation is precise tracing at a safepoint.** A managed object is
+   retained while reachable from a root through managed edges; an unreachable object is eligible for
+   reclamation by a precise tracing collector at a runtime safepoint -- reclamation occurs at the
+   next collection, not at the instant the object becomes unreachable. _Consequence: a
+   simulation-lifetime arena that never reclaims and pure reference counting are both rejected as
+   the model -- the first is unbounded, the second leaks cyclic object graphs._
+
+2. **The managed reference carries a traced edge.** `gc<T>` is nullable, freely copyable,
+   identity-bearing, and shallow-copy; copying performs no retain/release; it may point into cycles;
+   the collector follows it. _Consequence: a class handle is never a borrowed raw pointer; it is an
+   edge the collector traces._
+
+3. **Traceability is a recursive type property, and tracing is precise.** Every type answers whether
+   it can contain a managed edge; for any traceable object the runtime enumerates every outgoing
+   managed edge exactly. _Consequence: the collector never conservatively scans native stack or
+   memory guessing which words are pointers._
+
+4. **Every managed value that can be live at a safepoint has Lyra-visible storage.** Because
+   collection may be triggered by allocation pressure mid-execution, this covers not only values
+   live across a suspension but every managed value live during execution that can reach a safepoint
+   -- including a running activation's live managed values -- all of which reside in Lyra-owned
+   traceable storage, never in opaque backend execution state. _Consequence: a running activation's
+   managed locals are reachable to the collector at an allocation-pressure safepoint, not only a
+   suspended activation's._
+
+5. **A safepoint-capable instance method roots its receiver.** A managed object's instance method
+   that can reach a safepoint holds a managed root to its receiver in its activation; the borrowed
+   receiver used in the body derives from that root. _Consequence: the object a method runs on
+   cannot be reclaimed beneath it._
+
+6. **The execution-to-activation-frame edge is Lyra-visible and traceable.** The collector reaches
+   an activation frame through Lyra-owned runtime state -- the process or scheduling record -- never
+   through opaque backend execution state. _Consequence: a suspended execution's managed roots are
+   always findable without inspecting backend-private state._
+
+7. **Only managed-carrying execution state participates in tracing.** A frame, closure environment,
+   or scheduler payload gets a Lyra-owned traceable representation if and only if its type
+   recursively contains a managed edge; storage that cannot contain a managed reference need not
+   participate. _Consequence: the discipline touches exactly the managed path; managed-free
+   execution state is unaffected._
+
+8. **Allocation never reclaims its own in-flight result.** Safepoint placement around a `new`
+   guarantees the freshly allocated object is reachable from a root before any subsequent collection
+   runs. _Consequence: a new object is never reclaimed before it is stored into a traceable slot._
+
+9. **Reclamation is unobservable.** A managed object has no user-visible destructor or finalizer;
+   reclamation produces no observable behavior, and its timing does not affect simulation results.
+   _Consequence: collection cadence may vary freely -- by allocation pressure, by scheduler boundary
+   -- without changing program meaning._
+
+10. **Control flow and semantic state are separated.** A backend's control-flow mechanism may own
+    suspension, resumption, and native control bookkeeping; it owns no managed value that must
+    survive a safepoint. _Consequence: the activation frame, not backend execution state, is the
+    home of cross-safepoint managed state._
+
+## Boundary to Adjacent Layers
+
+- **Peer to `object_model.md`.** That document owns object structure and the reference-kind axis;
+  `gc<T>` is the managed entry of that axis. This document owns what the managed reference means for
+  lifetime and how a managed object is reclaimed.
+- **`mir.md`.** `gc<T>` is a MIR type; an activation frame is an ordinary MIR object whose fields
+  are the materialized managed values; a suspension point is the existing await expression. MIR
+  carries no basic blocks and no resume-state field -- the state machine is the backend's
+  control-flow concern.
+- **`callable.md`.** A suspendable or allocating callable's cross-safepoint state is its activation
+  frame; the receiver-rooting invariant refines the receiver rule for managed instance methods.
+- **`runtime_model.md` / `scheduling.md`.** The scheduler stores traceable work items, never opaque
+  payloads that hide managed references; safepoints are scheduler boundaries together with
+  allocation-pressure points.
+- **`backend_contract.md`, LIR, and the runtime.** The collector algorithm, the trace mechanism, the
+  managed-heap and frame layout, and the choice of control-flow machinery are below this contract.
+  Every backend realizes the same explicit frame and closure objects and hides no managed value in
+  backend-private state.
+
+## Forbidden Shapes
+
+- A managed value that can survive a safepoint living only in opaque backend execution state -- a
+  backend coroutine-frame local, a captured-callback environment, an awaiter's private field, or
+  arbitrary foreign storage. (Invariants 4, 7, 10.)
+- Reaching an activation frame only through opaque backend execution state. (Invariant 6.)
+- A simulation-lifetime arena that never reclaims, as the lifetime model. (Invariant 1.)
+- Pure reference counting as the lifetime model. (Invariant 1.)
+- A suspendable or allocating managed instance method relying on a borrowed receiver to keep its
+  object alive. (Invariant 5.)
+- Conservative scanning of native stack or heap to discover roots. (Invariant 3.)
+- An allocation that can reclaim its own not-yet-stored result. (Invariant 8.)
+- `gc<T>` modeled as a borrowed raw pointer with no traced edge. (Invariant 2.)
+- A managed object exposed to foreign or native code across a safepoint without an explicit root or
+  pin -- an untraced foreign holder is a root the collector cannot see. (Invariants 3, 4.)
+- A resume-state or state-machine field materialized into MIR. (Invariant 10.)
+- A user-observable finalizer or a destruction-ordering guarantee for managed objects. (Invariant
+  9.)
+
+## Notes / Examples
+
+The static instance hierarchy and the managed heap are two lifetime systems joined by a one-way
+edge. Module and generate-scope objects are owning, built at time zero, and torn down at simulation
+end; a static object's field of managed type is a root edge into the heap. A managed object reaches
+the static tree only through borrowed (untraced) edges -- for example a class holding a
+virtual-interface handle -- so the collector never traces into the static tree and the interface's
+lifetime stays independent. The shared reference -- the acyclic, reference-counted activation of an
+automatic scope -- is a separate internal system; a shared activation that itself contains managed
+fields is a root the collector traces through, while the activation's own lifetime stays
+reference-counted.
+
+A managed value live across a suspension illustrates the storage discipline:
+
+```
+initial begin
+  C h = new;   // h is allocated in the managed heap
+  #10;         // h is live across the suspension
+  h.f();
+end
+```
+
+`h` is a managed value live across the `#10`, so it is a field of the activation frame, reached
+frame-relative; backend execution state holds only control bookkeeping and the Lyra-visible edge to
+the frame. At a safepoint during the `#10`, the collector reaches the object through the scheduling
+record, then the frame, then `h`.
+
+The initial collector is a realization choice, not contract: precise, stop-the-world, non-moving,
+single-threaded mark-sweep. Non-moving keeps borrowed receivers, virtual-interface handles, and
+foreign pointers stable; the accepted cost is free-list allocation and fragmentation over long runs.
+Generational, incremental, or moving strategies are later collector choices that change none of the
+invariants above.

--- a/docs/architecture/object_model.md
+++ b/docs/architecture/object_model.md
@@ -55,9 +55,8 @@ direction. The governing thesis:
 - When and into what a cross-unit reference resolves, and the by-name mechanism. That is
   `reference_resolution.md` and `emission_model.md`. The object model states that a cross-unit
   object reference is by-name; those docs own the resolution.
-- Physical layout: object storage layout, dispatch-table layout, frame allocation, and the
-  realization of managed reachability (reference counting versus tracing collection). Those are LIR
-  and the runtime.
+- Physical layout: object storage layout, dispatch-table layout, frame allocation, and the collector
+  algorithm that realizes managed reachability. Those are LIR and the runtime.
 
 ## Core Invariants
 
@@ -87,13 +86,14 @@ direction. The governing thesis:
 4. **The reference reaching an instance carries its lifetime, orthogonal to the object's category.**
    The kinds are owning (one owner controls the lifetime), borrowed (refers, owns nothing), shared
    (a reference-counted, acyclic-by-construction owner), and managed (a language-managed object
-   handle: null is a legal value, identity is comparable, copies are shallow, the object is
-   reachable while any handle reaches it, it is created by construction, and it is never explicitly
-   freed). A SystemVerilog class handle is a managed reference, distinct from a shared one. Whether
-   an object is a node in the runtime tree is read from its base lineage, never from the reference
-   kind that reaches it. _Object-model consequence: topology, lifetime, and category are three axes;
-   collapsing any two -- "a unique reference means a tree child", "a class handle is a shared
-   pointer" -- loses a distinction a backend must read._
+   handle: null is a legal value, identity is comparable, copies are shallow, it is created by
+   construction, and it is never explicitly freed; its lifetime model -- retained while reachable,
+   reclaimed by precise tracing -- is owned by `object_lifetime.md`). A SystemVerilog class handle
+   is a managed reference, distinct from a shared one. Whether an object is a node in the runtime
+   tree is read from its base lineage, never from the reference kind that reaches it. _Object-model
+   consequence: topology, lifetime, and category are three axes; collapsing any two -- "a unique
+   reference means a tree child", "a class handle is a shared pointer" -- loses a distinction a
+   backend must read._
 
 5. **Construction is its own concept.** Allocating an object and running its constructor, with
    optional base-constructor chaining and a defined initialization ordering, is a construction form
@@ -123,12 +123,13 @@ direction. The governing thesis:
    category. _Object-model consequence: a static property is one cell owned by the type, never a
    field replicated into every instance._
 
-9. **Managed reachability is the contract; its realization is not.** The model commits to the
-   semantics that a managed object lives while any handle reaches it. Whether a backend realizes
-   that by reference counting or tracing collection, and whether cyclic garbage is reclaimed, are
-   realization choices outside the contract. _Object-model consequence: MIR states "managed
-   reachability" and a backend chooses the mechanism; MIR never states "reference counted" as the
-   meaning._
+9. **Managed reachability is realized by precise tracing.** A managed object is retained while
+   reachable and reclaimed by a precise tracing collector; an unreachable cycle is reclaimed by
+   reachability, not leaked. The collector algorithm and cadence are realization choices; the
+   reachability model and the storage discipline that makes tracing precise are the contract, owned
+   by `object_lifetime.md`. _Object-model consequence: the object model commits to
+   reachability-based reclamation, not to a reference-counted meaning; a class handle's lifetime
+   contract lives in `object_lifetime.md`._
 
 10. **A compilation unit owns one canonical registry of its local nominal object declarations, and
     identity, lexical name resolution, and emission nesting are three separate relations.** Every

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -108,8 +108,9 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
   data type at MIR; one reference type serves both `ref` formals (body local) and `ref` ports (unit
   member), distinct from a borrowed pointer because it preserves the observable-cell protocol.
 - [object-model](object-model.md) -- a module / scope and an SV class are one generic nominal object
-  type; an SV class handle is a managed reference, not the acyclic shared one; the receiver is an
-  instance-method property, not every callable's.
+  type; an SV class handle is a managed reference, not the acyclic shared one, realized by precise
+  tracing GC (arena and reference counting rejected); the receiver is an instance-method property,
+  not every callable's.
 - [object-model-storage](object-model-storage.md) -- a compilation unit owns one canonical registry
   of local nominal object declarations; identity, lexical name resolution, and backend emission
   nesting are separate relations; the lexical-tree-only storage and a second identity are rejected.

--- a/docs/decisions/object-model.md
+++ b/docs/decisions/object-model.md
@@ -1,6 +1,6 @@
-# Object model: managed handle, and the receiver is an instance-method property
+# Object model: managed handle, its reclamation, and the instance-method receiver
 
-Date: 2026-06-25 Status: accepted
+Date: 2026-06-25 (revised 2026-06-27) Status: accepted
 
 ## Why this decision matters
 
@@ -28,9 +28,8 @@ DAG that is **acyclic by construction** (an activation owns only data slots, nev
 closure, or a join group, so no ownership cycle can form). SystemVerilog class objects routinely
 form reference cycles -- two handles pointing at each other is ordinary LRM 8 code. Placing cyclic
 object graphs under a reference whose contract promises acyclicity would break that prior decision's
-invariant. The managed kind carries the reachability semantics SystemVerilog classes need; whether a
-backend realizes it by reference counting (the current realization) or tracing collection (a future
-one) is a realization choice, and reclaiming cyclic garbage is not part of the contract.
+invariant. The managed kind carries the reachability semantics SystemVerilog classes need; how that
+reachability is realized is Decision 3.
 
 A second alternative -- a separate parallel object-reference type carrying its own kind and
 nullability axes -- is also rejected: it would fold the deliberately distinct reference type (the
@@ -53,6 +52,40 @@ and forces every backend and every call site to carry and supply a receiver a st
 have. `mir.md` invariant 11 and `callable.md` invariant 2 are scoped accordingly: an instance method
 has `self`, a static function does not.
 
+## Decision 3: the managed reference is realized by precise tracing garbage collection
+
+A managed object's lifetime is reachability: it is retained while reachable from runtime roots
+through managed edges, and reclaimed by a precise tracing collector at a runtime safepoint. Three
+alternatives were weighed and rejected.
+
+A **simulation-lifetime arena** -- allocate, never reclaim until shutdown -- is the simplest
+realization and was the early lean. It is rejected as the model because memory grows without bound
+under allocation-heavy testbenches (a `forever` loop allocating a transaction per cycle),
+conflicting with the bounded-memory requirement. It is a valid intermediate state during
+implementation, never a terminal one for class support.
+
+**Pure reference counting** reclaims acyclic garbage promptly and needs no root enumeration, but
+SystemVerilog class graphs routinely form cycles (`a.next = b; b.next = a; a = null; b = null`
+leaves two mutually-referencing objects no handle reaches). Reference counting cannot reclaim an
+unreachable cycle, so it leaks legally-created object graphs.
+
+**Reference counting plus a cycle collector** is semantically sufficient but inherits the hard part
+of tracing -- root discovery, graph traversal, safepoints, enumerating managed references in
+suspended execution state -- while still paying reference-count traffic on every handle copy and
+running two lifetime systems. Absent profiling that shows reference counting materially helps the
+hot path, it is not the base model.
+
+Precise tracing requires that every managed reference live at a safepoint be enumerable. A backend's
+coroutine machinery places cross-suspend locals in an opaque frame with no enumeration interface, so
+tracing is impossible while managed state hides there. The enabling decision is therefore
+structural: every language-visible value that can survive a safepoint lives in compiler-described,
+Lyra-owned, traceable storage -- the activation frame and traceable closures -- reached through
+Lyra-visible runtime records, never through opaque backend execution state. An activation frame is
+owned by its execution record (it is not itself a managed object) and exposes a trace operation; the
+managed edges inside it are what the collector follows. This storage discipline, the root
+categories, and the safepoint contract are owned by `../architecture/object_lifetime.md`; reclaiming
+cyclic garbage is part of the model, not a gap.
+
 ## Consequences
 
 - `../architecture/object_model.md` states the managed reference (invariants 4 and 9) and the
@@ -61,12 +94,15 @@ has `self`, a static function does not.
 - `mir.md` invariant 11 and `callable.md` invariant 2 are scoped to instance methods; a static
   function is the no-receiver callable.
 - The managed reference is the SystemVerilog class handle's reference kind, distinct from the shared
-  (acyclic, reference-counted) one; cyclic class garbage is not yet reclaimed, and that is a
-  realization gap, not a semantic commitment.
+  (acyclic, reference-counted) one. Its lifetime is realized by precise tracing garbage collection,
+  and cyclic object graphs are reclaimed by reachability. The lifetime contract and the storage
+  discipline that makes tracing precise are owned by `../architecture/object_lifetime.md`.
 
 ## Cross-references
 
-- `../architecture/object_model.md` -- the object-model contract these two choices sit inside.
+- `../architecture/object_model.md` -- the object-model contract these choices sit inside.
+- `../architecture/object_lifetime.md` -- the managed-object lifetime contract Decision 3
+  establishes: reachability, precise tracing, activation frames, safepoints, and roots.
 - `lifetime-extended-automatic-scope.md` -- the shared reference's acyclic-DAG contract that
   Decision 1 declines to violate.
 - `reference-as-data-type.md` -- the observable-cell reference type Decision 1 declines to fold

--- a/docs/progress/object-model.md
+++ b/docs/progress/object-model.md
@@ -48,13 +48,21 @@ each stage establishes, not how.
       nested emission. Resolving a source name to an identity by lexical scope lands with
       SystemVerilog classes, the first references resolved by name.
 
+- [ ] Managed-object lifetime: a class object's liveness is reachability, and it is reclaimed by a
+      precise tracing collector at runtime safepoints, with cyclic object graphs reclaimed by
+      reachability. Every language-visible value that can survive a safepoint lives in a
+      compiler-described, runtime-traceable activation frame reached through Lyra-visible runtime
+      records, never in opaque backend execution state. The storage discipline (managed references,
+      activation frames, traceable scheduler payloads, root registration, receiver rooting) may land
+      before the collector algorithm, but class support is not complete until reclamation works -- a
+      never-reclaiming intermediate is not a terminal state.
+
 - [ ] A SystemVerilog class is the same generic object type, reached through a managed object
       reference: nullable as a value, identity-comparable, shallow-copied, participating in managed
       reachability, allocated by `new`, never explicitly freed -- distinct from an owning, a
-      borrowed, and a shared reference. The reachability semantics are the contract; a
-      reference-counted realization is not part of it, and cyclic garbage is not yet reclaimed.
-      Minimal surface: fields, `new`, direct instance-method call, handle equality against another
-      handle and against null.
+      borrowed, and a shared reference. Its lifetime and reclamation are the managed-object-lifetime
+      item above. Minimal surface: fields, `new`, direct instance-method call, handle equality
+      against another handle and against null.
 
 - [ ] Class inheritance: a single concrete base, `super` and the base-constructor call, and dynamic
       dispatch through logical method slots -- a method introduces, overrides, or finalizes a slot,
@@ -86,6 +94,8 @@ each stage establishes, not how.
 - `../architecture/object_model.md` -- the object-model contract: the one nominal-object reference,
   the override relation, the construction model, the reference kinds, and the registry (invariant
   10).
+- `../architecture/object_lifetime.md` -- the managed-object lifetime contract: reachability,
+  precise tracing, activation frames, safepoints, and roots.
 - `../architecture/mir.md`, `../architecture/callable.md`, `../architecture/runtime_model.md`,
   `../architecture/elaboration_lifecycle.md` -- the contracts this work satisfies and that the
   object model doc is a peer to.

--- a/include/lyra/mir/type.hpp
+++ b/include/lyra/mir/type.hpp
@@ -36,6 +36,7 @@ enum class TypeKind {
   kCoroutine,
   kReference,
   kPointer,
+  kManagedRef,
   kVector,
   kTuple,
   kUnion,
@@ -299,6 +300,18 @@ struct PointerType {
   auto operator==(const PointerType&) const -> bool = default;
 };
 
+// A managed reference (LRM 8.3 class handle): a traced edge to a
+// garbage-collected object on the managed heap. It is not a `PointerType` --
+// its target's lifetime is governed by reachability, not by RAII ownership, so
+// the tracing collector follows it as an edge. Null is a legal value, identity
+// is comparable, copies are shallow, and the target is retained while
+// reachable. The C++ backend renders it as `lyra::runtime::GcRef<T>`.
+struct ManagedRefType {
+  TypeId pointee;
+
+  auto operator==(const ManagedRefType&) const -> bool = default;
+};
+
 struct VectorType {
   TypeId element;
 
@@ -365,8 +378,8 @@ using TypeData = std::variant<
     AssociativeArrayType, WildcardIndexType, StringType, EventType, RealType,
     ShortRealType, RealTimeType, ChandleType, VoidType, ObjectType,
     ExternalUnitObjectType, ScopeType, ServicesType, FilesType, DiagnosticType,
-    RuntimeLibraryType, CoroutineType, RefType, PointerType, VectorType,
-    TupleType, UnionType, ExternalRefType, ObservableType>;
+    RuntimeLibraryType, CoroutineType, RefType, PointerType, ManagedRefType,
+    VectorType, TupleType, UnionType, ExternalRefType, ObservableType>;
 
 struct Type {
   TypeData data;

--- a/src/lyra/backend/cpp/render_type.cpp
+++ b/src/lyra/backend/cpp/render_type.cpp
@@ -167,6 +167,11 @@ auto RenderTypeAsCpp(
             }
             throw InternalError("RenderTypeAsCpp: unknown PointerOwnership");
           },
+          [&](const mir::ManagedRefType& m) -> std::string {
+            return std::format(
+                "lyra::runtime::GcRef<{}>",
+                RenderTypeAsCpp(unit, owner_class, m.pointee));
+          },
           [&](const mir::VectorType& v) -> std::string {
             return std::format(
                 "std::vector<{}>",

--- a/src/lyra/mir/dump.cpp
+++ b/src/lyra/mir/dump.cpp
@@ -227,6 +227,10 @@ class MirDumper {
               }
               throw InternalError("MirDumper: unknown PointerOwnership");
             },
+            [](const ManagedRefType& m) -> std::string {
+              return std::format(
+                  "ManagedRef(pointee=Type[{}])", m.pointee.value);
+            },
             [](const VectorType& v) -> std::string {
               return std::format("Vector(elem=Type[{}])", v.element.value);
             },

--- a/src/lyra/mir/type.cpp
+++ b/src/lyra/mir/type.cpp
@@ -83,6 +83,7 @@ auto Type::Kind() const -> TypeKind {
           [](const CoroutineType&) { return TypeKind::kCoroutine; },
           [](const RefType&) { return TypeKind::kReference; },
           [](const PointerType&) { return TypeKind::kPointer; },
+          [](const ManagedRefType&) { return TypeKind::kManagedRef; },
           [](const VectorType&) { return TypeKind::kVector; },
           [](const TupleType&) { return TypeKind::kTuple; },
           [](const UnionType&) { return TypeKind::kUnion; },

--- a/src/lyra/mir/type_interner.cpp
+++ b/src/lyra/mir/type_interner.cpp
@@ -85,6 +85,8 @@ auto SemanticTypeHash::operator()(const TypeData& data) const -> std::size_t {
         } else if constexpr (std::is_same_v<T, PointerType>) {
           HashId(seed, t.pointee);
           HashCombine(seed, std::hash<int>{}(static_cast<int>(t.ownership)));
+        } else if constexpr (std::is_same_v<T, ManagedRefType>) {
+          HashId(seed, t.pointee);
         } else if constexpr (std::is_same_v<T, VectorType>) {
           HashId(seed, t.element);
         } else if constexpr (std::is_same_v<T, TupleType>) {


### PR DESCRIPTION
## Summary

This establishes the object-lifetime architecture contract: a SystemVerilog class object's lifetime is reachability, realized by a precise tracing garbage collector at runtime safepoints, with every cross-safepoint managed value held in compiler-described, runtime-traceable, Lyra-owned storage rather than opaque backend execution state. It lands the first concrete piece of that contract -- a distinct MIR `ManagedRefType` for class handles, rendered as `lyra::runtime::GcRef<T>`. The change is behavior-neutral; nothing produces a managed reference yet.

## Design

A SystemVerilog class handle is a managed reference, distinct from the existing owning, borrowed, and shared kinds. It is modeled as its own MIR type family rather than a fourth pointer-ownership kind, because traceability -- whether the collector follows the edge -- is a separate axis from RAII ownership: keeping it distinct leaves the existing pointer paths untouched and makes "is this a traced edge?" a structural type fact. The realization is precise tracing GC; a simulation-lifetime arena (unbounded memory) and pure reference counting (leaks cyclic object graphs) were both weighed and rejected, with the rationale recorded in the object-model decision. The supporting storage discipline -- activation frames, traceable closures, root registration, safepoints -- is the contract in `object_lifetime.md`; the collector algorithm and the HIR and lowering that produce a managed reference are follow-on work.