### PR TITLE
Pin hier-ref routing on five-phase lifecycle

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -16,7 +16,7 @@ Read top to bottom on first pass:
 2. `compiler_overview.md` -- pipeline, worldview, compile-time vs runtime
 3. `compilation_unit_model.md` -- what a compilation unit is and owns
 4. `runtime_model.md` -- the constructor / simulation execution-context split
-5. `elaboration_lifecycle.md` -- the build / resolve / initialize / activate phase protocol
+5. `elaboration_lifecycle.md` -- the build / resolve / seal / initialize / activate phase protocol
 6. `specialization_model.md` -- how parameter values refine a unit into specializations
 7. `hir.md` -- source-near semantic IR
 8. `mir.md` -- object-oriented semantic IR (objects, members, callables)
@@ -31,10 +31,10 @@ Read top to bottom on first pass:
     cancellation relations
 14. `scheduling.md` -- stratified event scheduler, regions, suspension protocol
 15. `hierarchy_and_generate.md` -- hierarchy and generate ownership
-16. `reference_resolution.md` -- intra-unit vs cross-unit references; compile-time vs
-    construction-time resolution
-17. `emission_model.md` -- how a backend emits independent per-unit artifacts and realizes
-    cross-unit resolution through the SDK
+16. `reference_resolution.md` -- references as routes from origin to typed endpoint; per-segment
+    classification by layout visibility; sealed endpoint on the hot path
+17. `emission_model.md` -- how a backend emits independent per-unit artifacts and realizes each
+    route segment by visibility (typed for layout-owned, SDK for opaque)
 18. `backend_contract.md` -- per-node within-artifact realization rules; type mapping vs value
     emission; what a backend may and may not name in render
 19. `identity_and_ownership.md` -- identity rules and forbidden shapes
@@ -48,35 +48,35 @@ Read top to bottom on first pass:
 
 If you are looking for a concept, this table points to the canonical doc.
 
-| Concept                                                                   | Canonical doc               |
-| ------------------------------------------------------------------------- | --------------------------- |
-| Primary optimization target; non-negotiable design constraints            | `north_star.md`             |
-| Pipeline (HIR -> MIR -> LIR -> LLVM IR); compile-time vs runtime split    | `compiler_overview.md`      |
-| Compilation unit; class-level artifacts; instance records                 | `compilation_unit_model.md` |
-| Constructor vs simulation execution contexts; structural vs process       | `runtime_model.md`          |
-| Storage and binding vs construction; type-driven member walk              | `runtime_model.md`          |
-| Elaboration phases (build / resolve / initialize / activate); ctor scope  | `elaboration_lifecycle.md`  |
-| Generate as constructor-time logic; object graph shape                    | `hierarchy_and_generate.md` |
-| Instance array as a data type; multiplicity vs generate axes              | `hierarchy_and_generate.md` |
-| Intra-unit vs cross-unit references; compile-time vs construction resolve | `reference_resolution.md`   |
-| Per-unit artifact emission; cross-unit realization via the SDK; no wiring | `emission_model.md`         |
-| Per-node within-artifact render; type mapping vs value emission           | `backend_contract.md`       |
-| Parameter values, specialization keys, per-specialization artifacts       | `specialization_model.md`   |
-| Identity rules; ownership; forbidden identity shapes                      | `identity_and_ownership.md` |
-| Lowering permissions (what each lowering may and may not do)              | `lowering_boundaries.md`    |
-| Lowering pass organization (facts / registry / builder / walk frame)      | `lowering_organization.md`  |
-| HIR shape (statements, expressions, primaries)                            | `hir.md`                    |
-| MIR shape (objects, members, callables)                                   | `mir.md`                    |
-| Member and type model; object types; owning pointer; vector wrapper       | `mir.md`                    |
-| Callable model; code vs value; captures; references as a field type       | `callable.md`               |
-| Object model; nominal object types; inheritance; dispatch; handles        | `object_model.md`           |
-| Object lifetime; managed reclamation; tracing GC; activation frames       | `object_lifetime.md`        |
-| LIR shape (CFG, basic blocks, storage)                                    | `lir.md`                    |
-| Activation; execution instance; completion slot; cancellation domain      | `activation.md`             |
-| Stratified scheduler; regions; suspension protocol; NBA / closure submit  | `scheduling.md`             |
-| Incremental compilation; query-based caching                              | `incremental_build.md`      |
-| Locating/bundling the C++ runtime; run output contract                    | `runtime_distribution.md`   |
-| Test categories; suite layout; expectation forms                          | `testing_strategy.md`       |
+| Concept                                                                             | Canonical doc               |
+| ----------------------------------------------------------------------------------- | --------------------------- |
+| Primary optimization target; non-negotiable design constraints                      | `north_star.md`             |
+| Pipeline (HIR -> MIR -> LIR -> LLVM IR); compile-time vs runtime split              | `compiler_overview.md`      |
+| Compilation unit; class-level artifacts; instance records                           | `compilation_unit_model.md` |
+| Constructor vs simulation execution contexts; structural vs process                 | `runtime_model.md`          |
+| Storage and binding vs construction; type-driven member walk                        | `runtime_model.md`          |
+| Elaboration phases (build / resolve / seal / initialize / activate); ctor scope     | `elaboration_lifecycle.md`  |
+| Generate as constructor-time logic; object graph shape                              | `hierarchy_and_generate.md` |
+| Instance array as a data type; multiplicity vs generate axes                        | `hierarchy_and_generate.md` |
+| Reference routes; per-segment classification by layout visibility; sealed endpoints | `reference_resolution.md`   |
+| Per-unit artifact emission; cross-unit realization via the SDK; no wiring           | `emission_model.md`         |
+| Per-node within-artifact render; type mapping vs value emission                     | `backend_contract.md`       |
+| Parameter values, specialization keys, per-specialization artifacts                 | `specialization_model.md`   |
+| Identity rules; ownership; forbidden identity shapes                                | `identity_and_ownership.md` |
+| Lowering permissions (what each lowering may and may not do)                        | `lowering_boundaries.md`    |
+| Lowering pass organization (facts / registry / builder / walk frame)                | `lowering_organization.md`  |
+| HIR shape (statements, expressions, primaries)                                      | `hir.md`                    |
+| MIR shape (objects, members, callables)                                             | `mir.md`                    |
+| Member and type model; object types; owning pointer; vector wrapper                 | `mir.md`                    |
+| Callable model; code vs value; captures; references as a field type                 | `callable.md`               |
+| Object model; nominal object types; inheritance; dispatch; handles                  | `object_model.md`           |
+| Object lifetime; managed reclamation; tracing GC; activation frames                 | `object_lifetime.md`        |
+| LIR shape (CFG, basic blocks, storage)                                              | `lir.md`                    |
+| Activation; execution instance; completion slot; cancellation domain                | `activation.md`             |
+| Stratified scheduler; regions; suspension protocol; NBA / closure submit            | `scheduling.md`             |
+| Incremental compilation; query-based caching                                        | `incremental_build.md`      |
+| Locating/bundling the C++ runtime; run output contract                              | `runtime_distribution.md`   |
+| Test categories; suite layout; expectation forms                                    | `testing_strategy.md`       |
 
 These docs are the contracts. For the trade-off records behind them -- rejected alternatives and
 load-bearing invariants, grouped by subject -- see the Index in

--- a/docs/architecture/elaboration_lifecycle.md
+++ b/docs/architecture/elaboration_lifecycle.md
@@ -25,16 +25,18 @@ upward reference, input/output initial-value visibility) is a symptom of that co
 
 ## Owns
 
-- The rule that elaboration is a staged protocol with four semantic phases: **Build -> Resolve ->
-  Initialize -> Activate**. These are a contract, not necessarily four separate entry points; an
-  implementation may collapse phases for a unit that needs no separation, but it may never reorder
-  them or let one phase observe a later phase's results.
+- The rule that elaboration is a staged protocol with five semantic phases: **Build -> Resolve ->
+  Seal -> Initialize -> Activate**. These are a contract, not necessarily five separate entry
+  points; an implementation may collapse phases for a unit that needs no separation, but it may
+  never reorder them or let one phase observe a later phase's results.
 - The rule that a generated constructor allocates the instance shell only -- storage cells, port
   endpoint placeholders, the child table -- and runs no SystemVerilog semantic logic.
 - The rule that cross-instance connections are recorded as **declarative facts** during Build and
-  realized during Resolve, with one resolution phase for all reference directions.
-- The rule that variable initialization runs in Initialize, **after** Resolve, so an initializer
-  observes connected and bound values.
+  realized into candidate endpoints during Resolve, then committed at Seal.
+- The rule that Seal is a global barrier on the elaborated design: every required reference is
+  canonicalized, validated, and committed as a final endpoint atomically with respect to Initialize.
+- The rule that variable initialization runs in Initialize, **after** Seal, so an initializer
+  observes only sealed canonical endpoints and bound values.
 - The phase each port-connection realization belongs to, by port semantics.
 - The "observable only after sealing" contract: no SystemVerilog-visible behavior occurs, and no
   instance's incoming bindings are observed, before the phases that establish them complete.
@@ -51,15 +53,15 @@ upward reference, input/output initial-value visibility) is a symptom of that co
 - IR shapes (see `hir.md`, `mir.md`).
 - Event scheduling within simulation after Activate (see `scheduling.md`).
 
-## The four phases
+## The five phases
 
 ### Build
 
 Construct the instance shell and the structural object graph. This phase runs the unit's
 **structural** elaboration: it applies the parameter environment, evaluates generate (`if` / `for` /
 `case`) to decide which children exist, creates child shells (recursively), and **records** the
