### PR TITLE
Rename ClassLowerer to StructuralScopeLowerer

### DIFF
--- a/docs/architecture/lowering_organization.md
+++ b/docs/architecture/lowering_organization.md
@@ -77,9 +77,9 @@ threaded down, a per-callable-body temp counter) is defined separately under "Re
 ## Core Invariants
 
 1. Every construction pass is implemented as a class named for the unit of work it processes and the
-   action it performs (`ProcessLowerer`, `ClassLowerer`). The class is constructed once per task
-   instance and destroyed when that task completes; one class instance does not span multiple task
-   instances. A rendering fold is not a class (see "Rendering Folds").
+   action it performs (`ProcessLowerer`, `StructuralScopeLowerer`). The class is constructed once
+   per task instance and destroyed when that task completes; one class instance does not span
+   multiple task instances. A rendering fold is not a class (see "Rendering Folds").
 
 2. The class constructor receives the read-only facts the pass depends on. After construction those
    facts are not mutated. Registries the pass accumulates and the root output the pass is
@@ -383,9 +383,10 @@ When a layer's expression / statement dispatch grows past a single readable file
 into the pass class itself and one subsystem file per expression / statement family. The shape is
 fixed:
 
-- The pass class header (`process_lowerer.hpp`, `class_lowerer.hpp`, `module_lowerer.hpp`) declares
-  the dispatcher methods (`LowerExpr`, `LowerStmt`, `InternType`, etc.), the registry operations,
-  and the fact accessors. Per-kind handler declarations are not on the class.
+- The pass class header (`process_lowerer.hpp`, `structural_scope_lowerer.hpp`,
+  `module_lowerer.hpp`) declares the dispatcher methods (`LowerExpr`, `LowerStmt`, `InternType`,
+  etc.), the registry operations, and the fact accessors. Per-kind handler declarations are not on
+  the class.
 - The pass class implementation (`process_lowerer.cpp`, etc.) defines the dispatcher methods. Each
   dispatcher method body is a single switch over node kind, with each case routing to a per-kind
   handler in a subsystem file.

--- a/docs/decisions/lowering-organization.md
+++ b/docs/decisions/lowering-organization.md
@@ -130,8 +130,8 @@ share only the pattern shape.
 
 - `UnitLoweringState` is replaced by per-purpose objects: the HIR-to-MIR type-translation map
   becomes a `TypeMap` registry; canonical TypeIds remain as `BuiltinMirTypes` facts. Their
-  composition into the surrounding `ClassLowerer` / `ProcessLowerer` classes is per pass; no
-  `UnitLoweringState`-equivalent god class survives.
+  composition into the surrounding `StructuralScopeLowerer` / `ProcessLowerer` classes is per pass;
+  no `UnitLoweringState`-equivalent god class survives.
 
 - `StructuralScopeLoweringState` and `ProceduralScopeLoweringState` are dissolved into their
   corresponding IR scope types (`hir::StructuralScope`, `mir::Block`, etc.), which gain construction

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -163,15 +163,15 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       `(Lowerer&, WalkFrame, node)`; the `WalkFrame` value type carries `current_compilation_unit` /
       `current_class` / `current_block` / `static_frame_scope` / `block_depth` / `active_closure` /
       `active_index_binding` and every write goes through `frame.current_class->Add...` /
-      `frame.current_block->Add...` uniformly. `ModuleLowerer`, `ClassLowerer`, and `ProcessLowerer`
-      hold facts and registries only -- no borrowed pointer to in-flight IR, no delegate `Add` /
-      `Allocate` wrapper, no ambient `Set*` / `Enter*` / `Leave*`. `ProceduralDepthGuard` is gone.
-      The dead `facts.hpp` is deleted. `state.hpp` has been split into `module_lowerer.hpp` /
-      `class_lowerer.hpp` / `process_lowerer.hpp`. AST-to-HIR `StructuralScopeLowerer.scope_`,
-      `ModuleLowerer.hir_unit_`, and `ProcessLowerer.body_` are likewise off the lowerer. `~1400`
-      local-variable sites renamed (`unit_state` -> `module`, `scope_state` -> `scope`, `proc_state`
-      -> `process`, `proc_scope_state` -> `proc_scope`, etc.). The per-LRM-family subsystem split
-      ships as its own focused cut; see R13.
+      `frame.current_block->Add...` uniformly. `ModuleLowerer`, `StructuralScopeLowerer`, and
+      `ProcessLowerer` hold facts and registries only -- no borrowed pointer to in-flight IR, no
+      delegate `Add` / `Allocate` wrapper, no ambient `Set*` / `Enter*` / `Leave*`.
+      `ProceduralDepthGuard` is gone. The dead `facts.hpp` is deleted. `state.hpp` has been split
+      into `module_lowerer.hpp` / `structural_scope_lowerer.hpp` / `process_lowerer.hpp`. AST-to-HIR
+      `StructuralScopeLowerer.scope_`, `ModuleLowerer.hir_unit_`, and `ProcessLowerer.body_` are
+      likewise off the lowerer. `~1400` local-variable sites renamed (`unit_state` -> `module`,
+      `scope_state` -> `scope`, `proc_state` -> `process`, `proc_scope_state` -> `proc_scope`,
+      etc.). The per-LRM-family subsystem split ships as its own focused cut; see R13.
 
 - [x] R11 -- Remove the `mutable owned_temp_counter_` escape hatch on `RenderContext`. Today the C++
       backend's temp-name counter is a `mutable` field reached through a pointer from every
@@ -207,7 +207,7 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       `expression/system/{print, scan, sformat,     file_io, diagnostic, timescale, control}.{hpp,cpp}`,
       and `statement/{blocks, branches, loops,     timing, fork_join, assignment, flow}.{hpp,cpp}`.
       The procedural and class-level expression dispatchers are class methods
-      (`ProcessLowerer::LowerExpr` / `LowerStmt`, `ClassLowerer::LowerExpr`); the
+      (`ProcessLowerer::LowerExpr` / `LowerStmt`, `StructuralScopeLowerer::LowerExpr`); the
       for-generate-header vs generate-control distinction lives on `WalkFrame::loop_var_mode`.
       Subsystem files include only the pass-class headers and their own family header, so adding a
       kind touches three files (subsystem header, subsystem implementation, dispatcher switch) and

