### PR TITLE
Support the first working SystemVerilog class

### DIFF
--- a/include/lyra/base/registry.hpp
+++ b/include/lyra/base/registry.hpp
@@ -37,6 +37,10 @@ class Registry {
     return slots_.at(id.value).has_value();
   }
 
+  [[nodiscard]] auto size() const -> std::size_t {
+    return slots_.size();
+  }
+
   [[nodiscard]] auto Get(Id id) const -> const T& {
     const auto& slot = slots_.at(id.value);
     if (!slot.has_value()) {

--- a/include/lyra/diag/diag_code.hpp
+++ b/include/lyra/diag/diag_code.hpp
@@ -33,6 +33,7 @@ enum class DiagCode : std::uint32_t {
   kUnsupportedAssignmentPatternKind,
   kUnsupportedSubroutineArgument,
   kUnsupportedForkJoinForm,
+  kUnsupportedClassFeature,
 
   kErrorDelayValueOutOfRange,
   kErrorCaseEqualityOnRealOperand,

--- a/include/lyra/hir/class_decl.hpp
+++ b/include/lyra/hir/class_decl.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "lyra/base/arena.hpp"
+#include "lyra/hir/expr.hpp"
+#include "lyra/hir/expr_id.hpp"
+#include "lyra/hir/type_id.hpp"
+
+namespace lyra::hir {
+
+// A class property (LRM 8.4): a named member variable of a class, with its own
+// per-object storage. `initializer`, when present, is the declared `= value`
+// expression in the class's own `exprs` arena; absent means the property takes
+// its type's Table 7-1 default at construction.
+struct ClassField {
+  std::string name;
+  TypeId type;
+  std::optional<ExprId> initializer;
+};
+
+// A SystemVerilog class declaration (LRM 8). The class's properties and the
+// expressions their initializers reference; references to a class name resolve
+// to this declaration's id. A class is reached through a handle, so it carries
+// no structural position of its own.
+struct ClassDecl {
+  std::string name;
+  std::vector<ClassField> fields;
+  base::Arena<Expr, ExprId> exprs;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/class_id.hpp
+++ b/include/lyra/hir/class_id.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <compare>
+#include <cstdint>
+
+namespace lyra::hir {
+
+struct ClassId {
+  std::uint32_t value;
+
+  auto operator<=>(const ClassId&) const -> std::strong_ordering = default;
+};
+
+}  // namespace lyra::hir

--- a/include/lyra/hir/expr.hpp
+++ b/include/lyra/hir/expr.hpp
@@ -8,6 +8,7 @@
 
 #include "lyra/diag/source_span.hpp"
 #include "lyra/hir/binary_op.hpp"
+#include "lyra/hir/class_id.hpp"
 #include "lyra/hir/conversion.hpp"
 #include "lyra/hir/expr_id.hpp"
 #include "lyra/hir/inc_dec_op.hpp"
@@ -172,6 +173,14 @@ struct DynamicArrayNewExpr {
   std::optional<ExprId> initializer;
 };
 
+// LRM 8.5 class object construction `new`. Allocates a new object of the named
+// class and runs its constructor, yielding a handle. The class is named by its
+// declaration id; `Expr::type` is the class handle type. Carries no constructor
+// arguments (the default `new`).
+struct ClassNewExpr {
+  ClassId class_id;
+};
+
 // LRM 7.9.11 associative-array literal `'{index: value, ..., default: d}`. Each
 // entry pairs a key expression with a value expression; the optional default is
 // the persistent fallback a read of an absent key returns (LRM 7.8.6). Slang
@@ -191,7 +200,7 @@ using ExprData = std::variant<
     PrimaryExpr, UnaryExpr, BinaryExpr, ConditionalExpr, AssignExpr, IncDecExpr,
     CallExpr, ConversionExpr, InsideExpr, ElementSelectExpr, RangeSelectExpr,
     MemberAccessExpr, ConcatExpr, ReplicationExpr, AssignmentPatternExpr,
-    AssignmentPatternReplicationExpr, DynamicArrayNewExpr,
+    AssignmentPatternReplicationExpr, DynamicArrayNewExpr, ClassNewExpr,
     AssociativeAssignmentPatternExpr>;
 
 struct Expr {

--- a/include/lyra/hir/module_unit.hpp
+++ b/include/lyra/hir/module_unit.hpp
@@ -4,6 +4,9 @@
 #include <utility>
 
 #include "lyra/base/arena.hpp"
+#include "lyra/base/registry.hpp"
+#include "lyra/hir/class_decl.hpp"
+#include "lyra/hir/class_id.hpp"
 #include "lyra/hir/structural_scope.hpp"
 #include "lyra/hir/type.hpp"
 #include "lyra/hir/type_id.hpp"
@@ -30,6 +33,9 @@ struct ModuleUnit {
   base::Arena<Type, TypeId> types;
   BuiltinHirTypes builtins;
   StructuralScope root_scope;
+  // A class can be referenced -- as a handle type or a `new` target -- before
+  // its body is built, so its identity must exist before its definition.
+  base::Registry<ClassDecl, ClassId> classes;
 
   explicit ModuleUnit(std::string name)
       : name(std::move(name)), builtins(MakeBuiltins(types)) {

--- a/include/lyra/hir/primary.hpp
+++ b/include/lyra/hir/primary.hpp
@@ -31,6 +31,10 @@ struct RealLiteral {
   double value;
 };
 
+// LRM 8.4 `null`: the handle literal that refers to no object. Its type is the
+// class handle type it is compared or assigned against.
+struct NullLiteral {};
+
 // Primary mirrors LRM 11.2.1 - the atomic leaf level of the expression
 // grammar. Refs are listed directly here so the same StructuralVarRef /
 // ProceduralVarRef value appears identically when the expression is read and
@@ -39,7 +43,8 @@ struct RealLiteral {
 // the same shape under `BinaryExpr.lhs` is a read), not by an extra type
 // tag.
 using Primary = std::variant<
-    IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, StructuralVarRef,
-    ProceduralVarRef, LoopVarRef, CrossUnitVarRef, IterationBindingRef>;
+    IntegerLiteral, StringLiteral, TimeLiteral, RealLiteral, NullLiteral,
+    StructuralVarRef, ProceduralVarRef, LoopVarRef, CrossUnitVarRef,
+    IterationBindingRef>;
 
 }  // namespace lyra::hir

--- a/include/lyra/hir/type.hpp
+++ b/include/lyra/hir/type.hpp
@@ -6,6 +6,7 @@
 #include <variant>
 #include <vector>
 
+#include "lyra/hir/class_id.hpp"
 #include "lyra/hir/constant_value.hpp"
 #include "lyra/hir/integral_constant.hpp"
 #include "lyra/hir/type_id.hpp"
@@ -31,6 +32,8 @@ enum class TypeKind {
   kShortReal,
   kRealTime,
   kChandle,
+  kClassHandle,
+  kNull,
   kVoid,
 };
 
@@ -200,11 +203,25 @@ struct RealTimeType {};
 struct ChandleType {};
 struct VoidType {};
 
+// LRM 8.3 class handle: the type of a variable that refers to a class object.
+// Null is a legal value, the object is reached through the handle, and the
+// referenced class is named by its declaration id (resolved through the unit's
+// class registry).
+struct ClassHandleType {
+  ClassId class_id;
+};
+
+// LRM 8.4: the type slang gives the `null` literal. It is assignment- and
+// comparison-compatible with any class handle; the contextual handle determines
+// the operation, so this type carries no class identity of its own.
+struct NullType {};
+
 using TypeData = std::variant<
     ScalarBitType, PackedArrayType, PackedStructType, PackedUnionType, EnumType,
     UnpackedStructType, UnpackedUnionType, UnpackedArrayType, DynamicArrayType,
     QueueType, AssociativeArrayType, WildcardIndexType, StringType, EventType,
-    RealType, ShortRealType, RealTimeType, ChandleType, VoidType>;
+    RealType, ShortRealType, RealTimeType, ChandleType, ClassHandleType,
+    NullType, VoidType>;
 
 struct Type {
   TypeData data;

--- a/include/lyra/lowering/ast_to_hir/expression/aggregates.hpp
+++ b/include/lyra/lowering/ast_to_hir/expression/aggregates.hpp
@@ -16,6 +16,7 @@ namespace slang::ast {
 class AssignmentPatternExpressionBase;
 class ConcatenationExpression;
 class NewArrayExpression;
+class NewClassExpression;
 class ReplicatedAssignmentPatternExpression;
 class ReplicationExpression;
 class StructuredAssignmentPatternExpression;
@@ -65,5 +66,13 @@ auto LowerNewArrayExprProc(
     ProcessLowerer& proc, WalkFrame frame,
     const slang::ast::NewArrayExpression& na, diag::SourceSpan span)
     -> diag::Result<hir::Expr>;
+
+// The class constructor `new` (LRM 8.5) yields a handle; the construction is
+// independent of the enclosing scope, so one template over the pass class
+// serves both contexts.
+template <ExprLowerer Lowerer>
+auto LowerNewClassExpr(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::NewClassExpression& nc,
+    diag::SourceSpan span) -> diag::Result<hir::Expr>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
+++ b/include/lyra/lowering/ast_to_hir/module_lowerer.hpp
@@ -25,6 +25,7 @@
 
 namespace slang::ast {
 class Expression;
+class ClassType;
 }  // namespace slang::ast
 
 namespace lyra::lowering::ast_to_hir {
@@ -145,6 +146,13 @@ class ModuleLowerer {
   auto InternType(const slang::ast::Type& type, diag::SourceSpan span)
       -> diag::Result<hir::TypeId>;
 
+  // Registers a class declaration on first encounter and returns its id,
+  // memoizing by slang class pointer. The id is declared before the body is
+  // built so a property whose type names the same class (a self-reference)
+  // resolves against a stable identity.
+  auto InternClass(const slang::ast::ClassType& cls, diag::SourceSpan span)
+      -> diag::Result<hir::ClassId>;
+
   // Facts.
   [[nodiscard]] auto SourceMapper() const
       -> const frontend::SlangSourceMapper& {
@@ -237,6 +245,7 @@ class ModuleLowerer {
 
   // Registries.
   std::unordered_map<const slang::ast::Type*, hir::TypeId> type_cache_;
+  std::unordered_map<const slang::ast::ClassType*, hir::ClassId> class_cache_;
   StructuralVarBindings structural_var_bindings_;
   SubroutineBindings subroutine_bindings_;
   LoopVarBindings loop_var_bindings_;

--- a/include/lyra/lowering/hir_to_mir/class_decl_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/class_decl_lowerer.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "lyra/diag/diagnostic.hpp"
+#include "lyra/hir/class_decl.hpp"
+#include "lyra/lowering/hir_to_mir/module_lowerer.hpp"
+#include "lyra/mir/class.hpp"
+#include "lyra/mir/type_id.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+// Lowers one HIR class declaration to its MIR object. A class is the same
+// generic nominal object as a module or generate scope, differing in that it
+// extends no runtime base (it is not a tree node), is reached through a managed
+// reference, and is built by `new`. Its properties become plain value-typed
+// members -- not observable cells -- and their construction-time defaults are
+// the body of its constructor. `object_type` is the interned object type that
+// names the class, minted with its registry identity before type translation.
+class ClassDeclLowerer {
+ public:
+  ClassDeclLowerer(
+      ModuleLowerer& module, mir::TypeId object_type,
+      const hir::ClassDecl& hir_class)
+      : module_(&module), object_type_(object_type), hir_class_(&hir_class) {
+  }
+
+  // Builds and returns the class object. The caller, which owns the class
+  // registry and holds the pre-declared identity, defines the returned object
+  // into the unit.
+  auto Run() -> diag::Result<mir::Class>;
+
+ private:
+  ModuleLowerer* module_;
+  mir::TypeId object_type_;
+  const hir::ClassDecl* hir_class_;
+};
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/include/lyra/lowering/hir_to_mir/module_lowerer.hpp
+++ b/include/lyra/lowering/hir_to_mir/module_lowerer.hpp
@@ -72,6 +72,35 @@ class ModuleLowerer {
     type_map_.emplace_back(mir_id);
   }
 
+  // A HIR class declaration's MIR identity and the interned `ObjectType` that
+  // names it. Both are minted before any type is translated, so a class handle
+  // type can resolve to its managed-reference pointee while the class body is
+  // still being built.
+  void MapClass(
+      hir::ClassId hir_id, mir::ClassId mir_id, mir::TypeId object_type) {
+    if (hir_id.value != class_map_.size()) {
+      throw InternalError(
+          "ModuleLowerer::MapClass: HIR classes must be mapped in HIR id "
+          "order");
+    }
+    class_map_.emplace_back(mir_id);
+    class_object_type_map_.emplace_back(object_type);
+  }
+
+  [[nodiscard]] auto TranslateClass(hir::ClassId hir_id) const -> mir::ClassId {
+    if (hir_id.value >= class_map_.size()) {
+      throw InternalError("ModuleLowerer::TranslateClass: unmapped HIR class");
+    }
+    return class_map_[hir_id.value];
+  }
+
+  [[nodiscard]] auto ClassObjectType(hir::ClassId hir_id) const -> mir::TypeId {
+    if (hir_id.value >= class_object_type_map_.size()) {
+      throw InternalError("ModuleLowerer::ClassObjectType: unmapped HIR class");
+    }
+    return class_object_type_map_[hir_id.value];
+  }
+
   // Mints a collision-free class name for one generate scope, tagged by its
   // arm kind (`loop` / `then` / `else` / ...). The name is only an
   // implementation handle for the emitted type -- a generate scope's runtime
@@ -89,6 +118,8 @@ class ModuleLowerer {
   const diag::SourceManager* source_manager_;
   mir::CompilationUnit unit_;
   std::vector<mir::TypeId> type_map_;
+  std::vector<mir::ClassId> class_map_;
+  std::vector<mir::TypeId> class_object_type_map_;
   std::uint32_t next_generate_scope_name_ = 0;
 };
 

--- a/include/lyra/runtime/gc_ref.hpp
+++ b/include/lyra/runtime/gc_ref.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace lyra::runtime {
+
+// A managed reference to a class object (LRM 8.3): a handle that refers to a
+// heap object whose lifetime the simulator owns. Null is a legal value, copies
+// are shallow (two handles refer to the same object), and identity is compared
+// by object address.
+template <typename T>
+class GcRef {
+ public:
+  GcRef() = default;
+  // `null` (LRM 8.4) flows in as a null pointer; the implicit conversion lets a
+  // handle be assigned, initialized, and compared against `null` directly.
+  GcRef(std::nullptr_t) {  // NOLINT(google-explicit-constructor)
+  }
+  explicit GcRef(T* object) : object_(object) {
+  }
+
+  auto operator->() const -> T* {
+    return object_;
+  }
+  auto operator*() const -> T& {
+    return *object_;
+  }
+  [[nodiscard]] auto Get() const -> T* {
+    return object_;
+  }
+
+  friend auto operator==(const GcRef& a, const GcRef& b) -> bool {
+    return a.object_ == b.object_;
+  }
+  friend auto operator!=(const GcRef& a, const GcRef& b) -> bool {
+    return a.object_ != b.object_;
+  }
+
+ private:
+  T* object_ = nullptr;
+};
+
+// The managed heap. Every allocation is retained for the life of the run and
+// reclaimed at shutdown, so a handle never dangles.
+namespace detail {
+inline auto ManagedHeap() -> std::vector<std::shared_ptr<void>>& {
+  static std::vector<std::shared_ptr<void>> heap;
+  return heap;
+}
+}  // namespace detail
+
+// Allocates a class object on the managed heap and returns a handle to it. The
+// object is retained by the heap, so the returned handle never dangles.
+template <typename T, typename... Args>
+auto GcNew(Args&&... args) -> GcRef<T> {
+  auto object = std::make_shared<T>(std::forward<Args>(args)...);
+  T* raw = object.get();
+  detail::ManagedHeap().push_back(std::move(object));
+  return GcRef<T>(raw);
+}
+
+}  // namespace lyra::runtime

--- a/include/lyra/runtime/prelude.hpp
+++ b/include/lyra/runtime/prelude.hpp
@@ -29,6 +29,7 @@
 #include "lyra/runtime/file_table.hpp"         // IWYU pragma: keep
 #include "lyra/runtime/finish.hpp"             // IWYU pragma: keep
 #include "lyra/runtime/fork.hpp"               // IWYU pragma: keep
+#include "lyra/runtime/gc_ref.hpp"             // IWYU pragma: keep
 #include "lyra/runtime/hierarchy_segment.hpp"  // IWYU pragma: keep
 #include "lyra/runtime/named_event.hpp"        // IWYU pragma: keep
 #include "lyra/runtime/process_kind.hpp"       // IWYU pragma: keep

--- a/src/lyra/backend/cpp/emit_cpp.cpp
+++ b/src/lyra/backend/cpp/emit_cpp.cpp
@@ -249,11 +249,15 @@ auto RenderScopeAsClass(
     out += "\n";
   }
 
-  // A plain object (no runtime base) is not a tree node: it needs no
-  // registering constructor, only the implicit default one.
+  // A tree node forwards to its runtime base; a plain object (a class) has no
+  // base but still runs its constructor body to initialize its members. Either
+  // way the constructor is emitted when there is a base to forward to or a body
+  // to run; a baseless object with an empty body keeps the implicit default.
   if (s.base.has_value()) {
     out +=
         RenderConstructor(this_anchor, s, RenderBaseClass(*s.base), indent + 1);
+  } else if (!s.constructor_block.root_stmts.empty()) {
+    out += RenderConstructor(this_anchor, s, "", indent + 1);
   }
 
   // A unit-root scope is a module instance; its name is the def-name an upward
@@ -334,6 +338,7 @@ auto RenderScopeHeaderFile(
   out += "#include \"lyra/runtime/file_table.hpp\"\n";
   out += "#include \"lyra/runtime/finish.hpp\"\n";
   out += "#include \"lyra/runtime/fork.hpp\"\n";
+  out += "#include \"lyra/runtime/gc_ref.hpp\"\n";
   out += "#include \"lyra/runtime/named_event.hpp\"\n";
   out += "#include \"lyra/runtime/runtime_services.hpp\"\n";
   out += "#include \"lyra/runtime/scope.hpp\"\n";
@@ -405,6 +410,22 @@ auto RenderScopeHeaderFile(
   if (any_alias) {
     out += "\n";
   }
+
+  // A SystemVerilog class is a free-standing registry object with no runtime
+  // base and no structural parent, so it is not reached by the scope tree's
+  // `contained` walk. Emit every baseless class before the scope tree that may
+  // reference it through a handle or `new`. (The scope objects -- the module
+  // and its generate scopes -- carry a runtime base and are emitted by the
+  // tree walk below.)
+  for (std::size_t i = 0; i < unit.classes.size(); ++i) {
+    const mir::ClassId id{static_cast<std::uint32_t>(i)};
+    if (!unit.classes.IsDefined(id)) continue;
+    const mir::Class& cls = unit.GetClass(id);
+    if (cls.base.has_value()) continue;
+    out += RenderScopeAsClass(unit, cls, 0, nullptr);
+    out += "\n";
+  }
+
   out += RenderScopeAsClass(unit, s, 0, nullptr);
   return out;
 }

--- a/src/lyra/backend/cpp/render_call.cpp
+++ b/src/lyra/backend/cpp/render_call.cpp
@@ -482,6 +482,18 @@ auto RenderCalleePart(
                       RenderTypeAsCpp(view.Unit(), view.Class(), ptr->pointee)),
                   .leading_arg_count = 0};
             }
+            // A managed reference result is a class `new`: allocate on the
+            // managed heap and run the object's constructor.
+            if (const auto* managed =
+                    std::get_if<mir::ManagedRefType>(&result_ty.data);
+                managed != nullptr) {
+              return {
+                  .expr = std::format(
+                      "lyra::runtime::GcNew<{}>",
+                      RenderTypeAsCpp(
+                          view.Unit(), view.Class(), managed->pointee)),
+                  .leading_arg_count = 0};
+            }
             return {
                 .expr = RenderTypeAsCpp(view.Unit(), view.Class(), result_type),
                 .leading_arg_count = 0};

--- a/src/lyra/backend/cpp/render_expr.cpp
+++ b/src/lyra/backend/cpp/render_expr.cpp
@@ -338,9 +338,22 @@ auto RenderCastExpr(
 auto MemberFieldName(const ScopeView& view, const mir::MemberAccessExpr& m)
     -> const std::string& {
   const mir::TypeId recv_type = view.Expr(m.receiver).type;
-  const auto& ptr =
-      std::get<mir::PointerType>(view.Unit().types.Get(recv_type).data);
-  return view.ClassByObjectType(ptr.pointee).members.Get(m.member.var).name;
+  const auto& recv_data = view.Unit().types.Get(recv_type).data;
+  // The receiver reaches the object either through a borrowed pointer (a scope
+  // `self`) or a managed reference (a class handle); both name the object type
+  // as their pointee.
+  mir::TypeId pointee{};
+  if (const auto* ptr = std::get_if<mir::PointerType>(&recv_data)) {
+    pointee = ptr->pointee;
+  } else if (
+      const auto* managed = std::get_if<mir::ManagedRefType>(&recv_data)) {
+    pointee = managed->pointee;
+  } else {
+    throw InternalError(
+        "MemberFieldName: member-access receiver is neither a pointer nor a "
+        "managed reference");
+  }
+  return view.ClassByObjectType(pointee).members.Get(m.member.var).name;
 }
 
 auto RenderLhsExpr(const ScopeView& view, const mir::Expr& expr)

--- a/src/lyra/diag/diag_code.cpp
+++ b/src/lyra/diag/diag_code.cpp
@@ -121,6 +121,11 @@ constexpr std::array kEntries{
         DiagCodeInfo{
             .kind = DiagKind::kUnsupported,
             .name = "unsupported_fork_join_form"}},
+    std::pair{
+        DiagCode::kUnsupportedClassFeature,
+        DiagCodeInfo{
+            .kind = DiagKind::kUnsupported,
+            .name = "unsupported_class_feature"}},
 
     std::pair{
         DiagCode::kErrorDelayValueOutOfRange,

--- a/src/lyra/hir/dump.cpp
+++ b/src/lyra/hir/dump.cpp
@@ -224,6 +224,11 @@ class HirDumper {
             [](const ShortRealType&) -> std::string { return "ShortRealType"; },
             [](const RealTimeType&) -> std::string { return "RealTimeType"; },
             [](const ChandleType&) -> std::string { return "ChandleType"; },
+            [](const ClassHandleType& c) -> std::string {
+              return std::format(
+                  "ClassHandleType(class=Class[{}])", c.class_id.value);
+            },
+            [](const NullType&) -> std::string { return "NullType"; },
             [](const VoidType&) -> std::string { return "VoidType"; },
         },
         t.data);
@@ -393,6 +398,7 @@ class HirDumper {
             [](const RealLiteral& lit) -> std::string {
               return std::format("RealLiteral({})", lit.value);
             },
+            [](const NullLiteral&) -> std::string { return "NullLiteral"; },
             [](const StructuralVarRef& r) -> std::string {
               return std::format(
                   "StructuralVar[{}](hops={})", r.var.value, r.hops.value);
@@ -737,6 +743,10 @@ class HirDumper {
               return std::format(
                   "DynamicArrayNewExpr size=Expr[{}]", n.size.value);
             },
+            [](const ClassNewExpr& n) -> std::string {
+              return std::format(
+                  "ClassNewExpr class=Class[{}]", n.class_id.value);
+            },
             [](const AssociativeAssignmentPatternExpr& a) -> std::string {
               std::string entries;
               for (std::size_t i = 0; i < a.entries.size(); ++i) {
@@ -786,11 +796,41 @@ class HirDumper {
     }
     Dedent();
 
+    if (u.classes.size() > 0) {
+      Line("Classes:");
+      Indent();
+      for (std::size_t i = 0; i < u.classes.size(); ++i) {
+        const ClassId id{static_cast<std::uint32_t>(i)};
+        if (!u.classes.IsDefined(id)) {
+          Line(std::format("[{}] <declared>", i));
+          continue;
+        }
+        DumpClass(i, u.classes.Get(id));
+      }
+      Dedent();
+    }
+
     Line("Root:");
     Indent();
     DumpScope(u.root_scope);
     Dedent();
 
+    Dedent();
+  }
+
+  void DumpClass(std::size_t index, const ClassDecl& c) {
+    Line(std::format("[{}] class \"{}\"", index, c.name));
+    Indent();
+    for (const auto& field : c.fields) {
+      if (field.initializer.has_value()) {
+        Line(
+            std::format(
+                "{}:Type[{}] = Expr[{}]", field.name, field.type.value,
+                field.initializer->value));
+      } else {
+        Line(std::format("{}:Type[{}]", field.name, field.type.value));
+      }
+    }
     Dedent();
   }
 

--- a/src/lyra/hir/type.cpp
+++ b/src/lyra/hir/type.cpp
@@ -57,6 +57,8 @@ auto Type::Kind() const -> TypeKind {
           [](const ShortRealType&) { return TypeKind::kShortReal; },
           [](const RealTimeType&) { return TypeKind::kRealTime; },
           [](const ChandleType&) { return TypeKind::kChandle; },
+          [](const ClassHandleType&) { return TypeKind::kClassHandle; },
+          [](const NullType&) { return TypeKind::kNull; },
           [](const VoidType&) { return TypeKind::kVoid; },
       },
       data);
@@ -131,6 +133,8 @@ auto Type::IsValueChangeObservable() const -> bool {
     case TypeKind::kWildcardIndex:
     case TypeKind::kEvent:
     case TypeKind::kChandle:
+    case TypeKind::kClassHandle:
+    case TypeKind::kNull:
     case TypeKind::kVoid:
       return false;
   }

--- a/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/aggregates.cpp
@@ -7,7 +7,10 @@
 
 #include <slang/ast/Expression.h>
 #include <slang/ast/expressions/AssignmentExpressions.h>
+#include <slang/ast/expressions/CallExpression.h>
 #include <slang/ast/expressions/OperatorExpressions.h>
+#include <slang/ast/symbols/ClassSymbols.h>
+#include <slang/ast/types/AllTypes.h>
 #include <slang/ast/types/Type.h>
 
 #include "lyra/diag/diag_code.hpp"
@@ -200,6 +203,35 @@ auto LowerNewArrayExprProc(
   };
 }
 
+template <ExprLowerer Lowerer>
+auto LowerNewClassExpr(
+    Lowerer& lowerer, WalkFrame frame, const slang::ast::NewClassExpression& nc,
+    diag::SourceSpan span) -> diag::Result<hir::Expr> {
+  auto& module = lowerer.Module();
+  if (nc.isSuperClass) {
+    return diag::Fail(
+        span, diag::DiagCode::kUnsupportedClassFeature,
+        "super.new is not yet supported");
+  }
+  if (const auto* call = nc.constructorCall();
+      call != nullptr &&
+      !call->as<slang::ast::CallExpression>().arguments().empty()) {
+    return diag::Fail(
+        span, diag::DiagCode::kUnsupportedClassFeature,
+        "class constructor arguments are not yet supported");
+  }
+  const auto& cls = nc.type->getCanonicalType().as<slang::ast::ClassType>();
+  auto class_id = module.InternClass(cls, span);
+  if (!class_id) return std::unexpected(std::move(class_id.error()));
+  auto type_id = module.InternType(*nc.type, span);
+  if (!type_id) return std::unexpected(std::move(type_id.error()));
+  return hir::Expr{
+      .type = *type_id,
+      .data = hir::ClassNewExpr{.class_id = *class_id},
+      .span = span,
+  };
+}
+
 // One concrete instantiation per pass class; the templates are defined here so
 // the dispatchers in lower.cpp link against the symbols emitted in this file.
 template auto LowerConcatExpr(
@@ -240,5 +272,11 @@ template auto LowerReplicationExpr(
     StructuralScopeLowerer&, WalkFrame,
     const slang::ast::ReplicationExpression&, diag::SourceSpan)
     -> diag::Result<hir::Expr>;
+template auto LowerNewClassExpr(
+    ProcessLowerer&, WalkFrame, const slang::ast::NewClassExpression&,
+    diag::SourceSpan) -> diag::Result<hir::Expr>;
+template auto LowerNewClassExpr(
+    StructuralScopeLowerer&, WalkFrame, const slang::ast::NewClassExpression&,
+    diag::SourceSpan) -> diag::Result<hir::Expr>;
 
 }  // namespace lyra::lowering::ast_to_hir

--- a/src/lyra/lowering/ast_to_hir/expression/assignment.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/assignment.cpp
@@ -17,7 +17,6 @@
 
 #include "lyra/base/internal_error.hpp"
 #include "lyra/diag/diag_code.hpp"
-#include "lyra/diag/kind.hpp"
 #include "lyra/hir/conversion.hpp"
 #include "lyra/lowering/ast_to_hir/expression/slang_atoms.hpp"
 #include "lyra/lowering/ast_to_hir/process_lowerer.hpp"
@@ -157,8 +156,11 @@ auto ValidateAssignableImpl(
           expr.as<slang::ast::RangeSelectExpression>().value());
     case EK::MemberAccess: {
       const auto& ma = expr.as<slang::ast::MemberAccessExpression>();
-      if (ma.member.kind != slang::ast::SymbolKind::Field) {
-        return reject("member access target is not a struct field");
+      if (ma.member.kind != slang::ast::SymbolKind::Field &&
+          ma.member.kind != slang::ast::SymbolKind::ClassProperty) {
+        return reject(
+            "member access target is not a struct field or class "
+            "property");
       }
       return ValidateAssignableImpl(module, procedural_context, ma.value());
     }

--- a/src/lyra/lowering/ast_to_hir/expression/lower.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/lower.cpp
@@ -106,6 +106,14 @@ auto MakeRealLiteralExpr(double value, hir::TypeId type, diag::SourceSpan span)
   };
 }
 
+auto MakeNullLiteralExpr(hir::TypeId type, diag::SourceSpan span) -> hir::Expr {
+  return hir::Expr{
+      .type = type,
+      .data = hir::PrimaryExpr{.data = hir::NullLiteral{}},
+      .span = span,
+  };
+}
+
 // The one expression dispatcher, shared by both pass classes. An expression's
 // meaning does not depend on whether a process body or a structural scope
 // encloses it, so every context-free kind routes to one template handler listed
@@ -161,6 +169,12 @@ auto LowerExprImpl(
       auto type_id = module.InternType(*expr.type, span);
       if (!type_id) return std::unexpected(std::move(type_id.error()));
       return MakeRealLiteralExpr(rl.getValue(), *type_id, span);
+    }
+
+    case slang::ast::ExpressionKind::NullLiteral: {
+      auto type_id = module.InternType(*expr.type, span);
+      if (!type_id) return std::unexpected(std::move(type_id.error()));
+      return MakeNullLiteralExpr(*type_id, span);
     }
 
     case slang::ast::ExpressionKind::NamedValue:
@@ -308,6 +322,10 @@ auto LowerExprImpl(
             "dynamic-array new[] is not legal in a structural expression; "
             "LRM 7.5.1 restricts it to blocking assignments");
       }
+
+    case slang::ast::ExpressionKind::NewClass:
+      return LowerNewClassExpr(
+          lowerer, frame, expr.as<slang::ast::NewClassExpression>(), span);
 
     default:
       if constexpr (kProcedural) {

--- a/src/lyra/lowering/ast_to_hir/expression/selects.cpp
+++ b/src/lyra/lowering/ast_to_hir/expression/selects.cpp
@@ -5,6 +5,7 @@
 
 #include <slang/ast/Expression.h>
 #include <slang/ast/expressions/SelectExpressions.h>
+#include <slang/ast/symbols/ClassSymbols.h>
 #include <slang/ast/symbols/MemberSymbols.h>
 #include <slang/ast/types/Type.h>
 
@@ -162,17 +163,39 @@ auto LowerRangeSelectExpr(
   };
 }
 
+// A class property's index is its position among the class's properties in
+// slang's member order -- the same order `InternClass` registers the HIR
+// ClassDecl fields, so the two indices align.
+auto ClassPropertyIndex(const slang::ast::ClassPropertySymbol& prop)
+    -> std::uint32_t {
+  const auto* scope = prop.getParentScope();
+  std::uint32_t index = 0;
+  for (const auto& member :
+       scope->membersOfType<slang::ast::ClassPropertySymbol>()) {
+    if (&member == &prop) {
+      return index;
+    }
+    ++index;
+  }
+  throw InternalError("ClassPropertyIndex: property not found in its class");
+}
+
 template <ExprLowerer Lowerer>
 auto LowerMemberAccessExpr(
     Lowerer& lowerer, WalkFrame frame,
     const slang::ast::MemberAccessExpression& sel, diag::SourceSpan span)
     -> diag::Result<hir::Expr> {
-  if (sel.member.kind != slang::ast::SymbolKind::Field) {
+  std::uint32_t field_index = 0;
+  if (sel.member.kind == slang::ast::SymbolKind::Field) {
+    field_index = sel.member.as<slang::ast::FieldSymbol>().fieldIndex;
+  } else if (sel.member.kind == slang::ast::SymbolKind::ClassProperty) {
+    field_index =
+        ClassPropertyIndex(sel.member.as<slang::ast::ClassPropertySymbol>());
+  } else {
     return diag::Fail(
         span, diag::DiagCode::kUnsupportedExpressionForm,
-        "member access target is not a struct field");
+        "member access target is not a struct field or class property");
   }
-  const auto* field = &sel.member.as<slang::ast::FieldSymbol>();
   auto base_or = lowerer.LowerExpr(sel.value(), frame);
   if (!base_or) return std::unexpected(std::move(base_or.error()));
   const hir::ExprId base_id = frame.Exprs().Add(*std::move(base_or));
@@ -183,7 +206,7 @@ auto LowerMemberAccessExpr(
       .data =
           hir::MemberAccessExpr{
               .base_value = base_id,
-              .field_index = field->fieldIndex,
+              .field_index = field_index,
           },
       .span = span,
   };

--- a/src/lyra/lowering/ast_to_hir/type.cpp
+++ b/src/lyra/lowering/ast_to_hir/type.cpp
@@ -10,6 +10,7 @@
 #include <slang/ast/EvalContext.h>
 #include <slang/ast/Expression.h>
 #include <slang/ast/Symbol.h>
+#include <slang/ast/symbols/ClassSymbols.h>
 #include <slang/ast/symbols/VariableSymbols.h>
 #include <slang/ast/types/AllTypes.h>
 #include <slang/ast/types/Type.h>
@@ -325,6 +326,16 @@ auto TranslateTypeData(
       return hir::TypeData{hir::EventType{}};
     case slang::ast::SymbolKind::CHandleType:
       return hir::TypeData{hir::ChandleType{}};
+    case slang::ast::SymbolKind::NullType:
+      return hir::TypeData{hir::NullType{}};
+    case slang::ast::SymbolKind::ClassType: {
+      auto class_id_or =
+          module.InternClass(canonical.as<slang::ast::ClassType>(), decl_span);
+      if (!class_id_or) {
+        return std::unexpected(std::move(class_id_or.error()));
+      }
+      return hir::TypeData{hir::ClassHandleType{.class_id = *class_id_or}};
+    }
     case slang::ast::SymbolKind::VoidType:
       return hir::TypeData{hir::VoidType{}};
     case slang::ast::SymbolKind::PackedStructType: {
@@ -433,6 +444,41 @@ auto TranslateTypeData(
 }
 
 }  // namespace
+
+auto ModuleLowerer::InternClass(
+    const slang::ast::ClassType& cls, diag::SourceSpan span)
+    -> diag::Result<hir::ClassId> {
+  if (const auto it = class_cache_.find(&cls); it != class_cache_.end()) {
+    return it->second;
+  }
+  const hir::ClassId id = unit_.classes.Declare();
+  class_cache_.emplace(&cls, id);
+
+  hir::ClassDecl decl;
+  decl.name = std::string(cls.name);
+  for (const auto& prop :
+       cls.membersOfType<slang::ast::ClassPropertySymbol>()) {
+    if (prop.lifetime == slang::ast::VariableLifetime::Static) {
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedClassFeature,
+          "static class properties are not yet supported");
+    }
+    if (prop.getInitializer() != nullptr) {
+      return diag::Fail(
+          span, diag::DiagCode::kUnsupportedClassFeature,
+          "class property initializers are not yet supported");
+    }
+    auto field_type = InternType(prop.getType(), span);
+    if (!field_type) return std::unexpected(std::move(field_type.error()));
+    decl.fields.push_back(
+        hir::ClassField{
+            .name = std::string(prop.name),
+            .type = *field_type,
+            .initializer = std::nullopt});
+  }
+  unit_.classes.Define(id, std::move(decl));
+  return id;
+}
 
 auto ModuleLowerer::InternType(
     const slang::ast::Type& type, diag::SourceSpan span)

--- a/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/class_decl_lowerer.cpp
@@ -1,0 +1,69 @@
+#include "lyra/lowering/hir_to_mir/class_decl_lowerer.hpp"
+
+#include <utility>
+
+#include "lyra/lowering/hir_to_mir/default_value.hpp"
+#include "lyra/lowering/hir_to_mir/self_ref.hpp"
+#include "lyra/lowering/hir_to_mir/walk_frame.hpp"
+#include "lyra/mir/class.hpp"
+#include "lyra/mir/expr.hpp"
+#include "lyra/mir/local.hpp"
+#include "lyra/mir/member.hpp"
+#include "lyra/mir/stmt.hpp"
+#include "lyra/mir/type.hpp"
+
+namespace lyra::lowering::hir_to_mir {
+
+auto ClassDeclLowerer::Run() -> diag::Result<mir::Class> {
+  ModuleLowerer& module = *module_;
+  const hir::ClassDecl& hir_class = *hir_class_;
+
+  const mir::TypeId self_pointer_type = module.Unit().types.PointerTo(
+      object_type_, mir::PointerOwnership::kBorrowed);
+
+  mir::Class mir_class{
+      .name = hir_class.name,
+      .base = std::nullopt,
+      .self_pointer_type = self_pointer_type,
+      .time_resolution = {},
+      .ctor_prefix_params = {},
+      .params = {},
+      .members = {},
+      .constructor_block = {},
+      .contained = {},
+      .methods = {},
+      .type_aliases = {}};
+
+  mir::Block ctor_block;
+  const mir::LocalId self_id = ctor_block.vars.Add(
+      mir::LocalDecl{.name = "self", .type = self_pointer_type});
+  ScopeChainNode scope_link{};
+  const WalkFrame frame = WalkFrame{}
+                              .WithClass(&mir_class, scope_link)
+                              .WithBlock(&ctor_block)
+                              .WithSelfBinding(self_id, {});
+
+  // A class property owns its storage directly -- it is not an observable cell,
+  // so it is a plain value-typed member and its construction-time default is a
+  // plain assignment through `self`, not an observable `Set`.
+  for (const auto& field : hir_class.fields) {
+    const mir::TypeId field_type = module.TranslateType(field.type);
+    const mir::MemberId member_id = mir_class.members.Add(
+        mir::MemberDecl{.name = field.name, .type = field_type});
+    const mir::ExprId default_id = ctor_block.exprs.Add(
+        BuildDefaultValueFromHir(module, frame, field.type));
+    const mir::ExprId self_ref =
+        ctor_block.exprs.Add(MakeSelfRefExpr(frame, self_pointer_type));
+    const mir::ExprId target = ctor_block.exprs.Add(
+        mir::MakeMemberAccessExpr(
+            self_ref, mir::MemberRef{.var = member_id}, field_type));
+    const mir::ExprId assign = ctor_block.exprs.Add(
+        mir::MakeAssignExpr(target, default_id, field_type));
+    ctor_block.AppendStmt(mir::ExprStmt{.expr = assign});
+  }
+
+  mir_class.constructor_block = std::move(ctor_block);
+  return mir_class;
+}
+
+}  // namespace lyra::lowering::hir_to_mir

--- a/src/lyra/lowering/hir_to_mir/default_value.cpp
+++ b/src/lyra/lowering/hir_to_mir/default_value.cpp
@@ -297,6 +297,11 @@ auto BuildDefaultValueExpr(
           [&](const mir::PointerType&) -> mir::Expr {
             return mir::Expr{.data = mir::NullLiteral{}, .type = type};
           },
+          // LRM 8.4 / Table 7-1: an uninitialized class handle defaults to
+          // null.
+          [&](const mir::ManagedRefType&) -> mir::Expr {
+            return mir::Expr{.data = mir::NullLiteral{}, .type = type};
+          },
           [&](const mir::VectorType&) -> mir::Expr {
             return mir::Expr{
                 .data =

--- a/src/lyra/lowering/hir_to_mir/expression/dispatch.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/dispatch.cpp
@@ -129,6 +129,15 @@ auto LowerExprImpl(L& lowerer, const hir::Expr& expr, WalkFrame frame)
             return LowerHirAssociativeAssignmentPatternExpr(
                 lowerer, frame, a, result_type);
           },
+          [&](const hir::ClassNewExpr&) -> diag::Result<mir::Expr> {
+            // `new` allocates a managed object and runs its constructor: a
+            // construction whose result type (a managed reference) names what
+            // to build, with no constructor arguments.
+            return mir::Expr{
+                .data =
+                    mir::CallExpr{.callee = mir::Construct{}, .arguments = {}},
+                .type = result_type};
+          },
       },
       expr.data);
   if (!raw_or) return raw_or;

--- a/src/lyra/lowering/hir_to_mir/expression/operators.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/operators.cpp
@@ -326,6 +326,23 @@ auto BuildMirBinaryExpr(
   const bool string_lhs = lhs_ty.Kind() == mir::TypeKind::kString;
   const bool string_rhs = rhs_ty.Kind() == mir::TypeKind::kString;
 
+  // LRM 8.4: handle equality compares object identity and yields a 1-bit
+  // value. A handle's `==` / `!=` produces a host bool, reshaped to the SV
+  // 1-bit integral by `FromBool` so the result carries the value type a 1-bit
+  // signal assignment expects.
+  const auto is_handle = [](const mir::Type& ty) {
+    return ty.Kind() == mir::TypeKind::kManagedRef ||
+           ty.Kind() == mir::TypeKind::kChandle;
+  };
+  if ((is_handle(lhs_ty) || is_handle(rhs_ty)) &&
+      (op == mir::BinaryOp::kEquality || op == mir::BinaryOp::kInequality)) {
+    const mir::ExprId cmp = block.exprs.Add(
+        mir::Expr{
+            .data = mir::BinaryExpr{.op = op, .lhs = lhs_id, .rhs = rhs_id},
+            .type = result_type});
+    return MakeFromBoolCall(cmp, result_type);
+  }
+
   // LRM 11.3.1 / LRM 6.16 logical operator on real / string operands needs
   // `bool(...)` coercion on each operand before the host-native `&&` / `||`
   // / `==` composes them; `kFromBool` re-shapes the host bool back to a

--- a/src/lyra/lowering/hir_to_mir/expression/references.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/references.cpp
@@ -129,6 +129,10 @@ auto LowerHirTimeLiteral(const ModuleLowerer& module, const hir::TimeLiteral& t)
       .type = module.Unit().builtins.realtime};
 }
 
+auto LowerHirNullLiteral(mir::TypeId type) -> mir::Expr {
+  return mir::Expr{.data = mir::NullLiteral{}, .type = type};
+}
+
 auto LowerHirRealLiteral(const hir::RealLiteral& r, mir::TypeId type)
     -> mir::Expr {
   return mir::Expr{.data = mir::RealLiteral{.value = r.value}, .type = type};
@@ -294,6 +298,9 @@ auto LowerHirPrimaryExprProc(
           [&](const hir::RealLiteral& r) -> mir::Expr {
             return LowerHirRealLiteral(r, result_type);
           },
+          [&](const hir::NullLiteral&) -> mir::Expr {
+            return LowerHirNullLiteral(result_type);
+          },
           [&](const hir::StructuralVarRef& m) -> mir::Expr {
             return LowerStructuralVarRefExpr(lowerer, frame, m);
           },
@@ -330,6 +337,9 @@ auto LowerHirPrimaryExprStructural(
           },
           [&](const hir::RealLiteral& r) -> mir::Expr {
             return LowerHirRealLiteral(r, result_type);
+          },
+          [&](const hir::NullLiteral&) -> mir::Expr {
+            return LowerHirNullLiteral(result_type);
           },
           [&](const hir::StructuralVarRef& m) -> mir::Expr {
             return LowerStructuralVarRefExpr(lowerer, frame, m);

--- a/src/lyra/lowering/hir_to_mir/expression/selects.cpp
+++ b/src/lyra/lowering/hir_to_mir/expression/selects.cpp
@@ -772,6 +772,18 @@ auto LowerHirMemberAccessExpr(
   const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
   const auto& base_hir_expr = exprs.Get(sel.base_value);
+  // LRM 8.4: a class property access reaches the object through the handle. The
+  // handle is read (the receiver), and the property is named by its class-local
+  // member id, which is its declaration-order field index.
+  if (module.Hir().types.Get(base_hir_expr.type).Kind() ==
+      hir::TypeKind::kClassHandle) {
+    auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
+    if (!base_or) return std::unexpected(std::move(base_or.error()));
+    const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
+    return mir::MakeMemberAccessExpr(
+        base_id, mir::MemberRef{.var = mir::MemberId{sel.field_index}},
+        result_type);
+  }
   // LRM 7.2: an unpacked struct lowers to a generic product (`TupleType`);
   // member access is a positional projection by declaration-order index.
   if (module.Hir().types.Get(base_hir_expr.type).Kind() ==
@@ -865,6 +877,18 @@ auto LowerHirMemberAccessExprLhs(
   const auto& exprs = lowerer.HirExprs();
   auto& block = *frame.current_block;
   const auto& base_hir_expr = exprs.Get(sel.base_value);
+  // LRM 8.4: a class property write reaches the object through the handle. The
+  // handle is read to reach the shared object, and the property place is the
+  // member access through it; the write itself targets the object's storage.
+  if (module.Hir().types.Get(base_hir_expr.type).Kind() ==
+      hir::TypeKind::kClassHandle) {
+    auto base_or = lowerer.LowerExpr(base_hir_expr, frame);
+    if (!base_or) return std::unexpected(std::move(base_or.error()));
+    const mir::ExprId base_id = block.exprs.Add(*std::move(base_or));
+    return mir::MakeMemberAccessExpr(
+        base_id, mir::MemberRef{.var = mir::MemberId{sel.field_index}},
+        result_type);
+  }
   // LRM 7.2: an unpacked-struct member write is a positional projection by
   // index over the base place. The observable root's write routes through the
   // cell's mutate path later, so the place is just the projection here.

--- a/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
+++ b/src/lyra/lowering/hir_to_mir/module_lowerer.cpp
@@ -9,14 +9,27 @@
 #include <utility>
 
 #include "lyra/diag/diagnostic.hpp"
+#include "lyra/lowering/hir_to_mir/class_decl_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/structural_scope_lowerer.hpp"
 #include "lyra/lowering/hir_to_mir/walk_frame.hpp"
 #include "lyra/mir/compilation_unit.hpp"
+#include "lyra/mir/type.hpp"
 
 namespace lyra::lowering::hir_to_mir {
 
 auto ModuleLowerer::Run() -> diag::Result<mir::CompilationUnit> {
   WalkFrame root_frame;
+
+  // Every class identity is minted before any type is translated, so a class
+  // handle type resolves to the managed-reference pointee that names it while
+  // the class bodies are still being built.
+  for (std::size_t i = 0; i < hir_->classes.size(); ++i) {
+    const hir::ClassId hir_id{static_cast<std::uint32_t>(i)};
+    const mir::ClassId mir_id = unit_.DeclareClass();
+    const mir::TypeId object_type =
+        unit_.types.Intern(mir::ObjectType{.class_id = mir_id});
+    MapClass(hir_id, mir_id, object_type);
+  }
 
   // Every HIR type is MIR-representable: AST-to-HIR rejects the forms MIR has
   // no shape for, so this projection never fails.
@@ -26,6 +39,15 @@ auto ModuleLowerer::Run() -> diag::Result<mir::CompilationUnit> {
     const mir::TypeId mir_id =
         unit_.types.Intern(TranslateTypeData(hir_type.data));
     MapType(hir_id, mir_id);
+  }
+
+  for (std::size_t i = 0; i < hir_->classes.size(); ++i) {
+    const hir::ClassId hir_id{static_cast<std::uint32_t>(i)};
+    ClassDeclLowerer class_lowerer(
+        *this, ClassObjectType(hir_id), hir_->classes.Get(hir_id));
+    auto class_or = class_lowerer.Run();
+    if (!class_or) return std::unexpected(std::move(class_or.error()));
+    unit_.DefineClass(TranslateClass(hir_id), *std::move(class_or));
   }
 
   StructuralScopeLowerer root(*this, nullptr, hir_->name, hir_->root_scope);

--- a/src/lyra/lowering/hir_to_mir/translate_type.cpp
+++ b/src/lyra/lowering/hir_to_mir/translate_type.cpp
@@ -236,6 +236,19 @@ auto ModuleLowerer::TranslateTypeData(const hir::TypeData& data) const
           [](const hir::ChandleType&) -> mir::TypeData {
             return mir::ChandleType{};
           },
+          [&](const hir::ClassHandleType& src) -> mir::TypeData {
+            // A class handle is a managed reference to the class object: the
+            // pointee is the object type naming the class's registry identity,
+            // pre-interned when the class id was minted.
+            return mir::ManagedRefType{
+                .pointee = ClassObjectType(src.class_id)};
+          },
+          [](const hir::NullType&) -> mir::TypeData {
+            // The `null` literal carries no class identity; it renders as a
+            // null pointer that any handle absorbs, so MIR types it as the
+            // opaque handle. Its value, not its type, drives the comparison.
+            return mir::ChandleType{};
+          },
           [](const hir::VoidType&) -> mir::TypeData { return mir::VoidType{}; },
       },
       data);

--- a/tests/cases/cpp/class_basic/case.yaml
+++ b/tests/cases/cpp/class_basic/case.yaml
@@ -1,0 +1,15 @@
+id: cpp.class_basic
+tags: [cpp_run]
+input:
+  command: [run, cpp]
+  project: false
+  top: Top
+  files: [main.sv]
+expect:
+  exit: 0
+  variables:
+    x_val: 5
+    y_val: 12
+    eq_null: 0
+    eq_copy: 1
+    eq_distinct: 0

--- a/tests/cases/cpp/class_basic/main.sv
+++ b/tests/cases/cpp/class_basic/main.sv
@@ -1,0 +1,33 @@
+// First working SystemVerilog class (LRM 8): fields, `new`, member access
+// (read and write), handle copy, and handle equality against null and against
+// another handle. Field values and comparison results are copied into module
+// variables so the test asserts the feature's product, not a print side effect.
+module Top;
+  class C;
+    int x;
+    int y;
+  endclass
+
+  int x_val;
+  int y_val;
+  bit eq_null;
+  bit eq_copy;
+  bit eq_distinct;
+
+  initial begin
+    C h;
+    C g;
+    h = new;
+    h.x = 5;
+    h.y = h.x + 7;
+    x_val = h.x;
+    y_val = h.y;
+
+    g = h;
+    eq_null = (h == null);
+    eq_copy = (h == g);
+
+    g = new;
+    eq_distinct = (h == g);
+  end
+endmodule


### PR DESCRIPTION
## Summary

This lands the first end-to-end SystemVerilog class (LRM 8): a class with fields, `new`, member access (read and write through a handle), handle copy, and handle equality against `null` and against another handle. A class is modeled as the one generic nominal object the module and generate scope already use, differing only in that it extends no runtime base (it is not a tree node), is reached through a managed reference, and is built by `new`.

## Design

HIR gains the SV-faithful class vocabulary: a unit-level class registry (declared before defined so a class can be named before its body is built), a class-handle type, a `new` expression, and the `null` literal and its type. AST-to-HIR discovers a class lazily through its slang type, so a class declared in a module, package, or compilation-unit scope flows through one path. HIR-to-MIR pre-mints each class identity and its object type before type translation (so a handle type resolves to its managed-reference pointee), then a dedicated lowerer builds each class as a baseless `mir::Class` whose properties are plain value-typed members and whose constructor body initializes them. A class handle lowers to a managed reference; `new` to the generic construction form; member access through the handle to the existing member-access primitive; and handle equality to a 1-bit comparison reshaped from the host bool.

The runtime adds a `GcRef` handle (null, shallow copy, identity equality) backed by a managed heap that retains every allocation for the run -- the lifetime model that precedes precise tracing. The C++ backend renders `new` as a managed-heap allocation, member access through the handle, handle equality, and emits each free-standing class ahead of the scope tree that references it.

Methods, inheritance, and reclamation are out of scope here; constructor arguments, static properties, and property initializers are rejected with a clear diagnostic rather than mis-lowered.

## Testing

A new end-to-end case writes and reads class fields through a handle and exercises handle equality (after copy, against null, and across reallocation), asserting the results through module variables. The full suite passes.