-unit's connection facts -- port connections, cross-unit reference declarations, hierarchical paths
--- as declarative records. It does **not** execute any value-level SystemVerilog body: no variable
+unit's connection facts -- port connections, hierarchical references, alias bindings -- as
+declarative records. Build does **not** execute any value-level SystemVerilog body: no variable
 initializer, no process body, no port read, no reference dereference.
 
 Generate is Build-phase logic: its conditions are constant expressions (LRM 27.5), available from
@@ -67,22 +69,37 @@ the parameter environment, so generate never depends on Resolve.
 
 ### Resolve
 
-With the full shell graph in existence, realize every cross-instance connection. One phase resolves
-all reference directions -- downward (into an owned child), upward (climb to a named ancestor), and
-`ref` alias bindings -- into stored direct references, and materializes the persistent endpoints
-that reactive edges will read. Because every shell already exists, resolution sees the whole graph
-and is free of the ordering hazards that arise when resolution is interleaved with construction.
+With the full shell graph in existence and every connection fact recorded, execute each reference's
+route. Each route uses typed navigation through layout-visible segments and the runtime SDK across
+unit boundaries; each route produces a **candidate endpoint**. A route whose execution requires
+another reference's sealed endpoint waits for that reference's resolution first; the order respects
+those dependencies, however they are realized.
 
-A `ref` alias is resolved here to a **direct final cell**, flattening any chain: a pass-through
-`Top.z -> Mid.r -> Leaf.r` ends with both `Mid.r` and `Leaf.r` denoting `Top.z`'s cell, never a
-reference that points at another reference. Resolution may require dependency ordering among aliases
-(an alias whose actual is itself a not-yet-resolved reference resolves after it).
+Resolve produces candidates, not committed final endpoints. A candidate may still be a forwarding
+link, and a candidate may yet fail validation. Sealing those is the next phase.
+
+### Seal
+
+Commit every reference's resolved endpoint. Seal is a global barrier on the elaborated design: it
+validates each candidate endpoint against the reference's declared access protocol; collapses every
+forwarding link to the final canonical endpoint; rejects every reference whose route traverses a
+non-constructed runtime object (a non-selected conditional-generate arm, an out-of-range
+instance-array element); and commits each reference's endpoint atomically.
+
+A reference visible to Initialize is sealed; an unsealed reference is invisible. Seal is a property
+of the elaborated design as a whole, not of any single scope -- forwarding chains cross scope
+boundaries and CU boundaries, and a per-scope walk cannot model that.
+
+A forwarding chain ends at a **direct final cell** after Seal, flattening any number of intermediate
+forwarding links: a pass-through `Top.z -> Mid.r -> Leaf.r` ends with both `Mid.r` and `Leaf.r`
+denoting `Top.z`'s cell, never a reference that points at another reference.
 
 ### Initialize
 
-Execute SystemVerilog variable initializers (LRM 6.8 / 10.5). This runs after Resolve, so an
-initializer may read a port, an upward reference, or a `ref` -- all are bound. This is simulation
-time-zero activity, not construction.
+Execute SystemVerilog variable initializers (LRM 6.8 / 10.5). This runs after Seal, so an
+initializer reads only sealed canonical endpoints: a port read returns its bound source's value, an
+upward reference reads its committed target cell, a `ref` read denotes the final aliased storage.
+This is simulation time-zero activity, not construction.
 
 ### Activate
 
@@ -92,43 +109,49 @@ this phase.
 
 ## Core Invariants
 
-1. **Elaboration is staged; the constructor only allocates.** The four phases run in order. A
+1. **Elaboration is staged; the constructor only allocates.** The five phases run in order. A
    generated constructor produces an inert shell; it executes no variable initializer, no process
    body, and no port/reference read.
 2. **Build before Resolve, system-wide.** Every shell and every connection fact exists before any
    cross-instance reference is resolved. Resolution is never interleaved with shell construction.
 3. **Connections are declarative until Resolve.** A port connection or cross-unit reference is a
-   recorded fact after Build; it becomes a stored direct reference only in Resolve. Recording a
+   recorded fact after Build; it becomes a candidate endpoint only in Resolve. Recording a
    connection never requires the other endpoint to be resolved yet.
-4. **Initialize after Resolve.** A variable initializer observes connected and bound values, never
-   an unbound reference or an unconnected port. (This is the invariant our recursive-constructor
-   model violated: an initializer ran during construction, before the relevant binding existed.)
-5. **Reference sealing.** At the end of Resolve, every required reference points directly at a final
-   observable cell. No reference remains a chain to another reference, and none is unresolved.
-6. **Parent-edge ownership.** A connection whose behavior evaluates a parent-side actual expression
+4. **Resolve respects dependency order.** A reference's route may depend on another reference's
+   sealed endpoint to execute. The order in which routes resolve respects those dependencies; a
+   reference whose route requires another's sealed endpoint resolves after that reference seals. The
+   mechanism that realizes this order is unspecified at this layer.
+5. **Seal is a global barrier.** Seal commits each reference's validated, canonical final endpoint
+   atomically with respect to Initialize. No reference observable at or after Initialize is a chain
+   to another reference, an unresolved route, or a candidate that has not validated. Seal collapses
+   every forwarding chain to its final direct cell.
+6. **Initialize after Seal.** A variable initializer observes only sealed canonical endpoints, never
+   an unbound reference, an unsealed forwarding link, or an unconnected port.
+7. **Parent-edge ownership.** A connection whose behavior evaluates a parent-side actual expression
    or depends on parent-side sensitivity is realized as a **parent-owned reactive process**,
    registered in Activate. It is never relocated into the child, which cannot know the parent's
    expression, read-set, or scheduling.
-7. **Observable only after sealing.** No SystemVerilog-visible behavior occurs before Activate, and
-   no instance's incoming bindings are observed before Resolve completes for it.
-   SystemVerilog-visible time-zero ordering is a property of these phases, never an accident of when
-   a C++ constructor returns.
+8. **Observable only after sealing.** No SystemVerilog-visible behavior occurs before Activate, and
+   no instance's incoming bindings are observed before Seal commits them. SystemVerilog-visible
+   time-zero ordering is a property of these phases, never an accident of when a C++ constructor
+   returns.
+9. **The hot path consumes only sealed endpoints.** Simulation-time reads, writes, and observations
+   reach sealed endpoints; no hot-path access performs route traversal, name matching, or resolution
+   lookup. Whatever mechanism orders Resolve and Seal exists only at elaboration; it does not
+   persist into simulation.
 
 ## Boundary to Adjacent Layers
 
 - **The language (LRM 3.12, LRM 4).** Elaboration -- expanding instantiations, computing parameters,
   resolving hierarchical names, establishing connectivity -- happens after parsing and before
-  simulation; this is **Build + Resolve**. Variable initialization and process execution are
+  simulation; this is **Build + Resolve + Seal**. Variable initialization and process execution are
   simulation-time-zero; this is **Initialize + Activate**. The phase split mirrors the elaboration /
   simulation boundary the language already draws.
 - **`runtime_model.md`** defines the constructor / simulation execution-context split. This doc
-  refines that split into the four phases. Where `runtime_model.md` previously placed variable
-  initialization and downward-reference resolution "in the constructor," this doc relocates them to
-  Initialize and Resolve respectively; `runtime_model.md` is updated to point here.
-- **`reference_resolution.md`** owns what a cross-unit reference resolves into and the by-name
-  mechanism. This doc owns _when_: a single Resolve phase, after Build, for all directions. Where
-  `reference_resolution.md` previously split "downward in the constructor, upward at bind," this doc
-  unifies both into Resolve; that doc is updated to point here.
+  refines that split into the five phases.
+- **`reference_resolution.md`** owns _what_ a route segment classifies as and what its endpoint
+  becomes. This doc owns _when_: every reference resolves in Resolve, seals in Seal, and is read on
+  the hot path after Activate.
 - **`hierarchy_and_generate.md`** owns the object tree this lifecycle builds; generate is
   Build-phase constructor-time logic.
 - **`specialization_model.md`** owns parameter strategy, orthogonal to the lifecycle.
@@ -137,30 +160,37 @@ this phase.
 
 - A generated constructor that executes SystemVerilog semantic logic -- a variable initializer, a
   process body, a port read, a reference dereference -- rather than only allocating the shell.
-- Resolving a cross-instance reference inside the constructor that builds the subtree. It forces a
-  child to be fully constructed before its parent can bind it, which is the pass-through `ref`
-  hazard and the construction-time-read hazard.
-- Running a variable initializer before Resolve completes. It observes an unbound reference or an
-  unconnected port.
+- Resolving or sealing a cross-instance reference inside the constructor that builds the subtree. It
+  forces a child to be fully constructed before its parent can bind it, which is the pass-through
+  `ref` hazard and the construction-time-read hazard.
+- Running a variable initializer before Seal completes. It observes an unbound reference, an
+  unsealed candidate, or an unconnected port.
 - A reference that remains a chain (a reference pointing at another reference) or unresolved after
-  Resolve.
+  Seal.
+- A per-scope walk that pretends to seal. Seal is a global property of the elaborated design;
+  per-scope sealing cannot model cross-scope forwarding.
+- Resolution dispatched on the frontend's lexical-form classification or on source order. The
+  mechanism follows the route's segment layout visibility, not the form that named the target.
 - Realizing an input or output port as anything other than a parent-owned reactive process, or
   relocating that process into the child.
 - Realizing a `ref` port as a persistent cross-unit slot or a value-cell access path. A `ref` port
-  is a one-time alias binding performed in Resolve; it owns no child-side cell and needs no
+  is a forwarding link resolved away during Seal; it owns no child-side cell and needs no
   simulation-time reach from the parent.
 - Letting "when the C++ constructor returns" determine any SystemVerilog-observable ordering.
+- Reading a route's endpoint on the simulation hot path via hierarchy traversal or by-name lookup.
+  Every nonlocal hot-path read consumes a sealed endpoint; whatever resolution mechanism produced it
+  exists only across elaboration.
 
 ## Notes / Examples
 
 **The three port semantics land in different phases.** They share only the connection _fact_
 recorded in Build; their realization differs.
 