--- a/include/lyra/lowering/hir_to_mir/continuous_assign.hpp
+++ b/include/lyra/lowering/hir_to_mir/continuous_assign.hpp
@@ -4,14 +4,14 @@
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/continuous_assign.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/method.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
 auto LowerContinuousAssign(
-    const ClassLowerer& lowerer, WalkFrame frame, std::string name,
+    const StructuralScopeLowerer& lowerer, WalkFrame frame, std::string name,
     const hir::ContinuousAssign& src) -> diag::Result<mir::MethodDecl>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/expr_lowerer.hpp
@@ -13,9 +13,9 @@ namespace lyra::lowering::hir_to_mir {
 
 // The duck-typed contract a pass class fulfils for context-free expression
 // lowering: recurse into a sub-expression (read or lhs context), reach the
-// HIR expression arena, and reach the enclosing module. `ProcessLowerer`
-// (procedural bodies) and `ClassLowerer` (structural scopes) both satisfy
-// it; the shared per-expression handler templates are constrained on it so
+// HIR expression arena, and reach the enclosing module. The procedural-body
+// pass and the structural-scope pass both satisfy it; the shared per-expression
+// handler templates are constrained on it so
 // the surface they depend on is named and checked rather than surfacing as a
 // deep template error. It is deliberately not a base class -- the two pass
 // classes build different things and share no v-table.

--- a/include/lyra/lowering/hir_to_mir/expression/references.hpp
+++ b/include/lyra/lowering/hir_to_mir/expression/references.hpp
@@ -7,8 +7,8 @@
 
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/primary.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/type_id.hpp"
@@ -24,8 +24,8 @@ auto LowerHirPrimaryExprProc(
 // `LoopVarRef` arm to choose between procedural-induction and
 // structural-param resolution.
 auto LowerHirPrimaryExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame, const hir::Primary& p,
-    mir::TypeId result_type) -> diag::Result<mir::Expr>;
+    const StructuralScopeLowerer& lowerer, WalkFrame frame,
+    const hir::Primary& p, mir::TypeId result_type) -> diag::Result<mir::Expr>;
 
 // Translate a folded HIR integral constant to its MIR form. Shared by
 // primary-literal lowering and member-default materialization.

