### PR TITLE
Support packed arrays of packed aggregates

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -30,6 +30,9 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
 
 ### Aggregate types and access
 
+- [packed-array-representation](packed-array-representation.md) -- HIR represents a packed array
+  recursively (one dim per node, element by `TypeId`, scalar bit as an interned leaf), aligning it
+  with the other array families and the interned type graph; MIR stays flat and HIR-to-MIR flattens.
 - [unpacked-array-representation](unpacked-array-representation.md) -- representation of a
   fixed-size unpacked array.
 - [unpacked-struct-representation](unpacked-struct-representation.md) -- an unpacked struct is the

--- a/docs/decisions/packed-array-representation.md
+++ b/docs/decisions/packed-array-representation.md
@@ -1,0 +1,171 @@
+# Packed Array Representation
+
+## Date
+
+2026-06-26
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+HIR represented a packed array as a flat node: a scalar `atom` (bit / logic / reg) plus a vector of
+dimensions (`PackedArrayType { atom, signedness, dims, form }`). A bare scalar was the degenerate
+case -- a packed array with a single `[0:0]` dimension. This shape has three faults:
+
+- It cannot represent a packed array whose element is a packed aggregate. `byte_t [1:0]` (an array
+  of an 8-bit packed struct) has no scalar atom; the flat node can only fake it by treating the
+  struct's bits as a synthetic dimension and deriving the atom from the element's 4-state-ness, with
+  the element's type identity recovered later from slang's per-expression types rather than carried
+  in the type.
+- It flattens, inside HIR, two things that are HIR-faithful only when kept structured: the dimension
+  nest (a multi-dim packed array is `array of arrays` of bits in slang and the LRM) and the scalar
+  (slang keeps `ScalarType` as a distinct leaf; HIR collapsed it into a degenerate array). `hir.md`
+  invariant 3 reserves flattening into lower-level primitives for MIR.
+- It makes the packed array the only array family whose element is not a `TypeId`. Unpacked,
+  dynamic, queue, and associative arrays all reference their element by `TypeId`. The flat packed
+  node breaks that symmetry and, with it, the homogeneous interned type graph the stable-identity
+  architecture depends on.
+
+## Findings that shaped the design
+
+### F1. The LRM and slang define a packed array recursively
+
+`LRM 7.4.1`: a packed array's element may be a single-bit type, an enumerated type, "and recursively
+other packed arrays and packed structures." A packed array "appears as a primary [and] is treated as
+a single vector." slang mirrors this: a `PackedArrayType` carries one `range` and an `elementType`
+that nests one level per declared dimension, bottoming out at a `ScalarType`, an `EnumType`, or a
+packed `Struct` / `Union`. There is no flat-dimensions accessor; the nesting is the model.
+
+**Consequence:** the LRM-faithful HIR shape is single-dim per type node, nested via the element
+type, with the element named by its own type identity -- the same shape already adopted for unpacked
+arrays.
+
+### F2. HIR is required to preserve LRM structure, not flatten it
+
+`hir.md` invariant 3: HIR preserves LRM-level constructs without flattening them into lower-level
+primitives; flattening into a generic vocabulary is MIR's job. The flat `(atom, dims)` node does two
+flattenings inside HIR: it collapses the dimension nest onto one node, and it collapses the scalar
+leaf into a degenerate array. Both are MIR-level projections performed one layer too early.
+
+**Consequence:** the flatten belongs at HIR-to-MIR, not at AST-to-HIR. HIR carries the recursive
+shape; the translation to a flat vector is the next layer's work.
+
+### F3. The stable-identity architecture wants one homogeneous interned type graph
+
+`north_star.md` invariant 3 makes incremental and parallel compilation first-class.
+`incremental_build.md` expresses compilation as a memoized query graph keyed by ownership-based
+stable keys and semantic fingerprints, and forbids raw pointer identity and global sequential ids as
+keys. `identity_and_ownership.md` requires identity to be self-sufficient for resolution: given an
+id, a consumer resolves the target with no side table.
+
+A type graph that satisfies this is homogeneous: every node is an interned entity with a stable
+`TypeId`, and every reference between nodes -- including a packed array's element and the scalar
+terminal -- is a `TypeId`. A fingerprint then recurses uniformly over `TypeId` edges, and equal
+sub-types are structurally shared (the scalar `logic` is interned once and shared by every type that
+bottoms at it).
+
+**Consequence:** the scalar terminal must be a first-class interned leaf type with its own `TypeId`,
+not an inline payload embedded as a graph edge. A representation where the element edge is sometimes
+a `TypeId` and sometimes an inline atom is heterogeneous and leaves the scalar without a stable
+identity.
+
+### F4. The flat vector belongs to the value layer, produced by lowering
+
+`integral-representation.md` fixes the runtime / `backend::cpp` value as one flat
+`lyra::value::PackedArray` constructed from `(bit_width, is_signed, is_four_state)`, and keeps MIR's
+`PackedArrayType` as the flat `(atom, signedness, dims, form)` dispatch axis. That decision is about
+the value and MIR layers and stays unchanged. The flat shape is produced by flattening the recursive
+HIR type at HIR-to-MIR.
+
+**Consequence:** HIR and MIR carry different packed-array shapes -- recursive at HIR (faithful),
+flat at MIR (the value substrate). This is the same per-layer asymmetry as a loop at HIR becoming a
+callable at MIR. The substrate asymmetry that makes unpacked arrays recursive at both layers does
+not apply: a packed array's runtime value is a flat bit plane, so MIR stays flat while HIR is
+recursive.
+
+## The decision
+
+Packed-type representation follows these invariants:
+
+1. **HIR has a scalar bit leaf type.** A single bit is `ScalarBitType { atom }`, interned with its
+   own `TypeId`. A bare scalar (`logic`, `bit`, `reg`) is this leaf; so is the terminal of any
+   packed array. The scalar is a first-class type entity, not an inline payload.
+
+2. **HIR represents a packed array with a single dim per node, element by `TypeId`.**
+
+   ```text
+   hir::ScalarBitType  { atom: BitAtom }
+   hir::PackedArrayType { dim: PackedRange, element_type: TypeId, signedness, form }
+   ```
+
+   `logic [3:0]` is a `PackedArrayType` whose `element_type` is the interned `logic` scalar.
+   `logic [3:0][7:0]` is an outer node whose element resolves to an inner `PackedArrayType`.
+   `byte_t [1:0]` is a node whose `element_type` is the `byte_t` packed struct. A predefined-width
+   integer (`int`, `byte`) is a single-dim packed array over the scalar bit, with `form` recording
+   the syntactic origin. AST-to-HIR consumes slang's nested type 1:1 by recursing through
+   `InternType` on the element; there is no dimension-flattening walk.
+
+3. **Derived integral properties are computed against the type pool, not stored.** Bit width and
+   4-state-ness of a packed array resolve `element_type` through the pool (one bit for a scalar
+   leaf, the element's own width times the dim element count for an array). They are not cached on
+   the node. Signedness is a per-node field; the outermost node is authoritative (LRM 7.4.1:
+   elements are unsigned unless of a named signed type).
+
+4. **MIR stays flat; HIR-to-MIR flattens.** `mir::PackedArrayType { atom, signedness, dims, form }`
+   is unchanged (`integral-representation.md`). HIR-to-MIR projects the recursive HIR type onto it:
+   a scalar leaf becomes a one-bit flat vector; a packed array becomes the element's flat projection
+   with this node's dim prepended; a packed aggregate element becomes its single-vector projection.
+   The dimension-flattening that used to live in AST-to-HIR lives here, where projecting SV
+   structure into a generic vocabulary belongs.
+
+5. **A packed aggregate's single-vector projection is a packed array over the scalar bit.** A packed
+   struct's or union's `base` is `PackedArrayType { dim: [width-1:0], element_type: <scalar bit> }`.
+   Its field / member table is unchanged; member access still projects to a constant-bounds slice
+   over the base.
+
+## Consequences
+
+- A packed array whose element is a packed struct, union, or enum is represented faithfully -- the
+  element is named by its `TypeId`. Field and member access through an element select compose
+  naturally: the element select yields the aggregate type, whose field table drives the inner slice.
+- The AST-to-HIR dimension-flattening walk and its scalar-versus-aggregate branch are deleted; the
+  packed-array case recurses through `InternType` on the element, one node per declared dimension.
+- The packed array joins the other array families: its element is a `TypeId`, the type graph is
+  homogeneous, every node is interned, and the scalar bit is a stably identified entity shared
+  across every type that bottoms at it.
+- Bit width and 4-state-ness of a packed array become pool-relative queries. Their consumers thread
+  the type pool, the same way a layout query takes the type context.
+- MIR, the value layer, and the backend are unchanged: HIR-to-MIR still produces the same flat
+  `mir::PackedArrayType`.
+
+## Alternatives considered
+
+**Element as `variant<BitAtom, TypeId>` with no scalar leaf type.** The packed array would carry its
+element as either an inline scalar atom or a `TypeId`. Rejected. The element edge is heterogeneous:
+sometimes an interned entity, sometimes an inline payload that is not an entity and has no `TypeId`.
+The scalar then has no stable identity, contradicting the homogeneous interned type graph the
+stable-identity architecture requires (`incremental_build.md`, `identity_and_ownership.md`), and the
+packed array stays the only array family whose element is not a uniform `TypeId`. It is less
+invasive only because it leaves the existing "scalar as a degenerate packed array" flatten in place
+-- the very flatten this decision removes.
+
+**Flat dimensions at HIR (status quo).** A single node carrying a scalar atom and a vector of
+dimensions. Rejected. It flattens the dimension nest and the scalar leaf into MIR's vocabulary
+inside HIR, violating `hir.md` invariant 3, and it cannot name a non-scalar element type at all, so
+a packed array of a packed aggregate is unrepresentable except by faking a synthetic dimension and
+recovering the element type from slang's per-expression types.
+
+## Cross-references
+
+- [integral-representation](integral-representation.md) -- the MIR / value-layer flat packed shape,
+  unchanged; this decision flattens the recursive HIR type onto it at HIR-to-MIR.
+- [unpacked-array-representation](unpacked-array-representation.md) -- the recursive single-dim
+  element-by-`TypeId` shape this aligns the packed family with; the packed / unpacked substrate
+  asymmetry now lives at the MIR / value layer, not at HIR.
+- [mir-type-interning](mir-type-interning.md) -- the canonical-`TypeId` interner this homogeneous
+  type graph feeds.
+- `architecture/hir.md` (invariant 3: HIR preserves LRM structure; flattening is MIR's job).
+- `architecture/incremental_build.md`, `architecture/identity_and_ownership.md`,
+  `architecture/north_star.md` (the stable-identity / interned-type-graph rationale).

--- a/docs/decisions/unpacked-array-representation.md
+++ b/docs/decisions/unpacked-array-representation.md
@@ -212,9 +212,11 @@ Out of scope but unblocked by this design:
 **Flat dim list on a single unpacked type node.** Rejected. `LRM 7.4.4` explicitly defines multi-dim
 unpacked as "array of arrays". A flat list contradicts the LRM model HIR is required to preserve.
 C++ has no multi-dim vector type, so backend cpp would need to peel the dim list into nested
-`std::vector` at every render. The asymmetry vs PackedArray (flat-dims) is intentional and follows
-the substrate: bits are uniform and support flat storage; unpacked elements are heterogeneous and do
-not.
+`std::vector` at every render. The flat-dims shape this contrasts with is the MIR and value-layer
+representation of a packed array; at HIR a packed array is recursive like an unpacked one (see
+[packed-array-representation](packed-array-representation.md)). The surviving asymmetry is at the
+value layer and follows the substrate: a packed array's bits are uniform and support flat storage,
+while unpacked elements are heterogeneous and do not.
 
 **`std::array<T, N>` instead of `std::vector<T>`.** Rejected. Threading `N` into the cpp type string
 complicates rendering and breaks the symmetry with the variable-size container path

--- a/docs/progress/hierarchy.md
+++ b/docs/progress/hierarchy.md
@@ -53,12 +53,11 @@ C  Non-local access substrate
 - [x] A1 -- More than one module definition compiles in a single run; the design is no longer
       assumed to be a single top module. Each module is its own independently compiled unit. The LRM
       permits multiple top-level blocks (LRM 3.11): every elaborated but uninstantiated module is
-      implicitly a top-level block, and all of them sit under one implicit root scope
-      ($root). The
-      program constructs every top-level block as a child of $root and runs them
-      all under a single scheduler on one shared time axis -- there is no single "main" block. This
-      is end-to-end testable with no instantiation edge: two independent top modules each run their
-      own processes under the shared schedule.
+      implicitly a top-level block, and all of them sit under one implicit root scope ($root). The
+      program constructs every top-level block as a child of $root and runs them all under a single
+      scheduler on one shared time axis -- there is no single "main" block. This is end-to-end
+      testable with no instantiation edge: two independent top modules each run their own processes
+      under the shared schedule.
 - [x] A2 -- A module instantiated with different parameter values yields distinct specializations
       that each behave according to their own values. Distinct parameter bindings produce distinct
       compiled artifacts with distinct identity (see `docs/decisions/specialization-identity.md`),

--- a/docs/progress/ibex.md
+++ b/docs/progress/ibex.md
@@ -62,7 +62,7 @@ full support.
       compilation option, which skips assertion constructs during lowering. Implementing SVA proper
       (sampled-value functions `$rose`/`$fell`/`$stable`/`$past`, the `Observed` region) is a
       separate, optional feature off the critical path to running Ibex.
-- [ ] **Packed array whose element is a struct or enum** (a packed array of a packed aggregate, not
+- [x] **Packed array whose element is a struct or enum** (a packed array of a packed aggregate, not
       just of a scalar bit/logic).
 - [ ] **Net-typed port connections** -- connecting a net (`wire`) across a module port, as the
       testbench does when wiring the DUT. The first wall the full top-level testbench hits.

--- a/docs/progress/packed-value-model.md
+++ b/docs/progress/packed-value-model.md
@@ -1,0 +1,100 @@
+# Packed value model
+
+Tracks the migration that separates the roles the runtime integral value conflates today into clean
+layers, so an integral value is an ordinary value and SystemVerilog assignment semantics live in the
+variable cell. This is a pure-refactor workstream: no user-visible behaviour changes; the goal is
+the architecture, and the closure of a class of shape/assignment bugs.
+
+Extends the representation choice in `../decisions/integral-representation.md` (one value type for
+every integral, three attributes plus a dim stack); that decision stays, this workstream makes the
+descriptor immutable and lifts the cell semantics out of the value.
+
+## Why
+
+The runtime integral value is simultaneously three things:
+
+- a **value** -- the result of arithmetic and comparison;
+- a **typed storage cell** -- assignment preserves the variable's declared type, and a zero-width
+  sentinel adopts a shape on first store;
+- the **carrier of dimensional shape** for chained selects.
+
+Mixing these is the root of a bug class (a chained multi-dimensional read once dropped its shape and
+read back as a single bit) and of the special cases that surround it: shape-preserving assignment,
+the zero-width sentinel, and the relocation-only swap exemption. Each is a symptom of one object
+owning three responsibilities.
+
+## Target architecture
+
+- **Immutable shape descriptor** -- a dimension stack plus its total width, the width derived once
+  at construction and never independently settable. A rank-0 scalar is the empty dim stack (width
+  1), distinct from a length-one vector.
+- **Immutable value type** -- the shape plus signedness plus 2-state / 4-state domain.
+- **The integral value** -- a value type plus its bits, with ordinary value semantics (copy, move,
+  and assignment all replace the whole value) and no storage sentinel.
+- **The variable cell** -- owns its declared value type, is constructed with it, and stores an
+  already-converted right-hand side by overwriting bits while keeping its declared descriptor. The
+  assignment conversion is inserted upstream during lowering; the cell requires the right-hand side
+  to already match and never converts.
+- **Selector resolution** -- one shared computation maps (source shape, selector operands) to
+  (offset, result shape); read and write selectors consume the same result. The result's signedness
+  and state domain are decided by lowering per the LRM, not re-derived at runtime; the
+  value-producing selector receives that type and asserts its shape agrees.
+
+## Invariant
+
+A constructed integral value has an immutable descriptor (shape, signedness, state domain).
+Operations may mutate only its bits; they may never patch its shape, width, signedness, or state
+after construction. The two sanctioned descriptor-setting moments are constructing a new value and a
+cell adopting its declared type at initialization.
+
+## Done
+
+- [x] **Materialization builds shape at construction.** Every value-producing selector constructs
+      its result already carrying its derived shape; no value is built flat and then reshaped. This
+      is the first half of the invariant above and closed the original chained-read bug.
+- [x] **Single selector resolution.** The read and write selectors share one offset / result-shape
+      computation, so the two sides can no longer drift -- the structural cause of the original bug.
+
+## Steps
+
+The IDs are stable references.
+
+- [ ] V1 -- **Immutable shape and value descriptor.** Introduce the immutable shape (dims plus
+      cached width, factory-only construction, rank-0 scalar = empty dims, no zero-width
+      pseudo-state) and value type (shape plus signedness plus state). The value holds one
+      descriptor; every width / shape / signedness / state query derives from it. Replace the single
+      ambiguous "same shape" check (which today compares only width and state, not the dims) with
+      the three notions the layer actually needs: same layout (shape), same representation (shape +
+      signedness + state), and same storage width / domain (the raw bit-copy compatibility check).
+      Done when the value holds one immutable descriptor and the three equality notions are distinct
+      and used at the right sites.
+- [ ] V2 -- **Integral value becomes a pure value.** Remove the zero-width sentinel and the
+      shape-preserving assignment from the value; copy / move / assignment / swap all become
+      ordinary whole-value semantics. Done when the value has no special-case assignment and no
+      sentinel state.
+- [ ] V3 -- **Typed cell store.** The variable cell owns its declared value type, is constructed
+      with it and its default, and stores a right-hand side by overwriting bits while keeping its
+      declared descriptor; it requires the right-hand side to already be at the destination
+      representation. The sentinel's former job (first-store shape adoption) moves here. Done when
+      first-store adoption no longer exists on the value and the cell holds the declared type.
+- [ ] V4 -- **Store-boundary invariant.** Every lvalue write -- procedural assignment, cell store,
+      port bind, initialization, system-task backdoor write, foreign boundary -- carries an explicit
+      upstream conversion, so the right-hand side already matches the destination representation,
+      shape included. A store-time compatibility check fails with an explicit "missing upstream
+      conversion" message rather than silently converting. A static verifier over the mid-level IR
+      is the eventual enforcement; the runtime check is the first guard. Done when stores assert
+      representation compatibility and conversion targets carry full type including shape.
+- [ ] V5 -- **Selector materialization receives result type.** The shared resolver returns only
+      offset and result shape; the value-producing selector receives the lowering-decided result
+      type (signedness / state) and asserts its shape matches the resolved shape, instead of
+      transiently inheriting the source's signedness. Done when no selector result infers its own
+      signedness or state.
+- [ ] V6 -- **Descriptor sharing, profile-driven.** The descriptor is immutable and may be shared;
+      whether to back it with a stable interned handle is decided after measuring copy cost on the
+      temporary-heavy value paths (small values dominate). Done when the cost is measured and the
+      share / intern decision is recorded.
+
+## Cross-references
+
+- Selector read / write surface: `operators.md` (W4..W6).
+- Integral representation choice this extends: `../decisions/integral-representation.md`.

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -10,7 +10,6 @@ namespace lyra::diag {
 
 // Stable identity for primary diagnostics. Notes have no code.
 enum class DiagCode : std::uint32_t {
-  kUnsupportedPackedArrayElementType,
   kUnsupportedTaggedPackedUnion,
   kUnsupportedFixedSizeUnpackedArrayType,
   kUnsupportedDynamicArrayType,

--- a/include/lyra/hir/module_unit.hpp
+++ b/include/lyra/hir/module_unit.hpp
@@ -14,6 +14,8 @@ namespace lyra::hir {
 // (literal int type, void result of system tasks, etc.). Populated by
 // `ModuleUnit`'s constructor; consumers read them off the unit.
 struct BuiltinHirTypes {
+  TypeId scalar_bit;
+  TypeId scalar_logic;
   TypeId void_type;
   TypeId int32;
   TypeId integer;
@@ -30,37 +32,47 @@ struct ModuleUnit {
   StructuralScope root_scope;
 
   explicit ModuleUnit(std::string name)
-      : name(std::move(name)),
-        builtins{
-            .void_type = types.Add(Type{.data = VoidType{}}),
-            .int32 = types.Add(
-                Type{
-                    .data =
-                        PackedArrayType{
-                            .atom = BitAtom::kBit,
-                            .signedness = Signedness::kSigned,
-                            .dims = {PackedRange{.left = 31, .right = 0}},
-                            .form = PackedArrayForm::kInt}}),
-            .integer = types.Add(
-                Type{
-                    .data =
-                        PackedArrayType{
-                            .atom = BitAtom::kLogic,
-                            .signedness = Signedness::kSigned,
-                            .dims = {PackedRange{.left = 31, .right = 0}},
-                            .form = PackedArrayForm::kInteger}}),
-            .string = types.Add(Type{.data = StringType{}}),
-            .time = types.Add(
-                Type{
-                    .data =
-                        PackedArrayType{
-                            .atom = BitAtom::kLogic,
-                            .signedness = Signedness::kUnsigned,
-                            .dims = {PackedRange{.left = 63, .right = 0}},
-                            .form = PackedArrayForm::kTime}}),
-            .realtime = types.Add(Type{.data = RealTimeType{}}),
-            .wildcard_index = types.Add(Type{.data = WildcardIndexType{}}),
-        } {
+      : name(std::move(name)), builtins(MakeBuiltins(types)) {
+  }
+
+ private:
+  // The single-bit leaves and the predefined-width integers are the primitive
+  // canonical types. The leaves are added first; the predefined integers are
+  // single-dimension packed arrays over them (LRM 7.4.1: an integer type with a
+  // predefined width matches a single-dimension packed array).
+  static auto MakeBuiltins(base::Arena<Type, TypeId>& types)
+      -> BuiltinHirTypes {
+    const auto add = [&](TypeData data) {
+      return types.Add(Type{.data = std::move(data)});
+    };
+    const TypeId scalar_bit = add(ScalarBitType{.atom = BitAtom::kBit});
+    const TypeId scalar_logic = add(ScalarBitType{.atom = BitAtom::kLogic});
+    return BuiltinHirTypes{
+        .scalar_bit = scalar_bit,
+        .scalar_logic = scalar_logic,
+        .void_type = add(VoidType{}),
+        .int32 =
+            add(PackedArrayType{
+                .dim = PackedRange{.left = 31, .right = 0},
+                .element_type = scalar_bit,
+                .signedness = Signedness::kSigned,
+                .form = PackedArrayForm::kInt}),
+        .integer =
+            add(PackedArrayType{
+                .dim = PackedRange{.left = 31, .right = 0},
+                .element_type = scalar_logic,
+                .signedness = Signedness::kSigned,
+                .form = PackedArrayForm::kInteger}),
+        .string = add(StringType{}),
+        .time =
+            add(PackedArrayType{
+                .dim = PackedRange{.left = 63, .right = 0},
+                .element_type = scalar_logic,
+                .signedness = Signedness::kUnsigned,
+                .form = PackedArrayForm::kTime}),
+        .realtime = add(RealTimeType{}),
+        .wildcard_index = add(WildcardIndexType{}),
+    };
   }
 };
 

--- a/include/lyra/hir/type.hpp
+++ b/include/lyra/hir/type.hpp
@@ -6,7 +6,6 @@
 #include <variant>
 #include <vector>
 
-#include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/constant_value.hpp"
 #include "lyra/hir/integral_constant.hpp"
 #include "lyra/hir/type_id.hpp"
@@ -14,6 +13,7 @@
 namespace lyra::hir {
 
 enum class TypeKind {
+  kScalarBit,
   kPackedArray,
   kPackedStruct,
   kPackedUnion,
@@ -60,15 +60,25 @@ struct PackedRange {
   [[nodiscard]] auto LinearOffset(std::int64_t index) const -> std::uint64_t;
 };
 
-struct PackedArrayType {
+// A single bit, the terminal of every integral type. `logic`, `bit`, and `reg`
+// are this leaf; so is the element a packed array bottoms out at (LRM 7.4.1).
+// The atom carries the bit's 2-state (`bit`) versus 4-state (`logic` / `reg`)
+// nature.
+struct ScalarBitType {
   BitAtom atom;
-  Signedness signedness;
-  std::vector<PackedRange> dims;
-  PackedArrayForm form;
+};
 
-  [[nodiscard]] auto BitWidth() const -> std::uint64_t;
-  [[nodiscard]] auto IsFourState() const -> bool;
-  [[nodiscard]] auto DefaultInitialValue() const -> IntegralConstant;
+// LRM 7.4.1: a packed array is one declared dimension over an element type,
+// "recursively other packed arrays and packed structures." One node per
+// dimension; the element is named by its `TypeId`, so an array of a packed
+// aggregate carries that aggregate's identity. Multi-dim nests via
+// `element_type`. Signedness is the whole-vector property (the outermost node
+// is authoritative; elements are unsigned unless of a named signed type).
+struct PackedArrayType {
+  PackedRange dim;
+  TypeId element_type;
+  Signedness signedness;
+  PackedArrayForm form;
 };
 
 struct EnumMember {
@@ -93,25 +103,29 @@ struct PackedAggregateField {
   std::uint64_t bit_width;
 };
 
-// LRM 7.2.1: "When a packed structure appears as a primary, it shall be
-// treated as a single vector." `base` is that whole-vector projection (width
-// = sum of field widths; 4-state iff any field is 4-state); value-level uses
-// route through it. `fields` is the per-member offset/width table that
-// member-access expressions consult.
+// LRM 7.2.1: a packed struct is a heterogeneous set of bit-fields packed into
+// one vector. `fields` is the per-member offset/width table member-access
+// consults; `signedness` and `four_state` are the integral attributes the
+// struct carries as a whole (4-state iff any field is, LRM 7.2.1). The
+// single-vector projection -- total width is the sum of the field widths -- is
+// computed at HIR-to-MIR, not stored.
 struct PackedStructType {
-  PackedArrayType base;
   std::vector<PackedAggregateField> fields;
+  Signedness signedness;
+  bool four_state;
 };
 
-// LRM 7.3.1 untagged packed union. `base` is the "single vector" projection
-// (width = max member width; 4-state iff any member is 4-state). Members
-// overlap at the LSBs; for hard packed unions every member equals the union
-// width, for soft packed unions a narrower member's bits sit at the LSBs and
-// MSBs beyond the member are preserved across writes. Tagged unions are a
-// separate future feature (require runtime tag-bit logic, LRM 11.9).
+// LRM 7.3.1 untagged packed union. Members overlap at the LSBs (each field's
+// `bit_offset` is 0); for hard packed unions every member equals the union
+// width, for soft packed unions a narrower member's bits sit at the LSBs.
+// `signedness` and `four_state` are the union's integral attributes. The
+// single-vector projection -- total width is the widest member -- is computed
+// at HIR-to-MIR. Tagged unions are a separate future feature (runtime tag-bit
+// logic, LRM 11.9).
 struct PackedUnionType {
-  PackedArrayType base;
   std::vector<PackedAggregateField> fields;
+  Signedness signedness;
+  bool four_state;
 };
 
 // A named member of an unpacked aggregate (struct or union). Unlike a packed
@@ -187,7 +201,7 @@ struct ChandleType {};
 struct VoidType {};
 
 using TypeData = std::variant<
-    PackedArrayType, PackedStructType, PackedUnionType, EnumType,
+    ScalarBitType, PackedArrayType, PackedStructType, PackedUnionType, EnumType,
     UnpackedStructType, UnpackedUnionType, UnpackedArrayType, DynamicArrayType,
     QueueType, AssociativeArrayType, WildcardIndexType, StringType, EventType,
     RealType, ShortRealType, RealTimeType, ChandleType, VoidType>;
@@ -195,14 +209,15 @@ using TypeData = std::variant<
 struct Type {
   TypeData data;
 
-  // The declaration site that first interned this type. A downstream layer
-  // that cannot represent the type anchors its diagnostic here. Builtin types
-  // have no source and carry `UnknownSpan`.
-  diag::DiagSpan span;
-
   [[nodiscard]] auto Kind() const -> TypeKind;
+  [[nodiscard]] auto IsScalarBit() const -> bool;
+  [[nodiscard]] auto AsScalarBit() const -> const ScalarBitType&;
   [[nodiscard]] auto IsPackedArray() const -> bool;
   [[nodiscard]] auto AsPackedArray() const -> const PackedArrayType&;
+
+  // A single bit or a packed array of bits -- the integral operands an edge
+  // event, a bit / part select, and an unpacked-array element read accept.
+  [[nodiscard]] auto IsBitVector() const -> bool;
   [[nodiscard]] auto IsPackedStruct() const -> bool;
   [[nodiscard]] auto AsPackedStruct() const -> const PackedStructType&;
   [[nodiscard]] auto IsPackedUnion() const -> bool;

--- a/include/lyra/lowering/hir_to_mir/module_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/module_lowerer.hpp
@@ -82,9 +82,8 @@ class ModuleLowerer {
       -> std::string;
 
  private:
-  [[nodiscard]] auto TranslateTypeData(
-      const hir::TypeData& data, diag::DiagSpan type_span) const
-      -> diag::Result<mir::TypeData>;
+  [[nodiscard]] auto TranslateTypeData(const hir::TypeData& data) const
+      -> mir::TypeData;
 
   const hir::ModuleUnit* hir_;
   const diag::SourceManager* source_manager_;

--- a/include/lyra/value/packed_array.hpp
+++ b/include/lyra/value/packed_array.hpp
@@ -408,6 +408,14 @@ class PackedArray {
   // address space, dimension-agnostic. The element-level chain methods below
   // (`operator[]`, `Slice`) compose offsets in this address space and route
   // here at the chain leaf.
+  // Materializes the sub-region of shape `dims` whose least-significant bit is
+  // at `lsb_bit` into an owned value. Because the value is built with `dims`
+  // from the start, a chained select on the result sees the inner dimensions
+  // rather than a flattened bit run -- no post-construction reshaping. The
+  // width overload is the 1-D shorthand.
+  [[nodiscard]] auto ExtractBits(
+      const PackedArray& lsb_bit, std::span<const PackedRange> dims) const
+      -> PackedArray;
   [[nodiscard]] auto ExtractBits(
       const PackedArray& lsb_bit, std::uint32_t bit_width) const -> PackedArray;
   auto AssignSlice(
@@ -475,12 +483,24 @@ class PackedArray {
   [[nodiscard]] auto ReductionXnor() const -> PackedArray;
 
  private:
-  // Single source of truth for "construct a PackedArray with a known value".
-  // FromInt, FromWords, and any internal op that needs to materialize a
-  // result from word planes must delegate here. The helper guarantees both
-  // planes are fully written (value from `value_words`, unknown from
-  // `unknown_words` or zero when empty); no caller can leak the all-X
-  // residue left by LogicValue's default ctor.
+  // Constructs a value of the given runtime dim stack. Twin of the
+  // `initializer_list` dim constructor, for shapes computed at runtime (a
+  // selector's result dims). Bit width is the product of the dims.
+  PackedArray(
+      std::span<const PackedRange> dims, bool is_signed, bool is_four_state);
+
+  // Single source of truth for "construct a PackedArray with a known value and
+  // shape". FromInt, FromWords, and any internal op that materializes a result
+  // from word planes delegate here. The helper guarantees both planes are
+  // fully written (value from `value_words`, unknown from `unknown_words` or
+  // zero when empty); no caller can leak the all-X residue left by
+  // LogicValue's default ctor. The value is built with `dims` from the start,
+  // so its shape is never patched in afterward. `MakeFromWordPlanes` is the
+  // 1-D shorthand.
+  [[nodiscard]] static auto MakeFromWordPlanesShaped(
+      std::span<const PackedRange> dims, bool is_signed, bool is_four_state,
+      std::span<const std::uint64_t> value_words,
+      std::span<const std::uint64_t> unknown_words) -> PackedArray;
   [[nodiscard]] static auto MakeFromWordPlanes(
       std::uint64_t bit_width, bool is_signed, bool is_four_state,
       std::span<const std::uint64_t> value_words,
@@ -507,8 +527,10 @@ class PackedArray {
 // write (LRM "X/Z position is a no-op").
 class PackedArrayRef {
  public:
+  // Width is derived from `dims` (their product), so a ref's width can never
+  // drift from its shape.
   PackedArrayRef(
-      PackedArray& root, const PackedArray& bit_offset, std::uint32_t bit_width,
+      PackedArray& root, const PackedArray& bit_offset,
       std::vector<PackedRange> dims);
 
   // Move-only: a ref aliases its root by raw pointer, so duplicating the

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -12,11 +12,6 @@ namespace {
 
 constexpr std::array kEntries{
     std::pair{
-        DiagCode::kUnsupportedPackedArrayElementType,
-        DiagCodeInfo{
-            .kind = DiagKind::kUnsupported,
-            .name = "unsupported_packed_array_element_type"}},
-    std::pair{
         DiagCode::kUnsupportedTaggedPackedUnion,
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -120,26 +120,21 @@ class HirDumper {
     throw InternalError("HirDumper::FormatPackedForm: unknown PackedArrayForm");
   }
 
-  static auto FormatPackedDims(const std::vector<PackedRange>& dims)
-      -> std::string {
-    if (dims.empty()) {
-      return "[]";
-    }
-    std::string out;
-    for (const auto& d : dims) {
-      out += std::format("[{}:{}]", d.left, d.right);
-    }
-    return out;
+  static auto FormatPackedArray(const PackedArrayType& p) -> std::string {
+    return std::format(
+        "PackedArray(dim=[{}:{}], elem=Type[{}], signed={}, form={})",
+        p.dim.left, p.dim.right, p.element_type.value,
+        FormatSignedness(p.signedness), FormatPackedForm(p.form));
   }
 
   static auto FormatType(const Type& t) -> std::string {
     return std::visit(
         Overloaded{
+            [](const ScalarBitType& s) -> std::string {
+              return std::format("ScalarBit(atom={})", FormatBitAtom(s.atom));
+            },
             [](const PackedArrayType& p) -> std::string {
-              return std::format(
-                  "PackedArray(atom={}, signed={}, dims={}, form={})",
-                  FormatBitAtom(p.atom), FormatSignedness(p.signedness),
-                  FormatPackedDims(p.dims), FormatPackedForm(p.form));
+              return FormatPackedArray(p);
             },
             [](const PackedStructType& s) -> std::string {
               std::string fields;
@@ -151,10 +146,8 @@ class HirDumper {
                     s.fields[i].type.value);
               }
               return std::format(
-                  "PackedStruct(atom={}, signed={}, width={}, fields=[{}])",
-                  FormatBitAtom(s.base.atom),
-                  FormatSignedness(s.base.signedness), s.base.BitWidth(),
-                  fields);
+                  "PackedStruct(signed={}, four_state={}, fields=[{}])",
+                  FormatSignedness(s.signedness), s.four_state, fields);
             },
             [](const PackedUnionType& u) -> std::string {
               std::string fields;
@@ -166,10 +159,8 @@ class HirDumper {
                     u.fields[i].type.value);
               }
               return std::format(
-                  "PackedUnion(atom={}, signed={}, width={}, fields=[{}])",
-                  FormatBitAtom(u.base.atom),
-                  FormatSignedness(u.base.signedness), u.base.BitWidth(),
-                  fields);
+                  "PackedUnion(signed={}, four_state={}, fields=[{}])",
+                  FormatSignedness(u.signedness), u.four_state, fields);
             },
             [](const EnumType& e) -> std::string {
               std::string members;

--- a/src/lyra/hir/type.cpp
+++ b/src/lyra/hir/type.cpp
@@ -1,7 +1,6 @@
 #include "lyra/hir/type.hpp"
 
 #include <algorithm>
-#include <cstddef>
 #include <cstdint>
 #include <variant>
 
@@ -35,53 +34,10 @@ auto PackedRange::LinearOffset(std::int64_t index) const -> std::uint64_t {
   return static_cast<std::uint64_t>(index - left);
 }
 
-auto PackedArrayType::BitWidth() const -> std::uint64_t {
-  if (dims.empty()) {
-    return 1U;
-  }
-  std::uint64_t width = 1U;
-  for (const auto& dim : dims) {
-    width *= dim.ElementCount();
-  }
-  return width;
-}
-
-auto PackedArrayType::IsFourState() const -> bool {
-  return atom == BitAtom::kLogic || atom == BitAtom::kReg;
-}
-
-auto PackedArrayType::DefaultInitialValue() const -> IntegralConstant {
-  const auto width = static_cast<std::uint32_t>(BitWidth());
-  const std::size_t words = (static_cast<std::size_t>(width) + 63U) / 64U;
-  if (!IsFourState()) {
-    return IntegralConstant{
-        .value_words = std::vector<std::uint64_t>(words, 0U),
-        .state_words = {},
-        .width = width,
-        .signedness = signedness,
-        .state_kind = IntegralStateKind::kTwoState,
-    };
-  }
-  std::vector<std::uint64_t> v(words, ~std::uint64_t{0});
-  std::vector<std::uint64_t> s(words, ~std::uint64_t{0});
-  const std::uint32_t tail = width % 64U;
-  if (tail != 0U && !v.empty()) {
-    const std::uint64_t mask = (std::uint64_t{1} << tail) - 1U;
-    v.back() &= mask;
-    s.back() &= mask;
-  }
-  return IntegralConstant{
-      .value_words = std::move(v),
-      .state_words = std::move(s),
-      .width = width,
-      .signedness = signedness,
-      .state_kind = IntegralStateKind::kFourState,
-  };
-}
-
 auto Type::Kind() const -> TypeKind {
   return std::visit(
       Overloaded{
+          [](const ScalarBitType&) { return TypeKind::kScalarBit; },
           [](const PackedArrayType&) { return TypeKind::kPackedArray; },
           [](const PackedStructType&) { return TypeKind::kPackedStruct; },
           [](const PackedUnionType&) { return TypeKind::kPackedUnion; },
@@ -106,6 +62,17 @@ auto Type::Kind() const -> TypeKind {
       data);
 }
 
+auto Type::IsScalarBit() const -> bool {
+  return std::holds_alternative<ScalarBitType>(data);
+}
+
+auto Type::AsScalarBit() const -> const ScalarBitType& {
+  if (const auto* s = std::get_if<ScalarBitType>(&data)) {
+    return *s;
+  }
+  throw InternalError("Type::AsScalarBit called on non-scalar-bit type");
+}
+
 auto Type::IsPackedArray() const -> bool {
   return std::holds_alternative<PackedArrayType>(data);
 }
@@ -115,6 +82,10 @@ auto Type::AsPackedArray() const -> const PackedArrayType& {
     return *p;
   }
   throw InternalError("Type::AsPackedArray called on non-packed-array type");
+}
+
+auto Type::IsBitVector() const -> bool {
+  return IsScalarBit() || IsPackedArray();
 }
 
 auto Type::IsPackedStruct() const -> bool {
@@ -141,6 +112,7 @@ auto Type::AsPackedUnion() const -> const PackedUnionType& {
 
 auto Type::IsValueChangeObservable() const -> bool {
   switch (Kind()) {
+    case TypeKind::kScalarBit:
     case TypeKind::kPackedArray:
     case TypeKind::kPackedStruct:
     case TypeKind::kPackedUnion:

--- a/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
@@ -27,8 +27,8 @@ auto LowerConcatExpr(
   auto type_id = module.InternType(*cc.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   const auto kind = module.Unit().types.Get(*type_id).Kind();
-  if (kind != hir::TypeKind::kString && kind != hir::TypeKind::kPackedArray &&
-      kind != hir::TypeKind::kQueue) {
+  if (kind != hir::TypeKind::kString && kind != hir::TypeKind::kScalarBit &&
+      kind != hir::TypeKind::kPackedArray && kind != hir::TypeKind::kQueue) {
     return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "concatenation result type is not string, packed, or a queue (LRM "
@@ -66,7 +66,8 @@ auto LowerReplicationExpr(
   auto type_id = module.InternType(*rp.type, span);
   if (!type_id) return std::unexpected(std::move(type_id.error()));
   const auto kind = module.Unit().types.Get(*type_id).Kind();
-  if (kind != hir::TypeKind::kString && kind != hir::TypeKind::kPackedArray) {
+  if (kind != hir::TypeKind::kString && kind != hir::TypeKind::kScalarBit &&
+      kind != hir::TypeKind::kPackedArray) {
     return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
         "replication result type is neither string nor packed "

--- a/src/lyra/lowering/ast_to_hir/statement/timing.cpp
+++ b/src/lyra/lowering/ast_to_hir/statement/timing.cpp
@@ -50,7 +50,7 @@ auto LowerSignalEventTrigger(
   if (sig.edge != slang::ast::EdgeKind::None) {
     // The runtime classifies an edge only on a packed bit-vector cell (LRM
     // 9.4.2 Table 9-2); slang already restricts an edge to an integral operand.
-    if (!expr_type.IsPackedArray()) {
+    if (!expr_type.IsBitVector()) {
       return diag::Fail(
           span, diag::DiagCode::kUnsupportedEventTriggerForm,
           "edge event control is only supported on a packed bit-vector "

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -47,77 +47,68 @@ auto LowerRange(const slang::ConstantRange& r) -> hir::PackedRange {
   };
 }
 
-auto LowerPredefinedInteger(slang::ast::PredefinedIntegerType::Kind k)
+// A predefined-width integer is a single-dimension packed array over a scalar
+// bit (LRM 7.4.1); `form` records the syntactic origin (`int` vs the equivalent
+// `bit signed [31:0]`).
+auto LowerPredefinedInteger(
+    const ModuleLowerer& module, slang::ast::PredefinedIntegerType::Kind k)
     -> hir::PackedArrayType {
   using SK = slang::ast::PredefinedIntegerType::Kind;
+  const auto& builtins = module.Unit().builtins;
+  const auto make = [&](hir::TypeId element, std::int64_t msb,
+                        hir::Signedness signedness,
+                        hir::PackedArrayForm form) -> hir::PackedArrayType {
+    return hir::PackedArrayType{
+        .dim = hir::PackedRange{.left = msb, .right = 0},
+        .element_type = element,
+        .signedness = signedness,
+        .form = form,
+    };
+  };
   switch (k) {
     case SK::Byte:
-      return hir::PackedArrayType{
-          .atom = hir::BitAtom::kBit,
-          .signedness = hir::Signedness::kSigned,
-          .dims = {hir::PackedRange{.left = 7, .right = 0}},
-          .form = hir::PackedArrayForm::kByte,
-      };
+      return make(
+          builtins.scalar_bit, 7, hir::Signedness::kSigned,
+          hir::PackedArrayForm::kByte);
     case SK::ShortInt:
-      return hir::PackedArrayType{
-          .atom = hir::BitAtom::kBit,
-          .signedness = hir::Signedness::kSigned,
-          .dims = {hir::PackedRange{.left = 15, .right = 0}},
-          .form = hir::PackedArrayForm::kShortInt,
-      };
+      return make(
+          builtins.scalar_bit, 15, hir::Signedness::kSigned,
+          hir::PackedArrayForm::kShortInt);
     case SK::Int:
-      return hir::PackedArrayType{
-          .atom = hir::BitAtom::kBit,
-          .signedness = hir::Signedness::kSigned,
-          .dims = {hir::PackedRange{.left = 31, .right = 0}},
-          .form = hir::PackedArrayForm::kInt,
-      };
+      return make(
+          builtins.scalar_bit, 31, hir::Signedness::kSigned,
+          hir::PackedArrayForm::kInt);
     case SK::LongInt:
-      return hir::PackedArrayType{
-          .atom = hir::BitAtom::kBit,
-          .signedness = hir::Signedness::kSigned,
-          .dims = {hir::PackedRange{.left = 63, .right = 0}},
-          .form = hir::PackedArrayForm::kLongInt,
-      };
+      return make(
+          builtins.scalar_bit, 63, hir::Signedness::kSigned,
+          hir::PackedArrayForm::kLongInt);
     case SK::Integer:
-      return hir::PackedArrayType{
-          .atom = hir::BitAtom::kLogic,
-          .signedness = hir::Signedness::kSigned,
-          .dims = {hir::PackedRange{.left = 31, .right = 0}},
-          .form = hir::PackedArrayForm::kInteger,
-      };
+      return make(
+          builtins.scalar_logic, 31, hir::Signedness::kSigned,
+          hir::PackedArrayForm::kInteger);
     case SK::Time:
-      return hir::PackedArrayType{
-          .atom = hir::BitAtom::kLogic,
-          .signedness = hir::Signedness::kUnsigned,
-          .dims = {hir::PackedRange{.left = 63, .right = 0}},
-          .form = hir::PackedArrayForm::kTime,
-      };
+      return make(
+          builtins.scalar_logic, 63, hir::Signedness::kUnsigned,
+          hir::PackedArrayForm::kTime);
   }
   throw InternalError("LowerPredefinedInteger: unknown integer kind");
 }
 
+// One HIR node per declared dimension (LRM 7.4.1: a packed array is recursively
+// other packed arrays / structures). The element is interned and named by its
+// `TypeId`, so the nest -- and an aggregate element's identity -- is carried by
+// recursion, not flattened here.
 auto LowerExplicitPackedArray(
-    const slang::ast::PackedArrayType& outer, bool outer_signed,
-    diag::SourceSpan decl_span) -> diag::Result<hir::PackedArrayType> {
-  std::vector<hir::PackedRange> dims;
-  const slang::ast::Type* cur = &outer;
-  while (cur->kind == slang::ast::SymbolKind::PackedArrayType) {
-    const auto& pa = cur->as<slang::ast::PackedArrayType>();
-    dims.push_back(LowerRange(pa.range));
-    cur = &pa.elementType.getCanonicalType();
-  }
-  if (cur->kind != slang::ast::SymbolKind::ScalarType) {
-    return diag::Fail(
-        decl_span, diag::DiagCode::kUnsupportedPackedArrayElementType,
-        "packed array element must be a bit, logic, or reg scalar");
-  }
-  const auto& scalar = cur->as<slang::ast::ScalarType>();
+    ModuleLowerer& module, const slang::ast::PackedArrayType& array,
+    bool outer_signed, diag::SourceSpan span)
+    -> diag::Result<hir::PackedArrayType> {
+  auto element = module.InternType(array.elementType, span);
+  if (!element) return std::unexpected(std::move(element.error()));
   return hir::PackedArrayType{
-      .atom = LowerScalarAtom(scalar.scalarKind),
+      .dim = LowerRange(array.range),
+      .element_type = *element,
       .signedness =
           outer_signed ? hir::Signedness::kSigned : hir::Signedness::kUnsigned,
-      .dims = std::move(dims),
       .form = hir::PackedArrayForm::kExplicit,
   };
 }
@@ -125,20 +116,6 @@ auto LowerExplicitPackedArray(
 auto LowerPackedStruct(
     const slang::ast::PackedStructType& struct_type, diag::SourceSpan decl_span,
     ModuleLowerer& module) -> diag::Result<hir::PackedStructType> {
-  const auto width = static_cast<std::int64_t>(struct_type.bitWidth);
-  if (width <= 0) {
-    throw InternalError("LowerPackedStruct: zero-width packed struct");
-  }
-  const auto atom =
-      struct_type.isFourState ? hir::BitAtom::kLogic : hir::BitAtom::kBit;
-  const auto signedness = struct_type.isSigned ? hir::Signedness::kSigned
-                                               : hir::Signedness::kUnsigned;
-  hir::PackedArrayType base{
-      .atom = atom,
-      .signedness = signedness,
-      .dims = {hir::PackedRange{.left = width - 1, .right = 0}},
-      .form = hir::PackedArrayForm::kExplicit,
-  };
   std::vector<hir::PackedAggregateField> fields;
   for (const auto& field :
        struct_type.membersOfType<slang::ast::FieldSymbol>()) {
@@ -157,8 +134,10 @@ auto LowerPackedStruct(
         });
   }
   return hir::PackedStructType{
-      .base = std::move(base),
       .fields = std::move(fields),
+      .signedness = struct_type.isSigned ? hir::Signedness::kSigned
+                                         : hir::Signedness::kUnsigned,
+      .four_state = struct_type.isFourState,
   };
 }
 
@@ -170,20 +149,6 @@ auto LowerPackedUnion(
         decl_span, diag::DiagCode::kUnsupportedTaggedPackedUnion,
         "tagged packed unions are not yet supported");
   }
-  const auto width = static_cast<std::int64_t>(union_type.bitWidth);
-  if (width <= 0) {
-    throw InternalError("LowerPackedUnion: zero-width packed union");
-  }
-  const auto atom =
-      union_type.isFourState ? hir::BitAtom::kLogic : hir::BitAtom::kBit;
-  const auto signedness = union_type.isSigned ? hir::Signedness::kSigned
-                                              : hir::Signedness::kUnsigned;
-  hir::PackedArrayType base{
-      .atom = atom,
-      .signedness = signedness,
-      .dims = {hir::PackedRange{.left = width - 1, .right = 0}},
-      .form = hir::PackedArrayForm::kExplicit,
-  };
   std::vector<hir::PackedAggregateField> fields;
   for (const auto& field :
        union_type.membersOfType<slang::ast::FieldSymbol>()) {
@@ -202,8 +167,10 @@ auto LowerPackedUnion(
         });
   }
   return hir::PackedUnionType{
-      .base = std::move(base),
       .fields = std::move(fields),
+      .signedness = union_type.isSigned ? hir::Signedness::kSigned
+                                        : hir::Signedness::kUnsigned,
+      .four_state = union_type.isFourState,
   };
 }
 
@@ -267,6 +234,15 @@ auto LowerUnpackedStruct(
 auto LowerUnpackedUnion(
     const slang::ast::UnpackedUnionType& union_type, diag::SourceSpan decl_span,
     ModuleLowerer& module) -> diag::Result<hir::UnpackedUnionType> {
+  // A tagged union (LRM 7.3.2) is a type-checked sum type, a separate concept
+  // from the untagged overlapping-storage form; reject it here where the
+  // declaration span is available, so MIR translation only ever sees untagged
+  // unions.
+  if (union_type.isTagged) {
+    return diag::Fail(
+        decl_span, diag::DiagCode::kUnsupportedUnpackedUnionType,
+        "tagged unions are not yet supported");
+  }
   auto fields_or =
       LowerUnpackedAggregateFields(union_type.fields, decl_span, module);
   if (!fields_or) return std::unexpected(std::move(fields_or.error()));
@@ -307,25 +283,21 @@ auto TranslateTypeData(
   switch (canonical.kind) {
     case slang::ast::SymbolKind::ScalarType: {
       const auto& scalar = canonical.as<slang::ast::ScalarType>();
-      return hir::TypeData{hir::PackedArrayType{
-          .atom = LowerScalarAtom(scalar.scalarKind),
-          .signedness = hir::Signedness::kUnsigned,
-          .dims = {hir::PackedRange{.left = 0, .right = 0}},
-          .form = hir::PackedArrayForm::kExplicit,
-      }};
+      return hir::TypeData{
+          hir::ScalarBitType{.atom = LowerScalarAtom(scalar.scalarKind)}};
     }
     case slang::ast::SymbolKind::PredefinedIntegerType: {
       const auto& pi = canonical.as<slang::ast::PredefinedIntegerType>();
-      return hir::TypeData{LowerPredefinedInteger(pi.integerKind)};
+      return hir::TypeData{LowerPredefinedInteger(module, pi.integerKind)};
     }
     case slang::ast::SymbolKind::PackedArrayType: {
       auto pa = LowerExplicitPackedArray(
-          canonical.as<slang::ast::PackedArrayType>(), canonical.isSigned(),
-          decl_span);
+          module, canonical.as<slang::ast::PackedArrayType>(),
+          canonical.isSigned(), decl_span);
       if (!pa.has_value()) {
         return std::unexpected(std::move(pa.error()));
       }
-      return hir::TypeData{std::move(pa.value())};
+      return hir::TypeData{*std::move(pa)};
     }
     case slang::ast::SymbolKind::EnumType: {
       auto e =
@@ -472,7 +444,7 @@ auto ModuleLowerer::InternType(
   auto data_or = TranslateTypeData(*this, type, span);
   if (!data_or) return std::unexpected(std::move(data_or.error()));
   const hir::TypeId id =
-      unit_.types.Add(hir::Type{.data = *std::move(data_or), .span = span});
+      unit_.types.Add(hir::Type{.data = *std::move(data_or)});
   type_cache_.emplace(canonical, id);
   return id;
 }

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -524,7 +524,12 @@ auto BuildElementAccessCallExpr(
   } else if (
       const auto* pa = std::get_if<hir::PackedArrayType>(&hir_base_ty.data)) {
     effective_idx =
-        WrapPackedIndex(module, block, pa->dims.front(), idx_id, hir_idx_type);
+        WrapPackedIndex(module, block, pa->dim, idx_id, hir_idx_type);
+  } else if (std::holds_alternative<hir::ScalarBitType>(hir_base_ty.data)) {
+    // A bit-select on a single-bit scalar: its declared range is `[0:0]`.
+    static constexpr hir::PackedRange kScalarDim{.left = 0, .right = 0};
+    effective_idx =
+        WrapPackedIndex(module, block, kScalarDim, idx_id, hir_idx_type);
   }
   return mir::Expr{
       .data =
@@ -561,11 +566,11 @@ auto BuildRangeSliceCallExpr(
   } else if (
       const auto* pa = std::get_if<hir::PackedArrayType>(&hir_base_ty.data)) {
     strategy.container = RangeContainer::kPacked;
-    strategy.packed_declared = &pa->dims.front();
+    strategy.packed_declared = &pa->dim;
   } else {
-    // Dynamic arrays and a packed struct / union projected as a `[width-1:0]`
-    // vector index by raw zero-based offset, so their bounds are already
-    // physical; an identity declared range leaves them untranslated.
+    // A scalar bit, a dynamic array, and a packed struct / union all index by
+    // raw zero-based offset -- their bounds are already physical -- so an
+    // identity declared range leaves them untranslated.
     static constexpr hir::PackedRange kRawOffset{.left = 0, .right = 0};
     strategy.container = RangeContainer::kPacked;
     strategy.packed_declared = &kRawOffset;

--- a/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/system/file_io.cpp
@@ -237,7 +237,7 @@ auto LowerFileIOSystemSubroutineCallStmt(
         // scope; struct / union / multi-dim / dynamic-array element types
         // are deferred.
         const auto& elem_ty = module.Hir().types.Get(unpacked->element_type);
-        if (!std::holds_alternative<hir::PackedArrayType>(elem_ty.data)) {
+        if (!elem_ty.IsBitVector()) {
           return diag::Fail(
               diag::DiagCode::kUnsupportedSubroutineArgument,
               "$fread memory form: only 1D unpacked arrays of integral "

--- a/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
@@ -18,12 +18,13 @@ namespace lyra::lowering::hir_to_mir {
 auto ModuleLowerer::Run() -> diag::Result<mir::CompilationUnit> {
   WalkFrame root_frame;
 
+  // Every HIR type is MIR-representable: AST-to-HIR rejects the forms MIR has
+  // no shape for, so this projection never fails.
   for (std::size_t i = 0; i < hir_->types.size(); ++i) {
     const hir::TypeId hir_id{static_cast<std::uint32_t>(i)};
     const hir::Type& hir_type = hir_->types.Get(hir_id);
-    auto mir_data = TranslateTypeData(hir_type.data, hir_type.span);
-    if (!mir_data) return std::unexpected(std::move(mir_data.error()));
-    const mir::TypeId mir_id = unit_.types.Intern(*std::move(mir_data));
+    const mir::TypeId mir_id =
+        unit_.types.Intern(TranslateTypeData(hir_type.data));
     MapType(hir_id, mir_id);
   }
 

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -55,15 +55,19 @@ auto LowerDestructuringAssign(
   part_widths.reserve(lhs_concat.operands.size());
   bool any_four_state = false;
   std::uint64_t total_width = 0;
+  const auto& hir_types = process.Module().Hir().types;
+  const auto& mir_types = process.Module().Unit().types;
   for (const hir::ExprId op_id : lhs_concat.operands) {
     const hir::Expr& op = hir_proc.exprs.Get(op_id);
-    const hir::Type& op_ty = process.Module().Hir().types.Get(op.type);
-    if (!op_ty.IsPackedArray()) {
+    if (!hir_types.Get(op.type).IsBitVector()) {
       throw InternalError(
           "LowerDestructuringAssign: destructuring operand is not "
           "a packed integral type");
     }
-    const auto& packed = op_ty.AsPackedArray();
+    // Width and 4-state-ness are properties of the flat MIR vector; read them
+    // off it directly rather than recompute from the structural HIR type.
+    const auto& packed = mir_types.Get(process.Module().TranslateType(op.type))
+                             .AsIntegralPacked();
     const std::uint64_t w = packed.BitWidth();
     part_widths.push_back(w);
     total_width += w;

--- a/src/lyra/lowering/hir_to_mir/translate_type.cpp
+++ b/src/lyra/lowering/hir_to_mir/translate_type.cpp
@@ -1,9 +1,9 @@
+#include <cstdint>
 #include <variant>
 #include <vector>
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
-#include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/mir/type.hpp"
@@ -49,56 +49,96 @@ auto TranslatePackedArrayForm(hir::PackedArrayForm f) -> mir::PackedArrayForm {
   throw InternalError("TranslatePackedArrayForm: unknown PackedArrayForm");
 }
 
-auto TranslatePackedRanges(const std::vector<hir::PackedRange>& src)
-    -> std::vector<mir::PackedRange> {
-  std::vector<mir::PackedRange> out;
-  out.reserve(src.size());
-  for (const auto& r : src) {
-    out.push_back(mir::PackedRange{.left = r.left, .right = r.right});
+// Projects a recursive HIR packed array onto MIR's flat single-vector shape
+// (LRM 7.4.1). A scalar-bit terminal contributes the atom and this one
+// dimension; any other element (a nested packed array, or a packed aggregate's
+// single-vector projection) contributes its own flat dimensions, onto which
+// this dimension prepends.
+auto FlattenPackedArray(
+    const ModuleLowerer& module, const hir::PackedArrayType& pa)
+    -> mir::PackedArrayType {
+  const mir::PackedRange dim{.left = pa.dim.left, .right = pa.dim.right};
+  const hir::Type& element = module.Hir().types.Get(pa.element_type);
+  if (const auto* scalar = std::get_if<hir::ScalarBitType>(&element.data)) {
+    return mir::PackedArrayType{
+        .atom = TranslateBitAtom(scalar->atom),
+        .signedness = TranslateSignedness(pa.signedness),
+        .dims = {dim},
+        .form = TranslatePackedArrayForm(pa.form),
+    };
   }
-  return out;
+  const mir::PackedArrayType& inner =
+      module.Unit()
+          .types.Get(module.TranslateType(pa.element_type))
+          .AsIntegralPacked();
+  std::vector<mir::PackedRange> dims;
+  dims.reserve(inner.dims.size() + 1U);
+  dims.push_back(dim);
+  dims.insert(dims.end(), inner.dims.begin(), inner.dims.end());
+  return mir::PackedArrayType{
+      .atom = inner.atom,
+      .signedness = TranslateSignedness(pa.signedness),
+      .dims = std::move(dims),
+      .form = TranslatePackedArrayForm(pa.form),
+  };
+}
+
+// A packed aggregate's single-vector projection (LRM 7.2.1 / 7.3.1): one flat
+// `width`-bit vector, `logic` iff the aggregate is 4-state. The width is the
+// caller's -- a struct sums its fields, a union takes its widest.
+auto FlattenPackedAggregate(
+    std::uint64_t width, hir::Signedness signedness, bool four_state)
+    -> mir::PackedArrayType {
+  return mir::PackedArrayType{
+      .atom = four_state ? mir::BitAtom::kLogic : mir::BitAtom::kBit,
+      .signedness = TranslateSignedness(signedness),
+      .dims = {mir::PackedRange{
+          .left = static_cast<std::int64_t>(width) - 1, .right = 0}},
+      .form = mir::PackedArrayForm::kExplicit,
+  };
 }
 
 }  // namespace
 
-auto ModuleLowerer::TranslateTypeData(
-    const hir::TypeData& data, diag::DiagSpan type_span) const
-    -> diag::Result<mir::TypeData> {
+auto ModuleLowerer::TranslateTypeData(const hir::TypeData& data) const
+    -> mir::TypeData {
   return std::visit(
       Overloaded{
-          [&](const hir::PackedArrayType& src) -> diag::Result<mir::TypeData> {
+          [&](const hir::ScalarBitType& src) -> mir::TypeData {
+            // A bare scalar is a one-bit unsigned vector in MIR's flat shape.
             return mir::PackedArrayType{
                 .atom = TranslateBitAtom(src.atom),
-                .signedness = TranslateSignedness(src.signedness),
-                .dims = TranslatePackedRanges(src.dims),
-                .form = TranslatePackedArrayForm(src.form),
+                .signedness = mir::Signedness::kUnsigned,
+                .dims = {mir::PackedRange{.left = 0, .right = 0}},
+                .form = mir::PackedArrayForm::kExplicit,
             };
           },
-          [&](const hir::PackedStructType& src) -> diag::Result<mir::TypeData> {
-            // LRM 7.2.1: "treated as a single vector". MIR keeps only that
-            // projection -- a PackedArrayType. Per-field offset / width get
-            // baked into constant-bounds RangeSelect at expression
-            // lowering, so MIR carries no struct-specific type.
-            return mir::PackedArrayType{
-                .atom = TranslateBitAtom(src.base.atom),
-                .signedness = TranslateSignedness(src.base.signedness),
-                .dims = TranslatePackedRanges(src.base.dims),
-                .form = TranslatePackedArrayForm(src.base.form),
-            };
+          [&](const hir::PackedArrayType& src) -> mir::TypeData {
+            return FlattenPackedArray(*this, src);
           },
-          [&](const hir::PackedUnionType& src) -> diag::Result<mir::TypeData> {
-            // LRM 7.3.1: untagged packed union "appears as a primary" is
-            // "treated as a single vector". Same MIR shape as packed
-            // struct -- the per-member (offset=0, width) table flows
-            // through to RangeSelect at expression lowering.
-            return mir::PackedArrayType{
-                .atom = TranslateBitAtom(src.base.atom),
-                .signedness = TranslateSignedness(src.base.signedness),
-                .dims = TranslatePackedRanges(src.base.dims),
-                .form = TranslatePackedArrayForm(src.base.form),
-            };
+          [&](const hir::PackedStructType& src) -> mir::TypeData {
+            // LRM 7.2.1: a packed struct projects to one vector summing its
+            // fields. Per-field offset / width bake into constant-bounds
+            // RangeSelect at expression lowering, so MIR keeps no struct type.
+            std::uint64_t width = 0;
+            for (const auto& field : src.fields) {
+              width += field.bit_width;
+            }
+            return FlattenPackedAggregate(
+                width, src.signedness, src.four_state);
           },
-          [&](const hir::EnumType& src) -> diag::Result<mir::TypeData> {
+          [&](const hir::PackedUnionType& src) -> mir::TypeData {
+            // LRM 7.3.1: an untagged packed union projects to one vector as
+            // wide as its widest member; members overlap at the LSBs and each
+            // flows to RangeSelect at expression lowering.
+            std::uint64_t width = 0;
+            for (const auto& field : src.fields) {
+              width = field.bit_width > width ? field.bit_width : width;
+            }
+            return FlattenPackedAggregate(
+                width, src.signedness, src.four_state);
+          },
+          [&](const hir::EnumType& src) -> mir::TypeData {
             // Enum is kept as a distinct mir::EnumType wrapping its base
             // PackedArray plus the member table. Value-level operations
             // unwrap via Type::AsIntegralPacked(); method dispatch reads the
@@ -127,8 +167,7 @@ auto ModuleLowerer::TranslateTypeData(
                 .members = std::move(members),
             };
           },
-          [&](const hir::UnpackedStructType& src)
-              -> diag::Result<mir::TypeData> {
+          [&](const hir::UnpackedStructType& src) -> mir::TypeData {
             std::vector<mir::TypeId> elements;
             elements.reserve(src.fields.size());
             for (const auto& field : src.fields) {
@@ -136,14 +175,14 @@ auto ModuleLowerer::TranslateTypeData(
             }
             return mir::TupleType{.elements = std::move(elements)};
           },
-          [&](const hir::UnpackedUnionType& src)
-              -> diag::Result<mir::TypeData> {
-            // A tagged union is a sum type, a separate concept; only the
-            // untagged overlapping-storage form maps to `UnionType` (LRM 7.3).
+          [&](const hir::UnpackedUnionType& src) -> mir::TypeData {
+            // Only the untagged overlapping-storage form maps to `UnionType`
+            // (LRM 7.3). A tagged union is a sum type rejected at ast_to_hir,
+            // so it never reaches MIR translation.
             if (src.tagged) {
-              return diag::Fail(
-                  type_span, diag::DiagCode::kUnsupportedUnpackedUnionType,
-                  "tagged unions are not yet supported");
+              throw InternalError(
+                  "TranslateTypeData: tagged unpacked union reached MIR "
+                  "translation");
             }
             std::vector<mir::TypeId> elements;
             elements.reserve(src.fields.size());
@@ -152,8 +191,7 @@ auto ModuleLowerer::TranslateTypeData(
             }
             return mir::UnionType{.elements = std::move(elements)};
           },
-          [&](const hir::UnpackedArrayType& src)
-              -> diag::Result<mir::TypeData> {
+          [&](const hir::UnpackedArrayType& src) -> mir::TypeData {
             const std::int64_t span = (src.dim.left >= src.dim.right)
                                           ? (src.dim.left - src.dim.right)
                                           : (src.dim.right - src.dim.left);
@@ -162,48 +200,43 @@ auto ModuleLowerer::TranslateTypeData(
                 .size = static_cast<std::uint64_t>(span) + 1U,
             };
           },
-          [&](const hir::DynamicArrayType& src) -> diag::Result<mir::TypeData> {
+          [&](const hir::DynamicArrayType& src) -> mir::TypeData {
             return mir::DynamicArrayType{
                 .element_type = TranslateType(src.element_type),
             };
           },
-          [&](const hir::QueueType& src) -> diag::Result<mir::TypeData> {
+          [&](const hir::QueueType& src) -> mir::TypeData {
             return mir::QueueType{
                 .element_type = TranslateType(src.element_type),
                 .max_bound = src.max_bound,
             };
           },
-          [&](const hir::AssociativeArrayType& src)
-              -> diag::Result<mir::TypeData> {
+          [&](const hir::AssociativeArrayType& src) -> mir::TypeData {
             return mir::AssociativeArrayType{
                 .element_type = TranslateType(src.element_type),
                 .key_type = TranslateType(src.key_type),
             };
           },
-          [](const hir::WildcardIndexType&) -> diag::Result<mir::TypeData> {
+          [](const hir::WildcardIndexType&) -> mir::TypeData {
             return mir::WildcardIndexType{};
           },
-          [](const hir::StringType&) -> diag::Result<mir::TypeData> {
+          [](const hir::StringType&) -> mir::TypeData {
             return mir::StringType{};
           },
-          [](const hir::EventType&) -> diag::Result<mir::TypeData> {
+          [](const hir::EventType&) -> mir::TypeData {
             return mir::EventType{};
           },
-          [](const hir::RealType&) -> diag::Result<mir::TypeData> {
-            return mir::RealType{};
-          },
-          [](const hir::ShortRealType&) -> diag::Result<mir::TypeData> {
+          [](const hir::RealType&) -> mir::TypeData { return mir::RealType{}; },
+          [](const hir::ShortRealType&) -> mir::TypeData {
             return mir::ShortRealType{};
           },
-          [](const hir::RealTimeType&) -> diag::Result<mir::TypeData> {
+          [](const hir::RealTimeType&) -> mir::TypeData {
             return mir::RealTimeType{};
           },
-          [](const hir::ChandleType&) -> diag::Result<mir::TypeData> {
+          [](const hir::ChandleType&) -> mir::TypeData {
             return mir::ChandleType{};
           },
-          [](const hir::VoidType&) -> diag::Result<mir::TypeData> {
-            return mir::VoidType{};
-          },
+          [](const hir::VoidType&) -> mir::TypeData { return mir::VoidType{}; },
       },
       data);
 }

--- a/src/lyra/value/packed_array.cpp
+++ b/src/lyra/value/packed_array.cpp
@@ -101,6 +101,15 @@ PackedArray::PackedArray(
           .left = static_cast<std::int64_t>(bit_width) - 1, .right = 0}}) {
 }
 
+PackedArray::PackedArray(
+    std::span<const PackedRange> dims, bool is_signed, bool is_four_state)
+    : bit_width_(TotalBitWidthOf(dims)),
+      is_signed_(is_signed),
+      is_four_state_(is_four_state),
+      storage_(MakeStorage(bit_width_, is_four_state)),
+      dims_(dims.begin(), dims.end()) {
+}
+
 auto PackedArray::Int(std::int32_t value) -> PackedArray {
   return FromInt(value, 32U, true, false);
 }
@@ -121,32 +130,33 @@ auto PackedArray::FromBool(bool value) -> PackedArray {
   return Bit(value);
 }
 
-auto PackedArray::MakeFromWordPlanes(
-    std::uint64_t bit_width, bool is_signed, bool is_four_state,
+auto PackedArray::MakeFromWordPlanesShaped(
+    std::span<const PackedRange> dims, bool is_signed, bool is_four_state,
     std::span<const std::uint64_t> value_words,
     std::span<const std::uint64_t> unknown_words) -> PackedArray {
+  const auto bit_width = TotalBitWidthOf(dims);
   if (bit_width == 0U) {
     throw InternalError(
-        "PackedArray::MakeFromWordPlanes: bit_width must be >= 1");
+        "PackedArray::MakeFromWordPlanesShaped: bit_width must be >= 1");
   }
   const std::size_t expected = (bit_width + 63U) / 64U;
   if (value_words.size() != expected) {
     throw InternalError(
-        "PackedArray::MakeFromWordPlanes: value word count mismatch");
+        "PackedArray::MakeFromWordPlanesShaped: value word count mismatch");
   }
   if (!is_four_state && !unknown_words.empty()) {
     throw InternalError(
-        "PackedArray::MakeFromWordPlanes: 2-state shape forbids unknown "
+        "PackedArray::MakeFromWordPlanesShaped: 2-state shape forbids unknown "
         "words");
   }
   if (is_four_state && !unknown_words.empty() &&
       unknown_words.size() != expected) {
     throw InternalError(
-        "PackedArray::MakeFromWordPlanes: 4-state unknown word count "
+        "PackedArray::MakeFromWordPlanesShaped: 4-state unknown word count "
         "mismatch");
   }
 
-  PackedArray p{bit_width, is_signed, is_four_state};
+  PackedArray p{dims, is_signed, is_four_state};
   auto value_dst = std::visit(
       [](auto& v) { return detail::PackedAccess::ValueWords(v.View()); },
       p.storage_);
@@ -163,6 +173,21 @@ auto PackedArray::MakeFromWordPlanes(
     }
   }
   return p;
+}
+
+auto PackedArray::MakeFromWordPlanes(
+    std::uint64_t bit_width, bool is_signed, bool is_four_state,
+    std::span<const std::uint64_t> value_words,
+    std::span<const std::uint64_t> unknown_words) -> PackedArray {
+  if (bit_width == 0U) {
+    throw InternalError(
+        "PackedArray::MakeFromWordPlanes: bit_width must be >= 1");
+  }
+  const std::array<PackedRange, 1> dims{PackedRange{
+      .left = static_cast<std::int64_t>(bit_width) - 1, .right = 0}};
+  return MakeFromWordPlanesShaped(
+      std::span<const PackedRange>{dims}, is_signed, is_four_state, value_words,
+      unknown_words);
 }
 
 auto PackedArray::FromInt(
@@ -1250,15 +1275,17 @@ auto PackedArray::CasexEquals(const PackedArray& other) const -> PackedArray {
 }
 
 auto PackedArray::ExtractBits(
-    const PackedArray& lsb_bit, std::uint32_t bit_width) const -> PackedArray {
+    const PackedArray& lsb_bit, std::span<const PackedRange> dims) const
+    -> PackedArray {
+  const auto bit_width = static_cast<std::uint32_t>(TotalBitWidthOf(dims));
   if (bit_width == 0U) {
     throw InternalError("PackedArray::ExtractBits: bit_width must be >= 1");
   }
+  // A fully out-of-range start (X/Z lsb, or a magnitude beyond the 64-bit
+  // position carrier) yields an all-X value for a 4-state source, all-zero for
+  // a 2-state one. The shape is carried by constructing with `dims`.
   if (lsb_bit.HasUnknown() || lsb_bit.BitWidth() > 64U) {
-    if (is_four_state_) {
-      return AllX(bit_width, false);
-    }
-    return PackedArray{bit_width, false, false};
+    return PackedArray{dims, false, is_four_state_};
   }
   const std::int64_t start = lsb_bit.ToInt64();
   const auto src_value = ValueWords();
@@ -1287,12 +1314,22 @@ auto PackedArray::ExtractBits(
       unk_buf[i / 64U] |= out_mask;
     }
   }
-  return MakeFromWordPlanes(
-      bit_width, false, is_four_state_,
+  return MakeFromWordPlanesShaped(
+      dims, false, is_four_state_,
       std::span<const std::uint64_t>{val_buf.data(), val_buf.size()},
       is_four_state_
           ? std::span<const std::uint64_t>{unk_buf.data(), unk_buf.size()}
           : std::span<const std::uint64_t>{});
+}
+
+auto PackedArray::ExtractBits(
+    const PackedArray& lsb_bit, std::uint32_t bit_width) const -> PackedArray {
+  if (bit_width == 0U) {
+    throw InternalError("PackedArray::ExtractBits: bit_width must be >= 1");
+  }
+  const std::array<PackedRange, 1> dims{PackedRange{
+      .left = static_cast<std::int64_t>(bit_width) - 1, .right = 0}};
+  return ExtractBits(lsb_bit, std::span<const PackedRange>{dims});
 }
 
 auto PackedArray::AssignSlice(
@@ -1418,31 +1455,61 @@ auto ReplaceOuterDimCount(
   return result;
 }
 
+// A resolved sub-region of a packed value: the LSB-relative bit offset of the
+// region within the source's flat storage, and the region's dim stack (width is
+// the product of the dims). Both the value selectors (`Element` / `Slice` ->
+// `ExtractBits`) and the reference selectors (`ElementRef` / `SliceRef` ->
+// `PackedArrayRef`) consume one of these, so offset, width, and shape of a
+// selection are derived in exactly one place -- the read and write sides cannot
+// drift.
+struct PackedSelection {
+  PackedArray bit_offset;
+  std::vector<PackedRange> dims;
+};
+
+// Scales an outer-element position to a flat-bit offset. One outer element is
+// `element_bw` bits; when that is 1 (selecting the innermost dimension), the
+// position is already a bit offset. X/Z in the position propagates.
+auto ScaledOuterOffset(const PackedArray& outer_units, std::uint32_t element_bw)
+    -> PackedArray {
+  if (element_bw == 1U) {
+    return Canonicalize(outer_units);
+  }
+  return Canonicalize(outer_units) * PackedArray::FromInt(
+                                         static_cast<std::int64_t>(element_bw),
+                                         kOffsetBitWidth, kOffsetSigned,
+                                         kOffsetFourState);
+}
+
+auto ResolveElement(
+    std::uint64_t source_bit_width, std::span<const PackedRange> source_dims,
+    const PackedArray& idx) -> PackedSelection {
+  const auto element_bw = OuterElementBitWidth(source_bit_width, source_dims);
+  return PackedSelection{
+      .bit_offset = ScaledOuterOffset(idx, element_bw),
+      .dims = PopOuterDim(source_dims)};
+}
+
+auto ResolveSlice(
+    std::uint64_t source_bit_width, std::span<const PackedRange> source_dims,
+    const PackedArray& offset_in_outer_elements, std::uint32_t count)
+    -> PackedSelection {
+  const auto element_bw = OuterElementBitWidth(source_bit_width, source_dims);
+  return PackedSelection{
+      .bit_offset = ScaledOuterOffset(offset_in_outer_elements, element_bw),
+      .dims = ReplaceOuterDimCount(source_dims, count)};
+}
+
 }  // namespace
 
 auto PackedArray::ElementRef(const PackedArray& idx) -> PackedArrayRef {
-  const auto element_bw = OuterElementBitWidth(bit_width_, dims_);
-  return PackedArrayRef{
-      *this,
-      element_bw == 1U
-          ? Canonicalize(idx)
-          : (Canonicalize(idx) * PackedArray::FromInt(
-                                     static_cast<std::int64_t>(element_bw),
-                                     kOffsetBitWidth, kOffsetSigned,
-                                     kOffsetFourState)),
-      element_bw, PopOuterDim(dims_)};
+  auto sel = ResolveElement(bit_width_, dims_, idx);
+  return PackedArrayRef{*this, sel.bit_offset, std::move(sel.dims)};
 }
 
 auto PackedArray::Element(const PackedArray& idx) const -> PackedArray {
-  const auto element_bw = OuterElementBitWidth(bit_width_, dims_);
-  const auto bit_offset =
-      element_bw == 1U
-          ? Canonicalize(idx)
-          : (Canonicalize(idx) * PackedArray::FromInt(
-                                     static_cast<std::int64_t>(element_bw),
-                                     kOffsetBitWidth, kOffsetSigned,
-                                     kOffsetFourState));
-  return ExtractBits(bit_offset, element_bw);
+  auto sel = ResolveElement(bit_width_, dims_, idx);
+  return ExtractBits(sel.bit_offset, sel.dims);
 }
 
 auto PackedArray::SliceRef(
@@ -1450,16 +1517,8 @@ auto PackedArray::SliceRef(
     const PackedArray& count_in_outer_elements) -> PackedArrayRef {
   const auto count =
       static_cast<std::uint32_t>(count_in_outer_elements.ToInt64());
-  const auto element_bw = OuterElementBitWidth(bit_width_, dims_);
-  return PackedArrayRef{
-      *this,
-      element_bw == 1U
-          ? Canonicalize(offset_in_outer_elements)
-          : (Canonicalize(offset_in_outer_elements) *
-             PackedArray::FromInt(
-                 static_cast<std::int64_t>(element_bw), kOffsetBitWidth,
-                 kOffsetSigned, kOffsetFourState)),
-      count * element_bw, ReplaceOuterDimCount(dims_, count)};
+  auto sel = ResolveSlice(bit_width_, dims_, offset_in_outer_elements, count);
+  return PackedArrayRef{*this, sel.bit_offset, std::move(sel.dims)};
 }
 
 auto PackedArray::Slice(
@@ -1467,28 +1526,21 @@ auto PackedArray::Slice(
     const PackedArray& count_in_outer_elements) const -> PackedArray {
   const auto count =
       static_cast<std::uint32_t>(count_in_outer_elements.ToInt64());
-  const auto element_bw = OuterElementBitWidth(bit_width_, dims_);
-  const auto bit_offset =
-      element_bw == 1U
-          ? Canonicalize(offset_in_outer_elements)
-          : (Canonicalize(offset_in_outer_elements) *
-             PackedArray::FromInt(
-                 static_cast<std::int64_t>(element_bw), kOffsetBitWidth,
-                 kOffsetSigned, kOffsetFourState));
-  return ExtractBits(bit_offset, count * element_bw);
+  auto sel = ResolveSlice(bit_width_, dims_, offset_in_outer_elements, count);
+  return ExtractBits(sel.bit_offset, sel.dims);
 }
 
 PackedArrayRef::PackedArrayRef(
-    PackedArray& root, const PackedArray& bit_offset, std::uint32_t bit_width,
+    PackedArray& root, const PackedArray& bit_offset,
     std::vector<PackedRange> dims)
     : root_(&root),
       bit_offset_(Canonicalize(bit_offset)),
-      bit_width_(bit_width),
+      bit_width_(static_cast<std::uint32_t>(TotalBitWidthOf(dims))),
       dims_(std::move(dims)) {
 }
 
 auto PackedArrayRef::ToOwned() const -> PackedArray {
-  return std::as_const(*root_).ExtractBits(bit_offset_, bit_width_);
+  return std::as_const(*root_).ExtractBits(bit_offset_, dims_);
 }
 
 auto PackedArrayRef::operator=(const PackedArray& value) -> PackedArrayRef& {
@@ -1498,17 +1550,9 @@ auto PackedArrayRef::operator=(const PackedArray& value) -> PackedArrayRef& {
 
 auto PackedArrayRef::ElementRef(const PackedArray& idx) const
     -> PackedArrayRef {
-  const auto element_bw = OuterElementBitWidth(bit_width_, dims_);
+  auto sel = ResolveElement(bit_width_, dims_, idx);
   return PackedArrayRef{
-      *root_,
-      element_bw == 1U
-          ? (bit_offset_ + Canonicalize(idx))
-          : (bit_offset_ +
-             (Canonicalize(idx) * PackedArray::FromInt(
-                                      static_cast<std::int64_t>(element_bw),
-                                      kOffsetBitWidth, kOffsetSigned,
-                                      kOffsetFourState))),
-      element_bw, PopOuterDim(dims_)};
+      *root_, bit_offset_ + sel.bit_offset, std::move(sel.dims)};
 }
 
 auto PackedArrayRef::SliceRef(
@@ -1516,17 +1560,9 @@ auto PackedArrayRef::SliceRef(
     const PackedArray& count_in_outer_elements) const -> PackedArrayRef {
   const auto count =
       static_cast<std::uint32_t>(count_in_outer_elements.ToInt64());
-  const auto element_bw = OuterElementBitWidth(bit_width_, dims_);
+  auto sel = ResolveSlice(bit_width_, dims_, offset_in_outer_elements, count);
   return PackedArrayRef{
-      *root_,
-      element_bw == 1U
-          ? (bit_offset_ + Canonicalize(offset_in_outer_elements))
-          : (bit_offset_ +
-             (Canonicalize(offset_in_outer_elements) *
-              PackedArray::FromInt(
-                  static_cast<std::int64_t>(element_bw), kOffsetBitWidth,
-                  kOffsetSigned, kOffsetFourState))),
-      count * element_bw, ReplaceOuterDimCount(dims_, count)};
+      *root_, bit_offset_ + sel.bit_offset, std::move(sel.dims)};
 }
 
 auto PackedArray::operator<(const PackedArray& other) const -> PackedArray {

--- a/tests/cases/cpp/multi_dim_select_read/case.yaml
+++ b/tests/cases/cpp/multi_dim_select_read/case.yaml
@@ -12,3 +12,6 @@ expect:
     elem1: "8'hCD"
     high_nibble_1: "4'hC"
     bit_in_elem: "1'b1"
+    full3d: "32'h44332211"
+    elem3d: "8'h33"
+    nib3d: "4'h3"

--- a/tests/cases/cpp/multi_dim_select_read/main.sv
+++ b/tests/cases/cpp/multi_dim_select_read/main.sv
@@ -3,6 +3,9 @@ module Top;
   bit [7:0] elem1;
   bit [3:0] high_nibble_1;
   bit bit_in_elem;
+  bit [31:0] full3d;
+  bit [7:0] elem3d;
+  bit [3:0] nib3d;
   initial begin
     bit [1:0][7:0] data;
     int idx;
@@ -13,5 +16,18 @@ module Top;
     idx = 4;
     high_nibble_1 = data[1][idx+:4];
     bit_in_elem = data[1][0];
+
+    // A chained read on a 3-D packed array: `d3[1]` is itself a 2-D vector, so
+    // the inner select must see its dimensions rather than a flattened bit run.
+    begin
+      bit [1:0][1:0][7:0] d3;
+      d3[0][0] = 8'h11;
+      d3[0][1] = 8'h22;
+      d3[1][0] = 8'h33;
+      d3[1][1] = 8'h44;
+      full3d = d3;
+      elem3d = d3[1][0];
+      nib3d = d3[1][0][3:0];
+    end
   end
 endmodule

--- a/tests/cases/cpp/packed_array_aggregate_element/case.yaml
+++ b/tests/cases/cpp/packed_array_aggregate_element/case.yaml
@@ -1,0 +1,20 @@
+id: cpp.packed_array_aggregate_element
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    pas_full: "16'hAB12"
+    field_a: "4'h1"
+    elem1: "8'hAB"
+    pae_full: "8'h49"
+    pae0: "2'h1"
+    pau_full: "16'hABCD"
+    umem: "8'hCD"
+    pn_full: "32'h44332211"
+    pn_elem: "8'h33"
+    pn_field: "4'h4"

--- a/tests/cases/cpp/packed_array_aggregate_element/main.sv
+++ b/tests/cases/cpp/packed_array_aggregate_element/main.sv
@@ -1,0 +1,68 @@
+module Top;
+  // LRM 7.2.1 / 7.4: a packed array whose element is a packed aggregate (struct
+  // or enum) is itself a flat vector. Element selects yield the element type, so
+  // a member access through `pas[i].field` and an enum element read both work.
+  typedef struct packed {
+    logic [3:0] a;
+    logic [3:0] b;
+  } byte_t;
+
+  typedef enum logic [1:0] {
+    RED,
+    GREEN,
+    BLUE
+  } color_t;
+
+  typedef union packed {
+    logic [7:0] full;
+    logic [1:0][3:0] halves;
+  } u_t;
+
+  logic [15:0] pas_full;
+  logic [3:0] field_a;
+  logic [7:0] elem1;
+  logic [7:0] pae_full;
+  logic [1:0] pae0;
+  logic [15:0] pau_full;
+  logic [7:0] umem;
+  logic [31:0] pn_full;
+  logic [7:0] pn_elem;
+  logic [3:0] pn_field;
+
+  initial begin
+    byte_t [1:0] pas;
+    color_t [3:0] pae;
+    u_t [1:0] pau;
+    byte_t [1:0][1:0] pn;
+
+    pas[0].a = 4'h1;
+    pas[0].b = 4'h2;
+    pas[1] = 8'hAB;
+    pas_full = pas;
+    field_a = pas[0].a;
+    elem1 = pas[1];
+
+    pae[0] = GREEN;
+    pae[1] = BLUE;
+    pae[2] = RED;
+    pae[3] = GREEN;
+    pae_full = pae;
+    pae0 = pae[0];
+
+    // Packed array whose element is a packed union.
+    pau[0] = 8'hCD;
+    pau[1] = 8'hAB;
+    pau_full = pau;
+    umem = pau[0].full;
+
+    // Nested packed array of a packed struct: a chained element select
+    // (`pn[1][0]`) yields the struct, and a field reaches through it.
+    pn[0][0] = 8'h11;
+    pn[0][1] = 8'h22;
+    pn[1][0] = 8'h33;
+    pn[1][1] = 8'h44;
+    pn_full = pn;
+    pn_elem = pn[1][0];
+    pn_field = pn[1][1].a;
+  end
+endmodule


### PR DESCRIPTION
## Summary

HIR now represents a packed array recursively -- one node per dimension, the element referenced by `TypeId`, and a scalar bit as an interned leaf -- so a packed array whose element is a packed struct, union, or enum is representable (an Ibex gap). MIR keeps the flat single-vector shape (LRM 7.4.1) and HIR-to-MIR flattens the recursive form. The runtime now builds every packed select result already carrying its dimensional shape, and the read and write selectors share one resolution step, which fixes chained multi-dimensional reads and closes a class of shape-drift bugs.

## Design

HIR is SV-faithful (recursive, one dimension per node); MIR is the generic-PL flat shape (an integer with bit-slice views). The asymmetry is intentional and recorded in `docs/decisions/packed-array-representation.md`. Type translation stays infallible -- the only type-level failure, a tagged unpacked union, is rejected at AST-to-HIR where the declaration span is available -- which in turn lets `Type::span` and the redundant integral width/state fields be removed.

The runtime selector change is the first landed step of a larger value-layer workstream tracked in `docs/progress/packed-value-model.md`: a packed value is constructed with its shape from the start (never reshaped afterward), and one shared resolver computes a selection's offset and result shape for both the value and reference selector forms.

## Testing

`bazel test //...` green. New cases cover a packed array of a packed struct, enum, and union with chained element and field selects, plus 3-D chained reads.