-| Port               | Realization                                                                                                                                               | Phase                 |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| `input` / `output` | parent-owned directional reactive edge (an implied continuous assignment); persistent endpoint resolved in Resolve, process registered/seeded in Activate | Resolve + Activate    |
-| `ref`              | one-time alias binding of the child's reference member to the actual's final cell; no child cell, no persistent slot                                      | Resolve               |
-| `inout`            | attachment of both terminals to one net connectivity / resolution domain (a separate net model)                                                           | deferred (net domain) |
+| Port               | Realization                                                                                                                                                   | Phase                     |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `input` / `output` | parent-owned directional reactive edge (an implied continuous assignment); persistent endpoint resolved in Resolve, sealed in Seal, process armed in Activate | Resolve + Seal + Activate |
+| `ref`              | forwarding link; the child's reference member sealed to the actual's final cell                                                                               | Resolve + Seal            |
+| `inout`            | attachment of both terminals to one net connectivity / resolution domain (a separate net model)                                                               | deferred (net domain)     |
 
 **Pass-through `ref`.**
 
@@ -170,11 +200,11 @@ module Mid(ref int r);
 endmodule
 ```
 
-Build records the alias fact `Mid.c.r <- Mid.r` declaratively, without resolving it -- `Mid.r` may
-be unbound at that point, which is fine because no value-level code runs in Build. Resolve, with the
-whole graph present, resolves `Mid.r` first and then `Leaf.r`, flattening both to the final cell.
-The hazard that exists when `Mid`'s constructor builds `Leaf` before `Mid.r` is bound simply does
-not arise, because binding is not a constructor step.
+Build records two reference facts: `Mid.r` (alias of the parent's connected cell) and `Mid.c.r`
+(alias of `Mid.r`). `Mid.c.r` resolves after `Mid.r` because it requires `Mid.r`'s sealed endpoint;
+Seal collapses both to the final cell `Mid.r` ultimately aliases. The hazard that existed when
+`Mid`'s constructor built `Leaf` before `Mid.r` was bound does not arise: binding is not a
+constructor step.
 
 **An initializer that reads a port.**
 
@@ -184,9 +214,24 @@ module Child(ref int r);
 endmodule
 ```
 
-`x = r` runs in Initialize, after `r` is bound in Resolve, so it reads the aliased cell's value. In
-a recursive-constructor model this read would execute during `Child`'s construction, before the
-parent bound `r` -- the bug this lifecycle removes.
+`x = r` runs in Initialize, after `r` is sealed in Seal, so it reads the aliased cell's value. In a
+recursive-constructor model this read would execute during `Child`'s construction, before the parent
+bound `r` -- the bug this lifecycle removes.
+
+**A sibling-of-sibling hierarchical reference.**
+
+```
+module Top;
+  if (1) begin : a int ax; always_comb from_b = b.bx; end
+  if (1) begin : b int bx; always_comb from_a = a.ax; end
+endmodule
+```
+
+Both `a.bx` and `b.ax` are references recorded in Top's elaborated design. Build constructs `a` and
+`b` in either order; both produce reference records. Resolve walks each route through the typed
+parent edge into Top and the typed member access into the sibling's class; neither route depends on
+the other's resolution. Seal commits each reference's endpoint. `always_comb` bodies read sealed
+endpoints; the source order of `a` and `b` does not affect mechanism.
 
 **Baked parameters are orthogonal.** When a parameter is baked into a specialization, "apply the
 parameter environment" in Build is trivial (the value is a compile-time constant in that

--- a/docs/architecture/emission_model.md
+++ b/docs/architecture/emission_model.md
@@ -51,48 +51,44 @@ non-conforming code, not as a relaxation of the contract.
    cannot resolve from its own inputs are expressed as SDK operations. In the C++ backend the SDK is
    the runtime library; under LLVM its operations become intrinsics the linker resolves. A backend
    never invents a second cross-unit mechanism outside the SDK.
-4. **A cross-unit reference resolves once into a stored direct reference.** It resolves once -- in
-   the constructor for downward, at Bind for upward -- after which the simulation-time read and
-   change observation read it directly with no per-access lookup (`reference_resolution.md` inv 3,
-   5). How the reference is stored and filled differs by direction.
-5. **Storage and fill by direction:**
-   - **Downward** -- the target lives inside a unit the referrer instantiates, a declared
-     dependency. The referrer holds a slot it fills in its constructor by navigating its owned child
-     to the referenced member. Because the sub-module is a declared dependency, the navigation is
-     bound when the artifacts are linked; the referrer emits the access by name and the link
-     resolves it, carrying no offset.
-   - **Upward** -- the ancestor is one the referrer does **not** instantiate, so it is not a
-     dependency and is unknown to the referrer at compile time. The referrer holds the reference as
-     an ordinary member whose type marks it external; at Bind that member navigates the runtime
-     object graph (the parent chain) to the ancestor named by the reference, matching its instance
-     name or module definition name (LRM 23.8), then steps down any remaining path through the
-     ancestor's owned children by name, and obtains the leaf signal through the SDK. The referrer's
-     artifact carries zero knowledge of the ancestor's or those children's units -- it never names
-     their types and never includes their artifacts, and no cross-unit slot or side table records
-     the upward reference.
+4. **A reference's route resolves once and seals into a sealed endpoint.** Routes execute in
+   Resolve; each route produces a candidate endpoint that the sealing barrier commits as the
+   reference's final access point. The simulation-time read and change observation read the sealed
+   endpoint directly with no per-access lookup (`reference_resolution.md` inv 3, 5).
+5. **Storage and fill by segment layout visibility.** A route is a sequence of segments; each
+   segment's realization is determined by whether the emitting artifact owns the segment's source
+   and target classes:
+   - **Layout-visible segment** -- both classes live in the emitting artifact. Realization is typed
+     navigation through stable MIR member identities. The emitted code reaches the next pointer /
+     class member via a typed access expression; no string lookup, no SDK call.
+   - **Opaque segment** -- the segment crosses into another compilation unit's body. Realization is
+     one runtime-SDK by-name lookup, executed once at Resolve. The opaque segment carries the
+     canonical name (interface or registered signal name) and any indices it needs; it never names
+     the other unit's internal members, fields, or child types. A single route may alternate; an
+     artifact emits typed prefix code for the layout-visible segments and SDK calls for the opaque
+     ones, composed in route order. The sealed endpoint is one access point regardless of how many
+     segments of each kind the route contained.
 6. **A unit exposes its hierarchically reachable signals and owned children through the SDK.** So
-   that an upward referrer (which cannot name the ancestor's or an intervening child's type) can
-   reach a signal in an ancestor found only at runtime, each unit registers its reachable signals
-   and its owned children by name into the object graph node during construction, and the base SDK
-   answers a by-name query from those registrations -- the unit never inspects who asks, and the
-   dispatch is one generic scan, not a per-unit synthesized branch. The referrer walks that surface
-   once at construction and stores the direct reference; it never embeds another unit's layout.
+   that any artifact's opaque segments can reach into a unit whose body it does not know, each unit
+   registers its reachable signals and its owned children by name into the object graph node during
+   construction, and the base SDK answers a by-name query from those registrations -- the unit never
+   inspects who asks, and the dispatch is one generic scan, not a per-unit synthesized branch. The
+   referrer's emission consumes those registrations through one route execution and stores the
+   sealed endpoint; it never embeds another unit's layout.
 
 ## Boundary to Adjacent Layers
 
 - `compilation_unit_model.md` defines the unit and its interface; this doc defines what a unit's
   _emitted artifact_ may depend on, which is exactly that interface plus the SDK.
-- `reference_resolution.md` defines that a cross-unit reference resolves once at construction into a
-  stored direct reference; this doc defines how a backend realizes that without breaking unit
-  independence (downward link-binding into a slot vs upward runtime navigation through an extern
-  member).
+- `reference_resolution.md` defines route segment classification and the sealing contract; this doc
+  defines how a backend realizes each segment kind without breaking unit independence.
 - `backend_contract.md` defines the per-node within-an-artifact realization rules: how a MIR node
   becomes target-language source. This doc draws the artifact boundary; `backend_contract.md`
   governs what happens inside.
 - `runtime_distribution.md` owns where the SDK/runtime lives; this doc owns the SDK's role as the
-  resolution substrate.
-- `runtime_model.md` places the fill in the constructor context and the read in the simulation
-  context.
+  opaque-segment resolution substrate.
+- `runtime_model.md` places route execution in the constructor context and the read in the
+  simulation context.
 
 ## Forbidden Shapes
 
@@ -100,34 +96,51 @@ non-conforming code, not as a relaxation of the contract.
   global "wiring" file). This is the canonical violation: it serializes otherwise-independent
   compilation and reintroduces an undeclared whole-design dependency.
 - A referrer's artifact that names, includes, or casts to the type of a unit it does not instantiate