--- a/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/process_lowerer.hpp
@@ -17,8 +17,8 @@
 #include "lyra/hir/stmt.hpp"
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/lowering/hir_to_mir/block_depth.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/local.hpp"
@@ -77,7 +77,7 @@ class ProcessLowerer {
   // frame -- the static-local lowering reads it to place per-instance storage
   // and its init AssignExpr into the owner's constructor_block.
   ProcessLowerer(
-      ModuleLowerer& module, const ClassLowerer& lowerer,
+      ModuleLowerer& module, const StructuralScopeLowerer& lowerer,
       TimeResolution time_resolution, const hir::ProceduralBody& hir_body,
       std::string callable_name, WalkFrame owner_ctor_frame)
       : module_(&module),
@@ -127,9 +127,10 @@ class ProcessLowerer {
     return *hir_body_;
   }
 
-  // The expression arena of the body being lowered. The single uniform
-  // sub-expression accessor the context-free expression handler templates
-  // reach through, identical in shape to `ClassLowerer::HirExprs`.
+  // The expression arena of the body being lowered. The uniform sub-expression
+  // accessor the context-free expression handler templates reach through; both
+  // lowering pass classes expose it with the same shape so those templates bind
+  // to either.
   [[nodiscard]] auto HirExprs() const
       -> const base::Arena<hir::Expr, hir::ExprId>& {
     return hir_body_->exprs;
@@ -142,13 +143,13 @@ class ProcessLowerer {
     return *module_;
   }
 
-  [[nodiscard]] auto Owner() const -> const ClassLowerer& {
+  [[nodiscard]] auto Owner() const -> const StructuralScopeLowerer& {
     return *owner_;
   }
 
-  // The structural-subroutine tables live on the owning `ClassLowerer`; expose
-  // them here too so a templated call handler reaches a user subroutine through
-  // the same surface on either pass class (`ClassLowerer` has them directly).
+  // The structural-subroutine tables live on the owning structural-scope pass;
+  // this forwards to them so a templated call handler reaches a user subroutine
+  // through the same surface on either pass class.
   [[nodiscard]] auto LookupHirSubroutine(
       hir::StructuralHops hops, hir::StructuralSubroutineId id) const
       -> const hir::StructuralSubroutineDecl& {
@@ -241,7 +242,7 @@ class ProcessLowerer {
 
  private:
   ModuleLowerer* module_;
-  const ClassLowerer* owner_;
+  const StructuralScopeLowerer* owner_;
   TimeResolution time_resolution_;
   const hir::ProceduralBody* hir_body_;
   std::string callable_name_;

--- a/include/lyra/lowering/hir_to_mir/sensitivity_wait.hpp
+++ b/include/lyra/lowering/hir_to_mir/sensitivity_wait.hpp
@@ -8,7 +8,7 @@
 
 namespace lyra::lowering::hir_to_mir {
 
-class ClassLowerer;
+class StructuralScopeLowerer;
 
 // Materialises a mir::SensitivityWaitStmt from a HIR sensitivity entry list.
 // Lowering picks the observable-pointer expression per leaf so the backend
@@ -20,7 +20,7 @@ class ClassLowerer;
 // and `@*` (LRM 9.4.2.2).
 auto MakeSensitivityWaitStmt(
     mir::Block& target_block, const WalkFrame& frame,
-    const ClassLowerer& lowerer,
+    const StructuralScopeLowerer& lowerer,
     const std::vector<hir::SensitivityEntry>& sensitivity_list) -> mir::Stmt;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp
@@ -30,9 +30,9 @@ struct ChildStructuralScopeBinding {
   mir::MemberId var_id;
 };
 
-// Bindings produced by `InstallGenerateOwnedChildScopes` for a single
-// `hir::Generate`. Indexed by `hir::StructuralScopeId.value`. Phase-local to
-// constructor lowering and not part of `ClassLowerer`.
+// The owned-child-scope bindings for a single `hir::Generate`, indexed by
+// `hir::StructuralScopeId.value`. A transient table threaded through generate
+// installation during constructor lowering, not stored on the pass object.
 struct GenerateBindings {
   std::vector<ChildStructuralScopeBinding> by_scope_id;
 };
@@ -58,11 +58,11 @@ struct StructuralParamLocation {
 // scope-local HIR-to-MIR translation maps and the cross-unit-ref slot table.
 // Holds no pointer to the IR scope being built: handlers reach it through
 // `frame.current_class`.
-class ClassLowerer {
+class StructuralScopeLowerer {
  public:
-  ClassLowerer(
-      ModuleLowerer& module, const ClassLowerer* parent, std::string name,
-      const hir::StructuralScope& hir_scope)
+  StructuralScopeLowerer(
+      ModuleLowerer& module, const StructuralScopeLowerer* parent,
+      std::string name, const hir::StructuralScope& hir_scope)
       : module_(&module),
         parent_(parent),
         name_(std::move(name)),
@@ -84,7 +84,7 @@ class ClassLowerer {
       -> diag::Result<mir::Expr>;
 
   // LHS-context expression dispatcher: addressable kinds only, no auto-Get
-  // wrap. Mirrors `ProcessLowerer::LowerLhsExpr`.
+  // wrap.
   [[nodiscard]] auto LowerLhsExpr(const hir::Expr& expr, WalkFrame frame) const
       -> diag::Result<mir::Expr>;
 
@@ -92,7 +92,7 @@ class ClassLowerer {
     return *module_;
   }
 
-  [[nodiscard]] auto Parent() const -> const ClassLowerer* {
+  [[nodiscard]] auto Parent() const -> const StructuralScopeLowerer* {
     return parent_;
   }
 
@@ -104,9 +104,10 @@ class ClassLowerer {
     return *hir_scope_;
   }
 
-  // The expression arena of the scope being lowered. The single uniform
-  // sub-expression accessor the context-free expression handler templates
-  // reach through, identical in shape to `ProcessLowerer::HirExprs`.
+  // The expression arena of the scope being lowered. The uniform sub-expression
+  // accessor the context-free expression handler templates reach through; both
+  // lowering pass classes expose it with the same shape so those templates bind
+  // to either.
   [[nodiscard]] auto HirExprs() const
       -> const base::Arena<hir::Expr, hir::ExprId>& {
     return hir_scope_->exprs;
@@ -125,7 +126,7 @@ class ClassLowerer {
     }
     if (parent_ == nullptr) {
       throw InternalError(
-          "ClassLowerer::LookupHirSubroutine: hops walk ran "
+          "StructuralScopeLowerer::LookupHirSubroutine: hops walk ran "
           "past the root scope");
     }
     return parent_->LookupHirSubroutine(
@@ -155,7 +156,7 @@ class ClassLowerer {
   void MapStructuralVar(hir::StructuralVarId hir_id, mir::MemberId mir_id) {
     if (hir_id.value != structural_var_map_.size()) {
       throw InternalError(
-          "ClassLowerer::MapStructuralVar: HIR structural "
+          "StructuralScopeLowerer::MapStructuralVar: HIR structural "
           "vars must be mapped in HIR id order");
     }
     structural_var_map_.push_back(mir_id);
@@ -174,7 +175,7 @@ class ClassLowerer {
     }
     if (structural_param_map_[hir_id.value].has_value()) {
       throw InternalError(
-          "ClassLowerer::MapLoopVarAsStructuralParam: HIR "
+          "StructuralScopeLowerer::MapLoopVarAsStructuralParam: HIR "
           "loop var already mapped");
     }
     structural_param_map_[hir_id.value] = mir_id;
@@ -192,7 +193,7 @@ class ClassLowerer {
     }
     if (loop_var_procedural_map_[hir_id.value].has_value()) {
       throw InternalError(
-          "ClassLowerer::MapLoopVarAsProcedural: HIR loop var "
+          "StructuralScopeLowerer::MapLoopVarAsProcedural: HIR loop var "
           "already mapped");
     }
     loop_var_procedural_map_[hir_id.value] = ref;
@@ -202,7 +203,7 @@ class ClassLowerer {
     if (hir_id.value >= loop_var_procedural_map_.size() ||
         !loop_var_procedural_map_[hir_id.value].has_value()) {
       throw InternalError(
-          "ClassLowerer::TranslateLoopVarAsProcedural: unmapped "
+          "StructuralScopeLowerer::TranslateLoopVarAsProcedural: unmapped "
           "HIR loop var");
     }
     return *loop_var_procedural_map_[hir_id.value];
@@ -217,7 +218,7 @@ class ClassLowerer {
       -> StructuralParamLocation {
     if (hir_hops.value == 0) {
       throw InternalError(
-          "ClassLowerer::TranslateLoopVarAsStructuralParam: "
+          "StructuralScopeLowerer::TranslateLoopVarAsStructuralParam: "
           "HIR hops=0 cannot resolve to a structural param (the param is "
           "child-owned in MIR; header expressions must use the procedural "
           "induction var path)");
@@ -237,7 +238,8 @@ class ClassLowerer {
   void MapInstanceMember(hir::InstanceMemberId hir_id, mir::MemberId mir_id) {
     if (hir_id.value != instance_member_map_.size()) {
       throw InternalError(
-          "ClassLowerer::MapInstanceMember: HIR instance members must be "
+          "StructuralScopeLowerer::MapInstanceMember: HIR instance members "
+          "must be "
           "mapped in HIR id order");
     }
     instance_member_map_.push_back(mir_id);
@@ -246,7 +248,8 @@ class ClassLowerer {
   void MapGenerate(hir::GenerateId hir_id, GenerateBindings bindings) {
     if (hir_id.value != generate_map_.size()) {
       throw InternalError(
-          "ClassLowerer::MapGenerate: HIR generates must be mapped in HIR id "
+          "StructuralScopeLowerer::MapGenerate: HIR generates must be mapped "
+          "in HIR id "
           "order");
     }
     generate_map_.push_back(std::move(bindings));
@@ -268,7 +271,7 @@ class ClassLowerer {
       hir::StructuralSubroutineId hir_id, mir::MethodId mir_id) {
     if (hir_id.value != structural_subroutine_map_.size()) {
       throw InternalError(
-          "ClassLowerer::MapStructuralSubroutine: HIR "
+          "StructuralScopeLowerer::MapStructuralSubroutine: HIR "
           "structural subroutines must be mapped in HIR id order");
     }
     structural_subroutine_map_.push_back(mir_id);
@@ -292,7 +295,8 @@ class ClassLowerer {
               [&](const hir::InstanceMemberId& id) -> mir::MemberId {
                 if (id.value >= instance_member_map_.size()) {
                   throw InternalError(
-                      "ClassLowerer::TranslateOwnedChild: unmapped HIR "
+                      "StructuralScopeLowerer::TranslateOwnedChild: unmapped "
+                      "HIR "
                       "instance member");
                 }
                 return instance_member_map_[id.value];
@@ -300,7 +304,8 @@ class ClassLowerer {
               [&](const hir::GenerateChildRef& g) -> mir::MemberId {
                 if (g.generate.value >= generate_map_.size()) {
                   throw InternalError(
-                      "ClassLowerer::TranslateOwnedChild: unmapped HIR "
+                      "StructuralScopeLowerer::TranslateOwnedChild: unmapped "
+                      "HIR "
                       "generate");
                 }
                 return generate_map_[g.generate.value]
@@ -312,7 +317,8 @@ class ClassLowerer {
     }
     if (parent_ == nullptr) {
       throw InternalError(
-          "ClassLowerer::TranslateOwnedChild: hops exceed scope chain depth");
+          "StructuralScopeLowerer::TranslateOwnedChild: hops exceed scope "
+          "chain depth");
     }
     return parent_->LookupOwnedChildAtHops(
         hir::StructuralHops{hops.value - 1}, child);
@@ -324,14 +330,14 @@ class ClassLowerer {
     if (hops.value == 0) {
       if (hir_id.value >= structural_var_map_.size()) {
         throw InternalError(
-            "ClassLowerer::TranslateStructuralVar: unmapped "
+            "StructuralScopeLowerer::TranslateStructuralVar: unmapped "
             "HIR structural var");
       }
       return structural_var_map_[hir_id.value];
     }
     if (parent_ == nullptr) {
       throw InternalError(
-          "ClassLowerer::TranslateStructuralVar: hops out "
+          "StructuralScopeLowerer::TranslateStructuralVar: hops out "
           "of scope chain");
     }
     return parent_->LookupStructuralVarAtHops(
@@ -345,14 +351,14 @@ class ClassLowerer {
       if (hir_id.value >= structural_param_map_.size() ||
           !structural_param_map_[hir_id.value].has_value()) {
         throw InternalError(
-            "ClassLowerer::TranslateLoopVarAsStructuralParam: "
+            "StructuralScopeLowerer::TranslateLoopVarAsStructuralParam: "
             "unmapped HIR loop var");
       }
       return *structural_param_map_[hir_id.value];
     }
     if (parent_ == nullptr) {
       throw InternalError(
-          "ClassLowerer::TranslateLoopVarAsStructuralParam: "
+          "StructuralScopeLowerer::TranslateLoopVarAsStructuralParam: "
           "hops exceed scope chain depth");
     }
     return parent_->LookupStructuralParamAtMirHops(
@@ -365,14 +371,14 @@ class ClassLowerer {
     if (hops.value == 0) {
       if (hir_id.value >= structural_subroutine_map_.size()) {
         throw InternalError(
-            "ClassLowerer::TranslateStructuralSubroutine: "
+            "StructuralScopeLowerer::TranslateStructuralSubroutine: "
             "unmapped HIR subroutine");
       }
       return structural_subroutine_map_[hir_id.value];
     }
     if (parent_ == nullptr) {
       throw InternalError(
-          "ClassLowerer::TranslateStructuralSubroutine: hops "
+          "StructuralScopeLowerer::TranslateStructuralSubroutine: hops "
           "exceed scope chain depth");
     }
     return parent_->LookupStructuralSubroutineAtHops(
@@ -380,7 +386,7 @@ class ClassLowerer {
   }
 
   ModuleLowerer* module_;
-  const ClassLowerer* parent_;
+  const StructuralScopeLowerer* parent_;
   std::string name_;
   const hir::StructuralScope* hir_scope_;
   std::vector<mir::MemberId> structural_var_map_;

--- a/include/lyra/lowering/hir_to_mir/walk_frame.hpp
+++ b/include/lyra/lowering/hir_to_mir/walk_frame.hpp
@@ -20,7 +20,7 @@ class IterationBindingRegistry;
 
 // Singly-linked node carrying a class's parent chain so a leaf reference
 // can read the declared type of a member at `hops > 0`. Each node lives on
-// the stack of the `ClassLowerer::Run` that pushed it; the chain extends
+// the stack frame of the construction walk that pushed it; the chain extends
 // one node per class opened during traversal. This is the construction-side
 // half of the shared walk position: the rendering fold's read-only
 // `ScopeView` resolves the same (hops, var) reference by climbing its own
@@ -46,8 +46,8 @@ struct WalkFrame {
   mir::Class* current_class = nullptr;
 
   // Outer classes reached by climbing `parent` links, in the same order as the
-  // lowerer `parent_` chain. Populated by `WithClass` when a
-  // `ClassLowerer::Run` opens a new class. Read via `EnclosingClassAtHops` to
+  // lowerer `parent_` chain. Populated by `WithClass` when the construction
+  // walk opens a new class. Read via `EnclosingClassAtHops` to
   // resolve a member reference at `hops > 0`.
   const ScopeChainNode* outer_classes = nullptr;
 

--- a/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
+++ b/src/lyra/lowering/hir_to_mir/continuous_assign.cpp
@@ -26,7 +26,7 @@ namespace lyra::lowering::hir_to_mir {
 // eternal loop) before the first wait, matching LRM 9.2.2.2's "evaluate at
 // time 0" requirement for inferred sensitivity.
 auto LowerContinuousAssign(
-    const ClassLowerer& lowerer, WalkFrame frame, std::string name,
+    const StructuralScopeLowerer& lowerer, WalkFrame frame, std::string name,
     const hir::ContinuousAssign& src) -> diag::Result<mir::MethodDecl> {
   mir::Block process_block;
   const mir::LocalId self_id = process_block.vars.Add(

--- a/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/aggregates.cpp
@@ -11,10 +11,10 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/type.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
@@ -258,39 +258,39 @@ auto LowerHirAssociativeAssignmentPatternExpr(
 
 // One concrete instantiation per pass class. The handler templates are defined
 // in this file rather than the header so the file-local helpers stay private,
-// so the dispatchers in process_lowerer.cpp / class_lowerer.cpp link against
-// the symbols emitted here.
+// so the dispatchers in process_lowerer.cpp / structural_scope_lowerer.cpp link
+// against the symbols emitted here.
 template auto LowerHirConcatExpr(
     ProcessLowerer&, WalkFrame, const hir::ConcatExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirConcatExpr(
-    const ClassLowerer&, WalkFrame, const hir::ConcatExpr&, mir::TypeId)
-    -> diag::Result<mir::Expr>;
+    const StructuralScopeLowerer&, WalkFrame, const hir::ConcatExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
 template auto LowerHirAssignmentPatternExpr(
     ProcessLowerer&, WalkFrame, const hir::AssignmentPatternExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirAssignmentPatternExpr(
-    const ClassLowerer&, WalkFrame, const hir::AssignmentPatternExpr&,
+    const StructuralScopeLowerer&, WalkFrame, const hir::AssignmentPatternExpr&,
     mir::TypeId) -> diag::Result<mir::Expr>;
 template auto LowerHirAssignmentPatternReplicationExpr(
     ProcessLowerer&, WalkFrame, const hir::AssignmentPatternReplicationExpr&,
     mir::TypeId) -> diag::Result<mir::Expr>;
 template auto LowerHirAssignmentPatternReplicationExpr(
-    const ClassLowerer&, WalkFrame,
+    const StructuralScopeLowerer&, WalkFrame,
     const hir::AssignmentPatternReplicationExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirAssociativeAssignmentPatternExpr(
     ProcessLowerer&, WalkFrame, const hir::AssociativeAssignmentPatternExpr&,
     mir::TypeId) -> diag::Result<mir::Expr>;
 template auto LowerHirAssociativeAssignmentPatternExpr(
-    const ClassLowerer&, WalkFrame,
+    const StructuralScopeLowerer&, WalkFrame,
     const hir::AssociativeAssignmentPatternExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirReplicationExpr(
     ProcessLowerer&, WalkFrame, const hir::ReplicationExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirReplicationExpr(
-    const ClassLowerer&, WalkFrame, const hir::ReplicationExpr&, mir::TypeId)
-    -> diag::Result<mir::Expr>;
+    const StructuralScopeLowerer&, WalkFrame, const hir::ReplicationExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/calls.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/calls.cpp
@@ -552,7 +552,8 @@ template auto LowerHirCallExpr(
     ProcessLowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
     diag::SourceSpan span, mir::TypeId result_type) -> diag::Result<mir::Expr>;
 template auto LowerHirCallExpr(
-    const ClassLowerer& lowerer, WalkFrame frame, const hir::CallExpr& c,
-    diag::SourceSpan span, mir::TypeId result_type) -> diag::Result<mir::Expr>;
+    const StructuralScopeLowerer& lowerer, WalkFrame frame,
+    const hir::CallExpr& c, diag::SourceSpan span, mir::TypeId result_type)
+    -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/dispatch.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/dispatch.cpp
@@ -5,7 +5,6 @@
 #include "lyra/base/overloaded.hpp"
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/expression/aggregates.hpp"
 #include "lyra/lowering/hir_to_mir/expression/assignment.hpp"
 #include "lyra/lowering/hir_to_mir/expression/calls.hpp"
@@ -15,6 +14,7 @@
 #include "lyra/lowering/hir_to_mir/expression/references.hpp"
 #include "lyra/lowering/hir_to_mir/expression/selects.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/type.hpp"
@@ -197,13 +197,13 @@ auto ProcessLowerer::LowerLhsExpr(const hir::Expr& expr, WalkFrame frame)
   return LowerLhsExprImpl(*this, expr, frame);
 }
 
-auto ClassLowerer::LowerExpr(const hir::Expr& expr, WalkFrame frame) const
-    -> diag::Result<mir::Expr> {
+auto StructuralScopeLowerer::LowerExpr(
+    const hir::Expr& expr, WalkFrame frame) const -> diag::Result<mir::Expr> {
   return LowerExprImpl(*this, expr, frame);
 }
 
-auto ClassLowerer::LowerLhsExpr(const hir::Expr& expr, WalkFrame frame) const
-    -> diag::Result<mir::Expr> {
+auto StructuralScopeLowerer::LowerLhsExpr(
+    const hir::Expr& expr, WalkFrame frame) const -> diag::Result<mir::Expr> {
   return LowerLhsExprImpl(*this, expr, frame);
 }
 

--- a/src/lyra/lowering/hir_to_mir/expression/inside.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/inside.cpp
@@ -6,9 +6,9 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/hir/expr.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/inside_predicate.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/expr.hpp"
@@ -54,7 +54,7 @@ template auto LowerHirInsideExpr(
     ProcessLowerer&, WalkFrame, const hir::InsideExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirInsideExpr(
-    const ClassLowerer&, WalkFrame, const hir::InsideExpr&, mir::TypeId)
-    -> diag::Result<mir::Expr>;
+    const StructuralScopeLowerer&, WalkFrame, const hir::InsideExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -12,10 +12,10 @@
 #include "lyra/hir/expr.hpp"
 #include "lyra/hir/unary_op.hpp"
 #include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/lhs_observable.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
+#include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/compilation_unit.hpp"
@@ -493,31 +493,31 @@ auto LowerHirConversionExpr(
 
 // One concrete instantiation per pass class. The handler templates are defined
 // in this file rather than the header so the file-local helpers stay private,
-// so the dispatchers in process_lowerer.cpp / class_lowerer.cpp link against
-// the symbols emitted here.
+// so the dispatchers in process_lowerer.cpp / structural_scope_lowerer.cpp link
+// against the symbols emitted here.
 template auto LowerHirUnaryExpr(
     ProcessLowerer&, WalkFrame, const hir::UnaryExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirUnaryExpr(
-    const ClassLowerer&, WalkFrame, const hir::UnaryExpr&, mir::TypeId)
-    -> diag::Result<mir::Expr>;
+    const StructuralScopeLowerer&, WalkFrame, const hir::UnaryExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
 template auto LowerHirBinaryExpr(
     ProcessLowerer&, WalkFrame, const hir::BinaryExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirBinaryExpr(
-    const ClassLowerer&, WalkFrame, const hir::BinaryExpr&, mir::TypeId)
-    -> diag::Result<mir::Expr>;
+    const StructuralScopeLowerer&, WalkFrame, const hir::BinaryExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
 template auto LowerHirConditionalExpr(
     ProcessLowerer&, WalkFrame, const hir::ConditionalExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirConditionalExpr(
-    const ClassLowerer&, WalkFrame, const hir::ConditionalExpr&, mir::TypeId)
-    -> diag::Result<mir::Expr>;
+    const StructuralScopeLowerer&, WalkFrame, const hir::ConditionalExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
 template auto LowerHirConversionExpr(
     ProcessLowerer&, WalkFrame, const hir::ConversionExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirConversionExpr(
-    const ClassLowerer&, WalkFrame, const hir::ConversionExpr&, mir::TypeId)
-    -> diag::Result<mir::Expr>;
+    const StructuralScopeLowerer&, WalkFrame, const hir::ConversionExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -12,11 +12,11 @@
 #include "lyra/hir/value_ref.hpp"
 #include "lyra/lowering/hir_to_mir/block_depth.hpp"
 #include "lyra/lowering/hir_to_mir/capture_sink.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/iteration_binding_registry.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
+#include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
@@ -140,7 +140,7 @@ auto LowerHirRealLiteral(const hir::RealLiteral& r, mir::TypeId type)
 // value type otherwise. The dispatcher decides whether to wrap the result
 // in an `ObservableMethod{kGet}` call to unwrap to a value.
 auto LowerStructuralVarRefExpr(
-    const ClassLowerer& lowerer, const WalkFrame& frame,
+    const StructuralScopeLowerer& lowerer, const WalkFrame& frame,
     const hir::StructuralVarRef& m) -> mir::Expr {
   const mir::MemberId var = lowerer.TranslateStructuralVar(m.hops, m.var);
   return BuildStructuralMemberAccessExpr(
@@ -197,7 +197,7 @@ auto LowerProceduralVarRefExpr(
 }
 
 auto LowerCrossUnitVarRefExpr(
-    const ClassLowerer& lowerer, const WalkFrame& frame,
+    const StructuralScopeLowerer& lowerer, const WalkFrame& frame,
     const hir::CrossUnitVarRef& c) -> mir::Expr {
   const auto& meta = lowerer.CrossUnitRefTarget(c.id);
   const mir::MemberRef target = meta.target;
@@ -223,7 +223,7 @@ auto LowerCrossUnitVarRefExpr(
 // -- resolves to the structural param the constructed child binds the genvar to
 // (LRM 27.4). The hop count alone selects the path.
 auto LowerLoopVarRefExpr(
-    const ClassLowerer& lowerer, const WalkFrame& frame,
+    const StructuralScopeLowerer& lowerer, const WalkFrame& frame,
     const hir::LoopVarRef& lv, mir::TypeId type) -> mir::Expr {
   if (lv.hops.value == 0) {
     return mir::Expr{
@@ -314,8 +314,8 @@ auto LowerHirPrimaryExprProc(
 }
 
 auto LowerHirPrimaryExprStructural(
-    const ClassLowerer& lowerer, WalkFrame frame, const hir::Primary& p,
-    mir::TypeId result_type) -> diag::Result<mir::Expr> {
+    const StructuralScopeLowerer& lowerer, WalkFrame frame,
+    const hir::Primary& p, mir::TypeId result_type) -> diag::Result<mir::Expr> {
   return std::visit(
       Overloaded{
           [&](const hir::IntegerLiteral& i) -> mir::Expr {

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -12,9 +12,9 @@
 #include "lyra/diag/diagnostic.hpp"
 #include "lyra/hir/expr.hpp"
 #include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/compilation_unit.hpp"
@@ -903,43 +903,43 @@ auto LowerHirMemberAccessExprLhs(
 
 // One concrete instantiation per pass class. The handler templates are defined
 // in this file rather than the header so the file-local helpers stay private,
-// so the dispatchers in process_lowerer.cpp / class_lowerer.cpp link against
-// the symbols emitted here.
+// so the dispatchers in process_lowerer.cpp / structural_scope_lowerer.cpp link
+// against the symbols emitted here.
 template auto LowerHirElementSelectExpr(
     ProcessLowerer&, WalkFrame, const hir::ElementSelectExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirElementSelectExpr(
-    const ClassLowerer&, WalkFrame, const hir::ElementSelectExpr&, mir::TypeId)
-    -> diag::Result<mir::Expr>;
+    const StructuralScopeLowerer&, WalkFrame, const hir::ElementSelectExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
 template auto LowerHirRangeSelectExpr(
     ProcessLowerer&, WalkFrame, const hir::RangeSelectExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirRangeSelectExpr(
-    const ClassLowerer&, WalkFrame, const hir::RangeSelectExpr&, mir::TypeId)
-    -> diag::Result<mir::Expr>;
+    const StructuralScopeLowerer&, WalkFrame, const hir::RangeSelectExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
 template auto LowerHirMemberAccessExpr(
     ProcessLowerer&, WalkFrame, const hir::MemberAccessExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirMemberAccessExpr(
-    const ClassLowerer&, WalkFrame, const hir::MemberAccessExpr&, mir::TypeId)
-    -> diag::Result<mir::Expr>;
+    const StructuralScopeLowerer&, WalkFrame, const hir::MemberAccessExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
 template auto LowerHirElementSelectExprLhs(
     ProcessLowerer&, WalkFrame, const hir::ElementSelectExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirElementSelectExprLhs(
-    const ClassLowerer&, WalkFrame, const hir::ElementSelectExpr&, mir::TypeId)
-    -> diag::Result<mir::Expr>;
+    const StructuralScopeLowerer&, WalkFrame, const hir::ElementSelectExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
 template auto LowerHirRangeSelectExprLhs(
     ProcessLowerer&, WalkFrame, const hir::RangeSelectExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirRangeSelectExprLhs(
-    const ClassLowerer&, WalkFrame, const hir::RangeSelectExpr&, mir::TypeId)
-    -> diag::Result<mir::Expr>;
+    const StructuralScopeLowerer&, WalkFrame, const hir::RangeSelectExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
 template auto LowerHirMemberAccessExprLhs(
     ProcessLowerer&, WalkFrame, const hir::MemberAccessExpr&, mir::TypeId)
     -> diag::Result<mir::Expr>;
 template auto LowerHirMemberAccessExprLhs(
-    const ClassLowerer&, WalkFrame, const hir::MemberAccessExpr&, mir::TypeId)
-    -> diag::Result<mir::Expr>;
+    const StructuralScopeLowerer&, WalkFrame, const hir::MemberAccessExpr&,
+    mir::TypeId) -> diag::Result<mir::Expr>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
+++ b/src/lyra/lowering/hir_to_mir/inside_predicate.cpp
@@ -5,9 +5,9 @@
 
 #include "lyra/base/overloaded.hpp"
 #include "lyra/hir/inside_item.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/expression/operators.hpp"
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/mir/binary_op.hpp"
 #include "lyra/mir/expr.hpp"
 #include "lyra/mir/stmt.hpp"
@@ -62,7 +62,7 @@ template auto BuildHirInsideItemPredicate(
     ProcessLowerer&, WalkFrame, mir::ExprId, const hir::InsideItem&,
     mir::TypeId) -> diag::Result<mir::ExprId>;
 template auto BuildHirInsideItemPredicate(
-    const ClassLowerer&, WalkFrame, mir::ExprId, const hir::InsideItem&,
-    mir::TypeId) -> diag::Result<mir::ExprId>;
+    const StructuralScopeLowerer&, WalkFrame, mir::ExprId,
+    const hir::InsideItem&, mir::TypeId) -> diag::Result<mir::ExprId>;
 
 }  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
@@ -9,7 +9,7 @@
 #include <utility>
 
 #include "lyra/diag/diagnostic.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 
@@ -28,7 +28,7 @@ auto ModuleLowerer::Run() -> diag::Result<mir::CompilationUnit> {
     MapType(hir_id, mir_id);
   }
 
-  ClassLowerer root(*this, nullptr, hir_->name, hir_->root_scope);
+  StructuralScopeLowerer root(*this, nullptr, hir_->name, hir_->root_scope);
   auto top_r = root.Run(root_frame);
   if (!top_r) return std::unexpected(std::move(top_r.error()));
 

--- a/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
+++ b/src/lyra/lowering/hir_to_mir/sensitivity_wait.cpp
@@ -8,8 +8,8 @@
 #include "lyra/base/internal_error.hpp"
 #include "lyra/base/overloaded.hpp"
 #include "lyra/hir/stmt.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
+#include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
@@ -77,7 +77,7 @@ auto BuildObservablePtrExpr(
 
 auto MakeSensitivityWaitStmt(
     mir::Block& target_block, const WalkFrame& frame,
-    const ClassLowerer& lowerer,
+    const StructuralScopeLowerer& lowerer,
     const std::vector<hir::SensitivityEntry>& sensitivity_list) -> mir::Stmt {
   auto& unit = lowerer.Module().Unit();
   std::vector<mir::SensitivityRead> reads;

--- a/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
+++ b/src/lyra/lowering/hir_to_mir/statement/assignment.cpp
@@ -16,7 +16,6 @@
 #include "lyra/hir/subroutine.hpp"
 #include "lyra/hir/subroutine_ref.hpp"
 #include "lyra/lowering/hir_to_mir/cast_lowering.hpp"
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/completion_payload.hpp"
 #include "lyra/lowering/hir_to_mir/default_value.hpp"
 #include "lyra/lowering/hir_to_mir/expression/assignment.hpp"
@@ -26,6 +25,7 @@
 #include "lyra/lowering/hir_to_mir/process_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/self_ref.hpp"
 #include "lyra/lowering/hir_to_mir/services_call.hpp"
+#include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/compilation_unit.hpp"
 #include "lyra/mir/expr.hpp"
@@ -207,7 +207,7 @@ auto LowerDestructuringAssign(
 // its HIR declaration, or nullptr for a value-only call (system / builtin
 // callee, or an all-`input` user callee).
 auto SubroutineWithWritebacks(
-    const ClassLowerer& lowerer, const hir::CallExpr& call)
+    const StructuralScopeLowerer& lowerer, const hir::CallExpr& call)
     -> const hir::StructuralSubroutineDecl* {
   const auto* ref = std::get_if<hir::StructuralSubroutineRef>(&call.callee);
   if (ref == nullptr) {

--- a/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/structural_scope_lowerer.cpp
@@ -1,4 +1,4 @@
-#include "lyra/lowering/hir_to_mir/class_lowerer.hpp"
+#include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 
 #include <algorithm>
 #include <cstddef>
@@ -419,7 +419,7 @@ void AppendExternalUnitConstruction(
 // Returns the StructuralVarId of each instance member, indexed by
 // InstanceMemberId, so cross-unit reference resolution can reach the child
 // instance var by the same id the HIR recipe carries.
-auto InstallInstanceMembers(ClassLowerer& lowerer, WalkFrame frame)
+auto InstallInstanceMembers(StructuralScopeLowerer& lowerer, WalkFrame frame)
     -> std::vector<mir::MemberId> {
   mir::Class& mir_class = *frame.current_class;
   const hir::StructuralScope& hir_scope = lowerer.HirScope();
@@ -457,7 +457,8 @@ auto InstallInstanceMembers(ClassLowerer& lowerer, WalkFrame frame)
 // member; both record their MIR read target as a StructuralVarRef to that
 // member, in HIR slot order. The returned vector carries the allocated member
 // per ref in HIR order.
-auto MaterializeCrossUnitRefTargets(ClassLowerer& lowerer, WalkFrame frame)
+auto MaterializeCrossUnitRefTargets(
+    StructuralScopeLowerer& lowerer, WalkFrame frame)
     -> std::vector<mir::MemberId> {
   ModuleLowerer& module = lowerer.Module();
   mir::Class& mir_class = *frame.current_class;
@@ -607,9 +608,9 @@ auto FindMemberByName(const mir::Class& cls, std::string_view name)
 // enclosing access used for bare-name reads through `StructuralVarRef`;
 // this path extends it one `MemberAccess` further.
 auto BuildTypedEnclosingNavValue(
-    const ClassLowerer& lowerer, WalkFrame frame, const hir::DownwardHead& down,
-    const std::vector<hir::PathStep>& path, mir::TypeId slot_type)
-    -> mir::ExprId {
+    const StructuralScopeLowerer& lowerer, WalkFrame frame,
+    const hir::DownwardHead& down, const std::vector<hir::PathStep>& path,
+    mir::TypeId slot_type) -> mir::ExprId {
   ModuleLowerer& module = lowerer.Module();
   mir::Block& ctor_block = *frame.current_block;
   const mir::EnclosingHops mir_hops{.value = down.hops.value};
@@ -808,7 +809,7 @@ void AppendExternUpBinding(
 // `CallExpr` carrying flat MIR primitives, so the backend renders them
 // uniformly with every other call.
 void InstallCrossUnitRefs(
-    ClassLowerer& lowerer, WalkFrame frame,
+    StructuralScopeLowerer& lowerer, WalkFrame frame,
     const std::vector<mir::MemberId>& instance_member_vars,
     const std::vector<GenerateBindings>& gen_bindings,
     const std::vector<mir::MemberId>& slot_vars) {
@@ -937,7 +938,7 @@ void AppendProcessRegistration(
 // resolve block: one assignment of a reference, with no second cell and no
 // continuous assignment.
 auto InstallPortConnections(
-    ClassLowerer& lowerer, WalkFrame frame, WalkFrame resolve_frame,
+    StructuralScopeLowerer& lowerer, WalkFrame frame, WalkFrame resolve_frame,
     WalkFrame activate_frame,
     const std::vector<mir::MemberId>& instance_member_vars,
     const std::vector<GenerateBindings>& gen_bindings) -> diag::Result<void> {
@@ -1289,7 +1290,7 @@ auto BuildGenerateArmBody(
 }
 
 auto LowerIfGenerate(
-    ClassLowerer& lowerer, WalkFrame frame,
+    StructuralScopeLowerer& lowerer, WalkFrame frame,
     const GenerateBindings& gen_bindings, const hir::IfGenerate& if_gen)
     -> diag::Result<mir::Stmt> {
   const hir::StructuralScope& enclosing_scope = lowerer.HirScope();
@@ -1318,7 +1319,7 @@ auto LowerIfGenerate(
 }
 
 auto LowerCaseGenerate(
-    ClassLowerer& lowerer, WalkFrame frame,
+    StructuralScopeLowerer& lowerer, WalkFrame frame,
     const GenerateBindings& gen_bindings, const hir::CaseGenerate& case_gen)
     -> diag::Result<mir::Stmt> {
   const hir::StructuralScope& enclosing_scope = lowerer.HirScope();
@@ -1383,7 +1384,7 @@ auto LowerCaseGenerate(
 }
 
 auto LowerLoopGenerate(
-    ClassLowerer& lowerer, WalkFrame frame,
+    StructuralScopeLowerer& lowerer, WalkFrame frame,
     const GenerateBindings& gen_bindings, const hir::LoopGenerate& loop)
     -> diag::Result<mir::Stmt> {
   const hir::StructuralScope& enclosing_scope = lowerer.HirScope();
@@ -1451,7 +1452,7 @@ auto LowerLoopGenerate(
 }
 
 auto LowerGenerateAsStmt(
-    ClassLowerer& lowerer, WalkFrame frame, const hir::Generate& gen,
+    StructuralScopeLowerer& lowerer, WalkFrame frame, const hir::Generate& gen,
     const GenerateBindings& gen_bindings) -> diag::Result<mir::Stmt> {
   return std::visit(
       Overloaded{
@@ -1468,7 +1469,8 @@ auto LowerGenerateAsStmt(
       gen.data);
 }
 
-auto InstallGenerateOwnedChildScopes(ClassLowerer& lowerer, WalkFrame frame)
+auto InstallGenerateOwnedChildScopes(
+    StructuralScopeLowerer& lowerer, WalkFrame frame)
     -> diag::Result<std::vector<GenerateBindings>> {
   ModuleLowerer& module = lowerer.Module();
   mir::Class& mir_class = *frame.current_class;
@@ -1489,7 +1491,7 @@ auto InstallGenerateOwnedChildScopes(ClassLowerer& lowerer, WalkFrame frame)
       CheckNoNameCollision(
           module.Unit(), mir_class, spec.scope_name, companion_name);
 
-      ClassLowerer child_scope(
+      StructuralScopeLowerer child_scope(
           module, &lowerer, std::move(spec.scope_name), *spec.scope);
       auto child_r = child_scope.Run(frame, spec.entry_bindings);
       if (!child_r) return std::unexpected(std::move(child_r.error()));
@@ -1520,13 +1522,13 @@ auto InstallGenerateOwnedChildScopes(ClassLowerer& lowerer, WalkFrame frame)
 
 }  // namespace
 
-auto ClassLowerer::Run(
+auto StructuralScopeLowerer::Run(
     WalkFrame frame,
     std::span<const ScopeEntryStructuralParamBinding> entry_bindings)
     -> diag::Result<mir::ClassId> {
   ModuleLowerer& module = *module_;
   const hir::StructuralScope& hir_scope = *hir_scope_;
-  ClassLowerer& lowerer = *this;
+  StructuralScopeLowerer& lowerer = *this;
 
   // The identity is minted before the body so the object's own self type names
   // it; the registry slot is filled from the finished declaration below.
@@ -1762,7 +1764,7 @@ auto ClassLowerer::Run(
     const mir::MethodId added = mir_class.methods.Add(*std::move(decl_or));
     if (added.value != i) {
       throw InternalError(
-          "ClassLowerer::Run: subroutine added out of mapped "
+          "StructuralScopeLowerer::Run: subroutine added out of mapped "
           "id order");
     }
   }


### PR DESCRIPTION
## Summary

The HIR-to-MIR pass class that consumes a `hir::StructuralScope` and produces a `mir::Class` was named `ClassLowerer` after its MIR output. That is the odd one out among the lowerers, which are otherwise named for the source concept they lower (`ModuleLowerer`, `ProcessLowerer`, and the AST-to-HIR `StructuralScopeLowerer`). Worse, the `mir::Class` it builds is the one generic nominal object shared by modules, generate scopes, and SystemVerilog classes, so the name `ClassLowerer` falsely reads as "the pass that lowers SystemVerilog classes" while having nothing to do with SV `class`. This renames the type to `StructuralScopeLowerer` and its files to `structural_scope_lowerer.{hpp,cpp}`, matching the AST-to-HIR pass over the same concept and freeing the `Class` name for the real SystemVerilog class lowering to come.

The change is behavior-neutral: a pure rename across all references plus the three docs that named the old type, with no logic touched. A few comments that cross-referenced a sister pass by class name were rewritten to state the role instead, so they no longer couple to the class name.