-  -- in particular, an upward reference naming its ancestor's unit type.
-- Embedding another unit's storage offset in the referrer's own emitted output to resolve a
-  cross-unit reference (as opposed to emitting a by-name access the link resolves).
-- A design-global signal or path table that mirrors the object graph. Cross-unit resolution is local
-  object-graph navigation (an owned child, or the parent chain), resolved once at construction; a
-  per-object by-name signal lookup at construction is local and permitted, a global flat table is
-  not.
-- A per-access cross-unit lookup on the simulation path; the hot path reads the stored reference.
-- A second cross-unit access mechanism that bypasses the SDK and the resolved stored reference.
+  -- in particular, an opaque-segment realization naming the target unit's internal type, member, or
+  field.
+- Embedding another unit's storage offset in the referrer's own emitted output. An opaque segment is
+  by-name through the SDK; a layout-visible segment uses a stable in-artifact member identity, not
+  an offset.
+- A route mechanism dispatched on the frontend's lexical-form classification or on source order.
+  Mechanism follows segment layout visibility.
+- A reference shape that splits cross-unit and intra-unit references into separate IR species,
+  separate install paths, separate vocabulary items. One reference, one route, one sealing.
+- A design-global signal or path table that mirrors the object graph. Opaque segments resolve
+  through local object-graph navigation (the parent chain, an owned child); a per-object by-name
+  registration is local and permitted, a global flat table is not.
+- A per-access cross-instance lookup on the simulation path; the hot path reads a sealed endpoint.
+- A second cross-instance access mechanism that bypasses the SDK and the sealed endpoint.
+- An IR vocabulary item modeling a particular SDK opaque-segment resolver shape (a named-method
+  family carrying bind state, a wrapper-typed member kind). The SDK chooses how an opaque segment
+  resolves; the IR vocabulary names only segments, route, and endpoint.
+- A binding installed in the constructor block. Routes execute in Resolve and seal in Seal; ctor
+  allocates the shell only.
 
 ## Notes / Examples
 
-`always_comb r = c.x;` (downward): `c` is a unit the parent instantiates, so `c`'s interface is a
-declared input to the parent's emission and `x` is bound when the artifacts are linked. The parent
-emits a by-name access; the link resolves it; the parent's own output carries no offset.
+**Same-unit sibling reference.** `always_comb from_b = b.bx;` inside generate block `a` of `Top`.
+The route has two segments: `a -> Top` (typed; the parent edge whose target class lives in Top's
+artifact) and `Top -> b -> bx` (typed; sibling member access plus variable access, both in Top's
+artifact). Top's emission produces a typed pointer chain; no SDK call. Resolve produces the
+candidate endpoint; Seal commits the variable's cell.
 
-`always_comb x = Top.g;` (upward): `Top` is an ancestor the referrer does not instantiate, so the
-referrer knows nothing about `Top` at compile time. It cannot name `Top` or include its artifact.
-The referrer holds the reference as an ordinary member whose type marks it external; at Bind that
-member climbs the enclosing chain to the scope denoted by the head's canonical structural identity
-(the frontend resolves and canonicalizes the head; runtime does not re-implement name-resolution
-semantics), obtains the `g` signal from that scope through the SDK, and stores the direct reference.
-The simulation-time read and change observation then read that member directly
-(`reference_resolution.md` inv 5); no cross-unit slot or side table records the reference.
-Construction state for the extern member (the canonical head identity, the descent suffix, the leaf
-signal name) arrives as ordinary MIR primitives in the constructor body, not as type payload --
-`backend_contract.md` keeps render mechanical.
+**Cross-unit downward reference.** `always_comb r = c.x;`. The route has two segments: `parent -> c`
+(typed; the parent's artifact owns the `c` member's pointer type) and `c -> x` (opaque; `x` lives
+inside `c`'s unit). The parent's artifact emits the typed access for the first segment, then an SDK
+by-name lookup for the second; the SDK answers from `c`'s registered signals.
+
+**Cross-unit upward reference.** `always_comb x = Top.g;`. The referrer does not instantiate `Top`.
+The entire route is opaque: the SDK climbs the runtime tree by canonical instance name to the scope
+identified by the head, then performs a by-name signal lookup. The referrer's artifact carries zero
+knowledge of Top's body; the route's segments arrive as ordinary MIR primitives in the emitted
+resolve code, not as type payload -- `backend_contract.md` keeps render mechanical.
+
+**Mixed route.** `top.gen.child.x` from outside `top`: the first two segments (`top -> gen`,
+`gen -> child`) are typed because `top`, `gen`, and `gen.child` (a member of `gen`'s class) all live
+in `top`'s artifact. The final segment (`child -> x`) is opaque because `x` lives in `child`'s unit.
+The route alternates typed and opaque segments cleanly; the sealed endpoint is one access point
+regardless.
 
 Any artifact that aggregates multiple units' bodies into one is forbidden, however a build step
-packages the emitted sources: the per-unit artifact boundary and the resolution rules above are the
-contract every backend must satisfy.
+packages the emitted sources: the per-unit artifact boundary and the segment-classification rules
+above are the contract every backend must satisfy.

--- a/docs/architecture/hierarchy_and_generate.md
+++ b/docs/architecture/hierarchy_and_generate.md
@@ -65,6 +65,13 @@ shared by all consumers: external references, child routing, and construction.
     consumer reconstructs the bracketed name by reverse-searching a parent registry, and the parent
     never re-states an identity the child already carries. `%m`, hierarchical paths, debug output,
     and by-name lookup all read from this single source.
+11. A reference targeting a non-constructed runtime object is a sealing failure with a user
+    diagnostic, never a runtime fallback. A conditional-generate arm not selected at Build has a
+    class declaration but no runtime scope; a hierarchical reference whose route traverses such an
+    arm cannot seal. The same rule covers an out-of-range instance-array element and any other
+    object whose declaration exists at compile time but whose runtime object is absent in the
+    elaborated design. The reference is rejected at the sealing barrier; route execution does not
+    silently substitute a null, a default, or an alternate target.
 
 ## Boundary to Adjacent Layers
 
@@ -107,6 +114,10 @@ shared by all consumers: external references, child routing, and construction.
 - A scope's base constructor side-effecting its own attachment into the parent. Attachment is one
   explicit operation the parent performs once the child is fully constructed and its typed owner has
   committed, so a partially-built child is never visible in the parent's adjacency relation.
+- A runtime fallback for a reference whose route traverses a non-constructed object (a non-selected
+  conditional-generate arm, an out-of-range instance-array element). Such references are rejected at
+  the sealing barrier as user-diagnosable elaboration errors; substituting a null, a default value,
+  or an alternate object hides a SystemVerilog semantic violation.
 
 ## Notes / Examples
 

--- a/docs/architecture/mir.md
+++ b/docs/architecture/mir.md
@@ -143,6 +143,20 @@ suspect, not the analysis (`lowering_organization.md` states this discipline in 
     source level still expose it explicitly in their IRs (LLVM IR's first parameter, Python's
     `__call__(self, ...)`); MIR does the same. A static method, like a free function, takes none._
 
+12. A nonlocal cross-instance reference is one MIR shape; lexical form does not split it into
+    species. A reference whose target lives across an instance boundary is the same MIR concept
+    whether the source spelling reached it as a bare name, a downward dotted name, an upward dotted
+    name, or an absolute path. _Programming-language consequence: a program has one kind of "name
+    that reaches another scope's value"; the syntax that named it is not a structural fact about the
+    reference._
+
+13. A nonlocal reference's runtime endpoint seals before any read observes it, and is read directly
+    thereafter. The act of reaching across an instance boundary -- traversing the object graph,
+    matching a name, running by-name lookup -- happens once during elaboration; the hot path reads
+    the sealed endpoint without traversing. _Programming-language consequence: in the same way a
+    Rust binding once initialized refers to its target by address rather than re-locating it on
+    every use, a MIR reference's runtime cost is paid at sealing, not at access._
+
 ## Boundary to Adjacent Layers
 
 - Consumes HIR. HIR-to-MIR is the layer where SV-specific concepts get translated into MIR's generic
@@ -223,6 +237,25 @@ implies; the diagnostic for any new forbidden shape is "what identity property d
   through `LocalRef`; member access reads the receiver from the containing `MemberAccess`'s receiver
   field, never from a node that means "look around and figure it out". (Programming languages do not
   have expressions whose meaning depends on syntactic context.)
+- A HIR or MIR shape that splits a nonlocal reference by lexical form into separate species. The
+  syntax that named the target is not a structural fact about the reference; one shape carries every
+  nonlocal reference, and the mechanism that realizes it follows where the target lives relative to
+  the emitting artifact, not the form that named it.
+- An IR-level vocabulary item modeling a particular runtime library's resolver shape -- a wrapper
+  type for "the cross-tree upward resolver", a named-method family for one runtime API's bind state.
+  Runtime library shapes belong to the runtime; IR vocabulary names only the reference, its route
+  segments, and its sealed endpoint, and runtime library calls appear through the existing call
+  vocabulary.
+- A reference whose mechanism is selected by a frontend-supplied lexical-form discriminator at MIR
+  consumption time. The form that produced a reference is consumed at AST-to-HIR; no MIR consumer
+  reads it.
+- An identity for a layout-visible route segment that is a textual name. A segment whose source and
+  target classes are both owned by the emitting artifact has a stable in-artifact identity; textual
+  names belong to segments crossing the unit boundary, where the by-name SDK consumes them.
+- A MIR shape that decides a sealed reference's storage placement at this layer. Whether a sealed
+  endpoint is materialized as a stored member, hoisted into a local, or rematerialized at each use
+  is a layout choice owned by LIR; MIR states the reference's identity, its route, and the protocol
+  the body uses to access it.
 
 ## Notes / Examples
 

--- a/docs/architecture/reference_resolution.md
+++ b/docs/architecture/reference_resolution.md
@@ -2,23 +2,24 @@
 
 ## Purpose
 
-Define how a reference reaches its target, and when. Every reference resolves to a concrete target;
-the compilation-unit boundary decides the timing. A reference whose target is in the same unit
-resolves at compile time. A reference whose target is in another unit resolves once at construction.
-The same resolution serves both accessing the target's value and observing its changes.
+Define how a reference reaches its target. A route from referrer to target is a sequence of
+segments; each segment's realization follows whether the emitting artifact owns its layout. The same
+resolution serves both accessing the target's value and observing its changes.
 
 ## Owns
 
-- The classification of a reference as intra-unit or cross-unit by where its target lives relative
-  to the referrer's compilation unit.
-- The rule that an intra-unit reference resolves at compile time and a cross-unit reference resolves
-  once at construction into a stored direct reference.
-- The contract that cross-unit resolution is total: a resolution that fails is a compiler-invariant
-  violation, not a user error.
-- The contract that port connections, hierarchical references, and cross-instance triggers all reach
-  across the unit boundary through a cross-unit reference on one shared resolution path.
-- The contract that a cross-unit reference's resolution serves both accessing the target and
-  observing its changes, through one resolved reference.
+- The decomposition of a reference's route into segments and the rule that each segment is
+  classified independently by layout visibility.
+- The rule that a layout-visible segment realizes as typed navigation through stable member
+  identities, and an opaque segment realizes as a runtime-SDK by-name lookup.
+- The contract that route execution is total: a route that fails to seal is either a
+  user-diagnosable elaboration error (a non-constructed target, a forwarding cycle with no storage
+  root) or a compiler-invariant violation, never a runtime fallback.
+- The contract that port connections, hierarchical references, and cross-instance trigger
+  subscriptions all flow through the same binding-graph route mechanism. No form has its own
+  parallel resolution.
+- The contract that a sealed endpoint serves both value access and change observation through one
+  stored reference.
 - The rule that connectivity is linkage between objects and never alters what an object owns.
 
 ## Does Not Own
@@ -26,116 +27,131 @@ The same resolution serves both accessing the target's value and observing its c
 - The shape of the object graph, the construction order, and the graph's faithfulness to the
   frontend's elaboration (see `hierarchy_and_generate.md`). This doc relies on that faithfulness but
   does not establish it.
-- The compilation-unit boundary that defines what counts as intra-unit (see
+- The compilation-unit boundary that defines which segments are layout-visible (see
   `compilation_unit_model.md`).
-- The compile-time id kinds for intra-unit versus cross-unit references (see
-  `identity_and_ownership.md`, `hir.md`, `mir.md`).
-- How an observed cross-unit change wakes a dependent process (see `scheduling.md`).
+- The compile-time identity kinds used to thread route segments (see `identity_and_ownership.md`,
+  `hir.md`, `mir.md`).
+- How an observed change wakes a dependent process (see `scheduling.md`).
 - Storage placement and offsets of members (see `lir.md`).
+- The phases the route executes in (see `elaboration_lifecycle.md`).
 - Net resolution and net merging across ports (a single simulated net shared by both sides). That is
   a design-global net-resolution concern, separate from per-object reference resolution.
 
 ## Core Invariants
 
-1. Every reference resolves to a concrete target and is classified as intra-unit or cross-unit by
-   where that target lives relative to the referrer's compilation unit.
-2. An intra-unit reference resolves at compile time. The unit knows the layout of every object it
-   constructs, so the target is a constructed-object reference the unit owns plus a compile-time
-   offset. A reference into a generate scope is intra-unit even though the scope is a distinct
-   runtime object: the generate scope belongs to the same unit, so its layout is known at compile
-   time.
-3. A cross-unit reference cannot be resolved at compile time, because the target lives inside
-   another independently compiled unit whose layout is not visible during this unit's compilation.
-   It is resolved once, at construction, when the program is linked and the target unit's layout is
-   available, and stored as a direct reference to the target object's member. Simulation-time access
-   reads the stored reference directly, with no per-access lookup. The same stored reference serves
-   both value access and change observation; sensitivity to a cross-unit member rides this
-   reference, not a separate path.
-4. Cross-unit resolution is total. Every cross-unit reference is resolvable, because the frontend
-   fully elaborated and validated it before lowering and the constructed object graph is faithful to
-   that elaboration (see `hierarchy_and_generate.md`). A resolution that fails at construction is an
-   `InternalError`, never a user diagnostic and never a runtime fallback.
-5. Port connections, downward and upward hierarchical references, and cross-instance trigger
-   subscriptions all reach across the unit boundary through a cross-unit reference and share the
-   single resolution path. No form has its own parallel resolution.
+1. Every reference is a route from a structural origin to an endpoint. The route is a sequence of
+   segments; the endpoint, once sealed, is the canonical access point for every read, write, and
+   observation against the reference.
+2. Each segment is classified by layout visibility. A **layout-visible** segment's source class and
+   target class are both owned by the emitting artifact; its realization is typed navigation through
+   stable member identities, with no string lookup and no SDK call. An **opaque** segment crosses
+   into another compilation unit's body; its realization is a runtime-SDK by-name lookup. A single
+   route may alternate segments freely.
+3. A reference's route executes once during the binding-graph phase, producing a candidate endpoint;
+   the endpoint is committed at the sealing barrier and read directly thereafter. Simulation-time
+   access reads the sealed endpoint with no per-access lookup, no hierarchy traversal, and no name
+   matching. One sealed endpoint serves both value access and change observation.
+4. Route execution is total in the architecture's contract. The frontend fully elaborates and
+   validates every reference, and the constructed object graph is faithful to that elaboration (see
+   `hierarchy_and_generate.md`). A reference to a non-constructed runtime target (a non-selected
+   conditional-generate arm, an out-of-range instance-array element) is rejected at the sealing
+   barrier with a user diagnostic; a route whose segments cannot otherwise execute is an
+   `InternalError`.
+5. Port connections, hierarchical references, and cross-instance trigger subscriptions share one
+   route mechanism. There is no parallel resolution path per reference kind, per direction, or per
+   lexical form.
 6. Connectivity is linkage between objects. For a variable member it never removes the object's
-   storage, never changes the object's layout, and never makes an intra-unit member's addressing
-   depend on what it is wired to. (Merging nets into a single shared net is a design-global
-   net-resolution concern, outside this contract.)
+   storage, never changes the object's layout, and never makes a member's addressing depend on what
+   it is wired to. (Merging nets into a single shared net is a design-global net-resolution concern,
+   outside this contract.)
+7. The endpoint inherits the access protocol of the target it reaches. A reference to an observable
+   storage cell reads and writes through the cell's protocol; a reference to a class handle
+   dereferences the handle, then operates on the class object; a reference to an event participates
+   in the event's protocol. The endpoint is not a new access category; it is the target's access
+   surface reached through a sealed direct path.
 
 ## Boundary to Adjacent Layers
 
-- `compilation_unit_model.md` owns the unit boundary. Intra-unit is "inside this unit"; cross-unit
-  is "across that boundary".
-- `hierarchy_and_generate.md` owns the object graph that a cross-unit reference resolves into, and
-  the faithfulness of that graph to the frontend's elaboration that makes cross-unit resolution
-  total.
-- `runtime_model.md` places resolution of cross-unit references in the constructor context and the
-  access in the simulation context. A cross-unit reference resolves at t = 0 and is read or written
-  at t >= 0.
-- `elaboration_lifecycle.md` owns _when_ within t = 0 a reference resolves: a single resolve phase
-  after the whole shell graph is built, for all directions. It supersedes any "downward resolved
-  inside the constructor, upward at bind" reading -- both resolve in that one phase -- and requires
-  every reference to seal to a direct final cell (no reference-to-a-reference) before initializers
-  run.
-- `identity_and_ownership.md` requires a cross-unit reference to be a distinct id kind from an
-  intra-unit id.
-- `scheduling.md` owns the wakeup that fires when a resolved cross-unit member changes.
+- `compilation_unit_model.md` owns the unit boundary that decides which segments are layout-visible
+  to which artifact.
+- `hierarchy_and_generate.md` owns the object graph the routes navigate and the faithfulness of that
+  graph to the frontend's elaboration that makes route execution total.
+- `runtime_model.md` places route execution in the constructor context (the binding-graph phases at
+  t = 0) and access in the simulation context (t >= 0).
+- `elaboration_lifecycle.md` owns _when_ a route executes and seals. Routes execute in Resolve;
+  endpoints commit in Seal; initializers and reads observe only sealed endpoints.
+- `identity_and_ownership.md` owns the identity rules that route segments thread.
+- `scheduling.md` owns the wakeup that fires when a sealed endpoint's underlying cell changes.
 
 ## Forbidden Shapes
 
-- Compiled body code that bakes in another unit's layout to resolve a cross-unit reference at
-  compile time.
-- Resolving a cross-unit reference from the target's side: the referenced unit wiring, pushing, or
-  storing its own member into the units that reference it. A unit compiles against its own interface
-  and cannot know who references it, so it never drives resolution for a consumer and never carries
-  a list of its referrers. Every cross-unit reference -- downward or upward -- is driven by the
-  referrer, which reaches the target by name at construction; the target only answers by-name
-  queries about its own interface.
-- The referrer reaching a cross-unit target by typed member access into the other unit's body
-  (naming the other unit's members, fields, or child types) instead of by name against its
-  interface. Typed access bakes the target unit's layout into the referrer and breaks independent
-  compilation -- this holds even for a downward reference whose referrer instantiated the target,
-  and even when the access is evaluated at construction rather than compile time. The referrer knows
-  the target's name, never its layout.
+- Compiled body code that bakes another unit's layout to realize an opaque segment at compile time.
+  An opaque segment is by-name through the SDK by definition; baking the target's layout is the
+  canonical artifact-boundary violation.
+- Route mechanism dispatched on the frontend's lexical-form classification or on source order. The
+  mechanism follows each segment's layout visibility; the form that named the target is not visible
+  past the AST-to-HIR boundary.
+- A reference shape per direction or per lexical form (as separate species). One semantic shape; one
+  route decomposition.
+- Resolution driven from the target's side: the referenced unit wiring, pushing, or storing its own
+  member into the units that reference it. A unit compiles against its own interface and cannot know
+  who references it, so it never drives resolution for a consumer and never carries a list of its
+  referrers. Every route's opaque segment is driven by the referrer, which reaches the target by
+  name at Resolve; the target only answers by-name queries about its own interface.
+- A typed segment crossing into another unit's body, naming the other unit's members, fields, or
+  child types. Typed segments stay within the artifact that owns both the source and target class;
+  the segment that crosses the unit boundary is opaque by contract.
 - A resolution path for ports that is distinct from the one for hierarchical references. Two
-  mechanisms for cross-unit access is the canonical violation.
-- Resolving a cross-unit reference by flattened symbol-name lookup or a design-global path table
-  that mirrors the object graph.
-- A per-access runtime lookup on the simulation path. Cross-unit references resolve once at
-  construction; the hot path reads a stored direct reference.
-- A cross-unit reference keyed or resolved by a design-global coordinate, ordinal, or instance id.
-- A user-facing diagnostic or a runtime fallback for a cross-unit reference that fails to resolve.
-  Such a failure is a compiler-invariant violation and raises `InternalError`.
+  mechanisms for cross-instance access is the canonical violation.
+- Resolution by flattened symbol-name lookup or a design-global path table that mirrors the object
+  graph.
+- A per-access runtime lookup on the simulation path. Routes execute once during elaboration; the
+  hot path reads a sealed endpoint. A hot-path read that performs any hierarchy traversal, parent
+  walk, or by-name lookup is the canonical hot-path violation.
+- A route keyed or resolved by a design-global coordinate, ordinal, or instance id.
+- A reference whose sealing failure is silently swallowed at runtime. A user-diagnosable failure
+  (non-constructed target, forwarding cycle without storage root) surfaces a user diagnostic; an
+  impossible-by-contract failure raises `InternalError`. There is no runtime fallback.
+- A binding installed in the constructor block. Routes execute in Resolve and seal in Seal; ctor
+  allocates the shell only.
+- A runtime library wrapper for a particular resolver strategy appearing as an IR concept. Wrappers
+  belong to the runtime; HIR and MIR vocabulary names only the reference, its route, and its
+  endpoint.
+- A forwarding wrapper observed on the hot path. Forwarding chains collapse to the final endpoint at
+  sealing; a sealed endpoint reaches its target directly.
 - Connectivity that eliminates an object's local storage for a member, or that changes the object's
   layout based on what the member is wired to.
-- Intra-unit member addressing that differs between a wired and an unwired member.
+- Member addressing that differs between a wired and an unwired member.
 
 ## Notes / Examples
 
-`always_comb r = c.x;` inside a parent module, where `c` is a child module instance: the target `x`
-lives inside `c`'s unit, so this is a cross-unit reference. The parent's compiled body does not know
-`x`'s offset. At construction, once `c` is built, the reference resolves to `c`'s storage for `x`
-and is stored; the process then reads it directly. Because the body reads `c.x`, the process is also
-sensitive to it: the re-evaluation when `c.x` changes rides the same resolved reference, not a
-separate sensitivity path. An input port `.x(src)` and an upward reference `Parent.v` are also
-cross-unit references and resolve through the same path; they are not separate features.
+**Same-unit sibling reference.** `always_comb from_b = b.bx;` inside generate block `a` of `Top`,
+where `b` is a sibling generate of `a`. The route has two segments: `a -> Top` (the typed parent
+edge) and `Top -> b -> bx` (typed member access into the sibling generate's class then into its
+variable). Both segments are layout-visible: `Top`'s artifact owns `a`'s class, `b`'s class, and the
+`bx` member. The route executes the typed chain once and seals to the variable's cell. The mechanism
+does not depend on whether `a` is declared before or after `b`.
 
-A multi-segment path mixes both kinds. In `top.gen.child.x`, navigating `top.gen` is intra-unit (the
-generate scope belongs to `top`'s unit), reaching `gen.child` is an intra-unit reference to a child
-object the unit owns, and `child.x` crosses into `child`'s unit. The reference's classification
-follows its final target: `x` is cross-unit. Construction performs the full navigation once and
-stores the direct reference to `x`.
+**Cross-unit downward reference.** `always_comb r = c.x;` inside a parent module, where `c` is a
+child module instance: the route has two segments: `parent -> c` (typed; the parent's artifact owns
+the `c` member's pointer type) and `c -> x` (opaque; `x` lives inside `c`'s unit, whose body is not
+visible). The typed segment executes by member access, the opaque segment by SDK by-name lookup, and
+the route seals to the variable's cell. The body reads the sealed endpoint; sensitivity rides the
+same endpoint.
 
-A module port connection reaches across the unit boundary through a cross-unit reference, resolved
-at construction like any other. The connection's form follows the port: an input or output port is a
-continuous assignment between the two objects' own storage (LRM 23.3.3, 23.3.3.2), with the
-cross-unit side resolved as a reference; a `ref` port is itself a hierarchical reference to the
-connected variable, with no separate storage (LRM 23.3.3.2); an `inout` port is a bidirectional net
-connection and belongs to the deferred net-resolution domain (LRM 23.3.3.2). For input, output, and
-`ref` ports the cross-unit reach uses the one resolution path.
+**Multi-segment mixed route.** In `top.gen.child.x`, `top.gen` is typed (the generate scope belongs
+to top's unit), `gen.child` is typed (`child` is a member of `gen`'s class in the same unit), and
+`child.x` is opaque (it crosses into `child`'s unit). The route alternates two typed segments and
+one opaque segment; the SDK is reached only at the boundary crossing.
 
-Resolution is deferred, not dynamic. The deferral to construction is a compilation-architecture
-choice that keeps each unit independently and incrementally compilable; it carries no semantic
-uncertainty. The frontend has already proven every cross-unit reference has a determinate target, so
-construction always succeeds.
+**Port connections share the routing.** An input or output port is a continuous-assignment edge
+between the two objects' own storage (LRM 23.3.3); the cross-unit side reaches the partner cell
+through one route. A `ref` port (LRM 23.3.3.2) is a forwarding link that resolves to the connected
+cell at sealing. An `inout` port is a bidirectional net connection and belongs to the deferred
+net-resolution domain. Every form whose cross-instance reach passes through Resolve shares the one
+route mechanism.
+
+**Routing is deferred to Resolve, not dynamic.** The deferral keeps each unit independently and
+incrementally compilable; it carries no semantic uncertainty. The frontend has already proven every
+reference has a determinate target, so route execution always succeeds (or surfaces a
+user-diagnosable elaboration error at the sealing barrier).

--- a/docs/architecture/runtime_model.md
+++ b/docs/architecture/runtime_model.md
@@ -57,17 +57,16 @@ At program entry the runtime constructs every top-level block under the implicit
 (see `hierarchy_and_generate.md`). A single scheduler then drives the processes of all of them on
 one time axis; multiple top-level modules are one simulation, not several.
 
-Between construction and simulation -- still at t = 0, before any process runs -- the runtime links
-the constructed objects into the one `$root`-rooted tree and binds it. Binding resolves the
-cross-tree references a per-object constructor could not, because they need the whole tree to exist:
-an upward reference to an ancestor, a `$root`-anchored path (see `reference_resolution.md`,
-`emission_model.md`).
+Between construction and simulation -- still at t = 0, before any process runs -- the runtime
+executes the binding graph and seals every reference: each route reaches its target through typed
+in-artifact navigation and the runtime SDK only across opaque unit boundaries; the sealing barrier
+commits each binding's final endpoint (see `reference_resolution.md`, `emission_model.md`).
 
 `elaboration_lifecycle.md` refines this construction-vs-simulation boundary into ordered phases
-(build / resolve / initialize / activate) and is the authority on _when_ each piece runs: all
-cross-instance references resolve in one resolve phase after the shell graph is built, and variable
-initializers run in the initialize phase after resolution, not inside the constructor. The
-constructor allocates the shell; it is not the executor of elaboration semantics.
+(build / resolve / seal / initialize / activate) and is the authority on _when_ each piece runs:
+every cross-instance reference resolves in the Resolve phase and commits in the Seal phase, and
+variable initializers run in Initialize after Seal, not inside the constructor. The constructor
+allocates the shell; it is not the executor of elaboration semantics.
 
 ## Generate is not compile-time expansion
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -99,10 +99,16 @@ Grouped by subject so a decision is findable by concept, not only by filename. O
 
 ### References and construction
 
-- [hierarchical-reference-resolution](hierarchical-reference-resolution.md) -- how a cross-unit
-  hierarchical reference resolves once into a stored pointer: downward by emitted constructor
-  navigation, upward by a runtime self-climb at bind, both by name; and why the cross-unit hop is by
-  name, not a typed accessor.
+- [hierarchical-reference-routing](hierarchical-reference-routing.md) -- one semantic shape per
+  hierarchical reference; per-segment classification by layout visibility (typed for layout-owned
+  segments, runtime SDK across unit boundaries); sealed endpoint consumed on the hot path; lexical
+  form and source order are not mechanism dispatch keys.
+- [binding-graph-resolution](binding-graph-resolution.md) -- resolution and sealing respect
+  dependencies between references (a route requiring another's sealed endpoint resolves after it;
+  forwarding chains collapse end-to-end); the resolution mechanism itself is not fixed by the
+  architecture.
+- [hierarchical-reference-resolution](hierarchical-reference-resolution.md) (superseded) -- the
+  prior decision, replaced by the two entries above.
 - [specialization-identity](specialization-identity.md) -- a specialization's identity is a
   deterministic name (module name + content hash of a canonical, structural serialization of its
   parameter bindings), computed independently by producer and consumer and matched by name;

--- a/docs/decisions/binding-graph-resolution.md
+++ b/docs/decisions/binding-graph-resolution.md
@@ -1,0 +1,107 @@
+# Resolution Dependency Ordering
+
+## Date
+
+2026-06-27
+
+## Status
+
+Accepted
+
+## Why this decision matters
+
+Every cross-instance reference -- a hierarchical reference, a `ref` port alias, a port connection's
+reactive endpoint -- needs a resolution that respects dependencies between references. A reference
+whose route requires another's sealed endpoint must resolve after that reference seals; a chain of
+forwarding aliases must collapse end-to-end before any of them is read; a route that traverses a
+non-constructed runtime object must surface a user diagnostic. This entry settles the commitment
+that resolution respects these dependencies and the criteria a resolution mechanism must satisfy. It
+does not prescribe a particular mechanism today.
+
+## The commitment
+
+Resolution and sealing respect dependencies between references. Specifically:
+
+- A reference whose route execution requires another reference's sealed endpoint resolves only after
+  that other reference seals.
+- A forwarding chain (the prototype is a `ref` port chain) collapses end-to-end at sealing; no
+  reference observable to Initialize is a chain to another reference.
+- A reference whose route traverses a non-constructed runtime object surfaces a user diagnostic at
+  the sealing barrier, not `InternalError` and not a runtime fallback.
+- A cycle in the dependency relation with no concrete storage root is a user diagnostic; a cycle
+  that the language semantics forbid but the lowering should have rejected is an `InternalError`.
+
+These commitments are the contract Resolve and Seal owe Initialize. The architecture states the
+commitment; this entry records it as a decision so a downstream change does not weaken it under the
+rationale that "no specific mechanism requires this."
+
+## Mechanism is not fixed here
+
+How resolution orders references against the dependency relation is not fixed by this decision. A
+correctness-equivalent set of choices includes:
+
+- **Implicit ordering from the elaboration walk.** The top-down walk over the runtime object tree
+  satisfies the common dependency cases (a parent's `ref` port seals before its child reads the
+  alias; a sibling's reference reads only sealed peers). Today's runtime resolution mechanism
+  realizes ordering this way.
+- **Explicit dependency graph with topological resolution.** A general mechanism that records each
+  reference's `requires` set and executes them in topological order. Required if future endpoint
+  families (class-handle-reachable bindings whose handles are themselves bindings) add dependencies
+  the walk does not respect by accident.
+- **Iterative resolution with progress detection.** A general mechanism that retries until no
+  reference advances; cycles are detected by lack of progress.
+
+The choice between these is an implementation matter. It does not change the commitment above and
+does not change the architecture invariants.
+
+## Criteria a mechanism must satisfy
+
+Any resolution mechanism must:
+
+1. Execute each route at most once during Resolve (modulo retry in iterative variants for
+   forward-progress purposes only).
+2. Produce a sealed endpoint for every successfully resolved reference at the sealing barrier,
+   atomically with respect to Initialize.
+3. Surface a user diagnostic for the failure modes above; never silently substitute a value.
+4. Respect the dependency relation: a reference whose route requires another's sealed endpoint
+   resolves only after that other reference seals.
+5. Bound its work: a forwarding chain of length `N` resolves in `O(N)` work in the chain length, not
+   `O(N^2)`; a non-forwarding reference resolves in `O(1)` work in the design's reference count.
+
+## Rejected alternatives
+
+- **Mechanism dispatched on lexical form.** The current code reaches this through
+  `slang::isUpward()`: a forward-sibling reference (slang-upward) defers resolution to a runtime
+  wrapper, while a backward-sibling reference (slang-downward) resolves at constructor time. This is
+  a runtime-ordering escape hatch presented as a semantic distinction; it does not respect the
+  dependency relation in the general case, and it forces the IR to carry per-form vocabulary that
+  should not exist (`hierarchical-reference-routing.md` D1, forbidden shapes). Rejected.
+
+- **Resolution interleaved with construction.** Resolving a reference inside the constructor that
+  builds the subtree forces a child to be fully constructed before its parent can bind it, which is
+  the pass-through `ref` hazard and the construction-time-read hazard (`elaboration_lifecycle.md`
+  Forbidden Shapes). Resolution happens after Build, not within it.
+
+- **Resolution and sealing collapsed into one phase.** Loses the contract barrier Initialize needs.
+  Initialize must observe a sealed world or be deferred; a "Resolve that does both" muddles the
+  failure modes (an unresolved route and a forwarding cycle become indistinguishable from
+  Initialize's perspective).
+
+- **Per-scope sealing.** A forwarding chain may cross scope boundaries; per-scope sealing cannot
+  model cross-scope dependencies. Seal is a property of the elaborated design as a whole.
+
+## Consequences
+
+- `elaboration_lifecycle.md` invariant 4 ("Resolve respects dependency order") and invariant 5
+  ("Seal is a global barrier") state the commitment as contract.
+- The runtime engine exposes Resolve and Seal as elaboration steps the coordinator orchestrates; no
+  scope carries a `Seal` method. The mechanism behind Resolve is unspecified by the architecture and
+  may evolve as endpoint families grow.
+- A change that adds a new endpoint category whose dependencies the current mechanism does not
+  respect must either extend the mechanism or land its own decision entry justifying a new resolver.
+
+## Cross-references
+
+- `../architecture/elaboration_lifecycle.md` -- the lifecycle this commitment lives inside.
+- `../architecture/reference_resolution.md` -- the references whose routes this orders.
+- `hierarchical-reference-routing.md` -- the routing contract this resolution serves.

--- a/docs/decisions/hierarchical-reference-resolution.md
+++ b/docs/decisions/hierarchical-reference-resolution.md
@@ -6,7 +6,13 @@
 
 ## Status
 
-Accepted
+Superseded by `hierarchical-reference-routing.md` (2026-06-27) and `binding-graph-resolution.md`
+(2026-06-27).
+
+The two superseding entries replace this one's per-reference intra-unit / cross-unit classification
+with per-segment classification by layout visibility, introduce the binding graph as the resolution
+mechanism for all cross-instance bindings, and remove `ExternUp` from IR vocabulary. This entry is
+retained for history; it is not the current contract.
 
 ## Why this decision matters
 

--- a/docs/decisions/hierarchical-reference-routing.md
+++ b/docs/decisions/hierarchical-reference-routing.md
@@ -1,0 +1,162 @@
+# Hierarchical Reference Routing
+
+## Date
+
+2026-06-27
+
+## Status
+
+Accepted. Supersedes `hierarchical-reference-resolution.md`.
+
+## Why this decision matters
+
+A hierarchical reference reaches a target elsewhere on the elaborated object tree. The target's
+identity, the route segments traversed to reach it, the runtime endpoint the route binds to, and the
+hot-path access shape are four facts that must compose into one coherent model. Prior shapes
+fragmented these facts across `slang::isUpward()` dispatch, constructor-time downward installs,
+Resolve-time upward wrappers, and a HIR variant per lexical form. This entry fixes the model.
+
+## The model
+
+A hierarchical reference is a resolved route from a structural origin to a sealed endpoint.
+Structural lowering preserves canonical target and segment identities independently of lexical form.
+After Build materializes the runtime hierarchy, the route resolves: each segment uses typed
+navigation when its source and target classes are both owned by the emitting artifact, and the
+runtime SDK across unit boundaries. Seal commits each route's final endpoint. Process bodies and
+sensitivity logic consume only sealed endpoints; they never perform hierarchy traversal or name
+matching.
+
+## Decisions
+
+### D1. One semantic shape for every hierarchical reference
+
+HIR carries one shape for every hierarchical reference, regardless of lexical form (bare name,
+downward dotted, upward dotted, absolute `$root` path). Slang already returns aligning identity
+across lexical forms (the resolved leaf is one symbol pointer regardless of the form that reached
+it); Lyra preserves that alignment.
+
+`slang::isUpward()`, source order, and AST lexical form do not classify the reference and do not
+choose the mechanism. They are inputs to the route synthesis at AST-to-HIR; they do not appear
+beyond it.
+
+### D2. Routes are classified per segment by layout visibility
+
+A route is a sequence of segments. Each segment is either:
+
+- **Layout-visible** to the emitting artifact -- the segment's source class and target class are
+  both owned by this artifact. Realization: typed navigation through stable in-artifact member
+  identities. No string lookup, no SDK call.
+- **Opaque** to the emitting artifact -- the segment crosses into another compilation unit's body.
+  Realization: the runtime SDK's by-name resolution, executed once during Resolve.
+
+A single route may alternate. `top.gen.child.x` where `top.gen` is layout-visible, `gen.child` is
+layout-visible (a same-CU instance member's pointer field), and `child.x` is opaque (descent into
+Child's body) is three segments -- typed, typed, opaque -- composed in route order.
+
+Classification is per segment. "Intra-unit vs cross-unit" is not a property of a reference; it is a
+property of each segment.
+
+### D3. The endpoint inherits the target's access protocol
+
+A reference's sealed endpoint is the access surface of the target it reaches. A reference whose leaf
+is an observable storage cell seals to that cell; a reference whose leaf is a class object handle
+seals to the handle, with property access happening through the class's existing access protocol; a
+reference whose leaf is a named event seals to the event, with the existing event protocol. There is
+no synthetic "endpoint type" that wraps each target; the endpoint is the target itself, reached
+through a sealed direct path.
+
+The MIR representation reuses existing type variants -- a borrowed pointer to the appropriate
+observable cell, the managed reference for class handles, the event surface type. The fact that a
+particular field is a sealed reference (rather than, for example, a constructor-stored pointer) is
+recorded at the structural layer that records the reference; the type carries only the value's
+runtime shape.
+
+### D4. `ref` ports are forwarding links collapsed at Seal
+
+A `ref` port aliases an upstream cell. The runtime carries the alias as one route-segment
+realization, not as a value process bodies hold. Seal collapses every chain through `ref` ports to
+the final cell they alias; a process body's view of a hierarchical reference that traverses a `ref`
+port reaches the final cell directly, never an intermediate forwarding wrapper.
+
+A hierarchical reference whose route terminates at a `ref` port depends on the port's own
+resolution. After Seal, both denote the same final cell.
+
+### D5. Open target family; new categories need a decision
+
+The set of target categories a hierarchical reference may seal to is open. Adding a category
+requires:
+
+1. A SystemVerilog target whose access surface cannot be expressed through any existing protocol.
+2. A defined access protocol with sealed-endpoint semantics (the operations a body performs, the
+   sensitivity surface).
+3. A defined resolution and sealing contribution: how the route segments leading to this target
+   classify, how the sealing barrier validates the result.
+4. A MIR representation reusing or extending the existing type system.
+5. A hot-path realization defined for every supported backend.
+
+Interface members, chandle observability, and hierarchical callable dispatch are candidate
+extensions; each needs its own decision entry.
+
+### D6. Conditional-generate non-selected arms are sealing failures
+
+A hierarchical reference whose route traverses a conditional-generate arm not selected at Build
+cannot seal -- the traversed runtime scope does not exist. The reference is rejected at Seal as an
+illegal target with a user diagnostic, not `InternalError`; the SV elaboration semantics give the
+case no value. The frontend's elaboration check eliminates the case before Seal where it can;
+references that survive frontend elaboration but reach a non-selected arm at Build (the elaborated
+parameter environment differs from what the source expression assumed) are rejected at Seal with the
+same diagnostic.
+
+## Forbidden shapes
+
+- A HIR or MIR variant per lexical form (a "downward reference" kind, an "upward reference" kind, a
+  "root reference" kind, a "same-unit reference" kind as separate species). One semantic shape.
+- `slang::isUpward()`, source order, or AST lexical kind used as a mechanism dispatch key. The
+  mechanism follows segment layout visibility.
+- A reference installed in the constructor body. Every reference resolves during Resolve and seals
+  during Seal.
+- An IR vocabulary item modeling a particular runtime library's resolver shape -- a wrapper type
+  carrying bind state, a named-method family for "register a by-name climb" / "register a root
+  anchor" / "append a descent step". Runtime library shapes belong to the runtime; the IR names only
+  the reference, its route segments, and its sealed endpoint.
+- A "no runtime slot" or "always runtime slot" mandate for a route's endpoint. Storage placement of
+  the sealed endpoint is owned by LIR; MIR states the reference, its route, and the access protocol
+  the body uses, not the storage shape.
+- A textual name used as the identity of a layout-visible segment step. Layout-visible segments use
+  stable in-artifact member identities; canonical names appear only at the opaque-segment boundary
+  where the SDK consumes them.
+- A forwarding wrapper observed in a process body as a hierarchical reference's endpoint. Forwarding
+  wrappers exist only as resolution intermediates; they collapse at Seal.
+- A hot-path access that walks the runtime tree, calls a by-name lookup, or otherwise performs
+  hierarchy traversal. After Seal, every nonlocal read, write, and observation reads from a sealed
+  endpoint directly.
+- A reference whose mechanism flips between routes across compilation invocations because the
+  generate order changed. The mechanism is a function of the route, not of source order.
+
+## Consequences
+
+- `mir.md` carries no per-form hierarchical reference variant and no IR vocabulary for a particular
+  runtime resolver wrapper. The reference appears through the existing access primitives against the
+  target's existing type.
+- `emission_model.md`'s "storage and fill by direction" is replaced by "storage and fill by segment
+  layout visibility." Cross-unit downward and upward installs are not separate realizations; each is
+  a segment classification on one shared route.
+- `reference_resolution.md`'s intra-unit / cross-unit framing applies per segment, not per
+  reference.
+- The runtime SDK's by-name child and signal lookup family persists as the opaque-segment resolver.
+  The upward-by-name wrapper (the runtime class today carrying upward bind state) ceases to be an IR
+  concept; its function moves into ordinary resolve-time route code that reaches the SDK directly
+  for opaque segments and the typed traversal for layout-visible ones.
+- The runtime engine treats Seal as a property of the elaborated design as a whole, exposed through
+  the elaboration entry. No scope carries a `Seal` method.
+
+## Cross-references
+
+- `../architecture/reference_resolution.md` -- the per-segment classification.
+- `../architecture/emission_model.md` -- segment realization in each artifact.
+- `../architecture/elaboration_lifecycle.md` -- the five-phase lifecycle, with Seal explicit.
+- `../architecture/mir.md` -- the type vocabulary the sealed endpoint reuses.
+- `binding-graph-resolution.md` -- how the resolution order respects dependencies among references.
+- `reference-as-data-type.md` -- the alias data type that `ref` ports use as their forwarding link.
+- `object-model-storage.md` -- class declaration identity that a class-handle endpoint references.
+- `hierarchical-reference-resolution.md` (superseded) -- the prior decision.

--- a/docs/progress/refactor.md
+++ b/docs/progress/refactor.md
@@ -439,19 +439,38 @@ Entries get checked off as their PRs land. When the last entry lands, the file i
       and the value realization (getc for a string base, element access for an array) was already a
       property of the node at HIR-to-MIR, applied regardless of origin.
 
-- [ ] R35 -- Resolve the intra-unit part of a hierarchical reference at compile time as typed member
-      access, not by name at construction. `reference_resolution.md` invariant 2 says an intra-unit
-      reference -- including one into a same-unit named generate scope -- resolves at compile time
-      as a constructed-object reference plus a compile-time offset. Today such a reference is
-      lowered like a cross-unit one: a borrowed-pointer slot filled by a runtime by-name navigation
-      (`GetChild` / `GetSignal`) from `self`, even though the whole path stays inside the unit and
-      its layout is known at compile time. Only the genuine cross-unit hop (into another unit's
-      internal) must stay by name. Target shape: the intra-unit prefix is typed member access, and a
-      fully intra-unit reference is a plain member access with no runtime slot. **Blocker**: this
-      needs a MIR member-access form that descends into an owned child object's member, resolving
-      the member against the receiver's type. Member access today is hops-relative to the enclosing
-      class and cannot descend, so this rests on a new member-access capability that touches the
-      member-access model.
+- [ ] R35 -- Realize hierarchical references through the routing the architecture docs prescribe:
+      one semantic shape per reference, per-segment classification by layout visibility, route
+      execution in Resolve, endpoint committed in Seal, hot path reads only sealed endpoints. Today
+      the lowering uses three parallel mechanisms keyed off the frontend's lexical-form
+      classification and on source order: a downward by-name SDK install at construction, an upward
+      wrapper registered at construction and resolved later, and the typed enclosing access used for
+      bare names. These collapse to one route in the target shape. See
+      `../decisions/hierarchical-reference-routing.md` and
+      `../decisions/binding-graph-resolution.md`. The work bundles into one PR landing as five
+      checkpoints:
+  - [ ] Structural-first lowering pipeline. Every class's structural shape -- its members, its owned
+        children, the signal registrations it contributes to the runtime tree -- is complete in MIR
+        before any body lowers. A body, a process, an initializer, or an install statement may reach
+        a peer class's structural members through the artifact's identity model; the lowering order
+        guarantees the peer's shape is visible when the referring body translates.
+  - [ ] Reference install runs in Resolve. Every cross-instance reference's install code emits into
+        the resolve body, not the constructor body. The constructor allocates the instance shell and
+        constructs its children; resolution runs after the runtime tree is built. Forward and
+        backward reference directions stop differing in when they install.
+  - [ ] The upward-reference runtime wrapper retires from IR vocabulary. The wrapper used today to
+        defer upward references' resolution is no longer carried as an MIR type, an HIR variant, or
+        a vocabulary item the lowering names. Every reference's slot becomes a uniform borrowed
+        pointer to its target's cell, filled by ordinary resolve-time install code.
+  - [ ] Layout-visible route segments install typed. A route segment whose source and target classes
+        are both owned by this artifact emits as a typed member-access chain; the runtime SDK is
+        reached only for segments that cross the unit boundary. A reference whose entire route is
+        layout-visible installs with no SDK call; a mixed-route reference installs a typed prefix
+        composed with an SDK suffix.
+  - [ ] Reference mechanism unified; lexical-form dispatch retired. The lowering produces one route
+        shape per reference regardless of the form that named the target. The frontend's
+        lexical-form classification is consumed only at AST-to-HIR for route synthesis and does not
+        reach the route's mechanism dispatch.
 
 - [x] R36 -- The container default-value slot fused the read-miss value with the discarded-write
       target, forcing the const read to scrub the slot a prior write may have dirtied before


### PR DESCRIPTION
## Summary

Updates the architecture and decision docs to anchor hierarchical references on a single routing model: one semantic shape per reference, per-segment classification by layout visibility, route execution in Resolve, endpoint committed at Seal, hot path reads only sealed endpoints. The elaboration lifecycle gains an explicit Seal phase as the global barrier between Resolve and Initialize so the contract Initialize observes is unambiguous. Reference resolution's prior intra-unit / cross-unit framing is replaced with per-segment classification: each route segment is either layout-visible (typed navigation) or opaque (SDK by-name), and a single route may alternate. Two new decision docs land: `hierarchical-reference-routing.md` fixes the model and forbids per-form IR vocabulary; `binding-graph-resolution.md` records the dependency-ordering commitment without prescribing a particular mechanism. The prior `hierarchical-reference-resolution.md` decision is marked superseded.

## Design

The five phases (Build, Resolve, Seal, Initialize, Activate) mirror the LRM's elaboration / simulation boundary. Seal is a property of the elaborated design as a whole, not of any one scope -- forwarding chains cross scope and CU boundaries, and a per-scope walk cannot model that. Per-segment classification dissolves the "intra-unit vs cross-unit reference" axis: that distinction is a property of each segment, not of the reference. Architecture invariants are stated at the concept level only -- no MIR type names, no runtime class names, no HIR variant names appear in the invariants. Implementation choices (resolver mechanism, slot type, wrapper retirement) are owned by decision docs and code, not architecture.

The R35 refactor entry is restructured into one umbrella with five nested checkpoints landing in one PR: structural-first lowering pipeline, install runs in Resolve, upward-wrapper retires from IR vocabulary, layout-visible segments install typed, lexical-form dispatch retires.